### PR TITLE
Launch Electron demos with fresh isolated folders

### DIFF
--- a/evals/flows/demo-electron-fresh-folders.flow.mjs
+++ b/evals/flows/demo-electron-fresh-folders.flow.mjs
@@ -1,0 +1,120 @@
+import { spawnSync } from "node:child_process";
+import { access, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { createDemoRun, resolveDemoRoot } from "../../scripts/dev-two-electron-demo.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "demo-electron-fresh-folders";
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const LAUNCHER_PATH = path.join(ROOT, "scripts", "dev-two-electron-demo.mjs");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const exists = (filePath) => access(filePath).then(() => true, () => false);
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${actual})` : ""}`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "demo:electron launches two independent demos with fresh folders",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "One command launches both demo profiles",
+      run: async (ctx) => {
+        await ctx.prove("demo:electron starts Demo A and Demo B together", {
+          voiceover: vo[0],
+          assert: async () => {
+            const packageJson = JSON.parse(await readFile(path.join(ROOT, "package.json"), "utf8"));
+            const launcher = await readFile(LAUNCHER_PATH, "utf8");
+            const testRun = spawnSync(process.execPath, ["--test", "scripts/dev-two-electron-demo.test.mjs"], {
+              cwd: ROOT,
+              encoding: "utf8",
+            });
+            witness(ctx, packageJson.scripts["demo:electron"].includes("dev-two-electron-demo.mjs"), "demo:electron invokes the two-demo launcher");
+            witness(ctx, /startElectron\(\s*appProfiles\.admin\.label/.test(launcher), "the launcher starts Demo A");
+            witness(ctx, /startElectron\(\s*appProfiles\.consumer\.label/.test(launcher), "the launcher starts Demo B");
+            witness(ctx, testRun.status === 0, "the focused launcher tests pass", testRun.stderr.trim() || String(testRun.status));
+            ctx.output("$ node --test scripts/dev-two-electron-demo.test.mjs", testRun.stdout.trim());
+          },
+        });
+      },
+    },
+    {
+      name: "The two profiles use separate non-production folders",
+      run: async (ctx) => {
+        const testRoot = await mkdtemp(path.join(os.tmpdir(), "fraimz-electron-demo-"));
+        try {
+          await ctx.prove("each demo gets an independent folder under the temporary demo root", {
+            voiceover: vo[1],
+            action: async () => {},
+            assert: async () => {
+              const run = await createDemoRun(testRoot);
+              const productionRoot = path.join(os.homedir(), ".openwork");
+              witness(ctx, run.admin.root !== run.consumer.root, "Demo A and Demo B folders differ");
+              witness(ctx, !run.admin.root.startsWith(productionRoot), "Demo A does not use the production .openwork folder", run.admin.root);
+              witness(ctx, !run.consumer.root.startsWith(productionRoot), "Demo B does not use the production .openwork folder", run.consumer.root);
+              witness(ctx, await exists(run.admin.userDataDir), "Demo A Electron data folder exists");
+              witness(ctx, await exists(run.consumer.userDataDir), "Demo B Electron data folder exists");
+              ctx.output("Created demo folders", `Demo A: ${run.admin.root}\nDemo B: ${run.consumer.root}`);
+            },
+          });
+        } finally {
+          await rm(testRoot, { recursive: true, force: true });
+        }
+      },
+    },
+    {
+      name: "The launcher reports both isolated paths",
+      run: async (ctx) => {
+        await ctx.prove("terminal output labels the folder for each demo", {
+          voiceover: vo[2],
+          assert: async () => {
+            const launcher = await readFile(LAUNCHER_PATH, "utf8");
+            witness(ctx, launcher.includes("Demo A folder:"), "terminal output includes the Demo A folder label");
+            witness(ctx, launcher.includes("Demo B folder:"), "terminal output includes the Demo B folder label");
+            witness(ctx, launcher.includes("demoRun.admin.root"), "the Demo A label prints its actual generated path");
+            witness(ctx, launcher.includes("demoRun.consumer.root"), "the Demo B label prints its actual generated path");
+            ctx.output("Launcher output contract", "Demo A folder: <fresh path>\nDemo B folder: <fresh path>");
+          },
+        });
+      },
+    },
+    {
+      name: "Every launch starts clean",
+      run: async (ctx) => {
+        const testRoot = await mkdtemp(path.join(os.tmpdir(), "fraimz-electron-rerun-"));
+        try {
+          await ctx.prove("a rerun creates new folders with no state inherited from the prior run", {
+            voiceover: vo[3],
+            action: async () => {},
+            assert: async () => {
+              const first = await createDemoRun(testRoot);
+              const markerPath = path.join(first.admin.dataDir, "prior-run-marker");
+              await writeFile(markerPath, "old state", "utf8");
+              const second = await createDemoRun(testRoot);
+              witness(ctx, first.runRoot !== second.runRoot, "the rerun receives a different run root");
+              witness(ctx, first.admin.root !== second.admin.root, "Demo A receives a fresh folder on rerun");
+              witness(ctx, first.consumer.root !== second.consumer.root, "Demo B receives a fresh folder on rerun");
+              witness(ctx, !(await exists(path.join(second.admin.dataDir, "prior-run-marker"))), "prior Demo A state is absent from the rerun");
+              ctx.output("Consecutive run roots", `First:  ${first.runRoot}\nSecond: ${second.runRoot}`);
+            },
+          });
+        } finally {
+          await rm(testRoot, { recursive: true, force: true });
+        }
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/demo-electron-fresh-folders.md
+++ b/evals/voiceovers/demo-electron-fresh-folders.md
@@ -1,0 +1,9 @@
+# demo-electron-fresh-folders — launch two isolated demos with fresh data
+
+1. I run `pnpm demo:electron`, and two OpenWork demo windows launch together.
+
+2. Each window uses its own newly created temporary folder, completely separate from the production OpenWork data directory.
+
+3. The terminal prints both folder paths, making their isolation easy to verify.
+
+4. When I stop and rerun the command, two fresh folders are created, so neither demo inherits state from the previous run.

--- a/scripts/dev-two-electron-demo.mjs
+++ b/scripts/dev-two-electron-demo.mjs
@@ -1,4 +1,4 @@
-import { mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import net from "node:net";
 import os from "node:os";
 import path from "node:path";
@@ -9,9 +9,11 @@ const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), ".."
 const desktopRoot = path.join(repoRoot, "apps", "desktop");
 const desktopScriptsRoot = path.join(desktopRoot, "scripts");
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
-const demoRoot =
-  process.env.OPENWORK_ELECTRON_DEMO_ROOT?.trim() ||
-  path.join(os.homedir(), ".openwork", "two-electron-demo");
+export function resolveDemoRoot(env = process.env) {
+  return env.OPENWORK_ELECTRON_DEMO_ROOT?.trim() || path.join(os.tmpdir(), "openwork-two-electron-demo");
+}
+
+const demoRoot = resolveDemoRoot();
 const appProfiles = {
   admin: {
     appIdentifier: "com.differentai.openwork.demo.admin",
@@ -23,7 +25,6 @@ const appProfiles = {
     portFlag: "--admin-port",
     port: "5273",
     requireSignin: false,
-    userDataName: "admin-userdata",
   },
   consumer: {
     appIdentifier: "com.differentai.openwork.demo.consumer",
@@ -35,9 +36,32 @@ const appProfiles = {
     portFlag: "--consumer-port",
     port: "5274",
     requireSignin: true,
-    userDataName: "consumer-userdata",
   },
 };
+
+function profilePaths(runRoot, profile) {
+  const root = path.join(runRoot, profile.label);
+  return {
+    bootstrapPath: path.join(root, profile.bootstrapName),
+    dataDir: path.join(root, "openwork-data"),
+    root,
+    userDataDir: path.join(root, "electron-userdata"),
+  };
+}
+
+export async function createDemoRun(root = demoRoot) {
+  await mkdir(root, { recursive: true });
+  const runRoot = await mkdtemp(path.join(root, "run-"));
+  const admin = profilePaths(runRoot, appProfiles.admin);
+  const consumer = profilePaths(runRoot, appProfiles.consumer);
+  await Promise.all([
+    mkdir(admin.userDataDir, { recursive: true }),
+    mkdir(admin.dataDir, { recursive: true }),
+    mkdir(consumer.userDataDir, { recursive: true }),
+    mkdir(consumer.dataDir, { recursive: true }),
+  ]);
+  return { admin, consumer, runRoot };
+}
 
 function argValue(name, fallback) {
   const index = process.argv.indexOf(name);
@@ -231,22 +255,21 @@ async function writeBootstrap(filePath, requireSignin, baseUrl, apiBaseUrl) {
   );
 }
 
-async function resetDemoData() {
-  await rm(demoRoot, { recursive: true, force: true });
+export async function resetDemoData(root = demoRoot) {
+  await rm(root, { recursive: true, force: true });
 }
 
-function demoEnv(profile, bootstrapPath, port, cdpPort) {
-  const userDataDir = path.join(demoRoot, profile.userDataName);
+export function demoEnv(profile, paths, port, cdpPort) {
   return {
-    OPENWORK_DATA_DIR: path.join(userDataDir, "openwork-orchestrator-data"),
-    OPENWORK_DESKTOP_BOOTSTRAP_PATH: bootstrapPath,
+    OPENWORK_DATA_DIR: paths.dataDir,
+    OPENWORK_DESKTOP_BOOTSTRAP_PATH: paths.bootstrapPath,
     OPENWORK_DESKTOP_DISABLE_WORKSPACE_RECOVERY: "1",
     VITE_DISABLE_OPENWORK_MODELS: "1",
     OPENWORK_ELECTRON_APP_IDENTIFIER: profile.appIdentifier,
     OPENWORK_ELECTRON_APP_NAME: profile.appName,
     OPENWORK_ELECTRON_REMOTE_DEBUG_PORT: cdpPort,
     OPENWORK_ELECTRON_SKIP_SHARED_PREPARE: "1",
-    OPENWORK_ELECTRON_USERDATA: userDataDir,
+    OPENWORK_ELECTRON_USERDATA: paths.userDataDir,
     PORT: port,
   };
 }
@@ -278,21 +301,20 @@ async function main() {
   }
   if (flag("--reset-only")) return;
 
-  const adminBootstrap = path.join(demoRoot, appProfiles.admin.bootstrapName);
-  const consumerBootstrap = path.join(demoRoot, appProfiles.consumer.bootstrapName);
-
   await assertDemoPortsAvailable(portEntries);
 
-  await writeBootstrap(adminBootstrap, appProfiles.admin.requireSignin, denWebUrl, denApiUrl);
-  await writeBootstrap(consumerBootstrap, appProfiles.consumer.requireSignin, denWebUrl, denApiUrl);
-  await mkdir(path.join(demoRoot, appProfiles.admin.userDataName), { recursive: true });
-  await mkdir(path.join(demoRoot, appProfiles.consumer.userDataName), { recursive: true });
+  const demoRun = await createDemoRun();
+  await writeBootstrap(demoRun.admin.bootstrapPath, appProfiles.admin.requireSignin, denWebUrl, denApiUrl);
+  await writeBootstrap(demoRun.consumer.bootstrapPath, appProfiles.consumer.requireSignin, denWebUrl, denApiUrl);
 
   prepareSharedElectronResources();
 
   children = [
-    startElectron(appProfiles.admin.label, demoEnv(appProfiles.admin, adminBootstrap, adminPort, adminCdp)),
-    startElectron(appProfiles.consumer.label, demoEnv(appProfiles.consumer, consumerBootstrap, consumerPort, consumerCdp)),
+    startElectron(appProfiles.admin.label, demoEnv(appProfiles.admin, demoRun.admin, adminPort, adminCdp)),
+    startElectron(
+      appProfiles.consumer.label,
+      demoEnv(appProfiles.consumer, demoRun.consumer, consumerPort, consumerCdp),
+    ),
   ];
 
   console.log("\nTwo Electron demo is starting.");
@@ -302,8 +324,12 @@ async function main() {
   console.log(`Demo B URL:    http://localhost:${consumerPort}`);
   console.log(`Demo A CDP:    http://127.0.0.1:${adminCdp}`);
   console.log(`Demo B CDP:    http://127.0.0.1:${consumerCdp}`);
-  console.log(`Demo A data:   ${path.join(demoRoot, appProfiles.admin.userDataName)}`);
-  console.log(`Demo B data:   ${path.join(demoRoot, appProfiles.consumer.userDataName)}`);
+  console.log(`Demo A folder: ${demoRun.admin.root}`);
+  console.log(`  Electron:    ${demoRun.admin.userDataDir}`);
+  console.log(`  OpenWork:    ${demoRun.admin.dataDir}`);
+  console.log(`Demo B folder: ${demoRun.consumer.root}`);
+  console.log(`  Electron:    ${demoRun.consumer.userDataDir}`);
+  console.log(`  OpenWork:    ${demoRun.consumer.dataDir}`);
   const denStartup =
     adminPort === appProfiles.admin.port && consumerPort === appProfiles.consumer.port
       ? "pnpm demo:den"
@@ -312,10 +338,12 @@ async function main() {
   console.log("Press Ctrl-C to stop both instances.\n");
 }
 
-process.once("SIGINT", () => void stopAll(130));
-process.once("SIGTERM", () => void stopAll(143));
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  process.once("SIGINT", () => void stopAll(130));
+  process.once("SIGTERM", () => void stopAll(143));
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : String(error));
-  void stopAll(1);
-});
+  main().catch((error) => {
+    console.error(error instanceof Error ? error.message : String(error));
+    void stopAll(1);
+  });
+}

--- a/scripts/dev-two-electron-demo.test.mjs
+++ b/scripts/dev-two-electron-demo.test.mjs
@@ -1,0 +1,91 @@
+import assert from "node:assert/strict";
+import { access, mkdtemp, rm, stat } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  createDemoRun,
+  demoEnv,
+  resetDemoData,
+  resolveDemoRoot
+} from "./dev-two-electron-demo.mjs";
+
+test("uses a non-production temporary demo root by default", () => {
+  const root = resolveDemoRoot({});
+
+  assert.equal(root, path.join(os.tmpdir(), "openwork-two-electron-demo"));
+  assert.notEqual(root, path.join(os.homedir(), ".openwork"));
+});
+
+test("honors an explicit demo root", () => {
+  assert.equal(
+    resolveDemoRoot({
+      OPENWORK_ELECTRON_DEMO_ROOT: " /tmp/openwork-custom-demo "
+    }),
+    "/tmp/openwork-custom-demo"
+  );
+});
+
+test("creates fresh, independent folders for every demo launch", async context => {
+  const testRoot = await mkdtemp(path.join(os.tmpdir(), "openwork-demo-test-"));
+  context.after(() => rm(testRoot, { recursive: true, force: true }));
+
+  const first = await createDemoRun(testRoot);
+  const second = await createDemoRun(testRoot);
+
+  assert.notEqual(first.runRoot, second.runRoot);
+  assert.notEqual(first.admin.root, first.consumer.root);
+  assert.equal(path.dirname(first.admin.root), first.runRoot);
+  assert.equal(path.dirname(first.consumer.root), first.runRoot);
+
+  for (const paths of [
+    first.admin,
+    first.consumer,
+    second.admin,
+    second.consumer
+  ]) {
+    assert.equal((await stat(paths.userDataDir)).isDirectory(), true);
+    assert.equal((await stat(paths.dataDir)).isDirectory(), true);
+  }
+});
+
+test("reset removes all prior demo runs from the configured root", async context => {
+  const testRoot = await mkdtemp(
+    path.join(os.tmpdir(), "openwork-demo-reset-test-")
+  );
+  context.after(() => rm(testRoot, { recursive: true, force: true }));
+  const run = await createDemoRun(testRoot);
+
+  await resetDemoData(testRoot);
+
+  await assert.rejects(access(run.runRoot));
+});
+
+test("points each Electron instance at its own profile folders", async context => {
+  const testRoot = await mkdtemp(
+    path.join(os.tmpdir(), "openwork-demo-env-test-")
+  );
+  context.after(() => rm(testRoot, { recursive: true, force: true }));
+  const run = await createDemoRun(testRoot);
+  const profile = {
+    appIdentifier: "com.example.demo",
+    appName: "Demo"
+  };
+
+  const adminEnv = demoEnv(profile, run.admin, "5273", "9923");
+  const consumerEnv = demoEnv(profile, run.consumer, "5274", "9924");
+
+  assert.equal(adminEnv.OPENWORK_ELECTRON_USERDATA, run.admin.userDataDir);
+  assert.equal(adminEnv.OPENWORK_DATA_DIR, run.admin.dataDir);
+  assert.equal(
+    consumerEnv.OPENWORK_ELECTRON_USERDATA,
+    run.consumer.userDataDir
+  );
+  assert.equal(consumerEnv.OPENWORK_DATA_DIR, run.consumer.dataDir);
+  assert.notEqual(
+    adminEnv.OPENWORK_ELECTRON_USERDATA,
+    consumerEnv.OPENWORK_ELECTRON_USERDATA
+  );
+  assert.notEqual(adminEnv.OPENWORK_DATA_DIR, consumerEnv.OPENWORK_DATA_DIR);
+});


### PR DESCRIPTION
## What changed

- create a fresh temporary run directory for every `demo:electron` launch
- give Demo A and Demo B independent Electron, OpenWork data, and bootstrap paths
- keep production `~/.openwork` data out of the demo flow
- print both generated folder paths and preserve root overrides/reset behavior
- add focused tests and an internal fraimz flow backed by the approved voiceover

## Why

The two-demo launcher previously reused persistent profile directories under `~/.openwork`. Demo runs could inherit stale state and lived alongside the production default root.

## Validation

- `pnpm exec node --test scripts/dev-two-electron-demo.test.mjs` — 5 passed
- `pnpm --filter @openwork/desktop test` — 48 passed, 1 platform skip
- `pnpm fraimz --flow demo-electron-fresh-folders` — Passed
- live smoke: launched Demo A and Demo B on separate CDP endpoints, stopped them, reran, and confirmed a different `run-*` root with isolated `demo-a` / `demo-b` folders
