### PR TITLE
fix(den): enable on-prem workspace downloads by default

### DIFF
--- a/ee/apps/den-api/src/install-links.ts
+++ b/ee/apps/den-api/src/install-links.ts
@@ -28,7 +28,7 @@ function installPageUrl(token: string) {
 }
 
 export async function mintOrganizationInstallLink(input: MintOrganizationInstallLinkInput) {
-  if (!organizationHasCapability(input.metadata, "installLinks")) {
+  if (!organizationHasCapability(input.metadata, "installLinks", { installLinks: env.orgMode === "single_org" })) {
     return null
   }
 

--- a/ee/apps/den-api/src/organization-capabilities.ts
+++ b/ee/apps/den-api/src/organization-capabilities.ts
@@ -4,9 +4,9 @@ import { z } from "zod"
  * Per-organization capability flags ("org capabilities").
  *
  * Capabilities let platform admins enable shipped-but-dark features
- * org-by-org from the /admin backoffice. Every capability defaults to OFF
- * for every organization; only an explicit `true` in the organization's
- * metadata JSON (`metadata.capabilities.<key>`) turns one on.
+ * org-by-org from the /admin backoffice. Callers may provide deployment-level
+ * defaults for capabilities that should work out of the box when self-hosted;
+ * an explicit organization value always wins.
  *
  * Storage rides the existing organization metadata JSON column — the same
  * home as `limits`, `plan`, and `requireSso` — so no schema change is needed.
@@ -43,17 +43,24 @@ function parseMetadata(input: MetadataInput): Record<string, unknown> {
 }
 
 /** Every capability key resolved to a boolean, defaulting to false. */
-export function normalizeOrganizationCapabilities(metadata: MetadataInput): OrganizationCapabilities {
+export function normalizeOrganizationCapabilities(
+  metadata: MetadataInput,
+  defaults: Partial<OrganizationCapabilities> = {},
+): OrganizationCapabilities {
   const parsed = parseMetadata(metadata)
   const raw = isRecord(parsed.capabilities) ? parsed.capabilities : {}
 
   return {
-    installLinks: raw.installLinks === true,
-    mcpConnections: raw.mcpConnections === true,
+    installLinks: raw.installLinks === undefined ? defaults.installLinks === true : raw.installLinks === true,
+    mcpConnections: raw.mcpConnections === undefined ? defaults.mcpConnections === true : raw.mcpConnections === true,
   }
 }
 
-/** Whether the organization has an explicit opt-in for the capability. */
-export function organizationHasCapability(metadata: MetadataInput, key: OrganizationCapabilityKey): boolean {
-  return normalizeOrganizationCapabilities(metadata)[key]
+/** Resolve a capability after applying any deployment-level defaults. */
+export function organizationHasCapability(
+  metadata: MetadataInput,
+  key: OrganizationCapabilityKey,
+  defaults?: Partial<OrganizationCapabilities>,
+): boolean {
+  return normalizeOrganizationCapabilities(metadata, defaults)[key]
 }

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -487,7 +487,9 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
     async (c) => {
       const payload = c.get("organizationContext")
       const owner = payload.members.find((member: typeof payload.members[number]) => member.isOwner) ?? null
-      const capabilities = normalizeOrganizationCapabilities(payload.organization.metadata)
+      const capabilities = normalizeOrganizationCapabilities(payload.organization.metadata, {
+        installLinks: env.orgMode === "single_org",
+      })
       const [ssoRows, scimRows] = await Promise.all([
         db
           .select({ id: SsoConnectionTable.id })

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -278,9 +278,9 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
       const input = c.req.valid("json")
       const payload = c.get("organizationContext")
 
-      // Org capability gate: install links ship dark and are enabled
-      // org-by-org from the platform /admin backoffice.
-      if (!organizationHasCapability(payload.organization.metadata, "installLinks")) {
+      // Hosted organizations retain the explicit rollout gate. Single-org
+      // deployments get the supported download path without database setup.
+      if (!organizationHasCapability(payload.organization.metadata, "installLinks", { installLinks: env.orgMode === "single_org" })) {
         return c.json({ error: "capability_disabled", capability: "installLinks" }, 403)
       }
 

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -217,6 +217,17 @@ test("the organization capability still gates member install links", async () =>
   expect(insertedInstallLinks()).toHaveLength(0)
 })
 
+test("single-org members can mint install links without stored capability metadata", async () => {
+  const installLink = await installLinkMintingModule.mintOrganizationInstallLink({
+    organizationId,
+    createdByUserId: userId,
+    metadata: {},
+  })
+
+  expect(installLink?.installPageUrl).toContain("/install?token=")
+  expect(insertedInstallLinks()).toHaveLength(1)
+})
+
 test("invitation downloads mint the same org install page without storing the raw token", async () => {
   const downloadUrl = await installLinkMintingModule.resolveInvitationDownloadUrl({
     organizationId,

--- a/ee/apps/den-api/test/organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/organization-capabilities.test.ts
@@ -20,6 +20,15 @@ describe("normalizeOrganizationCapabilities", () => {
     expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: false, mcpConnections: false } })).toEqual(defaultCapabilities)
   })
 
+  test("applies deployment defaults only when an organization has no explicit value", () => {
+    const selfHostedDefaults = { installLinks: true }
+
+    expect(normalizeOrganizationCapabilities(null, selfHostedDefaults)).toEqual({ installLinks: true, mcpConnections: false })
+    expect(normalizeOrganizationCapabilities({ capabilities: {} }, selfHostedDefaults)).toEqual({ installLinks: true, mcpConnections: false })
+    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: false } }, selfHostedDefaults)).toEqual(defaultCapabilities)
+    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: "true" } }, selfHostedDefaults)).toEqual(defaultCapabilities)
+  })
+
   test("reads an explicit opt-in from JSON string metadata", () => {
     expect(normalizeOrganizationCapabilities(JSON.stringify({ capabilities: { installLinks: true, mcpConnections: true } }))).toEqual({ installLinks: true, mcpConnections: true })
   })
