### PR TITLE
fix(oauth): surface safe token exchange failures

### DIFF
--- a/ee/apps/den-api/src/capability-sources/generic-oauth.ts
+++ b/ee/apps/den-api/src/capability-sources/generic-oauth.ts
@@ -157,13 +157,133 @@ const tokenResponseSchema = z.object({
   scope: z.string().optional(),
 })
 
-export class OAuthTokenExchangeError extends Error {}
+const oauthErrorResponseSchema = z.object({
+  error: z.string().trim().min(1).max(128),
+  error_description: z.string().max(4_096).optional(),
+  error_codes: z.array(z.number().int()).max(16).optional(),
+  trace_id: z.string().uuid().optional(),
+  correlation_id: z.string().uuid().optional(),
+  timestamp: z.string().max(64).optional(),
+})
+
+export type OAuthTokenExchangeFailureCode =
+  | "oauth_invalid_client_secret"
+  | "oauth_invalid_client"
+  | "oauth_invalid_grant"
+  | "oauth_invalid_scope"
+  | "oauth_access_denied"
+  | "oauth_provider_unavailable"
+  | "oauth_token_response_invalid"
+  | "oauth_token_response_oversized"
+  | "oauth_token_endpoint_unreachable"
+  | "oauth_token_exchange_failed"
+
+export class OAuthTokenExchangeError extends Error {
+  readonly phase = "AUTH_TOKEN_ACQUISITION"
+
+  constructor(
+    message: string,
+    readonly code: OAuthTokenExchangeFailureCode = "oauth_token_exchange_failed",
+    readonly details: {
+      httpStatus?: number
+      providerOAuthError?: string
+      providerErrorCode?: number
+      providerTraceId?: string
+      providerCorrelationId?: string
+      providerTimestamp?: string
+    } = {},
+  ) {
+    super(message)
+    this.name = "OAuthTokenExchangeError"
+  }
+}
 export class OAuthClientConfigurationError extends Error {}
+
+export function oauthTokenExchangeErrorFromResponse(input: {
+  provider: NativeOAuthProviderConfig
+  status: number
+  body: unknown
+}): OAuthTokenExchangeError {
+  const parsed = oauthErrorResponseSchema.safeParse(input.body)
+  if (!parsed.success) {
+    return new OAuthTokenExchangeError(
+      `${input.provider.displayName} rejected the OAuth token exchange. Try Connect again; if it still fails, contact support with the diagnostic reference.`,
+      "oauth_token_exchange_failed",
+      { httpStatus: input.status },
+    )
+  }
+
+  const providerErrorCode = parsed.data.error_codes?.[0]
+  const details = {
+    httpStatus: input.status,
+    providerOAuthError: parsed.data.error,
+    ...(providerErrorCode !== undefined ? { providerErrorCode } : {}),
+    ...(parsed.data.trace_id ? { providerTraceId: parsed.data.trace_id } : {}),
+    ...(parsed.data.correlation_id ? { providerCorrelationId: parsed.data.correlation_id } : {}),
+    ...(parsed.data.timestamp ? { providerTimestamp: parsed.data.timestamp } : {}),
+  }
+
+  if (parsed.data.error === "invalid_client") {
+    if (input.provider.providerId === "microsoft-365" && providerErrorCode === 7_000_215) {
+      return new OAuthTokenExchangeError(
+        "Microsoft rejected the client secret during OAuth token exchange (AADSTS7000215). An organization administrator should replace the client secret value and try Connect again.",
+        "oauth_invalid_client_secret",
+        details,
+      )
+    }
+    return new OAuthTokenExchangeError(
+      `${input.provider.displayName} rejected the OAuth client credentials during token exchange. An organization administrator should verify the client ID and client secret value, then try Connect again.`,
+      "oauth_invalid_client",
+      details,
+    )
+  }
+
+  if (parsed.data.error === "invalid_grant") {
+    return new OAuthTokenExchangeError(
+      `${input.provider.displayName} rejected the authorization grant during token exchange. Restart Connect and complete a new authorization attempt.`,
+      "oauth_invalid_grant",
+      details,
+    )
+  }
+
+  if (parsed.data.error === "invalid_scope") {
+    return new OAuthTokenExchangeError(
+      `${input.provider.displayName} rejected the requested OAuth permissions. An organization administrator should review the configured permissions and consent, then try Connect again.`,
+      "oauth_invalid_scope",
+      details,
+    )
+  }
+
+  if (parsed.data.error === "access_denied") {
+    return new OAuthTokenExchangeError(
+      `${input.provider.displayName} denied the OAuth authorization request. Review consent and tenant policy, then try Connect again.`,
+      "oauth_access_denied",
+      details,
+    )
+  }
+
+  if (parsed.data.error === "server_error" || parsed.data.error === "temporarily_unavailable") {
+    return new OAuthTokenExchangeError(
+      `${input.provider.displayName} could not complete the OAuth token exchange because the provider was unavailable. Try Connect again later.`,
+      "oauth_provider_unavailable",
+      details,
+    )
+  }
+
+  return new OAuthTokenExchangeError(
+    `${input.provider.displayName} rejected the OAuth token exchange. Try Connect again; if it still fails, contact support with the diagnostic reference.`,
+    "oauth_token_exchange_failed",
+    details,
+  )
+}
 
 export function parseOAuthTokenResponse(value: unknown): TokenResponse {
   const parsed = tokenResponseSchema.safeParse(value)
   if (!parsed.success) {
-    throw new OAuthTokenExchangeError("Token endpoint returned an invalid OAuth response.")
+    throw new OAuthTokenExchangeError(
+      "The token endpoint returned an invalid OAuth response.",
+      "oauth_token_response_invalid",
+    )
   }
   return parsed.data
 }
