### PR TITLE
docs: add Cloud MCP tool exposure diagnostic

### DIFF
--- a/packages/docs/start-here/troubleshooting/diagnostic-prompts.mdx
+++ b/packages/docs/start-here/troubleshooting/diagnostic-prompts.mdx
@@ -32,7 +32,7 @@ My expected cloud web URL: https://app.openworklabs.com (replace with your self-
    - `~/.config/opencode/opencode.json`
    - any `.opencode/opencode.json` or `opencode.jsonc` in the current project
    - your own runtime config if you have an export tool
-2. Print these files in full if they exist (they can silently override server URLs beneath the Settings UI):
+2. Inspect these files if they exist (they can silently override server URLs beneath the Settings UI), but report only `baseUrl`, `apiBaseUrl`, `requireSignin`, and `writtenAt`. Never print `handoff`, `claimLinks`, grants, tokens, or other credential-bearing fields:
    - `~/.config/openwork/desktop-bootstrap.json`
    - `~/Library/Application Support/com.differentai.openwork/desktop-bootstrap.json`
 3. If the url from step 1 is a localhost address, find what serves that port:
@@ -60,10 +60,12 @@ State which world you are in:
 
 8. If a desktop-bootstrap.json contains stale/localhost URLs: show it, then delete that file.
 9. If a stale local server process is still listening: show the process, then stop it, so nothing can silently serve old answers again.
-10. Tell me to do the two steps only a human can do, then wait:
+10. Tell me to do these steps in OpenWork, then wait:
     - Restart the OpenWork app.
-    - Settings → Connections → OpenWork Cloud → Disconnect → Connect (rewrites the MCP url to the current server and mints a fresh token).
-    - Start a NEW chat session so the sidecar reloads MCP config.
+    - In the affected workspace, open Settings → Extensions and click Refresh (re-mints the token and rewrites the Cloud MCP config).
+    - Click Show hidden, then verify OpenWork Cloud Control under Your apps.
+    - Run Reload OpenCode config from the command palette.
+    - Start a NEW task so it receives the current tool set.
 
 ## Phase 6 — Verify (run in the NEW session)
 
@@ -74,8 +76,83 @@ State which world you are in:
 
 **Expected passing state**
 
