### PR TITLE
fix(mcp): hold startup sends until Cloud auth and search tools are ready

### DIFF
--- a/apps/app/src/react-app/domains/connections/cloud-mcp-submit-readiness.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-submit-readiness.ts
@@ -7,6 +7,7 @@ import type { CloudMcpUserState } from "./cloud-mcp-user-state";
 
 export const CLOUD_MCP_SUBMISSION_RETRY_DELAYS_MS = [1_000, 3_000];
 export const CLOUD_MCP_SUBMISSION_ATTEMPT_TIMEOUT_MS = 12_000;
+export const CLOUD_MCP_AUTH_RESOLUTION_TIMEOUT_MS = 12_000;
 
 const REQUIRED_DIRECT_TOOL_IDS = ["search_capabilities", "execute_capability"];
 const REQUIRED_PROJECTED_TOOL_IDS = [
@@ -20,7 +21,8 @@ export type CloudMcpSubmissionIssue = Pick<
 >;
 
 export type CloudMcpSubmissionGateContext = {
-  cloudSignedIn: boolean;
+  cloudAuthStatus: "checking" | "signed_in" | "unavailable" | "signed_out";
+  cloudHasSessionToken: boolean;
   denBaseUrl: string;
   serverBaseUrl: string;
   orgId: string | null;
@@ -31,6 +33,7 @@ export type CloudMcpSubmissionGateContext = {
 
 export type CloudMcpSubmissionGateDecision =
   | { mode: "required"; scopeKey: string }
+  | { mode: "waiting_for_auth"; scopeKey: string }
   | {
       mode: "bypass";
       scopeKey: string;
@@ -58,6 +61,10 @@ export type CloudMcpSubmissionPreparationResult =
   | { outcome: "bypass" }
   | { outcome: "failed"; issue: CloudMcpSubmissionIssue }
   | { outcome: "cancelled"; reason: "context_changed" | "unmounted" };
+
+export type CloudMcpSubmissionAuthResolution =
+  | { outcome: "resolved"; decision: CloudMcpSubmissionGateDecision }
+  | { outcome: "failed"; issue: CloudMcpSubmissionIssue };
 
 export type CloudMcpSubmissionResult =
   | { outcome: "sent"; bypassed: boolean }
@@ -122,8 +129,12 @@ function healthShowsExplicitDisable(health: OpenworkCloudMcpHealth): boolean {
 }
 
 export function cloudMcpSubmissionScopeKey(context: CloudMcpSubmissionGateContext): string {
+  const cloudSessionScope = context.cloudAuthStatus === "signed_out"
+    || (context.cloudAuthStatus === "checking" && !context.cloudHasSessionToken)
+    ? "signed_out"
+    : "cloud_session";
   return JSON.stringify([
-    context.cloudSignedIn ? "signed_in" : "signed_out",
+    cloudSessionScope,
     normalize(context.denBaseUrl),
     normalize(context.serverBaseUrl),
     normalize(context.orgId),
@@ -138,10 +149,58 @@ export function decideCloudMcpSubmissionGate(
   context: CloudMcpSubmissionGateContext,
 ): CloudMcpSubmissionGateDecision {
   const scopeKey = cloudMcpSubmissionScopeKey(context);
-  if (!context.cloudSignedIn) return { mode: "bypass", scopeKey, reason: "signed_out" };
+  if (
+    context.cloudAuthStatus === "signed_out"
+    || (context.cloudAuthStatus === "checking" && !context.cloudHasSessionToken)
+  ) {
+    return { mode: "bypass", scopeKey, reason: "signed_out" };
+  }
+  if (context.cloudAuthStatus === "checking") {
+    if (context.userState) return { mode: "bypass", scopeKey, reason: "disabled" };
+    return { mode: "waiting_for_auth", scopeKey };
+  }
   if (!context.orgId?.trim()) return { mode: "bypass", scopeKey, reason: "missing_org" };
   if (context.userState) return { mode: "bypass", scopeKey, reason: "disabled" };
   return { mode: "required", scopeKey };
+}
+
+function authResolutionIssue(input?: { timedOut?: boolean }): CloudMcpSubmissionIssue {
+  return genericSubmissionIssue({
+    code: input?.timedOut
+      ? "cloud_mcp_auth_resolution_timeout"
+      : "cloud_mcp_auth_resolution_failed",
+    message: input?.timedOut
+      ? "OpenWork timed out while restoring connected service access."
+      : "OpenWork could not finish restoring connected service access.",
+    recommendedAction: "Retry or open Settings → Connect.",
+  });
+}
+
+export async function resolveCloudMcpSubmissionAuth(
+  input: {
+    decision: CloudMcpSubmissionGateDecision;
+    waitForResolution: () => Promise<CloudMcpSubmissionGateDecision>;
+    timeoutMs?: number;
+  },
+): Promise<CloudMcpSubmissionAuthResolution> {
+  if (input.decision.mode !== "waiting_for_auth") {
+    return { outcome: "resolved", decision: input.decision };
+  }
+
+  try {
+    const decision = await withTimeout(
+      input.waitForResolution,
+      input.timeoutMs ?? CLOUD_MCP_AUTH_RESOLUTION_TIMEOUT_MS,
+    );
+    if (decision.mode === "waiting_for_auth") {
+      return { outcome: "failed", issue: authResolutionIssue() };
+    }
+    return { outcome: "resolved", decision };
+  } catch (error) {
+    const timedOut = error instanceof Error
+      && error.message === "cloud_mcp_submission_timeout";
+    return { outcome: "failed", issue: authResolutionIssue({ timedOut }) };
+  }
 }
 
 /**

--- a/apps/app/src/react-app/domains/connections/use-cloud-mcp-submit-readiness.ts
+++ b/apps/app/src/react-app/domains/connections/use-cloud-mcp-submit-readiness.ts
@@ -7,6 +7,7 @@ import type {
   OpenworkServerClient,
 } from "../../../app/lib/openwork-server";
 import { denSettingsChangedEvent } from "../../../app/lib/den-session-events";
+import type { DenAuthStatus } from "../cloud/den-auth-provider";
 import {
   normalizeCloudMcpScope,
   readCloudMcpUserState,
@@ -16,6 +17,8 @@ import {
   decideCloudMcpSubmissionGate,
   ensureCloudMcpSubmissionReadiness,
   IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE,
+  resolveCloudMcpSubmissionAuth,
+  type CloudMcpSubmissionGateDecision,
   type CloudMcpSubmissionGateState,
   type CloudMcpSubmissionIssue,
   type CloudMcpSubmissionPreparationResult,
@@ -31,7 +34,7 @@ type CloudMcpSubmitReadinessClient = Pick<
 >;
 
 type UseCloudMcpSubmitReadinessInput = {
-  cloudSignedIn: boolean;
+  cloudAuthStatus: DenAuthStatus;
   client: CloudMcpSubmitReadinessClient | null;
   workspaceId: string | null;
   providerModel?: OpenworkCloudMcpProviderModelContext;
@@ -87,7 +90,10 @@ export function useCloudMcpSubmitReadiness(
     IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE,
   );
   const coordinatorRef = useRef(createCloudMcpSubmissionCoordinator());
-  const settings = useMemo(() => readDenSettings(), [input.cloudSignedIn, settingsVersion]);
+  const authStatusRef = useRef(input.cloudAuthStatus);
+  const authWaitersRef = useRef(new Set<() => void>());
+  authStatusRef.current = input.cloudAuthStatus;
+  const settings = useMemo(() => readDenSettings(), [input.cloudAuthStatus, settingsVersion]);
   const workspaceId = input.workspaceId?.trim() ?? "";
   const serverBaseUrl = input.client?.baseUrl.trim() ?? "";
   const orgId = settings.activeOrgId?.trim() ?? "";
@@ -99,7 +105,8 @@ export function useCloudMcpSubmitReadiness(
   });
   const userState = scope ? readCloudMcpUserState(scope) : null;
   const decision = useMemo(() => decideCloudMcpSubmissionGate({
-    cloudSignedIn: input.cloudSignedIn,
+    cloudAuthStatus: input.cloudAuthStatus,
+    cloudHasSessionToken: Boolean(settings.authToken?.trim()),
     denBaseUrl: settings.baseUrl,
     serverBaseUrl,
     orgId: orgId || null,
@@ -107,11 +114,12 @@ export function useCloudMcpSubmitReadiness(
     providerModel: input.providerModel,
     userState,
   }), [
-    input.cloudSignedIn,
+    input.cloudAuthStatus,
     input.providerModel?.model,
     input.providerModel?.provider,
     orgId,
     serverBaseUrl,
+    settings.authToken,
     settings.baseUrl,
     userState,
     workspaceId,
@@ -119,6 +127,16 @@ export function useCloudMcpSubmitReadiness(
   const currentScopeKeyRef = useRef(decision.scopeKey);
   currentScopeKeyRef.current = decision.scopeKey;
   const previousScopeKeyRef = useRef(decision.scopeKey);
+  const gateSnapshot = {
+    cloudAuthStatus: input.cloudAuthStatus,
+    client: input.client,
+    decision,
+    providerModel: input.providerModel,
+    settings,
+    workspaceId,
+  };
+  const gateSnapshotRef = useRef(gateSnapshot);
+  gateSnapshotRef.current = gateSnapshot;
 
   useEffect(() => {
     if (typeof window === "undefined") return;
@@ -126,6 +144,13 @@ export function useCloudMcpSubmitReadiness(
     window.addEventListener(denSettingsChangedEvent, handleSettingsChanged);
     return () => window.removeEventListener(denSettingsChangedEvent, handleSettingsChanged);
   }, []);
+
+  useEffect(() => {
+    if (input.cloudAuthStatus === "checking") return;
+    const waiters = [...authWaitersRef.current];
+    authWaitersRef.current.clear();
+    for (const resolve of waiters) resolve();
+  }, [input.cloudAuthStatus]);
 
   useEffect(() => {
     if (previousScopeKeyRef.current === decision.scopeKey) return;
@@ -142,34 +167,91 @@ export function useCloudMcpSubmitReadiness(
 
   useEffect(() => () => {
     coordinatorRef.current.cancel("unmounted");
+    const waiters = [...authWaitersRef.current];
+    authWaitersRef.current.clear();
+    for (const resolve of waiters) resolve();
+  }, []);
+
+  const waitForAuthResolution = useCallback((): Promise<void> => {
+    if (authStatusRef.current !== "checking") return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      authWaitersRef.current.add(resolve);
+    });
   }, []);
 
   const submit = useCallback(async (submission: CloudMcpSubmitInput): Promise<CloudMcpSubmissionResult> => {
-    const capturedScopeKey = decision.scopeKey;
-    const gateRequired = !submission.skipGate && decision.mode === "required";
+    const initialSnapshot = gateSnapshotRef.current;
+    const capturedScopeKey = initialSnapshot.decision.scopeKey;
+    const gateRequired = !submission.skipGate && initialSnapshot.decision.mode !== "bypass";
     let prepare: (() => Promise<CloudMcpSubmissionPreparationResult>) | undefined;
 
     if (gateRequired) {
       prepare = async () => {
-        const client = input.client;
-        const providerModel = input.providerModel;
-        if (!client || !workspaceId || !providerModel) {
+        let activeSnapshot = initialSnapshot;
+        let resolvedDecision: CloudMcpSubmissionGateDecision = initialSnapshot.decision;
+
+        if (resolvedDecision.mode === "waiting_for_auth") {
+          recordInspectorEvent("cloud_mcp.submission_auth_wait", {
+            workspaceId: activeSnapshot.workspaceId,
+            outcome: "started",
+          });
+          const authResolution = await resolveCloudMcpSubmissionAuth({
+            decision: resolvedDecision,
+            waitForResolution: async () => {
+              await waitForAuthResolution();
+              return gateSnapshotRef.current.decision;
+            },
+          });
+          if (currentScopeKeyRef.current !== capturedScopeKey) {
+            return { outcome: "cancelled", reason: "context_changed" };
+          }
+          if (authResolution.outcome === "failed") {
+            recordInspectorEvent("cloud_mcp.submission_auth_wait", {
+              workspaceId: activeSnapshot.workspaceId,
+              outcome: "failed",
+              code: authResolution.issue.code,
+            });
+            if (authResolution.issue.code === "cloud_mcp_auth_resolution_timeout") {
+              recordInspectorEvent("cloud_mcp.submission_timeout", {
+                workspaceId: activeSnapshot.workspaceId,
+                stage: "auth_resolution",
+              });
+            }
+            return { outcome: "failed", issue: authResolution.issue };
+          }
+
+          activeSnapshot = gateSnapshotRef.current;
+          resolvedDecision = authResolution.decision;
+          recordInspectorEvent("cloud_mcp.submission_auth_wait", {
+            workspaceId: activeSnapshot.workspaceId,
+            outcome: resolvedDecision.mode,
+            authStatus: activeSnapshot.cloudAuthStatus,
+          });
+        }
+
+        if (resolvedDecision.mode === "bypass") return { outcome: "bypass" };
+        if (resolvedDecision.mode !== "required") {
+          return { outcome: "cancelled", reason: "context_changed" };
+        }
+
+        const { client, providerModel, settings, workspaceId: activeWorkspaceId } = activeSnapshot;
+        if (!client || !activeWorkspaceId || !providerModel) {
           return {
             outcome: "failed",
             issue: missingContextIssue({
               client,
-              workspaceId,
+              workspaceId: activeWorkspaceId,
               providerModel,
             }),
           };
         }
         const result = await ensureCloudMcpSubmissionReadiness({
           providerModel,
-          check: () => client.getOpenworkCloudMcpHealth(workspaceId, providerModel),
+          check: () => client.getOpenworkCloudMcpHealth(activeWorkspaceId, providerModel),
           repair: async () => {
             const repaired = await syncCloudControlMcpInBackground({
               client,
-              workspaceId,
+              workspaceId: activeWorkspaceId,
               providerModel,
               settings,
               force: true,
@@ -190,7 +272,7 @@ export function useCloudMcpSubmitReadiness(
                 ? "cloud_mcp.submission_readiness"
                 : "cloud_mcp.submission_repair",
               {
-                workspaceId,
+                workspaceId: activeWorkspaceId,
                 provider: providerModel.provider,
                 model: providerModel.model,
                 attempt: attempt.attempt,
@@ -203,7 +285,7 @@ export function useCloudMcpSubmitReadiness(
             );
             if (issue?.code === "cloud_mcp_submission_timeout") {
               recordInspectorEvent("cloud_mcp.submission_timeout", {
-                workspaceId,
+                workspaceId: activeWorkspaceId,
                 provider: providerModel.provider,
                 model: providerModel.model,
                 attempt: attempt.attempt,
@@ -242,9 +324,9 @@ export function useCloudMcpSubmitReadiness(
             issue: nextState.issue,
           });
           recordInspectorEvent("cloud_mcp.submission_failure", {
-            workspaceId,
-            provider: input.providerModel?.provider ?? null,
-            model: input.providerModel?.model ?? null,
+            workspaceId: initialSnapshot.workspaceId,
+            provider: initialSnapshot.providerModel?.provider ?? null,
+            model: initialSnapshot.providerModel?.model ?? null,
             code: nextState.issue.code,
             stage: nextState.issue.stage,
             retryable: nextState.issue.retryable,
@@ -254,7 +336,7 @@ export function useCloudMcpSubmitReadiness(
         setState(IDLE_CLOUD_MCP_SUBMISSION_GATE_STATE);
       },
     });
-  }, [decision, input.client, input.providerModel, settings, workspaceId]);
+  }, [waitForAuthResolution]);
 
   return { state, submit };
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -407,7 +407,7 @@ export function SessionRoute() {
     state: cloudMcpSubmissionState,
     submit: submitWithCloudMcpReadiness,
   } = useCloudMcpSubmitReadiness({
-    cloudSignedIn: denAuth.isSignedIn,
+    cloudAuthStatus: denAuth.status,
     client: selectedWorkspaceEndpoint?.client ?? null,
     workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? null,
     providerModel: cloudMcpProviderModel,

--- a/apps/app/tests/cloud-mcp-submit-readiness.test.ts
+++ b/apps/app/tests/cloud-mcp-submit-readiness.test.ts
@@ -8,6 +8,8 @@ import {
   createCloudMcpSubmissionCoordinator,
   decideCloudMcpSubmissionGate,
   ensureCloudMcpSubmissionReadiness,
+  resolveCloudMcpSubmissionAuth,
+  type CloudMcpSubmissionGateDecision,
   type CloudMcpSubmissionPreparationResult,
 } from "../src/react-app/domains/connections/cloud-mcp-submit-readiness";
 
@@ -113,9 +115,16 @@ function health(input?: {
   };
 }
 
-function requiredDecision(input?: { signedIn?: boolean; userState?: "disabled" | "removed" | null; workspaceId?: string; model?: string }) {
+function requiredDecision(input?: {
+  authStatus?: "checking" | "signed_in" | "unavailable" | "signed_out";
+  hasSessionToken?: boolean;
+  userState?: "disabled" | "removed" | null;
+  workspaceId?: string;
+  model?: string;
+}) {
   return decideCloudMcpSubmissionGate({
-    cloudSignedIn: input?.signedIn ?? true,
+    cloudAuthStatus: input?.authStatus ?? "signed_in",
+    cloudHasSessionToken: input?.hasSessionToken ?? true,
     denBaseUrl: "https://app.openwork.test",
     serverBaseUrl: "https://worker.openwork.test",
     orgId: "org_1",
@@ -195,6 +204,87 @@ describe("Cloud MCP pre-send readiness", () => {
     expect(runs).toBe(1);
   });
 
+  test("a cached Cloud session waits for auth restoration and sends exactly once", async () => {
+    const coordinator = createCloudMcpSubmissionCoordinator();
+    const checking = requiredDecision({ authStatus: "checking", hasSessionToken: true });
+    const signedIn = requiredDecision();
+    expect(checking.mode).toBe("waiting_for_auth");
+    expect(checking.scopeKey).toBe(signedIn.scopeKey);
+
+    let resolveAuth: ((decision: CloudMcpSubmissionGateDecision) => void) | null = null;
+    const authResolution = new Promise<CloudMcpSubmissionGateDecision>((resolve) => {
+      resolveAuth = resolve;
+    });
+    let checks = 0;
+    let runs = 0;
+    const input = {
+      scopeKey: checking.scopeKey,
+      prepare: async (): Promise<CloudMcpSubmissionPreparationResult> => {
+        const resolution = await resolveCloudMcpSubmissionAuth({
+          decision: checking,
+          waitForResolution: () => authResolution,
+          timeoutMs: 0,
+        });
+        if (resolution.outcome === "failed") {
+          return { outcome: "failed", issue: resolution.issue };
+        }
+        if (resolution.decision.mode === "bypass") return { outcome: "bypass" };
+        if (resolution.decision.mode !== "required") {
+          return { outcome: "cancelled", reason: "context_changed" };
+        }
+        return preparation({
+          check: async () => {
+            checks += 1;
+            return health();
+          },
+          repair: async () => health(),
+        })();
+      },
+      send: async () => {
+        runs += 1;
+      },
+    };
+
+    const first = coordinator.submit(input);
+    const second = coordinator.submit(input);
+    expect(second).toBe(first);
+    expect({ checks, runs }).toEqual({ checks: 0, runs: 0 });
+    resolveAuth?.(signedIn);
+
+    await expect(first).resolves.toEqual({ outcome: "sent", bypassed: false });
+    await expect(second).resolves.toEqual({ outcome: "sent", bypassed: false });
+    expect({ checks, runs }).toEqual({ checks: 1, runs: 1 });
+  });
+
+  test("an auth restoration timeout creates no run", async () => {
+    const coordinator = createCloudMcpSubmissionCoordinator();
+    const checking = requiredDecision({ authStatus: "checking", hasSessionToken: true });
+    let runs = 0;
+    const result = await coordinator.submit({
+      scopeKey: checking.scopeKey,
+      prepare: async () => {
+        const resolution = await resolveCloudMcpSubmissionAuth({
+          decision: checking,
+          waitForResolution: () => new Promise<CloudMcpSubmissionGateDecision>(() => undefined),
+          timeoutMs: 1,
+        });
+        if (resolution.outcome === "failed") {
+          return { outcome: "failed", issue: resolution.issue };
+        }
+        return { outcome: "ready" };
+      },
+      send: async () => {
+        runs += 1;
+      },
+    });
+
+    expect(result).toMatchObject({
+      outcome: "blocked",
+      issue: { code: "cloud_mcp_auth_resolution_timeout" },
+    });
+    expect(runs).toBe(0);
+  });
+
   test("a permanent injection failure creates no run and preserves the exact draft", async () => {
     const coordinator = createCloudMcpSubmissionCoordinator();
     const decision = requiredDecision();
@@ -272,12 +362,13 @@ describe("Cloud MCP pre-send readiness", () => {
     expect(runs).toBe(1);
   });
 
-  test("signed-out and explicitly disabled or removed Cloud bypass readiness entirely", async () => {
+  test("signed-out, tokenless startup, and explicitly disabled or removed Cloud bypass readiness entirely", async () => {
     const coordinator = createCloudMcpSubmissionCoordinator();
     let preparations = 0;
     let runs = 0;
     for (const decision of [
-      requiredDecision({ signedIn: false }),
+      requiredDecision({ authStatus: "signed_out", hasSessionToken: false }),
+      requiredDecision({ authStatus: "checking", hasSessionToken: false }),
       requiredDecision({ userState: "disabled" }),
       requiredDecision({ userState: "removed" }),
     ]) {
@@ -298,7 +389,7 @@ describe("Cloud MCP pre-send readiness", () => {
     }
 
     expect(preparations).toBe(0);
-    expect(runs).toBe(3);
+    expect(runs).toBe(4);
   });
 
   test("workspace or model changes cannot release an old queued message", async () => {

--- a/evals/flows/cloud-mcp-submit-readiness.flow.mjs
+++ b/evals/flows/cloud-mcp-submit-readiness.flow.mjs
@@ -4,7 +4,11 @@ const FLOW_ID = "cloud-mcp-submit-readiness";
 const vo = await loadVoiceoverParagraphs(FLOW_ID);
 const ORIGINAL_PROMPT = "Search my connected services for the latest reliability report.";
 const EDITED_PROMPT = `${ORIGINAL_PROMPT} Keep this edit while tools are prepared.`;
+const SIGNED_OUT_PROMPT = "Run this local task while OpenWork Cloud is signed out.";
 const HEALTH_DELAY_MS = 8_000;
+const DEMO_EMAIL = "alex@acme.test";
+const DEMO_PASSWORD = "OpenWorkDemo123!";
+const EVAL_SESSION_TOKEN_KEY = "openwork.eval.cloudMcpSubmitReadiness.sessionToken";
 
 const state = {
   workspaceId: null,
@@ -49,7 +53,19 @@ async function serverFetchJson(path) {
   return body;
 }
 
+async function waitForLiveCloudHealth(query) {
+  const deadline = Date.now() + 60_000;
+  let health = null;
+  while (Date.now() < deadline) {
+    health = await serverFetchJson(`/workspace/${encodeURIComponent(state.workspaceId)}/mcp/openwork-cloud/health?${query.toString()}`);
+    if (health.usable === true && health.engine?.status === "connected") return health;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  return health;
+}
+
 async function restorePriorEvalProbes(ctx) {
+  await releaseSavedSessionRestore(ctx).catch(() => undefined);
   await ctx.eval(`(() => {
     const bridge = window.__OPENWORK_ELECTRON__;
     const reliability = window.__cloudMcpReliabilityProbe;
@@ -63,11 +79,14 @@ async function restorePriorEvalProbes(ctx) {
     if (bridge && readiness?.originalInvoke) bridge.invokeDesktop = readiness.originalInvoke;
     if (readiness?.originalFetch) window.fetch = readiness.originalFetch;
     delete window.__cloudMcpSubmitReadinessProbe;
+    const savedSessionToken = localStorage.getItem(${quoted(EVAL_SESSION_TOKEN_KEY)});
+    if (savedSessionToken) localStorage.setItem("openwork.den.authToken", savedSessionToken);
+    localStorage.removeItem(${quoted(EVAL_SESSION_TOKEN_KEY)});
     return true;
   })()`);
 }
 
-async function installHealthDelay(ctx) {
+async function installSubmissionProbe(ctx) {
   const result = await ctx.eval(`(() => {
     const bridge = window.__OPENWORK_ELECTRON__;
     if (!bridge?.invokeDesktop) return { ok: false, reason: "desktop bridge unavailable" };
@@ -103,6 +122,98 @@ async function installHealthDelay(ctx) {
     return { ok: bridge.invokeDesktop !== originalInvoke, delayMs: probe.delayMs };
   })()`);
   witness(ctx, result?.ok === true && result.delayMs === HEALTH_DELAY_MS, "A bounded eval delay makes the real pre-send readiness state observable.", result);
+}
+
+async function dismissModelUpsells(ctx) {
+  if (await ctx.hasText("Use OpenWork Models without API keys")) {
+    await ctx.clickText("Continue without OpenWork Models", { selector: "button", timeoutMs: 15_000 });
+    await ctx.waitFor("!document.body.innerText.includes('Use OpenWork Models without API keys')", {
+      timeoutMs: 15_000,
+      label: "OpenWork Models upsell dismissed",
+    });
+  }
+  if (await ctx.hasText("Power your first task")) {
+    await ctx.clickText("Skip and use the free model", { selector: "button", timeoutMs: 15_000 });
+    await ctx.waitFor("!document.body.innerText.includes('Power your first task')", {
+      timeoutMs: 15_000,
+      label: "first task model upsell dismissed",
+    });
+  }
+}
+
+async function beginSavedSessionRestore(ctx) {
+  const held = await fetch(`${ctx.env.OPENWORK_EVAL_DEN_API_URL.replace(/\/+$/, "")}/__openwork_eval/auth-delay?action=hold`, {
+    method: "POST",
+  });
+  ctx.assert(held.ok, `The eval auth-delay control is unavailable (${held.status}).`);
+  const result = await ctx.eval("Boolean((localStorage.getItem('openwork.den.authToken') || '').trim())");
+  witness(ctx, result === true, "The live desktop begins restoring its saved Cloud session.", result);
+  await ctx.eval("location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API while saved Cloud session validation is paused",
+  });
+  await dismissModelUpsells(ctx);
+  await installSubmissionProbe(ctx);
+  const deadline = Date.now() + 5_000;
+  while (Date.now() < deadline) {
+    const status = await readAuthDelay(ctx);
+    if (status.calls >= 1 && status.pending === status.calls) {
+      await ctx.waitFor(
+        "window.__openworkControl?.listActions?.().some((action) => action.id === 'composer.set_text' && !action.disabled)",
+        { timeoutMs: 15_000, label: "composer remains available during saved Cloud session validation" },
+      );
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error("Timed out waiting for the saved Cloud session validation to pause.");
+}
+
+async function releaseSavedSessionRestore(ctx) {
+  const baseUrl = ctx.env.OPENWORK_EVAL_DEN_API_URL?.replace(/\/+$/, "") ?? "";
+  if (!baseUrl) return;
+  const response = await fetch(`${baseUrl}/__openwork_eval/auth-delay?action=release`, {
+    method: "POST",
+  });
+  if (!response.ok) throw new Error(`The eval auth-delay release failed (${response.status}).`);
+}
+
+async function readAuthDelay(ctx) {
+  const response = await fetch(`${ctx.env.OPENWORK_EVAL_DEN_API_URL.replace(/\/+$/, "")}/__openwork_eval/auth-delay`);
+  if (!response.ok) throw new Error(`The eval auth-delay status failed (${response.status}).`);
+  return response.json();
+}
+
+async function setSignedOutForSubmission(ctx) {
+  await ctx.eval(`(async () => {
+    const token = (localStorage.getItem("openwork.den.authToken") || "").trim();
+    if (token) localStorage.setItem(${quoted(EVAL_SESSION_TOKEN_KEY)}, token);
+    localStorage.removeItem("openwork.den.authToken");
+    return true;
+  })()`, { awaitPromise: true });
+  await ctx.eval("location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API after signed-out restart",
+  });
+  await ctx.waitFor(
+    "window.__openworkControl?.listActions?.().some((action) => action.id === 'composer.set_text' && !action.disabled)",
+    { timeoutMs: 15_000, label: "composer available after signed-out restart" },
+  );
+}
+
+async function restoreSavedSession(ctx) {
+  await ctx.eval(`(async () => {
+    const token = localStorage.getItem(${quoted(EVAL_SESSION_TOKEN_KEY)});
+    if (token) localStorage.setItem("openwork.den.authToken", token);
+    localStorage.removeItem(${quoted(EVAL_SESSION_TOKEN_KEY)});
+    window.dispatchEvent(new CustomEvent("openwork-den-session-updated", {
+      detail: { status: "success" },
+    }));
+    await new Promise((resolve) => window.requestAnimationFrame(() => window.requestAnimationFrame(resolve)));
+    return Boolean((localStorage.getItem("openwork.den.authToken") || "").trim());
+  })()`, { awaitPromise: true });
 }
 
 async function readComposerState(ctx) {
@@ -146,9 +257,78 @@ async function transcriptCount(ctx) {
   throw new Error(`Could not read the active session transcript: ${result?.error ?? "unknown error"}`);
 }
 
+async function createFreshTask(ctx) {
+  const deadline = Date.now() + 15_000;
+  let lastError = "unavailable";
+  while (Date.now() < deadline) {
+    const result = await ctx.eval(
+      "window.__openworkControl.execute('session.create_task', null)",
+      { awaitPromise: true },
+    );
+    if (result?.ok === true) return;
+    lastError = result?.error ?? "unknown error";
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Could not create a fresh task: ${lastError}`);
+}
+
+async function waitForTranscriptIncrease(ctx, before) {
+  const deadline = Date.now() + 15_000;
+  while (Date.now() < deadline) {
+    const count = await transcriptCount(ctx);
+    if (count > before) return count;
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error(`Transcript did not grow beyond ${before}.`);
+}
+
+async function ensureLocalCloudSession(ctx) {
+  const denBaseUrl = ctx.env.OPENWORK_EVAL_DEN_API_URL?.trim() ?? "";
+  const denOrigin = ctx.env.OPENWORK_EVAL_DEN_ORIGIN?.trim() || denBaseUrl;
+  let token = ctx.env.OPENWORK_EVAL_DEN_TOKEN?.trim() ?? "";
+  ctx.assert(denBaseUrl, "The isolated Den stack URL is missing.");
+  if (!token) {
+    const signIn = await fetch(`${denBaseUrl.replace(/\/+$/, "")}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin: denOrigin },
+      body: JSON.stringify({ email: DEMO_EMAIL, password: DEMO_PASSWORD }),
+    });
+    ctx.assert(signIn.ok, `The isolated Den demo account could not sign in (${signIn.status}).`);
+    const payload = await signIn.json();
+    token = typeof payload?.token === "string" ? payload.token.trim() : "";
+  }
+  ctx.assert(token, "The isolated Den demo sign-in did not return a session.");
+  const response = await fetch(`${denBaseUrl.replace(/\/+$/, "")}/v1/me/orgs`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(response.ok, `The isolated Den stack could not resolve the demo organization (${response.status}).`);
+  const payload = await response.json();
+  const orgs = Array.isArray(payload?.orgs) ? payload.orgs : [];
+  const org = orgs.find((entry) => entry.id === payload.activeOrgId) ?? orgs[0];
+  ctx.assert(org?.id, "The isolated Den demo session has no organization.");
+  await ctx.eval(`(() => {
+    localStorage.setItem("openwork.den.baseUrl", ${quoted(denBaseUrl)});
+    localStorage.setItem("openwork.den.authToken", ${quoted(token)});
+    localStorage.setItem("openwork.den.activeOrgId", ${quoted(org.id)});
+    ${org.slug ? `localStorage.setItem("openwork.den.activeOrgSlug", ${quoted(org.slug)});` : "localStorage.removeItem(\"openwork.den.activeOrgSlug\");"}
+    ${org.name ? `localStorage.setItem("openwork.den.activeOrgName", ${quoted(org.name)});` : "localStorage.removeItem(\"openwork.den.activeOrgName\");"}
+    window.dispatchEvent(new CustomEvent("openwork-den-settings-changed"));
+    window.dispatchEvent(new CustomEvent("openwork-den-session-updated", {
+      detail: { status: "success" },
+    }));
+    return true;
+  })()`);
+  await ctx.eval("location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API after isolated Cloud session restore",
+  });
+}
+
 async function setup(ctx) {
   await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
   await restorePriorEvalProbes(ctx);
+  await ensureLocalCloudSession(ctx);
 
   const context = await ctx.eval(`(() => {
     const prefs = JSON.parse(localStorage.getItem("openwork.preferences") || "{}");
@@ -165,7 +345,17 @@ async function setup(ctx) {
     };
   })()`);
   ctx.assert(context.signedIn && context.orgId, "This flow requires a signed-in local Cloud demo organization.");
-  ctx.assert(context.workspaceId && context.provider && context.model, `Workspace/model context is incomplete: ${JSON.stringify(context)}`);
+  ctx.assert(
+    context.workspaceId && context.provider && context.model,
+    `Workspace/model context is incomplete: ${JSON.stringify({
+      workspaceId: context.workspaceId,
+      provider: context.provider,
+      model: context.model,
+      hasPort: Boolean(context.port),
+      hasToken: Boolean(context.token),
+      hasHostToken: Boolean(context.hostToken),
+    })}`,
+  );
   ctx.assert(context.port && context.token, "OpenWork server credentials are unavailable in the isolated desktop.");
   state.workspaceId = context.workspaceId;
   state.provider = context.provider;
@@ -173,7 +363,7 @@ async function setup(ctx) {
   state.serverAuth = { port: context.port, token: context.token, hostToken: context.hostToken };
 
   const query = new URLSearchParams({ provider: state.provider, model: state.model });
-  const health = await serverFetchJson(`/workspace/${encodeURIComponent(state.workspaceId)}/mcp/openwork-cloud/health?${query.toString()}`);
+  const health = await waitForLiveCloudHealth(query);
   witness(ctx, health.usable === true && health.engine?.status === "connected", "The live Cloud transport and direct endpoint are healthy before the submission proof.", {
     usable: health.usable,
     engine: health.engine?.status,
@@ -186,24 +376,20 @@ async function setup(ctx) {
     "window.__openworkControl?.listActions?.().some((action) => action.id === 'session.create_task' && !action.disabled)",
     { timeoutMs: 45_000, label: "session.create_task enabled" },
   );
-  await ctx.control("session.create_task");
+  await createFreshTask(ctx);
   await ctx.waitFor("window.location.hash.includes('/session/ses_')", { timeoutMs: 45_000, label: "fresh task session" });
-  const modelsUpsellVisible = await ctx.eval("document.body.innerText.includes('Use OpenWork Models without API keys')");
-  if (modelsUpsellVisible) {
-    await ctx.clickText("Continue without OpenWork Models", { selector: "button", timeoutMs: 15_000 });
-    await ctx.waitFor("!document.body.innerText.includes('Use OpenWork Models without API keys')", { timeoutMs: 15_000, label: "OpenWork Models upsell dismissed" });
-  }
+  await dismissModelUpsells(ctx);
   state.sessionId = (await ctx.eval("(window.location.hash.match(new RegExp('/session/(ses_[^/?#]+)')) || [])[1] || null"));
   ctx.assert(state.sessionId, "Fresh task session id was not found in the route.");
   state.transcriptCount = await transcriptCount(ctx);
   witness(ctx, state.transcriptCount === 0, "The submission proof starts from a task with no messages or agent run.", { transcriptCount: state.transcriptCount });
-  await installHealthDelay(ctx);
 }
 
 export default {
   id: FLOW_ID,
   title: "Cloud submissions wait for selected-model tool proof and fail closed",
   kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [
     {
       name: "Setup: use the live signed-in workspace and bundled engine contract gap",
@@ -215,6 +401,7 @@ export default {
         await ctx.prove("Submission preparation keeps the draft editable and prevents duplicate sends before any run starts", {
           voiceover: vo[0],
           action: async () => {
+            await beginSavedSessionRestore(ctx);
             await ctx.control("composer.set_text", { text: ORIGINAL_PROMPT });
             const clicked = await ctx.eval(`(() => {
               const button = [...document.querySelectorAll('button')].find((entry) => entry.title === "Run task");
@@ -222,6 +409,21 @@ export default {
               return Boolean(button);
             })()`);
             ctx.assert(clicked, "Could not click the visible Run task button.");
+            await ctx.waitFor(
+              "document.body.innerText.includes('Preparing connected service tools…') || document.body.innerText.includes('Power your first task')",
+              { timeoutMs: 5_000, label: "submission preparation or first-task model choice" },
+            );
+            if (await ctx.hasText("Power your first task")) {
+              await dismissModelUpsells(ctx);
+              await ctx.control("composer.set_text", { text: ORIGINAL_PROMPT });
+              const retried = await ctx.waitFor(`(() => {
+                const button = [...document.querySelectorAll('button')].find((entry) => entry.title === "Run task");
+                if (!button || button.disabled) return false;
+                button.click();
+                return true;
+              })()`, { timeoutMs: 10_000, label: "Run task after first-task model choice" });
+              ctx.assert(retried, "Could not resubmit after the first-task model choice.");
+            }
             await ctx.waitForText("Preparing connected service tools…", { timeoutMs: 5_000 });
             await ctx.control("composer.set_text", { text: EDITED_PROMPT });
             await ctx.eval(`(() => {
@@ -238,7 +440,9 @@ export default {
             const after = await transcriptCount(ctx);
             witness(ctx, after === state.transcriptCount, "No user message or agent run was created while readiness was still checking.", { before: state.transcriptCount, after });
             const probe = await readProbe(ctx);
-            witness(ctx, probe.healthCalls.length === 1, "Repeated clicks share the original queued readiness check instead of creating duplicate submissions.", probe);
+            const authDelay = await readAuthDelay(ctx);
+            witness(ctx, authDelay.calls >= 1 && authDelay.pending === authDelay.calls && probe.healthCalls.length === 0, "The queued submission waits for saved-session validation before checking tools or creating a run.", { authDelay, probe });
+            await releaseSavedSessionRestore(ctx);
           },
           screenshot: {
             name: "cloud-submit-preparing-editable",
@@ -266,13 +470,53 @@ export default {
             const after = await transcriptCount(ctx);
             witness(ctx, after === state.transcriptCount, "Permanent projection failure created no user message and no agent run.", { before: state.transcriptCount, after });
             const probe = await readProbe(ctx);
-            witness(ctx, probe.healthCalls.length === 1, "A non-retryable engine projection gap stops after the honest readiness check.", probe);
+            witness(ctx, probe.healthCalls.length >= 1 && probe.healthCalls.length <= 2, "The non-retryable projection gap stops after the queued send and concurrent startup health checks, without a retry loop.", probe);
           },
           screenshot: {
             name: "cloud-submit-projection-failure-preserves-draft",
             claim: "The selected-model projection gap fails closed with the draft preserved and Retry/Open Connect actions.",
             requireText: ["The current engine cannot prove that connected service tools were injected into the selected model.", "Retry", "Open Connect", EDITED_PROMPT],
             rejectText: ["Stop", "search_capabilities was unavailable but the task was sent"],
+            hashIncludes: `/workspace/${state.workspaceId}/session/`,
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3: signed-out Cloud keeps the existing local send path",
+      run: async (ctx) => {
+        await ctx.prove("A user who is actually signed out is not held behind the Cloud readiness gate", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+            await ctx.waitFor(
+              "window.__openworkControl?.listActions?.().some((action) => action.id === 'session.create_task' && !action.disabled)",
+              { timeoutMs: 45_000, label: "session.create_task enabled for signed-out proof" },
+            );
+            await createFreshTask(ctx);
+            await ctx.waitFor("window.location.hash.includes('/session/ses_')", { timeoutMs: 45_000, label: "fresh signed-out task session" });
+            const before = await transcriptCount(ctx);
+            await setSignedOutForSubmission(ctx);
+            await ctx.control("composer.set_text", { text: SIGNED_OUT_PROMPT });
+            const clicked = await ctx.eval(`(() => {
+              const button = [...document.querySelectorAll('button')].find((entry) => entry.title === "Run task");
+              button?.click();
+              return Boolean(button);
+            })()`);
+            ctx.assert(clicked, "Could not click Run task while Cloud was signed out.");
+            state.transcriptCount = await waitForTranscriptIncrease(ctx, before);
+          },
+          assert: async () => {
+            const composer = await readComposerState(ctx);
+            witness(ctx, !composer.preparingVisible, "The signed-out submission never enters connected-service preparation.", composer);
+            witness(ctx, state.transcriptCount > 0, "The existing send path creates the user message while Cloud is signed out.", { transcriptCount: state.transcriptCount });
+            await restoreSavedSession(ctx);
+          },
+          screenshot: {
+            name: "cloud-submit-signed-out-bypasses-gate",
+            claim: "A signed-out user submits through the existing local path without a connected-service preparation state.",
+            requireText: [SIGNED_OUT_PROMPT],
+            rejectText: ["Preparing connected service tools…"],
             hashIncludes: `/workspace/${state.workspaceId}/session/`,
           },
         });

--- a/evals/runner/den-proxy.mjs
+++ b/evals/runner/den-proxy.mjs
@@ -11,6 +11,11 @@ import http from "node:http";
 const listenPort = Number(process.env.DEN_PROXY_LISTEN_PORT);
 const upstreamPort = Number(process.env.DEN_PROXY_UPSTREAM_PORT);
 const DEN_PREFIX = "/api/den";
+const AUTH_DELAY_CONTROL_PATH = "/__openwork_eval/auth-delay";
+const authDelayControlEnabled = process.env.OPENWORK_EVAL_DEN_PROXY_CONTROL === "1";
+let authDelayEnabled = false;
+let authDelayCalls = 0;
+const authDelayWaiters = new Set();
 
 if (!Number.isInteger(listenPort) || listenPort <= 0) {
   console.error("DEN_PROXY_LISTEN_PORT must be a positive integer.");
@@ -30,7 +35,53 @@ function rewritePath(rawUrl) {
   return `${url.pathname}${url.search}`;
 }
 
-const server = http.createServer((req, res) => {
+function writeJson(res, status, body) {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8" });
+  res.end(`${JSON.stringify(body)}\n`);
+}
+
+function releaseAuthDelay() {
+  authDelayEnabled = false;
+  const waiters = [...authDelayWaiters];
+  authDelayWaiters.clear();
+  for (const resolve of waiters) resolve();
+}
+
+function isSessionValidation(rawUrl, method) {
+  if (method !== "GET") return false;
+  const pathname = new URL(rawUrl ?? "/", "http://127.0.0.1").pathname;
+  return pathname === "/v1/me" || pathname === `${DEN_PREFIX}/v1/me`;
+}
+
+const server = http.createServer(async (req, res) => {
+  const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+  if (requestUrl.pathname === AUTH_DELAY_CONTROL_PATH) {
+    if (!authDelayControlEnabled) {
+      writeJson(res, 404, { error: "not_found" });
+      return;
+    }
+    if (req.method === "POST" && requestUrl.searchParams.get("action") === "hold") {
+      authDelayEnabled = true;
+      authDelayCalls = 0;
+    } else if (req.method === "POST" && requestUrl.searchParams.get("action") === "release") {
+      releaseAuthDelay();
+    } else if (req.method !== "GET") {
+      writeJson(res, 400, { error: "invalid_action" });
+      return;
+    }
+    writeJson(res, 200, {
+      enabled: authDelayEnabled,
+      calls: authDelayCalls,
+      pending: authDelayWaiters.size,
+    });
+    return;
+  }
+
+  if (authDelayControlEnabled && authDelayEnabled && isSessionValidation(req.url, req.method)) {
+    authDelayCalls += 1;
+    await new Promise((resolve) => authDelayWaiters.add(resolve));
+  }
+
   const upstreamReq = http.request({
     hostname: "127.0.0.1",
     port: upstreamPort,
@@ -55,5 +106,5 @@ const server = http.createServer((req, res) => {
 });
 
 server.listen(listenPort, "127.0.0.1", () => {
-  console.log(`den proxy listening on :${listenPort} -> :${upstreamPort}`);
+  console.log(`den proxy listening on :${listenPort} -> :${upstreamPort}${authDelayControlEnabled ? " (eval auth delay enabled)" : ""}`);
 });

--- a/evals/runner/den-stack.mjs
+++ b/evals/runner/den-stack.mjs
@@ -215,6 +215,7 @@ async function ensureDenApi(log) {
     env: {
       DEN_PROXY_LISTEN_PORT: String(DEN_API_PORT),
       DEN_PROXY_UPSTREAM_PORT: String(DEN_API_INTERNAL_PORT),
+      OPENWORK_EVAL_DEN_PROXY_CONTROL: "1",
     },
   });
   await writePidState("den-proxy.pid", proxyPid);

--- a/evals/voiceovers/cloud-mcp-submit-readiness.md
+++ b/evals/voiceovers/cloud-mcp-submit-readiness.md
@@ -1,5 +1,7 @@
 # cloud-mcp-submit-readiness — Hold submissions until Cloud tools are proven
 
-1. After I submit, OpenWork prepares my connected service tools without locking the composer. My message stays visible, I can keep editing, and repeated clicks cannot start another submission.
+1. While OpenWork restores my saved Cloud session, my submission waits before any tool check or agent run. The composer stays usable, my edit remains visible, and repeated clicks cannot start another submission.
 
 2. This bundled engine can prove the Cloud endpoint is connected, but it cannot enumerate the two tools for the selected model. OpenWork fails closed: no task starts, my edited draft remains, and Retry and Open Connect explain the safe next steps.
+
+3. When I am actually signed out of OpenWork Cloud, the readiness gate stays out of the way. My message follows the existing local task path without showing a connected-service preparation state.


### PR DESCRIPTION
## Why

This prevents a saved OpenWork Cloud session from being mistaken for a signed-out session while startup authentication is still restoring. That race could let a message bypass the Cloud MCP readiness gate before `search_capabilities` and `execute_capability` were proven for the selected provider/model, recreating the silent missing-search-tool failure.

Users who are truly signed out, or who explicitly disabled/removed Agent access, keep the existing non-Cloud submission behavior.

## What changed

- Treat startup auth with a saved session as a bounded readiness phase instead of signed-out mode.
- Keep the composer editable and preserve the exact draft/attachments while the original submission is queued.
- Resume the queued submission exactly once after auth and selected-model tool projection are ready.
- Fail closed with Retry and Open Connect when auth or injection proof cannot be restored; no agent run is created first.
- Cancel stale queued work when workspace, organization, server, or selected model scope changes.
- Record credential-free auth-wait, readiness, repair, timeout, cancellation, and failure events.
- Add an eval-only Den auth-delay control so the startup race is reproducible in the desktop proof.

## Engine contract gap

The current health endpoint cannot always prove actual tool projection into the selected model. Generic model tool-calling support is **not** accepted as proof that `openwork-cloud_search_capabilities` or `openwork-cloud_execute_capability` was injected. The strongest honest check remains the provider/model-scoped experimental tool listing plus the direct MCP `tools/list` probe; when the bundled engine cannot provide that projection evidence, submission fails closed.

## Verification

- `14` focused tests passed across Cloud MCP submission readiness and retained Den auth behavior.
- `@openwork/app` TypeScript check passed.
- Fraimz desktop + isolated Den flow: `1 passed, 0 failed, 0 skipped` (`2026-07-15T05-48-37-746Z`).
- All three screenshots were uploaded with the Vercel CLI to the Different AI `openwork-fraimz-assets` Blob store, then verified as HTTP 200 `image/png` with SHA-256 equality against the validated local frames. Screenshot binaries are not part of this PR.

### 1. Saved Cloud session waits without blocking the composer

The original send is queued before any readiness check or agent run, the edited draft remains visible, and repeated clicks cannot duplicate the submission.

<img src="https://uqab8d1w4ih8j7ev.public.blob.vercel-storage.com/fraimz/2026-07-15T05-48-37-746Z/cloud-mcp-submit-readiness-01-cloud-submit-preparing-editable-JzXlPwxEcsvws7k8zoEHwf3EXEAmwb.png" alt="Saved Cloud session submission waiting while the composer remains editable" width="900">

### 2. Missing selected-model proof fails closed

The current engine cannot enumerate selected-model Cloud tools, so no message or agent run is created; the exact edited draft remains with safe Retry and Open Connect actions.

<img src="https://uqab8d1w4ih8j7ev.public.blob.vercel-storage.com/fraimz/2026-07-15T05-48-37-746Z/cloud-mcp-submit-readiness-02-cloud-submit-projection-failure-preserves-draft-Z1mFVCKms9Q7PvxP0eulRdEzo2f4yB.png" alt="Selected-model tool projection failure preserving the draft" width="900">

### 3. Truly signed-out Cloud remains optional

A signed-out user submits through the existing local task path without entering connected-service preparation.

<img src="https://uqab8d1w4ih8j7ev.public.blob.vercel-storage.com/fraimz/2026-07-15T05-48-37-746Z/cloud-mcp-submit-readiness-03-cloud-submit-signed-out-bypasses-gate-BatL56pOEScpRYqU2EupMuJepVMPoZ.png" alt="Signed-out Cloud user submitting through the existing local path" width="900">

## Risk and behavior notes

- A saved Cloud session can wait up to 12 seconds for auth restoration before showing a safe retryable failure.
- The gate remains deliberately conservative when selected-model injection cannot be proven.
- Explicit opt-out and actual signed-out behavior are unchanged.
