### PR TITLE
fix(app): prompt when selected model is unavailable

### DIFF
--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -35,12 +35,20 @@ import {
   openWorkModelsPromoChangedEvent,
 } from "../../cloud/openwork-models-promo";
 
+export const MODEL_PICKER_DEFAULT_SUBTITLE = "Select a model for this session.";
+export const MODEL_PICKER_UNAVAILABLE_SUBTITLE = "The model you were using is no longer available, please select a different model for this session.";
+
+export function resolveModelPickerSubtitle(subtitle: string | undefined) {
+  return subtitle ?? MODEL_PICKER_DEFAULT_SUBTITLE;
+}
+
 export type ModelPickerModalProps = {
   open: boolean;
   options: ModelOption[];
   disabledProviders?: string[];
   query: string;
   setQuery: (value: string) => void;
+  subtitle?: string;
   target: "default" | "session";
   current: ModelRef;
   onSelect: (model: ModelRef) => void;
@@ -215,7 +223,7 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
         <DialogHeader>
           <DialogTitle>Models</DialogTitle>
           <DialogDescription>
-            Select a model for this session.
+            {resolveModelPickerSubtitle(props.subtitle)}
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -134,7 +134,7 @@ import {
   testRemoteWorkspaceConnection,
 } from "@/react-app/domains/workspace/remote-workspace-diagnostics";
 import { useShareWorkspaceState } from "@/react-app/domains/workspace/share-workspace-state";
-import { ModelPickerModal } from "@/react-app/domains/session/modals/model-picker-modal";
+import { ModelPickerModal, MODEL_PICKER_UNAVAILABLE_SUBTITLE } from "@/react-app/domains/session/modals/model-picker-modal";
 import { CommandPalette, type PaletteItem, type SessionGroupOption, type SessionOption as PaletteSessionOption } from "./command-palette";
 import { SessionSearchDialog } from "./session-search-dialog";
 import type { SessionMessageFetcher } from "@/react-app/domains/session/search/session-search";
@@ -230,6 +230,17 @@ function focusPromptSoon() {
   if (typeof window === "undefined") return;
   const focus = () => window.dispatchEvent(new Event("openwork:focusPrompt"));
   [0, 80, 240, 600].forEach((delay) => window.setTimeout(focus, delay));
+}
+
+const EVAL_UNAVAILABLE_PROVIDER_ID = "eval-unavailable-provider";
+
+function nextEvalUnavailableModel(current: ModelRef | null | undefined) {
+  return {
+    providerID: EVAL_UNAVAILABLE_PROVIDER_ID,
+    modelID: current?.providerID === EVAL_UNAVAILABLE_PROVIDER_ID && current.modelID === "eval-unavailable-model-a"
+      ? "eval-unavailable-model-b"
+      : "eval-unavailable-model-a",
+  } satisfies ModelRef;
 }
 
 // All workspace-scoped server URLs/clients/tokens come from
@@ -644,6 +655,25 @@ export function SessionRoute() {
         )
       ),
   );
+  const selectedModelUnavailableKey = selectedModelUnavailable && local.prefs.defaultModel
+    ? `${local.prefs.defaultModel.providerID}:${local.prefs.defaultModel.modelID}`
+    : null;
+  const autoOpenedUnavailableModelRef = useRef<string | null>(null);
+
+  useEffect(() => {
+    if (!selectedModelUnavailableKey) {
+      autoOpenedUnavailableModelRef.current = null;
+      return;
+    }
+    if (autoOpenedUnavailableModelRef.current === selectedModelUnavailableKey) return;
+
+    autoOpenedUnavailableModelRef.current = selectedModelUnavailableKey;
+    modelPicker.setQuery("");
+    modelPicker.setRecentProviderIds(new Set());
+    modelPicker.setCompactOpen(false);
+    modelPicker.setOpen(true);
+  }, [modelPicker.setCompactOpen, modelPicker.setOpen, modelPicker.setQuery, modelPicker.setRecentProviderIds, selectedModelUnavailableKey]);
+
   const hasUsableModel = Boolean(local.prefs.defaultModel && !selectedModelUnavailable);
   const canCreateTask = Boolean(
     opencodeClient && selectedWorkspaceId && !loading && !selectedWorkspaceError && !selectedModelUnavailable,
@@ -1421,6 +1451,64 @@ export function SessionRoute() {
     openModelPicker: openModelPickerForControl,
     refreshRouteState,
   });
