### PR TITLE
fix(app): scope auto-compaction to the selected workspace

### DIFF
--- a/apps/app/src/react-app/domains/settings/auto-compact-context.ts
+++ b/apps/app/src/react-app/domains/settings/auto-compact-context.ts
@@ -1,0 +1,37 @@
+export type AutoCompactContextConfig = {
+  opencode?: {
+    compaction?: unknown;
+  };
+};
+
+export type AutoCompactContextClient = {
+  getConfig: (workspaceId: string) => Promise<AutoCompactContextConfig>;
+  patchConfig: (
+    workspaceId: string,
+    patch: { opencode: { compaction: { auto: boolean } } },
+  ) => Promise<unknown>;
+};
+
+export type AutoCompactContextTarget = {
+  client: AutoCompactContextClient;
+  workspaceId: string;
+};
+
+export function readAutoCompactContextValue(config: AutoCompactContextConfig): boolean {
+  const compaction = config.opencode?.compaction;
+  if (!compaction || typeof compaction !== "object") return true;
+  return Reflect.get(compaction, "auto") !== false;
+}
+
+export async function loadAutoCompactContext(target: AutoCompactContextTarget): Promise<boolean> {
+  return readAutoCompactContextValue(await target.client.getConfig(target.workspaceId));
+}
+
+export async function saveAutoCompactContext(
+  target: AutoCompactContextTarget,
+  auto: boolean,
+): Promise<void> {
+  await target.client.patchConfig(target.workspaceId, {
+    opencode: { compaction: { auto } },
+  });
+}

