### PR TITLE
feat(den): expose live MCP tool catalogs

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -624,6 +624,13 @@ export async function saveExternalMcpPendingCodeVerifier(input: {
     .where(eq(ExternalMcpConnectionTable.id, input.connectionId))
 }
 
+export async function markExternalMcpConnectionConnected(connectionId: ExternalMcpConnectionId): Promise<void> {
+  await db
+    .update(ExternalMcpConnectionTable)
+    .set({ connectedAt: new Date() })
+    .where(eq(ExternalMcpConnectionTable.id, connectionId))
+}
+
 export async function clearExternalMcpTokens(input: {
   organizationId: OrganizationId
   connectionId: ExternalMcpConnectionId

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -29,6 +29,7 @@ import {
   abandonExternalMcpAuth,
   connectExternalMcp,
   completeExternalMcpAuth,
+  listExternalMcpTools,
 } from "../../capability-sources/external-mcp-client-runtime.js"
 import {
   createExternalMcpConnection,
@@ -38,6 +39,7 @@ import {
   listExternalMcpConnectionAccess,
   listExternalMcpConnections,
   listUsableExternalMcpConnections,
+  markExternalMcpConnectionConnected,
   memberCanUseExternalMcpConnection,
   replaceExternalMcpConnectionAccess,
   type ExternalMcpConnectionRow,
@@ -170,6 +172,32 @@ const connectionListResponseSchema = z.object({
   connections: z.array(connectionResponseSchema),
 }).meta({ ref: "ExternalMcpConnectionListResponse" })
 
+const connectionToolAnnotationsSchema = z.object({
+  title: z.string().optional(),
+  readOnlyHint: z.boolean().optional(),
+  destructiveHint: z.boolean().optional(),
+  idempotentHint: z.boolean().optional(),
+  openWorldHint: z.boolean().optional(),
+}).meta({ ref: "ExternalMcpConnectionToolAnnotations" })
+
+const connectionToolSchema = z.object({
+  name: z.string(),
+  title: z.string().optional(),
+  description: z.string().optional(),
+  inputSchema: z.record(z.string(), z.unknown()),
+  outputSchema: z.record(z.string(), z.unknown()).optional(),
+  annotations: connectionToolAnnotationsSchema.optional(),
+}).meta({ ref: "ExternalMcpConnectionTool" })
+
+const connectionToolListResponseSchema = z.object({
+  tools: z.array(connectionToolSchema),
+}).meta({ ref: "ExternalMcpConnectionToolListResponse" })
+
+const connectionNotReadySchema = z.object({
+  error: z.literal("connection_not_ready"),
+  message: z.string(),
+}).meta({ ref: "ExternalMcpConnectionNotReadyError" })
+
 const connectionCreatedResponseSchema = connectionResponseSchema.extend({
   links: z.object({
     /** Where members connect their own account for per_member connections. Share this with the team. */
@@ -243,6 +271,12 @@ const externalMcpDiagnosticSchema = z.object({
   providerRequestId: z.string().optional(),
   jsonRpcCode: z.number().int().optional(),
 }).meta({ ref: "ExternalMcpDiagnostic" })
+
+const connectionToolListFailedSchema = z.object({
+  error: z.literal("tool_catalog_failed"),
+  message: z.string(),
+  diagnostic: externalMcpDiagnosticSchema,
+}).meta({ ref: "ExternalMcpConnectionToolListFailedError" })
 
 const connectStartFailedSchema = z.object({
   error: z.literal("oauth_handshake_failed"),
@@ -577,6 +611,102 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
     },
   )
 
+  app.get(
+    "/v1/mcp-connections/:connectionId/tools",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "List tools exposed by an External MCP Connection",
+      description: "Admin-only. Uses the connection credential owned by Den to read its live MCP tools/list catalog. Credentials and tool calls are never returned.",
+      responses: {
+        200: jsonResponse("External MCP tool catalog.", connectionToolListResponseSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners and admins can inspect MCP tools.", forbiddenSchema),
+        404: jsonResponse("Unknown connection.", connectionNotFoundSchema),
+        409: jsonResponse("The connection has no usable credential for this member.", connectionNotReadySchema),
+        502: jsonResponse("The upstream MCP tool catalog could not be read.", connectionToolListFailedSchema),
+      },
+    }),
+    orgMemberRoute(),
+    paramValidator(connectionParamsSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const admin = ensureOrganizationAdminRole(c, "Only workspace owners and admins can inspect MCP tools.")
+      if (!admin.ok) return c.json(admin.response, orgAccessFailureStatus(admin.response))
+
+      const { connectionId } = c.req.valid("param")
+      const externalMcpConnectionId = normalizeDenTypeId("externalMcpConnection", connectionId)
+      const connection = await getExternalMcpConnection({
+        organizationId: payload.organization.id,
+        connectionId: externalMcpConnectionId,
+      })
+      if (!connection) {
+        return c.json({ error: "connection_not_found", message: "Unknown connection." }, 404)
+      }
+
+      const member = connection.credentialMode === "per_member"
+        ? { orgMembershipId: payload.currentMember.id }
+        : undefined
+      if (connection.credentialMode === "per_member") {
+        const account = await getConnectedAccount({
+          organizationId: payload.organization.id,
+          orgMembershipId: payload.currentMember.id,
+          providerId: connection.id,
+        })
+        if (!account?.accessToken) {
+          return c.json({
+            error: "connection_not_ready",
+            message: "Connect your account before inspecting this MCP's tools.",
+          }, 409)
+        }
+      } else if (!isConnectionConnected(connection)) {
+        return c.json({
+          error: "connection_not_ready",
+          message: "Connect this MCP before inspecting its tools.",
+        }, 409)
+      }
+
+      try {
+        const tools = await listExternalMcpTools(
+          connection,
+          callbackRedirectUri(c.req.raw, connectionId),
+          member,
+          c.get("requestId"),
+        )
+        return c.json({
+          tools: tools.map((tool) => ({
+            name: tool.name,
+            ...(tool.title ? { title: tool.title } : {}),
+            ...(tool.description ? { description: tool.description } : {}),
+            inputSchema: tool.inputSchema,
+            ...(tool.outputSchema ? { outputSchema: tool.outputSchema } : {}),
+            ...(tool.annotations ? {
+              annotations: {
+                ...(tool.annotations.title ? { title: tool.annotations.title } : {}),
+                ...(tool.annotations.readOnlyHint !== undefined ? { readOnlyHint: tool.annotations.readOnlyHint } : {}),
+                ...(tool.annotations.destructiveHint !== undefined ? { destructiveHint: tool.annotations.destructiveHint } : {}),
+                ...(tool.annotations.idempotentHint !== undefined ? { idempotentHint: tool.annotations.idempotentHint } : {}),
+                ...(tool.annotations.openWorldHint !== undefined ? { openWorldHint: tool.annotations.openWorldHint } : {}),
+              },
+            } : {}),
+          })),
+        })
+      } catch (error) {
+        const diagnostic = externalMcpDiagnosticForResponse(error, c.get("requestId"), "MCP_TOOL_DISCOVERY")
+        logger.error("external_mcp_tool_catalog_failed", {
+          connection_id: connection.id,
+          organization_id: payload.organization.id,
+          connection_endpoint: safeExternalMcpEndpointForLog(connection.url),
+          ...externalMcpDiagnosticForLog(error, c.get("requestId"), "MCP_TOOL_DISCOVERY"),
+        })
+        return c.json({
+          error: "tool_catalog_failed",
+          message: `Could not inspect "${connection.name}": ${diagnostic.message} Reference: ${diagnostic.referenceId}.`,
+          diagnostic,
+        }, 502)
+      }
+    },
+  )
+
   app.post(
     "/v1/mcp-connections",
     describeRoute({
@@ -660,6 +790,12 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         // No OAuth dance needed — validate the server is real and reachable now.
         try {
           await connectExternalMcp(created, callbackRedirectUri(c.req.raw, created.id), undefined, undefined, c.get("requestId"))
+          // OAuth records a successful connection while persisting tokens.
+          // A no-auth server has no token write, so retain the successful
+          // initialize probe explicitly for readiness and catalog discovery.
+          if (body.authType === "none") {
+            await markExternalMcpConnectionConnected(created.id)
+          }
         } catch (error) {
           const diagnostic = externalMcpDiagnosticForResponse(error, c.get("requestId"), "MCP_INITIALIZE")
           logger.error("external_mcp_connection_validation_failed", {

--- a/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
@@ -70,12 +70,14 @@ describe("agent-configurable org connections policy", () => {
   test("discovery surfaces the agent needs are readable", () => {
     expect(allowed("getV1McpConnections")).toBe(true)
     expect(allowed("getV1McpConnectionsPresets")).toBe(true)
+    expect(allowed("getV1McpConnectionsByConnectionIdTools")).toBe(true)
   })
 
   test("agent catalog search discovers member list and admin create mcp-connection operations", () => {
     const catalog = buildMcpCatalog(document)
     const memberMatches = searchCapabilities(catalog, "list external mcp connections", 10)
     const adminMatches = searchCapabilities(catalog, "register external mcp connection", 10)
+    const toolCatalogMatches = searchCapabilities(catalog, "inspect tools exposed by an external mcp connection", 10)
 
     expect(memberMatches).toContainEqual(expect.objectContaining({
       name: "getMcpConnections",
@@ -87,6 +89,10 @@ describe("agent-configurable org connections policy", () => {
       method: "POST",
       path: "/v1/mcp-connections",
       hasBody: true,
+    }))
+    expect(toolCatalogMatches).toContainEqual(expect.objectContaining({
+      method: "GET",
+      path: "/v1/mcp-connections/{connectionId}/tools",
     }))
   })
 

--- a/ee/apps/den-api/test/mcp-connections-tools.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-tools.test.ts
@@ -1,0 +1,315 @@
+import { StreamableHTTPTransport } from "@hono/mcp"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+import { z } from "zod"
+
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_mcp_tools"
+process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "local-dev-secret-not-for-production-use!!"
+process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+process.env.DEN_ALLOW_PRIVATE_MCP_URLS = "1"
+
+let app: typeof import("../src/app.js").default
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+let session: typeof import("../src/session.js")
+let createExternalMcpConnection: typeof import("../src/capability-sources/external-mcp-connections.js").createExternalMcpConnection
+
+const adminUserId = createDenTypeId("user")
+const memberUserId = createDenTypeId("user")
+const organizationId = createDenTypeId("organization")
+const otherOrganizationId = createDenTypeId("organization")
+const adminMemberId = createDenTypeId("member")
+const memberId = createDenTypeId("member")
+const otherMemberId = createDenTypeId("member")
+let connectionId: DenTypeId<"externalMcpConnection">
+let disconnectedConnectionId: DenTypeId<"externalMcpConnection">
+let perMemberConnectionId: DenTypeId<"externalMcpConnection">
+let otherConnectionId: DenTypeId<"externalMcpConnection">
+let failingConnectionId: DenTypeId<"externalMcpConnection">
+let fakeServer: ReturnType<typeof Bun.serve> | undefined
+let errorServer: ReturnType<typeof Bun.serve> | undefined
+const observedMethods: string[] = []
+const observedAuthorization: Array<string | null> = []
+
+beforeAll(async () => {
+  mock.restore()
+  const fakeMcp = new Hono()
+  fakeMcp.all("/mcp", async (c) => {
+    const payload: unknown = await c.req.raw.clone().json().catch(() => null)
+    if (payload && typeof payload === "object" && "method" in payload && typeof payload.method === "string") {
+      observedMethods.push(payload.method)
+      observedAuthorization.push(c.req.header("authorization") ?? null)
+    }
+    const server = new McpServer({ name: "catalog-proof", version: "1.0.0" })
+    server.registerTool(
+      "search_incidents",
+      {
+        title: "Search incidents",
+        description: "Search incidents by query and optional status.",
+        inputSchema: z.object({ query: z.string(), status: z.string().optional() }),
+        outputSchema: z.object({ resultCount: z.number() }),
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      },
+      async () => ({ content: [{ type: "text", text: "not called" }] }),
+    )
+    const transport = new StreamableHTTPTransport()
+    await server.connect(transport)
+    return await transport.handleRequest(c) ?? new Response(null, { status: 204 })
+  })
+  fakeServer = Bun.serve({ port: 0, fetch: fakeMcp.fetch })
+
+  const errorMcp = new Hono()
+  errorMcp.all("/mcp", async (c) => {
+    const payload: unknown = await c.req.raw.json().catch(() => null)
+    const id = payload && typeof payload === "object" && "id" in payload ? payload.id : null
+    return c.json({
+      jsonrpc: "2.0",
+      id,
+      error: { code: -32603, message: "provider-catalog-secret must never leave diagnostics" },
+    })
+  })
+  errorServer = Bun.serve({ port: 0, fetch: errorMcp.fetch })
+
+  const realDb = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL ?? "",
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db: realDb }))
+
+  const [appMod, dbMod, schemaMod, drizzleMod, sessionMod, connectionsMod] = await Promise.all([
+    import("../src/app.js"),
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+    import("../src/session.js"),
+    import("../src/capability-sources/external-mcp-connections.js"),
+  ])
+  app = appMod.default
+  db = dbMod.db
+  schema = schemaMod
+  drizzle = drizzleMod
+  session = sessionMod
+  createExternalMcpConnection = connectionsMod.createExternalMcpConnection
+
+  await db.insert(schema.AuthUserTable).values([
+    { id: adminUserId, name: "Catalog Admin", email: `catalog-admin+${adminUserId}@test.local` },
+    { id: memberUserId, name: "Catalog Member", email: `catalog-member+${memberUserId}@test.local` },
+  ])
+  await db.insert(schema.OrganizationTable).values([
+    { id: organizationId, name: "Catalog Org", slug: `catalog-${organizationId}` },
+    { id: otherOrganizationId, name: "Other Catalog Org", slug: `catalog-${otherOrganizationId}` },
+  ])
+  await db.insert(schema.MemberTable).values([
+    { id: adminMemberId, organizationId, userId: adminUserId, role: "admin" },
+    { id: memberId, organizationId, userId: memberUserId, role: "member" },
+    { id: otherMemberId, organizationId: otherOrganizationId, userId: adminUserId, role: "admin" },
+  ])
+
+  const url = `http://127.0.0.1:${fakeServer.port}/mcp`
+  const connected = await createExternalMcpConnection({
+    organizationId,
+    name: "Incident MCP",
+    url,
+    authType: "none",
+    credentialMode: "shared",
+    createdByOrgMembershipId: adminMemberId,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+  })
+  connectionId = connected.id
+  await db.update(schema.ExternalMcpConnectionTable)
+    .set({ connectedAt: new Date() })
+    .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connectionId))
+
+  disconnectedConnectionId = (await createExternalMcpConnection({
+    organizationId,
+    name: "Disconnected MCP",
+    url,
+    authType: "none",
+    credentialMode: "shared",
+    createdByOrgMembershipId: adminMemberId,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+  })).id
+
+  perMemberConnectionId = (await createExternalMcpConnection({
+    organizationId,
+    name: "Personal Incident MCP",
+    url,
+    authType: "oauth",
+    credentialMode: "per_member",
+    createdByOrgMembershipId: adminMemberId,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+  })).id
+  await db.insert(schema.ConnectedAccountTable).values({
+    id: createDenTypeId("connectedAccount"),
+    organizationId,
+    orgMembershipId: adminMemberId,
+    providerId: perMemberConnectionId,
+    accessToken: "member-catalog-token",
+    tokenType: "Bearer",
+  })
+
+  otherConnectionId = (await createExternalMcpConnection({
+    organizationId: otherOrganizationId,
+    name: "Other MCP",
+    url,
+    authType: "none",
+    credentialMode: "shared",
+    createdByOrgMembershipId: otherMemberId,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+  })).id
+
+  failingConnectionId = (await createExternalMcpConnection({
+    organizationId,
+    name: "Failing Catalog MCP",
+    url: `http://127.0.0.1:${errorServer.port}/mcp`,
+    authType: "none",
+    credentialMode: "shared",
+    createdByOrgMembershipId: adminMemberId,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+  })).id
+  await db.update(schema.ExternalMcpConnectionTable)
+    .set({ connectedAt: new Date() })
+    .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, failingConnectionId))
+})
+
+afterAll(async () => {
+  fakeServer?.stop(true)
+  errorServer?.stop(true)
+  if (!db || !schema || !drizzle) return
+  await db.delete(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.inArray(
+    schema.ExternalMcpConnectionAccessGrantTable.organizationId,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.ConnectedAccountTable).where(drizzle.inArray(
+    schema.ConnectedAccountTable.organizationId,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.ExternalMcpConnectionTable).where(drizzle.inArray(
+    schema.ExternalMcpConnectionTable.organizationId,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.MemberTable).where(drizzle.inArray(schema.MemberTable.organizationId, [organizationId, otherOrganizationId]))
+  await db.delete(schema.OrganizationTable).where(drizzle.inArray(schema.OrganizationTable.id, [organizationId, otherOrganizationId]))
+  await db.delete(schema.AuthUserTable).where(drizzle.inArray(schema.AuthUserTable.id, [adminUserId, memberUserId]))
+  mock.restore()
+})
+
+function request(id: string, userId = adminUserId) {
+  return app.fetch(new Request(`http://den-api.local/v1/mcp-connections/${id}/tools`, {
+    headers: {
+      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId, organizationId }),
+    },
+  }))
+}
+
+test("admin inspects a live Den-managed MCP catalog without calling a tool", async () => {
+  observedMethods.length = 0
+  const response = await request(connectionId)
+  expect(response.status).toBe(200)
+  expect(await response.json()).toEqual({
+    tools: [{
+      name: "search_incidents",
+      title: "Search incidents",
+      description: "Search incidents by query and optional status.",
+      inputSchema: {
+        type: "object",
+        properties: { query: { type: "string" }, status: { type: "string" } },
+        required: ["query"],
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+      outputSchema: {
+        type: "object",
+        properties: { resultCount: { type: "number" } },
+        required: ["resultCount"],
+        additionalProperties: false,
+        $schema: "http://json-schema.org/draft-07/schema#",
+      },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    }],
+  })
+  expect(observedMethods).toContain("tools/list")
+  expect(observedMethods).not.toContain("tools/call")
+})
+
+test("a validated no-auth MCP is immediately connected and inspectable", async () => {
+  observedMethods.length = 0
+  const response = await app.fetch(new Request("http://den-api.local/v1/mcp-connections", {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId: adminUserId, organizationId }),
+    },
+    body: JSON.stringify({
+      name: "Fresh no-auth MCP",
+      url: `http://127.0.0.1:${fakeServer?.port}/mcp`,
+      authType: "none",
+      credentialMode: "shared",
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    }),
+  }))
+  expect(response.status).toBe(200)
+  const body: unknown = await response.json()
+  expect(body).toMatchObject({ connected: true, connectedForMe: true })
+  if (!body || typeof body !== "object" || !("id" in body) || typeof body.id !== "string") {
+    throw new Error("created no-auth connection response did not include an id")
+  }
+
+  const catalogResponse = await request(body.id)
+  expect(catalogResponse.status).toBe(200)
+  expect(observedMethods).toContain("initialize")
+  expect(observedMethods).toContain("tools/list")
+  expect(observedMethods).not.toContain("tools/call")
+})
+
+test("catalog inspection requires a connected credential", async () => {
+  const response = await request(disconnectedConnectionId)
+  expect(response.status).toBe(409)
+  expect(await response.json()).toEqual({
+    error: "connection_not_ready",
+    message: "Connect this MCP before inspecting its tools.",
+  })
+})
+
+test("per-member catalog inspection uses only the calling admin's credential", async () => {
+  observedAuthorization.length = 0
+  const response = await request(perMemberConnectionId)
+  expect(response.status).toBe(200)
+  expect(observedAuthorization).toContain("Bearer member-catalog-token")
+})
+
+test("catalog inspection is tenant scoped", async () => {
+  const response = await request(otherConnectionId)
+  expect(response.status).toBe(404)
+})
+
+test("catalog inspection is admin only", async () => {
+  const response = await request(connectionId, memberUserId)
+  expect(response.status).toBe(403)
+})
+
+test("catalog failures return a structured diagnostic without provider secrets", async () => {
+  const response = await request(failingConnectionId)
+  expect(response.status).toBe(502)
+  const body: unknown = await response.json()
+  expect(body).toMatchObject({ error: "tool_catalog_failed" })
+  expect(JSON.stringify(body)).not.toContain("provider-catalog-secret")
+  if (!body || typeof body !== "object" || !("diagnostic" in body) || !body.diagnostic || typeof body.diagnostic !== "object") {
+    throw new Error("catalog failure response did not include a diagnostic")
+  }
+  expect("referenceId" in body.diagnostic && typeof body.diagnostic.referenceId === "string").toBe(true)
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -50,6 +50,21 @@ export type ExternalMcpConnection = {
   access: ExternalMcpAccessSummary | null;
 };
 
+export type ExternalMcpTool = {
+  name: string;
+  title?: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+  annotations?: {
+    title?: string;
+    readOnlyHint?: boolean;
+    destructiveHint?: boolean;
+    idempotentHint?: boolean;
+    openWorldHint?: boolean;
+  };
+};
+
 export type ExternalMcpPreset = {
   presetId: string;
   displayName: string;
@@ -79,10 +94,32 @@ export const mcpConnectionQueryKeys = {
   list: (orgId?: string | null, scope?: ExternalMcpConnectionScope) =>
     [...mcpConnectionQueryKeys.all, "list", orgId ?? "none", scope ?? "usable"] as const,
   presets: () => [...mcpConnectionQueryKeys.all, "presets"] as const,
+  tools: (orgId?: string | null, connectionId?: string | null) =>
+    [...mcpConnectionQueryKeys.all, "tools", orgId ?? "none", connectionId ?? "none"] as const,
   nativeProviderClient: (orgId?: string | null, providerId?: string | null) =>
     [...mcpConnectionQueryKeys.all, "native-provider-client", orgId ?? "none", providerId ?? "none"],
   telegram: (orgId?: string | null) => [...mcpConnectionQueryKeys.all, "telegram", orgId ?? "none"] as const,
 };
+
+export function useMcpConnectionTools(connectionId: string, enabled: boolean) {
+  const { orgId } = useOrgDashboard();
+  return useQuery({
+    enabled: enabled && Boolean(orgId),
+    queryKey: mcpConnectionQueryKeys.tools(orgId, connectionId),
+    queryFn: async (): Promise<ExternalMcpTool[]> => {
+      const { response, payload } = await requestJson(
+        `/v1/mcp-connections/${encodeURIComponent(connectionId)}/tools`,
+        { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
+        30000,
+      );
+      if (!response.ok) {
+        throw getRequestError(payload, response, `Failed to inspect MCP tools (${response.status}).`);
+      }
+      const record = payload as { tools?: ExternalMcpTool[] };
+      return record.tools ?? [];
+    },
+  });
+}
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Check, Loader2, Plug, Puzzle, Server, Trash2, Users } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Loader2, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenSelect } from "../../_components/ui/select";
@@ -23,6 +23,7 @@ import {
   type ExternalMcpConnection,
   type ExternalMcpCredentialMode,
   type ExternalMcpPreset,
+  type ExternalMcpTool,
   type McpConnectionAccessInput,
   formatMcpConnectedTimestamp,
   mcpConnectionQueryKeys,
@@ -30,6 +31,7 @@ import {
   useDeleteMcpConnection,
   useMcpConnectionPresets,
   useMcpConnections,
+  useMcpConnectionTools,
   useNativeProviderClient,
   useSaveNativeProviderClient,
   useStartMcpConnectionOAuth,
@@ -40,6 +42,7 @@ import { TelegramDialog } from "./telegram-dialog";
 
 const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
+const MCP_TOOL_PAGE_SIZE = 50;
 
 const GOOGLE_WORKSPACE_DEFAULT_FEATURES = ["calendarRead", "gmailDraft", "driveFile"];
 
@@ -212,6 +215,7 @@ export function McpConnectionsScreen() {
   const showStagingBanner = orgContext ? shouldShowMcpConnectionsStagingBanner(orgContext.capabilities) : false;
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
   const [connectionActionError, setConnectionActionError] = useState<{ connectionId: string; message: string } | null>(null);
+  const [toolsConnectionId, setToolsConnectionId] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
 
   useEffect(() => {
@@ -451,6 +455,8 @@ export function McpConnectionsScreen() {
               onConnect={() => void handleConnectOAuth(connection.id)}
               onRemove={() => deleteConnection.mutate(connection.id)}
               removing={deleteConnection.isPending && deleteConnection.variables === connection.id}
+              toolsOpen={toolsConnectionId === connection.id}
+              onToggleTools={() => setToolsConnectionId((current) => current === connection.id ? null : connection.id)}
             />
           ))}
         </div>
@@ -1069,6 +1075,8 @@ function ConnectionRow({
   onConnect,
   onRemove,
   removing,
+  toolsOpen,
+  onToggleTools,
 }: {
   connection: ExternalMcpConnection;
   polling: boolean;
@@ -1077,67 +1085,260 @@ function ConnectionRow({
   onConnect: () => void;
   onRemove: () => void;
   removing: boolean;
+  toolsOpen: boolean;
+  onToggleTools: () => void;
 }) {
   const isPerMember = connection.credentialMode === "per_member";
   const needsOAuthConnect = !isPerMember && connection.authType === "oauth" && !connection.connected;
 
+  const canInspectTools = connection.credentialMode === "shared" ? connection.connected : connection.connectedForMe;
+
   return (
-    <div className="flex items-center justify-between gap-4 px-6 py-4">
-      <div className="flex min-w-0 flex-1 items-center gap-3">
-        <IntegrationIcon name={connection.name} serviceUrl={connection.url} />
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-2">
-            <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
-            {isPerMember ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-gray-900 px-2 py-0.5 text-[11px] font-medium text-white">
-                <Users className="h-3 w-3" />
-                Individual accounts
-              </span>
-            ) : connection.connected ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
-                <Check className="h-3 w-3" />
-                Connected
-              </span>
-            ) : polling ? (
-              <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
-                <Loader2 className="h-3 w-3 animate-spin" />
-                Waiting for authorization…
-              </span>
-            ) : (
-              <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
-                Not connected
-              </span>
-            )}
-            {connection.access ? (
-              <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
-                {accessSummaryLabel(connection)}
-              </span>
-            ) : null}
+    <div>
+      <div className="flex flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
+        <div className="flex min-w-0 flex-1 items-center gap-3">
+          <IntegrationIcon name={connection.name} serviceUrl={connection.url} />
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
+              {isPerMember ? (
+                <span className="inline-flex items-center gap-1 rounded-full bg-gray-900 px-2 py-0.5 text-[11px] font-medium text-white">
+                  <Users className="h-3 w-3" />
+                  Individual accounts
+                </span>
+              ) : connection.connected ? (
+                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
+                  <Check className="h-3 w-3" />
+                  Connected
+                </span>
+              ) : polling ? (
+                <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                  Waiting for authorization…
+                </span>
+              ) : (
+                <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
+                  Not connected
+                </span>
+              )}
+              {connection.access ? (
+                <span className="inline-flex rounded-full bg-gray-100 px-2 py-0.5 text-[11px] font-medium text-gray-500">
+                  {accessSummaryLabel(connection)}
+                </span>
+              ) : null}
+            </div>
+            <p className="mt-0.5 truncate text-[12px] text-gray-500">
+              {connection.url} · {formatMcpConnectedTimestamp(connection.connectedAt)}
+            </p>
+            {errorMessage ? <p className="mt-1 text-[12px] text-red-600">{errorMessage}</p> : null}
           </div>
-          <p className="mt-0.5 truncate text-[12px] text-gray-500">
-            {connection.url} · {formatMcpConnectedTimestamp(connection.connectedAt)}
-          </p>
-          {errorMessage ? <p className="mt-1 text-[12px] text-red-600">{errorMessage}</p> : null}
+        </div>
+
+        <div className="flex flex-wrap items-center gap-2 sm:shrink-0 sm:flex-nowrap">
+          <DenButton
+            variant="secondary"
+            size="sm"
+            disabled={!canInspectTools}
+            onClick={onToggleTools}
+            title={canInspectTools ? "Inspect the tools this MCP exposes" : "Connect this account before inspecting tools"}
+          >
+            {toolsOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+            View tools
+          </DenButton>
+          {needsOAuthConnect ? (
+            <DenButton variant="secondary" size="sm" loading={connecting || polling} onClick={onConnect}>
+              Connect
+            </DenButton>
+          ) : null}
+          <DenButton
+            variant="destructive"
+            size="sm"
+            icon={Trash2}
+            loading={removing}
+            onClick={onRemove}
+            aria-label={`Remove ${connection.name}`}
+          >
+            Remove
+          </DenButton>
         </div>
       </div>
+      {toolsOpen && canInspectTools ? <McpToolCatalog connection={connection} /> : null}
+    </div>
+  );
+}
 
-      <div className="flex shrink-0 items-center gap-2">
-        {needsOAuthConnect ? (
-          <DenButton variant="secondary" size="sm" loading={connecting || polling} onClick={onConnect}>
-            Connect
-          </DenButton>
-        ) : null}
-        <DenButton
-          variant="destructive"
-          size="sm"
-          icon={Trash2}
-          loading={removing}
-          onClick={onRemove}
-          aria-label={`Remove ${connection.name}`}
-        >
-          Remove
+function schemaInputs(schema: Record<string, unknown>): Array<{ name: string; required: boolean; type: string | null }> {
+  const properties = isRecord(schema.properties) ? schema.properties : {};
+  const required = new Set(Array.isArray(schema.required) ? schema.required.filter((item): item is string => typeof item === "string") : []);
+  return Object.entries(properties).map(([name, definition]) => ({
+    name,
+    required: required.has(name),
+    type: isRecord(definition) && typeof definition.type === "string" ? definition.type : null,
+  }));
+}
+
+function toolHints(tool: ExternalMcpTool): Array<{ label: string; className: string }> {
+  const annotations = tool.annotations;
+  if (!annotations) return [];
+  return [
+    annotations.readOnlyHint ? { label: "Read-only hint", className: "bg-blue-50 text-blue-700" } : null,
+    annotations.destructiveHint ? { label: "Destructive hint", className: "bg-red-50 text-red-700" } : null,
+    annotations.idempotentHint ? { label: "Idempotent hint", className: "bg-emerald-50 text-emerald-700" } : null,
+    annotations.openWorldHint ? { label: "External access hint", className: "bg-amber-50 text-amber-700" } : null,
+  ].filter((hint): hint is { label: string; className: string } => hint !== null);
+}
+
+function McpToolCatalog({ connection }: { connection: ExternalMcpConnection }) {
+  const catalog = useMcpConnectionTools(connection.id, true);
+  const [toolSearch, setToolSearch] = useState("");
+  const [visibleToolLimit, setVisibleToolLimit] = useState(MCP_TOOL_PAGE_SIZE);
+  const filteredTools = useMemo(() => {
+    const needle = toolSearch.trim().toLowerCase();
+    if (!needle) return catalog.data ?? [];
+    return (catalog.data ?? []).filter((tool) =>
+      [tool.name, tool.title, tool.annotations?.title, tool.description]
+        .some((value) => value?.toLowerCase().includes(needle)),
+    );
+  }, [catalog.data, toolSearch]);
+  const visibleTools = filteredTools.slice(0, visibleToolLimit);
+  const remainingToolCount = filteredTools.length - visibleTools.length;
+
+  return (
+    <div className="border-t border-gray-100 bg-gray-50/70 px-6 py-5" data-mcp-tool-catalog={connection.id}>
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="flex items-center gap-2">
+            <Wrench className="h-4 w-4 text-gray-500" />
+            <p className="text-[13px] font-semibold text-gray-900">Tools available to your agents</p>
+          </div>
+          <p className="mt-1 text-[12px] leading-5 text-gray-500">
+            Live from {connection.name}. Inspecting this list does not run a tool. Provider annotations are hints, not guarantees.
+          </p>
+        </div>
+        <DenButton variant="secondary" size="sm" loading={catalog.isFetching} onClick={() => void catalog.refetch()}>
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refresh
         </DenButton>
       </div>
+
+      {catalog.data && catalog.data.length > 0 ? (
+        <div className="mt-4 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="w-full sm:max-w-sm">
+            <DenInput
+              aria-label="Search MCP tools"
+              icon={Search}
+              value={toolSearch}
+              onChange={(event) => {
+                setToolSearch(event.target.value);
+                setVisibleToolLimit(MCP_TOOL_PAGE_SIZE);
+              }}
+              placeholder="Search tools by name or description"
+            />
+          </div>
+          <p className="shrink-0 text-[11px] font-medium text-gray-500" role="status">
+            {toolSearch.trim()
+              ? `${filteredTools.length} of ${catalog.data.length} tools`
+              : `${catalog.data.length} ${catalog.data.length === 1 ? "tool" : "tools"} exposed`}
+          </p>
+        </div>
+      ) : null}
+
+      {catalog.isLoading ? (
+        <div className="mt-4 flex items-center gap-2 text-[12px] text-gray-500">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          Reading the MCP tool catalog…
+        </div>
+      ) : catalog.error ? (
+        <div className="mt-4 rounded-xl border border-red-100 bg-red-50 px-4 py-3 text-[12px] leading-5 text-red-700">
+          {catalog.error instanceof Error ? catalog.error.message : "Could not read this MCP's tools."}
+        </div>
+      ) : catalog.data?.length === 0 ? (
+        <div className="mt-4 rounded-xl border border-gray-200 bg-white px-4 py-3 text-[12px] text-gray-500">
+          This MCP is connected but does not currently expose any tools.
+        </div>
+      ) : filteredTools.length === 0 ? (
+        <div className="mt-4 rounded-xl border border-gray-200 bg-white px-4 py-3 text-[12px] text-gray-500">
+          No tools match “{toolSearch.trim()}”.
+        </div>
+      ) : (
+        <>
+          <div className="mt-4 grid gap-3 lg:grid-cols-2">
+            {visibleTools.map((tool) => {
+              const inputs = schemaInputs(tool.inputSchema);
+              const hints = toolHints(tool);
+              const displayTitle = tool.title || tool.annotations?.title;
+              return (
+                <details key={tool.name} className="group rounded-2xl border border-gray-200 bg-white p-4">
+                  <summary className="cursor-pointer list-none">
+                    <div className="flex items-start justify-between gap-3">
+                      <div className="min-w-0">
+                        {displayTitle ? (
+                          <>
+                            <p className="break-words text-[12px] font-semibold text-gray-900">{displayTitle}</p>
+                            <p className="mt-0.5 break-words font-mono text-[10px] text-gray-500">{tool.name}</p>
+                          </>
+                        ) : (
+                          <p className="break-words font-mono text-[12px] font-semibold text-gray-900">{tool.name}</p>
+                        )}
+                        <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-gray-500">
+                          {tool.description || "No description provided by this MCP."}
+                        </p>
+                      </div>
+                      <ChevronRight className="mt-0.5 h-4 w-4 shrink-0 text-gray-400 transition group-open:rotate-90" />
+                    </div>
+                    <div className="mt-3 flex flex-wrap items-center gap-2">
+                      <p className="text-[11px] font-medium text-gray-500">
+                        {inputs.length === 0 ? "No inputs" : `${inputs.length} ${inputs.length === 1 ? "input" : "inputs"}`}
+                      </p>
+                      {hints.map((hint) => (
+                        <span
+                          key={hint.label}
+                          className={`rounded-full px-2 py-0.5 text-[10px] font-medium ${hint.className}`}
+                          title="Provider-supplied MCP annotation; treat as a hint."
+                        >
+                          {hint.label}
+                        </span>
+                      ))}
+                    </div>
+                  </summary>
+                  <div className="mt-4 border-t border-gray-100 pt-4">
+                    {inputs.length > 0 ? (
+                      <div className="flex flex-wrap gap-2">
+                        {inputs.map((input) => (
+                          <span key={input.name} className="rounded-full bg-gray-100 px-2.5 py-1 font-mono text-[11px] text-gray-700">
+                            {input.name}{input.type ? `: ${input.type}` : ""}{input.required ? " · required" : ""}
+                          </span>
+                        ))}
+                      </div>
+                    ) : null}
+                    <details className="mt-3">
+                      <summary className="cursor-pointer text-[11px] font-medium text-gray-500">View input schema</summary>
+                      <pre className="mt-2 max-h-64 overflow-auto rounded-xl bg-gray-950 p-3 text-[10px] leading-4 text-gray-100">{JSON.stringify(tool.inputSchema, null, 2)}</pre>
+                    </details>
+                    {tool.outputSchema ? (
+                      <details className="mt-3">
+                        <summary className="cursor-pointer text-[11px] font-medium text-gray-500">View output schema</summary>
+                        <pre className="mt-2 max-h-64 overflow-auto rounded-xl bg-gray-950 p-3 text-[10px] leading-4 text-gray-100">{JSON.stringify(tool.outputSchema, null, 2)}</pre>
+                      </details>
+                    ) : null}
+                  </div>
+                </details>
+              );
+            })}
+          </div>
+          {remainingToolCount > 0 ? (
+            <div className="mt-4 flex justify-center">
+              <DenButton
+                variant="secondary"
+                size="sm"
+                onClick={() => setVisibleToolLimit((current) => current + MCP_TOOL_PAGE_SIZE)}
+              >
+                Show {Math.min(MCP_TOOL_PAGE_SIZE, remainingToolCount)} more
+              </DenButton>
+            </div>
+          ) : null}
+        </>
+      )}
     </div>
   );
 }

--- a/evals/flows/mcp-tool-catalog.flow.mjs
+++ b/evals/flows/mcp-tool-catalog.flow.mjs
@@ -1,0 +1,421 @@
+import http from "node:http";
+import { denApiFetch, denWebUrl, openAdminConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "mcp-tool-catalog";
+const CONNECTION_PREFIX = "Incident Response MCP — tool catalog proof";
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const state = {
+  adminToken: "",
+  connectionId: "",
+  connectionName: "",
+  observedMethods: [],
+  server: null,
+};
+
+async function waitForObserved(method, minimum, timeoutMs = 30_000) {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (state.observedMethods.filter((entry) => entry === method).length >= minimum) return;
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error(`Timed out waiting for ${minimum} observed ${method} requests.`);
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : JSON.stringify(actual).slice(0, 1_200),
+  });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : `. Actual: ${JSON.stringify(actual).slice(0, 600)}`}`);
+}
+
+function json(response, status, body) {
+  response.writeHead(status, {
+    "access-control-allow-origin": "*",
+    "content-type": "application/json",
+  });
+  response.end(JSON.stringify(body));
+}
+
+function readJson(request) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    request.on("data", (chunk) => { raw += chunk; });
+    request.on("end", () => {
+      try {
+        resolve(raw.trim() ? JSON.parse(raw) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    request.on("error", reject);
+  });
+}
+
+function mcpResult(message) {
+  if (message.method === "initialize") {
+    return {
+      protocolVersion: "2025-06-18",
+      capabilities: { tools: {} },
+      serverInfo: { name: "incident-response-proof", version: "1.0.0" },
+    };
+  }
+  if (message.method === "tools/list") {
+    return {
+      tools: [
+        {
+          name: "search_incidents",
+          title: "Search incidents",
+          description: "Search incidents by query and optional status.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              query: { type: "string", description: "Words to match in incident titles and summaries." },
+              status: { type: "string", enum: ["open", "resolved"], description: "Limit results to one status." },
+            },
+            required: ["query"],
+            additionalProperties: false,
+          },
+          outputSchema: {
+            type: "object",
+            properties: { resultCount: { type: "number" } },
+            required: ["resultCount"],
+            additionalProperties: false,
+          },
+          annotations: {
+            readOnlyHint: true,
+            destructiveHint: false,
+            idempotentHint: true,
+            openWorldHint: false,
+          },
+        },
+        {
+          name: "create_postmortem",
+          title: "Draft a postmortem",
+          description: "Create a draft postmortem for a resolved incident.",
+          inputSchema: {
+            type: "object",
+            properties: {
+              incidentId: { type: "string" },
+              owner: { type: "string" },
+            },
+            required: ["incidentId"],
+            additionalProperties: false,
+          },
+          annotations: {
+            readOnlyHint: false,
+            destructiveHint: true,
+            idempotentHint: false,
+            openWorldHint: false,
+          },
+        },
+      ],
+    };
+  }
+  if (message.method === "tools/call") {
+    return { isError: true, content: [{ type: "text", text: "This proof must never execute a tool." }] };
+  }
+  return {};
+}
+
+async function startMcpServer() {
+  if (state.server) return;
+  state.server = http.createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url || "/", "http://127.0.0.1");
+      if (url.pathname !== "/mcp" || request.method !== "POST") {
+        json(response, 404, { error: "not_found" });
+        return;
+      }
+      const body = await readJson(request);
+      const messages = Array.isArray(body) ? body : [body];
+      const replies = [];
+      for (const message of messages) {
+        if (message && typeof message === "object" && typeof message.method === "string") {
+          state.observedMethods.push(message.method);
+        }
+        if (message && typeof message === "object" && message.id !== undefined) {
+          replies.push({ jsonrpc: "2.0", id: message.id, result: mcpResult(message) });
+        }
+      }
+      if (replies.length === 0) {
+        response.writeHead(202, { "access-control-allow-origin": "*" });
+        response.end();
+        return;
+      }
+      json(response, 200, Array.isArray(body) ? replies : replies[0]);
+    } catch (error) {
+      json(response, 500, { error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+  await new Promise((resolve, reject) => {
+    state.server.once("error", reject);
+    state.server.listen(0, "127.0.0.1", resolve);
+  });
+  state.server.unref();
+}
+
+function mcpUrl() {
+  const address = state.server?.address();
+  if (!address || typeof address === "string") throw new Error("MCP proof server has no TCP address.");
+  return `http://127.0.0.1:${address.port}/mcp`;
+}
+
+async function ensureConnection(ctx) {
+  if (state.connectionId) return;
+  await startMcpServer();
+  state.adminToken = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
+  witness(ctx, Boolean(state.adminToken), `The demo owner can sign in as ${ADMIN_EMAIL}.`);
+
+  const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+    headers: { authorization: `Bearer ${state.adminToken}` },
+  });
+  witness(ctx, existing.response.ok, "The admin can read the manageable MCP connections.", { status: existing.response.status });
+  for (const connection of existing.body.connections ?? []) {
+    if (connection.name.startsWith(CONNECTION_PREFIX)) {
+      await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+        method: "DELETE",
+        headers: { authorization: `Bearer ${state.adminToken}` },
+      });
+    }
+  }
+
+  state.connectionName = `${CONNECTION_PREFIX} ${Date.now()}`;
+  const created = await denApiFetch("/v1/mcp-connections", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.adminToken}` },
+    body: JSON.stringify({
+      name: state.connectionName,
+      url: mcpUrl(),
+      authType: "none",
+      credentialMode: "shared",
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    }),
+  });
+  witness(ctx, created.response.ok && typeof created.body?.id === "string" && created.body?.connected === true, "Den validates and connects the protocol-compatible MCP server.", {
+    status: created.response.status,
+    id: created.body?.id,
+    connected: created.body?.connected,
+  });
+  state.connectionId = created.body.id;
+  state.observedMethods.length = 0;
+}
+
+async function navigateToConnections(ctx) {
+  const currentUrl = await ctx.eval("window.location.href");
+  if (!currentUrl.includes(new URL(denWebUrl()).host)) {
+    await ctx.eval(`(() => { window.location.href = ${JSON.stringify(denWebUrl())}; return true; })()`);
+  }
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "Den web loaded" });
+  await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+  await openAdminConnections(ctx);
+  await ctx.waitFor(`(() => {
+    const leaf = [...document.querySelectorAll('p, span')]
+      .find((entry) => (entry.textContent ?? '').trim() === ${JSON.stringify(state.connectionName)});
+    if (!leaf) return false;
+    leaf.scrollIntoView({ block: 'center' });
+    return true;
+  })()`, { timeoutMs: 30_000, label: "Incident Response MCP row" });
+}
+
+function connectionRowScript(action) {
+  return `(() => {
+    const leaf = [...document.querySelectorAll('p, span')]
+      .find((entry) => (entry.textContent ?? '').trim() === ${JSON.stringify(state.connectionName)});
+    let row = leaf;
+    for (let depth = 0; depth < 8 && row; depth += 1) {
+      const button = [...row.querySelectorAll('button')]
+        .find((entry) => (entry.textContent ?? '').replace(/\\s+/g, ' ').trim() === 'View tools');
+      if (button) {
+        if (button.disabled) return false;
+        row.scrollIntoView({ block: 'center' });
+        ${action === "click" ? "button.click();" : ""}
+        return true;
+      }
+      row = row.parentElement;
+    }
+    return false;
+  })()`;
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Admins can inspect a connected MCP's live tools, inputs, and schemas without executing anything",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "The existing connection row gains a safe discovery action",
+      run: async (ctx) => {
+        await ctx.prove("A connected MCP exposes View tools in the existing Connections workflow", {
+          voiceover: vo[0],
+          action: async () => {
+            if (ctx.client?.send) {
+              await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+                width: 1440,
+                height: 1000,
+                deviceScaleFactor: 1,
+                mobile: false,
+              });
+            }
+            await ensureConnection(ctx);
+            await navigateToConnections(ctx);
+          },
+          assert: async () => {
+            const hasAction = await ctx.eval(connectionRowScript("find"));
+            witness(ctx, hasAction, "The connected Incident Response MCP has a View tools action.", { hasAction });
+            witness(ctx, !state.observedMethods.includes("tools/list"), "Merely viewing the connection does not read or execute its tool catalog.", state.observedMethods);
+            witness(ctx, !state.observedMethods.includes("tools/call"), "No MCP tool has been executed.", state.observedMethods);
+          },
+          screenshot: {
+            name: "connected-mcp-view-tools",
+            requireText: ["Connections", "Incident Response MCP", "View tools", "Connected"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/dashboard/mcp-connections",
+          },
+        });
+      },
+    },
+    {
+      name: "Live tool names and descriptions appear without execution",
+      run: async (ctx) => {
+        await ctx.prove("The dashboard reads live tools/list data and states that inspection does not run a tool", {
+          voiceover: vo[1],
+          action: async () => {
+            const clicked = await ctx.eval(connectionRowScript("click"));
+            witness(ctx, clicked, "Alex can open the MCP's tool catalog from its row.", { clicked });
+            await ctx.waitFor(`(() => {
+              const catalog = document.querySelector('[data-mcp-tool-catalog="${state.connectionId}"]');
+              return (catalog?.textContent ?? '').includes('search_incidents')
+                && (catalog?.textContent ?? '').includes('create_postmortem');
+            })()`, { timeoutMs: 30_000, label: "live MCP tool catalog" });
+            const initialListCount = state.observedMethods.filter((method) => method === "tools/list").length;
+            const refreshed = await ctx.eval(`(() => {
+              const catalog = document.querySelector('[data-mcp-tool-catalog="${state.connectionId}"]');
+              const button = [...(catalog?.querySelectorAll('button') ?? [])]
+                .find((entry) => (entry.textContent ?? '').trim() === 'Refresh');
+              button?.click();
+              return Boolean(button);
+            })()`);
+            witness(ctx, refreshed, "Alex can explicitly refresh the live catalog.", { refreshed });
+            await waitForObserved("tools/list", initialListCount + 1);
+            const searched = await ctx.eval(`(() => {
+              const catalog = document.querySelector('[data-mcp-tool-catalog="${state.connectionId}"]');
+              const input = catalog?.querySelector('input[aria-label="Search MCP tools"]');
+              if (!input) return false;
+              const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+              setter?.call(input, 'postmortem');
+              input.dispatchEvent(new Event('input', { bubbles: true }));
+              return true;
+            })()`);
+            witness(ctx, searched, "Alex can search a large MCP catalog by tool name or description.", { searched });
+            await ctx.waitFor(`(() => {
+              const catalog = document.querySelector('[data-mcp-tool-catalog="${state.connectionId}"]');
+              const text = catalog?.textContent ?? '';
+              return text.includes('1 of 2 tools') && text.includes('create_postmortem') && !text.includes('search_incidents');
+            })()`, { timeoutMs: 10_000, label: "filtered MCP tool catalog" });
+            const cleared = await ctx.eval(`(() => {
+              const catalog = document.querySelector('[data-mcp-tool-catalog="${state.connectionId}"]');
+              const input = catalog?.querySelector('input[aria-label="Search MCP tools"]');
+              if (!input) return false;
+              const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+              setter?.call(input, '');
+              input.dispatchEvent(new Event('input', { bubbles: true }));
+              return true;
+            })()`);
+            witness(ctx, cleared, "Alex can clear the catalog search.", { cleared });
+            await ctx.waitFor(`(() => {
+              const catalog = document.querySelector('[data-mcp-tool-catalog="${state.connectionId}"]');
+              return (catalog?.textContent ?? '').includes('2 tools exposed');
+            })()`, { timeoutMs: 10_000, label: "complete MCP tool catalog" });
+            await ctx.eval(`(() => {
+              const catalog = document.querySelector('[data-mcp-tool-catalog="${state.connectionId}"]');
+              catalog?.scrollIntoView({ block: 'center' });
+              return Boolean(catalog);
+            })()`);
+          },
+          assert: async () => {
+            await ctx.expectText("Tools available to your agents");
+            await ctx.expectText("Inspecting this list does not run a tool.");
+            await ctx.expectText("Provider annotations are hints, not guarantees.");
+            await ctx.expectText("2 tools exposed");
+            await ctx.expectText("Search incidents by query and optional status.");
+            const listCount = state.observedMethods.filter((method) => method === "tools/list").length;
+            witness(ctx, listCount >= 2, "Opening and refreshing the catalog use tools/list.", { listCount, methods: state.observedMethods });
+            witness(ctx, !state.observedMethods.includes("tools/call"), "Opening and refreshing the catalog never send tools/call.", state.observedMethods);
+          },
+          screenshot: {
+            name: "live-mcp-tool-catalog",
+            requireText: [
+              "Tools available to your agents",
+              "Inspecting this list does not run a tool.",
+              "Provider annotations are hints, not guarantees.",
+              "2 tools exposed",
+              "search_incidents",
+              "create_postmortem",
+              "2 inputs",
+            ],
+            rejectText: ["Could not read this MCP's tools"],
+            hashIncludes: "/dashboard/mcp-connections",
+          },
+        });
+      },
+    },
+    {
+      name: "Inputs and the complete provider schema are understandable",
+      run: async (ctx) => {
+        await ctx.prove("A tool expands into required inputs, basic types, and its full provider schema", {
+          voiceover: vo[2],
+          action: async () => {
+            const expanded = await ctx.eval(`(() => {
+              const catalog = document.querySelector('[data-mcp-tool-catalog="${state.connectionId}"]');
+              const tool = [...(catalog?.querySelectorAll('details') ?? [])]
+                .find((entry) => (entry.querySelector(':scope > summary')?.textContent ?? '').includes('search_incidents'));
+              if (!tool) return false;
+              tool.open = true;
+              const schema = [...tool.querySelectorAll('details')]
+                .find((entry) => (entry.querySelector(':scope > summary')?.textContent ?? '').includes('View input schema'));
+              if (schema) schema.open = true;
+              tool.scrollIntoView({ block: 'center' });
+              return Boolean(schema);
+            })()`);
+            witness(ctx, expanded, "Alex can expand the tool and its complete input schema.", { expanded });
+            await ctx.waitFor("document.body.innerText.includes('query: string · required') && document.body.innerText.includes('status: string')", {
+              timeoutMs: 10_000,
+              label: "typed required and optional inputs",
+            });
+          },
+          assert: async () => {
+            await ctx.expectText("query: string · required");
+            await ctx.expectText("status: string");
+            await ctx.expectText("Read-only hint");
+            await ctx.expectText("View output schema");
+            await ctx.expectText("additionalProperties");
+            witness(ctx, !state.observedMethods.includes("tools/call"), "Inspecting descriptions, inputs, and JSON Schema still never executes a tool.", state.observedMethods);
+          },
+          screenshot: {
+            name: "mcp-tool-input-schema",
+            requireText: ["search_incidents", "Read-only hint", "query: string · required", "status: string", "View input schema", "View output schema", "additionalProperties"],
+            rejectText: ["This proof must never execute a tool"],
+            hashIncludes: "/dashboard/mcp-connections",
+          },
+        });
+
+        if (state.connectionId) {
+          await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+            method: "DELETE",
+            headers: { authorization: `Bearer ${state.adminToken}` },
+          });
+        }
+        state.server?.close();
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/mcp-tool-catalog.md
+++ b/evals/voiceovers/mcp-tool-catalog.md
@@ -1,0 +1,11 @@
+# mcp-tool-catalog — See what an MCP gives your agents before they use it
+
+Cast: Alex, an Acme Robotics workspace admin, in OpenWork Cloud. The connected
+Incident Response MCP is a real protocol-compatible test server. Catalog
+inspection reads its live `tools/list` response and never invokes a tool.
+
+1. Alex opens MCP Connections and sees a new View tools action on the connected Incident Response MCP. Discovery stays tucked into the existing connection row, so setup and inspection remain one workflow.
+
+2. Alex opens the searchable catalog and immediately sees the live tool names, descriptions, and input counts. Even a large catalog stays manageable, and OpenWork makes the safety boundary explicit: inspecting, searching, or refreshing this list does not run a tool.
+
+3. Alex expands search_incidents to see the provider's read-only hint, which inputs are required, their basic types, and separate input and output schema details. He can now understand what the MCP adds before an agent ever calls it.


### PR DESCRIPTION
## Summary

- add an admin-only, tenant-scoped API for reading a connected MCP's live `tools/list` catalog
- add a searchable, progressively rendered tool catalog to the existing Connections screen
- show provider titles, descriptions, inputs, JSON schemas, output schemas, and safety annotations
- mark successfully validated no-auth MCPs connected so their catalogs are immediately inspectable
- make the read-only catalog endpoint discoverable through Den capability search

## Why

Workspace admins could connect MCP servers but could not inspect what tools they exposed before an agent used them. This adds discovery to the existing connection workflow without executing a tool.

## Security and boundaries

- inspection sends `tools/list` and never `tools/call`
- credentials remain in Den and are never returned to the browser
- access is organization-scoped and restricted to workspace owners/admins
- per-member connections use only the calling admin's credential
- upstream failures return sanitized diagnostics without provider secrets
- existing SSRF, pagination, cursor-loop, duplicate-name, 2,000-tool, schema-size, and 8 MB catalog limits remain enforced
- provider annotations are labeled as hints, not guarantees

## Validation

- `./bin/openwork-hub run mcp mcp-tool-catalog -- pnpm --dir ee/apps/den-api exec bun test test/mcp-connections-tools.test.ts test/mcp-connections-connect-start.test.ts test/mcp-agent-config-policy.test.ts test/mcp-connections-required-by.test.ts` — 25 passed
- `pnpm exec bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs tests/marketplace-mcp-readiness.test.ts` from `ee/apps/den-web` — 33 passed
- `pnpm build` from `ee/apps/den-api` — passed
- `pnpm build` from `ee/apps/den-web` — passed
- `pnpm fraimz --flow mcp-tool-catalog` — passed all 3 user-facing frames plus voice-over coverage; opening, searching, refreshing, and expanding the catalog were proven without any `tools/call`
