### PR TITLE
feat: add conversation history controls

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/conversation-tab-history.ts
+++ b/apps/app/src/react-app/domains/session/chat/conversation-tab-history.ts
@@ -1,0 +1,106 @@
+export type ConversationTabHistory = {
+  workspaceId: string;
+  entries: string[];
+  index: number;
+};
+
+export type ConversationHistoryDirection = "back" | "forward";
+
+export function createConversationTabHistory(workspaceId: string, sessionId: string | null): ConversationTabHistory {
+  return {
+    workspaceId,
+    entries: sessionId ? [sessionId] : [],
+    index: sessionId ? 0 : -1,
+  };
+}
+
+export function syncConversationTabHistory(
+  history: ConversationTabHistory,
+  workspaceId: string,
+  sessionId: string | null,
+): ConversationTabHistory {
+  if (history.workspaceId !== workspaceId) {
+    return createConversationTabHistory(workspaceId, sessionId);
+  }
+
+  if (!sessionId) {
+    if (history.entries.length === 0 && history.index === -1) return history;
+    return createConversationTabHistory(workspaceId, null);
+  }
+
+  if (history.entries[history.index] === sessionId) return history;
+
+  const entriesBeforeForwardBranch = history.index >= 0
+    ? history.entries.slice(0, history.index + 1)
+    : [];
+  const last = entriesBeforeForwardBranch[entriesBeforeForwardBranch.length - 1];
+  const entries = last === sessionId
+    ? entriesBeforeForwardBranch
+    : [...entriesBeforeForwardBranch, sessionId];
+
+  return {
+    workspaceId,
+    entries,
+    index: entries.length - 1,
+  };
+}
+
+export function canNavigateConversationHistory(history: ConversationTabHistory, direction: ConversationHistoryDirection) {
+  if (direction === "back") return history.index > 0;
+  return history.index >= 0 && history.index < history.entries.length - 1;
+}
+
+export function isConversationTabHistoryCurrent(
+  history: ConversationTabHistory,
+  workspaceId: string,
+  sessionId: string | null,
+) {
+  return history.workspaceId === workspaceId && history.entries[history.index] === sessionId;
+}
+
+export function canNavigateSelectedConversationHistory(
+  history: ConversationTabHistory,
+  workspaceId: string,
+  sessionId: string | null,
+  direction: ConversationHistoryDirection,
+) {
+  return isConversationTabHistoryCurrent(history, workspaceId, sessionId) && canNavigateConversationHistory(history, direction);
+}
+
+export function removeConversationHistoryEntry(
+  history: ConversationTabHistory,
+  workspaceId: string,
+  sessionId: string,
+): ConversationTabHistory {
+  if (history.workspaceId !== workspaceId) return history;
+  const removedIndex = history.entries.indexOf(sessionId);
+  if (removedIndex === -1) return history;
+
+  const entries = history.entries.filter((entry) => entry !== sessionId);
+  if (entries.length === 0) return createConversationTabHistory(workspaceId, null);
+
+  const index = removedIndex <= history.index
+    ? Math.max(0, history.index - 1)
+    : history.index;
+
+  return {
+    workspaceId,
+    entries,
+    index: Math.min(index, entries.length - 1),
+  };
+}
+
+export function navigateConversationTabHistory(
+  history: ConversationTabHistory,
+  direction: ConversationHistoryDirection,
+): { history: ConversationTabHistory; sessionId: string | null } {
+  if (!canNavigateConversationHistory(history, direction)) {
+    return { history, sessionId: null };
+  }
+
+  const index = direction === "back" ? history.index - 1 : history.index + 1;
+  return {
+    history: { ...history, index },
+    sessionId: history.entries[index] ?? null,
+  };
+}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,7 +2,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { Cloud, Columns2, FileText, Globe, Mic2, Settings2, TextSearch, X, Zap } from "lucide-react";
+import { ArrowLeft, ArrowRight, Cloud, Columns2, FileText, Globe, Mic2, Settings2, TextSearch, X, Zap } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { OPENWORK_EXTENSION_CATALOG } from "../../../../app/constants";
@@ -69,6 +69,15 @@ import { useWorkspaceShellLayout } from "../../../shell/workspace-shell-layout";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
 import { getExtensionId, isOpenWorkExtensionEnabled, OPENWORK_EXTENSION_STATE_CHANGED } from "../../settings/extension-state";
 import { cn } from "@/lib/utils";
