### PR TITLE
Fix the full per-member MCP OAuth demo

### DIFF
--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
@@ -25,6 +25,7 @@ import {
   externalMcpIdentityBinding,
   type ExternalMcpConnectionRow,
 } from "./external-mcp-connections.js"
+import { normalizeConnectedAccountScopes, normalizeOAuthClientExtra } from "./oauth-credentials.js"
 
 const MAX_PENDING_AUTHORIZATIONS = 8
 
@@ -168,7 +169,9 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
         eq(ConnectedAccountTable.providerId, this.connection.id),
       ))
       .limit(1)
-    return rows[0] ?? null
+    return rows[0]
+      ? { ...rows[0], scopes: normalizeConnectedAccountScopes(rows[0].scopes) }
+      : null
   }
 
   readonly clientRegistrations = {
@@ -185,12 +188,13 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
         .limit(1)
       const row = rows[0]
       if (!row) return undefined
-      const clientInformation = restoredClientInformation(row)
+      const extra = normalizeOAuthClientExtra(row.extra)
+      const clientInformation = restoredClientInformation({ ...row, extra })
       return {
         clientInformation,
         revision: clientRevision(row),
         expiresAt: clientExpiration(clientInformation),
-        source: row.extra?.enterpriseMcpRegistrationSource === "dynamic" ? "dynamic" : "pre-registered",
+        source: extra?.enterpriseMcpRegistrationSource === "dynamic" ? "dynamic" : "pre-registered",
       }
     },
 

