### PR TITLE
fix(app): keep Settings connections on the workspace server

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -34,21 +34,17 @@ import {
 } from "../../../../app/utils/providers";
 import { getReactQueryClient } from "../../../infra/query-client";
 import { ensureProviderListQuery } from "../../../infra/provider-list-query";
-import type { OpenworkServerStoreSnapshot } from "../openwork-server-store";
+import {
+  canFallbackToDesktopEngineRestart,
+  type WorkspaceOpenworkServer,
+} from "../workspace-openwork-server";
 
 /**
- * The slice of the openwork-server store this store actually consumes.
- * The settings route passes the full store; the session route passes a
- * lightweight endpoint-backed adapter (previously forced through `as never`).
+ * The workspace-owned OpenWork connection consumed by provider actions.
+ * Both Settings and Session pass endpoint-backed adapters so a remote
+ * workspace can never inherit the local host client's authority.
  */
-export type ProviderAuthOpenworkServer = {
-  getSnapshot: () => Pick<
-    OpenworkServerStoreSnapshot,
-    "openworkServerStatus" | "openworkServerClient"
-  > & {
-    openworkServerCapabilities: { config?: { read?: boolean; write?: boolean } } | null;
-  };
-};
+export type ProviderAuthOpenworkServer = WorkspaceOpenworkServer;
 import {
   denSessionUpdatedEvent,
   type DenSessionUpdatedDetail,
@@ -1163,7 +1159,11 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
             } catch (error) {
               const unreachable =
                 error instanceof OpenworkServerError && error.code === "opencode_engine_unreachable";
-              if (!unreachable || !isDesktopRuntime()) {
+              if (!canFallbackToDesktopEngineRestart({
+                engineUnreachable: unreachable,
+                desktopRuntime: isDesktopRuntime(),
+                remoteWorkspace: openworkSnapshot.openworkServerIsRemote,
+              })) {
                 throw error;
               }
               await engineRestart({});

--- a/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
@@ -11,6 +11,7 @@ import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-pr
 import { useReloadCoordinator } from "@/react-app/shell/reload-coordinator";
 import { type RouteWorkspace, workspaceLabel } from "@/react-app/shell/route-workspaces";
 import { createProviderAuthStore, useProviderAuthStoreSnapshot } from "./store";
+import { workspaceOpenworkServerSnapshot } from "../workspace-openwork-server";
 
 const emptyWorkspaceDisplay: WorkspaceDisplay = {
   id: "",
@@ -101,15 +102,9 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
         selectedWorkspaceRoot: () => stateRef.current.selectedWorkspaceRoot,
         runtimeWorkspaceId: () => stateRef.current.selectedWorkspaceEndpoint?.workspaceId ?? null,
         openworkServer: {
-          getSnapshot: () => ({
-            openworkServerStatus: stateRef.current.selectedWorkspaceEndpoint ? "connected" : "disconnected",
-            openworkServerClient: stateRef.current.selectedWorkspaceEndpoint?.client ?? null,
-            openworkServerCapabilities: stateRef.current.selectedWorkspaceEndpoint
-              ? {
-                  config: { read: true, write: true },
-                }
-              : null,
-          }),
+          getSnapshot: () => workspaceOpenworkServerSnapshot(
+            stateRef.current.selectedWorkspaceEndpoint,
+          ),
         },
         setProviders,
         setProviderDefaults,

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -38,8 +38,8 @@ import type {
 } from "../../../app/types";
 import { isDesktopRuntime, normalizeDirectoryPath, safeStringify } from "../../../app/utils";
 
-import type { OpenworkServerStore } from "./openwork-server-store";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
+import type { WorkspaceOpenworkServer } from "./workspace-openwork-server";
 import {
   CLOUD_MCP_SERVER_NAME,
   clearCloudMcpUnhealthyRemintAttempt,
@@ -84,7 +84,7 @@ export function createConnectionsStore(options: {
   selectedWorkspaceId: () => string;
   selectedWorkspaceRoot: () => string;
   workspaceType: () => "local" | "remote";
-  openworkServer: OpenworkServerStore;
+  openworkServer: WorkspaceOpenworkServer;
   runtimeWorkspaceId: () => string | null;
   ensureRuntimeWorkspaceId?: () => Promise<string | null | undefined>;
   setProjectDir?: (value: string) => void;

--- a/apps/app/src/react-app/domains/connections/workspace-openwork-server.ts
+++ b/apps/app/src/react-app/domains/connections/workspace-openwork-server.ts
@@ -1,0 +1,77 @@
+import type {
+  OpenworkServerCapabilities,
+  OpenworkServerClient,
+  OpenworkServerStatus,
+} from "@/app/lib/openwork-server";
+import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
+
+export const WORKSPACE_OPENWORK_CAPABILITIES: OpenworkServerCapabilities = {
+  skills: { read: true, write: true, source: "openwork" },
+  plugins: { read: true, write: true },
+  mcp: { read: true, write: true },
+  commands: { read: true, write: true },
+  config: { read: true, write: true },
+};
+
+export type WorkspaceOpenworkServerSnapshot = {
+  openworkServerClient: OpenworkServerClient | null;
+  openworkServerStatus: OpenworkServerStatus;
+  openworkServerCapabilities: OpenworkServerCapabilities | null;
+  openworkServerIsRemote: boolean;
+  openworkServerBaseUrl: string;
+  openworkServerAuth: { token: string | null };
+};
+
+export type WorkspaceOpenworkServer = {
+  getSnapshot: () => WorkspaceOpenworkServerSnapshot;
+};
+
+export type WorkspaceReloadTarget = {
+  client: OpenworkServerClient;
+  workspaceId: string;
+  isRemote: boolean;
+};
+
+export function workspaceOpenworkServerSnapshot(
+  endpoint: ResolvedWorkspaceEndpoint | null,
+): WorkspaceOpenworkServerSnapshot {
+  return {
+    openworkServerClient: endpoint?.client ?? null,
+    openworkServerStatus: endpoint ? "connected" : "disconnected",
+    openworkServerCapabilities: endpoint ? WORKSPACE_OPENWORK_CAPABILITIES : null,
+    openworkServerIsRemote: endpoint?.isRemote === true,
+    openworkServerBaseUrl: endpoint?.baseUrl ?? "",
+    openworkServerAuth: { token: endpoint?.token || null },
+  };
+}
+
+export function canFallbackToDesktopEngineRestart(input: {
+  engineUnreachable: boolean;
+  desktopRuntime: boolean;
+  remoteWorkspace: boolean;
+}): boolean {
+  return (
+    input.engineUnreachable &&
+    input.desktopRuntime &&
+    !input.remoteWorkspace
+  );
+}
+
+export function captureWorkspaceReloadTarget(
+  snapshot: WorkspaceOpenworkServerSnapshot,
+  workspaceId: string | null | undefined,
+): WorkspaceReloadTarget | null {
+  const resolvedWorkspaceId = workspaceId?.trim() ?? "";
+  if (
+    snapshot.openworkServerStatus !== "connected" ||
+    !snapshot.openworkServerClient ||
+    !resolvedWorkspaceId
+  ) {
+    return null;
+  }
+  return {
+    client: snapshot.openworkServerClient,
+    workspaceId: resolvedWorkspaceId,
+    isRemote: snapshot.openworkServerIsRemote,
+  };
+}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -13,6 +13,7 @@ import {
   OpenworkServerError,
   type OpenworkServerCapabilities,
   type OpenworkServerClient,
+  type OpenworkServerStatus,
   type OpenworkWorkspaceInfo,
 } from "@/app/lib/openwork-server";
 import { resolveWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
@@ -25,6 +26,8 @@ import {
 import type {
   Client,
   ProviderListItem,
+  ReloadReason,
+  ReloadTrigger,
   SettingsTab,
   WorkspaceConnectionState,
   WorkspaceDisplay,
@@ -51,6 +54,14 @@ import {
   workspaceLabel,
 } from "@/react-app/shell/route-workspaces";
 import { createConnectionsStore, useConnectionsStoreSnapshot } from "@/react-app/domains/connections/store";
+import {
+  canFallbackToDesktopEngineRestart,
+  captureWorkspaceReloadTarget,
+  WORKSPACE_OPENWORK_CAPABILITIES,
+  workspaceOpenworkServerSnapshot,
+  type WorkspaceOpenworkServer,
+  type WorkspaceReloadTarget,
+} from "@/react-app/domains/connections/workspace-openwork-server";
 import { useOrgMcpConnections } from "@/react-app/domains/connections/use-org-mcp-connections";
 import { createOpenworkServerStore, useOpenworkServerStoreSnapshot } from "@/react-app/domains/connections/openwork-server-store";
 import { createProviderAuthStore, useProviderAuthStoreSnapshot } from "@/react-app/domains/connections/provider-auth/store";
@@ -165,29 +176,28 @@ import {
 } from "@/react-app/domains/settings/openai-image-extension";
 import { OLLAMA_PROVIDER_CONFIG, type LocalProviderInstallInput } from "@/react-app/domains/settings/openai-image-extension";
 
-const ROUTE_OPENWORK_CAPABILITIES: OpenworkServerCapabilities = {
-  skills: { read: true, write: true, source: "openwork" },
-  plugins: { read: true, write: true },
-  mcp: { read: true, write: true },
-  commands: { read: true, write: true },
-  config: { read: true, write: true },
-};
-
 async function reloadEngineOrRestartDesktop(
   client: Pick<OpenworkServerClient, "reloadEngine">,
   workspaceId: string,
-  afterRestart?: () => Promise<void>,
+  options?: {
+    afterRestart?: () => Promise<void>;
+    allowDesktopRestart?: boolean;
+  },
 ): Promise<void> {
   try {
     await client.reloadEngine(workspaceId);
   } catch (error) {
     const unreachable =
       error instanceof OpenworkServerError && error.code === "opencode_engine_unreachable";
-    if (!unreachable || !isDesktopRuntime()) {
+    if (!canFallbackToDesktopEngineRestart({
+      engineUnreachable: unreachable,
+      desktopRuntime: isDesktopRuntime(),
+      remoteWorkspace: options?.allowDesktopRestart === false,
+    })) {
       throw error;
     }
     await engineRestart({});
-    await afterRestart?.();
+    await options?.afterRestart?.();
   }
 }
 
@@ -459,8 +469,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     selectedWorkspaceType: "local" as "local" | "remote",
     runtimeWorkspaceId: null as string | null,
     openworkServerClient: null as OpenworkServerClient | null,
-    openworkServerStatus: "disconnected" as "connected" | "disconnected",
+    openworkServerStatus: "disconnected" as OpenworkServerStatus,
     openworkServerCapabilities: null as OpenworkServerCapabilities | null,
+    openworkServerIsRemote: false,
+    openworkServerBaseUrl: "",
+    openworkServerToken: "",
     selectedWorkspaceDisplay: emptyWorkspaceDisplay as WorkspaceDisplay,
     providerItems: [] as ProviderListItem[],
     providerDefaults: {} as Record<string, string>,
@@ -468,6 +481,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     disabledProviders: [] as string[],
     developerMode: false,
   });
+  const pendingWorkspaceReloadTargetRef = useRef<WorkspaceReloadTarget | null>(null);
 
   const selectedWorkspace = useMemo(
     () => workspaces.find((workspace) => workspace.id === selectedWorkspaceId) ?? (selectedWorkspaceId ? null : workspaces[0] ?? null),
@@ -512,7 +526,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     runtimeWorkspaceId: selectedWorkspace?.id ?? null,
     openworkServerClient: openworkClient,
     openworkServerStatus: openworkClient ? "connected" : "disconnected",
-    openworkServerCapabilities: openworkClient ? ROUTE_OPENWORK_CAPABILITIES : null,
+    openworkServerCapabilities: openworkClient ? WORKSPACE_OPENWORK_CAPABILITIES : null,
+    openworkServerIsRemote: false,
+    openworkServerBaseUrl: baseUrl,
+    openworkServerToken: token,
     selectedWorkspaceDisplay,
     providerItems: providers,
     providerDefaults,
@@ -520,6 +537,35 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     disabledProviders,
     developerMode,
   };
+
+  const workspaceOpenworkServer = useMemo<WorkspaceOpenworkServer>(
+    () => ({
+      getSnapshot: () => ({
+        openworkServerClient: routeStateRef.current.openworkServerClient,
+        openworkServerStatus: routeStateRef.current.openworkServerStatus,
+        openworkServerCapabilities: routeStateRef.current.openworkServerCapabilities,
+        openworkServerIsRemote: routeStateRef.current.openworkServerIsRemote,
+        openworkServerBaseUrl: routeStateRef.current.openworkServerBaseUrl,
+        openworkServerAuth: {
+          token: routeStateRef.current.openworkServerToken || null,
+        },
+      }),
+    }),
+    [],
+  );
+  const markWorkspaceReloadRequired = useCallback(
+    (reason: ReloadReason, trigger?: ReloadTrigger) => {
+      const target = captureWorkspaceReloadTarget(
+        workspaceOpenworkServer.getSnapshot(),
+        routeStateRef.current.runtimeWorkspaceId,
+      );
+      if (target) {
+        pendingWorkspaceReloadTargetRef.current = target;
+      }
+      reloadCoordinator.markReloadRequired(reason, trigger);
+    },
+    [reloadCoordinator.markReloadRequired, workspaceOpenworkServer],
+  );
 
   const activeReloadBlockingSessions = useMemo(
     () =>
@@ -581,16 +627,16 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         selectedWorkspaceId: () => routeStateRef.current.selectedWorkspaceId,
         selectedWorkspaceRoot: () => routeStateRef.current.selectedWorkspaceRoot,
         workspaceType: () => routeStateRef.current.selectedWorkspaceType,
-        openworkServer: openworkServerStore,
+        openworkServer: workspaceOpenworkServer,
         runtimeWorkspaceId: () => routeStateRef.current.runtimeWorkspaceId,
         ensureRuntimeWorkspaceId: async () =>
           routeStateRef.current.runtimeWorkspaceId?.trim() ||
           routeStateRef.current.selectedWorkspaceId.trim() ||
           null,
         developerMode: () => routeStateRef.current.developerMode,
-        markReloadRequired: reloadCoordinator.markReloadRequired,
+        markReloadRequired: markWorkspaceReloadRequired,
       }),
-    [openworkServerStore, reloadCoordinator.markReloadRequired],
+    [markWorkspaceReloadRequired, workspaceOpenworkServer],
   );
   refreshMcpServersRef.current = connectionsStore.refreshMcpServers;
   notifyMcpReloadingRef.current = connectionsStore.notifyMcpReloading;
@@ -611,21 +657,21 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           routeStateRef.current.runtimeWorkspaceId?.trim() ||
           routeStateRef.current.selectedWorkspaceId.trim() ||
           null,
-        openworkServer: openworkServerStore,
+        openworkServer: workspaceOpenworkServer,
         setProviders,
         setProviderDefaults,
         setProviderConnectedIds,
         setDisabledProviders,
         markOpencodeConfigReloadRequired: () => {
           setConfigActionStatus(t("settings.config_updated"));
-          reloadCoordinator.markReloadRequired("config", {
+          markWorkspaceReloadRequired("config", {
             type: "config",
             name: "opencode.json",
             action: "updated",
           });
         },
       }),
-    [checkDesktopRestriction, openworkServerStore, reloadCoordinator.markReloadRequired],
+    [checkDesktopRestriction, markWorkspaceReloadRequired, workspaceOpenworkServer],
   );
   const extensionsStore = useMemo(
     () =>
@@ -654,9 +700,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             toast.error(message);
           }
         },
-        markReloadRequired: reloadCoordinator.markReloadRequired,
+        markReloadRequired: markWorkspaceReloadRequired,
       }),
-    [openworkServerStore, reloadCoordinator.markReloadRequired],
+    [markWorkspaceReloadRequired, openworkServerStore],
   );
   const openworkServerSnapshot = useOpenworkServerStoreSnapshot(openworkServerStore);
   const connectionsSnapshot = useConnectionsStoreSnapshot(connectionsStore);
@@ -801,9 +847,16 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     () => resolveWorkspaceEndpoint(selectedWorkspace, { baseUrl, token }),
     [baseUrl, selectedWorkspace, token],
   );