--- a/apps/app/src/react-app/domains/settings/pages/preferences-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/preferences-view.tsx
@@ -34,6 +34,7 @@ export type PreferencesViewProps = {
   onToggleShowThinking: () => void;
   autoCompactContext: boolean;
   autoCompactContextBusy: boolean;
+  autoCompactContextLoaded: boolean;
   onToggleAutoCompactContext: () => void;
   analyticsEnabled: boolean;
   onToggleAnalytics: () => void;
@@ -93,7 +94,7 @@ export function PreferencesView(props: PreferencesViewProps) {
               <Switch
                 aria-label={t("settings.auto_compact")}
                 checked={props.autoCompactContext}
-                disabled={props.busy || props.autoCompactContextBusy}
+                disabled={props.busy || props.autoCompactContextBusy || !props.autoCompactContextLoaded}
                 onCheckedChange={props.onToggleAutoCompactContext}
               />
             </LayoutSectionItemHeaderActions>

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -15,7 +15,10 @@ import {
   type OpenworkServerClient,
   type OpenworkWorkspaceInfo,
 } from "@/app/lib/openwork-server";
-import { resolveWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
+import {
+  resolveWorkspaceEndpoint,
+  type ResolvedWorkspaceEndpoint,
+} from "@/app/lib/workspace-endpoint";
 import { buildOpenworkEnvRuntimeKey } from "@/app/lib/openwork-env-runtime";
 import {
   getInitialThemeMode,
@@ -65,6 +68,10 @@ import "@/react-app/domains/settings/browser-extension-config";
 import "@/react-app/domains/settings/openwork-voice-config";
 import "@/react-app/domains/settings/google-workspace-config";
 import { useSettingsExtensionController } from "@/react-app/domains/settings/settings-extension-controller";
+import {
+  loadAutoCompactContext,
+  saveAutoCompactContext,
+} from "@/react-app/domains/settings/auto-compact-context";
 import { buildExtensionItems } from "@/react-app/domains/settings/extension-items";
 import { isOpenWorkExtensionEnabled, OPENWORK_EXTENSION_STATE_CHANGED, setOpenWorkExtensionEnabled } from "@/react-app/domains/settings/extension-state";
 import { PreferencesView } from "@/react-app/domains/settings/pages/preferences-view";
@@ -424,7 +431,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [exportWorkspaceBusy, setExportWorkspaceBusy] = useState(false);
   const [autoCompactContext, setAutoCompactContext] = useState(true);
   const [autoCompactContextBusy, setAutoCompactContextBusy] = useState(false);
-  const [autoCompactContextLoaded, setAutoCompactContextLoaded] = useState(false);
+  const [autoCompactContextLoadedEndpoint, setAutoCompactContextLoadedEndpoint] =
+    useState<ResolvedWorkspaceEndpoint | null>(null);
+  const autoCompactContextEndpointRef = useRef<ResolvedWorkspaceEndpoint | null>(null);
   const [localProviderBusy, setLocalProviderBusy] = useState(false);
   const [localProviderStatus, setLocalProviderStatus] = useState<string | null>(null);
   const [localProviderError, setLocalProviderError] = useState<string | null>(null);
@@ -801,6 +810,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     () => resolveWorkspaceEndpoint(selectedWorkspace, { baseUrl, token }),
     [baseUrl, selectedWorkspace, token],
   );
+  autoCompactContextEndpointRef.current = selectedWorkspaceEndpoint;
+  const autoCompactContextLoaded =
+    selectedWorkspaceEndpoint !== null &&
+    autoCompactContextLoadedEndpoint === selectedWorkspaceEndpoint;
   const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
   const runtimeWorkspaceId = selectedWorkspaceEndpoint?.workspaceId ?? selectedWorkspace?.id ?? null;
   routeStateRef.current.runtimeWorkspaceId = runtimeWorkspaceId;
@@ -1409,48 +1422,44 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
 
   // Load auto-compaction state from OpenCode config on workspace change.
   useEffect(() => {
-    if (!openworkClient || !selectedWorkspaceId) return;
-    const workspaceId = routeStateRef.current.runtimeWorkspaceId?.trim() || selectedWorkspaceId;
+    const endpoint = selectedWorkspaceEndpoint;
+    if (!endpoint) return;
     let cancelled = false;
     (async () => {
       try {
-        const config = await openworkClient.getConfig(workspaceId);
+        const auto = await loadAutoCompactContext(endpoint);
         if (cancelled) return;
-        const compaction = config.opencode?.compaction;
-        const auto = compaction && typeof compaction === "object" && "auto" in compaction
-          ? (compaction as { auto?: boolean }).auto
-          : undefined;
-        setAutoCompactContext(auto !== false);
-        setAutoCompactContextLoaded(true);
+        setAutoCompactContext(auto);
+        setAutoCompactContextLoadedEndpoint(endpoint);
       } catch {
-        if (!cancelled) setAutoCompactContextLoaded(true);
+        // Keep the control disabled until this exact endpoint can provide an
+        // authoritative value. Never fall back to another workspace/server.
       }
     })();
     return () => { cancelled = true; };
-  }, [openworkClient, selectedWorkspaceId]);
+  }, [selectedWorkspaceEndpoint]);
 
   const toggleAutoCompactContext = useCallback(async () => {
-    if (autoCompactContextBusy) return;
-    const workspaceId = routeStateRef.current.runtimeWorkspaceId?.trim() || selectedWorkspaceId;
-    if (!openworkClient || !workspaceId) return;
+    const endpoint = selectedWorkspaceEndpoint;
+    if (autoCompactContextBusy || !autoCompactContextLoaded || !endpoint) return;
     const next = !autoCompactContext;
     setAutoCompactContext(next);
     setAutoCompactContextBusy(true);
     try {
-      await openworkClient.patchConfig(workspaceId, {
-        opencode: { compaction: { auto: next } },
-      });
+      await saveAutoCompactContext(endpoint, next);
       reloadCoordinator.markReloadRequired("config", {
         type: "config",
         name: "opencode.json",
         action: "updated",
       });
     } catch {
-      setAutoCompactContext(!next);
+      if (autoCompactContextEndpointRef.current === endpoint) {
+        setAutoCompactContext(!next);
+      }
     } finally {
       setAutoCompactContextBusy(false);
     }
-  }, [autoCompactContext, autoCompactContextBusy, openworkClient, reloadCoordinator, selectedWorkspaceId]);
+  }, [autoCompactContext, autoCompactContextBusy, autoCompactContextLoaded, reloadCoordinator, selectedWorkspaceEndpoint]);
 
   useEffect(() => {
     openworkServerStore.start();
@@ -2022,6 +2031,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             }}
             autoCompactContext={autoCompactContext}
             autoCompactContextBusy={autoCompactContextBusy}
