### PR TITLE
Prompt default-name users to update profile

### DIFF
--- a/ee/apps/den-api/src/routes/me/index.ts
+++ b/ee/apps/den-api/src/routes/me/index.ts
@@ -1,5 +1,5 @@
 import { eq } from "@openwork-ee/den-db/drizzle"
-import { AuthAccountTable, RateLimitTable } from "@openwork-ee/den-db/schema"
+import { AuthAccountTable, AuthUserTable, RateLimitTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { desktopConfigSchema } from "@openwork/types/den/desktop-policies"
 import type { Hono } from "hono"
@@ -53,6 +53,17 @@ const sendDownloadLinkEmailFailedSchema = z.object({
   message: z.string(),
 }).meta({ ref: "SendDownloadLinkEmailFailedError" })
 
+const updateProfileSchema = z.object({
+  firstName: z.string().trim().max(120),
+  lastName: z.string().trim().max(120),
+}).refine((value) => value.firstName.length > 0 || value.lastName.length > 0, {
+  message: "Enter a first or last name.",
+})
+
+const updateProfileResponseSchema = z.object({
+  user: z.object({}).passthrough(),
+}).meta({ ref: "UpdateCurrentUserProfileResponse" })
+
 const setActiveOrganizationSchema = z.object({
   organizationId: denTypeIdSchema("organization").optional(),
   organizationSlug: z.string().trim().min(1).max(255).optional(),
@@ -98,6 +109,10 @@ function normalizeAuthProvider(providerId: string) {
     return "scim"
   }
   return normalized || "unknown"
+}
+
+function normalizeNamePart(value: string) {
+  return value.replace(/\s+/g, " ").trim()
 }
 
 async function checkDownloadLinkRateLimit(userId: string, now: number) {
@@ -245,6 +260,43 @@ export function registerMeRoutes<T extends { Variables: AuthContextVariables & P
       }
 
       return c.json({ ok: true })
+    },
+  )
+
+  app.patch(
+    "/v1/me/profile",
+    describeRoute({
+      tags: ["Users"],
+      summary: "Update current user profile",
+      description: "Updates the signed-in user's display name.",
+      responses: {
+        200: jsonResponse("Current user profile updated successfully.", updateProfileResponseSchema),
+        400: jsonResponse("The profile update request body was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to update profile data.", unauthorizedSchema),
+      },
+    }),
+    authenticatedRoute(),
+    jsonValidator(updateProfileSchema),
+    async (c) => {
+      const user = c.get("user")
+      const input = c.req.valid("json")
+      const firstName = normalizeNamePart(input.firstName)
+      const lastName = normalizeNamePart(input.lastName)
+      const name = [firstName, lastName].filter((part) => part.length > 0).join(" ")
+      const updatedAt = new Date()
+
+      await db
+        .update(AuthUserTable)
+        .set({ name, updatedAt })
+        .where(eq(AuthUserTable.id, normalizeDenTypeId("user", user.id)))
+
+      return c.json({
+        user: {
+          ...user,
+          name,
+          updatedAt,
+        },
+      })
     },
   )
 

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -97,6 +97,7 @@ type DenFlowContextValue = {
   cancelVerification: () => void;
   beginSocialAuth: (provider: SocialAuthProvider) => Promise<void>;
   signOut: () => Promise<void>;
+  updateUserProfile: (input: { firstName: string; lastName: string }) => Promise<AuthUser>;
   resolveUserLandingRoute: () => Promise<string | null>;
   billingSummary: BillingSummary | null;
   billingBusy: boolean;
@@ -1292,6 +1293,30 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }
   }
 
