### PR TITLE
feat(inference): remove Fusion model

### DIFF
--- a/ee/apps/inference/src/models/openwork-models.json
+++ b/ee/apps/inference/src/models/openwork-models.json
@@ -1,33 +1,4 @@
 {
-  "openrouter/fusion": {
-    "id": "openrouter/fusion",
-    "name": "Fusion",
-    "family": "fusion",
-    "attachment": false,
-    "reasoning": false,
-    "tool_call": false,
-    "structured_output": false,
-    "temperature": false,
-    "release_date": "2026-06-13",
-    "last_updated": "2026-06-13",
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "limit": {
-      "context": 1000000,
-      "output": 128000
-    },
-    "cost": {
-      "input": 0,
-      "output": 0
-    }
-  },
   "z-ai/glm-5.2": {
     "id": "z-ai/glm-5.2",
     "name": "GLM-5.2",

--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -54,12 +54,6 @@ export const INFERENCE_WINDOW_DURATIONS_MS: Record<
 // For upstreamModel values, please get from models.dev/api.json provider = openrouter.models.id
 
 export const INFERENCE_MODEL_ALIASES = {
-  "openrouter/fusion": {
-    upstreamModel: "openrouter/fusion",
-    displayName: "OpenWork: Fusion",
-    enabled: true,
-    usageFactor: 1,
-  },
   "z-ai/glm-5.2": {
     upstreamModel: "z-ai/glm-5.2",
     displayName: "OpenWork: GLM-5.2",


### PR DESCRIPTION
## Summary
- remove the OpenRouter Fusion model from the OpenWork model catalog
- regenerate inference aliases so Fusion is no longer exposed

## Validation
- `node .opencode/skills/openwork-models/scripts/openwork-models.mjs validate` — passed (8 models)
- `node ee/apps/inference/scripts/build-models.mjs` — passed
- `git diff --check` — passed

## End-to-end proof
- Fraimz: Incomplete — this model-catalog change requires a running inference deployment to demonstrate through the end-user model picker; no deployment was started for this config-only PR.
- Reproduce: deploy the inference service from this branch, refresh the OpenWork model picker, and confirm Fusion is absent.