### PR TITLE
feat(den-api): add Gmail attachment download capability

### DIFF
--- a/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
+++ b/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
@@ -5,6 +5,11 @@ export type GoogleWorkspaceAttachment = {
   size: number | null
 }
 
+export type GoogleWorkspaceAttachmentData = {
+  size: number
+  dataBase64: string
+}
+
 export type GoogleWorkspaceGmailMessage = {
   id: string
   threadId: string
@@ -187,6 +192,21 @@ export function extractGmailMessage(payloadJson: unknown): GoogleWorkspaceGmailM
     snippet,
     body,
     attachments: state.attachments,
+  }
+}
+
+/**
+ * Gmail's attachments.get returns base64url data. Normalize to standard
+ * base64 so callers can decode the bytes locally with any base64 decoder.
+ */
+export function extractGmailAttachmentData(json: unknown): GoogleWorkspaceAttachmentData | null {
+  const root = isRecord(json) ? json : {}
+  const data = readString(root, "data")
+  if (!data) return null
+  const bytes = Buffer.from(data, "base64url")
+  return {
+    size: readNumber(root, "size") ?? bytes.byteLength,
+    dataBase64: bytes.toString("base64"),
   }
 }
 

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -13,6 +13,7 @@ import {
   buildDriveSearchQuery,
   extractCalendarEvents,
   extractDriveFiles,
+  extractGmailAttachmentData,
   extractGmailMessage,
   extractGmailMessageIds,
   extractGmailThreadReplyContext,
@@ -124,6 +125,19 @@ const gmailMessageResponseSchema = z.object({
   ok: z.literal(true),
   message: gmailMessageSchema,
 }).meta({ ref: "GoogleWorkspaceGmailMessageResponse" })
+
+const gmailAttachmentParamSchema = z.object({
+  messageId: z.string().trim().min(1).max(512).describe("Gmail message id that contains the attachment."),
+  attachmentId: z.string().trim().min(1).max(2_048).describe("Attachment id from the gmail-message capability's attachments metadata."),
+}).meta({ ref: "GoogleWorkspaceGmailAttachmentParams" })
+
+const gmailAttachmentResponseSchema = z.object({
+  ok: z.literal(true),
+  messageId: z.string(),
+  attachmentId: z.string(),
+  size: z.number().describe("Attachment size in bytes."),
+  dataBase64: z.string().describe("Standard base64-encoded attachment bytes; decode locally to reconstruct the file."),
+}).meta({ ref: "GoogleWorkspaceGmailAttachmentResponse" })
 
 const calendarEventsQuerySchema = z.object({
   timeMin: z.string().datetime().describe("Inclusive lower bound for event start time."),
@@ -418,7 +432,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     describeRoute({
       tags: ["Capability Sources"],
       summary: "Read a Gmail message with its plain-text body as the calling member",
-      description: "Reads one Gmail message, including decoded plain-text body content and attachment metadata, using the calling member's connected Google Workspace account.",
+      description: "Reads one Gmail message, including decoded plain-text body content and attachment metadata, using the calling member's connected Google Workspace account. To download an attachment's bytes, pass its attachmentId to the gmail-attachment capability.",
       responses: {
         200: jsonResponse("Gmail message returned.", gmailMessageResponseSchema),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
@@ -455,6 +469,55 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
       }
 
       return c.json({ ok: true, message: extractGmailMessage(await readJson(response)) })
+    },
+  )
+
+  app.get(
+    "/v1/capabilities/google-workspace/gmail-attachment/:messageId/:attachmentId",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "Download a Gmail attachment's bytes as the calling member",
+      description: "Downloads one Gmail attachment (file) as base64-encoded bytes, using the messageId and the attachmentId from the gmail-message capability's attachments metadata. Decode dataBase64 locally to reconstruct the file, e.g. a PDF or spreadsheet, then extract its contents.",
+      responses: {
+        200: jsonResponse("Gmail attachment returned.", gmailAttachmentResponseSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
+        502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
+      },
+    }),
+    orgMemberRoute(),
+    paramValidator(gmailAttachmentParamSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const token = await googleWorkspaceToken({
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if (token.kind === "google_api_error") {
+        return c.json({ error: "google_api_error", message: token.message }, 502)
+      }
+      if (token.kind === "needs_connection") {
+        return c.json({ error: "needs_connection", message: token.message }, 409)
+      }
+      if (missingScope(token.account, [GMAIL_READ_SCOPE])) {
+        return c.json({ error: "needs_connection", message: missingPermissionMessage("Gmail read") }, 409)
+      }
+
+      const { messageId, attachmentId } = c.req.valid("param")
+      const url = new URL(`${gmailApiBase()}/gmail/v1/users/me/messages/${encodeURIComponent(messageId)}/attachments/${encodeURIComponent(attachmentId)}`)
+      const response = await googleWorkspaceApiFetch(url, {
+        headers: { authorization: `Bearer ${token.accessToken}` },
+      })
+      if (!response.ok) {
+        return c.json(await googleApiError("Gmail attachment download", response), 502)
+      }
+
+      const attachment = extractGmailAttachmentData(await readJson(response))
+      if (!attachment) {
+        return c.json({ error: "google_api_error", message: "Gmail attachment download returned no data." }, 502)
+      }
+
+      return c.json({ ok: true, messageId, attachmentId, size: attachment.size, dataBase64: attachment.dataBase64 })
     },
   )
 
@@ -766,7 +829,7 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     "/v1/capabilities/google-workspace/gmail-drafts",
     describeRoute({
       tags: ["Capability Sources"],
-      summary: "Create a Gmail draft or threaded reply draft; attach workspace files with body.attachments: [{ filename, mimeType, dataBase64 }], where dataBase64 is the file bytes encoded as standard base64",
+      summary: "Create a Gmail draft or threaded reply draft; attach workspace files with body.attachments: [{ filename, mimeType, dataBase64 }], where dataBase64 is each attachment's file bytes encoded as standard base64",
       description: "Creates a plain-text Gmail draft in the calling member own mailbox, with optional Cc/Bcc recipients and files read from the active workspace. Set threadId to attach the draft to an existing Gmail thread as a reply using the thread's matching subject. Returns needs_connection when the member has not connected their Google account yet or when a threaded reply needs Gmail read permission.",
       responses: {
         200: jsonResponse("Draft created.", createDraftResponseSchema),

--- a/ee/apps/den-api/test/google-workspace-api.test.ts
+++ b/ee/apps/den-api/test/google-workspace-api.test.ts
@@ -3,6 +3,7 @@ import {
   buildDriveSearchQuery,
   extractCalendarEvents,
   extractDriveFiles,
+  extractGmailAttachmentData,
   extractGmailMessage,
   truncateText,
 } from "../src/capability-sources/google-workspace-api.js"
@@ -70,6 +71,25 @@ describe("extractGmailMessage", () => {
       payload: { mimeType: "text/plain", body: { data: base64Url("x".repeat(100_010)) } },
     })
     expect(message.body.length).toBe(100_000)
+  })
+})
+
+describe("extractGmailAttachmentData", () => {
+  test("normalizes base64url data to standard base64 and keeps Gmail's size", () => {
+    // "----_w" decodes to bytes fb ef be ff; standard base64 re-encodes them as "++++/w==".
+    expect(extractGmailAttachmentData({ size: 4, data: "----_w" })).toEqual({ size: 4, dataBase64: "++++/w==" })
+  })
+
+  test("falls back to decoded byte length when size is missing", () => {
+    expect(extractGmailAttachmentData({ data: base64Url("hello") })).toEqual({
+      size: 5,
+      dataBase64: Buffer.from("hello", "utf8").toString("base64"),
+    })
+  })
+
+  test("returns null when Gmail sends no data", () => {
+    expect(extractGmailAttachmentData({ size: 4 })).toBeNull()
+    expect(extractGmailAttachmentData(null)).toBeNull()
   })
 })
 

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -100,6 +100,9 @@ function resetFakeGoogle() {
   lastGmailThreadUrl = null
 }
 
+// Trailing high bytes force base64url output ("-"/"_") to differ from standard base64 ("+"/"/").
+const attachmentBytes = Buffer.concat([Buffer.from("%PDF-1.4 fake attachment", "utf8"), Buffer.from([0xfb, 0xef, 0xbe, 0xff])])
+
 function gmailMessagePayload() {
   return {
     id: "msg_1",
@@ -144,6 +147,9 @@ const fakeGoogleServer = Bun.serve({
     }
     if (url.pathname === "/gmail/v1/users/me/messages/msg_1") {
       return json(gmailMessagePayload())
+    }
+    if (url.pathname === "/gmail/v1/users/me/messages/msg_1/attachments/att_1") {
+      return json({ attachmentId: "att_1", size: attachmentBytes.byteLength, data: attachmentBytes.toString("base64url") })
     }
     if (url.pathname === "/gmail/v1/users/me/threads/thread_1") {
       lastGmailThreadUrl = request.url
@@ -520,6 +526,42 @@ test("gmail list returns metadata-mapped messages", async () => {
   })
 })
 
+test("gmail attachment download returns standard base64 bytes and sends the member token", async () => {
+  // The fixture must exercise base64url -> base64 normalization, or this test proves nothing.
+  expect(attachmentBytes.toString("base64url")).not.toBe(attachmentBytes.toString("base64"))
+
+  const response = await request("/v1/capabilities/google-workspace/gmail-attachment/msg_1/att_1")
+  expect(response.status).toBe(200)
+  expect(lastAuthorization).toBe("Bearer gws-token")
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    ok: true,
+    messageId: "msg_1",
+    attachmentId: "att_1",
+    size: attachmentBytes.byteLength,
+    dataBase64: attachmentBytes.toString("base64"),
+  })
+})
+
+test("gmail attachment download requires Gmail read scope before calling Google", async () => {
+  await seedConnectedAccount([CALENDAR_READ_SCOPE, CALENDAR_EVENTS_SCOPE, DRIVE_READ_SCOPE])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/gmail-attachment/msg_1/att_1")
+  expect(response.status).toBe(409)
+  expect(googleCallCount).toBe(0)
+  const body: unknown = await response.json()
+  expect(expectMessage(body)).toContain("missing the Gmail read permission")
+})
+
+test("gmail attachment download returns google_api_error when Google rejects the attachment id", async () => {
+  const response = await request("/v1/capabilities/google-workspace/gmail-attachment/msg_1/att_missing")
+  expect(response.status).toBe(502)
+  const body: unknown = await response.json()
+  const responseBody = expectRecord(body, "attachment error response")
+  expect(responseBody.error).toBe("google_api_error")
+  expect(expectMessage(body).startsWith("Gmail attachment download failed: 404")).toBe(true)
+})
+
 test("gmail plain draft supports cc without requiring a thread", async () => {
   const to = "sam@acme.test"
   const subject = "Quarterly plan"
@@ -810,10 +852,12 @@ test("Google Workspace capability tools are discoverable and keep readable names
   expect(draftMatch?.name).toBe("postCapabilitiesGoogleWorkspaceGmailDrafts")
   expect(draftMatch?.summary).toContain("attachments: [{ filename, mimeType, dataBase64 }]")
   expect(draftMatch?.summary).toContain("standard base64")
+  expect(searchCapabilities(catalog, "download gmail attachment bytes", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceGmailAttachment")
 
   const expectedNames = [
     "getCapabilitiesGoogleWorkspaceGmailMessages",
     "getCapabilitiesGoogleWorkspaceGmailMessage",
+    "getCapabilitiesGoogleWorkspaceGmailAttachment",
     "getCapabilitiesGoogleWorkspaceCalendarEvents",
     "postCapabilitiesGoogleWorkspaceCalendarEvents",
     "patchCapabilitiesGoogleWorkspaceCalendarEvent",


### PR DESCRIPTION
## Why

An agent working a real task hit this wall:

> The Workspace connector exposes attachment metadata but not attachment bytes. I found both files in the exact Gmail thread, so I'm opening them from Gmail and extracting their contents locally.

The Den capability surface (`search_capabilities`/`execute_capability`) returned attachment metadata on `gmail-message` with no way to fetch the bytes — only the local server extension had `gmail_download_attachment`.

## What

- New capability: `GET /v1/capabilities/google-workspace/gmail-attachment/:messageId/:attachmentId` → tool `getCapabilitiesGoogleWorkspaceGmailAttachment` (45 chars, within the 49-char Bedrock budget). Same pattern as sibling routes: member-brokered token, `gmail.readonly` scope check (409 `needs_connection`), Gmail `users.messages.attachments.get`, 502 `google_api_error` passthrough.
- Returns `{ ok, messageId, attachmentId, size, dataBase64 }` with **standard** base64 (Gmail returns base64url) so agents can decode with any decoder. No size cap: Gmail bounds attachments at ~25MB and the local extension behaves the same.
- `extractGmailAttachmentData()` parser in `google-workspace-api.ts` (+ null on missing data, size fallback to decoded byte length).
- `gmail-message` capability description now points at `gmail-attachment`, so discovery works: read message → `attachmentId` → download → decode locally.
- Reworded the `gmail-drafts` summary ("each attachment's file bytes") so the draft tool keeps winning `"gmail draft workspace attachment"` searches now that a second attachment tool exists — the scorer only exact-matches summary tokens, and the summary previously never contained the singular token "attachment". Existing `toContain` assertions unchanged.

## Tests

From `ee/apps/den-api` (bun 1.3.10, local MySQL, schema via `den-db db:push`):

- `bun test test/google-workspace-capabilities.test.ts test/google-workspace-api.test.ts` — **32 pass, 0 fail**
  - new: attachment download returns member-token-authorized standard base64 (fixture proves base64url→base64 normalization), scope-missing → 409 without calling Google, Google 404 → 502 `google_api_error`
  - catalog test extended: tool discoverable, `"download gmail attachment bytes"` ranks it first, name-length guard
  - 3 new parser tests
- `bun test test/mcp-tool-name-length.test.ts test/native-provider-scopes.test.ts test/gmail-draft.test.ts test/mcp-agent-config-policy.test.ts test/route-access-policy.test.ts` — **39 pass, 0 fail**
- `npx tsc --noEmit` — clean

No video/fraimz: server-side API capability with no UI surface; validated by driving the real Hono app against a fake Google server, including the MCP catalog/search discovery path. Reviewer repro:

```sh
pnpm --filter "@openwork-ee/den-api^..." build
docker exec <mysql> mysql -uroot -ppassword -e 'CREATE DATABASE IF NOT EXISTS openwork_test_gwscaps_pr;'
DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_test_gwscaps_pr pnpm --filter @openwork-ee/den-db db:push
cd ee/apps/den-api && DATABASE_URL=mysql://root:password@127.0.0.1:3306/openwork_test_gwscaps_pr bun test test/google-workspace-capabilities.test.ts test/google-workspace-api.test.ts
```