### PR TITLE
fix(app): cloud MCP user state gates provisioning, not token maintenance

### DIFF
--- a/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
@@ -220,7 +220,13 @@ function shouldSkipForPrerequisite(input: CloudMcpReconcilerInput, scope: CloudM
   if (input.mode === "health") return null;
   if (!input.context.denAuthToken?.trim()) return { status: "skipped", health: null, skippedReason: "signed_out", attempts: 0, markerWritten: false, reminted: false };
   if (!scope.orgId) return { status: "skipped", health: null, skippedReason: "missing_org", attempts: 0, markerWritten: false, reminted: false };
-  if (input.configuredEnabled === false || readCloudMcpUserState(scope) !== null) {
+  if (input.configuredEnabled === false) {
+    return { status: "skipped", health: null, skippedReason: "disabled", attempts: 0, markerWritten: false, reminted: false };
+  }
+  // Recorded user intent only blocks provisioning (entry absent/unknown). A
+  // known-enabled entry must keep its token fresh even when a stale
+  // disabled/removed intent is still recorded.
+  if (input.configuredEnabled !== true && readCloudMcpUserState(scope) !== null) {
     return { status: "skipped", health: null, skippedReason: "disabled", attempts: 0, markerWritten: false, reminted: false };
   }
   return null;

--- a/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
+++ b/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
@@ -158,13 +158,18 @@ export async function syncCloudControlMcpInBackground(input: {
     orgId,
     workspaceId,
   };
-  if (readCloudMcpUserState(scope) !== null) {
-    return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
-  }
-
   const listed = await input.client.listMcp(workspaceId);
   const configured = listed.items.find((entry) => entry.name === CLOUD_MCP_SERVER_NAME);
   if (configured?.config.enabled === false) {
+    return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
+  }
+  // Recorded user intent (disabled/removed) gates provisioning only: when no
+  // enabled entry exists we honor it, but an existing enabled entry must keep
+  // its token fresh regardless. A stale "removed" intent once silently
+  // disabled all maintenance until the 7-day token expired and the engine
+  // dropped the MCP.
+  const configuredEnabled = configured !== undefined && configured.config.enabled !== false;
+  if (!configuredEnabled && readCloudMcpUserState(scope) !== null) {
     return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
   }
   const configuredUrl = typeof configured?.config.url === "string" ? configured.config.url : null;
@@ -187,7 +192,7 @@ export async function syncCloudControlMcpInBackground(input: {
     force: input.force,
     refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
     now: input.now,
-    configuredEnabled: typeof configured?.config.enabled === "boolean" ? configured.config.enabled : null,
+    configuredEnabled: configured === undefined ? null : configured.config.enabled !== false,
   });
   if (result.health?.usable) {
     return {

--- a/apps/app/tests/cloud-mcp-maintenance-gate.test.ts
+++ b/apps/app/tests/cloud-mcp-maintenance-gate.test.ts
@@ -1,0 +1,288 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { DenMcpToken } from "../src/app/lib/den";
+import type { DenSettings } from "../src/app/lib/den-types";
+import type {
+  OpenworkCloudMcpFailure,
+  OpenworkCloudMcpHealth,
+  OpenworkMcpItem,
+} from "../src/app/lib/openwork-server";
+import {
+  __setCloudMcpUserStateStorageForTest,
+  CLOUD_MCP_SERVER_NAME,
+  writeCloudMcpUserState,
+} from "../src/react-app/domains/connections/cloud-mcp-user-state";
+import { runOpenworkCloudMcpReconciler } from "../src/react-app/domains/connections/cloud-mcp-reconciler";
+import { syncCloudControlMcpInBackground } from "../src/react-app/domains/connections/use-session-mcp-maintenance";
+
+const NOW = Date.parse("2026-07-14T12:00:00.000Z");
+const LEGACY_USER_STATE_KEY = "openwork.den.mcp.cloudControlUserState";
+
+const scope = {
+  denBaseUrl: "https://app.openwork.test",
+  serverBaseUrl: "https://worker.openwork.test",
+  orgId: "org_1",
+  workspaceId: "ws_1",
+};
+
+const settings: DenSettings = {
+  baseUrl: scope.denBaseUrl,
+  authToken: "den-session-token",
+  activeOrgId: scope.orgId,
+  activeOrgSlug: "org-one",
+  activeOrgName: "Org One",
+};
+
+const context = {
+  ...scope,
+  denAuthToken: settings.authToken,
+  providerModel: { provider: "openwork", model: "gpt-5" },
+};
+
+const token: DenMcpToken = {
+  token: "owt_mcp_secret_token",
+  expiresAt: new Date(NOW + 7 * 24 * 60 * 60 * 1000).toISOString(),
+  organizationId: scope.orgId,
+  scopes: ["mcp:read", "mcp:write"],
+  resource: "https://api.openwork.test/mcp",
+};
+
+let storageValues: Map<string, string>;
+
+function installStorageStub(initial?: Record<string, string>) {
+  storageValues = new Map(Object.entries(initial ?? {}));
+  __setCloudMcpUserStateStorageForTest({
+    getItem: (key) => storageValues.get(key) ?? null,
+    setItem: (key, value) => storageValues.set(key, value),
+    removeItem: (key) => storageValues.delete(key),
+  });
+}
+
+function failure(code: string): OpenworkCloudMcpFailure {
+  return {
+    code,
+    stage: "engine_status",
+    retryable: false,
+    recommendedAction: "fix it",
+    message: "failed",
+  };
+}
+
+function health(input: { usable: boolean; failure?: OpenworkCloudMcpFailure | null }): OpenworkCloudMcpHealth {
+  const usable = input.usable;
+  return {
+    schemaVersion: 1,
+    phase: usable ? "ready" : "engine_failed",
+    usable,
+    usableByCurrentModel: usable ? true : null,
+    connectCatalogEnabled: true,
+    workspace: { id: scope.workspaceId, type: "local", directory: "/workspace", path: "/workspace" },
+    desired: {
+      present: true,
+      name: CLOUD_MCP_SERVER_NAME,
+      revision: "rev_desired",
+      config: null,
+      token: { present: true, metadata: { expiresAt: token.expiresAt, scopes: "mcp:read mcp:write" } },
+    },
+    delivery: {
+      state: usable ? "ready" : "pending",
+      desiredRevision: "rev_desired",
+      appliedRevision: usable ? "rev_desired" : null,
+      updatedAt: NOW,
+      appliedAt: usable ? NOW : null,
+      lastAttemptAt: NOW,
+    },
+    engine: { status: usable ? "connected" : "failed" },
+    tools: {
+      expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+      present: usable ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"] : [],
+      missing: usable ? [] : ["openwork-cloud_search_capabilities"],
+      direct: {
+        checked: true,
+        source: "mcp_tools_list",
+        expected: ["search_capabilities", "execute_capability"],
+        present: usable ? ["search_capabilities", "execute_capability"] : [],
+        missing: usable ? [] : ["search_capabilities"],
+      },
+      providerProjection: {
+        checked: usable,
+        provider: "openwork",
+        model: "gpt-5",
+        source: "experimental_tool",
+        present: usable ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"] : [],
+        missing: usable ? [] : ["openwork-cloud_execute_capability"],
+      },
+    },
+    pluginCanaries: {
+      expected: ["openwork_docs_search"],
+      present: usable ? ["openwork_docs_search"] : [],
+      missing: usable ? [] : ["openwork_docs_search"],
+    },
+    compatibility: {
+      openwork: { serverVersion: "test", app: null },
+      opencode: { expectedVersion: "1.17.11", actualVersion: "1.17.11", probe: "ok" },
+      pluginFileHashes: [],
+      supportedFeatures: { dynamicMcp: true, directoryScoping: true, toolIds: true, providerToolProjection: usable, pluginCanaries: true },
+      experimentalToolIds: {
+        checked: true,
+        expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+        present: usable ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"] : [],
+        missing: usable ? [] : ["openwork-cloud_execute_capability"],
+        includesMcpTools: usable,
+      },
+      experimentalProviderTools: {
+        checked: usable,
+        provider: "openwork",
+        model: "gpt-5",
+        expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+        present: usable ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"] : [],
+        missing: usable ? [] : ["openwork-cloud_execute_capability"],
+        includesMcpTools: usable ? true : null,
+      },
+    },
+    toolDenies: [],
+    firstFailure: usable ? null : input.failure ?? failure("cloud_connection_failed"),
+    checkedAt: new Date(NOW).toISOString(),
+  };
+}
+
+function configuredItem(): OpenworkMcpItem {
+  return {
+    name: CLOUD_MCP_SERVER_NAME,
+    config: {
+      type: "remote",
+      enabled: true,
+      url: "https://api.openwork.test/mcp/agent",
+      headers: { Authorization: "Bearer owt_mcp_expired" },
+    },
+    source: "config.remote",
+  };
+}
+
+describe("cloud MCP maintenance user-state gate", () => {
+  beforeEach(() => installStorageStub());
+
+  test("field repro: legacy 'removed' intent must not block token maintenance of an existing enabled entry", async () => {
+    // The affected machine had the legacy raw-string value from an old manual
+    // toggle. Its 7-day token expired with maintenance permanently skipped.
+    installStorageStub({ [LEGACY_USER_STATE_KEY]: "removed" });
+
+    let mintCount = 0;
+    let reconcileCount = 0;
+    const result = await syncCloudControlMcpInBackground({
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        listMcp: async () => ({ items: [configuredItem()] }),
+        getOpenworkCloudMcpHealth: async () => health({ usable: false, failure: failure("invalid_mcp_token") }),
+        reconcileOpenworkCloudMcp: async () => {
+          reconcileCount += 1;
+          return health({ usable: true });
+        },
+      },
+      workspaceId: scope.workspaceId,
+      settings,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+    });
+
+    expect(result).toMatchObject({ outcome: "ready", status: "synced" });
+    expect(mintCount).toBeGreaterThanOrEqual(1);
+    expect(reconcileCount).toBeGreaterThanOrEqual(1);
+  });
+
+  test("provisioning stays gated: recorded intent with no configured entry skips without minting", async () => {
+    installStorageStub({ [LEGACY_USER_STATE_KEY]: "removed" });
+
+    let mintCount = 0;
+    let reconcileCount = 0;
+    const result = await syncCloudControlMcpInBackground({
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        listMcp: async () => ({ items: [] }),
+        getOpenworkCloudMcpHealth: async () => health({ usable: false }),
+        reconcileOpenworkCloudMcp: async () => {
+          reconcileCount += 1;
+          return health({ usable: true });
+        },
+      },
+      workspaceId: scope.workspaceId,
+      settings,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+    });
+
+    expect(result).toEqual({ outcome: "skipped", status: "skipped", reason: "disabled", health: null });
+    expect(mintCount).toBe(0);
+    expect(reconcileCount).toBe(0);
+  });
+
+  test("explicitly disabled entries stay skipped even without recorded intent", async () => {
+    let mintCount = 0;
+    const disabled: OpenworkMcpItem = { ...configuredItem(), config: { ...configuredItem().config, enabled: false } };
+    const result = await syncCloudControlMcpInBackground({
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        listMcp: async () => ({ items: [disabled] }),
+        getOpenworkCloudMcpHealth: async () => health({ usable: false }),
+        reconcileOpenworkCloudMcp: async () => health({ usable: true }),
+      },
+      workspaceId: scope.workspaceId,
+      settings,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+    });
+
+    expect(result).toEqual({ outcome: "skipped", status: "skipped", reason: "disabled", health: null });
+    expect(mintCount).toBe(0);
+  });
+
+  test("reconciler: scoped 'removed' intent yields to configuredEnabled=true and blocks when the entry is absent", async () => {
+    writeCloudMcpUserState("removed", scope);
+
+    let mintCount = 0;
+    const proceeding = await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => health({ usable: false }),
+        reconcileOpenworkCloudMcp: async () => health({ usable: true }),
+      },
+      context,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+      force: true,
+      refreshMarginMs: 1,
+      configuredEnabled: true,
+    });
+    expect(proceeding.status).toBe("repaired");
+    expect(mintCount).toBe(1);
+
+    const blocked = await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => health({ usable: false }),
+        reconcileOpenworkCloudMcp: async () => health({ usable: true }),
+      },
+      context,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+      force: true,
+      refreshMarginMs: 1,
+      configuredEnabled: null,
+    });
+    expect(blocked.status).toBe("skipped");
+    expect(blocked.skippedReason).toBe("disabled");
+    expect(mintCount).toBe(1);
+  });
+});

