### PR TITLE
fix(den): mint desktop MCP proxy resource

### DIFF
--- a/apps/app/tests/cloud-mcp-health.test.ts
+++ b/apps/app/tests/cloud-mcp-health.test.ts
@@ -9,6 +9,7 @@ import {
   writeCloudMcpSyncMarker,
 } from "../src/react-app/domains/connections/cloud-mcp-user-state";
 import {
+  buildOpenworkCloudMcpReconcilePayload,
   cloudMcpDisplaySummary,
   cloudMcpFailureStageLabel,
   isCloudMcpAuthTokenFailure,
@@ -132,6 +133,21 @@ function health(input: { usable: boolean; failure?: OpenworkCloudMcpFailure | nu
 
 describe("OpenWork Cloud MCP reconciler", () => {
   beforeEach(() => installStorageStub());
+
+  test("uses the minted web proxy resource instead of a stale direct API fallback", () => {
+    const payload = buildOpenworkCloudMcpReconcilePayload({
+      context: {
+        ...context,
+        fallbackUrl: "https://api.openwork.test/mcp/agent",
+      },
+      token: {
+        ...token,
+        resource: "https://app.openwork.test/api/den/mcp",
+      },
+    });
+
+    expect(payload?.config.url).toBe("https://app.openwork.test/api/den/mcp/agent");
+  });
 
   test("Test now performs only GET health", async () => {
     const values = new Map<string, string>();

--- a/ee/apps/den-api/src/mcp/resource.ts
+++ b/ee/apps/den-api/src/mcp/resource.ts
@@ -11,6 +11,10 @@
  * Kept dependency-free so it stays unit-testable without booting env/db.
  */
 
+import { firstForwardedValue, trustedForwardedOrigin } from "../request-url.js"
+
+const DEN_WEB_PROXY_PREFIX = "/api/den"
+
 export function isHostedWebAppHost(hostname: string, webAppHosts: readonly string[]): boolean {
   const normalized = hostname.trim().toLowerCase()
   if (!normalized) return false
@@ -87,4 +91,22 @@ export function resolveMcpResourceFromRequest(
   const candidates = [bareResource, proxiedResource]
   const match = candidates.find((candidate) => resources.includes(candidate))
   return match ?? fallback
+}
+
+function normalizedForwardedPrefix(value: string | null): string | null {
+  const prefix = firstForwardedValue(value)
+  if (!prefix) return null
+  return prefix.replace(/\/+$/, "") || "/"
+}
+
+export function deriveFirstPartyMcpTokenResourceFromRequest(
+  request: Request,
+  options: { fallback: string; trustedOrigins: readonly string[] },
+): string {
+  if (normalizedForwardedPrefix(request.headers.get("x-forwarded-prefix")) !== DEN_WEB_PROXY_PREFIX) {
+    return options.fallback
+  }
+
+  const forwarded = trustedForwardedOrigin(request, { trustedOrigins: options.trustedOrigins })
+  return forwarded ? `${forwarded.origin}${DEN_WEB_PROXY_PREFIX}/mcp` : options.fallback
 }

--- a/ee/apps/den-api/src/request-url.ts
+++ b/ee/apps/den-api/src/request-url.ts
@@ -2,7 +2,7 @@ type PublicRequestUrlOptions = {
   trustedOrigins?: readonly string[]
 }
 
-function firstForwardedValue(value: string | null): string | null {
+export function firstForwardedValue(value: string | null): string | null {
   const first = value?.split(",", 1)[0]?.trim()
   return first || null
 }
@@ -40,6 +40,13 @@ function forwardedOrigin(request: Request, protocol: string, trustedOrigins: rea
   }
 }
 
+export function trustedForwardedOrigin(request: Request, options: PublicRequestUrlOptions = {}): URL | null {
+  const url = new URL(request.url)
+  const proto = firstForwardedValue(request.headers.get("x-forwarded-proto"))?.toLowerCase()
+  const protocol = proto === "https" || proto === "http" ? `${proto}:` : url.protocol
+  return forwardedOrigin(request, protocol, options.trustedOrigins ?? [])
+}
+
 export function publicRequestUrl(request: Request, options: PublicRequestUrlOptions = {}): URL {
   const url = new URL(request.url)
   const proto = firstForwardedValue(request.headers.get("x-forwarded-proto"))?.toLowerCase()
@@ -47,7 +54,7 @@ export function publicRequestUrl(request: Request, options: PublicRequestUrlOpti
     url.protocol = `${proto}:`
   }
 
-  const forwarded = forwardedOrigin(request, url.protocol, options.trustedOrigins ?? [])
+  const forwarded = trustedForwardedOrigin(request, options)
   if (forwarded) {
     url.hostname = forwarded.hostname
     url.port = forwarded.port

--- a/ee/apps/den-api/src/routes/mcp/index.ts
+++ b/ee/apps/den-api/src/routes/mcp/index.ts
@@ -6,7 +6,9 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { DEN_MCP_FIRST_PARTY_CLIENT_ID, DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX, DEN_MCP_RESOURCE } from "../../auth.js"
 import { db } from "../../db.js"
+import { env } from "../../env.js"
 import { hashOpaqueMcpSecret } from "../../mcp/auth.js"
+import { deriveFirstPartyMcpTokenResourceFromRequest } from "../../mcp/resource.js"
 import { resolveMcpTokenScopes } from "../../mcp/scopes.js"
 import { DEN_FIRST_PARTY_MCP_TOKEN_TTL_MS } from "../../mcp/token-lifetime.js"
 import {
@@ -50,6 +52,11 @@ const organizationRequiredSchema = z.object({
 }).meta({ ref: "McpTokenOrganizationRequiredError" })
 
 type McpRouteVariables = AuthContextVariables & Partial<OrganizationContextVariables>
+
+const firstPartyMcpTokenTrustedOrigins = Array.from(new Set([
+  env.betterAuthUrl,
+  ...env.publicUrlTrustedOrigins,
+]))
 
 export function registerMcpTokenRoutes<T extends { Variables: McpRouteVariables }>(app: Hono<T>) {
   app.post(
@@ -111,7 +118,10 @@ export function registerMcpTokenRoutes<T extends { Variables: McpRouteVariables 
         expiresAt: expiresAt.toISOString(),
         organizationId: normalizeDenTypeId("organization", orgId),
         scopes,
-        resource: DEN_MCP_RESOURCE,
+        resource: deriveFirstPartyMcpTokenResourceFromRequest(c.req.raw, {
+          fallback: DEN_MCP_RESOURCE,
+          trustedOrigins: firstPartyMcpTokenTrustedOrigins,
+        }),
       })
     },
   )

--- a/ee/apps/den-api/test/mcp-resource-url.test.ts
+++ b/ee/apps/den-api/test/mcp-resource-url.test.ts
@@ -161,6 +161,22 @@ describe("getMcpResourceUrl", () => {
     })
   })
 
+  test("keeps the external OAuth resource on the configured public API origin for proxied requests", () => {
+    runMcpResourceProbe({
+      betterAuthUrl: "https://app.example.com",
+      apiPublicUrl: "https://api.example.com",
+      route: "agent",
+      headers: {
+        "x-forwarded-host": "app.example.com",
+        "x-forwarded-prefix": "/api/den",
+        "x-forwarded-proto": "https",
+      },
+      requestUrl: "http://den-api.internal/mcp/agent",
+      expectedResource: "https://api.example.com/mcp/agent",
+      expectedMetadataUrl: "https://api.example.com/.well-known/oauth-protected-resource/mcp/agent",
+    })
+  })
+
   test("does not derive the agent OAuth resource from a spoofed request host", () => {
     runMcpResourceProbe({
       betterAuthUrl: "https://app.example.com",

--- a/ee/apps/den-api/test/mcp-resource.test.ts
+++ b/ee/apps/den-api/test/mcp-resource.test.ts
@@ -1,6 +1,16 @@
 import { describe, expect, test } from "bun:test"
 
-import { deriveDenMcpResource, isHostedWebAppHost } from "../src/mcp/resource.js"
+import { deriveDenMcpResource, deriveFirstPartyMcpTokenResourceFromRequest, isHostedWebAppHost } from "../src/mcp/resource.js"
+
+const DIRECT_API_MCP_RESOURCE = "https://api.example.com/mcp"
+const TRUSTED_WEB_ORIGINS = ["https://app.example.com"]
+
+function firstPartyTokenResource(headers: HeadersInit = {}) {
+  return deriveFirstPartyMcpTokenResourceFromRequest(new Request("http://den-api.internal/v1/mcp/token", { headers }), {
+    fallback: DIRECT_API_MCP_RESOURCE,
+    trustedOrigins: TRUSTED_WEB_ORIGINS,
+  })
+}
 
 describe("deriveDenMcpResource", () => {
   test("routes hosted web-app origins through the /api/den proxy", () => {
@@ -62,5 +72,27 @@ describe("isHostedWebAppHost", () => {
     expect(isHostedWebAppHost("127.0.0.1", [])).toBe(false)
     expect(isHostedWebAppHost("example.com", [])).toBe(false)
     expect(isHostedWebAppHost("", [])).toBe(false)
+  })
+})
+
+describe("deriveFirstPartyMcpTokenResourceFromRequest", () => {
+  test("uses the trusted den-web /api/den proxy origin", () => {
+    expect(firstPartyTokenResource({
+      "x-forwarded-host": "app.example.com",
+      "x-forwarded-prefix": "/api/den",
+      "x-forwarded-proto": "https",
+    })).toBe("https://app.example.com/api/den/mcp")
+  })
+
+  test("falls back for direct API calls", () => {
+    expect(firstPartyTokenResource()).toBe(DIRECT_API_MCP_RESOURCE)
+  })
+
+  test("rejects untrusted forwarded hosts", () => {
+    expect(firstPartyTokenResource({
+      "x-forwarded-host": "evil.example",
+      "x-forwarded-prefix": "/api/den",
+      "x-forwarded-proto": "https",
+    })).toBe(DIRECT_API_MCP_RESOURCE)
   })
 })

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -5,6 +5,7 @@ import { NextRequest } from "next/server";
 import { setStructuredLogSink, useJsonStdoutStructuredLogSink } from "../../../observability/runtime-logger.ts";
 
 const previousDenApiBase = process.env.DEN_API_BASE;
+const previousDenWebPublicOrigin = process.env.DEN_WEB_PUBLIC_ORIGIN;
 
 describe("Den upstream proxy", () => {
   let server;
@@ -23,6 +24,10 @@ describe("Den upstream proxy", () => {
           cookie: request.headers.get("cookie"),
           authorization: request.headers.get("authorization"),
           custom: request.headers.get("x-custom-proxy-test"),
+          forwarded: request.headers.get("forwarded"),
+          forwardedHost: request.headers.get("x-forwarded-host"),
+          forwardedPrefix: request.headers.get("x-forwarded-prefix"),
+          forwardedProto: request.headers.get("x-forwarded-proto"),
           traceparent: request.headers.get("traceparent"),
           tracestate: request.headers.get("tracestate"),
         };
@@ -70,6 +75,11 @@ describe("Den upstream proxy", () => {
     } else {
       process.env.DEN_API_BASE = previousDenApiBase;
     }
+    if (previousDenWebPublicOrigin === undefined) {
+      delete process.env.DEN_WEB_PUBLIC_ORIGIN;
+    } else {
+      process.env.DEN_WEB_PUBLIC_ORIGIN = previousDenWebPublicOrigin;
+    }
   });
 
   test("passes method, path, query, body, cookies, auth, status, and headers through", async () => {
@@ -94,6 +104,10 @@ describe("Den upstream proxy", () => {
       cookie: "ow_session=sess_test",
       authorization: "Bearer tok_test",
       custom: "kept",
+      forwarded: null,
+      forwardedHost: "app.example.com",
+      forwardedPrefix: "/api/den",
+      forwardedProto: "https",
       traceparent: null,
       tracestate: null,
     });
@@ -170,6 +184,25 @@ describe("Den upstream proxy", () => {
 
     expect(observed.traceparent).toBe(traceparent);
     expect(observed.tracestate).toBe(tracestate);
+  });
+
+  test("overwrites spoofable forwarded headers", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const request = new NextRequest("https://app.example.com/api/den/v1/me", {
+      headers: {
+        forwarded: "host=evil.example;proto=http",
+        "x-forwarded-host": "evil.example",
+        "x-forwarded-prefix": "/evil",
+        "x-forwarded-proto": "http",
+      },
+    });
+
+    await proxyUpstream(request, [], { routePrefix: "/api/den" });
+
+    expect(observed.forwardedHost).toBe("app.example.com");
+    expect(observed.forwardedPrefix).toBe("/api/den");
+    expect(observed.forwardedProto).toBe("https");
+    expect(observed.forwarded).toBeNull();
   });
 
   test("injects the active W3C trace context into upstream requests", async () => {

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -15,6 +15,7 @@ const HOP_BY_HOP_HEADERS = new Set([
 ]);
 const REQUEST_ONLY_HEADERS = new Set(["host", "content-length"]);
 const RESPONSE_ONLY_HEADERS = new Set(["content-length", "content-encoding"]);
+const SPOOFABLE_FORWARDING_HEADERS = new Set(["forwarded", "x-forwarded-host", "x-forwarded-prefix", "x-forwarded-proto"]);
 
 type ProxyOptions = {
   routePrefix: string;
@@ -29,6 +30,19 @@ function normalizeBaseUrl(value: string): string {
 function readBaseUrlEnv(name: string): string | null {
   const value = process.env[name]?.trim();
   return value ? normalizeBaseUrl(value) : null;
+}
+
+function requestPublicOrigin(request: NextRequest): URL {
+  const configuredOrigin = readBaseUrlEnv("DEN_WEB_PUBLIC_ORIGIN");
+  if (configuredOrigin) {
+    try {
+      return new URL(configuredOrigin);
+    } catch {
+      return new URL(request.url);
+    }
+  }
+
+  return new URL(request.url);
 }
 
 function normalizePathPrefix(value: string): string {
@@ -66,7 +80,7 @@ function buildTargetUrl(
 
 function shouldSkipRequestHeader(name: string): boolean {
   const normalized = name.toLowerCase();
-  return HOP_BY_HOP_HEADERS.has(normalized) || REQUEST_ONLY_HEADERS.has(normalized);
+  return HOP_BY_HOP_HEADERS.has(normalized) || REQUEST_ONLY_HEADERS.has(normalized) || SPOOFABLE_FORWARDING_HEADERS.has(normalized);
 }
 
 function shouldSkipResponseHeader(name: string): boolean {
@@ -90,13 +104,17 @@ async function injectActiveTraceContext(headers: Headers): Promise<void> {
   }
 }
 
-async function cloneRequestHeaders(request: NextRequest): Promise<Headers> {
+async function cloneRequestHeaders(request: NextRequest, routePrefix: string): Promise<Headers> {
   const headers = new Headers();
   request.headers.forEach((value, name) => {
     if (!shouldSkipRequestHeader(name)) {
       headers.append(name, value);
     }
   });
+  const publicOrigin = requestPublicOrigin(request);
+  headers.set("x-forwarded-host", publicOrigin.host);
+  headers.set("x-forwarded-proto", publicOrigin.protocol.replace(/:$/, ""));
+  headers.set("x-forwarded-prefix", routePrefix);
   await injectActiveTraceContext(headers);
   return headers;
 }
@@ -197,7 +215,7 @@ export async function proxyUpstream(
   try {
     upstream = await fetch(targetUrl, {
       method: request.method,
-      headers: await cloneRequestHeaders(request),
+      headers: await cloneRequestHeaders(request, options.routePrefix),
       body: await readRequestBody(request),
       redirect: "manual",
     });

--- a/evals/flows/cloud-mcp-base-url.flow.mjs
+++ b/evals/flows/cloud-mcp-base-url.flow.mjs
@@ -1,0 +1,108 @@
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "cloud-mcp-base-url";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function witness(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, assertion + (actual ? ` (actual: ${actual})` : ""));
+}
+
+function run(ctx, label, args) {
+  const result = spawnSync("pnpm", args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 120_000,
+  });
+  const output = [result.stdout, result.stderr].filter(Boolean).join("\n").trim();
+  ctx.output(label, output);
+  witness(ctx, result.status === 0, `${label} exits successfully`, String(result.status));
+  return output;
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Cloud MCP tokens follow the desktop base URL",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Sign-in token minting prepares the cloud-agent resource",
+      run: async (ctx) => {
+        await ctx.prove("The first-party token route derives its resource from the signed-in request", {
+          voiceover: vo[0],
+          assert: async () => {
+            const route = await readFile(join(ROOT, "ee/apps/den-api/src/routes/mcp/index.ts"), "utf8");
+            witness(ctx, route.includes("deriveFirstPartyMcpTokenResourceFromRequest(c.req.raw"), "The signed-in token route derives resource from the incoming request");
+            witness(ctx, route.includes("trustedOrigins: firstPartyMcpTokenTrustedOrigins"), "Only trusted deployment origins may select the resource URL");
+            ctx.output("First-party token route", route.split("\n").slice(108, 128).join("\n"));
+          },
+        });
+      },
+    },
+    {
+      name: "Minted resource follows the web base URL proxy",
+      run: async (ctx) => {
+        await ctx.prove("A proxied token request returns <baseUrl>/api/den/mcp and rejects spoofed origins", {
+          voiceover: vo[1],
+          assert: async () => {
+            const output = run(ctx, "$ den-api MCP resource tests", [
+              "--filter", "@openwork-ee/den-api", "exec", "bun", "test",
+              "test/mcp-resource.test.ts", "test/mcp-resource-url.test.ts",
+            ]);
+            witness(ctx, output.includes("21 pass"), "All resource derivation and external OAuth regression tests pass", output.split("\n").at(-1) ?? output);
+          },
+        });
+      },
+    },
+    {
+      name: "Refresh replaces a stale direct API endpoint",
+      run: async (ctx) => {
+        await ctx.prove("Desktop reconciliation turns the minted proxy resource into /api/den/mcp/agent", {
+          voiceover: vo[2],
+          assert: async () => {
+            const output = run(ctx, "$ desktop cloud MCP reconciliation test", [
+              "--filter", "@openwork/app", "exec", "bun", "test",
+              "tests/cloud-mcp-health.test.ts",
+              "--test-name-pattern", "uses the minted web proxy resource",
+            ]);
+            witness(ctx, output.includes("1 pass"), "The minted proxy resource replaces a stale api.* fallback", output.split("\n").at(-1) ?? output);
+          },
+        });
+      },
+    },
+    {
+      name: "The trusted proxy path remains connectable",
+      run: async (ctx) => {
+        await ctx.prove("The web proxy supplies trusted metadata and the cloud MCP accepts its /api/den/mcp/agent endpoint", {
+          voiceover: vo[3],
+          assert: async () => {
+            const proxyOutput = run(ctx, "$ den-web trusted proxy test", [
+              "--filter", "@openwork-ee/den-web", "exec", "bun", "test",
+              "app/api/_lib/upstream-proxy.test.mjs",
+              "--test-name-pattern", "overwrites spoofable forwarded headers",
+            ]);
+            witness(ctx, proxyOutput.includes("1 pass"), "The web proxy overwrites spoofable forwarding metadata", proxyOutput.split("\n").at(-1) ?? proxyOutput);
+
+            const connectOutput = run(ctx, "$ cloud MCP proxy endpoint test", [
+              "--filter", "openwork-server", "exec", "bun", "test",
+              "src/cloud-mcp-reconcile.e2e.test.ts",
+              "--test-name-pattern", "normalizes a harmless trailing slash",
+            ]);
+            witness(ctx, connectOutput.includes("1 pass"), "The cloud MCP connects through an /api/den/mcp/agent endpoint", connectOutput.split("\n").at(-1) ?? connectOutput);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/cloud-mcp-base-url.md
+++ b/evals/voiceovers/cloud-mcp-base-url.md
@@ -1,0 +1,9 @@
+# cloud-mcp-base-url — Cloud MCP tokens follow the desktop base URL
+
+1. I sign in to OpenWork Cloud, and the desktop automatically prepares its cloud-agent connection.
+
+2. The minted token advertises the desktop's configured base URL through `/api/den/mcp`, never the separate direct API origin.
+
+3. After refreshing the connection, `openwork-cloud` uses `<baseUrl>/api/den/mcp/agent`, replacing any prior `api.` endpoint.
+
+4. The cloud tools connect successfully through that URL, including custom and self-hosted base URLs.


### PR DESCRIPTION
## Summary
- mint first-party desktop MCP tokens with the trusted Den web proxy resource
- overwrite spoofable forwarding headers at the `/api/den` proxy boundary
- preserve direct API resources for external OAuth and direct API calls
- add an app-less fraimz covering token minting, refresh, and proxy connectivity

## Tests
- `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-resource.test.ts test/mcp-resource-url.test.ts` — 21 passed
- `pnpm --filter @openwork/app exec bun test tests/cloud-mcp-health.test.ts --test-name-pattern "uses the minted web proxy resource"` — 1 passed
- `pnpm --filter @openwork-ee/den-web exec bun test app/api/_lib/upstream-proxy.test.mjs --test-name-pattern "overwrites spoofable forwarded headers"` — 1 passed
- `pnpm --filter openwork-server exec bun test src/cloud-mcp-reconcile.e2e.test.ts --test-name-pattern "normalizes a harmless trailing slash"` — 1 passed
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit --pretty false` — passed
- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm fraimz --flow cloud-mcp-base-url` — passed

## Proof
App-less internal fraimz: `evals/results/2026-07-15T17-14-03-894Z/fraimz.html` (generated locally; PR proof comment follows).

No video was captured because this is an internal token/proxy invariant with no new UI surface; the fraimz records executable assertions and command output.