### PR TITLE
Fix Gmail draft hard wrapping after send

### DIFF
--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -287,7 +287,13 @@ describe("Google Workspace extension", () => {
       to: ["accounts.payable@acme.test"],
       cc: ["purchasing.admin@acme.test", "casey.jordan@acme.test"],
       subject: "Invoice ACME-2026-001 for PO-000123",
-      body: "Please find attached invoice ACME-2026-001 for PO-000123.",
+      body: [
+        "Please find attached invoice ACME-2026-001 for PO-000123 and review",
+        "the proposed commercial terms before our next call.",
+        "",
+        "Thanks,",
+        "OpenWork",
+      ].join("\n"),
       attachments: [{ path: "invoices/acme-invoice-2026-001.pdf" }],
     }, { directory: workspaceRoot });
     expect(result?.ok).toBe(true);
@@ -299,7 +305,7 @@ describe("Google Workspace extension", () => {
     expect(decoded).toContain("Cc: purchasing.admin@acme.test, casey.jordan@acme.test");
     expect(decoded).toContain("Subject: Invoice ACME-2026-001 for PO-000123");
     expect(decoded).toContain("Content-Type: multipart/mixed;");
-    expect(decoded).toContain("Please find attached invoice ACME-2026-001 for PO-000123.");
+    expect(decoded).toContain("Please find attached invoice ACME-2026-001 for PO-000123 and review the proposed commercial terms before our next call.\n\nThanks,\nOpenWork");
     expect(decoded).toContain("Content-Type: application/pdf; name=\"acme-invoice-2026-001.pdf\"");
     expect(decoded).toContain("Content-Disposition: attachment; filename=\"acme-invoice-2026-001.pdf\"");
     expect(decoded).toContain(Buffer.from("%PDF-1.4\ninvoice bytes\n", "utf8").toString("base64"));

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -9,6 +9,7 @@ import type { ServerConfig } from "../types.js";
 
 export const GOOGLE_WORKSPACE_EXTENSION_ID = "google-workspace";
 
+const GMAIL_HARD_WRAP_MIN_LINE_LENGTH = 50;
 const GOOGLE_WORKSPACE_DESKTOP_CLIENT_ID = "929071212606-pmkqimjhm2tnp68kbklnout0irllj99h.apps.googleusercontent.com";
 const GOOGLE_WORKSPACE_CLIENT_ID_ENV = "OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID";
 const GOOGLE_WORKSPACE_CLIENT_SECRET_ENV = "GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET";
@@ -81,7 +82,7 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
         cc: { type: "array", items: { type: "string" }, description: "Optional CC recipients." },
         bcc: { type: "array", items: { type: "string" }, description: "Optional BCC recipients." },
         subject: { type: "string", description: "Draft subject." },
-        body: { type: "string", description: "Plain text draft body." },
+        body: { type: "string", description: "Plain text draft body. Separate paragraphs with blank lines and do not hard-wrap prose." },
         attachments: {
           type: "array",
           description: "Optional local files to attach. Paths may be relative to the active workspace/directory or absolute under an authorized workspace root.",
@@ -771,11 +772,12 @@ function gmailRawMessage(input: { to: string[]; cc?: string[]; bcc?: string[]; s
     ...(input.headers ?? []).map((header) => `${header.name}: ${header.value}`),
   ].filter((line): line is string => typeof line === "string");
   const attachments = input.attachments ?? [];
+  const body = normalizeGmailDraftBody(input.body);
   if (!attachments.length) return [
     ...headers,
     "Content-Type: text/plain; charset=UTF-8",
     "",
-    input.body,
+    body,
   ].filter((line): line is string => typeof line === "string").join("\r\n");
 
   const boundary = `openwork-${randomBytes(16).toString("hex")}`;
@@ -788,7 +790,7 @@ function gmailRawMessage(input: { to: string[]; cc?: string[]; bcc?: string[]; s
     "Content-Type: text/plain; charset=UTF-8",
     "Content-Transfer-Encoding: 8bit",
     "",
-    input.body,
+    body,
     ...attachments.flatMap((attachment) => [
       `--${boundary}`,
       `Content-Type: ${attachment.mimeType}; name="${gmailMimeParameter(attachment.filename)}"`,
@@ -800,6 +802,20 @@ function gmailRawMessage(input: { to: string[]; cc?: string[]; bcc?: string[]; s
     `--${boundary}--`,
     "",
   ].join("\r\n");
+}
+
+// Generated prose is sometimes hard-wrapped before it reaches Gmail. Those
+// literal breaks become visible after send, especially on narrow screens.
+function normalizeGmailDraftBody(body: string): string {
+  return body.replace(/\r\n?/g, "\n").replace(/[^\n]+(?:\n[^\n]+)+/g, (block) => {
+    const lines = block.split("\n");
+    const hasStructure = lines.some((line) => {
+      const trimmed = line.trimStart();
+      return trimmed.length !== line.length || /^(?:[-*+•]\s|\d+[.)]\s|>|```|~~~)/.test(trimmed);
+    });
+    const looksHardWrapped = lines.slice(0, -1).every((line) => line.trimEnd().length >= GMAIL_HARD_WRAP_MIN_LINE_LENGTH);
+    return hasStructure || !looksHardWrapped ? block : lines.map((line) => line.trim()).join(" ");
+  });
 }
 
 function splitEmailHeader(value: string): string[] {

--- a/ee/apps/den-api/src/capability-sources/gmail.ts
+++ b/ee/apps/den-api/src/capability-sources/gmail.ts
@@ -6,6 +6,8 @@
 
 import { randomUUID } from "node:crypto"
 
+const HARD_WRAP_MIN_LINE_LENGTH = 50
+
 function hasNonAscii(value: string): boolean {
   for (const char of value) {
     if (char.codePointAt(0)! > 0x7e || char.codePointAt(0)! < 0x20) return true
@@ -25,6 +27,20 @@ function encodeMimeParameter(value: string): string {
 
 function base64MimeContent(content: Buffer): string {
   return content.toString("base64").match(/.{1,76}/g)?.join("\r\n") ?? ""
+}
+
+// Generated prose is sometimes hard-wrapped before it reaches Gmail. Those
+// literal breaks become visible after send, especially on narrow screens.
+function normalizeDraftBody(body: string): string {
+  return body.replace(/\r\n?/g, "\n").replace(/[^\n]+(?:\n[^\n]+)+/g, (block) => {
+    const lines = block.split("\n")
+    const hasStructure = lines.some((line) => {
+      const trimmed = line.trimStart()
+      return trimmed.length !== line.length || /^(?:[-*+•]\s|\d+[.)]\s|>|```|~~~)/.test(trimmed)
+    })
+    const looksHardWrapped = lines.slice(0, -1).every((line) => line.trimEnd().length >= HARD_WRAP_MIN_LINE_LENGTH)
+    return hasStructure || !looksHardWrapped ? block : lines.map((line) => line.trim()).join(" ")
+  })
 }
 
 /** RFC 2047 B-encoding for header values that contain non-ASCII characters. */
@@ -63,13 +79,14 @@ export function buildGmailDraftRaw(input: { to: string; cc?: string; bcc?: strin
     ...(input.headers ?? []).map((header) => `${header.name}: ${header.value}`),
   ].filter((line) => typeof line === "string")
   const attachments = input.attachments ?? []
+  const body = normalizeDraftBody(input.body)
   const message = attachments.length === 0 ? [
     ...headers,
     "MIME-Version: 1.0",
     'Content-Type: text/plain; charset="UTF-8"',
     "Content-Transfer-Encoding: base64",
     "",
-    Buffer.from(input.body, "utf8").toString("base64"),
+    Buffer.from(body, "utf8").toString("base64"),
   ].join("\r\n") : (() => {
     const boundary = `openwork-${randomUUID()}`
     return [
@@ -81,7 +98,7 @@ export function buildGmailDraftRaw(input: { to: string; cc?: string; bcc?: strin
       'Content-Type: text/plain; charset="UTF-8"',
       "Content-Transfer-Encoding: base64",
       "",
-      Buffer.from(input.body, "utf8").toString("base64"),
+      Buffer.from(body, "utf8").toString("base64"),
       ...attachments.flatMap((attachment) => [
         `--${boundary}`,
         `Content-Type: ${attachment.mimeType}; name="${encodeMimeParameter(attachment.filename)}"`,

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -46,7 +46,7 @@ const createDraftBodySchema = z.object({
   cc: z.string().trim().min(3).max(1_000).optional().describe("Optional comma-separated Cc email addresses."),
   bcc: z.string().trim().min(3).max(1_000).optional().describe("Optional comma-separated Bcc email addresses."),
   subject: z.string().trim().min(1).max(500).describe("Draft subject line."),
-  body: z.string().min(1).max(50_000).describe("Plain-text draft body."),
+  body: z.string().min(1).max(50_000).describe("Plain-text draft body. Separate paragraphs with blank lines and do not hard-wrap prose."),
   threadId: z.string().trim().min(1).max(512).optional().describe("Optional Gmail thread id to reply on. Get it from the gmail-messages capability. When set, the draft is attached to that thread as a reply — keep the thread's subject (e.g. 'Re: …')."),
   attachments: z.array(gmailDraftAttachmentSchema).min(1).max(10).optional().describe("Optional files from the active workspace to attach to this draft."),
 }).strict().superRefine((input, context) => {

--- a/ee/apps/den-api/test/gmail-draft.test.ts
+++ b/ee/apps/den-api/test/gmail-draft.test.ts
@@ -44,6 +44,36 @@ describe("buildGmailDraftRaw", () => {
     expect(Buffer.from(bodyPart, "base64").toString("utf8")).toBe("Grüße aus Zürich ✅")
   })
 
+  test("unwraps hard-wrapped prose without changing paragraphs, short breaks, or lists", () => {
+    const body = [
+      "Thanks again for the conversation today. As promised, I have attached",
+      "a revised indicative pricing proposal for the air-gapped on-premises",
+      "deployment, covering both the minimal self-managed path and a",
+      "full-support option.",
+      "",
+      "Options:",
+      "- Self-managed deployment",
+      "- Full-support deployment",
+      "",
+      "Thanks again!",
+      "",
+      "Ben",
+    ].join("\n")
+    const decoded = decodeRaw(gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Follow up", body }))
+    const bodyPart = decoded.split("\r\n\r\n")[1]
+    expect(Buffer.from(bodyPart, "base64").toString("utf8")).toBe([
+      "Thanks again for the conversation today. As promised, I have attached a revised indicative pricing proposal for the air-gapped on-premises deployment, covering both the minimal self-managed path and a full-support option.",
+      "",
+      "Options:",
+      "- Self-managed deployment",
+      "- Full-support deployment",
+      "",
+      "Thanks again!",
+      "",
+      "Ben",
+    ].join("\n"))
+  })
+
   test("keeps legacy draft output unchanged when optional fields are absent", () => {
     const raw = gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Follow up", body: "Hello Sam" })
     expect(decodeRaw(raw)).toBe([


### PR DESCRIPTION
## Summary

- Normalize conventional hard-wrapped prose before both Google Workspace Gmail draft builders create their MIME payloads.
- Preserve intentional formatting such as paragraph gaps, short sign-offs, quotes, indentation, and list markers.
- Tell agents not to hard-wrap prose and cover the reported 60–70-column wrapping pattern with regressions for hosted and local draft paths.

## Root cause

The Gmail integrations accepted a plain-text body and preserved every literal newline. Agent-generated email prose can arrive hard-wrapped around 60–70 characters. A wide desktop draft view makes those breaks difficult to distinguish from normal visual wrapping; after send, a narrow client combines the literal breaks with its own wrapping and produces the ragged fragments in the report.

The fix unwraps only prose blocks whose non-final lines all look like conventional 50+ character hard wraps. Blank-line paragraphs and structured text remain byte-for-byte separated.

## Validation

- `bun test ee/apps/den-api/test/gmail-draft.test.ts` — 14 passed, 0 failed.
- `bun test apps/server/src/extensions/google-workspace.test.ts` — 16 passed, 0 failed.
- `pnpm exec tsc --noEmit` from `ee/apps/den-api` — passed.
- `pnpm --filter openwork-server typecheck` — passed.
- `pnpm --filter openwork-server test` — 315 passed, 6 skipped, 1 unrelated environment-sensitive failure because the test saw the user's globally configured `exa` MCP. The failing file passed all 8 assertions with an isolated `HOME`, although Bun exited with signal 133 after reporting 0 failures.
- `bun test ee/apps/den-api/test/google-workspace-capabilities.test.ts` — could not run because the local MySQL database `openwork_test_gwscaps` does not exist.

Fraimz, voiceover, browser automation, and video were skipped at the requester's direction. This server-side MIME transformation is covered by direct payload assertions.
