### PR TITLE
Fix typo: dekstop -> desktop in changelog

### DIFF
--- a/packages/docs/changelog.mdx
+++ b/packages/docs/changelog.mdx
@@ -268,7 +268,7 @@ title: "Changelog"
 
   ## [v0.11.146](https://github.com/different-ai/openwork/compare/v0.11.1444...v0.11.146): Den admin view and Aesthetic changes 
 
-  - Den worker redeploys, better dekstop skill reload and adjustable sidebar width. 
+  - Den worker redeploys, better desktop skill reload and adjustable sidebar width. 
 
 </Update>
 


### PR DESCRIPTION
Fix typo in packages/docs/changelog.mdx.