### PR TITLE
fix(den): match installer to allowed desktop versions

### DIFF
--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -96,7 +96,7 @@ type InstallPlatform = z.infer<typeof installPlatformSchema>
 
 export type InstallExperienceDependencies = {
   resolveConfiguredArtifact: typeof resolveConfiguredInstallerArtifact
-  resolveDirectUrl: (platform: InstallPlatform) => string
+  resolveDirectUrl: (platform: InstallPlatform, releaseTag: string) => string
   mintConnectGrant: typeof mintDesktopConnectGrant
   previewConnectGrant: typeof previewDesktopConnectGrant
   consumeConnectGrant: typeof consumeDesktopConnectGrant
@@ -104,9 +104,9 @@ export type InstallExperienceDependencies = {
 
 const defaultInstallerDependencies: InstallExperienceDependencies = {
   resolveConfiguredArtifact: resolveConfiguredInstallerArtifact,
-  resolveDirectUrl: (platform) => {
-    const fileName = desktopReleaseAssetName(platform, env.installerReleaseTag)
-    return fileName ? installerReleaseAssetUrl(fileName) : OPENWORK_DOWNLOAD_URL
+  resolveDirectUrl: (platform, releaseTag) => {
+    const fileName = desktopReleaseAssetName(platform, releaseTag)
+    return fileName ? installerReleaseAssetUrl(fileName, { releaseTag }) : OPENWORK_DOWNLOAD_URL
   },
   mintConnectGrant: mintDesktopConnectGrant,
   previewConnectGrant: previewDesktopConnectGrant,
@@ -170,6 +170,100 @@ function buildInstallConfig(input: { organization: { name: string; logo: string 
   })
 }
 
+type ComparableVersion = {
+  release: number[]
+  prerelease: string[]
+}
+
+function parseComparableVersion(value: string): ComparableVersion | null {
+  const normalized = value.trim().replace(/^v/i, "")
+  const [withoutBuild] = normalized.split("+", 1)
+  if (!withoutBuild) {
+    return null
+  }
+
+  const [releasePart, prereleasePart = ""] = withoutBuild.split("-", 2)
+  const release = releasePart.split(".").map((part) => Number(part))
+  if (release.length !== 3 || release.some((part) => !Number.isInteger(part) || part < 0)) {
+    return null
+  }
+
+  const prerelease = prereleasePart
+    .split(".")
+    .flatMap((part) => {
+      const trimmed = part.trim()
+      return trimmed ? [trimmed] : []
+    })
+  return { release, prerelease }
+}
+
+function comparePrerelease(left: string[], right: string[]) {
+  if (!left.length && !right.length) return 0
+  if (!left.length) return 1
+  if (!right.length) return -1
+
+  const count = Math.max(left.length, right.length)
+  for (let index = 0; index < count; index += 1) {
+    const leftPart = left[index]
+    const rightPart = right[index]
+    if (leftPart === undefined) return -1
+    if (rightPart === undefined) return 1
+
+    const leftNumeric = /^\d+$/.test(leftPart) ? Number(leftPart) : null
+    const rightNumeric = /^\d+$/.test(rightPart) ? Number(rightPart) : null
+    if (leftNumeric !== null && rightNumeric !== null) {
+      if (leftNumeric !== rightNumeric) return leftNumeric < rightNumeric ? -1 : 1
+      continue
+    }
+    if (leftNumeric !== null) return -1
+    if (rightNumeric !== null) return 1
+
+    const comparison = leftPart.localeCompare(rightPart)
+    if (comparison !== 0) return comparison < 0 ? -1 : 1
+  }
+  return 0
+}
+
+function compareVersions(left: string, right: string) {
+  const parsedLeft = parseComparableVersion(left)
+  const parsedRight = parseComparableVersion(right)
+  if (!parsedLeft || !parsedRight) return null
+
+  for (let index = 0; index < 3; index += 1) {
+    const leftPart = parsedLeft.release[index]
+    const rightPart = parsedRight.release[index]
+    if (leftPart === undefined || rightPart === undefined) return null
+    if (leftPart !== rightPart) return leftPart < rightPart ? -1 : 1
+  }
+  return comparePrerelease(parsedLeft.prerelease, parsedRight.prerelease)
+}
+
+function maxAllowedDesktopVersion(versions: string[]) {
+  let maxVersion: string | null = null
+  for (const version of versions) {
+    if (maxVersion === null) {
+      maxVersion = version
+      continue
+    }
+    const comparison = compareVersions(version, maxVersion)
+    if (comparison !== null && comparison > 0) {
+      maxVersion = version
+    }
+  }
+  return maxVersion
+}
+
+function installerReleaseTagForMetadata(metadataInput: unknown) {
+  const metadata = normalizeOrganizationMetadata(organizationMetadataInput(metadataInput)).metadata
+  const allowedVersions = metadata.allowedDesktopVersions
+  if (!allowedVersions?.length) {
+    return env.installerReleaseTag
+  }
+
+  const maxVersion = maxAllowedDesktopVersion(allowedVersions)
+  return maxVersion ? `v${maxVersion}` : env.installerReleaseTag
+}
+
 async function resolveInstallConfigForToken(token: string, request: Request) {
   const tokenHash = hashInstallLinkToken(token)
   const now = new Date()
@@ -193,6 +287,7 @@ async function resolveInstallConfigForToken(token: string, request: Request) {
   return {
     config: buildInstallConfig({ organization: row.organization, request }),
     installLinkId: row.installLink.id,
+    installerReleaseTag: installerReleaseTagForMetadata(row.organization.metadata),
   }
 }
 
@@ -200,8 +295,8 @@ function contentDisposition(filename: string) {
   return `attachment; filename="${filename.replace(/["\\]/g, "-")}"`
 }
 
-function artifactFileName(platform: InstallPlatform) {
-  return desktopReleaseAssetName(platform, env.installerReleaseTag)
+function artifactFileName(platform: InstallPlatform, releaseTag: string) {
+  return desktopReleaseAssetName(platform, releaseTag)
 }
 
 function installerContentType(platform: InstallPlatform) {
@@ -421,7 +516,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
       }
 
       const platform = platformResult.data.platform
-      const fileName = artifactFileName(platform)
+      const fileName = artifactFileName(platform, resolved.installerReleaseTag)
       if (!fileName) {
         return c.json({ error: "invalid_request", details: [{ message: "Unsupported installer platform." }] }, 400)
       }
@@ -441,7 +536,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
           }
         })
       }
-      return c.redirect(installer.resolveDirectUrl(platform), 302)
+      return c.redirect(installer.resolveDirectUrl(platform, resolved.installerReleaseTag), 302)
     },
   )
 }

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -26,11 +26,21 @@ const officialWindowsInstallerUrl = "https://github.com/different-ai/openwork/re
 const connectKeyPair = generateConnectLinkKeyPair()
 const connectKeyId = "owc-route-test"
 
