### PR TITLE
fix(mcp): retry and surface silent search_capabilities injection failures

### DIFF
--- a/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
+++ b/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import {
   mintCloudControlMcpToken,
@@ -6,7 +6,13 @@ import {
   type DenMcpToken,
   type DenSettings,
 } from "../../../app/lib/den";
-import type { OpenworkServerClient } from "../../../app/lib/openwork-server";
+import { recordInspectorEvent } from "../../../app/lib/app-inspector";
+import type {
+  OpenworkCloudMcpFailure,
+  OpenworkCloudMcpHealth,
+  OpenworkCloudMcpProviderModelContext,
+  OpenworkServerClient,
+} from "../../../app/lib/openwork-server";
 import { unwrap } from "../../../app/lib/opencode";
 import type { Client, McpServerEntry, McpStatusMap } from "../../../app/types";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
@@ -21,10 +27,77 @@ import {
 
 export const SESSION_MCP_MAINTENANCE_INTERVAL_MS = 5 * 60 * 1000;
 export const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
+export const CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS = [1_000, 3_000];
 
 type CloudMcpMaintenanceClient = CloudMcpClient & Pick<OpenworkServerClient, "listMcp">;
 
 const maintenanceInFlight = new Set<string>();
+
+export type CloudMcpMaintenanceIssue = Pick<
+  OpenworkCloudMcpFailure,
+  "code" | "stage" | "retryable" | "recommendedAction" | "message"
+>;
+
+export type CloudMcpBackgroundSyncResult =
+  | {
+      outcome: "ready";
+      status: "synced" | "unchanged";
+      health: OpenworkCloudMcpHealth;
+    }
+  | {
+      outcome: "skipped";
+      status: "skipped";
+      reason: "signed_out" | "missing_org" | "missing_workspace" | "disabled";
+      health: null;
+    }
+  | {
+      outcome: "failed";
+      status: "failed";
+      issue: CloudMcpMaintenanceIssue;
+      health: OpenworkCloudMcpHealth | null;
+    };
+
+export type SessionCloudMcpMaintenanceState = {
+  status: "idle" | "checking" | "ready" | "skipped" | "retrying" | "failed";
+  issue: CloudMcpMaintenanceIssue | null;
+  attempt: number;
+  maxAttempts: number;
+};
+
+const IDLE_CLOUD_MCP_MAINTENANCE_STATE: SessionCloudMcpMaintenanceState = {
+  status: "idle",
+  issue: null,
+  attempt: 0,
+  maxAttempts: 1 + CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS.length,
+};
+
+function genericCloudMcpMaintenanceIssue(input?: {
+  code?: string;
+  message?: string;
+  retryable?: boolean;
+}): CloudMcpMaintenanceIssue {
+  return {
+    code: input?.code ?? "cloud_mcp_maintenance_failed",
+    stage: "engine_delivery",
+    retryable: input?.retryable ?? true,
+    recommendedAction: "Retry, then open Settings → Connect if the problem continues.",
+    message: input?.message ?? "OpenWork could not verify connected service tools for this workspace.",
+  };
+}
+
+function failedCloudMcpBackgroundSync(input: {
+  health: OpenworkCloudMcpHealth | null;
+  issue?: CloudMcpMaintenanceIssue;
+  code?: string;
+  message?: string;
+}): CloudMcpBackgroundSyncResult {
+  return {
+    outcome: "failed",
+    status: "failed",
+    health: input.health,
+    issue: input.issue ?? genericCloudMcpMaintenanceIssue({ code: input.code, message: input.message }),
+  };
+}
 
 export function getSessionMcpMaintenanceTargetKey(input: {
   client: Pick<OpenworkServerClient, "baseUrl">;
@@ -32,12 +105,15 @@ export function getSessionMcpMaintenanceTargetKey(input: {
   denBaseUrl?: string | null;
   orgId?: string | null;
   workspaceId: string;
+  providerModel?: OpenworkCloudMcpProviderModelContext;
 }): string {
   return JSON.stringify([
     input.denBaseUrl?.trim().replace(/\/+$/, "") ?? "",
     input.client.baseUrl.trim().replace(/\/+$/, ""),
     input.workspaceId.trim(),
     input.cloudSignedIn ? input.orgId?.trim() ?? "" : "local-only",
+    input.providerModel?.provider.trim() ?? "",
+    input.providerModel?.model.trim() ?? "",
   ]);
 }
 
@@ -62,22 +138,35 @@ export async function syncCloudControlMcpInBackground(input: {
   now?: number;
   settings?: DenSettings;
   mintToken?: () => Promise<DenMcpToken | null>;
-}): Promise<"synced" | "unchanged" | "skipped"> {
+  providerModel?: OpenworkCloudMcpProviderModelContext;
+}): Promise<CloudMcpBackgroundSyncResult> {
   const workspaceId = input.workspaceId.trim();
   const settings = input.settings ?? readDenSettings();
   const orgId = settings.activeOrgId?.trim() ?? "";
-  if (!workspaceId || !orgId || !settings.authToken?.trim()) return "skipped";
+  if (!workspaceId) {
+    return { outcome: "skipped", status: "skipped", reason: "missing_workspace", health: null };
+  }
+  if (!settings.authToken?.trim()) {
+    return { outcome: "skipped", status: "skipped", reason: "signed_out", health: null };
+  }
+  if (!orgId) {
+    return { outcome: "skipped", status: "skipped", reason: "missing_org", health: null };
+  }
   const scope = {
     denBaseUrl: settings.baseUrl,
     serverBaseUrl: input.client.baseUrl,
     orgId,
     workspaceId,
   };
-  if (readCloudMcpUserState(scope) !== null) return "skipped";
+  if (readCloudMcpUserState(scope) !== null) {
+    return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
+  }
 
   const listed = await input.client.listMcp(workspaceId);
   const configured = listed.items.find((entry) => entry.name === CLOUD_MCP_SERVER_NAME);
-  if (configured?.config.enabled === false) return "skipped";
+  if (configured?.config.enabled === false) {
+    return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
+  }
   const configuredUrl = typeof configured?.config.url === "string" ? configured.config.url : null;
 
   const result = await runOpenworkCloudMcpReconciler({
@@ -89,6 +178,7 @@ export async function syncCloudControlMcpInBackground(input: {
       orgSlug: settings.activeOrgSlug,
       orgName: settings.activeOrgName,
       fallbackUrl: configured?.config.type === "remote" ? configuredUrl : null,
+      providerModel: input.providerModel,
       trigger: input.force ? "desktop-background-forced" : "desktop-background",
     },
     mintToken: input.mintToken
@@ -99,9 +189,71 @@ export async function syncCloudControlMcpInBackground(input: {
     now: input.now,
     configuredEnabled: typeof configured?.config.enabled === "boolean" ? configured.config.enabled : null,
   });
-  if (result.status === "unchanged" || result.status === "ready") return "unchanged";
-  if (result.health?.usable) return "synced";
-  return "skipped";
+  if (result.health?.usable) {
+    return {
+      outcome: "ready",
+      status: result.status === "unchanged" || result.status === "ready" ? "unchanged" : "synced",
+      health: result.health,
+    };
+  }
+  if (result.status === "skipped") {
+    if (result.skippedReason === "signed_out") {
+      return { outcome: "skipped", status: "skipped", reason: "signed_out", health: null };
+    }
+    if (result.skippedReason === "missing_org") {
+      return { outcome: "skipped", status: "skipped", reason: "missing_org", health: null };
+    }
+    if (result.skippedReason === "missing_workspace") {
+      return { outcome: "skipped", status: "skipped", reason: "missing_workspace", health: null };
+    }
+    if (result.skippedReason === "disabled") {
+      return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
+    }
+    if (result.skippedReason === "mint_failed") {
+      return failedCloudMcpBackgroundSync({
+        health: result.health,
+        code: "cloud_mcp_token_mint_failed",
+        message: "OpenWork could not refresh Cloud authentication for connected service tools.",
+      });
+    }
+  }
+  return failedCloudMcpBackgroundSync({
+    health: result.health,
+    issue: result.health?.firstFailure ?? undefined,
+  });
+}
+
+export async function runCloudMcpMaintenanceWithRetry(input: {
+  attempt: () => Promise<CloudMcpBackgroundSyncResult>;
+  retryDelaysMs?: number[];
+  wait?: (delayMs: number) => Promise<void>;
+  onAttempt?: (input: {
+    result: CloudMcpBackgroundSyncResult;
+    attempt: number;
+    maxAttempts: number;
+    willRetry: boolean;
+  }) => void;
+}): Promise<CloudMcpBackgroundSyncResult> {
+  const retryDelaysMs = input.retryDelaysMs ?? CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS;
+  const wait = input.wait ?? ((delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+  const maxAttempts = 1 + retryDelaysMs.length;
+  let lastResult: CloudMcpBackgroundSyncResult | null = null;
+
+  for (let index = 0; index < maxAttempts; index += 1) {
+    if (index > 0) await wait(retryDelaysMs[index - 1] ?? 0);
+    try {
+      lastResult = await input.attempt();
+    } catch {
+      lastResult = failedCloudMcpBackgroundSync({ health: null });
+    }
+    const willRetry = lastResult.outcome === "failed"
+      && lastResult.issue.retryable
+      && index < maxAttempts - 1;
+    input.onAttempt?.({ result: lastResult, attempt: index + 1, maxAttempts, willRetry });
+    if (!willRetry) return lastResult;
+  }
+
+  return lastResult ?? failedCloudMcpBackgroundSync({ health: null });
 }
 
 export async function healWorkspaceMcpInBackground(input: {
@@ -136,13 +288,21 @@ export function useSessionMcpMaintenance(input: {
   workspaceId: string | null;
   opencodeClient: Client | null;
   directory: string;
-}) {
+  providerModel?: OpenworkCloudMcpProviderModelContext;
+}): SessionCloudMcpMaintenanceState {
+  const [cloudMcpState, setCloudMcpState] = useState<SessionCloudMcpMaintenanceState>(
+    IDLE_CLOUD_MCP_MAINTENANCE_STATE,
+  );
+
   useEffect(() => {
     const workspaceId = input.workspaceId?.trim() ?? "";
     const directory = input.directory.trim();
     const client = input.client;
     const opencodeClient = input.opencodeClient;
-    if (!client || !opencodeClient || !workspaceId || !directory) return;
+    if (!client || !opencodeClient || !workspaceId || !directory) {
+      setCloudMcpState(IDLE_CLOUD_MCP_MAINTENANCE_STATE);
+      return;
+    }
     const settings = readDenSettings();
     const targetKey = getSessionMcpMaintenanceTargetKey({
       client,
@@ -150,28 +310,83 @@ export function useSessionMcpMaintenance(input: {
       denBaseUrl: settings.baseUrl,
       orgId: settings.activeOrgId,
       workspaceId,
+      providerModel: input.providerModel,
     });
 
     let cancelled = false;
+    let busyRetryTimer: number | null = null;
+    setCloudMcpState(input.cloudSignedIn
+      ? { ...IDLE_CLOUD_MCP_MAINTENANCE_STATE, status: "checking" }
+      : IDLE_CLOUD_MCP_MAINTENANCE_STATE);
+
+    const recordCloudAttempt = (attemptInput: {
+      result: CloudMcpBackgroundSyncResult;
+      attempt: number;
+      maxAttempts: number;
+      willRetry: boolean;
+    }) => {
+      const issue = attemptInput.result.outcome === "failed" ? attemptInput.result.issue : null;
+      recordInspectorEvent("cloud_mcp.session_maintenance", {
+        workspaceId,
+        outcome: attemptInput.result.outcome,
+        status: attemptInput.result.status,
+        attempt: attemptInput.attempt,
+        maxAttempts: attemptInput.maxAttempts,
+        willRetry: attemptInput.willRetry,
+        code: issue?.code ?? null,
+        stage: issue?.stage ?? null,
+        retryable: issue?.retryable ?? null,
+      });
+      if (cancelled) return;
+      setCloudMcpState({
+        status: attemptInput.result.outcome === "ready"
+          ? "ready"
+          : attemptInput.result.outcome === "skipped"
+            ? "skipped"
+            : attemptInput.willRetry
+              ? "retrying"
+              : "failed",
+        issue,
+        attempt: attemptInput.attempt,
+        maxAttempts: attemptInput.maxAttempts,
+      });
+    };
+
+    const scheduleBusyRetry = () => {
+      if (cancelled || busyRetryTimer !== null) return;
+      busyRetryTimer = window.setTimeout(() => {
+        busyRetryTimer = null;
+        void tick();
+      }, 250);
+    };
+
     const tick = async () => {
       if (cancelled) return;
-      await runSessionMcpMaintenanceTask({
+      const started = await runSessionMcpMaintenanceTask({
         targetKey,
         task: async () => {
-        if (input.cloudSignedIn) {
-          await syncCloudControlMcpInBackground({
+          if (input.cloudSignedIn) {
+            await runCloudMcpMaintenanceWithRetry({
+              attempt: () => syncCloudControlMcpInBackground({
+                client,
+                workspaceId,
+                providerModel: input.providerModel,
+              }),
+              onAttempt: recordCloudAttempt,
+            });
+          }
+          await healWorkspaceMcpInBackground({
             client,
             workspaceId,
-          }).catch(() => "skipped");
-        }
-        await healWorkspaceMcpInBackground({
-          client,
-          workspaceId,
-          opencodeClient,
-          directory,
-        }).catch(() => false);
+            opencodeClient,
+            directory,
+          }).catch(() => {
+            recordInspectorEvent("mcp.session_reauth_failed", { workspaceId });
+            return false;
+          });
         },
       });
+      if (!started) scheduleBusyRetry();
     };
 
     void tick();
@@ -187,6 +402,17 @@ export function useSessionMcpMaintenance(input: {
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("focus", handleFocus);
       window.clearInterval(interval);
+      if (busyRetryTimer !== null) window.clearTimeout(busyRetryTimer);
     };
-  }, [input.client, input.cloudSignedIn, input.directory, input.opencodeClient, input.workspaceId]);
+  }, [
+    input.client,
+    input.cloudSignedIn,
+    input.directory,
+    input.opencodeClient,
+    input.providerModel?.model,
+    input.providerModel?.provider,
+    input.workspaceId,
+  ]);
+
+  return cloudMcpState;
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -387,13 +387,51 @@ export function SessionRoute() {
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });
-  useSessionMcpMaintenance({
+  const sessionMcpMaintenance = useSessionMcpMaintenance({
     cloudSignedIn: denAuth.isSignedIn,
     client: selectedWorkspaceEndpoint?.client ?? null,
     workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? null,
     opencodeClient,
     directory: selectedWorkspaceRoot,
+    providerModel: local.prefs.defaultModel
+      ? {
+          provider: local.prefs.defaultModel.providerID,
+          model: local.prefs.defaultModel.modelID,
+        }
+      : undefined,
   });
+  useEffect(() => {
+    const toastId = `cloud-mcp-session-maintenance:${selectedWorkspaceEndpoint?.workspaceId ?? "none"}`;
+    if (sessionMcpMaintenance.status === "retrying") {
+      toast.warning("Restoring connected service tools", {
+        id: toastId,
+        description: `${sessionMcpMaintenance.issue?.message ?? "OpenWork could not verify the tools yet."} Retrying automatically (${sessionMcpMaintenance.attempt}/${sessionMcpMaintenance.maxAttempts}).`,
+        action: {
+          label: "Open Connect",
+          onClick: () => navigate("/settings/connect"),
+        },
+        duration: Infinity,
+      });
+    } else if (sessionMcpMaintenance.status === "failed") {
+      toast.error("Connected service tools are unavailable", {
+        id: toastId,
+        description: [
+          sessionMcpMaintenance.issue?.message,
+          sessionMcpMaintenance.issue?.recommendedAction,
+        ].filter(Boolean).join(" "),
+        action: {
+          label: "Open Connect",
+          onClick: () => navigate("/settings/connect"),
+        },
+        duration: Infinity,
+      });
+    } else {
+      toast.dismiss(toastId);
+    }
+    return () => {
+      toast.dismiss(toastId);
+    };
+  }, [navigate, selectedWorkspaceEndpoint?.workspaceId, sessionMcpMaintenance]);
   // Agent selection is persisted in local prefs (like the model variant) so
   // it survives reloads instead of silently falling back to "build" (#2101).
   const selectedAgent = local.prefs.selectedAgent;

--- a/apps/app/tests/session-mcp-maintenance.test.ts
+++ b/apps/app/tests/session-mcp-maintenance.test.ts
@@ -10,6 +10,7 @@ import {
 import { cleanupOpenworkCloudMcpAfterSignOut } from "../src/react-app/domains/connections/cloud-mcp-reconciler";
 import {
   getSessionMcpMaintenanceTargetKey,
+  runCloudMcpMaintenanceWithRetry,
   runSessionMcpMaintenanceTask,
   syncCloudControlMcpInBackground,
 } from "../src/react-app/domains/connections/use-session-mcp-maintenance";
@@ -78,6 +79,16 @@ function cloudHealth(usable: boolean): OpenworkCloudMcpHealth {
   };
 }
 
+function retryableCloudHealth(): OpenworkCloudMcpHealth {
+  const health = cloudHealth(false);
+  return {
+    ...health,
+    firstFailure: health.firstFailure
+      ? { ...health.firstFailure, retryable: true }
+      : null,
+  };
+}
+
 function installStorageStub() {
   const values = new Map<string, string>();
   __setCloudMcpUserStateStorageForTest({
@@ -112,7 +123,7 @@ describe("session MCP maintenance", () => {
       settings: SETTINGS,
       now: NOW,
       mintToken: async () => MINTED,
-    })).resolves.toBe("synced");
+    })).resolves.toMatchObject({ outcome: "ready", status: "synced" });
 
     expect(writes).toEqual([{
       workspaceId: WORKSPACE_ID,
@@ -149,6 +160,56 @@ describe("session MCP maintenance", () => {
       workspaceId: WORKSPACE_ID,
       expiresAt: MINTED.expiresAt,
     });
+  });
+
+  test("keeps a retryable injection failure visible until a bounded retry restores the tools", async () => {
+    let reconcileCount = 0;
+    const waits: number[] = [];
+    const attempts: Array<{ outcome: string; attempt: number; willRetry: boolean }> = [];
+    const client = {
+      baseUrl: "https://worker.openwork.test",
+      listMcp: async () => ({
+        items: [{
+          name: "openwork-cloud",
+          config: { type: "remote", enabled: true, url: "https://api.openwork.test/mcp/agent" },
+        }],
+      }),
+      getOpenworkCloudMcpHealth: async () => retryableCloudHealth(),
+      reconcileOpenworkCloudMcp: async () => {
+        reconcileCount += 1;
+        return reconcileCount === 3 ? cloudHealth(true) : retryableCloudHealth();
+      },
+    };
+
+    const result = await runCloudMcpMaintenanceWithRetry({
+      attempt: () => syncCloudControlMcpInBackground({
+        client,
+        workspaceId: WORKSPACE_ID,
+        settings: SETTINGS,
+        now: NOW,
+        mintToken: async () => MINTED,
+      }),
+      retryDelaysMs: [25, 50],
+      wait: async (delayMs) => {
+        waits.push(delayMs);
+      },
+      onAttempt: (attempt) => {
+        attempts.push({
+          outcome: attempt.result.outcome,
+          attempt: attempt.attempt,
+          willRetry: attempt.willRetry,
+        });
+      },
+    });
+
+    expect(result).toMatchObject({ outcome: "ready", status: "synced" });
+    expect(reconcileCount).toBe(3);
+    expect(waits).toEqual([25, 50]);
+    expect(attempts).toEqual([
+      { outcome: "failed", attempt: 1, willRetry: true },
+      { outcome: "failed", attempt: 2, willRetry: true },
+      { outcome: "ready", attempt: 3, willRetry: false },
+    ]);
   });
 
   test("a fresh per-workspace marker prevents repeated token and config writes", async () => {
@@ -190,7 +251,7 @@ describe("session MCP maintenance", () => {
         mintCount += 1;
         return MINTED;
       },
-    })).resolves.toBe("unchanged");
+    })).resolves.toMatchObject({ outcome: "ready", status: "unchanged" });
     expect(mintCount).toBe(0);
     expect(writeCount).toBe(0);
   });
@@ -229,21 +290,21 @@ describe("session MCP maintenance", () => {
       settings: SETTINGS,
       now: NOW,
       mintToken,
-    })).resolves.toBe("synced");
+    })).resolves.toMatchObject({ outcome: "ready", status: "synced" });
     await expect(syncCloudControlMcpInBackground({
       client,
       workspaceId: "workspace_b",
       settings: SETTINGS,
       now: NOW,
       mintToken,
-    })).resolves.toBe("synced");
+    })).resolves.toMatchObject({ outcome: "ready", status: "synced" });
     await expect(syncCloudControlMcpInBackground({
       client,
       workspaceId: "workspace_a",
       settings: SETTINGS,
       now: NOW + 1_000,
       mintToken,
-    })).resolves.toBe("unchanged");
+    })).resolves.toMatchObject({ outcome: "ready", status: "unchanged" });
 
     expect(mintCount).toBe(2);
     expect(writes).toEqual(["workspace_a", "workspace_b"]);
