### PR TITLE
fix(app): coalesce Den sync requests

### DIFF
--- a/apps/app/scripts/cloud-provider-auto-sync.test.ts
+++ b/apps/app/scripts/cloud-provider-auto-sync.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, test } from "bun:test";
+
+import { createCloudProviderSyncRunner } from "../src/react-app/domains/cloud/use-cloud-provider-auto-sync";
+import type { CloudProviderSyncReason } from "../src/react-app/domains/cloud/use-cloud-provider-auto-sync";
+
+function deferred() {
+  let resolve: () => void = () => undefined;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe("createCloudProviderSyncRunner", () => {
+  test("coalesces settings changes into one follow-up without overlap", async () => {
+    const first = deferred();
+    const reasons: CloudProviderSyncReason[] = [];
+    let active = 0;
+    let maxActive = 0;
+    const runner = createCloudProviderSyncRunner(async (reason) => {
+      reasons.push(reason);
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      if (reasons.length === 1) await first.promise;
+      active -= 1;
+    });
+
+    const idle = runner.request("interval");
+    void runner.request("sign_in");
+    void runner.request("settings_cloud_opened");
+    expect(reasons).toEqual(["interval"]);
+
+    first.resolve();
+    await idle;
+
+    expect(reasons).toEqual(["interval", "settings_cloud_opened"]);
+    expect(maxActive).toBe(1);
+  });
+
+  test("cancels a pending follow-up", async () => {
+    const first = deferred();
+    const reasons: CloudProviderSyncReason[] = [];
+    const runner = createCloudProviderSyncRunner(async (reason) => {
+      reasons.push(reason);
+      await first.promise;
+    });
+
+    const idle = runner.request("interval");
+    void runner.request("sign_in");
+    runner.cancel();
+    first.resolve();
+    await idle;
+
+    expect(reasons).toEqual(["interval"]);
+  });
+
+  test("runs the latest pending state after a failure", async () => {
+    const first = deferred();
+    const reasons: CloudProviderSyncReason[] = [];
+    const runner = createCloudProviderSyncRunner(async (reason) => {
+      reasons.push(reason);
+      if (reasons.length === 1) {
+        await first.promise;
+        throw new Error("network unavailable");
+      }
+    });
+
+    const idle = runner.request("interval");
+    void runner.request("sign_in");
+    first.resolve();
+    await idle;
+
+    expect(reasons).toEqual(["interval", "sign_in"]);
+  });
+});

--- a/apps/app/src/react-app/domains/cloud/use-cloud-provider-auto-sync.ts
+++ b/apps/app/src/react-app/domains/cloud/use-cloud-provider-auto-sync.ts
@@ -5,8 +5,44 @@ import { CLOUD_SYNC_INTERVAL_MS } from "../../../app/cloud/sync/constants";
 import { denSettingsChangedEvent } from "../../../app/lib/den-session-events";
 import { useDenAuth } from "./den-auth-provider";
 
-type CloudProviderSyncReason = "sign_in" | "app_launch" | "interval" | "settings_cloud_opened";
+export type CloudProviderSyncReason = "sign_in" | "app_launch" | "interval" | "settings_cloud_opened";
 type SyncFn = (reason: CloudProviderSyncReason) => Promise<unknown>;
+
+export function createCloudProviderSyncRunner(sync: SyncFn) {
+  let cancelled = false;
+  let pendingReason: CloudProviderSyncReason | null = null;
+  let drainPromise: Promise<void> | null = null;
+
+  const drain = async () => {
+    while (!cancelled && pendingReason) {
+      const reason = pendingReason;
+      pendingReason = null;
+      try {
+        await sync(reason);
+      } catch {
+        // The owning store surfaces user-visible errors. A failed pass still
+        // releases the runner so a newer settings state can reconcile.
+      }
+    }
+  };
+
+  return {
+    request(reason: CloudProviderSyncReason = "interval"): Promise<void> {
+      if (cancelled) return Promise.resolve();
+      pendingReason = reason;
+      if (!drainPromise) {
+        drainPromise = drain().finally(() => {
+          drainPromise = null;
+        });
+      }
+      return drainPromise;
+    },
+    cancel() {
+      cancelled = true;
+      pendingReason = null;
+    },
+  };
+}
 
 /**
   * Periodic cloud-provider reconciliation, ported from dev #1509 "auto-sync
@@ -22,7 +58,6 @@ type SyncFn = (reason: CloudProviderSyncReason) => Promise<unknown>;
 export function useCloudProviderAutoSync(sync: SyncFn) {
   const denAuth = useDenAuth();
   const syncRef = useRef(sync);
-  const inFlightRef = useRef(false);
 
   // Keep the ref current so we always call the latest closure (store
   // identity can change between mounts and we don't want to restart the
@@ -34,36 +69,22 @@ export function useCloudProviderAutoSync(sync: SyncFn) {
   useEffect(() => {
     if (!denAuth.isSignedIn) return;
 
-    let cancelled = false;
-
-    const tick = async (reason: CloudProviderSyncReason = "interval") => {
-      if (inFlightRef.current || cancelled) return;
-      inFlightRef.current = true;
-      try {
-        await syncRef.current(reason);
-      } catch {
-        // Network errors, org misconfig, etc. are non-fatal — we'll try
-        // again on the next interval. The refresh function owns surfacing
-        // any user-visible error state.
-      } finally {
-        inFlightRef.current = false;
-      }
-    };
+    const runner = createCloudProviderSyncRunner((reason) => syncRef.current(reason));
 
     // Immediate pass so users see server state quickly after sign-in.
-    void tick("sign_in");
+    void runner.request("sign_in");
 
     const handleDenSettingsChanged = () => {
-      void tick("sign_in");
+      void runner.request("sign_in");
     };
     window.addEventListener(denSettingsChangedEvent, handleDenSettingsChanged);
 
     const interval = window.setInterval(() => {
-      void tick();
+      void runner.request();
     }, CLOUD_SYNC_INTERVAL_MS);
 
     return () => {
-      cancelled = true;
+      runner.cancel();
       window.removeEventListener(denSettingsChangedEvent, handleDenSettingsChanged);
       window.clearInterval(interval);
     };

--- a/evals/flows/den-sync-coalesce.flow.mjs
+++ b/evals/flows/den-sync-coalesce.flow.mjs
@@ -1,0 +1,65 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "den-sync-coalesce";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+let run;
+
+function output() {
+  run ??= spawnSync("bun", ["test", "apps/app/scripts/cloud-provider-auto-sync.test.ts"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  return `${run.stdout ?? ""}\n${run.stderr ?? ""}`.trim();
+}
+
+function assertTest(ctx, name) {
+  const result = output();
+  ctx.assert(run.status === 0, `Auto-sync tests failed:\n${result}`);
+  ctx.assert(result.includes(name), `Missing regression: ${name}`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Den settings changes coalesce during provider sync",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "A settings change can arrive during reconciliation",
+      run: async (ctx) => ctx.prove("The regression holds the first request open while settings change", {
+        voiceover: vo[0],
+        assert: async () => assertTest(ctx, "coalesces settings changes into one follow-up without overlap"),
+      }),
+    },
+    {
+      name: "The newest settings state remains pending",
+      run: async (ctx) => ctx.prove("The latest reason replaces earlier pending signals", {
+        voiceover: vo[1],
+        assert: async () => assertTest(ctx, "coalesces settings changes into one follow-up without overlap"),
+      }),
+    },
+    {
+      name: "Exactly one non-overlapping follow-up runs",
+      run: async (ctx) => ctx.prove("Bursts coalesce and the maximum concurrent request count remains one", {
+        voiceover: vo[2],
+        assert: async () => assertTest(ctx, "coalesces settings changes into one follow-up without overlap"),
+      }),
+    },
+    {
+      name: "Cancellation and failure release pending state safely",
+      run: async (ctx) => ctx.prove("Unmount cancels pending work while failures still permit the latest reconciliation", {
+        voiceover: vo[3],
+        assert: async () => {
+          assertTest(ctx, "cancels a pending follow-up");
+          assertTest(ctx, "runs the latest pending state after a failure");
+          ctx.output("cloud-provider-auto-sync-tests.txt", output());
+        },
+      }),
+    },
+  ],
+};

--- a/evals/voiceovers/den-sync-coalesce.md
+++ b/evals/voiceovers/den-sync-coalesce.md
@@ -1,0 +1,9 @@
+# den-sync-coalesce — Den settings changes are not dropped during provider sync
+
+1. A cloud-provider reconciliation is already running when OpenWork receives a Den settings change, such as selecting another organization.
+
+2. Instead of dropping the event because a request is in flight, OpenWork records one pending synchronization for the newest settings state.
+
+3. When the current request settles, exactly one follow-up pass runs immediately; several settings events during the same request coalesce instead of creating overlapping network calls.
+
+4. Signing out or unmounting cancels the pending pass, while a failed request still releases the queue so the latest valid state can be reconciled without a retry loop.


### PR DESCRIPTION
## Problem

The provider auto-sync hook prevented overlapping network requests with an in-flight boolean. That guard also discarded every Den settings-change event received while a request was running. Switching organizations at the wrong moment could therefore leave providers and cloud MCP state on the previous settings until the periodic interval fired.

## State and ordering contract

- Never run more than one reconciliation at a time.
- While one is running, retain one pending pass for the newest settings state.
- Coalesce a burst into one immediate follow-up, using the latest reason.
- Cancel pending work on sign-out or unmount.
- A failed pass must release the runner and allow already-pending current state to reconcile.

## Implementation

- Replaced the drop-on-in-flight guard with a small serialized sync runner.
- Each signal updates one pending reason; the drain loop consumes it after the active request settles.
- The hook still keeps the latest sync closure without restarting its interval on render.
- Cancellation clears pending work but does not attempt to abort an already-owned request.
- Errors remain owned by the existing stores and do not create an automatic retry loop.

## Regression proof

Tests hold the first request open, send several settings changes, and prove:

- no second request starts concurrently;
- the burst produces exactly one follow-up using the newest reason;
- cancellation removes the pending pass;
- a failed first request still releases the queued current-state pass.

## Validation

- bun test apps/app/scripts/cloud-provider-auto-sync.test.ts — 3 passed, 0 failed
- pnpm --filter @openwork/app typecheck — passed
- pnpm fraimz --flow den-sync-coalesce — Passed, 4 proof frames plus voiceover coverage

## Evidence limitations

The fraimz run is an internal concurrency proof backed by deterministic deferred promises. It is not a live UI recording and does not exercise a production Den tenant or real network latency.

## Human review still required

This draft is intentionally not ready to merge until a human reviewer confirms:

- latest-reason coalescing is correct for both provider sync consumers mounted by Settings;
- one follow-up per in-flight window is the desired behavior under sustained settings-event traffic;
- clearing pending work without aborting the active request is correct on sign-out/unmount;
- swallowed promise failures remain correctly surfaced by each owning store;
- a manual organization switch during a deliberately slow sync refreshes current providers and MCP state immediately after the active request settles;
- the branch remains appropriate against the latest dev head.

## Scope and mergeability

This is independent from the stale-snapshot identity guard and other remote reliability drafts. It can be reviewed and merged separately.