### PR TITLE
fix(connect): compact MCP connection details

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { Check, ChevronDown, ChevronRight, Loader2, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
+import { AlertTriangle, Check, ChevronDown, ChevronRight, Loader2, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenNotice } from "../../_components/ui/notice";
@@ -1184,15 +1184,21 @@ function ConnectionRow({
   onMigrateCallback: () => void;
 }) {
   const [copiedOAuthUrl, setCopiedOAuthUrl] = useState<"callback" | "shared-callback" | "metadata" | null>(null);
+  const [detailsOpen, setDetailsOpen] = useState(false);
   const isPerMember = connection.credentialMode === "per_member";
   const callbackUpdateRequired = connection.oauthMigrationStatus === "legacy_manual_client";
   const automaticCallbackMigrationPending = connection.oauthMigrationStatus === "unclassified";
+  const callbackMigrationPending = connection.authType === "oauth" && connection.oauthCallbackMode !== "shared-v1";
   const needsOAuthConnect = connection.authType === "oauth"
     && (!connection.connected || automaticCallbackMigrationPending)
     && !callbackUpdateRequired
     && (!isPerMember || automaticCallbackMigrationPending);
 
   const canInspectTools = connection.credentialMode === "shared" ? connection.connected : connection.connectedForMe;
+  const toggleDetails = () => {
+    if (detailsOpen && toolsOpen) onToggleTools();
+    setDetailsOpen((open) => !open);
+  };
 
   return (
     <div>
@@ -1231,14 +1237,6 @@ function ConnectionRow({
             <p className="mt-0.5 truncate text-[12px] text-gray-500">
               {connection.url} · {formatMcpConnectedTimestamp(connection.connectedAt)}
             </p>
-            {connection.authType === "oauth" ? (
-              <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-gray-500">
-                <span>{connection.oauthCallbackMode === "shared-v1" ? "Shared callback" : callbackUpdateRequired ? "Callback update required" : "Callback migration pending"}</span>
-                <span>Registration: {connection.oauthRegistrationSource ?? "not registered"}</span>
-                {connection.authorizationServerIssuer ? <span className="max-w-full truncate">Issuer: {connection.authorizationServerIssuer}</span> : null}
-                {(connection.requestedScopes?.length ?? 0) > 0 ? <span>Scopes: {connection.requestedScopes?.join(", ")}</span> : null}
-              </div>
-            ) : null}
             {errorMessage ? <p className="mt-1 text-[12px] text-red-600">{errorMessage}</p> : null}
           </div>
         </div>
@@ -1255,16 +1253,6 @@ function ConnectionRow({
           >
             Edit
           </DenButton>
-          <DenButton
-            variant="secondary"
-            size="sm"
-            disabled={!canInspectTools}
-            onClick={onToggleTools}
-            title={canInspectTools ? "Inspect the tools this MCP exposes" : "Connect this account before inspecting tools"}
-          >
-            {toolsOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
-            View tools
-          </DenButton>
           {needsOAuthConnect ? (
             <DenButton
               variant="secondary"
@@ -1275,6 +1263,28 @@ function ConnectionRow({
               {automaticCallbackMigrationPending ? "Reconnect with shared callback" : "Connect"}
             </DenButton>
           ) : null}
+          {callbackUpdateRequired ? (
+            <DenButton
+              variant="secondary"
+              size="sm"
+              onClick={() => setDetailsOpen(true)}
+            >
+              Update callback
+            </DenButton>
+          ) : null}
+          <DenButton
+            variant="secondary"
+            size="sm"
+            onClick={toggleDetails}
+            aria-expanded={detailsOpen}
+            aria-controls={`mcp-connection-details-${connection.id}`}
+            aria-label={callbackMigrationPending ? `More details for ${connection.name}; callback update required` : `More details for ${connection.name}`}
+            title={callbackMigrationPending ? "Callback update required — open for details" : "Show tools and connection details"}
+          >
+            {callbackMigrationPending ? <AlertTriangle className="h-3.5 w-3.5 text-amber-600" /> : null}
+            More
+            {detailsOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+          </DenButton>
           <DenButton
             variant="destructive"
             size="sm"
@@ -1287,62 +1297,102 @@ function ConnectionRow({
           </DenButton>
         </div>
       </div>
-      {callbackUpdateRequired && connection.oauthSharedCallbackUrl ? (
-        <div className="border-t border-amber-200 bg-amber-50 px-6 py-4 text-[12px] leading-5 text-amber-950" data-testid={`mcp-callback-update-required-${connection.id}`}>
-          <p className="font-semibold">Callback update required</p>
-          <ol className="mt-2 list-decimal space-y-2 pl-5">
-            <li>
-              Copy the new shared callback.
-              <div className="mt-1 flex items-start justify-between gap-3 rounded-lg border border-amber-200 bg-white px-3 py-2">
-                <code className="min-w-0 break-all text-[11px]">{connection.oauthSharedCallbackUrl}</code>
-                <button
-                  type="button"
-                  className="shrink-0 font-medium underline"
-                  onClick={() => void copyTextToClipboard(connection.oauthSharedCallbackUrl ?? "").then((copied) => copied && setCopiedOAuthUrl("shared-callback"))}
-                >
-                  {copiedOAuthUrl === "shared-callback" ? "Copied" : "Copy"}
-                </button>
-              </div>
-            </li>
-            <li>Add it to the external OAuth application without removing the old callback yet.</li>
-            <li>
-              <DenButton variant="secondary" size="sm" loading={migratingCallback || connecting || polling} onClick={onMigrateCallback}>
-                Reconnect using shared callback
+      {detailsOpen ? (
+        <div
+          id={`mcp-connection-details-${connection.id}`}
+          className="border-t border-gray-100 bg-gray-50/70 px-6 py-4"
+          data-testid={`mcp-connection-details-${connection.id}`}
+        >
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+            <div>
+              <p className="text-[12px] font-semibold text-gray-900">Tools and connection details</p>
+              <p className="mt-0.5 text-[11px] text-gray-500">Technical setup is hidden until you need it.</p>
+            </div>
+            {canInspectTools ? (
+              <DenButton variant="secondary" size="sm" onClick={onToggleTools}>
+                {toolsOpen ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+                {toolsOpen ? "Hide tools" : "View tools"}
               </DenButton>
-              <p className="mt-1 text-[11px] text-amber-800">This migration is permanent. OpenWork preserves your manual client ID, secret, and access grants.</p>
-            </li>
-          </ol>
-        </div>
-      ) : null}
-      {connection.authType === "oauth" && (connection.oauthCallbackUrl || connection.oauthClientMetadataUrl) ? (
-        <div className="border-t border-gray-100 bg-gray-50/70 px-6 py-3 text-[11px] text-gray-600">
-          {connection.oauthCallbackUrl ? (
-            <div className="flex items-start justify-between gap-3">
-              <p className="min-w-0 break-all"><span className="font-semibold">Current callback:</span> {connection.oauthCallbackUrl}</p>
-              <button
-                type="button"
-                className="shrink-0 font-medium text-gray-900 underline"
-                onClick={() => void copyTextToClipboard(connection.oauthCallbackUrl ?? "").then((copied) => copied && setCopiedOAuthUrl("callback"))}
-              >
-                {copiedOAuthUrl === "callback" ? "Copied" : "Copy"}
-              </button>
+            ) : (
+              <p className="text-[11px] text-gray-500">Tool inspection becomes available after this account is connected.</p>
+            )}
+          </div>
+
+          {automaticCallbackMigrationPending ? (
+            <div className="mt-4 flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-[12px] text-amber-950" data-testid={`mcp-callback-update-required-${connection.id}`}>
+              <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+              <div>
+                <p className="font-semibold">Callback update required</p>
+                <p className="mt-0.5 text-[11px] text-amber-800">Reconnect using the shared callback to update this dynamic registration automatically.</p>
+              </div>
             </div>
           ) : null}
-          {connection.oauthClientMetadataUrl ? (
-            <div className="mt-1 flex items-start justify-between gap-3">
-              <p className="min-w-0 break-all"><span className="font-semibold">Client metadata:</span> {connection.oauthClientMetadataUrl}</p>
-              <button
-                type="button"
-                className="shrink-0 font-medium text-gray-900 underline"
-                onClick={() => void copyTextToClipboard(connection.oauthClientMetadataUrl ?? "").then((copied) => copied && setCopiedOAuthUrl("metadata"))}
-              >
-                {copiedOAuthUrl === "metadata" ? "Copied" : "Copy"}
-              </button>
+
+          {callbackUpdateRequired && connection.oauthSharedCallbackUrl ? (
+            <div className="mt-4 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-[12px] leading-5 text-amber-950" data-testid={`mcp-callback-update-required-${connection.id}`}>
+              <p className="font-semibold">Callback update required</p>
+              <ol className="mt-2 list-decimal space-y-2 pl-5">
+                <li>
+                  Copy the new shared callback.
+                  <div className="mt-1 flex items-start justify-between gap-3 rounded-lg border border-amber-200 bg-white px-3 py-2">
+                    <code className="min-w-0 break-all text-[11px]">{connection.oauthSharedCallbackUrl}</code>
+                    <button
+                      type="button"
+                      className="shrink-0 font-medium underline"
+                      onClick={() => void copyTextToClipboard(connection.oauthSharedCallbackUrl ?? "").then((copied) => copied && setCopiedOAuthUrl("shared-callback"))}
+                    >
+                      {copiedOAuthUrl === "shared-callback" ? "Copied" : "Copy"}
+                    </button>
+                  </div>
+                </li>
+                <li>Add it to the external OAuth application without removing the old callback yet.</li>
+                <li>
+                  <DenButton variant="secondary" size="sm" loading={migratingCallback || connecting || polling} onClick={onMigrateCallback}>
+                    Reconnect using shared callback
+                  </DenButton>
+                  <p className="mt-1 text-[11px] text-amber-800">This migration is permanent. OpenWork preserves your manual client ID, secret, and access grants.</p>
+                </li>
+              </ol>
+            </div>
+          ) : null}
+
+          {connection.authType === "oauth" ? (
+            <div className="mt-4 space-y-3 text-[11px] text-gray-600">
+              <dl className="grid gap-2 sm:grid-cols-2 lg:grid-cols-4">
+                <div><dt className="font-semibold text-gray-700">Callback</dt><dd>{connection.oauthCallbackMode === "shared-v1" ? "Shared" : "Legacy compatibility"}</dd></div>
+                <div><dt className="font-semibold text-gray-700">Registration</dt><dd>{connection.oauthRegistrationSource ?? "Not registered"}</dd></div>
+                {connection.authorizationServerIssuer ? <div className="min-w-0"><dt className="font-semibold text-gray-700">Issuer</dt><dd className="truncate" title={connection.authorizationServerIssuer}>{connection.authorizationServerIssuer}</dd></div> : null}
+                {(connection.requestedScopes?.length ?? 0) > 0 ? <div className="min-w-0"><dt className="font-semibold text-gray-700">Scopes</dt><dd className="truncate" title={connection.requestedScopes?.join(", ")}>{connection.requestedScopes?.join(", ")}</dd></div> : null}
+              </dl>
+              {connection.oauthCallbackUrl ? (
+                <div className="flex items-start justify-between gap-3 border-t border-gray-200 pt-3">
+                  <p className="min-w-0 break-all"><span className="font-semibold">Current callback:</span> {connection.oauthCallbackUrl}</p>
+                  <button
+                    type="button"
+                    className="shrink-0 font-medium text-gray-900 underline"
+                    onClick={() => void copyTextToClipboard(connection.oauthCallbackUrl ?? "").then((copied) => copied && setCopiedOAuthUrl("callback"))}
+                  >
+                    {copiedOAuthUrl === "callback" ? "Copied" : "Copy"}
+                  </button>
+                </div>
+              ) : null}
+              {connection.oauthClientMetadataUrl ? (
+                <div className="flex items-start justify-between gap-3">
+                  <p className="min-w-0 break-all"><span className="font-semibold">Client metadata:</span> {connection.oauthClientMetadataUrl}</p>
+                  <button
+                    type="button"
+                    className="shrink-0 font-medium text-gray-900 underline"
+                    onClick={() => void copyTextToClipboard(connection.oauthClientMetadataUrl ?? "").then((copied) => copied && setCopiedOAuthUrl("metadata"))}
+                  >
+                    {copiedOAuthUrl === "metadata" ? "Copied" : "Copy"}
+                  </button>
+                </div>
+              ) : null}
             </div>
           ) : null}
         </div>
       ) : null}
-      {toolsOpen && canInspectTools ? <McpToolCatalog connection={connection} /> : null}
+      {detailsOpen && toolsOpen && canInspectTools ? <McpToolCatalog connection={connection} /> : null}
     </div>
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
@@ -342,7 +342,7 @@ export function McpToolRunner({ connection }: { connection: ExternalMcpConnectio
           onClick={() => void catalog.refetch()}
         >
           <RefreshCw className="h-3.5 w-3.5" />
-          Refresh tools
+          <span>Refresh tools</span>
         </DenButton>
       </div>
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-runner.tsx
@@ -334,7 +334,13 @@ export function McpToolRunner({ connection }: { connection: ExternalMcpConnectio
             This runs through OpenWork with your available connection credential. Arguments and results are not written to OpenWork logs.
           </p>
         </div>
-        <DenButton variant="secondary" size="sm" loading={catalog.isFetching} onClick={() => void catalog.refetch()}>
+        <DenButton
+          variant="secondary"
+          size="sm"
+          className="shrink-0 whitespace-nowrap"
+          loading={catalog.isFetching}
+          onClick={() => void catalog.refetch()}
+        >
           <RefreshCw className="h-3.5 w-3.5" />
           Refresh tools
         </DenButton>

--- a/ee/apps/den-web/tests/mcp-oauth-callback-migration.test.ts
+++ b/ee/apps/den-web/tests/mcp-oauth-callback-migration.test.ts
@@ -27,6 +27,20 @@ describe("MCP OAuth callback migration UI contract", () => {
     expect(data).not.toContain("oauthCallbackMode:")
   })
 
+  test("keeps secondary tools and OAuth details collapsed behind More", () => {
+    const screen = readFileSync(screenPath, "utf8")
+
+    expect(screen).toContain("const [detailsOpen, setDetailsOpen] = useState(false)")
+    expect(screen).toContain("aria-expanded={detailsOpen}")
+    expect(screen).toContain("Tools and connection details")
+    expect(screen).toContain("aria-label={callbackMigrationPending")
+    expect(screen).toContain("Callback update required — open for details")
+    expect(screen).toContain("Reconnect using the shared callback to update this dynamic registration automatically.")
+    expect(screen).toContain("Tool inspection becomes available after this account is connected.")
+    expect(screen).toContain("detailsOpen && toolsOpen && canInspectTools")
+    expect(screen).not.toContain("Connect this account before inspecting tools")
+  })
+
   test("keeps deletion as a warned fallback instead of the primary migration path", () => {
     const screen = readFileSync(screenPath, "utf8")
 

--- a/ee/apps/den-web/tests/mcp-tool-runner-layout.test.ts
+++ b/ee/apps/den-web/tests/mcp-tool-runner-layout.test.ts
@@ -10,7 +10,7 @@ const runnerPath = join(
 describe("MCP tool runner layout", () => {
   test("keeps the Refresh tools action on one line", () => {
     const runner = readFileSync(runnerPath, "utf8");
-    const refreshLabelIndex = runner.indexOf("Refresh tools");
+    const refreshLabelIndex = runner.indexOf("<span>Refresh tools</span>");
     const refreshAction = runner.slice(Math.max(0, refreshLabelIndex - 400), refreshLabelIndex + 100);
 
     expect(refreshLabelIndex).toBeGreaterThan(-1);

--- a/ee/apps/den-web/tests/mcp-tool-runner-layout.test.ts
+++ b/ee/apps/den-web/tests/mcp-tool-runner-layout.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const runnerPath = join(
+  import.meta.dir,
+  "../app/(den)/dashboard/_components/mcp-tool-runner.tsx",
+);
+
+describe("MCP tool runner layout", () => {
+  test("keeps the Refresh tools action on one line", () => {
+    const runner = readFileSync(runnerPath, "utf8");
+    const refreshLabelIndex = runner.indexOf("Refresh tools");
+    const refreshAction = runner.slice(Math.max(0, refreshLabelIndex - 400), refreshLabelIndex + 100);
+
+    expect(refreshLabelIndex).toBeGreaterThan(-1);
+    expect(refreshAction).toContain('className="shrink-0 whitespace-nowrap"');
+  });
+});

--- a/evals/flows/mcp-oauth-conformance.flow.mjs
+++ b/evals/flows/mcp-oauth-conformance.flow.mjs
@@ -349,7 +349,7 @@ export default {
               return nodes.some((node) => {
                 let current = node;
                 for (let depth = 0; depth < 8 && current; depth += 1) {
-                  if ((current.textContent ?? '').includes('Connected') && (current.textContent ?? '').includes('Shared callback')) return true;
+                  if ((current.textContent ?? '').includes('Connected')) return true;
                   current = current.parentElement;
                 }
                 return false;
@@ -360,6 +360,21 @@ export default {
               node?.scrollIntoView({ block: 'center' });
               return Boolean(node);
             })()`);
+            const opened = await ctx.eval(`(() => {
+              const node = [...document.querySelectorAll('*')].find((entry) => entry.children.length === 0 && (entry.textContent ?? '').trim() === ${JSON.stringify(CONNECTION_NAME)});
+              let row = node;
+              for (let depth = 0; depth < 8 && row; depth += 1) {
+                const more = [...row.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').replace(/\\s+/g, ' ').trim() === 'More');
+                if (more) {
+                  if (more.getAttribute('aria-expanded') !== 'true') more.click();
+                  return true;
+                }
+                row = row.parentElement;
+              }
+              return false;
+            })()`);
+            ctx.assert(opened, "Could not reveal the connected MCP details.");
+            await ctx.waitForText("Tools and connection details", { timeoutMs: 10_000 });
           },
           assert: async () => {
             const connection = await findConnection(ctx);
@@ -384,7 +399,7 @@ export default {
           },
           screenshot: {
             name: "dashboard-shared-callback",
-            requireText: [CONNECTION_NAME, "Connected", "Shared callback", "Registration: dynamic", "Current callback:"],
+            requireText: [CONNECTION_NAME, "Connected", "Tools and connection details", "Registration", "dynamic", "Current callback:"],
             rejectText: ["Callback update required", "Return to legacy", "Something went wrong"],
           },
         });
@@ -402,6 +417,20 @@ export default {
               deviceScaleFactor: 1,
               mobile: false,
             });
+            await ctx.eval(`(() => {
+              const name = [...document.querySelectorAll('*')].find((entry) => entry.children.length === 0 && (entry.textContent ?? '').trim() === ${JSON.stringify(CONNECTION_NAME)});
+              let row = name;
+              for (let depth = 0; depth < 8 && row; depth += 1) {
+                const more = [...row.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').replace(/\\s+/g, ' ').trim() === 'More');
+                if (more) {
+                  if (more.getAttribute('aria-expanded') !== 'true') more.click();
+                  return true;
+                }
+                row = row.parentElement;
+              }
+              return false;
+            })()`);
+            await ctx.waitForText("View tools", { timeoutMs: 10_000 });
             const opened = await ctx.eval(`(() => {
               const name = [...document.querySelectorAll('*')].find((entry) => entry.children.length === 0 && (entry.textContent ?? '').trim() === ${JSON.stringify(CONNECTION_NAME)});
               let row = name;

--- a/evals/flows/mcp-tool-catalog.flow.mjs
+++ b/evals/flows/mcp-tool-catalog.flow.mjs
@@ -230,8 +230,15 @@ function connectionRowScript(action) {
       .find((entry) => (entry.textContent ?? '').trim() === ${JSON.stringify(state.connectionName)});
     let row = leaf;
     for (let depth = 0; depth < 8 && row; depth += 1) {
+      const more = [...row.querySelectorAll('button')]
+        .find((entry) => (entry.textContent ?? '').replace(/\\s+/g, ' ').trim() === 'More');
       const button = [...row.querySelectorAll('button')]
         .find((entry) => (entry.textContent ?? '').replace(/\\s+/g, ' ').trim() === 'View tools');
+      if (${JSON.stringify(action)}.startsWith('more') && more) {
+        if (${JSON.stringify(action)} === 'more' && more.getAttribute('aria-expanded') !== 'true') more.click();
+        row.scrollIntoView({ block: 'center' });
+        return true;
+      }
       if (button) {
         if (button.disabled) return false;
         row.scrollIntoView({ block: 'center' });
@@ -269,15 +276,15 @@ export default {
             await navigateToConnections(ctx);
           },
           assert: async () => {
-            const hasAction = await ctx.eval(connectionRowScript("find"));
-            witness(ctx, hasAction, "The connected Incident Response MCP has a View tools action.", { hasAction });
+            const hasMore = await ctx.eval(connectionRowScript("more-find"));
+            witness(ctx, hasMore, "The connected Incident Response MCP keeps secondary actions under More.", { hasMore });
             witness(ctx, !state.observedMethods.includes("tools/list"), "Merely viewing the connection does not read or execute its tool catalog.", state.observedMethods);
             witness(ctx, !state.observedMethods.includes("tools/call"), "No MCP tool has been executed.", state.observedMethods);
           },
           screenshot: {
             name: "connected-mcp-view-tools",
-            requireText: ["Connections", "Incident Response MCP", "View tools", "Connected"],
-            rejectText: ["Something went wrong"],
+            requireText: ["Connections", "Incident Response MCP", "More", "Connected"],
+            rejectText: ["Tools and connection details", "View tools", "Something went wrong"],
             hashIncludes: "/dashboard/mcp-connections",
           },
         });
@@ -289,6 +296,9 @@ export default {
         await ctx.prove("The dashboard reads live tools/list data and states that inspection does not run a tool", {
           voiceover: vo[1],
           action: async () => {
+            const revealed = await ctx.eval(connectionRowScript("more"));
+            witness(ctx, revealed, "Alex can reveal secondary connection actions from More.", { revealed });
+            await ctx.waitFor(connectionRowScript("find"), { timeoutMs: 10_000, label: "View tools action under More" });
             const clicked = await ctx.eval(connectionRowScript("click"));
             witness(ctx, clicked, "Alex can open the MCP's tool catalog from its row.", { clicked });
             await ctx.waitFor(`(() => {

--- a/evals/flows/mcp-tool-catalog.flow.mjs
+++ b/evals/flows/mcp-tool-catalog.flow.mjs
@@ -1,5 +1,5 @@
 import http from "node:http";
-import { denApiFetch, denWebUrl, openAdminConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+import { denApiFetch, denWebUrl, openAdminConnections, openYourConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
 const FLOW_ID = "mcp-tool-catalog";
@@ -253,7 +253,7 @@ function connectionRowScript(action) {
 
 export default {
   id: FLOW_ID,
-  title: "Admins can inspect a connected MCP's live tools, inputs, and schemas without executing anything",
+  title: "Admins can inspect a connected MCP's live tools and open its manual runner without executing anything",
   kind: "user-facing",
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
@@ -415,6 +415,86 @@ export default {
             requireText: ["search_incidents", "Read-only hint", "query: string · required", "status: string", "View input schema", "View output schema", "additionalProperties"],
             rejectText: ["This proof must never execute a tool"],
             hashIncludes: "/dashboard/mcp-connections",
+          },
+        });
+
+      },
+    },
+    {
+      name: "The manual tool runner keeps its refresh action readable",
+      run: async (ctx) => {
+        await ctx.prove("Refresh tools stays on one line at the constrained dashboard viewport", {
+          voiceover: vo[3],
+          action: async () => {
+            if (ctx.client?.send) {
+              await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+                width: 840,
+                height: 900,
+                deviceScaleFactor: 1,
+                mobile: false,
+              });
+            }
+            await openYourConnections(ctx);
+            await ctx.waitFor(`(() => {
+              const row = [...document.querySelectorAll('p')]
+                .find((entry) => (entry.textContent ?? '').trim() === ${JSON.stringify(state.connectionName)});
+              row?.scrollIntoView({ block: 'center' });
+              return Boolean(row);
+            })()`, { timeoutMs: 30_000, label: "Incident Response MCP on Your Connections" });
+            const opened = await ctx.eval(`(() => {
+              const button = document.querySelector('[data-testid="toggle-mcp-tool-runner-${state.connectionId}"]');
+              button?.click();
+              return Boolean(button);
+            })()`);
+            witness(ctx, opened, "Alex can open the manual tool runner for the connected MCP.", { opened });
+            await ctx.waitFor(`(() => {
+              const runner = document.querySelector('[data-testid="mcp-tool-runner-${state.connectionId}"]');
+              return (runner?.textContent ?? '').includes('Refresh tools')
+                && (runner?.textContent ?? '').includes('Run a tool manually');
+            })()`, { timeoutMs: 30_000, label: "manual MCP tool runner" });
+            await ctx.eval(`(() => {
+              const runner = document.querySelector('[data-testid="mcp-tool-runner-${state.connectionId}"]');
+              runner?.scrollIntoView({ block: 'center' });
+              return Boolean(runner);
+            })()`);
+          },
+          assert: async () => {
+            const layout = await ctx.eval(`(() => {
+              const runner = document.querySelector('[data-testid="mcp-tool-runner-${state.connectionId}"]');
+              const button = [...(runner?.querySelectorAll('button') ?? [])]
+                .find((entry) => (entry.textContent ?? '').replace(/\\s+/g, ' ').trim() === 'Refresh tools');
+              const label = button?.querySelector('span');
+              if (!runner || !button || !label) return null;
+              const range = document.createRange();
+              range.selectNodeContents(label);
+              const rows = new Set(
+                [...range.getClientRects()]
+                  .filter((rect) => rect.width > 0 && rect.height > 0)
+                  .map((rect) => Math.round(rect.top)),
+              ).size;
+              const rect = button.getBoundingClientRect();
+              return {
+                whiteSpace: getComputedStyle(button).whiteSpace,
+                rows,
+                buttonHeight: rect.height,
+                buttonLeft: rect.left,
+                buttonRight: rect.right,
+                viewportWidth: window.innerWidth,
+                pageScrollWidth: document.documentElement.scrollWidth,
+                pageClientWidth: document.documentElement.clientWidth,
+              };
+            })()`);
+            witness(ctx, layout?.whiteSpace === "nowrap", "The Refresh tools button enforces no wrapping.", layout);
+            witness(ctx, layout?.rows === 1, "The Refresh tools label occupies exactly one rendered text row.", layout);
+            witness(ctx, Boolean(layout && layout.buttonLeft >= 0 && layout.buttonRight <= layout.viewportWidth), "The Refresh tools action remains inside the viewport.", layout);
+            witness(ctx, layout?.pageScrollWidth === layout?.pageClientWidth, "The constrained dashboard has no horizontal overflow.", layout);
+            witness(ctx, !state.observedMethods.includes("tools/call"), "Opening the manual runner does not execute a tool.", state.observedMethods);
+          },
+          screenshot: {
+            name: "manual-tool-runner-refresh-nowrap",
+            requireText: ["Your Connections", "Run a tool manually", "Refresh tools", "Tool", "Search incidents", "search_incidents"],
+            rejectText: ["Something went wrong", "Could not read this MCP's tools"],
+            hashIncludes: "/dashboard/your-connections",
           },
         });
 

--- a/evals/voiceovers/mcp-tool-catalog.md
+++ b/evals/voiceovers/mcp-tool-catalog.md
@@ -9,3 +9,5 @@ inspection reads its live `tools/list` response and never invokes a tool.
 2. Alex opens More, chooses View tools, and immediately sees the searchable live tool names, descriptions, and input counts. Even a large catalog stays manageable, and OpenWork makes the safety boundary explicit: inspecting, searching, or refreshing this list does not run a tool.
 
 3. Alex expands search_incidents to see the provider's read-only hint, which inputs are required, their basic types, and separate input and output schema details. He can now understand what the MCP adds before an agent ever calls it.
+
+4. Alex opens the same connection's manual tool runner from Your Connections at a constrained dashboard width. Refresh tools stays on one line, remains fully visible, and does not create horizontal scrolling; simply opening the runner still does not execute a tool.

--- a/evals/voiceovers/mcp-tool-catalog.md
+++ b/evals/voiceovers/mcp-tool-catalog.md
@@ -4,8 +4,8 @@ Cast: Alex, an Acme Robotics workspace admin, in OpenWork Cloud. The connected
 Incident Response MCP is a real protocol-compatible test server. Catalog
 inspection reads its live `tools/list` response and never invokes a tool.
 
-1. Alex opens MCP Connections and sees a new View tools action on the connected Incident Response MCP. Discovery stays tucked into the existing connection row, so setup and inspection remain one workflow.
+1. Alex opens MCP Connections and sees a compact connected row. Tool inspection and technical setup stay tucked behind More, so the connection list remains easy to scan.
 
-2. Alex opens the searchable catalog and immediately sees the live tool names, descriptions, and input counts. Even a large catalog stays manageable, and OpenWork makes the safety boundary explicit: inspecting, searching, or refreshing this list does not run a tool.
+2. Alex opens More, chooses View tools, and immediately sees the searchable live tool names, descriptions, and input counts. Even a large catalog stays manageable, and OpenWork makes the safety boundary explicit: inspecting, searching, or refreshing this list does not run a tool.
 
 3. Alex expands search_incidents to see the provider's read-only hint, which inputs are required, their basic types, and separate input and output schema details. He can now understand what the MCP adds before an agent ever calls it.


### PR DESCRIPTION
## Summary

- Keep MCP connection cards compact by moving **View tools**, callback URLs, client metadata, issuer, registration, and scopes behind **More**.
- Keep connection actions visible: **Connect**, **Reconnect with shared callback**, or **Update callback** remains a primary action when needed.
- Show an amber warning icon on **More** for every legacy OAuth callback state and use the consistent message **Callback update required**.
- Preserve the correct migration guidance: manual clients get the copy/add/reconnect checklist, while dynamically registered clients explain that reconnect updates their registration automatically.
- Replace the confusing disabled-tools tooltip with a clear explanation inside the expanded details.
- Keep the manual tool runner’s **Refresh tools** action on one line instead of allowing the label to wrap.

## What existed and what changed

Previously, OAuth callback URLs and technical registration details were always visible, which made every connection row tall. Manual legacy clients said “Callback update required,” while older dynamic clients said “Callback migration pending,” even though both required moving to the shared callback. A disabled **View tools** button also surfaced “Connect this account before inspecting tools” before users had opened any details.

This PR leaves the connection workflow intact and changes only its presentation. The collapsed row is easy to scan; **More** reveals tools and technical setup on demand. Both legacy callback types now carry the same warning, while their expanded instructions remain specific to how each client migrates.

## Backward compatibility

- No API, database, OAuth protocol, callback route, authorization, or migration behavior changes.
- Existing manual clients keep the one-way guided shared-callback migration.
- Existing dynamic clients keep their automatic re-registration path on reconnect.
- Existing legacy callback compatibility remains untouched.
- No reverse migration action is added.

## Verification

- `pnpm --filter @openwork-ee/den-web exec bun test tests/mcp-oauth-callback-migration.test.ts` — 4 passed, 0 failed.
- `pnpm --filter @openwork-ee/den-web exec bun test tests/mcp-tool-runner-layout.test.ts` — 1 passed, 0 failed.
- `pnpm --filter @openwork-ee/den-web typecheck` — passed.
- `pnpm --filter @openwork-ee/den-web build` — passed.
- `pnpm --filter @openwork-ee/den-api... build` — passed as the Den Web dependency build.
- `node --check` for both updated MCP eval flows — passed.
- Fraimz `mcp-tool-catalog` journey — 1 passed, 0 failed, 0 skipped across four validated frames; proves the compact default row, More disclosure, live tool inspection, and the one-line **Refresh tools** action at an 840px viewport without clipping, horizontal overflow, or tool execution.

## Risk

Low and UI-scoped. The main risk is discoverability of secondary details; it is mitigated by the labeled **More** action, the persistent primary connection action, and the warning icon/accessibility label when callback migration is required.