@@ -315,7 +376,7 @@ describe("session MCP maintenance", () => {
       workspaceId: WORKSPACE_ID,
       settings: SETTINGS,
       mintToken: async () => MINTED,
-    })).resolves.toBe("skipped");
+    })).resolves.toEqual({ outcome: "skipped", status: "skipped", reason: "disabled", health: null });
     expect(listed).toBe(false);
   });
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -64,7 +64,11 @@ import { addRoute, matchRoute, type AuthMode, type RequestContext, type Route } 
 import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
 import { registerCloudMcpRoutes } from "./routes/cloud-mcp.js";
-import { markOpenworkCloudMcpStale, reconcilePersistedOpenworkCloudMcp } from "./cloud-mcp-health.js";
+import {
+  markOpenworkCloudMcpStale,
+  reconcilePersistedOpenworkCloudMcp,
+  type CloudMcpHealth,
+} from "./cloud-mcp-health.js";
 import { runAgentContextDiagnostics } from "./agent-context-diagnostics.js";
 import { createAgentDiagnosticsEngineFetch } from "./agent-context-engine-inspection.js";
 import {
@@ -3210,29 +3214,38 @@ async function reloadOpencodeEngine(
   // configs (including the server-managed runtime config file for the
   // primary workspace), but other workspaces' runtime MCPs only reach the
   // engine through this dynamic push.
-  await syncRuntimeMcpToOpencodeEngine(
-    config,
-    workspace,
-    undefined,
-    undefined,
-    activeState ?? null,
-  ).catch(() => undefined);
-  await reconcilePersistedOpenworkCloudMcp({
-    config,
-    workspace,
-    directory,
-    serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
-    createWorkspaceOpencodeClient,
-    registerRuntimeMcp: (routeConfig, routeWorkspace, onlyNames, options) =>
-      syncRuntimeMcpToOpencodeEngine(
-        routeConfig,
-        routeWorkspace,
-        onlyNames,
-        options,
-        activeState ?? null,
-      ),
-    trigger: "engine_reload",
-  }).catch(() => undefined);
+  try {
+    await syncRuntimeMcpToOpencodeEngine(
+      config,
+      workspace,
+      undefined,
+      undefined,
+      activeState ?? null,
+    );
+  } catch (error) {
+    logRuntimeMcpSyncError({ config, workspace, trigger: "engine_reload", error });
+  }
+  try {
+    const health = await reconcilePersistedOpenworkCloudMcp({
+      config,
+      workspace,
+      directory,
+      serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
+      createWorkspaceOpencodeClient,
+      registerRuntimeMcp: (routeConfig, routeWorkspace, onlyNames, options) =>
+        syncRuntimeMcpToOpencodeEngine(
+          routeConfig,
+          routeWorkspace,
+          onlyNames,
+          options,
+          activeState ?? null,
+        ),
+      trigger: "engine_reload",
+    });
+    logPersistedCloudMcpReconcileResult({ config, workspace, trigger: "engine_reload", health });
+  } catch (error) {
+    logPersistedCloudMcpReconcileError({ config, workspace, trigger: "engine_reload", error });
+  }
 }
 
 // Push runtime-DB MCP entries into the running OpenCode engine via its dynamic
@@ -3897,6 +3910,66 @@ function deleteEngineMcpRegistration(
   state.registrationByWorkspace.get(workspace.id)?.delete(name);
 }
 
+function logPersistedCloudMcpReconcileResult(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  trigger: "startup" | "engine_reload";
+  health: CloudMcpHealth;
+}): void {
+  if (!input.health.desired.present || input.health.usable) return;
+  const failure = input.health.firstFailure;
+  createServerLogger(input.config).log(
+    "warn",
+    `Cloud MCP ${input.trigger} reconciliation left connected service tools unavailable for workspace ${input.workspace.id}.`,
+    {
+      "workspace.id": input.workspace.id,
+      "mcp.name": "openwork-cloud",
+      "mcp.trigger": input.trigger,
+      "mcp.failure.code": failure?.code ?? "unknown",
+      "mcp.failure.stage": failure?.stage ?? "unknown",
+      "mcp.failure.retryable": failure?.retryable ?? null,
+      "mcp.failure.message": failure?.message ?? "Cloud MCP health remained unusable after reconciliation.",
+    },
+  );
+}
+
+function logRuntimeMcpSyncError(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  trigger: "startup" | "engine_reload";
+  error: unknown;
+}): void {
+  createServerLogger(input.config).log(
+    "error",
+    `Runtime MCP ${input.trigger} sync crashed for workspace ${input.workspace.id}.`,
+    {
+      "workspace.id": input.workspace.id,
+      "mcp.trigger": input.trigger,
+      "mcp.failure.code": "runtime_mcp_sync_exception",
+      "mcp.failure.message": input.error instanceof Error ? input.error.message : String(input.error),
+    },
+  );
+}
+
+function logPersistedCloudMcpReconcileError(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  trigger: "startup" | "engine_reload";
+  error: unknown;
+}): void {
+  createServerLogger(input.config).log(
+    "error",
+    `Cloud MCP ${input.trigger} reconciliation crashed for workspace ${input.workspace.id}.`,
+    {
+      "workspace.id": input.workspace.id,
+      "mcp.name": "openwork-cloud",
+      "mcp.trigger": input.trigger,
+      "mcp.failure.code": "cloud_mcp_reconcile_exception",
+      "mcp.failure.message": input.error instanceof Error ? input.error.message : String(input.error),
+    },
+  );
+}
+
 // Re-push every workspace's runtime-DB MCPs into the engine. Used at startup:
 // the runtime config file injected via OPENCODE_CONFIG covers workspaces[0]
 // only, so other workspaces' runtime MCPs are invisible to the engine until
