### PR TITLE
Fix diagnostics login in opaque browsers

### DIFF
--- a/ee/apps/diagnostics/app/api/dashboard-session/route.ts
+++ b/ee/apps/diagnostics/app/api/dashboard-session/route.ts
@@ -32,14 +32,22 @@ function redirect(request: Request, pathname: string): NextResponse {
   return response
 }
 
-function requestOriginAllowed(request: Request): boolean {
-  const origin = request.headers.get("origin")
-  if (!origin) return true
+function matchesOrigin(value: string, expectedOrigin: string): boolean {
   try {
-    return new URL(origin).origin === requestPublicOrigin(request)
+    return new URL(value).origin === expectedOrigin
   } catch {
     return false
   }
+}
+
+function requestOriginAllowed(request: Request): boolean {
+  const origin = request.headers.get("origin")
+  if (!origin) return true
+  const expectedOrigin = requestPublicOrigin(request)
+  if (origin !== "null") return matchesOrigin(origin, expectedOrigin)
+
+  const referrer = request.headers.get("referer")
+  return Boolean(referrer && matchesOrigin(referrer, expectedOrigin))
 }
 
 export async function POST(request: Request): Promise<NextResponse> {

--- a/ee/apps/diagnostics/test/dashboard-auth.test.ts
+++ b/ee/apps/diagnostics/test/dashboard-auth.test.ts
@@ -110,6 +110,45 @@ describe("Diagnostics dashboard authentication", () => {
     expect(response.status).toBe(403)
   })
 
+  test("accepts an opaque browser origin only with a same-origin referrer", async () => {
+    configureLocalAuthentication()
+    const response = await POST(new Request("http://0.0.0.0:3010/api/dashboard-session", {
+      body: new URLSearchParams({ password: config.adminPassword, username: config.adminUsername }),
+      headers: {
+        "content-type": "application/x-www-form-urlencoded",
+        origin: "null",
+        referer: "https://diagnostics.example/login",
+        "x-forwarded-host": "diagnostics.example",
+        "x-forwarded-proto": "https",
+      },
+      method: "POST",
+    }))
+
+    expect(response.status).toBe(303)
+    expect(response.headers.get("location")).toBe("https://diagnostics.example/")
+    expect(response.headers.get("set-cookie")).toContain(`${DASHBOARD_SESSION_COOKIE}=`)
+  })
+
+  test("rejects an opaque browser origin without a same-origin referrer", async () => {
+    configureLocalAuthentication()
+    const body = { password: config.adminPassword, username: config.adminUsername }
+    const request = formRequest(body)
+    const headers = { ...Object.fromEntries(request.headers), origin: "null" }
+
+    const missingReferrer = await POST(new Request(request, { headers }))
+    const crossOriginRequest = formRequest(body)
+    const crossOriginReferrer = await POST(new Request(crossOriginRequest, {
+      headers: {
+        ...Object.fromEntries(crossOriginRequest.headers),
+        origin: "null",
+        referer: "https://attacker.example/login",
+      },
+    }))
+
+    expect(missingReferrer.status).toBe(403)
+    expect(crossOriginReferrer.status).toBe(403)
+  })
+
   test("redirects the dashboard to login while returning JSON for history clients", async () => {
     configureLocalAuthentication()
     const dashboard = proxy(new NextRequest("http://localhost:3010/?runId=4ab6c4c2-2b5d-4f85-83b7-137cc93acb57"))

--- a/ee/apps/diagnostics/vercel.json
+++ b/ee/apps/diagnostics/vercel.json
@@ -6,7 +6,7 @@
     {
       "source": "/(.*)",
       "headers": [
-        { "key": "Referrer-Policy", "value": "no-referrer" },
+        { "key": "Referrer-Policy", "value": "same-origin" },
         { "key": "Strict-Transport-Security", "value": "max-age=63072000; includeSubDomains; preload" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },
         { "key": "X-Frame-Options", "value": "DENY" },


### PR DESCRIPTION
## Summary

- accept an opaque `Origin: null` login POST only when a same-origin referrer proves it came from the diagnostics login page
- use `Referrer-Policy: same-origin` so sandboxed in-app browsers retain that proof without leaking referrers cross-origin
- add regression coverage for accepted same-origin and rejected missing/cross-origin referrers

## Root cause

The diagnostics dashboard rejected form submissions from sandboxed in-app browsers before checking credentials. Those browsers emit an opaque `Origin: null`, while the deployment-wide `no-referrer` policy removed the only safe fallback signal.

## Security boundary

- ordinary mismatched origins remain rejected
- opaque origins without a same-origin referrer remain rejected
- the dashboard session cookie remains HTTP-only, secure, and `SameSite=Strict`
- `same-origin` referrers are not sent to external origins

## Validation

- `pnpm --filter @openwork-ee/diagnostics test` — 28 passed
- Vercel preview and production builds — passed
- live in-app-browser login at `https://diagnostic.openworklabs.com/login` — passed and reached the dashboard
- live cross-origin login POST — rejected with HTTP 403
- live health endpoint — HTTP 200

Production deployment: `dpl_EcxQXzKEjvjDeW8nYspCSw7HDL8T`.