### PR TITLE
Fix MCP OAuth endpoint resources

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -99,9 +99,14 @@ function apiPublicMcpResource(apiPublicUrl: string | undefined) {
   }
 }
 
+function mcpEndpointResourceAliases(resource: string) {
+  const base = resource.replace(/\/+$/, "");
+  return [`${base}/agent`, `${base}/admin`];
+}
+
 export const DEN_MCP_RESOURCE = env.mcpResourceUrl ?? deriveDenMcpResource(env.betterAuthUrl, env.webAppHosts);
 const DEN_API_PUBLIC_MCP_RESOURCES = apiPublicMcpResource(env.apiPublicUrl);
-export const DEN_MCP_RESOURCES = Array.from(new Set([
+const DEN_MCP_BASE_RESOURCES = [
   DEN_MCP_RESOURCE,
   // Audience compatibility: tokens issued before the proxied default carry
   // the bare-origin resource (`<betterAuthUrl>/mcp`); keep accepting them.
@@ -112,6 +117,13 @@ export const DEN_MCP_RESOURCES = Array.from(new Set([
   ...localMcpResourceAliases(DEN_MCP_RESOURCE),
   ...DEN_API_PUBLIC_MCP_RESOURCES.flatMap((resource) => localMcpResourceAliases(resource)),
   ...env.mcpAdditionalResources.flatMap((resource) => localMcpResourceAliases(resource)),
+];
+export const DEN_MCP_RESOURCES = Array.from(new Set([
+  ...DEN_MCP_BASE_RESOURCES,
+  // rmcp uses the configured concrete endpoint as the OAuth resource during
+  // token exchange. Accept the two registered child endpoints as aliases of
+  // their canonical parent resource.
+  ...DEN_MCP_BASE_RESOURCES.flatMap((resource) => mcpEndpointResourceAliases(resource)),
 ]));
 export const DEN_MCP_TOKEN_USE_CLAIM = `${env.mcpClaimNamespace}/token_use`;
 export const DEN_MCP_ORG_ID_CLAIM = `${env.mcpClaimNamespace}/org_id`;

--- a/ee/apps/den-api/test/mcp-auth.test.ts
+++ b/ee/apps/den-api/test/mcp-auth.test.ts
@@ -37,7 +37,11 @@ test("MCP resource metadata requests an offline refresh grant", () => {
 test("MCP JWT verification pins issuer, audience, and signing algorithm", () => {
   expect(mcpAuth.getMcpJwtVerifyOptions()).toEqual({
     issuer: getDenAuthIssuer("http://127.0.0.1:8790"),
-    audience: ["http://127.0.0.1:8790/mcp"],
+    audience: [
+      "http://127.0.0.1:8790/mcp",
+      "http://127.0.0.1:8790/mcp/agent",
+      "http://127.0.0.1:8790/mcp/admin",
+    ],
     algorithms: [DEN_JWT_SIGNING_ALGORITHM],
   })
 })


### PR DESCRIPTION
## What changed

- Add the registered `/mcp/agent` and `/mcp/admin` endpoints as accepted OAuth resource aliases for every configured canonical MCP resource.
- Use the same expanded allowlist for JWT audience verification and the OpenWork resource claim check.
- Add regression coverage for the concrete endpoint audiences used by Codex Desktop.

## Why

Codex Desktop bundles `rmcp 1.8.0`, which sends the configured concrete MCP URL as the `resource` parameter during authorization-code token exchange. OpenWork advertised the canonical parent resource (`…/mcp`) but rejected the concrete configured endpoint (`…/mcp/agent`) with `invalid_request: requested resource invalid`.

The aliases are limited to OpenWork's two registered child endpoints. Existing endpoint authorization remains unchanged, including the separate platform-admin gate on `/mcp/admin`.

## Validation

- `pnpm exec bun test test/auth-oauth-redirect.test.ts test/mcp-resource-url.test.ts test/mcp-auth.test.ts test/admin-mcp-routes.test.ts` — 18 passed, 0 failed
- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm exec tsc -p tsconfig.json --noEmit` from `ee/apps/den-api` — passed

Fraimz remains skipped at the reporter's request; this is an OAuth resource/audience compatibility fix with focused automated coverage.
