### PR TITLE
fix(mcp): restrict manual tool execution to admins

### DIFF
--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -17,6 +17,7 @@ import { appLogger } from "../../observability/logger.js"
 import {
   jsonValidator,
   orgMemberRoute,
+  orgRoleRoute,
   paramValidator,
   publicRoute,
   queryValidator,
@@ -825,19 +826,19 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
     describeRoute({
       tags: ["Authentication"],
       summary: "Manually run a tool from an External MCP Connection",
-      description: "Human-only diagnostic runner. Executes one named MCP tool with caller-supplied JSON arguments using the Den-managed shared credential or the calling member's connected credential. The caller must already be granted access to the connection. Credentials, arguments, and results are never written to logs.",
+      description: "Workspace owner/admin diagnostic runner. Executes one named MCP tool with caller-supplied JSON arguments using the Den-managed shared credential or the calling admin's connected credential. The caller must already be granted access to the connection. Credentials, arguments, and results are never written to logs.",
       responses: {
         200: jsonResponse("The MCP tool completed.", connectionToolRunResponseSchema),
         400: jsonResponse("Invalid tool name or arguments.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
-        403: jsonResponse("The caller has not been granted access to this connection.", forbiddenSchema),
+        403: jsonResponse("The caller must be a workspace owner/admin and have access to this connection.", forbiddenSchema),
         404: jsonResponse("Unknown connection.", connectionNotFoundSchema),
         409: jsonResponse("The connection has no usable credential for this member.", connectionNotReadySchema),
         413: jsonResponse("The tool arguments exceeded the request size limit.", connectionToolRequestTooLargeSchema),
         502: jsonResponse("The upstream MCP tool call failed.", connectionToolRunFailedSchema),
       },
     }),
-    orgMemberRoute(),
+    orgRoleRoute(["admin"]),
     resolveMemberTeamsMiddleware,
     bodyLimit({
       maxSize: MANUAL_MCP_TOOL_REQUEST_MAX_BYTES,

--- a/ee/apps/den-api/test/mcp-connections-tools.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-tools.test.ts
@@ -349,10 +349,10 @@ test("an ungranted member cannot inspect or run a connection", async () => {
   expect(callResponse.status).toBe(403)
 })
 
-test("a granted member manually runs a tool with a diagnostic reference", async () => {
+test("an admin manually runs a tool with a diagnostic reference", async () => {
   observedMethods.length = 0
   observedArguments.length = 0
-  const response = await callRequest(connectionId, memberUserId, {
+  const response = await callRequest(connectionId, adminUserId, {
     toolName: "search_incidents",
     arguments: { query: "network timeout", status: "active" },
   })
@@ -369,14 +369,21 @@ test("a granted member manually runs a tool with a diagnostic reference", async 
   expect(observedArguments).toEqual([{ query: "network timeout", status: "active" }])
 })
 
-test("per-member tool execution uses only the calling member's credential", async () => {
+test("per-member tool execution uses only the calling admin's credential", async () => {
   observedAuthorization.length = 0
   const response = await callRequest(perMemberConnectionId)
   expect(response.status).toBe(200)
   expect(observedAuthorization).toContain("Bearer member-catalog-token")
+})
 
-  const missingCredential = await callRequest(perMemberConnectionId, memberUserId)
-  expect(missingCredential.status).toBe(409)
+test("a granted regular member cannot manually run a tool", async () => {
+  const response = await callRequest(connectionId, memberUserId)
+  expect(response.status).toBe(403)
+})
+
+test("manual tool execution requires a connected admin credential", async () => {
+  const response = await callRequest(disconnectedConnectionId)
+  expect(response.status).toBe(409)
 })
 
 test("manual tool execution is tenant scoped", async () => {
@@ -397,7 +404,7 @@ test("manual tool execution validates a JSON object payload", async () => {
     method: "POST",
     headers: {
       "content-type": "application/json",
-      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId: memberUserId, organizationId }),
+      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId: adminUserId, organizationId }),
     },
     body: JSON.stringify({ toolName: "search_incidents", arguments: [] }),
   }))
@@ -414,7 +421,7 @@ test("manual tool execution rejects payloads larger than 1 MB", async () => {
     headers: {
       "content-length": String(Buffer.byteLength(body)),
       "content-type": "application/json",
-      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId: memberUserId, organizationId }),
+      "x-den-internal-mcp-principal": session.createInternalMcpPrincipalHeader({ userId: adminUserId, organizationId }),
     },
     body,
   }))

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
-import { AlertTriangle, Check, ChevronDown, ChevronRight, Loader2, Plug, Wrench } from "lucide-react";
+import { AlertTriangle, Check, Loader2, Plug, Wrench } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { getOrgAccessFlags } from "../../_lib/den-org";
@@ -127,7 +127,7 @@ export function YourConnectionsScreen() {
       icon={Plug}
       title="Your Connections"
       badgeLabel="Alpha"
-      description="Tools your organization has made available to you. Connect your own account where needed, then test a tool directly or let your AI coworker use it with your permissions."
+      description="Tools your organization has made available to you. Connect your own account where needed; workspace admins can test tools directly, and your AI coworker uses them with your permissions."
       colors={["#DBEAFE", "#1E3A8A", "#2563EB", "#93C5FD"]}
     >
       {error ? (
@@ -195,7 +195,7 @@ function YourConnectionRow({
   const needsMyConnect = isPerMember && !connection.connectedForMe;
   const needsAdminConnect = isAdmin && !isPerMember && connection.authType === "oauth" && !connection.connectedForMe;
   const canDisconnect = canDisconnectNativeProviderAccount(connection);
-  const canTestTools = !isNativeProviderConnectionId(connection.id) && connection.connectedForMe && !needsReconnect;
+  const canTestTools = isAdmin && !isNativeProviderConnectionId(connection.id) && connection.connectedForMe && !needsReconnect;
   const [toolRunnerOpen, setToolRunnerOpen] = useState(false);
   const microsoftScopes = connection.id === "microsoft-365"
     ? (connection.grantedScopes ?? []).filter((scope) => MICROSOFT_365_DISPLAY_SCOPES.has(scope))
@@ -272,11 +272,11 @@ function YourConnectionRow({
               icon={Wrench}
               onClick={() => setToolRunnerOpen((open) => !open)}
               aria-expanded={toolRunnerOpen}
+              aria-label={`Test tools for ${connection.name}`}
+              title={`Test tools for ${connection.name}`}
+              className="h-8 w-8 !px-0"
               data-testid={`toggle-mcp-tool-runner-${connection.id}`}
-            >
-              Test tools
-              {toolRunnerOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-            </DenButton>
+            />
           ) : null}
           {canDisconnect ? (
             <DenButton variant="destructive" size="sm" loading={disconnecting} onClick={onDisconnect}>


### PR DESCRIPTION
## Summary

- require workspace admin authorization for manual external MCP tool execution
- keep tool-catalog inspection available to granted members while returning 403 for regular-member execution attempts
- show the manual runner control only to admins
- preserve an accessible label and tooltip on the compact runner control
- update the API description and focused authorization coverage

## Root cause

The manual execution endpoint used member-level authorization, so any granted workspace member could invoke an external MCP tool. These tools can perform mutating or destructive actions in connected systems, making direct manual execution an administrative diagnostic capability. The dashboard also exposed the execution control to non-admin members even though the safer boundary is admin-only.

## Security boundaries

- manual execution now requires the workspace admin role
- tenant-scoped connection lookup and connection-access grants remain enforced
- execution uses only the calling admins connected credential
- the route remains excluded from the agent-facing API catalog
- credentials, tool names, arguments, and results remain absent from Den logs
- the existing request-size cap and secret-safe diagnostics remain unchanged

## Verification

- 30 focused Den API policy, Microsoft 365 route, MCP execution, and agent-catalog tests passed
- Den Web TypeScript validation passed
- Linux and macOS OpenWork test workflows passed
- i18n audit passed
- Den API, Den Web, and inference artifact builds and health checks passed
- Helm validation passed
- the branch contains one commit touching only the API route, its focused tests, and the matching dashboard control

## Manual verification

The authorization behavior is covered directly by focused tests: admins can execute, regular members receive 403, tenant isolation remains intact, and per-member credentials remain caller-scoped. The admin-versus-member browser visibility path was not rerun manually.

## Risk and rollback

Regular members can still inspect the tool catalogs granted to them, but they can no longer execute tools manually. Reverting the single commit restores the previous member-level execution behavior.