@@ -3904,29 +3977,38 @@ function deleteEngineMcpRegistration(
 export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig): Promise<void> {
   const serverState = activeEngineMcpServerState(config) ?? null;
   for (const workspace of config.workspaces) {
-    await syncRuntimeMcpToOpencodeEngine(
-      config,
-      workspace,
-      undefined,
-      undefined,
-      serverState,
-    ).catch(() => undefined);
-    await reconcilePersistedOpenworkCloudMcp({
-      config,
-      workspace,
-      directory: resolveOpencodeDirectory(workspace),
-      serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
-      createWorkspaceOpencodeClient,
-      registerRuntimeMcp: (routeConfig, routeWorkspace, onlyNames, options) =>
-        syncRuntimeMcpToOpencodeEngine(
-          routeConfig,
-          routeWorkspace,
-          onlyNames,
-          options,
-          serverState,
-        ),
-      trigger: "startup",
-    }).catch(() => undefined);
+    try {
+      await syncRuntimeMcpToOpencodeEngine(
+        config,
+        workspace,
+        undefined,
+        undefined,
+        serverState,
+      );
+    } catch (error) {
+      logRuntimeMcpSyncError({ config, workspace, trigger: "startup", error });
+    }
+    try {
+      const health = await reconcilePersistedOpenworkCloudMcp({
+        config,
+        workspace,
+        directory: resolveOpencodeDirectory(workspace),
+        serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
+        createWorkspaceOpencodeClient,
+        registerRuntimeMcp: (routeConfig, routeWorkspace, onlyNames, options) =>
+          syncRuntimeMcpToOpencodeEngine(
+            routeConfig,
+            routeWorkspace,
+            onlyNames,
+            options,
+            serverState,
+          ),
+        trigger: "startup",
+      });
+      logPersistedCloudMcpReconcileResult({ config, workspace, trigger: "startup", health });
+    } catch (error) {
+      logPersistedCloudMcpReconcileError({ config, workspace, trigger: "startup", error });
+    }
   }
 }
 


