### PR TITLE
fix(den): avoid duplicate signup verification emails

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -536,7 +536,7 @@ export const auth = betterAuth({
   },
   emailAndPassword: {
     enabled: true,
-    autoSignIn: false,
+    autoSignIn: true,
     requireEmailVerification: env.requireEmailVerification,
     revokeSessionsOnPasswordReset: true,
     async sendResetPassword({ user, url }) {

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -1108,33 +1108,6 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       const token = getToken(payload);
 
       if (authMode === "sign-up" && !token) {
-        const signInResult = await requestJson("/api/auth/sign-in/email", {
-          method: "POST",
-          body: JSON.stringify({
-            email: trimmedEmail,
-            password,
-          })
-        });
-
-        if (signInResult.response.ok) {
-          return await finalizeEmailPasswordSignIn(authMode, trimmedEmail, signInResult.payload);
-        }
-
-        if (signInResult.response.status !== 403) {
-          setAuthError(getErrorMessage(signInResult.payload, `Authentication failed with ${signInResult.response.status}.`));
-          trackPosthogEvent("den_auth_failed", {
-            mode: authMode,
-            method: "email",
-            status: signInResult.response.status
-          });
-          return null;
-        }
-
-        if (isSingleOrgMode) {
-          setAuthError(getErrorMessage(signInResult.payload, "Account created, but the server did not start a session. Try signing in again."));
-          return null;
-        }
-
         setUser(null);
         openVerificationStep(trimmedEmail, `We emailed a 6-digit verification code to ${trimmedEmail}. Enter it below to finish creating your account.`);
         appendEvent("info", "Verification code sent", trimmedEmail);


### PR DESCRIPTION
## Summary
- enable Better Auth auto sign-in so verification-disabled signups receive a session directly
- remove Den Web’s redundant post-signup sign-in request
- preserve `sendOnSignIn` so unverified users still receive a fresh code when they explicitly sign in

## Root cause
With verification enabled, signup sent the first OTP. Den Web then immediately called sign-in because signup returned no token; Better Auth sent and rotated a second OTP, invalidating the first.

## Validation
- `pnpm --filter @openwork-ee/den-web typecheck`
- `pnpm --filter @openwork-ee/den-web test` — 23 passed
- `pnpm --filter @openwork-ee/den-api build`
- Local verification-required API flow: signup returned 200/no token, exactly one verification email was recorded, and its first OTP verified successfully
- Local explicit unverified sign-in flow: sign-in returned 403 and sent a fresh second OTP, confirming `sendOnSignIn` remains active
- Local verification-disabled flow: signup returned 200 with a token and sent no verification email

## Proof
No fraimz/video attached; validation was performed against the real local Den API and dev email outbox.