### PR TITLE
Fix organization branding upload layout reflow

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -743,16 +743,17 @@ export function AppSidebar(props: AppSidebarProps) {
         {hasManagedBrand ? (
           <div
             data-testid="brand-logo"
-            className="flex shrink-0 items-center gap-2 px-3 pb-3 pt-2 mac:pt-0"
+            className="flex h-14 shrink-0 items-center px-3 pb-3 pt-2 mac:pt-0"
           >
             {brandLogoUrl ? (
               <img
                 src={brandLogoUrl}
                 alt={`${brandAppName} logo`}
-                className="h-9 max-h-9 w-auto max-w-[140px] object-contain object-left"
+                className="max-h-9 w-auto max-w-[140px] object-contain object-left"
               />
-            ) : null}
-            <span className="truncate text-sm font-semibold" data-testid="brand-app-name">{brandAppName}</span>
+            ) : (
+              <span className="truncate text-sm font-semibold" data-testid="brand-app-name">{brandAppName}</span>
+            )}
           </div>
         ) : null}
         {props.onOpenSessionSearch ? (

--- a/apps/app/tests/managed-brand-header.test.ts
+++ b/apps/app/tests/managed-brand-header.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const sidebarPath = fileURLToPath(
+  new URL("../src/react-app/domains/session/sidebar/app-sidebar.tsx", import.meta.url),
+);
+
+describe("managed brand header", () => {
+  test("shows the application name only when no wordmark is supplied", () => {
+    const source = readFileSync(sidebarPath, "utf8");
+
+    expect(source).toMatch(/brandLogoUrl \? \([\s\S]*?<img[\s\S]*?\) : \([\s\S]*?data-testid="brand-app-name"/);
+    expect(source).toMatch(/className="flex h-14 shrink-0 items-center/);
+    expect(source).toMatch(/className="max-h-9 w-auto max-w-\[140px\] object-contain object-left"/);
+  });
+});

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
@@ -183,7 +183,7 @@ function BrandAssetUploadField({
       : null;
 
   return (
-    <div className="grid gap-3 rounded-2xl border border-gray-200 bg-white p-4" data-testid={`brand-${kind}-asset-field`}>
+    <div className="grid min-w-0 gap-3 rounded-2xl border border-gray-200 bg-white p-4" data-testid={`brand-${kind}-asset-field`}>
       <div className="grid gap-1">
         <span className="text-[14px] font-medium text-gray-800">{title}</span>
         <span className="text-[11px] leading-5 text-gray-400">{description}</span>
@@ -200,7 +200,7 @@ function BrandAssetUploadField({
           <span className="text-center text-[12px] text-gray-400">Default OpenWork {kind}</span>
         )}
       </div>
-      <div className="min-h-9 text-[11px] leading-5 text-gray-500" data-testid={`brand-${kind}-status`}>
+      <div className="min-h-9 min-w-0 break-words text-[11px] leading-5 text-gray-500" data-testid={`brand-${kind}-status`}>
         {draft ? `Ready to upload: ${draft.file.name} · ${dimensions}` : null}
         {!draft && clearPending ? "Will restore the default after saving." : null}
         {!draft && !clearPending && managedAsset ? `Stored in this Den · ${dimensions} · version ${managedAsset.version.slice(0, 10)}` : null}
@@ -649,7 +649,7 @@ export function OrgSettingsScreen() {
         </div>
       ) : null}
 
-      <form className="grid gap-6" onSubmit={handleSaveSettings}>
+      <form className="grid min-w-0 grid-cols-1 gap-6" onSubmit={handleSaveSettings}>
         <DenCard size="spacious" className="grid gap-6">
           <div className="grid gap-2">
             <p className="text-[12px] font-semibold uppercase tracking-[0.16em] text-gray-400">
@@ -921,7 +921,7 @@ export function OrgSettingsScreen() {
               </span>
             </label>
 
-            <div className="grid gap-5 lg:grid-cols-2">
+            <div className="grid min-w-0 gap-5 lg:grid-cols-2">
               <BrandAssetUploadField
                 kind="logo"
                 title="Wordmark"
@@ -993,7 +993,7 @@ export function OrgSettingsScreen() {
           )}
         </DenCard>
 
-        <div className="flex flex-wrap items-center justify-between gap-3">
+        <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
           <p className="text-[13px] text-gray-500">
             {!isOwner && "Only workspace owners can change these settings."}
           </p>

--- a/ee/apps/den-web/tests/org-settings-branding-layout.test.ts
+++ b/ee/apps/den-web/tests/org-settings-branding-layout.test.ts
@@ -1,0 +1,19 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const settingsPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/org-settings-screen.tsx", import.meta.url),
+);
+
+describe("organization branding layout", () => {
+  test("contains long selected-image status text inside the responsive grid", () => {
+    const source = readFileSync(settingsPath, "utf8");
+
+    expect(source).toMatch(/<form className="grid min-w-0 grid-cols-1 gap-6"/);
+    expect(source).toMatch(/className="grid min-w-0 gap-5 lg:grid-cols-2"/);
+    expect(source).toMatch(/className="grid min-w-0 gap-3 rounded-2xl/);
+    expect(source).toMatch(/className="min-h-9 min-w-0 break-words/);
+    expect(source).toMatch(/className="flex min-w-0 flex-wrap items-center justify-between gap-3"/);
+  });
+});

--- a/evals/flows/organization-branding-upload-layout.flow.mjs
+++ b/evals/flows/organization-branding-upload-layout.flow.mjs
@@ -1,0 +1,342 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import {
+  ORG_SETTINGS_PATH,
+  adminEnsureFreshAuth,
+  clickSaveSettings,
+  denFetch,
+  ensureRendererMounted,
+  ensureWorkspaceReady,
+  getPanelTargetId,
+  memberRefresh,
+  openAdminPanel,
+  panelEval,
+  sleep,
+  waitForDesktopConfig,
+  waitForPanel,
+  waitUntil,
+} from "./desktop-brand-icon.flow.mjs";
+
+const vo = await loadVoiceoverParagraphs("organization-branding-upload-layout");
+const LONG_FILENAME = `example-corp-${"long-wordmark-name-".repeat(9)}final.png`;
+
+let adminPanelTargetId = null;
+let savedAssets = null;
+let brandShapeStates = [];
+
+function orgSettingsUrl(ctx) {
+  return `${ctx.env.OPENWORK_EVAL_DEN_WEB_URL.replace(/\/$/, "")}${ORG_SETTINGS_PATH}`;
+}
+
+function parseMetadata(value) {
+  if (value && typeof value === "object") return value;
+  if (typeof value !== "string" || !value.trim()) return {};
+  try {
+    const parsed = JSON.parse(value);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+async function readAssets(ctx) {
+  const { body } = await denFetch(ctx, "/v1/org");
+  const metadata = parseMetadata(body?.organization?.metadata);
+  return {
+    logo: metadata.brandLogoAsset ?? null,
+    icon: metadata.brandIconAsset ?? null,
+    logoUrl: metadata.brandLogoUrl ?? null,
+    iconUrl: metadata.brandIconUrl ?? null,
+  };
+}
+
+async function ensureDesktopSession(ctx) {
+  const { body } = await denFetch(ctx, "/v1/me/orgs");
+  const organizations = Array.isArray(body?.orgs) ? body.orgs : [];
+  const activeOrg = organizations.find((organization) => organization?.id === body?.activeOrgId) ?? organizations[0];
+  ctx.assert(activeOrg?.id, "The eval token does not have an organization.");
+
+  await denFetch(ctx, "/v1/org", {
+    method: "PATCH",
+    body: JSON.stringify({ name: "Example Corp", brandAppName: "Example Work", brandLogoUrl: null, brandIconUrl: null }),
+  });
+
+  await ctx.control("eval.auth.set-base-url", { baseUrl: process.env.OPENWORK_EVAL_DEN_WEB_URL });
+  await ctx.eval(`(() => {
+    localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(process.env.OPENWORK_EVAL_DEN_WEB_URL)});
+    localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(process.env.OPENWORK_EVAL_DEN_API_URL)});
+    localStorage.setItem('openwork.den.authToken', ${JSON.stringify(process.env.OPENWORK_EVAL_DEN_TOKEN)});
+    localStorage.setItem('openwork.den.activeOrgId', ${JSON.stringify(activeOrg.id)});
+    localStorage.setItem('openwork.den.activeOrgSlug', ${JSON.stringify(activeOrg.slug ?? "example-corp")});
+    localStorage.setItem('openwork.den.activeOrgName', 'Example Corp');
+    window.dispatchEvent(new CustomEvent('openwork-den-settings-changed', { detail: {} }));
+    window.dispatchEvent(new CustomEvent('openwork-den-session-updated', { detail: { token: ${JSON.stringify(process.env.OPENWORK_EVAL_DEN_TOKEN)} } }));
+    return true;
+  })()`);
+
+  await waitUntil(ctx, "desktop Den session", async () => {
+    const status = await ctx.control("auth.status", {}).catch(() => null);
+    return status?.status === "signed_in" ? status : null;
+  }, { timeoutMs: 30_000 });
+}
+
+async function navigateBrandSettings(ctx) {
+  await panelEval(ctx, `location.replace(${JSON.stringify(orgSettingsUrl(ctx))})`).catch(() => undefined);
+  await waitForPanel(ctx, `document.body.innerText.includes('Brand Appearance') && document.body.innerText.includes('Wordmark')`, {
+    timeoutMs: 60_000,
+    label: "Brand Appearance settings",
+  });
+}
+
+async function selectAsset(ctx, kind, { filename, width, height }) {
+  return panelEval(ctx, `(async () => {
+    const canvas = document.createElement('canvas');
+    canvas.width = ${width};
+    canvas.height = ${height};
+    const context = canvas.getContext('2d');
+    if (!context) throw new Error('Canvas unavailable');
+    context.fillStyle = ${JSON.stringify(kind === "logo" ? "#123f73" : "#0f766e")};
+    context.fillRect(0, 0, canvas.width, canvas.height);
+    context.fillStyle = '#fff';
+    context.textAlign = 'center';
+    context.textBaseline = 'middle';
+    context.font = 'bold 48px sans-serif';
+    context.fillText(${JSON.stringify(kind === "logo" ? "EXAMPLE CORP" : "EX")}, canvas.width / 2, canvas.height / 2);
+    const blob = await new Promise((resolve, reject) => canvas.toBlob((value) => value ? resolve(value) : reject(new Error('PNG encoding failed')), 'image/png'));
+    const file = new File([blob], ${JSON.stringify(filename)}, { type: 'image/png' });
+    const input = document.querySelector(${JSON.stringify(`#brand-${kind}-upload`)});
+    if (!(input instanceof HTMLInputElement)) throw new Error('File input unavailable');
+    const transfer = new DataTransfer();
+    transfer.items.add(file);
+    input.files = transfer.files;
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    return { name: file.name, width: canvas.width, height: canvas.height };
+  })()`, { awaitPromise: true });
+}
+
+async function layoutState(ctx) {
+  return panelEval(ctx, `(() => {
+    const field = document.querySelector('[data-testid="brand-logo-asset-field"]');
+    const preview = document.querySelector('[data-testid="brand-logo-preview"]');
+    const save = Array.from(document.querySelectorAll('button')).find((button) => button.textContent?.trim() === 'Save settings');
+    const rect = field?.getBoundingClientRect();
+    const previewRect = preview?.getBoundingClientRect();
+    const saveRect = save?.getBoundingClientRect();
+    return {
+      viewportWidth: document.documentElement.clientWidth,
+      scrollWidth: document.documentElement.scrollWidth,
+      fieldLeft: rect?.left ?? null,
+      fieldRight: rect?.right ?? null,
+      previewRight: previewRect?.right ?? null,
+      saveLeft: saveRect?.left ?? null,
+      saveRight: saveRect?.right ?? null,
+      zoom: getComputedStyle(document.body).zoom || '1',
+    };
+  })()`);
+}
+
+function assertContained(ctx, state, label) {
+  ctx.assert(state.scrollWidth <= state.viewportWidth + 1, `${label} horizontally overflowed: ${JSON.stringify(state)}`);
+  ctx.assert(state.fieldLeft >= 0 && state.fieldRight <= state.viewportWidth + 1, `${label} card escaped viewport: ${JSON.stringify(state)}`);
+  ctx.assert(state.previewRight <= state.fieldRight + 1, `${label} preview escaped card: ${JSON.stringify(state)}`);
+  ctx.assert(state.saveLeft >= 0 && state.saveRight <= state.viewportWidth + 1, `${label} Save action escaped viewport: ${JSON.stringify(state)}`);
+}
+
+export default {
+  id: "organization-branding-upload-layout",
+  title: "Branding uploads stay contained and desktop wordmarks align without adjacent text",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "setup",
+      run: async (ctx) => {
+        await ensureRendererMounted(ctx);
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "window.__openworkControl" });
+        await ctx.ensureLightMode();
+        await ensureDesktopSession(ctx);
+        await ensureWorkspaceReady(ctx);
+        await openAdminPanel(ctx);
+        await adminEnsureFreshAuth(ctx);
+        await navigateBrandSettings(ctx);
+        adminPanelTargetId = await getPanelTargetId(ctx);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("Brand Appearance opens at a desktop viewport with its controls inside the page", {
+          voiceover: vo[0],
+          action: async () => {
+            await panelEval(ctx, `(() => { document.body.style.zoom = '1'; document.querySelector('[data-testid="brand-logo-asset-field"]')?.scrollIntoView({ block: 'center' }); return true; })()`);
+            await sleep(400);
+          },
+          assert: async () => {
+            const state = await layoutState(ctx);
+            ctx.assert(state.scrollWidth <= state.viewportWidth + 1, `Settings page overflowed before selection: ${JSON.stringify(state)}`);
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Brand settings fit the desktop viewport before selection", actual: state });
+          },
+          screenshot: { name: "frame-1-brand-settings", sandboxCapture: true, targetId: adminPanelTargetId, textTargetId: adminPanelTargetId, requireText: ["Brand Appearance", "Wordmark", "Save settings"] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("A long selected filename and preview stay contained without horizontal reflow", {
+          voiceover: vo[1],
+          action: async () => {
+            await selectAsset(ctx, "logo", { filename: LONG_FILENAME, width: 640, height: 160 });
+            await selectAsset(ctx, "icon", { filename: "example-corp-square-icon.png", width: 256, height: 256 });
+            await waitForPanel(ctx, `document.querySelector('[data-testid="brand-logo-status"]')?.textContent?.includes('Ready to upload')`, { timeoutMs: 15_000, label: "long wordmark filename preview" });
+            await panelEval(ctx, `(() => { document.querySelector('[data-testid="brand-logo-asset-field"]')?.scrollIntoView({ block: 'center' }); return true; })()`);
+            await sleep(400);
+          },
+          assert: async () => {
+            const state = await layoutState(ctx);
+            assertContained(ctx, state, "Selected long filename");
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Long selected filename wraps without widening the editor", actual: { filenameLength: LONG_FILENAME.length, ...state } });
+          },
+          screenshot: { name: "frame-2-contained-long-filename", sandboxCapture: true, targetId: adminPanelTargetId, textTargetId: adminPanelTargetId, requireText: ["Ready to upload", "Replace image", "Save settings"] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Invalid image feedback appears without widening the settings page", {
+          voiceover: vo[2],
+          action: async () => {
+            await selectAsset(ctx, "icon", { filename: `${"invalid-wide-icon-".repeat(8)}.png`, width: 640, height: 160 });
+            await waitForPanel(ctx, `document.body.innerText.includes('Use a square image for the app icon.')`, { timeoutMs: 15_000, label: "invalid icon feedback" });
+            await panelEval(ctx, `(() => { document.querySelector('[data-testid="brand-asset-error"]')?.scrollIntoView({ block: 'center' }); return true; })()`);
+            await sleep(400);
+          },
+          assert: async () => {
+            const state = await layoutState(ctx);
+            assertContained(ctx, state, "Validation feedback");
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Validation feedback leaves the editor and Save action contained", actual: state });
+          },
+          screenshot: { name: "frame-3-validation-contained", sandboxCapture: true, targetId: adminPanelTargetId, textTargetId: adminPanelTargetId, requireText: ["Use a square image for the app icon.", "Save settings"] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("The preview and Save action remain reachable at 100% and 90% zoom", {
+          voiceover: vo[3],
+          action: async () => {
+            await selectAsset(ctx, "icon", { filename: "example-corp-square-icon.png", width: 256, height: 256 });
+            await waitForPanel(ctx, `document.querySelector('[data-testid="brand-icon-status"]')?.textContent?.includes('Ready to upload')`, { timeoutMs: 15_000, label: "valid icon restored" });
+          },
+          assert: async () => {
+            const states = [];
+            for (const zoom of ["1", "0.9"]) {
+              await panelEval(ctx, `(() => { document.body.style.zoom = ${JSON.stringify(zoom)}; return true; })()`);
+              await sleep(250);
+              const state = await layoutState(ctx);
+              assertContained(ctx, state, `${Number(zoom) * 100}% zoom`);
+              states.push(state);
+            }
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Editor, preview, and Save action remain horizontally contained at 100% and 90%", actual: states });
+          },
+          screenshot: { name: "frame-4-common-zoom", sandboxCapture: true, targetId: adminPanelTargetId, textTargetId: adminPanelTargetId, requireText: ["Ready to upload", "Save settings"] },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("The saved desktop header displays the uploaded wordmark without adjacent application text", {
+          voiceover: vo[4],
+          action: async () => {
+            await panelEval(ctx, `(() => { document.body.style.zoom = '1'; return true; })()`);
+            await clickSaveSettings(ctx);
+            savedAssets = await waitUntil(ctx, "saved branding assets", async () => {
+              const assets = await readAssets(ctx);
+              return assets.logo?.version && assets.icon?.version ? assets : null;
+            }, { timeoutMs: 30_000, intervalMs: 750 });
+            await memberRefresh(ctx);
+            await waitForDesktopConfig(ctx, "saved wordmark", (config) => config.brandLogoUrl === savedAssets.logoUrl);
+            await ctx.waitFor(`(() => { const image = document.querySelector('[data-testid="brand-logo"] img'); return Boolean(image?.complete && image.naturalWidth > 0); })()`, { timeoutMs: 30_000, label: "desktop wordmark" });
+          },
+          assert: async () => {
+            const state = await ctx.eval(`(() => ({
+              image: Boolean(document.querySelector('[data-testid="brand-logo"] img')),
+              adjacentName: Boolean(document.querySelector('[data-testid="brand-logo"] [data-testid="brand-app-name"]')),
+              headerText: document.querySelector('[data-testid="brand-logo"]')?.textContent?.trim() ?? '',
+            }))()`);
+            ctx.assert(state.image, `Saved wordmark image is missing: ${JSON.stringify(state)}`);
+            ctx.assert(!state.adjacentName && state.headerText === "", `Application text appeared beside the wordmark: ${JSON.stringify(state)}`);
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Uploaded wordmark is the only branding content in the desktop header", actual: state });
+          },
+          screenshot: { name: "frame-5-wordmark-only", requireText: ["Search sessions"], rejectText: ["Example Work"] },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("Wide, square, and absent wordmarks keep a stable aligned desktop header", {
+          voiceover: vo[5],
+          action: async () => {
+            brandShapeStates = [];
+            for (const logoUrl of [savedAssets.logoUrl, savedAssets.iconUrl, null]) {
+              await denFetch(ctx, "/v1/org", { method: "PATCH", body: JSON.stringify({ brandLogoUrl: logoUrl }) });
+              await memberRefresh(ctx);
+              await waitForDesktopConfig(ctx, "wordmark shape", (config) => (config.brandLogoUrl ?? null) === logoUrl);
+              if (logoUrl) {
+                await ctx.waitFor(`(() => { const image = document.querySelector('[data-testid="brand-logo"] img'); return image?.src === ${JSON.stringify(logoUrl)} && image.complete && image.naturalWidth > 0; })()`, { timeoutMs: 20_000, label: "shape wordmark" });
+              } else {
+                await ctx.waitFor(`Boolean(document.querySelector('[data-testid="brand-logo"] [data-testid="brand-app-name"]')) && !document.querySelector('[data-testid="brand-logo"] img')`, { timeoutMs: 20_000, label: "wordmark name fallback" });
+              }
+              const state = await ctx.eval(`(() => {
+                const header = document.querySelector('[data-testid="brand-logo"]');
+                const image = header?.querySelector('img');
+                const rect = header?.getBoundingClientRect();
+                return { logoUrl: ${JSON.stringify(logoUrl)}, height: rect?.height ?? 0, left: rect?.left ?? 0, imageWidth: image?.getBoundingClientRect().width ?? 0, imageHeight: image?.getBoundingClientRect().height ?? 0, fallback: Boolean(header?.querySelector('[data-testid="brand-app-name"]')) };
+              })()`);
+              brandShapeStates.push(state);
+            }
+            await sleep(1_500);
+          },
+          assert: async () => {
+            const states = brandShapeStates;
+            ctx.assert(states.length === 3, `Expected wide, square, and absent states: ${JSON.stringify(states)}`);
+            for (const state of states) {
+              ctx.assert(state.height === 56 && state.left === 0, `Header alignment changed: ${JSON.stringify(state)}`);
+              ctx.assert(state.imageHeight <= 36 && state.imageWidth <= 140, `Wordmark escaped its bounds: ${JSON.stringify(state)}`);
+            }
+            ctx.assert(states[2].fallback, `Absent wordmark did not use the name fallback: ${JSON.stringify(states[2])}`);
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Wide, square, and absent brand states share the same 56px left-aligned header chrome", actual: states });
+          },
+          screenshot: { name: "frame-6-aligned-fallback", requireText: ["Example Work", "Search sessions"] },
+        });
+      },
+    },
+    {
+      name: "Frame 7",
+      run: async (ctx) => {
+        await ctx.prove("Returning to Brand Appearance shows the saved image without editor overflow", {
+          voiceover: vo[6],
+          action: async () => {
+            await denFetch(ctx, "/v1/org", { method: "PATCH", body: JSON.stringify({ brandLogoUrl: savedAssets.logoUrl }) });
+            await openAdminPanel(ctx);
+            await adminEnsureFreshAuth(ctx);
+            await navigateBrandSettings(ctx);
+            adminPanelTargetId = await getPanelTargetId(ctx);
+            await waitForPanel(ctx, `(() => { const image = document.querySelector('[data-testid="brand-logo-preview"]'); const status = document.querySelector('[data-testid="brand-logo-status"]')?.textContent ?? ''; return image?.complete && image.naturalWidth > 0 && (status.includes('Stored in this Den') || status.includes('Current hosted image')); })()`, { timeoutMs: 30_000, label: "saved image after return" });
+            await panelEval(ctx, `(() => { document.querySelector('[data-testid="brand-logo-asset-field"]')?.scrollIntoView({ block: 'center' }); return true; })()`);
+            await sleep(400);
+          },
+          assert: async () => {
+            const state = await layoutState(ctx);
+            assertContained(ctx, state, "Returned editor");
+            ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Saved wordmark remains visible and the returned editor has no horizontal overflow", actual: state });
+          },
+          screenshot: { name: "frame-7-saved-editor-contained", sandboxCapture: true, targetId: adminPanelTargetId, textTargetId: adminPanelTargetId, requireText: ["Brand Appearance", "Save settings"] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/organization-branding-upload-layout.md
+++ b/evals/voiceovers/organization-branding-upload-layout.md
@@ -1,0 +1,15 @@
+# organization-branding-upload-layout — Branding uploads stay usable and aligned
+
+1. A Den organization owner opens Branding settings at a standard desktop viewport, with Back and Save clearly visible.
+
+2. The owner chooses a wordmark; file selection and preview do not resize the editor, shift navigation, or hide actions.
+
+3. An invalid image shows validation feedback without shrinking the pane or causing horizontal reflow.
+
+4. At 90% and 100% browser zoom, the preview remains contained and Back and Save stay reachable.
+
+5. After saving, the desktop app displays the uploaded wordmark by itself—no added product or organization text beside it.
+
+6. Whether the wordmark is wide, square, or absent, its container aligns cleanly with the rest of the desktop app without shifting nearby controls.
+
+7. Returning to Branding confirms the saved image while the editor retains the same usable layout.


### PR DESCRIPTION
## Summary

- contain branding upload cards, filenames, and the outer settings form so image selection and validation cannot widen the editor or clip Save
- render an uploaded desktop wordmark by itself, using the managed application name only when no wordmark exists
- keep wide, square, and absent branding aligned inside stable sidebar chrome
- add focused regression tests and an approved seven-frame fraimz flow

## Root cause

The responsive upload grid and its outer form used implicit/default `min-width: auto` sizing. A long selected filename became an intrinsic min-content contribution, widening the grid beyond the available pane. At the 305 CSS-pixel built-in admin panel and common 90–100% zoom states, the expanded auto track displaced the right-aligned Save action beyond the viewport.

## Validation

- `pnpm exec bun test ee/apps/den-web/tests/org-settings-branding-layout.test.ts apps/app/tests/managed-brand-header.test.ts` — 2 passed, 0 failed
- `pnpm --dir apps/app typecheck` — passed
- `pnpm --dir ee/apps/den-web build` — passed
- `git diff --check` — passed
- Daytona two-sandbox Den Web/API + Electron run: `pnpm fraimz --flow organization-branding-upload-layout --cdp-url http://127.0.0.1:9825` — Passed, 7/7 frames plus voiceover coverage

## Proof

- [Validated fraimz artifact](https://8090-ydxrrctysqi8kmyg.daytonaproxy01.net/validation/organization-branding-upload-layout/fraimz.html)

The screenshots were visually inspected after the passing run; a transient compositor capture was rejected and replaced before publishing this artifact.
