### PR TITLE
fix(helm): preserve Node options on upgrade

### DIFF
--- a/evals/flows/helm-den-api-node-options.flow.mjs
+++ b/evals/flows/helm-den-api-node-options.flow.mjs
@@ -58,14 +58,67 @@ export default {
             );
             witness(
               ctx,
-              rendered.includes("key: DEN_API_NODE_OPTIONS"),
-              "NODE_OPTIONS reads DEN_API_NODE_OPTIONS from the ConfigMap",
+              rendered.includes('- name: NODE_OPTIONS\n              value: "--use-openssl-ca --max-old-space-size=4096"'),
+              "Den API receives the configured value directly as NODE_OPTIONS",
+            );
+            witness(
+              ctx,
+              rendered.includes("valueFrom: null") && !rendered.includes("key: DEN_API_NODE_OPTIONS"),
+              "The chart explicitly clears the previous valueFrom reference during upgrades",
             );
             ctx.output(
               "$ helm template openwork-ee ... --set-string config.denApiNodeOptions=...",
               rendered
                 .split("\n")
                 .filter((line) => line.includes("DEN_API_NODE_OPTIONS") || line.includes("NODE_OPTIONS"))
+                .join("\n"),
+            );
+          },
+        });
+      },
+    },
+    {
+      name: "Preserve legacy denApi.env.NODE_OPTIONS configuration",
+      run: async (ctx) => {
+        let rendered = "";
+        await ctx.prove("Existing denApi.env.NODE_OPTIONS values upgrade without configuration changes", {
+          voiceover: vo[1],
+          action: async () => {
+            const result = spawnSync(
+              "helm",
+              [
+                "template",
+                "openwork-ee",
+                CHART,
+                "--set-string",
+                "denApi.env.NODE_OPTIONS=--tls-max-v1.2",
+              ],
+              { encoding: "utf8" },
+            );
+            witness(ctx, result.status === 0, "helm template exits successfully", result.stderr.trim());
+            rendered = result.stdout;
+          },
+          assert: async () => {
+            witness(
+              ctx,
+              (rendered.match(/name: NODE_OPTIONS/g) ?? []).length === 1,
+              "The rendered deployment contains one NODE_OPTIONS entry",
+            );
+            witness(
+              ctx,
+              rendered.includes('- name: NODE_OPTIONS\n              value: "--tls-max-v1.2"'),
+              "The existing denApi.env.NODE_OPTIONS value remains unchanged",
+            );
+            witness(
+              ctx,
+              !rendered.includes("key: DEN_API_NODE_OPTIONS"),
+              "The legacy direct value is not combined with valueFrom",
+            );
+            ctx.output(
+              "$ helm template openwork-ee ... --set-string denApi.env.NODE_OPTIONS=...",
+              rendered
+                .split("\n")
+                .filter((line) => line.includes("DEN_API_NODE_OPTIONS") || line.includes("NODE_OPTIONS") || line.includes("--tls-max"))
                 .join("\n"),
             );
           },

--- a/evals/voiceovers/helm-den-api-node-options.md
+++ b/evals/voiceovers/helm-den-api-node-options.md
@@ -1,3 +1,5 @@
 # helm-den-api-node-options — Configure Den API Node.js startup flags
 
-1. An operator sets Den API Node.js flags in the Helm values. The rendered ConfigMap keeps them as DEN_API_NODE_OPTIONS, and the Den API deployment passes that value to Node as NODE_OPTIONS when the container starts.
+1. An operator keeps the same Den API Node.js flags in the Helm values. The Den API deployment gives Node that value directly as NODE_OPTIONS, so an upgrade from an existing deployment remains valid without changing operator configuration.
+
+2. Deployments already using denApi.env.NODE_OPTIONS keep that exact setting during the upgrade. The chart renders one direct NODE_OPTIONS value and never combines it with valueFrom.

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -42,6 +42,8 @@ The chart stores this value in its ConfigMap as `DEN_API_NODE_OPTIONS` and
 passes it to the `den-api` container as `NODE_OPTIONS` before Node starts. It
 does not change the Node.js options for Den web or the optional inference
 service. Leaving the value empty preserves the default Node.js behavior.
+Existing deployments using `denApi.env.NODE_OPTIONS` can keep that setting when
+upgrading; it takes precedence over `config.denApiNodeOptions`.
 
 If you want self-hosted repository imports and sync from GitHub, configure the [GitHub connector for Helm](/start-here/github-connector-helm) after the core Den web and Den controller hosts are reachable.
 

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -517,6 +517,8 @@ Override `config.internal.*` only when routing through a mesh, gateway, or exter
 Set `config.denApiNodeOptions` to pass Node.js runtime flags to `den-api` through
 `NODE_OPTIONS` when the container starts. The configured value is stored in the
 chart ConfigMap as `DEN_API_NODE_OPTIONS` and defaults to an empty string.
+Existing values files that set `denApi.env.NODE_OPTIONS` remain supported and
+take precedence, so upgrading does not require changing that configuration.
 
 ```yaml
 config:

--- a/packaging/helm/openwork-ee/templates/den-api.yaml
+++ b/packaging/helm/openwork-ee/templates/den-api.yaml
@@ -92,11 +92,14 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.denApi.containerPort | quote }}
+            {{- if not (hasKey .Values.denApi.env "NODE_OPTIONS") }}
+            # Keep this as a direct value so upgrades from legacy denApi.env.NODE_OPTIONS
+            # do not leave both value and valueFrom in Kubernetes' strategic merge patch.
             - name: NODE_OPTIONS
-              valueFrom:
-                configMapKeyRef:
-                  name: {{ include "openwork-ee.configName" . }}
-                  key: DEN_API_NODE_OPTIONS
+              value: {{ .Values.config.denApiNodeOptions | quote }}
+              # Explicitly clear the valueFrom emitted by chart 0.17.24 during upgrades.
+              valueFrom: null
+            {{- end }}
             {{- if .Values.installerArtifacts.enabled }}
             - name: OPENWORK_INSTALLER_ARTIFACTS_DIR
               value: {{ .Values.installerArtifacts.mountPath | quote }}

--- a/packaging/helm/openwork-ee/tests/observability-env.sh
+++ b/packaging/helm/openwork-ee/tests/observability-env.sh
@@ -48,7 +48,8 @@ default_rendered="$tmp_dir/default.yaml"
 helm template openwork-ee "$chart_dir" --set inference.enabled=true > "$default_rendered"
 assert_contains "$default_rendered" 'DEN_API_NODE_OPTIONS: ""'
 assert_count "$default_rendered" 'name: NODE_OPTIONS' 1
-assert_contains "$default_rendered" 'key: DEN_API_NODE_OPTIONS'
+assert_count "$default_rendered" 'valueFrom: null' 1
+assert_not_contains "$default_rendered" 'key: DEN_API_NODE_OPTIONS'
 assert_count "$default_rendered" 'name: DEN_OBSERVABILITY_BACKEND' 2
 assert_count "$default_rendered" 'value: "none"' 2
 assert_not_contains "$default_rendered" 'name: OTEL_EXPORTER_OTLP_HEADERS'
@@ -83,6 +84,7 @@ denWeb:
 YAML
 helm template openwork-ee "$chart_dir" -f "$otel_values" > "$otel_rendered"
 assert_contains "$otel_rendered" 'DEN_API_NODE_OPTIONS: "--use-openssl-ca --max-old-space-size=4096"'
+assert_contains "$otel_rendered" 'value: "--use-openssl-ca --max-old-space-size=4096"'
 assert_count "$otel_rendered" 'name: DEN_OBSERVABILITY_BACKEND' 2
 assert_count "$otel_rendered" 'value: "otel"' 2
 assert_count "$otel_rendered" 'name: OTEL_EXPORTER_OTLP_HEADERS' 2
@@ -97,6 +99,19 @@ assert_contains "$otel_rendered" 'key: "otlp-headers"'
 assert_contains "$otel_rendered" 'name: CUSTOM_DEN_API_ENV'
 assert_contains "$otel_rendered" 'name: CUSTOM_DEN_WEB_ENV'
 assert_not_contains "$otel_rendered" 'name: SENTRY_AUTH_TOKEN'
+
+legacy_values="$tmp_dir/legacy-node-options-values.yaml"
+legacy_rendered="$tmp_dir/legacy-node-options.yaml"
+cat > "$legacy_values" <<'YAML'
+denApi:
+  env:
+    NODE_OPTIONS: --tls-max-v1.2
+YAML
+helm template openwork-ee "$chart_dir" -f "$legacy_values" > "$legacy_rendered"
+assert_count "$legacy_rendered" 'name: NODE_OPTIONS' 1
+assert_contains "$legacy_rendered" 'value: "--tls-max-v1.2"'
+assert_not_contains "$legacy_rendered" 'valueFrom: null'
+assert_not_contains "$legacy_rendered" 'key: DEN_API_NODE_OPTIONS'
 
 sentry_values="$tmp_dir/sentry-values.yaml"
 sentry_rendered="$tmp_dir/sentry.yaml"


### PR DESCRIPTION
## Summary
- render `config.denApiNodeOptions` as a direct `NODE_OPTIONS` value while explicitly clearing the 0.17.24 `valueFrom` field
- preserve existing `denApi.env.NODE_OPTIONS` values without requiring operator config changes
- add regression coverage and document legacy-value precedence

## Tests
- `helm lint packaging/helm/openwork-ee`
- `bash packaging/helm/openwork-ee/tests/observability-env.sh`
- `helm template openwork-ee packaging/helm/openwork-ee --set-string 'config.denApiNodeOptions=--tls-max-v1.2' | kubectl create --dry-run=client --validate=false -f - -o name`\n- `git diff --check`\n- `pnpm fraimz --flow helm-den-api-node-options` (Passed)