### PR TITLE
fix(connect): compare OAuth configuration semantically

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto"
+import { isDeepStrictEqual } from "node:util"
 import { and, desc, eq, inArray, isNull, or } from "@openwork-ee/den-db/drizzle"
 import {
   ConnectedAccountTable,
@@ -714,13 +715,14 @@ export async function updateExternalMcpConnection(
         isNull(PluginTable.deletedAt),
       ))
       .for("update")
+    const oauthConfigurationChanged = input.oauthConfiguration !== undefined
+      && !isDeepStrictEqual(existing.oauthConfiguration, input.oauthConfiguration)
     const marketplaceOwnedFieldsChanged = existing.url !== input.url
       || existing.authType !== input.authType
       || existing.credentialMode !== input.credentialMode
       || input.apiKey !== undefined
       || input.oauthClient !== undefined
-      || (input.oauthConfiguration !== undefined
-        && JSON.stringify(existing.oauthConfiguration) !== JSON.stringify(input.oauthConfiguration))
+      || oauthConfigurationChanged
     if (activeBindings.length > 0 && marketplaceOwnedFieldsChanged) {
       return { status: "marketplace_managed" }
     }
@@ -774,8 +776,7 @@ export async function updateExternalMcpConnection(
       || existing.credentialMode !== input.credentialMode
       || apiKeyChanged
       || identityChanged
-      || (input.oauthConfiguration !== undefined
-        && JSON.stringify(existing.oauthConfiguration) !== JSON.stringify(input.oauthConfiguration))
+      || oauthConfigurationChanged
     const changed = rowFieldsChanged || accessChanged || oauthClientChanged
 
     if (!changed) {

--- a/ee/apps/den-api/test/mcp-connections-edit.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-edit.test.ts
@@ -228,6 +228,20 @@ async function rawStoredApiKey(connectionId: string) {
   return row.api_key
 }
 
+function oauthConfigurationInApiOrder(
+  connection: Awaited<ReturnType<typeof currentConnection>>,
+) {
+  const configuration = connection.oauthConfiguration
+  if (!configuration) throw new Error("Expected an OAuth configuration")
+  return {
+    version: configuration.version,
+    authorizationServerIssuer: configuration.authorizationServerIssuer,
+    requestedScopes: [...configuration.requestedScopes],
+    callbackMode: configuration.callbackMode,
+    ...(configuration.discovery ? { discovery: configuration.discovery } : {}),
+  }
+}
+
 describe.serial("PUT /v1/mcp-connections/:connectionId", () => {
   test("rename preserves a connected shared OAuth session and client registration", async () => {
     const created = await createConnection({ name: "Shared OAuth", authType: "oauth", credentialMode: "shared" })
@@ -475,7 +489,7 @@ describe.serial("PUT /v1/mcp-connections/:connectionId", () => {
     expect(JSON.stringify(await responseRecord(agentResponse))).not.toContain("agent-secret-must-not-pass")
   })
 
-  test("marketplace bindings own identity while direct assignment edits preserve derived grants", async () => {
+  test("marketplace bindings protect identity without treating OAuth key order as a change", async () => {
     const connection = await createConnection({ name: "Marketplace MCP", authType: "oauth", credentialMode: "per_member" })
     const pluginId = createDenTypeId("plugin")
     const bindingId = createDenTypeId("pluginMcpRequirementBinding")
@@ -521,6 +535,8 @@ describe.serial("PUT /v1/mcp-connections/:connectionId", () => {
     expect(await responseRecord(blocked)).toMatchObject({ error: "marketplace_managed" })
 
     const fresh = await currentConnection(connection.id)
+    const apiOrderedConfiguration = oauthConfigurationInApiOrder(fresh)
+    expect(Object.keys(fresh.oauthConfiguration ?? {})).not.toEqual(Object.keys(apiOrderedConfiguration))
     const allowed = await humanRequest({
       connectionId: connection.id,
       body: updateBody(fresh, {
@@ -543,7 +559,7 @@ describe.serial("PUT /v1/mcp-connections/:connectionId", () => {
     expect(grants.some((grant) => grant.pluginMcpRequirementBindingId === null && grant.orgMembershipId === adminMemberId)).toBe(true)
   })
 
-  test("stale edits conflict, no-op edits stay connected, and old-identity writes are rejected", async () => {
+  test("stale edits conflict, OAuth key order stays a no-op, and old-identity writes are rejected", async () => {
     const connection = await createConnection({ name: "Concurrent OAuth", authType: "oauth", credentialMode: "per_member" })
     const first = await humanRequest({
       connectionId: connection.id,
@@ -559,6 +575,8 @@ describe.serial("PUT /v1/mcp-connections/:connectionId", () => {
     expect((await currentConnection(connection.id)).url).toBe(connection.url)
 
     const fresh = await currentConnection(connection.id)
+    const apiOrderedConfiguration = oauthConfigurationInApiOrder(fresh)
+    expect(Object.keys(fresh.oauthConfiguration ?? {})).not.toEqual(Object.keys(apiOrderedConfiguration))
     await oauthCredentials.upsertConnectedAccount({
       organizationId,
       orgMembershipId: memberId,


### PR DESCRIPTION
## Summary

- Compare persisted external MCP OAuth configuration semantically instead of comparing `JSON.stringify` output.
- Prevent equivalent MySQL JSON objects with different key order from being treated as authentication changes.
- Preserve marketplace-owned identity protection while allowing harmless name and direct-access edits.
- Keep true no-op edits from advancing `updatedAt` or disturbing connected credentials.

## Root cause

MySQL can return a JSON object with a different property order than the object reconstructed by the Den API. `JSON.stringify` is order-sensitive, so semantically identical OAuth configuration was classified as changed.

For marketplace-bound connections that produced a false `marketplace_managed` conflict. For ordinary connections it turned a no-op into a row update.

## Implementation

- Compute one semantic OAuth-configuration equality result with Node's `isDeepStrictEqual` and reuse it in marketplace ownership and row-change decisions.
- Strengthen the existing database-backed route tests to assert that stored and API OAuth configuration have different key order, then prove:
  - marketplace identity changes remain blocked while harmless edits succeed;
  - the same OAuth configuration remains a no-op and preserves the timestamp.

## Validation

- `pnpm --filter @openwork-ee/den-api... build` — passed.
- `pnpm --dir ee/apps/den-api exec bun test test/mcp-connections-edit.test.ts` — 10 passed, 0 failed.
- `git diff --check` — passed.

## Risk and scope

This is limited to Den-managed external MCP connection updates. Actual value changes, scope-array order changes, issuer changes, callback-mode changes, and discovery-state changes remain detectable. No HTTP contract, database schema, callback flow, credential format, or UI behavior is added or changed.

No separate UI recording was captured because this fixes an internal update decision without changing a visible flow; the isolated MySQL-backed route suite exercises the affected behavior directly.