+import {
+  canNavigateSelectedConversationHistory,
+  createConversationTabHistory,
+  navigateConversationTabHistory,
+  removeConversationHistoryEntry,
+  syncConversationTabHistory,
+  type ConversationTabHistory,
+  type ConversationHistoryDirection,
+} from "./conversation-tab-history";
 
 const STARTUP_SKELETON_ROWS = [
   { id: "intro", titleWidth: "42%", bodyWidth: "88%" },
@@ -81,6 +90,13 @@ const EMPTY_TRANSCRIPT_TARGETS: OpenTarget[] = [];
 export type OpenSessionTab = {
   workspaceId: string;
   sessionId: string;
+};
+
+type PendingConversationHistoryNavigation = {
+  history: ConversationTabHistory;
+  fromWorkspaceId: string;
+  fromSessionId: string | null;
+  targetSessionId: string;
 };
 
 type StatusBarOverrides = Pick<
@@ -353,6 +369,10 @@ export function SessionPage(props: SessionPageProps) {
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [sessionActionId, setSessionActionId] = useState<string | null>(null);
   const [sessionTabs, setSessionTabs] = useState<OpenSessionTab[]>([]);
+  const [conversationHistory, setConversationHistory] = useState(() => (
+    createConversationTabHistory(props.selectedWorkspaceId, props.selectedSessionId)
+  ));
+  const [pendingConversationHistoryNavigation, setPendingConversationHistoryNavigation] = useState<PendingConversationHistoryNavigation | null>(null);
   const [splitSessionId, setSplitSessionId] = useState<string | null>(null);
   const [createGroupOpen, setCreateGroupOpen] = useState(false);
   const [createGroupLabel, setCreateGroupLabel] = useState("");
@@ -665,6 +685,38 @@ export function SessionPage(props: SessionPageProps) {
     [props.selectedSessionId, props.sidebar.workspaceSessionGroups],
   );
   useEffect(() => {
+    if (pendingConversationHistoryNavigation) {
+      if (
+        pendingConversationHistoryNavigation.history.workspaceId === props.selectedWorkspaceId &&
+        pendingConversationHistoryNavigation.targetSessionId === props.selectedSessionId
+      ) {
+        setConversationHistory(pendingConversationHistoryNavigation.history);
+        setPendingConversationHistoryNavigation(null);
+        return;
+      }
+      if (
+        pendingConversationHistoryNavigation.fromWorkspaceId === props.selectedWorkspaceId &&
+        pendingConversationHistoryNavigation.fromSessionId === props.selectedSessionId
+      ) {
+        return;
+      }
+      setPendingConversationHistoryNavigation(null);
+    }
+
+    setConversationHistory((current) => syncConversationTabHistory(
+      current,
+      props.selectedWorkspaceId,
+      props.selectedSessionId,
+    ));
+  }, [pendingConversationHistoryNavigation, props.selectedSessionId, props.selectedWorkspaceId]);
+  useEffect(() => {
+    if (!pendingConversationHistoryNavigation) return undefined;
+    const id = window.setTimeout(() => {
+      setPendingConversationHistoryNavigation((current) => current === pendingConversationHistoryNavigation ? null : current);
+    }, 5000);
+    return () => window.clearTimeout(id);
+  }, [pendingConversationHistoryNavigation]);
+  useEffect(() => {
     setSessionTabs((current) => {
       const currentWorkspaceTabs = current.filter((tab) => tab.workspaceId === props.selectedWorkspaceId);
       const next = props.selectedSessionId && !currentWorkspaceTabs.some((tab) => tab.sessionId === props.selectedSessionId)
@@ -751,6 +803,18 @@ export function SessionPage(props: SessionPageProps) {
   );
   const canRenderSplitSurface = Boolean(canRenderReactSurface && splitSessionId && splitSessionId !== props.selectedSessionId);
   const findButtonSessionId = props.selectedSessionId;
+  const canGoBackInConversationHistory = !pendingConversationHistoryNavigation && canNavigateSelectedConversationHistory(
+    conversationHistory,
+    props.selectedWorkspaceId,
+    props.selectedSessionId,
+    "back",
+  );
+  const canGoForwardInConversationHistory = !pendingConversationHistoryNavigation && canNavigateSelectedConversationHistory(
+    conversationHistory,
+    props.selectedWorkspaceId,
+    props.selectedSessionId,
+    "forward",
+  );
 
   const openSessionTab = useCallback((workspaceId: string, sessionId: string) => {
     setSessionTabs((current) => {
@@ -762,17 +826,37 @@ export function SessionPage(props: SessionPageProps) {
   }, [props.sidebar]);
 
   const closeSessionTab = useCallback((sessionId: string) => {
+    const nextTab = sessionTabs.find((tab) => tab.sessionId !== sessionId && tab.workspaceId === props.selectedWorkspaceId);
     setSessionTabs((current) => current.filter((tab) => tab.sessionId !== sessionId));
     setSplitSessionId((current) => current === sessionId ? null : current);
+    setPendingConversationHistoryNavigation(null);
+    setConversationHistory((current) => removeConversationHistoryEntry(current, props.selectedWorkspaceId, sessionId));
     if (sessionId !== props.selectedSessionId) return;
 
-    const nextTab = sessionTabs.find((tab) => tab.sessionId !== sessionId && tab.workspaceId === props.selectedWorkspaceId);
     if (nextTab) {
       props.sidebar.onOpenSession(nextTab.workspaceId, nextTab.sessionId);
       return;
     }
     props.sidebar.onSelectWorkspace(props.selectedWorkspaceId);
   }, [props.selectedSessionId, props.selectedWorkspaceId, props.sidebar, sessionTabs]);
+
+  const navigateConversationHistory = useCallback((direction: ConversationHistoryDirection) => {
+    if (!canNavigateSelectedConversationHistory(
+      conversationHistory,
+      props.selectedWorkspaceId,
+      props.selectedSessionId,
+      direction,
+    )) return;
+    const next = navigateConversationTabHistory(conversationHistory, direction);
+    if (!next.sessionId) return;
+    setPendingConversationHistoryNavigation({
+      history: next.history,
+      fromWorkspaceId: props.selectedWorkspaceId,
+      fromSessionId: props.selectedSessionId,
+      targetSessionId: next.sessionId,
+    });
+    props.sidebar.onOpenSession(next.history.workspaceId, next.sessionId);
+  }, [conversationHistory, props.selectedSessionId, props.selectedWorkspaceId, props.sidebar]);
 
   useEffect(() => {
     if (!showSessionLoadingState) {
@@ -1010,53 +1094,96 @@ export function SessionPage(props: SessionPageProps) {
               {!showDelayedSessionLoadingState && canRenderReactSurface ? (
                 <div className="flex h-full min-h-0 flex-col">
                   {sessionTabs.length > 0 ? (
-                    <div className="flex h-10 shrink-0 items-center gap-1 overflow-x-auto border-b border-border bg-background/80 px-2 mac:backdrop-blur-xl">
-                      {sessionTabs.map((tab) => {
-                        const title = sessionTitleForId(props.sidebar.workspaceSessionGroups, tab.sessionId) || t("session.default_title");
-                        const active = tab.sessionId === props.selectedSessionId;
-                        const split = tab.sessionId === splitSessionId;
-                        return (
-                          <div
-                            key={tab.sessionId}
-                            data-session-tab-id={tab.sessionId}
-                            className={cn(
-                              "group flex max-w-56 shrink-0 items-center gap-1 rounded-lg border px-2 py-1 text-xs transition-colors",
-                              active
-                                ? "border-border bg-dls-surface text-dls-text shadow-sm"
-                                : "border-transparent text-dls-secondary hover:bg-dls-hover hover:text-dls-text",
-                              split && "border-primary/30 bg-primary/10 text-primary",
-                            )}
-                          >
-                            <button
-                              type="button"
-                              className="min-w-0 flex-1 truncate text-left"
-                              onClick={() => props.sidebar.onOpenSession(tab.workspaceId, tab.sessionId)}
-                              title={title}
+                    <div className="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-background/80 px-2 mac:backdrop-blur-xl">
+                      <div className="flex shrink-0 items-center gap-0.5 pr-1" role="group" aria-label="Conversation history controls">
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <Button
+                                variant="ghost"
+                                size="icon-xs"
+                                className="rounded-lg text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40"
+                                aria-label="Back in conversation history"
+                                title="Back in conversation history"
+                                data-conversation-history-control="back"
+                                disabled={!canGoBackInConversationHistory}
+                                onClick={() => navigateConversationHistory("back")}
+                              >
+                                <ArrowLeft size={14} />
+                              </Button>
+                            }
+                          />
+                          <TooltipContent>Back in conversation history</TooltipContent>
+                        </Tooltip>
+                        <Tooltip>
+                          <TooltipTrigger
+                            render={
+                              <Button
+                                variant="ghost"
+                                size="icon-xs"
+                                className="rounded-lg text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40"
+                                aria-label="Forward in conversation history"
+                                title="Forward in conversation history"
+                                data-conversation-history-control="forward"
+                                disabled={!canGoForwardInConversationHistory}
+                                onClick={() => navigateConversationHistory("forward")}
+                              >
+                                <ArrowRight size={14} />
+                              </Button>
+                            }
+                          />
+                          <TooltipContent>Forward in conversation history</TooltipContent>
+                        </Tooltip>
+                      </div>
+                      <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
+                        {sessionTabs.map((tab) => {
+                          const title = sessionTitleForId(props.sidebar.workspaceSessionGroups, tab.sessionId) || t("session.default_title");
+                          const active = tab.sessionId === props.selectedSessionId;
+                          const split = tab.sessionId === splitSessionId;
+                          return (
+                            <div
+                              key={tab.sessionId}
+                              data-session-tab-id={tab.sessionId}
+                              data-session-tab-active={active ? "true" : undefined}
+                              className={cn(
+                                "group flex max-w-56 shrink-0 items-center gap-1 rounded-lg border px-2 py-1 text-xs transition-colors",
+                                active
+                                  ? "border-border bg-dls-surface text-dls-text"
+                                  : "border-transparent text-dls-secondary hover:bg-dls-hover hover:text-dls-text",
+                                split && "border-primary/30 bg-primary/10 text-primary",
+                              )}
                             >
-                              {title}
-                            </button>
-                            <button
-                              type="button"
-                              className="rounded p-0.5 text-dls-secondary hover:bg-dls-hover hover:text-dls-text disabled:pointer-events-none disabled:opacity-40"
-                              onClick={() => setSplitSessionId(split ? null : tab.sessionId)}
-                              disabled={active}
-                              title={split ? "Close split" : "Open in split view"}
-                              aria-label={split ? "Close split" : "Open in split view"}
-                            >
-                              <Columns2 size={13} />
-                            </button>
-                            <button
-                              type="button"
-                              className="rounded p-0.5 text-dls-secondary opacity-80 hover:bg-dls-hover hover:text-dls-text group-hover:opacity-100"
-                              onClick={() => closeSessionTab(tab.sessionId)}
-                              title="Close tab"
-                              aria-label="Close tab"
-                            >
-                              <X size={13} />
-                            </button>
-                          </div>
-                        );
-                      })}
+                              <button
+                                type="button"
+                                className="min-w-0 flex-1 truncate text-left"
+                                onClick={() => props.sidebar.onOpenSession(tab.workspaceId, tab.sessionId)}
+                                title={title}
+                              >
+                                {title}
+                              </button>
+                              <button
+                                type="button"
+                                className="rounded p-0.5 text-dls-secondary hover:bg-dls-hover hover:text-dls-text disabled:pointer-events-none disabled:opacity-40"
+                                onClick={() => setSplitSessionId(split ? null : tab.sessionId)}
+                                disabled={active}
+                                title={split ? "Close split" : "Open in split view"}
+                                aria-label={split ? "Close split" : "Open in split view"}
+                              >
+                                <Columns2 size={13} />
+                              </button>
+                              <button
+                                type="button"
+                                className="rounded p-0.5 text-dls-secondary opacity-80 hover:bg-dls-hover hover:text-dls-text group-hover:opacity-100"
+                                onClick={() => closeSessionTab(tab.sessionId)}
+                                title="Close tab"
+                                aria-label="Close tab"
+                              >
+                                <X size={13} />
+                              </button>
+                            </div>
+                          );
+                        })}
+                      </div>
                     </div>
                   ) : null}
                   <div className="flex min-h-0 flex-1 flex-col lg:flex-row">

--- a/apps/app/tests/conversation-tab-history.test.ts
+++ b/apps/app/tests/conversation-tab-history.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  canNavigateConversationHistory,
+  createConversationTabHistory,
+  navigateConversationTabHistory,
+  removeConversationHistoryEntry,
+  syncConversationTabHistory,
+} from "../src/react-app/domains/session/chat/conversation-tab-history";
+
+describe("conversation tab history", () => {
+  test("records visits without duplicate adjacent entries", () => {
+    let history = createConversationTabHistory("workspace-a", "session-a");
+    history = syncConversationTabHistory(history, "workspace-a", "session-a");
+    history = syncConversationTabHistory(history, "workspace-a", "session-b");
+    history = syncConversationTabHistory(history, "workspace-a", "session-b");
+
+    expect(history.entries).toEqual(["session-a", "session-b"]);
+    expect(history.index).toBe(1);
+  });
+
+  test("navigates back and forward without wrapping", () => {
+    let history = createConversationTabHistory("workspace-a", "session-a");
+    history = syncConversationTabHistory(history, "workspace-a", "session-b");
+    history = syncConversationTabHistory(history, "workspace-a", "session-c");
+
+    expect(canNavigateConversationHistory(history, "back")).toBe(true);
+    expect(canNavigateConversationHistory(history, "forward")).toBe(false);
+
+    const back = navigateConversationTabHistory(history, "back");
+    expect(back.sessionId).toBe("session-b");
+    expect(back.history.index).toBe(1);
+
+    const secondBack = navigateConversationTabHistory(back.history, "back");
+    expect(secondBack.sessionId).toBe("session-a");
+    expect(canNavigateConversationHistory(secondBack.history, "back")).toBe(false);
+
+    const noWrapBack = navigateConversationTabHistory(secondBack.history, "back");
+    expect(noWrapBack.sessionId).toBeNull();
+    expect(noWrapBack.history).toBe(secondBack.history);
+
+    const forward = navigateConversationTabHistory(secondBack.history, "forward");
+    expect(forward.sessionId).toBe("session-b");
+  });
+
+  test("clears the forward branch after a new selection", () => {
+    let history = createConversationTabHistory("workspace-a", "session-a");
+    history = syncConversationTabHistory(history, "workspace-a", "session-b");
+    history = syncConversationTabHistory(history, "workspace-a", "session-c");
+
+    const back = navigateConversationTabHistory(history, "back");
+    const branched = syncConversationTabHistory(back.history, "workspace-a", "session-d");
+
+    expect(branched.entries).toEqual(["session-a", "session-b", "session-d"]);
+    expect(branched.index).toBe(2);
+    expect(canNavigateConversationHistory(branched, "forward")).toBe(false);
+  });
+
+  test("resets when the workspace changes", () => {
+    let history = createConversationTabHistory("workspace-a", "session-a");
+    history = syncConversationTabHistory(history, "workspace-a", "session-b");
+
+    const reset = syncConversationTabHistory(history, "workspace-b", "session-c");
+
+    expect(reset.workspaceId).toBe("workspace-b");
+    expect(reset.entries).toEqual(["session-c"]);
+    expect(reset.index).toBe(0);
+  });
+
+  test("removes an inactive closed entry without moving the current session", () => {
+    let history = createConversationTabHistory("workspace-a", "session-a");
+    history = syncConversationTabHistory(history, "workspace-a", "session-b");
+    history = syncConversationTabHistory(history, "workspace-a", "session-c");
+
+    const closed = removeConversationHistoryEntry(history, "workspace-a", "session-b");
+
+    expect(closed.entries).toEqual(["session-a", "session-c"]);
+    expect(closed.index).toBe(1);
+    expect(navigateConversationTabHistory(closed, "back").sessionId).toBe("session-a");
+  });
+
+  test("removes an active closed entry and lands on the nearest remaining history", () => {
+    let history = createConversationTabHistory("workspace-a", "session-a");
+    history = syncConversationTabHistory(history, "workspace-a", "session-b");
+    history = syncConversationTabHistory(history, "workspace-a", "session-c");
+    history = navigateConversationTabHistory(history, "back").history;
+
+    const closed = removeConversationHistoryEntry(history, "workspace-a", "session-b");
+
+    expect(closed.entries).toEqual(["session-a", "session-c"]);
+    expect(closed.index).toBe(0);
+    expect(canNavigateConversationHistory(closed, "back")).toBe(false);
+    expect(navigateConversationTabHistory(closed, "forward").sessionId).toBe("session-c");
+  });
+});

--- a/evals/flows/conversation-tab-history.flow.mjs
+++ b/evals/flows/conversation-tab-history.flow.mjs
@@ -1,0 +1,315 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "conversation-tab-history";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const state = {
+  sessionIds: [],
+  firstBoundary: null,
+  lastBoundary: null,
+};
+
+export default {
+  id: FLOW_ID,
+  title: "Conversation tabs have browser-style Back and Forward history controls",
+  kind: "user-facing",
+  spec: "evals/voiceovers/conversation-tab-history.md",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 60_000,
+      label: "control API",
+    });
+    const availability = await ctx.waitFor(
+      `(() => {
+        const control = window.__openworkControl;
+        const action = control?.listActions?.().find((item) => item.id === "session.create_task");
+        if (action && !action.disabled) return { ok: true };
+        const route = control?.snapshot?.().route ?? "";
+        const text = document.body.innerText;
+        if (route.includes("welcome") || text.includes("Create or connect a workspace") || text.includes("Create workspace")) {
+          return { ok: false, reason: "No workspace is available for conversation tabs; complete onboarding or create a workspace first." };
+        }
+        return null;
+      })()`,
+      { timeoutMs: 60_000, label: "workspace with enabled task creation" },
+    ).catch(() => null);
+    if (!availability?.ok) {
+      return availability?.reason ?? "session.create_task did not become available; complete onboarding and ensure the selected workspace is healthy.";
+    }
+  },
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("Several conversations open as flat, shadowless tabs", {
+          voiceover: vo[0],
+          action: async () => {
+            await ensureConversationTabs(ctx);
+          },
+          assert: async () => {
+            const proof = await readTabStripState(ctx);
+            ctx.assert(proof.tabCount >= 3, `Expected at least three conversation tabs, got ${proof.tabCount}`);
+            ctx.assert(proof.hasBackButton, "Back history button was missing from the tab strip.");
+            ctx.assert(proof.hasForwardButton, "Forward history button was missing from the tab strip.");
+            ctx.assert(proof.controlsBeforeTabs, "History controls were not at the leading edge of the conversation tab strip.");
+            ctx.assert(proof.controlsOutsideTabScroller, "History controls should remain fixed while only conversation tabs scroll.");
+            ctx.assert(proof.controlsVisible, "History controls were not visible in the viewport.");
+            ctx.assert(!proof.tabClassText.includes("shadow"), `Conversation tab classes still include shadow styling: ${proof.tabClassText}`);
+            ctx.assert(proof.activeBoxShadow === "none", `Active conversation tab still casts a shadow: ${proof.activeBoxShadow}`);
+          },
+          screenshot: {
+            name: "conversation-tabs-flat-strip",
+            claim: "Several conversations are open as flat tabs with Back and Forward controls leading the strip.",
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("Back returns through conversation selection history", {
+          voiceover: vo[1],
+          action: async () => {
+            const ids = await ensureConversationTabs(ctx);
+            await clickConversationTab(ctx, ids[0]);
+            await clickConversationTab(ctx, ids[1]);
+            await clickConversationTab(ctx, ids[2]);
+            await clickHistoryButton(ctx, "back", ids[1]);
+          },
+          assert: async () => {
+            const ids = await ensureConversationTabs(ctx);
+            const proof = await readTabStripState(ctx);
+            ctx.assert(proof.currentSessionId === ids[1], `Back should have returned to the previous conversation ${ids[1]}, got ${proof.currentSessionId}`);
+            ctx.assert(proof.activeTabMatchesRoute, "The active tab did not match the route after Back navigation.");
+            ctx.assert(proof.backDisabled === false, "Back should remain enabled with earlier history available.");
+            ctx.assert(proof.forwardDisabled === false, "Forward should be enabled after going back.");
+          },
+          screenshot: {
+            name: "conversation-history-back",
+            claim: "Clicking Back returns to the previous conversation in the visit stack.",
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Forward retraces the conversation history branch", {
+          voiceover: vo[2],
+          action: async () => {
+            const ids = await ensureConversationTabs(ctx);
+            await clickHistoryButton(ctx, "forward", ids[2]);
+          },
+          assert: async () => {
+            const ids = await ensureConversationTabs(ctx);
+            const proof = await readTabStripState(ctx);
+            ctx.assert(proof.currentSessionId === ids[2], `Forward should have returned to ${ids[2]}, got ${proof.currentSessionId}`);
+            ctx.assert(proof.activeTabMatchesRoute, "The active tab did not match the route after Forward navigation.");
+            ctx.assert(proof.backDisabled === false, "Back should be enabled after retracing forward.");
+            ctx.assert(proof.forwardDisabled === true, "Forward should be disabled at the end of the history stack.");
+          },
+          screenshot: {
+            name: "conversation-history-forward",
+            claim: "Clicking Forward retraces the same conversation history branch without wrapping.",
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Back and Forward disable at their history boundaries", {
+          voiceover: vo[3],
+          action: async () => {
+            await ensureConversationTabs(ctx);
+            state.firstBoundary = await clickUntilHistoryBoundary(ctx, "back");
+            state.lastBoundary = await clickUntilHistoryBoundary(ctx, "forward");
+            await clickUntilHistoryBoundary(ctx, "back");
+          },
+          assert: async () => {
+            ctx.assert(state.firstBoundary?.backDisabled === true, `Back was not disabled at the first history entry: ${JSON.stringify(state.firstBoundary)}`);
+            ctx.assert(state.firstBoundary?.forwardDisabled === false, "Forward should be enabled from the first history entry.");
+            ctx.assert(state.lastBoundary?.forwardDisabled === true, `Forward was not disabled at the last history entry: ${JSON.stringify(state.lastBoundary)}`);
+            ctx.assert(state.lastBoundary?.backDisabled === false, "Back should be enabled from the last history entry.");
+          },
+          screenshot: {
+            name: "conversation-history-boundary-disabled",
+            claim: "The history controls disable exactly at the beginning and end of the conversation visit stack.",
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};
+
+async function ensureConversationTabs(ctx) {
+  if (state.sessionIds.length >= 3) {
+    await waitForConversationTabs(ctx, state.sessionIds);
+    return state.sessionIds;
+  }
+
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API",
+  });
+  await ctx.waitFor(
+    "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+    { timeoutMs: 60_000, label: "enabled session.create_task action" },
+  );
+
+  let previousSessionId = await currentSessionId(ctx);
+  const sessionIds = [];
+  for (let index = 0; index < 3; index += 1) {
+    await ctx.control("session.create_task");
+    const sessionId = await waitForNewSession(ctx, previousSessionId);
+    sessionIds.push(sessionId);
+    previousSessionId = sessionId;
+  }
+
+  state.sessionIds = sessionIds;
+  await waitForConversationTabs(ctx, sessionIds);
+  return state.sessionIds;
+}
+
+async function waitForNewSession(ctx, previousSessionId) {
+  const previous = previousSessionId ?? "";
+  return ctx.waitFor(
+    `(() => {
+      const id = currentRouteSessionId();
+      return id && id !== ${JSON.stringify(previous)} ? id : null;
+      function currentRouteSessionId() {
+        const route = window.__openworkControl?.snapshot?.().route ?? window.location.hash ?? "";
+        const match = new RegExp("(?:^|/)session/([^/?#]+)").exec(route);
+        return match ? decodeURIComponent(match[1]) : null;
+      }
+    })()`,
+    { timeoutMs: 30_000, label: "new session route" },
+  );
+}
+
+async function currentSessionId(ctx) {
+  return ctx.eval(`(() => {
+    const route = window.__openworkControl?.snapshot?.().route ?? window.location.hash ?? "";
+    const match = new RegExp("(?:^|/)session/([^/?#]+)").exec(route);
+    return match ? decodeURIComponent(match[1]) : null;
+  })()`);
+}
+
+async function waitForConversationTabs(ctx, sessionIds) {
+  await ctx.waitFor(
+    `(() => {
+      const expectedIds = ${JSON.stringify(sessionIds)};
+      const tabs = Array.from(document.querySelectorAll("[data-session-tab-id]"));
+      const hasTabs = expectedIds.every((id) => tabs.some((tab) => tab.getAttribute("data-session-tab-id") === id));
+      const route = window.__openworkControl?.snapshot?.().route ?? window.location.hash ?? "";
+      const match = new RegExp("(?:^|/)session/([^/?#]+)").exec(route);
+      const currentSessionId = match ? decodeURIComponent(match[1]) : null;
+      const active = document.querySelector('[data-session-tab-active="true"]');
+      return hasTabs &&
+        active?.getAttribute("data-session-tab-id") === currentSessionId &&
+        Boolean(document.querySelector('[data-conversation-history-control="back"]')) &&
+        Boolean(document.querySelector('[data-conversation-history-control="forward"]'));
+    })()`,
+    { timeoutMs: 30_000, label: "conversation tabs and history controls" },
+  );
+}
+
+async function clickConversationTab(ctx, sessionId) {
+  const clicked = await ctx.eval(`(() => {
+    const tab = Array.from(document.querySelectorAll("[data-session-tab-id]"))
+      .find((item) => item.getAttribute("data-session-tab-id") === ${JSON.stringify(sessionId)});
+    const button = tab?.querySelector("button");
+    if (!button) return false;
+    button.scrollIntoView({ block: "nearest", inline: "center" });
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(clicked === true, `Could not click conversation tab ${sessionId}`);
+  await waitForSession(ctx, sessionId);
+}
+
+async function clickHistoryButton(ctx, direction, expectedSessionId) {
+  const clicked = await ctx.eval(`(() => {
+    const button = document.querySelector(${JSON.stringify(`[data-conversation-history-control="${direction}"]`)});
+    if (!button || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(clicked === true, `Could not click enabled ${direction} history button.`);
+  await waitForSession(ctx, expectedSessionId);
+}
+
+async function waitForSession(ctx, sessionId) {
+  await ctx.waitFor(
+    `(() => {
+      const route = window.__openworkControl?.snapshot?.().route ?? window.location.hash ?? "";
+      const match = new RegExp("(?:^|/)session/([^/?#]+)").exec(route);
+      const currentSessionId = match ? decodeURIComponent(match[1]) : null;
+      const active = document.querySelector('[data-session-tab-active="true"]');
+      return currentSessionId === ${JSON.stringify(sessionId)} && active?.getAttribute("data-session-tab-id") === currentSessionId;
+    })()`,
+    { timeoutMs: 15_000, label: `session route ${sessionId}` },
+  );
+}
+
+async function clickUntilHistoryBoundary(ctx, direction) {
+  for (let index = 0; index < 12; index += 1) {
+    const stateBeforeClick = await readTabStripState(ctx);
+    if (direction === "back" && stateBeforeClick.backDisabled) return stateBeforeClick;
+    if (direction === "forward" && stateBeforeClick.forwardDisabled) return stateBeforeClick;
+    const beforeSessionId = stateBeforeClick.currentSessionId;
+    const clicked = await ctx.eval(`(() => {
+      const button = document.querySelector(${JSON.stringify(`[data-conversation-history-control="${direction}"]`)});
+      if (!button || button.disabled) return false;
+      button.click();
+      return true;
+    })()`);
+    ctx.assert(clicked === true, `Could not click ${direction} while walking to the history boundary.`);
+    await ctx.waitFor(
+      `(() => {
+        const route = window.__openworkControl?.snapshot?.().route ?? window.location.hash ?? "";
+        const match = new RegExp("(?:^|/)session/([^/?#]+)").exec(route);
+        const id = match ? decodeURIComponent(match[1]) : null;
+        const active = document.querySelector('[data-session-tab-active="true"]');
+        return id && id !== ${JSON.stringify(beforeSessionId)} && active?.getAttribute("data-session-tab-id") === id;
+      })()`,
+      { timeoutMs: 15_000, label: `${direction} history route change` },
+    );
+  }
+  return readTabStripState(ctx);
+}
+
+async function readTabStripState(ctx) {
+  return ctx.eval(`(() => {
+    const route = window.__openworkControl?.snapshot?.().route ?? window.location.hash ?? "";
+    const match = new RegExp("(?:^|/)session/([^/?#]+)").exec(route);
+    const currentSessionId = match ? decodeURIComponent(match[1]) : null;
+    const tabs = Array.from(document.querySelectorAll("[data-session-tab-id]"));
+    const back = document.querySelector('[data-conversation-history-control="back"]');
+    const forward = document.querySelector('[data-conversation-history-control="forward"]');
+    const controls = back?.closest('[aria-label="Conversation history controls"]') ?? null;
+    const firstTab = tabs[0] ?? null;
+    const tabScroller = firstTab?.parentElement ?? null;
+    const active = tabs.find((tab) => tab.getAttribute("data-session-tab-id") === currentSessionId) ?? null;
+    const tabClassText = tabs.map((tab) => tab.getAttribute("class") ?? "").join(" ");
+    const controlsRect = controls?.getBoundingClientRect();
+    return {
+      currentSessionId,
+      tabCount: tabs.length,
+      hasBackButton: Boolean(back),
+      hasForwardButton: Boolean(forward),
+      backDisabled: back ? back.disabled === true : null,
+      forwardDisabled: forward ? forward.disabled === true : null,
+      controlsBeforeTabs: Boolean(controls && firstTab && (controls.compareDocumentPosition(firstTab) & Node.DOCUMENT_POSITION_FOLLOWING)),
+      controlsOutsideTabScroller: Boolean(controls && tabScroller && !tabScroller.contains(controls)),
+      controlsVisible: Boolean(controlsRect && controlsRect.left >= 0 && controlsRect.right <= window.innerWidth),
+      activeTabMatchesRoute: active?.getAttribute("data-session-tab-id") === currentSessionId,
+      tabClassText,
+      activeBoxShadow: active ? getComputedStyle(active).boxShadow : "missing-active-tab",
+    };
+  })()`);
+}

--- a/evals/voiceovers/conversation-tab-history.md
+++ b/evals/voiceovers/conversation-tab-history.md
@@ -1,0 +1,11 @@
+# conversation-tab-history — Browser-style conversation tab history
+
+The demo shows browser-style Back and Forward controls for conversation tab selection history.
+
+1. "I open several conversations as tabs, and the tab strip stays flat and clean without shadows."
+
+2. "I move between conversations, then use the new Back button to return through my conversation history."
+
+3. "I use Forward to retrace that history, just like browser navigation."
+
+4. "Back and Forward become disabled when there is nowhere left to navigate."


### PR DESCRIPTION
## Summary
- add fixed Back and Forward controls to the conversation tab strip
- maintain guarded, non-wrapping workspace-scoped visit history
- reconcile explicitly closed tabs and clear forward branches on new visits
- remove conversation-tab shadows and add the approved fraimz flow

## Validation
- `pnpm --filter @openwork/app exec bun test tests/conversation-tab-history.test.ts` (6 passed)
- `pnpm --filter @openwork/app typecheck` (passed)
- `pnpm fraimz --flow conversation-tab-history --cdp-url http://127.0.0.1:9823` (Passed, 4 frames)

Fraimz: `evals/results/2026-07-12T01-02-59-671Z/fraimz.html`