### PR TITLE
fix(den-db): precompile production migrations

### DIFF
--- a/.github/workflows/den-db-check.yml
+++ b/.github/workflows/den-db-check.yml
@@ -3,7 +3,15 @@ name: Den DB Check
 on:
   pull_request:
     paths:
+      - ".github/workflows/den-db-check.yml"
+      - ".github/workflows/den-db-migrate.yml"
+      - ".github/workflows/publish-ee-images.yml"
+      - "ee/apps/den-api/package.json"
+      - "ee/apps/den-api/scripts/build.mjs"
       - "ee/packages/den-db/**"
+      - "packaging/docker/Dockerfile.den"
+      - "packaging/helm/openwork-ee/values.yaml"
+      - "packaging/helm/openwork-ee/templates/migration-job.yaml"
 
 permissions:
   contents: read
@@ -32,6 +40,9 @@ jobs:
 
       - name: Generate migrations from schema
         run: pnpm --filter @openwork-ee/den-db db:generate
+
+      - name: Run migration readiness tests
+        run: pnpm --filter @openwork-ee/den-db test
 
       - name: Fail if schema changed without a committed migration
         run: |

--- a/.github/workflows/publish-ee-images.yml
+++ b/.github/workflows/publish-ee-images.yml
@@ -252,6 +252,20 @@ jobs:
             sentry_release=${{ secrets.SENTRY_RELEASE }}
             sentry_dist=${{ secrets.SENTRY_DIST }}
 
+      - name: Assert Den DB migration assets
+        if: ${{ github.event_name == 'pull_request' && matrix.image == 'openwork-den-api' }}
+        shell: bash
+        env:
+          IMAGE_TAGS: ${{ steps.meta.outputs.tags }}
+        run: |
+          set -euo pipefail
+          image_tag="${IMAGE_TAGS%%$'\n'*}"
+          docker run --rm --entrypoint sh "$image_tag" -lc '
+            test -s /app/ee/packages/den-db/dist/scripts/bootstrap.js
+            test -s /app/ee/packages/den-db/dist/current-schema.sql
+            test -s /app/ee/packages/den-db/dist/drizzle/meta/_journal.json
+          '
+
       - name: Smoke health endpoint
         if: ${{ github.event_name == 'pull_request' }}
         shell: bash

--- a/docs/memory-bank-architecture.md
+++ b/docs/memory-bank-architecture.md
@@ -119,8 +119,8 @@ on-device.
 ### Search backend [DECISION: MySQL FULLTEXT] + [FIX B2]
 PlanetScale/Vitess supports `FULLTEXT` + `MATCH … AGAINST`. v0 uses **NATURAL LANGUAGE
 MODE**, owner-scoped, relevance-ranked.
