### PR TITLE
fix(app): copy chat attachments into the workspace

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -782,7 +782,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
       captureAnalyticsEvent("task_send_failed", {});
       setError(parsed);
       useSessionActivityStore.getState().setError(props.workspaceId, props.sessionId, parsed.message);
-      setComposerDraft(props.sessionId, "");
       setAwaitingAssistantBaseline(null);
       setSending(false);
       throw nextError;
@@ -805,9 +804,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
       await sendDraft(nextDraft, sentAttachments);
       clearComposer();
     } catch {
-      setComposerDraft(props.sessionId, "");
     }
-  }, [attachments, buildDraft, clearComposer, draft, props.sessionId, sendDraft, setComposerDraft]);
+  }, [attachments, buildDraft, clearComposer, draft, props.sessionId, sendDraft]);
 
   const handleSteer = handleSend;
 

--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -1,6 +1,7 @@
-import type { FilePartInput } from "@opencode-ai/sdk/v2/client";
+import type { FilePartInput, TextPartInput } from "@opencode-ai/sdk/v2/client";
 
 import type { ComposerAttachment } from "../../../../app/types";
+import { joinWorkspaceRelativePath, toFileUrl } from "./prompt-file-parts";
 
 type AttachmentKind = "image" | "file";
 
@@ -12,6 +13,31 @@ type AttachmentFileMetadata = {
   kind: AttachmentKind;
   readable: boolean;
 };