+  const selectedWorkspaceServer = workspaceOpenworkServerSnapshot(selectedWorkspaceEndpoint);
   const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
   const runtimeWorkspaceId = selectedWorkspaceEndpoint?.workspaceId ?? selectedWorkspace?.id ?? null;
   routeStateRef.current.runtimeWorkspaceId = runtimeWorkspaceId;
+  routeStateRef.current.openworkServerClient = selectedWorkspaceServer.openworkServerClient;
+  routeStateRef.current.openworkServerStatus = selectedWorkspaceServer.openworkServerStatus;
+  routeStateRef.current.openworkServerCapabilities = selectedWorkspaceServer.openworkServerCapabilities;
+  routeStateRef.current.openworkServerIsRemote = selectedWorkspaceServer.openworkServerIsRemote;
+  routeStateRef.current.openworkServerBaseUrl = selectedWorkspaceServer.openworkServerBaseUrl;
+  routeStateRef.current.openworkServerToken = selectedWorkspaceServer.openworkServerAuth.token ?? "";
 
   const opencodeClient = useMemo(() => {
     if (!selectedWorkspaceEndpoint || !selectedWorkspaceEndpoint.token) return null;
@@ -1042,9 +1095,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
           modelVariant: null,
         }));
       }
-      reloadCoordinator.markReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
+      markWorkspaceReloadRequired("config", { type: "config", name: "opencode.json", action: "updated" });
       try {
-        await reloadEngineOrRestartDesktop(client, workspaceId);
+        await reloadEngineOrRestartDesktop(client, workspaceId, {
+          allowDesktopRestart: selectedWorkspaceEndpoint?.isRemote !== true,
+        });
       } catch {
         // The reload toast still lets the user retry if the immediate reload fails.
       }
