### PR TITLE
fix(app): keep remote workspaces visible while reconnecting

### DIFF
--- a/apps/app/src/app/types.ts
+++ b/apps/app/src/app/types.ts
@@ -202,7 +202,7 @@ export type SettingsTab = (typeof SETTINGS_TAB_VALUES)[number];
 
 export type WorkspacePreset = "starter" | "automation" | "minimal";
 
-export type WorkspaceConnectionStatus = "idle" | "connecting" | "connected" | "error";
+export type WorkspaceConnectionStatus = "idle" | "connecting" | "reconnecting" | "connected" | "error";
 
 export type WorkspaceConnectionState = {
   status: WorkspaceConnectionStatus;

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -984,6 +984,9 @@ function WorkspaceSidebarGroup({
     if (connectionState.status === "error") return connectionState.message?.trim() || taskLoadError.message;
     if (group.status === "error") return taskLoadError.label;
     if (isConnectionActionBusy) return t("workspace_list.connecting");
+    if (isRemoteWorkspace && connectionState.status === "reconnecting") {
+      return `${t("workspace.remote_badge")} · ${t("settings.reconnecting")}`;
+    }
     if (isRemoteWorkspace && connectionState.status === "connected") return connectionState.message?.trim() || t("workspace_list.connected");
     if (!ctx.developerMode) return "";
     if (isSelected) return t("workspace.selected");

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -7,7 +7,7 @@ import type { Session } from "@opencode-ai/sdk/v2/client";
 
 import type { OpenworkWorkspaceInfo } from "@/app/lib/openwork-server";
 import type { WorkspaceInfo } from "@/app/lib/desktop-types";
-import type { WorkspaceSessionGroup } from "@/app/types";
+import type { WorkspaceConnectionState, WorkspaceSessionGroup } from "@/app/types";
 import {
   normalizeDirectoryPath,
   normalizeSessionStatus,
@@ -30,6 +30,8 @@ export type RouteSession = Session & {
   runStatus?: unknown;
   slug?: string | null;
 };
+
+export const WORKSPACE_REFRESH_RETRY_INTERVAL_MS = 30_000;
 
 export function mapDesktopWorkspace(workspace: WorkspaceInfo): RouteWorkspace {
   return {
@@ -168,6 +170,43 @@ export function mergeRouteWorkspaces(
   });
 
   return [...mergedServer, ...missingDesktop];
+}
+
+/**
+ * A transport failure is not an authoritative empty workspace snapshot.
+ * Preserve the last successful server view while still applying fresher
+ * desktop-owned routing fields and newly-created desktop workspaces.
+ */
+export function retainRouteWorkspacesOnRefreshFailure(
+  lastKnownWorkspaces: RouteWorkspace[],
+  desktopWorkspaces: RouteWorkspace[],
+): RouteWorkspace[] {
+  return mergeRouteWorkspaces(lastKnownWorkspaces, desktopWorkspaces);
+}
+
+export function markRemoteWorkspacesReconnecting(
+  current: Record<string, WorkspaceConnectionState>,
+  workspaces: RouteWorkspace[],
+): Record<string, WorkspaceConnectionState> {
+  const next = { ...current };
+  for (const workspace of workspaces) {
+    if (workspace.workspaceType !== "remote") continue;
+    const existing = next[workspace.id];
+    if (existing?.status === "connecting" || existing?.status === "error") continue;
+    next[workspace.id] = {
+      status: "reconnecting",
+      message: null,
+      checkedAt: existing?.checkedAt ?? null,
+    };
+  }
+  return next;
+}
+
+export function shouldRetryFailedWorkspaceRefresh(input: {
+  refreshFailed: boolean;
+  online: boolean;
+}): boolean {
+  return input.refreshFailed && input.online;
 }
 
 export function orderRouteWorkspaces(workspaces: RouteWorkspace[], orderIds: string[]): RouteWorkspace[] {

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -209,6 +209,19 @@ export function shouldRetryFailedWorkspaceRefresh(input: {
   return input.refreshFailed && input.online;
 }
 
+export function shouldLoadRouteWorkspaceSessions(input: {
+  workspaceId: string;
+  selectedWorkspaceId: string;
+  alreadyLoaded: boolean;
+  reconnectPending: boolean;
+}): boolean {
+  return (
+    input.workspaceId === input.selectedWorkspaceId ||
+    !input.alreadyLoaded ||
+    input.reconnectPending
+  );
+}
+
 export function orderRouteWorkspaces(workspaces: RouteWorkspace[], orderIds: string[]): RouteWorkspace[] {
   if (orderIds.length === 0) return workspaces;
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1185,6 +1185,11 @@ export function SessionRoute() {
       if (isDesktopRuntime()) {
         await workspaceForget(workspaceId).catch(() => undefined);
       }
+      const retainedWorkspaces = workspacesRef.current.filter(
+        (workspace) => workspace.id !== workspaceId,
+      );
+      workspacesRef.current = retainedWorkspaces;
+      setWorkspaces(retainedWorkspaces);
       if (selectedWorkspaceId === workspaceId) {
         setLegacySelectedWorkspaceId("");
         writeActiveWorkspaceId(null);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -46,7 +46,10 @@ import {
   mapDesktopWorkspace,
   mergeRouteWorkspaces,
   orderRouteWorkspaces,
+  retainRouteWorkspacesOnRefreshFailure,
+  shouldRetryFailedWorkspaceRefresh,
   toSessionGroups,
+  WORKSPACE_REFRESH_RETRY_INTERVAL_MS,
   workspaceExportFilename,
   workspaceLabel,
 } from "@/react-app/shell/route-workspaces";
@@ -388,6 +391,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [busyLabel, setBusyLabel] = useState<string | null>(null);
   const workspacesRef = useRef<RouteWorkspace[]>([]);
   const refreshInFlightRef = useRef(false);
+  const refreshFailedRef = useRef(false);
   const reconnectAttemptedWorkspaceIdRef = useRef("");
   const refreshMcpServersRef = useRef<(() => void | Promise<void>) | null>(null);
   const notifyMcpReloadingRef = useRef<(() => void) | null>(null);
@@ -1112,11 +1116,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         setOpenworkClient(null);
         setBaseUrl("");
         setToken("");
-        setWorkspaces(desktopWorkspaces);
-        setSessionsByWorkspaceId({});
-        setErrorsByWorkspaceId({});
+        const retainedWorkspaces = retainRouteWorkspacesOnRefreshFailure(
+          workspacesRef.current,
+          desktopWorkspaces,
+        );
+        refreshFailedRef.current = retainedWorkspaces.length > 0;
+        setWorkspaces(retainedWorkspaces);
         setLegacySelectedWorkspaceId((current) => {
-          const next = current || readActiveWorkspaceId() || resolveWorkspaceListSelectedId(desktopList) || desktopWorkspaces[0]?.id || "";
+          const next = current || readActiveWorkspaceId() || resolveWorkspaceListSelectedId(desktopList) || retainedWorkspaces[0]?.id || "";
           writeActiveWorkspaceId(next || null);
           return next;
         });
@@ -1129,6 +1136,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         hostToken: resolvedHostToken || undefined,
       });
       const list = await client.listWorkspaces();
+      refreshFailedRef.current = false;
       const serverWorkspaceIds = new Set(list.items.map((workspace) => workspace.id));
       const nextWorkspaces = mergeRouteWorkspaces(list.items, desktopWorkspaces);
       const sessionEntries = await Promise.all(
@@ -1196,6 +1204,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         return next;
       });
     } catch (error) {
+      refreshFailedRef.current = true;
       const message = describeRouteError(error);
       console.error("[settings-route] refreshRouteState failed", error);
       recordInspectorEvent("route.refresh.error", {
@@ -1210,10 +1219,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         body: message,
         dedupeKey: "settings-route-refresh",
       });
-      if (desktopWorkspaces.length > 0) {
-        setWorkspaces(desktopWorkspaces);
+      const retainedWorkspaces = retainRouteWorkspacesOnRefreshFailure(
+        workspacesRef.current,
+        desktopWorkspaces,
+      );
+      if (retainedWorkspaces.length > 0) {
+        setWorkspaces(retainedWorkspaces);
         setLegacySelectedWorkspaceId((current) => {
-          const next = current || readActiveWorkspaceId() || resolveWorkspaceListSelectedId(desktopList) || desktopWorkspaces[0]?.id || "";
+          const next = current || readActiveWorkspaceId() || resolveWorkspaceListSelectedId(desktopList) || retainedWorkspaces[0]?.id || "";
           writeActiveWorkspaceId(next || null);
           return next;
         });
@@ -1401,9 +1414,29 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     const handleSettingsChange = () => {
       void refreshRouteState();
     };
+    const retryFailedRefresh = () => {
+      if (
+        !shouldRetryFailedWorkspaceRefresh({
+          refreshFailed: refreshFailedRef.current,
+          online: window.navigator.onLine !== false,
+        })
+      ) {
+        return;
+      }
+      void refreshRouteState();
+    };
     window.addEventListener("openwork-server-settings-changed", handleSettingsChange);
+    window.addEventListener("online", retryFailedRefresh);
+    window.addEventListener("focus", retryFailedRefresh);
+    const retryInterval = window.setInterval(
+      retryFailedRefresh,
+      WORKSPACE_REFRESH_RETRY_INTERVAL_MS,
+    );
     return () => {
       window.removeEventListener("openwork-server-settings-changed", handleSettingsChange);
+      window.removeEventListener("online", retryFailedRefresh);
+      window.removeEventListener("focus", retryFailedRefresh);
+      window.clearInterval(retryInterval);
     };
   }, [refreshRouteState]);
 
@@ -1833,6 +1866,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     if (isDesktopRuntime()) {
       await workspaceForget(workspaceId).catch(() => undefined);
     }
+    const retainedWorkspaces = workspacesRef.current.filter(
+      (workspace) => workspace.id !== workspaceId,
+    );
+    workspacesRef.current = retainedWorkspaces;
+    setWorkspaces(retainedWorkspaces);
     if (selectedWorkspaceId === workspaceId) {
       const nextWorkspace = workspaces.find((workspace) => workspace.id !== workspaceId);
       const nextId = nextWorkspace?.id ?? "";

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -42,6 +42,7 @@ import {
   mergeRouteWorkspaces,
   orderRouteWorkspaces,
   retainRouteWorkspacesOnRefreshFailure,
+  shouldLoadRouteWorkspaceSessions,
   shouldRetryFailedWorkspaceRefresh,
   WORKSPACE_REFRESH_RETRY_INTERVAL_MS,
   type RouteSession,
@@ -115,6 +116,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   );
   const refreshInFlightRef = useRef(false);
   const refreshFailedRef = useRef(false);
+  const remoteWorkspaceRefreshPendingRef = useRef(new Set<string>());
   const workspacesRef = useRef<RouteWorkspace[]>([]);
   const workspaceOrderIdsRef = useRef(workspaceOrderIds);
   const remoteWorkspaceCheckRunRef = useRef<Record<string, string>>({});
@@ -222,6 +224,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
             return next;
           });
           setErrorsByWorkspaceId((current) => ({ ...current, [workspace.id]: null }));
+          remoteWorkspaceRefreshPendingRef.current.delete(workspace.id);
           setWorkspaceConnectionOverrides((current) => {
             if (isRemoteOpenworkWorkspace) {
               return {
@@ -357,6 +360,9 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           (workspace) => workspace.workspaceType === "remote",
         );
         if (retainedRemoteWorkspaces.length > 0) {
+          for (const workspace of retainedRemoteWorkspaces) {
+            remoteWorkspaceRefreshPendingRef.current.add(workspace.id);
+          }
           void loadWorkspaceSessionsInBackground(retainedRemoteWorkspaces);
         }
         return;
@@ -461,10 +467,12 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       // loading state per-workspace until the list arrives.
       const selectedWorkspace = nextWorkspaces.find((workspace) => workspace.id === nextWorkspaceId);
       const backgroundWorkspaces = nextWorkspaces.filter(
-        (workspace) =>
-          workspace.workspaceType === "remote" ||
-          workspace.id === nextWorkspaceId ||
-          !alreadyLoadedWorkspaceIds.has(workspace.id),
+        (workspace) => shouldLoadRouteWorkspaceSessions({
+          workspaceId: workspace.id,
+          selectedWorkspaceId: nextWorkspaceId,
+          alreadyLoaded: alreadyLoadedWorkspaceIds.has(workspace.id),
+          reconnectPending: remoteWorkspaceRefreshPendingRef.current.has(workspace.id),
+        }),
       );
       if (backgroundWorkspaces.length > 0) {
         const orderedWorkspaces = selectedWorkspace
@@ -498,6 +506,9 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           (workspace) => workspace.workspaceType === "remote",
         );
         if (retainedRemoteWorkspaces.length > 0) {
+          for (const workspace of retainedRemoteWorkspaces) {
+            remoteWorkspaceRefreshPendingRef.current.add(workspace.id);
+          }
           void loadWorkspaceSessionsInBackground(retainedRemoteWorkspaces);
         }
       }

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -37,9 +37,13 @@ import { resolveOpenworkConnection } from "./openwork-connection";
 import {
   describeRouteError,
   isTransientStartupError,
+  markRemoteWorkspacesReconnecting,
   mapDesktopWorkspace,
   mergeRouteWorkspaces,
   orderRouteWorkspaces,
+  retainRouteWorkspacesOnRefreshFailure,
+  shouldRetryFailedWorkspaceRefresh,
+  WORKSPACE_REFRESH_RETRY_INTERVAL_MS,
   type RouteSession,
   type RouteWorkspace,
 } from "./route-workspaces";
@@ -110,6 +114,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     [],
   );
   const refreshInFlightRef = useRef(false);
+  const refreshFailedRef = useRef(false);
   const workspacesRef = useRef<RouteWorkspace[]>([]);
   const workspaceOrderIdsRef = useRef(workspaceOrderIds);
   const remoteWorkspaceCheckRunRef = useRef<Record<string, string>>({});
@@ -334,12 +339,26 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         setClient(null);
         setBaseUrl("");
         setToken("");
-        const orderedDesktopWorkspaces = orderRouteWorkspaces(desktopWorkspaces, workspaceOrderIdsRef.current);
-        setWorkspaces(orderedDesktopWorkspaces);
-        sessionsByWorkspaceIdRef.current = {};
-        setSessionsByWorkspaceId({});
-        setErrorsByWorkspaceId({});
-        setLegacySelectedWorkspaceId(resolveWorkspaceListSelectedId(desktopList) || orderedDesktopWorkspaces[0]?.id || "");
+        const retainedWorkspaces = orderRouteWorkspaces(
+          retainRouteWorkspacesOnRefreshFailure(workspacesRef.current, desktopWorkspaces),
+          workspaceOrderIdsRef.current,
+        );
+        refreshFailedRef.current = retainedWorkspaces.length > 0;
+        setWorkspaces(retainedWorkspaces);
+        setWorkspaceConnectionOverrides((current) =>
+          markRemoteWorkspacesReconnecting(current, retainedWorkspaces),
+        );
+        setLegacySelectedWorkspaceId((current) =>
+          current && retainedWorkspaces.some((workspace) => workspace.id === current)
+            ? current
+            : resolveWorkspaceListSelectedId(desktopList) || retainedWorkspaces[0]?.id || "",
+        );
+        const retainedRemoteWorkspaces = retainedWorkspaces.filter(
+          (workspace) => workspace.workspaceType === "remote",
+        );
+        if (retainedRemoteWorkspaces.length > 0) {
+          void loadWorkspaceSessionsInBackground(retainedRemoteWorkspaces);
+        }
         return;
       }
 
@@ -359,6 +378,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         hostToken: resolvedHostToken || undefined,
       });
       const list = await openworkClient.listWorkspaces();
+      refreshFailedRef.current = false;
       const nextWorkspaces = orderRouteWorkspaces(
         mergeRouteWorkspaces(list.items, desktopWorkspaces),
         workspaceOrderIdsRef.current,
@@ -441,7 +461,10 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       // loading state per-workspace until the list arrives.
       const selectedWorkspace = nextWorkspaces.find((workspace) => workspace.id === nextWorkspaceId);
       const backgroundWorkspaces = nextWorkspaces.filter(
-        (workspace) => workspace.id === nextWorkspaceId || !alreadyLoadedWorkspaceIds.has(workspace.id),
+        (workspace) =>
+          workspace.workspaceType === "remote" ||
+          workspace.id === nextWorkspaceId ||
+          !alreadyLoadedWorkspaceIds.has(workspace.id),
       );
       if (backgroundWorkspaces.length > 0) {
         const orderedWorkspaces = selectedWorkspace
@@ -450,6 +473,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         void loadWorkspaceSessionsInBackground(orderedWorkspaces);
       }
     } catch (error) {
+      refreshFailedRef.current = true;
       const message = describeRouteError(error);
       console.error("[session-route] refreshRouteState failed", error);
       recordInspectorEvent("route.refresh.error", {
@@ -458,12 +482,24 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         preservedWorkspaceCount: desktopWorkspaces.length,
       });
       setRouteError(message);
-      if (desktopWorkspaces.length > 0) {
-        const orderedDesktopWorkspaces = orderRouteWorkspaces(desktopWorkspaces, workspaceOrderIdsRef.current);
-        setWorkspaces(orderedDesktopWorkspaces);
-        setLegacySelectedWorkspaceId((current) =>
-          current || resolveWorkspaceListSelectedId(desktopList) || orderedDesktopWorkspaces[0]?.id || "",
+      const retainedWorkspaces = orderRouteWorkspaces(
+        retainRouteWorkspacesOnRefreshFailure(workspacesRef.current, desktopWorkspaces),
+        workspaceOrderIdsRef.current,
+      );
+      if (retainedWorkspaces.length > 0) {
+        setWorkspaces(retainedWorkspaces);
+        setWorkspaceConnectionOverrides((current) =>
+          markRemoteWorkspacesReconnecting(current, retainedWorkspaces),
         );
+        setLegacySelectedWorkspaceId((current) =>
+          current || resolveWorkspaceListSelectedId(desktopList) || retainedWorkspaces[0]?.id || "",
+        );
+        const retainedRemoteWorkspaces = retainedWorkspaces.filter(
+          (workspace) => workspace.workspaceType === "remote",
+        );
+        if (retainedRemoteWorkspaces.length > 0) {
+          void loadWorkspaceSessionsInBackground(retainedRemoteWorkspaces);
+        }
       }
     } finally {
       setLoading(false);
@@ -557,6 +593,24 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     };
     window.addEventListener("openwork-server-settings-changed", handleSettingsChange);
 
+    const retryFailedRefresh = () => {
+      if (
+        !shouldRetryFailedWorkspaceRefresh({
+          refreshFailed: refreshFailedRef.current,
+          online: window.navigator.onLine !== false,
+        })
+      ) {
+        return;
+      }
+      void refreshRouteState();
+    };
+    window.addEventListener("online", retryFailedRefresh);
+    window.addEventListener("focus", retryFailedRefresh);
+    const retryInterval = window.setInterval(
+      retryFailedRefresh,
+      WORKSPACE_REFRESH_RETRY_INTERVAL_MS,
+    );
+
     // Also retry on visibility flip independently — even when nobody else
     // dispatches the settings event.
     const handleVisibility = () => {
@@ -576,6 +630,9 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         startupRetryTimerRef.current = null;
       }
       window.removeEventListener("openwork-server-settings-changed", handleSettingsChange);
+      window.removeEventListener("online", retryFailedRefresh);
+      window.removeEventListener("focus", retryFailedRefresh);
+      window.clearInterval(retryInterval);
       if (typeof document !== "undefined") {
         document.removeEventListener("visibilitychange", handleVisibility);
       }
@@ -604,6 +661,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         path: workspace.path,
         sessionCount: (sessionsByWorkspaceId[workspace.id] ?? []).length,
         loading: retryingWorkspaceIds.includes(workspace.id),
+        connectionStatus: workspaceConnectionOverrides[workspace.id]?.status ?? "idle",
         error: errorsByWorkspaceId[workspace.id] ?? null,
       })),
       sessionsByWorkspaceId: Object.fromEntries(
@@ -630,6 +688,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     sessionsByWorkspaceId,
     token,
     workspaces,
+    workspaceConnectionOverrides,
   ]);
 
   // Once workspaces + sessions are loaded and the URL has no sessionId, try to

--- a/apps/app/tests/remote-workspace-resilience.test.ts
+++ b/apps/app/tests/remote-workspace-resilience.test.ts
@@ -4,6 +4,7 @@ import type { WorkspaceConnectionState } from "../src/app/types";
 import {
   markRemoteWorkspacesReconnecting,
   retainRouteWorkspacesOnRefreshFailure,
+  shouldLoadRouteWorkspaceSessions,
   shouldRetryFailedWorkspaceRefresh,
   type RouteWorkspace,
 } from "../src/react-app/shell/route-workspaces";
@@ -110,5 +111,20 @@ describe("remote workspace refresh resilience", () => {
     expect(shouldRetryFailedWorkspaceRefresh({ refreshFailed: true, online: true })).toBe(true);
     expect(shouldRetryFailedWorkspaceRefresh({ refreshFailed: true, online: false })).toBe(false);
     expect(shouldRetryFailedWorkspaceRefresh({ refreshFailed: false, online: true })).toBe(false);
+  });
+
+  test("does not refetch a healthy cached remote on every route refresh", () => {
+    expect(shouldLoadRouteWorkspaceSessions({
+      workspaceId: "remote_1",
+      selectedWorkspaceId: "local_1",
+      alreadyLoaded: true,
+      reconnectPending: false,
+    })).toBe(false);
+    expect(shouldLoadRouteWorkspaceSessions({
+      workspaceId: "remote_1",
+      selectedWorkspaceId: "local_1",
+      alreadyLoaded: true,
+      reconnectPending: true,
+    })).toBe(true);
   });
 });