--- a/apps/app/tests/session-mcp-maintenance.test.ts
+++ b/apps/app/tests/session-mcp-maintenance.test.ts
@@ -361,23 +361,31 @@ describe("session MCP maintenance", () => {
       orgId: SETTINGS.activeOrgId ?? "",
       workspaceId: WORKSPACE_ID,
     });
-    let listed = false;
+    let reconciled = false;
+    let minted = false;
 
     await expect(syncCloudControlMcpInBackground({
       client: {
         baseUrl: "https://worker.openwork.test",
-        listMcp: async () => {
-          listed = true;
-          return { items: [] };
-        },
+        // The engine list is consulted (an existing enabled entry must stay
+        // maintained even under recorded intent), but with no entry present
+        // the recorded removal keeps provisioning skipped.
+        listMcp: async () => ({ items: [] }),
         getOpenworkCloudMcpHealth: async () => cloudHealth(false),
-        reconcileOpenworkCloudMcp: async () => cloudHealth(true),
+        reconcileOpenworkCloudMcp: async () => {
+          reconciled = true;
+          return cloudHealth(true);
+        },
       },
       workspaceId: WORKSPACE_ID,
       settings: SETTINGS,
-      mintToken: async () => MINTED,
+      mintToken: async () => {
+        minted = true;
+        return MINTED;
+      },
     })).resolves.toEqual({ outcome: "skipped", status: "skipped", reason: "disabled", health: null });
