### PR TITLE
feat(helm): pass Node options to den-api

### DIFF
--- a/evals/flows/helm-den-api-node-options.flow.mjs
+++ b/evals/flows/helm-den-api-node-options.flow.mjs
@@ -1,0 +1,76 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "helm-den-api-node-options";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CHART = join(ROOT, "packaging", "helm", "openwork-ee");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, assertion);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Helm passes configured Node.js options to Den API startup",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Render configured Den API Node.js options",
+      run: async (ctx) => {
+        let rendered = "";
+        await ctx.prove("Configured Den API Node.js flags reach the Node process at startup", {
+          voiceover: vo[0],
+          action: async () => {
+            const result = spawnSync(
+              "helm",
+              [
+                "template",
+                "openwork-ee",
+                CHART,
+                "--set-string",
+                "config.denApiNodeOptions=--use-openssl-ca --max-old-space-size=4096",
+              ],
+              { encoding: "utf8" },
+            );
+            witness(ctx, result.status === 0, "helm template exits successfully", result.stderr.trim());
+            rendered = result.stdout;
+          },
+          assert: async () => {
+            witness(
+              ctx,
+              rendered.includes('DEN_API_NODE_OPTIONS: "--use-openssl-ca --max-old-space-size=4096"'),
+              "The ConfigMap contains DEN_API_NODE_OPTIONS",
+            );
+            witness(
+              ctx,
+              (rendered.match(/name: NODE_OPTIONS/g) ?? []).length === 1,
+              "Only Den API receives NODE_OPTIONS",
+            );
+            witness(
+              ctx,
+              rendered.includes("key: DEN_API_NODE_OPTIONS"),
+              "NODE_OPTIONS reads DEN_API_NODE_OPTIONS from the ConfigMap",
+            );
+            ctx.output(
+              "$ helm template openwork-ee ... --set-string config.denApiNodeOptions=...",
+              rendered
+                .split("\n")
+                .filter((line) => line.includes("DEN_API_NODE_OPTIONS") || line.includes("NODE_OPTIONS"))
+                .join("\n"),
+            );
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/helm-den-api-node-options.md
+++ b/evals/voiceovers/helm-den-api-node-options.md
@@ -1,0 +1,3 @@
+# helm-den-api-node-options — Configure Den API Node.js startup flags
+
+1. An operator sets Den API Node.js flags in the Helm values. The rendered ConfigMap keeps them as DEN_API_NODE_OPTIONS, and the Den API deployment passes that value to Node as NODE_OPTIONS when the container starts.

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -28,6 +28,21 @@ helm upgrade --install openwork-ee oci://ghcr.io/different-ai/charts/openwork-ee
 
 The chart pulls the matching GHCR images for `openwork-den-api`, `openwork-den-web`, and optional `openwork-inference`.
 
+### Configure Den API Node.js options
+
+Use `config.denApiNodeOptions` when `den-api` needs Node.js startup flags, such
+as using the OpenSSL CA store or increasing the old-space heap limit:
+
+```yaml
+config:
+  denApiNodeOptions: "--use-openssl-ca --max-old-space-size=4096"
+```
+
+The chart stores this value in its ConfigMap as `DEN_API_NODE_OPTIONS` and
+passes it to the `den-api` container as `NODE_OPTIONS` before Node starts. It
+does not change the Node.js options for Den web or the optional inference
+service. Leaving the value empty preserves the default Node.js behavior.
+
 If you want self-hosted repository imports and sync from GitHub, configure the [GitHub connector for Helm](/start-here/github-connector-helm) after the core Den web and Den controller hosts are reachable.
 
 To keep organization names, wordmarks, and desktop icons entirely inside your deployment, follow [Brand an on-prem deployment](/start-here/on-prem-branding).

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -512,6 +512,17 @@ By default, the chart wires internal services through Kubernetes DNS:
 
 Override `config.internal.*` only when routing through a mesh, gateway, or external service.
 
+## Den API Node Options
+
+Set `config.denApiNodeOptions` to pass Node.js runtime flags to `den-api` through
+`NODE_OPTIONS` when the container starts. The configured value is stored in the
+chart ConfigMap as `DEN_API_NODE_OPTIONS` and defaults to an empty string.
+
+```yaml
+config:
+  denApiNodeOptions: "--use-openssl-ca --max-old-space-size=4096"
+```
+
 ## Service Exposure
 
 Each service supports Kubernetes Service metadata and load balancer settings:

--- a/packaging/helm/openwork-ee/templates/configmap.yaml
+++ b/packaging/helm/openwork-ee/templates/configmap.yaml
@@ -9,6 +9,7 @@ data:
   NODE_ENV: "production"
   OPENWORK_DEV_MODE: {{ .Values.config.openworkDevMode | quote }}
   DEN_ENABLE_ENTERPRISE_MCP_CLIENT: {{ .Values.config.enterpriseMcpClientEnabled | quote }}
+  DEN_API_NODE_OPTIONS: {{ .Values.config.denApiNodeOptions | quote }}
   DB_MODE: {{ .Values.config.databaseMode | quote }}
   DEN_ORG_MODE: {{ .Values.config.tenancy.mode | quote }}
   DEN_SINGLE_ORG_NAME: {{ .Values.config.tenancy.singleOrgName | quote }}

--- a/packaging/helm/openwork-ee/templates/den-api.yaml
+++ b/packaging/helm/openwork-ee/templates/den-api.yaml
@@ -92,6 +92,11 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.denApi.containerPort | quote }}
+            - name: NODE_OPTIONS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "openwork-ee.configName" . }}
+                  key: DEN_API_NODE_OPTIONS
             {{- if .Values.installerArtifacts.enabled }}
             - name: OPENWORK_INSTALLER_ARTIFACTS_DIR
               value: {{ .Values.installerArtifacts.mountPath | quote }}

