### PR TITLE
fix(app): open command palette from settings

### DIFF
--- a/apps/app/src/react-app/shell/command-palette-sessions.ts
+++ b/apps/app/src/react-app/shell/command-palette-sessions.ts
@@ -1,0 +1,42 @@
+import { getDisplaySessionTitle } from "@/app/lib/session-title";
+import { t } from "@/i18n";
+
+import type { SessionOption } from "./command-palette";
+import type { RouteSession, RouteWorkspace } from "./route-workspaces";
+
+export function buildCommandPaletteSessions(
+  workspaces: RouteWorkspace[],
+  sessionsByWorkspaceId: Record<string, RouteSession[]>,
+  selectedWorkspaceId: string,
+) {
+  const options: SessionOption[] = [];
+
+  for (const workspace of workspaces) {
+    const workspaceTitle =
+      workspace.displayName?.trim() ||
+      workspace.name?.trim() ||
+      workspace.path?.trim() ||
+      t("session.workspace_fallback");
+
+    for (const session of sessionsByWorkspaceId[workspace.id] ?? []) {
+      const sessionId = session.id.trim();
+      if (!sessionId) continue;
+      const title = getDisplaySessionTitle(session.title ?? "");
+      const updatedAt = session.time.updated ?? session.time.created;
+      options.push({
+        workspaceId: workspace.id,
+        sessionId,
+        title,
+        workspaceTitle,
+        updatedAt,
+        searchText: `${title} ${workspaceTitle}`.toLowerCase(),
+        isActive: workspace.id === selectedWorkspaceId,
+      });
+    }
+  }
+
+  return options.sort((a, b) => {
+    if (a.isActive !== b.isActive) return a.isActive ? -1 : 1;
+    return b.updatedAt - a.updatedAt;
+  });
+}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -135,10 +135,10 @@ import {
 } from "@/react-app/domains/workspace/remote-workspace-diagnostics";
 import { useShareWorkspaceState } from "@/react-app/domains/workspace/share-workspace-state";
 import { ModelPickerModal, MODEL_PICKER_UNAVAILABLE_SUBTITLE } from "@/react-app/domains/session/modals/model-picker-modal";
-import { CommandPalette, type PaletteItem, type SessionGroupOption, type SessionOption as PaletteSessionOption } from "./command-palette";
+import { CommandPalette, type PaletteItem, type SessionGroupOption } from "./command-palette";
+import { buildCommandPaletteSessions } from "./command-palette-sessions";
 import { SessionSearchDialog } from "./session-search-dialog";
 import type { SessionMessageFetcher } from "@/react-app/domains/session/search/session-search";
-import { getDisplaySessionTitle } from "@/app/lib/session-title";
 import { useBootState } from "./boot-state";
 import {
   forgetWorkspaceMemory,
@@ -1515,44 +1515,10 @@ export function SessionRoute() {
   }), [checkDesktopRestriction, sessionProviderAuthStore]);
   useControlAction(addProviderControlAction);
 
-  const paletteSessionOptions = useMemo<PaletteSessionOption[]>(() => {
-    const out: PaletteSessionOption[] = [];
-    for (const workspace of workspaces) {
-      const workspaceTitle =
-        workspace.displayName?.trim() ||
-        workspace.name?.trim() ||
-        workspace.path?.trim() ||
-        t("session.workspace_fallback");
-      const list = sessionsByWorkspaceId[workspace.id] ?? [];
-      for (const session of list) {
-        const sessionId = (session as { id?: string }).id?.trim() ?? "";
-        if (!sessionId) continue;
-        const title = getDisplaySessionTitle(
-          (session as { title?: string }).title ?? "",
-        );
-        const updatedAt =
-          (session as { time?: { updated?: number; created?: number } }).time
-            ?.updated ??
-          (session as { time?: { updated?: number; created?: number } }).time
-            ?.created ??
-          0;
-        out.push({
-          workspaceId: workspace.id,
-          sessionId,
-          title,
-          workspaceTitle,
-          updatedAt,
-          searchText: `${title} ${workspaceTitle}`.toLowerCase(),
-          isActive: workspace.id === selectedWorkspaceId,
-        });
-      }
-    }
-    out.sort((a, b) => {
-      if (a.isActive !== b.isActive) return a.isActive ? -1 : 1;
-      return b.updatedAt - a.updatedAt;
-    });
-    return out;
-  }, [sessionsByWorkspaceId, selectedWorkspaceId, workspaces]);
+  const paletteSessionOptions = useMemo(
+    () => buildCommandPaletteSessions(workspaces, sessionsByWorkspaceId, selectedWorkspaceId),
+    [sessionsByWorkspaceId, selectedWorkspaceId, workspaces],
+  );
 
   // Refresh the non-tab fields of the nav ref during render. The `options`
   // field is maintained by the `onSessionTabsChange` callback from SessionPage.

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -5,7 +5,7 @@ import { toast } from "@/components/ui/sonner";
 
 import { SUGGESTED_PLUGINS } from "@/app/constants";
 import type { EnablementContext } from "@/app/enablement";