--- a/apps/app/tests/remote-workspace-resilience.test.ts
+++ b/apps/app/tests/remote-workspace-resilience.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, test } from "bun:test";
+
+import type { WorkspaceConnectionState } from "../src/app/types";
+import {
+  markRemoteWorkspacesReconnecting,
+  retainRouteWorkspacesOnRefreshFailure,
+  shouldRetryFailedWorkspaceRefresh,
+  type RouteWorkspace,
+} from "../src/react-app/shell/route-workspaces";
+
+function workspace(input: {
+  id: string;
+  name: string;
+  workspaceType: "local" | "remote";
+  path?: string;
+  baseUrl?: string;
+  openworkToken?: string;
+}): RouteWorkspace {
+  return {
+    id: input.id,
+    name: input.name,
+    displayNameResolved: input.name,
+    path: input.path ?? "",
+    preset: input.workspaceType === "remote" ? "remote" : "starter",
+    workspaceType: input.workspaceType,
+    remoteType: input.workspaceType === "remote" ? "openwork" : null,
+    baseUrl: input.baseUrl ?? null,
+    openworkToken: input.openworkToken ?? null,
+  };
+}
+
+describe("remote workspace refresh resilience", () => {
+  test("retains server-sourced remote workspaces when refresh fails", () => {
+    const local = workspace({
+      id: "local_1",
+      name: "Local",
+      workspaceType: "local",
+      path: "/workspaces/local",
+    });
+    const remote = workspace({
+      id: "remote_1",
+      name: "Remote design",
+      workspaceType: "remote",
+      baseUrl: "https://worker.example.com",
+      openworkToken: "retained-token",
+    });
+
+    const retained = retainRouteWorkspacesOnRefreshFailure(
+      [local, remote],
+      [local],
+    );
+
+    expect(retained.map((item) => item.id)).toEqual(["local_1", "remote_1"]);
+    expect(retained[1]?.openworkToken).toBe("retained-token");
+  });
+
+  test("prefers fresh desktop routing fields without duplicating a remote workspace", () => {
+    const staleRemote = workspace({
+      id: "remote_1",
+      name: "Remote design",
+      workspaceType: "remote",
+      baseUrl: "https://old-worker.example.com",
+      openworkToken: "old-token",
+    });
+    const freshDesktopRemote = workspace({
+      id: "remote_1",
+      name: "Remote design",
+      workspaceType: "remote",
+      baseUrl: "https://worker.example.com",
+      openworkToken: "new-token",
+    });
+
+    const retained = retainRouteWorkspacesOnRefreshFailure(
+      [staleRemote],
+      [freshDesktopRemote],
+    );
+
+    expect(retained).toHaveLength(1);
+    expect(retained[0]?.baseUrl).toBe("https://worker.example.com");
+    expect(retained[0]?.openworkToken).toBe("new-token");
+  });
+
+  test("marks retained remote workspaces reconnecting without hiding a specific error", () => {
+    const remote = workspace({
+      id: "remote_1",
+      name: "Remote design",
+      workspaceType: "remote",
+    });
+    const brokenRemote = workspace({
+      id: "remote_2",
+      name: "Broken worker",
+      workspaceType: "remote",
+    });
+    const current: Record<string, WorkspaceConnectionState> = {
+      remote_1: { status: "connected", checkedAt: 100 },
+      remote_2: { status: "error", message: "Token rejected", checkedAt: 200 },
+    };
+
+    const next = markRemoteWorkspacesReconnecting(current, [remote, brokenRemote]);
+
+    expect(next.remote_1).toEqual({
+      status: "reconnecting",
+      message: null,
+      checkedAt: 100,
+    });
+    expect(next.remote_2).toEqual(current.remote_2);
+  });
+
+  test("retries only after a failed refresh while the client is online", () => {
+    expect(shouldRetryFailedWorkspaceRefresh({ refreshFailed: true, online: true })).toBe(true);
+    expect(shouldRetryFailedWorkspaceRefresh({ refreshFailed: true, online: false })).toBe(false);
+    expect(shouldRetryFailedWorkspaceRefresh({ refreshFailed: false, online: true })).toBe(false);
+  });
+});