-    expect(listed).toBe(false);
+    expect(reconciled).toBe(false);
+    expect(minted).toBe(false);
   });
 
   test("pre-signout cleanup removes runtime MCP and disconnects the exact active workspace before resolving", async () => {


### PR DESCRIPTION
## What

Field incident (Jul 14): a machine had the legacy raw-string `openwork.den.mcp.cloudControlUserState = "removed"` left over from a manual connection toggle. Two gates treated ANY recorded intent as a veto on all maintenance:

- `syncCloudControlMcpInBackground` returned `skipped` before even listing the engine's MCPs
- `shouldSkipForPrerequisite` in the reconciler skipped on `readCloudMcpUserState(scope) !== null`

Result: the 7-day first-party token expired with nothing to remint it → engine dropped the MCP at connect (SSE 401) → `search_capabilities`/`execute_capability` vanished from sessions.

## Invariant implemented

**Recorded user intent (disabled/removed) gates provisioning only — never token freshness.** If the engine has a configured `openwork-cloud` entry with `enabled !== false`, maintenance and repair run regardless of recorded intent. Absent or explicitly disabled entries honor intent exactly as before.

- `use-session-mcp-maintenance.ts`: list the engine MCPs first; apply the intent gate only when no enabled entry exists; pass effective enablement to the reconciler
- `cloud-mcp-reconciler.ts` `shouldSkipForPrerequisite`: consult user state only when `configuredEnabled !== true`

## Testing

- `bun test tests/cloud-mcp-maintenance-gate.test.ts tests/cloud-mcp-health.test.ts tests/cloud-mcp-user-state.test.ts` in `apps/app` — **21 pass / 0 fail** (new file with 4 tests: the exact field repro with the legacy raw string + enabled entry + expired-token health → remint happens; provisioning still gated when the entry is absent; explicit disable still skips; reconciler-level yield/block matrix)
- `pnpm typecheck` in `apps/app` — clean

fraimz: skipped — unit-tested renderer logic, no visual surface change. Part 2/3 of the token-death-spiral fixes (#2776 is part 1; maintenance watchdog ships separately).