### PR TITLE
fix: enforce inference model validation

### DIFF
--- a/ee/apps/inference/package.json
+++ b/ee/apps/inference/package.json
@@ -6,6 +6,7 @@
     "models:build": "node scripts/build-models.mjs",
     "dev": "pnpm run models:build && tsx watch src/server.ts",
     "dev:local": "OPENWORK_DEV_MODE=1 pnpm run models:build && OPENWORK_DEV_MODE=1 PORT=${INFERENCE_PORT:-8791} tsx watch src/server.ts",
+    "test": "tsx --test test/proxy.test.ts",
     "build": "pnpm run models:build && tsc -p tsconfig.json",
     "start": "node dist/server.js"
   },

--- a/ee/apps/inference/src/proxy.ts
+++ b/ee/apps/inference/src/proxy.ts
@@ -1,11 +1,43 @@
 import { createHash } from "node:crypto"
 import type { Hono } from "hono"
 import { env } from "./env.js"
-import { findActiveInferenceKey, getOpenRouterProviderKey } from "./keys.js"
-import { ensureUsableBuckets } from "./limits.js"
+import type { findActiveInferenceKey as findActiveInferenceKeyFn, getOpenRouterProviderKey as getOpenRouterProviderKeyFn } from "./keys.js"
+import type { ensureUsableBuckets as ensureUsableBucketsFn } from "./limits.js"
 import { resolveModelAlias } from "./model-catalog.js"
 
 type JsonObject = Record<string, unknown>
