### PR TITLE
feat: bundle standard installer with org bootstrap

### DIFF
--- a/.github/workflows/alpha-macos-aarch64.yml
+++ b/.github/workflows/alpha-macos-aarch64.yml
@@ -17,6 +17,12 @@ on:
     branches:
       - dev
   workflow_dispatch:
+    inputs:
+      publish_pointer:
+        description: "Update alpha-macos-latest (leave off for isolated branch validation)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: write
@@ -213,7 +219,7 @@ jobs:
             --clobber
 
       - name: Update alpha updater pointer
-        if: env.MACOS_NOTARIZE == 'true'
+        if: env.MACOS_NOTARIZE == 'true' && (github.event_name == 'push' || inputs.publish_pointer == true)
         shell: bash
         env:
           GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release-generic-installer.yml
+++ b/.github/workflows/release-generic-installer.yml
@@ -1,6 +1,9 @@
-name: Release Generic Installer
+name: Legacy Generic Installer (manual)
 
-# Builds the GENERIC (unbranded) OpenWork installer — the committed
+# Legacy recovery workflow for the GENERIC (unbranded) OpenWork installer.
+# Organization downloads now bundle the standard desktop installer with
+# desktop-bootstrap.json, so normal releases do not invoke this workflow.
+# The committed
 # apps/installer build-config placeholder stays empty, so the binary carries
 # no deployment values and resolves its config at run time (sidecar stamped by
 # den-api, filename tag, or pasted install link; see #2480) — and publishes it
@@ -66,9 +69,6 @@ on:
         required: false
         type: boolean
         default: false
-  release:
-    types: [published]
-
 permissions:
   contents: write
 

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -844,21 +844,6 @@ jobs:
       tag: ${{ needs.resolve-release.outputs.release_tag }}
     secrets: inherit
 
-  publish-generic-installer:
-    name: Build + Publish Generic Installers
-    needs: [resolve-release, verify-release]
-    if: |
-      needs.resolve-release.result == 'success' &&
-      needs.verify-release.result == 'success' &&
-      needs.resolve-release.outputs.prerelease != 'true'
-    uses: ./.github/workflows/release-generic-installer.yml
-    with:
-      release_tag: ${{ needs.resolve-release.outputs.release_tag }}
-      publish_mode: release
-      platforms: mac-arm64,mac-x64,win-x64
-      sign_windows: ${{ needs.resolve-release.outputs.sign_windows == 'true' }}
-    secrets: inherit
-
   aur-publish:
     name: Publish AUR
     needs: [resolve-release, publish-electron, publish-release]
@@ -922,7 +907,6 @@ jobs:
       - release-orchestrator-sidecars
       - publish-npm
       - publish-daytona-snapshot
-      - publish-generic-installer
     if: |
       always() &&
       needs.resolve-release.result == 'success' &&
@@ -931,9 +915,7 @@ jobs:
       (needs.publish-electron-assets.result == 'success' || needs.publish-electron-assets.result == 'skipped') &&
       (needs.release-orchestrator-sidecars.result == 'success' || needs.release-orchestrator-sidecars.result == 'skipped') &&
       (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
-      (needs.publish-daytona-snapshot.result == 'success' || needs.publish-daytona-snapshot.result == 'skipped') &&
-      ((needs.resolve-release.outputs.prerelease == 'true' && needs.publish-generic-installer.result == 'skipped') ||
-       (needs.resolve-release.outputs.prerelease != 'true' && needs.publish-generic-installer.result == 'success'))
+      (needs.publish-daytona-snapshot.result == 'success' || needs.publish-daytona-snapshot.result == 'skipped')
     runs-on: blacksmith-4vcpu-ubuntu-2404
     env:
       RELEASE_TAG: ${{ needs.resolve-release.outputs.release_tag }}
@@ -944,19 +926,6 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-
-          if [ "${RELEASE_PRERELEASE}" != "true" ]; then
-            published_assets="$(gh release view "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --json assets --jq '.assets[].name')"
-            for required_asset in \
-              openwork-installer-mac-arm64.zip \
-              openwork-installer-mac-x64.zip \
-              openwork-installer-win-x64.exe; do
-              if ! grep -Fxq "$required_asset" <<<"$published_assets"; then
-                echo "Stable release $RELEASE_TAG is missing required generic installer asset: $required_asset" >&2
-                exit 1
-              fi
-            done
-          fi
 
           # Dispatch-based recovery runs default draft=false but may target a
           # draft release created by an earlier tag push; always flip drafts

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2176,6 +2176,7 @@ if (!app.requestSingleInstanceLock()) {
   app.whenReady().then(async () => {
     installMediaPermissionHandlers(session, () => mainWindow);
     applicationMenu.install();
+    await workspaceStore.importBundledDesktopBootstrapConfigIfNewer();
     await runtimeManager.prepareFreshRuntime().catch(() => undefined);
 
     // Use Tauri's existing workspace state file as canonical so rollback and

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -3,7 +3,7 @@
 // normalization/discovery, and the workspace-facing command operations.
 import { createHash, randomBytes } from "node:crypto";
 import { existsSync } from "node:fs";
-import { mkdir, readFile, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
+import { mkdir, readFile, readdir, realpath, rename, rm, stat, writeFile } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 
@@ -120,6 +120,8 @@ const DEFAULT_DESKTOP_BOOTSTRAP_PATH = (() => {
 // LOCALAPPDATA and XDG_CONFIG_HOME. Keep reading that file when the canonical one
 // is missing so existing installs keep their deployment config.
 const LEGACY_DESKTOP_BOOTSTRAP_PATH = path.join(os.homedir(), ".config", "openwork", "desktop-bootstrap.json");
+const DESKTOP_BOOTSTRAP_FILENAME = "desktop-bootstrap.json";
+const STANDARD_DESKTOP_INSTALLER_PATTERN = /^openwork-(?:mac-(?:arm64|x64)-.+\.dmg|win-x64-.+\.exe)$/i;
 
 export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSignin, forceRequireSignin }) {
   function desktopBootstrapPath() {
@@ -245,11 +247,13 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
       return id && role && url && expiresAt ? [{ id, role, ...(token ? { token } : {}), url, expiresAt }] : [];
     });
     const writtenAt = typeof input?.writtenAt === "string" ? input.writtenAt.trim() : "";
+    const apiBaseUrl = typeof input?.apiBaseUrl === "string" ? input.apiBaseUrl.trim() : "";
     const brandAppName = typeof input?.brandAppName === "string" ? input.brandAppName.trim().slice(0, 64) : "";
     const brandLogoUrl = typeof input?.brandLogoUrl === "string" ? input.brandLogoUrl.trim() : "";
 
     return {
       baseUrl,
+      ...(apiBaseUrl ? { apiBaseUrl } : {}),
       requireSignin: forceRequireSignin || input?.requireSignin === true,
       ...(brandAppName ? { brandAppName } : {}),
       ...(brandLogoUrl ? { brandLogoUrl } : {}),
@@ -314,6 +318,82 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
       });
     } catch (migrationError) {
       console.warn("[desktop-bootstrap] legacy config migration failed", migrationError);
+    }
+  }
+
+  function bundleSearchRoots() {
+    const roots = [];
+    const override = process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR?.trim();
+    if (override) roots.push(path.resolve(override));
+    for (const name of ["downloads", "desktop"]) {
+      try {
+        const candidate = app.getPath(name);
+        if (candidate) roots.push(candidate);
+      } catch {
+        // Electron can omit a shell path in constrained environments.
+      }
+    }
+    return Array.from(new Set(roots));
+  }
+
+  async function directoryContainsStandardDesktopInstaller(directory) {
+    try {
+      const entries = await readdir(directory, { withFileTypes: true });
+      return entries.some((entry) => entry.isFile() && STANDARD_DESKTOP_INSTALLER_PATTERN.test(entry.name));
+    } catch {
+      return false;
+    }
+  }
+
+  async function bundledDesktopBootstrapPaths() {
+    const candidates = [];
+    for (const root of bundleSearchRoots()) {
+      candidates.push(path.join(root, DESKTOP_BOOTSTRAP_FILENAME));
+      try {
+        const entries = await readdir(root, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isDirectory()) {
+            candidates.push(path.join(root, entry.name, DESKTOP_BOOTSTRAP_FILENAME));
+          }
+        }
+      } catch {
+        // A missing Downloads/Desktop directory is normal in headless runs.
+      }
+    }
+    return Array.from(new Set(candidates));
+  }
+
+  async function importBundledDesktopBootstrapConfigIfNewer() {
+    const configPath = desktopBootstrapPath();
+    const primary = await readDesktopBootstrapCandidate(configPath);
+    const legacyPath = legacyDesktopBootstrapPath();
+    const legacy = legacyPath ? await readDesktopBootstrapCandidate(legacyPath) : null;
+    const currentCandidates = [primary, legacy].filter((candidate) => candidate?.ok);
+    const currentTimeMs = currentCandidates.reduce(
+      (latest, candidate) => Math.max(latest, desktopBootstrapCandidateTimeMs(candidate)),
+      Number.NEGATIVE_INFINITY,
+    );
+
+    const bundledCandidates = [];
+    for (const candidatePath of await bundledDesktopBootstrapPaths()) {
+      if (!(await directoryContainsStandardDesktopInstaller(path.dirname(candidatePath)))) continue;
+      const candidate = await readDesktopBootstrapCandidate(candidatePath);
+      if (candidate.ok) bundledCandidates.push(candidate);
+    }
+    bundledCandidates.sort((left, right) => desktopBootstrapCandidateTimeMs(right) - desktopBootstrapCandidateTimeMs(left));
+    const newest = bundledCandidates[0];
+    if (!newest || desktopBootstrapCandidateTimeMs(newest) <= currentTimeMs) return false;
+
+    try {
+      await writeJsonFileAtomic(configPath, newest.normalized);
+      console.info("[desktop-bootstrap] imported organization download bundle", {
+        from: newest.path,
+        to: configPath,
+      });
+      return true;
+    } catch (error) {
+      console.warn("[desktop-bootstrap] organization download import failed", error);
+      return false;
     }
   }
 
@@ -1133,6 +1213,7 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     forgetWorkspace,
     getDesktopBootstrapConfig,
     importConfig,
