### PR TITLE
fix(mcp): extend capability execution timeout

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -26,7 +26,7 @@ import { executeAvailableAdminCapability, parseAdminCapabilityName, searchAvaila
 export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
 const searchCapabilityTypeSchema = z.enum(["all", "api", "admin", "mcp", "marketplace", "skills"])
 const skillMarketplaceObjectTypes: MarketplaceCapabilityObjectType[] = ["skill"]
-export const EXECUTE_CAPABILITY_TIMEOUT_MS = 45_000
+export const EXECUTE_CAPABILITY_TIMEOUT_MS = 180_000
 export const SEARCH_CAPABILITIES_ANNOTATIONS: ToolAnnotations = {
   readOnlyHint: true,
   destructiveHint: false,
@@ -108,7 +108,7 @@ export const AGENT_MCP_INSTRUCTIONS = [
   "Connection probes are live. After the requested human fixes that connector, search again in the same task; otherwise do not retry unchanged or improvise workarounds through other tools.",
 ].join("\n")
 
-const EXECUTE_CAPABILITY_TIMEOUT_MESSAGE = "The capability call exceeded 45s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect."
+const EXECUTE_CAPABILITY_TIMEOUT_MESSAGE = `The capability call exceeded ${EXECUTE_CAPABILITY_TIMEOUT_MS / 1_000}s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect.`
 
 export type ExecuteCapabilityToolResult = {
   isError?: boolean

--- a/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
@@ -50,6 +50,8 @@ beforeAll(async () => {
 })
 
 test("executeCapabilityWithBudget returns a structured timeout result", async () => {
+  expect(agentModule.EXECUTE_CAPABILITY_TIMEOUT_MS).toBeGreaterThan(150_000)
+
   const result = await agentModule.executeCapabilityWithBudget({
     capability: "gmail_search",
     timeoutMs: 1,
@@ -60,7 +62,7 @@ test("executeCapabilityWithBudget returns a structured timeout result", async ()
   expect(result.content[0]?.text).toBe(JSON.stringify({
     error: "capability_timeout",
     capability: "gmail_search",
-    message: "The capability call exceeded 45s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect.",
+    message: "The capability call exceeded 180s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect.",
   }))
 })
 
@@ -84,7 +86,7 @@ test("executeCapabilityWithBudget swallows late rejections after timeout", async
     expect(result.content[0]?.text).toBe(JSON.stringify({
       error: "capability_timeout",
       capability: "slow_google_workspace",
-      message: "The capability call exceeded 45s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect.",
+      message: "The capability call exceeded 180s. Retry once; if it times out again, narrow the request (fewer results, tighter query) and tell the user the service is slow — do NOT tell them to reconfigure or reconnect.",
     }))
 
     await new Promise((resolve) => setTimeout(resolve, 25))


### PR DESCRIPTION
## Summary

- extend the Den `execute_capability` outer budget from 45 seconds to 180 seconds
- keep the structured timeout message derived from the configured budget
- assert that the outer budget outlives the 150-second external MCP tool lifecycle

Follow-up to #2750.

## Root cause

#2750 extended external MCP tool requests to 120 seconds and their bounded lifecycle to 150 seconds. The engine-to-Den `execute_capability` wrapper still returned `capability_timeout` after 45 seconds, so callers could receive a premature failure while the downstream operation was still within its allowed lifecycle.

## Impact

Long-running external MCP tools can now use the full downstream lifecycle. The 180-second outer budget leaves a 30-second margin for Den authorization and persistence work around the provider call. Existing provider request/lifecycle bounds, retry guidance, and error envelopes are unchanged.

## Validation

- `pnpm exec bun test ee/apps/den-api/test/mcp-agent-timeouts.test.ts` — passed, 9 tests / 23 expectations
- `pnpm exec bun test ee/apps/den-api/test/external-mcp-diagnostics.test.ts -t "allows tool execution to use a longer bounded request timeout"` — passed, 1 test / 4 expectations
- `pnpm --filter @openwork-ee/den-api build` — passed
- `git diff --check` — passed

## Security and trust boundaries

- no authentication, credential storage, tenant scope, SSRF, authorization, or provider network behavior changes
- the downstream call remains capped at 120 seconds with a 150-second lifecycle
- timeout results remain structured and continue to discourage unnecessary reconnect/reconfiguration advice

## Verification gaps

- no live third-party provider call was run; this PR is covered by the MCP boundary tests and Den API production build
- no UI changed, so no fraimz, screenshot, or video evidence was produced
