### PR TITLE
feat(den): make MCP connections editable

### DIFF
--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
@@ -21,7 +21,10 @@ import {
 import { z } from "zod"
 import { db } from "../db.js"
 import type { ExternalMcpMemberContext } from "./external-mcp-client.js"
-import type { ExternalMcpConnectionRow } from "./external-mcp-connections.js"
+import {
+  externalMcpIdentityBinding,
+  type ExternalMcpConnectionRow,
+} from "./external-mcp-connections.js"
 
 const MAX_PENDING_AUTHORIZATIONS = 8
 
@@ -118,10 +121,12 @@ function restoredClientInformation(input: {
 
 export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersistence {
   private connection: ExternalMcpConnectionRow
+  private readonly identityBinding: string
   private readonly member?: ExternalMcpMemberContext
 
   constructor(connection: ExternalMcpConnectionRow, member?: ExternalMcpMemberContext) {
     this.connection = connection
+    this.identityBinding = externalMcpIdentityBinding(connection)
     this.member = member
     if (connection.credentialMode === "per_member" && !member) {
       throw new Error(`Connection "${connection.id}" uses per-member credentials; a member context is required.`)
@@ -130,6 +135,12 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
 
   private get isPerMember(): boolean {
     return this.connection.credentialMode === "per_member"
+  }
+
+  private assertCurrentIdentity(connection: ExternalMcpConnectionRow): void {
+    if (externalMcpIdentityBinding(connection) !== this.identityBinding) {
+      throw new Error("The enterprise MCP connection identity changed before credentials could be persisted.")
+    }
   }
 
   private async refreshConnection(): Promise<void> {
@@ -142,6 +153,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
       ))
       .limit(1)
     if (!rows[0]) throw new Error("The enterprise MCP connection no longer exists.")
+    this.assertCurrentIdentity(rows[0])
     this.connection = rows[0]
   }
 
@@ -162,6 +174,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
   readonly clientRegistrations = {
     load: async (context: EnterpriseMcpPersistenceContext): Promise<EnterpriseMcpOAuthClientRegistration | undefined> => {
       assertCommitActive(context)
+      await this.refreshConnection()
       const rows = await db
         .select()
         .from(OrgOAuthClientTable)
@@ -189,7 +202,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
     }): Promise<EnterpriseMcpOAuthClientRegistration> => {
       const row = await db.transaction(async (tx) => {
         const connections = await tx
-          .select({ id: ExternalMcpConnectionTable.id })
+          .select()
           .from(ExternalMcpConnectionTable)
           .where(and(
             eq(ExternalMcpConnectionTable.id, this.connection.id),
@@ -198,6 +211,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
           .limit(1)
           .for("update")
         if (!connections[0]) throw new Error("The enterprise MCP connection no longer exists.")
+        this.assertCurrentIdentity(connections[0])
         assertCommitActive(input.context)
         const existing = await tx
           .select()
@@ -243,13 +257,26 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
       context: EnterpriseMcpPersistenceContext
       reason: "expired" | "provider-rejected"
     }): Promise<void> => {
-      assertCommitActive(input.context)
-      await db
-        .delete(OrgOAuthClientTable)
-        .where(and(
-          eq(OrgOAuthClientTable.organizationId, this.connection.organizationId),
-          eq(OrgOAuthClientTable.providerId, this.connection.id),
-        ))
+      await db.transaction(async (tx) => {
+        const connections = await tx
+          .select()
+          .from(ExternalMcpConnectionTable)
+          .where(and(
+            eq(ExternalMcpConnectionTable.id, this.connection.id),
+            eq(ExternalMcpConnectionTable.organizationId, this.connection.organizationId),
+          ))
+          .limit(1)
+          .for("update")
+        if (!connections[0]) return
+        this.assertCurrentIdentity(connections[0])
+        assertCommitActive(input.context)
+        await tx
+          .delete(OrgOAuthClientTable)
+          .where(and(
+            eq(OrgOAuthClientTable.organizationId, this.connection.organizationId),
+            eq(OrgOAuthClientTable.providerId, this.connection.id),
+          ))
+      })
     },
   }
 
@@ -273,6 +300,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
           .for("update")
         const connection = connections[0]
         if (!connection) throw new Error("The enterprise MCP connection no longer exists.")
+        this.assertCurrentIdentity(connection)
         assertCommitActive(input.context)
         const account = this.member
           ? (await tx
@@ -408,6 +436,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
           .for("update")
         const connection = connections[0]
         if (!connection) throw new Error("The enterprise MCP connection no longer exists.")
+        this.assertCurrentIdentity(connection)
         assertCommitActive(input.context)
         const account = this.member
           ? (await tx
@@ -515,6 +544,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
           .for("update")
         const connection = connections[0]
         if (!connection) return
+        this.assertCurrentIdentity(connection)
         assertCommitActive(input.context)
         if (this.isPerMember && this.member) {
           await tx
@@ -557,6 +587,7 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
         .for("update")
       const connection = connections[0]
       if (!connection) return
+      this.assertCurrentIdentity(connection)
       assertCommitActive(context)
       const account = this.member
         ? (await tx

--- a/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
@@ -17,18 +17,16 @@ import type { RequestOptions } from "@modelcontextprotocol/sdk/shared/protocol.j
 import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import type { ExternalMcpConnectionRow } from "./external-mcp-connections.js"
 import {
-  clearExternalMcpTokens,
+  clearExternalMcpTokensForIdentity,
+  deleteOrgOAuthClientForExternalMcpIdentity,
   getExternalMcpConnection,
-  saveExternalMcpPendingCodeVerifier,
-  saveExternalMcpTokens,
+  readConnectedAccountForExternalMcpIdentity,
+  readOrgOAuthClientForExternalMcpIdentity,
+  saveExternalMcpPendingCodeVerifierForIdentity,
+  saveExternalMcpTokensForIdentity,
+  upsertConnectedAccountForExternalMcpIdentity,
+  upsertOrgOAuthClientForExternalMcpIdentity,
 } from "./external-mcp-connections.js"
-import {
-  deleteOrgOAuthClient,
-  getConnectedAccount,
-  getOrgOAuthClient,
-  upsertConnectedAccount,
-  upsertOrgOAuthClient,
-} from "./oauth-credentials.js"
 import {
   ExternalMcpDiagnosticError,
   ExternalMcpDiagnosticTracker,
@@ -208,11 +206,12 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
 
   private async memberAccount() {
     if (!this.member) return null
-    return getConnectedAccount({
-      organizationId: this.connection.organizationId,
+    const result = await readConnectedAccountForExternalMcpIdentity({
+      connection: this.connection,
       orgMembershipId: this.member.orgMembershipId,
-      providerId: this.connection.id,
     })
+    if (!result.current) throw new Error("The external MCP connection identity changed during authorization.")
+    return result.value
   }
 
   private assertLifecycleActive(phase: ExternalMcpDiagnosticPhase): void {
@@ -253,7 +252,9 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
 
   async clientInformation(): Promise<OAuthClientInformationMixed | undefined> {
     this.assertLifecycleActive("AUTH_CLIENT_REGISTRATION")
-    const client = await getOrgOAuthClient(this.connection.organizationId, this.connection.id)
+    const result = await readOrgOAuthClientForExternalMcpIdentity(this.connection)
+    if (!result.current) throw new Error("The external MCP connection identity changed during authorization.")
+    const client = result.value
     this.assertLifecycleActive("AUTH_CLIENT_REGISTRATION")
     if (!client) return undefined
     this.diagnostic.passed("AUTH_CLIENT_REGISTRATION", "reachable")
@@ -264,14 +265,13 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
 
   async saveClientInformation(clientInformation: OAuthClientInformationMixed): Promise<void> {
     this.assertLifecycleActive("AUTH_CLIENT_REGISTRATION")
-    await upsertOrgOAuthClient({
-      organizationId: this.connection.organizationId,
-      providerId: this.connection.id,
+    const saved = await upsertOrgOAuthClientForExternalMcpIdentity({
+      connection: this.connection,
       clientId: clientInformation.client_id,
       clientSecret: clientInformation.client_secret ?? null,
       extra: { clientInformation },
-      createdByOrgMembershipId: this.connection.createdByOrgMembershipId,
     })
+    if (!saved) throw new Error("The external MCP connection identity changed during client registration.")
     this.diagnostic.passed("AUTH_CLIENT_REGISTRATION", "reachable")
   }
 
@@ -302,30 +302,33 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
     if (this.isPerMember && this.member) {
       const existing = await this.memberAccount()
       this.assertLifecycleActive(this.diagnostic.activePhase === "CONTINUITY_REFRESH" ? "CONTINUITY_REFRESH" : "AUTH_TOKEN_ACQUISITION")
-      await upsertConnectedAccount({
-        organizationId: this.connection.organizationId,
+      const saved = await upsertConnectedAccountForExternalMcpIdentity({
+        connection: this.connection,
         orgMembershipId: this.member.orgMembershipId,
-        providerId: this.connection.id,
-        accessToken: tokens.access_token,
-        // Most providers omit refresh_token on refresh responses; keep the existing one.
-        refreshToken: tokens.refresh_token ?? existing?.refreshToken ?? null,
-        tokenType: tokens.token_type ?? null,
-        scopes: tokens.scope ? tokens.scope.split(" ") : null,
-        expiresAt,
-        pendingCodeVerifier: null,
+        changes: {
+          accessToken: tokens.access_token,
+          // Most providers omit refresh_token on refresh responses; keep the existing one.
+          refreshToken: tokens.refresh_token ?? existing?.refreshToken ?? null,
+          tokenType: tokens.token_type ?? null,
+          scopes: tokens.scope ? tokens.scope.split(" ") : null,
+          expiresAt,
+          pendingCodeVerifier: null,
+        },
       })
+      if (!saved) throw new Error("The external MCP connection identity changed during token persistence.")
       this.diagnostic.passed("AUTH_TOKEN_ACQUISITION")
       return
     }
     this.assertLifecycleActive(this.diagnostic.activePhase === "CONTINUITY_REFRESH" ? "CONTINUITY_REFRESH" : "AUTH_TOKEN_ACQUISITION")
-    await saveExternalMcpTokens({
-      connectionId: this.connection.id,
+    const saved = await saveExternalMcpTokensForIdentity({
+      connection: this.connection,
       accessToken: tokens.access_token,
       refreshToken: tokens.refresh_token ?? this.connection.refreshToken ?? null,
       tokenType: tokens.token_type ?? null,
       scope: tokens.scope ?? null,
       expiresAt,
     })
+    if (!saved) throw new Error("The external MCP connection identity changed during token persistence.")
     // Refresh the in-memory row so a subsequent tokens()/refresh in the same
     // connection attempt sees the just-saved values.
     const refreshed = await getExternalMcpConnection({
@@ -338,26 +341,27 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
 
   async invalidateCredentials(scope: "all" | "client" | "tokens" | "verifier" | "discovery"): Promise<void> {
     if (scope === "all" || scope === "client") {
-      await deleteOrgOAuthClient(this.connection.organizationId, this.connection.id)
+      const deleted = await deleteOrgOAuthClientForExternalMcpIdentity(this.connection)
+      if (!deleted) throw new Error("The external MCP connection identity changed during credential invalidation.")
     }
     if (scope === "all" || scope === "tokens") {
       if (this.isPerMember && this.member) {
-        await upsertConnectedAccount({
-          organizationId: this.connection.organizationId,
+        const cleared = await upsertConnectedAccountForExternalMcpIdentity({
+          connection: this.connection,
           orgMembershipId: this.member.orgMembershipId,
-          providerId: this.connection.id,
-          accessToken: null,
-          refreshToken: null,
-          tokenType: null,
-          scopes: null,
-          expiresAt: null,
-          ...(scope === "all" ? { pendingCodeVerifier: null } : {}),
+          changes: {
+            accessToken: null,
+            refreshToken: null,
+            tokenType: null,
+            scopes: null,
+            expiresAt: null,
+            ...(scope === "all" ? { pendingCodeVerifier: null } : {}),
+          },
         })
+        if (!cleared) throw new Error("The external MCP connection identity changed during credential invalidation.")
       } else {
-        await clearExternalMcpTokens({
-          organizationId: this.connection.organizationId,
-          connectionId: this.connection.id,
-        })
+        const cleared = await clearExternalMcpTokensForIdentity(this.connection)
+        if (!cleared) throw new Error("The external MCP connection identity changed during credential invalidation.")
         const refreshed = await getExternalMcpConnection({
           organizationId: this.connection.organizationId,
           connectionId: this.connection.id,
@@ -366,15 +370,16 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
       }
     }
     if ((scope === "all" || scope === "verifier") && !this.isPerMember) {
-      await saveExternalMcpPendingCodeVerifier({ connectionId: this.connection.id, codeVerifier: null })
+      const cleared = await saveExternalMcpPendingCodeVerifierForIdentity({ connection: this.connection, codeVerifier: null })
+      if (!cleared) throw new Error("The external MCP connection identity changed during verifier invalidation.")
     }
     if (scope === "verifier" && this.isPerMember && this.member) {
-      await upsertConnectedAccount({
-        organizationId: this.connection.organizationId,
+      const cleared = await upsertConnectedAccountForExternalMcpIdentity({
+        connection: this.connection,
         orgMembershipId: this.member.orgMembershipId,
-        providerId: this.connection.id,
-        pendingCodeVerifier: null,
+        changes: { pendingCodeVerifier: null },
       })
+      if (!cleared) throw new Error("The external MCP connection identity changed during verifier invalidation.")
     }
   }
 
@@ -386,15 +391,16 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
     this.assertLifecycleActive("AUTH_USER_OR_WORKLOAD")
     if (this.isPerMember && this.member) {
-      await upsertConnectedAccount({
-        organizationId: this.connection.organizationId,
+      const saved = await upsertConnectedAccountForExternalMcpIdentity({
+        connection: this.connection,
         orgMembershipId: this.member.orgMembershipId,
-        providerId: this.connection.id,
-        pendingCodeVerifier: codeVerifier,
+        changes: { pendingCodeVerifier: codeVerifier },
       })
+      if (!saved) throw new Error("The external MCP connection identity changed during verifier persistence.")
       return
     }
-    await saveExternalMcpPendingCodeVerifier({ connectionId: this.connection.id, codeVerifier })
+    const saved = await saveExternalMcpPendingCodeVerifierForIdentity({ connection: this.connection, codeVerifier })
+    if (!saved) throw new Error("The external MCP connection identity changed during verifier persistence.")
   }
 
   async codeVerifier(): Promise<string> {

--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { and, desc, eq, inArray, isNull, or } from "@openwork-ee/den-db/drizzle"
 import {
   ConnectedAccountTable,
@@ -27,6 +28,11 @@ import { db } from "../db.js"
 
 export type ExternalMcpConnectionRow = typeof ExternalMcpConnectionTable.$inferSelect
 export type ExternalMcpConnectionAccessGrantRow = typeof ExternalMcpConnectionAccessGrantTable.$inferSelect
+export type ActiveExternalMcpConnectionBinding = {
+  connectionId: DenTypeId<"externalMcpConnection">
+  pluginId: DenTypeId<"plugin">
+  pluginName: string
+}
 
 type OrganizationId = DenTypeId<"organization">
 type OrgMembershipId = DenTypeId<"member">
@@ -77,7 +83,7 @@ function marketplaceMcpServerEntries(spec: Record<string, unknown>, fallbackName
   return entries
 }
 
-function comparablePluginMcpRequirementUrl(value: string): string {
+export function normalizeExternalMcpIdentityUrl(value: string): string {
   try {
     const url = new URL(value.trim())
     url.hash = ""
@@ -86,6 +92,19 @@ function comparablePluginMcpRequirementUrl(value: string): string {
   } catch {
     return value.trim().replace(/\/+$/, "")
   }
+}
+
+/** A non-secret, one-way binding for OAuth state minted for this identity. */
+export function externalMcpIdentityBinding(
+  connection: Pick<ExternalMcpConnectionRow, "url" | "authType" | "credentialMode">,
+): string {
+  return createHash("sha256")
+    .update(JSON.stringify([
+      normalizeExternalMcpIdentityUrl(connection.url),
+      connection.authType,
+      connection.credentialMode,
+    ]))
+    .digest("base64url")
 }
 
 async function latestConfigObjectVersions(input: {
@@ -320,7 +339,7 @@ async function sourcedUsableExternalMcpConnections(input: {
       .find((candidate) => candidate.name === row.binding.serverName)
     const declaredUrl = readString(entry?.config.url)
     if (!declaredUrl) return []
-    return comparablePluginMcpRequirementUrl(row.connection.url) === comparablePluginMcpRequirementUrl(declaredUrl)
+    return normalizeExternalMcpIdentityUrl(row.connection.url) === normalizeExternalMcpIdentityUrl(declaredUrl)
       ? [row.connection]
       : []
   })
@@ -346,6 +365,28 @@ export async function getExternalMcpConnection(input: {
     ))
     .limit(1)
   return rows[0] ?? null
+}
+
+export async function listActiveExternalMcpConnectionBindings(input: {
+  organizationId: OrganizationId
+  connectionIds: ExternalMcpConnectionId[]
+}): Promise<ActiveExternalMcpConnectionBinding[]> {
+  if (input.connectionIds.length === 0) return []
+  return db
+    .select({
+      connectionId: PluginMcpRequirementBindingTable.externalMcpConnectionId,
+      pluginId: PluginTable.id,
+      pluginName: PluginTable.name,
+    })
+    .from(PluginMcpRequirementBindingTable)
+    .innerJoin(PluginTable, eq(PluginMcpRequirementBindingTable.pluginId, PluginTable.id))
+    .where(and(
+      eq(PluginMcpRequirementBindingTable.organizationId, input.organizationId),
+      inArray(PluginMcpRequirementBindingTable.externalMcpConnectionId, input.connectionIds),
+      eq(PluginTable.organizationId, input.organizationId),
+      eq(PluginTable.status, "active"),
+      isNull(PluginTable.deletedAt),
+    ))
 }
 
 export type ExternalMcpAccessInput = {
@@ -386,19 +427,29 @@ export async function createExternalMcpConnection(input: {
   return created
 }
 
-export async function listExternalMcpConnectionAccess(connectionId: ExternalMcpConnectionId): Promise<ExternalMcpConnectionAccessGrantRow[]> {
-  return db
-    .select()
-    .from(ExternalMcpConnectionAccessGrantTable)
-    .where(eq(ExternalMcpConnectionAccessGrantTable.externalMcpConnectionId, connectionId))
-}
-
-async function listDirectExternalMcpConnectionAccess(connectionId: ExternalMcpConnectionId): Promise<ExternalMcpConnectionAccessGrantRow[]> {
+export async function listExternalMcpConnectionAccess(input: {
+  organizationId: OrganizationId
+  connectionId: ExternalMcpConnectionId
+}): Promise<ExternalMcpConnectionAccessGrantRow[]> {
   return db
     .select()
     .from(ExternalMcpConnectionAccessGrantTable)
     .where(and(
-      eq(ExternalMcpConnectionAccessGrantTable.externalMcpConnectionId, connectionId),
+      eq(ExternalMcpConnectionAccessGrantTable.organizationId, input.organizationId),
+      eq(ExternalMcpConnectionAccessGrantTable.externalMcpConnectionId, input.connectionId),
+    ))
+}
+
+export async function listDirectExternalMcpConnectionAccess(input: {
+  organizationId: OrganizationId
+  connectionId: ExternalMcpConnectionId
+}): Promise<ExternalMcpConnectionAccessGrantRow[]> {
+  return db
+    .select()
+    .from(ExternalMcpConnectionAccessGrantTable)
+    .where(and(
+      eq(ExternalMcpConnectionAccessGrantTable.organizationId, input.organizationId),
+      eq(ExternalMcpConnectionAccessGrantTable.externalMcpConnectionId, input.connectionId),
       isNull(ExternalMcpConnectionAccessGrantTable.pluginMcpRequirementBindingId),
     ))
 }
@@ -493,7 +544,7 @@ export async function mergeExternalMcpConnectionAccess(input: {
   access: ExternalMcpAccessInput
   createdByOrgMembershipId: OrgMembershipId
 }): Promise<void> {
-  const existing = await listDirectExternalMcpConnectionAccess(input.connectionId)
+  const existing = await listDirectExternalMcpConnectionAccess(input)
   const rows: (typeof ExternalMcpConnectionAccessGrantTable.$inferInsert)[] = []
 
   if (input.access.orgWide) {
@@ -534,6 +585,271 @@ export async function mergeExternalMcpConnectionAccess(input: {
   if (rows.length > 0) {
     await db.insert(ExternalMcpConnectionAccessGrantTable).values(rows)
   }
+}
+
+function directAccessKeys(rows: ExternalMcpConnectionAccessGrantRow[]): Set<string> {
+  return new Set(rows.flatMap((row) => {
+    if (row.orgWide) return ["org"]
+    if (row.orgMembershipId) return [`member:${row.orgMembershipId}`]
+    if (row.teamId) return [`team:${row.teamId}`]
+    return []
+  }))
+}
+
+function requestedAccessKeys(access: ExternalMcpAccessInput): Set<string> {
+  if (access.orgWide) return new Set(["org"])
+  return new Set([
+    ...access.memberIds.map((id) => `member:${id}`),
+    ...access.teamIds.map((id) => `team:${id}`),
+  ])
+}
+
+function sameAccess(rows: ExternalMcpConnectionAccessGrantRow[], access: ExternalMcpAccessInput): boolean {
+  const current = directAccessKeys(rows)
+  const requested = requestedAccessKeys(access)
+  return rows.length === current.size
+    && current.size === requested.size
+    && [...current].every((key) => requested.has(key))
+}
+
+export type UpdateExternalMcpConnectionInput = {
+  organizationId: OrganizationId
+  connectionId: ExternalMcpConnectionId
+  expectedUpdatedAt: Date
+  name: string
+  url: string
+  authType: "oauth" | "apikey" | "none"
+  credentialMode: "shared" | "per_member"
+  apiKey?: string
+  oauthClient?: {
+    clientId: string
+    clientSecret?: string
+  }
+  access: ExternalMcpAccessInput
+  updatedByOrgMembershipId: OrgMembershipId
+  validatedAt?: Date
+}
+
+export type UpdateExternalMcpConnectionResult =
+  | { status: "not_found" }
+  | { status: "conflict" }
+  | { status: "marketplace_managed" }
+  | {
+    status: "updated"
+    connection: ExternalMcpConnectionRow
+    identityChanged: boolean
+    reconnectionRequired: boolean
+  }
+
+/**
+ * Atomically updates one tenant-scoped connection. The connection-row lock is
+ * shared with enterprise OAuth persistence, so credential writes and identity
+ * replacement have a deterministic winner. Direct grants are replaced without
+ * touching marketplace-derived grants.
+ */
+export async function updateExternalMcpConnection(
+  input: UpdateExternalMcpConnectionInput,
+): Promise<UpdateExternalMcpConnectionResult> {
+  return db.transaction(async (tx) => {
+    const rows = await tx
+      .select()
+      .from(ExternalMcpConnectionTable)
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionTable.id, input.connectionId),
+      ))
+      .limit(1)
+      .for("update")
+    const existing = rows[0]
+    if (!existing) return { status: "not_found" }
+    if (existing.updatedAt.getTime() !== input.expectedUpdatedAt.getTime()) {
+      return { status: "conflict" }
+    }
+
+    const activeBindings = await tx
+      .select({ id: PluginMcpRequirementBindingTable.id })
+      .from(PluginMcpRequirementBindingTable)
+      .innerJoin(PluginTable, eq(PluginMcpRequirementBindingTable.pluginId, PluginTable.id))
+      .where(and(
+        eq(PluginMcpRequirementBindingTable.organizationId, input.organizationId),
+        eq(PluginMcpRequirementBindingTable.externalMcpConnectionId, input.connectionId),
+        eq(PluginTable.organizationId, input.organizationId),
+        eq(PluginTable.status, "active"),
+        isNull(PluginTable.deletedAt),
+      ))
+      .for("update")
+    const marketplaceOwnedFieldsChanged = existing.url !== input.url
+      || existing.authType !== input.authType
+      || existing.credentialMode !== input.credentialMode
+      || input.apiKey !== undefined
+      || input.oauthClient !== undefined
+    if (activeBindings.length > 0 && marketplaceOwnedFieldsChanged) {
+      return { status: "marketplace_managed" }
+    }
+
+    const identityChanged = normalizeExternalMcpIdentityUrl(existing.url) !== normalizeExternalMcpIdentityUrl(input.url)
+      || existing.authType !== input.authType
+      || existing.credentialMode !== input.credentialMode
+    const directGrants = await tx
+      .select()
+      .from(ExternalMcpConnectionAccessGrantTable)
+      .where(and(
+        eq(ExternalMcpConnectionAccessGrantTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionAccessGrantTable.externalMcpConnectionId, input.connectionId),
+        isNull(ExternalMcpConnectionAccessGrantTable.pluginMcpRequirementBindingId),
+      ))
+      .for("update")
+    const accessChanged = !sameAccess(directGrants, input.access)
+
+    const clientRows = await tx
+      .select()
+      .from(OrgOAuthClientTable)
+      .where(and(
+        eq(OrgOAuthClientTable.organizationId, input.organizationId),
+        eq(OrgOAuthClientTable.providerId, input.connectionId),
+      ))
+      .limit(1)
+      .for("update")
+    const existingClient = clientRows[0]
+    const clientIdChanged = Boolean(input.oauthClient && existingClient?.clientId !== input.oauthClient.clientId)
+    const clientSecretChanged = Boolean(
+      input.oauthClient?.clientSecret !== undefined
+      && existingClient?.clientSecret !== input.oauthClient.clientSecret,
+    )
+    const oauthClientChanged = identityChanged
+      ? Boolean(existingClient || input.oauthClient)
+      : Boolean(input.oauthClient && (!existingClient || clientIdChanged || clientSecretChanged))
+    const apiKeyChanged = input.apiKey !== undefined && existing.apiKey !== input.apiKey
+    const rowFieldsChanged = existing.name !== input.name
+      || existing.url !== input.url
+      || existing.authType !== input.authType
+      || existing.credentialMode !== input.credentialMode
+      || apiKeyChanged
+      || identityChanged
+    const changed = rowFieldsChanged || accessChanged || oauthClientChanged
+
+    if (!changed) {
+      return {
+        status: "updated",
+        connection: existing,
+        identityChanged: false,
+        reconnectionRequired: false,
+      }
+    }
+
+    const changedAt = new Date(Math.max(Date.now(), existing.updatedAt.getTime() + 1))
+    if (identityChanged) {
+      await tx.delete(ConnectedAccountTable).where(and(
+        eq(ConnectedAccountTable.organizationId, input.organizationId),
+        eq(ConnectedAccountTable.providerId, input.connectionId),
+      ))
+      await tx.delete(OrgOAuthClientTable).where(and(
+        eq(OrgOAuthClientTable.organizationId, input.organizationId),
+        eq(OrgOAuthClientTable.providerId, input.connectionId),
+      ))
+      await tx
+        .update(ExternalMcpConnectionTable)
+        .set({
+          name: input.name,
+          url: input.url,
+          authType: input.authType,
+          credentialMode: input.credentialMode,
+          apiKey: input.authType === "apikey" ? input.apiKey ?? null : null,
+          accessToken: null,
+          refreshToken: null,
+          tokenType: null,
+          scope: null,
+          expiresAt: null,
+          pendingCodeVerifier: null,
+          connectedAt: input.authType === "none" ? input.validatedAt ?? changedAt : null,
+          updatedAt: changedAt,
+        })
+        .where(and(
+          eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+          eq(ExternalMcpConnectionTable.id, input.connectionId),
+        ))
+    } else {
+      await tx
+        .update(ExternalMcpConnectionTable)
+        .set({
+          name: input.name,
+          url: input.url,
+          authType: input.authType,
+          credentialMode: input.credentialMode,
+          ...(input.apiKey !== undefined ? { apiKey: input.apiKey } : {}),
+          ...(input.authType === "none" && input.validatedAt ? { connectedAt: input.validatedAt } : {}),
+          updatedAt: changedAt,
+        })
+        .where(and(
+          eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+          eq(ExternalMcpConnectionTable.id, input.connectionId),
+        ))
+    }
+
+    if (accessChanged) {
+      await tx.delete(ExternalMcpConnectionAccessGrantTable).where(and(
+        eq(ExternalMcpConnectionAccessGrantTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionAccessGrantTable.externalMcpConnectionId, input.connectionId),
+        isNull(ExternalMcpConnectionAccessGrantTable.pluginMcpRequirementBindingId),
+      ))
+      const grantRows = accessGrantRows({
+        organizationId: input.organizationId,
+        connectionId: input.connectionId,
+        access: input.access,
+        createdByOrgMembershipId: input.updatedByOrgMembershipId,
+      })
+      if (grantRows.length > 0) {
+        await tx.insert(ExternalMcpConnectionAccessGrantTable).values(grantRows)
+      }
+    }
+
+    if (input.authType === "oauth" && input.oauthClient) {
+      if (identityChanged || !existingClient) {
+        await tx.insert(OrgOAuthClientTable).values({
+          id: createDenTypeId("orgOAuthClient"),
+          organizationId: input.organizationId,
+          providerId: input.connectionId,
+          clientId: input.oauthClient.clientId,
+          clientSecret: input.oauthClient.clientSecret ?? null,
+          extra: null,
+          createdByOrgMembershipId: input.updatedByOrgMembershipId,
+        })
+      } else if (oauthClientChanged) {
+        await tx
+          .update(OrgOAuthClientTable)
+          .set({
+            clientId: input.oauthClient.clientId,
+            ...(input.oauthClient.clientSecret !== undefined
+              ? { clientSecret: input.oauthClient.clientSecret }
+              : clientIdChanged
+                ? { clientSecret: null }
+                : {}),
+            ...(clientIdChanged ? { extra: null } : {}),
+          })
+          .where(and(
+            eq(OrgOAuthClientTable.organizationId, input.organizationId),
+            eq(OrgOAuthClientTable.id, existingClient.id),
+          ))
+      }
+    }
+
+    const updatedRows = await tx
+      .select()
+      .from(ExternalMcpConnectionTable)
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionTable.id, input.connectionId),
+      ))
+      .limit(1)
+    const updated = updatedRows[0]
+    if (!updated) throw new Error("External MCP connection disappeared during update.")
+    return {
+      status: "updated",
+      connection: updated,
+      identityChanged,
+      reconnectionRequired: identityChanged && input.authType === "oauth",
+    }
+  })
 }
 
 /**
@@ -610,6 +926,264 @@ export async function deleteExternalMcpConnection(input: {
       eq(PluginMcpRequirementBindingTable.externalMcpConnectionId, existing.id),
     ))
     await tx.delete(ExternalMcpConnectionTable).where(eq(ExternalMcpConnectionTable.id, existing.id))
+    return true
+  })
+}
+
+type ExternalMcpIdentityRead<TValue> =
+  | { current: false }
+  | { current: true; value: TValue | null }
+
+type ExternalMcpTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0]
+
+function sameExternalMcpIdentity(
+  current: ExternalMcpConnectionRow,
+  expected: ExternalMcpConnectionRow,
+): boolean {
+  return current.id === expected.id
+    && current.organizationId === expected.organizationId
+    && normalizeExternalMcpIdentityUrl(current.url) === normalizeExternalMcpIdentityUrl(expected.url)
+    && current.authType === expected.authType
+    && current.credentialMode === expected.credentialMode
+}
+
+async function lockExternalMcpIdentity(
+  tx: ExternalMcpTransaction,
+  expected: ExternalMcpConnectionRow,
+): Promise<ExternalMcpConnectionRow | null> {
+  const rows = await tx
+    .select()
+    .from(ExternalMcpConnectionTable)
+    .where(and(
+      eq(ExternalMcpConnectionTable.organizationId, expected.organizationId),
+      eq(ExternalMcpConnectionTable.id, expected.id),
+    ))
+    .limit(1)
+    .for("update")
+  const current = rows[0]
+  return current && sameExternalMcpIdentity(current, expected) ? current : null
+}
+
+export async function readOrgOAuthClientForExternalMcpIdentity(
+  connection: ExternalMcpConnectionRow,
+): Promise<ExternalMcpIdentityRead<typeof OrgOAuthClientTable.$inferSelect>> {
+  return db.transaction(async (tx) => {
+    if (!await lockExternalMcpIdentity(tx, connection)) return { current: false }
+    const rows = await tx
+      .select()
+      .from(OrgOAuthClientTable)
+      .where(and(
+        eq(OrgOAuthClientTable.organizationId, connection.organizationId),
+        eq(OrgOAuthClientTable.providerId, connection.id),
+      ))
+      .limit(1)
+    return { current: true, value: rows[0] ?? null }
+  })
+}
+
+export async function upsertOrgOAuthClientForExternalMcpIdentity(input: {
+  connection: ExternalMcpConnectionRow
+  clientId: string
+  clientSecret?: string | null
+  extra?: Record<string, unknown> | null
+}): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    if (!await lockExternalMcpIdentity(tx, input.connection)) return false
+    const rows = await tx
+      .select()
+      .from(OrgOAuthClientTable)
+      .where(and(
+        eq(OrgOAuthClientTable.organizationId, input.connection.organizationId),
+        eq(OrgOAuthClientTable.providerId, input.connection.id),
+      ))
+      .limit(1)
+      .for("update")
+    const existing = rows[0]
+    if (existing) {
+      await tx
+        .update(OrgOAuthClientTable)
+        .set({
+          clientId: input.clientId,
+          ...(input.clientSecret !== undefined ? { clientSecret: input.clientSecret } : {}),
+          ...(input.extra !== undefined ? { extra: input.extra } : {}),
+        })
+        .where(eq(OrgOAuthClientTable.id, existing.id))
+      return true
+    }
+    await tx.insert(OrgOAuthClientTable).values({
+      id: createDenTypeId("orgOAuthClient"),
+      organizationId: input.connection.organizationId,
+      providerId: input.connection.id,
+      clientId: input.clientId,
+      clientSecret: input.clientSecret ?? null,
+      extra: input.extra ?? null,
+      createdByOrgMembershipId: input.connection.createdByOrgMembershipId,
+    })
+    return true
+  })
+}
+
+export async function deleteOrgOAuthClientForExternalMcpIdentity(
+  connection: ExternalMcpConnectionRow,
+): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    if (!await lockExternalMcpIdentity(tx, connection)) return false
+    await tx.delete(OrgOAuthClientTable).where(and(
+      eq(OrgOAuthClientTable.organizationId, connection.organizationId),
+      eq(OrgOAuthClientTable.providerId, connection.id),
+    ))
+    return true
+  })
+}
+
+export type ExternalMcpConnectedAccountChanges = {
+  externalAccountId?: string | null
+  scopes?: string[] | null
+  accessToken?: string | null
+  refreshToken?: string | null
+  tokenType?: string | null
+  expiresAt?: Date | null
+  pendingCodeVerifier?: string | null
+}
+
+function connectedAccountChanges(input: ExternalMcpConnectedAccountChanges) {
+  return {
+    ...(input.externalAccountId !== undefined ? { externalAccountId: input.externalAccountId } : {}),
+    ...(input.scopes !== undefined ? { scopes: input.scopes } : {}),
+    ...(input.accessToken !== undefined ? { accessToken: input.accessToken } : {}),
+    ...(input.refreshToken !== undefined ? { refreshToken: input.refreshToken } : {}),
+    ...(input.tokenType !== undefined ? { tokenType: input.tokenType } : {}),
+    ...(input.expiresAt !== undefined ? { expiresAt: input.expiresAt } : {}),
+    ...(input.pendingCodeVerifier !== undefined ? { pendingCodeVerifier: input.pendingCodeVerifier } : {}),
+  }
+}
+
+export async function readConnectedAccountForExternalMcpIdentity(input: {
+  connection: ExternalMcpConnectionRow
+  orgMembershipId: OrgMembershipId
+}): Promise<ExternalMcpIdentityRead<typeof ConnectedAccountTable.$inferSelect>> {
+  return db.transaction(async (tx) => {
+    if (!await lockExternalMcpIdentity(tx, input.connection)) return { current: false }
+    const rows = await tx
+      .select()
+      .from(ConnectedAccountTable)
+      .where(and(
+        eq(ConnectedAccountTable.organizationId, input.connection.organizationId),
+        eq(ConnectedAccountTable.orgMembershipId, input.orgMembershipId),
+        eq(ConnectedAccountTable.providerId, input.connection.id),
+      ))
+      .limit(1)
+    return { current: true, value: rows[0] ?? null }
+  })
+}
+
+export async function upsertConnectedAccountForExternalMcpIdentity(input: {
+  connection: ExternalMcpConnectionRow
+  orgMembershipId: OrgMembershipId
+  changes: ExternalMcpConnectedAccountChanges
+}): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    if (!await lockExternalMcpIdentity(tx, input.connection)) return false
+    const rows = await tx
+      .select()
+      .from(ConnectedAccountTable)
+      .where(and(
+        eq(ConnectedAccountTable.organizationId, input.connection.organizationId),
+        eq(ConnectedAccountTable.orgMembershipId, input.orgMembershipId),
+        eq(ConnectedAccountTable.providerId, input.connection.id),
+      ))
+      .limit(1)
+      .for("update")
+    const existing = rows[0]
+    if (existing) {
+      await tx
+        .update(ConnectedAccountTable)
+        .set(connectedAccountChanges(input.changes))
+        .where(eq(ConnectedAccountTable.id, existing.id))
+      return true
+    }
+    await tx.insert(ConnectedAccountTable).values({
+      id: createDenTypeId("connectedAccount"),
+      organizationId: input.connection.organizationId,
+      orgMembershipId: input.orgMembershipId,
+      providerId: input.connection.id,
+      externalAccountId: input.changes.externalAccountId ?? null,
+      scopes: input.changes.scopes ?? null,
+      accessToken: input.changes.accessToken ?? null,
+      refreshToken: input.changes.refreshToken ?? null,
+      tokenType: input.changes.tokenType ?? null,
+      expiresAt: input.changes.expiresAt ?? null,
+      pendingCodeVerifier: input.changes.pendingCodeVerifier ?? null,
+    })
+    return true
+  })
+}
+
+export async function saveExternalMcpPendingCodeVerifierForIdentity(input: {
+  connection: ExternalMcpConnectionRow
+  codeVerifier: string | null
+}): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    if (!await lockExternalMcpIdentity(tx, input.connection)) return false
+    await tx
+      .update(ExternalMcpConnectionTable)
+      .set({ pendingCodeVerifier: input.codeVerifier })
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.connection.organizationId),
+        eq(ExternalMcpConnectionTable.id, input.connection.id),
+      ))
+    return true
+  })
+}
+
+export async function saveExternalMcpTokensForIdentity(input: {
+  connection: ExternalMcpConnectionRow
+  accessToken: string
+  refreshToken?: string | null
+  tokenType?: string | null
+  scope?: string | null
+  expiresAt?: Date | null
+}): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    if (!await lockExternalMcpIdentity(tx, input.connection)) return false
+    await tx
+      .update(ExternalMcpConnectionTable)
+      .set({
+        accessToken: input.accessToken,
+        ...(input.refreshToken !== undefined ? { refreshToken: input.refreshToken } : {}),
+        ...(input.tokenType !== undefined ? { tokenType: input.tokenType } : {}),
+        ...(input.scope !== undefined ? { scope: input.scope } : {}),
+        ...(input.expiresAt !== undefined ? { expiresAt: input.expiresAt } : {}),
+        pendingCodeVerifier: null,
+        connectedAt: new Date(),
+      })
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.connection.organizationId),
+        eq(ExternalMcpConnectionTable.id, input.connection.id),
+      ))
+    return true
+  })
+}
+
+export async function clearExternalMcpTokensForIdentity(
+  connection: ExternalMcpConnectionRow,
+): Promise<boolean> {
+  return db.transaction(async (tx) => {
+    if (!await lockExternalMcpIdentity(tx, connection)) return false
+    await tx
+      .update(ExternalMcpConnectionTable)
+      .set({
+        accessToken: null,
+        refreshToken: null,
+        tokenType: null,
+        scope: null,
+        expiresAt: null,
+        connectedAt: null,
+      })
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, connection.organizationId),
+        eq(ExternalMcpConnectionTable.id, connection.id),
+      ))
     return true
   })
 }

--- a/ee/apps/den-api/src/capability-sources/generic-oauth.ts
+++ b/ee/apps/den-api/src/capability-sources/generic-oauth.ts
@@ -62,6 +62,7 @@ type OAuthStatePayload = {
   organizationId: DenTypeId<"organization">
   orgMembershipId: DenTypeId<"member">
   providerId: string
+  binding?: string
   nonce: string
   exp: number
 }
@@ -70,6 +71,7 @@ export function createOAuthStateToken(input: {
   organizationId: DenTypeId<"organization">
   orgMembershipId: DenTypeId<"member">
   providerId: string
+  binding?: string
   secret: string
   ttlSeconds?: number
   now?: number
@@ -79,6 +81,7 @@ export function createOAuthStateToken(input: {
     organizationId: input.organizationId,
     orgMembershipId: input.orgMembershipId,
     providerId: input.providerId,
+    ...(input.binding ? { binding: input.binding } : {}),
     nonce: randomUUID(),
     exp: Math.floor(nowMs / 1000) + (input.ttlSeconds ?? 10 * 60),
   }
@@ -106,6 +109,7 @@ export function verifyOAuthStateToken(input: { token: string; secret: string; no
       typeof payload.organizationId !== "string"
       || typeof payload.orgMembershipId !== "string"
       || typeof payload.providerId !== "string"
+      || (payload.binding !== undefined && typeof payload.binding !== "string")
       || typeof payload.nonce !== "string"
       || typeof payload.exp !== "number"
       || payload.exp < nowSeconds

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -7,7 +7,6 @@ import {
   ConfigObjectTable,
   ConfigObjectVersionTable,
   PluginConfigObjectTable,
-  PluginMcpRequirementBindingTable,
   PluginTable,
 } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
@@ -35,19 +34,23 @@ import {
   createExternalMcpConnection,
   deleteExternalMcpConnection,
   disconnectExternalMcpConnection,
+  externalMcpIdentityBinding,
   getExternalMcpConnection,
-  listExternalMcpConnectionAccess,
+  listActiveExternalMcpConnectionBindings,
+  listDirectExternalMcpConnectionAccess,
   listExternalMcpConnections,
   listUsableExternalMcpConnections,
   markExternalMcpConnectionConnected,
   memberCanUseExternalMcpConnection,
+  normalizeExternalMcpIdentityUrl,
   replaceExternalMcpConnectionAccess,
+  updateExternalMcpConnection,
   type ExternalMcpConnectionRow,
 } from "../../capability-sources/external-mcp-connections.js"
 import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
 import { listNativeProviderUsableEntries } from "../../capability-sources/native-provider-connections.js"
 import { connectCallbackPage } from "../../capability-sources/oauth-callback-page.js"
-import { getConnectedAccount, upsertOrgOAuthClient } from "../../capability-sources/oauth-credentials.js"
+import { getConnectedAccount, getOrgOAuthClient, upsertOrgOAuthClient } from "../../capability-sources/oauth-credentials.js"
 import { assertPublicUrl } from "../../capability-sources/url-guard.js"
 import type { MemberTeamSummary } from "../../orgs.js"
 import { EXTERNAL_MCP_PRESETS } from "../../capability-sources/external-mcp-presets.js"
@@ -122,6 +125,22 @@ const createConnectionBodySchema = z.object({
   access: accessInputSchema.optional().default({ orgWide: true, memberIds: [], teamIds: [] }),
 })
 
+const updateConnectionBodySchema = z.object({
+  expectedUpdatedAt: z.string().datetime(),
+  name: z.string().trim().min(1).max(255),
+  url: externalMcpUrlSchema,
+  authType: z.enum(["oauth", "apikey", "none"]),
+  credentialMode: z.enum(["shared", "per_member"]),
+  /** Omitted means preserve only when the connection identity is unchanged. Never returned by any read route. */
+  apiKey: z.string().trim().min(1).max(4096).optional(),
+  oauthClient: z.object({
+    clientId: z.string().trim().min(1).max(512),
+    /** Omitted preserves the secret only when both identity and client id are unchanged. */
+    clientSecret: z.string().trim().min(1).max(4096).optional(),
+  }).optional(),
+  access: accessInputSchema,
+})
+
 const replaceAccessBodySchema = z.object({
   access: accessInputSchema,
 })
@@ -130,6 +149,21 @@ const connectionNotFoundSchema = z.object({
   error: z.literal("connection_not_found"),
   message: z.string(),
 }).meta({ ref: "ExternalMcpConnectionNotFoundError" })
+
+const connectionConflictSchema = z.object({
+  error: z.literal("connection_conflict"),
+  message: z.string(),
+}).meta({ ref: "ExternalMcpConnectionConflictError" })
+
+const marketplaceManagedSchema = z.object({
+  error: z.literal("marketplace_managed"),
+  message: z.string(),
+}).meta({ ref: "ExternalMcpConnectionMarketplaceManagedError" })
+
+const connectionUpdateConflictSchema = z.union([
+  connectionConflictSchema,
+  marketplaceManagedSchema,
+]).meta({ ref: "ExternalMcpConnectionUpdateConflictError" })
 
 const accessSummarySchema = z.object({
   orgWide: z.boolean(),
@@ -150,6 +184,7 @@ const connectionResponseSchema = z.object({
   credentialMode: z.enum(["shared", "per_member"]),
   connected: z.boolean(),
   connectedAt: z.string().nullable(),
+  updatedAt: z.string().datetime().optional(),
   /** For per_member connections: whether the CALLING member has connected their own account. Always true for connected shared connections. */
   connectedForMe: z.boolean(),
   /** Present on native provider rows when the member's saved grant is missing currently selected scopes. */
@@ -164,8 +199,12 @@ const connectionResponseSchema = z.object({
   tenantId: z.string().nullable().optional(),
   /** Marketplace plugins whose declared MCP requirement is bound to this connection. Filtered to the caller's visible plugin names for scope=usable. */
   requiredBy: z.array(requiredBySchema),
+  /** Active plugin requirement bindings that own server/authentication identity. Derived server-side. */
+  identityManagedBy: z.array(requiredBySchema).optional(),
   /** Present only for scope=manageable (admin) listings. */
   access: accessSummarySchema.nullable(),
+  /** Public OAuth client id only. Client secrets and all other credentials are never returned. */
+  oauthClientId: z.string().nullable().optional(),
 }).meta({ ref: "ExternalMcpConnectionResponse" })
 
 const connectionListResponseSchema = z.object({
@@ -206,6 +245,13 @@ const connectionCreatedResponseSchema = connectionResponseSchema.extend({
     oauthCallback: z.string(),
   }),
 }).meta({ ref: "ExternalMcpConnectionCreatedResponse" })
+
+const connectionUpdatedResponseSchema = connectionResponseSchema.extend({
+  updatedAt: z.string().datetime(),
+  identityManagedBy: z.array(requiredBySchema),
+  identityChanged: z.boolean(),
+  reconnectionRequired: z.boolean(),
+}).meta({ ref: "ExternalMcpConnectionUpdatedResponse" })
 
 /**
  * The classical member handoff: after an admin (or their agent) publishes a
@@ -406,26 +452,15 @@ async function requiredByForConnections(input: {
   context: PluginArchActorContext
   includeAllPluginNames: boolean
   rows: ExternalMcpConnectionRow[]
-}): Promise<Map<string, ConnectionRequiredBy[]>> {
+}): Promise<{
+  requiredBy: Map<string, ConnectionRequiredBy[]>
+  identityManagedBy: Map<string, ConnectionRequiredBy[]>
+}> {
   const connectionIds = input.rows.map((row) => row.id)
-  if (connectionIds.length === 0) return new Map()
+  if (connectionIds.length === 0) return { requiredBy: new Map(), identityManagedBy: new Map() }
 
   const organizationId = input.context.organizationContext.organization.id
-  const bindingRows = await db
-    .select({
-      connectionId: PluginMcpRequirementBindingTable.externalMcpConnectionId,
-      pluginId: PluginTable.id,
-      pluginName: PluginTable.name,
-    })
-    .from(PluginMcpRequirementBindingTable)
-    .innerJoin(PluginTable, eq(PluginMcpRequirementBindingTable.pluginId, PluginTable.id))
-    .where(and(
-      eq(PluginMcpRequirementBindingTable.organizationId, organizationId),
-      inArray(PluginMcpRequirementBindingTable.externalMcpConnectionId, connectionIds),
-      eq(PluginTable.organizationId, organizationId),
-      eq(PluginTable.status, "active"),
-      isNull(PluginTable.deletedAt),
-    ))
+  const bindingRows = await listActiveExternalMcpConnectionBindings({ organizationId, connectionIds })
   const legacyRows = await legacyRequiredByForConnections({ connectionIds, organizationId })
   const candidatePluginIds = new Set<DenTypeId<"plugin">>([
     ...bindingRows.map((row) => row.pluginId),
@@ -447,6 +482,7 @@ async function requiredByForConnections(input: {
   }
 
   const grouped = new Map<string, Map<string, string>>()
+  const identityManaged = new Map<string, Map<string, string>>()
   for (const row of bindingRows) {
     if (!visiblePluginIds.has(row.pluginId)) continue
     let plugins = grouped.get(row.connectionId)
@@ -455,6 +491,12 @@ async function requiredByForConnections(input: {
       grouped.set(row.connectionId, plugins)
     }
     plugins.set(row.pluginId, row.pluginName)
+    let identityPlugins = identityManaged.get(row.connectionId)
+    if (!identityPlugins) {
+      identityPlugins = new Map()
+      identityManaged.set(row.connectionId, identityPlugins)
+    }
+    identityPlugins.set(row.pluginId, row.pluginName)
   }
   for (const row of legacyRows) {
     if (!visiblePluginIds.has(row.pluginId)) continue
@@ -470,7 +512,11 @@ async function requiredByForConnections(input: {
   for (const [connectionId, plugins] of grouped) {
     result.set(connectionId, [...plugins].map(([pluginId, name]) => ({ pluginId, name })).sort((left, right) => left.name.localeCompare(right.name)))
   }
-  return result
+  const identityManagedResult = new Map<string, ConnectionRequiredBy[]>()
+  for (const [connectionId, plugins] of identityManaged) {
+    identityManagedResult.set(connectionId, [...plugins].map(([pluginId, name]) => ({ pluginId, name })).sort((left, right) => left.name.localeCompare(right.name)))
+  }
+  return { requiredBy: result, identityManagedBy: identityManagedResult }
 }
 
 async function toConnectionResponse(
@@ -478,6 +524,7 @@ async function toConnectionResponse(
   options: {
     callerOrgMembershipId: DenTypeId<"member">
     includeAccess: boolean
+    identityManagedBy: ConnectionRequiredBy[]
     requiredBy: ConnectionRequiredBy[]
   },
 ) {
@@ -493,13 +540,19 @@ async function toConnectionResponse(
 
   let access: { orgWide: boolean; memberIds: string[]; teamIds: string[] } | null = null
   if (options.includeAccess) {
-    const grants = await listExternalMcpConnectionAccess(row.id)
+    const grants = await listDirectExternalMcpConnectionAccess({
+      organizationId: row.organizationId,
+      connectionId: row.id,
+    })
     access = {
       orgWide: grants.some((grant) => grant.orgWide),
       memberIds: grants.flatMap((grant) => (grant.orgMembershipId ? [grant.orgMembershipId] : [])),
       teamIds: grants.flatMap((grant) => (grant.teamId ? [grant.teamId] : [])),
     }
   }
+  const oauthClient = options.includeAccess
+    ? await getOrgOAuthClient(row.organizationId, row.id)
+    : null
 
   return {
     id: row.id,
@@ -509,9 +562,12 @@ async function toConnectionResponse(
     credentialMode: row.credentialMode,
     connected: isConnectionConnected(row),
     connectedAt: row.connectedAt ? row.connectedAt.toISOString() : null,
+    updatedAt: row.updatedAt.toISOString(),
     connectedForMe,
     requiredBy: options.requiredBy,
+    identityManagedBy: options.identityManagedBy,
     access,
+    ...(options.includeAccess ? { oauthClientId: oauthClient?.clientId ?? null } : {}),
   }
 }
 
@@ -579,9 +635,14 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
           return c.json({ error: "forbidden", message: "Only workspace owners and admins can list all MCP connections." }, 403)
         }
         const rows = await listExternalMcpConnections(payload.organization.id)
-        const requiredBy = await requiredByForConnections({ context, includeAllPluginNames: true, rows })
+        const provenance = await requiredByForConnections({ context, includeAllPluginNames: true, rows })
         const connections = await Promise.all(rows.map((row) =>
-          toConnectionResponse(row, { callerOrgMembershipId: payload.currentMember.id, includeAccess: true, requiredBy: requiredBy.get(row.id) ?? [] })))
+          toConnectionResponse(row, {
+            callerOrgMembershipId: payload.currentMember.id,
+            includeAccess: true,
+            requiredBy: provenance.requiredBy.get(row.id) ?? [],
+            identityManagedBy: provenance.identityManagedBy.get(row.id) ?? [],
+          })))
         return c.json({ connections })
       }
 
@@ -597,9 +658,14 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         orgMembershipId: payload.currentMember.id,
         teamIds: memberTeams.map((team) => team.id),
       })
-      const requiredBy = await requiredByForConnections({ context, includeAllPluginNames: false, rows })
+      const provenance = await requiredByForConnections({ context, includeAllPluginNames: false, rows })
       const connections = await Promise.all(rows.map((row) =>
-        toConnectionResponse(row, { callerOrgMembershipId: payload.currentMember.id, includeAccess: false, requiredBy: requiredBy.get(row.id) ?? [] })))
+        toConnectionResponse(row, {
+          callerOrgMembershipId: payload.currentMember.id,
+          includeAccess: false,
+          requiredBy: provenance.requiredBy.get(row.id) ?? [],
+          identityManagedBy: provenance.identityManagedBy.get(row.id) ?? [],
+        })))
       // Native providers (e.g. google-workspace) join the same list once the
       // org saved an OAuth client for them — same card, same connect flow,
       // same rollout gate (this sits after the gate check on purpose).
@@ -813,10 +879,205 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       }
 
       const refreshed = await getExternalMcpConnection({ organizationId: payload.organization.id, connectionId: created.id })
-      const response = await toConnectionResponse(refreshed ?? created, { callerOrgMembershipId: payload.currentMember.id, includeAccess: true, requiredBy: [] })
+      const response = await toConnectionResponse(refreshed ?? created, {
+        callerOrgMembershipId: payload.currentMember.id,
+        includeAccess: true,
+        requiredBy: [],
+        identityManagedBy: [],
+      })
       // The classical handoff: whoever created this (human or agent) gets
       // the link where members connect their own account, ready to share.
       return c.json({ ...response, links: memberConnectLinks(c.req.raw, created.id) })
+    },
+  )
+
+  app.put(
+    "/v1/mcp-connections/:connectionId",
+    describeRoute({
+      tags: ["Authentication"],
+      summary: "Edit an External MCP Connection",
+      description: "Organization-admin-only. Name and direct access changes preserve credentials. URL, authentication type, or credential-mode changes invalidate the old identity atomically. Secret fields are write-only optional replacements and are never returned. expectedUpdatedAt prevents stale edits.",
+      responses: {
+        200: jsonResponse("Connection updated.", connectionUpdatedResponseSchema),
+        400: jsonResponse("Invalid request.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        403: jsonResponse("Only workspace owners and admins can edit MCP connections.", forbiddenSchema),
+        404: jsonResponse("Unknown connection.", connectionNotFoundSchema),
+        409: jsonResponse("The edit is stale or changes marketplace-owned identity fields.", connectionUpdateConflictSchema),
+        502: jsonResponse("The proposed API-key or no-auth configuration could not be validated.", connectionValidationFailedSchema),
+      },
+    }),
+    orgMemberRoute(),
+    paramValidator(connectionParamsSchema),
+    jsonValidator(updateConnectionBodySchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const admin = ensureOrganizationAdminRole(c, "Only workspace owners and admins can edit MCP connections.")
+      if (!admin.ok) return c.json(admin.response, orgAccessFailureStatus(admin.response))
+
+      const { connectionId } = c.req.valid("param")
+      const externalMcpConnectionId = normalizeDenTypeId("externalMcpConnection", connectionId)
+      const connection = await getExternalMcpConnection({
+        organizationId: payload.organization.id,
+        connectionId: externalMcpConnectionId,
+      })
+      if (!connection) {
+        return c.json({ error: "connection_not_found", message: "Unknown connection." }, 404)
+      }
+
+      const body = c.req.valid("json")
+      const identityChanged = normalizeExternalMcpIdentityUrl(connection.url) !== normalizeExternalMcpIdentityUrl(body.url)
+        || connection.authType !== body.authType
+        || connection.credentialMode !== body.credentialMode
+      const marketplaceOwnedFieldsChanged = connection.url !== body.url
+        || connection.authType !== body.authType
+        || connection.credentialMode !== body.credentialMode
+        || body.apiKey !== undefined
+        || body.oauthClient !== undefined
+      const activeBindings = await listActiveExternalMcpConnectionBindings({
+        organizationId: payload.organization.id,
+        connectionIds: [externalMcpConnectionId],
+      })
+      if (activeBindings.length > 0 && marketplaceOwnedFieldsChanged) {
+        const owners = [...new Set(activeBindings.map((binding) => binding.pluginName))].join(", ")
+        return c.json({
+          error: "marketplace_managed",
+          message: `${owners || "A marketplace plugin"} owns this connection's server and authentication settings. Edit those values in the marketplace definition.`,
+        }, 409)
+      }
+
+      const sessionId = c.get("session")?.id
+      if (sessionId === "mcp_internal" && (body.apiKey !== undefined || body.oauthClient !== undefined)) {
+        return c.json({
+          error: "invalid_request",
+          message: "Connection credentials cannot be edited from the agent. Use the OpenWork Cloud dashboard under Connections.",
+        }, 400)
+      }
+      if (body.apiKey !== undefined && body.authType !== "apikey") {
+        return c.json({ error: "invalid_request", message: "apiKey is only allowed when authType is apikey." }, 400)
+      }
+      if (body.oauthClient && body.authType !== "oauth") {
+        return c.json({ error: "invalid_request", message: "oauthClient is only allowed when authType is oauth." }, 400)
+      }
+      if (body.credentialMode === "per_member" && body.authType !== "oauth") {
+        return c.json({ error: "invalid_request", message: "credentialMode per_member requires authType oauth — API keys and no-auth servers have no per-person identity to connect." }, 400)
+      }
+
+      const apiKey = body.authType === "apikey"
+        ? body.apiKey ?? (!identityChanged && connection.authType === "apikey" ? connection.apiKey : null)
+        : null
+      if (body.authType === "apikey" && !apiKey) {
+        return c.json({
+          error: "invalid_request",
+          message: identityChanged
+            ? "A replacement apiKey is required when changing an API-key connection's identity."
+            : "This API-key connection has no saved key; provide a replacement apiKey.",
+        }, 400)
+      }
+
+      if (!env.allowPrivateMcpUrls) {
+        try {
+          await assertPublicUrl(body.url)
+        } catch (error) {
+          return c.json({ error: "invalid_request", message: error instanceof Error ? error.message : "URL not allowed." }, 400)
+        }
+      }
+
+      const shouldValidate = body.authType !== "oauth"
+        && (identityChanged || connection.url !== body.url || body.apiKey !== undefined)
+      let validatedAt: Date | undefined
+      if (shouldValidate) {
+        const proposedConnection: ExternalMcpConnectionRow = {
+          ...connection,
+          name: body.name,
+          url: body.url,
+          authType: body.authType,
+          credentialMode: body.credentialMode,
+          apiKey,
+          accessToken: identityChanged ? null : connection.accessToken,
+          refreshToken: identityChanged ? null : connection.refreshToken,
+          tokenType: identityChanged ? null : connection.tokenType,
+          scope: identityChanged ? null : connection.scope,
+          expiresAt: identityChanged ? null : connection.expiresAt,
+          pendingCodeVerifier: identityChanged ? null : connection.pendingCodeVerifier,
+          connectedAt: identityChanged ? null : connection.connectedAt,
+        }
+        try {
+          await connectExternalMcp(
+            proposedConnection,
+            callbackRedirectUri(c.req.raw, connectionId),
+            undefined,
+            undefined,
+            c.get("requestId"),
+          )
+          validatedAt = new Date()
+        } catch (error) {
+          const diagnostic = externalMcpDiagnosticForResponse(error, c.get("requestId"), "MCP_INITIALIZE")
+          logger.error("external_mcp_connection_update_validation_failed", {
+            connection_id: connection.id,
+            organization_id: payload.organization.id,
+            connection_endpoint: safeExternalMcpEndpointForLog(body.url),
+            ...externalMcpDiagnosticForLog(error, c.get("requestId"), "MCP_INITIALIZE"),
+          })
+          return c.json({
+            error: "connection_validation_failed",
+            message: `Could not validate "${body.name}": ${diagnostic.message} Reference: ${diagnostic.referenceId}.`,
+            diagnostic,
+          }, 502)
+        }
+      }
+
+      const result = await updateExternalMcpConnection({
+        organizationId: payload.organization.id,
+        connectionId: externalMcpConnectionId,
+        expectedUpdatedAt: new Date(body.expectedUpdatedAt),
+        name: body.name,
+        url: body.url,
+        authType: body.authType,
+        credentialMode: body.credentialMode,
+        ...(body.apiKey !== undefined ? { apiKey: body.apiKey } : {}),
+        ...(body.oauthClient ? { oauthClient: body.oauthClient } : {}),
+        access: {
+          orgWide: body.access.orgWide,
+          memberIds: body.access.memberIds.map((id) => normalizeDenTypeId("member", id)),
+          teamIds: body.access.teamIds.map((id) => normalizeDenTypeId("team", id)),
+        },
+        updatedByOrgMembershipId: payload.currentMember.id,
+        ...(validatedAt ? { validatedAt } : {}),
+      })
+      if (result.status === "not_found") {
+        return c.json({ error: "connection_not_found", message: "Unknown connection." }, 404)
+      }
+      if (result.status === "conflict") {
+        return c.json({
+          error: "connection_conflict",
+          message: "This connection changed after you opened it. Close the dialog, review the latest settings, and try again.",
+        }, 409)
+      }
+      if (result.status === "marketplace_managed") {
+        return c.json({
+          error: "marketplace_managed",
+          message: "A marketplace plugin now owns this connection's server and authentication settings. Reload before editing.",
+        }, 409)
+      }
+
+      const context = { memberTeams: [], organizationContext: payload, session: c.get("session") } satisfies PluginArchActorContext
+      const provenance = await requiredByForConnections({
+        context,
+        includeAllPluginNames: true,
+        rows: [result.connection],
+      })
+      const response = await toConnectionResponse(result.connection, {
+        callerOrgMembershipId: payload.currentMember.id,
+        includeAccess: true,
+        requiredBy: provenance.requiredBy.get(result.connection.id) ?? [],
+        identityManagedBy: provenance.identityManagedBy.get(result.connection.id) ?? [],
+      })
+      return c.json({
+        ...response,
+        identityChanged: result.identityChanged,
+        reconnectionRequired: result.reconnectionRequired,
+      })
     },
   )
 
@@ -862,7 +1123,17 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         },
         createdByOrgMembershipId: payload.currentMember.id,
       })
-      return c.json(await toConnectionResponse(connection, { callerOrgMembershipId: payload.currentMember.id, includeAccess: true, requiredBy: [] }))
+      const provenance = await requiredByForConnections({
+        context: { memberTeams: [], organizationContext: payload, session: c.get("session") },
+        includeAllPluginNames: true,
+        rows: [connection],
+      })
+      return c.json(await toConnectionResponse(connection, {
+        callerOrgMembershipId: payload.currentMember.id,
+        includeAccess: true,
+        requiredBy: provenance.requiredBy.get(connection.id) ?? [],
+        identityManagedBy: provenance.identityManagedBy.get(connection.id) ?? [],
+      }))
     },
   )
 
@@ -979,6 +1250,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
           organizationId: payload.organization.id,
           orgMembershipId: payload.currentMember.id,
           providerId: connectionId,
+          binding: externalMcpIdentityBinding(connection),
           secret: env.betterAuthSecret,
         })
         const redirectUri = callbackRedirectUri(c.req.raw, connectionId)
@@ -1040,6 +1312,12 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       })
       if (!connection) {
         return c.json({ error: "invalid_request", message: "Unknown connection." }, 400)
+      }
+      if (statePayload.binding !== externalMcpIdentityBinding(connection)) {
+        return c.json({
+          error: "invalid_request",
+          message: "This connection changed after authorization started. Start the connection flow again.",
+        }, 400)
       }
 
       const providerErrorCode = url.searchParams.get("error")

--- a/ee/apps/den-api/test/enterprise-mcp-oauth-persistence.test.ts
+++ b/ee/apps/den-api/test/enterprise-mcp-oauth-persistence.test.ts
@@ -186,6 +186,51 @@ describe("Den enterprise MCP OAuth persistence adapter", () => {
     expect(after?.tokens.access_token).toBe(before?.tokens.access_token)
   })
 
+  test("rejects late credential and client writes after the connection identity changes", async () => {
+    const oldIdentity = await createExternalMcpConnection({
+      organizationId,
+      name: "Enterprise MCP old identity",
+      url: "https://old-mcp.example.test/mcp",
+      authType: "oauth",
+      credentialMode: "shared",
+      createdByOrgMembershipId: memberId,
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    })
+    const persistence = new DenEnterpriseMcpOAuthPersistence(oldIdentity)
+    await db
+      .update(schema.ExternalMcpConnectionTable)
+      .set({ url: "https://replacement-mcp.example.test/mcp", updatedAt: new Date() })
+      .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, oldIdentity.id))
+    const oldContext = {
+      connectionId: oldIdentity.id,
+      commitExpiresAt: Date.now() + 30_000,
+      signal: new AbortController().signal,
+    }
+
+    await expect(persistence.credentials.save({
+      context: oldContext,
+      tokens: { access_token: "late-enterprise-token", token_type: "Bearer" },
+      source: "refresh",
+    })).rejects.toThrow("identity changed")
+    await expect(persistence.clientRegistrations.save({
+      context: oldContext,
+      clientInformation: { client_id: "late-enterprise-client" },
+      source: "dynamic",
+    })).rejects.toThrow("identity changed")
+
+    const rows = await db
+      .select()
+      .from(schema.ExternalMcpConnectionTable)
+      .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, oldIdentity.id))
+      .limit(1)
+    expect(rows[0]?.accessToken).toBeNull()
+    const clients = await db
+      .select()
+      .from(schema.OrgOAuthClientTable)
+      .where(drizzle.eq(schema.OrgOAuthClientTable.providerId, oldIdentity.id))
+    expect(clients).toEqual([])
+  })
+
   test("removes a denied per-member authorization and keeps repeated cleanup idempotent", async () => {
     const perMemberConnection = await createExternalMcpConnection({
       organizationId,

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -20,6 +20,7 @@ let schema: typeof import("@openwork-ee/den-db/schema")
 let drizzle: typeof import("@openwork-ee/den-db/drizzle")
 let session: typeof import("../src/session.js")
 let createExternalMcpConnection: typeof import("../src/capability-sources/external-mcp-connections.js").createExternalMcpConnection
+let externalMcpIdentityBinding: typeof import("../src/capability-sources/external-mcp-connections.js").externalMcpIdentityBinding
 let createOAuthStateToken: typeof import("../src/capability-sources/generic-oauth.js").createOAuthStateToken
 
 const userId = createDenTypeId("user")
@@ -54,6 +55,7 @@ beforeAll(async () => {
   drizzle = drizzleMod
   session = sessionMod
   createExternalMcpConnection = connectionsMod.createExternalMcpConnection
+  externalMcpIdentityBinding = connectionsMod.externalMcpIdentityBinding
   createOAuthStateToken = genericOAuthMod.createOAuthStateToken
 
   await db.insert(schema.AuthUserTable).values({
@@ -179,6 +181,11 @@ test("public OAuth callback scopes the signed connection lookup to its organizat
     organizationId: createDenTypeId("organization"),
     orgMembershipId: memberId,
     providerId: seededConnectionId(),
+    binding: externalMcpIdentityBinding({
+      url: "http://127.0.0.1:9/mcp",
+      authType: "oauth",
+      credentialMode: "per_member",
+    }),
     secret: process.env.BETTER_AUTH_SECRET ?? "",
   })
   const callbackUrl = new URL(`http://den-api.local/v1/mcp-connections/${seededConnectionId()}/connect/callback`)
@@ -196,6 +203,11 @@ test("public OAuth callback validates state and renders a safe provider-denial d
     organizationId,
     orgMembershipId: memberId,
     providerId: seededConnectionId(),
+    binding: externalMcpIdentityBinding({
+      url: "http://127.0.0.1:9/mcp",
+      authType: "oauth",
+      credentialMode: "per_member",
+    }),
     secret: process.env.BETTER_AUTH_SECRET ?? "",
   })
   const callbackUrl = new URL(`http://den-api.local/v1/mcp-connections/${seededConnectionId()}/connect/callback`)

--- a/ee/apps/den-api/test/mcp-connections-edit.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-edit.test.ts
@@ -1,0 +1,614 @@
+import { StreamableHTTPTransport } from "@hono/mcp"
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, describe, expect, mock, test } from "bun:test"
+import { Hono } from "hono"
+
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_mcp_edit"
+process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "local-dev-secret-not-for-production-use!!"
+process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+process.env.DEN_ALLOW_PRIVATE_MCP_URLS = "1"
+
+let app: typeof import("../src/app.js").default
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+let session: typeof import("../src/session.js")
+let connections: typeof import("../src/capability-sources/external-mcp-connections.js")
+let genericOAuth: typeof import("../src/capability-sources/generic-oauth.js")
+let oauthCredentials: typeof import("../src/capability-sources/oauth-credentials.js")
+let fakeServer: ReturnType<typeof Bun.serve> | undefined
+
+const adminUserId = createDenTypeId("user")
+const memberUserId = createDenTypeId("user")
+const otherAdminUserId = createDenTypeId("user")
+const organizationId = createDenTypeId("organization")
+const otherOrganizationId = createDenTypeId("organization")
+const adminMemberId = createDenTypeId("member")
+const memberId = createDenTypeId("member")
+const otherAdminMemberId = createDenTypeId("member")
+const adminSessionId = createDenTypeId("session")
+const memberSessionId = createDenTypeId("session")
+const otherAdminSessionId = createDenTypeId("session")
+const adminToken = `mcp-edit-admin-${adminSessionId}`
+const memberToken = `mcp-edit-member-${memberSessionId}`
+const otherAdminToken = `mcp-edit-other-admin-${otherAdminSessionId}`
+const observedAuthorization: Array<string | null> = []
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+beforeAll(async () => {
+  mock.restore()
+  const fakeMcp = new Hono()
+  fakeMcp.all("/mcp", async (c) => {
+    observedAuthorization.push(c.req.header("authorization") ?? null)
+    const server = new McpServer({ name: "editable-mcp", version: "1.0.0" })
+    const transport = new StreamableHTTPTransport()
+    await server.connect(transport)
+    return await transport.handleRequest(c) ?? new Response(null, { status: 204 })
+  })
+  fakeServer = Bun.serve({ port: 0, fetch: fakeMcp.fetch })
+
+  const realDb = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL ?? "",
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db: realDb }))
+
+  const [appMod, dbMod, schemaMod, drizzleMod, sessionMod, connectionsMod, genericOAuthMod, oauthCredentialsMod] = await Promise.all([
+    import("../src/app.js"),
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+    import("../src/session.js"),
+    import("../src/capability-sources/external-mcp-connections.js"),
+    import("../src/capability-sources/generic-oauth.js"),
+    import("../src/capability-sources/oauth-credentials.js"),
+  ])
+  app = appMod.default
+  db = dbMod.db
+  schema = schemaMod
+  drizzle = drizzleMod
+  session = sessionMod
+  connections = connectionsMod
+  genericOAuth = genericOAuthMod
+  oauthCredentials = oauthCredentialsMod
+
+  await db.insert(schema.AuthUserTable).values([
+    { id: adminUserId, name: "MCP Edit Admin", email: `mcp-edit-admin+${adminUserId}@test.local` },
+    { id: memberUserId, name: "MCP Edit Member", email: `mcp-edit-member+${memberUserId}@test.local` },
+    { id: otherAdminUserId, name: "Other MCP Edit Admin", email: `mcp-edit-other+${otherAdminUserId}@test.local` },
+  ])
+  await db.insert(schema.OrganizationTable).values([
+    { id: organizationId, name: "MCP Edit Org", slug: `mcp-edit-${organizationId}` },
+    { id: otherOrganizationId, name: "Other MCP Edit Org", slug: `mcp-edit-${otherOrganizationId}` },
+  ])
+  await db.insert(schema.MemberTable).values([
+    { id: adminMemberId, organizationId, userId: adminUserId, role: "admin" },
+    { id: memberId, organizationId, userId: memberUserId, role: "member" },
+    { id: otherAdminMemberId, organizationId: otherOrganizationId, userId: otherAdminUserId, role: "admin" },
+  ])
+  const expiresAt = new Date(Date.now() + 24 * 60 * 60 * 1000)
+  await db.insert(schema.AuthSessionTable).values([
+    { id: adminSessionId, userId: adminUserId, activeOrganizationId: organizationId, token: adminToken, expiresAt },
+    { id: memberSessionId, userId: memberUserId, activeOrganizationId: organizationId, token: memberToken, expiresAt },
+    { id: otherAdminSessionId, userId: otherAdminUserId, activeOrganizationId: otherOrganizationId, token: otherAdminToken, expiresAt },
+  ])
+})
+
+afterAll(async () => {
+  fakeServer?.stop(true)
+  if (!db || !schema || !drizzle) return
+  await db.delete(schema.PluginMcpRequirementBindingTable).where(drizzle.inArray(
+    schema.PluginMcpRequirementBindingTable.organizationId,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.inArray(
+    schema.ExternalMcpConnectionAccessGrantTable.organizationId,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.ConnectedAccountTable).where(drizzle.inArray(
+    schema.ConnectedAccountTable.organizationId,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.OrgOAuthClientTable).where(drizzle.inArray(
+    schema.OrgOAuthClientTable.organizationId,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.ExternalMcpConnectionTable).where(drizzle.inArray(
+    schema.ExternalMcpConnectionTable.organizationId,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.PluginTable).where(drizzle.inArray(
+    schema.PluginTable.organizationId,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.AuthSessionTable).where(drizzle.inArray(
+    schema.AuthSessionTable.id,
+    [adminSessionId, memberSessionId, otherAdminSessionId],
+  ))
+  await db.delete(schema.MemberTable).where(drizzle.inArray(
+    schema.MemberTable.organizationId,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.OrganizationTable).where(drizzle.inArray(
+    schema.OrganizationTable.id,
+    [organizationId, otherOrganizationId],
+  ))
+  await db.delete(schema.AuthUserTable).where(drizzle.inArray(
+    schema.AuthUserTable.id,
+    [adminUserId, memberUserId, otherAdminUserId],
+  ))
+  mock.restore()
+})
+
+function workingUrl(path = "mcp") {
+  if (!fakeServer) throw new Error("Fake MCP server did not start")
+  return `http://127.0.0.1:${fakeServer.port}/${path}`
+}
+
+async function createConnection(input: {
+  organizationId?: DenTypeId<"organization">
+  memberId?: DenTypeId<"member">
+  name: string
+  authType: "oauth" | "apikey" | "none"
+  credentialMode: "shared" | "per_member"
+  url?: string
+  apiKey?: string | null
+}) {
+  const orgId = input.organizationId ?? organizationId
+  const creatorId = input.memberId ?? adminMemberId
+  const created = await connections.createExternalMcpConnection({
+    organizationId: orgId,
+    name: input.name,
+    url: input.url ?? workingUrl(),
+    authType: input.authType,
+    credentialMode: input.credentialMode,
+    apiKey: input.apiKey ?? null,
+    createdByOrgMembershipId: creatorId,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+  })
+  return created
+}
+
+async function currentConnection(
+  connectionId: DenTypeId<"externalMcpConnection">,
+  orgId: DenTypeId<"organization"> = organizationId,
+) {
+  const connection = await connections.getExternalMcpConnection({ organizationId: orgId, connectionId })
+  if (!connection) throw new Error(`Missing external MCP connection ${connectionId}`)
+  return connection
+}
+
+function humanRequest(input: {
+  connectionId: string
+  token?: string
+  body: Record<string, unknown>
+}) {
+  return app.fetch(new Request(`http://den-api.local/v1/mcp-connections/${input.connectionId}`, {
+    method: "PUT",
+    headers: {
+      authorization: `Bearer ${input.token ?? adminToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(input.body),
+  }))
+}
+
+function updateBody(
+  connection: Awaited<ReturnType<typeof currentConnection>>,
+  changes: Record<string, unknown> = {},
+) {
+  return {
+    expectedUpdatedAt: connection.updatedAt.toISOString(),
+    name: connection.name,
+    url: connection.url,
+    authType: connection.authType,
+    credentialMode: connection.credentialMode,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+    ...changes,
+  }
+}
+
+async function responseRecord(response: Response) {
+  const body: unknown = await response.json()
+  if (!isRecord(body)) throw new Error("Expected an object response")
+  return body
+}
+
+async function rawStoredApiKey(connectionId: string) {
+  const result: unknown = await db.execute(drizzle.sql`select api_key from external_mcp_connection where id = ${connectionId}`)
+  if (!Array.isArray(result) || !Array.isArray(result[0])) throw new Error("Unexpected raw API key result")
+  const row = result[0][0]
+  if (!isRecord(row) || typeof row.api_key !== "string") throw new Error("Missing raw API key")
+  return row.api_key
+}
+
+describe.serial("PUT /v1/mcp-connections/:connectionId", () => {
+  test("rename preserves a connected shared OAuth session and client registration", async () => {
+    const created = await createConnection({ name: "Shared OAuth", authType: "oauth", credentialMode: "shared" })
+    const connectedAt = new Date()
+    await db.update(schema.ExternalMcpConnectionTable).set({
+      accessToken: "shared-access",
+      refreshToken: "shared-refresh",
+      tokenType: "Bearer",
+      scope: "read write",
+      expiresAt: new Date(Date.now() + 60_000),
+      connectedAt,
+    }).where(drizzle.eq(schema.ExternalMcpConnectionTable.id, created.id))
+    await oauthCredentials.upsertOrgOAuthClient({
+      organizationId,
+      providerId: created.id,
+      clientId: "shared-client",
+      clientSecret: "shared-secret",
+      extra: { registrationAccessToken: "registration-secret" },
+      createdByOrgMembershipId: adminMemberId,
+    })
+    const before = await currentConnection(created.id)
+
+    const response = await humanRequest({
+      connectionId: created.id,
+      body: updateBody(before, { name: "Renamed Shared OAuth" }),
+    })
+    expect(response.status).toBe(200)
+    const body = await responseRecord(response)
+    expect(body).toMatchObject({ name: "Renamed Shared OAuth", connected: true, identityChanged: false, reconnectionRequired: false })
+    expect(JSON.stringify(body)).not.toContain("shared-access")
+    expect(JSON.stringify(body)).not.toContain("shared-refresh")
+    expect(JSON.stringify(body)).not.toContain("shared-secret")
+    expect(JSON.stringify(body)).not.toContain("registration-secret")
+
+    const after = await currentConnection(created.id)
+    expect(after).toMatchObject({
+      accessToken: "shared-access",
+      refreshToken: "shared-refresh",
+      tokenType: "Bearer",
+      scope: "read write",
+    })
+    expect(after.connectedAt?.getTime()).toBe(connectedAt.getTime())
+    const client = await oauthCredentials.getOrgOAuthClient(organizationId, created.id)
+    expect(client).toMatchObject({ clientId: "shared-client", clientSecret: "shared-secret", extra: { registrationAccessToken: "registration-secret" } })
+  })
+
+  test("assignment-only edit preserves API-key credentials and connected status", async () => {
+    const created = await createConnection({ name: "Assigned API MCP", authType: "apikey", credentialMode: "shared", apiKey: "assignment-key" })
+    const response = await humanRequest({
+      connectionId: created.id,
+      body: updateBody(created, {
+        access: { orgWide: false, memberIds: [memberId], teamIds: [] },
+      }),
+    })
+    expect(response.status).toBe(200)
+    expect(await responseRecord(response)).toMatchObject({ connected: true, identityChanged: false, reconnectionRequired: false })
+    expect((await currentConnection(created.id)).apiKey).toBe("assignment-key")
+    const grants = await connections.listDirectExternalMcpConnectionAccess({ organizationId, connectionId: created.id })
+    expect(grants.map((grant) => grant.orgMembershipId)).toEqual([memberId])
+  })
+
+  test("URL change clears shared and per-member OAuth identity state", async () => {
+    const created = await createConnection({ name: "Personal OAuth", authType: "oauth", credentialMode: "per_member" })
+    await db.update(schema.ExternalMcpConnectionTable).set({
+      accessToken: "unexpected-shared-access",
+      refreshToken: "unexpected-shared-refresh",
+      tokenType: "Bearer",
+      scope: "old-scope",
+      expiresAt: new Date(Date.now() + 60_000),
+      pendingCodeVerifier: "shared-pkce",
+      connectedAt: new Date(),
+    }).where(drizzle.eq(schema.ExternalMcpConnectionTable.id, created.id))
+    for (const [owner, suffix] of [[adminMemberId, "admin"], [memberId, "member"]] as const) {
+      await oauthCredentials.upsertConnectedAccount({
+        organizationId,
+        orgMembershipId: owner,
+        providerId: created.id,
+        externalAccountId: `old-${suffix}`,
+        scopes: ["old-scope"],
+        accessToken: `old-access-${suffix}`,
+        refreshToken: `old-refresh-${suffix}`,
+        tokenType: "Bearer",
+        pendingCodeVerifier: `old-pkce-${suffix}`,
+      })
+    }
+    await oauthCredentials.upsertOrgOAuthClient({
+      organizationId,
+      providerId: created.id,
+      clientId: "old-client",
+      clientSecret: "old-client-secret",
+      extra: { registrationAccessToken: "old-registration-token" },
+      createdByOrgMembershipId: adminMemberId,
+    })
+    const before = await currentConnection(created.id)
+
+    const response = await humanRequest({
+      connectionId: created.id,
+      body: updateBody(before, { url: workingUrl("new-mcp") }),
+    })
+    expect(response.status).toBe(200)
+    expect(await responseRecord(response)).toMatchObject({ identityChanged: true, reconnectionRequired: true })
+    const after = await currentConnection(created.id)
+    expect(after.id).toBe(created.id)
+    expect(after).toMatchObject({
+      accessToken: null,
+      refreshToken: null,
+      tokenType: null,
+      scope: null,
+      expiresAt: null,
+      pendingCodeVerifier: null,
+      connectedAt: null,
+      apiKey: null,
+    })
+    const accounts = await db.select().from(schema.ConnectedAccountTable).where(drizzle.and(
+      drizzle.eq(schema.ConnectedAccountTable.organizationId, organizationId),
+      drizzle.eq(schema.ConnectedAccountTable.providerId, created.id),
+    ))
+    expect(accounts).toEqual([])
+    expect(await oauthCredentials.getOrgOAuthClient(organizationId, created.id)).toBeNull()
+  })
+
+  test("authentication and both credential-mode changes clear incompatible credentials", async () => {
+    const apiConnection = await createConnection({ name: "API to OAuth", authType: "apikey", credentialMode: "shared", apiKey: "old-api-key" })
+    const apiResponse = await humanRequest({
+      connectionId: apiConnection.id,
+      body: updateBody(apiConnection, { authType: "oauth", credentialMode: "shared" }),
+    })
+    expect(apiResponse.status).toBe(200)
+    expect(await responseRecord(apiResponse)).toMatchObject({ connected: false, identityChanged: true, reconnectionRequired: true })
+    expect((await currentConnection(apiConnection.id)).apiKey).toBeNull()
+
+    const shared = await createConnection({ name: "Shared to personal", authType: "oauth", credentialMode: "shared" })
+    await db.update(schema.ExternalMcpConnectionTable).set({ accessToken: "shared-mode-token", connectedAt: new Date() })
+      .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, shared.id))
+    const sharedBefore = await currentConnection(shared.id)
+    const sharedResponse = await humanRequest({
+      connectionId: shared.id,
+      body: updateBody(sharedBefore, { credentialMode: "per_member" }),
+    })
+    expect(sharedResponse.status).toBe(200)
+    expect((await currentConnection(shared.id)).accessToken).toBeNull()
+
+    const personal = await createConnection({ name: "Personal to shared", authType: "oauth", credentialMode: "per_member" })
+    await oauthCredentials.upsertConnectedAccount({
+      organizationId,
+      orgMembershipId: memberId,
+      providerId: personal.id,
+      accessToken: "personal-mode-token",
+    })
+    const personalResponse = await humanRequest({
+      connectionId: personal.id,
+      body: updateBody(personal, { credentialMode: "shared" }),
+    })
+    expect(personalResponse.status).toBe(200)
+    const accounts = await db.select().from(schema.ConnectedAccountTable).where(drizzle.eq(schema.ConnectedAccountTable.providerId, personal.id))
+    expect(accounts).toEqual([])
+  })
+
+  test("API-key replacement is validated, encrypted, and never returned", async () => {
+    const created = await createConnection({ name: "Replace API key", authType: "apikey", credentialMode: "shared", apiKey: "old-api-key" })
+    observedAuthorization.length = 0
+    const response = await humanRequest({
+      connectionId: created.id,
+      body: updateBody(created, { apiKey: "new-api-key" }),
+    })
+    expect(response.status).toBe(200)
+    const body = await responseRecord(response)
+    expect(body).toMatchObject({ connected: true, identityChanged: false, reconnectionRequired: false })
+    expect(JSON.stringify(body)).not.toContain("new-api-key")
+    expect(JSON.stringify(body)).not.toContain("old-api-key")
+    expect(observedAuthorization).toContain("Bearer new-api-key")
+    expect(observedAuthorization).not.toContain("Bearer old-api-key")
+    expect((await currentConnection(created.id)).apiKey).toBe("new-api-key")
+    const raw = await rawStoredApiKey(created.id)
+    expect(raw.startsWith("enc:v1:")).toBe(true)
+    expect(raw).not.toContain("new-api-key")
+  })
+
+  test("invalid URLs and failed API-key/no-auth validation leave the working rows unchanged", async () => {
+    const unsafe = await createConnection({ name: "Unsafe URL", authType: "oauth", credentialMode: "shared" })
+    const unsafeResponse = await humanRequest({
+      connectionId: unsafe.id,
+      body: updateBody(unsafe, { url: "https://mcp.example.test/mcp?access_token=secret" }),
+    })
+    expect(unsafeResponse.status).toBe(400)
+    expect(await currentConnection(unsafe.id)).toMatchObject({ url: unsafe.url, name: unsafe.name })
+
+    const api = await createConnection({ name: "API rollback", authType: "apikey", credentialMode: "shared", apiKey: "working-api-key" })
+    const apiResponse = await humanRequest({
+      connectionId: api.id,
+      body: updateBody(api, { url: "http://127.0.0.1:9/mcp", apiKey: "replacement-that-fails" }),
+    })
+    expect(apiResponse.status).toBe(502)
+    expect(await currentConnection(api.id)).toMatchObject({ url: api.url, apiKey: "working-api-key" })
+
+    const noAuth = await createConnection({ name: "No-auth rollback", authType: "none", credentialMode: "shared" })
+    const connectedAt = new Date()
+    await db.update(schema.ExternalMcpConnectionTable).set({ connectedAt }).where(drizzle.eq(schema.ExternalMcpConnectionTable.id, noAuth.id))
+    const noAuthBefore = await currentConnection(noAuth.id)
+    const noAuthResponse = await humanRequest({
+      connectionId: noAuth.id,
+      body: updateBody(noAuthBefore, { url: "http://127.0.0.1:9/mcp" }),
+    })
+    expect(noAuthResponse.status).toBe(502)
+    const noAuthAfter = await currentConnection(noAuth.id)
+    expect(noAuthAfter.url).toBe(noAuth.url)
+    expect(noAuthAfter.connectedAt?.getTime()).toBe(connectedAt.getTime())
+  })
+
+  test("tenant scope, admin authorization, and internal-agent secret boundaries are enforced", async () => {
+    const other = await createConnection({
+      organizationId: otherOrganizationId,
+      memberId: otherAdminMemberId,
+      name: "Other tenant MCP",
+      authType: "oauth",
+      credentialMode: "shared",
+    })
+    const crossOrg = await humanRequest({
+      connectionId: other.id,
+      body: updateBody(other, { name: "Cross-org overwrite" }),
+    })
+    expect(crossOrg.status).toBe(404)
+
+    const own = await createConnection({ name: "Admin only MCP", authType: "oauth", credentialMode: "shared" })
+    const memberResponse = await humanRequest({
+      connectionId: own.id,
+      token: memberToken,
+      body: updateBody(own, { name: "Member overwrite" }),
+    })
+    expect(memberResponse.status).toBe(403)
+
+    const agentResponse = await app.fetch(new Request(`http://den-api.local/v1/mcp-connections/${own.id}`, {
+      method: "PUT",
+      headers: {
+        "content-type": "application/json",
+        "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId: adminUserId, organizationId }),
+      },
+      body: JSON.stringify(updateBody(own, {
+        authType: "apikey",
+        credentialMode: "shared",
+        apiKey: "agent-secret-must-not-pass",
+      })),
+    }))
+    expect(agentResponse.status).toBe(400)
+    expect(JSON.stringify(await responseRecord(agentResponse))).not.toContain("agent-secret-must-not-pass")
+  })
+
+  test("marketplace bindings own identity while direct assignment edits preserve derived grants", async () => {
+    const connection = await createConnection({ name: "Marketplace MCP", authType: "oauth", credentialMode: "per_member" })
+    const pluginId = createDenTypeId("plugin")
+    const bindingId = createDenTypeId("pluginMcpRequirementBinding")
+    const now = new Date()
+    await db.insert(schema.PluginTable).values({
+      id: pluginId,
+      organizationId,
+      name: "Marketplace Support",
+      description: null,
+      status: "active",
+      createdByOrgMembershipId: adminMemberId,
+      createdAt: now,
+      updatedAt: now,
+      deletedAt: null,
+    })
+    await db.insert(schema.PluginMcpRequirementBindingTable).values({
+      id: bindingId,
+      organizationId,
+      pluginId,
+      configObjectId: createDenTypeId("configObject"),
+      serverName: "support",
+      externalMcpConnectionId: connection.id,
+      createdByOrgMembershipId: adminMemberId,
+      createdAt: now,
+      updatedAt: now,
+    })
+    await db.insert(schema.ExternalMcpConnectionAccessGrantTable).values({
+      id: createDenTypeId("externalMcpConnectionAccessGrant"),
+      organizationId,
+      externalMcpConnectionId: connection.id,
+      pluginMcpRequirementBindingId: bindingId,
+      sourceKey: bindingId,
+      orgMembershipId: memberId,
+      orgWide: false,
+      createdByOrgMembershipId: adminMemberId,
+    })
+
+    const blocked = await humanRequest({
+      connectionId: connection.id,
+      body: updateBody(connection, { url: workingUrl("marketplace-change") }),
+    })
+    expect(blocked.status).toBe(409)
+    expect(await responseRecord(blocked)).toMatchObject({ error: "marketplace_managed" })
+
+    const fresh = await currentConnection(connection.id)
+    const allowed = await humanRequest({
+      connectionId: connection.id,
+      body: updateBody(fresh, {
+        name: "Renamed Marketplace MCP",
+        access: { orgWide: false, memberIds: [adminMemberId], teamIds: [] },
+      }),
+    })
+    expect(allowed.status).toBe(200)
+    const body = await responseRecord(allowed)
+    expect(body).toMatchObject({
+      name: "Renamed Marketplace MCP",
+      identityManagedBy: [{ pluginId, name: "Marketplace Support" }],
+      access: { orgWide: false, memberIds: [adminMemberId], teamIds: [] },
+    })
+    const grants = await db.select().from(schema.ExternalMcpConnectionAccessGrantTable).where(drizzle.eq(
+      schema.ExternalMcpConnectionAccessGrantTable.externalMcpConnectionId,
+      connection.id,
+    ))
+    expect(grants.some((grant) => grant.pluginMcpRequirementBindingId === bindingId && grant.orgMembershipId === memberId)).toBe(true)
+    expect(grants.some((grant) => grant.pluginMcpRequirementBindingId === null && grant.orgMembershipId === adminMemberId)).toBe(true)
+  })
+
+  test("stale edits conflict, no-op edits stay connected, and old-identity writes are rejected", async () => {
+    const connection = await createConnection({ name: "Concurrent OAuth", authType: "oauth", credentialMode: "per_member" })
+    const first = await humanRequest({
+      connectionId: connection.id,
+      body: updateBody(connection, { name: "Concurrent OAuth renamed" }),
+    })
+    expect(first.status).toBe(200)
+    const stale = await humanRequest({
+      connectionId: connection.id,
+      body: updateBody(connection, { url: workingUrl("stale-sensitive-change") }),
+    })
+    expect(stale.status).toBe(409)
+    expect(await responseRecord(stale)).toMatchObject({ error: "connection_conflict" })
+    expect((await currentConnection(connection.id)).url).toBe(connection.url)
+
+    const fresh = await currentConnection(connection.id)
+    await oauthCredentials.upsertConnectedAccount({
+      organizationId,
+      orgMembershipId: memberId,
+      providerId: fresh.id,
+      accessToken: "no-op-token",
+    })
+    const noOp = await humanRequest({ connectionId: fresh.id, body: updateBody(fresh, { name: fresh.name }) })
+    expect(noOp.status).toBe(200)
+    const noOpBody = await responseRecord(noOp)
+    expect(noOpBody).toMatchObject({ identityChanged: false, reconnectionRequired: false })
+    expect(noOpBody.updatedAt).toBe(fresh.updatedAt.toISOString())
+    expect((await oauthCredentials.getConnectedAccount({ organizationId, orgMembershipId: memberId, providerId: fresh.id }))?.accessToken).toBe("no-op-token")
+
+    const identityChange = await humanRequest({
+      connectionId: fresh.id,
+      body: updateBody(fresh, { url: workingUrl("new-concurrent-identity") }),
+    })
+    expect(identityChange.status).toBe(200)
+    const lateWrite = await connections.upsertConnectedAccountForExternalMcpIdentity({
+      connection: fresh,
+      orgMembershipId: memberId,
+      changes: { accessToken: "late-old-token", pendingCodeVerifier: "late-old-pkce" },
+    })
+    expect(lateWrite).toBe(false)
+    expect(await oauthCredentials.getConnectedAccount({ organizationId, orgMembershipId: memberId, providerId: fresh.id })).toBeNull()
+  })
+
+  test("OAuth callback state minted for an old identity cannot reach the replacement identity", async () => {
+    const connection = await createConnection({ name: "Bound OAuth state", authType: "oauth", credentialMode: "shared" })
+    const oldState = genericOAuth.createOAuthStateToken({
+      organizationId,
+      orgMembershipId: adminMemberId,
+      providerId: connection.id,
+      binding: connections.externalMcpIdentityBinding(connection),
+      secret: process.env.BETTER_AUTH_SECRET ?? "",
+    })
+    const update = await humanRequest({
+      connectionId: connection.id,
+      body: updateBody(connection, { url: workingUrl("replacement-bound-identity") }),
+    })
+    expect(update.status).toBe(200)
+
+    const callbackUrl = new URL(`http://den-api.local/v1/mcp-connections/${connection.id}/connect/callback`)
+    callbackUrl.searchParams.set("error", "access_denied")
+    callbackUrl.searchParams.set("state", oldState)
+    const callback = await app.fetch(new Request(callbackUrl))
+    expect(callback.status).toBe(400)
+    expect(await responseRecord(callback)).toEqual({
+      error: "invalid_request",
+      message: "This connection changed after authorization started. Start the connection flow again.",
+    })
+  })
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connection-editing.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connection-editing.ts
@@ -1,0 +1,38 @@
+import type {
+  ExternalMcpAccessSummary,
+  ExternalMcpAuthType,
+  ExternalMcpCredentialMode,
+  ExternalMcpRequiredBy,
+} from "./mcp-connections-data";
+
+export type McpConnectionAccessMode = "everyone" | "teams" | "people";
+
+export function normalizeEditableMcpIdentityUrl(value: string): string {
+  try {
+    const url = new URL(value.trim());
+    url.hash = "";
+    const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, "") : url.pathname;
+    return `${url.protocol}//${url.host}${pathname}${url.search}`;
+  } catch {
+    return value.trim().replace(/\/+$/, "");
+  }
+}
+
+export function editableMcpIdentityChanged(
+  current: { url: string; authType: ExternalMcpAuthType; credentialMode: ExternalMcpCredentialMode },
+  proposed: { url: string; authType: ExternalMcpAuthType; credentialMode: ExternalMcpCredentialMode },
+): boolean {
+  return normalizeEditableMcpIdentityUrl(current.url) !== normalizeEditableMcpIdentityUrl(proposed.url)
+    || current.authType !== proposed.authType
+    || current.credentialMode !== proposed.credentialMode;
+}
+
+export function mcpAccessMode(access: ExternalMcpAccessSummary | null): McpConnectionAccessMode {
+  if (!access || access.orgWide) return "everyone";
+  if (access.teamIds.length > 0) return "teams";
+  return "people";
+}
+
+export function marketplaceIdentityOwnerNames(owners: ExternalMcpRequiredBy[]): string {
+  return [...new Set(owners.map((owner) => owner.name))].join(", ");
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -40,6 +40,7 @@ export type ExternalMcpConnection = {
   credentialMode: ExternalMcpCredentialMode;
   connected: boolean;
   connectedAt: string | null;
+  updatedAt: string | null;
   connectedForMe: boolean;
   needsReconnect?: boolean;
   missingFeatures?: string[];
@@ -47,7 +48,9 @@ export type ExternalMcpConnection = {
   grantedScopes?: string[];
   tenantId?: string | null;
   requiredBy: ExternalMcpRequiredBy[];
+  identityManagedBy: ExternalMcpRequiredBy[];
   access: ExternalMcpAccessSummary | null;
+  oauthClientId?: string | null;
 };
 
 export type ExternalMcpTool = {
@@ -150,6 +153,8 @@ async function fetchConnections(scope: ExternalMcpConnectionScope, orgId: string
   return (record.connections ?? []).map((connection) => ({
     ...connection,
     requiredBy: parseRequiredBy(connection.requiredBy),
+    identityManagedBy: parseRequiredBy(connection.identityManagedBy),
+    updatedAt: typeof connection.updatedAt === "string" ? connection.updatedAt : null,
     ...(typeof connection.needsReconnect === "boolean" ? { needsReconnect: connection.needsReconnect } : {}),
     ...(isStringArray(connection.missingFeatures) ? { missingFeatures: connection.missingFeatures } : {}),
     ...(typeof connection.externalAccountId === "string" || connection.externalAccountId === null
@@ -202,6 +207,26 @@ export type CreateMcpConnectionInput = {
   access: McpConnectionAccessInput;
 };
 
+export type UpdateMcpConnectionInput = {
+  connectionId: string;
+  expectedUpdatedAt: string;
+  name: string;
+  url: string;
+  authType: ExternalMcpAuthType;
+  credentialMode: ExternalMcpCredentialMode;
+  apiKey?: string;
+  oauthClient?: {
+    clientId: string;
+    clientSecret?: string;
+  };
+  access: McpConnectionAccessInput;
+};
+
+export type UpdatedMcpConnection = ExternalMcpConnection & {
+  identityChanged: boolean;
+  reconnectionRequired: boolean;
+};
+
 export function useCreateMcpConnection() {
   const queryClient = useQueryClient();
   const { orgId, runReauthableAction } = useOrgDashboard();
@@ -222,6 +247,34 @@ export function useCreateMcpConnection() {
       });
       if (!created) throw new Error("Create MCP connection response was incomplete.");
       return created;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });
+    },
+  });
+}
+
+export function useUpdateMcpConnection() {
+  const queryClient = useQueryClient();
+  const { orgId, runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (input: UpdateMcpConnectionInput): Promise<UpdatedMcpConnection> => {
+      let updated: UpdatedMcpConnection | null = null;
+      await runReauthableAction("update-mcp-connection", async () => {
+        const { connectionId, ...body } = input;
+        const { response, payload } = await requestJson(
+          `/v1/mcp-connections/${encodeURIComponent(connectionId)}`,
+          { method: "PUT", headers: getOrgScopeHeaders(requireOrgId(orgId)), body: JSON.stringify(body) },
+          30000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to update MCP connection (${response.status}).`);
+        }
+        updated = payload as UpdatedMcpConnection;
+      });
+      if (!updated) throw new Error("Update MCP connection response was incomplete.");
+      return updated;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Check, ChevronDown, ChevronRight, Loader2, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
+import { Check, ChevronDown, ChevronRight, Loader2, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenSelect } from "../../_components/ui/select";
@@ -13,6 +13,12 @@ import { getRequestError, requestJson } from "../../_lib/den-flow";
 import { IntegrationIcon } from "./integration-icon";
 import { Microsoft365Dialog } from "./microsoft-365-dialog";
 import { safeMcpAuthorizationUrl } from "./mcp-authorization-url";
+import {
+  editableMcpIdentityChanged,
+  marketplaceIdentityOwnerNames,
+  mcpAccessMode,
+  type McpConnectionAccessMode,
+} from "./mcp-connection-editing";
 import { shouldShowMcpConnectionsStagingBanner } from "./mcp-connections-capability";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { marketplaceQueryKeys, useMarketplaces } from "./marketplace-data";
@@ -25,6 +31,8 @@ import {
   type ExternalMcpPreset,
   type ExternalMcpTool,
   type McpConnectionAccessInput,
+  type UpdatedMcpConnection,
+  type UpdateMcpConnectionInput,
   formatMcpConnectedTimestamp,
   mcpConnectionQueryKeys,
   useCreateMcpConnection,
@@ -36,6 +44,7 @@ import {
   useSaveNativeProviderClient,
   useStartMcpConnectionOAuth,
   useTelegramConnection,
+  useUpdateMcpConnection,
 } from "./mcp-connections-data";
 import { getPluginPartsSummary, pluginQueryKeys, usePlugins } from "./plugin-data";
 import { TelegramDialog } from "./telegram-dialog";
@@ -199,12 +208,14 @@ export function McpConnectionsScreen() {
   const { data: usableConnections = [] } = useMcpConnections("usable");
   const { data: presets = [] } = useMcpConnectionPresets();
   const createConnection = useCreateMcpConnection();
+  const updateConnection = useUpdateMcpConnection();
   const startOAuth = useStartMcpConnectionOAuth();
   const deleteConnection = useDeleteMcpConnection();
   const saveNativeClient = useSaveNativeProviderClient();
 
   const [formOpen, setFormOpen] = useState(false);
   const [formPreset, setFormPreset] = useState<ExternalMcpPreset | null>(null);
+  const [editingConnection, setEditingConnection] = useState<ExternalMcpConnection | null>(null);
   const [pluginDialogOpen, setPluginDialogOpen] = useState(false);
   const [googleDialogOpen, setGoogleDialogOpen] = useState(false);
   const [microsoftDialogOpen, setMicrosoftDialogOpen] = useState(false);
@@ -215,6 +226,7 @@ export function McpConnectionsScreen() {
   const showStagingBanner = orgContext ? shouldShowMcpConnectionsStagingBanner(orgContext.capabilities) : false;
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
   const [connectionActionError, setConnectionActionError] = useState<{ connectionId: string; message: string } | null>(null);
+  const [connectionActionNotice, setConnectionActionNotice] = useState<string | null>(null);
   const [toolsConnectionId, setToolsConnectionId] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
 
@@ -279,6 +291,19 @@ export function McpConnectionsScreen() {
     return created;
   }
 
+  async function handleUpdate(input: UpdateMcpConnectionInput): Promise<UpdatedMcpConnection> {
+    setConnectionActionError(null);
+    setConnectionActionNotice(null);
+    const updated = await updateConnection.mutateAsync(input);
+    setEditingConnection(null);
+    setConnectionActionNotice(updated.reconnectionRequired
+      ? `${updated.name} was saved securely. Reconnect it before the new identity can be used.`
+      : updated.identityChanged
+        ? `${updated.name} was saved and the replacement configuration was validated.`
+        : `${updated.name} was updated without disconnecting it.`);
+    return updated;
+  }
+
   return (
     <DashboardPageTemplate
       icon={Plug}
@@ -305,6 +330,12 @@ export function McpConnectionsScreen() {
       {connectionActionError ? (
         <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700" role="alert">
           {connectionActionError.message}
+        </div>
+      ) : null}
+
+      {connectionActionNotice ? (
+        <div className="mb-6 rounded-[24px] border border-emerald-200 bg-emerald-50 px-5 py-4 text-[14px] text-emerald-800" role="status">
+          {connectionActionNotice}
         </div>
       ) : null}
 
@@ -452,6 +483,10 @@ export function McpConnectionsScreen() {
               polling={pollingConnectionId === connection.id}
               connecting={startOAuth.isPending && startOAuth.variables === connection.id}
               errorMessage={connectionActionError?.connectionId === connection.id ? connectionActionError.message : null}
+              onEdit={() => {
+                updateConnection.reset();
+                setEditingConnection(connection);
+              }}
               onConnect={() => void handleConnectOAuth(connection.id)}
               onRemove={() => deleteConnection.mutate(connection.id)}
               removing={deleteConnection.isPending && deleteConnection.variables === connection.id}
@@ -472,6 +507,17 @@ export function McpConnectionsScreen() {
           setFormPreset(null);
         }}
         onSubmit={handleCreate}
+      />
+
+      <EditConnectionDialog
+        connection={editingConnection}
+        submitting={updateConnection.isPending}
+        error={updateConnection.error}
+        onClose={() => {
+          updateConnection.reset();
+          setEditingConnection(null);
+        }}
+        onSubmit={handleUpdate}
       />
 
       <ImportPluginConnectionDialog
@@ -1072,6 +1118,7 @@ function ConnectionRow({
   polling,
   connecting,
   errorMessage,
+  onEdit,
   onConnect,
   onRemove,
   removing,
@@ -1082,6 +1129,7 @@ function ConnectionRow({
   polling: boolean;
   connecting: boolean;
   errorMessage: string | null;
+  onEdit: () => void;
   onConnect: () => void;
   onRemove: () => void;
   removing: boolean;
@@ -1135,6 +1183,17 @@ function ConnectionRow({
         </div>
 
         <div className="flex flex-wrap items-center gap-2 sm:shrink-0 sm:flex-nowrap">
+          <DenButton
+            variant="secondary"
+            size="sm"
+            icon={Pencil}
+            onClick={onEdit}
+            disabled={!connection.updatedAt}
+            aria-label={`Edit ${connection.name}`}
+            data-testid={`edit-mcp-connection-${connection.id}`}
+          >
+            Edit
+          </DenButton>
           <DenButton
             variant="secondary"
             size="sm"
@@ -1352,10 +1411,12 @@ function SegmentedControl<TValue extends string>({
   options,
   value,
   onChange,
+  disabled = false,
 }: {
   options: SegmentedControlOption<TValue>[];
   value: TValue;
   onChange: (value: TValue) => void;
+  disabled?: boolean;
 }) {
   const gridColumns = options.length === 2 ? "grid-cols-2" : "grid-cols-3";
 
@@ -1365,9 +1426,10 @@ function SegmentedControl<TValue extends string>({
         <button
           key={option.value}
           type="button"
+          disabled={disabled}
           aria-pressed={value === option.value}
           onClick={() => onChange(option.value)}
-          className={`rounded-full px-3 py-1.5 text-[12px] font-medium transition ${
+          className={`rounded-full px-3 py-1.5 text-[12px] font-medium transition disabled:cursor-not-allowed disabled:opacity-60 ${
             value === option.value
               ? "bg-white text-gray-900 shadow-[0_1px_2px_rgba(15,23,42,0.08)]"
               : "text-gray-500 hover:text-gray-900"
@@ -1380,7 +1442,7 @@ function SegmentedControl<TValue extends string>({
   );
 }
 
-type AddConnectionAccessMode = "everyone" | "teams" | "people";
+type AddConnectionAccessMode = McpConnectionAccessMode;
 
 const AUTH_TYPE_OPTIONS: SegmentedControlOption<ExternalMcpAuthType>[] = [
   { value: "oauth", label: "OAuth" },
@@ -1398,6 +1460,336 @@ const ACCESS_MODE_OPTIONS: SegmentedControlOption<AddConnectionAccessMode>[] = [
   { value: "teams", label: "Specific teams" },
   { value: "people", label: "Specific people" },
 ];
+
+function EditConnectionDialog({
+  connection,
+  submitting,
+  error,
+  onClose,
+  onSubmit,
+}: {
+  connection: ExternalMcpConnection | null;
+  submitting: boolean;
+  error: unknown;
+  onClose: () => void;
+  onSubmit: (input: UpdateMcpConnectionInput) => Promise<UpdatedMcpConnection>;
+}) {
+  const { orgContext } = useOrgDashboard();
+  const [name, setName] = useState("");
+  const [url, setUrl] = useState("");
+  const [authType, setAuthType] = useState<ExternalMcpAuthType>("oauth");
+  const [credentialMode, setCredentialMode] = useState<ExternalMcpCredentialMode>("shared");
+  const [apiKey, setApiKey] = useState("");
+  const [showOAuthClient, setShowOAuthClient] = useState(false);
+  const [oauthClientId, setOAuthClientId] = useState("");
+  const [oauthClientSecret, setOAuthClientSecret] = useState("");
+  const [accessMode, setAccessMode] = useState<AddConnectionAccessMode>("everyone");
+  const [selectedTeamIds, setSelectedTeamIds] = useState<string[]>([]);
+  const [selectedMemberIds, setSelectedMemberIds] = useState<string[]>([]);
+  const [confirmingIdentityChange, setConfirmingIdentityChange] = useState(false);
+
+  useEffect(() => {
+    if (!connection) return;
+    setName(connection.name);
+    setUrl(connection.url);
+    setAuthType(connection.authType);
+    setCredentialMode(connection.credentialMode);
+    setApiKey("");
+    setShowOAuthClient(Boolean(connection.oauthClientId));
+    setOAuthClientId(connection.oauthClientId ?? "");
+    setOAuthClientSecret("");
+    setAccessMode(mcpAccessMode(connection.access));
+    setSelectedTeamIds(connection.access?.teamIds ?? []);
+    setSelectedMemberIds(connection.access?.memberIds ?? []);
+    setConfirmingIdentityChange(false);
+  }, [connection]);
+
+  const teams = useMemo(() => orgContext?.teams ?? [], [orgContext?.teams]);
+  const members = useMemo(
+    () => (orgContext?.members ?? []).filter((member) => Boolean(member.userId)),
+    [orgContext?.members],
+  );
+  const marketplaceOwners = connection?.identityManagedBy ?? [];
+  const marketplaceManaged = marketplaceOwners.length > 0;
+  const proposedCredentialMode = authType === "oauth" ? credentialMode : "shared";
+  const identityChanged = Boolean(connection && editableMcpIdentityChanged(connection, {
+    url,
+    authType,
+    credentialMode: proposedCredentialMode,
+  }));
+  const access: McpConnectionAccessInput = accessMode === "everyone"
+    ? { orgWide: true, memberIds: [], teamIds: [] }
+    : {
+      orgWide: false,
+      // Preserve a pre-existing mixed direct grant set on unrelated edits.
+      // Choosing a different mode below explicitly clears the hidden set.
+      memberIds: selectedMemberIds,
+      teamIds: selectedTeamIds,
+    };
+  const accessIncomplete = accessMode === "teams"
+    ? selectedTeamIds.length === 0
+    : accessMode === "people"
+      ? selectedMemberIds.length === 0
+      : false;
+  const replacementApiKeyRequired = authType === "apikey" && identityChanged && !apiKey.trim();
+
+  function toggle(list: string[], id: string): string[] {
+    return list.includes(id) ? list.filter((entry) => entry !== id) : [...list, id];
+  }
+
+  async function submit() {
+    if (!connection?.updatedAt) return;
+    if (identityChanged && !confirmingIdentityChange) {
+      setConfirmingIdentityChange(true);
+      return;
+    }
+    const trimmedApiKey = apiKey.trim();
+    const trimmedClientId = oauthClientId.trim();
+    const trimmedClientSecret = oauthClientSecret.trim();
+    const input: UpdateMcpConnectionInput = {
+      connectionId: connection.id,
+      expectedUpdatedAt: connection.updatedAt,
+      name: name.trim(),
+      url: url.trim(),
+      authType,
+      credentialMode: proposedCredentialMode,
+      ...(!marketplaceManaged && authType === "apikey" && trimmedApiKey ? { apiKey: trimmedApiKey } : {}),
+      ...(!marketplaceManaged && authType === "oauth" && showOAuthClient && trimmedClientId
+        ? {
+          oauthClient: {
+            clientId: trimmedClientId,
+            ...(trimmedClientSecret ? { clientSecret: trimmedClientSecret } : {}),
+          },
+        }
+        : {}),
+      access,
+    };
+    try {
+      await onSubmit(input);
+    } catch {
+      // The mutation error is rendered below and the dialog stays open with
+      // the proposed values, including a stale-edit response from the API.
+    }
+  }
+
+  if (!connection) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={onClose}>
+      <div
+        className="max-h-[92vh] w-full max-w-lg overflow-y-auto rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
+        onClick={(event) => event.stopPropagation()}
+        data-testid="edit-mcp-connection-dialog"
+      >
+        <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">Edit MCP connection</h2>
+        <p className="mt-1 text-[13px] leading-6 text-gray-600">
+          Update how this server is presented and who can use it. Saved credentials are never shown here.
+        </p>
+
+        {marketplaceManaged ? (
+          <div className="mt-4 rounded-2xl border border-blue-200 bg-blue-50 p-4 text-[12px] leading-5 text-blue-800" data-testid="marketplace-managed-identity-note">
+            <p className="font-semibold text-blue-900">Server and authentication are managed by {marketplaceIdentityOwnerNames(marketplaceOwners)}.</p>
+            <p className="mt-1">Change those values in the marketplace plugin definition. You can still rename this connection and edit its direct assignments here.</p>
+          </div>
+        ) : null}
+
+        <div className="mt-5 space-y-4">
+          <div>
+            <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Name</label>
+            <DenInput value={name} onChange={(event) => setName(event.target.value)} data-testid="edit-mcp-name" />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Server URL</label>
+            <DenInput
+              value={url}
+              data-testid="edit-mcp-url"
+              disabled={marketplaceManaged}
+              onChange={(event) => {
+                setUrl(event.target.value);
+                setConfirmingIdentityChange(false);
+              }}
+            />
+          </div>
+          <div>
+            <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Authentication</label>
+            <SegmentedControl
+              options={AUTH_TYPE_OPTIONS}
+              value={authType}
+              disabled={marketplaceManaged}
+              onChange={(option) => {
+                setAuthType(option);
+                if (option !== "oauth") {
+                  setCredentialMode("shared");
+                  setShowOAuthClient(false);
+                }
+                setConfirmingIdentityChange(false);
+              }}
+            />
+          </div>
+
+          {!marketplaceManaged && authType === "apikey" ? (
+            <div>
+              <label className="mb-1.5 block text-[12px] font-medium text-gray-700">
+                {identityChanged ? "Replacement API key (required)" : "Replacement API key (optional)"}
+              </label>
+              <DenInput
+                type="password"
+                value={apiKey}
+                onChange={(event) => {
+                  setApiKey(event.target.value);
+                  setConfirmingIdentityChange(false);
+                }}
+                placeholder={identityChanged ? "Enter a key for the new identity" : "Leave empty to keep the saved key"}
+                data-testid="edit-mcp-api-key"
+              />
+              <p className="mt-1.5 text-[11px] leading-5 text-gray-500">The saved key is encrypted and is never returned to this form.</p>
+            </div>
+          ) : null}
+
+          {!marketplaceManaged && authType === "oauth" && !showOAuthClient ? (
+            <button
+              type="button"
+              onClick={() => {
+                setShowOAuthClient(true);
+                setConfirmingIdentityChange(false);
+              }}
+              className="text-left text-[12px] font-medium text-gray-500 underline decoration-gray-300 underline-offset-4 transition hover:text-gray-900"
+            >
+              Replace a pre-registered OAuth app
+            </button>
+          ) : null}
+
+          {!marketplaceManaged && authType === "oauth" && showOAuthClient ? (
+            <div className="rounded-2xl border border-gray-100 bg-gray-50 p-4">
+              <p className="text-[13px] font-semibold text-gray-900">OAuth app</p>
+              <p className="mt-1 text-[12px] leading-5 text-gray-500">The client ID is safe to display. The saved client secret remains hidden.</p>
+              <div className="mt-3 space-y-3">
+                <div>
+                  <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID</label>
+                  <DenInput
+                    value={oauthClientId}
+                    onChange={(event) => {
+                      setOAuthClientId(event.target.value);
+                      setConfirmingIdentityChange(false);
+                    }}
+                  />
+                </div>
+                <div>
+                  <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Replacement client secret (optional)</label>
+                  <DenInput
+                    type="password"
+                    value={oauthClientSecret}
+                    onChange={(event) => {
+                      setOAuthClientSecret(event.target.value);
+                      setConfirmingIdentityChange(false);
+                    }}
+                    placeholder="Leave empty to keep it when identity and client ID are unchanged"
+                    data-testid="edit-mcp-oauth-client-secret"
+                  />
+                </div>
+              </div>
+            </div>
+          ) : null}
+
+          <div>
+            <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Whose account does the AI use?</label>
+            <SegmentedControl
+              options={CREDENTIAL_MODE_OPTIONS}
+              value={proposedCredentialMode}
+              disabled={marketplaceManaged || authType !== "oauth"}
+              onChange={(option) => {
+                setCredentialMode(option);
+                setConfirmingIdentityChange(false);
+              }}
+            />
+            {authType !== "oauth" ? (
+              <p className="mt-1.5 text-[11px] leading-5 text-gray-500">API-key and no-auth connections always use one organization connection.</p>
+            ) : null}
+          </div>
+
+          <div>
+            <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Who can use this?</label>
+            <SegmentedControl
+              options={ACCESS_MODE_OPTIONS}
+              value={accessMode}
+              onChange={(option) => {
+                if (option !== accessMode) {
+                  if (option === "teams") setSelectedMemberIds([]);
+                  if (option === "people") setSelectedTeamIds([]);
+                }
+                setAccessMode(option);
+              }}
+            />
+            {accessMode === "teams" ? (
+              <div className="mt-2 max-h-40 space-y-1 overflow-y-auto rounded-xl border border-gray-100 p-2">
+                {teams.length === 0 ? (
+                  <p className="px-2 py-1 text-[12px] text-gray-400">No teams in this org yet.</p>
+                ) : teams.map((team) => (
+                  <button
+                    key={team.id}
+                    type="button"
+                    onClick={() => setSelectedTeamIds((current) => toggle(current, team.id))}
+                    className={`flex w-full items-center justify-between rounded-lg px-2.5 py-1.5 text-left text-[13px] transition ${selectedTeamIds.includes(team.id) ? "bg-gray-100 text-gray-900" : "text-gray-700 hover:bg-gray-50"}`}
+                  >
+                    <span className="truncate">{team.name}</span>
+                    {selectedTeamIds.includes(team.id) ? <Check className="h-3.5 w-3.5 shrink-0" /> : null}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+            {accessMode === "people" ? (
+              <div className="mt-2 max-h-40 space-y-1 overflow-y-auto rounded-xl border border-gray-100 p-2">
+                {members.length === 0 ? (
+                  <p className="px-2 py-1 text-[12px] text-gray-400">No members in this org yet.</p>
+                ) : members.map((member) => (
+                  <button
+                    key={member.id}
+                    type="button"
+                    onClick={() => setSelectedMemberIds((current) => toggle(current, member.id))}
+                    className={`flex w-full items-center justify-between rounded-lg px-2.5 py-1.5 text-left text-[13px] transition ${selectedMemberIds.includes(member.id) ? "bg-gray-100 text-gray-900" : "text-gray-700 hover:bg-gray-50"}`}
+                  >
+                    <span className="truncate">{member.user.name || member.user.email}</span>
+                    {selectedMemberIds.includes(member.id) ? <Check className="h-3.5 w-3.5 shrink-0" /> : null}
+                  </button>
+                ))}
+              </div>
+            ) : null}
+          </div>
+        </div>
+
+        {identityChanged && !marketplaceManaged ? (
+          <div className="mt-5 rounded-2xl border border-amber-200 bg-amber-50 p-4 text-[12px] leading-5 text-amber-900" data-testid="mcp-identity-change-warning">
+            <p className="font-semibold">This changes the connection identity.</p>
+            <p className="mt-1">OpenWork will clear shared and individual sessions, API keys, pending OAuth state, OAuth client registration, scopes, and connected timestamps before the new server can be used.</p>
+            {authType === "oauth" ? <p className="mt-1 font-medium">The connection must be authorized again after saving.</p> : null}
+            {confirmingIdentityChange ? <p className="mt-2 font-semibold">Confirm that you want to invalidate the old identity.</p> : null}
+          </div>
+        ) : null}
+
+        {error ? (
+          <p className="mt-3 text-[13px] text-red-600" role="alert">{error instanceof Error ? error.message : "Failed to update connection."}</p>
+        ) : null}
+
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          {confirmingIdentityChange ? (
+            <DenButton variant="secondary" onClick={() => setConfirmingIdentityChange(false)} disabled={submitting}>Back</DenButton>
+          ) : (
+            <DenButton variant="secondary" onClick={onClose} disabled={submitting}>Cancel</DenButton>
+          )}
+          <DenButton
+            variant="primary"
+            loading={submitting}
+            disabled={!connection.updatedAt || !name.trim() || !url.trim() || replacementApiKeyRequired || accessIncomplete}
+            onClick={() => void submit()}
+            data-testid="save-mcp-connection-edit"
+          >
+            {confirmingIdentityChange ? "Confirm and save" : identityChanged ? "Review identity change" : "Save changes"}
+          </DenButton>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function AddConnectionDialog({
   open,

--- a/ee/apps/den-web/tests/mcp-connection-editing.test.ts
+++ b/ee/apps/den-web/tests/mcp-connection-editing.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  editableMcpIdentityChanged,
+  marketplaceIdentityOwnerNames,
+  mcpAccessMode,
+  normalizeEditableMcpIdentityUrl,
+} from "../app/(den)/dashboard/_components/mcp-connection-editing";
+
+describe("MCP connection edit projection", () => {
+  test("normalizes host/default-port and trailing slash without erasing path case or query", () => {
+    expect(normalizeEditableMcpIdentityUrl("https://MCP.EXAMPLE.com:443/MCP/?tenant=a"))
+      .toBe("https://mcp.example.com/MCP?tenant=a");
+    expect(normalizeEditableMcpIdentityUrl("https://mcp.example.com/mcp?tenant=a"))
+      .not.toBe("https://mcp.example.com/MCP?tenant=a");
+  });
+
+  test("warns only for normalized URL, authentication, or account-mode identity changes", () => {
+    const current = { url: "https://mcp.example.com/mcp/", authType: "oauth" as const, credentialMode: "shared" as const };
+
+    expect(editableMcpIdentityChanged(current, {
+      url: "https://MCP.EXAMPLE.com:443/mcp",
+      authType: "oauth",
+      credentialMode: "shared",
+    })).toBe(false);
+    expect(editableMcpIdentityChanged(current, {
+      url: "https://mcp.example.com/new-mcp",
+      authType: "oauth",
+      credentialMode: "shared",
+    })).toBe(true);
+    expect(editableMcpIdentityChanged(current, {
+      url: current.url,
+      authType: "apikey",
+      credentialMode: "shared",
+    })).toBe(true);
+    expect(editableMcpIdentityChanged(current, {
+      url: current.url,
+      authType: "oauth",
+      credentialMode: "per_member",
+    })).toBe(true);
+  });
+
+  test("prefills everyone, teams, or people from direct assignments", () => {
+    expect(mcpAccessMode({ orgWide: true, memberIds: [], teamIds: [] })).toBe("everyone");
+    expect(mcpAccessMode({ orgWide: false, memberIds: [], teamIds: ["team_1"] })).toBe("teams");
+    expect(mcpAccessMode({ orgWide: false, memberIds: ["mem_1"], teamIds: [] })).toBe("people");
+  });
+
+  test("explains marketplace ownership using unique server-derived plugin names", () => {
+    expect(marketplaceIdentityOwnerNames([
+      { pluginId: "plg_support", name: "Support Operations" },
+      { pluginId: "plg_support_copy", name: "Support Operations" },
+      { pluginId: "plg_triage", name: "Support Triage" },
+    ])).toBe("Support Operations, Support Triage");
+  });
+});

--- a/evals/flows/mcp-connection-editing.flow.mjs
+++ b/evals/flows/mcp-connection-editing.flow.mjs
@@ -1,0 +1,426 @@
+import { createServer } from "node:http";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, openAdminConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+
+const FLOW_ID = "mcp-connection-editing";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MOCK_PORT = Number(process.env.OPENWORK_EVAL_MCP_EDIT_MOCK_PORT ?? 4541);
+const MOCK_ORIGIN = `http://127.0.0.1:${MOCK_PORT}`;
+const RUN_TAG = Date.now().toString(36);
+const REGULAR_NAME = `Editable Operations ${RUN_TAG}`;
+const RENAMED_NAME = `Renamed Operations ${RUN_TAG}`;
+const MARKETPLACE_NAME = `Editable Connections Marketplace ${RUN_TAG}`;
+const PLUGIN_NAME = `Managed Operations ${RUN_TAG}`;
+const MANAGED_SERVER_NAME = "Managed server";
+const REGULAR_API_KEY = `regular-edit-key-${RUN_TAG}`;
+const MANAGED_API_KEY = `managed-edit-key-${RUN_TAG}`;
+
+const state = {
+  adminSession: null,
+  orgId: null,
+  regularConnectionId: null,
+  managedConnectionId: null,
+  marketplaceId: null,
+  pluginId: null,
+  managedConfigObjectId: null,
+};
+
+let mockServer = null;
+const mockRequests = [];
+
+function requireState(value, label) {
+  if (typeof value === "string" && value.trim()) return value;
+  throw new Error(`${label} was not prepared.`);
+}
+
+function authHeaders() {
+  const headers = { authorization: `Bearer ${requireState(state.adminSession, "admin session")}` };
+  if (state.orgId) {
+    headers["x-openwork-org-id"] = state.orgId;
+    headers["x-openwork-legacy-org-id"] = state.orgId;
+  }
+  return headers;
+}
+
+async function orgApi(ctx, path, init = {}) {
+  const response = await denApiFetch(path, {
+    ...init,
+    headers: { ...authHeaders(), ...(init.headers ?? {}) },
+  });
+  ctx.assert(response.response.ok || response.response.status === 204, `${path} failed: ${response.response.status} ${JSON.stringify(response.body).slice(0, 500)}`);
+  return response.body;
+}
+
+function jsonResponse(response, status, body, headers = {}) {
+  response.writeHead(status, { "content-type": "application/json", ...headers });
+  response.end(JSON.stringify(body));
+}
+
+async function readRequestBody(request) {
+  let raw = "";
+  for await (const chunk of request) raw += chunk;
+  return raw.trim() ? JSON.parse(raw) : {};
+}
+
+async function startMock(ctx) {
+  ctx.assert(!mockServer, "The MCP edit mock was already started.");
+  mockServer = createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", MOCK_ORIGIN);
+    if (url.pathname === "/health") return jsonResponse(response, 200, { ok: true });
+    if (url.pathname === "/requests") return jsonResponse(response, 200, { requests: mockRequests });
+    if (!url.pathname.endsWith("mcp")) return jsonResponse(response, 404, { error: "not_found" });
+    const authorization = request.headers.authorization ?? null;
+    const payload = await readRequestBody(request).catch(() => ({}));
+    mockRequests.push({ path: url.pathname, authorization, method: payload?.method ?? null });
+    if (!authorization?.startsWith("Bearer ")) {
+      return jsonResponse(response, 401, { error: "missing_api_key" });
+    }
+    if (payload?.id === undefined) {
+      response.writeHead(202);
+      response.end();
+      return;
+    }
+    if (payload.method === "initialize") {
+      return jsonResponse(response, 200, {
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name: "mcp-connection-editing-proof", version: "1.0.0" },
+        },
+      });
+    }
+    if (payload.method === "tools/list") {
+      return jsonResponse(response, 200, {
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: {
+          tools: [{
+            name: "connection_editing_proof",
+            description: "Proves that the preserved API key still reaches the MCP.",
+            inputSchema: { type: "object", properties: {} },
+          }],
+        },
+      });
+    }
+    return jsonResponse(response, 200, { jsonrpc: "2.0", id: payload.id, result: {} });
+  });
+  await new Promise((resolve, reject) => {
+    mockServer.once("error", reject);
+    mockServer.listen(MOCK_PORT, "127.0.0.1", resolve);
+  });
+  const health = await fetch(`${MOCK_ORIGIN}/health`, { signal: AbortSignal.timeout(2_000) });
+  ctx.assert(health.ok, "The local MCP edit mock did not become healthy.");
+}
+
+async function ensureAdminContext(ctx) {
+  state.adminSession = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
+  ctx.assert(Boolean(state.adminSession), `Den API sign-in failed for ${ADMIN_EMAIL}.`);
+  const listed = await denApiFetch("/v1/me/orgs", { headers: { authorization: `Bearer ${state.adminSession}` } });
+  ctx.assert(listed.response.ok, `Could not list admin organizations: ${listed.response.status}`);
+  const orgs = Array.isArray(listed.body?.orgs) ? listed.body.orgs : [];
+  const selected = orgs.find((org) => String(org.name ?? "").includes("Acme Robotics"))
+    ?? orgs.find((org) => ["owner", "admin"].includes(String(org.role ?? "").toLowerCase()))
+    ?? orgs[0];
+  ctx.assert(selected && typeof selected.id === "string", `No organization found for ${ADMIN_EMAIL}.`);
+  state.orgId = selected.id;
+  await orgApi(ctx, "/v1/me/active-organization", {
+    method: "POST",
+    body: JSON.stringify({ organizationId: state.orgId }),
+  });
+}
+
+async function seedRegularConnection(ctx) {
+  const created = await orgApi(ctx, "/v1/mcp-connections", {
+    method: "POST",
+    body: JSON.stringify({
+      name: REGULAR_NAME,
+      url: `${MOCK_ORIGIN}/regular-mcp`,
+      authType: "apikey",
+      credentialMode: "shared",
+      apiKey: REGULAR_API_KEY,
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    }),
+  });
+  state.regularConnectionId = created.id ?? null;
+  ctx.assert(Boolean(state.regularConnectionId), "Editable connection creation did not return an id.");
+  ctx.assert(created.connected === true, `Editable API-key connection was not validated: ${JSON.stringify(created)}`);
+  ctx.assert(!JSON.stringify(created).includes(REGULAR_API_KEY), "Editable connection create response exposed its API key.");
+}
+
+async function seedMarketplaceConnection(ctx) {
+  const marketplace = await orgApi(ctx, "/v1/marketplaces", {
+    method: "POST",
+    body: JSON.stringify({ name: MARKETPLACE_NAME, description: "Fraimz-owned marketplace for editable MCP proof." }),
+  });
+  state.marketplaceId = marketplace.item?.id ?? null;
+  ctx.assert(Boolean(state.marketplaceId), "Marketplace creation did not return an id.");
+
+  const payload = { mcpServers: { [MANAGED_SERVER_NAME]: { type: "remote", url: `${MOCK_ORIGIN}/managed-mcp` } } };
+  const plugin = await orgApi(ctx, "/v1/plugins", {
+    method: "POST",
+    body: JSON.stringify({
+      name: PLUGIN_NAME,
+      description: "Marketplace-managed MCP identity for edit proof.",
+      marketplaceId: state.marketplaceId,
+      components: [{
+        type: "mcp",
+        input: {
+          rawSourceText: JSON.stringify(payload, null, 2),
+          normalizedPayloadJson: payload,
+          metadata: { name: MANAGED_SERVER_NAME, title: MANAGED_SERVER_NAME, description: "Marketplace-owned MCP server." },
+        },
+      }],
+    }),
+  });
+  state.pluginId = plugin.item?.id ?? null;
+  ctx.assert(Boolean(state.pluginId), "Marketplace plugin creation did not return an id.");
+
+  const resolved = await orgApi(ctx, `/v1/plugins/${requireState(state.pluginId, "plugin id")}/resolved`);
+  state.managedConfigObjectId = (resolved.items ?? [])
+    .map((item) => item.configObject)
+    .find((item) => item?.objectType === "mcp")?.id ?? null;
+  ctx.assert(Boolean(state.managedConfigObjectId), "Marketplace plugin did not resolve an MCP config object.");
+
+  const configured = await orgApi(ctx, `/v1/plugins/${requireState(state.pluginId, "plugin id")}/mcp-connections`, {
+    method: "POST",
+    body: JSON.stringify({
+      configObjectId: state.managedConfigObjectId,
+      serverName: MANAGED_SERVER_NAME,
+      authType: "apikey",
+      credentialMode: "shared",
+      apiKey: MANAGED_API_KEY,
+    }),
+  });
+  state.managedConnectionId = configured.item?.connection?.id ?? null;
+  ctx.assert(Boolean(state.managedConnectionId), `Marketplace MCP configuration did not return a connection: ${JSON.stringify(configured).slice(0, 500)}`);
+  ctx.assert(!JSON.stringify(configured).includes(MANAGED_API_KEY), "Marketplace configuration response exposed its API key.");
+}
+
+async function setBrowserActiveOrganization(ctx) {
+  await ctx.eval(`fetch('/api/den/v1/me/active-organization', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ organizationId: ${JSON.stringify(requireState(state.orgId, "organization id"))} }),
+  }).then((response) => response.ok)`, { awaitPromise: true });
+}
+
+async function openEditDialog(ctx, connectionId) {
+  await ctx.waitFor(`Boolean(document.querySelector('[data-testid="edit-mcp-connection-${connectionId}"]'))`, { timeoutMs: 30_000, label: `edit action for ${connectionId}` });
+  const clicked = await ctx.eval(`(() => {
+    const button = document.querySelector('[data-testid="edit-mcp-connection-${connectionId}"]');
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked, `Could not open edit dialog for ${connectionId}.`);
+  await ctx.waitFor(`Boolean(document.querySelector('[data-testid="edit-mcp-connection-dialog"]'))`, { timeoutMs: 10_000, label: "MCP edit dialog" });
+}
+
+async function clickDialogButton(ctx, label) {
+  const clicked = await ctx.eval(`(() => {
+    const dialog = document.querySelector('[data-testid="edit-mcp-connection-dialog"]');
+    const button = dialog ? [...dialog.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === ${JSON.stringify(label)}) : null;
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked, `Could not click ${label} in the edit dialog.`);
+}
+
+async function manageableConnection(ctx, connectionId) {
+  const listed = await orgApi(ctx, "/v1/mcp-connections?scope=manageable");
+  const connection = (listed.connections ?? []).find((entry) => entry.id === connectionId);
+  ctx.assert(Boolean(connection), `Connection ${connectionId} was not returned by the manageable list.`);
+  return connection;
+}
+
+async function cleanup(ctx) {
+  for (const connectionId of [state.regularConnectionId, state.managedConnectionId]) {
+    if (!connectionId) continue;
+    const removed = await denApiFetch(`/v1/mcp-connections/${connectionId}`, {
+      method: "DELETE",
+      headers: authHeaders(),
+    });
+    ctx.assert(removed.response.ok || removed.response.status === 404, `Connection cleanup failed for ${connectionId}: ${removed.response.status}`);
+  }
+  if (state.marketplaceId && state.pluginId) {
+    await denApiFetch(`/v1/marketplaces/${state.marketplaceId}/plugins/${state.pluginId}`, { method: "DELETE", headers: authHeaders() });
+  }
+  if (state.pluginId) {
+    await denApiFetch(`/v1/plugins/${state.pluginId}/archive`, { method: "POST", headers: authHeaders() });
+  }
+  if (state.marketplaceId) {
+    await denApiFetch(`/v1/marketplaces/${state.marketplaceId}/archive`, { method: "POST", headers: authHeaders() });
+  }
+  await new Promise((resolve) => mockServer?.close(resolve));
+  mockServer = null;
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Admins safely edit existing MCP connections",
+  kind: "user-facing",
+  preserveTheme: true,
+  spec: "evals/voiceovers/mcp-connection-editing.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Setup",
+      run: async (ctx) => {
+        await startMock(ctx);
+        await ensureAdminContext(ctx);
+        await seedRegularConnection(ctx);
+        await seedMarketplaceConnection(ctx);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The admin opens a prefilled edit form without receiving the saved API key", {
+          voiceover: vo[0],
+          action: async () => {
+            await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await setBrowserActiveOrganization(ctx);
+            await openAdminConnections(ctx);
+            await ctx.waitForText(REGULAR_NAME, { timeoutMs: 30_000 });
+            await openEditDialog(ctx, requireState(state.regularConnectionId, "regular connection id"));
+          },
+          assert: async () => {
+            const form = await ctx.eval(`(() => {
+              const dialog = document.querySelector('[data-testid="edit-mcp-connection-dialog"]');
+              const key = dialog?.querySelector('[data-testid="edit-mcp-api-key"]');
+              const name = dialog?.querySelector('[data-testid="edit-mcp-name"]');
+              const url = dialog?.querySelector('[data-testid="edit-mcp-url"]');
+              return {
+                text: dialog?.innerText ?? '',
+                keyValue: key?.value ?? null,
+                nameValue: name?.value ?? null,
+                urlValue: url?.value ?? null,
+              };
+            })()`);
+            ctx.assert(form.nameValue === REGULAR_NAME, `Edit name was not prefilled: ${JSON.stringify(form)}`);
+            ctx.assert(form.urlValue === `${MOCK_ORIGIN}/regular-mcp`, `Edit URL was not prefilled: ${JSON.stringify(form)}`);
+            ctx.assert(form.keyValue === "", "Saved API key appeared in the browser.");
+            ctx.assert(form.text.includes("API key") && form.text.includes("One org account"), `Authentication/account mode were not visible: ${form.text}`);
+            ctx.assert(form.text.includes("Everyone"), "Assignment summary was not visible in the form.");
+          },
+          screenshot: {
+            name: "frame-1-prefilled-secret-safe-edit",
+            claim: "The edit form is prefilled with public connection settings and an empty optional replacement secret.",
+            requireText: ["Edit MCP connection", REGULAR_NAME, "Server URL", "Authentication", "Replacement API key (optional)", "One org account", "Who can use this?"],
+            rejectText: [REGULAR_API_KEY, "access_token", "refresh_token", "client_secret"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("A rename keeps the MCP connected and its existing API key operational", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.fill('[data-testid="edit-mcp-name"]', RENAMED_NAME);
+            await clickDialogButton(ctx, "Save changes");
+            await ctx.waitForText(`${RENAMED_NAME} was updated without disconnecting it.`, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const connection = await manageableConnection(ctx, state.regularConnectionId);
+            ctx.assert(connection.name === RENAMED_NAME && connection.connected === true, `Rename disconnected or failed: ${JSON.stringify(connection)}`);
+            const tools = await denApiFetch(`/v1/mcp-connections/${state.regularConnectionId}/tools`, { headers: authHeaders() });
+            ctx.assert(tools.response.ok, `Preserved API key no longer reached tools/list: ${tools.response.status} ${JSON.stringify(tools.body)}`);
+            ctx.assert((tools.body.tools ?? []).some((tool) => tool.name === "connection_editing_proof"), "Preserved credential did not return the proof tool.");
+          },
+          screenshot: {
+            name: "frame-2-rename-stays-connected",
+            claim: "The renamed MCP remains connected and the saved credential still works.",
+            requireText: [RENAMED_NAME, "Connected", "updated without disconnecting"],
+            rejectText: [REGULAR_API_KEY, "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("A sensitive identity change requires confirmation and invalidates the old credential", {
+          voiceover: vo[2],
+          action: async () => {
+            await openEditDialog(ctx, requireState(state.regularConnectionId, "regular connection id"));
+            await ctx.fill('[data-testid="edit-mcp-url"]', `${MOCK_ORIGIN}/replacement-oauth-mcp`);
+            await clickDialogButton(ctx, "OAuth");
+            await clickDialogButton(ctx, "Review identity change");
+            await ctx.waitForText("Confirm that you want to invalidate the old identity.", { timeoutMs: 10_000 });
+            await ctx.screenshot("frame-3-identity-change-warning", {
+              claim: "OpenWork names every credential class that the identity change will invalidate before confirmation.",
+              voiceover: vo[2],
+              requireText: ["This changes the connection identity", "shared and individual sessions", "pending OAuth state", "Confirm and save"],
+              rejectText: [REGULAR_API_KEY, "access_token", "refresh_token"],
+            });
+            await clickDialogButton(ctx, "Confirm and save");
+            await ctx.waitForText("Reconnect it before the new identity can be used.", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const connection = await manageableConnection(ctx, state.regularConnectionId);
+            ctx.assert(connection.url === `${MOCK_ORIGIN}/replacement-oauth-mcp`, `URL identity was not replaced: ${JSON.stringify(connection)}`);
+            ctx.assert(connection.authType === "oauth" && connection.connected === false, `OAuth replacement was not disconnected: ${JSON.stringify(connection)}`);
+            const tools = await denApiFetch(`/v1/mcp-connections/${state.regularConnectionId}/tools`, { headers: authHeaders() });
+            ctx.assert(tools.response.status === 409 && tools.body?.error === "connection_not_ready", `Old API key remained usable: ${tools.response.status} ${JSON.stringify(tools.body)}`);
+          },
+          screenshot: {
+            name: "frame-3-reconnection-required",
+            claim: "After confirmation the same connection id is disconnected and explicitly requires reconnection.",
+            requireText: [RENAMED_NAME, "Not connected", "Reconnect it before the new identity can be used"],
+            rejectText: [REGULAR_API_KEY, "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Marketplace ownership locks identity fields while direct assignments remain editable", {
+          voiceover: vo[3],
+          action: async () => {
+            await openEditDialog(ctx, requireState(state.managedConnectionId, "managed connection id"));
+            await clickDialogButton(ctx, "Everyone");
+            const locked = await ctx.eval(`(() => {
+              const dialog = document.querySelector('[data-testid="edit-mcp-connection-dialog"]');
+              const url = dialog?.querySelector('[data-testid="edit-mcp-url"]');
+              const authButtons = [...(dialog?.querySelectorAll('button') ?? [])].filter((button) => ['OAuth', 'API key', 'None'].includes((button.textContent ?? '').trim()));
+              return { urlDisabled: Boolean(url?.disabled), authDisabled: authButtons.length === 3 && authButtons.every((button) => button.disabled) };
+            })()`);
+            ctx.assert(locked.urlDisabled && locked.authDisabled, `Marketplace identity controls were editable: ${JSON.stringify(locked)}`);
+            await ctx.screenshot("frame-4-marketplace-identity-owned", {
+              claim: "The plugin source is named, identity controls are disabled, and Everyone remains selectable.",
+              voiceover: vo[3],
+              requireText: ["managed by", PLUGIN_NAME, "marketplace plugin definition", "Everyone", "Save changes"],
+              rejectText: [MANAGED_API_KEY, "Something went wrong"],
+            });
+            await clickDialogButton(ctx, "Save changes");
+            await ctx.waitForText("was updated without disconnecting it.", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const connection = await manageableConnection(ctx, state.managedConnectionId);
+            ctx.assert(connection.connected === true, `Marketplace connection disconnected during access edit: ${JSON.stringify(connection)}`);
+            ctx.assert(connection.access?.orgWide === true, `Direct Everyone assignment was not saved: ${JSON.stringify(connection.access)}`);
+            ctx.assert((connection.requiredBy ?? []).some((owner) => owner.name === PLUGIN_NAME), `requiredBy projection regressed: ${JSON.stringify(connection.requiredBy)}`);
+            ctx.assert((connection.identityManagedBy ?? []).some((owner) => owner.name === PLUGIN_NAME), `Marketplace identity ownership was not server-derived: ${JSON.stringify(connection.identityManagedBy)}`);
+          },
+          screenshot: {
+            name: "frame-4-marketplace-assignment-saved",
+            claim: "The marketplace MCP stays connected after its direct Everyone assignment is saved.",
+            requireText: [PLUGIN_NAME, "Connected", "Everyone in the org", "updated without disconnecting"],
+            rejectText: [MANAGED_API_KEY, "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup",
+      run: async (ctx) => cleanup(ctx),
+    },
+  ],
+};

--- a/evals/voiceovers/mcp-connection-editing.md
+++ b/evals/voiceovers/mcp-connection-editing.md
@@ -1,0 +1,9 @@
+# mcp-connection-editing — Admins safely edit existing MCP connections
+
+1. An organization admin opens an existing MCP connection and clicks Edit. The form shows its name, server URL, authentication type, account mode, and assignments, but never reveals saved secrets.
+
+2. The admin renames the connection or changes who can use it. After saving, the MCP remains connected and its existing credentials continue working.
+
+3. The admin changes the server URL, authentication type, or account mode. OpenWork clearly warns that this changes the connection’s identity and will require reconnection. After confirmation, old credentials and sessions are cleared before the new server can be used.
+
+4. For an MCP managed by a marketplace plugin, OpenWork allows assignment changes but prevents changing server/authentication fields owned by the marketplace definition and explains where those values come from.


### PR DESCRIPTION
## Summary

- add an organization-admin-only update API for existing external MCP connections
- add a prefilled Edit dialog on Den Connections with write-only replacement secret fields
- preserve credentials for name and direct-assignment edits while keeping the connection ID stable
- lock marketplace-owned URL, authentication, and account-mode fields while preserving derived access grants
- add the approved four-frame voiceover and real Den fraimz flow

## Security behavior

- tenant-scoped reads and updates with owner/admin enforcement and optimistic updatedAt conflicts
- existing MCP URL validation and SSRF policy remain in force
- normalized URL, authentication type, or credential mode changes atomically clear shared tokens, every per-member account, API keys, PKCE/state, OAuth registration, scopes, metadata, and connected timestamps
- API-key and no-auth replacements are validated before the working connection is changed
- API keys and OAuth client secrets are write-only; tokens and registration credentials are never returned
- OAuth state is bound to the connection identity, and both current and enterprise MCP persistence reject late writes from an old identity
- internal agent principals cannot submit credential-bearing edits
- no database migration

## Validation

- ./bin/openwork-hub check mcp mcp-connection-editing — passed
- Den API typecheck — passed
- Den Web typecheck — passed
- Den API focused suites — 43 passed, 0 failed across edit, callback, catalog, marketplace provenance, OAuth policy, internal-principal, and enterprise-persistence coverage
- Den Web focused suites — 23 passed, 0 failed
- @openwork-ee/den-api production build — passed
- @openwork-ee/den-web production build — passed
- database-backed route coverage runs against openwork_den_mcp_mcp_connection_editing
- pnpm fraimz --flow mcp-connection-editing — PASSED, 1 flow / 4 approved voiceover frames / 0 failed / 0 skipped
  - prefilled edit form never reveals the saved API key
  - rename stays connected and the preserved key still reaches tools/list
  - sensitive identity change warns, clears the old credential, and requires reconnection
  - marketplace identity fields stay locked while a direct Everyone assignment saves

## Fraimz

Flow: evals/flows/mcp-connection-editing.flow.mjs  
Voiceover: evals/voiceovers/mcp-connection-editing.md  
The PR proof comment is posted from the same flow after publication.
