### PR TITLE
feat(den): attach workspace files to Gmail drafts

### DIFF
--- a/ee/apps/den-api/src/capability-sources/gmail.ts
+++ b/ee/apps/den-api/src/capability-sources/gmail.ts
@@ -4,11 +4,27 @@
  * Kept pure so the encoding is unit-testable without any HTTP.
  */
 
+import { randomUUID } from "node:crypto"
+
 function hasNonAscii(value: string): boolean {
   for (const char of value) {
     if (char.codePointAt(0)! > 0x7e || char.codePointAt(0)! < 0x20) return true
   }
   return false
+}
+
+export type GmailDraftAttachment = {
+  filename: string
+  mimeType: string
+  content: Buffer
+}
+
+function encodeMimeParameter(value: string): string {
+  return value.replace(/[\r\n]+/g, " ").replace(/\\/g, "\\\\").replace(/"/g, '\\"')
+}
+
+function base64MimeContent(content: Buffer): string {
+  return content.toString("base64").match(/.{1,76}/g)?.join("\r\n") ?? ""
 }
 
 /** RFC 2047 B-encoding for header values that contain non-ASCII characters. */
@@ -38,18 +54,45 @@ export function readGmailDraftIds(text: string): { draftId: string | null; messa
   }
 }
 
-export function buildGmailDraftRaw(input: { to: string; cc?: string; bcc?: string; subject: string; body: string; headers?: { name: string; value: string }[] }): string {
-  const message = [
+export function buildGmailDraftRaw(input: { to: string; cc?: string; bcc?: string; subject: string; body: string; headers?: { name: string; value: string }[]; attachments?: GmailDraftAttachment[] }): string {
+  const headers = [
     `To: ${input.to}`,
     input.cc ? `Cc: ${input.cc}` : null,
     input.bcc ? `Bcc: ${input.bcc}` : null,
     `Subject: ${encodeMimeHeaderValue(input.subject)}`,
     ...(input.headers ?? []).map((header) => `${header.name}: ${header.value}`),
+  ].filter((line) => typeof line === "string")
+  const attachments = input.attachments ?? []
+  const message = attachments.length === 0 ? [
+    ...headers,
     "MIME-Version: 1.0",
     'Content-Type: text/plain; charset="UTF-8"',
     "Content-Transfer-Encoding: base64",
     "",
     Buffer.from(input.body, "utf8").toString("base64"),
-  ].filter((line) => typeof line === "string").join("\r\n")
+  ].join("\r\n") : (() => {
+    const boundary = `openwork-${randomUUID()}`
+    return [
+      ...headers,
+      "MIME-Version: 1.0",
+      `Content-Type: multipart/mixed; boundary="${boundary}"`,
+      "",
+      `--${boundary}`,
+      'Content-Type: text/plain; charset="UTF-8"',
+      "Content-Transfer-Encoding: base64",
+      "",
+      Buffer.from(input.body, "utf8").toString("base64"),
+      ...attachments.flatMap((attachment) => [
+        `--${boundary}`,
+        `Content-Type: ${attachment.mimeType}; name="${encodeMimeParameter(attachment.filename)}"`,
+        `Content-Disposition: attachment; filename="${encodeMimeParameter(attachment.filename)}"`,
+        "Content-Transfer-Encoding: base64",
+        "",
+        base64MimeContent(attachment.content),
+      ]),
+      `--${boundary}--`,
+      "",
+    ].join("\r\n")
+  })()
   return Buffer.from(message, "utf8").toString("base64url")
 }

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -7,6 +7,7 @@ import { env } from "../../env.js"
 import { jsonValidator, orgMemberRoute, paramValidator, queryValidator } from "../../middleware/index.js"
 import { jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import { buildGmailDraftRaw, readGmailDraftIds } from "../../capability-sources/gmail.js"
+import type { GmailDraftAttachment } from "../../capability-sources/gmail.js"
 import { getValidAccessToken } from "../../capability-sources/generic-oauth.js"
 import {
   buildDriveSearchQuery,
@@ -28,8 +29,17 @@ const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file"
 const DRIVE_READ_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
 const DRIVE_FULL_SCOPE = "https://www.googleapis.com/auth/drive"
 const GOOGLE_WORKSPACE_API_TIMEOUT_MS = 30_000
+const MAX_GMAIL_ATTACHMENT_BYTES = 10 * 1024 * 1024
+const MAX_GMAIL_ATTACHMENTS_TOTAL_BYTES = 20 * 1024 * 1024
+const MAX_GMAIL_ATTACHMENT_BASE64_LENGTH = Math.ceil(MAX_GMAIL_ATTACHMENT_BYTES / 3) * 4
 
 const CONNECT_GOOGLE_ACCOUNT_MESSAGE = "Connect your Google account first: open Settings > Connect and use Connect your account on the Google Workspace row, or connect from the OpenWork Cloud dashboard."
+
+const gmailDraftAttachmentSchema = z.object({
+  filename: z.string().trim().min(1).max(255).refine((value) => !/[\r\n]/.test(value), "Filename must not contain line breaks.").describe("Filename to show in Gmail."),
+  mimeType: z.string().trim().regex(/^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/).describe("Attachment MIME type."),
+  dataBase64: z.string().min(1).max(MAX_GMAIL_ATTACHMENT_BASE64_LENGTH).regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/).describe("File bytes encoded as standard base64. Read the file from the active workspace and base64-encode it. Maximum decoded size: 10 MiB per file and 20 MiB total."),
+}).strict()
 
 const createDraftBodySchema = z.object({
   to: z.string().trim().min(3).max(320).describe("Recipient email address."),
@@ -38,7 +48,17 @@ const createDraftBodySchema = z.object({
   subject: z.string().trim().min(1).max(500).describe("Draft subject line."),
   body: z.string().min(1).max(50_000).describe("Plain-text draft body."),
   threadId: z.string().trim().min(1).max(512).optional().describe("Optional Gmail thread id to reply on. Get it from the gmail-messages capability. When set, the draft is attached to that thread as a reply — keep the thread's subject (e.g. 'Re: …')."),
-}).strict()
+  attachments: z.array(gmailDraftAttachmentSchema).min(1).max(10).optional().describe("Optional files from the active workspace to attach to this draft."),
+}).strict().superRefine((input, context) => {
+  const totalBytes = (input.attachments ?? []).reduce((total, attachment) => total + Buffer.byteLength(attachment.dataBase64, "base64"), 0)
+  if (totalBytes > MAX_GMAIL_ATTACHMENTS_TOTAL_BYTES) {
+    context.addIssue({
+      code: "custom",
+      path: ["attachments"],
+      message: "Attachments must be 20 MiB or less in total.",
+    })
+  }
+})
 
 const createDraftResponseSchema = z.object({
   ok: z.literal(true),
@@ -47,6 +67,11 @@ const createDraftResponseSchema = z.object({
   to: z.string(),
   subject: z.string(),
   threadId: z.string().nullable(),
+  attachments: z.array(z.object({
+    filename: z.string(),
+    mimeType: z.string(),
+    size: z.number().int().nonnegative(),
+  })).optional(),
 }).meta({ ref: "GoogleWorkspaceDraftResponse" })
 
 const needsConnectionSchema = z.object({
@@ -741,8 +766,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     "/v1/capabilities/google-workspace/gmail-drafts",
     describeRoute({
       tags: ["Capability Sources"],
-      summary: "Create a Gmail draft or threaded reply draft as the calling member",
-      description: "Creates a plain-text Gmail draft in the calling member own mailbox, with optional Cc/Bcc recipients. Set threadId to attach the draft to an existing Gmail thread as a reply using the thread's matching subject. Returns needs_connection when the member has not connected their Google account yet or when a threaded reply needs Gmail read permission.",
+      summary: "Create a Gmail draft or threaded reply draft; attach workspace files with body.attachments: [{ filename, mimeType, dataBase64 }], where dataBase64 is the file bytes encoded as standard base64",
+      description: "Creates a plain-text Gmail draft in the calling member own mailbox, with optional Cc/Bcc recipients and files read from the active workspace. Set threadId to attach the draft to an existing Gmail thread as a reply using the thread's matching subject. Returns needs_connection when the member has not connected their Google account yet or when a threaded reply needs Gmail read permission.",
       responses: {
         200: jsonResponse("Draft created.", createDraftResponseSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
@@ -765,7 +790,12 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         return c.json({ error: "needs_connection", message: token.message }, 409)
       }
 
-      const { to, cc, bcc, subject, body, threadId } = c.req.valid("json")
+      const { to, cc, bcc, subject, body, threadId, attachments: attachmentInputs } = c.req.valid("json")
+      const attachments: GmailDraftAttachment[] = (attachmentInputs ?? []).map((attachment) => ({
+        filename: attachment.filename,
+        mimeType: attachment.mimeType,
+        content: Buffer.from(attachment.dataBase64, "base64"),
+      }))
       const headers: { name: string; value: string }[] = []
       if (threadId) {
         if (missingScope(token.account, [GMAIL_READ_SCOPE])) {
@@ -794,7 +824,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         )
       }
 
-      const message: { raw: string; threadId?: string } = { raw: buildGmailDraftRaw({ to, cc, bcc, subject, body, headers }) }
+      const message: { raw: string; threadId?: string } = { raw: buildGmailDraftRaw({ to, cc, bcc, subject, body, headers, attachments }) }
       if (threadId) {
         message.threadId = threadId
       }
@@ -816,7 +846,25 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         return c.json({ error: "google_api_error", message: "Gmail returned no draft id." }, 502)
       }
 
-      return c.json({ ok: true, draftId, messageId, to, subject, threadId: threadId ?? null })
+      const result = {
+        ok: true,
+        draftId,
+        messageId,
+        to,
+        subject,
+        threadId: threadId ?? null,
+      }
+      if (attachments.length === 0) {
+        return c.json(result)
+      }
+      return c.json({
+        ...result,
+        attachments: attachments.map((attachment) => ({
+          filename: attachment.filename,
+          mimeType: attachment.mimeType,
+          size: attachment.content.byteLength,
+        })),
+      })
     },
   )
 }

--- a/ee/apps/den-api/test/gmail-draft.test.ts
+++ b/ee/apps/den-api/test/gmail-draft.test.ts
@@ -104,6 +104,26 @@ describe("buildGmailDraftRaw", () => {
       "MIME-Version: 1.0",
     ])
   })
+
+  test("encodes attachments as multipart MIME while preserving filename, MIME type, and bytes", () => {
+    const decoded = decodeRaw(gmail.buildGmailDraftRaw({
+      to: "sam@acme.test",
+      subject: "Invoice",
+      body: "Please review the attached invoice.",
+      attachments: [{
+        filename: 'invoice "final".pdf',
+        mimeType: "application/pdf",
+        content: Buffer.from("%PDF attachment bytes", "utf8"),
+      }],
+    }))
+    const boundary = decoded.match(/boundary="([^"]+)"/)?.[1]
+    expect(boundary).toStartWith("openwork-")
+    expect(decoded).toContain("Content-Type: multipart/mixed;")
+    expect(decoded).toContain('Content-Type: application/pdf; name="invoice \\"final\\".pdf"')
+    expect(decoded).toContain('Content-Disposition: attachment; filename="invoice \\"final\\".pdf"')
+    expect(decoded).toContain(Buffer.from("%PDF attachment bytes", "utf8").toString("base64"))
+    expect(decoded).toContain(`--${boundary}--\r\n`)
+  })
 })
 
 describe("extractGmailThreadReplyContext", () => {

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -544,6 +544,36 @@ test("gmail plain draft supports cc without requiring a thread", async () => {
   expect(body).toEqual({ ok: true, draftId: "draft_1", messageId: "draft_msg_1", to, subject, threadId: null })
 })
 
+test("gmail plain draft attaches active workspace file bytes with filename and MIME type", async () => {
+  const attachmentBytes = Buffer.from("%PDF-1.4\nworkspace invoice\n", "utf8")
+  const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+    method: "POST",
+    body: {
+      to: "accounts@acme.test",
+      subject: "Workspace invoice",
+      body: "Please see the attached invoice.",
+      attachments: [{
+        filename: "invoice-2026.pdf",
+        mimeType: "application/pdf",
+        dataBase64: attachmentBytes.toString("base64"),
+      }],
+    },
+  })
+  expect(response.status).toBe(200)
+  expect(googleCallCount).toBe(1)
+  const decoded = decodeDraftRaw()
+  expect(decoded).toContain("Content-Type: multipart/mixed;")
+  expect(decoded).toContain('Content-Type: application/pdf; name="invoice-2026.pdf"')
+  expect(decoded).toContain('Content-Disposition: attachment; filename="invoice-2026.pdf"')
+  expect(decoded).toContain(attachmentBytes.toString("base64"))
+  const body: unknown = await response.json()
+  expect(expectRecord(body, "attachment draft response").attachments).toEqual([{
+    filename: "invoice-2026.pdf",
+    mimeType: "application/pdf",
+    size: attachmentBytes.byteLength,
+  }])
+})
+
 test("gmail threaded reply draft reads thread metadata and sends reply headers", async () => {
   const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
     method: "POST",
@@ -553,6 +583,11 @@ test("gmail threaded reply draft reads thread metadata and sends reply headers",
       subject: "Quarterly plan",
       threadId: "thread_1",
       body: "Reply body",
+      attachments: [{
+        filename: "notes.txt",
+        mimeType: "text/plain",
+        dataBase64: Buffer.from("workspace notes", "utf8").toString("base64"),
+      }],
     },
   })
   expect(response.status).toBe(200)
