### PR TITLE
fix(den-mcp): capture allowlisted provider evidence on tool-error results

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
@@ -50,6 +50,9 @@ export type ExternalMcpDiagnostic = {
   operationPhase?: ExternalMcpDiagnosticPhase
   outbound?: ExternalMcpSafeOutbound
   providerRequestId?: string
+  providerStatus?: number
+  providerCode?: string
+  payloadBytes?: number
   jsonRpcCode?: number
 }
 
@@ -156,6 +159,12 @@ const SAFE_ERROR_NAMES = new Set([
   "ServerError",
 ])
 
+const SAFE_PROVIDER_TOKEN_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:-]*$/
+const SAFE_PROVIDER_REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:/-]*$/
+const PROVIDER_STATUS_FIELDS = ["status", "statusCode", "httpStatus"]
+const PROVIDER_CODE_FIELDS = ["code", "error"]
+const PROVIDER_REQUEST_ID_FIELDS = ["requestId", "request_id", "transactionId", "transaction_id"]
+
 const TYPED_OAUTH_ERROR_NAMES = new Set([
   "InvalidClientError",
   "UnauthorizedClientError",
@@ -224,6 +233,129 @@ function safeNativeToken(value: string | undefined, pattern: RegExp, maxLength =
   return value
 }
 
+function safeProviderToken(value: unknown, maxLength = 64): string | undefined {
+  return typeof value === "string" ? safeNativeToken(value, SAFE_PROVIDER_TOKEN_PATTERN, maxLength) : undefined
+}
+
+function safeProviderRequestId(value: unknown): string | undefined {
+  return typeof value === "string" ? safeNativeToken(value, SAFE_PROVIDER_REQUEST_ID_PATTERN, 128) : undefined
+}
+
+function validProviderStatus(value: unknown): number | undefined {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 400 || value > 599) return undefined
+  return value
+}
+
+function providerStatusFromRecord(value: Record<string, unknown>): number | undefined {
+  for (const field of PROVIDER_STATUS_FIELDS) {
+    const status = validProviderStatus(value[field])
+    if (status !== undefined) return status
+  }
+  return undefined
+}
+
+function providerCodeFromRecord(value: Record<string, unknown>): string | undefined {
+  for (const field of PROVIDER_CODE_FIELDS) {
+    const code = safeProviderToken(value[field])
+    if (code) return code
+  }
+  return undefined
+}
+
+function providerRequestIdFromRecord(value: Record<string, unknown>): string | undefined {
+  for (const field of PROVIDER_REQUEST_ID_FIELDS) {
+    const requestId = safeProviderRequestId(value[field])
+    if (requestId) return requestId
+  }
+  return undefined
+}
+
+function providerStatusFromLeadingText(value: string): number | undefined {
+  const text = value.trimStart()
+  const statusMatch = /^(?:HTTP[ /])?([45]\d\d)\b/.exec(text) ?? /^([45]\d\d)\s+[A-Za-z]/.exec(text)
+  const statusText = statusMatch?.[1]
+  if (!statusText) return undefined
+  return validProviderStatus(Number(statusText))
+}
+
+function parsedTextRecord(value: string): Record<string, unknown> | null {
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return isRecord(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
+function providerToolContentArray(result: unknown): unknown[] | null {
+  if (!isRecord(result) || !Array.isArray(result.content)) return null
+  return result.content
+}
+
+function isProviderToolTextContent(value: unknown): value is { type: "text"; text: string } {
+  return isRecord(value) && value.type === "text" && typeof value.text === "string"
+}
+
+function serializedContentPayloadBytes(content: unknown[] | null): number {
+  if (!content || content.length === 0) return 0
+  try {
+    const serialized = JSON.stringify(content)
+    return typeof serialized === "string" ? Buffer.byteLength(serialized, "utf8") : 0
+  } catch {
+    return 0
+  }
+}
+
+function sanitizedProviderToolExcerpt(texts: string[]): string | undefined {
+  const sanitized = texts
+    .join("\n")
+    .replace(/[\u0000-\u001F\u007F-\u009F]/g, " ")
+    .replace(/\s+/g, " ")
+    .trim()
+  if (!sanitized) return undefined
+  return sanitized.length > 512 ? sanitized.slice(0, 512) : sanitized
+}
+
+type ProviderToolContentEvidence = {
+  providerStatus?: number
+  providerCode?: string
+  providerRequestId?: string
+  payloadBytes: number
+  excerpt?: string
+}
+
+function providerToolContentEvidence(result: unknown): ProviderToolContentEvidence {
+  const content = providerToolContentArray(result)
+  const payloadBytes = serializedContentPayloadBytes(content)
+  if (!content) return { payloadBytes }
+
+  let providerStatus: number | undefined
+  let providerCode: string | undefined
+  let providerRequestId: string | undefined
+  const texts: string[] = []
+
+  for (const item of content) {
+    if (!isProviderToolTextContent(item)) continue
+    texts.push(item.text)
+    const parsed = parsedTextRecord(item.text)
+    if (parsed) {
+      providerStatus ??= providerStatusFromRecord(parsed)
+      providerCode ??= providerCodeFromRecord(parsed)
+      providerRequestId ??= providerRequestIdFromRecord(parsed)
+    }
+    providerStatus ??= providerStatusFromLeadingText(item.text)
+  }
+
+  const excerpt = sanitizedProviderToolExcerpt(texts)
+  return {
+    payloadBytes,
+    ...(providerStatus === undefined ? {} : { providerStatus }),
+    ...(providerCode ? { providerCode } : {}),
+    ...(providerRequestId ? { providerRequestId } : {}),
+    ...(excerpt ? { excerpt } : {}),
+  }
+}
+
 function errorName(value: unknown): string {
   const name = value instanceof Error ? value.name : stringProperty(value, "name")
   return name && SAFE_ERROR_NAMES.has(name) ? name : "Error"
@@ -290,6 +422,21 @@ export function safeExternalMcpCauseChain(error: unknown): ExternalMcpSafeCause[
 }
 
 function safeMessageFor(input: {
+  phase: ExternalMcpDiagnosticPhase
+  category: string
+  code: string
+  providerStatus?: number
+  providerCode?: string
+}): string {
+  const message = safeBaseMessageFor(input)
+  const details = [
+    ...(input.providerStatus === undefined ? [] : [`provider status ${input.providerStatus}`]),
+    ...(input.providerCode ? [`code ${input.providerCode}`] : []),
+  ]
+  return details.length === 0 ? message : `${message} Provider evidence: ${details.join(", ")}.`
+}
+
+function safeBaseMessageFor(input: {
   phase: ExternalMcpDiagnosticPhase
   category: string
   code: string
@@ -365,6 +512,26 @@ function safeMessageFor(input: {
 }
 
 type Classification = Omit<ExternalMcpDiagnostic, "referenceId" | "highestPassed" | "message">
+
+function logProviderToolEvidence(input: {
+  referenceId: string
+  evidence: ProviderToolContentEvidence
+  diagnosticCode: string
+  providerStatus?: number
+  providerCode?: string
+  providerRequestId?: string
+}): void {
+  if (!input.evidence.excerpt) return
+  console.error("external_mcp_provider_tool_evidence", {
+    referenceId: input.referenceId,
+    diagnosticCode: input.diagnosticCode,
+    excerpt: input.evidence.excerpt,
+    payloadBytes: input.evidence.payloadBytes,
+    ...(input.providerStatus === undefined ? {} : { providerStatus: input.providerStatus }),
+    ...(input.providerCode ? { providerCode: input.providerCode } : {}),
+    ...(input.providerRequestId ? { providerRequestId: input.providerRequestId } : {}),
+  })
+}
 
 function httpClassification(input: {
   phase: ExternalMcpDiagnosticPhase
@@ -919,7 +1086,7 @@ export class ExternalMcpDiagnosticTracker {
       "request-id",
       "x-request-id",
     ]) {
-      const value = safeNativeToken(headers.get(name) ?? undefined, /^[A-Za-z0-9][A-Za-z0-9_.:/-]*$/, 128)
+      const value = safeProviderRequestId(headers.get(name))
       if (value) {
         this.providerRequestId = value
         return
@@ -931,16 +1098,18 @@ export class ExternalMcpDiagnosticTracker {
     const structuredContent = isRecord(result) && isRecord(result.structuredContent)
       ? result.structuredContent
       : null
-    const providerStatus = structuredContent?.providerStatus
-    const providerCategory = structuredContent?.category
-    const requestId = safeNativeToken(
-      typeof structuredContent?.requestId === "string" ? structuredContent.requestId : undefined,
-      /^[A-Za-z0-9][A-Za-z0-9_.:/-]*$/,
-      128,
-    )
+    const structuredProviderStatus = validProviderStatus(structuredContent?.providerStatus)
+    const providerCategory = typeof structuredContent?.category === "string" ? structuredContent.category : undefined
+    const evidence = providerToolContentEvidence(result)
+    const providerStatus = structuredProviderStatus ?? evidence.providerStatus
+    const providerCode = evidence.providerCode
+    const requestId = safeProviderRequestId(structuredContent?.requestId) ?? evidence.providerRequestId
     if (requestId) this.providerRequestId = requestId
 
-    const classification: Classification = providerStatus === 403 && providerCategory === "provider_policy"
+    const providerPolicyDenied = structuredProviderStatus === 403
+      ? providerCategory === "provider_policy"
+      : evidence.providerStatus === 403
+    const classificationBase: Classification = providerPolicyDenied
       ? {
           phase: "PROVIDER_AUTHORIZATION",
           category: "provider_policy_denied",
@@ -966,6 +1135,20 @@ export class ExternalMcpDiagnosticTracker {
             actionOwner: "provider_admin",
             operatorAction: "Inspect the provider operation result and provider logs using the diagnostic reference.",
           }
+    const classification: Classification = {
+      ...classificationBase,
+      ...(providerStatus === undefined ? {} : { providerStatus }),
+      ...(providerCode ? { providerCode } : {}),
+      payloadBytes: evidence.payloadBytes,
+    }
+    logProviderToolEvidence({
+      referenceId: this.referenceId,
+      evidence,
+      diagnosticCode: classification.code,
+      ...(providerStatus === undefined ? {} : { providerStatus }),
+      ...(providerCode ? { providerCode } : {}),
+      ...(requestId ? { providerRequestId: requestId } : {}),
+    })
     this.failed(classification.phase, classification)
     return this.error(new Error("Provider returned an MCP tool error result."), classification.phase)
   }

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -54,6 +54,9 @@ const externalMcpDiagnosticOutputSchema = z.object({
   operationPhase: z.enum(EXTERNAL_MCP_DIAGNOSTIC_PHASES).optional(),
   outbound: z.object({ origin: z.string(), pathHash: z.string() }).optional(),
   providerRequestId: z.string().optional(),
+  providerStatus: z.number().int().optional(),
+  providerCode: z.string().optional(),
+  payloadBytes: z.number().int().optional(),
   jsonRpcCode: z.number().int().optional(),
 })
 

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -315,6 +315,9 @@ const externalMcpDiagnosticSchema = z.object({
     pathHash: z.string(),
   }).optional(),
   providerRequestId: z.string().optional(),
+  providerStatus: z.number().int().optional(),
+  providerCode: z.string().optional(),
+  payloadBytes: z.number().int().optional(),
   jsonRpcCode: z.number().int().optional(),
 }).meta({ ref: "ExternalMcpDiagnostic" })
 

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -30,6 +30,29 @@ function networkError(code: string, secret = "Bearer super-secret-token") {
   return new Error("fetch failed", { cause })
 }
 
+function captureConsoleError<T>(run: () => T): { result: T; errors: unknown[][] } {
+  const errors: unknown[][] = []
+  const originalError = console.error
+  console.error = (...args: unknown[]) => {
+    errors.push(args)
+  }
+  try {
+    return { result: run(), errors }
+  } finally {
+    console.error = originalError
+  }
+}
+
+function serializedConsoleErrors(errors: unknown[][]): string {
+  return errors
+    .flat()
+    .map((entry) => {
+      const serialized = typeof entry === "string" ? entry : JSON.stringify(entry)
+      return serialized ?? ""
+    })
+    .join(" ")
+}
+
 class RecordingOAuthProvider implements OAuthClientProvider {
   client: OAuthClientInformationMixed | undefined
   tokensValue: OAuthTokens | undefined
@@ -352,12 +375,27 @@ describe("external MCP diagnostics", () => {
       })
     }
 
-    const denied = makeToolError("req_provider_denied", {
-      category: "provider_policy",
-      providerStatus: 403,
-      providerCode: "sensitive-provider-code",
-      requestId: "provider-request-403",
-    })
+    const { result: toolErrors } = captureConsoleError(() => ({
+      denied: makeToolError("req_provider_denied", {
+        category: "provider_policy",
+        providerStatus: 403,
+        providerCode: "sensitive-provider-code",
+        requestId: "provider-request-403",
+      }),
+      throttled: makeToolError("req_provider_throttled", {
+        category: "provider_api",
+        providerStatus: 429,
+        requestId: "provider-request-429",
+        retryAfterSeconds: "provider-secret-retry-value",
+      }),
+      unknown: makeToolError("req_provider_unknown", {
+        category: "provider_api",
+        providerStatus: 403,
+        providerCode: "sensitive-unknown-code",
+        requestId: "invalid request id with spaces",
+      }),
+    }))
+    const { denied, throttled, unknown } = toolErrors
     expect(denied.diagnostic).toMatchObject({
       phase: "PROVIDER_AUTHORIZATION",
       category: "provider_policy_denied",
@@ -368,12 +406,6 @@ describe("external MCP diagnostics", () => {
       providerRequestId: "provider-request-403",
     })
 
-    const throttled = makeToolError("req_provider_throttled", {
-      category: "provider_api",
-      providerStatus: 429,
-      requestId: "provider-request-429",
-      retryAfterSeconds: "provider-secret-retry-value",
-    })
     expect(throttled.diagnostic).toMatchObject({
       phase: "PROVIDER_EXECUTION",
       category: "provider_throttled",
@@ -384,12 +416,6 @@ describe("external MCP diagnostics", () => {
       providerRequestId: "provider-request-429",
     })
 
-    const unknown = makeToolError("req_provider_unknown", {
-      category: "provider_api",
-      providerStatus: 403,
-      providerCode: "sensitive-unknown-code",
-      requestId: "invalid request id with spaces",
-    })
     expect(unknown.diagnostic).toMatchObject({
       phase: "PROVIDER_EXECUTION",
       category: "provider_tool_error",
@@ -406,6 +432,93 @@ describe("external MCP diagnostics", () => {
     expect(serialized).not.toContain("provider-secret-retry-value")
     expect(serialized).not.toContain("sensitive-unknown-code")
     expect(serialized).not.toContain("invalid request id with spaces")
+  })
+
+  test("derives allowlisted provider evidence from ServiceNow-style text JSON", () => {
+    const providerText = '{"status":403,"error":"insufficient_acl","requestId":"TXN-abc-123"}'
+    const { result: error } = captureConsoleError(() => {
+      const tracker = new ExternalMcpDiagnosticTracker("req_servicenow_text")
+      tracker.passed("MCP_INITIALIZED", "protocol_ready")
+      return tracker.providerToolError({
+        isError: true,
+        content: [{ type: "text", text: providerText }],
+      })
+    })
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "PROVIDER_AUTHORIZATION",
+      category: "provider_policy_denied",
+      code: "MCP_PROVIDER_HTTP_403",
+      providerStatus: 403,
+      providerCode: "insufficient_acl",
+      providerRequestId: "TXN-abc-123",
+      highestPassed: "protocol_ready",
+    })
+    expect(error.diagnostic.payloadBytes ?? 0).toBeGreaterThan(0)
+    expect(error.diagnostic.message).toContain("provider status 403")
+    expect(error.diagnostic.message).toContain("code insufficient_acl")
+    expect(error.diagnostic.message).not.toContain(providerText)
+  })
+
+  test("logs Redis-style provider text evidence without surfacing it in the diagnostic", () => {
+    const providerText = "All slots are not covered by nodes. 0 of 16384 covered."
+    const { result: error, errors } = captureConsoleError(() => {
+      const tracker = new ExternalMcpDiagnosticTracker("req_redis_text")
+      tracker.passed("MCP_INITIALIZED", "protocol_ready")
+      return tracker.providerToolError({
+        isError: true,
+        content: [{ type: "text", text: providerText }],
+      })
+    })
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "PROVIDER_EXECUTION",
+      category: "provider_tool_error",
+      code: "MCP_PROVIDER_TOOL_ERROR",
+    })
+    expect(error.diagnostic.payloadBytes ?? 0).toBeGreaterThan(0)
+    expect(error.diagnostic.message).not.toContain(providerText)
+
+    const loggedText = serializedConsoleErrors(errors)
+    expect(loggedText).toContain("external_mcp_provider_tool_evidence")
+    expect(loggedText).toContain("req_redis_text")
+    expect(loggedText).toContain(providerText)
+  })
+
+  test("does not classify mid-sentence provider status-like numbers", () => {
+    const { result: error } = captureConsoleError(() => {
+      const tracker = new ExternalMcpDiagnosticTracker("req_mid_sentence_status")
+      tracker.passed("MCP_INITIALIZED", "protocol_ready")
+      return tracker.providerToolError({
+        isError: true,
+        content: [{ type: "text", text: "we found 403 records" }],
+      })
+    })
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "PROVIDER_EXECUTION",
+      category: "provider_tool_error",
+      code: "MCP_PROVIDER_TOOL_ERROR",
+    })
+    expect(error.diagnostic.providerStatus).toBeUndefined()
+  })
+
+  test("keeps empty provider tool content generic with zero payload bytes", () => {
+    const { result: error } = captureConsoleError(() => {
+      const tracker = new ExternalMcpDiagnosticTracker("req_empty_tool_content")
+      tracker.passed("MCP_INITIALIZED", "protocol_ready")
+      return tracker.providerToolError({
+        isError: true,
+        content: [],
+      })
+    })
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "PROVIDER_EXECUTION",
+      category: "provider_tool_error",
+      code: "MCP_PROVIDER_TOOL_ERROR",
+      payloadBytes: 0,
+    })
   })
 
   test("typed OAuth token errors override generic HTTP 400 classification", async () => {


### PR DESCRIPTION
## Summary

When an external MCP provider returns HTTP 200 with a tool result marked `isError: true` (exactly how ServiceNow's MCP tools fail), Den classifies it via `ExternalMcpDiagnosticTracker.providerToolError()`, which only read `result.structuredContent.{providerStatus, category, requestId}`. Real providers put the error in **text content** with no `structuredContent`, so classification always fell to the generic `MCP_PROVIDER_TOOL_ERROR` and the provider's actual error (a 403 ACL denial, a Redis cluster failure, `SyntaxError: Empty JSON string`) was discarded — absent from the diagnostic, absent from server logs, invisible to support.

This came directly out of an enterprise ServiceNow debugging session where the useful provider evidence was only ever visible through a direct (non-Cloud) connection, making the Cloud path undiagnosable.

## What changed

- `providerToolError()` now extracts **bounded, allowlisted** evidence from `isError` tool results:
  - `providerStatus` (400–599): from `structuredContent`, from top-level JSON fields (`status`/`statusCode`/`httpStatus`) in parsed text content, or from an explicit **leading** pattern (`HTTP 403`, `403 Forbidden`). Mid-sentence numbers (e.g. "we found 403 records") never classify.
  - `providerCode`: identifier-shaped `code`/`error` JSON fields (max 64 chars, safe charset).
  - `providerRequestId`: existing structuredContent path plus `requestId`/`request_id`/`transactionId`/`transaction_id` JSON fields (same `safeNativeToken` validation).
  - `payloadBytes`: UTF-8 size of the serialized content array.
- Derived text-level 403 → `MCP_PROVIDER_HTTP_403` / `PROVIDER_AUTHORIZATION` / `provider_admin` (same classification as the structured path); 429 → throttled; everything else stays `MCP_PROVIDER_TOOL_ERROR`.
- **Restricted raw evidence**: a sanitized excerpt (control chars stripped, whitespace collapsed, max 512 chars) is logged server-side as `external_mcp_provider_tool_evidence` keyed by the diagnostic `referenceId` — retrievable by operators, **never** included in any model-visible field.
- The model-visible diagnostic message now appends scalars only, e.g. `Provider evidence: provider status 403, code insufficient_acl.`
- Public schema mirrors kept in sync: `externalMcpDiagnosticOutputSchema` (`src/mcp/agent.ts`) and `externalMcpDiagnosticSchema` (`src/routes/org/mcp-connections.ts`) gain optional `providerStatus`, `providerCode`, `payloadBytes`.

## Security boundaries

- Raw provider text never reaches the model or API responses; only validated scalars do.
- All identifiers pass the existing safe-token patterns; the excerpt lives only in server logs behind the diagnostic reference.

## Testing

- `pnpm --filter @openwork-ee/den-api exec bun test test/external-mcp-diagnostics.test.ts` — **57 pass, 0 fail** (new coverage: ServiceNow-style JSON 403 with requestId, Redis-style plain text, mid-sentence 403 negative case, empty content, evidence-log capture; existing structuredContent tests unchanged).
- `pnpm --filter @openwork-ee/den-api exec bun test test/external-capabilities-search-divergence.test.ts` — **17 pass, 0 fail**.
- `pnpm --filter @openwork-ee/den-api exec tsc -p . --noEmit` — clean.
- Results were reproduced independently by a second run after implementation.

No video/fraimz attached: this is a Den API behavior change with no UI surface, covered by unit tests above. Reviewer repro: point an external MCP connection at a server whose tool returns `{ isError: true, content: [{ type: "text", text: '{"status":403,"error":"insufficient_acl","requestId":"TXN-1"}' }] }`, call it via `execute_capability`, and observe (1) the diagnostic carrying `MCP_PROVIDER_HTTP_403`, `providerStatus: 403`, `providerCode`, `providerRequestId`, `payloadBytes`, and (2) the `external_mcp_provider_tool_evidence` log line with the sanitized excerpt and matching `referenceId`.

## Notes

- Companion to the merged #2750 timeout work and the diagnostics program (#2669/#2674): this closes the "generic safe errors hide the useful provider result" gap for provider-executed tool failures.
- Touches the same files as #2752/#2675 lightly (additive optional fields); conflicts, if any, are trivial.
