### PR TITLE
feat(app): expose OpenCode SDK in developer mode

### DIFF
--- a/apps/app/src/app/lib/app-inspector.ts
+++ b/apps/app/src/app/lib/app-inspector.ts
@@ -1,3 +1,5 @@
+import type { Client } from "../types";
+
 /**
  * Lightweight runtime-inspection surface for the React app.
  *
@@ -17,6 +19,8 @@ export type InspectorSliceGetter = () => unknown;
 
 type InspectorAPI = {
   version: number;
+  /** Active workspace's authenticated OpenCode SDK client when developer mode is enabled. */
+  readonly opencode: Client | null;
   snapshot(): Record<string, unknown>;
   slice(name: string): unknown;
   listSlices(): string[];
@@ -39,12 +43,14 @@ const EVENT_BUFFER_MAX = 200;
 type Registry = {
   slices: Map<string, InspectorSliceGetter>;
   events: Array<{ at: number; name: string; data: unknown }>;
+  opencodeClient: Client | null;
   installed: boolean;
 };
 
 const registry: Registry = {
   slices: new Map(),
   events: [],
+  opencodeClient: null,
   installed: false,
 };
 
@@ -74,6 +80,9 @@ function installIfNeeded() {
 
   const api: InspectorAPI = {
     version: INSPECTOR_VERSION,
+    get opencode() {
+      return registry.opencodeClient;
+    },
     snapshot: buildSnapshot,
     slice(name) {
       const getter = registry.slices.get(name);
@@ -115,6 +124,14 @@ export function publishInspectorSlice(
   return () => {
     const current = registry.slices.get(name);
     if (current === getter) registry.slices.delete(name);
+  };
+}
+
+export function publishInspectorOpencodeClient(client: Client): () => void {
+  installIfNeeded();
+  registry.opencodeClient = client;
+  return () => {
+    if (registry.opencodeClient === client) registry.opencodeClient = null;
   };
 }
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -339,6 +339,10 @@ export function SessionRoute() {
   const restrictionNotice = useRestrictionNotice();
   const [openworkServerHostInfoState, setOpenworkServerHostInfoState] = useState<OpenworkServerInfo | null>(null);
   const [openworkServerSettingsVersion, setOpenworkServerSettingsVersion] = useState(0);
+  const [developerMode, setDeveloperMode] = useState(() => {
+    if (typeof window === "undefined") return false;
+    return window.localStorage.getItem("openwork.developerMode") === "1";
+  });
   const {
     navigateToWorkspaceSession,
     routeWorkspaceId,
@@ -386,6 +390,7 @@ export function SessionRoute() {
     handleRemoteWorkspaceConnectionSaved,
     runRemoteWorkspaceConnectionCheck,
   } = useWorkspaceRouteState({
+    developerMode,
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });
@@ -438,10 +443,6 @@ export function SessionRoute() {
   const [renameWorkspaceId, setRenameWorkspaceId] = useState<string | null>(null);
   const [renameWorkspaceTitle, setRenameWorkspaceTitle] = useState("");
   const [renameWorkspaceBusy, setRenameWorkspaceBusy] = useState(false);
-  const [developerMode, setDeveloperMode] = useState(() => {
-    if (typeof window === "undefined") return false;
-    return window.localStorage.getItem("openwork.developerMode") === "1";
-  });
   const [paletteAccessibleTargets, setPaletteAccessibleTargets] = useState<OpenTarget[]>([]);
   const [providers, setProviders] = useState<ProviderListItem[]>([]);
   const [providerDefaults, setProviderDefaults] = useState<Record<string, string>>({});

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -8,7 +8,11 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 
-import { publishInspectorSlice, recordInspectorEvent } from "@/app/lib/app-inspector";
+import {
+  publishInspectorOpencodeClient,
+  publishInspectorSlice,
+  recordInspectorEvent,
+} from "@/app/lib/app-inspector";
 import {
   resolveWorkspaceListSelectedId,
   workspaceBootstrap,
@@ -52,6 +56,7 @@ import {
 import { legacySessionRoute, workspaceSessionRoute } from "./workspace-routes";
 
 export type UseWorkspaceRouteStateInput = {
+  developerMode: boolean;
   /** Invoked when the openwork-server settings-changed event fires (the route bumps its settings version). */
   onServerSettingsChanged: () => void;
   /** Receives the local openwork-server host info discovered during refresh. */
@@ -59,7 +64,7 @@ export type UseWorkspaceRouteStateInput = {
 };
 
 export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
-  const { onServerSettingsChanged, onHostInfo } = input;
+  const { developerMode, onServerSettingsChanged, onHostInfo } = input;
   const navigate = useNavigate();
   const local = useLocal();
   const params = useParams<{ workspaceId?: string; sessionId?: string }>();
@@ -749,6 +754,10 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         : null,
     [opencodeBaseUrl, selectedWorkspaceError, selectedWorkspaceRoot, selectedWorkspaceServerToken],
   );
+  useEffect(() => {
+    if (!developerMode || !opencodeClient) return;
+    return publishInspectorOpencodeClient(opencodeClient);
+  }, [developerMode, opencodeClient]);
   const runRemoteWorkspaceConnectionCheck = useCallback(
     async (workspaceId: string, mode: "test" | "recover") => {
       const workspace = workspacesRef.current.find((item) => item.id === workspaceId);

--- a/apps/app/tests/app-inspector.test.ts
+++ b/apps/app/tests/app-inspector.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  ensureInspectorInstalled,
+  publishInspectorOpencodeClient,
+} from "../src/app/lib/app-inspector";
+import { createClient } from "../src/app/lib/opencode";
+
+describe("app inspector OpenCode client", () => {
+  test("tracks the latest published client and clears it safely", () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {},
+    });
+    ensureInspectorInstalled();
+
+    const first = createClient("http://127.0.0.1:3000");
+    const second = createClient("http://127.0.0.1:3001");
+    const disposeFirst = publishInspectorOpencodeClient(first);
+    const disposeSecond = publishInspectorOpencodeClient(second);
+
+    expect(window.__openwork?.opencode).toBe(second);
+    disposeFirst();
+    expect(window.__openwork?.opencode).toBe(second);
+    disposeSecond();
+    expect(window.__openwork?.opencode).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

- Expose the active workspace authenticated OpenCode SDK client at `window.__openwork.opencode`.
- Follow workspace changes and clear stale clients safely.
- Gate the client with the app runtime developer-mode toggle, including packaged production builds.

## Evidence

### Build verification

- `pnpm --filter @openwork/app build` - passed.
- `pnpm --filter @openwork/app typecheck` - passed.
- `pnpm --filter @openwork/app exec bun test --isolate tests/app-inspector.test.ts` - passed, 1 test and 3 assertions.

### Runtime verification

- With `openwork.developerMode=0`, `window.__openwork.opencode` was unavailable.
- With `openwork.developerMode=1`, the SDK was available and `global.health()` returned `{ healthy: true, version: "1.17.11" }`.
- Restored the original developer-mode setting after verification.

### Screenshots

- No visual UI changes.

### API verification

- No API changes.

## Test instructions

1. Run `pnpm dev`.
2. Enable Developer mode from the command palette.
3. Open Electron DevTools.
4. Run `await window.__openwork.opencode.global.health()`.
5. Run `await window.__openwork.opencode.mcp.status()`.
6. Disable Developer mode and confirm `window.__openwork.opencode` is `null`.