+            autoCompactContextLoaded={autoCompactContextLoaded}
             onToggleAutoCompactContext={toggleAutoCompactContext}
             analyticsEnabled={local.prefs.analyticsEnabled}
             onToggleAnalytics={() => {

--- a/apps/app/tests/remote-auto-compaction.test.ts
+++ b/apps/app/tests/remote-auto-compaction.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  loadAutoCompactContext,
+  readAutoCompactContextValue,
+  saveAutoCompactContext,
+  type AutoCompactContextClient,
+} from "../src/react-app/domains/settings/auto-compact-context";
+
+describe("remote auto-compaction settings", () => {
+  test("defaults to enabled only after an authoritative config is loaded", () => {
+    expect(readAutoCompactContextValue({})).toBe(true);
+    expect(readAutoCompactContextValue({ opencode: { compaction: {} } })).toBe(true);
+    expect(
+      readAutoCompactContextValue({ opencode: { compaction: { auto: false } } }),
+    ).toBe(false);
+  });
+
+  test("loads from the selected endpoint with its server-side workspace ID", async () => {
+    const requestedWorkspaceIds: string[] = [];
+    const client: AutoCompactContextClient = {
+      getConfig: async (workspaceId) => {
+        requestedWorkspaceIds.push(workspaceId);
+        return { opencode: { compaction: { auto: false } } };
+      },
+      patchConfig: async () => undefined,
+    };
+
+    const value = await loadAutoCompactContext({
+      client,
+      workspaceId: "workspace_remote",
+    });
+
+    expect(value).toBe(false);
+    expect(requestedWorkspaceIds).toEqual(["workspace_remote"]);
+  });
+
+  test("writes only through the selected endpoint target", async () => {
+    const writes: Array<{ workspaceId: string; auto: boolean }> = [];
+    const client: AutoCompactContextClient = {
+      getConfig: async () => ({}),
+      patchConfig: async (workspaceId, patch) => {
+        writes.push({ workspaceId, auto: patch.opencode.compaction.auto });
+      },
+    };
+
+    await saveAutoCompactContext(
+      { client, workspaceId: "workspace_remote" },
+      false,
+    );
+
+    expect(writes).toEqual([{ workspaceId: "workspace_remote", auto: false }]);
+  });
+});

--- a/docs/remote-auto-compaction.md
+++ b/docs/remote-auto-compaction.md
@@ -1,0 +1,55 @@
+# Remote auto-compaction preference ownership
+
+Auto context compaction is workspace configuration. The server that owns the
+selected workspace is therefore the only authoritative place to read or write
+`opencode.compaction.auto`.
+
+Before this change, Preferences resolved the selected workspace's runtime ID
+but always called the local OpenWork client. For a remote workspace, that mixed
+a remote ID with the local server. The result could be a false default in the
+UI, a failed update, or a change to unrelated local state. The switch was also
+enabled after a failed load, so an unverified default looked authoritative.
+
+## Endpoint-owned configuration
+
+```mermaid
+flowchart LR
+  W["Selected workspace"] --> R["resolveWorkspaceEndpoint"]
+  R -->|local| L["Local OpenWork server + local workspace ID"]
+  R -->|remote| X["Remote worker + server-side workspace ID"]
+  L --> C["Authoritative config"]
+  X --> C
+  C --> P["Preferences switch becomes enabled"]
+```
+
+The load and save helpers accept one endpoint target containing both the
+client and its workspace ID. Keeping those values together makes it difficult
+to accidentally send a remote ID through the local client. Local workspaces
+still resolve to the local endpoint, so their behavior is unchanged.
+
+## Loading, switching, and failure behavior
+
+The switch is enabled only when configuration has loaded for the exact
+endpoint object currently selected. When the user changes workspaces, the new
+endpoint has a different identity and the control immediately returns to its
+disabled loading state.
+
+Each load also has a cancellation guard. If an earlier workspace responds
+after the user selects another one, the late response is ignored instead of
+overwriting the current preference.
+
+If the owning server cannot provide configuration, the switch remains
+disabled. OpenWork does not present the default as confirmed and does not fall
+back to the local server. A reconnect or endpoint refresh creates a new target
+and reloads the authoritative value.
+
+## Security and compatibility
+
+- Remote requests use only the client and credential already associated with
+  the selected remote endpoint.
+- Local requests continue to use the local OpenWork client and local token.
+- No credential is copied, persisted, logged, or sent to a fallback endpoint.
+- No Den, server, IPC, database, generated client, or wire contract changes
+  are required.
+- The implementation is limited to app-side routing, loading state, and
+  focused tests for the preference contract.

--- a/evals/flows/remote-auto-compaction.flow.mjs
+++ b/evals/flows/remote-auto-compaction.flow.mjs
@@ -1,0 +1,103 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "remote-auto-compaction";
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const APP = path.join(ROOT, "apps", "app");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function run(command, args, cwd = ROOT) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return {
+    status: result.status,
+    output: `${result.stdout || ""}${result.stderr || ""}`.trim(),
+  };
+}
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${actual})` : ""}`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Auto-compaction follows the selected workspace's owning endpoint",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "The preference contract is characterized",
+      run: async (ctx) => {
+        await ctx.prove("A remote workspace starts from its authoritative saved value", {
+          voiceover: vo[0],
+          assert: async () => {
+            const result = run("bun", ["test", "tests/remote-auto-compaction.test.ts"], APP);
+            witness(ctx, result.status === 0, "The focused auto-compaction suite passes", result.output.split("\n").slice(-12).join("\n"));
+            witness(ctx, result.output.includes("defaults to enabled only after an authoritative config is loaded"), "The default parsing contract is exercised");
+            witness(ctx, result.output.includes("loads from the selected endpoint"), "Endpoint-owned loading is exercised");
+            ctx.output("remote-auto-compaction-tests", result.output);
+          },
+        });
+      },
+    },
+    {
+      name: "Reads and writes stay on one endpoint target",
+      run: async (ctx) => {
+        await ctx.prove("The selected endpoint owns both sides of the preference update", {
+          voiceover: vo[1],
+          assert: async () => {
+            const settings = readFileSync(path.join(APP, "src/react-app/shell/settings-route.tsx"), "utf8");
+            const helper = readFileSync(path.join(APP, "src/react-app/domains/settings/auto-compact-context.ts"), "utf8");
+            witness(ctx, settings.includes("loadAutoCompactContext(endpoint)"), "Settings loads through the resolved endpoint");
+            witness(ctx, settings.includes("saveAutoCompactContext(endpoint, next)"), "Settings saves through that same endpoint");
+            witness(ctx, helper.includes("target.client.patchConfig(target.workspaceId"), "The client and server-side workspace ID remain paired");
+          },
+        });
+      },
+    },
+    {
+      name: "Workspace changes cannot expose stale state",
+      run: async (ctx) => {
+        await ctx.prove("Only the current endpoint can enable or update the switch", {
+          voiceover: vo[2],
+          assert: async () => {
+            const settings = readFileSync(path.join(APP, "src/react-app/shell/settings-route.tsx"), "utf8");
+            const preferences = readFileSync(path.join(APP, "src/react-app/domains/settings/pages/preferences-view.tsx"), "utf8");
+            witness(ctx, settings.includes("autoCompactContextLoadedEndpoint === selectedWorkspaceEndpoint"), "Loaded state is tied to exact endpoint identity");
+            witness(ctx, settings.includes("if (cancelled) return"), "Late responses are ignored after selection changes");
+            witness(ctx, settings.includes("autoCompactContextEndpointRef.current === endpoint"), "A late failed save cannot revert another workspace's value");
+            witness(ctx, preferences.includes("!props.autoCompactContextLoaded"), "The switch stays disabled until the current endpoint is loaded");
+          },
+        });
+      },
+    },
+    {
+      name: "Failure stays scoped to the owning server",
+      run: async (ctx) => {
+        await ctx.prove("An unavailable worker cannot produce an unverified write or local fallback", {
+          voiceover: vo[3],
+          assert: async () => {
+            const settings = readFileSync(path.join(APP, "src/react-app/shell/settings-route.tsx"), "utf8");
+            const guide = readFileSync(path.join(ROOT, "docs/remote-auto-compaction.md"), "utf8");
+            const normalizedGuide = guide.replace(/\s+/g, " ");
+            witness(ctx, settings.includes("!autoCompactContextLoaded || !endpoint"), "Writes require a loaded current endpoint");
+            witness(ctx, normalizedGuide.includes("fall back to the local server"), "Fail-closed routing is documented");
+            witness(ctx, normalizedGuide.includes("No credential is copied, persisted, logged, or sent to a fallback endpoint"), "The credential boundary is documented");
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/remote-auto-compaction.md
+++ b/evals/voiceovers/remote-auto-compaction.md
@@ -1,0 +1,9 @@
+# remote-auto-compaction — workspace preferences read and write only their owning server
+
+1. A user opens Preferences for a remote workspace; Auto context compaction stays disabled while OpenWork loads that worker’s actual configuration, then shows the saved remote value.
+
+2. Toggling Auto context compaction writes `opencode.compaction.auto` through the selected workspace endpoint and server-side workspace ID, without reading from or mutating the local workspace configuration.
+
+3. Switching between local and remote workspaces reloads the preference from each owning server, and a late response from the previous workspace cannot overwrite the newly selected workspace’s state.
+
+4. If the remote worker is unavailable, the switch remains disabled instead of presenting an unverified default or attempting a local fallback; reconnecting and refreshing restores the authoritative remote value.


### PR DESCRIPTION
## Remote workspace reliability series

This is the third PR in a focused reliability series:

1. **#2685 — retain remote workspaces through disconnects**
2. **#2686 — route Settings task history to each workspace's owning server**
3. **#2687 — route Auto context compaction to the selected workspace endpoint** (this PR)
4. **#2688 — keep Settings connection stores and reloads on the workspace server**

Review this after #2685, #2686, and #2688. The config read/write is independently scoped, while #2688 supplies the endpoint-owned reload coordinator required before this draft should be marked ready.

## What was wrong

Auto context compaction is workspace-owned configuration, but Preferences always read and wrote it through the local OpenWork client. For a remote workspace, the route combined a remote server-side workspace ID with the local server. That could show an unverified default, fail the update, or target unrelated local state.

The existing `autoCompactContextLoaded` flag also became `true` after a failed read and was not used to disable the switch. An unavailable worker therefore looked like a confirmed enabled preference.

## What changed

- resolve one endpoint target for the selected workspace and use its paired client plus server-side workspace ID for both config reads and writes
- keep local workspaces on the existing local endpoint
- enable the switch only after configuration loads for the exact endpoint currently selected
- ignore late reads after a workspace change, and prevent a late failed save from reverting the newly selected workspace's value
- leave the switch disabled when the initial authoritative load fails; there is no local fallback or speculative write
- isolate config parsing and transport behind focused helpers with characterization tests
- document the endpoint ownership, reconnect, credential, and compatibility boundaries

## Why this shape

The client and workspace ID are passed as one target so they cannot drift independently. Loaded state is tied to endpoint identity instead of a global boolean, which makes selection changes fail closed. Async completion guards prevent stale reads and failed saves from crossing workspace boundaries.

No Den, server, IPC, database, generated client, or wire contract changes are introduced. Remote credentials remain attached only to their existing remote client and are not copied, logged, cached, or sent to a fallback endpoint.

## Validation

- `pnpm --filter @openwork/app test` — 177 passed, 0 failed
- focused route and remote auto-compaction tests — 4 passed, 0 failed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/app build` — passed
- `pnpm fraimz --flow remote-auto-compaction` — internal deterministic flow passed: four behavior steps plus voice-over coverage

The current Fraimz flow uses focused tests and source assertions with `requiresApp: false`; it does not launch a real remote worker or capture the Preferences switch. Live remote-worker evidence remains a follow-up review gate before this draft is marked ready.

## Review guide

Start with `docs/remote-auto-compaction.md` for the read/write ownership model, then review `auto-compact-context.ts` and the Preferences effect/toggle in `settings-route.tsx`.

## Known follow-up before ready

#2688 captures the originating endpoint for pending reloads and prevents remote failures from using the local desktop restart fallback. Rebase this PR after #2688 and route its reload request through that captured-target helper before promoting it from draft status.