### PR DESCRIPTION
This PR prevents a Cloud MCP tool-injection problem from looking like `search_capabilities` simply disappeared after an app restart. If the search tool is not available for the active workspace, provider, and model, OpenWork now treats that as a real failure instead of silently marking maintenance as skipped: it retries automatically, keeps an actionable warning visible, and records the exact failure stage for diagnosis. This means the issue either self-recovers or becomes visible to the user and support team instead of leaving the assistant without search capabilities and no explanation.

## What this changes

- distinguish Cloud MCP readiness failures from intentional `skipped` states
- retry transient session tool-restoration failures and surface persistent task-level notices when recovery does not complete
- validate readiness against the active provider and model, not only generic endpoint health
- preserve structured startup, reload, and reconcile failures in server logs instead of swallowing them
- add regression coverage for a retryable injection failure that recovers on the third attempt

## Why the search tool could disappear silently

Session MCP maintenance previously collapsed any unusable reconcile result into `skipped`, and caught maintenance errors without leaving a user-visible failure or durable diagnostic. The startup and engine-reload paths also discarded thrown synchronization errors. Because the selected provider and model were not included in the session health check, generic endpoint health could look ready while the active model still had no injected Cloud MCP tools.

Together, those behaviors made a registration, authentication, or model-projection failure look like the assistant had silently lost `search_capabilities` after restart.

