### PR TITLE
fix(den): include desktop version in Docker image

### DIFF
--- a/packaging/docker/Dockerfile.den
+++ b/packaging/docker/Dockerfile.den
@@ -23,6 +23,7 @@ COPY packages/install-config /app/packages/install-config
 COPY ee/packages/utils /app/ee/packages/utils
 COPY ee/packages/den-db /app/ee/packages/den-db
 COPY ee/apps/den-api /app/ee/apps/den-api
+COPY apps/desktop/package.json /app/apps/desktop/package.json
 
 RUN pnpm --dir /app/packages/email run build
 RUN pnpm --dir /app/packages/install-config run build


### PR DESCRIPTION
## Summary
- Copy apps/desktop/package.json into the Den API Docker image build context
- Lets den-api build script generate BUILD_LATEST_APP_VERSION from the desktop package version instead of falling back to 0.0.0 in self-hosted images

## Validation
- docker build -f packaging/docker/Dockerfile.den -t openwork-den-api:app-version-controls .
- docker run --rm openwork-den-api:app-version-controls node -e "import('/app/ee/apps/den-api/dist/version.js').then((m) => { console.log(JSON.stringify(m.denApiAppVersion)); if (m.denApiAppVersion.latestAppVersion === '0.0.0') process.exit(1); })" → {"minAppVersion":"0.11.207","latestAppVersion":"0.17.19"}

## Proof
- No video/screenshot captured: this is a Docker packaging fix with CLI/image validation rather than an interactive UI flow.