-- **Fresh-install hazard:** new DBs bootstrap via `drizzle-kit push` (which cannot see a
-  raw `FULLTEXT` index — Drizzle mysql-core has no FULLTEXT DSL,
+- **Fresh-install hazard:** new DBs bootstrap from the build-time current-schema
+  SQL snapshot (which cannot see a raw `FULLTEXT` index — Drizzle mysql-core has no FULLTEXT DSL,
   [drizzle-orm#1495](https://github.com/drizzle-team/drizzle-orm/issues/1495)) and
   baseline marks migrations applied-without-executing — so a plain migration-only index
   is **silently absent in production** while working on incrementally-migrated dev DBs.

--- a/docs/org-install-links.md
+++ b/docs/org-install-links.md
@@ -47,7 +47,7 @@ Run the migration once, then restart Den:
 
 ```bash
 docker compose -f packaging/docker/docker-compose.den-dev.yml exec den sh -lc \
-  "pnpm --dir /app/ee/packages/den-db run db:bootstrap"
+  "node /app/ee/packages/den-db/dist/scripts/bootstrap.js"
 ```
 
 If the stack has a custom Compose project name, include the same `-p <project>`

--- a/ee/packages/den-db/README.md
+++ b/ee/packages/den-db/README.md
@@ -35,6 +35,12 @@ Install or upgrade a production database, including empty first installs:
 pnpm --dir ee/packages/den-db db:bootstrap
 ```
 
+Containerized production installs run the precompiled artifact directly:
+
+```bash
+node /app/ee/packages/den-db/dist/scripts/bootstrap.js
+```
+
 ## Automated migrations (CI)
 
 Two GitHub Actions workflows keep schema and database in sync:
@@ -81,8 +87,9 @@ ship as a later migration once no deployed code references the old shape.
 
 - The migration chain has no `0000` baseline (history starts at `0001`,
   which alters pre-existing tables), so empty production databases should use
-  `db:bootstrap`. It applies the current schema once, records the migration
-  baseline, then runs `db:migrate`. Use `db:push` only for development.
+  `db:bootstrap`. It applies the build-time current-schema SQL snapshot once,
+  records the migration baseline, then runs pending migrations with Drizzle ORM.
+  Use `db:push` only for development.
 - `db:generate` is the default path for new migration files.
 - `drizzle/meta/` must stay in sync with the SQL migration history so future generation stays incremental.
 - Only repair `drizzle/meta/` manually when recovering broken Drizzle history.

--- a/ee/packages/den-db/drizzle.config.ts
+++ b/ee/packages/den-db/drizzle.config.ts
@@ -4,8 +4,8 @@ import { parseMySqlConnectionConfig } from "./src/mysql-config.ts"
 
 const databaseUrl = process.env.DATABASE_URL?.trim()
 
-function isGenerateCommand() {
-  return process.argv.some((arg) => arg === "generate")
+function isOfflineSchemaCommand() {
+  return process.argv.some((arg) => arg === "generate" || arg === "export")
 }
 
 function resolveDrizzleDbCredentials() {
@@ -19,7 +19,7 @@ function resolveDrizzleDbCredentials() {
   const database = process.env.DATABASE_NAME?.trim()
 
   if (!host || !user || !database) {
-    if (isGenerateCommand()) {
+    if (isOfflineSchemaCommand()) {
       return {
         host: "127.0.0.1",
         user: "root",

--- a/ee/packages/den-db/package.json
+++ b/ee/packages/den-db/package.json
@@ -78,13 +78,14 @@
     }
   },
   "scripts": {
-    "build": "pnpm run build:utils && tsup",
+    "build": "pnpm run build:utils && tsup && tsup --config tsup.scripts.config.ts && node scripts/build-assets.mjs",
     "build:utils": "pnpm --dir ../utils run build",
     "db:baseline": "node --import tsx scripts/baseline-migrations.ts",
-    "db:bootstrap": "pnpm run build && node --import tsx scripts/bootstrap.ts",
+    "db:bootstrap": "pnpm run build && node dist/scripts/bootstrap.js",
     "db:generate": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs generate --config drizzle.config.ts",
     "db:migrate": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs migrate --config drizzle.config.ts && node --import tsx scripts/ensure-fulltext-indexes.ts",
     "db:push": "pnpm run build && node --import tsx ./node_modules/drizzle-kit/bin.cjs push --config drizzle.config.ts && node --import tsx scripts/ensure-fulltext-indexes.ts",
+    "test": "tsx --test test/*.test.ts",
     "db:verify-memory": "pnpm run build && node --import tsx scripts/verify-memory-schema.ts",
     "benchmark:admin-scale:mysql": "node --import tsx scripts/admin-scale-benchmark.ts"
   },

--- a/ee/packages/den-db/scripts/bootstrap.ts
+++ b/ee/packages/den-db/scripts/bootstrap.ts
@@ -1,34 +1,75 @@
 /**
- * Production-oriented install/upgrade entrypoint for Den databases.
+ * Production install/upgrade entrypoint for Den databases.
  *
- * Empty databases cannot currently be built by replaying the historical
- * migration chain, because the migration history starts after early schema
- * state. For a new empty database we apply the current schema once, record the
- * committed migrations as the baseline, then run normal migrations.
- *
- * Existing databases skip schema push. If they have tables but no Drizzle
- * migration ledger, we baseline them before running db:migrate.
+ * Empty databases are initialized from the build-time current-schema snapshot,
+ * then committed migrations are recorded as the baseline. Existing databases
+ * without a migration ledger are baselined before the normal migration pass.
  */
 import "../src/load-env.ts"
-import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
 import path from "node:path"
 import { fileURLToPath } from "node:url"
+import { drizzle } from "drizzle-orm/mysql2"
+import { migrate } from "drizzle-orm/mysql2/migrator"
+import { readMigrationFiles } from "drizzle-orm/migrator"
+import mysql from "mysql2/promise"
 import { ensureFulltextIndexes } from "../src/fulltext.ts"
+import { parseMySqlConnectionConfig } from "../src/mysql-config.ts"
 import { createExecutor, type Executor } from "./db-executor.ts"
 
 const MIGRATIONS_TABLE = "__drizzle_migrations"
 
-const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const scriptPath = fileURLToPath(import.meta.url)
+const distDir = path.resolve(path.dirname(scriptPath), "..")
+const migrationsFolder = path.join(distDir, "drizzle")
+const currentSchemaPath = path.join(distDir, "current-schema.sql")
 
-function run(command: string, args: string[]) {
-  const result = spawnSync(command, args, {
-    cwd: packageDir,
-    env: process.env,
-    stdio: "inherit",
-  })
+function mysqlConnectionConfigFromEnv(): ReturnType<typeof parseMySqlConnectionConfig> {
+  const databaseUrl = process.env.DATABASE_URL?.trim()
+  if (databaseUrl) {
+    return parseMySqlConnectionConfig(databaseUrl)
+  }
 
-  if (result.status !== 0) {
-    process.exit(result.status ?? 1)
+  const host = process.env.DATABASE_HOST?.trim()
+  const user = process.env.DATABASE_USERNAME?.trim()
+  const password = process.env.DATABASE_PASSWORD ?? ""
+  const database = process.env.DATABASE_NAME?.trim()
+  const portValue = process.env.DATABASE_PORT?.trim()
+  const port = portValue ? Number(portValue) : 3306
+
+  if (!host || !user || !database) {
+    throw new Error("Provide DATABASE_URL, or DATABASE_HOST/DATABASE_USERNAME/DATABASE_PASSWORD/DATABASE_NAME.")
+  }
+
+  if (!Number.isInteger(port) || port <= 0) {
+    throw new Error("DATABASE_PORT must be a positive integer")
+  }
+
+  return {
+    host,
+    port,
+    user,
+    password,
+    database,
+    ssl: { rejectUnauthorized: true },
+  }
+}
+
+function splitSqlStatements(sql: string) {
+  return sql
+    .split(/;\s*(?:\r?\n|$)/)
+    .map((statement) => statement.trim())
+    .filter(Boolean)
+}
+
+async function applyCurrentSchema(executor: Executor) {
+  const statements = splitSqlStatements(readFileSync(currentSchemaPath, "utf8"))
+  if (statements.length === 0) {
+    throw new Error(`No SQL statements found in ${currentSchemaPath}`)
+  }
+
+  for (const statement of statements) {
+    await executor.query(statement)
   }
 }
 
@@ -39,36 +80,77 @@ async function listTables(executor: Executor) {
     .filter((value): value is string => Boolean(value))
 }
 
-async function hasMigrationLedger(executor: Executor) {
-  const tables = await listTables(executor)
-  return tables.some((table) => table === MIGRATIONS_TABLE)
+function latestMigrationMillis(rows: Record<string, unknown>[]) {
+  const latest = rows[0]?.latest
+  if (typeof latest === "number") {
+    return latest
+  }
+  if (typeof latest === "bigint") {
+    return Number(latest)
+  }
+  if (typeof latest === "string") {
+    const parsed = Number(latest)
+    return Number.isFinite(parsed) ? parsed : 0
+  }
+  return 0
 }
 
-async function main() {
+async function baselineCommittedMigrations(executor: Executor) {
+  const migrations = readMigrationFiles({ migrationsFolder }).sort((left, right) => left.folderMillis - right.folderMillis)
+
+  await executor.query(
+    `create table if not exists \`${MIGRATIONS_TABLE}\` (id serial primary key, hash text not null, created_at bigint)`,
+  )
+
+  const rows = await executor.query(`select max(created_at) as latest from \`${MIGRATIONS_TABLE}\``)
+  const latest = latestMigrationMillis(rows)
+  const pending = migrations.filter((migration) => migration.folderMillis > latest)
+
+  if (pending.length === 0) {
+    console.log("[den-db] migration baseline already current")
+    return
+  }
+
+  console.log(`[den-db] recording ${pending.length} committed migrations as baseline`)
+  for (const migration of pending) {
+    await executor.query(`insert into \`${MIGRATIONS_TABLE}\` (hash, created_at) values (?, ?)`, [
+      migration.hash,
+      migration.folderMillis,
+    ])
+  }
+}
+
+async function runCommittedMigrations() {
+  const connection = await mysql.createConnection(mysqlConnectionConfigFromEnv())
+  try {
+    const db = drizzle(connection)
+    await migrate(db, { migrationsFolder })
+  } finally {
+    await connection.end()
+  }
+}
+
+export async function bootstrapDenDb() {
   const executor = await createExecutor()
   try {
     const tables = await listTables(executor)
     const applicationTables = tables.filter((table) => table !== MIGRATIONS_TABLE)
 
     if (applicationTables.length === 0) {
-      console.log("[den-db] empty database detected; applying current schema")
-      run("sh", ["-lc", "yes | node --import tsx ./node_modules/drizzle-kit/bin.cjs push --config drizzle.config.ts"])
-      console.log("[den-db] recording migration baseline")
-      run("node", ["--import", "tsx", "scripts/baseline-migrations.ts", "--yes"])
-    } else if (!(await hasMigrationLedger(executor))) {
+      console.log("[den-db] empty database detected; applying current schema snapshot")
+      await applyCurrentSchema(executor)
+      await baselineCommittedMigrations(executor)
+    } else if (!tables.includes(MIGRATIONS_TABLE)) {
       console.log("[den-db] existing schema without migration ledger detected; recording baseline")
-      run("node", ["--import", "tsx", "scripts/baseline-migrations.ts", "--yes"])
+      await baselineCommittedMigrations(executor)
     }
   } finally {
     await executor.close()
   }
 
-  console.log("[den-db] running migrations")
-  run("node", ["--import", "tsx", "./node_modules/drizzle-kit/bin.cjs", "migrate", "--config", "drizzle.config.ts"])
+  console.log("[den-db] running committed migrations")
+  await runCommittedMigrations()
 
-  // FULLTEXT indexes cannot be expressed via Drizzle's DSL and are baselined-away on the
-  // fresh-install (push + baseline) path, so create them idempotently here — the same seam
-  // the post-`db:migrate` hook runs, so the two apply paths cannot drift (§3, B2).
   console.log("[den-db] ensuring FULLTEXT indexes")
   const indexExecutor = await createExecutor()
   try {
@@ -78,7 +160,9 @@ async function main() {
   }
 }
 
-main().catch((error) => {
-  console.error(error instanceof Error ? error.message : error)
-  process.exit(1)
-})
+if (process.argv[1] && path.resolve(process.argv[1]) === scriptPath) {
+  bootstrapDenDb().catch((error) => {
+    console.error(error instanceof Error ? error.message : error)
+    process.exit(1)
+  })
+}

--- a/ee/packages/den-db/scripts/build-assets.mjs
+++ b/ee/packages/den-db/scripts/build-assets.mjs
@@ -1,0 +1,46 @@
+import { spawnSync } from "node:child_process"
+import { cpSync, mkdirSync, rmSync, writeFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const distDir = path.join(packageDir, "dist")
+const migrationsDir = path.join(packageDir, "drizzle")
+const distMigrationsDir = path.join(distDir, "drizzle")
+const currentSchemaPath = path.join(distDir, "current-schema.sql")
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm"
+
+function sqlFromDrizzleKitExport(stdout) {
+  const lines = stdout.replace(/\r\n/g, "\n").split("\n")
+  const firstSqlLine = lines.findIndex((line) => /^(CREATE|ALTER|DROP)\s/i.test(line.trimStart()))
+
+  if (firstSqlLine === -1) {
+    throw new Error("drizzle-kit export did not emit SQL")
+  }
+
+  return `${lines.slice(firstSqlLine).join("\n").trim()}\n`
+}
+
+function generateCurrentSchemaSql() {
+  const result = spawnSync(pnpmCommand, ["exec", "drizzle-kit", "export", "--config", "drizzle.config.ts"], {
+    cwd: packageDir,
+    encoding: "utf8",
+    env: process.env,
+  })
+
+  if (result.status !== 0) {
+    process.stdout.write(result.stdout)
+    process.stderr.write(result.stderr)
+    process.exit(result.status ?? 1)
+  }
+
+  return sqlFromDrizzleKitExport(result.stdout)
+}
+
+mkdirSync(distDir, { recursive: true })
+rmSync(distMigrationsDir, { recursive: true, force: true })
+cpSync(migrationsDir, distMigrationsDir, { recursive: true })
+writeFileSync(currentSchemaPath, generateCurrentSchemaSql())
+
+console.log(`[den-db] copied migrations to ${path.relative(packageDir, distMigrationsDir)}`)
+console.log(`[den-db] wrote ${path.relative(packageDir, currentSchemaPath)}`)

--- a/ee/packages/den-db/scripts/db-executor.ts
+++ b/ee/packages/den-db/scripts/db-executor.ts
@@ -16,6 +16,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
+function recordsFromRows(rows: unknown): Record<string, unknown>[] {
+  return Array.isArray(rows) ? rows.filter(isRecord) : []
+}
+
 export async function createExecutor(): Promise<Executor> {
   const databaseUrl = process.env.DATABASE_URL?.trim()
 
@@ -25,7 +29,7 @@ export async function createExecutor(): Promise<Executor> {
     return {
       query: async (sql, args = []) => {
         const [rows] = await connection.query(sql, args)
-        return Array.isArray(rows) ? rows.filter(isRecord) : []
+        return recordsFromRows(rows)
       },
       close: () => connection.end(),
     }
@@ -44,7 +48,7 @@ export async function createExecutor(): Promise<Executor> {
   return {
     query: async (sql, args = []) => {
       const result = await client.execute(sql, args)
-      return result.rows.filter(isRecord)
+      return recordsFromRows(result.rows)
     },
     close: async () => {},
   }

--- a/ee/packages/den-db/src/fulltext.ts
+++ b/ee/packages/den-db/src/fulltext.ts
@@ -23,9 +23,10 @@ async function memoryFulltextIndexExists(executor: FulltextIndexExecutor): Promi
  * Idempotently create the FULLTEXT index on `memory.content`.
  *
  * This MUST run on a path both the fresh-install bootstrap and the incremental migrate
- * paths hit: `drizzle-kit push` cannot emit a raw FULLTEXT index and the baseline step
- * marks migrations applied-without-executing, so a migration-only index is silently
- * absent on freshly bootstrapped databases (memory-bank-architecture.md §3, B2).
+ * paths hit: Drizzle's schema snapshot/push cannot emit a raw FULLTEXT index and
+ * the baseline step marks migrations applied-without-executing, so a
+ * migration-only index is silently absent on freshly bootstrapped databases
+ * (memory-bank-architecture.md §3, B2).
  */
 export async function ensureMemoryFulltextIndex(
   executor: FulltextIndexExecutor,

--- a/ee/packages/den-db/test/migration-readiness.test.ts
+++ b/ee/packages/den-db/test/migration-readiness.test.ts
@@ -1,0 +1,137 @@
+import assert from "node:assert/strict"
+import { spawnSync } from "node:child_process"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { describe, test } from "node:test"
+import { fileURLToPath } from "node:url"
+
+const packageDir = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+const repoRoot = path.resolve(packageDir, "..", "..", "..")
+const forbiddenDeployTools = ["pnpm", "tsx", "tsup", "drizzle-kit"]
+const pnpmCommand = process.platform === "win32" ? "pnpm.cmd" : "pnpm"
+
+function readRepoFile(relativePath: string) {
+  return readFileSync(path.join(repoRoot, relativePath), "utf8")
+}
+
+function requireSlice(contents: string, start: string, end: string) {
+  const startIndex = contents.indexOf(start)
+  assert.notEqual(startIndex, -1, `Missing ${start}`)
+
+  const endIndex = contents.indexOf(end, startIndex + start.length)
+  assert.notEqual(endIndex, -1, `Missing ${end}`)
+
+  return contents.slice(startIndex, endIndex)
+}
+
+function assertNoForbiddenDeployTools(contents: string) {
+  for (const tool of forbiddenDeployTools) {
+    assert.equal(contents.includes(tool), false, `deploy path must not reference ${tool}`)
+  }
+}
+
+function shortOutput(output: string) {
+  return output.slice(Math.max(0, output.length - 4_000))
+}
+
+describe("Den DB migration readiness wiring", () => {
+  test("Helm migration defaults execute the precompiled dist runner", () => {
+    const values = readRepoFile("packaging/helm/openwork-ee/values.yaml")
+    const migrationsBlock = requireSlice(values, "migrations:\n", "\ningress:")
+
+    assert.match(migrationsBlock, /command:\n\s+- node/)
+    assert.match(migrationsBlock, /args:\n\s+- \/app\/ee\/packages\/den-db\/dist\/scripts\/bootstrap\.js/)
+    assertNoForbiddenDeployTools(migrationsBlock)
+  })
+
+  test("Dockerfile.den builds Den DB dist assets before the Den API image build", () => {
+    const dockerfile = readRepoFile("packaging/docker/Dockerfile.den")
+    const denDbBuildIndex = dockerfile.indexOf("RUN pnpm --dir /app/ee/packages/den-db run build")
+    const denApiBuildIndex = dockerfile.indexOf("pnpm --dir /app/ee/apps/den-api run build")
+
+    assert.notEqual(denDbBuildIndex, -1, "Dockerfile.den builds @openwork-ee/den-db")
+    assert.notEqual(denApiBuildIndex, -1, "Dockerfile.den builds @openwork-ee/den-api")
+    assert.ok(denDbBuildIndex < denApiBuildIndex, "den-db dist assets are built before den-api")
+  })
+
+  test("hosted Den API build includes den-db assets but start does not run migrations", () => {
+    const denApiPackage = readRepoFile("ee/apps/den-api/package.json")
+    const denApiBuild = readRepoFile("ee/apps/den-api/scripts/build.mjs")
+    const startLine = denApiPackage.split("\n").find((line) => line.includes('"start"')) ?? ""
+
+    assert.match(denApiPackage, /"build:den-db": "pnpm --filter @openwork-ee\/den-db build"/)
+    assert.match(denApiBuild, /run\(pnpmCommand, \["run", "build:den-db"\]\)/)
+    assert.match(startLine, /"start": "node dist\/main\.js"/)
+    assert.equal(startLine.includes("db:migrate"), false, "hosted start alone does not migrate")
+    assert.equal(startLine.includes("db:bootstrap"), false, "hosted start alone does not bootstrap")
+    assert.equal(startLine.includes("bootstrap.js"), false, "hosted start alone does not invoke the migration runner")
+  })
+
+  test("hosted migration workflow remains the explicit PlanetScale migration owner", () => {
+    const workflow = readRepoFile(".github/workflows/den-db-migrate.yml")
+
+    assert.match(workflow, /name: Den DB Migrate/)
+    assert.match(workflow, /branches:\n\s+- dev/)
+    assert.match(workflow, /paths:\n\s+- "ee\/packages\/den-db\/drizzle\/\*\*"/)
+    assert.match(workflow, /pscale branch safe-migrations disable/)
+    assert.match(workflow, /run_with_ddl_retry pnpm --filter @openwork-ee\/den-db db:migrate/)
+    assert.match(workflow, /pscale branch safe-migrations enable/)
+  })
+
+  test("PR guardrails run readiness tests and smoke Den DB assets in the Den API image", () => {
+    const checkWorkflow = readRepoFile(".github/workflows/den-db-check.yml")
+    const publishWorkflow = readRepoFile(".github/workflows/publish-ee-images.yml")
+
+    assert.match(checkWorkflow, /pnpm --filter @openwork-ee\/den-db test/)
+    assert.match(checkWorkflow, /"ee\/apps\/den-api\/package\.json"/)
+    assert.match(checkWorkflow, /"ee\/apps\/den-api\/scripts\/build\.mjs"/)
+    assert.match(checkWorkflow, /"packaging\/docker\/Dockerfile\.den"/)
+    assert.match(checkWorkflow, /"packaging\/helm\/openwork-ee\/templates\/migration-job\.yaml"/)
+    assert.match(checkWorkflow, /"\.github\/workflows\/publish-ee-images\.yml"/)
+    assert.match(publishWorkflow, /Assert Den DB migration assets/)
+    assert.match(publishWorkflow, /test -s \/app\/ee\/packages\/den-db\/dist\/scripts\/bootstrap\.js/)
+    assert.match(publishWorkflow, /test -s \/app\/ee\/packages\/den-db\/dist\/current-schema\.sql/)
+    assert.match(publishWorkflow, /test -s \/app\/ee\/packages\/den-db\/dist\/drizzle\/meta\/_journal\.json/)
+  })
+
+  test("production bootstrap source uses the mysql2 ORM migrator and no deploy-time toolchain", () => {
+    const bootstrap = readFileSync(path.join(packageDir, "scripts", "bootstrap.ts"), "utf8")
+
+    assert.match(bootstrap, /drizzle-orm\/mysql2\/migrator/)
+    assert.match(bootstrap, /await migrate\(db, \{ migrationsFolder \}\)/)
+    assert.match(bootstrap, /current-schema\.sql/)
+    assert.match(bootstrap, /await ensureFulltextIndexes\(indexExecutor\)/)
+    assertNoForbiddenDeployTools(bootstrap)
+  })
+
+  test("package build emits the precompiled runner, schema snapshot, and migration assets", { timeout: 120_000 }, () => {
+    const build = spawnSync(pnpmCommand, ["run", "build"], {
+      cwd: packageDir,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        DATABASE_HOST: "",
+        DATABASE_NAME: "",
+        DATABASE_PASSWORD: "",
+        DATABASE_URL: "",
+        DATABASE_USERNAME: "",
+      },
+    })
+
+    assert.equal(
+      build.status,
+      0,
+      `pnpm run build failed\nstdout:\n${shortOutput(build.stdout)}\nstderr:\n${shortOutput(build.stderr)}`,
+    )
+
+    const runner = readFileSync(path.join(packageDir, "dist", "scripts", "bootstrap.js"), "utf8")
+    const snapshot = readFileSync(path.join(packageDir, "dist", "current-schema.sql"), "utf8")
+    const journal = readFileSync(path.join(packageDir, "dist", "drizzle", "meta", "_journal.json"), "utf8")
+
+    assert.match(runner, /drizzle-orm\/mysql2\/migrator/)
+    assert.match(snapshot, /^CREATE TABLE `account`/)
+    assert.equal(snapshot.includes("Reading schema files"), false, "schema snapshot contains SQL only")
+    assert.match(journal, /"entries"/)
+    assert.match(journal, /"0040_rapid_lady_bullseye"/)
+  })
+})

--- a/ee/packages/den-db/tsup.scripts.config.ts
+++ b/ee/packages/den-db/tsup.scripts.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from "tsup"
+
+export default defineConfig({
+  entry: {
+    "scripts/bootstrap": "scripts/bootstrap.ts",
+  },
+  format: ["esm"],
+  dts: false,
+  clean: false,
+  target: "es2022",
+  platform: "node",
+  sourcemap: false,
+  splitting: false,
+  treeshake: true,
+})

--- a/evals/flows/db-migrations-readiness.flow.mjs
+++ b/evals/flows/db-migrations-readiness.flow.mjs
@@ -1,0 +1,323 @@
+import { spawnSync } from "node:child_process";
+import { randomUUID } from "node:crypto";
+import { access, readFile } from "node:fs/promises";
+import { createRequire } from "node:module";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "db-migrations-readiness";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const DEN_DB = join(ROOT, "ee", "packages", "den-db");
+const FORBIDDEN_DEPLOY_TOOLS = ["pnpm", "tsx", "tsup", "drizzle-kit"];
+const DEFAULT_DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_den";
+const FULLTEXT_INDEX = "memory_content_fulltext";
+const BOOTSTRAP_PATH = join(DEN_DB, "dist", "scripts", "bootstrap.js");
+const DIST_JOURNAL_PATH = join(DEN_DB, "dist", "drizzle", "meta", "_journal.json");
+const denDbRequire = createRequire(join(DEN_DB, "package.json"));
+
+// Narration is loaded from the approved script (evals/voiceovers/db-migrations-readiness.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const exists = (path) => access(path).then(() => true, () => false);
+
+function readDatabaseUrl() {
+  return process.env.OPENWORK_EVAL_DATABASE_URL?.trim() || process.env.DATABASE_URL?.trim() || DEFAULT_DATABASE_URL;
+}
+
+function readSslSettings(parsed) {
+  const sslAccept = parsed.searchParams.get("sslaccept")?.trim().toLowerCase();
+  const sslMode = parsed.searchParams.get("sslmode")?.trim().toLowerCase() ?? parsed.searchParams.get("ssl-mode")?.trim().toLowerCase();
+
+  if (!sslAccept && !sslMode) {
+    return undefined;
+  }
+
+  return {
+    rejectUnauthorized: sslAccept === "strict" || sslMode === "verify-ca" || sslMode === "verify-full" || sslMode === "require",
+  };
+}
+
+function serverConnectionConfig(databaseUrl) {
+  const parsed = new URL(databaseUrl);
+  if (!parsed.hostname || !parsed.username) {
+    throw new Error("Eval database URL must include host and username");
+  }
+
+  return {
+    host: parsed.hostname,
+    port: Number(parsed.port || "3306"),
+    user: decodeURIComponent(parsed.username),
+    password: decodeURIComponent(parsed.password),
+    ssl: readSslSettings(parsed),
+  };
+}
+
+function databaseUrlFor(databaseUrl, databaseName) {
+  const parsed = new URL(databaseUrl);
+  parsed.pathname = `/${databaseName}`;
+  return parsed.toString();
+}
+
+function quoteIdentifier(identifier) {
+  if (!/^[A-Za-z0-9_]+$/.test(identifier)) {
+    throw new Error(`Unsafe MySQL identifier: ${identifier}`);
+  }
+  return `\`${identifier}\``;
+}
+
+function temporaryDatabaseName() {
+  return `openwork_eval_db_migrations_${Date.now()}_${randomUUID().replaceAll("-", "").slice(0, 8)}`;
+}
+
+function countFromRows(rows, key) {
+  const value = rows[0]?.[key];
+  if (typeof value === "number") {
+    return value;
+  }
+  if (typeof value === "bigint") {
+    return Number(value);
+  }
+  if (typeof value === "string") {
+    return Number(value);
+  }
+  return 0;
+}
+
+function tablesFromRows(rows) {
+  return rows
+    .map((row) => Object.values(row).find((value) => typeof value === "string"))
+    .filter((value) => Boolean(value));
+}
+
+function buildPackageIfNeeded() {
+  return spawnSync("pnpm", ["--dir", DEN_DB, "run", "build"], {
+    cwd: ROOT,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      DATABASE_HOST: "",
+      DATABASE_NAME: "",
+      DATABASE_PASSWORD: "",
+      DATABASE_URL: "",
+      DATABASE_USERNAME: "",
+    },
+    timeout: 120_000,
+  });
+}
+
+function runBootstrap(databaseUrl) {
+  return spawnSync(process.execPath, [BOOTSTRAP_PATH], {
+    cwd: DEN_DB,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+      DEN_DB_ENCRYPTION_KEY: process.env.DEN_DB_ENCRYPTION_KEY || "eval-local-db-encryption-key-please-change-1234567890",
+    },
+    timeout: 120_000,
+  });
+}
+
+function bootstrapLogSummary(run) {
+  return run.stdout
+    .split("\n")
+    .filter((line) => line.startsWith("[den-db]"))
+    .join("\n");
+}
+
+function shortOutput(output) {
+  return output.trim().split("\n").slice(-12).join("\n");
+}
+
+function witness(ctx, condition, assertion, actual) {
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual });
+    ctx.assert(false, assertion + (actual ? ` (actual: ${actual})` : ""));
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual });
+}
+
+function sliceBetween(contents, start, end) {
+  const startIndex = contents.indexOf(start);
+  const endIndex = contents.indexOf(end, startIndex + start.length);
+  if (startIndex === -1 || endIndex === -1) {
+    return "";
+  }
+  return contents.slice(startIndex, endIndex);
+}
+
+function rejectForbiddenDeployTools(ctx, contents, label) {
+  for (const tool of FORBIDDEN_DEPLOY_TOOLS) {
+    witness(ctx, !contents.includes(tool), `${label} does not reference ${tool}`);
+  }
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Den production migrations run from precompiled JavaScript and committed assets",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "The Den image build prepares schema and migration assets",
+      run: async (ctx) => {
+        await ctx.prove("Dockerfile.den builds Den DB dist assets with a deterministic current-schema snapshot", {
+          voiceover: vo[0],
+          assert: async () => {
+            const packageJson = await readFile(join(DEN_DB, "package.json"), "utf8");
+            const buildAssets = await readFile(join(DEN_DB, "scripts", "build-assets.mjs"), "utf8");
+            const denApiPackage = await readFile(join(ROOT, "ee", "apps", "den-api", "package.json"), "utf8");
+            const denApiBuild = await readFile(join(ROOT, "ee", "apps", "den-api", "scripts", "build.mjs"), "utf8");
+            const dockerfile = await readFile(join(ROOT, "packaging", "docker", "Dockerfile.den"), "utf8");
+            const denDbBuildIndex = dockerfile.indexOf("RUN pnpm --dir /app/ee/packages/den-db run build");
+            const denApiBuildIndex = dockerfile.indexOf("pnpm --dir /app/ee/apps/den-api run build");
+            const build = buildPackageIfNeeded();
+
+            witness(ctx, build.status === 0, "den-db package build emits fresh dist assets", shortOutput(build.stderr || build.stdout));
+            witness(ctx, packageJson.includes("node scripts/build-assets.mjs"), "den-db build runs the asset emitter");
+            witness(ctx, buildAssets.includes("drizzle-kit") && buildAssets.includes("export"), "build-time export creates the current-schema SQL snapshot");
+            witness(ctx, buildAssets.includes("cpSync(migrationsDir, distMigrationsDir"), "committed migrations are copied into dist/drizzle");
+            witness(ctx, denApiPackage.includes('"build:den-db": "pnpm --filter @openwork-ee/den-db build"'), "hosted Den API build exposes the den-db build step");
+            witness(ctx, denApiBuild.includes('run(pnpmCommand, ["run", "build:den-db"])'), "hosted Den API build calls build:den-db before tsc");
+            witness(ctx, denDbBuildIndex !== -1 && denDbBuildIndex < denApiBuildIndex, "Dockerfile.den builds den-db before den-api");
+            witness(ctx, await exists(BOOTSTRAP_PATH), "dist/scripts/bootstrap.js exists after the build");
+            witness(ctx, await exists(join(DEN_DB, "dist", "current-schema.sql")), "dist/current-schema.sql exists after the build");
+            witness(ctx, await exists(DIST_JOURNAL_PATH), "dist/drizzle/meta/_journal.json exists after the build");
+            ctx.output("den-db build wiring", [
+              packageJson.split("\n").find((line) => line.includes("\"build\"")),
+              denApiPackage.split("\n").filter((line) => line.includes("build:den-db") || line.includes('"start"')).join("\n"),
+              buildAssets.split("\n").filter((line) => line.includes("current-schema.sql") || line.includes("distMigrationsDir") || line.includes("drizzle-kit")).join("\n"),
+              dockerfile.split("\n").filter((line) => line.includes("den-db run build") || line.includes("den-api run build")).join("\n"),
+            ].join("\n\n"));
+          },
+        });
+      },
+    },
+    {
+      name: "The Helm hook runs node against the precompiled dist runner",
+      run: async (ctx) => {
+        await ctx.prove("The production Helm migration path invokes node dist only, with no deploy-time TypeScript toolchain", {
+          voiceover: vo[1],
+          assert: async () => {
+            const values = await readFile(join(ROOT, "packaging", "helm", "openwork-ee", "values.yaml"), "utf8");
+            const migrationBlock = sliceBetween(values, "migrations:\n", "\ningress:");
+            const bootstrap = await readFile(join(DEN_DB, "scripts", "bootstrap.ts"), "utf8");
+            const publishWorkflow = await readFile(join(ROOT, ".github", "workflows", "publish-ee-images.yml"), "utf8");
+
+            witness(ctx, migrationBlock.includes("command:\n    - node"), "Helm migration command is node");
+            witness(ctx, migrationBlock.includes("/app/ee/packages/den-db/dist/scripts/bootstrap.js"), "Helm migration args point at dist/scripts/bootstrap.js");
+            witness(ctx, publishWorkflow.includes("Assert Den DB migration assets"), "Den API PR image smoke asserts migration assets before health smoke");
+            witness(ctx, publishWorkflow.includes("/app/ee/packages/den-db/dist/current-schema.sql"), "Den API image smoke checks the schema snapshot artifact");
+            witness(ctx, publishWorkflow.includes("/app/ee/packages/den-db/dist/drizzle/meta/_journal.json"), "Den API image smoke checks the migration journal artifact");
+            rejectForbiddenDeployTools(ctx, migrationBlock, "Helm migration defaults");
+            rejectForbiddenDeployTools(ctx, bootstrap, "Production bootstrap source");
+            witness(ctx, bootstrap.includes("drizzle-orm/mysql2/migrator"), "bootstrap imports Drizzle ORM's mysql2 migrator");
+            ctx.output("Helm migration defaults", migrationBlock.trim());
+          },
+        });
+      },
+    },
+    {
+      name: "Bootstrap preserves fresh, baselined, and pending-only behavior",
+      run: async (ctx) => {
+        await ctx.prove("The runner initializes empty databases, baselines legacy schemas, and lets the ORM apply only pending migrations", {
+          voiceover: vo[2],
+          assert: async () => {
+            const bootstrap = await readFile(join(DEN_DB, "scripts", "bootstrap.ts"), "utf8");
+            const journal = JSON.parse(await readFile(DIST_JOURNAL_PATH, "utf8"));
+            const expectedMigrationCount = Array.isArray(journal.entries) ? journal.entries.length : 0;
+            const mysql = denDbRequire("mysql2/promise");
+            const sourceDatabaseUrl = readDatabaseUrl();
+            const config = serverConnectionConfig(sourceDatabaseUrl);
+            const databaseName = temporaryDatabaseName();
+            const server = await mysql.createConnection(config);
+
+            try {
+              await server.query(`CREATE DATABASE ${quoteIdentifier(databaseName)}`);
+              const tempDatabaseUrl = databaseUrlFor(sourceDatabaseUrl, databaseName);
+              const firstRun = runBootstrap(tempDatabaseUrl);
+              witness(ctx, firstRun.status === 0, "first bootstrap run exits successfully", shortOutput(firstRun.stderr || firstRun.stdout));
+
+              const database = await mysql.createConnection({ ...config, database: databaseName });
+              try {
+                const [tableRows] = await database.query("show tables");
+                const tables = tablesFromRows(tableRows);
+                const [ledgerRows] = await database.query("select count(*) as count from `__drizzle_migrations`");
+                const ledgerCount = countFromRows(ledgerRows, "count");
+                const [fulltextRows] = await database.query(
+                  "select count(*) as count from information_schema.STATISTICS where table_schema = database() and table_name = 'memory' and index_name = ?",
+                  [FULLTEXT_INDEX],
+                );
+                const fulltextCount = countFromRows(fulltextRows, "count");
+
+                witness(ctx, bootstrap.includes("applicationTables.length === 0"), "fresh databases are detected by having no application tables");
+                witness(ctx, bootstrap.includes("await applyCurrentSchema(executor)"), "fresh databases apply the current-schema snapshot");
+                witness(ctx, tables.includes("organization") && tables.includes("memory"), "fresh bootstrap creates application schema tables", `tables=${tables.length}`);
+                witness(ctx, ledgerCount === expectedMigrationCount, "fresh bootstrap records every committed migration in the ledger", `ledger=${ledgerCount}, expected=${expectedMigrationCount}`);
+                witness(ctx, fulltextCount === 1, "fresh bootstrap creates the memory.content FULLTEXT index", `fulltext indexes=${fulltextCount}`);
+
+                const secondRun = runBootstrap(tempDatabaseUrl);
+                witness(ctx, secondRun.status === 0, "second bootstrap run exits successfully", shortOutput(secondRun.stderr || secondRun.stdout));
+
+                const [secondLedgerRows] = await database.query("select count(*) as count from `__drizzle_migrations`");
+                const [secondFulltextRows] = await database.query(
+                  "select count(*) as count from information_schema.STATISTICS where table_schema = database() and table_name = 'memory' and index_name = ?",
+                  [FULLTEXT_INDEX],
+                );
+                const secondLedgerCount = countFromRows(secondLedgerRows, "count");
+                const secondFulltextCount = countFromRows(secondFulltextRows, "count");
+
+                witness(ctx, secondLedgerCount === expectedMigrationCount, "idempotent second run does not add duplicate ledger entries", `ledger=${secondLedgerCount}, expected=${expectedMigrationCount}`);
+                witness(ctx, secondFulltextCount === 1, "idempotent second run leaves exactly one FULLTEXT index", `fulltext indexes=${secondFulltextCount}`);
+                witness(ctx, secondRun.stdout.includes("memory.content FULLTEXT index already present"), "second run observes the existing FULLTEXT index");
+                witness(ctx, bootstrap.includes("await migrate(db, { migrationsFolder })"), "existing ledgers use the ORM migrator for pending migrations");
+                ctx.output("Temporary MySQL bootstrap proof", [
+                  `temporary database: ${databaseName}`,
+                  `expected migration entries from journal: ${expectedMigrationCount}`,
+                  `created tables: ${tables.length}`,
+                  `first run logs:\n${bootstrapLogSummary(firstRun)}`,
+                  `second run logs:\n${bootstrapLogSummary(secondRun)}`,
+                ].join("\n"));
+              } finally {
+                await database.end();
+              }
+            } finally {
+              await server.query(`DROP DATABASE IF EXISTS ${quoteIdentifier(databaseName)}`);
+              await server.end();
+            }
+          },
+        });
+      },
+    },
+    {
+      name: "FULLTEXT indexes are ensured after migrations",
+      run: async (ctx) => {
+        await ctx.prove("The precompiled runner finishes by repairing required FULLTEXT indexes after migration work", {
+          voiceover: vo[3],
+          assert: async () => {
+            const bootstrap = await readFile(join(DEN_DB, "scripts", "bootstrap.ts"), "utf8");
+            const fulltext = await readFile(join(DEN_DB, "src", "fulltext.ts"), "utf8");
+            const tests = await readFile(join(DEN_DB, "test", "migration-readiness.test.ts"), "utf8");
+            const denApiPackage = await readFile(join(ROOT, "ee", "apps", "den-api", "package.json"), "utf8");
+            const startLine = denApiPackage.split("\n").find((line) => line.includes('"start"')) ?? "";
+            const migrateWorkflow = await readFile(join(ROOT, ".github", "workflows", "den-db-migrate.yml"), "utf8");
+
+            const migrateIndex = bootstrap.indexOf("await runCommittedMigrations()");
+            const fulltextIndex = bootstrap.indexOf("await ensureFulltextIndexes(indexExecutor)");
+            witness(ctx, migrateIndex !== -1 && fulltextIndex !== -1 && migrateIndex < fulltextIndex, "FULLTEXT repair runs after committed migrations");
+            witness(ctx, fulltext.includes("CREATE FULLTEXT INDEX"), "FULLTEXT creation is idempotent and explicit");
+            witness(ctx, startLine.includes('"start": "node dist/main.js"'), "hosted Den API start runs the server only");
+            witness(ctx, !startLine.includes("db:migrate") && !startLine.includes("db:bootstrap") && !startLine.includes("bootstrap.js"), "hosted Den API start does not silently migrate");
+            witness(ctx, migrateWorkflow.includes('paths:\n      - "ee/packages/den-db/drizzle/**"'), "Den DB Migrate owns hosted committed-migration pushes");
+            witness(ctx, migrateWorkflow.includes("run_with_ddl_retry pnpm --filter @openwork-ee/den-db db:migrate"), "Den DB Migrate explicitly invokes db:migrate");
+            witness(ctx, tests.includes("schema snapshot contains SQL only"), "focused tests cover build artifact wiring without a live DB");
+            rejectForbiddenDeployTools(ctx, sliceBetween(await readFile(join(ROOT, "packaging", "helm", "openwork-ee", "values.yaml"), "utf8"), "migrations:\n", "\ningress:"), "Final Helm migration path");
+            ctx.output("FULLTEXT finish", bootstrap.split("\n").filter((line) => line.includes("runCommittedMigrations") || line.includes("ensureFulltextIndexes")).join("\n"));
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/db-migrations-readiness.md
+++ b/evals/voiceovers/db-migrations-readiness.md
@@ -1,0 +1,9 @@
+# db-migrations-readiness — Den migrations run from precompiled production code
+
+1. Here’s the Den deployment image with its database schema and committed Drizzle migrations already prepared at build time.
+
+2. When the Helm migration job starts, it runs a lightweight, precompiled Drizzle ORM migration runner—without tsup, declaration generation, tsx, or drizzle-kit.
+
+3. On a fresh database, bootstrap establishes the current schema and migration baseline; on an existing database, only pending migrations run.
+
+4. The job finishes by ensuring required FULLTEXT indexes, using substantially less memory and preserving the existing migration behavior.

--- a/packaging/docker/README.md
+++ b/packaging/docker/README.md
@@ -254,7 +254,7 @@ Caveats: `grafana/otel-lgtm` is intended for development, demos, and tests, not 
 Run the install-link migration once against the Den database:
 
 ```bash
-docker compose -f packaging/docker/docker-compose.den-dev.yml exec den sh -lc "pnpm --dir /app/ee/packages/den-db run db:bootstrap"
+docker compose -f packaging/docker/docker-compose.den-dev.yml exec den sh -lc "node /app/ee/packages/den-db/dist/scripts/bootstrap.js"
 ```
 
 Set `DEN_BOOTSTRAP_ADMIN_EMAILS` on the Den API service, restart it, open `/admin`, and toggle `Install links` for each org. Optional installer artifact env vars are `OPENWORK_INSTALLER_RELEASE_TAG`, `OPENWORK_INSTALLER_RELEASE_REPO`, and `OPENWORK_INSTALLER_ARTIFACTS_DIR`; see the [operator guide](../../docs/org-install-links.md).

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -576,11 +576,13 @@ migrations:
   enabled: true
   hook: true
   hookDeletePolicy: before-hook-creation,hook-succeeded
+  command:
+    - node
   args:
-    - pnpm --dir /app/ee/packages/den-db run db:bootstrap
+    - /app/ee/packages/den-db/dist/scripts/bootstrap.js
 ```
 
-`db:bootstrap` uses `db:migrate` for normal upgrades. On a completely empty database it applies the current schema once, records the committed migrations as the baseline, then runs migrations. On an existing schema without a Drizzle ledger, it records the baseline before migrating.
+The default hook executes the precompiled Den DB bootstrap runner already built into the Den API image. On a completely empty database it applies the build-time current-schema SQL snapshot, records the committed migrations as the baseline, then runs pending migrations with Drizzle ORM. On an existing schema without a Drizzle ledger, it records the baseline before migrating.
 
 For retained-log troubleshooting, temporarily disable hook behavior and reduce
 retries:

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -267,10 +267,9 @@ migrations:
   podAnnotations: {}
   resources: {}
   command:
-    - sh
-    - -lc
+    - node
   args:
-    - pnpm --dir /app/ee/packages/den-db run db:bootstrap
+    - /app/ee/packages/den-db/dist/scripts/bootstrap.js
 
 ingress:
   enabled: false


### PR DESCRIPTION
## Summary
- ship a precompiled Drizzle ORM bootstrap runner and schema/migration assets in the Den API image
- make Helm migration hooks run the precompiled runner instead of compiling TypeScript at deploy time
- add CI, image, hosted-workflow, and live-MySQL migration readiness guardrails

## Validation
- `pnpm --dir ee/packages/den-db test` — 7/7 passed
- `helm lint packaging/helm/openwork-ee` — passed
- `helm template openwork-ee packaging/helm/openwork-ee --set ingress.enabled=true --set inference.enabled=true` — passed
- workflow YAML validation — passed
- Docker pre-change at 512 MiB — OOMKilled (exit 137)
- Docker post-change at 512 MiB — passed, including idempotent rerun
- hosted build/start commands — build passed at 4 GiB; start health check passed
- hosted `db:migrate` path against MySQL — passed
- `pnpm fraimz --flow db-migrations-readiness` — passed

## Deployment note
Hosted Den startup intentionally does not migrate. `.github/workflows/den-db-migrate.yml` remains the PlanetScale migration owner when committed migration files land on `dev`; external deployment automation must continue to wait for that workflow before rolling schema-dependent code.