### PR TITLE
fix(app): discard stale Den cloud snapshots

### DIFF
--- a/apps/app/scripts/desktop-cloud-sync.test.ts
+++ b/apps/app/scripts/desktop-cloud-sync.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import {
+  applyIdentityBoundSnapshot,
   derivePendingCloudPluginChanges,
+  isSameDesktopCloudSyncIdentity,
   readPendingCloudSyncChanges,
 } from "../src/app/cloud/desktop-cloud-sync";
+import type { DesktopCloudSyncIdentity } from "../src/app/cloud/desktop-cloud-sync";
 import type { OpenworkDesktopCloudSyncChange } from "../src/app/lib/openwork-server";
 
 function change(input: Partial<OpenworkDesktopCloudSyncChange> & Pick<OpenworkDesktopCloudSyncChange, "id" | "kind" | "resourceKind">): OpenworkDesktopCloudSyncChange {
@@ -27,6 +30,63 @@ const installedPlugins = {
     files: [],
   },
 };
+
+const organizationA: DesktopCloudSyncIdentity = {
+  baseUrl: "https://den.example.test",
+  authToken: "token-a",
+  activeOrgId: "org-a",
+};
+
+describe("desktop cloud sync identity", () => {
+  test("does not apply a snapshot after the active organization changes", async () => {
+    let currentIdentity = organizationA;
+    let resolveSnapshot: (snapshot: string) => void = () => undefined;
+    const snapshot = new Promise<string>((resolve) => {
+      resolveSnapshot = resolve;
+    });
+    const applied: string[] = [];
+
+    const result = applyIdentityBoundSnapshot({
+      identity: organizationA,
+      load: () => snapshot,
+      readCurrentIdentity: () => currentIdentity,
+      apply: async (value) => {
+        applied.push(value);
+        return value;
+      },
+    });
+
+    currentIdentity = { ...organizationA, activeOrgId: "org-b" };
+    resolveSnapshot("snapshot-a");
+
+    expect(await result).toBeNull();
+    expect(applied).toEqual([]);
+  });
+
+  test("applies a snapshot while the exact Den identity remains current", async () => {
+    const applied: string[] = [];
+    const result = await applyIdentityBoundSnapshot({
+      identity: organizationA,
+      load: async () => "snapshot-a",
+      readCurrentIdentity: () => organizationA,
+      apply: async (snapshot) => {
+        applied.push(snapshot);
+        return "synced";
+      },
+    });
+
+    expect(result).toBe("synced");
+    expect(applied).toEqual(["snapshot-a"]);
+  });
+
+  test("treats base URL, token, organization, and missing auth as identity changes", () => {
+    expect(isSameDesktopCloudSyncIdentity(organizationA, organizationA)).toBe(true);
+    expect(isSameDesktopCloudSyncIdentity(organizationA, { ...organizationA, baseUrl: "https://other.test" })).toBe(false);
+    expect(isSameDesktopCloudSyncIdentity(organizationA, { ...organizationA, authToken: "token-b" })).toBe(false);
+    expect(isSameDesktopCloudSyncIdentity(organizationA, { ...organizationA, activeOrgId: "org-b" })).toBe(false);
+    expect(isSameDesktopCloudSyncIdentity(organizationA, null)).toBe(false);
+  });
+});
 
 describe("derivePendingCloudPluginChanges", () => {
   test("maps modified plugin changes to update available", () => {

--- a/apps/app/src/app/cloud/desktop-cloud-sync.ts
+++ b/apps/app/src/app/cloud/desktop-cloud-sync.ts
@@ -16,6 +16,46 @@ type InstalledCloudPluginLike = {
   files: Array<{ configObjectId: string; updatedAt: string | null }>;
 };
 
+export type DesktopCloudSyncIdentity = {
+  baseUrl: string;
+  authToken: string;
+  activeOrgId: string;
+};
+
+export function readDesktopCloudSyncIdentity(): DesktopCloudSyncIdentity | null {
+  const settings = readDenSettings();
+  const authToken = settings.authToken?.trim() ?? "";
+  const activeOrgId = settings.activeOrgId?.trim() ?? "";
+  if (!authToken || !activeOrgId) return null;
+  return {
+    baseUrl: settings.baseUrl,
+    authToken,
+    activeOrgId,
+  };
+}
+
+export function isSameDesktopCloudSyncIdentity(
+  left: DesktopCloudSyncIdentity | null,
+  right: DesktopCloudSyncIdentity | null,
+): boolean {
+  return left !== null &&
+    right !== null &&
+    left.baseUrl === right.baseUrl &&
+    left.authToken === right.authToken &&
+    left.activeOrgId === right.activeOrgId;
+}
+
+export async function applyIdentityBoundSnapshot<TSnapshot, TResult>(input: {
+  identity: DesktopCloudSyncIdentity;
+  load: () => Promise<TSnapshot>;
+  readCurrentIdentity: () => DesktopCloudSyncIdentity | null;
+  apply: (snapshot: TSnapshot) => Promise<TResult>;
+}): Promise<TResult | null> {
+  const snapshot = await input.load();
+  if (!isSameDesktopCloudSyncIdentity(input.identity, input.readCurrentIdentity())) return null;
+  return input.apply(snapshot);
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
 }
@@ -104,17 +144,18 @@ async function runDesktopCloudSync(input: {
   openworkClient: OpenworkServerClient;
   workspaceId: string;
 }): Promise<OpenworkDesktopCloudSyncResult | null> {
-  const settings = readDenSettings();
-  const token = settings.authToken?.trim() ?? "";
-  const activeOrgId = settings.activeOrgId?.trim() ?? "";
-  if (!token || !activeOrgId) return null;
+  const identity = readDesktopCloudSyncIdentity();
+  if (!identity) return null;
 
-  const snapshot = await createDenClient({
-    baseUrl: settings.baseUrl,
-    token,
-  }).getResourceSnapshot(activeOrgId);
-
-  return input.openworkClient.syncDesktopCloud(input.workspaceId, snapshot);
+  return applyIdentityBoundSnapshot({
+    identity,
+    load: () => createDenClient({
+      baseUrl: identity.baseUrl,
+      token: identity.authToken,
+    }).getResourceSnapshot(identity.activeOrgId),
+    readCurrentIdentity: readDesktopCloudSyncIdentity,
+    apply: (snapshot) => input.openworkClient.syncDesktopCloud(input.workspaceId, snapshot),
+  });
 }
 
 export function refreshDesktopCloudSync(input: {

--- a/evals/flows/den-cloud-sync-identity.flow.mjs
+++ b/evals/flows/den-cloud-sync-identity.flow.mjs
@@ -1,0 +1,88 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "den-cloud-sync-identity";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const APP = join(ROOT, "apps", "app");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+let testRun;
+
+function runTests() {
+  testRun ??= spawnSync("bun", ["test", "scripts/desktop-cloud-sync.test.ts"], {
+    cwd: APP,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  return testRun;
+}
+
+function output() {
+  const run = runTests();
+  return `${run.stdout ?? ""}\n${run.stderr ?? ""}`.trim();
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Den cloud sync keeps organization identity stable",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "A stale organization snapshot is discarded",
+      run: async (ctx) => {
+        await ctx.prove("A delayed organization A snapshot cannot reach workspace sync after switching to organization B", {
+          claim: "The identity-bound sync discards the loaded snapshot before apply when the active Den organization changes.",
+          voiceover: vo[0],
+          action: async () => runTests(),
+          assert: async () => {
+            const run = runTests();
+            const result = output();
+            ctx.assert(run.status === 0, `Desktop cloud sync tests failed:\n${result}`);
+            ctx.assert(result.includes("does not apply a snapshot after the active organization changes"), "The stale-response regression did not run.");
+            ctx.output("desktop-cloud-sync-tests.txt", result);
+          },
+        });
+      },
+    },
+    {
+      name: "An organization switch invalidates the in-flight response",
+      run: async (ctx) => {
+        await ctx.prove("Switching organizations invalidates the earlier response before apply", {
+          claim: "The regression test changes the current identity while the first snapshot promise is unresolved and observes no apply call.",
+          voiceover: vo[1],
+          assert: async () => {
+            ctx.assert(output().includes("does not apply a snapshot after the active organization changes"), "The organization-switch assertion is missing.");
+          },
+        });
+      },
+    },
+    {
+      name: "The current identity still applies its snapshot",
+      run: async (ctx) => {
+        await ctx.prove("The matching organization snapshot continues to sync normally", {
+          claim: "The same guard allows apply when Den base URL, credential identity, and organization remain unchanged.",
+          voiceover: vo[2],
+          assert: async () => {
+            const result = output();
+            ctx.assert(result.includes("applies a snapshot while the exact Den identity remains current"), "The current-identity regression did not run.");
+            ctx.assert(result.includes("11 pass") && result.includes("0 fail"), "The focused suite did not pass completely.");
+          },
+        });
+      },
+    },
+    {
+      name: "Authentication absence and identity changes fail closed",
+      run: async (ctx) => {
+        await ctx.prove("The identity guard fails closed without exposing credentials", {
+          claim: "Base URL, credential, organization, and missing-auth changes are compared only in memory and reject a stale apply.",
+          voiceover: vo[3],
+          assert: async () => {
+            ctx.assert(output().includes("treats base URL, token, organization, and missing auth as identity changes"), "The full identity comparison assertion is missing.");
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/den-cloud-sync-identity.md
+++ b/evals/voiceovers/den-cloud-sync-identity.md
@@ -1,0 +1,9 @@
+# den-cloud-sync-identity — stale organization snapshots never reach workspace sync
+
+1. OpenWork begins a desktop cloud-resource sync for organization A and records the exact Den base URL, token identity, and active organization that authorized the snapshot request.
+
+2. Before organization A’s snapshot returns, the user switches to organization B; the delayed A response is recognized as stale and is not sent to the OpenWork workspace.
+
+3. A sync for organization B reads B’s current snapshot and applies it to the intended workspace, so providers, plugins, and configuration never briefly revert to the previous organization.
+
+4. Missing authentication still returns without syncing, and identity checks compare opaque settings without logging or copying token values into new persistence.


### PR DESCRIPTION
> [!WARNING]
> **Queue audit (2026-07-17): superseded by #2869 — do not merge this revision.** The stale-org snapshot race is real in the current desktop Cloud sync path, but ready upstream PR #2869 deletes that path and `apps/app/src/app/cloud/desktop-cloud-sync.ts` entirely as part of Connect-only Marketplace delivery. Hardening code scheduled for removal would create immediate conflict and no durable value. Reassess identity scoping only if #2869 does not land or an equivalent sync path returns.

## Problem

Desktop cloud sync captured the active Den organization before requesting its resource snapshot, but it did not verify that the same Den session was still active after the request completed. A slow organization A response could therefore be applied to the workspace after the user had already switched to organization B.

## State and ordering contract

A fetched Den snapshot may reach workspace sync only while the exact request identity is still current:

- Den base URL is unchanged
- authentication token identity is unchanged
- active organization is unchanged
- authentication is still present

If any part changes while the request is in flight, the response is stale and is discarded. A later sync for the current identity remains responsible for applying current state.

## Implementation

- Capture a small in-memory identity before loading the snapshot.
- Re-read that identity immediately before applying the result.
- Centralize the equality and identity-bound apply behavior in testable helpers.
- Keep credentials opaque: the token is compared in memory and is never logged or newly persisted.
- Preserve the existing serialized desktop cloud sync queue and missing-auth no-op behavior.

## Regression proof

- Added a delayed-promise test that starts organization A, switches to B before A resolves, and proves apply is never called.
- Added the positive counterpart proving an unchanged identity still applies normally.
- Added coverage for base URL, token, organization, and missing-auth identity changes.
- Added an approved voiceover and an internal fraimz flow for the ordering contract.

## Validation

- pnpm --filter @openwork/app test:desktop-cloud-sync — 11 passed, 0 failed
- pnpm --filter @openwork/app typecheck — passed
- pnpm --filter @openwork/app build — passed (existing bundle-size and module-directive warnings only)
- pnpm fraimz --flow den-cloud-sync-identity — Passed, 4 proof frames plus voiceover coverage

## Evidence limitations

The fraimz run is an internal, test-backed ordering proof. It does not claim to be a live UI recording or a real multi-organization Den session. No production Den credentials or tenant data were used.

## Human review still required

This draft is intentionally not ready to merge until a human reviewer confirms:

- comparing the full opaque token in memory is the desired session-identity boundary;
- discarding a stale response, rather than automatically scheduling another sync here, composes correctly with the existing event/interval triggers;
- the narrow check immediately before workspace apply is sufficient for the intended session-switch semantics;
- a manual desktop pass with two real test organizations shows no temporary cross-organization provider/plugin/config state;
- the branch is still appropriate against the latest dev head when reviewed.

## Scope and mergeability

This is an independent fix based on dev. It has no ordering dependency on the other remote-workspace or Den-state reliability drafts and should be reviewed and merged on its own merits.