### PR TITLE
Fix roadmap contrast in Safari

### DIFF
--- a/ee/apps/landing/components/roadmap-page-shell.tsx
+++ b/ee/apps/landing/components/roadmap-page-shell.tsx
@@ -1,20 +1,18 @@
 import { OpenWorkRoadmap } from "@openwork/ui/react";
-import { LandingBackground } from "./landing-background";
 import { SiteFooter } from "./site-footer";
 import { SiteNav } from "./site-nav";
 
 export function RoadmapPageShell({ stars }: { stars: string }) {
   return (
-    <div className="relative min-h-screen overflow-hidden text-[#011627]">
-      <LandingBackground />
-
-      <div className="relative z-10">
-        <SiteNav stars={stars} active="roadmap" />
-        <main className="mx-auto w-full max-w-6xl px-6 md:px-8">
-          <OpenWorkRoadmap />
-          <SiteFooter />
-        </main>
-      </div>
+    <div
+      data-testid="roadmap-page-shell"
+      className="min-h-screen overflow-hidden bg-[#f6f9fc] text-[#011627]"
+    >
+      <SiteNav stars={stars} active="roadmap" />
+      <main className="mx-auto w-full max-w-6xl px-6 md:px-8">
+        <OpenWorkRoadmap />
+        <SiteFooter />
+      </main>
     </div>
   );
 }

--- a/evals/flows/roadmap-every-surface.flow.mjs
+++ b/evals/flows/roadmap-every-surface.flow.mjs
@@ -90,11 +90,14 @@ export default {
           assert: async () => {
             const actual = await ctx.eval(`(() => {
               const roadmap = document.querySelector('[data-testid="openwork-roadmap"]');
+              const shell = document.querySelector('[data-testid="roadmap-page-shell"]');
               const text = roadmap?.innerText || "";
               const firstSectionAfterHero = roadmap?.children[1]?.querySelector("#desktop-home");
               return {
                 path: location.pathname,
                 roadmapExists: Boolean(roadmap),
+                shellBackground: shell ? getComputedStyle(shell).backgroundColor : null,
+                shaderCanvasCount: shell?.querySelectorAll("canvas").length ?? null,
                 startsWithDesktopSection: Boolean(firstSectionAfterHero),
                 hasRemovedWindowLabel: text.includes("Home base · live"),
                 hasRemovedProjectLabel: text.includes("Project workspace"),
@@ -102,9 +105,11 @@ export default {
             })()`);
             recordAssertion(
               ctx,
-              "The introduction is followed by the desktop roadmap section and the removed diagram labels are absent",
+              "The roadmap has a solid background with no shader canvas and the introduction is followed by the desktop section",
               actual.path === "/roadmap"
                 && actual.roadmapExists === true
+                && actual.shellBackground === "rgb(246, 249, 252)"
+                && actual.shaderCanvasCount === 0
                 && actual.startsWithDesktopSection === true
                 && actual.hasRemovedWindowLabel === false
                 && actual.hasRemovedProjectLabel === false,


### PR DESCRIPTION
## What changed

- Removed the animated grain shader from the shared roadmap page shell.
- Gave `/roadmap` and `/docs/roadmap` an explicit solid `#f6f9fc` background.
- Extended the existing roadmap Fraimz flow to assert the shell background and verify that no shader canvas is mounted.

## Root cause

The roadmap reused the homepage `PaperGrainGradient` background. Safari composited the fixed WebGL canvas over the roadmap content despite the intended z-index ordering, which obscured large parts of the page and reduced text contrast.

## User impact

Both roadmap routes now render on a stable light background in every browser. The homepage keeps its existing animated background.

## Validation

- `pnpm install --frozen-lockfile`
- `pnpm --filter @openwork-ee/landing build`
- `OPENWORK_EVAL_LANDING_URL=http://127.0.0.1:4312 pnpm fraimz --flow roadmap-every-surface --cdp-url http://127.0.0.1:9931`

Fraimz result: Passed, 6 frames with voiceover coverage.