### PR TITLE
fix(connect): extend external MCP tool timeout

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
@@ -56,6 +56,8 @@ import {
 const CLIENT_NAME = "OpenWork"
 const EXTERNAL_MCP_CALL_TIMEOUT_MS = 30_000
 const EXTERNAL_MCP_LIFECYCLE_TIMEOUT_MS = 45_000
+const EXTERNAL_MCP_TOOL_CALL_TIMEOUT_MS = 120_000
+const EXTERNAL_MCP_TOOL_LIFECYCLE_TIMEOUT_MS = 150_000
 const EXTERNAL_MCP_TOOL_PAGE_LIMIT = 20
 const EXTERNAL_MCP_TOOL_ITEM_LIMIT = 2_000
 const EXTERNAL_MCP_TOOL_NAME_LIMIT_BYTES = 512
@@ -119,6 +121,7 @@ export async function runExternalMcpRequestWithinDeadline<T>(input: {
   deadline: ExternalMcpLifecycleDeadline
   diagnostic: ExternalMcpDiagnosticTracker
   phase: ExternalMcpDiagnosticPhase
+  requestTimeoutMs?: number
   operation: (options: RequestOptions) => Promise<T>
 }): Promise<T> {
   input.diagnostic.begin(input.phase)
@@ -128,7 +131,7 @@ export async function runExternalMcpRequestWithinDeadline<T>(input: {
   const controller = new AbortController()
   const options: RequestOptions = {
     signal: AbortSignal.any([controller.signal, input.deadline.signal]),
-    timeout: Math.max(1, Math.min(EXTERNAL_MCP_CALL_TIMEOUT_MS, remaining)),
+    timeout: Math.max(1, Math.min(input.requestTimeoutMs ?? EXTERNAL_MCP_CALL_TIMEOUT_MS, remaining)),
     maxTotalTimeout: remaining,
     resetTimeoutOnProgress: false,
   }
@@ -917,7 +920,7 @@ export async function callExternalMcpTool(input: {
   diagnosticReferenceId?: string
 }) {
   const client = buildClient()
-  const deadline = createExternalMcpLifecycleDeadline()
+  const deadline = createExternalMcpLifecycleDeadline(EXTERNAL_MCP_TOOL_LIFECYCLE_TIMEOUT_MS)
   const { transport, diagnostic } = buildTransport(
     input.connection,
     input.redirectUri,
@@ -940,6 +943,7 @@ export async function callExternalMcpTool(input: {
       deadline,
       diagnostic,
       phase: "MCP_TOOL_EXECUTION",
+      requestTimeoutMs: EXTERNAL_MCP_TOOL_CALL_TIMEOUT_MS,
       operation: (options) => client.callTool({ name: input.toolName, arguments: input.args }, undefined, options),
     })
     if (result.isError) {

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -702,6 +702,26 @@ describe("external MCP diagnostics", () => {
     expect(resetFlags).toEqual([false, false])
   })
 
+  test("allows tool execution to use a longer bounded request timeout", async () => {
+    const {
+      createExternalMcpLifecycleDeadline,
+      runExternalMcpRequestWithinDeadline,
+    } = await import("../src/capability-sources/external-mcp-client.js")
+    const diagnostic = new ExternalMcpDiagnosticTracker("req_tool_timeout")
+    const options = await runExternalMcpRequestWithinDeadline({
+      diagnostic,
+      deadline: createExternalMcpLifecycleDeadline(150_000),
+      phase: "MCP_TOOL_EXECUTION",
+      requestTimeoutMs: 120_000,
+      operation: async (requestOptions) => requestOptions,
+    })
+
+    expect(options.timeout).toBe(120_000)
+    expect(options.maxTotalTimeout).toBeGreaterThanOrEqual(149_000)
+    expect(options.maxTotalTimeout).toBeLessThanOrEqual(150_000)
+    expect(options.resetTimeoutOnProgress).toBe(false)
+  })
+
   test("fails a hung catalog page at the absolute lifecycle deadline", async () => {
     const {
       collectExternalMcpToolPages,


### PR DESCRIPTION
## Summary

- extend external MCP tool execution requests from 30 seconds to 120 seconds
- give initialize-plus-tool execution a bounded 150-second lifecycle
- keep initialization, discovery, SSRF, response-size, and catalog protections unchanged

## Root cause

Long-running provider tools, including ServiceNow incident summarization, could exceed OpenWork's 30-second Den-side request limit even after authentication and MCP initialization succeeded.

## Impact

External MCP tools can complete longer operations without weakening the existing connection and payload safety limits.

## Validation

- `pnpm exec bun test ee/apps/den-api/test/external-mcp-diagnostics.test.ts -t "allows tool execution to use a longer bounded request timeout"`
- result: 1 passed, 0 failed

Full Den API and end-to-end provider suites were not run.
