### PR TITLE
feat(mcp): add compact failure attribution UI

### DIFF
--- a/apps/app/src/components/tools/error-attribution.ts
+++ b/apps/app/src/components/tools/error-attribution.ts
@@ -1,0 +1,112 @@
+export type ToolErrorAttribution = {
+  label: string
+  confidence: "Confirmed" | "Inferred"
+  description: string
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseErrorRecord(errorText: string): Record<string, unknown> | null {
+  const trimmed = errorText.trim()
+  const jsonStart = trimmed.indexOf("{")
+  const jsonEnd = trimmed.lastIndexOf("}")
+  const candidates = [
+    trimmed,
+    ...(jsonStart > 0 ? [trimmed.slice(jsonStart)] : []),
+    ...(jsonStart >= 0 && jsonEnd > jsonStart ? [trimmed.slice(jsonStart, jsonEnd + 1)] : []),
+  ]
+
+  for (const candidate of candidates) {
+    try {
+      const parsed: unknown = JSON.parse(candidate)
+      if (isRecord(parsed)) return parsed
+    } catch {
+      // The engine may wrap the MCP JSON in a plain error message.
+    }
+  }
+  return null
+}
+
+function diagnosticFromError(errorText: string): Record<string, unknown> | null {
+  const parsed = parseErrorRecord(errorText)
+  if (!parsed) return null
+  return isRecord(parsed.diagnostic) ? parsed.diagnostic : parsed
+}
+
+function stringValue(record: Record<string, unknown> | null, key: string): string | undefined {
+  const value = record?.[key]
+  return typeof value === "string" && value.trim() ? value : undefined
+}
+
+function numberValue(record: Record<string, unknown> | null, key: string): number | undefined {
+  const value = record?.[key]
+  return typeof value === "number" && Number.isFinite(value) ? value : undefined
+}
+
+function confirmed(label: string, description: string): ToolErrorAttribution {
+  return { label, confidence: "Confirmed", description }
+}
+
+export function attributeChatToolError(errorText: string): ToolErrorAttribution | null {
+  const diagnostic = diagnosticFromError(errorText)
+  const code = stringValue(diagnostic, "code")
+  const category = stringValue(diagnostic, "category")
+  const phase = stringValue(diagnostic, "phase")
+  const httpStatus = numberValue(diagnostic, "httpStatus")
+  const providerStatus = numberValue(diagnostic, "providerStatus")
+  const providerCode = stringValue(diagnostic, "providerCode")
+
+  if (
+    errorText.includes("OpenWork stopped waiting after")
+    || /The capability call exceeded \d+(?:\.\d+)?s\b/.test(errorText)
+    || code === "MCP_LIFECYCLE_DEADLINE"
+    || code === "MCP_REQUEST_TIMEOUT"
+    || category === "lifecycle_deadline"
+  ) {
+    return confirmed(
+      "OpenWork timeout",
+      "OpenWork created this deadline. The external operation may still have completed, so verify its state before retrying.",
+    )
+  }
+
+  if (
+    category === "security_blocked"
+    || code === "MCP_URL_BLOCKED"
+    || code === "MCP_FETCH_FORBIDDEN_PORT"
+  ) {
+    return confirmed("Blocked by OpenWork", "OpenWork blocked the request before it was sent.")
+  }
+
+  if (httpStatus !== undefined && (httpStatus < 200 || httpStatus >= 300)) {
+    return confirmed(
+      `Remote MCP · HTTP ${httpStatus}`,
+      `The remote MCP returned HTTP ${httpStatus}.`,
+    )
+  }
+
+  if (
+    phase?.startsWith("PROVIDER_")
+    || category?.startsWith("provider_")
+    || providerStatus !== undefined
+    || providerCode !== undefined
+  ) {
+    return confirmed(
+      "Provider error",
+      providerStatus === undefined
+        ? "The remote MCP responded, but the downstream provider or tool rejected the operation."
+        : `The remote MCP responded, but the downstream provider returned status ${providerStatus}.`,
+    )
+  }
+
+  if (/\b(?:timed out|timeout|deadline exceeded)\b/i.test(errorText)) {
+    return {
+      label: "Timeout · source unclear",
+      confidence: "Inferred",
+      description: "A timeout was reported, but the client did not receive structured evidence identifying which boundary created it.",
+    }
+  }
+
+  return null
+}

--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -5,6 +5,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
+import { attributeChatToolError } from "@/components/tools/error-attribution"
 import { getToolActivityLabel, isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
 import {
@@ -120,6 +121,9 @@ const Tool = ({ title, toolPart, defaultOpen = false, className }: ToolProps) =>
   const { state, input } = toolPart
   const inFlight = isToolPartInFlight(toolPart)
   const isError = state === "output-error"
+  const errorAttribution = isError && toolPart.errorText
+    ? attributeChatToolError(toolPart.errorText)
+    : null
   const label = title ?? getToolActivityLabel(toolPart)
   const hasInput = input !== null && input !== undefined
   const hasOutput = "output" in toolPart && toolPart.output !== undefined
@@ -144,8 +148,17 @@ const Tool = ({ title, toolPart, defaultOpen = false, className }: ToolProps) =>
           <ChevronDown className="absolute size-4 opacity-0 transition-opacity group-hover:opacity-100 group-data-panel-open:rotate-180" />
         </span>
         <span className="min-w-0 truncate">{label}</span>
-        {isError ? (
+        {isError && !errorAttribution ? (
           <span className="text-destructive shrink-0 text-xs">failed</span>
+        ) : null}
+        {errorAttribution ? (
+          <span
+            className="border-border/70 text-muted-foreground shrink-0 rounded-full border px-1.5 py-0.5 text-[10px] leading-none"
+            title={`${errorAttribution.confidence}: ${errorAttribution.description}`}
+            aria-label={`Error attribution: ${errorAttribution.label}. ${errorAttribution.confidence}.`}
+          >
+            {errorAttribution.label}
+          </span>
         ) : null}
       </CollapsibleTrigger>
       <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden text-sm transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">

--- a/apps/app/tests/tool-error-attribution-ui.test.tsx
+++ b/apps/app/tests/tool-error-attribution-ui.test.tsx
@@ -1,0 +1,25 @@
+import { expect, test } from "bun:test"
+import { renderToStaticMarkup } from "react-dom/server"
+import type { DynamicToolUIPart } from "ai"
+
+import { Tool } from "../src/components/ui/tool"
+
+test("renders compact MCP attribution in a failed chat tool row", () => {
+  const toolPart: DynamicToolUIPart = {
+    type: "dynamic-tool",
+    toolName: "openwork-cloud_execute_capability",
+    toolCallId: "call-1",
+    state: "output-error",
+    input: {},
+    errorText: JSON.stringify({
+      error: "connection_failed",
+      diagnostic: { code: "MCP_HTTP_504", httpStatus: 504 },
+    }),
+  }
+
+  const html = renderToStaticMarkup(<Tool toolPart={toolPart} />)
+
+  expect(html).toContain("Remote MCP · HTTP 504")
+  expect(html).toContain("Error attribution: Remote MCP · HTTP 504. Confirmed.")
+  expect(html).not.toContain(">failed<")
+})

--- a/apps/app/tests/tool-error-attribution.test.ts
+++ b/apps/app/tests/tool-error-attribution.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, test } from "bun:test"
+
+import { attributeChatToolError } from "../src/components/tools/error-attribution"
+
+describe("chat tool error attribution", () => {
+  test("identifies an OpenWork-created capability deadline", () => {
+    expect(attributeChatToolError("The capability call exceeded 180s. Retry once.")).toEqual({
+      label: "OpenWork timeout",
+      confidence: "Confirmed",
+      description: "OpenWork created this deadline. The external operation may still have completed, so verify its state before retrying.",
+    })
+  })
+
+  test("identifies a structured OpenWork lifecycle deadline", () => {
+    expect(attributeChatToolError(JSON.stringify({
+      error: "connection_failed",
+      diagnostic: {
+        code: "MCP_LIFECYCLE_DEADLINE",
+        category: "lifecycle_deadline",
+        phase: "MCP_TOOL_EXECUTION",
+      },
+    }))).toMatchObject({
+      label: "OpenWork timeout",
+      confidence: "Confirmed",
+    })
+  })
+
+  test("identifies an OpenWork block before send", () => {
+    expect(attributeChatToolError(JSON.stringify({
+      diagnostic: { code: "MCP_URL_BLOCKED", category: "security_blocked" },
+    }))).toMatchObject({
+      label: "Blocked by OpenWork",
+      confidence: "Confirmed",
+    })
+  })
+
+  test("identifies a remote MCP HTTP failure", () => {
+    expect(attributeChatToolError(`MCP error: ${JSON.stringify({
+      diagnostic: { code: "MCP_HTTP_504", httpStatus: 504 },
+    })} (tool execution failed)`)).toMatchObject({
+      label: "Remote MCP · HTTP 504",
+      confidence: "Confirmed",
+    })
+  })
+
+  test("identifies a provider failure returned through the remote MCP", () => {
+    expect(attributeChatToolError(JSON.stringify({
+      diagnostic: { phase: "PROVIDER_AUTHORIZATION", providerStatus: 403 },
+    }))).toMatchObject({
+      label: "Provider error",
+      confidence: "Confirmed",
+      description: "The remote MCP responded, but the downstream provider returned status 403.",
+    })
+  })
+
+  test("identifies provider attribution from a deploy-skew category and code", () => {
+    expect(attributeChatToolError(JSON.stringify({
+      diagnostic: { category: "provider_policy_denied", providerCode: "access_denied" },
+    }))).toMatchObject({
+      label: "Provider error",
+      confidence: "Confirmed",
+    })
+  })
+
+  test("does not claim ownership for an unstructured timeout", () => {
+    expect(attributeChatToolError("Tool request timed out while waiting for a response.")).toEqual({
+      label: "Timeout · source unclear",
+      confidence: "Inferred",
+      description: "A timeout was reported, but the client did not receive structured evidence identifying which boundary created it.",
+    })
+  })
+
+  test("does not add attribution without useful evidence", () => {
+    expect(attributeChatToolError("The tool failed.")).toBeNull()
+  })
+})

--- a/ee/apps/den-api/src/capability-sources/external-mcp-tool-inspection.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-tool-inspection.ts
@@ -381,13 +381,13 @@ export function diagnoseExternalMcpToolCall(input: {
       return {
         status: "failed",
         layer: "network",
-        summary: "Den sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
+        summary: "OpenWork sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
       }
     }
     return {
       status: "failed",
       layer: "network",
-      summary: "Den started tools/call but did not capture an HTTP response. This does not prove the remote MCP caused the failure.",
+      summary: "OpenWork started tools/call but did not capture an HTTP response. This does not prove the remote MCP caused the failure.",
     }
   }
   if (input.inspection.response.status < 200 || input.inspection.response.status >= 300) {

--- a/ee/apps/den-api/test/external-mcp-tool-inspection.test.ts
+++ b/ee/apps/den-api/test/external-mcp-tool-inspection.test.ts
@@ -104,7 +104,7 @@ test("ignores lifecycle requests and classifies a tools/call with no response as
   expect(diagnoseExternalMcpToolCall({ inspection, succeeded: false })).toEqual({
     status: "failed",
     layer: "network",
-    summary: "Den started tools/call but did not capture an HTTP response. This does not prove the remote MCP caused the failure.",
+    summary: "OpenWork started tools/call but did not capture an HTTP response. This does not prove the remote MCP caused the failure.",
   })
 })
 
@@ -209,7 +209,7 @@ test("attributes a blocked or deadline-stopped tools/call to the right layer", (
   })).toEqual({
     status: "failed",
     layer: "network",
-    summary: "Den sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
+    summary: "OpenWork sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
   })
 })
 

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -98,7 +98,7 @@ export class DenRequestTimeoutError extends Error {
 
   constructor(timeoutMs: number, cause?: unknown) {
     super(
-      `The OpenWork dashboard stopped waiting for Den after ${formatDeadlineDuration(timeoutMs)}. The operation’s outcome is unknown.`,
+      `OpenWork stopped waiting after ${formatDeadlineDuration(timeoutMs)}. The operation’s outcome is unknown.`,
       cause === undefined ? undefined : { cause },
     );
     this.name = "DenRequestTimeoutError";
@@ -111,7 +111,7 @@ export class DenRequestCanceledError extends Error {
 
   constructor(cause?: unknown) {
     super(
-      "The request to Den was canceled before the dashboard received a result. The operation’s outcome is unknown.",
+      "The OpenWork request was canceled before the dashboard received a result. The operation’s outcome is unknown.",
       cause === undefined ? undefined : { cause },
     );
     this.name = "DenRequestCanceledError";

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-error-attribution.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-error-attribution.ts
@@ -141,12 +141,12 @@ function unknownOutcomeGuidance(mayHaveSideEffects: boolean): string {
 }
 
 function lastBoundaryFromDiagnostic(diagnostic: ExternalMcpDiagnostic | null): string | undefined {
-  if (diagnostic?.highestPassed === "operation_ready") return "Den started remote tool execution";
-  if (diagnostic?.highestPassed === "catalog_ready") return "Den loaded the remote MCP tool catalog";
-  if (diagnostic?.highestPassed === "protocol_ready") return "Den initialized the remote MCP session";
+  if (diagnostic?.highestPassed === "operation_ready") return "OpenWork started remote tool execution";
+  if (diagnostic?.highestPassed === "catalog_ready") return "OpenWork loaded the remote MCP tool catalog";
+  if (diagnostic?.highestPassed === "protocol_ready") return "OpenWork initialized the remote MCP session";
   if (diagnostic?.highestPassed === "authorized") return "Remote MCP accepted the connection credential";
-  if (diagnostic?.highestPassed === "reachable") return "Den reached the remote MCP endpoint";
-  if (diagnostic?.highestPassed === "configured") return "Den loaded the MCP connection configuration";
+  if (diagnostic?.highestPassed === "reachable") return "OpenWork reached the remote MCP endpoint";
+  if (diagnostic?.highestPassed === "configured") return "OpenWork loaded the MCP connection configuration";
   return undefined;
 }
 
@@ -174,9 +174,9 @@ export function attributeExternalMcpToolFailure(input: {
     const seconds = browserTimeout.timeoutMs / 1000;
     const duration = Number.isInteger(seconds) ? `${seconds}` : seconds.toFixed(1);
     return {
-      summary: `The OpenWork dashboard stopped waiting for Den after ${duration} seconds. The operation’s outcome is unknown.`,
-      lastConfirmedBoundary: "Dashboard started the request to Den",
-      likelySource: "Den, the network path, the remote MCP, or the downstream tool",
+      summary: `OpenWork stopped waiting after ${duration} seconds. The operation’s outcome is unknown.`,
+      lastConfirmedBoundary: "OpenWork dashboard sent the request",
+      likelySource: "Source unclear after OpenWork timeout",
       confidence: "Inferred",
       retryGuidance: unknownOutcomeGuidance(mayHaveSideEffects),
       outcome: "unknown",
@@ -189,9 +189,9 @@ export function attributeExternalMcpToolFailure(input: {
     || diagnostic?.code === "MCP_FETCH_FORBIDDEN_PORT";
   if (blockedBeforeSend) {
     return {
-      summary: "OpenWork blocked the request before it left Den.",
-      lastConfirmedBoundary: "Den evaluated the outbound request",
-      likelySource: "OpenWork policy or connection configuration",
+      summary: "OpenWork blocked the request before it was sent.",
+      lastConfirmedBoundary: "OpenWork evaluated the outbound request",
+      likelySource: "OpenWork",
       confidence: "Confirmed",
       retryGuidance: diagnostic?.operatorAction ?? "Resolve the OpenWork policy or connection configuration, then run the tool again.",
       outcome: "failed",
@@ -206,7 +206,7 @@ export function attributeExternalMcpToolFailure(input: {
     return {
       summary: `The remote MCP returned HTTP ${responseStatus}.`,
       lastConfirmedBoundary: `Remote MCP returned HTTP ${responseStatus}`,
-      likelySource: "Remote MCP HTTP layer",
+      likelySource: "Remote MCP",
       confidence: "Confirmed",
       retryGuidance: mayHaveSideEffects && (responseStatus === 408 || responseStatus === 504)
         ? "Check the remote MCP or provider for a completed operation before retrying this tool."
@@ -228,7 +228,7 @@ export function attributeExternalMcpToolFailure(input: {
       lastConfirmedBoundary: responseStatus !== undefined
         ? `Remote MCP returned HTTP ${responseStatus} with a tool error`
         : "Remote MCP returned a tool error",
-      likelySource: "Downstream provider or tool",
+      likelySource: "Downstream provider",
       confidence: "Confirmed",
       retryGuidance: diagnostic?.operatorAction
         ?? (diagnostic?.retryable
@@ -244,9 +244,9 @@ export function attributeExternalMcpToolFailure(input: {
     && (diagnostic?.code === "MCP_LIFECYCLE_DEADLINE" || diagnostic?.code === "MCP_REQUEST_TIMEOUT");
   if (deadlineAfterSend) {
     return {
-      summary: "Den sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
-      lastConfirmedBoundary: "Den started the outbound tools/call",
-      likelySource: "Network path or remote MCP after Den",
+      summary: "OpenWork sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
+      lastConfirmedBoundary: "OpenWork started the outbound tools/call",
+      likelySource: "Network or remote MCP",
       confidence: "Inferred",
       retryGuidance: unknownOutcomeGuidance(mayHaveSideEffects),
       outcome: "unknown",
@@ -256,9 +256,9 @@ export function attributeExternalMcpToolFailure(input: {
 
   if (inspection?.request && !inspection.response) {
     return {
-      summary: "Den started the outbound request, but no HTTP response was captured. This does not prove the remote MCP caused the failure.",
-      lastConfirmedBoundary: "Den started the outbound tools/call",
-      likelySource: "Den outbound path, network, or remote MCP",
+      summary: "OpenWork started the outbound request, but no HTTP response was captured. This does not prove the remote MCP caused the failure.",
+      lastConfirmedBoundary: "OpenWork started the outbound tools/call",
+      likelySource: "Source unclear after send",
       confidence: "Inferred",
       retryGuidance: unknownOutcomeGuidance(mayHaveSideEffects),
       outcome: "unknown",
@@ -270,7 +270,7 @@ export function attributeExternalMcpToolFailure(input: {
     return {
       summary: inspection.diagnosis?.summary ?? "The remote MCP responded, but the tool result was not successful.",
       lastConfirmedBoundary: `Remote MCP returned HTTP ${inspection.response.status}`,
-      likelySource: "MCP protocol or tool result",
+      likelySource: "MCP tool result",
       confidence: "Inferred",
       retryGuidance: diagnostic?.operatorAction ?? "Inspect the MCP tool result and diagnostic reference before retrying.",
       outcome: "failed",
@@ -284,10 +284,10 @@ export function attributeExternalMcpToolFailure(input: {
       ?? diagnostic?.message
       ?? "The request failed before OpenWork received a tool result.",
     lastConfirmedBoundary: lastBoundaryFromDiagnostic(diagnostic)
-      ?? (diagnostic ? "Den returned a structured diagnostic" : "Dashboard started the request to Den"),
-    likelySource: networkSetup ? "Den connection path or remote MCP setup" : "OpenWork or MCP connection setup",
+      ?? (diagnostic ? "OpenWork returned a structured diagnostic" : "OpenWork dashboard sent the request"),
+    likelySource: networkSetup ? "Connection path or remote MCP" : "OpenWork or MCP setup",
     confidence: "Inferred",
-    retryGuidance: diagnostic?.operatorAction ?? "Use the diagnostic reference to inspect Den and MCP connection health before retrying.",
+    retryGuidance: diagnostic?.operatorAction ?? "Use the diagnostic reference to inspect OpenWork and MCP connection health before retrying.",
     outcome: "failed",
     ...details,
   };

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useMemo, useState } from "react";
-import { AlertTriangle, ArrowRight, Check, Loader2, LockKeyhole, Play, RefreshCw, Wrench } from "lucide-react";
+import { AlertTriangle, ArrowRight, Check, ChevronDown, Loader2, LockKeyhole, Play, RefreshCw, Wrench } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenSelect } from "../../_components/ui/select";
 import { DenTextarea } from "../../_components/ui/textarea";
@@ -118,35 +118,37 @@ function McpFailureAttribution({
       className={`${standalone ? "rounded-2xl border border-red-200" : "border-b border-red-200"} bg-red-50 px-4 py-3`}
       role="alert"
     >
-      <p className="inline-flex items-center gap-1.5 text-[12px] font-semibold text-red-800">
-        <AlertTriangle className="h-4 w-4" aria-hidden="true" /> Tool call failed
-      </p>
-      <p className="mt-1 text-[11px] leading-5 text-red-700">{attribution.summary}</p>
-      <dl className="mt-3 grid gap-2 text-[10px] sm:grid-cols-2">
-        <div>
-          <dt className="font-semibold uppercase tracking-wide text-red-500">Last confirmed boundary</dt>
-          <dd className="mt-0.5 text-gray-800">{attribution.lastConfirmedBoundary}</dd>
-        </div>
-        <div>
-          <dt className="font-semibold uppercase tracking-wide text-red-500">Likely source</dt>
-          <dd className="mt-0.5 text-gray-800">{attribution.likelySource}</dd>
-        </div>
-        <div>
-          <dt className="font-semibold uppercase tracking-wide text-red-500">Confidence</dt>
-          <dd className="mt-0.5 text-gray-800">{attribution.confidence}</dd>
-        </div>
-        <div>
-          <dt className="font-semibold uppercase tracking-wide text-red-500">Retry guidance</dt>
-          <dd className="mt-0.5 text-gray-800">{attribution.retryGuidance}</dd>
-        </div>
-      </dl>
-      {attribution.diagnosticReference || attribution.providerRequestId || attribution.diagnosticCode ? (
-        <div className="mt-3 flex flex-wrap gap-x-4 gap-y-1 border-t border-red-200 pt-2 font-mono text-[9px] text-red-700">
-          {attribution.diagnosticReference ? <span>Diagnostic reference: {attribution.diagnosticReference}</span> : null}
-          {attribution.providerRequestId ? <span>Provider request ID: {attribution.providerRequestId}</span> : null}
-          {attribution.diagnosticCode ? <span>Code: {attribution.diagnosticCode}</span> : null}
-        </div>
-      ) : null}
+      <div className="flex flex-wrap items-center gap-x-2 gap-y-1 text-[12px] text-red-800">
+        <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+        <span className="font-semibold">Tool call failed</span>
+        <span className="text-red-400">·</span>
+        <span>Attribution: <strong>{attribution.likelySource}</strong></span>
+        <span className="rounded-full border border-red-200 bg-white/60 px-1.5 py-0.5 text-[10px] font-medium">{attribution.confidence}</span>
+      </div>
+      <details className="group/attribution mt-2">
+        <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-[10px] font-medium text-red-700 [&::-webkit-details-marker]:hidden">
+          Developer details
+          <ChevronDown className="h-3 w-3 transition-transform group-open/attribution:rotate-180" aria-hidden="true" />
+        </summary>
+        <p className="mt-2 border-t border-red-200 pt-2 text-[10px] leading-4 text-red-700">{attribution.summary}</p>
+        <dl className="mt-2 grid gap-2 text-[10px] sm:grid-cols-2">
+          <div>
+            <dt className="font-semibold uppercase tracking-wide text-red-500">Last confirmed boundary</dt>
+            <dd className="mt-0.5 text-gray-800">{attribution.lastConfirmedBoundary}</dd>
+          </div>
+          <div>
+            <dt className="font-semibold uppercase tracking-wide text-red-500">Retry guidance</dt>
+            <dd className="mt-0.5 text-gray-800">{attribution.retryGuidance}</dd>
+          </div>
+        </dl>
+        {attribution.diagnosticReference || attribution.providerRequestId || attribution.diagnosticCode ? (
+          <div className="mt-2 flex flex-wrap gap-x-4 gap-y-1 font-mono text-[9px] text-red-700">
+            {attribution.diagnosticReference ? <span>Diagnostic reference: {attribution.diagnosticReference}</span> : null}
+            {attribution.providerRequestId ? <span>Provider request ID: {attribution.providerRequestId}</span> : null}
+            {attribution.diagnosticCode ? <span>Code: {attribution.diagnosticCode}</span> : null}
+          </div>
+        ) : null}
+      </details>
     </div>
   );
 }
@@ -190,50 +192,60 @@ function McpToolCallInspector({
         </div>
       )}
 
-      <div className="border-b border-amber-100 bg-amber-50/70 px-4 py-2 text-[10px] leading-4 text-amber-800">
-        Credential and session headers are redacted. Request and response bodies may contain sensitive provider data; this inspection is returned only for this run and is not stored in Den logs.
-      </div>
+      <details className="group/wire">
+        <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-[11px] font-medium text-gray-700 transition hover:bg-gray-50 [&::-webkit-details-marker]:hidden">
+          <span>Inspect request and response</span>
+          <span className="inline-flex items-center gap-2 font-mono text-[10px] text-gray-500">
+            {transportChip}
+            <ChevronDown className="h-3.5 w-3.5 transition-transform group-open/wire:rotate-180" aria-hidden="true" />
+          </span>
+        </summary>
 
-      <div className="grid gap-0 xl:grid-cols-2 xl:divide-x xl:divide-gray-200">
-        <div className="space-y-4 p-4">
-          <div>
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Outgoing request</p>
+        <div className="border-t border-amber-100 bg-amber-50/70 px-4 py-2 text-[10px] leading-4 text-amber-800">
+          Credential and session headers are redacted. Request and response bodies may contain sensitive provider data; this inspection is returned only for this run and is not stored in OpenWork logs.
+        </div>
+
+        <div className="grid gap-0 border-t border-gray-200 xl:grid-cols-2 xl:divide-x xl:divide-gray-200">
+          <div className="space-y-4 p-4">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Outgoing request</p>
+              {inspection.request ? (
+                <div className="mt-2 rounded-lg bg-gray-950 px-3 py-2 font-mono text-[10px] leading-4 text-gray-100">
+                  <span className="font-semibold text-blue-300">{inspection.request.method}</span> <span className="break-all">{inspection.request.url}</span>
+                </div>
+              ) : (
+                <p className="mt-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-[11px] text-gray-500">No tools/call request left OpenWork.</p>
+              )}
+            </div>
             {inspection.request ? (
-              <div className="mt-2 rounded-lg bg-gray-950 px-3 py-2 font-mono text-[10px] leading-4 text-gray-100">
-                <span className="font-semibold text-blue-300">{inspection.request.method}</span> <span className="break-all">{inspection.request.url}</span>
-              </div>
-            ) : (
-              <p className="mt-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-[11px] text-gray-500">No tools/call request left OpenWork.</p>
-            )}
+              <>
+                <div><p className="mb-1.5 text-[11px] font-medium text-gray-700">Headers</p><InspectionHeaders headers={inspection.request.headers} /></div>
+                <InspectionBody body={inspection.request.body} />
+              </>
+            ) : null}
           </div>
-          {inspection.request ? (
-            <>
-              <div><p className="mb-1.5 text-[11px] font-medium text-gray-700">Headers</p><InspectionHeaders headers={inspection.request.headers} /></div>
-              <InspectionBody body={inspection.request.body} />
-            </>
-          ) : null}
-        </div>
 
-        <div className="space-y-4 border-t border-gray-200 p-4 xl:border-t-0">
-          <div>
-            <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Response received</p>
+          <div className="space-y-4 border-t border-gray-200 p-4 xl:border-t-0">
+            <div>
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-gray-500">Response received</p>
+              {inspection.response ? (
+                <div className="mt-2 flex items-center justify-between gap-3 rounded-lg bg-gray-950 px-3 py-2 font-mono text-[10px] text-gray-100">
+                  <span><span className={inspection.response.status < 400 ? "text-emerald-300" : "text-red-300"}>HTTP {inspection.response.status}</span> {inspection.response.statusText}</span>
+                  <span className="text-gray-400">{inspection.response.durationMs} ms</span>
+                </div>
+              ) : (
+                <p className="mt-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-[11px] text-gray-500">No HTTP response was captured.</p>
+              )}
+            </div>
             {inspection.response ? (
-              <div className="mt-2 flex items-center justify-between gap-3 rounded-lg bg-gray-950 px-3 py-2 font-mono text-[10px] text-gray-100">
-                <span><span className={inspection.response.status < 400 ? "text-emerald-300" : "text-red-300"}>HTTP {inspection.response.status}</span> {inspection.response.statusText}</span>
-                <span className="text-gray-400">{inspection.response.durationMs} ms</span>
-              </div>
-            ) : (
-              <p className="mt-2 rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-[11px] text-gray-500">No HTTP response was captured.</p>
-            )}
+              <>
+                <div><p className="mb-1.5 text-[11px] font-medium text-gray-700">Headers</p><InspectionHeaders headers={inspection.response.headers} /></div>
+                <InspectionBody body={inspection.response.body} />
+              </>
+            ) : null}
           </div>
-          {inspection.response ? (
-            <>
-              <div><p className="mb-1.5 text-[11px] font-medium text-gray-700">Headers</p><InspectionHeaders headers={inspection.response.headers} /></div>
-              <InspectionBody body={inspection.response.body} />
-            </>
-          ) : null}
         </div>
-      </div>
+      </details>
     </section>
   );
 }
@@ -319,7 +331,7 @@ export function McpToolRunner({ connection }: { connection: ExternalMcpConnectio
             <p className="text-[13px] font-semibold text-gray-900">Run a tool manually</p>
           </div>
           <p className="mt-1 max-w-2xl text-[12px] leading-5 text-gray-500">
-            This runs directly from Den with your available connection credential. Arguments and results are not written to Den logs.
+            This runs through OpenWork with your available connection credential. Arguments and results are not written to OpenWork logs.
           </p>
         </div>
         <DenButton variant="secondary" size="sm" loading={catalog.isFetching} onClick={() => void catalog.refetch()}>

--- a/ee/apps/den-web/tests/mcp-tool-error-attribution.test.ts
+++ b/ee/apps/den-web/tests/mcp-tool-error-attribution.test.ts
@@ -41,10 +41,10 @@ describe("browser-to-Den timeout", () => {
     expect(error.timeoutMs).toBe(5);
     expect(error.outcome).toBe("unknown");
     expect(error.message).toBe(
-      "The OpenWork dashboard stopped waiting for Den after 5 milliseconds. The operation’s outcome is unknown.",
+      "OpenWork stopped waiting after 5 milliseconds. The operation’s outcome is unknown.",
     );
     expect(new DenRequestTimeoutError(160_000).message).toBe(
-      "The OpenWork dashboard stopped waiting for Den after 160 seconds. The operation’s outcome is unknown.",
+      "OpenWork stopped waiting after 160 seconds. The operation’s outcome is unknown.",
     );
   });
 
@@ -83,9 +83,9 @@ describe("MCP failure attribution", () => {
     });
 
     expect(attribution).toMatchObject({
-      summary: "Den sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
-      lastConfirmedBoundary: "Den started the outbound tools/call",
-      likelySource: "Network path or remote MCP after Den",
+      summary: "OpenWork sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
+      lastConfirmedBoundary: "OpenWork started the outbound tools/call",
+      likelySource: "Network or remote MCP",
       confidence: "Inferred",
       outcome: "unknown",
       diagnosticReference: "req_deadline",
@@ -104,7 +104,7 @@ describe("MCP failure attribution", () => {
     expect(attribution).toMatchObject({
       summary: `The remote MCP returned HTTP ${status}.`,
       lastConfirmedBoundary: `Remote MCP returned HTTP ${status}`,
-      likelySource: "Remote MCP HTTP layer",
+      likelySource: "Remote MCP",
       confidence: "Confirmed",
       outcome: "failed",
     });
@@ -130,7 +130,7 @@ describe("MCP failure attribution", () => {
     expect(attribution).toMatchObject({
       summary: "The remote MCP responded, but the downstream provider rejected the operation.",
       lastConfirmedBoundary: "Remote MCP returned HTTP 200 with a tool error",
-      likelySource: "Downstream provider or tool",
+      likelySource: "Downstream provider",
       confidence: "Confirmed",
       providerRequestId: "provider-request-123",
     });
@@ -154,9 +154,9 @@ describe("MCP failure attribution", () => {
     });
 
     expect(attribution).toMatchObject({
-      summary: "OpenWork blocked the request before it left Den.",
-      lastConfirmedBoundary: "Den evaluated the outbound request",
-      likelySource: "OpenWork policy or connection configuration",
+      summary: "OpenWork blocked the request before it was sent.",
+      lastConfirmedBoundary: "OpenWork evaluated the outbound request",
+      likelySource: "OpenWork",
       confidence: "Confirmed",
       outcome: "failed",
     });
@@ -171,7 +171,7 @@ describe("MCP failure attribution", () => {
     });
 
     expect(attribution.summary).toBe(
-      "The OpenWork dashboard stopped waiting for Den after 160 seconds. The operation’s outcome is unknown.",
+      "OpenWork stopped waiting after 160 seconds. The operation’s outcome is unknown.",
     );
     expect(attribution.retryGuidance).toContain("Do not retry immediately");
     expect(attribution.retryGuidance).toContain("may have changed external data");
@@ -218,7 +218,7 @@ describe("MCP failure attribution", () => {
           status: 504,
           headers: [{ name: "x-request-id", value: "wire-request-789", redacted: false }],
         },
-        diagnosis: { layer: "remote_http", summary: "Older Den failure shape." },
+        diagnosis: { layer: "remote_http", summary: "Older OpenWork failure shape." },
       },
       browserTimeout: null,
       mayHaveSideEffects: false,


### PR DESCRIPTION
## Summary

- add a compact attribution chip to failed desktop chat tool rows using the structured MCP diagnostic already present in the tool error
- distinguish OpenWork-created deadlines and blocks, remote MCP HTTP failures, downstream provider failures, and unstructured timeouts whose source is unclear
- collapse dashboard developer evidence and raw request/response inspection by default so the normal failure state stays concise
- use `OpenWork` in user-facing copy while preserving the existing internal Den implementation names

## Why

PR #2768 added structured failure attribution and transport inspection, but the desktop chat surface still showed a generic failed tool row and the dashboard presented too much diagnostic detail at once. This follow-up makes the answer visible without requiring a developer to guess, while keeping detailed evidence available on demand.

This branch is based directly on merged PR #2768 (`7a4f8fe2`) and has no unmerged PR dependency.

## Attribution behavior

- `OpenWork timeout` when OpenWork created the deadline; the tooltip warns that the external outcome may be unknown
- `Blocked by OpenWork` for confirmed pre-send policy blocks
- `Remote MCP · HTTP <status>` for a confirmed non-2xx remote response
- `Provider error` when the remote MCP responded with downstream provider evidence
- `Timeout · source unclear` for an unstructured timeout without enough evidence to assign ownership

Unknown and captured-request-without-response cases remain inferred; the UI does not claim that the external server caused them.

## Checks

- `pnpm exec bun test tests/tool-error-attribution.test.ts tests/tool-error-attribution-ui.test.tsx` from `apps/app` — 9 passed
- `pnpm typecheck` from `apps/app` — passed
- `pnpm exec bun test tests/mcp-tool-error-attribution.test.ts` from `ee/apps/den-web` — 9 passed
- `pnpm exec tsc --noEmit` from `ee/apps/den-web` — passed
- `pnpm exec bun test test/external-mcp-tool-inspection.test.ts` from `ee/apps/den-api` — 8 passed
- `pnpm exec tsc --noEmit` from `ee/apps/den-api` — passed
- `./bin/openwork-hub check mcp mcp-attribution-ui` — passed

## Manual review

1. In a desktop chat, trigger a failed `openwork-cloud_execute_capability` call with a structured remote HTTP, provider, OpenWork block, or deadline diagnostic.
2. Confirm the failed tool row shows one discreet attribution chip and still expands to the original error text.
3. In the Connections dashboard manual tool runner, trigger `remote_504` or an HTTP-200 provider error.
4. Confirm the failure header is one compact attribution line, `Developer details` is closed initially, and `Inspect request and response` is separately closed initially.
5. Expand both disclosures and confirm diagnostic IDs, retry guidance, redacted headers, and ephemeral request/response data are still available.

Fresh screenshot/video evidence was not captured for this follow-up because local browser control could not refresh the localhost preview. The focused component render test covers the desktop attribution row; the steps above remain the reviewer journey.

## Security and privacy

- no new wire contract, credential access, persistence, telemetry, or logging
- desktop attribution parses only the existing tool error text already rendered in chat
- request/response inspection remains ephemeral
- existing sensitive-header and query redaction behavior is unchanged and covered by the Den API inspection test
- request and response bodies are not added to logs

## Risk and fallback

The chip appears only when structured evidence or a recognizable timeout is available. Unknown future diagnostic shapes fall back to an inferred timeout label or the existing generic `failed` state rather than overclaiming attribution.

## Visual verification

Captured against the isolated local MCP proof stack. Each public Vercel Blob URL returned `200 image/png` and matched the SHA-256 of its local source.

### Desktop chat — compact confirmed Remote MCP attribution

![Desktop chat error attribution](https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/fraimz/mcp-attribution-ui/desktop-chat-error-attribution.png)

### Dashboard — compact failure attribution with details collapsed

![Dashboard compact attribution](https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/fraimz/mcp-attribution-ui/dashboard-compact-attribution-focused.png)

### Dashboard — expanded developer attribution details

![Dashboard developer details](https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/fraimz/mcp-attribution-ui/dashboard-developer-details.png)

### Dashboard — ephemeral request and response inspection

![Dashboard wire inspection](https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/fraimz/mcp-attribution-ui/dashboard-wire-inspection.png)

### Dashboard — downstream provider attribution through HTTP 200

![Dashboard provider attribution](https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/fraimz/mcp-attribution-ui/dashboard-provider-attribution.png)
