### PR TITLE
Fix MCP OAuth optional issuer metadata

### DIFF
--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -214,6 +214,32 @@ async function handleMcpClientRegistrationRequest(request: Request, path: string
   return rewritten instanceof Response ? rewritten : auth.handler(rewritten)
 }
 
+// Better Auth includes RFC 9207 `iss` on successful code responses but not on
+// every compatibility path. Keep clients tolerant of an absent value; clients
+// still validate it against `issuer` whenever the callback does include it.
+async function makeAuthorizationResponseIssuerOptional(response: Response) {
+  const metadata: unknown = await response.clone().json()
+  if (!isRecord(metadata)) {
+    return response
+  }
+
+  const headers = new Headers(response.headers)
+  headers.delete("content-length")
+  metadata.authorization_response_iss_parameter_supported = false
+  return new Response(JSON.stringify(metadata), {
+    status: response.status,
+    headers,
+  })
+}
+
+async function getOAuthAuthorizationServerMetadata(request: Request) {
+  return makeAuthorizationResponseIssuerOptional(await oauthProviderAuthServerMetadata(auth)(request))
+}
+
+async function getOAuthOpenIdConfiguration(request: Request) {
+  return makeAuthorizationResponseIssuerOptional(await oauthProviderOpenIdConfigMetadata(auth)(request))
+}
+
 const authLoginLockedSchema = z.object({
   error: z.literal("login_locked"),
   message: z.string(),
@@ -271,12 +297,12 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
   // Better Auth uses this configured base URL for the callback `iss` value.
   // Keep discovery on that same canonical issuer even when these routes are
   // reached through a separate API or reverse-proxy origin.
-  app.get("/api/auth/.well-known/oauth-authorization-server", publicRoute, (c) => oauthProviderAuthServerMetadata(auth)(c.req.raw))
-  app.get("/api/auth/.well-known/openid-configuration", publicRoute, (c) => oauthProviderOpenIdConfigMetadata(auth)(c.req.raw))
-  app.get("/.well-known/oauth-authorization-server/api/auth", publicRoute, (c) => oauthProviderAuthServerMetadata(auth)(c.req.raw))
-  app.get("/.well-known/openid-configuration/api/auth", publicRoute, (c) => oauthProviderOpenIdConfigMetadata(auth)(c.req.raw))
-  app.get("/.well-known/oauth-authorization-server", publicRoute, (c) => oauthProviderAuthServerMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/oauth-authorization-server")))
-  app.get("/.well-known/openid-configuration", publicRoute, (c) => oauthProviderOpenIdConfigMetadata(auth)(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/openid-configuration")))
+  app.get("/api/auth/.well-known/oauth-authorization-server", publicRoute, (c) => getOAuthAuthorizationServerMetadata(c.req.raw))
+  app.get("/api/auth/.well-known/openid-configuration", publicRoute, (c) => getOAuthOpenIdConfiguration(c.req.raw))
+  app.get("/.well-known/oauth-authorization-server/api/auth", publicRoute, (c) => getOAuthAuthorizationServerMetadata(c.req.raw))
+  app.get("/.well-known/openid-configuration/api/auth", publicRoute, (c) => getOAuthOpenIdConfiguration(c.req.raw))
+  app.get("/.well-known/oauth-authorization-server", publicRoute, (c) => getOAuthAuthorizationServerMetadata(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/oauth-authorization-server")))
+  app.get("/.well-known/openid-configuration", publicRoute, (c) => getOAuthOpenIdConfiguration(rewriteAuthRequest(c.req.raw, "/api/auth/.well-known/openid-configuration")))
   app.post("/register", publicRoute, async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
   app.post("/api/auth/oauth2/register", publicRoute, async (c) => handleMcpClientRegistrationRequest(c.req.raw, "/api/auth/oauth2/register"))
   app.get("/api/auth/oauth2/authorize", tokenRoute, async (c) => {

--- a/ee/apps/den-api/test/mcp-resource-url.test.ts
+++ b/ee/apps/den-api/test/mcp-resource-url.test.ts
@@ -75,6 +75,9 @@ if (authMetadataUrl) {
   if (metadata.issuer !== expectedAuthIssuer) {
     throw new Error(\`Expected auth issuer \${expectedAuthIssuer}, got \${metadata.issuer}\`)
   }
+  if (metadata.authorization_response_iss_parameter_supported !== false) {
+    throw new Error("Expected authorization response issuer support to remain optional")
+  }
   for (const key of ["authorization_endpoint", "token_endpoint", "registration_endpoint"]) {
     const endpoint = metadata[key]
     if (typeof endpoint !== "string" || !endpoint.startsWith(\`\${expectedAuthIssuer}/\`)) {


### PR DESCRIPTION
## What changed

- Advertise `authorization_response_iss_parameter_supported: false` from OAuth and OIDC discovery.
- Keep the canonical app-host issuer and every authorization/token endpoint unchanged.
- Add regression coverage for the optional callback issuer contract.

## Why

Codex Desktop bundles `rmcp 1.8.0`. When discovery advertises guaranteed RFC 9207 authorization-response issuer support, that client requires every callback to include `iss`. Better Auth includes `iss` on the normal successful code path but omits it on at least one compatibility/already-authorized path, causing Codex to discard an otherwise successful login.

Marking support as optional makes Codex tolerate an absent value while it continues to validate `iss` against the canonical issuer whenever the callback includes it.

## Validation

- `pnpm exec bun test test/auth-oauth-redirect.test.ts test/mcp-resource-url.test.ts test/mcp-auth.test.ts test/admin-mcp-routes.test.ts` — 18 passed, 0 failed
- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm exec tsc -p tsconfig.json --noEmit` from `ee/apps/den-api` — passed

Fraimz remains skipped at the reporter's request; this is a discovery metadata compatibility fix with focused automated coverage.
