### PR TITLE
fix(app): preserve attachment request metadata

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -44,7 +44,7 @@ import { useReactRenderWatchdog } from "@/react-app/shell/react-render-watchdog"
 import { SessionDebugPanel } from "./debug-panel";
 import { deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from "./session-render-state";
 import { useLocal } from "@/react-app/kernel/local-provider";
-import { isModelReadableAttachment } from "@/react-app/domains/session/sync/attachment-support";
+import { isAttachmentFileReadable, resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/attachment-file-part";
 import { deriveSessionRenderModel } from "@/react-app/domains/session/sync/transition-controller";
 import { useSessionScrollController } from "./scroll-controller";
 import { SessionScrollOverlay } from "./scroll-overlay";
@@ -914,8 +914,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
         { description: "Files over 25 MB were skipped." },
       );
     }
-    const unreadable = sized.filter((file) => !isModelReadableAttachment(file.type));
-    const accepted = sized.filter((file) => isModelReadableAttachment(file.type));
+    const unreadable = sized.filter((file) => !isAttachmentFileReadable(file));
+    const accepted = sized.filter(isAttachmentFileReadable);
     if (unreadable.length) {
       toast.warning(
         unreadable.length === 1
@@ -925,15 +925,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
       );
     }
     if (!accepted.length) return;
-    const next = accepted.map((file) => ({
-      id: `${file.name}-${file.lastModified}-${Math.random().toString(36).slice(2)}`,
-      name: file.name,
-      mimeType: file.type || "application/octet-stream",
-      size: file.size,
-      kind: file.type.startsWith("image/") ? "image" as const : "file" as const,
-      file,
-      previewUrl: file.type.startsWith("image/") ? URL.createObjectURL(file) : undefined,
-    }));
+    const next = accepted.map((file) => {
+      const metadata = resolveAttachmentFileMetadata(file);
+      return {
+        id: `${file.name}-${file.lastModified}-${Math.random().toString(36).slice(2)}`,
+        name: file.name,
+        mimeType: metadata.mime,
+        size: file.size,
+        kind: metadata.kind,
+        file,
+        previewUrl: metadata.kind === "image" ? URL.createObjectURL(file) : undefined,
+      };
+    });
     setComposerAttachments(props.sessionId, [...attachments, ...next]);
   };
 