+function defaultOrganizationMetadata(): Record<string, unknown> {
+  return {
+    capabilities: { installLinks: true },
+    brandAppName: "Acme Work",
+    brandLogoUrl: "https://assets.blueyonder.test/wordmark.svg",
+    brandIconUrl: "https://assets.blueyonder.test/icon.png",
+  }
+}
+
 let role = "member"
 let isOwner = false
 let capabilityEnabled = true
 let failInstallLinkInsert = false
 let sessionCreatedAt = new Date()
+let organizationMetadata = defaultOrganizationMetadata()
 
 mock.module("../src/db.js", () => ({
   db: {
@@ -52,12 +62,7 @@ mock.module("../src/db.js", () => ({
               name: "Acme Robotics",
               slug: "acme-robotics",
               logo: null,
-              metadata: {
-                capabilities: { installLinks: true },
-                brandAppName: "Acme Work",
-                brandLogoUrl: "https://assets.blueyonder.test/wordmark.svg",
-                brandIconUrl: "https://assets.blueyonder.test/icon.png",
-              },
+              metadata: organizationMetadata,
             },
           }]
         : []
@@ -103,10 +108,8 @@ mock.module("../src/orgs.js", () => ({
             slug: "acme-robotics",
             logo: null,
             metadata: {
+              ...organizationMetadata,
               capabilities: { installLinks: capabilityEnabled },
-              brandAppName: "Acme Work",
-              brandLogoUrl: "https://assets.blueyonder.test/wordmark.svg",
-              brandIconUrl: "https://assets.blueyonder.test/icon.png",
             },
           },
           currentMember: {
@@ -144,6 +147,9 @@ beforeEach(() => {
   envModule.env.installLinksGatingEnabled = true
   envModule.env.connectLink = null
   envModule.env.devMode = true
+  envModule.env.installerArtifactsDir = undefined
+  envModule.env.installerReleaseRepo = "different-ai/openwork"
+  envModule.env.installerReleaseTag = "v9.9.9"
   insertedRows.length = 0
   revokedRows.length = 0
   role = "member"
@@ -151,11 +157,13 @@ beforeEach(() => {
   capabilityEnabled = true
   failInstallLinkInsert = false
   sessionCreatedAt = new Date()
+  organizationMetadata = defaultOrganizationMetadata()
 })
 
 function createApp(options: {
   installerDirectUrl?: string
   configuredArtifact?: { filePath: string; size: number }
+  artifactFileNames?: string[]
   grantOverrides?: Partial<Pick<InstallExperienceDependencies, "mintConnectGrant" | "previewConnectGrant" | "consumeConnectGrant">>
 } = {}) {
   const app = new Hono()
@@ -176,9 +184,15 @@ function createApp(options: {
     })
     await next()
   })
+  const shouldResolveConfiguredArtifact = options.configuredArtifact !== undefined || options.artifactFileNames !== undefined
   const overrides: Partial<InstallExperienceDependencies> = {
-    ...(options.configuredArtifact !== undefined
-      ? { resolveConfiguredArtifact: () => Promise.resolve(options.configuredArtifact ?? null) }
+    ...(shouldResolveConfiguredArtifact
+      ? {
+          resolveConfiguredArtifact: (fileName: string) => {
+            options.artifactFileNames?.push(fileName)
+            return Promise.resolve(options.configuredArtifact ?? null)
+          },
+        }
       : {}),
     ...(options.installerDirectUrl
       ? { resolveDirectUrl: () => options.installerDirectUrl ?? officialWindowsInstallerUrl }
@@ -315,6 +329,76 @@ test("zero-config downloads redirect the browser to the official release", async
   expect(response.status).toBe(302)
   expect(response.headers.get("location")).toBe(officialWindowsInstallerUrl)
   expect(response.headers.get("location")).not.toContain("opaque-token")
+})
+
+test("unordered organization allowed desktop versions select the maximum direct release URL", async () => {
+  organizationMetadata = {
+    ...defaultOrganizationMetadata(),
+    allowedDesktopVersions: ["0.17.26", "0.17.25", "0.17.27"],
+  }
+
+  const response = await createApp().request("http://den.local/v1/install/win-x64?token=opaque-token", {
+    redirect: "manual",
+  })
+
+  expect(response.status).toBe(302)
+  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.27/openwork-win-x64-0.17.27.exe")
+  expect(response.headers.get("location")).not.toContain("v9.9.9")
+  expect(response.headers.get("location")).not.toContain("opaque-token")
+})
+
+test("mounted artifact lookup uses the organization-specific allowed desktop version filename", async () => {
+  organizationMetadata = {
+    ...defaultOrganizationMetadata(),
+    allowedDesktopVersions: ["0.17.26", "0.17.27"],
+  }
+  const artifactFileNames: string[] = []
+  const installer = Buffer.from("signed-standard-windows-installer", "utf8")
+  const artifactPath = path.join(mkdtempSync(path.join(os.tmpdir(), "openwork-installer-route-")), "installer.exe")
+  writeFileSync(artifactPath, installer)
+
+  const response = await createApp({
+    artifactFileNames,
+    configuredArtifact: { filePath: artifactPath, size: installer.byteLength },
+  }).request("http://den.local/v1/install/win-x64?token=opaque-token")
+
+  expect(response.status).toBe(200)
+  expect(artifactFileNames).toEqual(["openwork-win-x64-0.17.27.exe"])
+  expect(response.headers.get("content-disposition")).toContain("openwork-win-x64-0.17.27.exe")
+  expect(Buffer.from(await response.arrayBuffer())).toEqual(installer)
+})
+
+test("unrestricted organizations use Den's configured installer release tag", async () => {
+  organizationMetadata = {
+    ...defaultOrganizationMetadata(),
+    allowedDesktopVersions: [],
+  }
+
+  const response = await createApp().request("http://den.local/v1/install/win-x64?token=opaque-token", {
+    redirect: "manual",
+  })
+
+  expect(response.status).toBe(302)
+  expect(response.headers.get("location")).toBe(officialWindowsInstallerUrl)
+  expect(response.headers.get("location")).not.toContain("opaque-token")
+})
+
+test("install token organization policy applies to member and admin downloads", async () => {
+  organizationMetadata = {
+    ...defaultOrganizationMetadata(),
+    allowedDesktopVersions: ["0.17.26", "0.17.27"],
+  }
+  const expectedUrl = "https://github.com/different-ai/openwork/releases/download/v0.17.27/openwork-win-x64-0.17.27.exe"
+
+  for (const nextRole of ["member", "admin"]) {
+    role = nextRole
+    const response = await createApp().request("http://den.local/v1/install/win-x64?token=opaque-token", {
+      redirect: "manual",
+    })
+
+    expect(response.status).toBe(302)
+    expect(response.headers.get("location")).toBe(expectedUrl)
+  }
 })
 
 test.each(["mac-arm64", "win-x64", "linux-x64", "linux-arm64"])(

--- a/evals/flows/den-download-link-match-allowed-versions.flow.mjs
+++ b/evals/flows/den-download-link-match-allowed-versions.flow.mjs
@@ -1,0 +1,216 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "den-download-link-match-allowed-versions";
+const DEN_API_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_API_URL);
+const DEN_TOKEN = process.env.OPENWORK_EVAL_DEN_TOKEN?.trim() || "";
+const MEMBER_TOKEN = process.env.OPENWORK_EVAL_MEMBER_DEN_TOKEN?.trim() || DEN_TOKEN;
+const DEFAULT_RELEASE_TAG = process.env.OPENWORK_EVAL_DEFAULT_INSTALLER_RELEASE_TAG?.trim() || "v0.17.28";
+const DEFAULT_RELEASE_VERSION = DEFAULT_RELEASE_TAG.replace(/^v/i, "");
+const ALLOWED_VERSIONS = ["0.17.26", "0.17.27"];
+const SELECTED_VERSION = "0.17.27";
+const DISALLOWED_VERSION = "0.17.28";
+
+// Narration is loaded from the approved script (evals/voiceovers/den-download-link-match-allowed-versions.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const state = {
+  organizationId: null,
+  organizationName: null,
+  memberInstallToken: null,
+  restrictedDownload: null,
+  unrestrictedInstallToken: null,
+  unrestrictedDownload: null,
+};
+
+function cleanBaseUrl(value) {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : typeof actual === "string" ? actual : JSON.stringify(actual).slice(0, 900),
+  });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : ` (actual: ${JSON.stringify(actual).slice(0, 500)})`}`);
+}
+
+function readOrganizationMetadata(organization) {
+  const metadata = organization?.metadata;
+  if (metadata && typeof metadata === "object") return metadata;
+  if (typeof metadata !== "string") return {};
+  try {
+    const parsed = JSON.parse(metadata);
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    return {};
+  }
+}
+
+async function denApiFetch(path, options = {}) {
+  const { auth, token, ...fetchOptions } = options;
+  const headers = new Headers(options.headers ?? {});
+  headers.set("accept", "application/json");
+  if (options.body && !headers.has("content-type")) headers.set("content-type", "application/json");
+  if (auth !== false) headers.set("authorization", `Bearer ${token ?? DEN_TOKEN}`);
+
+  const response = await fetch(`${DEN_API_URL}${path}`, { ...fetchOptions, headers });
+  const text = await response.text();
+  let body = null;
+  if (text) {
+    try {
+      body = JSON.parse(text);
+    } catch {
+      body = text;
+    }
+  }
+  return { response, body, text };
+}
+
+async function ensureOrganization(ctx) {
+  if (state.organizationId) return;
+  const orgs = await denApiFetch("/v1/me/orgs");
+  witness(ctx, orgs.response.ok, "The signed-in Den user can list their organizations", { status: orgs.response.status, body: orgs.body });
+  const organizations = Array.isArray(orgs.body?.orgs) ? orgs.body.orgs : [];
+  const active = organizations.find((organization) => organization?.id === orgs.body?.activeOrgId) ?? organizations[0];
+  witness(ctx, typeof active?.id === "string", "The eval has an active organization", orgs.body);
+  state.organizationId = active.id;
+  state.organizationName = active.name ?? "the organization";
+}
+
+async function prepareEnterprisePolicySurface(ctx) {
+  await ensureOrganization(ctx);
+  const plan = await denApiFetch(`/v1/admin/organizations/${state.organizationId}/plan`, {
+    method: "PATCH",
+    body: JSON.stringify({ tier: "enterprise", seatLimit: 25 }),
+  });
+  ctx.output("enterprise-plan-prep", JSON.stringify({ status: plan.response.status, body: plan.body }, null, 2));
+
+  const capabilities = await denApiFetch(`/v1/admin/organizations/${state.organizationId}/capabilities`, {
+    method: "PUT",
+    body: JSON.stringify({ capabilities: { installLinks: true } }),
+  });
+  ctx.output("install-links-capability-prep", JSON.stringify({ status: capabilities.response.status, body: capabilities.body }, null, 2));
+}
+
+async function setAllowedDesktopVersions(ctx, versions) {
+  await prepareEnterprisePolicySurface(ctx);
+  const updated = await denApiFetch("/v1/org", {
+    method: "PATCH",
+    body: JSON.stringify({ allowedDesktopVersions: versions }),
+  });
+  witness(ctx, updated.response.ok, "The organization desktop-version policy is saved", { status: updated.response.status, body: updated.body });
+  return updated.body?.organization;
+}
+
+async function mintInstallToken(ctx, token = DEN_TOKEN) {
+  await ensureOrganization(ctx);
+  const result = await denApiFetch(`/v1/orgs/${state.organizationId}/install-links`, {
+    method: "POST",
+    token,
+    body: JSON.stringify({ rotate: false }),
+  });
+  witness(ctx, result.response.ok, "A member can mint an organization install link", { status: result.response.status, body: result.body });
+  const installToken = typeof result.body?.token === "string"
+    ? result.body.token
+    : new URL(result.body?.installPageUrl ?? "http://invalid.local").searchParams.get("token") ?? "";
+  witness(ctx, installToken.length >= 8, "The install link carries an opaque token", result.body);
+  return installToken;
+}
+
+async function fetchInstallerDownload(token) {
+  const response = await fetch(`${DEN_API_URL}/v1/install/win-x64?token=${encodeURIComponent(token)}`, {
+    redirect: "manual",
+  });
+  return {
+    status: response.status,
+    location: response.headers.get("location"),
+    contentDisposition: response.headers.get("content-disposition"),
+  };
+}
+
+function downloadMentionsVersion(download, version) {
+  const evidence = `${download.location ?? ""}\n${download.contentDisposition ?? ""}`;
+  return evidence.includes(version);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Organization install links download the highest allowed desktop version",
+  kind: "user-facing",
+  requiresApp: false,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  steps: [
+    {
+      name: "Frame 1 — Admin restricts desktop versions",
+      run: async (ctx) => {
+        await ctx.prove("An admin saves a policy allowing 0.17.26 and 0.17.27 while 0.17.28 remains disallowed", {
+          voiceover: vo[0],
+          action: async () => {
+            const organization = await setAllowedDesktopVersions(ctx, ALLOWED_VERSIONS);
+            ctx.output("allowed-desktop-versions", JSON.stringify({ organizationId: state.organizationId, organization }, null, 2));
+          },
+          assert: async () => {
+            const current = await denApiFetch("/v1/org");
+            const versions = readOrganizationMetadata(current.body?.organization).allowedDesktopVersions;
+            witness(ctx, Array.isArray(versions), "The saved organization metadata exposes allowedDesktopVersions", current.body);
+            witness(ctx, versions.includes("0.17.26") && versions.includes(SELECTED_VERSION), "The saved policy includes the two allowed versions", versions);
+            witness(ctx, !versions.includes(DISALLOWED_VERSION), "The saved policy excludes the disallowed latest version", versions);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2 — Non-admin resolves the same org install token",
+      run: async (ctx) => {
+        await ctx.prove("A non-admin member gets an organization install token from the same policy-backed flow", {
+          voiceover: vo[1],
+          action: async () => {
+            state.memberInstallToken = await mintInstallToken(ctx, MEMBER_TOKEN);
+          },
+          assert: async () => {
+            const config = await denApiFetch(`/v1/install-config?token=${encodeURIComponent(state.memberInstallToken)}`, { auth: false });
+            witness(ctx, config.response.ok, "The public install token resolves without a dashboard session", { status: config.response.status, body: config.body });
+            witness(ctx, config.body?.clientName === state.organizationName, "The install token is tied to the organization, not to the caller role", config.body);
+            witness(ctx, config.body?.requireSignin === true, "The guided installer still requires normal sign-in", config.body);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — Download selects the highest allowed version",
+      run: async (ctx) => {
+        await ctx.prove("Clicking download returns OpenWork 0.17.27 instead of the disallowed 0.17.28 release", {
+          voiceover: vo[2],
+          action: async () => {
+            state.restrictedDownload = await fetchInstallerDownload(state.memberInstallToken);
+          },
+          assert: async () => {
+            witness(ctx, [200, 302].includes(state.restrictedDownload.status), "The installer endpoint returns a download or redirect", state.restrictedDownload);
+            witness(ctx, downloadMentionsVersion(state.restrictedDownload, SELECTED_VERSION), "The selected direct URL or artifact filename contains 0.17.27", state.restrictedDownload);
+            witness(ctx, !downloadMentionsVersion(state.restrictedDownload, DISALLOWED_VERSION), "The selected download does not contain disallowed 0.17.28", state.restrictedDownload);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4 — Unrestricted org keeps Den default",
+      run: async (ctx) => {
+        await ctx.prove("Removing the allowed-version restriction restores Den's configured installer release", {
+          voiceover: vo[3],
+          action: async () => {
+            await setAllowedDesktopVersions(ctx, null);
+            state.unrestrictedInstallToken = await mintInstallToken(ctx, DEN_TOKEN);
+            state.unrestrictedDownload = await fetchInstallerDownload(state.unrestrictedInstallToken);
+          },
+          assert: async () => {
+            witness(ctx, [200, 302].includes(state.unrestrictedDownload.status), "The unrestricted installer endpoint returns a download or redirect", state.unrestrictedDownload);
+            witness(ctx, downloadMentionsVersion(state.unrestrictedDownload, DEFAULT_RELEASE_VERSION), `The unrestricted download uses Den's configured ${DEFAULT_RELEASE_TAG} release`, state.unrestrictedDownload);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/den-download-link-match-allowed-versions.md
+++ b/evals/voiceovers/den-download-link-match-allowed-versions.md
@@ -1,0 +1,11 @@
+# den-download-link-match-allowed-versions — Organization installers use the highest allowed desktop version
+
+The organization-wide desktop version policy applies to every member who uses the guided installer flow.
+
+1. An admin allows desktop versions 0.17.26 and 0.17.27, while 0.17.28 remains disallowed.
+
+2. A non-admin signs in to the single-organization dashboard and opens the three-step installer flow.
+
+3. Clicking “Download and install” downloads OpenWork 0.17.27—the highest version permitted by the organization.
+
+4. Organizations without version restrictions continue downloading Den’s configured latest release.


### PR DESCRIPTION
## Summary
- select the highest organization-allowed desktop version for guided installer downloads
- apply the organization policy to every install-link user, regardless of role
- preserve Den’s configured installer release for unrestricted organizations

## Tests
- `pnpm --filter @openwork-ee/den-api exec bun --conditions=development test test/install-link-access.test.ts` — 23 passed
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` — passed
- `pnpm fraimz --flow den-download-link-match-allowed-versions --stack den` — passed, 4/4 frames