### PR TITLE
fix(app): use reported model thinking levels

### DIFF
--- a/apps/app/src/app/lib/model-behavior.ts
+++ b/apps/app/src/app/lib/model-behavior.ts
@@ -33,20 +33,6 @@ function defaultBehaviorOption(): ModelBehaviorOption {
   };
 }
 
-const humanize = (value: string) => {
-  const cleaned = value.replace(/[_-]+/g, " ").replace(/\s+/g, " ").trim();
-  if (!cleaned) return value;
-  return cleaned
-    .split(" ")
-    .flatMap((word) => {
-      if (!word) return [];
-      if (/\d/.test(word) || word.length <= 3) return [word.toUpperCase()];
-      const lower = word.toLowerCase();
-      return [lower.charAt(0).toUpperCase() + lower.slice(1)];
-    })
-    .join(" ");
-};
-
 export const normalizeModelBehaviorValue = (value: string | null) => {
   if (!value) return null;
   const normalized = value.trim().toLowerCase();
@@ -143,21 +129,12 @@ const getBehaviorTitle = (
   return t("model_behavior.title_standard_generation");
 };
 
-const getVariantLabel = (providerID: string, key: string, providerName?: string | null) => {
-  const family = providerFamily(providerID, providerName);
-  if (key === "none") return t("model_behavior.label_fast");
-  if (key === "minimal") return t("model_behavior.label_quick");
-  if (key === "low") return t("model_behavior.label_light");
-  if (key === "medium") return t("model_behavior.label_balanced");
-  if (key === "high") return family === "anthropic" ? t("model_behavior.label_extended") : t("model_behavior.label_deep");
-  if (key === "xhigh" || key === "max") return t("model_behavior.label_maximum");
-  return humanize(key);
-};
+const getVariantLabel = (key: string) => key.charAt(0).toUpperCase() + key.slice(1);
 
 export const formatGenericBehaviorLabel = (value: string | null) => {
   const normalized = normalizeModelBehaviorValue(value);
   if (!normalized) return defaultBehaviorOption().label;
-  return getVariantLabel("generic", normalized);
+  return getVariantLabel(normalized);
 };
 
 const getVariantDescription = (
@@ -189,17 +166,14 @@ export const getModelBehaviorOptions = (
 ): ModelBehaviorOption[] => {
   const variantKeys = sortVariantKeys(getVariantKeys(model));
   if (!variantKeys.length) return [];
-  return [
-    defaultBehaviorOption(),
-    ...variantKeys.map((key) => {
-      const label = getVariantLabel(providerID, key, providerName);
-      return {
-        value: key,
-        label,
-        description: getVariantDescription(providerID, key, label, providerName),
-      };
-    }),
-  ];
+  return variantKeys.map((key) => {
+    const label = getVariantLabel(key);
+    return {
+      value: key,
+      label,
+      description: getVariantDescription(providerID, key, label, providerName),
+    };
+  });
 };
 
 const getDefaultModelBehaviorValue = (model: ProviderModel) =>

--- a/apps/app/tests/model-behavior.test.ts
+++ b/apps/app/tests/model-behavior.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, test } from "bun:test";
+
+import type { ProviderListItem } from "../src/app/types";
+import { getModelBehaviorOptions } from "../src/app/lib/model-behavior";
+
+type ProviderModel = ProviderListItem["models"][string];
+
+const model: ProviderModel = {
+  id: "test-model",
+  providerID: "openai",
+  api: {
+    id: "test-model",
+    url: "https://example.com",
+    npm: "@ai-sdk/openai-compatible",
+  },
+  name: "Test model",
+  capabilities: {
+    temperature: true,
+    reasoning: true,
+    attachment: false,
+    toolcall: true,
+    input: {
+      text: true,
+      audio: false,
+      image: false,
+      video: false,
+      pdf: false,
+    },
+    output: {
+      text: true,
+      audio: false,
+      image: false,
+      video: false,
+      pdf: false,
+    },
+    interleaved: false,
+  },
+  cost: {
+    input: 0,
+    output: 0,
+    cache: {
+      read: 0,
+      write: 0,
+    },
+  },
+  limit: {
+    context: 1,
+    output: 1,
+  },
+  status: "active",
+  options: {},
+  headers: {},
+  release_date: "2026-01-01",
+  variants: {
+    none: {},
+    low: {},
+    medium: {},
+    high: {},
+    xhigh: {},
+    max: {},
+  },
+};
+
+describe("model behavior options", () => {
+  test("uses only the raw effort values reported by the model", () => {
+    const options = getModelBehaviorOptions("openai", model);
+
+    expect(options.map(({ value, label }) => ({ value, label }))).toEqual([
+      { value: "none", label: "None" },
+      { value: "low", label: "Low" },
+      { value: "medium", label: "Medium" },
+      { value: "high", label: "High" },
+      { value: "xhigh", label: "Xhigh" },
+      { value: "max", label: "Max" },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- show the model-reported reasoning effort values instead of friendly aliases
- capitalize labels while preserving the underlying raw values
- remove the extra provider-default choice so only reported options are selectable
- add regression coverage for the supported effort list

## Tests
- `pnpm --filter @openwork/app exec bun test --isolate tests/model-behavior.test.ts` — passed
- `pnpm --filter @openwork/app typecheck` — passed

## Visual proof
Not captured: this worktree did not have a seeded provider/model UI state exposing reasoning variants. To reproduce, launch the desktop app with a reasoning model, open the model picker, and verify its Thinking choices are `None`, `Low`, `Medium`, `High`, `Xhigh`, and `Max` with no provider-default choice.