### PR TITLE
fix(den): standardize workspace reauthentication

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/access.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/access.ts
@@ -13,7 +13,7 @@ import {
 } from "@openwork-ee/den-db/schema"
 import type { MemberTeamSummary, OrganizationContext } from "../../../orgs.js"
 import { db } from "../../../db.js"
-import { hasFreshPrivilegedSession, memberHasRole } from "../shared.js"
+import { getFreshPrivilegedSessionRequiredResponse, hasFreshPrivilegedSession, memberHasRole } from "../shared.js"
 
 export type PluginArchResourceKind = "config_object" | "connector_instance" | "marketplace" | "plugin"
 export type PluginArchRole = "viewer" | "editor" | "manager"
@@ -107,7 +107,8 @@ function ensureFreshPluginArchAdmin(context: PluginArchActorContext) {
     return
   }
 
-  throw new PluginArchAuthorizationError(403, "reauth", "For security, confirm it's you before changing workspace settings.", "fresh_auth_required")
+  const response = getFreshPrivilegedSessionRequiredResponse()
+  throw new PluginArchAuthorizationError(403, response.error, response.message, response.reason)
 }
 
 function roleSatisfies(role: PluginArchRole | null, required: PluginArchRole) {

--- a/ee/apps/den-api/src/routes/org/shared.ts
+++ b/ee/apps/den-api/src/routes/org/shared.ts
@@ -17,6 +17,21 @@ export type OrgRouteVariables =
   & Partial<MemberTeamsContext>
 
 export const PRIVILEGED_SESSION_MAX_AGE_MS = 15 * 60 * 1000
+export const WORKSPACE_REAUTH_SECURITY_MESSAGE = "For security, confirm it's you before changing workspace settings."
+
+export type FreshPrivilegedSessionRequiredResponse = {
+  error: "reauth"
+  reason: "fresh_auth_required"
+  message: string
+}
+
+export function getFreshPrivilegedSessionRequiredResponse(): FreshPrivilegedSessionRequiredResponse {
+  return {
+    error: "reauth",
+    reason: "fresh_auth_required",
+    message: WORKSPACE_REAUTH_SECURITY_MESSAGE,
+  }
+}
 
 type PrivilegedOrgRouteContext = {
   get: <K extends "organizationContext" | "session">(key: K) => OrgRouteVariables[K]
@@ -49,11 +64,7 @@ function ensureFreshPrivilegedSession(c: { get: (key: "session") => OrgRouteVari
 
   return {
     ok: false as const,
-    response: {
-      error: "reauth",
-      reason: "fresh_auth_required",
-      message: "For security, confirm it's you before changing workspace settings.",
-    },
+    response: getFreshPrivilegedSessionRequiredResponse(),
   }
 }
 

--- a/ee/apps/den-api/test/org-identity-access.test.ts
+++ b/ee/apps/den-api/test/org-identity-access.test.ts
@@ -111,3 +111,11 @@ test("reauth failures remain forbidden responses", () => {
   expect(sharedModule.orgAccessFailureStatus({ error: "forbidden" })).toBe(403)
   expect(sharedModule.orgAccessFailureStatus({ error: "organization_not_found" })).toBe(404)
 })
+
+test("freshness failures share the standardized reauth response", () => {
+  expect(sharedModule.getFreshPrivilegedSessionRequiredResponse()).toEqual({
+    error: "reauth",
+    reason: "fresh_auth_required",
+    message: sharedModule.WORKSPACE_REAUTH_SECURITY_MESSAGE,
+  })
+})

--- a/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
@@ -5,12 +5,8 @@ import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
 import { DenButton, buttonVariants } from "./ui/button";
 import { DenInput } from "./ui/input";
 import { DenNotice } from "./ui/notice";
-import { type AuthUser, getErrorMessage, getUser, requestJson, type SocialAuthProvider } from "../_lib/den-flow";
+import { type AuthUser, getErrorMessage, getUser, requestJson, type SocialAuthProvider, WORKSPACE_REAUTH_SECURITY_MESSAGE } from "../_lib/den-flow";
 import { type DenOrgContext, getRequireSsoFromMetadata } from "../_lib/den-org";
-
-function getCurrentUrl() {
-  return typeof window === "undefined" ? "/" : window.location.href;
-}
 
 function getSocialLabel(provider: SocialAuthProvider) {
   return provider === "google" ? "Google" : "GitHub";
@@ -112,6 +108,7 @@ export function ReauthDialog({
         return;
       }
       stopPopupWatcher();
+      setError("The sign-in window was closed before confirmation. Try again when you're ready.");
       setBusy(false);
     }, 500);
   }
@@ -215,7 +212,7 @@ export function ReauthDialog({
   async function submitPassword(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
     if (!user?.email) {
-      setError("Confirm it's you to continue.");
+      setError(WORKSPACE_REAUTH_SECURITY_MESSAGE);
       return;
     }
 
@@ -243,11 +240,16 @@ export function ReauthDialog({
 
   async function continueSocial(provider: SocialAuthProvider) {
     const popup = window.open("", "openwork-reauth", "popup,width=480,height=640");
+    if (!popup) {
+      setError("OpenWork could not open the sign-in window. Allow popups for OpenWork, then try again.");
+      return;
+    }
+
     setBusy(true);
     setError(null);
     try {
-      const callbackURL = popup ? getReauthCompleteUrl(nonce) : getCurrentUrl();
-      const errorCallbackURL = popup ? getReauthCompleteUrl(nonce, true) : callbackURL;
+      const callbackURL = getReauthCompleteUrl(nonce);
+      const errorCallbackURL = getReauthCompleteUrl(nonce, true);
       const { response, payload } = await requestJson("/api/auth/sign-in/social", {
         method: "POST",
         body: JSON.stringify({ provider, callbackURL, errorCallbackURL }),
@@ -267,11 +269,6 @@ export function ReauthDialog({
         return;
       }
 
-      if (!popup) {
-        window.location.assign(redirectUrl);
-        return;
-      }
-
       popup.location.href = redirectUrl;
       startPopupWatcher(popup);
     } catch (nextError) {
@@ -288,17 +285,17 @@ export function ReauthDialog({
     }
 
     const popup = window.open("", "openwork-reauth", "popup,width=480,height=640");
+    if (!popup) {
+      setError("OpenWork could not open the sign-in window. Allow popups for OpenWork, then try again.");
+      return;
+    }
+
     setBusy(true);
     setError(null);
     try {
       const nextUrl = new URL(ssoUrl, window.location.origin);
-      nextUrl.searchParams.set("callbackURL", popup ? getReauthCompleteUrl(nonce) : getCurrentUrl());
+      nextUrl.searchParams.set("callbackURL", getReauthCompleteUrl(nonce));
       nextUrl.searchParams.set("loginHint", user.email);
-
-      if (!popup) {
-        window.location.assign(nextUrl.toString());
-        return;
-      }
 
       popup.location.href = nextUrl.toString();
       startPopupWatcher(popup);
@@ -339,10 +336,10 @@ export function ReauthDialog({
           <div className="grid gap-2 pr-8">
             <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">Security check</p>
             <h2 id="reauth-dialog-title" className="text-[22px] font-semibold tracking-[-0.03em] text-slate-950">
-              Confirm it's you to continue
+              {WORKSPACE_REAUTH_SECURITY_MESSAGE}
             </h2>
             <p className="text-[14px] leading-6 text-slate-600">
-              Changing workspace settings requires a recent sign-in. OpenWork retries the pending action automatically after you confirm.
+              OpenWork retries the pending action automatically after you confirm.
             </p>
           </div>
         </div>

--- a/ee/apps/den-web/app/(den)/_components/ui/notice.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/notice.tsx
@@ -1,10 +1,10 @@
 import { CircleAlert, Info } from "lucide-react";
+import { WORKSPACE_REAUTH_SECURITY_MESSAGE } from "../../_lib/den-flow";
 
 type DenNoticeTone = "error" | "info";
 
 const ROUTINE_SECURITY_MESSAGES = new Set([
-  "For security, confirm it's you before changing workspace settings.",
-  "Confirm it's you before continuing.",
+  WORKSPACE_REAUTH_SECURITY_MESSAGE,
 ]);
 
 export function DenNotice({

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -181,6 +181,7 @@ export const PENDING_AUTH_INTENT_STORAGE_KEY = "openwork:web:pending-auth-intent
 export const WORKER_STATUS_POLL_MS = DEN_WORKER_POLL_INTERVAL_MS;
 export const DEFAULT_AUTH_NAME = "OpenWork User";
 export const DEFAULT_WORKER_NAME = "My Worker";
+export const WORKSPACE_REAUTH_SECURITY_MESSAGE = "For security, confirm it's you before changing workspace settings.";
 
 export type AuthIntent = "models";
 
@@ -462,7 +463,7 @@ export function getReauthRequiredError(payload: unknown, response: Response): Re
   }
 
   return new ReauthRequiredError(
-    getErrorMessage(payload, "Sign in again before continuing."),
+    getErrorMessage(payload, WORKSPACE_REAUTH_SECURITY_MESSAGE),
     typeof payload.reason === "string" ? payload.reason : null,
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/api-keys-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/api-keys-screen.tsx
@@ -7,7 +7,7 @@ import { DenButton } from "../../_components/ui/button";
 import { DenNotice } from "../../_components/ui/notice";
 import { DenCard } from "../../_components/ui/card";
 import { DenInput } from "../../_components/ui/input";
-import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
+import { getRequestError, isReauthRequiredError, requestJson } from "../../_lib/den-flow";
 import {
     getOrgAccessFlags,
     parseOrgApiKeysPayload,
@@ -75,14 +75,18 @@ export function ApiKeysScreen() {
         [orgContext?.currentMember.isOwner, orgContext?.currentMember.role, orgContext?.roles],
     );
 
-    async function loadApiKeys() {
+    async function loadApiKeys(isCurrent = () => true) {
         if (!orgId || !access.canManageApiKeys) {
-            setApiKeys([]);
+            if (isCurrent()) {
+                setApiKeys([]);
+            }
             return;
         }
 
-        setBusy(true);
-        setError(null);
+        if (isCurrent()) {
+            setBusy(true);
+            setError(null);
+        }
         try {
             const { response, payload } = await requestJson(
                 `/v1/api-keys`,
@@ -90,28 +94,45 @@ export function ApiKeysScreen() {
                 12000,
             );
             if (!response.ok) {
-                throw new Error(
-                    getErrorMessage(
-                        payload,
-                        `Failed to load API keys (${response.status}).`,
-                    ),
-                );
+                throw getRequestError(payload, response, `Failed to load API keys (${response.status}).`);
             }
 
-            setApiKeys(parseOrgApiKeysPayload(payload));
+            if (isCurrent()) {
+                setApiKeys(parseOrgApiKeysPayload(payload));
+            }
         } catch (nextError) {
-            setError(
-                nextError instanceof Error
-                    ? nextError.message
-                    : "Failed to load API keys.",
-            );
+            if (isReauthRequiredError(nextError)) {
+                throw nextError;
+            }
+
+            if (isCurrent()) {
+                setError(
+                    nextError instanceof Error
+                        ? nextError.message
+                        : "Failed to load API keys.",
+                );
+            }
         } finally {
-            setBusy(false);
+            if (isCurrent()) {
+                setBusy(false);
+            }
         }
     }
 
     useEffect(() => {
-        void loadApiKeys();
+        let active = true;
+        void runReauthableAction("load-api-keys", () => loadApiKeys(() => active)).catch((nextError) => {
+            if (active) {
+                setError(
+                    nextError instanceof Error
+                        ? nextError.message
+                        : "Failed to load API keys.",
+                );
+            }
+        });
+        return () => {
+            active = false;
+        };
     }, [orgId, access.canManageApiKeys]);
 
     useEffect(() => {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/billing-dashboard-screen.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { CreditCard, RefreshCw } from "lucide-react";
 import { DenButton, buttonVariants } from "../../_components/ui/button";
+import { DenNotice } from "../../_components/ui/notice";
 import { formatMoneyMinor, formatSubscriptionStatus, getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { getInferenceRoute, getMembersRoute } from "../../_lib/den-org";
@@ -182,16 +183,20 @@ export function BillingDashboardScreen() {
       attempts += 1;
       if (attempts === 1 && sessionId) {
         try {
-          const { response, payload } = await requestJson(
-            "/v1/billing/stripe/checkout/sync",
-            { method: "POST", body: JSON.stringify({ sessionId }) },
-            12000,
-          );
-          if (!response.ok) {
-            setStripeError(getErrorMessage(payload, `Stripe checkout sync failed (${response.status}).`));
-          }
+          await runReauthableAction("stripe-checkout-sync", async () => {
+            const { response, payload } = await requestJson(
+              "/v1/billing/stripe/checkout/sync",
+              { method: "POST", body: JSON.stringify({ sessionId }) },
+              12000,
+            );
+            if (!response.ok) {
+              setStripeError(getErrorMessage(payload, `Stripe checkout sync failed (${response.status}).`));
+            }
+          });
         } catch (error) {
-          setStripeError(error instanceof Error ? error.message : "Could not sync Stripe checkout session.");
+          if (!cancelled) {
+            setStripeError(error instanceof Error ? error.message : "Could not sync Stripe checkout session.");
+          }
         }
       }
       const billing = await refreshStripeBilling(true);
@@ -271,9 +276,7 @@ export function BillingDashboardScreen() {
         colors={["#F5F3FF", "#312E81", "#635BFF", "#C4B5FD"]}
       >
       {stripeError && stripeBilling ? (
-        <div className="mb-6 rounded-[20px] border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700">
-          {stripeError}
-        </div>
+        <DenNotice message={stripeError} className="mb-6" />
       ) : null}
 
       {isOwner ? null : (

--- a/ee/apps/den-web/app/(den)/dashboard/_components/integration-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/integration-data.tsx
@@ -442,73 +442,84 @@ export function useStartGithubInstall() {
 }
 
 export function useGithubInstallCompletion(input: { installationId: number | null; state: string | null }) {
+  const { runReauthableAction } = useOrgDashboard();
+
   return useQuery({
     enabled: Number.isFinite(input.installationId ?? NaN) && (input.installationId ?? 0) > 0 && Boolean(input.state?.trim()),
     queryKey: [...integrationQueryKeys.githubInstall(input.installationId), input.state ?? "no-state"] as const,
     retry: false,
     queryFn: async (): Promise<GithubInstallCompleteResult> => {
-      const { response, payload } = await requestJson(
-        "/v1/connectors/github/install/complete",
-        {
-          method: "POST",
-          body: JSON.stringify({ installationId: input.installationId, state: input.state }),
-        },
-        20000,
-      );
+      let result: GithubInstallCompleteResult | null = null;
+      await runReauthableAction("complete-github-install", async () => {
+        const { response, payload } = await requestJson(
+          "/v1/connectors/github/install/complete",
+          {
+            method: "POST",
+            body: JSON.stringify({ installationId: input.installationId, state: input.state }),
+          },
+          20000,
+        );
 
-      if (!response.ok) {
-        throw new Error(getErrorMessage(payload, `Failed to complete GitHub installation (${response.status}).`));
-      }
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to complete GitHub installation (${response.status}).`);
+        }
 
-      const item = isRecord(payload) && isRecord(payload.item) ? payload.item : null;
-      const connectorAccount = item && isRecord(item.connectorAccount) ? item.connectorAccount : null;
-      const repositories = item && Array.isArray(item.repositories)
-        ? item.repositories.flatMap((entry) => {
-            if (!isRecord(entry)) {
-              return [];
-            }
+        const item = isRecord(payload) && isRecord(payload.item) ? payload.item : null;
+        const connectorAccount = item && isRecord(item.connectorAccount) ? item.connectorAccount : null;
+        const repositories = item && Array.isArray(item.repositories)
+          ? item.repositories.flatMap((entry) => {
+              if (!isRecord(entry)) {
+                return [];
+              }
 
-            const id = typeof entry.id === "number" ? String(entry.id) : asString(entry.id);
-            const fullName = asString(entry.fullName);
-            if (!id || !fullName) {
-              return [];
-            }
+              const id = typeof entry.id === "number" ? String(entry.id) : asString(entry.id);
+              const fullName = asString(entry.fullName);
+              if (!id || !fullName) {
+                return [];
+              }
 
-            const manifestKindValue = entry.manifestKind;
-            const manifestKind: IntegrationRepoManifestKind = manifestKindValue === "marketplace" || manifestKindValue === "plugin"
-              ? manifestKindValue
-              : null;
-            return [{
-              defaultBranch: asNullableString(entry.defaultBranch),
-              description: manifestKind === "marketplace"
-                ? "Claude marketplace manifest detected."
-                : manifestKind === "plugin"
-                  ? "Claude plugin manifest detected."
-                  : "Repository available to connect.",
-              fullName,
-              hasPluginManifest: Boolean(entry.hasPluginManifest),
-              hasPlugins: Boolean(entry.hasPluginManifest),
-              id,
-              manifestKind,
-              marketplacePluginCount: typeof entry.marketplacePluginCount === "number" ? entry.marketplacePluginCount : null,
-              name: toRepoName(fullName),
-              private: Boolean(entry.private),
-            } satisfies IntegrationRepo];
-          })
-        : [];
+              const manifestKindValue = entry.manifestKind;
+              const manifestKind: IntegrationRepoManifestKind = manifestKindValue === "marketplace" || manifestKindValue === "plugin"
+                ? manifestKindValue
+                : null;
+              return [{
+                defaultBranch: asNullableString(entry.defaultBranch),
+                description: manifestKind === "marketplace"
+                  ? "Claude marketplace manifest detected."
+                  : manifestKind === "plugin"
+                    ? "Claude plugin manifest detected."
+                    : "Repository available to connect.",
+                fullName,
+                hasPluginManifest: Boolean(entry.hasPluginManifest),
+                hasPlugins: Boolean(entry.hasPluginManifest),
+                id,
+                manifestKind,
+                marketplacePluginCount: typeof entry.marketplacePluginCount === "number" ? entry.marketplacePluginCount : null,
+                name: toRepoName(fullName),
+                private: Boolean(entry.private),
+              } satisfies IntegrationRepo];
+            })
+          : [];
 
-      if (!connectorAccount || !asString(connectorAccount.id) || !asString(connectorAccount.displayName)) {
+        const connectorAccountId = connectorAccount ? asString(connectorAccount.id) : null;
+        const connectorAccountName = connectorAccount ? asString(connectorAccount.displayName) : null;
+        if (!connectorAccount || !connectorAccountId || !connectorAccountName) {
+          throw new Error("GitHub install completion response was incomplete.");
+        }
+
+        result = {
+          connectorAccount: {
+            displayName: connectorAccountName,
+            id: connectorAccountId,
+            metadata: isRecord(connectorAccount.metadata) ? connectorAccount.metadata : undefined,
+          },
+          repositories,
+        };
+      });
+      if (!result) {
         throw new Error("GitHub install completion response was incomplete.");
       }
-
-      return {
-        connectorAccount: {
-          displayName: asString(connectorAccount.displayName) ?? "GitHub",
-          id: asString(connectorAccount.id) ?? "",
-          metadata: isRecord(connectorAccount.metadata) ? connectorAccount.metadata : undefined,
-        },
-        repositories,
-      };
+      return result;
     },
   });
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -454,21 +454,29 @@ export function useSaveNativeProviderClient() {
 }
 
 export function useNativeProviderClient(providerId: string, enabled: boolean) {
-  const { orgId } = useOrgDashboard();
+  const { orgId, runReauthableAction } = useOrgDashboard();
 
   return useQuery({
     enabled: enabled && Boolean(orgId),
     queryKey: mcpConnectionQueryKeys.nativeProviderClient(orgId, providerId),
+    retry: false,
     queryFn: async (): Promise<NativeProviderClient> => {
-      const { response, payload } = await requestJson(
-        `/v1/oauth-providers/${encodeURIComponent(providerId)}/client`,
-        { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
-        15000,
-      );
-      if (!response.ok) {
-        throw getRequestError(payload, response, `Failed to load the OAuth client (${response.status}).`);
+      let client: NativeProviderClient | null = null;
+      await runReauthableAction("load-native-oauth-client", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/oauth-providers/${encodeURIComponent(providerId)}/client`,
+          { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to load the OAuth client (${response.status}).`);
+        }
+        client = parseNativeProviderClient(payload);
+      });
+      if (!client) {
+        throw new Error("Native provider client response was incomplete.");
       }
-      return parseNativeProviderClient(payload);
+      return client;
     },
   });
 }
@@ -561,18 +569,26 @@ function parseTelegramConnectionPayload(payload: unknown): TelegramConnection | 
 }
 
 export function useTelegramConnection(enabled: boolean) {
-  const { orgId } = useOrgDashboard();
+  const { orgId, runReauthableAction } = useOrgDashboard();
   return useQuery({
     enabled: enabled && Boolean(orgId),
     queryKey: mcpConnectionQueryKeys.telegram(orgId),
+    retry: false,
     queryFn: async (): Promise<TelegramConnection | null> => {
-      const { response, payload } = await requestJson(
-        "/v1/telegram/connection",
-        { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
-        15000,
-      );
-      if (!response.ok) throw getRequestError(payload, response, `Failed to load Telegram (${response.status}).`);
-      return parseTelegramConnectionPayload(payload);
+      let connection: TelegramConnection | null = null;
+      let loaded = false;
+      await runReauthableAction("load-telegram-connection", async () => {
+        const { response, payload } = await requestJson(
+          "/v1/telegram/connection",
+          { headers: getOrgScopeHeaders(requireOrgId(orgId)) },
+          15000,
+        );
+        if (!response.ok) throw getRequestError(payload, response, `Failed to load Telegram (${response.status}).`);
+        connection = parseTelegramConnectionPayload(payload);
+        loaded = true;
+      });
+      if (!loaded) throw new Error("Telegram connection response was incomplete.");
+      return connection;
     },
   });
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -6,6 +6,7 @@ import { useQueryClient } from "@tanstack/react-query";
 import { Check, ChevronDown, ChevronRight, Loader2, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
+import { DenNotice } from "../../_components/ui/notice";
 import { DenSelect } from "../../_components/ui/select";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { getPluginRoute } from "../../_lib/den-org";
@@ -1079,7 +1080,7 @@ function GoogleWorkspaceDialog({
         </div>
 
         {formError ? (
-          <p className="mt-3 text-[13px] text-red-600">{formError instanceof Error ? formError.message : "Failed to save the OAuth client."}</p>
+          <DenNotice message={formError instanceof Error ? formError.message : "Failed to save the OAuth client."} className="mt-3" />
         ) : null}
 
         <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/microsoft-365-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/microsoft-365-dialog.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 import { Check } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
+import { DenNotice } from "../../_components/ui/notice";
 import { useNativeProviderClient } from "./mcp-connections-data";
 import {
   MICROSOFT_365_DEFAULT_FEATURES,
@@ -224,7 +225,7 @@ export function Microsoft365Dialog({
         </div>
 
         {formError ? (
-          <p className="mt-3 text-[13px] text-red-600">{formError instanceof Error ? formError.message : "Failed to save the Microsoft 365 setup."}</p>
+          <DenNotice message={formError instanceof Error ? formError.message : "Failed to save the Microsoft 365 setup."} className="mt-3" />
         ) : null}
 
         <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
@@ -448,7 +448,7 @@ export function OrgSettingsScreen() {
                     icon={Pencil}
                     onClick={() => {
                       setPageError(null);
-                      setPageSuccess(null);
+                      clearOrgSettingsCompletion();
                       setDomainEditModeEnabled(true);
                     }}
                   >

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
@@ -89,6 +89,8 @@ export function OrgSettingsScreen() {
     orgBusy,
     orgError,
     mutationBusy,
+    orgSettingsCompletion,
+    clearOrgSettingsCompletion,
     updateOrganizationSettings,
   } = useOrgDashboard();
   const [orgNameDraft, setOrgNameDraft] = useState("");
@@ -108,7 +110,6 @@ export function OrgSettingsScreen() {
     string | null
   >(null);
   const [pageError, setPageError] = useState<string | null>(null);
-  const [pageSuccess, setPageSuccess] = useState<string | null>(null);
   const [copiedOrgId, setCopiedOrgId] = useState(false);
 
   const currentAllowedDomains =
@@ -131,6 +132,7 @@ export function OrgSettingsScreen() {
     draftVersions: allowedDesktopVersionsDraft,
     publishedVersions: desktopVersionOptions,
   });
+  const pageSuccess = orgSettingsCompletion?.message ?? null;
 
   useEffect(() => {
     if (!orgContext) {
@@ -269,7 +271,7 @@ export function OrgSettingsScreen() {
     }
 
     setPageError(null);
-    setPageSuccess(null);
+    clearOrgSettingsCompletion();
     setDomainRestrictionsEnabled(nextValue);
     setDomainEditModeEnabled(nextValue && !currentAllowedDomains?.length);
   }
@@ -277,7 +279,7 @@ export function OrgSettingsScreen() {
   async function handleSaveSettings(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setPageError(null);
-    setPageSuccess(null);
+    clearOrgSettingsCompletion();
 
     try {
       await updateOrganizationSettings({
@@ -295,7 +297,6 @@ export function OrgSettingsScreen() {
         requireSso: requireSsoEnabled,
       });
       setDomainEditModeEnabled(false);
-      setPageSuccess("Workspace settings updated.");
     } catch (error) {
       setPageError(
         error instanceof Error

--- a/ee/apps/den-web/app/(den)/dashboard/_components/scim-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/scim-screen.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
 import { DenNotice } from "../../_components/ui/notice";
-import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
+import { getRequestError, isReauthRequiredError, requestJson } from "../../_lib/den-flow";
 import {
   type DenOrgScimConnection,
   type DenOrgScimHealth,
@@ -84,9 +84,7 @@ export function ScimScreen() {
       );
 
       if (!response.ok) {
-        throw new Error(
-          getErrorMessage(payload, `Failed to load SCIM settings (${response.status}).`),
-        );
+        throw getRequestError(payload, response, `Failed to load SCIM settings (${response.status}).`);
       }
 
       const parsed = parseOrgScimPayload(payload);
@@ -96,6 +94,10 @@ export function ScimScreen() {
         setHealth(parsed.health);
       }
     } catch (nextError) {
+      if (isReauthRequiredError(nextError)) {
+        throw nextError;
+      }
+
       if (isCurrent()) {
         setError(
           nextError instanceof Error ? nextError.message : "Failed to load SCIM settings.",
@@ -110,7 +112,11 @@ export function ScimScreen() {
 
   useEffect(() => {
     let active = true;
-    void loadScimConfig(() => active);
+    void runReauthableAction("load-scim-settings", () => loadScimConfig(() => active)).catch((nextError) => {
+      if (active) {
+        setError(nextError instanceof Error ? nextError.message : "Failed to load SCIM settings.");
+      }
+    });
     return () => {
       active = false;
     };

--- a/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/sso-screen.tsx
@@ -5,7 +5,7 @@ import { useEffect, useMemo, useState } from "react";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
 import { DenNotice } from "../../_components/ui/notice";
-import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
+import { getRequestError, isReauthRequiredError, requestJson } from "../../_lib/den-flow";
 import { getOrgAccessFlags, parseOrgSsoPayload, type DenOrgSsoConnection } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { EnterprisePlanNotice } from "./enterprise-plan-notice";
@@ -52,28 +52,42 @@ export function SsoScreen() {
     [orgContext?.currentMember.isOwner, orgContext?.currentMember.role, orgContext?.roles],
   );
 
-  async function loadSsoConfig() {
+  async function loadSsoConfig(isCurrent = () => true) {
     if (!orgId || !access.canManageSso) {
-      setConnection(null);
+      if (isCurrent()) {
+        setConnection(null);
+      }
       return;
     }
 
-    setBusy(true);
-    setError(null);
+    if (isCurrent()) {
+      setBusy(true);
+      setError(null);
+    }
     try {
       const { response, payload } = await requestJson("/v1/sso", { method: "GET", headers: getOrgScopedHeaders() }, 12000);
       if (!response.ok) {
-        throw new Error(getErrorMessage(payload, `Failed to load SSO settings (${response.status}).`));
+        throw getRequestError(payload, response, `Failed to load SSO settings (${response.status}).`);
       }
 
       const parsed = parseOrgSsoPayload(payload);
-      setConnection(parsed.connection);
-      syncFormFromConnection(parsed.connection);
-      setEditing(false);
+      if (isCurrent()) {
+        setConnection(parsed.connection);
+        syncFormFromConnection(parsed.connection);
+        setEditing(false);
+      }
     } catch (nextError) {
-      setError(nextError instanceof Error ? nextError.message : "Failed to load SSO settings.");
+      if (isReauthRequiredError(nextError)) {
+        throw nextError;
+      }
+
+      if (isCurrent()) {
+        setError(nextError instanceof Error ? nextError.message : "Failed to load SSO settings.");
+      }
     } finally {
-      setBusy(false);
+      if (isCurrent()) {
+        setBusy(false);
+      }
     }
   }
 
@@ -110,7 +124,15 @@ export function SsoScreen() {
   }
 
   useEffect(() => {
-    void loadSsoConfig();
+    let active = true;
+    void runReauthableAction("load-sso-settings", () => loadSsoConfig(() => active)).catch((nextError) => {
+      if (active) {
+        setError(nextError instanceof Error ? nextError.message : "Failed to load SSO settings.");
+      }
+    });
+    return () => {
+      active = false;
+    };
   }, [orgId, access.canManageSso]);
 
   useEffect(() => {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/telegram-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/telegram-dialog.tsx
@@ -5,6 +5,7 @@ import { Bot, Check, Copy, ExternalLink, ShieldCheck, Trash2 } from "lucide-reac
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenSelect } from "../../_components/ui/select";
+import { DenNotice } from "../../_components/ui/notice";
 import { getWorkerStatusMeta } from "../../_lib/den-flow";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import {
@@ -188,7 +189,7 @@ export function TelegramDialog({ open, onClose }: { open: boolean; onClose: () =
           </div>
         ) : null}
 
-        {formError ? <p className="mt-3 text-[13px] text-red-600">{formError instanceof Error ? formError.message : String(formError)}</p> : null}
+        {formError ? <DenNotice message={formError instanceof Error ? formError.message : String(formError)} className="mt-3" /> : null}
 
         {connection && !editing ? (
           <div className="mt-5 border-t border-gray-100 pt-4">

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -5,11 +5,12 @@ import {
   useContext,
   useEffect,
   useMemo,
+  useRef,
   useState,
 } from "react";
 import { useRouter } from "next/navigation";
 import { useDenFlow } from "../../_providers/den-flow-provider";
-import { getErrorMessage, getOrgLimitError, getOrgPaymentRequiredError, getRequestError, isReauthRequiredError, requestJson } from "../../_lib/den-flow";
+import { getErrorMessage, getOrgLimitError, getOrgPaymentRequiredError, getRequestError, isReauthRequiredError, requestJson, WORKSPACE_REAUTH_SECURITY_MESSAGE } from "../../_lib/den-flow";
 import { ReauthDialog } from "../../_components/reauth-dialog";
 import {
   PENDING_ORG_SELECTION_STORAGE_KEY,
@@ -84,7 +85,8 @@ export function OrgDashboardProvider({
   const [orgBusy, setOrgBusy] = useState(false);
   const [orgError, setOrgError] = useState<string | null>(null);
   const [mutationBusy, setMutationBusy] = useState<string | null>(null);
-  const [pendingReauthMutation, setPendingReauthMutation] = useState<PendingReauthMutation | null>(null);
+  const pendingReauthMutationsRef = useRef<PendingReauthMutation[]>([]);
+  const [reauthDialogOpen, setReauthDialogOpen] = useState(false);
 
   const activeOrg = useMemo(
     () =>
@@ -149,6 +151,17 @@ export function OrgDashboardProvider({
     return parsed;
   }
 
+  async function restoreDisplayedOrganization() {
+    const displayedOrgId = orgContext?.organization.id;
+    if (!displayedOrgId) {
+      return;
+    }
+
+    setRequestOrgScope(displayedOrgId);
+    await setActiveOrganization({ organizationId: displayedOrgId });
+    setOrgDirectory((current) => current.map((entry) => ({ ...entry, isActive: entry.id === displayedOrgId })));
+  }
+
   async function refreshOrgData() {
     if (!user) {
       setRequestOrgScope(null);
@@ -165,8 +178,26 @@ export function OrgDashboardProvider({
 
     try {
       let directoryPayload = await loadOrgDirectory();
+      const displayedOrgId = orgContext?.organization.id ?? null;
+      const displayedOrg = displayedOrgId
+        ? directoryPayload.orgs.find((entry) => entry.id === displayedOrgId) ?? null
+        : null;
+
+      if (displayedOrg && !displayedOrg.isActive) {
+        setRequestOrgScope(displayedOrg.id);
+        await setActiveOrganization({ organizationId: displayedOrg.id });
+        directoryPayload = await loadOrgDirectory();
+      }
+
+      if (displayedOrgId && directoryPayload.orgs.some((entry) => entry.id === displayedOrgId)) {
+        directoryPayload = {
+          ...directoryPayload,
+          orgs: directoryPayload.orgs.map((entry) => ({ ...entry, isActive: entry.id === displayedOrgId })),
+        };
+      }
+
       const targetOrg =
-        directoryPayload.orgs.find((entry) => entry.id === orgContext?.organization.id) ??
+        (displayedOrgId ? directoryPayload.orgs.find((entry) => entry.id === displayedOrgId) : null) ??
         directoryPayload.orgs.find((entry) => entry.isActive) ??
         directoryPayload.orgs[0] ??
         null;
@@ -260,7 +291,11 @@ export function OrgDashboardProvider({
       }
 
       await new Promise<void>((resolve, reject) => {
-        setPendingReauthMutation({ label, action, resolve, reject });
+        pendingReauthMutationsRef.current = [
+          ...pendingReauthMutationsRef.current,
+          { label, action, resolve, reject },
+        ];
+        setReauthDialogOpen(true);
       });
     }
   }
@@ -273,28 +308,62 @@ export function OrgDashboardProvider({
   }
 
   function cancelReauth() {
-    const pending = pendingReauthMutation;
-    setPendingReauthMutation(null);
-    pending?.reject(new Error("Confirm it's you before continuing."));
+    const pending = pendingReauthMutationsRef.current;
+    pendingReauthMutationsRef.current = [];
+    setReauthDialogOpen(false);
+    const error = new Error(WORKSPACE_REAUTH_SECURITY_MESSAGE);
+    for (const entry of pending) {
+      entry.reject(error);
+    }
   }
 
   async function retryReauthMutation() {
-    const pending = pendingReauthMutation;
-    if (!pending) {
+    const pending = pendingReauthMutationsRef.current;
+    if (pending.length === 0) {
       return;
     }
 
-    setPendingReauthMutation(null);
+    pendingReauthMutationsRef.current = [];
+    setReauthDialogOpen(false);
     try {
-      await executeReauthableAction(pending.label, pending.action);
-      pending.resolve();
+      await restoreDisplayedOrganization();
     } catch (error) {
-      if (isReauthRequiredError(error)) {
-        setPendingReauthMutation(pending);
+      for (const entry of pending) {
+        entry.reject(error);
+      }
+      return;
+    }
+
+    let queuedActions = pending;
+    while (queuedActions.length > 0) {
+      const retryAfterReauth: PendingReauthMutation[] = [];
+      for (const entry of queuedActions) {
+        try {
+          await executeReauthableAction(entry.label, entry.action);
+          entry.resolve();
+        } catch (error) {
+          if (isReauthRequiredError(error)) {
+            retryAfterReauth.push(entry);
+          } else {
+            entry.reject(error);
+          }
+        }
+      }
+
+      const queuedDuringRetry = pendingReauthMutationsRef.current;
+      pendingReauthMutationsRef.current = [];
+      setReauthDialogOpen(false);
+
+      if (retryAfterReauth.length > 0) {
+        pendingReauthMutationsRef.current = [
+          ...retryAfterReauth,
+          ...queuedDuringRetry,
+        ];
+        setReauthDialogOpen(true);
         return;
       }
 
-      pending.reject(error);
+      queuedActions = queuedDuringRetry;
     }
   }
 
@@ -704,7 +773,7 @@ export function OrgDashboardProvider({
     <OrgDashboardContext.Provider value={value}>
       {children}
       <ReauthDialog
-        open={Boolean(pendingReauthMutation)}
+        open={reauthDialogOpen}
         user={user}
         orgContext={orgContext}
         onCancel={cancelReauth}

--- a/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_providers/org-dashboard-provider.tsx
@@ -8,7 +8,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import { getErrorMessage, getOrgLimitError, getOrgPaymentRequiredError, getRequestError, isReauthRequiredError, requestJson, WORKSPACE_REAUTH_SECURITY_MESSAGE } from "../../_lib/den-flow";
 import { ReauthDialog } from "../../_components/reauth-dialog";
@@ -34,6 +34,8 @@ type OrgDashboardContextValue = {
   orgBusy: boolean;
   orgError: string | null;
   mutationBusy: string | null;
+  orgSettingsCompletion: OrgSettingsCompletion | null;
+  clearOrgSettingsCompletion: () => void;
   refreshOrgData: () => Promise<void>;
   createOrganization: (name: string) => Promise<void>;
   updateOrganizationName: (name: string) => Promise<void>;
@@ -53,6 +55,10 @@ type OrgDashboardContextValue = {
   runReauthableAction: (label: string, action: () => Promise<void>) => Promise<void>;
 };
 
+type OrgSettingsCompletion = {
+  message: string;
+};
+
 type PendingReauthMutation = {
   label: string;
   action: () => Promise<void>;
@@ -61,6 +67,8 @@ type PendingReauthMutation = {
 };
 
 const OrgDashboardContext = createContext<OrgDashboardContextValue | null>(null);
+const ORG_SETTINGS_PATH = "/dashboard/org-settings";
+const ORG_SETTINGS_UPDATED_MESSAGE = "Workspace settings updated.";
 
 function consumePendingOrgSelectionRequest(): boolean {
   if (typeof window === "undefined") {
@@ -78,6 +86,7 @@ export function OrgDashboardProvider({
   children: React.ReactNode;
 }) {
   const router = useRouter();
+  const pathname = usePathname();
   const { user, sessionHydrated, signOut, refreshWorkers, workersLoadedOnce, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
   const [orgDirectory, setOrgDirectory] = useState<DenOrgSummary[]>([]);
   const [orgContext, setOrgContext] = useState<DenOrgContext | null>(null);
@@ -85,7 +94,9 @@ export function OrgDashboardProvider({
   const [orgBusy, setOrgBusy] = useState(false);
   const [orgError, setOrgError] = useState<string | null>(null);
   const [mutationBusy, setMutationBusy] = useState<string | null>(null);
+  const [orgSettingsCompletion, setOrgSettingsCompletion] = useState<OrgSettingsCompletion | null>(null);
   const pendingReauthMutationsRef = useRef<PendingReauthMutation[]>([]);
+  const pathnameRef = useRef(pathname);
   const [reauthDialogOpen, setReauthDialogOpen] = useState(false);
 
   const activeOrg = useMemo(
@@ -307,6 +318,16 @@ export function OrgDashboardProvider({
     });
   }
 
+  function publishOrgSettingsCompletion() {
+    setOrgSettingsCompletion({
+      message: ORG_SETTINGS_UPDATED_MESSAGE,
+    });
+  }
+
+  function clearOrgSettingsCompletion() {
+    setOrgSettingsCompletion(null);
+  }
+
   function cancelReauth() {
     const pending = pendingReauthMutationsRef.current;
     pendingReauthMutationsRef.current = [];
@@ -462,6 +483,7 @@ export function OrgDashboardProvider({
   }
 
   async function updateOrganizationSettings(input: { name?: string; allowedEmailDomains?: string[] | null; allowedDesktopVersions?: string[] | null; requireSso?: boolean; brandAppName?: string | null; brandLogoUrl?: string | null; brandIconUrl?: string | null; brandAccentColor?: string | null }) {
+    const shouldPublishOrgSettingsCompletion = pathnameRef.current === ORG_SETTINGS_PATH;
     const body: { name?: string; allowedEmailDomains?: string[] | null; allowedDesktopVersions?: string[] | null; requireSso?: boolean; brandAppName?: string | null; brandLogoUrl?: string | null; brandIconUrl?: string | null; brandAccentColor?: string | null } = {};
     if (typeof input.name === "string") {
       const trimmed = input.name.trim();
@@ -507,6 +529,10 @@ export function OrgDashboardProvider({
         throw getRequestError(payload, response, `Failed to update organization (${response.status}).`);
       }
     });
+
+    if (shouldPublishOrgSettingsCompletion && pathnameRef.current === ORG_SETTINGS_PATH) {
+      publishOrgSettingsCompletion();
+    }
   }
 
   async function inviteMember(input: { email: string; role: string }) {
@@ -726,6 +752,13 @@ export function OrgDashboardProvider({
   }, []);
 
   useEffect(() => {
+    pathnameRef.current = pathname;
+    if (pathname !== ORG_SETTINGS_PATH) {
+      setOrgSettingsCompletion(null);
+    }
+  }, [pathname]);
+
+  useEffect(() => {
     if (!sessionHydrated) {
       return;
     }
@@ -750,6 +783,8 @@ export function OrgDashboardProvider({
     orgBusy,
     orgError,
     mutationBusy,
+    orgSettingsCompletion,
+    clearOrgSettingsCompletion,
     refreshOrgData,
     createOrganization,
     updateOrganizationName,

--- a/evals/flows/calm-security-notice.flow.mjs
+++ b/evals/flows/calm-security-notice.flow.mjs
@@ -12,8 +12,8 @@ import {
 // Narration is loaded from the approved script (evals/voiceovers/calm-security-notice.md).
 // The runner fails this flow if the narration drifts from that script.
 const vo = await loadVoiceoverParagraphs("calm-security-notice");
-const GUIDANCE_MESSAGE = "Confirm it's you before continuing.";
-const RAW_REAUTH_MESSAGE = "For security, confirm it's you before changing workspace settings.";
+const GUIDANCE_MESSAGE = "For security, confirm it's you before changing workspace settings.";
+const OLD_REAUTH_TITLE = "Confirm it's you to continue";
 const COPY_INSTALL_LINK_SELECTOR = '[data-testid="copy-install-link"]';
 
 function recordAssertion(ctx, assertion, passed, actual) {
@@ -29,7 +29,7 @@ function recordAssertion(ctx, assertion, passed, actual) {
 async function cancelReauth(ctx) {
   await ctx.waitFor(`(() => {
     const dialog = document.querySelector('[role="dialog"]');
-    return Boolean(dialog && dialog.textContent.includes("Confirm it's you to continue"));
+    return Boolean(dialog && dialog.textContent.includes(${JSON.stringify(GUIDANCE_MESSAGE)}));
   })()`, { timeoutMs: 30_000, label: "reauth dialog" });
   await clickExactText(ctx, "Cancel", "button");
   await ctx.waitFor(`(() => {
@@ -56,7 +56,7 @@ async function readGuidanceNotice(ctx) {
       tone: notice?.getAttribute('data-notice-tone') ?? '',
       role: notice?.getAttribute('role') ?? '',
       className: notice?.getAttribute('class') ?? '',
-      rawServerMessageVisible: document.body.innerText.includes(${JSON.stringify(RAW_REAUTH_MESSAGE)}),
+      oldReauthTitleVisible: document.body.innerText.includes(${JSON.stringify(OLD_REAUTH_TITLE)}),
     };
   })()`);
 }
@@ -89,12 +89,12 @@ export default {
           assert: async () => {
             const actual = await readGuidanceNotice(ctx);
             recordAssertion(ctx, "The routine confirmation is an informational status", actual.text === GUIDANCE_MESSAGE && actual.tone === "info" && actual.role === "status", actual);
-            recordAssertion(ctx, "The routine confirmation has no aggressive red treatment", !actual.className.includes("red-") && actual.rawServerMessageVisible === false, actual);
+            recordAssertion(ctx, "The routine confirmation has no aggressive red treatment", !actual.className.includes("red-") && actual.oldReauthTitleVisible === false, actual);
           },
           screenshot: {
             name: "calm-security-members",
             requireText: ["Members", GUIDANCE_MESSAGE],
-            rejectText: [RAW_REAUTH_MESSAGE],
+            rejectText: [OLD_REAUTH_TITLE],
           },
         });
       },
@@ -121,7 +121,7 @@ export default {
           screenshot: {
             name: "calm-security-org-settings",
             requireText: ["Org settings", GUIDANCE_MESSAGE],
-            rejectText: [RAW_REAUTH_MESSAGE],
+            rejectText: [OLD_REAUTH_TITLE],
           },
         });
       },
@@ -159,7 +159,7 @@ export default {
           },
           screenshot: {
             name: "calm-security-real-error",
-            requireText: ["Confirm it's you to continue"],
+            requireText: [GUIDANCE_MESSAGE],
           },
         });
       },

--- a/evals/flows/den-reauth-pending-action.flow.mjs
+++ b/evals/flows/den-reauth-pending-action.flow.mjs
@@ -311,7 +311,7 @@ export default {
             await clickSelectorWithMouse(ctx, COPY_INSTALL_LINK_SELECTOR, "copy install link button");
             await ctx.waitFor(`(() => {
               const dialog = document.querySelector('[role="dialog"]');
-              return Boolean(dialog && dialog.textContent.includes("Confirm it's you to continue"));
+              return Boolean(dialog && dialog.textContent.includes(${JSON.stringify(RAW_REAUTH_MESSAGE)}));
             })()`, { timeoutMs: 30_000, label: "reauth dialog" });
           },
           assert: async () => {
@@ -330,7 +330,7 @@ export default {
             recordAssertion(
               ctx,
               "The reauth dialog appears for the stale privileged action",
-              actual.dialogVisible === true && actual.dialogText.includes("Confirm it's you to continue"),
+              actual.dialogVisible === true && actual.dialogText.includes(RAW_REAUTH_MESSAGE),
               actual,
             );
             recordAssertion(
@@ -342,7 +342,7 @@ export default {
           },
           screenshot: {
             name: "reauth-security-check-dialog",
-            requireText: ["Confirm it's you to continue"],
+            requireText: [RAW_REAUTH_MESSAGE],
           },
         });
       },

--- a/evals/flows/den-reauth-popup-social.flow.mjs
+++ b/evals/flows/den-reauth-popup-social.flow.mjs
@@ -20,6 +20,7 @@ const DEN_WEB_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_WEB_URL);
 const MYSQL_CONTAINER = process.env.OPENWORK_EVAL_DEN_MYSQL_CONTAINER?.trim() ?? "";
 const DEMO_EMAIL = "alex@acme.test";
 const DEMO_PASSWORD = "OpenWorkDemo123!";
+const SECURITY_MESSAGE = "For security, confirm it's you before changing workspace settings.";
 const GOOGLE_ACCOUNT_ID = "acc_01kwx81tc6f208pn04555rws17";
 
 // AuthAccountTable.id is denTypeIdColumn("account", "id")
@@ -110,7 +111,7 @@ export default {
               return {
                 dialogOpen: Boolean(dialog),
                 nonce: dialog?.getAttribute('data-reauth-nonce') ?? '',
-                hasTitle: bodyText.includes("Confirm it's you to continue"),
+                hasTitle: bodyText.includes(${JSON.stringify(SECURITY_MESSAGE)}),
                 hasGoogle: bodyText.includes('Continue with Google'),
               };
             })()`);
@@ -123,7 +124,7 @@ export default {
           },
           screenshot: {
             name: "den-reauth-popup-google-offered",
-            requireText: ["Confirm it's you to continue", "Continue with Google"],
+            requireText: [SECURITY_MESSAGE, "Continue with Google"],
           },
         });
       },

--- a/evals/flows/den-ui-consistency.flow.mjs
+++ b/evals/flows/den-ui-consistency.flow.mjs
@@ -521,7 +521,7 @@ export default {
             await ctx.screenshot("fresh-signin-security-dialog", {
               claim: "The protected action opens a calm, contextual fresh-sign-in dialog.",
               voiceover: vo[6],
-              requireText: ["Confirm it's you to continue", "SIGNING IN AS", "Verify password"],
+              requireText: ["For security, confirm it's you before changing workspace settings.", "SIGNING IN AS", "Verify password"],
               rejectText: ["Redirecting to your dashboard"],
               hashIncludes: "/dashboard/plugins/new",
             });

--- a/evals/flows/durable-auth-mcp.flow.mjs
+++ b/evals/flows/durable-auth-mcp.flow.mjs
@@ -33,6 +33,7 @@ const ECHO_TEXT = `durable auth refresh ${RUN_TAG}`;
 const LOCAL_DRAFT = "Local draft remains available while OpenWork Cloud reconnects";
 const WORKSPACE_PATH = `/tmp/openwork-durable-auth-mcp-${RUN_TAG}`;
 const COPY_INSTALL_LINK_SELECTOR = '[data-testid="copy-install-link"]';
+const SECURITY_MESSAGE = "For security, confirm it's you before changing workspace settings.";
 
 const state = {
   adminSession: null,
@@ -390,7 +391,7 @@ async function openSharedConnectionDialog(ctx, name) {
 
 async function submitSharedConnectionAndConsent(ctx) {
   await ctx.clickText("Add connection", { timeoutMs: 15_000 });
-  const noOpenWorkReauth = await ctx.eval("!document.body.innerText.includes(\"Confirm it's you to continue\")");
+  const noOpenWorkReauth = await ctx.eval(`!document.body.innerText.includes(${JSON.stringify(SECURITY_MESSAGE)})`);
   await ctx.switchToNewTab({ timeoutMs: 20_000, label: "provider consent" });
   await ctx.waitForText("Mock MCP OAuth", { timeoutMs: 30_000 });
   await ctx.clickText("Approve OpenWork", { timeoutMs: 15_000 });
@@ -588,7 +589,7 @@ async function completeSensitiveAction(ctx) {
   await ctx.trustedClick(COPY_INSTALL_LINK_SELECTOR);
   await ctx.waitFor(`(() => {
     const dialog = document.querySelector('[role="dialog"]');
-    return Boolean(dialog && dialog.textContent.includes("Confirm it's you to continue"));
+    return Boolean(dialog && dialog.textContent.includes(${JSON.stringify(SECURITY_MESSAGE)}));
   })()`, { timeoutMs: 30_000, label: "security check" });
   state.reauthDialogText = await ctx.eval("document.querySelector('[role=dialog]')?.textContent ?? ''");
   await ctx.fill('input[autocomplete="current-password"]', DEMO_PASSWORD);
@@ -698,7 +699,7 @@ export default {
             name: "shared-mcp-connected-once",
             claim: "The shared MCP appears Connected in OpenWork Cloud after one provider consent.",
             requireText: ["Connected", FIRST_CONNECTION],
-            rejectText: ["Connection failed", "Confirm it's you to continue"],
+            rejectText: ["Connection failed", SECURITY_MESSAGE],
           },
         });
         await ctx.switchBack();
@@ -764,7 +765,7 @@ export default {
             name: "mcp-silent-refresh-ready",
             claim: "The engine-facing Cloud Control MCP is Ready after refresh-only recovery.",
             requireText: ["OpenWork Cloud Control", "Ready"],
-            rejectText: ["Sign in needed", "Confirm it's you to continue", "Applying changes before sign-in", "Reloading OpenCode config"],
+            rejectText: ["Sign in needed", SECURITY_MESSAGE, "Applying changes before sign-in", "Reloading OpenCode config"],
             hashIncludes: "/settings/extensions/mcp",
           },
         });
@@ -831,7 +832,7 @@ export default {
             name: "stale-session-direct-provider-consent",
             claim: "The second shared MCP appears Connected without an intervening OpenWork security check.",
             requireText: ["Connected", SECOND_CONNECTION],
-            rejectText: ["Connection failed", "Confirm it's you to continue"],
+            rejectText: ["Connection failed", SECURITY_MESSAGE],
           },
         });
       },
@@ -848,19 +849,19 @@ export default {
             recordAssertion(
               ctx,
               "The security check appeared before the sensitive action",
-              state.reauthDialogText?.includes("Confirm it's you to continue") === true,
+              state.reauthDialogText?.includes(SECURITY_MESSAGE) === true,
               state.reauthDialogText,
             );
             const buttonText = await ctx.eval(`document.querySelector(${JSON.stringify(COPY_INSTALL_LINK_SELECTOR)})?.textContent ?? ''`);
             recordAssertion(ctx, "The queued action resumed without a second click", buttonText.includes("Copied"), buttonText);
-            await ctx.expectNoText("For security, confirm it's you before changing workspace settings.");
+            await ctx.expectNoText(SECURITY_MESSAGE);
           },
           screenshot: {
             name: "sensitive-action-resumed-after-reauth",
             claim: "After one identity confirmation, the original sensitive action resumes and reaches Copied.",
             targetUrlIncludes: "/dashboard/members",
             requireText: ["Members", "Copied"],
-            rejectText: ["Confirm it's you to continue", "For security, confirm it's you before changing workspace settings."],
+            rejectText: ["Confirm it's you to continue", SECURITY_MESSAGE],
           },
         });
       },

--- a/evals/flows/google-slack-oauth-ux.flow.mjs
+++ b/evals/flows/google-slack-oauth-ux.flow.mjs
@@ -22,6 +22,7 @@ const PERMISSIONS_ONLY_FEATURES = ["calendarRead", "gmailDraft", "driveFile", "g
 const GOOGLE_WORKSPACE_CALLBACK_PATH = "/v1/oauth-providers/google-workspace/connect/callback";
 const CONNECTION_PREFIX = "slack-oauth-ux-";
 const CONNECTION_NAME = `${CONNECTION_PREFIX}${RUN_TAG}`;
+const SECURITY_MESSAGE = "For security, confirm it's you before changing workspace settings.";
 
 const state = {
   adminSession: null,
@@ -364,13 +365,12 @@ function reauthReadyScript() {
   return `(() => {
     const dialog = document.querySelector('[role="dialog"]');
     const text = dialog?.textContent ?? '';
-    const helperOk = text.includes('Changing workspace settings requires a recent sign-in')
-      && text.includes('OpenWork retries the pending action automatically');
+    const helperOk = text.includes('OpenWork retries the pending action automatically');
     const hasGoogle = text.includes('Continue with Google');
     const hasPassword = text.includes('Verify password');
     const hasSso = text.includes('Continue with organization SSO');
     return Boolean(dialog)
-      && text.includes("Confirm it's you to continue")
+      && text.includes(${JSON.stringify(SECURITY_MESSAGE)})
       && helperOk
       && (${JSON.stringify(expectsGoogle)} ? hasGoogle : (hasGoogle || hasPassword || hasSso));
   })()`;
@@ -476,7 +476,7 @@ async function clickCreateConnectionAndHandleReauth(ctx) {
   const stateName = await ctx.waitFor(`(() => {
     const text = document.body.innerText;
     if (text.includes('Almost done')) return 'created';
-    if (text.includes("Confirm it's you to continue")) return 'reauth';
+    if (text.includes(${JSON.stringify(SECURITY_MESSAGE)})) return 'reauth';
     return '';
   })()`, { timeoutMs: 30_000, label: "redirect handoff or reauth" });
   if (stateName === "reauth") {
@@ -548,8 +548,7 @@ export default {
           assert: async () => {
             const actual = await ctx.eval(reauthDialogStateScript());
             ctx.assert(actual.visible === true, "Reauth dialog should be visible.");
-            ctx.assert(actual.text.includes("Confirm it's you to continue"), `Reauth title missing: ${actual.text}`);
-            ctx.assert(actual.text.includes("Changing workspace settings requires a recent sign-in"), `Reauth helper missing recent sign-in copy: ${actual.text}`);
+            ctx.assert(actual.text.includes(SECURITY_MESSAGE), `Reauth guidance missing: ${actual.text}`);
             ctx.assert(actual.text.includes("OpenWork retries the pending action automatically"), `Reauth helper missing automatic retry copy: ${actual.text}`);
             if (state.authProviders.includes("google")) {
               ctx.assert(actual.hasGoogle === true, `Seeded Google auth provider should expose Continue with Google. Providers: ${JSON.stringify(state.authProviders)}. Dialog: ${actual.text}`);
@@ -561,9 +560,9 @@ export default {
             name: "google-workspace-reauth-security-check",
             claim: "The security check explains why it appeared and gives a clear way to continue before retrying the save.",
             requireText: state.authProviders.includes("google")
-              ? ["Confirm it's you to continue", "SECURITY CHECK", "OpenWork retries the pending action automatically", "Continue with Google"]
-              : ["Confirm it's you to continue", "SECURITY CHECK", "OpenWork retries the pending action automatically"],
-            rejectText: ["For security, confirm it's you before changing workspace settings."],
+              ? [SECURITY_MESSAGE, "SECURITY CHECK", "OpenWork retries the pending action automatically", "Continue with Google"]
+              : [SECURITY_MESSAGE, "SECURITY CHECK", "OpenWork retries the pending action automatically"],
+            rejectText: ["Confirm it's you to continue"],
           },
         });
 

--- a/evals/flows/managed-brand-asset-uploads.flow.mjs
+++ b/evals/flows/managed-brand-asset-uploads.flow.mjs
@@ -318,7 +318,7 @@ export default {
             await waitForPanel(ctx, `(() => {
               const dialog = document.querySelector('[role="dialog"]');
               const passwordInput = dialog?.querySelector('input[autocomplete="current-password"]');
-              return Boolean(dialog && passwordInput && dialog.textContent?.includes("Confirm it's you to continue"));
+              return Boolean(dialog && passwordInput && dialog.textContent?.includes(${JSON.stringify(RAW_REAUTH_MESSAGE)}));
             })()`, { timeoutMs: 30_000, label: "Brand Appearance password reauth dialog" });
           },
           assert: async () => {
@@ -336,7 +336,7 @@ export default {
                 selectedIcon: document.querySelector('#brand-icon-upload')?.files?.[0]?.name ?? null,
               };
             })()`);
-            ctx.assert(state.dialogText.includes("Confirm it's you to continue"), `Reauth dialog was missing: ${JSON.stringify(state)}`);
+            ctx.assert(state.dialogText.includes(RAW_REAUTH_MESSAGE), `Reauth dialog was missing: ${JSON.stringify(state)}`);
             ctx.assert(state.dialogText.includes("Signing in as"), `Polished account context was missing: ${JSON.stringify(state)}`);
             ctx.assert(!state.rawMessageOutsideDialog, `Raw reauth response leaked into the page: ${JSON.stringify(state)}`);
             ctx.assert(state.interceptedReauth, `The brand upload did not receive the staged production reauth response: ${JSON.stringify(state)}`);
@@ -348,8 +348,8 @@ export default {
             sandboxCapture: true,
             targetId: adminPanelTargetId,
             textTargetId: adminPanelTargetId,
-            requireText: ["SECURITY CHECK", "Confirm it's you to continue", "SIGNING IN AS", "Verify password"],
-            rejectText: [RAW_REAUTH_MESSAGE],
+            requireText: ["SECURITY CHECK", RAW_REAUTH_MESSAGE, "SIGNING IN AS", "Verify password"],
+            rejectText: ["Confirm it's you to continue"],
           },
         });
       },

--- a/evals/flows/standardized-workspace-reauth.flow.mjs
+++ b/evals/flows/standardized-workspace-reauth.flow.mjs
@@ -1,0 +1,570 @@
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import {
+  applyDesktopViewport,
+  clickExactText,
+  navigateTo,
+} from "./den-reauth-pending-action.flow.mjs";
+import { denApiFetch, signInApi } from "./lib/den-web.mjs";
+
+const FLOW_ID = "standardized-workspace-reauth";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const execFileAsync = promisify(execFile);
+
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const ORG_SCOPE_HEADER = "x-openwork-org-id";
+const ORG_SETTINGS_PATH = "/dashboard/org-settings";
+const API_KEYS_PATH = "/dashboard/api-keys";
+const ORG_NAME_INPUT_SELECTOR = 'form input[type="text"]:not([readonly])';
+const SECURITY_MESSAGE = "For security, confirm it's you before changing workspace settings.";
+const SENTINEL_KEY = "__standardizedWorkspaceReauthSentinel";
+const ORG_NAME_PREFIX = "Reauth Proof ";
+const API_KEY_PREFIX = "reauth-proof-";
+const SECONDARY_ORG_NAME = "Reauth Secondary Eval Org";
+
+const state = {
+  adminToken: null,
+  org: null,
+  originalOrgName: null,
+  savedOrgName: null,
+  apiKeyName: null,
+  sentinelToken: null,
+};
+
+function mysqlContainer(ctx) {
+  return ctx.env.OPENWORK_EVAL_DEN_MYSQL_CONTAINER || "openwork-web-local-mysql";
+}
+
+function recordAssertion(ctx, assertion, passed, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: passed ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(passed, `${assertion}. Actual: ${JSON.stringify(actual)}`);
+}
+
+async function runMysql(ctx, sql) {
+  const { stdout, stderr } = await execFileAsync("docker", [
+    "exec",
+    mysqlContainer(ctx),
+    "mysql",
+    "-uroot",
+    "-ppassword",
+    "openwork_den",
+    "-e",
+    sql,
+  ]);
+
+  if (stderr.trim()) {
+    ctx.log(`mysql stderr: ${stderr.trim()}`);
+  }
+
+  return stdout;
+}
+
+function orgScopedHeaders(extra = {}) {
+  return { authorization: `Bearer ${state.adminToken}`, [ORG_SCOPE_HEADER]: state.org.id, ...extra };
+}
+
+async function refreshAdminToken(ctx) {
+  state.adminToken = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
+  ctx.assert(Boolean(state.adminToken), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+  return state.adminToken;
+}
+
+async function listOrganizations(ctx) {
+  const { response, body } = await denApiFetch("/v1/me/orgs", {
+    headers: { authorization: `Bearer ${state.adminToken}` },
+  });
+  ctx.assert(response.ok, `Listing orgs failed (${response.status}): ${JSON.stringify(body)}`);
+  return Array.isArray(body?.orgs) ? body.orgs : [];
+}
+
+async function ensureSecondaryOrganization(ctx, orgs) {
+  const existingSecondary = orgs.find((org) => org.name === SECONDARY_ORG_NAME) ?? null;
+  if (orgs.length > 1 || existingSecondary) {
+    return orgs;
+  }
+
+  const created = await denApiFetch("/v1/org", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.adminToken}` },
+    body: JSON.stringify({ name: SECONDARY_ORG_NAME }),
+  });
+  ctx.assert(
+    created.response.ok,
+    `Creating a secondary eval org failed (${created.response.status}): ${JSON.stringify(created.body)} — this flow needs DEN_ORG_MODE=multi_org.`,
+  );
+
+  return listOrganizations(ctx);
+}
+
+async function readOrganization(ctx) {
+  const { response, body } = await denApiFetch("/v1/org", {
+    headers: orgScopedHeaders(),
+  });
+  ctx.assert(response.ok, `Loading org failed (${response.status}): ${JSON.stringify(body)}`);
+  ctx.assert(typeof body?.organization?.name === "string", "Organization response did not include a name.");
+  return body.organization;
+}
+
+async function renameOrganization(ctx, name) {
+  const { response, body } = await denApiFetch("/v1/org", {
+    method: "PATCH",
+    headers: orgScopedHeaders(),
+    body: JSON.stringify({ name }),
+  });
+  ctx.assert(response.ok, `Renaming org failed (${response.status}): ${JSON.stringify(body)}`);
+}
+
+async function cleanupApiKeys(ctx) {
+  const listed = await denApiFetch("/v1/api-keys", { headers: orgScopedHeaders() });
+  if (!listed.response.ok) {
+    ctx.log(`API key cleanup list skipped: ${listed.response.status} ${JSON.stringify(listed.body)}`);
+    return;
+  }
+
+  const apiKeys = Array.isArray(listed.body?.apiKeys) ? listed.body.apiKeys : [];
+  for (const apiKey of apiKeys) {
+    if (typeof apiKey?.id !== "string" || typeof apiKey?.name !== "string" || !apiKey.name.startsWith(API_KEY_PREFIX)) {
+      continue;
+    }
+
+    const deleted = await denApiFetch(`/v1/api-keys/${encodeURIComponent(apiKey.id)}`, {
+      method: "DELETE",
+      headers: orgScopedHeaders(),
+    });
+    if (!deleted.response.ok && deleted.response.status !== 404) {
+      ctx.log(`API key cleanup delete failed for ${apiKey.id}: ${deleted.response.status} ${JSON.stringify(deleted.body)}`);
+    }
+  }
+}
+
+async function cleanup(ctx) {
+  try {
+    await refreshAdminToken(ctx);
+    if (state.org && state.originalOrgName) {
+      await cleanupApiKeys(ctx);
+      const current = await readOrganization(ctx);
+      if (current.name !== state.originalOrgName) {
+        await renameOrganization(ctx, state.originalOrgName);
+      }
+    }
+  } catch (error) {
+    ctx.log(`cleanup failed: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function prepareSeededMultiOrg(ctx) {
+  await refreshAdminToken(ctx);
+  const orgs = await ensureSecondaryOrganization(ctx, await listOrganizations(ctx));
+  ctx.assert(orgs.length >= 2, `Expected a multi-org account for ${ADMIN_EMAIL}; found ${orgs.length}.`);
+
+  state.org = orgs.find((org) => org.name === "Acme Robotics")
+    ?? orgs.find((org) => org.slug === "acme-robotics")
+    ?? orgs.find((org) => org.name !== SECONDARY_ORG_NAME && org.slug === "default")
+    ?? orgs.find((org) => org.name !== SECONDARY_ORG_NAME)
+    ?? orgs[0];
+  ctx.assert(Boolean(state.org?.id), "Could not choose the primary seeded organization.");
+
+  await cleanupApiKeys(ctx);
+  let organization = await readOrganization(ctx);
+  if (organization.name.startsWith(ORG_NAME_PREFIX)) {
+    const healedName = state.org.slug === "default" ? "OpenWork" : "Acme Robotics";
+    await renameOrganization(ctx, healedName);
+    organization = await readOrganization(ctx);
+  }
+
+  state.originalOrgName = organization.name;
+  state.org = { ...state.org, name: organization.name };
+  state.savedOrgName = `${ORG_NAME_PREFIX}${Date.now()}`;
+  state.apiKeyName = `${API_KEY_PREFIX}${Date.now()}`;
+}
+
+async function clearSessionDataCookies(ctx) {
+  if (!ctx.client?.send) {
+    return;
+  }
+
+  const cookieResult = await ctx.client.send("Network.getAllCookies", {});
+  const cachedSessionCookies = cookieResult.cookies.filter((cookie) => cookie.name.includes("session_data"));
+  for (const cookie of cachedSessionCookies) {
+    await ctx.client.send("Network.deleteCookies", {
+      name: cookie.name,
+      domain: cookie.domain,
+      path: cookie.path,
+    });
+  }
+}
+
+async function ageSessions(ctx) {
+  await runMysql(ctx, "UPDATE session SET created_at = DATE_SUB(NOW(3), INTERVAL 1 HOUR);");
+  await clearSessionDataCookies(ctx);
+}
+
+async function setBrowserActiveOrg(ctx) {
+  const status = await ctx.eval(`fetch('/api/auth/organization/set-active', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: ${JSON.stringify(JSON.stringify({ organizationId: state.org.id }))},
+  }).then((response) => response.status)`, { awaitPromise: true });
+  ctx.assert(status === 200, `Setting the browser active org failed with status ${status}.`);
+}
+
+async function waitForOrgSettings(ctx) {
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body?.innerText ?? '';
+      if (text.includes('Organization Identity') && location.pathname === ${JSON.stringify(ORG_SETTINGS_PATH)}) return true;
+      if (text.includes('Choose an organization')) {
+        const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(state.org.name)}));
+        button?.click();
+        return false;
+      }
+      if (location.pathname !== ${JSON.stringify(ORG_SETTINGS_PATH)}) {
+        window.location.href = ${JSON.stringify(`${process.env.OPENWORK_EVAL_DEN_WEB_URL?.replace(/\/$/, "") ?? ""}${ORG_SETTINGS_PATH}`)};
+      }
+      return false;
+    })()`,
+    { timeoutMs: 60_000, label: "org settings screen" },
+  );
+}
+
+async function openOrgSettingsAsSeededAdmin(ctx) {
+  await applyDesktopViewport(ctx);
+  await navigateTo(ctx, "/");
+  await ctx.eval(
+    `fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).catch(() => null).then(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+      return true;
+    })`,
+    { awaitPromise: true },
+  );
+  if (ctx.client?.send) {
+    await ctx.client.send("Network.clearBrowserCookies", {}).catch((error) => {
+      ctx.log(`Cookie clear skipped: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }
+  await navigateTo(ctx, "/");
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"]'))", { timeoutMs: 30_000, label: "email input" });
+  const switchedToSignIn = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button[type="button"]')]
+      .find((entry) => (entry.textContent ?? '').trim() === 'Sign in');
+    button?.click();
+    return Boolean(button);
+  })()`);
+  if (switchedToSignIn) {
+    await ctx.waitFor(
+      `(() => (document.querySelector('button[type="submit"]')?.textContent ?? '').includes('Sign in'))()`,
+      { timeoutMs: 10_000, label: "sign-in mode selected" },
+    );
+  }
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 30_000, label: "password input" });
+  await ctx.fill('input[type="email"]', ADMIN_EMAIL);
+  await ctx.fill('input[type="password"]', ADMIN_PASSWORD);
+  await ctx.eval(`(() => {
+    const button = document.querySelector('button[type="submit"]');
+    button?.click();
+    return Boolean(button);
+  })()`);
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body?.innerText ?? '';
+      return text.includes('Dashboard') || text.includes('Choose an organization');
+    })()`,
+    { timeoutMs: 45_000, label: "dashboard or org chooser after sign-in" },
+  );
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body?.innerText ?? '';
+      if (text.includes('Dashboard') && !text.includes('Choose an organization')) return true;
+      if (text.includes('Choose an organization')) {
+        const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(state.org.name)}));
+        button?.click();
+        return false;
+      }
+      return false;
+    })()`,
+    { timeoutMs: 60_000, label: "seeded organization selected" },
+  );
+  await setBrowserActiveOrg(ctx);
+  await ctx.eval("window.sessionStorage.removeItem('openwork:web:pending-org-selection'); true");
+  await navigateTo(ctx, ORG_SETTINGS_PATH);
+  await waitForOrgSettings(ctx);
+}
+
+async function setOrgNameDraft(ctx, name) {
+  const value = await ctx.eval(`(() => {
+    const input = document.querySelector(${JSON.stringify(ORG_NAME_INPUT_SELECTOR)});
+    if (!(input instanceof HTMLInputElement)) return null;
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set;
+    if (!setter) return null;
+    input.scrollIntoView({ block: 'center', behavior: 'instant' });
+    setter.call(input, ${JSON.stringify(name)});
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    return input.value;
+  })()`);
+  ctx.assert(value === name, `Org name draft is ${value}, expected ${name}.`);
+}
+
+async function armNoReloadSentinel(ctx) {
+  state.sentinelToken = `sentinel-${Date.now()}`;
+  await ctx.eval(`(() => {
+    window[${JSON.stringify(SENTINEL_KEY)}] = {
+      token: ${JSON.stringify(state.sentinelToken)},
+      route: location.pathname,
+      draft: document.querySelector(${JSON.stringify(ORG_NAME_INPUT_SELECTOR)})?.value ?? null,
+    };
+    return true;
+  })()`);
+}
+
+async function waitForReauthDialog(ctx) {
+  await ctx.waitFor(`(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    return Boolean(dialog && dialog.textContent.includes(${JSON.stringify(SECURITY_MESSAGE)}) && dialog.querySelector('input[autocomplete="current-password"]'));
+  })()`, { timeoutMs: 30_000, label: "standardized reauth dialog" });
+}
+
+async function fillDialogPassword(ctx, password) {
+  await ctx.fill('[role="dialog"] input[autocomplete="current-password"]', password);
+}
+
+async function clickDialogButton(ctx, label) {
+  await ctx.waitFor(`(() => {
+    const dialog = document.querySelector('[role="dialog"]');
+    const button = [...(dialog?.querySelectorAll('button') ?? [])]
+      .find((candidate) => (candidate.textContent ?? '').trim() === ${JSON.stringify(label)} && !candidate.disabled);
+    button?.click();
+    return Boolean(button);
+  })()`, { timeoutMs: 20_000, label: `dialog button ${label}` });
+}
+
+async function readBrowserState(ctx) {
+  return ctx.eval(`(async () => {
+    const orgs = await fetch('/api/den/v1/me/orgs').then((response) => response.json()).catch(() => null);
+    const input = document.querySelector(${JSON.stringify(ORG_NAME_INPUT_SELECTOR)});
+    const keyInput = [...document.querySelectorAll('form input[type="text"]')].find((entry) => entry.placeholder === 'CI worker') ?? null;
+    const dialog = document.querySelector('[role="dialog"]');
+    const notice = document.querySelector('[data-notice-tone]');
+    const sentinel = window[${JSON.stringify(SENTINEL_KEY)}] ?? null;
+    return {
+      path: location.pathname,
+      activeOrgId: orgs?.activeOrgId ?? null,
+      bodyText: document.body.innerText,
+      dialogVisible: Boolean(dialog),
+      dialogText: dialog?.textContent ?? '',
+      draftName: input instanceof HTMLInputElement ? input.value : null,
+      keyNameDraft: keyInput instanceof HTMLInputElement ? keyInput.value : null,
+      noReloadSentinel: sentinel?.token ?? null,
+      noReloadSentinelDraft: sentinel?.draft ?? null,
+      noticeText: notice?.textContent?.trim() ?? '',
+      noticeTone: notice?.getAttribute('data-notice-tone') ?? '',
+      noticeRole: notice?.getAttribute('role') ?? '',
+      invalidPasswordAlert: Boolean(dialog?.querySelector('[data-notice-tone="error"][role="alert"]')),
+      apiKeyRetryReady: [...document.querySelectorAll('button')].some((button) => (button.textContent ?? '').trim() === 'Create API key' && !button.disabled),
+      orgPickerVisible: document.body.innerText.includes('Choose an organization'),
+      successVisible: document.body.innerText.includes('Workspace settings updated.'),
+    };
+  })()`, { awaitPromise: true });
+}
+
+async function readOrgFromBrowser(ctx) {
+  return ctx.eval("fetch('/api/den/v1/org').then((response) => response.json()).catch((error) => ({ error: String(error) }))", { awaitPromise: true });
+}
+
+async function openApiKeysWithFreshSession(ctx) {
+  await navigateTo(ctx, API_KEYS_PATH);
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body.innerText;
+      return location.pathname === ${JSON.stringify(API_KEYS_PATH)} && text.includes('API Keys') && (text.includes('New key') || text.includes('No API keys') || text.includes('Create a new API key'));
+    })()`,
+    { timeoutMs: 45_000, label: "API keys screen" },
+  );
+}
+
+async function prepareApiKeyCreateForm(ctx) {
+  await clickExactText(ctx, "New key", "button");
+  await ctx.waitFor("document.body.innerText.includes('Issue a new key')", { timeoutMs: 15_000, label: "new API key form" });
+  await ctx.fill('form input[type="text"]', state.apiKeyName);
+  const draft = await ctx.eval(`document.querySelector('form input[type="text"]')?.value ?? null`);
+  ctx.assert(draft === state.apiKeyName, `API key draft is ${draft}, expected ${state.apiKeyName}.`);
+}
+
+async function submitApiKeyCreate(ctx) {
+  await clickExactText(ctx, "Create API key", "button");
+  await waitForReauthDialog(ctx);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Workspace re-authentication keeps multi-org settings actions on the same route and org",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_MYSQL_CONTAINER", "OPENWORK_EVAL_DEN_MULTI_ORG"],
+  steps: [
+    {
+      name: "Org settings save opens the standardized security dialog",
+      run: async (ctx) => {
+        await ctx.prove("A stale protected settings save opens the exact standardized dialog", {
+          voiceover: vo[0],
+          action: async () => {
+            await prepareSeededMultiOrg(ctx);
+            await openOrgSettingsAsSeededAdmin(ctx);
+            await setOrgNameDraft(ctx, state.savedOrgName);
+            await armNoReloadSentinel(ctx);
+            await ageSessions(ctx);
+            await clickExactText(ctx, "Save settings", "button");
+            await waitForReauthDialog(ctx);
+          },
+          assert: async () => {
+            const actual = await readBrowserState(ctx);
+            recordAssertion(ctx, "The dialog uses the approved security sentence", actual.dialogVisible === true && actual.dialogText.includes(SECURITY_MESSAGE), actual);
+            recordAssertion(ctx, "The user remains on the same org settings route and org", actual.path === ORG_SETTINGS_PATH && actual.activeOrgId === state.org.id && actual.orgPickerVisible === false, actual);
+          },
+          screenshot: {
+            name: "standardized-dialog-org-settings",
+            requireText: ["Org settings", SECURITY_MESSAGE, "Verify password"],
+            rejectText: ["Choose an organization"],
+          },
+        });
+      },
+    },
+    {
+      name: "Password confirmation preserves route, org, draft, and no-reload sentinel",
+      run: async (ctx) => {
+        await ctx.prove("The settings page, selected org, draft name, and no-reload sentinel survive while confirming", {
+          voiceover: vo[1],
+          action: async () => {
+            await fillDialogPassword(ctx, ADMIN_PASSWORD);
+          },
+          assert: async () => {
+            const actual = await readBrowserState(ctx);
+            recordAssertion(ctx, "The route and active org are unchanged while the dialog is open", actual.path === ORG_SETTINGS_PATH && actual.activeOrgId === state.org.id, actual);
+            recordAssertion(ctx, "The unsaved org-name draft and no-reload sentinel are still present", actual.draftName === state.savedOrgName && actual.noReloadSentinel === state.sentinelToken && actual.noReloadSentinelDraft === state.savedOrgName, actual);
+          },
+          screenshot: {
+            name: "standardized-dialog-context-retained",
+            requireText: [SECURITY_MESSAGE, "Verify password"],
+            rejectText: ["Choose an organization"],
+          },
+        });
+      },
+    },
+    {
+      name: "Successful confirmation retries automatically without org picker or reload",
+      run: async (ctx) => {
+        await ctx.prove("After confirmation, the queued save retries automatically with no org picker and no reload", {
+          voiceover: vo[2],
+          action: async () => {
+            await clickDialogButton(ctx, "Verify password");
+            await ctx.waitFor(`(() => {
+              const text = document.body.innerText;
+              return !document.querySelector('[role="dialog"]') && text.includes('Workspace settings updated.') && location.pathname === ${JSON.stringify(ORG_SETTINGS_PATH)};
+            })()`, { timeoutMs: 45_000, label: "settings save retried after reauth" });
+          },
+          assert: async () => {
+            const actual = await readBrowserState(ctx);
+            recordAssertion(ctx, "The page never fell into the organization picker", actual.orgPickerVisible === false && actual.activeOrgId === state.org.id, actual);
+            recordAssertion(ctx, "The no-reload sentinel survived the confirmation and retry", actual.noReloadSentinel === state.sentinelToken, actual);
+          },
+          screenshot: {
+            name: "standardized-retry-no-picker",
+            requireText: ["Org settings", "Workspace settings updated."],
+            rejectText: ["Choose an organization"],
+          },
+        });
+      },
+    },
+    {
+      name: "The original settings change persists",
+      run: async (ctx) => {
+        await ctx.prove("The original workspace settings save is persisted on the selected org", {
+          voiceover: vo[3],
+          action: async () => {
+            await ctx.eval("window.scrollTo(0, 0); true");
+          },
+          assert: async () => {
+            const organization = await readOrgFromBrowser(ctx);
+            const actual = await readBrowserState(ctx);
+            recordAssertion(ctx, "The browser API reads the saved org name from the same selected org", organization?.organization?.name === state.savedOrgName && actual.activeOrgId === state.org.id, { organization, actual });
+            recordAssertion(ctx, "The success confirmation is visible on the settings page", actual.successVisible === true && actual.path === ORG_SETTINGS_PATH, actual);
+          },
+          screenshot: {
+            name: "standardized-save-persisted",
+            requireText: ["Workspace settings updated.", state.savedOrgName],
+            rejectText: ["Choose an organization"],
+          },
+        });
+      },
+    },
+    {
+      name: "API key creation uses the same standardized dialog",
+      run: async (ctx) => {
+        await ctx.prove("A second protected surface opens the same shared reauth dialog", {
+          voiceover: vo[4],
+          action: async () => {
+            await openApiKeysWithFreshSession(ctx);
+            await prepareApiKeyCreateForm(ctx);
+            await ageSessions(ctx);
+            await submitApiKeyCreate(ctx);
+          },
+          assert: async () => {
+            const actual = await readBrowserState(ctx);
+            recordAssertion(ctx, "API key creation shows the exact same security sentence", actual.dialogVisible === true && actual.dialogText.includes(SECURITY_MESSAGE), actual);
+            recordAssertion(ctx, "The API key draft and selected org are still intact", actual.path === API_KEYS_PATH && actual.activeOrgId === state.org.id && actual.keyNameDraft === state.apiKeyName, actual);
+          },
+          screenshot: {
+            name: "standardized-dialog-api-key",
+            requireText: ["API Keys", SECURITY_MESSAGE, "Verify password"],
+            rejectText: ["Choose an organization"],
+          },
+        });
+      },
+    },
+    {
+      name: "Invalid password and cancel keep the API key draft retryable",
+      run: async (ctx) => {
+        try {
+          await ctx.prove("Invalid confirmation and cancellation keep the same route, org, draft, and retry affordance", {
+            voiceover: vo[5],
+            action: async () => {
+              await fillDialogPassword(ctx, "definitely-not-the-password");
+              await clickDialogButton(ctx, "Verify password");
+              await ctx.waitFor(`(() => {
+                const dialog = document.querySelector('[role="dialog"]');
+                return Boolean(dialog?.querySelector('[data-notice-tone="error"][role="alert"]'));
+              })()`, { timeoutMs: 30_000, label: "invalid password remains in dialog" });
+              const invalidState = await readBrowserState(ctx);
+              recordAssertion(ctx, "Invalid password stays in the dialog without losing the API key draft", invalidState.invalidPasswordAlert === true && invalidState.path === API_KEYS_PATH && invalidState.keyNameDraft === state.apiKeyName, invalidState);
+              await clickDialogButton(ctx, "Cancel");
+              await ctx.waitFor(`(() => {
+                const notice = document.querySelector('[data-notice-tone="info"]');
+                return !document.querySelector('[role="dialog"]') && Boolean(notice && notice.textContent.includes(${JSON.stringify(SECURITY_MESSAGE)}));
+              })()`, { timeoutMs: 20_000, label: "calm cancel notice" });
+            },
+            assert: async () => {
+              const actual = await readBrowserState(ctx);
+              recordAssertion(ctx, "Cancellation keeps the user on the API key route and selected org", actual.path === API_KEYS_PATH && actual.activeOrgId === state.org.id && actual.orgPickerVisible === false, actual);
+              recordAssertion(ctx, "The draft remains visible and the create action can be retried", actual.keyNameDraft === state.apiKeyName && actual.apiKeyRetryReady === true, actual);
+              recordAssertion(ctx, "The cancellation feedback is a calm informational notice", actual.noticeTone === "info" && actual.noticeRole === "status" && actual.noticeText.includes(SECURITY_MESSAGE), actual);
+            },
+            screenshot: {
+              name: "standardized-cancel-retryable",
+              requireText: ["API Keys", SECURITY_MESSAGE, state.apiKeyName, "Create API key"],
+              rejectText: ["Choose an organization"],
+            },
+          });
+        } finally {
+          await cleanup(ctx);
+        }
+      },
+    },
+  ],
+};

--- a/evals/flows/standardized-workspace-reauth.flow.mjs
+++ b/evals/flows/standardized-workspace-reauth.flow.mjs
@@ -48,6 +48,10 @@ function recordAssertion(ctx, assertion, passed, actual) {
   ctx.assert(passed, `${assertion}. Actual: ${JSON.stringify(actual)}`);
 }
 
+async function removeNextDevPortal(ctx) {
+  await ctx.eval("document.querySelector('nextjs-portal')?.remove(); true");
+}
+
 async function runMysql(ctx, sql) {
   const container = mysqlContainer(ctx);
   const command = container ? "docker" : "mysql";
@@ -436,6 +440,7 @@ export default {
             await ageSessions(ctx);
             await clickExactText(ctx, "Save settings", "button");
             await waitForReauthDialog(ctx);
+            await removeNextDevPortal(ctx);
           },
           assert: async () => {
             const actual = await readBrowserState(ctx);
@@ -457,6 +462,7 @@ export default {
           voiceover: vo[1],
           action: async () => {
             await fillDialogPassword(ctx, ADMIN_PASSWORD);
+            await removeNextDevPortal(ctx);
           },
           assert: async () => {
             const actual = await readBrowserState(ctx);
@@ -482,6 +488,7 @@ export default {
               const text = document.body.innerText;
               return !document.querySelector('[role="dialog"]') && text.includes('Workspace settings updated.') && location.pathname === ${JSON.stringify(ORG_SETTINGS_PATH)};
             })()`, { timeoutMs: 45_000, label: "settings save retried after reauth" });
+            await removeNextDevPortal(ctx);
           },
           assert: async () => {
             const actual = await readBrowserState(ctx);
@@ -528,6 +535,7 @@ export default {
               };
             })()`, { awaitPromise: true });
             recordAssertion(ctx, "The persisted org-name input is focused with its saved value selected", selected.found === true && selected.value === state.savedOrgName && selected.active === true && selected.selectedText === state.savedOrgName, selected);
+            await removeNextDevPortal(ctx);
           },
           assert: async () => {
             const organization = await readOrgFromBrowser(ctx);
@@ -553,6 +561,7 @@ export default {
             await prepareApiKeyCreateForm(ctx);
             await ageSessions(ctx);
             await submitApiKeyCreate(ctx);
+            await removeNextDevPortal(ctx);
           },
           assert: async () => {
             const actual = await readBrowserState(ctx);
@@ -587,6 +596,7 @@ export default {
                 const notice = document.querySelector('[data-notice-tone="info"]');
                 return !document.querySelector('[role="dialog"]') && Boolean(notice && notice.textContent.includes(${JSON.stringify(SECURITY_MESSAGE)}));
               })()`, { timeoutMs: 20_000, label: "calm cancel notice" });
+              await removeNextDevPortal(ctx);
             },
             assert: async () => {
               const actual = await readBrowserState(ctx);

--- a/evals/flows/standardized-workspace-reauth.flow.mjs
+++ b/evals/flows/standardized-workspace-reauth.flow.mjs
@@ -502,7 +502,32 @@ export default {
         await ctx.prove("The original workspace settings save is persisted on the selected org", {
           voiceover: vo[3],
           action: async () => {
-            await ctx.eval("window.scrollTo(0, 0); true");
+            const selected = await ctx.eval(`(async () => {
+              const input = document.querySelector(${JSON.stringify(ORG_NAME_INPUT_SELECTOR)});
+              if (!(input instanceof HTMLInputElement)) {
+                return { found: false, value: null, active: false, selectedText: null };
+              }
+
+              input.scrollIntoView({ block: 'center', inline: 'nearest', behavior: 'instant' });
+              input.focus({ preventScroll: true });
+              input.select();
+
+              await new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)));
+
+              const selectionStart = input.selectionStart;
+              const selectionEnd = input.selectionEnd;
+              const selectedText = selectionStart === null || selectionEnd === null
+                ? null
+                : input.value.slice(selectionStart, selectionEnd);
+
+              return {
+                found: true,
+                value: input.value,
+                active: document.activeElement === input,
+                selectedText,
+              };
+            })()`, { awaitPromise: true });
+            recordAssertion(ctx, "The persisted org-name input is focused with its saved value selected", selected.found === true && selected.value === state.savedOrgName && selected.active === true && selected.selectedText === state.savedOrgName, selected);
           },
           assert: async () => {
             const organization = await readOrgFromBrowser(ctx);
@@ -512,7 +537,7 @@ export default {
           },
           screenshot: {
             name: "standardized-save-persisted",
-            requireText: ["Workspace settings updated.", state.savedOrgName],
+            requireText: ["Organization Identity", "Name", "Workspace settings updated."],
             rejectText: ["Choose an organization"],
           },
         });

--- a/evals/flows/standardized-workspace-reauth.flow.mjs
+++ b/evals/flows/standardized-workspace-reauth.flow.mjs
@@ -249,26 +249,43 @@ async function openOrgSettingsAsSeededAdmin(ctx) {
   }
   await navigateTo(ctx, "/");
   await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"]'))", { timeoutMs: 30_000, label: "email input" });
-  const switchedToSignIn = await ctx.eval(`(() => {
-    const button = [...document.querySelectorAll('button[type="button"]')]
-      .find((entry) => (entry.textContent ?? '').trim() === 'Sign in');
-    button?.click();
-    return Boolean(button);
-  })()`);
-  if (switchedToSignIn) {
+  const passwordAlreadyVisible = await ctx.eval("Boolean(document.querySelector('input[type=\"password\"]'))");
+  if (!passwordAlreadyVisible) {
+    await ctx.fill('input[type="email"]', ADMIN_EMAIL);
+    const advanced = await ctx.eval(`(() => {
+      const form = document.querySelector('input[type="email"]')?.closest('form');
+      const button = form?.querySelector('button[type="submit"]');
+      button?.click();
+      return Boolean(button);
+    })()`);
+    ctx.assert(advanced, "No Next button found on the email-first sign-in card.");
+    await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 20_000, label: "password step" });
+  } else {
+    const switchedToSignIn = await ctx.eval(`(() => {
+      const button = [...document.querySelectorAll('button[type="button"]')]
+        .find((entry) => (entry.textContent ?? '').trim() === 'Sign in');
+      button?.click();
+      return Boolean(button);
+    })()`);
+    if (switchedToSignIn) {
+      await ctx.waitFor(
+        `(() => (document.querySelector('button[type="submit"]')?.textContent ?? '').includes('Sign in'))()`,
+        { timeoutMs: 10_000, label: "sign-in mode selected" },
+      );
+    }
     await ctx.waitFor(
-      `(() => (document.querySelector('button[type="submit"]')?.textContent ?? '').includes('Sign in'))()`,
-      { timeoutMs: 10_000, label: "sign-in mode selected" },
+      "Boolean(document.querySelector('input[type=\"password\"]'))",
+      { timeoutMs: 30_000, label: "password input" },
     );
+    await ctx.fill('input[type="email"]', ADMIN_EMAIL);
   }
-  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 30_000, label: "password input" });
-  await ctx.fill('input[type="email"]', ADMIN_EMAIL);
   await ctx.fill('input[type="password"]', ADMIN_PASSWORD);
-  await ctx.eval(`(() => {
+  const submitted = await ctx.eval(`(() => {
     const button = document.querySelector('button[type="submit"]');
     button?.click();
     return Boolean(button);
   })()`);
+  ctx.assert(submitted, "No submit button found on the sign-in card.");
   await ctx.waitFor(
     `(() => {
       const text = document.body?.innerText ?? '';

--- a/evals/flows/standardized-workspace-reauth.flow.mjs
+++ b/evals/flows/standardized-workspace-reauth.flow.mjs
@@ -34,7 +34,8 @@ const state = {
 };
 
 function mysqlContainer(ctx) {
-  return ctx.env.OPENWORK_EVAL_DEN_MYSQL_CONTAINER || "openwork-web-local-mysql";
+  const container = ctx.env.OPENWORK_EVAL_DEN_MYSQL_CONTAINER?.trim();
+  return container ? container : null;
 }
 
 function recordAssertion(ctx, assertion, passed, actual) {
@@ -48,16 +49,12 @@ function recordAssertion(ctx, assertion, passed, actual) {
 }
 
 async function runMysql(ctx, sql) {
-  const { stdout, stderr } = await execFileAsync("docker", [
-    "exec",
-    mysqlContainer(ctx),
-    "mysql",
-    "-uroot",
-    "-ppassword",
-    "openwork_den",
-    "-e",
-    sql,
-  ]);
+  const container = mysqlContainer(ctx);
+  const command = container ? "docker" : "mysql";
+  const args = container
+    ? ["exec", container, "mysql", "-uroot", "-ppassword", "openwork_den", "-e", sql]
+    : ["-h127.0.0.1", "-uroot", "-ppassword", "openwork_den", "-e", sql];
+  const { stdout, stderr } = await execFileAsync(command, args);
 
   if (stderr.trim()) {
     ctx.log(`mysql stderr: ${stderr.trim()}`);
@@ -407,7 +404,7 @@ export default {
   title: "Workspace re-authentication keeps multi-org settings actions on the same route and org",
   kind: "user-facing",
   preserveTheme: true,
-  requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_MYSQL_CONTAINER", "OPENWORK_EVAL_DEN_MULTI_ORG"],
+  requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_MULTI_ORG"],
   steps: [
     {
       name: "Org settings save opens the standardized security dialog",

--- a/evals/flows/standardized-workspace-reauth.flow.mjs
+++ b/evals/flows/standardized-workspace-reauth.flow.mjs
@@ -571,7 +571,7 @@ export default {
             },
             screenshot: {
               name: "standardized-cancel-retryable",
-              requireText: ["API Keys", SECURITY_MESSAGE, state.apiKeyName, "Create API key"],
+              requireText: ["API Keys", SECURITY_MESSAGE, "Create API key"],
               rejectText: ["Choose an organization"],
             },
           });

--- a/evals/voiceovers/standardized-workspace-reauth.md
+++ b/evals/voiceovers/standardized-workspace-reauth.md
@@ -1,0 +1,13 @@
+# standardized-workspace-reauth — Workspace re-authentication returns users to their settings
+
+1. I’m in workspace settings, and when I change a sensitive setting, OpenWork shows one consistent identity-confirmation dialog: “For security, confirm it’s you before changing workspace settings.”
+
+2. I confirm my identity without losing the settings page, selected organization, or any unsaved context.
+
+3. When authentication completes, I return directly to the setting I was changing—there’s no page reload and no organization picker.
+
+4. I complete the original change successfully, with clear confirmation that it was saved.
+
+5. I try another protected workspace setting and get the same standardized re-authentication experience, proving all settings use one reliable flow.
+
+6. If I cancel or authentication fails, I remain on the same workspace and settings page, receive a clear message, and can retry safely.


### PR DESCRIPTION
## Summary
- route every freshness-protected Den Web action through one shared reauthentication coordinator and canonical security message
- restore the displayed organization before retry, preserve the current settings route and drafts, and remove destructive same-tab auth fallbacks
- queue concurrent stale actions safely and keep saved/cancelled outcomes visibly retryable
- add an approved six-frame Daytona fraimz flow covering settings save, multi-org recovery, a second protected surface, failure, and cancellation

## Daytona verification
- `pnpm --dir ee/apps/den-web typecheck` — passed
- `pnpm --dir ee/apps/den-web test` — 27 passed
- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm --filter @openwork-ee/den-api exec bun test test/org-identity-access.test.ts` — 6 passed
- `pnpm fraimz --flow standardized-workspace-reauth --cdp-url http://127.0.0.1:9222` — passed, 6/6 narrated frames plus voice-over coverage

All runtime validation was performed in Daytona, not locally.

## Proof
- [Daytona fraimz — run 2026-07-14T06-00-49-018Z](https://8090-bdnznukxhw14vhsj.daytonaproxy01.net/fraimz.html)
- Every frame asserts the selected org and route remain stable and rejects `Choose an organization`.
