### PR TITLE
fix(server): budget tool image request payloads

### DIFF
--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -10,7 +10,7 @@
     "dev": "OPENWORK_DEV_MODE=1 bun src/cli.ts",
     "test": "bun test",
     "test:artifacts": "bun test src/artifact-files.e2e.test.ts src/workspace-init.test.ts src/server.normalizeWorkspaceRelativePath.test.ts",
-    "build": "tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts --outdir dist/opencode-plugins --target node --format esm",
+    "build": "tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts src/opencode-plugins/openwork-media-budget.ts --outdir dist/opencode-plugins --target node --format esm",
     "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64 --target bun-windows-arm64",
     "start": "bun dist/cli.js",

--- a/apps/server/src/opencode-plugins/openwork-media-budget.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-media-budget.test.ts
@@ -1,0 +1,289 @@
+import { describe, expect, test } from "bun:test";
+import { readFile } from "node:fs/promises";
+import { join } from "node:path";
+import { OpenWorkMediaBudget } from "./openwork-media-budget.js";
+
+type FixtureMessage = Record<string, unknown> & {
+  info: Record<string, unknown>;
+  parts: unknown[];
+};
+
+const SESSION_ID = "ses_fixture";
+
+function messageId(id: string): string {
+  return `msg_${id}`;
+}
+
+function partId(id: string): string {
+  return `prt_${id}`;
+}
+
+function dataUrl(encodedBytes: number, fill = "A"): string {
+  if (encodedBytes % 4 !== 0) throw new Error("fixture base64 payload length must be structurally valid");
+  return `data:image/png;base64,${fill.repeat(encodedBytes)}`;
+}
+
+function userImageMessage(id: string, filename: string, encodedBytes: number, fill?: string): FixtureMessage {
+  return {
+    info: { id: messageId(id), sessionID: SESSION_ID, role: "user" },
+    parts: [
+      {
+        id: partId(id),
+        sessionID: SESSION_ID,
+        messageID: messageId(id),
+        type: "file",
+        mime: "image/png",
+        filename,
+        url: dataUrl(encodedBytes, fill),
+      },
+    ],
+  };
+}
+
+function toolImageMessage(
+  id: string,
+  images: Array<{ filename: string; encodedBytes: number; fill?: string }>,
+  options?: { compacted?: unknown },
+): FixtureMessage {
+  return {
+    info: { id: messageId(id), sessionID: SESSION_ID, role: "assistant" },
+    parts: [
+      {
+        id: partId(id),
+        sessionID: SESSION_ID,
+        messageID: messageId(id),
+        type: "tool",
+        tool: "fixture_image_tool",
+        callID: `call_${id}`,
+        state: {
+          status: "completed",
+          input: {},
+          output: "Tool returned image attachments.",
+          title: "fixture images",
+          metadata: {},
+          attachments: images.map((image) => ({
+            type: "file",
+            id: partId(`${id}_${image.filename}`),
+            sessionID: SESSION_ID,
+            messageID: messageId(id),
+            mime: "image/png",
+            filename: image.filename,
+            url: dataUrl(image.encodedBytes, image.fill),
+          })),
+          time: { start: 1, end: 2, ...(options?.compacted === undefined ? {} : { compacted: options.compacted }) },
+        },
+      },
+    ],
+  };
+}
+
+function textMessage(id: string): FixtureMessage {
+  return {
+    info: { id: messageId(id), sessionID: SESSION_ID, role: "user" },
+    parts: [{ id: partId(id), sessionID: SESSION_ID, messageID: messageId(id), type: "text", text: "hello" }],
+  };
+}
+
+async function transform(messages: FixtureMessage[], budget: number): Promise<FixtureMessage[]> {
+  const plugin = await OpenWorkMediaBudget(undefined, { inlineImageBudgetBytes: budget });
+  const output = { messages: structuredClone(messages) };
+  await plugin["experimental.chat.messages.transform"]({}, output);
+  return output.messages;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function partAt(messages: FixtureMessage[], messageIndex: number, partIndex: number): Record<string, unknown> {
+  const message = messages[messageIndex];
+  if (!message) throw new Error(`missing message ${messageIndex}`);
+  const part = message.parts[partIndex];
+  if (!isRecord(part)) throw new Error(`missing part ${messageIndex}.${partIndex}`);
+  return part;
+}
+
+function toolState(part: Record<string, unknown>): Record<string, unknown> {
+  const state = part.state;
+  if (!isRecord(state)) throw new Error("missing tool state");
+  return state;
+}
+
+function toolAttachments(part: Record<string, unknown>): unknown[] {
+  const attachments = toolState(part).attachments;
+  if (!Array.isArray(attachments)) throw new Error("missing attachments");
+  return attachments;
+}
+
+function recordAt(values: unknown[], index: number): Record<string, unknown> {
+  const value = values[index];
+  if (!isRecord(value)) throw new Error(`missing record ${index}`);
+  return value;
+}
+
+describe("OpenWorkMediaBudget plugin", () => {
+  test("leaves under-budget images unchanged", async () => {
+    const messages = [userImageMessage("u1", "user-new.png", 40), toolImageMessage("a1", [{ filename: "tool-new.png", encodedBytes: 40 }])];
+    const plugin = await OpenWorkMediaBudget(undefined, { inlineImageBudgetBytes: 100 });
+    const output = { messages };
+
+    await plugin["experimental.chat.messages.transform"]({}, output);
+
+    expect(output.messages).toBe(messages);
+    expect(output.messages).toEqual(messages);
+  });
+
+  test("drops oldest aggregate overflow and keeps the newest image", async () => {
+    const oldUrl = dataUrl(80, "A");
+    const newUrl = dataUrl(80, "B");
+    const messages: FixtureMessage[] = [
+      {
+        info: { id: messageId("u_old"), sessionID: SESSION_ID, role: "user" },
+        parts: [{ id: partId("u_old"), sessionID: SESSION_ID, messageID: messageId("u_old"), type: "file", mime: "image/png", filename: "old.png", url: oldUrl }],
+      },
+      toolImageMessage("a_new", [{ filename: "new.png", encodedBytes: 80, fill: "B" }]),
+    ];
+
+    const transformed = await transform(messages, 100);
+    const oldPart = partAt(transformed, 0, 0);
+    const newToolPart = partAt(transformed, 1, 0);
+    const keptAttachment = recordAt(toolAttachments(newToolPart), 0);
+
+    expect(oldPart.type).toBe("text");
+    expect(oldPart.id).toBe(partId("u_old"));
+    expect(oldPart.sessionID).toBe(SESSION_ID);
+    expect(oldPart.messageID).toBe(messageId("u_old"));
+    expect(oldPart.text).toContain("old.png");
+    expect(oldPart.text).toContain("encoded inline payload");
+    expect(oldPart.text).toContain("request image budget");
+    expect(toolAttachments(newToolPart)).toHaveLength(1);
+    expect(keptAttachment.id).toBe(partId("a_new_new.png"));
+    expect(keptAttachment.sessionID).toBe(SESSION_ID);
+    expect(keptAttachment.messageID).toBe(messageId("a_new"));
+    expect(JSON.stringify(transformed)).not.toContain(oldUrl);
+    expect(JSON.stringify(transformed)).toContain(newUrl);
+  });
+
+  test("shares one budget across user files and tool-result attachments", async () => {
+    const messages = [
+      userImageMessage("u_old", "old-user.png", 72, "A"),
+      toolImageMessage("a_middle", [{ filename: "middle-tool.png", encodedBytes: 72, fill: "B" }]),
+      userImageMessage("u_new", "new-user.png", 72, "C"),
+    ];
+
+    const transformed = await transform(messages, 144);
+
+    expect(partAt(transformed, 0, 0).type).toBe("text");
+    expect(String(partAt(transformed, 0, 0).text)).toContain("old-user.png");
+    expect(toolAttachments(partAt(transformed, 1, 0))).toHaveLength(1);
+    expect(partAt(transformed, 2, 0).type).toBe("file");
+  });
+
+  test("omits malformed image data URLs with placeholders", async () => {
+    const badUserUrl = "data:image/png;base64";
+    const badToolUrl = "data:image/png;base64,@@@";
+    const messages: FixtureMessage[] = [
+      {
+        info: { id: messageId("u_bad"), sessionID: SESSION_ID, role: "user" },
+        parts: [{ id: partId("u_bad"), sessionID: SESSION_ID, messageID: messageId("u_bad"), type: "file", mime: "image/png", filename: "bad-user.png", url: badUserUrl }],
+      },
+      {
+        info: { id: messageId("a_bad"), sessionID: SESSION_ID, role: "assistant" },
+        parts: [
+          {
+            id: partId("tool_bad"),
+            sessionID: SESSION_ID,
+            messageID: messageId("a_bad"),
+            type: "tool",
+            tool: "fixture_image_tool",
+            callID: "call_bad",
+            state: {
+              status: "completed",
+              input: {},
+              output: "Tool returned a malformed image.",
+              title: "malformed fixture",
+              metadata: {},
+              attachments: [{ id: partId("bad_tool_attachment"), sessionID: SESSION_ID, messageID: messageId("a_bad"), type: "file", mime: "image/png", filename: "bad-tool.png", url: badToolUrl }],
+              time: { start: 1, end: 2 },
+            },
+          },
+        ],
+      },
+    ];
+
+    const transformed = await transform(messages, 1_000);
+    const userPart = partAt(transformed, 0, 0);
+    const toolPart = partAt(transformed, 1, 0);
+
+    expect(userPart.type).toBe("text");
+    expect(userPart.text).toContain("malformed data URL");
+    expect(userPart.id).toBe(partId("u_bad"));
+    expect(userPart.sessionID).toBe(SESSION_ID);
+    expect(userPart.messageID).toBe(messageId("u_bad"));
+    expect(toolAttachments(toolPart)).toHaveLength(0);
+    expect(toolState(toolPart).output).toContain("invalid base64 structure");
+    expect(JSON.stringify(transformed)).not.toContain(badUserUrl);
+    expect(JSON.stringify(transformed)).not.toContain(badToolUrl);
+  });
+
+  test("omits malformed base64 length and padding structures", async () => {
+    const badLengthUrl = "data:image/png;base64,AAA";
+    const badPaddingUrl = "data:image/png;base64,A=AA";
+    const messages: FixtureMessage[] = [
+      {
+        info: { id: messageId("u_bad_length"), sessionID: SESSION_ID, role: "user" },
+        parts: [{ id: partId("u_bad_length"), sessionID: SESSION_ID, messageID: messageId("u_bad_length"), type: "file", mime: "image/png", filename: "bad-length.png", url: badLengthUrl }],
+      },
+      {
+        info: { id: messageId("u_bad_padding"), sessionID: SESSION_ID, role: "user" },
+        parts: [{ id: partId("u_bad_padding"), sessionID: SESSION_ID, messageID: messageId("u_bad_padding"), type: "file", mime: "image/png", filename: "bad-padding.png", url: badPaddingUrl }],
+      },
+    ];
+
+    const transformed = await transform(messages, 1_000);
+
+    expect(partAt(transformed, 0, 0).text).toContain("invalid base64 structure");
+    expect(partAt(transformed, 1, 0).text).toContain("invalid base64 structure");
+    expect(JSON.stringify(transformed)).not.toContain(badLengthUrl);
+    expect(JSON.stringify(transformed)).not.toContain(badPaddingUrl);
+  });
+
+  test("leaves compacted completed tool attachments unchanged", async () => {
+    const messages = [toolImageMessage("a_compacted", [{ filename: "compacted.png", encodedBytes: 80 }], { compacted: true })];
+    const plugin = await OpenWorkMediaBudget(undefined, { inlineImageBudgetBytes: 1 });
+    const output = { messages: structuredClone(messages) };
+    const before = JSON.stringify(output.messages);
+
+    await plugin["experimental.chat.messages.transform"]({}, output);
+
+    expect(JSON.stringify(output.messages)).toBe(before);
+    expect(toolAttachments(partAt(output.messages, 0, 0))).toHaveLength(1);
+  });
+
+  test("leaves text-only messages unchanged", async () => {
+    const messages = [textMessage("u_text")];
+    const plugin = await OpenWorkMediaBudget(undefined, { inlineImageBudgetBytes: 1 });
+    const output = { messages };
+
+    await plugin["experimental.chat.messages.transform"]({}, output);
+
+    expect(output.messages).toBe(messages);
+    expect(output.messages).toEqual(messages);
+  });
+
+  test("is deterministic and idempotent across repeat transforms", async () => {
+    const messages = [userImageMessage("u_old", "old.png", 80, "A"), toolImageMessage("a_new", [{ filename: "new.png", encodedBytes: 80, fill: "B" }])];
+    const once = await transform(messages, 100);
+    const twice = await transform(once, 100);
+
+    expect(twice).toEqual(once);
+  });
+
+  test("module and package build expose the runtime plugin", async () => {
+    const mod = await import("./openwork-media-budget.js");
+    expect(Object.keys(mod)).toEqual(["OpenWorkMediaBudget"]);
+
+    const packageJson = await readFile(join(import.meta.dir, "..", "..", "package.json"), "utf8");
+    expect(packageJson).toContain("src/opencode-plugins/openwork-media-budget.ts");
+  });
+});

--- a/apps/server/src/opencode-plugins/openwork-media-budget.ts
+++ b/apps/server/src/opencode-plugins/openwork-media-budget.ts
@@ -43,7 +43,10 @@ type InlineImageInfo =
       reason: string;
     }
   | {
-      type: "external" | "not-image";
+      type: "external";
+    }
+  | {
+      type: "not-image";
     };
 
 type ImageCandidate = {
@@ -131,22 +134,26 @@ function inlineImageInfo(record: Record<string, unknown>): InlineImageInfo {
 
 function candidateFromRecord(key: string, record: Record<string, unknown>): ImageCandidate | undefined {
   const info = inlineImageInfo(record);
-  if (info.type === "not-image" || info.type === "external") return undefined;
-  if (info.type === "malformed") {
-    return {
-      key,
-      mime: info.mime,
-      filename: info.filename,
-      encodedBytes: 0,
-      malformedReason: info.reason,
-    };
+  switch (info.type) {
+    case "not-image":
+    case "external":
+      return undefined;
+    case "malformed":
+      return {
+        key,
+        mime: info.mime,
+        filename: info.filename,
+        encodedBytes: 0,
+        malformedReason: info.reason,
+      };
+    case "inline":
+      return {
+        key,
+        mime: info.mime,
+        filename: info.filename,
+        encodedBytes: info.encodedBytes,
+      };
   }
-  return {
-    key,
-    mime: info.mime,
-    filename: info.filename,
-    encodedBytes: info.encodedBytes,
-  };
 }
 
 function imageName(candidate: ImageCandidate): string {

--- a/apps/server/src/opencode-plugins/openwork-media-budget.ts
+++ b/apps/server/src/opencode-plugins/openwork-media-budget.ts
@@ -1,0 +1,320 @@
+/**
+ * OpenWork Media Budget Plugin
+ *
+ * OpenCode 1.17.11 already serializes provider requests through the AI SDK and
+ * normalizes user-provided images to per-image limits before saving them. The
+ * missing guard for OpenWork is aggregate inline media: replayed history can
+ * combine user file parts and tool-result image attachments into a request body
+ * that is too large for a model/proxy even when every single image is valid.
+ *
+ * This request-only transform keeps the newest inline images within a small
+ * aggregate budget and replaces older or malformed inline images with compact
+ * text placeholders. It intentionally does not resize images, install native
+ * dependencies, or mutate persisted session history.
+ */
+
+const DEFAULT_INLINE_IMAGE_BUDGET_BYTES = 10 * 1024 * 1024;
+const INLINE_IMAGE_BUDGET_ENV = "OPENWORK_INLINE_IMAGE_BUDGET_BYTES";
+const BASE64_PAYLOAD = /^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/;
+
+type ChatMessage = Record<string, unknown> & {
+  parts?: unknown;
+};
+
+type TransformOutput = {
+  messages: ChatMessage[];
+};
+
+type PluginOptions = {
+  inlineImageBudgetBytes?: unknown;
+};
+
+type InlineImageInfo =
+  | {
+      type: "inline";
+      mime: string;
+      filename?: string;
+      encodedBytes: number;
+    }
+  | {
+      type: "malformed";
+      mime: string;
+      filename?: string;
+      reason: string;
+    }
+  | {
+      type: "external" | "not-image";
+    };
+
+type ImageCandidate = {
+  key: string;
+  mime: string;
+  filename?: string;
+  encodedBytes: number;
+  malformedReason?: string;
+};
+
+type ImageDecision = {
+  keep: boolean;
+  placeholder?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === "string" ? value : undefined;
+}
+
+function compactLabel(value: string): string {
+  const compacted = value.replace(/\s+/g, " ").trim();
+  return compacted.length > 80 ? `${compacted.slice(0, 77)}...` : compacted;
+}
+
+function formatBytes(value: number): string {
+  if (value < 1024) return `${value} B`;
+  if (value < 1024 * 1024) return `${Math.ceil(value / 1024)} KB`;
+  return `${Math.ceil(value / (1024 * 1024))} MB`;
+}
+
+function numericBudget(value: unknown): number | undefined {
+  if (typeof value !== "number") return undefined;
+  if (!Number.isFinite(value) || value < 0) return undefined;
+  return Math.floor(value);
+}
+
+function resolveBudget(options?: PluginOptions): number {
+  const fromOptions = numericBudget(options?.inlineImageBudgetBytes);
+  if (fromOptions !== undefined) return fromOptions;
+
+  const raw = process.env[INLINE_IMAGE_BUDGET_ENV]?.trim();
+  if (raw) {
+    const parsed = Number(raw);
+    const fromEnv = numericBudget(parsed);
+    if (fromEnv !== undefined) return fromEnv;
+  }
+
+  return DEFAULT_INLINE_IMAGE_BUDGET_BYTES;
+}
+
+function inlineImageInfo(record: Record<string, unknown>): InlineImageInfo {
+  const mime = stringValue(record.mime);
+  if (!mime?.startsWith("image/")) return { type: "not-image" };
+
+  const filename = stringValue(record.filename);
+  const url = stringValue(record.url);
+  if (!url) return { type: "malformed", mime, filename, reason: "missing data URL" };
+  if (!url.startsWith("data:")) return { type: "external" };
+
+  const comma = url.indexOf(",");
+  if (comma === -1) return { type: "malformed", mime, filename, reason: "malformed data URL" };
+
+  const header = url.slice("data:".length, comma);
+  const headerParts = header.toLowerCase().split(";");
+  const headerMime = headerParts[0] ?? "";
+  if (headerMime && !headerMime.startsWith("image/")) {
+    return { type: "malformed", mime, filename, reason: "data URL media type is not an image" };
+  }
+  if (!headerParts.includes("base64")) {
+    return { type: "malformed", mime, filename, reason: "data URL is not base64" };
+  }
+
+  const payload = url.slice(comma + 1);
+  if (!payload) return { type: "malformed", mime, filename, reason: "empty image payload" };
+  if (!BASE64_PAYLOAD.test(payload)) {
+    return { type: "malformed", mime, filename, reason: "invalid base64 structure" };
+  }
+
+  return { type: "inline", mime, filename, encodedBytes: Buffer.byteLength(payload, "utf8") };
+}
+
+function candidateFromRecord(key: string, record: Record<string, unknown>): ImageCandidate | undefined {
+  const info = inlineImageInfo(record);
+  if (info.type === "not-image" || info.type === "external") return undefined;
+  if (info.type === "malformed") {
+    return {
+      key,
+      mime: info.mime,
+      filename: info.filename,
+      encodedBytes: 0,
+      malformedReason: info.reason,
+    };
+  }
+  return {
+    key,
+    mime: info.mime,
+    filename: info.filename,
+    encodedBytes: info.encodedBytes,
+  };
+}
+
+function imageName(candidate: ImageCandidate): string {
+  return candidate.filename ? ` "${compactLabel(candidate.filename)}"` : "";
+}
+
+function placeholder(candidate: ImageCandidate, budget: number): string {
+  const name = imageName(candidate);
+  if (candidate.malformedReason) {
+    return `[OpenWork omitted image${name}: ${candidate.mime}; ${candidate.malformedReason}.]`;
+  }
+  return `[OpenWork omitted image${name}: ${candidate.mime}, ${formatBytes(candidate.encodedBytes)} encoded inline payload exceeds the ${formatBytes(budget)} request image budget; kept newer images.]`;
+}
+
+function decisionKey(messageIndex: number, partIndex: number, attachmentIndex?: number): string {
+  return attachmentIndex === undefined
+    ? `user:${messageIndex}:${partIndex}`
+    : `tool:${messageIndex}:${partIndex}:${attachmentIndex}`;
+}
+
+function completedToolAttachments(part: Record<string, unknown>): unknown[] | undefined {
+  if (part.type !== "tool") return undefined;
+  const state = part.state;
+  if (!isRecord(state) || state.status !== "completed") return undefined;
+  const time = state.time;
+  if (isRecord(time) && time.compacted) return undefined;
+  return Array.isArray(state.attachments) ? state.attachments : undefined;
+}
+
+function collectCandidates(messages: ChatMessage[]): ImageCandidate[] {
+  const candidates: ImageCandidate[] = [];
+  for (const [messageIndex, message] of messages.entries()) {
+    if (!Array.isArray(message.parts)) continue;
+    for (const [partIndex, part] of message.parts.entries()) {
+      if (!isRecord(part)) continue;
+      if (part.type === "file") {
+        const candidate = candidateFromRecord(decisionKey(messageIndex, partIndex), part);
+        if (candidate) candidates.push(candidate);
+      }
+
+      const attachments = completedToolAttachments(part);
+      if (!attachments) continue;
+      for (const [attachmentIndex, attachment] of attachments.entries()) {
+        if (!isRecord(attachment)) continue;
+        const candidate = candidateFromRecord(decisionKey(messageIndex, partIndex, attachmentIndex), attachment);
+        if (candidate) candidates.push(candidate);
+      }
+    }
+  }
+  return candidates;
+}
+
+function decideImages(candidates: ImageCandidate[], budget: number): Map<string, ImageDecision> {
+  const decisions = new Map<string, ImageDecision>();
+  for (const candidate of candidates) {
+    if (candidate.malformedReason) {
+      decisions.set(candidate.key, { keep: false, placeholder: placeholder(candidate, budget) });
+    }
+  }
+
+  let used = 0;
+  const valid = candidates.filter((candidate) => !candidate.malformedReason);
+  for (let index = valid.length - 1; index >= 0; index -= 1) {
+    const candidate = valid[index];
+    if (!candidate) continue;
+    if (used + candidate.encodedBytes <= budget) {
+      used += candidate.encodedBytes;
+      decisions.set(candidate.key, { keep: true });
+    } else {
+      decisions.set(candidate.key, { keep: false, placeholder: placeholder(candidate, budget) });
+    }
+  }
+  return decisions;
+}
+
+function hasOmissions(decisions: Map<string, ImageDecision>): boolean {
+  for (const decision of decisions.values()) {
+    if (!decision.keep) return true;
+  }
+  return false;
+}
+
+function textPartFromImage(part: Record<string, unknown>, text: string): Record<string, unknown> {
+  const result: Record<string, unknown> = { type: "text", text, synthetic: true };
+  // OpenCode v1.17.11 TextPart and FilePart share partBase fields:
+  // id, sessionID, and messageID are required, so preserve them when turning a
+  // request-only FilePart into a request-only TextPart placeholder.
+  for (const key of ["id", "messageID", "sessionID"]) {
+    const value = part[key];
+    if (typeof value === "string") result[key] = value;
+  }
+  return result;
+}
+
+function appendPlaceholders(output: unknown, placeholders: string[]): string {
+  const suffix = placeholders.join("\n");
+  if (typeof output === "string" && output.length > 0) return `${output}\n${suffix}`;
+  return suffix;
+}
+
+function transformToolPart(
+  part: Record<string, unknown>,
+  messageIndex: number,
+  partIndex: number,
+  decisions: Map<string, ImageDecision>,
+): Record<string, unknown> {
+  const state = part.state;
+  if (!isRecord(state) || !Array.isArray(state.attachments)) return part;
+
+  let changed = false;
+  const placeholders: string[] = [];
+  const attachments = state.attachments.filter((attachment, attachmentIndex) => {
+    if (!isRecord(attachment)) return true;
+    const decision = decisions.get(decisionKey(messageIndex, partIndex, attachmentIndex));
+    if (!decision || decision.keep) return true;
+    changed = true;
+    if (decision.placeholder) placeholders.push(decision.placeholder);
+    return false;
+  });
+
+  if (!changed) return part;
+  return {
+    ...part,
+    state: {
+      ...state,
+      attachments,
+      output: appendPlaceholders(state.output, placeholders),
+    },
+  };
+}
+
+function transformPart(
+  part: Record<string, unknown>,
+  messageIndex: number,
+  partIndex: number,
+  decisions: Map<string, ImageDecision>,
+): Record<string, unknown> {
+  if (part.type === "file") {
+    const decision = decisions.get(decisionKey(messageIndex, partIndex));
+    if (decision && !decision.keep && decision.placeholder) return textPartFromImage(part, decision.placeholder);
+  }
+  if (part.type === "tool") return transformToolPart(part, messageIndex, partIndex, decisions);
+  return part;
+}
+
+function transformMessages(messages: ChatMessage[], budget: number): ChatMessage[] {
+  const decisions = decideImages(collectCandidates(messages), budget);
+  if (!hasOmissions(decisions)) return messages;
+
+  return messages.map((message, messageIndex) => {
+    if (!Array.isArray(message.parts)) return message;
+    return {
+      ...message,
+      parts: message.parts.map((part, partIndex) =>
+        isRecord(part) ? transformPart(part, messageIndex, partIndex, decisions) : part,
+      ),
+    };
+  });
+}
+
+// Single export: the OpenCode plugin loader treats every export of a plugin
+// module as a plugin factory, so helpers must stay module-private.
+export const OpenWorkMediaBudget = async (_input?: unknown, options?: PluginOptions) => {
+  const budget = resolveBudget(options);
+  return {
+    "experimental.chat.messages.transform": async (_hookInput: unknown, output: TransformOutput) => {
+      const transformed = transformMessages(output.messages, budget);
+      if (transformed !== output.messages) output.messages.splice(0, output.messages.length, ...transformed);
+    },
+  };
+};

--- a/apps/server/src/openwork-extensions-plugin-path.ts
+++ b/apps/server/src/openwork-extensions-plugin-path.ts
@@ -29,3 +29,4 @@ export const openworkExtensionsPreviewPluginPath = () => openworkPluginPath("ope
 export const openworkCapabilitiesKnowledgePluginPath = () => openworkPluginPath("openwork-capabilities-knowledge");
 export const openworkAnthropicAdaptiveThinkingPluginPath = () => openworkPluginPath("openwork-anthropic-adaptive-thinking");
 export const openworkAnthropicToolSchemaPluginPath = () => openworkPluginPath("openwork-anthropic-tool-schema");
+export const openworkMediaBudgetPluginPath = () => openworkPluginPath("openwork-media-budget");

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -5,9 +5,11 @@ import { join } from "node:path";
 
 import {
   keepOpenworkRuntimeConfigFileFresh,
+  buildOpenworkRuntimeConfigObject,
   openworkRuntimeConfigFilePath,
   writeOpenworkRuntimeConfigFile,
 } from "./openwork-runtime-config.js";
+import { openworkMediaBudgetPluginPath } from "./openwork-extensions-plugin-path.js";
 import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
@@ -89,6 +91,13 @@ describe("openwork runtime config file", () => {
     expect(prompt).not.toContain("memory_search");
     // No-secrets guidance is the only v0 plaintext-at-rest mitigation.
     expect(prompt).toMatch(/secret|credential|API key|token|PII/i);
+  });
+
+  test("registers the request media budget plugin by default", async () => {
+    const { config } = await setup();
+    const parsed = await buildOpenworkRuntimeConfigObject(config, "ws_1");
+
+    expect(parsed.plugin).toContain(openworkMediaBudgetPluginPath());
   });
 
   test("keepOpenworkRuntimeConfigFileFresh rewrites the file on runtime-DB writes", async () => {

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -20,6 +20,7 @@ import {
   openworkCapabilitiesKnowledgePluginPath,
   openworkAnthropicAdaptiveThinkingPluginPath,
   openworkAnthropicToolSchemaPluginPath,
+  openworkMediaBudgetPluginPath,
 } from "./openwork-extensions-plugin-path.js";
 import type { ServerConfig } from "./types.js";
 import {
@@ -105,6 +106,7 @@ export async function buildOpenworkRuntimeConfigObject(
       openworkCapabilitiesKnowledgePluginPath(),
       openworkAnthropicAdaptiveThinkingPluginPath(),
       openworkAnthropicToolSchemaPluginPath(),
+      openworkMediaBudgetPluginPath(),
       ...runtimePluginList(runtimeConfig),
     ],
     ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),

--- a/evals/flows/tool-image-request-budget.flow.mjs
+++ b/evals/flows/tool-image-request-budget.flow.mjs
@@ -1,0 +1,218 @@
+import { execFile as execFileCallback } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const execFile = promisify(execFileCallback);
+const FLOW_ID = "tool-image-request-budget";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const PROBE_SCRIPT = String.raw`
+  const { readFile } = await import("node:fs/promises");
+  const { join } = await import("node:path");
+  const { OpenWorkMediaBudget } = await import("./apps/server/src/opencode-plugins/openwork-media-budget.ts");
+  const { buildOpenworkRuntimeConfigObject } = await import("./apps/server/src/openwork-runtime-config.ts");
+  const { openworkMediaBudgetPluginPath, openworkPluginPath } = await import("./apps/server/src/openwork-extensions-plugin-path.ts");
+  const budget = 180;
+  const dataUrl = (bytes, fill) => "data:image/png;base64," + fill.repeat(bytes);
+  const packageJson = JSON.parse(await readFile("./apps/server/package.json", "utf8"));
+  const runtimeConfig = await buildOpenworkRuntimeConfigObject();
+  const runtimePlugins = Array.isArray(runtimeConfig.plugin) ? runtimeConfig.plugin : [];
+  const runtimePath = openworkMediaBudgetPluginPath();
+  const builtPath = openworkPluginPath("openwork-media-budget", join(process.cwd(), "apps/server/dist"));
+  const buildScript = typeof packageJson.scripts?.build === "string" ? packageJson.scripts.build : "";
+  const runtime = {
+    registered: runtimePlugins.includes(runtimePath),
+    runtimePath,
+    registeredIndex: runtimePlugins.indexOf(runtimePath),
+    builtPath,
+    builtPathUsesJs: builtPath.endsWith("opencode-plugins/openwork-media-budget.js") || builtPath.endsWith("opencode-plugins\\openwork-media-budget.js"),
+    buildScriptIncludesPlugin: buildScript.includes("src/opencode-plugins/openwork-media-budget.ts"),
+  };
+  const messages = [
+    {
+      info: { id: "u_old", role: "user" },
+      parts: [{ id: "part_user_old", type: "file", mime: "image/png", filename: "old-user.png", url: dataUrl(120, "A") }],
+    },
+    {
+      info: { id: "a_tools", role: "assistant" },
+      parts: [{
+        id: "part_tool_images",
+        type: "tool",
+        tool: "fixture_image_tool",
+        callID: "call_images",
+        state: {
+          status: "completed",
+          input: {},
+          output: "Generated comparison images.",
+          attachments: [
+            { type: "file", mime: "image/png", filename: "older-tool.png", url: dataUrl(120, "B") },
+            { type: "file", mime: "image/png", filename: "newest-tool.png", url: dataUrl(120, "C") },
+          ],
+          time: { start: 1, end: 2 },
+        },
+      }],
+    },
+  ];
+
+  const isRecord = (value) => typeof value === "object" && value !== null && !Array.isArray(value);
+  const imageBytes = (record) => {
+    if (!isRecord(record) || typeof record.mime !== "string" || !record.mime.startsWith("image/")) return 0;
+    if (typeof record.url !== "string" || !record.url.startsWith("data:")) return 0;
+    const marker = ";base64,";
+    const markerIndex = record.url.indexOf(marker);
+    return markerIndex === -1 ? 0 : record.url.slice(markerIndex + marker.length).length;
+  };
+  const attachmentList = (part) => {
+    if (!isRecord(part) || part.type !== "tool" || !isRecord(part.state)) return [];
+    return Array.isArray(part.state.attachments) ? part.state.attachments : [];
+  };
+  const allParts = (items) => items.flatMap((message) => Array.isArray(message.parts) ? message.parts : []);
+  const encodedInlineImageBytes = (items) => allParts(items).reduce((total, part) => {
+    if (!isRecord(part)) return total;
+    if (part.type === "file") return total + imageBytes(part);
+    return total + attachmentList(part).reduce((sum, attachment) => sum + imageBytes(attachment), 0);
+  }, 0);
+  const attachmentCount = (items) => allParts(items).reduce((total, part) => total + attachmentList(part).length, 0);
+  const placeholderCount = (items) => (JSON.stringify(items).match(/OpenWork omitted image/g) ?? []).length;
+  const fakeProvider = (items) => {
+    const bytes = encodedInlineImageBytes(items);
+    const serialized = JSON.stringify({ messages: items });
+    if (bytes > budget) {
+      return {
+        ok: false,
+        encodedInlineImageBytes: bytes,
+        attachmentCount: attachmentCount(items),
+        placeholderCount: placeholderCount(items),
+        error: "malformed-body: encoded inline image payload " + bytes + " exceeds proxy request budget " + budget,
+      };
+    }
+    return {
+      ok: true,
+      encodedInlineImageBytes: bytes,
+      attachmentCount: attachmentCount(items),
+      placeholderCount: placeholderCount(items),
+      bodyJsonValid: true,
+      bodyLength: serialized.length,
+    };
+  };
+
+  const before = fakeProvider(messages);
+  const plugin = await OpenWorkMediaBudget(undefined, { inlineImageBudgetBytes: budget });
+  const output = { messages: structuredClone(messages) };
+  await plugin["experimental.chat.messages.transform"]({}, output);
+  const after = fakeProvider(output.messages);
+  const once = JSON.stringify(output.messages);
+  await plugin["experimental.chat.messages.transform"]({}, output);
+  const twice = JSON.stringify(output.messages);
+
+  const transformedSummary = output.messages.map((message) => ({
+    role: message.info?.role,
+    parts: (message.parts ?? []).map((part) => {
+      if (!isRecord(part)) return { type: typeof part };
+      if (part.type === "tool" && isRecord(part.state)) {
+        return {
+          type: "tool",
+          output: part.state.output,
+          attachments: Array.isArray(part.state.attachments)
+            ? part.state.attachments.map((attachment) => isRecord(attachment) ? attachment.filename : "unknown")
+            : [],
+        };
+      }
+      return { type: part.type, text: part.text, filename: part.filename };
+    }),
+  }));
+
+  console.log(JSON.stringify({ budget, runtime, before, after, idempotent: once === twice, transformedSummary }, null, 2));
+`;
+
+function pretty(value) {
+  return JSON.stringify(value, null, 2);
+}
+
+async function probeBudgetTransform() {
+  const { stdout } = await execFile("bun", ["-e", PROBE_SCRIPT], {
+    cwd: ROOT,
+    env: process.env,
+    maxBuffer: 1024 * 1024,
+  });
+  return JSON.parse(stdout.trim());
+}
+
+function witness(ctx, condition, assertion, actual) {
+  const detail = actual === undefined ? undefined : String(actual);
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual: detail });
+    ctx.assert(false, assertion + (detail ? ` (actual: ${detail})` : ""));
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual: detail });
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Runtime media budget omits old inline tool images before provider serialization",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "The fixture reproduces an oversized image request",
+      run: async (ctx) => {
+        let result = null;
+        await ctx.prove("A replayed user image plus tool images can exceed the request image budget before serialization", {
+          voiceover: vo[0],
+          action: async () => {
+            result = await probeBudgetTransform();
+            ctx.output("probe result", pretty(result));
+          },
+          assert: async () => {
+            witness(ctx, result.before.ok === false, "The unprotected request is rejected by the fake provider", pretty(result.before));
+            witness(ctx, result.before.encodedInlineImageBytes > result.budget, "Encoded inline image bytes exceed the eval request budget", `${result.before.encodedInlineImageBytes} > ${result.budget}`);
+            witness(ctx, String(result.before.error).includes("malformed-body"), "The simulated failure uses the reported malformed-body class", result.before.error);
+          },
+        });
+      },
+    },
+    {
+      name: "The request transform keeps newest media and communicates omissions",
+      run: async (ctx) => {
+        let result = null;
+        await ctx.prove("The transformed provider body is valid JSON under budget with text placeholders for omitted images", {
+          voiceover: vo[1],
+          action: async () => {
+            result = await probeBudgetTransform();
+            ctx.output("runtime integration + transformed request summary", pretty({ runtime: result.runtime, transformedSummary: result.transformedSummary }));
+          },
+          assert: async () => {
+            witness(ctx, result.runtime.registered === true, "The real OpenWork runtime config registers the media-budget plugin", pretty(result.runtime));
+            witness(ctx, result.runtime.builtPathUsesJs === true, "The plugin path helper resolves a built dist plugin to .js", result.runtime.builtPath);
+            witness(ctx, result.runtime.buildScriptIncludesPlugin === true, "The server build bundles openwork-media-budget into dist/opencode-plugins", result.runtime.builtPath);
+            witness(ctx, result.after.ok === true, "The transformed request is accepted by the fake provider", pretty(result.after));
+            witness(ctx, result.after.bodyJsonValid === true, "The transformed provider body serializes as valid JSON");
+            witness(ctx, result.after.encodedInlineImageBytes <= result.budget, "Remaining encoded inline image bytes stay within budget", `${result.after.encodedInlineImageBytes} <= ${result.budget}`);
+            witness(ctx, result.after.attachmentCount === 1, "Only the newest image attachment remains", String(result.after.attachmentCount));
+            witness(ctx, result.after.placeholderCount >= 2, "Omitted images are communicated with compact text placeholders", String(result.after.placeholderCount));
+          },
+        });
+      },
+    },
+    {
+      name: "Replaying transformed history is deterministic",
+      run: async (ctx) => {
+        let result = null;
+        await ctx.prove("A second request transform leaves the already-cleaned history unchanged", {
+          voiceover: vo[2],
+          action: async () => {
+            result = await probeBudgetTransform();
+            ctx.output("idempotence", pretty({ idempotent: result.idempotent, after: result.after }));
+          },
+          assert: async () => {
+            witness(ctx, result.idempotent === true, "Repeated transforms are deterministic and idempotent");
+            witness(ctx, result.after.placeholderCount >= 2, "Placeholders are not duplicated or lost on replay", String(result.after.placeholderCount));
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/tool-image-request-budget.md
+++ b/evals/voiceovers/tool-image-request-budget.md
@@ -1,0 +1,7 @@
+# tool-image-request-budget — Request-only image budget keeps tool images usable
+
+1. The demo starts with the regression shape: a normal user image plus a tool result that returns multiple inline images. With the eval budget lowered, the unprotected provider request is too large and the fake provider reports the same malformed-body class of failure users saw.
+
+2. The real OpenWork runtime config includes the media-budget plugin path, and the package build includes the built plugin. When the hook runs on the request copy, the newest image stays available, older images become clear text notes, and the next provider body is valid JSON under the encoded inline-image budget.
+
+3. The same transformed history is replayed through the hook again. Nothing changes on the second pass, proving the request cleanup is deterministic and safe for session history replay.


### PR DESCRIPTION
## Summary
- add a request-only OpenCode message transform that enforces a 10 MiB aggregate encoded inline-image budget
- keep newest user/tool images and replace omitted or malformed images with compact text placeholders
- protect replayed history without mutating persisted sessions or adding native image dependencies
- register and package the plugin in every OpenWork runtime config

## Root cause
The reported malformed-body/invalid-JSON symptom is caused by aggregate base64 media exceeding provider/proxy request limits. OpenCode already serializes JSON and normalizes each image individually, but had no aggregate request budget.

## Daytona validation
- `pnpm --filter openwork-server exec bun test src/opencode-plugins/openwork-media-budget.test.ts src/openwork-runtime-config.test.ts` — 14 passed
- `pnpm --filter openwork-server build` — passed; plugin bundled to `dist/opencode-plugins/openwork-media-budget.js`
- `pnpm fraimz --flow tool-image-request-budget` inside Daytona sandbox `openwork-test-20260713-225226` — passed, 3 internal proof frames

Fraimz run: `2026-07-14T06-01-21-525Z`

## Validation limitation
The deterministic Fraimz uses the real plugin and runtime config with a fake provider budget probe; it does not call a paid external model API.