+
+  const seedUnavailableModelControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+    return {
+      id: "eval.model_not_available.seed",
+      label: "Seed an unavailable selected model",
+      description: "Dev-only eval hook that selects a missing model and returns an available model to recover with.",
+      sideEffect: "mutation",
+      disabled: !opencodeClient,
+      execute: async () => {
+        if (!opencodeClient) return { ok: false, error: "OpenCode client is not connected." };
+
+        const providerList = await ensureProviderListQuery(getReactQueryClient(), {
+          client: opencodeClient,
+          baseUrl: opencodeBaseUrl,
+          directory: selectedWorkspaceRoot || undefined,
+          force: true,
+        });
+        const filteredProviderList = filterProviderList(providerList, disabledProviderIds);
+        const availableProvider = getConnectedProviderItems(filteredProviderList)
+          .filter((provider) => !isDesktopProviderBlocked({
+            providerId: provider.id,
+            checkRestriction: checkDesktopRestriction,
+          }))
+          .find((provider) => Object.keys(provider.models ?? {}).length > 0);
+        const availableModelId = availableProvider ? Object.keys(availableProvider.models ?? {})[0] : undefined;
+        const availableModel = availableProvider && availableModelId
+          ? availableProvider.models[availableModelId]
+          : undefined;
+
+        if (!availableProvider || !availableModelId || !availableModel) {
+          return { ok: false, error: "No available connected model found for eval recovery." };
+        }
+
+        const unavailableModel = nextEvalUnavailableModel(local.prefs.defaultModel);
+        modelPicker.setQuery("");
+        modelPicker.setRecentProviderIds(new Set());
+        local.setPrefs((previous) => ({
+          ...previous,
+          defaultModel: unavailableModel,
+          modelVariant: null,
+        }));
+
+        return {
+          unavailableModel,
+          availableModel: {
+            providerID: availableProvider.id,
+            providerName: availableProvider.name || availableProvider.id,
+            modelID: availableModelId,
+            title: availableModel.name || availableModelId,
+          },
+          sessionId: selectedSessionId,
+          workspaceId: selectedWorkspaceId,
+        };
+      },
+    };
+  }, [checkDesktopRestriction, disabledProviderIds, local, modelPicker.setQuery, modelPicker.setRecentProviderIds, opencodeBaseUrl, opencodeClient, selectedSessionId, selectedWorkspaceId, selectedWorkspaceRoot]);
+  useControlAction(seedUnavailableModelControlAction);
 
   const commandPaletteControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "command_palette.open",
