### PR TITLE
Fix Den sidebar organization icon

### DIFF
--- a/ee/apps/den-web/app/(den)/_lib/den-org.brand-icon.test.mts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.brand-icon.test.mts
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import { getManagedBrandIconUrl } from "./den-org.ts";
+
+const managedIconUrl = "https://den.example.test/v1/brand-assets/org_acme/icon/version.png";
+const managedIcon = {
+  kind: "icon",
+  version: "version",
+  extension: "png",
+  contentType: "image/png",
+  url: managedIconUrl,
+  width: 256,
+  height: 256,
+  byteLength: 1024,
+  originalName: "acme.png",
+  uploadedAt: "2026-07-10T00:00:00.000Z",
+};
+
+assert.equal(
+  getManagedBrandIconUrl(JSON.stringify({
+    brandIconUrl: "https://legacy.example.test/icon.png",
+    brandIconAsset: managedIcon,
+  })),
+  managedIconUrl,
+);
+assert.equal(
+  getManagedBrandIconUrl(JSON.stringify({
+    brandIconUrl: "https://legacy.example.test/icon.png",
+  })),
+  null,
+);
+assert.equal(getManagedBrandIconUrl(null), null);
+assert.equal(getManagedBrandIconUrl("not-json"), null);
+
+console.log("ok: Den sidebar resolves only the canonical managed square icon");

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -342,6 +342,10 @@ export function getManagedBrandAssetFromMetadata(
   };
 }
 
