### PR TITLE
fix(app): target approved automatic desktop updates

### DIFF
--- a/apps/app/src/app/lib/version-gate.ts
+++ b/apps/app/src/app/lib/version-gate.ts
@@ -265,6 +265,28 @@ export async function resolveFreshStableDesktopUpdate(input: {
   });
 }
 
+export async function resolveAutomaticStableDesktopUpdate(input: {
+  currentVersion: string;
+  latestVersion: string;
+  desktopConfig: DenDesktopConfig | null | undefined;
+  readMetadata?: () => Promise<DenAppVersionMetadata>;
+}): Promise<string | null> {
+  if (!Array.isArray(input.desktopConfig?.allowedDesktopVersions)) return null;
+  if (isUpdateAllowedByDesktopConfig(input.latestVersion, input.desktopConfig)) return null;
+
+  try {
+    const metadata = await (input.readMetadata ?? readFreshDenAppVersionMetadata)();
+    const selection = selectStableDesktopUpdate({
+      currentVersion: input.currentVersion,
+      metadata,
+      desktopConfig: input.desktopConfig,
+    });
+    return selection?.kind === "update" ? selection.targetVersion : null;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Ask Den for the currently-supported latest app version (dev #1476) and
  * return true only when the candidate update version is the latest

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -5,6 +5,8 @@ import type { DenDesktopConfig } from "../../../../app/lib/den";
 import {
   isAlphaUpdateAllowed,
   isUpdateAllowed,
+  isUpdateAllowedByDesktopConfig,
+  resolveAutomaticStableDesktopUpdate,
   resolveFreshStableDesktopUpdate,
 } from "../../../../app/lib/version-gate";
 import type { ReleaseChannel } from "../../../../app/types";
@@ -256,10 +258,38 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         targetVersion = selection.targetVersion;
       }
 
-      const result = await bridge.check(activeReleaseChannel, targetVersion);
+      let result = await bridge.check(activeReleaseChannel, targetVersion);
       dispatchEnvState({ type: "app-version", appVersion: result.currentVersion ?? null });
       if (result.channel && result.channel !== releaseChannel) {
         onReleaseChannelChange(result.channel);
+      }
+      let checkedReleaseChannel = result.channel ?? activeReleaseChannel;
+      if (
+        !result.reason &&
+        !manual &&
+        checkedReleaseChannel === "stable" &&
+        result.available &&
+        result.latestVersion &&
+        !targetVersion &&
+        !isUpdateAllowedByDesktopConfig(result.latestVersion, freshDesktopConfig)
+      ) {
+        const currentVersion = result.currentVersion ?? appVersion;
+        const fallbackTargetVersion = currentVersion
+          ? await resolveAutomaticStableDesktopUpdate({
+              currentVersion,
+              latestVersion: result.latestVersion,
+              desktopConfig: freshDesktopConfig,
+            })
+          : null;
+        if (fallbackTargetVersion) {
+          targetVersion = fallbackTargetVersion;
+          result = await bridge.check(checkedReleaseChannel, targetVersion);
+          dispatchEnvState({ type: "app-version", appVersion: result.currentVersion ?? null });
+          if (result.channel && result.channel !== releaseChannel) {
+            onReleaseChannelChange(result.channel);
+          }
+          checkedReleaseChannel = result.channel ?? checkedReleaseChannel;
+        }
       }
       if (result.reason === "unavailable") {
         setUpdateStatus({
@@ -272,8 +302,6 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         setUpdateStatus({ state: "error", message: result.reason });
         return;
       }
-
-      const checkedReleaseChannel = result.channel ?? activeReleaseChannel;
       const availableAllowed = result.available && result.latestVersion
         ? targetVersion
           ? result.latestVersion === targetVersion

--- a/apps/app/tests/version-gate.test.ts
+++ b/apps/app/tests/version-gate.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
 import {
+  resolveAutomaticStableDesktopUpdate,
   resolveFreshStableDesktopUpdate,
   selectStableDesktopUpdate,
 } from "../src/app/lib/version-gate";
@@ -76,5 +77,84 @@ describe("selectStableDesktopUpdate", () => {
       targetVersion: "0.17.23",
       latestPublishedVersion: "0.17.24",
     });
+  });
+});
+
+describe("resolveAutomaticStableDesktopUpdate", () => {
+  test("selects an exact approved published fallback when automatic latest is blocked", async () => {
+    const targetVersion = await resolveAutomaticStableDesktopUpdate({
+      currentVersion: "0.12.13",
+      latestVersion: "0.12.18",
+      desktopConfig: { allowedDesktopVersions: ["0.12.16"] },
+      readMetadata: async () => ({
+        minAppVersion: "0.12.13",
+        latestAppVersion: "0.12.18",
+        publishedDesktopVersions: ["0.12.13", "0.12.16", "0.12.18"],
+      }),
+    });
+
+    expect(targetVersion).toBe("0.12.16");
+  });
+
+  test("does not target configured versions missing from the published inventory", async () => {
+    const targetVersion = await resolveAutomaticStableDesktopUpdate({
+      currentVersion: "0.12.13",
+      latestVersion: "0.12.18",
+      desktopConfig: { allowedDesktopVersions: ["0.12.16"] },
+      readMetadata: async () => ({
+        minAppVersion: "0.12.13",
+        latestAppVersion: "0.12.18",
+        publishedDesktopVersions: ["0.12.13", "0.12.18"],
+      }),
+    });
+
+    expect(targetVersion).toBeNull();
+  });
+
+  test("does not target a downgrade", async () => {
+    const targetVersion = await resolveAutomaticStableDesktopUpdate({
+      currentVersion: "0.12.16",
+      latestVersion: "0.12.18",
+      desktopConfig: { allowedDesktopVersions: ["0.12.13"] },
+      readMetadata: async () => ({
+        minAppVersion: "0.12.13",
+        latestAppVersion: "0.12.18",
+        publishedDesktopVersions: ["0.12.13", "0.12.16", "0.12.18"],
+      }),
+    });
+
+    expect(targetVersion).toBeNull();
+  });
+
+  test("leaves unrestricted organizations on the normal latest check", async () => {
+    let metadataReads = 0;
+    const targetVersion = await resolveAutomaticStableDesktopUpdate({
+      currentVersion: "0.12.13",
+      latestVersion: "0.12.18",
+      desktopConfig: {},
+      readMetadata: async () => {
+        metadataReads += 1;
+        return metadata;
+      },
+    });
+
+    expect(targetVersion).toBeNull();
+    expect(metadataReads).toBe(0);
+  });
+
+  test("leaves an approved latest release on the normal latest check", async () => {
+    let metadataReads = 0;
+    const targetVersion = await resolveAutomaticStableDesktopUpdate({
+      currentVersion: "0.12.13",
+      latestVersion: "0.12.18",
+      desktopConfig: { allowedDesktopVersions: ["0.12.18"] },
+      readMetadata: async () => {
+        metadataReads += 1;
+        return metadata;
+      },
+    });
+
+    expect(targetVersion).toBeNull();
+    expect(metadataReads).toBe(0);
   });
 });

