### PR TITLE
feat(mcp): add tool call inspector

### DIFF
--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
@@ -23,8 +23,8 @@ import {
   type ExternalMcpDiagnosticPhase,
 } from "./external-mcp-diagnostics.js"
 import {
-  attachExternalMcpToolCallInspection,
-  ExternalMcpToolCallInspector,
+  withExternalMcpToolCallInspection,
+  type ExternalMcpToolCallInspector,
 } from "./external-mcp-tool-inspection.js"
 
 function toEnterpriseConnection(
@@ -307,13 +307,6 @@ export function callExternalMcpTool(input: ExternalMcpToolCallInput) {
   return runExternalMcpToolCall(input)
 }
 
-export async function inspectExternalMcpToolCall(input: ExternalMcpToolCallInput) {
-  const inspector = new ExternalMcpToolCallInspector()
-  try {
-    const result = await runExternalMcpToolCall(input, inspector)
-    return { result, inspection: inspector.snapshot() }
-  } catch (error) {
-    attachExternalMcpToolCallInspection(error, inspector.snapshot())
-    throw error
-  }
+export function inspectExternalMcpToolCall(input: ExternalMcpToolCallInput) {
+  return withExternalMcpToolCallInspection((inspector) => runExternalMcpToolCall(input, inspector))
 }

--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
@@ -22,6 +22,10 @@ import {
   providerToolDiagnosticError,
   type ExternalMcpDiagnosticPhase,
 } from "./external-mcp-diagnostics.js"
+import {
+  attachExternalMcpToolCallInspection,
+  ExternalMcpToolCallInspector,
+} from "./external-mcp-tool-inspection.js"
 
 function toEnterpriseConnection(
   connection: ExternalMcpConnectionRow,
@@ -155,16 +159,20 @@ function createOperationClient(input: {
   connection: ExternalMcpConnectionRow
   diagnosticReferenceId?: string
   lifecycleDeadline?: ExternalMcpLifecycleDeadline
+  toolCallInspector?: ExternalMcpToolCallInspector
 }): { client: EnterpriseMcpClient; tracker: ExternalMcpDiagnosticTracker } {
   const tracker = new ExternalMcpDiagnosticTracker(input.diagnosticReferenceId ?? randomUUID(), {
     authType: input.connection.authType,
     credentialMode: input.connection.credentialMode,
   })
-  const observedFetch = createExternalMcpDiagnosticFetch({
+  const diagnosticFetch = createExternalMcpDiagnosticFetch({
     fetch: guardedFetch,
     endpoint: input.connection.url,
     tracker,
   })
+  const observedFetch = input.toolCallInspector
+    ? input.toolCallInspector.observeFetch(diagnosticFetch)
+    : diagnosticFetch
   return {
     tracker,
     client: createEnterpriseMcpClient({
@@ -184,6 +192,7 @@ async function runEnterpriseMcpOperation<T>(input: {
   connection: ExternalMcpConnectionRow
   diagnosticReferenceId?: string
   lifecycleDeadline?: ExternalMcpLifecycleDeadline
+  toolCallInspector?: ExternalMcpToolCallInspector
   operation: (client: EnterpriseMcpClient) => Promise<T>
 }): Promise<T> {
   const { client, tracker } = createOperationClient(input)
@@ -268,17 +277,23 @@ export async function listExternalMcpTools(
   })
 }
 
-export async function callExternalMcpTool(input: {
+type ExternalMcpToolCallInput = {
   connection: ExternalMcpConnectionRow
   redirectUri: string
   toolName: string
   args: Record<string, unknown>
   member?: ExternalMcpMemberContext
   diagnosticReferenceId?: string
-}) {
+}
+
+function runExternalMcpToolCall(
+  input: ExternalMcpToolCallInput,
+  toolCallInspector?: ExternalMcpToolCallInspector,
+) {
   return runEnterpriseMcpOperation({
     connection: input.connection,
     diagnosticReferenceId: input.diagnosticReferenceId,
+    toolCallInspector,
     operation: (client) => client.callTool({
       connection: toEnterpriseConnection(input.connection, input.member),
       redirectUri: input.redirectUri,
@@ -286,4 +301,19 @@ export async function callExternalMcpTool(input: {
       arguments: input.args,
     }),
   })
+}
+
+export function callExternalMcpTool(input: ExternalMcpToolCallInput) {
+  return runExternalMcpToolCall(input)
+}
+
+export async function inspectExternalMcpToolCall(input: ExternalMcpToolCallInput) {
+  const inspector = new ExternalMcpToolCallInspector()
+  try {
+    const result = await runExternalMcpToolCall(input, inspector)
+    return { result, inspection: inspector.snapshot() }
+  } catch (error) {
+    attachExternalMcpToolCallInspection(error, inspector.snapshot())
+    throw error
+  }
 }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-client-runtime.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-client-runtime.ts
@@ -3,6 +3,7 @@ import {
   callExternalMcpTool as callWithCurrentClient,
   completeExternalMcpAuth as completeWithCurrentClient,
   connectExternalMcp as connectWithCurrentClient,
+  inspectExternalMcpToolCall as inspectWithCurrentClient,
   listExternalMcpTools as listWithCurrentClient,
 } from "./external-mcp-client.js"
 import {
@@ -10,6 +11,7 @@ import {
   callExternalMcpTool as callWithEnterpriseClient,
   completeExternalMcpAuth as completeWithEnterpriseClient,
   connectExternalMcp as connectWithEnterpriseClient,
+  inspectExternalMcpToolCall as inspectWithEnterpriseClient,
   listExternalMcpTools as listWithEnterpriseClient,
 } from "./enterprise-mcp-client-adapter.js"
 
@@ -21,6 +23,7 @@ export type ExternalMcpClientRuntime = {
   abandonExternalMcpAuth: typeof abandonWithEnterpriseClient
   listExternalMcpTools: typeof listWithCurrentClient
   callExternalMcpTool: typeof callWithCurrentClient
+  inspectExternalMcpToolCall: typeof inspectWithCurrentClient
 }
 
 const currentDenMcpClient: ExternalMcpClientRuntime = {
@@ -31,6 +34,7 @@ const currentDenMcpClient: ExternalMcpClientRuntime = {
   abandonExternalMcpAuth: async () => undefined,
   listExternalMcpTools: listWithCurrentClient,
   callExternalMcpTool: callWithCurrentClient,
+  inspectExternalMcpToolCall: inspectWithCurrentClient,
 }
 
 const enterpriseMcpClient: ExternalMcpClientRuntime = {
@@ -39,6 +43,7 @@ const enterpriseMcpClient: ExternalMcpClientRuntime = {
   abandonExternalMcpAuth: abandonWithEnterpriseClient,
   listExternalMcpTools: listWithEnterpriseClient,
   callExternalMcpTool: callWithEnterpriseClient,
+  inspectExternalMcpToolCall: inspectWithEnterpriseClient,
 }
 
 export function selectExternalMcpClientRuntime(input: {
@@ -65,4 +70,5 @@ export const {
   abandonExternalMcpAuth,
   listExternalMcpTools,
   callExternalMcpTool,
+  inspectExternalMcpToolCall,
 } = selectedRuntime

--- a/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
@@ -36,6 +36,10 @@ import {
   lifecycleDeadlineDiagnosticError,
   providerToolDiagnosticError,
 } from "./external-mcp-diagnostics.js"
+import {
+  attachExternalMcpToolCallInspection,
+  ExternalMcpToolCallInspector,
+} from "./external-mcp-tool-inspection.js"
 
 /**
  * Real MCP client for "add any MCP server" (External MCP Connections) —
@@ -430,6 +434,7 @@ function buildTransport(
   member?: ExternalMcpMemberContext,
   diagnosticReferenceId?: string,
   lifecycleDeadline?: ExternalMcpLifecycleDeadline,
+  toolCallInspector?: ExternalMcpToolCallInspector,
 ) {
   const diagnostic = new ExternalMcpDiagnosticTracker(diagnosticReferenceId ?? randomUUID(), {
     authType: connection.authType,
@@ -442,13 +447,14 @@ function buildTransport(
   const lifecycleFetch = lifecycleDeadline
     ? bindExternalMcpFetchToLifecycle(guardedFetch, lifecycleDeadline, diagnostic)
     : guardedFetch
+  const diagnosticFetch = createExternalMcpDiagnosticFetch({ fetch: lifecycleFetch, endpoint: connection.url, tracker: diagnostic })
   const transport = new StreamableHTTPClientTransport(new URL(connection.url), {
     authProvider: provider,
     // SSRF guard: every outbound request (the MCP endpoint itself, but also
     // discovery documents and token endpoints the SDK follows to OTHER
     // hosts) is checked against private/reserved address ranges at request
     // time. Hosted-deployment protection; self-hosted/dev opt out via env.
-    fetch: createExternalMcpDiagnosticFetch({ fetch: lifecycleFetch, endpoint: connection.url, tracker: diagnostic }),
+    fetch: toolCallInspector ? toolCallInspector.observeFetch(diagnosticFetch) : diagnosticFetch,
     requestInit: connection.authType === "apikey" && connection.apiKey
       ? { headers: { authorization: `Bearer ${connection.apiKey}` } }
       : undefined,
@@ -911,14 +917,19 @@ export async function listExternalMcpTools(
   }
 }
 
-export async function callExternalMcpTool(input: {
+type ExternalMcpToolCallInput = {
   connection: ExternalMcpConnectionRow
   redirectUri: string
   toolName: string
   args: Record<string, unknown>
   member?: ExternalMcpMemberContext
   diagnosticReferenceId?: string
-}) {
+}
+
+async function runExternalMcpToolCall(
+  input: ExternalMcpToolCallInput,
+  toolCallInspector?: ExternalMcpToolCallInspector,
+) {
   const client = buildClient()
   const deadline = createExternalMcpLifecycleDeadline(EXTERNAL_MCP_TOOL_LIFECYCLE_TIMEOUT_MS)
   const { transport, diagnostic } = buildTransport(
@@ -928,6 +939,7 @@ export async function callExternalMcpTool(input: {
     input.member,
     input.diagnosticReferenceId,
     deadline,
+    toolCallInspector,
   )
   let operationError: unknown
   try {
@@ -960,5 +972,20 @@ export async function callExternalMcpTool(input: {
     } catch (error) {
       if (!operationError) throw diagnostic.error(error, "SHUTDOWN")
     }
+  }
+}
+
+export function callExternalMcpTool(input: ExternalMcpToolCallInput) {
+  return runExternalMcpToolCall(input)
+}
+
+export async function inspectExternalMcpToolCall(input: ExternalMcpToolCallInput) {
+  const inspector = new ExternalMcpToolCallInspector()
+  try {
+    const result = await runExternalMcpToolCall(input, inspector)
+    return { result, inspection: inspector.snapshot() }
+  } catch (error) {
+    attachExternalMcpToolCallInspection(error, inspector.snapshot())
+    throw error
   }
 }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
@@ -37,8 +37,8 @@ import {
   providerToolDiagnosticError,
 } from "./external-mcp-diagnostics.js"
 import {
-  attachExternalMcpToolCallInspection,
-  ExternalMcpToolCallInspector,
+  withExternalMcpToolCallInspection,
+  type ExternalMcpToolCallInspector,
 } from "./external-mcp-tool-inspection.js"
 
 /**
@@ -979,13 +979,6 @@ export function callExternalMcpTool(input: ExternalMcpToolCallInput) {
   return runExternalMcpToolCall(input)
 }
 
-export async function inspectExternalMcpToolCall(input: ExternalMcpToolCallInput) {
-  const inspector = new ExternalMcpToolCallInspector()
-  try {
-    const result = await runExternalMcpToolCall(input, inspector)
-    return { result, inspection: inspector.snapshot() }
-  } catch (error) {
-    attachExternalMcpToolCallInspection(error, inspector.snapshot())
-    throw error
-  }
+export function inspectExternalMcpToolCall(input: ExternalMcpToolCallInput) {
+  return withExternalMcpToolCallInspection((inspector) => runExternalMcpToolCall(input, inspector))
 }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-tool-inspection.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-tool-inspection.ts
@@ -2,6 +2,10 @@ import { Buffer } from "node:buffer"
 import type { ExternalMcpDiagnostic } from "./external-mcp-diagnostics.js"
 
 const INSPECTION_BODY_LIMIT_BYTES = 512 * 1024
+// How long snapshotting waits for a response body that the remote has not
+// finished sending. A stream the server holds open must not delay returning
+// the inspection after the tool call itself has settled.
+const INSPECTION_BODY_SETTLE_TIMEOUT_MS = 1_000
 const REDACTED_VALUE = "[redacted]"
 
 type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>
@@ -93,19 +97,25 @@ function isSecretHeader(name: string): boolean {
     || normalized === "proxy-authorization"
     || normalized === "cookie"
     || normalized === "set-cookie"
-    || normalized === "mcp-session-id"
+    || normalized === "dpop"
     || normalized === "last-event-id"
-    || normalized === "x-api-key"
-    || normalized === "x-auth-token"
-    || normalized.includes("access-token")
-    || normalized.includes("refresh-token")
-    || normalized.includes("client-secret")
+    || normalized.endsWith("-key")
+    || normalized.includes("api-key")
+    || normalized.includes("apikey")
+    || normalized.includes("access-key")
+    || normalized.includes("private-key")
+    || normalized.includes("credential")
+    || normalized.includes("password")
+    || normalized.includes("session")
+    || normalized.includes("signature")
+    || normalized.includes("token")
+    || normalized.includes("secret")
 }
 
 function redactedHeaderValue(name: string, value: string): string {
   if (name.toLowerCase() !== "authorization") return REDACTED_VALUE
-  const scheme = value.trim().split(/\s+/, 1)[0]
-  return scheme ? `${scheme} ${REDACTED_VALUE}` : REDACTED_VALUE
+  const match = /^([A-Za-z][A-Za-z0-9+.-]*)\s+.+$/.exec(value.trim())
+  return match ? `${match[1]} ${REDACTED_VALUE}` : REDACTED_VALUE
 }
 
 function inspectionHeaders(rawHeaders?: HeadersInit): ExternalMcpInspectionHeader[] {
@@ -140,17 +150,93 @@ function requestBody(init?: RequestInit): ExternalMcpInspectionBody {
   return { text: "", bytes: 0, truncated: false, unavailable: init?.body !== undefined }
 }
 
-async function responseBody(response: Response): Promise<ExternalMcpInspectionBody> {
+type ResponseBodyCapture = {
+  settle: () => Promise<ExternalMcpInspectionBody>
+}
+
+const UNAVAILABLE_BODY: ExternalMcpInspectionBody = { text: "", bytes: 0, truncated: false, unavailable: true }
+
+/**
+ * Captures a bounded copy of the response body without consuming or delaying
+ * the stream the MCP transport reads. The capture must never change the
+ * behavior it observes: the transport receives the response immediately, the
+ * copy stops pulling at the inspection cap, and settle() abandons a stream
+ * the remote is still holding open instead of waiting for it to end.
+ */
+function captureBoundedResponseBody(response: Response): ResponseBodyCapture {
+  let stream: ReadableStream<Uint8Array> | null
   try {
-    return boundedBody(await response.clone().text())
+    stream = response.clone().body
   } catch {
-    return { text: "", bytes: 0, truncated: false, unavailable: true }
+    return { settle: async () => UNAVAILABLE_BODY }
+  }
+  if (!stream) return { settle: async () => ({ text: "", bytes: 0, truncated: false }) }
+
+  const reader = stream.getReader()
+  const decoder = new TextDecoder("utf-8", { fatal: false })
+  let text = ""
+  let observedBytes = 0
+  let capturedBytes = 0
+  let ended = false
+  let errored = false
+
+  const reading = (async () => {
+    try {
+      while (true) {
+        const next = await reader.read()
+        if (next.done) {
+          ended = true
+          return
+        }
+        observedBytes += next.value.byteLength
+        const remaining = INSPECTION_BODY_LIMIT_BYTES - capturedBytes
+        const slice = next.value.byteLength > remaining ? next.value.subarray(0, Math.max(0, remaining)) : next.value
+        text += decoder.decode(slice, { stream: true })
+        capturedBytes += slice.byteLength
+        if (observedBytes > capturedBytes) {
+          ended = true
+          // Do not await: a cloned branch's cancel promise resolves only when
+          // the transport's branch is also done with the stream.
+          reader.cancel().catch(() => undefined)
+          return
+        }
+      }
+    } catch {
+      errored = true
+    }
+  })()
+
+  let settled: Promise<ExternalMcpInspectionBody> | null = null
+  return {
+    settle: () => {
+      settled ??= (async () => {
+        let timer: ReturnType<typeof setTimeout> | undefined
+        await Promise.race([
+          reading,
+          new Promise<void>((resolve) => {
+            timer = setTimeout(resolve, INSPECTION_BODY_SETTLE_TIMEOUT_MS)
+          }),
+        ])
+        if (timer !== undefined) clearTimeout(timer)
+        if (!ended && !errored) reader.cancel().catch(() => undefined)
+        if (errored && capturedBytes === 0) return UNAVAILABLE_BODY
+        return {
+          text: text + decoder.decode(),
+          bytes: observedBytes,
+          // The capture is incomplete when bytes exceeded the cap or the
+          // cloned stream never reached EOF before settle stopped waiting.
+          truncated: observedBytes > capturedBytes || !ended,
+        }
+      })()
+      return settled
+    },
   }
 }
 
 export class ExternalMcpToolCallInspector {
   private request?: ExternalMcpInspectionRequest
   private response?: ExternalMcpInspectionResponse
+  private responseBodyCapture?: { capture: ResponseBodyCapture; target: ExternalMcpInspectionResponse }
 
   observeFetch(fetchImpl: FetchLike): FetchLike {
     return async (url, init) => {
@@ -164,16 +250,34 @@ export class ExternalMcpToolCallInspector {
         headers: inspectionHeaders(init?.headers),
         body: requestBody(init),
       }
+      // A retried tools/call must not pair its request with the previous
+      // attempt's response, so the failing attempt is the one displayed.
+      this.response = undefined
+      this.responseBodyCapture = undefined
 
       const response = await fetchImpl(url, init)
-      this.response = {
+      const captured: ExternalMcpInspectionResponse = {
         status: response.status,
         statusText: response.statusText,
         durationMs: Date.now() - startedAtMs,
         headers: inspectionHeaders(response.headers),
-        body: await responseBody(response),
+        body: UNAVAILABLE_BODY,
       }
+      this.response = captured
+      this.responseBodyCapture = { capture: captureBoundedResponseBody(response), target: captured }
       return response
+    }
+  }
+
+  /** Finalize the bounded response-body copy. Call after the tool call settles, before snapshot(). */
+  async settle(): Promise<void> {
+    if (!this.responseBodyCapture) return
+    try {
+      this.responseBodyCapture.target.body = await this.responseBodyCapture.capture.settle()
+    } catch {
+      // Inspection is diagnostic-only and must never change the tool call's
+      // success or preserve a provider failure as a different local error.
+      this.responseBodyCapture.target.body = UNAVAILABLE_BODY
     }
   }
 
@@ -182,6 +286,26 @@ export class ExternalMcpToolCallInspector {
       ...(this.request ? { request: this.request } : {}),
       ...(this.response ? { response: this.response } : {}),
     }
+  }
+}
+
+/**
+ * Shared inspect wrapper for the current and enterprise client entry points:
+ * run the tool call with a fresh inspector, settle the bounded body capture,
+ * and either return or attach the wire snapshot alongside the outcome.
+ */
+export async function withExternalMcpToolCallInspection<T>(
+  run: (inspector: ExternalMcpToolCallInspector) => Promise<T>,
+): Promise<{ result: T; inspection: ExternalMcpToolCallWireInspection }> {
+  const inspector = new ExternalMcpToolCallInspector()
+  try {
+    const result = await run(inspector)
+    await inspector.settle()
+    return { result, inspection: inspector.snapshot() }
+  } catch (error) {
+    await inspector.settle()
+    attachExternalMcpToolCallInspection(error, inspector.snapshot())
+    throw error
   }
 }
 
@@ -200,7 +324,7 @@ export function externalMcpToolCallInspectionForError(error: unknown): ExternalM
 export function diagnoseExternalMcpToolCall(input: {
   inspection: ExternalMcpToolCallWireInspection
   succeeded: boolean
-  diagnostic?: Pick<ExternalMcpDiagnostic, "phase">
+  diagnostic?: Pick<ExternalMcpDiagnostic, "phase"> & Partial<Pick<ExternalMcpDiagnostic, "category" | "code">>
 }): ExternalMcpToolCallDiagnosis {
   if (input.succeeded) {
     return {
@@ -239,6 +363,27 @@ export function diagnoseExternalMcpToolCall(input: {
     }
   }
   if (!input.inspection.response) {
+    // The inspector records the request before the SSRF guard and lifecycle
+    // deadline run, so "request captured, no response" does not always mean
+    // the request reached the network.
+    if (
+      input.diagnostic?.category === "security_blocked"
+      || input.diagnostic?.code === "MCP_URL_BLOCKED"
+      || input.diagnostic?.code === "MCP_FETCH_FORBIDDEN_PORT"
+    ) {
+      return {
+        status: "failed",
+        layer: "openwork",
+        summary: "OpenWork's outbound network safety policy blocked this tools/call request, so it was not sent to the remote MCP.",
+      }
+    }
+    if (input.diagnostic?.code === "MCP_LIFECYCLE_DEADLINE" || input.diagnostic?.code === "MCP_REQUEST_TIMEOUT") {
+      return {
+        status: "failed",
+        layer: "network",
+        summary: "OpenWork sent tools/call but the remote MCP did not answer before OpenWork stopped waiting at its deadline.",
+      }
+    }
     return {
       status: "failed",
       layer: "network",

--- a/ee/apps/den-api/src/capability-sources/external-mcp-tool-inspection.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-tool-inspection.ts
@@ -1,0 +1,262 @@
+import { Buffer } from "node:buffer"
+import type { ExternalMcpDiagnostic } from "./external-mcp-diagnostics.js"
+
+const INSPECTION_BODY_LIMIT_BYTES = 512 * 1024
+const REDACTED_VALUE = "[redacted]"
+
+type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>
+
+export type ExternalMcpInspectionHeader = {
+  name: string
+  value: string
+  redacted: boolean
+}
+
+export type ExternalMcpInspectionBody = {
+  text: string
+  bytes: number
+  truncated: boolean
+  unavailable?: boolean
+}
+
+export type ExternalMcpInspectionRequest = {
+  method: string
+  url: string
+  startedAt: string
+  headers: ExternalMcpInspectionHeader[]
+  body: ExternalMcpInspectionBody
+}
+
+export type ExternalMcpInspectionResponse = {
+  status: number
+  statusText: string
+  durationMs: number
+  headers: ExternalMcpInspectionHeader[]
+  body: ExternalMcpInspectionBody
+}
+
+export type ExternalMcpToolCallWireInspection = {
+  request?: ExternalMcpInspectionRequest
+  response?: ExternalMcpInspectionResponse
+}
+
+export type ExternalMcpToolCallDiagnosis = {
+  status: "succeeded" | "failed"
+  layer: "openwork" | "network" | "mcp_connection" | "remote_http" | "mcp_tool"
+  summary: string
+}
+
+export type ExternalMcpToolCallInspection = ExternalMcpToolCallWireInspection & {
+  diagnosis: ExternalMcpToolCallDiagnosis
+}
+
+const inspectionByError = new WeakMap<object, ExternalMcpToolCallWireInspection>()
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function requestBodyText(body: BodyInit | null | undefined): string | null {
+  if (typeof body === "string") return body
+  if (body instanceof URLSearchParams) return body.toString()
+  return null
+}
+
+function isToolCallRequest(init?: RequestInit): boolean {
+  const body = requestBodyText(init?.body)
+  if (!body) return false
+  try {
+    const parsed: unknown = JSON.parse(body)
+    return isRecord(parsed) && parsed.method === "tools/call"
+  } catch {
+    return false
+  }
+}
+
+function sanitizedUrl(rawUrl: string | URL): string {
+  try {
+    const url = new URL(String(rawUrl))
+    url.username = ""
+    url.password = ""
+    url.hash = ""
+    const parameterNames = Array.from(new Set(url.searchParams.keys()))
+    for (const name of parameterNames) url.searchParams.set(name, REDACTED_VALUE)
+    return url.toString()
+  } catch {
+    return "unavailable"
+  }
+}
+
+function isSecretHeader(name: string): boolean {
+  const normalized = name.toLowerCase()
+  return normalized === "authorization"
+    || normalized === "proxy-authorization"
+    || normalized === "cookie"
+    || normalized === "set-cookie"
+    || normalized === "mcp-session-id"
+    || normalized === "last-event-id"
+    || normalized === "x-api-key"
+    || normalized === "x-auth-token"
+    || normalized.includes("access-token")
+    || normalized.includes("refresh-token")
+    || normalized.includes("client-secret")
+}
+
+function redactedHeaderValue(name: string, value: string): string {
+  if (name.toLowerCase() !== "authorization") return REDACTED_VALUE
+  const scheme = value.trim().split(/\s+/, 1)[0]
+  return scheme ? `${scheme} ${REDACTED_VALUE}` : REDACTED_VALUE
+}
+
+function inspectionHeaders(rawHeaders?: HeadersInit): ExternalMcpInspectionHeader[] {
+  if (!rawHeaders) return []
+  try {
+    return Array.from(new Headers(rawHeaders).entries()).map(([name, value]) => {
+      const redacted = isSecretHeader(name)
+      return {
+        name,
+        value: redacted ? redactedHeaderValue(name, value) : value,
+        redacted,
+      }
+    })
+  } catch {
+    return []
+  }
+}
+
+function boundedBody(text: string): ExternalMcpInspectionBody {
+  const bytes = Buffer.byteLength(text, "utf8")
+  if (bytes <= INSPECTION_BODY_LIMIT_BYTES) return { text, bytes, truncated: false }
+  return {
+    text: Buffer.from(text, "utf8").subarray(0, INSPECTION_BODY_LIMIT_BYTES).toString("utf8"),
+    bytes,
+    truncated: true,
+  }
+}
+
+function requestBody(init?: RequestInit): ExternalMcpInspectionBody {
+  const text = requestBodyText(init?.body)
+  if (text !== null) return boundedBody(text)
+  return { text: "", bytes: 0, truncated: false, unavailable: init?.body !== undefined }
+}
+
+async function responseBody(response: Response): Promise<ExternalMcpInspectionBody> {
+  try {
+    return boundedBody(await response.clone().text())
+  } catch {
+    return { text: "", bytes: 0, truncated: false, unavailable: true }
+  }
+}
+
+export class ExternalMcpToolCallInspector {
+  private request?: ExternalMcpInspectionRequest
+  private response?: ExternalMcpInspectionResponse
+
+  observeFetch(fetchImpl: FetchLike): FetchLike {
+    return async (url, init) => {
+      if (!isToolCallRequest(init)) return fetchImpl(url, init)
+
+      const startedAtMs = Date.now()
+      this.request = {
+        method: (init?.method ?? "POST").toUpperCase(),
+        url: sanitizedUrl(url),
+        startedAt: new Date(startedAtMs).toISOString(),
+        headers: inspectionHeaders(init?.headers),
+        body: requestBody(init),
+      }
+
+      const response = await fetchImpl(url, init)
+      this.response = {
+        status: response.status,
+        statusText: response.statusText,
+        durationMs: Date.now() - startedAtMs,
+        headers: inspectionHeaders(response.headers),
+        body: await responseBody(response),
+      }
+      return response
+    }
+  }
+
+  snapshot(): ExternalMcpToolCallWireInspection {
+    return {
+      ...(this.request ? { request: this.request } : {}),
+      ...(this.response ? { response: this.response } : {}),
+    }
+  }
+}
+
+export function attachExternalMcpToolCallInspection(
+  error: unknown,
+  inspection: ExternalMcpToolCallWireInspection,
+): void {
+  if (typeof error === "object" && error !== null) inspectionByError.set(error, inspection)
+}
+
+export function externalMcpToolCallInspectionForError(error: unknown): ExternalMcpToolCallWireInspection {
+  if (typeof error !== "object" || error === null) return {}
+  return inspectionByError.get(error) ?? {}
+}
+
+export function diagnoseExternalMcpToolCall(input: {
+  inspection: ExternalMcpToolCallWireInspection
+  succeeded: boolean
+  diagnostic?: Pick<ExternalMcpDiagnostic, "phase">
+}): ExternalMcpToolCallDiagnosis {
+  if (input.succeeded) {
+    return {
+      status: "succeeded",
+      layer: "mcp_tool",
+      summary: "The remote MCP received tools/call and returned a successful tool result.",
+    }
+  }
+  if (!input.inspection.request) {
+    if (input.diagnostic?.phase.startsWith("NETWORK_")) {
+      return {
+        status: "failed",
+        layer: "network",
+        summary: "OpenWork could not reach the remote MCP while preparing the session, so tools/call was not sent.",
+      }
+    }
+    if (
+      input.diagnostic?.phase.startsWith("AUTH_")
+      || input.diagnostic?.phase.startsWith("CONTINUITY_")
+      || input.diagnostic?.phase === "HTTP_ROUTING"
+      || input.diagnostic?.phase === "MCP_TRANSPORT"
+      || input.diagnostic?.phase === "MCP_VERSION"
+      || input.diagnostic?.phase === "MCP_INITIALIZE"
+      || input.diagnostic?.phase === "MCP_INITIALIZED"
+    ) {
+      return {
+        status: "failed",
+        layer: "mcp_connection",
+        summary: "The remote MCP session, authentication, or initialization failed before tools/call could be sent.",
+      }
+    }
+    return {
+      status: "failed",
+      layer: "openwork",
+      summary: "The call failed inside OpenWork before an outbound tools/call request was sent.",
+    }
+  }
+  if (!input.inspection.response) {
+    return {
+      status: "failed",
+      layer: "network",
+      summary: "OpenWork sent tools/call but did not receive an HTTP response from the remote MCP.",
+    }
+  }
+  if (input.inspection.response.status < 200 || input.inspection.response.status >= 300) {
+    return {
+      status: "failed",
+      layer: "remote_http",
+      summary: `The remote MCP returned HTTP ${input.inspection.response.status} before the tool completed.`,
+    }
+  }
+  return {
+    status: "failed",
+    layer: "mcp_tool",
+    summary: input.diagnostic?.phase === "MCP_TOOL_EXECUTION" || input.diagnostic?.phase === "PROVIDER_EXECUTION"
+      ? "The remote MCP answered, but the MCP tool result reported a provider or tool failure."
+      : "The remote MCP answered, but OpenWork could not accept the MCP response as a successful tool result.",
+  }
+}

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -28,9 +28,9 @@ import { emptyResponse, forbiddenSchema, htmlResponse, invalidRequestSchema, jso
 import { createOAuthStateToken, resolvePublicOrigin, verifyOAuthStateToken } from "../../capability-sources/generic-oauth.js"
 import {
   abandonExternalMcpAuth,
-  callExternalMcpTool,
   connectExternalMcp,
   completeExternalMcpAuth,
+  inspectExternalMcpToolCall,
   listExternalMcpTools,
 } from "../../capability-sources/external-mcp-client-runtime.js"
 import {
@@ -64,6 +64,10 @@ import {
   externalMcpOAuthCallbackError,
   safeExternalMcpEndpointForLog,
 } from "../../capability-sources/external-mcp-diagnostics.js"
+import {
+  diagnoseExternalMcpToolCall,
+  externalMcpToolCallInspectionForError,
+} from "../../capability-sources/external-mcp-tool-inspection.js"
 import { resolvePluginArchResourceRole, type PluginArchActorContext } from "./plugin-system/access.js"
 import { ensureOrganizationAdmin, ensureOrganizationAdminRole, idParamSchema, orgAccessFailureStatus } from "./shared.js"
 import type { OrgRouteVariables } from "./shared.js"
@@ -241,10 +245,52 @@ const runConnectionToolBodySchema = z.object({
   arguments: z.record(z.string(), z.unknown()),
 }).meta({ ref: "ExternalMcpConnectionToolRunInput" })
 
+const connectionToolInspectionHeaderSchema = z.object({
+  name: z.string(),
+  value: z.string(),
+  redacted: z.boolean(),
+}).meta({ ref: "ExternalMcpConnectionToolInspectionHeader" })
+
+const connectionToolInspectionBodySchema = z.object({
+  text: z.string(),
+  bytes: z.number().int().nonnegative(),
+  truncated: z.boolean(),
+  unavailable: z.boolean().optional(),
+}).meta({ ref: "ExternalMcpConnectionToolInspectionBody" })
+
+const connectionToolInspectionRequestSchema = z.object({
+  method: z.string(),
+  url: z.string(),
+  startedAt: z.string().datetime(),
+  headers: z.array(connectionToolInspectionHeaderSchema),
+  body: connectionToolInspectionBodySchema,
+}).meta({ ref: "ExternalMcpConnectionToolInspectionRequest" })
+
+const connectionToolInspectionResponseSchema = z.object({
+  status: z.number().int().min(100).max(599),
+  statusText: z.string(),
+  durationMs: z.number().nonnegative(),
+  headers: z.array(connectionToolInspectionHeaderSchema),
+  body: connectionToolInspectionBodySchema,
+}).meta({ ref: "ExternalMcpConnectionToolInspectionResponse" })
+
+const connectionToolInspectionDiagnosisSchema = z.object({
+  status: z.enum(["succeeded", "failed"]),
+  layer: z.enum(["openwork", "network", "mcp_connection", "remote_http", "mcp_tool"]),
+  summary: z.string(),
+}).meta({ ref: "ExternalMcpConnectionToolInspectionDiagnosis" })
+
+const connectionToolInspectionSchema = z.object({
+  request: connectionToolInspectionRequestSchema.optional(),
+  response: connectionToolInspectionResponseSchema.optional(),
+  diagnosis: connectionToolInspectionDiagnosisSchema,
+}).meta({ ref: "ExternalMcpConnectionToolInspection" })
+
 const connectionToolRunResponseSchema = z.object({
   referenceId: z.string(),
   durationMs: z.number().nonnegative(),
   result: z.unknown(),
+  inspection: connectionToolInspectionSchema,
 }).meta({ ref: "ExternalMcpConnectionToolRunResponse" })
 
 const connectionNotReadySchema = z.object({
@@ -346,6 +392,7 @@ const connectionToolRunFailedSchema = z.object({
   error: z.literal("tool_execution_failed"),
   message: z.string(),
   diagnostic: externalMcpDiagnosticSchema,
+  inspection: connectionToolInspectionSchema,
 }).meta({ ref: "ExternalMcpConnectionToolRunFailedError" })
 
 const connectionToolRequestTooLargeSchema = z.object({
@@ -829,7 +876,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
     describeRoute({
       tags: ["Authentication"],
       summary: "Manually run a tool from an External MCP Connection",
-      description: "Workspace owner/admin diagnostic runner. Executes one named MCP tool with caller-supplied JSON arguments using the Den-managed shared credential or the calling admin's connected credential. The caller must already be granted access to the connection. Credentials, arguments, and results are never written to logs.",
+      description: "Workspace owner/admin diagnostic runner. Executes one named MCP tool with caller-supplied JSON arguments using the Den-managed shared credential or the calling admin's connected credential. Returns an ephemeral inspection of the actual tools/call HTTP request and response with credential and session headers redacted. The caller must already be granted access to the connection. Credentials, arguments, results, and inspection payloads are never written to logs.",
       responses: {
         200: jsonResponse("The MCP tool completed.", connectionToolRunResponseSchema),
         400: jsonResponse("Invalid tool name or arguments.", invalidRequestSchema),
@@ -886,7 +933,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
 
       const startedAt = Date.now()
       try {
-        const result = await callExternalMcpTool({
+        const inspected = await inspectExternalMcpToolCall({
           connection,
           redirectUri: callbackRedirectUri(c.req.raw, connectionId),
           toolName,
@@ -902,9 +949,18 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
           duration_ms: durationMs,
           diagnostic_reference_id: c.get("requestId"),
         })
-        return c.json({ referenceId: c.get("requestId"), durationMs, result })
+        return c.json({
+          referenceId: c.get("requestId"),
+          durationMs,
+          result: inspected.result,
+          inspection: {
+            ...inspected.inspection,
+            diagnosis: diagnoseExternalMcpToolCall({ inspection: inspected.inspection, succeeded: true }),
+          },
+        })
       } catch (error) {
         const diagnostic = externalMcpDiagnosticForResponse(error, c.get("requestId"), "MCP_TOOL_EXECUTION")
+        const wireInspection = externalMcpToolCallInspectionForError(error)
         logger.error("external_mcp_manual_tool_failed", {
           connection_id: connection.id,
           organization_id: payload.organization.id,
@@ -916,6 +972,10 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
           error: "tool_execution_failed",
           message: `Could not run "${toolName}" on "${connection.name}": ${diagnostic.message} Reference: ${diagnostic.referenceId}.`,
           diagnostic,
+          inspection: {
+            ...wireInspection,
+            diagnosis: diagnoseExternalMcpToolCall({ inspection: wireInspection, succeeded: false, diagnostic }),
+          },
         }, 502)
       }
     },

--- a/ee/apps/den-api/test/external-mcp-tool-inspection.test.ts
+++ b/ee/apps/den-api/test/external-mcp-tool-inspection.test.ts
@@ -1,0 +1,116 @@
+import { expect, test } from "bun:test"
+import {
+  diagnoseExternalMcpToolCall,
+  ExternalMcpToolCallInspector,
+} from "../src/capability-sources/external-mcp-tool-inspection.js"
+
+test("captures the real tools/call exchange while redacting credentials and query values", async () => {
+  const inspector = new ExternalMcpToolCallInspector()
+  const observedFetch = inspector.observeFetch(async () => new Response(
+    JSON.stringify({ jsonrpc: "2.0", id: 7, result: { content: [{ type: "text", text: "ok" }] } }),
+    {
+      status: 200,
+      headers: {
+        "content-type": "application/json",
+        "mcp-session-id": "provider-session-secret",
+        "x-request-id": "provider-request-123",
+      },
+    },
+  ))
+
+  await observedFetch("https://mcp.example.test/rpc?tenant=private-tenant", {
+    method: "POST",
+    headers: {
+      authorization: "Bearer access-token-secret",
+      "content-type": "application/json",
+      cookie: "session=browser-secret",
+      "mcp-protocol-version": "2025-11-25",
+    },
+    body: JSON.stringify({
+      jsonrpc: "2.0",
+      id: 7,
+      method: "tools/call",
+      params: { name: "search_incidents", arguments: { query: "INC0001" } },
+    }),
+  })
+
+  const inspection = inspector.snapshot()
+  expect(inspection).toMatchObject({
+    request: {
+      method: "POST",
+      url: "https://mcp.example.test/rpc?tenant=%5Bredacted%5D",
+      headers: expect.arrayContaining([
+        { name: "authorization", value: "Bearer [redacted]", redacted: true },
+        { name: "cookie", value: "[redacted]", redacted: true },
+        { name: "mcp-protocol-version", value: "2025-11-25", redacted: false },
+      ]),
+      body: { truncated: false },
+    },
+    response: {
+      status: 200,
+      headers: expect.arrayContaining([
+        { name: "mcp-session-id", value: "[redacted]", redacted: true },
+        { name: "x-request-id", value: "provider-request-123", redacted: false },
+      ]),
+      body: { truncated: false },
+    },
+  })
+  const serialized = JSON.stringify(inspection)
+  expect(serialized).not.toContain("access-token-secret")
+  expect(serialized).not.toContain("browser-secret")
+  expect(serialized).not.toContain("provider-session-secret")
+  expect(inspection.request?.body.text).toContain('"method":"tools/call"')
+  expect(inspection.response?.body.text).toContain('"text":"ok"')
+})
+
+test("ignores lifecycle requests and classifies a tools/call with no response as a network failure", async () => {
+  const inspector = new ExternalMcpToolCallInspector()
+  const observedFetch = inspector.observeFetch(async (_url, init) => {
+    const body = typeof init?.body === "string" ? init.body : ""
+    if (body.includes('"method":"tools/call"')) throw new TypeError("fetch failed")
+    return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }))
+  })
+
+  await observedFetch("https://mcp.example.test/rpc", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "initialize", params: {} }),
+  })
+  expect(inspector.snapshot()).toEqual({})
+
+  await expect(observedFetch("https://mcp.example.test/rpc", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "fail", arguments: {} } }),
+  })).rejects.toThrow("fetch failed")
+
+  const inspection = inspector.snapshot()
+  expect(inspection.request?.body.text).toContain('"method":"tools/call"')
+  expect(inspection.response).toBeUndefined()
+  expect(diagnoseExternalMcpToolCall({ inspection, succeeded: false })).toEqual({
+    status: "failed",
+    layer: "network",
+    summary: "OpenWork sent tools/call but did not receive an HTTP response from the remote MCP.",
+  })
+})
+
+test("distinguishes remote MCP setup failures from OpenWork failures before tools/call", () => {
+  expect(diagnoseExternalMcpToolCall({
+    inspection: {},
+    succeeded: false,
+    diagnostic: { phase: "MCP_INITIALIZE" },
+  })).toEqual({
+    status: "failed",
+    layer: "mcp_connection",
+    summary: "The remote MCP session, authentication, or initialization failed before tools/call could be sent.",
+  })
+  expect(diagnoseExternalMcpToolCall({
+    inspection: {},
+    succeeded: false,
+    diagnostic: { phase: "NETWORK_TCP" },
+  })).toEqual({
+    status: "failed",
+    layer: "network",
+    summary: "OpenWork could not reach the remote MCP while preparing the session, so tools/call was not sent.",
+  })
+})

--- a/ee/apps/den-api/test/external-mcp-tool-inspection.test.ts
+++ b/ee/apps/den-api/test/external-mcp-tool-inspection.test.ts
@@ -11,6 +11,7 @@ test("captures the real tools/call exchange while redacting credentials and quer
     {
       status: 200,
       headers: {
+        authorization: "opaque-response-secret",
         "content-type": "application/json",
         "mcp-session-id": "provider-session-secret",
         "x-request-id": "provider-request-123",
@@ -25,6 +26,9 @@ test("captures the real tools/call exchange while redacting credentials and quer
       "content-type": "application/json",
       cookie: "session=browser-secret",
       "mcp-protocol-version": "2025-11-25",
+      "ocp-apim-subscription-key": "azure-subscription-secret",
+      "x-client-credential": "client-credential-secret",
+      "x-provider-token": "provider-token-secret",
     },
     body: JSON.stringify({
       jsonrpc: "2.0",
@@ -34,6 +38,7 @@ test("captures the real tools/call exchange while redacting credentials and quer
     }),
   })
 
+  await inspector.settle()
   const inspection = inspector.snapshot()
   expect(inspection).toMatchObject({
     request: {
@@ -43,12 +48,16 @@ test("captures the real tools/call exchange while redacting credentials and quer
         { name: "authorization", value: "Bearer [redacted]", redacted: true },
         { name: "cookie", value: "[redacted]", redacted: true },
         { name: "mcp-protocol-version", value: "2025-11-25", redacted: false },
+        { name: "ocp-apim-subscription-key", value: "[redacted]", redacted: true },
+        { name: "x-client-credential", value: "[redacted]", redacted: true },
+        { name: "x-provider-token", value: "[redacted]", redacted: true },
       ]),
       body: { truncated: false },
     },
     response: {
       status: 200,
       headers: expect.arrayContaining([
+        { name: "authorization", value: "[redacted]", redacted: true },
         { name: "mcp-session-id", value: "[redacted]", redacted: true },
         { name: "x-request-id", value: "provider-request-123", redacted: false },
       ]),
@@ -57,8 +66,12 @@ test("captures the real tools/call exchange while redacting credentials and quer
   })
   const serialized = JSON.stringify(inspection)
   expect(serialized).not.toContain("access-token-secret")
+  expect(serialized).not.toContain("azure-subscription-secret")
   expect(serialized).not.toContain("browser-secret")
+  expect(serialized).not.toContain("client-credential-secret")
   expect(serialized).not.toContain("provider-session-secret")
+  expect(serialized).not.toContain("provider-token-secret")
+  expect(serialized).not.toContain("opaque-response-secret")
   expect(inspection.request?.body.text).toContain('"method":"tools/call"')
   expect(inspection.response?.body.text).toContain('"text":"ok"')
 })
@@ -84,6 +97,7 @@ test("ignores lifecycle requests and classifies a tools/call with no response as
     body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "tools/call", params: { name: "fail", arguments: {} } }),
   })).rejects.toThrow("fetch failed")
 
+  await inspector.settle()
   const inspection = inspector.snapshot()
   expect(inspection.request?.body.text).toContain('"method":"tools/call"')
   expect(inspection.response).toBeUndefined()
@@ -91,6 +105,111 @@ test("ignores lifecycle requests and classifies a tools/call with no response as
     status: "failed",
     layer: "network",
     summary: "OpenWork sent tools/call but did not receive an HTTP response from the remote MCP.",
+  })
+})
+
+test("returns a streamed response to the transport before the stream ends and settles a bounded capture", async () => {
+  const inspector = new ExternalMcpToolCallInspector()
+  const encoder = new TextEncoder()
+  const sseEvent = `event: message\ndata: ${JSON.stringify({ jsonrpc: "2.0", id: 3, result: { content: [] } })}\n\n`
+  // A remote MCP that sends the tool response event but holds the SSE stream
+  // open. The transport must still receive the response immediately.
+  const observedFetch = inspector.observeFetch(async () => new Response(
+    new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(encoder.encode(sseEvent))
+      },
+    }),
+    { status: 200, headers: { "content-type": "text/event-stream" } },
+  ))
+
+  const response = await observedFetch("https://mcp.example.test/rpc", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 3, method: "tools/call", params: { name: "stream", arguments: {} } }),
+  })
+  // The transport's branch of the body is untouched and readable right away.
+  const reader = response.body!.getReader()
+  const firstChunk = await reader.read()
+  expect(new TextDecoder().decode(firstChunk.value)).toContain('"jsonrpc"')
+
+  await inspector.settle()
+  const inspection = inspector.snapshot()
+  expect(inspection.response?.status).toBe(200)
+  expect(inspection.response?.body.text).toContain('"result"')
+  expect(inspection.response?.body.unavailable).toBeUndefined()
+  // The stream never ended, so the capture is marked incomplete.
+  expect(inspection.response?.body.truncated).toBe(true)
+})
+
+test("caps the captured response body at the inspection limit without failing on multibyte content", async () => {
+  const inspector = new ExternalMcpToolCallInspector()
+  const oversized = "é".repeat(400 * 1024) // 800 KiB of UTF-8, above the 512 KiB cap
+  const observedFetch = inspector.observeFetch(async () => new Response(oversized, {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  }))
+
+  await observedFetch("https://mcp.example.test/rpc", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 4, method: "tools/call", params: { name: "big", arguments: {} } }),
+  })
+  await inspector.settle()
+
+  const body = inspector.snapshot().response?.body
+  expect(body?.truncated).toBe(true)
+  expect(body?.bytes).toBeGreaterThan(512 * 1024)
+  // Capture stays within the limit (plus at most one replacement character
+  // for a multibyte sequence split at the boundary).
+  expect(Buffer.byteLength(body?.text ?? "", "utf8")).toBeLessThanOrEqual(512 * 1024 + 3)
+  expect(body?.text.startsWith("é")).toBe(true)
+})
+
+test("does not change the tool response when the body cannot be cloned for inspection", async () => {
+  const inspector = new ExternalMcpToolCallInspector()
+  const providerResponse = new Response("provider result", { status: 200 })
+  Object.defineProperty(providerResponse, "clone", {
+    value: () => {
+      throw new Error("body clone unavailable")
+    },
+  })
+  const observedFetch = inspector.observeFetch(async () => providerResponse)
+
+  const response = await observedFetch("https://mcp.example.test/rpc", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 5, method: "tools/call", params: { name: "clone_failure", arguments: {} } }),
+  })
+
+  expect(await response.text()).toBe("provider result")
+  await inspector.settle()
+  expect(inspector.snapshot().response?.body).toEqual({
+    text: "",
+    bytes: 0,
+    truncated: false,
+    unavailable: true,
+  })
+})
+
+test("attributes a blocked or deadline-stopped tools/call to the right layer", () => {
+  expect(diagnoseExternalMcpToolCall({
+    inspection: { request: { method: "POST", url: "https://mcp.example.test/rpc", startedAt: new Date().toISOString(), headers: [], body: { text: "{}", bytes: 2, truncated: false } } },
+    succeeded: false,
+    diagnostic: { phase: "CONFIGURATION", category: "security_blocked", code: "MCP_URL_BLOCKED" },
+  })).toEqual({
+    status: "failed",
+    layer: "openwork",
+    summary: "OpenWork's outbound network safety policy blocked this tools/call request, so it was not sent to the remote MCP.",
+  })
+  expect(diagnoseExternalMcpToolCall({
+    inspection: { request: { method: "POST", url: "https://mcp.example.test/rpc", startedAt: new Date().toISOString(), headers: [], body: { text: "{}", bytes: 2, truncated: false } } },
+    succeeded: false,
+    diagnostic: { phase: "MCP_TOOL_EXECUTION", category: "lifecycle_deadline", code: "MCP_LIFECYCLE_DEADLINE" },
+  })).toEqual({
+    status: "failed",
+    layer: "network",
+    summary: "OpenWork sent tools/call but the remote MCP did not answer before OpenWork stopped waiting at its deadline.",
   })
 })
 

--- a/ee/apps/den-api/test/mcp-connections-tools.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-tools.test.ts
@@ -80,6 +80,30 @@ beforeAll(async () => {
   errorMcp.all("/mcp", async (c) => {
     const payload: unknown = await c.req.raw.json().catch(() => null)
     const id = payload && typeof payload === "object" && "id" in payload ? payload.id : null
+    const method = payload && typeof payload === "object" && "method" in payload && typeof payload.method === "string"
+      ? payload.method
+      : null
+    if (method === "initialize") {
+      const protocolVersion = payload
+        && typeof payload === "object"
+        && "params" in payload
+        && payload.params
+        && typeof payload.params === "object"
+        && "protocolVersion" in payload.params
+        && typeof payload.params.protocolVersion === "string"
+        ? payload.params.protocolVersion
+        : "2025-11-25"
+      return c.json({
+        jsonrpc: "2.0",
+        id,
+        result: {
+          protocolVersion,
+          capabilities: { tools: {} },
+          serverInfo: { name: "failing-tool-proof", version: "1.0.0" },
+        },
+      })
+    }
+    if (method === "notifications/initialized") return new Response(null, { status: 202 })
     return c.json({
       jsonrpc: "2.0",
       id,
@@ -364,6 +388,22 @@ test("an admin manually runs a tool with a diagnostic reference", async () => {
       content: [{ type: "text", text: "Found incidents for network timeout" }],
       structuredContent: { resultCount: 1 },
     },
+    inspection: {
+      diagnosis: {
+        status: "succeeded",
+        layer: "mcp_tool",
+      },
+      request: {
+        method: "POST",
+        url: expect.stringContaining("/mcp"),
+        body: { text: expect.stringContaining('"method":"tools/call"'), truncated: false },
+      },
+      response: {
+        status: 200,
+        durationMs: expect.any(Number),
+        body: { text: expect.stringContaining("Found incidents for network timeout"), truncated: false },
+      },
+    },
   })
   expect(observedMethods).toContain("tools/call")
   expect(observedArguments).toEqual([{ query: "network timeout", status: "active" }])
@@ -374,6 +414,17 @@ test("per-member tool execution uses only the calling admin's credential", async
   const response = await callRequest(perMemberConnectionId)
   expect(response.status).toBe(200)
   expect(observedAuthorization).toContain("Bearer member-catalog-token")
+  const body: unknown = await response.json()
+  expect(body).toMatchObject({
+    inspection: {
+      request: {
+        headers: expect.arrayContaining([
+          { name: "authorization", value: "Bearer [redacted]", redacted: true },
+        ]),
+      },
+    },
+  })
+  expect(JSON.stringify(body)).not.toContain("member-catalog-token")
 })
 
 test("a granted regular member cannot manually run a tool", async () => {
@@ -391,12 +442,31 @@ test("manual tool execution is tenant scoped", async () => {
   expect(response.status).toBe(404)
 })
 
-test("manual tool failures return a structured diagnostic without provider secrets", async () => {
+test("manual tool failures separate safe diagnostics from the ephemeral raw MCP response", async () => {
   const response = await callRequest(failingConnectionId)
   expect(response.status).toBe(502)
   const body: unknown = await response.json()
-  expect(body).toMatchObject({ error: "tool_execution_failed" })
-  expect(JSON.stringify(body)).not.toContain("provider-catalog-secret")
+  expect(body).toMatchObject({
+    error: "tool_execution_failed",
+    inspection: {
+      diagnosis: {
+        status: "failed",
+        layer: "mcp_tool",
+      },
+      request: {
+        method: "POST",
+        body: { text: expect.stringContaining('"method":"tools/call"') },
+      },
+      response: {
+        status: 200,
+        body: { text: expect.stringContaining("provider-catalog-secret") },
+      },
+    },
+  })
+  if (!body || typeof body !== "object" || !("diagnostic" in body)) {
+    throw new Error("tool failure response did not include a diagnostic")
+  }
+  expect(JSON.stringify(body.diagnostic)).not.toContain("provider-catalog-secret")
 })
 
 test("manual tool execution validates a JSON object payload", async () => {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -72,7 +72,53 @@ export type ExternalMcpToolRun = {
   referenceId: string;
   durationMs: number;
   result: unknown;
+  inspection: ExternalMcpToolCallInspection;
 };
+
+export type ExternalMcpInspectionHeader = {
+  name: string;
+  value: string;
+  redacted: boolean;
+};
+
+export type ExternalMcpInspectionBody = {
+  text: string;
+  bytes: number;
+  truncated: boolean;
+  unavailable?: boolean;
+};
+
+export type ExternalMcpToolCallInspection = {
+  request?: {
+    method: string;
+    url: string;
+    startedAt: string;
+    headers: ExternalMcpInspectionHeader[];
+    body: ExternalMcpInspectionBody;
+  };
+  response?: {
+    status: number;
+    statusText: string;
+    durationMs: number;
+    headers: ExternalMcpInspectionHeader[];
+    body: ExternalMcpInspectionBody;
+  };
+  diagnosis: {
+    status: "succeeded" | "failed";
+    layer: "openwork" | "network" | "mcp_connection" | "remote_http" | "mcp_tool";
+    summary: string;
+  };
+};
+
+export class ExternalMcpToolRunError extends Error {
+  readonly inspection: ExternalMcpToolCallInspection | null;
+
+  constructor(message: string, inspection: ExternalMcpToolCallInspection | null) {
+    super(message);
+    this.name = "ExternalMcpToolRunError";
+    this.inspection = inspection;
+  }
+}
 
 export type ExternalMcpPreset = {
   presetId: string;
@@ -141,10 +187,14 @@ export function useRunMcpConnectionTool(connectionId: string) {
           headers: getOrgScopeHeaders(requireOrgId(orgId)),
           body: JSON.stringify(input),
         },
-        60000,
+        160000,
       );
       if (!response.ok) {
-        throw getRequestError(payload, response, `Failed to run MCP tool (${response.status}).`);
+        const requestError = getRequestError(payload, response, `Failed to run MCP tool (${response.status}).`);
+        throw new ExternalMcpToolRunError(
+          requestError.message,
+          isRecord(payload) ? parseToolCallInspection(payload.inspection) : null,
+        );
       }
       if (
         !isRecord(payload)
@@ -154,10 +204,13 @@ export function useRunMcpConnectionTool(connectionId: string) {
       ) {
         throw new Error("MCP tool result was incomplete.");
       }
+      const inspection = parseToolCallInspection(payload.inspection);
+      if (!inspection) throw new Error("MCP tool inspection was incomplete.");
       return {
         referenceId: payload.referenceId,
         durationMs: payload.durationMs,
         result: payload.result,
+        inspection,
       };
     },
   });
@@ -165,6 +218,82 @@ export function useRunMcpConnectionTool(connectionId: string) {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function parseInspectionHeaders(value: unknown): ExternalMcpInspectionHeader[] | null {
+  if (!Array.isArray(value)) return null;
+  const headers: ExternalMcpInspectionHeader[] = [];
+  for (const header of value) {
+    if (
+      !isRecord(header)
+      || typeof header.name !== "string"
+      || typeof header.value !== "string"
+      || typeof header.redacted !== "boolean"
+    ) return null;
+    headers.push({ name: header.name, value: header.value, redacted: header.redacted });
+  }
+  return headers;
+}
+
+function parseInspectionBody(value: unknown): ExternalMcpInspectionBody | null {
+  if (
+    !isRecord(value)
+    || typeof value.text !== "string"
+    || typeof value.bytes !== "number"
+    || typeof value.truncated !== "boolean"
+    || (value.unavailable !== undefined && typeof value.unavailable !== "boolean")
+  ) return null;
+  return {
+    text: value.text,
+    bytes: value.bytes,
+    truncated: value.truncated,
+    ...(value.unavailable === true ? { unavailable: true } : {}),
+  };
+}
+
+function parseInspectionRequest(value: unknown): ExternalMcpToolCallInspection["request"] | null {
+  if (
+    !isRecord(value)
+    || typeof value.method !== "string"
+    || typeof value.url !== "string"
+    || typeof value.startedAt !== "string"
+  ) return null;
+  const headers = parseInspectionHeaders(value.headers);
+  const body = parseInspectionBody(value.body);
+  if (!headers || !body) return null;
+  return { method: value.method, url: value.url, startedAt: value.startedAt, headers, body };
+}
+
+function parseInspectionResponse(value: unknown): ExternalMcpToolCallInspection["response"] | null {
+  if (
+    !isRecord(value)
+    || typeof value.status !== "number"
+    || typeof value.statusText !== "string"
+    || typeof value.durationMs !== "number"
+  ) return null;
+  const headers = parseInspectionHeaders(value.headers);
+  const body = parseInspectionBody(value.body);
+  if (!headers || !body) return null;
+  return { status: value.status, statusText: value.statusText, durationMs: value.durationMs, headers, body };
+}
+
+function parseToolCallInspection(value: unknown): ExternalMcpToolCallInspection | null {
+  if (!isRecord(value) || !isRecord(value.diagnosis)) return null;
+  const status = value.diagnosis.status;
+  const layer = value.diagnosis.layer;
+  if (
+    (status !== "succeeded" && status !== "failed")
+    || (layer !== "openwork" && layer !== "network" && layer !== "mcp_connection" && layer !== "remote_http" && layer !== "mcp_tool")
+    || typeof value.diagnosis.summary !== "string"
+  ) return null;
+  const request = value.request === undefined ? undefined : parseInspectionRequest(value.request);
+  const response = value.response === undefined ? undefined : parseInspectionResponse(value.response);
+  if (request === null || response === null) return null;
+  return {
+    ...(request ? { request } : {}),
+    ...(response ? { response } : {}),
+    diagnosis: { status, layer, summary: value.diagnosis.summary },
+  };
 }
 
 function isStringArray(value: unknown): value is string[] {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -72,7 +72,7 @@ export type ExternalMcpToolRun = {
   referenceId: string;
   durationMs: number;
   result: unknown;
-  inspection: ExternalMcpToolCallInspection;
+  inspection: ExternalMcpToolCallInspection | null;
 };
 
 export type ExternalMcpInspectionHeader = {
@@ -176,6 +176,11 @@ export function useMcpConnectionTools(connectionId: string, enabled: boolean) {
   });
 }
 
+// The den-api tool run is bounded by its 150s MCP tool lifecycle deadline;
+// give the request a little headroom so the server's structured failure
+// arrives instead of a client-side timeout.
+const RUN_TOOL_REQUEST_TIMEOUT_MS = 160000;
+
 export function useRunMcpConnectionTool(connectionId: string) {
   const { orgId } = useOrgDashboard();
   return useMutation({
@@ -187,7 +192,7 @@ export function useRunMcpConnectionTool(connectionId: string) {
           headers: getOrgScopeHeaders(requireOrgId(orgId)),
           body: JSON.stringify(input),
         },
-        160000,
+        RUN_TOOL_REQUEST_TIMEOUT_MS,
       );
       if (!response.ok) {
         const requestError = getRequestError(payload, response, `Failed to run MCP tool (${response.status}).`);
@@ -204,13 +209,14 @@ export function useRunMcpConnectionTool(connectionId: string) {
       ) {
         throw new Error("MCP tool result was incomplete.");
       }
-      const inspection = parseToolCallInspection(payload.inspection);
-      if (!inspection) throw new Error("MCP tool inspection was incomplete.");
       return {
         referenceId: payload.referenceId,
         durationMs: payload.durationMs,
         result: payload.result,
-        inspection,
+        // A missing or unparseable inspection must not fail a tool run that
+        // succeeded (for example across a den-api/den-web deploy skew); the
+        // runner simply renders without the inspector panel.
+        inspection: parseToolCallInspection(payload.inspection),
       };
     },
   });

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
@@ -1,13 +1,17 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, Check, Loader2, Play, RefreshCw, Wrench } from "lucide-react";
+import { AlertTriangle, ArrowRight, Check, Loader2, LockKeyhole, Play, RefreshCw, Wrench } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenSelect } from "../../_components/ui/select";
 import { DenTextarea } from "../../_components/ui/textarea";
 import {
   type ExternalMcpConnection,
+  type ExternalMcpInspectionBody,
+  type ExternalMcpInspectionHeader,
   type ExternalMcpTool,
+  type ExternalMcpToolCallInspection,
+  ExternalMcpToolRunError,
   useMcpConnectionTools,
   useRunMcpConnectionTool,
 } from "./mcp-connections-data";
@@ -44,6 +48,118 @@ export function mcpToolArgumentTemplate(tool: ExternalMcpTool): Record<string, u
 
 function formatJson(value: unknown): string {
   return JSON.stringify(value, null, 2) ?? "null";
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(bytes < 10 * 1024 ? 1 : 0)} KB`;
+}
+
+function InspectionHeaders({ headers }: { headers: ExternalMcpInspectionHeader[] }) {
+  if (headers.length === 0) return <p className="text-[11px] text-gray-400">No headers captured.</p>;
+  return (
+    <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
+      {headers.map((header) => (
+        <div key={header.name} className="grid grid-cols-[minmax(7rem,0.7fr)_minmax(0,1.3fr)] gap-3 border-b border-gray-100 px-3 py-2 last:border-b-0">
+          <code className="break-all text-[10px] font-semibold text-gray-600">{header.name}</code>
+          <code className="break-all text-[10px] text-gray-800">
+            {header.redacted ? <LockKeyhole className="mr-1 inline h-3 w-3 text-amber-600" aria-label="Redacted" /> : null}
+            {header.value}
+          </code>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function InspectionBody({ body }: { body: ExternalMcpInspectionBody }) {
+  return (
+    <div>
+      <div className="mb-1.5 flex items-center justify-between gap-3 text-[10px] text-gray-500">
+        <span>Raw body</span>
+        <span>{formatBytes(body.bytes)}{body.truncated ? " · truncated" : ""}</span>
+      </div>
+      {body.unavailable ? (
+        <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-800">The transport body could not be captured.</div>
+      ) : (
+        <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words rounded-lg bg-gray-950 p-3 text-[10px] leading-4 text-gray-100">{body.text || "(empty body)"}</pre>
+      )}
+    </div>
+  );
+}
+
+function diagnosisLayerLabel(layer: ExternalMcpToolCallInspection["diagnosis"]["layer"]): string {
+  if (layer === "openwork") return "OpenWork before send";
+  if (layer === "network") return "Network / no response";
+  if (layer === "mcp_connection") return "MCP connection / setup";
+  if (layer === "remote_http") return "Remote MCP HTTP";
+  return "MCP tool response";
+}
+
+function McpToolCallInspector({ inspection }: { inspection: ExternalMcpToolCallInspection }) {
+  const succeeded = inspection.diagnosis.status === "succeeded";
+  return (
+    <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white" aria-label="Tool call inspection">
+      <div className={`border-b px-4 py-3 ${succeeded ? "border-emerald-200 bg-emerald-50" : "border-red-200 bg-red-50"}`}>
+        <div className="flex flex-wrap items-center justify-between gap-2">
+          <p className={`text-[12px] font-semibold ${succeeded ? "text-emerald-800" : "text-red-800"}`}>
+            {succeeded ? "Remote MCP completed the call" : "Call stopped at: "}{!succeeded ? diagnosisLayerLabel(inspection.diagnosis.layer) : ""}
+          </p>
+          <div className="flex items-center gap-1.5 font-mono text-[10px] text-gray-600">
+            <span>OpenWork</span><ArrowRight className="h-3 w-3" />
+            <span>{inspection.response ? `HTTP ${inspection.response.status}` : inspection.request ? "No response" : "Not sent"}</span><ArrowRight className="h-3 w-3" />
+            <span>{succeeded ? "Tool result" : "Failure"}</span>
+          </div>
+        </div>
+        <p className={`mt-1 text-[11px] leading-5 ${succeeded ? "text-emerald-700" : "text-red-700"}`}>{inspection.diagnosis.summary}</p>
+      </div>
+
+      <div className="border-b border-amber-100 bg-amber-50/70 px-4 py-2 text-[10px] leading-4 text-amber-800">
+        Credential and session headers are redacted. Request and response bodies may contain sensitive provider data; this inspection is returned only for this run and is not stored in Den logs.
+      </div>
+
+      <div className="grid gap-0 xl:grid-cols-2 xl:divide-x xl:divide-gray-200">
+        <div className="space-y-4 p-4">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Request sent</p>
+            {inspection.request ? (
+              <div className="mt-2 rounded-lg bg-gray-950 px-3 py-2 font-mono text-[10px] leading-4 text-gray-100">
+                <span className="font-semibold text-blue-300">{inspection.request.method}</span> <span className="break-all">{inspection.request.url}</span>
+              </div>
+            ) : (
+              <p className="mt-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-[11px] text-gray-500">No tools/call request left OpenWork.</p>
+            )}
+          </div>
+          {inspection.request ? (
+            <>
+              <div><p className="mb-1.5 text-[11px] font-medium text-gray-700">Headers</p><InspectionHeaders headers={inspection.request.headers} /></div>
+              <InspectionBody body={inspection.request.body} />
+            </>
+          ) : null}
+        </div>
+
+        <div className="space-y-4 border-t border-gray-200 p-4 xl:border-t-0">
+          <div>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Response received</p>
+            {inspection.response ? (
+              <div className="mt-2 flex items-center justify-between gap-3 rounded-lg bg-gray-950 px-3 py-2 font-mono text-[10px] text-gray-100">
+                <span><span className={inspection.response.status < 400 ? "text-emerald-300" : "text-red-300"}>HTTP {inspection.response.status}</span> {inspection.response.statusText}</span>
+                <span className="text-gray-400">{inspection.response.durationMs} ms</span>
+              </div>
+            ) : (
+              <p className="mt-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-[11px] text-gray-500">No HTTP response was captured.</p>
+            )}
+          </div>
+          {inspection.response ? (
+            <>
+              <div><p className="mb-1.5 text-[11px] font-medium text-gray-700">Headers</p><InspectionHeaders headers={inspection.response.headers} /></div>
+              <InspectionBody body={inspection.response.body} />
+            </>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
 }
 
 export function McpToolRunner({ connection }: { connection: ExternalMcpConnection }) {
@@ -101,6 +217,8 @@ export function McpToolRunner({ connection }: { connection: ExternalMcpConnectio
 
   const executionError = localError
     ?? (runTool.error instanceof Error ? runTool.error.message : runTool.error ? "The MCP tool failed." : null);
+  const inspection = runTool.data?.inspection
+    ?? (runTool.error instanceof ExternalMcpToolRunError ? runTool.error.inspection : null);
 
   return (
     <div className="border-t border-gray-100 bg-gray-50/70 px-6 py-5" data-testid={`mcp-tool-runner-${connection.id}`}>
@@ -216,6 +334,8 @@ export function McpToolRunner({ connection }: { connection: ExternalMcpConnectio
             </DenButton>
             <p className="text-[11px] text-gray-500">Runs immediately against {connection.name}.</p>
           </div>
+
+          {inspection ? <McpToolCallInspector inspection={inspection} /> : null}
 
           {runTool.data ? (
             <div className="rounded-2xl border border-emerald-200 bg-emerald-50/70 p-4" role="status">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
@@ -59,11 +59,13 @@ function InspectionHeaders({ headers }: { headers: ExternalMcpInspectionHeader[]
   if (headers.length === 0) return <p className="text-[11px] text-gray-400">No headers captured.</p>;
   return (
     <div className="overflow-hidden rounded-lg border border-gray-200 bg-white">
-      {headers.map((header) => (
-        <div key={header.name} className="grid grid-cols-[minmax(7rem,0.7fr)_minmax(0,1.3fr)] gap-3 border-b border-gray-100 px-3 py-2 last:border-b-0">
+      {headers.map((header, index) => (
+        // Headers such as set-cookie can repeat, so the name alone is not a
+        // stable React key.
+        <div key={`${index}-${header.name}`} className="grid grid-cols-[minmax(7rem,0.7fr)_minmax(0,1.3fr)] gap-3 border-b border-gray-100 px-3 py-2 last:border-b-0">
           <code className="break-all text-[10px] font-semibold text-gray-600">{header.name}</code>
           <code className="break-all text-[10px] text-gray-800">
-            {header.redacted ? <LockKeyhole className="mr-1 inline h-3 w-3 text-amber-600" aria-label="Redacted" /> : null}
+            {header.redacted ? <LockKeyhole className="mr-1 inline h-3 w-3 text-amber-600" aria-hidden="true" /> : null}
             {header.value}
           </code>
         </div>
@@ -77,7 +79,10 @@ function InspectionBody({ body }: { body: ExternalMcpInspectionBody }) {
     <div>
       <div className="mb-1.5 flex items-center justify-between gap-3 text-[10px] text-gray-500">
         <span>Raw body</span>
-        <span>{formatBytes(body.bytes)}{body.truncated ? " · truncated" : ""}</span>
+        <span>
+          {formatBytes(body.bytes)}
+          {body.truncated ? <span className="ml-1 font-semibold text-amber-700">· capture truncated</span> : null}
+        </span>
       </div>
       {body.unavailable ? (
         <div className="rounded-lg border border-amber-200 bg-amber-50 px-3 py-2 text-[11px] text-amber-800">The transport body could not be captured.</div>
@@ -98,16 +103,24 @@ function diagnosisLayerLabel(layer: ExternalMcpToolCallInspection["diagnosis"]["
 
 function McpToolCallInspector({ inspection }: { inspection: ExternalMcpToolCallInspection }) {
   const succeeded = inspection.diagnosis.status === "succeeded";
+  // A captured request can still have been blocked inside OpenWork (for
+  // example by the outbound SSRF policy); the diagnosis layer decides
+  // between "never sent" and "sent but unanswered".
+  const transportChip = inspection.response
+    ? `HTTP ${inspection.response.status}`
+    : inspection.request && inspection.diagnosis.layer !== "openwork"
+      ? "No response"
+      : "Not sent";
   return (
     <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white" aria-label="Tool call inspection">
       <div className={`border-b px-4 py-3 ${succeeded ? "border-emerald-200 bg-emerald-50" : "border-red-200 bg-red-50"}`}>
         <div className="flex flex-wrap items-center justify-between gap-2">
           <p className={`text-[12px] font-semibold ${succeeded ? "text-emerald-800" : "text-red-800"}`}>
-            {succeeded ? "Remote MCP completed the call" : "Call stopped at: "}{!succeeded ? diagnosisLayerLabel(inspection.diagnosis.layer) : ""}
+            {succeeded ? "Remote MCP completed the call" : `Call stopped at: ${diagnosisLayerLabel(inspection.diagnosis.layer)}`}
           </p>
           <div className="flex items-center gap-1.5 font-mono text-[10px] text-gray-600">
-            <span>OpenWork</span><ArrowRight className="h-3 w-3" />
-            <span>{inspection.response ? `HTTP ${inspection.response.status}` : inspection.request ? "No response" : "Not sent"}</span><ArrowRight className="h-3 w-3" />
+            <span>OpenWork</span><ArrowRight className="h-3 w-3" aria-hidden="true" />
+            <span>{transportChip}</span><ArrowRight className="h-3 w-3" aria-hidden="true" />
             <span>{succeeded ? "Tool result" : "Failure"}</span>
           </div>
         </div>
@@ -121,7 +134,7 @@ function McpToolCallInspector({ inspection }: { inspection: ExternalMcpToolCallI
       <div className="grid gap-0 xl:grid-cols-2 xl:divide-x xl:divide-gray-200">
         <div className="space-y-4 p-4">
           <div>
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Request sent</p>
+            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Outgoing request</p>
             {inspection.request ? (
               <div className="mt-2 rounded-lg bg-gray-950 px-3 py-2 font-mono text-[10px] leading-4 text-gray-100">
                 <span className="font-semibold text-blue-300">{inspection.request.method}</span> <span className="break-all">{inspection.request.url}</span>
@@ -336,6 +349,12 @@ export function McpToolRunner({ connection }: { connection: ExternalMcpConnectio
           </div>
 
           {inspection ? <McpToolCallInspector inspection={inspection} /> : null}
+
+          {runTool.data && !runTool.data.inspection ? (
+            <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-[12px] leading-5 text-amber-800" role="status">
+              The tool completed, but request and response details were unavailable. Refresh after the dashboard and its server are running the same version.
+            </div>
+          ) : null}
 
           {runTool.data ? (
             <div className="rounded-2xl border border-emerald-200 bg-emerald-50/70 p-4" role="status">


### PR DESCRIPTION
## Summary

- Add a Postman-style inspector for manual MCP tool execution that shows the actual outgoing tools/call HTTP request and incoming HTTP response.
- Show raw headers and bodies, status, timing, byte counts, capture truncation, and a verdict identifying OpenWork, network, MCP setup, remote HTTP, or tool-response failures.
- Use the same inspection boundary for the current and enterprise MCP client implementations without adding capture overhead to normal agent tool calls.
- Capture response streams through a bounded clone so inspection never consumes or delays the MCP SDK response; held-open streams stop inspection capture after one second and are marked incomplete.
- Preserve a successful tool result if inspection is unavailable, with a clear dashboard notice for API/dashboard version skew.

## Security and privacy

- Keep the route admin-only, tenant-scoped, access-grant checked, SSRF guarded, and excluded from the agent API catalog.
- Redact authorization, DPoP, API/subscription/private keys, credentials, passwords, cookies, sessions, signatures, tokens, and secret headers. Authorization schemes are preserved only when a separate credential value is present.
- Strip URL credentials and fragments and redact every query value.
- Cap displayed request and response bodies at 512 KiB each.
- Return inspection data only to the initiating admin. It is not persisted or logged.
- Warn that raw bodies can contain sensitive provider data even though credential headers are redacted.
- Treat capture as diagnostic-only: clone/read failures cannot change the underlying tool-call outcome.

## Verification

- Current Den MCP path and policy coverage: 37 passed, 0 failed, 109 assertions.
- Enterprise Den MCP route path: 16 passed, 0 failed, 40 assertions.
- Enterprise MCP client package: 23 passed, 0 failed.
- Den API TypeScript check passed.
- Den Web TypeScript check passed.
- Enterprise MCP client TypeScript check passed.
- Diff whitespace check passed.
- Manually exercised the local Den dashboard against a live mock MCP: the success verdict, actual JSON-RPC request, HTTP 200 response headers, raw SSE response, timing, and parsed result rendered correctly.
- Focused tests prove held-open streaming responses return immediately to the SDK, oversized and multibyte bodies are bounded, capture failure does not change the result, secret-header variants stay redacted, and blocked/deadline failures receive the correct layer.
- Confirmed the manual route logs identifiers, duration, and safe diagnostics only, never arguments, results, or inspection payloads.

## Risk and rollback

The manual admin diagnostic response can carry up to 512 KiB of captured request and response body data and may expose provider-returned content to that admin. The UI calls this out and the data remains ephemeral. A held-open response can add up to one second to this manual diagnostic response while the inspector finishes its bounded copy. Normal agent execution is unaffected. Roll back the two feature commits if needed.

## Remaining evidence

No fraimz or video was posted because visual evidence was not requested. Reviewers can reproduce through Your Connections, expand a connection, select Test tools, and run any safe read-only tool.

## Review note

This touches the enterprise MCP transport and admin diagnostic surface, so it should receive the normal enterprise/security review before merge.