### PR TITLE
fix(app): make onboarding choices stick across relaunches

### DIFF
--- a/.github/workflows/build-client-installer.yml
+++ b/.github/workflows/build-client-installer.yml
@@ -163,7 +163,13 @@ jobs:
         shell: bash
         run: |
           cd apps/installer
+          # Windows exes ship Bun's default icon unless one is embedded here.
+          icon_flag=""
+          if [ "${{ matrix.os_type }}" = "windows" ]; then
+            icon_flag="--windows-icon=../desktop/resources/icons/icon.ico"
+          fi
           bun build --compile --minify --target=${{ matrix.bun_target }} \
+            $icon_flag \
             src/index.ts src/server-worker.ts \
             --outfile "dist/openwork-installer"
 

--- a/.github/workflows/release-generic-installer.yml
+++ b/.github/workflows/release-generic-installer.yml
@@ -189,7 +189,13 @@ jobs:
         shell: bash
         run: |
           cd apps/installer
+          # Windows exes ship Bun's default icon unless one is embedded here.
+          icon_flag=""
+          if [ "${{ matrix.os_type }}" = "windows" ]; then
+            icon_flag="--windows-icon=../desktop/resources/icons/icon.ico"
+          fi
           bun build --compile --minify --target=${{ matrix.bun_target }} \
+            $icon_flag \
             src/index.ts src/server-worker.ts \
             --outfile "dist/openwork-installer"
 

--- a/apps/app/src/react-app/domains/cloud/brand-theme.tsx
+++ b/apps/app/src/react-app/domains/cloud/brand-theme.tsx
@@ -111,6 +111,9 @@ function DesktopPolicyNotificationEffect() {
       title: "Organization policies active",
       body: "Some features and appearance settings are managed by your administrator.",
       dedupeKey: POLICY_NOTIFICATION_DEDUPE,
+      // Standing state, re-emitted on every launch: deliver a single time
+      // ever, so clearing it doesn't resurrect it on the next reopen.
+      once: true,
     });
   }, [config, addNotification]);
 

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
@@ -37,8 +37,17 @@ export const OPENWORK_MODEL_PREVIEWS: OpenWorkModelPreview[] = Object.entries(
     subtitle: "OpenWork hosted",
   }));
 
+/**
+ * True when the user already has hosted models available: the OpenWork
+ * Models provider itself, or an org-managed cloud provider (`lpr_*`).
+ * Org members whose administrators provision models must never be pitched
+ * a subscription to a provider their org doesn't control.
+ */
 export function hasOpenWorkModelsProvider(providerIds: readonly string[]) {
-  return providerIds.some((id) => id.trim().toLowerCase() === OPENWORK_MODELS_PROVIDER_ID);
+  return providerIds.some((id) => {
+    const normalized = id.trim().toLowerCase();
+    return normalized === OPENWORK_MODELS_PROVIDER_ID || normalized.startsWith("lpr_");
+  });
 }
 
 export function getOpenWorkModelsActionUrl(

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -30,7 +30,9 @@ import { usePlatform } from "../../kernel/platform";
 import { useBootState } from "../../shell/boot-state";
 import { resolveModelDisplayName, resolveProviderDisplayName } from "@/app/utils";
 import { ProviderIcon } from "../../design-system/provider-icon";
+import { useLocal } from "../../kernel/local-provider";
 import { writeStoredDefaultModel } from "../../kernel/model-config";
+import { markOrgOnboardingSeen } from "./org-onboarding-seen";
 import { orgOnboardingVisibilityEvent } from "../../shell/reload-coordinator";
 import {
   Page,
@@ -333,6 +335,7 @@ export function ResourceSelectionPage() {
   const navigate = useNavigate();
   const platform = usePlatform();
   const { markRouteReady } = useBootState();
+  const { setPrefs } = useLocal();
   const { authToken, denClient, orgId, orgName, settings } = useDenClient();
 
   const prepared = usePreparedBootstrap();
@@ -376,13 +379,20 @@ export function ResourceSelectionPage() {
   });
 
   const handleContinue = useCallback(() => {
-    // If user picked a default model, write it
+    // If user picked a default model, write it to BOTH stores: the legacy
+    // explicit-default key and the live preferences the session actually
+    // reads — otherwise the choice is ignored until the next full reload
+    // and the app keeps using the previous (possibly unavailable) default.
     if (selectedDefault) {
-      writeStoredDefaultModel({
+      const model = {
         providerID: selectedDefault.providerId,
         modelID: selectedDefault.modelId,
-      });
+      };
+      writeStoredDefaultModel(model);
+      setPrefs((previous) => ({ ...previous, defaultModel: model }));
     }
+    // Don't route back to this page on future launches.
+    markOrgOnboardingSeen();
     // Mark all providers shown on this page as "seen" so the global
     // toast doesn't re-fire for them on the next sync interval.
     markProvidersSeen(providers);
@@ -392,7 +402,7 @@ export function ResourceSelectionPage() {
       } catch {}
     }
     navigate("/session", { replace: true });
-  }, [navigate, providers, selectedDefault]);
+  }, [navigate, providers, selectedDefault, setPrefs]);
 
   const totalModels = providers.reduce((sum, provider) => sum + provider.models.length, 0);
   const hasResources = providers.length > 0 || marketplaces.length > 0;

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-seen.ts
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-seen.ts
@@ -1,0 +1,25 @@
+// One-shot latch: has the user already been shown the org onboarding
+// ("your organization resources") page? Set when they continue past it,
+// checked before auto-routing to /onboarding on relaunch so the page —
+// and its default-model picker — doesn't reappear on every app start.
+// The key is already covered by session-memory cleanup and the dev reset
+// button in session-page.tsx.
+const ORG_ONBOARDING_SEEN_KEY = "openwork.orgOnboardingSeen";
+
+export function hasSeenOrgOnboarding(): boolean {
+  if (typeof window === "undefined") return false;
+  try {
+    return window.localStorage.getItem(ORG_ONBOARDING_SEEN_KEY) === "1";
+  } catch {
+    return false;
+  }
+}
+
+export function markOrgOnboardingSeen(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(ORG_ONBOARDING_SEEN_KEY, "1");
+  } catch {
+    // ignore quota errors
+  }
+}

