### PR TITLE
fix(mcp): prevent expired Cloud tokens from silently removing search tools

### DIFF
--- a/apps/app/src/app/lib/app-inspector.ts
+++ b/apps/app/src/app/lib/app-inspector.ts
@@ -120,7 +120,7 @@ export function publishInspectorSlice(
 
 export function recordInspectorEvent(name: string, data?: unknown) {
   installIfNeeded();
-  window.__openwork?.record(name, data);
+  if (typeof window !== "undefined") window.__openwork?.record(name, data);
 }
 
 export function ensureInspectorInstalled() {

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
@@ -3,6 +3,7 @@ import {
   type DenMcpTokenMintContext,
   resolveCloudMcpResourceUrl,
 } from "../../../app/lib/den";
+import { recordInspectorEvent } from "../../../app/lib/app-inspector";
 import type {
   OpenworkCloudMcpFailure,
   OpenworkCloudMcpHealth,
@@ -82,6 +83,7 @@ type CloudMcpReconcilerInput = {
   force?: boolean;
   refreshMarginMs: number;
   now?: number;
+  configuredPresent?: boolean;
   configuredEnabled?: boolean | null;
 };
 
@@ -189,7 +191,8 @@ export function isCloudMcpAuthTokenFailureCode(code: string | null | undefined):
   ) {
     return false;
   }
-  return normalized === "openwork_cloud_auth_required" ||
+  return normalized === "invalid_mcp_token" ||
+    normalized === "openwork_cloud_auth_required" ||
     normalized === "openwork_cloud_auth_invalid" ||
     normalized === "openwork_cloud_token_expired" ||
     normalized.includes("invalid_token") ||
@@ -198,12 +201,47 @@ export function isCloudMcpAuthTokenFailureCode(code: string | null | undefined):
     normalized.includes("auth");
 }
 
+export function isCloudMcpAuthTokenFailure(failure: OpenworkCloudMcpFailure | null | undefined): boolean {
+  if (!failure) return false;
+  return [failure.code, ...(failure.aliases ?? [])].some(isCloudMcpAuthTokenFailureCode);
+}
+
+function reconcileStoredUserIntent(input: {
+  scope: CloudMcpScope;
+  configuredPresent: boolean;
+  configuredEnabled: boolean | null;
+  trigger?: string;
+}): CloudMcpUserState | null {
+  const userState = readCloudMcpUserState(input.scope);
+  if (!userState) return null;
+  if (!input.configuredPresent || input.configuredEnabled === false) return userState;
+
+  clearCloudMcpUserState(input.scope);
+  recordInspectorEvent("cloud_mcp.user_intent_reconciled", {
+    workspaceId: input.scope.workspaceId,
+    previousState: userState,
+    configuredPresent: true,
+    configuredEnabled: true,
+    trigger: input.trigger ?? "unknown",
+  });
+  return null;
+}
+
 function shouldSkipForPrerequisite(input: CloudMcpReconcilerInput, scope: CloudMcpScope): CloudMcpOperationResult | null {
   if (!scope.workspaceId) return { status: "skipped", health: null, skippedReason: "missing_workspace", attempts: 0, markerWritten: false, reminted: false };
   if (input.mode === "health") return null;
   if (!input.context.denAuthToken?.trim()) return { status: "skipped", health: null, skippedReason: "signed_out", attempts: 0, markerWritten: false, reminted: false };
   if (!scope.orgId) return { status: "skipped", health: null, skippedReason: "missing_org", attempts: 0, markerWritten: false, reminted: false };
-  if (input.configuredEnabled === false || readCloudMcpUserState(scope) !== null) {
+  if (input.configuredEnabled === false) {
+    return { status: "skipped", health: null, skippedReason: "disabled", attempts: 0, markerWritten: false, reminted: false };
+  }
+  const userState = reconcileStoredUserIntent({
+    scope,
+    configuredPresent: input.configuredPresent === true,
+    configuredEnabled: input.configuredEnabled ?? null,
+    trigger: input.context.trigger,
+  });
+  if (userState) {
     return { status: "skipped", health: null, skippedReason: "disabled", attempts: 0, markerWritten: false, reminted: false };
   }
   return null;
@@ -274,7 +312,7 @@ async function repairCloudMcp(input: CloudMcpReconcilerInput, scope: CloudMcpSco
   let health = first.health;
   let token = first.token;
   let reminted = false;
-  if (isCloudMcpAuthTokenFailureCode(health?.firstFailure?.code)) {
+  if (isCloudMcpAuthTokenFailure(health?.firstFailure)) {
     const second = await mintAndPost(input, scope);
     attempts += 1;
     reminted = true;
@@ -298,7 +336,18 @@ export async function runOpenworkCloudMcpReconciler(input: CloudMcpReconcilerInp
   const prerequisite = shouldSkipForPrerequisite(input, scope);
   if (prerequisite) return prerequisite;
 
-  if (input.mode === "health") return probeHealth(input, scope);
+  if (input.mode === "health") {
+    const result = await probeHealth(input, scope);
+    if (result.health) {
+      reconcileStoredUserIntent({
+        scope,
+        configuredPresent: result.health.desired.present,
+        configuredEnabled: result.health.desired.config?.enabled === false ? false : true,
+        trigger: input.context.trigger,
+      });
+    }
+    return result;
+  }
 
   const scopeKey = getCloudMcpScopeKey(scope);
   if (!scopeKey) return { status: "skipped", health: null, skippedReason: "missing_workspace", attempts: 0, markerWritten: false, reminted: false };

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-submit-readiness.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-submit-readiness.ts
@@ -1,0 +1,402 @@
+import type {
+  OpenworkCloudMcpFailure,
+  OpenworkCloudMcpHealth,
+  OpenworkCloudMcpProviderModelContext,
+} from "../../../app/lib/openwork-server";
+import type { CloudMcpUserState } from "./cloud-mcp-user-state";
+
+export const CLOUD_MCP_SUBMISSION_RETRY_DELAYS_MS = [1_000, 3_000];
+export const CLOUD_MCP_SUBMISSION_ATTEMPT_TIMEOUT_MS = 12_000;
+
+const REQUIRED_DIRECT_TOOL_IDS = ["search_capabilities", "execute_capability"];
+const REQUIRED_PROJECTED_TOOL_IDS = [
+  "openwork-cloud_search_capabilities",
+  "openwork-cloud_execute_capability",
+];
+
+export type CloudMcpSubmissionIssue = Pick<
+  OpenworkCloudMcpFailure,
+  "code" | "stage" | "retryable" | "recommendedAction" | "message"
+>;
+
+export type CloudMcpSubmissionGateContext = {
+  cloudSignedIn: boolean;
+  denBaseUrl: string;
+  serverBaseUrl: string;
+  orgId: string | null;
+  workspaceId: string;
+  providerModel?: OpenworkCloudMcpProviderModelContext;
+  userState: CloudMcpUserState | null;
+};
+
+export type CloudMcpSubmissionGateDecision =
+  | { mode: "required"; scopeKey: string }
+  | {
+      mode: "bypass";
+      scopeKey: string;
+      reason: "signed_out" | "missing_org" | "disabled";
+    };
+
+export type CloudMcpSubmissionReadinessAssessment =
+  | { ready: true; health: OpenworkCloudMcpHealth }
+  | { ready: false; health: OpenworkCloudMcpHealth | null; issue: CloudMcpSubmissionIssue };
+
+export type CloudMcpSubmissionReadinessResult =
+  | { outcome: "ready"; health: OpenworkCloudMcpHealth; attempts: number }
+  | { outcome: "bypass"; health: OpenworkCloudMcpHealth; attempts: number; reason: "disabled" }
+  | { outcome: "failed"; health: OpenworkCloudMcpHealth | null; issue: CloudMcpSubmissionIssue; attempts: number };
+
+export type CloudMcpSubmissionAttempt = {
+  phase: "readiness" | "repair";
+  attempt: number;
+  maxAttempts: number;
+  assessment: CloudMcpSubmissionReadinessAssessment;
+};
+
+export type CloudMcpSubmissionPreparationResult =
+  | { outcome: "ready" }
+  | { outcome: "bypass" }
+  | { outcome: "failed"; issue: CloudMcpSubmissionIssue }
+  | { outcome: "cancelled"; reason: "context_changed" | "unmounted" };
+
+export type CloudMcpSubmissionResult =
+  | { outcome: "sent"; bypassed: boolean }
+  | { outcome: "accepted" }
+  | { outcome: "blocked"; issue: CloudMcpSubmissionIssue }
+  | { outcome: "cancelled"; reason: "context_changed" | "unmounted" };
+
+export type CloudMcpSubmissionGateState = {
+  status: "idle" | "checking" | "repairing" | "sending" | "failed";
+  issue: CloudMcpSubmissionIssue | null;
+  attempt: number;
+  maxAttempts: number;
+};
+
+export const IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE: CloudMcpSubmissionGateState = {
+  status: "idle",
+  issue: null,
+  attempt: 0,
+  maxAttempts: 1 + CLOUD_MCP_SUBMISSION_RETRY_DELAYS_MS.length,
+};
+
+function normalize(value: string | null | undefined): string {
+  return value?.trim().replace(/\/+$/, "") ?? "";
+}
+
+function hasEvery(values: string[], required: string[]): boolean {
+  const available = new Set(values);
+  return required.every((value) => available.has(value));
+}
+
+function genericSubmissionIssue(input?: {
+  code?: string;
+  stage?: CloudMcpSubmissionIssue["stage"];
+  message?: string;
+  retryable?: boolean;
+  recommendedAction?: string;
+}): CloudMcpSubmissionIssue {
+  return {
+    code: input?.code ?? "cloud_mcp_submission_readiness_failed",
+    stage: input?.stage ?? "engine_delivery",
+    retryable: input?.retryable ?? true,
+    recommendedAction: input?.recommendedAction ?? "Retry, then open Settings → Connect if the problem continues.",
+    message: input?.message ?? "OpenWork could not verify connected service tools for the selected model.",
+  };
+}
+
+function failureIssue(health: OpenworkCloudMcpHealth): CloudMcpSubmissionIssue {
+  const failure = health.firstFailure;
+  if (!failure) return genericSubmissionIssue();
+  return {
+    code: failure.code,
+    stage: failure.stage,
+    retryable: failure.retryable,
+    recommendedAction: failure.recommendedAction,
+    message: failure.message,
+  };
+}
+
+function healthShowsExplicitDisable(health: OpenworkCloudMcpHealth): boolean {
+  const code = health.firstFailure?.code.trim().toLowerCase().replace(/[-.]/g, "_") ?? "";
+  return health.desired.config?.enabled === false || code === "cloud_mcp_disabled" || code === "cloud_disabled";
+}
+
+export function cloudMcpSubmissionScopeKey(context: CloudMcpSubmissionGateContext): string {
+  return JSON.stringify([
+    context.cloudSignedIn ? "signed_in" : "signed_out",
+    normalize(context.denBaseUrl),
+    normalize(context.serverBaseUrl),
+    normalize(context.orgId),
+    normalize(context.workspaceId),
+    context.providerModel?.provider.trim() ?? "",
+    context.providerModel?.model.trim() ?? "",
+    context.userState ?? "enabled",
+  ]);
+}
+
+export function decideCloudMcpSubmissionGate(
+  context: CloudMcpSubmissionGateContext,
+): CloudMcpSubmissionGateDecision {
+  const scopeKey = cloudMcpSubmissionScopeKey(context);
+  if (!context.cloudSignedIn) return { mode: "bypass", scopeKey, reason: "signed_out" };
+  if (!context.orgId?.trim()) return { mode: "bypass", scopeKey, reason: "missing_org" };
+  if (context.userState) return { mode: "bypass", scopeKey, reason: "disabled" };
+  return { mode: "required", scopeKey };
+}
+
+/**
+ * A connected MCP transport and generic model tool-calling support are not
+ * evidence that the selected provider/model received these two MCP tools.
+ * The strongest honest proof available today is the provider/model-scoped
+ * OpenCode experimental tool listing plus the direct MCP tools/list probe.
+ */
+export function assessCloudMcpSubmissionReadiness(input: {
+  health: OpenworkCloudMcpHealth | null;
+  providerModel: OpenworkCloudMcpProviderModelContext;
+}): CloudMcpSubmissionReadinessAssessment {
+  const health = input.health;
+  if (!health) {
+    return { ready: false, health: null, issue: genericSubmissionIssue() };
+  }
+  if (!health.usable) {
+    return { ready: false, health, issue: failureIssue(health) };
+  }
+  if (
+    health.engine.status !== "connected" ||
+    !health.tools.direct.checked ||
+    !hasEvery(health.tools.direct.present, REQUIRED_DIRECT_TOOL_IDS) ||
+    health.tools.direct.missing.length > 0
+  ) {
+    return {
+      ready: false,
+      health,
+      issue: genericSubmissionIssue({
+        code: "cloud_mcp_direct_tools_unverified",
+        stage: "tool_registration",
+        message: "OpenWork Cloud did not prove that search_capabilities and execute_capability are available.",
+      }),
+    };
+  }
+
+  const projection = health.tools.providerProjection;
+  if (
+    projection.provider !== input.providerModel.provider ||
+    projection.model !== input.providerModel.model
+  ) {
+    return {
+      ready: false,
+      health,
+      issue: genericSubmissionIssue({
+        code: "cloud_mcp_submission_context_mismatch",
+        stage: "provider_projection",
+        message: "Connected service tools were checked for a different provider or model.",
+      }),
+    };
+  }
+  if (!projection.checked || projection.source !== "experimental_tool") {
+    return {
+      ready: false,
+      health,
+      issue: genericSubmissionIssue({
+        code: "provider_tool_projection_unverified",
+        stage: "provider_projection",
+        retryable: false,
+        message: "The current engine cannot prove that connected service tools were injected into the selected model.",
+        recommendedAction: "Update or restart OpenWork, then Retry. Open Connect for detailed diagnostics.",
+      }),
+    };
+  }
+  if (
+    health.usableByCurrentModel !== true ||
+    !hasEvery(projection.present, REQUIRED_PROJECTED_TOOL_IDS) ||
+    projection.missing.length > 0
+  ) {
+    return {
+      ready: false,
+      health,
+      issue: genericSubmissionIssue({
+        code: "provider_tool_projection_missing",
+        stage: "provider_projection",
+        retryable: false,
+        message: "The selected model is missing search_capabilities or execute_capability.",
+        recommendedAction: "Choose a compatible model or open Settings → Connect for diagnostics.",
+      }),
+    };
+  }
+  return { ready: true, health };
+}
+
+function timeoutIssue(): CloudMcpSubmissionIssue {
+  return genericSubmissionIssue({
+    code: "cloud_mcp_submission_timeout",
+    message: "OpenWork timed out while preparing connected service tools.",
+  });
+}
+
+async function withTimeout<T>(task: () => Promise<T>, timeoutMs: number): Promise<T> {
+  if (timeoutMs <= 0) return task();
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  const timeout = new Promise<T>((_resolve, reject) => {
+    timer = setTimeout(() => reject(new Error("cloud_mcp_submission_timeout")), timeoutMs);
+  });
+  try {
+    return await Promise.race([task(), timeout]);
+  } finally {
+    if (timer !== null) clearTimeout(timer);
+  }
+}
+
+function errorAssessment(error: unknown): CloudMcpSubmissionReadinessAssessment {
+  const timedOut = error instanceof Error && error.message === "cloud_mcp_submission_timeout";
+  return {
+    ready: false,
+    health: null,
+    issue: timedOut
+      ? timeoutIssue()
+      : genericSubmissionIssue({
+          code: "cloud_mcp_submission_check_failed",
+          message: "OpenWork could not check connected service tools before sending.",
+        }),
+  };
+}
+
+export async function ensureCloudMcpSubmissionReadiness(input: {
+  providerModel: OpenworkCloudMcpProviderModelContext;
+  check: () => Promise<OpenworkCloudMcpHealth | null>;
+  repair: () => Promise<OpenworkCloudMcpHealth | null>;
+  retryDelaysMs?: number[];
+  attemptTimeoutMs?: number;
+  wait?: (delayMs: number) => Promise<void>;
+  onAttempt?: (attempt: CloudMcpSubmissionAttempt) => void;
+}): Promise<CloudMcpSubmissionReadinessResult> {
+  const retryDelaysMs = input.retryDelaysMs ?? CLOUD_MCP_SUBMISSION_RETRY_DELAYS_MS;
+  const maxAttempts = 1 + retryDelaysMs.length;
+  const timeoutMs = input.attemptTimeoutMs ?? CLOUD_MCP_SUBMISSION_ATTEMPT_TIMEOUT_MS;
+  const wait = input.wait ?? ((delayMs: number) => new Promise<void>((resolve) => setTimeout(resolve, delayMs)));
+  let lastAssessment: CloudMcpSubmissionReadinessAssessment = {
+    ready: false,
+    health: null,
+    issue: genericSubmissionIssue(),
+  };
+
+  for (let index = 0; index < maxAttempts; index += 1) {
+    const phase = index === 0 ? "readiness" : "repair";
+    if (index > 0) await wait(retryDelaysMs[index - 1] ?? 0);
+    try {
+      const health = await withTimeout(index === 0 ? input.check : input.repair, timeoutMs);
+      if (health && healthShowsExplicitDisable(health)) {
+        return { outcome: "bypass", health, attempts: index + 1, reason: "disabled" };
+      }
+      lastAssessment = assessCloudMcpSubmissionReadiness({ health, providerModel: input.providerModel });
+    } catch (error) {
+      lastAssessment = errorAssessment(error);
+    }
+    input.onAttempt?.({ phase, attempt: index + 1, maxAttempts, assessment: lastAssessment });
+    if (lastAssessment.ready) {
+      return { outcome: "ready", health: lastAssessment.health, attempts: index + 1 };
+    }
+    if (!lastAssessment.issue.retryable || index === maxAttempts - 1) {
+      return {
+        outcome: "failed",
+        health: lastAssessment.health,
+        issue: lastAssessment.issue,
+        attempts: index + 1,
+      };
+    }
+  }
+
+  return {
+    outcome: "failed",
+    health: lastAssessment.health,
+    issue: lastAssessment.ready ? genericSubmissionIssue() : lastAssessment.issue,
+    attempts: maxAttempts,
+  };
+}
+
+type SubmissionCoordinatorState =
+  | { status: "idle" }
+  | { status: "checking" }
+  | { status: "sending" }
+  | { status: "failed"; issue: CloudMcpSubmissionIssue }
+  | { status: "cancelled"; reason: "context_changed" | "unmounted" };
+
+type SubmissionCoordinatorInput = {
+  scopeKey: string;
+  prepare?: () => Promise<CloudMcpSubmissionPreparationResult>;
+  send: () => Promise<void>;
+  onState?: (state: SubmissionCoordinatorState) => void;
+};
+
+type ActiveSubmission = {
+  id: number;
+  scopeKey: string;
+  promise: Promise<CloudMcpSubmissionResult>;
+  cancel: (reason: "context_changed" | "unmounted") => void;
+  onState?: (state: SubmissionCoordinatorState) => void;
+};
+
+export type CloudMcpSubmissionCoordinator = {
+  submit: (input: SubmissionCoordinatorInput) => Promise<CloudMcpSubmissionResult>;
+  cancel: (reason: "context_changed" | "unmounted") => boolean;
+};
+
+export function createCloudMcpSubmissionCoordinator(): CloudMcpSubmissionCoordinator {
+  let active: ActiveSubmission | null = null;
+  let nextId = 0;
+
+  const cancel = (reason: "context_changed" | "unmounted"): boolean => {
+    if (!active) return false;
+    const current = active;
+    active = null;
+    current.onState?.({ status: "cancelled", reason });
+    current.cancel(reason);
+    return true;
+  };
+
+  const submit = (input: SubmissionCoordinatorInput): Promise<CloudMcpSubmissionResult> => {
+    if (active?.scopeKey === input.scopeKey) return active.promise;
+    if (active) cancel("context_changed");
+
+    const id = ++nextId;
+    let resolveCancellation: ((result: CloudMcpSubmissionPreparationResult) => void) | null = null;
+    const cancellation = new Promise<CloudMcpSubmissionPreparationResult>((resolve) => {
+      resolveCancellation = resolve;
+    });
+    if (input.prepare) input.onState?.({ status: "checking" });
+    const preparation = input.prepare?.() ?? Promise.resolve<CloudMcpSubmissionPreparationResult>({ outcome: "bypass" });
+
+    const task = (async (): Promise<CloudMcpSubmissionResult> => {
+      const prepared = await Promise.race([preparation, cancellation]);
+      if (prepared.outcome === "cancelled") return prepared;
+      if (prepared.outcome === "failed") {
+        input.onState?.({ status: "failed", issue: prepared.issue });
+        return { outcome: "blocked", issue: prepared.issue };
+      }
+      if (active?.id !== id) return { outcome: "cancelled", reason: "context_changed" };
+      input.onState?.({ status: "sending" });
+      try {
+        await input.send();
+        input.onState?.({ status: "idle" });
+        return { outcome: "sent", bypassed: prepared.outcome === "bypass" };
+      } catch (error) {
+        input.onState?.({ status: "idle" });
+        throw error;
+      }
+    })().finally(() => {
+      if (active?.id === id) active = null;
+    });
+
+    active = {
+      id,
+      scopeKey: input.scopeKey,
+      promise: task,
+      cancel: (reason) => {
+        resolveCancellation?.({ outcome: "cancelled", reason });
+      },
+      ...(input.onState ? { onState: input.onState } : {}),
+    };
+    return task;
+  };
+
+  return { submit, cancel };
+}

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-user-state.ts
@@ -3,6 +3,7 @@ import { CLOUD_MCP_SYNC_MARKER_STORAGE_KEY } from "../../../app/lib/den";
 /** Durable, scoped records for the auto-managed OpenWork Cloud MCP. */
 
 export const CLOUD_MCP_SERVER_NAME = "openwork-cloud";
+export const LEGACY_OPENWORK_ADMIN_MCP_SERVER_NAME = "openwork-admin";
 
 const CLOUD_MCP_USER_STATE_KEY = "openwork.den.mcp.cloudControlUserState";
 const CLOUD_MCP_UNHEALTHY_REMINT_ATTEMPT_KEY = "openwork.den.mcp.unhealthyRemintAttempt";

--- a/apps/app/src/react-app/domains/connections/store.ts
+++ b/apps/app/src/react-app/domains/connections/store.ts
@@ -40,7 +40,7 @@ import type { OpenworkServerStore } from "./openwork-server-store";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
 import {
   CLOUD_MCP_SERVER_NAME,
-  readCloudMcpUserState,
+  LEGACY_OPENWORK_ADMIN_MCP_SERVER_NAME,
 } from "./cloud-mcp-user-state";
 import {
   clearCloudMcpDisabledIntent,
@@ -905,10 +905,11 @@ export function createConnectionsStore(options: {
     if (!entry) return "skipped";
     const scope = { denBaseUrl: settings.baseUrl, serverBaseUrl, orgId, workspaceId };
 
-    // Respect explicit user intent for this exact workspace/org/server/deployment.
-    if (readCloudMcpUserState(scope) !== null) return "skipped";
-    const configuredEntry = snapshot.mcpServers.find((server) => server.name === CLOUD_MCP_SERVER_NAME);
-    if (configuredEntry?.config.enabled === false) return "skipped";
+    const listed = await openworkClient.listMcp(workspaceId).catch(() => null);
+    if (!listed) return "skipped";
+    const configuredEntry = listed.items.find((server) => server.name === CLOUD_MCP_SERVER_NAME);
+    const legacyAdminPresent = listed.items.some((server) => server.name === LEGACY_OPENWORK_ADMIN_MCP_SERVER_NAME);
+    const configuredUrl = typeof configuredEntry?.config.url === "string" ? configuredEntry.config.url : null;
 
     const result = await runOpenworkCloudMcpReconciler({
       mode: "repair",
@@ -918,12 +919,18 @@ export function createConnectionsStore(options: {
         denAuthToken: settings.authToken,
         orgSlug: settings.activeOrgSlug,
         orgName: settings.activeOrgName,
-        fallbackUrl: configuredEntry?.config.url ?? entry.url,
-        trigger: options?.force ? "desktop-settings-force" : "desktop-settings-background",
+        fallbackUrl: configuredUrl ?? entry.url,
+        trigger: legacyAdminPresent
+          ? "desktop-settings-legacy-admin-cleanup"
+          : options?.force
+            ? "desktop-settings-force"
+            : "desktop-settings-background",
       },
       mintToken: mintCloudControlMcpToken,
-      force: options?.force,
+      force: options?.force || legacyAdminPresent,
       refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+      configuredPresent: Boolean(configuredEntry),
+      configuredEnabled: typeof configuredEntry?.config.enabled === "boolean" ? configuredEntry.config.enabled : null,
     });
     if (result.status === "unchanged" || result.status === "ready") return "unchanged";
     if (result.health?.usable) {

--- a/apps/app/src/react-app/domains/connections/use-cloud-mcp-submit-readiness.ts
+++ b/apps/app/src/react-app/domains/connections/use-cloud-mcp-submit-readiness.ts
@@ -1,0 +1,260 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { readDenSettings } from "../../../app/lib/den";
+import { recordInspectorEvent } from "../../../app/lib/app-inspector";
+import type {
+  OpenworkCloudMcpProviderModelContext,
+  OpenworkServerClient,
+} from "../../../app/lib/openwork-server";
+import { denSettingsChangedEvent } from "../../../app/lib/den-session-events";
+import {
+  normalizeCloudMcpScope,
+  readCloudMcpUserState,
+} from "./cloud-mcp-user-state";
+import {
+  createCloudMcpSubmissionCoordinator,
+  decideCloudMcpSubmissionGate,
+  ensureCloudMcpSubmissionReadiness,
+  IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE,
+  type CloudMcpSubmissionGateState,
+  type CloudMcpSubmissionIssue,
+  type CloudMcpSubmissionPreparationResult,
+  type CloudMcpSubmissionResult,
+} from "./cloud-mcp-submit-readiness";
+import {
+  syncCloudControlMcpInBackground,
+} from "./use-session-mcp-maintenance";
+
+type CloudMcpSubmitReadinessClient = Pick<
+  OpenworkServerClient,
+  "baseUrl" | "getOpenworkCloudMcpHealth" | "reconcileOpenworkCloudMcp" | "listMcp"
+>;
+
+type UseCloudMcpSubmitReadinessInput = {
+  cloudSignedIn: boolean;
+  client: CloudMcpSubmitReadinessClient | null;
+  workspaceId: string | null;
+  providerModel?: OpenworkCloudMcpProviderModelContext;
+};
+
+type CloudMcpSubmitInput = {
+  skipGate?: boolean;
+  send: () => Promise<void>;
+};
+
+export type CloudMcpSubmitReadiness = {
+  state: CloudMcpSubmissionGateState;
+  submit: (input: CloudMcpSubmitInput) => Promise<CloudMcpSubmissionResult>;
+};
+
+function missingContextIssue(input: {
+  client: CloudMcpSubmitReadinessClient | null;
+  workspaceId: string;
+  providerModel?: OpenworkCloudMcpProviderModelContext;
+}): CloudMcpSubmissionIssue {
+  if (!input.client || !input.workspaceId) {
+    return {
+      code: "cloud_mcp_submission_context_missing",
+      stage: "engine_delivery",
+      retryable: true,
+      message: "OpenWork could not resolve the workspace server before checking connected service tools.",
+      recommendedAction: "Retry after the workspace finishes loading.",
+    };
+  }
+  if (!input.providerModel) {
+    return {
+      code: "cloud_mcp_submission_model_missing",
+      stage: "provider_projection",
+      retryable: false,
+      message: "Select a provider and model before using connected service tools.",
+      recommendedAction: "Choose a model, then Retry.",
+    };
+  }
+  return {
+    code: "cloud_mcp_submission_context_missing",
+    stage: "provider_projection",
+    retryable: false,
+    message: "OpenWork could not verify connected service tools for this submission.",
+    recommendedAction: "Retry or open Settings → Connect for diagnostics.",
+  };
+}
+
+export function useCloudMcpSubmitReadiness(
+  input: UseCloudMcpSubmitReadinessInput,
+): CloudMcpSubmitReadiness {
+  const [settingsVersion, setSettingsVersion] = useState(0);
+  const [state, setState] = useState<CloudMcpSubmissionGateState>(
+    IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE,
+  );
+  const coordinatorRef = useRef(createCloudMcpSubmissionCoordinator());
+  const settings = useMemo(() => readDenSettings(), [input.cloudSignedIn, settingsVersion]);
+  const workspaceId = input.workspaceId?.trim() ?? "";
+  const serverBaseUrl = input.client?.baseUrl.trim() ?? "";
+  const orgId = settings.activeOrgId?.trim() ?? "";
+  const scope = normalizeCloudMcpScope({
+    denBaseUrl: settings.baseUrl,
+    serverBaseUrl,
+    orgId,
+    workspaceId,
+  });
+  const userState = scope ? readCloudMcpUserState(scope) : null;
+  const decision = useMemo(() => decideCloudMcpSubmissionGate({
+    cloudSignedIn: input.cloudSignedIn,
+    denBaseUrl: settings.baseUrl,
+    serverBaseUrl,
+    orgId: orgId || null,
+    workspaceId,
+    providerModel: input.providerModel,
+    userState,
+  }), [
+    input.cloudSignedIn,
+    input.providerModel?.model,
+    input.providerModel?.provider,
+    orgId,
+    serverBaseUrl,
+    settings.baseUrl,
+    userState,
+    workspaceId,
+  ]);
+  const currentScopeKeyRef = useRef(decision.scopeKey);
+  currentScopeKeyRef.current = decision.scopeKey;
+  const previousScopeKeyRef = useRef(decision.scopeKey);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const handleSettingsChanged = () => setSettingsVersion((version) => version + 1);
+    window.addEventListener(denSettingsChangedEvent, handleSettingsChanged);
+    return () => window.removeEventListener(denSettingsChangedEvent, handleSettingsChanged);
+  }, []);
+
+  useEffect(() => {
+    if (previousScopeKeyRef.current === decision.scopeKey) return;
+    previousScopeKeyRef.current = decision.scopeKey;
+    const cancelled = coordinatorRef.current.cancel("context_changed");
+    setState(IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE);
+    if (cancelled) {
+      recordInspectorEvent("cloud_mcp.submission_cancelled", {
+        workspaceId,
+        reason: "context_changed",
+      });
+    }
+  }, [decision.scopeKey, workspaceId]);
+
+  useEffect(() => () => {
+    coordinatorRef.current.cancel("unmounted");
+  }, []);
+
+  const submit = useCallback(async (submission: CloudMcpSubmitInput): Promise<CloudMcpSubmissionResult> => {
+    const capturedScopeKey = decision.scopeKey;
+    const gateRequired = !submission.skipGate && decision.mode === "required";
+    let prepare: (() => Promise<CloudMcpSubmissionPreparationResult>) | undefined;
+
+    if (gateRequired) {
+      prepare = async () => {
+        const client = input.client;
+        const providerModel = input.providerModel;
+        if (!client || !workspaceId || !providerModel) {
+          return {
+            outcome: "failed",
+            issue: missingContextIssue({
+              client,
+              workspaceId,
+              providerModel,
+            }),
+          };
+        }
+        const result = await ensureCloudMcpSubmissionReadiness({
+          providerModel,
+          check: () => client.getOpenworkCloudMcpHealth(workspaceId, providerModel),
+          repair: async () => {
+            const repaired = await syncCloudControlMcpInBackground({
+              client,
+              workspaceId,
+              providerModel,
+              settings,
+              force: true,
+            });
+            return repaired.health;
+          },
+          onAttempt: (attempt) => {
+            if (currentScopeKeyRef.current !== capturedScopeKey) return;
+            const issue = attempt.assessment.ready ? null : attempt.assessment.issue;
+            setState({
+              status: attempt.phase === "readiness" ? "checking" : "repairing",
+              issue,
+              attempt: attempt.attempt,
+              maxAttempts: attempt.maxAttempts,
+            });
+            recordInspectorEvent(
+              attempt.phase === "readiness"
+                ? "cloud_mcp.submission_readiness"
+                : "cloud_mcp.submission_repair",
+              {
+                workspaceId,
+                provider: providerModel.provider,
+                model: providerModel.model,
+                attempt: attempt.attempt,
+                maxAttempts: attempt.maxAttempts,
+                outcome: attempt.assessment.ready ? "ready" : "failed",
+                code: issue?.code ?? null,
+                stage: issue?.stage ?? null,
+                retryable: issue?.retryable ?? null,
+              },
+            );
+            if (issue?.code === "cloud_mcp_submission_timeout") {
+              recordInspectorEvent("cloud_mcp.submission_timeout", {
+                workspaceId,
+                provider: providerModel.provider,
+                model: providerModel.model,
+                attempt: attempt.attempt,
+                maxAttempts: attempt.maxAttempts,
+              });
+            }
+          },
+        });
+        if (currentScopeKeyRef.current !== capturedScopeKey) {
+          return { outcome: "cancelled", reason: "context_changed" };
+        }
+        if (result.outcome === "ready") return { outcome: "ready" };
+        if (result.outcome === "bypass") return { outcome: "bypass" };
+        return { outcome: "failed", issue: result.issue };
+      };
+    }
+
+    return coordinatorRef.current.submit({
+      scopeKey: capturedScopeKey,
+      ...(prepare ? { prepare } : {}),
+      send: submission.send,
+      onState: (nextState) => {
+        if (currentScopeKeyRef.current !== capturedScopeKey) return;
+        if (nextState.status === "checking") {
+          setState({ ...IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE, status: "checking" });
+          return;
+        }
+        if (nextState.status === "sending") {
+          setState({ ...IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE, status: "sending" });
+          return;
+        }
+        if (nextState.status === "failed") {
+          setState({
+            ...IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE,
+            status: "failed",
+            issue: nextState.issue,
+          });
+          recordInspectorEvent("cloud_mcp.submission_failure", {
+            workspaceId,
+            provider: input.providerModel?.provider ?? null,
+            model: input.providerModel?.model ?? null,
+            code: nextState.issue.code,
+            stage: nextState.issue.stage,
+            retryable: nextState.issue.retryable,
+          });
+          return;
+        }
+        setState(IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE);
+      },
+    });
+  }, [decision, input.client, input.providerModel, settings, workspaceId]);
+
+  return { state, submit };
+}

--- a/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
+++ b/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
@@ -1,4 +1,4 @@
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 import {
   mintCloudControlMcpToken,
@@ -6,7 +6,13 @@ import {
   type DenMcpToken,
   type DenSettings,
 } from "../../../app/lib/den";
-import type { OpenworkServerClient } from "../../../app/lib/openwork-server";
+import { recordInspectorEvent } from "../../../app/lib/app-inspector";
+import type {
+  OpenworkCloudMcpFailure,
+  OpenworkCloudMcpHealth,
+  OpenworkCloudMcpProviderModelContext,
+  OpenworkServerClient,
+} from "../../../app/lib/openwork-server";
 import { unwrap } from "../../../app/lib/opencode";
 import type { Client, McpServerEntry, McpStatusMap } from "../../../app/types";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
@@ -21,10 +27,77 @@ import {
 
 export const SESSION_MCP_MAINTENANCE_INTERVAL_MS = 5 * 60 * 1000;
 export const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
+export const CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS = [1_000, 3_000];
 
 type CloudMcpMaintenanceClient = CloudMcpClient & Pick<OpenworkServerClient, "listMcp">;
 
 const maintenanceInFlight = new Set<string>();
+
+export type CloudMcpMaintenanceIssue = Pick<
+  OpenworkCloudMcpFailure,
+  "code" | "stage" | "retryable" | "recommendedAction" | "message"
+>;
+
+export type CloudMcpBackgroundSyncResult =
+  | {
+      outcome: "ready";
+      status: "synced" | "unchanged";
+      health: OpenworkCloudMcpHealth;
+    }
+  | {
+      outcome: "skipped";
+      status: "skipped";
+      reason: "signed_out" | "missing_org" | "missing_workspace" | "disabled";
+      health: null;
+    }
+  | {
+      outcome: "failed";
+      status: "failed";
+      issue: CloudMcpMaintenanceIssue;
+      health: OpenworkCloudMcpHealth | null;
+    };
+
+export type SessionCloudMcpMaintenanceState = {
+  status: "idle" | "checking" | "ready" | "skipped" | "retrying" | "failed";
+  issue: CloudMcpMaintenanceIssue | null;
+  attempt: number;
+  maxAttempts: number;
+};
+
+const IDLE_CLOUD_MCP_MAINTENANCE_STATE: SessionCloudMcpMaintenanceState = {
+  status: "idle",
+  issue: null,
+  attempt: 0,
+  maxAttempts: 1 + CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS.length,
+};
+
+function genericCloudMcpMaintenanceIssue(input?: {
+  code?: string;
+  message?: string;
+  retryable?: boolean;
+}): CloudMcpMaintenanceIssue {
+  return {
+    code: input?.code ?? "cloud_mcp_maintenance_failed",
+    stage: "engine_delivery",
+    retryable: input?.retryable ?? true,
+    recommendedAction: "Retry, then open Settings → Connect if the problem continues.",
+    message: input?.message ?? "OpenWork could not verify connected service tools for this workspace.",
+  };
+}
+
+function failedCloudMcpBackgroundSync(input: {
+  health: OpenworkCloudMcpHealth | null;
+  issue?: CloudMcpMaintenanceIssue;
+  code?: string;
+  message?: string;
+}): CloudMcpBackgroundSyncResult {
+  return {
+    outcome: "failed",
+    status: "failed",
+    health: input.health,
+    issue: input.issue ?? genericCloudMcpMaintenanceIssue({ code: input.code, message: input.message }),
+  };
+}
 
 export function getSessionMcpMaintenanceTargetKey(input: {
   client: Pick<OpenworkServerClient, "baseUrl">;
@@ -32,12 +105,15 @@ export function getSessionMcpMaintenanceTargetKey(input: {
   denBaseUrl?: string | null;
   orgId?: string | null;
   workspaceId: string;
+  providerModel?: OpenworkCloudMcpProviderModelContext;
 }): string {
   return JSON.stringify([
     input.denBaseUrl?.trim().replace(/\/+$/, "") ?? "",
     input.client.baseUrl.trim().replace(/\/+$/, ""),
     input.workspaceId.trim(),
     input.cloudSignedIn ? input.orgId?.trim() ?? "" : "local-only",
+    input.providerModel?.provider.trim() ?? "",
+    input.providerModel?.model.trim() ?? "",
   ]);
 }
 
@@ -62,22 +138,35 @@ export async function syncCloudControlMcpInBackground(input: {
   now?: number;
   settings?: DenSettings;
   mintToken?: () => Promise<DenMcpToken | null>;
-}): Promise<"synced" | "unchanged" | "skipped"> {
+  providerModel?: OpenworkCloudMcpProviderModelContext;
+}): Promise<CloudMcpBackgroundSyncResult> {
   const workspaceId = input.workspaceId.trim();
   const settings = input.settings ?? readDenSettings();
   const orgId = settings.activeOrgId?.trim() ?? "";
-  if (!workspaceId || !orgId || !settings.authToken?.trim()) return "skipped";
+  if (!workspaceId) {
+    return { outcome: "skipped", status: "skipped", reason: "missing_workspace", health: null };
+  }
+  if (!settings.authToken?.trim()) {
+    return { outcome: "skipped", status: "skipped", reason: "signed_out", health: null };
+  }
+  if (!orgId) {
+    return { outcome: "skipped", status: "skipped", reason: "missing_org", health: null };
+  }
   const scope = {
     denBaseUrl: settings.baseUrl,
     serverBaseUrl: input.client.baseUrl,
     orgId,
     workspaceId,
   };
-  if (readCloudMcpUserState(scope) !== null) return "skipped";
+  if (readCloudMcpUserState(scope) !== null) {
+    return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
+  }
 
   const listed = await input.client.listMcp(workspaceId);
   const configured = listed.items.find((entry) => entry.name === CLOUD_MCP_SERVER_NAME);
-  if (configured?.config.enabled === false) return "skipped";
+  if (configured?.config.enabled === false) {
+    return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
+  }
   const configuredUrl = typeof configured?.config.url === "string" ? configured.config.url : null;
 
   const result = await runOpenworkCloudMcpReconciler({
@@ -89,6 +178,7 @@ export async function syncCloudControlMcpInBackground(input: {
       orgSlug: settings.activeOrgSlug,
       orgName: settings.activeOrgName,
       fallbackUrl: configured?.config.type === "remote" ? configuredUrl : null,
+      providerModel: input.providerModel,
       trigger: input.force ? "desktop-background-forced" : "desktop-background",
     },
     mintToken: input.mintToken
@@ -99,9 +189,71 @@ export async function syncCloudControlMcpInBackground(input: {
     now: input.now,
     configuredEnabled: typeof configured?.config.enabled === "boolean" ? configured.config.enabled : null,
   });
-  if (result.status === "unchanged" || result.status === "ready") return "unchanged";
-  if (result.health?.usable) return "synced";
-  return "skipped";
+  if (result.health?.usable) {
+    return {
+      outcome: "ready",
+      status: result.status === "unchanged" || result.status === "ready" ? "unchanged" : "synced",
+      health: result.health,
+    };
+  }
+  if (result.status === "skipped") {
+    if (result.skippedReason === "signed_out") {
+      return { outcome: "skipped", status: "skipped", reason: "signed_out", health: null };
+    }
+    if (result.skippedReason === "missing_org") {
+      return { outcome: "skipped", status: "skipped", reason: "missing_org", health: null };
+    }
+    if (result.skippedReason === "missing_workspace") {
+      return { outcome: "skipped", status: "skipped", reason: "missing_workspace", health: null };
+    }
+    if (result.skippedReason === "disabled") {
+      return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
+    }
+    if (result.skippedReason === "mint_failed") {
+      return failedCloudMcpBackgroundSync({
+        health: result.health,
+        code: "cloud_mcp_token_mint_failed",
+        message: "OpenWork could not refresh Cloud authentication for connected service tools.",
+      });
+    }
+  }
+  return failedCloudMcpBackgroundSync({
+    health: result.health,
+    issue: result.health?.firstFailure ?? undefined,
+  });
+}
+
+export async function runCloudMcpMaintenanceWithRetry(input: {
+  attempt: () => Promise<CloudMcpBackgroundSyncResult>;
+  retryDelaysMs?: number[];
+  wait?: (delayMs: number) => Promise<void>;
+  onAttempt?: (input: {
+    result: CloudMcpBackgroundSyncResult;
+    attempt: number;
+    maxAttempts: number;
+    willRetry: boolean;
+  }) => void;
+}): Promise<CloudMcpBackgroundSyncResult> {
+  const retryDelaysMs = input.retryDelaysMs ?? CLOUD_MCP_MAINTENANCE_RETRY_DELAYS_MS;
+  const wait = input.wait ?? ((delayMs: number) => new Promise((resolve) => setTimeout(resolve, delayMs)));
+  const maxAttempts = 1 + retryDelaysMs.length;
+  let lastResult: CloudMcpBackgroundSyncResult | null = null;
+
+  for (let index = 0; index < maxAttempts; index += 1) {
+    if (index > 0) await wait(retryDelaysMs[index - 1] ?? 0);
+    try {
+      lastResult = await input.attempt();
+    } catch {
+      lastResult = failedCloudMcpBackgroundSync({ health: null });
+    }
+    const willRetry = lastResult.outcome === "failed"
+      && lastResult.issue.retryable
+      && index < maxAttempts - 1;
+    input.onAttempt?.({ result: lastResult, attempt: index + 1, maxAttempts, willRetry });
+    if (!willRetry) return lastResult;
+  }
+
+  return lastResult ?? failedCloudMcpBackgroundSync({ health: null });
 }
 
 export async function healWorkspaceMcpInBackground(input: {
@@ -136,13 +288,21 @@ export function useSessionMcpMaintenance(input: {
   workspaceId: string | null;
   opencodeClient: Client | null;
   directory: string;
-}) {
+  providerModel?: OpenworkCloudMcpProviderModelContext;
+}): SessionCloudMcpMaintenanceState {
+  const [cloudMcpState, setCloudMcpState] = useState<SessionCloudMcpMaintenanceState>(
+    IDLE_CLOUD_MCP_MAINTENANCE_STATE,
+  );
+
   useEffect(() => {
     const workspaceId = input.workspaceId?.trim() ?? "";
     const directory = input.directory.trim();
     const client = input.client;
     const opencodeClient = input.opencodeClient;
-    if (!client || !opencodeClient || !workspaceId || !directory) return;
+    if (!client || !opencodeClient || !workspaceId || !directory) {
+      setCloudMcpState(IDLE_CLOUD_MCP_MAINTENANCE_STATE);
+      return;
+    }
     const settings = readDenSettings();
     const targetKey = getSessionMcpMaintenanceTargetKey({
       client,
@@ -150,28 +310,83 @@ export function useSessionMcpMaintenance(input: {
       denBaseUrl: settings.baseUrl,
       orgId: settings.activeOrgId,
       workspaceId,
+      providerModel: input.providerModel,
     });
 
     let cancelled = false;
+    let busyRetryTimer: number | null = null;
+    setCloudMcpState(input.cloudSignedIn
+      ? { ...IDLE_CLOUD_MCP_MAINTENANCE_STATE, status: "checking" }
+      : IDLE_CLOUD_MCP_MAINTENANCE_STATE);
+
+    const recordCloudAttempt = (attemptInput: {
+      result: CloudMcpBackgroundSyncResult;
+      attempt: number;
+      maxAttempts: number;
+      willRetry: boolean;
+    }) => {
+      const issue = attemptInput.result.outcome === "failed" ? attemptInput.result.issue : null;
+      recordInspectorEvent("cloud_mcp.session_maintenance", {
+        workspaceId,
+        outcome: attemptInput.result.outcome,
+        status: attemptInput.result.status,
+        attempt: attemptInput.attempt,
+        maxAttempts: attemptInput.maxAttempts,
+        willRetry: attemptInput.willRetry,
+        code: issue?.code ?? null,
+        stage: issue?.stage ?? null,
+        retryable: issue?.retryable ?? null,
+      });
+      if (cancelled) return;
+      setCloudMcpState({
+        status: attemptInput.result.outcome === "ready"
+          ? "ready"
+          : attemptInput.result.outcome === "skipped"
+            ? "skipped"
+            : attemptInput.willRetry
+              ? "retrying"
+              : "failed",
+        issue,
+        attempt: attemptInput.attempt,
+        maxAttempts: attemptInput.maxAttempts,
+      });
+    };
+
+    const scheduleBusyRetry = () => {
+      if (cancelled || busyRetryTimer !== null) return;
+      busyRetryTimer = window.setTimeout(() => {
+        busyRetryTimer = null;
+        void tick();
+      }, 250);
+    };
+
     const tick = async () => {
       if (cancelled) return;
-      await runSessionMcpMaintenanceTask({
+      const started = await runSessionMcpMaintenanceTask({
         targetKey,
         task: async () => {
-        if (input.cloudSignedIn) {
-          await syncCloudControlMcpInBackground({
+          if (input.cloudSignedIn) {
+            await runCloudMcpMaintenanceWithRetry({
+              attempt: () => syncCloudControlMcpInBackground({
+                client,
+                workspaceId,
+                providerModel: input.providerModel,
+              }),
+              onAttempt: recordCloudAttempt,
+            });
+          }
+          await healWorkspaceMcpInBackground({
             client,
             workspaceId,
-          }).catch(() => "skipped");
-        }
-        await healWorkspaceMcpInBackground({
-          client,
-          workspaceId,
-          opencodeClient,
-          directory,
-        }).catch(() => false);
+            opencodeClient,
+            directory,
+          }).catch(() => {
+            recordInspectorEvent("mcp.session_reauth_failed", { workspaceId });
+            return false;
+          });
         },
       });
+      if (!started) scheduleBusyRetry();
     };
 
     void tick();
@@ -187,6 +402,17 @@ export function useSessionMcpMaintenance(input: {
       window.removeEventListener("online", handleOnline);
       window.removeEventListener("focus", handleFocus);
       window.clearInterval(interval);
+      if (busyRetryTimer !== null) window.clearTimeout(busyRetryTimer);
     };
-  }, [input.client, input.cloudSignedIn, input.directory, input.opencodeClient, input.workspaceId]);
+  }, [
+    input.client,
+    input.cloudSignedIn,
+    input.directory,
+    input.opencodeClient,
+    input.providerModel?.model,
+    input.providerModel?.provider,
+    input.workspaceId,
+  ]);
+
+  return cloudMcpState;
 }

--- a/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
+++ b/apps/app/src/react-app/domains/connections/use-session-mcp-maintenance.ts
@@ -18,11 +18,12 @@ import type { Client, McpServerEntry, McpStatusMap } from "../../../app/types";
 import { attemptSilentMcpReauth } from "./mcp-silent-reauth";
 import {
   CLOUD_MCP_SERVER_NAME,
-  readCloudMcpUserState,
+  LEGACY_OPENWORK_ADMIN_MCP_SERVER_NAME,
 } from "./cloud-mcp-user-state";
 import {
   runOpenworkCloudMcpReconciler,
   type CloudMcpClient,
+  type CloudMcpOperationResult,
 } from "./cloud-mcp-reconciler";
 
 export const SESSION_MCP_MAINTENANCE_INTERVAL_MS = 5 * 60 * 1000;
@@ -73,14 +74,16 @@ const IDLE_CLOUD_MCP_MAINTENANCE_STATE: SessionCloudMcpMaintenanceState = {
 
 function genericCloudMcpMaintenanceIssue(input?: {
   code?: string;
+  stage?: string;
   message?: string;
   retryable?: boolean;
+  recommendedAction?: string;
 }): CloudMcpMaintenanceIssue {
   return {
     code: input?.code ?? "cloud_mcp_maintenance_failed",
-    stage: "engine_delivery",
+    stage: input?.stage ?? "engine_delivery",
     retryable: input?.retryable ?? true,
-    recommendedAction: "Retry, then open Settings → Connect if the problem continues.",
+    recommendedAction: input?.recommendedAction ?? "Retry, then open Settings → Connect if the problem continues.",
     message: input?.message ?? "OpenWork could not verify connected service tools for this workspace.",
   };
 }
@@ -89,13 +92,22 @@ function failedCloudMcpBackgroundSync(input: {
   health: OpenworkCloudMcpHealth | null;
   issue?: CloudMcpMaintenanceIssue;
   code?: string;
+  stage?: string;
   message?: string;
+  retryable?: boolean;
+  recommendedAction?: string;
 }): CloudMcpBackgroundSyncResult {
   return {
     outcome: "failed",
     status: "failed",
     health: input.health,
-    issue: input.issue ?? genericCloudMcpMaintenanceIssue({ code: input.code, message: input.message }),
+    issue: input.issue ?? genericCloudMcpMaintenanceIssue({
+      code: input.code,
+      stage: input.stage,
+      message: input.message,
+      retryable: input.retryable,
+      recommendedAction: input.recommendedAction,
+    }),
   };
 }
 
@@ -158,38 +170,86 @@ export async function syncCloudControlMcpInBackground(input: {
     orgId,
     workspaceId,
   };
-  if (readCloudMcpUserState(scope) !== null) {
-    return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
+  let listed: Awaited<ReturnType<CloudMcpMaintenanceClient["listMcp"]>>;
+  try {
+    listed = await input.client.listMcp(workspaceId);
+  } catch {
+    return failedCloudMcpBackgroundSync({
+      health: null,
+      code: "cloud_mcp_config_read_failed",
+      stage: "prerequisites",
+      message: "OpenWork could not read the connected service configuration for this workspace.",
+    });
   }
-
-  const listed = await input.client.listMcp(workspaceId);
   const configured = listed.items.find((entry) => entry.name === CLOUD_MCP_SERVER_NAME);
-  if (configured?.config.enabled === false) {
-    return { outcome: "skipped", status: "skipped", reason: "disabled", health: null };
-  }
+  const legacyAdminPresent = listed.items.some((entry) => entry.name === LEGACY_OPENWORK_ADMIN_MCP_SERVER_NAME);
   const configuredUrl = typeof configured?.config.url === "string" ? configured.config.url : null;
 
-  const result = await runOpenworkCloudMcpReconciler({
-    mode: "repair",
-    client: input.client,
-    context: {
-      ...scope,
-      denAuthToken: settings.authToken,
-      orgSlug: settings.activeOrgSlug,
-      orgName: settings.activeOrgName,
-      fallbackUrl: configured?.config.type === "remote" ? configuredUrl : null,
-      providerModel: input.providerModel,
-      trigger: input.force ? "desktop-background-forced" : "desktop-background",
-    },
-    mintToken: input.mintToken
-      ? async () => input.mintToken?.() ?? null
-      : mintCloudControlMcpToken,
-    force: input.force,
-    refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
-    now: input.now,
-    configuredEnabled: typeof configured?.config.enabled === "boolean" ? configured.config.enabled : null,
-  });
+  const trigger = legacyAdminPresent
+    ? "desktop-legacy-admin-cleanup"
+    : input.force
+      ? "desktop-background-forced"
+      : "desktop-background";
+  let result: CloudMcpOperationResult;
+  try {
+    result = await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client: input.client,
+      context: {
+        ...scope,
+        denAuthToken: settings.authToken,
+        orgSlug: settings.activeOrgSlug,
+        orgName: settings.activeOrgName,
+        fallbackUrl: configured?.config.type === "remote" ? configuredUrl : null,
+        providerModel: input.providerModel,
+        trigger,
+      },
+      mintToken: async (context) => {
+        try {
+          return input.mintToken
+            ? await input.mintToken()
+            : await mintCloudControlMcpToken(context);
+        } catch {
+          return null;
+        }
+      },
+      force: input.force || legacyAdminPresent,
+      refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+      now: input.now,
+      configuredPresent: Boolean(configured),
+      configuredEnabled: typeof configured?.config.enabled === "boolean" ? configured.config.enabled : null,
+    });
+  } catch {
+    return failedCloudMcpBackgroundSync({
+      health: null,
+      code: "cloud_mcp_reconcile_request_failed",
+      message: "OpenWork could not complete the Cloud tool health and reconciliation request.",
+    });
+  }
   if (result.health?.usable) {
+    if (legacyAdminPresent) {
+      let legacyStillPresent = true;
+      try {
+        const refreshed = await input.client.listMcp(workspaceId);
+        legacyStillPresent = refreshed.items.some((entry) => entry.name === LEGACY_OPENWORK_ADMIN_MCP_SERVER_NAME);
+      } catch {
+        // The next bounded maintenance attempt will verify cleanup again.
+      }
+      recordInspectorEvent("cloud_mcp.legacy_admin_cleanup", {
+        workspaceId,
+        outcome: legacyStillPresent ? "failed" : "removed",
+      });
+      if (legacyStillPresent) {
+        return failedCloudMcpBackgroundSync({
+          health: result.health,
+          code: "legacy_openwork_admin_cleanup_failed",
+          stage: "desired_config",
+          retryable: false,
+          recommendedAction: "Open Connect and remove the retired openwork-admin entry.",
+          message: "The retired openwork-admin connection could not be removed from this workspace.",
+        });
+      }
+    }
     return {
       outcome: "ready",
       status: result.status === "unchanged" || result.status === "ready" ? "unchanged" : "synced",

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
-import { AppWindowMac, ArrowUp, Check, ChevronDown, ChevronRight, FileText, ListPlus, Paperclip, Plug, Settings, Square, Terminal, X, Zap } from "lucide-react";
+import { AppWindowMac, ArrowUp, Check, ChevronDown, ChevronRight, FileText, ListPlus, LoaderCircle, Paperclip, Plug, Settings, Square, Terminal, X, Zap } from "lucide-react";
 import fuzzysort from "fuzzysort";
 import { toast } from "@/components/ui/sonner";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuShortcut, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
@@ -54,6 +54,7 @@ type ComposerProps = {
   onQueue: () => void | Promise<void>;
   onStop: () => void | Promise<void>;
   busy: boolean;
+  submissionPreparing: boolean;
   queuedCount: number;
   disabled: boolean;
   modelUnavailable?: boolean;
@@ -375,13 +376,14 @@ export function ReactSessionComposer(props: ComposerProps) {
   const handleEditorSubmit = useCallback((options: { queue: boolean }) => {
     const hasContent = props.draft.trim().length > 0 || props.attachments.length > 0;
     if (!hasContent) return;
+    if (props.submissionPreparing) return;
     if (props.busy) {
       if (options.queue) void props.onQueue();
       else void props.onSteer();
       return;
     }
     void props.onSend();
-  }, [props.busy, props.draft, props.attachments, props.onSend, props.onSteer, props.onQueue]);
+  }, [props.busy, props.draft, props.attachments, props.onSend, props.onSteer, props.onQueue, props.submissionPreparing]);
 
   const slashCommandQuery = getSlashCommandQuery(props.draft);
   const slashOpenNext = slashCommandQuery !== null;
@@ -1729,17 +1731,17 @@ export function ReactSessionComposer(props: ComposerProps) {
                 ) : (
                   <button
                     type="button"
-                    onClick={canSend ? props.onSend : undefined}
-                    disabled={props.disabled || !canSend}
+                    onClick={canSend && !props.submissionPreparing ? props.onSend : undefined}
+                    disabled={props.disabled || !canSend || props.submissionPreparing}
                     className={`inline-flex h-9 max-h-9 items-center gap-2 rounded-full px-4 text-[13px] font-medium transition-colors ${
-                      !canSend || props.disabled
+                      !canSend || props.disabled || props.submissionPreparing
                         ? "bg-gray-4 text-gray-10"
                         : "bg-[var(--dls-accent)] text-[var(--dls-accent-fg)] hover:bg-[var(--dls-accent-hover)]"
                     }`}
-                    title={t("composer.run_task")}
+                    title={props.submissionPreparing ? "Preparing connected service tools…" : t("composer.run_task")}
                   >
-                    <ArrowUp size={15} />
-                    <span>{t("composer.run_task")}</span>
+                    {props.submissionPreparing ? <LoaderCircle size={15} className="animate-spin" /> : <ArrowUp size={15} />}
+                    <span>{props.submissionPreparing ? "Preparing connected service tools…" : t("composer.run_task")}</span>
                   </button>
                 )}
               </div>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -33,6 +33,10 @@ import {
 } from "@/app/lib/app-inspector";
 import { useControlAction, type OpenworkControlAction } from "@/react-app/shell/control/control-provider";
 import { attemptSilentMcpReauth } from "@/react-app/domains/connections/mcp-silent-reauth";
+import type {
+  CloudMcpSubmissionGateState,
+  CloudMcpSubmissionResult,
+} from "@/react-app/domains/connections/cloud-mcp-submit-readiness";
 import { ReactSessionComposer } from "./composer/composer";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./composer/mention-encoding";
 import { desktopBridge } from "@/app/lib/desktop";
@@ -111,7 +115,9 @@ export type SessionSurfaceProps = {
   selectedModel: ModelRef;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
-  onSendDraft: (draft: ComposerDraft, sessionId: string) => void;
+  onSendDraft: (draft: ComposerDraft, sessionId: string) => Promise<CloudMcpSubmissionResult>;
+  cloudMcpSubmissionState: CloudMcpSubmissionGateState;
+  onOpenConnect: () => void;
   onDraftChange: (draft: ComposerDraft) => void;
   attachmentsEnabled: boolean;
   attachmentsDisabledReason: string | null;
@@ -397,6 +403,10 @@ function revokeAttachmentPreview(attachment: { previewUrl?: string | undefined }
   URL.revokeObjectURL(attachment.previewUrl);
 }
 
+function sameAttachments(left: ComposerAttachment[], right: ComposerAttachment[]): boolean {
+  return left.length === right.length && left.every((attachment, index) => attachment.id === right[index]?.id);
+}
+
 // Combine multiple queued follow-up drafts into a single send. Their text and
 // parts are concatenated with blank-line separators and attachments are
 // merged, so the whole queue is delivered to the agent as one message.
@@ -459,7 +469,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const clearQueuedDrafts = useComposerStateStore((state) => state.clearQueuedDrafts);
   const prependQueuedDrafts = useComposerStateStore((state) => state.prependQueuedDrafts);
   const [error, setError] = useState<SessionError | null>(null);
-  const [sending, setSending] = useState(false);
   const [showDelayedLoading, setShowDelayedLoading] = useState(false);
   const [awaitingAssistantBaseline, setAwaitingAssistantBaseline] = useState<number | null>(null);
   const [rendered, setRendered] = useState<{ sessionId: string; snapshot: OpenworkSessionSnapshot } | null>(null);
@@ -469,6 +478,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [toolMcpStatuses, setToolMcpStatuses] = useState<McpStatusMap>({});
   const [toolImportedPlugins, setToolImportedPlugins] = useState<CloudImportedPlugin[]>([]);
   const [verifiedOpenTargets, setVerifiedOpenTargets] = useState<OpenTarget[]>([]);
+  const [cloudQueueRetryVersion, setCloudQueueRetryVersion] = useState(0);
+  const sending = props.cloudMcpSubmissionState.status === "sending";
+  const cloudQueueBlockedRef = useRef(false);
   const composerShellRef = useRef<HTMLDivElement>(null);
   const hydratedKeyRef = useRef<string | null>(null);
   const autoOpenedTargetRef = useRef<string | null>(null);
@@ -508,7 +520,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
   useEffect(() => {
     hydratedKeyRef.current = null;
     setError(null);
-    setSending(false);
     setShowDelayedLoading(false);
     setAwaitingAssistantBaseline(null);
     // Composer draft state lives in the shared store keyed by session id, so
@@ -540,6 +551,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
         lines: part.lines,
       })),
       sending,
+      cloudMcpSubmission: {
+        status: props.cloudMcpSubmissionState.status,
+        attempt: props.cloudMcpSubmissionState.attempt,
+        maxAttempts: props.cloudMcpSubmissionState.maxAttempts,
+        code: props.cloudMcpSubmissionState.issue?.code ?? null,
+        stage: props.cloudMcpSubmissionState.issue?.stage ?? null,
+      },
       error,
     }));
     return dispose;
@@ -551,6 +569,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     pasteParts,
     props.sessionId,
     props.workspaceId,
+    props.cloudMcpSubmissionState,
     sending,
   ]);
 
@@ -580,6 +599,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     cachedRendered: rendered,
   });
   const liveStatus = statusState ?? snapshot?.status ?? IDLE_STATUS;
+  const preparingCloudTools = props.cloudMcpSubmissionState.status === "checking" ||
+    props.cloudMcpSubmissionState.status === "repairing";
   const chatStreaming = sending || liveStatus.type === "busy" || liveStatus.type === "retry";
   const status = useMemo((): ThreadStatus => {
     if (sending) {
@@ -766,27 +787,26 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Core sender shared by initial send and steered follow-ups. OpenCode
   // accepts follow-up user turns mid-run (steering) — the running loop picks
   // up the new message — so this is safe to call while the agent is busy.
-  const sendDraft = useCallback(async (nextDraft: ComposerDraft, draftAttachments: ComposerAttachment[]) => {
+  const sendDraft = useCallback(async (nextDraft: ComposerDraft) => {
     setError(null);
-    // Record the prompt for Up/Down recall in the composer (#2012).
-    appendComposerHistory(props.sessionId, nextDraft.text);
-    useSessionActivityStore.getState().setRunStatus(props.workspaceId, props.sessionId, { type: "busy" });
-    setSending(true);
-    setAwaitingAssistantBaseline(renderedMessages.length);
     try {
-      await props.onSendDraft(nextDraft, props.sessionId);
-      draftAttachments.forEach(revokeAttachmentPreview);
-      setSending(false);
+      const result = await props.onSendDraft(nextDraft, props.sessionId);
+      if (result.outcome === "blocked" || result.outcome === "cancelled") return result;
+      // Only report a run after the pre-send gate released the exact queued
+      // submission and the route accepted or sent it.
+      appendComposerHistory(props.sessionId, nextDraft.text);
+      useSessionActivityStore.getState().setRunStatus(props.workspaceId, props.sessionId, { type: "busy" });
+      setAwaitingAssistantBaseline(renderedMessages.length);
+      return result;
     } catch (nextError) {
       const parsed = parseSessionError(nextError);
       captureAnalyticsEvent("task_send_failed", {});
       setError(parsed);
       useSessionActivityStore.getState().setError(props.workspaceId, props.sessionId, parsed.message);
       setAwaitingAssistantBaseline(null);
-      setSending(false);
       throw nextError;
     }
-  }, [appendComposerHistory, props.onSendDraft, props.sessionId, props.workspaceId, renderedMessages.length, setComposerDraft]);
+  }, [appendComposerHistory, props.onSendDraft, props.sessionId, props.workspaceId, renderedMessages.length]);
 
   const clearComposer = useCallback(() => {
     clearComposerSession(props.sessionId);
@@ -796,18 +816,40 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Initial send (agent idle) and explicit "Steer" follow-up (agent busy)
   // share the same immediate path.
   const handleSend = useCallback(async () => {
-    const text = draft.trim();
+    const originalDraft = draft;
+    const text = originalDraft.trim();
     if (!text && attachments.length === 0) return;
     const nextDraft = buildDraft(text, attachments);
     const sentAttachments = attachments;
     try {
-      await sendDraft(nextDraft, sentAttachments);
-      clearComposer();
+      const result = await sendDraft(nextDraft);
+      if (result.outcome === "blocked" || result.outcome === "cancelled") return;
+      const currentState = useComposerStateStore.getState();
+      const currentDraft = getComposerDraft(currentState, props.sessionId);
+      const currentAttachments = getComposerAttachments(currentState, props.sessionId);
+      if (currentDraft === originalDraft && sameAttachments(currentAttachments, sentAttachments)) {
+        clearComposer();
+        sentAttachments.forEach(revokeAttachmentPreview);
+      } else {
+        const retainedIds = new Set(currentAttachments.map((attachment) => attachment.id));
+        sentAttachments
+          .filter((attachment) => !retainedIds.has(attachment.id))
+          .forEach(revokeAttachmentPreview);
+      }
     } catch {
     }
   }, [attachments, buildDraft, clearComposer, draft, props.sessionId, sendDraft]);
 
   const handleSteer = handleSend;
+
+  const handleRetryCloudSubmission = useCallback(() => {
+    if (draft.trim() || attachments.length > 0) {
+      void handleSend();
+      return;
+    }
+    cloudQueueBlockedRef.current = false;
+    setCloudQueueRetryVersion((version) => version + 1);
+  }, [attachments.length, draft, handleSend]);
 
   // Queue: hold the draft locally and clear the composer. The drain effect
   // sends it once the session reports idle.
@@ -864,18 +906,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     useSessionActivityStore.getState().clearError(props.workspaceId, props.sessionId);
   }, [props.sessionId, props.workspaceId]);
 
-  useEffect(() => {
-    if (liveStatus.type === "idle") {
-      setSending(false);
-    }
-  }, [liveStatus.type]);
-
   // Drain the queued follow-ups once the session goes idle. OpenCode has no
   // server-side queue, so we send everything that's queued as a single merged
   // message. The ref guards against re-entrancy while the send is in flight.
   const drainingQueueRef = useRef(false);
   useEffect(() => {
     if (drainingQueueRef.current) return;
+    if (cloudQueueBlockedRef.current) return;
     if (queuedDrafts.length === 0) return;
     if (chatStreaming || liveStatus.type !== "idle") return;
     const merged = mergeDrafts(queuedDrafts);
@@ -885,7 +922,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
     clearQueuedDrafts(props.sessionId);
     void (async () => {
       try {
-        await sendDraft(merged, merged.attachments);
+        const result = await sendDraft(merged);
+        if (result.outcome === "blocked") {
+          cloudQueueBlockedRef.current = true;
+          prependQueuedDrafts(props.sessionId, drained);
+        } else if (result.outcome === "cancelled") {
+          prependQueuedDrafts(props.sessionId, drained);
+        }
       } catch {
         // Restore the queue so the user can retry / edit on failure.
         prependQueuedDrafts(props.sessionId, drained);
@@ -893,7 +936,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
         drainingQueueRef.current = false;
       }
     })();
-  }, [chatStreaming, clearQueuedDrafts, liveStatus.type, prependQueuedDrafts, props.sessionId, queuedDrafts, sendDraft]);
+  }, [chatStreaming, clearQueuedDrafts, cloudQueueRetryVersion, liveStatus.type, prependQueuedDrafts, props.sessionId, queuedDrafts, sendDraft]);
+
+  useEffect(() => {
+    if (props.cloudMcpSubmissionState.status !== "failed") {
+      cloudQueueBlockedRef.current = false;
+    }
+  }, [props.cloudMcpSubmissionState.status]);
 
   useEffect(() => {
     props.onDraftChange(buildDraft(draft, attachments));
@@ -1440,6 +1489,25 @@ export function SessionSurface(props: SessionSurfaceProps) {
           </button>
         ) : null}
         <DevProfiler id="SessionComposer">
+        {props.cloudMcpSubmissionState.status === "failed" ? (
+          <div
+            className="mx-3 mb-2 flex items-center gap-3 rounded-xl border border-red-7/40 bg-red-2/40 px-3 py-2 text-xs text-red-11"
+            data-testid="cloud-mcp-submission-failure"
+          >
+            <span className="min-w-0 flex-1">
+              {[
+                props.cloudMcpSubmissionState.issue?.message ?? "Connected service tools could not be prepared.",
+                props.cloudMcpSubmissionState.issue?.recommendedAction,
+              ].filter(Boolean).join(" ")}
+            </span>
+            <button type="button" className="font-medium hover:underline" onClick={handleRetryCloudSubmission}>
+              Retry
+            </button>
+            <button type="button" className="font-medium hover:underline" onClick={props.onOpenConnect}>
+              Open Connect
+            </button>
+          </div>
+        ) : null}
         <ReactSessionComposer
           draft={draft}
           mentions={mentions}
@@ -1449,6 +1517,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         onQueue={handleQueue}
         onStop={handleAbort}
         busy={chatStreaming}
+        submissionPreparing={preparingCloudTools}
         queuedCount={queuedMessages.length}
         disabled={model.transitionState !== "idle" || Boolean(props.modelUnavailable)}
         modelUnavailable={Boolean(props.modelUnavailable)}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -387,13 +387,51 @@ export function SessionRoute() {
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });
-  useSessionMcpMaintenance({
+  const sessionMcpMaintenance = useSessionMcpMaintenance({
     cloudSignedIn: denAuth.isSignedIn,
     client: selectedWorkspaceEndpoint?.client ?? null,
     workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? null,
     opencodeClient,
     directory: selectedWorkspaceRoot,
+    providerModel: local.prefs.defaultModel
+      ? {
+          provider: local.prefs.defaultModel.providerID,
+          model: local.prefs.defaultModel.modelID,
+        }
+      : undefined,
   });
+  useEffect(() => {
+    const toastId = `cloud-mcp-session-maintenance:${selectedWorkspaceEndpoint?.workspaceId ?? "none"}`;
+    if (sessionMcpMaintenance.status === "retrying") {
+      toast.warning("Restoring connected service tools", {
+        id: toastId,
+        description: `${sessionMcpMaintenance.issue?.message ?? "OpenWork could not verify the tools yet."} Retrying automatically (${sessionMcpMaintenance.attempt}/${sessionMcpMaintenance.maxAttempts}).`,
+        action: {
+          label: "Open Connect",
+          onClick: () => navigate("/settings/connect"),
+        },
+        duration: Infinity,
+      });
+    } else if (sessionMcpMaintenance.status === "failed") {
+      toast.error("Connected service tools are unavailable", {
+        id: toastId,
+        description: [
+          sessionMcpMaintenance.issue?.message,
+          sessionMcpMaintenance.issue?.recommendedAction,
+        ].filter(Boolean).join(" "),
+        action: {
+          label: "Open Connect",
+          onClick: () => navigate("/settings/connect"),
+        },
+        duration: Infinity,
+      });
+    } else {
+      toast.dismiss(toastId);
+    }
+    return () => {
+      toast.dismiss(toastId);
+    };
+  }, [navigate, selectedWorkspaceEndpoint?.workspaceId, sessionMcpMaintenance]);
   // Agent selection is persisted in local prefs (like the model variant) so
   // it survives reloads instead of silently falling back to "build" (#2101).
   const selectedAgent = local.prefs.selectedAgent;

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -114,6 +114,8 @@ import type { CreateWorkspaceOptions } from "@/react-app/domains/workspace/types
 import { useSessionProviderAuth } from "@/react-app/domains/connections/provider-auth/use-session-provider-auth";
 import { useMcpConnectedCount } from "@/react-app/domains/connections/use-mcp-connected-count";
 import { useSessionMcpMaintenance } from "@/react-app/domains/connections/use-session-mcp-maintenance";
+import { useCloudMcpSubmitReadiness } from "@/react-app/domains/connections/use-cloud-mcp-submit-readiness";
+import type { CloudMcpSubmissionResult } from "@/react-app/domains/connections/cloud-mcp-submit-readiness";
 import { useRemoteAccessRestart } from "@/react-app/domains/workspace/remote-access-restart";
 import { RenameWorkspaceModal } from "@/react-app/domains/workspace/rename-workspace-modal";
 import { useRemoteWorkspaceConnectionEditor } from "@/react-app/domains/workspace/use-remote-workspace-connection-editor";
@@ -387,18 +389,28 @@ export function SessionRoute() {
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });
+  const cloudMcpProviderModel = useMemo(() => local.prefs.defaultModel
+    ? {
+        provider: local.prefs.defaultModel.providerID,
+        model: local.prefs.defaultModel.modelID,
+      }
+    : undefined, [local.prefs.defaultModel?.modelID, local.prefs.defaultModel?.providerID]);
   const sessionMcpMaintenance = useSessionMcpMaintenance({
     cloudSignedIn: denAuth.isSignedIn,
     client: selectedWorkspaceEndpoint?.client ?? null,
     workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? null,
     opencodeClient,
     directory: selectedWorkspaceRoot,
-    providerModel: local.prefs.defaultModel
-      ? {
-          provider: local.prefs.defaultModel.providerID,
-          model: local.prefs.defaultModel.modelID,
-        }
-      : undefined,
+    providerModel: cloudMcpProviderModel,
+  });
+  const {
+    state: cloudMcpSubmissionState,
+    submit: submitWithCloudMcpReadiness,
+  } = useCloudMcpSubmitReadiness({
+    cloudSignedIn: denAuth.isSignedIn,
+    client: selectedWorkspaceEndpoint?.client ?? null,
+    workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? null,
+    providerModel: cloudMcpProviderModel,
   });
   useEffect(() => {
     const toastId = `cloud-mcp-session-maintenance:${selectedWorkspaceEndpoint?.workspaceId ?? "none"}`;
@@ -906,11 +918,13 @@ export function SessionRoute() {
       onOpenSettingsSection: (section: "commands" | "skills" | "mcps" | "plugins" | "providers") => {
         handleOpenSettings(section === "skills" ? "/settings/skills" : section === "mcps" ? "/settings/extensions/mcp" : section === "plugins" ? "/settings/extensions/plugins" : section === "providers" ? "/settings/ai" : "/settings/general");
       },
-      onSendDraft: async (draft: ComposerDraft, sessionId: string) => {
+      onSendDraft: async (draft: ComposerDraft, sessionId: string): Promise<CloudMcpSubmissionResult> => {
         const targetSessionId = sessionId.trim() || selectedSessionId;
-        if (!targetSessionId) return;
+        if (!targetSessionId) return { outcome: "cancelled", reason: "context_changed" };
         const text = (draft.resolvedText ?? draft.text).trim();
-        if (!text && draft.attachments.length === 0) return;
+        if (!text && draft.attachments.length === 0) {
+          return { outcome: "cancelled", reason: "context_changed" };
+        }
         // One-shot provider selection on the first send whenever no user-added
         // provider is connected. The free default model being usable is the
         // normal case here, not a reason to skip the step.
@@ -923,67 +937,74 @@ export function SessionRoute() {
         ) {
           pendingProviderDraftRef.current = { draft, sessionId: targetSessionId };
           setProviderStepOpen(true);
-          return;
+          return { outcome: "accepted" };
         }
         if (selectedModelUnavailable) throw new Error("Selected model is unavailable. Choose another model before sending.");
 
-        captureAnalyticsEvent("task_message_sent", {
-          mode: draft.mode ?? "prompt",
-          is_command: Boolean(draft.command),
-          attachment_count: draft.attachments.length,
-          text_length: text.length,
-          workspace_type: selectedWorkspace?.workspaceType ?? "unknown",
-          provider_id: local.prefs.defaultModel?.providerID ?? null,
-          model_id: local.prefs.defaultModel?.modelID ?? null,
-        });
-        markTaskRunStart(targetSessionId);
-        // Den org adoption signals (auth-gated inside; no-op when signed out).
-        // Lives here — the live send choke point — because its previous call
-        // site was in the orphaned actions-store and never fired.
-        const projectDimension = readWorkspaceProjectDimension(selectedWorkspaceId);
-        const telemetryDimensions = projectDimension
-          ? [{
-              type: "project",
-              label: projectDimension.label,
-            }]
-          : undefined;
-        trackSessionActive(targetSessionId, telemetryDimensions);
-        trackTaskStarted(targetSessionId, telemetryDimensions);
+        return submitWithCloudMcpReadiness({
+          skipGate: draft.mode === "shell",
+          send: async () => {
+            captureAnalyticsEvent("task_message_sent", {
+              mode: draft.mode ?? "prompt",
+              is_command: Boolean(draft.command),
+              attachment_count: draft.attachments.length,
+              text_length: text.length,
+              workspace_type: selectedWorkspace?.workspaceType ?? "unknown",
+              provider_id: local.prefs.defaultModel?.providerID ?? null,
+              model_id: local.prefs.defaultModel?.modelID ?? null,
+            });
+            markTaskRunStart(targetSessionId);
+            // Den org adoption signals (auth-gated inside; no-op when signed out).
+            // This remains inside the post-readiness send closure so a blocked
+            // Cloud submission cannot create a run or report that one started.
+            const projectDimension = readWorkspaceProjectDimension(selectedWorkspaceId);
+            const telemetryDimensions = projectDimension
+              ? [{
+                  type: "project",
+                  label: projectDimension.label,
+                }]
+              : undefined;
+            trackSessionActive(targetSessionId, telemetryDimensions);
+            trackTaskStarted(targetSessionId, telemetryDimensions);
 
-        if (draft.mode === "shell") {
-          await shellInSession(opencodeClient, targetSessionId, text);
-          return;
-        }
+            if (draft.mode === "shell") {
+              await shellInSession(opencodeClient, targetSessionId, text);
+              return;
+            }
 
-        if (draft.command) {
-          const result = await opencodeClient.session.command({
-            sessionID: targetSessionId,
-            command: draft.command.name,
-            arguments: draft.command.arguments,
-          });
-          if (result.error) {
-            throw new Error(serializeSDKError(result.error));
-          }
-          return;
-        }
+            if (draft.command) {
+              const result = await opencodeClient.session.command({
+                sessionID: targetSessionId,
+                command: draft.command.name,
+                arguments: draft.command.arguments,
+              });
+              if (result.error) {
+                throw new Error(serializeSDKError(result.error));
+              }
+              return;
+            }
 
-        const parts = await draftToParts(draft, selectedWorkspaceRoot, targetSessionId, selectedWorkspaceEndpoint);
-        const envSystemContext = await buildOpenworkEnvSystemContext(client, {
-          cacheKey: targetSessionId,
-          runtimeKey: environmentRuntimeKey,
+            const parts = await draftToParts(draft, selectedWorkspaceRoot, targetSessionId, selectedWorkspaceEndpoint);
+            const envSystemContext = await buildOpenworkEnvSystemContext(client, {
+              cacheKey: targetSessionId,
+              runtimeKey: environmentRuntimeKey,
+            });
+            const result = await opencodeClient.session.promptAsync({
+              sessionID: targetSessionId,
+              parts,
+              model: local.prefs.defaultModel ?? undefined,
+              agent: selectedAgent ?? undefined,
+              ...(modelVariantValue ? { variant: modelVariantValue } : {}),
+              ...(envSystemContext ? { system: envSystemContext } : {}),
+            });
+            if (result.error) {
+              throw new Error(serializeSDKError(result.error));
+            }
+          },
         });
-        const result = await opencodeClient.session.promptAsync({
-          sessionID: targetSessionId,
-          parts,
-          model: local.prefs.defaultModel ?? undefined,
-          agent: selectedAgent ?? undefined,
-          ...(modelVariantValue ? { variant: modelVariantValue } : {}),
-          ...(envSystemContext ? { system: envSystemContext } : {}),
-        });
-        if (result.error) {
-          throw new Error(serializeSDKError(result.error));
-        }
       },
+      cloudMcpSubmissionState,
+      onOpenConnect: () => navigate("/settings/connect"),
       onDraftChange: () => {
         // Draft persistence will be wired once the full React shell owns session state.
       },
@@ -1079,6 +1100,7 @@ export function SessionRoute() {
     listAgents,
     listSlashCommands,
     modelBehaviorOptions,
+    cloudMcpSubmissionState,
     modelLabel,
     modelVariantLabel,
     modelVariantValue,
@@ -1093,6 +1115,7 @@ export function SessionRoute() {
     selectedWorkspaceId,
     selectedWorkspaceRoot,
     sessionsByWorkspaceId,
+    submitWithCloudMcpReadiness,
     token,
   ]);
 

--- a/apps/app/tests/cloud-mcp-health.test.ts
+++ b/apps/app/tests/cloud-mcp-health.test.ts
@@ -11,6 +11,7 @@ import {
 import {
   cloudMcpDisplaySummary,
   cloudMcpFailureStageLabel,
+  isCloudMcpAuthTokenFailure,
   isCloudMcpAuthTokenFailureCode,
   runOpenworkCloudMcpReconciler,
 } from "../src/react-app/domains/connections/cloud-mcp-reconciler";
@@ -44,13 +45,14 @@ function installStorageStub() {
   });
 }
 
-function failure(code: string): OpenworkCloudMcpFailure {
+function failure(code: string, aliases?: string[]): OpenworkCloudMcpFailure {
   return {
     code,
     stage: "engine_status",
     retryable: false,
     recommendedAction: "fix it",
     message: "failed",
+    ...(aliases ? { aliases } : {}),
   };
 }
 
@@ -198,7 +200,8 @@ describe("OpenWork Cloud MCP reconciler", () => {
     expect(readCloudMcpSyncMarker(scope)?.expiresAt).toBe(token.expiresAt);
   });
 
-  test("auth failures remint exactly once", async () => {
+  test("the exact invalid_mcp_token failure remints exactly once", async () => {
+    expect(isCloudMcpAuthTokenFailureCode("invalid_mcp_token")).toBe(true);
     let mintCount = 0;
     const posts: OpenworkCloudMcpReconcilePayload[] = [];
     const result = await runOpenworkCloudMcpReconciler({
@@ -209,7 +212,7 @@ describe("OpenWork Cloud MCP reconciler", () => {
         reconcileOpenworkCloudMcp: async (_workspaceId, payload) => {
           posts.push(payload);
           return posts.length === 1
-            ? health({ usable: false, failure: failure("openwork_cloud_token_expired") })
+            ? health({ usable: false, failure: failure("invalid_mcp_token") })
             : health({ usable: true });
         },
       },
@@ -225,6 +228,36 @@ describe("OpenWork Cloud MCP reconciler", () => {
     expect(result.health?.usable).toBe(true);
     expect(mintCount).toBe(2);
     expect(posts).toHaveLength(2);
+  });
+
+  test("a canonical auth alias remints exactly once", async () => {
+    let mintCount = 0;
+    let postCount = 0;
+    const result = await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => health({ usable: false }),
+        reconcileOpenworkCloudMcp: async () => {
+          postCount += 1;
+          return postCount === 1
+            ? health({ usable: false, failure: failure("cloud_connection_failed", ["openwork_cloud_token_expired"]) })
+            : health({ usable: true });
+        },
+      },
+      context,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+      force: true,
+      refreshMarginMs: 1,
+    });
+
+    expect(isCloudMcpAuthTokenFailure(failure("cloud_connection_failed", ["openwork_cloud_token_expired"]))).toBe(true);
+    expect(result.health?.usable).toBe(true);
+    expect(mintCount).toBe(2);
+    expect(postCount).toBe(2);
   });
 
   test("membership and scope failures do not retry", async () => {

--- a/apps/app/tests/cloud-mcp-submit-readiness.test.ts
+++ b/apps/app/tests/cloud-mcp-submit-readiness.test.ts
@@ -1,0 +1,334 @@
+import { describe, expect, test } from "bun:test";
+
+import type {
+  OpenworkCloudMcpFailure,
+  OpenworkCloudMcpHealth,
+} from "../src/app/lib/openwork-server";
+import {
+  createCloudMcpSubmissionCoordinator,
+  decideCloudMcpSubmissionGate,
+  ensureCloudMcpSubmissionReadiness,
+  type CloudMcpSubmissionPreparationResult,
+} from "../src/react-app/domains/connections/cloud-mcp-submit-readiness";
+
+const PROVIDER_MODEL = { provider: "openwork", model: "gpt-5" };
+
+function failure(input?: Partial<OpenworkCloudMcpFailure>): OpenworkCloudMcpFailure {
+  return {
+    code: input?.code ?? "cloud_registration_failed",
+    stage: input?.stage ?? "engine_delivery",
+    retryable: input?.retryable ?? true,
+    recommendedAction: input?.recommendedAction ?? "Retry",
+    message: input?.message ?? "Cloud tools are not ready.",
+  };
+}
+
+function health(input?: {
+  usable?: boolean;
+  firstFailure?: OpenworkCloudMcpFailure | null;
+  projectionSource?: "experimental_tool" | "provider_capability";
+}): OpenworkCloudMcpHealth {
+  const usable = input?.usable ?? true;
+  const projectionSource = input?.projectionSource ?? "experimental_tool";
+  const projected = usable
+    ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"]
+    : [];
+  const direct = usable ? ["search_capabilities", "execute_capability"] : [];
+  return {
+    schemaVersion: 1,
+    phase: usable ? "ready" : "registration_failed",
+    usable,
+    usableByCurrentModel: usable,
+    connectCatalogEnabled: true,
+    workspace: { id: "workspace_1", type: "local", directory: "/workspace", path: "/workspace" },
+    desired: {
+      present: true,
+      name: "openwork-cloud",
+      revision: "rev_1",
+      config: { type: "remote", enabled: true },
+      token: { present: true, metadata: {} },
+    },
+    delivery: {
+      state: usable ? "ready" : "failed",
+      desiredRevision: "rev_1",
+      appliedRevision: usable ? "rev_1" : null,
+      updatedAt: 1,
+      appliedAt: usable ? 1 : null,
+      lastAttemptAt: 1,
+    },
+    engine: { status: usable ? "connected" : "missing" },
+    tools: {
+      expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+      present: projected,
+      missing: usable ? [] : ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+      direct: {
+        checked: true,
+        source: "mcp_tools_list",
+        expected: ["search_capabilities", "execute_capability"],
+        present: direct,
+        missing: usable ? [] : ["search_capabilities", "execute_capability"],
+      },
+      providerProjection: {
+        checked: true,
+        provider: PROVIDER_MODEL.provider,
+        model: PROVIDER_MODEL.model,
+        source: projectionSource,
+        ...(projectionSource === "provider_capability"
+          ? {
+              limitation: "Only generic model tool-call capability is available.",
+              modelExists: true,
+              toolCalling: true,
+            }
+          : {}),
+        present: projected,
+        missing: usable ? [] : ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+      },
+    },
+    pluginCanaries: { expected: ["openwork_docs_search"], present: usable ? ["openwork_docs_search"] : [], missing: usable ? [] : ["openwork_docs_search"] },
+    compatibility: {
+      openwork: { serverVersion: "test", app: null },
+      opencode: { expectedVersion: "test", actualVersion: "test", probe: "ok" },
+      pluginFileHashes: [],
+      supportedFeatures: { dynamicMcp: true, directoryScoping: true, toolIds: true, providerToolProjection: projectionSource === "experimental_tool", pluginCanaries: true },
+      experimentalToolIds: {
+        checked: true,
+        expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+        present: projected,
+        missing: usable ? [] : ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+        includesMcpTools: usable,
+      },
+      experimentalProviderTools: {
+        checked: true,
+        provider: PROVIDER_MODEL.provider,
+        model: PROVIDER_MODEL.model,
+        expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+        present: projected,
+        missing: usable ? [] : ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+        includesMcpTools: projectionSource === "experimental_tool" && usable,
+      },
+    },
+    toolDenies: [],
+    firstFailure: usable ? input?.firstFailure ?? null : input?.firstFailure ?? failure(),
+    checkedAt: "2026-07-15T00:00:00.000Z",
+  };
+}
+
+function requiredDecision(input?: { signedIn?: boolean; userState?: "disabled" | "removed" | null; workspaceId?: string; model?: string }) {
+  return decideCloudMcpSubmissionGate({
+    cloudSignedIn: input?.signedIn ?? true,
+    denBaseUrl: "https://app.openwork.test",
+    serverBaseUrl: "https://worker.openwork.test",
+    orgId: "org_1",
+    workspaceId: input?.workspaceId ?? "workspace_1",
+    providerModel: { ...PROVIDER_MODEL, model: input?.model ?? PROVIDER_MODEL.model },
+    userState: input?.userState ?? null,
+  });
+}
+
+function preparation(input: {
+  check: () => Promise<OpenworkCloudMcpHealth | null>;
+  repair: () => Promise<OpenworkCloudMcpHealth | null>;
+}): () => Promise<CloudMcpSubmissionPreparationResult> {
+  return async () => {
+    const result = await ensureCloudMcpSubmissionReadiness({
+      providerModel: PROVIDER_MODEL,
+      check: input.check,
+      repair: input.repair,
+      retryDelaysMs: [0],
+      attemptTimeoutMs: 0,
+    });
+    if (result.outcome === "ready") return { outcome: "ready" };
+    if (result.outcome === "bypass") return { outcome: "bypass" };
+    return { outcome: "failed", issue: result.issue };
+  };
+}
+
+describe("Cloud MCP pre-send readiness", () => {
+  test("ready projected tools send immediately", async () => {
+    const coordinator = createCloudMcpSubmissionCoordinator();
+    const decision = requiredDecision();
+    let checks = 0;
+    let repairs = 0;
+    let runs = 0;
+    const result = await coordinator.submit({
+      scopeKey: decision.scopeKey,
+      prepare: preparation({
+        check: async () => {
+          checks += 1;
+          return health();
+        },
+        repair: async () => {
+          repairs += 1;
+          return health();
+        },
+      }),
+      send: async () => {
+        runs += 1;
+      },
+    });
+
+    expect(result).toEqual({ outcome: "sent", bypassed: false });
+    expect({ checks, repairs, runs }).toEqual({ checks: 1, repairs: 0, runs: 1 });
+  });
+
+  test("a transient startup failure repairs and sends exactly once", async () => {
+    const coordinator = createCloudMcpSubmissionCoordinator();
+    const decision = requiredDecision();
+    let repairs = 0;
+    let runs = 0;
+    const result = await coordinator.submit({
+      scopeKey: decision.scopeKey,
+      prepare: preparation({
+        check: async () => health({ usable: false, firstFailure: failure({ retryable: true }) }),
+        repair: async () => {
+          repairs += 1;
+          return health();
+        },
+      }),
+      send: async () => {
+        runs += 1;
+      },
+    });
+
+    expect(result).toEqual({ outcome: "sent", bypassed: false });
+    expect(repairs).toBe(1);
+    expect(runs).toBe(1);
+  });
+
+  test("a permanent injection failure creates no run and preserves the exact draft", async () => {
+    const coordinator = createCloudMcpSubmissionCoordinator();
+    const decision = requiredDecision();
+    const originalDraft = {
+      text: "Search my connected services",
+      attachments: [{ id: "attachment_1", name: "brief.pdf" }],
+    };
+    let storedDraft = originalDraft;
+    let runs = 0;
+    const result = await coordinator.submit({
+      scopeKey: decision.scopeKey,
+      prepare: preparation({
+        check: async () => health({
+          usable: false,
+          firstFailure: failure({
+            code: "provider_tool_projection_missing",
+            stage: "provider_projection",
+            retryable: false,
+            message: "The selected model is missing an injected Cloud tool.",
+          }),
+        }),
+        repair: async () => health(),
+      }),
+      send: async () => {
+        runs += 1;
+        storedDraft = { text: "", attachments: [] };
+      },
+    });
+
+    expect(result).toMatchObject({ outcome: "blocked", issue: { code: "provider_tool_projection_missing" } });
+    expect(runs).toBe(0);
+    expect(storedDraft).toEqual(originalDraft);
+  });
+
+  test("generic model tool-calling support is never accepted as projection proof", async () => {
+    const coordinator = createCloudMcpSubmissionCoordinator();
+    const decision = requiredDecision();
+    let runs = 0;
+    const result = await coordinator.submit({
+      scopeKey: decision.scopeKey,
+      prepare: preparation({
+        check: async () => health({ projectionSource: "provider_capability" }),
+        repair: async () => health(),
+      }),
+      send: async () => {
+        runs += 1;
+      },
+    });
+
+    expect(result).toMatchObject({ outcome: "blocked", issue: { code: "provider_tool_projection_unverified" } });
+    expect(runs).toBe(0);
+  });
+
+  test("repeated clicks share one queued submission and cannot duplicate the send", async () => {
+    const coordinator = createCloudMcpSubmissionCoordinator();
+    const decision = requiredDecision();
+    let release: ((result: CloudMcpSubmissionPreparationResult) => void) | null = null;
+    const pending = new Promise<CloudMcpSubmissionPreparationResult>((resolve) => {
+      release = resolve;
+    });
+    let runs = 0;
+    const input = {
+      scopeKey: decision.scopeKey,
+      prepare: () => pending,
+      send: async () => {
+        runs += 1;
+      },
+    };
+
+    const first = coordinator.submit(input);
+    const second = coordinator.submit(input);
+    expect(second).toBe(first);
+    release?.({ outcome: "ready" });
+    await Promise.all([first, second]);
+    expect(runs).toBe(1);
+  });
+
+  test("signed-out and explicitly disabled or removed Cloud bypass readiness entirely", async () => {
+    const coordinator = createCloudMcpSubmissionCoordinator();
+    let preparations = 0;
+    let runs = 0;
+    for (const decision of [
+      requiredDecision({ signedIn: false }),
+      requiredDecision({ userState: "disabled" }),
+      requiredDecision({ userState: "removed" }),
+    ]) {
+      await coordinator.submit({
+        scopeKey: decision.scopeKey,
+        ...(decision.mode === "required"
+          ? {
+              prepare: async () => {
+                preparations += 1;
+                return { outcome: "ready" };
+              },
+            }
+          : {}),
+        send: async () => {
+          runs += 1;
+        },
+      });
+    }
+
+    expect(preparations).toBe(0);
+    expect(runs).toBe(3);
+  });
+
+  test("workspace or model changes cannot release an old queued message", async () => {
+    const coordinator = createCloudMcpSubmissionCoordinator();
+    const original = requiredDecision({ workspaceId: "workspace_a", model: "gpt-5" });
+    const replacement = requiredDecision({ workspaceId: "workspace_b", model: "gpt-5-mini" });
+    let releaseOriginal: ((result: CloudMcpSubmissionPreparationResult) => void) | null = null;
+    const originalPreparation = new Promise<CloudMcpSubmissionPreparationResult>((resolve) => {
+      releaseOriginal = resolve;
+    });
+    const sentContexts: string[] = [];
+
+    const originalResult = coordinator.submit({
+      scopeKey: original.scopeKey,
+      prepare: () => originalPreparation,
+      send: async () => {
+        sentContexts.push("workspace_a/gpt-5");
+      },
+    });
+    const replacementResult = coordinator.submit({
+      scopeKey: replacement.scopeKey,
+      prepare: async () => ({ outcome: "ready" }),
+      send: async () => {
+        sentContexts.push("workspace_b/gpt-5-mini");
+      },
+    });
+    releaseOriginal?.({ outcome: "ready" });
+
+    await expect(originalResult).resolves.toEqual({ outcome: "cancelled", reason: "context_changed" });
+    await expect(replacementResult).resolves.toEqual({ outcome: "sent", bypassed: false });
+    expect(sentContexts).toEqual(["workspace_b/gpt-5-mini"]);
+  });
+});

--- a/apps/app/tests/session-mcp-maintenance.test.ts
+++ b/apps/app/tests/session-mcp-maintenance.test.ts
@@ -10,6 +10,7 @@ import {
 import { cleanupOpenworkCloudMcpAfterSignOut } from "../src/react-app/domains/connections/cloud-mcp-reconciler";
 import {
   getSessionMcpMaintenanceTargetKey,
+  runCloudMcpMaintenanceWithRetry,
   runSessionMcpMaintenanceTask,
   syncCloudControlMcpInBackground,
 } from "../src/react-app/domains/connections/use-session-mcp-maintenance";
@@ -78,6 +79,16 @@ function cloudHealth(usable: boolean): OpenworkCloudMcpHealth {
   };
 }
 
+function retryableCloudHealth(): OpenworkCloudMcpHealth {
+  const health = cloudHealth(false);
+  return {
+    ...health,
+    firstFailure: health.firstFailure
+      ? { ...health.firstFailure, retryable: true }
+      : null,
+  };
+}
+
 function installStorageStub() {
   const values = new Map<string, string>();
   __setCloudMcpUserStateStorageForTest({
@@ -112,7 +123,7 @@ describe("session MCP maintenance", () => {
       settings: SETTINGS,
       now: NOW,
       mintToken: async () => MINTED,
-    })).resolves.toBe("synced");
+    })).resolves.toMatchObject({ outcome: "ready", status: "synced" });
 
     expect(writes).toEqual([{
       workspaceId: WORKSPACE_ID,
@@ -149,6 +160,56 @@ describe("session MCP maintenance", () => {
       workspaceId: WORKSPACE_ID,
       expiresAt: MINTED.expiresAt,
     });
+  });
+
+  test("keeps a retryable injection failure visible until a bounded retry restores the tools", async () => {
+    let reconcileCount = 0;
+    const waits: number[] = [];
+    const attempts: Array<{ outcome: string; attempt: number; willRetry: boolean }> = [];
+    const client = {
+      baseUrl: "https://worker.openwork.test",
+      listMcp: async () => ({
+        items: [{
+          name: "openwork-cloud",
+          config: { type: "remote", enabled: true, url: "https://api.openwork.test/mcp/agent" },
+        }],
+      }),
+      getOpenworkCloudMcpHealth: async () => retryableCloudHealth(),
+      reconcileOpenworkCloudMcp: async () => {
+        reconcileCount += 1;
+        return reconcileCount === 3 ? cloudHealth(true) : retryableCloudHealth();
+      },
+    };
+
+    const result = await runCloudMcpMaintenanceWithRetry({
+      attempt: () => syncCloudControlMcpInBackground({
+        client,
+        workspaceId: WORKSPACE_ID,
+        settings: SETTINGS,
+        now: NOW,
+        mintToken: async () => MINTED,
+      }),
+      retryDelaysMs: [25, 50],
+      wait: async (delayMs) => {
+        waits.push(delayMs);
+      },
+      onAttempt: (attempt) => {
+        attempts.push({
+          outcome: attempt.result.outcome,
+          attempt: attempt.attempt,
+          willRetry: attempt.willRetry,
+        });
+      },
+    });
+
+    expect(result).toMatchObject({ outcome: "ready", status: "synced" });
+    expect(reconcileCount).toBe(3);
+    expect(waits).toEqual([25, 50]);
+    expect(attempts).toEqual([
+      { outcome: "failed", attempt: 1, willRetry: true },
+      { outcome: "failed", attempt: 2, willRetry: true },
+      { outcome: "ready", attempt: 3, willRetry: false },
+    ]);
   });
 
   test("a fresh per-workspace marker prevents repeated token and config writes", async () => {
@@ -190,7 +251,7 @@ describe("session MCP maintenance", () => {
         mintCount += 1;
         return MINTED;
       },
-    })).resolves.toBe("unchanged");
+    })).resolves.toMatchObject({ outcome: "ready", status: "unchanged" });
     expect(mintCount).toBe(0);
     expect(writeCount).toBe(0);
   });
@@ -229,21 +290,21 @@ describe("session MCP maintenance", () => {
       settings: SETTINGS,
       now: NOW,
       mintToken,
-    })).resolves.toBe("synced");
+    })).resolves.toMatchObject({ outcome: "ready", status: "synced" });
     await expect(syncCloudControlMcpInBackground({
       client,
       workspaceId: "workspace_b",
       settings: SETTINGS,
       now: NOW,
       mintToken,
-    })).resolves.toBe("synced");
+    })).resolves.toMatchObject({ outcome: "ready", status: "synced" });
     await expect(syncCloudControlMcpInBackground({
       client,
       workspaceId: "workspace_a",
       settings: SETTINGS,
       now: NOW + 1_000,
       mintToken,
-    })).resolves.toBe("unchanged");
+    })).resolves.toMatchObject({ outcome: "ready", status: "unchanged" });
 
     expect(mintCount).toBe(2);
     expect(writes).toEqual(["workspace_a", "workspace_b"]);
@@ -315,7 +376,7 @@ describe("session MCP maintenance", () => {
       workspaceId: WORKSPACE_ID,
       settings: SETTINGS,
       mintToken: async () => MINTED,
-    })).resolves.toBe("skipped");
+    })).resolves.toEqual({ outcome: "skipped", status: "skipped", reason: "disabled", health: null });
     expect(listed).toBe(false);
   });
 

--- a/apps/app/tests/session-mcp-maintenance.test.ts
+++ b/apps/app/tests/session-mcp-maintenance.test.ts
@@ -4,6 +4,7 @@ import type { DenMcpToken, DenSettings } from "../src/app/lib/den";
 import type { OpenworkCloudMcpHealth, OpenworkCloudMcpReconcilePayload } from "../src/app/lib/openwork-server";
 import {
   __setCloudMcpUserStateStorageForTest,
+  readCloudMcpUserState,
   readCloudMcpSyncMarker,
   writeCloudMcpUserState,
 } from "../src/react-app/domains/connections/cloud-mcp-user-state";
@@ -96,6 +97,7 @@ function installStorageStub() {
     setItem: (key, value) => values.set(key, value),
     removeItem: (key) => values.delete(key),
   });
+  return values;
 }
 
 afterAll(() => {
@@ -354,7 +356,7 @@ describe("session MCP maintenance", () => {
     expect(writes).toEqual([workerA.baseUrl, workerB.baseUrl]);
   });
 
-  test("explicit removal keeps background maintenance disabled", async () => {
+  test("a genuinely removed Cloud entry keeps background maintenance disabled", async () => {
     writeCloudMcpUserState("removed", {
       denBaseUrl: SETTINGS.baseUrl,
       serverBaseUrl: "https://worker.openwork.test",
@@ -377,7 +379,145 @@ describe("session MCP maintenance", () => {
       settings: SETTINGS,
       mintToken: async () => MINTED,
     })).resolves.toEqual({ outcome: "skipped", status: "skipped", reason: "disabled", health: null });
-    expect(listed).toBe(false);
+    expect(listed).toBe(true);
+  });
+
+  test("enabled Cloud config clears stale legacy removed intent and repairs", async () => {
+    const backing = installStorageStub();
+    backing.set("openwork.den.mcp.cloudControlUserState", "removed");
+    const scope = {
+      denBaseUrl: SETTINGS.baseUrl,
+      serverBaseUrl: "https://worker.openwork.test",
+      orgId: SETTINGS.activeOrgId ?? "",
+      workspaceId: WORKSPACE_ID,
+    };
+    let mintCount = 0;
+
+    const result = await syncCloudControlMcpInBackground({
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        listMcp: async () => ({
+          items: [{
+            name: "openwork-cloud",
+            config: { type: "remote", enabled: true, url: "https://api.openwork.test/mcp/agent" },
+          }],
+        }),
+        getOpenworkCloudMcpHealth: async () => cloudHealth(false),
+        reconcileOpenworkCloudMcp: async () => cloudHealth(true),
+      },
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      mintToken: async () => {
+        mintCount += 1;
+        return MINTED;
+      },
+    });
+
+    expect(result).toMatchObject({ outcome: "ready", status: "synced" });
+    expect(mintCount).toBe(1);
+    expect(readCloudMcpUserState(scope)).toBeNull();
+  });
+
+  test("an explicitly disabled Cloud config remains disabled", async () => {
+    const scope = {
+      denBaseUrl: SETTINGS.baseUrl,
+      serverBaseUrl: "https://worker.openwork.test",
+      orgId: SETTINGS.activeOrgId ?? "",
+      workspaceId: WORKSPACE_ID,
+    };
+    writeCloudMcpUserState("disabled", scope);
+
+    await expect(syncCloudControlMcpInBackground({
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        listMcp: async () => ({
+          items: [{
+            name: "openwork-cloud",
+            config: { type: "remote", enabled: false, url: "https://api.openwork.test/mcp/agent" },
+          }],
+        }),
+        getOpenworkCloudMcpHealth: async () => cloudHealth(false),
+        reconcileOpenworkCloudMcp: async () => cloudHealth(true),
+      },
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      mintToken: async () => MINTED,
+    })).resolves.toEqual({ outcome: "skipped", status: "skipped", reason: "disabled", health: null });
+    expect(readCloudMcpUserState(scope)).toBe("disabled");
+  });
+
+  test("observes localStorage intent changes without reloading the module", async () => {
+    const backing = installStorageStub();
+    backing.set("openwork.den.mcp.cloudControlUserState", "removed");
+    let mintCount = 0;
+    const client = {
+      baseUrl: "https://worker.openwork.test",
+      listMcp: async () => ({ items: [] }),
+      getOpenworkCloudMcpHealth: async () => cloudHealth(false),
+      reconcileOpenworkCloudMcp: async () => cloudHealth(true),
+    };
+
+    await expect(syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      mintToken: async () => {
+        mintCount += 1;
+        return MINTED;
+      },
+    })).resolves.toMatchObject({ outcome: "skipped", reason: "disabled" });
+
+    backing.delete("openwork.den.mcp.cloudControlUserState");
+    await expect(syncCloudControlMcpInBackground({
+      client,
+      workspaceId: WORKSPACE_ID,
+      settings: SETTINGS,
+      mintToken: async () => {
+        mintCount += 1;
+        return MINTED;
+      },
+    })).resolves.toMatchObject({ outcome: "ready", status: "synced" });
+    expect(mintCount).toBe(1);
+  });
+
+  test("token mint failure remains actionable after bounded retry exhaustion", async () => {
+    const attempts: Array<{ attempt: number; willRetry: boolean; code: string | null }> = [];
+    const client = {
+      baseUrl: "https://worker.openwork.test",
+      listMcp: async () => ({ items: [] }),
+      getOpenworkCloudMcpHealth: async () => cloudHealth(false),
+      reconcileOpenworkCloudMcp: async () => cloudHealth(true),
+    };
+
+    const result = await runCloudMcpMaintenanceWithRetry({
+      attempt: () => syncCloudControlMcpInBackground({
+        client,
+        workspaceId: WORKSPACE_ID,
+        settings: SETTINGS,
+        mintToken: async () => null,
+      }),
+      retryDelaysMs: [0],
+      wait: async () => {},
+      onAttempt: ({ result: attemptResult, attempt, willRetry }) => {
+        attempts.push({
+          attempt,
+          willRetry,
+          code: attemptResult.outcome === "failed" ? attemptResult.issue.code : null,
+        });
+      },
+    });
+
+    expect(result).toMatchObject({
+      outcome: "failed",
+      issue: {
+        code: "cloud_mcp_token_mint_failed",
+        recommendedAction: "Retry, then open Settings → Connect if the problem continues.",
+      },
+    });
+    expect(attempts).toEqual([
+      { attempt: 1, willRetry: true, code: "cloud_mcp_token_mint_failed" },
+      { attempt: 2, willRetry: false, code: "cloud_mcp_token_mint_failed" },
+    ]);
   });
 
   test("pre-signout cleanup removes runtime MCP and disconnects the exact active workspace before resolving", async () => {

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -11,6 +11,7 @@ import type { ServerConfig, WorkspaceInfo } from "./types.js";
 import { validateMcpConfig } from "./validators.js";
 
 export const OPENWORK_CLOUD_MCP_NAME = "openwork-cloud";
+export const LEGACY_OPENWORK_ADMIN_MCP_NAME = "openwork-admin";
 export const OPENWORK_CLOUD_EXPECTED_TOOLS = [
   "openwork-cloud_search_capabilities",
   "openwork-cloud_execute_capability",
@@ -135,6 +136,12 @@ export type CloudMcpRuntimeRegistrar = (
   onlyNames?: string[],
   options?: { throwOnFailure?: boolean },
 ) => Promise<CloudMcpRuntimeRegistrationResult>;
+
+export type CloudMcpLegacyRuntimeCleaner = (
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  name: typeof LEGACY_OPENWORK_ADMIN_MCP_NAME,
+) => Promise<void>;
 
 export type CloudMcpServerMetadata = {
   serverVersion?: string;
@@ -1905,14 +1912,16 @@ export async function readOpenworkCloudMcpHealth(input: {
   };
 }
 
-async function persistDesiredConfig(config: ServerConfig, workspaceId: string, desiredConfig: Record<string, unknown>): Promise<void> {
-  await writeRuntimeOpencodeConfig(config, workspaceId, (current) => ({
-    ...current,
-    mcp: {
-      ...runtimeMcpMap(current),
-      [OPENWORK_CLOUD_MCP_NAME]: desiredConfig,
-    },
-  }));
+async function persistDesiredConfig(config: ServerConfig, workspaceId: string, desiredConfig: Record<string, unknown>): Promise<boolean> {
+  let legacyAdminRemoved = false;
+  await writeRuntimeOpencodeConfig(config, workspaceId, (current) => {
+    const mcp = { ...runtimeMcpMap(current) };
+    legacyAdminRemoved = Object.hasOwn(mcp, LEGACY_OPENWORK_ADMIN_MCP_NAME);
+    delete mcp[LEGACY_OPENWORK_ADMIN_MCP_NAME];
+    mcp[OPENWORK_CLOUD_MCP_NAME] = desiredConfig;
+    return { ...current, mcp };
+  });
+  return legacyAdminRemoved;
 }
 
 function registrationFailure(failures: CloudMcpRuntimeRegistrationFailure[]): CloudMcpFailure {
@@ -1973,6 +1982,7 @@ export async function reconcileOpenworkCloudMcp(input: {
   serverMetadata?: CloudMcpServerMetadata;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   registerRuntimeMcp: CloudMcpRuntimeRegistrar;
+  cleanupLegacyRuntimeMcp?: CloudMcpLegacyRuntimeCleaner;
 }): Promise<CloudMcpHealth> {
   const configBody = input.body.config ?? input.body;
   const desiredConfig = canonicalizeCloudMcpConfig(normalizeCloudMcpConfig(configBody));
@@ -1983,7 +1993,10 @@ export async function reconcileOpenworkCloudMcp(input: {
     return healthWithFailure(await readOpenworkCloudMcpHealth(input), validationFailure);
   }
   const desiredRevision = calculateCloudMcpDesiredRevision(desiredConfig, metadata);
-  await persistDesiredConfig(input.config, input.workspace.id, desiredConfig);
+  const legacyAdminRemoved = await persistDesiredConfig(input.config, input.workspace.id, desiredConfig);
+  if (legacyAdminRemoved) {
+    await input.cleanupLegacyRuntimeMcp?.(input.config, input.workspace, LEGACY_OPENWORK_ADMIN_MCP_NAME);
+  }
   cloudMcpDeliveryState.markDesired(input.workspace, input.directory, desiredRevision, metadata);
 
   if (!input.directory) {
@@ -2043,6 +2056,7 @@ export async function reconcilePersistedOpenworkCloudMcp(input: {
   serverMetadata?: CloudMcpServerMetadata;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   registerRuntimeMcp: CloudMcpRuntimeRegistrar;
+  cleanupLegacyRuntimeMcp?: CloudMcpLegacyRuntimeCleaner;
   trigger?: string;
 }): Promise<CloudMcpHealth> {
   const runtimeConfig = await readRuntimeOpencodeConfig(input.config, input.workspace.id);

--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -79,6 +79,9 @@ function startMockOpencode(options: MockOpencodeOptions = {}) {
         return Response.json({ healthy: true, version: "1.17.11" });
       }
       if (url.pathname === "/instance/dispose") return Response.json({ disposed: true });
+      if (url.pathname === "/mcp/openwork-admin/disconnect" && request.method === "POST") {
+        return Response.json({ disconnected: true });
+      }
       if (url.pathname === "/mcp" && request.method === "POST") {
         if (options.postFailure) return Response.json(options.postFailure.body, { status: options.postFailure.status });
         registerCount += 1;
@@ -291,6 +294,43 @@ describe("openwork-cloud MCP strict reconcile", () => {
     const mcpPosts = mock.requests.filter((request) => request.method === "POST" && request.pathname === "/mcp");
     expect(mcpPosts.length).toBe(1);
     expect(mcpPosts[0]?.search).toContain(`directory=${encodeURIComponent(root)}`);
+  });
+
+  test("removes retired openwork-admin config before engine sync and never reintroduces it", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode();
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
+      ...current,
+      mcp: {
+        ...current.mcp,
+        "openwork-admin": {
+          type: "remote",
+          enabled: true,
+          url: "https://api.openwork.test/mcp/admin",
+          headers: { Authorization: "Bearer expired-token" },
+          oauth: false,
+        },
+      },
+    }));
+
+    expect((await responseRecord(await reconcile(openwork.base))).phase).toBe("ready");
+    const firstRuntime = await readRuntimeOpencodeConfig(openwork.config, "ws_1");
+    expect(firstRuntime.mcp?.["openwork-admin"]).toBeUndefined();
+    expect(firstRuntime.mcp?.["openwork-cloud"]).toBeDefined();
+
+    expect((await responseRecord(await reconcile(openwork.base))).phase).toBe("ready");
+    const secondRuntime = await readRuntimeOpencodeConfig(openwork.config, "ws_1");
+    expect(secondRuntime.mcp?.["openwork-admin"]).toBeUndefined();
+    expect(mock.requests.some((request) => (
+      request.method === "POST" && request.pathname === "/mcp/openwork-admin/disconnect"
+    ))).toBe(true);
+    expect(mock.requests.some((request) => (
+      request.method === "POST"
+      && request.pathname === "/mcp"
+      && isRecord(request.body)
+      && request.body.name === "openwork-admin"
+    ))).toBe(false);
   });
 
   test("rejects malformed desired config without persisting or registering it", async () => {

--- a/apps/server/src/routes/cloud-mcp.ts
+++ b/apps/server/src/routes/cloud-mcp.ts
@@ -3,6 +3,7 @@ import {
   OPENWORK_CLOUD_MCP_NAME,
   readOpenworkCloudMcpHealth,
   reconcileOpenworkCloudMcp,
+  type CloudMcpLegacyRuntimeCleaner,
   type CloudMcpServerMetadata,
   type CloudMcpProviderModelContext,
   type CloudMcpRuntimeRegistrar,
@@ -26,6 +27,7 @@ export type RegisterCloudMcpRoutesOptions = {
   resolveOpencodeDirectory: (workspace: WorkspaceInfo) => string | null;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   registerRuntimeMcp: CloudMcpRuntimeRegistrar;
+  cleanupLegacyRuntimeMcp?: CloudMcpLegacyRuntimeCleaner;
   serverMetadata?: CloudMcpServerMetadata;
 };
 
@@ -81,6 +83,7 @@ export function registerCloudMcpRoutes(options: RegisterCloudMcpRoutesOptions): 
     resolveOpencodeDirectory,
     createWorkspaceOpencodeClient,
     registerRuntimeMcp,
+    cleanupLegacyRuntimeMcp,
     serverMetadata,
   } = options;
 
@@ -117,6 +120,7 @@ export function registerCloudMcpRoutes(options: RegisterCloudMcpRoutesOptions): 
       serverMetadata,
       createWorkspaceOpencodeClient,
       registerRuntimeMcp,
+      cleanupLegacyRuntimeMcp,
     });
     return jsonResponse(health);
   });

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -64,7 +64,11 @@ import { addRoute, matchRoute, type AuthMode, type RequestContext, type Route } 
 import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
 import { registerCloudMcpRoutes } from "./routes/cloud-mcp.js";
-import { markOpenworkCloudMcpStale, reconcilePersistedOpenworkCloudMcp } from "./cloud-mcp-health.js";
+import {
+  markOpenworkCloudMcpStale,
+  reconcilePersistedOpenworkCloudMcp,
+  type CloudMcpHealth,
+} from "./cloud-mcp-health.js";
 import { runAgentContextDiagnostics } from "./agent-context-diagnostics.js";
 import { createAgentDiagnosticsEngineFetch } from "./agent-context-engine-inspection.js";
 import {
@@ -3210,29 +3214,38 @@ async function reloadOpencodeEngine(
   // configs (including the server-managed runtime config file for the
   // primary workspace), but other workspaces' runtime MCPs only reach the
   // engine through this dynamic push.
-  await syncRuntimeMcpToOpencodeEngine(
-    config,
-    workspace,
-    undefined,
-    undefined,
-    activeState ?? null,
-  ).catch(() => undefined);
-  await reconcilePersistedOpenworkCloudMcp({
-    config,
-    workspace,
-    directory,
-    serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
-    createWorkspaceOpencodeClient,
-    registerRuntimeMcp: (routeConfig, routeWorkspace, onlyNames, options) =>
-      syncRuntimeMcpToOpencodeEngine(
-        routeConfig,
-        routeWorkspace,
-        onlyNames,
-        options,
-        activeState ?? null,
-      ),
-    trigger: "engine_reload",
-  }).catch(() => undefined);
+  try {
+    await syncRuntimeMcpToOpencodeEngine(
+      config,
+      workspace,
+      undefined,
+      undefined,
+      activeState ?? null,
+    );
+  } catch (error) {
+    logRuntimeMcpSyncError({ config, workspace, trigger: "engine_reload", error });
+  }
+  try {
+    const health = await reconcilePersistedOpenworkCloudMcp({
+      config,
+      workspace,
+      directory,
+      serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
+      createWorkspaceOpencodeClient,
+      registerRuntimeMcp: (routeConfig, routeWorkspace, onlyNames, options) =>
+        syncRuntimeMcpToOpencodeEngine(
+          routeConfig,
+          routeWorkspace,
+          onlyNames,
+          options,
+          activeState ?? null,
+        ),
+      trigger: "engine_reload",
+    });
+    logPersistedCloudMcpReconcileResult({ config, workspace, trigger: "engine_reload", health });
+  } catch (error) {
+    logPersistedCloudMcpReconcileError({ config, workspace, trigger: "engine_reload", error });
+  }
 }
 
 // Push runtime-DB MCP entries into the running OpenCode engine via its dynamic
@@ -3897,6 +3910,66 @@ function deleteEngineMcpRegistration(
   state.registrationByWorkspace.get(workspace.id)?.delete(name);
 }
 
+function logPersistedCloudMcpReconcileResult(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  trigger: "startup" | "engine_reload";
+  health: CloudMcpHealth;
+}): void {
+  if (!input.health.desired.present || input.health.usable) return;
+  const failure = input.health.firstFailure;
+  createServerLogger(input.config).log(
+    "warn",
+    `Cloud MCP ${input.trigger} reconciliation left connected service tools unavailable for workspace ${input.workspace.id}.`,
+    {
+      "workspace.id": input.workspace.id,
+      "mcp.name": "openwork-cloud",
+      "mcp.trigger": input.trigger,
+      "mcp.failure.code": failure?.code ?? "unknown",
+      "mcp.failure.stage": failure?.stage ?? "unknown",
+      "mcp.failure.retryable": failure?.retryable ?? null,
+      "mcp.failure.message": failure?.message ?? "Cloud MCP health remained unusable after reconciliation.",
+    },
+  );
+}
+
+function logRuntimeMcpSyncError(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  trigger: "startup" | "engine_reload";
+  error: unknown;
+}): void {
+  createServerLogger(input.config).log(
+    "error",
+    `Runtime MCP ${input.trigger} sync crashed for workspace ${input.workspace.id}.`,
+    {
+      "workspace.id": input.workspace.id,
+      "mcp.trigger": input.trigger,
+      "mcp.failure.code": "runtime_mcp_sync_exception",
+      "mcp.failure.message": input.error instanceof Error ? input.error.message : String(input.error),
+    },
+  );
+}
+
+function logPersistedCloudMcpReconcileError(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  trigger: "startup" | "engine_reload";
+  error: unknown;
+}): void {
+  createServerLogger(input.config).log(
+    "error",
+    `Cloud MCP ${input.trigger} reconciliation crashed for workspace ${input.workspace.id}.`,
+    {
+      "workspace.id": input.workspace.id,
+      "mcp.name": "openwork-cloud",
+      "mcp.trigger": input.trigger,
+      "mcp.failure.code": "cloud_mcp_reconcile_exception",
+      "mcp.failure.message": input.error instanceof Error ? input.error.message : String(input.error),
+    },
+  );
+}
+
 // Re-push every workspace's runtime-DB MCPs into the engine. Used at startup:
 // the runtime config file injected via OPENCODE_CONFIG covers workspaces[0]
 // only, so other workspaces' runtime MCPs are invisible to the engine until
@@ -3904,29 +3977,38 @@ function deleteEngineMcpRegistration(
 export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig): Promise<void> {
   const serverState = activeEngineMcpServerState(config) ?? null;
   for (const workspace of config.workspaces) {
-    await syncRuntimeMcpToOpencodeEngine(
-      config,
-      workspace,
-      undefined,
-      undefined,
-      serverState,
-    ).catch(() => undefined);
-    await reconcilePersistedOpenworkCloudMcp({
-      config,
-      workspace,
-      directory: resolveOpencodeDirectory(workspace),
-      serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
-      createWorkspaceOpencodeClient,
-      registerRuntimeMcp: (routeConfig, routeWorkspace, onlyNames, options) =>
-        syncRuntimeMcpToOpencodeEngine(
-          routeConfig,
-          routeWorkspace,
-          onlyNames,
-          options,
-          serverState,
-        ),
-      trigger: "startup",
-    }).catch(() => undefined);
+    try {
+      await syncRuntimeMcpToOpencodeEngine(
+        config,
+        workspace,
+        undefined,
+        undefined,
+        serverState,
+      );
+    } catch (error) {
+      logRuntimeMcpSyncError({ config, workspace, trigger: "startup", error });
+    }
+    try {
+      const health = await reconcilePersistedOpenworkCloudMcp({
+        config,
+        workspace,
+        directory: resolveOpencodeDirectory(workspace),
+        serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
+        createWorkspaceOpencodeClient,
+        registerRuntimeMcp: (routeConfig, routeWorkspace, onlyNames, options) =>
+          syncRuntimeMcpToOpencodeEngine(
+            routeConfig,
+            routeWorkspace,
+            onlyNames,
+            options,
+            serverState,
+          ),
+        trigger: "startup",
+      });
+      logPersistedCloudMcpReconcileResult({ config, workspace, trigger: "startup", health });
+    } catch (error) {
+      logPersistedCloudMcpReconcileError({ config, workspace, trigger: "startup", error });
+    }
   }
 }
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -65,6 +65,7 @@ import { registerSessionRoutes } from "./routes/sessions.js";
 import { registerWorkspaceRoutes } from "./routes/workspaces.js";
 import { registerCloudMcpRoutes } from "./routes/cloud-mcp.js";
 import {
+  LEGACY_OPENWORK_ADMIN_MCP_NAME,
   markOpenworkCloudMcpStale,
   reconcilePersistedOpenworkCloudMcp,
   type CloudMcpHealth,
@@ -1486,6 +1487,8 @@ function createRoutes(
         options,
         engineMcpServerState,
       ),
+    cleanupLegacyRuntimeMcp: (routeConfig, workspace, name) =>
+      cleanupRetiredRuntimeMcp(routeConfig, workspace, name, engineMcpServerState),
     serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
   });
 
@@ -3240,6 +3243,8 @@ async function reloadOpencodeEngine(
           options,
           activeState ?? null,
         ),
+      cleanupLegacyRuntimeMcp: (routeConfig, routeWorkspace, name) =>
+        cleanupRetiredRuntimeMcp(routeConfig, routeWorkspace, name, activeState ?? null),
       trigger: "engine_reload",
     });
     logPersistedCloudMcpReconcileResult({ config, workspace, trigger: "engine_reload", health });
@@ -3270,7 +3275,17 @@ async function syncRuntimeMcpToOpencodeEngine(
     return { status: "skipped", syncedNames: [], failures: [] };
   }
 
-  const runtimeConfig = await readRuntimeOpencodeConfig(config, workspace.id);
+  let runtimeConfig = await readRuntimeOpencodeConfig(config, workspace.id);
+  if (Object.hasOwn(runtimeMcpMap(runtimeConfig), LEGACY_OPENWORK_ADMIN_MCP_NAME)) {
+    await removeMcp(config, workspace.id, LEGACY_OPENWORK_ADMIN_MCP_NAME);
+    await cleanupRetiredRuntimeMcp(
+      config,
+      workspace,
+      LEGACY_OPENWORK_ADMIN_MCP_NAME,
+      activeState ?? null,
+    );
+    runtimeConfig = await readRuntimeOpencodeConfig(config, workspace.id);
+  }
   const entries = Object.entries(runtimeMcpMap(runtimeConfig)).filter(
     ([name]) => !onlyNames || onlyNames.includes(name),
   );
@@ -4003,6 +4018,8 @@ export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig):
             options,
             serverState,
           ),
+        cleanupLegacyRuntimeMcp: (routeConfig, routeWorkspace, name) =>
+          cleanupRetiredRuntimeMcp(routeConfig, routeWorkspace, name, serverState),
         trigger: "startup",
       });
       logPersistedCloudMcpReconcileResult({ config, workspace, trigger: "startup", health });
@@ -4015,6 +4032,29 @@ export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig):
 // Counterpart of syncRuntimeMcpToOpencodeEngine for removals: tell the engine
 // to drop the MCP's client so deleted MCPs stop serving tools immediately
 // instead of lingering until the next engine restart. Best-effort.
+async function cleanupRetiredRuntimeMcp(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  name: typeof LEGACY_OPENWORK_ADMIN_MCP_NAME,
+  serverState?: EngineMcpServerState | null,
+): Promise<void> {
+  if (serverState) deleteEngineMcpRegistration(config, serverState, workspace, name);
+  try {
+    await disconnectMcpFromOpencodeEngine(config, workspace, name);
+  } catch (error) {
+    createServerLogger(config).log(
+      "warn",
+      `Retired MCP cleanup could not disconnect ${name} for workspace ${workspace.id}.`,
+      {
+        "workspace.id": workspace.id,
+        "mcp.name": name,
+        "mcp.trigger": "retired_mcp_cleanup",
+        "mcp.failure.code": error instanceof ApiError ? error.code : "retired_mcp_disconnect_failed",
+      },
+    );
+  }
+}
+
 async function disconnectMcpFromOpencodeEngine(
   config: ServerConfig,
   workspace: WorkspaceInfo,


### PR DESCRIPTION
> [!WARNING]
> **Review status (2026-07-17): supersede/reslice — do not merge this branch.**
>
> The incident is real, but the broad branch is stale and conflict-heavy. Most of its core protection is now present on `dev` through #2776, #2777, #2778, #2779, #2786, and #2829. The remaining behavior should be rebuilt as focused current-`dev` changes rather than resolving this branch wholesale.

## Independent review findings

- A stale maintenance snapshot can race with a fresh explicit **Disable** or removal and clear that newer intent, re-enabling a connection the user just turned off. Clearing legacy state needs a compare-and-set/revision guard and must only target the raw legacy marker.
- The branch can clear intent after health alone without proving that the repaired Cloud tools are actually usable.
- Cancellation must be rethrown rather than converted into retry/repair failure; otherwise later transport cancellation work will be swallowed here.
- Automatic retired-`openwork-admin` cleanup should only mutate the server-owned runtime source. Static/project/global entries must remain diagnostic-only.
- A failed engine disconnect is currently swallowed while configuration is removed, which can report readiness with a lingering live client.
- Token mint failures are attributed to the wrong diagnostic stage.
- The reported GitHub test failure is an unrelated 5 ms evidence-window flake; the same focused test passed 20/20 locally and does not validate this branch's incident behavior.

## Recommended path

Keep the merged incident protections, then add only the residual legacy-intent compare-and-set repair with a race regression test. Handle retired-admin cleanup separately. This PR remains useful as incident history, not as a merge candidate.

---

Depends on #2779.

This follow-up prevents an expired seven-day OpenWork Cloud MCP token from silently removing `search_capabilities` and `execute_capability`. PR #2779 protects message submission while tools are being prepared; this PR fixes the underlying repair loop so a stale desktop intent marker or the exact Den expiry error cannot permanently suppress token renewal.

## Confirmed incident

Ben desktop retained `openwork.den.mcp.cloudControlUserState = "removed"` while an enabled `openwork-cloud` configuration still existed. When the first-party opaque token expired after seven days, maintenance treated any stored state as a permanent opt-out. The health result then returned `invalid_mcp_token`, but the remint matcher neither recognized that exact code nor inspected `firstFailure.aliases`. OpenCode consequently dropped the MCP and its search and execution tools.

## What changed

- Recognize exact `invalid_mcp_token` failures and all canonical health aliases, while retaining the existing membership, scope, policy, and resource exclusions.
- Compare stored disabled or removed intent with the authoritative workspace MCP configuration before skipping maintenance.
  - Missing or disabled Cloud configuration still preserves explicit user intent.
  - Existing enabled Cloud configuration makes contradictory intent stale; OpenWork clears it, records a credential-free inspector event, and repairs the token.
- Read storage on every maintenance attempt so external changes are observed without a module reload or desktop restart.
- Return structured, actionable failures for configuration reads, token minting, reconciliation, bounded retry exhaustion, and authentication health failures. These flow into the Connect/session status UI added by #2779.
- Remove the retired `openwork-admin` runtime entry before engine registration, disconnect a lingering engine client, and never register it again. Static project or global entries are not silently rewritten; maintenance surfaces a safe removal action instead.
- Keep runtime `/mcp`, strict Cloud health, and direct tool checks authoritative. No `opencode.jsonc` timestamp inference was added.

## Verification

Passed:

- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter openwork-server typecheck`
- `bun test --isolate tests/cloud-mcp-submit-readiness.test.ts tests/connect-view.test.ts tests/builtin-mcp-visibility.test.ts tests/cloud-mcp-health.test.ts tests/session-mcp-maintenance.test.ts tests/cloud-mcp-user-state.test.ts` — 55 passed
- `bun test src/cloud-mcp-reconcile.e2e.test.ts` — 16 passed

The regressions cover exact and aliased token failures, stale legacy removed state with enabled Cloud config, genuine removal and disablement, live storage changes, actionable mint retry exhaustion, pre-send readiness compatibility, and retired admin cleanup without re-registration.

## Manual verification

Not run — the affected desktop is remote and a real seven-day token-aging cycle was not available locally. Ben incident bundle already confirms that clearing the stale state and restarting allowed a fresh token, an engine-connected `openwork-cloud`, and a successful real `search_capabilities` call.

Reviewer reproduction:

1. Seed an enabled `openwork-cloud` entry with stale legacy `cloudControlUserState = "removed"`.
2. Return `invalid_mcp_token` from strict Cloud health.
3. Trigger session maintenance or focus the app.
4. Confirm intent is cleared, a new token is minted, reconciliation runs once, and both Cloud tools remain available.
5. Remove or disable the Cloud entry explicitly and confirm maintenance does not recreate it.

## Security and risk

- Structured events contain workspace IDs, states, stages, retry flags, and failure codes only; no bearer tokens, Den session tokens, headers, URLs, or credentials are logged.
- The only automatic legacy deletion is the retired server-managed runtime name `openwork-admin`; user-owned static configuration is preserved and surfaced for manual action.
- This PR is intentionally stacked on #2779 and should remain draft until that readiness-gate PR finishes verification.