### PR TITLE
fix: restrict inference model routing

### DIFF
--- a/ee/apps/inference/src/proxy.ts
+++ b/ee/apps/inference/src/proxy.ts
@@ -1,9 +1,9 @@
 import { createHash } from "node:crypto"
-import type { Hono } from "hono"
+import type { Context, Hono } from "hono"
 import { env } from "./env.js"
 import type { findActiveInferenceKey as findActiveInferenceKeyFn, getOpenRouterProviderKey as getOpenRouterProviderKeyFn } from "./keys.js"
 import type { ensureUsableBuckets as ensureUsableBucketsFn } from "./limits.js"
-import { resolveModelAlias } from "./model-catalog.js"
+import { listModelCatalog, resolveModelAlias } from "./model-catalog.js"
 
 type JsonObject = Record<string, unknown>
 type PreparedBody = {
@@ -14,7 +14,16 @@ type PreparedBody = {
 type PreparedBodyResult = PreparedBody | { error: Response }
 type ProxyRequestInit = RequestInit & { duplex: "half" }
 
-const bodylessMethods = new Set(["GET", "HEAD"])
+const chatCompletionsPath = "/api/v1/chat/completions"
+const modelsPath = "/api/v1/models"
+const topLevelModelSelectorFields = ["models", "fallbacks", "preset", "route"]
+const pluginModelSelectorFields = ["model", "analysis_models", "allowed_models"]
+const blockedServerToolTypes = new Set([
+  "openrouter:advisor",
+  "openrouter:subagent",
+  "openrouter:fusion",
+  "openrouter:image_generation",
+])
 
 const defaultProxyDependencies: ProxyDependencies = {
   async findActiveInferenceKey(rawKey) {
@@ -62,20 +71,77 @@ function isJsonContentType(contentType: string | null) {
     && mediaType.length > applicationPrefix.length + jsonSuffix.length
 }
 
-function isBodylessMethod(method: string) {
-  return bodylessMethods.has(method)
-}
-
 function isJsonObject(value: unknown): value is JsonObject {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
-function sanitizeHeaders(request: Request, apiKey: string, openworkRequestId: string) {
-  const headers = new Headers(request.headers)
-  for (const name of ["authorization", "x-api-key", "host", "content-length", "connection", "accept-encoding"]) {
-    headers.delete(name)
+function hasOwnField(value: JsonObject, field: string) {
+  return Object.prototype.hasOwnProperty.call(value, field)
+}
+
+function findPresentField(value: JsonObject, fields: string[]) {
+  return fields.find((field) => hasOwnField(value, field)) ?? null
+}
+
+function normalizeOpenRouterToolType(type: string) {
+  return type.trim().toLowerCase().replace(/-/g, "_")
+}
+
+function findBlockedPluginSelector(json: JsonObject) {
+  const plugins = json.plugins
+  if (!Array.isArray(plugins)) return null
+
+  for (const plugin of plugins) {
+    if (!isJsonObject(plugin)) continue
+
+    if (typeof plugin.id === "string" && plugin.id.trim().toLowerCase() === "fusion") {
+      return "plugins[].id"
+    }
+
+    const field = findPresentField(plugin, pluginModelSelectorFields)
+    if (field) return `plugins[].${field}`
+
+    if (isJsonObject(plugin.parameters)) {
+      const parametersField = findPresentField(plugin.parameters, pluginModelSelectorFields)
+      if (parametersField) return `plugins[].parameters.${parametersField}`
+    }
   }
+
+  return null
+}
+
+function findBlockedServerTool(json: JsonObject) {
+  const tools = json.tools
+  if (!Array.isArray(tools)) return null
+
+  for (const tool of tools) {
+    if (!isJsonObject(tool) || typeof tool.type !== "string") continue
+    const type = normalizeOpenRouterToolType(tool.type)
+    if (blockedServerToolTypes.has(type)) return tool.type
+  }
+
+  return null
+}
+
+function validateModelSelection(json: JsonObject) {
+  const topLevelField = findPresentField(json, topLevelModelSelectorFields)
+  if (topLevelField) return `top-level ${topLevelField}`
+
+  const pluginSelector = findBlockedPluginSelector(json)
+  if (pluginSelector) return pluginSelector
+
+  const serverTool = findBlockedServerTool(json)
+  if (serverTool) return `server tool ${serverTool}`
+
+  return null
+}
+
+function sanitizeHeaders(request: Request, apiKey: string, openworkRequestId: string) {
+  const headers = new Headers()
+  const accept = request.headers.get("accept")
+  if (accept) headers.set("accept", accept)
   headers.set("authorization", `Bearer ${apiKey}`)
+  headers.set("content-type", "application/json")
   headers.set("x-openwork-request-id", openworkRequestId)
   if (env.proxyBaseUrl) {
     headers.set("http-referer", env.proxyBaseUrl)
@@ -157,16 +223,12 @@ async function prepareBody(request: Request, input: {
   inferenceKeyId: string
   openworkRequestId: string
 }): Promise<PreparedBodyResult> {
-  if (isBodylessMethod(request.method)) {
-    return { body: request.body, modelAlias: "unknown", upstreamModel: null }
-  }
-
   if (!isJsonRequest(request)) {
     return { error: openAiError(415, "unsupported_media_type", "Inference requests with a body must use a JSON Content-Type.") }
   }
 
   const json: unknown = await request.json()
-  if (!isJsonObject(json) || typeof json.model !== "string") {
+  if (!isJsonObject(json)) {
     logProxyError("Missing model in JSON request body", {
       openworkRequestId: input.openworkRequestId,
       organizationId: input.organizationId,
@@ -174,6 +236,27 @@ async function prepareBody(request: Request, input: {
     })
     return { error: openAiError(400, "model_required", "JSON request body must include a string model.") }
   }
+
+  const blockedSelection = validateModelSelection(json)
+  if (blockedSelection) {
+    logProxyError("Unsupported OpenRouter model selection feature", {
+      openworkRequestId: input.openworkRequestId,
+      organizationId: input.organizationId,
+      orgMembershipId: input.orgMembershipId,
+      blockedSelection,
+    })
+    return { error: openAiError(400, "unsupported_model_selection", `OpenWork inference does not allow alternate model selection (${blockedSelection}).`) }
+  }
+
+  if (typeof json.model !== "string") {
+    logProxyError("Missing model in JSON request body", {
+      openworkRequestId: input.openworkRequestId,
+      organizationId: input.organizationId,
+      orgMembershipId: input.orgMembershipId,
+    })
+    return { error: openAiError(400, "model_required", "JSON request body must include a string model.") }
+  }
+
   const requestedModel = json.model
   const body = json
   const model = resolveModelAlias(requestedModel)
@@ -189,7 +272,7 @@ async function prepareBody(request: Request, input: {
 
   body.model = model.upstreamModel
   body.user = input.orgMembershipId
-  body.session_id = typeof body.session_id === "string" ? body.session_id : input.openworkRequestId
+  body.session_id = input.openworkRequestId
   body.trace = {
     trace_id: input.openworkRequestId,
     trace_name: "OpenWork Inference",
@@ -206,8 +289,30 @@ async function prepareBody(request: Request, input: {
   }
 }
 
+function listOpenAiModels() {
+  return {
+    object: "list",
+    data: listModelCatalog().map((model) => ({
+      id: model.alias,
+      object: "model",
+      created: 0,
+      owned_by: "openwork",
+    })),
+  }
+}
+
+function localRouteRejection(path: string, method: string) {
+  if (path === chatCompletionsPath) {
+    return openAiError(405, "method_not_allowed", `Method ${method} is not allowed for ${path}. Use POST.`)
+  }
+  if (path === modelsPath) {
+    return openAiError(405, "method_not_allowed", `Method ${method} is not allowed for ${path}. Use GET.`)
+  }
+  return openAiError(404, "not_found", `Unsupported OpenWork inference route: ${method} ${path}.`)
+}
+
 export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies = defaultProxyDependencies) {
-  app.all("/api/v1/*", async (c) => {
+  async function handleApiRequest(c: Context) {
     const rawKey = readApiKey(c.req.raw)
     if (!rawKey) {
       logProxyError("Missing inference API key", { path: c.req.path, method: c.req.method })
@@ -218,6 +323,18 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
     if (!inferenceKey) {
       logProxyError("Invalid inference API key", { path: c.req.path, method: c.req.method })
       return c.json({ error: { message: "Invalid OpenWork inference API key.", type: "authentication_error", code: "invalid_api_key" } }, 401)
+    }
+
+    if (c.req.path === modelsPath && c.req.method === "GET") {
+      return c.json(listOpenAiModels())
+    }
+
+    if (c.req.path !== chatCompletionsPath || c.req.method !== "POST") {
+      return localRouteRejection(c.req.path, c.req.method)
+    }
+
+    if (new URL(c.req.url).search) {
+      return openAiError(400, "unsupported_query_parameters", "OpenWork chat completions does not accept query parameters.")
     }
 
     const openworkRequestId = buildRequestId()
@@ -276,13 +393,13 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
     }
 
     const upstreamPath = c.req.path.replace(/^\/api\/v1/, "")
-    const upstreamUrl = new URL(`${env.openRouterUpstreamUrl}${upstreamPath}${new URL(c.req.url).search}`)
+    const upstreamUrl = new URL(`${env.openRouterUpstreamUrl}${upstreamPath}`)
     let upstream: Response
     try {
       const upstreamInit: ProxyRequestInit = {
         method: c.req.method,
         headers: sanitizeHeaders(c.req.raw, providerKey.encrypted_api_key, openworkRequestId),
-        body: isBodylessMethod(c.req.method) ? undefined : prepared.body,
+        body: prepared.body,
         duplex: "half",
       }
       upstream = await dependencies.fetch(upstreamUrl, upstreamInit)
@@ -314,5 +431,8 @@ export function registerProxyRoutes(app: Hono, dependencies: ProxyDependencies =
       async () => {},
       async () => {},
     ), { status: upstream.status, statusText: upstream.statusText, headers })
-  })
+  }
+
+  app.all("/api/v1", handleApiRequest)
+  app.all("/api/v1/*", handleApiRequest)
 }

--- a/ee/apps/inference/test/proxy.test.ts
+++ b/ee/apps/inference/test/proxy.test.ts
@@ -16,6 +16,12 @@ type UpstreamRequest = {
   headers: Headers
 }
 
+type DependencyCalls = {
+  findActiveInferenceKey: number
+  getOpenRouterProviderKey: number
+  ensureUsableBuckets: number
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -75,6 +81,11 @@ function inferenceRequest(input: { method: string; headers: Headers; body?: stri
 function createTestServer() {
   const app = new Hono()
   const upstreamRequests: UpstreamRequest[] = []
+  const calls: DependencyCalls = {
+    findActiveInferenceKey: 0,
+    getOpenRouterProviderKey: 0,
+    ensureUsableBuckets: 0,
+  }
   const upstreamFetch: typeof fetch = async (input, init) => {
     upstreamRequests.push({
       url: requestUrl(input),
@@ -86,27 +97,52 @@ function createTestServer() {
   }
 
   registerProxyRoutes(app, {
-    findActiveInferenceKey: async (_rawKey: string) => ({
-      id: "inference_key_123",
-      organization_id: "organization_123",
-      org_membership_id: "member_123",
-    }),
-    getOpenRouterProviderKey: async (_organizationId: string) => ({
-      encrypted_api_key: "provider-key",
-    }),
-    ensureUsableBuckets: async (_organizationId: string) => ({
-      ok: true,
-      bucketIds: {},
-      bucketLimits: {},
-    }),
+    async findActiveInferenceKey(_rawKey: string) {
+      calls.findActiveInferenceKey += 1
+      return {
+        id: "inference_key_123",
+        organization_id: "organization_123",
+        org_membership_id: "member_123",
+      }
+    },
+    async getOpenRouterProviderKey(_organizationId: string) {
+      calls.getOpenRouterProviderKey += 1
+      return {
+        encrypted_api_key: "provider-key",
+      }
+    },
+    async ensureUsableBuckets(_organizationId: string) {
+      calls.ensureUsableBuckets += 1
+      return {
+        ok: true,
+        bucketIds: {},
+        bucketLimits: {},
+      }
+    },
     fetch: upstreamFetch,
   })
 
-  return { app, upstreamRequests }
+  return { app, upstreamRequests, calls }
+}
+
+async function expectUnsupportedModelSelection(body: Record<string, unknown>) {
+  const { app, upstreamRequests, calls } = createTestServer()
+  const response = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers: authHeaders("application/json"),
+    body: JSON.stringify(body),
+  }))
+
+  assert.equal(response.status, 400)
+  assert.equal(await readErrorCode(response), "unsupported_model_selection")
+  assert.equal(calls.findActiveInferenceKey, 1)
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
+  assert.equal(upstreamRequests.length, 0)
 }
 
 test("rewrites approved model aliases before forwarding JSON requests", async () => {
-  const { app, upstreamRequests } = createTestServer()
+  const { app, upstreamRequests, calls } = createTestServer()
   const response = await app.fetch(inferenceRequest({
     method: "POST",
     headers: authHeaders("application/json; charset=utf-8"),
@@ -114,23 +150,26 @@ test("rewrites approved model aliases before forwarding JSON requests", async ()
   }))
 
   assert.equal(response.status, 200)
+  assert.equal(calls.ensureUsableBuckets, 1)
+  assert.equal(calls.getOpenRouterProviderKey, 1)
   assert.equal(upstreamRequests.length, 1)
   const upstream = upstreamRequests[0]
   assert.ok(upstream)
   assert.equal(upstream.method, "POST")
   assert.equal(upstream.url, "https://upstream.test/api/v1/chat/completions")
   assert.equal(upstream.headers.get("authorization"), "Bearer provider-key")
-  assert.equal(upstream.headers.get("content-type"), "application/json; charset=utf-8")
+  assert.equal(upstream.headers.get("content-type"), "application/json")
   const body = parseJsonObject(requireBodyText(upstream.body))
   assert.equal(body.model, "openrouter/fusion")
   assert.equal(body.user, "member_123")
+  assert.equal(body.session_id, upstream.headers.get("x-openwork-request-id"))
   const trace = body.trace
   assert.ok(isRecord(trace))
   assert.equal(trace.generation_name, "openrouter/fusion")
 })
 
 test("returns model_not_found for unknown JSON model aliases", async () => {
-  const { app, upstreamRequests } = createTestServer()
+  const { app, upstreamRequests, calls } = createTestServer()
   const response = await app.fetch(inferenceRequest({
     method: "POST",
     headers: authHeaders("application/json"),
@@ -139,11 +178,13 @@ test("returns model_not_found for unknown JSON model aliases", async () => {
 
   assert.equal(response.status, 404)
   assert.equal(await readErrorCode(response), "model_not_found")
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
   assert.equal(upstreamRequests.length, 0)
 })
 
 test("blocks an unknown model when Content-Type is omitted", async () => {
-  const { app, upstreamRequests } = createTestServer()
+  const { app, upstreamRequests, calls } = createTestServer()
   const response = await app.fetch(inferenceRequest({
     method: "POST",
     headers: authHeaders(),
@@ -152,11 +193,13 @@ test("blocks an unknown model when Content-Type is omitted", async () => {
 
   assert.equal(response.status, 415)
   assert.equal(await readErrorCode(response), "unsupported_media_type")
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
   assert.equal(upstreamRequests.length, 0)
 })
 
 test("blocks an unknown model sent as text/plain", async () => {
-  const { app, upstreamRequests } = createTestServer()
+  const { app, upstreamRequests, calls } = createTestServer()
   const response = await app.fetch(inferenceRequest({
     method: "POST",
     headers: authHeaders("text/plain"),
@@ -165,6 +208,8 @@ test("blocks an unknown model sent as text/plain", async () => {
 
   assert.equal(response.status, 415)
   assert.equal(await readErrorCode(response), "unsupported_media_type")
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
   assert.equal(upstreamRequests.length, 0)
 })
 
@@ -184,8 +229,112 @@ test("accepts application/*+json media types", async () => {
   assert.equal(body.model, "openrouter/fusion")
 })
 
-test("forwards bodyless GET requests without requiring Content-Type", async () => {
+test("does not forward caller headers or session IDs that can affect routing", async () => {
   const { app, upstreamRequests } = createTestServer()
+  const headers = authHeaders("application/json")
+  headers.set("x-session-id", "caller-session")
+  headers.set("x-openrouter-model", "attacker/model")
+  const response = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers,
+    body: JSON.stringify({ model: "openrouter/fusion", messages: [], session_id: "caller-session" }),
+  }))
+
+  assert.equal(response.status, 200)
+  const upstream = upstreamRequests[0]
+  assert.ok(upstream)
+  assert.equal(upstream.headers.get("x-session-id"), null)
+  assert.equal(upstream.headers.get("x-openrouter-model"), null)
+  const body = parseJsonObject(requireBodyText(upstream.body))
+  assert.equal(body.session_id, upstream.headers.get("x-openwork-request-id"))
+})
+
+for (const [field, value] of [
+  ["models", []],
+  ["fallbacks", null],
+  ["preset", ""],
+  ["route", null],
+] satisfies [string, unknown][]) {
+  test(`rejects the top-level ${field} selector when present`, async () => {
+    await expectUnsupportedModelSelection({
+      model: "openrouter/fusion",
+      messages: [],
+      [field]: value,
+    })
+  })
+}
+
+test("rejects the Fusion plugin", async () => {
+  await expectUnsupportedModelSelection({
+    model: "openrouter/fusion",
+    messages: [],
+    plugins: [{ id: "fusion" }],
+  })
+})
+
+for (const field of ["model", "analysis_models", "allowed_models"]) {
+  test(`rejects ${field} in an OpenRouter plugin context`, async () => {
+    await expectUnsupportedModelSelection({
+      model: "openrouter/fusion",
+      messages: [],
+      plugins: [{ id: "web", [field]: null }],
+    })
+  })
+
+  test(`rejects parameters.${field} in an OpenRouter plugin context`, async () => {
+    await expectUnsupportedModelSelection({
+      model: "openrouter/fusion",
+      messages: [],
+      plugins: [{ id: "web", parameters: { [field]: null } }],
+    })
+  })
+}
+
+for (const type of [
+  "openrouter:advisor",
+  "openrouter:subagent",
+  "openrouter:fusion",
+  "openrouter:image_generation",
+]) {
+  test(`rejects the ${type} server tool`, async () => {
+    await expectUnsupportedModelSelection({
+      model: "openrouter/fusion",
+      messages: [],
+      tools: [{ type }],
+    })
+  })
+}
+
+test("allows ordinary function tools with a model property in their JSON Schema", async () => {
+  const { app, upstreamRequests } = createTestServer()
+  const tools = [{
+    type: "function",
+    function: {
+      name: "inspect_model",
+      parameters: {
+        type: "object",
+        properties: {
+          model: { type: "string" },
+        },
+      },
+    },
+  }]
+  const response = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers: authHeaders("application/json"),
+    body: JSON.stringify({ model: "openrouter/fusion", messages: [], tools }),
+  }))
+
+  assert.equal(response.status, 200)
+  assert.equal(upstreamRequests.length, 1)
+  const upstream = upstreamRequests[0]
+  assert.ok(upstream)
+  const body = parseJsonObject(requireBodyText(upstream.body))
+  assert.deepEqual(body.tools, tools)
+})
+
+test("returns the authenticated local model catalog without forwarding", async () => {
+  const { app, upstreamRequests, calls } = createTestServer()
   const response = await app.fetch(inferenceRequest({
     method: "GET",
     headers: authHeaders(),
@@ -193,10 +342,114 @@ test("forwards bodyless GET requests without requiring Content-Type", async () =
   }))
 
   assert.equal(response.status, 200)
+  const payload: unknown = await response.json()
+  assert.ok(isRecord(payload))
+  assert.equal(payload.object, "list")
+  assert.ok(Array.isArray(payload.data))
+  assert.ok(payload.data.length > 0)
+  const model = payload.data[0]
+  assert.ok(isRecord(model))
+  assert.equal(typeof model.id, "string")
+  assert.ok(!model.id.startsWith("openwork/"))
+  assert.equal(calls.findActiveInferenceKey, 1)
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
+  assert.equal(upstreamRequests.length, 0)
+})
+
+test("returns model IDs that can be requested as aliases", async () => {
+  const { app, upstreamRequests } = createTestServer()
+  const modelsResponse = await app.fetch(inferenceRequest({
+    method: "GET",
+    headers: authHeaders(),
+    path: "/api/v1/models",
+  }))
+  const payload: unknown = await modelsResponse.json()
+  assert.ok(isRecord(payload))
+  assert.ok(Array.isArray(payload.data))
+  const listedModel = payload.data[0]
+  assert.ok(isRecord(listedModel))
+  if (typeof listedModel.id !== "string") {
+    throw new Error("Expected the local catalog to contain a model ID")
+  }
+
+  const chatResponse = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers: authHeaders("application/json"),
+    body: JSON.stringify({ model: listedModel.id, messages: [] }),
+  }))
+
+  assert.equal(chatResponse.status, 200)
   assert.equal(upstreamRequests.length, 1)
-  const upstream = upstreamRequests[0]
-  assert.ok(upstream)
-  assert.equal(upstream.method, "GET")
-  assert.equal(upstream.url, "https://upstream.test/api/v1/models")
-  assert.equal(upstream.body, null)
+})
+
+test("requires authentication before returning the local model catalog", async () => {
+  const { app, upstreamRequests, calls } = createTestServer()
+  const response = await app.fetch(inferenceRequest({
+    method: "GET",
+    headers: new Headers(),
+    path: "/api/v1/models",
+  }))
+
+  assert.equal(response.status, 401)
+  assert.equal(await readErrorCode(response), "missing_api_key")
+  assert.equal(calls.findActiveInferenceKey, 0)
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
+  assert.equal(upstreamRequests.length, 0)
+})
+
+for (const input of [
+  { method: "GET", path: "/api/v1/chat/completions", status: 405, code: "method_not_allowed" },
+  { method: "POST", path: "/api/v1/models", status: 405, code: "method_not_allowed" },
+  { method: "POST", path: "/api/v1/responses", status: 404, code: "not_found" },
+  { method: "GET", path: "/api/v1", status: 404, code: "not_found" },
+]) {
+  test(`blocks unsupported ${input.method} ${input.path} locally`, async () => {
+    const { app, upstreamRequests, calls } = createTestServer()
+    const response = await app.fetch(inferenceRequest({
+      method: input.method,
+      headers: authHeaders(),
+      path: input.path,
+    }))
+
+    assert.equal(response.status, input.status)
+    assert.equal(await readErrorCode(response), input.code)
+    assert.equal(calls.findActiveInferenceKey, 1)
+    assert.equal(calls.ensureUsableBuckets, 0)
+    assert.equal(calls.getOpenRouterProviderKey, 0)
+    assert.equal(upstreamRequests.length, 0)
+  })
+}
+
+test("blocks chat completion query parameters locally", async () => {
+  const { app, upstreamRequests, calls } = createTestServer()
+  const response = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers: authHeaders("application/json"),
+    path: "/api/v1/chat/completions?model=attacker/random-model",
+    body: JSON.stringify({ model: "openrouter/fusion", messages: [] }),
+  }))
+
+  assert.equal(response.status, 400)
+  assert.equal(await readErrorCode(response), "unsupported_query_parameters")
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
+  assert.equal(upstreamRequests.length, 0)
+})
+
+test("authenticates before rejecting unsupported routes", async () => {
+  const { app, upstreamRequests, calls } = createTestServer()
+  const response = await app.fetch(inferenceRequest({
+    method: "POST",
+    headers: new Headers(),
+    path: "/api/v1/responses",
+  }))
+
+  assert.equal(response.status, 401)
+  assert.equal(await readErrorCode(response), "missing_api_key")
+  assert.equal(calls.findActiveInferenceKey, 0)
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.getOpenRouterProviderKey, 0)
+  assert.equal(upstreamRequests.length, 0)
 })

--- a/evals/flows/inference-model-routing-hardening.flow.mjs
+++ b/evals/flows/inference-model-routing-hardening.flow.mjs
@@ -1,0 +1,119 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Narration is loaded from the approved script (evals/voiceovers/inference-model-routing-hardening.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("inference-model-routing-hardening");
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+let testRun;
+
+function runTests() {
+  testRun ??= spawnSync("pnpm", ["--filter", "@openwork-ee/inference", "test"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  return testRun;
+}
+
+function provePassingTests(ctx, names) {
+  const run = runTests();
+  const output = `${run.stdout ?? ""}\n${run.stderr ?? ""}`.trim();
+  ctx.assert(run.status === 0, `Inference regression tests exit 0 (actual: ${run.status})`);
+  for (const name of names) {
+    ctx.assert(output.includes(`✔ ${name}`), `Passing test witnessed: ${name}`);
+  }
+  ctx.output("$ pnpm --filter @openwork-ee/inference test", output);
+}
+
+export default {
+  id: "inference-model-routing-hardening",
+  title: "Only approved model selections reach OpenRouter",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Approved chat requests still work",
+      run: async (ctx) => {
+        await ctx.prove("An enabled alias is rewritten and forwarded through chat completions", {
+          voiceover: vo[0],
+          // "An authenticated client sends `POST /api/v1/chat/completions` with an enable"
+          assert: async () => {
+            provePassingTests(ctx, ["rewrites approved model aliases before forwarding JSON requests"]);
+          },
+        });
+      },
+    },
+    {
+      name: "Top-level alternate selectors are blocked",
+      run: async (ctx) => {
+        await ctx.prove("Every supported top-level alternate model selector is rejected locally", {
+          voiceover: vo[1],
+          // "Requests containing `models`, `fallbacks`, `preset`, or `route` are rejected"
+          assert: async () => {
+            provePassingTests(ctx, [
+              "rejects the top-level models selector when present",
+              "rejects the top-level fallbacks selector when present",
+              "rejects the top-level preset selector when present",
+              "rejects the top-level route selector when present",
+            ]);
+          },
+        });
+      },
+    },
+    {
+      name: "Nested selectors are blocked without breaking function tools",
+      run: async (ctx) => {
+        await ctx.prove("Model-selecting OpenRouter plugins and tools are blocked while ordinary tools remain valid", {
+          voiceover: vo[2],
+          // "OpenRouter tools/plugins that can select nested models—Fusion, advisor, suba"
+          assert: async () => {
+            provePassingTests(ctx, [
+              "rejects the Fusion plugin",
+              "rejects the openrouter:advisor server tool",
+              "rejects the openrouter:subagent server tool",
+              "rejects the openrouter:fusion server tool",
+              "rejects the openrouter:image_generation server tool",
+              "allows ordinary function tools with a model property in their JSON Schema",
+            ]);
+          },
+        });
+      },
+    },
+    {
+      name: "The proxy exposes only its intended API",
+      run: async (ctx) => {
+        await ctx.prove("The local model catalog is returned without forwarding and unsupported routes stay local", {
+          voiceover: vo[3],
+          // "Only approved inference routes and methods are accepted; `GET /api/v1/models"
+          assert: async () => {
+            provePassingTests(ctx, [
+              "returns the authenticated local model catalog without forwarding",
+              "blocks unsupported POST /api/v1/responses locally",
+              "authenticates before rejecting unsupported routes",
+            ]);
+          },
+        });
+      },
+    },
+    {
+      name: "The complete regression contract passes",
+      run: async (ctx) => {
+        await ctx.prove("All focused inference routing regression tests pass", {
+          voiceover: vo[4],
+          // "Regression tests prove no alternate model selector or unsupported route reac"
+          assert: async () => {
+            const run = runTests();
+            const output = `${run.stdout ?? ""}\n${run.stderr ?? ""}`;
+            ctx.assert(run.status === 0, "Focused inference tests exit successfully");
+            ctx.assert(output.includes("fail 0"), "No focused inference regression failed");
+            ctx.output("Focused regression result", output.trim());
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/inference-model-routing-hardening.md
+++ b/evals/voiceovers/inference-model-routing-hardening.md
@@ -1,0 +1,11 @@
+# inference-model-routing-hardening — Only approved model selections reach OpenRouter
+
+1. An authenticated client sends `POST /api/v1/chat/completions` with an enabled OpenWork model, and it is rewritten and forwarded normally.
+
+2. Requests containing `models`, `fallbacks`, `preset`, or `route` are rejected before reaching OpenRouter.
+
+3. OpenRouter tools/plugins that can select nested models—Fusion, advisor, subagent, and image generation—are rejected, while ordinary function tools remain supported.
+
+4. Only approved inference routes and methods are accepted; `GET /api/v1/models` returns the local enabled catalog instead of OpenRouter’s full catalog.
+
+5. Regression tests prove no alternate model selector or unsupported route reaches OpenRouter.


### PR DESCRIPTION
## Summary
- allow only authenticated `POST /api/v1/chat/completions` to reach OpenRouter and serve `GET /api/v1/models` from the enabled local catalog
- reject alternate top-level selectors, model-selecting OpenRouter plugins/tools, query parameters, caller routing headers, and caller-controlled session IDs
- keep ordinary function tools working and add regression coverage proving rejected requests never reach limits, provider lookup, or upstream fetch

## Testing
- `pnpm --filter @openwork-ee/inference test` — passed (31/31)
- `pnpm --filter @openwork-ee/inference build` — passed
- `git diff --check` — passed
- `pnpm fraimz --flow inference-model-routing-hardening` — passed

## Proof
- `evals/results/2026-07-11T22-21-52-869Z/fraimz.html`
- API-only internal fraimz; no UI video is applicable.