### PR TITLE
docs: establish Connect-first service onboarding

### DIFF
--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
@@ -27,6 +27,11 @@ describe("OpenWork capabilities knowledge plugin", () => {
     expect(knowledge).toContain("JWTs signed and validated with EdDSA");
     expect(knowledge).toContain("30-day inactivity window");
     expect(knowledge).toContain("reference_id");
+    expect(knowledge).toContain("require the user to sign in to OpenWork first");
+    expect(knowledge).toContain("openwork-cloud_search_capabilities");
+    expect(knowledge).toContain("openwork-cloud_execute_capability");
+    expect(knowledge).toContain("Settings > Connect");
+    expect(knowledge).toContain("custom or local MCP server");
     expect(knowledge).not.toContain("Access tokens are opaque");
     expect(knowledge).not.toContain("https://api.openworklabs.com/mcp`");
     expect(knowledge).not.toContain("openwork-ui-mcp");

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
@@ -44,7 +44,7 @@ describe("OpenWork capabilities knowledge plugin", () => {
     const search = await plugin.tool.openwork_docs_search.execute({ query: "how can i connect slack", limit: 3 });
 
     expect(search).toContain("start-here/connect-your-stack/connect-slack-mcp.mdx");
-    expect(search).toContain("Connect Slack MCP");
+    expect(search).toContain("Connect Slack as a custom MCP");
 
     const read = await plugin.tool.openwork_docs_read.execute({
       path: "start-here/connect-your-stack/connect-slack-mcp.mdx",
@@ -54,6 +54,24 @@ describe("OpenWork capabilities knowledge plugin", () => {
     expect(read).toContain("Advanced OAuth");
     expect(read).toContain("http://127.0.0.1:19876/mcp/oauth/callback");
     expect(read).toContain("search:read.public");
+  });
+
+  test("retrieves the Connect-first member flow from bundled docs", async () => {
+    process.env.OPENWORK_DOCS_DIR = resolve(import.meta.dir, "../../../../packages/docs");
+
+    const plugin = await OpenWorkCapabilitiesKnowledge();
+    const search = await plugin.tool.openwork_docs_search.execute({ query: "connect gmail calendar slack", limit: 3 });
+
+    expect(search).toContain("start-here/connect-your-stack/connect-services.mdx");
+
+    const read = await plugin.tool.openwork_docs_read.execute({
+      path: "start-here/connect-your-stack/connect-services.mdx",
+    });
+
+    expect(read).toContain("Settings` > `Connect");
+    expect(read).toContain("Needs your sign-in");
+    expect(read).toContain("Ready to use");
+    expect(read).toContain("advanced path for a custom or local server");
   });
 
   test("reads current Cloud MCP endpoint and proxy guidance from bundled docs", async () => {

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -29,7 +29,7 @@ Important docs to know:
 - Shared workspaces: packages/docs/cloud/run-in-the-cloud/shared-workspace.mdx
 - Team templates: packages/docs/cloud/share-with-your-team/team-templates.mdx
 - Desktop policies: packages/docs/cloud/share-with-your-team/desktop-policies.mdx
-- Local MCP setup: packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
+- Custom/local MCP setup: packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
 - Cross-chat memory: packages/docs/start-here/do-work-with-it/cross-chat-memory.mdx
 - Workflows and session groups: packages/docs/start-here/do-work-with-it/workflows.mdx
 
@@ -55,10 +55,12 @@ Here is what you can help users with:
 - This requires macOS accessibility permissions; the app will prompt for them.
 - Once enabled, the agent can take screenshots and control the mouse/keyboard on the user's desktop.
 
-## Connecting MCP Extensions
-- Go to Settings > Extensions to add MCP servers.
-- Popular integrations: Google Workspace, GitHub, Slack, databases, file systems.
-- Users can browse the marketplace for pre-built extensions, or add custom MCPs by providing a command (e.g. \`npx -y @some/mcp-server\`) or URL.
+## Connecting services with OpenWork Connect
+- For Gmail, Google Calendar, Google Drive, Slack, Notion, Linear, and other managed integrations, require the user to sign in to OpenWork first. Direct them to the desktop app's \`Sign in\` button if they are not signed in.
+- Once signed in, use OpenWork Connect as the default path. First call \`openwork-cloud_search_capabilities\` with 2–4 relevant query variants; then call \`openwork-cloud_execute_capability\` using the exact capability name returned by search. Do not claim a service is unavailable before searching.
+- If search returns a \`connection_status\` result, relay its action exactly: members use \`Settings > Connect\`; organization admins use the Connections dashboard; provider-side failures go to the provider's admin console. After the user fixes the connection, search again in the same task.
+- Never recommend adding a Google Workspace, Gmail, Calendar, Drive, Slack, Notion, or Linear MCP in \`Settings > Extensions\` as the normal setup path. Use \`Settings > Connect\` for a member's managed connection instead.
+- \`Settings > Extensions\` and custom MCP commands/URLs are for a custom or local MCP server that is not available through OpenWork Connect.
 - OpenWork Connect's public hosted endpoint is \`https://api.openworklabs.com/mcp/agent\`. \`app.openworklabs.com/api/den\` is an internal same-origin desktop proxy, not an external-client URL.
 - OpenCode is verified with native remote MCP OAuth. Codex is setup-only until native proof is rerun on this exact branch, but its add/login/reconnect commands remain: \`codex mcp add openwork --url https://api.openworklabs.com/mcp/agent\`, \`codex mcp login openwork\`, and \`codex mcp logout openwork\` then \`codex mcp login openwork\`. Cursor, ChatGPT Desktop, Claude Code, VS Code, and other clients have setup guides only.
 - Cursor setup is only for Cursor Web/Agents with HTTPS OAuth callbacks. Cursor Desktop OAuth uses \`cursor://anysphere.cursor-mcp/oauth/callback\`, which OpenWork's MCP profile intentionally rejects, so Cursor Desktop OAuth is not currently supported. For ChatGPT, use ChatGPT Settings > MCP servers.

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -25,6 +25,7 @@ For OpenWork product questions, use openwork_docs_search and openwork_docs_read 
 
 Important docs to know:
 - General docs navigation: packages/docs/docs.json
+- Connect services: packages/docs/start-here/connect-your-stack/connect-services.mdx
 - Cloud MCP: packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
 - Shared workspaces: packages/docs/cloud/run-in-the-cloud/shared-workspace.mdx
 - Team templates: packages/docs/cloud/share-with-your-team/team-templates.mdx
@@ -61,6 +62,8 @@ Here is what you can help users with:
 - If search returns a \`connection_status\` result, relay its action exactly: members use \`Settings > Connect\`; organization admins use the Connections dashboard; provider-side failures go to the provider's admin console. After the user fixes the connection, search again in the same task.
 - Never recommend adding a Google Workspace, Gmail, Calendar, Drive, Slack, Notion, or Linear MCP in \`Settings > Extensions\` as the normal setup path. Use \`Settings > Connect\` for a member's managed connection instead.
 - \`Settings > Extensions\` and custom MCP commands/URLs are for a custom or local MCP server that is not available through OpenWork Connect.
+
+## Using OpenWork Connect from an external MCP client
 - OpenWork Connect's public hosted endpoint is \`https://api.openworklabs.com/mcp/agent\`. \`app.openworklabs.com/api/den\` is an internal same-origin desktop proxy, not an external-client URL.
 - OpenCode is verified with native remote MCP OAuth. Codex is setup-only until native proof is rerun on this exact branch, but its add/login/reconnect commands remain: \`codex mcp add openwork --url https://api.openworklabs.com/mcp/agent\`, \`codex mcp login openwork\`, and \`codex mcp logout openwork\` then \`codex mcp login openwork\`. Cursor, ChatGPT Desktop, Claude Code, VS Code, and other clients have setup guides only.
 - Cursor setup is only for Cursor Web/Agents with HTTPS OAuth callbacks. Cursor Desktop OAuth uses \`cursor://anysphere.cursor-mcp/oauth/callback\`, which OpenWork's MCP profile intentionally rejects, so Cursor Desktop OAuth is not currently supported. For ChatGPT, use ChatGPT Settings > MCP servers.

--- a/packages/docs/cloud/get-started.mdx
+++ b/packages/docs/cloud/get-started.mdx
@@ -64,6 +64,8 @@ After sign-in, pick your org in `Settings -> Cloud -> Active org`.
 
 ## What to do next
 
+- Send members to [Connect your services](/start-here/connect-your-stack/connect-services) to sign in to team-approved accounts from the desktop app.
+- Use [MCP Connections](/cloud/share-with-your-team/shared-mcp-connections) to publish a managed service and grant member or team access.
 - Use marketplace plugins to publish grouped skills and MCPs for teams, or save a single skill directly from the desktop app and install it from `Skills -> Cloud`.
 - Use [Shared workspaces](/cloud/run-in-the-cloud/shared-workspace) to deploy hosted OpenWork runtimes that teammates can open from the desktop app.
 - Use [LLM providers](/cloud/share-with-your-team/managed-llm-provider) or [custom LLM providers](/cloud/share-with-your-team/custom-llm-provider) to manage shared model access.

--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -11,6 +11,11 @@ OpenWork Connect lets an external MCP client use the OpenWork capabilities your 
 https://api.openworklabs.com/mcp/agent
 ```
 
+This guide is for connecting an external MCP client to OpenWork. To connect
+Gmail, calendar, Drive, Slack, Notion, Linear, or another service inside the
+OpenWork desktop app, use
+[Connect your services](/start-here/connect-your-stack/connect-services).
+
 Your client opens a browser, you sign in to OpenWork, choose the organization to authorize, and the client stores the OAuth token for that organization.
 
 `app.openworklabs.com/api/den` is an internal same-origin desktop proxy used by OpenWork first-party flows. Do not paste it into external MCP clients.
@@ -19,7 +24,10 @@ Your client opens a browser, you sign in to OpenWork, choose the organization to
 
 ## In the OpenWork desktop app
 
-If you use the OpenWork desktop app, there is nothing to configure. When you sign in, the app injects OpenWork Connect with access scoped to your active organization and refreshes that first-party access automatically.
+If you use the OpenWork desktop app, there is no MCP endpoint to configure.
+When you sign in, the app injects OpenWork Connect with access scoped to your
+active organization and refreshes that first-party access automatically. Use
+`Settings` > `Connect` to sign in to the services available to you.
 
 ## Client support status
 

--- a/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
+++ b/packages/docs/cloud/share-with-your-team/shared-mcp-connections.mdx
@@ -50,35 +50,29 @@ Slack's MCP server requires a pre-registered Slack OAuth app.
    then add it to the Slack app's `OAuth & Permissions` redirect URLs.
 4. Members open `Your Connections` and connect their own Slack account.
 
-For the local desktop-only setup, see
-[Connect Slack MCP](/start-here/connect-your-stack/connect-slack-mcp).
+For the advanced local desktop-only setup, see
+[Connect Slack as a custom MCP](/start-here/connect-your-stack/connect-slack-mcp).
 
 ## What members see in the desktop app
 
-Granted members find the connection in `Settings -> Extensions`, in the same
-catalog as everything else the org shares:
+Granted members find the connection in `Settings` > `Connect`, grouped by what
+they need to do:
 
-- **Marketplace tab** — connections you can use but haven't connected yet,
-  with a `Connect your account` action.
-- **My Extensions tab** — connections that are ready: ones you've connected,
-  and One org account connections your admin manages.
-
-<Frame>
-  ![An org-shared connection in the Marketplace tab, ready to connect](/images/desktop-org-mcp-marketplace.png)
-</Frame>
+- **Needs your sign-in** — individual-account connections that require the
+  member to authenticate or reconnect.
+- **Needs admin setup** — connections that an organization admin still needs
+  to configure or authenticate.
+- **Ready to use** — connections ready for the agent, including accounts
+  managed by the organization.
 
 ## Connect your account
 
-1. Open `Settings -> Extensions -> Marketplace`.
-2. Click the connection card, then `Connect your account`.
+1. Sign in to OpenWork, then open `Settings` > `Connect`.
+2. Find the service under `Needs your sign-in`, then click `Connect`.
 3. Your browser opens the provider's own sign-in page. Approve access.
 4. The browser shows `Connected` — return to OpenWork.
-5. The card updates by itself, no reload needed, and moves to
-   `My Extensions`.
-
-<Frame>
-  ![The same card flipped to Connected after the browser sign-in](/images/desktop-org-mcp-connected.png)
-</Frame>
+5. The connection updates by itself, no reload needed, and moves to
+   `Ready to use`.
 
 Your sign-in is stored in OpenWork Cloud, not on this machine — connect once
 and every device you use is connected.
@@ -89,16 +83,16 @@ No restart, no resync. Ask for something the tool can do:
 
 > Find the "Q3 launch" page in Notion and summarize it.
 
-The agent discovers the org's tools through the `OpenWork Cloud Control`
-connection, and executes them with **your** account — your permissions,
-your audit trail on the provider's side.
+The agent searches the live capabilities available through OpenWork Connect,
+then executes an exact match with **your** account — your permissions, your
+audit trail on the provider's side.
 
 <Frame>
   ![The agent executing an org-shared MCP tool in chat](/images/desktop-org-mcp-chat.png)
 </Frame>
 
-If the agent finds a tool you haven't connected yet, it tells you in the
-chat with a `Connect` button — you never have to go hunting in settings.
+If a connection needs attention, the agent should tell you which account needs
+action and direct you to `Settings` > `Connect`.
 
 ## Notes for admins
 
@@ -113,7 +107,7 @@ chat with a `Connect` button — you never have to go hunting in settings.
 
 ## Relationship to local MCP servers
 
-Everything in [Add an MCP server](/start-here/connect-your-stack/add-an-mcp-server)
-still works, with or without a cloud account. Local servers (like OpenWork
-Browser and UI Control) always run on your machine. Org connections are for
-the things a team shares.
+[Add a custom MCP server](/start-here/connect-your-stack/add-an-mcp-server)
+still works without a cloud account. Use that advanced path for local tools or
+servers your organization does not provide. Use Connect for accounts and
+services managed through OpenWork Cloud.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -27,6 +27,7 @@
               "start-here/connect-your-stack/sign-in-with-chatgpt",
               "start-here/connect-your-stack/add-anthropic-api-key",
               "start-here/connect-your-stack/add-a-custom-llm",
+              "start-here/connect-your-stack/connect-services",
               "start-here/connect-your-stack/add-an-mcp-server",
               "start-here/connect-your-stack/connect-slack-mcp",
               "start-here/connect-your-stack/enable-exa-search"

--- a/packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
+++ b/packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
@@ -3,7 +3,11 @@ title: "Add an MCP server"
 description: "How to connect a custom MCP server with openwork"
 ---
 
-Connecting a custom MCP server with openwork takes four clicks.
+Use this guide only when you need a custom or local MCP server that is not available through OpenWork Connect.
+
+For Gmail, Google Calendar, Google Drive, Slack, Notion, Linear, and other managed services, sign in to OpenWork first and use `Settings` > `Connect`. OpenWork Connect discovers the capabilities available to your account, so your agent can search the live catalog before it tries to use a service.
+
+Connecting a custom MCP server with OpenWork takes four clicks.
 
 - Inside your workspace, click in `Extensions` \> `Advanced Settings` \> `Add MCP server`
 

--- a/packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
+++ b/packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
@@ -1,11 +1,12 @@
 ---
-title: "Add an MCP server"
-description: "How to connect a custom MCP server with openwork"
+title: "Add a custom MCP server"
+description: "Connect a custom or local MCP server that is not available through OpenWork Connect"
 ---
 
 Use this guide only when you need a custom or local MCP server that is not available through OpenWork Connect.
 
-For Gmail, Google Calendar, Google Drive, Slack, Notion, Linear, and other managed services, sign in to OpenWork first and use `Settings` > `Connect`. OpenWork Connect discovers the capabilities available to your account, so your agent can search the live catalog before it tries to use a service.
+For Gmail, Google Calendar, Google Drive, Slack, Notion, Linear, and other
+managed services, follow [Connect your services](/start-here/connect-your-stack/connect-services).
 
 Connecting a custom MCP server with OpenWork takes four clicks.
 
@@ -15,27 +16,30 @@ Connecting a custom MCP server with OpenWork takes four clicks.
   ![Extensions page with Advanced Settings link](/images/mcp-extensions-advanced-settings.png)
 </Frame>
 
-You can choose to add the MCP server in this workspace or for all workspaces (global Ow config)
+You can add the MCP server to this workspace or to your global OpenCode configuration for all workspaces.
 
 <Frame>
   ![Add MCP Server dialog with name, URL, and OAuth toggle](/images/mcp-add-server-dialog.png)
 
-  You should indicate wether it requires OAuth or not.
+  Indicate whether the server requires OAuth.
 </Frame>
 
-This setup is aimed at servers that allow for dynamic user registration (eg: OAuth based MCPs)
+This setup is intended for servers that support dynamic OAuth client registration.
 
 <Frame>
   ![OAuth approval page for MCP server](/images/mcp-oauth-approval-page.png)
 </Frame>
 
-Once in their Oath page, you should just continue with the registration or custom setup. It should redirect back to openwork. Feel free to [open an issue](https://github.com/different-ai/openwork/issues/) if you require a custom MCP that we currently do not support.
+Complete the provider's OAuth approval flow in your browser. It should redirect
+back to OpenWork. If a custom MCP needs behavior OpenWork does not support,
+[open an issue](https://github.com/different-ai/openwork/issues/).
 
 ### Troubleshooting
 
 Some MCP servers do not support dynamic client registration. If the server gives you a pre-registered OAuth client ID and client secret, add it through `Add Custom App` > `Advanced OAuth`.
 
-For Slack, follow [Connect Slack MCP](/start-here/connect-your-stack/connect-slack-mcp).
+For an advanced local Slack setup, follow
+[Connect Slack as a custom MCP](/start-here/connect-your-stack/connect-slack-mcp).
 
 <Frame>
   ![Error when MCP server does not support dynamic client registration](/images/mcp-dynamic-registration-error.png)

--- a/packages/docs/start-here/connect-your-stack/connect-services.mdx
+++ b/packages/docs/start-here/connect-your-stack/connect-services.mdx
@@ -1,0 +1,64 @@
+---
+title: "Connect your services"
+description: "Sign in to OpenWork and connect the accounts your agent can use"
+---
+
+Use `Settings` > `Connect` for services your organization makes available,
+including Gmail, Google Calendar, Google Drive, Slack, Notion, and Linear. This
+is the recommended setup for everyday integrations.
+
+## Before you start
+
+Connect requires signing in to an OpenWork account and joining an organization
+that has Connect enabled. This is separate from signing in to an LLM provider
+such as ChatGPT.
+
+1. Open the OpenWork desktop app.
+2. Click `Sign in`, or open `Settings` > `Connect` and choose `Sign in`.
+3. Complete sign-in in your browser and return to OpenWork.
+4. Choose the OpenWork organization you want to use if prompted.
+
+If Connect is not available for your organization, ask an organization admin
+to enable it.
+
+## Connect an account
+
+1. Open `Settings` > `Connect`.
+2. Find the service under `Needs your sign-in`.
+3. Click `Connect` and approve access on the provider's sign-in page.
+4. Return to OpenWork. The service moves to `Ready to use` automatically.
+
+Some connections are managed by your organization. If a service is not
+listed, ask an organization admin to publish it from the OpenWork Cloud
+`Connections` dashboard and grant you access.
+
+## Ask your agent to use it
+
+You do not need to know an MCP server name or tool name. Ask for the outcome
+you want, for example:
+
+- “Summarize my five newest emails.”
+- “Find the Q3 launch page in Notion.”
+- “What meetings do I have tomorrow?”
+
+The agent searches the live capabilities available to your signed-in account,
+then executes an exact match. If an account still needs attention, it should
+send you back to `Settings` > `Connect` with the action to take instead of
+telling you to add an MCP server.
+
+## Connect, Connections, and MCP servers
+
+- **Connect** is the member-facing page in the desktop app for signing in to
+  services and checking connection readiness.
+- **Connections** is the organization-admin dashboard in OpenWork Cloud for
+  publishing a service, choosing whose account it uses, and granting member or
+  team access.
+- **OpenWork Connect MCP** is the hosted endpoint that lets external MCP
+  clients use capabilities from an OpenWork organization.
+- **Add an MCP server** is the advanced path for a custom or local server that
+  your organization does not provide through Connect.
+
+If you are building a custom integration, continue with
+[Add an MCP server](/start-here/connect-your-stack/add-an-mcp-server). If you
+are an organization admin, see
+[Sharing MCP connections with your team](/cloud/share-with-your-team/shared-mcp-connections).

--- a/packages/docs/start-here/connect-your-stack/connect-slack-mcp.mdx
+++ b/packages/docs/start-here/connect-your-stack/connect-slack-mcp.mdx
@@ -1,9 +1,13 @@
 ---
-title: "Connect Slack MCP"
-description: "Connect Slack's MCP server with a pre-registered Slack OAuth app"
+title: "Connect Slack as a custom MCP"
+description: "Advanced local setup for Slack's MCP server with a pre-registered OAuth app"
 ---
 
-Slack's official MCP server does not support automatic OAuth client registration. To connect it in OpenWork, ask a Slack admin to create or approve a Slack app for MCP, then add the app's OAuth client credentials in OpenWork.
+This is the advanced local setup. For the recommended member experience,
+sign in to OpenWork and start with
+[Connect your services](/start-here/connect-your-stack/connect-services).
+
+Slack's official MCP server does not support automatic OAuth client registration. To connect it as a custom local MCP in OpenWork, ask a Slack admin to create or approve a Slack app for MCP, then add the app's OAuth client credentials in OpenWork.
 
 You do not need the old Slack bot tokens (`xoxb-...` or `xapp-...`) for this flow.
 

--- a/packages/docs/start-here/get-started.mdx
+++ b/packages/docs/start-here/get-started.mdx
@@ -13,7 +13,7 @@ Get started by connecting your LLM provider of choice and sending your first mes
   <Card title="Connect a provider" icon="plug" href="/start-here/connect-your-stack/sign-in-with-chatgpt">
     Sign in with ChatGPT or bring your own LLM key in a few clicks.
   </Card>
-  <Card title="Sign in to Connect" icon="plug" href="/cloud/get-started">
+  <Card title="Connect your services" icon="plug" href="/start-here/connect-your-stack/connect-services">
     Sign in to OpenWork, then connect Gmail, calendar, Drive, Slack, and other managed services in Connect.
   </Card>
   <Card title="Control the browser" icon="globe" href="/start-here/do-work-with-it/control-the-browser">

--- a/packages/docs/start-here/get-started.mdx
+++ b/packages/docs/start-here/get-started.mdx
@@ -13,8 +13,8 @@ Get started by connecting your LLM provider of choice and sending your first mes
   <Card title="Connect a provider" icon="plug" href="/start-here/connect-your-stack/sign-in-with-chatgpt">
     Sign in with ChatGPT or bring your own LLM key in a few clicks.
   </Card>
-  <Card title="Add an MCP" icon="puzzle-piece" href="/start-here/connect-your-stack/add-an-mcp-server">
-    Plug custom MCP servers into your workspace in minutes.
+  <Card title="Sign in to Connect" icon="plug" href="/cloud/get-started">
+    Sign in to OpenWork, then connect Gmail, calendar, Drive, Slack, and other managed services in Connect.
   </Card>
   <Card title="Control the browser" icon="globe" href="/start-here/do-work-with-it/control-the-browser">
     Let OpenWork run and screenshot tasks in Chrome for you.
@@ -25,7 +25,7 @@ Get started by connecting your LLM provider of choice and sending your first mes
 
 <CardGroup cols={3}>
   <Card title="Download OpenWork" icon="download" href="https://openworklabs.com/download">
-    Start with the desktop app, connect providers, add MCP servers, and run tasks right away.
+    Start with the desktop app, sign in, connect providers and managed services, and run tasks right away.
   </Card>
   <Card title="OpenWork Cloud" icon="users" href="/cloud/get-started">
     Meant for teams: Shared workspaces, org marketplaces, hosted workers, and managed LLM providers.


### PR DESCRIPTION
## What changed

- Add a first-class Connect your services member guide and make it the getting-started default.
- Define Connect (desktop), Connections (organization admin), OpenWork Connect MCP (external clients), and custom MCP setup.
- Require OpenWork sign-in and live capability search before agents claim managed services are unavailable.
- Update team connection docs to the current Settings > Connect groups and remove the stale Marketplace and My Extensions flow.
- Mark direct MCP and Slack setup as advanced custom or local paths.

## Why

The old guidance conflated managed connections, the hosted meta-MCP, and direct MCP setup. That could send Gmail or Slack users to Extensions, or send everyday members to an admin-only Cloud page.

## Validation

- Focused OpenWork capabilities knowledge tests: 4 passed
- OpenWork server TypeScript check
- Docs navigation JSON parse
- Git diff whitespace check