### PR TITLE
feat: add global pinned sessions

### DIFF
--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -6,7 +6,7 @@ import type { OpenworkServerClient, OpenworkWorkspaceInfo } from "../../../../ap
 import { setSessionArchived } from "../../../../app/lib/opencode-session";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
-import { useSessionManagementStore } from "../sidebar/session-management-store";
+import { isSessionPinnedInWorkspace, useSessionManagementStore } from "../sidebar/session-management-store";
 
 type SessionLike = {
   id?: string;
@@ -46,7 +46,15 @@ function findSessionWorkspace(
   sessionsByWorkspaceId: Record<string, SessionLike[]>,
   sessionId: string,
 ) {
-  return workspaces.find((workspace) => (
+  return findSessionWorkspaces(workspaces, sessionsByWorkspaceId, sessionId)[0];
+}
+
+function findSessionWorkspaces(
+  workspaces: SessionControlWorkspace[],
+  sessionsByWorkspaceId: Record<string, SessionLike[]>,
+  sessionId: string,
+) {
+  return workspaces.filter((workspace) => (
     sessionsByWorkspaceId[workspace.id] ?? []
   ).some((session) => session.id === sessionId));
 }
@@ -231,18 +239,41 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
   const pinControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.pin",
     label: "Pin or unpin a session",
-    description: "Toggle pin on a session. Pinned sessions float to the top of the sidebar.",
+    description: "Toggle pin on a session. Pinned sessions appear in the global Pinned section and float to the top of their workspace.",
     sideEffect: "mutation",
     requiresArgs: true,
-    args: [{ name: "sessionId", type: "string", required: true, description: "Session ID to pin/unpin." }],
+    args: [
+      { name: "sessionId", type: "string", required: true, description: "Session ID to pin/unpin." },
+      { name: "workspaceId", type: "string", required: false, description: "Workspace ID. Required when multiple workspaces have the same session ID." },
+    ],
     execute: (args) => {
       const sessionId = stringArg(args, "sessionId");
       if (!sessionId) return { ok: false, error: "sessionId is required" };
-      store.getState().togglePin(sessionId);
-      const pinned = store.getState().pinnedIds.includes(sessionId);
-      return { ok: true, sessionId, pinned };
+      const workspaceArg = stringArg(args, "workspaceId");
+      const requestedWorkspaceId = workspaceArg ? resolveWorkspaceId(workspaceArg) : undefined;
+      const ownerWorkspaces = findSessionWorkspaces(workspaces, sessionsByWorkspaceId, sessionId);
+      const targetWorkspace = requestedWorkspaceId
+        ? ownerWorkspaces.find((workspace) => workspace.id === requestedWorkspaceId)
+        : ownerWorkspaces.length === 1
+          ? ownerWorkspaces[0]
+          : undefined;
+
+      if (!targetWorkspace) {
+        return ownerWorkspaces.length > 1
+          ? { ok: false, error: "workspaceId is required because this session ID exists in multiple workspaces" }
+          : { ok: false, error: "Session was not found in the current session list" };
+      }
+
+      const currentPinned = isSessionPinnedInWorkspace(
+        store.getState().pinnedIds,
+        targetWorkspace.id,
+        sessionId,
+        ownerWorkspaces.length,
+      );
+      store.getState().setPin(targetWorkspace.id, sessionId, !currentPinned);
+      return { ok: true, sessionId, workspaceId: targetWorkspace.id, pinned: !currentPinned };
     },
-  }), []);
+  }), [resolveWorkspaceId, sessionsByWorkspaceId, workspaces]);
   useControlAction(pinControlAction);
 
   const archiveControlAction = useMemo<OpenworkControlAction>(() => ({

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -86,18 +86,20 @@ import type { SidebarContextValue } from "./app-sidebar-provider";
 import {
   MAX_SESSIONS_PREVIEW,
   buildSessionTreeState,
+  buildPinnedSessionLookup,
   flattenSessionRows,
+  getGlobalPinnedSessionEntries,
   getRootSessions,
+  isPinnedSessionInLookup,
   isSessionArchived,
   isStreamingSessionStatus,
   partitionArchivedSessions,
   workspaceKindLabel,
   workspaceLabel,
 } from "./utils";
-import type { FlattenedSessionRow, SessionListItem, SessionTreeState } from "./utils";
+import type { FlattenedSessionRow, GlobalPinnedSessionEntry, PinnedSessionLookup, SessionListItem, SessionTreeState } from "./utils";
 import {
   useSessionManagementStore,
-  usePinnedSessionIds,
   useSessionOrder,
   useWorkspaceGroups,
   type SessionGroupDefinition,
@@ -186,7 +188,7 @@ function SessionMenuContent({ variant, sessionId, workspaceId, isPinned, isArchi
   if (variant === "dropdown") {
     return (
       <>
-        <DropdownMenuItem onClick={() => store.getState().togglePin(sessionId)}>
+        <DropdownMenuItem onClick={() => store.getState().setPin(workspaceId, sessionId, !isPinned)}>
           {isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
           {isPinned ? t("session_management.unpin_session") : t("session_management.pin_session")}
         </DropdownMenuItem>
@@ -259,7 +261,7 @@ function SessionMenuContent({ variant, sessionId, workspaceId, isPinned, isArchi
 
   return (
     <>
-      <ContextMenuItem onClick={() => store.getState().togglePin(sessionId)}>
+      <ContextMenuItem onClick={() => store.getState().setPin(workspaceId, sessionId, !isPinned)}>
         {isPinned ? <PinOff className="size-4" /> : <Pin className="size-4" />}
         {isPinned ? t("session_management.unpin_session") : t("session_management.pin_session")}
       </ContextMenuItem>
@@ -732,6 +734,15 @@ export function AppSidebar(props: AppSidebarProps) {
   const brandLogoUrl = useBrandLogoUrl();
   const brandAppName = useBrandAppName();
   const hasManagedBrand = brandLogoUrl || brandAppName !== "OpenWork";
+  const pinnedIds = useSessionManagementStore((state) => state.pinnedIds);
+  const pinnedLookup = React.useMemo(
+    () => buildPinnedSessionLookup(props.workspaceSessionGroups, pinnedIds),
+    [pinnedIds, props.workspaceSessionGroups],
+  );
+  const globalPinnedSessions = React.useMemo(
+    () => getGlobalPinnedSessionEntries(props.workspaceSessionGroups, pinnedIds),
+    [pinnedIds, props.workspaceSessionGroups],
+  );
 
   return (
     <SidebarContext.Provider value={contextValue}>
@@ -782,6 +793,7 @@ export function AppSidebar(props: AppSidebarProps) {
             data-sidebar="content"
             className="no-scrollbar flex min-h-0 flex-1 flex-col gap-px overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden"
           >
+            <GlobalPinnedSessionsSection entries={globalPinnedSessions} />
             <Reorder.Group
               as="div"
               axis="y"
@@ -797,6 +809,7 @@ export function AppSidebar(props: AppSidebarProps) {
                   showInitialLoading={props.showInitialLoading}
                   previewCount={previewCount(group.workspace.id)}
                   showMoreSessions={showMoreSessions}
+                  pinnedLookup={pinnedLookup}
                 />
               ))}
             </Reorder.Group>
@@ -826,12 +839,98 @@ export function AppSidebar(props: AppSidebarProps) {
   );
 }
 
+function GlobalPinnedSessionsSection({ entries }: { entries: GlobalPinnedSessionEntry[] }) {
+  if (entries.length === 0) return null;
+
+  return (
+    <SidebarGroup className="pb-1 pt-0" data-testid="global-pinned-sessions">
+      <SidebarGroupContent>
+        <div className="flex items-center gap-1.5 px-2 pb-1 pt-2 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          <Pin className="size-3 shrink-0" />
+          <span>{t("session_management.pinned")}</span>
+          <span className="text-[10px] tabular-nums text-muted-foreground/70">{entries.length}</span>
+        </div>
+        <SidebarMenu data-testid="global-pinned-session-list" className="gap-px">
+          {entries.map((entry) => (
+            <GlobalPinnedSessionItem key={`${entry.workspace.id}:${entry.session.id}`} entry={entry} />
+          ))}
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
+function GlobalPinnedSessionItem({ entry }: { entry: GlobalPinnedSessionEntry }) {
+  const ctx = useSidebarContext();
+  const store = useSessionManagementStore;
+  const displayTitle = getDisplaySessionTitle(entry.session.title);
+  const isSelected = ctx.selectedWorkspaceId === entry.workspace.id && ctx.selectedSessionId === entry.session.id;
+  const sessionActivityStatus = ctx.sessionStatusById?.[entry.session.id];
+  const isSessionActive = Boolean(sessionActivityStatus && sessionActivityStatus !== "idle");
+  const isSessionStreaming = isStreamingSessionStatus(sessionActivityStatus);
+
+  const openSession = () => {
+    ctx.onOpenSession(entry.workspace.id, entry.session.id);
+  };
+
+  const prefetchSession = () => {
+    if (entry.workspace.id !== ctx.selectedWorkspaceId) return;
+    ctx.onPrefetchSession?.(entry.workspace.id, entry.session.id);
+  };
+
+  return (
+    <SidebarMenuItem
+      data-testid="global-pinned-session"
+      data-session-id={entry.session.id}
+      data-workspace-id={entry.workspace.id}
+    >
+      <SidebarMenuButton
+        isActive={isSelected}
+        onClick={openSession}
+        onPointerEnter={prefetchSession}
+        onFocus={prefetchSession}
+        className="h-auto min-h-10 items-start py-2 pe-9"
+        aria-label={`${displayTitle} (${entry.workspaceLabel})`}
+      >
+        <Pin className="mt-0.5 size-3.5 shrink-0 text-muted-foreground/70" />
+        <span className="min-w-0 flex-1">
+          <span className="block truncate" title={displayTitle}>{displayTitle}</span>
+          <span className="block truncate text-[11px] font-normal text-muted-foreground" title={entry.workspaceLabel}>
+            {entry.workspaceLabel}
+          </span>
+        </span>
+      </SidebarMenuButton>
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon-sm"
+        aria-label={`${t("session_management.unpin_session")}: ${displayTitle}`}
+        title={t("session_management.unpin_session")}
+        className="absolute right-2 top-5 size-6 -translate-y-1/2 text-muted-foreground opacity-0 group-hover/menu-item:opacity-100 group-focus-within/menu-item:opacity-100 focus-visible:opacity-100"
+        onClick={(event) => {
+          event.stopPropagation();
+          store.getState().setPin(entry.workspace.id, entry.session.id, false);
+        }}
+      >
+        <PinOff className="size-4" />
+      </Button>
+      <SessionStatusIndicator
+        className="absolute right-3 top-5 -translate-y-1/2 opacity-100 group-hover/menu-item:opacity-0 group-focus-within/menu-item:opacity-0 pointer-events-none select-none"
+        status={sessionActivityStatus}
+        isStreaming={isSessionStreaming}
+        isActive={isSessionActive}
+      />
+    </SidebarMenuItem>
+  );
+}
+
 type WorkspaceReorderItemProps = {
   className: string;
   group: WorkspaceSessionGroup;
   showInitialLoading?: boolean;
   previewCount: number;
   showMoreSessions: (workspaceId: string, totalRoots: number) => void;
+  pinnedLookup: PinnedSessionLookup;
 };
 
 function WorkspaceReorderItem({
@@ -840,6 +939,7 @@ function WorkspaceReorderItem({
   showInitialLoading,
   previewCount,
   showMoreSessions,
+  pinnedLookup,
 }: WorkspaceReorderItemProps) {
   const dragControls = useDragControls();
 
@@ -865,6 +965,7 @@ function WorkspaceReorderItem({
         showInitialLoading={showInitialLoading}
         previewCount={previewCount}
         showMoreSessions={showMoreSessions}
+        pinnedLookup={pinnedLookup}
         onWorkspaceTitlePointerDown={(event) => dragControls.start(event)}
       />
     </Reorder.Item>
@@ -936,6 +1037,7 @@ type WorkspaceSidebarGroupProps = {
   showInitialLoading?: boolean;
   previewCount: number;
   showMoreSessions: (workspaceId: string, totalRoots: number) => void;
+  pinnedLookup: PinnedSessionLookup;
   onWorkspaceTitlePointerDown: React.PointerEventHandler<HTMLDivElement>;
 };
 
@@ -945,6 +1047,7 @@ function WorkspaceSidebarGroup({
   showInitialLoading,
   previewCount,
   showMoreSessions,
+  pinnedLookup,
   onWorkspaceTitlePointerDown,
 }: WorkspaceSidebarGroupProps) {
   const ctx = useSidebarContext();
@@ -953,11 +1056,11 @@ function WorkspaceSidebarGroup({
 
   const forcedExpandedSessionIds = React.useMemo(
     () => new Set(
-      ctx.selectedSessionId
+      ctx.selectedWorkspaceId === workspace.id && ctx.selectedSessionId
         ? tree.ancestorIdsBySessionId.get(ctx.selectedSessionId) ?? []
         : [],
     ),
-    [ctx.selectedSessionId, tree.ancestorIdsBySessionId],
+    [ctx.selectedSessionId, ctx.selectedWorkspaceId, tree.ancestorIdsBySessionId, workspace.id],
   );
 
   const isConnecting = ctx.connectingWorkspaceId === workspace.id;
@@ -990,7 +1093,14 @@ function WorkspaceSidebarGroup({
     return workspaceKindLabel(workspace);
   })();
 
-  const pinnedIds = usePinnedSessionIds();
+  const pinnedIds = React.useMemo(
+    () => new Set(
+      group.sessions
+        .filter((session) => isPinnedSessionInLookup(pinnedLookup, workspace.id, session.id))
+        .map((session) => session.id),
+    ),
+    [group.sessions, pinnedLookup, workspace.id],
+  );
   const orderIds = useSessionOrder(workspace.id);
   const { groups: wsGroups, assignments: wsAssignments } = useWorkspaceGroups(workspace.id);
   const store = useSessionManagementStore;
@@ -1025,7 +1135,7 @@ function WorkspaceSidebarGroup({
     : t("workspace_list.show_more_fallback");
 
   return (
-    <SidebarGroup className={className}>
+    <SidebarGroup className={className} data-testid="workspace-sidebar-group" data-workspace-id={workspace.id}>
       <SidebarGroupContent>
         <SidebarMenu>
           <Collapsible
@@ -1066,6 +1176,7 @@ function WorkspaceSidebarGroup({
               <Button
                 variant="ghost"
                 size="icon"
+                data-testid="workspace-expand-toggle"
                 className="absolute right-2 top-1/2 size-6 -translate-y-1/2 text-muted-foreground flex items-center justify-center group/expand-collapse-button"
                 aria-label={isExpanded ? t("sidebar.collapse") : t("sidebar.expand")}
                 aria-expanded={isExpanded}
@@ -1177,6 +1288,7 @@ function WorkspaceSidebarGroup({
                         sessions={archivedSessions}
                         tree={tree}
                         workspaceId={workspace.id}
+                        pinnedLookup={pinnedLookup}
                         forcedExpandedSessionIds={forcedExpandedSessionIds}
                         expanded={archivedExpanded}
                         onToggle={() => setArchivedExpanded((value) => !value)}
@@ -1230,6 +1342,7 @@ function SessionGroupSeparator({ label, count, expanded, onToggle, onRemove, onT
   return (
     <button
       type="button"
+      data-testid="session-group-toggle"
       onClick={onToggle}
       className="group/separator flex w-full items-center gap-1.5 rounded px-2 pb-1 pt-2.5 text-left transition-colors first:pt-1 hover:bg-sidebar-accent/50"
       aria-expanded={expanded}
@@ -1580,7 +1693,7 @@ function SessionMenuItem({
   draggable = false,
 }: SessionMenuItemProps) {
   const ctx = useSidebarContext();
-  const isSelected = ctx.selectedSessionId === session.id;
+  const isSelected = ctx.selectedWorkspaceId === workspaceId && ctx.selectedSessionId === session.id;
   const displayTitle = getDisplaySessionTitle(session.title);
   const hasChildren = (tree.descendantCountBySessionId.get(session.id) ?? 0) > 0;
   const isExpanded = ctx.expandedSessionIds.has(session.id) || forcedExpandedSessionIds.has(session.id);
@@ -1695,6 +1808,7 @@ type ArchivedSessionsSectionProps = {
   sessions: SessionListItem[];
   tree: SessionTreeState;
   workspaceId: string;
+  pinnedLookup: PinnedSessionLookup;
   forcedExpandedSessionIds: Set<string>;
   expanded: boolean;
   onToggle: () => void;
@@ -1704,11 +1818,11 @@ function ArchivedSessionsSection({
   sessions,
   tree,
   workspaceId,
+  pinnedLookup,
   forcedExpandedSessionIds,
   expanded,
   onToggle,
 }: ArchivedSessionsSectionProps) {
-  const pinned = usePinnedSessionIds();
   return (
     <Collapsible open={expanded} onOpenChange={onToggle} className="group/archived">
       <CollapsibleTrigger
@@ -1735,7 +1849,7 @@ function ArchivedSessionsSection({
             tree={tree}
             workspaceId={workspaceId}
             forcedExpandedSessionIds={forcedExpandedSessionIds}
-            isPinned={pinned.has(session.id)}
+            isPinned={isPinnedSessionInLookup(pinnedLookup, workspaceId, session.id)}
           />
         ))}
       </CollapsibleContent>

--- a/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/session-management-store.ts
@@ -1,5 +1,6 @@
 /**
- * Zustand store for session management primitives (pin, manual order, custom
+ * Zustand store for session management primitives (workspace-scoped pin,
+ * manual order, custom
  * group mirror + expanded state). Persisted to localStorage via
  * zustand/middleware/persist.
  *
@@ -60,7 +61,8 @@ type SessionManagementState = {
 };
 
 type SessionManagementActions = {
-  togglePin: (sessionId: string) => void;
+  setPin: (workspaceId: string, sessionId: string, pinned: boolean) => void;
+  togglePin: (workspaceId: string, sessionId: string) => void;
   reorderSessions: (workspaceId: string, sessionIds: string[]) => void;
   assignGroup: (workspaceId: string, sessionId: string, groupId: string | null) => void;
   createGroup: (workspaceId: string, label: string) => void;
@@ -75,6 +77,47 @@ type SessionManagementActions = {
 type SessionManagementStore = SessionManagementState & SessionManagementActions;
 
 const EMPTY_GROUP_STATE: WorkspaceGroupState = { groups: [], assignments: {} };
+const PIN_ID_PREFIX = "workspace:";
+
+export type ScopedPinnedSessionId = {
+  workspaceId: string;
+  sessionId: string;
+};
+
+export function getPinnedSessionStorageId(workspaceId: string, sessionId: string): string {
+  return `${PIN_ID_PREFIX}${encodeURIComponent(workspaceId)}:${encodeURIComponent(sessionId)}`;
+}
+
+export function parsePinnedSessionStorageId(pinId: string): ScopedPinnedSessionId | null {
+  if (!pinId.startsWith(PIN_ID_PREFIX)) return null;
+  const encoded = pinId.slice(PIN_ID_PREFIX.length);
+  const separatorIndex = encoded.indexOf(":");
+  if (separatorIndex <= 0 || separatorIndex === encoded.length - 1) return null;
+
+  try {
+    return {
+      workspaceId: decodeURIComponent(encoded.slice(0, separatorIndex)),
+      sessionId: decodeURIComponent(encoded.slice(separatorIndex + 1)),
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function isSessionPinnedInWorkspace(
+  pinnedIds: string[],
+  workspaceId: string,
+  sessionId: string,
+  sessionOwnerCount: number,
+): boolean {
+  return pinnedIds.includes(getPinnedSessionStorageId(workspaceId, sessionId)) ||
+    (sessionOwnerCount === 1 && pinnedIds.includes(sessionId));
+}
+
+function withoutPinId(pinnedIds: string[], workspaceId: string, sessionId: string): string[] {
+  const scopedId = getPinnedSessionStorageId(workspaceId, sessionId);
+  return pinnedIds.filter((pinId) => pinId !== scopedId && pinId !== sessionId);
+}
 
 let sessionGroupSyncHandler: SessionGroupSyncHandler | null = null;
 const sessionGroupSyncStatusByWorkspace: Record<string, SessionGroupSyncStatus> = {};
@@ -169,15 +212,22 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
       orderByWorkspace: {},
       groupsByWorkspace: {},
 
-      togglePin: (sessionId) =>
+      setPin: (workspaceId, sessionId, pinned) =>
         set((state) => {
-          const idx = state.pinnedIds.indexOf(sessionId);
+          const nextPinnedIds = withoutPinId(state.pinnedIds, workspaceId, sessionId);
           return {
-            pinnedIds:
-              idx >= 0
-                ? state.pinnedIds.filter((id) => id !== sessionId)
-                : [...state.pinnedIds, sessionId],
+            pinnedIds: pinned
+              ? [...nextPinnedIds, getPinnedSessionStorageId(workspaceId, sessionId)]
+              : nextPinnedIds,
           };
+        }),
+
+      togglePin: (workspaceId, sessionId) =>
+        set((state) => {
+          const scopedId = getPinnedSessionStorageId(workspaceId, sessionId);
+          const pinned = state.pinnedIds.includes(scopedId);
+          const nextPinnedIds = withoutPinId(state.pinnedIds, workspaceId, sessionId);
+          return { pinnedIds: pinned ? nextPinnedIds : [...nextPinnedIds, scopedId] };
         }),
 
       reorderSessions: (workspaceId, sessionIds) =>
@@ -307,7 +357,11 @@ export const useSessionManagementStore = create<SessionManagementStore>()(
         set((state) => {
           const { [workspaceId]: _o, ...orderRest } = state.orderByWorkspace;
           const { [workspaceId]: _g, ...groupsRest } = state.groupsByWorkspace;
-          return { orderByWorkspace: orderRest, groupsByWorkspace: groupsRest };
+          const pinnedIds = state.pinnedIds.filter((pinId) => {
+            const scoped = parsePinnedSessionStorageId(pinId);
+            return scoped?.workspaceId !== workspaceId;
+          });
+          return { pinnedIds, orderByWorkspace: orderRest, groupsByWorkspace: groupsRest };
         }),
     }),
     {

--- a/apps/app/src/react-app/domains/session/sidebar/utils.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/utils.ts
@@ -2,11 +2,25 @@ import type { WorkspaceInfo } from "../../../../app/lib/desktop";
 import type { WorkspaceSessionGroup } from "../../../../app/types";
 import { isSandboxWorkspace } from "../../../../app/utils";
 import { t } from "../../../../i18n";
+import {
+  getPinnedSessionStorageId,
+  isSessionPinnedInWorkspace,
+  parsePinnedSessionStorageId,
+} from "./session-management-store";
 
 export const MAX_SESSIONS_PREVIEW = 6;
 
 export type SessionListItem = WorkspaceSessionGroup["sessions"][number];
 export type FlattenedSessionRow = { session: SessionListItem; depth: number };
+export type GlobalPinnedSessionEntry = {
+  session: SessionListItem;
+  workspace: WorkspaceInfo;
+  workspaceLabel: string;
+};
+export type PinnedSessionLookup = {
+  pinnedIds: string[];
+  ownerCountBySessionId: Map<string, number>;
+};
 export type SessionTreeState = {
   childrenByParent: Map<string, SessionListItem[]>;
   ancestorIdsBySessionId: Map<string, string[]>;
@@ -174,6 +188,78 @@ export const workspaceLabel = (workspace: WorkspaceInfo) =>
   workspace.name?.trim() ||
   workspace.path?.trim() ||
   t("workspace_list.workspace_fallback");
+
+export const getGlobalPinnedSessionEntries = (
+  workspaceSessionGroups: WorkspaceSessionGroup[],
+  pinnedSessionIds: string[],
+): GlobalPinnedSessionEntry[] => {
+  const byScopedPinId = new Map<string, { session: SessionListItem; workspace: WorkspaceInfo }>();
+  const bySessionId = new Map<string, { session: SessionListItem; workspace: WorkspaceInfo }>();
+  const ownerCountBySessionId = getSessionOwnerCountById(workspaceSessionGroups);
+
+  for (const group of workspaceSessionGroups) {
+    for (const session of group.sessions) {
+      const entry = { session, workspace: group.workspace };
+      byScopedPinId.set(getPinnedSessionStorageId(group.workspace.id, session.id), entry);
+      if ((ownerCountBySessionId.get(session.id) ?? 0) === 1) bySessionId.set(session.id, entry);
+    }
+  }
+
+  const used = new Set<string>();
+  const entries: GlobalPinnedSessionEntry[] = [];
+  for (const pinId of pinnedSessionIds) {
+    const scoped = parsePinnedSessionStorageId(pinId);
+    const match = scoped ? byScopedPinId.get(pinId) : bySessionId.get(pinId);
+    if (!match) continue;
+    const scopedPinId = getPinnedSessionStorageId(match.workspace.id, match.session.id);
+    if (used.has(scopedPinId)) continue;
+    used.add(scopedPinId);
+    entries.push({
+      session: match.session,
+      workspace: match.workspace,
+      workspaceLabel: workspaceLabel(match.workspace),
+    });
+  }
+  return entries;
+};
+
+export const getSessionOwnerCountById = (
+  workspaceSessionGroups: WorkspaceSessionGroup[],
+): Map<string, number> => {
+  const workspaceIdsBySessionId = new Map<string, Set<string>>();
+  for (const group of workspaceSessionGroups) {
+    for (const session of group.sessions) {
+      const workspaceIds = workspaceIdsBySessionId.get(session.id) ?? new Set<string>();
+      workspaceIds.add(group.workspace.id);
+      workspaceIdsBySessionId.set(session.id, workspaceIds);
+    }
+  }
+
+  const ownerCountBySessionId = new Map<string, number>();
+  for (const [sessionId, workspaceIds] of workspaceIdsBySessionId) {
+    ownerCountBySessionId.set(sessionId, workspaceIds.size);
+  }
+  return ownerCountBySessionId;
+};
+
+export const buildPinnedSessionLookup = (
+  workspaceSessionGroups: WorkspaceSessionGroup[],
+  pinnedIds: string[],
+): PinnedSessionLookup => ({
+  pinnedIds,
+  ownerCountBySessionId: getSessionOwnerCountById(workspaceSessionGroups),
+});
+
+export const isPinnedSessionInLookup = (
+  lookup: PinnedSessionLookup,
+  workspaceId: string,
+  sessionId: string,
+): boolean => isSessionPinnedInWorkspace(
+  lookup.pinnedIds,
+  workspaceId,
+  sessionId,
+  lookup.ownerCountBySessionId.get(sessionId) ?? 0,
+);
 
 export const workspaceKindLabel = (workspace: WorkspaceInfo) =>
   workspace.workspaceType === "remote"

--- a/apps/app/tests/global-pinned-sessions.test.ts
+++ b/apps/app/tests/global-pinned-sessions.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import type { WorkspaceInfo } from "../src/app/lib/desktop";
+import type { WorkspaceSessionGroup } from "../src/app/types";
+import { getPinnedSessionStorageId } from "../src/react-app/domains/session/sidebar/session-management-store";
+import { getGlobalPinnedSessionEntries } from "../src/react-app/domains/session/sidebar/utils";
+
+function workspace(id: string, name: string): WorkspaceInfo {
+  return {
+    id,
+    name,
+    path: `/tmp/${id}`,
+    preset: "starter",
+    workspaceType: "local",
+  };
+}
+
+const groups: WorkspaceSessionGroup[] = [
+  {
+    workspace: workspace("workspace-alpha", "Alpha Workspace"),
+    status: "ready",
+    sessions: [
+      { id: "session-alpha", title: "Duplicate title", time: { created: 1, updated: 1 } },
+    ],
+  },
+  {
+    workspace: workspace("workspace-beta", "Beta Workspace"),
+    status: "ready",
+    sessions: [
+      { id: "session-beta", title: "Duplicate title", time: { created: 2, updated: 2 } },
+    ],
+  },
+];
+
+describe("global pinned sessions", () => {
+  test("derives pinned entries in pin order with owning workspace labels", () => {
+    const entries = getGlobalPinnedSessionEntries(groups, ["session-beta", "missing", "session-alpha", "session-beta"]);
+
+    expect(entries.map((entry) => entry.session.id)).toEqual(["session-beta", "session-alpha"]);
+    expect(entries.map((entry) => entry.workspace.id)).toEqual(["workspace-beta", "workspace-alpha"]);
+    expect(entries.map((entry) => entry.workspaceLabel)).toEqual(["Beta Workspace", "Alpha Workspace"]);
+  });
+
+  test("returns no global entries when no listed sessions are pinned", () => {
+    expect(getGlobalPinnedSessionEntries(groups, [])).toEqual([]);
+    expect(getGlobalPinnedSessionEntries(groups, ["missing"])).toEqual([]);
+  });
+
+  test("requires scoped pin identity when the same session ID exists in multiple workspaces", () => {
+    const duplicateGroups: WorkspaceSessionGroup[] = [
+      {
+        workspace: workspace("workspace-one", "One Workspace"),
+        status: "ready",
+        sessions: [{ id: "same-session", title: "Shared ID", time: { created: 1, updated: 1 } }],
+      },
+      {
+        workspace: workspace("workspace-two", "Two Workspace"),
+        status: "ready",
+        sessions: [{ id: "same-session", title: "Shared ID", time: { created: 2, updated: 2 } }],
+      },
+    ];
+
+    expect(getGlobalPinnedSessionEntries(duplicateGroups, ["same-session"])).toEqual([]);
+
+    const entries = getGlobalPinnedSessionEntries(duplicateGroups, [
+      getPinnedSessionStorageId("workspace-two", "same-session"),
+      getPinnedSessionStorageId("workspace-one", "same-session"),
+    ]);
+
+    expect(entries.map((entry) => entry.workspace.id)).toEqual(["workspace-two", "workspace-one"]);
+    expect(entries.map((entry) => entry.workspaceLabel)).toEqual(["Two Workspace", "One Workspace"]);
+  });
+});

--- a/evals/flows/global-pinned-sessions.flow.mjs
+++ b/evals/flows/global-pinned-sessions.flow.mjs
@@ -1,0 +1,396 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("global-pinned-sessions");
+const RUN_ID = Date.now().toString(36);
+const SESSION_TITLE = `Global pinned conversation ${RUN_ID}`;
+const GROUP_LABEL = `Global pinned group ${RUN_ID}`;
+const SWITCH_WORKSPACE_PATH = `/tmp/openwork-global-pinned-switch-${RUN_ID}`;
+
+let pinnedSessionId = null;
+let originalWorkspaceId = null;
+let originalWorkspaceLabel = null;
+let groupId = null;
+let secondPinnedSessionId = null;
+let secondWorkspaceId = null;
+let secondWorkspaceLabel = null;
+
+const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function currentRouteSessionId(ctx) {
+  return ctx.eval(`(() => {
+    const route = window.__openworkControl.snapshot().route || "";
+    const match = new RegExp("session/([^/?#]+)").exec(route);
+    return match ? decodeURIComponent(match[1]) : null;
+  })()`);
+}
+
+async function waitForNewRouteSessionId(ctx, previousId, label) {
+  return ctx.waitFor(
+    `(() => {
+      const route = window.__openworkControl.snapshot().route || "";
+      const match = new RegExp("session/([^/?#]+)").exec(route);
+      if (!match) return null;
+      const sessionId = decodeURIComponent(match[1]);
+      return sessionId === ${JSON.stringify(previousId)} ? null : sessionId;
+    })()`,
+    { timeoutMs: 45_000, label },
+  );
+}
+
+async function waitForSessionListEntry(ctx, sessionId, title) {
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    const sessions = await ctx.control("session.list_sessions");
+    const match = sessions.find((session) => session.sessionId === sessionId && session.title === title);
+    if (match) return match;
+    await wait(500);
+  }
+  throw new Error(`Session ${sessionId} with title ${title} did not appear in session.list_sessions.`);
+}
+
+function globalPinnedStateExpression(sessionId) {
+  return `(() => {
+    const section = document.querySelector('[data-testid="global-pinned-sessions"]');
+    const workspace = document.querySelector('[data-testid="workspace-sidebar-group"]');
+    const entries = Array.from(document.querySelectorAll('[data-testid="global-pinned-session"]'));
+    const entry = entries.find((candidate) => candidate.getAttribute('data-session-id') === ${JSON.stringify(sessionId)});
+    const visible = (element) => {
+      if (!element) return false;
+      const rect = element.getBoundingClientRect();
+      return rect.width > 0 && rect.height > 0;
+    };
+    return {
+      sectionVisible: visible(section),
+      entryVisible: visible(entry),
+      entryText: entry ? entry.innerText : "",
+      entryWorkspaceId: entry ? entry.getAttribute('data-workspace-id') : null,
+      sectionBeforeWorkspace: Boolean(section && workspace && (section.compareDocumentPosition(workspace) & Node.DOCUMENT_POSITION_FOLLOWING)),
+      entryIds: entries.map((candidate) => candidate.getAttribute('data-session-id')),
+    };
+  })()`;
+}
+
+function workspaceSelector(workspaceId) {
+  const escaped = String(workspaceId).replaceAll("\\", "\\\\").replaceAll('"', '\\"');
+  return `[data-testid="workspace-sidebar-group"][data-workspace-id="${escaped}"]`;
+}
+
+async function setWorkspaceExpanded(ctx, workspaceId, expanded) {
+  const expected = expanded ? "true" : "false";
+  const result = await ctx.eval(`(() => {
+    const workspace = document.querySelector(${JSON.stringify(workspaceSelector(workspaceId))});
+    const button = workspace ? workspace.querySelector('[data-testid="workspace-expand-toggle"]') : null;
+    if (!button) return { ok: false, reason: 'workspace toggle missing' };
+    if (button.getAttribute('aria-expanded') !== ${JSON.stringify(expected)}) button.click();
+    return { ok: true };
+  })()`);
+  ctx.assert(result?.ok === true, `Could not toggle workspace ${workspaceId}: ${JSON.stringify(result)}`);
+  await ctx.waitFor(
+    `(() => {
+      const workspace = document.querySelector(${JSON.stringify(workspaceSelector(workspaceId))});
+      const button = workspace ? workspace.querySelector('[data-testid="workspace-expand-toggle"]') : null;
+      return Boolean(button && button.getAttribute('aria-expanded') === ${JSON.stringify(expected)});
+    })()`,
+    { timeoutMs: 10_000, label: `workspace ${workspaceId} expanded=${expanded}` },
+  );
+}
+
+async function setGroupExpanded(ctx, workspaceId, label, expanded) {
+  const expected = expanded ? "true" : "false";
+  const result = await ctx.eval(`(() => {
+    const workspace = document.querySelector(${JSON.stringify(workspaceSelector(workspaceId))});
+    const button = workspace
+      ? Array.from(workspace.querySelectorAll('[data-testid="session-group-toggle"]')).find((candidate) => (candidate.textContent || '').includes(${JSON.stringify(label)}))
+      : null;
+    if (!button) return { ok: false, reason: 'group toggle missing' };
+    if (button.getAttribute('aria-expanded') !== ${JSON.stringify(expected)}) button.click();
+    return { ok: true };
+  })()`);
+  ctx.assert(result?.ok === true, `Could not toggle group ${label}: ${JSON.stringify(result)}`);
+  await ctx.waitFor(
+    `(() => {
+      const workspace = document.querySelector(${JSON.stringify(workspaceSelector(workspaceId))});
+      const button = workspace
+        ? Array.from(workspace.querySelectorAll('[data-testid="session-group-toggle"]')).find((candidate) => (candidate.textContent || '').includes(${JSON.stringify(label)}))
+        : null;
+      return Boolean(button && button.getAttribute('aria-expanded') === ${JSON.stringify(expected)});
+    })()`,
+    { timeoutMs: 10_000, label: `group ${label} expanded=${expanded}` },
+  );
+}
+
+async function clickGlobalPinnedEntry(ctx, sessionId) {
+  await ctx.waitFor(
+    `(() => {
+      const state = ${globalPinnedStateExpression(sessionId)};
+      return state.entryVisible ? state : null;
+    })()`,
+    { timeoutMs: 15_000, label: `global pinned entry ${sessionId}` },
+  );
+  const clicked = await ctx.eval(`(() => {
+    const entry = Array.from(document.querySelectorAll('[data-testid="global-pinned-session"]'))
+      .find((candidate) => candidate.getAttribute('data-session-id') === ${JSON.stringify(sessionId)});
+    const button = entry ? entry.querySelector('[data-sidebar="menu-button"]') : null;
+    if (!button) return false;
+    button.scrollIntoView({ block: 'center' });
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(clicked === true, `Could not click global pinned entry ${sessionId}.`);
+}
+
+async function waitForGlobalPinnedWorkspaceLabel(ctx, sessionId) {
+  return ctx.waitFor(
+    `(() => {
+      const entry = Array.from(document.querySelectorAll('[data-testid="global-pinned-session"]'))
+        .find((candidate) => candidate.getAttribute('data-session-id') === ${JSON.stringify(sessionId)});
+      const lines = (entry?.innerText || '').split('\\n').map((line) => line.trim()).filter(Boolean);
+      return lines.length > 1 ? lines[lines.length - 1] : null;
+    })()`,
+    { timeoutMs: 15_000, label: `pinned workspace label for ${sessionId}` },
+  );
+}
+
+function normalWorkspaceSessionExpression(workspaceId, title) {
+  return `(() => {
+    const workspace = document.querySelector(${JSON.stringify(workspaceSelector(workspaceId))});
+    const normalRows = workspace
+      ? Array.from(workspace.querySelectorAll('[data-sidebar="menu-sub-item"]'))
+      : [];
+    const row = normalRows.find((candidate) => (candidate.innerText || '').includes(${JSON.stringify(title)}));
+    return {
+      workspaceVisible: Boolean(workspace),
+      rowVisible: Boolean(row),
+      rowText: row ? row.innerText : "",
+    };
+  })()`;
+}
+
+function globalPinnedTitleEntriesExpression(title) {
+  return `(() => Array.from(document.querySelectorAll('[data-testid="global-pinned-session"]'))
+    .map((entry) => ({
+      sessionId: entry.getAttribute('data-session-id'),
+      workspaceId: entry.getAttribute('data-workspace-id'),
+      text: entry.innerText || '',
+    }))
+    .filter((entry) => entry.text.includes(${JSON.stringify(title)})))()`;
+}
+
+export default {
+  id: "global-pinned-sessions",
+  title: "Pinned sessions appear in one global sidebar section and still belong to their workspace",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 60_000,
+      label: "control API",
+    });
+    const state = await ctx.waitFor(
+      `(() => {
+        const control = window.__openworkControl;
+        const route = control.snapshot().route;
+        if (route.startsWith('/welcome') || route.startsWith('/signin')) return { state: 'blocked' };
+        const actions = control.listActions();
+        const required = ['session.create_task', 'session.rename', 'session.pin', 'session.group.create', 'session.group.move', 'session.list_sessions', 'workspace.create'];
+        const missing = required.filter((id) => !actions.some((action) => action.id === id && !action.disabled));
+        return missing.length === 0 ? { state: 'ready' } : null;
+      })()`,
+      { timeoutMs: 45_000, label: "required session and workspace control actions" },
+    );
+    return state.state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); global pinned sessions requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "Pin a grouped conversation into the global Pinned section",
+      run: async (ctx) => {
+        await ctx.prove("A pinned conversation appears above workspaces and groups", {
+          claim: "Pinning a workspace conversation duplicates it into a dedicated global Pinned section above the workspace containers.",
+          voiceover: vo[0],
+          action: async () => {
+            const previousSessionId = await currentRouteSessionId(ctx);
+            await ctx.control("session.create_task");
+            pinnedSessionId = await waitForNewRouteSessionId(ctx, previousSessionId, "new pinned session route");
+            ctx.assert(Boolean(pinnedSessionId), "No session id was captured for the pinned conversation.");
+
+            const renamed = await ctx.control("session.rename", { sessionId: pinnedSessionId, title: SESSION_TITLE });
+            ctx.assert(renamed?.ok === true, `Rename failed: ${JSON.stringify(renamed)}`);
+            await waitForSessionListEntry(ctx, pinnedSessionId, SESSION_TITLE);
+
+            const createdGroup = await ctx.control("session.group.create", { label: GROUP_LABEL });
+            ctx.assert(
+              createdGroup?.ok === true && typeof createdGroup.groupId === "string" && typeof createdGroup.workspaceId === "string",
+              `Group creation failed: ${JSON.stringify(createdGroup)}`,
+            );
+            originalWorkspaceId = createdGroup.workspaceId;
+            groupId = createdGroup.groupId;
+            const moved = await ctx.control("session.group.move", {
+              sessionId: pinnedSessionId,
+              workspaceId: originalWorkspaceId,
+              groupId,
+            });
+            ctx.assert(moved?.ok === true, `Group move failed: ${JSON.stringify(moved)}`);
+
+            const pinned = await ctx.control("session.pin", { sessionId: pinnedSessionId, workspaceId: originalWorkspaceId });
+            ctx.assert(pinned?.pinned === true, `Expected session to be pinned: ${JSON.stringify(pinned)}`);
+            originalWorkspaceLabel = await waitForGlobalPinnedWorkspaceLabel(ctx, pinnedSessionId);
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `(() => {
+                const state = ${globalPinnedStateExpression(pinnedSessionId)};
+                return state.sectionVisible && state.entryVisible && state.sectionBeforeWorkspace && state.entryText.includes(${JSON.stringify(SESSION_TITLE)});
+              })()`,
+              { timeoutMs: 15_000, label: "global pinned section with new session above workspaces" },
+            );
+            const state = await ctx.eval(globalPinnedStateExpression(pinnedSessionId));
+            ctx.assert(state.entryWorkspaceId === originalWorkspaceId, `Pinned entry has wrong workspace id: ${JSON.stringify(state)}`);
+            ctx.assert(state.sectionBeforeWorkspace, "Pinned section is not before the workspace containers in the sidebar.");
+          },
+          screenshot: {
+            name: "pinned-section-above-workspaces",
+            requireText: ["PINNED", SESSION_TITLE],
+          },
+        });
+      },
+    },
+    {
+      name: "Pinned entry includes title and workspace label",
+      run: async (ctx) => {
+        await ctx.prove("Same-title pinned entries stay distinguishable by workspace", {
+          claim: "A second pinned conversation with the same title appears as another global Pinned row, and each row shows its owning workspace label.",
+          voiceover: vo[1],
+          action: async () => {
+            ctx.assert(Boolean(pinnedSessionId), "Pinned session id was not seeded.");
+            ctx.assert(Boolean(originalWorkspaceLabel), "Original workspace label was not captured.");
+            const previousSessionId = await currentRouteSessionId(ctx);
+            const created = await ctx.control("workspace.create", {
+              path: SWITCH_WORKSPACE_PATH,
+              projectLabel: "Global pinned sessions eval",
+            });
+            ctx.assert(created?.path === SWITCH_WORKSPACE_PATH, `Workspace switch seed failed: ${JSON.stringify(created)}`);
+            secondWorkspaceId = await ctx.waitFor(
+              `(() => {
+                const route = window.__openworkControl.snapshot().route || "";
+                const match = new RegExp("workspace/([^/?#]+)").exec(route);
+                return match ? decodeURIComponent(match[1]) : null;
+              })()`,
+              { timeoutMs: 15_000, label: "second workspace id in route" },
+            );
+            const createdSessionId = await currentRouteSessionId(ctx);
+            if (createdSessionId && createdSessionId !== previousSessionId) {
+              secondPinnedSessionId = createdSessionId;
+            } else {
+              await ctx.control("session.create_task");
+              secondPinnedSessionId = await waitForNewRouteSessionId(ctx, previousSessionId, "second same-title session route");
+            }
+
+            const renamed = await ctx.control("session.rename", { sessionId: secondPinnedSessionId, title: SESSION_TITLE });
+            ctx.assert(renamed?.ok === true, `Second rename failed: ${JSON.stringify(renamed)}`);
+            await waitForSessionListEntry(ctx, secondPinnedSessionId, SESSION_TITLE);
+            const pinned = await ctx.control("session.pin", { sessionId: secondPinnedSessionId, workspaceId: secondWorkspaceId });
+            ctx.assert(pinned?.pinned === true, `Expected second session to be pinned: ${JSON.stringify(pinned)}`);
+            secondWorkspaceLabel = await waitForGlobalPinnedWorkspaceLabel(ctx, secondPinnedSessionId);
+          },
+          assert: async () => {
+            const entries = await ctx.waitFor(
+              `(() => {
+                const entries = ${globalPinnedTitleEntriesExpression(SESSION_TITLE)};
+                return entries.length >= 2 ? entries : null;
+              })()`,
+              { timeoutMs: 15_000, label: "two same-title global pinned entries" },
+            );
+            const originalEntry = entries.find((entry) => entry.sessionId === pinnedSessionId);
+            const secondEntry = entries.find((entry) => entry.sessionId === secondPinnedSessionId);
+            ctx.assert(originalEntry?.text.includes(originalWorkspaceLabel), `Original pinned entry is missing workspace label: ${JSON.stringify(originalEntry)}`);
+            ctx.assert(secondEntry?.text.includes(secondWorkspaceLabel), `Second pinned entry is missing workspace label: ${JSON.stringify(secondEntry)}`);
+            ctx.assert(originalEntry.text.includes(SESSION_TITLE) && secondEntry.text.includes(SESSION_TITLE), "Same-title pinned entries are not both visible.");
+          },
+          screenshot: {
+            name: "same-title-pinned-entries-show-workspaces",
+            requireText: ["PINNED", SESSION_TITLE],
+          },
+        });
+      },
+    },
+    {
+      name: "Collapse workspace and group, switch away, then open from global Pinned",
+      run: async (ctx) => {
+        await ctx.prove("The global pinned entry survives collapse and opens the original workspace", {
+          claim: "Collapsing the original workspace and group, then switching to another workspace, leaves the global pinned entry visible; clicking it opens the original workspace/session.",
+          voiceover: vo[2],
+          action: async () => {
+            ctx.assert(Boolean(pinnedSessionId && originalWorkspaceId && secondPinnedSessionId), "Pinned sessions were not seeded before collapse/switch.");
+            await setWorkspaceExpanded(ctx, originalWorkspaceId, true);
+            await setGroupExpanded(ctx, originalWorkspaceId, GROUP_LABEL, false);
+            await setWorkspaceExpanded(ctx, originalWorkspaceId, false);
+
+            const stateWhileAway = await ctx.eval(globalPinnedStateExpression(pinnedSessionId));
+            ctx.assert(stateWhileAway.entryVisible, `Pinned entry disappeared while switched away: ${JSON.stringify(stateWhileAway)}`);
+            await clickGlobalPinnedEntry(ctx, secondPinnedSessionId);
+            await ctx.waitFor(
+              `(() => {
+                const route = window.__openworkControl.snapshot().route || "";
+                return route.includes(${JSON.stringify(secondPinnedSessionId)}) && route.includes(${JSON.stringify(secondWorkspaceId)});
+              })()`,
+              { timeoutMs: 30_000, label: "global pin opened second workspace/session route" },
+            );
+            await clickGlobalPinnedEntry(ctx, pinnedSessionId);
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `(() => {
+                const route = window.__openworkControl.snapshot().route || "";
+                return route.includes(${JSON.stringify(pinnedSessionId)}) && route.includes(${JSON.stringify(originalWorkspaceId)});
+              })()`,
+              { timeoutMs: 30_000, label: "global pin opened original workspace/session route" },
+            );
+            const state = await ctx.eval(globalPinnedStateExpression(pinnedSessionId));
+            ctx.assert(state.entryVisible, `Pinned entry is not visible after reopening original workspace: ${JSON.stringify(state)}`);
+          },
+          screenshot: {
+            name: "pinned-entry-opens-original-workspace",
+            requireText: ["PINNED", SESSION_TITLE],
+          },
+        });
+      },
+    },
+    {
+      name: "Unpin removes only the global duplicate",
+      run: async (ctx) => {
+        await ctx.prove("Unpinning removes the global duplicate and keeps the normal workspace row", {
+          claim: "Unpinning the conversation removes its global Pinned row while the same conversation remains in its original workspace/group.",
+          voiceover: vo[3],
+          action: async () => {
+            ctx.assert(Boolean(pinnedSessionId && originalWorkspaceId), "Pinned session was not seeded before unpin.");
+            const unpinned = await ctx.control("session.pin", { sessionId: pinnedSessionId, workspaceId: originalWorkspaceId });
+            ctx.assert(unpinned?.pinned === false, `Expected session to be unpinned: ${JSON.stringify(unpinned)}`);
+            await setWorkspaceExpanded(ctx, originalWorkspaceId, true);
+            await setGroupExpanded(ctx, originalWorkspaceId, GROUP_LABEL, true);
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `(() => {
+                const state = ${globalPinnedStateExpression(pinnedSessionId)};
+                return !state.entryIds.includes(${JSON.stringify(pinnedSessionId)});
+              })()`,
+              { timeoutMs: 15_000, label: "unpinned session absent from global pinned section" },
+            );
+            const normalState = await ctx.waitFor(
+              `(() => {
+                const state = ${normalWorkspaceSessionExpression(originalWorkspaceId, SESSION_TITLE)};
+                return state.rowVisible ? state : null;
+              })()`,
+              { timeoutMs: 15_000, label: "normal workspace session row remains" },
+            );
+            ctx.assert(normalState.rowText.includes(SESSION_TITLE), `Normal workspace row is wrong: ${JSON.stringify(normalState)}`);
+          },
+          screenshot: {
+            name: "unpinned-normal-workspace-row-remains",
+            requireText: [SESSION_TITLE],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/global-pinned-sessions.md
+++ b/evals/voiceovers/global-pinned-sessions.md
@@ -1,0 +1,9 @@
+# global-pinned-sessions
+
+1. "I pin a conversation inside a workspace, and it immediately appears in a dedicated Pinned section above every workspace and group."
+
+2. "The pinned entry shows its conversation title and workspace, so similarly named conversations remain easy to distinguish."
+
+3. "I can collapse or switch workspaces and groups, while the pinned conversation remains visible and opens its original workspace."
+
+4. "When I unpin the conversation, it leaves the global Pinned section and remains in its normal workspace location."


### PR DESCRIPTION
## Summary
- add a global Pinned section above workspaces and groups
- scope pin identity by workspace while preserving unambiguous legacy pins
- keep normal workspace entries and provide safe global open/unpin actions
- add the approved voiceover and coded fraimz flow

## Validation
- `pnpm --filter @openwork/app exec bun test tests/global-pinned-sessions.test.ts` (3 passed)
- `pnpm --filter @openwork/app typecheck` (passed)
- `pnpm fraimz --flow global-pinned-sessions --cdp-url http://127.0.0.1:9823` (Passed, 4 frames)

Fraimz: `evals/results/2026-07-12T01-00-02-896Z/fraimz.html`