### PR TITLE
fix(app): ignore stale Den organization refreshes

### DIFF
--- a/apps/app/scripts/den-org-refresh-order.test.ts
+++ b/apps/app/scripts/den-org-refresh-order.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+
+import { createLatestRequestGate } from "../src/react-app/domains/settings/cloud/use-den-session";
+
+describe("createLatestRequestGate", () => {
+  test("only the newest organization refresh remains current", () => {
+    const gate = createLatestRequestGate();
+    const older = gate.begin();
+    const newer = gate.begin();
+
+    expect(gate.isCurrent(older)).toBe(false);
+    expect(gate.isCurrent(newer)).toBe(true);
+  });
+
+  test("a session identity change invalidates an in-flight refresh", () => {
+    const gate = createLatestRequestGate();
+    const request = gate.begin();
+    gate.invalidate();
+
+    expect(gate.isCurrent(request)).toBe(false);
+  });
+
+  test("stale success, error, and completion mutations are all rejected", async () => {
+    const gate = createLatestRequestGate();
+    const mutations: string[] = [];
+    const older = gate.begin();
+    const newer = gate.begin();
+
+    if (gate.isCurrent(newer)) mutations.push("newer-success");
+    if (gate.isCurrent(older)) mutations.push("older-success");
+    if (gate.isCurrent(older)) mutations.push("older-error");
+    if (gate.isCurrent(older)) mutations.push("older-complete");
+    if (gate.isCurrent(newer)) mutations.push("newer-complete");
+
+    expect(mutations).toEqual(["newer-success", "newer-complete"]);
+  });
+});

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -42,6 +42,22 @@ export type UseDenSessionProps = {
   openLink: (url: string) => void;
 };
 
