### PR TITLE
fix: resolve suggestion card icon via BASE_URL for packaged Electron builds

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
 import { Cloud, Columns2, FileText, Globe, Mic2, Settings2, TextSearch, X, Zap } from "lucide-react";
 
+import { resolveExtensionIconSrc } from "@/react-app/design-system/extension-icon-src";
 import { t } from "../../../../i18n";
 import { OPENWORK_EXTENSION_CATALOG } from "../../../../app/constants";
 import { buildDenAuthUrl, readDenBootstrapConfig } from "../../../../app/lib/den";
@@ -1231,7 +1232,7 @@ export function SessionPage(props: SessionPageProps) {
                               );
                             }}
                           >
-                            <img src="/openwork-mark.svg" alt="" width={20} height={20} className="mt-0.5 shrink-0" />
+                            <img src={resolveExtensionIconSrc("/openwork-mark.svg")} alt="" width={20} height={20} className="mt-0.5 shrink-0" />
                             <div>
                               <div className="text-[13px] font-medium text-dls-text">Browse the web</div>
                               <div className="mt-0.5 text-[11px] text-dls-secondary">Search Craigslist for couches and list the results</div>

--- a/evals/flows/packaged-suggestion-icon.flow.mjs
+++ b/evals/flows/packaged-suggestion-icon.flow.mjs
@@ -1,0 +1,100 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/packaged-suggestion-icon.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("packaged-suggestion-icon");
+
+export default {
+  id: "packaged-suggestion-icon",
+  title: "Suggestion card icon loads in a packaged Electron build under file://",
+  kind: "user-facing",
+  preserveTheme: true,
+  steps: [
+    {
+      name: "Frame 1 — suggestion cards visible with a loaded icon on Browse the web",
+      run: async (ctx) => {
+        await ctx.prove("The session empty state shows all three suggestion cards, and the Browse the web icon loaded with non-zero natural dimensions under file://", {
+          voiceover: vo[0],
+          action: async () => {
+            await ctx.waitForText("Browse the web", { timeoutMs: 30_000 });
+            await ctx.waitFor(`(() => {
+              const buttons = Array.from(document.querySelectorAll("button"));
+              const browseBtn = buttons.find((b) => (b.textContent || "").includes("Browse the web"));
+              if (!browseBtn) return false;
+              const img = browseBtn.querySelector("img");
+              return Boolean(img && img.complete && img.naturalWidth > 0);
+            })()`, { timeoutMs: 30_000, label: "Browse the web icon image loaded under file://" });
+          },
+          assert: async () => {
+            await ctx.expectText("Edit a CSV");
+            await ctx.expectText("Browse the web");
+            await ctx.expectText("Connect an extension");
+            const result = await ctx.eval(`(() => {
+              const buttons = Array.from(document.querySelectorAll("button"));
+              const browseBtn = buttons.find((b) => (b.textContent || "").includes("Browse the web"));
+              if (!browseBtn) return { found: false };
+              const img = browseBtn.querySelector("img");
+              if (!img) return { found: true, hasImg: false };
+              return {
+                found: true,
+                hasImg: true,
+                src: img.getAttribute("src"),
+                complete: img.complete,
+                naturalWidth: img.naturalWidth,
+                naturalHeight: img.naturalHeight,
+                pageProtocol: location.protocol,
+              };
+            })()`);
+            ctx.assert(result.found, "Browse the web button not found.");
+            ctx.assert(result.hasImg, "Browse the web button has no img element.");
+            ctx.assert(result.complete, "Browse the web icon image did not finish loading.");
+            ctx.assert(result.naturalWidth > 0, `Browse the web icon naturalWidth is ${result.naturalWidth}, expected > 0.`);
+            ctx.assert(result.pageProtocol === "file:", `Expected file:// protocol but got ${result.pageProtocol}`);
+          },
+          screenshot: {
+            name: "suggestion-cards-icon-loaded",
+            requireText: ["Edit a CSV", "Browse the web", "Connect an extension"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2 — icon src is a rebased relative path, not a bare absolute path",
+      run: async (ctx) => {
+        await ctx.prove("The Browse the web icon src is a relative path rebased by resolveExtensionIconSrc, not a bare absolute /openwork-mark.svg", {
+          voiceover: vo[1],
+          action: async () => {
+            const result = await ctx.eval(`(() => {
+              const buttons = Array.from(document.querySelectorAll("button"));
+              const browseBtn = buttons.find((b) => (b.textContent || "").includes("Browse the web"));
+              if (!browseBtn) return { found: false };
+              const img = browseBtn.querySelector("img");
+              return {
+                found: true,
+                src: img ? img.getAttribute("src") : null,
+                currentSrc: img ? img.currentSrc : null,
+              };
+            })()`);
+            ctx.output("icon-src", JSON.stringify(result, null, 2));
+          },
+          assert: async () => {
+            const result = await ctx.eval(`(() => {
+              const buttons = Array.from(document.querySelectorAll("button"));
+              const browseBtn = buttons.find((b) => (b.textContent || "").includes("Browse the web"));
+              if (!browseBtn) return { found: false };
+              const img = browseBtn.querySelector("img");
+              return {
+                found: true,
+                src: img ? img.getAttribute("src") : null,
+              };
+            })()`);
+            ctx.assert(result.found, "Browse the web button not found.");
+            ctx.assert(result.src !== null, "Browse the web img has no src attribute.");
+            ctx.assert(!result.src.startsWith("/openwork-mark"), `Icon src is absolute "${result.src}" — should be rebased to relative.`);
+            ctx.assert(result.src.includes("openwork-mark.svg"), `Icon src "${result.src}" does not reference openwork-mark.svg.`);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/packaged-suggestion-icon.md
+++ b/evals/voiceovers/packaged-suggestion-icon.md
@@ -1,0 +1,13 @@
+# packaged-suggestion-icon — Suggestion card icon loads in a packaged Electron build
+
+In packaged Electron builds the renderer is loaded via `file://`, and Vite
+emits relative asset paths (`base: "./"`). A hardcoded absolute `src` like
+`/openwork-mark.svg` bypasses Vite's asset rebasing, resolves to the filesystem
+root under `file://`, and silently 404s — so the Browse the web suggestion card
+showed no icon. The fix routes the path through `resolveExtensionIconSrc`,
+which prepends `import.meta.env.BASE_URL`, producing a relative `./openwork-mark.svg`
+that resolves correctly next to index.html.
+
+1. I launch the packaged Electron app and land on the session empty state. The three suggestion cards are visible — Edit a CSV, Browse the web, Connect an extension. The Browse the web card's icon image has loaded with non-zero natural dimensions, confirming the SVG resolved under the file:// protocol.
+
+2. I confirm the icon src is a relative path — ./openwork-mark.svg — rebased by the resolveExtensionIconSrc helper, not a bare absolute /openwork-mark.svg that would break under file://.


### PR DESCRIPTION
## The "Browse the web" icon is invisible in the packaged desktop app

When users open the app for the first time, the **Browse the web** suggestion card shows a blank space where its icon should be — while the other two cards ("Edit a CSV", "Connect an extension") display their icons correctly. This only happens in the **packaged** app (`.app`/`.exe`/AppImage), not in dev mode.

### Before (broken) → After (fixed)

| Before — icon blank | After — icon visible |
|---|---|
| ![before](https://github.com/yomgui/openwork/raw/fix/electron-absolute-asset-paths/evals/results/packaged-suggestion-icon-proof/before-broken-icon.png) | ![after](https://github.com/yomgui/openwork/raw/fix/electron-absolute-asset-paths/evals/results/packaged-suggestion-icon-proof/after-fixed-icon.png) |

---

### Technical details

In packaged Electron builds the renderer loads via `file://` and Vite emits relative asset paths (`base: "./"`). The suggestion card hardcoded `src="/openwork-mark.svg"` directly in JSX, bypassing Vite's asset rebasing. Under `file://`, the absolute path resolves to the filesystem root and silently 404s.

The fix routes the path through the existing `resolveExtensionIconSrc` helper, which prepends `import.meta.env.BASE_URL`, producing `./openwork-mark.svg` that resolves correctly. This was the **only** occurrence bypassing the resolver; all other references were already safe.

### Validation
- `pnpm typecheck` — passed
- `pnpm build` (`OPENWORK_ELECTRON_BUILD=1`) — passed
- `pnpm fraimz --flow packaged-suggestion-icon` — **Passed** (2 frames, asserts `file:` protocol + relative src + non-zero natural dimensions)