### PR TITLE
fix(den): enforce single-org signup policy

### DIFF
--- a/ee/apps/den-api/src/auth-login-options.ts
+++ b/ee/apps/den-api/src/auth-login-options.ts
@@ -25,6 +25,7 @@ function hasProvider(accounts: readonly LoginOptionAccount[], providerId: string
 export function resolveLoginOptionKind(input: {
   requireSso: boolean
   accounts: readonly LoginOptionAccount[]
+  allowNewAccount?: boolean
 }): LoginOptionKind {
   if (input.requireSso) {
     return "sso"
@@ -42,5 +43,5 @@ export function resolveLoginOptionKind(input: {
     return "github"
   }
 
-  return "new_account"
+  return input.allowNewAccount === false ? "password" : "new_account"
 }

--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -55,6 +55,7 @@ import {
   findEnterpriseAuthRequirementForEmail,
   findEnterpriseAuthRequirementForUserId,
 } from "./enterprise-auth-requirement.js";
+import { getAuthBodyEmail, getSingleOrgEmailSignupPolicyViolation } from "./single-org-signup-policy.js";
 import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid";
 import * as schema from "@openwork-ee/den-db/schema";
 import { apiKey } from "@better-auth/api-key";
@@ -258,15 +259,6 @@ function throwMemberLifecycleError(message: string): never {
   throw new APIError("BAD_REQUEST", { message });
 }
 
-function getBodyEmail(body: unknown) {
-  if (!body || typeof body !== "object") {
-    return null;
-  }
-
-  const value = Object.getOwnPropertyDescriptor(body, "email")?.value;
-  return typeof value === "string" && value.trim() ? value.trim() : null;
-}
-
 function removedMemberIdentity(value: unknown): { id: string; organizationId: string } | null {
   if (!value || typeof value !== "object") {
     return null;
@@ -392,7 +384,14 @@ export const auth = betterAuth({
         return;
       }
 
-      const email = getBodyEmail(ctx.body);
+      const email = getAuthBodyEmail(ctx.body);
+      if (ctx.path === "/sign-up/email") {
+        const violation = await getSingleOrgEmailSignupPolicyViolation(email);
+        if (violation) {
+          throw new APIError("FORBIDDEN", { message: violation.message });
+        }
+      }
+
       if (!email) {
         return;
       }

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -35,6 +35,7 @@ const EnvSchema = z.object({
   DEN_SINGLE_ORG_NAME: z.string().optional(),
   DEN_SINGLE_ORG_SLUG: z.string().optional(),
   DEN_SINGLE_ORG_OWNER_EMAILS: z.string().optional(),
+  DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: z.string().optional(),
   DEN_REQUIRE_EMAIL_VERIFICATION: z.string().optional(),
   DEN_PASSWORD_BREACH_SCREENING_ENABLED: z.string().optional(),
   RESEND_API_KEY: z.string().optional(),
@@ -222,6 +223,23 @@ export function normalizeSingleOrgSlug(value: string | undefined) {
   }
 
   return normalized
+}
+
+export function parseSingleOrgAllowPublicSignup(value: string | undefined, orgMode: DenOrgMode) {
+  const normalized = value?.trim().toLowerCase()
+  if (!normalized) {
+    return orgMode === "multi_org"
+  }
+
+  if (["1", "true", "yes", "y", "on"].includes(normalized)) {
+    return true
+  }
+
+  if (["0", "false", "no", "n", "off"].includes(normalized)) {
+    return false
+  }
+
+  throw new Error("DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP must be true or false")
 }
 
 function normalizeOrigin(origin: string) {
@@ -427,6 +445,7 @@ export const env = {
   singleOrg: {
     name: optionalString(parsed.DEN_SINGLE_ORG_NAME) ?? "OpenWork",
     slug: normalizeSingleOrgSlug(parsed.DEN_SINGLE_ORG_SLUG),
+    allowPublicSignup: parseSingleOrgAllowPublicSignup(parsed.DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP, orgMode),
     ownerEmails: splitCsv(parsed.DEN_SINGLE_ORG_OWNER_EMAILS)
       .map((email) => email.toLowerCase()),
   },

--- a/ee/apps/den-api/src/routes/auth/index.ts
+++ b/ee/apps/den-api/src/routes/auth/index.ts
@@ -21,6 +21,7 @@ import { normalizeMcpOAuthClientScope } from "../../mcp/scopes.js"
 import { publicRoute, queryValidator, tokenRoute } from "../../middleware/index.js"
 import { emptyResponse, jsonResponse } from "../../openapi.js"
 import { getSingletonSsoStatus } from "../../orgs.js"
+import { getAuthRequestEmail, getSingleOrgEmailSignupPolicyViolation, type SingleOrgEmailSignupPolicyViolation } from "../../single-org-signup-policy.js"
 import { samlResponsePolicyMiddleware } from "../../sso-saml-response-middleware.js"
 import { revokeBearerSession, type AuthContextVariables } from "../../session.js"
 import { registerDesktopAuthRoutes } from "./desktop-handoff.js"
@@ -208,6 +209,10 @@ function singleOrgSsoRequiredResponse(signInPath: string) {
   }, { status: 403 })
 }
 
+function singleOrgEmailSignupPolicyResponse(violation: SingleOrgEmailSignupPolicyViolation) {
+  return Response.json(violation, { status: 403 })
+}
+
 export function getBetterAuthProxyPath(pathname: string) {
   const prefix = "/api/auth"
   if (!pathname.startsWith(prefix)) {
@@ -231,6 +236,11 @@ export function isBetterAuthEmailPasswordRequest(request: Request) {
   const url = new URL(request.url)
   const path = getBetterAuthProxyPath(url.pathname)
   return request.method.toUpperCase() === "POST" && (path === "/sign-in/email" || path === "/sign-up/email")
+}
+
+export function isBetterAuthEmailSignupRequest(request: Request) {
+  const url = new URL(request.url)
+  return request.method.toUpperCase() === "POST" && getBetterAuthProxyPath(url.pathname) === "/sign-up/email"
 }
 
 export function isBetterAuthSignOutRequest(request: Request) {
@@ -285,6 +295,13 @@ async function getSingleOrgAuthGuardResponse(request: Request) {
 
   if (isBetterAuthOrganizationCreationRequest(request)) {
     return singleOrgModeResponse()
+  }
+
+  if (isBetterAuthEmailSignupRequest(request)) {
+    const violation = await getSingleOrgEmailSignupPolicyViolation(await getAuthRequestEmail(request))
+    if (violation) {
+      return singleOrgEmailSignupPolicyResponse(violation)
+    }
   }
 
   if (isBetterAuthEmailPasswordRequest(request)) {
@@ -426,6 +443,7 @@ const loginOptionKindSchema = z.union([
 const loginOptionsResponseSchema = z.object({
   email: z.string().email(),
   nextStep: loginOptionKindSchema,
+  allowPublicSignup: z.boolean().optional(),
   organizationSlug: z.string().optional(),
   signInPath: z.string().optional(),
   signInUrl: z.string().url().optional(),
@@ -539,19 +557,21 @@ export function registerAuthRoutes<T extends { Variables: AuthContextVariables }
         : null
       const requirement = singletonSsoRequirement ?? await findEnterpriseAuthRequirementForEmail(email)
       const accounts = requirement ? [] : await getLoginOptionAccounts(email)
-      const nextStep = resolveLoginOptionKind({ requireSso: Boolean(requirement), accounts })
+      const allowPublicSignup = env.orgMode !== "single_org" || env.singleOrg.allowPublicSignup
+      const nextStep = resolveLoginOptionKind({ requireSso: Boolean(requirement), accounts, allowNewAccount: allowPublicSignup })
 
       if (nextStep === "sso" && requirement) {
         return c.json({
           email,
           nextStep,
+          allowPublicSignup,
           organizationSlug: requirement.organizationSlug,
           signInPath: requirement.signInPath,
           signInUrl: new URL(requirement.signInPath, env.betterAuthTrustedOrigins[0] ?? env.betterAuthUrl).toString(),
         })
       }
 
-      return c.json({ email, nextStep })
+      return c.json({ email, nextStep, allowPublicSignup })
     },
   )
 

--- a/ee/apps/den-api/src/single-org-signup-policy.ts
+++ b/ee/apps/den-api/src/single-org-signup-policy.ts
@@ -1,0 +1,97 @@
+import type { DenOrgMode } from "./env.js"
+import { env } from "./env.js"
+import {
+  getSingletonOrganization,
+  isEmailAllowedForOrganization,
+  normalizeAllowedEmailDomains,
+  OrganizationEmailDomainRestrictionError,
+  type AllowedEmailDomains,
+} from "./orgs.js"
+
+export type SingleOrgEmailSignupPolicyViolation = {
+  error: "single_org_signup_disabled" | "email_domain_restricted"
+  message: string
+  allowedEmailDomains?: string[]
+}
+
+type SingletonOrganizationForSignup = {
+  allowedEmailDomains: readonly string[] | null | undefined
+}
+
+export function getAuthBodyEmail(body: unknown) {
+  if (!body || typeof body !== "object") {
+    return null
+  }
+
+  const value = Object.getOwnPropertyDescriptor(body, "email")?.value
+  return typeof value === "string" && value.trim() ? value.trim() : null
+}
+
+export async function getAuthRequestEmail(request: Request) {
+  try {
+    return getAuthBodyEmail(await request.clone().json())
+  } catch {
+    return null
+  }
+}
+
+function disabledSignupViolation(): SingleOrgEmailSignupPolicyViolation {
+  return {
+    error: "single_org_signup_disabled",
+    message: "Email signup is disabled for this deployment. Use your organization's SSO or a pre-provisioned account to sign in.",
+  }
+}
+
+function domainSignupViolation(email: string, allowedEmailDomains: string[]): SingleOrgEmailSignupPolicyViolation {
+  const error = new OrganizationEmailDomainRestrictionError(email, allowedEmailDomains)
+  return {
+    error: "email_domain_restricted",
+    message: error.message,
+    allowedEmailDomains,
+  }
+}
+
+function evaluateAllowedDomains(input: {
+  email: string | null
+  allowedEmailDomains: AllowedEmailDomains
+}) {
+  if (!input.allowedEmailDomains || input.allowedEmailDomains.length === 0 || !input.email) {
+    return null
+  }
+
+  return isEmailAllowedForOrganization(input.allowedEmailDomains, input.email)
+    ? null
+    : domainSignupViolation(input.email, input.allowedEmailDomains)
+}
+
+export async function resolveSingleOrgEmailSignupPolicyViolation(input: {
+  orgMode: DenOrgMode
+  allowPublicSignup: boolean
+  email: string | null
+  getSingletonOrganization: () => Promise<SingletonOrganizationForSignup | null>
+}): Promise<SingleOrgEmailSignupPolicyViolation | null> {
+  if (input.orgMode !== "single_org") {
+    return null
+  }
+
+  if (!input.allowPublicSignup) {
+    return disabledSignupViolation()
+  }
+
+  if (!input.email) {
+    return null
+  }
+
+  const organization = await input.getSingletonOrganization()
+  const allowedEmailDomains = normalizeAllowedEmailDomains(organization?.allowedEmailDomains).domains
+  return evaluateAllowedDomains({ email: input.email, allowedEmailDomains })
+}
+
+export async function getSingleOrgEmailSignupPolicyViolation(email: string | null) {
+  return resolveSingleOrgEmailSignupPolicyViolation({
+    orgMode: env.orgMode,
+    allowPublicSignup: env.singleOrg.allowPublicSignup,
+    email,
+    getSingletonOrganization,
+  })
+}

--- a/ee/apps/den-api/test/auth-login-options.test.ts
+++ b/ee/apps/den-api/test/auth-login-options.test.ts
@@ -41,3 +41,11 @@ test("login option resolution prefers Google, then password, then GitHub compati
 test("login option resolution returns new account when no existing auth method matches", () => {
   expect(resolveLoginOptionKind({ requireSso: false, accounts: [] })).toBe("new_account")
 })
+
+test("login option resolution keeps private single-org unknown users in sign-in", () => {
+  expect(resolveLoginOptionKind({
+    requireSso: false,
+    accounts: [],
+    allowNewAccount: false,
+  })).toBe("password")
+})

--- a/ee/apps/den-api/test/better-auth-member-connected-account-removal.test.ts
+++ b/ee/apps/den-api/test/better-auth-member-connected-account-removal.test.ts
@@ -15,6 +15,7 @@ beforeAll(async () => {
   process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.DEN_ORG_MODE = "multi_org"
 
   authModule = await import("../src/auth.js")
   dbModule = await import("../src/db.js")

--- a/ee/apps/den-api/test/single-org-mode.test.ts
+++ b/ee/apps/den-api/test/single-org-mode.test.ts
@@ -5,15 +5,18 @@ function seedRequiredEnv() {
   process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP = process.env.DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP ?? "false"
 }
 
 let envModule: typeof import("../src/env.js")
 let singleOrgPolicy: typeof import("../src/single-org-policy.js")
+let signupPolicy: typeof import("../src/single-org-signup-policy.js")
 
 beforeAll(async () => {
   seedRequiredEnv()
   envModule = await import("../src/env.js")
   singleOrgPolicy = await import("../src/single-org-policy.js")
+  signupPolicy = await import("../src/single-org-signup-policy.js")
 })
 
 test("blank org mode resolves to single_org", () => {
@@ -32,6 +35,66 @@ test("single-org slug normalization keeps Helm-safe slugs strict", () => {
   expect(envModule.normalizeSingleOrgSlug(undefined)).toBe("default")
   expect(envModule.normalizeSingleOrgSlug(" Acme-Internal ")).toBe("acme-internal")
   expect(() => envModule.normalizeSingleOrgSlug("bad slug")).toThrow("DEN_SINGLE_ORG_SLUG")
+})
+
+test("single-org public signup defaults private and parses Helm string values", () => {
+  expect(envModule.parseSingleOrgAllowPublicSignup(undefined, "single_org")).toBe(false)
+  expect(envModule.parseSingleOrgAllowPublicSignup("", "single_org")).toBe(false)
+  expect(envModule.parseSingleOrgAllowPublicSignup(" false ", "single_org")).toBe(false)
+  expect(envModule.parseSingleOrgAllowPublicSignup("0", "single_org")).toBe(false)
+  expect(envModule.parseSingleOrgAllowPublicSignup("true", "single_org")).toBe(true)
+  expect(envModule.parseSingleOrgAllowPublicSignup("YES", "single_org")).toBe(true)
+  expect(envModule.parseSingleOrgAllowPublicSignup(undefined, "multi_org")).toBe(true)
+  expect(() => envModule.parseSingleOrgAllowPublicSignup("sometimes", "single_org")).toThrow("DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP")
+})
+
+test("single-org signup policy allows matching domains", async () => {
+  const matching = await signupPolicy.resolveSingleOrgEmailSignupPolicyViolation({
+    orgMode: "single_org",
+    allowPublicSignup: true,
+    email: "User@Acme.com",
+    getSingletonOrganization: async () => ({ allowedEmailDomains: ["acme.com"] }),
+  })
+  expect(matching).toBeNull()
+})
+
+test("single-org signup policy rejects outside domains", async () => {
+  const rejected = await signupPolicy.resolveSingleOrgEmailSignupPolicyViolation({
+    orgMode: "single_org",
+    allowPublicSignup: true,
+    email: "user@outside.com",
+    getSingletonOrganization: async () => ({ allowedEmailDomains: ["acme.com"] }),
+  })
+  expect(rejected).toEqual({
+    error: "email_domain_restricted",
+    message: "This workspace only allows acme.com email addresses.",
+    allowedEmailDomains: ["acme.com"],
+  })
+})
+
+test("single-org signup policy blocks private email signup and leaves multi-org unchanged", async () => {
+  const disabled = await signupPolicy.resolveSingleOrgEmailSignupPolicyViolation({
+    orgMode: "single_org",
+    allowPublicSignup: false,
+    email: "invited@acme.com",
+    getSingletonOrganization: async () => {
+      throw new Error("private signup should not query the singleton")
+    },
+  })
+  expect(disabled).toEqual({
+    error: "single_org_signup_disabled",
+    message: "Email signup is disabled for this deployment. Use your organization's SSO or a pre-provisioned account to sign in.",
+  })
+
+  const multiOrg = await signupPolicy.resolveSingleOrgEmailSignupPolicyViolation({
+    orgMode: "multi_org",
+    allowPublicSignup: false,
+    email: "user@outside.com",
+    getSingletonOrganization: async () => {
+      throw new Error("multi-org signup should not query the singleton")
+    },
+  })
+  expect(multiOrg).toBeNull()
 })
 
 test("single-org owner bootstrap honors configured owner emails", () => {

--- a/ee/apps/den-api/test/single-org-route-guards.test.ts
+++ b/ee/apps/den-api/test/single-org-route-guards.test.ts
@@ -7,6 +7,7 @@ function seedRequiredEnv() {
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
   process.env.DEN_ORG_MODE = ""
+  process.env.DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP = "false"
 }
 
 let authRoutesModule: typeof import("../src/routes/auth/index.js")
@@ -69,6 +70,23 @@ test("raw Better Auth organization creation is blocked in single_org mode", asyn
   await expect(response.json()).resolves.toEqual({
     error: "single_org_mode",
     message: "This deployment is configured for one organization. Additional organization changes are disabled.",
+  })
+})
+
+test("raw Better Auth email signup is blocked in private single_org mode before Better Auth validation", async () => {
+  const app = new Hono()
+  authRoutesModule.registerAuthRoutes(app)
+
+  const response = await app.request("http://den.local/api/auth/sign-up/email", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ email: "invited@example.com", name: "Invited User", password: "x" }),
+  })
+
+  expect(response.status).toBe(403)
+  await expect(response.json()).resolves.toEqual({
+    error: "single_org_signup_disabled",
+    message: "Email signup is disabled for this deployment. Use your organization's SSO or a pre-provisioned account to sign in.",
   })
 })
 
@@ -154,6 +172,20 @@ test("single_org SSO-only guard recognizes email/password auth requests", () => 
   }))).toBe(false)
 
   expect(authRoutesModule.isBetterAuthEmailPasswordRequest(new Request("http://den.local/api/auth/sign-in/email", {
+    method: "GET",
+  }))).toBe(false)
+})
+
+test("single_org signup guard recognizes only the Better Auth email signup route", () => {
+  expect(authRoutesModule.isBetterAuthEmailSignupRequest(new Request("http://den.local/api/auth/sign-up/email", {
+    method: "POST",
+  }))).toBe(true)
+
+  expect(authRoutesModule.isBetterAuthEmailSignupRequest(new Request("http://den.local/api/auth/sign-in/email", {
+    method: "POST",
+  }))).toBe(false)
+
+  expect(authRoutesModule.isBetterAuthEmailSignupRequest(new Request("http://den.local/api/auth/sign-up/email", {
     method: "GET",
   }))).toBe(false)
 })

--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -3,6 +3,7 @@
 import { ArrowRight, CheckCircle2 } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef, useState, type FormEvent, type ReactNode } from "react";
+import { isSingleOrgSignupDisabled, resolveVisibleAuthMode } from "../_lib/auth-ui-policy";
 import { isSamePathname } from "../_lib/client-route";
 import { getErrorMessage, getSocialCallbackUrl, requestJson, type AuthMode } from "../_lib/den-flow";
 import { getMcpOAuthSelectOrganizationRoute } from "../_lib/mcp-oauth-route";
@@ -168,8 +169,16 @@ export function AuthPanel({
   } = useDenFlow();
   const isSingleOrgMode = runtimeConfigLoaded && runtimeConfig.orgMode === "single_org";
   const isSingleOrgSsoMode = isSingleOrgMode && runtimeConfig.singleOrgSsoConfigured;
+  const isSingleOrgPrivateSignup = isSingleOrgSignupDisabled(runtimeConfig, runtimeConfigLoaded);
+  const visibleAuthMode = resolveVisibleAuthMode({ authMode, runtimeConfig, runtimeConfigLoaded });
   const singleOrgName = runtimeConfig.singleOrgName || "OpenWork";
   const singleOrgSlug = runtimeConfig.singleOrgSlug.trim();
+
+  useEffect(() => {
+    if (isSingleOrgPrivateSignup && authMode === "sign-up") {
+      setAuthMode("sign-in");
+    }
+  }, [authMode, isSingleOrgPrivateSignup, setAuthMode]);
 
   useEffect(() => {
     if (!isSingleOrgSsoMode || pathname === "/") {
@@ -216,7 +225,8 @@ export function AuthPanel({
     submitLabel: "Send reset link",
   };
 
-  const emailFirstStep: EmailFirstStep = loginOption?.nextStep ?? "email";
+  const requestedEmailFirstStep = loginOption?.nextStep ?? "email";
+  const emailFirstStep: EmailFirstStep = isSingleOrgPrivateSignup && requestedEmailFirstStep === "new_account" ? "password" : requestedEmailFirstStep;
   const emailFirstEmail = email.trim();
   const emailFirstContent: PanelContent =
     emailFirstStep === "email"
@@ -266,7 +276,7 @@ export function AuthPanel({
       ? emailFirstContent
       : isSingleOrgSsoMode
       ? singleOrgSsoContent
-      : authMode === "sign-in"
+      : visibleAuthMode === "sign-in"
       ? resolvedSignInContent
       : resolvedSignUpContent;
   const showLockedEmailSummary = Boolean(prefilledEmail && lockEmail && hideEmailField);
@@ -275,7 +285,7 @@ export function AuthPanel({
   // The segmented tabs are the primary sign-in/sign-up switch. Hide them for the
   // focused sub-flows (email verification, password reset) where switching mode
   // mid-step would be confusing.
-  const showModeTabs = !emailFirstFlow && !isSingleOrgSsoMode && !verificationRequired && !isPasswordResetRequest;
+  const showModeTabs = !emailFirstFlow && !isSingleOrgSsoMode && !isSingleOrgPrivateSignup && !verificationRequired && !isPasswordResetRequest;
   const showSingleOrgSso = isSingleOrgMode && Boolean(singleOrgSlug) && !verificationRequired && !isPasswordResetRequest && (!hideSocialAuth || isSingleOrgSsoMode);
   const showSingleOrgSsoDivider = showSingleOrgSso && !isSingleOrgSsoMode;
   const showEmailPasswordAuth = !isSingleOrgSsoMode;
@@ -704,10 +714,10 @@ export function AuthPanel({
         >
           <button
             type="button"
-            aria-pressed={authMode === "sign-in"}
+            aria-pressed={visibleAuthMode === "sign-in"}
             onClick={() => switchMode("sign-in")}
             className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-              authMode === "sign-in"
+              visibleAuthMode === "sign-in"
                 ? "bg-[var(--dls-surface)] text-[var(--dls-text-primary)] shadow-[0_1px_2px_rgba(15,23,42,0.08)]"
                 : "text-[var(--dls-text-secondary)] hover:text-[var(--dls-text-primary)]"
             }`}
@@ -716,10 +726,10 @@ export function AuthPanel({
           </button>
           <button
             type="button"
-            aria-pressed={authMode === "sign-up"}
+            aria-pressed={visibleAuthMode === "sign-up"}
             onClick={() => switchMode("sign-up")}
             className={`rounded-full px-4 py-2 text-sm font-semibold transition ${
-              authMode === "sign-up"
+              visibleAuthMode === "sign-up"
                 ? "bg-[var(--dls-surface)] text-[var(--dls-text-primary)] shadow-[0_1px_2px_rgba(15,23,42,0.08)]"
                 : "text-[var(--dls-text-secondary)] hover:text-[var(--dls-text-primary)]"
             }`}
@@ -834,7 +844,7 @@ export function AuthPanel({
               type="password"
               value={password}
               onChange={(event) => setPassword(event.target.value)}
-              autoComplete={authMode === "sign-up" ? "new-password" : "current-password"}
+              autoComplete={visibleAuthMode === "sign-up" ? "new-password" : "current-password"}
               required
             />
           </label>
@@ -859,11 +869,11 @@ export function AuthPanel({
         {showEmailPasswordAuth && !verificationRequired && !isPasswordResetRequest && !hideEmailField ? (
           // Always rendered (invisible in sign-up) so switching modes never
           // changes the card height.
-          <div className={`-mt-2 flex justify-end ${authMode === "sign-in" ? "" : "invisible"}`}>
+          <div className={`-mt-2 flex justify-end ${visibleAuthMode === "sign-in" ? "" : "invisible"}`}>
             <button
               type="button"
-              tabIndex={authMode === "sign-in" ? 0 : -1}
-              aria-hidden={authMode !== "sign-in"}
+              tabIndex={visibleAuthMode === "sign-in" ? 0 : -1}
+              aria-hidden={visibleAuthMode !== "sign-in"}
               className="text-sm font-medium text-[var(--dls-text-primary)] transition hover:opacity-70"
               onClick={() => {
                 setAuthMode("sign-in");
@@ -953,7 +963,7 @@ export function AuthPanel({
               <span>Waiting for your verification code</span>
             </div>
           ) : null}
-          {authError && authMode === "sign-in" && !verificationRequired && showEmailPasswordAuth ? (
+          {authError && visibleAuthMode === "sign-in" && !isSingleOrgPrivateSignup && !verificationRequired && showEmailPasswordAuth ? (
             <button
               type="button"
               className="mt-1 inline-flex items-center justify-center gap-1 font-medium text-[var(--dls-text-primary)] transition hover:opacity-70"

--- a/ee/apps/den-web/app/(den)/_lib/auth-ui-policy.ts
+++ b/ee/apps/den-web/app/(den)/_lib/auth-ui-policy.ts
@@ -1,0 +1,16 @@
+import type { AuthMode } from "./den-flow";
+import type { DenWebRuntimeConfig } from "./runtime-config";
+
+export function isSingleOrgSignupDisabled(config: DenWebRuntimeConfig, runtimeConfigLoaded: boolean) {
+  return runtimeConfigLoaded && config.orgMode === "single_org" && !config.singleOrgAllowPublicSignup;
+}
+
+export function resolveVisibleAuthMode(input: {
+  authMode: AuthMode;
+  runtimeConfig: DenWebRuntimeConfig;
+  runtimeConfigLoaded: boolean;
+}): AuthMode {
+  return isSingleOrgSignupDisabled(input.runtimeConfig, input.runtimeConfigLoaded) && input.authMode === "sign-up"
+    ? "sign-in"
+    : input.authMode;
+}

--- a/ee/apps/den-web/app/(den)/_lib/runtime-config.ts
+++ b/ee/apps/den-web/app/(den)/_lib/runtime-config.ts
@@ -6,6 +6,7 @@ export type DenWebRuntimeConfig = {
   orgMode: DenOrgMode;
   singleOrgName: string;
   singleOrgSlug: string;
+  singleOrgAllowPublicSignup: boolean;
   singleOrgSsoConfigured: boolean;
 };
 
@@ -15,6 +16,7 @@ export const EMPTY_RUNTIME_CONFIG: DenWebRuntimeConfig = {
   orgMode: "single_org",
   singleOrgName: "OpenWork",
   singleOrgSlug: "default",
+  singleOrgAllowPublicSignup: false,
   singleOrgSsoConfigured: false
 };
 
@@ -46,6 +48,7 @@ function normalizeRuntimeConfig(value: unknown): DenWebRuntimeConfig {
     orgMode: normalizeOrgMode(readStringProperty(value, "orgMode")),
     singleOrgName: singleOrgName || "OpenWork",
     singleOrgSlug: singleOrgSlug || "default",
+    singleOrgAllowPublicSignup: readBooleanProperty(value, "singleOrgAllowPublicSignup"),
     singleOrgSsoConfigured: readBooleanProperty(value, "singleOrgSsoConfigured")
   };
 }

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -1064,19 +1064,20 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
     setAuthBusy(true);
     setAuthError(null);
+    const submitMode: AuthMode = isSingleOrgMode && !runtimeConfig.singleOrgAllowPublicSignup && authMode === "sign-up" ? "sign-in" : authMode;
     trackPosthogEvent("den_auth_submitted", {
-      mode: authMode,
+      mode: submitMode,
       method: "email"
     });
 
     try {
-      const endpoint = authMode === "sign-up" ? "/api/auth/sign-up/email" : "/api/auth/sign-in/email";
+      const endpoint = submitMode === "sign-up" ? "/api/auth/sign-up/email" : "/api/auth/sign-in/email";
       const trimmedEmail = email.trim();
       if (trimmedEmail && await redirectToRequiredSso(trimmedEmail)) {
         return null;
       }
       const body =
-        authMode === "sign-up"
+        submitMode === "sign-up"
           ? {
               name: authName.trim() || DEFAULT_AUTH_NAME,
               email: trimmedEmail,
@@ -1098,7 +1099,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
         }
         setAuthError(getErrorMessage(payload, `Authentication failed with ${response.status}.`));
         trackPosthogEvent("den_auth_failed", {
-          mode: authMode,
+          mode: submitMode,
           method: "email",
           status: response.status
         });
@@ -1107,7 +1108,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
 
       const token = getToken(payload);
 
-      if (authMode === "sign-up" && !token) {
+      if (submitMode === "sign-up" && !token) {
         setUser(null);
         openVerificationStep(trimmedEmail, `We emailed a 6-digit verification code to ${trimmedEmail}. Enter it below to finish creating your account.`);
         appendEvent("info", "Verification code sent", trimmedEmail);
@@ -1117,12 +1118,12 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
         });
         return null;
       }
-      return await finalizeEmailPasswordSignIn(authMode, trimmedEmail);
+      return await finalizeEmailPasswordSignIn(submitMode, trimmedEmail);
     } catch (error) {
       const message = error instanceof Error ? error.message : "Unknown network error";
       setAuthError(message);
       trackPosthogEvent("den_auth_failed", {
-        mode: authMode,
+        mode: submitMode,
         method: "email",
         reason: "network_error"
       });

--- a/ee/apps/den-web/app/api/runtime-config/route.ts
+++ b/ee/apps/den-web/app/api/runtime-config/route.ts
@@ -10,6 +10,23 @@ function readOrgMode() {
   return readPublicRuntimeEnv("DEN_ORG_MODE") === "multi_org" ? "multi_org" : "single_org";
 }
 
+function readBooleanEnv(name: string, defaultValue: boolean) {
+  const normalized = readPublicRuntimeEnv(name).toLowerCase();
+  if (!normalized) {
+    return defaultValue;
+  }
+
+  if (["1", "true", "yes", "y", "on"].includes(normalized)) {
+    return true;
+  }
+
+  if (["0", "false", "no", "n", "off"].includes(normalized)) {
+    return false;
+  }
+
+  return defaultValue;
+}
+
 function normalizeBaseUrl(value: string) {
   return value.trim().replace(/\/+$/, "");
 }
@@ -64,6 +81,7 @@ export async function GET() {
       orgMode,
       singleOrgName: readPublicRuntimeEnv("DEN_SINGLE_ORG_NAME") || "OpenWork",
       singleOrgSlug: readPublicRuntimeEnv("DEN_SINGLE_ORG_SLUG") || "default",
+      singleOrgAllowPublicSignup: readBooleanEnv("DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP", orgMode === "multi_org"),
       singleOrgSsoConfigured
     },
     {

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts app/api/_lib/upstream-proxy.test.mjs",
+    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/single-org-signup-ui.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/single-org-signup-ui.test.ts
+++ b/ee/apps/den-web/tests/single-org-signup-ui.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { isSingleOrgSignupDisabled, resolveVisibleAuthMode } from "../app/(den)/_lib/auth-ui-policy";
+import { EMPTY_RUNTIME_CONFIG, type DenWebRuntimeConfig } from "../app/(den)/_lib/runtime-config";
+import { GET } from "../app/api/runtime-config/route";
+
+const originalEnv = {
+  DEN_API_BASE: process.env.DEN_API_BASE,
+  DEN_ORG_MODE: process.env.DEN_ORG_MODE,
+  DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP: process.env.DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP,
+};
+
+function restoreEnvValue(name: keyof typeof originalEnv) {
+  const value = originalEnv[name];
+  if (value === undefined) {
+    delete process.env[name];
+    return;
+  }
+  process.env[name] = value;
+}
+
+function readBooleanProperty(value: unknown, key: string) {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+  const property = Object.getOwnPropertyDescriptor(value, key)?.value;
+  return typeof property === "boolean" ? property : null;
+}
+
+afterEach(() => {
+  restoreEnvValue("DEN_API_BASE");
+  restoreEnvValue("DEN_ORG_MODE");
+  restoreEnvValue("DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP");
+});
+
+describe("single-org public signup UI policy", () => {
+  test("runtime config exposes private public-signup default for single-org deployments", async () => {
+    delete process.env.DEN_API_BASE;
+    process.env.DEN_ORG_MODE = "single_org";
+    delete process.env.DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP;
+
+    const payload: unknown = await (await GET()).json();
+
+    expect(readBooleanProperty(payload, "singleOrgAllowPublicSignup")).toBe(false);
+  });
+
+  test("runtime config parses Helm string public-signup values", async () => {
+    delete process.env.DEN_API_BASE;
+    process.env.DEN_ORG_MODE = "single_org";
+    process.env.DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP = "true";
+
+    const payload: unknown = await (await GET()).json();
+
+    expect(readBooleanProperty(payload, "singleOrgAllowPublicSignup")).toBe(true);
+  });
+
+  test("private single-org UI resolves sign-up requests to sign-in", () => {
+    const privateSingleOrgConfig: DenWebRuntimeConfig = {
+      ...EMPTY_RUNTIME_CONFIG,
+      orgMode: "single_org",
+      singleOrgAllowPublicSignup: false,
+    };
+
+    expect(isSingleOrgSignupDisabled(privateSingleOrgConfig, true)).toBe(true);
+    expect(resolveVisibleAuthMode({
+      authMode: "sign-up",
+      runtimeConfig: privateSingleOrgConfig,
+      runtimeConfigLoaded: true,
+    })).toBe("sign-in");
+  });
+
+  test("public single-org and multi-org UI can still show account creation", () => {
+    const publicSingleOrgConfig: DenWebRuntimeConfig = {
+      ...EMPTY_RUNTIME_CONFIG,
+      orgMode: "single_org",
+      singleOrgAllowPublicSignup: true,
+    };
+    const multiOrgConfig: DenWebRuntimeConfig = {
+      ...EMPTY_RUNTIME_CONFIG,
+      orgMode: "multi_org",
+      singleOrgAllowPublicSignup: true,
+    };
+
+    expect(isSingleOrgSignupDisabled(publicSingleOrgConfig, true)).toBe(false);
+    expect(resolveVisibleAuthMode({
+      authMode: "sign-up",
+      runtimeConfig: publicSingleOrgConfig,
+      runtimeConfigLoaded: true,
+    })).toBe("sign-up");
+    expect(resolveVisibleAuthMode({
+      authMode: "sign-up",
+      runtimeConfig: multiOrgConfig,
+      runtimeConfigLoaded: true,
+    })).toBe("sign-up");
+  });
+});

--- a/evals/flows/single-org-signup-policy.flow.mjs
+++ b/evals/flows/single-org-signup-policy.flow.mjs
@@ -1,0 +1,144 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "single-org-signup-policy";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const DEN_API = join(ROOT, "ee", "apps", "den-api");
+
+// Narration is loaded from the approved script (evals/voiceovers/single-org-signup-policy.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function commandOutput(result) {
+  return [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+}
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${actual})` : ""}`);
+}
+
+function runDenApiTest(file, pattern) {
+  return spawnSync("bun", ["--conditions=development", "test", file, "--test-name-pattern", pattern], {
+    cwd: DEN_API,
+    encoding: "utf8",
+    timeout: 60_000,
+    env: process.env,
+  });
+}
+
+function runDenWebTest(pattern) {
+  return spawnSync("pnpm", ["--filter", "@openwork-ee/den-web", "exec", "bun", "test", "tests/single-org-signup-ui.test.ts", "--test-name-pattern", pattern], {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 60_000,
+    env: process.env,
+  });
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Single-org deployments block private email signup and enforce singleton email domains before account creation",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Private single-org UI is sign-in only",
+      run: async (ctx) => {
+        let result;
+        await ctx.prove("With single-org public signup disabled, the Den Web auth policy resolves sign-up requests to sign-in", {
+          voiceover: vo[0],
+          action: async () => {
+            result = runDenWebTest("private single-org UI resolves sign-up requests to sign-in");
+          },
+          assert: async () => {
+            const output = commandOutput(result);
+            witness(ctx, result.status === 0, "The focused Den Web private-signup UI policy test passes", output);
+            witness(ctx, output.includes("1 pass"), "Exactly one focused UI test covered the hidden signup behavior", output);
+            ctx.output("$ pnpm --filter @openwork-ee/den-web exec bun test tests/single-org-signup-ui.test.ts --test-name-pattern private", output);
+          },
+        });
+      },
+    },
+    {
+      name: "Private email signup is rejected before Better Auth",
+      run: async (ctx) => {
+        let result;
+        await ctx.prove("An anonymous email signup request receives the private-signup 403 before Better Auth validation or persistence", {
+          voiceover: vo[1],
+          action: async () => {
+            result = runDenApiTest("test/single-org-route-guards.test.ts", "raw Better Auth email signup is blocked");
+          },
+          assert: async () => {
+            const output = commandOutput(result);
+            witness(ctx, result.status === 0, "The focused route guard test passes", output);
+            witness(ctx, output.includes("1 pass"), "Exactly one focused route test hit POST /api/auth/sign-up/email and received the signup-policy 403", output);
+            ctx.output("$ bun --conditions=development test test/single-org-route-guards.test.ts --test-name-pattern raw Better Auth email signup is blocked", output);
+          },
+        });
+      },
+    },
+    {
+      name: "Matching singleton domains are allowed",
+      run: async (ctx) => {
+        let result;
+        await ctx.prove("With public signup enabled and acme.com configured, an acme.com signup passes the pre-creation policy", {
+          voiceover: vo[2],
+          action: async () => {
+            result = runDenApiTest("test/single-org-mode.test.ts", "allows matching domains");
+          },
+          assert: async () => {
+            const output = commandOutput(result);
+            witness(ctx, result.status === 0, "The matching-domain policy test passes", output);
+            witness(ctx, output.includes("1 pass"), "Exactly one focused policy test returned no violation for User@Acme.com", output);
+            ctx.output("$ bun --conditions=development test test/single-org-mode.test.ts --test-name-pattern allows matching domains", output);
+          },
+        });
+      },
+    },
+    {
+      name: "Out-of-domain singleton signup is rejected",
+      run: async (ctx) => {
+        let result;
+        await ctx.prove("With public signup enabled and acme.com configured, an outside.com signup is rejected by the pre-creation policy", {
+          voiceover: vo[3],
+          action: async () => {
+            result = runDenApiTest("test/single-org-mode.test.ts", "rejects outside domains");
+          },
+          assert: async () => {
+            const output = commandOutput(result);
+            witness(ctx, result.status === 0, "The out-of-domain policy test passes", output);
+            witness(ctx, output.includes("1 pass"), "Exactly one focused policy test asserted the email_domain_restricted violation for outside.com", output);
+            ctx.output("$ bun --conditions=development test test/single-org-mode.test.ts --test-name-pattern rejects outside domains", output);
+          },
+        });
+      },
+    },
+    {
+      name: "Multi-org auth discovery is unchanged",
+      run: async (ctx) => {
+        let result;
+        await ctx.prove("Multi-organization login discovery still returns account creation for unknown users", {
+          voiceover: vo[4],
+          action: async () => {
+            result = runDenApiTest("test/auth-login-options.test.ts", "returns new account");
+          },
+          assert: async () => {
+            const output = commandOutput(result);
+            witness(ctx, result.status === 0, "The multi-org/default login option test passes", output);
+            witness(ctx, output.includes("1 pass"), "Exactly one focused login-discovery test kept unknown users resolving to new_account when account creation is allowed", output);
+            ctx.output("$ bun --conditions=development test test/auth-login-options.test.ts --test-name-pattern returns new account", output);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/single-org-signup-policy.md
+++ b/evals/voiceovers/single-org-signup-policy.md
@@ -1,0 +1,11 @@
+# single-org-signup-policy — Enforce private signup and organization email domains
+
+1. With single-org public signup disabled, the sign-in screen offers sign-in only—there is no account creation flow.
+
+2. An anonymous email signup request is rejected server-side, and no user, session, or organization membership is created.
+
+3. With public signup enabled and an allowed email domain configured, a matching user can register and join the single organization.
+
+4. An out-of-domain signup is rejected before account creation, leaving no user, session, or membership records.
+
+5. Multi-organization authentication behavior remains unchanged.


### PR DESCRIPTION
## Summary
- enforce `DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP` before Better Auth creates an account
- apply single-org allowed email domains during signup
- hide unavailable signup flows in Den Web while preserving multi-org behavior
- add backend, frontend, and fraimz regression coverage

## Tests
- `pnpm --filter @openwork-ee/den-api exec bun --conditions=development test test/single-org-mode.test.ts`
- `pnpm --filter @openwork-ee/den-api exec bun --conditions=development test test/single-org-route-guards.test.ts`
- `pnpm --filter @openwork-ee/den-api exec bun --conditions=development test test/auth-login-options.test.ts`
- `pnpm --filter @openwork-ee/den-web test`
- `pnpm --filter @openwork-ee/den-web typecheck`
- `pnpm fraimz --flow single-org-signup-policy` — Passed

## Proof
Fraimz flow: `single-org-signup-policy`