-- The `openwork-cloud` entry's `url` points at your real server's `/api/den/mcp/agent`.
+- The `openwork-cloud` entry's `url` points at your real server and ends in `/mcp/agent` (either a direct API host or the web app's `/api/den` proxy).
 - `search_capabilities` reflects your server's current catalog.
 - `execute_capability` on a known capability returns data or an actionable connection message — never `unknown_capability`.
 
 If the agent completes all phases and verification still fails, [open an issue](https://github.com/different-ai/openwork/issues) and paste the agent's final report (it is already redacted).
+
+## 2. Cloud MCP is configured, but its tools are missing
+
+**Symptoms**
+
+- Settings shows an `openwork-cloud` MCP entry, but the agent calls `openwork_docs_search` for requests involving connected services.
+- The agent claims that `search_capabilities` and `execute_capability` are only "conceptual capabilities" rather than callable tools.
+- A connected service such as ServiceNow appears ready in OpenWork Cloud, but the task does not expose `openwork-cloud_search_capabilities` or `openwork-cloud_execute_capability`.
+
+**What this diagnostic checks**
+
+The prompt below runs OpenWork's bundled OpenCode executable against its generated runtime config and checks whether a fresh OpenCode process can connect to `openwork-cloud`. It does not attach to the OpenCode server already running inside OpenWork, so it combines that result with the live status shown in OpenWork and a forced tool call from a new task.
+
+**Paste this to your agent**
+
+````text
+Diagnose whether OpenWork Cloud MCP tools are available in this workspace. Gather evidence only: do not modify configuration, authenticate, log out, remove anything, restart services, or print configuration-file contents.
+
+## Phase 1 — Test the task's actual tools
+
+1. Attempt to call `openwork-cloud_search_capabilities` with `{"query":"ServiceNow incident","type":"mcp","limit":10}`. Do not use documentation or explain alternatives. Record whether the runtime accepts the tool call and its exact non-secret result or rejection.
+2. Attempt to call `openwork_extension_list_actions`. Record whether the runtime accepts the call. Do not infer tool availability from an answer to "list your tools"; models can omit or invent tools.
+
+## Phase 2 — Find OpenWork's exact OpenCode runtime
+
+3. Detect whether this machine is Windows, macOS, or Linux.
+4. Find the exact OpenCode executable used by the OpenWork desktop app. Prefer the bundled executable in OpenWork's `resources/sidecars` directory; do not assume an unrelated `opencode` on `PATH` is the same binary. If multiple OpenWork builds are running, use the process associated with this task when that can be established safely; otherwise report the ambiguity.
+5. Find OpenWork's generated `runtime-opencode-config.json` beside the active `server.json`. Respect discovered `OPENWORK_SERVER_CONFIG`, `OPENWORK_RUNTIME_DB`, or XDG overrides. Typical locations are:
+   - Windows: `%APPDATA%\openwork\runtime-opencode-config.json`
+   - macOS/Linux: `${XDG_CONFIG_HOME:-$HOME/.config}/openwork/runtime-opencode-config.json`
+6. Report whether the runtime config exists and its last-modified time. Never display, copy, parse, or summarize its contents: it can contain Authorization headers and other credentials.
+
+## Phase 3 — Run a safe fresh-process probe
+
+7. From this task's workspace root, set `OPENCODE_CONFIG` to the discovered runtime config for the subprocess only, then run:
+   - `<exact-opencode-executable> --version`
+   - `<exact-opencode-executable> mcp list`
+8. Do not run `mcp add`, `mcp auth`, `mcp logout`, `debug config`, or any command that changes or prints configuration. Do not use `--print-logs` if it could expose headers or tokens.
+9. Report:
+   - operating system
+   - exact OpenCode executable path and version
+   - runtime config path, existence, and last-modified time
+   - whether `openwork-cloud` is listed
+   - its exact status and non-secret error
+   - whether the failing workspace is the primary managed workspace or may be a secondary workspace configured dynamically
+
+Important: `opencode mcp list` starts a fresh process. Do not claim that it attaches to or tests the OpenCode server already running inside OpenWork. Describe it only as a fresh-process probe using the same binary and generated config.
+
+## Phase 4 — Classify the result
+
+- Fresh probe omits `openwork-cloud`: the generated config is missing, the wrong runtime config was selected, or this is a secondary workspace whose MCPs are registered dynamically.
+- Fresh probe reports `failed` or `needs_auth`: preserve the exact non-secret error; investigate token, endpoint, TLS, or authentication.
+- Fresh probe reports `connected`, but Phase 1 rejects the Cloud tool: the stored endpoint and token work, but the live desktop engine or task has stale/missing tool registration.
+- Both Phase 1 calls are rejected: investigate whether the running engine loaded the injected config and plugins, plus project/global tool-deny policy.
+- The forced Cloud call works, but a natural request chooses documentation: tool exposure is healthy; investigate system-prompt steering.
+
+Finish with a concise redacted report. Never reveal bearer tokens, Authorization values, cookies, passwords, API keys, local server tokens, or strings beginning with `ow_mcp_at_`.
+````
+
+**Verify inside OpenWork**
+
+1. In the affected workspace, open **Settings → Extensions** and click **Refresh**.
+2. Click **Show hidden**, then find **OpenWork Cloud Control** under **Your apps**. This row shows live OpenCode MCP status; the catalog card only proves that the entry is configured.
+3. Expand the row and retain its status and non-secret error: **Ready**, **Issue**, **Sign in needed**, **Offline**, or **Paused**.
+4. Return to the task, open the command palette, run **Reload OpenCode config**, and create a new task in the same workspace.
+5. Repeat the forced Cloud tool call from Phase 1.
+
+**How to interpret both results**
+
+| Fresh `opencode mcp list` | OpenWork status / forced call | Likely boundary |
+| --- | --- | --- |
+| Missing or failed | Missing or failed | Generated config, endpoint, token, TLS, or authentication |
+| Connected | In-app status failed | Live engine registration or workspace routing |
+| Connected | In-app Ready, forced call rejected | Stale task tool snapshot or engine compatibility |
+| Connected | Forced call succeeds, natural request uses docs | Agent steering rather than MCP exposure |


### PR DESCRIPTION
## What changed

- add a cross-platform troubleshooting prompt for cases where OpenWork Cloud is configured but its MCP tools are missing from an agent task
- distinguish a fresh bundled-OpenCode `mcp list` probe from the live desktop engine and task tool snapshot
- document in-app Extension refresh, hidden Cloud Control status, OpenCode config reload, and forced-tool verification
- add a result matrix for config/auth, workspace routing, engine registration, stale task snapshots, and prompt steering
- harden the existing diagnostic so it never prints credential-bearing bootstrap fields
- clarify that Cloud MCP may use either a direct API endpoint or the web app's `/api/den` proxy

## Why

A connected service can appear ready in OpenWork while an agent falls back to product documentation because the Cloud MCP tools were not registered in that task. The diagnostic gathers enough redacted evidence to identify which boundary failed without assuming that a standalone CLI process is the running desktop engine.

## User impact

Users and support engineers get one pasteable prompt that works across Windows, macOS, and Linux, plus a short in-app verification flow and interpretation table.

## Validation

- `git diff --check`
- MDX frontmatter and four-backtick fence balance
- trailing-whitespace scan
- credential-pattern scan
- confirmed the page is already registered in `packages/docs/docs.json`

Fraimz was not run because this is a documentation-only change with no runtime path.