### PR TITLE
feat: verify Cloud MCP readiness per workspace

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -2233,10 +2233,16 @@ export async function fetchDenOrgSkillsCatalog(
  * current desktop Den session. Returns null when signed out or no active
  * organization is selected.
  */
-export async function mintCloudControlMcpToken(): Promise<DenMcpToken | null> {
-  const settings = readDenSettings();
+export type DenMcpTokenMintContext = {
+  baseUrl: string;
+  authToken: string | null;
+  orgId: string | null;
+};
+
+export async function mintCloudControlMcpToken(context?: DenMcpTokenMintContext): Promise<DenMcpToken | null> {
+  const settings = context ?? readDenSettings();
   const token = settings.authToken?.trim() ?? "";
-  const orgId = settings.activeOrgId?.trim() ?? "";
+  const orgId = ("orgId" in settings ? settings.orgId : settings.activeOrgId)?.trim() ?? "";
   if (!token || !orgId) {
     return null;
   }

--- a/apps/app/src/app/lib/diagnostic-sanitizer.ts
+++ b/apps/app/src/app/lib/diagnostic-sanitizer.ts
@@ -1,0 +1,84 @@
+const REDACTED = "[REDACTED]";
+
+const SENSITIVE_KEYS = new Set([
+  "authorization",
+  "token",
+  "secret",
+  "password",
+  "cookie",
+  "api_key",
+  "api-key",
+  "apikey",
+  "client_secret",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEYS.has(key.trim().toLowerCase());
+}
+
+export function sanitizeDiagnosticString(value: string): string {
+  return value
+    .replace(/Bearer\s+[A-Za-z0-9._~+\/-]+=*/gi, `Bearer ${REDACTED}`)
+    .replace(/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g, REDACTED)
+    .replace(/\bow[thc]_[A-Za-z0-9_-]+\b/g, REDACTED);
+}
+
+export function sanitizeDiagnosticValue(value: unknown): unknown {
+  if (typeof value === "string") return sanitizeDiagnosticString(value);
+  if (typeof value === "number" || typeof value === "boolean" || value === null) return value;
+  if (Array.isArray(value)) return value.map((item) => sanitizeDiagnosticValue(item));
+  if (!isRecord(value)) return String(value);
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    sanitized[key] = isSensitiveKey(key) ? REDACTED : sanitizeDiagnosticValue(nested);
+  }
+  return sanitized;
+}
+
+export function sanitizeDiagnosticRecord(value: Record<string, unknown>): Record<string, unknown> {
+  const sanitized = sanitizeDiagnosticValue(value);
+  return isRecord(sanitized) ? sanitized : {};
+}
+
+function isSafeCloudTokenMetadataKey(key: string): boolean {
+  const normalized = key.trim().toLowerCase();
+  return normalized.includes("fingerprint") ||
+    normalized.includes("hash") ||
+    normalized.includes("expir") ||
+    normalized === "scope" ||
+    normalized === "scopes";
+}
+
+function safeCloudTokenMetadata(value: unknown): Record<string, unknown> | null {
+  if (!isRecord(value)) return null;
+  const output: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    if (!isSafeCloudTokenMetadataKey(key)) continue;
+    if (typeof nested === "string") output[key] = sanitizeDiagnosticString(nested);
+    else if (typeof nested === "number" || typeof nested === "boolean" || nested === null) output[key] = nested;
+    else if (Array.isArray(nested)) output[key] = nested.map((item) => typeof item === "string" ? sanitizeDiagnosticString(item) : String(item));
+  }
+  return Object.keys(output).length ? output : null;
+}
+
+export function sanitizeCloudMcpHealthDiagnostic(value: unknown): unknown {
+  const sanitized = sanitizeDiagnosticValue(value);
+  if (!isRecord(value) || !isRecord(sanitized)) return sanitized;
+  const desired = isRecord(value.desired) ? value.desired : null;
+  const desiredSanitized = isRecord(sanitized.desired) ? sanitized.desired : null;
+  const token = desired && isRecord(desired.token) ? desired.token : null;
+  const metadata = token ? safeCloudTokenMetadata(token.metadata) : null;
+  if (!desiredSanitized || !metadata) return sanitized;
+  return {
+    ...sanitized,
+    desired: {
+      ...desiredSanitized,
+      tokenMetadata: metadata,
+    },
+  };
+}

--- a/apps/app/src/app/lib/diagnostics-bundle.ts
+++ b/apps/app/src/app/lib/diagnostics-bundle.ts
@@ -9,6 +9,7 @@ import {
   type OpenworkServerInfo,
 } from "./desktop";
 import { readPerfLogs, type PerfLogRecord } from "./perf-log";
+import { sanitizeCloudMcpHealthDiagnostic } from "./diagnostic-sanitizer";
 import {
   readOpenworkServerSettings,
   type OpenworkServerSettings,
@@ -27,6 +28,7 @@ export type DiagnosticsBundleContext = {
   openworkServerStatus?: OpenworkServerStatus;
   openworkServerUrl?: string;
   runtimeWorkspaceId?: string | null;
+  cloudMcpHealth?: unknown;
 };
 
 export type DiagnosticsBundleInputs = {
@@ -39,6 +41,7 @@ export type DiagnosticsBundleInputs = {
   developerLogs: DevLogRecord[];
   perfLogs: PerfLogRecord[];
   context?: DiagnosticsBundleContext;
+  cloudMcpHealth?: unknown;
 };
 
 type DiagnosticsExecution = {
@@ -166,6 +169,7 @@ export function composeDiagnosticsBundleJson(input: DiagnosticsBundleInputs): st
       },
       host: pickHostInfo(input.hostInfo),
     },
+    cloudMcp: sanitizeCloudMcpHealthDiagnostic(input.cloudMcpHealth ?? context?.cloudMcpHealth ?? null),
     reload: {
       canReloadWorkspace: context?.canReloadWorkspace === true,
     },

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -303,6 +303,202 @@ export type OpenworkMcpEngineSync = {
   failures: Array<{ name: string; status?: number; message?: string }>;
 };
 
+export type OpenworkCloudMcpProviderModelContext = {
+  provider: string;
+  model: string;
+};
+
+export type OpenworkCloudMcpFailureStage =
+  | "prerequisites"
+  | "token_mint"
+  | "desired_config"
+  | "engine_delivery"
+  | "transport_auth"
+  | "tool_registration"
+  | "provider_projection"
+  | "plugin_load"
+  | "steering"
+  | "desired"
+  | "workspace"
+  | "configuration"
+  | "registration"
+  | "engine_status"
+  | "tool_ids"
+  | "plugin_canary";
+
+export type OpenworkCloudMcpFailureCode =
+  | "cloud_desired_missing"
+  | "cloud_mcp_missing"
+  | "cloud_mcp_disabled"
+  | "cloud_endpoint_invalid"
+  | "cloud_token_org_mismatch"
+  | "cloud_mcp_needs_auth"
+  | "invalid_mcp_token"
+  | "mcp_session_revoked"
+  | "mcp_membership_revoked"
+  | "insufficient_mcp_scope"
+  | "wrong_mcp_resource"
+  | "workspace_directory_ambiguous"
+  | "opencode_unconfigured"
+  | "opencode_engine_unreachable"
+  | "opencode_unreachable"
+  | "cloud_status_missing"
+  | "cloud_disabled"
+  | "openwork_cloud_auth_required"
+  | "openwork_cloud_auth_invalid"
+  | "openwork_cloud_token_expired"
+  | "openwork_cloud_membership_required"
+  | "openwork_cloud_scope_missing"
+  | "openwork_cloud_resource_forbidden"
+  | "openwork_cloud_resource_not_found"
+  | "openwork_cloud_client_registration_required"
+  | "cloud_connection_failed"
+  | "cloud_registration_failed"
+  | "cloud_tools_denied"
+  | "opencode_tool_ids_unsupported"
+  | "opencode_tool_ids_unavailable"
+  | "cloud_tools_missing"
+  | "provider_projection_unavailable"
+  | "provider_projection_missing"
+  | "extensions_plugin_missing"
+  | string;
+
+export type OpenworkCloudMcpFailure = {
+  code: OpenworkCloudMcpFailureCode;
+  stage: OpenworkCloudMcpFailureStage | string;
+  retryable: boolean;
+  recommendedAction: string;
+  message: string;
+  aliases?: string[];
+  requestId?: string;
+  referenceId?: string;
+  details?: unknown;
+};
+
+export type OpenworkCloudMcpCompatibility = {
+  openwork: {
+    serverVersion: string | null;
+    app: Record<string, string | number | boolean | null> | null;
+  };
+  opencode: {
+    expectedVersion: string | null;
+    actualVersion: string | null;
+    probe: "ok" | "unavailable" | "not_checked" | string;
+    error?: unknown;
+  };
+  pluginFileHashes: Array<{
+    name: string;
+    sha256: string | null;
+    error?: string;
+  }>;
+  supportedFeatures: {
+    dynamicMcp: boolean;
+    directoryScoping: boolean;
+    toolIds: boolean;
+    providerToolProjection: boolean;
+    pluginCanaries: boolean;
+  };
+};
+
+export type OpenworkCloudMcpHealthPhase =
+  | "missing_desired"
+  | "workspace_ambiguous"
+  | "engine_unconfigured"
+  | "engine_unreachable"
+  | "engine_missing"
+  | "engine_disabled"
+  | "engine_needs_auth"
+  | "engine_needs_client_registration"
+  | "engine_failed"
+  | "registration_failed"
+  | "denied_by_tools"
+  | "tool_ids_unsupported"
+  | "cloud_tools_missing"
+  | "provider_projection_missing"
+  | "extensions_plugin_missing"
+  | "ready"
+  | string;
+
+export type OpenworkCloudMcpDeliverySnapshot = {
+  state: "not_desired" | "pending" | "registering" | "ready" | "failed" | "stale" | string;
+  desiredRevision: string | null;
+  appliedRevision: string | null;
+  updatedAt: number | null;
+  appliedAt: number | null;
+  lastAttemptAt: number | null;
+  trigger?: string;
+  failure?: OpenworkCloudMcpFailure;
+};
+
+export type OpenworkCloudMcpHealth = {
+  schemaVersion: 1;
+  phase: OpenworkCloudMcpHealthPhase;
+  usable: boolean;
+  usableByCurrentModel: boolean | null;
+  connectCatalogEnabled: boolean;
+  workspace: {
+    id: string;
+    type: string;
+    directory: string | null;
+    path: string;
+  };
+  desired: {
+    present: boolean;
+    name: "openwork-cloud";
+    revision: string | null;
+    config: Record<string, unknown> | null;
+    token: {
+      present: boolean;
+      metadata: Record<string, string | number | boolean | null>;
+    };
+    org?: Record<string, string | number | boolean | null>;
+    app?: Record<string, string | number | boolean | null>;
+    updatedAt?: number;
+  };
+  delivery: OpenworkCloudMcpDeliverySnapshot;
+  engine: {
+    status: "not_checked" | "missing" | "connected" | "disabled" | "failed" | "needs_auth" | "needs_client_registration" | "unreachable" | "unknown" | string;
+    error?: unknown;
+  };
+  tools: {
+    expected: string[];
+    present: string[];
+    missing: string[];
+    providerProjection: {
+      checked: boolean;
+      provider?: string;
+      model?: string;
+      present: string[];
+      missing: string[];
+      error?: unknown;
+    };
+  };
+  pluginCanaries: {
+    expected: string[];
+    present: string[];
+    missing: string[];
+  };
+  compatibility: OpenworkCloudMcpCompatibility;
+  toolDenies: unknown[];
+  firstFailure: OpenworkCloudMcpFailure | null;
+  checkedAt: string;
+};
+
+export type OpenworkCloudMcpReconcilePayload = {
+  workspaceId: string;
+  name: "openwork-cloud";
+  config: Record<string, unknown>;
+  tokenMetadata?: Record<string, string | number | boolean | null>;
+  org?: Record<string, string | number | boolean | null>;
+  app?: Record<string, string | number | boolean | null>;
+  appVersion?: string;
+  buildSha?: string;
+  connectCatalogEnabled?: boolean;
+  trigger?: string;
+  provider?: string;
+  model?: string;
+};
+
 export type OpenworkWorkspaceExport = {
   workspaceId: string;
   exportedAt: number;
@@ -1021,6 +1217,8 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     sessionRead: 12_000,
     status: 6_000,
     config: 10_000,
+    cloudMcpHealth: 12_000,
+    cloudMcpReconcile: 60_000,
     workspaceExport: 30_000,
     workspaceImport: 30_000,
     binary: 60_000,
@@ -1464,6 +1662,31 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         baseUrl,
         `/workspace/${workspaceId}/mcp`,
         { token, hostToken },
+      ),
+    getOpenworkCloudMcpHealth: (workspaceId: string, providerModel?: OpenworkCloudMcpProviderModelContext) => {
+      const query = new URLSearchParams();
+      if (providerModel?.provider.trim() && providerModel.model.trim()) {
+        query.set("provider", providerModel.provider.trim());
+        query.set("model", providerModel.model.trim());
+      }
+      const suffix = query.size ? `?${query.toString()}` : "";
+      return requestJson<OpenworkCloudMcpHealth>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/mcp/openwork-cloud/health${suffix}`,
+        { token, hostToken, timeoutMs: timeouts.cloudMcpHealth },
+      );
+    },
+    reconcileOpenworkCloudMcp: (workspaceId: string, payload: OpenworkCloudMcpReconcilePayload) =>
+      requestJson<OpenworkCloudMcpHealth>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/mcp/openwork-cloud/reconcile`,
+        {
+          token,
+          hostToken,
+          method: "POST",
+          body: payload,
+          timeoutMs: timeouts.cloudMcpReconcile,
+        },
       ),
     addMcp: (workspaceId: string, payload: { name: string; config: Record<string, unknown> }) =>
       requestJson<{ items: OpenworkMcpItem[] }>(baseUrl, `/workspace/${workspaceId}/mcp`, {

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
@@ -1,0 +1,444 @@
+import {
+  type DenMcpToken,
+  type DenMcpTokenMintContext,
+  resolveCloudMcpResourceUrl,
+} from "../../../app/lib/den";
+import type {
+  OpenworkCloudMcpFailure,
+  OpenworkCloudMcpHealth,
+  OpenworkCloudMcpProviderModelContext,
+  OpenworkCloudMcpReconcilePayload,
+} from "../../../app/lib/openwork-server";
+import {
+  CLOUD_MCP_SERVER_NAME,
+  clearCloudMcpScopedMetadata,
+  clearCloudMcpUserState,
+  getCloudMcpScopeKey,
+  isCloudMcpSyncMarkerFresh,
+  normalizeCloudMcpScope,
+  readCloudMcpSyncMarker,
+  readCloudMcpUserState,
+  writeCloudMcpSyncMarker,
+  writeCloudMcpUserState,
+  type CloudMcpScope,
+  type CloudMcpUserState,
+} from "./cloud-mcp-user-state";
+
+export const OPENWORK_CLOUD_EXPECTED_TOOLS = [
+  "openwork-cloud_search_capabilities",
+  "openwork-cloud_execute_capability",
+];
+
+export type CloudMcpClient = {
+  baseUrl: string;
+  getOpenworkCloudMcpHealth: (
+    workspaceId: string,
+    providerModel?: OpenworkCloudMcpProviderModelContext,
+  ) => Promise<OpenworkCloudMcpHealth>;
+  reconcileOpenworkCloudMcp: (
+    workspaceId: string,
+    payload: OpenworkCloudMcpReconcilePayload,
+  ) => Promise<OpenworkCloudMcpHealth>;
+};
+
+export type CloudMcpOperationContext = CloudMcpScope & {
+  denAuthToken: string | null;
+  orgSlug?: string | null;
+  orgName?: string | null;
+  fallbackUrl?: string | null;
+  providerModel?: OpenworkCloudMcpProviderModelContext;
+  connectCatalogEnabled?: boolean;
+  trigger?: string;
+};
+
+export type CloudMcpOperationMode = "health" | "repair";
+
+export type CloudMcpOperationResult = {
+  status: "checked" | "ready" | "repaired" | "unchanged" | "skipped" | "failed";
+  health: OpenworkCloudMcpHealth | null;
+  skippedReason?: "signed_out" | "missing_org" | "missing_workspace" | "disabled" | "deduped" | "mint_failed";
+  attempts: number;
+  markerWritten: boolean;
+  reminted: boolean;
+};
+
+export type CloudMcpMainStatus = "ready" | "connecting" | "disabled" | "degraded" | "signed_out";
+
+export type CloudMcpDisplaySummary = {
+  status: CloudMcpMainStatus;
+  statusLabel: "Ready" | "Connecting" | "Disabled" | "Degraded" | "Signed out";
+  tone: "ready" | "warning" | "neutral" | "error";
+  stageLabel: string;
+  recommendedAction: string;
+};
+
+type MintCloudMcpToken = (context: DenMcpTokenMintContext) => Promise<DenMcpToken | null>;
+
+type CloudMcpReconcilerInput = {
+  mode: CloudMcpOperationMode;
+  client: CloudMcpClient;
+  context: CloudMcpOperationContext;
+  mintToken: MintCloudMcpToken;
+  force?: boolean;
+  refreshMarginMs: number;
+  now?: number;
+  configuredEnabled?: boolean | null;
+};
+
+type OpenCodeDisconnectClient = {
+  mcp: {
+    disconnect: (input: { directory: string; name: string }) => Promise<unknown>;
+  };
+};
+
+type CleanupClient = {
+  baseUrl: string;
+  removeMcp: (workspaceId: string, name: string) => Promise<unknown>;
+};
+
+const repairInFlight = new Map<string, Promise<CloudMcpOperationResult>>();
+
+const APP_VERSION = String(import.meta.env.VITE_OPENWORK_APP_VERSION ?? "").trim();
+const APP_BUILD_SHA = String(import.meta.env.VITE_OPENWORK_BUILD_SHA ?? import.meta.env.VITE_OPENWORK_GIT_SHA ?? "").trim();
+
+function normalizeCode(code: string | null | undefined): string {
+  return code?.trim().toLowerCase().replace(/[-.]/g, "_") ?? "";
+}
+
+function normalizedContextScope(context: CloudMcpOperationContext): CloudMcpScope | null {
+  return normalizeCloudMcpScope({
+    denBaseUrl: context.denBaseUrl,
+    serverBaseUrl: context.serverBaseUrl,
+    orgId: context.orgId,
+    workspaceId: context.workspaceId,
+  });
+}
+
+function tokenMetadata(token: DenMcpToken): Record<string, string | number | boolean | null> {
+  return {
+    organizationId: token.organizationId,
+    expiresAt: token.expiresAt,
+    resource: token.resource,
+    scopes: token.scopes.join(" "),
+  };
+}
+
+function orgMetadata(context: CloudMcpOperationContext): Record<string, string | number | boolean | null> {
+  return {
+    id: context.orgId.trim(),
+    slug: context.orgSlug?.trim() || null,
+    name: context.orgName?.trim() || null,
+  };
+}
+
+function appMetadata(): Record<string, string | number | boolean | null> | undefined {
+  const metadata: Record<string, string | number | boolean | null> = {};
+  if (APP_VERSION) metadata.version = APP_VERSION;
+  if (APP_BUILD_SHA) metadata.buildSha = APP_BUILD_SHA;
+  return Object.keys(metadata).length ? metadata : undefined;
+}
+
+function resolveMcpUrl(token: DenMcpToken, fallbackUrl?: string | null): string | null {
+  const healedResource = resolveCloudMcpResourceUrl(token.resource);
+  if (healedResource) return `${healedResource}/agent`;
+  const fallback = fallbackUrl?.trim() ?? "";
+  return fallback || null;
+}
+
+export function buildOpenworkCloudMcpReconcilePayload(input: {
+  context: CloudMcpOperationContext;
+  token: DenMcpToken;
+}): OpenworkCloudMcpReconcilePayload | null {
+  const workspaceId = input.context.workspaceId.trim();
+  const url = resolveMcpUrl(input.token, input.context.fallbackUrl);
+  if (!workspaceId || !url) return null;
+  const app = appMetadata();
+  return {
+    workspaceId,
+    name: CLOUD_MCP_SERVER_NAME,
+    config: {
+      type: "remote",
+      enabled: true,
+      url,
+      headers: { Authorization: `Bearer ${input.token.token}` },
+      oauth: false,
+    },
+    tokenMetadata: tokenMetadata(input.token),
+    org: orgMetadata(input.context),
+    ...(app ? { app, appVersion: typeof app.version === "string" ? app.version : undefined, buildSha: typeof app.buildSha === "string" ? app.buildSha : undefined } : {}),
+    connectCatalogEnabled: input.context.connectCatalogEnabled ?? true,
+    trigger: input.context.trigger ?? "desktop-repair",
+    ...(input.context.providerModel ? {
+      provider: input.context.providerModel.provider,
+      model: input.context.providerModel.model,
+    } : {}),
+  };
+}
+
+export function isCloudMcpAuthTokenFailureCode(code: string | null | undefined): boolean {
+  const normalized = normalizeCode(code);
+  if (!normalized) return false;
+  if (
+    normalized.includes("membership") ||
+    normalized.includes("scope") ||
+    normalized.includes("policy") ||
+    normalized.includes("forbidden") ||
+    normalized.includes("resource") ||
+    normalized.includes("not_found") ||
+    normalized.includes("client_registration")
+  ) {
+    return false;
+  }
+  return normalized === "openwork_cloud_auth_required" ||
+    normalized === "openwork_cloud_auth_invalid" ||
+    normalized === "openwork_cloud_token_expired" ||
+    normalized.includes("invalid_token") ||
+    normalized.includes("unauthorized") ||
+    normalized.includes("expired") ||
+    normalized.includes("auth");
+}
+
+function shouldSkipForPrerequisite(input: CloudMcpReconcilerInput, scope: CloudMcpScope): CloudMcpOperationResult | null {
+  if (!scope.workspaceId) return { status: "skipped", health: null, skippedReason: "missing_workspace", attempts: 0, markerWritten: false, reminted: false };
+  if (input.mode === "health") return null;
+  if (!input.context.denAuthToken?.trim()) return { status: "skipped", health: null, skippedReason: "signed_out", attempts: 0, markerWritten: false, reminted: false };
+  if (!scope.orgId) return { status: "skipped", health: null, skippedReason: "missing_org", attempts: 0, markerWritten: false, reminted: false };
+  if (input.configuredEnabled === false || readCloudMcpUserState(scope) !== null) {
+    return { status: "skipped", health: null, skippedReason: "disabled", attempts: 0, markerWritten: false, reminted: false };
+  }
+  return null;
+}
+
+function writeUsableMarker(input: {
+  health: OpenworkCloudMcpHealth | null;
+  scope: CloudMcpScope;
+  expiresAt: string | null;
+}): boolean {
+  if (!input.health?.usable || !input.expiresAt) return false;
+  writeCloudMcpSyncMarker({ ...input.scope, expiresAt: input.expiresAt });
+  return true;
+}
+
+async function probeHealth(input: CloudMcpReconcilerInput, scope: CloudMcpScope, options?: { writeFreshnessMarker?: boolean }): Promise<CloudMcpOperationResult> {
+  const health = await input.client.getOpenworkCloudMcpHealth(scope.workspaceId, input.context.providerModel);
+  const marker = options?.writeFreshnessMarker ? readCloudMcpSyncMarker(scope) : null;
+  const markerWritten = options?.writeFreshnessMarker === true
+    ? writeUsableMarker({ health, scope, expiresAt: marker?.expiresAt ?? null })
+    : false;
+  return {
+    status: health.usable ? "ready" : "checked",
+    health,
+    attempts: 0,
+    markerWritten,
+    reminted: false,
+  };
+}
+
+async function mintAndPost(input: CloudMcpReconcilerInput, scope: CloudMcpScope): Promise<{ health: OpenworkCloudMcpHealth | null; token: DenMcpToken | null }> {
+  const token = await input.mintToken({
+    baseUrl: scope.denBaseUrl,
+    authToken: input.context.denAuthToken,
+    orgId: scope.orgId,
+  });
+  if (!token) return { health: null, token: null };
+  const payload = buildOpenworkCloudMcpReconcilePayload({ context: { ...input.context, ...scope }, token });
+  if (!payload) return { health: null, token };
+  return {
+    health: await input.client.reconcileOpenworkCloudMcp(scope.workspaceId, payload),
+    token,
+  };
+}
+
+async function repairCloudMcp(input: CloudMcpReconcilerInput, scope: CloudMcpScope): Promise<CloudMcpOperationResult> {
+  if (!input.force) {
+    const healthResult = await probeHealth(input, scope, { writeFreshnessMarker: true });
+    if (healthResult.health?.usable) return { ...healthResult, status: "unchanged" };
+  }
+
+  const marker = readCloudMcpSyncMarker(scope);
+  if (!input.force && marker && isCloudMcpSyncMarkerFresh({
+    expiresAt: marker.expiresAt,
+    now: input.now ?? Date.now(),
+    refreshMarginMs: input.refreshMarginMs,
+  })) {
+    const health = await input.client.getOpenworkCloudMcpHealth(scope.workspaceId, input.context.providerModel);
+    if (health.usable) return { status: "unchanged", health, attempts: 0, markerWritten: false, reminted: false };
+  }
+
+  const first = await mintAndPost(input, scope);
+  if (!first.token) {
+    return { status: "skipped", health: null, skippedReason: "mint_failed", attempts: 1, markerWritten: false, reminted: false };
+  }
+
+  let attempts = 1;
+  let health = first.health;
+  let token = first.token;
+  let reminted = false;
+  if (isCloudMcpAuthTokenFailureCode(health?.firstFailure?.code)) {
+    const second = await mintAndPost(input, scope);
+    attempts += 1;
+    reminted = true;
+    if (second.token) token = second.token;
+    if (second.health) health = second.health;
+  }
+
+  const markerWritten = writeUsableMarker({ health, scope, expiresAt: token.expiresAt });
+  return {
+    status: health?.usable ? "repaired" : "failed",
+    health,
+    attempts,
+    markerWritten,
+    reminted,
+  };
+}
+
+export async function runOpenworkCloudMcpReconciler(input: CloudMcpReconcilerInput): Promise<CloudMcpOperationResult> {
+  const scope = normalizedContextScope(input.context);
+  if (!scope) return { status: "skipped", health: null, skippedReason: "missing_workspace", attempts: 0, markerWritten: false, reminted: false };
+  const prerequisite = shouldSkipForPrerequisite(input, scope);
+  if (prerequisite) return prerequisite;
+
+  if (input.mode === "health") return probeHealth(input, scope);
+
+  const scopeKey = getCloudMcpScopeKey(scope);
+  if (!scopeKey) return { status: "skipped", health: null, skippedReason: "missing_workspace", attempts: 0, markerWritten: false, reminted: false };
+  const existing = repairInFlight.get(scopeKey);
+  if (existing) return existing;
+  const task = repairCloudMcp(input, scope).finally(() => {
+    repairInFlight.delete(scopeKey);
+  });
+  repairInFlight.set(scopeKey, task);
+  return task;
+}
+
+export function cloudMcpFailureStageLabel(input: {
+  signedIn: boolean;
+  orgSelected: boolean;
+  userState?: CloudMcpUserState | null;
+  health?: OpenworkCloudMcpHealth | null;
+}): string {
+  if (!input.signedIn) return "Sign in required";
+  if (!input.orgSelected) return "Select an organization";
+  if (input.userState) return "Agent access disabled";
+  const code = normalizeCode(input.health?.firstFailure?.code);
+  if (!code) return input.health?.usableByCurrentModel === null ? "Current model access not checked" : "Agent access ready";
+  if (code === "cloud_mcp_disabled" || code === "cloud_disabled") return "Agent access disabled";
+  if (code === "cloud_desired_missing" || code === "cloud_mcp_missing") return "Couldn’t apply Cloud access to this workspace";
+  if (code.includes("auth") || code.includes("token") || code.includes("unauthorized")) return "Cloud authentication expired";
+  if (code === "cloud_status_missing" || code === "cloud_registration_failed" || code === "cloud_tools_missing") return "Cloud tools weren’t registered";
+  if (code.includes("provider_projection")) return "Current model can’t use Cloud tools";
+  if (code.includes("tool_ids") || code.includes("client_registration")) return "OpenWork components need updating";
+  if (code === "extensions_plugin_missing") return "Agent instructions are out of date";
+  if (code.includes("unreachable") || code.includes("connection") || code.includes("status_missing")) return "Cloud connection unavailable";
+  return "Couldn’t apply Cloud access to this workspace";
+}
+
+export function cloudMcpRecommendedAction(input: {
+  signedIn: boolean;
+  orgSelected: boolean;
+  userState?: CloudMcpUserState | null;
+  health?: OpenworkCloudMcpHealth | null;
+}): string {
+  if (!input.signedIn) return "Sign in to OpenWork Cloud.";
+  if (!input.orgSelected) return "Choose the organization agents should use.";
+  if (input.userState) return "Enable Agent access or use Repair and test when you want agents to use connected services.";
+  const code = normalizeCode(input.health?.firstFailure?.code);
+  if (!code) {
+    if (input.health?.usableByCurrentModel === null) return "Model access was not checked because no current model is selected.";
+    return "No action needed.";
+  }
+  if (code === "cloud_mcp_disabled" || code === "cloud_disabled") return "Enable Agent access or use Repair and test when you want agents to use connected services.";
+  if (code === "cloud_desired_missing" || code === "cloud_mcp_missing") return "Use Repair and test to apply agent access for this workspace.";
+  if (code.includes("auth") || code.includes("token") || code.includes("unauthorized")) return "Use Repair and test to refresh Cloud authentication.";
+  if (code.includes("membership")) return "Ask an organization admin to grant access.";
+  if (code.includes("scope")) return "Reconnect OpenWork Cloud with the required permissions.";
+  if (code.includes("policy") || code.includes("forbidden") || code.includes("resource")) return "Check organization policy and resource access.";
+  if (code.includes("provider_projection")) return "Choose a model that can use OpenWork Cloud tools.";
+  if (code.includes("tool_ids") || code.includes("client_registration")) return "Update OpenWork, then retry.";
+  if (code === "extensions_plugin_missing") return "Reload the agent so OpenWork instructions are current.";
+  if (code === "cloud_status_missing" || code === "cloud_registration_failed" || code === "cloud_tools_missing") return "Use Repair and test to register the Cloud tools.";
+  return input.health?.firstFailure?.recommendedAction || "Use Repair and test, then check Advanced Settings if it still fails.";
+}
+
+export function cloudMcpDisplaySummary(input: {
+  signedIn: boolean;
+  orgSelected: boolean;
+  connecting: boolean;
+  userState?: CloudMcpUserState | null;
+  health?: OpenworkCloudMcpHealth | null;
+}): CloudMcpDisplaySummary {
+  if (input.connecting) {
+    return {
+      status: "connecting",
+      statusLabel: "Connecting",
+      tone: "warning",
+      stageLabel: "Cloud connection unavailable",
+      recommendedAction: "Checking agent access now.",
+    };
+  }
+  if (!input.signedIn) {
+    return {
+      status: "signed_out",
+      statusLabel: "Signed out",
+      tone: "neutral",
+      stageLabel: cloudMcpFailureStageLabel(input),
+      recommendedAction: cloudMcpRecommendedAction(input),
+    };
+  }
+  const code = normalizeCode(input.health?.firstFailure?.code);
+  const configEnabled = input.health?.desired.config?.enabled;
+  const disabled = input.userState || code === "cloud_mcp_disabled" || code === "cloud_disabled" || configEnabled === false;
+  if (disabled) {
+    return {
+      status: "disabled",
+      statusLabel: "Disabled",
+      tone: "neutral",
+      stageLabel: cloudMcpFailureStageLabel(input),
+      recommendedAction: cloudMcpRecommendedAction(input),
+    };
+  }
+  if (input.health?.usable) {
+    return {
+      status: "ready",
+      statusLabel: "Ready",
+      tone: "ready",
+      stageLabel: cloudMcpFailureStageLabel(input),
+      recommendedAction: cloudMcpRecommendedAction(input),
+    };
+  }
+  return {
+    status: "degraded",
+    statusLabel: "Degraded",
+    tone: "error",
+    stageLabel: cloudMcpFailureStageLabel(input),
+    recommendedAction: cloudMcpRecommendedAction(input),
+  };
+}
+
+export async function cleanupOpenworkCloudMcpAfterSignOut(input: {
+  context: CloudMcpScope;
+  openworkClient: CleanupClient | null;
+  opencodeClient: OpenCodeDisconnectClient | null;
+  directory: string;
+}): Promise<void> {
+  const scope = normalizeCloudMcpScope(input.context);
+  if (scope) clearCloudMcpScopedMetadata(scope);
+
+  await Promise.all([
+    input.openworkClient && scope
+      ? input.openworkClient.removeMcp(scope.workspaceId, CLOUD_MCP_SERVER_NAME).catch(() => null)
+      : Promise.resolve(null),
+    input.opencodeClient && input.directory.trim()
+      ? input.opencodeClient.mcp.disconnect({ directory: input.directory.trim(), name: CLOUD_MCP_SERVER_NAME }).catch(() => null)
+      : Promise.resolve(null),
+  ]);
+}
+
+export function recordCloudMcpDisabledIntent(scope: CloudMcpScope, state: CloudMcpUserState): void {
+  writeCloudMcpUserState(state, scope);
+  clearCloudMcpScopedMetadata(scope);
+}
+
+export function clearCloudMcpDisabledIntent(scope: CloudMcpScope): void {
+  clearCloudMcpUserState(scope);
+}

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.test.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.test.ts
@@ -14,6 +14,12 @@ import {
 } from "./cloud-mcp-user-state";
 
 const UNHEALTHY_REMINT_ATTEMPT_KEY = "openwork.den.mcp.unhealthyRemintAttempt";
+const scope = {
+  denBaseUrl: "https://cloud.openwork.test",
+  serverBaseUrl: "https://worker.openwork.test",
+  orgId: "org_1",
+  workspaceId: "ws_1",
+};
 
 function createStorageStub() {
   const values = new Map<string, string>();
@@ -42,13 +48,13 @@ describe("cloud MCP unhealthy re-mint attempt marker", () => {
     const { storage } = createStorageStub();
     __setCloudMcpUserStateStorageForTest(storage);
 
-    expect(readCloudMcpUnhealthyRemintAttempt()).toBe(null);
+    expect(readCloudMcpUnhealthyRemintAttempt(scope)).toBe(null);
 
-    writeCloudMcpUnhealthyRemintAttempt({ orgId: "org_1" });
-    expect(readCloudMcpUnhealthyRemintAttempt()).toEqual({ orgId: "org_1" });
+    writeCloudMcpUnhealthyRemintAttempt({ ...scope, attemptedAt: 123 });
+    expect(readCloudMcpUnhealthyRemintAttempt(scope)).toEqual({ ...scope, attemptedAt: 123 });
 
-    clearCloudMcpUnhealthyRemintAttempt();
-    expect(readCloudMcpUnhealthyRemintAttempt()).toBe(null);
+    clearCloudMcpUnhealthyRemintAttempt(scope);
+    expect(readCloudMcpUnhealthyRemintAttempt(scope)).toBe(null);
   });
 
   test("returns null for corrupt JSON", () => {
@@ -56,15 +62,16 @@ describe("cloud MCP unhealthy re-mint attempt marker", () => {
     __setCloudMcpUserStateStorageForTest(storage);
     values.set(UNHEALTHY_REMINT_ATTEMPT_KEY, "{");
 
-    expect(readCloudMcpUnhealthyRemintAttempt()).toBe(null);
+    expect(readCloudMcpUnhealthyRemintAttempt(scope)).toBe(null);
   });
 
-  test("returns the stored org so callers can compare org mismatches", () => {
+  test("keeps org-scoped markers separate", () => {
     const { storage } = createStorageStub();
     __setCloudMcpUserStateStorageForTest(storage);
 
-    writeCloudMcpUnhealthyRemintAttempt({ orgId: "org_a" });
+    writeCloudMcpUnhealthyRemintAttempt({ ...scope, orgId: "org_a", attemptedAt: 456 });
 
-    expect(readCloudMcpUnhealthyRemintAttempt()).toEqual({ orgId: "org_a" });
+    expect(readCloudMcpUnhealthyRemintAttempt(scope)).toBe(null);
+    expect(readCloudMcpUnhealthyRemintAttempt({ ...scope, orgId: "org_a" })).toEqual({ ...scope, orgId: "org_a", attemptedAt: 456 });
   });
 });

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
@@ -1,17 +1,6 @@
 import { CLOUD_MCP_SYNC_MARKER_STORAGE_KEY } from "../../../app/lib/den";
 
-/**
- * Durable record of the user's intent for the auto-configured OpenWork
- * Cloud Control MCP ("openwork-cloud").
- *
- * A background reconciler (`syncCloudControlMcp`) keeps that entry
- * configured with a fresh first-party token while the user is signed in to
- * OpenWork Cloud. Its writes hardcode `enabled: true` and recreate removed
- * entries, so without a durable record of "the user turned this off" the
- * reconciler resurrected the MCP on every sync tick — making it impossible
- * to disable. These helpers persist that intent; the reconciler consults it
- * before touching the entry, and any explicit user reconnect clears it.
- */
+/** Durable, scoped records for the auto-managed OpenWork Cloud MCP. */
 
 export const CLOUD_MCP_SERVER_NAME = "openwork-cloud";
 
@@ -19,18 +8,23 @@ const CLOUD_MCP_USER_STATE_KEY = "openwork.den.mcp.cloudControlUserState";
 const CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY = "openwork.den.mcp.unhealthyRemintAttempt";
 
 export type CloudMcpUserState = "disabled" | "removed";
-export type CloudMcpUnhealthyRemintAttempt = { orgId: string };
-export type CloudMcpSyncMarker = {
+export type CloudMcpScope = {
   denBaseUrl: string;
   serverBaseUrl: string;
   orgId: string;
   workspaceId: string;
+};
+export type CloudMcpUserStateEntry = CloudMcpScope & {
+  state: CloudMcpUserState;
+  updatedAt: number;
+};
+export type CloudMcpUnhealthyRemintAttempt = CloudMcpScope & {
+  attemptedAt: number;
+};
+export type CloudMcpSyncMarker = CloudMcpScope & {
   expiresAt: string;
 };
-export type CloudMcpSyncMarkerScope = Pick<
-  CloudMcpSyncMarker,
-  "denBaseUrl" | "serverBaseUrl" | "orgId" | "workspaceId"
->;
+export type CloudMcpSyncMarkerScope = CloudMcpScope;
 
 type StorageLike = Pick<Storage, "getItem" | "setItem" | "removeItem">;
 
@@ -54,106 +48,226 @@ function getStorage(): StorageLike | null {
   }
 }
 
-export function readCloudMcpUserState(): CloudMcpUserState | null {
+function normalizeMarkerBaseUrl(baseUrl: string): string {
+  return baseUrl.trim().replace(/\/+$/, "");
+}
+
+export function normalizeCloudMcpScope(scope: CloudMcpScope): CloudMcpScope | null {
+  const denBaseUrl = normalizeMarkerBaseUrl(scope.denBaseUrl);
+  const serverBaseUrl = normalizeMarkerBaseUrl(scope.serverBaseUrl);
+  const orgId = scope.orgId.trim();
+  const workspaceId = scope.workspaceId.trim();
+  if (!denBaseUrl || !serverBaseUrl || !orgId || !workspaceId) return null;
+  return { denBaseUrl, serverBaseUrl, orgId, workspaceId };
+}
+
+export function cloudMcpScopeEquals(left: CloudMcpScope, right: CloudMcpScope): boolean {
+  const normalizedLeft = normalizeCloudMcpScope(left);
+  const normalizedRight = normalizeCloudMcpScope(right);
+  if (!normalizedLeft || !normalizedRight) return false;
+  return normalizedLeft.denBaseUrl === normalizedRight.denBaseUrl &&
+    normalizedLeft.serverBaseUrl === normalizedRight.serverBaseUrl &&
+    normalizedLeft.orgId === normalizedRight.orgId &&
+    normalizedLeft.workspaceId === normalizedRight.workspaceId;
+}
+
+export function getCloudMcpScopeKey(scope: CloudMcpScope): string | null {
+  const normalized = normalizeCloudMcpScope(scope);
+  if (!normalized) return null;
+  return JSON.stringify([
+    normalized.denBaseUrl,
+    normalized.serverBaseUrl,
+    normalized.workspaceId,
+    normalized.orgId,
+  ]);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseUserStateEntry(value: unknown): CloudMcpUserStateEntry | null {
+  if (!isRecord(value)) return null;
+  if (value.state !== "disabled" && value.state !== "removed") return null;
+  const denBaseUrl = typeof value.denBaseUrl === "string" ? value.denBaseUrl : "";
+  const serverBaseUrl = typeof value.serverBaseUrl === "string" ? value.serverBaseUrl : "";
+  const orgId = typeof value.orgId === "string" ? value.orgId : "";
+  const workspaceId = typeof value.workspaceId === "string" ? value.workspaceId : "";
+  const scope = normalizeCloudMcpScope({ denBaseUrl, serverBaseUrl, orgId, workspaceId });
+  if (!scope) return null;
+  return {
+    ...scope,
+    state: value.state,
+    updatedAt: typeof value.updatedAt === "number" && Number.isFinite(value.updatedAt) ? value.updatedAt : 0,
+  };
+}
+
+function readCloudMcpUserStateEntries(): { entries: CloudMcpUserStateEntry[]; legacyState: CloudMcpUserState | null } {
   try {
     const raw = getStorage()?.getItem(CLOUD_MCP_USER_STATE_KEY);
-    if (raw === "disabled" || raw === "removed") return raw;
+    if (raw === "disabled" || raw === "removed") return { entries: [], legacyState: raw };
+    if (!raw) return { entries: [], legacyState: null };
+    const parsed: unknown = JSON.parse(raw);
+    const candidates = isRecord(parsed) && Array.isArray(parsed.entries) ? parsed.entries : [];
+    return {
+      entries: candidates.flatMap((entry) => {
+        const parsedEntry = parseUserStateEntry(entry);
+        return parsedEntry ? [parsedEntry] : [];
+      }),
+      legacyState: null,
+    };
   } catch {
-    // Storage unavailable — treat as no recorded intent.
+    // Storage unavailable or corrupt — treat as no recorded intent.
   }
+  return { entries: [], legacyState: null };
+}
+
+function writeCloudMcpUserStateEntries(entries: CloudMcpUserStateEntry[]) {
+  getStorage()?.setItem(
+    CLOUD_MCP_USER_STATE_KEY,
+    JSON.stringify({ version: 1, entries }),
+  );
+}
+
+export function readCloudMcpUserState(scope: CloudMcpScope): CloudMcpUserState | null {
+  const normalized = normalizeCloudMcpScope(scope);
+  if (!normalized) return null;
+  const { entries, legacyState } = readCloudMcpUserStateEntries();
+  const entry = entries.find((candidate) => cloudMcpScopeEquals(candidate, normalized));
+  if (entry) return entry.state;
+
+  if (legacyState) {
+    // One-time compatibility: old builds stored a single global intent. Move it
+    // to the currently active scope so it does not suppress other workspaces.
+    writeCloudMcpUserState(legacyState, normalized);
+    return legacyState;
+  }
+
   return null;
 }
 
-export function writeCloudMcpUserState(state: CloudMcpUserState) {
+export function writeCloudMcpUserState(state: CloudMcpUserState, scope: CloudMcpScope) {
   try {
-    getStorage()?.setItem(CLOUD_MCP_USER_STATE_KEY, state);
+    const normalized = normalizeCloudMcpScope(scope);
+    if (!normalized) return;
+    const entries = readCloudMcpUserStateEntries().entries.filter(
+      (entry) => !cloudMcpScopeEquals(entry, normalized),
+    );
+    writeCloudMcpUserStateEntries([...entries, { ...normalized, state, updatedAt: Date.now() }]);
   } catch {
-    // Storage unavailable — the reconciler may resurrect the entry; the
-    // enabled-flag guard in syncCloudControlMcp still applies.
+    // Storage unavailable — the enabled-flag guard in reconciliation still applies.
   }
 }
 
-export function clearCloudMcpUserState() {
+export function clearCloudMcpUserState(scope: CloudMcpScope) {
   try {
-    getStorage()?.removeItem(CLOUD_MCP_USER_STATE_KEY);
+    const normalized = normalizeCloudMcpScope(scope);
+    if (!normalized) return;
+    const entries = readCloudMcpUserStateEntries().entries.filter(
+      (entry) => !cloudMcpScopeEquals(entry, normalized),
+    );
+    if (entries.length) writeCloudMcpUserStateEntries(entries);
+    else getStorage()?.removeItem(CLOUD_MCP_USER_STATE_KEY);
   } catch {
     // ignore
   }
 }
 
-/**
- * One re-mint attempt per unhealthy Cloud Control MCP episode must survive
- * store remounts: the settings route recreates the connections store per
- * mount, which re-armed the re-mint and reloaded the engine on every settings
- * open. The episode ends when the entry reports connected, or when the user
- * forces a refresh.
- */
-export function readCloudMcpUnhealthyRemintAttempt(): CloudMcpUnhealthyRemintAttempt | null {
+function parseUnhealthyAttempt(value: unknown): CloudMcpUnhealthyRemintAttempt | null {
+  if (!isRecord(value)) return null;
+  const denBaseUrl = typeof value.denBaseUrl === "string" ? value.denBaseUrl : "";
+  const serverBaseUrl = typeof value.serverBaseUrl === "string" ? value.serverBaseUrl : "";
+  const orgId = typeof value.orgId === "string" ? value.orgId : "";
+  const workspaceId = typeof value.workspaceId === "string" ? value.workspaceId : "";
+  const scope = normalizeCloudMcpScope({ denBaseUrl, serverBaseUrl, orgId, workspaceId });
+  if (!scope) return null;
+  return {
+    ...scope,
+    attemptedAt: typeof value.attemptedAt === "number" && Number.isFinite(value.attemptedAt) ? value.attemptedAt : 0,
+  };
+}
+
+function readCloudMcpUnhealthyRemintAttempts(): { entries: CloudMcpUnhealthyRemintAttempt[]; legacyOrgId: string | null } {
   try {
     const raw = getStorage()?.getItem(CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY);
-    if (!raw) return null;
+    if (!raw) return { entries: [], legacyOrgId: null };
     const parsed: unknown = JSON.parse(raw);
-    if (
-      parsed &&
-      typeof parsed === "object" &&
-      !Array.isArray(parsed) &&
-      "orgId" in parsed &&
-      typeof parsed.orgId === "string"
-    ) {
-      return { orgId: parsed.orgId };
+    if (isRecord(parsed) && typeof parsed.orgId === "string" && !("entries" in parsed)) {
+      return { entries: [], legacyOrgId: parsed.orgId.trim() || null };
     }
+    const candidates = isRecord(parsed) && Array.isArray(parsed.entries) ? parsed.entries : [];
+    return {
+      entries: candidates.flatMap((entry) => {
+        const parsedEntry = parseUnhealthyAttempt(entry);
+        return parsedEntry ? [parsedEntry] : [];
+      }),
+      legacyOrgId: null,
+    };
   } catch {
     // Corrupt marker or storage unavailable — treat as no recorded attempt.
+  }
+  return { entries: [], legacyOrgId: null };
+}
+
+function writeCloudMcpUnhealthyRemintAttempts(entries: CloudMcpUnhealthyRemintAttempt[]) {
+  getStorage()?.setItem(
+    CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY,
+    JSON.stringify({ version: 1, entries }),
+  );
+}
+
+/** One re-mint attempt per unhealthy Cloud MCP episode, scoped to this exact workspace/org/server/deployment. */
+export function readCloudMcpUnhealthyRemintAttempt(scope: CloudMcpScope): CloudMcpUnhealthyRemintAttempt | null {
+  const normalized = normalizeCloudMcpScope(scope);
+  if (!normalized) return null;
+  const { entries, legacyOrgId } = readCloudMcpUnhealthyRemintAttempts();
+  const entry = entries.find((candidate) => cloudMcpScopeEquals(candidate, normalized)) ?? null;
+  if (entry) return entry;
+  if (legacyOrgId === normalized.orgId) {
+    const migrated = { ...normalized, attemptedAt: Date.now() };
+    writeCloudMcpUnhealthyRemintAttempt(migrated);
+    return migrated;
   }
   return null;
 }
 
 export function writeCloudMcpUnhealthyRemintAttempt(marker: CloudMcpUnhealthyRemintAttempt) {
   try {
-    getStorage()?.setItem(CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY, JSON.stringify(marker));
+    const normalized = normalizeCloudMcpScope(marker);
+    if (!normalized) return;
+    const entries = readCloudMcpUnhealthyRemintAttempts().entries.filter(
+      (entry) => !cloudMcpScopeEquals(entry, normalized),
+    );
+    writeCloudMcpUnhealthyRemintAttempts([...entries, { ...normalized, attemptedAt: marker.attemptedAt }]);
   } catch {
-    // Storage unavailable — the in-memory guard still suppresses same-store retries.
+    // Storage unavailable — in-memory guards still suppress same-operation retries.
   }
 }
 
-export function clearCloudMcpUnhealthyRemintAttempt() {
+export function clearCloudMcpUnhealthyRemintAttempt(scope: CloudMcpScope) {
   try {
-    getStorage()?.removeItem(CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY);
+    const normalized = normalizeCloudMcpScope(scope);
+    if (!normalized) return;
+    const entries = readCloudMcpUnhealthyRemintAttempts().entries.filter(
+      (entry) => !cloudMcpScopeEquals(entry, normalized),
+    );
+    if (entries.length) writeCloudMcpUnhealthyRemintAttempts(entries);
+    else getStorage()?.removeItem(CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY);
   } catch {
     // ignore
   }
 }
 
-function normalizeMarkerBaseUrl(baseUrl: string): string {
-  return baseUrl.trim().replace(/\/+$/, "");
-}
-
 function parseCloudMcpSyncMarker(value: unknown): CloudMcpSyncMarker | null {
-  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
-  if (
-    !("denBaseUrl" in value) ||
-    typeof value.denBaseUrl !== "string" ||
-    !("serverBaseUrl" in value) ||
-    typeof value.serverBaseUrl !== "string" ||
-    !("orgId" in value) ||
-    typeof value.orgId !== "string" ||
-    !("workspaceId" in value) ||
-    typeof value.workspaceId !== "string" ||
-    !("expiresAt" in value) ||
-    typeof value.expiresAt !== "string"
-  ) {
-    return null;
-  }
-  const denBaseUrl = normalizeMarkerBaseUrl(value.denBaseUrl);
-  const serverBaseUrl = normalizeMarkerBaseUrl(value.serverBaseUrl);
-  if (!denBaseUrl || !serverBaseUrl) return null;
-  return {
-    denBaseUrl,
-    serverBaseUrl,
-    orgId: value.orgId,
-    workspaceId: value.workspaceId,
-    expiresAt: value.expiresAt,
-  };
+  if (!isRecord(value)) return null;
+  const denBaseUrl = typeof value.denBaseUrl === "string" ? value.denBaseUrl : "";
+  const serverBaseUrl = typeof value.serverBaseUrl === "string" ? value.serverBaseUrl : "";
+  const orgId = typeof value.orgId === "string" ? value.orgId : "";
+  const workspaceId = typeof value.workspaceId === "string" ? value.workspaceId : "";
+  const expiresAt = typeof value.expiresAt === "string" ? value.expiresAt : "";
+  const scope = normalizeCloudMcpScope({ denBaseUrl, serverBaseUrl, orgId, workspaceId });
+  if (!scope || !expiresAt) return null;
+  return { ...scope, expiresAt };
 }
 
 function readCloudMcpSyncMarkers(): CloudMcpSyncMarker[] {
@@ -163,10 +277,7 @@ function readCloudMcpSyncMarkers(): CloudMcpSyncMarker[] {
     const parsed: unknown = JSON.parse(raw);
     const candidates = Array.isArray(parsed)
       ? parsed
-      : parsed &&
-          typeof parsed === "object" &&
-          "markers" in parsed &&
-          Array.isArray(parsed.markers)
+      : isRecord(parsed) && Array.isArray(parsed.markers)
         ? parsed.markers
         : [parsed];
     return candidates.flatMap((value) => {
@@ -179,32 +290,19 @@ function readCloudMcpSyncMarkers(): CloudMcpSyncMarker[] {
   return [];
 }
 
-export function readCloudMcpSyncMarker(
-  scope: CloudMcpSyncMarkerScope,
-): CloudMcpSyncMarker | null {
-  const denBaseUrl = normalizeMarkerBaseUrl(scope.denBaseUrl);
-  const serverBaseUrl = normalizeMarkerBaseUrl(scope.serverBaseUrl);
-  return readCloudMcpSyncMarkers().find(
-    (marker) =>
-      marker.denBaseUrl === denBaseUrl &&
-      marker.serverBaseUrl === serverBaseUrl &&
-      marker.orgId === scope.orgId &&
-      marker.workspaceId === scope.workspaceId,
-  ) ?? null;
+export function readCloudMcpSyncMarker(scope: CloudMcpSyncMarkerScope): CloudMcpSyncMarker | null {
+  const normalized = normalizeCloudMcpScope(scope);
+  if (!normalized) return null;
+  return readCloudMcpSyncMarkers().find((marker) => cloudMcpScopeEquals(marker, normalized)) ?? null;
 }
 
 export function writeCloudMcpSyncMarker(marker: CloudMcpSyncMarker) {
   try {
-    const denBaseUrl = normalizeMarkerBaseUrl(marker.denBaseUrl);
-    const serverBaseUrl = normalizeMarkerBaseUrl(marker.serverBaseUrl);
-    if (!denBaseUrl || !serverBaseUrl) return;
-    const normalizedMarker = { ...marker, denBaseUrl, serverBaseUrl };
+    const normalized = normalizeCloudMcpScope(marker);
+    if (!normalized) return;
+    const normalizedMarker = { ...normalized, expiresAt: marker.expiresAt };
     const markers = readCloudMcpSyncMarkers().filter(
-      (entry) =>
-        entry.denBaseUrl !== denBaseUrl ||
-        entry.serverBaseUrl !== serverBaseUrl ||
-        entry.orgId !== marker.orgId ||
-        entry.workspaceId !== marker.workspaceId,
+      (entry) => !cloudMcpScopeEquals(entry, normalized),
     );
     getStorage()?.setItem(
       CLOUD_MCP_SYNC_MARKER_STORAGE_KEY,
@@ -215,12 +313,29 @@ export function writeCloudMcpSyncMarker(marker: CloudMcpSyncMarker) {
   }
 }
 
+export function clearCloudMcpSyncMarker(scope: CloudMcpSyncMarkerScope) {
+  try {
+    const normalized = normalizeCloudMcpScope(scope);
+    if (!normalized) return;
+    const markers = readCloudMcpSyncMarkers().filter((entry) => !cloudMcpScopeEquals(entry, normalized));
+    if (markers.length) {
+      getStorage()?.setItem(CLOUD_MCP_SYNC_MARKER_STORAGE_KEY, JSON.stringify({ version: 1, markers }));
+    } else {
+      getStorage()?.removeItem(CLOUD_MCP_SYNC_MARKER_STORAGE_KEY);
+    }
+  } catch {
+    // ignore
+  }
+}
+
+export function clearCloudMcpScopedMetadata(scope: CloudMcpScope) {
+  clearCloudMcpSyncMarker(scope);
+  clearCloudMcpUnhealthyRemintAttempt(scope);
+}
+
 /**
  * Pure marker-freshness check for the cloud MCP sync marker. Extracted so
- * the margin arithmetic is unit-testable: the previous inline check used a
- * refresh margin equal to the minted token's TTL, which made
- * the marker stale the moment it was written and turned the reconciler into
- * an every-tick config rewrite.
+ * the margin arithmetic is unit-testable.
  */
 export function isCloudMcpSyncMarkerFresh(input: {
   expiresAt: string;

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -10,10 +10,8 @@ import {
 } from "../../../app/constants";
 import { extensionResource } from "../../../app/extensions";
 import {
-  isLegacyWebAppMcpUrl,
   mintCloudControlMcpToken,
   readDenSettings,
-  resolveCloudMcpResourceUrl,
 } from "../../../app/lib/den";
 import { createClient, unwrap } from "../../../app/lib/opencode";
 import { finishPerf, perfNow, recordPerfLog } from "../../../app/lib/perf-log";
@@ -42,16 +40,15 @@ import type { OpenworkServerStore } from "./openwork-server-store";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
 import {
   CLOUD_MCP_SERVER_NAME,
-  clearCloudMcpUnhealthyRemintAttempt,
-  clearCloudMcpUserState,
-  isCloudMcpSyncMarkerFresh,
-  readCloudMcpSyncMarker,
-  readCloudMcpUnhealthyRemintAttempt,
   readCloudMcpUserState,
-  writeCloudMcpSyncMarker,
-  writeCloudMcpUnhealthyRemintAttempt,
-  writeCloudMcpUserState,
 } from "./cloud-mcp-user-state";
+import {
+  clearCloudMcpDisabledIntent,
+  cloudMcpDisplaySummary,
+  recordCloudMcpDisabledIntent,
+  runOpenworkCloudMcpReconciler,
+  type CloudMcpOperationContext,
+} from "./cloud-mcp-reconciler";
 
 type SetStateAction<T> = T | ((current: T) => T);
 
@@ -253,6 +250,24 @@ export function createConnectionsStore(options: {
 
   const resolveWritableOpenworkTarget = async () => {
     return resolveMcpOpenworkTarget("write");
+  };
+
+  const resolveCloudMcpOperationContext = async (fallbackUrl?: string | null): Promise<CloudMcpOperationContext | null> => {
+    const settings = readDenSettings();
+    const workspaceId = await resolveOpenworkWorkspaceId();
+    const serverBaseUrl = getOpenworkSnapshot().openworkServerClient?.baseUrl.trim() ?? "";
+    const orgId = settings.activeOrgId?.trim() ?? "";
+    if (!workspaceId || !serverBaseUrl || !orgId) return null;
+    return {
+      denBaseUrl: settings.baseUrl,
+      serverBaseUrl,
+      workspaceId,
+      orgId,
+      denAuthToken: settings.authToken ?? null,
+      orgSlug: settings.activeOrgSlug,
+      orgName: settings.activeOrgName,
+      fallbackUrl,
+    };
   };
 
   const resolveProjectDir = async (activeClient: Client | null, currentProjectDir: string) => {
@@ -631,6 +646,48 @@ export function createConnectionsStore(options: {
     try {
       mutateState((current) => ({ ...current, mcpStatus: null, mcpConnectingName: entry.name }));
 
+      if (entry.serverName === CLOUD_MCP_SERVER_NAME) {
+        if (!canUseOpenworkServer || !openworkClient || !openworkWorkspaceId) {
+          throw new Error("OpenWork server is required to repair agent access to connected services.");
+        }
+        const context = await resolveCloudMcpOperationContext(entry.url);
+        if (!context) {
+          throw new Error("Sign in to OpenWork Cloud and choose an organization first.");
+        }
+        clearCloudMcpDisabledIntent(context);
+        const result = await runOpenworkCloudMcpReconciler({
+          mode: "repair",
+          client: openworkClient,
+          context: { ...context, trigger: "desktop-explicit-connect" },
+          mintToken: mintCloudControlMcpToken,
+          force: true,
+          refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+        });
+        await refreshMcpServers();
+        if (result.health?.usable) {
+          setStateField("mcpStatus", t("mcp.connected"));
+          finishPerf(options.developerMode(), "mcp.connect", "done", startedAt, {
+            name: entry.name,
+            type: entryType,
+            slug,
+          });
+          return true;
+        }
+        const summary = cloudMcpDisplaySummary({
+          signedIn: Boolean(context.denAuthToken?.trim()),
+          orgSelected: Boolean(context.orgId.trim()),
+          connecting: false,
+          health: result.health,
+        });
+        setStateField("mcpStatus", `${summary.stageLabel}. ${summary.recommendedAction}`);
+        finishPerf(options.developerMode(), "mcp.connect", "error", startedAt, {
+          name: entry.name,
+          type: entryType,
+          error: summary.stageLabel,
+        });
+        return false;
+      }
+
       // Resolve dynamic URLs for built-in MCPs
       let resolvedUrl = entry.url;
       let resolvedHeaders: Record<string, string> | undefined;
@@ -645,31 +702,6 @@ export function createConnectionsStore(options: {
           }
         } catch {
           // Bridge not available
-        }
-      }
-
-      // Signed-in cloud users connect the Den MCPs with a first-party token —
-      // no browser OAuth round-trip. Signed-out users fall back to OAuth.
-      // Use the signed-in member's first-party token for OpenWork Cloud.
-      // Allowlisted platform-admin tools are discovered through this same
-      // search_capabilities / execute_capability connection.
-      if (entry.serverName === "openwork-cloud") {
-        try {
-          const minted = await mintCloudControlMcpToken();
-          if (minted) {
-            // Never trust `minted.resource` verbatim: older den-api builds
-            // mint the bare web-app origin (https://app.openworklabs.com/mcp)
-            // where MCP 404s. Heal it to the canonical /mcp origin, then
-            // route the desktop app to the minimal, harness-facing
-            // /mcp/agent surface (search_capabilities + execute_capability
-            // only) rather than the full catalog — falling back to the
-            // entry's bootstrap-derived URL (which already targets /agent).
-            const healed = resolveCloudMcpResourceUrl(minted.resource);
-            resolvedUrl = healed ? `${healed}/agent` : resolvedUrl;
-            resolvedHeaders = { Authorization: `Bearer ${minted.token}` };
-          }
-        } catch {
-          // Minting failed (offline, expired session) — fall back to OAuth.
         }
       }
 
@@ -825,11 +857,6 @@ export function createConnectionsStore(options: {
       }
 
       await refreshMcpServers();
-      if (slug === CLOUD_MCP_SERVER_NAME) {
-        // An explicit connect overrides any earlier disable/remove intent,
-        // letting the background reconciler manage the entry again.
-        clearCloudMcpUserState();
-      }
       finishPerf(options.developerMode(), "mcp.connect", "done", startedAt, {
         name: entry.name,
         type: entryType,
@@ -853,15 +880,6 @@ export function createConnectionsStore(options: {
     }
   }
 
-  // Guards the unhealthy-status self-heal in syncCloudControlMcp with a
-  // persisted marker that survives settings-route store remounts: each
-  // re-mint writes a new token to config, which marks an engine reload as
-  // required. Until that reload happens the status stays needs_auth, so
-  // retrying on every sync tick produced an endless "MCP 'openwork-cloud'
-  // was updated. Reload to connect." nag. One attempt per unhealthy episode;
-  // reset when the entry reports connected again.
-  let cloudMcpUnhealthyRemintAttempted = false;
-
   /**
    * Background reconciliation for the Den cloud MCP: when the desktop is
    * signed in to OpenWork Cloud with an active org, keep the
@@ -879,94 +897,40 @@ export function createConnectionsStore(options: {
     if (!orgId || !settings.authToken?.trim()) return "skipped";
     const workspaceId = await resolveOpenworkWorkspaceId();
     if (!workspaceId) return "skipped";
-    const serverBaseUrl = getOpenworkSnapshot().openworkServerClient?.baseUrl.trim() ?? "";
-    if (!serverBaseUrl) return "skipped";
+    const openworkClient = getOpenworkSnapshot().openworkServerClient;
+    const serverBaseUrl = openworkClient?.baseUrl.trim() ?? "";
+    if (!openworkClient || !serverBaseUrl) return "skipped";
 
     const entry = MCP_QUICK_CONNECT.find((candidate) => candidate.serverName === CLOUD_MCP_SERVER_NAME);
     if (!entry) return "skipped";
-    const slug = entry.id ?? getMcpServerName(entry);
+    const scope = { denBaseUrl: settings.baseUrl, serverBaseUrl, orgId, workspaceId };
 
-    // Respect explicit user intent: a Cloud Control MCP the user disabled
-    // or removed must stay that way. Without this guard the reconciler
-    // rewrote the entry with `enabled: true` on every tick, making it
-    // impossible to turn off. Any explicit reconnect clears the record.
-    if (readCloudMcpUserState() !== null) return "skipped";
-    const configuredEntry = snapshot.mcpServers.find((server) => server.name === slug);
+    // Respect explicit user intent for this exact workspace/org/server/deployment.
+    if (readCloudMcpUserState(scope) !== null) return "skipped";
+    const configuredEntry = snapshot.mcpServers.find((server) => server.name === CLOUD_MCP_SERVER_NAME);
     if (configuredEntry?.config.enabled === false) return "skipped";
-    if (options?.force) {
-      cloudMcpUnhealthyRemintAttempted = false;
-      clearCloudMcpUnhealthyRemintAttempt();
-    }
 
-    const marker = readCloudMcpSyncMarker({
-      denBaseUrl: settings.baseUrl,
-      serverBaseUrl,
-      orgId,
-      workspaceId,
+    const result = await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client: openworkClient,
+      context: {
+        ...scope,
+        denAuthToken: settings.authToken,
+        orgSlug: settings.activeOrgSlug,
+        orgName: settings.activeOrgName,
+        fallbackUrl: configuredEntry?.config.url ?? entry.url,
+        trigger: options?.force ? "desktop-settings-force" : "desktop-settings-background",
+      },
+      mintToken: mintCloudControlMcpToken,
+      force: options?.force,
+      refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
     });
-    const markerFresh =
-      marker !== null &&
-      marker.orgId === orgId &&
-      marker.workspaceId === workspaceId &&
-      isCloudMcpSyncMarkerFresh({
-        expiresAt: marker.expiresAt,
-        now: Date.now(),
-        refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
-      });
-
-    // A revoked/expired token surfaces as needs_auth or failed from opencode;
-    // while signed in, that means re-mint instead of standing pat — but only
-    // once per unhealthy episode (see cloudMcpUnhealthyRemintAttempted).
-    const entryStatus = snapshot.mcpStatuses[slug]?.status;
-    if (entryStatus === "connected") {
-      cloudMcpUnhealthyRemintAttempted = false;
-      clearCloudMcpUnhealthyRemintAttempt();
+    if (result.status === "unchanged" || result.status === "ready") return "unchanged";
+    if (result.health?.usable) {
+      await refreshMcpServers();
+      return "synced";
     }
-    const entryUnhealthy = entryStatus === "needs_auth" || entryStatus === "failed";
-    const attempted = cloudMcpUnhealthyRemintAttempted || readCloudMcpUnhealthyRemintAttempt()?.orgId === orgId;
-    const shouldRemintForHealth = entryUnhealthy && !attempted;
-
-    // Builds before #2116's follow-up wrote the MCP URL against the bare
-    // web-app origin (https://app.openworklabs.com/mcp), which 404s.
-    // Reconfigure those entries even when the marker is still fresh.
-    const hasLegacyUrl =
-      configuredEntry?.config.type === "remote" && isLegacyWebAppMcpUrl(configuredEntry.config.url);
-
-    // The marker is the source of truth for "configured recently". Do NOT
-    // gate this on snapshot.mcpServers: the store is recreated on every
-    // settings mount with an empty (or refresh-errored) server list, and
-    // treating that as "not configured" re-minted a token and rewrote config
-    // on every visit — endless "Reload to connect" toasts. If a user
-    // manually removed the entry, we respect that until the marker expires
-    // instead of silently re-adding it.
-    if (!options?.force && markerFresh && !shouldRemintForHealth && !hasLegacyUrl) {
-      return "unchanged";
-    }
-    if (shouldRemintForHealth) {
-      cloudMcpUnhealthyRemintAttempted = true;
-      writeCloudMcpUnhealthyRemintAttempt({ orgId });
-    }
-
-    // Validate the session up front so a failed mint never reaches
-    // connectMcp's signed-out fallback (which opens the OAuth modal).
-    const minted = await mintCloudControlMcpToken().catch(() => null);
-    if (!minted) return "skipped";
-
-    // Trust connectMcp's own result. Judging success via snapshot.mcpServers
-    // broke whenever the post-connect refresh errored: the marker was never
-    // written, so every subsequent tick re-minted and re-wrote config.
-    const connected = await connectMcp(entry);
-    if (!connected) {
-      return "skipped";
-    }
-    writeCloudMcpSyncMarker({
-      denBaseUrl: settings.baseUrl,
-      serverBaseUrl,
-      orgId,
-      workspaceId,
-      expiresAt: minted.expiresAt,
-    });
-    return "synced";
+    return "skipped";
   }
 
   function authorizeMcp(entry: McpServerEntry) {
@@ -1092,7 +1056,8 @@ export function createConnectionsStore(options: {
       }
 
       if (name === CLOUD_MCP_SERVER_NAME) {
-        writeCloudMcpUserState("removed");
+        const context = await resolveCloudMcpOperationContext(null);
+        if (context) recordCloudMcpDisabledIntent(context, "removed");
       }
       options.markReloadRequired?.("mcp", { type: "mcp", name, action: "removed" });
       await refreshMcpServers();
@@ -1162,10 +1127,11 @@ export function createConnectionsStore(options: {
 
       await openworkClient.setMcpEnabled(openworkWorkspaceId, name, enabled);
       if (name === CLOUD_MCP_SERVER_NAME) {
+        const context = await resolveCloudMcpOperationContext(null);
         if (enabled) {
-          clearCloudMcpUserState();
-        } else {
-          writeCloudMcpUserState("disabled");
+          if (context) clearCloudMcpDisabledIntent(context);
+        } else if (context) {
+          recordCloudMcpDisabledIntent(context, "disabled");
         }
       }
       options.markReloadRequired?.("mcp", { type: "mcp", name, action: "updated" });

--- a/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
+++ b/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
@@ -1,10 +1,8 @@
 import { useEffect } from "react";
 
-import { getMcpServerName, MCP_QUICK_CONNECT } from "../../../app/constants";
 import {
   mintCloudControlMcpToken,
   readDenSettings,
-  resolveCloudMcpResourceUrl,
   type DenMcpToken,
   type DenSettings,
 } from "../../../app/lib/den";
@@ -14,31 +12,32 @@ import type { Client, McpServerEntry, McpStatusMap } from "../../../app/types";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
 import {
   CLOUD_MCP_SERVER_NAME,
-  isCloudMcpSyncMarkerFresh,
-  readCloudMcpSyncMarker,
   readCloudMcpUserState,
-  writeCloudMcpSyncMarker,
 } from "./cloud-mcp-user-state";
+import {
+  runOpenworkCloudMcpReconciler,
+  type CloudMcpClient,
+} from "./cloud-mcp-reconciler";
 
 export const SESSION_MCP_MAINTENANCE_INTERVAL_MS = 5 * 60 * 1000;
 export const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
 
-type CloudMcpMaintenanceClient = Pick<OpenworkServerClient, "baseUrl" | "listMcp" | "addMcp">;
+type CloudMcpMaintenanceClient = CloudMcpClient & Pick<OpenworkServerClient, "listMcp">;
 
 const maintenanceInFlight = new Set<string>();
 
 export function getSessionMcpMaintenanceTargetKey(input: {
-  client: Pick<OpenworkServerClient, "baseUrl" | "token">;
+  client: Pick<OpenworkServerClient, "baseUrl">;
   cloudSignedIn: boolean;
+  denBaseUrl?: string | null;
+  orgId?: string | null;
   workspaceId: string;
-  directory: string;
 }): string {
   return JSON.stringify([
+    input.denBaseUrl?.trim().replace(/\/+$/, "") ?? "",
     input.client.baseUrl.trim().replace(/\/+$/, ""),
-    input.client.token?.trim() ?? "",
-    input.cloudSignedIn ? "signed-in" : "local-only",
     input.workspaceId.trim(),
-    input.directory.trim(),
+    input.cloudSignedIn ? input.orgId?.trim() ?? "" : "local-only",
   ]);
 }
 
@@ -68,56 +67,41 @@ export async function syncCloudControlMcpInBackground(input: {
   const settings = input.settings ?? readDenSettings();
   const orgId = settings.activeOrgId?.trim() ?? "";
   if (!workspaceId || !orgId || !settings.authToken?.trim()) return "skipped";
-  if (readCloudMcpUserState() !== null) return "skipped";
+  const scope = {
+    denBaseUrl: settings.baseUrl,
+    serverBaseUrl: input.client.baseUrl,
+    orgId,
+    workspaceId,
+  };
+  if (readCloudMcpUserState(scope) !== null) return "skipped";
 
-  const cloudEntry = MCP_QUICK_CONNECT.find((entry) => entry.serverName === CLOUD_MCP_SERVER_NAME);
-  if (!cloudEntry) return "skipped";
-  const slug = cloudEntry.id ?? getMcpServerName(cloudEntry);
   const listed = await input.client.listMcp(workspaceId);
-  const configured = listed.items.find((entry) => entry.name === slug);
+  const configured = listed.items.find((entry) => entry.name === CLOUD_MCP_SERVER_NAME);
   if (configured?.config.enabled === false) return "skipped";
+  const configuredUrl = typeof configured?.config.url === "string" ? configured.config.url : null;
 
-  const marker = readCloudMcpSyncMarker({
-    denBaseUrl: settings.baseUrl,
-    serverBaseUrl: input.client.baseUrl,
-    orgId,
-    workspaceId,
-  });
-  const markerFresh =
-    marker !== null &&
-    marker.orgId === orgId &&
-    marker.workspaceId === workspaceId &&
-    isCloudMcpSyncMarkerFresh({
-      expiresAt: marker.expiresAt,
-      now: input.now ?? Date.now(),
-      refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
-    });
-  if (!input.force && configured && markerFresh) return "unchanged";
-
-  const minted = await (input.mintToken ?? mintCloudControlMcpToken)();
-  if (!minted) return "skipped";
-  const healedResource = resolveCloudMcpResourceUrl(minted.resource);
-  const url = healedResource ? `${healedResource}/agent` : cloudEntry.url;
-  if (!url) return "skipped";
-
-  await input.client.addMcp(workspaceId, {
-    name: slug,
-    config: {
-      type: "remote",
-      enabled: true,
-      url,
-      headers: { Authorization: `Bearer ${minted.token}` },
-      oauth: false,
+  const result = await runOpenworkCloudMcpReconciler({
+    mode: "repair",
+    client: input.client,
+    context: {
+      ...scope,
+      denAuthToken: settings.authToken,
+      orgSlug: settings.activeOrgSlug,
+      orgName: settings.activeOrgName,
+      fallbackUrl: configured?.config.type === "remote" ? configuredUrl : null,
+      trigger: input.force ? "desktop-background-forced" : "desktop-background",
     },
+    mintToken: input.mintToken
+      ? async () => input.mintToken?.() ?? null
+      : mintCloudControlMcpToken,
+    force: input.force,
+    refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+    now: input.now,
+    configuredEnabled: typeof configured?.config.enabled === "boolean" ? configured.config.enabled : null,
   });
-  writeCloudMcpSyncMarker({
-    denBaseUrl: settings.baseUrl,
-    serverBaseUrl: input.client.baseUrl,
-    orgId,
-    workspaceId,
-    expiresAt: minted.expiresAt,
-  });
-  return "synced";
+  if (result.status === "unchanged" || result.status === "ready") return "unchanged";
+  if (result.health?.usable) return "synced";
+  return "skipped";
 }
 
 export async function healWorkspaceMcpInBackground(input: {
@@ -159,11 +143,13 @@ export function useSessionMcpMaintenance(input: {
     const client = input.client;
     const opencodeClient = input.opencodeClient;
     if (!client || !opencodeClient || !workspaceId || !directory) return;
+    const settings = readDenSettings();
     const targetKey = getSessionMcpMaintenanceTargetKey({
       client,
       cloudSignedIn: input.cloudSignedIn,
+      denBaseUrl: settings.baseUrl,
+      orgId: settings.activeOrgId,
       workspaceId,
-      directory,
     });
 
     let cancelled = false;

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -14,6 +14,7 @@ import {
   readDenSettings,
   resolveDenBaseUrls,
   writeDenSettings,
+  type DenSettings,
   type DenOrgSummary,
 } from "@/app/lib/den";
 import { clearDesktopBootstrapConfig } from "@/app/lib/desktop";
@@ -40,7 +41,27 @@ declare global {
 export type UseDenSessionProps = {
   developerMode: boolean;
   openLink: (url: string) => void;
+  onBeforeSignedOut?: (settings: DenSettings) => void | Promise<void>;
 };
+
+const SIGN_OUT_CLEANUP_TIMEOUT_MS = 5_000;
+
+async function runBeforeSignedOut(callback: UseDenSessionProps["onBeforeSignedOut"], settings: DenSettings): Promise<void> {
+  if (!callback) return;
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    await Promise.race([
+      Promise.resolve(callback(settings)),
+      new Promise<void>((resolve) => {
+        timeout = setTimeout(resolve, SIGN_OUT_CLEANUP_TIMEOUT_MS);
+      }),
+    ]);
+  } catch {
+    // Best-effort cleanup must not trap the user in a signed-in state.
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
 
 function parseManualAuthInput(value: string) {
   const trimmed = value.trim();
@@ -71,6 +92,7 @@ function parseManualAuthInput(value: string) {
 
 export function useDenSession({
   developerMode,
+  onBeforeSignedOut,
   openLink,
 }: UseDenSessionProps) {
   const denAuth = useDenAuth();
@@ -164,7 +186,9 @@ export function useDenSession({
       options?: { includeBaseUrls?: boolean },
     ) => {
       const includeBaseUrls = options?.includeBaseUrls ?? !developerMode;
-      clearDenSession({ includeBaseUrls });
+      const previousSettings = readDenSettings();
+      return runBeforeSignedOut(onBeforeSignedOut, previousSettings).then(() => {
+        clearDenSession({ includeBaseUrls });
       if (includeBaseUrls) {
         setBaseUrl(DEFAULT_DEN_BASE_URL);
         setBaseUrlDraft(DEFAULT_DEN_BASE_URL);
@@ -197,8 +221,9 @@ export function useDenSession({
       } catch {}
       // Notify provider auth store so it can clean up cloud-imported providers
       dispatchDenSessionUpdated({ status: "signed_out", ...eventDetail });
+      });
     },
-    [clearSessionState, developerMode, setAuthToken, setBaseUrl],
+    [clearSessionState, developerMode, onBeforeSignedOut, setAuthToken, setBaseUrl],
   );
 
   React.useEffect(() => {
@@ -252,7 +277,7 @@ export function useDenSession({
 
       setBaseUrl(persisted.baseUrl);
       setBaseUrlDraft(persisted.baseUrl);
-      clearSignedInState(t("den.status_base_url_updated"), {
+      await clearSignedInState(t("den.status_base_url_updated"), {
         baseUrl: persisted.baseUrl,
       }, { includeBaseUrls: false });
     } catch (error) {
@@ -275,7 +300,7 @@ export function useDenSession({
       setBaseUrlError(null);
       setBaseUrl(persisted.baseUrl);
       setBaseUrlDraft(persisted.baseUrl);
-      clearSignedInState(t("den.status_base_url_updated"), {
+      await clearSignedInState(t("den.status_base_url_updated"), {
         baseUrl: persisted.baseUrl,
       }, { includeBaseUrls: false });
     } catch (error) {
@@ -309,7 +334,7 @@ export function useDenSession({
       );
       setBaseUrl(resolved.baseUrl);
       setBaseUrlDraft(resolved.baseUrl);
-      clearSignedInState(t("den.status_server_config_cleared"), {
+      await clearSignedInState(t("den.status_server_config_cleared"), {
         baseUrl: resolved.baseUrl,
       }, { includeBaseUrls: false });
     } catch (error) {
@@ -339,10 +364,10 @@ export function useDenSession({
         setUser(nextUser);
         setStatusMessage(t("den.status_signed_in_as", { email: nextUser.email }));
       })
-      .catch((error) => {
+      .catch(async (error) => {
         if (cancelled) return;
         if (error instanceof DenApiError && error.status === 401) {
-          clearSignedInState();
+          await clearSignedInState();
         }
         // A timeout, offline state, or server failure does not invalidate the
         // last confirmed session. Keep it available while surfacing the error.
@@ -497,7 +522,7 @@ export function useDenSession({
       if (authToken.trim()) {
         await client.signOut();
       }
-      clearSignedInState(t("den.status_signed_out"));
+      await clearSignedInState(t("den.status_signed_out"));
     } catch (error) {
       setAuthError(
         error instanceof DenApiError

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -8,7 +8,8 @@ import { Button } from "@/components/ui/button";
 import { Field, FieldLabel } from "@/components/ui/field";
 import { Switch } from "@/components/ui/switch";
 import { Textarea } from "@/components/ui/textarea";
-import type { OpenworkRuntimeConfigStatus, OpenworkServerStatus } from "@/app/lib/openwork-server";
+import type { OpenworkCloudMcpHealth, OpenworkRuntimeConfigStatus, OpenworkServerStatus } from "@/app/lib/openwork-server";
+import { sanitizeCloudMcpHealthDiagnostic, sanitizeDiagnosticRecord } from "@/app/lib/diagnostic-sanitizer";
 import {
   DEFAULT_DEN_API_BASE_URL,
   DEFAULT_DEN_BASE_URL,
@@ -320,6 +321,130 @@ export function AdvancedRuntimeSection(props: AdvancedRuntimeSectionProps) {
   );
 }
 
+function DiagnosticRow(props: { label: string; value: string }) {
+  return (
+    <div className="grid gap-1 rounded-lg border border-gray-6 bg-gray-2/50 p-2 sm:grid-cols-[12rem_minmax(0,1fr)]">
+      <div className="text-[10px] font-semibold uppercase tracking-wide text-gray-8">{props.label}</div>
+      <div className="min-w-0 break-all font-mono text-[11px] text-gray-12">{props.value}</div>
+    </div>
+  );
+}
+
+function joinList(values: string[]): string {
+  return values.length ? values.join(", ") : "none";
+}
+
+function formatMaybe(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined || value === "") return "unknown";
+  return String(value);
+}
+
+function formatMetadataRecord(value: Record<string, string | number | boolean | null> | null | undefined): string {
+  if (!value || Object.keys(value).length === 0) return "none";
+  return Object.entries(value).map(([key, nested]) => `${key}=${formatMaybe(nested)}`).join(", ");
+}
+
+function formatSupportedFeatures(features: OpenworkCloudMcpHealth["compatibility"]["supportedFeatures"]): string {
+  return Object.entries(features).map(([key, enabled]) => `${key}:${enabled ? "yes" : "no"}`).join(", ");
+}
+
+function formatPluginHashes(hashes: OpenworkCloudMcpHealth["compatibility"]["pluginFileHashes"]): string {
+  if (hashes.length === 0) return "none";
+  return hashes.map((hash) => `${hash.name}=${hash.sha256 ? hash.sha256.slice(0, 12) : `unavailable${hash.error ? ` (${hash.error})` : ""}`}`).join(", ");
+}
+
+interface AdvancedCloudMcpDiagnosticsSectionProps {
+  cloudMcpHealth: OpenworkCloudMcpHealth | null;
+  onRefresh: () => Promise<OpenworkCloudMcpHealth | null>;
+}
+
+export function AdvancedCloudMcpDiagnosticsSection(props: AdvancedCloudMcpDiagnosticsSectionProps) {
+  const [busy, setBusy] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+  const safeHealth = sanitizeCloudMcpHealthDiagnostic(props.cloudMcpHealth);
+  const projection = props.cloudMcpHealth?.tools.providerProjection;
+  const compatibility = props.cloudMcpHealth?.compatibility;
+
+  const refresh = async () => {
+    setBusy(true);
+    setCopyStatus(null);
+    try {
+      await props.onRefresh();
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const copy = async () => {
+    const payload = JSON.stringify({ cloudMcpHealth: safeHealth }, null, 2);
+    await navigator.clipboard.writeText(payload);
+    setCopyStatus("Copied sanitized Cloud diagnostic.");
+  };
+
+  return (
+    <LayoutSection>
+      <LayoutSectionHeader>
+        <LayoutSectionTitle>Agent access diagnostics</LayoutSectionTitle>
+        <LayoutSectionDescription>
+          Technical details for OpenWork Cloud MCP delivery. Tokens and Authorization headers are redacted before display or copy.
+        </LayoutSectionDescription>
+      </LayoutSectionHeader>
+
+      <LayoutSectionItem>
+        <LayoutSectionItemHeader>
+          <LayoutSectionItemTitle>OpenWork Cloud MCP health</LayoutSectionItemTitle>
+          <LayoutSectionItemDescription>
+            Use this when support needs exact runtime state. The main Connect card stays user-facing.
+          </LayoutSectionItemDescription>
+          <LayoutSectionItemHeaderActions>
+            <Button type="button" variant="outline" size="sm" onClick={() => void refresh()} disabled={busy}>
+              <RefreshCcw size={14} className={busy ? "animate-spin" : ""} />
+              Refresh
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={() => void copy()} disabled={!props.cloudMcpHealth}>
+              Copy sanitized diagnostic
+            </Button>
+          </LayoutSectionItemHeaderActions>
+        </LayoutSectionItemHeader>
+
+        {copyStatus ? <SettingsNotice>{copyStatus}</SettingsNotice> : null}
+        {props.cloudMcpHealth ? (
+          <div className="space-y-2 rounded-xl border border-gray-6 bg-gray-1/60 p-3">
+            <div className="grid gap-2">
+              <DiagnosticRow label="Active workspace" value={`${props.cloudMcpHealth.workspace.id} (${props.cloudMcpHealth.workspace.directory ?? "no directory"})`} />
+              <DiagnosticRow label="Desired revision" value={props.cloudMcpHealth.desired.revision ?? "none"} />
+              <DiagnosticRow label="Applied revision" value={props.cloudMcpHealth.delivery.appliedRevision ?? "none"} />
+              <DiagnosticRow label="Delivery" value={`${props.cloudMcpHealth.delivery.state}${props.cloudMcpHealth.delivery.trigger ? ` / ${props.cloudMcpHealth.delivery.trigger}` : ""}`} />
+              <DiagnosticRow label="Engine status" value={props.cloudMcpHealth.engine.status} />
+              <DiagnosticRow label="Provider/model" value={projection?.checked ? `${projection.provider ?? "unknown"}/${projection.model ?? "unknown"}; present ${joinList(projection.present)}; missing ${joinList(projection.missing)}` : "not checked"} />
+              <DiagnosticRow label="Cloud tools" value={`present ${joinList(props.cloudMcpHealth.tools.present)}; missing ${joinList(props.cloudMcpHealth.tools.missing)}`} />
+              <DiagnosticRow label="Plugin canaries" value={`present ${joinList(props.cloudMcpHealth.pluginCanaries.present)}; missing ${joinList(props.cloudMcpHealth.pluginCanaries.missing)}`} />
+              <DiagnosticRow label="Safe capabilities" value={`schema v${props.cloudMcpHealth.schemaVersion}; connect catalog ${props.cloudMcpHealth.connectCatalogEnabled ? "enabled" : "disabled"}`} />
+              {compatibility ? (
+                <>
+                  <DiagnosticRow label="OpenWork versions" value={`server ${formatMaybe(compatibility.openwork.serverVersion)}; app ${formatMetadataRecord(compatibility.openwork.app)}`} />
+                  <DiagnosticRow label="OpenCode compatibility" value={`expected ${formatMaybe(compatibility.opencode.expectedVersion)}; actual ${formatMaybe(compatibility.opencode.actualVersion)}; probe ${compatibility.opencode.probe}`} />
+                  <DiagnosticRow label="Feature probes" value={formatSupportedFeatures(compatibility.supportedFeatures)} />
+                  <DiagnosticRow label="Plugin hashes" value={formatPluginHashes(compatibility.pluginFileHashes)} />
+                </>
+              ) : null}
+              <DiagnosticRow label="Live verification" value={props.cloudMcpHealth.checkedAt} />
+            </div>
+            <details className="rounded-lg bg-gray-3 p-2">
+              <summary className="cursor-pointer text-[11px] font-medium text-gray-11">Show sanitized health JSON</summary>
+              <pre className="mt-2 max-h-72 overflow-auto font-mono text-[11px] text-gray-11">
+                {JSON.stringify(safeHealth, null, 2)}
+              </pre>
+            </details>
+          </div>
+        ) : (
+          <SettingsNotice>No Cloud MCP health has been loaded for this workspace yet.</SettingsNotice>
+        )}
+      </LayoutSectionItem>
+    </LayoutSection>
+  );
+}
+
 interface AdvancedRuntimeMigrationSectionProps {
   busy: boolean;
   canMigrate: boolean;
@@ -338,6 +463,10 @@ function formatKeys(keys: string[]) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
+}
+
+function sanitizedConfig(config: Record<string, unknown>): Record<string, unknown> {
+  return sanitizeDiagnosticRecord(config);
 }
 
 function countRecord(value: unknown) {
@@ -403,6 +532,7 @@ function RuntimeConfigSourceBlock(props: {
   keys: string[];
   config: Record<string, unknown>;
 }) {
+  const safeConfig = sanitizedConfig(props.config);
   return (
     <div className="space-y-2 rounded-xl border border-gray-6 bg-gray-1/70 p-3">
       <div>
@@ -412,11 +542,11 @@ function RuntimeConfigSourceBlock(props: {
         {props.exists !== undefined ? <div className="text-[11px] text-gray-9">{props.exists ? "Found" : "Not found"}</div> : null}
         <div className="text-[11px] text-gray-9">Keys: {formatKeys(props.keys)}</div>
       </div>
-      <RuntimeConfigSummary config={props.config} />
+      <RuntimeConfigSummary config={safeConfig} />
       <details className="rounded-lg bg-gray-3 p-2">
         <summary className="cursor-pointer text-[11px] font-medium text-gray-11">Show raw JSON</summary>
         <pre className="mt-2 max-h-56 overflow-auto font-mono text-[11px] text-gray-11">
-          {JSON.stringify(props.config, null, 2)}
+          {JSON.stringify(safeConfig, null, 2)}
         </pre>
       </details>
     </div>
@@ -424,6 +554,10 @@ function RuntimeConfigSourceBlock(props: {
 }
 
 export function AdvancedRuntimeMigrationSection(props: AdvancedRuntimeMigrationSectionProps) {
+  const effectiveRuntimeConfig = props.configStatus
+    ? sanitizedConfig(props.configStatus.effectiveRuntime ?? props.configStatus.runtime)
+    : null;
+  const runtimeConfig = props.configStatus ? sanitizedConfig(props.configStatus.runtime) : null;
   return (
     <LayoutSection>
       <LayoutSectionHeader>
@@ -467,15 +601,15 @@ export function AdvancedRuntimeMigrationSection(props: AdvancedRuntimeMigrationS
         {props.configStatus ? (
           <div className="space-y-3 rounded-xl border border-gray-6 bg-gray-1/60 p-3 text-xs text-gray-10">
             <div className="space-y-2 rounded-xl border border-blue-6/50 bg-blue-2/40 p-3">
-              <div className="font-medium text-gray-12">Effective injected OpenCode config</div>
+              <div className="font-medium text-gray-12">Desired OpenWork runtime config</div>
               <div className="text-[11px] text-gray-9">
-                This is the OpenWork-built config object injected through the server-managed `OPENCODE_CONFIG` file. It includes OpenWork defaults plus runtime DB values and is rewritten on every runtime config change.
+                This is the OpenWork-built config object requested for the runtime database and injected safely by the server. Sensitive headers are redacted here.
               </div>
-              <RuntimeConfigSummary config={props.configStatus.effectiveRuntime ?? props.configStatus.runtime} />
+              <RuntimeConfigSummary config={effectiveRuntimeConfig ?? {}} />
               <details className="rounded-lg bg-gray-3 p-2">
-                <summary className="cursor-pointer text-[11px] font-medium text-gray-11">Show raw injected JSON</summary>
+                <summary className="cursor-pointer text-[11px] font-medium text-gray-11">Show desired JSON</summary>
                 <pre className="mt-2 max-h-72 overflow-auto font-mono text-[11px] text-gray-11">
-                  {JSON.stringify(props.configStatus.effectiveRuntime ?? props.configStatus.runtime, null, 2)}
+                  {JSON.stringify(effectiveRuntimeConfig, null, 2)}
                 </pre>
               </details>
             </div>
@@ -539,7 +673,7 @@ export function AdvancedRuntimeMigrationSection(props: AdvancedRuntimeMigrationS
             <div>
               <div className="font-medium text-gray-12">Runtime DB JSON</div>
               <pre className="mt-1 max-h-48 overflow-auto rounded-lg bg-gray-3 p-2 font-mono text-[11px] text-gray-11">
-                {JSON.stringify(props.configStatus.runtime, null, 2)}
+                {JSON.stringify(runtimeConfig, null, 2)}
               </pre>
             </div>
           </div>

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view.tsx
@@ -4,7 +4,7 @@ import { useEffect, useReducer, useState } from "react";
 import { Separator } from "@/components/ui/separator";
 
 import type { OpencodeConnectStatus } from "@/app/types";
-import type { OpenworkRuntimeConfigStatus, OpenworkServerStatus } from "@/app/lib/openwork-server";
+import type { OpenworkCloudMcpHealth, OpenworkRuntimeConfigStatus, OpenworkServerStatus } from "@/app/lib/openwork-server";
 import { t } from "@/i18n";
 import { LayoutStack } from "../settings-layout";
 import type { useDenSession } from "../cloud/use-den-session";
@@ -12,6 +12,7 @@ import type { useDenSession } from "../cloud/use-den-session";
 import { advancedLocalReducer, initialAdvancedLocalState } from "./advanced-view-state";
 import {
   AdvancedDeveloperSection,
+  AdvancedCloudMcpDiagnosticsSection,
   AdvancedOrganizationServerSection,
   AdvancedRuntimeMigrationSection,
   AdvancedRuntimeSection,
@@ -45,6 +46,8 @@ export type AdvancedViewProps = {
   getRuntimeConfigStatus: () => Promise<OpenworkRuntimeConfigStatus>;
   organizationServer: AdvancedOrganizationServerSession;
   cloudMcpUrl: string | null;
+  cloudMcpHealth: OpenworkCloudMcpHealth | null;
+  refreshCloudMcpHealth: () => Promise<OpenworkCloudMcpHealth | null>;
 };
 
 type AdvancedStatusTone = "ready" | "warning" | "error" | "neutral";
@@ -199,6 +202,11 @@ export function AdvancedView(props: AdvancedViewProps) {
         openworkStatusLabel={openworkStatusLabel}
         openworkTone={openworkTone}
         openworkDetailLines={openworkDetailLines}
+      />
+
+      <AdvancedCloudMcpDiagnosticsSection
+        cloudMcpHealth={props.cloudMcpHealth}
+        onRefresh={props.refreshCloudMcpHealth}
       />
 
       <AdvancedRuntimeMigrationSection

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -3,8 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 import { ArrowUpRight } from "lucide-react";
 
 import type { DenExternalMcpConnection, DenOrgPlugin } from "@/app/lib/den";
-import { readDenSettings } from "@/app/lib/den";
+import { mintCloudControlMcpToken, readDenSettings } from "@/app/lib/den";
 import { openDesktopUrl } from "@/app/lib/desktop";
+import type { OpenworkCloudMcpHealth, OpenworkCloudMcpProviderModelContext, OpenworkServerClient } from "@/app/lib/openwork-server";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
@@ -36,7 +37,16 @@ import {
   SettingsSectionHeaderDescription,
   SettingsSectionHeaderTitle,
   SettingsStack,
+  SettingsStatusBadge,
 } from "../settings-section";
+import {
+  OPENWORK_CLOUD_EXPECTED_TOOLS,
+  clearCloudMcpDisabledIntent,
+  cloudMcpDisplaySummary,
+  runOpenworkCloudMcpReconciler,
+  type CloudMcpOperationContext,
+} from "../../connections/cloud-mcp-reconciler";
+import { readCloudMcpUserState } from "../../connections/cloud-mcp-user-state";
 
 export type ConnectViewState = "loading" | "signin" | "active" | "pitch";
 
@@ -44,10 +54,11 @@ export function resolveConnectViewState(input: {
   authStatus: DenAuthStatus;
   connectEnabled?: boolean;
   connectionsCount: number;
+  activeOrgSelected?: boolean;
 }): ConnectViewState {
   if (input.authStatus === "checking") return "loading";
   if (input.authStatus === "signed_out") return "signin";
-  if (input.connectEnabled === true || input.connectionsCount > 0) return "active";
+  if (input.connectEnabled === true || input.connectionsCount > 0 || (input.authStatus === "signed_in" && input.activeOrgSelected === true)) return "active";
   return "pitch";
 }
 
@@ -73,9 +84,15 @@ export type ConnectViewProps = {
   session: ConnectSession;
   marketplaceItems?: ExtensionItem[];
   refreshMarketplaceItems?: () => Promise<unknown> | void;
+  openworkClient: OpenworkServerClient | null;
+  workspaceId: string | null;
+  currentModel: OpenworkCloudMcpProviderModelContext | null;
+  onCloudMcpHealthChange?: (health: OpenworkCloudMcpHealth | null) => void;
 };
 
 type CloudMarketplaceItem = ExtensionItem & { plugin: DenOrgPlugin };
+
+const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
 
 function denManageConnectionsUrl() {
   return new URL("/dashboard/mcp-connections", readDenSettings().baseUrl).toString();
@@ -92,6 +109,190 @@ function ManageInDenButton() {
       {t("connect.manage_in_den_web")}
       <ArrowUpRight size={13} />
     </Button>
+  );
+}
+
+function buildCloudMcpContext(input: {
+  client: OpenworkServerClient | null;
+  workspaceId: string | null;
+  currentModel: OpenworkCloudMcpProviderModelContext | null;
+}): CloudMcpOperationContext | null {
+  const workspaceId = input.workspaceId?.trim() ?? "";
+  const serverBaseUrl = input.client?.baseUrl.trim() ?? "";
+  const settings = readDenSettings();
+  const orgId = settings.activeOrgId?.trim() ?? "";
+  if (!workspaceId || !serverBaseUrl || !orgId) return null;
+  return {
+    denBaseUrl: settings.baseUrl,
+    serverBaseUrl,
+    orgId,
+    workspaceId,
+    denAuthToken: settings.authToken ?? null,
+    orgSlug: settings.activeOrgSlug,
+    orgName: settings.activeOrgName,
+    providerModel: input.currentModel ?? undefined,
+  };
+}
+
+export function readyCloudMcpToolIds(health: OpenworkCloudMcpHealth | null): string[] {
+  if (!health?.usable) return [];
+  return health.tools.present.filter((tool) => OPENWORK_CLOUD_EXPECTED_TOOLS.some((expected) => expected === tool));
+}
+
+function AgentAccessCard(props: {
+  client: OpenworkServerClient | null;
+  workspaceId: string | null;
+  currentModel: OpenworkCloudMcpProviderModelContext | null;
+  onHealthChange?: (health: OpenworkCloudMcpHealth | null) => void;
+}) {
+  const cloudSession = useCloudSession();
+  const [health, setHealth] = useState<OpenworkCloudMcpHealth | null>(null);
+  const [busy, setBusy] = useState<"test" | "repair" | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const context = buildCloudMcpContext(props);
+  const userState = context ? readCloudMcpUserState(context) : null;
+  const signedIn = cloudSession.isSignedIn && Boolean(cloudSession.authToken.trim());
+  const orgSelected = Boolean(context?.orgId.trim());
+  const summary = cloudMcpDisplaySummary({
+    signedIn,
+    orgSelected,
+    connecting: busy !== null,
+    userState,
+    health,
+  });
+
+  const updateHealth = (next: OpenworkCloudMcpHealth | null) => {
+    setHealth(next);
+    props.onHealthChange?.(next);
+  };
+
+  const testNow = async () => {
+    if (!props.client || !context) return;
+    setBusy("test");
+    setError(null);
+    try {
+      const result = await runOpenworkCloudMcpReconciler({
+        mode: "health",
+        client: props.client,
+        context: { ...context, trigger: "desktop-connect-test" },
+        mintToken: mintCloudControlMcpToken,
+        refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+      });
+      updateHealth(result.health);
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Could not test agent access.");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const repairAndTest = async () => {
+    if (!props.client || !context) return;
+    setBusy("repair");
+    setError(null);
+    try {
+      clearCloudMcpDisabledIntent(context);
+      const result = await runOpenworkCloudMcpReconciler({
+        mode: "repair",
+        client: props.client,
+        context: { ...context, trigger: "desktop-connect-repair" },
+        mintToken: mintCloudControlMcpToken,
+        force: true,
+        refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+      });
+      updateHealth(result.health);
+      if (!result.health && result.skippedReason === "mint_failed") {
+        setError("Could not refresh Cloud authentication. Sign in again, then retry.");
+      }
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Could not repair agent access.");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  useEffect(() => {
+    if (!props.client || !context || !signedIn) {
+      updateHealth(null);
+      return;
+    }
+    let cancelled = false;
+    setBusy("test");
+    setError(null);
+    void runOpenworkCloudMcpReconciler({
+      mode: "health",
+      client: props.client,
+      context: { ...context, trigger: "desktop-connect-autocheck" },
+      mintToken: mintCloudControlMcpToken,
+      refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+    })
+      .then((result) => {
+        if (!cancelled) updateHealth(result.health);
+      })
+      .catch((nextError) => {
+        if (!cancelled) setError(nextError instanceof Error ? nextError.message : "Could not test agent access.");
+      })
+      .finally(() => {
+        if (!cancelled) setBusy(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [props.client, props.currentModel, props.workspaceId, signedIn]);
+
+  const canRun = Boolean(props.client && context && signedIn);
+  const readyTools = readyCloudMcpToolIds(health);
+
+  return (
+    <SettingsInset className="space-y-4 bg-dls-surface" data-testid="agent-access-card">
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1">
+          <div className="text-base font-semibold text-dls-text">Agent access to connected services</div>
+          <div className="max-w-[62ch] text-sm text-dls-secondary">
+            Lets agents use the exact OpenWork Cloud tools for this active workspace and organization.
+          </div>
+        </div>
+        <SettingsStatusBadge label={summary.statusLabel} tone={summary.tone} />
+      </div>
+
+      <div className="grid gap-2 text-sm text-dls-secondary sm:grid-cols-2">
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.14em] text-dls-secondary">First issue</div>
+          <div className="mt-1 text-dls-text">{summary.stageLabel}</div>
+        </div>
+        <div>
+          <div className="text-xs font-semibold uppercase tracking-[0.14em] text-dls-secondary">Recommended action</div>
+          <div className="mt-1 text-dls-text">{summary.recommendedAction}</div>
+        </div>
+      </div>
+
+      {health?.usable ? (
+        <div className="space-y-2 rounded-xl border border-green-6/30 bg-green-2 p-3 text-sm text-green-11">
+          <div className="font-medium">Cloud tools registered for this workspace</div>
+          <div className="flex flex-wrap gap-2 font-mono text-xs">
+            {readyTools.map((tool) => <span key={tool} className="rounded-md bg-green-3 px-2 py-1">{tool}</span>)}
+          </div>
+          <div className="text-xs">
+            {health.usableByCurrentModel === null
+              ? "Current model access was not checked."
+              : health.usableByCurrentModel
+                ? "Current model can use these Cloud tools."
+                : "Current model cannot use these Cloud tools."}
+          </div>
+        </div>
+      ) : null}
+
+      {error ? <SettingsNotice tone="error">{error}</SettingsNotice> : null}
+
+      <div className="flex flex-wrap gap-2">
+        <Button variant="outline" size="sm" disabled={!canRun || busy !== null} onClick={() => void testNow()}>
+          {busy === "test" ? "Testing…" : "Test now"}
+        </Button>
+        <Button size="sm" disabled={!canRun || busy !== null} onClick={() => void repairAndTest()}>
+          {busy === "repair" ? "Repairing…" : "Repair and test"}
+        </Button>
+      </div>
+    </SettingsInset>
   );
 }
 
@@ -408,6 +609,10 @@ function ConnectOrganizationList(props: {
 function ConnectActivePanel(props: {
   connections: DenExternalMcpConnection[];
   marketplaceItems: ExtensionItem[];
+  openworkClient: OpenworkServerClient | null;
+  workspaceId: string | null;
+  currentModel: OpenworkCloudMcpProviderModelContext | null;
+  onCloudMcpHealthChange?: (health: OpenworkCloudMcpHealth | null) => void;
   loading: boolean;
   error: string | null;
   connectingId: string | null;
@@ -420,6 +625,13 @@ function ConnectActivePanel(props: {
 
   return (
     <SettingsSection>
+      <AgentAccessCard
+        client={props.openworkClient}
+        workspaceId={props.workspaceId}
+        currentModel={props.currentModel}
+        onHealthChange={props.onCloudMcpHealthChange}
+      />
+
       <div
         data-testid="connect-org-status-row"
         className="flex items-center gap-2 rounded-2xl border border-green-6/30 bg-green-2 px-4 py-3 text-sm font-medium text-green-11"
@@ -468,10 +680,12 @@ export function ConnectView(props: ConnectViewProps) {
   const denAuth = useDenAuth();
   const desktopConfig = useDesktopConfig();
   const connectEnabled = useConnectEnabled();
+  const cloudSession = useCloudSession();
   const orgMcpConnections = useOrgMcpConnections();
   const marketplaceItems = props.marketplaceItems ?? [];
   const refreshMarketplaceItems = props.refreshMarketplaceItems;
   const connectionsCount = orgMcpConnections.connections.length;
+  const activeOrgSelected = Boolean(cloudSession.activeOrganization?.id.trim() || readDenSettings().activeOrgId?.trim());
   const signedInLoading = denAuth.status === "signed_in"
     && connectionsCount === 0
     && connectEnabled !== true
@@ -482,6 +696,7 @@ export function ConnectView(props: ConnectViewProps) {
         authStatus: denAuth.status,
         connectEnabled,
         connectionsCount,
+        activeOrgSelected,
       });
 
   useEffect(() => {
@@ -499,6 +714,10 @@ export function ConnectView(props: ConnectViewProps) {
         <ConnectActivePanel
           connections={orgMcpConnections.connections}
           marketplaceItems={marketplaceItems}
+          openworkClient={props.openworkClient}
+          workspaceId={props.workspaceId}
+          currentModel={props.currentModel}
+          onCloudMcpHealthChange={props.onCloudMcpHealthChange}
           loading={orgMcpConnections.loading}
           error={orgMcpConnections.error}
           connectingId={orgMcpConnections.connectingId}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -11,6 +11,8 @@ import {
   isLoopbackOpenworkServerUrl,
   readOpenworkServerSettings,
   OpenworkServerError,
+  type OpenworkCloudMcpHealth,
+  type OpenworkCloudMcpProviderModelContext,
   type OpenworkServerCapabilities,
   type OpenworkServerClient,
   type OpenworkWorkspaceInfo,
@@ -51,6 +53,7 @@ import {
   workspaceLabel,
 } from "@/react-app/shell/route-workspaces";
 import { createConnectionsStore, useConnectionsStoreSnapshot } from "@/react-app/domains/connections/store";
+import { cleanupOpenworkCloudMcpAfterSignOut } from "@/react-app/domains/connections/cloud-mcp-reconciler";
 import { useOrgMcpConnections } from "@/react-app/domains/connections/use-org-mcp-connections";
 import { createOpenworkServerStore, useOpenworkServerStoreSnapshot } from "@/react-app/domains/connections/openwork-server-store";
 import { createProviderAuthStore, useProviderAuthStoreSnapshot } from "@/react-app/domains/connections/provider-auth/store";
@@ -157,7 +160,7 @@ import { CommandPalette } from "./command-palette";
 import { buildCommandPaletteSessions } from "./command-palette-sessions";
 import { useCommandPaletteShortcut } from "./use-shell-shortcuts";
 import { buildFeedbackUrl } from "@/app/lib/feedback";
-import { getDenInferenceUrl } from "@/app/lib/den";
+import { getDenInferenceUrl, type DenSettings } from "@/app/lib/den";
 import { readActiveWorkspaceId, writeActiveWorkspaceId } from "./session-memory";
 import { workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
@@ -445,6 +448,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const [voiceStatus, setVoiceStatus] = useState<string | null>(null);
   const [voiceError, setVoiceError] = useState<string | null>(null);
   const [userEnvKeys, setUserEnvKeys] = useState<string[]>([]);
+  const [cloudMcpHealth, setCloudMcpHealth] = useState<OpenworkCloudMcpHealth | null>(null);
   const emptyWorkspaceDisplay = useMemo<WorkspaceDisplay>(
     () => ({
       id: "",
@@ -463,6 +467,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     selectedWorkspaceType: "local" as "local" | "remote",
     runtimeWorkspaceId: null as string | null,
     openworkServerClient: null as OpenworkServerClient | null,
+    selectedWorkspaceOpenworkClient: null as OpenworkServerClient | null,
     openworkServerStatus: "disconnected" as "connected" | "disconnected",
     openworkServerCapabilities: null as OpenworkServerCapabilities | null,
     selectedWorkspaceDisplay: emptyWorkspaceDisplay as WorkspaceDisplay,
@@ -515,6 +520,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     selectedWorkspaceType: selectedWorkspace?.workspaceType ?? "local",
     runtimeWorkspaceId: selectedWorkspace?.id ?? null,
     openworkServerClient: openworkClient,
+    selectedWorkspaceOpenworkClient: openworkClient,
     openworkServerStatus: openworkClient ? "connected" : "disconnected",
     openworkServerCapabilities: openworkClient ? ROUTE_OPENWORK_CAPABILITIES : null,
     selectedWorkspaceDisplay,
@@ -680,8 +686,31 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     void connectionsStore.refreshMcpServers();
   }, [connectionsStore, openworkServerStatusForMcp]);
 
+  const cleanupCloudMcpForSignOut = useCallback(async (settings: DenSettings) => {
+    const client = routeStateRef.current.selectedWorkspaceOpenworkClient;
+    const workspaceId = routeStateRef.current.runtimeWorkspaceId?.trim() ?? "";
+    const orgId = settings.activeOrgId?.trim() ?? "";
+    if (!client || !workspaceId || !orgId) return;
+    // Settings only has a safe, exact OpenCode client/directory for the active
+    // workspace here, so sign-out cleanup is intentionally scoped to that
+    // workspace instead of guessing across every configured worker.
+    await cleanupOpenworkCloudMcpAfterSignOut({
+      context: {
+        denBaseUrl: settings.baseUrl,
+        serverBaseUrl: client.baseUrl,
+        workspaceId,
+        orgId,
+      },
+      openworkClient: client,
+      opencodeClient: routeStateRef.current.activeClient,
+      directory: routeStateRef.current.selectedWorkspaceRoot,
+    });
+    setCloudMcpHealth(null);
+    await refreshMcpServersRef.current?.();
+  }, []);
   const denSession = useDenSession({
     developerMode,
+    onBeforeSignedOut: cleanupCloudMcpForSignOut,
     openLink: (url) => platform.openLink(url),
   });
   const cloudSession = useCloudSession();
@@ -809,6 +838,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
   const runtimeWorkspaceId = selectedWorkspaceEndpoint?.workspaceId ?? selectedWorkspace?.id ?? null;
   routeStateRef.current.runtimeWorkspaceId = runtimeWorkspaceId;
+  routeStateRef.current.selectedWorkspaceOpenworkClient = selectedWorkspaceEndpoint?.client ?? openworkClient;
 
   const opencodeClient = useMemo(() => {
     if (!selectedWorkspaceEndpoint || !selectedWorkspaceEndpoint.token) return null;
@@ -835,6 +865,22 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     workspaceRoot: selectedWorkspaceRoot,
     onLoadError: handleModelPickerLoadError,
   });
+  const currentCloudMcpModel = useMemo<OpenworkCloudMcpProviderModelContext | null>(() => {
+    const provider = local.prefs.defaultModel?.providerID.trim() ?? "";
+    const model = local.prefs.defaultModel?.modelID.trim() ?? "";
+    return provider && model ? { provider, model } : null;
+  }, [local.prefs.defaultModel]);
+  const refreshCloudMcpHealth = useCallback(async () => {
+    const client = selectedWorkspaceEndpoint?.client ?? openworkClient;
+    const workspaceId = runtimeWorkspaceId?.trim() ?? "";
+    if (!client || !workspaceId) {
+      setCloudMcpHealth(null);
+      return null;
+    }
+    const health = await client.getOpenworkCloudMcpHealth(workspaceId, currentCloudMcpModel ?? undefined);
+    setCloudMcpHealth(health);
+    return health;
+  }, [currentCloudMcpModel, openworkClient, runtimeWorkspaceId, selectedWorkspaceEndpoint]);
   const { commandPaletteOpen, setCommandPaletteOpen } = useCommandPaletteShortcut(!props.embedded);
   const paletteSessionOptions = useMemo(
     () => buildCommandPaletteSessions(workspaces, sessionsByWorkspaceId, selectedWorkspaceId),
@@ -2191,6 +2237,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             session={denSession}
             marketplaceItems={extensionItems.cloudPluginItems}
             refreshMarketplaceItems={refreshConnectMarketplaceItems}
+            openworkClient={selectedWorkspaceEndpoint?.client ?? openworkClient}
+            workspaceId={runtimeWorkspaceId}
+            currentModel={currentCloudMcpModel}
+            onCloudMcpHealthChange={setCloudMcpHealth}
           />
         );
       case "cloud-marketplaces":
@@ -2268,6 +2318,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               }
               return openworkClient.getRuntimeConfigStatus(selectedWorkspaceId);
             }}
+            cloudMcpHealth={cloudMcpHealth}
+            refreshCloudMcpHealth={refreshCloudMcpHealth}
             organizationServer={denSession}
           />
         );

--- a/apps/app/tests/cloud-mcp-health.test.ts
+++ b/apps/app/tests/cloud-mcp-health.test.ts
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { DenMcpToken } from "../src/app/lib/den";
+import type { OpenworkCloudMcpFailure, OpenworkCloudMcpHealth, OpenworkCloudMcpReconcilePayload } from "../src/app/lib/openwork-server";
+import {
+  __setCloudMcpUserStateStorageForTest,
+  getCloudMcpScopeKey,
+  readCloudMcpSyncMarker,
+  writeCloudMcpSyncMarker,
+} from "../src/react-app/domains/connections/cloud-mcp-user-state";
+import {
+  cloudMcpDisplaySummary,
+  cloudMcpFailureStageLabel,
+  isCloudMcpAuthTokenFailureCode,
+  runOpenworkCloudMcpReconciler,
+} from "../src/react-app/domains/connections/cloud-mcp-reconciler";
+
+const NOW = Date.parse("2026-07-09T12:00:00.000Z");
+const scope = {
+  denBaseUrl: "https://app.openwork.test",
+  serverBaseUrl: "https://worker.openwork.test",
+  orgId: "org_1",
+  workspaceId: "ws_1",
+};
+const context = {
+  ...scope,
+  denAuthToken: "den-session-token",
+  providerModel: { provider: "openwork", model: "gpt-5" },
+};
+const token: DenMcpToken = {
+  token: "owt_mcp_secret_token",
+  expiresAt: new Date(NOW + 7 * 24 * 60 * 60 * 1000).toISOString(),
+  organizationId: "org_1",
+  scopes: ["mcp:read", "mcp:write"],
+  resource: "https://api.openwork.test/mcp",
+};
+
+function installStorageStub() {
+  const values = new Map<string, string>();
+  __setCloudMcpUserStateStorageForTest({
+    getItem: (key) => values.get(key) ?? null,
+    setItem: (key, value) => values.set(key, value),
+    removeItem: (key) => values.delete(key),
+  });
+}
+
+function failure(code: string): OpenworkCloudMcpFailure {
+  return {
+    code,
+    stage: "engine_status",
+    retryable: false,
+    recommendedAction: "fix it",
+    message: "failed",
+  };
+}
+
+function health(input: { usable: boolean; failure?: OpenworkCloudMcpFailure | null; projectionChecked?: boolean }): OpenworkCloudMcpHealth {
+  const usable = input.usable;
+  const projectionChecked = input.projectionChecked ?? usable;
+  return {
+    schemaVersion: 1,
+    phase: usable ? "ready" : "engine_failed",
+    usable,
+    usableByCurrentModel: projectionChecked ? usable : null,
+    connectCatalogEnabled: true,
+    workspace: { id: scope.workspaceId, type: "local", directory: "/workspace", path: "/workspace" },
+    desired: {
+      present: true,
+      name: "openwork-cloud",
+      revision: "rev_desired",
+      config: null,
+      token: { present: true, metadata: { expiresAt: token.expiresAt, scopes: "mcp:read mcp:write" } },
+    },
+    delivery: {
+      state: usable ? "ready" : "pending",
+      desiredRevision: "rev_desired",
+      appliedRevision: usable ? "rev_desired" : null,
+      updatedAt: NOW,
+      appliedAt: usable ? NOW : null,
+      lastAttemptAt: NOW,
+    },
+    engine: { status: usable ? "connected" : "failed" },
+    tools: {
+      expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+      present: usable ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"] : [],
+      missing: usable ? [] : ["openwork-cloud_search_capabilities"],
+      providerProjection: {
+        checked: projectionChecked,
+        provider: "openwork",
+        model: "gpt-5",
+        present: usable ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"] : [],
+        missing: usable ? [] : ["openwork-cloud_execute_capability"],
+      },
+    },
+    pluginCanaries: { expected: ["openwork_docs_search"], present: usable ? ["openwork_docs_search"] : [], missing: usable ? [] : ["openwork_docs_search"] },
+    toolDenies: [],
+    firstFailure: usable ? null : input.failure ?? failure("cloud_connection_failed"),
+    checkedAt: new Date(NOW).toISOString(),
+  };
+}
+
+describe("OpenWork Cloud MCP reconciler", () => {
+  beforeEach(() => installStorageStub());
+
+  test("Test now performs only GET health", async () => {
+    const values = new Map<string, string>();
+    let writes = 0;
+    __setCloudMcpUserStateStorageForTest({
+      getItem: (key) => values.get(key) ?? null,
+      setItem: (key, value) => {
+        writes += 1;
+        values.set(key, value);
+      },
+      removeItem: (key) => values.delete(key),
+    });
+    writeCloudMcpSyncMarker({ ...scope, expiresAt: token.expiresAt });
+    writes = 0;
+    let getCount = 0;
+    let mintCount = 0;
+    let postCount = 0;
+    const result = await runOpenworkCloudMcpReconciler({
+      mode: "health",
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => {
+          getCount += 1;
+          return health({ usable: true });
+        },
+        reconcileOpenworkCloudMcp: async () => {
+          postCount += 1;
+          return health({ usable: true });
+        },
+      },
+      context,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+      refreshMarginMs: 24 * 60 * 60 * 1000,
+    });
+
+    expect(result.health?.usable).toBe(true);
+    expect(getCount).toBe(1);
+    expect(mintCount).toBe(0);
+    expect(postCount).toBe(0);
+    expect(result.markerWritten).toBe(false);
+    expect(writes).toBe(0);
+  });
+
+  test("writes marker only when returned health is usable", async () => {
+    const client = {
+      baseUrl: scope.serverBaseUrl,
+      getOpenworkCloudMcpHealth: async () => health({ usable: false, failure: failure("cloud_status_missing") }),
+      reconcileOpenworkCloudMcp: async () => health({ usable: false, failure: failure("cloud_status_missing") }),
+    };
+
+    await runOpenworkCloudMcpReconciler({ mode: "repair", client, context, mintToken: async () => token, force: true, refreshMarginMs: 1 });
+    expect(readCloudMcpSyncMarker(scope)).toBeNull();
+
+    await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client: { ...client, reconcileOpenworkCloudMcp: async () => health({ usable: true }) },
+      context,
+      mintToken: async () => token,
+      force: true,
+      refreshMarginMs: 1,
+    });
+    expect(readCloudMcpSyncMarker(scope)?.expiresAt).toBe(token.expiresAt);
+  });
+
+  test("auth failures remint exactly once", async () => {
+    let mintCount = 0;
+    const posts: OpenworkCloudMcpReconcilePayload[] = [];
+    const result = await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => health({ usable: false }),
+        reconcileOpenworkCloudMcp: async (_workspaceId, payload) => {
+          posts.push(payload);
+          return posts.length === 1
+            ? health({ usable: false, failure: failure("openwork_cloud_token_expired") })
+            : health({ usable: true });
+        },
+      },
+      context,
+      mintToken: async () => {
+        mintCount += 1;
+        return { ...token, token: `owt_mcp_secret_${mintCount}` };
+      },
+      force: true,
+      refreshMarginMs: 1,
+    });
+
+    expect(result.health?.usable).toBe(true);
+    expect(mintCount).toBe(2);
+    expect(posts).toHaveLength(2);
+  });
+
+  test("membership and scope failures do not retry", async () => {
+    for (const code of ["openwork_cloud_membership_required", "openwork_cloud_scope_missing", "openwork_cloud_resource_forbidden"]) {
+      expect(isCloudMcpAuthTokenFailureCode(code)).toBe(false);
+    }
+    let mintCount = 0;
+    let postCount = 0;
+    await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => health({ usable: false }),
+        reconcileOpenworkCloudMcp: async () => {
+          postCount += 1;
+          return health({ usable: false, failure: failure("openwork_cloud_membership_required") });
+        },
+      },
+      context,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+      force: true,
+      refreshMarginMs: 1,
+    });
+
+    expect(mintCount).toBe(1);
+    expect(postCount).toBe(1);
+  });
+
+  test("dedupe key is scoped by deployment, server, workspace, and org without token", () => {
+    const key = getCloudMcpScopeKey(scope);
+    expect(key).toContain(scope.denBaseUrl);
+    expect(key).toContain(scope.serverBaseUrl);
+    expect(key).toContain(scope.workspaceId);
+    expect(key).toContain(scope.orgId);
+    expect(key).not.toContain("den-session-token");
+    expect(getCloudMcpScopeKey({ ...scope, orgId: "org_2" })).not.toBe(key);
+  });
+
+  test("plain-language helpers map model projection and missing provider checks", () => {
+    expect(cloudMcpFailureStageLabel({
+      signedIn: true,
+      orgSelected: true,
+      health: health({ usable: false, failure: failure("provider_projection_missing") }),
+    })).toBe("Current model can’t use Cloud tools");
+
+    const summary = cloudMcpDisplaySummary({
+      signedIn: true,
+      orgSelected: true,
+      connecting: false,
+      health: health({ usable: true, projectionChecked: false }),
+    });
+    expect(summary.statusLabel).toBe("Ready");
+    expect(summary.recommendedAction).toContain("not checked");
+  });
+
+  test("missing desired config is degraded while explicit disabled config is disabled", () => {
+    const missingDesired = {
+      ...health({ usable: false, failure: { ...failure("cloud_mcp_missing"), stage: "desired_config" } }),
+      desired: {
+        present: false,
+        name: "openwork-cloud",
+        revision: null,
+        config: null,
+        token: { present: false, metadata: {} },
+      },
+    };
+    const missingSummary = cloudMcpDisplaySummary({
+      signedIn: true,
+      orgSelected: true,
+      connecting: false,
+      health: missingDesired,
+    });
+    expect(missingSummary.statusLabel).toBe("Degraded");
+    expect(missingSummary.stageLabel).toBe("Couldn’t apply Cloud access to this workspace");
+
+    const disabledSummary = cloudMcpDisplaySummary({
+      signedIn: true,
+      orgSelected: true,
+      connecting: false,
+      health: {
+        ...health({ usable: false, failure: { ...failure("cloud_mcp_disabled"), stage: "desired_config" } }),
+        desired: {
+          ...health({ usable: false }).desired,
+          config: { enabled: false },
+        },
+      },
+    });
+    expect(disabledSummary.statusLabel).toBe("Disabled");
+  });
+});

--- a/apps/app/tests/cloud-mcp-user-state.test.ts
+++ b/apps/app/tests/cloud-mcp-user-state.test.ts
@@ -3,14 +3,27 @@ import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 import {
   __setCloudMcpUserStateStorageForTest,
   clearCloudMcpUserState,
+  clearCloudMcpUnhealthyRemintAttempt,
   isCloudMcpSyncMarkerFresh,
   readCloudMcpSyncMarker,
+  readCloudMcpUnhealthyRemintAttempt,
   readCloudMcpUserState,
   writeCloudMcpSyncMarker,
+  writeCloudMcpUnhealthyRemintAttempt,
   writeCloudMcpUserState,
 } from "../src/react-app/domains/connections/cloud-mcp-user-state";
 
 const DAY_MS = 24 * 60 * 60 * 1000;
+const scope = {
+  denBaseUrl: "https://cloud.openwork.test",
+  serverBaseUrl: "https://worker.openwork.test",
+  orgId: "organization_1",
+  workspaceId: "workspace_1",
+};
+const otherScope = {
+  ...scope,
+  workspaceId: "workspace_2",
+};
 
 // Bun on Linux exposes a readonly `globalThis.window`, so the storage is
 // injected via the test hook instead of stubbing the global.
@@ -37,20 +50,28 @@ describe("cloud MCP user state", () => {
     installStorageStub();
   });
 
-  test("round-trips disabled and removed intents", () => {
-    expect(readCloudMcpUserState()).toBeNull();
-    writeCloudMcpUserState("disabled");
-    expect(readCloudMcpUserState()).toBe("disabled");
-    writeCloudMcpUserState("removed");
-    expect(readCloudMcpUserState()).toBe("removed");
-    clearCloudMcpUserState();
-    expect(readCloudMcpUserState()).toBeNull();
+  test("round-trips disabled and removed intents per scope", () => {
+    expect(readCloudMcpUserState(scope)).toBeNull();
+    writeCloudMcpUserState("disabled", scope);
+    expect(readCloudMcpUserState(scope)).toBe("disabled");
+    expect(readCloudMcpUserState(otherScope)).toBeNull();
+    writeCloudMcpUserState("removed", scope);
+    expect(readCloudMcpUserState(scope)).toBe("removed");
+    clearCloudMcpUserState(scope);
+    expect(readCloudMcpUserState(scope)).toBeNull();
   });
 
   test("ignores corrupt stored values", () => {
     const backing = installStorageStub();
     backing.set("openwork.den.mcp.cloudControlUserState", "banana");
-    expect(readCloudMcpUserState()).toBeNull();
+    expect(readCloudMcpUserState(scope)).toBeNull();
+  });
+
+  test("migrates legacy global intent to only the active scope", () => {
+    const backing = installStorageStub();
+    backing.set("openwork.den.mcp.cloudControlUserState", "disabled");
+    expect(readCloudMcpUserState(scope)).toBe("disabled");
+    expect(readCloudMcpUserState(otherScope)).toBeNull();
   });
 
   test("rejects ambiguous legacy sync markers", () => {
@@ -86,6 +107,14 @@ describe("cloud MCP user state", () => {
     };
     writeCloudMcpSyncMarker(marker);
     expect(readCloudMcpSyncMarker(marker)).toEqual(marker);
+  });
+
+  test("scopes unhealthy remint attempts", () => {
+    writeCloudMcpUnhealthyRemintAttempt({ ...scope, attemptedAt: 123 });
+    expect(readCloudMcpUnhealthyRemintAttempt(scope)?.attemptedAt).toBe(123);
+    expect(readCloudMcpUnhealthyRemintAttempt(otherScope)).toBeNull();
+    clearCloudMcpUnhealthyRemintAttempt(scope);
+    expect(readCloudMcpUnhealthyRemintAttempt(scope)).toBeNull();
   });
 });
 

--- a/apps/app/tests/connect-view.test.ts
+++ b/apps/app/tests/connect-view.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveConnectViewState } from "../src/react-app/domains/settings/pages/connect-view";
+import type { OpenworkCloudMcpHealth } from "../src/app/lib/openwork-server";
+import { readyCloudMcpToolIds, resolveConnectViewState } from "../src/react-app/domains/settings/pages/connect-view";
 import {
   formatPluginConnectRowMeta,
   isDesktopInstallableMarketplacePlugin,
@@ -31,6 +32,44 @@ describe("resolveConnectViewState", () => {
   test("signed-in users with no flag and no connections see the pitch", () => {
     expect(resolveConnectViewState({ authStatus: "signed_in", connectEnabled: false, connectionsCount: 0 })).toBe("pitch");
     expect(resolveConnectViewState({ authStatus: "signed_in", connectionsCount: 0 })).toBe("pitch");
+  });
+
+  test("signed-in users with an active org keep the Agent access card visible without catalog rollout", () => {
+    expect(resolveConnectViewState({ authStatus: "signed_in", connectEnabled: false, connectionsCount: 0, activeOrgSelected: true })).toBe("active");
+  });
+});
+
+function cloudHealth(usable: boolean): OpenworkCloudMcpHealth {
+  return {
+    schemaVersion: 1,
+    phase: usable ? "ready" : "cloud_tools_missing",
+    usable,
+    usableByCurrentModel: usable,
+    connectCatalogEnabled: true,
+    workspace: { id: "ws_1", type: "local", directory: "/workspace", path: "/workspace" },
+    desired: { present: true, name: "openwork-cloud", revision: "rev", config: null, token: { present: true, metadata: {} } },
+    delivery: { state: usable ? "ready" : "pending", desiredRevision: "rev", appliedRevision: usable ? "rev" : null, updatedAt: 1, appliedAt: usable ? 1 : null, lastAttemptAt: 1 },
+    engine: { status: usable ? "connected" : "failed" },
+    tools: {
+      expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+      present: usable ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability", "other_tool"] : ["openwork-cloud_search_capabilities"],
+      missing: usable ? [] : ["openwork-cloud_execute_capability"],
+      providerProjection: { checked: true, present: [], missing: [] },
+    },
+    pluginCanaries: { expected: [], present: [], missing: [] },
+    toolDenies: [],
+    firstFailure: usable ? null : { code: "cloud_tools_missing", stage: "tool_ids", retryable: true, recommendedAction: "repair", message: "missing" },
+    checkedAt: "2026-07-09T12:00:00.000Z",
+  };
+}
+
+describe("Agent access card helpers", () => {
+  test("returns exact Cloud tools only when health is ready", () => {
+    expect(readyCloudMcpToolIds(cloudHealth(false))).toEqual([]);
+    expect(readyCloudMcpToolIds(cloudHealth(true))).toEqual([
+      "openwork-cloud_search_capabilities",
+      "openwork-cloud_execute_capability",
+    ]);
   });
 });
 

--- a/apps/app/tests/diagnostics-bundle.test.ts
+++ b/apps/app/tests/diagnostics-bundle.test.ts
@@ -110,4 +110,39 @@ describe("diagnostics bundle", () => {
     expect(parsed.openworkServer.host).toBeNull();
     expect(parsed.openworkServer.settings.tokenPresent).toBe(false);
   });
+
+  test("includes sanitized Cloud health without Den or MCP tokens", () => {
+    const input = baseInputs();
+    input.cloudMcpHealth = {
+      desired: {
+        config: {
+          headers: {
+            Authorization: "Bearer owt_mcp_synthetic_secret",
+          },
+        },
+        token: {
+          present: true,
+          metadata: {
+            fingerprint: "sha256:abc123",
+            expiresAt: "2026-07-20T00:00:00.000Z",
+            scopes: "mcp:read mcp:write",
+          },
+        },
+      },
+      firstFailure: {
+        details: "den token Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJzZWNyZXQifQ.signatureee leaked",
+      },
+      opaque: "owt_den_synthetic_secret",
+    };
+
+    const json = composeDiagnosticsBundleJson(input);
+    const parsed = JSON.parse(json);
+
+    expect(parsed.cloudMcp.desired.config.headers.Authorization).toBe("[REDACTED]");
+    expect(JSON.stringify(parsed.cloudMcp)).toContain("sha256:abc123");
+    expect(JSON.stringify(parsed.cloudMcp)).toContain("mcp:read mcp:write");
+    expect(json).not.toContain("owt_mcp_synthetic_secret");
+    expect(json).not.toContain("owt_den_synthetic_secret");
+    expect(json).not.toContain("eyJhbGciOiJIUzI1NiJ9");
+  });
 });

--- a/apps/app/tests/session-mcp-maintenance.test.ts
+++ b/apps/app/tests/session-mcp-maintenance.test.ts
@@ -1,11 +1,13 @@
 import { afterAll, beforeEach, describe, expect, test } from "bun:test";
 
 import type { DenMcpToken, DenSettings } from "../src/app/lib/den";
+import type { OpenworkCloudMcpHealth, OpenworkCloudMcpReconcilePayload } from "../src/app/lib/openwork-server";
 import {
   __setCloudMcpUserStateStorageForTest,
   readCloudMcpSyncMarker,
   writeCloudMcpUserState,
 } from "../src/react-app/domains/connections/cloud-mcp-user-state";
+import { cleanupOpenworkCloudMcpAfterSignOut } from "../src/react-app/domains/connections/cloud-mcp-reconciler";
 import {
   getSessionMcpMaintenanceTargetKey,
   runSessionMcpMaintenanceTask,
@@ -27,6 +29,55 @@ const MINTED: DenMcpToken = {
   resource: "https://api.openwork.test/mcp",
 };
 
+function cloudHealth(usable: boolean): OpenworkCloudMcpHealth {
+  return {
+    schemaVersion: 1,
+    phase: usable ? "ready" : "missing_desired",
+    usable,
+    usableByCurrentModel: usable ? true : null,
+    connectCatalogEnabled: true,
+    workspace: { id: WORKSPACE_ID, type: "local", directory: "/workspace", path: "/workspace" },
+    desired: {
+      present: usable,
+      name: "openwork-cloud",
+      revision: usable ? "rev_ready" : null,
+      config: null,
+      token: { present: usable, metadata: {} },
+    },
+    delivery: {
+      state: usable ? "ready" : "not_desired",
+      desiredRevision: usable ? "rev_ready" : null,
+      appliedRevision: usable ? "rev_ready" : null,
+      updatedAt: usable ? NOW : null,
+      appliedAt: usable ? NOW : null,
+      lastAttemptAt: usable ? NOW : null,
+    },
+    engine: { status: usable ? "connected" : "not_checked" },
+    tools: {
+      expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+      present: usable ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"] : [],
+      missing: usable ? [] : ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+      providerProjection: {
+        checked: usable,
+        provider: "openwork",
+        model: "gpt-5",
+        present: usable ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"] : [],
+        missing: [],
+      },
+    },
+    pluginCanaries: { expected: [], present: [], missing: [] },
+    toolDenies: [],
+    firstFailure: usable ? null : {
+      code: "cloud_desired_missing",
+      stage: "desired",
+      retryable: false,
+      recommendedAction: "Connect OpenWork Cloud",
+      message: "missing",
+    },
+    checkedAt: new Date(NOW).toISOString(),
+  };
+}
+
 function installStorageStub() {
   const values = new Map<string, string>();
   __setCloudMcpUserStateStorageForTest({
@@ -44,13 +95,14 @@ describe("session MCP maintenance", () => {
   beforeEach(() => installStorageStub());
 
   test("mints and hot-updates the Cloud MCP without opening Settings", async () => {
-    const writes: Array<{ workspaceId: string; payload: { name: string; config: Record<string, unknown> } }> = [];
+    const writes: Array<{ workspaceId: string; payload: OpenworkCloudMcpReconcilePayload }> = [];
     const client = {
       baseUrl: "https://worker.openwork.test",
       listMcp: async () => ({ items: [] }),
-      addMcp: async (workspaceId: string, payload: { name: string; config: Record<string, unknown> }) => {
+      getOpenworkCloudMcpHealth: async () => cloudHealth(false),
+      reconcileOpenworkCloudMcp: async (workspaceId: string, payload: OpenworkCloudMcpReconcilePayload) => {
         writes.push({ workspaceId, payload });
-        return { items: [] };
+        return cloudHealth(true);
       },
     };
 
@@ -65,6 +117,7 @@ describe("session MCP maintenance", () => {
     expect(writes).toEqual([{
       workspaceId: WORKSPACE_ID,
       payload: {
+        workspaceId: WORKSPACE_ID,
         name: "openwork-cloud",
         config: {
           type: "remote",
@@ -73,6 +126,15 @@ describe("session MCP maintenance", () => {
           headers: { Authorization: "Bearer mcp-token" },
           oauth: false,
         },
+        tokenMetadata: {
+          organizationId: "organization_1",
+          expiresAt: MINTED.expiresAt,
+          resource: "https://api.openwork.test/mcp",
+          scopes: "mcp:read mcp:write",
+        },
+        org: { id: "organization_1", slug: null, name: null },
+        connectCatalogEnabled: true,
+        trigger: "desktop-background",
       },
     }]);
     expect(readCloudMcpSyncMarker({
@@ -92,6 +154,7 @@ describe("session MCP maintenance", () => {
   test("a fresh per-workspace marker prevents repeated token and config writes", async () => {
     let mintCount = 0;
     let writeCount = 0;
+    let healthReady = false;
     const client = {
       baseUrl: "https://worker.openwork.test",
       listMcp: async () => ({
@@ -100,9 +163,11 @@ describe("session MCP maintenance", () => {
           config: { type: "remote", enabled: true, url: "https://api.openwork.test/mcp/agent" },
         }],
       }),
-      addMcp: async () => {
+      getOpenworkCloudMcpHealth: async () => cloudHealth(healthReady),
+      reconcileOpenworkCloudMcp: async () => {
         writeCount += 1;
-        return { items: [] };
+        healthReady = true;
+        return cloudHealth(true);
       },
     };
 
@@ -133,6 +198,7 @@ describe("session MCP maintenance", () => {
   test("keeps independent markers when switching between workspaces", async () => {
     let mintCount = 0;
     const writes: string[] = [];
+    const readyWorkspaces = new Set<string>();
     const client = {
       baseUrl: "https://worker.openwork.test",
       listMcp: async () => ({
@@ -144,6 +210,12 @@ describe("session MCP maintenance", () => {
       addMcp: async (workspaceId: string) => {
         writes.push(workspaceId);
         return { items: [] };
+      },
+      getOpenworkCloudMcpHealth: async (workspaceId: string) => cloudHealth(readyWorkspaces.has(workspaceId)),
+      reconcileOpenworkCloudMcp: async (workspaceId: string) => {
+        writes.push(workspaceId);
+        readyWorkspaces.add(workspaceId);
+        return cloudHealth(true);
       },
     };
     const mintToken = async () => {
@@ -180,6 +252,7 @@ describe("session MCP maintenance", () => {
   test("keeps same-named remote workspaces separate across workers", async () => {
     let mintCount = 0;
     const writes: string[] = [];
+    const readyWorkers = new Set<string>();
     const makeClient = (baseUrl: string) => ({
       baseUrl,
       listMcp: async () => ({
@@ -191,6 +264,12 @@ describe("session MCP maintenance", () => {
       addMcp: async () => {
         writes.push(baseUrl);
         return { items: [] };
+      },
+      getOpenworkCloudMcpHealth: async () => cloudHealth(readyWorkers.has(baseUrl)),
+      reconcileOpenworkCloudMcp: async () => {
+        writes.push(baseUrl);
+        readyWorkers.add(baseUrl);
+        return cloudHealth(true);
       },
     });
     const workerA = makeClient("https://worker-a.openwork.test");
@@ -215,7 +294,12 @@ describe("session MCP maintenance", () => {
   });
 
   test("explicit removal keeps background maintenance disabled", async () => {
-    writeCloudMcpUserState("removed");
+    writeCloudMcpUserState("removed", {
+      denBaseUrl: SETTINGS.baseUrl,
+      serverBaseUrl: "https://worker.openwork.test",
+      orgId: SETTINGS.activeOrgId ?? "",
+      workspaceId: WORKSPACE_ID,
+    });
     let listed = false;
 
     await expect(syncCloudControlMcpInBackground({
@@ -225,7 +309,8 @@ describe("session MCP maintenance", () => {
           listed = true;
           return { items: [] };
         },
-        addMcp: async () => ({ items: [] }),
+        getOpenworkCloudMcpHealth: async () => cloudHealth(false),
+        reconcileOpenworkCloudMcp: async () => cloudHealth(true),
       },
       workspaceId: WORKSPACE_ID,
       settings: SETTINGS,
@@ -234,26 +319,62 @@ describe("session MCP maintenance", () => {
     expect(listed).toBe(false);
   });
 
+  test("pre-signout cleanup removes runtime MCP and disconnects the exact active workspace before resolving", async () => {
+    const events: string[] = [];
+    await cleanupOpenworkCloudMcpAfterSignOut({
+      context: {
+        denBaseUrl: SETTINGS.baseUrl,
+        serverBaseUrl: "https://worker.openwork.test",
+        orgId: SETTINGS.activeOrgId ?? "",
+        workspaceId: WORKSPACE_ID,
+      },
+      openworkClient: {
+        baseUrl: "https://worker.openwork.test",
+        removeMcp: async (workspaceId, name) => {
+          events.push(`remove:${workspaceId}:${name}`);
+        },
+      },
+      opencodeClient: {
+        mcp: {
+          disconnect: async (input) => {
+            events.push(`disconnect:${input.directory}:${input.name}`);
+          },
+        },
+      },
+      directory: "/workspace/exact",
+    });
+    events.push("auth-cleared");
+
+    expect(events.slice(0, 2).sort()).toEqual([
+      "disconnect:/workspace/exact:openwork-cloud",
+      `remove:${WORKSPACE_ID}:openwork-cloud`,
+    ].sort());
+    expect(events[2]).toBe("auth-cleared");
+  });
+
   test("deduplicates the same target without blocking another workspace", async () => {
-    const firstClient = { baseUrl: "https://worker.openwork.test", token: "worker-token" };
-    const recreatedClient = { baseUrl: "https://worker.openwork.test/", token: "worker-token" };
+    const firstClient = { baseUrl: "https://worker.openwork.test" };
+    const recreatedClient = { baseUrl: "https://worker.openwork.test/" };
     const targetA = getSessionMcpMaintenanceTargetKey({
       client: firstClient,
       cloudSignedIn: true,
+      denBaseUrl: SETTINGS.baseUrl,
+      orgId: SETTINGS.activeOrgId,
       workspaceId: "workspace_a",
-      directory: "/workspace/a",
     });
     const recreatedTargetA = getSessionMcpMaintenanceTargetKey({
       client: recreatedClient,
       cloudSignedIn: true,
+      denBaseUrl: SETTINGS.baseUrl,
+      orgId: SETTINGS.activeOrgId,
       workspaceId: "workspace_a",
-      directory: "/workspace/a",
     });
     const targetB = getSessionMcpMaintenanceTargetKey({
       client: recreatedClient,
       cloudSignedIn: true,
+      denBaseUrl: SETTINGS.baseUrl,
+      orgId: SETTINGS.activeOrgId,
       workspaceId: "workspace_b",
-      directory: "/workspace/b",
     });
     let releaseTargetA = () => {};
     let targetARuns = 0;

--- a/apps/server/src/cloud-mcp-health.test.ts
+++ b/apps/server/src/cloud-mcp-health.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, test } from "bun:test";
+import {
+  CloudMcpDeliveryStateStore,
+  calculateCloudMcpDesiredRevision,
+  OPENWORK_CLOUD_EXPECTED_TOOLS,
+} from "./cloud-mcp-health.js";
+import { sanitizeDiagnosticValue } from "./diagnostic-sanitizer.js";
+import { diagnoseMcpToolDeniesFromConfigs } from "./mcp.js";
+import type { WorkspaceInfo } from "./types.js";
+
+const workspace: WorkspaceInfo = {
+  id: "ws_1",
+  name: "Workspace",
+  path: "/tmp/workspace",
+  preset: "starter",
+  workspaceType: "local",
+};
+
+describe("cloud MCP health foundation", () => {
+  test("sanitizes nested diagnostics and never returns raw authorization tokens", () => {
+    const sanitized = sanitizeDiagnosticValue({
+      Authorization: "Bearer owt_secret_client_token",
+      nested: {
+        token: "eyJhbGciOiJub25lIn0.eyJzdWIiOiIxMjM0NTY3ODkwIn0.signature123456789",
+        message: "failed with Bearer abc.def.ghi and request_id=req_123 reference_id=ref_456",
+      },
+      cookie: "session=secret",
+    });
+
+    const text = JSON.stringify(sanitized);
+    expect(text).not.toContain("owt_secret_client_token");
+    expect(text).not.toContain("eyJhbGci");
+    expect(text).not.toContain("abc.def.ghi");
+    expect(text).not.toContain("session=secret");
+    expect(text).toContain("[REDACTED]");
+  });
+
+  test("desired revisions detect token metadata change without embedding raw tokens", () => {
+    const config = {
+      type: "remote",
+      url: "https://api.openworklabs.com/mcp/agent",
+      headers: { Authorization: "Bearer owt_super_secret" },
+      oauth: false,
+    };
+    const first = calculateCloudMcpDesiredRevision(config, {
+      token: { present: true, metadata: { expiresAt: "2026-07-13T00:00:00.000Z" } },
+      connectCatalogEnabled: true,
+      updatedAt: 1,
+    });
+    const second = calculateCloudMcpDesiredRevision(config, {
+      token: { present: true, metadata: { expiresAt: "2026-07-14T00:00:00.000Z" } },
+      connectCatalogEnabled: true,
+      updatedAt: 1,
+    });
+
+    expect(first).not.toBe(second);
+    expect(first).not.toContain("owt_super_secret");
+  });
+
+  test("delivery state does not claim applied after revision changes", () => {
+    const store = new CloudMcpDeliveryStateStore();
+    const metadata = {
+      token: { present: true, metadata: { authorizationHash: "hash_1" } },
+      connectCatalogEnabled: true,
+      updatedAt: 1,
+    };
+
+    store.markDesired(workspace, workspace.path, "rev_1", metadata);
+    store.markReady(workspace, workspace.path, "rev_1");
+
+    expect(store.snapshot(workspace, workspace.path, "rev_1").appliedRevision).toBe("rev_1");
+    const changed = store.snapshot(workspace, workspace.path, "rev_2");
+    expect(changed.state).toBe("pending");
+    expect(changed.appliedRevision).toBeNull();
+  });
+
+  test("diagnoses project and global OpenCode tool denies for exact Cloud IDs", () => {
+    const denies = diagnoseMcpToolDeniesFromConfigs({
+      name: "openwork-cloud",
+      toolIds: [...OPENWORK_CLOUD_EXPECTED_TOOLS],
+      projectConfig: {
+        tools: {
+          "openwork-cloud_search_capabilities": false,
+        },
+      },
+      globalConfig: {
+        permission: [
+          { permission: "tool", pattern: "openwork-cloud_execute_capability", action: "deny" },
+        ],
+      },
+    });
+
+    expect(denies.map((deny) => deny.source).sort()).toEqual(["config.global", "config.project"]);
+    expect(denies.map((deny) => deny.matched).sort()).toEqual([
+      "openwork-cloud_execute_capability",
+      "openwork-cloud_search_capabilities",
+    ]);
+  });
+
+  test("project tool allows override global denies for matching Cloud tool IDs", () => {
+    const denies = diagnoseMcpToolDeniesFromConfigs({
+      name: "openwork-cloud",
+      toolIds: [...OPENWORK_CLOUD_EXPECTED_TOOLS],
+      projectConfig: {
+        tools: {
+          "openwork-cloud_search_capabilities": true,
+        },
+      },
+      globalConfig: {
+        tools: { deny: ["openwork-cloud_*"] },
+      },
+    });
+
+    expect(denies).toHaveLength(1);
+    expect(denies[0]).toMatchObject({
+      source: "config.global",
+      pattern: "openwork-cloud_*",
+      matched: "openwork-cloud_execute_capability",
+    });
+  });
+
+  test("plugin canary denies are not reported as Cloud tool denies", () => {
+    const denies = diagnoseMcpToolDeniesFromConfigs({
+      name: "openwork-cloud",
+      toolIds: [...OPENWORK_CLOUD_EXPECTED_TOOLS],
+      projectConfig: {
+        tools: {
+          openwork_extension_list_actions: false,
+        },
+      },
+      globalConfig: {},
+    });
+
+    expect(denies).toEqual([]);
+  });
+});

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -1,0 +1,1591 @@
+import { createHash } from "node:crypto";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { createOpencodeClient, McpStatus, ToolIds, ToolList } from "@opencode-ai/sdk/v2/client";
+import { ApiError } from "./errors.js";
+import { diagnoseMcpToolDenies, type McpToolDeny } from "./mcp.js";
+import { sanitizeDiagnosticString, sanitizeDiagnosticValue } from "./diagnostic-sanitizer.js";
+import { readRuntimeOpencodeConfig, runtimeMcpMap, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+import { validateMcpConfig } from "./validators.js";
+
+export const OPENWORK_CLOUD_MCP_NAME = "openwork-cloud";
+export const OPENWORK_CLOUD_EXPECTED_TOOLS = [
+  "openwork-cloud_search_capabilities",
+  "openwork-cloud_execute_capability",
+] satisfies string[];
+export const OPENWORK_CLOUD_PLUGIN_CANARIES = [
+  "openwork_docs_search",
+  "openwork_extension_list_actions",
+] satisfies string[];
+
+const POLL_DELAYS_MS = [0, 250, 750, 1500, 3000];
+function engineProbeTimeoutMs(): number {
+  return Number(process.env.OPENWORK_CLOUD_MCP_PROBE_TIMEOUT_MS ?? "") || 5_000;
+}
+
+type WorkspaceOpencodeClient = ReturnType<typeof createOpencodeClient>;
+
+export type CloudMcpProviderModelContext = {
+  provider: string;
+  model: string;
+};
+
+export type CloudMcpFailureStage =
+  | "prerequisites"
+  | "token_mint"
+  | "desired_config"
+  | "engine_delivery"
+  | "transport_auth"
+  | "tool_registration"
+  | "provider_projection"
+  | "plugin_load"
+  | "steering";
+
+export type CloudMcpFailureCode =
+  | "cloud_mcp_missing"
+  | "cloud_mcp_disabled"
+  | "cloud_endpoint_invalid"
+  | "cloud_token_org_mismatch"
+  | "cloud_mcp_needs_auth"
+  | "invalid_mcp_token"
+  | "mcp_session_revoked"
+  | "mcp_membership_revoked"
+  | "insufficient_mcp_scope"
+  | "wrong_mcp_resource"
+  | "opencode_engine_unreachable"
+  | "opencode_mcp_sync_failed"
+  | "provider_tool_projection_missing"
+  | "cloud_steering_stale"
+  | "cloud_desired_missing"
+  | "workspace_directory_ambiguous"
+  | "opencode_unconfigured"
+  | "opencode_unreachable"
+  | "cloud_status_missing"
+  | "cloud_disabled"
+  | "openwork_cloud_auth_required"
+  | "openwork_cloud_auth_invalid"
+  | "openwork_cloud_token_expired"
+  | "openwork_cloud_membership_required"
+  | "openwork_cloud_scope_missing"
+  | "openwork_cloud_resource_forbidden"
+  | "openwork_cloud_resource_not_found"
+  | "openwork_cloud_client_registration_required"
+  | "cloud_connection_failed"
+  | "cloud_registration_failed"
+  | "cloud_tools_denied"
+  | "opencode_tool_ids_unsupported"
+  | "opencode_tool_ids_unavailable"
+  | "cloud_tools_missing"
+  | "provider_projection_unavailable"
+  | "provider_projection_missing"
+  | "extensions_plugin_missing";
+
+export type CloudMcpHealthPhase =
+  | "missing_desired"
+  | "workspace_ambiguous"
+  | "engine_unconfigured"
+  | "engine_unreachable"
+  | "engine_missing"
+  | "engine_disabled"
+  | "engine_needs_auth"
+  | "engine_needs_client_registration"
+  | "engine_failed"
+  | "registration_failed"
+  | "denied_by_tools"
+  | "tool_ids_unsupported"
+  | "cloud_tools_missing"
+  | "provider_projection_missing"
+  | "extensions_plugin_missing"
+  | "ready";
+
+export type CloudMcpFailure = {
+  code: CloudMcpFailureCode;
+  stage: CloudMcpFailureStage;
+  retryable: boolean;
+  recommendedAction: string;
+  message: string;
+  aliases?: string[];
+  requestId?: string;
+  referenceId?: string;
+  details?: unknown;
+};
+
+export type CloudMcpRuntimeRegistrationFailure = {
+  name: string;
+  status?: number;
+  body?: unknown;
+  message?: string;
+};
+
+export type CloudMcpRuntimeRegistrationResult = {
+  status: "ok" | "failed" | "skipped";
+  syncedNames: string[];
+  failures: CloudMcpRuntimeRegistrationFailure[];
+};
+
+export type CloudMcpRuntimeRegistrar = (
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  onlyNames?: string[],
+  options?: { throwOnFailure?: boolean },
+) => Promise<CloudMcpRuntimeRegistrationResult>;
+
+export type CloudMcpServerMetadata = {
+  serverVersion?: string;
+  expectedOpencodeVersion?: string;
+};
+
+export type CloudMcpCompatibilitySnapshot = {
+  openwork: {
+    serverVersion: string | null;
+    app: Record<string, string | number | boolean | null> | null;
+  };
+  opencode: {
+    expectedVersion: string | null;
+    actualVersion: string | null;
+    probe: "ok" | "unavailable" | "not_checked";
+    error?: unknown;
+  };
+  pluginFileHashes: Array<{
+    name: string;
+    sha256: string | null;
+    error?: string;
+  }>;
+  supportedFeatures: {
+    dynamicMcp: boolean;
+    directoryScoping: boolean;
+    toolIds: boolean;
+    providerToolProjection: boolean;
+    pluginCanaries: boolean;
+  };
+};
+
+export type CloudMcpHealth = {
+  schemaVersion: 1;
+  phase: CloudMcpHealthPhase;
+  usable: boolean;
+  usableByCurrentModel: boolean | null;
+  connectCatalogEnabled: boolean;
+  workspace: {
+    id: string;
+    type: WorkspaceInfo["workspaceType"];
+    directory: string | null;
+    path: string;
+  };
+  desired: {
+    present: boolean;
+    name: typeof OPENWORK_CLOUD_MCP_NAME;
+    revision: string | null;
+    config: RedactedCloudMcpConfig | null;
+    token: CloudMcpTokenHealth;
+    org?: Record<string, string | number | boolean | null>;
+    app?: Record<string, string | number | boolean | null>;
+    updatedAt?: number;
+  };
+  delivery: CloudMcpDeliverySnapshot;
+  engine: {
+    status: "not_checked" | "missing" | "connected" | "disabled" | "failed" | "needs_auth" | "needs_client_registration" | "unreachable" | "unknown";
+    error?: unknown;
+  };
+  tools: {
+    expected: string[];
+    present: string[];
+    missing: string[];
+    providerProjection: {
+      checked: boolean;
+      provider?: string;
+      model?: string;
+      present: string[];
+      missing: string[];
+      error?: unknown;
+    };
+  };
+  pluginCanaries: {
+    expected: string[];
+    present: string[];
+    missing: string[];
+  };
+  compatibility: CloudMcpCompatibilitySnapshot;
+  toolDenies: McpToolDeny[];
+  firstFailure: CloudMcpFailure | null;
+  checkedAt: string;
+};
+
+type RedactedCloudMcpConfig = {
+  type: "remote";
+  url: string;
+  enabled?: boolean;
+  oauth?: false | true | "configured";
+  timeout?: number;
+  headers?: {
+    keys: string[];
+    authorizationPresent: boolean;
+  };
+};
+
+type CloudMcpTokenHealth = {
+  present: boolean;
+  metadata: Record<string, string | number | boolean | null>;
+};
+
+type CloudMcpDesiredMetadata = {
+  token: CloudMcpTokenHealth;
+  org?: Record<string, string | number | boolean | null>;
+  app?: Record<string, string | number | boolean | null>;
+  connectCatalogEnabled: boolean;
+  trigger?: string;
+  updatedAt: number;
+};
+
+type CloudMcpDeliveryStateName = "not_desired" | "pending" | "registering" | "ready" | "failed" | "stale";
+
+export type CloudMcpDeliverySnapshot = {
+  state: CloudMcpDeliveryStateName;
+  desiredRevision: string | null;
+  appliedRevision: string | null;
+  updatedAt: number | null;
+  appliedAt: number | null;
+  lastAttemptAt: number | null;
+  trigger?: string;
+  failure?: CloudMcpFailure;
+};
+
+type CloudMcpDeliveryEntry = {
+  workspaceId: string;
+  directory: string | null;
+  desiredRevision: string;
+  metadata: CloudMcpDesiredMetadata;
+  state: CloudMcpDeliveryStateName;
+  updatedAt: number;
+  appliedRevision?: string;
+  appliedAt?: number;
+  lastAttemptAt?: number;
+  trigger?: string;
+  failure?: CloudMcpFailure;
+};
+
+type CloudMcpDesiredState = {
+  present: boolean;
+  revision: string | null;
+  config: Record<string, unknown> | null;
+  redactedConfig: RedactedCloudMcpConfig | null;
+  metadata: CloudMcpDesiredMetadata;
+  validationProblem?: CloudMcpValidationProblem;
+};
+
+type CloudMcpValidationProblem = {
+  code: CloudMcpFailureCode;
+  stage: "desired_config";
+  retryable: boolean;
+  recommendedAction: string;
+  message: string;
+  aliases?: string[];
+  details?: unknown;
+};
+
+type ToolSnapshot = {
+  expected: string[];
+  present: string[];
+  missing: string[];
+};
+
+type ProviderProjectionSnapshot = {
+  checked: boolean;
+  provider?: string;
+  model?: string;
+  present: string[];
+  missing: string[];
+  error?: unknown;
+  failure?: CloudMcpFailure;
+};
+
+type Inspection = {
+  engine: CloudMcpHealth["engine"];
+  tools: ToolSnapshot;
+  providerProjection: ProviderProjectionSnapshot;
+  pluginCanaries: ToolSnapshot;
+  opencodeVersion: CloudMcpCompatibilitySnapshot["opencode"];
+  failures: CloudMcpFailure[];
+};
+
+export class CloudMcpDeliveryStateStore {
+  private entries = new Map<string, CloudMcpDeliveryEntry>();
+
+  snapshot(workspace: WorkspaceInfo, directory: string | null, desiredRevision: string | null): CloudMcpDeliverySnapshot {
+    if (!desiredRevision) {
+      return {
+        state: "not_desired",
+        desiredRevision: null,
+        appliedRevision: null,
+        updatedAt: null,
+        appliedAt: null,
+        lastAttemptAt: null,
+      };
+    }
+    const entry = this.entries.get(this.key(workspace.id, directory));
+    if (!entry || entry.desiredRevision !== desiredRevision) {
+      return {
+        state: "pending",
+        desiredRevision,
+        appliedRevision: null,
+        updatedAt: entry?.updatedAt ?? null,
+        appliedAt: null,
+        lastAttemptAt: entry?.lastAttemptAt ?? null,
+        ...(entry?.trigger ? { trigger: entry.trigger } : {}),
+      };
+    }
+    return this.entrySnapshot(entry);
+  }
+
+  metadata(workspace: WorkspaceInfo, directory: string | null, desiredRevision: string | null): CloudMcpDesiredMetadata | null {
+    if (!desiredRevision) return null;
+    const entry = this.entries.get(this.key(workspace.id, directory));
+    if (!entry || entry.desiredRevision !== desiredRevision) return null;
+    return entry.metadata;
+  }
+
+  latestMetadata(workspace: WorkspaceInfo, directory: string | null): CloudMcpDesiredMetadata | null {
+    return this.entries.get(this.key(workspace.id, directory))?.metadata ?? null;
+  }
+
+  markDesired(
+    workspace: WorkspaceInfo,
+    directory: string | null,
+    desiredRevision: string,
+    metadata: CloudMcpDesiredMetadata,
+  ): CloudMcpDeliverySnapshot {
+    const now = Date.now();
+    const key = this.key(workspace.id, directory);
+    const existing = this.entries.get(key);
+    const entry: CloudMcpDeliveryEntry = {
+      workspaceId: workspace.id,
+      directory,
+      desiredRevision,
+      metadata,
+      state: existing?.appliedRevision === desiredRevision ? "ready" : "pending",
+      updatedAt: now,
+      appliedRevision: existing?.appliedRevision === desiredRevision ? existing.appliedRevision : undefined,
+      appliedAt: existing?.appliedRevision === desiredRevision ? existing.appliedAt : undefined,
+      lastAttemptAt: existing?.lastAttemptAt,
+      trigger: metadata.trigger,
+    };
+    this.entries.set(key, entry);
+    return this.entrySnapshot(entry);
+  }
+
+  markRegistering(workspace: WorkspaceInfo, directory: string | null, desiredRevision: string): void {
+    this.update(workspace.id, directory, desiredRevision, (entry) => ({
+      ...entry,
+      state: "registering",
+      lastAttemptAt: Date.now(),
+      failure: undefined,
+    }));
+  }
+
+  markReady(workspace: WorkspaceInfo, directory: string | null, desiredRevision: string): void {
+    const now = Date.now();
+    this.update(workspace.id, directory, desiredRevision, (entry) => ({
+      ...entry,
+      state: "ready",
+      appliedRevision: desiredRevision,
+      appliedAt: now,
+      updatedAt: now,
+      failure: undefined,
+    }));
+  }
+
+  markFailed(workspace: WorkspaceInfo, directory: string | null, desiredRevision: string, failure: CloudMcpFailure): void {
+    const now = Date.now();
+    this.update(workspace.id, directory, desiredRevision, (entry) => ({
+      ...entry,
+      state: "failed",
+      updatedAt: now,
+      lastAttemptAt: now,
+      failure,
+      appliedRevision: entry.appliedRevision === desiredRevision ? entry.appliedRevision : undefined,
+      appliedAt: entry.appliedRevision === desiredRevision ? entry.appliedAt : undefined,
+    }));
+  }
+
+  markWorkspaceStale(workspace: WorkspaceInfo, directory: string | null): void {
+    const entry = this.entries.get(this.key(workspace.id, directory));
+    if (!entry) return;
+    this.entries.set(this.key(workspace.id, directory), {
+      ...entry,
+      state: "stale",
+      appliedRevision: undefined,
+      appliedAt: undefined,
+      updatedAt: Date.now(),
+    });
+  }
+
+  clear(): void {
+    this.entries.clear();
+  }
+
+  private key(workspaceId: string, directory: string | null): string {
+    return `${workspaceId}\0${directory ?? ""}`;
+  }
+
+  private update(
+    workspaceId: string,
+    directory: string | null,
+    desiredRevision: string,
+    updater: (entry: CloudMcpDeliveryEntry) => CloudMcpDeliveryEntry,
+  ): void {
+    const key = this.key(workspaceId, directory);
+    const entry = this.entries.get(key);
+    if (!entry || entry.desiredRevision !== desiredRevision) return;
+    this.entries.set(key, updater(entry));
+  }
+
+  private entrySnapshot(entry: CloudMcpDeliveryEntry): CloudMcpDeliverySnapshot {
+    return {
+      state: entry.state,
+      desiredRevision: entry.desiredRevision,
+      appliedRevision: entry.appliedRevision ?? null,
+      updatedAt: entry.updatedAt,
+      appliedAt: entry.appliedAt ?? null,
+      lastAttemptAt: entry.lastAttemptAt ?? null,
+      ...(entry.trigger ? { trigger: entry.trigger } : {}),
+      ...(entry.failure ? { failure: entry.failure } : {}),
+    };
+  }
+}
+
+export const cloudMcpDeliveryState = new CloudMcpDeliveryStateStore();
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function hashString(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+function safeMetadataRecord(value: unknown): Record<string, string | number | boolean | null> | undefined {
+  if (!isRecord(value)) return undefined;
+  const output: Record<string, string | number | boolean | null> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    if (typeof nested === "string") output[key] = sanitizeDiagnosticString(nested);
+    else if (typeof nested === "number" || typeof nested === "boolean" || nested === null) output[key] = nested;
+  }
+  return Object.keys(output).length ? output : undefined;
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function readBoolean(value: unknown): boolean | undefined {
+  return typeof value === "boolean" ? value : undefined;
+}
+
+function readNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function normalizeStringRecord(value: unknown): Record<string, string> | undefined {
+  if (!isRecord(value)) return undefined;
+  const output: Record<string, string> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    if (typeof nested === "string") output[key] = nested;
+  }
+  return Object.keys(output).length ? output : undefined;
+}
+
+function authorizationHeader(config: Record<string, unknown>): string | null {
+  const headers = isRecord(config.headers) ? config.headers : null;
+  if (!headers) return null;
+  for (const [key, value] of Object.entries(headers)) {
+    if (key.toLowerCase() === "authorization" && typeof value === "string") return value;
+  }
+  return null;
+}
+
+function tokenHealthFromConfig(config: Record<string, unknown> | null, metadata?: Record<string, string | number | boolean | null>): CloudMcpTokenHealth {
+  const authorization = config ? authorizationHeader(config) : null;
+  const tokenMetadata: Record<string, string | number | boolean | null> = { ...(metadata ?? {}) };
+  if (authorization) tokenMetadata.authorizationHash = hashString(authorization);
+  return {
+    present: Boolean(authorization) || Object.keys(tokenMetadata).length > 0,
+    metadata: tokenMetadata,
+  };
+}
+
+function extractDesiredMetadata(body: Record<string, unknown>, config: Record<string, unknown>): CloudMcpDesiredMetadata {
+  const tokenMetadata = safeMetadataRecord(body.tokenMetadata) ?? safeMetadataRecord(body.token);
+  const org = safeMetadataRecord(body.org) ?? safeMetadataRecord(body.organization);
+  const app = safeMetadataRecord(body.app) ?? safeMetadataRecord({
+    version: body.appVersion,
+    buildSha: body.buildSha ?? body.buildSHA,
+  });
+  const trigger = readString(body.trigger);
+  const connectCatalogEnabled = readBoolean(body.connectCatalogEnabled) ?? true;
+  return {
+    token: tokenHealthFromConfig(config, tokenMetadata),
+    ...(org ? { org } : {}),
+    ...(app ? { app } : {}),
+    connectCatalogEnabled,
+    ...(trigger ? { trigger } : {}),
+    updatedAt: Date.now(),
+  };
+}
+
+function defaultDesiredMetadata(config: Record<string, unknown> | null, connectCatalogEnabled: boolean): CloudMcpDesiredMetadata {
+  return {
+    token: tokenHealthFromConfig(config),
+    connectCatalogEnabled,
+    updatedAt: Date.now(),
+  };
+}
+
+function normalizeCloudEndpointUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (url.search || url.hash) return null;
+    const normalizedPath = url.pathname.replace(/\/+$/, "") || "/";
+    if (!normalizedPath.endsWith("/mcp/agent")) return null;
+    url.pathname = normalizedPath;
+    return url.toString();
+  } catch {
+    return null;
+  }
+}
+
+function canonicalizeCloudMcpConfig(config: Record<string, unknown>): Record<string, unknown> {
+  const url = readString(config.url);
+  const normalizedUrl = url ? normalizeCloudEndpointUrl(url) : null;
+  return normalizedUrl ? { ...config, url: normalizedUrl } : config;
+}
+
+function normalizeCloudMcpConfig(input: unknown): Record<string, unknown> {
+  if (!isRecord(input)) {
+    throw new ApiError(400, "invalid_payload", "config is required");
+  }
+  const type = input.type ?? "remote";
+  const url = readString(input.url);
+  const output: Record<string, unknown> = { type };
+  if (url) output.url = normalizeCloudEndpointUrl(url) ?? url;
+  const enabled = readBoolean(input.enabled);
+  if (enabled !== undefined) output.enabled = enabled;
+  const headers = normalizeStringRecord(input.headers);
+  if (headers) output.headers = headers;
+  if (input.oauth === false) output.oauth = false;
+  else if (input.oauth === true) output.oauth = {};
+  else if (isRecord(input.oauth)) output.oauth = input.oauth;
+  const timeout = readNumber(input.timeout);
+  if (timeout !== undefined) output.timeout = timeout;
+  return output;
+}
+
+function strictCloudMcpDesiredConfigProblem(config: Record<string, unknown>, metadata: CloudMcpDesiredMetadata): CloudMcpValidationProblem | null {
+  if (config.type !== "remote") {
+    return {
+      code: "cloud_endpoint_invalid",
+      stage: "desired_config",
+      retryable: false,
+      recommendedAction: "Reconnect OpenWork Cloud",
+      message: "openwork-cloud must be configured as a remote MCP endpoint.",
+      details: { type: typeof config.type === "string" ? config.type : null },
+    };
+  }
+
+  if (config.enabled !== true) {
+    return {
+      code: "cloud_mcp_disabled",
+      stage: "desired_config",
+      retryable: false,
+      recommendedAction: "Enable Agent access in Settings → Connect",
+      message: "openwork-cloud desired config is disabled.",
+      aliases: ["cloud_disabled"],
+      details: { enabled: config.enabled ?? null },
+    };
+  }
+
+  const url = readString(config.url);
+  const normalizedUrl = url ? normalizeCloudEndpointUrl(url) : null;
+  if (!url || !normalizedUrl) {
+    return {
+      code: "cloud_endpoint_invalid",
+      stage: "desired_config",
+      retryable: false,
+      recommendedAction: "Reconnect OpenWork Cloud",
+      message: "openwork-cloud URL must be a valid http(s) endpoint at /mcp/agent.",
+      details: { url: typeof config.url === "string" ? sanitizeDiagnosticString(config.url) : null },
+    };
+  }
+
+  const authorization = authorizationHeader(config)?.trim();
+  if (!authorization) {
+    return {
+      code: "invalid_mcp_token",
+      stage: "desired_config",
+      retryable: false,
+      recommendedAction: "Reconnect OpenWork Cloud",
+      message: "openwork-cloud desired config is missing an Authorization header.",
+      aliases: ["openwork_cloud_auth_required"],
+    };
+  }
+
+  if (config.oauth !== false) {
+    return {
+      code: "invalid_mcp_token",
+      stage: "desired_config",
+      retryable: false,
+      recommendedAction: "Reconnect OpenWork Cloud",
+      message: "openwork-cloud desired config must use the minted bearer token, not OAuth.",
+      aliases: ["openwork_cloud_auth_invalid"],
+      details: { oauth: config.oauth === undefined ? "missing" : "configured" },
+    };
+  }
+
+  const tokenOrganizationId = typeof metadata.token.metadata.organizationId === "string" ? metadata.token.metadata.organizationId.trim() : "";
+  const activeOrganizationId = typeof metadata.org?.id === "string" ? metadata.org.id.trim() : "";
+  if (tokenOrganizationId && activeOrganizationId && tokenOrganizationId !== activeOrganizationId) {
+    return {
+      code: "cloud_token_org_mismatch",
+      stage: "desired_config",
+      retryable: false,
+      recommendedAction: "Choose the matching organization, then Repair and test",
+      message: "openwork-cloud token organization does not match the active organization.",
+      details: { tokenOrganizationId, activeOrganizationId },
+    };
+  }
+
+  try {
+    validateMcpConfig(canonicalizeCloudMcpConfig(config));
+  } catch (error) {
+    return {
+      code: "cloud_endpoint_invalid",
+      stage: "desired_config",
+      retryable: false,
+      recommendedAction: "Reconnect OpenWork Cloud",
+      message: "openwork-cloud desired config is not a valid remote MCP config.",
+      details: { error: error instanceof Error ? error.message : String(error) },
+    };
+  }
+
+  return null;
+}
+
+function redactedConfig(config: Record<string, unknown>): RedactedCloudMcpConfig {
+  const headers = isRecord(config.headers) ? config.headers : null;
+  const headerKeys = headers ? Object.keys(headers).sort() : [];
+  const oauth = config.oauth === false
+    ? false
+    : config.oauth === true
+      ? true
+      : isRecord(config.oauth)
+        ? "configured"
+        : undefined;
+  return {
+    type: "remote",
+    url: typeof config.url === "string" ? sanitizeDiagnosticString(config.url) : "",
+    ...(typeof config.enabled === "boolean" ? { enabled: config.enabled } : {}),
+    ...(oauth !== undefined ? { oauth } : {}),
+    ...(typeof config.timeout === "number" ? { timeout: config.timeout } : {}),
+    ...(headers
+      ? {
+          headers: {
+            keys: headerKeys.map((key) => sanitizeDiagnosticString(key)),
+            authorizationPresent: headerKeys.some((key) => key.toLowerCase() === "authorization"),
+          },
+        }
+      : {}),
+  };
+}
+
+function revisionValue(value: unknown, key?: string): unknown {
+  if (key && ["authorization", "token", "secret", "password", "cookie", "api_key", "api-key", "apikey", "client_secret"].includes(key.toLowerCase())) {
+    if (typeof value === "string") return { redacted: true, sha256: hashString(value) };
+    if (!isRecord(value) && !Array.isArray(value)) return "[REDACTED]";
+  }
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean" || value === null) return value;
+  if (Array.isArray(value)) return value.map((item) => revisionValue(item));
+  if (!isRecord(value)) return null;
+  const output: Record<string, unknown> = {};
+  for (const nestedKey of Object.keys(value).sort()) {
+    const nested = value[nestedKey];
+    if (nested !== undefined) output[nestedKey] = revisionValue(nested, nestedKey);
+  }
+  return output;
+}
+
+export function calculateCloudMcpDesiredRevision(config: Record<string, unknown>, metadata: CloudMcpDesiredMetadata): string {
+  return hashString(JSON.stringify(revisionValue({
+    config,
+    metadata: {
+      token: metadata.token,
+      org: metadata.org,
+      connectCatalogEnabled: metadata.connectCatalogEnabled,
+    },
+  })));
+}
+
+async function readDesiredState(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  directory: string | null;
+  connectCatalogEnabled?: boolean;
+}): Promise<CloudMcpDesiredState> {
+  const runtimeConfig = await readRuntimeOpencodeConfig(input.config, input.workspace.id);
+  const entry = runtimeMcpMap(runtimeConfig)[OPENWORK_CLOUD_MCP_NAME];
+  if (!entry) {
+    const metadata = defaultDesiredMetadata(null, input.connectCatalogEnabled ?? false);
+    return { present: false, revision: null, config: null, redactedConfig: null, metadata };
+  }
+  const config = canonicalizeCloudMcpConfig(entry);
+  const storedMetadata = cloudMcpDeliveryState.latestMetadata(input.workspace, input.directory);
+  const metadata = storedMetadata ?? defaultDesiredMetadata(config, input.connectCatalogEnabled ?? true);
+  const validationProblem = strictCloudMcpDesiredConfigProblem(config, metadata) ?? undefined;
+  const revision = calculateCloudMcpDesiredRevision(config, metadata);
+  const revisionMetadata = cloudMcpDeliveryState.metadata(input.workspace, input.directory, revision) ?? metadata;
+  return {
+    present: true,
+    revision,
+    config,
+    redactedConfig: redactedConfig(config),
+    metadata: revisionMetadata,
+    ...(validationProblem ? { validationProblem } : {}),
+  };
+}
+
+function locationParams(directory: string | null): { directory?: string } {
+  return directory ? { directory } : {};
+}
+
+function expectedTools(): string[] {
+  return [...OPENWORK_CLOUD_EXPECTED_TOOLS];
+}
+
+function expectedCanaries(): string[] {
+  return [...OPENWORK_CLOUD_PLUGIN_CANARIES];
+}
+
+function splitPresentMissing(ids: string[], expected: string[]): ToolSnapshot {
+  return {
+    expected,
+    present: expected.filter((id) => ids.includes(id)),
+    missing: expected.filter((id) => !ids.includes(id)),
+  };
+}
+
+function failure(input: {
+  code: CloudMcpFailureCode;
+  stage: CloudMcpFailureStage;
+  retryable: boolean;
+  recommendedAction: string;
+  message: string;
+  aliases?: string[];
+  details?: unknown;
+}): CloudMcpFailure {
+  const ids = extractDiagnosticIds(input.details);
+  return {
+    code: input.code,
+    stage: input.stage,
+    retryable: input.retryable,
+    recommendedAction: input.recommendedAction,
+    message: input.message,
+    ...(input.aliases?.length ? { aliases: input.aliases.map(sanitizeDiagnosticString) } : {}),
+    ...(ids.requestId ? { requestId: ids.requestId } : {}),
+    ...(ids.referenceId ? { referenceId: ids.referenceId } : {}),
+    ...(input.details !== undefined ? { details: sanitizeDiagnosticValue(input.details) } : {}),
+  };
+}
+
+function failureFromValidationProblem(problem: CloudMcpValidationProblem): CloudMcpFailure {
+  return failure(problem);
+}
+
+function extractDiagnosticIds(value: unknown): { requestId?: string; referenceId?: string } {
+  const found: { requestId?: string; referenceId?: string } = {};
+  const visit = (nested: unknown): void => {
+    if (typeof nested === "string") {
+      const requestMatch = nested.match(/(?:x-request-id|request[_ -]?id)[=: ]+([A-Za-z0-9._:-]+)/i);
+      const referenceMatch = nested.match(/(?:reference[_ -]?id)[=: ]+([A-Za-z0-9._:-]+)/i);
+      if (requestMatch?.[1] && !found.requestId) found.requestId = sanitizeDiagnosticString(requestMatch[1]);
+      if (referenceMatch?.[1] && !found.referenceId) found.referenceId = sanitizeDiagnosticString(referenceMatch[1]);
+      return;
+    }
+    if (Array.isArray(nested)) {
+      for (const item of nested) visit(item);
+      return;
+    }
+    if (!isRecord(nested)) return;
+    for (const [key, item] of Object.entries(nested)) {
+      const normalized = key.toLowerCase().replace(/[-_]/g, "");
+      if ((normalized === "requestid" || normalized === "xrequestid") && typeof item === "string" && !found.requestId) {
+        found.requestId = sanitizeDiagnosticString(item);
+      }
+      if (normalized === "referenceid" && typeof item === "string" && !found.referenceId) {
+        found.referenceId = sanitizeDiagnosticString(item);
+      }
+      visit(item);
+    }
+  };
+  visit(value);
+  return found;
+}
+
+function opencodeRequestFailure(stage: CloudMcpFailureStage, path: string, response: Response, error: unknown): CloudMcpFailure {
+  if (stage === "engine_delivery") {
+    return failure({
+      code: response.status >= 500 ? "opencode_engine_unreachable" : "opencode_mcp_sync_failed",
+      stage,
+      retryable: response.status >= 500,
+      recommendedAction: response.status >= 500 ? "Restart OpenCode or retry when the engine is reachable" : "Check OpenCode MCP status support",
+      message: "OpenCode request failed while checking MCP status.",
+      aliases: response.status >= 500 ? ["opencode_unreachable"] : ["cloud_connection_failed"],
+      details: { path, status: response.status, error },
+    });
+  }
+  if (stage === "tool_registration" && (response.status === 404 || response.status === 405)) {
+    return failure({
+      code: "opencode_tool_ids_unsupported",
+      stage,
+      retryable: false,
+      recommendedAction: "Update OpenWork",
+      message: "OpenCode does not support listing tool IDs.",
+      details: { path, status: response.status, error },
+    });
+  }
+  return failure({
+    code: stage === "provider_projection" ? "provider_tool_projection_missing" : "opencode_tool_ids_unavailable",
+    stage,
+    retryable: response.status >= 500,
+    recommendedAction: response.status >= 500 ? "Retry after OpenCode is healthy" : "Update OpenWork",
+    message: "OpenCode request failed while checking openwork-cloud MCP readiness.",
+    aliases: stage === "provider_projection" ? ["provider_projection_unavailable"] : undefined,
+    details: { path, status: response.status, error },
+  });
+}
+
+function thrownOpencodeFailure(stage: CloudMcpFailureStage, path: string, error: unknown): CloudMcpFailure {
+  return failure({
+    code: "opencode_engine_unreachable",
+    stage,
+    retryable: true,
+    recommendedAction: "Restart OpenCode or retry when the engine is reachable",
+    message: "OpenCode engine is not reachable.",
+    aliases: ["opencode_unreachable"],
+    details: { path, error: error instanceof Error ? error.message : String(error) },
+  });
+}
+
+async function withEngineProbeTimeout<T>(task: () => Promise<T>): Promise<T> {
+  return await new Promise<T>((resolve, reject) => {
+    const timeoutMs = engineProbeTimeoutMs();
+    const handle = setTimeout(() => {
+      reject(new Error(`OpenCode health probe timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+    task()
+      .then(resolve, reject)
+      .finally(() => clearTimeout(handle));
+  });
+}
+
+async function readMcpStatus(
+  opencode: WorkspaceOpencodeClient,
+  directory: string | null,
+): Promise<{ data?: Record<string, McpStatus>; failure?: CloudMcpFailure }> {
+  try {
+    const result = await withEngineProbeTimeout(() => opencode.mcp.status(locationParams(directory)));
+    if (result.data) return { data: result.data };
+    return { failure: opencodeRequestFailure("engine_delivery", "/mcp", result.response, result.error) };
+  } catch (error) {
+    return { failure: thrownOpencodeFailure("engine_delivery", "/mcp", error) };
+  }
+}
+
+async function readToolIds(
+  opencode: WorkspaceOpencodeClient,
+  directory: string | null,
+): Promise<{ data?: ToolIds; failure?: CloudMcpFailure }> {
+  try {
+    const result = await withEngineProbeTimeout(() => opencode.tool.ids(locationParams(directory)));
+    if (result.data) return { data: result.data };
+    return { failure: opencodeRequestFailure("tool_registration", "/experimental/tool/ids", result.response, result.error) };
+  } catch (error) {
+    return { failure: thrownOpencodeFailure("tool_registration", "/experimental/tool/ids", error) };
+  }
+}
+
+async function readProviderProjection(input: {
+  opencode: WorkspaceOpencodeClient;
+  directory: string | null;
+  providerModel: CloudMcpProviderModelContext;
+}): Promise<ProviderProjectionSnapshot> {
+  try {
+    const result = await withEngineProbeTimeout(() => input.opencode.tool.list({
+      ...locationParams(input.directory),
+      provider: input.providerModel.provider,
+      model: input.providerModel.model,
+    }));
+    if (!result.data) {
+      const projectionFailure = opencodeRequestFailure("provider_projection", "/experimental/tool", result.response, result.error);
+      return {
+        checked: true,
+        provider: input.providerModel.provider,
+        model: input.providerModel.model,
+        present: [],
+        missing: expectedTools(),
+        error: projectionFailure.details,
+        failure: projectionFailure,
+      };
+    }
+    const ids = toolListIds(result.data);
+    const split = splitPresentMissing(ids, expectedTools());
+    const projectionFailure = split.missing.length
+      ? failure({
+          code: "provider_tool_projection_missing",
+          stage: "provider_projection",
+          retryable: false,
+          recommendedAction: "Update OpenWork",
+          message: "The current provider/model projection is missing openwork-cloud tools.",
+          aliases: ["provider_projection_missing"],
+          details: { provider: input.providerModel.provider, model: input.providerModel.model, missing: split.missing },
+        })
+      : undefined;
+    return {
+      checked: true,
+      provider: input.providerModel.provider,
+      model: input.providerModel.model,
+      present: split.present,
+      missing: split.missing,
+      ...(projectionFailure ? { failure: projectionFailure } : {}),
+    };
+  } catch (error) {
+    const projectionFailure = thrownOpencodeFailure("provider_projection", "/experimental/tool", error);
+    return {
+      checked: true,
+      provider: input.providerModel.provider,
+      model: input.providerModel.model,
+      present: [],
+      missing: expectedTools(),
+      error: projectionFailure.details,
+      failure: projectionFailure,
+    };
+  }
+}
+
+function toolListIds(list: ToolList): string[] {
+  return list.map((tool) => tool.id).filter((id) => typeof id === "string");
+}
+
+function statusFailure(status: McpStatus | undefined): CloudMcpFailure {
+  if (!status) {
+    return failure({
+      code: "cloud_mcp_missing",
+      stage: "engine_delivery",
+      retryable: true,
+      recommendedAction: "Run reconcile to register openwork-cloud with OpenCode",
+      message: "OpenCode does not report an openwork-cloud MCP status.",
+      aliases: ["cloud_status_missing"],
+    });
+  }
+  if (status.status === "disabled") {
+    return failure({
+      code: "cloud_mcp_disabled",
+      stage: "engine_delivery",
+      retryable: false,
+      recommendedAction: "Enable the openwork-cloud MCP entry",
+      message: "openwork-cloud MCP is disabled.",
+      aliases: ["cloud_disabled"],
+    });
+  }
+  if (status.status === "needs_auth") {
+    return failure({
+      code: "cloud_mcp_needs_auth",
+      stage: "transport_auth",
+      retryable: false,
+      recommendedAction: "Reconnect OpenWork Cloud",
+      message: "openwork-cloud MCP needs authentication.",
+      aliases: ["openwork_cloud_auth_required"],
+    });
+  }
+  if (status.status === "needs_client_registration") {
+    return failure({
+      code: "opencode_mcp_sync_failed",
+      stage: "engine_delivery",
+      retryable: false,
+      recommendedAction: "Reconnect OpenWork Cloud or update OpenWork",
+      message: "openwork-cloud MCP needs OAuth client registration.",
+      aliases: ["openwork_cloud_client_registration_required"],
+      details: { error: status.error },
+    });
+  }
+  if (status.status === "failed") {
+    return inferFailedStatus(status.error);
+  }
+  return failure({
+    code: "opencode_mcp_sync_failed",
+    stage: "engine_delivery",
+    retryable: true,
+    recommendedAction: "Retry reconcile",
+    message: "openwork-cloud MCP is not connected.",
+    aliases: ["cloud_connection_failed"],
+  });
+}
+
+function inferFailedStatus(error: string): CloudMcpFailure {
+  const lower = error.toLowerCase();
+  if (lower.includes("expired")) {
+    return failure({ code: "invalid_mcp_token", stage: "transport_auth", retryable: false, recommendedAction: "Reconnect OpenWork Cloud", message: "openwork-cloud token is expired.", aliases: ["openwork_cloud_token_expired"], details: { error } });
+  }
+  if (lower.includes("invalid_token") || lower.includes("unauthorized") || lower.includes("401") || lower.includes("auth")) {
+    return failure({ code: "invalid_mcp_token", stage: "transport_auth", retryable: false, recommendedAction: "Reconnect OpenWork Cloud", message: "openwork-cloud authentication failed.", aliases: ["openwork_cloud_auth_invalid"], details: { error } });
+  }
+  if (lower.includes("invalid_grant") || lower.includes("session") || lower.includes("revoked")) {
+    return failure({ code: "mcp_session_revoked", stage: "transport_auth", retryable: false, recommendedAction: "Reconnect OpenWork Cloud", message: "openwork-cloud session was revoked.", details: { error } });
+  }
+  if (lower.includes("membership") || lower.includes("member")) {
+    return failure({ code: "mcp_membership_revoked", stage: "transport_auth", retryable: false, recommendedAction: "Ask an organization admin to grant access", message: "OpenWork Cloud membership is required.", aliases: ["openwork_cloud_membership_required"], details: { error } });
+  }
+  if (lower.includes("insufficient_scope") || lower.includes("scope")) {
+    return failure({ code: "insufficient_mcp_scope", stage: "transport_auth", retryable: false, recommendedAction: "Reconnect OpenWork Cloud with the required scopes", message: "openwork-cloud token is missing required scopes.", aliases: ["openwork_cloud_scope_missing"], details: { error } });
+  }
+  if (lower.includes("forbidden") || lower.includes("403") || lower.includes("policy")) {
+    return failure({ code: "wrong_mcp_resource", stage: "transport_auth", retryable: false, recommendedAction: "Check organization policy and resource access", message: "OpenWork Cloud denied access to this resource.", aliases: ["openwork_cloud_resource_forbidden"], details: { error } });
+  }
+  if (lower.includes("not found") || lower.includes("404") || lower.includes("resource")) {
+    return failure({ code: "wrong_mcp_resource", stage: "transport_auth", retryable: false, recommendedAction: "Reconnect OpenWork Cloud or choose an accessible organization", message: "OpenWork Cloud resource was not found.", aliases: ["openwork_cloud_resource_not_found"], details: { error } });
+  }
+  if (lower.includes("client registration")) {
+    return failure({ code: "opencode_mcp_sync_failed", stage: "engine_delivery", retryable: false, recommendedAction: "Reconnect OpenWork Cloud or update OpenWork", message: "openwork-cloud needs client registration.", aliases: ["openwork_cloud_client_registration_required"], details: { error } });
+  }
+  return failure({
+    code: "opencode_mcp_sync_failed",
+    stage: "engine_delivery",
+    retryable: true,
+    recommendedAction: "Retry reconcile or reconnect OpenWork Cloud",
+    message: "openwork-cloud MCP connection failed.",
+    aliases: ["cloud_connection_failed"],
+    details: { error },
+  });
+}
+
+function engineStatusFromMcpStatus(status: McpStatus | undefined): CloudMcpHealth["engine"] {
+  if (!status) return { status: "missing" };
+  if (status.status === "failed" || status.status === "needs_client_registration") {
+    return { status: status.status, error: sanitizeDiagnosticValue(status.error) };
+  }
+  return { status: status.status };
+}
+
+function readVersionFromHealthPayload(payload: unknown): string | null {
+  if (!isRecord(payload)) return null;
+  return typeof payload.version === "string" ? sanitizeDiagnosticString(payload.version) : null;
+}
+
+async function readOpencodeVersion(opencode: WorkspaceOpencodeClient): Promise<CloudMcpCompatibilitySnapshot["opencode"]> {
+  try {
+    const result = await withEngineProbeTimeout(() => opencode.global.health());
+    if (result.data) {
+      return { expectedVersion: null, actualVersion: readVersionFromHealthPayload(result.data), probe: "ok" };
+    }
+    return {
+      expectedVersion: null,
+      actualVersion: null,
+      probe: "unavailable",
+      error: sanitizeDiagnosticValue({ status: result.response.status, error: result.error }),
+    };
+  } catch (error) {
+    return {
+      expectedVersion: null,
+      actualVersion: null,
+      probe: "unavailable",
+      error: sanitizeDiagnosticValue(error instanceof Error ? error.message : String(error)),
+    };
+  }
+}
+
+async function inspectOpenworkCloud(input: {
+  opencode: WorkspaceOpencodeClient;
+  directory: string | null;
+  providerModel?: CloudMcpProviderModelContext;
+}): Promise<Inspection> {
+  const failures: CloudMcpFailure[] = [];
+  const emptyTools = splitPresentMissing([], expectedTools());
+  const emptyCanaries = splitPresentMissing([], expectedCanaries());
+  const opencodeVersion = await readOpencodeVersion(input.opencode);
+  const statusResult = await readMcpStatus(input.opencode, input.directory);
+  if (statusResult.failure) {
+    failures.push(statusResult.failure);
+    return {
+      engine: { status: statusResult.failure.code === "opencode_engine_unreachable" ? "unreachable" : "unknown", error: statusResult.failure.details },
+      tools: emptyTools,
+      providerProjection: providerProjectionNotChecked(input.providerModel),
+      pluginCanaries: emptyCanaries,
+      opencodeVersion,
+      failures,
+    };
+  }
+
+  const cloudStatus = statusResult.data?.[OPENWORK_CLOUD_MCP_NAME];
+  const engine = engineStatusFromMcpStatus(cloudStatus);
+  if (cloudStatus?.status !== "connected") {
+    failures.push(statusFailure(cloudStatus));
+    return {
+      engine,
+      tools: emptyTools,
+      providerProjection: providerProjectionNotChecked(input.providerModel),
+      pluginCanaries: emptyCanaries,
+      opencodeVersion,
+      failures,
+    };
+  }
+
+  const idsResult = await readToolIds(input.opencode, input.directory);
+  if (idsResult.failure) {
+    failures.push(idsResult.failure);
+    return {
+      engine,
+      tools: emptyTools,
+      providerProjection: providerProjectionNotChecked(input.providerModel),
+      pluginCanaries: emptyCanaries,
+      opencodeVersion,
+      failures,
+    };
+  }
+  const ids = idsResult.data ?? [];
+  const tools = splitPresentMissing(ids, expectedTools());
+  const pluginCanaries = splitPresentMissing(ids, expectedCanaries());
+  if (tools.missing.length) {
+    failures.push(failure({
+      code: "cloud_tools_missing",
+      stage: "tool_registration",
+      retryable: true,
+      recommendedAction: "Run reconcile to re-register openwork-cloud with OpenCode",
+      message: "OpenCode is connected to openwork-cloud but required Cloud tools are missing.",
+      details: { missing: tools.missing },
+    }));
+  }
+
+  const providerProjection = input.providerModel
+    ? await readProviderProjection({ opencode: input.opencode, directory: input.directory, providerModel: input.providerModel })
+    : providerProjectionNotChecked(input.providerModel);
+  if (providerProjection.failure) failures.push(providerProjection.failure);
+
+  if (pluginCanaries.missing.length) {
+    failures.push(failure({
+      code: "extensions_plugin_missing",
+      stage: "plugin_load",
+      retryable: true,
+      recommendedAction: "Reload the OpenCode engine so OpenWork extensions are loaded",
+      message: "OpenWork extension plugin canary tools are missing.",
+      details: { missing: pluginCanaries.missing },
+    }));
+  }
+
+  return { engine, tools, providerProjection, pluginCanaries, opencodeVersion, failures };
+}
+
+function providerProjectionNotChecked(providerModel?: CloudMcpProviderModelContext): ProviderProjectionSnapshot {
+  return {
+    checked: false,
+    ...(providerModel ? { provider: providerModel.provider, model: providerModel.model } : {}),
+    present: [],
+    missing: [],
+  };
+}
+
+function phaseFromFailure(firstFailure: CloudMcpFailure | null): CloudMcpHealthPhase {
+  if (!firstFailure) return "ready";
+  if (firstFailure.code === "cloud_mcp_missing" && firstFailure.stage === "engine_delivery") return "engine_missing";
+  if (firstFailure.code === "cloud_mcp_missing" || firstFailure.code === "cloud_desired_missing") return "missing_desired";
+  if (firstFailure.code === "cloud_endpoint_invalid" || firstFailure.code === "cloud_token_org_mismatch") return "missing_desired";
+  if (firstFailure.code === "workspace_directory_ambiguous") return "workspace_ambiguous";
+  if (firstFailure.code === "opencode_unconfigured") return "engine_unconfigured";
+  if (firstFailure.code === "opencode_engine_unreachable" || firstFailure.code === "opencode_unreachable") return "engine_unreachable";
+  if (firstFailure.code === "cloud_status_missing") return "engine_missing";
+  if (firstFailure.code === "cloud_mcp_disabled" || firstFailure.code === "cloud_disabled") return "engine_disabled";
+  if (
+    firstFailure.code === "cloud_mcp_needs_auth" ||
+    firstFailure.code === "invalid_mcp_token" ||
+    firstFailure.code === "mcp_session_revoked" ||
+    firstFailure.code === "mcp_membership_revoked" ||
+    firstFailure.code === "insufficient_mcp_scope" ||
+    firstFailure.code === "wrong_mcp_resource" ||
+    firstFailure.code === "openwork_cloud_auth_required" ||
+    firstFailure.code === "openwork_cloud_auth_invalid" ||
+    firstFailure.code === "openwork_cloud_token_expired"
+  ) return "engine_needs_auth";
+  if (firstFailure.code === "openwork_cloud_client_registration_required") return "engine_needs_client_registration";
+  if (firstFailure.code === "opencode_mcp_sync_failed" || firstFailure.code === "cloud_registration_failed") return "registration_failed";
+  if (firstFailure.code === "cloud_tools_denied") return "denied_by_tools";
+  if (firstFailure.code === "opencode_tool_ids_unsupported") return "tool_ids_unsupported";
+  if (firstFailure.code === "cloud_tools_missing") return "cloud_tools_missing";
+  if (firstFailure.code === "provider_tool_projection_missing" || firstFailure.code === "provider_projection_missing" || firstFailure.code === "provider_projection_unavailable") return "provider_projection_missing";
+  if (firstFailure.code === "extensions_plugin_missing") return "extensions_plugin_missing";
+  return "engine_failed";
+}
+
+function firstFailureFromDenies(denies: McpToolDeny[]): CloudMcpFailure | null {
+  if (!denies.length) return null;
+  return failure({
+    code: "cloud_tools_denied",
+    stage: "prerequisites",
+    retryable: false,
+    recommendedAction: "Remove project/global OpenCode tool denies for openwork-cloud tools",
+    message: "OpenCode configuration denies one or more openwork-cloud tools.",
+    details: { denies },
+  });
+}
+
+function chooseFirstFailure(failures: CloudMcpFailure[]): CloudMcpFailure | null {
+  return failures[0] ?? null;
+}
+
+function usableByModel(providerProjection: ProviderProjectionSnapshot, firstFailure: CloudMcpFailure | null): boolean | null {
+  if (!providerProjection.checked) return null;
+  if (firstFailure?.stage === "provider_projection") return false;
+  return providerProjection.missing.length === 0;
+}
+
+function baseUrlConfigured(config: ServerConfig, workspace: WorkspaceInfo): boolean {
+  return Boolean(workspace.baseUrl?.trim() || config.opencodeBaseUrl?.trim());
+}
+
+async function pluginFileHashes(): Promise<CloudMcpCompatibilitySnapshot["pluginFileHashes"]> {
+  const here = dirname(fileURLToPath(import.meta.url));
+  const names = ["openwork-extensions-preview", "openwork-capabilities-knowledge"];
+  return Promise.all(names.map(async (name) => {
+    let lastError = "not found";
+    for (const extension of ["ts", "js"]) {
+      try {
+        return { name, sha256: hashString(await readFile(join(here, "opencode-plugins", `${name}.${extension}`), "utf8")) };
+      } catch (error) {
+        lastError = error instanceof Error ? error.message : String(error);
+      }
+    }
+    return { name, sha256: null, error: sanitizeDiagnosticString(lastError) };
+  }));
+}
+
+async function compatibilitySnapshot(input: {
+  serverMetadata?: CloudMcpServerMetadata;
+  appMetadata?: Record<string, string | number | boolean | null>;
+  directory: string | null;
+  inspection: Inspection;
+}): Promise<CloudMcpCompatibilitySnapshot> {
+  const opencode = {
+    ...input.inspection.opencodeVersion,
+    expectedVersion: input.serverMetadata?.expectedOpencodeVersion ?? null,
+  };
+  return {
+    openwork: {
+      serverVersion: input.serverMetadata?.serverVersion ?? null,
+      app: input.appMetadata ?? null,
+    },
+    opencode,
+    pluginFileHashes: await pluginFileHashes(),
+    supportedFeatures: {
+      dynamicMcp: true,
+      directoryScoping: input.directory !== null,
+      toolIds: !input.inspection.failures.some((item) => item.code === "opencode_tool_ids_unsupported" || item.code === "opencode_tool_ids_unavailable"),
+      providerToolProjection: input.inspection.providerProjection.checked && !input.inspection.failures.some((item) => item.stage === "provider_projection" && item.code !== "provider_tool_projection_missing"),
+      pluginCanaries: input.inspection.pluginCanaries.expected.length > 0,
+    },
+  };
+}
+
+export async function readOpenworkCloudMcpHealth(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  directory: string | null;
+  providerModel?: CloudMcpProviderModelContext;
+  serverMetadata?: CloudMcpServerMetadata;
+  createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
+}): Promise<CloudMcpHealth> {
+  const checkedAt = new Date().toISOString();
+  const desired = await readDesiredState({ config: input.config, workspace: input.workspace, directory: input.directory });
+  let delivery = cloudMcpDeliveryState.snapshot(input.workspace, input.directory, desired.revision);
+  const toolDenies = desired.present
+    ? await diagnoseMcpToolDenies(input.workspace.path, OPENWORK_CLOUD_MCP_NAME, expectedTools())
+    : [];
+  const failures: CloudMcpFailure[] = [];
+
+  if (!desired.present) {
+    failures.push(failure({
+      code: "cloud_mcp_missing",
+      stage: "desired_config",
+      retryable: false,
+      recommendedAction: "Connect OpenWork Cloud",
+      message: "No openwork-cloud MCP desired config is persisted for this workspace.",
+      aliases: ["cloud_desired_missing"],
+    }));
+  }
+  if (desired.validationProblem) {
+    failures.push(failureFromValidationProblem(desired.validationProblem));
+  }
+  if (desired.present && !input.directory) {
+    failures.push(failure({
+      code: "workspace_directory_ambiguous",
+      stage: "prerequisites",
+      retryable: false,
+      recommendedAction: "Set an explicit OpenCode directory for this remote workspace",
+      message: "Remote workspace has no exact OpenCode directory, so Cloud MCP readiness cannot be claimed.",
+    }));
+  }
+  if (desired.present && input.directory && !baseUrlConfigured(input.config, input.workspace)) {
+    failures.push(failure({
+      code: "opencode_unconfigured",
+      stage: "prerequisites",
+      retryable: false,
+      recommendedAction: "Start or attach an OpenCode engine for this workspace",
+      message: "OpenCode base URL is missing for this workspace.",
+    }));
+  }
+  const denyFailure = firstFailureFromDenies(toolDenies);
+  if (denyFailure) failures.push(denyFailure);
+
+  let inspection: Inspection = {
+    engine: { status: "not_checked" },
+    tools: splitPresentMissing([], expectedTools()),
+    providerProjection: providerProjectionNotChecked(input.providerModel),
+    pluginCanaries: splitPresentMissing([], expectedCanaries()),
+    opencodeVersion: { expectedVersion: input.serverMetadata?.expectedOpencodeVersion ?? null, actualVersion: null, probe: "not_checked" },
+    failures: [],
+  };
+  if (desired.present && input.directory && baseUrlConfigured(input.config, input.workspace)) {
+    inspection = await inspectOpenworkCloud({
+      opencode: input.createWorkspaceOpencodeClient(input.config, input.workspace),
+      directory: input.directory,
+      providerModel: input.providerModel,
+    });
+    failures.push(...inspection.failures);
+  }
+
+  if (desired.present && desired.revision && failures.length === 0 && delivery.appliedRevision !== desired.revision) {
+    cloudMcpDeliveryState.markDesired(input.workspace, input.directory, desired.revision, desired.metadata);
+    cloudMcpDeliveryState.markReady(input.workspace, input.directory, desired.revision);
+    delivery = cloudMcpDeliveryState.snapshot(input.workspace, input.directory, desired.revision);
+  }
+
+  const firstFailure = chooseFirstFailure(failures);
+  const compatibility = await compatibilitySnapshot({
+    serverMetadata: input.serverMetadata,
+    appMetadata: desired.metadata.app,
+    directory: input.directory,
+    inspection,
+  });
+  return {
+    schemaVersion: 1,
+    phase: phaseFromFailure(firstFailure),
+    usable: firstFailure === null,
+    usableByCurrentModel: usableByModel(inspection.providerProjection, firstFailure),
+    connectCatalogEnabled: desired.metadata.connectCatalogEnabled,
+    workspace: {
+      id: input.workspace.id,
+      type: input.workspace.workspaceType,
+      directory: input.directory,
+      path: input.workspace.path,
+    },
+    desired: {
+      present: desired.present,
+      name: OPENWORK_CLOUD_MCP_NAME,
+      revision: desired.revision,
+      config: desired.redactedConfig,
+      token: desired.metadata.token,
+      ...(desired.metadata.org ? { org: desired.metadata.org } : {}),
+      ...(desired.metadata.app ? { app: desired.metadata.app } : {}),
+      updatedAt: desired.metadata.updatedAt,
+    },
+    delivery,
+    engine: inspection.engine,
+    tools: {
+      expected: inspection.tools.expected,
+      present: inspection.tools.present,
+      missing: inspection.tools.missing,
+      providerProjection: {
+        checked: inspection.providerProjection.checked,
+        ...(inspection.providerProjection.provider ? { provider: inspection.providerProjection.provider } : {}),
+        ...(inspection.providerProjection.model ? { model: inspection.providerProjection.model } : {}),
+        present: inspection.providerProjection.present,
+        missing: inspection.providerProjection.missing,
+        ...(inspection.providerProjection.error ? { error: inspection.providerProjection.error } : {}),
+      },
+    },
+    pluginCanaries: inspection.pluginCanaries,
+    compatibility,
+    toolDenies,
+    firstFailure,
+    checkedAt,
+  };
+}
+
+async function persistDesiredConfig(config: ServerConfig, workspaceId: string, desiredConfig: Record<string, unknown>): Promise<void> {
+  await writeRuntimeOpencodeConfig(config, workspaceId, (current) => ({
+    ...current,
+    mcp: {
+      ...runtimeMcpMap(current),
+      [OPENWORK_CLOUD_MCP_NAME]: desiredConfig,
+    },
+  }));
+}
+
+function registrationFailure(failures: CloudMcpRuntimeRegistrationFailure[]): CloudMcpFailure {
+  return failure({
+    code: "opencode_mcp_sync_failed",
+    stage: "engine_delivery",
+    retryable: failures.some((item) => item.status === undefined || item.status >= 500),
+    recommendedAction: "Retry reconcile after OpenCode is reachable",
+    message: "Failed to dynamically register openwork-cloud with OpenCode.",
+    aliases: ["cloud_registration_failed"],
+    details: { failures },
+  });
+}
+
+async function wait(ms: number): Promise<void> {
+  if (ms === 0) return;
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pollConnected(input: {
+  opencode: WorkspaceOpencodeClient;
+  directory: string | null;
+}): Promise<CloudMcpFailure | null> {
+  let lastFailure: CloudMcpFailure | null = null;
+  for (const delay of POLL_DELAYS_MS) {
+    await wait(delay);
+    const statusResult = await readMcpStatus(input.opencode, input.directory);
+    if (statusResult.failure) {
+      lastFailure = statusResult.failure;
+      continue;
+    }
+    const cloudStatus = statusResult.data?.[OPENWORK_CLOUD_MCP_NAME];
+    if (cloudStatus?.status === "connected") return null;
+    lastFailure = statusFailure(cloudStatus);
+    if (cloudStatus?.status === "disabled" || cloudStatus?.status === "needs_auth" || cloudStatus?.status === "needs_client_registration" || cloudStatus?.status === "failed") {
+      return lastFailure;
+    }
+  }
+  return lastFailure;
+}
+
+function healthWithFailure(health: CloudMcpHealth, firstFailure: CloudMcpFailure): CloudMcpHealth {
+  return {
+    ...health,
+    phase: phaseFromFailure(firstFailure),
+    usable: false,
+    usableByCurrentModel: health.tools.providerProjection.checked ? false : health.usableByCurrentModel,
+    firstFailure,
+  };
+}
+
+export async function reconcileOpenworkCloudMcp(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  directory: string | null;
+  body: Record<string, unknown>;
+  providerModel?: CloudMcpProviderModelContext;
+  serverMetadata?: CloudMcpServerMetadata;
+  createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
+  registerRuntimeMcp: CloudMcpRuntimeRegistrar;
+}): Promise<CloudMcpHealth> {
+  const configBody = input.body.config ?? input.body;
+  const desiredConfig = canonicalizeCloudMcpConfig(normalizeCloudMcpConfig(configBody));
+  const metadata = extractDesiredMetadata(input.body, desiredConfig);
+  const validationProblem = strictCloudMcpDesiredConfigProblem(desiredConfig, metadata);
+  if (validationProblem) {
+    const validationFailure = failureFromValidationProblem(validationProblem);
+    return healthWithFailure(await readOpenworkCloudMcpHealth(input), validationFailure);
+  }
+  const desiredRevision = calculateCloudMcpDesiredRevision(desiredConfig, metadata);
+  await persistDesiredConfig(input.config, input.workspace.id, desiredConfig);
+  cloudMcpDeliveryState.markDesired(input.workspace, input.directory, desiredRevision, metadata);
+
+  if (!input.directory) {
+    const directoryFailure = failure({
+      code: "workspace_directory_ambiguous",
+      stage: "prerequisites",
+      retryable: false,
+      recommendedAction: "Set an explicit OpenCode directory for this remote workspace",
+      message: "Remote workspace has no exact OpenCode directory, so Cloud MCP readiness cannot be claimed.",
+    });
+    cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, directoryFailure);
+    return healthWithFailure(await readOpenworkCloudMcpHealth(input), directoryFailure);
+  }
+
+  if (!baseUrlConfigured(input.config, input.workspace)) {
+    const unconfiguredFailure = failure({
+      code: "opencode_unconfigured",
+      stage: "prerequisites",
+      retryable: false,
+      recommendedAction: "Start or attach an OpenCode engine for this workspace",
+      message: "OpenCode base URL is missing for this workspace.",
+    });
+    cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, unconfiguredFailure);
+    return healthWithFailure(await readOpenworkCloudMcpHealth(input), unconfiguredFailure);
+  }
+
+  cloudMcpDeliveryState.markRegistering(input.workspace, input.directory, desiredRevision);
+  const registration = await input.registerRuntimeMcp(input.config, input.workspace, [OPENWORK_CLOUD_MCP_NAME], { throwOnFailure: false });
+  if (registration.failures.length > 0) {
+    const registrationError = registrationFailure(registration.failures);
+    cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, registrationError);
+    return healthWithFailure(await readOpenworkCloudMcpHealth(input), registrationError);
+  }
+
+  const opencode = input.createWorkspaceOpencodeClient(input.config, input.workspace);
+  const connectedFailure = await pollConnected({ opencode, directory: input.directory });
+  if (connectedFailure) {
+    cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, connectedFailure);
+    return healthWithFailure(await readOpenworkCloudMcpHealth(input), connectedFailure);
+  }
+
+  let health = await readOpenworkCloudMcpHealth(input);
+  if (health.firstFailure?.code === "cloud_tools_missing") {
+    const secondRegistration = await input.registerRuntimeMcp(input.config, input.workspace, [OPENWORK_CLOUD_MCP_NAME], { throwOnFailure: false });
+    if (secondRegistration.failures.length > 0) {
+      const secondRegistrationError = registrationFailure(secondRegistration.failures);
+      cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, secondRegistrationError);
+      return healthWithFailure(await readOpenworkCloudMcpHealth(input), secondRegistrationError);
+    }
+    const secondConnectedFailure = await pollConnected({ opencode, directory: input.directory });
+    if (secondConnectedFailure) {
+      cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, secondConnectedFailure);
+      return healthWithFailure(await readOpenworkCloudMcpHealth(input), secondConnectedFailure);
+    }
+    health = await readOpenworkCloudMcpHealth(input);
+  }
+
+  if (health.firstFailure) {
+    cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, health.firstFailure);
+    return healthWithFailure(await readOpenworkCloudMcpHealth(input), health.firstFailure);
+  }
+
+  cloudMcpDeliveryState.markReady(input.workspace, input.directory, desiredRevision);
+  return readOpenworkCloudMcpHealth(input);
+}
+
+export async function reconcilePersistedOpenworkCloudMcp(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  directory: string | null;
+  serverMetadata?: CloudMcpServerMetadata;
+  createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
+  registerRuntimeMcp: CloudMcpRuntimeRegistrar;
+  trigger?: string;
+}): Promise<CloudMcpHealth> {
+  const runtimeConfig = await readRuntimeOpencodeConfig(input.config, input.workspace.id);
+  const desiredConfig = runtimeMcpMap(runtimeConfig)[OPENWORK_CLOUD_MCP_NAME];
+  if (!desiredConfig) {
+    return readOpenworkCloudMcpHealth(input);
+  }
+  return reconcileOpenworkCloudMcp({
+    ...input,
+    body: {
+      config: desiredConfig,
+      ...(input.trigger ? { trigger: input.trigger } : {}),
+    },
+  });
+}
+
+export function markOpenworkCloudMcpStale(workspace: WorkspaceInfo, directory: string | null): void {
+  cloudMcpDeliveryState.markWorkspaceStale(workspace, directory);
+}

--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -1,0 +1,413 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { OPENWORK_CLOUD_EXPECTED_TOOLS, OPENWORK_CLOUD_PLUGIN_CANARIES, cloudMcpDeliveryState } from "./cloud-mcp-health.js";
+import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { startServer } from "./server.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+type EngineRequest = {
+  method: string;
+  pathname: string;
+  search: string;
+  body: unknown;
+};
+
+type MockOpencodeOptions = {
+  toolIds?: string[];
+  providerToolIds?: string[];
+  unsupportedToolIds?: boolean;
+  initialConnected?: boolean;
+  hangHealth?: boolean;
+  delayMcpStatusMs?: number;
+  postFailure?: { status: number; body: unknown };
+};
+
+const CLIENT_TOKEN = "owt_cloud_mcp_client";
+const HOST_TOKEN = "owt_cloud_mcp_host";
+const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  cloudMcpDeliveryState.clear();
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+  if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+});
+
+async function createRoot(prefix = "openwork-cloud-mcp-"): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function allReadyToolIds(): string[] {
+  return [...OPENWORK_CLOUD_EXPECTED_TOOLS, ...OPENWORK_CLOUD_PLUGIN_CANARIES];
+}
+
+function startMockOpencode(options: MockOpencodeOptions = {}) {
+  const requests: EngineRequest[] = [];
+  let registerCount = 0;
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      const body = request.method === "POST" ? await request.json().catch(() => null) : null;
+      requests.push({ method: request.method, pathname: url.pathname, search: url.search, body });
+
+      if (url.pathname === "/global/health") {
+        if (options.hangHealth) return await new Promise<Response>(() => {});
+        return Response.json({ healthy: true, version: "1.17.11" });
+      }
+      if (url.pathname === "/instance/dispose") return Response.json({ disposed: true });
+      if (url.pathname === "/mcp" && request.method === "POST") {
+        if (options.postFailure) return Response.json(options.postFailure.body, { status: options.postFailure.status });
+        registerCount += 1;
+        return Response.json({});
+      }
+      if (url.pathname === "/mcp" && request.method === "GET") {
+        if (options.delayMcpStatusMs) await new Promise((resolve) => setTimeout(resolve, options.delayMcpStatusMs));
+        return Response.json(registerCount > 0 || options.initialConnected ? { "openwork-cloud": { status: "connected" } } : {});
+      }
+      if (url.pathname === "/experimental/tool/ids") {
+        if (options.unsupportedToolIds) return Response.json({ code: "not_found" }, { status: 404 });
+        return Response.json(options.toolIds ?? allReadyToolIds());
+      }
+      if (url.pathname === "/experimental/tool") {
+        const ids = options.providerToolIds ?? options.toolIds ?? allReadyToolIds();
+        return Response.json(ids.map((id) => ({ id, description: id, parameters: {} })));
+      }
+      return Response.json({ code: "not_found" }, { status: 404 });
+    },
+  });
+  stops.push(() => server.stop(true));
+  return { server, requests };
+}
+
+function workspace(id: string, path: string, baseUrl: string, extra?: Partial<WorkspaceInfo>): WorkspaceInfo {
+  return {
+    id,
+    name: id,
+    path,
+    preset: "starter",
+    workspaceType: "local",
+    baseUrl,
+    ...extra,
+  };
+}
+
+async function startOpenwork(workspaces: WorkspaceInfo[], runtimeRoot: string): Promise<{ base: string; config: ServerConfig }> {
+  process.env.OPENWORK_RUNTIME_DB = join(runtimeRoot, "runtime.sqlite");
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: CLIENT_TOKEN,
+    hostToken: HOST_TOKEN,
+    configPath: join(runtimeRoot, "server.json"),
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces,
+    authorizedRoots: workspaces.map((item) => item.path),
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config);
+  stops.push(() => server.stop());
+  return { base: `http://127.0.0.1:${server.port}`, config };
+}
+
+function headers(): Record<string, string> {
+  return { Authorization: `Bearer ${CLIENT_TOKEN}`, "Content-Type": "application/json" };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (isRecord(value)) return value;
+  throw new Error(`${label} was not an object`);
+}
+
+function requireArray(value: unknown, label: string): unknown[] {
+  if (Array.isArray(value)) return value;
+  throw new Error(`${label} was not an array`);
+}
+
+async function responseRecord(response: Response): Promise<Record<string, unknown>> {
+  return requireRecord(await response.json(), "response");
+}
+
+function firstFailure(body: Record<string, unknown>): Record<string, unknown> {
+  return requireRecord(body.firstFailure, "firstFailure");
+}
+
+function delivery(body: Record<string, unknown>): Record<string, unknown> {
+  return requireRecord(body.delivery, "delivery");
+}
+
+const CLOUD_CONFIG = {
+  type: "remote",
+  url: "https://api.openworklabs.com/mcp/agent",
+  enabled: true,
+  headers: { Authorization: "Bearer owt_secret_cloud_token" },
+  oauth: false,
+};
+
+async function reconcile(base: string, workspaceId = "ws_1", body: Record<string, unknown> = {}): Promise<Response> {
+  return fetch(`${base}/workspace/${workspaceId}/mcp/openwork-cloud/reconcile`, {
+    method: "POST",
+    headers: headers(),
+    body: JSON.stringify({ config: CLOUD_CONFIG, ...body }),
+  });
+}
+
+async function getHealth(base: string, workspaceId = "ws_1"): Promise<Response> {
+  return fetch(`${base}/workspace/${workspaceId}/mcp/openwork-cloud/health`, { headers: headers() });
+}
+
+describe("openwork-cloud MCP strict reconcile", () => {
+  test("clean ready persists desired config, verifies tools, and redacts the token", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode();
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+
+    const response = await reconcile(openwork.base, "ws_1", {
+      tokenMetadata: { expiresAt: "2026-07-13T00:00:00.000Z" },
+      org: { id: "org_1", name: "Acme" },
+      provider: "anthropic",
+      model: "claude-sonnet-4",
+      trigger: "test",
+    });
+    const text = await response.text();
+    expect(response.status).toBe(200);
+    expect(text).not.toContain("owt_secret_cloud_token");
+    expect(text).not.toContain("Bearer owt_secret_cloud_token");
+
+    const body = requireRecord(JSON.parse(text), "health");
+    expect(body.phase).toBe("ready");
+    expect(body.usable).toBe(true);
+    expect(body.usableByCurrentModel).toBe(true);
+    expect(delivery(body).appliedRevision).toBe(delivery(body).desiredRevision);
+    expect(requireRecord(body.workspace, "workspace").directory).toBe(root);
+    expect(requireRecord(requireRecord(body.compatibility, "compatibility").opencode, "opencode").actualVersion).toBe("1.17.11");
+    expect(requireRecord(requireRecord(body.compatibility, "compatibility").opencode, "opencode").expectedVersion).toBeTruthy();
+    expect((await readRuntimeOpencodeConfig(openwork.config, "ws_1")).mcp?.["openwork-cloud"]?.url).toBe(CLOUD_CONFIG.url);
+
+    const mcpPosts = mock.requests.filter((request) => request.method === "POST" && request.pathname === "/mcp");
+    expect(mcpPosts.length).toBe(1);
+    expect(mcpPosts[0]?.search).toContain(`directory=${encodeURIComponent(root)}`);
+  });
+
+  test("rejects malformed desired config without persisting or registering it", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode();
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+
+    const cases: Array<{ config: Record<string, unknown>; code: string }> = [
+      { config: { ...CLOUD_CONFIG, url: "https://api.openworklabs.com/mcp" }, code: "cloud_endpoint_invalid" },
+      { config: { ...CLOUD_CONFIG, enabled: false }, code: "cloud_mcp_disabled" },
+      { config: { ...CLOUD_CONFIG, headers: {} }, code: "invalid_mcp_token" },
+      { config: { ...CLOUD_CONFIG, oauth: {} }, code: "invalid_mcp_token" },
+    ];
+
+    for (const item of cases) {
+      const body = await responseRecord(await reconcile(openwork.base, "ws_1", { config: item.config }));
+      expect(firstFailure(body).code).toBe(item.code);
+      expect(firstFailure(body).stage).toBe("desired_config");
+    }
+
+    const mismatch = await responseRecord(await reconcile(openwork.base, "ws_1", {
+      tokenMetadata: { organizationId: "org_token" },
+      org: { id: "org_active" },
+    }));
+    expect(firstFailure(mismatch).code).toBe("cloud_token_org_mismatch");
+    expect(firstFailure(mismatch).stage).toBe("desired_config");
+
+    expect((await readRuntimeOpencodeConfig(openwork.config, "ws_1")).mcp?.["openwork-cloud"]).toBeUndefined();
+    expect(mock.requests.some((request) => request.method === "POST" && request.pathname === "/mcp")).toBe(false);
+  });
+
+  test("normalizes a harmless trailing slash on the Cloud MCP endpoint", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode();
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+
+    const body = await responseRecord(await reconcile(openwork.base, "ws_1", {
+      config: { ...CLOUD_CONFIG, url: "https://api.openworklabs.com/api/den/mcp/agent/" },
+    }));
+    expect(body.phase).toBe("ready");
+    expect((await readRuntimeOpencodeConfig(openwork.config, "ws_1")).mcp?.["openwork-cloud"]?.url).toBe("https://api.openworklabs.com/api/den/mcp/agent");
+  });
+
+  test("GET health reports persisted malformed desired config even when the engine looks live", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ initialConnected: true });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
+      ...current,
+      mcp: { "openwork-cloud": { ...CLOUD_CONFIG, url: "https://api.openworklabs.com/mcp" } },
+    }));
+
+    const body = await responseRecord(await getHealth(openwork.base));
+    expect(body.usable).toBe(false);
+    expect(firstFailure(body).code).toBe("cloud_endpoint_invalid");
+    expect(firstFailure(body).stage).toBe("desired_config");
+  });
+
+  test("GET health safely adopts a live exact match before reporting ready", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ initialConnected: true });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
+      ...current,
+      mcp: { "openwork-cloud": CLOUD_CONFIG },
+    }));
+
+    const body = await responseRecord(await getHealth(openwork.base));
+    expect(body.phase).toBe("ready");
+    expect(body.usable).toBe(true);
+    expect(delivery(body).appliedRevision).toBe(delivery(body).desiredRevision);
+  });
+
+  test("health probe timeout is bounded", async () => {
+    const previousTimeout = process.env.OPENWORK_CLOUD_MCP_PROBE_TIMEOUT_MS;
+    process.env.OPENWORK_CLOUD_MCP_PROBE_TIMEOUT_MS = "25";
+    try {
+      const root = await createRoot();
+      const mock = startMockOpencode({ initialConnected: true, delayMcpStatusMs: 100 });
+      const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+      await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
+        ...current,
+        mcp: { "openwork-cloud": CLOUD_CONFIG },
+      }));
+
+      const body = await responseRecord(await getHealth(openwork.base));
+      expect(body.usable).toBe(false);
+      expect(firstFailure(body).code).toBe("opencode_engine_unreachable");
+    } finally {
+      if (previousTimeout === undefined) delete process.env.OPENWORK_CLOUD_MCP_PROBE_TIMEOUT_MS;
+      else process.env.OPENWORK_CLOUD_MCP_PROBE_TIMEOUT_MS = previousTimeout;
+    }
+  });
+
+  test("unreachable engine leaves desired config persisted but not applied", async () => {
+    const root = await createRoot();
+    const openwork = await startOpenwork([workspace("ws_1", root, "http://127.0.0.1:9")], root);
+
+    const response = await reconcile(openwork.base);
+    const body = await responseRecord(response);
+    expect(response.status).toBe(200);
+    expect(firstFailure(body).code).toBe("opencode_mcp_sync_failed");
+    expect(delivery(body).appliedRevision).toBeNull();
+    expect((await readRuntimeOpencodeConfig(openwork.config, "ws_1")).mcp?.["openwork-cloud"]?.url).toBe(CLOUD_CONFIG.url);
+  });
+
+  test("uses the exact secondary workspace directory", async () => {
+    const rootA = await createRoot("openwork-cloud-primary-");
+    const rootB = await createRoot("openwork-cloud-secondary-");
+    const mock = startMockOpencode();
+    const baseUrl = `http://127.0.0.1:${mock.server.port}`;
+    const openwork = await startOpenwork([
+      workspace("ws_1", rootA, baseUrl),
+      workspace("ws_2", rootB, baseUrl),
+    ], rootA);
+
+    const response = await reconcile(openwork.base, "ws_2");
+    const body = await responseRecord(response);
+    expect(body.phase).toBe("ready");
+    const post = mock.requests.find((request) => request.method === "POST" && request.pathname === "/mcp");
+    expect(post?.search).toContain(`directory=${encodeURIComponent(rootB)}`);
+  });
+
+  test("uses an explicit remote workspace directory and refuses ambiguous remotes", async () => {
+    const root = await createRoot();
+    const explicitDirectory = join(root, "remote-project");
+    const mock = startMockOpencode();
+    const baseUrl = `http://127.0.0.1:${mock.server.port}`;
+    const openwork = await startOpenwork([
+      workspace("ws_remote", root, baseUrl, { workspaceType: "remote", directory: explicitDirectory }),
+      workspace("ws_ambiguous", root, baseUrl, { workspaceType: "remote" }),
+    ], root);
+
+    const ready = await reconcile(openwork.base, "ws_remote");
+    expect((await responseRecord(ready)).phase).toBe("ready");
+    expect(mock.requests.find((request) => request.method === "POST" && request.pathname === "/mcp")?.search)
+      .toContain(`directory=${encodeURIComponent(explicitDirectory)}`);
+
+    const ambiguous = await reconcile(openwork.base, "ws_ambiguous");
+    const body = await responseRecord(ambiguous);
+    expect(firstFailure(body).code).toBe("workspace_directory_ambiguous");
+    expect(delivery(body).appliedRevision).toBeNull();
+  });
+
+  test("connected engine with missing Cloud tools re-registers once then reports cloud_tools_missing", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ toolIds: [...OPENWORK_CLOUD_PLUGIN_CANARIES] });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+
+    const body = await responseRecord(await reconcile(openwork.base));
+    expect(firstFailure(body).code).toBe("cloud_tools_missing");
+    expect(mock.requests.filter((request) => request.method === "POST" && request.pathname === "/mcp").length).toBe(2);
+  });
+
+  test("reports provider projection missing when model tool list omits Cloud tools", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ providerToolIds: [...OPENWORK_CLOUD_PLUGIN_CANARIES] });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+
+    const body = await responseRecord(await reconcile(openwork.base, "ws_1", { provider: "anthropic", model: "claude" }));
+    expect(firstFailure(body).code).toBe("provider_tool_projection_missing");
+    expect(firstFailure(body).recommendedAction).toBe("Update OpenWork");
+    expect(requireRecord(requireRecord(body.tools, "tools").providerProjection, "projection").missing).toEqual([...OPENWORK_CLOUD_EXPECTED_TOOLS]);
+  });
+
+  test("reports extension canary missing when docs canary is present but extension canary is absent", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ toolIds: [...OPENWORK_CLOUD_EXPECTED_TOOLS, "openwork_docs_search"] });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+
+    const body = await responseRecord(await reconcile(openwork.base));
+    expect(firstFailure(body).code).toBe("extensions_plugin_missing");
+    expect(requireArray(requireRecord(body.pluginCanaries, "pluginCanaries").missing, "missing")).toContain("openwork_extension_list_actions");
+  });
+
+  test("old engines without tool.ids return Update OpenWork guidance", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ unsupportedToolIds: true });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+
+    const body = await responseRecord(await reconcile(openwork.base));
+    expect(firstFailure(body).code).toBe("opencode_tool_ids_unsupported");
+    expect(firstFailure(body).recommendedAction).toBe("Update OpenWork");
+  });
+
+  test("health detects project tool denies while generic MCP add remains best-effort", async () => {
+    const root = await createRoot();
+    await writeFile(join(root, "opencode.jsonc"), JSON.stringify({ tools: { deny: ["openwork-cloud_*"] } }), "utf8");
+    const mock = startMockOpencode();
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+
+    const strictBody = await responseRecord(await reconcile(openwork.base));
+    expect(firstFailure(strictBody).code).toBe("cloud_tools_denied");
+    expect(requireArray(strictBody.toolDenies, "toolDenies").length).toBeGreaterThan(0);
+
+    const generic = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify({ name: "posthog", config: { type: "remote", url: "https://mcp.posthog.com/mcp", enabled: true } }),
+    });
+    expect(generic.status).toBe(200);
+    const genericBody = await responseRecord(generic);
+    expect(requireArray(genericBody.items, "items").some((item) => isRecord(item) && item.name === "posthog")).toBe(true);
+  });
+});

--- a/apps/server/src/connect-state.test.ts
+++ b/apps/server/src/connect-state.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { OPENWORK_CLOUD_EXPECTED_TOOLS, OPENWORK_CLOUD_PLUGIN_CANARIES } from "./cloud-mcp-health.js";
+import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { startServer } from "./server.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
+
+const CLIENT_TOKEN = "owt_connect_state_client";
+const HOST_TOKEN = "owt_connect_state_host";
+const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) await rm(roots.pop() ?? "", { recursive: true, force: true });
+  if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+});
+
+async function createRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function startMockOpencode() {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/global/health") return Response.json({ healthy: true, version: "1.17.11" });
+      if (url.pathname === "/mcp" && request.method === "GET") return Response.json({ "openwork-cloud": { status: "connected" } });
+      if (url.pathname === "/experimental/tool/ids") return Response.json([...OPENWORK_CLOUD_EXPECTED_TOOLS, ...OPENWORK_CLOUD_PLUGIN_CANARIES]);
+      return Response.json({ code: "not_found" }, { status: 404 });
+    },
+  });
+  stops.push(() => server.stop(true));
+  return server;
+}
+
+function workspace(id: string, path: string, baseUrl: string): WorkspaceInfo {
+  return { id, name: id, path, preset: "starter", workspaceType: "local", baseUrl };
+}
+
+async function startOpenwork(workspaces: WorkspaceInfo[], runtimeRoot: string): Promise<{ base: string; config: ServerConfig }> {
+  process.env.OPENWORK_RUNTIME_DB = join(runtimeRoot, "runtime.sqlite");
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: CLIENT_TOKEN,
+    hostToken: HOST_TOKEN,
+    configPath: join(runtimeRoot, "server.json"),
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces,
+    authorizedRoots: workspaces.map((item) => item.path),
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config);
+  stops.push(() => server.stop());
+  return { base: `http://127.0.0.1:${server.port}`, config };
+}
+
+function clientHeaders(): Record<string, string> {
+  return { Authorization: `Bearer ${CLIENT_TOKEN}` };
+}
+
+function hostHeaders(): Record<string, string> {
+  return { "X-OpenWork-Host-Token": HOST_TOKEN, "Content-Type": "application/json" };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+async function responseRecord(response: Response): Promise<Record<string, unknown>> {
+  const body: unknown = await response.json();
+  if (!isRecord(body)) throw new Error("Response body was not an object");
+  return body;
+}
+
+function requireRecord(value: unknown, label: string): Record<string, unknown> {
+  if (!isRecord(value)) throw new Error(`${label} was not an object`);
+  return value;
+}
+
+describe("connect state Cloud health scoping", () => {
+  test("uses verified health for the exact requested directory without borrowing another workspace", async () => {
+    const rootA = await createRoot("openwork-connect-state-a-");
+    const rootB = await createRoot("openwork-connect-state-b-");
+    const engine = startMockOpencode();
+    const baseUrl = `http://127.0.0.1:${engine.port}`;
+    const openwork = await startOpenwork([
+      workspace("ws_a", rootA, baseUrl),
+      workspace("ws_b", rootB, baseUrl),
+    ], rootA);
+
+    await fetch(`${openwork.base}/experimental/connect/state`, {
+      method: "PUT",
+      headers: hostHeaders(),
+      body: JSON.stringify({ connectEnabled: true }),
+    });
+    await writeRuntimeOpencodeConfig(openwork.config, "ws_b", (current) => ({
+      ...current,
+      mcp: {
+        ...current.mcp,
+        "openwork-cloud": {
+          type: "remote",
+          url: "https://api.openworklabs.com/mcp/agent",
+          enabled: true,
+          headers: { Authorization: "Bearer owt_connect_state_cloud_token" },
+          oauth: false,
+        },
+      },
+    }));
+
+    const first = await responseRecord(await fetch(`${openwork.base}/experimental/connect/state?directory=${encodeURIComponent(rootA)}`, { headers: clientHeaders() }));
+    expect(first.cloudMcpPresent).toBe(false);
+    expect(requireRecord(first.workspace, "workspace").id).toBe("ws_a");
+    expect(requireRecord(requireRecord(first.cloudHealth, "cloudHealth").desired, "desired").present).toBe(false);
+
+    const second = await responseRecord(await fetch(`${openwork.base}/experimental/connect/state?directory=${encodeURIComponent(rootB)}`, { headers: clientHeaders() }));
+    expect(second.cloudMcpPresent).toBe(true);
+    expect(requireRecord(second.workspace, "workspace").id).toBe("ws_b");
+    expect(requireRecord(second.cloudHealth, "cloudHealth").usable).toBe(true);
+
+    const unknown = await responseRecord(await fetch(`${openwork.base}/experimental/connect/state?directory=${encodeURIComponent(join(rootA, "other"))}`, { headers: clientHeaders() }));
+    expect(unknown.cloudMcpPresent).toBe(false);
+    expect(unknown.cloudHealth).toBeNull();
+    expect(requireRecord(unknown.workspace, "workspace").resolution).toBe("unknown");
+  });
+});

--- a/apps/server/src/connect-state.ts
+++ b/apps/server/src/connect-state.ts
@@ -1,17 +1,20 @@
 import { readFile, writeFile } from "node:fs/promises";
 import { join } from "node:path";
+import type { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 
-import { googleWorkspaceLegacyConfigured } from "./extensions/google-workspace.js";
 import {
-  readRuntimeOpencodeConfig,
-  runtimeMcpMap,
-  runtimeStorageDir,
-} from "./runtime-opencode-config-store.js";
-import type { ServerConfig } from "./types.js";
+  readOpenworkCloudMcpHealth,
+  type CloudMcpHealth,
+  type CloudMcpProviderModelContext,
+  type CloudMcpServerMetadata,
+} from "./cloud-mcp-health.js";
+import { googleWorkspaceLegacyConfigured } from "./extensions/google-workspace.js";
+import { runtimeStorageDir } from "./runtime-opencode-config-store.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
 import { ensureDir } from "./utils.js";
 
 const CONNECT_STATE_FILE = "connect-state.json";
-const OPENWORK_CLOUD_MCP_NAME = "openwork-cloud";
+type WorkspaceOpencodeClient = ReturnType<typeof createOpencodeClient>;
 
 type PersistedConnectState = {
   connectEnabled: boolean;
@@ -20,10 +23,27 @@ type PersistedConnectState = {
 
 export type ConnectSnapshot = {
   connectEnabled: boolean;
+  connectCatalogEnabled: boolean;
   cloudMcpPresent: boolean;
+  cloudHealth: CloudMcpHealth | null;
+  workspace: {
+    resolution: "resolved" | "unknown" | "ambiguous";
+    id: string | null;
+    directory: string | null;
+    reason?: string;
+  };
   googleWorkspace: {
     legacyConfigured: boolean;
   };
+};
+
+export type ConnectSnapshotOptions = {
+  workspaceId?: string;
+  directory?: string;
+  providerModel?: CloudMcpProviderModelContext;
+  serverMetadata?: CloudMcpServerMetadata;
+  resolveOpencodeDirectory?: (workspace: WorkspaceInfo) => string | null;
+  createWorkspaceOpencodeClient?: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -44,10 +64,17 @@ function normalizeConnectState(value: unknown): PersistedConnectState {
   };
 }
 
-export function googleWorkspaceConnectGuidance(cloudMcpPresent: boolean): string {
-  return cloudMcpPresent
-    ? "Google Workspace is available through the OpenWork Cloud connection: call search_capabilities to find the capability, then execute_capability to run it. Do not tell the user to reconfigure extensions; the relevant settings surface is Settings > Connect."
-    : "Google Workspace is not connected on this device. Direct the user to Settings > Connect to connect their account. Do not direct them to Settings > Extensions.";
+export function googleWorkspaceConnectGuidance(cloudHealthOrReady: CloudMcpHealth | boolean | null): string {
+  const usable = typeof cloudHealthOrReady === "boolean" ? cloudHealthOrReady : cloudHealthOrReady?.usable === true;
+  if (usable) {
+    return "Google Workspace is available through the OpenWork Cloud connection: call search_capabilities to find the capability, then execute_capability to run it. Do not tell the user to reconfigure extensions; the relevant settings surface is Settings > Connect.";
+  }
+  if (cloudHealthOrReady && typeof cloudHealthOrReady !== "boolean" && cloudHealthOrReady.desired.present) {
+    const failure = cloudHealthOrReady.firstFailure;
+    const suffix = failure ? ` Current health check: ${failure.code}; ${failure.recommendedAction}.` : "";
+    return `Google Workspace is connected through OpenWork Connect, but agent access is not ready for this exact workspace. Direct the user to Settings > Connect > Repair and test. Do not substitute docs, browser tools, or Settings > Extensions for the connected-service action.${suffix}`;
+  }
+  return "Google Workspace is not connected on this device. Direct the user to Settings > Connect to connect their account. Do not direct them to Settings > Extensions.";
 }
 
 export async function readConnectState(config: ServerConfig): Promise<PersistedConnectState> {
@@ -67,21 +94,100 @@ export async function writeConnectState(config: ServerConfig, state: { connectEn
   return next;
 }
 
-export async function getConnectSnapshot(config: ServerConfig): Promise<ConnectSnapshot> {
-  const state = await readConnectState(config);
-  let cloudMcpPresent = false;
+function normalizeDirectory(directory: string): string {
+  return directory.trim().replace(/[\/]+$/, "");
+}
 
-  for (const workspace of config.workspaces) {
-    const runtimeConfig = await readRuntimeOpencodeConfig(config, workspace.id);
-    if (Object.hasOwn(runtimeMcpMap(runtimeConfig), OPENWORK_CLOUD_MCP_NAME)) {
-      cloudMcpPresent = true;
-      break;
+function workspaceDirectory(workspace: WorkspaceInfo, resolveOpencodeDirectory?: (workspace: WorkspaceInfo) => string | null): string | null {
+  return resolveOpencodeDirectory?.(workspace) ?? (workspace.workspaceType === "local" ? workspace.path : workspace.directory ?? null);
+}
+
+function resolveConnectWorkspace(config: ServerConfig, options: ConnectSnapshotOptions): { workspace: WorkspaceInfo; directory: string | null } | { resolution: "unknown" | "ambiguous"; directory: string | null; reason: string } {
+  const workspaceId = options.workspaceId?.trim();
+  const requestedDirectory = options.directory?.trim();
+  if (workspaceId) {
+    const workspace = config.workspaces.find((entry) => entry.id === workspaceId);
+    if (!workspace) {
+      return { resolution: "unknown", directory: requestedDirectory ? normalizeDirectory(requestedDirectory) : null, reason: `Workspace ${workspaceId} was not found` };
     }
+    return { workspace, directory: workspaceDirectory(workspace, options.resolveOpencodeDirectory) };
   }
+
+  if (requestedDirectory) {
+    const normalizedRequested = normalizeDirectory(requestedDirectory);
+    const matches = config.workspaces.filter((workspace) => {
+      const directory = workspaceDirectory(workspace, options.resolveOpencodeDirectory);
+      return directory !== null && normalizeDirectory(directory) === normalizedRequested;
+    });
+    if (matches.length === 1) {
+      const workspace = matches[0];
+      if (workspace) return { workspace, directory: workspaceDirectory(workspace, options.resolveOpencodeDirectory) };
+    }
+    if (matches.length > 1) {
+      return { resolution: "ambiguous", directory: normalizedRequested, reason: "Multiple workspaces have this exact OpenCode directory" };
+    }
+    return { resolution: "unknown", directory: normalizedRequested, reason: "No workspace has this exact OpenCode directory" };
+  }
+
+  const only = config.workspaces[0];
+  if (config.workspaces.length === 1 && only) {
+    return { workspace: only, directory: workspaceDirectory(only, options.resolveOpencodeDirectory) };
+  }
+  return { resolution: "unknown", directory: null, reason: "Workspace id or exact directory is required when multiple workspaces are configured" };
+}
+
+async function resolveCloudHealth(config: ServerConfig, options: ConnectSnapshotOptions): Promise<{ cloudHealth: CloudMcpHealth | null; workspace: ConnectSnapshot["workspace"] }> {
+  const resolved = resolveConnectWorkspace(config, options);
+  if (!("workspace" in resolved)) {
+    return {
+      cloudHealth: null,
+      workspace: {
+        resolution: resolved.resolution,
+        id: null,
+        directory: resolved.directory,
+        reason: resolved.reason,
+      },
+    };
+  }
+  if (!options.createWorkspaceOpencodeClient) {
+    return {
+      cloudHealth: null,
+      workspace: {
+        resolution: "resolved",
+        id: resolved.workspace.id,
+        directory: resolved.directory,
+        reason: "OpenCode health probe is not available in this route",
+      },
+    };
+  }
+  const cloudHealth = await readOpenworkCloudMcpHealth({
+    config,
+    workspace: resolved.workspace,
+    directory: resolved.directory,
+    providerModel: options.providerModel,
+    serverMetadata: options.serverMetadata,
+    createWorkspaceOpencodeClient: options.createWorkspaceOpencodeClient,
+  });
+  return {
+    cloudHealth,
+    workspace: {
+      resolution: "resolved",
+      id: resolved.workspace.id,
+      directory: resolved.directory,
+    },
+  };
+}
+
+export async function getConnectSnapshot(config: ServerConfig, options: ConnectSnapshotOptions = {}): Promise<ConnectSnapshot> {
+  const state = await readConnectState(config);
+  const { cloudHealth, workspace } = await resolveCloudHealth(config, options);
 
   return {
     connectEnabled: state.connectEnabled,
-    cloudMcpPresent,
+    connectCatalogEnabled: state.connectEnabled,
+    cloudMcpPresent: cloudHealth?.usable === true,
+    cloudHealth,
+    workspace,
     googleWorkspace: {
       legacyConfigured: googleWorkspaceLegacyConfigured(),
     },
@@ -89,7 +195,7 @@ export async function getConnectSnapshot(config: ServerConfig): Promise<ConnectS
 }
 
 export function shouldGateLegacyGoogleWorkspace(snapshot: ConnectSnapshot): boolean {
-  return snapshot.connectEnabled && !snapshot.googleWorkspace.legacyConfigured;
+  return snapshot.connectCatalogEnabled && !snapshot.googleWorkspace.legacyConfigured;
 }
 
 export function googleWorkspaceStatusConnectExtra(snapshot: ConnectSnapshot): Record<string, unknown> {
@@ -98,7 +204,7 @@ export function googleWorkspaceStatusConnectExtra(snapshot: ConnectSnapshot): Re
     connect: {
       enabled: true,
       cloudMcpPresent: snapshot.cloudMcpPresent,
-      guidance: googleWorkspaceConnectGuidance(snapshot.cloudMcpPresent),
+      guidance: googleWorkspaceConnectGuidance(snapshot.cloudHealth),
     },
   };
 }

--- a/apps/server/src/diagnostic-sanitizer.ts
+++ b/apps/server/src/diagnostic-sanitizer.ts
@@ -1,0 +1,45 @@
+const REDACTED = "[REDACTED]";
+
+const SENSITIVE_KEYS = new Set([
+  "authorization",
+  "token",
+  "secret",
+  "password",
+  "cookie",
+  "api_key",
+  "api-key",
+  "apikey",
+  "client_secret",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function normalizedKey(key: string): string {
+  return key.trim().toLowerCase();
+}
+
+function isSensitiveKey(key: string): boolean {
+  return SENSITIVE_KEYS.has(normalizedKey(key));
+}
+
+export function sanitizeDiagnosticString(value: string): string {
+  return value
+    .replace(/Bearer\s+[A-Za-z0-9._~+\/-]+=*/gi, `Bearer ${REDACTED}`)
+    .replace(/\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\b/g, REDACTED)
+    .replace(/\bow[thc]_[A-Za-z0-9_-]+\b/g, REDACTED);
+}
+
+export function sanitizeDiagnosticValue(value: unknown): unknown {
+  if (typeof value === "string") return sanitizeDiagnosticString(value);
+  if (typeof value === "number" || typeof value === "boolean" || value === null) return value;
+  if (Array.isArray(value)) return value.map((item) => sanitizeDiagnosticValue(item));
+  if (!isRecord(value)) return String(value);
+
+  const sanitized: Record<string, unknown> = {};
+  for (const [key, nested] of Object.entries(value)) {
+    sanitized[key] = isSensitiveKey(key) ? REDACTED : sanitizeDiagnosticValue(nested);
+  }
+  return sanitized;
+}

--- a/apps/server/src/extensions-connect-gating.test.ts
+++ b/apps/server/src/extensions-connect-gating.test.ts
@@ -293,8 +293,8 @@ describe("Connect-aware legacy extension gating", () => {
 
     const cloudGated = await callCalendarListEvents(base);
     const cloudBody = await readSchema(cloudGated, gatedCallSchema);
-    expect(cloudBody.message).toContain("call search_capabilities");
-    expect(cloudBody.message).toContain("execute_capability");
+    expect(cloudBody.message).toContain("agent access is not ready for this exact workspace");
+    expect(cloudBody.message).toContain("Repair and test");
     expect(cloudBody.message).toContain("Settings > Connect");
 
     const cloudStatus = await readSchema(
@@ -303,7 +303,7 @@ describe("Connect-aware legacy extension gating", () => {
     );
     expect(cloudStatus.connect).toEqual({
       enabled: true,
-      cloudMcpPresent: true,
+      cloudMcpPresent: false,
       guidance: cloudBody.message,
     });
   });
@@ -327,6 +327,8 @@ describe("Connect-aware legacy extension gating", () => {
     const get = await fetch(`${base}/experimental/connect/state`, { headers: clientHeaders() });
     expect(get.status).toBe(200);
     const getState = await readSchema(get, connectStateResponseSchema);
-    expect(getState).toEqual(putState);
+    expect(getState.connectEnabled).toBe(putState.connectEnabled);
+    expect(getState.cloudMcpPresent).toBe(putState.cloudMcpPresent);
+    expect(getState.googleWorkspace).toEqual(putState.googleWorkspace);
   });
 });

--- a/apps/server/src/extensions/index.ts
+++ b/apps/server/src/extensions/index.ts
@@ -67,7 +67,7 @@ export async function callExperimentalExtensionAction(config: ServerConfig, env:
     return {
       ok: false,
       error: "use_openwork_cloud",
-      message: googleWorkspaceConnectGuidance(connectSnapshot.cloudMcpPresent),
+      message: googleWorkspaceConnectGuidance(connectSnapshot.cloudHealth),
     };
   }
 

--- a/apps/server/src/mcp.ts
+++ b/apps/server/src/mcp.ts
@@ -3,10 +3,31 @@ import { existsSync } from "node:fs";
 import { join } from "node:path";
 import { homedir } from "node:os";
 import type { McpItem, ServerConfig } from "./types.js";
+import { sanitizeDiagnosticString } from "./diagnostic-sanitizer.js";
 import { readJsoncFile } from "./jsonc.js";
 import { opencodeConfigPath } from "./workspace-files.js";
 import { validateMcpConfig, validateMcpName } from "./validators.js";
 import { readRuntimeOpencodeConfig, runtimeMcpMap, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+
+export type McpToolDenySource = "config.project" | "config.global";
+
+export type McpToolDeny = {
+  source: McpToolDenySource;
+  style: "tools.deny" | "tools" | "permission" | "permissions";
+  pattern: string;
+  matched: string;
+};
+
+type McpToolAllow = McpToolDeny;
+
+const OPENWORK_CLOUD_DIAGNOSTIC_TOOL_IDS = [
+  "openwork-cloud_search_capabilities",
+  "openwork-cloud_execute_capability",
+];
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
 
 function globalOpenCodeConfigPath(): string {
   const base = join(homedir(), ".config", "opencode");
@@ -19,23 +40,270 @@ function globalOpenCodeConfigPath(): string {
 
 function getMcpConfig(config: Record<string, unknown>): Record<string, Record<string, unknown>> {
   const mcp = config.mcp;
-  if (!mcp || typeof mcp !== "object") return {};
-  return mcp as Record<string, Record<string, unknown>>;
+  if (!isRecord(mcp)) return {};
+  const output: Record<string, Record<string, unknown>> = {};
+  for (const [name, value] of Object.entries(mcp)) {
+    if (isRecord(value)) output[name] = value;
+  }
+  return output;
 }
 
 function getDeniedToolPatterns(config: Record<string, unknown>): string[] {
   const tools = config.tools;
-  if (!tools || typeof tools !== "object") return [];
-  const deny = (tools as { deny?: unknown }).deny;
+  if (!isRecord(tools)) return [];
+  const deny = tools.deny;
   if (!Array.isArray(deny)) return [];
-  return deny.filter((item) => typeof item === "string") as string[];
+  return deny.filter((item): item is string => typeof item === "string");
 }
 
-function isMcpDisabledByTools(config: Record<string, unknown>, name: string): boolean {
-  const patterns = getDeniedToolPatterns(config);
-  if (patterns.length === 0) return false;
-  const candidates = [`mcp.${name}`, `mcp.${name}.*`, `mcp:${name}`, `mcp:${name}:*`, "mcp.*", "mcp:*"];
-  return patterns.some((pattern) => candidates.some((candidate) => minimatch(candidate, pattern)));
+function getToolIdsForDiagnostics(name: string, toolIds: string[]): string[] {
+  if (toolIds.length > 0) return toolIds;
+  return [name];
+}
+
+function diagnosticToolIdsForMcp(name: string): string[] {
+  return name === "openwork-cloud" ? OPENWORK_CLOUD_DIAGNOSTIC_TOOL_IDS : [];
+}
+
+function permissionCandidates(name: string, toolId: string): string[] {
+  const candidates = new Set([toolId, `tool.${toolId}`, `tool:${toolId}`, `mcp.${name}`, `mcp.${name}.*`, `mcp:${name}`, `mcp:${name}:*`, "mcp.*", "mcp:*"]);
+  const prefix = `${name}_`;
+  if (toolId.startsWith(prefix)) {
+    const suffix = toolId.slice(prefix.length);
+    candidates.add(`mcp.${name}.${suffix}`);
+    candidates.add(`mcp:${name}:${suffix}`);
+  }
+  return Array.from(candidates);
+}
+
+function matchesToolPattern(name: string, toolId: string, pattern: string): boolean {
+  for (const candidate of permissionCandidates(name, toolId)) {
+    if (candidate === pattern || minimatch(candidate, pattern)) return true;
+  }
+  return false;
+}
+
+function deniesValue(value: unknown): boolean {
+  if (value === false || value === "deny") return true;
+  if (!isRecord(value)) return false;
+  return value.enabled === false || value.action === "deny" || value.effect === "deny" || value.permission === "deny";
+}
+
+function allowsValue(value: unknown): boolean {
+  if (value === true || value === "allow") return true;
+  if (!isRecord(value)) return false;
+  return value.enabled === true || value.action === "allow" || value.effect === "allow" || value.permission === "allow";
+}
+
+function pushDeny(
+  denies: McpToolDeny[],
+  source: McpToolDenySource,
+  style: McpToolDeny["style"],
+  pattern: string,
+  matched: string,
+): void {
+  denies.push({
+    source,
+    style,
+    pattern: sanitizeDiagnosticString(pattern),
+    matched: sanitizeDiagnosticString(matched),
+  });
+}
+
+function collectToolsDenyArray(
+  config: Record<string, unknown>,
+  source: McpToolDenySource,
+  name: string,
+  toolIds: string[],
+): McpToolDeny[] {
+  const denies: McpToolDeny[] = [];
+  for (const pattern of getDeniedToolPatterns(config)) {
+    for (const toolId of toolIds) {
+      if (matchesToolPattern(name, toolId, pattern)) pushDeny(denies, source, "tools.deny", pattern, toolId);
+    }
+  }
+  return denies;
+}
+
+function collectToolsRecordDenies(
+  config: Record<string, unknown>,
+  source: McpToolDenySource,
+  name: string,
+  toolIds: string[],
+  mode: "deny" | "allow",
+): McpToolDeny[] {
+  const tools = config.tools;
+  if (!isRecord(tools)) return [];
+  const denies: McpToolDeny[] = [];
+  for (const [pattern, value] of Object.entries(tools)) {
+    if (pattern === "deny") continue;
+    const matchesMode = mode === "deny" ? deniesValue(value) : allowsValue(value);
+    if (!matchesMode) continue;
+    for (const toolId of toolIds) {
+      if (matchesToolPattern(name, toolId, pattern)) pushDeny(denies, source, "tools", pattern, toolId);
+    }
+  }
+  return denies;
+}
+
+function collectPermissionRulesetDenies(
+  value: unknown,
+  source: McpToolDenySource,
+  style: "permission" | "permissions",
+  name: string,
+  toolIds: string[],
+  mode: "deny" | "allow",
+): McpToolDeny[] {
+  if (!Array.isArray(value)) return [];
+  const denies: McpToolDeny[] = [];
+  for (const entry of value) {
+    if (!isRecord(entry)) continue;
+    const action = typeof entry.action === "string" ? entry.action : typeof entry.effect === "string" ? entry.effect : "";
+    if (action !== mode) continue;
+    const pattern = typeof entry.pattern === "string"
+      ? entry.pattern
+      : typeof entry.permission === "string"
+        ? entry.permission
+        : "";
+    if (!pattern) continue;
+    for (const toolId of toolIds) {
+      if (matchesToolPattern(name, toolId, pattern)) pushDeny(denies, source, style, pattern, toolId);
+    }
+  }
+  return denies;
+}
+
+function collectPermissionScalarDeny(
+  value: unknown,
+  source: McpToolDenySource,
+  style: "permission" | "permissions",
+  toolIds: string[],
+  mode: "deny" | "allow",
+): McpToolDeny[] {
+  const matchesMode = mode === "deny" ? deniesValue(value) : allowsValue(value);
+  if (!matchesMode) return [];
+  const denies: McpToolDeny[] = [];
+  for (const toolId of toolIds) pushDeny(denies, source, style, "*", toolId);
+  return denies;
+}
+
+function collectPermissionObjectDenies(
+  value: unknown,
+  source: McpToolDenySource,
+  style: "permission" | "permissions",
+  name: string,
+  toolIds: string[],
+  mode: "deny" | "allow",
+): McpToolDeny[] {
+  if (!isRecord(value)) return [];
+  const denies: McpToolDeny[] = [];
+  for (const [key, nested] of Object.entries(value)) {
+    const matchesMode = mode === "deny" ? deniesValue(nested) : allowsValue(nested);
+    if (matchesMode) {
+      for (const toolId of toolIds) {
+        if (matchesToolPattern(name, toolId, key)) pushDeny(denies, source, style, key, toolId);
+      }
+      continue;
+    }
+    if (key === "tool" || key === "tools") {
+      const nestedMatchesMode = mode === "deny" ? deniesValue(nested) : allowsValue(nested);
+      if (nestedMatchesMode) {
+        for (const toolId of toolIds) pushDeny(denies, source, style, key, toolId);
+        continue;
+      }
+      for (const [pattern, permission] of Object.entries(isRecord(nested) ? nested : {})) {
+        const nestedPermissionMatchesMode = mode === "deny" ? deniesValue(permission) : allowsValue(permission);
+        if (!nestedPermissionMatchesMode) continue;
+        for (const toolId of toolIds) {
+          if (matchesToolPattern(name, toolId, pattern)) pushDeny(denies, source, style, pattern, toolId);
+        }
+      }
+    }
+  }
+  return denies;
+}
+
+function uniqueDenies(denies: McpToolDeny[]): McpToolDeny[] {
+  const seen = new Set<string>();
+  const unique: McpToolDeny[] = [];
+  for (const deny of denies) {
+    const key = `${deny.source}\0${deny.style}\0${deny.pattern}\0${deny.matched}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    unique.push(deny);
+  }
+  return unique;
+}
+
+function collectMcpToolMatchesFromConfig(
+  config: Record<string, unknown>,
+  source: McpToolDenySource,
+  name: string,
+  toolIds: string[],
+  mode: "deny" | "allow",
+): McpToolDeny[] {
+  const diagnosticToolIds = getToolIdsForDiagnostics(name, toolIds);
+  return uniqueDenies([
+    ...(mode === "deny" ? collectToolsDenyArray(config, source, name, diagnosticToolIds) : []),
+    ...collectToolsRecordDenies(config, source, name, diagnosticToolIds, mode),
+    ...collectPermissionScalarDeny(config.permission, source, "permission", diagnosticToolIds, mode),
+    ...collectPermissionRulesetDenies(config.permission, source, "permission", name, diagnosticToolIds, mode),
+    ...collectPermissionObjectDenies(config.permission, source, "permission", name, diagnosticToolIds, mode),
+    ...collectPermissionScalarDeny(config.permissions, source, "permissions", diagnosticToolIds, mode),
+    ...collectPermissionRulesetDenies(config.permissions, source, "permissions", name, diagnosticToolIds, mode),
+    ...collectPermissionObjectDenies(config.permissions, source, "permissions", name, diagnosticToolIds, mode),
+  ]);
+}
+
+function diagnoseMcpToolDeniesFromConfig(
+  config: Record<string, unknown>,
+  source: McpToolDenySource,
+  name: string,
+  toolIds: string[],
+): McpToolDeny[] {
+  return collectMcpToolMatchesFromConfig(config, source, name, toolIds, "deny");
+}
+
+function collectProjectAllows(
+  config: Record<string, unknown>,
+  name: string,
+  toolIds: string[],
+): McpToolAllow[] {
+  return collectMcpToolMatchesFromConfig(config, "config.project", name, toolIds, "allow");
+}
+
+function projectAllowOverridesGlobalDeny(allow: McpToolAllow, deny: McpToolDeny): boolean {
+  return allow.matched === deny.matched || minimatch(deny.matched, allow.pattern);
+}
+
+function filterGlobalDeniesOverriddenByProjectAllows(globalDenies: McpToolDeny[], projectAllows: McpToolAllow[]): McpToolDeny[] {
+  return globalDenies.filter((deny) => !projectAllows.some((allow) => projectAllowOverridesGlobalDeny(allow, deny)));
+}
+
+export function diagnoseMcpToolDeniesFromConfigs(input: {
+  projectConfig: Record<string, unknown>;
+  globalConfig: Record<string, unknown>;
+  name: string;
+  toolIds?: string[];
+}): McpToolDeny[] {
+  const toolIds = input.toolIds ?? diagnosticToolIdsForMcp(input.name);
+  const projectAllows = collectProjectAllows(input.projectConfig, input.name, toolIds);
+  const projectDenies = diagnoseMcpToolDeniesFromConfig(input.projectConfig, "config.project", input.name, toolIds);
+  const globalDenies = diagnoseMcpToolDeniesFromConfig(input.globalConfig, "config.global", input.name, toolIds);
+  return uniqueDenies([
+    ...projectDenies,
+    ...filterGlobalDeniesOverriddenByProjectAllows(globalDenies, projectAllows),
+  ]);
+}
+
+export async function diagnoseMcpToolDenies(
+  workspaceRoot: string,
+  name: string,
+  toolIds?: string[],
+): Promise<McpToolDeny[]> {
+  const { data: config } = await readJsoncFile(opencodeConfigPath(workspaceRoot), {} as Record<string, unknown>, { allowInvalid: true });
+  const { data: globalConfig } = await readJsoncFile(globalOpenCodeConfigPath(), {} as Record<string, unknown>, { allowInvalid: true });
+  return diagnoseMcpToolDeniesFromConfigs({ projectConfig: config, globalConfig, name, toolIds });
 }
 
 export async function listMcp(serverConfig: ServerConfig, workspaceId: string, workspaceRoot: string): Promise<McpItem[]> {
@@ -52,33 +320,38 @@ export async function listMcp(serverConfig: ServerConfig, workspaceId: string, w
   // Global MCPs first; project-level entries override global ones with the same name.
   for (const [name, entry] of Object.entries(globalMcpMap)) {
     if (Object.prototype.hasOwnProperty.call(projectMcpMap, name)) continue;
+    const toolDenies = diagnoseMcpToolDeniesFromConfigs({ projectConfig: config, globalConfig, name });
     items.push({
       name,
       config: entry,
       source: "config.global",
-      disabledByTools:
-        (isMcpDisabledByTools(globalConfig, name) || isMcpDisabledByTools(config, name)) || undefined,
+      disabledByTools: toolDenies.length > 0 || undefined,
+      ...(toolDenies.length ? { toolDenies } : {}),
     });
   }
 
   // Project MCPs (highest priority).
   for (const [name, entry] of Object.entries(projectMcpMap)) {
     if (Object.prototype.hasOwnProperty.call(runtimeMap, name)) continue;
+    const toolDenies = diagnoseMcpToolDeniesFromConfigs({ projectConfig: config, globalConfig, name });
     items.push({
       name,
       config: entry,
       source: "config.project",
-      disabledByTools: isMcpDisabledByTools(config, name) || undefined,
+      disabledByTools: toolDenies.length > 0 || undefined,
+      ...(toolDenies.length ? { toolDenies } : {}),
     });
   }
 
   // OpenWork-owned MCPs are stored by the server and injected at runtime.
   for (const [name, entry] of Object.entries(runtimeMap)) {
+    const toolDenies = diagnoseMcpToolDeniesFromConfigs({ projectConfig: config, globalConfig, name });
     items.push({
       name,
       config: entry,
       source: "config.remote",
-      disabledByTools: isMcpDisabledByTools(config, name) || undefined,
+      disabledByTools: toolDenies.length > 0 || undefined,
+      ...(toolDenies.length ? { toolDenies } : {}),
     });
   }
 

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
@@ -27,9 +27,11 @@ describe("OpenWork capabilities knowledge plugin", () => {
     expect(knowledge).toContain("JWTs signed and validated with EdDSA");
     expect(knowledge).toContain("30-day inactivity window");
     expect(knowledge).toContain("reference_id");
+    expect(knowledge).toContain("OpenWork documentation tools answer product questions. Never use them as a substitute for performing an action against ServiceNow, Slack, Notion, Linear, Google Workspace, a marketplace, or another connected service.");
     expect(knowledge).toContain("require the user to sign in to OpenWork first");
-    expect(knowledge).toContain("openwork-cloud_search_capabilities");
-    expect(knowledge).toContain("openwork-cloud_execute_capability");
+    expect(knowledge).toContain("Runtime steering from the OpenWork extensions plugin is the source of truth");
+    expect(knowledge).not.toContain("First call `openwork-cloud_search_capabilities`");
+    expect(knowledge).not.toContain("then call `openwork-cloud_execute_capability`");
     expect(knowledge).toContain("Settings > Connect");
     expect(knowledge).toContain("custom or local MCP server");
     expect(knowledge).not.toContain("Access tokens are opaque");

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -21,7 +21,7 @@ const OPENWORK_CAPABILITIES_KNOWLEDGE = `You are running inside OpenWork, a desk
 
 CRITICAL: To navigate or control the OpenWork app (open settings, add providers, etc.), use the openwork_ui_execute_action tool, NOT browser tools. For example, to open settings: openwork_ui_execute_action({actionId:"settings.panel.open", args:{panel:"general"}}).
 
-For OpenWork product questions, use openwork_docs_search and openwork_docs_read as the first source of truth. Read and summarize relevant docs before answering. Cite the docs path when it helps the user verify or continue. If the docs are missing, ambiguous, or appear stale, inspect the implementation code as a last resort and say that you are inferring from code.
+For OpenWork product questions, use openwork_docs_search and openwork_docs_read as the first source of truth. OpenWork documentation tools answer product questions. Never use them as a substitute for performing an action against ServiceNow, Slack, Notion, Linear, Google Workspace, a marketplace, or another connected service. Read and summarize relevant docs before answering. Cite the docs path when it helps the user verify or continue. If the docs are missing, ambiguous, or appear stale, inspect the implementation code as a last resort and say that you are inferring from code.
 
 Important docs to know:
 - General docs navigation: packages/docs/docs.json
@@ -58,8 +58,8 @@ Here is what you can help users with:
 
 ## Connecting services with OpenWork Connect
 - For Gmail, Google Calendar, Google Drive, Slack, Notion, Linear, and other managed integrations, require the user to sign in to OpenWork first. Direct them to the desktop app's \`Sign in\` button if they are not signed in.
-- Once signed in, use OpenWork Connect as the default path. First call \`openwork-cloud_search_capabilities\` with 2–4 relevant query variants; then call \`openwork-cloud_execute_capability\` using the exact capability name returned by search. Do not claim a service is unavailable before searching.
-- If search returns a \`connection_status\` result, relay its action exactly: members use \`Settings > Connect\`; organization admins use the Connections dashboard; provider-side failures go to the provider's admin console. After the user fixes the connection, search again in the same task.
+- Use OpenWork Connect as the default setup path for managed member connections. Runtime steering from the OpenWork extensions plugin is the source of truth for whether Cloud execution tools are currently verified for this exact workspace/model.
+- If runtime steering says OpenWork Cloud is not ready, do not substitute documentation, browser, or UI tools for the connected-service action; direct the user to \`Settings > Connect\` to repair and test agent access.
 - Never recommend adding a Google Workspace, Gmail, Calendar, Drive, Slack, Notion, or Linear MCP in \`Settings > Extensions\` as the normal setup path. Use \`Settings > Connect\` for a member's managed connection instead.
 - \`Settings > Extensions\` and custom MCP commands/URLs are for a custom or local MCP server that is not available through OpenWork Connect.
 
@@ -81,8 +81,8 @@ Here is what you can help users with:
 - The browser panel is visible on the right side of the session view.
 
 ## Cross-chat Session Memory
-- Two sources of cross-chat memory: (1) the durable Memory Bank — a per-user store the user can explicitly save facts to and recall, reached by discovering a memory capability via search_capabilities and running it via execute_capability (see the "Memory Bank" section of the system prompt); and (2) saved OpenWork session history, exposed through OpenWork UI actions below.
-- To save or recall a durable fact the user wants remembered across sessions, use the Memory Bank capability — never a local file.
+- Two sources of cross-chat memory: (1) the durable Memory Bank — a per-user store the user can explicitly save facts to and recall when runtime steering verifies OpenWork Cloud is ready (see the "Memory Bank" section of the system prompt); and (2) saved OpenWork session history, exposed through OpenWork UI actions below.
+- To save or recall a durable fact the user wants remembered across sessions, use the Memory Bank capability only when runtime steering verifies OpenWork Cloud is ready — never a local file.
 - If the user asks what they said, what happened, or what was decided in another OpenWork session, use the UI control actions: list sessions, open the matching session, then read the transcript.
 - Match sessions by ID, title, workspace, or topic words. Ask a short clarifying question if multiple sessions match.
 - Answer only from the returned transcript. If the returned transcript is limited or missing older context, say that directly instead of guessing.
@@ -102,7 +102,7 @@ Here is what you can help users with:
 - Some skills and MCP servers are managed by OpenWork at runtime (stored server-side and injected into the engine config), so they are not visible as plain workspace files. Do not try to read the OPENCODE_CONFIG file or runtime database directly.
 - To get portable definitions of installed skills and MCP servers — including runtime-managed ones — use the openwork_extensions_export tool. It returns full SKILL.md content and MCP configs with secret header/environment values redacted (listed in redactedKeys).
 - When packaging exported components into a plugin or publishing to a marketplace, never inline secret values; declare the redacted keys as required inputs the installer must provide.
-- To publish to an OpenWork Cloud marketplace, use the OpenWork Cloud MCP (plugins, config-objects, marketplaces resources) with the exported components.
+- To publish to an OpenWork Cloud marketplace, follow the marketplace docs and only use Cloud execution tools when runtime steering verifies they are ready for this workspace/model.
 
 ## Creating Plugins
 - Plugins extend OpenWork/OpenCode with custom tools.

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
@@ -3,24 +3,20 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 import {
   composeOpenWorkExtensionDiscoveryInstruction,
   OPENWORK_CLOUD_CONNECTION_INSTRUCTION,
-  OPENWORK_CONNECT_GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION,
+  OPENWORK_CONNECT_DEGRADED_INSTRUCTION,
+  OPENWORK_CONNECT_DISABLED_INSTRUCTION,
+  OPENWORK_CONNECT_SIGN_IN_INSTRUCTION,
   OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION,
   resetOpenWorkExtensionDiscoveryInstructionCacheForTests,
   resolveOpenWorkExtensionDiscoveryInstruction,
   type OpenWorkExtensionConnectState,
-} from "./openwork-extensions-preview.js";
+} from "./openwork-extensions-preview-steering.js";
 
 const originalServerUrl = process.env.OPENWORK_SERVER_URL;
 const originalServerToken = process.env.OPENWORK_SERVER_TOKEN;
 
 const UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION =
   "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
-
-const CLOUD_CONNECTION_INSTRUCTION =
-  "The OpenWork Cloud connection is active. For email (Gmail), calendar, Google Drive, and org-connected services such as Notion, Linear, Slack, etc., FIRST call openwork-cloud_search_capabilities with 2-4 keyword variants, then call openwork-cloud_execute_capability with an exact returned name. Do not claim these are unavailable without searching. OpenWork extensions (openwork_extension_list_actions / openwork_extension_call) remain available for other local actions such as image generation, but do NOT use them for Google Workspace, and never direct the user to Settings > Extensions for Google Workspace; use Settings > Connect. A successful search proves OpenWork Cloud itself is authorized, so never tell the user to reconnect OpenWork Cloud because a downstream connector failed. If a result has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly: use Your Connections for the member, the organization Connections dashboard for an org admin, or the provider admin console for a provider-side failure. After the requested human fixes that connector, search again in the same task. Do not try browser_* or openwork_ui_* workarounds or repeat the same call unchanged; results are live, not cached, so unchanged retries return the same error.";
-
-const GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION =
-  `${UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION} Google Workspace is not connected on this device; if the user asks for email, calendar, or Google Drive, tell them to connect their account in Settings > Connect (never Settings > Extensions).`;
 
 beforeEach(() => {
   resetOpenWorkExtensionDiscoveryInstructionCacheForTests();
@@ -34,68 +30,120 @@ afterEach(() => {
   else process.env.OPENWORK_SERVER_TOKEN = originalServerToken;
 });
 
+function health(overrides: Partial<NonNullable<OpenWorkExtensionConnectState["cloudHealth"]>> = {}): NonNullable<OpenWorkExtensionConnectState["cloudHealth"]> {
+  return {
+    usable: true,
+    usableByCurrentModel: true,
+    phase: "ready",
+    workspace: { id: "ws_1", directory: "/tmp/ws_1" },
+    desired: { present: true, revision: "rev_ready" },
+    firstFailure: null,
+    ...overrides,
+  };
+}
+
+function state(cloudHealth: OpenWorkExtensionConnectState["cloudHealth"]): OpenWorkExtensionConnectState {
+  return {
+    connectEnabled: true,
+    connectCatalogEnabled: true,
+    cloudMcpPresent: cloudHealth?.usable === true,
+    cloudHealth,
+    workspace: { resolution: "resolved", id: "ws_1", directory: "/tmp/ws_1" },
+    googleWorkspace: { legacyConfigured: false },
+  };
+}
+
 describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
-  test("keeps the fallback instruction byte-identical when state is unavailable", () => {
+  test("keeps the fallback instruction byte-identical when state is unavailable or rollout disabled", () => {
     expect(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
     expect(composeOpenWorkExtensionDiscoveryInstruction(null)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(composeOpenWorkExtensionDiscoveryInstruction({ ...state(health()), connectCatalogEnabled: false })).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
   });
 
-  test("keeps the fallback instruction byte-identical when Connect is disabled", () => {
-    const state: OpenWorkExtensionConnectState = {
-      connectEnabled: false,
-      cloudMcpPresent: true,
-      googleWorkspace: { legacyConfigured: false },
-    };
-
-    expect(composeOpenWorkExtensionDiscoveryInstruction(state)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+  test("keeps fallback when legacy Google Workspace is configured", () => {
+    expect(composeOpenWorkExtensionDiscoveryInstruction({ ...state(health()), googleWorkspace: { legacyConfigured: true } })).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
   });
 
-  test("keeps the fallback instruction byte-identical when legacy Google Workspace is configured", () => {
-    const state: OpenWorkExtensionConnectState = {
-      connectEnabled: true,
-      cloudMcpPresent: true,
-      googleWorkspace: { legacyConfigured: true },
-    };
-
-    expect(composeOpenWorkExtensionDiscoveryInstruction(state)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
-  });
-
-  test("steers active Connect users to openwork-cloud capabilities first", () => {
-    const state: OpenWorkExtensionConnectState = {
-      connectEnabled: true,
-      cloudMcpPresent: true,
-      googleWorkspace: { legacyConfigured: false },
-    };
-
-    expect(OPENWORK_CLOUD_CONNECTION_INSTRUCTION).toBe(CLOUD_CONNECTION_INSTRUCTION);
+  test("steers ready Connect users to verified openwork-cloud capabilities first", () => {
+    expect(OPENWORK_CLOUD_CONNECTION_INSTRUCTION).toContain("verified ready for this exact workspace/model");
+    expect(OPENWORK_CLOUD_CONNECTION_INSTRUCTION).toContain("FIRST call openwork-cloud_search_capabilities");
     expect(OPENWORK_CLOUD_CONNECTION_INSTRUCTION).toContain("relay connectionStatus.action exactly");
-    expect(OPENWORK_CLOUD_CONNECTION_INSTRUCTION).toContain("never tell the user to reconnect OpenWork Cloud");
-    expect(OPENWORK_CLOUD_CONNECTION_INSTRUCTION).toContain("connectionStatus.connectionName");
-    expect(OPENWORK_CLOUD_CONNECTION_INSTRUCTION).toContain("browser_* or openwork_ui_* workarounds");
     expect(OPENWORK_CLOUD_CONNECTION_INSTRUCTION).toContain("results are live, not cached");
-    expect(composeOpenWorkExtensionDiscoveryInstruction(state)).toBe(CLOUD_CONNECTION_INSTRUCTION);
+    expect(composeOpenWorkExtensionDiscoveryInstruction(state(health()))).toBe(OPENWORK_CLOUD_CONNECTION_INSTRUCTION);
   });
 
-  test("steers missing cloud MCP Google Workspace requests to Settings > Connect", () => {
-    const state: OpenWorkExtensionConnectState = {
-      connectEnabled: true,
-      cloudMcpPresent: false,
-      googleWorkspace: { legacyConfigured: false },
-    };
+  test("does not claim Cloud readiness when provider projection is missing", () => {
+    const instruction = composeOpenWorkExtensionDiscoveryInstruction(state(health({
+      usable: true,
+      usableByCurrentModel: false,
+      phase: "provider_projection_missing",
+      firstFailure: {
+        code: "provider_tool_projection_missing",
+        stage: "provider_projection",
+        recommendedAction: "Update OpenWork",
+        message: "missing",
+      },
+    })));
 
-    expect(OPENWORK_CONNECT_GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION).toBe(GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION);
-    expect(composeOpenWorkExtensionDiscoveryInstruction(state)).toBe(GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION);
+    expect(instruction).not.toBe(OPENWORK_CLOUD_CONNECTION_INSTRUCTION);
+    expect(instruction).toContain("Settings → Connect → Repair and test");
+  });
+
+  test("uses degraded, signed-out, and disabled branches", () => {
+    const degraded = composeOpenWorkExtensionDiscoveryInstruction(state(health({
+      usable: false,
+      phase: "cloud_tools_missing",
+      firstFailure: {
+        code: "cloud_tools_missing",
+        stage: "tool_registration",
+        recommendedAction: "Run reconcile",
+        message: "missing",
+      },
+    })));
+    expect(degraded).toContain("Do not use OpenWork documentation tools, browser tools, or OpenWork UI tools as a substitute");
+    expect(degraded).toContain("Settings → Connect → Repair and test");
+    expect(degraded).toContain("cloud_tools_missing");
+
+    expect(composeOpenWorkExtensionDiscoveryInstruction(state(health({
+      usable: false,
+      phase: "missing_desired",
+      desired: { present: false, revision: null },
+      firstFailure: {
+        code: "cloud_mcp_missing",
+        stage: "desired_config",
+        recommendedAction: "Connect OpenWork Cloud",
+        message: "missing",
+      },
+    })))).toBe(OPENWORK_CONNECT_SIGN_IN_INSTRUCTION);
+
+    expect(composeOpenWorkExtensionDiscoveryInstruction(state(health({
+      usable: false,
+      phase: "engine_disabled",
+      firstFailure: {
+        code: "cloud_mcp_disabled",
+        stage: "engine_delivery",
+        recommendedAction: "Enable",
+        message: "disabled",
+      },
+    })))).toBe(OPENWORK_CONNECT_DISABLED_INSTRUCTION);
+  });
+
+  test("treats unknown workspace as degraded instead of borrowing another workspace", () => {
+    const instruction = composeOpenWorkExtensionDiscoveryInstruction({
+      ...state(null),
+      workspace: { resolution: "unknown", id: null, directory: "/tmp/unknown", reason: "No workspace has this exact OpenCode directory" },
+    });
+    expect(instruction).toBe(OPENWORK_CONNECT_DEGRADED_INSTRUCTION);
   });
 });
 
 describe("resolveOpenWorkExtensionDiscoveryInstruction", () => {
-  test("fetches connect state with bearer auth and caches the instruction for 15 seconds", async () => {
+  test("fetches verified health for the current directory/model without caching stale failures", async () => {
     process.env.OPENWORK_SERVER_URL = "http://openwork.test/";
     process.env.OPENWORK_SERVER_TOKEN = "test-token";
-    let now = 1_000;
-    let calls = 0;
     const urls: string[] = [];
     const authorizations: Array<string | null> = [];
+    let calls = 0;
     const fakeFetch = async (url: string, init?: RequestInit): Promise<Response> => {
       calls += 1;
       urls.push(url);
@@ -104,47 +152,68 @@ describe("resolveOpenWorkExtensionDiscoveryInstruction", () => {
         ok: true,
         schemaVersion: 1,
         connectEnabled: true,
-        cloudMcpPresent: true,
+        connectCatalogEnabled: true,
+        cloudMcpPresent: calls > 1,
+        cloudHealth: calls > 1 ? health() : health({
+          usable: false,
+          phase: "cloud_tools_missing",
+          firstFailure: {
+            code: "cloud_tools_missing",
+            stage: "tool_registration",
+            recommendedAction: "Run reconcile",
+            message: "missing",
+          },
+        }),
+        workspace: { resolution: "resolved", id: "ws_1", directory: "/tmp/ws_1" },
         googleWorkspace: { legacyConfigured: false },
       });
     };
 
-    expect(await resolveOpenWorkExtensionDiscoveryInstruction(fakeFetch, () => now)).toBe(CLOUD_CONNECTION_INSTRUCTION);
-    now += 14_999;
-    expect(await resolveOpenWorkExtensionDiscoveryInstruction(fakeFetch, () => now)).toBe(CLOUD_CONNECTION_INSTRUCTION);
-    expect(calls).toBe(1);
-
-    now += 2;
-    expect(await resolveOpenWorkExtensionDiscoveryInstruction(fakeFetch, () => now)).toBe(CLOUD_CONNECTION_INSTRUCTION);
+    const input = {
+      context: { directory: "/tmp/ws_1" },
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
+    };
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction(input, fakeFetch)).toContain("cloud_tools_missing");
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction(input, fakeFetch)).toBe(OPENWORK_CLOUD_CONNECTION_INSTRUCTION);
     expect(calls).toBe(2);
     expect(urls).toEqual([
-      "http://openwork.test/experimental/connect/state",
-      "http://openwork.test/experimental/connect/state",
+      "http://openwork.test/experimental/connect/state?directory=%2Ftmp%2Fws_1&provider=anthropic&model=claude-sonnet-4",
+      "http://openwork.test/experimental/connect/state?directory=%2Ftmp%2Fws_1&provider=anthropic&model=claude-sonnet-4",
     ]);
     expect(authorizations).toEqual(["Bearer test-token", "Bearer test-token"]);
   });
 
-  test("fails open and caches the fallback instruction when fetching throws", async () => {
+  test("passes workspace id and worktree from plugin context", async () => {
     process.env.OPENWORK_SERVER_URL = "http://openwork.test";
     process.env.OPENWORK_SERVER_TOKEN = "test-token";
-    let now = 2_000;
-    let calls = 0;
-    const failingFetch = async (): Promise<Response> => {
-      calls += 1;
-      throw new Error("network unavailable");
+    let requested = "";
+    const fakeFetch = async (url: string): Promise<Response> => {
+      requested = url;
+      return Response.json({
+        ok: true,
+        schemaVersion: 1,
+        connectEnabled: true,
+        connectCatalogEnabled: true,
+        cloudMcpPresent: true,
+        cloudHealth: health(),
+        workspace: { resolution: "resolved", id: "ws_2", directory: "/tmp/worktree" },
+        googleWorkspace: { legacyConfigured: false },
+      });
     };
 
-    expect(await resolveOpenWorkExtensionDiscoveryInstruction(failingFetch, () => now)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
-    now += 1;
-    expect(await resolveOpenWorkExtensionDiscoveryInstruction(failingFetch, () => now)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
-    expect(calls).toBe(1);
+    await resolveOpenWorkExtensionDiscoveryInstruction({ context: { workspaceId: "ws_2", worktree: "/tmp/worktree" } }, fakeFetch);
+    expect(requested).toBe("http://openwork.test/experimental/connect/state?workspaceId=ws_2&directory=%2Ftmp%2Fworktree");
   });
 
-  test("fails open when connect state parsing fails", async () => {
+  test("fails open when connect state fetching or parsing fails", async () => {
     process.env.OPENWORK_SERVER_URL = "http://openwork.test";
     process.env.OPENWORK_SERVER_TOKEN = "test-token";
+    const failingFetch = async (): Promise<Response> => {
+      throw new Error("network unavailable");
+    };
     const invalidFetch = async (): Promise<Response> => Response.json({ ok: true });
 
-    expect(await resolveOpenWorkExtensionDiscoveryInstruction(invalidFetch, () => 3_000)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction({}, failingFetch)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction({}, invalidFetch)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
   });
 });

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
@@ -1,0 +1,260 @@
+import { z } from "zod";
+
+export type OpenCodeContext = {
+  agent?: string;
+  sessionID?: string;
+  messageID?: string;
+  directory?: string;
+  worktree?: string;
+  workspaceId?: string;
+  workspaceID?: string;
+};
+
+export type OpenWorkExtensionConnectState = {
+  connectEnabled: boolean;
+  connectCatalogEnabled: boolean;
+  cloudMcpPresent: boolean;
+  cloudHealth: OpenWorkCloudHealthSummary | null;
+  workspace?: {
+    resolution?: string;
+    id?: string | null;
+    directory?: string | null;
+    reason?: string;
+  };
+  googleWorkspace: {
+    legacyConfigured: boolean;
+  };
+};
+
+export type OpenWorkCloudHealthSummary = {
+  usable: boolean;
+  usableByCurrentModel: boolean | null;
+  phase: string;
+  connectCatalogEnabled?: boolean;
+  workspace: {
+    id: string;
+    directory: string | null;
+  };
+  desired: {
+    present: boolean;
+    revision: string | null;
+  };
+  delivery?: {
+    appliedRevision?: string | null;
+  };
+  firstFailure: {
+    code: string;
+    stage: string;
+    recommendedAction: string;
+    message: string;
+  } | null;
+};
+
+type OpenWorkFetch = (url: string, init?: RequestInit) => Promise<Response>;
+
+type ProviderModel = {
+  provider: string;
+  model: string;
+};
+
+const cloudFailureSchema = z.object({
+  code: z.string(),
+  stage: z.string(),
+  recommendedAction: z.string(),
+  message: z.string(),
+}).passthrough();
+
+const cloudHealthSchema = z.object({
+  usable: z.boolean(),
+  usableByCurrentModel: z.boolean().nullable(),
+  phase: z.string(),
+  connectCatalogEnabled: z.boolean().optional(),
+  workspace: z.object({
+    id: z.string(),
+    directory: z.string().nullable(),
+  }).passthrough(),
+  desired: z.object({
+    present: z.boolean(),
+    revision: z.string().nullable(),
+  }).passthrough(),
+  delivery: z.object({
+    appliedRevision: z.string().nullable().optional(),
+  }).passthrough().optional(),
+  firstFailure: cloudFailureSchema.nullable(),
+}).passthrough();
+
+const connectStateResponseSchema = z.object({
+  ok: z.literal(true),
+  schemaVersion: z.number(),
+  connectEnabled: z.boolean(),
+  connectCatalogEnabled: z.boolean().optional(),
+  cloudMcpPresent: z.boolean(),
+  cloudHealth: cloudHealthSchema.nullable().optional(),
+  workspace: z.object({
+    resolution: z.string().optional(),
+    id: z.string().nullable().optional(),
+    directory: z.string().nullable().optional(),
+    reason: z.string().optional(),
+  }).passthrough().optional(),
+  googleWorkspace: z.object({
+    legacyConfigured: z.boolean(),
+  }).passthrough(),
+}).passthrough();
+
+export const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
+  "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
+
+export const OPENWORK_CLOUD_CONNECTION_INSTRUCTION =
+  "The OpenWork Cloud connection is verified ready for this exact workspace/model. For email (Gmail), calendar, Google Drive, and org-connected services such as Notion, Linear, Slack, etc., FIRST call openwork-cloud_search_capabilities with 2-4 keyword variants, then call openwork-cloud_execute_capability with an exact returned name. Do not claim these are unavailable without searching. OpenWork extensions (openwork_extension_list_actions / openwork_extension_call) remain available for other local actions such as image generation, but do NOT use them for Google Workspace, and never direct the user to Settings > Extensions for Google Workspace; use Settings > Connect. A successful search proves OpenWork Cloud itself is authorized, so never tell the user to reconnect OpenWork Cloud because a downstream connector failed. If a result has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly: use Your Connections for the member, the organization Connections dashboard for an org admin, or the provider admin console for a provider-side failure. After the requested human fixes that connector, search again in the same task. Do not try browser_* or openwork_ui_* workarounds or repeat the same call unchanged; results are live, not cached, so unchanged retries return the same error.";
+
+export const OPENWORK_CONNECT_DEGRADED_INSTRUCTION =
+  `${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION} OpenWork Cloud agent access is not ready for this exact workspace/model. Do not use OpenWork documentation tools, browser tools, or OpenWork UI tools as a substitute for performing an action against a connected service. Direct the user to Settings → Connect → Repair and test.`;
+
+export const OPENWORK_CONNECT_SIGN_IN_INSTRUCTION =
+  `${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION} OpenWork Cloud is not signed in or no desired agent access configuration exists for this workspace. Direct the user to sign in to OpenWork and connect the service in Settings → Connect.`;
+
+export const OPENWORK_CONNECT_DISABLED_INSTRUCTION =
+  `${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION} OpenWork Cloud agent access is explicitly disabled for this workspace. Explain that the user can enable agent access in Settings → Connect, then use Repair and test.`;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function getRecordProperty(value: unknown, key: string): unknown {
+  return isRecord(value) ? value[key] : undefined;
+}
+
+function readNestedString(value: unknown, keys: string[]): string | undefined {
+  let current = value;
+  for (const key of keys) current = getRecordProperty(current, key);
+  return readString(current);
+}
+
+function readContext(input: unknown): OpenCodeContext {
+  const context = getRecordProperty(input, "context");
+  const session = getRecordProperty(input, "session");
+  const directory = readNestedString(input, ["directory"]) ?? readNestedString(context, ["directory"]) ?? readNestedString(session, ["directory"]);
+  const worktree = readNestedString(input, ["worktree"]) ?? readNestedString(context, ["worktree"]) ?? readNestedString(session, ["worktree"]);
+  const workspaceId = readNestedString(input, ["workspaceId"]) ?? readNestedString(input, ["workspaceID"]) ?? readNestedString(context, ["workspaceId"]) ?? readNestedString(context, ["workspaceID"]);
+  return {
+    ...(directory ? { directory } : {}),
+    ...(worktree ? { worktree } : {}),
+    ...(workspaceId ? { workspaceId } : {}),
+  };
+}
+
+function readProviderModel(input: unknown): ProviderModel | undefined {
+  const model = getRecordProperty(input, "model");
+  const provider = readNestedString(model, ["providerID"]) ?? readNestedString(model, ["provider"]) ?? readNestedString(input, ["provider"]);
+  const modelId = readNestedString(model, ["modelID"]) ?? readNestedString(model, ["id"]) ?? readNestedString(input, ["modelID"]);
+  if (provider && modelId) return { provider, model: modelId };
+  const combined = modelId?.includes("/") ? modelId : readNestedString(input, ["model"]) ?? readNestedString(model, ["name"]);
+  if (combined?.includes("/")) {
+    const [providerPart, ...modelParts] = combined.split("/");
+    const joinedModel = modelParts.join("/").trim();
+    if (providerPart?.trim() && joinedModel) return { provider: providerPart.trim(), model: joinedModel };
+  }
+  return undefined;
+}
+
+function serverUrl(): string {
+  return String(process.env.OPENWORK_SERVER_URL || "").replace(/\/$/, "");
+}
+
+function serverToken(): string {
+  return String(process.env.OPENWORK_SERVER_TOKEN || "");
+}
+
+function requireOpenWorkServer(): { url: string; token: string } {
+  const url = serverUrl();
+  const token = serverToken();
+  if (!url || !token) {
+    throw new Error("OpenWork extension tools are only available when OpenCode is launched by OpenWork.");
+  }
+  return { url, token };
+}
+
+async function parseResponse(response: Response): Promise<unknown> {
+  const text = await response.text();
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { message: text };
+  }
+}
+
+function getStringProperty(value: unknown, key: string): string | null {
+  if (!isRecord(value)) return null;
+  const property = value[key];
+  return typeof property === "string" ? property : null;
+}
+
+function errorMessage(payload: unknown, fallback: string): string {
+  return getStringProperty(payload, "message") ?? getStringProperty(payload, "code") ?? fallback;
+}
+
+async function fetchOpenWorkConnectState(input: unknown, fetcher: OpenWorkFetch): Promise<OpenWorkExtensionConnectState> {
+  const { url, token } = requireOpenWorkServer();
+  const context = readContext(input);
+  const providerModel = readProviderModel(input);
+  const query = new URLSearchParams();
+  const workspaceId = context.workspaceId ?? context.workspaceID;
+  const directory = context.worktree ?? context.directory;
+  if (workspaceId) query.set("workspaceId", workspaceId);
+  if (directory) query.set("directory", directory);
+  if (providerModel) {
+    query.set("provider", providerModel.provider);
+    query.set("model", providerModel.model);
+  }
+  const suffix = query.size ? `?${query.toString()}` : "";
+  const response = await fetcher(`${url}/experimental/connect/state${suffix}`, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  const payload = await parseResponse(response);
+  if (!response.ok) throw new Error(errorMessage(payload, "OpenWork connect state request failed"));
+  const parsed = connectStateResponseSchema.parse(payload);
+  return {
+    connectEnabled: parsed.connectEnabled,
+    connectCatalogEnabled: parsed.connectCatalogEnabled ?? parsed.connectEnabled,
+    cloudMcpPresent: parsed.cloudMcpPresent,
+    cloudHealth: parsed.cloudHealth ?? null,
+    ...(parsed.workspace ? { workspace: parsed.workspace } : {}),
+    googleWorkspace: {
+      legacyConfigured: parsed.googleWorkspace.legacyConfigured,
+    },
+  };
+}
+
+function degradedInstruction(health: OpenWorkCloudHealthSummary | null): string {
+  if (!health?.firstFailure) return OPENWORK_CONNECT_DEGRADED_INSTRUCTION;
+  return `${OPENWORK_CONNECT_DEGRADED_INSTRUCTION} Current verified health: ${health.firstFailure.code}; ${health.firstFailure.recommendedAction}.`;
+}
+
+export function composeOpenWorkExtensionDiscoveryInstruction(state: OpenWorkExtensionConnectState | null): string {
+  if (!state || !state.connectCatalogEnabled || state.googleWorkspace.legacyConfigured) {
+    return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
+  }
+  if (state.workspace?.resolution && state.workspace.resolution !== "resolved") return degradedInstruction(null);
+  const health = state.cloudHealth;
+  if (health?.usable === true && health.usableByCurrentModel !== false) return OPENWORK_CLOUD_CONNECTION_INSTRUCTION;
+  if (health?.phase === "engine_disabled" || health?.firstFailure?.code === "cloud_mcp_disabled") return OPENWORK_CONNECT_DISABLED_INSTRUCTION;
+  if (!health || !health.desired.present || health.firstFailure?.code === "cloud_mcp_missing") return OPENWORK_CONNECT_SIGN_IN_INSTRUCTION;
+  return degradedInstruction(health);
+}
+
+export function resetOpenWorkExtensionDiscoveryInstructionCacheForTests(): void {
+  // Retained for older tests; steering is deliberately uncached so repair is observed immediately.
+}
+
+export async function resolveOpenWorkExtensionDiscoveryInstruction(input?: unknown, fetcher: OpenWorkFetch = fetch): Promise<string> {
+  try {
+    return composeOpenWorkExtensionDiscoveryInstruction(await fetchOpenWorkConnectState(input, fetcher));
+  } catch {
+    return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
+  }
+}

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { z } from "zod";
 
 import { OpenWorkExtensionsPreview } from "./openwork-extensions-preview.js";
+import * as OpenWorkExtensionsPreviewEntry from "./openwork-extensions-preview.js";
 
 const originalServerUrl = process.env.OPENWORK_SERVER_URL;
 const originalServerToken = process.env.OPENWORK_SERVER_TOKEN;
@@ -71,6 +72,26 @@ function startFakeOpenWorkServer() {
         return Response.json({ message: "Unauthorized" }, { status: 401 });
       }
 
+      if (url.pathname === "/experimental/connect/state") {
+        return Response.json({
+          ok: true,
+          schemaVersion: 1,
+          connectEnabled: true,
+          connectCatalogEnabled: true,
+          cloudMcpPresent: true,
+          cloudHealth: {
+            usable: true,
+            usableByCurrentModel: true,
+            phase: "ready",
+            workspace: { id: "ws_2", directory: "/tmp/archive" },
+            desired: { present: true, revision: "rev_ready" },
+            firstFailure: null,
+          },
+          workspace: { resolution: "resolved", id: "ws_2", directory: "/tmp/archive" },
+          googleWorkspace: { legacyConfigured: false },
+        });
+      }
+
       if (url.pathname === "/workspaces") {
         return Response.json({ items: [workspaceOne, workspaceTwo], workspaces: [workspaceOne, workspaceTwo] });
       }
@@ -128,6 +149,10 @@ function startFakeOpenWorkServer() {
 }
 
 describe("OpenWorkExtensionsPreview session tools", () => {
+  test("plugin entry exposes only the factory export for the OpenCode loader", () => {
+    expect(Object.keys(OpenWorkExtensionsPreviewEntry)).toEqual(["OpenWorkExtensionsPreview"]);
+  });
+
   test("searches past chat transcript text and prefers the user's matching message", async () => {
     const fake = startFakeOpenWorkServer();
     const plugin = await OpenWorkExtensionsPreview();
@@ -148,6 +173,21 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     });
     expect(parsed.results[0]?.snippet.match.toLowerCase()).toBe("raven launch");
     expect(fake.requests.some((request) => request.pathname === "/workspace/ws_1/sessions/ses_alpha/messages" && request.search === "?limit=400")).toBe(true);
+  });
+
+  test("merges factory directory into transform steering when hook input omits it", async () => {
+    const fake = startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview({ directory: "/tmp/archive" });
+    const output: { system: string[] } = { system: [] };
+
+    await plugin["experimental.chat.system.transform"]({
+      context: { sessionID: "ses_factory" },
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
+    }, output);
+
+    const connectStateRequest = fake.requests.find((request) => request.pathname === "/experimental/connect/state");
+    expect(connectStateRequest?.search).toBe("?directory=%2Ftmp%2Farchive&provider=anthropic&model=claude-sonnet-4");
+    expect(output.system.join("\n")).toContain("verified ready for this exact workspace/model");
   });
 
   test("reads a transcript by session id without opening the UI", async () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -2,14 +2,11 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir, platform } from "node:os";
 import { z } from "zod";
-
-type OpenCodeContext = {
-  agent?: string;
-  sessionID?: string;
-  messageID?: string;
-  directory?: string;
-  worktree?: string;
-};
+import {
+  OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION,
+  resolveOpenWorkExtensionDiscoveryInstruction,
+  type OpenCodeContext,
+} from "./openwork-extensions-preview-steering.js";
 
 type ExtensionActionPayload = {
   extensionId: string;
@@ -112,77 +109,6 @@ const sessionMessagesEnvelopeSchema = z.object({
   items: z.array(sessionMessageSchema),
 }).passthrough();
 
-const connectStateResponseSchema = z.object({
-  ok: z.literal(true),
-  schemaVersion: z.number(),
-  connectEnabled: z.boolean(),
-  cloudMcpPresent: z.boolean(),
-  googleWorkspace: z.object({
-    legacyConfigured: z.boolean(),
-  }).passthrough(),
-}).passthrough();
-
-export type OpenWorkExtensionConnectState = {
-  connectEnabled: boolean;
-  cloudMcpPresent: boolean;
-  googleWorkspace: {
-    legacyConfigured: boolean;
-  };
-};
-
-export const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
-  "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
-
-export const OPENWORK_CLOUD_CONNECTION_INSTRUCTION =
-  "The OpenWork Cloud connection is active. For email (Gmail), calendar, Google Drive, and org-connected services such as Notion, Linear, Slack, etc., FIRST call openwork-cloud_search_capabilities with 2-4 keyword variants, then call openwork-cloud_execute_capability with an exact returned name. Do not claim these are unavailable without searching. OpenWork extensions (openwork_extension_list_actions / openwork_extension_call) remain available for other local actions such as image generation, but do NOT use them for Google Workspace, and never direct the user to Settings > Extensions for Google Workspace; use Settings > Connect. A successful search proves OpenWork Cloud itself is authorized, so never tell the user to reconnect OpenWork Cloud because a downstream connector failed. If a result has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly: use Your Connections for the member, the organization Connections dashboard for an org admin, or the provider admin console for a provider-side failure. After the requested human fixes that connector, search again in the same task. Do not try browser_* or openwork_ui_* workarounds or repeat the same call unchanged; results are live, not cached, so unchanged retries return the same error.";
-
-export const OPENWORK_CONNECT_GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION =
-  `${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION} Google Workspace is not connected on this device; if the user asks for email, calendar, or Google Drive, tell them to connect their account in Settings > Connect (never Settings > Extensions).`;
-
-const CONNECT_STATE_CACHE_MS = 15_000;
-
-type OpenWorkFetch = (url: string, init?: RequestInit) => Promise<Response>;
-type Clock = () => number;
-type CachedOpenWorkExtensionDiscoveryInstruction = {
-  at: number;
-  instruction: string;
-};
-
-let cachedOpenWorkExtensionDiscoveryInstruction: CachedOpenWorkExtensionDiscoveryInstruction | null = null;
-
-export function composeOpenWorkExtensionDiscoveryInstruction(state: OpenWorkExtensionConnectState | null): string {
-  if (!state || !state.connectEnabled || state.googleWorkspace.legacyConfigured) {
-    return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
-  }
-  return state.cloudMcpPresent
-    ? OPENWORK_CLOUD_CONNECTION_INSTRUCTION
-    : OPENWORK_CONNECT_GOOGLE_WORKSPACE_DISCONNECTED_INSTRUCTION;
-}
-
-export function resetOpenWorkExtensionDiscoveryInstructionCacheForTests(): void {
-  cachedOpenWorkExtensionDiscoveryInstruction = null;
-}
-
-export async function resolveOpenWorkExtensionDiscoveryInstruction(fetcher: OpenWorkFetch = fetch, now: Clock = Date.now): Promise<string> {
-  const currentTime = now();
-  if (
-    cachedOpenWorkExtensionDiscoveryInstruction &&
-    currentTime - cachedOpenWorkExtensionDiscoveryInstruction.at < CONNECT_STATE_CACHE_MS
-  ) {
-    return cachedOpenWorkExtensionDiscoveryInstruction.instruction;
-  }
-
-  let instruction = OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
-  try {
-    instruction = composeOpenWorkExtensionDiscoveryInstruction(await fetchOpenWorkConnectState(fetcher));
-  } catch {
-    instruction = OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
-  }
-
-  cachedOpenWorkExtensionDiscoveryInstruction = { at: currentTime, instruction };
-  return instruction;
-}
-
 const OPENWORK_UI_CONTROL_INSTRUCTION =
   `IMPORTANT: You are running inside the OpenWork desktop app. When the user asks you to open settings, navigate the app, add providers, or control the OpenWork UI in any way, ALWAYS use the openwork_ui_* tools — NOT the browser_* tools. The browser tools are for external websites only. The openwork_ui_* tools control the app directly and are instant (one tool call).
 
@@ -229,6 +155,49 @@ type SessionSearchResult = {
   messageId?: string;
   messageIndex?: number;
 };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalStringProperty(value: unknown, key: string): string | undefined {
+  if (!isRecord(value)) return undefined;
+  const property = value[key];
+  return typeof property === "string" && property.trim().length > 0 ? property : undefined;
+}
+
+function normalizeOpenCodeContext(value: unknown): OpenCodeContext {
+  const nested = isRecord(value) && isRecord(value.context) ? value.context : value;
+  const agent = optionalStringProperty(nested, "agent");
+  const sessionID = optionalStringProperty(nested, "sessionID");
+  const messageID = optionalStringProperty(nested, "messageID");
+  const directory = optionalStringProperty(nested, "directory");
+  const worktree = optionalStringProperty(nested, "worktree");
+  const workspaceId = optionalStringProperty(nested, "workspaceId");
+  const workspaceID = optionalStringProperty(nested, "workspaceID");
+  return {
+    ...(agent ? { agent } : {}),
+    ...(sessionID ? { sessionID } : {}),
+    ...(messageID ? { messageID } : {}),
+    ...(directory ? { directory } : {}),
+    ...(worktree ? { worktree } : {}),
+    ...(workspaceId ? { workspaceId } : {}),
+    ...(workspaceID ? { workspaceID } : {}),
+  };
+}
+
+function mergeTransformInputWithFactoryContext(input: unknown, factoryContext: OpenCodeContext): unknown {
+  if (Object.keys(factoryContext).length === 0) return input;
+  const inputRecord = isRecord(input) ? input : {};
+  const inputContext = isRecord(inputRecord.context) ? inputRecord.context : {};
+  return {
+    ...inputRecord,
+    context: {
+      ...factoryContext,
+      ...inputContext,
+    },
+  };
+}
 
 const SESSION_SEARCH_DEFAULT_LIMIT = 10;
 const SESSION_SEARCH_DEFAULT_SCAN_LIMIT = 100;
@@ -309,23 +278,6 @@ async function serverGet(path: string): Promise<unknown> {
   const payload = await parseResponse(response);
   if (!response.ok) throw new Error(errorMessage(payload, "OpenWork server request failed"));
   return payload;
-}
-
-async function fetchOpenWorkConnectState(fetcher: OpenWorkFetch): Promise<OpenWorkExtensionConnectState> {
-  const { url, token } = requireOpenWorkServer();
-  const response = await fetcher(`${url}/experimental/connect/state`, {
-    headers: { Authorization: `Bearer ${token}` },
-  });
-  const payload = await parseResponse(response);
-  if (!response.ok) throw new Error(errorMessage(payload, "OpenWork connect state request failed"));
-  const parsed = connectStateResponseSchema.parse(payload);
-  return {
-    connectEnabled: parsed.connectEnabled,
-    cloudMcpPresent: parsed.cloudMcpPresent,
-    googleWorkspace: {
-      legacyConfigured: parsed.googleWorkspace.legacyConfigured,
-    },
-  };
 }
 
 function collapseWhitespace(value: string): string {
@@ -689,16 +641,18 @@ function contextPayload(context: OpenCodeContext) {
     agent: context.agent,
     sessionId: context.sessionID,
     messageId: context.messageID,
+    workspaceId: context.workspaceId ?? context.workspaceID,
     directory: context.directory,
     worktree: context.worktree,
   };
 }
 
-export const OpenWorkExtensionsPreview = async () => {
+export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
   const uiControlEnabled = uiControlToolsEnabled();
+  const factoryContext = normalizeOpenCodeContext(factoryInput);
   return {
-  "experimental.chat.system.transform": async (_input: unknown, output: { system: string[] }) => {
-    output.system.push(await resolveOpenWorkExtensionDiscoveryInstruction());
+  "experimental.chat.system.transform": async (input: unknown, output: { system: string[] }) => {
+    output.system.push(await resolveOpenWorkExtensionDiscoveryInstruction(mergeTransformInputWithFactoryContext(input, factoryContext)));
     output.system.push(OPENWORK_SESSION_MEMORY_INSTRUCTION);
     output.system.push(OPENWORK_BROWSER_INSTRUCTION);
     if (uiControlEnabled) output.system.push(OPENWORK_UI_CONTROL_INSTRUCTION);

--- a/apps/server/src/routes/cloud-mcp.ts
+++ b/apps/server/src/routes/cloud-mcp.ts
@@ -1,0 +1,123 @@
+import type { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+import {
+  OPENWORK_CLOUD_MCP_NAME,
+  readOpenworkCloudMcpHealth,
+  reconcileOpenworkCloudMcp,
+  type CloudMcpServerMetadata,
+  type CloudMcpProviderModelContext,
+  type CloudMcpRuntimeRegistrar,
+} from "../cloud-mcp-health.js";
+import { ApiError } from "../errors.js";
+import type { ServerConfig, TokenScope, WorkspaceInfo } from "../types.js";
+import { addRoute, type RequestContext, type Route } from "./registry.js";
+
+type JsonResponse = (data: unknown, status?: number) => Response;
+type ReadJsonBody = (request: Request) => Promise<Record<string, unknown>>;
+type WorkspaceOpencodeClient = ReturnType<typeof createOpencodeClient>;
+
+export type RegisterCloudMcpRoutesOptions = {
+  routes: Route[];
+  config: ServerConfig;
+  jsonResponse: JsonResponse;
+  readJsonBody: ReadJsonBody;
+  ensureWritable: (config: ServerConfig) => void;
+  requireClientScope: (ctx: RequestContext, required: TokenScope) => void;
+  resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
+  resolveOpencodeDirectory: (workspace: WorkspaceInfo) => string | null;
+  createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
+  registerRuntimeMcp: CloudMcpRuntimeRegistrar;
+  serverMetadata?: CloudMcpServerMetadata;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function providerModelFromValues(provider: unknown, model: unknown): CloudMcpProviderModelContext | undefined {
+  const providerValue = typeof provider === "string" ? provider.trim() : "";
+  const modelValue = typeof model === "string" ? model.trim() : "";
+  if (!providerValue && !modelValue) return undefined;
+  if (!providerValue || !modelValue) {
+    throw new ApiError(400, "invalid_payload", "provider and model must be supplied together");
+  }
+  return { provider: providerValue, model: modelValue };
+}
+
+function providerModelFromQuery(url: URL): CloudMcpProviderModelContext | undefined {
+  return providerModelFromValues(url.searchParams.get("provider"), url.searchParams.get("model"));
+}
+
+function providerModelFromBody(body: Record<string, unknown>): CloudMcpProviderModelContext | undefined {
+  const direct = providerModelFromValues(body.provider, body.model);
+  if (direct) return direct;
+  if (!isRecord(body.context)) return undefined;
+  return providerModelFromValues(body.context.provider, body.context.model);
+}
+
+function assertExactWorkspace(requestedId: string, workspace: WorkspaceInfo): void {
+  if (requestedId.trim() !== workspace.id) {
+    throw new ApiError(404, "workspace_not_found", "Workspace not found");
+  }
+}
+
+function assertStrictBody(body: Record<string, unknown>, workspace: WorkspaceInfo): void {
+  if (typeof body.workspaceId === "string" && body.workspaceId.trim() !== workspace.id) {
+    throw new ApiError(400, "workspace_id_mismatch", "workspaceId must match the route workspace");
+  }
+  if (typeof body.name === "string" && body.name.trim() !== OPENWORK_CLOUD_MCP_NAME) {
+    throw new ApiError(400, "invalid_mcp_name", "Only openwork-cloud can be reconciled by this endpoint");
+  }
+}
+
+export function registerCloudMcpRoutes(options: RegisterCloudMcpRoutesOptions): void {
+  const {
+    routes,
+    config,
+    jsonResponse,
+    readJsonBody,
+    ensureWritable,
+    requireClientScope,
+    resolveWorkspace,
+    resolveOpencodeDirectory,
+    createWorkspaceOpencodeClient,
+    registerRuntimeMcp,
+    serverMetadata,
+  } = options;
+
+  addRoute(routes, "GET", "/workspace/:id/mcp/openwork-cloud/health", "client", async (ctx) => {
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    assertExactWorkspace(ctx.params.id, workspace);
+    const health = await readOpenworkCloudMcpHealth({
+      config,
+      workspace,
+      directory: resolveOpencodeDirectory(workspace),
+      providerModel: providerModelFromQuery(ctx.url),
+      serverMetadata,
+      createWorkspaceOpencodeClient,
+    });
+    return jsonResponse(health);
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/mcp/openwork-cloud/reconcile", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    assertExactWorkspace(ctx.params.id, workspace);
+    const body = await readJsonBody(ctx.request);
+    if (!isRecord(body)) {
+      throw new ApiError(400, "invalid_payload", "JSON object body is required");
+    }
+    assertStrictBody(body, workspace);
+    const health = await reconcileOpenworkCloudMcp({
+      config,
+      workspace,
+      directory: resolveOpencodeDirectory(workspace),
+      body,
+      providerModel: providerModelFromBody(body),
+      serverMetadata,
+      createWorkspaceOpencodeClient,
+      registerRuntimeMcp,
+    });
+    return jsonResponse(health);
+  });
+}

--- a/apps/server/src/routes/core.ts
+++ b/apps/server/src/routes/core.ts
@@ -1,6 +1,8 @@
 import { appendFile, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
+import type { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import {
+  type ConnectSnapshotOptions,
   getConnectSnapshot,
   googleWorkspaceStatusConnectExtra,
   writeConnectState,
@@ -34,6 +36,7 @@ type JsonResponse = (data: unknown, status?: number) => Response;
 type ReadJsonBody = (request: Request) => Promise<Record<string, unknown>>;
 type ParseOptionalBoolean = (value: string | null, name: string) => boolean | undefined;
 type FetchRuntimeControl = (path: string, init?: { method?: string; body?: unknown }) => Promise<unknown>;
+type WorkspaceOpencodeClient = ReturnType<typeof createOpencodeClient>;
 
 interface RegisterCoreRoutesOptions {
   routes: Route[];
@@ -50,6 +53,8 @@ interface RegisterCoreRoutesOptions {
   buildCapabilities: (config: ServerConfig) => Capabilities;
   fetchRuntimeControl: FetchRuntimeControl;
   resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
+  resolveOpencodeDirectory: (workspace: WorkspaceInfo) => string | null;
+  createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   serializeWorkspace: (workspace: ServerConfig["workspaces"][number]) => unknown;
   resolveToyUiEnabled: () => boolean;
   resolveDevLogPath: () => string | null;
@@ -58,6 +63,35 @@ interface RegisterCoreRoutesOptions {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalTrimmedString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function providerModelFromValues(provider: unknown, model: unknown): ConnectSnapshotOptions["providerModel"] {
+  const providerValue = optionalTrimmedString(provider);
+  const modelValue = optionalTrimmedString(model);
+  if (!providerValue && !modelValue) return undefined;
+  if (!providerValue || !modelValue) return undefined;
+  return { provider: providerValue, model: modelValue };
+}
+
+function connectSnapshotOptionsFromQuery(url: URL): ConnectSnapshotOptions {
+  return {
+    workspaceId: optionalTrimmedString(url.searchParams.get("workspaceId")) ?? optionalTrimmedString(url.searchParams.get("workspace")),
+    directory: optionalTrimmedString(url.searchParams.get("directory")) ?? optionalTrimmedString(url.searchParams.get("worktree")),
+    providerModel: providerModelFromValues(url.searchParams.get("provider"), url.searchParams.get("model")),
+  };
+}
+
+function connectSnapshotOptionsFromBody(body: Record<string, unknown>): ConnectSnapshotOptions {
+  const context = isRecord(body.context) ? body.context : {};
+  return {
+    workspaceId: optionalTrimmedString(context.workspaceId) ?? optionalTrimmedString(context.workspaceID) ?? optionalTrimmedString(body.workspaceId),
+    directory: optionalTrimmedString(context.worktree) ?? optionalTrimmedString(context.directory) ?? optionalTrimmedString(body.directory),
+    providerModel: providerModelFromValues(context.provider, context.model) ?? providerModelFromValues(body.provider, body.model),
+  };
 }
 
 export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
@@ -76,6 +110,8 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
     buildCapabilities,
     fetchRuntimeControl,
     resolveWorkspace,
+    resolveOpencodeDirectory,
+    createWorkspaceOpencodeClient,
     serializeWorkspace,
     resolveToyUiEnabled,
     resolveDevLogPath,
@@ -83,6 +119,12 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
   } = options;
   const googleWorkspaceConnectFlows = createGoogleWorkspaceConnectFlowManager(config);
   const envPendingChangesByRuntime = new Map<string, boolean>();
+
+  const connectSnapshotBaseOptions = {
+    resolveOpencodeDirectory,
+    createWorkspaceOpencodeClient,
+    serverMetadata: { serverVersion, expectedOpencodeVersion: opencodeVersion },
+  };
 
   const healthResponse = () => jsonResponse({
     ok: true,
@@ -268,8 +310,12 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
     return jsonResponse(buildCapabilities(config));
   });
 
-  addRoute(routes, "GET", "/experimental/connect/state", "client", async () => {
-    return jsonResponse({ ok: true, schemaVersion: 1, ...(await getConnectSnapshot(config)) });
+  addRoute(routes, "GET", "/experimental/connect/state", "client", async (ctx) => {
+    return jsonResponse({
+      ok: true,
+      schemaVersion: 1,
+      ...(await getConnectSnapshot(config, { ...connectSnapshotBaseOptions, ...connectSnapshotOptionsFromQuery(ctx.url) })),
+    });
   });
 
   addRoute(routes, "PUT", "/experimental/connect/state", "host", async (ctx) => {
@@ -279,12 +325,12 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
       throw new ApiError(400, "invalid_payload", "connectEnabled must be a boolean");
     }
     await writeConnectState(config, { connectEnabled: body.connectEnabled });
-    return jsonResponse({ ok: true, schemaVersion: 1, ...(await getConnectSnapshot(config)) });
+    return jsonResponse({ ok: true, schemaVersion: 1, ...(await getConnectSnapshot(config, connectSnapshotBaseOptions)) });
   });
 
   addRoute(routes, "GET", "/experimental/extensions/actions", "client", async (ctx) => {
     const extensionId = ctx.url.searchParams.get("extensionId") ?? "";
-    const connectSnapshot = await getConnectSnapshot(config);
+    const connectSnapshot = await getConnectSnapshot(config, { ...connectSnapshotBaseOptions, ...connectSnapshotOptionsFromQuery(ctx.url) });
     return jsonResponse({
       ok: true,
       schemaVersion: 1,
@@ -297,11 +343,11 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
       throw new ApiError(403, "forbidden", "Viewer tokens cannot call extension actions");
     }
     const body = await readJsonBody(ctx.request);
-    return jsonResponse(await callExperimentalExtensionAction(config, env, body, await getConnectSnapshot(config)));
+    return jsonResponse(await callExperimentalExtensionAction(config, env, body, await getConnectSnapshot(config, { ...connectSnapshotBaseOptions, ...connectSnapshotOptionsFromBody(body) })));
   });
 
-  addRoute(routes, "GET", "/experimental/google-workspace/status", "client", async () => {
-    const connectSnapshot = await getConnectSnapshot(config);
+  addRoute(routes, "GET", "/experimental/google-workspace/status", "client", async (ctx) => {
+    const connectSnapshot = await getConnectSnapshot(config, { ...connectSnapshotBaseOptions, ...connectSnapshotOptionsFromQuery(ctx.url) });
     return jsonResponse(await googleWorkspaceStatus(config, googleWorkspaceStatusConnectExtra(connectSnapshot)));
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -8,6 +8,7 @@ import { ApprovalService } from "./approvals.js";
 import { addPlugin, listPlugins, normalizePluginSpec, removePlugin } from "./plugins.js";
 import { sanitizePortableOpencodeConfig } from "./portable-opencode.js";
 import { addMcp, listMcp, removeMcp, setMcpEnabled } from "./mcp.js";
+import { sanitizeDiagnosticString, sanitizeDiagnosticValue } from "./diagnostic-sanitizer.js";
 import { exportExtensions } from "./extensions-export.js";
 import { deleteSkill, listSkills, upsertSkill } from "./skills.js";
 import { installHubSkill, listHubSkills } from "./skill-hub.js";
@@ -62,6 +63,8 @@ import { registerOperationRoutes } from "./routes/operations.js";
 import { addRoute, matchRoute, type AuthMode, type RequestContext, type Route } from "./routes/registry.js";
 import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
+import { registerCloudMcpRoutes } from "./routes/cloud-mcp.js";
+import { markOpenworkCloudMcpStale, reconcilePersistedOpenworkCloudMcp } from "./cloud-mcp-health.js";
 import {
   mergeOpencodeConfigs,
   mergeRuntimeProviderUpdate,
@@ -1320,6 +1323,8 @@ function createRoutes(
     buildCapabilities,
     fetchRuntimeControl,
     resolveWorkspace,
+    resolveOpencodeDirectory,
+    createWorkspaceOpencodeClient,
     serializeWorkspace,
     resolveToyUiEnabled,
     resolveDevLogPath,
@@ -1353,6 +1358,20 @@ function createRoutes(
     resolveWorkspace,
     createWorkspaceOpencodeClient,
     unwrapOpencodeResult,
+  });
+
+  registerCloudMcpRoutes({
+    routes,
+    config,
+    jsonResponse,
+    readJsonBody,
+    ensureWritable,
+    requireClientScope,
+    resolveWorkspace,
+    resolveOpencodeDirectory,
+    createWorkspaceOpencodeClient,
+    registerRuntimeMcp: syncRuntimeMcpToOpencodeEngine,
+    serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
   });
 
   addRoute(routes, "GET", "/workspace/:id/config", "client", async (ctx) => {
@@ -2861,11 +2880,21 @@ async function reloadOpencodeEngine(config: ServerConfig, workspace: WorkspaceIn
     });
   }
 
+  markOpenworkCloudMcpStale(workspace, directory);
   // Re-register runtime-DB MCPs: dispose rebuilds engine state from disk
   // configs (including the server-managed runtime config file for the
   // primary workspace), but other workspaces' runtime MCPs only reach the
   // engine through this dynamic push.
   await syncRuntimeMcpToOpencodeEngine(config, workspace).catch(() => undefined);
+  await reconcilePersistedOpenworkCloudMcp({
+    config,
+    workspace,
+    directory,
+    serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
+    createWorkspaceOpencodeClient,
+    registerRuntimeMcp: syncRuntimeMcpToOpencodeEngine,
+    trigger: "engine_reload",
+  }).catch(() => undefined);
 }
 
 // Push runtime-DB MCP entries into the running OpenCode engine via its dynamic
@@ -2877,16 +2906,17 @@ async function syncRuntimeMcpToOpencodeEngine(
   config: ServerConfig,
   workspace: WorkspaceInfo,
   onlyNames?: string[],
-): Promise<void> {
+  options?: { throwOnFailure?: boolean },
+): Promise<EngineMcpSyncResult> {
   const connection = resolveWorkspaceOpencodeConnection(config, workspace);
   const baseUrl = connection.baseUrl?.trim() ?? "";
-  if (!baseUrl) return;
+  if (!baseUrl) return { status: "skipped", syncedNames: [], failures: [] };
 
   const runtimeConfig = await readRuntimeOpencodeConfig(config, workspace.id);
   const entries = Object.entries(runtimeMcpMap(runtimeConfig)).filter(
     ([name]) => !onlyNames || onlyNames.includes(name),
   );
-  if (entries.length === 0) return;
+  if (entries.length === 0) return { status: "skipped", syncedNames: [], failures: [] };
 
   const url = new URL(baseUrl);
   url.pathname = "/mcp";
@@ -2919,10 +2949,18 @@ async function syncRuntimeMcpToOpencodeEngine(
       "workspace.id": workspace.id,
       "mcp.failed": names,
     });
-    throw new ApiError(502, "opencode_mcp_sync_failed", `Failed to register MCPs with the engine: ${names}`, {
-      failures,
-    });
+    if (options?.throwOnFailure !== false) {
+      throw new ApiError(502, "opencode_mcp_sync_failed", `Failed to register MCPs with the engine: ${names}`, {
+        failures,
+      });
+    }
   }
+
+  return {
+    status: failures.length > 0 ? "failed" : "ok",
+    syncedNames: entries.map(([name]) => name),
+    failures,
+  };
 }
 
 // POST one MCP entry to the engine, retrying once on 5xx/network errors
@@ -2945,10 +2983,10 @@ async function postMcpEntryWithRetry(
         signal: AbortSignal.timeout(15_000),
       });
       if (response.ok) return null;
-      failure = { name, status: response.status, body: parseOpencodeErrorBody(await response.text()) };
+      failure = { name, status: response.status, body: sanitizeDiagnosticValue(parseOpencodeErrorBody(await response.text())) };
       if (response.status < 500) return failure;
     } catch (error) {
-      failure = { name, message: error instanceof Error ? error.message : String(error) };
+      failure = { name, message: sanitizeDiagnosticString(error instanceof Error ? error.message : String(error)) };
     }
   }
   return failure;
@@ -2961,6 +2999,7 @@ function engineMcpSyncRetryDelayMs(): number {
 }
 
 export type EngineMcpSyncFailure = { name: string; status?: number; body?: unknown; message?: string };
+export type EngineMcpSyncResult = { status: "ok" | "failed" | "skipped"; syncedNames: string[]; failures: EngineMcpSyncFailure[] };
 export type EngineMcpSyncState = { status: "ok" | "failed"; at: number; failures: EngineMcpSyncFailure[] };
 
 // Last engine sync outcome per workspace, surfaced on GET /workspace/:id/mcp
@@ -2997,6 +3036,15 @@ export function engineMcpSyncState(workspaceId: string): EngineMcpSyncState | nu
 export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig): Promise<void> {
   for (const workspace of config.workspaces) {
     await syncRuntimeMcpToOpencodeEngine(config, workspace).catch(() => undefined);
+    await reconcilePersistedOpenworkCloudMcp({
+      config,
+      workspace,
+      directory: resolveOpencodeDirectory(workspace),
+      serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
+      createWorkspaceOpencodeClient,
+      registerRuntimeMcp: syncRuntimeMcpToOpencodeEngine,
+      trigger: "startup",
+    }).catch(() => undefined);
   }
 }
 

--- a/apps/server/src/types.ts
+++ b/apps/server/src/types.ts
@@ -179,6 +179,12 @@ export interface McpItem {
   config: Record<string, unknown>;
   source: "config.project" | "config.global" | "config.remote";
   disabledByTools?: boolean;
+  toolDenies?: Array<{
+    source: "config.project" | "config.global";
+    style: "tools.deny" | "tools" | "permission" | "permissions";
+    pattern: string;
+    matched: string;
+  }>;
 }
 
 export interface SkillItem {

--- a/evals/flows/cloud-mcp-reliability.flow.mjs
+++ b/evals/flows/cloud-mcp-reliability.flow.mjs
@@ -292,6 +292,22 @@ async function waitForControl(ctx) {
   await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 90_000, label: "control API" });
 }
 
+async function runSetupStage(ctx, stage, operation) {
+  ctx.log(`Cloud reliability setup stage started: ${stage}`);
+  try {
+    const result = await operation();
+    ctx.log(`Cloud reliability setup stage succeeded: ${stage}`);
+    return result;
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    const wrapped = new Error(`Cloud reliability setup failed during ${stage}: ${message}`);
+    if (error instanceof Error && error.stack) {
+      wrapped.stack = `${wrapped.message}\nOriginal stack:\n${error.stack}`;
+    }
+    throw wrapped;
+  }
+}
+
 async function configureDesktopForDen(ctx) {
   const baseUrl = denDesktopWebBase(ctx);
   const apiBaseUrl = denDesktopApiBase(ctx);
@@ -705,15 +721,15 @@ function assertNoSecretText(ctx, text, secrets) {
 }
 
 async function setupProof(ctx) {
-  await setViewport(ctx);
-  await waitForControl(ctx);
-  await configureDesktopForDen(ctx);
-  await signInWithFreshHandoff(ctx);
-  await createFreshWorkspace(ctx);
-  await ensureUsableModel(ctx);
-  await createFixtureConnection(ctx);
-  await initialStrictReconcile(ctx);
-  await deleteCloudRuntimeConfig(ctx);
+  await runSetupStage(ctx, "setViewport", () => setViewport(ctx));
+  await runSetupStage(ctx, "control wait", () => waitForControl(ctx));
+  await runSetupStage(ctx, "bootstrap", () => configureDesktopForDen(ctx));
+  await runSetupStage(ctx, "handoff", () => signInWithFreshHandoff(ctx));
+  await runSetupStage(ctx, "create workspace", () => createFreshWorkspace(ctx));
+  await runSetupStage(ctx, "model", () => ensureUsableModel(ctx));
+  await runSetupStage(ctx, "fixture", () => createFixtureConnection(ctx));
+  await runSetupStage(ctx, "reconcile", () => initialStrictReconcile(ctx));
+  await runSetupStage(ctx, "degradation", () => deleteCloudRuntimeConfig(ctx));
 }
 
 export default {

--- a/evals/flows/cloud-mcp-reliability.flow.mjs
+++ b/evals/flows/cloud-mcp-reliability.flow.mjs
@@ -1,0 +1,989 @@
+import http from "node:http";
+import { mkdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/cloud-mcp-reliability.md).
+// The runner fails this flow if the narration drifts from that script.
+const FLOW_ID = "cloud-mcp-reliability";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const RUN_TAG = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+const CONNECTION_BASE_NAME = "Cloud Reliability Check";
+const CONNECTION_NAME = `${CONNECTION_BASE_NAME} ${RUN_TAG}`;
+const FIXTURE_TOOL_NAME = "record_reliability_check";
+const RESULT_MARKER = `cloud-reliability-result-${RUN_TAG}`;
+const WORKSPACE_PATH = join(tmpdir(), `openwork-cloud-mcp-reliability-${RUN_TAG}`);
+const CLOUD_MCP_NAME = "openwork-cloud";
+const EXPECTED_TOOL_IDS = [
+  "openwork-cloud_search_capabilities",
+  "openwork-cloud_execute_capability",
+];
+const EXPECTED_AGENT_TOOLS = ["execute_capability", "search_capabilities"];
+const PLUGIN_CANARY = "openwork_docs_search";
+
+const state = {
+  fixtureServer: null,
+  fixturePort: null,
+  fixtureExecutions: [],
+  connectionId: null,
+  workspaceId: null,
+  workspacePath: WORKSPACE_PATH,
+  org: null,
+  model: null,
+  serverAuth: null,
+  degradedHealth: null,
+  readyHealth: null,
+  mcpToken: null,
+  chatStartedAt: null,
+};
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function quoted(value) {
+  return JSON.stringify(value);
+}
+
+function denBase(ctx) {
+  return ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : JSON.stringify(actual).slice(0, 1_200),
+  });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : `. Actual: ${JSON.stringify(actual).slice(0, 600)}`}`);
+}
+
+async function denFetch(ctx, path, options = {}) {
+  const response = await fetch(`${denBase(ctx)}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+      ...(state.org?.id ? { "x-openwork-legacy-org-id": state.org.id } : {}),
+      ...(options.headers || {}),
+    },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  if (!response.ok) {
+    throw new Error(`${options.method || "GET"} ${path} -> ${response.status}: ${typeof body === "string" ? body : JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+async function mcpAgentCall(ctx, mcpToken, method, params) {
+  const response = await fetch(`${denBase(ctx)}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${mcpToken}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params: params ?? {} }),
+  });
+  const raw = await response.text();
+  ctx.assert(response.ok, `MCP ${method} failed: ${response.status} ${raw.slice(0, 300)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  ctx.assert(Boolean(dataLine), `MCP ${method} returned no data frame: ${raw.slice(0, 300)}`);
+  const parsed = JSON.parse(dataLine.slice(5));
+  ctx.assert(!parsed.error, `MCP ${method} returned a JSON-RPC error: ${JSON.stringify(parsed.error)}`);
+  return parsed.result;
+}
+
+function json(response, status, body) {
+  response.writeHead(status, {
+    "access-control-allow-origin": "*",
+    "content-type": "application/json",
+  });
+  response.end(JSON.stringify(body));
+}
+
+function readJson(request) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    request.on("data", (chunk) => { raw += chunk; });
+    request.on("end", () => {
+      try {
+        resolve(raw.trim() ? JSON.parse(raw) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    request.on("error", reject);
+  });
+}
+
+function fixtureTool() {
+  return {
+    name: FIXTURE_TOOL_NAME,
+    title: "Record reliability check",
+    description: `Run the ${CONNECTION_BASE_NAME} fixture and return the exact marker ${RESULT_MARKER}.`,
+    inputSchema: {
+      type: "object",
+      properties: {
+        note: { type: "string", description: "Optional note about the reliability check request." },
+      },
+      additionalProperties: true,
+    },
+    annotations: {
+      readOnlyHint: false,
+      destructiveHint: false,
+      idempotentHint: true,
+      openWorldHint: false,
+    },
+  };
+}
+
+function mcpFixtureResult(message) {
+  if (message.method === "initialize") {
+    return {
+      protocolVersion: "2025-06-18",
+      capabilities: { tools: {} },
+      serverInfo: { name: "cloud-reliability-check", version: "1.0.0" },
+    };
+  }
+  if (message.method === "tools/list") {
+    return { tools: [fixtureTool()] };
+  }
+  if (message.method === "tools/call") {
+    const params = message.params && typeof message.params === "object" ? message.params : {};
+    const name = typeof params.name === "string" ? params.name : "";
+    if (name === FIXTURE_TOOL_NAME) {
+      const execution = {
+        at: new Date().toISOString(),
+        toolName: name,
+        arguments: params.arguments ?? {},
+      };
+      state.fixtureExecutions.push(execution);
+      return {
+        content: [{ type: "text", text: `${CONNECTION_BASE_NAME} completed: ${RESULT_MARKER}` }],
+      };
+    }
+    return {
+      isError: true,
+      content: [{ type: "text", text: `Unknown fixture tool: ${name}` }],
+    };
+  }
+  return {};
+}
+
+async function startFixtureServer() {
+  if (state.fixtureServer) return;
+  state.fixtureServer = http.createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url || "/", "http://127.0.0.1");
+      if (url.pathname === "/health") {
+        json(response, 200, { ok: true, connectionName: CONNECTION_NAME, resultMarker: RESULT_MARKER });
+        return;
+      }
+      if (url.pathname !== "/mcp" || request.method !== "POST") {
+        json(response, 404, { error: "not_found" });
+        return;
+      }
+      const body = await readJson(request);
+      const messages = Array.isArray(body) ? body : [body];
+      const replies = [];
+      for (const message of messages) {
+        if (message && typeof message === "object" && message.id !== undefined) {
+          replies.push({ jsonrpc: "2.0", id: message.id, result: mcpFixtureResult(message) });
+        }
+      }
+      if (replies.length === 0) {
+        response.writeHead(202, { "access-control-allow-origin": "*" });
+        response.end();
+        return;
+      }
+      json(response, 200, Array.isArray(body) ? replies : replies[0]);
+    } catch (error) {
+      json(response, 500, { error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+  await new Promise((resolve, reject) => {
+    state.fixtureServer.once("error", reject);
+    state.fixtureServer.listen(0, "127.0.0.1", resolve);
+  });
+  state.fixtureServer.unref();
+  const address = state.fixtureServer.address();
+  if (!address || typeof address === "string") throw new Error("Fixture server has no TCP address.");
+  state.fixturePort = address.port;
+}
+
+function fixtureUrl() {
+  if (!state.fixturePort) throw new Error("Fixture server is not started.");
+  return `http://127.0.0.1:${state.fixturePort}/mcp`;
+}
+
+async function setViewport(ctx) {
+  if (!ctx.client?.send) return;
+  await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1440,
+    height: 1000,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+}
+
+async function waitForControl(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 90_000, label: "control API" });
+}
+
+async function configureDesktopForDen(ctx) {
+  const baseUrl = denBase(ctx).replace("127.0.0.1", "localhost");
+  const written = await ctx.eval(`(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!bridge) return { ok: false, reason: "desktop bridge missing" };
+    await bridge("setDesktopBootstrapConfig", { baseUrl: ${quoted(baseUrl)}, apiBaseUrl: ${quoted(baseUrl)}, requireSignin: false, handoff: null });
+    localStorage.setItem("openwork.den.baseUrl", ${quoted(baseUrl)});
+    localStorage.setItem("openwork.den.apiBaseUrl", ${quoted(baseUrl)});
+    return { ok: true };
+  })()`, { awaitPromise: true });
+  witness(ctx, written?.ok === true, "The desktop bootstrap points at the local Den stack.", written);
+  await ctx.eval("location.reload()");
+  await waitForControl(ctx);
+}
+
+async function loadOrg(ctx) {
+  const orgsPayload = await denFetch(ctx, "/v1/me/orgs");
+  const orgs = Array.isArray(orgsPayload?.orgs) ? orgsPayload.orgs : [];
+  const selected = orgs.find((org) => org.id === orgsPayload.activeOrgId) ?? orgs[0];
+  ctx.assert(selected?.id, `No organization returned by Den: ${JSON.stringify(orgsPayload)}`);
+  state.org = { id: selected.id, slug: selected.slug ?? null, name: selected.name ?? null };
+  await denFetch(ctx, "/v1/me/active-organization", {
+    method: "POST",
+    body: JSON.stringify({ organizationId: state.org.id }),
+  });
+}
+
+async function signInWithFreshHandoff(ctx) {
+  await loadOrg(ctx);
+  await ctx.eval(`(() => {
+    localStorage.removeItem("openwork.den.authToken");
+    localStorage.removeItem("openwork.den.activeOrgId");
+    localStorage.removeItem("openwork.den.activeOrgSlug");
+    localStorage.removeItem("openwork.den.activeOrgName");
+    localStorage.removeItem("openwork.den.mcp.sync");
+    return true;
+  })()`);
+  const handoff = await denFetch(ctx, "/v1/auth/desktop-handoff", {
+    method: "POST",
+    body: JSON.stringify({ desktopScheme: "openwork" }),
+  });
+  ctx.assert(typeof handoff?.grant === "string" && handoff.grant.trim(), "Desktop handoff did not return a grant.");
+  await ctx.control("auth.exchange-grant", { grant: handoff.grant, baseUrl: denBase(ctx).replace("127.0.0.1", "localhost") });
+  await ctx.eval(`(() => {
+    localStorage.setItem("openwork.den.activeOrgId", ${quoted(state.org.id)});
+    ${state.org.slug ? `localStorage.setItem("openwork.den.activeOrgSlug", ${quoted(state.org.slug)});` : "localStorage.removeItem(\"openwork.den.activeOrgSlug\");"}
+    ${state.org.name ? `localStorage.setItem("openwork.den.activeOrgName", ${quoted(state.org.name)});` : "localStorage.removeItem(\"openwork.den.activeOrgName\");"}
+    window.dispatchEvent(new Event("openwork:den-settings-changed"));
+    window.dispatchEvent(new Event("openwork:den-session-updated"));
+    return true;
+  })()`);
+  await ctx.waitFor(
+    `Boolean((localStorage.getItem("openwork.den.authToken") ?? "").trim()) && localStorage.getItem("openwork.den.activeOrgId") === ${quoted(state.org.id)}`,
+    { timeoutMs: 45_000, label: "fresh Den handoff signed in with active org" },
+  );
+  witness(ctx, true, "A fresh Den desktop handoff was exchanged and the eval organization is active.", state.org);
+}
+
+async function getServerAuth(ctx, requireWorkspace = false) {
+  const auth = await ctx.eval(`(() => {
+    const hash = window.location.hash;
+    const workspaceFromHash = (hash.match(/\/workspace\/([^/]+)/) ?? [])[1] ?? "";
+    return {
+      port: (localStorage.getItem("openwork.server.port") ?? "").trim(),
+      token: (localStorage.getItem("openwork.server.token") ?? "").trim(),
+      hostToken: (localStorage.getItem("openwork.server.hostToken") ?? "").trim(),
+      workspaceId: workspaceFromHash || (localStorage.getItem("openwork.react.activeWorkspace") ?? "").trim(),
+    };
+  })()`);
+  ctx.assert(auth?.port && auth.token, `OpenWork server credentials missing: ${JSON.stringify(auth)}`);
+  if (requireWorkspace) ctx.assert(auth.workspaceId, `Workspace id missing from desktop state: ${JSON.stringify(auth)}`);
+  state.serverAuth = auth;
+  return auth;
+}
+
+async function serverFetchJson(ctx, path, options = {}) {
+  const auth = state.serverAuth ?? await getServerAuth(ctx);
+  const response = await fetch(`http://127.0.0.1:${auth.port}${path}`, {
+    method: options.method ?? "GET",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${auth.token}`,
+      ...(auth.hostToken ? { "x-openwork-host-token": auth.hostToken } : {}),
+      ...(options.headers || {}),
+    },
+    body: options.body === undefined ? undefined : JSON.stringify(options.body),
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  if (!response.ok) {
+    throw new Error(`${options.method || "GET"} ${path} -> ${response.status}: ${typeof body === "string" ? body : JSON.stringify(body)}`);
+  }
+  return body;
+}
+
+async function createFreshWorkspace(ctx) {
+  await mkdir(WORKSPACE_PATH, { recursive: true });
+  await getServerAuth(ctx);
+  const created = await serverFetchJson(ctx, "/workspaces/local", {
+    method: "POST",
+    body: { folderPath: WORKSPACE_PATH, name: `cloud-mcp-reliability-${RUN_TAG}`, preset: "starter" },
+  });
+  const workspaceId = created?.activeId ?? created?.selectedId ?? created?.workspaces?.find((workspace) => workspace.path === WORKSPACE_PATH)?.id;
+  ctx.assert(typeof workspaceId === "string" && workspaceId.trim(), `Workspace create did not return an id: ${JSON.stringify(created)}`);
+  state.workspaceId = workspaceId;
+  await serverFetchJson(ctx, `/workspaces/${encodeURIComponent(workspaceId)}/activate?persist=true`, { method: "POST" });
+  await ctx.eval(`(() => {
+    localStorage.setItem("openwork.react.activeWorkspace", ${quoted(workspaceId)});
+    const prefs = JSON.parse(localStorage.getItem("openwork.preferences") || "{}");
+    localStorage.setItem("openwork.preferences", JSON.stringify({ ...prefs, hasCompletedOnboarding: true, providerStepCompleted: true, selectedAgent: "openwork" }));
+    return true;
+  })()`);
+  await ctx.navigateHash(`/workspace/${workspaceId}/session`);
+  await ctx.waitFor(`window.location.hash.includes(${quoted(`/workspace/${workspaceId}`)})`, { timeoutMs: 45_000, label: "fresh workspace route" });
+  await getServerAuth(ctx, true);
+  witness(ctx, true, "A fresh local workspace is active for this proof.", { workspaceId, workspacePath: WORKSPACE_PATH });
+}
+
+async function ensureUsableModel(ctx) {
+  await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+  await ctx.waitFor(`window.location.hash.includes(${quoted(`/workspace/${state.workspaceId}/session`)})`, { timeoutMs: 45_000, label: "session route for model discovery" });
+  await ctx.waitFor(
+    `window.__openworkControl?.listActions?.().some((item) => item.id === "eval.model_not_available.seed" && !item.disabled)`,
+    { timeoutMs: 60_000, label: "available model eval seed action" },
+  );
+  const seeded = await ctx.control("eval.model_not_available.seed");
+  const available = seeded?.availableModel;
+  ctx.assert(available?.providerID && available?.modelID, `No available connected model found: ${JSON.stringify(seeded)}`);
+  state.model = { provider: available.providerID, model: available.modelID, title: available.title ?? available.modelID };
+  await ctx.eval(`(() => {
+    const prefs = JSON.parse(localStorage.getItem("openwork.preferences") || "{}");
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...prefs,
+      defaultModel: { providerID: ${quoted(state.model.provider)}, modelID: ${quoted(state.model.model)} },
+      modelVariant: null,
+      selectedAgent: "openwork",
+      providerStepCompleted: true,
+      hasCompletedOnboarding: true,
+    }));
+    return true;
+  })()`);
+  await ctx.eval("location.reload()");
+  await waitForControl(ctx);
+  await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+  await ctx.waitFor(
+    `(() => {
+      const prefs = JSON.parse(localStorage.getItem("openwork.preferences") || "{}");
+      return prefs.defaultModel?.providerID === ${quoted(state.model.provider)} && prefs.defaultModel?.modelID === ${quoted(state.model.model)};
+    })()`,
+    { timeoutMs: 20_000, label: "selected eval model persisted" },
+  );
+  witness(ctx, true, "A connected provider/model is selected for provider projection and the real task.", state.model);
+}
+
+async function cleanupExistingFixtureConnections(ctx) {
+  const manageable = await denFetch(ctx, "/v1/mcp-connections?scope=manageable");
+  const connections = Array.isArray(manageable?.connections) ? manageable.connections : [];
+  for (const connection of connections) {
+    if (typeof connection?.name === "string" && connection.name.startsWith(CONNECTION_BASE_NAME)) {
+      await denFetch(ctx, `/v1/mcp-connections/${encodeURIComponent(connection.id)}`, { method: "DELETE" }).catch(() => null);
+    }
+  }
+}
+
+async function createFixtureConnection(ctx) {
+  await startFixtureServer();
+  await cleanupExistingFixtureConnections(ctx);
+  const created = await denFetch(ctx, "/v1/mcp-connections", {
+    method: "POST",
+    body: JSON.stringify({
+      name: CONNECTION_NAME,
+      url: fixtureUrl(),
+      authType: "none",
+      credentialMode: "shared",
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    }),
+  });
+  ctx.assert(typeof created?.id === "string" && created.connected === true, `Fixture connection was not connected: ${JSON.stringify(created)}`);
+  state.connectionId = created.id;
+  witness(ctx, true, "A real no-auth external MCP fixture is registered through Den and connected.", {
+    connectionId: state.connectionId,
+    connectionName: CONNECTION_NAME,
+  });
+}
+
+async function mintDenMcpToken(ctx) {
+  const minted = await denFetch(ctx, "/v1/mcp/token", {
+    method: "POST",
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  });
+  ctx.assert(typeof minted?.token === "string" && minted.token.startsWith("ow_mcp_at_"), "Den did not mint a first-party MCP token.");
+  state.mcpToken = minted.token;
+  return minted;
+}
+
+function mcpAgentUrlFromResource(resource) {
+  const trimmed = typeof resource === "string" ? resource.trim().replace(/\/+$/, "") : "";
+  if (!trimmed) return `${denBase({ env: { OPENWORK_EVAL_DEN_API_URL: "" } })}/mcp/agent`;
+  return trimmed.endsWith("/agent") ? trimmed : `${trimmed}/agent`;
+}
+
+async function initialStrictReconcile(ctx) {
+  const minted = await mintDenMcpToken(ctx);
+  const payload = {
+    workspaceId: state.workspaceId,
+    name: CLOUD_MCP_NAME,
+    config: {
+      type: "remote",
+      enabled: true,
+      url: mcpAgentUrlFromResource(minted.resource),
+      headers: { Authorization: `Bearer ${minted.token}` },
+      oauth: false,
+    },
+    tokenMetadata: {
+      organizationId: minted.organizationId,
+      expiresAt: minted.expiresAt,
+      resource: minted.resource,
+      scopes: minted.scopes.join(" "),
+    },
+    org: { id: state.org.id, slug: state.org.slug, name: state.org.name },
+    connectCatalogEnabled: true,
+    trigger: "fraimz-initial-strict-reconcile",
+    ...(state.model ? { provider: state.model.provider, model: state.model.model } : {}),
+  };
+  const health = await serverFetchJson(ctx, `/workspace/${encodeURIComponent(state.workspaceId)}/mcp/openwork-cloud/reconcile`, {
+    method: "POST",
+    body: payload,
+  });
+  ctx.assert(health?.workspace?.id === state.workspaceId, "Initial reconcile returned a different workspace.");
+  ctx.assert(health.usable === true && health.firstFailure === null, `Initial strict reconcile did not become usable: ${JSON.stringify(health.firstFailure)}`);
+  witness(ctx, true, "Initial strict Cloud reconcile succeeded before inducing degradation.", {
+    workspaceId: health.workspace.id,
+    desiredRevision: health.desired.revision,
+    engine: health.engine.status,
+  });
+}
+
+async function deleteCloudRuntimeConfig(ctx) {
+  await ctx.navigateHash(`/workspace/${state.workspaceId}/settings/general`);
+  await ctx.waitFor(`window.location.hash.includes(${quoted(`/workspace/${state.workspaceId}/settings/general`)})`, { timeoutMs: 30_000, label: "settings route before deletion" });
+  await serverFetchJson(ctx, `/workspace/${encodeURIComponent(state.workspaceId)}/mcp/${encodeURIComponent(CLOUD_MCP_NAME)}`, { method: "DELETE" });
+  await ctx.eval(`(() => {
+    localStorage.removeItem("openwork.den.mcp.sync");
+    return true;
+  })()`);
+  state.degradedHealth = await waitForHealth(ctx, (health) => (
+    health?.workspace?.id === state.workspaceId &&
+    health.usable === false &&
+    health.firstFailure?.stage === "desired_config" &&
+    health.firstFailure?.code === "cloud_mcp_missing"
+  ), "desired_config cloud_mcp_missing after deleting runtime config");
+  witness(ctx, true, "Deleting only this workspace's openwork-cloud runtime config makes direct health unusable with desired_config/cloud_mcp_missing.", {
+    workspaceId: state.degradedHealth.workspace.id,
+    firstFailure: state.degradedHealth.firstFailure,
+  });
+}
+
+async function getHealth(ctx) {
+  const query = new URLSearchParams();
+  if (state.model?.provider && state.model.model) {
+    query.set("provider", state.model.provider);
+    query.set("model", state.model.model);
+  }
+  const suffix = query.size ? `?${query.toString()}` : "";
+  return serverFetchJson(ctx, `/workspace/${encodeURIComponent(state.workspaceId)}/mcp/openwork-cloud/health${suffix}`);
+}
+
+async function waitForHealth(ctx, predicate, label, timeoutMs = 90_000) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    try {
+      last = await getHealth(ctx);
+      if (predicate(last)) return last;
+    } catch (error) {
+      last = { error: error instanceof Error ? error.message : String(error) };
+    }
+    await sleep(1_000);
+  }
+  ctx.assert(false, `Timed out waiting for ${label}: ${JSON.stringify(last)}`);
+}
+
+async function openConnect(ctx) {
+  await ctx.navigateHash(`/workspace/${state.workspaceId}/settings/connect`);
+  await ctx.expectHashIncludes("/settings/connect");
+  await ctx.waitForText("Agent access to connected services", { timeoutMs: 60_000 });
+  await ctx.waitForText(CONNECTION_NAME, { timeoutMs: 60_000 });
+}
+
+async function scrollToText(ctx, text) {
+  await ctx.eval(`(() => {
+    const candidates = [...document.querySelectorAll('button, [data-testid], [data-slot], summary, pre, code, h1, h2, h3, p, span, div')]
+      .filter((node) => (node.textContent || "").includes(${quoted(text)}));
+    const target = candidates.find((node) => [...node.children].every((child) => !(child.textContent || "").includes(${quoted(text)})))
+      || candidates[candidates.length - 1];
+    target?.scrollIntoView({ block: "center", inline: "nearest" });
+    return Boolean(target);
+  })()`);
+}
+
+async function installNetworkProbe(ctx, label) {
+  const result = await ctx.eval(`(() => {
+    const key = "__cloudMcpReliabilityProbe";
+    if (!window[key]) {
+      const originalFetch = window.fetch.bind(window);
+      const bridge = window.__OPENWORK_ELECTRON__;
+      const originalInvoke = bridge?.invokeDesktop?.bind(bridge) ?? null;
+      const probe = { requests: [], desktopFetches: [], originalFetch, originalInvoke, label: ${quoted(label)}, installedAt: Date.now(), desktopPatched: false };
+      window.fetch = async (input, init) => {
+        const url = typeof input === "string" ? input : input?.url || String(input);
+        const method = (init?.method || input?.method || "GET").toUpperCase();
+        const body = typeof init?.body === "string" ? init.body : null;
+        probe.requests.push({ at: Date.now(), url, method, body });
+        return originalFetch(input, init);
+      };
+      if (bridge && originalInvoke) {
+        try {
+          bridge.invokeDesktop = async (command, ...args) => {
+            if (command === "__fetch") {
+              const init = args[1] && typeof args[1] === "object" ? args[1] : {};
+              probe.desktopFetches.push({ at: Date.now(), url: String(args[0] || ""), method: String(init.method || "GET").toUpperCase() });
+            }
+            return originalInvoke(command, ...args);
+          };
+          probe.desktopPatched = true;
+        } catch {
+          probe.desktopPatched = false;
+        }
+      }
+      window[key] = probe;
+    }
+    window[key].requests.length = 0;
+    window[key].desktopFetches.length = 0;
+    window[key].label = ${quoted(label)};
+    return { ok: true, desktopPatched: window[key].desktopPatched };
+  })()`);
+  witness(ctx, result?.ok === true && result.desktopPatched === true, "Renderer network probe is installed for fetch and desktop __fetch calls.", result);
+}
+
+async function networkSummary(ctx) {
+  return ctx.eval(`(() => {
+    const probe = window.__cloudMcpReliabilityProbe;
+    if (!probe) return null;
+    const sanitizeRequest = (request) => {
+      let parsedBody = null;
+      try {
+        const raw = typeof request.body === "string" ? JSON.parse(request.body) : null;
+        if (raw && typeof raw === "object") {
+          parsedBody = {
+            workspaceId: raw.workspaceId ?? null,
+            name: raw.name ?? null,
+            trigger: raw.trigger ?? null,
+            provider: raw.provider ?? null,
+            model: raw.model ?? null,
+            configUrl: raw.config?.url ?? null,
+            hasAuthorization: Boolean(raw.config?.headers?.Authorization),
+          };
+        }
+      } catch {}
+      return { at: request.at, method: request.method, url: request.url, body: parsedBody };
+    };
+    return {
+      label: probe.label,
+      requests: probe.requests.map(sanitizeRequest),
+      desktopFetches: probe.desktopFetches.map((request) => ({ at: request.at, method: request.method, url: request.url })),
+    };
+  })()`);
+}
+
+async function readMarker(ctx) {
+  return ctx.eval("localStorage.getItem('openwork.den.mcp.sync')");
+}
+
+async function clickAgentAccessButton(ctx, label) {
+  const clicked = await ctx.eval(`(() => {
+    const card = document.querySelector('[data-testid="agent-access-card"]');
+    const button = [...(card?.querySelectorAll('button') ?? [])].find((candidate) => (candidate.textContent || "").trim() === ${quoted(label)} && !candidate.disabled);
+    button?.scrollIntoView({ block: "center", inline: "nearest" });
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked, `Could not click Agent access button: ${label}`);
+}
+
+async function waitForAgentButton(ctx, label) {
+  await ctx.waitFor(`(() => {
+    const card = document.querySelector('[data-testid="agent-access-card"]');
+    return [...(card?.querySelectorAll('button') ?? [])].some((button) => (button.textContent || "").trim() === ${quoted(label)} && !button.disabled);
+  })()`, { timeoutMs: 90_000, label: `Agent access ${label} button enabled` });
+}
+
+function assertExpectedTools(ctx, actual, label) {
+  for (const tool of EXPECTED_TOOL_IDS) {
+    ctx.assert(actual.includes(tool), `${label} missing ${tool}: ${actual.join(", ")}`);
+  }
+}
+
+function assertNoSecretText(ctx, text, secrets) {
+  for (const secret of secrets.filter((value) => typeof value === "string" && value.trim().length >= 8)) {
+    ctx.assert(!text.includes(secret), "Sanitized diagnostic leaked a live secret value.");
+  }
+  ctx.assert(!/Bearer\s+[A-Za-z0-9._~+\-/]+=*/.test(text), "Sanitized diagnostic leaked a Bearer token.");
+  ctx.assert(!/ow_mcp_at_[A-Za-z0-9_-]+/.test(text), "Sanitized diagnostic leaked a raw Den MCP token.");
+}
+
+async function setupProof(ctx) {
+  await setViewport(ctx);
+  await waitForControl(ctx);
+  await configureDesktopForDen(ctx);
+  await signInWithFreshHandoff(ctx);
+  await createFreshWorkspace(ctx);
+  await ensureUsableModel(ctx);
+  await createFixtureConnection(ctx);
+  await initialStrictReconcile(ctx);
+  await deleteCloudRuntimeConfig(ctx);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Users can verify, repair, diagnose, and use Cloud agent access per workspace",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  steps: [
+    {
+      name: "Setup: fresh Den handoff, workspace, fixture, and degraded state",
+      run: async (ctx) => {
+        await setupProof(ctx);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("Settings → Connect separates the real connected service row from the Agent access readiness card", {
+          voiceover: vo[0],
+          action: async () => {
+            await openConnect(ctx);
+            await scrollToText(ctx, CONNECTION_NAME);
+          },
+          assert: async () => {
+            const separation = await ctx.eval(`(() => {
+              const card = document.querySelector('[data-testid="agent-access-card"]');
+              const rows = [...document.querySelectorAll('[data-testid="connect-organization-row"]')];
+              const row = rows.find((entry) => (entry.textContent || "").includes(${quoted(CONNECTION_NAME)}));
+              return {
+                hasCard: Boolean(card),
+                hasRow: Boolean(row),
+                rowInsideCard: Boolean(card && row && card.contains(row)),
+                rowKind: row?.getAttribute('data-connect-row-kind') ?? null,
+                sectionExists: Boolean(document.querySelector('[data-testid="connect-organization-section"]')),
+              };
+            })()`);
+            witness(ctx, separation.hasCard && separation.hasRow && separation.sectionExists && separation.rowInsideCard === false, "The connected service row is in the organization section, not nested inside the Agent access card.", separation);
+            await ctx.expectText("Agent access to connected services");
+            await ctx.expectText(CONNECTION_NAME);
+            await ctx.expectText("From your organization");
+          },
+          screenshot: {
+            name: "frame-1-connect-separation",
+            requireText: ["Agent access to connected services", "From your organization", CONNECTION_NAME],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/connect",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The Agent access card reports Degraded with the first failing stage and Repair and test guidance", {
+          voiceover: vo[1],
+          action: async () => {
+            await scrollToText(ctx, "Agent access to connected services");
+            await ctx.waitForText("Degraded", { timeoutMs: 60_000 });
+            await ctx.waitForText("Use Repair and test to apply agent access for this workspace.", { timeoutMs: 60_000 });
+          },
+          assert: async () => {
+            state.degradedHealth = await waitForHealth(ctx, (health) => (
+              health.usable === false &&
+              health.workspace.id === state.workspaceId &&
+              health.firstFailure?.stage === "desired_config" &&
+              health.firstFailure?.code === "cloud_mcp_missing"
+            ), "visible degraded desired_config health");
+            witness(ctx, true, "Live health firstFailure is desired_config/cloud_mcp_missing for the exact workspace.", {
+              workspaceId: state.degradedHealth.workspace.id,
+              firstFailure: state.degradedHealth.firstFailure,
+            });
+            await ctx.expectText("Degraded");
+            await ctx.expectText("First issue");
+            await ctx.expectText("Recommended action");
+          },
+          screenshot: {
+            name: "frame-2-degraded-first-issue",
+            requireText: ["Degraded", "First issue", "Recommended action", "Use Repair and test"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: "/settings/connect",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Test now performs a read-only live health GET and leaves the degraded state untouched", {
+          voiceover: vo[2],
+          action: async () => {
+            await installNetworkProbe(ctx, "test-now");
+            state.markerBeforeTest = await readMarker(ctx);
+            await clickAgentAccessButton(ctx, "Test now");
+            await waitForAgentButton(ctx, "Test now");
+            await scrollToText(ctx, "Recommended action");
+          },
+          assert: async () => {
+            const summary = await networkSummary(ctx);
+            const healthGets = summary.requests.filter((request) => request.method === "GET" && request.url.includes(`/workspace/${state.workspaceId}/mcp/openwork-cloud/health`));
+            const reconcilePosts = summary.requests.filter((request) => request.method === "POST" && request.url.includes("/mcp/openwork-cloud/reconcile"));
+            const tokenMints = summary.desktopFetches.filter((request) => request.method === "POST" && request.url.includes("/v1/mcp/token"));
+            witness(ctx, healthGets.length >= 1 && reconcilePosts.length === 0 && tokenMints.length === 0, "Test now made GET health requests only: no reconcile POST and no Den MCP token mint.", {
+              healthGets: healthGets.length,
+              reconcilePosts: reconcilePosts.length,
+              tokenMints: tokenMints.length,
+            });
+            const markerAfter = await readMarker(ctx);
+            witness(ctx, markerAfter === state.markerBeforeTest, "Test now did not write or change the Cloud MCP sync marker.", { before: state.markerBeforeTest, after: markerAfter });
+            const health = await getHealth(ctx);
+            witness(ctx, health.usable === false && health.firstFailure?.code === "cloud_mcp_missing", "The exact workspace remains degraded after the read-only test.", { firstFailure: health.firstFailure });
+          },
+          screenshot: {
+            name: "frame-3-test-now-read-only",
+            requireText: ["Degraded", "Test now", "Repair and test"],
+            rejectText: ["Something went wrong", "Repairing…"],
+            hashIncludes: "/settings/connect",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Repair and test reconciles exactly this workspace, writes the marker only after usable health, and connects the engine", {
+          voiceover: vo[3],
+          action: async () => {
+            await installNetworkProbe(ctx, "repair-and-test");
+            state.markerBeforeRepair = await readMarker(ctx);
+            await clickAgentAccessButton(ctx, "Repair and test");
+            await ctx.waitForText("Ready", { timeoutMs: 120_000 });
+            await waitForAgentButton(ctx, "Repair and test");
+            await scrollToText(ctx, "Agent access to connected services");
+          },
+          assert: async () => {
+            const summary = await networkSummary(ctx);
+            const posts = summary.requests.filter((request) => request.method === "POST" && request.url.includes(`/workspace/${state.workspaceId}/mcp/openwork-cloud/reconcile`));
+            witness(ctx, posts.length === 1 && posts[0].body?.workspaceId === state.workspaceId && posts[0].body?.name === CLOUD_MCP_NAME && posts[0].body?.hasAuthorization === true, "Repair posted one sanitized reconcile request to the exact workspace route and body.", posts.map((post) => post.body));
+            const tokenMints = summary.desktopFetches.filter((request) => request.method === "POST" && request.url.includes("/v1/mcp/token"));
+            witness(ctx, tokenMints.length === 1, "Repair minted one Den MCP token through the desktop fetch bridge.", { tokenMints: tokenMints.length });
+            state.readyHealth = await waitForHealth(ctx, (health) => health.usable === true && health.workspace.id === state.workspaceId && health.firstFailure === null, "usable health after repair");
+            const markerAfter = await readMarker(ctx);
+            witness(ctx, !state.markerBeforeRepair && typeof markerAfter === "string" && markerAfter.includes(state.workspaceId), "The sync marker was absent before repair and written only after usable health returned.", { before: state.markerBeforeRepair, afterPresent: Boolean(markerAfter) });
+            witness(ctx, state.readyHealth.delivery.desiredRevision === state.readyHealth.delivery.appliedRevision && state.readyHealth.engine.status === "connected", "Health shows desired/applied revisions match and the engine is connected.", {
+              desiredRevision: state.readyHealth.delivery.desiredRevision,
+              appliedRevision: state.readyHealth.delivery.appliedRevision,
+              engine: state.readyHealth.engine.status,
+            });
+          },
+          screenshot: {
+            name: "frame-4-repair-ready",
+            requireText: ["Ready", "No action needed.", "Repair and test"],
+            rejectText: ["Degraded", "Something went wrong"],
+            hashIncludes: "/settings/connect",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("Ready health exposes both OpenWork Cloud tools to the selected model and Den /mcp/agent exposes exactly two unprefixed tools", {
+          voiceover: vo[4],
+          action: async () => {
+            await scrollToText(ctx, EXPECTED_TOOL_IDS[0]);
+          },
+          assert: async () => {
+            const health = await getHealth(ctx);
+            witness(ctx, health.workspace.id === state.workspaceId && health.usable === true && health.firstFailure === null, "Live health is usable for the exact workspace with no firstFailure.", {
+              workspaceId: health.workspace.id,
+              firstFailure: health.firstFailure,
+            });
+            assertExpectedTools(ctx, health.tools.present, "health.tools.present");
+            witness(ctx, health.tools.missing.length === 0, "No expected OpenWork Cloud tools are missing.", { missing: health.tools.missing });
+            if (state.model) {
+              witness(ctx, health.tools.providerProjection.checked === true && health.tools.providerProjection.provider === state.model.provider && health.tools.providerProjection.model === state.model.model, "Provider projection was checked for the selected provider/model.", health.tools.providerProjection);
+              assertExpectedTools(ctx, health.tools.providerProjection.present, "providerProjection.present");
+              witness(ctx, health.tools.providerProjection.missing.length === 0, "Provider projection has no missing Cloud tools.", { missing: health.tools.providerProjection.missing });
+            }
+            witness(ctx, health.pluginCanaries.present.includes(PLUGIN_CANARY) && health.pluginCanaries.missing.length === 0, "Plugin canary tools are present and not missing.", health.pluginCanaries);
+            const listed = await serverFetchJson(ctx, `/workspace/${encodeURIComponent(state.workspaceId)}/mcp`);
+            const cloud = listed.items.find((item) => item.name === CLOUD_MCP_NAME);
+            witness(ctx, Boolean(cloud) && listed.engineSync?.status === "ok", "Workspace MCP status includes openwork-cloud and engine sync is ok.", {
+              names: listed.items.map((item) => item.name),
+              engineSync: listed.engineSync,
+            });
+            const minted = await mintDenMcpToken(ctx);
+            const agentTools = await mcpAgentCall(ctx, minted.token, "tools/list", {});
+            const names = agentTools.tools.map((tool) => tool.name).sort();
+            witness(ctx, names.length === 2 && names.join(",") === EXPECTED_AGENT_TOOLS.join(","), "Den /mcp/agent tools/list exposes exactly the two unprefixed agent tools.", { tools: names });
+            const search = await mcpAgentCall(ctx, minted.token, "tools/call", { name: "search_capabilities", arguments: { query: CONNECTION_BASE_NAME, type: "mcp", limit: 5 } });
+            const parsed = JSON.parse(search.content?.[0]?.text ?? "{}");
+            const expectedCapability = `mcp:${state.connectionId}:${FIXTURE_TOOL_NAME}`;
+            witness(ctx, (parsed.matches ?? []).some((match) => match.name === expectedCapability), "Den agent capability search can discover the connected fixture before chat uses it.", { expectedCapability, matches: (parsed.matches ?? []).map((match) => match.name) });
+            state.readyHealth = health;
+          },
+          screenshot: {
+            name: "frame-5-tool-ids-ready",
+            requireText: [EXPECTED_TOOL_IDS[0], EXPECTED_TOOL_IDS[1], "Current model can use these Cloud tools."],
+            rejectText: ["Something went wrong", "Current model cannot use"],
+            hashIncludes: "/settings/connect",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("Advanced Settings shows safe Cloud MCP diagnostics and copies a sanitized report without credentials", {
+          voiceover: vo[5],
+          action: async () => {
+            await ctx.navigateHash(`/workspace/${state.workspaceId}/settings/advanced`);
+            await ctx.expectHashIncludes("/settings/advanced");
+            await ctx.waitForText("Agent access diagnostics", { timeoutMs: 60_000 });
+            const hasHealth = await ctx.eval("document.body.innerText.includes('Active workspace')");
+            if (!hasHealth) {
+              await ctx.eval(`(() => {
+                const section = [...document.querySelectorAll('section, div')].find((entry) => (entry.textContent || '').includes('Agent access diagnostics'));
+                const button = [...(section?.querySelectorAll('button') ?? [])].find((entry) => (entry.textContent || '').trim() === 'Refresh');
+                button?.click();
+                return Boolean(button);
+              })()`);
+            }
+            await ctx.waitForText("Active workspace", { timeoutMs: 60_000 });
+            await scrollToText(ctx, "Plugin hashes");
+            await ctx.clickText("Copy sanitized diagnostic", { timeoutMs: 30_000 });
+            await ctx.waitForText("Copied sanitized Cloud diagnostic.", { timeoutMs: 15_000 });
+          },
+          assert: async () => {
+            const clipboard = await ctx.eval("navigator.clipboard.readText()", { awaitPromise: true });
+            ctx.assert(typeof clipboard === "string" && clipboard.trim().startsWith("{"), "Clipboard did not contain JSON diagnostics.");
+            const parsed = JSON.parse(clipboard);
+            const health = parsed.cloudMcpHealth;
+            ctx.assert(health?.workspace?.id === state.workspaceId, "Diagnostic workspace id was not preserved.");
+            ctx.assert(health.desired?.revision === state.readyHealth.desired.revision, "Diagnostic desired revision was not preserved.");
+            ctx.assert(health.delivery?.appliedRevision === state.readyHealth.delivery.appliedRevision, "Diagnostic applied revision was not preserved.");
+            assertExpectedTools(ctx, health.tools?.present ?? [], "diagnostic tools.present");
+            const secrets = [
+              state.serverAuth?.token,
+              state.serverAuth?.hostToken,
+              state.mcpToken,
+              await ctx.eval("localStorage.getItem('openwork.den.authToken')"),
+            ];
+            assertNoSecretText(ctx, clipboard, secrets);
+            witness(ctx, true, "Copied diagnostic preserves safe workspace/revision/tool IDs and excludes Den/MCP/server/host tokens.", {
+              workspaceId: health.workspace.id,
+              desiredRevision: health.desired.revision,
+              appliedRevision: health.delivery.appliedRevision,
+              tools: health.tools.present,
+            });
+          },
+          screenshot: {
+            name: "frame-6-advanced-sanitized-diagnostic",
+            requireText: ["Agent access diagnostics", "Active workspace", "Desired revision", "Applied revision", "Delivery", "OpenWork versions", "OpenCode compatibility", "Plugin hashes", "Copied sanitized Cloud diagnostic."],
+            rejectText: ["Bearer ", "ow_mcp_at_", "No Cloud MCP health"],
+            hashIncludes: "/settings/advanced",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 7",
+      run: async (ctx) => {
+        await ctx.prove("A fresh real task searches Cloud capabilities before executing the connected fixture and does not substitute docs search", {
+          voiceover: vo[6],
+          action: async () => {
+            await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+            await ctx.waitFor(`window.location.hash.includes(${quoted(`/workspace/${state.workspaceId}/session`)})`, { timeoutMs: 45_000, label: "session route" });
+            await ctx.waitFor(
+              "window.__openworkControl?.listActions?.().find((item) => item.id === 'session.create_task' && !item.disabled)",
+              { timeoutMs: 45_000, label: "session.create_task enabled" },
+            );
+            await ctx.control("session.create_task");
+            await ctx.waitFor("window.location.hash.includes('/session/ses_')", { timeoutMs: 45_000, label: "fresh task session" });
+            state.chatStartedAt = new Date().toISOString();
+            const prompt = `Please run the reliability check in my connected service named ${CONNECTION_BASE_NAME}. Reply with the exact marker it returns.`;
+            await ctx.control("composer.set_text", { text: prompt });
+            await ctx.waitFor(
+              "window.__openworkControl?.listActions?.().find((item) => item.id === 'composer.send' && !item.disabled)",
+              { timeoutMs: 30_000, label: "composer.send enabled" },
+            );
+            await ctx.control("composer.send");
+          },
+          assert: async () => {
+            await ctx.waitFor("!Boolean([...document.querySelectorAll('button')].find((button) => button.textContent.trim() === 'Stop'))", { timeoutMs: 240_000, label: "assistant finished" });
+            await ctx.waitForText(RESULT_MARKER, { timeoutMs: 60_000 });
+            const transcript = await ctx.control("session.read_transcript", { count: 30 });
+            const transcriptText = (transcript.messages ?? []).map((message) => message.text).join("\n---\n");
+            const searchIndex = transcriptText.indexOf("[tool:openwork-cloud_search_capabilities]");
+            const executeIndex = transcriptText.indexOf("[tool:openwork-cloud_execute_capability]");
+            witness(ctx, searchIndex >= 0 && executeIndex > searchIndex, "Transcript tool order is openwork-cloud_search_capabilities before openwork-cloud_execute_capability.", { searchIndex, executeIndex });
+            witness(ctx, !transcriptText.includes(PLUGIN_CANARY), "Transcript did not substitute OpenWork documentation search for the connected-service action.", { containsDocsSearch: transcriptText.includes(PLUGIN_CANARY) });
+            const freshExecutions = state.fixtureExecutions.filter((entry) => !state.chatStartedAt || entry.at >= state.chatStartedAt);
+            witness(ctx, freshExecutions.length >= 1, "The external Cloud Reliability Check fixture observed a real tools/call execution from the task.", freshExecutions.map((entry) => ({ at: entry.at, toolName: entry.toolName })));
+            const latest = await ctx.control("session.latest_message");
+            witness(ctx, latest.role === "assistant" && latest.text.includes(RESULT_MARKER), "The final visible task output includes the unique fixture result marker.", { role: latest.role, includesMarker: latest.text.includes(RESULT_MARKER) });
+            await ctx.control("session.scroll_bottom");
+          },
+          screenshot: {
+            name: "frame-7-real-task-fixture-executed",
+            requireText: [RESULT_MARKER, CONNECTION_BASE_NAME],
+            rejectText: ["openwork_docs_search", "Something went wrong"],
+            hashIncludes: "/session",
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup fixture resources",
+      run: async (ctx) => {
+        if (state.connectionId) {
+          await denFetch(ctx, `/v1/mcp-connections/${encodeURIComponent(state.connectionId)}`, { method: "DELETE" }).catch((error) => {
+            ctx.log(`Fixture connection cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
+          });
+        }
+        if (state.fixtureServer) {
+          state.fixtureServer.close();
+          state.fixtureServer = null;
+        }
+        await ctx.eval(`(() => {
+          const probe = window.__cloudMcpReliabilityProbe;
+          if (probe?.originalFetch) window.fetch = probe.originalFetch;
+          if (probe?.originalInvoke && window.__OPENWORK_ELECTRON__) window.__OPENWORK_ELECTRON__.invokeDesktop = probe.originalInvoke;
+          delete window.__cloudMcpReliabilityProbe;
+          return true;
+        })()`).catch(() => null);
+      },
+    },
+  ],
+};

--- a/evals/flows/cloud-mcp-reliability.flow.mjs
+++ b/evals/flows/cloud-mcp-reliability.flow.mjs
@@ -60,6 +60,20 @@ function normalizeFixtureUrl(value) {
   return url.toString();
 }
 
+function cleanBaseUrl(value) {
+  const url = new URL(value.trim());
+  url.hash = "";
+  url.search = "";
+  url.pathname = url.pathname.replace(/\/+$/, "");
+  return url.toString().replace(/\/+$/, "");
+}
+
+function desktopReachableBaseUrl(value) {
+  const url = new URL(cleanBaseUrl(value));
+  if (url.hostname === "127.0.0.1") url.hostname = "localhost";
+  return cleanBaseUrl(url.toString());
+}
+
 function configureFixtureFromEnv(ctx) {
   const portText = optionalEnv(ctx, "OPENWORK_EVAL_MCP_FIXTURE_PORT");
   const listenPort = portText ? Number(portText) : 0;
@@ -70,8 +84,21 @@ function configureFixtureFromEnv(ctx) {
   state.fixturePublicUrl = publicUrl ? normalizeFixtureUrl(publicUrl) : null;
 }
 
-function denBase(ctx) {
-  return ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+function denApiBase(ctx) {
+  return cleanBaseUrl(ctx.env.OPENWORK_EVAL_DEN_API_URL);
+}
+
+function denWebBase(ctx) {
+  const webBase = optionalEnv(ctx, "OPENWORK_EVAL_DEN_WEB_URL");
+  return cleanBaseUrl(webBase || ctx.env.OPENWORK_EVAL_DEN_API_URL);
+}
+
+function denDesktopWebBase(ctx) {
+  return desktopReachableBaseUrl(denWebBase(ctx));
+}
+
+function denDesktopApiBase(ctx) {
+  return desktopReachableBaseUrl(denApiBase(ctx));
 }
 
 function witness(ctx, condition, assertion, actual) {
@@ -85,7 +112,7 @@ function witness(ctx, condition, assertion, actual) {
 }
 
 async function denFetch(ctx, path, options = {}) {
-  const response = await fetch(`${denBase(ctx)}${path}`, {
+  const response = await fetch(`${denApiBase(ctx)}${path}`, {
     ...options,
     headers: {
       "content-type": "application/json",
@@ -108,7 +135,7 @@ async function denFetch(ctx, path, options = {}) {
 }
 
 async function mcpAgentCall(ctx, mcpToken, method, params) {
-  const response = await fetch(`${denBase(ctx)}/mcp/agent`, {
+  const response = await fetch(`${denApiBase(ctx)}/mcp/agent`, {
     method: "POST",
     headers: {
       "content-type": "application/json",
@@ -266,13 +293,14 @@ async function waitForControl(ctx) {
 }
 
 async function configureDesktopForDen(ctx) {
-  const baseUrl = denBase(ctx).replace("127.0.0.1", "localhost");
+  const baseUrl = denDesktopWebBase(ctx);
+  const apiBaseUrl = denDesktopApiBase(ctx);
   const written = await ctx.eval(`(async () => {
     const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
     if (!bridge) return { ok: false, reason: "desktop bridge missing" };
-    await bridge("setDesktopBootstrapConfig", { baseUrl: ${quoted(baseUrl)}, apiBaseUrl: ${quoted(baseUrl)}, requireSignin: false, handoff: null });
+    await bridge("setDesktopBootstrapConfig", { baseUrl: ${quoted(baseUrl)}, apiBaseUrl: ${quoted(apiBaseUrl)}, requireSignin: false, handoff: null });
     localStorage.setItem("openwork.den.baseUrl", ${quoted(baseUrl)});
-    localStorage.setItem("openwork.den.apiBaseUrl", ${quoted(baseUrl)});
+    localStorage.setItem("openwork.den.apiBaseUrl", ${quoted(apiBaseUrl)});
     return { ok: true };
   })()`, { awaitPromise: true });
   witness(ctx, written?.ok === true, "The desktop bootstrap points at the local Den stack.", written);
@@ -307,7 +335,7 @@ async function signInWithFreshHandoff(ctx) {
     body: JSON.stringify({ desktopScheme: "openwork" }),
   });
   ctx.assert(typeof handoff?.grant === "string" && handoff.grant.trim(), "Desktop handoff did not return a grant.");
-  await ctx.control("auth.exchange-grant", { grant: handoff.grant, baseUrl: denBase(ctx).replace("127.0.0.1", "localhost") });
+  await ctx.control("auth.exchange-grant", { grant: handoff.grant, baseUrl: denDesktopWebBase(ctx) });
   await ctx.eval(`(() => {
     localStorage.setItem("openwork.den.activeOrgId", ${quoted(state.org.id)});
     ${state.org.slug ? `localStorage.setItem("openwork.den.activeOrgSlug", ${quoted(state.org.slug)});` : "localStorage.removeItem(\"openwork.den.activeOrgSlug\");"}
@@ -465,10 +493,11 @@ async function mintDenMcpToken(ctx) {
   return minted;
 }
 
-function mcpAgentUrlFromResource(resource) {
-  const trimmed = typeof resource === "string" ? resource.trim().replace(/\/+$/, "") : "";
-  if (!trimmed) return `${denBase({ env: { OPENWORK_EVAL_DEN_API_URL: "" } })}/mcp/agent`;
-  return trimmed.endsWith("/agent") ? trimmed : `${trimmed}/agent`;
+function mcpAgentUrlFromResource(ctx, resource) {
+  const trimmed = typeof resource === "string" ? resource.trim() : "";
+  if (!trimmed) return `${denApiBase(ctx)}/mcp/agent`;
+  const baseUrl = cleanBaseUrl(trimmed);
+  return baseUrl.endsWith("/agent") ? baseUrl : `${baseUrl}/agent`;
 }
 
 async function initialStrictReconcile(ctx) {
@@ -479,7 +508,7 @@ async function initialStrictReconcile(ctx) {
     config: {
       type: "remote",
       enabled: true,
-      url: mcpAgentUrlFromResource(minted.resource),
+      url: mcpAgentUrlFromResource(ctx, minted.resource),
       headers: { Authorization: `Bearer ${minted.token}` },
       oauth: false,
     },

--- a/evals/flows/cloud-mcp-reliability.flow.mjs
+++ b/evals/flows/cloud-mcp-reliability.flow.mjs
@@ -370,7 +370,8 @@ async function signInWithFreshHandoff(ctx) {
 async function getServerAuth(ctx, requireWorkspace = false) {
   const auth = await ctx.eval(`(() => {
     const hash = window.location.hash;
-    const workspaceFromHash = (hash.match(/\/workspace\/([^/]+)/) ?? [])[1] ?? "";
+    // Keep this template-safe: regex literals lose backslashes inside the outer eval string.
+    const workspaceFromHash = (hash.match(new RegExp("/workspace/([^/]+)")) ?? [])[1] ?? "";
     return {
       port: (localStorage.getItem("openwork.server.port") ?? "").trim(),
       token: (localStorage.getItem("openwork.server.token") ?? "").trim(),

--- a/evals/flows/cloud-mcp-reliability.flow.mjs
+++ b/evals/flows/cloud-mcp-reliability.flow.mjs
@@ -26,6 +26,8 @@ const PLUGIN_CANARY = "openwork_docs_search";
 const state = {
   fixtureServer: null,
   fixturePort: null,
+  fixtureListenPort: null,
+  fixturePublicUrl: null,
   fixtureExecutions: [],
   connectionId: null,
   workspaceId: null,
@@ -43,6 +45,29 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 function quoted(value) {
   return JSON.stringify(value);
+}
+
+function optionalEnv(ctx, name) {
+  const value = ctx.env[name];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function normalizeFixtureUrl(value) {
+  const url = new URL(value);
+  url.hash = "";
+  const pathname = url.pathname.replace(/\/+$/, "");
+  url.pathname = pathname.endsWith("/mcp") ? pathname : `${pathname}/mcp`;
+  return url.toString();
+}
+
+function configureFixtureFromEnv(ctx) {
+  const portText = optionalEnv(ctx, "OPENWORK_EVAL_MCP_FIXTURE_PORT");
+  const listenPort = portText ? Number(portText) : 0;
+  ctx.assert(Number.isInteger(listenPort) && listenPort >= 0 && listenPort <= 65535, `OPENWORK_EVAL_MCP_FIXTURE_PORT must be a TCP port, got ${quoted(portText)}.`);
+  state.fixtureListenPort = listenPort;
+
+  const publicUrl = optionalEnv(ctx, "OPENWORK_EVAL_MCP_FIXTURE_URL");
+  state.fixturePublicUrl = publicUrl ? normalizeFixtureUrl(publicUrl) : null;
 }
 
 function denBase(ctx) {
@@ -178,7 +203,8 @@ function mcpFixtureResult(message) {
   return {};
 }
 
-async function startFixtureServer() {
+async function startFixtureServer(ctx) {
+  configureFixtureFromEnv(ctx);
   if (state.fixtureServer) return;
   state.fixtureServer = http.createServer(async (request, response) => {
     try {
@@ -211,7 +237,8 @@ async function startFixtureServer() {
   });
   await new Promise((resolve, reject) => {
     state.fixtureServer.once("error", reject);
-    state.fixtureServer.listen(0, "127.0.0.1", resolve);
+    const listenPort = state.fixtureListenPort ?? 0;
+    state.fixtureServer.listen(listenPort, listenPort > 0 ? "0.0.0.0" : "127.0.0.1", resolve);
   });
   state.fixtureServer.unref();
   const address = state.fixtureServer.address();
@@ -221,7 +248,7 @@ async function startFixtureServer() {
 
 function fixtureUrl() {
   if (!state.fixturePort) throw new Error("Fixture server is not started.");
-  return `http://127.0.0.1:${state.fixturePort}/mcp`;
+  return state.fixturePublicUrl ?? `http://127.0.0.1:${state.fixturePort}/mcp`;
 }
 
 async function setViewport(ctx) {
@@ -408,7 +435,7 @@ async function cleanupExistingFixtureConnections(ctx) {
 }
 
 async function createFixtureConnection(ctx) {
-  await startFixtureServer();
+  await startFixtureServer(ctx);
   await cleanupExistingFixtureConnections(ctx);
   const created = await denFetch(ctx, "/v1/mcp-connections", {
     method: "POST",

--- a/evals/voiceovers/cloud-mcp-reliability.md
+++ b/evals/voiceovers/cloud-mcp-reliability.md
@@ -1,0 +1,15 @@
+# cloud-mcp-reliability — Verify and repair Cloud agent access per workspace
+
+1. I open **Settings → Connect** and see my connected service separately from **Agent access to connected services**, so service connectivity and agent readiness are clearly distinguished.
+
+2. Agent access clearly says Ready, Connecting, Disabled, or Degraded. If it is degraded, I see the first failing stage and what to do next—for example, sign in, select an organization, repair authentication, update OpenWork, or choose a model that supports the Cloud tools.
+
+3. I click **Test now** for a read-only live check. OpenWork confirms whether Cloud is actually available in this workspace rather than trusting saved configuration.
+
+4. I click **Repair and test**. OpenWork repairs access for this exact workspace and verifies the live connection and tools.
+
+5. Every stage becomes healthy, and the card shows both `openwork-cloud_search_capabilities` and `openwork-cloud_execute_capability` as available to my current model.
+
+6. In **Advanced Settings**, I can inspect workspace, revision, delivery, version, plugin, and compatibility diagnostics or copy a sanitized report without exposing credentials.
+
+7. I start a new task and request an action against my connected service. The agent searches Cloud capabilities first and does not substitute documentation search for the requested action.


### PR DESCRIPTION
## Summary
- add strict workspace-scoped `openwork-cloud` health and reconcile endpoints
- verify desired config, dynamic engine delivery, MCP transport, exact Cloud tools, current-model projection, plugin canaries, and runtime compatibility
- centralize desktop reconciliation with scoped user intent, one auth remint, sign-out cleanup, and freshness only after usable health
- add a first-class Agent access card in Settings → Connect and sanitized technical details in Advanced Settings
- steer connected-service tasks from verified workspace health instead of config presence

## Validation run
- `pnpm --filter openwork-server exec bun test src/cloud-mcp-health.test.ts src/cloud-mcp-reconcile.e2e.test.ts src/mcp.engine-sync.e2e.test.ts src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts` — 39 passed
- `pnpm --filter @openwork/app exec bun test tests/session-mcp-maintenance.test.ts tests/cloud-mcp-user-state.test.ts tests/connect-view.test.ts tests/cloud-mcp-health.test.ts` — 37 passed
- `pnpm --filter @openwork/app exec bun test tests/diagnostics-bundle.test.ts` — 3 passed
- `pnpm --filter openwork-server exec bun test src/connect-state.test.ts src/extensions-connect-gating.test.ts src/opencode-plugins/openwork-extensions-preview.test.ts src/opencode-plugins/openwork-capabilities-knowledge.test.ts` — 16 passed after correcting the strict-config fixture
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter openwork-server build` — passed
- `pnpm --filter @openwork/app build` — passed with existing Vite chunk/directive warnings

## Fraimz / untested
- Approved voiceover and coded flow are included at `evals/voiceovers/cloud-mcp-reliability.md` and `evals/flows/cloud-mcp-reliability.flow.mjs`.
- **Incomplete:** the real `pnpm fraimz --flow cloud-mcp-reliability --stack den` run was not completed, so there is no validated `fraimz.html` or screenshot/video proof yet.
- Consequently, the real Settings click-through, live repair against the Den stack, clipboard interaction, and model-driven search→execute ordering are **not end-to-end validated**.
- Sign-out cleanup is currently limited to the active exact workspace because Settings only safely owns that workspace client/directory.