+export function getManagedBrandIconUrl(metadata: string | null): string | null {
+  return getManagedBrandAssetFromMetadata(metadata, "icon")?.url ?? null;
+}
+
 function parsePermissionRecord(value: unknown): Record<string, string[]> {
   if (!isRecord(value)) {
     return {};

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -34,6 +34,7 @@ import {
   getIntegrationsRoute,
   getInferenceRoute,
   getMcpConnectionsRoute,
+  getManagedBrandIconUrl,
   getMembersRoute,
   getYourConnectionsRoute,
   getOrgDashboardRoute,
@@ -117,6 +118,51 @@ function OpenWorkMark({ className = "h-9 w-auto" }: { className?: string }) {
         d="M443.216 29.48C452.02 29.0815 460.018 30.0261 467.903 34.1434C489.625 45.4892 510.693 58.4477 532.373 69.8693C514.905 78.2946 493.564 90.995 476.372 100.542L386.895 149.628C376.357 155.498 365.774 161.287 355.148 166.992C337.373 176.588 322.776 183.695 307.595 197.464C287.772 215.608 273.675 239.14 267.014 265.17C262.116 284.284 262.909 298.302 262.917 317.836L262.939 357.47L262.926 471.524L262.961 530.447C262.98 532.198 263.562 543.941 263.164 544.751L262.58 544.549L215.582 518.061C189.232 503.261 169.189 495.747 169.845 460.795C170.068 448.934 169.804 435.617 169.812 423.605L169.831 344.391L169.818 269.769C169.814 254.383 168.977 231.859 171.873 217.311C175.825 198.048 184.641 180.127 197.478 165.236C204.056 157.596 211.686 150.929 220.143 145.432C231.916 137.708 249.246 128.979 262.061 121.995L328.787 85.3185L391.28 50.97C401.594 45.3095 412 39.3027 422.528 34.3441C428.812 31.3849 436.148 30.2484 443.216 29.48Z"
       />
     </svg>
+  );
+}
+
+export function SidebarBrandMark({
+  metadata,
+  organizationName,
+}: {
+  metadata: string | null | undefined;
+  organizationName: string;
+}) {
+  const [loadedUrl, setLoadedUrl] = useState<string | null>(null);
+  const [failedUrl, setFailedUrl] = useState<string | null>(null);
+
+  if (metadata === undefined) {
+    return (
+      <div
+        className="h-10 w-10 rounded-xl bg-gray-100"
+        aria-label="Loading organization icon"
+        data-sidebar-brand-icon="loading"
+      />
+    );
+  }
+
+  const iconUrl = getManagedBrandIconUrl(metadata);
+  if (!iconUrl || failedUrl === iconUrl) {
+    return (
+      <div data-sidebar-brand-icon="fallback">
+        <OpenWorkMark />
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="h-10 w-10 overflow-hidden rounded-xl bg-gray-100"
+      data-sidebar-brand-icon={loadedUrl === iconUrl ? "ready" : "loading"}
+    >
+      <img
+        src={iconUrl}
+        alt={`${organizationName} icon`}
+        className={`h-full w-full object-cover transition-opacity ${loadedUrl === iconUrl ? "opacity-100" : "opacity-0"}`}
+        onLoad={() => setLoadedUrl(iconUrl)}
+        onError={() => setFailedUrl(iconUrl)}
+      />
+    </div>
   );
 }
 
@@ -474,7 +520,10 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     <div className="flex flex-1 flex-col">
       <div className="border-b border-gray-100 px-4 pb-4 pt-5">
         <div className="flex items-center justify-between gap-3">
-          <OpenWorkMark />
+          <SidebarBrandMark
+            metadata={orgContext?.organization.metadata}
+            organizationName={activeOrg?.name ?? runtimeConfig.singleOrgName}
+          />
           <button
             type="button"
             className="rounded-lg p-1.5 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-700 md:hidden"

--- a/ee/apps/den-web/tests/org-dashboard-sidebar-brand-icon.test.tsx
+++ b/ee/apps/den-web/tests/org-dashboard-sidebar-brand-icon.test.tsx
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { SidebarBrandMark } from "../app/(den)/dashboard/_components/org-dashboard-shell";
+
+const managedIconUrl = "https://den.example.test/v1/brand-assets/org_acme/icon/version.png";
+const managedIconMetadata = JSON.stringify({
+  brandIconAsset: {
+    kind: "icon",
+    version: "version",
+    extension: "png",
+    contentType: "image/png",
+    url: managedIconUrl,
+    width: 256,
+    height: 256,
+    byteLength: 1024,
+    originalName: "acme.png",
+    uploadedAt: "2026-07-10T00:00:00.000Z",
+  },
+});
+
+describe("Den dashboard sidebar brand icon", () => {
+  test("holds a neutral square while organization branding loads", () => {
+    const markup = renderToStaticMarkup(
+      <SidebarBrandMark metadata={undefined} organizationName="Acme" />,
+    );
+
+    expect(markup).toContain('data-sidebar-brand-icon="loading"');
+    expect(markup).not.toContain("<img");
+    expect(markup).not.toContain("<svg");
+  });
+
+  test("renders the canonical managed square icon without first rendering the OpenWork mark", () => {
+    const markup = renderToStaticMarkup(
+      <SidebarBrandMark metadata={managedIconMetadata} organizationName="Acme" />,
+    );
+
+    expect(markup).toContain(`src="${managedIconUrl}"`);
+    expect(markup).toContain('alt="Acme icon"');
+    expect(markup).toContain('data-sidebar-brand-icon="loading"');
+    expect(markup).toContain("opacity-0");
+    expect(markup).not.toContain("<svg");
+  });
+
+  test("uses the OpenWork mark when no managed square icon exists", () => {
+    const markup = renderToStaticMarkup(
+      <SidebarBrandMark metadata={null} organizationName="Acme" />,
+    );
+
+    expect(markup).toContain("<svg");
+    expect(markup).toContain('aria-label="OpenWork"');
+    expect(markup).toContain('data-sidebar-brand-icon="fallback"');
+    expect(markup).not.toContain("<img");
+  });
+});

--- a/evals/flows/den-sidebar-brand-icon.flow.mjs
+++ b/evals/flows/den-sidebar-brand-icon.flow.mjs
@@ -1,4 +1,3 @@
-import sharp from "sharp";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
 const vo = await loadVoiceoverParagraphs("den-sidebar-brand-icon");
@@ -34,22 +33,37 @@ async function signInApi(ctx) {
 }
 
 async function uploadManagedIcon(ctx) {
-  const png = await sharp({
-    create: { width: 128, height: 128, channels: 4, background: "#0f766e" },
-  })
-    .composite([
-      {
-        input: Buffer.from('<svg width="128" height="128"><circle cx="64" cy="64" r="38" fill="#ccfbf1"/><path d="M43 65l14 14 30-34" fill="none" stroke="#0f766e" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/></svg>'),
-      },
-    ])
-    .png()
-    .toBuffer();
-  const form = new FormData();
-  form.set("icon", new Blob([png], { type: "image/png" }), "den-sidebar-icon.png");
-  const { response, body } = await apiRequest("/v1/org/brand-assets", { method: "POST", body: form });
-  ctx.assert(response.ok, `Managed icon upload failed: ${response.status} ${JSON.stringify(body)}`);
-  state.iconUrl = body.assets?.icon?.url ?? null;
-  ctx.assert(typeof state.iconUrl === "string", `Upload did not return a managed icon: ${JSON.stringify(body)}`);
+  const result = await ctx.eval(`new Promise((resolve) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 128;
+    canvas.height = 128;
+    const context = canvas.getContext('2d');
+    context.fillStyle = '#0f766e';
+    context.fillRect(0, 0, 128, 128);
+    context.fillStyle = '#ccfbf1';
+    context.beginPath();
+    context.arc(64, 64, 38, 0, Math.PI * 2);
+    context.fill();
+    context.strokeStyle = '#0f766e';
+    context.lineWidth = 10;
+    context.lineCap = 'round';
+    context.lineJoin = 'round';
+    context.beginPath();
+    context.moveTo(43, 65);
+    context.lineTo(57, 79);
+    context.lineTo(87, 45);
+    context.stroke();
+    canvas.toBlob(async (blob) => {
+      if (!blob) return resolve({ status: 0, body: { error: 'canvas_blob_failed' } });
+      const form = new FormData();
+      form.set('icon', blob, 'den-sidebar-icon.png');
+      const response = await fetch('/api/den/v1/org/brand-assets', { method: 'POST', body: form });
+      resolve({ status: response.status, body: await response.json() });
+    }, 'image/png');
+  })`, { awaitPromise: true });
+  ctx.assert(result.status === 200, `Managed icon upload failed: ${result.status} ${JSON.stringify(result.body)}`);
+  state.iconUrl = result.body.assets?.icon?.url ?? null;
+  ctx.assert(typeof state.iconUrl === "string", `Upload did not return a managed icon: ${JSON.stringify(result.body)}`);
 }
 
 async function clearManagedIcon(ctx) {
@@ -116,8 +130,8 @@ export default {
       run: async (ctx) => {
         await signInApi(ctx);
         await clearManagedIcon(ctx);
-        await uploadManagedIcon(ctx);
         await enterDashboard(ctx);
+        await uploadManagedIcon(ctx);
       },
     },
     {

--- a/evals/flows/den-sidebar-brand-icon.flow.mjs
+++ b/evals/flows/den-sidebar-brand-icon.flow.mjs
@@ -83,12 +83,9 @@ async function enterDashboard(ctx) {
   );
   await ctx.eval(`location.assign(${JSON.stringify(DEN_WEB_URL)})`);
   await ctx.waitFor('Boolean(document.querySelector(\'input[type="email"]\'))', { timeoutMs: 30_000, label: "sign-in form" });
-  await ctx.eval(`(() => {
-    const tab = [...document.querySelectorAll('button')].find((button) => (button.textContent ?? '').trim() === 'Sign in');
-    tab?.click();
-    return true;
-  })()`);
   await ctx.fill('input[type="email"]', ADMIN_EMAIL);
+  await ctx.eval(`(() => { document.querySelector('button[type="submit"]')?.click(); return true; })()`);
+  await ctx.waitFor('Boolean(document.querySelector(\'input[type="password"]\'))', { timeoutMs: 30_000, label: "password step" });
   await ctx.fill('input[type="password"]', ADMIN_PASSWORD);
   await ctx.eval(`(() => { document.querySelector('button[type="submit"]')?.click(); return true; })()`);
   await ctx.waitFor(`(() => {
@@ -181,7 +178,7 @@ export default {
               uploadThroughput: -1,
               connectionType: "wifi",
             });
-            await ctx.waitFor(`document.querySelector('[data-sidebar-brand-icon="ready"]')`, { timeoutMs: 30_000, label: "managed sidebar icon" });
+            await ctx.waitFor(`Boolean(document.querySelector('[data-sidebar-brand-icon="ready"]'))`, { timeoutMs: 30_000, label: "managed sidebar icon" });
           },
           assert: async () => {
             const icon = await iconState(ctx);
@@ -206,7 +203,7 @@ export default {
           action: async () => {
             await clearManagedIcon(ctx);
             await reloadDashboard(ctx);
-            await ctx.waitFor(`document.querySelector('[data-sidebar-brand-icon="fallback"]')`, { timeoutMs: 30_000, label: "sidebar fallback" });
+            await ctx.waitFor(`Boolean(document.querySelector('[data-sidebar-brand-icon="fallback"]'))`, { timeoutMs: 30_000, label: "sidebar fallback" });
           },
           assert: async () => {
             const icon = await iconState(ctx);
@@ -229,7 +226,7 @@ export default {
           action: async () => {
             await uploadManagedIcon(ctx);
             await reloadDashboard(ctx);
-            await ctx.waitFor(`document.querySelector('[data-sidebar-brand-icon="ready"]')`, { timeoutMs: 30_000, label: "restored managed sidebar icon" });
+            await ctx.waitFor(`Boolean(document.querySelector('[data-sidebar-brand-icon="ready"]'))`, { timeoutMs: 30_000, label: "restored managed sidebar icon" });
             await ctx.clickText("Settings", { timeoutMs: 15_000 });
             await ctx.waitForText("Brand Appearance", { timeoutMs: 30_000 });
             await ctx.eval(`(() => {
@@ -248,9 +245,9 @@ export default {
           },
           screenshot: {
             name: "brand-controls-and-sidebar-icon",
-            claim: "Brand Appearance still shows the managed square-icon controls while the sidebar uses that icon.",
+            claim: "Brand Appearance still shows the existing managed square-icon controls and stored icon.",
             requireText: ["Brand Appearance", "Square app icon", "Stored in this Den"],
-            rejectText: ["Something went wrong", "No custom image saved"],
+            rejectText: ["Something went wrong"],
           },
         });
       },

--- a/evals/flows/den-sidebar-brand-icon.flow.mjs
+++ b/evals/flows/den-sidebar-brand-icon.flow.mjs
@@ -1,0 +1,245 @@
+import sharp from "sharp";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("den-sidebar-brand-icon");
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const state = { token: null, iconUrl: null };
+
+async function apiRequest(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: {
+      ...(options.body instanceof FormData ? {} : { "content-type": "application/json" }),
+      authorization: `Bearer ${state.token}`,
+      origin: DEN_WEB_URL,
+      ...(options.headers ?? {}),
+    },
+  });
+  const body = await response.json();
+  return { response, body };
+}
+
+async function signInApi(ctx) {
+  const response = await fetch(`${DEN_API_URL}/api/auth/sign-in/email`, {
+    method: "POST",
+    headers: { "content-type": "application/json", origin: DEN_WEB_URL },
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
+  });
+  const body = await response.json();
+  ctx.assert(response.ok && typeof body.token === "string", `API sign-in failed: ${response.status} ${JSON.stringify(body)}`);
+  state.token = body.token;
+}
+
+async function uploadManagedIcon(ctx) {
+  const png = await sharp({
+    create: { width: 128, height: 128, channels: 4, background: "#0f766e" },
+  })
+    .composite([
+      {
+        input: Buffer.from('<svg width="128" height="128"><circle cx="64" cy="64" r="38" fill="#ccfbf1"/><path d="M43 65l14 14 30-34" fill="none" stroke="#0f766e" stroke-width="10" stroke-linecap="round" stroke-linejoin="round"/></svg>'),
+      },
+    ])
+    .png()
+    .toBuffer();
+  const form = new FormData();
+  form.set("icon", new Blob([png], { type: "image/png" }), "den-sidebar-icon.png");
+  const { response, body } = await apiRequest("/v1/org/brand-assets", { method: "POST", body: form });
+  ctx.assert(response.ok, `Managed icon upload failed: ${response.status} ${JSON.stringify(body)}`);
+  state.iconUrl = body.assets?.icon?.url ?? null;
+  ctx.assert(typeof state.iconUrl === "string", `Upload did not return a managed icon: ${JSON.stringify(body)}`);
+}
+
+async function clearManagedIcon(ctx) {
+  const { response, body } = await apiRequest("/v1/org", {
+    method: "PATCH",
+    body: JSON.stringify({ brandIconUrl: null }),
+  });
+  ctx.assert(response.ok, `Clearing the managed icon failed: ${response.status} ${JSON.stringify(body)}`);
+}
+
+async function enterDashboard(ctx) {
+  await ctx.eval(`location.assign(${JSON.stringify(DEN_WEB_URL)})`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "Den web loaded" });
+  await ctx.eval(
+    `fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)`,
+    { awaitPromise: true },
+  );
+  await ctx.eval(`location.assign(${JSON.stringify(DEN_WEB_URL)})`);
+  await ctx.waitFor('Boolean(document.querySelector(\'input[type="email"]\'))', { timeoutMs: 30_000, label: "sign-in form" });
+  await ctx.eval(`(() => {
+    const tab = [...document.querySelectorAll('button')].find((button) => (button.textContent ?? '').trim() === 'Sign in');
+    tab?.click();
+    return true;
+  })()`);
+  await ctx.fill('input[type="email"]', ADMIN_EMAIL);
+  await ctx.fill('input[type="password"]', ADMIN_PASSWORD);
+  await ctx.eval(`(() => { document.querySelector('button[type="submit"]')?.click(); return true; })()`);
+  await ctx.waitFor(`(() => {
+    const text = document.body?.innerText ?? '';
+    if (document.querySelector('nav') && !text.includes('Choose an organization')) return true;
+    if (!text.includes('Choose an organization')) return false;
+    const org = [...document.querySelectorAll('button')].find((button) => (button.textContent ?? '').includes('member'));
+    org?.click();
+    return false;
+  })()`, { timeoutMs: 60_000, label: "dashboard sidebar" });
+}
+
+async function reloadDashboard(ctx) {
+  await ctx.eval("location.reload()").catch(() => undefined);
+}
+
+async function iconState(ctx) {
+  return ctx.eval(`(() => {
+    const mark = document.querySelector('[data-sidebar-brand-icon]');
+    const image = mark?.querySelector('img');
+    return {
+      state: mark?.getAttribute('data-sidebar-brand-icon') ?? null,
+      hasImage: Boolean(image),
+      hasSvg: Boolean(mark?.querySelector('svg')),
+      src: image?.getAttribute('src') ?? null,
+      naturalWidth: image?.naturalWidth ?? 0,
+    };
+  })()`);
+}
+
+export default {
+  id: "den-sidebar-brand-icon",
+  title: "Den uses the managed organization square icon in its sidebar without flashes or broken images",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Setup",
+      run: async (ctx) => {
+        await signInApi(ctx);
+        await clearManagedIcon(ctx);
+        await uploadManagedIcon(ctx);
+        await enterDashboard(ctx);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The sidebar holds a neutral square while organization branding loads", {
+          voiceover: vo[0],
+          action: async () => {
+            await ctx.client.send("Network.enable");
+            await ctx.client.send("Network.emulateNetworkConditions", {
+              offline: false,
+              latency: 2_500,
+              downloadThroughput: -1,
+              uploadThroughput: -1,
+              connectionType: "wifi",
+            });
+            await reloadDashboard(ctx);
+            await ctx.waitFor(`document.querySelector('[data-sidebar-brand-icon="loading"]') && !document.querySelector('[data-sidebar-brand-icon] img')`, {
+              timeoutMs: 30_000,
+              label: "neutral sidebar icon placeholder",
+            });
+          },
+          assert: async () => {
+            const icon = await iconState(ctx);
+            ctx.assert(icon.state === "loading", `Expected loading placeholder: ${JSON.stringify(icon)}`);
+            ctx.assert(!icon.hasImage && !icon.hasSvg, `Loading state flashed an image or SVG: ${JSON.stringify(icon)}`);
+          },
+          screenshot: {
+            name: "sidebar-branding-loading",
+            claim: "The Den sidebar reserves a neutral square while organization branding loads.",
+            requireText: ["Dashboard"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The sidebar replaces the generic OpenWork mark with the managed organization icon", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.client.send("Network.emulateNetworkConditions", {
+              offline: false,
+              latency: 0,
+              downloadThroughput: -1,
+              uploadThroughput: -1,
+              connectionType: "wifi",
+            });
+            await ctx.waitFor(`document.querySelector('[data-sidebar-brand-icon="ready"]')`, { timeoutMs: 30_000, label: "managed sidebar icon" });
+          },
+          assert: async () => {
+            const icon = await iconState(ctx);
+            ctx.assert(icon.state === "ready" && icon.hasImage && !icon.hasSvg, `Managed icon was not ready: ${JSON.stringify(icon)}`);
+            ctx.assert(icon.naturalWidth === 128, `Managed icon did not decode at 128px: ${JSON.stringify(icon)}`);
+            ctx.assert(icon.src === state.iconUrl, `Sidebar used ${icon.src} instead of ${state.iconUrl}`);
+          },
+          screenshot: {
+            name: "sidebar-managed-brand-icon",
+            claim: "The Den sidebar visibly shows the organization's managed square icon instead of the OpenWork SVG.",
+            requireText: ["Dashboard"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("An organization without a managed icon gets the intact OpenWork fallback", {
+          voiceover: vo[2],
+          action: async () => {
+            await clearManagedIcon(ctx);
+            await reloadDashboard(ctx);
+            await ctx.waitFor(`document.querySelector('[data-sidebar-brand-icon="fallback"]')`, { timeoutMs: 30_000, label: "sidebar fallback" });
+          },
+          assert: async () => {
+            const icon = await iconState(ctx);
+            ctx.assert(icon.state === "fallback" && icon.hasSvg && !icon.hasImage, `Fallback was not intact: ${JSON.stringify(icon)}`);
+          },
+          screenshot: {
+            name: "sidebar-brand-icon-fallback",
+            claim: "Without a custom square icon, Den shows the intact OpenWork fallback and no broken image.",
+            requireText: ["Dashboard"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Brand upload controls and desktop delivery remain intact while the sidebar consumes the same managed icon", {
+          voiceover: vo[3],
+          action: async () => {
+            await uploadManagedIcon(ctx);
+            await reloadDashboard(ctx);
+            await ctx.waitFor(`document.querySelector('[data-sidebar-brand-icon="ready"]')`, { timeoutMs: 30_000, label: "restored managed sidebar icon" });
+            await ctx.clickText("Settings", { timeoutMs: 15_000 });
+            await ctx.waitForText("Brand Appearance", { timeoutMs: 30_000 });
+            await ctx.eval(`(() => {
+              const heading = [...document.querySelectorAll('h2')].find((node) => node.textContent?.trim() === 'Brand Appearance');
+              heading?.scrollIntoView({ block: 'start' });
+              return Boolean(heading);
+            })()`);
+          },
+          assert: async () => {
+            await ctx.expectText("Square app icon");
+            await ctx.expectText("Stored in this Den");
+            const config = await apiRequest("/v1/me/desktop-config");
+            ctx.assert(config.response.ok && config.body.brandIconUrl === state.iconUrl, `Desktop config did not retain the managed icon: ${JSON.stringify(config.body)}`);
+            const icon = await iconState(ctx);
+            ctx.assert(icon.state === "ready" && icon.src === state.iconUrl, `Sidebar did not retain the managed icon: ${JSON.stringify(icon)}`);
+          },
+          screenshot: {
+            name: "brand-controls-and-sidebar-icon",
+            claim: "Brand Appearance still shows the managed square-icon controls while the sidebar uses that icon.",
+            requireText: ["Brand Appearance", "Square app icon", "Stored in this Den"],
+            rejectText: ["Something went wrong", "No custom image saved"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/den-sidebar-brand-icon.md
+++ b/evals/voiceovers/den-sidebar-brand-icon.md
@@ -1,0 +1,9 @@
+# den-sidebar-brand-icon — Den shows the organization icon in its sidebar
+
+1. I open Den while organization branding is loading, and the sidebar icon stays visually stable without a broken image or a flash of the generic OpenWork mark.
+
+2. Once branding is available, Den's sidebar shows the configured square organization icon instead of the generic OpenWork mark.
+
+3. For an organization without a custom square icon, the Den sidebar shows a consistent fallback without a broken image.
+
+4. The branding upload layout and Windows desktop shortcut remain unchanged while the Den sidebar uses the organization icon.


### PR DESCRIPTION
## What changed

- replace Den's hard-coded sidebar OpenWork mark with the canonical managed organization square icon
- reserve a neutral fixed-size placeholder until organization metadata and the image are ready
- retain the existing OpenWork SVG as the no-icon or failed-image fallback
- add focused resolver/rendering tests and an approved four-frame fraimz flow

## Root cause

The dashboard sidebar always rendered an inline OpenWork SVG and never read the existing `brandIconAsset` stored by the organization branding API.

## Impact

Organizations with configured branding now see their managed square icon in Den's sidebar without a generic-icon flash or broken image. Branding upload controls and desktop icon delivery remain on their existing paths.

## Validation

- `pnpm exec bun test ee/apps/den-web/tests/org-dashboard-sidebar-brand-icon.test.tsx ee/apps/den-web/tests/org-dashboard-shell-layout.test.ts` — 4 passed
- `node 'ee/apps/den-web/app/(den)/_lib/den-org.brand-icon.test.mts'` — passed
- `pnpm --dir ee/apps/den-web exec tsc --noEmit --incremental false` — passed
- `node --check evals/flows/den-sidebar-brand-icon.flow.mjs` — passed
- Daytona Den Web + Chromium: `pnpm fraimz --flow den-sidebar-brand-icon --cdp-url <daytona-cdp-url>` — Passed, 4/4 frames plus voiceover coverage
- proof artifact: `evals/results/2026-07-10T23-45-43-590Z/fraimz.html` (generated locally; gitignored)