-import { createClient } from "@/app/lib/opencode";
+import { createClient, unwrap } from "@/app/lib/opencode";
 import {
   createOpenworkServerClient,
   isLoopbackOpenworkServerUrl,
@@ -153,6 +153,9 @@ import { resolveOpenworkConnection } from "./openwork-connection";
 import { abortSessionSafe } from "@/app/lib/opencode-session";
 import { notifyAlert } from "./notifications";
 import { useReloadCoordinator } from "./reload-coordinator";
+import { CommandPalette } from "./command-palette";
+import { buildCommandPaletteSessions } from "./command-palette-sessions";
+import { useCommandPaletteShortcut } from "./use-shell-shortcuts";
 import { buildFeedbackUrl } from "@/app/lib/feedback";
 import { getDenInferenceUrl } from "@/app/lib/den";
 import { readActiveWorkspaceId, writeActiveWorkspaceId } from "./session-memory";
@@ -831,6 +834,25 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     workspaceRoot: selectedWorkspaceRoot,
     onLoadError: handleModelPickerLoadError,
   });
+  const { commandPaletteOpen, setCommandPaletteOpen } = useCommandPaletteShortcut(!props.embedded);
+  const paletteSessionOptions = useMemo(
+    () => buildCommandPaletteSessions(workspaces, sessionsByWorkspaceId, selectedWorkspaceId),
+    [sessionsByWorkspaceId, selectedWorkspaceId, workspaces],
+  );
+  const handleCreatePaletteSession = useCallback(async () => {
+    if (!opencodeClient || !selectedWorkspaceId) {
+      navigate(selectedWorkspaceId ? workspaceSessionRoute(selectedWorkspaceId) : "/session");
+      return;
+    }
+    try {
+      const session = unwrap(
+        await opencodeClient.session.create({ directory: selectedWorkspaceRoot || undefined }),
+      );
+      navigate(workspaceSessionRoute(selectedWorkspaceId, session.id));
+    } catch (error) {
+      toast.error(describeRouteError(error));
+    }
+  }, [navigate, opencodeClient, selectedWorkspaceId, selectedWorkspaceRoot]);
   // Settings refreshes provider auth whenever the picker opens (the session
   // route does not need this; its provider state is kept fresh elsewhere).
   useEffect(() => {
@@ -2337,6 +2359,25 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       >
         {settingsView}
       </SettingsShell>
+
+      <CommandPalette
+        open={commandPaletteOpen}
+        onClose={() => setCommandPaletteOpen(false)}
+        onCreateNewSession={() => void handleCreatePaletteSession()}
+        onOpenSession={(workspaceId, sessionId) => {
+          navigate(workspaceSessionRoute(workspaceId, sessionId));
+        }}
+        onOpenSettings={(path = "/settings/general") => {
+          navigateSettingsPath(path.replace(/^\/settings\//, ""));
+        }}
+        onOpenModelPicker={() => {
+          modelPicker.setQuery("");
+          modelPicker.setRecentProviderIds(new Set());
+          window.requestAnimationFrame(() => modelPicker.setOpen(true));
+        }}
+        selectedModelLabel={defaultModelLabel}
+        sessions={paletteSessionOptions}
+      />
 
       <ProviderAuthModal
         open={providerAuthSnapshot.providerAuthModalOpen}

--- a/apps/app/src/react-app/shell/use-shell-shortcuts.ts
+++ b/apps/app/src/react-app/shell/use-shell-shortcuts.ts
@@ -11,9 +11,29 @@ export type UseShellShortcutsInput = {
   onPrevSessionTab?: () => void;
 };
 
+export function useCommandPaletteShortcut(enabled = true) {
+  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const handleCommandPaletteShortcut = useEffectEvent((event: KeyboardEvent) => {
+    if (!enabled) return;
+    const isMac = typeof navigator !== "undefined" && /Mac/i.test(navigator.platform);
+    const mod = isMac ? event.metaKey : event.ctrlKey;
+    if (!mod || event.shiftKey || event.altKey || event.key?.toLowerCase() !== "k") return;
+    event.preventDefault();
+    setCommandPaletteOpen((value) => !value);
+  });
+
+  useEffect(() => {
+    const handler = (event: KeyboardEvent) => handleCommandPaletteShortcut(event);
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
+  return { commandPaletteOpen, setCommandPaletteOpen };
+}
+
 export function useShellShortcuts(input: UseShellShortcutsInput) {
   const { canCreateTask, workspaceId, onCreateTask, onNextSessionTab, onPrevSessionTab } = input;
-  const [commandPaletteOpen, setCommandPaletteOpen] = useState(false);
+  const { commandPaletteOpen, setCommandPaletteOpen } = useCommandPaletteShortcut();
   const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
 
@@ -54,11 +74,6 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
       if (canCreateTask && workspaceId) {
         void onCreateTask(workspaceId);
       }
-      return;
-    }
-    if (key === "k") {
-      event.preventDefault();
-      setCommandPaletteOpen((value) => !value);
       return;
     }
     if (key === "j") {

--- a/evals/flows/command-k-settings.flow.mjs
+++ b/evals/flows/command-k-settings.flow.mjs
@@ -1,0 +1,117 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/command-k-settings.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("command-k-settings");
+
+async function pressCommandK(ctx) {
+  const isMac = await ctx.eval("/Mac/i.test(navigator.platform)");
+  const modifier = isMac
+    ? { key: "Meta", code: "MetaLeft", windowsVirtualKeyCode: 91, modifiers: 4 }
+    : { key: "Control", code: "ControlLeft", windowsVirtualKeyCode: 17, modifiers: 2 };
+  await ctx.client.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: modifier.key,
+    code: modifier.code,
+    windowsVirtualKeyCode: modifier.windowsVirtualKeyCode,
+    modifiers: modifier.modifiers,
+  });
+  await ctx.client.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "k",
+    code: "KeyK",
+    windowsVirtualKeyCode: 75,
+    modifiers: modifier.modifiers,
+  });
+  await ctx.client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "k",
+    code: "KeyK",
+    windowsVirtualKeyCode: 75,
+    modifiers: modifier.modifiers,
+  });
+  await ctx.client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: modifier.key,
+    code: modifier.code,
+    windowsVirtualKeyCode: modifier.windowsVirtualKeyCode,
+  });
+}
+
+async function pressEscape(ctx) {
+  await ctx.client.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+  });
+  await ctx.client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "Escape",
+    code: "Escape",
+    windowsVirtualKeyCode: 27,
+  });
+}
+
+export default {
+  id: "command-k-settings",
+  title: "Command K opens the command palette from Settings",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Open Settings",
+      run: async (ctx) => {
+        await ctx.prove("Settings is open and ready for keyboard navigation", {
+          voiceover: vo[0],
+          action: async () => {
+            await pressEscape(ctx);
+            await ctx.waitFor("Boolean(window.__openworkControl)", {
+              timeoutMs: 30_000,
+              label: "control API",
+            });
+            await ctx.control("route.settings.general");
+            await ctx.waitFor("location.pathname.endsWith('/settings/general')", {
+              timeoutMs: 30_000,
+              label: "settings route",
+            });
+          },
+          assert: async () => {
+            const pathname = await ctx.eval("location.pathname");
+            ctx.assert(pathname.endsWith("/settings/general"), `Expected settings pathname, got ${pathname}`);
+            await ctx.expectText("Settings");
+          },
+          screenshot: {
+            name: "settings-open",
+            requireText: ["Settings"],
+          },
+        });
+      },
+    },
+    {
+      name: "Open the command palette",
+      run: async (ctx) => {
+        await ctx.prove("Command K opens the usual command palette over Settings", {
+          voiceover: vo[1],
+          action: async () => {
+            await pressCommandK(ctx);
+            await ctx.waitFor("Boolean(document.querySelector('[data-slot=\"autocomplete-input\"]'))", {
+              timeoutMs: 15_000,
+              label: "command palette input",
+            });
+            await new Promise((resolve) => setTimeout(resolve, 300));
+          },
+          assert: async () => {
+            const pathname = await ctx.eval("location.pathname");
+            ctx.assert(pathname.endsWith("/settings/general"), `Command palette left Settings for ${pathname}`);
+            await ctx.expectText("Create new session");
+            await ctx.expectText("Search sessions");
+          },
+          screenshot: {
+            name: "command-palette-over-settings",
+            requireText: ["Create new session", "Search sessions"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/command-k-settings.md
+++ b/evals/voiceovers/command-k-settings.md
@@ -1,0 +1,5 @@
+# command-k-settings - Command K opens the palette from Settings
+
+1. I'm in Settings, where I can adjust OpenWork without interrupting my current task.
+
+2. I press Command K, and the command palette opens immediately over Settings with my usual actions and sessions ready.


### PR DESCRIPTION
## Summary
- make Command/Ctrl+K open the command palette on full-screen Settings routes
- keep embedded Settings from registering a duplicate shortcut
- share session option mapping between Session and Settings palettes

## Validation
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app test` (185 passed)
- `pnpm --filter @openwork/app build`
- `pnpm fraimz --flow command-k-settings --cdp-url http://127.0.0.1:9834` (Passed)