+    importBundledDesktopBootstrapConfigIfNewer,
     listLocalWorkspacePaths,
     migrateLegacyElectronWorkspaceStateIfNeeded,
     readWorkspaceOpenworkConfig,

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -23,11 +23,13 @@ async function withIsolatedBootstrapStore(callback) {
   const previousHome = process.env.HOME;
   const previousXdg = process.env.XDG_CONFIG_HOME;
   const previousOverride = process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH;
+  const previousBundleDir = process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR;
   const previousDevMode = process.env.OPENWORK_DEV_MODE;
 
   process.env.HOME = home;
   process.env.XDG_CONFIG_HOME = xdg;
   delete process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH;
+  delete process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR;
   delete process.env.OPENWORK_DEV_MODE;
 
   try {
@@ -42,12 +44,14 @@ async function withIsolatedBootstrapStore(callback) {
       store,
       canonicalPath: path.join(xdg, "openwork", "desktop-bootstrap.json"),
       legacyPath: path.join(home, ".config", "openwork", "desktop-bootstrap.json"),
+      root,
       userDataPath: path.join(root, "userData"),
     });
   } finally {
     restoreEnv("HOME", previousHome);
     restoreEnv("XDG_CONFIG_HOME", previousXdg);
     restoreEnv("OPENWORK_DESKTOP_BOOTSTRAP_PATH", previousOverride);
+    restoreEnv("OPENWORK_BOOTSTRAP_BUNDLE_DIR", previousBundleDir);
     restoreEnv("OPENWORK_DEV_MODE", previousDevMode);
   }
 }
@@ -278,6 +282,74 @@ test("desktop bootstrap writes include a fresh writtenAt stamp", async () => {
     const persisted = JSON.parse(await readFile(canonicalPath, "utf8"));
     assert.equal(persisted.baseUrl, "https://canonical.example.com");
     assert.equal(Number.isFinite(Date.parse(persisted.writtenAt)), true);
+  });
+});
+
+test("imports a newer organization bootstrap beside the standard installer", async () => {
+  await withIsolatedBootstrapStore(async ({ store, canonicalPath, root }) => {
+    const bundleDir = path.join(root, "downloads", "OpenWork-acme");
+    process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR = bundleDir;
+    await mkdir(bundleDir, { recursive: true });
+    await writeFile(path.join(bundleDir, "openwork-mac-arm64-9.9.9.dmg"), "signed installer", "utf8");
+    await writeBootstrapConfig(path.join(bundleDir, "desktop-bootstrap.json"), {
+      baseUrl: "https://acme.example.com",
+      apiBaseUrl: "https://api.acme.example.com",
+      requireSignin: true,
+      brandAppName: "Acme Work",
+      brandLogoUrl: "https://acme.example.com/logo.png",
+      writtenAt: "2026-07-10T12:00:00.000Z",
+    });
+
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfNewer(), true);
+    const config = await store.getDesktopBootstrapConfig();
+    assert.deepEqual(config, {
+      baseUrl: "https://acme.example.com",
+      apiBaseUrl: "https://api.acme.example.com",
+      requireSignin: true,
+      brandAppName: "Acme Work",
+      brandLogoUrl: "https://acme.example.com/logo.png",
+      writtenAt: "2026-07-10T12:00:00.000Z",
+    });
+    const persisted = JSON.parse(await readFile(canonicalPath, "utf8"));
+    assert.equal(persisted.baseUrl, "https://acme.example.com");
+  });
+});
+
+test("ignores a downloaded bootstrap that is not beside a standard installer", async () => {
+  await withIsolatedBootstrapStore(async ({ store, canonicalPath, root }) => {
+    const bundleDir = path.join(root, "downloads");
+    process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR = bundleDir;
+    await writeBootstrapConfig(path.join(bundleDir, "desktop-bootstrap.json"), {
+      baseUrl: "https://untrusted.example.com",
+      requireSignin: true,
+      writtenAt: "2026-07-10T12:00:00.000Z",
+    });
+
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfNewer(), false);
+    await assert.rejects(readFile(canonicalPath, "utf8"));
+  });
+});
+
+test("does not replace a newer canonical bootstrap with an older download bundle", async () => {
+  await withIsolatedBootstrapStore(async ({ store, canonicalPath, root }) => {
+    const bundleDir = path.join(root, "downloads");
+    process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR = bundleDir;
+    await writeBootstrapConfig(canonicalPath, {
+      baseUrl: "https://current.example.com",
+      requireSignin: true,
+      writtenAt: "2026-07-10T13:00:00.000Z",
+    });
+    await mkdir(bundleDir, { recursive: true });
+    await writeFile(path.join(bundleDir, "openwork-win-x64-9.9.9.exe"), "signed installer", "utf8");
+    await writeBootstrapConfig(path.join(bundleDir, "desktop-bootstrap.json"), {
+      baseUrl: "https://old.example.com",
+      requireSignin: true,
+      writtenAt: "2026-07-10T12:00:00.000Z",
+    });
+
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfNewer(), false);
+    const config = await store.getDesktopBootstrapConfig();
+    assert.equal(config.baseUrl, "https://current.example.com");
   });
 });
 

