### PR TITLE
Fix Brand Appearance upload reauthentication

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { ShieldCheck, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { DenButton, buttonVariants } from "./ui/button";
 import { DenInput } from "./ui/input";
@@ -312,82 +313,114 @@ export function ReauthDialog({
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/50 px-4 py-6 backdrop-blur-[2px]">
       <div
         role="dialog"
         aria-modal="true"
+        aria-labelledby="reauth-dialog-title"
         // Test seam: the reauth popup eval matches the completion message to this nonce.
         data-reauth-nonce={nonce}
-        className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
+        className="w-full max-w-[460px] overflow-hidden rounded-[28px] border border-white/80 bg-white shadow-[0_32px_100px_-28px_rgba(15,23,42,0.55)]"
       >
-        <div className="grid gap-3">
-          <p className="text-[12px] font-semibold uppercase tracking-[0.18em] text-gray-400">Security check</p>
-          <div className="grid gap-2">
-            <h2 className="text-[24px] font-semibold tracking-[-0.03em] text-gray-950">Confirm it's you to continue</h2>
-            <p className="text-[15px] leading-7 text-gray-600">
-              Changing workspace settings requires a recent sign-in. Choose a sign-in method below; after you confirm, OpenWork retries the pending action automatically.
+        <div className="relative border-b border-slate-100 bg-gradient-to-br from-slate-50 via-white to-indigo-50/60 px-6 pb-6 pt-7">
+          <button
+            type="button"
+            aria-label="Close security check"
+            className="absolute right-4 top-4 flex size-9 items-center justify-center rounded-full text-slate-400 transition-colors hover:bg-white hover:text-slate-700"
+            disabled={busy}
+            onClick={onCancel}
+          >
+            <X size={17} aria-hidden="true" />
+          </button>
+          <div className="mb-5 flex size-12 items-center justify-center rounded-2xl border border-indigo-100 bg-white text-indigo-600 shadow-sm">
+            <ShieldCheck size={24} strokeWidth={1.8} aria-hidden="true" />
+          </div>
+          <div className="grid gap-2 pr-8">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.2em] text-indigo-500">Security check</p>
+            <h2 id="reauth-dialog-title" className="text-[25px] font-semibold tracking-[-0.035em] text-slate-950">
+              Confirm it's you to continue
+            </h2>
+            <p className="text-[14px] leading-6 text-slate-600">
+              Changing workspace settings requires a recent sign-in. OpenWork retries the pending action automatically after you confirm.
             </p>
           </div>
         </div>
 
-        {error ? (
-          <div className="mt-5 rounded-[18px] border border-red-200 bg-red-50 px-4 py-3 text-[14px] text-red-700">
-            {error}
-          </div>
-        ) : null}
-
-        <div className="mt-6 grid gap-4">
-          {loadingMethods ? (
-            <div className="rounded-[18px] border border-gray-200 bg-gray-50 px-4 py-3 text-[14px] text-gray-500">
-              Checking available sign-in methods...
+        <div className="p-6">
+          {user?.email ? (
+            <div className="mb-5 flex items-center gap-3 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3">
+              <div className="flex size-8 shrink-0 items-center justify-center rounded-full bg-slate-900 text-[12px] font-semibold uppercase text-white">
+                {user.email.slice(0, 1)}
+              </div>
+              <div className="min-w-0">
+                <p className="text-[11px] font-medium uppercase tracking-[0.12em] text-slate-400">Signing in as</p>
+                <p className="truncate text-[13px] font-medium text-slate-700">{user.email}</p>
+              </div>
             </div>
           ) : null}
 
-          {hasManagedOrgSignIn ? (
-            <DenButton onClick={continueSso} loading={busy || loadingMethods} disabled={!ssoUrl || busy || loadingMethods}>
-              Continue with organization SSO
-            </DenButton>
+          {error ? (
+            <div className="mb-5 rounded-[18px] border border-red-200 bg-red-50 px-4 py-3 text-[14px] text-red-700">
+              {error}
+            </div>
           ) : null}
 
-          {socialProviders.map((provider) => {
-            const primarySocial = !hasManagedOrgSignIn && (provider === "google" || socialProviders.length === 1);
-            return (
-              <button
-                key={provider}
-                type="button"
-                className={buttonVariants({ variant: primarySocial ? "primary" : "secondary", className: "w-full" })}
-                disabled={busy}
-                onClick={() => void continueSocial(provider)}
-              >
-                Continue with {getSocialLabel(provider)}
-              </button>
-            );
-          })}
+          <div className="grid gap-4">
+            {loadingMethods ? (
+              <div className="rounded-[18px] border border-gray-200 bg-gray-50 px-4 py-3 text-[14px] text-gray-500">
+                Checking available sign-in methods...
+              </div>
+            ) : null}
 
-          {hasPassword ? (
-            <form className="grid gap-3" onSubmit={submitPassword}>
-              <label className="grid gap-2">
-                <span className="text-[13px] font-medium text-gray-700">Password for {user?.email ?? "your account"}</span>
-                <DenInput
-                  type="password"
-                  value={password}
-                  onChange={(event) => setPassword(event.target.value)}
-                  autoComplete="current-password"
-                  disabled={busy}
-                  required
-                />
-              </label>
-              <DenButton type="submit" loading={busy} disabled={!password.trim()}>
-                Verify password
+            {hasManagedOrgSignIn ? (
+              <DenButton className="w-full" onClick={continueSso} loading={busy || loadingMethods} disabled={!ssoUrl || busy || loadingMethods}>
+                Continue with organization SSO
               </DenButton>
-            </form>
-          ) : null}
-        </div>
+            ) : null}
 
-        <div className="mt-6 flex justify-end">
-          <DenButton variant="secondary" onClick={onCancel} disabled={busy}>
+            {socialProviders.map((provider) => {
+              const primarySocial = !hasManagedOrgSignIn && (provider === "google" || socialProviders.length === 1);
+              return (
+                <button
+                  key={provider}
+                  type="button"
+                  className={buttonVariants({ variant: primarySocial ? "primary" : "secondary", className: "w-full" })}
+                  disabled={busy}
+                  onClick={() => void continueSocial(provider)}
+                >
+                  Continue with {getSocialLabel(provider)}
+                </button>
+              );
+            })}
+
+            {hasPassword ? (
+              <form className="grid gap-3" onSubmit={submitPassword}>
+                <label className="grid gap-2">
+                  <span className="text-[13px] font-medium text-gray-700">Password</span>
+                  <DenInput
+                    type="password"
+                    value={password}
+                    onChange={(event) => setPassword(event.target.value)}
+                    autoComplete="current-password"
+                    disabled={busy}
+                    required
+                  />
+                </label>
+                <DenButton className="w-full" type="submit" loading={busy} disabled={!password.trim()}>
+                  Verify password
+                </DenButton>
+              </form>
+            ) : null}
+          </div>
+
+          <button
+            type="button"
+            className="mt-5 w-full rounded-full py-2 text-[13px] font-medium text-slate-500 transition-colors hover:text-slate-800 disabled:opacity-60"
+            onClick={onCancel}
+            disabled={busy}
+          >
             Cancel
-          </DenButton>
+          </button>
         </div>
       </div>
     </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
@@ -2,7 +2,7 @@
 
 import { Check, Copy, ImageUp, Pencil, SlidersHorizontal, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
-import { getErrorMessage, requestJson } from "../../_lib/den-flow";
+import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
 import { getAllowedDesktopVersionsFromMetadata, getManagedBrandAssetFromMetadata, getRequireSsoFromMetadata, parseOrganizationMetadata, type DenManagedBrandAsset } from "../../_lib/den-org";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
@@ -286,6 +286,7 @@ export function OrgSettingsScreen() {
     orgBusy,
     orgError,
     mutationBusy,
+    runReauthableAction,
     updateOrganizationSettings,
   } = useOrgDashboard();
   const [orgNameDraft, setOrgNameDraft] = useState("");
@@ -564,20 +565,27 @@ export function OrgSettingsScreen() {
 
   async function uploadBrandAssetDrafts() {
     if (!brandLogoDraft && !brandIconDraft) return;
-    const body = new FormData();
-    if (brandLogoDraft) body.set("logo", brandLogoDraft.file);
-    if (brandIconDraft) body.set("icon", brandIconDraft.file);
 
     setBrandAssetUploadBusy(true);
     try {
-      const { response, payload } = await requestJson(
-        "/v1/org/brand-assets",
-        { method: "POST", body },
-        30000,
-      );
-      if (!response.ok) {
-        throw new Error(getErrorMessage(payload, `Could not upload brand images (${response.status}).`));
-      }
+      await runReauthableAction("upload-brand-assets", async () => {
+        const body = new FormData();
+        if (brandLogoDraft) body.set("logo", brandLogoDraft.file);
+        if (brandIconDraft) body.set("icon", brandIconDraft.file);
+
+        const { response, payload } = await requestJson(
+          "/v1/org/brand-assets",
+          { method: "POST", body },
+          30000,
+        );
+        if (!response.ok) {
+          throw getRequestError(
+            payload,
+            response,
+            `Could not upload brand images (${response.status}).`,
+          );
+        }
+      });
     } finally {
       setBrandAssetUploadBusy(false);
     }

--- a/evals/flows/desktop-brand-icon.flow.mjs
+++ b/evals/flows/desktop-brand-icon.flow.mjs
@@ -106,6 +106,14 @@ async function panelEval(ctx, expression, options = {}) {
   return withPanelClient(ctx, (client) => evaluate(client, expression, options));
 }
 
+async function getPanelTargetId(ctx) {
+  const target = await waitUntil(ctx, "built-in browser panel CDP target", () => findPanelTarget(ctx), {
+    timeoutMs: 30_000,
+    intervalMs: 250,
+  });
+  return target.id;
+}
+
 async function waitForPanel(ctx, expression, { timeoutMs = 20_000, label = expression } = {}) {
   return waitUntil(ctx, label, () => panelEval(ctx, expression, { awaitPromise: true }), {
     timeoutMs,
@@ -442,6 +450,7 @@ export {
   denFetch,
   ensureRendererMounted,
   ensureWorkspaceReady,
+  getPanelTargetId,
   memberRefresh,
   navigateAdminOrgSettings,
   openAdminPanel,

--- a/evals/flows/managed-brand-asset-uploads.flow.mjs
+++ b/evals/flows/managed-brand-asset-uploads.flow.mjs
@@ -7,6 +7,7 @@ import {
   denFetch,
   ensureRendererMounted,
   ensureWorkspaceReady,
+  getPanelTargetId,
   memberRefresh,
   openAdminPanel,
   panelEval,
@@ -20,9 +21,12 @@ import {
 // Narration is loaded from the approved script (evals/voiceovers/managed-brand-asset-uploads.md).
 // The runner fails this flow if the narration drifts from that script.
 const vo = await loadVoiceoverParagraphs("managed-brand-asset-uploads");
+const ADMIN_PASSWORD = "OpenWorkDemo123!";
+const RAW_REAUTH_MESSAGE = "For security, confirm it's you before changing workspace settings.";
 
 let firstAssets = null;
 let firstIconBytes = null;
+let adminPanelTargetId = null;
 
 function orgSettingsUrl(ctx) {
   return `${ctx.env.OPENWORK_EVAL_DEN_WEB_URL.replace(/\/$/, "")}${ORG_SETTINGS_PATH}`;
@@ -77,6 +81,46 @@ async function ensureDesktopSession(ctx) {
     const status = await ctx.control("auth.status", {}).catch(() => null);
     return status?.status === "signed_in" ? status : null;
   }, { timeoutMs: 30_000 });
+}
+
+async function stageBrandUploadReauthResponse(ctx) {
+  await panelEval(ctx, `(() => {
+    const originalFetch = window.fetch.bind(window);
+    window.fetch = async (...args) => {
+      const [input, init] = args;
+      const url = typeof input === 'string' ? input : input instanceof Request ? input.url : String(input);
+      const method = String(init?.method ?? (input instanceof Request ? input.method : 'GET')).toUpperCase();
+      if (method === 'POST' && url.includes('/api/den/v1/org/brand-assets')) {
+        window.fetch = originalFetch;
+        window.__openworkBrandReauthIntercepted = true;
+        return new Response(${JSON.stringify(JSON.stringify({
+          error: "reauth",
+          reason: "fresh_auth_required",
+          message: RAW_REAUTH_MESSAGE,
+        }))}, {
+          status: 403,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      return originalFetch(...args);
+    };
+    return true;
+  })()`);
+}
+
+async function verifyPasswordInPanel(ctx) {
+  await panelEval(ctx, `(() => {
+    const input = document.querySelector('input[autocomplete="current-password"]');
+    if (!(input instanceof HTMLInputElement)) throw new Error('Reauth password input not found');
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+    if (!setter) throw new Error('Native password setter not found');
+    setter.call(input, ${JSON.stringify(ADMIN_PASSWORD)});
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    const button = Array.from(document.querySelectorAll('button')).find((candidate) => candidate.textContent?.trim() === 'Verify password');
+    if (!button || button.disabled) throw new Error('Verify password button not available');
+    button.click();
+    return true;
+  })()`);
 }
 
 async function navigateBrandSettings(ctx) {
@@ -189,6 +233,7 @@ export default {
         await openAdminPanel(ctx);
         await adminEnsureFreshAuth(ctx);
         await navigateBrandSettings(ctx);
+        adminPanelTargetId = await getPanelTargetId(ctx);
       },
     },
     {
@@ -215,7 +260,8 @@ export default {
           screenshot: {
             name: "frame-1-local-brand-files",
             sandboxCapture: true,
-            textTargetUrlIncludes: ORG_SETTINGS_PATH,
+            targetId: adminPanelTargetId,
+            textTargetId: adminPanelTargetId,
             requireText: ["Brand Appearance", "Ready to upload: example-corp-logo.png", "Ready to upload: example-corp-icon.png"],
           },
         });
@@ -232,6 +278,11 @@ export default {
               timeoutMs: 10_000,
               label: "square-icon validation message",
             });
+            await panelEval(ctx, `(() => {
+              document.querySelector('[data-testid="brand-asset-error"]')?.scrollIntoView({ block: 'center' });
+              return true;
+            })()`);
+            await sleep(500);
           },
           assert: async () => {
             const state = await panelEval(ctx, `(() => ({
@@ -247,7 +298,8 @@ export default {
           screenshot: {
             name: "frame-2-validation-and-previews",
             sandboxCapture: true,
-            textTargetUrlIncludes: ORG_SETTINGS_PATH,
+            targetId: adminPanelTargetId,
+            textTargetId: adminPanelTargetId,
             requireText: ["Ready to upload", "Use a square image for the app icon."],
           },
         });
@@ -256,12 +308,59 @@ export default {
     {
       name: "Frame 3",
       run: async (ctx) => {
-        await ctx.prove("Saving stores immutable assets in the Example Corp Den for members", {
+        await ctx.prove("A stale Brand Appearance save opens the security check without leaking the server response", {
           voiceover: vo[2],
           action: async () => {
             await selectGeneratedAsset(ctx, "icon", "initial");
             await waitForReadyDrafts(ctx);
+            await stageBrandUploadReauthResponse(ctx);
             await clickSaveSettings(ctx);
+            await waitForPanel(ctx, `(() => {
+              const dialog = document.querySelector('[role="dialog"]');
+              const passwordInput = dialog?.querySelector('input[autocomplete="current-password"]');
+              return Boolean(dialog && passwordInput && dialog.textContent?.includes("Confirm it's you to continue"));
+            })()`, { timeoutMs: 30_000, label: "Brand Appearance password reauth dialog" });
+          },
+          assert: async () => {
+            const state = await panelEval(ctx, `(() => {
+              const dialog = document.querySelector('[role="dialog"]');
+              const pageText = Array.from(document.body.children)
+                .filter((element) => !element.querySelector('[role="dialog"]'))
+                .map((element) => element.textContent ?? '')
+                .join(' ');
+              return {
+                dialogText: dialog?.textContent ?? '',
+                rawMessageOutsideDialog: pageText.includes(${JSON.stringify(RAW_REAUTH_MESSAGE)}),
+                interceptedReauth: window.__openworkBrandReauthIntercepted === true,
+                selectedLogo: document.querySelector('#brand-logo-upload')?.files?.[0]?.name ?? null,
+                selectedIcon: document.querySelector('#brand-icon-upload')?.files?.[0]?.name ?? null,
+              };
+            })()`);
+            ctx.assert(state.dialogText.includes("Confirm it's you to continue"), `Reauth dialog was missing: ${JSON.stringify(state)}`);
+            ctx.assert(state.dialogText.includes("Signing in as"), `Polished account context was missing: ${JSON.stringify(state)}`);
+            ctx.assert(!state.rawMessageOutsideDialog, `Raw reauth response leaked into the page: ${JSON.stringify(state)}`);
+            ctx.assert(state.interceptedReauth, `The brand upload did not receive the staged production reauth response: ${JSON.stringify(state)}`);
+            ctx.assert(state.selectedLogo === "example-corp-logo.png" && state.selectedIcon === "example-corp-icon.png", `Selected files were lost: ${JSON.stringify(state)}`);
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "The polished security dialog replaces the raw reauth response and both selected files remain queued", actual: state });
+          },
+          screenshot: {
+            name: "frame-3-brand-upload-security-check",
+            sandboxCapture: true,
+            targetId: adminPanelTargetId,
+            textTargetId: adminPanelTargetId,
+            requireText: ["SECURITY CHECK", "Confirm it's you to continue", "SIGNING IN AS", "Verify password"],
+            rejectText: [RAW_REAUTH_MESSAGE],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Verifying once resumes the queued brand upload without reselecting files", {
+          voiceover: vo[3],
+          action: async () => {
+            await verifyPasswordInPanel(ctx);
             firstAssets = await waitUntil(ctx, "managed asset metadata", async () => {
               const assets = await readManagedAssets(ctx);
               return assets.logo?.version && assets.icon?.version ? assets : null;
@@ -294,19 +393,40 @@ export default {
             ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Both assets have signed content-addressed Den URLs; unsigned access is rejected and signed responses are immutable", actual: { logo: firstAssets.logo.url, icon: firstAssets.icon.url } });
           },
           screenshot: {
-            name: "frame-3-saved-in-example-corp-den",
+            name: "frame-4-reauthenticated-upload-saved",
             sandboxCapture: true,
-            textTargetUrlIncludes: ORG_SETTINGS_PATH,
+            targetId: adminPanelTargetId,
+            textTargetId: adminPanelTargetId,
             requireText: ["Stored in this Den"],
           },
         });
       },
     },
     {
-      name: "Frame 4",
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("The saved assets are available to every member through the Example Corp Den", {
+          voiceover: vo[4],
+          assert: async () => {
+            ctx.assert(firstAssets?.logoUrl === firstAssets?.logo?.url, "Wordmark URL and managed metadata diverged.");
+            ctx.assert(firstAssets?.iconUrl === firstAssets?.icon?.url, "Icon URL and managed metadata diverged.");
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Both managed asset URLs were committed to the organization after reauth", actual: { logo: firstAssets.logo.url, icon: firstAssets.icon.url } });
+          },
+          screenshot: {
+            name: "frame-5-saved-in-example-corp-den",
+            sandboxCapture: true,
+            targetId: adminPanelTargetId,
+            textTargetId: adminPanelTargetId,
+            requireText: ["Stored in this Den"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
       run: async (ctx) => {
         await ctx.prove("A member desktop loads both brand URLs only from its Den", {
-          voiceover: vo[3],
+          voiceover: vo[5],
           action: async () => {
             await ctx.eval("performance.clearResourceTimings()");
             await memberRefresh(ctx);
@@ -335,18 +455,18 @@ export default {
             ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Sidebar wordmark and native icon source URLs use only the configured Den API origin", actual: { desktop, iconState, denOrigin } });
           },
           screenshot: {
-            name: "frame-4-member-desktop-den-branding",
+            name: "frame-6-member-desktop-den-branding",
             requireText: ["Search sessions"],
           },
         });
       },
     },
     {
-      name: "Frame 5",
+      name: "Frame 7",
       run: async (ctx) => {
         let replacement = null;
         await ctx.prove("Replacing an asset creates a new immutable version without invalidating the old bytes", {
-          voiceover: vo[4],
+          voiceover: vo[6],
           action: async () => {
             await openAdminPanel(ctx);
             await adminEnsureFreshAuth(ctx);
@@ -382,19 +502,20 @@ export default {
             ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Replacement has a new SHA-256 URL while both old and new immutable bytes remain readable", actual: { oldVersion: firstAssets.icon.version, newVersion: replacement.version, oldSha256: oldResult.sha256, newSha256: newResult.sha256 } });
           },
           screenshot: {
-            name: "frame-5-versioned-replacement",
+            name: "frame-7-versioned-replacement",
             sandboxCapture: true,
-            textTargetUrlIncludes: ORG_SETTINGS_PATH,
+            targetId: adminPanelTargetId,
+            textTargetId: adminPanelTargetId,
             requireText: ["Stored in this Den"],
           },
         });
       },
     },
     {
-      name: "Frame 6",
+      name: "Frame 8",
       run: async (ctx) => {
         await ctx.prove("Clearing managed assets restores default desktop branding", {
-          voiceover: vo[5],
+          voiceover: vo[7],
           action: async () => {
             await clearManagedAssetsInPanel(ctx);
             await sleep(250);
@@ -418,7 +539,7 @@ export default {
             ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Desktop config has no managed URLs, the sidebar wordmark is gone, and native icon state is default", actual: { brandLogoUrl: config.body.brandLogoUrl ?? null, brandIconUrl: config.body.brandIconUrl ?? null, iconState } });
           },
           screenshot: {
-            name: "frame-6-default-branding-restored",
+            name: "frame-8-default-branding-restored",
             requireText: ["Search sessions"],
           },
         });

--- a/evals/voiceovers/managed-brand-asset-uploads.md
+++ b/evals/voiceovers/managed-brand-asset-uploads.md
@@ -6,10 +6,14 @@ This proof covers Den-managed wordmark and square-icon uploads for an on-prem de
 
 2. OpenWork previews both files and validates their format, dimensions, and intended use.
 
-3. Saving makes the assets available to every member through the Example Corp deployment.
+3. If the owner's sign-in is no longer recent, saving opens a clear security check instead of exposing a raw server error.
 
-4. A teammate’s desktop loads the branding without contacting a public image CDN.
+4. The owner verifies once, and OpenWork resumes the pending upload automatically without making them choose the files again.
 
-5. Replacing an image produces a versioned asset, so desktops receive the new bytes instead of stale cache.
+5. The saved assets are now available to every member through the Example Corp deployment.
 
-6. Clearing the assets restores default branding.
+6. A teammate’s desktop loads the branding without contacting a public image CDN.
+
+7. Replacing an image produces a versioned asset, so desktops receive the new bytes instead of stale cache.
+
+8. Clearing the assets restores default branding.


### PR DESCRIPTION
## What changed

- route Brand Appearance logo and icon uploads through the shared reauthentication queue
- recreate multipart form data when the queued upload retries so selected files survive verification
- replace the raw `fresh_auth_required` response with the standard security dialog
- polish the dialog hierarchy and add deterministic end-to-end proof for the stale-upload flow

## Root cause

Brand asset uploads used `requestJson` directly and converted every non-2xx response into a plain `Error`. That bypassed the shared `ReauthRequiredError` handling used by other privileged organization mutations, so the raw server response could reach the page and the upload could not resume after verification.

## Validation

- `pnpm --filter @openwork-ee/den-web build` — passed, including TypeScript
- `OPENWORK_EVAL_DEN_PORT=8890 OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3015 pnpm fraimz --flow managed-brand-asset-uploads --stack den --cdp-url http://127.0.0.1:9823` — passed all 8 frames plus voice-over coverage
- fraimz: `evals/results/2026-07-10T06-40-17-863Z/fraimz.html`