@@ -2309,6 +2397,7 @@ export function SessionRoute() {
 
       query={modelPicker.query}
       setQuery={modelPicker.setQuery}
+      subtitle={selectedModelUnavailable ? MODEL_PICKER_UNAVAILABLE_SUBTITLE : undefined}
       target="default"
       current={local.prefs.defaultModel ?? ({ providerID: "", modelID: "" } satisfies ModelRef)}
       onSelect={(next: ModelRef) => {

--- a/apps/app/tests/model-picker-modal.test.ts
+++ b/apps/app/tests/model-picker-modal.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  MODEL_PICKER_DEFAULT_SUBTITLE,
+  MODEL_PICKER_UNAVAILABLE_SUBTITLE,
+  resolveModelPickerSubtitle,
+} from "../src/react-app/domains/session/modals/model-picker-modal";
+
+describe("model picker subtitle", () => {
+  test("keeps the normal session subtitle by default", () => {
+    expect(resolveModelPickerSubtitle(undefined)).toBe(MODEL_PICKER_DEFAULT_SUBTITLE);
+  });
+
+  test("supports the unavailable-model recovery subtitle", () => {
+    expect(resolveModelPickerSubtitle(MODEL_PICKER_UNAVAILABLE_SUBTITLE)).toBe(
+      "The model you were using is no longer available, please select a different model for this session.",
+    );
+  });
+});

--- a/evals/flows/model-not-available-block.flow.mjs
+++ b/evals/flows/model-not-available-block.flow.mjs
@@ -1,0 +1,211 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/model-not-available-block.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("model-not-available-block");
+
+const GUIDANCE = "The model you were using is no longer available, please select a different model for this session.";
+const WARNING = "Model no longer available";
+const MODEL_DIALOG = '[data-slot="dialog-content"]';
+const MODEL_SEARCH_INPUT = 'input[placeholder="Search providers and models..."]';
+const CONTINUE_TEXT = "Model recovery can continue.";
+
+let seededRecovery = null;
+
+function quoted(value) {
+  return JSON.stringify(value);
+}
+
+function requireSeededRecovery(ctx) {
+  ctx.assert(seededRecovery?.availableModel?.modelID, "The eval seed action did not return an available model.");
+  return seededRecovery;
+}
+
+async function waitForControl(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API",
+  });
+}
+
+async function ensureSession(ctx) {
+  await waitForControl(ctx);
+  const inSession = await ctx.eval(`window.__openworkControl.snapshot().route.includes("/session/")`);
+  if (inSession) return;
+
+  await ctx.waitFor(
+    `(() => {
+      const action = window.__openworkControl.listActions().find((item) => item.id === "session.create_task");
+      return action && !action.disabled;
+    })()`,
+    { timeoutMs: 45_000, label: "session.create_task enabled" },
+  );
+  await ctx.control("session.create_task");
+  await ctx.waitFor(`window.__openworkControl.snapshot().route.includes("/session/")`, {
+    timeoutMs: 45_000,
+    label: "created session route",
+  });
+}
+
+async function seedUnavailableSelectedModel(ctx) {
+  await ctx.waitFor(
+    `window.__openworkControl.listActions().some((item) => item.id === "eval.model_not_available.seed" && !item.disabled)`,
+    { timeoutMs: 45_000, label: "unavailable model eval seed action" },
+  );
+  seededRecovery = await ctx.control("eval.model_not_available.seed");
+  const recovery = requireSeededRecovery(ctx);
+  ctx.log(`Seeded unavailable model: ${JSON.stringify(recovery.unavailableModel)}`);
+  ctx.log(`Available recovery model: ${JSON.stringify(recovery.availableModel)}`);
+  return recovery;
+}
+
+async function waitForModelsDialog(ctx) {
+  await ctx.waitFor(
+    `(() => {
+      const dialog = document.querySelector(${quoted(MODEL_DIALOG)});
+      return Boolean(dialog && dialog.innerText.includes("Models"));
+    })()`,
+    { timeoutMs: 30_000, label: "Models dialog" },
+  );
+}
+
+async function searchPicker(ctx, value) {
+  await waitForModelsDialog(ctx);
+  await ctx.fill(MODEL_SEARCH_INPUT, value);
+}
+
+async function pasteComposer(ctx, text) {
+  return ctx.eval(
+    `(() => {
+      const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
+        || document.querySelector('[contenteditable="true"]');
+      if (!editor) return { ok: false, reason: "composer not found" };
+      editor.focus();
+      const data = new DataTransfer();
+      data.setData("text/plain", ${quoted(text)});
+      editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+      return { ok: true };
+    })()`,
+  );
+}
+
+export default {
+  id: "model-not-available-block",
+  title: "Prompt for a replacement when a selected model disappears",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    await waitForControl(ctx);
+    const route = await ctx.eval(`window.__openworkControl.snapshot().route || ""`);
+    return route.startsWith("/welcome") || route.startsWith("/signin")
+      ? "Profile is not onboarded; this flow requires a workspace with a usable model."
+      : null;
+  },
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The active session can be put into the unavailable selected-model state", {
+          voiceover: vo[0],
+          action: async () => {
+            await ensureSession(ctx);
+            const recovery = await seedUnavailableSelectedModel(ctx);
+            await ctx.waitForText(WARNING, { timeoutMs: 30_000 });
+            await ctx.waitForText(recovery.unavailableModel.modelID, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const recovery = requireSeededRecovery(ctx);
+            await ctx.expectText(WARNING);
+            await ctx.expectText(recovery.unavailableModel.modelID);
+          },
+          screenshot: { name: "unavailable-selected-model", requireText: [WARNING] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The existing Models picker opens automatically for recovery", {
+          voiceover: vo[1],
+          action: async () => {
+            const recovery = requireSeededRecovery(ctx);
+            await waitForModelsDialog(ctx);
+            await searchPicker(ctx, recovery.availableModel.providerName);
+            await ctx.waitForText(recovery.availableModel.providerName, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Models");
+            await ctx.expectText("Done");
+          },
+          screenshot: { name: "models-picker-auto-open", requireText: ["Models", "Done"] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("The Models picker replaces its subtitle with exact unavailable-model guidance", {
+          voiceover: vo[2],
+          action: async () => {
+            const recovery = requireSeededRecovery(ctx);
+            await searchPicker(ctx, recovery.availableModel.modelID);
+            await ctx.waitForText(recovery.availableModel.modelID, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText(GUIDANCE);
+          },
+          screenshot: { name: "models-picker-recovery-guidance", requireText: [GUIDANCE] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Selecting the returned available model closes recovery and leaves the composer usable", {
+          voiceover: vo[3],
+          action: async () => {
+            const recovery = requireSeededRecovery(ctx);
+            await searchPicker(ctx, recovery.availableModel.modelID);
+            await ctx.waitFor(
+              `(() => {
+                const buttons = Array.from(document.querySelectorAll(${quoted(`${MODEL_DIALOG} button`)}));
+                const target = buttons.find((button) => {
+                  const text = button.innerText || button.textContent || "";
+                  return text.includes(${quoted(recovery.availableModel.modelID)}) && !button.disabled;
+                });
+                if (!target) return null;
+                target.scrollIntoView({ block: "center", inline: "nearest" });
+                target.click();
+                return target.textContent || true;
+              })()`,
+              { timeoutMs: 30_000, label: "available model row" },
+            );
+            await ctx.waitFor(`!document.body.innerText.includes(${quoted(GUIDANCE)})`, {
+              timeoutMs: 30_000,
+              label: "Models recovery dialog closed",
+            });
+            const pasted = await pasteComposer(ctx, CONTINUE_TEXT);
+            ctx.assert(pasted?.ok, `Composer was not ready: ${pasted?.reason ?? "unknown"}`);
+            await ctx.waitForText(CONTINUE_TEXT, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectNoText(GUIDANCE);
+            await ctx.expectNoText(WARNING);
+            await ctx.expectText(CONTINUE_TEXT);
+            const canRun = await ctx.eval(`(() => {
+              return Array.from(document.querySelectorAll("button")).some((button) => {
+                const text = (button.textContent || "").trim();
+                return text.includes("Run task") && !button.disabled;
+              });
+            })()`);
+            ctx.assert(canRun, "The composer Run task button was not enabled after selecting an available model.");
+          },
+          screenshot: {
+            name: "available-model-selected-composer-ready",
+            requireText: [CONTINUE_TEXT, "Run task"],
+            rejectText: [GUIDANCE, WARNING],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/model-not-available-block.md
+++ b/evals/voiceovers/model-not-available-block.md
@@ -1,0 +1,9 @@
+# model-not-available-block — Prompt for a replacement when a selected model disappears
+
+1. The session starts with a previously selected model that is no longer available.
+
+2. OpenWork automatically opens the existing **Models** picker instead of leaving the user to discover the inline error.
+
+3. The picker explains: **“The model you were using is no longer available, please select a different model for this session.”**
+
+4. The user selects an available model, the picker closes, and they can continue normally.


### PR DESCRIPTION
## Summary
- automatically open the existing Models picker when the selected model disappears
- show recovery guidance in the picker while preserving the default subtitle
- add focused coverage and a four-frame fraimz flow

## Validation
- `pnpm --filter @openwork/app exec bun test tests/model-picker-modal.test.ts` — passed (2 tests)
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm fraimz --flow model-not-available-block --cdp-url http://127.0.0.1:9826` — passed (4 frames + voice-over coverage)

Fraimz artifact: `evals/results/2026-07-13T10-56-27-102Z/fraimz.html`