### PR TITLE
feat(den-mcp): expose bounded input schemas in capability search and refuse un-constructible executes

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -131,6 +131,8 @@ export function externalCapabilityErrorToolResult(
       ...(result.actionOwner ? { actionOwner: result.actionOwner } : {}),
       ...(result.operatorAction ? { operatorAction: result.operatorAction } : {}),
       ...(result.connectionStatus ? { connectionStatus: result.connectionStatus } : {}),
+      ...(result.inputSummary ? { inputSummary: result.inputSummary } : {}),
+      ...(result.schemaHash ? { schemaHash: result.schemaHash } : {}),
     })),
   }
 }
@@ -309,6 +311,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
           "Search covers native Google Workspace capabilities (Gmail, Calendar, Drive, Gmail drafts), org-connected external MCPs, and namespaced OpenWork Admin tools for allowlisted platform admins.",
           "Try 2-4 keyword variants before deciding a capability is unavailable.",
           "Each match includes pathParams/queryParams/hasBody describing exactly what execute_capability needs.",
+          "External MCP tool matches also include inputSummary describing body arguments.",
           "Skill matches use method SKILL and return stored SKILL.md content when executed.",
         ].join(" "),
         annotations: SEARCH_CAPABILITIES_ANNOTATIONS,

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -1,3 +1,5 @@
+import { Buffer } from "node:buffer"
+import { createHash } from "node:crypto"
 import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
 import { UnauthorizedError } from "@modelcontextprotocol/sdk/client/auth.js"
 import { StreamableHTTPError } from "@modelcontextprotocol/sdk/client/streamableHttp.js"
