### PR TITLE
test: assert displayed Den server in keyless flow

### DIFF
--- a/evals/flows/keyless-den-connect.flow.mjs
+++ b/evals/flows/keyless-den-connect.flow.mjs
@@ -298,7 +298,7 @@ export default {
           await ctx.waitFor("Boolean(window.__keylessConnectCapture?.connectUrl)", { timeoutMs: 20_000, label: "fresh click-time connection link" });
           state.connectUrl = await ctx.eval("window.__keylessConnectCapture.connectUrl");
           const connect = new URL(state.connectUrl);
-          state.serverHost = new URL(connect.searchParams.get("apiBaseUrl") ?? "http://invalid").host;
+          state.serverHost = new URL(initialConfig.webUrl).host;
           witness(ctx, connect.protocol === "openwork:" && Boolean(connect.searchParams.get("code")) && !connect.searchParams.has("token"), "The default handoff is a keyless short-lived exchange", state.connectUrl.replace(connect.searchParams.get("code") ?? "", "<redacted>"));
           witness(ctx, initialConfig.connectUrl !== state.connectUrl, "Clicking Open mints a fresh link after the installer wait", {
             initial: "redacted",


### PR DESCRIPTION
## What changed

- derive the expected confirmation-dialog server from the install config's `webUrl`
- keep the exchange `apiBaseUrl` assertion focused on transport and code exchange

## Why

Post-merge macOS fraimz validation showed the product correctly displays the organization server (`localhost:8790`), while the flow incorrectly expected the API transport host (`127.0.0.1:8790`). This made a correct confirmation dialog fail its proof.

## Validation

- `node --check evals/flows/keyless-den-connect.flow.mjs` — passed
- `OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3005 OPENWORK_EVAL_WEB_CDP_ADMIN=http://127.0.0.1:9225 pnpm fraimz --flow keyless-den-connect --stack den --cdp-url http://127.0.0.1:9823` — passed all 6 user-facing frames plus voiceover coverage
- fraimz: `evals/results/2026-07-14T15-26-22-834Z/fraimz.html`

No product runtime code changes.