+export function createLatestRequestGate() {
+  let latestRequest = 0;
+  return {
+    begin() {
+      latestRequest += 1;
+      return latestRequest;
+    },
+    isCurrent(request: number) {
+      return request === latestRequest;
+    },
+    invalidate() {
+      latestRequest += 1;
+    },
+  };
+}
+
 function parseManualAuthInput(value: string) {
   const trimmed = value.trim();
   if (!trimmed) return null;
@@ -87,6 +103,7 @@ export function useDenSession({
     user,
   } = useCloudSession();
   const initial = React.useMemo(() => readDenSettings(), []);
+  const orgRefreshGateRef = React.useRef(createLatestRequestGate());
 
   const [baseUrlDraft, setBaseUrlDraft] = React.useState(baseUrl);
   const [baseUrlBusy, setBaseUrlBusy] = React.useState(false);
@@ -107,6 +124,10 @@ export function useDenSession({
   );
 
   const isSignedIn = Boolean(authToken.trim()) && (Boolean(user) || denAuth.isSignedIn);
+
+  React.useEffect(() => {
+    orgRefreshGateRef.current.invalidate();
+  }, [authToken, baseUrl, client]);
 
   const summaryTone = React.useMemo<SettingsTone>(() => {
     if (authError || orgsError) {
@@ -359,6 +380,7 @@ export function useDenSession({
 
   const refreshOrgs = React.useCallback(
     async (quiet = false) => {
+      const request = orgRefreshGateRef.current.begin();
       if (!authToken.trim()) {
         setOrgs([]);
         setActiveOrgId("");
@@ -370,6 +392,7 @@ export function useDenSession({
 
       try {
         const response = await client.listOrgs();
+        if (!orgRefreshGateRef.current.isCurrent(request)) return;
         setOrgs(response.orgs);
         const current = activeOrgId.trim();
 
@@ -403,13 +426,15 @@ export function useDenSession({
         if (next) {
           await ensureDenActiveOrganization({ forceServerSync: true }).catch(() => null);
         }
+        if (!orgRefreshGateRef.current.isCurrent(request)) return;
         if (!quiet && response.orgs.length > 0) {
           toast.info(t("den.status_loaded_orgs", { count: response.orgs.length }));
         }
       } catch (error) {
+        if (!orgRefreshGateRef.current.isCurrent(request)) return;
         setOrgsError(error instanceof Error ? error.message : t("den.error_load_orgs"));
       } finally {
-        setOrgsBusy(false);
+        if (orgRefreshGateRef.current.isCurrent(request)) setOrgsBusy(false);
       }
     },
     [activeOrgId, authToken, baseUrl, client, setActiveOrganization],

--- a/evals/flows/den-org-refresh-order.flow.mjs
+++ b/evals/flows/den-org-refresh-order.flow.mjs
@@ -1,0 +1,64 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "den-org-refresh-order";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+let run;
+
+function result() {
+  run ??= spawnSync("bun", ["test", "apps/app/scripts/den-org-refresh-order.test.ts"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  return `${run.stdout ?? ""}\n${run.stderr ?? ""}`.trim();
+}
+
+function proveTest(ctx, name) {
+  const output = result();
+  ctx.assert(run.status === 0, `Organization refresh tests failed:\n${output}`);
+  ctx.assert(output.includes(name), `Missing regression: ${name}`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "The latest Den session owns organization refresh state",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "An organization request can outlive its session identity",
+      run: async (ctx) => ctx.prove("Session identity changes invalidate in-flight organization refreshes", {
+        voiceover: vo[0],
+        assert: async () => proveTest(ctx, "a session identity change invalidates an in-flight refresh"),
+      }),
+    },
+    {
+      name: "A newer refresh becomes the sole state owner",
+      run: async (ctx) => ctx.prove("Only the newest request generation remains current", {
+        voiceover: vo[1],
+        assert: async () => proveTest(ctx, "only the newest organization refresh remains current"),
+      }),
+    },
+    {
+      name: "The older success cannot overwrite organization state",
+      run: async (ctx) => ctx.prove("Stale success mutations are rejected by the same request gate", {
+        voiceover: vo[2],
+        assert: async () => proveTest(ctx, "stale success, error, and completion mutations are all rejected"),
+      }),
+    },
+    {
+      name: "Stale errors and completion cannot cover current state",
+      run: async (ctx) => ctx.prove("Error and busy completion mutations are latest-request-only", {
+        voiceover: vo[3],
+        assert: async () => {
+          proveTest(ctx, "stale success, error, and completion mutations are all rejected");
+          ctx.output("den-org-refresh-order-tests.txt", result());
+        },
+      }),
+    },
+  ],
+};

--- a/evals/voiceovers/den-org-refresh-order.md
+++ b/evals/voiceovers/den-org-refresh-order.md
@@ -1,0 +1,9 @@
+# den-org-refresh-order — the latest Den session owns organization state
+
+1. OpenWork starts loading organizations for one Den session while the account or Den endpoint is still allowed to change.
+
+2. A newer session starts its own organization refresh before the first response returns; the newer response sets the organization list, selection, and persisted active-organization metadata.
+
+3. When the older response finally arrives, it is ignored and cannot replace the newer organizations, clear the newer selection, change the active organization context, or dismiss the current loading state.
+
+4. Errors and busy-state completion are also latest-request-only, so a stale failure cannot cover healthy organization data with an error after an account or endpoint switch.


### PR DESCRIPTION
## Problem

Organization refreshes had no request ownership. If a session, credential, or Den endpoint changed while listOrgs was in flight, an older response could arrive last and overwrite the newer organization list, selected organization, persisted Den metadata, active-organization context, loading state, or error state.

## State and ordering contract

- Each refresh receives a monotonically newer request generation.
- Only the latest generation may mutate organization success state.
- Authentication token, Den endpoint, or client changes invalidate in-flight generations.
- Error and completion state obey the same latest-request rule as successful data.
- Starting a newer refresh keeps loading true when an older request finishes.

## Implementation

- Added a small latest-request gate owned by the hook instance.
- Begin a generation before every refresh, including the signed-out clear path.
- Recheck ownership immediately after listOrgs and after active-organization synchronization.
- Guard catch and finally so stale failure/completion cannot cover current data or clear current loading state.
- Invalidate the gate whenever token, base URL, or Den client identity changes.

## Regression proof

Focused tests prove:

- a second refresh immediately makes the first stale;
- changing session identity invalidates the active refresh;
- stale success, error, and completion mutations are all rejected while the newest success/completion remain allowed.

## Validation

- bun test apps/app/scripts/den-org-refresh-order.test.ts — 3 passed, 0 failed
- pnpm --filter @openwork/app typecheck — passed
- pnpm fraimz --flow den-org-refresh-order — Passed, 4 proof frames plus voiceover coverage

## Evidence limitations

The fraimz run is an internal request-ownership proof. It does not claim to be a live UI recording, and it does not inject delayed responses into a real Den endpoint or verify persisted browser storage visually.

## Human review still required

This draft is intentionally not ready to merge until a human reviewer confirms:

- token, base URL, and client are the complete session identity boundary for organization refresh ownership;
- every organization-state mutation in refreshOrgs is behind the latest-generation check;
- allowing already-current response mutations before ensureDenActiveOrganization completes is the desired sequence;
- busy state remains correct across manual refresh, automatic refresh, sign-out, and endpoint changes;
- a manual delayed-response test across two accounts/endpoints confirms the older response cannot replace list, selection, persistence, context, error, or loading state;
- the branch remains appropriate against the latest dev head.

## Scope and mergeability

This is an independent latest-request-wins fix. It has no merge-order dependency on the other Den synchronization or remote-workspace drafts.