### PR TITLE
feat(mcp): improve tool failure attribution

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-tool-inspection.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-tool-inspection.ts
@@ -381,27 +381,29 @@ export function diagnoseExternalMcpToolCall(input: {
       return {
         status: "failed",
         layer: "network",
-        summary: "OpenWork sent tools/call but the remote MCP did not answer before OpenWork stopped waiting at its deadline.",
+        summary: "Den sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
       }
     }
     return {
       status: "failed",
       layer: "network",
-      summary: "OpenWork sent tools/call but did not receive an HTTP response from the remote MCP.",
+      summary: "Den started tools/call but did not capture an HTTP response. This does not prove the remote MCP caused the failure.",
     }
   }
   if (input.inspection.response.status < 200 || input.inspection.response.status >= 300) {
     return {
       status: "failed",
       layer: "remote_http",
-      summary: `The remote MCP returned HTTP ${input.inspection.response.status} before the tool completed.`,
+      summary: `The remote MCP returned HTTP ${input.inspection.response.status}.`,
     }
   }
   return {
     status: "failed",
     layer: "mcp_tool",
-    summary: input.diagnostic?.phase === "MCP_TOOL_EXECUTION" || input.diagnostic?.phase === "PROVIDER_EXECUTION"
-      ? "The remote MCP answered, but the MCP tool result reported a provider or tool failure."
+    summary: input.diagnostic?.phase === "PROVIDER_AUTHORIZATION" || input.diagnostic?.phase === "PROVIDER_EXECUTION"
+      ? "The remote MCP responded, but the downstream provider rejected the operation."
+      : input.diagnostic?.phase === "MCP_TOOL_EXECUTION"
+        ? "The remote MCP responded, but the MCP tool returned an error."
       : "The remote MCP answered, but OpenWork could not accept the MCP response as a successful tool result.",
   }
 }

--- a/ee/apps/den-api/test/external-mcp-tool-inspection.test.ts
+++ b/ee/apps/den-api/test/external-mcp-tool-inspection.test.ts
@@ -104,7 +104,7 @@ test("ignores lifecycle requests and classifies a tools/call with no response as
   expect(diagnoseExternalMcpToolCall({ inspection, succeeded: false })).toEqual({
     status: "failed",
     layer: "network",
-    summary: "OpenWork sent tools/call but did not receive an HTTP response from the remote MCP.",
+    summary: "Den started tools/call but did not capture an HTTP response. This does not prove the remote MCP caused the failure.",
   })
 })
 
@@ -209,7 +209,41 @@ test("attributes a blocked or deadline-stopped tools/call to the right layer", (
   })).toEqual({
     status: "failed",
     layer: "network",
-    summary: "OpenWork sent tools/call but the remote MCP did not answer before OpenWork stopped waiting at its deadline.",
+    summary: "Den sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
+  })
+})
+
+test("attributes remote HTTP and downstream provider failures without crossing evidence boundaries", () => {
+  const request = {
+    method: "POST",
+    url: "https://mcp.example.test/rpc",
+    startedAt: new Date().toISOString(),
+    headers: [],
+    body: { text: "{}", bytes: 2, truncated: false },
+  }
+  const response = {
+    status: 504,
+    statusText: "Gateway Timeout",
+    durationMs: 500,
+    headers: [],
+    body: { text: "", bytes: 0, truncated: false },
+  }
+  expect(diagnoseExternalMcpToolCall({
+    inspection: { request, response },
+    succeeded: false,
+  })).toEqual({
+    status: "failed",
+    layer: "remote_http",
+    summary: "The remote MCP returned HTTP 504.",
+  })
+  expect(diagnoseExternalMcpToolCall({
+    inspection: { request, response: { ...response, status: 200, statusText: "OK" } },
+    succeeded: false,
+    diagnostic: { phase: "PROVIDER_EXECUTION" },
+  })).toEqual({
+    status: "failed",
+    layer: "mcp_tool",
+    summary: "The remote MCP responded, but the downstream provider rejected the operation.",
   })
 })
 

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -86,6 +86,38 @@ export class ReauthRequiredError extends Error {
   }
 }
 