--- a/packaging/helm/openwork-ee/tests/observability-env.sh
+++ b/packaging/helm/openwork-ee/tests/observability-env.sh
@@ -46,6 +46,9 @@ assert_file_not_contains() {
 
 default_rendered="$tmp_dir/default.yaml"
 helm template openwork-ee "$chart_dir" --set inference.enabled=true > "$default_rendered"
+assert_contains "$default_rendered" 'DEN_API_NODE_OPTIONS: ""'
+assert_count "$default_rendered" 'name: NODE_OPTIONS' 1
+assert_contains "$default_rendered" 'key: DEN_API_NODE_OPTIONS'
 assert_count "$default_rendered" 'name: DEN_OBSERVABILITY_BACKEND' 2
 assert_count "$default_rendered" 'value: "none"' 2
 assert_not_contains "$default_rendered" 'name: OTEL_EXPORTER_OTLP_HEADERS'
@@ -56,6 +59,8 @@ otel_rendered="$tmp_dir/otel.yaml"
 cat > "$otel_values" <<'YAML'
 inference:
   enabled: true
+config:
+  denApiNodeOptions: --use-openssl-ca --max-old-space-size=4096
 observability:
   backend: otel
   otel:
@@ -77,6 +82,7 @@ denWeb:
     CUSTOM_DEN_WEB_ENV: web
 YAML
 helm template openwork-ee "$chart_dir" -f "$otel_values" > "$otel_rendered"
+assert_contains "$otel_rendered" 'DEN_API_NODE_OPTIONS: "--use-openssl-ca --max-old-space-size=4096"'
 assert_count "$otel_rendered" 'name: DEN_OBSERVABILITY_BACKEND' 2
 assert_count "$otel_rendered" 'value: "otel"' 2
 assert_count "$otel_rendered" 'name: OTEL_EXPORTER_OTLP_HEADERS' 2

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -11,6 +11,7 @@ config:
   databaseMode: mysql
   openworkDevMode: "0"
   enterpriseMcpClientEnabled: "false"
+  denApiNodeOptions: ""
   tenancy:
     mode: single_org
     singleOrgName: OpenWork

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -11,6 +11,7 @@ config:
   databaseMode: mysql
   openworkDevMode: "0"
   enterpriseMcpClientEnabled: "false"
+  # Passed to the den-api Node.js process as NODE_OPTIONS at container startup.
   denApiNodeOptions: ""
   tenancy:
     mode: single_org


### PR DESCRIPTION
## Summary
- add `config.denApiNodeOptions` and render it as `DEN_API_NODE_OPTIONS`
- pass the ConfigMap value to the den-api container as `NODE_OPTIONS` at startup
- document and test the Helm configuration with internal fraimz proof

## Tests
- `helm lint packaging/helm/openwork-ee`
- `bash packaging/helm/openwork-ee/tests/observability-env.sh`
- `git diff --check`
- `pnpm fraimz --flow helm-den-api-node-options` (Passed)