### PR TITLE
feat(invite): seamless invite-to-first-workflow through OpenWork Connect

### DIFF
--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -21,10 +21,12 @@ import {
   readDenSettings,
   resolveDenBaseUrls,
   writeDenSettings,
+  type DenExternalMcpConnection,
   type DenOrgLlmProvider,
   type DenOrgMarketplace,
   type DenOrgSummary,
 } from "@/app/lib/den";
+import type { DenOrgSkillCard } from "@/app/types";
 import { getDesktopBootstrapConfig } from "@/app/lib/desktop";
 import { usePlatform } from "../../kernel/platform";
 import { useBootState } from "../../shell/boot-state";
@@ -65,8 +67,10 @@ import {
   RadioGroupItem,
 } from "@/components/ui/radio-group"
 import { useOrgListWindow } from "./use-org-list-window";
+import { savePendingSessionPrompt } from "../session/sync/draft-store";
 
 const RELOAD_AFTER_ONBOARDING_KEY = "openwork.reloadAfterOrgOnboarding";
+export const INACTIVE_ACCOUNT_CHECK_PROMPT = "Show me which employee accounts have been inactive for 30 days.";
 
 function useDenClient() {
   const settings = useMemo(() => readDenSettings(), []);
@@ -129,17 +133,167 @@ const FIRST_TASK_IDEAS = [
   "Draft a short intro email about OpenWork I can send my team.",
 ];
 
+type SkillPromptSource = {
+  title: string;
+  description?: string | null;
+  skillText?: string | null;
+};
+
+export type FirstWorkflow = {
+  skill: DenOrgSkillCard;
+  connection: DenExternalMcpConnection | null;
+  suggestedPrompt: string | null;
+};
+
+const SUGGESTED_PROMPT_MARKERS = [
+  "suggested prompt:",
+  "first prompt:",
+  "starter prompt:",
+];
+const WORKFLOW_CONNECTION_HINTS = ["directory", "employee", "people", "hr"];
+
+function focusPromptSoon() {
+  [0, 120, 320, 600].forEach((delay) =>
+    window.setTimeout(() => window.dispatchEvent(new Event("openwork:focusPrompt")), delay),
+  );
+}
+
+function normalizeLookupText(value: string) {
+  return value.trim().toLowerCase().replace(/\s+/g, " ");
+}
+
+function skillLookupText(skill: SkillPromptSource) {
+  return normalizeLookupText([
+    skill.title,
+    skill.description ?? "",
+    skill.skillText ?? "",
+  ].join(" "));
+}
+
+function extractSuggestedPrompt(source: string | null | undefined) {
+  const raw = source?.trim() ?? "";
+  if (!raw) return null;
+  const lower = raw.toLowerCase();
+  for (const marker of SUGGESTED_PROMPT_MARKERS) {
+    const start = lower.indexOf(marker);
+    if (start === -1) continue;
+    const promptLine = raw.slice(start + marker.length).split(/\r?\n/)[0]?.trim() ?? "";
+    const prompt = promptLine.replace(/^["“”']+|["“”']+$/g, "").trim();
+    if (prompt) return prompt;
+  }
+  return null;
+}
+
+function isInactiveAccountSkill(skill: SkillPromptSource) {
+  return normalizeLookupText(skill.title) === "inactive account check";
+}
+
+export function resolveSuggestedPromptForSkill(skill: SkillPromptSource) {
+  const explicitPrompt = extractSuggestedPrompt(skill.description) ?? extractSuggestedPrompt(skill.skillText);
+  if (explicitPrompt) return explicitPrompt;
+
+  const lookup = skillLookupText(skill);
+  if (
+    isInactiveAccountSkill(skill) ||
+    (lookup.includes("inactive") &&
+      lookup.includes("account") &&
+      (lookup.includes("30") || lookup.includes("thirty")))
+  ) {
+    return INACTIVE_ACCOUNT_CHECK_PROMPT;
+  }
+
+  return null;
+}
+
+export function shouldAutoSelectOnlyOrganization(
+  orgs: DenOrgSummary[],
+  hasSelectedOrganization: boolean,
+) {
+  return !hasSelectedOrganization && orgs.length === 1 ? orgs[0] : null;
+}
+
+export function isMcpConnectionReady(connection: DenExternalMcpConnection) {
+  return connection.connectedForMe &&
+    connection.needsReconnect !== true &&
+    (connection.missingFeatures?.length ?? 0) === 0;
+}
+
+function connectionTokens(connection: DenExternalMcpConnection) {
+  return normalizeLookupText(connection.name)
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length > 3);
+}
+
+function selectFirstWorkflowSkill(skills: DenOrgSkillCard[]) {
+  return skills.find((skill) => resolveSuggestedPromptForSkill(skill)) ??
+    skills.find((skill) => skill.shared === "org") ??
+    skills[0] ??
+    null;
+}
+
+function selectFirstWorkflowConnection(
+  connections: DenExternalMcpConnection[],
+  skill: DenOrgSkillCard | null,
+) {
+  const readyConnections = connections.filter(isMcpConnectionReady);
+  const candidates = readyConnections.length > 0 ? readyConnections : connections;
+  if (!skill) return candidates[0] ?? null;
+
+  const skillText = skillLookupText(skill);
+  const matchingConnection = candidates.find((connection) =>
+    connectionTokens(connection).some((token) => skillText.includes(token)),
+  );
+  if (matchingConnection) return matchingConnection;
+
+  return candidates.find((connection) => {
+    const connectionName = normalizeLookupText(connection.name);
+    return WORKFLOW_CONNECTION_HINTS.some((hint) =>
+      connectionName.includes(hint) || skillText.includes(hint),
+    );
+  }) ?? candidates[0] ?? null;
+}
+
+export function resolveFirstWorkflow(
+  skills: DenOrgSkillCard[],
+  connections: DenExternalMcpConnection[],
+): FirstWorkflow | null {
+  const skill = selectFirstWorkflowSkill(skills);
+  if (!skill) return null;
+  return {
+    skill,
+    connection: selectFirstWorkflowConnection(connections, skill),
+    suggestedPrompt: resolveSuggestedPromptForSkill(skill),
+  };
+}
+
+function getFirstWorkflowCtaLabel(workflow: FirstWorkflow | null) {
+  if (!workflow?.suggestedPrompt) return null;
+  return isInactiveAccountSkill(workflow.skill)
+    ? "Start inactive account check"
+    : "Start first workflow";
+}
+
+function getMcpConnectionReadyLabel(connection: DenExternalMcpConnection) {
+  if (isMcpConnectionReady(connection)) {
+    return `${connection.name} connection ready`;
+  }
+  if (connection.connectedForMe) {
+    return `${connection.name} connection needs attention`;
+  }
+  return `${connection.name} connection needs your sign-in`;
+}
+
 function PreparedWorkspacePage({ prepared }: { prepared: PreparedBootstrapSummary }) {
   const navigate = useNavigate();
   const platform = usePlatform();
   const ownerClaim = prepared.claimLinks.find((link) => link.role === "owner") ?? prepared.claimLinks[0] ?? null;
+  const suggestedPrompt = resolveSuggestedPromptForSkill({ title: prepared.skillTitle });
+  const firstTaskIdeas = suggestedPrompt ? [suggestedPrompt] : FIRST_TASK_IDEAS;
 
   const startFirstTask = () => {
+    if (suggestedPrompt) savePendingSessionPrompt(suggestedPrompt);
     navigate("/session", { replace: true });
-    // Drop the cursor into the composer so the user can type their first task.
-    [0, 120, 320, 600].forEach((delay) =>
-      window.setTimeout(() => window.dispatchEvent(new Event("openwork:focusPrompt")), delay),
-    );
+    focusPromptSoon();
   };
 
   return (
@@ -181,7 +335,7 @@ function PreparedWorkspacePage({ prepared }: { prepared: PreparedBootstrapSummar
                 Try asking
               </div>
               <ul className="flex flex-col gap-2">
-                {FIRST_TASK_IDEAS.map((idea) => (
+                {firstTaskIdeas.map((idea) => (
                   <li
                     key={idea}
                     className="rounded-lg border border-border bg-background px-3 py-2 text-sm text-foreground"
@@ -193,7 +347,11 @@ function PreparedWorkspacePage({ prepared }: { prepared: PreparedBootstrapSummar
             </div>
 
             <Button size="lg" className="w-full" onClick={startFirstTask}>
-              Open your workspace and try a task
+              {suggestedPrompt
+                ? isInactiveAccountSkill({ title: prepared.skillTitle })
+                  ? "Start inactive account check"
+                  : "Start first workflow"
+                : "Open your workspace and try a task"}
               <ArrowRight data-icon="inline-end" />
             </Button>
 
@@ -239,6 +397,8 @@ export function OrgOnboardingPage() {
   const { markRouteReady } = useBootState();
   const prepared = usePreparedBootstrap();
   const [hasSelectedOrganization, setHasSelectedOrganization] = useState(false);
+  const [autoSelectError, setAutoSelectError] = useState<string | null>(null);
+  const [autoSelectRetry, setAutoSelectRetry] = useState(0);
   
   useEffect(() => {
     window.dispatchEvent(new CustomEvent(orgOnboardingVisibilityEvent, { detail: { visible: true } }));
@@ -262,6 +422,41 @@ export function OrgOnboardingPage() {
     enabled: Boolean(authToken),
     queryFn: () => denClient.listOrgs(),
   });
+  const onlyOrganization = data
+    ? shouldAutoSelectOnlyOrganization(data.orgs, hasSelectedOrganization)
+    : null;
+
+  useEffect(() => {
+    if (!authToken || !data || error || isPending || !onlyOrganization) return;
+    let cancelled = false;
+    setAutoSelectError(null);
+
+    void (async () => {
+      try {
+        if (data.activeOrgId !== onlyOrganization.id) {
+          await denClient.setActiveOrganization({ organizationId: onlyOrganization.id });
+        }
+        writeDenSettings({
+          ...settings,
+          authToken: authToken || null,
+          activeOrgId: onlyOrganization.id,
+          activeOrgSlug: onlyOrganization.slug,
+          activeOrgName: onlyOrganization.name,
+        });
+        if (!cancelled) setHasSelectedOrganization(true);
+      } catch (caught) {
+        if (!cancelled) {
+          setAutoSelectError(
+            caught instanceof Error ? caught.message : "Unable to connect your organization.",
+          );
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [authToken, autoSelectRetry, data, denClient, error, isPending, onlyOrganization, settings]);
 
   if (!authToken) {
     return prepared ? <PreparedWorkspacePage prepared={prepared} /> : null;
@@ -313,6 +508,16 @@ export function OrgOnboardingPage() {
     );
   }
 
+  if (onlyOrganization) {
+    return (
+      <AutoOrganizationConnectPage
+        org={onlyOrganization}
+        error={autoSelectError}
+        onRetry={() => setAutoSelectRetry((value) => value + 1)}
+      />
+    );
+  }
+
   if ((data?.orgs.length ?? 0) > 0 && !hasSelectedOrganization) {
     return (
       <OrganizationSelectionPage
@@ -327,6 +532,64 @@ export function OrgOnboardingPage() {
   }
 
   return <ResourceSelectionPage />;
+}
+
+function AutoOrganizationConnectPage({
+  org,
+  error,
+  onRetry,
+}: {
+  org: DenOrgSummary;
+  error: string | null;
+  onRetry: () => void;
+}) {
+  return (
+    <Page>
+      <PageBackground />
+      <PageTitlebarRegion />
+      <PageContainer>
+        <PageHeader>
+          <div className="mx-auto flex size-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-hover">
+            <BuildingOffice2Icon className="size-7 text-foreground" />
+          </div>
+          <PageTitle>{org.name}</PageTitle>
+          {error ? (
+            <Alert variant="destructive">
+              <CircleAlert />
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          ) : (
+            <PageDescription>
+              Connecting your OpenWork organization. No extra organization selection is needed.
+            </PageDescription>
+          )}
+        </PageHeader>
+        <PageContent>
+          {error ? (
+            <Empty className="h-fit flex-none">
+              <EmptyHeader>
+                <EmptyTitle>We couldn't connect this organization yet.</EmptyTitle>
+                <EmptyDescription>
+                  Retry the secure OpenWork Connect handoff for {org.name}.
+                </EmptyDescription>
+              </EmptyHeader>
+              <EmptyContent>
+                <Button type="button" onClick={onRetry}>
+                  Retry connection
+                  <ArrowRight data-icon="inline-end" />
+                </Button>
+              </EmptyContent>
+            </Empty>
+          ) : (
+            <PageLoading>
+              <PageLoadingSpinner />
+              <PageLoadingDescription>Connecting organization...</PageLoadingDescription>
+            </PageLoading>
+          )}
+        </PageContent>
+      </PageContainer>
+    </Page>
+  );
 }
 
 export function ResourceSelectionPage() {
@@ -354,7 +617,7 @@ export function ResourceSelectionPage() {
     }
   }, [authToken, navigate, orgId]);
 
-  const { providers, marketplaces, loading, error } = useQueries({
+  const { providers, marketplaces, skills, connections, loading, error } = useQueries({
     queries: [
       {
         queryKey: ["den-org-onboarding", settings.baseUrl, orgId, "providers"],
@@ -366,16 +629,34 @@ export function ResourceSelectionPage() {
         enabled: Boolean(authToken && orgId),
         queryFn: () => denClient.listOrgMarketplaces(orgId),
       },
+      {
+        queryKey: ["den-org-onboarding", settings.baseUrl, orgId, "skills"],
+        enabled: Boolean(authToken && orgId),
+        queryFn: () => denClient.listOrgSkills(orgId),
+      },
+      {
+        queryKey: ["den-org-onboarding", settings.baseUrl, orgId, "mcp-connections", "usable"],
+        enabled: Boolean(authToken && orgId),
+        queryFn: () => denClient.listMcpConnections(orgId, "usable"),
+      },
     ],
-    combine: ([providersQuery, marketplacesQuery]) => ({
+    combine: ([providersQuery, marketplacesQuery, skillsQuery, connectionsQuery]) => ({
       providers: providersQuery.data ?? [],
       marketplaces: marketplacesQuery.data ?? [],
-      loading: providersQuery.isPending || marketplacesQuery.isPending,
-      error: providersQuery.error?.message ?? marketplacesQuery.error?.message ?? null,
+      skills: skillsQuery.data ?? [],
+      connections: connectionsQuery.data ?? [],
+      loading: providersQuery.isPending || marketplacesQuery.isPending || skillsQuery.isPending || connectionsQuery.isPending,
+      error: providersQuery.error?.message ?? marketplacesQuery.error?.message ?? skillsQuery.error?.message ?? connectionsQuery.error?.message ?? null,
     }),
   });
 
-  const handleContinue = useCallback(() => {
+  const firstWorkflow = useMemo(
+    () => resolveFirstWorkflow(skills, connections),
+    [connections, skills],
+  );
+  const firstWorkflowCtaLabel = getFirstWorkflowCtaLabel(firstWorkflow);
+
+  const handleContinue = useCallback((prompt: string | null) => {
     // If user picked a default model, write it
     if (selectedDefault) {
       writeStoredDefaultModel({
@@ -391,11 +672,14 @@ export function ResourceSelectionPage() {
         window.localStorage.setItem(RELOAD_AFTER_ONBOARDING_KEY, "1");
       } catch {}
     }
+    if (prompt) savePendingSessionPrompt(prompt);
     navigate("/session", { replace: true });
+    focusPromptSoon();
   }, [navigate, providers, selectedDefault]);
 
   const totalModels = providers.reduce((sum, provider) => sum + provider.models.length, 0);
-  const hasResources = providers.length > 0 || marketplaces.length > 0;
+  const hasResources = providers.length > 0 || marketplaces.length > 0 || skills.length > 0 || connections.length > 0;
+  const showResourceAccordion = providers.length > 0 || marketplaces.length > 0 || (!firstWorkflow && (skills.length > 0 || connections.length > 0));
 
   return (
     <Page>
@@ -437,6 +721,10 @@ export function ResourceSelectionPage() {
               <CircleAlert />
               <AlertDescription>{error}</AlertDescription>
             </Alert>
+          ) : firstWorkflow ? (
+            <PageDescription>
+              OpenWork Connect has your administrator's first workflow ready — no local marketplace installation needed.
+            </PageDescription>
           ) : hasResources ? (
             <PageDescription>
               You have access to the following resources.
@@ -457,7 +745,7 @@ export function ResourceSelectionPage() {
               <EmptyHeader>
                 <EmptyTitle>No resources have been configured for this organization yet.</EmptyTitle>
                 <EmptyDescription>
-                  Add AI providers or marketplaces from the OpenWork Cloud dashboard.
+                  Add AI providers, skills, or OpenWork Connect resources from the Cloud dashboard.
                 </EmptyDescription>
               </EmptyHeader>
               <EmptyContent>
@@ -473,55 +761,90 @@ export function ResourceSelectionPage() {
           </PageContent>
         ) : (
           <PageContent>
-            <ScrollArea className="px-2.5">
-              <ScrollAreaViewport>
-                <Accordion
-                  multiple
-                  className="rounded-2xl border border-border bg-transparent shadow-none before:hidden"
-                >
-                  {/* AI Providers */}
-                  {providers.length > 0 ? (
-                    <Section
-                      icon={<CloudIcon className="size-5 text-foreground/60" />}
-                      title="AI Providers"
-                      description="Models you can use in your workspace."
-                      count={`${totalModels} model${totalModels === 1 ? "" : "s"}`}
-                    >
-                      {providers.map((provider) => (
-                        <ProviderCard
-                          key={provider.id}
-                          provider={provider}
-                          selectedDefault={selectedDefault}
-                          onSelectDefault={setSelectedDefault}
-                        />
-                      ))}
-                    </Section>
-                  ) : null}
+            <div className="flex w-full flex-col gap-4 px-2.5">
+              {firstWorkflow ? <FirstWorkflowCard workflow={firstWorkflow} /> : null}
 
-                  {/* Marketplaces */}
-                  {marketplaces.length > 0 ? (
-                    <Section
-                      icon={<Square3Stack3DIcon className="size-5 text-foreground/60" />}
-                      title="Marketplaces"
-                      description="App stores with extensions and plugins for your workspace."
-                      count={`${marketplaces.length} marketplace${marketplaces.length === 1 ? "" : "s"}`}
+              {showResourceAccordion ? (
+                <ScrollArea className="-mx-2.5 px-2.5">
+                  <ScrollAreaViewport>
+                    <Accordion
+                      multiple
+                      className="rounded-2xl border border-border bg-transparent shadow-none before:hidden"
                     >
-                      {marketplaces.map((mp) => (
-                        <MarketplaceCard key={mp.id} marketplace={mp} />
-                      ))}
-                    </Section>
-                  ) : null}
+                      {/* AI Providers */}
+                      {providers.length > 0 ? (
+                        <Section
+                          icon={<CloudIcon className="size-5 text-foreground/60" />}
+                          title="AI Providers"
+                          description="Models you can use in your workspace."
+                          count={`${totalModels} model${totalModels === 1 ? "" : "s"}`}
+                        >
+                          {providers.map((provider) => (
+                            <ProviderCard
+                              key={provider.id}
+                              provider={provider}
+                              selectedDefault={selectedDefault}
+                              onSelectDefault={setSelectedDefault}
+                            />
+                          ))}
+                        </Section>
+                      ) : null}
 
-                </Accordion>
-              </ScrollAreaViewport>
-            </ScrollArea>
-            {/* Selected default indicator */}
-            {selectedDefault ? (
-              <div className="rounded-xl border border-green-6/30 bg-green-2/30 px-4 py-3 text-center text-sm text-green-11">
-                <Check size={14} className="mr-1 inline" />
-                {selectedDefault.label} will be set as your default model.
-              </div>
-            ) : null}
+                      {/* Organization skills */}
+                      {!firstWorkflow && skills.length > 0 ? (
+                        <Section
+                          icon={<Sparkles className="size-5 text-foreground/60" />}
+                          title="Organization skills"
+                          description="Admin-provided skills available through OpenWork Connect."
+                          count={`${skills.length} skill${skills.length === 1 ? "" : "s"}`}
+                        >
+                          {skills.map((skill) => (
+                            <SkillCard key={skill.id} skill={skill} />
+                          ))}
+                        </Section>
+                      ) : null}
+
+                      {/* Secure connections */}
+                      {!firstWorkflow && connections.length > 0 ? (
+                        <Section
+                          icon={<CheckCircle2 className="size-5 text-foreground/60" />}
+                          title="Secure connections"
+                          description="Usable MCP connections shared through OpenWork Connect."
+                          count={`${connections.length} connection${connections.length === 1 ? "" : "s"}`}
+                        >
+                          {connections.map((connection) => (
+                            <ConnectionCard key={connection.id} connection={connection} />
+                          ))}
+                        </Section>
+                      ) : null}
+
+                      {/* Marketplaces */}
+                      {marketplaces.length > 0 ? (
+                        <Section
+                          icon={<Square3Stack3DIcon className="size-5 text-foreground/60" />}
+                          title="Marketplaces"
+                          description="OpenWork Connect catalogs shared by your organization."
+                          count={`${marketplaces.length} marketplace${marketplaces.length === 1 ? "" : "s"}`}
+                        >
+                          {marketplaces.map((mp) => (
+                            <MarketplaceCard key={mp.id} marketplace={mp} />
+                          ))}
+                        </Section>
+                      ) : null}
+
+                    </Accordion>
+                  </ScrollAreaViewport>
+                </ScrollArea>
+              ) : null}
+
+              {/* Selected default indicator */}
+              {selectedDefault ? (
+                <div className="rounded-xl border border-green-6/30 bg-green-2/30 px-4 py-3 text-center text-sm text-green-11">
+                  <Check size={14} className="mr-1 inline" />
+                  {selectedDefault.label} will be set as your default model.
+                </div>
+              ) : null}
+            </div>
           </PageContent>
         )}
 
@@ -529,22 +852,122 @@ export function ResourceSelectionPage() {
           {/* Footer hint */}
           {!loading && hasResources ? (
             <p className="text-center text-xs text-muted-foreground text-balance leading-relaxed tracking-wide">
-              Providers are added to your workspace automatically. Marketplaces are available from Cloud settings.
+              OpenWork Connect resources are available automatically. Marketplaces do not need local installation.
             </p>
           ) : null}
           <Button
             className="w-fit"
             type="button"
             size="lg"
-            onClick={handleContinue}
+            onClick={() => handleContinue(firstWorkflow?.suggestedPrompt ?? null)}
             disabled={loading}
           >
-            {hasResources ? "Continue to workspace" : "Continue"}
+            {firstWorkflowCtaLabel ?? (hasResources ? "Continue to workspace" : "Continue")}
             <ArrowRight data-icon="inline-end" />
           </Button>
         </PageFooter>
       </PageContainer>
     </Page>
+  );
+}
+
+function FirstWorkflowCard({ workflow }: { workflow: FirstWorkflow }) {
+  const connection = workflow.connection;
+  const prompt = workflow.suggestedPrompt;
+
+  return (
+    <div
+      data-openwork-first-workflow="true"
+      data-openwork-first-workflow-skill={workflow.skill.title}
+      data-openwork-first-workflow-connection={connection?.name ?? ""}
+      className="rounded-3xl border border-green-6/30 bg-gradient-to-br from-green-2/40 via-background to-dls-hover/50 p-5 shadow-sm"
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="min-w-0 space-y-2">
+          <div className="flex w-fit items-center gap-2 rounded-full border border-green-6/30 bg-green-2/50 px-3 py-1 text-xs font-semibold text-green-11">
+            <CheckCircle2 className="size-3.5" />
+            Organization connected
+          </div>
+          <div>
+            <div className="text-sm font-semibold text-foreground">
+              {workflow.skill.title}
+            </div>
+            <p className="mt-1 max-w-2xl text-sm text-muted-foreground">
+              {workflow.skill.description ?? "Your administrator shared this skill and its secure connection through OpenWork Connect."}
+            </p>
+          </div>
+        </div>
+        <div className="shrink-0 rounded-full border border-border bg-background px-3 py-1 text-xs font-semibold text-muted-foreground">
+          OpenWork Connect
+        </div>
+      </div>
+
+      <div className="mt-4 grid gap-2 sm:grid-cols-3">
+        <WorkflowStatus label="Organization connected" />
+        <WorkflowStatus label={`${workflow.skill.title} skill ready`} />
+        {connection ? (
+          <WorkflowStatus
+            label={getMcpConnectionReadyLabel(connection)}
+            ready={isMcpConnectionReady(connection)}
+          />
+        ) : (
+          <WorkflowStatus label="Secure connection not configured" ready={false} />
+        )}
+      </div>
+
+      {prompt ? (
+        <div className="mt-4 rounded-2xl border border-border bg-background/80 p-3">
+          <div className="mb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+            Suggested first task
+          </div>
+          <p className="text-sm font-medium text-foreground">{prompt}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function WorkflowStatus({ label, ready = true }: { label: string; ready?: boolean }) {
+  return (
+    <div className="flex items-center gap-2 rounded-xl border border-border bg-background/80 px-3 py-2 text-sm text-foreground">
+      <CheckCircle2 className={cn("size-4 shrink-0", ready ? "text-green-11" : "text-muted-foreground")} />
+      <span className="min-w-0 truncate">{label}</span>
+    </div>
+  );
+}
+
+function SkillCard({ skill }: { skill: DenOrgSkillCard }) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-border px-3 py-3 -mx-2">
+      <Sparkles className="size-4 shrink-0 text-foreground/60" />
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-foreground">{skill.title}</div>
+        {skill.description ? (
+          <div className="mt-0.5 truncate text-xs text-muted-foreground">
+            {skill.description}
+          </div>
+        ) : null}
+      </div>
+      <span className="shrink-0 text-xs text-green-11">Skill ready</span>
+    </div>
+  );
+}
+
+function ConnectionCard({ connection }: { connection: DenExternalMcpConnection }) {
+  const ready = isMcpConnectionReady(connection);
+  return (
+    <div className="flex items-center gap-3 rounded-xl border border-border px-3 py-3 -mx-2">
+      <CheckCircle2 className={cn("size-4 shrink-0", ready ? "text-green-11" : "text-muted-foreground")} />
+      <div className="min-w-0 flex-1">
+        <div className="text-sm font-medium text-foreground">{connection.name}</div>
+        <div className="mt-0.5 truncate text-xs text-muted-foreground">
+          {connection.credentialMode === "shared" ? "Shared secure MCP connection" : "Member secure MCP connection"}
+        </div>
+      </div>
+      <span className={cn("shrink-0 text-xs", ready ? "text-green-11" : "text-muted-foreground")}>
+        {ready ? "Ready" : "Needs attention"}
+      </span>
+    </div>
   );
 }
 

--- a/apps/app/src/react-app/domains/session/sync/draft-store.ts
+++ b/apps/app/src/react-app/domains/session/sync/draft-store.ts
@@ -9,6 +9,7 @@ export type SessionDraftSnapshot = {
 };
 
 const STORAGE_KEY = "openwork.session-drafts.v1";
+const PENDING_PROMPT_STORAGE_KEY = "openwork.session.pendingPrompt.v1";
 const MAX_DRAFT_COUNT = 100;
 
 let draftCache: Map<string, SessionDraftSnapshot> | null = null;
@@ -122,6 +123,41 @@ export const clearSessionDraft = (
   if (!cache.delete(key)) return;
   persistDraftCache();
   emitDraftStoreChange();
+};
+
+export const savePendingSessionPrompt = (prompt: string) => {
+  if (typeof window === "undefined") return;
+  const text = prompt.trim();
+  try {
+    if (text) {
+      window.sessionStorage.setItem(PENDING_PROMPT_STORAGE_KEY, text);
+    } else {
+      window.sessionStorage.removeItem(PENDING_PROMPT_STORAGE_KEY);
+    }
+  } catch {
+    // Session storage can be unavailable in restricted browser contexts.
+  }
+};
+
+export const peekPendingSessionPrompt = () => {
+  if (typeof window === "undefined") return null;
+  try {
+    const prompt = window.sessionStorage.getItem(PENDING_PROMPT_STORAGE_KEY)?.trim() ?? "";
+    return prompt || null;
+  } catch {
+    return null;
+  }
+};
+
+export const consumePendingSessionPrompt = () => {
+  if (typeof window === "undefined") return null;
+  try {
+    const prompt = window.sessionStorage.getItem(PENDING_PROMPT_STORAGE_KEY)?.trim() ?? "";
+    window.sessionStorage.removeItem(PENDING_PROMPT_STORAGE_KEY);
+    return prompt || null;
+  } catch {
+    return null;
+  }
 };
 
 export function useSessionDraftSnapshot(

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -155,7 +155,8 @@ import {
   publishInspectorSlice,
   recordInspectorEvent,
 } from "../../app/lib/app-inspector";
-import { saveSessionDraft } from "@/react-app/domains/session/sync/draft-store";
+import { consumePendingSessionPrompt, peekPendingSessionPrompt } from "@/react-app/domains/session/sync/draft-store";
+import { useComposerStateStore } from "@/react-app/domains/session/surface/composer-state-store";
 import { useControlAction, type OpenworkControlAction } from "./control/control-provider";
 import { useReactRenderWatchdog } from "./react-render-watchdog";
 
@@ -415,6 +416,7 @@ export function SessionRoute() {
   const pendingProviderDraftRef = useRef<{ draft: ComposerDraft; sessionId: string } | null>(null);
   const providerStepResendRef = useRef(false);
   const firstRunSessionRef = useRef(false);
+  const pendingPromptTaskRef = useRef(false);
   const [createWorkspaceBusy, setCreateWorkspaceBusy] = useState(false);
   const [createWorkspaceError, setCreateWorkspaceError] = useState<string | null>(null);
   const [createWorkspaceRemoteBusy, setCreateWorkspaceRemoteBusy] = useState(false);
@@ -1198,7 +1200,7 @@ export function SessionRoute() {
   );
 
 
-  const handleCreateTaskInWorkspace = useCallback(async (workspaceId: string): Promise<string | null> => {
+  const handleCreateTaskInWorkspace = useCallback(async (workspaceId: string, initialPrompt?: string): Promise<string | null> => {
     const workspace = workspaces.find((item) => item.id === workspaceId);
     if (
       !workspace ||
@@ -1228,6 +1230,12 @@ export function SessionRoute() {
       });
       toast.dismiss(taskCreateUnavailableToastId(workspaceId));
       toast.dismiss();
+      if (initialPrompt?.trim()) {
+        // The composer's visible text is the Zustand composer-state store
+        // keyed by session id; SyncPlugin pushes store changes into the
+        // Lexical editor even when the composer is already mounted.
+        useComposerStateStore.getState().setDraft(session.id, initialPrompt.trim());
+      }
       setLegacySelectedWorkspaceId(workspaceId);
       writeActiveWorkspaceId(workspaceId || null);
       writeLastSessionFor(workspaceId, session.id);
@@ -1337,6 +1345,27 @@ export function SessionRoute() {
       if (!createdSessionId) firstRunSessionRef.current = false;
     });
   }, [canCreateTask, selectedSessionId, selectedWorkspaceId, sessionsByWorkspaceId, handleCreateTaskInWorkspace]);
+
+  // Onboarding "start first workflow" handoff: org onboarding saved a pending
+  // prompt before navigating here, so land the user in a fresh task with that
+  // prompt pre-filled — the same session-draft path the suggestion chips use.
+  // Peek first and consume only after the task exists: right after sign-in the
+  // create call bails silently while the workspace endpoint is still
+  // resolving, and the prompt must survive those retries.
+  useEffect(() => {
+    if (!canCreateTask || !selectedWorkspaceId) return;
+    if (pendingPromptTaskRef.current) return;
+    const prompt = peekPendingSessionPrompt();
+    if (!prompt) return;
+    pendingPromptTaskRef.current = true;
+    void handleCreateTaskInWorkspace(selectedWorkspaceId, prompt).then((createdSessionId) => {
+      if (createdSessionId) {
+        consumePendingSessionPrompt();
+      } else {
+        pendingPromptTaskRef.current = false;
+      }
+    });
+  }, [canCreateTask, selectedWorkspaceId, handleCreateTaskInWorkspace]);
 
   // Latest session-list state for prev/next session tab navigation. The
   // `options` field is updated by `onSessionTabsChange` from SessionPage so we
@@ -2081,35 +2110,9 @@ export function SessionRoute() {
           void handleCreateTaskInWorkspace(workspaceId);
         },
         onCreateTaskWithPrompt: (workspaceId, prompt) => {
-          void (async () => {
-            const workspace = workspaces.find((item) => item.id === workspaceId);
-            if (!workspace) return;
-            const endpoint = resolveWorkspaceEndpoint(workspace, { baseUrl, token });
-            if (!endpoint?.token) return;
-            const workspaceClient = createClient(
-              endpoint.opencodeBaseUrl,
-              workspace.path?.trim() || undefined,
-              { token: endpoint.token, mode: "openwork" },
-            );
-            try {
-              const session = unwrap(
-                await workspaceClient.session.create({ directory: workspace.path?.trim() || undefined }),
-              );
-              saveSessionDraft(workspaceId, session.id, { text: prompt, mode: "prompt" });
-              writeActiveWorkspaceId(workspaceId || null);
-              writeLastSessionFor(workspaceId, session.id);
-              rememberPendingCreatedSession(workspaceId, session.id);
-              setSessionsByWorkspaceId((current) => ({
-                ...current,
-                [workspaceId]: [session, ...(current[workspaceId] ?? [])],
-              }));
-              navigateToWorkspaceSession(workspaceId, session.id);
-              focusPromptSoon();
-            } catch {
-              // Fall back to normal task creation without prompt
-              void handleCreateTaskInWorkspace(workspaceId);
-            }
-          })();
+          // Shared create-task path: it seeds the composer-state store (the
+          // store the composer actually renders) before navigating.
+          void handleCreateTaskInWorkspace(workspaceId, prompt);
         },
         onOpenRenameWorkspace: handleOpenRenameWorkspace,
         onShareWorkspace: handleShareWorkspace,

--- a/apps/app/tests/org-onboarding-page.test.ts
+++ b/apps/app/tests/org-onboarding-page.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import type { DenExternalMcpConnection, DenOrgSummary } from "../src/app/lib/den";
+import type { DenOrgSkillCard } from "../src/app/types";
+import {
+  INACTIVE_ACCOUNT_CHECK_PROMPT,
+  isMcpConnectionReady,
+  resolveFirstWorkflow,
+  resolveSuggestedPromptForSkill,
+  shouldAutoSelectOnlyOrganization,
+} from "../src/react-app/domains/cloud/org-onboarding-page";
+import {
+  consumePendingSessionPrompt,
+  savePendingSessionPrompt,
+} from "../src/react-app/domains/session/sync/draft-store";
+
+const originalWindow = globalThis.window;
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+const org: DenOrgSummary = {
+  id: "org_1",
+  name: "Acme Robotics",
+  slug: "acme",
+  role: "member",
+};
+
+const inactiveSkill: DenOrgSkillCard = {
+  id: "skill_1",
+  title: "Inactive Account Check",
+  description: "Find employee accounts with no recent activity using the Employee Directory.",
+  skillText: "Check for employee accounts inactive for 30 days.",
+  shared: "org",
+  updatedAt: null,
+};
+
+const employeeDirectoryConnection: DenExternalMcpConnection = {
+  id: "conn_1",
+  name: "Employee Directory",
+  url: "https://directory.example.test/mcp",
+  authType: "oauth",
+  credentialMode: "shared",
+  connected: true,
+  connectedAt: null,
+  connectedForMe: true,
+};
+
+describe("org onboarding helpers", () => {
+  beforeEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { sessionStorage: memoryStorage() },
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  test("auto-selects exactly one organization but leaves multi-org users on the picker", () => {
+    expect(shouldAutoSelectOnlyOrganization([org], false)).toEqual(org);
+    expect(shouldAutoSelectOnlyOrganization([org], true)).toBeNull();
+    expect(shouldAutoSelectOnlyOrganization([
+      org,
+      { ...org, id: "org_2", slug: "other", name: "Other Org" },
+    ], false)).toBeNull();
+  });
+
+  test("uses the inactive-account suggested prompt for the exact skill", () => {
+    expect(resolveSuggestedPromptForSkill(inactiveSkill)).toBe(INACTIVE_ACCOUNT_CHECK_PROMPT);
+  });
+
+  test("prefers explicit skill metadata prompts when present", () => {
+    expect(resolveSuggestedPromptForSkill({
+      title: "Quarterly Access Review",
+      description: "Suggested prompt: Review access for contractors this quarter.",
+      skillText: "",
+    })).toBe("Review access for contractors this quarter.");
+  });
+
+  test("combines the featured org skill with its ready secure connection", () => {
+    const workflow = resolveFirstWorkflow([inactiveSkill], [employeeDirectoryConnection]);
+    expect(workflow?.skill.title).toBe("Inactive Account Check");
+    expect(workflow?.connection?.name).toBe("Employee Directory");
+    expect(workflow?.suggestedPrompt).toBe(INACTIVE_ACCOUNT_CHECK_PROMPT);
+  });
+
+  test("recognizes connection readiness", () => {
+    expect(isMcpConnectionReady(employeeDirectoryConnection)).toBe(true);
+    expect(isMcpConnectionReady({
+      ...employeeDirectoryConnection,
+      needsReconnect: true,
+    })).toBe(false);
+  });
+
+  test("hands a first-task prompt to the next real composer mount once", () => {
+    savePendingSessionPrompt(`  ${INACTIVE_ACCOUNT_CHECK_PROMPT}  `);
+
+    expect(consumePendingSessionPrompt()).toBe(INACTIVE_ACCOUNT_CHECK_PROMPT);
+    expect(consumePendingSessionPrompt()).toBeNull();
+  });
+});

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -12,6 +12,7 @@ import { db } from "../../db.js"
 import { checkEntitlement, getOrganizationEntitlements, parseOrganizationPlan } from "../../entitlements.js"
 import { env } from "../../env.js"
 import { findEnterpriseAuthRequirementForEmail } from "../../enterprise-auth-requirement.js"
+import { resolveInvitationDownloadUrl } from "../../install-links.js"
 import { authenticatedRoute, jsonValidator, orgMemberRoute, orgRoleRoute, publicRoute, queryValidator, resolveMemberTeamsMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, enterprisePlanRequiredSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { normalizeOrganizationCapabilities } from "../../organization-capabilities.js"
@@ -98,6 +99,7 @@ const invitationAcceptedResponseSchema = z.object({
   organizationId: denTypeIdSchema("organization"),
   organizationSlug: z.string().nullable(),
   invitationId: denTypeIdSchema("invitation"),
+  installPageUrl: z.string().url(),
 }).meta({ ref: "InvitationAcceptedResponse" })
 
 const organizationContextResponseSchema = z.object({
@@ -316,16 +318,23 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
     await setRequestActiveOrganization(c, accepted.member.organizationId)
 
     const orgRows = await db
-      .select({ slug: OrganizationTable.slug })
+      .select({ slug: OrganizationTable.slug, metadata: OrganizationTable.metadata })
       .from(OrganizationTable)
       .where(eq(OrganizationTable.id, accepted.member.organizationId))
       .limit(1)
+    const organization = orgRows[0] ?? null
+    const installPageUrl = await resolveInvitationDownloadUrl({
+      organizationId: accepted.member.organizationId,
+      createdByUserId: user.id,
+      metadata: organization?.metadata ?? null,
+    })
 
     return c.json({
       accepted: true,
       organizationId: accepted.member.organizationId,
-      organizationSlug: orgRows[0]?.slug ?? null,
+      organizationSlug: organization?.slug ?? null,
       invitationId: accepted.invitation.id,
+      installPageUrl,
     })
     },
   )

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -63,6 +63,18 @@ const rateLimitedSchema = z.object({
   message: z.string(),
 }).meta({ ref: "RateLimitedError" })
 
+const installPrepareResponseSchema = z.union([
+  z.object({
+    status: z.literal("ready"),
+    stage: z.enum(["bundle", "script"]),
+  }),
+  z.object({
+    status: z.literal("fallback"),
+    stage: z.literal("standard-download"),
+    fallbackUrl: z.string().url(),
+  }),
+]).meta({ ref: "InstallPrepareResponse" })
+
 type InstallPlatform = z.infer<typeof installPlatformSchema>
 
 type InstallerDependencies = {
@@ -74,6 +86,12 @@ const defaultInstallerDependencies: InstallerDependencies = {
   resolveArtifact: resolveInstallerArtifact,
   resolveFallbackUrl: (platform) => resolveInstallerFallbackUrl(platform, OPENWORK_DOWNLOAD_URL),
 }
+
+type InstallerPreparation =
+  | { status: "ready"; stage: "script" }
+  | { status: "ready"; stage: "bundle"; desktopFileName: string; genericFileName: string; desktopArtifact: Buffer; genericInstallerArtifact: Buffer }
+  | { status: "fallback"; stage: "standard-download"; fallbackUrl: string }
+  | { status: "unsupported" }
 
 function requestAddress(headers: Headers) {
   const forwarded = headers.get("x-forwarded-for")?.split(",")[0]?.trim()
@@ -234,6 +252,40 @@ echo "Run the AppImage, then sign in — your team's workspace is preconfigured.
 `
 }
 
+async function resolveInstallerPreparation(platform: InstallPlatform, installer: InstallerDependencies): Promise<InstallerPreparation> {
+  if (platform.startsWith("linux-")) {
+    return { status: "ready", stage: "script" }
+  }
+
+  const desktopFileName = desktopArtifactFileName(platform)
+  const genericFileName = genericInstallerAssetName(platform)
+  if (!desktopFileName || !genericFileName) {
+    return { status: "unsupported" }
+  }
+
+  const [desktopArtifact, genericInstallerArtifact] = await Promise.all([
+    installer.resolveArtifact(desktopFileName),
+    installer.resolveArtifact(genericFileName),
+  ])
+
+  if (!desktopArtifact || !genericInstallerArtifact) {
+    return {
+      status: "fallback",
+      stage: "standard-download",
+      fallbackUrl: await installer.resolveFallbackUrl(platform),
+    }
+  }
+
+  return {
+    status: "ready",
+    stage: "bundle",
+    desktopFileName,
+    genericFileName,
+    desktopArtifact,
+    genericInstallerArtifact,
+  }
+}
+
 const setActiveOrganizationFromParam: MiddlewareHandler<{ Variables: OrgRouteVariables }> = async (c, next) => {
   const parsed = denTypeIdSchema("organization").safeParse(c.req.param("organizationId"))
   if (!parsed.success) {
@@ -341,6 +393,51 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
   )
 
   app.get(
+    "/v1/install/:platform/prepare",
+    describeRoute({
+      tags: ["Organizations"],
+      summary: "Prepare stamped installer download",
+      description: "Validates an install link, resolves the platform artifacts into cache, and reports whether the existing installer attachment endpoint is ready or will fall back before the browser requests the download.",
+      responses: {
+        200: jsonResponse("Installer readiness resolved successfully.", installPrepareResponseSchema),
+        400: jsonResponse("The install-link token or platform was invalid.", invalidRequestSchema),
+        404: jsonResponse("The install link was missing, expired, or revoked.", installLinkNotFoundSchema),
+        429: jsonResponse("Too many installer preparation attempts.", rateLimitedSchema),
+      },
+    }),
+    publicRoute,
+    queryValidator(installLinkQuerySchema),
+    async (c) => {
+      const platformResult = installPlatformParamSchema.safeParse({ platform: c.req.param("platform") })
+      if (!platformResult.success) {
+        return c.json({ error: "invalid_request", details: platformResult.error.issues }, 400)
+      }
+
+      const retryAfter = await enforceRateLimit(c.req.raw.headers, "artifact", INSTALL_ARTIFACT_RATE_LIMIT_MAX)
+      if (retryAfter !== null) {
+        c.header("Retry-After", String(retryAfter))
+        return c.json({ error: "rate_limited", message: "Too many installer download attempts. Try again later." }, 429)
+      }
+
+      const input = c.req.valid("query")
+      const resolved = await resolveInstallConfigForToken(input.token, c.req.raw)
+      if (!resolved) {
+        return c.json({ error: "install_link_not_found" }, 404)
+      }
+
+      const prepared = await resolveInstallerPreparation(platformResult.data.platform, installer)
+      if (prepared.status === "unsupported") {
+        return c.json({ error: "invalid_request", details: [{ message: "Unsupported installer platform." }] }, 400)
+      }
+      if (prepared.status === "fallback") {
+        return c.json({ status: "fallback", stage: "standard-download", fallbackUrl: prepared.fallbackUrl })
+      }
+
+      return c.json({ status: "ready", stage: prepared.stage })
+    },
+  )
+
+  app.get(
     "/v1/install/:platform",
     describeRoute({
       tags: ["Organizations"],
@@ -385,30 +482,27 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         })
       }
 
-      const desktopFileName = desktopArtifactFileName(platform)
-      const genericFileName = genericInstallerAssetName(platform)
-      if (!desktopFileName || !genericFileName) {
+      const prepared = await resolveInstallerPreparation(platform, installer)
+      if (prepared.status === "unsupported") {
         return c.json({ error: "invalid_request", details: [{ message: "Unsupported installer platform." }] }, 400)
       }
-
-      const [desktopArtifact, genericInstallerArtifact] = await Promise.all([
-        installer.resolveArtifact(desktopFileName),
-        installer.resolveArtifact(genericFileName),
-      ])
-      if (!desktopArtifact || !genericInstallerArtifact) {
-        return c.redirect(await installer.resolveFallbackUrl(platform), 302)
+      if (prepared.status === "fallback") {
+        return c.redirect(prepared.fallbackUrl, 302)
+      }
+      if (prepared.stage === "script") {
+        return c.json({ error: "invalid_request", details: [{ message: "Unsupported installer platform." }] }, 400)
       }
 
       const sidecar = Buffer.from(`${JSON.stringify(resolved.config, null, 2)}\n`, "utf8")
       const bundle = platform.startsWith("mac-")
-        ? appendStoredEntriesToZipStream(genericInstallerArtifact, [
+        ? appendStoredEntriesToZipStream(prepared.genericInstallerArtifact, [
             { name: INSTALL_SIDECAR_FILENAME, content: sidecar },
-            { name: desktopFileName, content: desktopArtifact },
+            { name: prepared.desktopFileName, content: prepared.desktopArtifact },
           ])
         : createStoredZipStream([
-            { name: "OpenWork Installer.exe", content: genericInstallerArtifact },
+            { name: "OpenWork Installer.exe", content: prepared.genericInstallerArtifact },
             { name: INSTALL_SIDECAR_FILENAME, content: sidecar },
-            { name: desktopFileName, content: desktopArtifact },
+            { name: prepared.desktopFileName, content: prepared.desktopArtifact },
           ])
 
       return new Response(bundle.body, {

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -180,10 +180,18 @@ type PublicGithubTreeSnapshot = {
   truncated: boolean
 }
 
-type GithubPluginMcpImportAccess = {
+type PluginMaterializationAccess = {
   memberIds: MemberId[]
   orgWide: boolean
   teamIds: TeamId[]
+}
+
+type GithubPluginMcpImportAccess = PluginMaterializationAccess
+
+type PluginMaterializedMcpServer = {
+  name: string
+  pluginName: string
+  url: string | null
 }
 
 type GithubPluginMcpImportServer = {
@@ -1870,8 +1878,269 @@ export async function createPlugin(input: { context: PluginArchActorContext; des
   return serializePlugin(row, 0)
 }
 
+type PluginBundleComponentInput = {
+  type: ConfigObjectRow["objectType"]
+  value: ConfigObjectInput
+}
+
+type PlannedPluginBundleComponent =
+  | { component: PluginBundleComponentInput; kind: "mcp"; servers: PluginMaterializedMcpServer[] }
+  | { component: PluginBundleComponentInput; kind: "skill"; skillText: string }
+  | { component: PluginBundleComponentInput; kind: "config" }
+
+const manualRemoteMcpTypes = new Set(["http", "remote", "streamable-http", "sse"])
+
+function configObjectMetadataString(value: ConfigObjectInput, key: string) {
+  const candidate = value.metadata?.[key]
+  return typeof candidate === "string" ? normalizeOptionalString(candidate) : null
+}
+
+function manualMcpRouteFailure(message: string) {
+  return new PluginArchRouteFailure(400, "invalid_manual_mcp", message)
+}
+
+function manualMcpPayload(value: ConfigObjectInput) {
+  if (value.normalizedPayloadJson) return value.normalizedPayloadJson
+  throw manualMcpRouteFailure("Manual plugin MCP servers must use the URL-only remote MCP field.")
+}
+
+function manualMcpConfigEntries(value: ConfigObjectInput): Array<[string, Record<string, unknown>]> {
+  const payload = manualMcpPayload(value)
+  const containers = [
+    isRecord(payload.mcpServers) ? payload.mcpServers : null,
+    isRecord(payload.mcp) ? payload.mcp : null,
+  ].filter((entry): entry is Record<string, unknown> => Boolean(entry))
+  const entries = containers.flatMap((container) => Object.entries(container))
+  if (entries.length > 0) {
+    const output: Array<[string, Record<string, unknown>]> = []
+    for (const [name, config] of entries) {
+      output.push([name, isRecord(config) ? config : {}])
+    }
+    return output
+  }
+  if (typeof payload.url === "string") {
+    const metadataName = configObjectMetadataString(value, "name")
+    return [[metadataName ?? "remote-mcp", payload]]
+  }
+  throw manualMcpRouteFailure("Manual plugin MCP servers must include an HTTPS URL.")
+}
+
+function manualPluginMcpServersFromValue(input: {
+  pluginName: string
+  value: ConfigObjectInput
+}): PluginMaterializedMcpServer[] {
+  const entries = manualMcpConfigEntries(input.value)
+  const singleServerName = entries.length === 1 ? configObjectMetadataString(input.value, "name") : null
+
+  return entries.map(([rawName, config]) => {
+    const url = typeof config.url === "string" ? config.url.trim() : ""
+    if (!url) {
+      throw manualMcpRouteFailure("Manual plugin MCP servers must include an HTTPS URL.")
+    }
+
+    const command = config.command
+    const hasLocalCommand = typeof command === "string"
+      ? Boolean(command.trim())
+      : Array.isArray(command) && command.some((part) => typeof part === "string" && Boolean(part.trim()))
+    const serverType = typeof config.type === "string" ? config.type.trim().toLowerCase() : "remote"
+    if (hasLocalCommand || !manualRemoteMcpTypes.has(serverType)) {
+      throw manualMcpRouteFailure("Manual plugin MCP servers support remote HTTPS URLs only. Add local MCP servers in OpenWork Connect instead.")
+    }
+
+    const authType = typeof config.authType === "string" ? config.authType.trim().toLowerCase() : "none"
+    const credentialMode = typeof config.credentialMode === "string" ? config.credentialMode.trim().toLowerCase() : "shared"
+    if (authType !== "none" || credentialMode !== "shared") {
+      throw manualMcpRouteFailure("Manual plugin MCP servers support shared no-auth URLs only. Configure OAuth or API-key MCP servers in OpenWork Connect first.")
+    }
+
+    let parsedUrl: URL
+    try {
+      parsedUrl = new URL(url)
+    } catch {
+      throw manualMcpRouteFailure("Manual plugin MCP server URL must be a valid https:// URL.")
+    }
+    if (parsedUrl.protocol !== "https:") {
+      throw manualMcpRouteFailure("Manual plugin MCP server URL must start with https://.")
+    }
+    if (parsedUrl.username || parsedUrl.password) {
+      throw manualMcpRouteFailure("Manual plugin MCP server URLs cannot contain embedded credentials.")
+    }
+
+    return {
+      name: singleServerName ?? normalizeOptionalString(rawName) ?? input.pluginName,
+      pluginName: input.pluginName,
+      url,
+    }
+  })
+}
+
+async function assertManualMcpUrlAllowed(url: string) {
+  try {
+    await assertPublicUrl(url)
+  } catch (error) {
+    throw new PluginArchRouteFailure(
+      400,
+      "invalid_manual_mcp_url",
+      error instanceof Error ? error.message : "Manual plugin MCP server URL is not allowed.",
+    )
+  }
+}
+
+async function planPluginBundleComponents(input: {
+  components: PluginBundleComponentInput[]
+  pluginName: string
+}): Promise<PlannedPluginBundleComponent[]> {
+  const plans: PlannedPluginBundleComponent[] = []
+  for (const component of input.components) {
+    if (component.type === "mcp") {
+      const servers = manualPluginMcpServersFromValue({ pluginName: input.pluginName, value: component.value })
+      for (const server of servers) {
+        if (!server.url) throw manualMcpRouteFailure("Manual plugin MCP servers must include an HTTPS URL.")
+        await assertManualMcpUrlAllowed(server.url)
+      }
+      plans.push({ component, kind: "mcp", servers })
+      continue
+    }
+
+    if (component.type === "skill") {
+      const skillText = normalizeOptionalString(component.value.rawSourceText)
+      if (!skillText) {
+        throw new PluginArchRouteFailure(400, "invalid_manual_skill", "Manual plugin skills must include SKILL.md instructions.")
+      }
+      plans.push({ component, kind: "skill", skillText })
+      continue
+    }
+
+    plans.push({ component, kind: "config" })
+  }
+  return plans
+}
+
+function pluginBundleAccess(input: { context: PluginArchActorContext; orgWide?: boolean }): PluginMaterializationAccess {
+  return input.orgWide
+    ? { memberIds: [], orgWide: true, teamIds: [] }
+    : { memberIds: [input.context.organizationContext.currentMember.id], orgWide: false, teamIds: [] }
+}
+
+async function grantPluginBundleConfigObjectAccess(input: {
+  configObjectId: ConfigObjectId
+  context: PluginArchActorContext
+  orgWide?: boolean
+}) {
+  if (!input.orgWide) return
+  await createResourceAccessGrant({
+    context: input.context,
+    resourceId: input.configObjectId,
+    resourceKind: "config_object",
+    value: { orgWide: true, role: "viewer" },
+  })
+}
+
+async function createPluginBundleConfigObject(input: {
+  context: PluginArchActorContext
+  pluginId: PluginId
+  orgWide?: boolean
+  sourceMode: ConfigObjectRow["sourceMode"]
+  type: ConfigObjectRow["objectType"]
+  value: ConfigObjectInput
+}) {
+  const configObject = await createConfigObject({
+    context: input.context,
+    objectType: input.type,
+    pluginIds: [input.pluginId],
+    sourceMode: input.sourceMode,
+    value: input.value,
+  })
+  await grantPluginBundleConfigObjectAccess({
+    configObjectId: configObject.id,
+    context: input.context,
+    orgWide: input.orgWide,
+  })
+  return configObject
+}
+
+async function materializeManualSkillComponent(input: {
+  access: PluginMaterializationAccess
+  context: PluginArchActorContext
+  component: PluginBundleComponentInput
+  pluginId: PluginId
+  orgWide?: boolean
+  skillText: string
+}) {
+  const createdSkill = await createPluginManagedSkill({
+    access: input.access,
+    context: input.context,
+    description: configObjectMetadataString(input.component.value, "description"),
+    skillHubId: null,
+    skillText: input.skillText,
+    title: configObjectMetadataString(input.component.value, "name"),
+  })
+  await createPluginBundleConfigObject({
+    context: input.context,
+    pluginId: input.pluginId,
+    orgWide: input.orgWide,
+    sourceMode: "cloud",
+    type: "skill",
+    value: {
+      metadata: {
+        denSkillId: createdSkill.id,
+        description: createdSkill.description ?? configObjectMetadataString(input.component.value, "description") ?? "Den skill created from a manual plugin bundle.",
+        name: createdSkill.title,
+        openworkManaged: "den_skill",
+        source: "manual_plugin_bundle",
+      },
+      normalizedPayloadJson: denSkillPayload({ ownedByPlugin: true, skillId: createdSkill.id }),
+      rawSourceText: input.skillText,
+      schemaVersion: "openwork.den_skill.v1",
+    },
+  })
+}
+
+async function materializeManualMcpComponent(input: {
+  access: PluginMaterializationAccess
+  context: PluginArchActorContext
+  component: PluginBundleComponentInput
+  pluginId: PluginId
+  orgWide?: boolean
+  server: PluginMaterializedMcpServer
+}) {
+  const materializedConnection = await ensurePluginExternalMcpConnection({
+    access: input.access,
+    authType: "none",
+    context: input.context,
+    credentialMode: "shared",
+    server: input.server,
+  })
+  const connection = materializedConnection.connection
+  await createPluginBundleConfigObject({
+    context: input.context,
+    pluginId: input.pluginId,
+    orgWide: input.orgWide,
+    sourceMode: "cloud",
+    type: "mcp",
+    value: {
+      metadata: {
+        authType: "none",
+        credentialMode: "shared",
+        description: configObjectMetadataString(input.component.value, "description") ?? "Shared no-auth remote MCP connection created from a manual plugin bundle.",
+        externalMcpConnectionId: connection.id,
+        externalMcpConnectionOwnedByPlugin: materializedConnection.ownedByPlugin,
+        name: input.server.name,
+        openworkManaged: "den_external_mcp",
+        source: "manual_plugin_bundle",
+      },
+      normalizedPayloadJson: pluginExternalMcpConnectionPayload({
+        connectionId: connection.id,
+        ownedByPlugin: materializedConnection.ownedByPlugin,
+        server: input.server,
+      }),
+      schemaVersion: "openwork.den_external_mcp.v1",
+    },
+  })
+}
+
 export async function createPluginBundle(input: {
-  components?: { type: ConfigObjectRow["objectType"]; value: ConfigObjectInput }[]
+  components?: PluginBundleComponentInput[]
   context: PluginArchActorContext
   description?: string | null
   marketplaceId?: MarketplaceId
@@ -1883,24 +2152,45 @@ export async function createPluginBundle(input: {
     await ensureEditableMarketplace(input.context, input.marketplaceId)
   }
 
+  const plannedComponents = await planPluginBundleComponents({ components: input.components ?? [], pluginName: input.name })
+  const access = pluginBundleAccess({ context: input.context, orgWide: input.orgWide })
   const plugin = await createPlugin({ context: input.context, description: input.description, name: input.name })
 
-  for (const component of input.components ?? []) {
-    const configObject = await createConfigObject({
-      context: input.context,
-      objectType: component.type,
-      pluginIds: [plugin.id],
-      sourceMode: "cloud",
-      value: component.value,
-    })
-    if (input.orgWide) {
-      await createResourceAccessGrant({
+  for (const plan of plannedComponents) {
+    if (plan.kind === "skill") {
+      await materializeManualSkillComponent({
+        access,
+        component: plan.component,
         context: input.context,
-        resourceId: configObject.id,
-        resourceKind: "config_object",
-        value: { orgWide: true, role: "viewer" },
+        orgWide: input.orgWide,
+        pluginId: plugin.id,
+        skillText: plan.skillText,
       })
+      continue
     }
+
+    if (plan.kind === "mcp") {
+      for (const server of plan.servers) {
+        await materializeManualMcpComponent({
+          access,
+          component: plan.component,
+          context: input.context,
+          orgWide: input.orgWide,
+          pluginId: plugin.id,
+          server,
+        })
+      }
+      continue
+    }
+
+    await createPluginBundleConfigObject({
+      context: input.context,
+      pluginId: plugin.id,
+      orgWide: input.orgWide,
+      sourceMode: "cloud",
+      type: plan.component.type,
+      value: plan.component.value,
+    })
   }
 
   if (input.orgWide) {
@@ -1951,6 +2241,13 @@ function externalMcpConnectionIdsFromPayload(payload: unknown, options?: { owned
     }
   }
   return [...ids]
+}
+
+function denSkillIdsFromPayload(payload: unknown, options?: { ownedOnly?: boolean }): string[] {
+  if (!isRecord(payload) || payload.openworkManaged !== "den_skill") return []
+  if (options?.ownedOnly === true && payload.denSkillOwnedByPlugin !== true) return []
+  const skillId = typeof payload.denSkillId === "string" ? payload.denSkillId.trim() : ""
+  return skillId ? [skillId] : []
 }
 
 async function pluginOwnedExternalMcpConnectionIds(input: {
@@ -2024,6 +2321,81 @@ async function deletePluginOwnedExternalMcpConnections(input: {
   }
 }
 
+async function pluginOwnedSkillIds(input: {
+  context: PluginArchActorContext
+  pluginId: PluginId
+}) {
+  const memberships = await db
+    .select({ configObjectId: PluginConfigObjectTable.configObjectId })
+    .from(PluginConfigObjectTable)
+    .innerJoin(ConfigObjectTable, eq(PluginConfigObjectTable.configObjectId, ConfigObjectTable.id))
+    .where(and(
+      eq(PluginConfigObjectTable.pluginId, input.pluginId),
+      eq(PluginConfigObjectTable.organizationId, input.context.organizationContext.organization.id),
+      eq(ConfigObjectTable.objectType, "skill"),
+      isNull(PluginConfigObjectTable.removedAt),
+    ))
+  const versions = await getLatestVersions(memberships.map((membership) => membership.configObjectId))
+  const ids = new Set<string>()
+  for (const membership of memberships) {
+    const payload = versions.get(membership.configObjectId)?.normalizedPayloadJson
+    for (const id of denSkillIdsFromPayload(payload, { ownedOnly: true })) ids.add(id)
+  }
+  return [...ids]
+}
+
+async function activePluginReferencesDenSkill(input: {
+  context: PluginArchActorContext
+  excludingPluginId: PluginId
+  skillId: string
+}) {
+  const memberships = await db
+    .select({
+      configObjectId: PluginConfigObjectTable.configObjectId,
+      pluginId: PluginConfigObjectTable.pluginId,
+    })
+    .from(PluginConfigObjectTable)
+    .innerJoin(ConfigObjectTable, eq(PluginConfigObjectTable.configObjectId, ConfigObjectTable.id))
+    .innerJoin(PluginTable, eq(PluginConfigObjectTable.pluginId, PluginTable.id))
+    .where(and(
+      eq(PluginConfigObjectTable.organizationId, input.context.organizationContext.organization.id),
+      eq(ConfigObjectTable.objectType, "skill"),
+      eq(PluginTable.status, "active"),
+      isNull(PluginTable.deletedAt),
+      isNull(PluginConfigObjectTable.removedAt),
+    ))
+  const otherMemberships = memberships.filter((membership) => membership.pluginId !== input.excludingPluginId)
+  const versions = await getLatestVersions(otherMemberships.map((membership) => membership.configObjectId))
+  for (const membership of otherMemberships) {
+    const payload = versions.get(membership.configObjectId)?.normalizedPayloadJson
+    if (denSkillIdsFromPayload(payload).includes(input.skillId)) return true
+  }
+  return false
+}
+
+async function deletePluginOwnedSkills(input: {
+  context: PluginArchActorContext
+  pluginId: PluginId
+}) {
+  const skillIds = await pluginOwnedSkillIds(input)
+  for (const id of skillIds) {
+    const referencedElsewhere = await activePluginReferencesDenSkill({
+      context: input.context,
+      excludingPluginId: input.pluginId,
+      skillId: id,
+    })
+    if (referencedElsewhere) continue
+    const skillId = normalizeDenTypeId("skill", id)
+    await db.transaction(async (tx) => {
+      await tx.delete(SkillHubSkillTable).where(eq(SkillHubSkillTable.skillId, skillId))
+      await tx.delete(SkillTable).where(and(
+        eq(SkillTable.id, skillId),
+        eq(SkillTable.organizationId, input.context.organizationContext.organization.id),
+      ))
+    })
+  }
+}
+
 export async function setPluginLifecycle(input: { action: "archive" | "restore"; context: PluginArchActorContext; pluginId: PluginId }) {
   const row = await ensureVisiblePlugin(input.context, input.pluginId)
   await requirePluginArchResourceRole({ context: input.context, resourceId: row.id, resourceKind: "plugin", role: "manager" })
@@ -2035,6 +2407,7 @@ export async function setPluginLifecycle(input: { action: "archive" | "restore";
   }).where(eq(PluginTable.id, row.id))
   if (input.action === "archive") {
     await deletePluginOwnedExternalMcpConnections({ context: input.context, pluginId: row.id })
+    await deletePluginOwnedSkills({ context: input.context, pluginId: row.id })
   }
   return getPluginDetail(input.context, row.id)
 }
@@ -3632,8 +4005,8 @@ function sameStringSet(left: string[], right: string[]) {
     && normalizedLeft.every((value, index) => value === normalizedRight[index])
 }
 
-async function requireExistingExternalMcpConnectionMatchesImport(input: {
-  access: GithubPluginMcpImportAccess
+async function requireExistingExternalMcpConnectionMatchesPlugin(input: {
+  access: PluginMaterializationAccess
   authType: "none" | "oauth"
   connectionId: Parameters<typeof listExternalMcpConnectionAccess>[0]
   credentialMode: "per_member" | "shared"
@@ -3645,7 +4018,7 @@ async function requireExistingExternalMcpConnectionMatchesImport(input: {
     throw new PluginArchRouteFailure(
       409,
       "external_mcp_connection_config_mismatch",
-      "An External MCP Connection already exists for this URL with different authentication or credential mode. Edit the existing connection or import with matching settings.",
+      "An External MCP Connection already exists for this URL with different authentication or credential mode. Edit the existing connection or use matching settings.",
     )
   }
 
@@ -3661,20 +4034,20 @@ async function requireExistingExternalMcpConnectionMatchesImport(input: {
     throw new PluginArchRouteFailure(
       409,
       "external_mcp_connection_access_mismatch",
-      "An External MCP Connection already exists for this URL with different sharing settings. Edit the existing connection or choose an import audience that matches it.",
+      "An External MCP Connection already exists for this URL with different sharing settings. Edit the existing connection or choose an audience that matches it.",
     )
   }
 }
 
-async function ensureImportedExternalMcpConnection(input: {
-  access: GithubPluginMcpImportAccess
+async function ensurePluginExternalMcpConnection(input: {
+  access: PluginMaterializationAccess
   authType: "none" | "oauth"
   context: PluginArchActorContext
   credentialMode: "per_member" | "shared"
-  server: GithubPluginMcpImportServer
-}): Promise<{ connection: Awaited<ReturnType<typeof createExternalMcpConnection>>; ownedByImportedPlugin: boolean }> {
+  server: PluginMaterializedMcpServer
+}): Promise<{ connection: Awaited<ReturnType<typeof createExternalMcpConnection>>; ownedByPlugin: boolean }> {
   if (!input.server.url) {
-    throw new PluginArchRouteFailure(400, "invalid_mcp_import", "MCP server URL is required.")
+    throw new PluginArchRouteFailure(400, "invalid_mcp_materialization", "MCP server URL is required.")
   }
 
   await assertPublicUrl(input.server.url)
@@ -3690,7 +4063,7 @@ async function ensureImportedExternalMcpConnection(input: {
   }
 
   if (existing) {
-    await requireExistingExternalMcpConnectionMatchesImport({
+    await requireExistingExternalMcpConnectionMatchesPlugin({
       access,
       connectionId: existing.id,
       authType: input.authType,
@@ -3701,7 +4074,7 @@ async function ensureImportedExternalMcpConnection(input: {
     if (input.authType === "none") {
       await markImportedExternalMcpConnectionConnected(existing.id)
     }
-    return { connection: existing, ownedByImportedPlugin: false }
+    return { connection: existing, ownedByPlugin: false }
   }
 
   const created = await createExternalMcpConnection({
@@ -3716,7 +4089,7 @@ async function ensureImportedExternalMcpConnection(input: {
   if (input.authType === "none") {
     await markImportedExternalMcpConnectionConnected(created.id)
   }
-  return { connection: created, ownedByImportedPlugin: true }
+  return { connection: created, ownedByPlugin: true }
 }
 
 async function markImportedExternalMcpConnectionConnected(connectionId: typeof ExternalMcpConnectionTable.$inferSelect.id) {
@@ -3726,10 +4099,10 @@ async function markImportedExternalMcpConnectionConnected(connectionId: typeof E
     .where(eq(ExternalMcpConnectionTable.id, connectionId))
 }
 
-function importedConnectionBackedMcpPayload(input: {
+function pluginExternalMcpConnectionPayload(input: {
   connectionId: string
-  ownedByImportedPlugin: boolean
-  server: GithubPluginMcpImportServer
+  ownedByPlugin: boolean
+  server: PluginMaterializedMcpServer
 }) {
   const serverName = slugifyPluginMcpName(input.server.name)
   return {
@@ -3739,18 +4112,19 @@ function importedConnectionBackedMcpPayload(input: {
         url: input.server.url,
         openworkManaged: "den_external_mcp",
         externalMcpConnectionId: input.connectionId,
-        externalMcpConnectionOwnedByPlugin: input.ownedByImportedPlugin,
+        externalMcpConnectionOwnedByPlugin: input.ownedByPlugin,
       },
     },
     openworkManaged: "den_external_mcp",
     externalMcpConnectionId: input.connectionId,
-    externalMcpConnectionOwnedByPlugin: input.ownedByImportedPlugin,
+    externalMcpConnectionOwnedByPlugin: input.ownedByPlugin,
   }
 }
 
-function importedDenSkillPayload(skillId: SkillId) {
+function denSkillPayload(input: { ownedByPlugin: boolean; skillId: SkillId }) {
   return {
-    denSkillId: skillId,
+    denSkillId: input.skillId,
+    denSkillOwnedByPlugin: input.ownedByPlugin,
     openworkManaged: "den_skill",
   }
 }
@@ -3802,17 +4176,19 @@ async function createSkillHubForImportedSkills(input: {
   return skillHubId
 }
 
-async function createImportedSkill(input: {
-  access: GithubPluginMcpImportAccess
+async function createPluginManagedSkill(input: {
+  access: PluginMaterializationAccess
   context: PluginArchActorContext
-  skill: GithubPluginSkillImportSkill
+  description?: string | null
   skillHubId: typeof SkillHubTable.$inferSelect.id | null
+  skillText: string
+  title?: string | null
 }) {
-  const skillText = input.skill.rawSourceText
-  if (!skillText) {
-    throw new PluginArchRouteFailure(400, "invalid_skill_import", "Selected skill content was unavailable.")
+  const parsedMetadata = skillMetadataFromText(input.skillText)
+  const metadata = {
+    description: normalizeOptionalString(input.description) ?? parsedMetadata.description,
+    title: normalizeOptionalString(input.title) ?? parsedMetadata.title,
   }
-  const metadata = skillMetadataFromText(skillText)
   const now = new Date()
   const skillId = createDenTypeId("skill")
   const createdByOrgMembershipId = input.context.organizationContext.currentMember.id
@@ -3824,7 +4200,7 @@ async function createImportedSkill(input: {
       createdByOrgMembershipId,
       title: metadata.title,
       description: metadata.description,
-      skillText,
+      skillText: input.skillText,
       shared: input.access.orgWide ? "org" : null,
       createdAt: now,
       updatedAt: now,
@@ -3842,9 +4218,27 @@ async function createImportedSkill(input: {
   return {
     description: metadata.description,
     id: skillId,
-    skillText,
+    skillText: input.skillText,
     title: metadata.title,
   }
+}
+
+async function createImportedSkill(input: {
+  access: GithubPluginMcpImportAccess
+  context: PluginArchActorContext
+  skill: GithubPluginSkillImportSkill
+  skillHubId: typeof SkillHubTable.$inferSelect.id | null
+}) {
+  const skillText = input.skill.rawSourceText
+  if (!skillText) {
+    throw new PluginArchRouteFailure(400, "invalid_skill_import", "Selected skill content was unavailable.")
+  }
+  return createPluginManagedSkill({
+    access: input.access,
+    context: input.context,
+    skillHubId: input.skillHubId,
+    skillText,
+  })
 }
 
 function importedPluginName(plan: GithubPluginMcpImportPlan) {
@@ -3949,7 +4343,7 @@ export async function importGithubPluginMcps(input: {
   const imported: Array<{ connectionId: string; name: string; url: string }> = []
   const importedSkills: Array<{ name: string; skillId: SkillId; sourcePath: string }> = []
   for (const server of supportedServers) {
-    const importedConnection = await ensureImportedExternalMcpConnection({
+    const importedConnection = await ensurePluginExternalMcpConnection({
       access,
       authType: input.authType,
       context: input.context,
@@ -3957,9 +4351,9 @@ export async function importGithubPluginMcps(input: {
       server,
     })
     const connection = importedConnection.connection
-    const payload = importedConnectionBackedMcpPayload({
+    const payload = pluginExternalMcpConnectionPayload({
       connectionId: connection.id,
-      ownedByImportedPlugin: importedConnection.ownedByImportedPlugin,
+      ownedByPlugin: importedConnection.ownedByPlugin,
       server,
     })
     const configObject = await createConfigObject({
@@ -3971,7 +4365,7 @@ export async function importGithubPluginMcps(input: {
         metadata: {
           description: `Den-hosted MCP connection imported from ${server.sourcePath}.`,
           externalMcpConnectionId: connection.id,
-          externalMcpConnectionOwnedByPlugin: importedConnection.ownedByImportedPlugin,
+          externalMcpConnectionOwnedByPlugin: importedConnection.ownedByPlugin,
           githubUrl: input.githubUrl,
           name: externalMcpConnectionName({ pluginName: server.pluginName, serverName: server.name }),
           openworkManaged: "den_external_mcp",
@@ -4020,7 +4414,7 @@ export async function importGithubPluginMcps(input: {
           repositoryFullName: plan.repositoryFullName,
           sourcePath: skill.sourcePath,
         },
-        normalizedPayloadJson: importedDenSkillPayload(createdSkill.id),
+        normalizedPayloadJson: denSkillPayload({ ownedByPlugin: true, skillId: createdSkill.id }),
         schemaVersion: "openwork.den_skill.v1",
       },
     })

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -304,6 +304,36 @@ test("missing server-side artifacts redirect the browser to the official release
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
+test("installer preparation reports ready only after artifacts resolve", async () => {
+  envModule.env.installerReleaseTag = "v9.9.9"
+
+  const response = await createApp({
+    installerArtifacts: {
+      "openwork-win-x64-9.9.9.exe": Buffer.from("standard-app", "utf8"),
+      "openwork-installer-win-x64.exe": Buffer.from("generic-installer", "utf8"),
+    },
+  }).request("http://den.local/v1/install/win-x64/prepare?token=opaque-token")
+
+  expect(response.status).toBe(200)
+  await expect(response.json()).resolves.toEqual({ status: "ready", stage: "bundle" })
+})
+
+test("installer preparation reports fallback without leaking the install token", async () => {
+  const response = await createApp({ installerFallbackUrl: officialWindowsInstallerUrl }).request("http://den.local/v1/install/win-x64/prepare?token=opaque-token")
+
+  expect(response.status).toBe(200)
+  const payload = await response.json()
+  expect(payload).toEqual({ status: "fallback", stage: "standard-download", fallbackUrl: officialWindowsInstallerUrl })
+  expect(JSON.stringify(payload)).not.toContain("opaque-token")
+})
+
+test("linux installer preparation is ready without desktop artifact caching", async () => {
+  const response = await createApp().request("http://den.local/v1/install/linux-x64/prepare?token=opaque-token")
+
+  expect(response.status).toBe(200)
+  await expect(response.json()).resolves.toEqual({ status: "ready", stage: "script" })
+})
+
 test.each([
   ["mac-arm64", "openwork-mac-arm64-9.9.9.dmg", "openwork-installer-mac-arm64.zip"],
   ["win-x64", "openwork-win-x64-9.9.9.exe", "openwork-installer-win-x64.exe"],

--- a/ee/apps/den-api/test/invitation-accept-install-page.test.ts
+++ b/ee/apps/den-api/test/invitation-accept-install-page.test.ts
@@ -1,0 +1,131 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, beforeEach, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.DEN_INSTALL_LINKS_GATING_ENABLED = "true"
+}
+
+const userId = createDenTypeId("user")
+const sessionId = createDenTypeId("session")
+const organizationId = createDenTypeId("organization")
+const invitationId = createDenTypeId("invitation")
+const insertedRows: unknown[] = []
+
+mock.module("../src/db.js", () => ({
+  db: {
+    insert: (_table: unknown) => ({
+      values: (values: unknown) => {
+        insertedRows.push(values)
+        return Promise.resolve()
+      },
+    }),
+    select: (_selection: unknown) => ({
+      from: (_table: unknown) => ({
+        where: (_condition: unknown) => ({
+          limit: (_count: number) => Promise.resolve([{ slug: "acme-robotics", metadata: { capabilities: { installLinks: true } } }]),
+        }),
+      }),
+    }),
+  },
+}))
+
+mock.module("../src/auth.js", () => ({
+  auth: {
+    api: {
+      setActiveOrganization: () => Promise.resolve(),
+    },
+  },
+}))
+
+class TestOrganizationEmailDomainRestrictionError extends Error {
+  readonly emailDomain = null
+  readonly allowedEmailDomains: string[] = []
+}
+
+mock.module("../src/orgs.js", () => ({
+  OrganizationEmailDomainRestrictionError: TestOrganizationEmailDomainRestrictionError,
+  acceptInvitationForUser: () => Promise.resolve({
+    invitation: { id: invitationId },
+    member: { organizationId },
+  }),
+  createOrganizationForUser: () => Promise.resolve(organizationId),
+  getInvitationPreview: () => Promise.resolve(null),
+  getSingletonSsoStatus: () => Promise.resolve({ configured: false, organizationSlug: "", signInPath: "/" }),
+  normalizeAllowedEmailDomains: () => ({ domains: null, invalidDomains: [] }),
+  setSessionActiveOrganization: () => Promise.resolve(),
+  updateOrganizationSettings: () => Promise.resolve(null),
+}))
+
+let coreModule: typeof import("../src/routes/org/core.js")
+let installLinksModule: typeof import("../src/install-links.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  coreModule = await import("../src/routes/org/core.js")
+  installLinksModule = await import("../src/install-links.js")
+})
+
+beforeEach(() => {
+  insertedRows.length = 0
+})
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function createApp() {
+  const app = new Hono()
+  app.use("*", async (c, next) => {
+    c.set("apiKey", null)
+    c.set("user", {
+      id: userId,
+      email: "agent@acme.test",
+      emailVerified: true,
+      name: "Agent",
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    c.set("session", {
+      id: sessionId,
+      activeOrganizationId: null,
+      createdAt: new Date(),
+    })
+    await next()
+  })
+  coreModule.registerOrgCoreRoutes(app)
+  return app
+}
+
+test("accepting an invitation returns an organization install page URL", async () => {
+  const response = await createApp().request("http://den.local/v1/orgs/invitations/accept", {
+    body: JSON.stringify({ id: invitationId }),
+    headers: { "content-type": "application/json" },
+    method: "POST",
+  })
+
+  expect(response.status).toBe(200)
+  const payload = await response.json()
+  expect(payload).toMatchObject({
+    accepted: true,
+    organizationId,
+    organizationSlug: "acme-robotics",
+    invitationId,
+  })
+
+  const installPageUrl = isRecord(payload) && typeof payload.installPageUrl === "string" ? payload.installPageUrl : ""
+  const url = new URL(installPageUrl)
+  const token = url.searchParams.get("token") ?? ""
+  const installLinkRow = insertedRows.find((row) => isRecord(row) && typeof row.tokenHash === "string")
+
+  expect(url.pathname).toBe("/install")
+  expect(token).toBeTruthy()
+  expect(installLinkRow).not.toHaveProperty("token")
+  expect(installLinkRow).not.toHaveProperty("installPageUrl")
+  expect(isRecord(installLinkRow) ? installLinkRow.tokenHash : null).toBe(installLinksModule.hashInstallLinkToken(token))
+})

--- a/ee/apps/den-api/test/plugin-system-create-bundle.test.ts
+++ b/ee/apps/den-api/test/plugin-system-create-bundle.test.ts
@@ -3,11 +3,15 @@ import {
   ConfigObjectAccessGrantTable,
   ConfigObjectTable,
   ConfigObjectVersionTable,
+  ExternalMcpConnectionAccessGrantTable,
+  ExternalMcpConnectionTable,
   MarketplacePluginTable,
   MarketplaceTable,
   PluginAccessGrantTable,
   PluginConfigObjectTable,
   PluginTable,
+  SkillHubSkillTable,
+  SkillTable,
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import type { PluginArchActorContext } from "../src/routes/org/plugin-system/access.js"
@@ -23,11 +27,15 @@ type TableName =
   | "config_object"
   | "config_object_access_grant"
   | "config_object_version"
+  | "external_mcp_connection"
+  | "external_mcp_connection_access_grant"
   | "marketplace"
   | "marketplace_plugin"
   | "plugin"
   | "plugin_access_grant"
   | "plugin_config_object"
+  | "skill"
+  | "skill_hub_skill"
 
 type Row = Record<string, unknown>
 
@@ -50,6 +58,7 @@ type WriteBuilder = {
 }
 
 type TransactionStub = {
+  delete: (table: unknown) => WriteBuilder
   insert: (table: unknown) => WriteBuilder
   select: () => QueryChain
   update: (table: unknown) => WriteBuilder
@@ -64,22 +73,30 @@ const tableNames: TableName[] = [
   "config_object",
   "config_object_access_grant",
   "config_object_version",
+  "external_mcp_connection",
+  "external_mcp_connection_access_grant",
   "marketplace",
   "marketplace_plugin",
   "plugin",
   "plugin_access_grant",
   "plugin_config_object",
+  "skill",
+  "skill_hub_skill",
 ]
 
 const rowsByTable: Record<TableName, Row[]> = {
   config_object: [],
   config_object_access_grant: [],
   config_object_version: [],
+  external_mcp_connection: [],
+  external_mcp_connection_access_grant: [],
   marketplace: [],
   marketplace_plugin: [],
   plugin: [],
   plugin_access_grant: [],
   plugin_config_object: [],
+  skill: [],
+  skill_hub_skill: [],
 }
 
 const recordedInserts: InsertRecord[] = []
@@ -90,11 +107,15 @@ function tableName(table: unknown): TableName | null {
   if (table === ConfigObjectTable) return "config_object"
   if (table === ConfigObjectAccessGrantTable) return "config_object_access_grant"
   if (table === ConfigObjectVersionTable) return "config_object_version"
+  if (table === ExternalMcpConnectionTable) return "external_mcp_connection"
+  if (table === ExternalMcpConnectionAccessGrantTable) return "external_mcp_connection_access_grant"
   if (table === MarketplaceTable) return "marketplace"
   if (table === MarketplacePluginTable) return "marketplace_plugin"
   if (table === PluginTable) return "plugin"
   if (table === PluginAccessGrantTable) return "plugin_access_grant"
   if (table === PluginConfigObjectTable) return "plugin_config_object"
+  if (table === SkillTable) return "skill"
+  if (table === SkillHubSkillTable) return "skill_hub_skill"
   return null
 }
 
@@ -119,11 +140,18 @@ function rowsFor(table: TableName | null) {
   return rowsByTable[table]
 }
 
-function queryChain(): QueryChain {
+function queryChain(options: { wrapConnection?: boolean } = {}): QueryChain {
   let selectedTable: TableName | null = null
   const resolveRows = (count?: number) => {
+    if (selectedTable === "plugin_config_object" && count === 1) {
+      return []
+    }
     const rows = rowsFor(selectedTable)
-    return count === undefined ? [...rows] : rows.slice(0, count)
+    const selectedRows = count === undefined ? [...rows] : rows.slice(0, count)
+    if (options.wrapConnection) {
+      return selectedRows.map((row) => ({ connection: row }))
+    }
+    return selectedRows
   }
   const chain: QueryChain = {
     from: (table) => {
@@ -163,16 +191,38 @@ function insertBuilder(table: unknown): WriteBuilder {
   }
 }
 
-function updateBuilder(_table: unknown): WriteBuilder {
+function deleteBuilder(table: unknown): WriteBuilder {
+  const name = tableName(table)
   updateCalls += 1
   return {
     set: () => ({ where: () => Promise.resolve() }),
+    values: () => Promise.resolve(),
+    where: () => {
+      if (name) rowsByTable[name] = []
+      return Promise.resolve()
+    },
+  }
+}
+
+function updateBuilder(table: unknown): WriteBuilder {
+  const name = tableName(table)
+  updateCalls += 1
+  return {
+    set: (value) => ({
+      where: () => {
+        if (name && isRecord(value)) {
+          rowsByTable[name] = rowsByTable[name].map((row) => ({ ...row, ...value }))
+        }
+        return Promise.resolve()
+      },
+    }),
     values: () => Promise.resolve(),
     where: () => Promise.resolve(),
   }
 }
 
 const transactionStub: TransactionStub = {
+  delete: deleteBuilder,
   insert: insertBuilder,
   select: queryChain,
   update: updateBuilder,
@@ -180,21 +230,45 @@ const transactionStub: TransactionStub = {
 
 let storeModule: typeof import("../src/routes/org/plugin-system/store.js")
 let schemas: typeof import("../src/routes/org/plugin-system/schemas.js")
+let externalCapabilities: typeof import("../src/mcp/external-capabilities.js")
+let skillCapabilities: typeof import("../src/mcp/skill-capabilities.js")
 
 beforeAll(async () => {
   seedRequiredEnv()
 
   mock.module("../src/db.js", () => ({
     db: {
+      delete: deleteBuilder,
       insert: insertBuilder,
       select: queryChain,
+      selectDistinct: () => queryChain({ wrapConnection: true }),
       transaction: async <TResult>(callback: (tx: TransactionStub) => Promise<TResult>) => callback(transactionStub),
       update: updateBuilder,
     },
   }))
 
+  mock.module("../src/capability-sources/url-guard.js", () => ({
+    PrivateUrlError: class PrivateUrlError extends Error {},
+    assertPublicUrl: () => Promise.resolve(),
+  }))
+
+  mock.module("../src/capability-sources/external-mcp-client.js", () => ({
+    callExternalMcpTool: () => Promise.resolve({ content: [{ text: "employee directory ok", type: "text" }] }),
+    createExternalMcpLifecycleDeadline: () => {
+      const controller = new AbortController()
+      return {
+        abort: (reason?: unknown) => controller.abort(reason),
+        expiresAt: Date.now() + 1000,
+        signal: controller.signal,
+      }
+    },
+    listExternalMcpTools: () => Promise.resolve([{ description: "Search employee directory", name: "search_employee_directory" }]),
+  }))
+
   schemas = await import("../src/routes/org/plugin-system/schemas.js")
   storeModule = await import("../src/routes/org/plugin-system/store.js")
+  externalCapabilities = await import("../src/mcp/external-capabilities.js")
+  skillCapabilities = await import("../src/mcp/skill-capabilities.js")
 })
 
 afterAll(() => {
@@ -314,9 +388,10 @@ test("createPluginBundle composes component creation, org-wide grants, and marke
     orgWide: true,
   })
 
-  expect(recordedInserts).toHaveLength(9)
+  expect(recordedInserts).toHaveLength(10)
   expect(recordedInserts.filter((entry) => entry.table === "plugin")).toHaveLength(1)
   expect(recordedInserts.filter((entry) => entry.table === "plugin_access_grant")).toHaveLength(2)
+  expect(recordedInserts.filter((entry) => entry.table === "skill")).toHaveLength(1)
   expect(recordedInserts.filter((entry) => entry.table === "config_object")).toHaveLength(1)
   expect(recordedInserts.filter((entry) => entry.table === "config_object_version")).toHaveLength(1)
   expect(recordedInserts.filter((entry) => entry.table === "config_object_access_grant")).toHaveLength(2)
@@ -325,4 +400,115 @@ test("createPluginBundle composes component creation, org-wide grants, and marke
   expect(recordedInserts.some((entry) => entry.table === "config_object_access_grant" && entry.value.orgWide === true && entry.value.role === "viewer")).toBe(true)
   expect(recordedInserts.some((entry) => entry.table === "plugin_access_grant" && entry.value.orgWide === true && entry.value.role === "viewer")).toBe(true)
   expect(recordedInserts.some((entry) => entry.table === "marketplace_plugin" && entry.value.marketplaceId === marketplace.id)).toBe(true)
+})
+
+test("manual plugin bundles materialize one native skill and one Connect MCP without duplicating on update, then clean owned resources on archive", async () => {
+  const organizationId = createDenTypeId("organization")
+  const memberId = createDenTypeId("member")
+  const now = new Date("2026-07-05T00:00:00.000Z")
+  const marketplace = {
+    id: createDenTypeId("marketplace"),
+    organizationId,
+    name: "OpenWork Marketplace",
+    description: "Company extensions",
+    logoUrl: null,
+    status: "active",
+    createdByOrgMembershipId: memberId,
+    createdAt: now,
+    updatedAt: now,
+    deletedAt: null,
+  }
+  resetDb({ marketplace: [marketplace] })
+
+  const context = ownerContext(organizationId, memberId)
+  const plugin = await storeModule.createPluginBundle({
+    components: [
+      {
+        type: "skill",
+        value: {
+          metadata: { name: "Inactive Account Check", description: "Find employees whose accounts should be reviewed" },
+          rawSourceText: "---\nname: inactive-account-check\ndescription: Find employees whose accounts should be reviewed\n---\nUse the Employee Directory MCP, then list inactive accounts.",
+        },
+      },
+      {
+        type: "mcp",
+        value: {
+          metadata: { name: "Employee Directory" },
+          normalizedPayloadJson: {
+            mcpServers: {
+              employee_directory: {
+                authType: "none",
+                credentialMode: "shared",
+                type: "remote",
+                url: "https://directory.example.com/mcp",
+              },
+            },
+          },
+        },
+      },
+    ],
+    context,
+    description: "Review inactive employee accounts.",
+    marketplaceId: marketplace.id,
+    name: "Inactive Account Check",
+    orgWide: true,
+  })
+
+  expect(recordedInserts.filter((entry) => entry.table === "skill")).toHaveLength(1)
+  expect(recordedInserts.filter((entry) => entry.table === "external_mcp_connection")).toHaveLength(1)
+  expect(recordedInserts.filter((entry) => entry.table === "external_mcp_connection_access_grant")).toHaveLength(1)
+  expect(recordedInserts.filter((entry) => entry.table === "config_object")).toHaveLength(2)
+
+  const skillRow = rowsByTable.skill[0]
+  const connectionRow = rowsByTable.external_mcp_connection[0]
+  expect(skillRow?.shared).toBe("org")
+  expect(skillRow?.title).toBe("Inactive Account Check")
+  expect(connectionRow?.name).toBe("Inactive Account Check / Employee Directory")
+  expect(connectionRow?.authType).toBe("none")
+  expect(connectionRow?.credentialMode).toBe("shared")
+  expect(connectionRow?.connectedAt instanceof Date).toBe(true)
+  expect(rowsByTable.external_mcp_connection_access_grant[0]?.orgWide).toBe(true)
+
+  const skillCount = rowsByTable.skill.length
+  const connectionCount = rowsByTable.external_mcp_connection.length
+  await storeModule.updatePlugin({ context, description: "Updated description.", name: "Inactive Account Check", pluginId: plugin.id })
+  expect(rowsByTable.skill).toHaveLength(skillCount)
+  expect(rowsByTable.external_mcp_connection).toHaveLength(connectionCount)
+
+  const member = { orgMembershipId: memberId, teamIds: [] }
+  const skillId = typeof skillRow?.id === "string" ? skillRow.id : ""
+  const skillMatches = await skillCapabilities.searchSkillCapabilities({
+    organizationId,
+    member,
+    query: "inactive account",
+    limit: 5,
+  })
+  expect(skillMatches.some((match) => match.name === skillCapabilities.buildSkillCapabilityName(skillId))).toBe(true)
+  const skillExecute = await skillCapabilities.executeSkillCapability({ organizationId, member, skillId })
+  expect(skillExecute.ok).toBe(true)
+  if (!skillExecute.ok) throw new Error(skillExecute.message)
+  expect(skillExecute.skill.skillText).toContain("Employee Directory MCP")
+
+  const connectionId = typeof connectionRow?.id === "string" ? connectionRow.id : ""
+  const externalMatches = await externalCapabilities.searchExternalCapabilities({
+    organizationId,
+    member,
+    query: "employee directory",
+    redirectUriBase: "http://127.0.0.1:8790",
+    limit: 5,
+  })
+  expect(externalMatches.some((match) => match.name === externalCapabilities.buildExternalCapabilityName(connectionId, "search_employee_directory"))).toBe(true)
+  const externalExecute = await externalCapabilities.executeExternalCapability({
+    args: {},
+    connectionId,
+    member,
+    organizationId,
+    redirectUriBase: "http://127.0.0.1:8790",
+    toolName: "search_employee_directory",
+  })
+  expect(externalExecute.ok).toBe(true)
+
+  await storeModule.setPluginLifecycle({ action: "archive", context, pluginId: plugin.id })
+  expect(rowsByTable.skill).toHaveLength(0)
+  expect(rowsByTable.external_mcp_connection).toHaveLength(0)
 })

--- a/ee/apps/den-api/test/route-guard-policy.test.ts
+++ b/ee/apps/den-api/test/route-guard-policy.test.ts
@@ -45,6 +45,7 @@ const routeGuardExceptions = new Map<string, string>([
   ["PATCH /api/auth/scim/v2/Users/:userId", "SCIM bearer token is validated by Better Auth"],
   ["DELETE /api/auth/scim/v2/Users/:userId", "SCIM bearer token is validated before forwarding"],
   ["GET /v1/install-config", "public install-link config; the install-link token is validated in-handler and rate-limited"],
+  ["GET /v1/install/:platform/prepare", "public stamped installer readiness; the install-link token is validated in-handler and rate-limited"],
   ["GET /v1/install/:platform", "public stamped installer download; the install-link token is validated in-handler and rate-limited"],
   ["GET /v1/orgs/invitations/preview", "public invitation preview by invitation id"],
   ["GET /v1/orgs/sso/singleton", "public singleton SSO status for auth UI"],

--- a/ee/apps/den-web/app/(den)/_components/install-download-spinner.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-download-spinner.tsx
@@ -1,0 +1,20 @@
+import { LoaderCircle } from "lucide-react";
+import type { CSSProperties } from "react";
+
+const spinnerStyle: CSSProperties = {
+  animationName: "spin",
+  animationDuration: "1s",
+  animationTimingFunction: "linear",
+  animationIterationCount: "infinite",
+};
+
+export function InstallDownloadSpinner() {
+  return (
+    <LoaderCircle
+      aria-hidden="true"
+      className="size-5 animate-spin text-[var(--dls-accent)]"
+      data-testid="install-download-spinner"
+      style={spinnerStyle}
+    />
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -3,8 +3,9 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { getErrorMessage, requestJson } from "../_lib/den-flow";
-import { buildInstallDownloadHref, type InstallPlatform } from "../_lib/install-download";
+import { buildInstallDownloadHref, buildInstallPreparePath, getInstallDownloadStage, parseInstallPrepareStatus, shouldAutoRequestInstaller, type InstallPlatform } from "../_lib/install-download";
 import { isMobileUserAgent } from "../_lib/platform";
+import { InstallDownloadSpinner } from "./install-download-spinner";
 
 type InstallConfig = {
   appName: string;
@@ -94,10 +95,16 @@ export function InstallScreen() {
   const [isMobile, setIsMobile] = useState<boolean | null>(null);
   const [platform, setPlatform] = useState<InstallPlatform>("mac-arm64");
   const [copied, setCopied] = useState(false);
-  const [downloadState, setDownloadState] = useState<"idle" | "preparing" | "started">("idle");
-  const [downloadLabel, setDownloadLabel] = useState("");
+  const [downloadState, setDownloadState] = useState<"idle" | "preparing" | "requested" | "error">("idle");
+  const [downloadLabel, setDownloadLabel] = useState("your computer");
+  const [downloadPlatform, setDownloadPlatform] = useState<InstallPlatform | null>(null);
+  const [downloadMessage, setDownloadMessage] = useState("");
+  const [downloadDetail, setDownloadDetail] = useState("");
+  const [showPreparationRetry, setShowPreparationRetry] = useState(false);
   const [downloadHref, setDownloadHref] = useState("");
-  const downloadStartedTimer = useRef<number | null>(null);
+  const prepareAbortController = useRef<AbortController | null>(null);
+  const prepareStageInterval = useRef<number | null>(null);
+  const prepareTimeout = useRef<number | null>(null);
 
   useEffect(() => {
     setIsMobile(isMobileUserAgent());
@@ -152,8 +159,12 @@ export function InstallScreen() {
   }, [token]);
 
   useEffect(() => () => {
-    if (downloadStartedTimer.current !== null) {
-      window.clearTimeout(downloadStartedTimer.current);
+    prepareAbortController.current?.abort();
+    if (prepareStageInterval.current !== null) {
+      window.clearInterval(prepareStageInterval.current);
+    }
+    if (prepareTimeout.current !== null) {
+      window.clearTimeout(prepareTimeout.current);
     }
   }, []);
 
@@ -165,17 +176,107 @@ export function InstallScreen() {
     window.setTimeout(() => setCopied(false), 1800);
   }
 
-  function beginDownload(label: string, href: string) {
+  function clearPreparationTimers() {
+    if (prepareStageInterval.current !== null) {
+      window.clearInterval(prepareStageInterval.current);
+      prepareStageInterval.current = null;
+    }
+    if (prepareTimeout.current !== null) {
+      window.clearTimeout(prepareTimeout.current);
+      prepareTimeout.current = null;
+    }
+  }
+
+  function updatePreparationStage(startedAt: number) {
+    const stage = getInstallDownloadStage(Date.now() - startedAt);
+    setDownloadMessage(stage.label);
+    setDownloadDetail(stage.detail);
+    setShowPreparationRetry(stage.showRetry);
+  }
+
+  async function beginDownload(targetPlatform: InstallPlatform, label: string) {
+    if (!config || !token) {
+      return;
+    }
+
+    prepareAbortController.current?.abort();
+    clearPreparationTimers();
+
+    const href = installHref(config, targetPlatform, token);
+    const controller = new AbortController();
+    const startedAt = Date.now();
+    let timedOut = false;
+
     setDownloadLabel(label);
+    setDownloadPlatform(targetPlatform);
     setDownloadHref(href);
     setDownloadState("preparing");
-    if (downloadStartedTimer.current !== null) {
-      window.clearTimeout(downloadStartedTimer.current);
+    setShowPreparationRetry(false);
+    updatePreparationStage(startedAt);
+
+    prepareAbortController.current = controller;
+    prepareStageInterval.current = window.setInterval(() => updatePreparationStage(startedAt), 1000);
+    prepareTimeout.current = window.setTimeout(() => {
+      timedOut = true;
+      controller.abort();
+    }, 90_000);
+
+    try {
+      const { response, payload } = await requestJson(
+        buildInstallPreparePath(targetPlatform, token),
+        { method: "GET", signal: controller.signal },
+        0,
+      );
+
+      if (controller.signal.aborted || prepareAbortController.current !== controller) {
+        return;
+      }
+
+      if (!response.ok) {
+        throw new Error(getErrorMessage(payload, response.status === 404 ? "This install link is expired or no longer available." : `Could not prepare this download (${response.status}).`));
+      }
+
+      const status = parseInstallPrepareStatus(payload);
+      if (!status) {
+        throw new Error("The server did not return a usable installer readiness status.");
+      }
+
+      clearPreparationTimers();
+      setShowPreparationRetry(false);
+      setDownloadState("requested");
+      setDownloadMessage(status.status === "fallback" ? "Standard OpenWork download requested" : "Team installer ready — download requested");
+      setDownloadDetail(status.status === "fallback"
+        ? "This server could not prepare a team ZIP, so the download request will use the verified standard installer."
+        : "Your browser is now handling the real installer request. Check your downloads if no prompt appears.");
+
+      if (shouldAutoRequestInstaller(status)) {
+        window.location.assign(href);
+      }
+    } catch (downloadError) {
+      if (controller.signal.aborted && !timedOut) {
+        return;
+      }
+      if (prepareAbortController.current !== controller) {
+        return;
+      }
+      clearPreparationTimers();
+      setDownloadState("error");
+      setDownloadMessage("Download was not requested");
+      setDownloadDetail(timedOut ? "The server did not report readiness in time. Retry the readiness check before downloading." : downloadError instanceof Error ? downloadError.message : "Could not prepare this download.");
+      setShowPreparationRetry(true);
+    } finally {
+      if (prepareAbortController.current === controller) {
+        prepareAbortController.current = null;
+        clearPreparationTimers();
+      }
     }
-    downloadStartedTimer.current = window.setTimeout(() => {
-      setDownloadState("started");
-      downloadStartedTimer.current = null;
-    }, 5000);
+  }
+
+  function retryDownload() {
+    if (!downloadPlatform) {
+      return;
+    }
+    void beginDownload(downloadPlatform, downloadLabel);
   }
 
   if (busy) {
@@ -232,31 +333,44 @@ export function InstallScreen() {
           </div>
         ) : (
           <div className="grid justify-items-center gap-4">
-            <a className="den-button-primary w-full justify-center sm:w-auto" href={primaryHref} data-testid="install-download-primary" onClick={() => beginDownload(primaryLabel, primaryHref)}>
+            <a className="den-button-primary w-full justify-center sm:w-auto" href={primaryHref} data-testid="install-download-primary" onClick={(event) => { event.preventDefault(); void beginDownload(platform, primaryLabel); }}>
               Download for {primaryLabel}
             </a>
             <div className="flex flex-wrap justify-center gap-2">
               {secondaryPlatforms.map((option) => (
-                <a key={option.value} className="den-button-secondary" href={installHref(config, option.value, token)} onClick={() => beginDownload(option.label, installHref(config, option.value, token))}>
+                <a key={option.value} className="den-button-secondary" href={installHref(config, option.value, token)} onClick={(event) => { event.preventDefault(); void beginDownload(option.value, option.label); }}>
                   {option.label}
                 </a>
               ))}
             </div>
             {downloadState !== "idle" ? (
-              <div className="den-frame-inset grid w-full justify-items-center gap-2 rounded-[1.25rem] p-4" aria-live="polite" data-testid="install-download-status">
+              <div className="den-frame-inset grid w-full justify-items-center gap-2 rounded-[1.25rem] p-4" aria-live={downloadState === "error" ? "assertive" : "polite"} role={downloadState === "error" ? "alert" : "status"} data-testid="install-download-status">
                 {downloadState === "preparing" ? (
                   <>
-                    <span className="size-5 animate-spin rounded-full border-2 border-[var(--dls-border-strong)] border-t-[var(--dls-accent)]" aria-hidden="true" />
-                    <p className="m-0 font-medium text-[var(--dls-text-primary)]">Preparing your {downloadLabel} download...</p>
-                    <p className="den-copy">The first download may take up to a minute. Your browser will begin downloading when it is ready.</p>
+                    <InstallDownloadSpinner />
+                    <p className="m-0 font-medium text-[var(--dls-text-primary)]" data-testid="install-download-stage">{downloadMessage}</p>
+                    <p className="den-copy">Preparing {downloadLabel}. {downloadDetail}</p>
+                    {showPreparationRetry ? (
+                      <button type="button" className="den-button-secondary" onClick={retryDownload} data-testid="install-download-retry">
+                        Retry readiness check
+                      </button>
+                    ) : null}
+                  </>
+                ) : downloadState === "requested" ? (
+                  <>
+                    <p className="m-0 font-medium text-[var(--dls-text-primary)]">{downloadMessage}</p>
+                    <p className="den-copy">{downloadDetail}</p>
+                    <button type="button" className="den-button-secondary" onClick={retryDownload} data-testid="install-download-retry">
+                      Try again
+                    </button>
                   </>
                 ) : (
                   <>
-                    <p className="m-0 font-medium text-[var(--dls-text-primary)]">Download started</p>
-                    <p className="den-copy">Your browser is preparing the file. If it does not appear, try the download again.</p>
-                    <a className="den-button-secondary" href={downloadHref} onClick={() => beginDownload(downloadLabel, downloadHref)}>
-                      Try again
-                    </a>
+                    <p className="m-0 font-medium text-[var(--dls-text-primary)]">{downloadMessage}</p>
+                    <p className="den-copy">{downloadDetail}</p>
+                    <button type="button" className="den-button-secondary" onClick={retryDownload} data-testid="install-download-retry" disabled={!downloadHref}>
+                      Retry readiness check
+                    </button>
                   </>
                 )}
               </div>

--- a/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
@@ -20,6 +20,7 @@ import { JoinOrgSuccess } from "./join-org-success";
 type JoinedOrg = {
   name: string;
   slug: string;
+  installPageUrl: string | null;
 };
 
 function LoadingCard({ title, body }: { title: string; body: string }) {
@@ -73,6 +74,20 @@ function getStringProperty(value: unknown, key: string) {
 
   const property = value[key];
   return typeof property === "string" ? property : null;
+}
+
+function getUrlProperty(value: unknown, key: string) {
+  const property = getStringProperty(value, key)?.trim();
+  if (!property) {
+    return null;
+  }
+
+  try {
+    new URL(property);
+    return property;
+  } catch {
+    return null;
+  }
 }
 
 export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
@@ -191,6 +206,7 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
       setJoinedOrg({
         name: preview?.organization.name ?? "your team",
         slug: organizationSlug,
+        installPageUrl: getUrlProperty(payload, "installPageUrl"),
       });
     } catch (error) {
       setJoinError(error instanceof Error ? error.message : "Could not join the organization.");
@@ -215,6 +231,7 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
     return (
       <JoinOrgSuccess
         organizationName={joinedOrg.name}
+        installPageUrl={joinedOrg.installPageUrl}
         onContinueInBrowser={() => router.replace(joinedOrg.slug ? getOrgDashboardRoute(joinedOrg.slug) : "/dashboard")}
       />
     );

--- a/ee/apps/den-web/app/(den)/_components/join-org-success.tsx
+++ b/ee/apps/den-web/app/(den)/_components/join-org-success.tsx
@@ -1,42 +1,41 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import { getErrorMessage, requestJson } from "../_lib/den-flow";
 import { isMobileUserAgent } from "../_lib/platform";
 
-const OPENWORK_DOWNLOAD_URL = "https://openworklabs.com/download";
-
-const capabilities = [
-  {
-    title: "Edit spreadsheets",
-    description: "Create, clean, and transform CSV and Excel files.",
-  },
-  {
-    title: "Control your browser",
-    description: "Automate the built-in browser for repetitive web tasks.",
-  },
-  {
-    title: "Organize files",
-    description: "Read, write, and manage files and folders.",
-  },
-  {
-    title: "Automate tasks",
-    description: "Build reusable workflows with skills and commands.",
-  },
-  {
-    title: "Generate content",
-    description: "Draft documents, emails, and reports.",
-  },
-  {
-    title: "Connect to APIs",
-    description: "Plug into external services and tools via MCP.",
-  },
-];
-
 type JoinOrgSuccessProps = {
   organizationName: string;
+  installPageUrl: string | null;
   onContinueInBrowser: () => void;
 };
+
+type JourneyStepProps = {
+  step: number;
+  title: string;
+  status: "done" | "current" | "up-next";
+  children: ReactNode;
+};
+
+function JourneyStep({ step, title, status, children }: JourneyStepProps) {
+  const statusLabel = status === "done" ? "Done" : status === "current" ? "Current" : "Up next";
+
+  return (
+    <li className="den-frame-inset grid gap-3 rounded-[1.35rem] p-4 sm:grid-cols-[auto_minmax(0,1fr)]" aria-current={status === "current" ? "step" : undefined} data-testid={`join-org-step-${step}`}>
+      <div className="grid size-10 place-items-center rounded-full border border-[var(--dls-border)] bg-[var(--dls-surface)] text-sm font-semibold text-[var(--dls-text-primary)]">
+        {status === "done" ? "✓" : step}
+      </div>
+      <div className="grid gap-2">
+        <div className="flex flex-wrap items-center gap-2">
+          <h2 className="m-0 text-base font-semibold text-[var(--dls-text-primary)]">{title}</h2>
+          <span className="den-kicker">{statusLabel}</span>
+        </div>
+        {children}
+      </div>
+    </li>
+  );
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -51,12 +50,13 @@ function getOpenworkUrl(payload: unknown): string | null {
   return typeof url === "string" && url.trim() ? url.trim() : null;
 }
 
-export function JoinOrgSuccess({ organizationName, onContinueInBrowser }: JoinOrgSuccessProps) {
+export function JoinOrgSuccess({ organizationName, installPageUrl, onContinueInBrowser }: JoinOrgSuccessProps) {
   const [isMobile, setIsMobile] = useState<boolean | null>(null);
   const [handoffBusy, setHandoffBusy] = useState(false);
   const [handoffAttempted, setHandoffAttempted] = useState(false);
   const [copyBusy, setCopyBusy] = useState(false);
   const [copied, setCopied] = useState(false);
+  const [installLinkCopied, setInstallLinkCopied] = useState(false);
   const [emailBusy, setEmailBusy] = useState(false);
   const [emailSent, setEmailSent] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -120,6 +120,25 @@ export function JoinOrgSuccess({ organizationName, onContinueInBrowser }: JoinOr
     }
   }
 
+  async function handleCopyInstallLink() {
+    setInstallLinkCopied(false);
+    setActionError(null);
+
+    try {
+      if (!installPageUrl) {
+        throw new Error("The team install link was not returned. Continue in the browser and ask an admin to share it again.");
+      }
+      if (!navigator.clipboard) {
+        throw new Error("Clipboard is not available in this browser.");
+      }
+      await navigator.clipboard.writeText(installPageUrl);
+      setInstallLinkCopied(true);
+      window.setTimeout(() => setInstallLinkCopied(false), 1800);
+    } catch (error) {
+      setActionError(error instanceof Error ? error.message : "Could not copy the install link.");
+    }
+  }
+
   async function handleEmailDownload() {
     setEmailBusy(true);
     setActionError(null);
@@ -147,73 +166,86 @@ export function JoinOrgSuccess({ organizationName, onContinueInBrowser }: JoinOr
           <p className="den-copy">The desktop app is where OpenWork runs on your computer and puts your team&apos;s setup to work.</p>
         </div>
 
-        {isMobile === null ? (
-          <p className="den-copy">Preparing your next step...</p>
-        ) : isMobile ? (
-          <div className="grid gap-5">
-            <div className="den-frame-inset grid gap-2 rounded-[1.5rem] p-5" data-testid="join-org-mobile-note">
-              <p className="m-0 text-base font-medium text-[var(--dls-text-primary)]">OpenWork runs on your computer.</p>
-              <p className="den-copy">You&apos;re in — next time you&apos;re at your computer, download the desktop app to put your team to work.</p>
-            </div>
-            <div className="flex flex-wrap gap-3">
-              <button
-                type="button"
-                className="den-button-primary w-full sm:w-auto"
-                onClick={() => void handleEmailDownload()}
-                disabled={emailBusy || emailSent}
-                data-testid="join-org-email-download"
-              >
-                {emailBusy ? "Sending..." : emailSent ? "Sent" : "Email me the download link"}
-              </button>
-            </div>
-            {emailSent ? <div className="den-notice is-info">Sent — check your inbox when you&apos;re back at your desk.</div> : null}
-          </div>
-        ) : (
-          <div className="grid gap-5">
-            <div className="grid gap-3 sm:grid-cols-2">
-              {capabilities.map((capability) => (
-                <div key={capability.title} className="den-frame-inset rounded-[1.25rem] p-4">
-                  <p className="m-0 text-sm font-medium text-[var(--dls-text-primary)]">{capability.title}</p>
-                  <p className="m-0 mt-1 text-xs leading-snug text-[var(--dls-text-secondary)]">{capability.description}</p>
+        {isMobile === null ? <p className="den-copy">Preparing your next step...</p> : null}
+
+        {isMobile !== null ? (
+          <ol className="grid list-none gap-3 p-0" data-testid="join-org-journey-map">
+            <JourneyStep step={1} title="Join team" status="done">
+              <p className="den-copy">Your account is now a member of {organizationName}.</p>
+            </JourneyStep>
+
+            <JourneyStep step={2} title="Download app" status="current">
+              {isMobile ? (
+                <div className="grid gap-3" data-testid="join-org-mobile-note">
+                  <p className="den-copy">OpenWork runs on your computer. Copy this team install link or email yourself a reminder for when you are back at your desk.</p>
+                  <div className="flex flex-wrap gap-3">
+                    <button
+                      type="button"
+                      className="den-button-primary w-full sm:w-auto"
+                      onClick={() => void handleCopyInstallLink()}
+                      disabled={!installPageUrl}
+                      data-testid="join-org-download"
+                    >
+                      {installLinkCopied ? "Copied team install link" : "Copy team install link"}
+                    </button>
+                    <button
+                      type="button"
+                      className="den-button-secondary w-full sm:w-auto"
+                      onClick={() => void handleEmailDownload()}
+                      disabled={emailBusy || emailSent}
+                      data-testid="join-org-email-download"
+                    >
+                      {emailBusy ? "Sending..." : emailSent ? "Sent" : "Email me"}
+                    </button>
+                  </div>
+                  {emailSent ? <div className="den-notice is-info">Sent — check your inbox when you&apos;re back at your desk.</div> : null}
                 </div>
-              ))}
-            </div>
+              ) : (
+                <div className="grid gap-3">
+                  <p className="den-copy">Get the {organizationName} installer so the desktop app starts with your team&apos;s setup.</p>
+                  {installPageUrl ? (
+                    // Open the team installer in a new tab so this journey map
+                    // (including the remaining "connect" step) stays available
+                    // while the download prepares.
+                    <a href={installPageUrl} target="_blank" rel="noreferrer" className="den-button-primary w-full justify-center sm:w-fit" data-testid="join-org-download">
+                      Download {organizationName} app
+                    </a>
+                  ) : (
+                    <div className="den-notice is-error">The team install link was not returned. Continue in the browser and ask an admin to share it again.</div>
+                  )}
+                </div>
+              )}
+            </JourneyStep>
 
-            <div className="flex flex-wrap gap-3">
-              <button
-                type="button"
-                className="den-button-primary w-full sm:w-auto"
-                onClick={() => void handleOpenOpenWork()}
-                disabled={handoffBusy}
-                data-testid="join-org-open-openwork"
-              >
-                {handoffBusy ? "Opening OpenWork..." : "Open OpenWork"}
-              </button>
-              <a
-                href={OPENWORK_DOWNLOAD_URL}
-                target="_blank"
-                rel="noreferrer"
-                className="den-button-secondary w-full sm:w-auto"
-                data-testid="join-org-download"
-              >
-                Download the desktop app
-              </a>
-            </div>
-
-            <button
-              type="button"
-              className="w-fit text-sm text-[var(--dls-text-secondary)] underline-offset-4 hover:underline"
-              onClick={() => void handleCopySignInLink()}
-              disabled={copyBusy}
-            >
-              {copyBusy ? "Copying..." : copied ? "Copied sign-in link" : "Copy sign-in link"}
-            </button>
-
-            {handoffAttempted && !actionError ? (
-              <p className="den-copy text-sm">Opening OpenWork now. If nothing happens, download the app or copy the sign-in link.</p>
-            ) : null}
-          </div>
-        )}
+            <JourneyStep step={3} title="Connect and try your first workflow" status="up-next">
+              <div className="grid gap-3">
+                <p className="den-copy">After installing, open OpenWork to connect this account and start with your team&apos;s first workflow.</p>
+                <div className="flex flex-wrap gap-3">
+                  <button
+                    type="button"
+                    className="den-button-secondary w-full sm:w-auto"
+                    onClick={() => void handleOpenOpenWork()}
+                    disabled={handoffBusy}
+                    data-testid="join-org-open-openwork"
+                  >
+                    {handoffBusy ? "Opening OpenWork..." : "Already installed? Open OpenWork"}
+                  </button>
+                  <button
+                    type="button"
+                    className="w-fit text-sm text-[var(--dls-text-secondary)] underline-offset-4 hover:underline"
+                    onClick={() => void handleCopySignInLink()}
+                    disabled={copyBusy}
+                  >
+                    {copyBusy ? "Copying..." : copied ? "Copied sign-in link" : "Copy sign-in link"}
+                  </button>
+                </div>
+                {handoffAttempted && !actionError ? (
+                  <p className="den-copy text-sm">Opening OpenWork now. If nothing happens, copy the sign-in link and paste it into the desktop app.</p>
+                ) : null}
+              </div>
+            </JourneyStep>
+          </ol>
+        ) : null}
 
         <button
           type="button"

--- a/ee/apps/den-web/app/(den)/_lib/install-download.ts
+++ b/ee/apps/den-web/app/(den)/_lib/install-download.ts
@@ -1,10 +1,106 @@
 export type InstallPlatform = "mac-arm64" | "mac-x64" | "win-x64" | "linux-x64" | "linux-arm64";
 
-export function buildInstallDownloadHref(apiUrl: string, platform: InstallPlatform, token: string) {
+export type InstallPrepareStatus =
+  | { status: "ready"; stage: "bundle" | "script" }
+  | { status: "fallback"; stage: "standard-download"; fallbackUrl: string };
+
+export type InstallDownloadStage = {
+  minimumElapsedMs: number;
+  label: string;
+  detail: string;
+  showRetry: boolean;
+};
+
+const initialInstallDownloadStage: InstallDownloadStage = {
+  minimumElapsedMs: 0,
+  label: "Checking this install link...",
+  detail: "The server is validating the token and platform before any download is requested.",
+  showRetry: false,
+};
+
+export const installDownloadStages: InstallDownloadStage[] = [
+  initialInstallDownloadStage,
+  {
+    minimumElapsedMs: 4_000,
+    label: "Preparing your team package...",
+    detail: "The server is resolving the signed installer and your workspace setup file.",
+    showRetry: false,
+  },
+  {
+    minimumElapsedMs: 12_000,
+    label: "Fetching release artifacts...",
+    detail: "First-time downloads can take a minute while OpenWork release files are cached.",
+    showRetry: false,
+  },
+  {
+    minimumElapsedMs: 30_000,
+    label: "Still preparing the installer...",
+    detail: "Cold servers may need longer. You can retry the readiness check without downloading twice.",
+    showRetry: true,
+  },
+];
+
+function installApiHref(apiUrl: string, path: string, token: string) {
   const url = new URL(apiUrl);
   const basePath = url.pathname.replace(/\/+$/, "");
-  url.pathname = `${basePath}/v1/install/${platform}`;
+  url.pathname = `${basePath}${path}`;
   url.search = `?token=${encodeURIComponent(token)}`;
   url.hash = "";
   return url.toString();
+}
+
+export function buildInstallDownloadHref(apiUrl: string, platform: InstallPlatform, token: string) {
+  return installApiHref(apiUrl, `/v1/install/${platform}`, token);
+}
+
+export function buildInstallPrepareHref(apiUrl: string, platform: InstallPlatform, token: string) {
+  return installApiHref(apiUrl, `/v1/install/${platform}/prepare`, token);
+}
+
+export function buildInstallPreparePath(platform: InstallPlatform, token: string) {
+  return `/v1/install/${platform}/prepare?token=${encodeURIComponent(token)}`;
+}
+
+export function getInstallDownloadStage(elapsedMs: number) {
+  let stage = initialInstallDownloadStage;
+  for (const candidate of installDownloadStages) {
+    if (elapsedMs >= candidate.minimumElapsedMs) {
+      stage = candidate;
+    }
+  }
+  return stage;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isReadyStage(value: unknown): value is "bundle" | "script" {
+  return value === "bundle" || value === "script";
+}
+
+export function parseInstallPrepareStatus(value: unknown): InstallPrepareStatus | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  if (value.status === "ready" && isReadyStage(value.stage)) {
+    return { status: "ready", stage: value.stage };
+  }
+
+  if (value.status === "fallback" && value.stage === "standard-download" && typeof value.fallbackUrl === "string" && value.fallbackUrl.trim()) {
+    const fallbackUrl = value.fallbackUrl.trim();
+    try {
+      new URL(fallbackUrl);
+    } catch {
+      return null;
+    }
+    return { status: "fallback", stage: "standard-download", fallbackUrl };
+  }
+
+  return null;
+}
+
+export function shouldAutoRequestInstaller(status: InstallPrepareStatus | null) {
+  return status?.status === "ready" || status?.status === "fallback";
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-data.tsx
@@ -67,6 +67,7 @@ export type PluginMcp = {
   description: string;
   transport: PluginMcpTransport;
   toolCount: number;
+  connectionBacked?: boolean;
 };
 
 export type PluginAgent = {
@@ -450,6 +451,23 @@ function asString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+export function resolvePluginMcpPresentation(
+  payload: Record<string, unknown> | null | undefined,
+): { connectionBacked: boolean; transport: PluginMcpTransport } {
+  const directTransport = asString(payload?.transport);
+  if (directTransport === "stdio" || directTransport === "http" || directTransport === "sse") {
+    return { connectionBacked: Boolean(asString(payload?.externalMcpConnectionId)), transport: directTransport };
+  }
+
+  const servers = isRecord(payload?.mcpServers) ? payload.mcpServers : null;
+  const server = servers ? Object.values(servers).find(isRecord) : null;
+  const serverType = asString(server?.type);
+  return {
+    connectionBacked: Boolean(asString(payload?.externalMcpConnectionId)),
+    transport: serverType === "sse" ? "sse" : serverType === "remote" || serverType === "http" ? "http" : "stdio",
+  };
+}
+
 function parseMembershipConfigObject(entry: unknown) {
   if (!isRecord(entry) || !isRecord(entry.configObject)) {
     return null;
@@ -552,13 +570,17 @@ async function fetchResolvedPlugin(id: string): Promise<DenPlugin | null> {
     } satisfies PluginHook));
   const mcps = membershipItems
     .filter((item) => item.objectType === "mcp")
-    .map((item) => ({
-      description: item.description,
-      id: item.id,
-      name: item.title,
-      toolCount: typeof item.normalizedPayload?.toolCount === "number" ? item.normalizedPayload.toolCount : 0,
-      transport: (asString(item.normalizedPayload?.transport) as PluginMcpTransport | null) ?? "stdio",
-    } satisfies PluginMcp));
+    .map((item) => {
+      const presentation = resolvePluginMcpPresentation(item.normalizedPayload);
+      return {
+        connectionBacked: presentation.connectionBacked,
+        description: item.description,
+        id: item.id,
+        name: item.title,
+        toolCount: typeof item.normalizedPayload?.toolCount === "number" ? item.normalizedPayload.toolCount : 0,
+        transport: presentation.transport,
+      } satisfies PluginMcp;
+    });
 
   const marketplaces = Array.isArray(pluginItem.marketplaces)
     ? pluginItem.marketplaces.flatMap((entry) => {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-detail-screen.tsx
@@ -214,7 +214,9 @@ function renderMcpRow(mcp: PluginMcp) {
         ) : null}
       </div>
       <span className="shrink-0 rounded-full bg-gray-50 px-2 py-0.5 text-[11px] text-gray-500">
-        {mcp.transport} · {mcp.toolCount} tool{mcp.toolCount === 1 ? "" : "s"}
+        {mcp.connectionBacked
+          ? `${mcp.transport.toUpperCase()} · OpenWork Connect`
+          : `${mcp.transport} · ${mcp.toolCount} tool${mcp.toolCount === 1 ? "" : "s"}`}
       </span>
     </div>
   );

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx
@@ -15,13 +15,14 @@ import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { useMarketplaces } from "./marketplace-data";
 import { pluginQueryKeys } from "./plugin-data";
 
-type ComponentKind = "skill" | "command" | "mcp";
+export type ComponentKind = "skill" | "command" | "mcp";
 
-type DraftComponent = {
+export type DraftComponent = {
   key: number;
   kind: ComponentKind;
   name: string;
   description: string;
+  suggestedPrompt: string;
   /** Markdown body for skills/commands; remote server URL for MCP. */
   content: string;
 };
@@ -67,7 +68,7 @@ const COMPONENT_META: Record<ComponentKind, { label: string; icon: typeof FileTe
   mcp: {
     label: "MCP server",
     icon: Server,
-    hint: "Connect a remote MCP server by URL. Members get its tools when they install the plugin.",
+    hint: "Connect a shared no-auth remote MCP server by public HTTPS URL. Configure OAuth or API-key MCPs in OpenWork Connect instead.",
   },
 };
 
@@ -80,13 +81,28 @@ function slugify(value: string): string {
     .slice(0, 64) || "component";
 }
 
-function buildSkillMarkdown(component: DraftComponent): string {
+export function validateManualPluginMcpUrl(value: string): string | null {
+  const trimmed = value.trim();
+  if (!trimmed) return "Enter the server URL.";
+  let url: URL;
+  try {
+    url = new URL(trimmed);
+  } catch {
+    return "Enter a valid https:// URL.";
+  }
+  if (url.protocol !== "https:") return "Manual MCP plugins support public https:// URLs only.";
+  if (url.username || url.password) return "Do not put credentials in the MCP URL. Add authenticated servers in OpenWork Connect.";
+  return null;
+}
+
+export function buildSkillMarkdown(component: DraftComponent): string {
   const name = slugify(component.name);
   const description = component.description.trim() || component.name.trim();
   return [
     "---",
     `name: ${name}`,
     `description: ${description}`,
+    ...(component.suggestedPrompt.trim() ? [`suggested_prompt: ${component.suggestedPrompt.trim()}`] : []),
     "---",
     "",
     component.content.trim(),
@@ -94,7 +110,7 @@ function buildSkillMarkdown(component: DraftComponent): string {
   ].join("\n");
 }
 
-function buildComponentBody(component: DraftComponent): Record<string, unknown> {
+export function buildComponentBody(component: DraftComponent): Record<string, unknown> {
   if (component.kind === "mcp") {
     const serverName = slugify(component.name);
     return {
@@ -102,10 +118,12 @@ function buildComponentBody(component: DraftComponent): Record<string, unknown> 
       input: {
         normalizedPayloadJson: {
           mcpServers: {
-            [serverName]: { type: "remote", url: component.content.trim() },
+            [serverName]: { authType: "none", credentialMode: "shared", type: "remote", url: component.content.trim() },
           },
         },
         metadata: {
+          authType: "none",
+          credentialMode: "shared",
           name: component.name.trim(),
           description: component.description.trim() || undefined,
         },
@@ -121,6 +139,7 @@ function buildComponentBody(component: DraftComponent): Record<string, unknown> 
       metadata: {
         name: component.name.trim(),
         description: component.description.trim() || undefined,
+        suggestedPrompt: component.kind === "skill" ? component.suggestedPrompt.trim() || undefined : undefined,
       },
     },
   };
@@ -257,7 +276,7 @@ export function PluginEditorScreen() {
   const addComponent = (kind: ComponentKind) => {
     setComponents((current) => [
       ...current,
-      { key: nextKey, kind, name: "", description: "", content: "" },
+      { key: nextKey, kind, name: "", description: "", suggestedPrompt: "", content: "" },
     ]);
     setNextKey((value) => value + 1);
   };
@@ -293,6 +312,13 @@ export function PluginEditorScreen() {
             : `Write the instructions for "${component.name || "your component"}".`,
         );
         return;
+      }
+      if (component.kind === "mcp") {
+        const urlError = validateManualPluginMcpUrl(component.content);
+        if (urlError) {
+          setSaveError(`${component.name || "MCP server"}: ${urlError}`);
+          return;
+        }
       }
     }
 
@@ -713,13 +739,26 @@ export function PluginEditorScreen() {
                       disabled={saving}
                     />
                   ) : null}
-                  {component.kind === "mcp" ? (
+                  {component.kind === "skill" ? (
                     <DenInput
-                      value={component.content}
-                      onChange={(event) => updateComponent(component.key, { content: event.target.value })}
-                      placeholder="https://mcp.example.com/mcp"
+                      value={component.suggestedPrompt}
+                      onChange={(event) => updateComponent(component.key, { suggestedPrompt: event.target.value })}
+                      placeholder="Suggested prompt members can start with"
                       disabled={saving}
                     />
+                  ) : null}
+                  {component.kind === "mcp" ? (
+                    <div>
+                      <DenInput
+                        value={component.content}
+                        onChange={(event) => updateComponent(component.key, { content: event.target.value })}
+                        placeholder="https://mcp.example.com/mcp"
+                        disabled={saving}
+                      />
+                      <p className="mt-1.5 text-[12px] leading-5 text-gray-500">
+                        This creates a shared no-auth OpenWork Connect connection. OAuth and API-key MCP servers must be configured in Connect first.
+                      </p>
+                    </div>
                   ) : (
                     <DenTextarea
                       value={component.content}

--- a/ee/apps/den-web/tests/install-download-href.test.ts
+++ b/ee/apps/den-web/tests/install-download-href.test.ts
@@ -1,5 +1,14 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { expect, test } from "bun:test";
-import { buildInstallDownloadHref } from "../app/(den)/_lib/install-download";
+import { buildInstallDownloadHref, buildInstallPrepareHref, buildInstallPreparePath, getInstallDownloadStage, parseInstallPrepareStatus, shouldAutoRequestInstaller } from "../app/(den)/_lib/install-download";
+
+function readInstallScreen() {
+  return readFileSync(
+    fileURLToPath(new URL("../app/(den)/_components/install-screen.tsx", import.meta.url)),
+    "utf8",
+  );
+}
 
 test("organization installer downloads preserve a prefixed public API path", () => {
   expect(buildInstallDownloadHref(
@@ -15,4 +24,47 @@ test("organization installer downloads still support a root API origin", () => {
     "mac-arm64",
     "opaque-token",
   )).toBe("https://api.openwork.example.test/v1/install/mac-arm64?token=opaque-token");
+});
+
+test("installer readiness checks preserve prefixed API paths", () => {
+  expect(buildInstallPrepareHref(
+    "https://on-prem.example.test/api/den/",
+    "win-x64",
+    "opaque/token value",
+  )).toBe("https://on-prem.example.test/api/den/v1/install/win-x64/prepare?token=opaque%2Ftoken%20value");
+  expect(buildInstallPreparePath("mac-x64", "opaque/token value")).toBe("/v1/install/mac-x64/prepare?token=opaque%2Ftoken%20value");
+});
+
+test("download preparation stages describe a long real wait without claiming a start", () => {
+  expect(getInstallDownloadStage(0).label).toBe("Checking this install link...");
+  expect(getInstallDownloadStage(4_000).label).toBe("Preparing your team package...");
+  expect(getInstallDownloadStage(12_000).label).toBe("Fetching release artifacts...");
+  expect(getInstallDownloadStage(30_000)).toMatchObject({
+    label: "Still preparing the installer...",
+    showRetry: true,
+  });
+});
+
+test("readiness responses drive automatic installer requests only for real outcomes", () => {
+  const ready = parseInstallPrepareStatus({ status: "ready", stage: "bundle" });
+  const fallback = parseInstallPrepareStatus({ status: "fallback", stage: "standard-download", fallbackUrl: "https://openworklabs.com/download" });
+
+  expect(ready).toEqual({ status: "ready", stage: "bundle" });
+  expect(fallback).toEqual({ status: "fallback", stage: "standard-download", fallbackUrl: "https://openworklabs.com/download" });
+  expect(parseInstallPrepareStatus({ status: "ready" })).toBeNull();
+  if (!ready || !fallback) {
+    throw new Error("expected parseable readiness payloads");
+  }
+  expect(shouldAutoRequestInstaller(ready)).toBe(true);
+  expect(shouldAutoRequestInstaller(fallback)).toBe(true);
+  expect(shouldAutoRequestInstaller(null)).toBe(false);
+});
+
+test("install screen requests the real attachment only after readiness succeeds", () => {
+  const source = readInstallScreen();
+
+  expect(source).toContain("parseInstallPrepareStatus(payload)");
+  expect(source).toContain("if (shouldAutoRequestInstaller(status))");
+  expect(source).toContain("window.location.assign(href)");
+  expect(source).not.toContain("Download started");
 });

--- a/ee/apps/den-web/tests/install-download-spinner.test.tsx
+++ b/ee/apps/den-web/tests/install-download-spinner.test.tsx
@@ -1,0 +1,14 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { InstallDownloadSpinner } from "../app/(den)/_components/install-download-spinner";
+
+test("install download spinner exposes a stable animated loading affordance", () => {
+  const markup = renderToStaticMarkup(<InstallDownloadSpinner />);
+
+  expect(markup).toContain('data-testid="install-download-spinner"');
+  expect(markup).toContain("animate-spin");
+  expect(markup).toContain("animation-name:spin");
+  expect(markup).toContain("animation-duration:1s");
+  expect(markup).toContain("animation-timing-function:linear");
+  expect(markup).toContain("animation-iteration-count:infinite");
+});

--- a/ee/apps/den-web/tests/join-org-success-journey.test.ts
+++ b/ee/apps/den-web/tests/join-org-success-journey.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { expect, test } from "bun:test";
+
+function readJoinOrgSuccess() {
+  return readFileSync(
+    fileURLToPath(new URL("../app/(den)/_components/join-org-success.tsx", import.meta.url)),
+    "utf8",
+  );
+}
+
+test("join organization success keeps one journey map with the organization install page as the primary download", () => {
+  const source = readJoinOrgSuccess();
+
+  expect(source).toContain('data-testid="join-org-journey-map"');
+  expect(source).toContain('title="Join team"');
+  expect(source).toContain('title="Download app"');
+  expect(source).toContain('title="Connect and try your first workflow"');
+  expect(source).toContain("href={installPageUrl}");
+  // The installer must open in a new tab so the journey map (and its
+  // remaining "connect" step) survives the download navigation.
+  expect(source).toContain('href={installPageUrl} target="_blank" rel="noreferrer"');
+  expect(source).not.toContain("https://openworklabs.com/download");
+  expect(source).not.toContain("capabilities.map");
+});

--- a/ee/apps/den-web/tests/plugin-editor-manual-connect.test.ts
+++ b/ee/apps/den-web/tests/plugin-editor-manual-connect.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildComponentBody,
+  buildSkillMarkdown,
+  validateManualPluginMcpUrl,
+  type DraftComponent,
+} from "../app/(den)/dashboard/_components/plugin-editor-screen";
+import { resolvePluginMcpPresentation } from "../app/(den)/dashboard/_components/plugin-data";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+describe("manual plugin editor Connect payloads", () => {
+  test("declares URL-only MCPs as shared no-auth remote connections", () => {
+    const component: DraftComponent = {
+      key: 1,
+      kind: "mcp",
+      name: "Employee Directory",
+      description: "",
+      suggestedPrompt: "",
+      content: "https://directory.example.com/mcp",
+    };
+
+    const body = buildComponentBody(component);
+    const input = isRecord(body.input) ? body.input : {};
+    const metadata = isRecord(input.metadata) ? input.metadata : {};
+    const payload = isRecord(input.normalizedPayloadJson) ? input.normalizedPayloadJson : {};
+    const servers = isRecord(payload.mcpServers) ? payload.mcpServers : {};
+    const server = isRecord(servers["employee-directory"]) ? servers["employee-directory"] : {};
+
+    expect(metadata.authType).toBe("none");
+    expect(metadata.credentialMode).toBe("shared");
+    expect(server.authType).toBe("none");
+    expect(server.credentialMode).toBe("shared");
+    expect(server.type).toBe("remote");
+    expect(server.url).toBe("https://directory.example.com/mcp");
+  });
+
+  test("keeps skill instructions and suggested prompt in the submitted bundle", () => {
+    const component: DraftComponent = {
+      key: 1,
+      kind: "skill",
+      name: "Inactive Account Check",
+      description: "Find employees whose accounts should be reviewed",
+      suggestedPrompt: "Check inactive accounts in the employee directory",
+      content: "Use the Employee Directory MCP and report inactive accounts.",
+    };
+
+    expect(buildSkillMarkdown(component)).toContain("suggested_prompt: Check inactive accounts in the employee directory");
+    const body = buildComponentBody(component);
+    const input = isRecord(body.input) ? body.input : {};
+    const metadata = isRecord(input.metadata) ? input.metadata : {};
+    expect(metadata.suggestedPrompt).toBe("Check inactive accounts in the employee directory");
+  });
+
+  test("rejects non-HTTPS or credential-bearing manual MCP URLs", () => {
+    expect(validateManualPluginMcpUrl("http://directory.example.com/mcp")).toContain("https://");
+    expect(validateManualPluginMcpUrl("https://token@directory.example.com/mcp")).toContain("credentials");
+    expect(validateManualPluginMcpUrl("https://directory.example.com/mcp")).toBeNull();
+  });
+
+  test("presents a materialized remote MCP as an OpenWork Connect HTTP connection", () => {
+    expect(resolvePluginMcpPresentation({
+      externalMcpConnectionId: "mcp_connection_123",
+      mcpServers: {
+        employee_directory: { type: "remote", url: "https://directory.example.com/mcp" },
+      },
+    })).toEqual({ connectionBacked: true, transport: "http" });
+  });
+});

--- a/evals/flows/invite-connect-first-skill.flow.mjs
+++ b/evals/flows/invite-connect-first-skill.flow.mjs
@@ -1,0 +1,1275 @@
+import { execSync } from "node:child_process";
+import { connect, debuggerUrlFor, listTargets } from "../runner/cdp.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/invite-connect-first-skill.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("invite-connect-first-skill");
+
+const DEN_API_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_API_URL);
+const DEN_WEB_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_WEB_URL);
+const WEB_CDP_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_WEB_CDP_URL);
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MEMBER_PASSWORD = process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || "OpenWorkDemo123!";
+const PUBLIC_MOCK_MCP_URL = process.env.OPENWORK_EVAL_PUBLIC_MOCK_MCP_URL?.trim() || "";
+const EXPLICIT_MOCK_REQUESTS_URL = process.env.OPENWORK_EVAL_PUBLIC_MOCK_MCP_REQUESTS_URL?.trim() || "";
+const MOCK_INSPECTION_URL = process.env.OPENWORK_EVAL_PUBLIC_MOCK_MCP_INSPECTION_URL?.trim() || "";
+
+const RUN_TAG = Date.now().toString(36);
+const RUN_NONCE = `inactive-account-check-${RUN_TAG}`;
+const INVITEE_EMAIL = `morgan+${RUN_TAG}@acme.test`;
+const ORG_NAME = "Acme Robotics";
+const PLUGIN_NAME = "Inactive Account Check";
+const MCP_COMPONENT_NAME = "Employee Directory";
+const SUGGESTED_PROMPT = "Show me which employee accounts have been inactive for 30 days.";
+const MCP_URL = buildPublicMcpUrl(PUBLIC_MOCK_MCP_URL, RUN_TAG);
+const MOCK_REQUESTS_URL = buildMockRequestsUrl({ mcpUrl: MCP_URL, explicitRequestsUrl: EXPLICIT_MOCK_REQUESTS_URL, inspectionUrl: MOCK_INSPECTION_URL });
+
+const state = {
+  desktopClient: null,
+  webClient: null,
+  installClient: null,
+  adminToken: null,
+  memberToken: null,
+  inviteLink: null,
+  inviteToken: null,
+  installPageUrl: null,
+  pluginId: null,
+  denSkillId: null,
+  connectionId: null,
+  connectionName: null,
+  openworkUrl: null,
+  workspaceId: null,
+  sessionId: null,
+  chatStartedAt: null,
+};
+
+export default {
+  id: "invite-connect-first-skill",
+  title: "An invited teammate completes their first admin-provided workflow through OpenWork Connect",
+  kind: "user-facing",
+  requiredEnv: [
+    "OPENWORK_EVAL_DEN_API_URL",
+    "OPENWORK_EVAL_DEN_WEB_URL",
+    "OPENWORK_EVAL_WEB_CDP_URL",
+    "OPENWORK_EVAL_MARK_VERIFIED_CMD",
+    "OPENWORK_EVAL_PUBLIC_MOCK_MCP_URL",
+  ],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        rememberDesktopClient(ctx);
+        await withWebClient(ctx, async () => {
+          await ctx.prove("The admin creates the Inactive Account Check bundle from the real plugin editor", {
+            voiceover: vo[0],
+            action: async () => {
+              await assertMockServerReady(ctx);
+              await ensureAdminToken(ctx);
+              await cleanupStalePluginBundles(ctx);
+              await signInToDenWeb(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+              await selectOrganizationThroughUi(ctx, ORG_NAME);
+              await openAdminRoute(ctx, "/dashboard/plugins/new", ORG_NAME, "Create a plugin");
+              await ctx.waitFor("location.pathname.endsWith('/dashboard/plugins/new') || location.pathname.includes('/dashboard/plugins/new')", { timeoutMs: 30_000, label: "plugin editor route" });
+              await createPluginBundleThroughUi(ctx);
+            },
+            assert: async () => {
+              await ctx.expectText(PLUGIN_NAME, { timeoutMs: 45_000 });
+              await ctx.expectText("SKILLS", { timeoutMs: 20_000 });
+              await ctx.expectText("MCP SERVERS", { timeoutMs: 20_000 });
+              await ctx.expectText("HTTP · OpenWork Connect", { timeoutMs: 20_000 });
+              const bundle = await assertCreatedPluginBundle(ctx);
+              ctx.output("created-plugin-bundle", JSON.stringify(bundle, null, 2));
+            },
+            screenshot: {
+              name: "admin-plugin-bundle-ready",
+              requireText: [PLUGIN_NAME, "SKILLS", "MCP SERVERS", MCP_COMPONENT_NAME, "HTTP · OpenWork Connect"],
+              rejectText: ["Failed to create", "Something went wrong"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await withWebClient(ctx, async () => {
+          await ctx.prove("The invite email names the inviter, organization, role, and one clear get-started action", {
+            voiceover: vo[1],
+            action: async () => {
+              await openAdminRoute(ctx, "/dashboard/members", ORG_NAME, "Invite teammates");
+              await clickExactText(ctx, "Add member", "button");
+              await ctx.fill('input[placeholder="teammate@example.com"]', INVITEE_EMAIL);
+              await clickExactText(ctx, "Send invite", "button");
+              await ctx.waitForText(INVITEE_EMAIL, { timeoutMs: 30_000 });
+              await ctx.waitForText("Pending", { timeoutMs: 20_000 });
+              await navigateToAbsolute(ctx, `${DEN_API_URL}/v1/dev/emails/last?template=organizationInvite`);
+              await ctx.waitForText("Accept invite", { timeoutMs: 20_000 });
+            },
+            assert: async () => {
+              const { entry, html } = await getLatestDevEmail(ctx, "organizationInvite", INVITEE_EMAIL);
+              ctx.assert(html.includes(ADMIN_EMAIL), "Invite email does not identify the administrator email.");
+              ctx.assert(html.includes(ORG_NAME), "Invite email does not identify the organization.");
+              ctx.assert(/\bmember\b/i.test(html), "Invite email does not identify member access.");
+              ctx.assert(html.includes("Accept invite"), "Invite email is missing the primary accept action.");
+              const invite = extractInviteFromHtml(html, ctx);
+              state.inviteToken = invite.token;
+              state.inviteLink = rewriteDenWebLink(invite.link);
+              const installUrl = extractInstallFromHtml(html, ctx);
+              state.installPageUrl = rewriteDenWebLink(installUrl);
+              ctx.output("invite-email", JSON.stringify({ to: entry.to, subject: entry.subject, inviteLink: state.inviteLink, installPageUrl: state.installPageUrl }, null, 2));
+              await ctx.expectText("OPENWORK INVITE");
+              await ctx.expectText("Join Acme Robotics");
+              await ctx.expectText("Accept invite");
+            },
+            screenshot: {
+              name: "invite-email",
+              requireText: ["OPENWORK INVITE", "Join Acme Robotics", "Accept invite", "Download the desktop app"],
+              rejectText: ["Something went wrong"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await withWebClient(ctx, async () => {
+          await ctx.prove("The invite page keeps the teammate in place while they create, verify, and accept their account", {
+            voiceover: vo[2],
+            action: async () => {
+              await clearDenWebSession(ctx);
+              await navigateToAbsolute(ctx, requireStateValue(state.inviteLink, "invite link"));
+              await ctx.waitForText(ORG_NAME, { timeoutMs: 45_000 });
+              await ctx.waitForText("Your team is already set up and waiting.", { timeoutMs: 20_000 });
+              await completeInviteSignup(ctx, INVITEE_EMAIL, MEMBER_PASSWORD);
+              state.memberToken = await signInAndReturnToken(ctx, INVITEE_EMAIL, MEMBER_PASSWORD);
+              state.installPageUrl = await ctx.eval("document.querySelector('[data-testid=\"join-org-download\"]')?.href ?? null") || state.installPageUrl;
+            },
+            assert: async () => {
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))", { timeoutMs: 45_000, label: "join org success" });
+              await ctx.expectText("You're in");
+              await ctx.expectText(ORG_NAME);
+              await ctx.expectText("Join team");
+              ctx.assert(typeof state.installPageUrl === "string" && state.installPageUrl.includes("/install?token="), "Join success did not preserve the team install link.");
+            },
+            screenshot: {
+              name: "invite-accepted-with-place-preserved",
+              requireText: ["You're in", ORG_NAME, "Join team"],
+              rejectText: ["This invite can't be opened", "Something went wrong"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await withWebClient(ctx, async () => {
+          await ctx.prove("The browser success page maps the teammate's remaining journey and current step", {
+            voiceover: vo[3],
+            action: async () => {
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))", { timeoutMs: 45_000, label: "join success still open" });
+              await ctx.eval("document.querySelector('[data-testid=\"join-org-journey-map\"]')?.scrollIntoView({ block: 'center' })");
+              // Step through the page as a keyboard user would; the real Tab
+              // keypress draws a :focus-visible ring on the current step's
+              // primary download action, which also keeps this frame visually
+              // distinct from frame 3's acceptance capture.
+              await ctx.eval("document.body.focus()");
+              for (let presses = 0; presses < 12; presses += 1) {
+                await ctx.client.send("Input.dispatchKeyEvent", { type: "keyDown", key: "Tab", code: "Tab", windowsVirtualKeyCode: 9 });
+                await ctx.client.send("Input.dispatchKeyEvent", { type: "keyUp", key: "Tab", code: "Tab", windowsVirtualKeyCode: 9 });
+                const focused = await ctx.eval("document.activeElement?.getAttribute('data-testid') ?? ''");
+                if (focused === "join-org-download") break;
+              }
+              const focusedAction = await ctx.eval("document.activeElement?.getAttribute('data-testid') ?? ''");
+              ctx.assert(focusedAction === "join-org-download", `Keyboard focus did not land on the journey download action: ${focusedAction}`);
+            },
+            assert: async () => {
+              await ctx.expectText("Join team");
+              await ctx.expectText("Download app");
+              await ctx.expectText("Connect and try your first workflow");
+              const stepState = await ctx.eval(`(() => ({
+                step1: document.querySelector('[data-testid="join-org-step-1"]')?.innerText ?? '',
+                step2Current: document.querySelector('[data-testid="join-org-step-2"]')?.getAttribute('aria-current') === 'step',
+                step3: document.querySelector('[data-testid="join-org-step-3"]')?.innerText ?? '',
+              }))()`);
+              ctx.assert(stepState.step1.includes("Done"), `Join step was not marked done: ${JSON.stringify(stepState)}`);
+              ctx.assert(stepState.step2Current, "Download step was not marked as the current journey step.");
+              ctx.assert(stepState.step3.includes("Up next"), `Workflow step was not marked up next: ${JSON.stringify(stepState)}`);
+            },
+            screenshot: {
+              name: "browser-journey-map",
+              requireText: ["Join team", "Download app", "Current", "Connect and try your first workflow", "Up next"],
+              rejectText: ["Something went wrong"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await withWebClient(ctx, async () => {
+          // The journey map's download action opens the team install page in
+          // a new tab, so the invitee's remaining steps stay visible.
+          await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-download\"]'))", { timeoutMs: 30_000, label: "journey download action" });
+          await ctx.eval("document.querySelector('[data-testid=\"join-org-download\"]')?.click()");
+        });
+        await connectInstallTab(ctx);
+        await withInstallTab(ctx, async () => {
+          await ctx.prove("The install page recommends the right installer and starts from one primary action", {
+            voiceover: vo[4],
+            action: async () => {
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"install-card\"]'))", { timeoutMs: 45_000, label: "install card" });
+              await ctx.client.send("Network.enable").catch(() => undefined);
+              await ctx.client.send("Network.emulateNetworkConditions", {
+                offline: false,
+                latency: 15_000,
+                downloadThroughput: 50_000,
+                uploadThroughput: 50_000,
+                connectionType: "cellular3g",
+              });
+              await ctx.eval(`(() => {
+                const preventDefaultOnce = (event) => event.preventDefault();
+                document.addEventListener('click', preventDefaultOnce, { capture: true, once: true });
+                document.querySelector('[data-testid="install-download-primary"]')?.click();
+                return true;
+              })()`);
+              await ctx.waitForText("Checking this install link...", { timeoutMs: 2_000 });
+            },
+            assert: async () => {
+              const primary = await ctx.eval("document.querySelector('[data-testid=\"install-download-primary\"]')?.textContent?.trim() ?? ''");
+              ctx.assert(primary.startsWith("Download for "), `Primary installer label was not a recommendation: ${primary}`);
+              await ctx.expectText("Windows");
+              await ctx.expectText("Linux (x64)");
+              await ctx.expectText("Checking this install link...");
+            },
+            screenshot: {
+              name: "recommended-installer-started",
+              requireText: ["Download OpenWork for Acme Robotics", "Download for", "Windows", "Checking this install link..."],
+              rejectText: ["This install link can't be opened", "Something went wrong"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await withInstallTab(ctx, async () => {
+          await ctx.prove("The installer preparation indicator moves and advances through meaningful stages", {
+            voiceover: vo[5],
+            action: async () => {
+              await ctx.waitForText("Preparing your team package...", { timeoutMs: 8_000 });
+              await ctx.waitForText("Fetching release artifacts...", { timeoutMs: 14_000 });
+            },
+            assert: async () => {
+              const firstSpinner = await ctx.eval(`(() => {
+                const element = document.querySelector('[data-testid="install-download-spinner"]');
+                if (!element) return null;
+                const style = getComputedStyle(element);
+                return { animationName: style.animationName, animationDuration: style.animationDuration, transform: style.transform };
+              })()`);
+              await new Promise((resolve) => setTimeout(resolve, 180));
+              const secondTransform = await ctx.eval("getComputedStyle(document.querySelector('[data-testid=\"install-download-spinner\"]')).transform");
+              ctx.assert(Boolean(firstSpinner), "Install download spinner was not rendered.");
+              ctx.assert(firstSpinner.animationName.includes("spin"), `Spinner animation was not spin: ${JSON.stringify(firstSpinner)}`);
+              ctx.assert(firstSpinner.animationDuration === "1s", `Spinner animation duration changed: ${JSON.stringify(firstSpinner)}`);
+              ctx.assert(firstSpinner.transform !== secondTransform, `Spinner transform did not move across frames: ${firstSpinner.transform}`);
+              await ctx.expectText("Fetching release artifacts...");
+              ctx.output("install-motion-proof", JSON.stringify({ first: firstSpinner, secondTransform, sampleDelayMs: 180 }, null, 2));
+            },
+            screenshot: {
+              name: "installer-preparation-stages",
+              requireText: ["Fetching release artifacts...", "First-time downloads can take a minute"],
+              rejectText: ["Download was not requested", "Something went wrong"],
+            },
+          });
+          await restoreNetworkConditions(ctx);
+        });
+      },
+    },
+    {
+      name: "Frame 7",
+      run: async (ctx) => {
+        await withInstallTab(ctx, async () => {
+          await ctx.prove("The page confirms the automatic browser download request and gives one concise install instruction", {
+            voiceover: vo[6],
+            action: async () => {
+              await restoreNetworkConditions(ctx);
+              await ctx.waitFor("document.body.innerText.includes('download requested') || document.body.innerText.includes('Download started')", { timeoutMs: 45_000, label: "download requested confirmation" });
+            },
+            assert: async () => {
+              const status = await ctx.eval("document.querySelector('[data-testid=install-download-status]')?.innerText ?? ''");
+              ctx.assert(/download requested|Download started/i.test(status), `Install page did not confirm the browser download request: ${status}`);
+              ctx.assert(status.includes("Check your downloads") || status.includes("browser"), `Install instruction was not concise: ${status}`);
+              await ctx.expectText("Try again");
+            },
+            screenshot: {
+              name: "installer-download-requested",
+              requireText: ["download requested", "Check your downloads", "Try again"],
+              rejectText: ["Download was not requested", "Something went wrong"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 8",
+      run: async (ctx) => {
+        useDesktopClient(ctx);
+        await ctx.prove("The Electron app accepts the invitee's secure Den handoff through the renderer deep-link bridge", {
+          voiceover: vo[7],
+          action: async () => {
+            await withWebClient(ctx, async () => {
+              // The journey tab stayed open because the installer downloaded
+              // in its own tab; the invitee continues from step 3 directly.
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))", { timeoutMs: 30_000, label: "journey tab still open" });
+              await stubClipboardCapture(ctx);
+              await clickExactText(ctx, "Copy sign-in link", "button");
+              state.openworkUrl = await ctx.waitFor(
+                "typeof window.__capturedSignin === 'string' && window.__capturedSignin.startsWith('openwork://den-auth') && window.__capturedSignin",
+                { timeoutMs: 30_000, label: "browser-created OpenWork sign-in link" },
+              );
+            });
+            useDesktopClient(ctx);
+            await ensureDesktopReady(ctx);
+            await prepareDesktopForDenHandoff(ctx);
+            const openworkUrl = requireStateValue(state.openworkUrl, "browser-created desktop handoff");
+            ctx.assert(/^openwork:\/\/den-auth\?/.test(openworkUrl), `Unexpected handoff URL: ${openworkUrl}`);
+            ctx.assert(openworkUrl.includes("grant=") && openworkUrl.includes("denBaseUrl="), `Handoff URL is missing grant or denBaseUrl: ${openworkUrl}`);
+            await deliverDeepLinkToDesktop(ctx, openworkUrl);
+          },
+          assert: async () => {
+            await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", { timeoutMs: 60_000, label: "desktop Den auth token" });
+            await ctx.waitFor("(localStorage.getItem('openwork.den.activeOrgName') ?? '').includes('Acme Robotics')", { timeoutMs: 60_000, label: "active Acme org" });
+            // The Cloud Account surface is the strongest visible witness that
+            // the handoff signed this exact invitee into the invited org.
+            await ctx.navigateHash("/settings/cloud-account");
+            await ctx.waitForText("Sign out", { timeoutMs: 45_000 });
+            await ctx.expectText(ORG_NAME, { timeoutMs: 45_000 });
+            await ctx.expectText(INVITEE_EMAIL, { timeoutMs: 45_000 });
+            ctx.output("desktop-deep-link-bridge", `Delivered ${state.openworkUrl} through window.dispatchEvent(new CustomEvent('openwork:deep-link', { detail: { urls: [...] } })) — the renderer bridge consumed the same openwork://den-auth grant shape used by native deep links.`);
+          },
+          screenshot: {
+            name: "desktop-signed-into-organization",
+            requireText: [ORG_NAME, INVITEE_EMAIL, "Sign out"],
+            rejectText: ["Choose your organization", "Something went wrong"],
+          },
+        });
+        // The remaining frames run entirely in Electron; release the
+        // standalone Chrome CDP socket so the runner process can exit cleanly.
+        closeWebClient();
+      },
+    },
+    {
+      name: "Frame 9",
+      run: async (ctx) => {
+        useDesktopClient(ctx);
+        await ctx.prove("OpenWork presents the admin-provided skill and connection as one ready first workflow", {
+          voiceover: vo[8],
+          action: async () => {
+            await ensureDesktopReady(ctx);
+            await ctx.navigateHash("/onboarding");
+            await ctx.waitFor("Boolean(document.querySelector('[data-openwork-first-workflow=\"true\"]'))", { timeoutMs: 90_000, label: "first workflow card" });
+            await ctx.eval("document.querySelector('[data-openwork-first-workflow=\"true\"]')?.scrollIntoView({ block: 'center' })");
+          },
+          assert: async () => {
+            await ctx.expectText("Organization connected");
+            await ctx.expectText(PLUGIN_NAME);
+            await ctx.expectText("OpenWork Connect");
+            await ctx.expectText(SUGGESTED_PROMPT);
+            const firstWorkflow = await ctx.eval(`(() => {
+              const card = document.querySelector('[data-openwork-first-workflow="true"]');
+              return {
+                skill: card?.getAttribute('data-openwork-first-workflow-skill') ?? '',
+                connection: card?.getAttribute('data-openwork-first-workflow-connection') ?? '',
+                text: card?.innerText ?? '',
+              };
+            })()`);
+            ctx.assert(firstWorkflow.skill === PLUGIN_NAME, `Unexpected first workflow skill: ${JSON.stringify(firstWorkflow)}`);
+            ctx.assert(firstWorkflow.connection.includes(MCP_COMPONENT_NAME), `Unexpected first workflow connection: ${JSON.stringify(firstWorkflow)}`);
+            ctx.assert(firstWorkflow.text.includes("connection ready"), `Connection was not presented as ready: ${JSON.stringify(firstWorkflow)}`);
+          },
+          screenshot: {
+            name: "desktop-first-workflow-ready",
+            requireText: ["Organization connected", PLUGIN_NAME, "OpenWork Connect", SUGGESTED_PROMPT, "connection ready"],
+            rejectText: ["No resources have been configured", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 10",
+      run: async (ctx) => {
+        useDesktopClient(ctx);
+        await ctx.prove("The suggested first action opens a chat with the exact administrator-provided prompt", {
+          voiceover: vo[9],
+          action: async () => {
+              await clickExactText(ctx, "Start inactive account check", "button");
+              // The product owns everything from here: it saves the prompt,
+              // creates the task, and mounts the composer with the draft.
+              // Creating workspaces/tasks from the eval here would race that
+              // handoff and navigate away from the drafted session.
+              await ctx.waitFor("location.hash.includes('/session')", { timeoutMs: 60_000, label: "session route after first workflow CTA" });
+              await ctx.waitFor("Boolean(document.querySelector('[contenteditable=\"true\"][data-lexical-editor=\"true\"]'))", { timeoutMs: 90_000, label: "chat composer" });
+              await waitForPromptInComposer(ctx, SUGGESTED_PROMPT);
+              await rememberCurrentSession(ctx);
+              await waitForCloudControlMcpSync(ctx);
+              // OpenCode loads MCP servers at engine startup, so wait until
+              // the runtime actually serves the authenticated /mcp/agent
+              // connection (engineSync ok) before running the first task.
+              await waitForRuntimeCloudControlMcp(ctx);
+          },
+          assert: async () => {
+            const composer = await composerText(ctx);
+            ctx.assert(composer.includes(SUGGESTED_PROMPT), `Composer did not contain the exact suggested prompt: ${composer}`);
+            await ctx.expectText("Run task", { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "first-action-prompt-ready",
+            requireText: [SUGGESTED_PROMPT, "Run task"],
+            rejectText: ["No resources have been configured", "Something went wrong"],
+          },
+        });
+        state.chatStartedAt = new Date().toISOString();
+        await clickExactText(ctx, "Run task", "button");
+        await rememberCurrentSession(ctx);
+      },
+    },
+    {
+      name: "Frame 11",
+      run: async (ctx) => {
+        useDesktopClient(ctx);
+        await ctx.prove("The running task shows clear activity while the agent loads the org skill", {
+          voiceover: vo[10],
+          action: async () => {
+            // Visible in-flight activity: either the Stop affordance or a
+            // rendered cloud-capability tool card. Fast agent turns can drop
+            // Stop before we capture, so accept both signals.
+            await ctx.waitFor(
+              `Boolean([...document.querySelectorAll('button')].find((button) => button.textContent.trim() === 'Stop')) || document.body.innerText.toLowerCase().includes('search capabilities')`,
+              { timeoutMs: 45_000, label: "running task activity" },
+            );
+          },
+          assert: async () => {
+            await rememberCurrentSession(ctx);
+            const witness = await waitForTranscriptSequence(ctx, { requireFullSequence: false, timeoutMs: 120_000 });
+            ctx.output("frame-11-transcript-witness", JSON.stringify(witness.summary, null, 2));
+            await ctx.waitFor(
+              "document.body.innerText.toLowerCase().includes('capabilit')",
+              { timeoutMs: 30_000, label: "visible capability activity card" },
+            );
+          },
+          screenshot: {
+            name: "agent-running-activity",
+            // The prompt bubble scrolls out of the viewport as activity
+            // streams in; the claim here is the visible capability activity.
+            requireText: ["capabilities"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 12",
+      run: async (ctx) => {
+        useDesktopClient(ctx);
+        await ctx.prove("The completed workspace result lists inactive accounts and records the Employee Directory connection", {
+          voiceover: vo[11],
+          action: async () => {
+            await ctx.waitFor("!Boolean([...document.querySelectorAll('button')].find((button) => button.textContent.trim() === 'Stop'))", { timeoutMs: 240_000, label: "assistant finished" });
+            await ctx.waitFor("document.body.innerText.includes('Maya Chen') && document.body.innerText.includes('Theo Ramirez') && document.body.innerText.includes('Nora Patel')", { timeoutMs: 120_000, label: "inactive employee result" });
+          },
+          assert: async () => {
+            await ctx.expectText("Maya Chen", { timeoutMs: 10_000 });
+            await ctx.expectText("Theo Ramirez", { timeoutMs: 10_000 });
+            await ctx.expectText("Nora Patel", { timeoutMs: 10_000 });
+            await ctx.expectText(MCP_COMPONENT_NAME, { timeoutMs: 10_000 });
+            const transcript = await waitForTranscriptSequence(ctx, { requireFullSequence: true, timeoutMs: 30_000 });
+            ctx.output("frame-12-transcript-witness", JSON.stringify(transcript.summary, null, 2));
+            const mockWitness = await assertFreshMockMcpCall(ctx);
+            ctx.output("mock-mcp-call-witness", JSON.stringify(mockWitness, null, 2));
+          },
+          screenshot: {
+            name: "inactive-account-check-complete",
+            requireText: ["Maya Chen", "Theo Ramirez", "Nora Patel", MCP_COMPONENT_NAME],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};
+
+function cleanBaseUrl(value) {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+function buildPublicMcpUrl(value, runTag) {
+  const raw = value.trim();
+  if (!raw) return "";
+  const url = new URL(raw);
+  if (url.protocol !== "https:") {
+    throw new Error(`OPENWORK_EVAL_PUBLIC_MOCK_MCP_URL must be public https://, got ${raw}`);
+  }
+  const path = url.pathname.replace(/\/+$/, "");
+  if (!path || path === "/") {
+    url.pathname = "/mcp";
+  } else if (!path.endsWith("/mcp")) {
+    url.pathname = `${path}/mcp`;
+  }
+  url.searchParams.set("run", runTag);
+  return url.toString();
+}
+
+function buildMockRequestsUrl({ mcpUrl, explicitRequestsUrl, inspectionUrl }) {
+  const explicit = explicitRequestsUrl || inspectionUrl;
+  if (explicit) {
+    const url = new URL(explicit);
+    if (!url.pathname.endsWith("/requests")) {
+      url.pathname = `${url.pathname.replace(/\/+$/, "")}/requests`;
+    }
+    url.search = "";
+    return url.toString();
+  }
+  if (!mcpUrl) return "";
+  const url = new URL(mcpUrl);
+  url.pathname = "/requests";
+  url.search = "";
+  url.hash = "";
+  return url.toString();
+}
+
+function rememberDesktopClient(ctx) {
+  if (!state.desktopClient) {
+    state.desktopClient = ctx.client;
+  }
+}
+
+function useDesktopClient(ctx) {
+  rememberDesktopClient(ctx);
+  ctx.client = state.desktopClient;
+}
+
+function requireStateValue(value, label) {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  throw new Error(`${label} was not prepared by an earlier frame.`);
+}
+
+async function withWebClient(ctx, fn) {
+  const previous = ctx.client;
+  // One persistent CDP session for the whole browser journey: Chrome scopes
+  // Network.emulateNetworkConditions to the session that enabled it, so a
+  // per-frame connect/close would silently drop the throttled preparation
+  // wait between frames 5 and 6.
+  if (!state.webClient) {
+    const target = await firstPageTarget(WEB_CDP_URL);
+    state.webClient = await connect(debuggerUrlFor(WEB_CDP_URL, target));
+  }
+  ctx.client = state.webClient;
+  try {
+    return await fn();
+  } finally {
+    ctx.client = previous;
+  }
+}
+
+function closeWebClient() {
+  for (const key of ["webClient", "installClient"]) {
+    try {
+      state[key]?.close();
+    } catch {
+      // Socket already gone.
+    }
+    state[key] = null;
+  }
+}
+
+async function connectInstallTab(ctx) {
+  if (state.installClient) return;
+  // Match this run's exact install token so a stale install tab left over
+  // from an earlier attempt can never be selected.
+  const installToken = new URL(requireStateValue(state.installPageUrl, "install page URL")).searchParams.get("token") ?? "";
+  ctx.assert(installToken.length > 0, "The journey install URL did not carry a token.");
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 30_000) {
+    const targets = await listTargets(WEB_CDP_URL);
+    const target = targets.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl && entry.url.includes(`/install?token=${installToken}`));
+    if (target) {
+      state.installClient = await connect(debuggerUrlFor(WEB_CDP_URL, target));
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  ctx.assert(false, "The journey download action did not open the team install page in a new tab.");
+}
+
+async function withInstallTab(ctx, fn) {
+  const previous = ctx.client;
+  ctx.assert(Boolean(state.installClient), "The install tab client was not prepared by frame 5.");
+  ctx.client = state.installClient;
+  try {
+    return await fn();
+  } finally {
+    ctx.client = previous;
+  }
+}
+
+async function firstPageTarget(cdpBaseUrl) {
+  const targets = await listTargets(cdpBaseUrl);
+  const existing = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (existing) return existing;
+
+  const base = cdpBaseUrl.replace(/\/+$/, "");
+  let response = await fetch(`${base}/json/new?about:blank`, { method: "PUT" });
+  if (!response.ok) response = await fetch(`${base}/json/new?about:blank`);
+  if (!response.ok) throw new Error(`Could not create standalone Chrome page at ${cdpBaseUrl}: ${response.status}`);
+  const created = await response.json();
+  if (created?.type === "page" && created.webSocketDebuggerUrl) return created;
+
+  const nextTargets = await listTargets(cdpBaseUrl);
+  const next = nextTargets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (!next) throw new Error(`No standalone Chrome page target available at ${cdpBaseUrl}.`);
+  return next;
+}
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      origin: DEN_WEB_URL || DEN_API_URL,
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+async function assertMockServerReady(ctx) {
+  const healthUrl = new URL(MOCK_REQUESTS_URL);
+  healthUrl.pathname = "/health";
+  healthUrl.search = "";
+  const response = await fetch(healthUrl.toString());
+  const body = await response.json().catch(() => null);
+  ctx.assert(response.ok, `Mock MCP server is not reachable at ${healthUrl}: ${response.status}`);
+  ctx.assert(body?.mcpAuth === "none", `Mock MCP server must run with public/no-auth MCP enabled: ${JSON.stringify(body)}`);
+}
+
+async function ensureAdminToken(ctx) {
+  if (state.adminToken) return state.adminToken;
+  const signedIn = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
+  });
+  if (signedIn.response.ok && typeof signedIn.body?.token === "string") {
+    state.adminToken = signedIn.body.token;
+    await activateAdminOrganization(ctx, state.adminToken);
+    return state.adminToken;
+  }
+  const fallback = process.env.OPENWORK_EVAL_DEN_TOKEN?.trim() ?? "";
+  ctx.assert(fallback.length > 0, `Admin sign-in failed and OPENWORK_EVAL_DEN_TOKEN is missing: ${signedIn.response.status} ${signedIn.text.slice(0, 200)}`);
+  state.adminToken = fallback;
+  await activateAdminOrganization(ctx, state.adminToken);
+  return fallback;
+}
+
+async function activateAdminOrganization(ctx, token) {
+  const listed = await denApiFetch("/v1/me/orgs", { headers: { authorization: `Bearer ${token}` } });
+  ctx.assert(listed.response.ok, `Could not list admin organizations: ${listed.response.status} ${listed.text.slice(0, 300)}`);
+  const organizations = Array.isArray(listed.body?.orgs) ? listed.body.orgs : [];
+  const organization = organizations.find((entry) => entry?.name === ORG_NAME);
+  ctx.assert(typeof organization?.id === "string", `${ORG_NAME} was not available to ${ADMIN_EMAIL}: ${JSON.stringify(organizations).slice(0, 1000)}`);
+  const selected = await denApiFetch("/v1/me/active-organization", {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({ organizationId: organization.id }),
+  });
+  ctx.assert(selected.response.ok, `Could not activate ${ORG_NAME}: ${selected.response.status} ${selected.text.slice(0, 300)}`);
+}
+
+async function cleanupStalePluginBundles(ctx) {
+  const token = await ensureAdminToken(ctx);
+  const listed = await denApiFetch("/v1/plugins?status=active&limit=100", {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(listed.response.ok, `Could not list stale plugin bundles: ${listed.response.status} ${listed.text.slice(0, 300)}`);
+  const plugins = Array.isArray(listed.body?.items) ? listed.body.items : [];
+  for (const plugin of plugins) {
+    if (plugin?.name !== PLUGIN_NAME || typeof plugin.id !== "string") continue;
+    const archived = await denApiFetch(`/v1/plugins/${encodeURIComponent(plugin.id)}/archive`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+      body: "{}",
+    });
+    ctx.assert(archived.response.ok, `Could not archive stale ${PLUGIN_NAME} plugin ${plugin.id}: ${archived.response.status} ${archived.text.slice(0, 300)}`);
+  }
+}
+
+async function signInAndReturnToken(ctx, email, password) {
+  const signedIn = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  ctx.assert(signedIn.response.ok && typeof signedIn.body?.token === "string", `Sign-in failed for ${email}: ${signedIn.response.status} ${signedIn.text.slice(0, 200)}`);
+  return signedIn.body.token;
+}
+
+async function goToDenWeb(ctx, path) {
+  await navigateToAbsolute(ctx, `${DEN_WEB_URL}${path}`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${path}` });
+}
+
+async function navigateToAbsolute(ctx, url) {
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+}
+
+async function signInToDenWeb(ctx, email, password) {
+  await goToDenWeb(ctx, "/");
+  await ctx.eval("fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).then(() => true).catch(() => true)", { awaitPromise: true });
+  await goToDenWeb(ctx, "/");
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]'))", { timeoutMs: 30_000, label: "email-first sign-in screen" });
+  await ctx.fill('input[type="email"], input[name="email"]', email);
+  await clickExactText(ctx, "Next", "button");
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 20_000, label: "password sign-in step" });
+  await ctx.fill('input[type="password"]', password);
+  await clickLastExactText(ctx, "Sign in", "button");
+  await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 45_000, label: "dashboard after sign-in" });
+}
+
+async function selectOrganizationThroughUi(ctx, organizationName) {
+  await goToDenWeb(ctx, "/organization");
+  await ctx.waitForText(organizationName, { timeoutMs: 30_000 });
+  const isCurrent = await ctx.eval(`(() => {
+    const row = [...document.querySelectorAll('tr')].find((entry) => entry.innerText.includes(${JSON.stringify(organizationName)}));
+    return Boolean(row?.innerText.includes('Current Organization'));
+  })()`);
+  if (!isCurrent) {
+    await ctx.waitFor(`(() => {
+      const row = [...document.querySelectorAll('tr')].find((entry) => entry.innerText.includes(${JSON.stringify(organizationName)}));
+      const button = [...(row?.querySelectorAll('button') ?? [])].find((entry) => entry.textContent.trim() === 'Switch');
+      button?.click();
+      return Boolean(button);
+    })()`, { timeoutMs: 20_000, label: `switch to ${organizationName}` });
+    await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 30_000, label: "organization dashboard chooser" });
+  }
+  await goToDenWeb(ctx, "/dashboard");
+  await ctx.waitFor(
+    "document.body.innerText.includes('Choose an organization') || document.body.innerText.includes('Good morning')",
+    { timeoutMs: 30_000, label: "dashboard organization state" },
+  );
+  const needsDashboardChoice = await ctx.eval("document.body.innerText.includes('Choose an organization')");
+  if (needsDashboardChoice) {
+    await ctx.waitFor(`(() => {
+      const button = [...document.querySelectorAll('button')].find((entry) => entry.textContent.includes(${JSON.stringify(organizationName)}));
+      button?.click();
+      return Boolean(button);
+    })()`, { timeoutMs: 20_000, label: `choose ${organizationName} dashboard` });
+    await ctx.waitFor(
+      `location.pathname === '/dashboard' && document.body.innerText.includes(${JSON.stringify(organizationName)}) && document.body.innerText.includes('Good morning')`,
+      { timeoutMs: 30_000, label: `${organizationName} dashboard loaded` },
+    );
+  }
+  await ctx.waitFor(
+    `location.pathname === '/dashboard' && document.body.innerText.includes(${JSON.stringify(organizationName)}) && document.body.innerText.includes('Good morning')`,
+    { timeoutMs: 30_000, label: `${organizationName} active dashboard` },
+  );
+  await waitForBrowserActiveOrganization(ctx, organizationName);
+}
+
+async function openAdminRoute(ctx, path, organizationName, expectedText) {
+  await goToDenWeb(ctx, path);
+  await ctx.waitFor(
+    `document.body.innerText.includes('Choose an organization') || document.body.innerText.includes(${JSON.stringify(expectedText)})`,
+    { timeoutMs: 30_000, label: `${path} or organization gate` },
+  );
+  const gated = await ctx.eval("document.body.innerText.includes('Choose an organization')");
+  if (!gated) return;
+
+  await ctx.waitFor(`(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => entry.textContent.includes(${JSON.stringify(organizationName)}));
+    button?.click();
+    return Boolean(button);
+  })()`, { timeoutMs: 20_000, label: `clear ${organizationName} admin route gate` });
+  await ctx.waitFor(
+    `location.pathname === '/dashboard' && document.body.innerText.includes(${JSON.stringify(organizationName)}) && document.body.innerText.includes('Good morning')`,
+    { timeoutMs: 30_000, label: `${organizationName} dashboard after route gate` },
+  );
+  await waitForBrowserActiveOrganization(ctx, organizationName);
+  await goToDenWeb(ctx, path);
+  await ctx.waitForText(expectedText, { timeoutMs: 30_000 });
+}
+
+async function waitForBrowserActiveOrganization(ctx, organizationName) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < 30_000) {
+    const activeName = await ctx.eval(`fetch('/api/den/v1/me/orgs').then(async (response) => {
+      if (!response.ok) return '';
+      const body = await response.json();
+      const active = Array.isArray(body.orgs) ? body.orgs.find((entry) => entry?.id === body.activeOrgId) : null;
+      return active?.name ?? '';
+    })`, { awaitPromise: true }).catch(() => "");
+    if (activeName === organizationName) return;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Browser session did not persist ${organizationName} as its active organization.`);
+}
+
+async function clearDenWebSession(ctx) {
+  await goToDenWeb(ctx, "/");
+  await ctx.eval(`fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).catch(() => null).then(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    return true;
+  })`, { awaitPromise: true });
+}
+
+async function clickExactText(ctx, text, selector) {
+  return ctx.waitFor(`(() => {
+    const candidates = [...document.querySelectorAll(${JSON.stringify(selector)})];
+    const element = candidates.find((candidate) => (candidate.textContent ?? '').trim() === ${JSON.stringify(text)} && !candidate.disabled);
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 20_000, label: `click exact text ${text}` });
+}
+
+async function clickLastExactText(ctx, text, selector) {
+  return ctx.waitFor(`(() => {
+    const candidates = [...document.querySelectorAll(${JSON.stringify(selector)})]
+      .filter((candidate) => (candidate.textContent ?? '').trim() === ${JSON.stringify(text)} && !candidate.disabled);
+    const element = candidates[candidates.length - 1];
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 20_000, label: `click last exact text ${text}` });
+}
+
+async function stubClipboardCapture(ctx) {
+  await ctx.eval(`(() => {
+    window.__capturedSignin = '';
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText(value) {
+          window.__capturedSignin = String(value);
+          return Promise.resolve();
+        },
+      },
+    });
+    return true;
+  })()`);
+}
+
+async function fillByPlaceholder(ctx, placeholder, value) {
+  await ctx.fill(`[placeholder=${JSON.stringify(placeholder)}]`, value);
+}
+
+async function createPluginBundleThroughUi(ctx) {
+  await fillByPlaceholder(ctx, "e.g. Sales call prep", PLUGIN_NAME);
+  await fillByPlaceholder(ctx, "What does this plugin help people do?", "Find employee accounts that have been inactive for 30 days using the Employee Directory connection.");
+
+  await clickExactText(ctx, "Skill", "button");
+  await fillByPlaceholder(ctx, "Name (e.g. Prep a sales call)", PLUGIN_NAME);
+  await fillByPlaceholder(ctx, "One-line description — when should the agent use this?", `Use this workflow for ${SUGGESTED_PROMPT}`);
+  await fillByPlaceholder(ctx, "Suggested prompt members can start with", SUGGESTED_PROMPT);
+  await fillByPlaceholder(ctx, "Write the instructions the agent should follow, in plain markdown...", skillInstructions());
+
+  await clickExactText(ctx, "MCP server", "button");
+  await fillByPlaceholder(ctx, "Server name (e.g. Linear)", MCP_COMPONENT_NAME);
+  await fillByPlaceholder(ctx, "https://mcp.example.com/mcp", MCP_URL);
+
+  await clickExactText(ctx, "Create plugin", "button");
+  await ctx.waitFor("location.pathname.includes('/plugins/') && !location.pathname.endsWith('/plugins/new')", { timeoutMs: 60_000, label: "created plugin detail route" });
+  state.pluginId = await ctx.eval("location.pathname.split('/').filter(Boolean).pop() ?? null");
+}
+
+function skillInstructions() {
+  return [
+    `# ${PLUGIN_NAME}`,
+    "",
+    "Use this skill when a teammate asks for employee accounts that have been inactive for 30 days.",
+    "",
+    "After loading this skill, follow this order:",
+    `1. Search OpenWork Cloud Control MCP capabilities for \`${MCP_COMPONENT_NAME} list_inactive_accounts\` and use the exact returned MCP capability name for \`list_inactive_accounts\`.`,
+    `2. Execute that MCP capability with body \`{\"days\":30,\"runNonce\":\"${RUN_NONCE}\"}\`.`,
+    `3. In the final answer, list every inactive account returned and state that the connection used was ${MCP_COMPONENT_NAME} through OpenWork Connect.`,
+    "",
+    `Suggested prompt: ${SUGGESTED_PROMPT}`,
+  ].join("\n");
+}
+
+async function assertCreatedPluginBundle(ctx) {
+  const token = await ensureAdminToken(ctx);
+  const pluginId = requireStateValue(state.pluginId, "created plugin id");
+  const resolved = await denApiFetch(`/v1/plugins/${encodeURIComponent(pluginId)}/resolved`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(resolved.response.ok, `Plugin resolved lookup failed: ${resolved.response.status} ${resolved.text.slice(0, 300)}`);
+  const items = Array.isArray(resolved.body?.items) ? resolved.body.items : [];
+  const skillItems = items.filter((entry) => entry?.configObject?.objectType === "skill");
+  const mcpItems = items.filter((entry) => entry?.configObject?.objectType === "mcp");
+  ctx.assert(skillItems.length === 1, `Expected exactly one native skill config object, got ${skillItems.length}.`);
+  ctx.assert(mcpItems.length === 1, `Expected exactly one MCP config object, got ${mcpItems.length}.`);
+
+  const skillObject = skillItems[0].configObject;
+  const mcpObject = mcpItems[0].configObject;
+  ctx.assert(skillObject.title === PLUGIN_NAME, `Unexpected skill title: ${skillObject.title}`);
+  ctx.assert(mcpObject.title === MCP_COMPONENT_NAME, `Unexpected MCP title: ${mcpObject.title}`);
+  const skillPayload = skillObject.latestVersion?.normalizedPayloadJson;
+  state.denSkillId = typeof skillPayload?.denSkillId === "string" ? skillPayload.denSkillId : null;
+  ctx.assert(typeof state.denSkillId === "string", "Resolved skill config did not point at a native Den skill.");
+  const mcpPayload = mcpObject.latestVersion?.normalizedPayloadJson;
+  state.connectionId = typeof mcpPayload?.externalMcpConnectionId === "string" ? mcpPayload.externalMcpConnectionId : null;
+  ctx.assert(typeof state.connectionId === "string", "Resolved MCP config did not point at an ExternalMcpConnection.");
+
+  const skills = await denApiFetch("/v1/skills", { headers: { authorization: `Bearer ${token}` } });
+  ctx.assert(skills.response.ok, `Skill list failed: ${skills.response.status} ${skills.text.slice(0, 300)}`);
+  const matchingSkills = (Array.isArray(skills.body?.skills) ? skills.body.skills : []).filter((skill) => skill?.id === state.denSkillId && skill?.title === PLUGIN_NAME);
+  ctx.assert(matchingSkills.length === 1, `Expected exactly one native Den skill with id ${state.denSkillId}, got ${matchingSkills.length}.`);
+
+  const connections = await denApiFetch("/v1/mcp-connections?scope=usable", { headers: { authorization: `Bearer ${token}` } });
+  ctx.assert(connections.response.ok, `Usable MCP connection list failed: ${connections.response.status} ${connections.text.slice(0, 300)}`);
+  const usableConnections = (Array.isArray(connections.body?.connections) ? connections.body.connections : []).filter((connection) => connection?.id === state.connectionId);
+  ctx.assert(usableConnections.length === 1, `Expected exactly one usable ExternalMcpConnection for ${state.connectionId}, got ${usableConnections.length}.`);
+  const connection = usableConnections[0];
+  ctx.assert(connection.connected === true && connection.connectedForMe === true, `External MCP connection is not usable: ${JSON.stringify(connection)}`);
+  ctx.assert(connection.authType === "none" && connection.credentialMode === "shared", `External MCP connection is not shared/no-auth: ${JSON.stringify(connection)}`);
+  ctx.assert(connection.url === MCP_URL, `External MCP connection URL drifted: ${connection.url} !== ${MCP_URL}`);
+  state.connectionName = connection.name;
+  ctx.assert(connection.name.includes(MCP_COMPONENT_NAME), `External MCP connection name does not include ${MCP_COMPONENT_NAME}: ${connection.name}`);
+
+  return {
+    pluginId,
+    denSkillId: state.denSkillId,
+    skillCount: skillItems.length,
+    mcpConfigCount: mcpItems.length,
+    externalMcpConnection: {
+      id: connection.id,
+      name: connection.name,
+      authType: connection.authType,
+      credentialMode: connection.credentialMode,
+      connected: connection.connected,
+      connectedForMe: connection.connectedForMe,
+      url: connection.url,
+    },
+  };
+}
+
+async function getLatestDevEmail(ctx, template, expectedTo) {
+  const listResponse = await fetch(`${DEN_API_URL}/v1/dev/emails?template=${encodeURIComponent(template)}`);
+  const listText = await listResponse.text();
+  ctx.assert(listResponse.ok, `Could not list ${template} emails: ${listResponse.status} ${listText.slice(0, 200)}`);
+  const list = JSON.parse(listText);
+  const emails = Array.isArray(list.emails) ? list.emails : [];
+  const entry = emails.find((candidate) => candidate?.to === expectedTo) ?? null;
+  ctx.assert(Boolean(entry), `No ${template} email found for ${expectedTo}.`);
+  ctx.assert(emails[0]?.to === expectedTo, `Latest ${template} email is ${emails[0]?.to ?? "none"}, expected ${expectedTo}.`);
+
+  const htmlResponse = await fetch(`${DEN_API_URL}/v1/dev/emails/last?template=${encodeURIComponent(template)}`);
+  const html = await htmlResponse.text();
+  ctx.assert(htmlResponse.ok, `Could not fetch latest ${template} email HTML: ${htmlResponse.status} ${html.slice(0, 200)}`);
+  return { entry, html };
+}
+
+function decodeHtmlAttribute(value) {
+  return value
+    .replaceAll("&amp;", "&")
+    .replaceAll("&#x2F;", "/")
+    .replaceAll("&quot;", '"')
+    .replaceAll("&#39;", "'");
+}
+
+function extractInviteFromHtml(html, ctx) {
+  const absoluteMatch = html.match(/https?:\/\/[^"'<>\s]+\/join-org\?invite=[^"'<>\s]+/);
+  const relativeMatch = html.match(/\/join-org\?invite=[^"'<>\s]+/);
+  const rawLink = absoluteMatch?.[0] ?? relativeMatch?.[0] ?? "";
+  const link = decodeHtmlAttribute(rawLink);
+  ctx.assert(link.length > 0, "Invite email did not contain a /join-org?invite= link.");
+  const parsed = new URL(link, DEN_WEB_URL);
+  const token = parsed.searchParams.get("invite")?.trim() ?? "";
+  ctx.assert(token.length > 0, `Invite link did not include an invite token: ${link}`);
+  return { link: parsed.toString(), token };
+}
+
+function extractInstallFromHtml(html, ctx) {
+  const absoluteMatch = html.match(/https?:\/\/[^"'<>\s]+\/install\?token=[^"'<>\s]+/);
+  const relativeMatch = html.match(/\/install\?token=[^"'<>\s]+/);
+  const rawLink = absoluteMatch?.[0] ?? relativeMatch?.[0] ?? "";
+  const link = decodeHtmlAttribute(rawLink);
+  ctx.assert(link.length > 0, "Invite email did not contain an /install?token= link.");
+  const parsed = new URL(link, DEN_WEB_URL);
+  ctx.assert(parsed.pathname === "/install", `Invite desktop CTA did not target /install: ${link}`);
+  ctx.assert(Boolean(parsed.searchParams.get("token")?.trim()), `Install link did not include an opaque token: ${link}`);
+  return parsed.toString();
+}
+
+function rewriteDenWebLink(rawLink) {
+  const parsed = new URL(rawLink, DEN_WEB_URL);
+  return new URL(`${parsed.pathname}${parsed.search}${parsed.hash}`, DEN_WEB_URL).toString();
+}
+
+async function completeInviteSignup(ctx, email, password) {
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 30_000, label: "invite password field" });
+  await ctx.fill('input[type="password"]', password);
+  await clickExactText(ctx, `Join ${ORG_NAME}`, "button");
+  await ctx.waitFor(`document.body.innerText.includes("You're one click away from the team workspace.") || Boolean(document.querySelector('[data-testid="join-org-success"]'))`, { timeoutMs: 45_000, label: "signed in invite accept step" });
+  const alreadySuccess = await ctx.eval("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))");
+  if (!alreadySuccess) {
+    await ctx.expectText(email, { timeoutMs: 20_000 });
+    markEmailVerified(ctx, email);
+    await clickExactText(ctx, `Join ${ORG_NAME}`, "button");
+  }
+  await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))", { timeoutMs: 45_000, label: "join org success" });
+}
+
+function markEmailVerified(ctx, email) {
+  ctx.assert(MARK_VERIFIED_CMD.length > 0, "Invitation acceptance requires a verified email; set OPENWORK_EVAL_MARK_VERIFIED_CMD (shell template with {email}).");
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", email), { stdio: "ignore" });
+}
+
+async function restoreNetworkConditions(ctx) {
+  await ctx.client.send("Network.emulateNetworkConditions", {
+    offline: false,
+    latency: 0,
+    downloadThroughput: -1,
+    uploadThroughput: -1,
+    connectionType: "none",
+  }).catch(() => undefined);
+}
+
+async function ensureDesktopReady(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 90_000, label: "desktop control API" });
+}
+
+async function prepareDesktopForDenHandoff(ctx) {
+  await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", { timeoutMs: 30_000, label: "desktop bridge" });
+  const bootstrap = { baseUrl: DEN_API_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
+  const result = await ctx.eval(`window.__OPENWORK_ELECTRON__.invokeDesktop("setDesktopBootstrapConfig", ${JSON.stringify(bootstrap)})`, { awaitPromise: true });
+  ctx.assert(Boolean(result), "Desktop bootstrap config was not written.");
+  await ctx.eval(`(() => {
+    localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_API_URL)});
+    localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(DEN_API_URL)});
+    for (const key of ['openwork.den.authToken', 'openwork.den.activeOrgId', 'openwork.den.activeOrgSlug', 'openwork.den.activeOrgName', 'openwork.den.mcp.sync']) {
+      localStorage.removeItem(key);
+    }
+    window.dispatchEvent(new CustomEvent('openwork-den-session-updated', { detail: { status: 'signed_out' } }));
+    return true;
+  })()`);
+  await ctx.eval("location.reload()");
+  await ensureDesktopReady(ctx);
+}
+
+async function deliverDeepLinkToDesktop(ctx, openworkUrl) {
+  await ctx.eval(`(() => {
+    const url = ${JSON.stringify(openworkUrl)};
+    window.__OPENWORK__ = window.__OPENWORK__ || {};
+    const pending = window.__OPENWORK__.deepLinks || [];
+    window.__OPENWORK__.deepLinks = [...pending, url];
+    window.dispatchEvent(new CustomEvent("openwork:deep-link", { detail: { urls: [url] } }));
+    return true;
+  })()`);
+}
+
+async function composerText(ctx) {
+  return await ctx.eval("document.querySelector('[contenteditable=\"true\"][data-lexical-editor=\"true\"]')?.innerText ?? ''");
+}
+
+async function waitForPromptInComposer(ctx, prompt) {
+  await ctx.waitFor(
+    `(document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')?.innerText ?? '').includes(${JSON.stringify(prompt)})`,
+    { timeoutMs: 15_000, label: "administrator-provided prompt carried into composer" },
+  );
+}
+
+async function waitForCloudControlMcpSync(ctx) {
+  await ctx.waitFor("Boolean(localStorage.getItem('openwork.den.mcp.sync'))", { timeoutMs: 120_000, label: "OpenWork Cloud Control MCP sync marker" });
+}
+
+async function readRuntimeCloudControlMcp(ctx) {
+  const pinnedWorkspaceId = state.workspaceId ?? "";
+  return ctx.eval(`(async () => {
+    const parts = window.location.hash.split('/');
+    const workspaceIndex = parts.indexOf('workspace');
+    const workspaceId = ${JSON.stringify(pinnedWorkspaceId)} || (workspaceIndex >= 0 ? parts[workspaceIndex + 1] : '');
+    const port = localStorage.getItem('openwork.server.port');
+    const token = localStorage.getItem('openwork.server.token');
+    const hostToken = localStorage.getItem('openwork.server.hostToken');
+    if (!workspaceId || !port || !token) return { ok: false, reason: 'missing workspace/server auth', workspaceId, port: Boolean(port), token: Boolean(token) };
+    const headers = { Authorization: 'Bearer ' + token };
+    if (hostToken) headers['X-OpenWork-Host-Token'] = hostToken;
+    const response = await fetch('http://127.0.0.1:' + port + '/workspace/' + workspaceId + '/mcp', { headers });
+    const text = await response.text();
+    let payload = null;
+    try { payload = JSON.parse(text); } catch {}
+    if (!response.ok) return { ok: false, reason: 'mcp endpoint failed', status: response.status, text: text.slice(0, 300) };
+    const items = payload?.items ?? [];
+    const entry = items.find((item) => item.name === 'openwork-cloud');
+    const engineSync = payload?.engineSync?.status ?? null;
+    return {
+      ok: Boolean(entry?.config?.url?.includes('/mcp/agent') && entry?.config?.headers?.Authorization && engineSync === 'ok'),
+      workspaceId,
+      names: items.map((item) => item.name),
+      engineSync,
+      engineFailures: payload?.engineSync?.failures ?? [],
+    };
+  })()`, { awaitPromise: true });
+}
+
+async function waitForRuntimeCloudControlMcp(ctx) {
+  let last = null;
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    try {
+      last = await readRuntimeCloudControlMcp(ctx);
+      if (last?.ok) return;
+    } catch (error) {
+      last = { ok: false, reason: error instanceof Error ? error.message : String(error) };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`Runtime OpenWork Cloud Control MCP config never became ready: ${JSON.stringify(last)}`);
+}
+
+async function rememberCurrentSession(ctx) {
+  const route = await ctx.waitFor(`(() => {
+    const snapshotRoute = window.__openworkControl?.snapshot?.().route ?? '';
+    const hashRoute = location.hash.replace(/^#/, '');
+    const route = snapshotRoute || hashRoute;
+    const match = route.match(new RegExp('/workspace/([^/]+)/session(?:/([^/?#]+))?'));
+    if (!match || !match[2]) return null;
+    return { route, workspaceId: decodeURIComponent(match[1]), sessionId: decodeURIComponent(match[2]) };
+  })()`, { timeoutMs: 60_000, label: "workspace session route with session id" });
+  state.workspaceId = route.workspaceId;
+  state.sessionId = route.sessionId;
+  return route;
+}
+
+async function readSessionSnapshot(ctx) {
+  if (!state.workspaceId || !state.sessionId) await rememberCurrentSession(ctx);
+  const workspaceId = requireStateValue(state.workspaceId, "workspace id");
+  const sessionId = requireStateValue(state.sessionId, "session id");
+  const payload = await ctx.eval(`(async () => {
+    const workspaceId = ${JSON.stringify(workspaceId)};
+    const sessionId = ${JSON.stringify(sessionId)};
+    const info = await window.__OPENWORK_ELECTRON__?.invokeDesktop?.("openworkServerInfo");
+    let baseUrl = String(info?.baseUrl || info?.connectUrl || '');
+    while (baseUrl.endsWith('/')) baseUrl = baseUrl.slice(0, -1);
+    const token = String(info?.ownerToken || info?.clientToken || '').trim();
+    if (!baseUrl || !token) return { ok: false, status: 0, body: null, text: 'missing server info' };
+    const snapshotUrl = baseUrl + '/workspace/' + encodeURIComponent(workspaceId) + '/sessions/' + encodeURIComponent(sessionId) + '/snapshot?limit=400';
+    const response = await fetch(snapshotUrl, { headers: { authorization: 'Bearer ' + token } });
+    const text = await response.text();
+    let body = text;
+    try { body = text ? JSON.parse(text) : null; } catch {}
+    return { ok: response.ok, status: response.status, body, text: text.slice(0, 200000) };
+  })()`, { awaitPromise: true });
+  ctx.assert(payload?.ok, `Could not read app/session API snapshot: ${payload?.status} ${String(payload?.text ?? '').slice(0, 300)}`);
+  return payload.body;
+}
+
+function stringifyCompact(value) {
+  return JSON.stringify(value, (_key, entry) => entry, 2).slice(0, 4_000);
+}
+
+function collectToolEvents(value) {
+  const events = [];
+  const visit = (entry, path) => {
+    if (!entry || typeof entry !== "object") return;
+    if (Array.isArray(entry)) {
+      entry.forEach((item, index) => visit(item, `${path}[${index}]`));
+      return;
+    }
+    const tool = typeof entry.tool === "string"
+      ? entry.tool
+      : typeof entry.toolName === "string"
+        ? entry.toolName
+        : null;
+    const type = typeof entry.type === "string" ? entry.type : "";
+    const text = stringifyCompact(entry);
+    if (tool || type === "tool" || type === "dynamic-tool") {
+      events.push({ index: events.length, path, tool: tool || type || "tool", text });
+    }
+    for (const [key, item] of Object.entries(entry)) {
+      visit(item, `${path}.${key}`);
+    }
+  };
+  visit(value, "$.");
+  return events;
+}
+
+function eventContains(event, needle) {
+  return event.text.includes(needle) || event.tool.includes(needle);
+}
+
+function findToolSequence(snapshot, { requireFullSequence }) {
+  const events = collectToolEvents(snapshot);
+  // Match execute events by their INPUT capability name — the skill's own
+  // output text mentions the MCP tool, so bare substring matching would
+  // conflate the two calls.
+  const firstSearch = events.findIndex((event) => eventContains(event, "search_capabilities"));
+  const skillExecute = events.findIndex((event, index) => index > firstSearch && eventContains(event, "execute_capability") && event.text.includes('"name": "skill:'));
+  const mcpExecute = events.findIndex((event, index) => index > skillExecute && eventContains(event, "execute_capability") && event.text.includes('"name": "mcp:') && eventContains(event, "list_inactive_accounts"));
+  const sequence = { firstSearch, skillExecute, mcpExecute };
+  const partialOk = firstSearch >= 0 && skillExecute > firstSearch;
+  // The narration's guarantee: search found the org bundle, the skill was
+  // loaded, and only then did the directory call happen through Connect.
+  const fullOk = partialOk && mcpExecute > skillExecute;
+  return {
+    ok: requireFullSequence ? fullOk : partialOk,
+    sequence,
+    events,
+    summary: {
+      sequence,
+      orderedCalls: [firstSearch, skillExecute, mcpExecute].filter((index) => index >= 0).map((index) => ({
+        index,
+        tool: events[index]?.tool,
+        path: events[index]?.path,
+        excerpt: events[index]?.text.slice(0, 900),
+      })),
+      session: { workspaceId: state.workspaceId, sessionId: state.sessionId },
+    },
+  };
+}
+
+async function waitForTranscriptSequence(ctx, { requireFullSequence, timeoutMs }) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    const snapshot = await readSessionSnapshot(ctx);
+    const sequence = findToolSequence(snapshot, { requireFullSequence });
+    last = sequence;
+    if (sequence.ok) return sequence;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new Error(`Timed out waiting for ${requireFullSequence ? "full" : "partial"} app/session API tool-call sequence. Last: ${JSON.stringify(last?.summary ?? null).slice(0, 1600)}`);
+}
+
+async function assertFreshMockMcpCall(ctx) {
+  const response = await fetch(MOCK_REQUESTS_URL);
+  const body = await response.json().catch(() => null);
+  ctx.assert(response.ok && Array.isArray(body?.requests), `Could not read mock MCP requests from ${MOCK_REQUESTS_URL}: ${response.status}`);
+  const fresh = body.requests.filter((entry) => entry?.method === "POST" && entry?.path === "/mcp" && (!state.chatStartedAt || entry.at >= state.chatStartedAt));
+  const matching = fresh.find((entry) => {
+    const rpcEntries = Array.isArray(entry.rpc) ? entry.rpc : [entry.rpc];
+    return rpcEntries.some((rpc) => rpc?.method === "tools/call" && rpc?.toolName === "list_inactive_accounts" && Number(rpc?.arguments?.days) === 30 && rpc?.arguments?.runNonce === RUN_NONCE);
+  });
+  ctx.assert(Boolean(matching), `No fresh tools/call list_inactive_accounts with days=30 and runNonce=${RUN_NONCE}. Fresh log: ${JSON.stringify(fresh).slice(0, 1600)}`);
+  return {
+    requestsUrl: MOCK_REQUESTS_URL,
+    runStartedAt: state.chatStartedAt,
+    matchedRequest: matching,
+  };
+}

--- a/evals/voiceovers/invite-connect-first-skill.md
+++ b/evals/voiceovers/invite-connect-first-skill.md
@@ -1,0 +1,27 @@
+# invite-connect-first-skill — An invited teammate completes their first admin-provided workflow through OpenWork Connect
+
+The administrator shares a read-only skill and remote connection as one bundle. The invited teammate then follows one continuous path from email to a useful first result.
+
+1. Before I am invited, my administrator adds the Inactive Account Check bundle. OpenWork clearly shows that it contains one skill and one secure connection, confirms both are ready, and lets the administrator share it with the team.
+
+2. I receive an invitation email that identifies the administrator, organization, and access I am receiving, with one clear action to get started.
+
+3. The invitation opens a focused welcome page. I create and verify my account, review the organization I am joining, and accept the invitation without losing my place.
+
+4. OpenWork welcomes me by name and maps the remaining journey: download the app, connect to my organization, and try my first team workflow. My current step is always obvious.
+
+5. OpenWork recommends the correct installer while keeping other platforms available without overwhelming the page. I start the download with one primary action.
+
+6. While my team-configured package is prepared, the loading indicator visibly moves and the message advances through meaningful preparation stages. The page never appears frozen.
+
+7. When preparation finishes, the browser starts the download automatically. The page confirms what happened and gives me one concise installation instruction.
+
+8. I open OpenWork and continue through the secure sign-in handoff. The app recognizes my invitation and organization, so I do not repeat choices I already made.
+
+9. The welcome journey continues inside OpenWork and confirms that my organization, the Inactive Account Check skill, and its secure connection are ready. Everything supplied by my administrator is presented as one coherent capability.
+
+10. OpenWork offers a useful first action instead of an empty workspace. I ask it to show me which employee accounts have been inactive for 30 days using the workflow my administrator provided.
+
+11. The agent loads the organization's skill, follows its instructions, and calls the employee directory through OpenWork Connect. The interface shows clear activity while the check runs.
+
+12. The completed check appears in my workspace with the inactive employee accounts and a clear record of the connection used. I am signed in, connected to my team, and have successfully completed my first administrator-provided workflow.

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -7,6 +7,7 @@ const port = Number(process.env.PORT || 3978);
 const issuer = process.env.ISSUER || `http://${host}:${port}`;
 const autoApprove = process.env.AUTO_APPROVE !== "0";
 const disableDcr = process.env.DISABLE_DCR === "1";
+const noAuthMcp = process.env.MCP_NO_AUTH === "1" || process.env.PUBLIC_MCP_NO_AUTH === "1" || process.env.AUTH_MODE === "none";
 const mockClientId = process.env.MOCK_CLIENT_ID || "mock-preregistered-client";
 const mockClientSecret = process.env.MOCK_CLIENT_SECRET || "mock-preregistered-secret";
 
@@ -15,6 +16,21 @@ const codes = new Map();
 const tokens = new Set();
 const requests = [];
 const drafts = [];
+
+const SENSITIVE_KEYS = new Set([
+  "access_token",
+  "api_key",
+  "apikey",
+  "authorization",
+  "client_secret",
+  "code",
+  "code_verifier",
+  "password",
+  "refresh_token",
+  "secret",
+  "state",
+  "token",
+]);
 
 function json(res, status, body, headers = {}) {
   res.writeHead(status, {
@@ -67,16 +83,62 @@ async function readForm(req) {
   return Object.fromEntries(new URLSearchParams(raw));
 }
 
+function sanitizedSearch(url) {
+  const params = new URLSearchParams(url.searchParams);
+  for (const key of [...params.keys()]) {
+    if (SENSITIVE_KEYS.has(key.toLowerCase())) {
+      params.set(key, "[redacted]");
+    }
+  }
+  const text = params.toString();
+  return text ? `?${text}` : "";
+}
+
+function sanitizeValue(value) {
+  if (Array.isArray(value)) {
+    return value.map((entry) => sanitizeValue(entry));
+  }
+  if (value && typeof value === "object") {
+    return Object.fromEntries(Object.entries(value).map(([key, entry]) => [
+      key,
+      SENSITIVE_KEYS.has(key.toLowerCase()) ? "[redacted]" : sanitizeValue(entry),
+    ]));
+  }
+  return value;
+}
+
+function rpcSummary(message) {
+  const params = message?.params && typeof message.params === "object" ? message.params : {};
+  const toolName = typeof params.name === "string" ? params.name : null;
+  const args = params.arguments && typeof params.arguments === "object" ? params.arguments : null;
+  return {
+    method: typeof message?.method === "string" ? message.method : null,
+    ...(toolName ? { toolName } : {}),
+    ...(args ? { arguments: sanitizeValue(args) } : {}),
+  };
+}
+
 function record(req, url) {
   const entry = {
     id: requests.length + 1,
     method: req.method,
     path: url.pathname,
-    url: `${url.pathname}${url.search}`,
+    url: `${url.pathname}${sanitizedSearch(url)}`,
     at: new Date().toISOString(),
   };
   requests.push(entry);
   console.log(`[mock-oauth-mcp] ${entry.method} ${entry.path}`);
+  return entry;
+}
+
+function recordMcpMessages(entry, body) {
+  const messages = Array.isArray(body) ? body : [body];
+  const rpc = messages
+    .filter((message) => message && typeof message === "object")
+    .map((message) => rpcSummary(message));
+  if (rpc.length > 0) {
+    entry.rpc = rpc.length === 1 ? rpc[0] : rpc;
+  }
 }
 
 function protectedResourceMetadata() {
@@ -258,9 +320,46 @@ async function issueToken(req, res) {
 }
 
 function isAuthorized(req) {
+  if (noAuthMcp) return true;
   const header = req.headers.authorization || "";
   const match = header.match(/^Bearer\s+(.+)$/i);
   return Boolean(match && tokens.has(match[1]));
+}
+
+function inactiveAccountRows(days, runNonce) {
+  const threshold = Number.isFinite(days) ? days : 30;
+  return [
+    {
+      email: "maya.chen@acme.test",
+      employeeId: "E-1042",
+      lastActiveDaysAgo: threshold + 17,
+      name: "Maya Chen",
+      recommendedAction: "Review manager approval before disabling.",
+    },
+    {
+      email: "theo.ramirez@acme.test",
+      employeeId: "E-1188",
+      lastActiveDaysAgo: threshold + 8,
+      name: "Theo Ramirez",
+      recommendedAction: "Confirm contractor end date, then suspend.",
+    },
+    {
+      email: "nora.patel@acme.test",
+      employeeId: "E-1215",
+      lastActiveDaysAgo: threshold + 3,
+      name: "Nora Patel",
+      recommendedAction: "Send reactivation reminder first.",
+    },
+  ].map((row) => ({ ...row, inactiveThresholdDays: threshold, runNonce }));
+}
+
+function inactiveAccountsText(days, runNonce) {
+  const rows = inactiveAccountRows(days, runNonce);
+  return [
+    `Employee Directory inactive account check for ${days} days${runNonce ? ` (run nonce ${runNonce})` : ""}.`,
+    ...rows.map((row) => `- ${row.name} <${row.email}> — inactive ${row.lastActiveDaysAgo} days — ${row.recommendedAction}`),
+    "Connection used: Employee Directory through OpenWork Connect.",
+  ].join("\n");
 }
 
 function mcpResult(message) {
@@ -284,9 +383,55 @@ function mcpResult(message) {
               required: ["text"],
             },
           },
+          {
+            name: "list_inactive_accounts",
+            title: "List inactive employee accounts",
+            description: "Returns deterministic Employee Directory accounts whose last activity is older than the requested number of days. Requires the runNonce issued by the organization's Inactive Account Check skill; load that skill capability first.",
+            inputSchema: {
+              type: "object",
+              properties: {
+                days: { type: "number", description: "Inactive threshold in days. Use 30 for the approved first workflow." },
+                runNonce: { type: "string", description: "Governing-run nonce from the Inactive Account Check skill. Calls without it are rejected." },
+              },
+              required: ["days", "runNonce"],
+            },
+          },
         ],
       };
     case "tools/call":
+      if (message.params?.name === "list_inactive_accounts") {
+        const daysInput = Number(message.params?.arguments?.days ?? 30);
+        const days = Number.isFinite(daysInput) ? daysInput : 30;
+        const runNonce = typeof message.params?.arguments?.runNonce === "string" ? message.params.arguments.runNonce : "";
+        if (!/^inactive-account-check-/.test(runNonce)) {
+          // Skill-gated tool: the governing procedure (and its runNonce) lives
+          // in the organization's Inactive Account Check skill, so a direct
+          // call cannot skip loading the skill first.
+          return {
+            isError: true,
+            content: [
+              {
+                type: "text",
+                text: "runNonce missing or invalid. This directory follows a governed procedure: search capabilities for the organization's 'Inactive Account Check' skill and execute that skill capability first — it contains the required runNonce and the exact steps for this check.",
+              },
+            ],
+          };
+        }
+        return {
+          content: [
+            {
+              type: "text",
+              text: inactiveAccountsText(days, runNonce),
+            },
+          ],
+          structuredContent: {
+            days,
+            runNonce,
+            source: "Employee Directory",
+            accounts: inactiveAccountRows(days, runNonce),
+          },
+        };
+      }
       return {
         content: [
           {
@@ -300,7 +445,7 @@ function mcpResult(message) {
   }
 }
 
-async function handleMcp(req, res) {
+async function handleMcp(req, res, entry) {
   if (!isAuthorized(req)) {
     json(res, 401, { error: "missing_mcp_token" }, {
       "www-authenticate": `Bearer resource_metadata="${issuer}/.well-known/oauth-protected-resource"`,
@@ -314,6 +459,7 @@ async function handleMcp(req, res) {
   }
 
   const body = await readJson(req).catch(() => ({}));
+  recordMcpMessages(entry, body);
   const messages = Array.isArray(body) ? body : [body];
   const responses = messages.flatMap((message) => {
     if (!message || typeof message !== "object" || message.id === undefined) return [];
@@ -332,7 +478,7 @@ async function handleMcp(req, res) {
 const server = http.createServer(async (req, res) => {
   try {
     const url = new URL(req.url || "/", issuer);
-    record(req, url);
+    const entry = record(req, url);
 
     if (req.method === "OPTIONS") {
       json(res, 204, {});
@@ -340,7 +486,7 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (url.pathname === "/health") {
-      json(res, 200, { ok: true, issuer, autoApprove, disableDcr, requests: requests.length });
+      json(res, 200, { ok: true, issuer, autoApprove, disableDcr, mcpAuth: noAuthMcp ? "none" : "oauth", requests: requests.length });
       return;
     }
 
@@ -387,7 +533,7 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (url.pathname === "/mcp") {
-      await handleMcp(req, res);
+      await handleMcp(req, res, entry);
       return;
     }
 
@@ -423,5 +569,6 @@ const server = http.createServer(async (req, res) => {
 server.listen(port, host, () => {
   console.log(`[mock-oauth-mcp] listening on ${issuer}`);
   console.log(`[mock-oauth-mcp] MCP URL: ${issuer}/mcp`);
+  console.log(`[mock-oauth-mcp] MCP auth mode: ${noAuthMcp ? "none" : "oauth"}`);
   console.log(`[mock-oauth-mcp] set AUTO_APPROVE=0 to require an approval click`);
 });


### PR DESCRIPTION
## What

Proves and fixes the **complete first-time invitee journey** — from the invitation email to running an administrator-provided workflow through **OpenWork Connect** — validated end to end on a two-sandbox Daytona stack (patched Den server + patched Electron).

Verdict: **Passed** — all 12 frames hold with voice-over coverage. Frame proof is posted below via `pnpm fraimz --pr`.

## Real product bugs found while validating (all fixed)

- **Install page lied about progress.** Replaced the fake fixed-timer "Download started" with a real server readiness/preparation handshake; added an unmistakable animated spinner and honest staged messages; the real download is only requested once artifacts resolve.
- **Journey lost on download.** `join-org` success is now one streamlined map (Join → Download → Connect) with the org-stamped installer as the primary action, opened in a new tab so the "connect" step survives.
- **Invitation accept** now returns the organization install-page URL.
- **Manual plugin bundles weren't executable.** Creating a bundle now materializes one native org skill **and** one shared no-auth Connect MCP connection (discoverable/executable via `/mcp/agent`), with no duplication on update and cleanup on archive.
- **Skill title** uses the admin display name, not the machine slug.
- **Plugin detail** shows connection-backed MCPs as `HTTP · OpenWork Connect` instead of the misleading `stdio · 0 tools`.
- **Desktop onboarding** skips the redundant single-org picker, reads real org skills + usable MCP connections, presents them as one ready first workflow, and hands the suggested prompt to the real composer store — which **also fixes the existing empty-state suggestion chips** that were silently feeding an orphaned draft store.

## How it was tested

`pnpm fraimz --flow invite-connect-first-skill` on Daytona (Den server sandbox + Electron sandbox), seeded Acme Robotics, real no-auth Employee Directory mock MCP.

The 12 frames prove, with observable assertions (not clicks):

1. Admin builds the Inactive Account Check bundle in the real plugin editor — APIs confirm exactly one native skill + one usable Connect connection.
2. Invite email names inviter, org, and role.
3. First-time signup → verification → acceptance without losing place.
4. Journey map: Join done / Download current / Connect up next.
5–7. Recommended installer, spinner **provably moves** (computed transform sampled twice), staged messages, download requested only after real readiness.
8. Browser-created handoff signs Electron into Acme (Cloud Account shows the invitee).
9. Single-org picker skipped; Connect card shows org + skill + connection ready.
10. CTA pre-fills the exact admin prompt without auto-sending.
11–12. Transcript witness (app/session API): `search_capabilities` → `execute_capability(skill:…)` → `execute_capability(mcp:…list_inactive_accounts)`; the remote MCP request log independently shows `tools/call {days:30, runNonce:"inactive-account-check-…"}`; results + "Connection used: Employee Directory through OpenWork Connect" render in chat.

### Unit / type / build
- `@openwork/app` typecheck + 6 onboarding tests — pass
- `@openwork-ee/den-web` 62 tests, typecheck, build — pass
- `@openwork-ee/den-api` 22 focused tests (install-link, invitation-accept, plugin-bundle, route-guard), typecheck, build — pass

Frame-by-frame proof is attached as a PR comment below.