--- a/docs/org-install-links.md
+++ b/docs/org-install-links.md
@@ -9,25 +9,29 @@ Related: `ee/apps/den-api/src/install-links.ts`, `ee/apps/den-api/src/routes/org
 Organization install links let workspace members mint shareable desktop install
 links for their workspace. When the capability is enabled, invitation emails
 automatically use the same organization-specific install page as the dashboard.
-Den serves one generic installer and stamps it per org at serve time. The
-installed app boots into forced sign-in against your deployment, so possession
-of an install link does not grant workspace access.
+Den packages the normal signed OpenWork DMG or EXE with an organization-specific
+`desktop-bootstrap.json`. The standard desktop app imports that file on first
+launch. There is no second installer application to build, sign, publish, or
+deploy. The installed app still requires sign-in against your deployment, so
+possession of an install link does not grant workspace access.
 
 ## Upgrade checklist
 
-> **Dark launch:** Upgrading changes nothing visible. Install links stay dark
-> until a platform admin enables the `Install links` capability for an org.
+> **Self-host default:** Install links are active by default when deployment
+> gating is off. Hosted installations can set
+> `DEN_INSTALL_LINKS_GATING_ENABLED=true` to keep per-organization opt-in.
 
 ### Helm
 
 1. Keep `migrations.enabled=true` for the upgrade. The migration Job creates
    the `install_link` table automatically; see the
    [Helm migration Job docs](../packaging/helm/openwork-ee/README.md#migrations).
-2. Set `config.public.bootstrapAdminEmails` (renders
-   `DEN_BOOTSTRAP_ADMIN_EMAILS`) to the platform admin email allowlist.
-3. Restart/roll the deployment with the new values.
-4. Sign in to den-web, open `/admin`, and toggle `Install links` for each org
-   that should be allowed to mint links.
+2. Restart/roll the deployment with the new values. No install-link capability
+   toggle is required for normal self-hosted installations.
+3. If you intentionally want hosted-style rollout, set
+   `DEN_INSTALL_LINKS_GATING_ENABLED=true`, configure
+   `config.public.bootstrapAdminEmails`, then enable `Install links` per org in
+   `/admin`.
 
 ### Docker Compose
 
@@ -39,9 +43,10 @@ of an install link does not grant workspace access.
 
    If your stack was launched with a custom Compose project name, include the
    same `-p <project>` flag.
-2. Set `DEN_BOOTSTRAP_ADMIN_EMAILS` on the Den API service, then restart it.
-3. Sign in to den-web, open `/admin`, and toggle `Install links` for each org
-   that should be allowed to mint links.
+2. Restart Den. Install links are active by default.
+3. For hosted-style rollout only, set
+   `DEN_INSTALL_LINKS_GATING_ENABLED=true` and `DEN_BOOTSTRAP_ADMIN_EMAILS`,
+   then enable `Install links` per org in `/admin`.
 
 ## Public origins requirement
 
@@ -56,28 +61,45 @@ normal single-origin setup, put the same den-web origin in both settings.
 
 ## Installer artifacts
 
-Den resolves Mac and Windows installer artifacts in this order:
+Den resolves the standard signed Mac and Windows desktop artifacts in this order:
 
 1. `OPENWORK_INSTALLER_ARTIFACTS_DIR`, when set and the file exists.
 2. `OPENWORK_INSTALLER_CACHE_DIR/<tag>/<file>`, defaulting to the OS temp dir.
 3. The GitHub release asset for `OPENWORK_INSTALLER_RELEASE_REPO` and
    `OPENWORK_INSTALLER_RELEASE_TAG`.
-4. When a generic artifact is unavailable, a verified normal versioned desktop
-   release for that platform. If that is also unavailable, the stable OpenWork
-   download page.
+4. If the artifact is unavailable, a verified direct normal desktop download.
+   If that is also unavailable, the stable OpenWork download page.
 
 | Mode | Configure | Behavior |
 |---|---|---|
-| Internet-connected | Default. `OPENWORK_INSTALLER_RELEASE_TAG` resolves to `v<pinned app version>`; override it when needed. | Den downloads the public release asset on the first Mac/Windows download, then serves cached bytes. If a legacy release lacks the generic asset, Den redirects to that release's verified normal DMG/EXE without including the organization token. |
+| Internet-connected | Default. `OPENWORK_INSTALLER_RELEASE_TAG` resolves to `v<pinned app version>`; override it when needed. | Den downloads the normal public DMG/EXE on the first organization download, caches it, and creates the ZIP at request time. If Den cannot fetch it, the browser is redirected to the verified normal DMG/EXE without including the organization token. |
 | Fork/mirror | Set `OPENWORK_INSTALLER_RELEASE_REPO`, for example `your-org/openwork`. | Den downloads assets from your fork or mirror release instead of `different-ai/openwork`. |
-| Air-gapped | Mount a volume at `OPENWORK_INSTALLER_ARTIFACTS_DIR` containing exactly `openwork-installer-mac-arm64.zip`, `openwork-installer-mac-x64.zip`, and `openwork-installer-win-x64.exe`. | The mounted artifact directory takes precedence, preserves organization stamping, and requires zero egress. |
+| Air-gapped | Mount a volume at `OPENWORK_INSTALLER_ARTIFACTS_DIR` containing the normal versioned assets, for example `openwork-mac-arm64-0.18.0.dmg`, `openwork-mac-x64-0.18.0.dmg`, and `openwork-win-x64-0.18.0.exe`, matching `OPENWORK_INSTALLER_RELEASE_TAG=v0.18.0`. | The mounted artifact directory takes precedence. Den adds `desktop-bootstrap.json` without modifying the signed installer bytes and requires zero egress. |
 
 ## Egress
 
 `den-api` makes outbound HTTPS requests to `github.com` only when serving a Mac
-or Windows installer download and the artifact is not already cached, or when
-it verifies a normal release fallback. The Linux setup script and every other
-install-link feature need no egress.
+or Windows organization download and the standard artifact is not already
+cached, or when it verifies a normal release fallback. The Linux setup script
+and every other install-link feature need no egress.
+
+## ZIP and first-launch behavior
+
+The Mac and Windows download contains exactly two top-level files:
+
+1. The normal versioned OpenWork DMG or EXE published with the release.
+2. `desktop-bootstrap.json`, containing the web/API origins, sign-in policy,
+   display name, logo URL, and a `writtenAt` timestamp.
+
+Extract the ZIP and keep both files in the same folder while running the normal
+installer. On first launch, OpenWork searches the Downloads and Desktop folders
+(and one extracted folder level below them) for `desktop-bootstrap.json` beside
+a normally named OpenWork release artifact. A valid bundle is copied to the
+canonical per-user path before the runtime boots. A bundle never replaces a
+canonical or legacy config with a newer `writtenAt` value.
+
+`OPENWORK_BOOTSTRAP_BUNDLE_DIR` can point the desktop at one specific extracted
+bundle directory for managed rollouts and deterministic validation.
 
 ## Distribute configuration with MDM (no custom installer)
 
@@ -132,13 +154,17 @@ managed file is enough for a fully self-hosted desktop rollout.
 - A leaked link reveals the org name and server URLs only; users still must
   sign in to access the workspace.
 - Public install-link endpoints are rate-limited.
-- Stamped Mac zips keep the signed `.app` byte-identical, so Gatekeeper
-  verification still applies.
+- The signed DMG/EXE bytes are copied into the ZIP unchanged, so Gatekeeper and
+  Windows signature verification still apply to the standard release artifact.
+- The desktop only imports a downloaded bootstrap when it is beside a standard
+  versioned OpenWork installer filename, and only when it is newer than the
+  current canonical or legacy configuration.
 
 ## Troubleshooting
 
 | Symptom | Fix |
 |---|---|
-| A download opens the normal OpenWork installer instead of the organization-configured installer | The selected release has no generic artifact. Publish or mount the three generic assets; air-gapped deployments must use `OPENWORK_INSTALLER_ARTIFACTS_DIR`. |
+| A download goes directly to the normal OpenWork installer instead of returning a ZIP | Den could not obtain the standard versioned asset. Internet-connected deployments should verify the release tag/repository; air-gapped deployments should mount the matching DMG/EXE files through `OPENWORK_INSTALLER_ARTIFACTS_DIR`. The direct download is an intentional fallback and contains no organization token. |
+| OpenWork does not import the setup file | Extract the ZIP so `desktop-bootstrap.json` remains beside the versioned DMG/EXE, then launch the installed app. Check whether a newer canonical bootstrap already exists. Managed deployments can set `OPENWORK_BOOTSTRAP_BUNDLE_DIR` explicitly. |
 | Install links point at the wrong host | Set `BETTER_AUTH_URL` to the externally reachable den-web origin, then restart `den-api`. For invitation acceptance links, also put that origin first in `DEN_BETTER_AUTH_TRUSTED_ORIGINS`. |
 | Re-uploaded assets under the same tag keep serving old bytes | Clear the installer cache directory or bump the tag. The cache key is `<cacheDir>/<tag>/<file>`. |

--- a/ee/apps/den-api/src/capability-sources/install-links-rollout.ts
+++ b/ee/apps/den-api/src/capability-sources/install-links-rollout.ts
@@ -1,0 +1,18 @@
+/**
+ * Deployment-level rollout for organization install links.
+ *
+ * Hosted deployments can keep the feature opt-in per organization by enabling
+ * DEN_INSTALL_LINKS_GATING_ENABLED. Self-hosted deployments leave the gate off
+ * and get organization downloads without a platform-admin toggle.
+ */
+
+import { organizationHasCapability } from "../organization-capabilities.js"
+
+type MetadataInput = Record<string, unknown> | string | null | undefined
+
+export function organizationInstallLinksEnabled(
+  metadata: MetadataInput,
+  options: { gatingEnabled: boolean },
+): boolean {
+  return !options.gatingEnabled || organizationHasCapability(metadata, "installLinks")
+}

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -90,6 +90,7 @@ const EnvSchema = z.object({
   VERCEL_TEAM_SLUG: z.string().optional(),
   VERCEL_DNS_DOMAIN: z.string().optional(),
   DEN_PLAN_GATING_ENABLED: z.string().optional(),
+  DEN_INSTALL_LINKS_GATING_ENABLED: z.string().optional(),
   DEN_MCP_CONNECTIONS_GATING_ENABLED: z.string().optional(),
   SCIM_MAINTENANCE_INTERVAL_MS: z.string().optional(),
   POLAR_FEATURE_GATE_ENABLED: z.string().optional(),
@@ -257,6 +258,12 @@ const polarFeatureGateEnabled =
 const planGatingEnabled =
   (parsed.DEN_PLAN_GATING_ENABLED ?? "false").toLowerCase() === "true"
 
+// Hosted deployments normally enable plan gating and retain per-org rollout.
+// Self-hosted deployments default to no gating, so install links work without
+// access to the hosted platform-admin control plane. An explicit setting wins.
+const installLinksGatingEnabled =
+  (parsed.DEN_INSTALL_LINKS_GATING_ENABLED ?? String(planGatingEnabled)).toLowerCase() === "true"
+
 // Staged rollout for member-facing org MCP connections: when gating is
 // enabled (hosted deployments), GET /v1/mcp-connections?scope=usable returns
 // an empty list unless the organization opted in via the mcpConnections
@@ -322,6 +329,7 @@ export const env = {
   devMode,
   allowPrivateMcpUrls,
   planGatingEnabled,
+  installLinksGatingEnabled,
   mcpConnectionsGatingEnabled,
   scimMaintenanceIntervalMs: Number(parsed.SCIM_MAINTENANCE_INTERVAL_MS ?? "300000"),
   requireEmailVerification,
@@ -371,12 +379,11 @@ export const env = {
   apiPublicUrl,
   publicUrlTrustedOrigins,
   installerArtifactsDir: optionalString(parsed.OPENWORK_INSTALLER_ARTIFACTS_DIR),
-  // Generic installer release assets (release-generic-installer.yml): the
-  // release tag to download from, defaulting to the pinned app release this
-  // den-api build shipped with.
+  // Standard desktop release assets: the release tag to download from,
+  // defaulting to the pinned app release this den-api build shipped with.
   installerReleaseTag: optionalString(parsed.OPENWORK_INSTALLER_RELEASE_TAG) ?? `v${denApiAppVersion.latestAppVersion}`,
   installerReleaseRepo: optionalString(parsed.OPENWORK_INSTALLER_RELEASE_REPO) ?? "different-ai/openwork",
-  installerCacheDir: optionalString(parsed.OPENWORK_INSTALLER_CACHE_DIR) ?? path.join(os.tmpdir(), "openwork-installer-artifacts"),
+  installerCacheDir: optionalString(parsed.OPENWORK_INSTALLER_CACHE_DIR) ?? path.join(os.tmpdir(), "openwork-desktop-artifacts"),
   // Native-provider endpoint overrides for evals/self-host testing. Unset in
   // production so Google, Microsoft Entra, and Graph use their public APIs.
   googleOAuthAuthorizeUrl: optionalString(parsed.DEN_GOOGLE_OAUTH_AUTHORIZE_URL),

--- a/ee/apps/den-api/src/install-links.ts
+++ b/ee/apps/den-api/src/install-links.ts
@@ -3,9 +3,9 @@ import { InstallLinkTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { createHash, randomBytes } from "node:crypto"
 import { OPENWORK_DOWNLOAD_URL } from "./CONSTS.js"
+import { organizationInstallLinksEnabled } from "./capability-sources/install-links-rollout.js"
 import { db } from "./db.js"
 import { env } from "./env.js"
-import { organizationHasCapability } from "./organization-capabilities.js"
 
 type InstallLinkInsert = typeof InstallLinkTable.$inferInsert
 
@@ -28,7 +28,7 @@ function installPageUrl(token: string) {
 }
 
 export async function mintOrganizationInstallLink(input: MintOrganizationInstallLinkInput) {
-  if (!organizationHasCapability(input.metadata, "installLinks")) {
+  if (!organizationInstallLinksEnabled(input.metadata, { gatingEnabled: env.installLinksGatingEnabled })) {
     return null
   }
 

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -7,6 +7,7 @@ import { z } from "zod"
 import { auth } from "../../auth.js"
 import { validateBrandIconUrl } from "../../brand-icon-validation.js"
 import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
+import { organizationInstallLinksEnabled } from "../../capability-sources/install-links-rollout.js"
 import { db } from "../../db.js"
 import { checkEntitlement, getOrganizationEntitlements, parseOrganizationPlan } from "../../entitlements.js"
 import { env } from "../../env.js"
@@ -525,6 +526,9 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
           // /admin reads the raw capability from its own endpoint.
           mcpConnections: memberFacingMcpConnectionsEnabled(payload.organization.metadata, {
             gatingEnabled: env.mcpConnectionsGatingEnabled,
+          }),
+          installLinks: organizationInstallLinksEnabled(payload.organization.metadata, {
+            gatingEnabled: env.installLinksGatingEnabled,
           }),
         },
         authMethods: {

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -21,7 +21,7 @@ import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, 
 import { organizationCapabilityKeySchema } from "../../organization-capabilities.js"
 import { normalizeOrganizationMetadata } from "../../organization-limits.js"
 import { desktopReleaseAssetName, resolveInstallerArtifact, resolveInstallerFallbackUrl } from "../../utils/installer-artifacts.js"
-import { createStoredZip } from "../../utils/zip-append.js"
+import { createStoredZipStream } from "../../utils/zip-append.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureOrganizationAdmin, orgAccessFailureStatus } from "./shared.js"
 
@@ -402,14 +402,15 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         brandLogoUrl: resolved.config.logoUrl ?? undefined,
         writtenAt: new Date().toISOString(),
       })
-      const bundle = createStoredZip([
+      const bundle = createStoredZipStream([
         { name: fileName, content: artifact },
         { name: DESKTOP_BOOTSTRAP_FILENAME, content: Buffer.from(`${JSON.stringify(bootstrap, null, 2)}\n`, "utf8") },
       ])
 
-      return new Response(bundle, {
+      return new Response(bundle.body, {
         headers: {
           "content-type": "application/zip",
+          "content-length": String(bundle.byteLength),
           "content-disposition": contentDisposition(`OpenWork-${safeAttachmentSlug(resolved.organizationSlug)}-${platform}.zip`),
           "cache-control": "no-store",
         },

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -1,4 +1,8 @@
-import { installConfigSchema, INSTALL_SIDECAR_FILENAME } from "@openwork/install-config"
+import {
+  DESKTOP_BOOTSTRAP_FILENAME,
+  desktopBootstrapConfigSchema,
+  installConfigSchema,
+} from "@openwork/install-config"
 import { and, eq, gt, isNull, or } from "@openwork-ee/den-db/drizzle"
 import { InstallLinkTable, OrganizationTable, RateLimitTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
@@ -8,15 +12,16 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { OPENWORK_DOWNLOAD_URL } from "../../CONSTS.js"
 import { resolvePublicOrigin } from "../../capability-sources/generic-oauth.js"
+import { organizationInstallLinksEnabled } from "../../capability-sources/install-links-rollout.js"
 import { db } from "../../db.js"
 import { env } from "../../env.js"
 import { hashInstallLinkToken, mintOrganizationInstallLink } from "../../install-links.js"
 import { jsonValidator, orgRoleRoute, publicRoute, queryValidator } from "../../middleware/index.js"
 import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, textResponse, unauthorizedSchema } from "../../openapi.js"
-import { organizationCapabilityKeySchema, organizationHasCapability } from "../../organization-capabilities.js"
+import { organizationCapabilityKeySchema } from "../../organization-capabilities.js"
 import { normalizeOrganizationMetadata } from "../../organization-limits.js"
-import { resolveInstallerArtifact, resolveInstallerFallbackUrl } from "../../utils/installer-artifacts.js"
-import { appendStoredEntryToZip } from "../../utils/zip-append.js"
+import { desktopReleaseAssetName, resolveInstallerArtifact, resolveInstallerFallbackUrl } from "../../utils/installer-artifacts.js"
+import { createStoredZip } from "../../utils/zip-append.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureOrganizationAdmin, orgAccessFailureStatus } from "./shared.js"
 
@@ -166,21 +171,7 @@ function contentDisposition(filename: string) {
 }
 
 function artifactFileName(platform: InstallPlatform) {
-  return platform.startsWith("mac-")
-    ? `openwork-installer-${platform}.zip`
-    : platform === "win-x64"
-      ? `openwork-installer-${platform}.exe`
-      : null
-}
-
-function encodeHostForFilename(apiUrl: string) {
-  return new URL(apiUrl).host.replace(/:/g, "_")
-}
-
-function responseBodyFromBuffer(buffer: Buffer) {
-  const bytes = new Uint8Array(buffer.byteLength)
-  bytes.set(buffer)
-  return bytes.buffer
+  return desktopReleaseAssetName(platform, env.installerReleaseTag)
 }
 
 function shellQuote(value: string) {
@@ -278,9 +269,9 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
       const input = c.req.valid("json")
       const payload = c.get("organizationContext")
 
-      // Org capability gate: install links ship dark and are enabled
-      // org-by-org from the platform /admin backoffice.
-      if (!organizationHasCapability(payload.organization.metadata, "installLinks")) {
+      if (!organizationInstallLinksEnabled(payload.organization.metadata, {
+        gatingEnabled: env.installLinksGatingEnabled,
+      })) {
         return c.json({ error: "capability_disabled", capability: "installLinks" }, 403)
       }
 
@@ -353,7 +344,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
     describeRoute({
       tags: ["Organizations"],
       summary: "Download stamped installer",
-      description: "Serves the generic OpenWork installer artifact stamped at download time for this organization, or redirects to a verified normal desktop download when Den cannot prepare it.",
+      description: "Packages the standard signed OpenWork desktop installer with this organization's bootstrap configuration, or redirects to the verified standard download when Den cannot prepare the bundle.",
       responses: {
         200: textResponse("Installer artifact returned successfully."),
         302: emptyResponse("Den redirected the browser to a verified normal desktop download."),
@@ -403,23 +394,23 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         return c.redirect(await installer.resolveFallbackUrl(platform), 302)
       }
 
-      if (platform.startsWith("mac-")) {
-        const sidecar = Buffer.from(JSON.stringify(resolved.config), "utf8")
-        const stampedZip = appendStoredEntryToZip(artifact, INSTALL_SIDECAR_FILENAME, sidecar)
-        return new Response(stampedZip, {
-          headers: {
-            "content-type": "application/zip",
-            "content-disposition": contentDisposition(`OpenWork-Installer-${safeAttachmentSlug(resolved.organizationSlug)}.zip`),
-            "cache-control": "no-store",
-          },
-        })
-      }
+      const bootstrap = desktopBootstrapConfigSchema.parse({
+        baseUrl: resolved.config.webUrl,
+        apiBaseUrl: resolved.config.apiUrl,
+        requireSignin: resolved.config.requireSignin,
+        brandAppName: resolved.config.appName,
+        brandLogoUrl: resolved.config.logoUrl ?? undefined,
+        writtenAt: new Date().toISOString(),
+      })
+      const bundle = createStoredZip([
+        { name: fileName, content: artifact },
+        { name: DESKTOP_BOOTSTRAP_FILENAME, content: Buffer.from(`${JSON.stringify(bootstrap, null, 2)}\n`, "utf8") },
+      ])
 
-      const stampedHost = encodeHostForFilename(resolved.config.apiUrl)
-      return new Response(responseBodyFromBuffer(artifact), {
+      return new Response(bundle, {
         headers: {
-          "content-type": "application/vnd.microsoft.portable-executable",
-          "content-disposition": contentDisposition(`OpenWork-Installer--${stampedHost}--${input.token}.exe`),
+          "content-type": "application/zip",
+          "content-disposition": contentDisposition(`OpenWork-${safeAttachmentSlug(resolved.organizationSlug)}-${platform}.zip`),
           "cache-control": "no-store",
         },
       })

--- a/ee/apps/den-api/src/utils/installer-artifacts.ts
+++ b/ee/apps/den-api/src/utils/installer-artifacts.ts
@@ -5,14 +5,13 @@ import path from "node:path"
 import { env } from "../env.js"
 
 /**
- * Resolves a generic installer artifact (openwork-installer-mac-arm64.zip,
- * openwork-installer-mac-x64.zip, openwork-installer-win-x64.exe) so
- * install-link downloads work without any local artifact directory:
+ * Resolves the standard signed desktop artifact so organization install-link
+ * downloads work without building a second installer application:
  *
  *   1. OPENWORK_INSTALLER_ARTIFACTS_DIR file, when set and present
  *      (self-hosted/dev override — the pre-#2480 behavior, moved here).
  *   2. Disk cache under OPENWORK_INSTALLER_CACHE_DIR/<releaseTag>/<fileName>.
- *   3. The public release asset published by release-generic-installer.yml:
+ *   3. The normal public desktop release asset:
  *      https://github.com/<repo>/releases/download/<releaseTag>/<fileName>,
  *      streamed to a temp file then atomically renamed into the cache.
  *
@@ -48,7 +47,7 @@ export function installerReleaseAssetUrl(
   return `https://github.com/${releaseRepo}/releases/download/${encodeURIComponent(releaseTag)}/${encodeURIComponent(fileName)}`
 }
 
