### PR TITLE
Calm routine workspace security notices

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
@@ -4,6 +4,7 @@ import { ShieldCheck, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { DenButton, buttonVariants } from "./ui/button";
 import { DenInput } from "./ui/input";
+import { DenNotice } from "./ui/notice";
 import { type AuthUser, getErrorMessage, getUser, requestJson, type SocialAuthProvider } from "../_lib/den-flow";
 import { type DenOrgContext, getRequireSsoFromMetadata } from "../_lib/den-org";
 
@@ -360,9 +361,7 @@ export function ReauthDialog({
           ) : null}
 
           {error ? (
-            <div className="mb-5 rounded-[18px] border border-red-200 bg-red-50 px-4 py-3 text-[14px] text-red-700">
-              {error}
-            </div>
+            <DenNotice message={error} tone="error" className="mb-5" />
           ) : null}
 
           <div className="grid gap-4">

--- a/ee/apps/den-web/app/(den)/_components/ui/notice.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/notice.tsx
@@ -1,0 +1,41 @@
+import { CircleAlert, Info } from "lucide-react";
+
+type DenNoticeTone = "error" | "info";
+
+const ROUTINE_SECURITY_MESSAGES = new Set([
+  "For security, confirm it's you before changing workspace settings.",
+  "Confirm it's you before continuing.",
+]);
+
+export function DenNotice({
+  message,
+  tone,
+  className,
+}: {
+  message: string;
+  tone?: DenNoticeTone;
+  className?: string;
+}) {
+  const resolvedTone =
+    tone ?? (ROUTINE_SECURITY_MESSAGES.has(message) ? "info" : "error");
+  const Icon = resolvedTone === "info" ? Info : CircleAlert;
+
+  return (
+    <div
+      role={resolvedTone === "error" ? "alert" : "status"}
+      data-notice-tone={resolvedTone}
+      className={[
+        "flex items-start gap-3 rounded-[24px] border px-5 py-4 text-[14px]",
+        resolvedTone === "info"
+          ? "border-sky-200 bg-sky-50 text-slate-700"
+          : "border-red-200 bg-red-50 text-red-700",
+        className ?? "",
+      ]
+        .filter(Boolean)
+        .join(" ")}
+    >
+      <Icon className="mt-0.5 size-4 shrink-0" aria-hidden="true" />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/api-keys-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/api-keys-screen.tsx
@@ -4,6 +4,7 @@ import { type FormEvent, useEffect, useMemo, useState } from "react";
 import { Copy, KeyRound, Trash2 } from "lucide-react";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
+import { DenNotice } from "../../_components/ui/notice";
 import { DenCard } from "../../_components/ui/card";
 import { DenInput } from "../../_components/ui/input";
 import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
@@ -283,9 +284,7 @@ export function ApiKeysScreen() {
             ) : (
                 <>
                     {error ? (
-                        <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">
-                            {error}
-                        </div>
+                        <DenNotice message={error} className="mb-6" />
                     ) : null}
 
                     <DenCard className="mb-6">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/manage-members-screen.tsx
@@ -34,6 +34,7 @@ import { DenButton } from "../../_components/ui/button";
 import { DenCard } from "../../_components/ui/card";
 import { DenInput } from "../../_components/ui/input";
 import { DenSelect } from "../../_components/ui/select";
+import { DenNotice } from "../../_components/ui/notice";
 import { OrgMemberIdentity } from "./org-member-identity";
 
 type MembersTab = "members" | "teams" | "roles";
@@ -738,9 +739,7 @@ export function ManageMembersScreen() {
       />
 
       {pageError ? (
-        <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">
-          {pageError}
-        </div>
+        <DenNotice message={pageError} className="mb-6" />
       ) : null}
 
       <UnderlineTabs

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
@@ -9,6 +9,7 @@ import { DenButton } from "../../_components/ui/button";
 import { DenCard } from "../../_components/ui/card";
 import { DenInput } from "../../_components/ui/input";
 import { DenTextarea } from "../../_components/ui/textarea";
+import { DenNotice } from "../../_components/ui/notice";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { EnterprisePlanNotice } from "./enterprise-plan-notice";
 
@@ -640,9 +641,7 @@ export function OrgSettingsScreen() {
         <EnterprisePlanNotice feature="Enforced SSO and desktop version control" />
       ) : null}
       {pageError ? (
-        <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">
-          {pageError}
-        </div>
+        <DenNotice message={pageError} className="mb-6" />
       ) : null}
       {pageSuccess ? (
         <div className="mb-6 rounded-[24px] border border-emerald-200 bg-emerald-50 px-5 py-4 text-[14px] text-emerald-700">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/scim-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/scim-screen.tsx
@@ -4,6 +4,7 @@ import { Copy, RefreshCw, Shield, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
+import { DenNotice } from "../../_components/ui/notice";
 import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
 import {
   type DenOrgScimConnection,
@@ -284,9 +285,7 @@ export function ScimScreen() {
       ) : (
         <>
           {error ? (
-            <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">
-              {error}
-            </div>
+            <DenNotice message={error} className="mb-6" />
           ) : null}
 
           {health.unresolvedFailureCount > 0 ? (

--- a/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
@@ -4,6 +4,7 @@ import { Copy, KeyRound, RefreshCw, Shield, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
+import { DenNotice } from "../../_components/ui/notice";
 import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
 import { getOrgAccessFlags, parseOrgSsoPayload, type DenOrgSsoConnection } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
@@ -279,7 +280,7 @@ export function SsoScreen() {
       ) : (
         <>
           {!orgContext.entitlements.sso ? <EnterprisePlanNotice feature="SSO" /> : null}
-          {error ? <div className="mb-6 rounded-[28px] border border-red-200 bg-red-50 px-6 py-4 text-[14px] text-red-700">{error}</div> : null}
+          {error ? <DenNotice message={error} className="mb-6" /> : null}
 
           {showConnectionForm ? (
             <div className="mb-6 rounded-[30px] border border-gray-200 bg-white p-6 shadow-[0_18px_48px_-34px_rgba(15,23,42,0.22)]">

--- a/evals/flows/calm-security-notice.flow.mjs
+++ b/evals/flows/calm-security-notice.flow.mjs
@@ -1,0 +1,168 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import {
+  applyDesktopViewport,
+  clickExactText,
+  clickSelectorWithMouse,
+  grantClipboardPermissions,
+  navigateTo,
+  signInToDenWeb,
+  stageStaleSessionAndInstallLinks,
+} from "./den-reauth-pending-action.flow.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/calm-security-notice.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("calm-security-notice");
+const GUIDANCE_MESSAGE = "Confirm it's you before continuing.";
+const RAW_REAUTH_MESSAGE = "For security, confirm it's you before changing workspace settings.";
+const COPY_INSTALL_LINK_SELECTOR = '[data-testid="copy-install-link"]';
+
+function recordAssertion(ctx, assertion, passed, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: passed ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(passed, `${assertion}. Actual: ${JSON.stringify(actual)}`);
+}
+
+async function cancelReauth(ctx) {
+  await ctx.waitFor(`(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    return Boolean(dialog && dialog.textContent.includes("Confirm it's you to continue"));
+  })()`, { timeoutMs: 30_000, label: "reauth dialog" });
+  await clickExactText(ctx, "Cancel", "button");
+  await ctx.waitFor(`(() => {
+    const notice = document.querySelector('[data-notice-tone="info"]');
+    return Boolean(notice && notice.textContent.includes(${JSON.stringify(GUIDANCE_MESSAGE)}));
+  })()`, { timeoutMs: 20_000, label: "calm security guidance" });
+  await ctx.eval(`(() => {
+    document.querySelector('[data-notice-tone="info"]')?.scrollIntoView({ block: 'center', behavior: 'instant' });
+    return true;
+  })()`);
+  await ctx.waitFor(`(() => {
+    const notice = document.querySelector('[data-notice-tone="info"]');
+    if (!notice) return false;
+    const rect = notice.getBoundingClientRect();
+    return rect.top >= 0 && rect.bottom <= window.innerHeight;
+  })()`, { timeoutMs: 10_000, label: "security guidance in viewport" });
+}
+
+async function readGuidanceNotice(ctx) {
+  return ctx.eval(`(() => {
+    const notice = document.querySelector('[data-notice-tone]');
+    return {
+      text: notice?.textContent?.trim() ?? '',
+      tone: notice?.getAttribute('data-notice-tone') ?? '',
+      role: notice?.getAttribute('role') ?? '',
+      className: notice?.getAttribute('class') ?? '',
+      rawServerMessageVisible: document.body.innerText.includes(${JSON.stringify(RAW_REAUTH_MESSAGE)}),
+    };
+  })()`);
+}
+
+export default {
+  id: "calm-security-notice",
+  title: "Routine security confirmation reads as calm guidance across workspace settings",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MYSQL_CONTAINER"],
+  steps: [
+    {
+      name: "Members shows canceled reauth as calm guidance",
+      run: async (ctx) => {
+        await ctx.prove("Members presents routine identity confirmation as guidance instead of an error", {
+          voiceover: vo[0],
+          action: async () => {
+            await applyDesktopViewport(ctx);
+            await signInToDenWeb(ctx);
+            await stageStaleSessionAndInstallLinks(ctx);
+            await navigateTo(ctx, "/dashboard/members");
+            await grantClipboardPermissions(ctx);
+            await ctx.waitFor(`(() => {
+              const button = document.querySelector(${JSON.stringify(COPY_INSTALL_LINK_SELECTOR)});
+              return Boolean(button && !button.disabled && button.textContent.includes('Copy install link'));
+            })()`, { timeoutMs: 45_000, label: "copy install link button" });
+            await clickSelectorWithMouse(ctx, COPY_INSTALL_LINK_SELECTOR, "copy install link button");
+            await cancelReauth(ctx);
+          },
+          assert: async () => {
+            const actual = await readGuidanceNotice(ctx);
+            recordAssertion(ctx, "The routine confirmation is an informational status", actual.text === GUIDANCE_MESSAGE && actual.tone === "info" && actual.role === "status", actual);
+            recordAssertion(ctx, "The routine confirmation has no aggressive red treatment", !actual.className.includes("red-") && actual.rawServerMessageVisible === false, actual);
+          },
+          screenshot: {
+            name: "calm-security-members",
+            requireText: ["Members", GUIDANCE_MESSAGE],
+            rejectText: [RAW_REAUTH_MESSAGE],
+          },
+        });
+      },
+    },
+    {
+      name: "Org settings uses the same calm notice",
+      run: async (ctx) => {
+        await ctx.prove("Org settings uses the same reusable informational notice", {
+          voiceover: vo[1],
+          action: async () => {
+            await navigateTo(ctx, "/dashboard/org-settings");
+            await ctx.waitFor("document.body.innerText.includes('Org settings') && document.body.innerText.includes('Save settings')", {
+              timeoutMs: 45_000,
+              label: "organization settings",
+            });
+            await clickExactText(ctx, "Save settings", "button");
+            await cancelReauth(ctx);
+          },
+          assert: async () => {
+            const actual = await readGuidanceNotice(ctx);
+            recordAssertion(ctx, "Org settings renders the same informational security guidance", actual.text === GUIDANCE_MESSAGE && actual.tone === "info" && actual.role === "status", actual);
+            recordAssertion(ctx, "The settings notice remains free of red error styling", !actual.className.includes("red-"), actual);
+          },
+          screenshot: {
+            name: "calm-security-org-settings",
+            requireText: ["Org settings", GUIDANCE_MESSAGE],
+            rejectText: [RAW_REAUTH_MESSAGE],
+          },
+        });
+      },
+    },
+    {
+      name: "A real authentication failure remains distinct",
+      run: async (ctx) => {
+        await ctx.prove("An invalid password remains a clearly marked error", {
+          voiceover: vo[2],
+          action: async () => {
+            await clickExactText(ctx, "Save settings", "button");
+            await ctx.waitFor("Boolean(document.querySelector('[role=\"dialog\"] input[autocomplete=\"current-password\"]'))", {
+              timeoutMs: 30_000,
+              label: "password reauth form",
+            });
+            await ctx.fill('[role="dialog"] input[autocomplete="current-password"]', "definitely-wrong-password");
+            await clickExactText(ctx, "Verify password", "button");
+            await ctx.waitFor(`(() => {
+              const dialog = document.querySelector('[role="dialog"]');
+              return Boolean(dialog?.querySelector('[data-notice-tone="error"][role="alert"]'));
+            })()`, { timeoutMs: 30_000, label: "invalid password error" });
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => {
+              const error = document.querySelector('[role="dialog"] [data-notice-tone="error"]');
+              return {
+                visible: Boolean(error),
+                role: error?.getAttribute('role') ?? '',
+                className: error?.getAttribute('class') ?? '',
+                text: error?.textContent?.trim() ?? '',
+              };
+            })()`);
+            recordAssertion(ctx, "The failed verification is exposed as an alert", actual.visible === true && actual.role === "alert" && actual.text.length > 0, actual);
+            recordAssertion(ctx, "The real failure retains explicit red error styling", actual.className.includes("border-red-200") && actual.className.includes("bg-red-50") && actual.className.includes("text-red-700"), actual);
+          },
+          screenshot: {
+            name: "calm-security-real-error",
+            requireText: ["Confirm it's you to continue"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/den-reauth-pending-action.flow.mjs
+++ b/evals/flows/den-reauth-pending-action.flow.mjs
@@ -224,7 +224,31 @@ async function stageStaleSessionAndInstallLinks(ctx) {
 
     UPDATE session SET created_at = DATE_SUB(NOW(3), INTERVAL 1 HOUR);
   `);
+
+  if (!ctx.client?.send) {
+    return;
+  }
+
+  const cookieResult = await ctx.client.send("Network.getAllCookies", {});
+  const cachedSessionCookies = cookieResult.cookies.filter((cookie) => cookie.name.includes("session_data"));
+  for (const cookie of cachedSessionCookies) {
+    await ctx.client.send("Network.deleteCookies", {
+      name: cookie.name,
+      domain: cookie.domain,
+      path: cookie.path,
+    });
+  }
 }
+
+export {
+  applyDesktopViewport,
+  clickExactText,
+  clickSelectorWithMouse,
+  grantClipboardPermissions,
+  navigateTo,
+  signInToDenWeb,
+  stageStaleSessionAndInstallLinks,
+};
 
 export default {
   id: FLOW_ID,

--- a/evals/voiceovers/calm-security-notice.md
+++ b/evals/voiceovers/calm-security-notice.md
@@ -1,0 +1,7 @@
+# calm-security-notice — Security confirmation reads as guidance, not failure
+
+1. When a workspace action needs identity confirmation, OpenWork presents the security message as calm guidance instead of a red error.
+
+2. The same reusable notice appears consistently across Members and other workspace settings screens.
+
+3. Real failures remain visually distinct, while routine confirmation prompts no longer feel alarming.


### PR DESCRIPTION
## What changed

- add a reusable DenNotice with calm informational and explicit error tones
- render routine workspace re-auth guidance calmly across Members, Org settings, SSO, SCIM, and API Keys
- keep genuine re-authentication failures visually and semantically distinct
- add an approved three-frame voiceover and fraimz regression flow

## Why

Routine identity confirmation was flowing through page-level error banners, making an expected security step look like a failure.

## Validation

- `pnpm exec tsc --noEmit` from `ee/apps/den-web` — passed
- `git diff --check` — passed
- `OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3005 OPENWORK_EVAL_DEN_MYSQL_CONTAINER=openwork-web-local-mysql pnpm fraimz --flow calm-security-notice --cdp-url http://127.0.0.1:9823` — passed (3/3 narrated frames plus voiceover coverage)

Fraimz artifact: `evals/results/2026-07-10T06-44-02-121Z/fraimz.html` (local, generated and gitignored); the proof will be posted to this PR.