@@ -1060,7 +1115,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     } finally {
       setLocalProviderBusy(false);
     }
-  }, [local, openworkClient, reloadCoordinator, runtimeWorkspaceId, selectedWorkspaceEndpoint]);
+  }, [local, markWorkspaceReloadRequired, openworkClient, runtimeWorkspaceId, selectedWorkspaceEndpoint]);
 
   useEffect(() => {
     local.setUi((previous) => ({ ...previous, view: "settings", tab: route.tab }));
@@ -1229,13 +1284,24 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   }, [markBootRouteReady, navigationSessionId, navigationWorkspaceId, routeWorkspaceId]);
 
   const reloadWorkspaceEngineFromUi = useCallback(async () => {
-    const workspaceId = routeStateRef.current.runtimeWorkspaceId?.trim() || selectedWorkspaceId.trim();
-    if (!openworkClient || !workspaceId) {
+    const selectedTarget = selectedWorkspaceEndpoint
+      ? {
+          client: selectedWorkspaceEndpoint.client,
+          workspaceId: selectedWorkspaceEndpoint.workspaceId,
+          isRemote: selectedWorkspaceEndpoint.isRemote,
+        }
+      : null;
+    const target = pendingWorkspaceReloadTargetRef.current ?? selectedTarget;
+    if (!target) {
       toast.error(t("app.error_connect_first"));
       return false;
     }
 
-    await reloadEngineOrRestartDesktop(openworkClient, workspaceId, refreshRouteState);
+    await reloadEngineOrRestartDesktop(target.client, target.workspaceId, {
+      afterRestart: refreshRouteState,
+      allowDesktopRestart: !target.isRemote,
+    });
+    pendingWorkspaceReloadTargetRef.current = null;
     await refreshProviderListQueries(getReactQueryClient());
 
     try {
@@ -1249,11 +1315,13 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     void pollMcpServersAfterReloadRef.current?.();
 
     return true;
-  }, [openworkClient, refreshRouteState, selectedWorkspaceId]);
+  }, [refreshRouteState, selectedWorkspaceEndpoint]);
 
   useEffect(() => {
     return reloadCoordinator.registerWorkspaceReloadControls({
-      canReloadWorkspaceEngine: () => Boolean(openworkClient && (selectedWorkspace?.id || selectedWorkspaceId)),
+      canReloadWorkspaceEngine: () => Boolean(
+        pendingWorkspaceReloadTargetRef.current ?? selectedWorkspaceEndpoint,
+      ),
       reloadWorkspaceEngine: reloadWorkspaceEngineFromUi,
       activeSessions: () => activeReloadBlockingSessions,
       stopSession: async (sessionId) => {
@@ -1264,11 +1332,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   }, [
     activeClient,
     activeReloadBlockingSessions,
-    openworkClient,
     reloadCoordinator,
     reloadWorkspaceEngineFromUi,
-    selectedWorkspace?.id,
-    selectedWorkspaceId,
+    selectedWorkspaceEndpoint,
   ]);
 
   useEffect(() => {
@@ -1440,7 +1506,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       await openworkClient.patchConfig(workspaceId, {
         opencode: { compaction: { auto: next } },
       });
-      reloadCoordinator.markReloadRequired("config", {
+      markWorkspaceReloadRequired("config", {
         type: "config",
         name: "opencode.json",
         action: "updated",
@@ -1450,7 +1516,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     } finally {
       setAutoCompactContextBusy(false);
     }
-  }, [autoCompactContext, autoCompactContextBusy, openworkClient, reloadCoordinator, selectedWorkspaceId]);
+  }, [autoCompactContext, autoCompactContextBusy, markWorkspaceReloadRequired, openworkClient, selectedWorkspaceId]);
 
   useEffect(() => {
     openworkServerStore.start();
@@ -1690,7 +1756,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     }
   }, [notFoundRouteError]);
   const routeOpenworkCapabilities: OpenworkServerCapabilities | null = openworkClient
-    ? ROUTE_OPENWORK_CAPABILITIES
+    ? WORKSPACE_OPENWORK_CAPABILITIES
     : null;
   const environmentRuntimeKey = buildOpenworkEnvRuntimeKey({
     baseUrl: openworkServerSnapshot.openworkServerBaseUrl || openworkServerSnapshot.openworkServerUrl,

--- a/apps/app/tests/settings-workspace-server-target.test.ts
+++ b/apps/app/tests/settings-workspace-server-target.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveWorkspaceEndpoint } from "../src/app/lib/workspace-endpoint";
+import {
+  canFallbackToDesktopEngineRestart,
+  captureWorkspaceReloadTarget,
+  workspaceOpenworkServerSnapshot,
+} from "../src/react-app/domains/connections/workspace-openwork-server";
+
+describe("Settings workspace server target", () => {
+  test("projects the selected remote endpoint into the connection stores", () => {
+    const endpoint = resolveWorkspaceEndpoint(
+      {
+        id: "rem_workspace_remote",
+        workspaceType: "remote",
+        baseUrl: "https://worker.example.com",
+        openworkHostUrl: null,
+        openworkToken: "remote-token",
+        openworkClientToken: null,
+        openworkHostToken: null,
+        openworkWorkspaceId: "workspace_remote",
+      },
+      { baseUrl: "http://127.0.0.1:8787", token: "local-token" },
+    );
+
+    expect(endpoint).not.toBeNull();
+    const snapshot = workspaceOpenworkServerSnapshot(endpoint);
+
+    expect(snapshot.openworkServerClient).toBe(endpoint?.client);
+    expect(snapshot.openworkServerStatus).toBe("connected");
+    expect(snapshot.openworkServerCapabilities?.config?.write).toBe(true);
+    expect(snapshot.openworkServerCapabilities?.mcp?.write).toBe(true);
+    expect(snapshot.openworkServerIsRemote).toBe(true);
+    expect(captureWorkspaceReloadTarget(snapshot, endpoint?.workspaceId)).toEqual({
+      client: endpoint?.client,
+      workspaceId: "workspace_remote",
+      isRemote: true,
+    });
+  });
+
+  test("fails closed when no selected workspace endpoint is available", () => {
+    expect(workspaceOpenworkServerSnapshot(null)).toEqual({
+      openworkServerClient: null,
+      openworkServerStatus: "disconnected",
+      openworkServerCapabilities: null,
+      openworkServerIsRemote: false,
+      openworkServerBaseUrl: "",
+      openworkServerAuth: { token: null },
+    });
+  });
+
+  test("never restarts the local desktop engine for a remote worker failure", () => {
+    expect(canFallbackToDesktopEngineRestart({
+      engineUnreachable: true,
+      desktopRuntime: true,
+      remoteWorkspace: true,
+    })).toBe(false);
+    expect(canFallbackToDesktopEngineRestart({
+      engineUnreachable: true,
+      desktopRuntime: true,
+      remoteWorkspace: false,
+    })).toBe(true);
+  });
+});

--- a/docs/remote-settings-connections.md
+++ b/docs/remote-settings-connections.md
@@ -1,0 +1,57 @@
+# Remote Settings connection ownership
+
+Settings has several long-lived stores for MCP connections, provider
+credentials, imported extensions, and engine reloads. Those stores operate on
+workspace-owned state, so they must all agree on the OpenWork server that owns
+the selected workspace.
+
+Before this change, Settings created a remote OpenCode client for the selected
+workspace but continued passing the local host's OpenWork server store to its
+MCP and provider stores. A remote workspace ID could therefore be paired with
+the local client. Reads could show local connections, writes could target the
+wrong config, and a remote provider reload could restart the local desktop
+engine.
+
+## One selected-workspace server projection
+
+```mermaid
+flowchart LR
+  W["Selected workspace"] --> E["resolveWorkspaceEndpoint"]
+  E --> P["Workspace OpenWork snapshot"]
+  P --> M["MCP connection store"]
+  P --> A["Provider auth store"]
+  P --> X["Extension config store"]
+  P --> R["Workspace reload target"]
+```
+
+`workspaceOpenworkServerSnapshot` projects the endpoint into the narrow server
+shape consumed by the stores: client, status, capabilities, base URL, token
+presence, and whether the owner is remote. The stores no longer receive the
+host-wide local server store for workspace-scoped work.
+
+The endpoint's client and server-side workspace ID are captured together when
+a config mutation requests a reload. A later workspace selection cannot move
+that pending reload to another server.
+
+## Reload and failure behavior
+
+- Local workspaces may use the existing desktop engine restart fallback when
+  their local managed OpenCode engine is unreachable.
+- Remote workspaces never invoke that local desktop fallback. A failed remote
+  server reload remains a remote failure and can fall back only to the remote
+  OpenCode client behavior already owned by the provider store.
+- Missing endpoints project as disconnected with no capabilities, client, or
+  token, so workspace configuration actions fail closed.
+- The host-wide local server store remains available for host diagnostics and
+  lifecycle actions; only workspace-owned stores use the endpoint projection.
+
+## Security and compatibility
+
+- A remote worker token stays in its existing endpoint-bound client and is not
+  substituted with the local client token.
+- No token value is logged or copied into a new persistence layer.
+- No Den, server, IPC, database, generated-client, or wire-contract change is
+  introduced.
+- The current proof is deterministic and internal (`requiresApp: false`). It
+  validates endpoint projection, reload ownership, and fallback policy but
+  does not claim a live remote-worker screenshot.

--- a/evals/flows/remote-settings-connections.flow.mjs
+++ b/evals/flows/remote-settings-connections.flow.mjs
@@ -1,0 +1,100 @@
+import { spawnSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "remote-settings-connections";
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..");
+const APP = path.join(ROOT, "apps", "app");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function run(command, args, cwd = ROOT) {
+  const result = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    maxBuffer: 32 * 1024 * 1024,
+  });
+  return {
+    status: result.status,
+    output: `${result.stdout || ""}${result.stderr || ""}`.trim(),
+  };
+}
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${actual})` : ""}`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Settings connections stay on the selected workspace's server",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "The workspace server projection is characterized",
+      run: async (ctx) => {
+        await ctx.prove("Remote connection lists begin from the owning worker", {
+          voiceover: vo[0],
+          assert: async () => {
+            const result = run("bun", ["test", "tests/settings-workspace-server-target.test.ts"], APP);
+            witness(ctx, result.status === 0, "The focused workspace-server suite passes", result.output.split("\n").slice(-12).join("\n"));
+            witness(ctx, result.output.includes("projects the selected remote endpoint"), "Remote endpoint projection is exercised");
+            witness(ctx, result.output.includes("fails closed"), "Missing endpoint behavior is exercised");
+            ctx.output("remote-settings-connections-tests", result.output);
+          },
+        });
+      },
+    },
+    {
+      name: "Workspace stores share one endpoint-backed server",
+      run: async (ctx) => {
+        await ctx.prove("MCP and provider mutations cannot inherit the local host client", {
+          voiceover: vo[1],
+          assert: async () => {
+            const settings = readFileSync(path.join(APP, "src/react-app/shell/settings-route.tsx"), "utf8");
+            witness(ctx, settings.includes("openworkServer: workspaceOpenworkServer"), "Workspace stores receive the endpoint-backed adapter");
+            witness(ctx, settings.includes("routeStateRef.current.openworkServerClient = selectedWorkspaceServer.openworkServerClient"), "The adapter follows the selected endpoint");
+            witness(ctx, settings.includes("markReloadRequired: markWorkspaceReloadRequired"), "Connection mutations capture workspace reload ownership");
+          },
+        });
+      },
+    },
+    {
+      name: "Reload ownership survives workspace changes",
+      run: async (ctx) => {
+        await ctx.prove("Provider reloads remain attached to the worker that was changed", {
+          voiceover: vo[2],
+          assert: async () => {
+            const settings = readFileSync(path.join(APP, "src/react-app/shell/settings-route.tsx"), "utf8");
+            const target = readFileSync(path.join(APP, "src/react-app/domains/connections/workspace-openwork-server.ts"), "utf8");
+            witness(ctx, settings.includes("pendingWorkspaceReloadTargetRef.current ?? selectedTarget"), "A captured pending target wins over later selection");
+            witness(ctx, target.includes("captureWorkspaceReloadTarget"), "Client and workspace ID are captured together");
+            witness(ctx, target.includes("!input.remoteWorkspace"), "Remote reloads cannot use the local desktop fallback");
+          },
+        });
+      },
+    },
+    {
+      name: "Disconnected workers fail within their own boundary",
+      run: async (ctx) => {
+        await ctx.prove("A remote outage cannot mutate local connection state", {
+          voiceover: vo[3],
+          assert: async () => {
+            const provider = readFileSync(path.join(APP, "src/react-app/domains/connections/provider-auth/store.ts"), "utf8");
+            const guide = readFileSync(path.join(ROOT, "docs/remote-settings-connections.md"), "utf8").replace(/\s+/g, " ");
+            witness(ctx, provider.includes("remoteWorkspace: openworkSnapshot.openworkServerIsRemote"), "Provider fallback checks endpoint ownership");
+            witness(ctx, guide.includes("fail closed"), "Disconnected behavior is documented");
+            witness(ctx, guide.includes("No token value is logged or copied"), "Credential handling is documented");
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/remote-settings-connections.md
+++ b/evals/voiceovers/remote-settings-connections.md
@@ -1,0 +1,9 @@
+# remote-settings-connections — Settings manages connections on the selected workspace's server
+
+1. A user selects a remote workspace and opens Connect or AI Providers in Settings; the lists come from that workspace's owning worker, so they match the connections available in the remote session.
+
+2. Adding, editing, or removing an MCP or provider configuration sends the request through the same remote endpoint and its server-side workspace ID; the local OpenWork server and local workspace configuration remain unchanged.
+
+3. When a provider change requires an engine reload, Settings asks the owning remote worker to reload that workspace, then refreshes providers from the remote engine instead of reloading the local engine or silently disposing the wrong client.
+
+4. If the remote worker disconnects, connection changes fail within that remote workspace and never fall back to local configuration; reconnecting and refreshing restores the authoritative remote MCP and provider state.


### PR DESCRIPTION
## Remote workspace reliability series

This is an independent follow-up to #2685, #2686, and #2687. It can merge directly against `dev`, but it also closes #2687's known reload-ownership gap and should land before #2687 is promoted from draft.

## What was wrong

Settings already resolved a remote OpenCode client for the selected workspace, but its MCP and provider stores still received the local host's OpenWork server store. That mixed two authorities: a remote server-side workspace ID and the local server client.

The mismatch could show local connection state inside a remote workspace, write connection/provider configuration to the wrong server, or service a remote reload through the local desktop engine. A delayed reload could also follow a later workspace selection instead of the workspace that originated the mutation.

## What changed

- introduces one narrow selected-workspace OpenWork server projection containing the endpoint client, capabilities, base URL, token presence, and remote/local ownership
- passes that endpoint-backed projection to Settings' MCP and provider stores
- updates the extension-store connection override from the same selected endpoint
- captures the endpoint client and server-side workspace ID together when a config mutation requests a reload
- makes the captured mutation target win over later workspace selection when the reload executes
- prevents remote engine failures from invoking the local desktop restart fallback
- shares the same projection with Session provider auth, replacing its parallel partial adapter
- fails closed when no selected workspace endpoint is available

## Ownership and ordering

```mermaid
flowchart LR
  W["Selected workspace"] --> E["resolveWorkspaceEndpoint"]
  E --> P["Workspace OpenWork snapshot"]
  P --> M["MCP store"]
  P --> A["Provider store"]
  P --> X["Extension store"]
  P --> R["Captured reload target"]
  R -->|local| L["Local server / allowed desktop fallback"]
  R -->|remote| Q["Owning worker / no local fallback"]
```

The client and workspace ID are captured at mutation time. Reload execution therefore cannot drift to whichever workspace happens to be selected later.

## Security and compatibility

- remote credentials remain attached to the existing endpoint client and are never substituted with the local token
- no token value is logged or copied into a new cache
- remote failures cannot restart the local desktop engine
- no Den, server, IPC, database, generated-client, or wire-contract changes are introduced

See `docs/remote-settings-connections.md` for the full design and failure behavior.

## Validation

- `pnpm --filter @openwork/app test` — **177 passed, 0 failed**
- focused Settings/MCP/provider suite — **16 passed, 0 failed**
- `pnpm --filter @openwork/app typecheck` — **passed**
- `pnpm --filter @openwork/app build` — **passed**
- `pnpm fraimz --flow remote-settings-connections` — **internal deterministic flow passed: 4 chapters plus voice-over coverage**

The Fraimz flow uses focused tests and source-level assertions with `requiresApp: false`; it does not claim a live remote-worker screenshot. A live worker/disconnect journey remains a review gate before this draft is marked ready.
