### PR TITLE
fix(app): bypass Cloud MCP pre-send gate

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -942,7 +942,9 @@ export function SessionRoute() {
         if (selectedModelUnavailable) throw new Error("Selected model is unavailable. Choose another model before sending.");
 
         return submitWithCloudMcpReadiness({
-          skipGate: draft.mode === "shell",
+          // Temporarily bypass the pre-send Cloud MCP gate: it blocks every
+          // message, including tasks that do not use connected services.
+          skipGate: true,
           send: async () => {
             captureAnalyticsEvent("task_message_sent", {
               mode: draft.mode ?? "prompt",


### PR DESCRIPTION
## Summary
- temporarily bypass the Cloud MCP readiness gate for all message submissions
- prevent unrelated tasks from being blocked by connected-service health checks
- retain the gate implementation for follow-up redesign

## Tests
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/app test -- cloud-mcp-submit-readiness.test.ts` — 300 passed
- `git diff --check` — passed

## Validation
Fraimz was not completed because manual desktop validation was requested first.