@@ -52,5 +61,11 @@ describe("organizationHasCapability", () => {
     expect(organizationHasCapability({ capabilities: { mcpConnections: true } }, "mcpConnections")).toBe(true)
     expect(organizationHasCapability(JSON.stringify({ capabilities: { installLinks: true } }), "installLinks")).toBe(true)
     expect(organizationHasCapability(JSON.stringify({ capabilities: { mcpConnections: true } }), "mcpConnections")).toBe(true)
+  })
+
+  test("supports an on-prem default without changing the hosted default", () => {
+    expect(organizationHasCapability(null, "installLinks", { installLinks: true })).toBe(true)
+    expect(organizationHasCapability(null, "installLinks")).toBe(false)
+    expect(organizationHasCapability({ capabilities: { installLinks: false } }, "installLinks", { installLinks: true })).toBe(false)
   })
 })

--- a/evals/flows/on-prem-install-links-default.flow.mjs
+++ b/evals/flows/on-prem-install-links-default.flow.mjs
@@ -20,7 +20,7 @@ function withApprovedProof(ctx, index, claim) {
 async function clickText(ctx, text) {
   const clicked = await ctx.eval(`(() => {
     const element = [...document.querySelectorAll('button, a')]
-      .find((candidate) => candidate.textContent?.trim() === ${JSON.stringify(text)});
+      .find((candidate) => candidate.textContent?.trim().startsWith(${JSON.stringify(text)}));
     element?.click();
     return Boolean(element);
   })()`);

--- a/evals/flows/on-prem-install-links-default.flow.mjs
+++ b/evals/flows/on-prem-install-links-default.flow.mjs
@@ -1,0 +1,106 @@
+import { execFileSync } from "node:child_process";
+import baseFlow, { orgAwareDashboardDownloadsHarness as harness } from "./org-aware-dashboard-downloads.flow.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "on-prem-install-links-default";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function withApprovedProof(ctx, index, claim) {
+  return new Proxy(ctx, {
+    get(target, property) {
+      if (property === "prove") {
+        return (_baseClaim, options) => target.prove(claim, { ...options, voiceover: vo[index] });
+      }
+      const value = Reflect.get(target, property);
+      return typeof value === "function" ? value.bind(target) : value;
+    },
+  });
+}
+
+async function clickText(ctx, text) {
+  const clicked = await ctx.eval(`(() => {
+    const element = [...document.querySelectorAll('button, a')]
+      .find((candidate) => candidate.textContent?.trim() === ${JSON.stringify(text)});
+    element?.click();
+    return Boolean(element);
+  })()`);
+  ctx.assert(clicked === true, `Could not click ${text}.`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Self-deployed organizations get workspace downloads by default while hosted controls stay explicit",
+  kind: "user-facing",
+  requiredEnv: baseFlow.requiredEnv,
+  steps: [
+    {
+      name: "Frame 1",
+      run: (ctx) => baseFlow.steps[0].run(withApprovedProof(
+        ctx,
+        0,
+        "A fresh single-org deployment shows the organization download without a stored capability opt-in",
+      )),
+    },
+    {
+      name: "Frame 2",
+      run: (ctx) => baseFlow.steps[1].run(withApprovedProof(
+        ctx,
+        1,
+        "The default download opens the organization's configured install page and still requires sign-in",
+      )),
+    },
+    {
+      name: "Frame 3",
+      run: (ctx) => baseFlow.steps[2].run(withApprovedProof(
+        ctx,
+        2,
+        "An ordinary member gets the download while privileged link rotation remains forbidden",
+      )),
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Hosted multi-org capability controls remain off until explicitly enabled", {
+          voiceover: vo[3],
+          action: async () => {
+            await harness.uiSignIn(ctx, harness.ADMIN_EMAIL, harness.ADMIN_PASSWORD);
+            await harness.navigateTo(ctx, `${harness.DEN_WEB_URL}/admin`);
+            await ctx.waitForText("User backoffice", { timeoutMs: 30_000 });
+            await clickText(ctx, "Organizations");
+            await ctx.waitForText("Install links", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const raw = await harness.denApiFetch(
+              `/v1/admin/organizations/${harness.state.organizationId}/capabilities`,
+              { headers: harness.authHeaders(harness.state.adminToken) },
+            );
+            ctx.assert(raw.response.ok, `Could not read stored capabilities (${raw.response.status}).`);
+            ctx.assert(raw.body?.capabilities?.installLinks === false, "Hosted-facing stored capability unexpectedly defaulted on.");
+
+            const checkbox = await ctx.eval(`(() => {
+              const row = [...document.querySelectorAll('[data-testid^="admin-org-row-"]')]
+                .find((candidate) => candidate.textContent?.includes(${JSON.stringify(harness.ORGANIZATION_NAME)}));
+              return row?.querySelector('[data-testid="admin-capability-installLinks"]')?.checked;
+            })()`);
+            ctx.assert(checkbox === false, "The platform-admin install-links control was not visibly off.");
+
+            const testOutput = execFileSync("pnpm", [
+              "exec",
+              "bun",
+              "test",
+              "ee/apps/den-api/test/organization-capabilities.test.ts",
+              "--test-name-pattern",
+              "supports an on-prem default without changing the hosted default",
+            ], { encoding: "utf8" });
+            ctx.output("hosted-capability-regression", testOutput);
+            await ctx.expectText("Install links");
+          },
+          screenshot: {
+            name: "hosted-install-links-control-off",
+            requireText: ["User backoffice", harness.ORGANIZATION_NAME, "Install links"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/on-prem-install-links-default.flow.mjs
+++ b/evals/flows/on-prem-install-links-default.flow.mjs
@@ -68,6 +68,12 @@ export default {
             await ctx.waitForText("User backoffice", { timeoutMs: 30_000 });
             await clickText(ctx, "Organizations");
             await ctx.waitForText("Install links", { timeoutMs: 30_000 });
+            await ctx.eval(`(() => {
+              const row = [...document.querySelectorAll('[data-testid^="admin-org-row-"]')]
+                .find((candidate) => candidate.textContent?.includes(${JSON.stringify(harness.ORGANIZATION_NAME)}));
+              row?.scrollIntoView({ block: 'center' });
+              return Boolean(row);
+            })()`);
           },
           assert: async () => {
             const raw = await harness.denApiFetch(

--- a/evals/flows/org-aware-dashboard-downloads.flow.mjs
+++ b/evals/flows/org-aware-dashboard-downloads.flow.mjs
@@ -191,16 +191,29 @@ async function clearBrowserSession(ctx) {
 
 async function uiSignIn(ctx, email, password) {
   await clearBrowserSession(ctx);
-  await ctx.waitFor("document.body.innerText.includes('Sign in')", { timeoutMs: 30_000, label: "Den sign-in screen" });
-  await ctx.eval(`(() => {
-    const tab = [...document.querySelectorAll('button, a')].find((element) => element.textContent?.trim() === 'Sign in');
-    tab?.click();
-    return true;
-  })()`);
-  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]'))", {
-    timeoutMs: 15_000,
-    label: "email input",
+  await ctx.waitFor("document.body.innerText.includes('Continue to OpenWork') || document.body.innerText.includes('Sign in')", {
+    timeoutMs: 30_000,
+    label: "Den sign-in screen",
   });
+  const emailFirst = await ctx.eval("document.body.innerText.includes('Continue to OpenWork')");
+  if (emailFirst) {
+    await ctx.fill('input[type="email"], input[name="email"]', email);
+    await ctx.clickText("Next");
+    await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", {
+      timeoutMs: 15_000,
+      label: "email-first password input",
+    });
+  } else {
+    await ctx.eval(`(() => {
+      const tab = [...document.querySelectorAll('button, a')].find((element) => element.textContent?.trim() === 'Sign in');
+      tab?.click();
+      return true;
+    })()`);
+    await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]'))", {
+      timeoutMs: 15_000,
+      label: "email input",
+    });
+  }
   const submitted = await ctx.eval(`(() => {
     const setValue = (element, value) => {
       const descriptor = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'value');
@@ -210,8 +223,8 @@ async function uiSignIn(ctx, email, password) {
     };
     const emailInput = document.querySelector('input[type="email"], input[name="email"]');
     const passwordInput = document.querySelector('input[type="password"]');
-    if (!emailInput || !passwordInput) return false;
-    setValue(emailInput, ${JSON.stringify(email)});
+    if (!passwordInput || (!emailInput && !${JSON.stringify(emailFirst)})) return false;
+    if (emailInput) setValue(emailInput, ${JSON.stringify(email)});
     setValue(passwordInput, ${JSON.stringify(password)});
     const buttons = [...document.querySelectorAll('button')]
       .filter((button) => button.textContent?.trim() === 'Sign in' && !button.disabled);

--- a/evals/flows/org-aware-dashboard-downloads.flow.mjs
+++ b/evals/flows/org-aware-dashboard-downloads.flow.mjs
@@ -3,7 +3,8 @@
  *
  * Run this against a single-org Den sandbox configured as Acme Robotics with:
  * - alex@acme.test in DEN_SINGLE_ORG_OWNER_EMAILS and DEN_BOOTSTRAP_ADMIN_EMAILS
- * - installLinks enabled by this flow through the platform-admin API
+ * - installLinks absent from stored organization capabilities, exercising the
+ *   single-org deployment default
  * - a generic win-x64 installer available through OPENWORK_INSTALLER_ARTIFACTS_DIR
  *
  * Riley is created through ordinary sign-up and single-org membership
@@ -125,17 +126,16 @@ async function ensureSetup(ctx) {
   witness(ctx, typeof org.body?.organization?.id === "string", "Acme exposes an organization id", org.body?.organization);
   state.organizationId = org.body.organization.id;
 
-  const capability = await denApiFetch(`/v1/admin/organizations/${state.organizationId}/capabilities`, {
-    method: "PUT",
+  const storedCapabilities = await denApiFetch(`/v1/admin/organizations/${state.organizationId}/capabilities`, {
     headers: authHeaders(state.adminToken),
-    body: JSON.stringify({ capabilities: { installLinks: true } }),
   });
   witness(
     ctx,
-    capability.response.ok,
-    "Alex is allowlisted as a platform admin and enables Acme install links",
-    { status: capability.response.status, body: capability.body },
+    storedCapabilities.response.ok && storedCapabilities.body?.capabilities?.installLinks === false,
+    "Acme has no stored install-links opt-in",
+    { status: storedCapabilities.response.status, body: storedCapabilities.body },
   );
+  witness(ctx, org.body?.capabilities?.installLinks === true, "Single-org Den enables install links by deployment default", org.body?.capabilities);
 
   state.memberToken = await ensureAccount(ctx, {
     email: MEMBER_EMAIL,
@@ -160,6 +160,22 @@ async function ensureSetup(ctx) {
     memberProvisioning: "single-org sign-up; no invitation endpoint",
   }, null, 2));
 }
+
+export const orgAwareDashboardDownloadsHarness = {
+  ADMIN_EMAIL,
+  ADMIN_PASSWORD,
+  DEN_API_URL,
+  DEN_WEB_URL,
+  MEMBER_EMAIL,
+  MEMBER_PASSWORD,
+  ORGANIZATION_NAME,
+  authHeaders,
+  denApiFetch,
+  ensureSetup,
+  navigateTo,
+  state,
+  uiSignIn,
+};
 
 async function navigateTo(ctx, url) {
   await ctx.eval(`location.assign(${JSON.stringify(url)}); true`);

--- a/evals/flows/org-aware-dashboard-downloads.flow.mjs
+++ b/evals/flows/org-aware-dashboard-downloads.flow.mjs
@@ -304,6 +304,7 @@ export default {
             await uiSignIn(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
             await navigateTo(ctx, `${DEN_WEB_URL}/dashboard`);
             await ctx.waitForText(`Download OpenWork for ${ORGANIZATION_NAME}`, { timeoutMs: 30_000 });
+            await ctx.eval("document.querySelector('[data-testid=\"organization-download-card\"]')?.scrollIntoView({ block: 'center' }); true");
           },
           assert: async () => {
             await ctx.expectText(`Download OpenWork for ${ORGANIZATION_NAME}`);
@@ -364,6 +365,7 @@ export default {
             await navigateTo(ctx, `${DEN_WEB_URL}/dashboard`);
             await ctx.waitForText("WORKSPACE MEMBER", { timeoutMs: 30_000 });
             await ctx.waitForText("Download for this workspace", { timeoutMs: 30_000 });
+            await ctx.eval("document.querySelector('[data-testid=\"organization-download-card\"]')?.scrollIntoView({ block: 'center' }); true");
           },
           assert: async () => {
             await ctx.expectText(`Download OpenWork for ${ORGANIZATION_NAME}`);

--- a/evals/voiceovers/on-prem-install-links-default.md
+++ b/evals/voiceovers/on-prem-install-links-default.md
@@ -1,0 +1,9 @@
+# on-prem-install-links-default — On-prem downloads work without database setup
+
+1. Alex opens a newly deployed on-prem OpenWork dashboard and immediately sees “Download OpenWork for Acme,” without enabling a feature flag or editing the database.
+
+2. Alex chooses “Download for this workspace” and reaches Acme’s configured install page, where required sign-in is clearly stated.
+
+3. Riley, an ordinary Acme member, sees the same supported download action, while administrative rotation controls remain restricted.
+
+4. In a hosted multi-organization deployment, an organization without the install-links capability still does not receive the organization download experience.


### PR DESCRIPTION
## Summary
- default organization install links on for single-org/self-deployed Den instances when no org override exists
- preserve explicit false overrides and the existing multi-org hosted rollout gate
- keep membership, rotation, token, and rate-limit authorization boundaries unchanged
- add regression coverage and an approved Daytona fraimz journey

## Validation
- `pnpm exec bun test ee/apps/den-api/test/organization-capabilities.test.ts ee/apps/den-api/test/install-link-access.test.ts` — 19 passed
- `pnpm --filter @openwork-ee/den-api build` — passed
- Daytona `on-prem-install-links-default` fraimz — 4 frames passed; raw capability off while effective single-org capability is on

## Evidence
- Admin and ordinary-member dashboards visibly offer the Acme-configured download without setting the capability
- Install page resolves the opaque token and requires normal sign-in
- Member link rotation remains forbidden
- Platform-admin hosted capability control remains visibly off by default
