### PR TITLE
fix(updater): target the latest approved desktop release

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -300,6 +300,7 @@ let desktopBootstrapConfig: DenBootstrapConfig = {
 export type DenAppVersionMetadata = {
   minAppVersion: string;
   latestAppVersion: string;
+  publishedDesktopVersions: string[];
 };
 
 type RawJsonResponse<T> = {
@@ -338,11 +339,14 @@ function getDenAppVersionMetadata(payload: unknown): DenAppVersionMetadata | nul
   const latestAppVersion =
     typeof payload.latestAppVersion === "string" ? payload.latestAppVersion.trim() : "";
   if (!latestAppVersion) return null;
+  const publishedDesktopVersions = readStringArray(payload.publishedDesktopVersions);
 
   return {
     minAppVersion:
       typeof payload.minAppVersion === "string" ? payload.minAppVersion.trim() : "",
     latestAppVersion,
+    publishedDesktopVersions:
+      publishedDesktopVersions.length > 0 ? publishedDesktopVersions : [latestAppVersion],
   };
 }
 

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -109,7 +109,7 @@ declare global {
           feedUrl: string;
           currentVersion: string;
         }>;
-        check?: (channel?: "stable" | "alpha") => Promise<{
+        check?: (channel?: "stable" | "alpha", targetVersion?: string) => Promise<{
           available: boolean;
           currentVersion?: string;
           latestVersion?: string | null;

--- a/apps/app/src/app/lib/version-gate.ts
+++ b/apps/app/src/app/lib/version-gate.ts
@@ -4,7 +4,18 @@
 // so they're reusable from any React feature site once the updater flow
 // gets wired.
 
-import { createDenClient, readDenSettings, type DenDesktopConfig } from "./den";
+import {
+  createDenClient,
+  readDenSettings,
+  type DenAppVersionMetadata,
+  type DenDesktopConfig,
+} from "./den";
+
+declare global {
+  interface Window {
+    __openworkReadDesktopVersionMetadataEval?: () => DenAppVersionMetadata | Promise<DenAppVersionMetadata>;
+  }
+}
 
 type ParsedVersion = {
   release: number[];
@@ -67,6 +78,11 @@ function comparePrereleaseIdentifiers(left: string[], right: string[]): number {
 
 function releasePart(value: string): number[] | null {
   return parseComparableVersion(value)?.release ?? null;
+}
+
+function normalizeStableDesktopVersion(value: string): string | null {
+  const normalized = value.trim().replace(/^v/i, "");
+  return /^\d+\.\d+\.\d+$/.test(normalized) ? normalized : null;
 }
 
 /**
@@ -161,17 +177,92 @@ function isWithinOnePatchAhead(updateVersion: string, maxVersion: string): boole
 
 async function readDenLatestAppVersion(): Promise<string | null> {
   try {
-    const settings = readDenSettings();
-    const token = settings.authToken?.trim() ?? "";
-    const client = createDenClient({
-      baseUrl: settings.baseUrl,
-      ...(token ? { token } : {}),
-    });
-    const metadata = await client.getAppVersionMetadata();
+    const metadata = await readFreshDenAppVersionMetadata();
     return metadata.latestAppVersion;
   } catch {
     return null;
   }
+}
+
+export async function readFreshDenAppVersionMetadata(): Promise<DenAppVersionMetadata> {
+  if (import.meta.env.DEV && typeof window !== "undefined" && window.__openworkReadDesktopVersionMetadataEval) {
+    return window.__openworkReadDesktopVersionMetadataEval();
+  }
+  const settings = readDenSettings();
+  const token = settings.authToken?.trim() ?? "";
+  return createDenClient({
+    baseUrl: settings.baseUrl,
+    ...(token ? { token } : {}),
+  }).getAppVersionMetadata();
+}
+
+export type StableDesktopUpdateSelection =
+  | { kind: "update"; targetVersion: string; latestPublishedVersion: string }
+  | { kind: "blocked"; latestPublishedVersion: string }
+  | { kind: "current"; latestPublishedVersion: string };
+
+/**
+ * Select the highest stable release that is both published and approved.
+ * The explicit Den inventory is the trust boundary: stored policy entries
+ * that do not correspond to a published updater manifest are never targeted.
+ */
+export function selectStableDesktopUpdate(input: {
+  currentVersion: string;
+  metadata: DenAppVersionMetadata;
+  desktopConfig: DenDesktopConfig | null | undefined;
+}): StableDesktopUpdateSelection | null {
+  const currentVersion = normalizeStableDesktopVersion(input.currentVersion);
+  if (!currentVersion) return null;
+
+  const publishedVersions = [...new Set(input.metadata.publishedDesktopVersions.flatMap((version) => {
+    const normalized = normalizeStableDesktopVersion(version);
+    if (!normalized) return [];
+    const atOrAboveMinimum = compareVersions(normalized, input.metadata.minAppVersion);
+    const atOrBelowLatest = compareVersions(normalized, input.metadata.latestAppVersion);
+    return atOrAboveMinimum !== null && atOrAboveMinimum >= 0 && atOrBelowLatest !== null && atOrBelowLatest <= 0
+      ? [normalized]
+      : [];
+  }))].sort((left, right) => compareVersions(left, right) ?? 0);
+  const latestPublishedVersion = publishedVersions.at(-1);
+  if (!latestPublishedVersion) return null;
+
+  const restrictedVersions = Array.isArray(input.desktopConfig?.allowedDesktopVersions)
+    ? input.desktopConfig.allowedDesktopVersions
+    : null;
+  const approvedPublishedVersions = restrictedVersions === null
+    ? publishedVersions
+    : publishedVersions.filter((publishedVersion) =>
+        restrictedVersions.some((allowedVersion) => compareVersions(publishedVersion, allowedVersion) === 0),
+      );
+  const targetVersion = approvedPublishedVersions
+    .filter((version) => compareVersions(version, currentVersion) === 1)
+    .at(-1);
+
+  if (targetVersion) {
+    return { kind: "update", targetVersion, latestPublishedVersion };
+  }
+
+  if (compareVersions(latestPublishedVersion, currentVersion) === 1 && restrictedVersions !== null) {
+    return { kind: "blocked", latestPublishedVersion };
+  }
+
+  return { kind: "current", latestPublishedVersion };
+}
+
+export async function resolveFreshStableDesktopUpdate(input: {
+  currentVersion: string;
+  refreshDesktopConfig: () => Promise<DenDesktopConfig>;
+  readMetadata?: () => Promise<DenAppVersionMetadata>;
+}): Promise<StableDesktopUpdateSelection | null> {
+  const [desktopConfig, metadata] = await Promise.all([
+    input.refreshDesktopConfig(),
+    (input.readMetadata ?? readFreshDenAppVersionMetadata)(),
+  ]);
+  return selectStableDesktopUpdate({
+    currentVersion: input.currentVersion,
+    metadata,
+    desktopConfig,
+  });
 }
 
 /**

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1309,6 +1309,8 @@ export default {
   "settings.update": "Update",
   "settings.update_available": "Update available: v",
   "settings.update_available_version": "Update available: v{version}",
+  "settings.update_blocked_version": "Update available: v{version}",
+  "settings.update_blocked_org": "OpenWork {version} is available, but your organization has not approved it yet. Ask an organization administrator to enable this version.",
   "settings.update_check_button": "Check now",
   "settings.update_check_failed": "Couldn't check for updates",
   "settings.update_checking": "Checking for updates…",

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -37,6 +37,7 @@ export type DesktopConfigStore = {
   config: DenDesktopConfig;
   loading: boolean;
   refresh: () => Promise<void>;
+  refreshFresh: () => Promise<DenDesktopConfig>;
   /**
    * Stable checker function that matches the `DesktopAppRestrictionChecker`
    * shape Solid passes to its stores. Useful when wiring restriction gates
@@ -163,6 +164,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
   // Safe in-memory copy of the last config we actually applied. State drives
   // rendering, while this ref lets the handler compare without stale closures.
   const currentDesktopConfigRef = useRef<DenDesktopConfig>(DEFAULT_DESKTOP_CONFIG);
+  const devRefreshDesktopConfigRef = useRef<DenDesktopConfig | null>(null);
   const isSignedIn = denAuth.isSignedIn;
 
   const applyDesktopConfigActions = useCallback((latestConfig: DenDesktopConfig) => {
@@ -202,7 +204,13 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     return true;
   }, []);
 
-  const desktopConfigHandler = useCallback(async () => {
+  const desktopConfigHandler = useCallback(async (requireFresh = false): Promise<DenDesktopConfig> => {
+    if (import.meta.env.DEV && requireFresh && devRefreshDesktopConfigRef.current) {
+      const nextConfig = devRefreshDesktopConfigRef.current;
+      applyDesktopConfigActions(nextConfig);
+      return nextConfig;
+    }
+
     const currentRun = ++refreshRunRef.current;
     const settings = readDenSettings();
     const token = settings.authToken?.trim() ?? "";
@@ -212,7 +220,7 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     if (!isSignedIn || !token || !activeOrgId) {
       applyDesktopConfigActions(DEFAULT_DESKTOP_CONFIG);
       setDesktopConfigState((current) => ({ ...current, loading: false }));
-      return;
+      return DEFAULT_DESKTOP_CONFIG;
     }
 
     const cached = readCachedDesktopConfig(cacheKey);
@@ -230,12 +238,16 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
         token,
       }).getDesktopConfig(activeOrgId);
 
-      if (currentRun !== refreshRunRef.current) return;
+      if (currentRun !== refreshRunRef.current) return nextConfig;
 
       writeCachedDesktopConfig(cacheKey, nextConfig);
       applyDesktopConfigActions(nextConfig);
+      return nextConfig;
     } catch (error) {
-      if (currentRun !== refreshRunRef.current) return;
+      if (currentRun !== refreshRunRef.current) {
+        if (requireFresh) throw error;
+        return cached ?? DEFAULT_DESKTOP_CONFIG;
+      }
 
       // If the server says the active org doesn't exist, re-sync Better Auth
       // so the next refresh hits a valid org. Same recovery path as Solid.
@@ -249,7 +261,10 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
         );
       }
 
-      applyDesktopConfigActions(cached ?? DEFAULT_DESKTOP_CONFIG);
+      const fallbackConfig = cached ?? DEFAULT_DESKTOP_CONFIG;
+      applyDesktopConfigActions(fallbackConfig);
+      if (requireFresh) throw error;
+      return fallbackConfig;
     } finally {
       if (currentRun === refreshRunRef.current) {
         setDesktopConfigState((current) => ({ ...current, loading: false }));
@@ -257,7 +272,16 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     }
   }, [applyDesktopConfigActions, isSignedIn]);
 
-  const refresh = desktopConfigHandler;
+  const refresh = useCallback(
+    async () => {
+      await desktopConfigHandler();
+    },
+    [desktopConfigHandler],
+  );
+  const refreshFresh = useCallback(
+    () => desktopConfigHandler(true),
+    [desktopConfigHandler],
+  );
 
   // Re-run whenever auth flips or Den settings change. Read the cache
   // synchronously so gated UI never flickers through "unrestricted" just
@@ -334,8 +358,16 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
       );
     };
     Object.defineProperty(window, "__openworkApplyDesktopConfig", { value: bridge, configurable: true });
+    const refreshBridge = (configPayload: unknown) => {
+      devRefreshDesktopConfigRef.current = normalizeDenDesktopConfig(configPayload);
+    };
+    Object.defineProperty(window, "__openworkSetDesktopConfigRefreshResult", {
+      value: refreshBridge,
+      configurable: true,
+    });
     return () => {
       Object.defineProperty(window, "__openworkApplyDesktopConfig", { value: undefined, configurable: true });
+      Object.defineProperty(window, "__openworkSetDesktopConfigRefreshResult", { value: undefined, configurable: true });
     };
   }, [applyDesktopConfigActions]);
 
@@ -344,8 +376,8 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
     // recent org restrictions without having to recompute every render.
     const checkRestriction: DesktopAppRestrictionChecker = ({ restriction }) =>
       checkDesktopAppRestriction({ config, restriction });
-    return { config, loading, refresh, checkRestriction };
-  }, [config, loading, refresh]);
+    return { config, loading, refresh, refreshFresh, checkRestriction };
+  }, [config, loading, refresh, refreshFresh]);
 
   return (
     <DesktopConfigContext.Provider value={value}>

--- a/apps/app/src/react-app/domains/settings/pages/updates-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/updates-view.tsx
@@ -122,6 +122,8 @@ export function UpdatesView(props: UpdatesViewProps) {
                     ? t("settings.update_checking")
                     : updateState === "available"
                       ? t("settings.update_available_version", undefined, { version: updateVersion ?? "" })
+                      : updateState === "blocked"
+                        ? t("settings.update_blocked_version", undefined, { version: updateVersion ?? "" })
                       : updateState === "downloading"
                         ? t("settings.update_downloading")
                         : updateState === "ready"
@@ -131,7 +133,7 @@ export function UpdatesView(props: UpdatesViewProps) {
                             : t("settings.update_uptodate")}
                 </LayoutSectionItemTitle>
                 <LayoutSectionItemDescription>
-                  {updateState === "idle" && updateLastCheckedAt
+                  {(updateState === "idle" || updateState === "blocked") && updateLastCheckedAt
                     ? t("settings.update_last_checked", undefined, {
                         time: formatRelativeTime(updateLastCheckedAt),
                       })
@@ -186,6 +188,13 @@ export function UpdatesView(props: UpdatesViewProps) {
               {updateState === "error" && updateErrorMessage ? (
                 <Alert variant="destructive">
                   <CircleAlert />
+                  <AlertDescription>{updateErrorMessage}</AlertDescription>
+                </Alert>
+              ) : null}
+
+              {updateState === "blocked" && updateErrorMessage ? (
+                <Alert>
+                  <Info />
                   <AlertDescription>{updateErrorMessage}</AlertDescription>
                 </Alert>
               ) : null}

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -2,13 +2,18 @@
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
 import type { DenDesktopConfig } from "../../../../app/lib/den";
-import { isAlphaUpdateAllowed, isUpdateAllowed } from "../../../../app/lib/version-gate";
+import {
+  isAlphaUpdateAllowed,
+  isUpdateAllowed,
+  resolveFreshStableDesktopUpdate,
+} from "../../../../app/lib/version-gate";
 import type { ReleaseChannel } from "../../../../app/types";
 import { isElectronRuntime, safeStringify } from "../../../../app/utils";
+import { t } from "../../../../i18n";
 import { useUpdateCheckRequestStore } from "./update-check-request";
 
 export type SettingsUpdateStatus = {
-  state: "idle" | "checking" | "available" | "downloading" | "ready" | "error";
+  state: "idle" | "checking" | "available" | "blocked" | "downloading" | "ready" | "error";
   lastCheckedAt?: number | null;
   version?: string;
   date?: string;
@@ -21,12 +26,20 @@ export type SettingsUpdateStatus = {
 type ElectronUpdaterBridge = NonNullable<Window["__OPENWORK_ELECTRON__"]>["updater"] & {
   onDownloadProgress?: (callback: (data: { transferred: number; total: number; percent: number; bytesPerSecond: number }) => void) => (() => void);
 };
+
+declare global {
+  interface Window {
+    __openworkUpdaterEvalBridge?: ElectronUpdaterBridge;
+  }
+}
+
 type UseElectronUpdaterStateOptions = {
   releaseChannel: ReleaseChannel;
   onReleaseChannelChange: (next: ReleaseChannel) => void;
   updateAutoCheck: boolean;
   updateAutoDownload: boolean;
   desktopConfig: DenDesktopConfig | null | undefined;
+  refreshDesktopConfig: () => Promise<DenDesktopConfig>;
   setError: (message: string | null) => void;
 };
 
@@ -56,6 +69,9 @@ function electronUpdaterEnvReducer(
 
 function electronUpdaterBridge(): ElectronUpdaterBridge | null {
   if (typeof window === "undefined") return null;
+  if (import.meta.env.DEV && window.__openworkUpdaterEvalBridge) {
+    return window.__openworkUpdaterEvalBridge;
+  }
   return window.__OPENWORK_ELECTRON__?.updater ?? null;
 }
 
@@ -94,7 +110,15 @@ function updateProgress(event: unknown): { downloaded?: number; total?: number }
 }
 
 export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions) {
-  const { releaseChannel, onReleaseChannelChange, updateAutoCheck, updateAutoDownload, desktopConfig, setError } = options;
+  const {
+    releaseChannel,
+    onReleaseChannelChange,
+    updateAutoCheck,
+    updateAutoDownload,
+    desktopConfig,
+    refreshDesktopConfig,
+    setError,
+  } = options;
   const [updateStatus, setUpdateStatus] = useState<SettingsUpdateStatus>(null);
   const [envState, dispatchEnvState] = useReducer(electronUpdaterEnvReducer, {
     appVersion: null,
@@ -179,7 +203,10 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     }
   }, [desktopConfig, releaseChannel, setError]);
 
-  const checkForUpdates = useCallback(async (channelOverride?: ReleaseChannel) => {
+  const runCheckForUpdates = useCallback(async (
+    channelOverride?: ReleaseChannel,
+    manual = false,
+  ) => {
     const activeReleaseChannel = channelOverride ?? releaseChannel;
     const bridge = electronUpdaterBridge();
     if (!bridge?.check) {
@@ -191,7 +218,45 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
 
     setUpdateStatus({ state: "checking" });
     try {
-      const result = await bridge.check(activeReleaseChannel);
+      let targetVersion: string | undefined;
+      const freshDesktopConfig = desktopConfig;
+      if (manual && activeReleaseChannel === "stable") {
+        const channelState = await bridge.getChannel?.();
+        const currentVersion = channelState?.currentVersion ?? appVersion;
+        if (!currentVersion) {
+          throw new Error("Could not determine the installed OpenWork version.");
+        }
+
+        const selection = await resolveFreshStableDesktopUpdate({
+          currentVersion,
+          refreshDesktopConfig,
+        });
+        if (!selection) {
+          throw new Error("Den returned an invalid desktop release inventory.");
+        }
+        if (selection.kind === "blocked") {
+          setUpdateStatus({
+            state: "blocked",
+            lastCheckedAt: Date.now(),
+            version: selection.latestPublishedVersion,
+            message: t("settings.update_blocked_org", undefined, {
+              version: selection.latestPublishedVersion,
+            }),
+          });
+          return;
+        }
+        if (selection.kind === "current") {
+          setUpdateStatus({
+            state: "idle",
+            lastCheckedAt: Date.now(),
+            version: selection.latestPublishedVersion,
+          });
+          return;
+        }
+        targetVersion = selection.targetVersion;
+      }
+
+      const result = await bridge.check(activeReleaseChannel, targetVersion);
       dispatchEnvState({ type: "app-version", appVersion: result.currentVersion ?? null });
       if (result.channel && result.channel !== releaseChannel) {
         onReleaseChannelChange(result.channel);
@@ -210,9 +275,11 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
 
       const checkedReleaseChannel = result.channel ?? activeReleaseChannel;
       const availableAllowed = result.available && result.latestVersion
-        ? checkedReleaseChannel === "alpha"
-          ? await isAlphaUpdateAllowed(result.latestVersion, desktopConfig)
-          : await isUpdateAllowed(result.latestVersion, desktopConfig)
+        ? targetVersion
+          ? result.latestVersion === targetVersion
+          : checkedReleaseChannel === "alpha"
+            ? await isAlphaUpdateAllowed(result.latestVersion, freshDesktopConfig)
+            : await isUpdateAllowed(result.latestVersion, freshDesktopConfig)
         : result.available;
       const nextStatus: Exclude<SettingsUpdateStatus, null> = availableAllowed
         ? {
@@ -236,15 +303,20 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     } catch (error) {
       setUpdateStatus({ state: "error", message: describeError(error) });
     }
-  }, [desktopConfig, downloadUpdate, onReleaseChannelChange, releaseChannel, setError, updateAutoDownload]);
+  }, [appVersion, desktopConfig, downloadUpdate, onReleaseChannelChange, refreshDesktopConfig, releaseChannel, setError, updateAutoDownload]);
+
+  const checkForUpdates = useCallback(
+    (channelOverride?: ReleaseChannel) => runCheckForUpdates(channelOverride, true),
+    [runCheckForUpdates],
+  );
 
   useEffect(() => {
     if (!updateAutoCheck || updateEnv?.supported === false) return;
     const key = `${releaseChannel}:${appVersion ?? "unknown"}`;
     if (autoCheckKeyRef.current === key) return;
     autoCheckKeyRef.current = key;
-    void checkForUpdates();
-  }, [appVersion, checkForUpdates, releaseChannel, updateAutoCheck, updateEnv?.supported]);
+    void runCheckForUpdates(undefined, false);
+  }, [appVersion, releaseChannel, runCheckForUpdates, updateAutoCheck, updateEnv?.supported]);
 
   // Run a check when the native "Check for Updates..." menu item was used.
   const updateCheckRequestedAt = useUpdateCheckRequestStore((state) => state.requestedAt);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -780,6 +780,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     updateAutoCheck,
     updateAutoDownload,
     desktopConfig: desktopConfig.config,
+    refreshDesktopConfig: desktopConfig.refreshFresh,
     setError: (message) => {
       if (message) {
         // Auto-checks can fail without any user action; alert + log to the

--- a/apps/app/tests/den-desktop-config.test.ts
+++ b/apps/app/tests/den-desktop-config.test.ts
@@ -37,6 +37,29 @@ describe("Den desktop config client", () => {
     expect(headers[0]?.get("x-openwork-legacy-org-id")).toBe("org_test");
   });
 
+  test("falls back to latestAppVersion for older Den version metadata", async () => {
+    const fetchMock: typeof fetch = async () => new Response(JSON.stringify({
+      minAppVersion: "0.11.207",
+      latestAppVersion: "0.17.24",
+    }), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: fetchMock,
+    });
+
+    await expect(
+      createDenClient({ baseUrl: "https://den.test" }).getAppVersionMetadata(),
+    ).resolves.toEqual({
+      minAppVersion: "0.11.207",
+      latestAppVersion: "0.17.24",
+      publishedDesktopVersions: ["0.17.24"],
+    });
+  });
+
   test("normalizes organization onboarding prompts from desktop config", () => {
     expect(normalizeDenDesktopConfig({
       onboardingPrompts: [" First task ", "Second task", "Third task"],

--- a/apps/app/tests/version-gate.test.ts
+++ b/apps/app/tests/version-gate.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, test } from "bun:test";
+import {
+  resolveFreshStableDesktopUpdate,
+  selectStableDesktopUpdate,
+} from "../src/app/lib/version-gate";
+
+const metadata = {
+  minAppVersion: "0.11.207",
+  latestAppVersion: "0.17.24",
+  publishedDesktopVersions: ["0.17.22", "0.17.23", "0.17.24"],
+};
+
+describe("selectStableDesktopUpdate", () => {
+  test("selects the highest approved published release above the installed version", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.22",
+      metadata,
+      desktopConfig: { allowedDesktopVersions: ["0.17.23"] },
+    })).toEqual({
+      kind: "update",
+      targetVersion: "0.17.23",
+      latestPublishedVersion: "0.17.24",
+    });
+  });
+
+  test("reports a newer published release that still needs administrator approval", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.23",
+      metadata,
+      desktopConfig: { allowedDesktopVersions: ["0.17.23"] },
+    })).toEqual({ kind: "blocked", latestPublishedVersion: "0.17.24" });
+  });
+
+  test("never selects an older approved release", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.23",
+      metadata,
+      desktopConfig: { allowedDesktopVersions: ["0.17.22"] },
+    })).toEqual({ kind: "blocked", latestPublishedVersion: "0.17.24" });
+  });
+
+  test("keeps unrestricted organizations on the latest compatible published release", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.22",
+      metadata,
+      desktopConfig: {},
+    })).toEqual({
+      kind: "update",
+      targetVersion: "0.17.24",
+      latestPublishedVersion: "0.17.24",
+    });
+  });
+
+  test("does not downgrade when the installed version is newer than Den's inventory", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.25",
+      metadata,
+      desktopConfig: {},
+    })).toEqual({ kind: "current", latestPublishedVersion: "0.17.24" });
+  });
+
+  test("uses the config returned by the manual refresh instead of a stale cached policy", async () => {
+    let refreshCalls = 0;
+    const selection = await resolveFreshStableDesktopUpdate({
+      currentVersion: "0.17.22",
+      refreshDesktopConfig: async () => {
+        refreshCalls += 1;
+        return { allowedDesktopVersions: ["0.17.23"] };
+      },
+      readMetadata: async () => metadata,
+    });
+
+    expect(refreshCalls).toBe(1);
+    expect(selection).toEqual({
+      kind: "update",
+      targetVersion: "0.17.23",
+      latestPublishedVersion: "0.17.24",
+    });
+  });
+});

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -99,8 +99,8 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     setChannel(channel) {
       return ipcRenderer.invoke("openwork:updater:setChannel", channel);
     },
-    check(channel) {
-      return ipcRenderer.invoke("openwork:updater:check", channel);
+    check(channel, targetVersion) {
+      return ipcRenderer.invoke("openwork:updater:check", channel, targetVersion);
     },
     download() {
       return ipcRenderer.invoke("openwork:updater:download");

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -69,6 +69,12 @@ function electronUpdaterFeedUrl(channel) {
   return ELECTRON_UPDATER_FEEDS[normalizeElectronUpdaterChannel(channel)];
 }
 
+function normalizeStableTargetVersion(value) {
+  if (typeof value !== "string") return null;
+  const normalized = value.trim().replace(/^v/i, "");
+  return /^\d+\.\d+\.\d+$/.test(normalized) ? normalized : null;
+}
+
 function parseComparableVersion(value) {
   if (typeof value !== "string") return null;
   const normalized = value.trim().replace(/^v/i, "");
@@ -141,22 +147,43 @@ function isVersionNewer(candidate, current) {
   return comparison === null ? candidate !== current : comparison > 0;
 }
 
-function updaterChannelState(app, channel) {
+export function targetedStableUpdaterFeed(currentVersion, targetVersion) {
+  const normalizedTarget = normalizeStableTargetVersion(targetVersion);
+  if (!normalizedTarget) {
+    throw new Error("Target update version must use the stable x.y.z format.");
+  }
+  const comparison = compareVersions(normalizedTarget, currentVersion);
+  if (comparison === null) {
+    throw new Error("Installed version could not be validated for a targeted update.");
+  }
+  if (comparison <= 0) {
+    throw new Error("Target update version must be newer than the installed version.");
+  }
+  return `https://github.com/different-ai/openwork/releases/download/v${normalizedTarget}`;
+}
+
+function updaterChannelState(app, channel, targetVersion = null) {
   const normalized = normalizeElectronUpdaterChannel(channel);
+  const currentVersion = resolveAppVersion(app);
   return {
     channel: normalized,
-    feedUrl: electronUpdaterFeedUrl(normalized),
-    currentVersion: resolveAppVersion(app),
+    feedUrl: targetVersion
+      ? targetedStableUpdaterFeed(currentVersion, targetVersion)
+      : electronUpdaterFeedUrl(normalized),
+    currentVersion,
   };
 }
 
-async function applyElectronUpdaterFeed(app, updater) {
+async function applyElectronUpdaterFeed(app, updater, targetVersion = null) {
   const channel = await readElectronUpdaterChannel(app);
-  const state = updaterChannelState(app, channel);
+  if (targetVersion && channel !== "stable") {
+    throw new Error("Version-specific update feeds are supported only on the stable channel.");
+  }
+  const state = updaterChannelState(app, channel, targetVersion);
   updater.allowPrerelease = state.channel === "alpha";
   // Moving from alpha back to stable can be a semver downgrade; still show
   // the latest stable so users can return to the stable channel deliberately.
-  updater.allowDowngrade = state.channel === "stable";
+  updater.allowDowngrade = state.channel === "stable" && !targetVersion;
   if (updater?.setFeedURL) {
     updater.setFeedURL({ provider: "generic", url: state.feedUrl });
   }
@@ -219,6 +246,7 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
   let autoUpdaterInstance = null;
   let autoUpdaterLoaded = false;
   let checkedUpdateVersion = null;
+  let checkedUpdateTargetVersion = null;
 
   function sendToRenderer(channel, data) {
     try {
@@ -281,6 +309,7 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
   ipcMain.handle("openwork:updater:setChannel", async (_event, rawChannel) => {
     const channel = await writeElectronUpdaterChannel(app, rawChannel);
     checkedUpdateVersion = null;
+    checkedUpdateTargetVersion = null;
     const updater = await ensureAutoUpdater();
     if (updater) {
       return applyElectronUpdaterFeed(app, updater);
@@ -288,32 +317,48 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     return updaterChannelState(app, channel);
   });
 
-  ipcMain.handle("openwork:updater:check", async (_event, rawChannel) => {
+  ipcMain.handle("openwork:updater:check", async (_event, rawChannel, rawTargetVersion) => {
     if (rawChannel !== undefined) {
       await writeElectronUpdaterChannel(app, rawChannel);
     }
     const updater = await ensureAutoUpdater();
-    const channelState = updater
-      ? await applyElectronUpdaterFeed(app, updater)
-      : updaterChannelState(app, await readElectronUpdaterChannel(app));
-    if (!updater) return { available: false, reason: "unavailable", ...channelState };
     try {
+      const targetVersion = rawTargetVersion === undefined
+        ? null
+        : normalizeStableTargetVersion(rawTargetVersion);
+      if (rawTargetVersion !== undefined && !targetVersion) {
+        throw new Error("Target update version must use the stable x.y.z format.");
+      }
+      const channelState = updater
+        ? await applyElectronUpdaterFeed(app, updater, targetVersion)
+        : updaterChannelState(app, await readElectronUpdaterChannel(app), targetVersion);
+      if (!updater) return { available: false, reason: "unavailable", ...channelState };
+
       const result = await updater.checkForUpdates();
       const info = result?.updateInfo ?? null;
       const currentVersion = resolveAppVersion(app);
+      if (targetVersion && compareVersions(info?.version ?? "", targetVersion) !== 0) {
+        throw new Error(`Target update manifest did not resolve to v${targetVersion}.`);
+      }
       const available = Boolean(info?.version && isVersionNewer(info.version, currentVersion));
       checkedUpdateVersion = available ? info.version : null;
+      checkedUpdateTargetVersion = available ? targetVersion : null;
       return {
         available,
         currentVersion,
-        latestVersion: info?.version ?? null,
+        latestVersion: targetVersion ?? info?.version ?? null,
         releaseDate: info?.releaseDate ?? null,
         releaseNotes: info?.releaseNotes ?? null,
         ...channelState,
       };
     } catch (error) {
       checkedUpdateVersion = null;
-      return { available: false, reason: String(error?.message ?? error), ...channelState };
+      checkedUpdateTargetVersion = null;
+      return {
+        available: false,
+        reason: String(error?.message ?? error),
+        ...updaterChannelState(app, await readElectronUpdaterChannel(app)),
+      };
     }
   });
 
@@ -321,11 +366,17 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };
     try {
-      await applyElectronUpdaterFeed(app, updater);
+      await applyElectronUpdaterFeed(app, updater, checkedUpdateTargetVersion);
       const currentVersion = resolveAppVersion(app);
       if (!checkedUpdateVersion || !isVersionNewer(checkedUpdateVersion, currentVersion)) {
         const result = await updater.checkForUpdates();
         const info = result?.updateInfo ?? null;
+        if (
+          checkedUpdateTargetVersion &&
+          compareVersions(info?.version ?? "", checkedUpdateTargetVersion) !== 0
+        ) {
+          throw new Error(`Target update manifest did not resolve to v${checkedUpdateTargetVersion}.`);
+        }
         checkedUpdateVersion = info?.version && isVersionNewer(info.version, currentVersion)
           ? info.version
           : null;

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { staleUpdaterStatePaths } from "./updater.mjs";
+import { staleUpdaterStatePaths, targetedStableUpdaterFeed } from "./updater.mjs";
 
 const fakeApp = { getPath: (key) => (key === "home" ? "/Users/test" : `/Users/test/${key}`) };
 
@@ -14,5 +14,43 @@ describe("staleUpdaterStatePaths", () => {
 
   it("is a no-op off macOS", { skip: process.platform === "darwin" }, () => {
     assert.deepEqual(staleUpdaterStatePaths(fakeApp), []);
+  });
+});
+
+describe("targetedStableUpdaterFeed", () => {
+  it("builds a fixed GitHub release feed from a strict stable version", () => {
+    assert.equal(
+      targetedStableUpdaterFeed("0.17.22", "0.17.23"),
+      "https://github.com/different-ai/openwork/releases/download/v0.17.23",
+    );
+  });
+
+  it("rejects arbitrary URLs and prerelease targets", () => {
+    assert.throws(
+      () => targetedStableUpdaterFeed("0.17.22", "https://example.test/latest.yml"),
+      /stable x\.y\.z format/,
+    );
+    assert.throws(
+      () => targetedStableUpdaterFeed("0.17.22", "0.17.23-alpha.1"),
+      /stable x\.y\.z format/,
+    );
+  });
+
+  it("rejects equal and older targets", () => {
+    assert.throws(
+      () => targetedStableUpdaterFeed("0.17.23", "0.17.23"),
+      /newer than the installed version/,
+    );
+    assert.throws(
+      () => targetedStableUpdaterFeed("0.17.23", "0.17.22"),
+      /newer than the installed version/,
+    );
+  });
+
+  it("fails closed when the installed version cannot be compared", () => {
+    assert.throws(
+      () => targetedStableUpdaterFeed("unknown", "0.17.23"),
+      /could not be validated/,
+    );
   });
 });

--- a/ee/apps/den-api/src/desktop-release-inventory.ts
+++ b/ee/apps/den-api/src/desktop-release-inventory.ts
@@ -1,0 +1,151 @@
+import { z } from "zod"
+
+const GITHUB_RELEASES_URL = "https://api.github.com/repos/different-ai/openwork/releases?per_page=100"
+const INVENTORY_CACHE_MS = 5 * 60 * 1000
+const INVENTORY_STALE_MS = 24 * 60 * 60 * 1000
+const REQUIRED_STABLE_MANIFESTS = new Set([
+  "latest.yml",
+  "latest-mac.yml",
+  "latest-linux.yml",
+  "latest-linux-arm64.yml",
+])
+
+const githubReleaseSchema = z.object({
+  tag_name: z.string(),
+  draft: z.boolean(),
+  prerelease: z.boolean(),
+  published_at: z.string().nullable(),
+  assets: z.array(z.object({ name: z.string() })),
+})
+
+const githubReleasesSchema = z.array(githubReleaseSchema)
+
+type StableVersion = {
+  major: number
+  minor: number
+  patch: number
+}
+
+type CachedInventory = {
+  fetchedAt: number
+  versions: string[]
+}
+
+let cachedInventory: CachedInventory | null = null
+let inventoryRequest: Promise<string[]> | null = null
+
+function parseStableVersion(value: string): StableVersion | null {
+  const normalized = value.trim().replace(/^v/i, "")
+  const parts = normalized.split(".")
+  if (parts.length !== 3 || parts.some((part) => !/^\d+$/.test(part))) return null
+
+  const major = Number(parts[0])
+  const minor = Number(parts[1])
+  const patch = Number(parts[2])
+  if (![major, minor, patch].every(Number.isSafeInteger)) return null
+
+  return { major, minor, patch }
+}
+
+function compareStableVersions(left: string, right: string): number | null {
+  const parsedLeft = parseStableVersion(left)
+  const parsedRight = parseStableVersion(right)
+  if (!parsedLeft || !parsedRight) return null
+
+  if (parsedLeft.major !== parsedRight.major) return parsedLeft.major < parsedRight.major ? -1 : 1
+  if (parsedLeft.minor !== parsedRight.minor) return parsedLeft.minor < parsedRight.minor ? -1 : 1
+  if (parsedLeft.patch !== parsedRight.patch) return parsedLeft.patch < parsedRight.patch ? -1 : 1
+  return 0
+}
+
+export function publishedDesktopVersionsFromGitHubPayload(input: {
+  payload: unknown
+  minAppVersion: string
+  latestAppVersion: string
+}): string[] {
+  const parsed = githubReleasesSchema.safeParse(input.payload)
+  if (!parsed.success) return []
+
+  const versions = parsed.data.flatMap((release) => {
+    if (release.draft || release.prerelease || !release.published_at) return []
+
+    const version = release.tag_name.trim().replace(/^v/i, "")
+    if (!parseStableVersion(version)) return []
+
+    const aboveMinimum = compareStableVersions(version, input.minAppVersion)
+    const atOrBelowLatest = compareStableVersions(version, input.latestAppVersion)
+    if (aboveMinimum === null || aboveMinimum < 0 || atOrBelowLatest === null || atOrBelowLatest > 0) {
+      return []
+    }
+
+    const assetNames = new Set(release.assets.map((asset) => asset.name))
+    if ([...REQUIRED_STABLE_MANIFESTS].some((manifest) => !assetNames.has(manifest))) return []
+
+    return [version]
+  })
+
+  return [...new Set(versions)].sort((left, right) => compareStableVersions(left, right) ?? 0)
+}
+
+async function fetchPublishedDesktopVersions(input: {
+  minAppVersion: string
+  latestAppVersion: string
+}): Promise<string[]> {
+  const githubToken = process.env.GITHUB_TOKEN?.trim()
+  const response = await fetch(GITHUB_RELEASES_URL, {
+    headers: {
+      Accept: "application/vnd.github+json",
+      "User-Agent": "openwork-den-api",
+      "X-GitHub-Api-Version": "2022-11-28",
+      ...(githubToken ? { Authorization: `Bearer ${githubToken}` } : {}),
+    },
+    signal: AbortSignal.timeout(5_000),
+  })
+
+  if (!response.ok) {
+    throw new Error(`GitHub releases request failed (${response.status})`)
+  }
+
+  const versions = publishedDesktopVersionsFromGitHubPayload({
+    payload: await response.json(),
+    minAppVersion: input.minAppVersion,
+    latestAppVersion: input.latestAppVersion,
+  })
+  if (versions.length === 0) {
+    throw new Error("GitHub releases response did not include usable stable desktop releases")
+  }
+  return versions
+}
+
+export async function getPublishedDesktopVersions(input: {
+  minAppVersion: string
+  latestAppVersion: string
+}): Promise<string[]> {
+  const now = Date.now()
+  if (cachedInventory && now - cachedInventory.fetchedAt < INVENTORY_CACHE_MS) {
+    return cachedInventory.versions
+  }
+
+  if (!inventoryRequest) {
+    inventoryRequest = fetchPublishedDesktopVersions(input)
+      .then((versions) => {
+        cachedInventory = { fetchedAt: Date.now(), versions }
+        return versions
+      })
+      .finally(() => {
+        inventoryRequest = null
+      })
+  }
+
+  try {
+    return await inventoryRequest
+  } catch (error) {
+    if (cachedInventory && now - cachedInventory.fetchedAt < INVENTORY_STALE_MS) {
+      console.warn("[desktop-releases] using stale release inventory", error)
+      return cachedInventory.versions
+    }
+
+    console.warn("[desktop-releases] using Den build version as release inventory fallback", error)
+    return [input.latestAppVersion]
+  }
+}

--- a/ee/apps/den-api/src/routes/version/index.ts
+++ b/ee/apps/den-api/src/routes/version/index.ts
@@ -4,10 +4,12 @@ import { z } from "zod"
 import { publicRoute } from "../../middleware/index.js"
 import { jsonResponse } from "../../openapi.js"
 import { denApiAppVersion } from "../../version.js"
+import { getPublishedDesktopVersions } from "../../desktop-release-inventory.js"
 
 const appVersionResponseSchema = z.object({
   minAppVersion: z.string(),
   latestAppVersion: z.string().min(1),
+  publishedDesktopVersions: z.array(z.string().min(1)),
 }).meta({ ref: "DenAppVersionResponse" })
 
 export function registerVersionRoutes<T extends Env>(app: Hono<T>) {
@@ -16,14 +18,16 @@ export function registerVersionRoutes<T extends Env>(app: Hono<T>) {
     describeRoute({
       tags: ["System"],
       summary: "Get desktop app version metadata",
-      description: "Returns the minimum supported desktop app version and the latest desktop app version published with this Den API build.",
+      description: "Returns the supported desktop app range and the stable published releases that include complete updater manifests.",
       responses: {
         200: jsonResponse("Desktop app version metadata returned successfully.", appVersionResponseSchema),
       },
     }),
     publicRoute,
-    (c) => {
-      return c.json(denApiAppVersion)
+    async (c) => {
+      const publishedDesktopVersions = await getPublishedDesktopVersions(denApiAppVersion)
+      c.header("Cache-Control", "public, max-age=300, stale-if-error=86400")
+      return c.json({ ...denApiAppVersion, publishedDesktopVersions })
     },
   )
 }

--- a/ee/apps/den-api/test/desktop-release-inventory.test.ts
+++ b/ee/apps/den-api/test/desktop-release-inventory.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test"
+import { publishedDesktopVersionsFromGitHubPayload } from "../src/desktop-release-inventory.js"
+
+const completeAssets = [
+  { name: "latest.yml" },
+  { name: "latest-mac.yml" },
+  { name: "latest-linux.yml" },
+  { name: "latest-linux-arm64.yml" },
+]
+
+function release(input: {
+  version: string
+  draft?: boolean
+  prerelease?: boolean
+  assets?: { name: string }[]
+}) {
+  return {
+    tag_name: input.version,
+    draft: input.draft ?? false,
+    prerelease: input.prerelease ?? false,
+    published_at: "2026-07-13T18:53:10Z",
+    assets: input.assets ?? completeAssets,
+  }
+}
+
+describe("publishedDesktopVersionsFromGitHubPayload", () => {
+  test("returns only stable, supported releases with complete platform manifests", () => {
+    const versions = publishedDesktopVersionsFromGitHubPayload({
+      payload: [
+        release({ version: "v0.17.24" }),
+        release({ version: "v0.17.22" }),
+        release({ version: "v0.17.23" }),
+        release({ version: "v0.17.25" }),
+        release({ version: "v0.17.21" }),
+        release({ version: "v0.17.23-alpha.1", prerelease: true }),
+        release({ version: "v0.17.23-draft", draft: true }),
+        release({ version: "v0.17.23", assets: [{ name: "latest.yml" }] }),
+      ],
+      minAppVersion: "0.17.22",
+      latestAppVersion: "0.17.24",
+    })
+
+    expect(versions).toEqual(["0.17.22", "0.17.23", "0.17.24"])
+  })
+
+  test("fails closed for malformed GitHub payloads", () => {
+    expect(publishedDesktopVersionsFromGitHubPayload({
+      payload: { tag_name: "v0.17.24" },
+      minAppVersion: "0.17.22",
+      latestAppVersion: "0.17.24",
+    })).toEqual([])
+  })
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/desktop-version-options.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/desktop-version-options.ts
@@ -1,0 +1,71 @@
+type DesktopVersionMetadata = {
+  minAppVersion: string
+  latestAppVersion: string
+  publishedDesktopVersions: string[]
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+export function normalizeDesktopVersionString(value: string): string | null {
+  const normalized = value.trim().replace(/^v/i, "")
+  return /^\d+\.\d+\.\d+$/.test(normalized) ? normalized : null
+}
+
+function compareDesktopVersions(left: string, right: string): number {
+  const leftParts = left.split(".").map(Number)
+  const rightParts = right.split(".").map(Number)
+  for (let index = 0; index < 3; index += 1) {
+    const difference = (leftParts[index] ?? 0) - (rightParts[index] ?? 0)
+    if (difference !== 0) return difference
+  }
+  return 0
+}
+
+export function getDesktopVersionMetadata(payload: unknown): DesktopVersionMetadata | null {
+  if (!isRecord(payload)) return null
+
+  const minAppVersion = typeof payload.minAppVersion === "string"
+    ? normalizeDesktopVersionString(payload.minAppVersion)
+    : null
+  const latestAppVersion = typeof payload.latestAppVersion === "string"
+    ? normalizeDesktopVersionString(payload.latestAppVersion)
+    : null
+  const publishedDesktopVersions = Array.isArray(payload.publishedDesktopVersions)
+    ? payload.publishedDesktopVersions.flatMap((value) => {
+        if (typeof value !== "string") return []
+        const normalized = normalizeDesktopVersionString(value)
+        return normalized ? [normalized] : []
+      })
+    : []
+
+  if (!minAppVersion || !latestAppVersion) return null
+
+  return {
+    minAppVersion,
+    latestAppVersion,
+    publishedDesktopVersions: [...new Set(
+      publishedDesktopVersions.length > 0 ? publishedDesktopVersions : [latestAppVersion],
+    )].sort(compareDesktopVersions),
+  }
+}
+
+export function initialAllowedDesktopVersions(
+  storedVersions: string[] | null,
+  publishedVersions: string[],
+): string[] {
+  return storedVersions === null ? publishedVersions : [...storedVersions]
+}
+
+export function allPublishedDesktopVersionsAllowed(input: {
+  draftVersions: string[]
+  publishedVersions: string[]
+}): boolean {
+  if (input.publishedVersions.length === 0) return false
+
+  const publishedSet = new Set(input.publishedVersions)
+  const draftSet = new Set(input.draftVersions)
+  const hasStoredVersionOutsideInventory = input.draftVersions.some((version) => !publishedSet.has(version))
+  return !hasStoredVersionOutsideInventory && input.publishedVersions.every((version) => draftSet.has(version))
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
@@ -13,6 +13,11 @@ import { DenNotice } from "../../_components/ui/notice";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { EnterprisePlanNotice } from "./enterprise-plan-notice";
 import { EgressDiagnosticsCard } from "./egress-diagnostics-card";
+import {
+  allPublishedDesktopVersionsAllowed,
+  getDesktopVersionMetadata,
+  initialAllowedDesktopVersions,
+} from "./desktop-version-options";
 
 function normalizeAllowedEmailDomainsInput(value: string): string[] | null {
   const domains = [
@@ -27,64 +32,6 @@ function normalizeAllowedEmailDomainsInput(value: string): string[] | null {
   return domains.length > 0 ? domains : null;
 }
 
-function normalizeDesktopVersionString(value: string): string | null {
-  const normalized = value.trim().replace(/^v/i, "");
-  return /^\d+\.\d+\.\d+$/.test(normalized) ? normalized : null;
-}
-
-function getDesktopVersionMetadata(payload: unknown): {
-  minAppVersion: string;
-  latestAppVersion: string;
-} | null {
-  if (!payload || typeof payload !== "object") {
-    return null;
-  }
-
-  const record = payload as Record<string, unknown>;
-
-  const minAppVersion =
-    typeof record.minAppVersion === "string"
-      ? normalizeDesktopVersionString(record.minAppVersion)
-      : null;
-  const latestAppVersion =
-    typeof record.latestAppVersion === "string"
-      ? normalizeDesktopVersionString(record.latestAppVersion)
-      : null;
-
-  if (!minAppVersion || !latestAppVersion) {
-    return null;
-  }
-
-  return { minAppVersion, latestAppVersion };
-}
-
-function buildDesktopVersionOptions(
-  minVersion: string,
-  maxVersion: string,
-): string[] {
-  const minMatch = minVersion.match(/^(\d+)\.(\d+)\.(\d+)$/);
-  const maxMatch = maxVersion.match(/^(\d+)\.(\d+)\.(\d+)$/);
-  if (!minMatch || !maxMatch) {
-    return [...new Set([minVersion, maxVersion])];
-  }
-
-  const minMajor = Number(minMatch[1]);
-  const minMinor = Number(minMatch[2]);
-  const minPatch = Number(minMatch[3]);
-  const maxMajor = Number(maxMatch[1]);
-  const maxMinor = Number(maxMatch[2]);
-  const maxPatch = Number(maxMatch[3]);
-
-  if (minMajor !== maxMajor || minMinor !== maxMinor || minPatch > maxPatch) {
-    return [...new Set([minVersion, maxVersion])];
-  }
-
-  return Array.from(
-    { length: maxPatch - minPatch + 1 },
-    (_, index) => `${minMajor}.${minMinor}.${minPatch + index}`,
-  );
-}
-
 function toggleAllowedDesktopVersion(
   current: string[],
   version: string,
@@ -95,18 +42,6 @@ function toggleAllowedDesktopVersion(
   }
 
   return current.filter((entry) => entry !== version);
-}
-
-function filterAllowedDesktopVersionsToVisibleOptions(
-  storedVersions: string[] | null,
-  visibleOptions: string[],
-) {
-  if (storedVersions === null) {
-    return null;
-  }
-
-  const visibleOptionSet = new Set(visibleOptions);
-  return storedVersions.filter((version) => visibleOptionSet.has(version));
 }
 
 function SettingsToggle({
@@ -188,23 +123,14 @@ export function OrgSettingsScreen() {
     [allowedDomainsDraft],
   );
   const hasDraftDomains = (draftAllowedDomains?.length ?? 0) > 0;
-  const visibleAllowedDesktopVersionsDraft = useMemo(
-    () =>
-      filterAllowedDesktopVersionsToVisibleOptions(
-        allowedDesktopVersionsDraft,
-        desktopVersionOptions,
-      ) ?? [],
-    [allowedDesktopVersionsDraft, desktopVersionOptions],
-  );
   const selectedDesktopVersions = useMemo(
-    () => new Set(visibleAllowedDesktopVersionsDraft),
-    [visibleAllowedDesktopVersionsDraft],
+    () => new Set(allowedDesktopVersionsDraft),
+    [allowedDesktopVersionsDraft],
   );
-  const allDesktopVersionsAllowed =
-    desktopVersionOptions.length > 0 &&
-    desktopVersionOptions.every((version) =>
-      selectedDesktopVersions.has(version),
-    );
+  const allDesktopVersionsAllowed = allPublishedDesktopVersionsAllowed({
+    draftVersions: allowedDesktopVersionsDraft,
+    publishedVersions: desktopVersionOptions,
+  });
 
   useEffect(() => {
     if (!orgContext) {
@@ -254,12 +180,7 @@ export function OrgSettingsScreen() {
           return;
         }
 
-        setDesktopVersionOptions(
-          buildDesktopVersionOptions(
-            metadata.minAppVersion,
-            metadata.latestAppVersion,
-          ),
-        );
+        setDesktopVersionOptions(metadata.publishedDesktopVersions);
       } catch (error) {
         if (!cancelled) {
           setDesktopVersionOptions([]);
@@ -288,30 +209,11 @@ export function OrgSettingsScreen() {
       return;
     }
 
-    const storedAllowedDesktopVersions =
-      filterAllowedDesktopVersionsToVisibleOptions(
-        getAllowedDesktopVersionsFromMetadata(orgContext.organization.metadata),
-        desktopVersionOptions,
-      );
-
-    if (storedAllowedDesktopVersions === null) {
-      setAllowedDesktopVersionsDraft(desktopVersionOptions);
-      return;
-    }
-
-    setAllowedDesktopVersionsDraft(storedAllowedDesktopVersions);
+    setAllowedDesktopVersionsDraft(initialAllowedDesktopVersions(
+      getAllowedDesktopVersionsFromMetadata(orgContext.organization.metadata),
+      desktopVersionOptions,
+    ));
   }, [desktopVersionOptions, orgContext]);
-
-  useEffect(() => {
-    if (
-      visibleAllowedDesktopVersionsDraft.length ===
-      allowedDesktopVersionsDraft.length
-    ) {
-      return;
-    }
-
-    setAllowedDesktopVersionsDraft(visibleAllowedDesktopVersionsDraft);
-  }, [allowedDesktopVersionsDraft.length, visibleAllowedDesktopVersionsDraft]);
 
   useEffect(() => {
     if (!copiedOrgId) {
@@ -387,9 +289,7 @@ export function OrgSettingsScreen() {
           ? {
               allowedDesktopVersions: allDesktopVersionsAllowed
                 ? null
-                : desktopVersionOptions.filter((version) =>
-                    selectedDesktopVersions.has(version),
-                  ),
+                : allowedDesktopVersionsDraft,
             }
           : {}),
         requireSso: requireSsoEnabled,

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs",
+    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/desktop-version-options.test.ts
+++ b/ee/apps/den-web/tests/desktop-version-options.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, test } from "bun:test"
+import {
+  allPublishedDesktopVersionsAllowed,
+  getDesktopVersionMetadata,
+  initialAllowedDesktopVersions,
+} from "../app/(den)/dashboard/_components/desktop-version-options"
+
+describe("desktop version options", () => {
+  test("uses the explicit published inventory without synthesizing intermediate versions", () => {
+    expect(getDesktopVersionMetadata({
+      minAppVersion: "0.11.207",
+      latestAppVersion: "0.17.24",
+      publishedDesktopVersions: ["0.17.24", "0.17.22", "0.17.23"],
+    })?.publishedDesktopVersions).toEqual(["0.17.22", "0.17.23", "0.17.24"])
+  })
+
+  test("falls back to the latest version from older Den APIs", () => {
+    expect(getDesktopVersionMetadata({
+      minAppVersion: "0.11.207",
+      latestAppVersion: "0.17.24",
+    })?.publishedDesktopVersions).toEqual(["0.17.24"])
+  })
+
+  test("preserves stored versions that are absent from the current inventory", () => {
+    expect(initialAllowedDesktopVersions(
+      ["0.17.21", "0.17.23"],
+      ["0.17.22", "0.17.23", "0.17.24"],
+    )).toEqual(["0.17.21", "0.17.23"])
+
+    expect(allPublishedDesktopVersionsAllowed({
+      draftVersions: ["0.17.21", "0.17.22", "0.17.23", "0.17.24"],
+      publishedVersions: ["0.17.22", "0.17.23", "0.17.24"],
+    })).toBe(false)
+  })
+
+  test("represents an unrestricted policy by selecting the full inventory", () => {
+    const publishedVersions = ["0.17.22", "0.17.23", "0.17.24"]
+    const draftVersions = initialAllowedDesktopVersions(null, publishedVersions)
+    expect(allPublishedDesktopVersionsAllowed({ draftVersions, publishedVersions })).toBe(true)
+  })
+})

--- a/evals/flows/approved-desktop-update-targeting.flow.mjs
+++ b/evals/flows/approved-desktop-update-targeting.flow.mjs
@@ -1,0 +1,325 @@
+import { connect, debuggerUrlFor, listTargets } from "../runner/cdp.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "approved-desktop-update-targeting";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "http://127.0.0.1:3005").replace(/\/+$/, "");
+const ADMIN_CDP_URL = (process.env.OPENWORK_EVAL_WEB_CDP_ADMIN ?? "").replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function firstPageTarget(cdpBaseUrl) {
+  const targets = await listTargets(cdpBaseUrl);
+  const target = targets.find((entry) => entry.type === "page" && entry.webSocketDebuggerUrl);
+  if (!target) throw new Error(`No page target available at ${cdpBaseUrl}`);
+  return target;
+}
+
+async function withClient(ctx, cdpBaseUrl, callback) {
+  const previous = ctx.client;
+  const target = await firstPageTarget(cdpBaseUrl);
+  const client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+  ctx.client = client;
+  try {
+    return await callback();
+  } finally {
+    ctx.client = previous;
+    client.close();
+  }
+}
+
+async function clickExact(ctx, text, selector = "button, a") {
+  await ctx.waitFor(`(() => {
+    const element = [...document.querySelectorAll(${JSON.stringify(selector)})]
+      .find((entry) => (entry.textContent ?? '').replace(/\\s+/g, ' ').trim() === ${JSON.stringify(text)} && !entry.disabled);
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 30_000, label: `click ${text}` });
+}
+
+async function signInAndOpenOrgSettings(ctx) {
+  await ctx.client.send("Network.clearBrowserCookies", {}).catch(() => undefined);
+  await ctx.client.send("Network.clearBrowserCache", {}).catch(() => undefined);
+  await ctx.client.send("Network.setCacheDisabled", { cacheDisabled: true }).catch(() => undefined);
+  await ctx.client.send("Page.navigate", { url: DEN_WEB_URL });
+  await ctx.waitFor("location.origin !== 'null' && document.readyState === 'complete'", { timeoutMs: 30_000, label: "Den sign-in page" });
+  await ctx.eval("(() => { localStorage.clear(); sessionStorage.clear(); return true; })()");
+  await ctx.client.send("Page.reload", { ignoreCache: true });
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"]'))", { timeoutMs: 45_000, label: "Den email sign-in" });
+  await ctx.fill('input[type="email"]', ADMIN_EMAIL);
+  await clickExact(ctx, "Next", "button");
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 30_000, label: "Den password sign-in" });
+  await ctx.fill('input[type="password"]', ADMIN_PASSWORD);
+  await clickExact(ctx, "Sign in", "button");
+  await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 45_000, label: "Den dashboard" });
+  await ctx.eval(`location.assign(${JSON.stringify(`${DEN_WEB_URL}/dashboard/org-settings`)})`);
+  await ctx.waitForText("Allowed Desktop Versions", { timeoutMs: 60_000 });
+}
+
+async function setChecked(ctx, version, checked) {
+  await ctx.waitFor(`(() => {
+    const input = document.querySelector(${JSON.stringify(`input[aria-label="Allow desktop version ${version}"]`)});
+    if (!input) return false;
+    input.scrollIntoView({ block: 'center' });
+    if (input.checked !== ${checked}) input.click();
+    return input.checked === ${checked};
+  })()`, { timeoutMs: 30_000, label: `${version} checked=${checked}` });
+}
+
+async function configureDesktopEval(ctx, input) {
+  await ctx.eval(`(() => {
+    const metadata = {
+      minAppVersion: '0.11.207',
+      latestAppVersion: '0.17.24',
+      publishedDesktopVersions: ['0.17.22', '0.17.23', '0.17.24'],
+    };
+    window.__approvedUpdateEval ??= { currentVersion: '0.17.22', checks: [], metadataReads: 0 };
+    if (${input.reset === true}) {
+      window.__approvedUpdateEval.checks = [];
+      window.__approvedUpdateEval.metadataReads = 0;
+    }
+    window.__approvedUpdateEval.currentVersion = ${JSON.stringify(input.currentVersion)};
+    window.__approvedUpdateEval.delayMs = ${input.delayMs ?? 0};
+    const stale = window.__openworkApplyDesktopConfig;
+    const fresh = window.__openworkSetDesktopConfigRefreshResult;
+    if (typeof stale !== 'function' || typeof fresh !== 'function') throw new Error('Desktop policy eval bridge unavailable');
+    stale(${JSON.stringify(input.staleConfig)});
+    fresh(${JSON.stringify(input.freshConfig)});
+    window.__openworkReadDesktopVersionMetadataEval = async () => {
+      window.__approvedUpdateEval.metadataReads += 1;
+      return metadata;
+    };
+    window.__openworkUpdaterEvalBridge = {
+      getChannel: async () => ({ channel: 'stable', feedUrl: 'eval://stable', currentVersion: window.__approvedUpdateEval.currentVersion }),
+      check: async (channel, targetVersion) => {
+        window.__approvedUpdateEval.checks.push({ channel, targetVersion, currentVersion: window.__approvedUpdateEval.currentVersion });
+        if (window.__approvedUpdateEval.delayMs) await new Promise((resolve) => setTimeout(resolve, window.__approvedUpdateEval.delayMs));
+        return {
+          available: Boolean(targetVersion),
+          currentVersion: window.__approvedUpdateEval.currentVersion,
+          latestVersion: targetVersion ?? null,
+          channel: 'stable',
+          feedUrl: targetVersion ? 'https://github.com/different-ai/openwork/releases/download/v' + targetVersion : 'eval://stable',
+          releaseDate: '2026-07-13T18:43:13.427Z',
+        };
+      },
+      download: async () => ({ ok: true }),
+      installAndRestart: async () => ({ ok: true }),
+    };
+    return true;
+  })()`);
+}
+
+async function ensureDesktopSession(ctx) {
+  const apiUrl = ctx.env.OPENWORK_EVAL_DEN_API_URL.replace(/\/+$/, "");
+  const token = ctx.env.OPENWORK_EVAL_DEN_TOKEN;
+  const response = await fetch(`${apiUrl}/v1/me/orgs`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  const body = await response.json();
+  const organizations = Array.isArray(body?.orgs) ? body.orgs : [];
+  const activeOrg = organizations.find((organization) => organization?.id === body?.activeOrgId) ?? organizations[0];
+  if (!activeOrg?.id) throw new Error("The fraimz Den token has no active organization");
+
+  await ctx.control("eval.auth.set-base-url", { baseUrl: DEN_WEB_URL });
+  await ctx.eval(`(() => {
+    localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_WEB_URL)});
+    localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(apiUrl)});
+    localStorage.setItem('openwork.den.authToken', ${JSON.stringify(token)});
+    localStorage.setItem('openwork.den.activeOrgId', ${JSON.stringify(activeOrg.id)});
+    localStorage.setItem('openwork.den.activeOrgSlug', ${JSON.stringify(activeOrg.slug ?? "acme-robotics-demo")});
+    localStorage.setItem('openwork.den.activeOrgName', ${JSON.stringify(activeOrg.name ?? "Acme Robotics")});
+    window.dispatchEvent(new CustomEvent('openwork-den-settings-changed', { detail: {} }));
+    window.dispatchEvent(new CustomEvent('openwork-den-session-updated', { detail: { token: ${JSON.stringify(token)} } }));
+    return true;
+  })()`);
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    const status = await ctx.control("auth.status", {}).catch(() => null);
+    if (status?.status === "signed_in") return;
+    await sleep(250);
+  }
+  throw new Error("Desktop did not retain the seeded Den session");
+}
+
+async function openDesktopUpdates(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl && window.__openworkApplyDesktopConfig && window.__openworkSetDesktopConfigRefreshResult)", {
+    timeoutMs: 45_000,
+    label: "desktop eval bridges",
+  });
+  await ensureDesktopSession(ctx);
+  await ctx.navigateHash("/settings/updates");
+  await ctx.waitForText("Check now", { timeoutMs: 30_000 });
+  await ctx.eval(`(() => {
+    const toggle = document.querySelector('[aria-label="Check automatically"]');
+    if (toggle?.getAttribute('aria-checked') === 'true') toggle.click();
+    return true;
+  })()`);
+  await ctx.waitFor("document.querySelector('[aria-label=\"Check automatically\"]')?.getAttribute('aria-checked') === 'false'", {
+    timeoutMs: 5_000,
+    label: "automatic checks disabled for deterministic manual-check proof",
+  });
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Manual desktop checks refresh Den policy and install the highest approved published release",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_WEB_CDP_ADMIN"],
+  steps: [
+    {
+      name: "Frame 1 — Den exposes real published versions",
+      run: async (ctx) => withClient(ctx, ADMIN_CDP_URL, async () => {
+        await ctx.prove("Den shows the published 0.17.22–0.17.24 releases and saves 0.17.23 as the approved target", {
+          voiceover: vo[0],
+          action: async () => {
+            await signInAndOpenOrgSettings(ctx);
+            await setChecked(ctx, "0.17.22", false);
+            await setChecked(ctx, "0.17.23", true);
+            await setChecked(ctx, "0.17.24", false);
+            await clickExact(ctx, "Save settings", "button");
+          },
+          assert: async () => {
+            await sleep(500);
+            const state = await ctx.eval(`(() => Object.fromEntries(['0.17.22', '0.17.23', '0.17.24'].map((version) => {
+              const input = document.querySelector('input[aria-label="Allow desktop version ' + version + '"]');
+              return [version, input?.checked ?? null];
+            })))()`);
+            ctx.assert(state["0.17.22"] === false && state["0.17.23"] === true && state["0.17.24"] === false, JSON.stringify(state));
+            await ctx.eval(`document.querySelector('input[aria-label="Allow desktop version 0.17.23"]')?.closest('div.grid.gap-3')?.scrollIntoView({ block: 'center' })`);
+          },
+          screenshot: { name: "den-approved-01723", requireText: ["Allowed Desktop Versions", "0.17.22", "0.17.23", "0.17.24"] },
+        });
+      }),
+    },
+    {
+      name: "Frame 2 — Manual check refreshes stale policy",
+      run: async (ctx) => {
+        await ctx.prove("Check now refreshes the cached organization policy and Den release inventory", {
+          voiceover: vo[1],
+          action: async () => {
+            await openDesktopUpdates(ctx);
+            await configureDesktopEval(ctx, {
+              currentVersion: "0.17.22",
+              staleConfig: { allowedDesktopVersions: ["0.17.22"] },
+              freshConfig: { allowedDesktopVersions: ["0.17.23"] },
+              delayMs: 1_500,
+              reset: true,
+            });
+            await ctx.clickText("Check now");
+          },
+          assert: async () => {
+            await ctx.waitFor("window.__approvedUpdateEval.metadataReads > 0", {
+              timeoutMs: 5_000,
+              label: "fresh Den release inventory request",
+            });
+            await ctx.expectText("Checking for updates…");
+            const reads = await ctx.eval("window.__approvedUpdateEval.metadataReads");
+            ctx.assert(reads > 0, `expected a fresh metadata request, got ${reads}`);
+          },
+          screenshot: { name: "desktop-checking-fresh-policy", requireText: ["Updates", "Checking for updates…"] },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — Highest approved release wins",
+      run: async (ctx) => {
+        await ctx.prove("A 0.17.22 desktop offers approved 0.17.23 instead of unapproved latest 0.17.24", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.waitForText("Update available: v0.17.23", { timeoutMs: 10_000 });
+          },
+          assert: async () => {
+            const lastCheck = await ctx.eval("window.__approvedUpdateEval.checks.at(-1)");
+            ctx.assert(lastCheck?.targetVersion === "0.17.23", JSON.stringify(lastCheck));
+            await ctx.expectText("Download");
+          },
+          screenshot: { name: "desktop-offers-approved-01723", requireText: ["Update available: v0.17.23", "Download"], rejectText: ["v0.17.24"] },
+        });
+      },
+    },
+    {
+      name: "Frame 4 — Newer release is visibly blocked",
+      run: async (ctx) => {
+        await ctx.prove("On 0.17.23, OpenWork explains that 0.17.24 exists but still needs organization approval", {
+          voiceover: vo[3],
+          action: async () => {
+            await configureDesktopEval(ctx, {
+              currentVersion: "0.17.23",
+              staleConfig: { allowedDesktopVersions: ["0.17.23"] },
+              freshConfig: { allowedDesktopVersions: ["0.17.23"] },
+            });
+            await ctx.clickText("Check now");
+          },
+          assert: async () => {
+            await ctx.expectText("Update available: v0.17.24");
+            await ctx.expectText("OpenWork 0.17.24 is available, but your organization has not approved it yet. Ask an organization administrator to enable this version.");
+          },
+          screenshot: { name: "desktop-01724-needs-admin", requireText: ["Update available: v0.17.24", "Ask an organization administrator"] },
+        });
+      },
+    },
+    {
+      name: "Frame 5 — Next check sees new approval",
+      run: async (ctx) => {
+        await ctx.prove("The next manual check immediately offers 0.17.24 after the administrator approves it", {
+          voiceover: vo[4],
+          action: async () => {
+            await configureDesktopEval(ctx, {
+              currentVersion: "0.17.23",
+              staleConfig: { allowedDesktopVersions: ["0.17.23"] },
+              freshConfig: { allowedDesktopVersions: ["0.17.24"] },
+            });
+            await ctx.clickText("Check now");
+          },
+          assert: async () => {
+            await ctx.expectText("Download");
+            await ctx.expectText("Update available: v0.17.24");
+            const lastCheck = await ctx.eval("window.__approvedUpdateEval.checks.at(-1)");
+            ctx.assert(lastCheck?.targetVersion === "0.17.24", JSON.stringify(lastCheck));
+          },
+          screenshot: { name: "desktop-offers-newly-approved-01724", requireText: ["Update available: v0.17.24", "Download"], rejectText: ["has not approved"] },
+        });
+      },
+    },
+    {
+      name: "Frame 6 — Unrestricted latest, never downgrade",
+      run: async (ctx) => {
+        await ctx.prove("Unrestricted organizations receive latest while an older approved version never triggers a downgrade", {
+          voiceover: vo[5],
+          action: async () => {
+            await configureDesktopEval(ctx, {
+              currentVersion: "0.17.22",
+              staleConfig: {},
+              freshConfig: {},
+            });
+            await ctx.clickText("Check now");
+            await ctx.waitFor("(() => { const check = window.__approvedUpdateEval.checks.at(-1); return check?.currentVersion === '0.17.22' && check?.targetVersion === '0.17.24'; })()", {
+              timeoutMs: 10_000,
+              label: "unrestricted latest updater target",
+            });
+            const unrestrictedCheck = await ctx.eval("window.__approvedUpdateEval.checks.at(-1)");
+            ctx.assert(unrestrictedCheck?.targetVersion === "0.17.24", JSON.stringify(unrestrictedCheck));
+
+            await configureDesktopEval(ctx, {
+              currentVersion: "0.17.25",
+              staleConfig: { allowedDesktopVersions: ["0.17.24"] },
+              freshConfig: { allowedDesktopVersions: ["0.17.24"] },
+            });
+            await ctx.clickText("Check now");
+          },
+          assert: async () => {
+            await ctx.expectText("You're up to date");
+            await sleep(250);
+            const checks = await ctx.eval("window.__approvedUpdateEval.checks");
+            ctx.assert(checks.some((entry) => entry.targetVersion === "0.17.24"), JSON.stringify(checks));
+            ctx.assert(!checks.some((entry) => entry.currentVersion === "0.17.25"), `downgrade check reached updater: ${JSON.stringify(checks)}`);
+          },
+          screenshot: { name: "desktop-never-downgrades", requireText: ["You're up to date", "Check now"] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/approved-desktop-update-targeting.md
+++ b/evals/voiceovers/approved-desktop-update-targeting.md
@@ -1,0 +1,15 @@
+# approved-desktop-update-targeting — Manual update checks select the highest organization-approved published release
+
+Rashmi uses an organization-managed Windows desktop where administrators approve which OpenWork releases members can install.
+
+1. Rashmi is running OpenWork 0.17.22. Den shows the actual published versions 0.17.22, 0.17.23, and 0.17.24; her administrator approves 0.17.23, but not 0.17.24.
+
+2. Although Rashmi's desktop still has an older cached policy, manually clicking Check for updates refreshes the organization policy and published release inventory from Den.
+
+3. OpenWork selects the highest approved version newer than Rashmi's installation. It offers 0.17.23—not the unapproved latest release, 0.17.24.
+
+4. After Rashmi reaches 0.17.23, another check explains: “OpenWork 0.17.24 is available, but your organization has not approved it yet. Ask an organization administrator to enable this version.”
+
+5. When an administrator approves 0.17.24, the next manual check sees the change immediately and offers the update without waiting for the hourly policy refresh.
+
+6. Organizations without version restrictions continue receiving the latest compatible release normally. Older approved versions never cause a downgrade.


### PR DESCRIPTION
## Problem

A manual **Check now** could use an hour-old organization desktop policy. Even after an administrator approved a released version in Den, the desktop could report no update. Den also synthesized patch versions between its minimum and latest versions, so the settings UI could omit real intermediate releases or show versions with no updater artifacts.

 concrete case:

- installed: 0.17.22
- published: 0.17.23 and 0.17.24
- organization-approved: 0.17.23
- expected: offer 0.17.23, not the unapproved 0.17.24

## Change

- Refresh organization desktop policy and Den release metadata on a user-initiated stable update check.
- Expose Den's explicit stable desktop release inventory, derived from GitHub releases that contain all platform updater manifests.
- Select the highest version that is published, approved, and newer than the installed version.
- Show “OpenWork X is available, but your organization has not approved it yet” when a newer release exists but is blocked.
- Point Electron at the exact trusted GitHub release feed and verify that its manifest resolves to the selected version.
- Preserve existing automatic-check behavior and never downgrade.
- Keep compatibility with older Den APIs by treating only their reported latest version as published.

Release-inventory lookup uses a 5-minute in-process cache, coalesces concurrent requests, uses the last good value for up to 24 hours, and safely falls back to the Den build's latest version. Deployments can set GITHUB_TOKEN to avoid anonymous API limits; semi-air-gapped Den deployments need api.github.com allowlisted to expose intermediate versions.

## Validation

Passed locally:

- app: 192 tests, 0 failures; TypeScript typecheck
- Electron: 61 tests passed, 1 macOS-only skip; 53 renderer bridge methods covered; Electron TypeScript typecheck
- Den API inventory: 2 tests, 0 failures; TypeScript typecheck
- Den Web: 27 tests, 0 failures; TypeScript typecheck
- git diff --check

Fraimz passed all six claims:

1. Den lists actual 0.17.22, 0.17.23, and 0.17.24 releases.
2. Check now refreshes stale organization policy and release inventory.
3. A 0.17.22 client targets approved 0.17.23, not unapproved 0.17.24.
4. A 0.17.23 client shows that 0.17.24 needs administrator approval.
5. The next check sees a newly approved 0.17.24 immediately.
6. Unrestricted organizations get latest and older approvals never downgrade.

Windows release evidence for v0.17.23:

- latest.yml resolves successfully from the exact version feed
- manifest version is 0.17.23
- x64 installer: 231,266,041 bytes and HTTP 200 after redirects
- ARM64 installer: 216,604,690 bytes

The repository Windows x64/ARM build workflow will be dispatched on this branch and linked below.