--- a/docs/remote-workspace-reconciliation.md
+++ b/docs/remote-workspace-reconciliation.md
@@ -1,0 +1,62 @@
+# Remote workspace reconciliation
+
+OpenWork combines workspace records from more than one runtime:
+
+- the desktop workspace store owns local connection details, including remote
+  worker routing and credentials;
+- the connected OpenWork server provides its current workspace snapshot; and
+- the React client keeps the last successfully rendered snapshot while it is
+  running.
+
+Before this change, Session and Settings treated a failed server refresh like
+an authoritative empty response. They replaced the rendered list with the
+desktop-only list, so server-sourced remote workspaces disappeared and then
+returned after a later successful refresh.
+
+## Reconciliation model
+
+```mermaid
+flowchart LR
+  D["Desktop workspace store"] -->|routing fields| C["Client reconciliation"]
+  S["OpenWork server"] -->|successful workspace snapshot| C
+  L["Last successful client snapshot"] -->|temporary fallback| C
+  C --> U["Stable workspace sidebar"]
+  S -. "timeout / disconnect" .-> R["Retain + mark reconnecting"]
+  R --> U
+  R -->|online, focus, or bounded timer| S
+```
+
+The client now separates **absence** from **unknown availability**:
+
+| Event | Workspace-list decision |
+| --- | --- |
+| Successful server response | Reconcile against the live snapshot; confirmed missing entries may be removed. |
+| Desktop store refresh | Apply newer desktop-owned routing fields and add newly created desktop workspaces. |
+| Timeout, network error, or unavailable server | Retain the last successful snapshot; do not infer deletion. |
+| Explicit user removal | Remove immediately from both persistent stores and the retained in-memory snapshot. |
+| Connectivity returns | Retry, verify remote workers, and reconcile without duplicate rows or order churn. |
+
+## Why this is safe
+
+- The fallback is in memory only. It does not copy worker tokens or workspace
+  paths into a new browser cache.
+- Existing desktop storage remains authoritative for desktop-managed remote
+  connection details.
+- A specific worker error, such as a rejected token, is not overwritten by a
+  generic reconnecting state.
+- Retry signals are bounded and respect the existing in-flight guard, so a
+  slow request is not multiplied by the background timer.
+- No Den, OpenWork server, IPC, or database contract changes are required.
+
+## Recovery behavior
+
+Remote rows remain visible with their cached tasks and show
+`Remote · Reconnecting…` while the owning endpoint is rechecked. OpenWork
+retries when the network returns, when the app regains focus, and every 30
+seconds while a refresh is known to have failed. A successful remote task load
+clears the reconnecting state.
+
+A completely fresh browser launch still cannot reconstruct a server-only
+workspace while every server is unavailable. Desktop-managed remote
+workspaces remain recoverable because their existing desktop store is loaded
+before server reconciliation.

