### PR TITLE
Fix OpenWork MCP auth and plugin binding

### DIFF
--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -140,9 +140,11 @@ function readTokenAudiences(payload: Record<string, unknown>) {
   return []
 }
 
-function hasExactMcpOauthAudience(payload: Record<string, unknown>) {
+function hasAcceptedMcpOauthAudience(payload: Record<string, unknown>) {
   const audiences = readTokenAudiences(payload)
-  return audiences.length === 1 && audiences[0] === DEN_MCP_OAUTH_RESOURCE
+  const userInfoAudience = `${getDenAuthIssuer(env.betterAuthUrl)}/oauth2/userinfo`
+  return audiences.includes(DEN_MCP_OAUTH_RESOURCE)
+    && audiences.every((audience) => audience === DEN_MCP_OAUTH_RESOURCE || audience === userInfoAudience)
 }
 
 function hasMatchingMcpResourceClaim(payload: Record<string, unknown>) {
@@ -152,7 +154,7 @@ function hasMatchingMcpResourceClaim(payload: Record<string, unknown>) {
 
 function readTokenResource(payload: Record<string, unknown>, source: McpTokenSource) {
   if (source === "jwt") {
-    return hasExactMcpOauthAudience(payload) && hasMatchingMcpResourceClaim(payload) ? DEN_MCP_OAUTH_RESOURCE : null
+    return hasAcceptedMcpOauthAudience(payload) && hasMatchingMcpResourceClaim(payload) ? DEN_MCP_OAUTH_RESOURCE : null
   }
 
   const resource = readStringClaim(payload, DEN_MCP_RESOURCE_CLAIM)

--- a/ee/apps/den-api/src/mcp/policy.ts
+++ b/ee/apps/den-api/src/mcp/policy.ts
@@ -67,10 +67,6 @@ export function isMcpOperationAllowed(input: {
     return false
   }
 
-  if (input.method.toUpperCase() === "POST" && /^\/v1\/plugins\/[^/]+\/mcp-connections$/.test(input.path)) {
-    return false
-  }
-
   const tags = input.operation.tags ?? []
   if (tags.some((tag) => BLOCKED_TAGS.has(tag))) {
     return false

--- a/ee/apps/den-api/test/mcp-access-token-contract.test.ts
+++ b/ee/apps/den-api/test/mcp-access-token-contract.test.ts
@@ -162,6 +162,13 @@ async function expectError(name, token, context, expected) {
   }
 }
 
+async function expectPrincipal(name, token, context) {
+  const principal = await verifyMcpRequest(new Headers({ authorization: "Bearer " + token }), context)
+  if (principal instanceof Response) {
+    throw new Error(name + " failed with " + JSON.stringify(await principal.json()))
+  }
+}
+
 await expectError("mismatched custom resource claim", signJwt({ [resourceClaim]: parentResource }), agentContext("req_mismatch"), {
   status: 401,
   error: "wrong_mcp_resource",
@@ -176,6 +183,12 @@ await expectError("multi audience", signJwt({ aud: [agentResource, parentResourc
   status: 401,
   error: "wrong_mcp_resource",
 })
+
+await expectPrincipal(
+  "OAuth token with standard userinfo audience",
+  signJwt({ aud: [agentResource, apiOrigin + "/api/auth/oauth2/userinfo"] }),
+  agentContext("req_userinfo_aud"),
+)
 
 await expectError("agent JWT on parent route", signJwt({}), parentContext("req_exact_agent_parent"), {
   status: 401,

--- a/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
@@ -106,12 +106,15 @@ describe("agent-configurable org connections policy", () => {
     }))
   })
 
-  test("plugin MCP setup that can carry secrets is excluded from the agent catalog", () => {
-    expect(allowed("postV1PluginsByPluginIdMcpConnections")).toBe(false)
+  test("plugin MCP requirements are agent-configurable without exposing secret setup", () => {
+    expect(allowed("postV1PluginsByPluginIdMcpConnections")).toBe(true)
     expect(document.paths["/v1/plugins/{pluginId}/mcp-requirements/configure"]).toBeUndefined()
     const catalog = buildMcpCatalog(document)
-    expect(catalog.some((operation) => operation.path === "/v1/plugins/{pluginId}/mcp-connections")).toBe(false)
-    expect(searchCapabilities(catalog, "configure plugin mcp connection oauth client", 20).some((match) => match.path.includes("/plugins/") && match.path.includes("/mcp-connections"))).toBe(false)
+    expect(catalog.some((operation) => operation.path === "/v1/plugins/{pluginId}/mcp-connections")).toBe(true)
+    expect(searchCapabilities(catalog, "configure plugin mcp requirement per member oauth", 20)).toContainEqual(expect.objectContaining({
+      method: "POST",
+      path: "/v1/plugins/{pluginId}/mcp-connections",
+    }))
   })
 
   test("agent capability search source filter can restrict searches to skills", () => {


### PR DESCRIPTION
## What changed

- Accept real Codex OAuth tokens whose audience array contains the OpenWork MCP resource plus the issuer's exact `oauth2/userinfo` audience.
- Keep rejecting arbitrary multi-audience tokens.
- Expose the safe plugin MCP connection binding route in the agent capability catalog.
- Keep API-key and OAuth secret setup blocked for the internal MCP agent principal.
- Add regression coverage for both contracts.

## Why

A full OpenWork Connect Daytona run found two blockers:

1. Codex completed OAuth successfully, but Den rejected its standards-compliant access token with `wrong_mcp_resource` because the verifier required exactly one audience.
2. Codex could create a plugin, MCP config object, and per-member OAuth connection, but the agent catalog hid the existing safe route that binds that connection to the plugin. The route already enforces the secret boundary in-route.

## Impact

External agents can authenticate through the OpenWork MCP and safely finish packaging an organization workflow without gaining access to API keys, OAuth client secrets, or manual MCP tool execution.

## Verification

- `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-agent-config-policy.test.ts test/mcp-access-token-contract.test.ts`
  - 11 pass, 0 fail, 39 expectations
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit`
  - passed
- Full owner-to-member Daytona E2E
  - real Codex CLI 0.144.4 on Linux
  - separate Windows VM running public OpenWork 0.17.26
  - owner packaged Customer Briefing plus a per-member Notion OAuth MCP
  - Susan joined, received the workflow without manual installation, connected Notion, and received `CUSTOMER_BRIEFING_READY`

[Frame-by-frame E2E proof](https://8090-n9zgk0w87upbtruy.daytonaproxy01.net/validation/openwork-connect-full-20260714/fraimz.html)

The proof URL is a temporary signed Daytona artifact link.