@@ -146,10 +148,24 @@ export function selectExternalMcpSearchConnections<T extends { name: string }>(
 export type ExternalCapabilityMatch = CapabilityMatch & {
   /** Distinguishes a connection-health result from a callable capability. */
   kind?: "connection_status"
+  inputSummary?: ExternalCapabilityInputSummary
+  schemaHash?: string
   /** Set for connection-level status rows: the tool exists but needs a human/admin fix before real tools can be listed. */
   status?: "needs_connection" | "error"
   hint?: string
   connectionStatus?: ExternalConnectionStatus
+}
+
+export type ExternalCapabilityInputPropertySummary = {
+  type?: string
+  description?: string
+  enum?: unknown[]
+}
+
+export type ExternalCapabilityInputSummary = {
+  required: string[]
+  properties: Record<string, ExternalCapabilityInputPropertySummary>
+  truncated?: true
 }
 
 export type ExternalConnectionStatus = {
@@ -181,6 +197,129 @@ const PROVIDER_ADMIN_ACTION_PATTERN = /\b(?:app (?:is )?not installed|admin(?:is
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+const INPUT_SUMMARY_MAX_PROPERTIES = 24
+const INPUT_SUMMARY_DESCRIPTION_LIMIT = 120
+const INPUT_SUMMARY_ENUM_LIMIT = 8
+const INPUT_SUMMARY_SERIALIZED_LIMIT = 1_536
+const PRIMITIVE_SCHEMA_TYPES = new Set(["string", "number", "integer", "boolean", "null"])
+
+function schemaRequiredNames(schema: unknown): string[] {
+  if (!isRecord(schema) || !Array.isArray(schema.required)) return []
+  return schema.required.filter((value) => typeof value === "string")
+}
+
+function schemaProperties(schema: unknown): Record<string, unknown> | null {
+  if (!isRecord(schema) || !isRecord(schema.properties)) return null
+  return schema.properties
+}
+
+function firstSchemaType(value: unknown): string | undefined {
+  if (typeof value === "string") return value
+  if (!Array.isArray(value)) return undefined
+  return value.find((candidate) => typeof candidate === "string" && candidate !== "null")
+    ?? value.find((candidate) => typeof candidate === "string")
+}
+
+function primitiveSchemaType(schema: unknown): string | undefined {
+  if (!isRecord(schema)) return undefined
+  const schemaType = firstSchemaType(schema.type)
+  return schemaType && PRIMITIVE_SCHEMA_TYPES.has(schemaType) ? schemaType : undefined
+}
+
+function inputPropertyType(schema: unknown): string | undefined {
+  if (!isRecord(schema)) return undefined
+  const schemaType = firstSchemaType(schema.type)
+  if (schemaType === "array" || "items" in schema) {
+    const itemType = primitiveSchemaType(schema.items)
+    return itemType ? `array<${itemType}>` : "array"
+  }
+  if (schemaType === "object" || isRecord(schema.properties)) return "object"
+  return schemaType
+}
+
+function summarizeInputProperty(schema: unknown): { summary: ExternalCapabilityInputPropertySummary; truncated: boolean } {
+  if (!isRecord(schema)) return { summary: {}, truncated: false }
+  let truncated = false
+  const summary: ExternalCapabilityInputPropertySummary = {}
+  const type = inputPropertyType(schema)
+  if (type) summary.type = type
+  if (typeof schema.description === "string") {
+    truncated = schema.description.length > INPUT_SUMMARY_DESCRIPTION_LIMIT
+    summary.description = schema.description.slice(0, INPUT_SUMMARY_DESCRIPTION_LIMIT)
+  }
+  if (Array.isArray(schema.enum)) {
+    if (schema.enum.length > INPUT_SUMMARY_ENUM_LIMIT) truncated = true
+    summary.enum = schema.enum.slice(0, INPUT_SUMMARY_ENUM_LIMIT)
+  }
+  return { summary, truncated }
+}
+
+function orderedSchemaPropertyNames(properties: Record<string, unknown>, required: string[]): string[] {
+  const requiredSet = new Set(required)
+  return [
+    ...required.filter((name) => Object.hasOwn(properties, name)),
+    ...Object.keys(properties).filter((name) => !requiredSet.has(name)).sort(),
+  ]
+}
+
+function buildInputSummary(input: {
+  required: string[]
+  rawProperties: Record<string, unknown> | null
+  propertyNames: string[]
+  truncated: boolean
+}): ExternalCapabilityInputSummary {
+  let truncated = input.truncated
+  const properties: Record<string, ExternalCapabilityInputPropertySummary> = {}
+  if (input.rawProperties) {
+    for (const name of input.propertyNames) {
+      const property = summarizeInputProperty(input.rawProperties[name])
+      properties[name] = property.summary
+      if (property.truncated) truncated = true
+    }
+  }
+  return truncated
+    ? { required: input.required, properties, truncated: true }
+    : { required: input.required, properties }
+}
+
+function serializedInputSummaryLength(summary: ExternalCapabilityInputSummary): number {
+  return Buffer.byteLength(JSON.stringify(summary), "utf8")
+}
+
+export function summarizeExternalMcpInputSchema(inputSchema: unknown): ExternalCapabilityInputSummary {
+  const required = schemaRequiredNames(inputSchema)
+  const rawProperties = schemaProperties(inputSchema)
+  if (!rawProperties) return { required, properties: {} }
+
+  const orderedNames = orderedSchemaPropertyNames(rawProperties, required)
+  const propertyNames = orderedNames.slice(0, INPUT_SUMMARY_MAX_PROPERTIES)
+  let truncated = orderedNames.length > propertyNames.length
+  let summary = buildInputSummary({ required, rawProperties, propertyNames, truncated })
+  while (serializedInputSummaryLength(summary) > INPUT_SUMMARY_SERIALIZED_LIMIT && propertyNames.length > 0) {
+    propertyNames.pop()
+    truncated = true
+    summary = buildInputSummary({ required, rawProperties, propertyNames, truncated })
+  }
+  return summary
+}
+
+function canonicalizeJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map((item) => canonicalizeJson(item))
+  if (!isRecord(value)) return value
+  const canonical: Record<string, unknown> = {}
+  for (const key of Object.keys(value).sort()) {
+    canonical[key] = canonicalizeJson(value[key])
+  }
+  return canonical
+}
+
+export function externalMcpInputSchemaHash(inputSchema: unknown): string {
+  return createHash("sha256")
+    .update(JSON.stringify(canonicalizeJson(inputSchema)) ?? "undefined")
+    .digest("hex")
+    .slice(0, 12)
 }
 
 function cappedErrorMessage(message: string): string {
@@ -639,6 +778,8 @@ async function probeExternalMcpConnection(input: {
       pathParams: [],
       queryParams: [],
       hasBody: true,
+      inputSummary: summarizeExternalMcpInputSchema(tool.inputSchema),
+      schemaHash: externalMcpInputSchemaHash(tool.inputSchema),
     })
   }
   return matches
@@ -695,12 +836,14 @@ export type ExternalCapabilityExecuteResult =
   | { ok: true; result: Awaited<ReturnType<typeof callExternalMcpTool>> }
   | {
       ok: false
-      error: "unknown_capability" | "forbidden" | "connection_not_connected" | "needs_connection" | "connection_failed" | "provider_error"
+      error: "unknown_capability" | "forbidden" | "connection_not_connected" | "needs_connection" | "connection_failed" | "provider_error" | "missing_required_arguments"
       message: string
       diagnostic?: ExternalMcpDiagnostic
       actionOwner?: ExternalMcpDiagnostic["actionOwner"]
       operatorAction?: string
       connectionStatus?: ExternalConnectionStatus
+      inputSummary?: ExternalCapabilityInputSummary
+      schemaHash?: string
     }
 
 /**
@@ -787,6 +930,29 @@ export async function executeExternalCapability(input: {
       error: "connection_not_connected",
       message,
       connectionStatus: buildExternalConnectionStatus({ connection, state: "needs_connection", errorCode: "not_connected", message }),
+    }
+  }
+
+  if (Object.keys(input.args).length === 0) {
+    try {
+      const tools = await listExternalMcpTools(
+        connection,
+        redirectUriFor(input.redirectUriBase, connection.id),
+        member,
+      )
+      const tool = tools.find((candidate) => candidate.name === input.toolName)
+      const required = tool ? schemaRequiredNames(tool.inputSchema) : []
+      if (tool && required.length > 0) {
+        return {
+          ok: false,
+          error: "missing_required_arguments",
+          message: `Missing required arguments for "${input.toolName}": ${required.join(", ")}. Retry with these fields in the execute_capability body.`,
+          inputSummary: summarizeExternalMcpInputSchema(tool.inputSchema),
+          schemaHash: externalMcpInputSchemaHash(tool.inputSchema),
+        }
+      }
+    } catch {
+      // Best-effort guard: if discovery fails here, fall through to the normal execute path.
     }
   }
 

--- a/ee/apps/den-api/test/external-capabilities-input-schema.test.ts
+++ b/ee/apps/den-api/test/external-capabilities-input-schema.test.ts
@@ -1,0 +1,261 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, beforeEach, expect, mock, test } from "bun:test"
+import type { ExternalMcpConnectionRow } from "../src/capability-sources/external-mcp-connections.js"
+import type { McpMemberIdentity } from "../src/mcp/external-capabilities.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_inputschema"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "local-dev-secret-not-for-production-use!!"
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+seedRequiredEnv()
+
+const redirectUriBase = "http://127.0.0.1:8790"
+const longDescription = "Long incident field description. ".repeat(8)
+const enumValues = Array.from({ length: 12 }, (_, index) => `value-${index}`)
+
+type FakeTool = {
+  name: string
+  title?: string
+  description?: string
+  inputSchema: unknown
+}
+
+let currentConnection = connectionFixture()
+let currentTools: FakeTool[] = []
+const listExternalMcpToolsMock = mock(async () => currentTools)
+const callExternalMcpToolMock = mock(async () => ({ content: [{ type: "text", text: "provider called" }] }))
+const getExternalMcpConnectionMock = mock(async () => currentConnection)
+const listUsableExternalMcpConnectionsMock = mock(async () => [currentConnection])
+const memberCanUseExternalMcpConnectionMock = mock(async () => true)
+const getConnectedAccountMock = mock(async () => null)
+const listTeamsForMemberMock = mock(async () => [])
+
+let searchExternalCapabilities: typeof import("../src/mcp/external-capabilities.js").searchExternalCapabilities
+let executeExternalCapability: typeof import("../src/mcp/external-capabilities.js").executeExternalCapability
+let externalMcpInputSchemaHash: typeof import("../src/mcp/external-capabilities.js").externalMcpInputSchemaHash
+
+function connectionFixture(): ExternalMcpConnectionRow {
+  const now = new Date()
+  return {
+    id: createDenTypeId("externalMcpConnection"),
+    organizationId: createDenTypeId("organization"),
+    name: "ServiceNow",
+    url: "https://servicenow.example.test/mcp",
+    authType: "none",
+    credentialMode: "shared",
+    apiKey: null,
+    accessToken: null,
+    refreshToken: null,
+    tokenType: null,
+    scope: null,
+    expiresAt: null,
+    pendingCodeVerifier: null,
+    connectedAt: null,
+    createdByOrgMembershipId: createDenTypeId("member"),
+    createdAt: now,
+    updatedAt: now,
+  }
+}
+
+function memberIdentity(): McpMemberIdentity {
+  return { orgMembershipId: createDenTypeId("member"), teamIds: [] }
+}
+
+function requiredIncidentSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    required: ["incident_number"],
+    properties: {
+      incident_number: { type: "string", description: "Incident number" },
+    },
+  }
+}
+
+function optionalPingSchema(): Record<string, unknown> {
+  return {
+    type: "object",
+    properties: {
+      optional_note: { type: "string", description: "Optional note" },
+    },
+  }
+}
+
+function manyPropertySchema(): Record<string, unknown> {
+  const properties: Record<string, unknown> = {}
+  for (let index = 0; index < 30; index += 1) {
+    const name = `field_${String(index).padStart(2, "0")}`
+    properties[name] = index === 0
+      ? { type: "string", description: longDescription, enum: enumValues }
+      : { type: "string" }
+  }
+  return {
+    type: "object",
+    required: ["field_00", "field_01"],
+    properties,
+  }
+}
+
+function createExternalMcpLifecycleDeadline() {
+  const controller = new AbortController()
+  return {
+    expiresAt: Date.now() + 45_000,
+    signal: controller.signal,
+    abort: (reason?: unknown) => controller.abort(reason),
+  }
+}
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.restore()
+  mock.module("../src/db.js", () => ({ db: {} }))
+  mock.module("../src/orgs.js", () => ({ listTeamsForMember: listTeamsForMemberMock }))
+  mock.module("../src/capability-sources/oauth-credentials.js", () => ({ getConnectedAccount: getConnectedAccountMock }))
+  mock.module("../src/capability-sources/external-mcp-client.js", () => ({ createExternalMcpLifecycleDeadline }))
+  mock.module("../src/capability-sources/external-mcp-client-runtime.js", () => ({
+    callExternalMcpTool: callExternalMcpToolMock,
+    listExternalMcpTools: listExternalMcpToolsMock,
+  }))
+  mock.module("../src/capability-sources/external-mcp-connections.js", () => ({
+    getExternalMcpConnection: getExternalMcpConnectionMock,
+    listUsableExternalMcpConnections: listUsableExternalMcpConnectionsMock,
+    memberCanUseExternalMcpConnection: memberCanUseExternalMcpConnectionMock,
+  }))
+  const capabilitiesMod = await import("../src/mcp/external-capabilities.js")
+  searchExternalCapabilities = capabilitiesMod.searchExternalCapabilities
+  executeExternalCapability = capabilitiesMod.executeExternalCapability
+  externalMcpInputSchemaHash = capabilitiesMod.externalMcpInputSchemaHash
+})
+
+beforeEach(() => {
+  currentConnection = connectionFixture()
+  currentTools = []
+  listExternalMcpToolsMock.mockClear()
+  listExternalMcpToolsMock.mockImplementation(async () => currentTools)
+  callExternalMcpToolMock.mockClear()
+  callExternalMcpToolMock.mockImplementation(async () => ({ content: [{ type: "text", text: "provider called" }] }))
+  getExternalMcpConnectionMock.mockClear()
+  getExternalMcpConnectionMock.mockImplementation(async () => currentConnection)
+  listUsableExternalMcpConnectionsMock.mockClear()
+  listUsableExternalMcpConnectionsMock.mockImplementation(async () => [currentConnection])
+  memberCanUseExternalMcpConnectionMock.mockClear()
+  memberCanUseExternalMcpConnectionMock.mockImplementation(async () => true)
+  getConnectedAccountMock.mockClear()
+  listTeamsForMemberMock.mockClear()
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+test("external MCP search includes a bounded inputSummary", async () => {
+  const schema = manyPropertySchema()
+  currentTools = [{ name: "wide_incident_search", description: "Search incidents with a wide schema.", inputSchema: schema }]
+
+  const matches = await searchExternalCapabilities({
+    organizationId: currentConnection.organizationId,
+    member: memberIdentity(),
+    query: "wide incident",
+    redirectUriBase,
+    limit: 10,
+  })
+  const match = matches.find((candidate) => candidate.name === `mcp:${currentConnection.id}:wide_incident_search`)
+  if (!match?.inputSummary) throw new Error("wide_incident_search match did not include inputSummary")
+
+  expect(Object.keys(match.inputSummary.properties)).toHaveLength(24)
+  expect(match.inputSummary.truncated).toBe(true)
+  expect(match.inputSummary.properties.field_00?.description).toBe(longDescription.slice(0, 120))
+  expect(match.inputSummary.properties.field_00?.enum).toEqual(enumValues.slice(0, 8))
+  expect(match.inputSummary.properties.field_24).toBeUndefined()
+  expect(match.schemaHash).toBe(externalMcpInputSchemaHash(schema))
+  expect(listExternalMcpToolsMock.mock.calls).toHaveLength(1)
+})
+
+test("schemaHash is stable across key order and changes when schema changes", () => {
+  const schemaA = {
+    type: "object",
+    required: ["incident_number"],
+    properties: {
+      incident_number: { type: "string", description: "Incident number" },
+      limit: { type: "integer" },
+    },
+  }
+  const schemaB = {
+    properties: {
+      limit: { type: "integer" },
+      incident_number: { description: "Incident number", type: "string" },
+    },
+    required: ["incident_number"],
+    type: "object",
+  }
+  const schemaC = {
+    type: "object",
+    required: ["incident_number"],
+    properties: {
+      incident_number: { type: "string", description: "Changed" },
+      limit: { type: "integer" },
+    },
+  }
+
+  expect(externalMcpInputSchemaHash(schemaA)).toBe(externalMcpInputSchemaHash(schemaB))
+  expect(externalMcpInputSchemaHash(schemaA)).not.toBe(externalMcpInputSchemaHash(schemaC))
+})
+
+test("empty execute args for a required-input tool returns missing_required_arguments without calling the provider tool", async () => {
+  currentTools = [{ name: "lookup_incident", description: "Lookup an incident.", inputSchema: requiredIncidentSchema() }]
+
+  const result = await executeExternalCapability({
+    organizationId: currentConnection.organizationId,
+    member: memberIdentity(),
+    connectionId: currentConnection.id,
+    toolName: "lookup_incident",
+    args: {},
+    redirectUriBase,
+  })
+
+  expect(result.ok).toBe(false)
+  if (result.ok) throw new Error("Required-input tool unexpectedly executed")
+  expect(result.error).toBe("missing_required_arguments")
+  expect(result.message).toContain("incident_number")
+  expect(result.inputSummary?.required).toEqual(["incident_number"])
+  expect(result.schemaHash).toBe(externalMcpInputSchemaHash(requiredIncidentSchema()))
+  expect(listExternalMcpToolsMock.mock.calls).toHaveLength(1)
+  expect(callExternalMcpToolMock.mock.calls).toHaveLength(0)
+})
+
+test("empty execute args for a tool with no required fields calls the provider normally", async () => {
+  currentTools = [{ name: "ping_without_args", description: "Ping without args.", inputSchema: optionalPingSchema() }]
+
+  const result = await executeExternalCapability({
+    organizationId: currentConnection.organizationId,
+    member: memberIdentity(),
+    connectionId: currentConnection.id,
+    toolName: "ping_without_args",
+    args: {},
+    redirectUriBase,
+  })
+
+  expect(result.ok).toBe(true)
+  expect(listExternalMcpToolsMock.mock.calls).toHaveLength(1)
+  expect(callExternalMcpToolMock.mock.calls).toHaveLength(1)
+})
+
+test("non-empty execute args skip the tools/list pre-check", async () => {
+  currentTools = [{ name: "lookup_incident", description: "Lookup an incident.", inputSchema: requiredIncidentSchema() }]
+
+  const result = await executeExternalCapability({
+    organizationId: currentConnection.organizationId,
+    member: memberIdentity(),
+    connectionId: currentConnection.id,
+    toolName: "lookup_incident",
+    args: { incident_number: "INC001" },
+    redirectUriBase,
+  })
+
+  expect(result.ok).toBe(true)
+  expect(listExternalMcpToolsMock.mock.calls).toHaveLength(0)
+  expect(callExternalMcpToolMock.mock.calls).toHaveLength(1)
+})


### PR DESCRIPTION
## Summary

`search_capabilities` on `/mcp/agent` returned external MCP tool matches with `pathParams: [], queryParams: [], hasBody: true` — the live `inputSchema` (which `listExternalMcpTools` already fetches, and which the admin route `/v1/mcp-connections/:id/tools` already returns) was discarded. The calling model had to guess tool arguments, producing empty/garbage payload calls at providers (the `SyntaxError: Empty JSON string` class of failures seen in an enterprise ServiceNow debugging session).

## What changed

- **`inputSummary` on external tool matches** (`searchExternalCapabilities`): a bounded rendering of the tool's JSON schema — `{ required, properties: { name: { type, description, enum } }, truncated? }`:
  - caps: 24 properties (required-first, rest alphabetical), 120-char descriptions, 8 enum values, ~1.5KB serialized total (shrinks property list until under budget); `truncated: true` whenever anything was cut;
  - shallow rendering: nested objects → `"object"`, arrays → `"array<primitive>"`/`"array"`; defensive parsing with type guards throughout.
- **`schemaHash`**: sha256 of the recursively key-sorted schema JSON, first 12 hex chars — detects provider schema drift between search and execute.
- **Execute guard**: `executeExternalCapability` with an **empty** args object now pre-checks the live tool schema; if the tool declares non-empty `required`, it returns a structured `missing_required_arguments` error naming the fields and carrying `inputSummary` + `schemaHash` instead of forwarding an empty payload to the provider. The pre-check is best-effort (discovery failure falls through to the normal call path) and is skipped entirely when args are non-empty — zero added latency on the happy path.
- `search_capabilities` tool description mentions `inputSummary`.

## Testing

- `pnpm --filter @openwork-ee/den-api exec bun test test/external-capabilities-input-schema.test.ts` — **5 pass** (summary bounding + truncation flag, hash stability across key order, empty-args refusal with required fields and no provider call, empty-args passthrough when nothing required, non-empty args skip the pre-check).
- `pnpm --filter @openwork-ee/den-api exec bun test test/external-capabilities-search-divergence.test.ts` — **17 pass, 0 fail** (unchanged behavior preserved).
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` — clean.
- Results reproduced independently by a second run after implementation.

No video/fraimz attached: Den API/MCP surface change covered by the unit tests above. Reviewer repro: connect any external MCP whose tool declares required fields, run `search_capabilities` (observe `inputSummary`/`schemaHash` on the match), then `execute_capability` with an empty body (observe `missing_required_arguments` naming the fields, provider untouched).

## Notes

- Complements the manual tool runner (#2752) and the diagnostics ledger (#2674): search now tells agents *how* to call a tool, and Den refuses calls it knows cannot be constructed.
- Additive optional fields on `ExternalCapabilityMatch`/`ExternalCapabilityExecuteResult`; no change to REST catalog matches.
