### PR TITLE
Fix single-org email invite joins

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -4,7 +4,7 @@
   "version": "0.17.19",
   "type": "module",
   "scripts": {
-    "test": "bun test tests/",
+    "test": "bun test --isolate tests/",
     "dev": "OPENWORK_DEV_MODE=1 vite",
     "build": "vite build",
     "dev:web": "OPENWORK_DEV_MODE=1 vite",

--- a/ee/apps/den-api/src/organization-join-verification.ts
+++ b/ee/apps/den-api/src/organization-join-verification.ts
@@ -5,17 +5,16 @@ export type JoinVerificationResult =
 /**
  * Verification boundary for organization membership.
  *
- * Unverified accounts are intentionally allowed to sign up, create their OWN
- * organization, and invite teammates so that an agent can bootstrap a workspace
- * end-to-end with no human in the loop. The one hard boundary is JOINING an
- * organization owned by someone else: that requires a verified email. This keeps
- * the open self-serve signup path agent-friendly while ensuring an unverified
- * actor can only ever affect their own sandbox org.
+ * Unverified accounts are intentionally allowed to sign up when a deployment
+ * does not require email verification. When verification is required, joining
+ * another organization remains the hard boundary; when it is not required (the
+ * single-org default), the email invite itself is the join proof.
  */
 export function validateInvitationAcceptVerification(input: {
   emailVerified: boolean | null | undefined
+  emailVerificationRequired: boolean
 }): JoinVerificationResult {
-  if (input.emailVerified === true) {
+  if (!input.emailVerificationRequired || input.emailVerified === true) {
     return { ok: true }
   }
 

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -678,7 +678,23 @@ export async function acceptInvitationForUser(input: {
     return null
   }
 
-  if (getInvitationStatus(invitation) !== "pending") {
+  const invitationStatus = getInvitationStatus(invitation)
+  if (invitationStatus !== "pending") {
+    if (invitationStatus === "accepted") {
+      const memberRows = await db
+        .select()
+        .from(MemberTable)
+        .where(and(eq(MemberTable.organizationId, invitation.organizationId), eq(MemberTable.userId, input.userId), isNull(MemberTable.removedAt)))
+        .limit(1)
+      const member = memberRows[0]
+      if (member) {
+        return {
+          invitation,
+          member,
+        }
+      }
+    }
+
     return null
   }
 

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -258,7 +258,7 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         200: jsonResponse("Invitation accepted successfully.", invitationAcceptedResponseSchema),
         400: jsonResponse("The invitation acceptance request body was invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to accept an invitation.", unauthorizedSchema),
-        403: jsonResponse("API keys cannot accept invitations, or the account email is unverified.", forbiddenSchema),
+        403: jsonResponse("API keys cannot accept invitations, or the deployment requires a verified account email.", forbiddenSchema),
         409: jsonResponse("The current account email is not allowed to join this organization.", accountEmailDomainNotAllowedSchema),
         404: jsonResponse("The invitation could not be found.", notFoundSchema),
       },
@@ -281,7 +281,10 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
       return c.json({ error: "user_email_required" }, 400)
     }
 
-    const verification = validateInvitationAcceptVerification({ emailVerified: user.emailVerified })
+    const verification = validateInvitationAcceptVerification({
+      emailVerified: user.emailVerified,
+      emailVerificationRequired: env.requireEmailVerification,
+    })
     if (!verification.ok) {
       return c.json({ error: verification.error, message: verification.message }, 403)
     }

--- a/ee/apps/den-api/test/invite-duplicate-members.test.ts
+++ b/ee/apps/den-api/test/invite-duplicate-members.test.ts
@@ -19,6 +19,7 @@ const noPendingUserId = createDenTypeId("user")
 const noInviteUserId = createDenTypeId("user")
 const mergeUserId = createDenTypeId("user")
 const ownerMergeUserId = createDenTypeId("user")
+const acceptedInviteUserId = createDenTypeId("user")
 const expiredInviteUserId = createDenTypeId("user")
 const nonMatchingInviteUserId = createDenTypeId("user")
 const otherOrgInviteUserId = createDenTypeId("user")
@@ -32,6 +33,7 @@ const noPendingEmail = `no-pending+${noPendingUserId}@invite-duplicates.test`
 const noInviteEmail = `no-invite+${noInviteUserId}@invite-duplicates.test`
 const mergeEmail = `merge+${mergeUserId}@invite-duplicates.test`
 const ownerMergeEmail = `owner-merge+${ownerMergeUserId}@invite-duplicates.test`
+const acceptedInviteEmail = `accepted+${acceptedInviteUserId}@invite-duplicates.test`
 const expiredEmail = `expired+${expiredInviteUserId}@invite-duplicates.test`
 const nonMatchingEmail = `non-matching+${nonMatchingInviteUserId}@invite-duplicates.test`
 const otherOrgEmail = `other-org+${otherOrgInviteUserId}@invite-duplicates.test`
@@ -61,6 +63,7 @@ const userIds = [
   noInviteUserId,
   mergeUserId,
   ownerMergeUserId,
+  acceptedInviteUserId,
   expiredInviteUserId,
   nonMatchingInviteUserId,
   otherOrgInviteUserId,
@@ -176,6 +179,7 @@ beforeAll(async () => {
     { id: noInviteUserId, name: "No Invite", email: noInviteEmail, emailVerified: false },
     { id: mergeUserId, name: "Merge User", email: mergeEmail, emailVerified: true },
     { id: ownerMergeUserId, name: "Owner Merge", email: ownerMergeEmail, emailVerified: true },
+    { id: acceptedInviteUserId, name: "Accepted Invite", email: acceptedInviteEmail, emailVerified: false },
     { id: expiredInviteUserId, name: "Expired Invite", email: expiredEmail, emailVerified: false },
     { id: nonMatchingInviteUserId, name: "Non Matching", email: nonMatchingEmail, emailVerified: false },
     { id: otherOrgInviteUserId, name: "Other Org", email: otherOrgEmail, emailVerified: false },
@@ -432,6 +436,40 @@ test("acceptInvitation does not downgrade an existing owner while removing the p
   expect(relatedMembers[0]?.role).toBe("owner")
   expect(relatedMembers[0]?.joinedAt).toBeInstanceOf(Date)
   await expect(invitationStatus(invitationId)).resolves.toBe("accepted")
+})
+
+test("acceptInvitationForUser returns the existing member when bootstrap already accepted the invite", async () => {
+  if (!orgs) {
+    throw new Error("orgs module not initialized")
+  }
+  const invitationId = createDenTypeId("invitation")
+  const placeholderId = createDenTypeId("member")
+  await createInvitation({
+    invitationId,
+    memberId: placeholderId,
+    organizationId,
+    email: acceptedInviteEmail,
+    role: "member",
+    expiresAt: future,
+    inviterMemberId: ownerMemberId,
+  })
+
+  const bootstrapMember = await orgs.ensureBootstrapMembershipForOrganization({
+    organizationId,
+    userId: acceptedInviteUserId,
+    role: "member",
+    email: acceptedInviteEmail,
+  })
+  await expect(invitationStatus(invitationId)).resolves.toBe("accepted")
+
+  const accepted = await orgs.acceptInvitationForUser({
+    userId: acceptedInviteUserId,
+    email: acceptedInviteEmail,
+    invitationId,
+  })
+
+  expect(accepted?.invitation.id).toBe(invitationId)
+  expect(accepted?.member.id).toBe(bootstrapMember.id)
 })
 
 test("bootstrap ignores expired, non-matching, and other-org invitations", async () => {

--- a/ee/apps/den-api/test/organization-join-verification.test.ts
+++ b/ee/apps/den-api/test/organization-join-verification.test.ts
@@ -8,6 +8,7 @@ function seedRequiredEnv() {
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
   process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.DEN_REQUIRE_EMAIL_VERIFICATION = "true"
 }
 
 let orgRoutesModule: typeof import("../src/routes/org/index.js")
@@ -43,19 +44,18 @@ function createOrgAppWithUser(user: { id: string; email: string; emailVerified: 
   return app
 }
 
-test("unverified accounts may create their own org and invite, but not join one", () => {
-  // Unverified is the only blocked transition: joining someone else's org.
-  expect(validateInvitationAcceptVerification({ emailVerified: false })).toEqual({
+test("deployments with required email verification block unverified joins", () => {
+  expect(validateInvitationAcceptVerification({ emailVerified: false, emailVerificationRequired: true })).toEqual({
     ok: false,
     error: "email_verification_required",
     message: "Verify your email address before joining an organization.",
   })
-  expect(validateInvitationAcceptVerification({ emailVerified: null })).toEqual({
+  expect(validateInvitationAcceptVerification({ emailVerified: null, emailVerificationRequired: true })).toEqual({
     ok: false,
     error: "email_verification_required",
     message: "Verify your email address before joining an organization.",
   })
-  expect(validateInvitationAcceptVerification({ emailVerified: undefined })).toEqual({
+  expect(validateInvitationAcceptVerification({ emailVerified: undefined, emailVerificationRequired: true })).toEqual({
     ok: false,
     error: "email_verification_required",
     message: "Verify your email address before joining an organization.",
@@ -63,7 +63,13 @@ test("unverified accounts may create their own org and invite, but not join one"
 })
 
 test("verified accounts are allowed to join an organization", () => {
-  expect(validateInvitationAcceptVerification({ emailVerified: true })).toEqual({ ok: true })
+  expect(validateInvitationAcceptVerification({ emailVerified: true, emailVerificationRequired: true })).toEqual({ ok: true })
+})
+
+test("deployments without required email verification let invited users join", () => {
+  expect(validateInvitationAcceptVerification({ emailVerified: false, emailVerificationRequired: false })).toEqual({ ok: true })
+  expect(validateInvitationAcceptVerification({ emailVerified: null, emailVerificationRequired: false })).toEqual({ ok: true })
+  expect(validateInvitationAcceptVerification({ emailVerified: undefined, emailVerificationRequired: false })).toEqual({ ok: true })
 })
 
 test("accept-invitation route blocks an unverified user with 403 before touching the database", async () => {


### PR DESCRIPTION
## Summary
- Allow invitation acceptance when the deployment does not require email verification (single-org default).
- Keep the verified-email guard for deployments that explicitly require email verification.
- Treat an invite already accepted by single-org bootstrap as success for the same user, so the final Join click lands on the success screen.
- Add tests for verification-required vs verification-not-required joins and already-adopted invitations.

## Validation
- `pnpm exec bun test ee/apps/den-api/test/organization-join-verification.test.ts` ✅
- `DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_den pnpm exec bun test ee/apps/den-api/test/invite-duplicate-members.test.ts` ✅
- `pnpm --filter @openwork-ee/den-api build` ✅

## Manual Chrome proof
- Ran `OPENWORK_DEV_MODE=1 DEN_ORG_MODE=single_org DEN_REQUIRE_EMAIL_VERIFICATION=false pnpm dev:web-local`.
- Opened `http://127.0.0.1:3005/join-org?invite=<token>` in Chrome via CDP.
- Signed up as the invited email, clicked Join, and verified the success screen: “You're in, welcome to OpenWork”.
- Confirmed the page did not show “Verify your email address before joining an organization”.
- Screenshot captured locally at `/var/folders/vr/43v2k79x62b1gtyskgx7zjb40000gn/T/browser-screenshot-1783675533893.png`; public upload was not available from CLI because Infisical login for the blob upload token is not active.

## Fraimz
Not run; validated the real browser flow manually via Chrome CDP as above.