+  async function updateUserProfile(input: { firstName: string; lastName: string }) {
+    const { response, payload } = await requestJson(
+      "/v1/me/profile",
+      {
+        method: "PATCH",
+        body: JSON.stringify(input),
+      },
+      12000,
+    );
+
+    if (!response.ok) {
+      throw new Error(getErrorMessage(payload, `Failed to update profile (${response.status}).`));
+    }
+
+    const nextUser = getUser(payload);
+    if (!nextUser) {
+      throw new Error("Profile update response did not include a user.");
+    }
+
+    setUser(nextUser);
+    identifyPosthogUser(nextUser);
+    return nextUser;
+  }
+
   async function launchWorker(options: { source?: "manual" | "signup_auto"; workerNameOverride?: string } = {}) {
     if (!user) {
       setAuthError("Sign in before launching a worker.");
@@ -2083,6 +2108,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     cancelVerification,
     beginSocialAuth,
     signOut,
+    updateUserProfile,
     resolveUserLandingRoute,
     billingSummary,
     billingBusy,

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -21,6 +21,7 @@ import {
   X,
 } from "lucide-react";
 import { useDenFlow } from "../../_providers/den-flow-provider";
+import { DEFAULT_AUTH_NAME } from "../../_lib/den-flow";
 import {
   formatRoleLabel,
   getAnalyticsRoute,
@@ -46,6 +47,7 @@ import { useOrgListWindow } from "../../_lib/use-org-list-window";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { buildDenFeedbackUrl } from "../../_lib/feedback";
 import { OrgSelectionScreen } from "./org-selection-screen";
+import { UserProfileDialog } from "./user-profile-dialog";
 
 const OPENWORK_DOCS_URL = "/docs";
 
@@ -182,7 +184,7 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
 
 export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
-  const { user, signOut, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
+  const { user, signOut, updateUserProfile, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
   const {
     activeOrg,
     orgDirectory,
@@ -195,6 +197,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   } = useOrgDashboard();
   const [switcherOpen, setSwitcherOpen] = useState(false);
   const [sidebarOpen, setSidebarOpen] = useState(false);
+  const [profilePromptDismissed, setProfilePromptDismissed] = useState(false);
   const isSingleOrgMode = runtimeConfigLoaded && runtimeConfig.orgMode === "single_org";
   const {
     query: switcherQuery,
@@ -226,6 +229,11 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   );
 
   const pageTitle = getDashboardPageTitle(pathname, activeOrg?.slug ?? null);
+  const shouldShowProfilePrompt = Boolean(
+    user &&
+      !profilePromptDismissed &&
+      user.name?.trim() === DEFAULT_AUTH_NAME,
+  );
   const feedbackHref = buildDenFeedbackUrl({
     pathname,
     orgSlug: activeOrg?.slug,
@@ -624,6 +632,19 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
 
         <main className="flex-1 overflow-y-auto bg-[#fafafa]">{children}</main>
       </div>
+
+      {shouldShowProfilePrompt && user ? (
+        <UserProfileDialog
+          key={user.id}
+          user={user}
+          descriptor="Change how your name appears in the organization"
+          onCancel={() => setProfilePromptDismissed(true)}
+          onSave={async (input) => {
+            await updateUserProfile(input);
+            setProfilePromptDismissed(true);
+          }}
+        />
+      ) : null}
     </div>
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/user-profile-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/user-profile-dialog.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useMemo, useState, type FormEvent } from "react";
+import type { AuthUser } from "../../_lib/den-flow";
+
+type UserProfileDialogProps = {
+  user: AuthUser;
+  title?: string;
+  descriptor?: string;
+  onCancel: () => void;
+  onSave: (input: { firstName: string; lastName: string }) => Promise<void>;
+};
+
+function getProfileNameParts(name: string | null) {
+  const parts = (name ?? "").trim().split(/\s+/).filter(Boolean);
+  return {
+    firstName: parts[0] ?? "",
+    lastName: parts.slice(1).join(" "),
+  };
+}
+
+export function UserProfileDialog({
+  user,
+  title = "User Profile",
+  descriptor,
+  onCancel,
+  onSave,
+}: UserProfileDialogProps) {
+  const initialName = useMemo(() => getProfileNameParts(user.name), [user.name]);
+  const [firstName, setFirstName] = useState(initialName.firstName);
+  const [lastName, setLastName] = useState(initialName.lastName);
+  const [busy, setBusy] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const normalizedFirstName = firstName.trim();
+  const normalizedLastName = lastName.trim();
+  const hasChanged = normalizedFirstName !== initialName.firstName || normalizedLastName !== initialName.lastName;
+  const hasName = normalizedFirstName.length > 0 || normalizedLastName.length > 0;
+  const canSave = hasChanged && hasName && !busy;
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!canSave) {
+      return;
+    }
+
+    setBusy(true);
+    setError(null);
+    try {
+      await onSave({ firstName, lastName });
+    } catch (saveError) {
+      setError(saveError instanceof Error ? saveError.message : "Could not update your profile.");
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-[80] flex items-center justify-center bg-gray-950/45 px-4 py-6" role="presentation">
+      <section
+        className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-36px_rgba(15,23,42,0.7)] sm:p-7"
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="user-profile-title"
+        aria-describedby={descriptor ? "user-profile-description" : undefined}
+      >
+        <div className="mb-6">
+          <p className="text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-400">OpenWork</p>
+          <h2 id="user-profile-title" className="mt-2 text-2xl font-semibold tracking-[-0.04em] text-gray-950">
+            {title}
+          </h2>
+          {descriptor ? (
+            <p id="user-profile-description" className="mt-2 text-sm leading-6 text-gray-500">
+              {descriptor}
+            </p>
+          ) : null}
+        </div>
+
+        <form onSubmit={handleSubmit} className="grid gap-5">
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="grid gap-2">
+              <span className="text-sm font-medium text-gray-700">First name</span>
+              <input
+                type="text"
+                value={firstName}
+                onChange={(event) => setFirstName(event.target.value)}
+                className="w-full rounded-2xl border border-gray-200 px-4 py-3 text-sm text-gray-900 outline-none transition focus:border-gray-400 focus:ring-4 focus:ring-gray-900/5"
+                autoComplete="given-name"
+                autoFocus
+              />
+            </label>
+
+            <label className="grid gap-2">
+              <span className="text-sm font-medium text-gray-700">Last name</span>
+              <input
+                type="text"
+                value={lastName}
+                onChange={(event) => setLastName(event.target.value)}
+                className="w-full rounded-2xl border border-gray-200 px-4 py-3 text-sm text-gray-900 outline-none transition focus:border-gray-400 focus:ring-4 focus:ring-gray-900/5"
+                autoComplete="family-name"
+              />
+            </label>
+          </div>
+
+          {error ? <p className="text-sm font-medium text-rose-600">{error}</p> : null}
+
+          <div className="flex flex-col-reverse gap-3 sm:flex-row sm:justify-end">
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-2xl border border-gray-200 px-5 py-3 text-sm font-medium text-gray-700 transition hover:bg-gray-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              disabled={!canSave}
+              className="rounded-2xl bg-gray-900 px-5 py-3 text-sm font-medium text-white transition hover:bg-gray-800 disabled:cursor-not-allowed disabled:opacity-50"
+            >
+              {busy ? "Saving..." : "Save"}
+            </button>
+          </div>
+        </form>
+      </section>
+    </div>
+  );
+}

--- a/evals/flows/on-sign-in-verify-name.flow.mjs
+++ b/evals/flows/on-sign-in-verify-name.flow.mjs
@@ -1,0 +1,295 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/on-sign-in-verify-name.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("on-sign-in-verify-name");
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function goTo(ctx, path) {
+  await ctx.eval(`location.assign(${JSON.stringify(`${DEN_WEB_URL}${path}`)})`);
+  await sleep(1_500);
+}
+
+async function resetSession(ctx) {
+  await ctx.eval(
+    `(async () => {
+      const token = localStorage.getItem("openwork:web:auth-token");
+      try {
+        await fetch("/api/auth/sign-out", {
+          method: "POST",
+          headers: {
+            "content-type": "application/json",
+            ...(token ? { authorization: "Bearer " + token } : {}),
+          },
+          body: "{}",
+        });
+      } catch {}
+      localStorage.removeItem("openwork:web:auth-token");
+      return true;
+    })()`,
+    { awaitPromise: true },
+  );
+}
+
+async function uiSignIn(ctx) {
+  await goTo(ctx, "/");
+  if (await ctx.eval("location.pathname.startsWith('/dashboard')")) {
+    await resetSession(ctx);
+    await goTo(ctx, "/");
+  }
+
+  await ctx.waitFor("document.body.innerText.includes('Sign in')", { timeoutMs: 30_000, label: "auth screen" });
+  await ctx.eval(`(() => {
+    const tab = [...document.querySelectorAll('button, a')].find((el) => el.textContent.trim() === 'Sign in');
+    tab?.click();
+    return true;
+  })()`);
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]'))", { timeoutMs: 15_000, label: "email input" });
+
+  const submitted = await ctx.eval(`(() => {
+    const setNative = (el, value) => {
+      const proto = Object.getPrototypeOf(el);
+      const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+      desc.set.call(el, value);
+      el.dispatchEvent(new Event('input', { bubbles: true }));
+      el.dispatchEvent(new Event('change', { bubbles: true }));
+    };
+    const email = document.querySelector('input[type="email"], input[name="email"]');
+    const password = document.querySelector('input[type="password"]');
+    if (!email || !password) return false;
+    setNative(email, ${JSON.stringify(ADMIN_EMAIL)});
+    setNative(password, ${JSON.stringify(ADMIN_PASSWORD)});
+    const buttons = [...document.querySelectorAll('button')].filter((el) => el.textContent.trim() === 'Sign in' && !el.disabled);
+    buttons[buttons.length - 1]?.click();
+    return buttons.length > 0;
+  })()`);
+  ctx.assert(submitted, "Could not fill and submit the sign-in form.");
+  await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 45_000, label: "dashboard after sign-in" });
+  await ctx.waitFor("Boolean(document.querySelector('nav'))", { timeoutMs: 30_000, label: "dashboard sidebar rendered" });
+}
+
+async function updateProfileName(ctx, firstName, lastName) {
+  const result = await ctx.eval(
+    `(async () => {
+      const token = localStorage.getItem("openwork:web:auth-token");
+      const response = await fetch(${JSON.stringify(`${DEN_API_URL}/v1/me/profile`)}, {
+        method: "PATCH",
+        credentials: "include",
+        headers: {
+          "accept": "application/json",
+          "content-type": "application/json",
+          ...(token ? { authorization: "Bearer " + token } : {}),
+        },
+        body: JSON.stringify({ firstName: ${JSON.stringify(firstName)}, lastName: ${JSON.stringify(lastName)} }),
+      });
+      const body = await response.json().catch(() => null);
+      return { ok: response.ok, status: response.status, body };
+    })()`,
+    { awaitPromise: true },
+  );
+  ctx.assert(result.ok, `Profile setup failed with ${result.status}.`);
+}
+
+async function readProfileName(ctx) {
+  const result = await ctx.eval(
+    `(async () => {
+      const token = localStorage.getItem("openwork:web:auth-token");
+      const response = await fetch(${JSON.stringify(`${DEN_API_URL}/v1/me`)}, {
+        method: "GET",
+        credentials: "include",
+        headers: {
+          "accept": "application/json",
+          ...(token ? { authorization: "Bearer " + token } : {}),
+        },
+      });
+      const body = await response.json().catch(() => null);
+      return { ok: response.ok, status: response.status, name: body?.user?.name ?? null };
+    })()`,
+    { awaitPromise: true },
+  );
+  ctx.assert(result.ok, `Profile read failed with ${result.status}.`);
+  return result.name;
+}
+
+async function waitForProfileDialog(ctx) {
+  await ctx.waitFor(`(() => {
+    const text = document.body.innerText;
+    return text.includes("User Profile") && text.includes("Change how your name appears in the organization");
+  })()`, { timeoutMs: 20_000, label: "default-name profile dialog" });
+}
+
+async function selectProfileField(ctx, autoComplete) {
+  const selected = await ctx.eval(`(() => {
+    const input = document.querySelector(${JSON.stringify(`input[autocomplete="${autoComplete}"]`)});
+    if (!input) return false;
+    input.focus();
+    input.select();
+    return true;
+  })()`);
+  ctx.assert(selected, `Could not select ${autoComplete}.`);
+  await sleep(250);
+}
+
+async function fillProfileField(ctx, autoComplete, value) {
+  const filled = await ctx.eval(`(() => {
+    const input = document.querySelector(${JSON.stringify(`input[autocomplete="${autoComplete}"]`)});
+    if (!input) return false;
+    const proto = Object.getPrototypeOf(input);
+    const desc = Object.getOwnPropertyDescriptor(proto, 'value');
+    desc.set.call(input, ${JSON.stringify(value)});
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    return true;
+  })()`);
+  ctx.assert(filled, `Could not fill ${autoComplete}.`);
+}
+
+async function clickDialogButton(ctx, label) {
+  const clicked = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === ${JSON.stringify(label)} && !el.disabled);
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked, `Could not click ${label}.`);
+}
+
+export default {
+  id: "on-sign-in-verify-name",
+  title: "Default-name users are prompted to update their profile from the dashboard",
+  kind: "user-facing",
+  spec: "evals/voiceovers/on-sign-in-verify-name.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("A signed-in dashboard user with the default name sees the User Profile dialog", {
+          voiceover: vo[0],
+          action: async () => {
+            await uiSignIn(ctx);
+            await updateProfileName(ctx, "OpenWork", "User");
+            await goTo(ctx, "/dashboard");
+          },
+          assert: async () => {
+            await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 20_000, label: "dashboard route" });
+            await waitForProfileDialog(ctx);
+          },
+          screenshot: {
+            name: "default-name-dashboard-dialog",
+            claim: "The dashboard opens a User Profile dialog for the default OpenWork User name.",
+            requireText: ["User Profile", "Change how your name appears in the organization"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The dialog shows first and last name fields with Save disabled until a change", {
+          voiceover: vo[1],
+          action: async () => {
+            await waitForProfileDialog(ctx);
+            await selectProfileField(ctx, "given-name");
+          },
+          assert: async () => {
+            const state = await ctx.eval(`(() => {
+              const first = document.querySelector('input[autocomplete="given-name"]');
+              const last = document.querySelector('input[autocomplete="family-name"]');
+              const save = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === 'Save');
+              return { first: first?.value ?? null, last: last?.value ?? null, saveDisabled: save?.disabled === true };
+            })()`);
+            ctx.assert(state.first === "OpenWork", "First name is prefilled from the default name.");
+            ctx.assert(state.last === "User", "Last name is prefilled from the default name.");
+            ctx.assert(state.saveDisabled, "Save is disabled before the user changes a field.");
+          },
+          screenshot: {
+            name: "profile-dialog-disabled-save",
+            claim: "The profile dialog asks for first and last name and Save starts disabled.",
+            requireText: ["First name", "Last name", "Save", "Cancel"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Changing either name field enables Save", {
+          voiceover: vo[2],
+          action: async () => {
+            await fillProfileField(ctx, "given-name", "Maya");
+            await fillProfileField(ctx, "family-name", "Rivera");
+          },
+          assert: async () => {
+            const saveEnabled = await ctx.eval(`(() => {
+              const save = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === 'Save');
+              return Boolean(save && !save.disabled);
+            })()`);
+            ctx.assert(saveEnabled, "Save is enabled after changing the profile fields.");
+          },
+          screenshot: {
+            name: "profile-dialog-save-enabled",
+            claim: "Editing the fields enables Save.",
+            requireText: ["User Profile", "Save", "Cancel"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Saving writes the new display name and returns to the dashboard", {
+          voiceover: vo[3],
+          action: async () => {
+            await clickDialogButton(ctx, "Save");
+          },
+          assert: async () => {
+            await ctx.waitFor("!document.body.innerText.includes('User Profile')", { timeoutMs: 20_000, label: "profile dialog closes after save" });
+            const name = await readProfileName(ctx);
+            ctx.assert(name === "Maya Rivera", "The user table stores the saved profile name.");
+          },
+          screenshot: {
+            name: "dashboard-after-profile-save",
+            claim: "After Save, the dialog closes and the dashboard remains visible.",
+            requireText: ["Dashboard"],
+            rejectText: ["User Profile", "Could not update your profile"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("Cancel closes the dialog without changing the default name during that dashboard visit", {
+          voiceover: vo[4],
+          action: async () => {
+            await updateProfileName(ctx, "OpenWork", "User");
+            await goTo(ctx, "/dashboard");
+            await waitForProfileDialog(ctx);
+            await clickDialogButton(ctx, "Cancel");
+            await sleep(1_000);
+          },
+          assert: async () => {
+            await ctx.waitFor("!document.body.innerText.includes('User Profile')", { timeoutMs: 10_000, label: "profile dialog remains dismissed" });
+            const name = await readProfileName(ctx);
+            ctx.assert(name === "OpenWork User", "Cancel leaves the stored default name unchanged.");
+          },
+          screenshot: {
+            name: "dashboard-after-profile-cancel",
+            claim: "Cancel dismisses the prompt for the current dashboard visit without saving.",
+            requireText: ["Dashboard"],
+            rejectText: ["User Profile", "Could not update your profile"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/on-sign-in-verify-name.md
+++ b/evals/voiceovers/on-sign-in-verify-name.md
@@ -1,0 +1,11 @@
+# on-sign-in-verify-name — prompt default-name users to identify themselves
+
+1. A user signs in and lands on the OpenWork dashboard. Because their profile still says “OpenWork User,” OpenWork immediately opens a “User Profile” dialog instead of leaving the team with an indistinguishable default name.
+
+2. The dialog explains, “Change how your name appears in the organization,” and shows two fields: First name and Last name. The Save button is disabled because nothing has changed yet.
+
+3. The user edits one or both fields. Save becomes available as soon as the displayed name would change.
+
+4. The user clicks Save. OpenWork updates the user’s profile name and closes the dialog, leaving the dashboard visible with the corrected name stored for the organization.
+
+5. If the user clicks Cancel instead, the dialog closes without changing the name, and OpenWork does not prompt again during that same dashboard visit.


### PR DESCRIPTION
## Summary
- add a current-user profile update endpoint that writes the display name to the user table
- show a generic User Profile dialog on the dashboard when the signed-in user's name is the default `OpenWork User`
- add a voiceover + fraimz flow for the default-name profile prompt

## Verification
- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm --filter @openwork-ee/den-web build` — passed
- `node --check evals/flows/on-sign-in-verify-name.flow.mjs` — passed
- `OPENWORK_EVAL_DEN_PORT=8890 OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3006 OPENWORK_EVAL_DEN_API_URL=http://127.0.0.1:8890 pnpm fraimz --flow on-sign-in-verify-name --stack den --cdp-url http://127.0.0.1:9223` — passed
  - Proof: `evals/results/2026-07-10T09-23-26-746Z/fraimz.html`
- Manual Chrome validation with `pnpm dev:web-local` at `http://localhost:3005` — passed: dialog appeared for `OpenWork User`, Save enabled after changes, Save persisted the DB name, Cancel dismissed without saving.