### PR TITLE
feat(app): expose global SDK client on window.__OPENWORK_SDK__ in dev

### DIFF
--- a/apps/app/src/react-app/kernel/dev-sdk-global.ts
+++ b/apps/app/src/react-app/kernel/dev-sdk-global.ts
@@ -1,0 +1,33 @@
+import type { createClient } from "../../app/lib/opencode";
+
+type OpencodeWrapperClient = ReturnType<typeof createClient>;
+
+/**
+ * Dev-only DevTools handle for the live opencode SDK surface.
+ *
+ * `createClient` mints ad-hoc clients against any base URL; `workspace`
+ * carries the exact client + directory the active session route is using,
+ * so console checks (tool.ids, mcp.status, session.messages) match what
+ * sessions actually see.
+ */
+export type DevSdkGlobal = {
+  url?: string;
+  healthy?: boolean;
+  createClient?: typeof createClient;
+  workspace?: {
+    directory: string;
+    baseUrl: string;
+    client: OpencodeWrapperClient;
+  } | null;
+};
+
+declare global {
+  interface Window {
+    __OPENWORK_SDK__?: DevSdkGlobal;
+  }
+}
+
+export function exposeDevSdkGlobal(partial: Partial<DevSdkGlobal>): void {
+  if (!import.meta.env.DEV || typeof window === "undefined") return;
+  window.__OPENWORK_SDK__ = { ...window.__OPENWORK_SDK__, ...partial };
+}

--- a/apps/app/src/react-app/kernel/server-provider.tsx
+++ b/apps/app/src/react-app/kernel/server-provider.tsx
@@ -12,8 +12,10 @@ import {
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 
 import { desktopFetch } from "../../app/lib/desktop";
+import { createClient } from "../../app/lib/opencode";
 import { isWebDeployment } from "../../app/lib/openwork-deployment";
 import { isDesktopRuntime } from "../../app/utils";
+import { exposeDevSdkGlobal } from "./dev-sdk-global";
 import { initialServerState, serverReducer } from "./server-provider-state";
 
 export function normalizeServerUrl(input: string): string | undefined {
@@ -174,6 +176,10 @@ export function ServerProvider({ children, defaultUrl }: ServerProviderProps) {
       window.clearInterval(interval);
     };
   }, [active]);
+
+  useEffect(() => {
+    exposeDevSdkGlobal({ url: active, healthy, createClient });
+  }, [active, healthy]);
 
   const setActive = useCallback((input: string) => {
     const next = normalizeServerUrl(input);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -89,6 +89,7 @@ import {
   workspaceExportFilename,
   workspaceLabel,
 } from "@/react-app/shell/route-workspaces";
+import { exposeDevSdkGlobal } from "@/react-app/kernel/dev-sdk-global";
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { SessionPage, type OpenSessionTab } from "@/react-app/domains/session/chat/session-page";
@@ -413,6 +414,18 @@ export function SessionRoute() {
     workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? null,
     providerModel: cloudMcpProviderModel,
   });
+  useEffect(() => {
+    exposeDevSdkGlobal({
+      workspace:
+        opencodeClient && selectedWorkspaceRoot
+          ? {
+              directory: selectedWorkspaceRoot,
+              baseUrl: opencodeBaseUrl ?? "",
+              client: opencodeClient,
+            }
+          : null,
+    });
+  }, [opencodeBaseUrl, opencodeClient, selectedWorkspaceRoot]);
   // Agent selection is persisted in local prefs (like the model variant) so
   // it survives reloads instead of silently falling back to "build" (#2101).
   const selectedAgent = local.prefs.selectedAgent;


### PR DESCRIPTION
## What

Dev-only DevTools handle on `window.__OPENWORK_SDK__`, published from the providers that are actually mounted:

- `ServerProvider` stamps the active server `url`, `healthy`, and the app's `createClient` factory (from `app/lib/opencode`).
- The session route stamps `workspace` — the live workspace-scoped client, its base URL, and the selected workspace `directory`.

Both go through a shared `exposeDevSdkGlobal` helper gated on `import.meta.env.DEV`, so it is compiled out of production builds. A typed `declare global` covers the window field.

An earlier revision hooked `GlobalSDKProvider`, which is not mounted in the app tree; this revision targets the live providers instead.

## Why

Makes it easy to check session context from the DevTools console — e.g. which tools/MCP servers are injected for the workspace you're looking at, using the exact client the app uses:

```js
const { workspace, createClient } = __OPENWORK_SDK__;
await workspace.client.tool.ids({ query: { directory: workspace.directory } })
await workspace.client.mcp.status({ query: { directory: workspace.directory } })
```

No new credential exposure: the bearer token already lives in `localStorage` (`openwork.server.token`).

## Notes

- `pnpm --filter @openwork/app typecheck` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)