### PR TITLE
fix(app): watchdog + recorded outcomes for cloud MCP maintenance

### DIFF
--- a/apps/app/src/react-app/domains/connections/cloud-mcp-maintenance-outcome.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-maintenance-outcome.ts
@@ -1,0 +1,109 @@
+/**
+ * Last-outcome bookkeeping for the background cloud MCP maintenance loop.
+ *
+ * The maintenance tick used to swallow every failure (`.catch(() =>
+ * "skipped")`), so a wedged or permanently failing loop was invisible — in the
+ * field a machine sat with an expired token for days with zero surfaced
+ * signal. Each run now records its outcome per maintenance target so the
+ * connection status UI and diagnostics (see the Live MCP Connection
+ * Diagnostics work) can show when maintenance last ran and how it ended.
+ */
+
+const CLOUD_MCP_MAINTENANCE_OUTCOME_KEY = "openwork.den.mcp.lastMaintenanceOutcome";
+const MAX_RECORDED_OUTCOMES = 8;
+const MAX_DETAIL_LENGTH = 200;
+
+export type CloudMcpMaintenanceOutcomeStatus = "ok" | "error" | "timed_out";
+
+export type CloudMcpMaintenanceOutcome = {
+  status: CloudMcpMaintenanceOutcomeStatus;
+  detail?: string;
+  at: number;
+};
+
+type StorageLike = {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+};
+
+let storageOverrideForTest: StorageLike | null = null;
+
+/**
+ * Bun on Linux exposes a readonly `globalThis.window`, so tests cannot stub
+ * the global. Inject a storage instead (pass null to restore the default).
+ */
+export function __setCloudMcpMaintenanceOutcomeStorageForTest(storage: StorageLike | null) {
+  storageOverrideForTest = storage;
+}
+
+function getStorage(): StorageLike | null {
+  if (storageOverrideForTest) return storageOverrideForTest;
+  if (typeof window === "undefined") return null;
+  try {
+    return window.localStorage;
+  } catch {
+    return null;
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function parseOutcome(value: unknown): CloudMcpMaintenanceOutcome | null {
+  if (!isRecord(value)) return null;
+  if (value.status !== "ok" && value.status !== "error" && value.status !== "timed_out") return null;
+  if (typeof value.at !== "number" || !Number.isFinite(value.at)) return null;
+  return {
+    status: value.status,
+    at: value.at,
+    ...(typeof value.detail === "string" && value.detail ? { detail: value.detail } : {}),
+  };
+}
+
+function readOutcomeMap(): Map<string, CloudMcpMaintenanceOutcome> {
+  const outcomes = new Map<string, CloudMcpMaintenanceOutcome>();
+  try {
+    const raw = getStorage()?.getItem(CLOUD_MCP_MAINTENANCE_OUTCOME_KEY);
+    if (!raw) return outcomes;
+    const parsed: unknown = JSON.parse(raw);
+    const entries = isRecord(parsed) && isRecord(parsed.outcomes) ? parsed.outcomes : {};
+    for (const [targetKey, candidate] of Object.entries(entries)) {
+      const outcome = parseOutcome(candidate);
+      if (outcome) outcomes.set(targetKey, outcome);
+    }
+  } catch {
+    // Storage unavailable or corrupt — treat as no recorded outcomes.
+  }
+  return outcomes;
+}
+
+export function recordCloudMcpMaintenanceOutcome(
+  targetKey: string,
+  outcome: { status: CloudMcpMaintenanceOutcomeStatus; detail?: string },
+  now?: number,
+): void {
+  try {
+    const outcomes = readOutcomeMap();
+    const detail = outcome.detail?.trim().slice(0, MAX_DETAIL_LENGTH);
+    outcomes.set(targetKey, {
+      status: outcome.status,
+      at: now ?? Date.now(),
+      ...(detail ? { detail } : {}),
+    });
+    const kept = [...outcomes.entries()]
+      .sort((left, right) => right[1].at - left[1].at)
+      .slice(0, MAX_RECORDED_OUTCOMES);
+    getStorage()?.setItem(
+      CLOUD_MCP_MAINTENANCE_OUTCOME_KEY,
+      JSON.stringify({ version: 1, outcomes: Object.fromEntries(kept) }),
+    );
+  } catch {
+    // Storage unavailable — recording outcomes must never break maintenance.
+  }
+}
+
+export function readCloudMcpMaintenanceOutcome(targetKey: string): CloudMcpMaintenanceOutcome | null {
+  return readOutcomeMap().get(targetKey) ?? null;
+}

--- a/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
+++ b/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
@@ -16,6 +16,7 @@ import type {
 import { unwrap } from "../../../app/lib/opencode";
 import type { Client, McpServerEntry, McpStatusMap } from "../../../app/types";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
+import { recordCloudMcpMaintenanceOutcome } from "./cloud-mcp-maintenance-outcome";
 import {
   CLOUD_MCP_SERVER_NAME,
   readCloudMcpUserState,
@@ -26,12 +27,13 @@ import {
 } from "./cloud-mcp-reconciler";
 
 export const SESSION_MCP_MAINTENANCE_INTERVAL_MS = 5 * 60 * 1000;
+export const SESSION_MCP_MAINTENANCE_TIMEOUT_MS = 2 * 60 * 1000;
 export const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
 export const CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS = [1_000, 3_000];
 
 type CloudMcpMaintenanceClient = CloudMcpClient & Pick<OpenworkServerClient, "listMcp">;
 
-const maintenanceInFlight = new Set<string>();
+const maintenanceInFlight = new Map<string, symbol>();
 
 export type CloudMcpMaintenanceIssue = Pick<
   OpenworkCloudMcpFailure,
@@ -117,17 +119,55 @@ export function getSessionMcpMaintenanceTargetKey(input: {
   ]);
 }
 
+type MaintenanceTaskSettled =
+  | { kind: "ok" }
+  | { kind: "error"; detail: string }
+  | { kind: "timed_out" };
+
+function maintenanceErrorDetail(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export async function runSessionMcpMaintenanceTask(input: {
   targetKey: string;
   task: () => Promise<void>;
+  timeoutMs?: number;
 }): Promise<boolean> {
   if (maintenanceInFlight.has(input.targetKey)) return false;
-  maintenanceInFlight.add(input.targetKey);
+  const runToken = Symbol("session-mcp-maintenance-run");
+  maintenanceInFlight.set(input.targetKey, runToken);
+  // A hung await inside one tick must not wedge every future tick for this
+  // target (field incident: maintenance stayed blocked until app restart).
+  // The run token keeps a late-settling task from releasing a newer run's
+  // lock after we timed out and moved on.
+  const releaseOwnLock = () => {
+    if (maintenanceInFlight.get(input.targetKey) === runToken) {
+      maintenanceInFlight.delete(input.targetKey);
+    }
+  };
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timedOut = new Promise<MaintenanceTaskSettled>((resolve) => {
+    timer = setTimeout(() => resolve({ kind: "timed_out" }), input.timeoutMs ?? SESSION_MCP_MAINTENANCE_TIMEOUT_MS);
+  });
   try {
-    await input.task();
+    const settled = await Promise.race([
+      input.task().then(
+        (): MaintenanceTaskSettled => ({ kind: "ok" }),
+        (error: unknown): MaintenanceTaskSettled => ({ kind: "error", detail: maintenanceErrorDetail(error) }),
+      ),
+      timedOut,
+    ]);
+    if (settled.kind === "timed_out") {
+      recordCloudMcpMaintenanceOutcome(input.targetKey, { status: "timed_out" });
+    } else if (settled.kind === "error") {
+      recordCloudMcpMaintenanceOutcome(input.targetKey, { status: "error", detail: settled.detail });
+    } else {
+      recordCloudMcpMaintenanceOutcome(input.targetKey, { status: "ok" });
+    }
     return true;
   } finally {
-    maintenanceInFlight.delete(input.targetKey);
+    if (timer !== undefined) clearTimeout(timer);
+    releaseOwnLock();
   }
 }
 

--- a/apps/app/tests/cloud-mcp-maintenance-outcome.test.ts
+++ b/apps/app/tests/cloud-mcp-maintenance-outcome.test.ts
@@ -1,0 +1,128 @@
+import { afterAll, beforeEach, describe, expect, test } from "bun:test";
+
+import {
+  __setCloudMcpMaintenanceOutcomeStorageForTest,
+  readCloudMcpMaintenanceOutcome,
+  recordCloudMcpMaintenanceOutcome,
+} from "../src/react-app/domains/connections/cloud-mcp-maintenance-outcome";
+import { runSessionMcpMaintenanceTask } from "../src/react-app/domains/connections/use-session-mcp-maintenance";
+
+let storageValues: Map<string, string>;
+
+function installStorageStub() {
+  storageValues = new Map();
+  __setCloudMcpMaintenanceOutcomeStorageForTest({
+    getItem: (key) => storageValues.get(key) ?? null,
+    setItem: (key, value) => storageValues.set(key, value),
+    removeItem: (key) => storageValues.delete(key),
+  });
+}
+
+afterAll(() => {
+  __setCloudMcpMaintenanceOutcomeStorageForTest(null);
+});
+
+describe("cloud MCP maintenance watchdog", () => {
+  beforeEach(() => installStorageStub());
+
+  test("a hung tick releases the lock after the timeout and records timed_out", async () => {
+    const targetKey = "target-hung";
+    let secondRan = false;
+
+    const first = await runSessionMcpMaintenanceTask({
+      targetKey,
+      task: () => new Promise<void>(() => {
+        // never settles — simulates a network await with no timeout
+      }),
+      timeoutMs: 10,
+    });
+    expect(first).toBe(true);
+    expect(readCloudMcpMaintenanceOutcome(targetKey)?.status).toBe("timed_out");
+
+    // The lock must be free: the next tick for the same target executes.
+    const second = await runSessionMcpMaintenanceTask({
+      targetKey,
+      task: async () => {
+        secondRan = true;
+      },
+    });
+    expect(second).toBe(true);
+    expect(secondRan).toBe(true);
+    expect(readCloudMcpMaintenanceOutcome(targetKey)?.status).toBe("ok");
+  });
+
+  test("a late-settling timed-out task cannot release a newer run's lock", async () => {
+    const targetKey = "target-late-settle";
+    let settleFirst = () => {};
+    const firstGate = new Promise<void>((resolve) => {
+      settleFirst = resolve;
+    });
+    await runSessionMcpMaintenanceTask({
+      targetKey,
+      task: () => firstGate,
+      timeoutMs: 5,
+    });
+    expect(readCloudMcpMaintenanceOutcome(targetKey)?.status).toBe("timed_out");
+
+    // Second run acquires the lock and blocks.
+    let settleSecond = () => {};
+    const secondGate = new Promise<void>((resolve) => {
+      settleSecond = resolve;
+    });
+    const second = runSessionMcpMaintenanceTask({ targetKey, task: () => secondGate });
+    await Promise.resolve();
+
+    // The first (timed-out) task finally settles — it must NOT free the lock
+    // held by the second run.
+    settleFirst();
+    await Promise.resolve();
+    await expect(runSessionMcpMaintenanceTask({
+      targetKey,
+      task: async () => {},
+    })).resolves.toBe(false);
+
+    settleSecond();
+    await expect(second).resolves.toBe(true);
+  });
+
+  test("a throwing tick records the error and releases the lock", async () => {
+    const targetKey = "target-error";
+    const ran = await runSessionMcpMaintenanceTask({
+      targetKey,
+      task: async () => {
+        throw new Error("sync: mint failed with 401");
+      },
+    });
+    expect(ran).toBe(true);
+    const outcome = readCloudMcpMaintenanceOutcome(targetKey);
+    expect(outcome?.status).toBe("error");
+    expect(outcome?.detail).toBe("sync: mint failed with 401");
+
+    await expect(runSessionMcpMaintenanceTask({
+      targetKey,
+      task: async () => {},
+    })).resolves.toBe(true);
+    expect(readCloudMcpMaintenanceOutcome(targetKey)?.status).toBe("ok");
+  });
+
+  test("details are length-capped and outcome storage keeps only the newest entries", () => {
+    recordCloudMcpMaintenanceOutcome("target-detail", { status: "error", detail: "x".repeat(1000) }, 1);
+    expect(readCloudMcpMaintenanceOutcome("target-detail")?.detail).toHaveLength(200);
+
+    for (let index = 0; index < 10; index += 1) {
+      recordCloudMcpMaintenanceOutcome(`target-${index}`, { status: "ok" }, index + 2);
+    }
+    // 11 total recorded; the two oldest (target-detail at t=1, target-0 at t=2)
+    // fall out of the capped map.
+    expect(readCloudMcpMaintenanceOutcome("target-detail")).toBeNull();
+    expect(readCloudMcpMaintenanceOutcome("target-0")).toBeNull();
+    expect(readCloudMcpMaintenanceOutcome("target-9")).toMatchObject({ status: "ok", at: 11 });
+  });
+
+  test("corrupt storage is treated as no recorded outcomes", () => {
+    storageValues.set("openwork.den.mcp.lastMaintenanceOutcome", "{not json");
+    expect(readCloudMcpMaintenanceOutcome("anything")).toBeNull();
+    recordCloudMcpMaintenanceOutcome("anything", { status: "ok" }, 5);
+    expect(readCloudMcpMaintenanceOutcome("anything")?.at).toBe(5);
+  });
+});


### PR DESCRIPTION
## What

Field incident (Jul 14): after the cloud MCP token death spiral, clearing the localStorage gates did nothing until a full app restart — consistent with a **wedged in-flight lock**: `runSessionMcpMaintenanceTask` releases its lock only in `finally`, so one hung network await blocks every future tick for that target forever.

Rebased onto the structured-maintenance rewrite (#2779) and slimmed to the two pieces it does not cover:

- **Watchdog**: the task races a timeout (default 2 min, injectable). On timeout the lock is released and the run is recorded as `timed_out`; a run-token guard prevents the late-settling task from releasing a newer run's lock.
- **Persisted outcomes**: every run records `ok | error | timed_out` (+ length-capped detail, newest 8 targets) under `openwork.den.mcp.lastMaintenanceOutcome`, with `readCloudMcpMaintenanceOutcome(targetKey)` exported for the diagnostics UI (#2672). This complements #2779's ephemeral inspector events and per-session React state with a cross-restart signal.

Dropped from the original version of this PR: the tick catch-rewrite — #2779's retry/state/inspector plumbing now covers failure surfacing inside the tick.

## Testing

- `bun test tests/` in `apps/app` — **298 pass / 0 fail** (5 tests: hung tick → lock released + timed_out recorded + next tick runs; late-settle cannot release a newer run's lock; throwing tick records error + releases; detail cap + newest-8 retention; corrupt storage tolerated)
- `pnpm typecheck` in `apps/app` — clean

fraimz: skipped — unit-tested renderer logic, no visual surface change. Part 3/3 of the token-death-spiral fixes (#2776 auth-code matching, #2777 provisioning-only gate — both merged).