### PR TITLE
fix(app): cancel stale onboarding redirects

### DIFF
--- a/apps/app/scripts/den-onboarding-redirect-order.test.ts
+++ b/apps/app/scripts/den-onboarding-redirect-order.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, test } from "bun:test";
+
+import { createOnboardingRedirectScheduler } from "../src/react-app/shell/app-root";
+
+function harness(maxAttempts = 10) {
+  let identity = { authToken: "token-a", activeOrgId: "" };
+  let navigations = 0;
+  let nextHandle = 1;
+  const callbacks = new Map<number, () => void>();
+  const scheduler = createOnboardingRedirectScheduler({
+    readIdentity: () => identity,
+    navigate: () => {
+      navigations += 1;
+    },
+    schedule: (callback) => {
+      const handle = nextHandle++;
+      callbacks.set(handle, callback);
+      return handle;
+    },
+    clear: (handle) => callbacks.delete(handle),
+    maxAttempts,
+    delayMs: 1,
+  });
+  const runNext = () => {
+    const entry = callbacks.entries().next().value;
+    if (!entry) return false;
+    callbacks.delete(entry[0]);
+    entry[1]();
+    return true;
+  };
+  return {
+    scheduler,
+    runNext,
+    pending: () => callbacks.size,
+    navigations: () => navigations,
+    setIdentity: (next: typeof identity) => {
+      identity = next;
+    },
+  };
+}
+
+describe("createOnboardingRedirectScheduler", () => {
+  test("only the latest successful sign-in can navigate once", () => {
+    const test = harness();
+    test.scheduler.start("token-a");
+    test.scheduler.start("token-b");
+    test.setIdentity({ authToken: "token-b", activeOrgId: "org-b" });
+    test.runNext();
+
+    expect(test.navigations()).toBe(1);
+    expect(test.pending()).toBe(0);
+    expect(test.runNext()).toBe(false);
+  });
+
+  test("cancels pending navigation on sign-out or unmount", () => {
+    const test = harness();
+    test.scheduler.start("token-a");
+    test.scheduler.cancel();
+    test.setIdentity({ authToken: "token-a", activeOrgId: "org-a" });
+
+    expect(test.runNext()).toBe(false);
+    expect(test.navigations()).toBe(0);
+  });
+
+  test("does not navigate for a different current token", () => {
+    const test = harness(2);
+    test.scheduler.start("token-a");
+    test.setIdentity({ authToken: "token-b", activeOrgId: "org-b" });
+    test.runNext();
+    test.runNext();
+
+    expect(test.navigations()).toBe(0);
+    expect(test.pending()).toBe(0);
+  });
+
+  test("stops quietly when the bounded wait expires", () => {
+    const test = harness(3);
+    test.scheduler.start("token-a");
+    while (test.runNext()) {}
+
+    expect(test.navigations()).toBe(0);
+    expect(test.pending()).toBe(0);
+  });
+});

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -53,6 +53,54 @@ const subscribeToRequireSignin = (onStoreChange: () => void) => {
   };
 };
 
