### PR TITLE
feat(inference): report unknown usage models

### DIFF
--- a/ee/apps/inference/package.json
+++ b/ee/apps/inference/package.json
@@ -6,7 +6,7 @@
     "models:build": "node scripts/build-models.mjs",
     "dev": "pnpm run models:build && tsx watch src/server.ts",
     "dev:local": "OPENWORK_DEV_MODE=1 pnpm run models:build && OPENWORK_DEV_MODE=1 PORT=${INFERENCE_PORT:-8791} tsx watch src/server.ts",
-    "test": "tsx --test test/proxy.test.ts",
+    "test": "NODE_OPTIONS=--conditions=development tsx --test test/*.test.ts",
     "build": "pnpm run models:build && tsc -p tsconfig.json",
     "start": "node --import ./dist/instrumentation.js dist/server.js"
   },

--- a/ee/apps/inference/src/webhooks.ts
+++ b/ee/apps/inference/src/webhooks.ts
@@ -4,24 +4,100 @@ import { InferenceKeyTable, InferenceUsageLedgerBucketChargeTable, InferenceUsag
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import { INFERENCE_USAGE_CONVERSION_FACTOR } from "@openwork/types/den/inference"
+import * as Sentry from "@sentry/node"
 import { db } from "./db.js"
 import { env } from "./env.js"
 import { constantTimeEquals } from "./keys.js"
-import { ensureUsableBuckets } from "./limits.js"
+import { ensureUsableBuckets as ensureUsageBuckets } from "./limits.js"
+import type { BucketLimitMetadata, BucketMetadata } from "./limits.js"
 import { resolveModelByUpstreamModel } from "./model-catalog.js"
 
 type JsonRecord = Record<string, unknown>
+
+type OpenRouterUsageMetadata = {
+  requestModel: string | null
+  responseModel: string | null
+  inputCost: number
+  outputCost: number
+  totalCost: number
+  inputTokens: number | null
+  outputTokens: number | null
+  totalTokens: number | null
+  generationId: string | null
+  spanId: string | null
+  traceId: string | null
+  spanName: string | null
+  currency: string | null
+}
+
+export type OpenRouterUnknownModelUsageReport = {
+  reportedModel: string
+  organizationId: string
+  orgMembershipId: string
+  inferenceKeyId: string
+  openworkRequestId: string
+  externalEventId: string | null
+  generationId: string | null
+  usage: OpenRouterUsageMetadata
+}
+
+type OpenRouterUsageWebhookReporter = {
+  unknownModel(report: OpenRouterUnknownModelUsageReport): void
+}
 
 type ParsedSpan = {
   orgMembershipId: string
   inferenceKeyId: string
   openworkRequestId: string
   externalEventId: string | null
-  costAmount: number
+  generationId: string | null
   occurredAt: Date
-  upstreamModel: string
+  reportedModel: string
+  requestModel: string | null
+  responseModel: string | null
   inputCost: number
   outputCost: number
+  usageMetadata: OpenRouterUsageMetadata
+}
+
+type WebhookInferenceKey = {
+  id: DenTypeId<"inferenceKey">
+  status: string
+  organization_id: DenTypeId<"organization">
+  org_membership_id: DenTypeId<"member">
+}
+
+type UsageBucketSettlement = {
+  ok: boolean
+  bucketIds: BucketMetadata
+  bucketLimits: BucketLimitMetadata
+  limitedBy?: string
+}
+
+type UsageLedgerEntryRef = {
+  id: DenTypeId<"inferenceUsageLedgerEntry">
+}
+
+type InsertUsageLedgerEntryInput = {
+  inferenceKey: WebhookInferenceKey
+  span: ParsedSpan
+  costAmount: number
+}
+
+type ChargeBucketsInput = {
+  limits: UsageBucketSettlement
+  ledgerEntryId: DenTypeId<"inferenceUsageLedgerEntry">
+  costAmount: number
+}
+
+type WebhookDependencies = {
+  reporter: OpenRouterUsageWebhookReporter
+  findInferenceKey(inferenceKeyId: string): Promise<WebhookInferenceKey | null>
+  ensureUsableBuckets(organizationId: string, occurredAt: Date): Promise<UsageBucketSettlement>
+  findLedgerEntryByExternalEventId(externalEventId: string): Promise<UsageLedgerEntryRef | null>
+  findOpenRouterUsageLedgerEntry(openworkRequestId: string): Promise<UsageLedgerEntryRef | null>
+  insertOpenRouterUsageLedgerEntry(input: InsertUsageLedgerEntryInput): Promise<UsageLedgerEntryRef>
+  chargeBuckets(input: ChargeBucketsInput): Promise<void>
 }
 
 function isRecord(value: unknown): value is JsonRecord {
@@ -71,6 +147,11 @@ function numberAttr(attrs: JsonRecord, keys: string[]) {
   return null
 }
 
+function spanString(span: JsonRecord, key: string) {
+  const value = span[key]
+  return typeof value === "string" && value.trim() ? value.trim() : null
+}
+
 function usageUnitsForModel(input: { upstreamModel: string; inputCost: number; outputCost: number }) {
   const model = resolveModelByUpstreamModel(input.upstreamModel)
   if (!model) return null
@@ -88,35 +169,62 @@ function timeFromSpan(span: JsonRecord) {
   return Number.isFinite(ms) ? new Date(ms) : new Date()
 }
 
+function usageMetadataFromSpan(input: {
+  span: JsonRecord
+  attrs: JsonRecord
+  requestModel: string | null
+  responseModel: string | null
+  inputCost: number
+  outputCost: number
+  generationId: string | null
+}): OpenRouterUsageMetadata {
+  return {
+    requestModel: input.requestModel,
+    responseModel: input.responseModel,
+    inputCost: input.inputCost,
+    outputCost: input.outputCost,
+    totalCost: input.inputCost + input.outputCost,
+    inputTokens: numberAttr(input.attrs, ["gen_ai.usage.input_tokens", "gen_ai.usage.prompt_tokens", "llm.usage.prompt_tokens", "prompt_tokens"]),
+    outputTokens: numberAttr(input.attrs, ["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens", "llm.usage.completion_tokens", "completion_tokens"]),
+    totalTokens: numberAttr(input.attrs, ["gen_ai.usage.total_tokens", "llm.usage.total_tokens", "total_tokens"]),
+    generationId: input.generationId,
+    spanId: spanString(input.span, "spanId") ?? stringAttr(input.attrs, ["span_id"]),
+    traceId: spanString(input.span, "traceId") ?? stringAttr(input.attrs, ["trace_id"]),
+    spanName: spanString(input.span, "name"),
+    currency: stringAttr(input.attrs, ["gen_ai.usage.currency", "gen_ai.cost.currency"]),
+  }
+}
+
 function parseSpan(span: JsonRecord, resourceAttrs: JsonRecord, scopeAttrs: JsonRecord): ParsedSpan | null {
   const attrs = { ...resourceAttrs, ...scopeAttrs, ...attributesToRecord(span.attributes) }
   const orgMembershipId = stringAttr(attrs, ["trace.metadata.org_membership_id", "trace.org_membership_id", "metadata.org_membership_id", "org_membership_id"])
   const inferenceKeyId = stringAttr(attrs, ["trace.metadata.inference_key_id", "trace.inference_key_id", "metadata.inference_key_id", "inference_key_id"])
   const openworkRequestId = stringAttr(attrs, ["trace.metadata.openwork_request_id", "trace.openwork_request_id", "metadata.openwork_request_id", "openwork_request_id", "trace_id"])
     ?? (typeof span.traceId === "string" ? span.traceId : null)
-  const upstreamModel = stringAttr(attrs, ["gen_ai.request.model", "gen_ai.response.model"])
+  const requestModel = stringAttr(attrs, ["gen_ai.request.model"])
+  const responseModel = stringAttr(attrs, ["gen_ai.response.model"])
+  const reportedModel = responseModel ?? requestModel
   const inputCost = numberAttr(attrs, ["gen_ai.usage.input_cost"])
   const outputCost = numberAttr(attrs, ["gen_ai.usage.output_cost"])
-  if (!orgMembershipId || !inferenceKeyId || !openworkRequestId || !upstreamModel || inputCost === null || outputCost === null) {
+  if (!orgMembershipId || !inferenceKeyId || !openworkRequestId || !reportedModel || inputCost === null || outputCost === null) {
     return null
   }
-
-  const costAmount = usageUnitsForModel({ upstreamModel, inputCost, outputCost })
-  if (costAmount === null) {
-    logWebhookError("skipped span for unknown priced model", { upstreamModel })
-    return null
-  }
+  const generationId = stringAttr(attrs, ["gen_ai.response.id", "gen_ai.generation.id", "generation_id", "response_id"])
+  const externalEventId = stringAttr(attrs, ["event_id", "id", "span_id"]) ?? generationId ?? spanString(span, "spanId")
 
   return {
     orgMembershipId,
     inferenceKeyId,
     openworkRequestId,
-    externalEventId: stringAttr(attrs, ["event_id", "id", "span_id"]) ?? (typeof span.spanId === "string" ? span.spanId : null),
-    costAmount,
+    externalEventId,
+    generationId,
     occurredAt: timeFromSpan(span),
-    upstreamModel,
+    reportedModel,
+    requestModel,
+    responseModel,
     inputCost,
     outputCost,
+    usageMetadata: usageMetadataFromSpan({ span, attrs, requestModel, responseModel, inputCost, outputCost, generationId }),
   }
 }
 
@@ -141,19 +249,123 @@ function parseOtlpSpans(body: unknown) {
 
 function isAuthorized(request: Request) {
   if (!env.webhookSecret) return false
+  const webhookSecret = env.webhookSecret
   const auth = request.headers.get("authorization")
   const bearer = auth?.toLowerCase().startsWith("bearer ") ? auth.slice(7).trim() : null
   const signature = request.headers.get("x-webhook-signature")?.trim() ?? null
-  return [bearer, signature].some((value) => value !== null && constantTimeEquals(value, env.webhookSecret!))
+  return [bearer, signature].some((value) => value !== null && constantTimeEquals(value, webhookSecret))
 }
 
-async function ingestSpan(span: ParsedSpan) {
-  const [inferenceKey] = await db.select().from(InferenceKeyTable)
-    .where(eq(InferenceKeyTable.id, normalizeDenTypeId("inferenceKey", span.inferenceKeyId)))
-    .limit(1)
+const sentryWebhookReporter: OpenRouterUsageWebhookReporter = {
+  unknownModel(report) {
+    Sentry.captureMessage("OpenRouter usage webhook could not infer cost for reported model", {
+      level: "fatal",
+      tags: {
+        organization_id: report.organizationId,
+        openwork_request_id: report.openworkRequestId,
+        external_event_id: report.externalEventId ?? "none",
+        reported_model: report.reportedModel,
+      },
+      contexts: {
+        openrouter_usage_webhook: report,
+      },
+    })
+  },
+}
+
+const defaultWebhookDependencies: WebhookDependencies = {
+  reporter: sentryWebhookReporter,
+  async findInferenceKey(inferenceKeyId) {
+    const [inferenceKey] = await db.select().from(InferenceKeyTable)
+      .where(eq(InferenceKeyTable.id, normalizeDenTypeId("inferenceKey", inferenceKeyId)))
+      .limit(1)
+    return inferenceKey ?? null
+  },
+  async ensureUsableBuckets(organizationId, occurredAt) {
+    return ensureUsageBuckets(organizationId, occurredAt)
+  },
+  async findLedgerEntryByExternalEventId(externalEventId) {
+    const [event] = await db.select({ id: InferenceUsageLedgerEntryTable.id }).from(InferenceUsageLedgerEntryTable)
+      .where(eq(InferenceUsageLedgerEntryTable.external_event_id, externalEventId))
+      .limit(1)
+    return event ?? null
+  },
+  async findOpenRouterUsageLedgerEntry(openworkRequestId) {
+    const [existing] = await db.select({ id: InferenceUsageLedgerEntryTable.id }).from(InferenceUsageLedgerEntryTable)
+      .where(and(eq(InferenceUsageLedgerEntryTable.external_job_id, openworkRequestId), eq(InferenceUsageLedgerEntryTable.event_type, "openrouter_usage"))).limit(1)
+    return existing ?? null
+  },
+  async insertOpenRouterUsageLedgerEntry(input) {
+    const entryId = createDenTypeId("inferenceUsageLedgerEntry")
+    await db.insert(InferenceUsageLedgerEntryTable).values({
+      id: entryId,
+      organization_id: input.inferenceKey.organization_id,
+      org_membership_id: input.inferenceKey.org_membership_id,
+      inference_key_id: input.inferenceKey.id,
+      external_job_id: input.span.openworkRequestId,
+      external_event_id: input.span.externalEventId,
+      cost_amount: input.costAmount,
+      event_type: "openrouter_usage",
+      occurred_at: input.span.occurredAt,
+    })
+    return { id: entryId }
+  },
+  async chargeBuckets(input) {
+    await db.transaction(async (tx) => {
+      for (const [windowType, bucketId] of Object.entries(input.limits.bucketIds)) {
+        if (!bucketId) continue
+        const limitAmount = input.limits.bucketLimits[windowType]
+        if (limitAmount === undefined) continue
+        const [charge] = await tx.select({ id: InferenceUsageLedgerBucketChargeTable.id })
+          .from(InferenceUsageLedgerBucketChargeTable)
+          .where(and(
+            eq(InferenceUsageLedgerBucketChargeTable.ledger_entry_id, input.ledgerEntryId),
+            eq(InferenceUsageLedgerBucketChargeTable.bucket_id, bucketId),
+          ))
+          .limit(1)
+        if (charge) {
+          continue
+        }
+
+        await tx.insert(InferenceUsageLedgerBucketChargeTable).values({
+          id: createDenTypeId("inferenceUsageLedgerBucketCharge"),
+          ledger_entry_id: input.ledgerEntryId,
+          bucket_id: bucketId,
+          amount: input.costAmount,
+        })
+        await tx.update(InferenceOrgUsageBucketTable).set({
+          limit_amount: limitAmount,
+          used_amount: sql`${InferenceOrgUsageBucketTable.used_amount} + ${input.costAmount}`,
+        }).where(eq(InferenceOrgUsageBucketTable.id, bucketId))
+      }
+    })
+  },
+}
+
+function reportUnknownPricedModel(input: { span: ParsedSpan; inferenceKey: WebhookInferenceKey; reporter: OpenRouterUsageWebhookReporter }) {
+  logWebhookError("skipped span for unknown priced model", {
+    reportedModel: input.span.reportedModel,
+    organizationId: input.inferenceKey.organization_id,
+    openworkRequestId: input.span.openworkRequestId,
+    externalEventId: input.span.externalEventId,
+  })
+  input.reporter.unknownModel({
+    reportedModel: input.span.reportedModel,
+    organizationId: input.inferenceKey.organization_id,
+    orgMembershipId: input.inferenceKey.org_membership_id,
+    inferenceKeyId: input.inferenceKey.id,
+    openworkRequestId: input.span.openworkRequestId,
+    externalEventId: input.span.externalEventId,
+    generationId: input.span.generationId,
+    usage: input.span.usageMetadata,
+  })
+}
+
+async function ingestSpan(span: ParsedSpan, dependencies: WebhookDependencies) {
+  const inferenceKey = await dependencies.findInferenceKey(span.inferenceKeyId)
   if (!inferenceKey || inferenceKey.status !== "active") {
     logWebhookError("skipped span for missing or inactive inference key", { inferenceKeyId: span.inferenceKeyId })
-    return
+    return false
   }
   if (inferenceKey.org_membership_id !== normalizeDenTypeId("member", span.orgMembershipId)) {
     logWebhookError("skipped span for mismatched org membership", {
@@ -161,10 +373,16 @@ async function ingestSpan(span: ParsedSpan) {
       spanOrgMembershipId: span.orgMembershipId,
       keyOrgMembershipId: inferenceKey.org_membership_id,
     })
-    return
+    return false
   }
 
-  const limits = await ensureUsableBuckets(inferenceKey.organization_id, span.occurredAt)
+  const costAmount = usageUnitsForModel({ upstreamModel: span.reportedModel, inputCost: span.inputCost, outputCost: span.outputCost })
+  if (costAmount === null) {
+    reportUnknownPricedModel({ span, inferenceKey, reporter: dependencies.reporter })
+    return false
+  }
+
+  const limits = await dependencies.ensureUsableBuckets(inferenceKey.organization_id, span.occurredAt)
   if (!limits.ok) {
     logWebhookError("settling usage after limit was exceeded", {
       inferenceKeyId: span.inferenceKeyId,
@@ -173,63 +391,17 @@ async function ingestSpan(span: ParsedSpan) {
   }
 
   if (span.externalEventId) {
-    const [event] = await db.select({ id: InferenceUsageLedgerEntryTable.id }).from(InferenceUsageLedgerEntryTable)
-      .where(eq(InferenceUsageLedgerEntryTable.external_event_id, span.externalEventId))
-      .limit(1)
-    if (event) return
+    const event = await dependencies.findLedgerEntryByExternalEventId(span.externalEventId)
+    if (event) return false
   }
 
-  const [existing] = await db.select({ id: InferenceUsageLedgerEntryTable.id }).from(InferenceUsageLedgerEntryTable)
-    .where(and(eq(InferenceUsageLedgerEntryTable.external_job_id, span.openworkRequestId), eq(InferenceUsageLedgerEntryTable.event_type, "openrouter_usage"))).limit(1)
-  const entry = existing ?? await (async () => {
-    const entryId = createDenTypeId("inferenceUsageLedgerEntry")
-    await db.insert(InferenceUsageLedgerEntryTable).values({
-      id: entryId,
-      organization_id: inferenceKey.organization_id,
-      org_membership_id: inferenceKey.org_membership_id,
-      inference_key_id: inferenceKey.id,
-      external_job_id: span.openworkRequestId,
-      external_event_id: span.externalEventId,
-      cost_amount: span.costAmount,
-      event_type: "openrouter_usage",
-      occurred_at: span.occurredAt,
-    })
-    return { id: entryId }
-  })()
-  if (!entry) return
-
-  await db.transaction(async (tx) => {
-    const bucketLimits = limits.bucketLimits as Record<string, number | undefined>
-    for (const [windowType, bucketId] of Object.entries(limits.bucketIds)) {
-      if (!bucketId) continue
-      const limitAmount = bucketLimits[windowType]
-      if (limitAmount === undefined) continue
-      const [charge] = await tx.select({ id: InferenceUsageLedgerBucketChargeTable.id })
-        .from(InferenceUsageLedgerBucketChargeTable)
-        .where(and(
-          eq(InferenceUsageLedgerBucketChargeTable.ledger_entry_id, entry.id),
-          eq(InferenceUsageLedgerBucketChargeTable.bucket_id, bucketId),
-        ))
-        .limit(1)
-      if (charge) {
-        continue
-      }
-
-      await tx.insert(InferenceUsageLedgerBucketChargeTable).values({
-        id: createDenTypeId("inferenceUsageLedgerBucketCharge"),
-        ledger_entry_id: entry.id,
-        bucket_id: bucketId,
-        amount: span.costAmount,
-      })
-      await tx.update(InferenceOrgUsageBucketTable).set({
-        limit_amount: limitAmount,
-        used_amount: sql`${InferenceOrgUsageBucketTable.used_amount} + ${span.costAmount}`,
-      }).where(eq(InferenceOrgUsageBucketTable.id, bucketId))
-    }
-  })
+  const existing = await dependencies.findOpenRouterUsageLedgerEntry(span.openworkRequestId)
+  const entry = existing ?? await dependencies.insertOpenRouterUsageLedgerEntry({ inferenceKey, span, costAmount })
+  await dependencies.chargeBuckets({ limits, ledgerEntryId: entry.id, costAmount })
+  return true
 }
 
-export function registerWebhookRoutes(app: Hono) {
+export function registerWebhookRoutes(app: Hono, dependencies: WebhookDependencies = defaultWebhookDependencies) {
   app.post("/webhooks/openrouter", async (c) => {
     if (c.req.header("x-test-connection")?.toLowerCase() === "true") {
       return c.body(null, 204)
@@ -255,8 +427,11 @@ export function registerWebhookRoutes(app: Hono) {
     let skipped = 0
     for (const span of spans) {
       try {
-        await ingestSpan(span)
-        ingested += 1
+        if (await ingestSpan(span, dependencies)) {
+          ingested += 1
+        } else {
+          skipped += 1
+        }
       } catch (error) {
         skipped += 1
         logWebhookError("failed to ingest OpenRouter usage span", { error: error instanceof Error ? error.message : String(error) })

--- a/ee/apps/inference/test/webhooks.test.ts
+++ b/ee/apps/inference/test/webhooks.test.ts
@@ -1,0 +1,216 @@
+import assert from "node:assert/strict"
+import { test } from "node:test"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { Hono } from "hono"
+import type { OpenRouterUnknownModelUsageReport } from "../src/webhooks.js"
+
+process.env.OPENWORK_DEV_MODE = "1"
+process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_den"
+process.env.DEN_DB_ENCRYPTION_KEY = "local-dev-db-encryption-key-please-change-1234567890"
+process.env.INFERENCE_WEBHOOK_SECRET = "local-dev-webhook-secret"
+
+const { registerWebhookRoutes } = await import("../src/webhooks.js")
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function attribute(key: string, value: string | number | boolean) {
+  if (typeof value === "string") return { key, value: { stringValue: value } }
+  if (typeof value === "boolean") return { key, value: { boolValue: value } }
+  if (Number.isInteger(value)) return { key, value: { intValue: value } }
+  return { key, value: { doubleValue: value } }
+}
+
+function webhookRequest(body: unknown) {
+  return new Request("http://openwork.test/webhooks/openrouter", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer local-dev-webhook-secret",
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(body),
+  })
+}
+
+async function responseJson(response: Response) {
+  const payload: unknown = await response.json()
+  assert.ok(isRecord(payload))
+  return payload
+}
+
+function createWebhookTestServer() {
+  const app = new Hono()
+  const organizationId = createDenTypeId("organization")
+  const orgMembershipId = createDenTypeId("member")
+  const inferenceKeyId = createDenTypeId("inferenceKey")
+  const ledgerEntryId = createDenTypeId("inferenceUsageLedgerEntry")
+  const bucketId = createDenTypeId("inferenceOrgUsageBucket")
+  const reports: OpenRouterUnknownModelUsageReport[] = []
+  const insertedEntries: { openworkRequestId: string; externalEventId: string | null; costAmount: number }[] = []
+  const bucketCharges: { amount: number }[] = []
+  const calls = {
+    ensureUsableBuckets: 0,
+    findLedgerEntryByExternalEventId: 0,
+    findOpenRouterUsageLedgerEntry: 0,
+    insertOpenRouterUsageLedgerEntry: 0,
+    chargeBuckets: 0,
+  }
+
+  registerWebhookRoutes(app, {
+    reporter: {
+      unknownModel(report) {
+        reports.push(report)
+      },
+    },
+    async findInferenceKey(_inferenceKeyId) {
+      return {
+        id: inferenceKeyId,
+        status: "active",
+        organization_id: organizationId,
+        org_membership_id: orgMembershipId,
+      }
+    },
+    async ensureUsableBuckets(_organizationId, _occurredAt) {
+      calls.ensureUsableBuckets += 1
+      return {
+        ok: true,
+        bucketIds: { monthly: bucketId },
+        bucketLimits: { monthly: 1_000_000 },
+      }
+    },
+    async findLedgerEntryByExternalEventId(_externalEventId) {
+      calls.findLedgerEntryByExternalEventId += 1
+      return null
+    },
+    async findOpenRouterUsageLedgerEntry(_openworkRequestId) {
+      calls.findOpenRouterUsageLedgerEntry += 1
+      return null
+    },
+    async insertOpenRouterUsageLedgerEntry(input) {
+      calls.insertOpenRouterUsageLedgerEntry += 1
+      insertedEntries.push({
+        openworkRequestId: input.span.openworkRequestId,
+        externalEventId: input.span.externalEventId,
+        costAmount: input.costAmount,
+      })
+      return { id: ledgerEntryId }
+    },
+    async chargeBuckets(input) {
+      calls.chargeBuckets += 1
+      bucketCharges.push({ amount: input.costAmount })
+    },
+  })
+
+  function usagePayload(input: { requestId: string; eventId: string; generationId: string; requestModel: string; responseModel: string; includeSensitive?: boolean }) {
+    const attributes = [
+      attribute("trace.org_membership_id", orgMembershipId),
+      attribute("trace.inference_key_id", inferenceKeyId),
+      attribute("trace.openwork_request_id", input.requestId),
+      attribute("event_id", input.eventId),
+      attribute("gen_ai.response.id", input.generationId),
+      attribute("gen_ai.request.model", input.requestModel),
+      attribute("gen_ai.response.model", input.responseModel),
+      attribute("gen_ai.usage.input_cost", 0),
+      attribute("gen_ai.usage.output_cost", 0),
+      attribute("gen_ai.usage.input_tokens", 11),
+      attribute("gen_ai.usage.output_tokens", 13),
+      attribute("gen_ai.usage.total_tokens", 24),
+      attribute("gen_ai.usage.currency", "USD"),
+    ]
+    if (input.includeSensitive) {
+      attributes.push(
+        attribute("authorization", "Bearer caller-secret"),
+        attribute("gen_ai.prompt.0.content", "secret prompt content"),
+        attribute("gen_ai.completion.0.content", "secret response content"),
+      )
+    }
+
+    return {
+      resourceSpans: [{
+        resource: { attributes: [] },
+        scopeSpans: [{
+          scope: { attributes: [] },
+          spans: [{
+            traceId: "trace-123",
+            spanId: "span-123",
+            name: "OpenRouter usage",
+            startTimeUnixNano: "1700000000000000000",
+            endTimeUnixNano: "1700000001000000000",
+            attributes,
+          }],
+        }],
+      }],
+    }
+  }
+
+  return { app, reports, insertedEntries, bucketCharges, calls, organizationId, usagePayload }
+}
+
+test("reports fatal Sentry diagnostics and skips deduction when OpenRouter usage reports an unknown model", async () => {
+  const { app, reports, insertedEntries, bucketCharges, calls, organizationId, usagePayload } = createWebhookTestServer()
+  const response = await app.fetch(webhookRequest(usagePayload({
+    requestId: "request-unknown",
+    eventId: "event-unknown",
+    generationId: "generation-unknown",
+    requestModel: "openrouter/fusion",
+    responseModel: "vendor/new-model",
+    includeSensitive: true,
+  })))
+
+  assert.equal(response.status, 200)
+  const payload = await responseJson(response)
+  assert.equal(payload.ingested, 0)
+  assert.equal(payload.skipped, 1)
+  assert.equal(calls.ensureUsableBuckets, 0)
+  assert.equal(calls.findLedgerEntryByExternalEventId, 0)
+  assert.equal(calls.findOpenRouterUsageLedgerEntry, 0)
+  assert.equal(calls.insertOpenRouterUsageLedgerEntry, 0)
+  assert.equal(calls.chargeBuckets, 0)
+  assert.equal(insertedEntries.length, 0)
+  assert.equal(bucketCharges.length, 0)
+  assert.equal(reports.length, 1)
+
+  const report = reports[0]
+  assert.ok(report)
+  assert.equal(report.reportedModel, "vendor/new-model")
+  assert.equal(report.organizationId, organizationId)
+  assert.equal(report.openworkRequestId, "request-unknown")
+  assert.equal(report.externalEventId, "event-unknown")
+  assert.equal(report.generationId, "generation-unknown")
+  assert.equal(report.usage.requestModel, "openrouter/fusion")
+  assert.equal(report.usage.responseModel, "vendor/new-model")
+  assert.equal(report.usage.inputTokens, 11)
+  assert.equal(report.usage.outputTokens, 13)
+  assert.equal(report.usage.totalTokens, 24)
+  assert.equal(report.usage.currency, "USD")
+
+  const diagnosticText = JSON.stringify(report)
+  assert.ok(!diagnosticText.includes("caller-secret"))
+  assert.ok(!diagnosticText.includes("secret prompt content"))
+  assert.ok(!diagnosticText.includes("secret response content"))
+})
+
+test("deducts usage without Sentry diagnostics when OpenRouter usage reports a known model", async () => {
+  const { app, reports, insertedEntries, bucketCharges, calls, usagePayload } = createWebhookTestServer()
+  const response = await app.fetch(webhookRequest(usagePayload({
+    requestId: "request-known",
+    eventId: "event-known",
+    generationId: "generation-known",
+    requestModel: "openrouter/fusion",
+    responseModel: "openrouter/fusion",
+  })))
+
+  assert.equal(response.status, 200)
+  const payload = await responseJson(response)
+  assert.equal(payload.ingested, 1)
+  assert.equal(payload.skipped, 0)
+  assert.equal(reports.length, 0)
+  assert.equal(calls.ensureUsableBuckets, 1)
+  assert.equal(calls.findLedgerEntryByExternalEventId, 1)
+  assert.equal(calls.findOpenRouterUsageLedgerEntry, 1)
+  assert.equal(calls.insertOpenRouterUsageLedgerEntry, 1)
+  assert.equal(calls.chargeBuckets, 1)
+  assert.deepEqual(insertedEntries, [{ openworkRequestId: "request-known", externalEventId: "event-known", costAmount: 1 }])
+  assert.deepEqual(bucketCharges, [{ amount: 1 }])
+})

--- a/evals/flows/inference-non-matching-model-as-error.flow.mjs
+++ b/evals/flows/inference-non-matching-model-as-error.flow.mjs
@@ -1,0 +1,84 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("inference-non-matching-model-as-error");
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+let testRun;
+
+function runTests() {
+  testRun ??= spawnSync("pnpm", ["--filter", "@openwork-ee/inference", "test"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 60_000,
+  });
+  return testRun;
+}
+
+function proveTests(ctx, names) {
+  const run = runTests();
+  const output = `${run.stdout ?? ""}\n${run.stderr ?? ""}`.trim();
+  ctx.assert(run.status === 0, `Focused inference tests exit successfully (actual: ${run.status})`);
+  for (const name of names) {
+    ctx.assert(output.includes(`✔ ${name}`), `Passing test witnessed: ${name}`);
+  }
+  ctx.output("$ pnpm --filter @openwork-ee/inference test", output);
+}
+
+const unknownModelTest = "reports fatal Sentry diagnostics and skips deduction when OpenRouter usage reports an unknown model";
+const knownModelTest = "deducts usage without Sentry diagnostics when OpenRouter usage reports a known model";
+
+export default {
+  id: "inference-non-matching-model-as-error",
+  title: "OpenRouter usage webhooks fail loudly when reported models leave the supported catalog",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "OpenRouter usage reaches the webhook",
+      run: async (ctx) => {
+        await ctx.prove("A representative OpenRouter usage webhook payload is accepted by the inference service test harness", {
+          voiceover: vo[0],
+          assert: async () => {
+            proveTests(ctx, [unknownModelTest, knownModelTest]);
+          },
+        });
+      },
+    },
+    {
+      name: "Reported models are catalog checked",
+      run: async (ctx) => {
+        await ctx.prove("The webhook uses the reported response model when deciding whether usage can be priced", {
+          voiceover: vo[1],
+          assert: async () => {
+            proveTests(ctx, [unknownModelTest]);
+          },
+        });
+      },
+    },
+    {
+      name: "Unknown models report fatally without deduction",
+      run: async (ctx) => {
+        await ctx.prove("Unknown reported models skip bucket deduction and emit safe fatal diagnostics", {
+          voiceover: vo[2],
+          assert: async () => {
+            proveTests(ctx, [unknownModelTest]);
+          },
+        });
+      },
+    },
+    {
+      name: "Known models still deduct normally",
+      run: async (ctx) => {
+        await ctx.prove("Known reported models continue through ledger insertion and bucket charging without Sentry diagnostics", {
+          voiceover: vo[3],
+          assert: async () => {
+            proveTests(ctx, [knownModelTest]);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/inference-non-matching-model-as-error.md
+++ b/evals/voiceovers/inference-non-matching-model-as-error.md
@@ -1,0 +1,7 @@
+1. OpenRouter sends usage data to the inference webhook for an organization’s request.
+
+2. The server checks the reported model against the supported model catalog in the types package.
+
+3. If the model is unknown and its cost cannot be calculated, no estimated deduction is made. Sentry receives a critical/fatal event with the reported model, organization ID, request ID, and usage metadata—excluding secrets and prompt content.
+
+4. Known models continue through normal cost calculation and bucket deduction without a Sentry error.


### PR DESCRIPTION
## Summary
- detect OpenRouter-reported models that are absent from the supported inference catalog
- emit a fatal Sentry event with safe organization, request, model, and usage diagnostics
- skip unpriceable bucket deductions while preserving normal deductions for known models
- add focused webhook coverage and an internal fraimz flow

## Validation
- `pnpm --filter @openwork-ee/inference test` — passed (38 tests)
- `pnpm --filter @openwork-ee/inference build` — passed
- `pnpm fraimz --flow inference-non-matching-model-as-error` — passed

Fraimz proof will be posted as a PR comment.