### PR TITLE
fix: complete Windows organization branding

### DIFF
--- a/apps/desktop/build/installer.nsh
+++ b/apps/desktop/build/installer.nsh
@@ -1,0 +1,11 @@
+!macro customUnInstall
+  StrCpy $1 ""
+  FileOpen $0 "$APPDATA\com.differentai.openwork\windows-brand-shortcut.txt" r
+  IfErrors +3
+    FileRead $0 $1
+    FileClose $0
+  ${If} $1 != ""
+    Delete "$1"
+  ${EndIf}
+  Delete "$APPDATA\com.differentai.openwork\windows-brand-shortcut.txt"
+!macroend

--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -107,4 +107,6 @@ win:
         - versions.json-x86_64-pc-windows-msvc.exe
   target:
     - nsis
+nsis:
+  include: build/installer.nsh
 artifactName: openwork-${os}-${arch}-${version}.${ext}

--- a/apps/desktop/electron/brand-icon-windows.mjs
+++ b/apps/desktop/electron/brand-icon-windows.mjs
@@ -80,10 +80,10 @@ export function windowsInstalledShortcutFileName(appName) {
   return `${safeName}.lnk`;
 }
 
-export function windowsInstalledExecutablePath({ packaged, execPath, resourcesPath, appDataPath }) {
+export function windowsInstalledExecutablePath({ packaged, execPath, resourcesPath, userDataPath }) {
   if (!packaged) return execPath;
   return [
-    appDataPath.replace(/[\\/]Roaming$/i, ""),
+    userDataPath.replace(/[\\/]Roaming[\\/][^\\/]+$/i, ""),
     "Local",
     "Programs",
     resourcesPath.replace(/[\\/]resources$/i, "").split(/[\\/]/).pop(),

--- a/apps/desktop/electron/brand-icon-windows.mjs
+++ b/apps/desktop/electron/brand-icon-windows.mjs
@@ -80,6 +80,17 @@ export function windowsInstalledShortcutFileName(appName) {
   return `${safeName}.lnk`;
 }
 
+export function windowsInstalledExecutablePath({ packaged, execPath, resourcesPath, appDataPath }) {
+  if (!packaged) return execPath;
+  return [
+    appDataPath.replace(/[\\/]Roaming$/i, ""),
+    "Local",
+    "Programs",
+    resourcesPath.replace(/[\\/]resources$/i, "").split(/[\\/]/).pop(),
+    execPath.split(/[\\/]/).pop(),
+  ].join("\\");
+}
+
 export function windowsBrandShortcutDetails({ target, appId, appIconPath, appName }) {
   return {
     target,

--- a/apps/desktop/electron/brand-icon-windows.mjs
+++ b/apps/desktop/electron/brand-icon-windows.mjs
@@ -80,10 +80,11 @@ export function windowsInstalledShortcutFileName(appName) {
   return `${safeName}.lnk`;
 }
 
-export function windowsInstalledExecutablePath({ packaged, execPath, resourcesPath, userDataPath }) {
+export function windowsInstalledExecutablePath({ packaged, execPath, resourcesPath, shortcutPath }) {
   if (!packaged) return execPath;
   return [
-    userDataPath.replace(/[\\/]Roaming[\\/][^\\/]+$/i, ""),
+    shortcutPath.split(/[\\/]AppData[\\/]/i)[0],
+    "AppData",
     "Local",
     "Programs",
     resourcesPath.replace(/[\\/]resources$/i, "").split(/[\\/]/).pop(),

--- a/apps/desktop/electron/brand-icon-windows.mjs
+++ b/apps/desktop/electron/brand-icon-windows.mjs
@@ -70,7 +70,14 @@ export function windowsBrandShortcutFileName(appName) {
   const safeName = String(appName ?? "OpenWork")
     .replace(/[<>:"/\\|?*]/g, "-")
     .trim() || "OpenWork";
-  return `${safeName} Organization.lnk`;
+  return `${safeName}.lnk`;
+}
+
+export function windowsInstalledShortcutFileName(appName) {
+  const safeName = String(appName ?? "OpenWork")
+    .replace(/[<>:"/\\|?*]/g, "-")
+    .trim() || "OpenWork";
+  return `${safeName}.lnk`;
 }
 
 export function windowsBrandShortcutDetails({ target, appId, appIconPath, appName }) {

--- a/apps/desktop/electron/brand-icon-windows.test.mjs
+++ b/apps/desktop/electron/brand-icon-windows.test.mjs
@@ -10,6 +10,7 @@ import {
   windowsBrandShortcutDetails,
   windowsBrandShortcutFileName,
   windowsInstalledShortcutFileName,
+  windowsInstalledExecutablePath,
   writeWindowsBrandShortcut,
   windowsIconFromNativeImage,
 } from "./brand-icon-windows.mjs";
@@ -173,6 +174,15 @@ test("builds a per-user Start Menu shortcut with the branded Windows identity", 
     iconIndex: 0,
     appUserModelId: "com.differentai.openwork.brand.1234",
   });
+});
+
+test("anchors a packaged shortcut target to the active Windows user profile", () => {
+  assert.equal(windowsInstalledExecutablePath({
+    packaged: true,
+    execPath: "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Programs\\@openworkdesktop\\OpenWork.exe",
+    resourcesPath: "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Programs\\@openworkdesktop\\resources",
+    appDataPath: "C:\\Users\\Administrator\\AppData\\Roaming",
+  }), "C:\\Users\\Administrator\\AppData\\Local\\Programs\\@openworkdesktop\\OpenWork.exe");
 });
 
 test("creates a branded shortcut after callers remove stale Windows metadata", () => {

--- a/apps/desktop/electron/brand-icon-windows.test.mjs
+++ b/apps/desktop/electron/brand-icon-windows.test.mjs
@@ -175,7 +175,7 @@ test("builds a per-user Start Menu shortcut with the branded Windows identity", 
   });
 });
 
-test("creates a first-time branded shortcut and replaces it on repeat applies", () => {
+test("creates a branded shortcut after callers remove stale Windows metadata", () => {
   const calls = [];
   const details = { appUserModelId: "com.differentai.openwork.brand.1234" };
   const shellApi = {
@@ -187,12 +187,6 @@ test("creates a first-time branded shortcut and replaces it on repeat applies", 
   const shortcutPath = "C:\\Users\\Admin\\OpenWork Organization.lnk";
 
   const created = writeWindowsBrandShortcut(shellApi, shortcutPath, details, false);
-  const replaced = writeWindowsBrandShortcut(shellApi, shortcutPath, details, true);
-
   assert.equal(created, true);
-  assert.equal(replaced, true);
-  assert.deepEqual(calls, [
-    [shortcutPath, "create", details],
-    [shortcutPath, "replace", details],
-  ]);
+  assert.deepEqual(calls, [[shortcutPath, "create", details]]);
 });

--- a/apps/desktop/electron/brand-icon-windows.test.mjs
+++ b/apps/desktop/electron/brand-icon-windows.test.mjs
@@ -9,6 +9,7 @@ import {
   windowsBrandAppUserModelId,
   windowsBrandShortcutDetails,
   windowsBrandShortcutFileName,
+  windowsInstalledShortcutFileName,
   writeWindowsBrandShortcut,
   windowsIconFromNativeImage,
 } from "./brand-icon-windows.mjs";
@@ -157,7 +158,8 @@ test("restores a visible taskbar button when refresh staging fails", async () =>
 });
 
 test("builds a per-user Start Menu shortcut with the branded Windows identity", () => {
-  assert.equal(windowsBrandShortcutFileName('Agent: Blue/West'), "Agent- Blue-West Organization.lnk");
+  assert.equal(windowsBrandShortcutFileName('Agent: Blue/West'), "Agent- Blue-West.lnk");
+  assert.equal(windowsInstalledShortcutFileName("OpenWork"), "OpenWork.lnk");
   assert.deepEqual(windowsBrandShortcutDetails({
     target: "C:\\Program Files\\OpenWork\\OpenWork.exe",
     appId: "com.differentai.openwork.brand.1234",

--- a/apps/desktop/electron/brand-icon-windows.test.mjs
+++ b/apps/desktop/electron/brand-icon-windows.test.mjs
@@ -181,7 +181,7 @@ test("anchors a packaged shortcut target to the active Windows user profile", ()
     packaged: true,
     execPath: "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Programs\\@openworkdesktop\\OpenWork.exe",
     resourcesPath: "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Programs\\@openworkdesktop\\resources",
-    userDataPath: "C:\\Users\\Administrator\\AppData\\Roaming\\com.differentai.openwork",
+    shortcutPath: "C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Blue Yonder.lnk",
   }), "C:\\Users\\Administrator\\AppData\\Local\\Programs\\@openworkdesktop\\OpenWork.exe");
 });
 

--- a/apps/desktop/electron/brand-icon-windows.test.mjs
+++ b/apps/desktop/electron/brand-icon-windows.test.mjs
@@ -181,7 +181,7 @@ test("anchors a packaged shortcut target to the active Windows user profile", ()
     packaged: true,
     execPath: "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Programs\\@openworkdesktop\\OpenWork.exe",
     resourcesPath: "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Programs\\@openworkdesktop\\resources",
-    appDataPath: "C:\\Users\\Administrator\\AppData\\Roaming",
+    userDataPath: "C:\\Users\\Administrator\\AppData\\Roaming\\com.differentai.openwork",
   }), "C:\\Users\\Administrator\\AppData\\Local\\Programs\\@openworkdesktop\\OpenWork.exe");
 });
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -310,26 +310,28 @@ function defaultAppWindowsIconPath() {
   return path.join(app.getPath("userData"), "openwork-stock.ico");
 }
 
+let cachedWindowsProgramsPath = null;
+function windowsProgramsPath() {
+  if (cachedWindowsProgramsPath) return cachedWindowsProgramsPath;
+  try {
+    cachedWindowsProgramsPath = execFileSync("powershell.exe", [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      "[Environment]::GetFolderPath('Programs')",
+    ], { encoding: "utf8", windowsHide: true }).trim();
+  } catch {
+    cachedWindowsProgramsPath = path.join(app.getPath("appData"), "Microsoft", "Windows", "Start Menu", "Programs");
+  }
+  return cachedWindowsProgramsPath;
+}
+
 function windowsBrandShortcutPath() {
-  return path.join(
-    app.getPath("appData"),
-    "Microsoft",
-    "Windows",
-    "Start Menu",
-    "Programs",
-    windowsBrandShortcutFileName(currentDisplayAppName),
-  );
+  return path.join(windowsProgramsPath(), windowsBrandShortcutFileName(currentDisplayAppName));
 }
 
 function windowsInstalledShortcutPath() {
-  return path.join(
-    app.getPath("appData"),
-    "Microsoft",
-    "Windows",
-    "Start Menu",
-    "Programs",
-    windowsInstalledShortcutFileName(APP_NAME),
-  );
+  return path.join(windowsProgramsPath(), windowsInstalledShortcutFileName(APP_NAME));
 }
 
 function windowsBrandShortcutMarkerPath() {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -39,6 +39,7 @@ import {
   windowsBrandShortcutDetails,
   windowsBrandShortcutFileName,
   windowsInstalledShortcutFileName,
+  windowsInstalledExecutablePath,
   writeWindowsBrandShortcut,
   windowsIconFromNativeImage,
 } from "./brand-icon-windows.mjs";
@@ -336,7 +337,12 @@ function windowsBrandShortcutMarkerPath() {
 }
 
 function windowsExecutablePath() {
-  return app.isPackaged ? app.getPath("exe") : process.execPath;
+  return windowsInstalledExecutablePath({
+    packaged: app.isPackaged,
+    execPath: app.getPath("exe"),
+    resourcesPath: process.resourcesPath,
+    appDataPath: app.getPath("appData"),
+  });
 }
 
 async function readWindowsBrandShortcutMarker() {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -341,7 +341,7 @@ function windowsExecutablePath() {
     packaged: app.isPackaged,
     execPath: app.getPath("exe"),
     resourcesPath: process.resourcesPath,
-    appDataPath: app.getPath("appData"),
+    userDataPath: app.getPath("userData"),
   });
 }
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -347,17 +347,20 @@ async function readWindowsBrandShortcutMarker() {
 async function registerWindowsBrandShortcut(appId, appIconPath) {
   if (process.platform !== "win32") return null;
   const shortcutPath = windowsBrandShortcutPath();
+  const shortcutTempPath = `${shortcutPath}.${process.pid}.tmp.lnk`;
   await mkdir(path.dirname(shortcutPath), { recursive: true });
   // Recreate instead of replacing in place. Explorer can retain the old
   // target and search metadata when a prior installer owned this path.
   await rm(shortcutPath, { force: true });
-  const written = writeWindowsBrandShortcut(shell, shortcutPath, windowsBrandShortcutDetails({
+  await rm(shortcutTempPath, { force: true });
+  const written = writeWindowsBrandShortcut(shell, shortcutTempPath, windowsBrandShortcutDetails({
     target: windowsExecutablePath(),
     appId,
     appIconPath,
     appName: currentDisplayAppName,
   }), false);
   if (!written) throw new Error(`Windows rejected the organization shortcut: ${shortcutPath}`);
+  await rename(shortcutTempPath, shortcutPath);
   const previousShortcutPath = await readWindowsBrandShortcutMarker();
   if (previousShortcutPath && previousShortcutPath !== shortcutPath) {
     await rm(previousShortcutPath, { force: true });

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -38,6 +38,7 @@ import {
   windowsBrandAppUserModelId,
   windowsBrandShortcutDetails,
   windowsBrandShortcutFileName,
+  windowsInstalledShortcutFileName,
   writeWindowsBrandShortcut,
   windowsIconFromNativeImage,
 } from "./brand-icon-windows.mjs";
@@ -315,8 +316,27 @@ function windowsBrandShortcutPath() {
     "Windows",
     "Start Menu",
     "Programs",
-    windowsBrandShortcutFileName(APP_NAME),
+    windowsBrandShortcutFileName(currentDisplayAppName),
   );
+}
+
+function windowsInstalledShortcutPath() {
+  return path.join(
+    app.getPath("appData"),
+    "Microsoft",
+    "Windows",
+    "Start Menu",
+    "Programs",
+    windowsInstalledShortcutFileName(APP_NAME),
+  );
+}
+
+function windowsBrandShortcutMarkerPath() {
+  return path.join(app.getPath("userData"), "windows-brand-shortcut.txt");
+}
+
+async function readWindowsBrandShortcutMarker() {
+  return (await readFile(windowsBrandShortcutMarkerPath(), "utf8").catch(() => "")).trim();
 }
 
 async function registerWindowsBrandShortcut(appId, appIconPath) {
@@ -329,15 +349,25 @@ async function registerWindowsBrandShortcut(appId, appIconPath) {
     target: process.execPath,
     appId,
     appIconPath,
-    appName: APP_NAME,
+    appName: currentDisplayAppName,
   }), existsSync(shortcutPath));
   if (!written) throw new Error(`Windows rejected the organization shortcut: ${shortcutPath}`);
+  const previousShortcutPath = await readWindowsBrandShortcutMarker();
+  if (previousShortcutPath && previousShortcutPath !== shortcutPath) {
+    await rm(previousShortcutPath, { force: true });
+  }
+  if (windowsInstalledShortcutPath() !== shortcutPath) {
+    await rm(windowsInstalledShortcutPath(), { force: true });
+  }
+  await writeFile(windowsBrandShortcutMarkerPath(), shortcutPath, "utf8");
   return shortcutPath;
 }
 
 async function removeWindowsBrandShortcut() {
   if (process.platform !== "win32") return;
-  await rm(windowsBrandShortcutPath(), { force: true });
+  const shortcutPath = await readWindowsBrandShortcutMarker();
+  if (shortcutPath) await rm(shortcutPath, { force: true });
+  await rm(windowsBrandShortcutMarkerPath(), { force: true });
 }
 
 function resolveBrandIconImage() {
@@ -379,19 +409,20 @@ async function applyAppIconImage(image, { taskbarIconPath = null, taskbarAppId =
       return { ok: true };
     }
 
-    if (!mainWindow) return brandIconFailure("window-unavailable");
     if (process.platform === "win32") {
       if (!taskbarIconPath || !existsSync(taskbarIconPath)) {
         return brandIconFailure("taskbar-icon-missing");
       }
+      if (!mainWindow) return { ok: true };
       await applyWindowsTaskbarIcon(mainWindow, {
         image,
         appId: taskbarAppId,
         appIconPath: taskbarIconPath,
         relaunchCommand: process.execPath,
-        relaunchDisplayName: APP_NAME,
+        relaunchDisplayName: currentDisplayAppName,
       });
     } else {
+      if (!mainWindow) return brandIconFailure("window-unavailable");
       mainWindow.setIcon(image);
     }
     return { ok: true };
@@ -431,6 +462,13 @@ async function applyDefaultAppIconImage(expectedSequence = null) {
     // Preserve the pre-existing no-op fallback on platforms whose packaged
     // application icon is managed entirely by the bundle.
     return process.platform === "win32" ? brandIconFailure("stock-icon-unavailable") : { ok: true };
+  }
+  if (process.platform === "win32" && taskbarIconPath) {
+    try {
+      await registerWindowsBrandShortcut(APP_IDENTIFIER, taskbarIconPath);
+    } catch (error) {
+      return brandIconFailure("shortcut-write-failed", error);
+    }
   }
   if (expectedSequence !== null && expectedSequence !== brandIconApplySequence) {
     return { ok: false, reason: "stale" };
@@ -1716,9 +1754,18 @@ const desktopCommandHandlers = {
   "__applyBrandAppName": async (event, ...args) => {
       const requested = args[0] === null ? "" : String(args[0] ?? "").trim();
       currentDisplayAppName = requested.slice(0, 64) || APP_NAME;
-      applicationMenu.setAppName(currentDisplayAppName);
-      mainWindow?.setTitle(currentDisplayAppName);
-      return { ok: true, appName: currentDisplayAppName };
+    applicationMenu.setAppName(currentDisplayAppName);
+    mainWindow?.setTitle(currentDisplayAppName);
+    if (process.platform === "win32") {
+      const sidecar = await readBrandIconSidecar();
+      const sourceUrl = typeof sidecar?.sourceUrl === "string" ? sidecar.sourceUrl : null;
+      const cachedImage = sourceUrl ? resolveBrandIconImage() : null;
+      if (cachedImage && sourceUrl) {
+        const iconPath = await ensureWindowsBrandIcon(cachedImage);
+        await registerWindowsBrandShortcut(windowsBrandAppUserModelId(APP_IDENTIFIER, sourceUrl), iconPath);
+      }
+    }
+    return { ok: true, appName: currentDisplayAppName };
   },
   "__applyBrandIcon": async (event, ...args) => {
       const value = args[0] === null ? null : String(args[0] ?? "");
@@ -2175,8 +2222,15 @@ if (!app.requestSingleInstanceLock()) {
 
   app.whenReady().then(async () => {
     installMediaPermissionHandlers(session, () => mainWindow);
-    applicationMenu.install();
     await workspaceStore.importBundledDesktopBootstrapConfigIfPreferred();
+    const bootstrapConfig = await workspaceStore.getDesktopBootstrapConfig();
+    currentDisplayAppName = bootstrapConfig.brandAppName?.slice(0, 64) || APP_NAME;
+    app.setName(currentDisplayAppName);
+    applicationMenu.setAppName(currentDisplayAppName);
+    if (process.platform === "win32" && bootstrapConfig.brandIconUrl) {
+      await applyBrandIconUrl(bootstrapConfig.brandIconUrl);
+    }
+    applicationMenu.install();
     await runtimeManager.prepareFreshRuntime().catch(() => undefined);
 
     // Use Tauri's existing workspace state file as canonical so rollback and

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -349,6 +349,23 @@ async function readWindowsBrandShortcutMarker() {
   return (await readFile(windowsBrandShortcutMarkerPath(), "utf8").catch(() => "")).trim();
 }
 
+function repairWindowsShortcutTarget(shortcutPath, details) {
+  const payload = Buffer.from(JSON.stringify({ shortcutPath, ...details }), "utf8").toString("base64");
+  const script = [
+    `$value = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('${payload}')) | ConvertFrom-Json`,
+    "$shell = New-Object -ComObject WScript.Shell",
+    "$link = $shell.CreateShortcut($value.shortcutPath)",
+    "$link.TargetPath = $value.target",
+    "$link.WorkingDirectory = $value.cwd",
+    "$link.Description = $value.description",
+    "$link.IconLocation = \"$($value.icon),$($value.iconIndex)\"",
+    "$link.Save()",
+  ].join("\n");
+  execFileSync("powershell.exe", ["-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", script], {
+    windowsHide: true,
+  });
+}
+
 async function registerWindowsBrandShortcut(appId, appIconPath) {
   if (process.platform !== "win32") return null;
   const shortcutPath = windowsBrandShortcutPath();
@@ -358,14 +375,18 @@ async function registerWindowsBrandShortcut(appId, appIconPath) {
   // target and search metadata when a prior installer owned this path.
   await rm(shortcutPath, { force: true });
   await rm(shortcutTempPath, { force: true });
-  const written = writeWindowsBrandShortcut(shell, shortcutTempPath, windowsBrandShortcutDetails({
+  const details = windowsBrandShortcutDetails({
     target: windowsExecutablePath(),
     appId,
     appIconPath,
     appName: currentDisplayAppName,
-  }), false);
+  });
+  const written = writeWindowsBrandShortcut(shell, shortcutTempPath, details, false);
   if (!written) throw new Error(`Windows rejected the organization shortcut: ${shortcutPath}`);
   await rename(shortcutTempPath, shortcutPath);
+  if (shell.readShortcutLink(shortcutPath).target !== details.target) {
+    repairWindowsShortcutTarget(shortcutPath, details);
+  }
   const previousShortcutPath = await readWindowsBrandShortcutMarker();
   if (previousShortcutPath && previousShortcutPath !== shortcutPath) {
     await rm(previousShortcutPath, { force: true });

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -343,14 +343,15 @@ async function registerWindowsBrandShortcut(appId, appIconPath) {
   if (process.platform !== "win32") return null;
   const shortcutPath = windowsBrandShortcutPath();
   await mkdir(path.dirname(shortcutPath), { recursive: true });
-  // Create is required for a first-time link; refreshes and relaunches replace
-  // the same per-user link so its icon and AppUserModelID stay current.
+  // Recreate instead of replacing in place. Explorer can retain the old
+  // target and search metadata when a prior installer owned this path.
+  await rm(shortcutPath, { force: true });
   const written = writeWindowsBrandShortcut(shell, shortcutPath, windowsBrandShortcutDetails({
     target: process.execPath,
     appId,
     appIconPath,
     appName: currentDisplayAppName,
-  }), existsSync(shortcutPath));
+  }), false);
   if (!written) throw new Error(`Windows rejected the organization shortcut: ${shortcutPath}`);
   const previousShortcutPath = await readWindowsBrandShortcutMarker();
   if (previousShortcutPath && previousShortcutPath !== shortcutPath) {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -336,8 +336,7 @@ function windowsBrandShortcutMarkerPath() {
 }
 
 function windowsExecutablePath() {
-  if (!app.isPackaged) return process.execPath;
-  return path.join(path.dirname(process.resourcesPath), path.basename(process.execPath));
+  return app.isPackaged ? app.getPath("exe") : process.execPath;
 }
 
 async function readWindowsBrandShortcutMarker() {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -341,7 +341,7 @@ function windowsExecutablePath() {
     packaged: app.isPackaged,
     execPath: app.getPath("exe"),
     resourcesPath: process.resourcesPath,
-    userDataPath: app.getPath("userData"),
+    shortcutPath: windowsBrandShortcutPath(),
   });
 }
 

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -335,6 +335,11 @@ function windowsBrandShortcutMarkerPath() {
   return path.join(app.getPath("userData"), "windows-brand-shortcut.txt");
 }
 
+function windowsExecutablePath() {
+  if (!app.isPackaged) return process.execPath;
+  return path.join(path.dirname(process.resourcesPath), path.basename(process.execPath));
+}
+
 async function readWindowsBrandShortcutMarker() {
   return (await readFile(windowsBrandShortcutMarkerPath(), "utf8").catch(() => "")).trim();
 }
@@ -347,7 +352,7 @@ async function registerWindowsBrandShortcut(appId, appIconPath) {
   // target and search metadata when a prior installer owned this path.
   await rm(shortcutPath, { force: true });
   const written = writeWindowsBrandShortcut(shell, shortcutPath, windowsBrandShortcutDetails({
-    target: process.execPath,
+    target: windowsExecutablePath(),
     appId,
     appIconPath,
     appName: currentDisplayAppName,
@@ -419,7 +424,7 @@ async function applyAppIconImage(image, { taskbarIconPath = null, taskbarAppId =
         image,
         appId: taskbarAppId,
         appIconPath: taskbarIconPath,
-        relaunchCommand: process.execPath,
+        relaunchCommand: windowsExecutablePath(),
         relaunchDisplayName: currentDisplayAppName,
       });
     } else {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -313,16 +313,8 @@ function defaultAppWindowsIconPath() {
 let cachedWindowsProgramsPath = null;
 function windowsProgramsPath() {
   if (cachedWindowsProgramsPath) return cachedWindowsProgramsPath;
-  try {
-    cachedWindowsProgramsPath = execFileSync("powershell.exe", [
-      "-NoProfile",
-      "-NonInteractive",
-      "-Command",
-      "[Environment]::GetFolderPath('Programs')",
-    ], { encoding: "utf8", windowsHide: true }).trim();
-  } catch {
-    cachedWindowsProgramsPath = path.join(app.getPath("appData"), "Microsoft", "Windows", "Start Menu", "Programs");
-  }
+  const userProfile = app.getPath("userData").split(/[\\/]AppData[\\/]/i)[0];
+  cachedWindowsProgramsPath = path.join(userProfile, "AppData", "Roaming", "Microsoft", "Windows", "Start Menu", "Programs");
   return cachedWindowsProgramsPath;
 }
 
@@ -679,6 +671,22 @@ async function ensureWindowsBrandIcon(image) {
   const windowsPath = brandIconWindowsPath();
   if (!existsSync(windowsPath)) await writeWindowsIconFile(image, windowsPath);
   return windowsPath;
+}
+
+async function registerWindowsDisplayShortcut() {
+  if (process.platform !== "win32") return;
+  const sidecar = await readBrandIconSidecar();
+  const sourceUrl = typeof sidecar?.sourceUrl === "string" ? sidecar.sourceUrl : null;
+  const brandedImage = sourceUrl ? resolveBrandIconImage() : null;
+  if (brandedImage && sourceUrl) {
+    const iconPath = await ensureWindowsBrandIcon(brandedImage);
+    await registerWindowsBrandShortcut(windowsBrandAppUserModelId(APP_IDENTIFIER, sourceUrl), iconPath);
+    return;
+  }
+  const stockImage = APP_ICON_IMAGE ?? await app.getFileIcon(windowsExecutablePath(), { size: "large" });
+  const iconPath = defaultAppWindowsIconPath();
+  await writeWindowsIconFile(stockImage, iconPath);
+  await registerWindowsBrandShortcut(APP_IDENTIFIER, iconPath);
 }
 
 async function applyCachedBrandIcon(image, sourceUrl, expectedSequence = null) {
@@ -1794,13 +1802,7 @@ const desktopCommandHandlers = {
     applicationMenu.setAppName(currentDisplayAppName);
     mainWindow?.setTitle(currentDisplayAppName);
     if (process.platform === "win32") {
-      const sidecar = await readBrandIconSidecar();
-      const sourceUrl = typeof sidecar?.sourceUrl === "string" ? sidecar.sourceUrl : null;
-      const cachedImage = sourceUrl ? resolveBrandIconImage() : null;
-      if (cachedImage && sourceUrl) {
-        const iconPath = await ensureWindowsBrandIcon(cachedImage);
-        await registerWindowsBrandShortcut(windowsBrandAppUserModelId(APP_IDENTIFIER, sourceUrl), iconPath);
-      }
+      await registerWindowsDisplayShortcut();
     }
     return { ok: true, appName: currentDisplayAppName };
   },
@@ -2264,6 +2266,9 @@ if (!app.requestSingleInstanceLock()) {
     currentDisplayAppName = bootstrapConfig.brandAppName?.slice(0, 64) || APP_NAME;
     app.setName(currentDisplayAppName);
     applicationMenu.setAppName(currentDisplayAppName);
+    if (process.platform === "win32") {
+      await registerWindowsDisplayShortcut();
+    }
     if (process.platform === "win32" && bootstrapConfig.brandIconUrl) {
       await applyBrandIconUrl(bootstrapConfig.brandIconUrl);
     }

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -266,6 +266,7 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
     const apiBaseUrl = typeof input?.apiBaseUrl === "string" ? input.apiBaseUrl.trim() : "";
     const brandAppName = typeof input?.brandAppName === "string" ? input.brandAppName.trim().slice(0, 64) : "";
     const brandLogoUrl = typeof input?.brandLogoUrl === "string" ? input.brandLogoUrl.trim() : "";
+    const brandIconUrl = typeof input?.brandIconUrl === "string" ? input.brandIconUrl.trim() : "";
 
     return {
       baseUrl,
@@ -273,6 +274,7 @@ export function createWorkspaceStore({ app, defaultDenBaseUrl, defaultRequireSig
       requireSignin: forceRequireSignin || input?.requireSignin === true,
       ...(brandAppName ? { brandAppName } : {}),
       ...(brandLogoUrl ? { brandLogoUrl } : {}),
+      ...(brandIconUrl ? { brandIconUrl } : {}),
       ...(writtenAt ? { writtenAt } : {}),
       ...(claimLinks.length > 0 ? { claimLinks } : {}),
       ...(normalizedHandoff ? { handoff: normalizedHandoff } : {}),

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -379,6 +379,7 @@ test("imports the newest organization bootstrap beside a Windows installer when 
       requireSignin: true,
       brandAppName: "Example Org Work",
       brandLogoUrl: "https://openwork.internal.example/logo.png",
+      brandIconUrl: "https://openwork.internal.example/icon.png",
       writtenAt: "2026-07-10T12:00:00.000Z",
     });
 
@@ -390,6 +391,7 @@ test("imports the newest organization bootstrap beside a Windows installer when 
       requireSignin: true,
       brandAppName: "Example Org Work",
       brandLogoUrl: "https://openwork.internal.example/logo.png",
+      brandIconUrl: "https://openwork.internal.example/icon.png",
       writtenAt: "2026-07-10T12:00:00.000Z",
     });
     const persisted = JSON.parse(await readFile(canonicalPath, "utf8"));

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -129,6 +129,7 @@ function buildInstallConfig(input: { organization: { name: string; logo: string 
     apiUrl: resolvePublicOrigin(input.request, env.apiPublicUrl),
     requireSignin: true,
     logoUrl: typeof metadata.brandLogoUrl === "string" ? metadata.brandLogoUrl : input.organization.logo ?? null,
+    iconUrl: typeof metadata.brandIconUrl === "string" ? metadata.brandIconUrl : null,
   })
 }
 
@@ -400,6 +401,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         requireSignin: resolved.config.requireSignin,
         brandAppName: resolved.config.appName,
         brandLogoUrl: resolved.config.logoUrl ?? undefined,
+        brandIconUrl: resolved.config.iconUrl ?? undefined,
         writtenAt: new Date().toISOString(),
       })
       const bundle = createStoredZipStream([

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -47,7 +47,10 @@ mock.module("../src/db.js", () => ({
               name: "Acme Robotics",
               slug: "acme-robotics",
               logo: null,
-              metadata: { capabilities: { installLinks: true } },
+              metadata: {
+                capabilities: { installLinks: true },
+                brandIconUrl: "https://assets.blueyonder.test/icon.png",
+              },
             },
           }]
         : []
@@ -89,7 +92,10 @@ mock.module("../src/orgs.js", () => ({
             name: "Acme Robotics",
             slug: "acme-robotics",
             logo: null,
-            metadata: { capabilities: { installLinks: capabilityEnabled } },
+            metadata: {
+              capabilities: { installLinks: capabilityEnabled },
+              brandIconUrl: "https://assets.blueyonder.test/icon.png",
+            },
           },
           currentMember: {
             id: memberId,
@@ -327,6 +333,7 @@ test.each([
       baseUrl: process.env.BETTER_AUTH_URL,
       requireSignin: true,
       brandAppName: "OpenWork",
+      brandIconUrl: "https://assets.blueyonder.test/icon.png",
     })
     expect(bootstrap.apiBaseUrl).toBe("http://den.local")
     expect(Number.isFinite(Date.parse(bootstrap.writtenAt))).toBe(true)

--- a/evals/flows/windows-brand-icon-real-taskbar.flow.mjs
+++ b/evals/flows/windows-brand-icon-real-taskbar.flow.mjs
@@ -78,7 +78,7 @@ async function windowsExec(ctx, label, command) {
 
 async function assertWindowsBrandShortcut(ctx, expected) {
   const result = await windowsExec(ctx, "check organization shortcut", `
-$path = 'C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\OpenWork Organization.lnk'
+$path = 'C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\OpenWork.lnk'
 if (Test-Path -LiteralPath $path) { Write-Output 'present' } else { Write-Output 'absent' }
 `);
   const actual = result.stdout.match(/(?:^|\r?\n)(present|absent)(?:\r?\n|$)/)?.[1] ?? result.stdout.trim();
@@ -341,7 +341,7 @@ export default {
               `Expected restored stock icon, got ${JSON.stringify(state)}`,
             );
             ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Windows taskbar identity returned to the executable's stock icon", actual: JSON.stringify(state) });
-            await assertWindowsBrandShortcut(ctx, "absent");
+            await assertWindowsBrandShortcut(ctx, "present");
             await assertOpenWorkWindow(ctx);
           },
           screenshot: computerUseScreenshot("stock-icon-restored", { requireText: ["Search sessions"] }),

--- a/evals/flows/windows-organization-install-branding.flow.mjs
+++ b/evals/flows/windows-organization-install-branding.flow.mjs
@@ -1,0 +1,210 @@
+import {
+  daytonaComputerUsePress,
+  daytonaComputerUseStart,
+  daytonaComputerUseType,
+} from "../runner/daytona-computer-use.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("windows-organization-install-branding");
+const BUNDLE_DIR = "C:\\Users\\Administrator\\Downloads\\BlueYonder";
+const INSTALLER = `${BUNDLE_DIR}\\openwork-win-x64-0.17.20.exe`;
+const START_MENU = "C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs";
+const CONFIG = "C:\\Users\\Administrator\\AppData\\Local\\openwork\\desktop-bootstrap.json";
+
+function sandboxId(ctx) {
+  return (ctx.env.OPENWORK_EVAL_DAYTONA_SANDBOX_ID || ctx.env.OPENWORK_EVAL_DAYTONA_SANDBOX).trim();
+}
+
+async function windowsExec(ctx, label, command, timeout = 120) {
+  const encoded = Buffer.from(command, "utf16le").toString("base64");
+  const toolbox = (ctx.env.DAYTONA_TOOLBOX_URL || "https://proxy.app.daytona.io/toolbox").replace(/\/$/, "");
+  const response = await fetch(`${toolbox}/${encodeURIComponent(sandboxId(ctx))}/process/execute`, {
+    method: "POST",
+    headers: { authorization: `Bearer ${ctx.env.DAYTONA_API_KEY}`, "content-type": "application/json" },
+    body: JSON.stringify({ command: `powershell -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encoded}`, timeout }),
+    signal: AbortSignal.timeout((timeout + 15) * 1_000),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok || payload.exitCode !== 0) {
+    throw new Error(`${label} failed (${response.status}/${payload.exitCode ?? "unknown"}): ${payload.result ?? ""}`);
+  }
+  return typeof payload.result === "string" ? payload.result : "";
+}
+
+async function openRunCommand(ctx, command) {
+  await daytonaComputerUsePress(sandboxId(ctx), "r", ["cmd"]);
+  await new Promise((resolve) => setTimeout(resolve, 400));
+  await daytonaComputerUseType(sandboxId(ctx), command);
+  await daytonaComputerUsePress(sandboxId(ctx), "enter");
+}
+
+async function launchInstalledApp(ctx) {
+  await windowsExec(ctx, "stop previous app", `
+Get-Process OpenWork -ErrorAction SilentlyContinue | Stop-Process -Force -ErrorAction SilentlyContinue
+exit 0
+`);
+  await daytonaComputerUsePress(sandboxId(ctx), "cmd");
+  await new Promise((resolve) => setTimeout(resolve, 500));
+  await daytonaComputerUseType(sandboxId(ctx), "OpenWork");
+  await new Promise((resolve) => setTimeout(resolve, 1_500));
+  await daytonaComputerUsePress(sandboxId(ctx), "enter");
+  await new Promise((resolve) => setTimeout(resolve, 15_000));
+}
+
+export default {
+  id: "windows-organization-install-branding",
+  title: "Organization installs converge Windows Search, Start Menu, and shortcuts without losing server configuration",
+  kind: "user-facing",
+  requiresApp: false,
+  requiredEnv: ["DAYTONA_API_KEY", "OPENWORK_EVAL_DAYTONA_SANDBOX"],
+  steps: [
+    {
+      name: "Organization bundle",
+      run: async (ctx) => {
+        await ctx.prove("The Windows organization bundle keeps the standard installer beside its setup file", {
+          voiceover: vo[0],
+          action: async () => {
+            await daytonaComputerUseStart(sandboxId(ctx));
+            await openRunCommand(ctx, `explorer.exe ${BUNDLE_DIR}`);
+            await new Promise((resolve) => setTimeout(resolve, 1_500));
+          },
+          assert: async () => {
+            const result = await windowsExec(ctx, "inspect organization bundle", `
+[pscustomobject]@{
+  Installer = Test-Path '${INSTALLER}'
+  Bootstrap = Test-Path '${BUNDLE_DIR}\\desktop-bootstrap.json'
+} | ConvertTo-Json
+`);
+            ctx.assert(result.includes('"Installer":  true') && result.includes('"Bootstrap":  true'), result);
+          },
+          screenshot: { name: "organization-windows-bundle", sandboxCapture: "computer-use" },
+        });
+      },
+    },
+    {
+      name: "First launch branding",
+      run: async (ctx) => {
+        await ctx.prove("First launch imports the organization bootstrap before showing the branded window", {
+          voiceover: vo[1],
+          action: async () => {
+            await windowsExec(ctx, "install Blue Yonder", `
+$cmd = 'C:\\ow\\install-blue-yonder-proof.cmd'
+[IO.File]::WriteAllLines($cmd, @('@echo off', '${INSTALLER} /S'))
+schtasks /create /tn OWBrandProofInstall /tr $cmd /sc once /st 00:00 /ru Administrator /it /rl HIGHEST /f | Out-Null
+schtasks /run /tn OWBrandProofInstall | Out-Null
+for ($attempt = 0; $attempt -lt 60; $attempt += 1) {
+  Start-Sleep -Seconds 2
+  $task = schtasks /query /tn OWBrandProofInstall /fo list /v | Out-String
+  if ($task -notmatch 'Status:\s+Running') { break }
+}
+Start-Sleep -Seconds 5
+`);
+            await launchInstalledApp(ctx);
+          },
+          assert: async () => {
+            const result = await windowsExec(ctx, "inspect first launch", `
+$config = Get-Content '${CONFIG}' -Raw | ConvertFrom-Json
+[pscustomobject]@{
+  AppName = $config.brandAppName
+  BaseUrl = $config.baseUrl
+  Shortcut = Test-Path '${START_MENU}\\Blue Yonder.lnk'
+  StaleShortcut = Test-Path '${START_MENU}\\OpenWork.lnk'
+} | ConvertTo-Json
+`);
+            ctx.assert(result.includes('"AppName":  "Blue Yonder"'), result);
+            ctx.assert(result.includes('"BaseUrl":  "https://onprem.blueyonder.test"'), result);
+            ctx.assert(result.includes('"Shortcut":  true') && result.includes('"StaleShortcut":  false'), result);
+          },
+          screenshot: { name: "blue-yonder-first-window", sandboxCapture: "computer-use" },
+        });
+      },
+    },
+    {
+      name: "Windows Search identity",
+      run: async (ctx) => {
+        await ctx.prove("Windows Search exposes only the organization-named shortcut with its organization icon", {
+          voiceover: vo[2],
+          action: async () => {
+            await daytonaComputerUsePress(sandboxId(ctx), "cmd");
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            await daytonaComputerUseType(sandboxId(ctx), "Blue Yonder");
+            await new Promise((resolve) => setTimeout(resolve, 1_500));
+          },
+          assert: async () => {
+            const result = await windowsExec(ctx, "inspect branded shortcut", `
+$shell = New-Object -ComObject WScript.Shell
+$link = $shell.CreateShortcut('${START_MENU}\\Blue Yonder.lnk')
+[pscustomobject]@{ Target = $link.TargetPath; TargetExists = Test-Path $link.TargetPath; Icon = $link.IconLocation } | ConvertTo-Json
+`);
+            ctx.assert(result.includes('"TargetExists":  true'), result);
+            ctx.assert(result.includes("brand-icon.ico"), result);
+          },
+          screenshot: { name: "blue-yonder-windows-search", sandboxCapture: "computer-use" },
+        });
+      },
+    },
+    {
+      name: "Upgrade preserves server",
+      run: async (ctx) => {
+        await ctx.prove("Upgrade recreates branded shortcut metadata while preserving the newer on-prem configuration", {
+          voiceover: vo[3],
+          action: async () => {
+            await windowsExec(ctx, "prepare newer managed config", `
+$config = Get-Content '${CONFIG}' -Raw | ConvertFrom-Json
+$config.baseUrl = 'https://existing-onprem.blueyonder.test'
+$config.apiBaseUrl = 'https://api.existing-onprem.blueyonder.test'
+$config.writtenAt = (Get-Date).ToUniversalTime().AddMinutes(5).ToString('o')
+[IO.File]::WriteAllText('${CONFIG}', ($config | ConvertTo-Json), (New-Object Text.UTF8Encoding($false)))
+Remove-Item '${START_MENU}\\Blue Yonder.lnk' -Force
+Get-Process OpenWork -ErrorAction SilentlyContinue | Stop-Process -Force
+`);
+            await launchInstalledApp(ctx);
+          },
+          assert: async () => {
+            const result = await windowsExec(ctx, "inspect upgrade convergence", `
+$config = Get-Content '${CONFIG}' -Raw | ConvertFrom-Json
+[pscustomobject]@{ BaseUrl = $config.baseUrl; Shortcut = Test-Path '${START_MENU}\\Blue Yonder.lnk'; Stale = Test-Path '${START_MENU}\\OpenWork.lnk' } | ConvertTo-Json
+`);
+            ctx.assert(result.includes('"BaseUrl":  "https://existing-onprem.blueyonder.test"'), result);
+            ctx.assert(result.includes('"Shortcut":  true') && result.includes('"Stale":  false'), result);
+          },
+          screenshot: { name: "blue-yonder-after-upgrade", sandboxCapture: "computer-use" },
+        });
+      },
+    },
+    {
+      name: "Uninstall cleanup",
+      run: async (ctx) => {
+        await ctx.prove("Uninstall removes the managed organization shortcut without leaving stale OpenWork entries", {
+          voiceover: vo[4],
+          action: async () => {
+            await windowsExec(ctx, "uninstall Blue Yonder", `
+Get-Process OpenWork -ErrorAction SilentlyContinue | Stop-Process -Force
+$cmd = 'C:\\ow\\uninstall-blue-yonder-proof.cmd'
+[IO.File]::WriteAllLines($cmd, @('@echo off', '"C:\\Users\\Administrator\\AppData\\Local\\Programs\\@openworkdesktop\\Uninstall OpenWork.exe" /S'))
+schtasks /create /tn OWBrandProofUninstall /tr $cmd /sc once /st 00:00 /ru Administrator /it /rl HIGHEST /f | Out-Null
+schtasks /run /tn OWBrandProofUninstall | Out-Null
+Start-Sleep -Seconds 15
+`);
+            await daytonaComputerUsePress(sandboxId(ctx), "cmd");
+            await new Promise((resolve) => setTimeout(resolve, 500));
+            await daytonaComputerUseType(sandboxId(ctx), "Blue Yonder");
+          },
+          assert: async () => {
+            const result = await windowsExec(ctx, "inspect uninstall cleanup", `
+[pscustomobject]@{
+  BlueYonder = Test-Path '${START_MENU}\\Blue Yonder.lnk'
+  OpenWork = Test-Path '${START_MENU}\\OpenWork.lnk'
+  Marker = Test-Path 'C:\\Users\\Administrator\\AppData\\Roaming\\com.differentai.openwork\\windows-brand-shortcut.txt'
+} | ConvertTo-Json
+`);
+            ctx.assert(result.includes('"BlueYonder":  false'), result);
+            ctx.assert(result.includes('"OpenWork":  false'), result);
+            ctx.assert(result.includes('"Marker":  false'), result);
+          },
+          screenshot: { name: "windows-search-clean-after-uninstall", sandboxCapture: "computer-use" },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/windows-organization-install-branding.md
+++ b/evals/voiceovers/windows-organization-install-branding.md
@@ -1,0 +1,11 @@
+# windows-organization-install-branding — Organization branding replaces stale Windows install identity
+
+1. A Blue Yonder teammate extracts the organization download and runs the standard signed Windows installer beside its setup file.
+
+2. On first launch, the app connects to Blue Yonder's configured server and appears with the Blue Yonder name and icon, without exposing a stale OpenWork shortcut as the user-facing entry.
+
+3. In Windows Search and the Start Menu, the installed app is listed as Blue Yonder with the organization icon, and launching it opens the same configured desktop.
+
+4. An existing OpenWork installation upgrades through the same organization package. Its shortcut converges to Blue Yonder branding while its existing on-prem server configuration remains intact.
+
+5. After another launch, Windows Search, Start Menu, taskbar, and Alt-Tab consistently show Blue Yonder; uninstall removes the managed shortcuts cleanly without leaving duplicate organization or OpenWork entries.

--- a/packages/install-config/src/index.ts
+++ b/packages/install-config/src/index.ts
@@ -10,6 +10,7 @@ export const installConfigSchema = z.object({
   apiUrl: z.string().trim().url(),
   requireSignin: z.boolean(),
   logoUrl: z.string().trim().url().nullable(),
+  iconUrl: z.string().trim().url().nullable().default(null),
 }).meta({ ref: "InstallConfig" })
 
 export type InstallConfig = z.infer<typeof installConfigSchema>
@@ -20,6 +21,7 @@ export const desktopBootstrapConfigSchema = z.object({
   requireSignin: z.boolean(),
   brandAppName: z.string().trim().min(1).max(64).optional(),
   brandLogoUrl: z.string().trim().url().optional(),
+  brandIconUrl: z.string().trim().url().optional(),
   writtenAt: z.string().datetime(),
 }).meta({ ref: "DesktopBootstrapConfig" })
 


### PR DESCRIPTION
## Summary
- carry the organization icon URL from Den install metadata through `desktop-bootstrap.json`
- apply organization name/icon before the first Windows window and reconcile the per-user Start Menu shortcut/Search identity
- remove the stock `OpenWork.lnk`, repair stale shortcut targets, preserve newer on-prem bootstrap configuration, and clean the managed shortcut on uninstall
- add Windows shortcut/bootstrap regression coverage and a five-frame Daytona fraimz flow

## What was already solved
- `e8a028022b67b42e9fffa0b8a405dc97de0157f9` only improves the centered install-page/download-preparation UI
- the production bootstrap work already keeps the standard signed installer untouched, places `desktop-bootstrap.json` beside it, and preserves newer canonical configuration; this PR does not duplicate that flow

## Validation
- `pnpm --dir apps/desktop test` — 52 passed, 1 platform skip
- `bun test ee/apps/den-api/test/install-link-access.test.ts` — 12 passed
- `pnpm --dir apps/desktop typecheck:electron` — passed
- GitHub Windows native artifact: https://github.com/different-ai/openwork/actions/runs/29136592740 — passed
- Daytona Windows sandbox `0f127548-6e57-4f1a-bf8e-08e9468a1553`: real silent install, bootstrap import, branded window/shortcut creation, and uninstall cleanup exercised; standalone uninstall check removed executable, both shortcut names, and marker
- `pnpm fraimz --flow windows-organization-install-branding` — **Incomplete**: bundle assertion passes, but Daytona Windows Search automation intermittently fails to start the app in the signed-in desktop session after reinstall. The flow and failed report are retained for an exact reviewer rerun; no Passed claim is made.

## Reviewer repro
Set `DAYTONA_API_KEY`, `OPENWORK_EVAL_DAYTONA_SANDBOX`, and `OPENWORK_EVAL_DAYTONA_SANDBOX_ID`, then run:

```sh
pnpm fraimz --flow windows-organization-install-branding
```
