### PR TITLE
test(mcp): prove engine silently refreshes expired OAuth tokens

### DIFF
--- a/apps/server/src/mcp.oauth-flow.e2e.test.ts
+++ b/apps/server/src/mcp.oauth-flow.e2e.test.ts
@@ -103,7 +103,7 @@ describeMaybe("mcp oauth flow against mock provider", () => {
     );
 
     mockProc = spawn("node", [join(repoRoot, "scripts/mock-oauth-mcp-server.mjs")], {
-      env: { ...process.env, PORT: String(mockPort), AUTO_APPROVE: "1" },
+      env: { ...process.env, PORT: String(mockPort), AUTO_APPROVE: "1", STRICT_REFRESH_TOKENS: "1" },
       stdio: "ignore",
     });
     await waitFor(
@@ -223,6 +223,76 @@ describeMaybe("mcp oauth flow against mock provider", () => {
       expect(paths).toContain("POST /mcp");
     },
     90_000,
+  );
+
+  test(
+    "engine silently refreshes an expired access token without re-authorization",
+    async () => {
+      const authFile = join(dataDir, "xdg-data", "opencode", "mcp-auth.json");
+      const before = JSON.parse(readFileSync(authFile, "utf8")) as Record<
+        string,
+        { tokens?: { accessToken?: string; refreshToken?: string } }
+      >;
+      const beforeAccess = before[MCP_NAME]?.tokens?.accessToken;
+      expect(beforeAccess).toStartWith("mock-access-");
+      expect(before[MCP_NAME]?.tokens?.refreshToken).toStartWith("mock-refresh-");
+
+      // Only assert on traffic that happens after this point.
+      const markLog = (await (await fetch(`${mockUrl()}/requests`)).json()) as { requests: Array<unknown> };
+      const mark = markLog.requests.length;
+
+      // Kill every live access token server-side (refresh grants stay
+      // valid). The engine's next MCP round-trip gets a 401 challenge —
+      // exactly what an expired access token looks like in production.
+      const expire = await fetch(`${mockUrl()}/admin/expire-access-tokens`, { method: "POST" });
+      expect(expire.ok).toBe(true);
+
+      // Force a fresh authenticated round-trip: re-register the MCP so the
+      // engine reconnects using its stored tokens.
+      const reregister = await engineFetch("/mcp", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          name: MCP_NAME,
+          config: { type: "remote", url: `${mockUrl()}/mcp`, enabled: true, oauth: {} },
+        }),
+      });
+      expect(reregister.ok).toBe(true);
+
+      const connected = await waitFor(
+        async () => {
+          const res = await engineFetch("/mcp");
+          if (!res.ok) return null;
+          const statuses = (await res.json()) as Record<string, { status: string }>;
+          return statuses[MCP_NAME]?.status === "connected" ? statuses : null;
+        },
+        30_000,
+        "mcp reconnected after access-token expiry",
+      );
+      expect(connected[MCP_NAME].status).toBe("connected");
+
+      // Recovery must have used the refresh grant — never a new browser
+      // authorization or a re-registration.
+      const log = (await (await fetch(`${mockUrl()}/requests`)).json()) as {
+        requests: Array<{ method: string; path: string; grantType?: string }>;
+      };
+      const afterMark = log.requests.slice(mark);
+      expect(
+        afterMark.some((r) => r.method === "POST" && r.path === "/token" && r.grantType === "refresh_token"),
+      ).toBe(true);
+      expect(afterMark.some((r) => r.path === "/authorize")).toBe(false);
+      expect(afterMark.some((r) => r.method === "POST" && r.path === "/register")).toBe(false);
+
+      // The rotated tokens were persisted for the next restart.
+      const after = JSON.parse(readFileSync(authFile, "utf8")) as Record<
+        string,
+        { tokens?: { accessToken?: string; refreshToken?: string } }
+      >;
+      expect(after[MCP_NAME]?.tokens?.accessToken).toStartWith("mock-access-");
+      expect(after[MCP_NAME]?.tokens?.accessToken).not.toBe(beforeAccess);
+      expect(after[MCP_NAME]?.tokens?.refreshToken).not.toBe(before[MCP_NAME]?.tokens?.refreshToken);
+    },
+    60_000,
   );
 
   test("logout removes stored tokens and drops the connection", async () => {

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -7,6 +7,10 @@ const port = Number(process.env.PORT || 3978);
 const issuer = process.env.ISSUER || `http://${host}:${port}`;
 const autoApprove = process.env.AUTO_APPROVE !== "0";
 const disableDcr = process.env.DISABLE_DCR === "1";
+// Strict mode rejects refresh tokens this instance did not issue (and
+// rotates on every refresh grant). Off by default: eval flows restart the
+// mock mid-scenario and legitimately present pre-restart refresh tokens.
+const strictRefreshTokens = process.env.STRICT_REFRESH_TOKENS === "1";
 const mockClientId = process.env.MOCK_CLIENT_ID || "mock-preregistered-client";
 const mockClientSecret = process.env.MOCK_CLIENT_SECRET || "mock-preregistered-secret";
 const extraToolName = (process.env.MOCK_EXTRA_TOOL_NAME || "").trim();
@@ -17,6 +21,7 @@ const extraToolResult = process.env.MOCK_EXTRA_TOOL_RESULT || "mock oauth mcp ok
 const clients = new Map();
 const codes = new Map();
 const tokens = new Set();
+const refreshTokens = new Set();
 const requests = [];
 const drafts = [];
 
@@ -220,9 +225,10 @@ async function registerClient(req, res) {
   json(res, 201, client);
 }
 
-async function issueToken(req, res) {
+async function issueToken(req, res, entry) {
   const form = await readForm(req);
   const grantType = form.grant_type || "authorization_code";
+  if (entry) entry.grantType = grantType;
   let grantedScope = "mcp:read mcp:write";
 
   if (grantType === "authorization_code") {
@@ -246,6 +252,19 @@ async function issueToken(req, res) {
         return;
       }
     }
+  } else if (grantType === "refresh_token") {
+    if (!requirePreregisteredTokenClient(req, res, form, null)) {
+      return;
+    }
+    if (strictRefreshTokens) {
+      if (!form.refresh_token || !refreshTokens.has(form.refresh_token)) {
+        json(res, 400, { error: "invalid_grant", error_description: "unknown refresh token" });
+        return;
+      }
+      // Rotate, like real providers (and the Den) do: the old refresh token
+      // dies with this exchange, so the client must persist the replacement.
+      refreshTokens.delete(form.refresh_token);
+    }
   } else if (!requirePreregisteredTokenClient(req, res, form, null)) {
     return;
   }
@@ -253,9 +272,11 @@ async function issueToken(req, res) {
   if (form.code) codes.delete(form.code);
   const accessToken = `mock-access-${randomUUID()}`;
   tokens.add(accessToken);
+  const refreshToken = `mock-refresh-${randomUUID()}`;
+  refreshTokens.add(refreshToken);
   json(res, 200, {
     access_token: accessToken,
-    refresh_token: `mock-refresh-${randomUUID()}`,
+    refresh_token: refreshToken,
     token_type: "Bearer",
     expires_in: 3600,
     scope: grantedScope,
@@ -370,7 +391,7 @@ async function handleMcp(req, res) {
 const server = http.createServer(async (req, res) => {
   try {
     const url = new URL(req.url || "/", issuer);
-    record(req, url);
+    const entry = record(req, url);
 
     if (req.method === "OPTIONS") {
       json(res, 204, {});
@@ -420,7 +441,17 @@ const server = http.createServer(async (req, res) => {
     }
 
     if (url.pathname === "/token" && req.method === "POST") {
-      await issueToken(req, res);
+      await issueToken(req, res, entry);
+      return;
+    }
+
+    // Test hook: kill every live access token (refresh grants stay valid),
+    // so the next authenticated MCP call gets a 401 challenge — the same
+    // thing a client sees in production when its access token expires.
+    if (url.pathname === "/admin/expire-access-tokens" && req.method === "POST") {
+      const expired = tokens.size;
+      tokens.clear();
+      json(res, 200, { expired });
       return;
     }
 


### PR DESCRIPTION
## Why

Today's production incident: an opencode engine whose MCP client was registered **before** the offline_access fix (#2628/#2629) had a 15-minute access token and no refresh token. Every `/mcp/agent` call 401'd in <1ms, the SDK correctly fetched the RFC 9728 challenge doc after each 401, but the only recovery path was interactive browser OAuth — impossible mid-session. The agent surfaced bare `Unauthorized` until a manual re-login.

The server side is already fixed and tested on dev (`mcp-oauth-refresh-flow.test.ts` proves issuance/rotation/replay-protection; prod verified: DCR default scope is `mcp:read mcp:write offline_access`). **What was missing is the client half:** nothing proved the engine actually recovers from access-token expiry via a `refresh_token` grant instead of demanding a new browser authorization. This is also the exact path enterprise-gateway users (Salesforce/ServiceNow via customer MCP gateway) will exercise daily.

## What

- `scripts/mock-oauth-mcp-server.mjs`
  - tracks issued refresh tokens; records `grant_type` on the `/requests` log
  - `POST /admin/expire-access-tokens` — kills all live access tokens (refresh grants stay valid) to simulate expiry deterministically
  - opt-in `STRICT_REFRESH_TOKENS=1`: rejects refresh tokens this instance didn't issue and rotates on every refresh grant. **Default stays loose** because eval flows (`durable-auth-mcp.flow.mjs`) restart the mock mid-scenario and legitimately present pre-restart refresh tokens.
- `apps/server/src/mcp.oauth-flow.e2e.test.ts` — new test between connect and logout:
  1. snapshot persisted tokens, mark the mock request log
  2. expire all access tokens server-side
  3. re-register the MCP (`POST /mcp`) forcing a fresh authenticated round-trip
  4. assert: connection returns to `connected`, recovery used `POST /token` with `grant_type=refresh_token`, **no** `/authorize`, **no** `/register`, and the rotated access+refresh tokens were persisted to `mcp-auth.json`

## Tests run

```
cd apps/server && bun test src/mcp.oauth-flow.e2e.test.ts
 3 pass, 0 fail, 32 expect() calls   (ran twice, stable)

pnpm typecheck  # clean
```

Negative control (proves the strict branch gates): forged refresh token against `STRICT_REFRESH_TOKENS=1` mock → `{"error":"invalid_grant","error_description":"unknown refresh token"}`, grantType recorded in log.

## Fraimz

Skipped, stated explicitly: no product runtime path changes — this PR touches only the test mock (default behavior byte-compatible: additive `grantType` field, additive admin endpoint, strictness opt-in) and an e2e test. The e2e run above is the executable proof of the claim in the title.