### PR TITLE
fix(app): refine pasted text composer

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -19,6 +19,7 @@ import { LexicalPromptEditor, type LexicalPromptEditorHandle } from "./editor";
 import { listRunningAppsForMention } from "./app-mentions";
 import type { ComposerMentionKind } from "./mention-encoding";
 import { getSlashCommandQuery } from "./slash-command";
+import { FILE_URL_RE, HTTP_URL_RE } from "./pasted-text";
 
 type MentionItem = {
   id: string;
@@ -110,8 +111,6 @@ const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
 const IMAGE_COMPRESS_MAX_PX = 2048;
 const IMAGE_COMPRESS_QUALITY = 0.82;
 const IMAGE_COMPRESS_TARGET_BYTES = 1_500_000;
-const FILE_URL_RE = /^file:\/\//i;
-const HTTP_URL_RE = /^https?:\/\//i;
 const DEFAULT_AGENT_NAME = "openwork";
 
 function isNonDefaultAgent(agent: Agent) {
@@ -705,7 +704,7 @@ export function ReactSessionComposer(props: ComposerProps) {
     return fuzzysort.go(mentionQuery, mentionItems, { keys: ["label"], limit: 8 }).map((entry) => entry.obj);
   }, [mentionItems, mentionOpen, mentionQuery]);
   const pastedTextTokens = useMemo(
-    () => props.pastedText.map((item) => ({ label: item.label, lines: item.lines })),
+    () => props.pastedText.map((item) => ({ label: item.label, lines: item.lines, text: item.text })),
     [props.pastedText],
   );
 
@@ -1245,11 +1244,10 @@ export function ReactSessionComposer(props: ComposerProps) {
 
                 const text = event.clipboardData?.getData("text/plain") ?? "";
 
-                // Long pastes (3+ lines / 200+ chars) are collapsed into
-                // an inline chip by PasteChipPlugin inside the Lexical
-                // editor. Do NOT duplicate that here — calling onPasteText
-                // from both the React onPaste handler and the Lexical
-                // PASTE_COMMAND handler causes double chip creation.
+                // Plain text paste display is owned by PasteChipPlugin inside
+                // the Lexical editor: >50 chars collapse unless the whole
+                // string is a standalone HTTP(S) URL; expanded pasted text gets
+                // the gray pasted-content styling. Do NOT duplicate that here.
 
                 if (
                   text.trim() &&

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -12,8 +12,10 @@ import {
   $createRangeSelection,
   $createParagraphNode,
   $createTextNode,
+  $getNearestNodeFromDOMNode,
   $getRoot,
   $getSelection,
+  $nodesOfType,
   $setSelection,
   $isElementNode,
   $isRangeSelection,
@@ -34,11 +36,14 @@ import {
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./mention-encoding";
 import { shouldCollapsePastedText } from "./pasted-text";
+import { insertStyledPastedText } from "./pasted-text-insertion";
+
+type PastedTextToken = { label: string; lines: number; text: string };
 
 type EditorProps = {
   value: string;
   mentions: Record<string, ComposerMentionKind>;
-  pastedText?: Array<{ label: string; lines: number }>;
+  pastedText?: PastedTextToken[];
   disabled: boolean;
   placeholder: string;
   onChange: (value: string) => void;
@@ -318,12 +323,12 @@ function createPastedTextChipDom(label: string, lines: number) {
   const button = document.createElement("button");
   button.type = "button";
   button.className = "ml-1 inline-flex items-center gap-0.5 rounded px-1 py-0.5 text-[11px] font-medium text-amber-11 underline decoration-amber-8 underline-offset-2 transition-colors hover:bg-amber-4 hover:text-amber-12";
-  button.title = "Show in text field";
-  button.setAttribute("aria-label", "Show pasted text in text field");
+  button.title = "Expand";
+  button.setAttribute("aria-label", "Expand pasted text in composer");
   button.dataset.pastedExpandLabel = label;
 
   const actionText = document.createElement("span");
-  actionText.textContent = "Show in text field";
+  actionText.textContent = "Expand";
 
   const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
   svg.setAttribute("viewBox", "0 0 16 16");
@@ -347,6 +352,8 @@ function updatePastedTextChipDom(dom: HTMLElement, label: string, lines: number)
   if (text) text.textContent = pastedTextChipLabel(lines);
   const button = dom.querySelector("button[data-pasted-expand-label]");
   if (button instanceof HTMLButtonElement) {
+    button.title = "Expand";
+    button.setAttribute("aria-label", "Expand pasted text in composer");
     button.dataset.pastedExpandLabel = label;
   }
   dom.title = `Pasted text · ${label}`;
@@ -382,6 +389,10 @@ class ComposerPastedTextNode extends TextNode {
     super(`[pasted text ${label}]`, key);
     this.__pastedLabel = label;
     this.__pastedLines = lines;
+  }
+
+  getPastedLabel() {
+    return this.__pastedLabel;
   }
 
   override exportJSON(): SerializedComposerPastedTextNode {
@@ -475,7 +486,7 @@ function appendSegmentWithNewlines(
   return current;
 }
 
-function setPrompt(value: string, mentions: Record<string, ComposerMentionKind>, pastedText?: Array<{ label: string; lines: number }>) {
+function setPrompt(value: string, mentions: Record<string, ComposerMentionKind>, pastedText?: PastedTextToken[]) {
   const root = $getRoot();
   root.clear();
   let paragraph = $createParagraphNode();
@@ -554,7 +565,7 @@ function serializePromptFromRoot(): string {
     .join("\n");
 }
 
-function SyncPlugin(props: { value: string; mentions: Record<string, ComposerMentionKind>; pastedText?: Array<{ label: string; lines: number }>; disabled: boolean }) {
+function SyncPlugin(props: { value: string; mentions: Record<string, ComposerMentionKind>; pastedText?: PastedTextToken[]; disabled: boolean }) {
   const [editor] = useLexicalComposerContext();
   const valueRef = useRef(props.value);
 
@@ -653,20 +664,88 @@ function PasteChipPlugin(props: { onPasteText?: (text: string) => void }) {
     return editor.registerCommand(
       PASTE_COMMAND,
       (event: ClipboardEvent) => {
-        if (!onPasteTextRef.current) return false;
-        // Only handle plain-text pastes; files are handled in the React onPaste.
+        if (event.defaultPrevented) return false;
+        // Only handle plain-text pastes; files and URI lists are handled in the React onPaste.
         const files = event.clipboardData?.files;
         if (files && files.length > 0) return false;
+        if (event.clipboardData?.getData("text/uri-list").trim()) return false;
         const text = event.clipboardData?.getData("text/plain") ?? "";
         if (!text.trim()) return false;
-        if (!shouldCollapsePastedText(text)) return false;
-        // Collapse into a paste chip.
+        if (shouldCollapsePastedText(text)) {
+          if (!onPasteTextRef.current) return false;
+          event.preventDefault();
+          onPasteTextRef.current(text);
+          return true;
+        }
         event.preventDefault();
-        onPasteTextRef.current(text);
-        return true;
+        return insertStyledPastedText(text);
       },
       COMMAND_PRIORITY_CRITICAL,
     );
+  }, [editor]);
+
+  return null;
+}
+
+function pastedExpandButton(target: EventTarget | null) {
+  if (!(target instanceof Element)) return null;
+  const button = target.closest("button[data-pasted-expand-label]");
+  return button instanceof HTMLButtonElement ? button : null;
+}
+
+function replacePastedTextChip(label: string, text: string, button: HTMLButtonElement) {
+  const nearest = $getNearestNodeFromDOMNode(button);
+  if (nearest instanceof ComposerPastedTextNode && nearest.getPastedLabel() === label) {
+    nearest.select(0, nearest.getTextContentSize());
+    return insertStyledPastedText(text);
+  }
+  for (const node of $nodesOfType(ComposerPastedTextNode)) {
+    if (node.getPastedLabel() !== label) continue;
+    node.select(0, node.getTextContentSize());
+    return insertStyledPastedText(text);
+  }
+  return false;
+}
+
+function PastedTextExpandPlugin(props: { pastedText?: PastedTextToken[]; onExpandPastedText?: (label: string) => void }) {
+  const [editor] = useLexicalComposerContext();
+  const pastedTextRef = useRef(props.pastedText);
+  const onExpandPastedTextRef = useRef(props.onExpandPastedText);
+
+  useEffect(() => {
+    pastedTextRef.current = props.pastedText;
+    onExpandPastedTextRef.current = props.onExpandPastedText;
+  }, [props.onExpandPastedText, props.pastedText]);
+
+  useEffect(() => {
+    const handleMouseDown = (event: MouseEvent) => {
+      if (!pastedExpandButton(event.target)) return;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      const button = pastedExpandButton(event.target);
+      if (!button) return;
+      const label = button.dataset.pastedExpandLabel;
+      if (!label) return;
+      event.preventDefault();
+      event.stopPropagation();
+      const target = pastedTextRef.current?.find((item) => item.label === label);
+      if (target) {
+        editor.update(() => {
+          replacePastedTextChip(label, target.text, button);
+        });
+      }
+      onExpandPastedTextRef.current?.(label);
+    };
+
+    return editor.registerRootListener((rootElement, previousRootElement) => {
+      previousRootElement?.removeEventListener("mousedown", handleMouseDown, true);
+      previousRootElement?.removeEventListener("click", handleClick, true);
+      rootElement?.addEventListener("mousedown", handleMouseDown, true);
+      rootElement?.addEventListener("click", handleClick, true);
+    });
   }, [editor]);
 
   return null;
@@ -841,26 +920,6 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
     [],
   );
 
-  const handlePastedTextExpandPointer = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    const target = event.target;
-    if (!(target instanceof Element)) return;
-    const button = target.closest("button[data-pasted-expand-label]");
-    if (!(button instanceof HTMLButtonElement)) return;
-    const label = button.dataset.pastedExpandLabel;
-    if (!label) return;
-    event.preventDefault();
-    event.stopPropagation();
-    props.onExpandPastedText?.(label);
-  }, [props.onExpandPastedText]);
-
-  const handlePastedTextExpandMouseDown = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
-    const target = event.target;
-    if (!(target instanceof Element)) return;
-    if (!target.closest("button[data-pasted-expand-label]")) return;
-    event.preventDefault();
-    event.stopPropagation();
-  }, []);
-
   return (
     <LexicalComposer initialConfig={initialConfig}>
       {/*
@@ -869,7 +928,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         - max-h caps the composer — long pastes / multi-paragraph drafts scroll
           inside the editor instead of pushing the transcript out of view.
       */}
-      <div className="relative" onClickCapture={handlePastedTextExpandPointer} onMouseDownCapture={handlePastedTextExpandMouseDown}>
+      <div className="relative">
         <PlainTextPlugin
           contentEditable={
             <ContentEditable
@@ -894,6 +953,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         <SyncPlugin value={props.value} mentions={props.mentions} pastedText={props.pastedText} disabled={props.disabled} />
         <SubmitPlugin onSubmit={props.onSubmit} disabled={props.disabled} />
         <PasteChipPlugin onPasteText={props.onPasteText} />
+        <PastedTextExpandPlugin pastedText={props.pastedText} onExpandPastedText={props.onExpandPastedText} />
         <MentionChipNavigationPlugin />
         <ImperativeHandlePlugin editorRef={ref} />
       </div>

--- a/apps/app/src/react-app/domains/session/surface/composer/pasted-text-insertion.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/pasted-text-insertion.ts
@@ -6,20 +6,17 @@ import {
   $isRangeSelection,
   type LexicalNode,
 } from "lexical";
-
-export const PASTED_TEXT_INLINE_STYLE = "background-color: rgba(229, 231, 235, 0.6); border-radius: 4px; box-decoration-break: clone; -webkit-box-decoration-break: clone; padding: 1px 2px;";
+import { PASTED_TEXT_INLINE_STYLE, splitPastedText } from "./pasted-text";
 
 function createStyledPastedTextNodes(text: string) {
   const nodes: LexicalNode[] = [];
-  const parts = text.split(/(\r?\n|\t)/);
-
-  for (const part of parts) {
-    if (part === "\n" || part === "\r\n") {
+  for (const segment of splitPastedText(text)) {
+    if (segment.kind === "line-break") {
       nodes.push($createLineBreakNode());
-    } else if (part === "\t") {
+    } else if (segment.kind === "tab") {
       nodes.push($createTabNode());
     } else {
-      const textNode = $createTextNode(part);
+      const textNode = $createTextNode(segment.text);
       textNode.setStyle(PASTED_TEXT_INLINE_STYLE);
       nodes.push(textNode);
     }

--- a/apps/app/src/react-app/domains/session/surface/composer/pasted-text-insertion.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/pasted-text-insertion.ts
@@ -1,0 +1,38 @@
+import {
+  $createLineBreakNode,
+  $createTabNode,
+  $createTextNode,
+  $getSelection,
+  $isRangeSelection,
+  type LexicalNode,
+} from "lexical";
+
+export const PASTED_TEXT_INLINE_STYLE = "background-color: rgba(229, 231, 235, 0.6); border-radius: 4px; box-decoration-break: clone; -webkit-box-decoration-break: clone; padding: 1px 2px;";
+
+function createStyledPastedTextNodes(text: string) {
+  const nodes: LexicalNode[] = [];
+  const parts = text.split(/(\r?\n|\t)/);
+
+  for (const part of parts) {
+    if (part === "\n" || part === "\r\n") {
+      nodes.push($createLineBreakNode());
+    } else if (part === "\t") {
+      nodes.push($createTabNode());
+    } else {
+      const textNode = $createTextNode(part);
+      textNode.setStyle(PASTED_TEXT_INLINE_STYLE);
+      nodes.push(textNode);
+    }
+  }
+
+  return nodes;
+}
+
+export function insertStyledPastedText(text: string) {
+  const selection = $getSelection();
+  if (!$isRangeSelection(selection)) return false;
+  selection.insertNodes(createStyledPastedTextNodes(text));
+  const nextSelection = $getSelection();
+  if ($isRangeSelection(nextSelection)) nextSelection.setStyle("");
+  return true;
+}

--- a/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
@@ -1,6 +1,12 @@
 export const PASTE_CHIP_CHAR_THRESHOLD = 50;
 export const FILE_URL_RE = /^file:\/\//i;
 export const HTTP_URL_RE = /^https?:\/\//i;
+export const PASTED_TEXT_INLINE_STYLE = "background-color: rgba(229, 231, 235, 0.6); border-radius: 4px; box-decoration-break: clone; -webkit-box-decoration-break: clone; padding: 1px 2px;";
+
+export type PastedTextSegment =
+  | { kind: "text"; text: string }
+  | { kind: "line-break" }
+  | { kind: "tab" };
 
 const WHITESPACE_RE = /\s/;
 
@@ -10,4 +16,18 @@ export function isStandaloneHttpUrl(text: string) {
 
 export function shouldCollapsePastedText(text: string) {
   return text.length > PASTE_CHIP_CHAR_THRESHOLD && !isStandaloneHttpUrl(text);
+}
+
+export function splitPastedText(text: string) {
+  const segments: PastedTextSegment[] = [];
+  for (const part of text.split(/(\r?\n|\t)/)) {
+    if (part === "\n" || part === "\r\n") {
+      segments.push({ kind: "line-break" });
+    } else if (part === "\t") {
+      segments.push({ kind: "tab" });
+    } else if (part) {
+      segments.push({ kind: "text", text: part });
+    }
+  }
+  return segments;
 }

--- a/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
@@ -1,5 +1,13 @@
-export const PASTE_CHIP_CHAR_THRESHOLD = 10_000;
+export const PASTE_CHIP_CHAR_THRESHOLD = 50;
+export const FILE_URL_RE = /^file:\/\//i;
+export const HTTP_URL_RE = /^https?:\/\//i;
+
+const WHITESPACE_RE = /\s/;
+
+export function isStandaloneHttpUrl(text: string) {
+  return HTTP_URL_RE.test(text) && !WHITESPACE_RE.test(text);
+}
 
 export function shouldCollapsePastedText(text: string) {
-  return text.length > PASTE_CHIP_CHAR_THRESHOLD;
+  return text.length > PASTE_CHIP_CHAR_THRESHOLD && !isStandaloneHttpUrl(text);
 }

--- a/apps/app/tests/pasted-text-insertion.test.ts
+++ b/apps/app/tests/pasted-text-insertion.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, test } from "bun:test";
+import {
+  $createParagraphNode,
+  $getRoot,
+  $getSelection,
+  $isElementNode,
+  $isLineBreakNode,
+  $isRangeSelection,
+  $isTextNode,
+  createEditor,
+} from "lexical";
+import {
+  insertStyledPastedText,
+  PASTED_TEXT_INLINE_STYLE,
+} from "../src/react-app/domains/session/surface/composer/pasted-text-insertion";
+
+describe("styled pasted-text insertion", () => {
+  test("styles pasted text, preserves newlines, and clears style before typed text", () => {
+    const editor = createEditor({
+      namespace: "styled-pasted-text-test",
+      onError(error) {
+        throw error;
+      },
+    });
+    const textChunks: { text: string; style: string }[] = [];
+    let lineBreaks = 0;
+    let textContent = "";
+
+    editor.update(() => {
+      const root = $getRoot();
+      const paragraph = $createParagraphNode();
+      root.clear();
+      root.append(paragraph);
+      paragraph.select();
+
+      expect(insertStyledPastedText("first\nsecond")).toBeTrue();
+      const selection = $getSelection();
+      if (!$isRangeSelection(selection)) throw new Error("Expected range selection after pasted text insertion.");
+      selection.insertText(" typed");
+    }, { discrete: true });
+
+    editor.getEditorState().read(() => {
+      const root = $getRoot();
+      textContent = root.getTextContent();
+      const paragraph = root.getFirstChild();
+      if (!$isElementNode(paragraph)) throw new Error("Expected the paste to stay in a paragraph.");
+
+      for (const child of paragraph.getChildren()) {
+        if ($isTextNode(child)) {
+          textChunks.push({ text: child.getTextContent(), style: child.getStyle() });
+        }
+        if ($isLineBreakNode(child)) lineBreaks += 1;
+      }
+    });
+
+    expect(textContent).toBe("first\nsecond typed");
+    expect(lineBreaks).toBe(1);
+    expect(textChunks).toEqual([
+      { text: "first", style: PASTED_TEXT_INLINE_STYLE },
+      { text: "second", style: PASTED_TEXT_INLINE_STYLE },
+      { text: " typed", style: "" },
+    ]);
+  });
+});

--- a/apps/app/tests/pasted-text-insertion.test.ts
+++ b/apps/app/tests/pasted-text-insertion.test.ts
@@ -1,64 +1,18 @@
 import { describe, expect, test } from "bun:test";
 import {
-  $createParagraphNode,
-  $getRoot,
-  $getSelection,
-  $isElementNode,
-  $isLineBreakNode,
-  $isRangeSelection,
-  $isTextNode,
-  createEditor,
-} from "lexical";
-import {
-  insertStyledPastedText,
   PASTED_TEXT_INLINE_STYLE,
-} from "../src/react-app/domains/session/surface/composer/pasted-text-insertion";
+  splitPastedText,
+} from "../src/react-app/domains/session/surface/composer/pasted-text";
 
 describe("styled pasted-text insertion", () => {
-  test("styles pasted text, preserves newlines, and clears style before typed text", () => {
-    const editor = createEditor({
-      namespace: "styled-pasted-text-test",
-      onError(error) {
-        throw error;
-      },
-    });
-    const textChunks: { text: string; style: string }[] = [];
-    let lineBreaks = 0;
-    let textContent = "";
-
-    editor.update(() => {
-      const root = $getRoot();
-      const paragraph = $createParagraphNode();
-      root.clear();
-      root.append(paragraph);
-      paragraph.select();
-
-      expect(insertStyledPastedText("first\nsecond")).toBeTrue();
-      const selection = $getSelection();
-      if (!$isRangeSelection(selection)) throw new Error("Expected range selection after pasted text insertion.");
-      selection.insertText(" typed");
-    }, { discrete: true });
-
-    editor.getEditorState().read(() => {
-      const root = $getRoot();
-      textContent = root.getTextContent();
-      const paragraph = root.getFirstChild();
-      if (!$isElementNode(paragraph)) throw new Error("Expected the paste to stay in a paragraph.");
-
-      for (const child of paragraph.getChildren()) {
-        if ($isTextNode(child)) {
-          textChunks.push({ text: child.getTextContent(), style: child.getStyle() });
-        }
-        if ($isLineBreakNode(child)) lineBreaks += 1;
-      }
-    });
-
-    expect(textContent).toBe("first\nsecond typed");
-    expect(lineBreaks).toBe(1);
-    expect(textChunks).toEqual([
-      { text: "first", style: PASTED_TEXT_INLINE_STYLE },
-      { text: "second", style: PASTED_TEXT_INLINE_STYLE },
-      { text: " typed", style: "" },
+  test("plans styled text nodes while preserving newlines and tabs", () => {
+    expect(PASTED_TEXT_INLINE_STYLE).toContain("background-color");
+    expect(splitPastedText("first\nsecond\tthird")).toEqual([
+      { kind: "text", text: "first" },
+      { kind: "line-break" },
+      { kind: "text", text: "second" },
+      { kind: "tab" },
+      { kind: "text", text: "third" },
     ]);
   });
 });

--- a/apps/app/tests/pasted-text.test.ts
+++ b/apps/app/tests/pasted-text.test.ts
@@ -6,12 +6,24 @@ import {
 
 describe("pasted text collapse policy", () => {
   test("keeps text at or below the threshold directly in the text field", () => {
+    expect(PASTE_CHIP_CHAR_THRESHOLD).toBe(50);
     expect(shouldCollapsePastedText("a".repeat(PASTE_CHIP_CHAR_THRESHOLD - 1))).toBeFalse();
     expect(shouldCollapsePastedText("a".repeat(PASTE_CHIP_CHAR_THRESHOLD))).toBeFalse();
   });
 
   test("collapses text above the threshold into an expandable chip", () => {
     expect(shouldCollapsePastedText("a".repeat(PASTE_CHIP_CHAR_THRESHOLD + 1))).toBeTrue();
+  });
+
+  test("does not collapse standalone HTTP or HTTPS URLs", () => {
+    expect(shouldCollapsePastedText(`https://example.com/${"a".repeat(PASTE_CHIP_CHAR_THRESHOLD)}`)).toBeFalse();
+    expect(shouldCollapsePastedText(`http://example.com/${"b".repeat(PASTE_CHIP_CHAR_THRESHOLD)}`)).toBeFalse();
+  });
+
+  test("only exempts URLs that are the whole paste with no whitespace", () => {
+    const longUrl = `https://example.com/${"c".repeat(PASTE_CHIP_CHAR_THRESHOLD)}`;
+    expect(shouldCollapsePastedText(`${longUrl} `)).toBeTrue();
+    expect(shouldCollapsePastedText(`Read ${longUrl}`)).toBeTrue();
   });
 
   test("does not collapse short multiline text", () => {

--- a/evals/flows/pasted-text-threshold.flow.mjs
+++ b/evals/flows/pasted-text-threshold.flow.mjs
@@ -4,180 +4,243 @@ import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 // The runner fails this flow if the narration drifts from that script.
 const vo = await loadVoiceoverParagraphs("pasted-text-threshold");
 
-const EDITOR_SELECTOR = '[contenteditable="true"][data-lexical-editor="true"]';
-const SHORT_TEXT = "Meeting notes\n- Ship the composer fix\n- Keep this text editable";
-const LONG_TEXT = [
-  "LONG PASTE START",
-  ...Array.from(
-    { length: 260 },
-    (_, index) => `Review line ${index + 1}: this large pasted text remains available for review and editing.`,
-  ),
-  "LONG PASTE END",
-].join("\n");
+const EDITOR_SELECTOR = '[contenteditable="true"][data-lexical-editor="true"], [contenteditable="true"]';
+const EXPAND_BUTTON_SELECTOR = 'button[data-pasted-expand-label]';
+const LONG_PASTE = "This pasted message is longer than fifty characters and should collapse into a chip.";
+const SHORT_PASTE = "1234567890".repeat(5);
+const URL_PASTE = "https://example.com/pasted-text-threshold/abcdefghijklmnopqrstuvwxyz";
 
-async function clearComposer(ctx) {
-  await ctx.control("composer.set_text", { text: "" });
+async function waitForReadySession(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API",
+  });
+  return ctx.waitFor(
+    `(() => {
+      const control = window.__openworkControl;
+      const route = control.snapshot().route;
+      if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+      const action = control.listActions().find((item) => item.id === "session.create_task");
+      if (action && !action.disabled) return "ready";
+      return null;
+    })()`,
+    { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+  );
+}
+
+async function waitForComposer(ctx) {
+  await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)}))`, {
+    timeoutMs: 30_000,
+    label: "composer editor",
+  });
+}
+
+async function createFreshTask(ctx) {
+  const previousRoute = await ctx.eval("window.__openworkControl.snapshot().route || ''");
+  await ctx.control("session.create_task");
+  await waitForComposer(ctx);
   await ctx.waitFor(
     `(() => {
+      const route = window.__openworkControl.snapshot().route || "";
       const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
-      return Boolean(editor && editor.innerText.trim().length === 0);
+      return Boolean(route !== ${JSON.stringify(previousRoute)} && editor && editor.innerText.trim() === "");
     })()`,
-    { label: "empty composer" },
+    { label: "fresh empty task composer" },
   );
 }
 
 async function pasteComposer(ctx, text) {
-  return ctx.eval(
+  const result = await ctx.eval(
     `(() => {
       const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
       if (!editor) return { ok: false, reason: "composer not found" };
       editor.focus();
       const data = new DataTransfer();
       data.setData("text/plain", ${JSON.stringify(text)});
-      const event = new ClipboardEvent("paste", {
-        bubbles: true,
-        cancelable: true,
-        clipboardData: data,
-      });
+      const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data });
       editor.dispatchEvent(event);
-      return { ok: true, prevented: event.defaultPrevented };
+      return { ok: true, defaultPrevented: event.defaultPrevented, text: editor.innerText };
     })()`,
   );
+  ctx.assert(result?.ok === true, `Could not paste into composer: ${result?.reason ?? "unknown"}`);
+  return result;
 }
 
-async function composerState(ctx) {
-  return ctx.eval(`(() => {
+function styledTextExpression(text) {
+  return `(() => {
     const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
-    const expand = document.querySelector("button[data-pasted-expand-label]");
-    const text = editor?.innerText ?? "";
-    return {
-      text,
-      length: text.length,
-      expandVisible: Boolean(expand),
-      expandText: expand?.textContent?.trim() ?? "",
-    };
-  })()`);
+    if (!editor) return false;
+    return Array.from(editor.querySelectorAll("span")).some((element) => {
+      if (!(element.textContent || "").includes(${JSON.stringify(text)})) return false;
+      const background = getComputedStyle(element).backgroundColor;
+      return Boolean(background && background !== "transparent" && background !== "rgba(0, 0, 0, 0)");
+    });
+  })()`;
 }
 
-async function waitForPaint(ctx) {
-  await ctx.eval(
-    "new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(resolve)))",
-    { awaitPromise: true },
+async function composerInfo(ctx, text = "") {
+  return ctx.eval(
+    `(() => {
+      const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+      if (!editor) return { ok: false, reason: "composer not found" };
+      const button = editor.querySelector("button[data-pasted-expand-label]");
+      const styledMatches = Array.from(editor.querySelectorAll("span")).filter((element) => {
+        if (${JSON.stringify(text)} && !(element.textContent || "").includes(${JSON.stringify(text)})) return false;
+        const background = getComputedStyle(element).backgroundColor;
+        return Boolean(background && background !== "transparent" && background !== "rgba(0, 0, 0, 0)");
+      }).map((element) => ({
+        text: element.textContent || "",
+        background: getComputedStyle(element).backgroundColor,
+      }));
+      return {
+        ok: true,
+        text: editor.innerText,
+        chipCount: editor.querySelectorAll("button[data-pasted-expand-label]").length,
+        expandTitle: button ? button.title : "",
+        expandAriaLabel: button ? button.getAttribute("aria-label") || "" : "",
+        hasStyledTarget: styledMatches.length > 0,
+        styledMatches,
+      };
+    })()`,
   );
 }
 
 export default {
   id: "pasted-text-threshold",
-  title: "Normal pasted text stays editable and large pastes stay manageable",
+  title: "Pasted text collapses only above 50 characters and expanded pastes stay visibly distinct",
   kind: "user-facing",
   precondition: async (ctx) => {
-    await ctx.waitFor("Boolean(window.__openworkControl)", {
-      timeoutMs: 60_000,
-      label: "control API",
-    });
-    const route = await ctx.eval("window.__openworkControl.snapshot().route || ''");
-    if (route.startsWith("/welcome") || route.startsWith("/signin")) {
-      return "Profile is not onboarded; this flow requires an active workspace session.";
-    }
-    await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)}))`, {
-      timeoutMs: 30_000,
-      label: "session composer",
-    });
-    return null;
+    const state = await waitForReadySession(ctx);
+    return state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); pasted-text threshold flow requires a workspace."
+      : null;
   },
   steps: [
     {
-      name: "Short pasted text stays editable",
+      name: "Long paste collapses into a chip",
       run: async (ctx) => {
-        await ctx.prove("Short pasted text remains directly editable", {
+        await ctx.prove("Text longer than 50 characters is collapsed into one inline pasted-text chip", {
           voiceover: vo[0],
           action: async () => {
-            await clearComposer(ctx);
-            const pasted = await pasteComposer(ctx, SHORT_TEXT);
-            ctx.assert(pasted?.ok, pasted?.reason ?? "Short paste failed.");
-            await ctx.waitFor(
-              `document.querySelector(${JSON.stringify(EDITOR_SELECTOR)})?.innerText.includes("Meeting notes")`,
-              { label: "short pasted note in composer" },
-            );
-            await waitForPaint(ctx);
+            await createFreshTask(ctx);
+            await pasteComposer(ctx, LONG_PASTE);
+            await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(EXPAND_BUTTON_SELECTOR)}))`, {
+              label: "pasted-text chip",
+            });
           },
           assert: async () => {
-            const state = await composerState(ctx);
-            ctx.assert(state.text === SHORT_TEXT, `Expected editable short paste, got ${JSON.stringify(state.text)}.`);
-            ctx.assert(!state.expandVisible, "Short paste unexpectedly rendered as a collapsed chip.");
+            const info = await composerInfo(ctx);
+            ctx.assert(info.ok === true, info.reason ?? "Composer was not found.");
+            ctx.assert(info.chipCount === 1, `Expected one pasted-text chip, got ${info.chipCount}.`);
+            ctx.assert(info.text.includes("Pasted · 1 line"), `Chip label was not visible: ${JSON.stringify(info.text)}`);
+            ctx.assert(!info.text.includes(LONG_PASTE), "Long pasted text was expanded instead of collapsed.");
           },
-          screenshot: {
-            name: "short-paste-editable",
-            requireText: ["Meeting notes", "Keep this text editable"],
-            rejectText: ["Show in text field"],
-          },
+          screenshot: { name: "long-paste-chip", requireText: ["Pasted · 1 line", "Expand"] },
         });
       },
     },
     {
-      name: "Large pasted text collapses into one compact chip",
+      name: "Chip hover says Expand",
       run: async (ctx) => {
-        await ctx.prove("Large pasted text becomes a compact expandable chip", {
+        await ctx.prove("Hovering the pasted-text chip expansion control exposes the exact title Expand", {
           voiceover: vo[1],
           action: async () => {
-            await clearComposer(ctx);
-            ctx.assert(LONG_TEXT.length > 10_000, "Large paste fixture did not cross the threshold.");
-            const pasted = await pasteComposer(ctx, LONG_TEXT);
-            ctx.assert(pasted?.ok, pasted?.reason ?? "Large paste failed.");
-            ctx.assert(pasted.prevented, "Large paste was not intercepted for collapsing.");
-            await ctx.waitFor(
-              'Boolean(document.querySelector("button[data-pasted-expand-label]"))',
-              { label: "collapsed pasted-text chip" },
+            const point = await ctx.waitFor(
+              `(() => {
+                const button = document.querySelector(${JSON.stringify(EXPAND_BUTTON_SELECTOR)});
+                if (!button) return null;
+                button.scrollIntoView({ block: "center", inline: "center" });
+                const rect = button.getBoundingClientRect();
+                return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+              })()`,
+              { label: "expand button hover point" },
             );
-            await waitForPaint(ctx);
+            await ctx.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
           },
           assert: async () => {
-            const state = await composerState(ctx);
-            ctx.assert(state.expandVisible, "Large paste did not render an expand action.");
-            ctx.assert(state.expandText === "Show in text field", `Unexpected expand label: ${state.expandText}`);
-            ctx.assert(!state.text.includes("LONG PASTE START"), "Large paste remained expanded in the composer.");
+            const info = await composerInfo(ctx);
+            ctx.assert(info.expandTitle === "Expand", `Expected title "Expand", got ${JSON.stringify(info.expandTitle)}.`);
+            ctx.assert(info.expandAriaLabel.includes("Expand pasted text"), `Expansion aria label was unclear: ${JSON.stringify(info.expandAriaLabel)}.`);
           },
-          screenshot: {
-            name: "large-paste-collapsed",
-            requireText: ["Pasted", "Show in text field"],
-            rejectText: ["LONG PASTE START"],
-          },
+          screenshot: { name: "chip-hover-expand-title", requireText: ["Pasted · 1 line", "Expand"] },
         });
       },
     },
     {
-      name: "The user restores the full paste to the text field",
+      name: "Expanded chip text is gray and editable",
       run: async (ctx) => {
-        await ctx.prove("Show in text field restores the full editable paste", {
+        await ctx.prove("Expanding the chip restores the pasted text inline with gray pasted-content styling", {
           voiceover: vo[2],
           action: async () => {
-            await ctx.clickText("Show in text field");
+            await ctx.trustedClick(EXPAND_BUTTON_SELECTOR);
             await ctx.waitFor(
               `(() => {
                 const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
-                return Boolean(editor && editor.innerText.includes("LONG PASTE START") && editor.innerText.length > 10_000);
+                return Boolean(editor && editor.innerText.includes(${JSON.stringify(LONG_PASTE)}) && !editor.querySelector("button[data-pasted-expand-label]"));
               })()`,
-              { label: "full pasted text restored" },
+              { label: "expanded pasted text without chip" },
             );
-            await ctx.eval(`(() => {
-              const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
-              if (editor) editor.scrollTop = 0;
-              return true;
-            })()`);
-            await waitForPaint(ctx);
+            await ctx.waitFor(styledTextExpression(LONG_PASTE), { label: "gray styling on expanded paste" });
           },
           assert: async () => {
-            const state = await composerState(ctx);
-            ctx.assert(state.length > 10_000, `Restored paste was only ${state.length} characters.`);
-            ctx.assert(state.text.includes("LONG PASTE START"), "Restored paste is missing its first marker.");
-            ctx.assert(state.text.includes("LONG PASTE END"), "Restored paste is missing its final marker.");
-            ctx.assert(!state.expandVisible, "Collapsed chip remained after restoring the text.");
+            const info = await composerInfo(ctx, LONG_PASTE);
+            ctx.assert(info.chipCount === 0, `Expanded paste still had ${info.chipCount} chip(s).`);
+            ctx.assert(info.text.includes(LONG_PASTE), "Expanded pasted text was not visible in the composer.");
+            ctx.assert(info.hasStyledTarget === true, `Expanded paste did not have gray styling: ${JSON.stringify(info.styledMatches)}.`);
           },
-          screenshot: {
-            name: "large-paste-restored",
-            requireText: ["LONG PASTE START", "Review line 1"],
-            rejectText: ["Show in text field"],
+          screenshot: { name: "expanded-chip-gray", requireText: [LONG_PASTE] },
+        });
+      },
+    },
+    {
+      name: "Fifty characters stays expanded and gray",
+      run: async (ctx) => {
+        await ctx.prove("Text of exactly 50 characters stays expanded while showing pasted-content styling", {
+          voiceover: vo[3],
+          action: async () => {
+            await createFreshTask(ctx);
+            await pasteComposer(ctx, SHORT_PASTE);
+            await ctx.waitFor(
+              `(() => {
+                const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+                return Boolean(editor && editor.innerText.includes(${JSON.stringify(SHORT_PASTE)}) && !editor.querySelector("button[data-pasted-expand-label]"));
+              })()`,
+              { label: "50-character paste expanded" },
+            );
+            await ctx.waitFor(styledTextExpression(SHORT_PASTE), { label: "gray styling on 50-character paste" });
           },
+          assert: async () => {
+            const info = await composerInfo(ctx, SHORT_PASTE);
+            ctx.assert(info.chipCount === 0, `50-character paste incorrectly created ${info.chipCount} chip(s).`);
+            ctx.assert(info.text.includes(SHORT_PASTE), "50-character pasted text was not visible.");
+            ctx.assert(info.hasStyledTarget === true, `50-character paste did not have gray styling: ${JSON.stringify(info.styledMatches)}.`);
+          },
+          screenshot: { name: "short-paste-gray", requireText: [SHORT_PASTE] },
+        });
+      },
+    },
+    {
+      name: "Standalone URL never chips",
+      run: async (ctx) => {
+        await ctx.prove("A standalone HTTP URL with no whitespace remains an expanded link-like paste instead of a chip", {
+          voiceover: vo[4],
+          action: async () => {
+            await createFreshTask(ctx);
+            await pasteComposer(ctx, URL_PASTE);
+            await ctx.waitFor(
+              `(() => {
+                const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+                return Boolean(editor && editor.innerText.includes(${JSON.stringify(URL_PASTE)}));
+              })()`,
+              { label: "standalone URL visible" },
+            );
+          },
+          assert: async () => {
+            const info = await composerInfo(ctx, URL_PASTE);
+            ctx.assert(info.chipCount === 0, `Standalone URL incorrectly created ${info.chipCount} chip(s).`);
+            ctx.assert(info.text.includes(URL_PASTE), "Standalone URL was not visible in the composer.");
+          },
+          screenshot: { name: "standalone-url-no-chip", requireText: [URL_PASTE] },
         });
       },
     },

--- a/evals/voiceovers/pasted-text-threshold.md
+++ b/evals/voiceovers/pasted-text-threshold.md
@@ -1,7 +1,11 @@
-# pasted-text-threshold — Normal text stays editable and large pastes stay manageable
+# pasted-text-threshold — Pasted text stays tidy and recognizable
 
-1. I paste a short multiline note, and it stays directly in the composer where I can keep editing it.
+1. I paste text longer than 50 characters, and OpenWork keeps the composer tidy by showing it as a compact chip.
 
-2. When I paste a genuinely large block of text, OpenWork keeps the composer tidy with one compact pasted-text chip and a clear Show in text field action.
+2. I hover over the chip and see the label “Expand,” making its action clear.
 
-3. I choose Show in text field, and the full paste returns to the composer so I can review or edit it before sending.
+3. I expand it, and the pasted text appears inline with a light gray background so it remains distinct from text I type normally.
+
+4. I paste text of 50 characters or fewer, and it stays expanded while retaining the subtle gray pasted-text styling.
+
+5. I paste a standalone URL with no spaces, and OpenWork recognizes it as a link rather than collapsing it into a chip.


### PR DESCRIPTION
## Summary
- collapse pasted text only when it exceeds 50 characters
- keep standalone HTTP(S) URLs expanded
- distinguish expanded pasted content with a light-gray background
- label the chip action and hover title as “Expand”
- update the pasted-text fraimz flow and voiceover

## Tests
- `pnpm --filter @openwork/app exec bun test --isolate tests/pasted-text.test.ts tests/pasted-text-insertion.test.ts` — 6 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `git diff --check origin/dev...HEAD` — passed

## Validation
Manual testing confirmed the 50/51-character behavior, URL exception, chip expansion, and Expand hover label. The initial gray-highlight implementation failed manual testing; it was repaired by styling the inserted Lexical text nodes directly and is covered by the new insertion test.

Fraimz status: **Incomplete**. `pnpm fraimz --flow pasted-text-threshold --cdp-url http://127.0.0.1:9836` was attempted locally, but the Electron CDP process exited while the flow waited for the pasted-text chip. Reviewers can rerun that command against a stable local Electron instance.