@@ -569,9 +604,71 @@ test("gmail threaded reply draft reads thread metadata and sends reply headers",
   const decoded = decodeDraftRaw()
   expect(decoded).toContain("In-Reply-To: <orig-2@mail.gmail.com>\r\n")
   expect(decoded).toContain("References: <orig-1@mail.gmail.com> <orig-2@mail.gmail.com>\r\n")
+  expect(decoded).toContain('Content-Disposition: attachment; filename="notes.txt"')
+  expect(decoded).toContain(Buffer.from("workspace notes", "utf8").toString("base64"))
   const body: unknown = await response.json()
   const responseBody = expectRecord(body, "threaded draft response")
   expect(responseBody.threadId).toBe("thread_1")
+})
+
+test("gmail draft rejects invalid attachment encoding and MIME type without calling Google", async () => {
+  for (const attachment of [
+    { filename: "invoice.pdf", mimeType: "application/pdf", dataBase64: "not base64!" },
+    { filename: "invoice.pdf", mimeType: "invalid mime type", dataBase64: "aW52b2ljZQ==" },
+    { filename: "invoice.pdf\r\nBcc: attacker@acme.test", mimeType: "application/pdf", dataBase64: "aW52b2ljZQ==" },
+  ]) {
+    resetFakeGoogle()
+    const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+      method: "POST",
+      body: {
+        to: "sam@acme.test",
+        subject: "Quarterly plan",
+        body: "Draft body",
+        attachments: [attachment],
+      },
+    })
+    expect(response.status).toBe(400)
+    expect(googleCallCount).toBe(0)
+    const body: unknown = await response.json()
+    expect(expectRecord(body, "invalid attachment response").error).toBe("invalid_request")
+  }
+})
+
+test("gmail draft rejects attachments over per-file and aggregate size limits without calling Google", async () => {
+  const overPerFile = Buffer.alloc((10 * 1024 * 1024) + 1).toString("base64")
+  const aggregateFiles = Array.from({ length: 3 }, (_, index) => ({
+    filename: `part-${index}.bin`,
+    mimeType: "application/octet-stream",
+    dataBase64: Buffer.alloc(7 * 1024 * 1024).toString("base64"),
+  }))
+  for (const attachments of [
+    [{ filename: "large.bin", mimeType: "application/octet-stream", dataBase64: overPerFile }],
+    aggregateFiles,
+  ]) {
+    resetFakeGoogle()
+    const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+      method: "POST",
+      body: { to: "sam@acme.test", subject: "Quarterly plan", body: "Draft body", attachments },
+    })
+    expect(response.status).toBe(400)
+    expect(googleCallCount).toBe(0)
+  }
+})
+
+test("gmail draft rejects empty and excessive attachment lists without calling Google", async () => {
+  for (const attachments of [[], Array.from({ length: 11 }, (_, index) => ({
+    filename: `file-${index}.txt`,
+    mimeType: "text/plain",
+    dataBase64: "ZmlsZQ==",
+  }))]) {
+    resetFakeGoogle()
+    const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+      method: "POST",
+      body: { to: "sam@acme.test", subject: "Quarterly plan", body: "Draft body", attachments },
+    })
+    expect(response.status).toBe(400)
+    expect(googleCallCount).toBe(0)
+  }
 })
 
 test("gmail threaded reply draft requires Gmail read scope before calling Google", async () => {
@@ -709,6 +806,10 @@ test("Google Workspace capability tools are discoverable and keep readable names
   expect(searchCapabilities(catalog, "add meet link existing event", 10)[0]?.name).toBe("patchCapabilitiesGoogleWorkspaceCalendarEvent")
   expect(searchCapabilities(catalog, "drive files", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceDriveFiles")
   expect(searchCapabilities(catalog, "gmail search read messages", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceGmailMessages")
+  const draftMatch = searchCapabilities(catalog, "gmail draft workspace attachment", 10)[0]
+  expect(draftMatch?.name).toBe("postCapabilitiesGoogleWorkspaceGmailDrafts")
+  expect(draftMatch?.summary).toContain("attachments: [{ filename, mimeType, dataBase64 }]")
+  expect(draftMatch?.summary).toContain("standard base64")
 
   const expectedNames = [
     "getCapabilitiesGoogleWorkspaceGmailMessages",
@@ -718,6 +819,7 @@ test("Google Workspace capability tools are discoverable and keep readable names
     "patchCapabilitiesGoogleWorkspaceCalendarEvent",
     "getCapabilitiesGoogleWorkspaceDriveFiles",
     "getCapabilitiesGoogleWorkspaceDriveFile",
+    "postCapabilitiesGoogleWorkspaceGmailDrafts",
   ]
   const catalogNames = new Set(catalog.map((tool) => tool.name))
   for (const name of expectedNames) {

--- a/evals/flows/google-workspace-gmail-draft-attachments.flow.mjs
+++ b/evals/flows/google-workspace-gmail-draft-attachments.flow.mjs
@@ -1,0 +1,161 @@
+/**
+ * Internal proof for the Google Workspace Gmail-draft attachment capability.
+ *
+ * The user-facing surface is an agent capability rather than dedicated UI, so
+ * the proof binds the discoverable tool contract to the MIME sent to the mock
+ * Gmail API and the focused integration tests that exercise that boundary.
+ */
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "google-workspace-gmail-draft-attachments";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const DEN_API_ROOT = join(ROOT, "ee", "apps", "den-api");
+const ROUTE_PATH = join(ROOT, "ee", "apps", "den-api", "src", "routes", "org", "google-workspace.ts");
+const MIME_PATH = join(ROOT, "ee", "apps", "den-api", "src", "capability-sources", "gmail.ts");
+const ROUTE_TEST_PATH = join(ROOT, "ee", "apps", "den-api", "test", "google-workspace-capabilities.test.ts");
+const MIME_TEST_PATH = join(ROOT, "ee", "apps", "den-api", "test", "gmail-draft.test.ts");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+let testRun;
+
+function witness(ctx, condition, assertion, actual = "") {
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual });
+    ctx.assert(false, actual ? `${assertion} (actual: ${actual})` : assertion);
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual });
+}
+
+function snippet(source, anchor, lineCount) {
+  const lines = source.split("\n");
+  const start = lines.findIndex((line) => line.includes(anchor));
+  if (start === -1) return `Missing snippet anchor: ${anchor}`;
+  return lines.slice(start, start + lineCount).map((line, index) => `${start + index + 1}: ${line}`).join("\n");
+}
+
+async function sources() {
+  const [route, mime, routeTest, mimeTest] = await Promise.all([
+    readFile(ROUTE_PATH, "utf8"),
+    readFile(MIME_PATH, "utf8"),
+    readFile(ROUTE_TEST_PATH, "utf8"),
+    readFile(MIME_TEST_PATH, "utf8"),
+  ]);
+  return { route, mime, routeTest, mimeTest };
+}
+
+function targetedTests() {
+  testRun ??= spawnSync("pnpm", ["exec", "bun", "test", "test/gmail-draft.test.ts", "test/google-workspace-capabilities.test.ts"], {
+    cwd: DEN_API_ROOT,
+    encoding: "utf8",
+    timeout: 120_000,
+  });
+  return testRun;
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Google Workspace Gmail drafts accept bounded workspace-file attachments for new messages and threaded replies",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "The agent can discover the workspace attachment contract",
+      run: async (ctx) => {
+        await ctx.prove("Capability search tells the agent exactly how to attach active-workspace file bytes", {
+          voiceover: vo[0],
+          assert: async () => {
+            const { route } = await sources();
+            witness(
+              ctx,
+              route.includes("body.attachments: [{ filename, mimeType, dataBase64 }]") ,
+              "The searchable operation summary exposes the exact attachment body shape",
+            );
+            witness(ctx, route.includes("Read the file from the active workspace and base64-encode it"), "The data field directs the agent to the active workspace file");
+            witness(ctx, route.includes("attachments: z.array(gmailDraftAttachmentSchema).min(1).max(10).optional()"), "The draft body accepts an optional bounded attachment list");
+            ctx.output("discoverable Gmail-draft contract", [
+              snippet(route, "const gmailDraftAttachmentSchema", 20),
+              snippet(route, "summary: \"Create a Gmail draft", 5),
+            ].join("\n\n"));
+          },
+        });
+      },
+    },
+    {
+      name: "Filename, MIME type, and bytes become a real attachment",
+      run: async (ctx) => {
+        await ctx.prove("The MIME builder preserves the requested filename and file type and carries the exact workspace bytes", {
+          voiceover: vo[1],
+          action: async () => {
+            targetedTests();
+          },
+          assert: async () => {
+            const { mime, mimeTest } = await sources();
+            const run = targetedTests();
+            witness(ctx, run.status === 0, "The focused Gmail MIME and capability tests pass", (run.stdout + run.stderr).trim().split("\n").slice(-8).join("\n"));
+            witness(ctx, mime.includes('Content-Type: ${attachment.mimeType}; name="${encodeMimeParameter(attachment.filename)}"'), "The attachment MIME part uses the requested type and safe filename");
+            witness(ctx, mime.includes('Content-Disposition: attachment; filename="${encodeMimeParameter(attachment.filename)}"'), "The part is explicitly marked as an attachment");
+            witness(ctx, mime.includes("base64MimeContent(attachment.content)"), "The MIME part contains the supplied file bytes encoded as base64");
+            witness(ctx, mimeTest.includes("encodes attachments as multipart MIME while preserving filename, MIME type, and bytes"), "A focused unit test decodes and checks the multipart draft");
+            ctx.output("$ pnpm exec bun test Gmail attachment suites", (run.stdout + run.stderr).trim());
+            ctx.output("multipart MIME builder", snippet(mime, "const message = attachments.length === 0", 38));
+          },
+        });
+      },
+    },
+    {
+      name: "Creating the draft confirms the attachment without sending",
+      run: async (ctx) => {
+        await ctx.prove("The capability calls Gmail drafts.create and returns recipient, subject, and attachment metadata", {
+          voiceover: vo[2],
+          assert: async () => {
+            const { route, routeTest } = await sources();
+            witness(ctx, route.includes('/gmail/v1/users/me/drafts'), "The Google request targets Gmail drafts.create, not a send endpoint");
+            witness(ctx, !route.includes('/gmail/v1/users/me/messages/send'), "The capability contains no Gmail send call");
+            witness(ctx, route.includes("attachments: attachments.map((attachment) => ({"), "The response confirms each attachment filename, MIME type, and byte size");
+            witness(ctx, routeTest.includes("gmail plain draft attaches active workspace file bytes with filename and MIME type"), "The route integration test creates an attached plain draft");
+            witness(ctx, routeTest.includes('to: "sam@acme.test"') && routeTest.includes('subject: "Quarterly plan"'), "The integration request includes the expected recipient and subject");
+            ctx.output("draft creation and confirmation", snippet(route, "const message: { raw: string; threadId?: string }", 44));
+          },
+        });
+      },
+    },
+    {
+      name: "The mock Gmail receives a review-ready attached draft",
+      run: async (ctx) => {
+        await ctx.prove("The Gmail-side witness decodes a multipart draft with the exact attachment metadata and contents", {
+          voiceover: vo[3],
+          assert: async () => {
+            const { routeTest } = await sources();
+            witness(ctx, routeTest.includes('expect(decoded).toContain("Content-Type: multipart/mixed;")'), "The Gmail-bound raw message is multipart/mixed");
+            witness(ctx, routeTest.includes('Content-Type: application/pdf; name="invoice-2026.pdf"'), "The Gmail-bound attachment keeps its PDF type and filename");
+            witness(ctx, routeTest.includes('Content-Disposition: attachment; filename="invoice-2026.pdf"'), "The Gmail-bound message exposes the file as an attachment");
+            witness(ctx, routeTest.includes('attachmentBytes.toString("base64")'), "The Gmail-bound MIME contains the exact workspace file bytes");
+            witness(ctx, routeTest.includes('size: attachmentBytes.byteLength'), "The capability response reports the observed attachment byte size");
+            ctx.output("mock Gmail external witness", snippet(routeTest, "test(\"gmail plain draft attaches active workspace file bytes", 42));
+          },
+        });
+      },
+    },
+    {
+      name: "Threaded reply drafts retain the same attachment",
+      run: async (ctx) => {
+        await ctx.prove("A threaded reply keeps Gmail reply headers, thread id, and the attached workspace file", {
+          voiceover: vo[4],
+          assert: async () => {
+            const { routeTest } = await sources();
+            witness(ctx, routeTest.includes('expect(message.threadId).toBe("thread_1")'), "The reply draft remains attached to the requested Gmail thread");
+            witness(ctx, routeTest.includes('In-Reply-To: <orig-2@mail.gmail.com>'), "The reply draft retains In-Reply-To metadata");
+            witness(ctx, routeTest.includes('References: <orig-1@mail.gmail.com> <orig-2@mail.gmail.com>'), "The reply draft retains References metadata");
+            witness(ctx, routeTest.includes('filename: "notes.txt"'), "The threaded draft request includes the workspace attachment filename");
+            witness(ctx, routeTest.includes('Content-Disposition: attachment; filename="notes.txt"'), "The threaded Gmail MIME includes the attachment");
+            ctx.output("threaded reply attachment witness", snippet(routeTest, "test(\"gmail threaded reply draft reads thread metadata", 54));
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/google-workspace-gmail-draft-attachments.md
+++ b/evals/voiceovers/google-workspace-gmail-draft-attachments.md
@@ -1,0 +1,11 @@
+# google-workspace-gmail-draft-attachments — Attach workspace files to Gmail drafts
+
+1. I ask OpenWork to create a Google draft and attach a file from my active workspace.
+
+2. OpenWork finds the requested file and shows that it will be included with the draft, preserving its filename and file type.
+
+3. OpenWork creates the message as a Gmail draft—it does not send the email—and confirms the recipient, subject, and attachment.
+
+4. In Gmail, I open the draft and see the workspace file attached and ready to review or send.
+
+5. The same attachment flow also works when creating a reply draft in an existing Gmail thread.


### PR DESCRIPTION
## What changed

- add optional `attachments: [{ filename, mimeType, dataBase64 }]` to the OpenWork Cloud Google Workspace Gmail draft capability
- build multipart/mixed RFC 822 drafts while preserving filename, MIME type, and file bytes
- support attachments on both new drafts and `threadId` reply drafts
- expose attachment metadata in successful attached-draft responses while preserving the existing response shape for attachment-free drafts
- make the attachment input shape discoverable through `search_capabilities`
- reject invalid base64, MIME types, header injection, more than 10 files, files over 10 MiB, and aggregate attachments over 20 MiB before calling Google

## Why

The local Google Workspace extension could attach files, but the OpenWork Cloud capability used from a workspace only created plain-text Gmail drafts. Hosted Den cannot read a desktop path directly, so the agent reads the active-workspace file and sends bounded standard-base64 bytes across the cloud capability boundary.

## Validation

- `pnpm --filter @openwork-ee/den-api exec bun test test/gmail-draft.test.ts test/google-workspace-capabilities.test.ts` — 32 passed, 0 failed
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` — passed
- `git diff --check` — passed
- `pnpm fraimz --flow google-workspace-gmail-draft-attachments` — Passed; 5 claims plus voiceover coverage