+
+type InboxUploadResult = {
+  ok: boolean;
+  path: string;
+  bytes: number;
+};
+
+type ChatAttachmentUploadClient = {
+  uploadInbox: (workspaceId: string, file: File, options?: { path?: string }) => Promise<InboxUploadResult>;
+};
+
+export type ChatAttachmentWorkspaceEndpoint = {
+  client: ChatAttachmentUploadClient;
+  workspaceId: string;
+};
+
+type UploadedChatAttachment = {
+  filename: string;
+  mime: string;
+  bytes: number;
+  workspacePath: string;
+  url: string;
+};
+
+const WORKSPACE_INBOX_ROOT = ".opencode/openwork/inbox";
 
 const EXTENSION_MIME_TYPES: Record<string, string> = {
   jpg: "image/jpeg",
@@ -112,10 +138,22 @@ function normalizeFilenameExtension(filename: string, mime: string) {
   return `${stem.trim() || "attachment"}.${preferredExtension}`;
 }
 
+export function safeAttachmentFilename(filename: string) {
+  const normalized = filename.replace(/\\/g, "/");
+  const basename = normalized.split("/").filter(Boolean).pop()?.trim() ?? "";
+  const safe = basename.replace(/[\u0000-\u001f\u007f<>:"|?*]/g, "_").trim();
+  return safe && safe !== "." && safe !== ".." ? safe : "attachment";
+}
+
+function safePathSegment(value: string, fallback: string) {
+  const safe = safeAttachmentFilename(value).replace(/\.+/g, ".");
+  return safe && safe !== "." ? safe : fallback;
+}
+
 export function resolveAttachmentFileMetadata(file: Pick<File, "name" | "type">): AttachmentFileMetadata {
   const mime = resolveAttachmentMime(file);
   return {
-    filename: normalizeFilenameExtension(file.name, mime),
+    filename: safeAttachmentFilename(normalizeFilenameExtension(file.name, mime)),
     mime,
     kind: mime.startsWith("image/") ? "image" : "file",
     readable: isResolvedAttachmentMimeReadable(mime),
@@ -138,6 +176,115 @@ function arrayBufferToBase64(buffer: ArrayBuffer) {
 
 async function fileToDataUrl(file: AttachmentFile, mime: string) {
   return `data:${mime};base64,${arrayBufferToBase64(await file.arrayBuffer())}`;
+}
+
+function randomAttachmentId() {
+  const cryptoApi = globalThis.crypto;
+  if (cryptoApi?.randomUUID) return cryptoApi.randomUUID();
+
+  const bytes = new Uint8Array(16);
+  cryptoApi?.getRandomValues(bytes);
+  if (bytes.some((byte) => byte !== 0)) {
+    return Array.from(bytes, (byte) => byte.toString(16).padStart(2, "0")).join("");
+  }
+
+  return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2)}`;
+}
+
+export function buildChatAttachmentInboxPath(input: { sessionId: string; filename: string; id: string }) {
+  const session = safePathSegment(input.sessionId, "session");
+  const id = safePathSegment(input.id, "attachment");
+  const filename = safeAttachmentFilename(input.filename);
+  return `chat-attachments/${session}/${id}-${filename}`;
+}
+
+export function workspaceInboxPath(inboxRelativePath: string) {
+  return joinWorkspaceRelativePath(WORKSPACE_INBOX_ROOT, inboxRelativePath);
+}
+
+function uploadErrorMessage(filename: string, error: unknown) {
+  const detail = error instanceof Error ? error.message : String(error || "Unknown upload error");
+  return `Failed to copy attachment "${filename}" into this worker workspace: ${detail}`;
+}
+
+function attachmentPathNote(uploaded: UploadedChatAttachment[]) {
+  return [
+    "Attached files were copied into this worker workspace for tool access:",
+    ...uploaded.map((item) => `- ${item.filename}: ${item.workspacePath} (${item.url})`),
+    "Use these paths with Read/Bash/MCP/Docling when a tool needs the file bytes.",
+  ].join("\n");
+}
+
+function uploadedAttachmentFilePart(item: UploadedChatAttachment): FilePartInput {
+  return {
+    type: "file",
+    url: item.url,
+    filename: item.filename,
+    mime: item.mime,
+  };
+}
+
+export async function composerAttachmentsToWorkspaceFileParts(input: {
+  attachments: ComposerAttachment[];
+  endpoint: ChatAttachmentWorkspaceEndpoint;
+  sessionId: string;
+  workspaceRoot: string;
+  createId?: () => string;
+}): Promise<Array<TextPartInput | FilePartInput>> {
+  if (input.attachments.length === 0) return [];
+
+  const workspaceRoot = input.workspaceRoot.trim();
+  if (!workspaceRoot) {
+    throw new Error("Workspace path is unavailable; attachments could not be copied for tool access.");
+  }
+
+  const workspaceId = input.endpoint.workspaceId.trim();
+  if (!workspaceId) {
+    throw new Error("Workspace endpoint is unavailable; attachments could not be copied for tool access.");
+  }
+
+  const uploaded: UploadedChatAttachment[] = [];
+  for (const attachment of input.attachments) {
+    const metadata = resolveAttachmentFileMetadata(attachment.file);
+    const id = input.createId ? input.createId() : randomAttachmentId();
+    const inboxPath = buildChatAttachmentInboxPath({
+      sessionId: input.sessionId,
+      filename: metadata.filename,
+      id,
+    });
+
+    let result: InboxUploadResult;
+    try {
+      result = await input.endpoint.client.uploadInbox(workspaceId, attachment.file, { path: inboxPath });
+    } catch (error) {
+      throw new Error(uploadErrorMessage(metadata.filename, error));
+    }
+
+    if (result.ok === false) {
+      throw new Error(`Failed to copy attachment "${metadata.filename}" into this worker workspace: upload was rejected`);
+    }
+    if (!result.path.trim()) {
+      throw new Error(`Failed to copy attachment "${metadata.filename}" into this worker workspace: upload did not return a path`);
+    }
+    if (result.bytes !== attachment.file.size) {
+      throw new Error(`Failed to copy attachment "${metadata.filename}" into this worker workspace: expected ${attachment.file.size} bytes, wrote ${result.bytes}`);
+    }
+
+    const workspacePath = workspaceInboxPath(result.path);
+    const absolutePath = joinWorkspaceRelativePath(workspaceRoot, workspacePath);
+    uploaded.push({
+      filename: metadata.filename,
+      mime: metadata.mime,
+      bytes: result.bytes,
+      workspacePath,
+      url: toFileUrl(absolutePath),
+    });
+  }
+
+  return [
+    { type: "text", text: attachmentPathNote(uploaded) },
+    ...uploaded.map(uploadedAttachmentFilePart),
+  ];
 }
 
 export async function composerAttachmentToFilePart(attachment: ComposerAttachment): Promise<FilePartInput> {

--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -208,11 +208,11 @@ function uploadErrorMessage(filename: string, error: unknown) {
 }
 
 function attachmentPathNote(uploaded: UploadedChatAttachment[]) {
-  return [
+  return `\n\n${[
     "Attached files were copied into this worker workspace for tool access:",
     ...uploaded.map((item) => `- ${item.filename}: ${item.workspacePath} (${item.url})`),
     "Use these paths with Read/Bash/MCP/Docling when a tool needs the file bytes.",
-  ].join("\n");
+  ].join("\n")}`;
 }
 
 function uploadedAttachmentFilePart(item: UploadedChatAttachment): FilePartInput {

--- a/apps/app/src/react-app/domains/session/sync/prompt-file-parts.ts
+++ b/apps/app/src/react-app/domains/session/sync/prompt-file-parts.ts
@@ -65,10 +65,17 @@ function encodeFilePath(path: string) {
   return path.replace(/\\/g, "/").split("/").map(encodeURIComponent).join("/");
 }
 
-function toFileUrl(path: string) {
+export function toFileUrl(path: string) {
   const normalized = path.replace(/\\/g, "/");
   if (/^[A-Za-z]:\//.test(normalized)) return `file:///${encodeFilePath(normalized).replace(/^([A-Za-z])%3A/, "$1:")}`;
   return `file://${encodeFilePath(normalized)}`;
+}
+
+export function joinWorkspaceRelativePath(workspaceRoot: string, relativePath: string) {
+  const root = workspaceRoot.trim().replace(/\\/g, "/").replace(/\/+$/, "");
+  const relative = relativePath.trim().replace(/\\/g, "/").replace(/^\/+/, "");
+  if (!root || !relative) return "";
+  return `${root}/${relative}`;
 }
 
 export function firstLineLocalFileParts(text: string, workspaceRoot: string): FilePartInput[] {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -101,8 +101,8 @@ import { buildOpenworkEnvSystemContext } from "@/react-app/domains/session/sync/
 import {
   applySessionRevert,
 } from "@/react-app/domains/session/sync/session-sync";
-import { firstLineLocalFileParts } from "@/react-app/domains/session/sync/prompt-file-parts";
-import { composerAttachmentToFilePart } from "@/react-app/domains/session/sync/attachment-file-part";
+import { firstLineLocalFileParts, joinWorkspaceRelativePath, toFileUrl } from "@/react-app/domains/session/sync/prompt-file-parts";
+import { composerAttachmentsToWorkspaceFileParts } from "@/react-app/domains/session/sync/attachment-file-part";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
 import { useSessionFindStore } from "@/react-app/domains/session/surface/find-store";
@@ -247,7 +247,12 @@ function nextEvalUnavailableModel(current: ModelRef | null | undefined) {
 // `resolveWorkspaceEndpoint` in apps/app/src/app/lib/workspace-endpoint.ts.
 // Don't compose `<baseUrl>/workspace/<id>` here.
 
-async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
+async function draftToParts(
+  draft: ComposerDraft,
+  workspaceRoot: string,
+  sessionId: string,
+  endpoint: ResolvedWorkspaceEndpoint | null,
+) {
   const parts: Array<TextPartInput | FilePartInput | AgentPartInput> = [];
   const root = workspaceRoot.trim();
 
@@ -255,9 +260,9 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
     const trimmed = path.trim();
     if (!trimmed) return "";
     if (trimmed.startsWith("/")) return trimmed;
-    if (/^[a-zA-Z]:\\/.test(trimmed)) return trimmed;
+    if (/^[a-zA-Z]:[\\/]/.test(trimmed)) return trimmed;
     if (!root) return "";
-    return `${root}/${trimmed}`.replace(/\/\/+/g, "/");
+    return joinWorkspaceRelativePath(root, trimmed);
   };
 
   const filenameFromPath = (path: string) => {
@@ -293,7 +298,7 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
       parts.push({
         type: "file",
         mime: "text/plain",
-        url: `file://${absolute}`,
+        url: toFileUrl(absolute),
         filename: filenameFromPath(part.path),
       });
     }
@@ -301,7 +306,17 @@ async function draftToParts(draft: ComposerDraft, workspaceRoot: string) {
 
   parts.push(...firstLineLocalFileParts(draft.resolvedText ?? draft.text, root));
 
-  parts.push(...(await Promise.all(draft.attachments.map(composerAttachmentToFilePart))));
+  if (draft.attachments.length > 0) {
+    if (!endpoint) {
+      throw new Error("Workspace endpoint is unavailable; attachments could not be copied for tool access.");
+    }
+    parts.push(...(await composerAttachmentsToWorkspaceFileParts({
+      attachments: draft.attachments,
+      endpoint,
+      sessionId,
+      workspaceRoot: root,
+    })));
+  }
 
   return parts;
 }
@@ -914,7 +929,7 @@ export function SessionRoute() {
           return;
         }
 
-        const parts = await draftToParts(draft, selectedWorkspaceRoot);
+        const parts = await draftToParts(draft, selectedWorkspaceRoot, targetSessionId, selectedWorkspaceEndpoint);
         const envSystemContext = await buildOpenworkEnvSystemContext(client, {
           cacheKey: targetSessionId,
           runtimeKey: environmentRuntimeKey,

--- a/apps/app/tests/attachment-file-part.test.ts
+++ b/apps/app/tests/attachment-file-part.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, test } from "bun:test";
 
 import type { ComposerAttachment } from "../src/app/types";
-import { composerAttachmentToFilePart, resolveAttachmentFileMetadata } from "../src/react-app/domains/session/sync/attachment-file-part";
+import {
+  buildChatAttachmentInboxPath,
+  composerAttachmentsToWorkspaceFileParts,
+  composerAttachmentToFilePart,
+  resolveAttachmentFileMetadata,
+  safeAttachmentFilename,
+  workspaceInboxPath,
+  type ChatAttachmentWorkspaceEndpoint,
+} from "../src/react-app/domains/session/sync/attachment-file-part";
 
 const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01]);
+const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a, 0x25, 0xe2, 0xe3, 0xcf, 0xd3]);
+
+type UploadCall = {
+  workspaceId: string;
+  path: string;
+  filename: string;
+  bytes: number[];
+};
 
 function attachmentFor(file: File, metadata: Partial<Pick<ComposerAttachment, "name" | "mimeType" | "kind">> = {}): ComposerAttachment {
   return {
@@ -22,6 +38,39 @@ function decodedDataUrlBytes(url: string) {
   expect(markerIndex).toBeGreaterThan(0);
   const binary = atob(url.slice(markerIndex + marker.length));
   return Uint8Array.from(binary, (char) => char.charCodeAt(0));
+}
+
+function uploadRecorder(workspaceId: string) {
+  const calls: UploadCall[] = [];
+  const endpoint: ChatAttachmentWorkspaceEndpoint = {
+    workspaceId,
+    client: {
+      uploadInbox: async (id, file, options) => {
+        const bytes = new Uint8Array(await file.arrayBuffer());
+        const path = options?.path?.trim() || file.name;
+        calls.push({
+          workspaceId: id,
+          path,
+          filename: file.name,
+          bytes: Array.from(bytes),
+        });
+        return { ok: true, path, bytes: file.size };
+      },
+    },
+  };
+  return { endpoint, calls };
+}
+
+function textPartText(parts: Awaited<ReturnType<typeof composerAttachmentsToWorkspaceFileParts>>) {
+  const part = parts[0];
+  if (!part || part.type !== "text") throw new Error("Expected first attachment part to be a text note");
+  return part.text;
+}
+
+function filePartUrl(parts: Awaited<ReturnType<typeof composerAttachmentsToWorkspaceFileParts>>, index: number) {
+  const part = parts[index];
+  if (!part || part.type !== "file") throw new Error(`Expected attachment part ${index} to be a file`);
+  return part.url;
 }
 
 describe("composer attachment file parts", () => {
@@ -69,5 +118,121 @@ describe("composer attachment file parts", () => {
 
     expect((await composerAttachmentToFilePart(attachmentFor(imageNamedPdf))).filename).toBe("PassaportoPaolo_small.jpg");
     expect((await composerAttachmentToFilePart(attachmentFor(pdfNamedPng))).filename).toBe("scan.pdf");
+  });
+
+  test("sanitizes desktop-style filenames without leaking local path segments", () => {
+    expect(safeAttachmentFilename("C:\\Users\\omar\\Scans\\scan one 李?.pdf")).toBe("scan one 李_.pdf");
+    expect(resolveAttachmentFileMetadata(new File([PDF_BYTES], "C:\\Users\\omar\\scan one 李.pdf", { type: "application/pdf" }))).toMatchObject({
+      filename: "scan one 李.pdf",
+      mime: "application/pdf",
+    });
+  });
+
+  test("generates session-scoped inbox paths under the workspace inbox", () => {
+    const inboxPath = buildChatAttachmentInboxPath({
+      sessionId: "ses_123",
+      id: "nonce-abc",
+      filename: "scan one 李.pdf",
+    });
+
+    expect(inboxPath).toBe("chat-attachments/ses_123/nonce-abc-scan one 李.pdf");
+    expect(workspaceInboxPath(inboxPath)).toBe(".opencode/openwork/inbox/chat-attachments/ses_123/nonce-abc-scan one 李.pdf");
+  });
+
+  test("uploads exact bytes to the endpoint workspace id and exposes a worker file URL plus path note", async () => {
+    const { endpoint, calls } = uploadRecorder("server-workspace-42");
+    const file = new File([PDF_BYTES], "image-only scan.pdf", { type: "application/pdf" });
+
+    const parts = await composerAttachmentsToWorkspaceFileParts({
+      attachments: [attachmentFor(file)],
+      endpoint,
+      sessionId: "ses_abc",
+      workspaceRoot: "/workspaces/Worker Root",
+      createId: () => "nonce-a",
+    });
+
+    expect(calls).toEqual([{
+      workspaceId: "server-workspace-42",
+      path: "chat-attachments/ses_abc/nonce-a-image-only scan.pdf",
+      filename: "image-only scan.pdf",
+      bytes: Array.from(PDF_BYTES),
+    }]);
+    expect(textPartText(parts)).toContain(".opencode/openwork/inbox/chat-attachments/ses_abc/nonce-a-image-only scan.pdf");
+    expect(textPartText(parts)).toContain("Read/Bash/MCP/Docling");
+    expect(filePartUrl(parts, 1)).toBe("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_abc/nonce-a-image-only%20scan.pdf");
+    expect(parts[1]).toMatchObject({
+      type: "file",
+      filename: "image-only scan.pdf",
+      mime: "application/pdf",
+    });
+  });
+
+  test("uploads duplicate filenames to distinct non-overwriting paths", async () => {
+    const { endpoint, calls } = uploadRecorder("workspace-a");
+    const first = new File([PDF_BYTES], "scan.pdf", { type: "application/pdf" });
+    const second = new File([PDF_BYTES], "scan.pdf", { type: "application/pdf" });
+    const ids = ["nonce-a", "nonce-b"];
+
+    const parts = await composerAttachmentsToWorkspaceFileParts({
+      attachments: [attachmentFor(first), attachmentFor(second)],
+      endpoint,
+      sessionId: "ses_dupes",
+      workspaceRoot: "C:\\Users\\Ada Lovelace\\工作区",
+      createId: () => {
+        const id = ids.shift();
+        if (!id) throw new Error("missing nonce");
+        return id;
+      },
+    });
+
+    expect(calls.map((call) => call.path)).toEqual([
+      "chat-attachments/ses_dupes/nonce-a-scan.pdf",
+      "chat-attachments/ses_dupes/nonce-b-scan.pdf",
+    ]);
+    expect(new Set(calls.map((call) => call.path)).size).toBe(2);
+    expect(filePartUrl(parts, 1)).toBe("file:///C:/Users/Ada%20Lovelace/%E5%B7%A5%E4%BD%9C%E5%8C%BA/.opencode/openwork/inbox/chat-attachments/ses_dupes/nonce-a-scan.pdf");
+    expect(filePartUrl(parts, 2)).toBe("file:///C:/Users/Ada%20Lovelace/%E5%B7%A5%E4%BD%9C%E5%8C%BA/.opencode/openwork/inbox/chat-attachments/ses_dupes/nonce-b-scan.pdf");
+  });
+
+  test("fails before producing prompt parts when workspace upload fails", async () => {
+    const endpoint: ChatAttachmentWorkspaceEndpoint = {
+      workspaceId: "workspace-a",
+      client: {
+        uploadInbox: async () => {
+          throw new Error("disk full");
+        },
+      },
+    };
+    const file = new File([PDF_BYTES], "scan.pdf", { type: "application/pdf" });
+
+    await expect(composerAttachmentsToWorkspaceFileParts({
+      attachments: [attachmentFor(file)],
+      endpoint,
+      sessionId: "ses_fail",
+      workspaceRoot: "/workspace/a",
+      createId: () => "nonce-a",
+    })).rejects.toThrow("Failed to copy attachment \"scan.pdf\" into this worker workspace: disk full");
+  });
+
+  test("treats an ok:false upload result as a hard failure", async () => {
+    const endpoint: ChatAttachmentWorkspaceEndpoint = {
+      workspaceId: "workspace-a",
+      client: {
+        uploadInbox: async (_workspaceId, file, options) => ({
+          ok: false,
+          path: options?.path?.trim() || file.name,
+          bytes: file.size,
+        }),
+      },
+    };
+    const file = new File([PDF_BYTES], "scan.pdf", { type: "application/pdf" });
+
+    await expect(composerAttachmentsToWorkspaceFileParts({
+      attachments: [attachmentFor(file)],
+      endpoint,
+      sessionId: "ses_rejected",
+      workspaceRoot: "/workspace/a",
+      createId: () => "nonce-a",
+    })).rejects.toThrow("Failed to copy attachment \"scan.pdf\" into this worker workspace: upload was rejected");
   });
 });

--- a/apps/app/tests/attachment-file-part.test.ts
+++ b/apps/app/tests/attachment-file-part.test.ts
@@ -157,6 +157,7 @@ describe("composer attachment file parts", () => {
       filename: "image-only scan.pdf",
       bytes: Array.from(PDF_BYTES),
     }]);
+    expect(textPartText(parts).startsWith("\n\nAttached files were copied")).toBe(true);
     expect(textPartText(parts)).toContain(".opencode/openwork/inbox/chat-attachments/ses_abc/nonce-a-image-only scan.pdf");
     expect(textPartText(parts)).toContain("Read/Bash/MCP/Docling");
     expect(filePartUrl(parts, 1)).toBe("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_abc/nonce-a-image-only%20scan.pdf");

--- a/apps/app/tests/workspace-endpoint.test.ts
+++ b/apps/app/tests/workspace-endpoint.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveWorkspaceEndpoint, workspaceServerId } from "../src/app/lib/workspace-endpoint";
+
+describe("workspace endpoint resolution", () => {
+  test("local workspaces use the local server and local workspace id", () => {
+    const endpoint = resolveWorkspaceEndpoint({
+      id: "ws_local",
+      name: "Local",
+      path: "/tmp/ws-local",
+      preset: "minimal",
+      workspaceType: "local",
+    }, {
+      baseUrl: "http://127.0.0.1:4096",
+      token: "local-token",
+    });
+
+    expect(endpoint?.workspaceId).toBe("ws_local");
+    expect(endpoint?.baseUrl).toBe("http://127.0.0.1:4096");
+    expect(endpoint?.isRemote).toBe(false);
+    expect(endpoint?.mountedBaseUrl).toBe("http://127.0.0.1:4096/workspace/ws_local");
+  });
+
+  test("remote workspaces use the owning worker URL and server-side workspace id", () => {
+    const endpoint = resolveWorkspaceEndpoint({
+      id: "rem_ui-workspace-b",
+      name: "Remote",
+      path: "/workspace/server-workspace-b",
+      preset: "minimal",
+      workspaceType: "remote",
+      baseUrl: "https://worker.example.test",
+      openworkToken: "remote-token",
+      openworkWorkspaceId: "server-workspace-b",
+    }, {
+      baseUrl: "http://127.0.0.1:4096",
+      token: "local-token",
+    });
+
+    expect(endpoint?.workspaceId).toBe("server-workspace-b");
+    expect(endpoint?.baseUrl).toBe("https://worker.example.test");
+    expect(endpoint?.isRemote).toBe(true);
+    expect(endpoint?.mountedBaseUrl).toBe("https://worker.example.test/workspace/server-workspace-b");
+  });
+
+  test("remote workspace ids fall back to stripping rem_ when no explicit server id exists", () => {
+    expect(workspaceServerId({
+      id: "rem_workspace-c",
+      name: "Remote fallback",
+      path: "/workspace/workspace-c",
+      preset: "minimal",
+      workspaceType: "remote",
+      baseUrl: "https://worker.example.test",
+    })).toBe("workspace-c");
+  });
+});

--- a/evals/flows/chat-attachment-workspace-path.flow.mjs
+++ b/evals/flows/chat-attachment-workspace-path.flow.mjs
@@ -1,0 +1,215 @@
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "chat-attachment-workspace-path";
+const FILENAME = "image-only scan.pdf";
+const PROMPT = "Please inspect the attached scanned PDF. Use the provided worker file path when a tool needs the bytes.";
+const IMAGE_ONLY_PDF_SOURCE = `%PDF-1.4
+1 0 obj
+<< /Type /Catalog /Pages 2 0 R >>
+endobj
+2 0 obj
+<< /Type /Pages /Kids [3 0 R] /Count 1 >>
+endobj
+3 0 obj
+<< /Type /Page /Parent 2 0 R /MediaBox [0 0 72 72] /Resources << /XObject << /Im0 4 0 R >> >> /Contents 5 0 R >>
+endobj
+4 0 obj
+<< /Type /XObject /Subtype /Image /Width 1 /Height 1 /ColorSpace /DeviceRGB /BitsPerComponent 8 /Filter /ASCIIHexDecode /Length 7 >>
+stream
+FF0000>
+endstream
+endobj
+5 0 obj
+<< /Length 31 >>
+stream
+q 72 0 0 72 0 0 cm /Im0 Do Q
+endstream
+endobj
+%%EOF
+`;
+const EXPECTED_BYTES = Buffer.from(IMAGE_ONLY_PDF_SOURCE, "utf8");
+const EXPECTED_SHA256 = createHash("sha256").update(EXPECTED_BYTES).digest("hex");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const execFileAsync = promisify(execFile);
+
+function assertEvidence(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${actual})` : ""}`);
+}
+
+async function activeSessionId(ctx) {
+  return ctx.waitFor(
+    `(() => {
+      const route = window.__openworkControl.snapshot().route || "";
+      const match = route.match(/ses_[A-Za-z0-9]+/);
+      return match ? match[0] : null;
+    })()`,
+    { timeoutMs: 30_000, label: "active session id" },
+  );
+}
+
+async function pastePdfAttachment(ctx) {
+  const result = await ctx.eval(`(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
+      || document.querySelector('[contenteditable="true"]');
+    if (!editor) return { ok: false, reason: "composer not found" };
+    editor.focus();
+    const file = new File([${JSON.stringify(IMAGE_ONLY_PDF_SOURCE)}], ${JSON.stringify(FILENAME)}, { type: "application/pdf" });
+    const data = new DataTransfer();
+    data.items.add(file);
+    editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+    return { ok: true };
+  })()`);
+  ctx.assert(result?.ok, result?.reason ?? "Failed to paste PDF attachment into composer.");
+}
+
+function transcriptText(transcript) {
+  return (transcript?.messages ?? [])
+    .map((message) => message?.text ?? "")
+    .join("\n\n");
+}
+
+function extractAttachmentFileUrl(text) {
+  const match = text.match(/file:\/\/[^\s)]+image-only%20scan\.pdf/);
+  return match ? match[0] : "";
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function readSandboxFileDigest(ctx, filePath) {
+  const sandbox = ctx.env.OPENWORK_EVAL_DAYTONA_SANDBOX.trim();
+  const pathBase64 = Buffer.from(filePath, "utf8").toString("base64");
+  // The Daytona CLI builds a remote shell command after `--`, so keep the
+  // filename out of that shell string. The only interpolated value below is a
+  // base64 payload decoded inside Node before readFileSync opens the file.
+  const script = `set -euo pipefail
+node <<'NODE'
+const { createHash } = require("node:crypto");
+const { readFileSync } = require("node:fs");
+const filePath = Buffer.from(${JSON.stringify(pathBase64)}, "base64").toString("utf8");
+const bytes = readFileSync(filePath);
+console.log(JSON.stringify({
+  bytes: bytes.length,
+  sha256: createHash("sha256").update(bytes).digest("hex"),
+}));
+NODE
+`;
+  const encodedScript = Buffer.from(script, "utf8").toString("base64");
+  try {
+    const result = await execFileAsync(
+      "daytona",
+      ["exec", sandbox, "--", "echo", encodedScript, "|", "base64", "-d", "|", "bash"],
+      { timeout: 30_000, maxBuffer: 1024 * 1024 },
+    );
+    const line = result.stdout.split(/\r?\n/).map((entry) => entry.trim()).find((entry) => entry.startsWith("{"));
+    if (!line) throw new Error(`No digest JSON returned: ${result.stdout}`);
+    return JSON.parse(line);
+  } catch (error) {
+    const stdout = error && typeof error === "object" && "stdout" in error ? error.stdout : "";
+    const stderr = error && typeof error === "object" && "stderr" in error ? error.stderr : "";
+    throw new Error(`Daytona file digest failed: ${errorMessage(error)} stdout=${String(stdout ?? "").slice(0, 500)} stderr=${String(stderr ?? "").slice(0, 500)}`);
+  }
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Chat attachments are copied into the active worker workspace before send",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DAYTONA_SANDBOX"],
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 60_000,
+      label: "control API",
+    });
+    const state = await ctx.waitFor(
+      `(() => {
+        const control = window.__openworkControl;
+        const route = control.snapshot().route;
+        if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+        const action = control.listActions().find((item) => item.id === "session.create_task");
+        if (action && !action.disabled) return "ready";
+        return null;
+      })()`,
+      { timeoutMs: 30_000, label: "session.create_task enabled" },
+    );
+    return state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); chat attachment proof requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "Attach an image-only PDF through the composer",
+      run: async (ctx) => {
+        await ctx.prove("A normal chat attachment appears in the composer before sending", {
+          voiceover: vo[0],
+          action: async () => {
+            await ctx.control("session.create_task");
+            await activeSessionId(ctx);
+            await pastePdfAttachment(ctx);
+            await ctx.control("composer.set_text", { text: PROMPT });
+          },
+          assert: async () => {
+            await ctx.waitForText(FILENAME, { timeoutMs: 10_000 });
+            const composer = await ctx.eval("window.__openwork?.slice('composer')");
+            const attached = (composer?.attachments ?? []).some((attachment) => attachment?.name === FILENAME && attachment?.mimeType === "application/pdf");
+            assertEvidence(ctx, attached, "Composer inspector shows the PDF as an accepted attachment", JSON.stringify(composer?.attachments ?? []));
+          },
+          screenshot: { name: "pdf-attached", requireText: [FILENAME] },
+        });
+      },
+    },
+    {
+      name: "Send the prompt and expose the worker inbox path",
+      run: async (ctx) => {
+        await ctx.prove("The submitted user turn includes the worker inbox path", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.control("composer.send");
+          },
+          assert: async () => {
+            await ctx.waitForText(".opencode/openwork/inbox/chat-attachments/", { timeoutMs: 30_000 });
+            const transcript = await ctx.control("session.read_transcript", { count: 5 });
+            const text = transcriptText(transcript);
+            assertEvidence(ctx, text.includes(".opencode/openwork/inbox/chat-attachments/"), "Transcript contains the workspace inbox path", text);
+            assertEvidence(ctx, !text.includes("data:application/pdf"), "Transcript does not expose the PDF as a data URL fallback", text);
+            ctx.output("submitted user turn", text);
+          },
+          screenshot: { name: "worker-path-in-turn", requireText: [".opencode/openwork/inbox/chat-attachments/", FILENAME] },
+        });
+      },
+    },
+    {
+      name: "Read the uploaded PDF bytes from the worker path",
+      run: async (ctx) => {
+        await ctx.prove("The uploaded scan path is a real file path for tools such as Docling", {
+          voiceover: vo[2],
+          assert: async () => {
+            const transcript = await ctx.control("session.read_transcript", { count: 5 });
+            const text = transcriptText(transcript);
+            const fileUrl = extractAttachmentFileUrl(text);
+            assertEvidence(ctx, Boolean(fileUrl), "Submitted turn includes a file:// URL for the uploaded PDF", text);
+            const filePath = fileURLToPath(fileUrl);
+            assertEvidence(ctx, filePath.includes(".opencode/openwork/inbox/chat-attachments/"), "File path is inside the worker chat-attachments inbox", filePath);
+            const digest = await readSandboxFileDigest(ctx, filePath);
+            assertEvidence(ctx, digest.bytes === EXPECTED_BYTES.length, "Uploaded PDF byte count matches the image-only PDF fixture", `${digest.bytes} bytes`);
+            assertEvidence(ctx, digest.sha256 === EXPECTED_SHA256, "Uploaded PDF sha256 matches the image-only PDF fixture exactly", digest.sha256);
+            assertEvidence(ctx, !text.toLowerCase().includes("ocr complete"), "The prompt does not claim OpenWork performed native OCR", text);
+            ctx.output("Docling-ready path", filePath);
+          },
+          screenshot: { name: "docling-ready-path", requireText: [FILENAME, "chat-attachments"] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/chat-attachment-workspace-path.md
+++ b/evals/voiceovers/chat-attachment-workspace-path.md
@@ -1,0 +1,7 @@
+# chat-attachment-workspace-path — Chat attachments become worker files
+
+1. I start a normal task and attach a scanned PDF from the composer, the same way a user would paste or drop a file into chat.
+
+2. When I send the prompt, OpenWork shows the attachment path in the same user turn, under the worker workspace inbox instead of a desktop-only data URL.
+
+3. The uploaded scan is still the exact PDF bytes, and the path is a real file path a tool such as Docling can open; OpenWork has not done native OCR itself.


### PR DESCRIPTION
## Summary
- copy every accepted chat attachment into the active worker inbox before prompt submission
- send a worker-backed `file://` part plus an explicit tool-readable workspace path
- preserve drafts on upload failure and cover local/remote workspace ownership
- enable path-based document skills such as Docling to open scanned PDFs (no built-in OCR added)

## Daytona validation
- `pnpm --filter @openwork/app exec bun test tests/attachment-file-part.test.ts tests/workspace-endpoint.test.ts` — 13 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `OPENWORK_EVAL_DAYTONA_SANDBOX=openwork-test-20260713-224941 pnpm fraimz --flow chat-attachment-workspace-path --cdp-url <Daytona CDP>` — passed, 3 validated frames

Fraimz run: `2026-07-14T06-01-20-579Z`

## Scope note
This fixes the missing worker path that blocked Tim’s Docling workflow. OpenWork still does not ship native OCR; an installed OCR/document skill can now read the exact workspace copy.