### PR TITLE
fix(app): match invalid_mcp_token in cloud MCP auth-failure codes

### DIFF
--- a/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
@@ -192,10 +192,27 @@ export function isCloudMcpAuthTokenFailureCode(code: string | null | undefined):
   return normalized === "openwork_cloud_auth_required" ||
     normalized === "openwork_cloud_auth_invalid" ||
     normalized === "openwork_cloud_token_expired" ||
+    // The Den rejects an expired/missing first-party bearer with exactly these
+    // codes; the `_mcp_` infix means the `invalid_token` substring below never
+    // matches them (field incident: token sat expired for 7 days because the
+    // remint retry never fired).
+    normalized === "invalid_mcp_token" ||
+    normalized === "missing_mcp_token" ||
     normalized.includes("invalid_token") ||
     normalized.includes("unauthorized") ||
     normalized.includes("expired") ||
     normalized.includes("auth");
+}
+
+/**
+ * Health failures carry the primary `code` plus optional `aliases` (e.g. the
+ * direct-probe 401 reports code `invalid_mcp_token` with alias
+ * `openwork_cloud_token_expired`). Remint decisions must consider both.
+ */
+export function isCloudMcpAuthTokenFailure(failure: Pick<OpenworkCloudMcpFailure, "code" | "aliases"> | null | undefined): boolean {
+  if (!failure) return false;
+  if (isCloudMcpAuthTokenFailureCode(failure.code)) return true;
+  return (failure.aliases ?? []).some((alias) => isCloudMcpAuthTokenFailureCode(alias));
 }
 
 function shouldSkipForPrerequisite(input: CloudMcpReconcilerInput, scope: CloudMcpScope): CloudMcpOperationResult | null {
@@ -274,7 +291,7 @@ async function repairCloudMcp(input: CloudMcpReconcilerInput, scope: CloudMcpSco
   let health = first.health;
   let token = first.token;
   let reminted = false;
-  if (isCloudMcpAuthTokenFailureCode(health?.firstFailure?.code)) {
+  if (isCloudMcpAuthTokenFailure(health?.firstFailure)) {
     const second = await mintAndPost(input, scope);
     attempts += 1;
     reminted = true;

--- a/apps/app/tests/cloud-mcp-health.test.ts
+++ b/apps/app/tests/cloud-mcp-health.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   cloudMcpDisplaySummary,
   cloudMcpFailureStageLabel,
+  isCloudMcpAuthTokenFailure,
   isCloudMcpAuthTokenFailureCode,
   runOpenworkCloudMcpReconciler,
 } from "../src/react-app/domains/connections/cloud-mcp-reconciler";
@@ -254,6 +255,53 @@ describe("OpenWork Cloud MCP reconciler", () => {
 
     expect(mintCount).toBe(1);
     expect(postCount).toBe(1);
+  });
+
+  test("expired first-party token codes count as auth failures", () => {
+    // Field incident regression: the Den rejects an expired opaque bearer with
+    // code `invalid_mcp_token`; the `_mcp_` infix defeated the substring check
+    // and the remint retry never fired for ~7 days.
+    expect(isCloudMcpAuthTokenFailureCode("invalid_mcp_token")).toBe(true);
+    expect(isCloudMcpAuthTokenFailureCode("missing_mcp_token")).toBe(true);
+    expect(isCloudMcpAuthTokenFailureCode("openwork_cloud_token_expired")).toBe(true);
+    expect(isCloudMcpAuthTokenFailureCode("invalid_token")).toBe(true);
+    // Exclusions still hold.
+    expect(isCloudMcpAuthTokenFailureCode("openwork_cloud_client_registration_required")).toBe(false);
+    expect(isCloudMcpAuthTokenFailureCode("membership_not_found")).toBe(false);
+    expect(isCloudMcpAuthTokenFailureCode(null)).toBe(false);
+  });
+
+  test("auth aliases trigger the remint retry when the primary code is unrecognized", async () => {
+    expect(isCloudMcpAuthTokenFailure({ code: "cloud_connection_failed", aliases: ["openwork_cloud_token_expired"] })).toBe(true);
+    expect(isCloudMcpAuthTokenFailure({ code: "cloud_connection_failed", aliases: ["cloud_tools_missing"] })).toBe(false);
+    expect(isCloudMcpAuthTokenFailure(null)).toBe(false);
+
+    let mintCount = 0;
+    const posts: OpenworkCloudMcpReconcilePayload[] = [];
+    const result = await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => health({ usable: false }),
+        reconcileOpenworkCloudMcp: async (_workspaceId, payload) => {
+          posts.push(payload);
+          return posts.length === 1
+            ? health({ usable: false, failure: { ...failure("invalid_mcp_token"), aliases: ["openwork_cloud_token_expired"] } })
+            : health({ usable: true });
+        },
+      },
+      context,
+      mintToken: async () => {
+        mintCount += 1;
+        return { ...token, token: `owt_mcp_secret_${mintCount}` };
+      },
+      force: true,
+      refreshMarginMs: 1,
+    });
+
+    expect(result.health?.usable).toBe(true);
+    expect(mintCount).toBe(2);
+    expect(posts).toHaveLength(2);
   });
 
   test("dedupe key is scoped by deployment, server, workspace, and org without token", () => {


### PR DESCRIPTION
## What

Field incident (Jul 14): a desktop's 7-day first-party MCP token expired and the reconciler's remint-retry never fired — cloud tools 401'd, then vanished from sessions.

Root cause: the Den rejects an expired/missing opaque bearer with code `invalid_mcp_token` (health prober maps the direct tools/list 401 to this code with alias `openwork_cloud_token_expired` — `apps/server/src/cloud-mcp-health.ts:1434`). `isCloudMcpAuthTokenFailureCode` relied on `.includes("invalid_token")`, which the `_mcp_` infix defeats, and the call site checked `.code` only, never `aliases`.

- Add exact matches for `invalid_mcp_token` / `missing_mcp_token`
- Add `isCloudMcpAuthTokenFailure(failure)` that also consults `aliases` and use it at the retry site (`repairCloudMcp`)

## Testing

- `bun test tests/cloud-mcp-health.test.ts` in `apps/app` — 9 pass / 0 fail (2 new tests: expired-token code regression incl. exclusions; alias-driven remint drives the reconciler to a second mint and usable health)
- `pnpm typecheck` in `apps/app` — clean

fraimz: skipped — unit-tested renderer logic, no visual surface change. Part 1/3 of the token-death-spiral fixes (gate fix and maintenance watchdog ship separately).