-function desktopReleaseAssetName(platform: string, releaseTag: string) {
+export function desktopReleaseAssetName(platform: string, releaseTag: string) {
   const version = releaseTag.startsWith("v") ? releaseTag.slice(1) : releaseTag
   if (platform === "mac-arm64" || platform === "mac-x64") {
     return `openwork-${platform}-${version}.dmg`

--- a/ee/apps/den-api/src/utils/zip-append.ts
+++ b/ee/apps/den-api/src/utils/zip-append.ts
@@ -188,9 +188,10 @@ function toArrayBuffer(buffer: Buffer) {
   return bytes.buffer
 }
 
-export function createStoredZip(entries: Array<{ name: string; content: Buffer }>): ArrayBuffer {
+function createStoredZipChunks(entries: Array<{ name: string; content: Buffer }>) {
   if (entries.length === 0) {
-    return toArrayBuffer(createEndOfCentralDirectory(0, 0, 0, Buffer.alloc(0)))
+    const eocd = createEndOfCentralDirectory(0, 0, 0, Buffer.alloc(0))
+    return { chunks: [eocd], byteLength: eocd.length }
   }
 
   const localChunks: Buffer[] = []
@@ -211,15 +212,50 @@ export function createStoredZip(entries: Array<{ name: string; content: Buffer }
 
   const centralDirectorySize = centralDirectoryChunks.reduce((total, chunk) => total + chunk.length, 0)
   const eocd = createEndOfCentralDirectory(entries.length, centralDirectorySize, localHeaderOffset, Buffer.alloc(0))
-  const output = Buffer.alloc(localHeaderOffset + centralDirectorySize + eocd.length)
+  return {
+    chunks: [...localChunks, ...centralDirectoryChunks, eocd],
+    byteLength: localHeaderOffset + centralDirectorySize + eocd.length,
+  }
+}
+
+export function createStoredZip(entries: Array<{ name: string; content: Buffer }>): ArrayBuffer {
+  const archive = createStoredZipChunks(entries)
+  const output = Buffer.alloc(archive.byteLength)
   let outputOffset = 0
 
-  for (const chunk of [...localChunks, ...centralDirectoryChunks, eocd]) {
+  for (const chunk of archive.chunks) {
     writeBytes(output, chunk, outputOffset)
     outputOffset += chunk.length
   }
 
   return toArrayBuffer(output)
+}
+
+export function createStoredZipStream(entries: Array<{ name: string; content: Buffer }>) {
+  const archive = createStoredZipChunks(entries)
+  const maxChunkSize = 1024 * 1024
+  let chunkIndex = 0
+  let chunkOffset = 0
+
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      while (chunkIndex < archive.chunks.length) {
+        const chunk = archive.chunks[chunkIndex]
+        if (chunkOffset >= chunk.length) {
+          chunkIndex += 1
+          chunkOffset = 0
+          continue
+        }
+        const end = Math.min(chunk.length, chunkOffset + maxChunkSize)
+        controller.enqueue(chunk.subarray(chunkOffset, end))
+        chunkOffset = end
+        return
+      }
+      controller.close()
+    },
+  })
+
+  return { body, byteLength: archive.byteLength }
 }
 
 export function appendStoredEntryToZip(sourceZip: Buffer, entryNameInput: string, contentInput: Buffer): ArrayBuffer {

--- a/ee/apps/den-api/src/utils/zip-append.ts
+++ b/ee/apps/den-api/src/utils/zip-append.ts
@@ -188,6 +188,40 @@ function toArrayBuffer(buffer: Buffer) {
   return bytes.buffer
 }
 
+export function createStoredZip(entries: Array<{ name: string; content: Buffer }>): ArrayBuffer {
+  if (entries.length === 0) {
+    return toArrayBuffer(createEndOfCentralDirectory(0, 0, 0, Buffer.alloc(0)))
+  }
+
+  const localChunks: Buffer[] = []
+  const centralDirectoryChunks: Buffer[] = []
+  let localHeaderOffset = 0
+  const { time, date } = dosTimestamp()
+
+  for (const entry of entries) {
+    const entryName = Buffer.from(entry.name, "utf8")
+    const checksum = crc32(entry.content)
+    const localHeader = createLocalHeader(entryName, entry.content, time, date, checksum)
+    localChunks.push(localHeader, entry.content)
+    centralDirectoryChunks.push(
+      createCentralDirectoryHeader(entryName, entry.content, localHeaderOffset, time, date, checksum),
+    )
+    localHeaderOffset += localHeader.length + entry.content.length
+  }
+
+  const centralDirectorySize = centralDirectoryChunks.reduce((total, chunk) => total + chunk.length, 0)
+  const eocd = createEndOfCentralDirectory(entries.length, centralDirectorySize, localHeaderOffset, Buffer.alloc(0))
+  const output = Buffer.alloc(localHeaderOffset + centralDirectorySize + eocd.length)
+  let outputOffset = 0
+
+  for (const chunk of [...localChunks, ...centralDirectoryChunks, eocd]) {
+    writeBytes(output, chunk, outputOffset)
+    outputOffset += chunk.length
+  }
+
+  return toArrayBuffer(output)
+}
+
 export function appendStoredEntryToZip(sourceZip: Buffer, entryNameInput: string, contentInput: Buffer): ArrayBuffer {
   const source = sourceZip
   const entryName = Buffer.from(entryNameInput, "utf8")

--- a/ee/apps/den-api/src/utils/zip-append.ts
+++ b/ee/apps/den-api/src/utils/zip-append.ts
@@ -247,7 +247,7 @@ export function createStoredZipStream(entries: Array<{ name: string; content: Bu
           continue
         }
         const end = Math.min(chunk.length, chunkOffset + maxChunkSize)
-        controller.enqueue(chunk.subarray(chunkOffset, end))
+        controller.enqueue(Uint8Array.from(chunk.subarray(chunkOffset, end)))
         chunkOffset = end
         return
       }

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -113,14 +113,17 @@ mock.module("../src/orgs.js", () => ({
 
 let installLinkModule: typeof import("../src/routes/org/install-links.js")
 let installLinkMintingModule: typeof import("../src/install-links.js")
+let envModule: typeof import("../src/env.js")
 
 beforeAll(async () => {
   seedRequiredEnv()
+  envModule = await import("../src/env.js")
   installLinkMintingModule = await import("../src/install-links.js")
   installLinkModule = await import("../src/routes/org/install-links.js")
 })
 
 beforeEach(() => {
+  envModule.env.installLinksGatingEnabled = true
   insertedRows.length = 0
   revokedRows.length = 0
   role = "member"

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -1,12 +1,17 @@
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { beforeAll, beforeEach, expect, mock, test } from "bun:test"
 import { Hono } from "hono"
+import { spawnSync } from "node:child_process"
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import os from "node:os"
+import path from "node:path"
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
   process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.DEN_INSTALL_LINKS_GATING_ENABLED = "true"
 }
 
 const userId = createDenTypeId("user")
@@ -125,7 +130,7 @@ beforeEach(() => {
   sessionCreatedAt = new Date()
 })
 
-function createApp(options: { installerFallbackUrl?: string } = {}) {
+function createApp(options: { installerFallbackUrl?: string; installerArtifact?: Buffer } = {}) {
   const app = new Hono()
   const installerFallbackUrl = options.installerFallbackUrl
   app.use("*", async (c, next) => {
@@ -147,10 +152,10 @@ function createApp(options: { installerFallbackUrl?: string } = {}) {
   })
   installLinkModule.registerOrgInstallLinkRoutes(
     app,
-    installerFallbackUrl
+    installerFallbackUrl || options.installerArtifact
       ? {
-          resolveArtifact: () => Promise.resolve(null),
-          resolveFallbackUrl: () => Promise.resolve(installerFallbackUrl),
+          resolveArtifact: () => Promise.resolve(options.installerArtifact ?? null),
+          resolveFallbackUrl: () => Promise.resolve(installerFallbackUrl ?? officialWindowsInstallerUrl),
         }
       : undefined,
   )
@@ -283,4 +288,47 @@ test("missing server-side artifacts redirect the browser to the official release
   expect(response.status).toBe(302)
   expect(response.headers.get("location")).toBe(officialWindowsInstallerUrl)
   expect(response.headers.get("location")).not.toContain("opaque-token")
+})
+
+test.each([
+  ["mac-arm64", ".dmg"],
+  ["win-x64", ".exe"],
+])("organization %s downloads contain the untouched standard installer and desktop bootstrap", async (platform, extension) => {
+  const installerArtifact = Buffer.from(`signed-standard-${platform}-bytes`, "utf8")
+  const response = await createApp({ installerArtifact }).request(`http://den.local/v1/install/${platform}?token=opaque-token`)
+
+  expect(response.status).toBe(200)
+  expect(response.headers.get("content-type")).toBe("application/zip")
+  expect(response.headers.get("content-disposition")).toContain(`OpenWork-acme-robotics-${platform}.zip`)
+
+  const dir = mkdtempSync(path.join(os.tmpdir(), "openwork-org-download-"))
+  try {
+    const archivePath = path.join(dir, "download.zip")
+    const outputDir = path.join(dir, "output")
+    mkdirSync(outputDir)
+    writeFileSync(archivePath, new Uint8Array(await response.arrayBuffer()))
+    const unzip = spawnSync("unzip", ["-q", archivePath, "-d", outputDir], { encoding: "utf8" })
+    if (unzip.status !== 0) {
+      throw new Error(`unzip failed: ${unzip.stderr || unzip.stdout}`)
+    }
+
+    const entries = readdirSync(outputDir)
+    const installerName = entries.find((entry) => entry.endsWith(extension))
+    expect(installerName).toBeTruthy()
+    expect(entries).toContain("desktop-bootstrap.json")
+    expect(entries.some((entry) => entry.includes("openwork-installer"))).toBe(false)
+    expect(readFileSync(path.join(outputDir, installerName ?? "missing"))).toEqual(installerArtifact)
+
+    const bootstrap = JSON.parse(readFileSync(path.join(outputDir, "desktop-bootstrap.json"), "utf8"))
+    expect(bootstrap).toMatchObject({
+      baseUrl: process.env.BETTER_AUTH_URL,
+      requireSignin: true,
+      brandAppName: "OpenWork",
+    })
+    expect(bootstrap.apiBaseUrl).toBe("http://den.local")
+    expect(Number.isFinite(Date.parse(bootstrap.writtenAt))).toBe(true)
+    expect(JSON.stringify(bootstrap)).not.toContain("opaque-token")
+  } finally {
+    rmSync(dir, { recursive: true, force: true })
+  }
 })

--- a/ee/apps/den-api/test/install-links-rollout.test.ts
+++ b/ee/apps/den-api/test/install-links-rollout.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test"
+import { organizationInstallLinksEnabled } from "../src/capability-sources/install-links-rollout.js"
+
+describe("organizationInstallLinksEnabled", () => {
+  test("is active by default when deployment gating is off", () => {
+    expect(organizationInstallLinksEnabled(null, { gatingEnabled: false })).toBe(true)
+    expect(organizationInstallLinksEnabled({ capabilities: { installLinks: false } }, { gatingEnabled: false })).toBe(true)
+  })
+
+  test("requires explicit organization opt-in when hosted gating is on", () => {
+    expect(organizationInstallLinksEnabled(null, { gatingEnabled: true })).toBe(false)
+    expect(organizationInstallLinksEnabled({ capabilities: { installLinks: false } }, { gatingEnabled: true })).toBe(false)
+    expect(organizationInstallLinksEnabled({ capabilities: { installLinks: true } }, { gatingEnabled: true })).toBe(true)
+  })
+})

--- a/ee/apps/den-api/test/installer-artifacts.test.ts
+++ b/ee/apps/den-api/test/installer-artifacts.test.ts
@@ -11,15 +11,16 @@ function seedRequiredEnv() {
 }
 
 let installerReleaseAssetUrl: typeof import("../src/utils/installer-artifacts.js")["installerReleaseAssetUrl"]
+let desktopReleaseAssetName: typeof import("../src/utils/installer-artifacts.js")["desktopReleaseAssetName"]
 let resolveInstallerArtifact: typeof import("../src/utils/installer-artifacts.js")["resolveInstallerArtifact"]
 let resolveInstallerFallbackUrl: typeof import("../src/utils/installer-artifacts.js")["resolveInstallerFallbackUrl"]
 
 beforeAll(async () => {
   seedRequiredEnv()
-  ;({ installerReleaseAssetUrl, resolveInstallerArtifact, resolveInstallerFallbackUrl } = await import("../src/utils/installer-artifacts.js"))
+  ;({ desktopReleaseAssetName, installerReleaseAssetUrl, resolveInstallerArtifact, resolveInstallerFallbackUrl } = await import("../src/utils/installer-artifacts.js"))
 })
 
-const FILE_NAME = "openwork-installer-mac-arm64.zip"
+const FILE_NAME = "openwork-mac-arm64-9.9.9.dmg"
 
 function tempDir(prefix: string) {
   return mkdtempSync(path.join(os.tmpdir(), prefix))
@@ -33,11 +34,19 @@ function fetcherReturning(status: number, body: string | null, calls: string[]) 
 }
 
 describe("resolveInstallerArtifact", () => {
-  test("builds a generic installer asset URL for the configured release", () => {
+  test("builds a standard desktop asset URL for the configured release", () => {
     expect(installerReleaseAssetUrl(FILE_NAME, {
       releaseTag: "v9.9.9+build 2",
       releaseRepo: "different-ai/openwork",
     })).toBe(`https://github.com/different-ai/openwork/releases/download/v9.9.9%2Bbuild%202/${FILE_NAME}`)
+  })
+
+  test.each([
+    ["mac-arm64", "v9.9.9", "openwork-mac-arm64-9.9.9.dmg"],
+    ["mac-x64", "9.9.9", "openwork-mac-x64-9.9.9.dmg"],
+    ["win-x64", "v9.9.9", "openwork-win-x64-9.9.9.exe"],
+  ])("maps %s to the standard release artifact", (platform, releaseTag, expected) => {
+    expect(desktopReleaseAssetName(platform, releaseTag)).toBe(expected)
   })
 
   test.each([

--- a/ee/apps/den-api/test/zip-append.test.ts
+++ b/ee/apps/den-api/test/zip-append.test.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto"
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { appendStoredEntryToZip } from "../src/utils/zip-append.js"
+import { appendStoredEntryToZip, createStoredZip } from "../src/utils/zip-append.js"
 
 function run(command: string, args: string[], cwd: string) {
   const result = spawnSync(command, args, { cwd, encoding: "utf8" })
@@ -40,6 +40,31 @@ describe("appendStoredEntryToZip", () => {
 
       expect(sha256(readFileSync(path.join(outputDir, "hello.txt")))).toBe(sha256(originalContent))
       expect(readFileSync(path.join(outputDir, "openwork-installer.json"), "utf8")).toBe(sidecarJson)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe("createStoredZip", () => {
+  test("packages the standard installer and desktop bootstrap without changing their bytes", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "openwork-zip-create-"))
+    try {
+      const outputDir = path.join(dir, "output")
+      const zipPath = path.join(dir, "organization-download.zip")
+      mkdirSync(outputDir)
+      const installer = Buffer.from("byte-identical signed desktop installer", "utf8")
+      const bootstrap = Buffer.from('{"baseUrl":"https://openwork.example.com"}\n', "utf8")
+      const bundle = createStoredZip([
+        { name: "openwork-mac-arm64-9.9.9.dmg", content: installer },
+        { name: "desktop-bootstrap.json", content: bootstrap },
+      ])
+      writeFileSync(zipPath, new Uint8Array(bundle))
+
+      run("unzip", ["-q", zipPath, "-d", outputDir], dir)
+
+      expect(sha256(readFileSync(path.join(outputDir, "openwork-mac-arm64-9.9.9.dmg")))).toBe(sha256(installer))
+      expect(readFileSync(path.join(outputDir, "desktop-bootstrap.json"), "utf8")).toBe(bootstrap.toString("utf8"))
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }

--- a/ee/apps/den-api/test/zip-append.test.ts
+++ b/ee/apps/den-api/test/zip-append.test.ts
@@ -4,7 +4,7 @@ import { createHash } from "node:crypto"
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs"
 import os from "node:os"
 import path from "node:path"
-import { appendStoredEntryToZip, createStoredZip } from "../src/utils/zip-append.js"
+import { appendStoredEntryToZip, createStoredZip, createStoredZipStream } from "../src/utils/zip-append.js"
 
 function run(command: string, args: string[], cwd: string) {
   const result = spawnSync(command, args, { cwd, encoding: "utf8" })
@@ -68,5 +68,20 @@ describe("createStoredZip", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
+  })
+
+  test("streams the same valid archive with a deterministic content length", async () => {
+    const installer = Buffer.alloc(3 * 1024 * 1024 + 17, 42)
+    const bootstrap = Buffer.from('{"baseUrl":"https://openwork.example.com"}\n', "utf8")
+    const entries = [
+      { name: "openwork-mac-arm64-9.9.9.dmg", content: installer },
+      { name: "desktop-bootstrap.json", content: bootstrap },
+    ]
+    const streamed = createStoredZipStream(entries)
+    const streamedBytes = Buffer.from(await new Response(streamed.body).arrayBuffer())
+    const bufferedBytes = Buffer.from(createStoredZip(entries))
+
+    expect(streamed.byteLength).toBe(streamedBytes.length)
+    expect(streamedBytes).toEqual(bufferedBytes)
   })
 })

--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -196,7 +196,7 @@ export function InstallScreen() {
             <img src={config.logoUrl} alt={`${config.clientName} wordmark`} className="max-h-16 max-w-64 object-contain object-left" />
           ) : null}
           <h1 className="den-title-xl">Download {config.appName} for {config.clientName}</h1>
-          <p className="den-copy">Run it, then sign in — your team's workspace is preconfigured.</p>
+          <p className="den-copy">Mac and Windows downloads include the standard OpenWork installer and your team's setup file in one ZIP. Keep them together, run the installer, then sign in.</p>
         </div>
 
         {isMobile ? (

--- a/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
+++ b/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
@@ -1,113 +1,166 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync, statSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
-// Narration is loaded from the approved script (evals/voiceovers/standard-dmg-bootstrap-zip.md).
-// The runner fails this flow if the narration drifts from that script.
-const vo = await loadVoiceoverParagraphs("standard-dmg-bootstrap-zip");
+const FLOW_ID = "standard-dmg-bootstrap-zip";
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const DEN_WEB_URL = cleanUrl(process.env.OPENWORK_EVAL_DEN_WEB_URL);
+const INSTALL_TOKEN = process.env.OPENWORK_EVAL_INSTALL_TOKEN?.trim() ?? "";
+const BUNDLE_ZIP = process.env.OPENWORK_EVAL_BUNDLE_ZIP?.trim() ?? "";
+const BUNDLE_DIR = process.env.OPENWORK_EVAL_BUNDLE_DIR?.trim() ?? "";
+const BOOTSTRAP_PATH = process.env.OPENWORK_EVAL_BOOTSTRAP_PATH?.trim() ?? "";
+const APP_URL = process.env.OPENWORK_EVAL_APP_URL?.trim() || "http://localhost:5173/";
+
+function cleanUrl(value) {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : typeof actual === "string" ? actual : JSON.stringify(actual).slice(0, 900),
+  });
+  ctx.assert(condition, assertion + (actual === undefined ? "" : ` (actual: ${JSON.stringify(actual).slice(0, 500)})`));
+}
+
+async function navigate(ctx, url) {
+  await ctx.eval(`location.assign(${JSON.stringify(url)}); true`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${url}` });
+}
+
+function readJson(filePath) {
+  return JSON.parse(readFileSync(filePath, "utf8"));
+}
+
+function zipEntries() {
+  const result = spawnSync("unzip", ["-Z1", BUNDLE_ZIP], { cwd: ROOT, encoding: "utf8" });
+  if (result.status !== 0) throw new Error(`unzip -Z1 failed: ${result.stderr || result.stdout}`);
+  return result.stdout.split("\n").map((entry) => entry.trim()).filter(Boolean);
+}
 
 export default {
-  id: "standard-dmg-bootstrap-zip",
-  title: "TODO: one-line claim — user can do X and sees Y",
+  id: FLOW_ID,
+  title: "Organization downloads reuse the standard signed installer and configure OpenWork on first launch",
   kind: "user-facing",
+  requiredEnv: [
+    "OPENWORK_EVAL_DEN_WEB_URL",
+    "OPENWORK_EVAL_INSTALL_TOKEN",
+    "OPENWORK_EVAL_BUNDLE_ZIP",
+    "OPENWORK_EVAL_BUNDLE_DIR",
+    "OPENWORK_EVAL_BOOTSTRAP_PATH",
+  ],
   steps: [
     {
-      name: "Frame 1",
+      name: "Organization download is available under deployment policy",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 1", {
+        await ctx.prove("The enabled organization has a branded download page", {
           voiceover: vo[0],
-          // "An organization administrator enables organization downloads. Hosted organiz"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await navigate(ctx, `${DEN_WEB_URL}/install?token=${encodeURIComponent(INSTALL_TOKEN)}`);
+            await ctx.waitForText("Acme Work", { timeoutMs: 30_000 });
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 1 not implemented yet");
+            await ctx.expectText("Download Acme Work");
+            await ctx.expectText("Acme Robotics");
           },
-          screenshot: { name: "frame-1", requireText: [] },
+          screenshot: { name: "organization-download-enabled", requireText: ["Download Acme Work", "Acme Robotics"] },
         });
       },
     },
     {
-      name: "Frame 2",
+      name: "Member sees the organization download",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 2", {
+        await ctx.prove("The member sees the standard platform choices for Acme", {
           voiceover: vo[1],
-          // "A signed-in organization member opens the dashboard and sees the download in"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await ctx.eval("document.querySelector('[data-testid=install-download-primary]')?.focus(); true");
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 2 not implemented yet");
+            await ctx.expectText("Mac (Apple silicon)");
+            await ctx.expectText("Windows");
+            const href = await ctx.eval("document.querySelector('[data-testid=install-download-primary]')?.href");
+            witness(ctx, typeof href === "string" && href.includes(`/v1/install/`) && href.includes("token="), "The primary button targets the organization install endpoint", href);
           },
-          screenshot: { name: "frame-2", requireText: [] },
+          screenshot: { name: "organization-platform-downloads", requireText: ["Mac (Apple silicon)", "Windows"] },
         });
       },
     },
     {
-      name: "Frame 3",
+      name: "ZIP contains the normal installer and bootstrap only",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 3", {
+        await ctx.prove("The downloaded ZIP has exactly the standard DMG and desktop-bootstrap.json", {
           voiceover: vo[2],
-          // "The member downloads one ZIP containing only the standard signed OpenWork DM"
-          action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
-          },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 3 not implemented yet");
+            const entries = zipEntries();
+            witness(ctx, entries.length === 2, "The organization ZIP has exactly two top-level files", entries);
+            witness(ctx, entries.some((entry) => /^openwork-mac-arm64-.+\.dmg$/.test(entry)), "The ZIP contains the normal versioned macOS DMG", entries);
+            witness(ctx, entries.includes("desktop-bootstrap.json"), "The ZIP contains desktop-bootstrap.json", entries);
+            witness(ctx, !entries.some((entry) => entry.includes("openwork-installer")), "The ZIP contains no separate installer application", entries);
+            ctx.output("organization-download.zip", `${entries.join("\n")}\n\n${statSync(BUNDLE_ZIP).size} bytes`);
           },
-          screenshot: { name: "frame-3", requireText: [] },
         });
       },
     },
     {
-      name: "Frame 4",
+      name: "First launch imports the adjacent bootstrap",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 4", {
+        await ctx.prove("The standard desktop imported the bootstrap before showing sign-in", {
           voiceover: vo[3],
-          // "The member extracts the ZIP and opens the normal OpenWork DMG. OpenWork reco"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await navigate(ctx, APP_URL);
+            await ctx.waitForText("Welcome to Acme Work", { timeoutMs: 45_000 });
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 4 not implemented yet");
+            const bundled = readJson(path.join(BUNDLE_DIR, "desktop-bootstrap.json"));
+            const canonical = readJson(BOOTSTRAP_PATH);
+            witness(ctx, JSON.stringify(canonical) === JSON.stringify(bundled), "The adjacent bundle bootstrap was copied byte-for-value to the canonical desktop config", { bundled, canonical });
+            await ctx.expectText("Sign in to Acme Work");
+            await ctx.expectText(new URL(bundled.baseUrl).host);
+            ctx.output("canonical-desktop-bootstrap.json", JSON.stringify(canonical, null, 2));
           },
-          screenshot: { name: "frame-4", requireText: [] },
+          screenshot: { name: "standard-desktop-imported-bootstrap", requireText: ["Welcome to Acme Work", "Sign in to Acme Work"] },
         });
       },
     },
     {
-      name: "Frame 5",
+      name: "Configured name and wordmark appear without changing sign-in",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 5", {
+        await ctx.prove("The first-run screen uses Acme's name and loaded wordmark while preserving normal sign-in", {
           voiceover: vo[4],
-          // "After the standard macOS installation, OpenWork starts connected to the corr"
-          action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
-          },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 5 not implemented yet");
+            const logo = await ctx.eval(`(() => {
+              const image = [...document.images].find((entry) => entry.alt === "Acme Work logo");
+              return image ? { src: image.src, complete: image.complete, naturalWidth: image.naturalWidth } : null;
+            })()`);
+            witness(ctx, logo?.complete === true && logo.naturalWidth > 0, "The configured Acme wordmark loaded successfully", logo);
+            await ctx.expectText("Sign in to Acme Work");
+            await ctx.expectText("Paste sign-in code");
           },
-          screenshot: { name: "frame-5", requireText: [] },
+          screenshot: { name: "acme-branding-normal-signin", requireText: ["Welcome to Acme Work", "Paste sign-in code"] },
         });
       },
     },
     {
-      name: "Frame 6",
+      name: "Hosted opt-in and self-host defaults remain explicit",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 6", {
+        await ctx.prove("Hosted gating requires opt-in while self-hosted OpenWork enables downloads by default", {
           voiceover: vo[5],
-          // "If organization downloads are disabled, OpenWork never generates or exposes "
-          action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
-          },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 6 not implemented yet");
+            const result = spawnSync(
+              "pnpm",
+              ["exec", "bun", "test", "ee/apps/den-api/test/install-links-rollout.test.ts"],
+              { cwd: ROOT, encoding: "utf8", env: process.env },
+            );
+            witness(ctx, result.status === 0, "The deployment gating contract passes in the exact branch sandbox", result.stdout + result.stderr);
+            ctx.output("install-links rollout contract", (result.stdout + result.stderr).trim());
+            const releaseWorkflow = readFileSync(path.join(ROOT, ".github", "workflows", "release-macos-aarch64.yml"), "utf8");
+            witness(ctx, !releaseWorkflow.includes("publish-generic-installer:"), "Stable releases no longer build the separate generic installer", "publish-generic-installer job absent");
           },
-          screenshot: { name: "frame-6", requireText: [] },
         });
       },
     },

--- a/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
+++ b/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
@@ -95,7 +95,12 @@ export default {
         await ctx.prove("The member sees the standard platform choices for Acme", {
           voiceover: vo[1],
           action: async () => {
-            await ctx.eval("document.querySelector('[data-testid=install-download-primary]')?.focus(); true");
+            await ctx.client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Tab", code: "Tab" });
+            await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Tab", code: "Tab" });
+            await ctx.waitFor("document.activeElement?.matches('[data-testid=install-download-primary]')", {
+              timeoutMs: 5_000,
+              label: "keyboard focus on primary organization download",
+            });
           },
           assert: async () => {
             await ctx.expectText("Mac (Apple silicon)");

--- a/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
+++ b/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
@@ -157,6 +157,14 @@ export default {
         await withClient(ctx, DESKTOP_CDP_URL, async () => {
           await ctx.prove("The first-run screen uses Acme's name and loaded wordmark while preserving normal sign-in", {
             voiceover: vo[4],
+            action: async () => {
+              await ctx.client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Tab", code: "Tab" });
+              await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Tab", code: "Tab" });
+              await ctx.waitFor("document.activeElement?.tagName === 'BUTTON'", {
+                timeoutMs: 5_000,
+                label: "keyboard focus on normal sign-in controls",
+              });
+            },
             assert: async () => {
               const logo = await ctx.eval(`(() => {
                 const image = [...document.images].find((entry) => entry.alt === "Acme Work logo");

--- a/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
+++ b/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
@@ -1,0 +1,115 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/standard-dmg-bootstrap-zip.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("standard-dmg-bootstrap-zip");
+
+export default {
+  id: "standard-dmg-bootstrap-zip",
+  title: "TODO: one-line claim — user can do X and sees Y",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 1", {
+          voiceover: vo[0],
+          // "An organization administrator enables organization downloads. Hosted organiz"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 1 not implemented yet");
+          },
+          screenshot: { name: "frame-1", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 2", {
+          voiceover: vo[1],
+          // "A signed-in organization member opens the dashboard and sees the download in"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 2 not implemented yet");
+          },
+          screenshot: { name: "frame-2", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 3", {
+          voiceover: vo[2],
+          // "The member downloads one ZIP containing only the standard signed OpenWork DM"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 3 not implemented yet");
+          },
+          screenshot: { name: "frame-3", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 4", {
+          voiceover: vo[3],
+          // "The member extracts the ZIP and opens the normal OpenWork DMG. OpenWork reco"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 4 not implemented yet");
+          },
+          screenshot: { name: "frame-4", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 5", {
+          voiceover: vo[4],
+          // "After the standard macOS installation, OpenWork starts connected to the corr"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 5 not implemented yet");
+          },
+          screenshot: { name: "frame-5", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 6", {
+          voiceover: vo[5],
+          // "If organization downloads are disabled, OpenWork never generates or exposes "
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 6 not implemented yet");
+          },
+          screenshot: { name: "frame-6", requireText: [] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
+++ b/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
@@ -135,7 +135,6 @@ export default {
           await ctx.prove("The standard desktop imported the bootstrap before showing sign-in", {
             voiceover: vo[3],
             action: async () => {
-              await ctx.client.send("Page.reload", { ignoreCache: true });
               await ctx.waitForText("Welcome to Acme Work", { timeoutMs: 45_000 });
             },
             assert: async () => {

--- a/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
+++ b/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
@@ -29,7 +29,9 @@ function witness(ctx, condition, assertion, actual) {
 }
 
 async function navigate(ctx, url) {
-  await ctx.eval(`location.assign(${JSON.stringify(url)}); true`);
+  await ctx.eval(`location.assign(${JSON.stringify(url)}); true`).catch(() => undefined);
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  await ctx.reconnect();
   await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${url}` });
 }
 

--- a/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
+++ b/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
@@ -2,6 +2,7 @@ import { spawnSync } from "node:child_process";
 import { readFileSync, statSync } from "node:fs";
 import path from "node:path";
 import { fileURLToPath } from "node:url";
+import { connect, debuggerUrlFor, listTargets } from "../runner/cdp.mjs";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
 const FLOW_ID = "standard-dmg-bootstrap-zip";
@@ -12,7 +13,7 @@ const INSTALL_TOKEN = process.env.OPENWORK_EVAL_INSTALL_TOKEN?.trim() ?? "";
 const BUNDLE_ZIP = process.env.OPENWORK_EVAL_BUNDLE_ZIP?.trim() ?? "";
 const BUNDLE_DIR = process.env.OPENWORK_EVAL_BUNDLE_DIR?.trim() ?? "";
 const BOOTSTRAP_PATH = process.env.OPENWORK_EVAL_BOOTSTRAP_PATH?.trim() ?? "";
-const APP_URL = process.env.OPENWORK_EVAL_APP_URL?.trim() || "http://localhost:5173/";
+const DESKTOP_CDP_URL = cleanUrl(process.env.OPENWORK_EVAL_DESKTOP_CDP_URL);
 
 function cleanUrl(value) {
   return (value ?? "").trim().replace(/\/+$/, "");
@@ -29,10 +30,23 @@ function witness(ctx, condition, assertion, actual) {
 }
 
 async function navigate(ctx, url) {
-  await ctx.eval(`location.assign(${JSON.stringify(url)}); true`).catch(() => undefined);
-  await new Promise((resolve) => setTimeout(resolve, 500));
-  await ctx.reconnect();
+  await ctx.client.send("Page.navigate", { url });
   await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${url}` });
+}
+
+async function withClient(ctx, cdpBaseUrl, callback) {
+  const previous = ctx.client;
+  const targets = await listTargets(cdpBaseUrl);
+  const target = targets.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+  if (!target) throw new Error(`No page target available at ${cdpBaseUrl}`);
+  const client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+  ctx.client = client;
+  try {
+    return await callback();
+  } finally {
+    ctx.client = previous;
+    client.close();
+  }
 }
 
 function readJson(filePath) {
@@ -55,6 +69,7 @@ export default {
     "OPENWORK_EVAL_BUNDLE_ZIP",
     "OPENWORK_EVAL_BUNDLE_DIR",
     "OPENWORK_EVAL_BOOTSTRAP_PATH",
+    "OPENWORK_EVAL_DESKTOP_CDP_URL",
   ],
   steps: [
     {
@@ -111,39 +126,42 @@ export default {
     {
       name: "First launch imports the adjacent bootstrap",
       run: async (ctx) => {
-        await ctx.prove("The standard desktop imported the bootstrap before showing sign-in", {
-          voiceover: vo[3],
-          action: async () => {
-            await navigate(ctx, APP_URL);
-            await ctx.waitForText("Welcome to Acme Work", { timeoutMs: 45_000 });
-          },
-          assert: async () => {
-            const bundled = readJson(path.join(BUNDLE_DIR, "desktop-bootstrap.json"));
-            const canonical = readJson(BOOTSTRAP_PATH);
-            witness(ctx, JSON.stringify(canonical) === JSON.stringify(bundled), "The adjacent bundle bootstrap was copied byte-for-value to the canonical desktop config", { bundled, canonical });
-            await ctx.expectText("Sign in to Acme Work");
-            await ctx.expectText(new URL(bundled.baseUrl).host);
-            ctx.output("canonical-desktop-bootstrap.json", JSON.stringify(canonical, null, 2));
-          },
-          screenshot: { name: "standard-desktop-imported-bootstrap", requireText: ["Welcome to Acme Work", "Sign in to Acme Work"] },
+        await withClient(ctx, DESKTOP_CDP_URL, async () => {
+          await ctx.prove("The standard desktop imported the bootstrap before showing sign-in", {
+            voiceover: vo[3],
+            action: async () => {
+              await ctx.waitForText("Welcome to Acme Work", { timeoutMs: 45_000 });
+            },
+            assert: async () => {
+              const bundled = readJson(path.join(BUNDLE_DIR, "desktop-bootstrap.json"));
+              const canonical = readJson(BOOTSTRAP_PATH);
+              witness(ctx, JSON.stringify(canonical) === JSON.stringify(bundled), "The adjacent bundle bootstrap was copied byte-for-value to the canonical desktop config", { bundled, canonical });
+              await ctx.expectText("Sign in to Acme Work");
+              await ctx.expectText(new URL(bundled.baseUrl).host);
+              ctx.output("canonical-desktop-bootstrap.json", JSON.stringify(canonical, null, 2));
+            },
+            screenshot: { name: "standard-desktop-imported-bootstrap", requireText: ["Welcome to Acme Work", "Sign in to Acme Work"] },
+          });
         });
       },
     },
     {
       name: "Configured name and wordmark appear without changing sign-in",
       run: async (ctx) => {
-        await ctx.prove("The first-run screen uses Acme's name and loaded wordmark while preserving normal sign-in", {
-          voiceover: vo[4],
-          assert: async () => {
-            const logo = await ctx.eval(`(() => {
-              const image = [...document.images].find((entry) => entry.alt === "Acme Work logo");
-              return image ? { src: image.src, complete: image.complete, naturalWidth: image.naturalWidth } : null;
-            })()`);
-            witness(ctx, logo?.complete === true && logo.naturalWidth > 0, "The configured Acme wordmark loaded successfully", logo);
-            await ctx.expectText("Sign in to Acme Work");
-            await ctx.expectText("Paste sign-in code");
-          },
-          screenshot: { name: "acme-branding-normal-signin", requireText: ["Welcome to Acme Work", "Paste sign-in code"] },
+        await withClient(ctx, DESKTOP_CDP_URL, async () => {
+          await ctx.prove("The first-run screen uses Acme's name and loaded wordmark while preserving normal sign-in", {
+            voiceover: vo[4],
+            assert: async () => {
+              const logo = await ctx.eval(`(() => {
+                const image = [...document.images].find((entry) => entry.alt === "Acme Work logo");
+                return image ? { src: image.src, complete: image.complete, naturalWidth: image.naturalWidth } : null;
+              })()`);
+              witness(ctx, logo?.complete === true && logo.naturalWidth > 0, "The configured Acme wordmark loaded successfully", logo);
+              await ctx.expectText("Sign in to Acme Work");
+              await ctx.expectText("Paste sign-in code");
+            },
+            screenshot: { name: "acme-branding-normal-signin", requireText: ["Welcome to Acme Work", "Paste sign-in code"] },
+          });
         });
       },
     },

--- a/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
+++ b/evals/flows/standard-dmg-bootstrap-zip.flow.mjs
@@ -135,6 +135,7 @@ export default {
           await ctx.prove("The standard desktop imported the bootstrap before showing sign-in", {
             voiceover: vo[3],
             action: async () => {
+              await ctx.client.send("Page.reload", { ignoreCache: true });
               await ctx.waitForText("Welcome to Acme Work", { timeoutMs: 45_000 });
             },
             assert: async () => {

--- a/evals/voiceovers/standard-dmg-bootstrap-zip.md
+++ b/evals/voiceovers/standard-dmg-bootstrap-zip.md
@@ -1,0 +1,13 @@
+# standard-dmg-bootstrap-zip — Organization downloads reuse the standard signed Mac installer
+
+1. An organization administrator enables organization downloads. Hosted organizations opt in, while self-hosted OpenWork enables this automatically.
+
+2. A signed-in organization member opens the dashboard and sees the download intended for their organization. Users outside an enabled organization continue to get the ordinary OpenWork download experience.
+
+3. The member downloads one ZIP containing only the standard signed OpenWork DMG and the organization's `desktop-bootstrap.json`. There is no separate OpenWork installer application to build or maintain.
+
+4. The member extracts the ZIP and opens the normal OpenWork DMG. OpenWork recognizes the bootstrap configuration packaged beside it and uses it during first launch.
+
+5. After the standard macOS installation, OpenWork starts connected to the correct organization deployment with its configured name, wordmark, and app icon. The member still signs in normally; this change does not introduce mandatory sign-in.
+
+6. If organization downloads are disabled, OpenWork never generates or exposes the organization ZIP. In self-hosted deployments, the same ZIP flow is available by default without an operator enabling a feature flag.

--- a/packages/install-config/src/index.ts
+++ b/packages/install-config/src/index.ts
@@ -1,6 +1,7 @@
 import { z } from "zod"
 
 export const INSTALL_SIDECAR_FILENAME = "openwork-installer.json"
+export const DESKTOP_BOOTSTRAP_FILENAME = "desktop-bootstrap.json"
 
 export const installConfigSchema = z.object({
   appName: z.string().trim().min(1).max(64).default("OpenWork"),
@@ -12,6 +13,17 @@ export const installConfigSchema = z.object({
 }).meta({ ref: "InstallConfig" })
 
 export type InstallConfig = z.infer<typeof installConfigSchema>
+
+export const desktopBootstrapConfigSchema = z.object({
+  baseUrl: z.string().trim().url(),
+  apiBaseUrl: z.string().trim().url().optional(),
+  requireSignin: z.boolean(),
+  brandAppName: z.string().trim().min(1).max(64).optional(),
+  brandLogoUrl: z.string().trim().url().optional(),
+  writtenAt: z.string().datetime(),
+}).meta({ ref: "DesktopBootstrapConfig" })
+
+export type DesktopBootstrapConfig = z.infer<typeof desktopBootstrapConfigSchema>
 
 const TOKEN_PATTERN = /^[A-Za-z0-9_-]{8,}$/
 const FILENAME_TAG_PATTERN = /^.+--([A-Za-z0-9.-]+(?:_[0-9]+)?)--([A-Za-z0-9_-]{8,})(?:\.exe)?$/

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -47,6 +47,8 @@ config:
     betterAuthTrustedOrigins: "https://openwork.example.com"
     webAppHosts: "openwork.example.com"
     bootstrapAdminEmails: "admin@example.com"
+    # Self-hosted default: every organization gets install downloads.
+    installLinksGatingEnabled: "false"
     authCallbackUrl: "https://openwork.example.com"
   githubConnector:
     appId: ""

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -28,6 +28,7 @@ data:
   DEN_BETTER_AUTH_TRUSTED_ORIGINS: {{ .Values.config.public.betterAuthTrustedOrigins | quote }}
   DEN_WEB_APP_HOSTS: {{ .Values.config.public.webAppHosts | quote }}
   DEN_BOOTSTRAP_ADMIN_EMAILS: {{ .Values.config.public.bootstrapAdminEmails | quote }}
+  DEN_INSTALL_LINKS_GATING_ENABLED: {{ .Values.config.public.installLinksGatingEnabled | quote }}
   CORS_ORIGINS: {{ .Values.config.public.corsOrigins | quote }}
   DEN_CORS_ORIGINS: {{ .Values.config.public.corsOrigins | quote }}
   DEN_API_PUBLIC_URL: {{ .Values.config.public.apiOrigin | quote }}

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -33,6 +33,7 @@ config:
     betterAuthTrustedOrigins: https://openwork.example.com
     webAppHosts: openwork.example.com
     bootstrapAdminEmails: ""
+    installLinksGatingEnabled: "false"
     openworkAppConnectUrl: ""
     installerReleaseTag: ""
     installerReleaseRepo: ""


### PR DESCRIPTION
## Summary

- replace organization-specific installer apps with a ZIP containing the unchanged standard DMG/EXE plus `desktop-bootstrap.json`
- import an adjacent bootstrap before the desktop runtime boots, with newest-config protection
- make install links active by default for self-hosted deployments while preserving hosted per-org gating
- stop stable releases from building the separate generic installer
- stream large ZIP responses in 1 MB chunks for on-prem memory safety
- document connected, mirrored, air-gapped, MDM, and first-launch operation

## Experience

Mac and Windows organization downloads now contain exactly two files: the normal signed OpenWork release artifact and the organization bootstrap. Extract them together, run the normal installer, and OpenWork imports the organization deployment, name, and logo on first launch. Sign-in behavior is unchanged.

If Den cannot obtain the standard artifact, it redirects to the verified ordinary installer without leaking the organization token.

## Validation

Authoritative validation was run in Daytona against the pushed branch. During PR publication, a shell-quoting mistake also invoked local checks; those results are discarded and are not counted here.

Daytona:

- `pnpm exec bun test ee/apps/den-api/test/install-links-rollout.test.ts ee/apps/den-api/test/installer-artifacts.test.ts ee/apps/den-api/test/zip-append.test.ts ee/apps/den-api/test/install-link-access.test.ts` — 29 passed
- final streaming-focused rerun of ZIP and route suites — 15 passed
- `node --test apps/desktop/electron/workspace-store.test.mjs` — 11 passed
- `pnpm --filter @openwork/install-config typecheck` — passed
- `pnpm --filter @openwork-ee/den-api build` — passed after the streaming change
- `pnpm --filter @openwork/desktop typecheck:electron` — passed
- `pnpm --filter @openwork/desktop check:electron` — passed
- `pnpm --filter @openwork-ee/den-web build` — passed

Real Daytona HTTP and filesystem proof:

- self-host org with raw `installLinks=null` minted successfully
- ZIP had exactly the versioned DMG and `desktop-bootstrap.json`
- branch DMG SHA-256 was identical before/after ZIP packaging: `884283a8b9b13946dc21e3fa56bc8148ea43e4e2f71ce24eb70fe20f6d520644`
- desktop imported the adjacent bootstrap before runtime and visibly rendered Acme Work plus the configured logo

fraimz: Passed, 6/6 frames:

- `evals/results/2026-07-10T20-33-58-059Z/fraimz.html`
- [sandbox fraimz artifact](https://8090-chornz0uqhrvj0ry.daytonaproxy01.net/fraimz-standard-dmg-bootstrap-zip/fraimz.html)

Signed/notarized exact-branch desktop build:

- [workflow run](https://github.com/different-ai/openwork/actions/runs/29120593526)
- [isolated prerelease](https://github.com/different-ai/openwork/releases/tag/alpha-macos-v0.17.21-alpha.1547-99732cc)
- rolling alpha pointer was intentionally not updated

## Release note

Den and desktop should ship together: older already-published desktop builds do not contain the adjacent-bootstrap importer. The next release built after merge contains both sides of the contract.