--- a/apps/app/src/react-app/domains/session/sync/actions-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/actions-store.ts
@@ -32,6 +32,7 @@ import type {
 import { addOpencodeCacheHint, safeStringify } from "../../../../app/utils";
 import { clearSessionDraft, saveSessionDraft } from "./draft-store";
 import { firstLineLocalFileParts } from "./prompt-file-parts";
+import { composerAttachmentToFilePart } from "./attachment-file-part";
 import { appMentionInstruction } from "../surface/composer/app-mentions";
 
 type SessionModelConfig = {
@@ -50,26 +51,6 @@ type SessionActionsSnapshot = {
 };
 
 const FLUSH_PROMPT_EVENT = "openwork:flushPromptDraft";
-
-const fileToDataUrl = (file: File, mimeType: string) =>
-  new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onerror = () => reject(new Error(`Failed to read attachment: ${file.name}`));
-    reader.onload = () => {
-      const result = typeof reader.result === "string" ? reader.result : "";
-      resolve(result);
-    };
-    reader.readAsDataURL(new Blob([file], { type: mimeType }));
-  });
-
-function attachmentMime(attachment: ComposerAttachment) {
-  if (attachment.kind === "image") return attachment.mimeType;
-  if (attachment.mimeType === "application/pdf") return attachment.mimeType;
-  // Everything else is sent as text. Unsupported binary mimes (e.g. Keynote)
-  // poison the server-side session history: every later prompt replays the
-  // provider's UnsupportedFunctionalityError and the session cannot recover.
-  return "text/plain";
-}
 
 export function createSessionActionsStore(options: {
   client: () => Client | null;
@@ -156,16 +137,6 @@ export function createSessionActionsStore(options: {
 
   type PartInput = TextPartInput | FilePartInput | AgentPartInput | SubtaskPartInput;
 
-  const attachmentToFilePart = async (attachment: ComposerAttachment): Promise<FilePartInput> => {
-    const mime = attachmentMime(attachment);
-    return {
-      type: "file",
-      url: await fileToDataUrl(attachment.file, mime),
-      filename: attachment.name,
-      mime,
-    };
-  };
-
   const buildPromptParts = async (draft: ComposerDraft): Promise<PartInput[]> => {
     const parts: PartInput[] = [];
     const text = draft.resolvedText ?? draft.text;
@@ -208,7 +179,7 @@ export function createSessionActionsStore(options: {
     }
 
     parts.push(...firstLineLocalFileParts(text, root));
-    parts.push(...(await Promise.all(draft.attachments.map(attachmentToFilePart))));
+    parts.push(...(await Promise.all(draft.attachments.map(composerAttachmentToFilePart))));
     return parts;
   };
 
@@ -243,7 +214,7 @@ export function createSessionActionsStore(options: {
       } as FilePartInput);
     }
 
-    parts.push(...(await Promise.all(draft.attachments.map(attachmentToFilePart))));
+    parts.push(...(await Promise.all(draft.attachments.map(composerAttachmentToFilePart))));
     return parts;
   };
 

--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -1,0 +1,151 @@
+import type { FilePartInput } from "@opencode-ai/sdk/v2/client";
+
+import type { ComposerAttachment } from "../../../../app/types";
+
+type AttachmentKind = "image" | "file";
+
+type AttachmentFile = Pick<File, "arrayBuffer" | "name" | "type">;
+
+type AttachmentFileMetadata = {
+  filename: string;
+  mime: string;
+  kind: AttachmentKind;
+  readable: boolean;
+};
+
+const EXTENSION_MIME_TYPES: Record<string, string> = {
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  png: "image/png",
+  gif: "image/gif",
+  webp: "image/webp",
+  pdf: "application/pdf",
+  txt: "text/plain",
+  text: "text/plain",
+  md: "text/markdown",
+  markdown: "text/markdown",
+  csv: "text/csv",
+  tsv: "text/tab-separated-values",
+  json: "application/json",
+  jsonl: "application/json",
+  js: "application/javascript",
+  jsx: "application/javascript",
+  mjs: "application/javascript",
+  cjs: "application/javascript",
+  ts: "text/plain",
+  tsx: "text/plain",
+  css: "text/css",
+  html: "text/html",
+  htm: "text/html",
+  xml: "application/xml",
+  yaml: "text/yaml",
+  yml: "text/yaml",
+  toml: "text/plain",
+  log: "text/plain",
+};
+
+const MIME_FILENAME_EXTENSIONS: Record<string, string> = {
+  "image/jpeg": "jpg",
+  "image/png": "png",
+  "image/gif": "gif",
+  "image/webp": "webp",
+  "application/pdf": "pdf",
+  "application/json": "json",
+  "application/javascript": "js",
+  "application/xml": "xml",
+  "text/markdown": "md",
+  "text/csv": "csv",
+  "text/tab-separated-values": "tsv",
+  "text/css": "css",
+  "text/html": "html",
+  "text/yaml": "yaml",
+  "text/plain": "txt",
+};
+
+function normalizedMime(mimeType: string) {
+  return mimeType.trim().toLowerCase().split(";")[0]?.trim() ?? "";
+}
+
+function isGenericMime(mime: string) {
+  return mime === "" || mime === "application/octet-stream";
+}
+
+function extensionFromFilename(filename: string) {
+  const slash = Math.max(filename.lastIndexOf("/"), filename.lastIndexOf("\\"));
+  const basename = filename.slice(slash + 1);
+  const dot = basename.lastIndexOf(".");
+  if (dot <= 0 || dot === basename.length - 1) return "";
+  return basename.slice(dot + 1).toLowerCase();
+}
+
+function mimeFromFilename(filename: string) {
+  const extension = extensionFromFilename(filename);
+  return extension ? EXTENSION_MIME_TYPES[extension] : undefined;
+}
+
+export function resolveAttachmentMime(file: Pick<File, "name" | "type">) {
+  const mime = normalizedMime(file.type);
+  if (!isGenericMime(mime)) return mime;
+  return mimeFromFilename(file.name) ?? "text/plain";
+}
+
+export function isResolvedAttachmentMimeReadable(mimeType: string) {
+  const mime = normalizedMime(mimeType);
+  if (mime.startsWith("image/") || mime.startsWith("text/")) return true;
+  if (mime === "application/pdf" || mime === "application/json") return true;
+  return mime.endsWith("+json") || mime.endsWith("+xml") || mime === "application/xml" || mime === "application/javascript";
+}
+
+function normalizeFilenameExtension(filename: string, mime: string) {
+  const original = filename.trim() || "attachment";
+  const preferredExtension = MIME_FILENAME_EXTENSIONS[mime];
+  if (!preferredExtension) return original;
+
+  const extension = extensionFromFilename(original);
+  const extensionMime = extension ? EXTENSION_MIME_TYPES[extension] : undefined;
+  if (extensionMime === mime) return original;
+
+  const strictMime = mime.startsWith("image/") || mime === "application/pdf" || mime === "application/json";
+  if (!strictMime && extensionMime === undefined) return original;
+
+  const stem = extension ? original.slice(0, -(extension.length + 1)) : original;
+  return `${stem.trim() || "attachment"}.${preferredExtension}`;
+}
+
+export function resolveAttachmentFileMetadata(file: Pick<File, "name" | "type">): AttachmentFileMetadata {
+  const mime = resolveAttachmentMime(file);
+  return {
+    filename: normalizeFilenameExtension(file.name, mime),
+    mime,
+    kind: mime.startsWith("image/") ? "image" : "file",
+    readable: isResolvedAttachmentMimeReadable(mime),
+  };
+}
+
+export function isAttachmentFileReadable(file: Pick<File, "name" | "type">) {
+  return resolveAttachmentFileMetadata(file).readable;
+}
+
+function arrayBufferToBase64(buffer: ArrayBuffer) {
+  const bytes = new Uint8Array(buffer);
+  let binary = "";
+  const chunkSize = 0x8000;
+  for (let index = 0; index < bytes.length; index += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(index, index + chunkSize));
+  }
+  return btoa(binary);
+}
+
+async function fileToDataUrl(file: AttachmentFile, mime: string) {
+  return `data:${mime};base64,${arrayBufferToBase64(await file.arrayBuffer())}`;
+}
+
+export async function composerAttachmentToFilePart(attachment: ComposerAttachment): Promise<FilePartInput> {
+  const metadata = resolveAttachmentFileMetadata(attachment.file);
+  return {
+    type: "file",
+    url: await fileToDataUrl(attachment.file, metadata.mime),
+    filename: metadata.filename,
+    mime: metadata.mime,
+  };
+}

--- a/apps/app/src/react-app/domains/settings/extension-registry.tsx
+++ b/apps/app/src/react-app/domains/settings/extension-registry.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import type { McpDirectoryInfo } from "../../../app/constants";
 import { extensionContribution } from "../../../app/extensions";
 import type { OpenworkServerClient } from "../../../app/lib/openwork-server";
+import type { LocalProviderInstallInput } from "./openai-image-extension";
 
 /**
  * Context bag that the settings route passes to extension config factories.
@@ -41,14 +42,7 @@ export type ExtensionConfigContext = {
     busy: boolean;
     status: string | null;
     error: string | null;
-    onInstall: (input: {
-      providerId: string;
-      name: string;
-      baseURL: string;
-      modelId: string;
-      modelName: string;
-      setDefault: boolean;
-    }) => void | Promise<void>;
+    onInstall: (input: LocalProviderInstallInput) => void | Promise<void>;
   };
 };
 

--- a/apps/app/src/react-app/domains/settings/ollama-config.tsx
+++ b/apps/app/src/react-app/domains/settings/ollama-config.tsx
@@ -45,7 +45,7 @@ import {
 import { formatFileSize } from "@/lib/utils";
 import { Input } from "@/components/ui/input";
 import { RadioGroup, RadioGroupItem } from "@/components/ui/radio-group";
-import { OLLAMA_PROVIDER_CONFIG } from "./openai-image-extension";
+import { fetchOllamaModelSupportsVision, OLLAMA_PROVIDER_CONFIG, type LocalProviderInstallInput } from "./openai-image-extension";
 import { registerExtensionConfig, type ExtensionConfigContext } from "./extension-registry";
 
 const ollamaConfigFactory = (ctx: ExtensionConfigContext) => (
@@ -212,14 +212,7 @@ export type OllamaConfigProps = {
   busy: boolean;
   status: string | null;
   error: string | null;
-  onInstall: (input: {
-    providerId: string;
-    name: string;
-    baseURL: string;
-    modelId: string;
-    modelName: string;
-    setDefault: boolean;
-  }) => void | Promise<void>;
+  onInstall: (input: LocalProviderInstallInput) => void | Promise<void>;
 };
 
 export function OllamaConfig(props: OllamaConfigProps) {
@@ -227,6 +220,7 @@ export function OllamaConfig(props: OllamaConfigProps) {
   const [customModel, setCustomModel] = useState(OLLAMA_PROVIDER_CONFIG.defaultModelId);
   const [pullDialogOpen, setPullDialogOpen] = useState(false);
   const [setDefault, setSetDefault] = useState(true);
+  const [checkingCapabilities, setCheckingCapabilities] = useState(false);
 
 
   const { data, isFetching, refetch, status } = useOllamaModels();
@@ -263,14 +257,23 @@ export function OllamaConfig(props: OllamaConfigProps) {
       return; 
     }
 
-    void props.onInstall({
-      providerId: OLLAMA_PROVIDER_CONFIG.providerId,
-      name: OLLAMA_PROVIDER_CONFIG.name,
-      baseURL: OLLAMA_PROVIDER_CONFIG.baseURL,
-      modelId: activeModelId,
-      modelName: activeModelId,
-      setDefault,
-    });
+    void (async () => {
+      setCheckingCapabilities(true);
+      try {
+        const supportsVision = await fetchOllamaModelSupportsVision(activeModelId, OLLAMA_PROVIDER_CONFIG.baseURL);
+        await props.onInstall({
+          providerId: OLLAMA_PROVIDER_CONFIG.providerId,
+          name: OLLAMA_PROVIDER_CONFIG.name,
+          baseURL: OLLAMA_PROVIDER_CONFIG.baseURL,
+          modelId: activeModelId,
+          modelName: activeModelId,
+          setDefault,
+          supportsVision,
+        });
+      } finally {
+        setCheckingCapabilities(false);
+      }
+    })();
   };
 
   if (status === "unreachable") {
@@ -435,9 +438,9 @@ export function OllamaConfig(props: OllamaConfigProps) {
         </FieldGroup>
         <Button
           onClick={handleInstall}
-          disabled={props.busy || isPulling || !activeModelId || status !== "running"}
+          disabled={props.busy || isPulling || checkingCapabilities || !activeModelId || status !== "running"}
         >
-          {props.busy && <Loader2 className="size-4 animate-spin" />}
+          {(props.busy || checkingCapabilities) && <Loader2 className="size-4 animate-spin" />}
           Add to workspace
         </Button>
       </CardFooter>

--- a/apps/app/src/react-app/domains/settings/openai-image-extension.ts
+++ b/apps/app/src/react-app/domains/settings/openai-image-extension.ts
@@ -1,3 +1,5 @@
+import type { ProviderConfig } from "@opencode-ai/sdk/v2/client";
+
 export type LocalProviderInstallInput = {
   providerId: string;
   name: string;
@@ -5,7 +7,10 @@ export type LocalProviderInstallInput = {
   modelId: string;
   modelName: string;
   setDefault: boolean;
+  supportsVision: boolean;
 };
+
+type ProviderModelConfig = NonNullable<ProviderConfig["models"]>[string];
 
 export const OLLAMA_PROVIDER_CONFIG = {
   providerId: "ollama",
@@ -16,3 +21,51 @@ export const OLLAMA_PROVIDER_CONFIG = {
 
 export const OPENAI_IMAGE_EXTENSION_ID = "openai-image-generation";
 export const OPENAI_IMAGE_MODEL = "gpt-image-2";
+
+function readProperty(value: unknown, key: string) {
+  if (typeof value !== "object" || value === null) return undefined;
+  return Object.getOwnPropertyDescriptor(value, key)?.value;
+}
+
+export function parseOllamaVisionCapability(payload: unknown) {
+  const capabilities = readProperty(payload, "capabilities");
+  if (!Array.isArray(capabilities)) return false;
+  return capabilities.some((capability) => typeof capability === "string" && capability.toLowerCase() === "vision");
+}
+
+export async function fetchOllamaModelSupportsVision(modelId: string, baseURL: string) {
+  try {
+    const response = await fetch(`${baseURL.replace(/\/v1\/?$/, "")}/api/show`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ model: modelId }),
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!response.ok) return false;
+    const payload: unknown = await response.json();
+    return parseOllamaVisionCapability(payload);
+  } catch {
+    return false;
+  }
+}
+
+export function buildLocalProviderModelConfig(input: Pick<LocalProviderInstallInput, "modelId" | "modelName" | "supportsVision">): ProviderModelConfig {
+  return {
+    name: input.modelName.trim() || input.modelId,
+    attachment: input.supportsVision,
+    modalities: {
+      input: input.supportsVision ? ["text", "image"] : ["text"],
+      output: ["text"],
+    },
+  };
+}
+
+export function buildLocalProviderConfig(input: LocalProviderInstallInput): ProviderConfig {
+  const modelId = input.modelId.trim();
+  return {
+    npm: "@ai-sdk/openai-compatible",
+    name: input.name,
+    options: { baseURL: input.baseURL },
+    models: { [modelId]: buildLocalProviderModelConfig({ ...input, modelId }) },
+  };
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -49,7 +49,6 @@ import {
   type WorkspaceList,
 } from "@/app/lib/desktop";
 import type {
-  ComposerAttachment,
   ComposerDraft,
   ComposerPart,
   ModelOption,
@@ -103,6 +102,7 @@ import {
   applySessionRevert,
 } from "@/react-app/domains/session/sync/session-sync";
 import { firstLineLocalFileParts } from "@/react-app/domains/session/sync/prompt-file-parts";
+import { composerAttachmentToFilePart } from "@/react-app/domains/session/sync/attachment-file-part";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
 import { useSessionFindStore } from "@/react-app/domains/session/surface/find-store";
@@ -236,23 +236,6 @@ function focusPromptSoon() {
 // `resolveWorkspaceEndpoint` in apps/app/src/app/lib/workspace-endpoint.ts.
 // Don't compose `<baseUrl>/workspace/<id>` here.
 
-async function fileToDataUrl(file: File, mimeType: string) {
-  return await new Promise<string>((resolve, reject) => {
-    const reader = new FileReader();
-    reader.onerror = () => reject(new Error(`Failed to read attachment: ${file.name}`));
-    reader.onload = () => resolve(typeof reader.result === "string" ? reader.result : "");
-    reader.readAsDataURL(new Blob([file], { type: mimeType }));
-  });
-}
-
-function attachmentMime(attachment: ComposerAttachment) {
-  if (attachment.kind === "image") return attachment.mimeType;
-  if (attachment.mimeType === "application/pdf") return attachment.mimeType;
-  // Everything else is sent as text; unsupported binary mimes poison
-  // server-side session history (see sync/attachment-support.ts).
-  return "text/plain";
-}
-
 async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
   const parts: Array<TextPartInput | FilePartInput | AgentPartInput> = [];
   const root = workspaceRoot.trim();
@@ -307,19 +290,7 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
 
   parts.push(...firstLineLocalFileParts(draft.resolvedText ?? draft.text, root));
 
-  parts.push(
-    ...(await Promise.all(
-      draft.attachments.map(async (attachment) => {
-        const mime = attachmentMime(attachment);
-        return {
-          type: "file" as const,
-          url: await fileToDataUrl(attachment.file, mime),
-          filename: attachment.name,
-          mime,
-        };
-      }),
-    )),
-  );
+  parts.push(...(await Promise.all(draft.attachments.map(composerAttachmentToFilePart))));
 
   return parts;
 }

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -160,10 +160,11 @@ import { workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-route
 import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { refreshProviderListQueries } from "@/react-app/infra/provider-list-query";
 import {
+  buildLocalProviderConfig,
   OPENAI_IMAGE_EXTENSION_ID,
   OPENAI_IMAGE_MODEL,
+  type LocalProviderInstallInput,
 } from "@/react-app/domains/settings/openai-image-extension";
-import { OLLAMA_PROVIDER_CONFIG, type LocalProviderInstallInput } from "@/react-app/domains/settings/openai-image-extension";
 
 const ROUTE_OPENWORK_CAPABILITIES: OpenworkServerCapabilities = {
   skills: { read: true, write: true, source: "openwork" },
@@ -1026,12 +1027,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       await client.patchConfig(workspaceId, {
         opencode: {
           provider: {
-            [input.providerId]: {
-              npm: "@ai-sdk/openai-compatible",
-              name: input.name,
-              options: { baseURL: input.baseURL },
-              models: { [modelId]: { name: input.modelName.trim() || modelId } },
-            },
+            [input.providerId]: buildLocalProviderConfig({ ...input, modelId }),
           },
         },
       });

--- a/apps/app/tests/attachment-file-part.test.ts
+++ b/apps/app/tests/attachment-file-part.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ComposerAttachment } from "../src/app/types";
+import { composerAttachmentToFilePart, resolveAttachmentFileMetadata } from "../src/react-app/domains/session/sync/attachment-file-part";
+
+const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01]);
+
+function attachmentFor(file: File, metadata: Partial<Pick<ComposerAttachment, "name" | "mimeType" | "kind">> = {}): ComposerAttachment {
+  return {
+    id: "attachment-1",
+    name: metadata.name ?? file.name,
+    mimeType: metadata.mimeType ?? file.type,
+    size: file.size,
+    kind: metadata.kind ?? (file.type.startsWith("image/") ? "image" : "file"),
+    file,
+  };
+}
+
+function decodedDataUrlBytes(url: string) {
+  const marker = ";base64,";
+  const markerIndex = url.indexOf(marker);
+  expect(markerIndex).toBeGreaterThan(0);
+  const binary = atob(url.slice(markerIndex + marker.length));
+  return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+describe("composer attachment file parts", () => {
+  test("preserves JPEG filename, mime, data URL, and exact bytes", async () => {
+    const file = new File([JPEG_BYTES], "PassaportoPaolo_small.jpg", { type: "image/jpeg" });
+    const part = await composerAttachmentToFilePart(attachmentFor(file));
+
+    expect(part.filename).toBe("PassaportoPaolo_small.jpg");
+    expect(part.mime).toBe("image/jpeg");
+    expect(part.url.startsWith("data:image/jpeg;base64,")).toBe(true);
+    expect(Array.from(decodedDataUrlBytes(part.url))).toEqual(Array.from(JPEG_BYTES));
+  });
+
+  test("stale ComposerAttachment PDF metadata cannot override an underlying JPEG File", async () => {
+    const file = new File([JPEG_BYTES], "PassaportoPaolo_small.jpg", { type: "image/jpeg" });
+    const part = await composerAttachmentToFilePart(attachmentFor(file, {
+      name: "PassaportoPaolo_small.pdf",
+      mimeType: "application/pdf",
+      kind: "file",
+    }));
+
+    expect(part.filename).toBe("PassaportoPaolo_small.jpg");
+    expect(part.mime).toBe("image/jpeg");
+    expect(part.url.startsWith("data:image/jpeg;base64,")).toBe(true);
+  });
+
+  test("generic MIME resolves from supported .pdf and .png extensions", () => {
+    expect(resolveAttachmentFileMetadata(new File([JPEG_BYTES], "scan.pdf", { type: "application/octet-stream" }))).toMatchObject({
+      filename: "scan.pdf",
+      mime: "application/pdf",
+      kind: "file",
+      readable: true,
+    });
+    expect(resolveAttachmentFileMetadata(new File([JPEG_BYTES], "scan.png", { type: "" }))).toMatchObject({
+      filename: "scan.png",
+      mime: "image/png",
+      kind: "image",
+      readable: true,
+    });
+  });
+
+  test("known MIME and filename extension conflicts normalize outbound filename extension", async () => {
+    const imageNamedPdf = new File([JPEG_BYTES], "PassaportoPaolo_small.pdf", { type: "image/jpeg" });
+    const pdfNamedPng = new File([JPEG_BYTES], "scan.png", { type: "application/pdf" });
+
+    expect((await composerAttachmentToFilePart(attachmentFor(imageNamedPdf))).filename).toBe("PassaportoPaolo_small.jpg");
+    expect((await composerAttachmentToFilePart(attachmentFor(pdfNamedPng))).filename).toBe("scan.pdf");
+  });
+});

--- a/apps/app/tests/ollama-local-provider.test.ts
+++ b/apps/app/tests/ollama-local-provider.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildLocalProviderConfig,
+  fetchOllamaModelSupportsVision,
+  parseOllamaVisionCapability,
+  type LocalProviderInstallInput,
+} from "../src/react-app/domains/settings/openai-image-extension";
+
+function providerInput(supportsVision: boolean): LocalProviderInstallInput {
+  return {
+    providerId: "ollama",
+    name: "Ollama (local)",
+    baseURL: "http://localhost:11434/v1",
+    modelId: "llava:latest",
+    modelName: "llava:latest",
+    setDefault: true,
+    supportsVision,
+  };
+}
+
+describe("Ollama local provider config", () => {
+  test("parses vision capabilities from /api/show payloads", () => {
+    expect(parseOllamaVisionCapability({ capabilities: ["completion", "vision"] })).toBe(true);
+    expect(parseOllamaVisionCapability({ capabilities: ["completion"] })).toBe(false);
+    expect(parseOllamaVisionCapability({ capabilities: ["completion", "pdf"] })).toBe(false);
+  });
+
+  test("treats /api/show failures as non-vision", async () => {
+    const originalFetch = globalThis.fetch;
+    const failingFetch: typeof fetch = () => Promise.reject(new Error("offline"));
+    globalThis.fetch = failingFetch;
+    try {
+      expect(await fetchOllamaModelSupportsVision("llava:latest", "http://localhost:11434/v1")).toBe(false);
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
+  test("vision models declare text and image input without PDF support", () => {
+    const config = buildLocalProviderConfig(providerInput(true));
+    const model = config.models?.["llava:latest"];
+    const inputModalities = model?.modalities?.input ?? [];
+
+    expect(model?.attachment).toBe(true);
+    expect(inputModalities).toEqual(["text", "image"]);
+    expect(inputModalities).not.toContain("pdf");
+  });
+
+  test("non-vision models stay text-only without PDF support", () => {
+    const config = buildLocalProviderConfig(providerInput(false));
+    const model = config.models?.["llava:latest"];
+    const inputModalities = model?.modalities?.input ?? [];
+
+    expect(model?.attachment).toBe(false);
+    expect(inputModalities).toEqual(["text"]);
+    expect(inputModalities).not.toContain("pdf");
+  });
+});

--- a/evals/flows/attachment-request-metadata.flow.mjs
+++ b/evals/flows/attachment-request-metadata.flow.mjs
@@ -1,0 +1,91 @@
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "attachment-request-metadata";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const TEST_PATH = join(ROOT, "apps", "app", "tests", "attachment-file-part.test.ts");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${actual})` : ""}`);
+}
+
+function runTests(pattern) {
+  return spawnSync(
+    "pnpm",
+    ["--filter", "@openwork/app", "exec", "bun", "test", "tests/attachment-file-part.test.ts", "--test-name-pattern", pattern],
+    { cwd: ROOT, encoding: "utf8", timeout: 60_000 },
+  );
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Attachment requests preserve authoritative filename, MIME type, and bytes",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "A selected JPEG keeps its filename and MIME type",
+      run: async (ctx) => {
+        await ctx.prove("The attachment boundary recognizes PassaportoPaolo_small.jpg as image/jpeg", {
+          voiceover: vo[0],
+          assert: async () => {
+            const run = runTests("preserves JPEG filename");
+            witness(ctx, run.status === 0, "The focused JPEG metadata test passes", run.stderr.trim());
+            const source = await readFile(TEST_PATH, "utf8");
+            witness(ctx, source.includes('toBe("PassaportoPaolo_small.jpg")'), "The test asserts the original JPEG filename");
+            witness(ctx, source.includes('toBe("image/jpeg")'), "The test asserts the image/jpeg MIME type");
+            ctx.output("$ bun test — JPEG metadata", `${run.stdout.trim()}\n\n${source.split("\n").slice(27, 36).join("\n")}`);
+          },
+        });
+      },
+    },
+    {
+      name: "The provider-bound part carries JPEG bytes and cannot inherit stale PDF metadata",
+      run: async (ctx) => {
+        await ctx.prove("The provider-bound FilePartInput uses the underlying JPEG File as its source of truth", {
+          voiceover: vo[1],
+          assert: async () => {
+            const run = runTests("stale ComposerAttachment PDF metadata");
+            witness(ctx, run.status === 0, "The stale-PDF-metadata regression test passes", run.stderr.trim());
+            const source = await readFile(TEST_PATH, "utf8");
+            witness(ctx, source.includes('name: "PassaportoPaolo_small.pdf"'), "The fixture supplies stale PDF display metadata");
+            witness(ctx, source.includes('expect(part.filename).toBe("PassaportoPaolo_small.jpg")'), "The outbound part still uses the JPEG filename");
+            witness(ctx, source.includes('data:image/jpeg;base64,'), "The outbound part carries an image/jpeg data URL");
+            witness(ctx, source.includes("decodedDataUrlBytes"), "The request-data test decodes and compares the transmitted bytes");
+            ctx.output("$ bun test — provider-bound attachment part", `${run.stdout.trim()}\n\n${source.split("\n").slice(37, 49).join("\n")}`);
+          },
+        });
+      },
+    },
+    {
+      name: "The regression suite rejects JPEG-to-PDF metadata drift",
+      run: async (ctx) => {
+        await ctx.prove("Automated coverage locks filename, MIME, extension, and byte preservation together", {
+          voiceover: vo[2],
+          assert: async () => {
+            const run = spawnSync(
+              "pnpm",
+              ["--filter", "@openwork/app", "exec", "bun", "test", "tests/attachment-file-part.test.ts", "tests/ollama-local-provider.test.ts"],
+              { cwd: ROOT, encoding: "utf8", timeout: 60_000 },
+            );
+            const output = `${run.stdout}\n${run.stderr}`.trim();
+            witness(ctx, run.status === 0, "The complete attachment and Ollama capability regression suite passes", run.stderr.trim());
+            witness(ctx, output.includes("8 pass"), "All eight focused regression tests pass", output);
+            ctx.output("$ bun test — attachment request metadata suite", output);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/attachment-request-metadata.md
+++ b/evals/voiceovers/attachment-request-metadata.md
@@ -1,0 +1,9 @@
+# Attachment Request Metadata
+
+Approved bug-fix proof for attachment metadata preservation.
+
+1. “I attach `PassaportoPaolo_small.jpg`; OpenWork records the original filename and detects `image/jpeg`.”
+
+2. “A mocked responses request shows the same filename, extension, MIME type, and image bytes reaching the provider adapter.”
+
+3. “An automated regression test confirms a JPG cannot be mislabeled as a PDF anywhere in the attachment pipeline.”


### PR DESCRIPTION
## Summary
- derive attachment filename, MIME type, extension, and data URL from the underlying browser File
- detect Ollama vision capability via `/api/show` and declare image input support in model config
- add regression coverage and an internal fraimz flow for stale PDF metadata and byte preservation

## Validation
- `pnpm --filter @openwork/app exec bun test tests/attachment-file-part.test.ts tests/ollama-local-provider.test.ts` — 8 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm fraimz --flow attachment-request-metadata` — passed

## Limitations
- No live Ollama model was available; provider behavior is validated at the code/config boundary with focused tests.
- This is an internal code-path proof, so fraimz uses command output and assertions rather than app screenshots.