### PR TITLE
fix: improve organization installer download feedback

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -175,7 +175,7 @@ export function InstallScreen() {
     downloadStartedTimer.current = window.setTimeout(() => {
       setDownloadState("started");
       downloadStartedTimer.current = null;
-    }, 1500);
+    }, 5000);
   }
 
   if (busy) {

--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getErrorMessage, requestJson } from "../_lib/den-flow";
 import { buildInstallDownloadHref, type InstallPlatform } from "../_lib/install-download";
@@ -94,6 +94,10 @@ export function InstallScreen() {
   const [isMobile, setIsMobile] = useState<boolean | null>(null);
   const [platform, setPlatform] = useState<InstallPlatform>("mac-arm64");
   const [copied, setCopied] = useState(false);
+  const [downloadState, setDownloadState] = useState<"idle" | "preparing" | "started">("idle");
+  const [downloadLabel, setDownloadLabel] = useState("");
+  const [downloadHref, setDownloadHref] = useState("");
+  const downloadStartedTimer = useRef<number | null>(null);
 
   useEffect(() => {
     setIsMobile(isMobileUserAgent());
@@ -147,6 +151,12 @@ export function InstallScreen() {
     };
   }, [token]);
 
+  useEffect(() => () => {
+    if (downloadStartedTimer.current !== null) {
+      window.clearTimeout(downloadStartedTimer.current);
+    }
+  }, []);
+
   const secondaryPlatforms = useMemo(() => platformOptions.filter((option) => option.value !== platform), [platform]);
 
   async function copyCurrentLink() {
@@ -155,10 +165,23 @@ export function InstallScreen() {
     window.setTimeout(() => setCopied(false), 1800);
   }
 
+  function beginDownload(label: string, href: string) {
+    setDownloadLabel(label);
+    setDownloadHref(href);
+    setDownloadState("preparing");
+    if (downloadStartedTimer.current !== null) {
+      window.clearTimeout(downloadStartedTimer.current);
+    }
+    downloadStartedTimer.current = window.setTimeout(() => {
+      setDownloadState("started");
+      downloadStartedTimer.current = null;
+    }, 1500);
+  }
+
   if (busy) {
     return (
-      <section className="den-page py-4 lg:py-6" data-testid="install-page">
-        <div className="den-frame grid max-w-[44rem] gap-4 p-6 md:p-8">
+      <section className="den-page grid min-h-dvh place-items-center py-4 lg:py-6" data-testid="install-page">
+        <div className="den-frame grid w-full max-w-[44rem] gap-4 p-6 md:p-8">
           <p className="den-eyebrow">OpenWork Desktop</p>
           <h1 className="den-title-lg">Loading your install link.</h1>
           <p className="den-copy">Checking your team's OpenWork setup...</p>
@@ -169,8 +192,8 @@ export function InstallScreen() {
 
   if (!config) {
     return (
-      <section className="den-page py-4 lg:py-6" data-testid="install-page">
-        <div className="den-frame grid max-w-[44rem] gap-6 p-6 md:p-8">
+      <section className="den-page grid min-h-dvh place-items-center py-4 lg:py-6" data-testid="install-page">
+        <div className="den-frame grid w-full max-w-[44rem] gap-6 p-6 md:p-8">
           <div className="grid gap-2">
             <p className="den-eyebrow">OpenWork Desktop</p>
             <h1 className="den-title-lg">This install link can't be opened.</h1>
@@ -185,15 +208,15 @@ export function InstallScreen() {
   const primaryLabel = platformOptions.find((option) => option.value === platform)?.label ?? "your computer";
 
   return (
-    <section className="den-page py-4 lg:py-6" data-testid="install-page">
-      <div className="den-frame grid max-w-[48rem] gap-6 p-6 md:p-8">
-        <div className="grid gap-3">
+    <section className="den-page grid min-h-dvh place-items-center py-4 lg:py-6" data-testid="install-page">
+      <div className="den-frame grid w-full max-w-[44rem] gap-6 p-6 text-center md:p-8" data-testid="install-card">
+        <div className="grid justify-items-center gap-3">
           <p className="den-eyebrow">{config.appName} Desktop</p>
           {config.logoUrl ? (
             // Organization logos may be served by private on-prem hosts that
             // are intentionally absent from this deployment's image allowlist.
             // eslint-disable-next-line @next/next/no-img-element
-            <img src={config.logoUrl} alt={`${config.clientName} wordmark`} className="max-h-16 max-w-64 object-contain object-left" />
+            <img src={config.logoUrl} alt={`${config.clientName} wordmark`} className="max-h-16 max-w-64 object-contain object-center" />
           ) : null}
           <h1 className="den-title-xl">Download {config.appName} for {config.clientName}</h1>
           <p className="den-copy">Mac and Windows downloads include the standard OpenWork installer and your team's setup file in one ZIP. Keep them together, run the installer, then sign in.</p>
@@ -208,24 +231,38 @@ export function InstallScreen() {
             </button>
           </div>
         ) : (
-          <div className="grid gap-4">
-            <a className="den-button-primary w-full justify-center sm:w-auto" href={primaryHref} data-testid="install-download-primary">
+          <div className="grid justify-items-center gap-4">
+            <a className="den-button-primary w-full justify-center sm:w-auto" href={primaryHref} data-testid="install-download-primary" onClick={() => beginDownload(primaryLabel, primaryHref)}>
               Download for {primaryLabel}
             </a>
-            <div className="flex flex-wrap gap-2">
+            <div className="flex flex-wrap justify-center gap-2">
               {secondaryPlatforms.map((option) => (
-                <a key={option.value} className="den-button-secondary" href={installHref(config, option.value, token)}>
+                <a key={option.value} className="den-button-secondary" href={installHref(config, option.value, token)} onClick={() => beginDownload(option.label, installHref(config, option.value, token))}>
                   {option.label}
                 </a>
               ))}
             </div>
+            {downloadState !== "idle" ? (
+              <div className="den-frame-inset grid w-full justify-items-center gap-2 rounded-[1.25rem] p-4" aria-live="polite" data-testid="install-download-status">
+                {downloadState === "preparing" ? (
+                  <>
+                    <span className="size-5 animate-spin rounded-full border-2 border-[var(--dls-border-strong)] border-t-[var(--dls-accent)]" aria-hidden="true" />
+                    <p className="m-0 font-medium text-[var(--dls-text-primary)]">Preparing your {downloadLabel} download...</p>
+                    <p className="den-copy">The first download may take up to a minute. Your browser will begin downloading when it is ready.</p>
+                  </>
+                ) : (
+                  <>
+                    <p className="m-0 font-medium text-[var(--dls-text-primary)]">Download started</p>
+                    <p className="den-copy">Your browser is preparing the file. If it does not appear, try the download again.</p>
+                    <a className="den-button-secondary" href={downloadHref} onClick={() => beginDownload(downloadLabel, downloadHref)}>
+                      Try again
+                    </a>
+                  </>
+                )}
+              </div>
+            ) : null}
           </div>
         )}
-
-        <div className="den-meta-row">
-          <span className="den-kicker">Team · {config.clientName}</span>
-          <span>{config.webUrl}</span>
-        </div>
       </div>
     </section>
   );

--- a/evals/flows/install-download-feedback.flow.mjs
+++ b/evals/flows/install-download-feedback.flow.mjs
@@ -18,10 +18,6 @@ async function openInstallPage(ctx) {
     method: "PATCH",
     body: JSON.stringify({ name: ORG_NAME }),
   });
-  await denFetch(ctx, `/v1/admin/organizations/${orgId}/capabilities`, {
-    method: "PUT",
-    body: JSON.stringify({ capabilities: { installLinks: true } }),
-  });
   const minted = await denFetch(ctx, `/v1/orgs/${orgId}/install-links`, {
     method: "POST",
     body: JSON.stringify({ rotate: false }),

--- a/evals/flows/install-download-feedback.flow.mjs
+++ b/evals/flows/install-download-feedback.flow.mjs
@@ -35,7 +35,6 @@ export default {
     {
       name: "setup",
       run: async (ctx) => {
-        await ctx.ensureLightMode();
         await openInstallPage(ctx);
       },
     },

--- a/evals/flows/install-download-feedback.flow.mjs
+++ b/evals/flows/install-download-feedback.flow.mjs
@@ -1,0 +1,131 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import {
+  assertSignedIntoDen,
+  denFetch,
+  ensureRendererMounted,
+  ensureWorkspaceReady,
+  memberRefresh,
+  panelEval,
+  waitForPanel,
+} from "./desktop-brand-icon.flow.mjs";
+
+const vo = await loadVoiceoverParagraphs("install-download-feedback");
+const ORG_NAME = "Different AI";
+const state = { installPageUrl: null };
+
+async function openInstallPage(ctx) {
+  const org = await denFetch(ctx, "/v1/org");
+  const orgId = org.body?.organization?.id;
+  ctx.assert(typeof orgId === "string", `Organization response was missing id: ${JSON.stringify(org.body).slice(0, 500)}`);
+  await denFetch(ctx, "/v1/org", {
+    method: "PATCH",
+    body: JSON.stringify({ name: ORG_NAME }),
+  });
+  await denFetch(ctx, `/v1/admin/organizations/${orgId}/capabilities`, {
+    method: "PUT",
+    body: JSON.stringify({ capabilities: { installLinks: true } }),
+  });
+  const minted = await denFetch(ctx, `/v1/orgs/${orgId}/install-links`, {
+    method: "POST",
+    body: JSON.stringify({ rotate: false }),
+  });
+  state.installPageUrl = minted.body?.installPageUrl ?? null;
+  ctx.assert(typeof state.installPageUrl === "string", "Install-link response was missing installPageUrl.");
+  await panelEval(ctx, `location.replace(${JSON.stringify(state.installPageUrl)})`).catch(() => undefined);
+  await waitForPanel(ctx, `document.body.innerText.includes('Download OpenWork for ${ORG_NAME}')`, {
+    timeoutMs: 45_000,
+    label: "organization install page",
+  });
+}
+
+export default {
+  id: "install-download-feedback",
+  title: "Installer downloads stay clear while the bundle is prepared",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "setup",
+      run: async (ctx) => {
+        await ensureRendererMounted(ctx);
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "desktop control surface" });
+        await ctx.ensureLightMode();
+        await assertSignedIntoDen(ctx);
+        await ensureWorkspaceReady(ctx);
+        await memberRefresh(ctx);
+        await openInstallPage(ctx);
+      },
+    },
+    {
+      name: "Centered install card",
+      run: async (ctx) => {
+        await ctx.prove("The organization install page presents a centered, focused download card", {
+          voiceover: vo[0],
+          action: async () => {},
+          assert: async () => {
+            const geometry = await panelEval(ctx, `(() => {
+              const card = document.querySelector('[data-testid="install-card"]')?.getBoundingClientRect();
+              if (!card) return null;
+              return { cardCenter: card.left + card.width / 2, viewportCenter: innerWidth / 2 };
+            })()`);
+            ctx.assert(geometry && Math.abs(geometry.cardCenter - geometry.viewportCenter) < 4, `Install card was not centered: ${JSON.stringify(geometry)}`);
+          },
+          screenshot: { name: "frame-1-centered-install-card", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: [`Download OpenWork for ${ORG_NAME}`] },
+        });
+      },
+    },
+    {
+      name: "Focused installer choices",
+      run: async (ctx) => {
+        await ctx.prove("Redundant team and server metadata are absent from the install page", {
+          voiceover: vo[1],
+          action: async () => {},
+          assert: async () => {
+            const text = await panelEval(ctx, "document.body.innerText");
+            ctx.assert(!text.includes(`Team · ${ORG_NAME}`), "The redundant team footer is still visible.");
+            const metaRows = await panelEval(ctx, "document.querySelectorAll('.den-meta-row').length");
+            ctx.assert(metaRows === 0, `Found ${metaRows} metadata rows.`);
+          },
+          screenshot: { name: "frame-2-focused-installer-choices", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: ["Mac (Apple silicon)", "Windows"], rejectText: [`Team · ${ORG_NAME}`] },
+        });
+      },
+    },
+    {
+      name: "Preparing feedback",
+      run: async (ctx) => {
+        await ctx.prove("Choosing a platform immediately explains that the download is being prepared", {
+          voiceover: vo[2],
+          action: async () => {
+            await panelEval(ctx, `(() => {
+              const cancelDownload = (event) => event.preventDefault();
+              document.addEventListener('click', cancelDownload, { capture: true, once: true });
+              document.querySelector('[data-testid="install-download-primary"]')?.click();
+            })()`);
+            await waitForPanel(ctx, "document.body.innerText.includes('Preparing your')", { timeoutMs: 1_000, label: "preparing download feedback" });
+          },
+          assert: async () => {
+            const text = await panelEval(ctx, "document.querySelector('[data-testid=install-download-status]')?.textContent ?? ''");
+            ctx.assert(text.includes("The first download may take up to a minute"), `Preparation guidance was missing: ${text}`);
+          },
+          screenshot: { name: "frame-3-preparing-download", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: ["Preparing your", "The first download may take up to a minute"] },
+        });
+      },
+    },
+    {
+      name: "Download started feedback",
+      run: async (ctx) => {
+        await ctx.prove("The page confirms the browser download request and offers a retry", {
+          voiceover: vo[3],
+          action: async () => {
+            await waitForPanel(ctx, "document.body.innerText.includes('Download started')", { timeoutMs: 5_000, label: "download started feedback" });
+          },
+          assert: async () => {
+            const text = await panelEval(ctx, "document.querySelector('[data-testid=install-download-status]')?.textContent ?? ''");
+            ctx.assert(text.includes("Try again"), `Retry action was missing: ${text}`);
+          },
+          screenshot: { name: "frame-4-download-started", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: ["Download started", "Try again"] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/install-download-feedback.flow.mjs
+++ b/evals/flows/install-download-feedback.flow.mjs
@@ -1,10 +1,7 @@
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 import {
-  assertSignedIntoDen,
   denFetch,
   ensureRendererMounted,
-  ensureWorkspaceReady,
-  memberRefresh,
   panelEval,
   waitForPanel,
 } from "./desktop-brand-icon.flow.mjs";
@@ -50,9 +47,6 @@ export default {
         await ensureRendererMounted(ctx);
         await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "desktop control surface" });
         await ctx.ensureLightMode();
-        await assertSignedIntoDen(ctx);
-        await ensureWorkspaceReady(ctx);
-        await memberRefresh(ctx);
         await openInstallPage(ctx);
       },
     },

--- a/evals/flows/install-download-feedback.flow.mjs
+++ b/evals/flows/install-download-feedback.flow.mjs
@@ -1,10 +1,5 @@
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
-import {
-  denFetch,
-  ensureRendererMounted,
-  panelEval,
-  waitForPanel,
-} from "./desktop-brand-icon.flow.mjs";
+import { denFetch } from "./desktop-brand-icon.flow.mjs";
 
 const vo = await loadVoiceoverParagraphs("install-download-feedback");
 const ORG_NAME = "Different AI";
@@ -24,8 +19,8 @@ async function openInstallPage(ctx) {
   });
   state.installPageUrl = minted.body?.installPageUrl ?? null;
   ctx.assert(typeof state.installPageUrl === "string", "Install-link response was missing installPageUrl.");
-  await panelEval(ctx, `location.replace(${JSON.stringify(state.installPageUrl)})`).catch(() => undefined);
-  await waitForPanel(ctx, `document.body.innerText.includes('Download OpenWork for ${ORG_NAME}')`, {
+  await ctx.eval(`location.replace(${JSON.stringify(state.installPageUrl)})`).catch(() => undefined);
+  await ctx.waitFor(`document.body.innerText.includes('Download OpenWork for ${ORG_NAME}')`, {
     timeoutMs: 45_000,
     label: "organization install page",
   });
@@ -40,8 +35,6 @@ export default {
     {
       name: "setup",
       run: async (ctx) => {
-        await ensureRendererMounted(ctx);
-        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "desktop control surface" });
         await ctx.ensureLightMode();
         await openInstallPage(ctx);
       },
@@ -53,7 +46,7 @@ export default {
           voiceover: vo[0],
           action: async () => {},
           assert: async () => {
-            const geometry = await panelEval(ctx, `(() => {
+            const geometry = await ctx.eval(`(() => {
               const card = document.querySelector('[data-testid="install-card"]')?.getBoundingClientRect();
               if (!card) return null;
               return { cardCenter: card.left + card.width / 2, viewportCenter: innerWidth / 2 };
@@ -71,9 +64,9 @@ export default {
           voiceover: vo[1],
           action: async () => {},
           assert: async () => {
-            const text = await panelEval(ctx, "document.body.innerText");
+            const text = await ctx.eval("document.body.innerText");
             ctx.assert(!text.includes(`Team · ${ORG_NAME}`), "The redundant team footer is still visible.");
-            const metaRows = await panelEval(ctx, "document.querySelectorAll('.den-meta-row').length");
+            const metaRows = await ctx.eval("document.querySelectorAll('.den-meta-row').length");
             ctx.assert(metaRows === 0, `Found ${metaRows} metadata rows.`);
           },
           screenshot: { name: "frame-2-focused-installer-choices", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: ["Mac (Apple silicon)", "Windows"], rejectText: [`Team · ${ORG_NAME}`] },
@@ -86,15 +79,15 @@ export default {
         await ctx.prove("Choosing a platform immediately explains that the download is being prepared", {
           voiceover: vo[2],
           action: async () => {
-            await panelEval(ctx, `(() => {
+            await ctx.eval(`(() => {
               const cancelDownload = (event) => event.preventDefault();
               document.addEventListener('click', cancelDownload, { capture: true, once: true });
               document.querySelector('[data-testid="install-download-primary"]')?.click();
             })()`);
-            await waitForPanel(ctx, "document.body.innerText.includes('Preparing your')", { timeoutMs: 1_000, label: "preparing download feedback" });
+            await ctx.waitFor("document.body.innerText.includes('Preparing your')", { timeoutMs: 1_000, label: "preparing download feedback" });
           },
           assert: async () => {
-            const text = await panelEval(ctx, "document.querySelector('[data-testid=install-download-status]')?.textContent ?? ''");
+            const text = await ctx.eval("document.querySelector('[data-testid=install-download-status]')?.textContent ?? ''");
             ctx.assert(text.includes("The first download may take up to a minute"), `Preparation guidance was missing: ${text}`);
           },
           screenshot: { name: "frame-3-preparing-download", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: ["Preparing your", "The first download may take up to a minute"] },
@@ -107,10 +100,10 @@ export default {
         await ctx.prove("The page confirms the browser download request and offers a retry", {
           voiceover: vo[3],
           action: async () => {
-            await waitForPanel(ctx, "document.body.innerText.includes('Download started')", { timeoutMs: 5_000, label: "download started feedback" });
+            await ctx.waitFor("document.body.innerText.includes('Download started')", { timeoutMs: 5_000, label: "download started feedback" });
           },
           assert: async () => {
-            const text = await panelEval(ctx, "document.querySelector('[data-testid=install-download-status]')?.textContent ?? ''");
+            const text = await ctx.eval("document.querySelector('[data-testid=install-download-status]')?.textContent ?? ''");
             ctx.assert(text.includes("Try again"), `Retry action was missing: ${text}`);
           },
           screenshot: { name: "frame-4-download-started", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: ["Download started", "Try again"] },

--- a/evals/flows/install-download-feedback.flow.mjs
+++ b/evals/flows/install-download-feedback.flow.mjs
@@ -61,7 +61,9 @@ export default {
       run: async (ctx) => {
         await ctx.prove("Redundant team and server metadata are absent from the install page", {
           voiceover: vo[1],
-          action: async () => {},
+          action: async () => {
+            await ctx.eval(`Array.from(document.querySelectorAll('a')).find((link) => link.textContent?.trim() === 'Windows')?.focus()`);
+          },
           assert: async () => {
             const text = await ctx.eval("document.body.innerText");
             ctx.assert(!text.includes(`Team · ${ORG_NAME}`), "The redundant team footer is still visible.");

--- a/evals/flows/organization-display-branding.flow.mjs
+++ b/evals/flows/organization-display-branding.flow.mjs
@@ -255,7 +255,7 @@ export default {
             const logoLoaded = await panelEval(ctx, `(() => { const image = document.querySelector('img[alt="${ORG_NAME} wordmark"]'); return Boolean(image?.complete && image?.naturalWidth > 0); })()`);
             ctx.assert(logoLoaded, "Example Corp wordmark did not load on the install page.");
           },
-          screenshot: { name: "frame-2-acme-work-install-page", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: [`Download ${APP_NAME} for ${ORG_NAME}`, `Team · ${ORG_NAME}`] },
+          screenshot: { name: "frame-2-acme-work-install-page", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: [`Download ${APP_NAME} for ${ORG_NAME}`], rejectText: [`Team · ${ORG_NAME}`] },
         });
       },
     },

--- a/evals/voiceovers/install-download-feedback.md
+++ b/evals/voiceovers/install-download-feedback.md
@@ -1,0 +1,9 @@
+# install-download-feedback — Installer downloads stay clear while the bundle is prepared
+
+1.  The organization install link opens as a centered, focused card with the organization branding and “Download OpenWork for Different AI.”
+
+2.  The redundant team and server details are gone, so the page stays focused on choosing the right installer.
+
+3.  When I choose my platform, the page immediately says it is preparing that download and explains that the first download can take up to a minute.
+
+4.  When the bundle is ready, the browser download starts and the page confirms it, with a clear way to retry if the download does not appear.


### PR DESCRIPTION
## Summary

- center the organization installer experience in a focused card
- remove the redundant `Team · <organization>` and server URL footer
- show immediate, accessible preparation feedback when a platform download is requested
- confirm the request and provide a retry action while preserving direct streamed downloads

## Why

The organization ZIP can take time to prepare on its first request. Previously the browser appeared idle during that wait, and the install page repeated organization/server metadata that did not help users choose an installer.

This stays friendly to on-prem deployments: it adds no service, shared cache, or durable job infrastructure, and keeps the existing direct download endpoint and fallback behavior.

## Evaluation

- Daytona `@openwork-ee/den-web` production build and TypeScript: passed
- Daytona Fraimz `install-download-feedback`: 4/4 frames passed plus voiceover coverage
  - centered card measured against the browser viewport
  - redundant footer rejected
  - preparation guidance asserted immediately after the click
  - started/retry state asserted

Fraimz run: `2026-07-10T22-21-00-931Z`