+type OnboardingRedirectIdentity = {
+  authToken: string;
+  activeOrgId: string;
+};
+
+export function createOnboardingRedirectScheduler(input: {
+  readIdentity: () => OnboardingRedirectIdentity;
+  navigate: () => void;
+  schedule: (callback: () => void, delayMs: number) => ReturnType<typeof setTimeout>;
+  clear: (handle: ReturnType<typeof setTimeout>) => void;
+  maxAttempts?: number;
+  delayMs?: number;
+}) {
+  let generation = 0;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+
+  const cancel = () => {
+    generation += 1;
+    if (timer) input.clear(timer);
+    timer = null;
+  };
+
+  const start = (expectedToken: string) => {
+    cancel();
+    const currentGeneration = generation;
+    const maxAttempts = input.maxAttempts ?? 10;
+    const delayMs = input.delayMs ?? 500;
+    let attempts = 0;
+
+    const check = () => {
+      timer = null;
+      if (currentGeneration !== generation) return;
+      attempts += 1;
+      const identity = input.readIdentity();
+      if (identity.authToken && identity.authToken === expectedToken && identity.activeOrgId) {
+        generation += 1;
+        input.navigate();
+        return;
+      }
+      if (attempts < maxAttempts) timer = input.schedule(check, delayMs);
+    };
+
+    timer = input.schedule(check, delayMs);
+  };
+
+  return { start, cancel };
+}
+
 /**
  * Forced-signin gate ported from the Solid shell.
  *
@@ -116,24 +164,29 @@ function DenSigninGate({ children }: DenSigninGateProps) {
   // Poll for activeOrgId (set asynchronously by refreshOrgs) rather
   // than using a fixed delay — handles both fast and slow org lookups.
   useEffect(() => {
-    const handler = (event: WindowEventMap[typeof denSessionUpdatedEvent]) => {
-      if (event.detail?.status !== "success") return;
-      let attempts = 0;
-      const check = () => {
-        attempts++;
+    const scheduler = createOnboardingRedirectScheduler({
+      readIdentity: () => {
         const settings = readDenSettings();
-        if (settings.authToken?.trim() && settings.activeOrgId?.trim()) {
-          navigate("/onboarding", { replace: true });
-        } else if (attempts < 10) {
-          // Org not selected yet — retry (max ~5 seconds)
-          setTimeout(check, 500);
-        }
-      };
-      // First check after a short delay for the auth to settle
-      setTimeout(check, 500);
+        return {
+          authToken: settings.authToken?.trim() ?? "",
+          activeOrgId: settings.activeOrgId?.trim() ?? "",
+        };
+      },
+      navigate: () => navigate("/onboarding", { replace: true }),
+      schedule: (callback, delayMs) => setTimeout(callback, delayMs),
+      clear: (handle) => clearTimeout(handle),
+    });
+    const handler = (event: WindowEventMap[typeof denSessionUpdatedEvent]) => {
+      scheduler.cancel();
+      if (event.detail?.status !== "success") return;
+      const expectedToken = event.detail.token?.trim() ?? "";
+      if (expectedToken) scheduler.start(expectedToken);
     };
     window.addEventListener(denSessionUpdatedEvent, handler);
-    return () => window.removeEventListener(denSessionUpdatedEvent, handler);
+    return () => {
+      scheduler.cancel();
+      window.removeEventListener(denSessionUpdatedEvent, handler);
+    };
   }, [navigate]);
 
   if (requireSignin && denAuth.status === "checking") {

--- a/evals/flows/den-onboarding-redirect-order.flow.mjs
+++ b/evals/flows/den-onboarding-redirect-order.flow.mjs
@@ -1,0 +1,67 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "den-onboarding-redirect-order";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+let run;
+
+function result() {
+  run ??= spawnSync("bun", ["test", "apps/app/scripts/den-onboarding-redirect-order.test.ts"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  return `${run.stdout ?? ""}\n${run.stderr ?? ""}`.trim();
+}
+
+function proveTest(ctx, name) {
+  const output = result();
+  ctx.assert(run.status === 0, `Redirect-order tests failed:\n${output}`);
+  ctx.assert(output.includes(name), `Missing regression: ${name}`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Only the current Den sign-in may redirect to onboarding",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Successful sign-in begins a bounded organization wait",
+      run: async (ctx) => ctx.prove("The redirect waits for the asynchronously selected organization", {
+        voiceover: vo[0],
+        assert: async () => proveTest(ctx, "only the latest successful sign-in can navigate once"),
+      }),
+    },
+    {
+      name: "Later session events cancel older timers",
+      run: async (ctx) => ctx.prove("Sign-out and unmount remove pending redirect work", {
+        voiceover: vo[1],
+        assert: async () => proveTest(ctx, "cancels pending navigation on sign-out or unmount"),
+      }),
+    },
+    {
+      name: "Only the latest matching token navigates once",
+      run: async (ctx) => ctx.prove("An older sign-in token cannot redirect after a newer session becomes current", {
+        voiceover: vo[2],
+        assert: async () => {
+          proveTest(ctx, "only the latest successful sign-in can navigate once");
+          proveTest(ctx, "does not navigate for a different current token");
+        },
+      }),
+    },
+    {
+      name: "The wait expires without late navigation",
+      run: async (ctx) => ctx.prove("The existing five-second polling budget ends quietly", {
+        voiceover: vo[3],
+        assert: async () => {
+          proveTest(ctx, "stops quietly when the bounded wait expires");
+          ctx.output("den-onboarding-redirect-order-tests.txt", result());
+        },
+      }),
+    },
+  ],
+};

--- a/evals/voiceovers/den-onboarding-redirect-order.md
+++ b/evals/voiceovers/den-onboarding-redirect-order.md
@@ -1,0 +1,9 @@
+# den-onboarding-redirect-order — only the current sign-in may redirect to onboarding
+
+1. A successful Den sign-in starts a bounded wait for the active organization that is selected asynchronously after authentication.
+
+2. If another session event arrives, the user signs out, or the shell unmounts before that organization appears, OpenWork cancels the older wait instead of leaving background timers alive.
+
+3. Only the latest successful sign-in with both a current token and active organization can navigate to onboarding, and it navigates once rather than letting overlapping timers repeat the redirect.
+
+4. If no organization becomes available within the existing five-second window, the wait ends quietly and leaves the user on their current route without a late surprise navigation.


### PR DESCRIPTION
## Problem

After a successful Den sign-in, the shell recursively scheduled up to ten organization checks. Cleanup removed only the session event listener; it did not cancel those timers. Repeated success events could create overlapping polling chains, and an older chain could redirect to onboarding after sign-out, navigation, a newer sign-in, or unmount.

## State and ordering contract

- Every session event invalidates any older redirect wait.
- Only a success event with a token starts a new bounded wait.
- The current stored token must still match that success event when the organization appears.
- A matching token plus active organization may navigate once.
- Sign-out, error, newer success, and unmount cancel pending timers.
- The existing ten checks at 500ms remain the maximum wait; expiry is silent.

## Implementation

- Extracted a small cancellable redirect scheduler with a generation boundary.
- Captured the successful sign-in token and compare it with current Den settings before navigation.
- Clear the active timer and invalidate the generation on every session event and effect cleanup.
- Mark the generation complete before navigating so no duplicate callback can redirect twice.

## Regression proof

Deterministic fake-timer tests prove:

- two successful sign-ins leave only the latest eligible to navigate;
- a matching current token and organization navigate exactly once;
- sign-out/unmount cancellation leaves no timer or navigation;
- a different current token cannot redirect;
- the bounded wait expires without late navigation.

## Validation

- bun test apps/app/scripts/den-onboarding-redirect-order.test.ts — 4 passed, 0 failed
- pnpm --filter @openwork/app typecheck — passed
- pnpm fraimz --flow den-onboarding-redirect-order — Passed, 4 proof frames plus voiceover coverage

## Evidence limitations

The fraimz run is an internal scheduler proof with deterministic timers. It is not a live UI recording and does not exercise browser handoff timing against a real Den deployment.

## Human review still required

This draft is intentionally not ready to merge until a human reviewer confirms:

- the session event token is the correct identity to bind to the redirect;
- all success producers include the token required to start the wait;
- cancelling on every non-success session event matches intended error and sign-out behavior;
- retaining the existing five-second maximum is still the desired UX;
- a manual desktop test covering success, rapid second sign-in, sign-out during org loading, and route navigation produces no surprise redirect;
- the branch remains appropriate against the latest dev head.

## Scope and mergeability

This is an independent shell ordering fix with no merge dependency on the other Den synchronization drafts.