The captured incident also exposed an important distinction: the live meta-MCP remained connected and returned both `search_capabilities` and `execute_capability`; the observed calls failed farther downstream because of invalid Microsoft provider aliases and a Microsoft Graph 401. This change does not misreport those provider failures as MCP transport loss. It makes actual tool-injection and readiness failures visible, diagnosable, and recoverable.

## User impact

- Transient restoration failures retry after 1 second and 3 seconds.
- The task screen keeps a warning visible while automatic restoration is running and shows a persistent error if it cannot recover.
- The notice links directly to Connect and clears after recovery.
- Focus, online, and periodic maintenance can re-check readiness after the initial retry budget.
- Explicitly disabled, removed, or signed-out Cloud MCP states remain quiet and are not automatically overridden.
- Server logs now identify the workspace, trigger, failure code, and stage for startup/reload synchronization and reconcile failures.

## Security and trust boundaries

- Inspector events, toasts, and server logs do not include access tokens, authorization headers, or connector payloads.
- User-facing diagnostics reuse the existing redacted Cloud MCP health code, stage, message, and recommended action.
- The change does not alter Den credential ownership, tenant boundaries, or OAuth token handling.

## Validation

- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm --filter @openwork/app exec bun test --isolate tests/session-mcp-maintenance.test.ts` — 8 passed, 0 failed
- `pnpm --filter openwork-server exec bun test src/cloud-mcp-reconcile.e2e.test.ts src/mcp.engine-sync.e2e.test.ts` — 34 passed, 0 failed

## Remaining verification

The packaged desktop restart journey with a real organization and deliberate network/tool-injection fault has not yet been run. Windows/Linux coverage and visual evidence were also not collected. This PR is therefore opened as a draft until that final real-desktop failure-and-recovery journey is confirmed.