@@ -171,7 +291,10 @@ export function parseOAuthTokenResponse(value: unknown): TokenResponse {
 async function readBoundedTokenResponse(response: Response): Promise<string> {
   const declaredBytes = Number(response.headers.get("content-length"))
   if (Number.isFinite(declaredBytes) && declaredBytes > TOKEN_RESPONSE_MAX_BYTES) {
-    throw new OAuthTokenExchangeError("Token endpoint response exceeded the allowed size.")
+    throw new OAuthTokenExchangeError(
+      "The token endpoint response exceeded the allowed size.",
+      "oauth_token_response_oversized",
+    )
   }
   if (!response.body) return ""
 
@@ -184,7 +307,10 @@ async function readBoundedTokenResponse(response: Response): Promise<string> {
     totalBytes += result.value.byteLength
     if (totalBytes > TOKEN_RESPONSE_MAX_BYTES) {
       await reader.cancel()
-      throw new OAuthTokenExchangeError("Token endpoint response exceeded the allowed size.")
+      throw new OAuthTokenExchangeError(
+        "The token endpoint response exceeded the allowed size.",
+        "oauth_token_response_oversized",
+      )
     }
     chunks.push(result.value)
   }
@@ -218,17 +344,24 @@ export function resolveOAuthEndpointUrl(input: {
   }
 }
 
-async function postTokenRequest(tokenUrl: string, params: URLSearchParams): Promise<TokenResponse> {
+async function postTokenRequest(input: {
+  provider: NativeOAuthProviderConfig
+  tokenUrl: string
+  params: URLSearchParams
+}): Promise<TokenResponse> {
   let response: Response
   try {
-    response = await fetch(tokenUrl, {
+    response = await fetch(input.tokenUrl, {
       method: "POST",
       headers: { "content-type": "application/x-www-form-urlencoded" },
-      body: params,
+      body: input.params,
       signal: AbortSignal.timeout(TOKEN_REQUEST_TIMEOUT_MS),
     })
   } catch {
-    throw new OAuthTokenExchangeError("Token endpoint could not be reached before the request deadline.")
+    throw new OAuthTokenExchangeError(
+      `${input.provider.displayName} token endpoint could not be reached before the request deadline.`,
+      "oauth_token_endpoint_unreachable",
+    )
   }
 
   const text = await readBoundedTokenResponse(response)
@@ -239,7 +372,11 @@ async function postTokenRequest(tokenUrl: string, params: URLSearchParams): Prom
     body = text
   }
   if (!response.ok) {
-    throw new OAuthTokenExchangeError(`Token request failed with status ${response.status}.`)
+    throw oauthTokenExchangeErrorFromResponse({
+      provider: input.provider,
+      status: response.status,
+      body,
+    })
   }
   return parseOAuthTokenResponse(body)
 }
@@ -259,7 +396,11 @@ export async function exchangeCodeForTokens(input: {
   })
   if (input.client.clientSecret) params.set("client_secret", input.client.clientSecret)
   if (input.provider.usesPkce && input.codeVerifier) params.set("code_verifier", input.codeVerifier)
-  return postTokenRequest(resolveOAuthEndpointUrl({ provider: input.provider, client: input.client, endpoint: "token" }), params)
+  return postTokenRequest({
+    provider: input.provider,
+    tokenUrl: resolveOAuthEndpointUrl({ provider: input.provider, client: input.client, endpoint: "token" }),
+    params,
+  })
 }
 
 async function refreshTokens(input: {
@@ -273,7 +414,11 @@ async function refreshTokens(input: {
     client_id: input.client.clientId,
   })
   if (input.client.clientSecret) params.set("client_secret", input.client.clientSecret)
-  return postTokenRequest(resolveOAuthEndpointUrl({ provider: input.provider, client: input.client, endpoint: "token" }), params)
+  return postTokenRequest({
+    provider: input.provider,
+    tokenUrl: resolveOAuthEndpointUrl({ provider: input.provider, client: input.client, endpoint: "token" }),
+    params,
+  })
 }
 
 /**

--- a/ee/apps/den-api/src/routes/org/oauth-providers.ts
+++ b/ee/apps/den-api/src/routes/org/oauth-providers.ts
@@ -16,6 +16,7 @@ import {
   createPkcePair,
   exchangeCodeForTokens,
   OAuthClientConfigurationError,
+  OAuthTokenExchangeError,
   resolvePublicOrigin,
   verifyOAuthStateToken,
 } from "../../capability-sources/generic-oauth.js"
@@ -449,7 +450,38 @@ export function registerOAuthProviderRoutes<T extends { Variables: OrgRouteVaria
           }), 400)
         }
       } catch (error) {
-        return c.html(connectCallbackPage({ ok: false, name: provider.displayName, message: error instanceof Error ? error.message : String(error) }), 400)
+        const requestId = c.get("requestId")
+        if (error instanceof OAuthTokenExchangeError) {
+          console.error("native_oauth_connect_callback_token_exchange_failed", {
+            requestId,
+            organizationId: statePayload.organizationId,
+            providerId,
+            phase: error.phase,
+            code: error.code,
+            ...error.details,
+          })
+          return c.html(connectCallbackPage({
+            ok: false,
+            name: provider.displayName,
+            message: error.message,
+            referenceId: requestId,
+          }), 400)
+        }
+
+        console.error("native_oauth_connect_callback_failed", {
+          requestId,
+          organizationId: statePayload.organizationId,
+          providerId,
+          phase: "AUTH_TOKEN_ACQUISITION",
+          code: "oauth_callback_failed",
+          errorName: error instanceof Error ? error.name : "UnknownError",
+        })
+        return c.html(connectCallbackPage({
+          ok: false,
+          name: provider.displayName,
+          message: "OpenWork could not finish the OAuth connection. Try Connect again; if it still fails, contact support with the diagnostic reference.",
+          referenceId: requestId,
+        }), 400)
       }
 
       return c.html(connectCallbackPage({ ok: true, name: provider.displayName }))

--- a/ee/apps/den-api/test/generic-oauth-token-response.test.ts
+++ b/ee/apps/den-api/test/generic-oauth-token-response.test.ts
@@ -33,4 +33,92 @@ describe("OAuth token response validation", () => {
       expect(() => oauth.parseOAuthTokenResponse(response)).toThrow(oauth.OAuthTokenExchangeError)
     }
   })
+
+  test("classifies Microsoft's invalid secret response without exposing the provider body", () => {
+    const error = oauth.oauthTokenExchangeErrorFromResponse({
+      provider: {
+        providerId: "microsoft-365",
+        displayName: "Microsoft 365",
+        authorizeUrl: "https://login.microsoftonline.test/authorize",
+        tokenUrl: "https://login.microsoftonline.test/token",
+        websiteUrl: "https://microsoft.test",
+        defaultScopes: ["openid"],
+        usesPkce: true,
+      },
+      status: 401,
+      body: {
+        error: "invalid_client",
+        error_description: "AADSTS7000215: invalid client secret value client_secret=must-not-escape",
+        error_codes: [7_000_215],
+        trace_id: "020c20ed-efd1-4399-af27-4c3593de1c00",
+        correlation_id: "6bb6c186-4672-4d6c-bc1d-970fb858d536",
+        timestamp: "2026-07-13 00:47:25Z",
+      },
+    })
+
+    expect(error.code).toBe("oauth_invalid_client_secret")
+    expect(error.phase).toBe("AUTH_TOKEN_ACQUISITION")
+    expect(error.details).toEqual({
+      httpStatus: 401,
+      providerOAuthError: "invalid_client",
+      providerErrorCode: 7_000_215,
+      providerTraceId: "020c20ed-efd1-4399-af27-4c3593de1c00",
+      providerCorrelationId: "6bb6c186-4672-4d6c-bc1d-970fb858d536",
+      providerTimestamp: "2026-07-13 00:47:25Z",
+    })
+    expect(error.message).toContain("AADSTS7000215")
+    expect(error.message).toContain("replace the client secret value")
+    expect(error.message).not.toContain("must-not-escape")
+    expect(JSON.stringify(error.details)).not.toContain("must-not-escape")
+  })
+
+  test("classifies a ServiceNow-style invalid client without claiming unverified provider wording", () => {
+    const error = oauth.oauthTokenExchangeErrorFromResponse({
+      provider: {
+        providerId: "servicenow-development",
+        displayName: "ServiceNow",
+        authorizeUrl: "https://servicenow.test/oauth_auth.do",
+        tokenUrl: "https://servicenow.test/oauth_token.do",
+        websiteUrl: "https://servicenow.test",
+        defaultScopes: ["mcp_server"],
+        usesPkce: true,
+      },
+      status: 401,
+      body: {
+        error: "invalid_client",
+        error_description: "client_secret=must-not-escape",
+      },
+    })
+
+    expect(error.code).toBe("oauth_invalid_client")
+    expect(error.details).toEqual({
+      httpStatus: 401,
+      providerOAuthError: "invalid_client",
+    })
+    expect(error.message).toContain("ServiceNow rejected the OAuth client credentials")
+    expect(error.message).toContain("verify the client ID and client secret value")
+    expect(error.message).not.toContain("must-not-escape")
+  })
+
+  test("redacts unknown and malformed provider errors", () => {
+    const provider = {
+      providerId: "unknown-provider",
+      displayName: "Unknown Provider",
+      authorizeUrl: "https://provider.test/authorize",
+      tokenUrl: "https://provider.test/token",
+      websiteUrl: "https://provider.test",
+      defaultScopes: ["openid"],
+      usesPkce: true,
+    }
+
+    for (const body of [
+      { error: "custom_secret_failure", error_description: "access_token=must-not-escape" },
+      "client_secret=must-not-escape",
+    ]) {
+      const error = oauth.oauthTokenExchangeErrorFromResponse({ provider, status: 400, body })
+      expect(error.code).toBe("oauth_token_exchange_failed")
+      expect(error.message).not.toContain("must-not-escape")
+      expect(JSON.stringify(error.details)).not.toContain("must-not-escape")
+    }
+  })
 })

--- a/ee/apps/den-api/test/generic-oauth-token-response.test.ts
+++ b/ee/apps/den-api/test/generic-oauth-token-response.test.ts
@@ -50,9 +50,9 @@ describe("OAuth token response validation", () => {
         error: "invalid_client",
         error_description: "AADSTS7000215: invalid client secret value client_secret=must-not-escape",
         error_codes: [7_000_215],
-        trace_id: "020c20ed-efd1-4399-af27-4c3593de1c00",
-        correlation_id: "6bb6c186-4672-4d6c-bc1d-970fb858d536",
-        timestamp: "2026-07-13 00:47:25Z",
+        trace_id: "00000000-0000-4000-8000-000000000001",
+        correlation_id: "00000000-0000-4000-8000-000000000002",
+        timestamp: "2030-01-02 03:04:05Z",
       },
     })
 
@@ -62,9 +62,9 @@ describe("OAuth token response validation", () => {
       httpStatus: 401,
       providerOAuthError: "invalid_client",
       providerErrorCode: 7_000_215,
-      providerTraceId: "020c20ed-efd1-4399-af27-4c3593de1c00",
-      providerCorrelationId: "6bb6c186-4672-4d6c-bc1d-970fb858d536",
-      providerTimestamp: "2026-07-13 00:47:25Z",
+      providerTraceId: "00000000-0000-4000-8000-000000000001",
+      providerCorrelationId: "00000000-0000-4000-8000-000000000002",
+      providerTimestamp: "2030-01-02 03:04:05Z",
     })
     expect(error.message).toContain("AADSTS7000215")
     expect(error.message).toContain("replace the client secret value")

--- a/ee/apps/den-api/test/microsoft-365-provider-scopes.test.ts
+++ b/ee/apps/den-api/test/microsoft-365-provider-scopes.test.ts
@@ -146,9 +146,9 @@ describe("Microsoft 365 native provider", () => {
         error: "invalid_client",
         error_description: "AADSTS7000215: client_secret=microsoft-client-secret-value",
         error_codes: [7_000_215],
-        trace_id: "020c20ed-efd1-4399-af27-4c3593de1c00",
-        correlation_id: "6bb6c186-4672-4d6c-bc1d-970fb858d536",
-        timestamp: "2026-07-13 00:47:25Z",
+        trace_id: "00000000-0000-4000-8000-000000000001",
+        correlation_id: "00000000-0000-4000-8000-000000000002",
+        timestamp: "2030-01-02 03:04:05Z",
       }), {
         status: 401,
         headers: { "content-type": "application/json" },
@@ -168,7 +168,7 @@ describe("Microsoft 365 native provider", () => {
       expect(error).toBeInstanceOf(oauth.OAuthTokenExchangeError)
       if (!(error instanceof oauth.OAuthTokenExchangeError)) throw error
       expect(error.code).toBe("oauth_invalid_client_secret")
-      expect(error.details.providerTraceId).toBe("020c20ed-efd1-4399-af27-4c3593de1c00")
+      expect(error.details.providerTraceId).toBe("00000000-0000-4000-8000-000000000001")
       expect(error.message).toContain("AADSTS7000215")
       expect(error.message).not.toContain("microsoft-client-secret-value")
     }

--- a/ee/apps/den-api/test/microsoft-365-provider-scopes.test.ts
+++ b/ee/apps/den-api/test/microsoft-365-provider-scopes.test.ts
@@ -1,5 +1,5 @@
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
-import { beforeAll, describe, expect, test } from "bun:test"
+import { afterEach, beforeAll, describe, expect, test } from "bun:test"
 import type { OrgOAuthClientRow } from "../src/capability-sources/oauth-credentials.js"
 
 function seedRequiredEnv() {
@@ -12,11 +12,16 @@ function seedRequiredEnv() {
 
 let registry: typeof import("../src/capability-sources/provider-registry.js")
 let oauth: typeof import("../src/capability-sources/generic-oauth.js")
+const originalFetch = globalThis.fetch
 
 beforeAll(async () => {
   seedRequiredEnv()
   registry = await import("../src/capability-sources/provider-registry.js")
   oauth = await import("../src/capability-sources/generic-oauth.js")
+})
+
+afterEach(() => {
+  globalThis.fetch = originalFetch
 })
 
 function microsoft365Provider() {
@@ -120,5 +125,57 @@ describe("Microsoft 365 native provider", () => {
       redirectUri: "https://cloud.openwork.so/v1/oauth-providers/microsoft-365/connect/callback",
       codeChallenge: "pkce-challenge",
     })).toThrow("requires a valid tenant ID")
+  })
+
+  test("preserves Microsoft's safe invalid-secret evidence through the real token request", async () => {
+    const client: OrgOAuthClientRow = {
+      id: createDenTypeId("orgOAuthClient"),
+      organizationId: createDenTypeId("organization"),
+      providerId: "microsoft-365",
+      clientId: "microsoft-client-id",
+      clientSecret: "microsoft-client-secret-value",
+      extra: { tenantId: "12345678-1234-1234-1234-123456789abc" },
+      createdByOrgMembershipId: createDenTypeId("member"),
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+    }
+    let postedBody = ""
+    globalThis.fetch = async (_request, init) => {
+      if (init?.body instanceof URLSearchParams) postedBody = init.body.toString()
+      return new Response(JSON.stringify({
+        error: "invalid_client",
+        error_description: "AADSTS7000215: client_secret=microsoft-client-secret-value",
+        error_codes: [7_000_215],
+        trace_id: "020c20ed-efd1-4399-af27-4c3593de1c00",
+        correlation_id: "6bb6c186-4672-4d6c-bc1d-970fb858d536",
+        timestamp: "2026-07-13 00:47:25Z",
+      }), {
+        status: 401,
+        headers: { "content-type": "application/json" },
+      })
+    }
+
+    try {
+      await oauth.exchangeCodeForTokens({
+        provider: microsoft365Provider(),
+        client,
+        code: "authorization-code",
+        redirectUri: "http://localhost:31585/v1/oauth-providers/microsoft-365/connect/callback",
+        codeVerifier: "pkce-verifier",
+      })
+      throw new Error("Expected token exchange to fail")
+    } catch (error) {
+      expect(error).toBeInstanceOf(oauth.OAuthTokenExchangeError)
+      if (!(error instanceof oauth.OAuthTokenExchangeError)) throw error
+      expect(error.code).toBe("oauth_invalid_client_secret")
+      expect(error.details.providerTraceId).toBe("020c20ed-efd1-4399-af27-4c3593de1c00")
+      expect(error.message).toContain("AADSTS7000215")
+      expect(error.message).not.toContain("microsoft-client-secret-value")
+    }
+
+    const posted = new URLSearchParams(postedBody)
+    expect(posted.get("client_secret")).toBe("microsoft-client-secret-value")
+    expect(posted.get("code_verifier")).toBe("pkce-verifier")
+    expect(posted.get("redirect_uri")).toBe("http://localhost:31585/v1/oauth-providers/microsoft-365/connect/callback")
   })
 })


### PR DESCRIPTION
> [!IMPORTANT]
> This is a focused native-provider OAuth fix. It covers Den's Microsoft 365/Google-style OAuth callback and token exchange. It does **not** implement or claim conformance with Microsoft Work IQ, Microsoft Enterprise MCP, Agent 365, or ServiceNow MCP.

## Relationship to the package-first MCP work

The **Microsoft 365 quick add** is a native OAuth/Microsoft Graph integration. This PR improves and verifies that native path; it does not use `@openwork/enterprise-mcp-client`, even when `DEN_ENABLE_ENTERPRISE_MCP_CLIENT=true` is enabled. That flag selects Den's external remote MCP runtime only.

The longer-term direction is to place reusable remote MCP behavior behind package contracts. Migrating this native Microsoft 365 provider is outside the current MCP package scope and must not be inferred from the successful connection below.

## Managerial summary

We set out to make an administrator's failed Connect attempt identify the actual source of failure.

During a real Microsoft 365 development connection, Microsoft sign-in and consent succeeded and the browser returned to Den. Den then displayed only:

> Token request failed with status 401.

That message proved the HTTP status but hid the actionable provider diagnosis. A controlled replay of the same token request showed:

- OAuth error: `invalid_client`;
- Entra code: `AADSTS7000215`;
- first failed stage: OAuth token acquisition/client authentication;
- root cause: Den held a different client-secret value from the active Azure app registration.

The tenant ID, client ID, application state, web redirect type, exact `localhost` callback, authorization code return, and PKCE request were all correct. Replacing the stored secret **value** and starting a fresh authorization completed the connection.

## Before and after

| Before | Added here | Administrator outcome |
| --- | --- | --- |
| Every non-2xx token response became `Token request failed with status <n>`. | A bounded OAuth error parser retains safe error codes and provider correlation fields. | The administrator knows which OAuth sub-step failed and who should act. |
| The callback reflected an arbitrary thrown error string into HTML. | Callback messages come from an allowlisted safe mapping; unknown provider bodies are redacted. | Secrets, tokens, codes, and hostile provider text cannot be echoed into the browser. |
| Native OAuth callback failures were not logged with a stable stage/reference. | Structured callback logging includes Den request ID, provider ID, `AUTH_TOKEN_ACQUISITION`, stable code, status, and safe provider trace/correlation fields. | Support can correlate the browser reference with provider and Den evidence. |
| `invalid_client`, `invalid_grant`, invalid scope, denied consent, and provider availability looked alike. | Each maps to distinct safe wording and remediation. | Replacing credentials is no longer suggested for a stale authorization code or provider outage. |

For the verified Microsoft failure, the callback now says:

> Microsoft rejected the client secret during OAuth token exchange (AADSTS7000215). An organization administrator should replace the client secret value and try Connect again.

The page also displays the Den diagnostic reference.

## Root-cause record

| Field | Verified result |
| --- | --- |
| Plane | Den-managed native provider OAuth |
| Topology | Browser → Microsoft Entra authorization → Den callback/token exchange → Microsoft Graph capability routes |
| Highest passing state | Authorization callback returned with valid code/state |
| First failed state | `AUTH_TOKEN_ACQUISITION` / client authentication |
| Provider evidence | HTTP 401, `invalid_client`, `AADSTS7000215`, trace/correlation/timestamp |
| Fix owner | Organization administrator / Azure app registration |
| Remediation | Save the current client-secret **value**, not Secret ID; start a fresh Connect |
| Recovery verification | Real development connection succeeded after credential correction |

## Safe diagnostic contract

Retained when valid and bounded:

- HTTP status;
- OAuth error identifier;
- first numeric provider error code;
- provider trace ID, correlation ID, and timestamp;
- stable OpenWork error code and OAuth phase.

Never retained or returned:

- client secret;
- authorization code;
- access or refresh token;
- PKCE verifier;
- raw provider error description;
- arbitrary response fields or response body.

Microsoft `AADSTS7000215` receives provider-specific wording because it was verified against the development tenant and is a stable Entra error class. A ServiceNow-style `invalid_client` remains provider-generic unless an approved ServiceNow test instance supplies authoritative wire evidence.

## Validation

Passed on Node 24 / pnpm 11.4 / Bun:

```text
pnpm --filter @openwork-ee/den-db build
pnpm --filter @openwork-ee/den-api exec bun test \
  test/generic-oauth-token-response.test.ts \
  test/microsoft-365-provider-scopes.test.ts
pnpm --filter @openwork-ee/den-api exec tsc --noEmit
git diff --check
```

Result: **10 tests passed / 41 expectations**.

Coverage includes:

- the real token-request path sends client secret, PKCE verifier, and exact `localhost` callback;
- Microsoft `AADSTS7000215` classification and correlation evidence;
- generic/ServiceNow-style `invalid_client` classification without invented provider wording;
- unknown/malformed provider-body redaction;
- successful token response regression;
- tenant-scoped Microsoft authority and delegated read-only scope regression.

## Reviewer boundaries

Verified:

- real Microsoft authorization and callback;
- real invalid-secret token response;
- real recovery after correcting the secret;
- safe parser and request-path regression tests.

Not verified by this PR:

- live ServiceNow;
- Microsoft Work IQ, Microsoft Enterprise MCP, or Agent 365;
- token refresh after long-lived production use;
- customer proxy, CA, Conditional Access, licensing, or sovereign-cloud behavior;
- provider operations beyond successful native Microsoft account connection.

Those belong to the enterprise mock/client and approved-tenant verification tracks, not this focused fix.