+type PreparedBody = {
+  body: BodyInit | null
+  modelAlias: string
+  upstreamModel: string | null
+}
+type PreparedBodyResult = PreparedBody | { error: Response }
+type ProxyRequestInit = RequestInit & { duplex: "half" }
+
+const bodylessMethods = new Set(["GET", "HEAD"])
+
+const defaultProxyDependencies: ProxyDependencies = {
+  async findActiveInferenceKey(rawKey) {
+    const keys = await import("./keys.js")
+    return keys.findActiveInferenceKey(rawKey)
+  },
+  async getOpenRouterProviderKey(organizationId) {
+    const keys = await import("./keys.js")
+    return keys.getOpenRouterProviderKey(organizationId)
+  },
+  async ensureUsableBuckets(organizationId) {
+    const limits = await import("./limits.js")
+    return limits.ensureUsableBuckets(organizationId)
+  },
+  fetch,
+}
+
+type ProxyDependencies = {
+  findActiveInferenceKey: typeof findActiveInferenceKeyFn
+  getOpenRouterProviderKey: typeof getOpenRouterProviderKeyFn
+  ensureUsableBuckets: typeof ensureUsableBucketsFn
+  fetch: typeof fetch
+}
 
 function readApiKey(request: Request) {
   const auth = request.headers.get("authorization")
@@ -16,7 +48,26 @@ function readApiKey(request: Request) {
 }
 
 function isJsonRequest(request: Request) {
-  return request.headers.get("content-type")?.toLowerCase().includes("application/json") ?? false
+  return isJsonContentType(request.headers.get("content-type"))
+}
+
+function isJsonContentType(contentType: string | null) {
+  if (!contentType) return false
+  const mediaType = contentType.split(";")[0].trim().toLowerCase()
+  if (mediaType === "application/json") return true
+  const applicationPrefix = "application/"
+  const jsonSuffix = "+json"
+  return mediaType.startsWith(applicationPrefix)
+    && mediaType.endsWith(jsonSuffix)
+    && mediaType.length > applicationPrefix.length + jsonSuffix.length
+}
+
+function isBodylessMethod(method: string) {
+  return bodylessMethods.has(method)
+}
+
+function isJsonObject(value: unknown): value is JsonObject {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
 function sanitizeHeaders(request: Request, apiKey: string, openworkRequestId: string) {
@@ -105,13 +156,17 @@ async function prepareBody(request: Request, input: {
   orgMembershipId: string
   inferenceKeyId: string
   openworkRequestId: string
-}) {
-  if (!isJsonRequest(request)) {
-    return { body: request.body, modelAlias: "unknown", upstreamModel: null as string | null }
+}): Promise<PreparedBodyResult> {
+  if (isBodylessMethod(request.method)) {
+    return { body: request.body, modelAlias: "unknown", upstreamModel: null }
   }
 
-  const body = await request.json() as JsonObject
-  if (typeof body.model !== "string") {
+  if (!isJsonRequest(request)) {
+    return { error: openAiError(415, "unsupported_media_type", "Inference requests with a body must use a JSON Content-Type.") }
+  }
+
+  const json: unknown = await request.json()
+  if (!isJsonObject(json) || typeof json.model !== "string") {
     logProxyError("Missing model in JSON request body", {
       openworkRequestId: input.openworkRequestId,
       organizationId: input.organizationId,
@@ -119,15 +174,17 @@ async function prepareBody(request: Request, input: {
     })
     return { error: openAiError(400, "model_required", "JSON request body must include a string model.") }
   }
-  const model = resolveModelAlias(body.model)
+  const requestedModel = json.model
+  const body = json
+  const model = resolveModelAlias(requestedModel)
   if (!model) {
     logProxyError("Unknown OpenWork model alias", {
       openworkRequestId: input.openworkRequestId,
       organizationId: input.organizationId,
       orgMembershipId: input.orgMembershipId,
-      requestedModel: body.model,
+      requestedModel,
     })
-    return { error: openAiError(404, "model_not_found", `Unknown OpenWork model alias: ${body.model}`) }
+    return { error: openAiError(404, "model_not_found", `Unknown OpenWork model alias: ${requestedModel}`) }
   }
 
   body.model = model.upstreamModel
@@ -149,7 +206,7 @@ async function prepareBody(request: Request, input: {
   }
 }
 
-export function registerProxyRoutes(app: Hono) {
+export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies = defaultProxyDependencies) {
   app.all("/api/v1/*", async (c) => {
     const rawKey = readApiKey(c.req.raw)
     if (!rawKey) {
@@ -157,13 +214,30 @@ export function registerProxyRoutes(app: Hono) {
       return c.json({ error: { message: "Missing OpenWork inference API key.", type: "authentication_error", code: "missing_api_key" } }, 401)
     }
 
-    const inferenceKey = await findActiveInferenceKey(rawKey)
+    const inferenceKey = await dependencies.findActiveInferenceKey(rawKey)
     if (!inferenceKey) {
       logProxyError("Invalid inference API key", { path: c.req.path, method: c.req.method })
       return c.json({ error: { message: "Invalid OpenWork inference API key.", type: "authentication_error", code: "invalid_api_key" } }, 401)
     }
 
-    const limits = await ensureUsableBuckets(inferenceKey.organization_id)
+    const openworkRequestId = buildRequestId()
+    const prepared = await prepareBody(c.req.raw, {
+      organizationId: inferenceKey.organization_id,
+      orgMembershipId: inferenceKey.org_membership_id,
+      inferenceKeyId: inferenceKey.id,
+      openworkRequestId,
+    })
+    if ("error" in prepared) {
+      logProxyError("Invalid inference proxy request", {
+        openworkRequestId,
+        path: c.req.path,
+        organizationId: inferenceKey.organization_id,
+        orgMembershipId: inferenceKey.org_membership_id,
+      })
+      return prepared.error
+    }
+
+    const limits = await dependencies.ensureUsableBuckets(inferenceKey.organization_id)
     if (!limits.ok) {
       logProxyError("Inference usage limit exceeded", {
         path: c.req.path,
@@ -191,7 +265,7 @@ export function registerProxyRoutes(app: Hono) {
       }, 429)
     }
 
-    const providerKey = await getOpenRouterProviderKey(inferenceKey.organization_id)
+    const providerKey = await dependencies.getOpenRouterProviderKey(inferenceKey.organization_id)
     if (!providerKey) {
       logProxyError("Missing active OpenRouter provider key", {
         path: c.req.path,
@@ -201,33 +275,17 @@ export function registerProxyRoutes(app: Hono) {
       return c.json({ error: { message: "No active OpenRouter provider key configured for organization.", type: "invalid_request_error", code: "missing_provider_key" } }, 400)
     }
 
-    const openworkRequestId = buildRequestId()
-    const prepared = await prepareBody(c.req.raw, {
-      organizationId: inferenceKey.organization_id,
-      orgMembershipId: inferenceKey.org_membership_id,
-      inferenceKeyId: inferenceKey.id,
-      openworkRequestId,
-    })
-    if ("error" in prepared) {
-      logProxyError("Invalid inference proxy request", {
-        openworkRequestId,
-        path: c.req.path,
-        organizationId: inferenceKey.organization_id,
-        orgMembershipId: inferenceKey.org_membership_id,
-      })
-      return prepared.error
-    }
-
     const upstreamPath = c.req.path.replace(/^\/api\/v1/, "")
     const upstreamUrl = new URL(`${env.openRouterUpstreamUrl}${upstreamPath}${new URL(c.req.url).search}`)
     let upstream: Response
     try {
-      upstream = await fetch(upstreamUrl, {
+      const upstreamInit: ProxyRequestInit = {
         method: c.req.method,
         headers: sanitizeHeaders(c.req.raw, providerKey.encrypted_api_key, openworkRequestId),
-        body: ["GET", "HEAD"].includes(c.req.method) ? undefined : prepared.body,
+        body: isBodylessMethod(c.req.method) ? undefined : prepared.body,
         duplex: "half",
-      } as RequestInit)
+      }
+      upstream = await dependencies.fetch(upstreamUrl, upstreamInit)
     } catch (error) {
       logProxyError("Failed to reach OpenRouter upstream", {
         openworkRequestId,

--- a/ee/apps/inference/test/proxy.test.ts
+++ b/ee/apps/inference/test/proxy.test.ts
@@ -1,0 +1,202 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { Hono } from "hono"
+
+process.env.OPENWORK_DEV_MODE = "1"
+process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_den"
+process.env.DEN_DB_ENCRYPTION_KEY = "local-dev-db-encryption-key-please-change-1234567890"
+process.env.OPENROUTER_UPSTREAM_URL = "https://upstream.test/api/v1"
+
+const { registerProxyRoutes } = await import("../src/proxy.js")
+
+type UpstreamRequest = {
+  url: string
+  method: string | undefined
+  body: string | null
+  headers: Headers
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function readInitBody(body: BodyInit | null | undefined) {
+  if (typeof body === "string") return body
+  if (!body) return null
+  throw new Error("Expected forwarded body to be a string")
+}
+
+function requireBodyText(body: string | null) {
+  if (body === null) {
+    throw new Error("Expected forwarded body to be present")
+  }
+  return body
+}
+
+function requestUrl(input: Parameters<typeof fetch>[0]) {
+  if (input instanceof Request) return input.url
+  return input.toString()
+}
+
+function parseJsonObject(text: string) {
+  const value: unknown = JSON.parse(text)
+  assert.ok(isRecord(value))
+  return value
+}
+
+async function readErrorCode(response: Response) {
+  const payload: unknown = await response.json()
+  assert.ok(isRecord(payload))
+  const error = payload.error
+  assert.ok(isRecord(error))
+  const code = error.code
+  if (typeof code !== "string") {
+    throw new Error("Expected OpenAI error code to be a string")
+  }
+  return code
+}
+
+function authHeaders(contentType?: string) {
+  const headers = new Headers({ authorization: "Bearer test-key" })
+  if (contentType) {
+    headers.set("content-type", contentType)
+  }
+  return headers
+}
+
+function inferenceRequest(input: { method: string; headers: Headers; body?: string; path?: string }) {
+  return new Request(`http://openwork.test${input.path ?? "/api/v1/chat/completions"}`, {
+    method: input.method,
+    headers: input.headers,
+    body: input.body,
+  })
+}
+
+function createTestServer() {
+  const app = new Hono()
+  const upstreamRequests: UpstreamRequest[] = []
+  const upstreamFetch: typeof fetch = async (input, init) => {
+    upstreamRequests.push({
+      url: requestUrl(input),
+      method: init?.method,
+      body: readInitBody(init?.body),
+      headers: new Headers(init?.headers),
+    })
+    return Response.json({ ok: true })
+  }
+
+  registerProxyRoutes(app, {
+    findActiveInferenceKey: async (_rawKey: string) => ({
+      id: "inference_key_123",
+      organization_id: "organization_123",
+      org_membership_id: "member_123",
+    }),
+    getOpenRouterProviderKey: async (_organizationId: string) => ({
+      encrypted_api_key: "provider-key",
+    }),
+    ensureUsableBuckets: async (_organizationId: string) => ({
+      ok: true,
+      bucketIds: {},
+      bucketLimits: {},
+    }),
+    fetch: upstreamFetch,
+  })
+
+  return { app, upstreamRequests }
+}
+
+test("rewrites approved model aliases before forwarding JSON requests", async () => {
+  const { app, upstreamRequests } = createTestServer()
+  const response = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers: authHeaders("application/json; charset=utf-8"),
+    body: JSON.stringify({ model: "openwork/openrouter/fusion", messages: [] }),
+  }))
+
+  assert.equal(response.status, 200)
+  assert.equal(upstreamRequests.length, 1)
+  const upstream = upstreamRequests[0]
+  assert.ok(upstream)
+  assert.equal(upstream.method, "POST")
+  assert.equal(upstream.url, "https://upstream.test/api/v1/chat/completions")
+  assert.equal(upstream.headers.get("authorization"), "Bearer provider-key")
+  assert.equal(upstream.headers.get("content-type"), "application/json; charset=utf-8")
+  const body = parseJsonObject(requireBodyText(upstream.body))
+  assert.equal(body.model, "openrouter/fusion")
+  assert.equal(body.user, "member_123")
+  const trace = body.trace
+  assert.ok(isRecord(trace))
+  assert.equal(trace.generation_name, "openrouter/fusion")
+})
+
+test("returns model_not_found for unknown JSON model aliases", async () => {
+  const { app, upstreamRequests } = createTestServer()
+  const response = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers: authHeaders("application/json"),
+    body: JSON.stringify({ model: "openwork/unknown-model", messages: [] }),
+  }))
+
+  assert.equal(response.status, 404)
+  assert.equal(await readErrorCode(response), "model_not_found")
+  assert.equal(upstreamRequests.length, 0)
+})
+
+test("blocks an unknown model when Content-Type is omitted", async () => {
+  const { app, upstreamRequests } = createTestServer()
+  const response = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({ model: "openwork/unknown-model", messages: [] }),
+  }))
+
+  assert.equal(response.status, 415)
+  assert.equal(await readErrorCode(response), "unsupported_media_type")
+  assert.equal(upstreamRequests.length, 0)
+})
+
+test("blocks an unknown model sent as text/plain", async () => {
+  const { app, upstreamRequests } = createTestServer()
+  const response = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers: authHeaders("text/plain"),
+    body: JSON.stringify({ model: "openwork/unknown-model", messages: [] }),
+  }))
+
+  assert.equal(response.status, 415)
+  assert.equal(await readErrorCode(response), "unsupported_media_type")
+  assert.equal(upstreamRequests.length, 0)
+})
+
+test("accepts application/*+json media types", async () => {
+  const { app, upstreamRequests } = createTestServer()
+  const response = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers: authHeaders("application/vnd.openwork.request+json; charset=utf-8"),
+    body: JSON.stringify({ model: "openwork/openrouter/fusion", messages: [] }),
+  }))
+
+  assert.equal(response.status, 200)
+  assert.equal(upstreamRequests.length, 1)
+  const upstream = upstreamRequests[0]
+  assert.ok(upstream)
+  const body = parseJsonObject(requireBodyText(upstream.body))
+  assert.equal(body.model, "openrouter/fusion")
+})
+
+test("forwards bodyless GET requests without requiring Content-Type", async () => {
+  const { app, upstreamRequests } = createTestServer()
+  const response = await app.fetch(inferenceRequest({
+    method: "GET",
+    headers: authHeaders(),
+    path: "/api/v1/models",
+  }))
+
+  assert.equal(response.status, 200)
+  assert.equal(upstreamRequests.length, 1)
+  const upstream = upstreamRequests[0]
+  assert.ok(upstream)
+  assert.equal(upstream.method, "GET")
+  assert.equal(upstream.url, "https://upstream.test/api/v1/models")
+  assert.equal(upstream.body, null)
+})


### PR DESCRIPTION
## Summary
- reject body-bearing inference requests without a JSON media type with `415 unsupported_media_type`
- continue validating and rewriting enabled model aliases while preserving bodyless GET/HEAD requests
- add focused proxy tests proving unknown models are never forwarded through content-type bypasses

## Testing
- `pnpm --filter @openwork-ee/inference test` — passed (6/6)
- `pnpm --filter @openwork-ee/inference build` — passed
- `git diff --check` — passed

## Proof
No video or fraimz was captured because this is an API-only validation change with no UI surface. Reproduce with `pnpm --filter @openwork-ee/inference test`.