### PR TITLE
Keep MCP write access opt-in

### DIFF
--- a/ee/apps/den-api/src/mcp/scopes.ts
+++ b/ee/apps/den-api/src/mcp/scopes.ts
@@ -18,7 +18,6 @@ export const DEN_MCP_DEFAULT_CLIENT_SCOPES = [
   "profile",
   "email",
   DEN_MCP_READ_SCOPE,
-  DEN_MCP_WRITE_SCOPE,
 ]
 
 export const DEN_MCP_DEFAULT_TOKEN_SCOPES: readonly DenMcpTokenScope[] = [DEN_MCP_READ_SCOPE]

--- a/ee/apps/den-api/test/mcp-scopes.test.ts
+++ b/ee/apps/den-api/test/mcp-scopes.test.ts
@@ -7,8 +7,8 @@ import {
   resolveMcpTokenScopes,
 } from "../src/mcp/scopes.js"
 
-test("MCP OAuth client defaults include read and write access", () => {
-  expect(DEN_MCP_DEFAULT_CLIENT_SCOPES).toEqual(["openid", "profile", "email", "mcp:read", "mcp:write"])
+test("MCP OAuth client defaults remain read-only", () => {
+  expect(DEN_MCP_DEFAULT_CLIENT_SCOPES).toEqual(["openid", "profile", "email", "mcp:read"])
 })
 
 test("first-party MCP token mint defaults to read-only", () => {
@@ -28,14 +28,14 @@ test("OAuth client registration scope normalization does not upgrade MCP scopes"
   expect(normalizeMcpOAuthClientScope(undefined)).toBeNull()
 })
 
-test("a legacy MCP client can opt in to requested write access", () => {
+test("a read-only MCP client can opt in to requested write access", () => {
   expect(addRequestedMcpClientScopes(
     ["openid", "mcp:read"],
     ["openid", "mcp:read", "mcp:write"],
   )).toEqual(["openid", "mcp:read", "mcp:write"])
 })
 
-test("a legacy MCP client is not implicitly upgraded to write access", () => {
+test("write access is not added when authorization requests only offline access", () => {
   expect(addRequestedMcpClientScopes(
     ["openid", "mcp:read"],
     ["openid", "mcp:read", "offline_access"],

--- a/evals/flows/mcp-write-scope.flow.mjs
+++ b/evals/flows/mcp-write-scope.flow.mjs
@@ -41,7 +41,7 @@ export default {
       name: "OpenWork Cloud MCP receives requested write access",
       run: async (ctx) => {
         let result;
-        await ctx.prove("New MCP connections include write access and legacy connections can explicitly opt in", {
+        await ctx.prove("MCP connections remain read-only until authorization explicitly requests write access", {
           voiceover: vo[0],
           action: async () => {
             result = runTest("test/mcp-scopes.test.ts");
@@ -49,9 +49,9 @@ export default {
           assert: async () => {
             const output = commandOutput(result);
             witness(ctx, result.status === 0, "The MCP scope policy tests pass", output);
-            witness(ctx, output.includes("MCP OAuth client defaults include read and write access"), "New MCP OAuth clients receive mcp:write by default");
-            witness(ctx, output.includes("a legacy MCP client can opt in to requested write access"), "A legacy MCP client accepts an explicitly requested mcp:write scope");
-            witness(ctx, output.includes("a legacy MCP client is not implicitly upgraded to write access"), "A legacy MCP client stays read-only when authorization does not request mcp:write");
+            witness(ctx, output.includes("MCP OAuth client defaults remain read-only"), "New MCP OAuth clients remain read-only by default");
+            witness(ctx, output.includes("a read-only MCP client can opt in to requested write access"), "A read-only MCP client accepts an explicitly requested mcp:write scope");
+            witness(ctx, output.includes("write access is not added when authorization requests only offline access"), "An MCP client does not gain mcp:write when authorization does not request it");
             ctx.output("$ bun --conditions=development test test/mcp-scopes.test.ts", output);
           },
         });


### PR DESCRIPTION
## What changed

- restore read-only defaults for newly dynamically registered MCP clients
- preserve PR #2657's authorize-time upgrade so an MCP client gains `mcp:write` only when the OAuth request explicitly includes it
- keep `offline_access` independently opt-in
- update scope-policy assertions and fraimz claims

## Why

PR #2657 fixed OpenWork Cloud write operations but also made `mcp:write` part of every new MCP client's default allowed scopes. This follow-up restores least privilege without removing the explicit write authorization path.

## Impact

New clients remain read-only unless they ask for write access during OAuth authorization. Existing RBAC, membership, active-session, route exposure, and entitlement checks remain unchanged.

No Settings UI toggle is required: the OAuth client requests scopes in the authorization URL. The current organization-selection consent surface does not clearly explain read versus write access; that disclosure is intentionally not bundled into this corrective backend PR.

## Validation

- `pnpm --filter @openwork-ee/den-api exec bun --conditions=development test test/mcp-scopes.test.ts test/mcp-invoke-body.test.ts` — 16 passed, 0 failed
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit -p tsconfig.json` — passed
- `pnpm fraimz --flow mcp-write-scope` — Passed
- `git diff origin/dev...HEAD --check` — passed

Fraimz artifact: `evals/results/2026-07-10T21-42-30-920Z/fraimz.html`