--- a/apps/app/src/react-app/kernel/local-provider.tsx
+++ b/apps/app/src/react-app/kernel/local-provider.tsx
@@ -10,10 +10,14 @@ import {
   type ReactNode,
 } from "react";
 
-import { THINKING_PREF_KEY } from "../../app/constants";
+import { DEFAULT_MODEL, THINKING_PREF_KEY } from "../../app/constants";
 import { coerceReleaseChannel } from "../../app/lib/release-channels";
 import type { ModelRef, ReleaseChannel, SettingsTab, View } from "../../app/types";
-import { readStoredDefaultModel } from "./model-config";
+import {
+  readExplicitStoredDefaultModel,
+  readStoredDefaultModel,
+  writeStoredDefaultModel,
+} from "./model-config";
 
 export type LocalUIState = {
   view: View;
@@ -135,7 +139,23 @@ export function LocalProvider({ children }: LocalProviderProps) {
     } catch {
       // ignore parse failures; defaults apply
     }
-    if (persisted.defaultModel) {
+    // Default-model reconciliation across the two stores. The legacy key
+    // (`openwork.defaultModel`) holds the user's explicit choice — the org
+    // onboarding "use as default" flow writes it — while the preferences
+    // blob may still hold the hardcoded fallback that was baked in on first
+    // boot before any choice existed. Prefer the explicit choice whenever
+    // the preferences value is missing or still that fallback, so an org
+    // default picked during onboarding survives relaunches (#2624).
+    const explicit = readExplicitStoredDefaultModel();
+    const persistedDefault = persisted.defaultModel;
+    const persistedIsFallback =
+      persistedDefault !== null &&
+      persistedDefault.providerID === DEFAULT_MODEL.providerID &&
+      persistedDefault.modelID === DEFAULT_MODEL.modelID;
+    if (explicit && (!persistedDefault || persistedIsFallback)) {
+      return { ...persisted, defaultModel: explicit };
+    }
+    if (persistedDefault) {
       return persisted;
     }
     return {
@@ -152,6 +172,11 @@ export function LocalProvider({ children }: LocalProviderProps) {
 
   useEffect(() => {
     writePersisted(PREFS_STORAGE_KEY, prefs);
+    // Keep the legacy explicit-default key in sync so the two stores can
+    // never disagree again after this point.
+    if (prefs.defaultModel) {
+      writeStoredDefaultModel(prefs.defaultModel);
+    }
   }, [prefs]);
 
   useEffect(() => {

--- a/apps/app/src/react-app/kernel/model-config.ts
+++ b/apps/app/src/react-app/kernel/model-config.ts
@@ -146,12 +146,21 @@ export function parseWorkspaceModelVariants(
 }
 
 export function readStoredDefaultModel(): ModelRef {
-  if (typeof window === "undefined") return DEFAULT_MODEL;
+  return readExplicitStoredDefaultModel() ?? DEFAULT_MODEL;
+}
+
+/**
+ * The default model the user explicitly chose (org onboarding "use as
+ * default", legacy settings), or null when none was ever picked. Unlike
+ * `readStoredDefaultModel` this never substitutes the hardcoded fallback,
+ * so callers can tell a real choice apart from the built-in default.
+ */
+export function readExplicitStoredDefaultModel(): ModelRef | null {
+  if (typeof window === "undefined") return null;
   try {
-    const stored = window.localStorage.getItem(MODEL_PREF_KEY);
-    return parseModelRef(stored) ?? DEFAULT_MODEL;
+    return parseModelRef(window.localStorage.getItem(MODEL_PREF_KEY));
   } catch {
-    return DEFAULT_MODEL;
+    return null;
   }
 }
 

--- a/apps/app/src/react-app/kernel/notification-store.ts
+++ b/apps/app/src/react-app/kernel/notification-store.ts
@@ -52,10 +52,18 @@ export type NotificationInput = {
   dedupeKey?: string;
   action?: NotificationAction;
   actionLabel?: string;
+  /**
+   * Only ever notify once per dedupeKey — across restarts, reads, and
+   * "Clear all". Use for standing-state notices (e.g. "Organization
+   * policies active") that producers re-emit on every launch.
+   */
+  once?: boolean;
 };
 
 type NotificationStore = {
   notifications: AppNotification[];
+  /** dedupeKeys of `once` notifications that were already delivered. */
+  onceKeys: string[];
   add: (input: NotificationInput) => void;
   markAllRead: () => void;
   clearAll: () => void;
@@ -135,13 +143,30 @@ function sanitizeNotifications(value: unknown): AppNotification[] {
   return notifications;
 }
 
+const MAX_ONCE_KEYS = 100;
+
+function sanitizeOnceKeys(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value
+    .filter((entry): entry is string => typeof entry === "string")
+    .slice(-MAX_ONCE_KEYS);
+}
+
 export const useNotificationStore = create<NotificationStore>()(
   persist(
     (set) => ({
       notifications: [],
+      onceKeys: [],
       add: (input) =>
         set((state) => {
           const now = Date.now();
+          if (input.once && input.dedupeKey && state.onceKeys.includes(input.dedupeKey)) {
+            return state;
+          }
+          const onceKeys =
+            input.once && input.dedupeKey
+              ? [...state.onceKeys, input.dedupeKey].slice(-MAX_ONCE_KEYS)
+              : state.onceKeys;
           if (input.dedupeKey) {
             const existing = state.notifications.find(
               (notification) =>
@@ -159,6 +184,7 @@ export const useNotificationStore = create<NotificationStore>()(
                 updatedAt: now,
               };
               return {
+                onceKeys,
                 notifications: prune([
                   merged,
                   ...state.notifications.filter((notification) => notification.id !== existing.id),
@@ -180,7 +206,7 @@ export const useNotificationStore = create<NotificationStore>()(
             action: input.action,
             actionLabel: input.actionLabel,
           };
-          return { notifications: prune([notification, ...state.notifications]) };
+          return { onceKeys, notifications: prune([notification, ...state.notifications]) };
         }),
       markAllRead: () =>
         set((state) => {
@@ -199,17 +225,21 @@ export const useNotificationStore = create<NotificationStore>()(
     {
       name: PERSISTED_NOTIFICATION_STORE_KEY,
       storage: createJSONStorage(() => localStorage),
-      partialize: (state) => ({ notifications: state.notifications }),
-      merge: (persistedState, currentState) => ({
-        ...currentState,
-        notifications: prune(
-          sanitizeNotifications(
-            typeof persistedState === "object" && persistedState !== null
-              ? Reflect.get(persistedState, "notifications")
-              : null,
-          ),
-        ),
+      partialize: (state) => ({
+        notifications: state.notifications,
+        onceKeys: state.onceKeys,
       }),
+      merge: (persistedState, currentState) => {
+        const persisted =
+          typeof persistedState === "object" && persistedState !== null ? persistedState : null;
+        return {
+          ...currentState,
+          notifications: prune(
+            sanitizeNotifications(persisted ? Reflect.get(persisted, "notifications") : null),
+          ),
+          onceKeys: sanitizeOnceKeys(persisted ? Reflect.get(persisted, "onceKeys") : null),
+        };
+      },
     },
   ),
 );

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -18,6 +18,7 @@ import { evalRelaunchDesktopApp } from "../../app/lib/desktop";
 import { useDenAuth } from "../domains/cloud/den-auth-provider";
 import { ForcedSigninPage } from "../domains/cloud/forced-signin-page";
 import { OrgOnboardingPage } from "../domains/cloud/org-onboarding-page";
+import { hasSeenOrgOnboarding } from "../domains/cloud/org-onboarding-seen";
 import { NewProvidersListener } from "./new-providers-listener";
 import { useDesktopFontZoomBehavior } from "./font-zoom";
 import { LoadingOverlay } from "./loading-overlay";
@@ -87,12 +88,19 @@ function DenSigninGate({ children }: DenSigninGateProps) {
       if (!denAuth.isSignedIn && !onSignin) {
         navigate("/signin", { replace: true });
       } else if (denAuth.isSignedIn && onSignin) {
-        // Signed in — route to onboarding so the user sees their org resources.
-        navigate("/onboarding", { replace: true });
+        // Signed in — route to onboarding so the user sees their org
+        // resources, but only the first time. Once they've continued past
+        // it, relaunches go straight to the session (#2624).
+        navigate(hasSeenOrgOnboarding() ? "/session" : "/onboarding", { replace: true });
       }
     } else if (onSignin) {
       navigate("/session", { replace: true });
-    } else if (!denAuth.isSignedIn && hasPreparedBootstrap && !onOnboarding) {
+    } else if (
+      !denAuth.isSignedIn &&
+      hasPreparedBootstrap &&
+      !onOnboarding &&
+      !hasSeenOrgOnboarding()
+    ) {
       navigate("/onboarding", { replace: true });
     }
 
@@ -109,18 +117,21 @@ function DenSigninGate({ children }: DenSigninGateProps) {
   ]);
 
   // After a fresh sign-in, navigate to the onboarding page so the
-  // user sees what their org provides.
+  // user sees what their org provides. Skipped once the user has already
+  // continued past onboarding — token refreshes and re-exchanged handoff
+  // grants on relaunch must not drag them back there (#2624).
   // Poll for activeOrgId (set asynchronously by refreshOrgs) rather
   // than using a fixed delay — handles both fast and slow org lookups.
   useEffect(() => {
     const handler = (event: WindowEventMap[typeof denSessionUpdatedEvent]) => {
       if (event.detail?.status !== "success") return;
+      if (hasSeenOrgOnboarding()) return;
       let attempts = 0;
       const check = () => {
         attempts++;
         const settings = readDenSettings();
         if (settings.authToken?.trim() && settings.activeOrgId?.trim()) {
-          navigate("/onboarding", { replace: true });
+          if (!hasSeenOrgOnboarding()) navigate("/onboarding", { replace: true });
         } else if (attempts < 10) {
           // Org not selected yet — retry (max ~5 seconds)
           setTimeout(check, 500);

--- a/apps/app/tests/notification-store.test.ts
+++ b/apps/app/tests/notification-store.test.ts
@@ -24,7 +24,7 @@ Object.defineProperty(globalThis, "localStorage", {
 const { useNotificationStore } = await import("../src/react-app/kernel/notification-store");
 
 function reset() {
-  useNotificationStore.setState({ notifications: [] });
+  useNotificationStore.setState({ notifications: [], onceKeys: [] });
   storage.clear();
 }
 
@@ -105,6 +105,37 @@ describe("notification store", () => {
     add({ kind: "system", title: "One" });
     add({ kind: "system", title: "Two" });
     clearAll();
+    expect(useNotificationStore.getState().notifications).toHaveLength(0);
+  });
+
+  test("once notifications are delivered a single time ever", () => {
+    const { add } = useNotificationStore.getState();
+    add({ kind: "cloud", title: "Organization policies active", dedupeKey: "desktop-policy-active", once: true });
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+
+    // Re-emitted on a later launch: no new entry, no unread resurrection.
+    add({ kind: "cloud", title: "Organization policies active", dedupeKey: "desktop-policy-active", once: true });
+    expect(useNotificationStore.getState().notifications).toHaveLength(1);
+    expect(useNotificationStore.getState().notifications[0].count).toBe(1);
+  });
+
+  test("once notifications stay dismissed after markAllRead", () => {
+    const { add, markAllRead } = useNotificationStore.getState();
+    add({ kind: "cloud", title: "Organization policies active", dedupeKey: "desktop-policy-active", once: true });
+    markAllRead();
+    add({ kind: "cloud", title: "Organization policies active", dedupeKey: "desktop-policy-active", once: true });
+
+    const notifications = useNotificationStore.getState().notifications;
+    expect(notifications).toHaveLength(1);
+    expect(notifications[0].readAt).not.toBeNull();
+  });
+
+  test("once notifications stay dismissed after clearAll", () => {
+    const { add, clearAll } = useNotificationStore.getState();
+    add({ kind: "cloud", title: "Organization policies active", dedupeKey: "desktop-policy-active", once: true });
+    clearAll();
+    add({ kind: "cloud", title: "Organization policies active", dedupeKey: "desktop-policy-active", once: true });
+
     expect(useNotificationStore.getState().notifications).toHaveLength(0);
   });
 

--- a/apps/app/tests/openwork-models-promo.test.ts
+++ b/apps/app/tests/openwork-models-promo.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { hasOpenWorkModelsProvider } from "../src/react-app/domains/cloud/openwork-models-promo";
+
+describe("hasOpenWorkModelsProvider", () => {
+  test("true for the OpenWork Models provider", () => {
+    expect(hasOpenWorkModelsProvider(["openai", "openwork"])).toBe(true);
+    expect(hasOpenWorkModelsProvider([" OpenWork "])).toBe(true);
+  });
+
+  test("true for org-managed cloud providers so members are never pitched a subscription", () => {
+    expect(hasOpenWorkModelsProvider(["lpr_evalorg"])).toBe(true);
+    expect(hasOpenWorkModelsProvider(["opencode", "LPR_ACME"])).toBe(true);
+  });
+
+  test("false without hosted models", () => {
+    expect(hasOpenWorkModelsProvider([])).toBe(false);
+    expect(hasOpenWorkModelsProvider(["openai", "opencode", "anthropic"])).toBe(false);
+  });
+});

--- a/apps/installer/src/install.ts
+++ b/apps/installer/src/install.ts
@@ -247,11 +247,24 @@ export async function runInstall(config: InstallerConfig, opts: InstallOptions =
   return installStatus()
 }
 
-export function launchInstalledApp(installedPath: string): void {
-  if (!installedPath || !existsSync(installedPath)) return
+export function launchInstalledApp(installedPath: string): boolean {
+  if (!installedPath || !existsSync(installedPath)) {
+    console.error(`launch: installed app not found at ${installedPath}`)
+    return false
+  }
   if (process.platform === "darwin") {
     Bun.spawn(["open", installedPath], { stdio: ["ignore", "ignore", "ignore"] })
+  } else if (process.platform === "win32") {
+    // Detach via `cmd /c start` so the app survives the installer exiting:
+    // the launch request is handled by the --server-worker child, which the
+    // main process kills right after the window closes. A plain Bun.spawn
+    // child would be torn down with it. spawnSync guarantees `start` has
+    // handed the app off to a new process group before we respond.
+    Bun.spawnSync(["cmd", "/c", "start", "", installedPath], {
+      stdio: ["ignore", "ignore", "ignore"],
+    })
   } else {
     Bun.spawn([installedPath], { stdio: ["ignore", "ignore", "ignore"] })
   }
+  return true
 }

--- a/apps/installer/src/server.ts
+++ b/apps/installer/src/server.ts
@@ -71,7 +71,12 @@ export function startInstallerServer(initialResolution: InstallerConfigResolutio
         if (request.method === "POST" && url.pathname === "/api/launch") {
           const installedPath = installStatus().installedPath
           if (!installedPath) return Response.json({ error: "not_installed" }, { status: 409 })
-          launchInstalledApp(installedPath)
+          if (!launchInstalledApp(installedPath)) {
+            return Response.json(
+              { error: "launch_failed", message: `Installed app not found at ${installedPath}.` },
+              { status: 500 },
+            )
+          }
           return Response.json({ ok: true })
         }
         if (request.method === "POST" && url.pathname === "/api/exit") {

--- a/apps/installer/src/ui-html.ts
+++ b/apps/installer/src/ui-html.ts
@@ -175,7 +175,15 @@ ${configuredContent}
 
   if (actionBtn) actionBtn.addEventListener("click", async () => {
     if (installed) {
-      try { await api("/api/launch"); } catch {}
+      // Only close once the launch actually succeeded — otherwise show the
+      // failure instead of silently exiting with nothing started.
+      try {
+        await api("/api/launch");
+      } catch (error) {
+        statusEl.textContent = "Could not launch OpenWork: " + (error.message || "unknown error");
+        statusEl.classList.add("error");
+        return;
+      }
       closeWindow();
       return;
     }

--- a/evals/flows/lib/den-onboarding-stub.mjs
+++ b/evals/flows/lib/den-onboarding-stub.mjs
@@ -67,6 +67,10 @@ export function startDenStub(port = DEN_STUB_PORT) {
       respond(200, { llmProviders: [PROVIDER] });
       return;
     }
+    if (req.method === "POST" && pathname === "/v1/me/active-organization") {
+      respond(200, { ok: true, activeOrgId: "org_eval", activeOrgSlug: "eval-org" });
+      return;
+    }
     if (req.method === "GET" && pathname === "/v1/marketplaces") {
       respond(200, { items: [] });
       return;

--- a/evals/flows/lib/den-onboarding-stub.mjs
+++ b/evals/flows/lib/den-onboarding-stub.mjs
@@ -50,8 +50,17 @@ export function startDenStub(port = DEN_STUB_PORT) {
     // The den client requests API routes under the `/api/den` proxy prefix.
     const rawPathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
     const pathname = rawPathname.replace(/^\/api\/den(?=\/)/, "");
+    console.log(`${new Date().toISOString()} ${req.method} ${rawPathname}`);
     if (req.method === "GET" && pathname === "/v1/me") {
       respond(200, { user: { id: "usr_eval", email: "jonas@example.com", name: "Jonas Nielsen" } });
+      return;
+    }
+    if (req.method === "GET" && pathname === "/v1/me/orgs") {
+      respond(200, {
+        orgs: [{ id: "org_eval", name: DEN_STUB_ORG_NAME, slug: "eval-org", role: "member" }],
+        activeOrgId: "org_eval",
+        activeOrgSlug: "eval-org",
+      });
       return;
     }
     if (req.method === "GET" && pathname === "/v1/llm-providers") {

--- a/evals/flows/lib/den-onboarding-stub.mjs
+++ b/evals/flows/lib/den-onboarding-stub.mjs
@@ -47,7 +47,9 @@ export function startDenStub(port = DEN_STUB_PORT) {
       res.end();
       return;
     }
-    const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+    // The den client requests API routes under the `/api/den` proxy prefix.
+    const rawPathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+    const pathname = rawPathname.replace(/^\/api\/den(?=\/)/, "");
     if (req.method === "GET" && pathname === "/v1/me") {
       respond(200, { user: { id: "usr_eval", email: "jonas@example.com", name: "Jonas Nielsen" } });
       return;

--- a/evals/flows/lib/den-onboarding-stub.mjs
+++ b/evals/flows/lib/den-onboarding-stub.mjs
@@ -1,0 +1,74 @@
+/**
+ * Minimal Den API stub for the onboarding-feedback-fixes flow: a signed-in
+ * member of an org with one managed LLM provider. Import { startDenStub }
+ * from the flow, or run standalone next to the app under test:
+ *
+ *   node evals/flows/lib/den-onboarding-stub.mjs   # listens on 127.0.0.1:18975
+ */
+import { createServer } from "node:http";
+
+export const DEN_STUB_PORT = 18975;
+export const DEN_STUB_ORG_NAME = "Eval Org";
+export const DEN_STUB_PROVIDER_NAME = "Acme AI Gateway";
+export const DEN_STUB_PROVIDER_ID = "lpr_evalorg";
+/** models[0] — the one "Use as default" picks. */
+export const DEN_STUB_FIRST_MODEL_ID = "glm-5.2-turbo";
+
+const CORS_HEADERS = {
+  "access-control-allow-origin": "*",
+  "access-control-allow-headers": "authorization, content-type, accept, x-openwork-legacy-org-id",
+  "access-control-allow-methods": "GET, POST, OPTIONS",
+};
+
+const PROVIDER = {
+  id: DEN_STUB_PROVIDER_ID,
+  source: "custom",
+  providerId: "zai",
+  name: DEN_STUB_PROVIDER_NAME,
+  providerConfig: {},
+  hasApiKey: true,
+  models: [
+    { id: DEN_STUB_FIRST_MODEL_ID, name: "GLM 5.2 Turbo", config: {} },
+    { id: "glm-5.2", name: "GLM 5.2", config: {} },
+    { id: "glm-5.2-air", name: "GLM 5.2 Air", config: {} },
+  ],
+  createdAt: null,
+  updatedAt: null,
+};
+
+export function startDenStub(port = DEN_STUB_PORT) {
+  const server = createServer((req, res) => {
+    const respond = (status, payload) => {
+      res.writeHead(status, { "content-type": "application/json", ...CORS_HEADERS });
+      res.end(JSON.stringify(payload));
+    };
+    if (req.method === "OPTIONS") {
+      res.writeHead(204, CORS_HEADERS);
+      res.end();
+      return;
+    }
+    const pathname = new URL(req.url ?? "/", "http://127.0.0.1").pathname;
+    if (req.method === "GET" && pathname === "/v1/me") {
+      respond(200, { user: { id: "usr_eval", email: "jonas@example.com", name: "Jonas Nielsen" } });
+      return;
+    }
+    if (req.method === "GET" && pathname === "/v1/llm-providers") {
+      respond(200, { llmProviders: [PROVIDER] });
+      return;
+    }
+    if (req.method === "GET" && pathname === "/v1/marketplaces") {
+      respond(200, { items: [] });
+      return;
+    }
+    respond(404, { error: "not_found", message: `no stub for ${req.method} ${pathname}` });
+  });
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => resolve(server));
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await startDenStub();
+  console.log(`den onboarding stub listening on http://127.0.0.1:${DEN_STUB_PORT}`);
+}

--- a/evals/flows/onboarding-feedback-fixes.flow.mjs
+++ b/evals/flows/onboarding-feedback-fixes.flow.mjs
@@ -1,0 +1,347 @@
+/**
+ * Onboarding feedback fixes (#2624): the three "it forgets what I chose"
+ * bugs reported from Windows onboarding, replayed end-to-end:
+ *
+ *   1. A default model chosen during org onboarding survives a relaunch —
+ *      the legacy explicit-default key and the live preferences blob are
+ *      reconciled instead of falling back to the retired built-in model.
+ *   2. The org onboarding page shows once: fresh sign-ins land there, but
+ *      after the user continues past it, refreshed sign-ins on relaunch
+ *      stay on the session view.
+ *   3. The "Organization policies active" notification stays cleared after
+ *      a relaunch while the policy is still active.
+ *
+ * The den org backend is a local stub HTTP server started by this flow
+ * (sign-in session + one org provider with models); relaunches are
+ * simulated at the renderer level with location.reload(), which re-runs
+ * the exact boot code paths (LocalProvider init, DesktopPolicyNotification
+ * effect, den session routing) the fixes changed.
+ *
+ * Run against an isolated profile to avoid touching a real dev profile:
+ *   OPENWORK_ELECTRON_USERDATA=$(mktemp -d) OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9826 pnpm dev
+ *   pnpm fraimz --flow onboarding-feedback-fixes --cdp-url http://127.0.0.1:9826
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import {
+  DEN_STUB_FIRST_MODEL_ID,
+  DEN_STUB_ORG_NAME as ORG_NAME,
+  DEN_STUB_PORT,
+  DEN_STUB_PROVIDER_ID,
+  DEN_STUB_PROVIDER_NAME as PROVIDER_NAME,
+  startDenStub,
+} from "./lib/den-onboarding-stub.mjs";
+
+const vo = await loadVoiceoverParagraphs("onboarding-feedback-fixes");
+
+// Frame 2 simulates the pre-fix bitten state with this explicit choice…
+const LEGACY_DEFAULT = { providerID: DEN_STUB_PROVIDER_ID, modelID: "glm-5.2" };
+// …while frame 4 picks the provider's first model through the real UI.
+const UI_DEFAULT = { providerID: DEN_STUB_PROVIDER_ID, modelID: DEN_STUB_FIRST_MODEL_ID };
+const BIG_PICKLE = { providerID: "opencode", modelID: "big-pickle" };
+
+// When the app runs on another host (Daytona), start the stub next to the
+// app (`node evals/flows/lib/den-onboarding-stub.mjs`) and set
+// OPENWORK_EVAL_DEN_STUB_EXTERNAL=1 for the runner. The baseUrl written into
+// the app's localStorage always targets the app-local loopback.
+const externalStub = process.env.OPENWORK_EVAL_DEN_STUB_EXTERNAL === "1";
+
+let denStub = null;
+
+async function waitForControl(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "window.__openworkControl",
+  });
+  await ctx.waitFor("document.body.innerText.trim().length > 40", {
+    timeoutMs: 30_000,
+    label: "rendered body text",
+  });
+}
+
+async function readPrefsDefaultModel(ctx) {
+  return ctx.eval(
+    "JSON.parse(localStorage.getItem('openwork.preferences') ?? '{}').defaultModel ?? null",
+  );
+}
+
+export default {
+  id: "onboarding-feedback-fixes",
+  title: "Onboarding choices stick: default model, one-time org page, dismissible policy notice",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Reset eval state, start den stub, boot to the session view",
+      run: async (ctx) => {
+        if (!externalStub) denStub ??= await startDenStub();
+        await waitForControl(ctx);
+
+        // Idempotence: wipe every key this flow exercises so reruns start
+        // from the same "member finished setup" baseline.
+        await ctx.eval(`(() => {
+          const keys = [
+            'openwork.defaultModel',
+            'openwork.orgOnboardingSeen',
+            'openwork.den.baseUrl',
+            'openwork.den.authToken',
+            'openwork.den.activeOrgId',
+            'openwork.den.activeOrgName',
+            'openwork:notifications:v1',
+            'openwork.openworkModelsPromo.hidden',
+            'openwork.openworkModelsPromo.startupShown',
+          ];
+          for (const key of keys) localStorage.removeItem(key);
+          const prefs = JSON.parse(localStorage.getItem('openwork.preferences') ?? '{}');
+          prefs.defaultModel = null;
+          localStorage.setItem('openwork.preferences', JSON.stringify(prefs));
+          const bridge = window.__openworkApplyDesktopConfig;
+          if (typeof bridge === 'function') bridge({});
+          return true;
+        })()`);
+        await ctx.eval("location.reload()");
+        await waitForControl(ctx);
+
+        // Fresh isolated profiles land on /welcome: create a workspace so
+        // the flow starts where a set-up member would.
+        const onWelcome = await ctx.eval("location.hash.includes('/welcome')");
+        if (onWelcome) {
+          const wsPath = mkdtempSync(join(tmpdir(), "openwork-eval-ws-"));
+          await ctx.fill("input", wsPath);
+          await ctx.clickText("Use this folder", { timeoutMs: 5_000 });
+          await ctx.waitFor(
+            "location.hash.includes('/workspace/') || location.hash.includes('/session')",
+            { timeoutMs: 30_000, label: "workspace route after creation" },
+          );
+          // The first-run flow may interpose provider/attribution steps;
+          // dismiss anything with a Skip affordance.
+          await ctx.clickText("Skip", { timeoutMs: 3_000 }).catch(() => {});
+        }
+        await ctx.navigateHash("/session");
+        await new Promise((resolve) => setTimeout(resolve, 800));
+
+        await ctx.prove("App boots to the session view for a set-up member", {
+          claim: "OpenWork opens on the session view — the state a member is in right after finishing setup.",
+          voiceover: vo[0],
+          assert: async () => {
+            await ctx.expectHashIncludes("/session");
+          },
+          screenshot: {
+            name: "baseline-session",
+            hashIncludes: "/session",
+          },
+        });
+      },
+    },
+
+    {
+      name: "Explicit org default survives a relaunch instead of the retired fallback",
+      run: async (ctx) => {
+        await ctx.prove("Chosen default model wins over the baked-in fallback after relaunch", {
+          claim: `With the pre-fix bitten storage (explicit ${LEGACY_DEFAULT.providerID}/${LEGACY_DEFAULT.modelID} + baked ${BIG_PICKLE.modelID} in preferences), a relaunch reconciles preferences to the member's explicit choice.`,
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.eval(`(() => {
+              localStorage.setItem('openwork.defaultModel', ${JSON.stringify(`${LEGACY_DEFAULT.providerID}/${LEGACY_DEFAULT.modelID}`)});
+              const prefs = JSON.parse(localStorage.getItem('openwork.preferences') ?? '{}');
+              prefs.defaultModel = ${JSON.stringify(BIG_PICKLE)};
+              localStorage.setItem('openwork.preferences', JSON.stringify(prefs));
+              return true;
+            })()`);
+            await ctx.eval("location.reload()");
+            await waitForControl(ctx);
+            await ctx.navigateHash("/session");
+            await new Promise((resolve) => setTimeout(resolve, 500));
+          },
+          assert: async () => {
+            const defaultModel = await readPrefsDefaultModel(ctx);
+            ctx.log(`preferences.defaultModel after relaunch: ${JSON.stringify(defaultModel)}`);
+            ctx.assert(
+              defaultModel &&
+                defaultModel.providerID === LEGACY_DEFAULT.providerID &&
+                defaultModel.modelID === LEGACY_DEFAULT.modelID,
+              `Expected preferences.defaultModel to be the explicit ${LEGACY_DEFAULT.providerID}/${LEGACY_DEFAULT.modelID}, got ${JSON.stringify(defaultModel)}.`,
+            );
+            const legacy = await ctx.eval("localStorage.getItem('openwork.defaultModel')");
+            ctx.assert(
+              legacy === `${LEGACY_DEFAULT.providerID}/${LEGACY_DEFAULT.modelID}`,
+              `Expected the explicit default key to survive, got ${JSON.stringify(legacy)}.`,
+            );
+          },
+          screenshot: {
+            name: "default-model-reconciled",
+            hashIncludes: "/session",
+          },
+        });
+      },
+    },
+
+    {
+      name: "Fresh sign-in lands on the org onboarding page",
+      run: async (ctx) => {
+        await ctx.prove("First sign-in routes to the org resources page", {
+          claim: "A fresh cloud sign-in routes to /onboarding, where the member sees their org's provider and models.",
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.eval(`(() => {
+              localStorage.setItem('openwork.den.baseUrl', 'http://127.0.0.1:${DEN_STUB_PORT}');
+              localStorage.setItem('openwork.den.authToken', 'eval-fake-token');
+              localStorage.setItem('openwork.den.activeOrgId', 'org_eval');
+              localStorage.setItem('openwork.den.activeOrgName', ${JSON.stringify(ORG_NAME)});
+              localStorage.removeItem('openwork.orgOnboardingSeen');
+              window.dispatchEvent(new CustomEvent('openwork-den-session-updated', { detail: { status: 'success' } }));
+              return true;
+            })()`);
+            await ctx.waitFor("location.hash.includes('/onboarding')", {
+              timeoutMs: 15_000,
+              label: "route to /onboarding after sign-in",
+            });
+            await ctx.waitForText(PROVIDER_NAME, { timeoutMs: 15_000 });
+          },
+          assert: async () => {
+            await ctx.expectHashIncludes("/onboarding");
+            await ctx.expectText(PROVIDER_NAME);
+          },
+          screenshot: {
+            name: "org-onboarding-page",
+            hashIncludes: "/onboarding",
+            requireText: [PROVIDER_NAME],
+          },
+        });
+      },
+    },
+
+    {
+      name: "Continuing past onboarding latches it: relaunch sign-ins stay on the session",
+      run: async (ctx) => {
+        await ctx.prove("Onboarding does not reappear after the member continues past it", {
+          claim: "The member picks a default model, continues to the workspace, and a refreshed sign-in (as on every relaunch) no longer routes back to /onboarding; the picked model is live in preferences.",
+          voiceover: vo[3],
+          action: async () => {
+            await ctx.clickText("Use as default", { timeoutMs: 5_000 });
+            await ctx.waitForText("will be set as your default model", { timeoutMs: 5_000 });
+            await ctx.clickText("Continue to workspace", { timeoutMs: 5_000 });
+            await ctx.waitFor("location.hash.includes('/session')", {
+              timeoutMs: 15_000,
+              label: "back on the session view",
+            });
+            // Simulate the relaunch-time refreshed sign-in that used to drag
+            // the member back to onboarding.
+            await ctx.eval(
+              "window.dispatchEvent(new CustomEvent('openwork-den-session-updated', { detail: { status: 'success' } })) ?? true",
+            );
+            await new Promise((resolve) => setTimeout(resolve, 3_000));
+          },
+          assert: async () => {
+            await ctx.expectHashIncludes("/session");
+            const seen = await ctx.eval("localStorage.getItem('openwork.orgOnboardingSeen')");
+            ctx.assert(seen === "1", `Expected the onboarding-seen latch to be set, got ${JSON.stringify(seen)}.`);
+            const defaultModel = await readPrefsDefaultModel(ctx);
+            ctx.assert(
+              defaultModel &&
+                defaultModel.providerID === UI_DEFAULT.providerID &&
+                defaultModel.modelID === UI_DEFAULT.modelID,
+              `Expected the UI-picked default ${UI_DEFAULT.providerID}/${UI_DEFAULT.modelID} in live preferences, got ${JSON.stringify(defaultModel)}.`,
+            );
+          },
+          screenshot: {
+            name: "session-after-continue",
+            hashIncludes: "/session",
+          },
+        });
+      },
+    },
+
+    {
+      name: "Active org policies raise a one-time notification",
+      run: async (ctx) => {
+        await ctx.prove("Policy notice appears in the notification bell", {
+          claim: "Applying an org desktop policy raises the 'Organization policies active' notification in the bell.",
+          voiceover: vo[4],
+          action: async () => {
+            await ctx.eval("window.__openworkApplyDesktopConfig({ brandAccentColor: 'grass' }) ?? true");
+            await ctx.waitFor(
+              `(() => {
+                try {
+                  const raw = localStorage.getItem('openwork:notifications:v1');
+                  const list = JSON.parse(raw ?? '{}')?.state?.notifications ?? [];
+                  return list.some((n) => n.dedupeKey === 'desktop-policy-active' && n.readAt === null);
+                } catch { return false; }
+              })()`,
+              { timeoutMs: 10_000, label: "desktop-policy-active notification in the store" },
+            );
+            await ctx.eval(`(() => {
+              const bell = document.querySelector('button[aria-label^="Notifications"]');
+              if (!bell) return false;
+              bell.click();
+              return true;
+            })()`);
+            await ctx.waitForText("Organization policies active", { timeoutMs: 5_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Organization policies active");
+          },
+          screenshot: {
+            name: "policy-notification",
+            requireText: ["Organization policies active"],
+          },
+        });
+      },
+    },
+
+    {
+      name: "Cleared policy notification stays cleared across a relaunch",
+      run: async (ctx) => {
+        await ctx.prove("Dismissing the policy notice is permanent", {
+          claim: "After 'Clear all' and a relaunch with the policy still active, the notification is not recreated and the bell shows no unread badge.",
+          voiceover: vo[5],
+          action: async () => {
+            await ctx.clickText("Clear all", { timeoutMs: 5_000 });
+            await ctx.eval("location.reload()");
+            await waitForControl(ctx);
+            // Give the policy-notification effect time to (wrongly) re-fire.
+            await new Promise((resolve) => setTimeout(resolve, 2_000));
+          },
+          assert: async () => {
+            const store = await ctx.eval(`(() => {
+              try {
+                const raw = localStorage.getItem('openwork:notifications:v1');
+                const state = JSON.parse(raw ?? '{}')?.state ?? {};
+                const list = state.notifications ?? [];
+                return {
+                  policyEntries: list.filter((n) => n.dedupeKey === 'desktop-policy-active').length,
+                  onceKeys: state.onceKeys ?? [],
+                };
+              } catch (error) { return { error: String(error) }; }
+            })()`);
+            ctx.log(`notification store after relaunch: ${JSON.stringify(store)}`);
+            ctx.assert(
+              store.policyEntries === 0,
+              `Expected no desktop-policy-active notification after clearing + relaunch, found ${store.policyEntries}.`,
+            );
+            ctx.assert(
+              Array.isArray(store.onceKeys) && store.onceKeys.includes("desktop-policy-active"),
+              "Expected the once-delivered latch to be persisted for desktop-policy-active.",
+            );
+            // Brand accent is still applied, so the policy really is active.
+            const accentActive = await ctx.eval(
+              "getComputedStyle(document.documentElement).getPropertyValue('--dls-accent').trim().length > 0",
+            );
+            ctx.assert(accentActive, "Expected the org policy (brand accent) to still be active after relaunch.");
+          },
+          screenshot: {
+            name: "policy-notification-stays-cleared",
+            rejectText: ["Organization policies active"],
+          },
+        });
+
+        // Leave the profile clean: reset the injected policy config.
+        await ctx.eval("window.__openworkApplyDesktopConfig({}) ?? true");
+        denStub?.close();
+        denStub = null;
+      },
+    },
+  ],
+};

--- a/evals/flows/onboarding-feedback-fixes.flow.mjs
+++ b/evals/flows/onboarding-feedback-fixes.flow.mjs
@@ -198,6 +198,19 @@ export default {
               timeoutMs: 15_000,
               label: "route to /onboarding after sign-in",
             });
+            // The page opens with an organization chooser before the
+            // resource list; confirm the (only) org.
+            const hasOrgChooser = await ctx.waitFor(
+              "document.body.innerText.includes('Continue with organization') || document.body.innerText.includes('Acme AI Gateway')",
+              { timeoutMs: 15_000, label: "org chooser or resource list" },
+            );
+            void hasOrgChooser;
+            const onChooser = await ctx.eval(
+              "document.body.innerText.includes('Continue with organization')",
+            );
+            if (onChooser) {
+              await ctx.clickText("Continue with organization", { timeoutMs: 5_000 });
+            }
             await ctx.waitForText(PROVIDER_NAME, { timeoutMs: 15_000 });
           },
           assert: async () => {

--- a/evals/flows/onboarding-feedback-fixes.flow.mjs
+++ b/evals/flows/onboarding-feedback-fixes.flow.mjs
@@ -211,7 +211,11 @@ export default {
             if (onChooser) {
               await ctx.clickText("Continue with organization", { timeoutMs: 5_000 });
             }
-            await ctx.waitForText(PROVIDER_NAME, { timeoutMs: 15_000 });
+            await ctx.waitForText("AI Providers", { timeoutMs: 15_000 });
+            // Expand the providers accordion so the org's provider card
+            // (with its "Use as default" affordance) is visible.
+            await ctx.clickText("AI Providers", { timeoutMs: 5_000 });
+            await ctx.waitForText(PROVIDER_NAME, { timeoutMs: 10_000 });
           },
           assert: async () => {
             await ctx.expectHashIncludes("/onboarding");

--- a/evals/voiceovers/onboarding-feedback-fixes.md
+++ b/evals/voiceovers/onboarding-feedback-fixes.md
@@ -1,0 +1,15 @@
+# onboarding-feedback-fixes — Onboarding choices stick across relaunches
+
+A member of a managed organization sets up OpenWork once and the app remembers it. This fraimz replays the reported Windows-onboarding feedback against the fixed app: the default model chosen during org onboarding survives a relaunch instead of falling back to a retired built-in model, the organization onboarding page shows only once, and the "Organization policies active" notice stays dismissed after the user clears it.
+
+1. OpenWork is open on the session view. This is the app a new organization member sees right after signing in and finishing setup.
+
+2. We recreate the reported bug state from before the fix: the member chose their organization's GLM model as default during onboarding, but the app's preferences still carried the retired built-in fallback model. After a relaunch, the app now reconciles the two and keeps the member's real choice — the preferences agree with the model they picked, and the retired fallback is gone.
+
+3. Signing in used to drag the member back to the organization onboarding page on every launch. Fresh sign-ins still land there once, so new members see what their organization provides.
+
+4. After the member has continued past onboarding once, a relaunch with a refreshed sign-in stays on the session view — the model selection page does not come back.
+
+5. Organization policies are active, so a one-time notice appears in the notification bell telling the member some settings are managed by their administrator.
+
+6. The member clears the notification. After a relaunch with the same policies still active, the notice stays cleared instead of reappearing — dismissing it means dismissed.


### PR DESCRIPTION
Fixes the managed-org onboarding feedback reported by Jonas (Windows SSO onboarding):

## Bugs fixed

1. **Chosen default model didn't stick ("wasn't GLM my default?" → big-pickle unavailable).**
   Org onboarding wrote the choice to the legacy `openwork.defaultModel` key, but the app reads `openwork.preferences.defaultModel`, which had been pre-filled with the hardcoded `opencode/big-pickle` fallback on first boot. Onboarding now writes both stores, the persist effect keeps them in sync, and `LocalProvider` reconciles on boot (explicit choice wins over the baked fallback) — which also migrates users already bitten.

2. **Model-selection/onboarding page reappeared on every launch.**
   `openwork.orgOnboardingSeen` was a dead latch (cleared but never set/read). Continuing past onboarding now sets it, and both sign-in routing paths (`DenSigninGate`, the `den-session-updated` handler) honor it: first sign-in still lands on `/onboarding`, relaunches stay on the session.

3. **"Subscribe to OpenWork Models" pitched to org-managed users.**
   `hasOpenWorkModelsProvider` now also counts org-managed (`lpr_*`) providers, suppressing the startup dialog, model-picker banner, and status-bar promo for members whose org provisions models.

4. **"Organization policies active" notification resurrected after clearing.**
   The producer re-fires on every launch and dedupe only matched unread entries. The notification store now supports `once` notifications (persisted `onceKeys`): delivered a single time ever, surviving `markAllRead` and `Clear all`.

5. **Windows installer "Launch" closed the installer but OpenWork never started.**
   `launchInstalledApp` spawned the app non-detached from the `--server-worker` child that gets killed milliseconds later. Now launches via `cmd /c start` (spawnSync so the handoff completes), verifies the installed path, and the UI shows launch failures instead of silently closing. Bun-compiled installer exes now embed the OpenWork icon (`--windows-icon`) instead of shipping the Bun icon.

## Not addressed here (needs infra decisions)

- **SmartScreen "unknown publisher"**: Windows code signing exists (SignPath) but is off by default in all release workflows (`SIGN_WINDOWS=false`, and hardcoded false for the auto-published generic installer). Flipping it is a release-owner decision.
- **Zip with two exes**: no repo code produces a Windows zip; the release page carries both `openwork-installer-win-x64.exe` (bootstrap) and `openwork-win-x64-<v>.exe` (NSIS), which someone likely zipped for distribution. The landing page asset picker (`ee/apps/landing/lib/github.ts`) matches both — worth a follow-up.
- **"JustWork" naming**: zero occurrences in this repo; likely an older packaged build.

## Testing

- `pnpm --filter @openwork/app typecheck` — pass
- `apps/app: bun test tests/` — 148 pass (new: `once` notification semantics, promo suppression)
- `apps/installer: bun test` — 25 pass (requires `pnpm --filter @openwork/install-config build` locally)
- **fraimz** (`onboarding-feedback-fixes`, run against real Electron in a Daytona sandbox with a stubbed Den org backend): all 6 frames pass — see comment below. Renderer-level `location.reload()` stands in for relaunch; the Windows installer launch path was not exercised on a real Windows machine.