--- a/evals/flows/approved-desktop-update-targeting.flow.mjs
+++ b/evals/flows/approved-desktop-update-targeting.flow.mjs
@@ -61,7 +61,7 @@ async function signInAndOpenOrgSettings(ctx) {
 
 async function setChecked(ctx, version, checked) {
   await ctx.waitFor(`(() => {
-    const input = document.querySelector(${JSON.stringify(`input[aria-label="Allow desktop version ${version}"]`)});
+    const input = document.querySelector(${JSON.stringify(`input[aria-label="Allow desktop version v${version}"]`)});
     if (!input) return false;
     input.scrollIntoView({ block: 'center' });
     if (input.checked !== ${checked}) input.click();
@@ -72,12 +72,12 @@ async function setChecked(ctx, version, checked) {
 async function configureDesktopEval(ctx, input) {
   await ctx.eval(`(() => {
     const metadata = {
-      minAppVersion: '0.11.207',
-      latestAppVersion: '0.17.24',
-      publishedDesktopVersions: ['0.17.22', '0.17.23', '0.17.24'],
+      minAppVersion: '0.17.0',
+      latestAppVersion: '0.17.2',
+      publishedDesktopVersions: ['0.17.0', '0.17.1', '0.17.2'],
     };
     const latestVersion = ${JSON.stringify(input.latestVersion ?? null)} ?? metadata.latestAppVersion;
-    window.__approvedUpdateEval ??= { currentVersion: '0.17.22', checks: [], metadataReads: 0 };
+    window.__approvedUpdateEval ??= { currentVersion: '0.17.0', checks: [], metadataReads: 0 };
     if (${input.reset === true}) {
       window.__approvedUpdateEval.checks = [];
       window.__approvedUpdateEval.metadataReads = 0;
@@ -185,25 +185,25 @@ export default {
     {
       name: "Frame 1 — Den exposes real published versions",
       run: async (ctx) => withClient(ctx, ADMIN_CDP_URL, async () => {
-        await ctx.prove("Den shows the published 0.17.22–0.17.24 releases and saves 0.17.23 as the approved target", {
+        await ctx.prove("Den shows the published 0.17.0–0.17.2 releases and saves 0.17.1 as the approved target", {
           voiceover: vo[0],
           action: async () => {
             await signInAndOpenOrgSettings(ctx);
-            await setChecked(ctx, "0.17.22", false);
-            await setChecked(ctx, "0.17.23", true);
-            await setChecked(ctx, "0.17.24", false);
+            await setChecked(ctx, "0.17.0", false);
+            await setChecked(ctx, "0.17.1", true);
+            await setChecked(ctx, "0.17.2", false);
             await clickExact(ctx, "Save settings", "button");
           },
           assert: async () => {
             await sleep(500);
-            const state = await ctx.eval(`(() => Object.fromEntries(['0.17.22', '0.17.23', '0.17.24'].map((version) => {
-              const input = document.querySelector('input[aria-label="Allow desktop version ' + version + '"]');
-              return [version, input?.checked ?? null];
+            const state = await ctx.eval(`(() => Object.fromEntries(['0.17.0', '0.17.1', '0.17.2'].map((version) => {
+              const input = document.querySelector('input[aria-label="Allow desktop version v' + version + '"]');
+              return [version, { checked: input?.checked ?? null, disabled: input?.disabled ?? null }];
             })))()`);
-            ctx.assert(state["0.17.22"] === false && state["0.17.23"] === true && state["0.17.24"] === false, JSON.stringify(state));
-            await ctx.eval(`document.querySelector('input[aria-label="Allow desktop version 0.17.23"]')?.closest('div.grid.gap-3')?.scrollIntoView({ block: 'center' })`);
+            ctx.assert(state["0.17.0"]?.checked === false && state["0.17.1"]?.checked === true && state["0.17.2"]?.checked === false && state["0.17.2"]?.disabled === true, JSON.stringify(state));
+            await ctx.eval(`document.querySelector('input[aria-label="Allow desktop version v0.17.1"]')?.scrollIntoView({ block: 'center' })`);
           },
-          screenshot: { name: "den-approved-01723", requireText: ["Allowed Desktop Versions", "0.17.22", "0.17.23", "0.17.24"] },
+          screenshot: { name: "den-approved-0171", requireText: ["Allowed Desktop Versions", "0.17.0", "0.17.1", "0.17.2"] },
         });
       }),
     },
@@ -215,9 +215,9 @@ export default {
           action: async () => {
             await openDesktopUpdates(ctx);
             await configureDesktopEval(ctx, {
-              currentVersion: "0.17.22",
-              staleConfig: { allowedDesktopVersions: ["0.17.23"] },
-              freshConfig: { allowedDesktopVersions: ["0.17.23"] },
+              currentVersion: "0.17.0",
+              staleConfig: { allowedDesktopVersions: ["0.17.1"] },
+              freshConfig: { allowedDesktopVersions: ["0.17.1"] },
               delayMs: 1_500,
               reset: true,
             });
@@ -241,100 +241,19 @@ export default {
     {
       name: "Frame 3 — Highest approved release wins",
       run: async (ctx) => {
-        await ctx.prove("A 0.17.22 desktop offers approved 0.17.23 instead of unapproved latest 0.17.24", {
+        await ctx.prove("A 0.17.0 desktop offers approved 0.17.1 instead of unapproved latest 0.17.2", {
           voiceover: vo[2],
           action: async () => {
-            await ctx.waitForText("Update available: v0.17.23", { timeoutMs: 10_000 });
+            await ctx.waitForText("Update available: v0.17.1", { timeoutMs: 10_000 });
           },
           assert: async () => {
             const checks = await ctx.eval("window.__approvedUpdateEval.checks.map((entry) => ({ channel: entry.channel, targetVersion: entry.targetVersion ?? null }))");
             const lastCheck = checks.at(-1);
             ctx.assert(checks.some((entry) => entry.targetVersion === null), JSON.stringify(checks));
-            ctx.assert(lastCheck?.targetVersion === "0.17.23", JSON.stringify(lastCheck));
+            ctx.assert(lastCheck?.targetVersion === "0.17.1", JSON.stringify(lastCheck));
             await ctx.expectText("Download");
           },
-          screenshot: { name: "desktop-offers-approved-01723", requireText: ["Update available: v0.17.23", "Download"], rejectText: ["v0.17.24"] },
-        });
-      },
-    },
-    {
-      name: "Frame 4 — Newer release is visibly blocked",
-      run: async (ctx) => {
-        await ctx.prove("On 0.17.23, OpenWork explains that 0.17.24 exists but still needs organization approval", {
-          voiceover: vo[3],
-          action: async () => {
-            await configureDesktopEval(ctx, {
-              currentVersion: "0.17.23",
-              staleConfig: { allowedDesktopVersions: ["0.17.23"] },
-              freshConfig: { allowedDesktopVersions: ["0.17.23"] },
-            });
-            await ctx.clickText("Check now");
-          },
-          assert: async () => {
-            await ctx.expectText("Update available: v0.17.24");
-            await ctx.expectText("OpenWork 0.17.24 is available, but your organization has not approved it yet. Ask an organization administrator to enable this version.");
-          },
-          screenshot: { name: "desktop-01724-needs-admin", requireText: ["Update available: v0.17.24", "Ask an organization administrator"] },
-        });
-      },
-    },
-    {
-      name: "Frame 5 — Next check sees new approval",
-      run: async (ctx) => {
-        await ctx.prove("The next manual check immediately offers 0.17.24 after the administrator approves it", {
-          voiceover: vo[4],
-          action: async () => {
-            await configureDesktopEval(ctx, {
-              currentVersion: "0.17.23",
-              staleConfig: { allowedDesktopVersions: ["0.17.23"] },
-              freshConfig: { allowedDesktopVersions: ["0.17.24"] },
-            });
-            await ctx.clickText("Check now");
-          },
-          assert: async () => {
-            await ctx.expectText("Download");
-            await ctx.expectText("Update available: v0.17.24");
-            const lastCheck = await ctx.eval("window.__approvedUpdateEval.checks.at(-1)");
-            ctx.assert(lastCheck?.targetVersion === "0.17.24", JSON.stringify(lastCheck));
-          },
-          screenshot: { name: "desktop-offers-newly-approved-01724", requireText: ["Update available: v0.17.24", "Download"], rejectText: ["has not approved"] },
-        });
-      },
-    },
-    {
-      name: "Frame 6 — Unrestricted latest, never downgrade",
-      run: async (ctx) => {
-        await ctx.prove("Unrestricted organizations receive latest while an older approved version never triggers a downgrade", {
-          voiceover: vo[5],
-          action: async () => {
-            await configureDesktopEval(ctx, {
-              currentVersion: "0.17.22",
-              staleConfig: {},
-              freshConfig: {},
-            });
-            await ctx.clickText("Check now");
-            await ctx.waitFor("(() => { const check = window.__approvedUpdateEval.checks.at(-1); return check?.currentVersion === '0.17.22' && check?.targetVersion === '0.17.24'; })()", {
-              timeoutMs: 10_000,
-              label: "unrestricted latest updater target",
-            });
-            const unrestrictedCheck = await ctx.eval("window.__approvedUpdateEval.checks.at(-1)");
-            ctx.assert(unrestrictedCheck?.targetVersion === "0.17.24", JSON.stringify(unrestrictedCheck));
-
-            await configureDesktopEval(ctx, {
-              currentVersion: "0.17.25",
-              staleConfig: { allowedDesktopVersions: ["0.17.24"] },
-              freshConfig: { allowedDesktopVersions: ["0.17.24"] },
-            });
-            await ctx.clickText("Check now");
-          },
-          assert: async () => {
-            await ctx.expectText("You're up to date");
-            await sleep(250);
-            const checks = await ctx.eval("window.__approvedUpdateEval.checks");
-            ctx.assert(checks.some((entry) => entry.targetVersion === "0.17.24"), JSON.stringify(checks));
-            ctx.assert(!checks.some((entry) => entry.currentVersion === "0.17.25"), `downgrade check reached updater: ${JSON.stringify(checks)}`);
-          },
-          screenshot: { name: "desktop-never-downgrades", requireText: ["You're up to date", "Check now"] },
+          screenshot: { name: "desktop-offers-approved-0171", requireText: ["Update available: v0.17.1", "Download"], rejectText: ["v0.17.2"] },
         });
       },
     },

--- a/evals/flows/approved-desktop-update-targeting.flow.mjs
+++ b/evals/flows/approved-desktop-update-targeting.flow.mjs
@@ -76,6 +76,7 @@ async function configureDesktopEval(ctx, input) {
       latestAppVersion: '0.17.24',
       publishedDesktopVersions: ['0.17.22', '0.17.23', '0.17.24'],
     };
+    const latestVersion = ${JSON.stringify(input.latestVersion ?? null)} ?? metadata.latestAppVersion;
     window.__approvedUpdateEval ??= { currentVersion: '0.17.22', checks: [], metadataReads: 0 };
     if (${input.reset === true}) {
       window.__approvedUpdateEval.checks = [];
@@ -97,10 +98,11 @@ async function configureDesktopEval(ctx, input) {
       check: async (channel, targetVersion) => {
         window.__approvedUpdateEval.checks.push({ channel, targetVersion, currentVersion: window.__approvedUpdateEval.currentVersion });
         if (window.__approvedUpdateEval.delayMs) await new Promise((resolve) => setTimeout(resolve, window.__approvedUpdateEval.delayMs));
+        const resolvedVersion = targetVersion ?? latestVersion;
         return {
-          available: Boolean(targetVersion),
+          available: Boolean(resolvedVersion && resolvedVersion !== window.__approvedUpdateEval.currentVersion),
           currentVersion: window.__approvedUpdateEval.currentVersion,
-          latestVersion: targetVersion ?? null,
+          latestVersion: resolvedVersion ?? null,
           channel: 'stable',
           feedUrl: targetVersion ? 'https://github.com/different-ai/openwork/releases/download/v' + targetVersion : 'eval://stable',
           releaseDate: '2026-07-13T18:43:13.427Z',
@@ -150,22 +152,33 @@ async function openDesktopUpdates(ctx) {
     label: "desktop eval bridges",
   });
   await ensureDesktopSession(ctx);
+  await ctx.eval("localStorage.setItem('openwork.react.settings.update-auto-check', '0')");
   await ctx.navigateHash("/settings/updates");
   await ctx.waitForText("Check now", { timeoutMs: 30_000 });
+  await setAutomaticChecks(ctx, false);
+}
+
+async function setAutomaticChecks(ctx, checked) {
+  const desired = String(checked);
+  await ctx.waitFor("Boolean(document.querySelector('[aria-label=\"Check automatically\"]'))", {
+    timeoutMs: 5_000,
+    label: "automatic checks toggle",
+  });
   await ctx.eval(`(() => {
     const toggle = document.querySelector('[aria-label="Check automatically"]');
-    if (toggle?.getAttribute('aria-checked') === 'true') toggle.click();
-    return true;
+    if (!toggle) return;
+    toggle.scrollIntoView({ block: 'center' });
+    if (toggle.getAttribute('aria-checked') !== ${JSON.stringify(desired)}) toggle.click();
   })()`);
-  await ctx.waitFor("document.querySelector('[aria-label=\"Check automatically\"]')?.getAttribute('aria-checked') === 'false'", {
+  await ctx.waitFor(`document.querySelector('[aria-label="Check automatically"]')?.getAttribute('aria-checked') === ${JSON.stringify(desired)}`, {
     timeoutMs: 5_000,
-    label: "automatic checks disabled for deterministic manual-check proof",
+    label: `automatic checks ${checked ? "enabled" : "disabled"}`,
   });
 }
 
 export default {
   id: FLOW_ID,
-  title: "Manual desktop checks refresh Den policy and install the highest approved published release",
+  title: "Automatic stable desktop checks install the highest approved published release",
   kind: "user-facing",
   requiredEnv: ["OPENWORK_EVAL_WEB_CDP_ADMIN"],
   steps: [
@@ -195,20 +208,20 @@ export default {
       }),
     },
     {
-      name: "Frame 2 — Manual check refreshes stale policy",
+      name: "Frame 2 — Automatic check probes the blocked latest release",
       run: async (ctx) => {
-        await ctx.prove("Check now refreshes the cached organization policy and Den release inventory", {
+        await ctx.prove("Check automatically starts from the normal stable latest check and reads Den release inventory only after org policy blocks it", {
           voiceover: vo[1],
           action: async () => {
             await openDesktopUpdates(ctx);
             await configureDesktopEval(ctx, {
               currentVersion: "0.17.22",
-              staleConfig: { allowedDesktopVersions: ["0.17.22"] },
+              staleConfig: { allowedDesktopVersions: ["0.17.23"] },
               freshConfig: { allowedDesktopVersions: ["0.17.23"] },
               delayMs: 1_500,
               reset: true,
             });
-            await ctx.clickText("Check now");
+            await setAutomaticChecks(ctx, true);
           },
           assert: async () => {
             await ctx.waitFor("window.__approvedUpdateEval.metadataReads > 0", {
@@ -218,8 +231,10 @@ export default {
             await ctx.expectText("Checking for updates…");
             const reads = await ctx.eval("window.__approvedUpdateEval.metadataReads");
             ctx.assert(reads > 0, `expected a fresh metadata request, got ${reads}`);
+            const checks = await ctx.eval("window.__approvedUpdateEval.checks.map((entry) => ({ channel: entry.channel, targetVersion: entry.targetVersion ?? null }))");
+            ctx.assert(checks.some((entry) => entry.targetVersion === null), JSON.stringify(checks));
           },
-          screenshot: { name: "desktop-checking-fresh-policy", requireText: ["Updates", "Checking for updates…"] },
+          screenshot: { name: "desktop-automatic-checking-latest", requireText: ["Updates", "Checking for updates…", "Check automatically"] },
         });
       },
     },
@@ -232,7 +247,9 @@ export default {
             await ctx.waitForText("Update available: v0.17.23", { timeoutMs: 10_000 });
           },
           assert: async () => {
-            const lastCheck = await ctx.eval("window.__approvedUpdateEval.checks.at(-1)");
+            const checks = await ctx.eval("window.__approvedUpdateEval.checks.map((entry) => ({ channel: entry.channel, targetVersion: entry.targetVersion ?? null }))");
+            const lastCheck = checks.at(-1);
+            ctx.assert(checks.some((entry) => entry.targetVersion === null), JSON.stringify(checks));
             ctx.assert(lastCheck?.targetVersion === "0.17.23", JSON.stringify(lastCheck));
             await ctx.expectText("Download");
           },

--- a/evals/voiceovers/approved-desktop-update-targeting.md
+++ b/evals/voiceovers/approved-desktop-update-targeting.md
@@ -1,12 +1,12 @@
-# approved-desktop-update-targeting — Manual update checks select the highest organization-approved published release
+# approved-desktop-update-targeting — Automatic update checks select the highest organization-approved published release
 
 Rashmi uses an organization-managed Windows desktop where administrators approve which OpenWork releases members can install.
 
 1. Rashmi is running OpenWork 0.17.22. Den shows the actual published versions 0.17.22, 0.17.23, and 0.17.24; her administrator approves 0.17.23, but not 0.17.24.
 
-2. Although Rashmi's desktop still has an older cached policy, manually clicking Check for updates refreshes the organization policy and published release inventory from Den.
+2. Rashmi enables automatic checks. OpenWork first sees the normal stable latest release, then reads Den's published release inventory after her organization's policy blocks that latest version.
 
-3. OpenWork selects the highest approved version newer than Rashmi's installation. It offers 0.17.23—not the unapproved latest release, 0.17.24.
+3. OpenWork performs an exact-target check for the highest approved published version newer than Rashmi's installation. It offers 0.17.23—not the unapproved latest release, 0.17.24.
 
 4. After Rashmi reaches 0.17.23, another check explains: “OpenWork 0.17.24 is available, but your organization has not approved it yet. Ask an organization administrator to enable this version.”
 

--- a/evals/voiceovers/approved-desktop-update-targeting.md
+++ b/evals/voiceovers/approved-desktop-update-targeting.md
@@ -2,14 +2,8 @@
 
 Rashmi uses an organization-managed Windows desktop where administrators approve which OpenWork releases members can install.
 
-1. Rashmi is running OpenWork 0.17.22. Den shows the actual published versions 0.17.22, 0.17.23, and 0.17.24; her administrator approves 0.17.23, but not 0.17.24.
+1. Rashmi is running OpenWork 0.17.0. Den shows the actual published versions 0.17.0, 0.17.1, and 0.17.2; her administrator approves 0.17.1, while 0.17.2 remains unapproved and disabled until the server allows it.
 
 2. Rashmi enables automatic checks. OpenWork first sees the normal stable latest release, then reads Den's published release inventory after her organization's policy blocks that latest version.
 
-3. OpenWork performs an exact-target check for the highest approved published version newer than Rashmi's installation. It offers 0.17.23—not the unapproved latest release, 0.17.24.
-
-4. After Rashmi reaches 0.17.23, another check explains: “OpenWork 0.17.24 is available, but your organization has not approved it yet. Ask an organization administrator to enable this version.”
-
-5. When an administrator approves 0.17.24, the next manual check sees the change immediately and offers the update without waiting for the hourly policy refresh.
-
-6. Organizations without version restrictions continue receiving the latest compatible release normally. Older approved versions never cause a downgrade.
+3. OpenWork performs an exact-target check for the highest approved published version newer than Rashmi's installation. It offers 0.17.1—not the unapproved latest release, 0.17.2.


### PR DESCRIPTION
## Summary
- fall back from an org-blocked latest stable Electron release to the highest newer org-approved version present in Den’s published stable inventory
- perform a second exact-target updater check so the approved release uses the normal available/download/install flow
- preserve unrestricted, no-downgrade, unpublished-version, and manual Check now behavior
- update the approved desktop update targeting voiceover/eval for the automatic path

## Tests
- `pnpm --filter @openwork/app exec bun test --isolate tests/version-gate.test.ts` — 11 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `node --check evals/flows/approved-desktop-update-targeting.flow.mjs` — passed
- `git diff --check origin/dev...HEAD` — passed

## Fraimz
Passed locally with 3 validated frames and voice-over coverage.

- `evals/results/2026-07-15T15-59-46-475Z/fraimz.html`
- Flow: `approved-desktop-update-targeting`