--- a/docs/remote-workspace-reconciliation.md
+++ b/docs/remote-workspace-reconciliation.md
@@ -36,6 +36,11 @@ The client now separates **absence** from **unknown availability**:
 | Explicit user removal | Remove immediately from both persistent stores and the retained in-memory snapshot. |
 | Connectivity returns | Retry, verify remote workers, and reconcile without duplicate rows or order churn. |
 
+Reconnect work is targeted. A normal successful route refresh reloads the
+selected workspace, newly discovered workspaces, and remote workspaces that
+were explicitly marked pending by a failed refresh. Healthy cached remote
+workspaces are not re-fetched on every unrelated route refresh.
+
 ## Why this is safe
 
 - The fallback is in memory only. It does not copy worker tokens or workspace

--- a/evals/flows/remote-workspace-resilience.flow.mjs
+++ b/evals/flows/remote-workspace-resilience.flow.mjs
@@ -1,0 +1,105 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "remote-workspace-resilience";
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const APP = path.join(ROOT, "apps", "app");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function run(command, args, cwd = ROOT) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return {
+    status: result.status,
+    output: `${result.stdout || ""}${result.stderr || ""}`.trim(),
+  };
+}
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${actual})` : ""}`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Remote workspaces remain stable through server disconnects and reconnect cleanly",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "A mixed local and remote workspace snapshot is characterized",
+      run: async (ctx) => {
+        await ctx.prove("Local and remote workspace state begins from a verified reconciliation contract", {
+          voiceover: vo[0],
+          assert: async () => {
+            const result = run("bun", ["test", "tests/remote-workspace-resilience.test.ts"], APP);
+            witness(ctx, result.status === 0, "The focused workspace reconciliation suite passes", result.output.split("\n").slice(-12).join("\n"));
+            witness(ctx, result.output.includes("retains server-sourced remote workspaces"), "Server-sourced remote retention is exercised");
+            ctx.output("workspace-resilience-tests", result.output);
+          },
+        });
+      },
+    },
+    {
+      name: "Refresh failure preserves the rendered workspace list",
+      run: async (ctx) => {
+        await ctx.prove("A temporary disconnect retains remote rows and exposes reconnecting state", {
+          voiceover: vo[1],
+          assert: async () => {
+            const route = readFileSync(path.join(APP, "src/react-app/shell/use-workspace-route-state.ts"), "utf8");
+            const settings = readFileSync(path.join(APP, "src/react-app/shell/settings-route.tsx"), "utf8");
+            const sidebar = readFileSync(path.join(APP, "src/react-app/domains/session/sidebar/app-sidebar.tsx"), "utf8");
+            witness(ctx, route.includes("retainRouteWorkspacesOnRefreshFailure(workspacesRef.current, desktopWorkspaces)"), "Session retains its last successful snapshot on refresh failure");
+            witness(ctx, settings.includes("retainRouteWorkspacesOnRefreshFailure("), "Settings uses the same failure reconciliation policy");
+            witness(ctx, sidebar.includes('connectionState.status === "reconnecting"'), "The sidebar renders a distinct reconnecting state");
+          },
+        });
+      },
+    },
+    {
+      name: "Deletion and conflict rules remain explicit",
+      run: async (ctx) => {
+        await ctx.prove("Unknown availability cannot delete data, while explicit removal still wins", {
+          voiceover: vo[2],
+          assert: async () => {
+            const reconciliation = readFileSync(path.join(APP, "src/react-app/shell/route-workspaces.ts"), "utf8");
+            const sessionRoute = readFileSync(path.join(APP, "src/react-app/shell/session-route.tsx"), "utf8");
+            const settingsRoute = readFileSync(path.join(APP, "src/react-app/shell/settings-route.tsx"), "utf8");
+            const guide = readFileSync(path.join(ROOT, "docs/remote-workspace-reconciliation.md"), "utf8");
+            witness(ctx, reconciliation.includes("desktop-owned routing fields"), "Desktop-owned routing fields remain authoritative during fallback");
+            witness(ctx, sessionRoute.includes("workspacesRef.current = retainedWorkspaces"), "Session removal updates the retained snapshot immediately");
+            witness(ctx, settingsRoute.includes("workspacesRef.current = retainedWorkspaces"), "Settings removal updates the retained snapshot immediately");
+            witness(ctx, guide.includes("Successful server response") && guide.includes("Explicit user removal"), "The conflict and deletion policy is documented");
+          },
+        });
+      },
+    },
+    {
+      name: "Reconnect signals are bounded and converge on live state",
+      run: async (ctx) => {
+        await ctx.prove("OpenWork retries automatically without overlapping an in-flight refresh", {
+          voiceover: vo[3],
+          assert: async () => {
+            const route = readFileSync(path.join(APP, "src/react-app/shell/use-workspace-route-state.ts"), "utf8");
+            const reconciliation = readFileSync(path.join(APP, "src/react-app/shell/route-workspaces.ts"), "utf8");
+            witness(ctx, route.includes('window.addEventListener("online", retryFailedRefresh)'), "Network restoration triggers a retry");
+            witness(ctx, route.includes('window.addEventListener("focus", retryFailedRefresh)'), "Returning to the app triggers a retry");
+            witness(ctx, reconciliation.includes("WORKSPACE_REFRESH_RETRY_INTERVAL_MS = 30_000"), "Background retry is bounded to a 30-second interval");
+            witness(ctx, !route.includes("retryFailedRefresh = () => {\n      refreshInFlightRef.current = false"), "Automatic retry respects the in-flight guard");
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/remote-workspace-resilience.md
+++ b/evals/voiceovers/remote-workspace-resilience.md
@@ -1,0 +1,9 @@
+# remote-workspace-resilience — remote workspaces remain visible while OpenWork reconnects
+
+1. A user starts with local and remote workspaces visible in the sidebar, including tasks loaded from a remote OpenWork server discovered through OpenWork Cloud.
+
+2. When the client temporarily loses its connection to Den or an OpenWork server, the remote workspace stays in place with its cached tasks and a clear Remote · Reconnecting status instead of disappearing.
+
+3. OpenWork treats a failed refresh as unknown state, never as deletion: desktop connection details remain authoritative for routing, the last successful server snapshot remains visible, and only an explicit removal or a successful live response can remove a workspace.
+
+4. When connectivity returns, OpenWork retries automatically, reconciles the live workspace list without duplicates or reordering, clears the warning, and restores normal task actions without requiring the user to add the remote workspace again.


### PR DESCRIPTION
## Remote workspace reliability series

This is the foundation of a focused reliability series. Review and merge in this order:

1. **#2685 — retain remote workspaces through disconnects** (this PR)
2. **#2686 — route Settings task history to each workspace's owning server**
3. **#2687 — route Auto context compaction to the selected workspace endpoint**
4. **#2688 — keep Settings connection stores and reloads on the workspace server**

#2686 has two straightforward overlap conflicts with this PR in the shared route reconciliation code and will be rebased after this foundation lands. #2688 can merge independently and closes the reload-ownership gap required before #2687 is marked ready.

## Proposal

This PR makes workspace visibility resilient to temporary disconnects between the OpenWork client, its local OpenWork server, remote workers, and OpenWork Cloud.

It extends the same principle already used for durable Den authentication: **an unavailable dependency is unknown state, not proof that data was deleted**.

## The issue

Session and Settings each merge two workspace sources:

1. the desktop workspace store, which owns local and desktop-managed remote connection details; and
2. the connected OpenWork server's live workspace list.

On a successful refresh, that merge is correct. On a failed refresh, both routes replaced the last rendered list with only the desktop list. A remote workspace known only through the server therefore disappeared from the sidebar, then reappeared after the next successful refresh.

That made a transport failure look like deletion and could also move the user's selection.

## Before and after

| Event | Before | This PR |
| --- | --- | --- |
| Server or network disconnect | Server-sourced remote rows disappear. | Last successful rows remain visible. |
| Remote workspace during recovery | No stable transitional state. | The main Session sidebar shows `Remote · Reconnecting…`. |
| Cached tasks | Workspace replacement discards the visible grouping. | Cached sessions remain associated with the retained row while the worker is rechecked. |
| Reconnection | A later refresh makes rows reappear. | Online, focus, visibility, settings changes, and a bounded timer retry automatically. |
| Explicit removal during outage | A stale fallback could resurrect the row. | Removal updates persistent stores and the retained in-memory snapshot immediately. |

## Reconciliation contract

```mermaid
flowchart LR
  D["Desktop workspace store"] -->|routing fields| C["Client reconciliation"]
  S["OpenWork server"] -->|successful snapshot| C
  L["Last successful client snapshot"] -->|temporary fallback| C
  C --> U["Stable workspace sidebar"]
  S -. "timeout / disconnect" .-> R["Retain + mark reconnecting"]
  R --> U
  R -->|online, focus, or 30-second retry| S
```

The ordering is deliberate:

1. explicit user removal wins immediately;
2. fresh desktop-owned routing fields win for desktop-managed connections;
3. a successful server response may reconcile confirmed additions and removals; and
4. a transport failure retains the previous successful snapshot and cannot infer deletion.

The full explainer is in [`docs/remote-workspace-reconciliation.md`](https://github.com/reachjalil/openwork/blob/codex/remote-workspace-resilience/docs/remote-workspace-reconciliation.md).

## What changed

- Adds one shared failure-reconciliation helper used by Session and Settings.
- Preserves existing sessions and selection when the server is unavailable.
- Adds a distinct `reconnecting` workspace connection state and Session-sidebar label.
- Rechecks retained remote workspaces directly so an unavailable local server does not automatically make a healthy remote worker unusable.
- Retries failed refreshes on network restoration, app focus, visibility changes, settings changes, and every 30 seconds while failure remains known.
- Keeps the existing in-flight guard intact so the timer does not multiply slow requests within one route.
- Removes explicitly forgotten workspaces from the retained snapshot before another refresh can run.
- Exposes connection state through the existing route inspector for deterministic support diagnostics.

## Best-practice and security notes

- No new browser or disk cache is introduced; worker tokens and paths are not copied to another persistence layer.
- Existing desktop storage remains the authority for desktop-managed connection details.
- Specific worker failures, such as a rejected token, are preserved instead of being overwritten by a generic reconnecting state.
- Successful live responses remain authoritative, so real server-side removals converge normally after reconnection.
- No Den API, OpenWork server, IPC, database, or wire-contract change is required.

## Validation

- `pnpm --filter @openwork/app exec bun test tests/remote-workspace-resilience.test.ts tests/den-auth-provider.test.ts tests/settings-route.test.ts` — **10 passed**
- `pnpm --filter @openwork/app test` — **178 passed across 39 files**
- `pnpm --filter @openwork/app typecheck` — **passed**
- `pnpm --filter @openwork/app build` — **passed**
- `pnpm fraimz --flow remote-workspace-resilience` — **internal deterministic flow passed: 4 chapters plus voice-over coverage**

The current Fraimz flow runs unit tests and source-level assertions with `requiresApp: false`; it does not launch a real remote worker or produce a live disconnect screenshot. A reviewer can reproduce the internal proof with the command above. Live remote-worker evidence remains a follow-up review gate before this draft is marked ready.

## Scope and limitations

This PR protects workspace state already known to the running client. A completely fresh browser launch cannot reconstruct a server-only workspace while every server is unavailable. Desktop-managed remote workspaces remain recoverable on fresh launch because their existing desktop store is loaded before server reconciliation.

The reconnecting label is currently rendered in the main Session sidebar. Settings retains the workspace and cached tasks but does not yet render that same status label.
