### PR TITLE
feat(helm): support custom CA bundles

### DIFF
--- a/.github/workflows/publish-ee-images.yml
+++ b/.github/workflows/publish-ee-images.yml
@@ -93,6 +93,12 @@ jobs:
       - name: Render chart
         run: helm template openwork-ee packaging/helm/openwork-ee --set ingress.enabled=true --set inference.enabled=true
 
+      - name: Run chart tests
+        run: |
+          for test in packaging/helm/openwork-ee/tests/*.sh; do
+            bash "$test"
+          done
+
       - name: Package chart
         if: ${{ needs.artifact-version.outputs.chart_version != '' }}
         run: |

--- a/evals/flows/helm-custom-ca.flow.mjs
+++ b/evals/flows/helm-custom-ca.flow.mjs
@@ -1,0 +1,273 @@
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/helm-custom-ca.md).
+// The runner fails this flow if the narration drifts from that script.
+const FLOW_ID = "helm-custom-ca";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CHART = join(ROOT, "packaging", "helm", "openwork-ee");
+const MYSQL_TLS_TEST = join(CHART, "tests", "custom-ca-mysql-tls.mjs");
+const CUSTOM_CA_PATH = "/etc/openwork/custom-ca/ca-bundle.pem";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function run(command, args) {
+  return spawnSync(command, args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 300_000,
+    maxBuffer: 10 * 1024 * 1024,
+  });
+}
+
+function helmTemplate(args) {
+  return run("helm", ["template", "openwork-ee", CHART, ...args]);
+}
+
+function countOccurrences(text, needle) {
+  return text.split(needle).length - 1;
+}
+
+function selectedLines(text, needles) {
+  return text
+    .split("\n")
+    .filter((line) => needles.some((needle) => line.includes(needle)))
+    .join("\n");
+}
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, assertion);
+}
+
+function failureSummary(results) {
+  return results
+    .map((result) => `${result.name}: status=${result.status}\n${result.stderr.trim()}`)
+    .join("\n\n");
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Helm custom CA support reaches every Node workload without changing defaults",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        let rendered = "";
+        const valuesSnippet = `customCa:
+  enabled: true
+  existingSecret: openwork-ca-secret
+  existingConfigMap: ""
+  key: corp-root.pem`;
+        await ctx.prove("Operators reference an existing CA Secret without embedding PEM material in Helm values", {
+          voiceover: vo[0],
+          action: async () => {
+            const result = helmTemplate([
+              "--set",
+              "customCa.enabled=true",
+              "--set",
+              "customCa.existingSecret=openwork-ca-secret",
+              "--set",
+              "customCa.key=corp-root.pem",
+            ]);
+            witness(ctx, result.status === 0, "helm template succeeds with a Secret-backed custom CA", result.stderr.trim());
+            rendered = result.stdout;
+          },
+          assert: async () => {
+            witness(ctx, rendered.includes('secretName: "openwork-ca-secret"'), "The rendered volume references the existing Secret by name");
+            witness(ctx, rendered.includes('key: "corp-root.pem"'), "The rendered volume selects the configured Secret key");
+            witness(ctx, !valuesSnippet.includes("-----BEGIN CERTIFICATE-----"), "The values snippet contains no PEM certificate material");
+            ctx.output("Secret-backed values", valuesSnippet);
+            ctx.output(
+              "Rendered Secret source",
+              selectedLines(rendered, ["custom-ca", "secretName", "corp-root.pem", "ca-bundle.pem"]),
+            );
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        let rendered = "";
+        await ctx.prove("The selected CA key is mounted read-only into every Helm-managed Node workload", {
+          voiceover: vo[1],
+          action: async () => {
+            const result = helmTemplate([
+              "--set",
+              "inference.enabled=true",
+              "--set",
+              "customCa.enabled=true",
+              "--set",
+              "customCa.existingSecret=openwork-ca-secret",
+            ]);
+            witness(ctx, result.status === 0, "helm template succeeds with inference enabled", result.stderr.trim());
+            rendered = result.stdout;
+          },
+          assert: async () => {
+            witness(ctx, rendered.includes("name: openwork-ee-den-api"), "Den API renders");
+            witness(ctx, rendered.includes("name: openwork-ee-den-web"), "Den Web renders");
+            witness(ctx, rendered.includes("name: openwork-ee-inference"), "Inference renders when enabled");
+            witness(ctx, rendered.includes("name: openwork-ee-migrate"), "The migration Job renders");
+            witness(ctx, countOccurrences(rendered, 'mountPath: "/etc/openwork/custom-ca"') === 4, "All four workloads mount the chart-controlled CA directory");
+            witness(ctx, countOccurrences(rendered, "readOnly: true") >= 4, "The custom CA mount is read-only in every workload");
+            witness(ctx, countOccurrences(rendered, "path: ca-bundle.pem") === 4, "Only the selected key is projected to ca-bundle.pem");
+            witness(ctx, !rendered.includes("subPath:"), "The custom CA mount does not use subPath");
+            ctx.output(
+              "Rendered read-only mounts",
+              selectedLines(rendered, ["openwork-ee-den-api", "openwork-ee-den-web", "openwork-ee-inference", "openwork-ee-migrate", "custom-ca", "mountPath", "readOnly", "ca-bundle.pem", "subPath"]),
+            );
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        let rendered = "";
+        await ctx.prove("Every rendered Node workload receives NODE_EXTRA_CA_CERTS pointing at the mounted CA file", {
+          voiceover: vo[2],
+          action: async () => {
+            const result = helmTemplate([
+              "--set",
+              "inference.enabled=true",
+              "--set",
+              "customCa.enabled=true",
+              "--set",
+              "customCa.existingConfigMap=openwork-ca-config",
+            ]);
+            witness(ctx, result.status === 0, "helm template succeeds with a ConfigMap-backed custom CA", result.stderr.trim());
+            rendered = result.stdout;
+          },
+          assert: async () => {
+            witness(ctx, countOccurrences(rendered, "name: NODE_EXTRA_CA_CERTS") === 4, "All four Node workloads receive NODE_EXTRA_CA_CERTS");
+            witness(ctx, countOccurrences(rendered, `value: "${CUSTOM_CA_PATH}"`) === 4, "NODE_EXTRA_CA_CERTS uses the chart-controlled file path");
+            witness(ctx, rendered.includes('name: "openwork-ca-config"'), "The ConfigMap source is rendered when selected");
+            ctx.output(
+              "Rendered NODE_EXTRA_CA_CERTS",
+              selectedLines(rendered, ["NODE_EXTRA_CA_CERTS", CUSTOM_CA_PATH, "openwork-ca-config"]),
+            );
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        let output = "";
+        await ctx.prove("The actual migration bootstrap and an OpenWork/mysql2 query connect to a strict-TLS MySQL endpoint signed by the private CA", {
+          voiceover: vo[3],
+          action: async () => {
+            const result = run("node", [MYSQL_TLS_TEST]);
+            output = `${result.stdout}\n${result.stderr}`.trim();
+            witness(ctx, result.status === 0, "The MySQL TLS integration test exits successfully", output);
+          },
+          assert: async () => {
+            witness(ctx, output.includes("Generated private CA and MySQL server certificate"), "The test generates the private CA and matching MySQL server certificate");
+            witness(ctx, output.includes("Strict OpenWork/mysql2 without custom CA: rejected"), "Strict OpenWork/mysql2 connection fails without the custom CA");
+            witness(ctx, output.includes("OpenWork migration bootstrap completed with NODE_EXTRA_CA_CERTS and strict DATABASE_URL"), "The actual OpenWork migration bootstrap completes with the mounted custom CA");
+            witness(ctx, output.includes("OpenWork/mysql2 strict query succeeded after migration"), "OpenWork/mysql2 connects successfully after migration using strict TLS");
+            ctx.output("MySQL TLS integration evidence", output);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        const failures = [];
+        await ctx.prove("Invalid custom CA states and environment conflicts fail during Helm rendering with clear errors", {
+          voiceover: vo[4],
+          action: async () => {
+            const cases = [
+              {
+                name: "missing source",
+                args: ["--set", "customCa.enabled=true"],
+                message: "customCa.existingSecret or customCa.existingConfigMap is required when customCa.enabled=true",
+              },
+              {
+                name: "multiple sources",
+                args: ["--set", "customCa.enabled=true", "--set", "customCa.existingSecret=openwork-ca-secret", "--set", "customCa.existingConfigMap=openwork-ca-config"],
+                message: "customCa.existingSecret and customCa.existingConfigMap are mutually exclusive when customCa.enabled=true",
+              },
+              {
+                name: "empty key",
+                args: ["--set", "customCa.enabled=true", "--set", "customCa.existingSecret=openwork-ca-secret", "--set-string", "customCa.key="],
+                message: "customCa.key is required when customCa.enabled=true",
+              },
+              {
+                name: "Den API env conflict",
+                args: ["--set", "customCa.enabled=true", "--set", "customCa.existingSecret=openwork-ca-secret", "--set", "denApi.env.NODE_EXTRA_CA_CERTS=/tmp/ca.pem"],
+                message: "denApi.env.NODE_EXTRA_CA_CERTS conflicts with customCa.enabled=true; remove it and use customCa instead",
+              },
+              {
+                name: "Den Web env conflict",
+                args: ["--set", "customCa.enabled=true", "--set", "customCa.existingSecret=openwork-ca-secret", "--set", "denWeb.env.NODE_EXTRA_CA_CERTS=/tmp/ca.pem"],
+                message: "denWeb.env.NODE_EXTRA_CA_CERTS conflicts with customCa.enabled=true; remove it and use customCa instead",
+              },
+              {
+                name: "inference env conflict",
+                args: ["--set", "customCa.enabled=true", "--set", "customCa.existingSecret=openwork-ca-secret", "--set", "inference.env.NODE_EXTRA_CA_CERTS=/tmp/ca.pem"],
+                message: "inference.env.NODE_EXTRA_CA_CERTS conflicts with customCa.enabled=true; remove it and use customCa instead",
+              },
+            ];
+
+            for (const helmCase of cases) {
+              const result = helmTemplate(helmCase.args);
+              failures.push({ name: helmCase.name, status: result.status, stderr: result.stderr, message: helmCase.message });
+            }
+          },
+          assert: async () => {
+            for (const failure of failures) {
+              witness(ctx, failure.status !== 0, `${failure.name} fails Helm rendering`, failure.stderr.trim());
+              witness(ctx, failure.stderr.includes(failure.message), `${failure.name} reports a clear customCa error`, failure.stderr.trim());
+            }
+            ctx.output("Helm validation failures", failureSummary(failures));
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        let defaultRendered = "";
+        let disabledRendered = "";
+        await ctx.prove("Disabled custom CA support leaves the rendered chart byte-for-byte compatible with the default output", {
+          voiceover: vo[5],
+          action: async () => {
+            const defaultResult = helmTemplate(["--set", "inference.enabled=true"]);
+            witness(ctx, defaultResult.status === 0, "default helm template succeeds", defaultResult.stderr.trim());
+            defaultRendered = defaultResult.stdout;
+
+            const disabledResult = helmTemplate([
+              "--set",
+              "inference.enabled=true",
+              "--set",
+              "customCa.enabled=false",
+              "--set",
+              "customCa.existingSecret=ignored-ca-secret",
+              "--set",
+              "customCa.key=ignored.pem",
+            ]);
+            witness(ctx, disabledResult.status === 0, "helm template succeeds when customCa is explicitly disabled", disabledResult.stderr.trim());
+            disabledRendered = disabledResult.stdout;
+          },
+          assert: async () => {
+            witness(ctx, disabledRendered === defaultRendered, "Explicitly disabled customCa rendering is byte-for-byte identical to the default render");
+            witness(ctx, !defaultRendered.includes("name: NODE_EXTRA_CA_CERTS"), "Default rendering does not add NODE_EXTRA_CA_CERTS");
+            witness(ctx, !defaultRendered.includes(CUSTOM_CA_PATH), "Default rendering does not mount the custom CA file path");
+            ctx.output("Compatibility evidence", "Default render and explicit customCa.enabled=false render are identical; no NODE_EXTRA_CA_CERTS or custom CA mount path appears.");
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/helm-custom-ca.md
+++ b/evals/voiceovers/helm-custom-ca.md
@@ -1,0 +1,13 @@
+# helm-custom-ca — Private certificate authorities work across the self-hosted Helm release
+
+1. Here is an existing Kubernetes Secret containing our private CA certificate. OpenWork's Helm values reference it globally without embedding certificate material.
+
+2. Rendering the chart shows the CA mounted read-only into Den API, Den Web, inference, and the database migration Job.
+
+3. Each workload receives `NODE_EXTRA_CA_CERTS`, extending Node's normal public trust store with the private CA.
+
+4. With strict certificate verification enabled, the migration completes and OpenWork connects successfully to a MySQL endpoint signed by that private CA.
+
+5. Invalid configurations—missing sources, multiple sources, or conflicting environment overrides—fail during Helm rendering with a clear message.
+
+6. With custom CA support disabled, the chart renders exactly as before, preserving compatibility for existing installations.

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -145,6 +145,83 @@ The existing Secret must contain the keys listed under `secret.keys`, especially
 
 Set `DAYTONA_API_KEY` when `config.provisioner.mode` is `daytona`. Set `POLAR_ACCESS_TOKEN` when Polar feature gating is enabled. Set `OPENROUTER_MANAGEMENT_API_KEY` when enabling OpenWork Models management.
 
+## Custom CA certificates
+
+Use `customCa` when OpenWork must trust a private certificate authority for
+strict TLS verification, such as a MySQL endpoint signed by an internal or cloud
+private CA. The chart does not accept PEM material in values and does not create
+the CA resource for you; create the Kubernetes Secret or ConfigMap in the
+release namespace before running `helm install` or `helm upgrade`.
+
+Secret example:
+
+```bash
+kubectl create secret generic openwork-custom-ca \
+  --namespace openwork \
+  --from-file=ca.crt=./corp-root-ca.pem
+```
+
+```yaml
+customCa:
+  enabled: true
+  existingSecret: openwork-custom-ca
+  existingConfigMap: ""
+  key: ca.crt
+```
+
+ConfigMap example:
+
+```bash
+kubectl create configmap openwork-custom-ca \
+  --namespace openwork \
+  --from-file=ca.crt=./corp-root-ca.pem
+```
+
+```yaml
+customCa:
+  enabled: true
+  existingSecret: ""
+  existingConfigMap: openwork-custom-ca
+  key: ca.crt
+```
+
+When enabled, set exactly one of `existingSecret` or `existingConfigMap`, and set
+`key` to the data key containing the CA bundle. The chart mounts only that key as
+`/etc/openwork/custom-ca/ca-bundle.pem` and sets `NODE_EXTRA_CA_CERTS` to that
+file for `den-api`, `den-web`, enabled `inference`, and the migration Job. Do
+not also set `denApi.env.NODE_EXTRA_CA_CERTS`, `denWeb.env.NODE_EXTRA_CA_CERTS`,
+or `inference.env.NODE_EXTRA_CA_CERTS`; Helm rejects those conflicts while
+`customCa.enabled=true`.
+
+For strict MySQL TLS verification, pair the mounted CA with a verifying
+`DATABASE_URL`, for example:
+
+```yaml
+secret:
+  values:
+    databaseUrl: "mysql://openwork:REPLACE_DB_PASSWORD@mysql.example.internal:3306/openwork_den?sslmode=verify-full"
+```
+
+`sslmode=verify-ca`, `sslmode=verify-full`, and `sslaccept=strict` enable strict
+certificate verification. `sslaccept=accept` keeps TLS enabled but does not
+verify the certificate chain, so use it only for smoke tests or while preparing
+the CA bundle.
+
+The custom CA is release-wide for Node.js processes in this chart. Treat it as a
+global trust decision for outbound TLS from those workloads, and include only CA
+roots your OpenWork deployment should trust. On CA rotation, update the existing
+Secret or ConfigMap and restart the running workloads so Node reloads the CA
+file, for example:
+
+```bash
+kubectl rollout restart deployment/openwork-ee-den-api --namespace openwork
+kubectl rollout restart deployment/openwork-ee-den-web --namespace openwork
+kubectl rollout restart deployment/openwork-ee-inference --namespace openwork
+```
+
+The next migration hook Job will mount the current CA data; rerun a failed
+upgrade after the CA resource is corrected.
+
 ## Observability
 
 The chart exposes first-class runtime observability settings for `den-api` and
@@ -522,8 +599,12 @@ take precedence, so upgrading does not require changing that configuration.
 
 ```yaml
 config:
-  denApiNodeOptions: "--use-openssl-ca --max-old-space-size=4096"
+  denApiNodeOptions: "--max-old-space-size=4096"
 ```
+
+`--use-openssl-ca` only changes how Node reads operating-system trust. It does
+not create or mount a private CA bundle into the container; use `customCa` for
+that.
 
 ## Service Exposure
 

--- a/packaging/helm/openwork-ee/templates/_helpers.tpl
+++ b/packaging/helm/openwork-ee/templates/_helpers.tpl
@@ -77,6 +77,65 @@ app.kubernetes.io/component: {{ .component }}
 {{- default (printf "http://%s:%v" (include "openwork-ee.inferenceServiceName" .) .Values.inference.service.port) .Values.config.internal.inferenceProxyBaseUrl -}}
 {{- end -}}
 
+{{- define "openwork-ee.customCa.mountPath" -}}
+/etc/openwork/custom-ca
+{{- end -}}
+
+{{- define "openwork-ee.customCa.filePath" -}}
+{{ include "openwork-ee.customCa.mountPath" . }}/ca-bundle.pem
+{{- end -}}
+
+{{- define "openwork-ee.customCa.validate" -}}
+{{- if .Values.customCa.enabled -}}
+{{- if and .Values.customCa.existingSecret .Values.customCa.existingConfigMap -}}
+{{- fail "customCa.existingSecret and customCa.existingConfigMap are mutually exclusive when customCa.enabled=true" -}}
+{{- end -}}
+{{- if not (or .Values.customCa.existingSecret .Values.customCa.existingConfigMap) -}}
+{{- fail "customCa.existingSecret or customCa.existingConfigMap is required when customCa.enabled=true" -}}
+{{- end -}}
+{{- if not .Values.customCa.key -}}
+{{- fail "customCa.key is required when customCa.enabled=true" -}}
+{{- end -}}
+{{- if hasKey .Values.denApi.env "NODE_EXTRA_CA_CERTS" -}}
+{{- fail "denApi.env.NODE_EXTRA_CA_CERTS conflicts with customCa.enabled=true; remove it and use customCa instead" -}}
+{{- end -}}
+{{- if hasKey .Values.denWeb.env "NODE_EXTRA_CA_CERTS" -}}
+{{- fail "denWeb.env.NODE_EXTRA_CA_CERTS conflicts with customCa.enabled=true; remove it and use customCa instead" -}}
+{{- end -}}
+{{- if hasKey .Values.inference.env "NODE_EXTRA_CA_CERTS" -}}
+{{- fail "inference.env.NODE_EXTRA_CA_CERTS conflicts with customCa.enabled=true; remove it and use customCa instead" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "openwork-ee.customCa.volume" -}}
+- name: custom-ca
+  {{- if .Values.customCa.existingSecret }}
+  secret:
+    secretName: {{ .Values.customCa.existingSecret | quote }}
+    items:
+      - key: {{ .Values.customCa.key | quote }}
+        path: ca-bundle.pem
+  {{- else }}
+  configMap:
+    name: {{ .Values.customCa.existingConfigMap | quote }}
+    items:
+      - key: {{ .Values.customCa.key | quote }}
+        path: ca-bundle.pem
+  {{- end }}
+{{- end -}}
+
+{{- define "openwork-ee.customCa.volumeMount" -}}
+- name: custom-ca
+  mountPath: {{ include "openwork-ee.customCa.mountPath" . | quote }}
+  readOnly: true
+{{- end -}}
+
+{{- define "openwork-ee.customCa.env" -}}
+- name: NODE_EXTRA_CA_CERTS
+  value: {{ include "openwork-ee.customCa.filePath" . | quote }}
+{{- end -}}
+
 {{- define "openwork-ee.observabilityBackend" -}}
 {{- $backend := default "none" .Values.observability.backend -}}
 {{- if not (has $backend (list "none" "otel" "sentry")) -}}

--- a/packaging/helm/openwork-ee/templates/den-api.yaml
+++ b/packaging/helm/openwork-ee/templates/den-api.yaml
@@ -1,3 +1,4 @@
+{{- include "openwork-ee.customCa.validate" . }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -60,7 +61,10 @@ spec:
       {{- if not (or .Values.installerArtifacts.existingClaim .Values.installerArtifacts.hostPath) }}
       {{- fail "installerArtifacts.existingClaim or installerArtifacts.hostPath is required when installerArtifacts.enabled=true" }}
       {{- end }}
+      {{- end }}
+      {{- if or .Values.installerArtifacts.enabled .Values.customCa.enabled }}
       volumes:
+        {{- if .Values.installerArtifacts.enabled }}
         - name: installer-artifacts
           {{- if .Values.installerArtifacts.existingClaim }}
           persistentVolumeClaim:
@@ -70,6 +74,10 @@ spec:
             path: {{ .Values.installerArtifacts.hostPath | quote }}
             type: Directory
           {{- end }}
+        {{- end }}
+        {{- if .Values.customCa.enabled }}
+        {{- include "openwork-ee.customCa.volume" . | nindent 8 }}
+        {{- end }}
       {{- end }}
       containers:
         - name: den-api
@@ -78,11 +86,16 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.denApi.containerPort }}
-          {{- if .Values.installerArtifacts.enabled }}
+          {{- if or .Values.installerArtifacts.enabled .Values.customCa.enabled }}
           volumeMounts:
+            {{- if .Values.installerArtifacts.enabled }}
             - name: installer-artifacts
               mountPath: {{ .Values.installerArtifacts.mountPath | quote }}
               readOnly: true
+            {{- end }}
+            {{- if .Values.customCa.enabled }}
+            {{- include "openwork-ee.customCa.volumeMount" . | nindent 12 }}
+            {{- end }}
           {{- end }}
           envFrom:
             - configMapRef:
@@ -103,6 +116,9 @@ spec:
             {{- if .Values.installerArtifacts.enabled }}
             - name: OPENWORK_INSTALLER_ARTIFACTS_DIR
               value: {{ .Values.installerArtifacts.mountPath | quote }}
+            {{- end }}
+            {{- if .Values.customCa.enabled }}
+            {{- include "openwork-ee.customCa.env" . | nindent 12 }}
             {{- end }}
             {{- include "openwork-ee.observabilityEnv" (dict "root" . "serviceName" .Values.observability.serviceNames.denApi) | nindent 12 }}
             {{- range $key, $value := .Values.denApi.env }}

--- a/packaging/helm/openwork-ee/templates/den-web.yaml
+++ b/packaging/helm/openwork-ee/templates/den-web.yaml
@@ -1,3 +1,4 @@
+{{- include "openwork-ee.customCa.validate" . }}
 apiVersion: v1
 kind: Service
 metadata:
@@ -53,6 +54,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.customCa.enabled }}
+      volumes:
+        {{- include "openwork-ee.customCa.volume" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: den-web
           image: "{{ .Values.denWeb.image.repository }}:{{ default .Values.image.tag .Values.denWeb.image.tag }}"
@@ -60,6 +65,10 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.denWeb.containerPort }}
+          {{- if .Values.customCa.enabled }}
+          volumeMounts:
+            {{- include "openwork-ee.customCa.volumeMount" . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "openwork-ee.configName" . }}
@@ -68,6 +77,9 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.denWeb.containerPort | quote }}
+            {{- if .Values.customCa.enabled }}
+            {{- include "openwork-ee.customCa.env" . | nindent 12 }}
+            {{- end }}
             {{- include "openwork-ee.observabilityEnv" (dict "root" . "serviceName" .Values.observability.serviceNames.denWeb) | nindent 12 }}
             {{- range $key, $value := .Values.denWeb.env }}
             - name: {{ $key }}

--- a/packaging/helm/openwork-ee/templates/inference.yaml
+++ b/packaging/helm/openwork-ee/templates/inference.yaml
@@ -1,3 +1,4 @@
+{{- include "openwork-ee.customCa.validate" . }}
 {{- if .Values.inference.enabled }}
 apiVersion: v1
 kind: Service
@@ -54,6 +55,10 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.customCa.enabled }}
+      volumes:
+        {{- include "openwork-ee.customCa.volume" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: inference
           image: "{{ .Values.inference.image.repository }}:{{ default .Values.image.tag .Values.inference.image.tag }}"
@@ -61,6 +66,10 @@ spec:
           ports:
             - name: http
               containerPort: {{ .Values.inference.containerPort }}
+          {{- if .Values.customCa.enabled }}
+          volumeMounts:
+            {{- include "openwork-ee.customCa.volumeMount" . | nindent 12 }}
+          {{- end }}
           envFrom:
             - configMapRef:
                 name: {{ include "openwork-ee.configName" . }}
@@ -69,6 +78,9 @@ spec:
           env:
             - name: PORT
               value: {{ .Values.inference.containerPort | quote }}
+            {{- if .Values.customCa.enabled }}
+            {{- include "openwork-ee.customCa.env" . | nindent 12 }}
+            {{- end }}
             {{- range $key, $value := .Values.inference.env }}
             - name: {{ $key }}
               value: {{ $value | quote }}

--- a/packaging/helm/openwork-ee/templates/migration-job.yaml
+++ b/packaging/helm/openwork-ee/templates/migration-job.yaml
@@ -1,3 +1,4 @@
+{{- include "openwork-ee.customCa.validate" . }}
 {{- if .Values.migrations.enabled }}
 apiVersion: batch/v1
 kind: Job
@@ -30,10 +31,18 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- if .Values.customCa.enabled }}
+      volumes:
+        {{- include "openwork-ee.customCa.volume" . | nindent 8 }}
+      {{- end }}
       containers:
         - name: migrate
           image: "{{ .Values.denApi.image.repository }}:{{ default .Values.image.tag .Values.denApi.image.tag }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- if .Values.customCa.enabled }}
+          volumeMounts:
+            {{- include "openwork-ee.customCa.volumeMount" . | nindent 12 }}
+          {{- end }}
           command:
             {{- toYaml .Values.migrations.command | nindent 12 }}
           args:
@@ -59,6 +68,9 @@ spec:
                   name: {{ include "openwork-ee.secretName" . }}
                   key: {{ .Values.secret.keys.denDbEncryptionKey }}
               {{- end }}
+            {{- if .Values.customCa.enabled }}
+            {{- include "openwork-ee.customCa.env" . | nindent 12 }}
+            {{- end }}
           {{- with .Values.migrations.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/packaging/helm/openwork-ee/tests/custom-ca-mysql-tls.mjs
+++ b/packaging/helm/openwork-ee/tests/custom-ca-mysql-tls.mjs
@@ -1,0 +1,271 @@
+import { spawnSync } from "node:child_process";
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { createRequire } from "node:module";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const chartDir = join(dirname(fileURLToPath(import.meta.url)), "..");
+const repoRoot = join(chartDir, "..", "..", "..");
+const denDbDir = join(repoRoot, "ee", "packages", "den-db");
+const denDbPackage = join(denDbDir, "package.json");
+const denDbRequire = createRequire(denDbPackage);
+const mysql = denDbRequire("mysql2/promise");
+const bootstrapPath = join(denDbDir, "dist", "scripts", "bootstrap.js");
+const currentSchemaPath = join(denDbDir, "dist", "current-schema.sql");
+const denDbIndexPath = join(denDbDir, "dist", "index.js");
+const image = process.env.OPENWORK_EVAL_MYSQL_IMAGE?.trim() || "mysql:8.4";
+const containerName = `openwork-custom-ca-mysql-${process.pid}-${Date.now()}`;
+const tmp = mkdtempSync(join(tmpdir(), "openwork-custom-ca-mysql-"));
+const certsDir = join(tmp, "certs");
+const caKey = join(certsDir, "ca.key");
+const caCert = join(certsDir, "ca.crt");
+const serverKey = join(certsDir, "server.key");
+const serverCsr = join(certsDir, "server.csr");
+const serverCert = join(certsDir, "server.crt");
+const opensslConfig = join(tmp, "openssl.cnf");
+const mysqlConfig = join(tmp, "tls.cnf");
+const databaseName = "openwork_den";
+const databaseUser = "openwork";
+const databasePassword = "openwork_tls_test_password";
+let containerStarted = false;
+
+function run(command, args, options = {}) {
+  return spawnSync(command, args, {
+    cwd: repoRoot,
+    encoding: "utf8",
+    maxBuffer: 20 * 1024 * 1024,
+    timeout: 180_000,
+    ...options,
+  });
+}
+
+function ensureSuccess(result, description) {
+  if (result.status !== 0) {
+    throw new Error(`${description} failed\nstdout:\n${result.stdout}\nstderr:\n${result.stderr}`);
+  }
+}
+
+function runOpenSsl(args) {
+  ensureSuccess(run("openssl", args), `openssl ${args.join(" ")}`);
+}
+
+function ensureBuildArtifacts() {
+  if (existsSync(bootstrapPath) && existsSync(currentSchemaPath) && existsSync(denDbIndexPath)) {
+    return;
+  }
+
+  const result = run("pnpm", ["--dir", denDbDir, "run", "build"], { timeout: 240_000 });
+  ensureSuccess(result, "pnpm --dir ee/packages/den-db run build");
+  console.log("Built @openwork-ee/den-db migration artifacts");
+}
+
+function generateCertificates() {
+  mkdirSync(certsDir, { recursive: true });
+  writeFileSync(
+    opensslConfig,
+    `[req]
+distinguished_name = dn
+prompt = no
+req_extensions = v3_req
+[dn]
+CN = localhost
+[v3_req]
+basicConstraints = CA:FALSE
+keyUsage = digitalSignature,keyEncipherment
+extendedKeyUsage = serverAuth
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = localhost
+DNS.2 = mysql.private.test
+IP.1 = 127.0.0.1
+`,
+  );
+
+  runOpenSsl(["req", "-x509", "-newkey", "rsa:2048", "-nodes", "-days", "1", "-subj", "/CN=OpenWork Test MySQL CA", "-keyout", caKey, "-out", caCert]);
+  runOpenSsl(["req", "-newkey", "rsa:2048", "-nodes", "-keyout", serverKey, "-out", serverCsr, "-config", opensslConfig]);
+  runOpenSsl(["x509", "-req", "-in", serverCsr, "-CA", caCert, "-CAkey", caKey, "-CAcreateserial", "-out", serverCert, "-days", "1", "-extensions", "v3_req", "-extfile", opensslConfig]);
+  chmodSync(serverKey, 0o644);
+  chmodSync(serverCert, 0o644);
+  chmodSync(caCert, 0o644);
+
+  writeFileSync(
+    mysqlConfig,
+    `[mysqld]
+ssl-ca=/etc/mysql/certs/ca.crt
+ssl-cert=/etc/mysql/certs/server.crt
+ssl-key=/etc/mysql/certs/server.key
+require_secure_transport=ON
+tls_version=TLSv1.2,TLSv1.3
+`,
+  );
+  chmodSync(mysqlConfig, 0o644);
+  console.log("Generated private CA and MySQL server certificate with SAN DNS:localhost, DNS:mysql.private.test, IP:127.0.0.1");
+}
+
+function docker(args, options = {}) {
+  return run("docker", args, { timeout: 240_000, ...options });
+}
+
+function startMysqlContainer() {
+  const result = docker([
+    "run",
+    "--rm",
+    "--detach",
+    "--name",
+    containerName,
+    "--publish",
+    "127.0.0.1::3306",
+    "--env",
+    "MYSQL_ROOT_PASSWORD=openwork_root_password",
+    "--env",
+    "MYSQL_ROOT_HOST=%",
+    "--env",
+    `MYSQL_DATABASE=${databaseName}`,
+    "--env",
+    `MYSQL_USER=${databaseUser}`,
+    "--env",
+    `MYSQL_PASSWORD=${databasePassword}`,
+    "--volume",
+    `${certsDir}:/etc/mysql/certs:ro`,
+    "--volume",
+    `${mysqlConfig}:/etc/mysql/conf.d/tls.cnf:ro`,
+    image,
+  ]);
+  ensureSuccess(result, `docker run ${image}`);
+  containerStarted = true;
+  console.log(`Started TLS-enabled MySQL container ${containerName} from ${image}`);
+}
+
+function mappedPort() {
+  const result = docker(["port", containerName, "3306/tcp"]);
+  ensureSuccess(result, "docker port");
+  const endpoint = result.stdout.trim().split("\n").find(Boolean);
+  const port = endpoint?.split(":").pop();
+  if (!port) {
+    throw new Error(`Unable to resolve mapped MySQL port from: ${result.stdout}`);
+  }
+  return Number(port);
+}
+
+async function waitForMysql(port) {
+  const started = Date.now();
+  let lastError = "";
+  while (Date.now() - started < 90_000) {
+    try {
+      const connection = await mysql.createConnection({
+        host: "127.0.0.1",
+        port,
+        user: databaseUser,
+        password: databasePassword,
+        database: databaseName,
+        ssl: { rejectUnauthorized: false },
+      });
+      await connection.query("select 1");
+      await connection.end();
+      return;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+      await new Promise((resolve) => setTimeout(resolve, 750));
+    }
+  }
+
+  const logs = docker(["logs", containerName], { timeout: 30_000 });
+  throw new Error(`MySQL container did not become ready: ${lastError}\n${logs.stdout}\n${logs.stderr}`);
+}
+
+function strictDatabaseUrl(port) {
+  return `mysql://${databaseUser}:${databasePassword}@127.0.0.1:${port}/${databaseName}?sslmode=verify-full`;
+}
+
+function redactedDatabaseUrl(port) {
+  return `mysql://${databaseUser}:REDACTED@127.0.0.1:${port}/${databaseName}?sslmode=verify-full`;
+}
+
+function childEnv(extra = {}) {
+  const env = { ...process.env, ...extra };
+  delete env.NODE_TLS_REJECT_UNAUTHORIZED;
+  return env;
+}
+
+function runOpenWorkMysqlQuery(databaseUrl, query, extraEnv = {}) {
+  const source = `
+import { createRequire } from "node:module";
+const mysql = createRequire(process.argv[1])("mysql2/promise");
+const { parseMySqlConnectionConfig } = await import(process.argv[2]);
+const connection = await mysql.createConnection(parseMySqlConnectionConfig(process.argv[3]));
+try {
+  const [rows] = await connection.query(process.argv[4]);
+  console.log(JSON.stringify(rows));
+} finally {
+  await connection.end();
+}
+`;
+
+  return run(process.execPath, ["--input-type=module", "-e", source, denDbPackage, pathToFileURL(denDbIndexPath).href, databaseUrl, query], {
+    env: childEnv(extraEnv),
+    timeout: 90_000,
+  });
+}
+
+function runBootstrap(databaseUrl) {
+  return run(process.execPath, [bootstrapPath], {
+    cwd: denDbDir,
+    env: childEnv({
+      DATABASE_URL: databaseUrl,
+      DEN_DB_ENCRYPTION_KEY: "openwork-custom-ca-mysql-tls-test-key-1234567890",
+      NODE_EXTRA_CA_CERTS: caCert,
+      OPENWORK_DEN_DB_ENV_PATH: join(tmp, "does-not-exist.env"),
+    }),
+    timeout: 180_000,
+  });
+}
+
+function cleanup() {
+  if (containerStarted) {
+    docker(["rm", "-f", containerName], { timeout: 30_000 });
+  }
+  rmSync(tmp, { recursive: true, force: true });
+}
+
+try {
+  ensureBuildArtifacts();
+  generateCertificates();
+  startMysqlContainer();
+  const port = mappedPort();
+  await waitForMysql(port);
+  const databaseUrl = strictDatabaseUrl(port);
+  console.log(`TLS MySQL endpoint ready at ${redactedDatabaseUrl(port)}`);
+
+  const withoutCa = runOpenWorkMysqlQuery(databaseUrl, "select 1 as ok");
+  if (withoutCa.status === 0) {
+    throw new Error("Strict OpenWork/mysql2 unexpectedly connected without NODE_EXTRA_CA_CERTS");
+  }
+  const withoutCaError = `${withoutCa.stdout}\n${withoutCa.stderr}`.trim();
+  if (!/certificate|verify|self-signed|unable/i.test(withoutCaError)) {
+    throw new Error(`Strict OpenWork/mysql2 failed for a non-certificate reason:\n${withoutCaError}`);
+  }
+  const certificateError = withoutCaError.split("\n").find((line) => /certificate|verify|self-signed|unable/i.test(line)) ?? withoutCaError.split("\n").find(Boolean);
+  console.log(`Strict OpenWork/mysql2 without custom CA: rejected (${certificateError})`);
+
+  const bootstrap = runBootstrap(databaseUrl);
+  ensureSuccess(bootstrap, "OpenWork migration bootstrap with NODE_EXTRA_CA_CERTS");
+  console.log("OpenWork migration bootstrap completed with NODE_EXTRA_CA_CERTS and strict DATABASE_URL");
+  console.log(bootstrap.stdout.trim());
+
+  const query = runOpenWorkMysqlQuery(
+    databaseUrl,
+    "select (select count(*) from information_schema.tables where table_schema = database()) as table_count, (select count(*) from `__drizzle_migrations`) as migration_count",
+    { NODE_EXTRA_CA_CERTS: caCert },
+  );
+  ensureSuccess(query, "OpenWork/mysql2 strict post-migration query with NODE_EXTRA_CA_CERTS");
+  const rows = JSON.parse(query.stdout.trim());
+  const tableCount = Number(rows[0]?.table_count ?? 0);
+  const migrationCount = Number(rows[0]?.migration_count ?? 0);
+  if (tableCount <= 0 || migrationCount <= 0) {
+    throw new Error(`Expected migrated OpenWork tables and migration ledger rows, got ${query.stdout}`);
+  }
+  console.log(`OpenWork/mysql2 strict query succeeded after migration: tables=${tableCount}, migrations=${migrationCount}`);
+} finally {
+  cleanup();
+}

--- a/packaging/helm/openwork-ee/tests/custom-ca-node-trust.mjs
+++ b/packaging/helm/openwork-ee/tests/custom-ca-node-trust.mjs
@@ -1,0 +1,147 @@
+import { spawn, spawnSync } from "node:child_process";
+import { createServer } from "node:https";
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const tmp = mkdtempSync(join(tmpdir(), "openwork-custom-ca-"));
+const caKey = join(tmp, "ca.key");
+const caCert = join(tmp, "ca.crt");
+const serverKey = join(tmp, "server.key");
+const serverCsr = join(tmp, "server.csr");
+const serverCert = join(tmp, "server.crt");
+const opensslConfig = join(tmp, "openssl.cnf");
+
+function runOpenSsl(args) {
+  const result = spawnSync("openssl", args, { encoding: "utf8" });
+  if (result.status !== 0) {
+    throw new Error(`openssl ${args.join(" ")} failed\n${result.stderr}`);
+  }
+}
+
+function clientEnvironment(caPath) {
+  const env = { ...process.env };
+  delete env.NODE_EXTRA_CA_CERTS;
+  delete env.NODE_TLS_REJECT_UNAUTHORIZED;
+  if (caPath) {
+    env.NODE_EXTRA_CA_CERTS = caPath;
+  }
+  return env;
+}
+
+function runClient(url, caPath) {
+  const clientSource = `
+const https = require("node:https");
+https.get(process.argv[1], (response) => {
+  let body = "";
+  response.setEncoding("utf8");
+  response.on("data", (chunk) => { body += chunk; });
+  response.on("end", () => {
+    if (response.statusCode === 200 && body === "openwork-custom-ca-ok") {
+      console.log(body);
+      process.exit(0);
+    }
+    console.error(\`unexpected response: \${response.statusCode} \${body}\`);
+    process.exit(1);
+  });
+}).on("error", (error) => {
+  console.error(error.code || error.message);
+  process.exit(2);
+});
+`;
+
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, ["-e", clientSource, url], {
+      env: clientEnvironment(caPath),
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+    let stdout = "";
+    let stderr = "";
+    child.stdout.on("data", (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on("data", (chunk) => {
+      stderr += chunk;
+    });
+    child.on("close", (status) => {
+      resolve({ status, stdout, stderr });
+    });
+  });
+}
+
+function listen(server) {
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+}
+
+function close(server) {
+  return new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+try {
+  writeFileSync(
+    opensslConfig,
+    `[req]
+distinguished_name = dn
+prompt = no
+[dn]
+CN = localhost
+[v3_req]
+subjectAltName = @alt_names
+[alt_names]
+DNS.1 = localhost
+IP.1 = 127.0.0.1
+`,
+  );
+
+  runOpenSsl(["req", "-x509", "-newkey", "rsa:2048", "-nodes", "-days", "1", "-subj", "/CN=OpenWork Test CA", "-keyout", caKey, "-out", caCert]);
+  runOpenSsl(["req", "-newkey", "rsa:2048", "-nodes", "-keyout", serverKey, "-out", serverCsr, "-config", opensslConfig]);
+  runOpenSsl(["x509", "-req", "-in", serverCsr, "-CA", caCert, "-CAkey", caKey, "-CAcreateserial", "-out", serverCert, "-days", "1", "-extensions", "v3_req", "-extfile", opensslConfig]);
+
+  const server = createServer(
+    {
+      key: readFileSync(serverKey),
+      cert: readFileSync(serverCert),
+    },
+    (_request, response) => {
+      response.end("openwork-custom-ca-ok");
+    },
+  );
+
+  await listen(server);
+  const address = server.address();
+  const url = `https://127.0.0.1:${address.port}/`;
+
+  try {
+    const withoutCustomCa = await runClient(url);
+    if (withoutCustomCa.status === 0) {
+      throw new Error("Strict TLS unexpectedly trusted the private CA without NODE_EXTRA_CA_CERTS");
+    }
+
+    const withCustomCa = await runClient(url, caCert);
+    if (withCustomCa.status !== 0) {
+      throw new Error(`Strict TLS did not trust NODE_EXTRA_CA_CERTS=${caCert}\n${withCustomCa.stderr}`);
+    }
+
+    console.log(`Strict TLS without NODE_EXTRA_CA_CERTS: rejected (${withoutCustomCa.stderr.trim()})`);
+    console.log(`Strict TLS with NODE_EXTRA_CA_CERTS=${caCert}: accepted (${withCustomCa.stdout.trim()})`);
+    console.log("Focused runtime trust check passed; this verifies Node's strict TLS trust path without starting MySQL.");
+  } finally {
+    await close(server);
+  }
+} finally {
+  rmSync(tmp, { recursive: true, force: true });
+}

--- a/packaging/helm/openwork-ee/tests/custom-ca.sh
+++ b/packaging/helm/openwork-ee/tests/custom-ca.sh
@@ -1,0 +1,189 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assert_count() {
+  local file="$1"
+  local needle="$2"
+  local expected="$3"
+  local count
+  count="$(grep -F -c -- "$needle" "$file" || true)"
+  if [[ "$count" != "$expected" ]]; then
+    printf 'Expected %s occurrences of %s, found %s\n' "$expected" "$needle" "$count" >&2
+    return 1
+  fi
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart not to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+assert_failure() {
+  local values_file="$1"
+  local expected="$2"
+  local output_file="$tmp_dir/failure-output.yaml"
+  local error_file="$tmp_dir/failure-error.txt"
+
+  if helm template openwork-ee "$chart_dir" -f "$values_file" > "$output_file" 2> "$error_file"; then
+    printf 'Expected helm template to fail for %s\n' "$values_file" >&2
+    return 1
+  fi
+  assert_contains "$error_file" "$expected"
+}
+
+default_rendered="$tmp_dir/default.yaml"
+disabled_values="$tmp_dir/disabled-values.yaml"
+disabled_rendered="$tmp_dir/disabled.yaml"
+helm template openwork-ee "$chart_dir" --set inference.enabled=true > "$default_rendered"
+cat > "$disabled_values" <<'YAML'
+inference:
+  enabled: true
+customCa:
+  enabled: false
+  existingSecret: ignored-ca-secret
+  key: ignored.pem
+YAML
+helm template openwork-ee "$chart_dir" -f "$disabled_values" > "$disabled_rendered"
+cmp -s "$default_rendered" "$disabled_rendered"
+assert_not_contains "$default_rendered" 'name: NODE_EXTRA_CA_CERTS'
+assert_not_contains "$default_rendered" '/etc/openwork/custom-ca'
+assert_not_contains "$default_rendered" 'name: custom-ca'
+
+secret_values="$tmp_dir/secret-values.yaml"
+secret_rendered="$tmp_dir/secret.yaml"
+cat > "$secret_values" <<'YAML'
+customCa:
+  enabled: true
+  existingSecret: openwork-ca-secret
+  key: corp-root.pem
+YAML
+helm template openwork-ee "$chart_dir" -f "$secret_values" > "$secret_rendered"
+assert_count "$secret_rendered" 'name: NODE_EXTRA_CA_CERTS' 3
+assert_count "$secret_rendered" 'value: "/etc/openwork/custom-ca/ca-bundle.pem"' 3
+assert_count "$secret_rendered" 'name: custom-ca' 6
+assert_count "$secret_rendered" 'secretName: "openwork-ca-secret"' 3
+assert_count "$secret_rendered" 'key: "corp-root.pem"' 3
+assert_count "$secret_rendered" 'path: ca-bundle.pem' 3
+assert_count "$secret_rendered" 'mountPath: "/etc/openwork/custom-ca"' 3
+assert_not_contains "$secret_rendered" 'subPath:'
+assert_not_contains "$secret_rendered" 'name: "openwork-ca-config"'
+assert_not_contains "$secret_rendered" 'name: openwork-ee-inference'
+
+configmap_values="$tmp_dir/configmap-values.yaml"
+configmap_rendered="$tmp_dir/configmap.yaml"
+cat > "$configmap_values" <<'YAML'
+inference:
+  enabled: true
+customCa:
+  enabled: true
+  existingConfigMap: openwork-ca-config
+  key: ca.crt
+YAML
+helm template openwork-ee "$chart_dir" -f "$configmap_values" > "$configmap_rendered"
+assert_contains "$configmap_rendered" 'name: openwork-ee-den-api'
+assert_contains "$configmap_rendered" 'name: openwork-ee-den-web'
+assert_contains "$configmap_rendered" 'name: openwork-ee-inference'
+assert_contains "$configmap_rendered" 'name: openwork-ee-migrate'
+assert_count "$configmap_rendered" 'name: NODE_EXTRA_CA_CERTS' 4
+assert_count "$configmap_rendered" 'value: "/etc/openwork/custom-ca/ca-bundle.pem"' 4
+assert_count "$configmap_rendered" 'name: custom-ca' 8
+assert_count "$configmap_rendered" 'name: "openwork-ca-config"' 4
+assert_count "$configmap_rendered" 'key: "ca.crt"' 4
+assert_count "$configmap_rendered" 'path: ca-bundle.pem' 4
+assert_count "$configmap_rendered" 'mountPath: "/etc/openwork/custom-ca"' 4
+assert_not_contains "$configmap_rendered" 'subPath:'
+assert_not_contains "$configmap_rendered" 'secretName: "openwork-ca-secret"'
+
+installer_values="$tmp_dir/installer-values.yaml"
+installer_rendered="$tmp_dir/installer.yaml"
+cat > "$installer_values" <<'YAML'
+customCa:
+  enabled: true
+  existingSecret: openwork-ca-secret
+installerArtifacts:
+  enabled: true
+  existingClaim: installer-artifacts-pvc
+YAML
+helm template openwork-ee "$chart_dir" -f "$installer_values" > "$installer_rendered"
+assert_contains "$installer_rendered" 'name: installer-artifacts'
+assert_contains "$installer_rendered" 'claimName: "installer-artifacts-pvc"'
+assert_contains "$installer_rendered" 'name: OPENWORK_INSTALLER_ARTIFACTS_DIR'
+assert_contains "$installer_rendered" 'name: custom-ca'
+assert_contains "$installer_rendered" 'name: NODE_EXTRA_CA_CERTS'
+
+missing_source_values="$tmp_dir/missing-source-values.yaml"
+cat > "$missing_source_values" <<'YAML'
+customCa:
+  enabled: true
+YAML
+assert_failure "$missing_source_values" 'customCa.existingSecret or customCa.existingConfigMap is required when customCa.enabled=true'
+
+multiple_sources_values="$tmp_dir/multiple-sources-values.yaml"
+cat > "$multiple_sources_values" <<'YAML'
+customCa:
+  enabled: true
+  existingSecret: openwork-ca-secret
+  existingConfigMap: openwork-ca-config
+YAML
+assert_failure "$multiple_sources_values" 'customCa.existingSecret and customCa.existingConfigMap are mutually exclusive when customCa.enabled=true'
+
+empty_key_values="$tmp_dir/empty-key-values.yaml"
+cat > "$empty_key_values" <<'YAML'
+customCa:
+  enabled: true
+  existingSecret: openwork-ca-secret
+  key: ""
+YAML
+assert_failure "$empty_key_values" 'customCa.key is required when customCa.enabled=true'
+
+den_api_conflict_values="$tmp_dir/den-api-conflict-values.yaml"
+cat > "$den_api_conflict_values" <<'YAML'
+customCa:
+  enabled: true
+  existingSecret: openwork-ca-secret
+denApi:
+  env:
+    NODE_EXTRA_CA_CERTS: /already/set.pem
+YAML
+assert_failure "$den_api_conflict_values" 'denApi.env.NODE_EXTRA_CA_CERTS conflicts with customCa.enabled=true; remove it and use customCa instead'
+
+den_web_conflict_values="$tmp_dir/den-web-conflict-values.yaml"
+cat > "$den_web_conflict_values" <<'YAML'
+customCa:
+  enabled: true
+  existingSecret: openwork-ca-secret
+denWeb:
+  env:
+    NODE_EXTRA_CA_CERTS: /already/set.pem
+YAML
+assert_failure "$den_web_conflict_values" 'denWeb.env.NODE_EXTRA_CA_CERTS conflicts with customCa.enabled=true; remove it and use customCa instead'
+
+inference_conflict_values="$tmp_dir/inference-conflict-values.yaml"
+cat > "$inference_conflict_values" <<'YAML'
+customCa:
+  enabled: true
+  existingSecret: openwork-ca-secret
+inference:
+  env:
+    NODE_EXTRA_CA_CERTS: /already/set.pem
+YAML
+assert_failure "$inference_conflict_values" 'inference.env.NODE_EXTRA_CA_CERTS conflicts with customCa.enabled=true; remove it and use customCa instead'
+
+node "$chart_dir/tests/custom-ca-node-trust.mjs"

--- a/packaging/helm/openwork-ee/tests/observability-env.sh
+++ b/packaging/helm/openwork-ee/tests/observability-env.sh
@@ -61,7 +61,7 @@ cat > "$otel_values" <<'YAML'
 inference:
   enabled: true
 config:
-  denApiNodeOptions: --use-openssl-ca --max-old-space-size=4096
+  denApiNodeOptions: --max-old-space-size=4096
 observability:
   backend: otel
   otel:
@@ -83,8 +83,8 @@ denWeb:
     CUSTOM_DEN_WEB_ENV: web
 YAML
 helm template openwork-ee "$chart_dir" -f "$otel_values" > "$otel_rendered"
-assert_contains "$otel_rendered" 'DEN_API_NODE_OPTIONS: "--use-openssl-ca --max-old-space-size=4096"'
-assert_contains "$otel_rendered" 'value: "--use-openssl-ca --max-old-space-size=4096"'
+assert_contains "$otel_rendered" 'DEN_API_NODE_OPTIONS: "--max-old-space-size=4096"'
+assert_contains "$otel_rendered" 'value: "--max-old-space-size=4096"'
 assert_count "$otel_rendered" 'name: DEN_OBSERVABILITY_BACKEND' 2
 assert_count "$otel_rendered" 'value: "otel"' 2
 assert_count "$otel_rendered" 'name: OTEL_EXPORTER_OTLP_HEADERS' 2

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -125,6 +125,12 @@ observability:
     release: ""
     dist: ""
 
+customCa:
+  enabled: false
+  existingSecret: ""
+  existingConfigMap: ""
+  key: ca.crt
+
 secret:
   create: true
   existingSecret: ""


### PR DESCRIPTION
## Summary
- add optional release-wide custom CA support backed by an existing Secret or ConfigMap
- mount the bundle and configure `NODE_EXTRA_CA_CERTS` for Den API, Den Web, inference, and migrations
- validate invalid/conflicting values and document strict MySQL TLS setup and CA rotation
- add Helm render tests plus deterministic Node and MySQL TLS verification

## Validation
- `helm lint packaging/helm/openwork-ee` — passed
- `for test in packaging/helm/openwork-ee/tests/*.sh; do bash "$test"; done` — passed
- `node packaging/helm/openwork-ee/tests/custom-ca-mysql-tls.mjs` — passed; strict connection rejected without CA, migration and query succeeded with CA
- `pnpm fraimz --flow helm-custom-ca` — passed, 6/6 frames

## Proof
- Fraimz: `evals/results/2026-07-15T15-31-07-494Z/fraimz.html`
