### PR TITLE
feat(app): support XLSX chat attachments

### DIFF
--- a/apps/app/src/components/chat/utils.ts
+++ b/apps/app/src/components/chat/utils.ts
@@ -3,6 +3,7 @@ import type { ThreadStatus } from "@/lib/messages"
 
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
 const SAFE_DOWNLOAD_PROTOCOLS = new Set(["blob:", "data:"])
 
 interface MessageGroup {
@@ -55,9 +56,10 @@ export function getMediaBadge(part: Pick<FileUIPart, "filename" | "mediaType">) 
 
   if (mime === DOCX_MIME) return "DOCX"
   if (mime === PPTX_MIME) return "PPTX"
+  if (mime === XLSX_MIME) return "XLSX"
 
   const fromExtension = extensionBadge(part.filename)
-  if (fromExtension === "DOCX" || fromExtension === "PPTX") return fromExtension
+  if (fromExtension === "DOCX" || fromExtension === "PPTX" || fromExtension === "XLSX") return fromExtension
 
   if (mime && mime !== "application/octet-stream") {
     return mime.replace(/^application\//, "").replace(/^text\//, "").toUpperCase()

--- a/apps/app/src/i18n/locales/ca.ts
+++ b/apps/app/src/i18n/locales/ca.ts
@@ -76,7 +76,7 @@ export default {
   "common.submit": "Envia",
   "common.unknown": "Desconegut",
   "composer.agent_label": "Agent",
-  "composer.any_file_type_supported": "S'admeten: PDF, imatges, text, Word i PowerPoint.",
+  "composer.any_file_type_supported": "S'admeten: PDF, imatges, text, Word, PowerPoint i Excel.",
   "composer.attach_files": "Adjuntar fitxers",
   "composer.attachments_unavailable": "Els fitxers adjunts no estan disponibles.",
   "composer.behavior_label": "Comportament",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -86,7 +86,7 @@ export default {
   "composer.app_kind": "App · Computer Use",
   "composer.computer_use_permissions_missing": "Computer Use needs macOS permissions before it can control {app}.",
   "composer.computer_use_permissions_setup": "Set up",
-  "composer.any_file_type_supported": "Supported: PDF, images, text, Word, and PowerPoint.",
+  "composer.any_file_type_supported": "Supported: PDF, images, text, Word, PowerPoint, and Excel.",
   "composer.attach_files": "Attach files",
   "composer.attachments_unavailable": "Attachments are unavailable.",
   "composer.behavior_label": "Behavior",

--- a/apps/app/src/i18n/locales/es.ts
+++ b/apps/app/src/i18n/locales/es.ts
@@ -76,7 +76,7 @@ export default {
   "common.submit": "Enviar",
   "common.unknown": "Desconocido",
   "composer.agent_label": "Agente",
-  "composer.any_file_type_supported": "Compatible: PDF, imágenes, texto, Word y PowerPoint.",
+  "composer.any_file_type_supported": "Compatible: PDF, imágenes, texto, Word, PowerPoint y Excel.",
   "composer.attach_files": "Adjuntar archivos",
   "composer.attachments_unavailable": "Los archivos adjuntos no están disponibles.",
   "composer.behavior_label": "Comportamiento",

--- a/apps/app/src/i18n/locales/fr.ts
+++ b/apps/app/src/i18n/locales/fr.ts
@@ -76,7 +76,7 @@ export default {
   "common.submit": "Envoyer",
   "common.unknown": "Inconnu",
   "composer.agent_label": "Agent",
-  "composer.any_file_type_supported": "Pris en charge : PDF, images, texte, Word et PowerPoint.",
+  "composer.any_file_type_supported": "Pris en charge : PDF, images, texte, Word, PowerPoint et Excel.",
   "composer.attach_files": "Joindre des fichiers",
   "composer.attachments_unavailable": "Les pièces jointes ne sont pas disponibles.",
   "composer.behavior_label": "Comportement",

--- a/apps/app/src/i18n/locales/ja.ts
+++ b/apps/app/src/i18n/locales/ja.ts
@@ -75,7 +75,7 @@ export default {
   "common.submit": "送信",
   "common.unknown": "不明",
   "composer.agent_label": "エージェント",
-  "composer.any_file_type_supported": "対応形式: PDF、画像、テキスト、Word、PowerPoint。",
+  "composer.any_file_type_supported": "対応形式: PDF、画像、テキスト、Word、PowerPoint、Excel。",
   "composer.attach_files": "ファイルを添付",
   "composer.attachments_unavailable": "添付ファイルは利用できません。",
   "composer.behavior_label": "動作",

--- a/apps/app/src/i18n/locales/pt-BR.ts
+++ b/apps/app/src/i18n/locales/pt-BR.ts
@@ -76,7 +76,7 @@ export default {
   "common.submit": "Enviar",
   "common.unknown": "Desconhecido",
   "composer.agent_label": "Agente",
-  "composer.any_file_type_supported": "Compatível com: PDF, imagens, texto, Word e PowerPoint.",
+  "composer.any_file_type_supported": "Compatível com: PDF, imagens, texto, Word, PowerPoint e Excel.",
   "composer.attach_files": "Anexar arquivos",
   "composer.attachments_unavailable": "Anexos não estão disponíveis.",
   "composer.behavior_label": "Comportamento",

--- a/apps/app/src/i18n/locales/ru.ts
+++ b/apps/app/src/i18n/locales/ru.ts
@@ -77,7 +77,7 @@ export default {
   "common.submit": "Отправить",
   "common.unknown": "Неизвестно",
   "composer.agent_label": "Агент",
-  "composer.any_file_type_supported": "Поддерживаются: PDF, изображения, текст, Word и PowerPoint.",
+  "composer.any_file_type_supported": "Поддерживаются: PDF, изображения, текст, Word, PowerPoint и Excel.",
   "composer.attach_files": "Прикрепить файлы",
   "composer.attachments_unavailable": "Вложения недоступны.",
   "composer.behavior_label": "Поведение",

--- a/apps/app/src/i18n/locales/th.ts
+++ b/apps/app/src/i18n/locales/th.ts
@@ -76,7 +76,7 @@ export default {
   "common.submit": "ส่ง",
   "common.unknown": "ไม่ทราบ",
   "composer.agent_label": "Agent",
-  "composer.any_file_type_supported": "รองรับ: PDF, รูปภาพ, ข้อความ, Word และ PowerPoint",
+  "composer.any_file_type_supported": "รองรับ: PDF, รูปภาพ, ข้อความ, Word, PowerPoint และ Excel",
   "composer.attach_files": "แนบไฟล์",
   "composer.attachments_unavailable": "ไฟล์แนบไม่พร้อมใช้งาน",
   "composer.behavior_label": "พฤติกรรม",

--- a/apps/app/src/i18n/locales/vi.ts
+++ b/apps/app/src/i18n/locales/vi.ts
@@ -76,7 +76,7 @@ export default {
   "common.submit": "Gửi",
   "common.unknown": "Không rõ",
   "composer.agent_label": "Agent",
-  "composer.any_file_type_supported": "Hỗ trợ: PDF, hình ảnh, văn bản, Word và PowerPoint.",
+  "composer.any_file_type_supported": "Hỗ trợ: PDF, hình ảnh, văn bản, Word, PowerPoint và Excel.",
   "composer.attach_files": "Đính kèm tệp",
   "composer.attachments_unavailable": "Đính kèm không khả dụng.",
   "composer.behavior_label": "Hành vi",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -79,7 +79,7 @@ export default {
   "common.submit": "提交",
   "common.unknown": "未知",
   "composer.agent_label": "智能体",
-  "composer.any_file_type_supported": "支持：PDF、图片、文本、Word 和 PowerPoint。",
+  "composer.any_file_type_supported": "支持：PDF、图片、文本、Word、PowerPoint 和 Excel。",
   "composer.attach_files": "附加文件",
   "composer.attachments_unavailable": "附件功能不可用。",
   "composer.behavior_label": "行为",

--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -17,6 +17,7 @@ type AttachmentFileMetadata = {
 const GENERIC_BINARY_MIME = "application/octet-stream";
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
 type InboxUploadResult = {
   ok: boolean;
@@ -52,6 +53,7 @@ const EXTENSION_MIME_TYPES: Record<string, string> = {
   pdf: "application/pdf",
   docx: DOCX_MIME,
   pptx: PPTX_MIME,
+  xlsx: XLSX_MIME,
   txt: "text/plain",
   text: "text/plain",
   md: "text/markdown",
@@ -84,6 +86,7 @@ const MIME_FILENAME_EXTENSIONS: Record<string, string> = {
   "application/pdf": "pdf",
   [DOCX_MIME]: "docx",
   [PPTX_MIME]: "pptx",
+  [XLSX_MIME]: "xlsx",
   "application/json": "json",
   "application/javascript": "js",
   "application/xml": "xml",
@@ -105,7 +108,7 @@ function isGenericMime(mime: string) {
 }
 
 function isOfficeMime(mime: string) {
-  return mime === DOCX_MIME || mime === PPTX_MIME;
+  return mime === DOCX_MIME || mime === PPTX_MIME || mime === XLSX_MIME;
 }
 
 function extensionFromFilename(filename: string) {

--- a/apps/app/src/react-app/domains/session/sync/attachment-support.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-support.ts
@@ -2,8 +2,8 @@
  * Which attachment media types can be sent to the model as file parts.
  *
  * Providers (via opencode + the AI SDK) accept images, PDFs, and text.
- * Anything else (e.g. Keynote `application/x-iwork-keynote-sffkey`, Office
- * binaries) is rejected by the provider with an UnsupportedFunctionalityError
+ * Anything else (e.g. Keynote `application/x-iwork-keynote-sffkey`) is
+ * rejected by the provider with an UnsupportedFunctionalityError
  * — and because the file part lives in server-side session history, every
  * later message in the session replays the failure. Blocking these at attach
  * time prevents poisoning the session.
@@ -15,6 +15,9 @@ export function isModelReadableAttachment(mimeType: string) {
   const mime = mimeType.toLowerCase();
   if (mime === "" || mime === "application/octet-stream") return true;
   if (mime.startsWith("image/") || mime.startsWith("text/")) return true;
+  if (mime === "application/vnd.openxmlformats-officedocument.wordprocessingml.document") return true;
+  if (mime === "application/vnd.openxmlformats-officedocument.presentationml.presentation") return true;
+  if (mime === "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet") return true;
   if (mime === "application/pdf" || mime === "application/json") return true;
   return mime.endsWith("+json") || mime.endsWith("+xml") || mime === "application/xml" || mime === "application/javascript";
 }

--- a/apps/app/tests/attachment-file-part.test.ts
+++ b/apps/app/tests/attachment-file-part.test.ts
@@ -14,8 +14,10 @@ import {
 const JPEG_BYTES = new Uint8Array([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46, 0x49, 0x46, 0x00, 0x01]);
 const DOCX_BYTES = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x77, 0x6f, 0x72, 0x64]);
 const PPTX_BYTES = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x70, 0x70, 0x74, 0x78]);
+const XLSX_BYTES = new Uint8Array([0x50, 0x4b, 0x03, 0x04, 0x14, 0x00, 0x78, 0x6c, 0x73, 0x78]);
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 const PDF_BYTES = new Uint8Array([0x25, 0x50, 0x44, 0x46, 0x2d, 0x31, 0x2e, 0x34, 0x0a, 0x25, 0xe2, 0xe3, 0xcf, 0xd3]);
 
 type UploadCall = {
@@ -119,6 +121,7 @@ describe("composer attachment file parts", () => {
   test("preserves canonical Office MIME, data URL headers, filenames, and exact bytes", async () => {
     const docx = new File([DOCX_BYTES], "PlanningMemo.docx", { type: DOCX_MIME });
     const pptx = new File([PPTX_BYTES], "RoadshowDeck.pptx", { type: PPTX_MIME });
+    const xlsx = new File([XLSX_BYTES], "RevenueWorkbook.xlsx", { type: XLSX_MIME });
 
     expect(resolveAttachmentFileMetadata(docx)).toMatchObject({
       filename: "PlanningMemo.docx",
@@ -132,9 +135,16 @@ describe("composer attachment file parts", () => {
       kind: "file",
       readable: true,
     });
+    expect(resolveAttachmentFileMetadata(xlsx)).toMatchObject({
+      filename: "RevenueWorkbook.xlsx",
+      mime: XLSX_MIME,
+      kind: "file",
+      readable: true,
+    });
 
     const docxPart = await composerAttachmentToFilePart(attachmentFor(docx));
     const pptxPart = await composerAttachmentToFilePart(attachmentFor(pptx));
+    const xlsxPart = await composerAttachmentToFilePart(attachmentFor(xlsx));
 
     expect(docxPart.filename).toBe("PlanningMemo.docx");
     expect(docxPart.mime).toBe(DOCX_MIME);
@@ -145,11 +155,17 @@ describe("composer attachment file parts", () => {
     expect(pptxPart.mime).toBe(PPTX_MIME);
     expect(pptxPart.url.startsWith(`data:${PPTX_MIME};base64,`)).toBe(true);
     expect(Array.from(decodedDataUrlBytes(pptxPart.url))).toEqual(Array.from(PPTX_BYTES));
+
+    expect(xlsxPart.filename).toBe("RevenueWorkbook.xlsx");
+    expect(xlsxPart.mime).toBe(XLSX_MIME);
+    expect(xlsxPart.url.startsWith(`data:${XLSX_MIME};base64,`)).toBe(true);
+    expect(Array.from(decodedDataUrlBytes(xlsxPart.url))).toEqual(Array.from(XLSX_BYTES));
   });
 
   test("resolves generic Office MIME from case-insensitive extensions without coercing bytes to text", async () => {
     const docx = new File([DOCX_BYTES], "QuarterlyReport.DOCX", { type: "application/octet-stream" });
     const pptx = new File([PPTX_BYTES], "LaunchPlan.PPTX", { type: "" });
+    const xlsx = new File([XLSX_BYTES], "BudgetModel.XLSX", { type: "application/octet-stream" });
 
     expect(resolveAttachmentFileMetadata(docx)).toMatchObject({
       filename: "QuarterlyReport.DOCX",
@@ -163,9 +179,16 @@ describe("composer attachment file parts", () => {
       kind: "file",
       readable: true,
     });
+    expect(resolveAttachmentFileMetadata(xlsx)).toMatchObject({
+      filename: "BudgetModel.XLSX",
+      mime: XLSX_MIME,
+      kind: "file",
+      readable: true,
+    });
 
     const docxPart = await composerAttachmentToFilePart(attachmentFor(docx));
     const pptxPart = await composerAttachmentToFilePart(attachmentFor(pptx));
+    const xlsxPart = await composerAttachmentToFilePart(attachmentFor(xlsx));
 
     expect(docxPart.filename).toBe("QuarterlyReport.DOCX");
     expect(docxPart.mime).toBe(DOCX_MIME);
@@ -176,14 +199,21 @@ describe("composer attachment file parts", () => {
     expect(pptxPart.mime).toBe(PPTX_MIME);
     expect(pptxPart.url.startsWith(`data:${PPTX_MIME};base64,`)).toBe(true);
     expect(Array.from(decodedDataUrlBytes(pptxPart.url))).toEqual(Array.from(PPTX_BYTES));
+
+    expect(xlsxPart.filename).toBe("BudgetModel.XLSX");
+    expect(xlsxPart.mime).toBe(XLSX_MIME);
+    expect(xlsxPart.url.startsWith(`data:${XLSX_MIME};base64,`)).toBe(true);
+    expect(Array.from(decodedDataUrlBytes(xlsxPart.url))).toEqual(Array.from(XLSX_BYTES));
   });
 
   test("normalizes Office filename extensions from canonical MIME when filenames disagree", async () => {
     const docxNamedBin = new File([DOCX_BYTES], "PlanningMemo.bin", { type: DOCX_MIME });
     const pptxWithoutExtension = new File([PPTX_BYTES], "RoadshowDeck", { type: PPTX_MIME });
+    const xlsxWithoutExtension = new File([XLSX_BYTES], "RevenueWorkbook", { type: XLSX_MIME });
 
     expect((await composerAttachmentToFilePart(attachmentFor(docxNamedBin))).filename).toBe("PlanningMemo.docx");
     expect((await composerAttachmentToFilePart(attachmentFor(pptxWithoutExtension))).filename).toBe("RoadshowDeck.pptx");
+    expect((await composerAttachmentToFilePart(attachmentFor(xlsxWithoutExtension))).filename).toBe("RevenueWorkbook.xlsx");
   });
 
   test("rejects unsupported binary attachments instead of broadly treating generic bytes as text", () => {
@@ -201,6 +231,12 @@ describe("composer attachment file parts", () => {
     });
     expect(resolveAttachmentFileMetadata(new File([PPTX_BYTES], "archive.zip", { type: "" }))).toMatchObject({
       filename: "archive.zip",
+      mime: "application/octet-stream",
+      kind: "file",
+      readable: false,
+    });
+    expect(resolveAttachmentFileMetadata(new File([XLSX_BYTES], "legacy.xls", { type: "" }))).toMatchObject({
+      filename: "legacy.xls",
       mime: "application/octet-stream",
       kind: "file",
       readable: false,

--- a/apps/app/tests/office-attachment-ui.test.ts
+++ b/apps/app/tests/office-attachment-ui.test.ts
@@ -5,12 +5,15 @@ import { getArtifactsFromMessages } from "../src/lib/artifacts";
 
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 
 describe("Office attachment UI affordances", () => {
   test("uses compact Office badges instead of exposing MIME subtypes", () => {
     expect(getMediaBadge({ filename: "QuarterlyBrief.docx", mediaType: DOCX_MIME })).toBe("DOCX");
     expect(getMediaBadge({ filename: "LaunchRoadmap.PPTX", mediaType: PPTX_MIME })).toBe("PPTX");
     expect(getMediaBadge({ filename: "LaunchRoadmap.PPTX", mediaType: "application/octet-stream" })).toBe("PPTX");
+    expect(getMediaBadge({ filename: "RevenueWorkbook.XLSX", mediaType: XLSX_MIME })).toBe("XLSX");
+    expect(getMediaBadge({ filename: "RevenueWorkbook.XLSX", mediaType: "" })).toBe("XLSX");
   });
 
   test("only exposes download actions for browser-managed file URLs", () => {

--- a/apps/server/src/opencode-plugins/openwork-office-attachments.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-office-attachments.test.ts
@@ -12,8 +12,10 @@ import { OpenWorkOfficeAttachments } from "./openwork-office-attachments.js";
 
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 const DOCX_SENTINEL = "DOCX sentinel fact: Northstar margin lift is 17.42 percent.";
 const PPTX_SENTINEL = "PPTX sentinel fact: Launch window opens on 2026-09-17.";
+const XLSX_SENTINEL = "XLSX sentinel fact: Northstar revenue is 1742.42.";
 const ZIP_LOCAL_FILE_HEADER = 0x04034b50;
 const ZIP_CENTRAL_DIRECTORY_HEADER = 0x02014b50;
 const ZIP_END_OF_CENTRAL_DIRECTORY = 0x06054b50;
@@ -145,6 +147,16 @@ function pptxFixture(text = PPTX_SENTINEL) {
   ]);
 }
 
+function xlsxFixture(text = XLSX_SENTINEL) {
+  return zip([
+    { name: "xl/workbook.xml", data: Buffer.from(`<workbook xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships"><sheets><sheet name="Summary" sheetId="1" r:id="rId1"/></sheets></workbook>`, "utf8") },
+    { name: "xl/_rels/workbook.xml.rels", data: Buffer.from(`<Relationships><Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/></Relationships>`, "utf8") },
+    { name: "xl/sharedStrings.xml", data: Buffer.from(`<sst><si><t>${text}</t></si><si><t>Northstar Revenue</t></si><si><r><t>EM</t></r><r><t>EA</t></r></si></sst>`, "utf8") },
+    { name: "xl/styles.xml", data: Buffer.from(`<styleSheet><numFmts count="1"><numFmt numFmtId="164" formatCode="$#,##0.00"/></numFmts><cellXfs count="2"><xf numFmtId="0"/><xf numFmtId="164" applyNumberFormat="1"/></cellXfs></styleSheet>`, "utf8") },
+    { name: "xl/worksheets/sheet1.xml", data: Buffer.from(`<worksheet><dimension ref="A1:D3"/><sheetData><row r="1"><c r="A1" t="s"><v>0</v></c></row><row r="2"><c r="A2" t="s"><v>1</v></c><c r="B2" t="s"><v>2</v></c><c r="C2" s="1"><v>1742.42</v></c><c r="D2" s="1"><f>SUM(C2:C3)</f><v>3484.84</v></c></row><row r="3"><c r="C3" s="1"><v>1742.42</v></c></row></sheetData><mergeCells count="1"><mergeCell ref="A1:D1"/></mergeCells></worksheet>`, "utf8") },
+  ]);
+}
+
 async function transform(root: string, messages: unknown[]) {
   const plugin = await OpenWorkOfficeAttachments({ directory: root });
   const output = { messages: structuredClone(messages) };
@@ -185,6 +197,35 @@ describe("OpenWorkOfficeAttachments", () => {
     });
   });
 
+  test("extracts XLSX structure, values, formulas, styles, merged cells, and materializes exact bytes", async () => {
+    await withWorkspace(async (root) => {
+      const xlsx = xlsxFixture();
+      const messages = await transform(root, [{
+        role: "user",
+        parts: [{ id: "part-xlsx", sessionID: "ses_xlsx", messageID: "msg_xlsx", type: "file", filename: "RevenueWorkbook.xlsx", mediaType: XLSX_MIME, url: dataUrl(XLSX_MIME, xlsx) }],
+      }]);
+
+      const xlsxRecord = expectRecord(messageParts(messages[0])[0]);
+      const text = textOf(xlsxRecord);
+      expect(xlsxRecord).toMatchObject({ id: "part-xlsx", sessionID: "ses_xlsx", messageID: "msg_xlsx", type: "text" });
+      expect(text).toContain(`canonical_mime: ${XLSX_MIME}`);
+      expect(text).toContain(`sha256: ${sha256(xlsx)}`);
+      expect(text).toContain("xlsx_workbook:");
+      expect(text).toContain("sheet_count: 1");
+      expect(text).toContain("name: \"Summary\"");
+      expect(text).toContain("merged_ranges: \"A1:D1\"");
+      expect(text).toContain("cell: \"A1\"");
+      expect(text).toContain(`displayed_value: "${XLSX_SENTINEL}"`);
+      expect(text).toContain("cell: \"C2\"");
+      expect(text).toContain("raw_value: \"1742.42\"");
+      expect(text).toContain("number_format: \"$#,##0.00\"");
+      expect(text).toContain("formula: \"SUM(C2:C3)\"");
+      expect(JSON.stringify(messages)).not.toContain(xlsx.toString("base64"));
+      expect(JSON.stringify(messages)).not.toContain('"type":"file"');
+      await expect(readFile(join(root, pathFromText(text)))).resolves.toEqual(xlsx);
+    });
+  });
+
   test("preserves the output messages array reference", async () => {
     await withWorkspace(async (root) => {
       const docx = docxFixture();
@@ -199,25 +240,39 @@ describe("OpenWorkOfficeAttachments", () => {
 
   test("is idempotent on replay", async () => {
     await withWorkspace(async (root) => {
-      const docx = docxFixture();
-      const messages = [{ role: "user", parts: [{ id: "stable", type: "file", filename: "QuarterlyBrief.docx", mediaType: DOCX_MIME, url: dataUrl(DOCX_MIME, docx) }] }];
+      const xlsx = xlsxFixture();
+      const messages = [{ role: "user", parts: [{ id: "stable", type: "file", filename: "RevenueWorkbook.xlsx", mediaType: XLSX_MIME, url: dataUrl(XLSX_MIME, xlsx) }] }];
       const firstText = textOf(messageParts((await transform(root, messages))[0])[0]);
       const secondText = textOf(messageParts((await transform(root, messages))[0])[0]);
       expect(firstText).toBe(secondText);
-      await expect(readFile(join(root, pathFromText(firstText)))).resolves.toEqual(docx);
+      expect(firstText).toContain(XLSX_SENTINEL);
+      await expect(readFile(join(root, pathFromText(firstText)))).resolves.toEqual(xlsx);
     });
   });
 
   test("normalizes generic-MIME workspace file URLs by safe extension", async () => {
     await withWorkspace(async (root) => {
       const pptx = pptxFixture();
+      const xlsx = xlsxFixture();
       await mkdir(join(root, "input"), { recursive: true });
       const path = join(root, "input", "LaunchRoadmap.PPTX");
+      const spreadsheetPath = join(root, "input", "RevenueWorkbook.XLSX");
       await writeFile(path, pptx);
-      const messages = await transform(root, [{ role: "user", parts: [{ type: "file", filename: "LaunchRoadmap.PPTX", mime: "application/octet-stream", url: pathToFileURL(path).toString() }] }]);
-      const text = textOf(messageParts(messages[0])[0]);
-      expect(text).toContain(PPTX_SENTINEL);
-      expect(text).toContain(`canonical_mime: ${PPTX_MIME}`);
+      await writeFile(spreadsheetPath, xlsx);
+      const messages = await transform(root, [{
+        role: "user",
+        parts: [
+          { type: "file", filename: "LaunchRoadmap.PPTX", mime: "application/octet-stream", url: pathToFileURL(path).toString() },
+          { type: "file", filename: "RevenueWorkbook.XLSX", mime: "", url: pathToFileURL(spreadsheetPath).toString() },
+        ],
+      }]);
+      const [pptxPart, xlsxPart] = messageParts(messages[0]);
+      const pptxText = textOf(pptxPart);
+      const xlsxText = textOf(xlsxPart);
+      expect(pptxText).toContain(PPTX_SENTINEL);
+      expect(pptxText).toContain(`canonical_mime: ${PPTX_MIME}`);
+      expect(xlsxText).toContain(XLSX_SENTINEL);
+      expect(xlsxText).toContain(`canonical_mime: ${XLSX_MIME}`);
     });
   });
 
@@ -301,6 +356,17 @@ describe("OpenWorkOfficeAttachments", () => {
     });
   });
 
+  test("materializes malformed XLSX files but replaces them with an actionable placeholder", async () => {
+    await withWorkspace(async (root) => {
+      const malformed = Buffer.from("not a zip", "utf8");
+      const messages = await transform(root, [{ role: "user", parts: [{ type: "file", filename: "RevenueWorkbook.xlsx", mediaType: XLSX_MIME, url: dataUrl(XLSX_MIME, malformed) }] }]);
+      const text = textOf(messageParts(messages[0])[0]);
+      expect(text).toContain("extraction_error:");
+      expect(text).toContain("No text could be safely extracted");
+      await expect(readFile(join(root, pathFromText(text)))).resolves.toEqual(malformed);
+    });
+  });
+
   test("rejects EOCD comment-length mismatches", async () => {
     await withWorkspace(async (root) => {
       const corrupted = Buffer.from(docxFixture());
@@ -328,6 +394,7 @@ describe("OpenWorkOfficeAttachments", () => {
       const tooManyEntries = zip(Array.from({ length: 130 }, (_item, index) => ({ name: `word/header${index}.xml`, data: Buffer.from("<w:t>x</w:t>", "utf8") })));
       const tooLargeEntry = zip([{ name: "word/document.xml", data: Buffer.alloc(2 * 1024 * 1024 + 1, "A") }]);
       const tooLargeTotal = zip(Array.from({ length: 11 }, (_item, index) => ({ name: `word/header${index}.xml`, data: Buffer.alloc(1024 * 1024, "A") })));
+      const xlsxRatioBomb = zip([{ name: "xl/worksheets/sheet1.xml", data: Buffer.alloc(200_000, "A"), method: 8 }]);
       const messages = await transform(root, [{
         role: "user",
         parts: [
@@ -335,19 +402,27 @@ describe("OpenWorkOfficeAttachments", () => {
           { type: "file", filename: "entries.docx", mediaType: DOCX_MIME, url: dataUrl(DOCX_MIME, tooManyEntries) },
           { type: "file", filename: "entry.docx", mediaType: DOCX_MIME, url: dataUrl(DOCX_MIME, tooLargeEntry) },
           { type: "file", filename: "total.docx", mediaType: DOCX_MIME, url: dataUrl(DOCX_MIME, tooLargeTotal) },
+          { type: "file", filename: "ratio.xlsx", mediaType: XLSX_MIME, url: dataUrl(XLSX_MIME, xlsxRatioBomb) },
         ],
       }]);
-      const [ratioPart, entriesPart, entryPart, totalPart] = messageParts(messages[0]);
+      const [ratioPart, entriesPart, entryPart, totalPart, xlsxRatioPart] = messageParts(messages[0]);
       expect(textOf(ratioPart)).toContain("compression ratio limit");
       expect(textOf(entriesPart)).toContain("entry count");
       expect(textOf(entryPart)).toContain("per-entry uncompressed limit");
       expect(textOf(totalPart)).toContain("total uncompressed limit");
+      expect(textOf(xlsxRatioPart)).toContain("compression ratio limit");
     });
   });
 
   test("leaves non-Office file parts unchanged", async () => {
     await withWorkspace(async (root) => {
-      const original = [{ role: "user", parts: [{ id: "pdf", type: "file", filename: "brief.pdf", mediaType: "application/pdf", url: "data:application/pdf;base64,JVBERi0=" }] }];
+      const original = [{
+        role: "user",
+        parts: [
+          { id: "pdf", type: "file", filename: "brief.pdf", mediaType: "application/pdf", url: "data:application/pdf;base64,JVBERi0=" },
+          { id: "xls", type: "file", filename: "legacy.xls", mediaType: "application/octet-stream", url: "data:application/octet-stream;base64,AA==" },
+        ],
+      }];
       expect(await transform(root, original)).toEqual(original);
     });
   });

--- a/apps/server/src/opencode-plugins/openwork-office-attachments.ts
+++ b/apps/server/src/opencode-plugins/openwork-office-attachments.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 const GENERIC_MIME = "application/octet-stream";
 const ZIP_LOCAL_FILE_HEADER = 0x04034b50;
 const ZIP_CENTRAL_DIRECTORY_HEADER = 0x02014b50;
@@ -21,13 +22,16 @@ const MAX_TOTAL_UNCOMPRESSED_BYTES = 10 * 1024 * 1024;
 const MAX_ENTRY_UNCOMPRESSED_BYTES = 2 * 1024 * 1024;
 const MAX_ZIP_COMPRESSION_RATIO = 100;
 const MAX_EXTRACTED_TEXT_CHARS = 24_000;
+const MAX_XLSX_SHEETS = 24;
+const MAX_XLSX_CELLS = 600;
+const MAX_XLSX_SHARED_STRINGS = 4_000;
 const MATERIALIZED_DIR = join(".opencode", "openwork", "inbox", "chat-attachments");
 
 type RuntimeContext = {
   directory?: string;
 };
 
-type OfficeKind = "docx" | "pptx";
+type OfficeKind = "docx" | "pptx" | "xlsx";
 
 type OfficeFilePart = {
   filename: string;
@@ -93,15 +97,19 @@ function isGenericMime(mime: string): boolean {
 function officeKindFromMimeOrFilename(mime: string, filename: string): OfficeKind | null {
   if (mime === DOCX_MIME) return "docx";
   if (mime === PPTX_MIME) return "pptx";
+  if (mime === XLSX_MIME) return "xlsx";
   if (!isGenericMime(mime)) return null;
   const extension = extensionFromFilename(filename);
   if (extension === "docx") return "docx";
   if (extension === "pptx") return "pptx";
+  if (extension === "xlsx") return "xlsx";
   return null;
 }
 
 function canonicalMime(kind: OfficeKind): string {
-  return kind === "docx" ? DOCX_MIME : PPTX_MIME;
+  if (kind === "docx") return DOCX_MIME;
+  if (kind === "pptx") return PPTX_MIME;
+  return XLSX_MIME;
 }
 
 function officeFilePart(value: unknown): OfficeFilePart | null {
@@ -353,7 +361,284 @@ function xmlText(xml: string): string {
   return decodeXmlEntities(xml.replace(/<[^>]+>/g, " ")).replace(/\s+/g, " ").trim();
 }
 
+type XmlBlock = {
+  attributes: Record<string, string>;
+  inner: string;
+};
+
+type XlsxSheet = {
+  name: string;
+  sheetId: string;
+  relationshipId: string;
+  path: string;
+};
+
+type XlsxCell = {
+  reference: string;
+  type: string;
+  styleIndex?: string;
+  numberFormat?: string;
+  formula?: string;
+  formulaType?: string;
+  formulaRef?: string;
+  rawValue?: string;
+  displayedValue?: string;
+};
+
+function xmlTagPattern(name: string): string {
+  return `(?:[A-Za-z_][\\w.-]*:)?${name}`;
+}
+
+function xmlAttributes(source: string): Record<string, string> {
+  const attributes: Record<string, string> = {};
+  const regex = /([\w:.-]+)\s*=\s*(?:"([^"]*)"|'([^']*)')/g;
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(source))) {
+    const name = match[1];
+    const value = match[2] ?? match[3] ?? "";
+    attributes[name] = decodeXmlEntities(value);
+  }
+  return attributes;
+}
+
+function xmlBlocks(xml: string, name: string): XmlBlock[] {
+  const tag = xmlTagPattern(name);
+  const regex = new RegExp(`<${tag}\\b([^>]*)>([\\s\\S]*?)<\\/${tag}>`, "g");
+  const blocks: XmlBlock[] = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(xml))) {
+    blocks.push({ attributes: xmlAttributes(match[1]), inner: match[2] });
+  }
+  return blocks;
+}
+
+function xmlStartTagAttributes(xml: string, name: string): Array<Record<string, string>> {
+  const tag = xmlTagPattern(name);
+  const regex = new RegExp(`<${tag}\\b([^>]*)\\/?\\s*>`, "g");
+  const attributes: Array<Record<string, string>> = [];
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(xml))) attributes.push(xmlAttributes(match[1]));
+  return attributes;
+}
+
+function firstXmlText(xml: string, name: string): string | undefined {
+  const block = xmlBlocks(xml, name)[0];
+  if (!block) return undefined;
+  return decodeXmlEntities(block.inner.replace(/<[^>]+>/g, "")).trim();
+}
+
+function zipEntryMap(entries: ZipEntry[]): Map<string, ZipEntry> {
+  const map = new Map<string, ZipEntry>();
+  for (const entry of entries) map.set(entry.name, entry);
+  return map;
+}
+
+function readZipTextEntry(bytes: Buffer, entries: Map<string, ZipEntry>, name: string): string | null {
+  const entry = entries.get(name);
+  return entry ? readZipEntryData(bytes, entry).toString("utf8") : null;
+}
+
+function normalizedZipPath(...segments: string[]): string {
+  const parts: string[] = [];
+  for (const segment of segments.join("/").split("/")) {
+    if (!segment || segment === ".") continue;
+    if (segment === "..") parts.pop();
+    else parts.push(segment);
+  }
+  return parts.join("/");
+}
+
+function relationshipTargets(xml: string | null, basePath: string): Map<string, string> {
+  const targets = new Map<string, string>();
+  if (!xml) return targets;
+  for (const attributes of xmlStartTagAttributes(xml, "Relationship")) {
+    const id = attributes.Id;
+    const target = attributes.Target;
+    if (!id || !target || attributes.TargetMode === "External" || /^[a-z][a-z0-9+.-]*:/i.test(target)) continue;
+    targets.set(id, target.startsWith("/") ? normalizedZipPath(target.slice(1)) : normalizedZipPath(basePath, target));
+  }
+  return targets;
+}
+
+function parseWorkbookSheets(workbookXml: string, relsXml: string | null): XlsxSheet[] {
+  const targets = relationshipTargets(relsXml, "xl");
+  return xmlStartTagAttributes(workbookXml, "sheet").map((attributes, index) => {
+    const relationshipId = attributes["r:id"] ?? attributes.id ?? "";
+    const path = relationshipId && targets.has(relationshipId)
+      ? targets.get(relationshipId) ?? ""
+      : `xl/worksheets/sheet${index + 1}.xml`;
+    return {
+      name: attributes.name ?? `Sheet${index + 1}`,
+      sheetId: attributes.sheetId ?? String(index + 1),
+      relationshipId,
+      path,
+    };
+  });
+}
+
+function sharedStringText(xml: string): string {
+  const pieces = xmlBlocks(xml, "t").map((block) => decodeXmlEntities(block.inner.replace(/<[^>]+>/g, "")));
+  const text = pieces.join("").replace(/\s+/g, " ").trim();
+  return text || xmlText(xml);
+}
+
+function parseSharedStrings(xml: string | null): string[] {
+  if (!xml) return [];
+  const strings: string[] = [];
+  for (const block of xmlBlocks(xml, "si")) {
+    if (strings.length >= MAX_XLSX_SHARED_STRINGS) break;
+    strings.push(sharedStringText(block.inner));
+  }
+  return strings;
+}
+
+function builtinNumberFormat(id: string): string {
+  switch (id) {
+    case "0": return "General";
+    case "1": return "0";
+    case "2": return "0.00";
+    case "9": return "0%";
+    case "10": return "0.00%";
+    case "14": return "mm-dd-yy";
+    case "22": return "m/d/yy h:mm";
+    case "49": return "@";
+    default: return "";
+  }
+}
+
+function parseXlsxNumberFormats(stylesXml: string | null): string[] {
+  if (!stylesXml) return [];
+  const custom = new Map<string, string>();
+  for (const attributes of xmlStartTagAttributes(stylesXml, "numFmt")) {
+    if (attributes.numFmtId && attributes.formatCode) custom.set(attributes.numFmtId, attributes.formatCode);
+  }
+  const cellXfs = xmlBlocks(stylesXml, "cellXfs")[0]?.inner ?? "";
+  return xmlStartTagAttributes(cellXfs, "xf").map((attributes) => {
+    const id = attributes.numFmtId ?? "0";
+    return custom.get(id) ?? builtinNumberFormat(id);
+  });
+}
+
+function cellTypeLabel(type: string): string {
+  if (type === "s") return "shared_string";
+  if (type === "inlineStr") return "inline_string";
+  if (type === "str") return "formula_string";
+  if (type === "b") return "boolean";
+  if (type === "e") return "error";
+  return type || "number";
+}
+
+function displayedCellValue(type: string, rawValue: string | undefined, body: string, sharedStrings: string[]): string | undefined {
+  if (type === "inlineStr") {
+    const text = sharedStringText(body);
+    return text || undefined;
+  }
+  if (type === "s" && rawValue !== undefined) {
+    const index = Number.parseInt(rawValue, 10);
+    return Number.isInteger(index) ? sharedStrings[index] : undefined;
+  }
+  if (type === "b" && rawValue !== undefined) return rawValue === "1" ? "TRUE" : "FALSE";
+  return rawValue;
+}
+
+function parseXlsxSheetData(xml: string, sharedStrings: string[], numberFormats: string[], cellLimit: number) {
+  const dimension = xmlStartTagAttributes(xml, "dimension")[0]?.ref ?? "";
+  const mergedRanges: string[] = [];
+  for (const attributes of xmlStartTagAttributes(xml, "mergeCell")) {
+    if (attributes.ref) mergedRanges.push(attributes.ref);
+  }
+  const tag = xmlTagPattern("c");
+  const cellRegex = new RegExp(`<${tag}\\b([^>]*)>([\\s\\S]*?)<\\/${tag}>`, "g");
+  const cells: XlsxCell[] = [];
+  let omittedCells = 0;
+  let seenCells = 0;
+  let match: RegExpExecArray | null;
+  while ((match = cellRegex.exec(xml))) {
+    seenCells += 1;
+    if (cells.length >= cellLimit) {
+      omittedCells += 1;
+      continue;
+    }
+    const attributes = xmlAttributes(match[1]);
+    const body = match[2];
+    const formulaBlock = xmlBlocks(body, "f")[0];
+    const rawValue = firstXmlText(body, "v");
+    const type = attributes.t ?? "";
+    const styleIndex = attributes.s;
+    const numberFormat = styleIndex !== undefined ? numberFormats[Number.parseInt(styleIndex, 10)] : undefined;
+    const displayValue = displayedCellValue(type, rawValue, body, sharedStrings);
+    cells.push({
+      reference: attributes.r ?? `cell_${seenCells}`,
+      type: cellTypeLabel(type),
+      ...(styleIndex !== undefined ? { styleIndex } : {}),
+      ...(numberFormat ? { numberFormat } : {}),
+      ...(formulaBlock ? { formula: xmlText(formulaBlock.inner) } : {}),
+      ...(formulaBlock?.attributes.t ? { formulaType: formulaBlock.attributes.t } : {}),
+      ...(formulaBlock?.attributes.ref ? { formulaRef: formulaBlock.attributes.ref } : {}),
+      ...(rawValue !== undefined ? { rawValue } : {}),
+      ...(displayValue !== undefined ? { displayedValue: displayValue } : {}),
+    });
+  }
+  return { dimension, mergedRanges, cells, omittedCells };
+}
+
+function quoted(value: string): string {
+  const encoded = JSON.stringify(value.length > 500 ? `${value.slice(0, 500)}…` : value);
+  return typeof encoded === "string" ? encoded : "\"\"";
+}
+
+function extractXlsxText(bytes: Buffer): string {
+  const entries = zipEntryMap(listZipEntries(bytes));
+  const workbookXml = readZipTextEntry(bytes, entries, "xl/workbook.xml");
+  if (!workbookXml) throw new Error("XLSX workbook.xml was not found.");
+  const sharedStrings = parseSharedStrings(readZipTextEntry(bytes, entries, "xl/sharedStrings.xml"));
+  const numberFormats = parseXlsxNumberFormats(readZipTextEntry(bytes, entries, "xl/styles.xml"));
+  const sheets = parseWorkbookSheets(workbookXml, readZipTextEntry(bytes, entries, "xl/_rels/workbook.xml.rels"));
+  if (sheets.length === 0) throw new Error("XLSX workbook contained no sheets.");
+
+  const lines = [
+    "xlsx_workbook:",
+    `  sheet_count: ${sheets.length}`,
+    `  shared_string_count: ${sharedStrings.length}`,
+    `  style_count: ${numberFormats.length}`,
+    "  sheets:",
+  ];
+  let remainingCells = MAX_XLSX_CELLS;
+  for (const sheet of sheets.slice(0, MAX_XLSX_SHEETS)) {
+    lines.push(`  - name: ${quoted(sheet.name)}`);
+    lines.push(`    sheet_id: ${quoted(sheet.sheetId)}`);
+    if (sheet.relationshipId) lines.push(`    relationship_id: ${quoted(sheet.relationshipId)}`);
+    lines.push(`    path: ${quoted(sheet.path)}`);
+    const safeSheetPath = sheet.path.startsWith("xl/worksheets/") && sheet.path.endsWith(".xml") ? sheet.path : "";
+    const sheetXml = safeSheetPath ? readZipTextEntry(bytes, entries, safeSheetPath) : null;
+    if (!sheetXml) {
+      lines.push("    error: worksheet XML was not found or was outside xl/worksheets");
+      continue;
+    }
+    const data = parseXlsxSheetData(sheetXml, sharedStrings, numberFormats, remainingCells);
+    remainingCells -= data.cells.length;
+    if (data.dimension) lines.push(`    dimension: ${quoted(data.dimension)}`);
+    if (data.mergedRanges.length) lines.push(`    merged_ranges: ${data.mergedRanges.map(quoted).join(", ")}`);
+    lines.push("    cells:");
+    for (const cell of data.cells) {
+      lines.push(`    - cell: ${quoted(cell.reference)}`);
+      lines.push(`      type: ${quoted(cell.type)}`);
+      if (cell.rawValue !== undefined) lines.push(`      raw_value: ${quoted(cell.rawValue)}`);
+      if (cell.displayedValue !== undefined) lines.push(`      displayed_value: ${quoted(cell.displayedValue)}`);
+      if (cell.formula) lines.push(`      formula: ${quoted(cell.formula)}`);
+      if (cell.formulaType) lines.push(`      formula_type: ${quoted(cell.formulaType)}`);
+      if (cell.formulaRef) lines.push(`      formula_ref: ${quoted(cell.formulaRef)}`);
+      if (cell.styleIndex !== undefined) lines.push(`      style_index: ${quoted(cell.styleIndex)}`);
+      if (cell.numberFormat) lines.push(`      number_format: ${quoted(cell.numberFormat)}`);
+    }
+    if (data.omittedCells > 0) lines.push(`    omitted_cells: ${data.omittedCells}`);
+  }
+  if (sheets.length > MAX_XLSX_SHEETS) lines.push(`  omitted_sheets: ${sheets.length - MAX_XLSX_SHEETS}`);
+  return lines.join("\n").slice(0, MAX_EXTRACTED_TEXT_CHARS);
+}
+
 function extractOfficeText(kind: OfficeKind, bytes: Buffer): string {
+  if (kind === "xlsx") return extractXlsxText(bytes);
   const entries = listZipEntries(bytes).filter((entry) => relevantXmlEntry(kind, entry.name)).sort(compareEntryName);
   if (entries.length === 0) throw new Error("No supported Office XML text entries were found.");
   const pieces: string[] = [];

--- a/evals/drivers/office-attachments-mock-provider.mjs
+++ b/evals/drivers/office-attachments-mock-provider.mjs
@@ -5,18 +5,13 @@ import { existsSync, readFileSync } from "node:fs";
 import { isAbsolute, join, posix } from "node:path";
 
 import {
-  DOCX_SENTINEL,
   OFFICE_FIXTURES,
-  PPTX_SENTINEL,
+  XLSX_FIXTURE,
 } from "../fixtures/ooxml-office-fixtures.mjs";
 
 const OFFICE_TOOL_CALL_ID = "call_write_office_artifacts";
 const OFFICE_TOOL_NAME = "bash";
 const MATERIALIZED_PREFIX = ".opencode/openwork/inbox/chat-attachments/";
-const ARTIFACT_PATHS = {
-  docx: "artifacts/QuarterlyBrief.docx",
-  pptx: "artifacts/LaunchRoadmap.pptx",
-};
 
 function parseArgs(argv) {
   const args = new Map();
@@ -26,6 +21,13 @@ function parseArgs(argv) {
   }
   return args;
 }
+
+const args = parseArgs(process.argv.slice(2));
+const mode = args.get("mode") === "xlsx" ? "xlsx" : "office";
+const EXPECTED_FIXTURES = mode === "xlsx" ? { xlsx: XLSX_FIXTURE } : OFFICE_FIXTURES;
+const ARTIFACT_PATHS = mode === "xlsx"
+  ? { xlsx: "artifacts/RevenueWorkbook.xlsx" }
+  : { docx: "artifacts/QuarterlyBrief.docx", pptx: "artifacts/LaunchRoadmap.pptx" };
 
 function sha256(buffer) {
   return createHash("sha256").update(buffer).digest("hex");
@@ -160,7 +162,7 @@ function countOfficeFileMarkers(value, context = { filename: "", mime: "" }) {
 
   const nextContext = contextFromRecord(value, context);
   const type = stringField(value, ["type"]).toLowerCase();
-  const officeLike = Object.values(OFFICE_FIXTURES).some((expected) => nextContext.filename === expected.filename || nextContext.mime === expected.mime);
+  const officeLike = Object.values(EXPECTED_FIXTURES).some((expected) => nextContext.filename === expected.filename || nextContext.mime === expected.mime);
   const fileLike = type.includes("file") || "file_data" in value || "fileData" in value || "contentBase64" in value;
   let count = officeLike && fileLike ? 1 : 0;
   for (const item of Object.values(value)) count += countOfficeFileMarkers(item, nextContext);
@@ -204,13 +206,13 @@ function verifyOfficePayloads(body) {
   const promptTexts = collectPromptText(body);
   const rawBody = JSON.stringify(body);
   const officeFileMarkers = countOfficeFileMarkers(body);
-  const rawOfficeBinaryLeak = Object.values(OFFICE_FIXTURES).some((expected) => {
+  const rawOfficeBinaryLeak = Object.values(EXPECTED_FIXTURES).some((expected) => {
     return rawBody.includes(expected.dataBase64)
       || payloads.some((item) => item.sha256 === expected.sha256 || item.filename === expected.filename || item.mime === expected.mime);
   });
   const attachments = {};
 
-  for (const [kind, expected] of Object.entries(OFFICE_FIXTURES)) {
+  for (const [kind, expected] of Object.entries(EXPECTED_FIXTURES)) {
     attachments[kind] = parseNormalizedAttachment(promptTexts, expected) ?? { received: false, expected };
   }
 
@@ -257,7 +259,7 @@ function isToolResultRecord(record) {
 function hasExpectedToolOutput(record) {
   const text = collectStringValues(record).join("\n");
   return Object.values(ARTIFACT_PATHS).every((path) => text.includes(path))
-    && Object.values(OFFICE_FIXTURES).every((expected) => text.includes(expected.sha256));
+    && Object.values(EXPECTED_FIXTURES).every((expected) => text.includes(expected.sha256));
 }
 
 function hasExactIssuedToolResult(value) {
@@ -291,16 +293,16 @@ function shellQuote(value) {
 }
 
 function artifactWriteCommand(attachments) {
-  const docx = attachments.docx?.workerRelativePath;
-  const pptx = attachments.pptx?.workerRelativePath;
-  if (!docx || !pptx) throw new Error(`Missing materialized Office paths: ${JSON.stringify(attachments)}`);
+  const entries = Object.entries(ARTIFACT_PATHS).map(([kind, path]) => {
+    const source = attachments[kind]?.workerRelativePath;
+    if (!source) throw new Error(`Missing materialized Office path for ${kind}: ${JSON.stringify(attachments)}`);
+    return { source, path };
+  });
+  const paths = entries.map((entry) => shellQuote(entry.path)).join(" ");
   return `set -euo pipefail
 mkdir -p artifacts
-test -s ${shellQuote(docx)}
-test -s ${shellQuote(pptx)}
-cp ${shellQuote(docx)} ${shellQuote(ARTIFACT_PATHS.docx)}
-cp ${shellQuote(pptx)} ${shellQuote(ARTIFACT_PATHS.pptx)}
-(sha256sum ${shellQuote(ARTIFACT_PATHS.docx)} ${shellQuote(ARTIFACT_PATHS.pptx)} 2>/dev/null || shasum -a 256 ${shellQuote(ARTIFACT_PATHS.docx)} ${shellQuote(ARTIFACT_PATHS.pptx)})`;
+${entries.map((entry) => `test -s ${shellQuote(entry.source)}\ncp ${shellQuote(entry.source)} ${shellQuote(entry.path)}`).join("\n")}
+(sha256sum ${paths} 2>/dev/null || shasum -a 256 ${paths})`;
 }
 
 function toolCallStream(attachments) {
@@ -339,13 +341,11 @@ function toolCallStream(attachments) {
 
 function finalText() {
   return [
-    `Verified ${OFFICE_FIXTURES.docx.filename}: ${DOCX_SENTINEL}`,
-    `Verified ${OFFICE_FIXTURES.pptx.filename}: ${PPTX_SENTINEL}`,
-    "Created artifacts/QuarterlyBrief.docx and artifacts/LaunchRoadmap.pptx from the exact safely materialized Office bytes.",
+    ...Object.values(EXPECTED_FIXTURES).map((expected) => `Verified ${expected.filename}: ${expected.sentinels.join(" | ")}`),
+    `Created ${Object.values(ARTIFACT_PATHS).join(" and ")} from the exact safely materialized Office bytes.`,
   ].join("\n");
 }
 
-const args = parseArgs(process.argv.slice(2));
 const host = args.get("host") || "127.0.0.1";
 const port = Number(args.get("port") || 18081);
 const workspaceRoot = args.get("workspace") || process.cwd();

--- a/evals/fixtures/ooxml-office-fixtures.mjs
+++ b/evals/fixtures/ooxml-office-fixtures.mjs
@@ -6,10 +6,13 @@ const ZIP_END_OF_CENTRAL_DIRECTORY = 0x06054b50;
 
 export const DOCX_FILENAME = "QuarterlyBrief.docx";
 export const PPTX_FILENAME = "LaunchRoadmap.pptx";
+export const XLSX_FILENAME = "RevenueWorkbook.xlsx";
 export const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
 export const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+export const XLSX_MIME = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
 export const DOCX_SENTINEL = "DOCX sentinel fact: Northstar margin lift is 17.42 percent.";
 export const PPTX_SENTINEL = "PPTX sentinel fact: Launch window opens on 2026-09-17.";
+export const XLSX_SENTINEL = "XLSX sentinel fact: Northstar revenue is 1742.42.";
 
 let crcTable = null;
 
@@ -246,13 +249,82 @@ const pptx = writeZip([
   },
 ]);
 
+const xlsx = writeZip([
+  {
+    name: "[Content_Types].xml",
+    data: xml`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Types xmlns="http://schemas.openxmlformats.org/package/2006/content-types">
+  <Default Extension="rels" ContentType="application/vnd.openxmlformats-package.relationships+xml"/>
+  <Default Extension="xml" ContentType="application/xml"/>
+  <Override PartName="/xl/workbook.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml"/>
+  <Override PartName="/xl/worksheets/sheet1.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml"/>
+  <Override PartName="/xl/sharedStrings.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.sharedStrings+xml"/>
+  <Override PartName="/xl/styles.xml" ContentType="application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"/>
+</Types>`,
+  },
+  {
+    name: "_rels/.rels",
+    data: xml`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/officeDocument" Target="xl/workbook.xml"/>
+</Relationships>`,
+  },
+  {
+    name: "xl/workbook.xml",
+    data: xml`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<workbook xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" xmlns:r="http://schemas.openxmlformats.org/officeDocument/2006/relationships">
+  <sheets><sheet name="Summary" sheetId="1" r:id="rId1"/></sheets>
+</workbook>`,
+  },
+  {
+    name: "xl/_rels/workbook.xml.rels",
+    data: xml`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Relationships xmlns="http://schemas.openxmlformats.org/package/2006/relationships">
+  <Relationship Id="rId1" Type="http://schemas.openxmlformats.org/officeDocument/2006/relationships/worksheet" Target="worksheets/sheet1.xml"/>
+</Relationships>`,
+  },
+  {
+    name: "xl/sharedStrings.xml",
+    data: xml`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sst xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main" count="3" uniqueCount="3">
+  <si><t>${XLSX_SENTINEL}</t></si>
+  <si><t>Northstar Revenue</t></si>
+  <si><r><t>EM</t></r><r><t>EA</t></r></si>
+</sst>`,
+  },
+  {
+    name: "xl/styles.xml",
+    data: xml`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<styleSheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <numFmts count="1"><numFmt numFmtId="164" formatCode="$#,##0.00"/></numFmts>
+  <cellXfs count="2"><xf numFmtId="0"/><xf numFmtId="164" applyNumberFormat="1"/></cellXfs>
+</styleSheet>`,
+  },
+  {
+    name: "xl/worksheets/sheet1.xml",
+    data: xml`<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<worksheet xmlns="http://schemas.openxmlformats.org/spreadsheetml/2006/main">
+  <dimension ref="A1:D3"/>
+  <sheetData>
+    <row r="1"><c r="A1" t="s"><v>0</v></c></row>
+    <row r="2"><c r="A2" t="s"><v>1</v></c><c r="B2" t="s"><v>2</v></c><c r="C2" s="1"><v>1742.42</v></c><c r="D2" s="1"><f>SUM(C2:C3)</f><v>3484.84</v></c></row>
+    <row r="3"><c r="C3" s="1"><v>1742.42</v></c></row>
+  </sheetData>
+  <mergeCells count="1"><mergeCell ref="A1:D1"/></mergeCells>
+</worksheet>`,
+  },
+]);
+
 export const OFFICE_FIXTURES = {
   docx: fixture(DOCX_FILENAME, DOCX_MIME, [DOCX_SENTINEL], docx),
   pptx: fixture(PPTX_FILENAME, PPTX_MIME, [PPTX_SENTINEL], pptx),
 };
 
+export const XLSX_FIXTURE = fixture(XLSX_FILENAME, XLSX_MIME, [XLSX_SENTINEL, "Northstar Revenue", "1742.42", "SUM(C2:C3)", "$#,##0.00", "A1:D1"], xlsx);
+
 export function fixtureBytes(kind) {
   if (kind === "docx") return Buffer.from(OFFICE_FIXTURES.docx.dataBase64, "base64");
   if (kind === "pptx") return Buffer.from(OFFICE_FIXTURES.pptx.dataBase64, "base64");
+  if (kind === "xlsx") return Buffer.from(XLSX_FIXTURE.dataBase64, "base64");
   throw new Error(`Unknown fixture kind: ${kind}`);
 }

--- a/evals/flows/xlsx-chat-attachments.flow.mjs
+++ b/evals/flows/xlsx-chat-attachments.flow.mjs
@@ -1,0 +1,623 @@
+import { spawnSync } from "node:child_process";
+import { createHash } from "node:crypto";
+import { dirname, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { XLSX_FILENAME, XLSX_FIXTURE, XLSX_SENTINEL } from "../fixtures/ooxml-office-fixtures.mjs";
+
+const FLOW_ID = "xlsx-chat-attachments";
+const PROVIDER_ID = "xlsx-attachments-mock";
+const MODEL_ID = "office-attachment-mock";
+const MOCK_PORT = 18082;
+const DOWNLOAD_DIR = "/tmp/openwork-xlsx-attachment-downloads";
+const ARTIFACT_PATH = "artifacts/RevenueWorkbook.xlsx";
+const PROMPT = "Please inspect the attached Excel workbook, preserve an exact copy as a workspace artifact, and summarize the sheet values, formula, formatting, and merge range.";
+const FOLLOW_UP = "Confirm this spreadsheet attachment session still works after reopening.";
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function shellQuote(value) {
+  return `'${String(value).replaceAll("'", "'\"'\"'")}'`;
+}
+
+function runInSandbox(ctx, script, timeout = 120_000) {
+  const sandbox = ctx.env?.OPENWORK_EVAL_DAYTONA_SANDBOX?.trim();
+  if (!sandbox) {
+    const result = spawnSync("bash", ["-lc", script], { cwd: REPO_ROOT, encoding: "utf8", timeout });
+    ctx.assert(result.status === 0, `Local command failed: ${result.stderr || result.stdout}`);
+    return result.stdout;
+  }
+
+  const sandboxScript = `cd /workspace\n${script}`;
+  const encoded = Buffer.from(sandboxScript, "utf8").toString("base64");
+  const result = spawnSync(
+    "daytona",
+    ["exec", sandbox, "--", "echo", encoded, "|", "base64", "-d", "|", "bash"],
+    { encoding: "utf8", timeout },
+  );
+  ctx.assert(result.status === 0, `Daytona command failed: ${result.stderr || result.stdout}`);
+  return result.stdout;
+}
+
+function record(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({ type: "assertion", status: condition ? "passed" : "failed", assertion, actual });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${actual})` : ""}`);
+}
+
+function startMockProvider(ctx) {
+  return runInSandbox(ctx, `
+set -euo pipefail
+if [ -f /tmp/openwork-xlsx-attachments-mock.pid ]; then
+  kill "$(cat /tmp/openwork-xlsx-attachments-mock.pid)" >/dev/null 2>&1 || true
+fi
+rm -f /tmp/openwork-xlsx-attachments-mock.log /tmp/openwork-xlsx-attachments-mock.pid
+nohup node evals/drivers/office-attachments-mock-provider.mjs --mode xlsx --port ${MOCK_PORT} --workspace ${shellQuote(ctx.workspacePath || "/workspace")} > /tmp/openwork-xlsx-attachments-mock.log 2>&1 < /dev/null &
+echo $! > /tmp/openwork-xlsx-attachments-mock.pid
+for _ in $(seq 1 80); do
+  if curl -sf http://127.0.0.1:${MOCK_PORT}/health >/tmp/openwork-xlsx-attachments-health.json; then
+    cat /tmp/openwork-xlsx-attachments-health.json
+    exit 0
+  fi
+  sleep 0.25
+done
+cat /tmp/openwork-xlsx-attachments-mock.log >&2
+exit 1
+`).trim();
+}
+
+function stopMockProvider(ctx) {
+  return runInSandbox(ctx, `
+set -uo pipefail
+curl -sf --connect-timeout 1 --max-time 2 -X POST http://127.0.0.1:${MOCK_PORT}/shutdown >/dev/null 2>&1 || true
+if [ -s /tmp/openwork-xlsx-attachments-mock.pid ]; then
+  pid="$(cat /tmp/openwork-xlsx-attachments-mock.pid 2>/dev/null || true)"
+  if [ -n "$pid" ] && kill -0 "$pid" >/dev/null 2>&1; then
+    kill "$pid" >/dev/null 2>&1 || true
+  fi
+fi
+rm -f /tmp/openwork-xlsx-attachments-mock.pid
+printf 'mock stopped\n'
+`, 30_000).trim();
+}
+
+function proofFromSandbox(ctx) {
+  return JSON.parse(runInSandbox(ctx, `curl -sf http://127.0.0.1:${MOCK_PORT}/proof`, 30_000));
+}
+
+async function pollProof(ctx, predicate, timeoutMs, label) {
+  const startedAt = Date.now();
+  let last = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    last = proofFromSandbox(ctx);
+    if (predicate(last)) return last;
+    await sleep(500);
+  }
+  throw new Error(`Timed out after ${timeoutMs}ms waiting for ${label}. Last proof: ${JSON.stringify(last)}`);
+}
+
+async function forceEnglish(ctx) {
+  const shouldReload = await ctx.eval(`(() => {
+    const current = localStorage.getItem("openwork.language");
+    localStorage.setItem("openwork.language", "en");
+    return current !== "en" || document.documentElement.getAttribute("lang") !== "en";
+  })()`);
+  if (!shouldReload) return;
+  await ctx.eval("location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after language reload" });
+}
+
+async function appRouteState(ctx) {
+  return await ctx.eval(`(() => {
+    const hash = location.hash;
+    const control = window.__openworkControl;
+    const snapshot = control && typeof control.snapshot === "function" ? control.snapshot() : null;
+    const route = (snapshot && snapshot.route) || (hash.startsWith("#") ? hash.slice(1) : hash);
+    const pathSegment = (value, segment) => {
+      const marker = "/" + segment + "/";
+      const text = String(value || "");
+      const index = text.indexOf(marker);
+      if (index < 0) return "";
+      const rest = text.slice(index + marker.length);
+      const end = rest.indexOf("/");
+      return end < 0 ? rest : rest.slice(0, end);
+    };
+    const workspaceId = pathSegment(hash, "workspace") || localStorage.getItem("openwork.react.activeWorkspace") || "";
+    const sessionId = pathSegment(hash, "session") || pathSegment(route, "session") || "";
+    return { hash, route, workspaceId, sessionId };
+  })()`);
+}
+
+async function serverJson(ctx, path, init = {}) {
+  const method = init.method || "GET";
+  const raw = await ctx.eval(`(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return JSON.stringify({ ok: false, status: 0, text: "missing server port/token" });
+    const response = await fetch("http://127.0.0.1:" + port + ${JSON.stringify(path)}, {
+      method: ${JSON.stringify(method)},
+      headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      body: ${init.body === undefined ? "undefined" : JSON.stringify(JSON.stringify(init.body))},
+    });
+    const text = await response.text();
+    return JSON.stringify({ ok: response.ok, status: response.status, text });
+  })()`, { awaitPromise: true });
+  const result = JSON.parse(raw);
+  ctx.assert(result.ok, `${method} ${path} failed: ${result.status} ${String(result.text).slice(0, 500)}`);
+  return result.text ? JSON.parse(result.text) : null;
+}
+
+async function serverShell(ctx, path, init = {}) {
+  const auth = await ctx.eval(`JSON.stringify({ port: localStorage.getItem("openwork.server.port"), token: localStorage.getItem("openwork.server.token") })`);
+  const { port, token } = JSON.parse(auth);
+  ctx.assert(Boolean(port && token), "missing server port/token");
+  const method = init.method || "GET";
+  const body = init.body === undefined ? "" : JSON.stringify(init.body);
+  return runInSandbox(ctx, `
+set -euo pipefail
+url=${shellQuote(`http://127.0.0.1:${port}${path}`)}
+body=${shellQuote(body)}
+if [ -n "$body" ]; then
+  curl -sf --max-time 120 -X ${shellQuote(method)} -H ${shellQuote(`Authorization: Bearer ${token}`)} -H 'Content-Type: application/json' --data "$body" "$url"
+else
+  curl -sf --max-time 120 -X ${shellQuote(method)} -H ${shellQuote(`Authorization: Bearer ${token}`)} -H 'Content-Type: application/json' "$url"
+fi
+`, 150_000);
+}
+
+async function loadWorkspacePath(ctx) {
+  const payload = await serverJson(ctx, "/workspaces");
+  const workspaces = Array.isArray(payload) ? payload : payload?.items ?? payload?.workspaces ?? [];
+  const workspace = workspaces.find((item) => item?.id === ctx.workspaceId);
+  ctx.workspacePath = typeof workspace?.path === "string" ? workspace.path : "";
+  ctx.assert(Boolean(ctx.workspacePath), `Could not determine workspace path for ${ctx.workspaceId}`);
+}
+
+async function configureMockProvider(ctx) {
+  const state = await appRouteState(ctx);
+  ctx.assert(Boolean(state.workspaceId), `Could not determine workspace id from ${state.hash}`);
+  ctx.workspaceId = state.workspaceId;
+  await loadWorkspacePath(ctx);
+  const baseURL = `http://127.0.0.1:${MOCK_PORT}/v1`;
+  await serverJson(ctx, `/workspace/${encodeURIComponent(ctx.workspaceId)}/config`, {
+    method: "PATCH",
+    body: {
+      opencode: {
+        provider: {
+          [PROVIDER_ID]: {
+            npm: "@ai-sdk/openai-compatible",
+            name: "XLSX Attachments Mock",
+            options: { baseURL, apiKey: "sk-openwork-xlsx-attachments-eval" },
+            models: {
+              [MODEL_ID]: {
+                name: "Spreadsheet attachment mock",
+                attachment: true,
+                modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  await serverShell(ctx, `/workspace/${encodeURIComponent(ctx.workspaceId)}/engine/reload`, { method: "POST" });
+  await ctx.eval(`(() => {
+    const prefsRaw = localStorage.getItem("openwork.preferences");
+    let prefs = {};
+    try { prefs = prefsRaw ? JSON.parse(prefsRaw) : {}; } catch { prefs = {}; }
+    if (!prefs || typeof prefs !== "object" || Array.isArray(prefs)) prefs = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...prefs,
+      defaultModel: { providerID: ${JSON.stringify(PROVIDER_ID)}, modelID: ${JSON.stringify(MODEL_ID)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${PROVIDER_ID}/${MODEL_ID}`)});
+    localStorage.removeItem("openwork.sessionModels.${ctx.workspaceId}");
+  })()`);
+  ctx.output("XLSX mock provider", JSON.stringify({ provider: PROVIDER_ID, model: MODEL_ID, baseURL }, null, 2));
+}
+
+async function createFreshSession(ctx) {
+  await ctx.waitFor(`window.__openworkControl.listActions().some((item) => item.id === "session.create_task" && !item.disabled)`, { timeoutMs: 60_000, label: "session.create_task enabled" });
+  await ctx.control("session.create_task");
+  await ctx.waitFor(`location.hash.includes("/session/")`, { timeoutMs: 60_000, label: "fresh session route" });
+  const state = await appRouteState(ctx);
+  ctx.workspaceId = state.workspaceId;
+  ctx.sessionId = state.sessionId;
+  ctx.assert(Boolean(ctx.workspaceId && ctx.sessionId), `Missing session route info: ${JSON.stringify(state)}`);
+  await ctx.waitFor(`Boolean(document.querySelector('input[type="file"][multiple]'))`, { timeoutMs: 30_000, label: "composer file input" });
+}
+
+async function assertMockSelected(ctx) {
+  const selected = await ctx.waitFor(`(() => {
+    const button = Array.from(document.querySelectorAll("button")).find((item) => item.getAttribute("aria-label") === "Change model");
+    const text = button && button.textContent ? button.textContent : "";
+    return text.includes("Spreadsheet attachment mock") ? text : null;
+  })()`, { timeoutMs: 60_000, label: "visible Spreadsheet mock selected model" });
+  record(ctx, selected.includes("Spreadsheet attachment mock"), "Visible selected model is Spreadsheet attachment mock", selected);
+}
+
+async function attachXlsxFile(ctx) {
+  return ctx.eval(
+    `(() => {
+      const input = document.querySelector('input[type="file"][multiple]');
+      if (!(input instanceof HTMLInputElement)) return { ok: false, reason: "file input not found" };
+      const binary = atob(${JSON.stringify(XLSX_FIXTURE.dataBase64)});
+      const bytes = new Uint8Array(binary.length);
+      for (let index = 0; index < binary.length; index += 1) bytes[index] = binary.charCodeAt(index);
+      const transfer = new DataTransfer();
+      transfer.items.add(new File([bytes], ${JSON.stringify(XLSX_FILENAME)}, { type: "application/octet-stream", lastModified: 1767225600000 }));
+      input.files = transfer.files;
+      input.dispatchEvent(new Event("change", { bubbles: true }));
+      return { ok: true, files: Array.from(transfer.files).map((file) => ({ name: file.name, type: file.type, size: file.size })) };
+    })()`,
+  );
+}
+
+async function dismissOpenWorkModelsModal(ctx) {
+  const result = await ctx.eval(`(() => {
+    const dialog = Array.from(document.querySelectorAll('[role="dialog"], [data-slot="dialog-content"], [data-radix-dialog-content]')).find((item) => (item.textContent || "").includes("OpenWork Models"));
+    if (!dialog) return { dismissed: false };
+    const button = Array.from(dialog.querySelectorAll("button")).find((item) => (item.textContent || "").trim().includes("Continue without OpenWork Models") || item.getAttribute("aria-label") === "Close");
+    if (!button) return { dismissed: false };
+    button.click();
+    return { dismissed: true };
+  })()`);
+  if (!result?.dismissed) return;
+  await ctx.waitFor(`!Array.from(document.querySelectorAll('[role="dialog"], [data-slot="dialog-content"], [data-radix-dialog-content]')).some((item) => (item.textContent || "").includes("OpenWork Models"))`, { timeoutMs: 10_000, label: "OpenWork Models modal dismissed" });
+}
+
+function sentXlsxCardExpr() {
+  return `(() => {
+    const buttons = Array.from(document.querySelectorAll("button"));
+    const button = buttons.find((item) => item.getAttribute("aria-label") === "Download " + ${JSON.stringify(XLSX_FILENAME)});
+    const card = button ? button.closest("div") : null;
+    const text = card && card.textContent ? card.textContent : "";
+    return button && text.includes(${JSON.stringify(XLSX_FILENAME)}) && text.includes("XLSX") && text.includes("Download") ? { ok: true } : null;
+  })()`;
+}
+
+async function clickDownloadButtonAndVerifySha(ctx, { buttonLabel, filename, expectedSha, assertion }) {
+  runInSandbox(ctx, `rm -rf ${shellQuote(DOWNLOAD_DIR)} && mkdir -p ${shellQuote(DOWNLOAD_DIR)}`, 30_000);
+  await ctx.client.send("Page.setDownloadBehavior", { behavior: "allow", downloadPath: DOWNLOAD_DIR }).catch(async () => {
+    await ctx.client.send("Browser.setDownloadBehavior", { behavior: "allow", downloadPath: DOWNLOAD_DIR });
+  });
+  const clicked = await ctx.eval(`(() => {
+    const buttons = Array.from(document.querySelectorAll("button")).filter((item) => item.getAttribute("aria-label") === ${JSON.stringify(buttonLabel)} && !item.disabled);
+    if (buttons.length !== 1) return { ok: false, count: buttons.length };
+    buttons[0].scrollIntoView({ block: "center", inline: "center" });
+    buttons[0].click();
+    return { ok: true, count: 1 };
+  })()`);
+  ctx.assert(clicked?.ok, `Expected exactly one enabled ${buttonLabel} button, found ${clicked?.count ?? "unknown"}`);
+  const output = runInSandbox(ctx, `
+set -euo pipefail
+path=${shellQuote(`${DOWNLOAD_DIR}/${filename}`)}
+for _ in $(seq 1 80); do
+  if [ -f "$path" ]; then break; fi
+  sleep 0.25
+done
+test -f "$path"
+node - "$path" <<'EOF'
+const { createHash } = require("node:crypto");
+const { readFileSync } = require("node:fs");
+process.stdout.write(createHash("sha256").update(readFileSync(process.argv[2])).digest("hex"));
+EOF
+`, 45_000).trim();
+  record(ctx, output === expectedSha, assertion, output);
+}
+
+async function sessionMessages(ctx) {
+  const payload = await serverJson(ctx, `/workspace/${encodeURIComponent(ctx.workspaceId)}/sessions/${encodeURIComponent(ctx.sessionId)}/messages?limit=80`);
+  return payload.items ?? [];
+}
+
+function isRecord(value) {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function stringField(record, names) {
+  for (const name of names) {
+    const value = record[name];
+    if (typeof value === "string" && value.trim()) return value.trim();
+  }
+  return "";
+}
+
+function collectFileParts(value, out = []) {
+  if (Array.isArray(value)) {
+    for (const item of value) collectFileParts(item, out);
+    return out;
+  }
+  if (!isRecord(value)) return out;
+  const filename = stringField(value, ["filename", "fileName", "name"]);
+  if (stringField(value, ["type"]) === "file" || filename === XLSX_FILENAME) out.push(value);
+  for (const item of Object.values(value)) collectFileParts(item, out);
+  return out;
+}
+
+function dataUrlDetails(value) {
+  if (typeof value !== "string") return null;
+  const match = /^data:([^;,]+)?(?:;[^,]*)?;base64,([A-Za-z0-9+/=\s]+)$/i.exec(value);
+  if (!match) return null;
+  const bytes = Buffer.from(match[2].replace(/\s+/g, ""), "base64");
+  return { mime: (match[1] || "application/octet-stream").trim().toLowerCase(), sha256: createHash("sha256").update(bytes).digest("hex"), size: bytes.byteLength };
+}
+
+function findDataUrlDetails(value) {
+  const direct = dataUrlDetails(value);
+  if (direct) return direct;
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const found = findDataUrlDetails(item);
+      if (found) return found;
+    }
+  }
+  if (!isRecord(value)) return null;
+  for (const item of Object.values(value)) {
+    const found = findDataUrlDetails(item);
+    if (found) return found;
+  }
+  return null;
+}
+
+function collectStrings(value, out = []) {
+  if (typeof value === "string") {
+    out.push(value);
+    return out;
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) collectStrings(item, out);
+    return out;
+  }
+  if (!isRecord(value)) return out;
+  for (const item of Object.values(value)) collectStrings(item, out);
+  return out;
+}
+
+function workspaceRelativePath(root, target) {
+  const relativePath = relative(resolve(root), resolve(target));
+  const outside = relativePath === ".." || relativePath.startsWith("../") || relativePath.startsWith("..\\");
+  return relativePath && !outside ? relativePath : "";
+}
+
+function hashWorkspaceFile(ctx, filePath) {
+  const raw = runInSandbox(ctx, `
+set -euo pipefail
+root=${shellQuote(ctx.workspacePath)}
+target=${shellQuote(filePath)}
+node - "$root" "$target" <<'EOF'
+const { createHash } = require("node:crypto");
+const { readFileSync, realpathSync } = require("node:fs");
+const { isAbsolute, relative } = require("node:path");
+const root = realpathSync(process.argv[2]);
+const target = realpathSync(process.argv[3]);
+const relativePath = relative(root, target);
+const outside = relativePath === ".." || relativePath.startsWith("../") || relativePath.startsWith("..\\\\");
+if (!relativePath || outside || isAbsolute(relativePath)) throw new Error("attachment path is outside workspace: " + target);
+const bytes = readFileSync(target);
+process.stdout.write(JSON.stringify({ relativePath, bytes: bytes.byteLength, sha256: createHash("sha256").update(bytes).digest("hex") }));
+EOF
+`, 30_000).trim();
+  return JSON.parse(raw);
+}
+
+function assertPersistedOriginalXlsx(ctx, messages) {
+  const candidates = collectFileParts(messages).filter((part) => stringField(part, ["filename", "fileName", "name"]) === XLSX_FILENAME);
+  const expectedUrl = `data:${XLSX_FIXTURE.mime};base64,${XLSX_FIXTURE.dataBase64}`;
+  const found = candidates.find((part) => stringField(part, ["url"]) === expectedUrl) || candidates[0];
+  record(ctx, Boolean(found), "Session read API retained the original XLSX FilePart", JSON.stringify({ candidates: candidates.length }));
+  if (!found) return;
+  const dataUrl = findDataUrlDetails(found);
+  record(ctx, stringField(found, ["mime", "mimeType", "mediaType", "contentType"]).toLowerCase() === XLSX_FIXTURE.mime, "Persisted XLSX MIME is canonical");
+  record(ctx, stringField(found, ["url"]) === expectedUrl, "Persisted XLSX FilePart URL is the exact canonical data URL");
+  record(ctx, dataUrl?.sha256 === XLSX_FIXTURE.sha256, "Persisted XLSX data URL sha256 matches original bytes", dataUrl?.sha256 || "missing");
+}
+
+function assertWorkspaceAttachmentPathNote(ctx, messages) {
+  const text = collectStrings(messages).filter((item) => item.includes(".opencode/openwork/inbox/chat-attachments/") || item.includes("Attached files were copied into this worker workspace")).join("\n");
+  const line = text.split(/\r?\n/).find((item) => item.includes(XLSX_FILENAME)) || "";
+  const path = /\.opencode\/openwork\/inbox\/chat-attachments\/[^\s)]*RevenueWorkbook\.xlsx/.exec(line)?.[0] ?? "";
+  const url = /file:\/\/[^\s)]+/i.exec(line)?.[0] ?? "";
+  record(ctx, Boolean(path), "Submitted XLSX path note includes a workspace-local inbox path", line || text.slice(0, 1000));
+  record(ctx, Boolean(url), "Submitted XLSX path note includes a file: URL", line || text.slice(0, 1000));
+  const filePath = url ? fileURLToPath(url) : "";
+  record(ctx, workspaceRelativePath(ctx.workspacePath, filePath) === path, "Submitted XLSX file: URL resolves to the noted workspace path", JSON.stringify({ filePath, path }));
+  const hash = hashWorkspaceFile(ctx, filePath);
+  record(ctx, hash.sha256 === XLSX_FIXTURE.sha256, "Workspace XLSX copy sha256 matches the fixture exactly", JSON.stringify(hash));
+  record(ctx, hash.bytes === XLSX_FIXTURE.size, "Workspace XLSX copy size matches the fixture exactly", JSON.stringify(hash));
+}
+
+function resetXlsxArtifact(ctx) {
+  runInSandbox(ctx, `rm -f ${shellQuote(`${ctx.workspacePath}/${ARTIFACT_PATH}`)}`, 30_000);
+}
+
+function xlsxArtifactHash(ctx) {
+  return runInSandbox(ctx, `
+set -euo pipefail
+path=${shellQuote(`${ctx.workspacePath}/${ARTIFACT_PATH}`)}
+test -f "$path"
+node - "$path" <<'EOF'
+const { createHash } = require("node:crypto");
+const { readFileSync } = require("node:fs");
+process.stdout.write(createHash("sha256").update(readFileSync(process.argv[2])).digest("hex"));
+EOF
+`, 30_000).trim();
+}
+
+async function waitForFinalResponse(ctx) {
+  await ctx.waitFor(`(() => {
+    const text = document.body.innerText;
+    return text.includes(${JSON.stringify(XLSX_SENTINEL)})
+      && text.includes("Northstar Revenue")
+      && text.includes("SUM(C2:C3)")
+      && text.includes("$#,##0.00")
+      && text.includes(${JSON.stringify(ARTIFACT_PATH)});
+  })()`, { timeoutMs: 120_000, label: "final assistant response with XLSX facts" });
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Session composer safely normalizes valid Excel XLSX attachments through the real model boundary",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+    const serverExited = await ctx.eval(`document.body.innerText.includes("OpenCode server exited")`);
+    if (serverExited) {
+      await ctx.eval("location.reload()");
+      await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after server-error reload" });
+    }
+    const state = await ctx.waitFor(`(() => {
+      const control = window.__openworkControl;
+      const route = control.snapshot().route;
+      if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+      if (document.body.innerText.includes("OpenCode server exited")) return "server-exited";
+      const action = control.listActions().find((item) => item.id === "session.create_task");
+      if (action && !action.disabled) return "ready";
+      return null;
+    })()`, { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" });
+    if (state === "server-exited") return "OpenCode server exited before the flow could create a task.";
+    return state === "blocked" ? "Profile is not onboarded (welcome/signin); XLSX attachment flow requires a workspace." : null;
+  },
+  steps: [
+    {
+      name: "Attach an XLSX workbook",
+      run: async (ctx) => {
+        await ctx.prove("The real composer accepts a generic-MIME .xlsx workbook without an unsupported-format warning", {
+          voiceover: vo[0],
+          action: async () => {
+            await forceEnglish(ctx);
+            const state = await appRouteState(ctx);
+            ctx.assert(Boolean(state.workspaceId), `Could not determine workspace id from ${state.hash}`);
+            ctx.workspaceId = state.workspaceId;
+            await loadWorkspacePath(ctx);
+            ctx.output("XLSX mock health", startMockProvider(ctx));
+            await configureMockProvider(ctx);
+            await ctx.eval("location.reload()");
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after provider reload" });
+            await createFreshSession(ctx);
+            await assertMockSelected(ctx);
+            const attached = await attachXlsxFile(ctx);
+            ctx.assert(attached?.ok, `Could not attach XLSX file: ${attached?.reason ?? "unknown"}`);
+            await ctx.control("composer.set_text", { text: PROMPT });
+            await ctx.waitFor(`document.body.innerText.includes(${JSON.stringify(XLSX_FILENAME)}) && document.body.innerText.includes(${JSON.stringify(PROMPT)})`, { timeoutMs: 30_000, label: "XLSX chip and prompt" });
+          },
+          assert: async () => {
+            await ctx.expectText(XLSX_FILENAME);
+            await ctx.expectText("Run task");
+            await ctx.expectNoText("has a format the model can't read");
+          },
+          screenshot: { name: "xlsx-attached-composer", requireText: [XLSX_FILENAME, "Run task"], rejectText: ["has a format the model can't read"], hashIncludes: "/session/" },
+        });
+      },
+    },
+    {
+      name: "Sent XLSX card is downloadable",
+      run: async (ctx) => {
+        await ctx.prove("After sending, the workbook renders as an XLSX file card and its Download action saves the exact original bytes", {
+          voiceover: vo[1],
+          action: async () => {
+            resetXlsxArtifact(ctx);
+            await ctx.control("composer.send");
+            await ctx.waitFor(sentXlsxCardExpr(), { timeoutMs: 45_000, label: "sent XLSX card with Download action" });
+            await dismissOpenWorkModelsModal(ctx);
+            await clickDownloadButtonAndVerifySha(ctx, {
+              buttonLabel: `Download ${XLSX_FILENAME}`,
+              filename: XLSX_FILENAME,
+              expectedSha: XLSX_FIXTURE.sha256,
+              assertion: `Sent attachment card Download for ${XLSX_FILENAME} saves the exact expected sha256`,
+            });
+          },
+          assert: async () => {
+            await ctx.expectText(XLSX_FILENAME);
+            await ctx.expectText("XLSX");
+            await ctx.expectText("Download");
+          },
+          screenshot: { name: "xlsx-sent-card-downloadable", requireText: [XLSX_FILENAME, "XLSX", "Download"], hashIncludes: "/session/" },
+        });
+      },
+    },
+    {
+      name: "Provider sees structured XLSX text and exact workspace bytes",
+      run: async (ctx) => {
+        await ctx.prove("The provider receives bounded structured spreadsheet text while exact original XLSX bytes stay in workspace-safe paths", {
+          voiceover: vo[2],
+          action: async () => {
+            const proof = await pollProof(
+              ctx,
+              (item) => item.providerReceipt && item.normalizedTextOnly && item.exactHashes && item.exactMimes && item.materializedPaths && item.sentinelsExtracted && item.toolCallCompleted && item.finalResponse,
+              120_000,
+              "normalized XLSX provider text, materialized hash, completed tool call, and final response",
+            );
+            ctx.output("XLSX mock proof after send", JSON.stringify(proof, null, 2));
+            record(ctx, proof.normalizedTextOnly && proof.payloadCount === 0 && proof.officeFileMarkers === 0 && !proof.rawOfficeBinaryLeak, "Provider request contains normalized XLSX text only, with no raw spreadsheet binary or file media", JSON.stringify({ payloadCount: proof.payloadCount, officeFileMarkers: proof.officeFileMarkers, rawOfficeBinaryLeak: proof.rawOfficeBinaryLeak }));
+            record(ctx, proof.sentinelsExtracted, "Provider proof found cell values, formula, number format, and merged range in the structured XLSX text", JSON.stringify(proof.attachments));
+            record(ctx, xlsxArtifactHash(ctx) === XLSX_FIXTURE.sha256, "Workspace XLSX artifact was written from exact materialized bytes");
+            const messages = await sessionMessages(ctx);
+            assertPersistedOriginalXlsx(ctx, messages);
+            assertWorkspaceAttachmentPathNote(ctx, messages);
+          },
+          assert: async () => {
+            await ctx.expectText(XLSX_FILENAME);
+            await ctx.expectText("XLSX");
+          },
+          screenshot: { name: "xlsx-normalized-provider-proof", requireText: [XLSX_FILENAME, "XLSX"], hashIncludes: "/session/" },
+        });
+      },
+    },
+    {
+      name: "Assistant summarizes workbook contents",
+      run: async (ctx) => {
+        await ctx.prove("The assistant summarizes the workbook's sheet values, formula, number format, merge range, and copied artifact", {
+          voiceover: vo[3],
+          action: async () => {
+            await waitForFinalResponse(ctx);
+            await dismissOpenWorkModelsModal(ctx);
+            await ctx.control("session.scroll_bottom");
+          },
+          assert: async () => {
+            await ctx.expectText(XLSX_SENTINEL);
+            await ctx.expectText("Northstar Revenue");
+            await ctx.expectText("SUM(C2:C3)");
+            await ctx.expectText(ARTIFACT_PATH);
+          },
+          screenshot: { name: "xlsx-final-summary", requireText: [XLSX_SENTINEL, "Northstar Revenue", "SUM(C2:C3)", ARTIFACT_PATH], hashIncludes: "/session/" },
+        });
+      },
+    },
+    {
+      name: "Reloaded XLSX session can continue",
+      run: async (ctx) => {
+        await ctx.prove("Reloading the session keeps spreadsheet history safe, and a follow-up message succeeds without provider errors", {
+          voiceover: vo[4],
+          action: async () => {
+            await ctx.eval("location.reload()");
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after session reload" });
+            await ctx.navigateHash(`/workspace/${ctx.workspaceId}/session/${ctx.sessionId}`);
+            await ctx.waitFor(sentXlsxCardExpr(), { timeoutMs: 45_000, label: "restored XLSX sent card" });
+            await ctx.control("composer.set_text", { text: FOLLOW_UP });
+            await ctx.control("composer.send");
+            const replayProof = await pollProof(ctx, (item) => item.replayResponse && item.replayOfficeHistoryOk && item.replay?.normalizedTextOnly, 90_000, "successful replay follow-up with normalized XLSX history");
+            ctx.output("XLSX mock proof after replay", JSON.stringify(replayProof, null, 2));
+            await ctx.waitFor(`document.body.innerText.includes("Replay succeeded after reopening the session")`, { timeoutMs: 60_000, label: "replay success assistant response" });
+            await dismissOpenWorkModelsModal(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText(XLSX_FILENAME);
+            await ctx.expectText("Download");
+            await ctx.expectText("Replay succeeded after reopening the session");
+          },
+          screenshot: { name: "xlsx-reopened-session-safe", requireText: [XLSX_FILENAME, "Download", "Replay succeeded after reopening the session"], hashIncludes: "/session/" },
+        });
+      },
+    },
+    {
+      name: "Stop XLSX mock provider",
+      run: async (ctx) => {
+        ctx.output("XLSX mock shutdown", stopMockProvider(ctx));
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/xlsx-chat-attachments.md
+++ b/evals/voiceovers/xlsx-chat-attachments.md
@@ -1,0 +1,11 @@
+# xlsx-chat-attachments — Excel workbooks are safe, readable chat attachments
+
+1. I attach an Excel `.xlsx` workbook to a chat, and OpenWork accepts it like Word and PowerPoint files.
+
+2. The attachment appears as an XLSX file card with its original filename and remains downloadable without modification.
+
+3. I send the message, and OpenWork preserves the original workbook while exposing cell values, formulas, formatting, and workbook structure to the assistant.
+
+4. The assistant accurately summarizes the workbook's contents, including text, numeric values, and formulas.
+
+5. I continue the conversation, showing that the spreadsheet attachment does not cause provider errors or break later messages.


### PR DESCRIPTION
## Summary
- accept `.xlsx` files in the chat composer while preserving exact original bytes
- normalize workbook structure, values, formulas, number formats, and merged ranges before provider submission
- add XLSX attachment UI/copy, focused tests, and a five-frame user-facing fraimz flow

Legacy `.xls` remains unsupported.

## Validation
- `pnpm --filter @openwork/app exec bun test tests/attachment-file-part.test.ts tests/office-attachment-ui.test.ts` — 17 passed
- `pnpm --filter openwork-server exec bun test src/opencode-plugins/openwork-office-attachments.test.ts` — 18 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm fraimz --flow xlsx-chat-attachments --cdp-url http://127.0.0.1:9826` — passed locally, 1 passed / 0 failed / 0 skipped

Fraimz artifact: `evals/results/2026-07-15T12-33-25-831Z/fraimz.html` (generated locally).

## Proof
The fraimz flow verifies attachment acceptance, exact-byte download, structured provider normalization, assistant workbook understanding, and successful session continuation after reopening.