### PR TITLE
Preserve on-prem server URL across desktop upgrades

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2176,7 +2176,7 @@ if (!app.requestSingleInstanceLock()) {
   app.whenReady().then(async () => {
     installMediaPermissionHandlers(session, () => mainWindow);
     applicationMenu.install();
-    await workspaceStore.importBundledDesktopBootstrapConfigIfNewer();
+    await workspaceStore.importBundledDesktopBootstrapConfigIfMissing();
     await runtimeManager.prepareFreshRuntime().catch(() => undefined);
 
     // Use Tauri's existing workspace state file as canonical so rollback and

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2176,7 +2176,7 @@ if (!app.requestSingleInstanceLock()) {
   app.whenReady().then(async () => {
     installMediaPermissionHandlers(session, () => mainWindow);
     applicationMenu.install();
-    await workspaceStore.importBundledDesktopBootstrapConfigIfMissing();
+    await workspaceStore.importBundledDesktopBootstrapConfigIfPreferred();
     await runtimeManager.prepareFreshRuntime().catch(() => undefined);
 
     // Use Tauri's existing workspace state file as canonical so rollback and

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -363,16 +363,12 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     return Array.from(new Set(candidates));
   }
 
-  async function importBundledDesktopBootstrapConfigIfNewer() {
+  async function importBundledDesktopBootstrapConfigIfMissing() {
     const configPath = desktopBootstrapPath();
     const primary = await readDesktopBootstrapCandidate(configPath);
     const legacyPath = legacyDesktopBootstrapPath();
     const legacy = legacyPath ? await readDesktopBootstrapCandidate(legacyPath) : null;
-    const currentCandidates = [primary, legacy].filter((candidate) => candidate?.ok);
-    const currentTimeMs = currentCandidates.reduce(
-      (latest, candidate) => Math.max(latest, desktopBootstrapCandidateTimeMs(candidate)),
-      Number.NEGATIVE_INFINITY,
-    );
+    if (primary.ok || legacy?.ok) return false;
 
     const bundledCandidates = [];
     for (const candidatePath of await bundledDesktopBootstrapPaths()) {
@@ -382,7 +378,7 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     }
     bundledCandidates.sort((left, right) => desktopBootstrapCandidateTimeMs(right) - desktopBootstrapCandidateTimeMs(left));
     const newest = bundledCandidates[0];
-    if (!newest || desktopBootstrapCandidateTimeMs(newest) <= currentTimeMs) return false;
+    if (!newest) return false;
 
     try {
       await writeJsonFileAtomic(configPath, newest.normalized);
@@ -1213,7 +1209,7 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     forgetWorkspace,
     getDesktopBootstrapConfig,
     importConfig,
-    importBundledDesktopBootstrapConfigIfNewer,
+    importBundledDesktopBootstrapConfigIfMissing,
     listLocalWorkspacePaths,
     migrateLegacyElectronWorkspaceStateIfNeeded,
     readWorkspaceOpenworkConfig,

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -122,6 +122,22 @@ const DEFAULT_DESKTOP_BOOTSTRAP_PATH = (() => {
 const LEGACY_DESKTOP_BOOTSTRAP_PATH = path.join(os.homedir(), ".config", "openwork", "desktop-bootstrap.json");
 const DESKTOP_BOOTSTRAP_FILENAME = "desktop-bootstrap.json";
 const STANDARD_DESKTOP_INSTALLER_PATTERN = /^openwork-(?:mac-(?:arm64|x64)-.+\.dmg|win-x64-.+\.exe)$/i;
+const HOSTED_DESKTOP_WEB_URL = "https://app.openworklabs.com";
+const HOSTED_DESKTOP_API_URL = "https://api.openworklabs.com";
+
+function bootstrapUrlOrigin(value) {
+  if (typeof value !== "string" || !value.trim()) return "";
+  try {
+    return new URL(value.trim()).origin;
+  } catch {
+    return value.trim().replace(/\/+$/, "");
+  }
+}
+
+function isHostedDesktopBootstrapConfig(config) {
+  const baseUrlOrigin = bootstrapUrlOrigin(config?.baseUrl);
+  return baseUrlOrigin === HOSTED_DESKTOP_WEB_URL || baseUrlOrigin === HOSTED_DESKTOP_API_URL;
+}
 
 export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSignin, forceRequireSignin }) {
   function desktopBootstrapPath() {
@@ -270,6 +286,11 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     return Number.isFinite(writtenAtMs) ? writtenAtMs : candidate.mtimeMs;
   }
 
+  function compareDesktopBootstrapCandidates(left, right) {
+    const classDifference = Number(!isHostedDesktopBootstrapConfig(left.normalized)) - Number(!isHostedDesktopBootstrapConfig(right.normalized));
+    return classDifference || desktopBootstrapCandidateTimeMs(left) - desktopBootstrapCandidateTimeMs(right);
+  }
+
   async function readDesktopBootstrapCandidate(candidatePath) {
     let exists = false;
     let mtimeMs = 0;
@@ -363,12 +384,15 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     return Array.from(new Set(candidates));
   }
 
-  async function importBundledDesktopBootstrapConfigIfMissing() {
+  async function importBundledDesktopBootstrapConfigIfPreferred() {
     const configPath = desktopBootstrapPath();
     const primary = await readDesktopBootstrapCandidate(configPath);
     const legacyPath = legacyDesktopBootstrapPath();
     const legacy = legacyPath ? await readDesktopBootstrapCandidate(legacyPath) : null;
-    if (primary.ok || legacy?.ok) return false;
+    const installedCandidates = [primary, legacy].filter((candidate) => candidate?.ok);
+    installedCandidates.sort((left, right) => compareDesktopBootstrapCandidates(right, left));
+    const installed = installedCandidates[0];
+    if (installed && !isHostedDesktopBootstrapConfig(installed.normalized)) return false;
 
     const bundledCandidates = [];
     for (const candidatePath of await bundledDesktopBootstrapPaths()) {
@@ -376,9 +400,9 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
       const candidate = await readDesktopBootstrapCandidate(candidatePath);
       if (candidate.ok) bundledCandidates.push(candidate);
     }
-    bundledCandidates.sort((left, right) => desktopBootstrapCandidateTimeMs(right) - desktopBootstrapCandidateTimeMs(left));
+    bundledCandidates.sort((left, right) => compareDesktopBootstrapCandidates(right, left));
     const newest = bundledCandidates[0];
-    if (!newest) return false;
+    if (!newest || (installed && compareDesktopBootstrapCandidates(newest, installed) <= 0)) return false;
 
     try {
       await writeJsonFileAtomic(configPath, newest.normalized);
@@ -400,7 +424,7 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     const legacy = legacyPath ? await readDesktopBootstrapCandidate(legacyPath) : null;
 
     if (primary.ok && legacy?.ok) {
-      if (desktopBootstrapCandidateTimeMs(legacy) > desktopBootstrapCandidateTimeMs(primary)) {
+      if (compareDesktopBootstrapCandidates(legacy, primary) > 0) {
         await migrateLegacyDesktopBootstrapConfig(configPath, legacy);
         return legacy.normalized;
       }
@@ -410,10 +434,8 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     if (primary.ok) return primary.normalized;
 
     if (legacy?.ok) {
-      if (!primary.exists || desktopBootstrapCandidateTimeMs(legacy) >= desktopBootstrapCandidateTimeMs(primary)) {
-        await migrateLegacyDesktopBootstrapConfig(configPath, legacy);
-        return legacy.normalized;
-      }
+      await migrateLegacyDesktopBootstrapConfig(configPath, legacy);
+      return legacy.normalized;
     }
 
     console.warn("[desktop-bootstrap] falling back to defaults", {
@@ -1209,7 +1231,7 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     forgetWorkspace,
     getDesktopBootstrapConfig,
     importConfig,
-    importBundledDesktopBootstrapConfigIfMissing,
+    importBundledDesktopBootstrapConfigIfPreferred,
     listLocalWorkspacePaths,
     migrateLegacyElectronWorkspaceStateIfNeeded,
     readWorkspaceOpenworkConfig,

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -34,14 +34,16 @@ async function withIsolatedBootstrapStore(callback) {
 
   try {
     const module = await import(`./workspace-store.mjs?bootstrap-test=${Date.now()}-${Math.random()}`);
-    const store = module.createWorkspaceStore({
+    const createStore = () => module.createWorkspaceStore({
       app: { getPath: (name) => name === "userData" ? path.join(root, "userData") : root },
       defaultDenBaseUrl: "https://default.example.com",
       defaultRequireSignin: false,
       forceRequireSignin: false,
     });
+    const store = createStore();
     return await callback({
       store,
+      createStore,
       canonicalPath: path.join(xdg, "openwork", "desktop-bootstrap.json"),
       legacyPath: path.join(home, ".config", "openwork", "desktop-bootstrap.json"),
       root,
@@ -285,33 +287,40 @@ test("desktop bootstrap writes include a fresh writtenAt stamp", async () => {
   });
 });
 
-test("imports a newer organization bootstrap beside the standard installer", async () => {
+test("imports the newest organization bootstrap beside a Windows installer when config is absent", async () => {
   await withIsolatedBootstrapStore(async ({ store, canonicalPath, root }) => {
-    const bundleDir = path.join(root, "downloads", "OpenWork-acme");
+    const bundleDir = path.join(root, "downloads", "OpenWork-example-org");
+    const newerBundleDir = path.join(bundleDir, "latest");
     process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR = bundleDir;
-    await mkdir(bundleDir, { recursive: true });
-    await writeFile(path.join(bundleDir, "openwork-mac-arm64-9.9.9.dmg"), "signed installer", "utf8");
+    await mkdir(newerBundleDir, { recursive: true });
+    await writeFile(path.join(bundleDir, "openwork-win-x64-9.9.8.exe"), "signed installer", "utf8");
     await writeBootstrapConfig(path.join(bundleDir, "desktop-bootstrap.json"), {
-      baseUrl: "https://acme.example.com",
-      apiBaseUrl: "https://api.acme.example.com",
+      baseUrl: "https://older.internal.example",
       requireSignin: true,
-      brandAppName: "Acme Work",
-      brandLogoUrl: "https://acme.example.com/logo.png",
+      writtenAt: "2026-07-10T11:00:00.000Z",
+    });
+    await writeFile(path.join(newerBundleDir, "openwork-win-x64-9.9.9.exe"), "signed installer", "utf8");
+    await writeBootstrapConfig(path.join(newerBundleDir, "desktop-bootstrap.json"), {
+      baseUrl: "https://openwork.internal.example",
+      apiBaseUrl: "https://api.openwork.internal.example",
+      requireSignin: true,
+      brandAppName: "Example Org Work",
+      brandLogoUrl: "https://openwork.internal.example/logo.png",
       writtenAt: "2026-07-10T12:00:00.000Z",
     });
 
-    assert.equal(await store.importBundledDesktopBootstrapConfigIfNewer(), true);
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfMissing(), true);
     const config = await store.getDesktopBootstrapConfig();
     assert.deepEqual(config, {
-      baseUrl: "https://acme.example.com",
-      apiBaseUrl: "https://api.acme.example.com",
+      baseUrl: "https://openwork.internal.example",
+      apiBaseUrl: "https://api.openwork.internal.example",
       requireSignin: true,
-      brandAppName: "Acme Work",
-      brandLogoUrl: "https://acme.example.com/logo.png",
+      brandAppName: "Example Org Work",
+      brandLogoUrl: "https://openwork.internal.example/logo.png",
       writtenAt: "2026-07-10T12:00:00.000Z",
     });
     const persisted = JSON.parse(await readFile(canonicalPath, "utf8"));
-    assert.equal(persisted.baseUrl, "https://acme.example.com");
+    assert.equal(persisted.baseUrl, "https://openwork.internal.example");
   });
 });
 
@@ -325,31 +334,63 @@ test("ignores a downloaded bootstrap that is not beside a standard installer", a
       writtenAt: "2026-07-10T12:00:00.000Z",
     });
 
-    assert.equal(await store.importBundledDesktopBootstrapConfigIfNewer(), false);
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfMissing(), false);
     await assert.rejects(readFile(canonicalPath, "utf8"));
   });
 });
 
-test("does not replace a newer canonical bootstrap with an older download bundle", async () => {
-  await withIsolatedBootstrapStore(async ({ store, canonicalPath, root }) => {
+test("keeps an installed organization bootstrap across a newer Windows installer bundle and restart", async () => {
+  await withIsolatedBootstrapStore(async ({ store, createStore, canonicalPath, root }) => {
     const bundleDir = path.join(root, "downloads");
     process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR = bundleDir;
     await writeBootstrapConfig(canonicalPath, {
-      baseUrl: "https://current.example.com",
+      baseUrl: "https://openwork.organization.internal.example",
       requireSignin: true,
-      writtenAt: "2026-07-10T13:00:00.000Z",
+      writtenAt: "2026-07-09T12:00:00.000Z",
     });
     await mkdir(bundleDir, { recursive: true });
     await writeFile(path.join(bundleDir, "openwork-win-x64-9.9.9.exe"), "signed installer", "utf8");
     await writeBootstrapConfig(path.join(bundleDir, "desktop-bootstrap.json"), {
-      baseUrl: "https://old.example.com",
-      requireSignin: true,
+      baseUrl: "https://cloud.default.example.com",
+      requireSignin: false,
       writtenAt: "2026-07-10T12:00:00.000Z",
     });
 
-    assert.equal(await store.importBundledDesktopBootstrapConfigIfNewer(), false);
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfMissing(), false);
     const config = await store.getDesktopBootstrapConfig();
-    assert.equal(config.baseUrl, "https://current.example.com");
+    assert.equal(config.baseUrl, "https://openwork.organization.internal.example");
+
+    const restartedStore = createStore();
+    assert.equal(await restartedStore.importBundledDesktopBootstrapConfigIfMissing(), false);
+    const restartedConfig = await restartedStore.getDesktopBootstrapConfig();
+    assert.equal(restartedConfig.baseUrl, "https://openwork.organization.internal.example");
+    const persisted = JSON.parse(await readFile(canonicalPath, "utf8"));
+    assert.equal(persisted.baseUrl, "https://openwork.organization.internal.example");
+  });
+});
+
+test("keeps and migrates an installed legacy bootstrap beside a newer Windows installer bundle", async () => {
+  await withIsolatedBootstrapStore(async ({ store, canonicalPath, legacyPath, root }) => {
+    const bundleDir = path.join(root, "downloads");
+    process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR = bundleDir;
+    await writeBootstrapConfig(legacyPath, {
+      baseUrl: "https://legacy.organization.internal.example",
+      requireSignin: true,
+      writtenAt: "2026-07-09T12:00:00.000Z",
+    });
+    await mkdir(bundleDir, { recursive: true });
+    await writeFile(path.join(bundleDir, "openwork-win-x64-9.9.9.exe"), "signed installer", "utf8");
+    await writeBootstrapConfig(path.join(bundleDir, "desktop-bootstrap.json"), {
+      baseUrl: "https://cloud.default.example.com",
+      requireSignin: false,
+      writtenAt: "2026-07-10T12:00:00.000Z",
+    });
+
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfMissing(), false);
+    const config = await store.getDesktopBootstrapConfig();
+    assert.equal(config.baseUrl, "https://legacy.organization.internal.example");
+    const migrated = JSON.parse(await readFile(canonicalPath, "utf8"));
+    assert.equal(migrated.baseUrl, "https://legacy.organization.internal.example");
   });
 });
 

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -253,6 +253,70 @@ test("desktop bootstrap migrates a newer legacy writtenAt to canonical", async (
   });
 });
 
+test("desktop bootstrap prefers an older legacy organization config over a newer canonical hosted default", async () => {
+  await withIsolatedBootstrapStore(async ({ store, canonicalPath, legacyPath }) => {
+    await writeBootstrapConfig(canonicalPath, {
+      baseUrl: "https://app.openworklabs.com/api/den/",
+      apiBaseUrl: "https://api.unrelated.example",
+      requireSignin: false,
+      writtenAt: "2026-07-10T13:00:00.000Z",
+    });
+    await writeBootstrapConfig(legacyPath, {
+      baseUrl: "https://openwork.organization.internal.example",
+      apiBaseUrl: "https://api.organization.internal.example",
+      requireSignin: true,
+      writtenAt: "2026-07-09T12:00:00.000Z",
+    });
+
+    const config = await store.getDesktopBootstrapConfig();
+    assert.equal(config.baseUrl, "https://openwork.organization.internal.example");
+    const migrated = JSON.parse(await readFile(canonicalPath, "utf8"));
+    assert.equal(migrated.baseUrl, "https://openwork.organization.internal.example");
+  });
+});
+
+test("desktop bootstrap keeps an older canonical organization config over a newer legacy hosted default", async () => {
+  await withIsolatedBootstrapStore(async ({ store, canonicalPath, legacyPath }) => {
+    await writeBootstrapConfig(canonicalPath, {
+      baseUrl: "https://openwork.organization.internal.example",
+      apiBaseUrl: "https://api.organization.internal.example",
+      requireSignin: true,
+      writtenAt: "2026-07-09T12:00:00.000Z",
+    });
+    await writeBootstrapConfig(legacyPath, {
+      baseUrl: "https://api.openworklabs.com/v1/",
+      apiBaseUrl: "https://api.unrelated.example",
+      requireSignin: false,
+      writtenAt: "2026-07-10T13:00:00.000Z",
+    });
+
+    const config = await store.getDesktopBootstrapConfig();
+    assert.equal(config.baseUrl, "https://openwork.organization.internal.example");
+    const persisted = JSON.parse(await readFile(canonicalPath, "utf8"));
+    assert.equal(persisted.baseUrl, "https://openwork.organization.internal.example");
+  });
+});
+
+test("desktop bootstrap ignores a newer malformed canonical config when legacy is valid", async () => {
+  await withIsolatedBootstrapStore(async ({ store, canonicalPath, legacyPath }) => {
+    await writeBootstrapConfig(legacyPath, {
+      baseUrl: "https://legacy.organization.internal.example",
+      requireSignin: true,
+    });
+    await mkdir(path.dirname(canonicalPath), { recursive: true });
+    await writeFile(canonicalPath, "{ malformed", "utf8");
+    const older = new Date("2026-07-09T12:00:00.000Z");
+    const newer = new Date("2026-07-10T12:00:00.000Z");
+    await utimes(legacyPath, older, older);
+    await utimes(canonicalPath, newer, newer);
+
+    const config = await store.getDesktopBootstrapConfig();
+    assert.equal(config.baseUrl, "https://legacy.organization.internal.example");
+    const migrated = JSON.parse(await readFile(canonicalPath, "utf8"));
+    assert.equal(migrated.baseUrl, "https://legacy.organization.internal.example");
+  });
+});
+
 test("desktop bootstrap falls back to mtime when writtenAt is missing", async () => {
   await withIsolatedBootstrapStore(async ({ store, canonicalPath, legacyPath }) => {
     await writeBootstrapConfig(canonicalPath, {
@@ -290,11 +354,20 @@ test("desktop bootstrap writes include a fresh writtenAt stamp", async () => {
 test("imports the newest organization bootstrap beside a Windows installer when config is absent", async () => {
   await withIsolatedBootstrapStore(async ({ store, canonicalPath, root }) => {
     const bundleDir = path.join(root, "downloads", "OpenWork-example-org");
+    const olderBundleDir = path.join(bundleDir, "older");
     const newerBundleDir = path.join(bundleDir, "latest");
     process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR = bundleDir;
+    await mkdir(olderBundleDir, { recursive: true });
     await mkdir(newerBundleDir, { recursive: true });
-    await writeFile(path.join(bundleDir, "openwork-win-x64-9.9.8.exe"), "signed installer", "utf8");
+    await writeFile(path.join(bundleDir, "openwork-win-x64-10.0.0.exe"), "signed installer", "utf8");
     await writeBootstrapConfig(path.join(bundleDir, "desktop-bootstrap.json"), {
+      baseUrl: "https://app.openworklabs.com/",
+      apiBaseUrl: "https://api.openworklabs.com/",
+      requireSignin: false,
+      writtenAt: "2026-07-10T13:00:00.000Z",
+    });
+    await writeFile(path.join(olderBundleDir, "openwork-win-x64-9.9.8.exe"), "signed installer", "utf8");
+    await writeBootstrapConfig(path.join(olderBundleDir, "desktop-bootstrap.json"), {
       baseUrl: "https://older.internal.example",
       requireSignin: true,
       writtenAt: "2026-07-10T11:00:00.000Z",
@@ -309,7 +382,7 @@ test("imports the newest organization bootstrap beside a Windows installer when 
       writtenAt: "2026-07-10T12:00:00.000Z",
     });
 
-    assert.equal(await store.importBundledDesktopBootstrapConfigIfMissing(), true);
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfPreferred(), true);
     const config = await store.getDesktopBootstrapConfig();
     assert.deepEqual(config, {
       baseUrl: "https://openwork.internal.example",
@@ -334,7 +407,7 @@ test("ignores a downloaded bootstrap that is not beside a standard installer", a
       writtenAt: "2026-07-10T12:00:00.000Z",
     });
 
-    assert.equal(await store.importBundledDesktopBootstrapConfigIfMissing(), false);
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfPreferred(), false);
     await assert.rejects(readFile(canonicalPath, "utf8"));
   });
 });
@@ -351,17 +424,18 @@ test("keeps an installed organization bootstrap across a newer Windows installer
     await mkdir(bundleDir, { recursive: true });
     await writeFile(path.join(bundleDir, "openwork-win-x64-9.9.9.exe"), "signed installer", "utf8");
     await writeBootstrapConfig(path.join(bundleDir, "desktop-bootstrap.json"), {
-      baseUrl: "https://cloud.default.example.com",
+      baseUrl: "https://app.openworklabs.com/",
+      apiBaseUrl: "https://api.openworklabs.com/",
       requireSignin: false,
       writtenAt: "2026-07-10T12:00:00.000Z",
     });
 
-    assert.equal(await store.importBundledDesktopBootstrapConfigIfMissing(), false);
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfPreferred(), false);
     const config = await store.getDesktopBootstrapConfig();
     assert.equal(config.baseUrl, "https://openwork.organization.internal.example");
 
     const restartedStore = createStore();
-    assert.equal(await restartedStore.importBundledDesktopBootstrapConfigIfMissing(), false);
+    assert.equal(await restartedStore.importBundledDesktopBootstrapConfigIfPreferred(), false);
     const restartedConfig = await restartedStore.getDesktopBootstrapConfig();
     assert.equal(restartedConfig.baseUrl, "https://openwork.organization.internal.example");
     const persisted = JSON.parse(await readFile(canonicalPath, "utf8"));
@@ -381,16 +455,44 @@ test("keeps and migrates an installed legacy bootstrap beside a newer Windows in
     await mkdir(bundleDir, { recursive: true });
     await writeFile(path.join(bundleDir, "openwork-win-x64-9.9.9.exe"), "signed installer", "utf8");
     await writeBootstrapConfig(path.join(bundleDir, "desktop-bootstrap.json"), {
-      baseUrl: "https://cloud.default.example.com",
+      baseUrl: "https://app.openworklabs.com/",
+      apiBaseUrl: "https://api.openworklabs.com/",
       requireSignin: false,
       writtenAt: "2026-07-10T12:00:00.000Z",
     });
 
-    assert.equal(await store.importBundledDesktopBootstrapConfigIfMissing(), false);
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfPreferred(), false);
     const config = await store.getDesktopBootstrapConfig();
     assert.equal(config.baseUrl, "https://legacy.organization.internal.example");
     const migrated = JSON.parse(await readFile(canonicalPath, "utf8"));
     assert.equal(migrated.baseUrl, "https://legacy.organization.internal.example");
+  });
+});
+
+test("replaces an installed hosted default with a custom organization Windows bundle", async () => {
+  await withIsolatedBootstrapStore(async ({ store, canonicalPath, root }) => {
+    const bundleDir = path.join(root, "downloads");
+    process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR = bundleDir;
+    await writeBootstrapConfig(canonicalPath, {
+      baseUrl: "https://app.openworklabs.com/",
+      apiBaseUrl: "https://api.openworklabs.com/",
+      requireSignin: false,
+      writtenAt: "2026-07-10T13:00:00.000Z",
+    });
+    await mkdir(bundleDir, { recursive: true });
+    await writeFile(path.join(bundleDir, "openwork-win-x64-9.9.9.exe"), "signed installer", "utf8");
+    await writeBootstrapConfig(path.join(bundleDir, "desktop-bootstrap.json"), {
+      baseUrl: "https://custom.organization.internal.example",
+      apiBaseUrl: "https://api.custom.organization.internal.example",
+      requireSignin: true,
+      writtenAt: "2026-07-09T12:00:00.000Z",
+    });
+
+    assert.equal(await store.importBundledDesktopBootstrapConfigIfPreferred(), true);
+    const config = await store.getDesktopBootstrapConfig();
+    assert.equal(config.baseUrl, "https://custom.organization.internal.example");
+    const persisted = JSON.parse(await readFile(canonicalPath, "utf8"));
+    assert.equal(persisted.baseUrl, "https://custom.organization.internal.example");
   });
 });
 

--- a/apps/installer/src/install.ts
+++ b/apps/installer/src/install.ts
@@ -1,5 +1,5 @@
 import { spawn } from "node:child_process"
-import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs"
+import { chmodSync, existsSync, mkdirSync, readFileSync, readdirSync, rmSync, statSync, writeFileSync } from "node:fs"
 import os from "node:os"
 import path from "node:path"
 
@@ -37,6 +37,54 @@ const status: InstallStatus = {
   error: null,
 }
 
+const HOSTED_DESKTOP_WEB_URL = "https://app.openworklabs.com"
+const HOSTED_DESKTOP_API_URL = "https://api.openworklabs.com"
+
+type BootstrapCandidate = {
+  config: Record<string, unknown>
+  mtimeMs: number
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === "object" && !Array.isArray(value)
+}
+
+function bootstrapUrlOrigin(value: unknown): string {
+  if (typeof value !== "string" || !value.trim()) return ""
+  try {
+    return new URL(value.trim()).origin
+  } catch {
+    return value.trim().replace(/\/+$/, "")
+  }
+}
+
+function isHostedBootstrapConfig(config: Record<string, unknown>): boolean {
+  const baseUrlOrigin = bootstrapUrlOrigin(config.baseUrl)
+  return baseUrlOrigin === HOSTED_DESKTOP_WEB_URL || baseUrlOrigin === HOSTED_DESKTOP_API_URL
+}
+
+function readBootstrapCandidate(candidatePath: string): BootstrapCandidate | null {
+  try {
+    const parsed: unknown = JSON.parse(readFileSync(candidatePath, "utf8"))
+    if (!isRecord(parsed)) return null
+    if (typeof parsed.baseUrl !== "string" || !parsed.baseUrl.trim()) return null
+    return { config: parsed, mtimeMs: statSync(candidatePath).mtimeMs }
+  } catch {
+    return null
+  }
+}
+
+function bootstrapCandidateTimeMs(candidate: BootstrapCandidate): number {
+  const writtenAt = typeof candidate.config.writtenAt === "string" ? candidate.config.writtenAt.trim() : ""
+  const writtenAtMs = writtenAt ? Date.parse(writtenAt) : Number.NaN
+  return Number.isFinite(writtenAtMs) ? writtenAtMs : candidate.mtimeMs
+}
+
+function compareBootstrapCandidates(left: BootstrapCandidate, right: BootstrapCandidate): number {
+  const classDifference = Number(!isHostedBootstrapConfig(left.config)) - Number(!isHostedBootstrapConfig(right.config))
+  return classDifference || bootstrapCandidateTimeMs(left) - bootstrapCandidateTimeMs(right)
+}
+
 export function installStatus(): InstallStatus {
   return { ...status }
 }
@@ -47,34 +95,46 @@ function update(partial: Partial<InstallStatus>, onStatus?: (status: InstallStat
 }
 
 /**
- * Merge the deployment config into any existing bootstrap file rather than
- * replacing it: a re-run must not destroy prepared/claimLinks state written by
- * the bootstrap CLI, but one-time handoff grants must not survive reinstall
- * (see normalizeDesktopBootstrapConfig in the Electron shell for the full shape).
+ * Prefer an installed organization deployment over hosted defaults while
+ * retaining prepared/claimLinks state. One-time handoff grants must not survive
+ * reinstall (see normalizeDesktopBootstrapConfig in the Electron shell).
  */
-export function writeBootstrapConfig(config: InstallerConfig, env: NodeJS.ProcessEnv = process.env): string {
-  const target = desktopBootstrapPath(env)
-  let existing: Record<string, unknown> = {}
-  try {
-    const parsed = JSON.parse(readFileSync(target, "utf8"))
-    if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) existing = parsed
-  } catch {
-    // Missing or invalid file: start fresh.
-  }
-
-  const next = {
+export function writeBootstrapConfig(
+  config: InstallerConfig,
+  env: NodeJS.ProcessEnv = process.env,
+  platform: NodeJS.Platform = process.platform,
+): string {
+  const target = desktopBootstrapPath(env, platform)
+  const legacy = legacyDesktopBootstrapPath(env, platform)
+  const canonicalCandidate = readBootstrapCandidate(target)
+  const legacyCandidate = path.resolve(legacy) === path.resolve(target) ? null : readBootstrapCandidate(legacy)
+  const installedCandidates: BootstrapCandidate[] = []
+  if (canonicalCandidate) installedCandidates.push(canonicalCandidate)
+  if (legacyCandidate) installedCandidates.push(legacyCandidate)
+  installedCandidates.sort((left, right) => compareBootstrapCandidates(right, left))
+  const installed = installedCandidates[0]
+  const existing = installed ? installed.config : {}
+  const preserveInstalledDeployment = installed ? !isHostedBootstrapConfig(installed.config) : false
+  const prepared = canonicalCandidate?.config.prepared ?? legacyCandidate?.config.prepared
+  const claimLinks = canonicalCandidate?.config.claimLinks ?? legacyCandidate?.config.claimLinks
+  const next: Record<string, unknown> = {
     ...existing,
-    baseUrl: config.webUrl,
-    apiBaseUrl: config.apiUrl,
-    requireSignin: config.requireSignin,
-    brandAppName: config.appName,
-    ...(config.logoUrl ? { brandLogoUrl: config.logoUrl } : {}),
+    ...(!preserveInstalledDeployment
+      ? {
+          baseUrl: config.webUrl,
+          apiBaseUrl: config.apiUrl,
+          requireSignin: config.requireSignin,
+          brandAppName: config.appName,
+          ...(config.logoUrl ? { brandLogoUrl: config.logoUrl } : {}),
+        }
+      : {}),
+    ...(prepared !== undefined ? { prepared } : {}),
+    ...(claimLinks !== undefined ? { claimLinks } : {}),
     writtenAt: new Date().toISOString(),
   }
   delete next.handoff
   mkdirSync(path.dirname(target), { recursive: true })
   writeFileSync(target, `${JSON.stringify(next, null, 2)}\n`, "utf8")
-  const legacy = legacyDesktopBootstrapPath(env)
   try {
     if (path.resolve(legacy) !== path.resolve(target) && existsSync(legacy)) rmSync(legacy, { force: true })
   } catch {

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -301,42 +301,125 @@ describe("install link helpers", () => {
 })
 
 describe("writeBootstrapConfig", () => {
-  test("writes the deployment config, stamps it, drops handoff, and removes stale legacy", () => {
+  test("migrates a legacy organization config instead of replacing it with hosted defaults", () => {
     const dir = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-test-"))
-    const target = path.join(dir, "canonical", "desktop-bootstrap.json")
-    const home = path.join(dir, "home")
-    const legacy = path.join(home, ".config", "openwork", "desktop-bootstrap.json")
-    const previousHome = process.env.HOME
+    const env = {
+      LOCALAPPDATA: path.join(dir, "LocalAppData"),
+      USERPROFILE: path.join(dir, "profile"),
+    }
+    const target = desktopBootstrapPath(env, "win32")
+    const legacy = legacyDesktopBootstrapPath(env, "win32")
     try {
-      process.env.HOME = home
       mkdirSync(path.dirname(target), { recursive: true })
       mkdirSync(path.dirname(legacy), { recursive: true })
-      writeFileSync(legacy, JSON.stringify({ baseUrl: "https://legacy.example.com" }))
       writeFileSync(target, JSON.stringify({
-        baseUrl: "https://old.example.com",
+        baseUrl: "https://app.openworklabs.com/api/den/",
+        writtenAt: "2026-07-10T13:00:00.000Z",
+      }))
+      writeFileSync(legacy, JSON.stringify({
+        baseUrl: "https://openwork.organization.internal.example",
+        apiBaseUrl: "https://api.organization.internal.example",
         handoff: { grant: "drop-me" },
-        prepared: { orgId: "org" },
-        claimLinks: [{ id: "claim" }],
+        prepared: { orgId: "org_example" },
+        claimLinks: [{ id: "claim_example" }],
+        writtenAt: "2026-07-09T12:00:00.000Z",
       }))
       const written = writeBootstrapConfig(
-        { appName: "Acme Work", clientName: "Acme", webUrl: "https://openwork.acme.com", apiUrl: "https://openwork-api.acme.com", requireSignin: true, logoUrl: "https://openwork.acme.com/assets/wordmark.svg" },
-        { OPENWORK_DESKTOP_BOOTSTRAP_PATH: target, HOME: home, USERPROFILE: home },
+        { appName: "OpenWork", clientName: "Hosted", webUrl: "https://app.openworklabs.com/", apiUrl: "https://api.openworklabs.com/", requireSignin: false, logoUrl: null },
+        env,
+        "win32",
       )
       expect(written).toBe(target)
       const parsed = JSON.parse(readFileSync(target, "utf8"))
-      expect(parsed.baseUrl).toBe("https://openwork.acme.com")
-      expect(parsed.apiBaseUrl).toBe("https://openwork-api.acme.com")
-      expect(parsed.requireSignin).toBe(true)
-      expect(parsed.brandAppName).toBe("Acme Work")
-      expect(parsed.brandLogoUrl).toBe("https://openwork.acme.com/assets/wordmark.svg")
+      expect(parsed.baseUrl).toBe("https://openwork.organization.internal.example")
+      expect(parsed.apiBaseUrl).toBe("https://api.organization.internal.example")
       expect(parsed.handoff).toBeUndefined()
-      expect(parsed.prepared).toEqual({ orgId: "org" })
-      expect(parsed.claimLinks).toEqual([{ id: "claim" }])
+      expect(parsed.prepared).toEqual({ orgId: "org_example" })
+      expect(parsed.claimLinks).toEqual([{ id: "claim_example" }])
       expect(Number.isFinite(Date.parse(parsed.writtenAt))).toBe(true)
       expect(existsSync(legacy)).toBe(false)
     } finally {
-      if (previousHome === undefined) delete process.env.HOME
-      else process.env.HOME = previousHome
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("keeps a canonical organization config across repeated hosted reinstalls", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-test-"))
+    const env = {
+      LOCALAPPDATA: path.join(dir, "LocalAppData"),
+      USERPROFILE: path.join(dir, "profile"),
+    }
+    const target = desktopBootstrapPath(env, "win32")
+    try {
+      mkdirSync(path.dirname(target), { recursive: true })
+      writeFileSync(target, JSON.stringify({
+        baseUrl: "https://openwork.organization.internal.example",
+        apiBaseUrl: "https://api.organization.internal.example",
+        handoff: { grant: "drop-me" },
+        prepared: { orgId: "org_example" },
+        claimLinks: [{ id: "claim_example" }],
+      }))
+      const hostedConfig = {
+        appName: "OpenWork",
+        clientName: "Hosted",
+        webUrl: "https://api.openworklabs.com/v1/",
+        apiUrl: "https://api.openworklabs.com/",
+        requireSignin: false,
+        logoUrl: null,
+      }
+
+      writeBootstrapConfig(hostedConfig, env, "win32")
+      writeBootstrapConfig(hostedConfig, env, "win32")
+
+      const parsed = JSON.parse(readFileSync(target, "utf8"))
+      expect(parsed.baseUrl).toBe("https://openwork.organization.internal.example")
+      expect(parsed.apiBaseUrl).toBe("https://api.organization.internal.example")
+      expect(parsed.handoff).toBeUndefined()
+      expect(parsed.prepared).toEqual({ orgId: "org_example" })
+      expect(parsed.claimLinks).toEqual([{ id: "claim_example" }])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("replaces an installed hosted default with a custom organization config", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-test-"))
+    const env = {
+      LOCALAPPDATA: path.join(dir, "LocalAppData"),
+      USERPROFILE: path.join(dir, "profile"),
+    }
+    const target = desktopBootstrapPath(env, "win32")
+    try {
+      mkdirSync(path.dirname(target), { recursive: true })
+      writeFileSync(target, JSON.stringify({
+        baseUrl: "https://app.openworklabs.com/api/den/",
+        apiBaseUrl: "https://api.openworklabs.com/",
+        prepared: { orgId: "org_example" },
+        claimLinks: [{ id: "claim_example" }],
+      }))
+
+      writeBootstrapConfig(
+        {
+          appName: "Example Org Work",
+          clientName: "Example Org",
+          webUrl: "https://openwork.custom.internal.example",
+          apiUrl: "https://api.custom.internal.example",
+          requireSignin: true,
+          logoUrl: "https://openwork.custom.internal.example/assets/wordmark.svg",
+        },
+        env,
+        "win32",
+      )
+
+      const parsed = JSON.parse(readFileSync(target, "utf8"))
+      expect(parsed.baseUrl).toBe("https://openwork.custom.internal.example")
+      expect(parsed.apiBaseUrl).toBe("https://api.custom.internal.example")
+      expect(parsed.requireSignin).toBe(true)
+      expect(parsed.brandAppName).toBe("Example Org Work")
+      expect(parsed.brandLogoUrl).toBe("https://openwork.custom.internal.example/assets/wordmark.svg")
+      expect(parsed.prepared).toEqual({ orgId: "org_example" })
+      expect(parsed.claimLinks).toEqual([{ id: "claim_example" }])
+    } finally {
       rmSync(dir, { recursive: true, force: true })
     }
   })

--- a/evals/flows/desktop-upgrade-preserves-server-url.flow.mjs
+++ b/evals/flows/desktop-upgrade-preserves-server-url.flow.mjs
@@ -1,0 +1,451 @@
+import {
+  daytonaComputerUsePress,
+  daytonaComputerUseStart,
+  daytonaComputerUseType,
+  daytonaComputerUseWindows,
+} from "../runner/daytona-computer-use.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "desktop-upgrade-preserves-server-url";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const ORG_URL = "http://openwork.example-manufacturing.internal:48765";
+const HOSTED_URL = "https://app.openworklabs.com";
+const CANONICAL_BOOTSTRAP = "C:\\Users\\Administrator\\AppData\\Local\\openwork\\desktop-bootstrap.json";
+const LEGACY_BOOTSTRAP = "C:\\Users\\Administrator\\.config\\openwork\\desktop-bootstrap.json";
+const DOWNLOAD_BUNDLE = "C:\\Users\\Administrator\\Downloads\\Example Manufacturing Upgrade";
+const INSTALLED_DESKTOP_DIR = "C:\\Users\\Administrator\\AppData\\Local\\Programs\\@openworkdesktop";
+const BRANCH_LAUNCHER = "C:\\ow\\desktop-upgrade-url\\launch-openwork.cmd";
+const FIREWALL_RULE = "OpenWork Upgrade URL Airgap Eval";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function sandboxId(ctx) {
+  return (ctx.env.OPENWORK_EVAL_DAYTONA_SANDBOX_ID || ctx.env.OPENWORK_EVAL_DAYTONA_SANDBOX).trim();
+}
+
+function windowsAppPath(ctx) {
+  return ctx.env.OPENWORK_EVAL_WINDOWS_APP_PATH.trim();
+}
+
+function windowsInstallerPath(ctx) {
+  return ctx.env.OPENWORK_EVAL_WINDOWS_INSTALLER_PATH.trim();
+}
+
+function standardInstallerPath(ctx) {
+  return ctx.env.OPENWORK_EVAL_WINDOWS_STANDARD_INSTALLER_PATH.trim();
+}
+
+function computerUseScreenshot(name, options = {}) {
+  return {
+    name,
+    sandboxCapture: "computer-use",
+    ...options,
+  };
+}
+
+async function windowsExec(ctx, label, command, timeout = 60) {
+  const encoded = Buffer.from(command, "utf16le").toString("base64");
+  const toolboxBase = (ctx.env.DAYTONA_TOOLBOX_URL || "https://proxy.app.daytona.io/toolbox").replace(/\/$/, "");
+  const response = await fetch(`${toolboxBase}/${encodeURIComponent(sandboxId(ctx))}/process/execute`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${ctx.env.DAYTONA_API_KEY}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      command: `powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encoded}`,
+      timeout,
+    }),
+    signal: AbortSignal.timeout((timeout + 10) * 1_000),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || payload.exitCode !== 0) {
+    throw new Error(`Daytona Windows ${label} failed (${response.status}/${payload.exitCode ?? "unknown"}): ${payload.result ?? ""}`.trim());
+  }
+  const stdout = typeof payload.result === "string" ? payload.result : "";
+  ctx.log(`Daytona Windows ${label}: ${stdout.trim().slice(0, 700)}`);
+  return stdout;
+}
+
+function parseJsonOutput(output) {
+  const start = output.indexOf("{");
+  if (start < 0) throw new Error(`Windows output did not contain JSON: ${output}`);
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+  for (let index = start; index < output.length; index += 1) {
+    const char = output[index];
+    if (inString) {
+      if (escaped) escaped = false;
+      else if (char === "\\") escaped = true;
+      else if (char === '"') inString = false;
+      continue;
+    }
+    if (char === '"') inString = true;
+    else if (char === "{") depth += 1;
+    else if (char === "}") {
+      depth -= 1;
+      if (depth === 0) return JSON.parse(output.slice(start, index + 1));
+    }
+  }
+  throw new Error(`Windows output contained incomplete JSON: ${output}`);
+}
+
+async function readCanonicalBootstrap(ctx) {
+  const output = await windowsExec(ctx, "read canonical bootstrap", `
+$path = '${CANONICAL_BOOTSTRAP}'
+if (-not (Test-Path -LiteralPath $path)) { throw "Missing canonical bootstrap: $path" }
+Get-Content -LiteralPath $path -Raw
+`);
+  return parseJsonOutput(output);
+}
+
+async function assertOrganizationBootstrap(ctx, label) {
+  const config = await readCanonicalBootstrap(ctx);
+  ctx.assert(config.baseUrl === ORG_URL, `${label}: expected ${ORG_URL}, got ${config.baseUrl}`);
+  ctx.assert(config.baseUrl !== HOSTED_URL, `${label}: hosted default replaced the organization URL`);
+  ctx.recordEvidence({
+    type: "assertion",
+    status: "passed",
+    assertion: `${label}: canonical desktop-bootstrap.json retains the Example Manufacturing on-prem URL`,
+    actual: JSON.stringify({ baseUrl: config.baseUrl, apiBaseUrl: config.apiBaseUrl, writtenAt: config.writtenAt }),
+  });
+  ctx.output(`${label} desktop-bootstrap.json`, JSON.stringify(config, null, 2));
+  return config;
+}
+
+async function stopOpenWork(ctx) {
+  await windowsExec(ctx, "stop OpenWork", `
+Get-Process -Name OpenWork -ErrorAction SilentlyContinue | Stop-Process -Force
+Start-Sleep -Milliseconds 800
+Write-Output 'OpenWork stopped'
+`);
+}
+
+async function launchViaRun(ctx, command) {
+  await daytonaComputerUsePress(sandboxId(ctx), "escape");
+  await daytonaComputerUsePress(sandboxId(ctx), "r", ["cmd"]);
+  await sleep(400);
+  await daytonaComputerUseType(sandboxId(ctx), command);
+  await daytonaComputerUsePress(sandboxId(ctx), "enter");
+}
+
+async function launchBranchApp(ctx) {
+  const launcher = `@echo off\r\nset "XDG_CONFIG_HOME="\r\nset "LOCALAPPDATA=C:\\Users\\Administrator\\AppData\\Local"\r\nset "OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9825"\r\nstart "" "${windowsAppPath(ctx)}"\r\n`;
+  const launcherBase64 = Buffer.from(launcher, "utf8").toString("base64");
+  await windowsExec(ctx, "write branch app launcher", `
+[IO.File]::WriteAllBytes('${BRANCH_LAUNCHER}', [Convert]::FromBase64String('${launcherBase64}'))
+Write-Output 'branch app launcher ready'
+`);
+  await launchViaRun(ctx, BRANCH_LAUNCHER);
+  await sleep(1_000);
+  await ctx.reconnect({ timeoutMs: 120_000 });
+  await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__)", {
+    timeoutMs: 60_000,
+    label: "Windows Electron bridge",
+  });
+}
+
+async function waitForWindow(ctx, pattern, expected, timeoutMs = 30_000) {
+  const startedAt = Date.now();
+  let lastTitles = [];
+  while (Date.now() - startedAt < timeoutMs) {
+    const result = await daytonaComputerUseWindows(sandboxId(ctx));
+    lastTitles = Array.isArray(result?.windows) ? result.windows.map((entry) => entry?.title ?? "") : [];
+    const present = lastTitles.some((title) => pattern.test(title));
+    if (present === expected) return lastTitles;
+    await sleep(500);
+  }
+  throw new Error(`Timed out waiting for Windows title ${pattern} present=${expected}: ${JSON.stringify(lastTitles)}`);
+}
+
+async function showAdvancedServer(ctx) {
+  await ctx.navigateHash("/settings/advanced");
+  await ctx.waitForText("Organization server", { timeoutMs: 60_000 });
+  await ctx.waitForText(ORG_URL, { timeoutMs: 60_000 });
+  await ctx.eval(`(() => {
+    const nodes = [...document.querySelectorAll("div,section")];
+    const target = nodes.find((node) => node.children.length < 8 && (node.textContent ?? "").includes("Server endpoints"));
+    target?.scrollIntoView({ block: "center" });
+    return Boolean(target);
+  })()`);
+  await sleep(500);
+}
+
+async function showBootstrapDebug(ctx) {
+  await ctx.eval(`localStorage.setItem("openwork.developerMode", "1")`);
+  await ctx.navigateHash("/settings/debug");
+  await ctx.waitForText("Bootstrap config", { timeoutMs: 60_000 });
+  await ctx.waitForText(ORG_URL, { timeoutMs: 60_000 });
+  await ctx.eval(`(() => {
+    const nodes = [...document.querySelectorAll("div,section")];
+    const target = nodes.find((node) => node.children.length < 10 && (node.textContent ?? "").includes("Bootstrap config"));
+    target?.scrollIntoView({ block: "center" });
+    return Boolean(target);
+  })()`);
+  await sleep(500);
+}
+
+async function prepareCanonicalState(ctx) {
+  const standardInstaller = standardInstallerPath(ctx).replaceAll("'", "''");
+  await windowsExec(ctx, "prepare canonical organization state", `
+$canonical = '${CANONICAL_BOOTSTRAP}'
+$legacy = '${LEGACY_BOOTSTRAP}'
+$bundle = '${DOWNLOAD_BUNDLE}'
+Get-Process -Name msedge,openwork-installer -ErrorAction SilentlyContinue | Stop-Process -Force
+Get-Process -ErrorAction SilentlyContinue | Where-Object { $_.MainWindowTitle -match '^OpenWork Setup' } | Stop-Process -Force
+Remove-Item -LiteralPath 'C:\\Users\\Administrator\\AppData\\Local\\Microsoft\\Edge\\User Data\\Default\\Sessions' -Recurse -Force -ErrorAction SilentlyContinue
+New-Item -Path 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge' -Force | Out-Null
+New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge' -Name HideFirstRunExperience -PropertyType DWord -Value 1 -Force | Out-Null
+New-ItemProperty -Path 'HKLM:\\SOFTWARE\\Policies\\Microsoft\\Edge' -Name RestoreOnStartup -PropertyType DWord -Value 5 -Force | Out-Null
+New-Item -ItemType Directory -Path (Split-Path -Parent $canonical) -Force | Out-Null
+New-Item -ItemType Directory -Path $bundle -Force | Out-Null
+Remove-Item -LiteralPath $legacy -Force -ErrorAction SilentlyContinue
+$organization = [ordered]@{
+  baseUrl = '${ORG_URL}'
+  apiBaseUrl = '${ORG_URL}'
+  requireSignin = $false
+  brandAppName = 'Example Manufacturing Work'
+  writtenAt = '2026-07-09T12:00:00.000Z'
+}
+$hosted = [ordered]@{
+  baseUrl = '${HOSTED_URL}'
+  apiBaseUrl = 'https://api.openworklabs.com'
+  requireSignin = $true
+  brandAppName = 'OpenWork'
+  writtenAt = '2026-07-10T12:00:00.000Z'
+}
+$utf8NoBom = New-Object Text.UTF8Encoding($false)
+[IO.File]::WriteAllText($canonical, ($organization | ConvertTo-Json), $utf8NoBom)
+[IO.File]::WriteAllText((Join-Path $bundle 'desktop-bootstrap.json'), ($hosted | ConvertTo-Json), $utf8NoBom)
+Copy-Item -LiteralPath '${standardInstaller}' -Destination (Join-Path $bundle 'openwork-win-x64-0.17.20.exe') -Force
+Remove-NetFirewallRule -DisplayName '${FIREWALL_RULE}' -ErrorAction SilentlyContinue
+Write-Output 'canonical organization state ready'
+`);
+}
+
+async function prepareLegacyUpgradeState(ctx) {
+  await windowsExec(ctx, "prepare legacy organization state", `
+$canonical = '${CANONICAL_BOOTSTRAP}'
+$legacy = '${LEGACY_BOOTSTRAP}'
+New-Item -ItemType Directory -Path (Split-Path -Parent $legacy) -Force | Out-Null
+$organization = [ordered]@{
+  baseUrl = '${ORG_URL}'
+  apiBaseUrl = '${ORG_URL}'
+  requireSignin = $false
+  brandAppName = 'Example Manufacturing Work'
+  writtenAt = '2026-07-09T12:00:00.000Z'
+}
+$utf8NoBom = New-Object Text.UTF8Encoding($false)
+[IO.File]::WriteAllText($legacy, ($organization | ConvertTo-Json), $utf8NoBom)
+Remove-Item -LiteralPath $canonical -Force -ErrorAction SilentlyContinue
+Write-Output 'legacy organization state ready beside newer hosted download bundle'
+`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Windows upgrades preserve organization bootstrap URLs across canonical, legacy, restart, and air-gapped paths",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: [
+    "DAYTONA_API_KEY",
+    "OPENWORK_EVAL_DAYTONA_SANDBOX",
+    "OPENWORK_EVAL_WINDOWS_APP_PATH",
+    "OPENWORK_EVAL_WINDOWS_INSTALLER_PATH",
+    "OPENWORK_EVAL_WINDOWS_STANDARD_INSTALLER_PATH",
+  ],
+  steps: [
+    {
+      name: "Setup isolated Windows organization state",
+      run: async (ctx) => {
+        await daytonaComputerUseStart(sandboxId(ctx));
+        await stopOpenWork(ctx);
+        await prepareCanonicalState(ctx);
+        await launchBranchApp(ctx);
+      },
+    },
+    {
+      name: "Frame 1 — existing organization bootstrap",
+      run: async (ctx) => {
+        await ctx.prove("The installed Windows desktop is configured for Example Manufacturing", {
+          voiceover: vo[0],
+          action: async () => {
+            await showAdvancedServer(ctx);
+          },
+          assert: async () => {
+            const runtime = await ctx.eval("window.__OPENWORK_ELECTRON__?.system?.getArchitectureInfo?.()", { awaitPromise: true });
+            ctx.assert(runtime?.platform === "windows", `Expected Windows Electron, got ${JSON.stringify(runtime)}`);
+            await ctx.expectText("From bootstrap file");
+            await ctx.expectText(ORG_URL);
+            await assertOrganizationBootstrap(ctx, "before upgrade");
+          },
+          screenshot: computerUseScreenshot("existing-organization-bootstrap", {
+            requireText: ["Organization server", "From bootstrap file", ORG_URL],
+          }),
+        });
+      },
+    },
+    {
+      name: "Frame 2 — upgrade installer runs",
+      run: async (ctx) => {
+        let installerTitles = [];
+        await ctx.prove("The Windows installer upgrades an existing organization-configured desktop", {
+          voiceover: vo[1],
+          action: async () => {
+            await stopOpenWork(ctx);
+            await windowsExec(ctx, "remove prior installed desktop binaries", `
+Remove-Item -LiteralPath '${INSTALLED_DESKTOP_DIR}' -Recurse -Force -ErrorAction SilentlyContinue
+Write-Output 'prior desktop binaries removed; bootstrap retained'
+            `);
+            await windowsExec(ctx, "exercise organization bootstrap migration", `
+$env:LOCALAPPDATA = 'C:\\Users\\Administrator\\AppData\\Local'
+$env:USERPROFILE = 'C:\\Users\\Administrator'
+& '${windowsInstallerPath(ctx)}' --headless --dry-run
+if ($LASTEXITCODE -ne 0) { throw "Organization installer dry run failed with exit code $LASTEXITCODE" }
+`);
+            await launchViaRun(ctx, standardInstallerPath(ctx));
+            installerTitles = await waitForWindow(ctx, /OpenWork Setup/i, true, 30_000);
+            await sleep(500);
+          },
+          assert: async () => {
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "The real Windows desktop upgrade installer is visibly running", actual: JSON.stringify(installerTitles.filter(Boolean)) });
+            await assertOrganizationBootstrap(ctx, "while installer is running");
+          },
+          screenshot: computerUseScreenshot("windows-upgrade-installer-progress"),
+        });
+      },
+    },
+    {
+      name: "Frame 3 — upgraded app reuses organization URL",
+      run: async (ctx) => {
+        await ctx.prove("The upgraded branch desktop reuses the installed organization URL", {
+          voiceover: vo[2],
+          action: async () => {
+            const startedAt = Date.now();
+            let installedReady = false;
+            while (Date.now() - startedAt < 180_000) {
+              const installed = await windowsExec(ctx, "check installed desktop", `
+if (Test-Path -LiteralPath '${INSTALLED_DESKTOP_DIR}\\OpenWork.exe') { Write-Output 'installed' } else { Write-Output 'missing' }
+`);
+              if (installed.includes("installed")) {
+                installedReady = true;
+                break;
+              }
+              await sleep(2_000);
+            }
+            ctx.assert(installedReady, "The Windows installer did not restore the packaged desktop within 180 seconds.");
+            await sleep(5_000);
+            await stopOpenWork(ctx);
+            await launchBranchApp(ctx);
+            await showAdvancedServer(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("From bootstrap file");
+            await ctx.expectText(ORG_URL);
+            await ctx.expectNoText(HOSTED_URL);
+            await assertOrganizationBootstrap(ctx, "after upgrade launch");
+          },
+          screenshot: computerUseScreenshot("upgraded-app-reuses-organization-url", {
+            requireText: ["Server endpoints", "From bootstrap file", ORG_URL],
+            rejectText: [HOSTED_URL],
+          }),
+        });
+      },
+    },
+    {
+      name: "Frame 4 — full app restart persists organization URL",
+      run: async (ctx) => {
+        await ctx.prove("A full app relaunch keeps the organization bootstrap", {
+          voiceover: vo[3],
+          action: async () => {
+            try {
+              await ctx.eval("window.__OPENWORK_ELECTRON__.shell.relaunch()", { awaitPromise: true });
+            } catch (error) {
+              ctx.log(`Expected relaunch disconnect: ${error instanceof Error ? error.message : String(error)}`);
+            }
+            await sleep(1_000);
+            await ctx.reconnect({ timeoutMs: 120_000 });
+            await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__)", { timeoutMs: 60_000, label: "Electron bridge after restart" });
+            await showBootstrapDebug(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("Bootstrap config");
+            await ctx.expectText(ORG_URL);
+            await assertOrganizationBootstrap(ctx, "after full restart");
+          },
+          screenshot: computerUseScreenshot("organization-url-after-full-restart", {
+            requireText: ["Bootstrap config", ORG_URL],
+          }),
+        });
+      },
+    },
+    {
+      name: "Frame 5 — legacy update path preserves organization URL",
+      run: async (ctx) => {
+        await ctx.prove("The legacy Windows bootstrap path outranks a newer hosted download bundle", {
+          voiceover: vo[4],
+          action: async () => {
+            await stopOpenWork(ctx);
+            await prepareLegacyUpgradeState(ctx);
+            await launchBranchApp(ctx);
+            await showAdvancedServer(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("From bootstrap file");
+            await ctx.expectText(ORG_URL);
+            await ctx.expectNoText(HOSTED_URL);
+            await assertOrganizationBootstrap(ctx, "after legacy-path upgrade");
+          },
+          screenshot: computerUseScreenshot("legacy-upgrade-path-keeps-organization-url", {
+            requireText: ["Organization server", "From bootstrap file", ORG_URL],
+            rejectText: [HOSTED_URL],
+          }),
+        });
+      },
+    },
+    {
+      name: "Frame 6 — air-gapped restart keeps organization URL",
+      run: async (ctx) => {
+        await ctx.prove("An offline Windows restart keeps the organization bootstrap without cloud replacement", {
+          voiceover: vo[5],
+          action: async () => {
+            await stopOpenWork(ctx);
+            const appPath = windowsAppPath(ctx).replaceAll("'", "''");
+            await windowsExec(ctx, "block desktop outbound network", `
+Remove-NetFirewallRule -DisplayName '${FIREWALL_RULE}' -ErrorAction SilentlyContinue
+New-NetFirewallRule -DisplayName '${FIREWALL_RULE}' -Direction Outbound -Program '${appPath}' -Action Block -Profile Any | Out-Null
+Write-Output 'outbound network blocked for branch desktop'
+`);
+            await launchBranchApp(ctx);
+            await showBootstrapDebug(ctx);
+          },
+          assert: async () => {
+            const firewall = await windowsExec(ctx, "verify outbound firewall rule", `
+$rule = Get-NetFirewallRule -DisplayName '${FIREWALL_RULE}' -ErrorAction Stop
+Write-Output $rule.Enabled
+Write-Output $rule.Action
+`);
+            ctx.assert(firewall.includes("True") && firewall.includes("Block"), `Expected active outbound block rule, got ${firewall}`);
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Windows Firewall blocks outbound traffic for the tested OpenWork executable", actual: firewall.trim() });
+            await ctx.expectText("Bootstrap config");
+            await ctx.expectText(ORG_URL);
+            await assertOrganizationBootstrap(ctx, "during air-gapped restart");
+          },
+          screenshot: computerUseScreenshot("air-gapped-restart-keeps-organization-url", {
+            requireText: ["Bootstrap config", ORG_URL],
+          }),
+        });
+      },
+    },
+    {
+      name: "Cleanup Windows firewall rule",
+      run: async (ctx) => {
+        await windowsExec(ctx, "remove eval firewall rule", `
+Remove-NetFirewallRule -DisplayName '${FIREWALL_RULE}' -ErrorAction SilentlyContinue
+Write-Output 'eval firewall rule removed'
+`);
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/desktop-upgrade-preserves-server-url.md
+++ b/evals/voiceovers/desktop-upgrade-preserves-server-url.md
@@ -1,0 +1,15 @@
+# desktop-upgrade-preserves-server-url — Desktop upgrades preserve the organization server
+
+The Daytona end-to-end evidence uses the fictional organization “Example Manufacturing” and contains no customer names or server details.
+
+1. This Windows desktop installation is connected to Example Manufacturing’s on-prem OpenWork server, and its organization URL is recorded in the desktop-bootstrap configuration.
+
+2. I install the latest desktop version over the existing installation, following the same upgrade path that previously caused the app to lose its server.
+
+3. When OpenWork launches after the upgrade, it reconnects to the configured on-prem server—not a stale, default, or cloud URL.
+
+4. I fully quit and restart the desktop app, and the organization server remains selected, proving the configuration persists beyond the first upgraded launch.
+
+5. I repeat the flow through the alternate reinstall/update path, matching the two reported outcomes, and the desktop-bootstrap URL still takes precedence.
+
+6. Finally, with cloud access unavailable, OpenWork continues using the on-prem URL without attempting to replace it, preserving support for air-gapped deployments.


### PR DESCRIPTION
## Summary

- preserve a valid organization or on-prem desktop-bootstrap URL when newer hosted defaults appear during Windows upgrade, reinstall, or bundle import
- migrate the legacy Windows bootstrap path to LOCALAPPDATA without allowing a hosted canonical file to win by timestamp
- make the organization installer retain the installed deployment URL while preserving prepared and claim-link state and removing one-time handoff grants
- add focused canonical, legacy, bundle, malformed-config, repeated-restart, and Windows installer regression coverage

## Root cause

The Windows bootstrap path moved from the legacy user config directory to LOCALAPPDATA. Selection then used newest-wins semantics, and the organization installer only read the canonical path before stamping its incoming hosted values and deleting the legacy file. That made legacy organization installs vulnerable to a newer hosted canonical file or bundled config, while already-canonical installs usually stayed correct.

## Validation

- pnpm --dir apps/desktop exec node --test electron/workspace-store.test.mjs — 16 passed
- pnpm --dir packages/install-config build && pnpm --dir apps/installer test — 27 passed
- pnpm --dir apps/desktop test — 56 passed, 1 platform skip
- pnpm --dir apps/desktop run check:electron — 53 methods validated
- pnpm --dir apps/desktop run typecheck:electron — passed
- git diff --check — passed
- Daytona Windows fraimz desktop-upgrade-preserves-server-url — 6 frames passed, including a real standard installer reinstall, full restart, legacy migration, and outbound-blocked air-gapped restart

All organization names and URLs in tests and evidence use the fictional Example Manufacturing deployment. No install-page UI work is included.