--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -18,6 +18,7 @@ import {
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "../db.js"
+import { normalizeConnectedAccountScopes, normalizeOAuthClientExtra } from "./oauth-credentials.js"
 
 /**
  * CRUD for ExternalMcpConnectionTable and its access grants — the "add any
@@ -977,7 +978,10 @@ export async function readOrgOAuthClientForExternalMcpIdentity(
         eq(OrgOAuthClientTable.providerId, connection.id),
       ))
       .limit(1)
-    return { current: true, value: rows[0] ?? null }
+    const value = rows[0]
+      ? { ...rows[0], extra: normalizeOAuthClientExtra(rows[0].extra) }
+      : null
+    return { current: true, value }
   })
 }
 
@@ -1073,7 +1077,10 @@ export async function readConnectedAccountForExternalMcpIdentity(input: {
         eq(ConnectedAccountTable.providerId, input.connection.id),
       ))
       .limit(1)
-    return { current: true, value: rows[0] ?? null }
+    const value = rows[0]
+      ? { ...rows[0], scopes: normalizeConnectedAccountScopes(rows[0].scopes) }
+      : null
+    return { current: true, value }
   })
 }
 

--- a/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
+++ b/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
@@ -489,6 +489,39 @@ test("shared invalid_grant recovery cannot reuse the cleared in-memory refresh t
   })).toMatchObject({ accessToken: null, refreshToken: null })
 })
 
+test("per-member OAuth reads JSON scopes returned as text by MySQL", async () => {
+  const { ExternalMcpOAuthProvider } = await import("../src/capability-sources/external-mcp-client.js")
+  const { ExternalMcpDiagnosticTracker } = await import("../src/capability-sources/external-mcp-diagnostics.js")
+  const seed = await seedOrganization("per-member-json-scopes")
+  const connection = await createGrantedConnection(seed, {
+    name: "Per-member OAuth",
+    authType: "oauth",
+    credentialMode: "per_member",
+    url: "https://mcp.example.test/mcp",
+  })
+  await db.insert(schema.ConnectedAccountTable).values({
+    id: createDenTypeId("connectedAccount"),
+    organizationId: seed.organizationId,
+    orgMembershipId: seed.memberId,
+    providerId: connection.id,
+    accessToken: "member-access-token",
+    tokenType: "Bearer",
+    scopes: ["tools.read", "tools.write"],
+  })
+  const provider = new ExternalMcpOAuthProvider(
+    connection,
+    `${redirectUriBase}/callback`,
+    "signed-state",
+    { orgMembershipId: seed.memberId },
+    new ExternalMcpDiagnosticTracker("req_per_member_json_scopes"),
+  )
+
+  expect(await provider.tokens()).toMatchObject({
+    access_token: "member-access-token",
+    scope: "tools.read tools.write",
+  })
+})
+
 test("the 16-connection fanout reports incomplete coverage when the only match is connection 17", async () => {
   if (!slackServer || !needleServer) throw new Error("Coverage MCP servers were not started")
   const { externalMcpSearchCoverageHint } = await import("../src/mcp/external-capabilities.js")

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
@@ -21,3 +21,12 @@ export function safeMcpAuthorizationUrl(rawUrl: string): string {
   }
   return url.toString()
 }
+
+export function openMcpAuthorizationWindow(): Window {
+  const popup = window.open("", "openwork-mcp-authorization", "popup,width=600,height=760")
+  if (!popup) {
+    throw new Error("OpenWork could not open the sign-in window. Allow popups for OpenWork, then try again.")
+  }
+  popup.opener = null
+  return popup
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -13,7 +13,7 @@ import { getPluginRoute } from "../../_lib/den-org";
 import { getRequestError, requestJson } from "../../_lib/den-flow";
 import { IntegrationIcon } from "./integration-icon";
 import { Microsoft365Dialog } from "./microsoft-365-dialog";
-import { safeMcpAuthorizationUrl } from "./mcp-authorization-url";
+import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl } from "./mcp-authorization-url";
 import {
   editableMcpIdentityChanged,
   marketplaceIdentityOwnerNames,
@@ -257,18 +257,22 @@ export function McpConnectionsScreen() {
     }, OAUTH_POLL_INTERVAL_MS);
   }
 
-  async function handleConnectOAuth(connectionId: string) {
+  async function handleConnectOAuth(connectionId: string, pendingAuthorizationWindow?: Window) {
     setConnectionActionError(null);
+    let authorizationWindow: Window | null = pendingAuthorizationWindow ?? null;
     try {
+      authorizationWindow = authorizationWindow ?? openMcpAuthorizationWindow();
       const result = await startOAuth.mutateAsync(connectionId);
       if (result.status === "connected") {
+        authorizationWindow.close();
         void refetch();
         return;
       }
       if (!result.authorizeUrl) throw new Error("The MCP provider did not return an authorization URL.");
-      window.open(safeMcpAuthorizationUrl(result.authorizeUrl), "_blank", "noopener,noreferrer");
+      authorizationWindow.location.href = safeMcpAuthorizationUrl(result.authorizeUrl);
       pollUntilConnected(connectionId);
     } catch (connectError) {
+      authorizationWindow?.close();
       setConnectionActionError({
         connectionId,
         message: connectError instanceof Error ? connectError.message : "Failed to connect the MCP server.",
@@ -277,19 +281,27 @@ export function McpConnectionsScreen() {
   }
 
   async function handleCreate(input: CreateMcpConnectionInput): Promise<CreatedMcpConnection> {
-    const created = await createConnection.mutateAsync(input);
-    if (input.oauthClient) {
+    const authorizationWindow = input.authType === "oauth" && input.credentialMode === "shared" && !input.oauthClient
+      ? openMcpAuthorizationWindow()
+      : undefined;
+    try {
+      const created = await createConnection.mutateAsync(input);
+      if (input.oauthClient) {
+        return created;
+      }
+      setFormOpen(false);
+      setFormPreset(null);
+      // Shared-credential OAuth: the admin authorizes the org's single account
+      // right now. Per-member: nothing to authorize here — each granted person
+      // connects their own account from Your Connections.
+      if (input.authType === "oauth" && input.credentialMode === "shared") {
+        await handleConnectOAuth(created.id, authorizationWindow);
+      }
       return created;
+    } catch (createError) {
+      authorizationWindow?.close();
+      throw createError;
     }
-    setFormOpen(false);
-    setFormPreset(null);
-    // Shared-credential OAuth: the admin authorizes the org's single account
-    // right now. Per-member: nothing to authorize here — each granted person
-    // connects their own account from Your Connections.
-    if (input.authType === "oauth" && input.credentialMode === "shared") {
-      await handleConnectOAuth(created.id);
-    }
-    return created;
   }
 
   async function handleUpdate(input: UpdateMcpConnectionInput): Promise<UpdatedMcpConnection> {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -9,7 +9,7 @@ import { getOrgAccessFlags } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { IntegrationIcon } from "./integration-icon";
 import { formatRequiredBy, sortConnectionsForFocus, trustedConnectionFocusId } from "./mcp-connection-display";
-import { safeMcpAuthorizationUrl } from "./mcp-authorization-url";
+import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl } from "./mcp-authorization-url";
 import { MICROSOFT_365_DISPLAY_SCOPES } from "./microsoft-365-permissions";
 import {
   canDisconnectNativeProviderAccount,
@@ -86,16 +86,20 @@ export function YourConnectionsScreen() {
 
   async function handleConnectMyAccount(connectionId: string) {
     setRowError(null);
+    let authorizationWindow: Window | null = null;
     try {
+      authorizationWindow = openMcpAuthorizationWindow();
       const result = await startOAuth.mutateAsync(connectionId);
       if (result.status === "connected") {
+        authorizationWindow.close();
         void refetch();
         return;
       }
       if (!result.authorizeUrl) throw new Error("The MCP provider did not return an authorization URL.");
-      window.open(safeMcpAuthorizationUrl(result.authorizeUrl), "_blank", "noopener,noreferrer");
+      authorizationWindow.location.href = safeMcpAuthorizationUrl(result.authorizeUrl);
       pollUntilConnectedForMe(connectionId);
     } catch (connectError) {
+      authorizationWindow?.close();
       setRowError({
         connectionId,
         message: connectError instanceof Error ? connectError.message : "Failed to connect account.",

--- a/evals/flows/marketplace-plugin-mcp-auth.flow.mjs
+++ b/evals/flows/marketplace-plugin-mcp-auth.flow.mjs
@@ -1119,14 +1119,16 @@ async function openNeedsConnectionUrl(ctx) {
 }
 
 async function clickFocusedConnect(ctx) {
-  const clicked = await ctx.eval(`(() => {
+  const selector = '[data-openwork-eval-focused-connect="true"]';
+  const marked = await ctx.eval(`(() => {
     const highlighted = [...document.querySelectorAll('div')]
       .find((node) => (node.className ?? '').toString().includes('ring-blue-200') && (node.innerText ?? '').includes('Required by Support Operations'));
     const button = highlighted ? [...highlighted.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === 'Connect') : null;
-    button?.click();
+    button?.setAttribute('data-openwork-eval-focused-connect', 'true');
     return Boolean(button);
   })()`);
-  ctx.assert(clicked, "Focused Slack row did not expose a Connect button.");
+  ctx.assert(marked, "Focused Slack row did not expose a Connect button.");
+  await ctx.trustedClick(selector, { timeoutMs: 20_000 });
 }
 
 async function routeLocalSplitOriginCallback(ctx) {

--- a/evals/flows/marketplace-plugin-mcp-auth.flow.mjs
+++ b/evals/flows/marketplace-plugin-mcp-auth.flow.mjs
@@ -20,7 +20,8 @@ const PLATFORM_ADMIN_EMAIL = process.env.OPENWORK_EVAL_PLATFORM_ADMIN_EMAIL?.tri
 const PLATFORM_ADMIN_PASSWORD = process.env.OPENWORK_EVAL_PLATFORM_ADMIN_PASSWORD?.trim() || "";
 const MOCK_PORT = Number(process.env.OPENWORK_EVAL_MARKETPLACE_SLACK_MOCK_PORT ?? 4537);
 const MOCK_BASE = `http://127.0.0.1:${MOCK_PORT}`;
-const MOCK_MCP_URL = `${MOCK_BASE}/mcp`;
+const MOCK_MCP_URL = process.env.OPENWORK_EVAL_MARKETPLACE_SLACK_MCP_URL?.trim() || `${MOCK_BASE}/mcp`;
+const MOCK_ISSUER = new URL(MOCK_MCP_URL).origin;
 const MOCK_CLIENT_ID = process.env.MOCK_CLIENT_ID || "mock-preregistered-client";
 const MOCK_CLIENT_SECRET = process.env.MOCK_CLIENT_SECRET || "mock-preregistered-secret";
 const MOCK_SERVER_SCRIPT = fileURLToPath(new URL("../../scripts/mock-oauth-mcp-server.mjs", import.meta.url));
@@ -709,6 +710,7 @@ async function startMock(ctx) {
       PORT: String(MOCK_PORT),
       AUTO_APPROVE: "1",
       DISABLE_DCR: "1",
+      ISSUER: MOCK_ISSUER,
       MOCK_CLIENT_ID,
       MOCK_CLIENT_SECRET,
       MOCK_EXTRA_TOOL_NAME: EXTERNAL_TOOL_NAME,
@@ -940,11 +942,10 @@ async function assertConfiguredConnection(ctx) {
   const listed = await orgApi(ctx, "/v1/mcp-connections?scope=manageable");
   const connection = (listed.connections ?? []).find((entry) => entry.id === state.connectionId);
   ctx.assert(Boolean(connection), `Configured connection ${state.connectionId} not found.`);
-  recordAssertion(ctx, "Configured connection is per-member, Support-scoped through inherited marketplace access, and URL is the plugin payload URL", connection.credentialMode === "per_member"
+  recordAssertion(ctx, "Configured connection is per-member, bound to Support Operations, and uses the plugin payload URL", connection.credentialMode === "per_member"
     && connection.url === MOCK_MCP_URL
-    && connection.access?.orgWide === false
-    && (connection.access?.teamIds ?? []).includes(state.supportTeamId)
-    && (connection.requiredBy ?? []).some((entry) => entry.name === PLUGIN_NAME), {
+    && (connection.requiredBy ?? []).some((entry) => entry.pluginId === state.pluginId && entry.name === PLUGIN_NAME)
+    && (connection.identityManagedBy ?? []).some((entry) => entry.pluginId === state.pluginId && entry.name === PLUGIN_NAME), {
     id: connection.id,
     name: connection.name,
     url: connection.url,

--- a/evals/flows/marketplace-plugin-mcp-auth.flow.mjs
+++ b/evals/flows/marketplace-plugin-mcp-auth.flow.mjs
@@ -269,8 +269,11 @@ export default {
               requireText: ["Your Connections", "Connect your account", "Required by Support Operations", "Connect"],
               rejectText: ["Nothing has been shared with you yet", "Connection failed"],
             });
-            await clickFocusedConnect(ctx);
-            await ctx.switchToNewTab({ timeoutMs: 20_000, label: "Slack mock OAuth popup" });
+            await ctx.switchToNewTab({
+              timeoutMs: 20_000,
+              label: "Slack mock OAuth popup",
+              trigger: () => clickFocusedConnect(ctx),
+            });
             await routeLocalSplitOriginCallback(ctx);
             await ctx.waitForText("Connected", { timeoutMs: 30_000 });
             await ctx.switchBack();

--- a/evals/runner/context.mjs
+++ b/evals/runner/context.mjs
@@ -56,15 +56,18 @@ export class EvalContext {
    * Waits for a new browser tab/page target to appear (e.g. an OAuth
    * `window.open` popup) and switches ctx.eval/screenshot/etc to it. Push
    * the previous target with switchBack() once done with the new tab.
+   * Pass `trigger` when the action opens its popup synchronously so the
+   * target baseline is captured before the user action runs.
    * Requires cdpBaseUrl (set automatically by the runner); not available
    * against a raw client-only context.
    */
-  async switchToNewTab({ match, timeoutMs = DEFAULT_TIMEOUT_MS, label } = {}) {
+  async switchToNewTab({ match, timeoutMs = DEFAULT_TIMEOUT_MS, label, trigger } = {}) {
     if (!this.cdpBaseUrl) {
       throw new EvalError("switchToNewTab requires cdpBaseUrl on the context.");
     }
     const before = await listTargets(this.cdpBaseUrl);
     const beforeIds = new Set(before.map((entry) => entry.id));
+    if (trigger) await trigger();
     const startedAt = Date.now();
     while (Date.now() - startedAt < timeoutMs) {
       const targets = await listTargets(this.cdpBaseUrl);


### PR DESCRIPTION
## Summary

- open the downstream MCP OAuth popup synchronously from the user click so normal browser popup protection allows it
- normalize MySQL JSON credential fields before the current and enterprise MCP clients consume them
- make the marketplace OAuth fraimz work across split Daytona sandboxes and capture synchronous popups without a race

## Validation

- `pnpm --filter @openwork-ee/den-web typecheck` passed
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit --pretty false` passed
- `pnpm --filter @openwork-ee/den-web exec bun test tests/mcp-authorization-url.test.ts` passed, 7 tests
- Daytona: `bun test test/external-capabilities-search-divergence.test.ts --timeout 30000` passed, 17 tests
- Daytona: `pnpm fraimz --flow marketplace-plugin-mcp-auth` passed all 7 user-facing frames plus cleanup and voice-over coverage

## End-to-end proof

- [fraimz, all validated frames](https://8090-vvfjdxmko2bsdgem.daytonaproxy01.net/validation/openwork-v1-connect-full-demo-20260714/fraimz.html)
- [42 second Daytona recording](https://8090-vvfjdxmko2bsdgem.daytonaproxy01.net/recordings/openwork-v1-connect-full-demo-20260714.mp4)

The final frame shows Maya retrying the same shared capability, discovering the bound `create_shift_handoff` Slack MCP tool, and receiving `SHIFT_HANDOFF_READY` through her per-member connection.