+function formatDeadlineDuration(timeoutMs: number): string {
+  if (timeoutMs < 1000) return `${timeoutMs} milliseconds`;
+  const seconds = timeoutMs / 1000;
+  return Number.isInteger(seconds) ? `${seconds} seconds` : `${seconds.toFixed(1)} seconds`;
+}
+
+export class DenRequestTimeoutError extends Error {
+  readonly timeoutMs: number;
+  readonly outcome: "unknown" = "unknown";
+
+  constructor(timeoutMs: number, cause?: unknown) {
+    super(
+      `The OpenWork dashboard stopped waiting for Den after ${formatDeadlineDuration(timeoutMs)}. The operation’s outcome is unknown.`,
+      cause === undefined ? undefined : { cause },
+    );
+    this.name = "DenRequestTimeoutError";
+    this.timeoutMs = timeoutMs;
+  }
+}
+
+export class DenRequestCanceledError extends Error {
+  readonly outcome: "unknown" = "unknown";
+
+  constructor(cause?: unknown) {
+    super(
+      "The request to Den was canceled before the dashboard received a result. The operation’s outcome is unknown.",
+      cause === undefined ? undefined : { cause },
+    );
+    this.name = "DenRequestCanceledError";
+  }
+}
+
 export type WorkerLaunch = {
   workerId: string;
   workerName: string;
@@ -1058,8 +1090,10 @@ export async function requestJson(path: string, init: RequestInit = {}, timeoutM
 
   const shouldAttachTimeout = !init.signal && timeoutMs > 0;
   const timeoutController = shouldAttachTimeout ? new AbortController() : null;
+  let didReachDashboardDeadline = false;
   const timeoutHandle = timeoutController
     ? setTimeout(() => {
+        didReachDashboardDeadline = true;
         timeoutController.abort();
       }, timeoutMs)
     : null;
@@ -1073,6 +1107,16 @@ export async function requestJson(path: string, init: RequestInit = {}, timeoutM
       credentials: "include",
       signal: init.signal ?? timeoutController?.signal
     });
+  } catch (error) {
+    // Only the deadline created by this helper becomes a timeout. An abort
+    // supplied by a caller becomes a distinct cancellation error.
+    if (didReachDashboardDeadline) {
+      throw new DenRequestTimeoutError(timeoutMs, error);
+    }
+    if (init.signal?.aborted && error instanceof Error && error.name === "AbortError") {
+      throw new DenRequestCanceledError(error);
+    }
+    throw error;
   } finally {
     if (timeoutHandle) {
       clearTimeout(timeoutHandle);

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -3,6 +3,10 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { getRequestError, requestJson } from "../../_lib/den-flow";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import {
+  type ExternalMcpDiagnostic,
+  parseExternalMcpDiagnostic,
+} from "./mcp-tool-error-attribution";
 
 const ORG_SCOPE_HEADER = "x-openwork-org-id";
 
@@ -112,11 +116,17 @@ export type ExternalMcpToolCallInspection = {
 
 export class ExternalMcpToolRunError extends Error {
   readonly inspection: ExternalMcpToolCallInspection | null;
+  readonly diagnostic: ExternalMcpDiagnostic | null;
 
-  constructor(message: string, inspection: ExternalMcpToolCallInspection | null) {
+  constructor(
+    message: string,
+    inspection: ExternalMcpToolCallInspection | null,
+    diagnostic: ExternalMcpDiagnostic | null,
+  ) {
     super(message);
     this.name = "ExternalMcpToolRunError";
     this.inspection = inspection;
+    this.diagnostic = diagnostic;
   }
 }
 
@@ -199,6 +209,7 @@ export function useRunMcpConnectionTool(connectionId: string) {
         throw new ExternalMcpToolRunError(
           requestError.message,
           isRecord(payload) ? parseToolCallInspection(payload.inspection) : null,
+          isRecord(payload) ? parseExternalMcpDiagnostic(payload.diagnostic) : null,
         );
       }
       if (

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-error-attribution.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-error-attribution.ts
@@ -1,0 +1,294 @@
+export type ExternalMcpDiagnostic = {
+  referenceId?: string;
+  phase?: string;
+  category?: string;
+  code?: string;
+  retryable?: boolean;
+  actionOwner?: "openwork" | "network_admin" | "provider_admin" | "organization_admin" | "member";
+  operatorAction?: string;
+  message?: string;
+  highestPassed?: "configured" | "reachable" | "authorized" | "protocol_ready" | "catalog_ready" | "operation_ready";
+  httpStatus?: number;
+  operationPhase?: string;
+  providerStatus?: number;
+  providerRequestId?: string;
+  providerCode?: string;
+};
+
+type InspectionEvidence = {
+  request?: unknown;
+  response?: {
+    status: number;
+    headers?: Array<{ name: string; value: string; redacted: boolean }>;
+  };
+  diagnosis?: {
+    layer?: string;
+    summary?: string;
+  };
+};
+
+type BrowserTimeoutEvidence = {
+  timeoutMs: number;
+  outcome: "unknown";
+};
+
+export type ExternalMcpFailureAttribution = {
+  summary: string;
+  lastConfirmedBoundary: string;
+  likelySource: string;
+  confidence: "Confirmed" | "Inferred";
+  retryGuidance: string;
+  outcome: "failed" | "unknown";
+  diagnosticReference?: string;
+  providerRequestId?: string;
+  diagnosticCode?: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function optionalNumber(value: unknown): number | undefined {
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined;
+}
+
+function optionalActionOwner(value: unknown): ExternalMcpDiagnostic["actionOwner"] {
+  if (
+    value === "openwork"
+    || value === "network_admin"
+    || value === "provider_admin"
+    || value === "organization_admin"
+    || value === "member"
+  ) return value;
+  return undefined;
+}
+
+function optionalHighestPassed(value: unknown): ExternalMcpDiagnostic["highestPassed"] {
+  if (
+    value === "configured"
+    || value === "reachable"
+    || value === "authorized"
+    || value === "protocol_ready"
+    || value === "catalog_ready"
+    || value === "operation_ready"
+  ) return value;
+  return undefined;
+}
+
+export function parseExternalMcpDiagnostic(value: unknown): ExternalMcpDiagnostic | null {
+  if (!isRecord(value)) return null;
+
+  const referenceId = optionalString(value.referenceId);
+  const phase = optionalString(value.phase);
+  const category = optionalString(value.category);
+  const code = optionalString(value.code);
+  const actionOwner = optionalActionOwner(value.actionOwner);
+  const operatorAction = optionalString(value.operatorAction);
+  const message = optionalString(value.message);
+  const highestPassed = optionalHighestPassed(value.highestPassed);
+  const httpStatus = optionalNumber(value.httpStatus);
+  const operationPhase = optionalString(value.operationPhase);
+  const providerStatus = optionalNumber(value.providerStatus);
+  const providerRequestId = optionalString(value.providerRequestId);
+  const providerCode = optionalString(value.providerCode);
+  const diagnostic: ExternalMcpDiagnostic = {
+    ...(referenceId ? { referenceId } : {}),
+    // Keep unknown future phases/categories as safe strings so an older
+    // dashboard can still show the reference and fall back to wire evidence.
+    ...(phase ? { phase } : {}),
+    ...(category ? { category } : {}),
+    ...(code ? { code } : {}),
+    ...(typeof value.retryable === "boolean" ? { retryable: value.retryable } : {}),
+    ...(actionOwner ? { actionOwner } : {}),
+    ...(operatorAction ? { operatorAction } : {}),
+    ...(message ? { message } : {}),
+    ...(highestPassed ? { highestPassed } : {}),
+    ...(httpStatus !== undefined ? { httpStatus } : {}),
+    ...(operationPhase ? { operationPhase } : {}),
+    ...(providerStatus !== undefined ? { providerStatus } : {}),
+    ...(providerRequestId ? { providerRequestId } : {}),
+    ...(providerCode ? { providerCode } : {}),
+  };
+
+  return Object.keys(diagnostic).length > 0 ? diagnostic : null;
+}
+
+function providerRequestIdFromInspection(inspection: InspectionEvidence | null): string | undefined {
+  const requestIdHeaders = new Set([
+    "x-ms-request-id",
+    "x-ms-correlation-request-id",
+    "x-servicenow-request-id",
+    "x-correlation-id",
+    "x-transaction-id",
+    "request-id",
+    "x-request-id",
+  ]);
+  return inspection?.response?.headers?.find((header) => (
+    !header.redacted
+    && requestIdHeaders.has(header.name.toLowerCase())
+    && header.value.trim().length > 0
+  ))?.value;
+}
+
+function unknownOutcomeGuidance(mayHaveSideEffects: boolean): string {
+  return mayHaveSideEffects
+    ? "Do not retry immediately. This tool may have changed external data; verify provider state before trying again."
+    : "The first call may still finish. Check recent provider activity before retrying.";
+}
+
+function lastBoundaryFromDiagnostic(diagnostic: ExternalMcpDiagnostic | null): string | undefined {
+  if (diagnostic?.highestPassed === "operation_ready") return "Den started remote tool execution";
+  if (diagnostic?.highestPassed === "catalog_ready") return "Den loaded the remote MCP tool catalog";
+  if (diagnostic?.highestPassed === "protocol_ready") return "Den initialized the remote MCP session";
+  if (diagnostic?.highestPassed === "authorized") return "Remote MCP accepted the connection credential";
+  if (diagnostic?.highestPassed === "reachable") return "Den reached the remote MCP endpoint";
+  if (diagnostic?.highestPassed === "configured") return "Den loaded the MCP connection configuration";
+  return undefined;
+}
+
+function diagnosticDetails(diagnostic: ExternalMcpDiagnostic | null, inspection: InspectionEvidence | null) {
+  const providerRequestId = diagnostic?.providerRequestId ?? providerRequestIdFromInspection(inspection);
+  return {
+    ...(diagnostic?.referenceId ? { diagnosticReference: diagnostic.referenceId } : {}),
+    ...(providerRequestId ? { providerRequestId } : {}),
+    ...(diagnostic?.code || diagnostic?.category
+      ? { diagnosticCode: diagnostic.code ?? diagnostic.category }
+      : {}),
+  };
+}
+
+export function attributeExternalMcpToolFailure(input: {
+  diagnostic: ExternalMcpDiagnostic | null;
+  inspection: InspectionEvidence | null;
+  browserTimeout: BrowserTimeoutEvidence | null;
+  mayHaveSideEffects: boolean;
+}): ExternalMcpFailureAttribution {
+  const { browserTimeout, diagnostic, inspection, mayHaveSideEffects } = input;
+  const details = diagnosticDetails(diagnostic, inspection);
+
+  if (browserTimeout) {
+    const seconds = browserTimeout.timeoutMs / 1000;
+    const duration = Number.isInteger(seconds) ? `${seconds}` : seconds.toFixed(1);
+    return {
+      summary: `The OpenWork dashboard stopped waiting for Den after ${duration} seconds. The operation’s outcome is unknown.`,
+      lastConfirmedBoundary: "Dashboard started the request to Den",
+      likelySource: "Den, the network path, the remote MCP, or the downstream tool",
+      confidence: "Inferred",
+      retryGuidance: unknownOutcomeGuidance(mayHaveSideEffects),
+      outcome: "unknown",
+      ...details,
+    };
+  }
+
+  const blockedBeforeSend = diagnostic?.category === "security_blocked"
+    || diagnostic?.code === "MCP_URL_BLOCKED"
+    || diagnostic?.code === "MCP_FETCH_FORBIDDEN_PORT";
+  if (blockedBeforeSend) {
+    return {
+      summary: "OpenWork blocked the request before it left Den.",
+      lastConfirmedBoundary: "Den evaluated the outbound request",
+      likelySource: "OpenWork policy or connection configuration",
+      confidence: "Confirmed",
+      retryGuidance: diagnostic?.operatorAction ?? "Resolve the OpenWork policy or connection configuration, then run the tool again.",
+      outcome: "failed",
+      ...details,
+    };
+  }
+
+  const responseStatus = inspection?.response?.status ?? diagnostic?.httpStatus;
+  if (responseStatus !== undefined && (responseStatus < 200 || responseStatus >= 300)) {
+    const retryableStatus = responseStatus === 408 || responseStatus === 429 || responseStatus === 502
+      || responseStatus === 503 || responseStatus === 504;
+    return {
+      summary: `The remote MCP returned HTTP ${responseStatus}.`,
+      lastConfirmedBoundary: `Remote MCP returned HTTP ${responseStatus}`,
+      likelySource: "Remote MCP HTTP layer",
+      confidence: "Confirmed",
+      retryGuidance: mayHaveSideEffects && (responseStatus === 408 || responseStatus === 504)
+        ? "Check the remote MCP or provider for a completed operation before retrying this tool."
+        : diagnostic?.operatorAction
+          ?? (diagnostic?.retryable || retryableStatus
+            ? "Retry with bounded backoff after confirming the operation is safe to repeat."
+            : "Inspect the remote MCP response and configuration before retrying."),
+      outcome: "failed",
+      ...details,
+    };
+  }
+
+  const providerFailure = diagnostic?.phase?.startsWith("PROVIDER_")
+    || diagnostic?.providerStatus !== undefined
+    || diagnostic?.providerCode !== undefined;
+  if (providerFailure) {
+    return {
+      summary: "The remote MCP responded, but the downstream provider rejected the operation.",
+      lastConfirmedBoundary: responseStatus !== undefined
+        ? `Remote MCP returned HTTP ${responseStatus} with a tool error`
+        : "Remote MCP returned a tool error",
+      likelySource: "Downstream provider or tool",
+      confidence: "Confirmed",
+      retryGuidance: diagnostic?.operatorAction
+        ?? (diagnostic?.retryable
+          ? "Retry with bounded backoff after checking the provider status."
+          : "Resolve the provider error before retrying."),
+      outcome: "failed",
+      ...details,
+    };
+  }
+
+  const deadlineAfterSend = Boolean(inspection?.request)
+    && !inspection?.response
+    && (diagnostic?.code === "MCP_LIFECYCLE_DEADLINE" || diagnostic?.code === "MCP_REQUEST_TIMEOUT");
+  if (deadlineAfterSend) {
+    return {
+      summary: "Den sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
+      lastConfirmedBoundary: "Den started the outbound tools/call",
+      likelySource: "Network path or remote MCP after Den",
+      confidence: "Inferred",
+      retryGuidance: unknownOutcomeGuidance(mayHaveSideEffects),
+      outcome: "unknown",
+      ...details,
+    };
+  }
+
+  if (inspection?.request && !inspection.response) {
+    return {
+      summary: "Den started the outbound request, but no HTTP response was captured. This does not prove the remote MCP caused the failure.",
+      lastConfirmedBoundary: "Den started the outbound tools/call",
+      likelySource: "Den outbound path, network, or remote MCP",
+      confidence: "Inferred",
+      retryGuidance: unknownOutcomeGuidance(mayHaveSideEffects),
+      outcome: "unknown",
+      ...details,
+    };
+  }
+
+  if (inspection?.response) {
+    return {
+      summary: inspection.diagnosis?.summary ?? "The remote MCP responded, but the tool result was not successful.",
+      lastConfirmedBoundary: `Remote MCP returned HTTP ${inspection.response.status}`,
+      likelySource: "MCP protocol or tool result",
+      confidence: "Inferred",
+      retryGuidance: diagnostic?.operatorAction ?? "Inspect the MCP tool result and diagnostic reference before retrying.",
+      outcome: "failed",
+      ...details,
+    };
+  }
+
+  const networkSetup = diagnostic?.phase?.startsWith("NETWORK_") || inspection?.diagnosis?.layer === "network";
+  return {
+    summary: inspection?.diagnosis?.summary
+      ?? diagnostic?.message
+      ?? "The request failed before OpenWork received a tool result.",
+    lastConfirmedBoundary: lastBoundaryFromDiagnostic(diagnostic)
+      ?? (diagnostic ? "Den returned a structured diagnostic" : "Dashboard started the request to Den"),
+    likelySource: networkSetup ? "Den connection path or remote MCP setup" : "OpenWork or MCP connection setup",
+    confidence: "Inferred",
+    retryGuidance: diagnostic?.operatorAction ?? "Use the diagnostic reference to inspect Den and MCP connection health before retrying.",
+    outcome: "failed",
+    ...details,
+  };
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
@@ -5,6 +5,7 @@ import { AlertTriangle, ArrowRight, Check, Loader2, LockKeyhole, Play, RefreshCw
 import { DenButton } from "../../_components/ui/button";
 import { DenSelect } from "../../_components/ui/select";
 import { DenTextarea } from "../../_components/ui/textarea";
+import { DenRequestTimeoutError } from "../../_lib/den-flow";
 import {
   type ExternalMcpConnection,
   type ExternalMcpInspectionBody,
@@ -15,6 +16,10 @@ import {
   useMcpConnectionTools,
   useRunMcpConnectionTool,
 } from "./mcp-connections-data";
+import {
+  attributeExternalMcpToolFailure,
+  type ExternalMcpFailureAttribution,
+} from "./mcp-tool-error-attribution";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -101,7 +106,58 @@ function diagnosisLayerLabel(layer: ExternalMcpToolCallInspection["diagnosis"]["
   return "MCP tool response";
 }
 
-function McpToolCallInspector({ inspection }: { inspection: ExternalMcpToolCallInspection }) {
+function McpFailureAttribution({
+  attribution,
+  standalone = false,
+}: {
+  attribution: ExternalMcpFailureAttribution;
+  standalone?: boolean;
+}) {
+  return (
+    <div
+      className={`${standalone ? "rounded-2xl border border-red-200" : "border-b border-red-200"} bg-red-50 px-4 py-3`}
+      role="alert"
+    >
+      <p className="inline-flex items-center gap-1.5 text-[12px] font-semibold text-red-800">
+        <AlertTriangle className="h-4 w-4" aria-hidden="true" /> Tool call failed
+      </p>
+      <p className="mt-1 text-[11px] leading-5 text-red-700">{attribution.summary}</p>
+      <dl className="mt-3 grid gap-2 text-[10px] sm:grid-cols-2">
+        <div>
+          <dt className="font-semibold uppercase tracking-wide text-red-500">Last confirmed boundary</dt>
+          <dd className="mt-0.5 text-gray-800">{attribution.lastConfirmedBoundary}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold uppercase tracking-wide text-red-500">Likely source</dt>
+          <dd className="mt-0.5 text-gray-800">{attribution.likelySource}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold uppercase tracking-wide text-red-500">Confidence</dt>
+          <dd className="mt-0.5 text-gray-800">{attribution.confidence}</dd>
+        </div>
+        <div>
+          <dt className="font-semibold uppercase tracking-wide text-red-500">Retry guidance</dt>
+          <dd className="mt-0.5 text-gray-800">{attribution.retryGuidance}</dd>
+        </div>
+      </dl>
+      {attribution.diagnosticReference || attribution.providerRequestId || attribution.diagnosticCode ? (
+        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 border-t border-red-200 pt-2 font-mono text-[9px] text-red-700">
+          {attribution.diagnosticReference ? <span>Diagnostic reference: {attribution.diagnosticReference}</span> : null}
+          {attribution.providerRequestId ? <span>Provider request ID: {attribution.providerRequestId}</span> : null}
+          {attribution.diagnosticCode ? <span>Code: {attribution.diagnosticCode}</span> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function McpToolCallInspector({
+  inspection,
+  failureAttribution,
+}: {
+  inspection: ExternalMcpToolCallInspection;
+  failureAttribution: ExternalMcpFailureAttribution | null;
+}) {
   const succeeded = inspection.diagnosis.status === "succeeded";
   // A captured request can still have been blocked inside OpenWork (for
   // example by the outbound SSRF policy); the diagnosis layer decides
@@ -113,19 +169,26 @@ function McpToolCallInspector({ inspection }: { inspection: ExternalMcpToolCallI
       : "Not sent";
   return (
     <section className="overflow-hidden rounded-2xl border border-gray-200 bg-white" aria-label="Tool call inspection">
-      <div className={`border-b px-4 py-3 ${succeeded ? "border-emerald-200 bg-emerald-50" : "border-red-200 bg-red-50"}`}>
-        <div className="flex flex-wrap items-center justify-between gap-2">
-          <p className={`text-[12px] font-semibold ${succeeded ? "text-emerald-800" : "text-red-800"}`}>
-            {succeeded ? "Remote MCP completed the call" : `Call stopped at: ${diagnosisLayerLabel(inspection.diagnosis.layer)}`}
-          </p>
-          <div className="flex items-center gap-1.5 font-mono text-[10px] text-gray-600">
-            <span>OpenWork</span><ArrowRight className="h-3 w-3" aria-hidden="true" />
-            <span>{transportChip}</span><ArrowRight className="h-3 w-3" aria-hidden="true" />
-            <span>{succeeded ? "Tool result" : "Failure"}</span>
+      {succeeded ? (
+        <div className="border-b border-emerald-200 bg-emerald-50 px-4 py-3">
+          <div className="flex flex-wrap items-center justify-between gap-2">
+            <p className="text-[12px] font-semibold text-emerald-800">Remote MCP completed the call</p>
+            <div className="flex items-center gap-1.5 font-mono text-[10px] text-gray-600">
+              <span>OpenWork</span><ArrowRight className="h-3 w-3" aria-hidden="true" />
+              <span>{transportChip}</span><ArrowRight className="h-3 w-3" aria-hidden="true" />
+              <span>Tool result</span>
+            </div>
           </div>
+          <p className="mt-1 text-[11px] leading-5 text-emerald-700">{inspection.diagnosis.summary}</p>
         </div>
-        <p className={`mt-1 text-[11px] leading-5 ${succeeded ? "text-emerald-700" : "text-red-700"}`}>{inspection.diagnosis.summary}</p>
-      </div>
+      ) : failureAttribution ? (
+        <McpFailureAttribution attribution={failureAttribution} />
+      ) : (
+        <div className="border-b border-red-200 bg-red-50 px-4 py-3">
+          <p className="text-[12px] font-semibold text-red-800">Call stopped at: {diagnosisLayerLabel(inspection.diagnosis.layer)}</p>
+          <p className="mt-1 text-[11px] leading-5 text-red-700">{inspection.diagnosis.summary}</p>
+        </div>
+      )}
 
       <div className="border-b border-amber-100 bg-amber-50/70 px-4 py-2 text-[10px] leading-4 text-amber-800">
         Credential and session headers are redacted. Request and response bodies may contain sensitive provider data; this inspection is returned only for this run and is not stored in Den logs.
@@ -228,10 +291,24 @@ export function McpToolRunner({ connection }: { connection: ExternalMcpConnectio
     await runTool.mutateAsync({ toolName: selectedTool.name, arguments: parsed }).catch(() => undefined);
   }
 
-  const executionError = localError
-    ?? (runTool.error instanceof Error ? runTool.error.message : runTool.error ? "The MCP tool failed." : null);
   const inspection = runTool.data?.inspection
     ?? (runTool.error instanceof ExternalMcpToolRunError ? runTool.error.inspection : null);
+  const serverFailure = runTool.error instanceof ExternalMcpToolRunError ? runTool.error : null;
+  const browserTimeout = runTool.error instanceof DenRequestTimeoutError ? runTool.error : null;
+  const failureAttribution = !localError && (serverFailure || browserTimeout)
+    ? attributeExternalMcpToolFailure({
+        diagnostic: serverFailure?.diagnostic ?? null,
+        inspection,
+        browserTimeout,
+        mayHaveSideEffects: selectedTool?.annotations?.readOnlyHint !== true,
+      })
+    : null;
+  const executionError = localError
+    ?? (!failureAttribution && runTool.error instanceof Error
+      ? runTool.error.message
+      : !failureAttribution && runTool.error
+        ? "The MCP tool failed."
+        : null);
 
   return (
     <div className="border-t border-gray-100 bg-gray-50/70 px-6 py-5" data-testid={`mcp-tool-runner-${connection.id}`}>
@@ -348,7 +425,11 @@ export function McpToolRunner({ connection }: { connection: ExternalMcpConnectio
             <p className="text-[11px] text-gray-500">Runs immediately against {connection.name}.</p>
           </div>
 
-          {inspection ? <McpToolCallInspector inspection={inspection} /> : null}
+          {inspection ? (
+            <McpToolCallInspector inspection={inspection} failureAttribution={failureAttribution} />
+          ) : failureAttribution ? (
+            <McpFailureAttribution attribution={failureAttribution} standalone />
+          ) : null}
 
           {runTool.data && !runTool.data.inspection ? (
             <div className="rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-[12px] leading-5 text-amber-800" role="status">

--- a/ee/apps/den-web/tests/mcp-tool-error-attribution.test.ts
+++ b/ee/apps/den-web/tests/mcp-tool-error-attribution.test.ts
@@ -1,0 +1,232 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import {
+  DenRequestCanceledError,
+  DenRequestTimeoutError,
+  requestJson,
+} from "../app/(den)/_lib/den-flow";
+import {
+  attributeExternalMcpToolFailure,
+  parseExternalMcpDiagnostic,
+} from "../app/(den)/dashboard/_components/mcp-tool-error-attribution";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function abortingFetch(_input: string | URL | Request, init?: RequestInit): Promise<Response> {
+  return new Promise<Response>((_resolve, reject) => {
+    const signal = init?.signal;
+    const rejectAbort = () => reject(new DOMException("The operation was aborted.", "AbortError"));
+    if (!signal) {
+      reject(new Error("Expected an abort signal."));
+      return;
+    }
+    if (signal.aborted) {
+      rejectAbort();
+      return;
+    }
+    signal.addEventListener("abort", rejectAbort, { once: true });
+  });
+}
+
+describe("browser-to-Den timeout", () => {
+  test("throws a typed unknown-outcome error for the dashboard-created deadline", async () => {
+    globalThis.fetch = abortingFetch;
+    const error = await requestJson("/v1/mcp-connections/test/tools/call", {}, 5).catch((failure) => failure);
+
+    expect(error).toBeInstanceOf(DenRequestTimeoutError);
+    if (!(error instanceof DenRequestTimeoutError)) throw new Error("Expected DenRequestTimeoutError");
+    expect(error.timeoutMs).toBe(5);
+    expect(error.outcome).toBe("unknown");
+    expect(error.message).toBe(
+      "The OpenWork dashboard stopped waiting for Den after 5 milliseconds. The operation’s outcome is unknown.",
+    );
+    expect(new DenRequestTimeoutError(160_000).message).toBe(
+      "The OpenWork dashboard stopped waiting for Den after 160 seconds. The operation’s outcome is unknown.",
+    );
+  });
+
+  test("distinguishes a caller cancellation without exposing AbortError", async () => {
+    globalThis.fetch = abortingFetch;
+    const controller = new AbortController();
+    controller.abort();
+    const error = await requestJson(
+      "/v1/mcp-connections/test/tools/call",
+      { signal: controller.signal },
+      5,
+    ).catch((failure) => failure);
+
+    expect(error).not.toBeInstanceOf(DenRequestTimeoutError);
+    expect(error).toBeInstanceOf(DenRequestCanceledError);
+    if (!(error instanceof DenRequestCanceledError)) throw new Error("Expected DenRequestCanceledError");
+    expect(error.name).toBe("DenRequestCanceledError");
+    expect(error.outcome).toBe("unknown");
+  });
+});
+
+describe("MCP failure attribution", () => {
+  test("marks a Den lifecycle deadline after tools/call as inferred and unknown", () => {
+    const attribution = attributeExternalMcpToolFailure({
+      diagnostic: {
+        referenceId: "req_deadline",
+        phase: "MCP_TOOL_EXECUTION",
+        category: "lifecycle_deadline",
+        code: "MCP_LIFECYCLE_DEADLINE",
+        retryable: true,
+        actionOwner: "provider_admin",
+      },
+      inspection: { request: {} },
+      browserTimeout: null,
+      mayHaveSideEffects: false,
+    });
+
+    expect(attribution).toMatchObject({
+      summary: "Den sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
+      lastConfirmedBoundary: "Den started the outbound tools/call",
+      likelySource: "Network path or remote MCP after Den",
+      confidence: "Inferred",
+      outcome: "unknown",
+      diagnosticReference: "req_deadline",
+      diagnosticCode: "MCP_LIFECYCLE_DEADLINE",
+    });
+  });
+
+  test.each([408, 504])("attributes remote MCP HTTP %d responses as confirmed", (status) => {
+    const attribution = attributeExternalMcpToolFailure({
+      diagnostic: { referenceId: `req_${status}`, retryable: true, httpStatus: status },
+      inspection: { request: {}, response: { status, headers: [] } },
+      browserTimeout: null,
+      mayHaveSideEffects: false,
+    });
+
+    expect(attribution).toMatchObject({
+      summary: `The remote MCP returned HTTP ${status}.`,
+      lastConfirmedBoundary: `Remote MCP returned HTTP ${status}`,
+      likelySource: "Remote MCP HTTP layer",
+      confidence: "Confirmed",
+      outcome: "failed",
+    });
+  });
+
+  test("attributes an MCP/provider error returned through HTTP 200", () => {
+    const attribution = attributeExternalMcpToolFailure({
+      diagnostic: {
+        referenceId: "req_provider",
+        phase: "PROVIDER_AUTHORIZATION",
+        category: "provider_policy_denied",
+        code: "MCP_PROVIDER_HTTP_403",
+        retryable: false,
+        actionOwner: "provider_admin",
+        providerStatus: 403,
+        providerRequestId: "provider-request-123",
+      },
+      inspection: { request: {}, response: { status: 200, headers: [] } },
+      browserTimeout: null,
+      mayHaveSideEffects: false,
+    });
+
+    expect(attribution).toMatchObject({
+      summary: "The remote MCP responded, but the downstream provider rejected the operation.",
+      lastConfirmedBoundary: "Remote MCP returned HTTP 200 with a tool error",
+      likelySource: "Downstream provider or tool",
+      confidence: "Confirmed",
+      providerRequestId: "provider-request-123",
+    });
+  });
+
+  test("attributes an OpenWork block before send as confirmed", () => {
+    const attribution = attributeExternalMcpToolFailure({
+      diagnostic: {
+        referenceId: "req_blocked",
+        phase: "CONFIGURATION",
+        category: "security_blocked",
+        code: "MCP_URL_BLOCKED",
+        retryable: false,
+        actionOwner: "organization_admin",
+      },
+      // The inspector captures before the SSRF guard, so this request record
+      // does not prove that anything left Den.
+      inspection: { request: {} },
+      browserTimeout: null,
+      mayHaveSideEffects: true,
+    });
+
+    expect(attribution).toMatchObject({
+      summary: "OpenWork blocked the request before it left Den.",
+      lastConfirmedBoundary: "Den evaluated the outbound request",
+      likelySource: "OpenWork policy or connection configuration",
+      confidence: "Confirmed",
+      outcome: "failed",
+    });
+  });
+
+  test("warns against immediately retrying a destructive tool with unknown outcome", () => {
+    const attribution = attributeExternalMcpToolFailure({
+      diagnostic: null,
+      inspection: null,
+      browserTimeout: { timeoutMs: 160_000, outcome: "unknown" },
+      mayHaveSideEffects: true,
+    });
+
+    expect(attribution.summary).toBe(
+      "The OpenWork dashboard stopped waiting for Den after 160 seconds. The operation’s outcome is unknown.",
+    );
+    expect(attribution.retryGuidance).toContain("Do not retry immediately");
+    expect(attribution.retryGuidance).toContain("may have changed external data");
+  });
+
+  test("parses current diagnostics and falls back to wire evidence across deploy skew", () => {
+    expect(parseExternalMcpDiagnostic({
+      referenceId: "req_full",
+      phase: "FUTURE_PROVIDER_PHASE",
+      category: "provider_error",
+      code: "MCP_PROVIDER_ERROR",
+      retryable: false,
+      actionOwner: "provider_admin",
+      operatorAction: "Inspect provider logs.",
+      message: "Safe provider failure.",
+      highestPassed: "operation_ready",
+      httpStatus: 200,
+      operationPhase: "MCP_TOOL_EXECUTION",
+      providerStatus: 403,
+      providerRequestId: "provider-request-456",
+      providerCode: "access_denied",
+    })).toEqual({
+      referenceId: "req_full",
+      phase: "FUTURE_PROVIDER_PHASE",
+      category: "provider_error",
+      code: "MCP_PROVIDER_ERROR",
+      retryable: false,
+      actionOwner: "provider_admin",
+      operatorAction: "Inspect provider logs.",
+      message: "Safe provider failure.",
+      highestPassed: "operation_ready",
+      httpStatus: 200,
+      operationPhase: "MCP_TOOL_EXECUTION",
+      providerStatus: 403,
+      providerRequestId: "provider-request-456",
+      providerCode: "access_denied",
+    });
+
+    const attribution = attributeExternalMcpToolFailure({
+      diagnostic: null,
+      inspection: {
+        request: {},
+        response: {
+          status: 504,
+          headers: [{ name: "x-request-id", value: "wire-request-789", redacted: false }],
+        },
+        diagnosis: { layer: "remote_http", summary: "Older Den failure shape." },
+      },
+      browserTimeout: null,
+      mayHaveSideEffects: false,
+    });
+    expect(attribution).toMatchObject({
+      summary: "The remote MCP returned HTTP 504.",
+      confidence: "Confirmed",
+      providerRequestId: "wire-request-789",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- preserve Den's structured MCP diagnostic in the dashboard and derive a compact, evidence-bounded failure attribution
- add typed browser-to-Den timeout and caller-cancellation errors, including the dashboard deadline and unknown-outcome semantics
- consolidate the duplicate error banner and inspector failure header into one failure experience with boundary, source, confidence, retry guidance, diagnostic reference, and provider request ID
- clarify Den-side inspector summaries for lifecycle deadlines, remote HTTP failures, and downstream provider/tool failures

## Follow-up and dependency

This is a narrow follow-up to #2762. That PR is merged, and this branch is based directly on its merge commit/current `upstream/dev`, so there is no open PR dependency.

## Behavior and attribution rules

- a Den security-policy block is confirmed as stopped before send
- an observed remote HTTP 408/504 is confirmed at the remote MCP HTTP boundary
- a provider/tool error carried through HTTP 200 is confirmed only at the downstream provider/tool boundary
- a lifecycle deadline after `tools/call` was started is inferred and marked as an unknown outcome
- a captured request without a response is explicitly not treated as proof that the remote MCP caused the failure
- mutation-capable tools with unknown outcomes warn users to verify provider state instead of immediately retrying
- deploy-skew fallback uses the existing redacted wire inspection when an older Den does not return the structured diagnostic

## Checks run

- `pnpm --dir ee/apps/den-web exec bun test tests/mcp-tool-error-attribution.test.ts` — 9 passed
- `DEN_ENABLE_ENTERPRISE_MCP_CLIENT=false pnpm --dir ee/apps/den-api exec bun test test/external-mcp-tool-inspection.test.ts test/mcp-connections-tools.test.ts` — 24 passed
- `DEN_ENABLE_ENTERPRISE_MCP_CLIENT=true pnpm --dir ee/apps/den-api exec bun test test/mcp-connections-tools.test.ts` — 16 passed
- Den Web TypeScript check — passed
- Den API TypeScript check — passed

## Manual verification

Using the isolated Den Web/API environment and a local deterministic MCP mock:

1. Ran a tool that returned HTTP 504 and confirmed one failure panel showed the remote MCP boundary, `Confirmed` confidence, Den diagnostic reference, provider request ID, and safe retry guidance.
2. Ran a tool that returned a downstream provider rejection through HTTP 200 and confirmed one failure panel showed the downstream provider/tool boundary, `Confirmed` confidence, provider request ID, and provider-specific guidance.
3. Confirmed the existing request/response inspector remained available and the duplicate raw red banner was removed.

## Security considerations

- no new request/response logging or persistence
- existing header/body redaction and ephemeral inspection capture are unchanged
- provider request-ID fallback reads only known request-ID response headers that the existing inspector marked non-redacted
- no credential ownership, tenant authorization, outbound request policy, or MCP transport behavior changed

## Deferred checks

- did not wait 160 seconds for a real browser timeout; the typed timeout path is covered deterministically by the focused test
- did not use live third-party MCP/provider credentials; remote HTTP and provider failures were exercised with a deterministic local mock
- no staging/production verification, screenshots, video, or Fraimz evidence

## Risk and rollback

The behavioral change is limited to browser error typing/attribution and Den inspector summary copy. Reverting the two commits restores the previous generic error presentation without changing MCP execution or stored data.
