### PR TITLE
feat(den): add descriptions to organization prompts

### DIFF
--- a/apps/app/src/components/chat/task-suggestions.tsx
+++ b/apps/app/src/components/chat/task-suggestions.tsx
@@ -20,13 +20,28 @@ const BROWSER_PROMPT =
 
 const ORGANIZATION_PROMPT_TITLES = ["Organization prompt 1", "Organization prompt 2", "Organization prompt 3"]
 
+export function resolveOrganizationPromptCardContent(input: {
+  prompt: string
+  description?: string
+  index: number
+}) {
+  const title = input.description?.trim()
+  return {
+    title: title || ORGANIZATION_PROMPT_TITLES[input.index] || "Organization prompt",
+    description: input.prompt,
+    selectionPrompt: input.prompt,
+  }
+}
+
 interface TaskSuggestionsProps {
   className?: string
 }
 
 export function TaskSuggestions({ className }: TaskSuggestionsProps) {
   const { displaySuggestions, providerConnectedCount, dispatchAction, setPrompt } = useMessageList()
-  const organizationPrompts = useOrgRestrictions().onboardingPrompts
+  const orgRestrictions = useOrgRestrictions()
+  const organizationPrompts = orgRestrictions.onboardingPrompts
+  const organizationPromptDescriptions = orgRestrictions.onboardingPromptDescriptions
 
   if (!displaySuggestions) {
     return null
@@ -70,17 +85,24 @@ export function TaskSuggestions({ className }: TaskSuggestionsProps) {
         ) : null}
 
         {hasOrganizationPrompts ? (
-          organizationPrompts.map((prompt, index) => (
-            <DescriptiveButton key={`${index}-${prompt}`} orientation="vertical" onClick={() => setPrompt(prompt)}>
-              <DescriptiveButtonIcon>
-                <SparklesIcon className="size-6 text-purple-10" aria-hidden />
-              </DescriptiveButtonIcon>
-              <DescriptiveButtonContent>
-                <DescriptiveButtonTitle>{ORGANIZATION_PROMPT_TITLES[index] ?? "Organization prompt"}</DescriptiveButtonTitle>
-                <DescriptiveButtonDescription>{prompt}</DescriptiveButtonDescription>
-              </DescriptiveButtonContent>
-            </DescriptiveButton>
-          ))
+          organizationPrompts.map((prompt, index) => {
+            const card = resolveOrganizationPromptCardContent({
+              prompt,
+              description: organizationPromptDescriptions?.[index],
+              index,
+            })
+            return (
+              <DescriptiveButton key={`${index}-${prompt}`} orientation="vertical" onClick={() => setPrompt(card.selectionPrompt)}>
+                <DescriptiveButtonIcon>
+                  <SparklesIcon className="size-6 text-purple-10" aria-hidden />
+                </DescriptiveButtonIcon>
+                <DescriptiveButtonContent>
+                  <DescriptiveButtonTitle>{card.title}</DescriptiveButtonTitle>
+                  <DescriptiveButtonDescription>{card.description}</DescriptiveButtonDescription>
+                </DescriptiveButtonContent>
+              </DescriptiveButton>
+            )
+          })
         ) : (
           <>
             <DescriptiveButton orientation="vertical" onClick={() => setPrompt(CSV_PROMPT)}>

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -62,6 +62,7 @@ const DESKTOP_CONFIG_ITEMS = [
   "brandAccentColor",
   "connectEnabled",
   "onboardingPrompts",
+  "onboardingPromptDescriptions",
 ] as const satisfies readonly (keyof DenDesktopConfig)[];
 
 type DesktopConfigItem = (typeof DESKTOP_CONFIG_ITEMS)[number];

--- a/apps/app/tests/den-desktop-config.test.ts
+++ b/apps/app/tests/den-desktop-config.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import {
   normalizeDesktopPolicyDocumentWrite,
   resolveDesktopPolicyDocumentWrite,
+  selectEffectiveOnboardingPromptConfig,
   selectEffectiveOnboardingPrompts,
 } from "@openwork/types/den/desktop-policies";
 import { createDenClient, normalizeDenDesktopConfig } from "../src/app/lib/den";
@@ -63,11 +64,20 @@ describe("Den desktop config client", () => {
   test("normalizes organization onboarding prompts from desktop config", () => {
     expect(normalizeDenDesktopConfig({
       onboardingPrompts: [" First task ", "Second task", "Third task"],
+      onboardingPromptDescriptions: [" First card ", "Second card", ""],
     }).onboardingPrompts).toEqual(["First task", "Second task", "Third task"]);
+    expect(normalizeDenDesktopConfig({
+      onboardingPrompts: [" First task ", "Second task", "Third task"],
+      onboardingPromptDescriptions: [" First card ", "Second card", ""],
+    }).onboardingPromptDescriptions).toEqual(["First card", "Second card", ""]);
 
     expect(normalizeDenDesktopConfig({
       onboardingPrompts: ["First task", "   "],
     }).onboardingPrompts).toBeUndefined();
+    expect(normalizeDenDesktopConfig({
+      onboardingPrompts: ["First task", "Second task", "Third task"],
+      onboardingPromptDescriptions: ["Mismatched", "Descriptions"],
+    }).onboardingPromptDescriptions).toBeUndefined();
   });
 
   test("selects targeted onboarding prompts by priority before default fallback", () => {
@@ -129,12 +139,32 @@ describe("Den desktop config client", () => {
         },
       ],
     })).toEqual(["Policy A", "Policy A follow-up"]);
+
+    expect(selectEffectiveOnboardingPromptConfig({
+      defaultPolicy: {
+        onboardingPrompts: defaultPrompts,
+        onboardingPromptDescriptions: ["Default card", "Default follow-up card"],
+      },
+      assignedPolicies: [{
+        id: "policy_with_descriptions",
+        priority: 20,
+        createdAt: "2026-01-04T00:00:00.000Z",
+        policy: {
+          onboardingPrompts: ["Targeted task", "Targeted follow-up"],
+          onboardingPromptDescriptions: ["Targeted card", "Targeted follow-up card"],
+        },
+      }],
+    })).toEqual({
+      onboardingPrompts: ["Targeted task", "Targeted follow-up"],
+      onboardingPromptDescriptions: ["Targeted card", "Targeted follow-up card"],
+    });
   });
 
   test("applies desktop policy prompt write semantics", () => {
     const existingPolicy = {
       allowZenModel: true,
       onboardingPrompts: ["Existing prompt", "Existing follow-up"],
+      onboardingPromptDescriptions: ["Existing card", "Existing follow-up card"],
     };
 
     expect(resolveDesktopPolicyDocumentWrite({
@@ -144,6 +174,7 @@ describe("Den desktop config client", () => {
     })).toEqual({
       allowZenModel: false,
       onboardingPrompts: ["Existing prompt", "Existing follow-up"],
+      onboardingPromptDescriptions: ["Existing card", "Existing follow-up card"],
     });
 
     expect(resolveDesktopPolicyDocumentWrite({
@@ -159,9 +190,24 @@ describe("Den desktop config client", () => {
     })).toEqual({ onboardingPrompts: ["Replacement", "Replacement follow-up"] });
 
     expect(resolveDesktopPolicyDocumentWrite({
+      value: {
+        onboardingPrompts: [" Replacement ", "Replacement follow-up"],
+        onboardingPromptDescriptions: [" Replacement card ", ""],
+      },
+      existingPolicy,
+      preserveExistingOnboardingPrompts: true,
+    })).toEqual({
+      onboardingPrompts: ["Replacement", "Replacement follow-up"],
+      onboardingPromptDescriptions: ["Replacement card", ""],
+    });
+
+    expect(resolveDesktopPolicyDocumentWrite({
       value: { onboardingPrompts: null },
     })).toEqual({});
 
-    expect(normalizeDesktopPolicyDocumentWrite({ onboardingPrompts: null })).toEqual({ onboardingPrompts: null });
+    expect(normalizeDesktopPolicyDocumentWrite({ onboardingPrompts: null })).toEqual({
+      onboardingPrompts: null,
+      onboardingPromptDescriptions: null,
+    });
   });
 });

--- a/apps/app/tests/task-suggestions.test.ts
+++ b/apps/app/tests/task-suggestions.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveOrganizationPromptCardContent } from "../src/components/chat/task-suggestions";
+
+describe("organization task suggestions", () => {
+  test("uses the saved description as the card title and selects the full prompt", () => {
+    const prompt = "Analyze the latest churn feedback and summarize the top three risks.";
+
+    expect(resolveOrganizationPromptCardContent({
+      prompt,
+      description: "Review churn feedback",
+      index: 0,
+    })).toEqual({
+      title: "Review churn feedback",
+      description: prompt,
+      selectionPrompt: prompt,
+    });
+  });
+
+  test("keeps a prompt-only fallback title for older policy data", () => {
+    expect(resolveOrganizationPromptCardContent({
+      prompt: "Draft a customer update.",
+      index: 1,
+    }).title).toBe("Organization prompt 2");
+  });
+});

--- a/ee/apps/den-api/src/desktop-policies.ts
+++ b/ee/apps/den-api/src/desktop-policies.ts
@@ -12,7 +12,7 @@ import {
   desktopPolicyDefaults,
   normalizeDesktopPolicyDocument,
   normalizeDesktopPolicyValue,
-  selectEffectiveOnboardingPrompts,
+  selectEffectiveOnboardingPromptConfig,
   type DesktopConfig,
   type DesktopPolicyValue,
 } from "@openwork/types/den/desktop-policies"
@@ -24,7 +24,7 @@ export type DesktopPolicyMemberRow = typeof DesktopPolicyMemberTable.$inferSelec
 export type OrgId = typeof DesktopPolicyTable.$inferSelect.organizationId
 export type OrgMemberId = typeof DesktopPolicyTable.$inferSelect.createdByOrgMemberId
 export type TeamId = typeof TeamTable.$inferSelect.id
-export type EffectiveDesktopPolicyConfig = Required<DesktopPolicyValue> & Pick<DesktopConfig, "onboardingPrompts">
+export type EffectiveDesktopPolicyConfig = Required<DesktopPolicyValue> & Pick<DesktopConfig, "onboardingPrompts" | "onboardingPromptDescriptions">
 
 export const DEFAULT_DESKTOP_POLICY_NAME = "Default desktop policy"
 
@@ -139,7 +139,7 @@ export async function calculateDesktopPolicyForOrgMember(input: {
     defaultPolicy: defaultPolicy?.policy ?? {},
     assignedPolicies: uniqueAssignedPolicies.map((row) => normalizeDesktopPolicyValue(row.policy)),
   })
-  const onboardingPrompts = selectEffectiveOnboardingPrompts({
+  const onboardingPromptConfig = selectEffectiveOnboardingPromptConfig({
     defaultPolicy: defaultPolicy?.policy ?? {},
     assignedPolicies: uniqueAssignedPolicies.map((row) => ({
       id: row.id,
@@ -151,6 +151,6 @@ export async function calculateDesktopPolicyForOrgMember(input: {
 
   return {
     ...effectivePolicy,
-    ...(onboardingPrompts !== undefined ? { onboardingPrompts } : {}),
+    ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
   }
 }

--- a/ee/apps/den-api/test/me-desktop-config.test.ts
+++ b/ee/apps/den-api/test/me-desktop-config.test.ts
@@ -46,6 +46,8 @@ const flatConnectMetadata = {
 const capabilityMetadata = { capabilities: { mcpConnections: true } }
 const defaultOnboardingPrompts = ["Default onboarding task", "Default onboarding follow-up"]
 const highPriorityOnboardingPrompts = ["High priority task", "High priority follow-up", "High priority optional"]
+const defaultOnboardingPromptDescriptions = ["Default onboarding", "Default follow-up"]
+const highPriorityOnboardingPromptDescriptions = ["High priority onboarding", "High priority follow-up", "High priority optional"]
 let crudDesktopPolicyId: string | null = null
 
 beforeAll(async () => {
@@ -126,7 +128,10 @@ beforeAll(async () => {
       policyName: "Default desktop policy",
       isDefault: true,
       isEnabled: true,
-      policy: { onboardingPrompts: defaultOnboardingPrompts },
+      policy: {
+        onboardingPrompts: defaultOnboardingPrompts,
+        onboardingPromptDescriptions: defaultOnboardingPromptDescriptions,
+      },
       createdByOrgMemberId: onboardingMemberId,
     },
     {
@@ -146,7 +151,10 @@ beforeAll(async () => {
       isDefault: null,
       isEnabled: true,
       priority: 10,
-      policy: { onboardingPrompts: highPriorityOnboardingPrompts },
+      policy: {
+        onboardingPrompts: highPriorityOnboardingPrompts,
+        onboardingPromptDescriptions: highPriorityOnboardingPromptDescriptions,
+      },
       createdByOrgMemberId: onboardingMemberId,
     },
   ])
@@ -292,9 +300,10 @@ test("GET /v1/me/desktop-config exposes the effective connectEnabled org flag", 
 test("GET /v1/me/desktop-config returns the effective onboarding prompts", async () => {
   const body = await requestDesktopConfig(onboardingOrganizationId)
   expect(body.onboardingPrompts).toEqual(highPriorityOnboardingPrompts)
+  expect(body.onboardingPromptDescriptions).toEqual(highPriorityOnboardingPromptDescriptions)
 })
 
-test("desktop policy CRUD preserves, replaces, and clears onboarding prompts", async () => {
+test("desktop policy CRUD preserves, replaces, and clears onboarding prompts and descriptions", async () => {
   const createPayload = await requestDesktopPolicyAdmin({
     method: "POST",
     path: "/v1/desktop-policies",
@@ -305,6 +314,7 @@ test("desktop policy CRUD preserves, replaces, and clears onboarding prompts", a
       policy: {
         allowZenModel: true,
         onboardingPrompts: ["CRUD prompt one", "CRUD prompt two"],
+        onboardingPromptDescriptions: ["CRUD card one", "CRUD card two"],
       },
       memberIds: [],
       teamIds: [],
@@ -315,6 +325,7 @@ test("desktop policy CRUD preserves, replaces, and clears onboarding prompts", a
   crudDesktopPolicyId = expectString(created.id, "Created desktop policy was missing id")
   expect(created.priority).toBe(3)
   expect(expectRecord(created.policy, "Created desktop policy was missing policy").onboardingPrompts).toEqual(["CRUD prompt one", "CRUD prompt two"])
+  expect(expectRecord(created.policy, "Created desktop policy was missing policy").onboardingPromptDescriptions).toEqual(["CRUD card one", "CRUD card two"])
 
   const listPayload = await requestDesktopPolicyAdmin({
     method: "GET",
@@ -325,6 +336,7 @@ test("desktop policy CRUD preserves, replaces, and clears onboarding prompts", a
   const listed = findListedDesktopPolicy(listPayload, crudDesktopPolicyId)
   expect(listed.priority).toBe(3)
   expect(expectRecord(listed.policy, "Listed desktop policy was missing policy").onboardingPrompts).toEqual(["CRUD prompt one", "CRUD prompt two"])
+  expect(expectRecord(listed.policy, "Listed desktop policy was missing policy").onboardingPromptDescriptions).toEqual(["CRUD card one", "CRUD card two"])
 
   const preservedPayload = await requestDesktopPolicyAdmin({
     method: "PATCH",
@@ -342,6 +354,29 @@ test("desktop policy CRUD preserves, replaces, and clears onboarding prompts", a
   const preserved = expectDesktopPolicy(preservedPayload)
   expect(preserved.priority).toBe(4)
   expect(expectRecord(preserved.policy, "Preserved desktop policy was missing policy").onboardingPrompts).toEqual(["CRUD prompt one", "CRUD prompt two"])
+  expect(expectRecord(preserved.policy, "Preserved desktop policy was missing policy").onboardingPromptDescriptions).toEqual(["CRUD card one", "CRUD card two"])
+
+  const replacedPayload = await requestDesktopPolicyAdmin({
+    method: "PATCH",
+    path: `/v1/desktop-policies/${encodeURIComponent(crudDesktopPolicyId)}`,
+    expectedStatus: 200,
+    body: {
+      policyName: "CRUD onboarding policy replaced",
+      priority: 5,
+      policy: {
+        allowZenModel: false,
+        onboardingPrompts: ["Replacement prompt one", "Replacement prompt two"],
+        onboardingPromptDescriptions: ["Replacement card one", "Replacement card two"],
+      },
+      memberIds: [],
+      teamIds: [],
+    },
+  })
+  if (!replacedPayload) throw new Error("Replace response was empty")
+  const replaced = expectDesktopPolicy(replacedPayload)
+  expect(replaced.priority).toBe(5)
+  expect(expectRecord(replaced.policy, "Replaced desktop policy was missing policy").onboardingPrompts).toEqual(["Replacement prompt one", "Replacement prompt two"])
+  expect(expectRecord(replaced.policy, "Replaced desktop policy was missing policy").onboardingPromptDescriptions).toEqual(["Replacement card one", "Replacement card two"])
 
   const clearedPayload = await requestDesktopPolicyAdmin({
     method: "PATCH",
@@ -349,7 +384,7 @@ test("desktop policy CRUD preserves, replaces, and clears onboarding prompts", a
     expectedStatus: 200,
     body: {
       policyName: "CRUD onboarding policy cleared",
-      priority: 5,
+      priority: 6,
       policy: { allowZenModel: false, onboardingPrompts: null },
       memberIds: [],
       teamIds: [],
@@ -357,8 +392,9 @@ test("desktop policy CRUD preserves, replaces, and clears onboarding prompts", a
   })
   if (!clearedPayload) throw new Error("Clear response was empty")
   const cleared = expectDesktopPolicy(clearedPayload)
-  expect(cleared.priority).toBe(5)
+  expect(cleared.priority).toBe(6)
   expect(expectRecord(cleared.policy, "Cleared desktop policy was missing policy").onboardingPrompts).toBeUndefined()
+  expect(expectRecord(cleared.policy, "Cleared desktop policy was missing policy").onboardingPromptDescriptions).toBeUndefined()
 
   await requestDesktopPolicyAdmin({
     method: "DELETE",

--- a/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policy-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/desktop-policy-editor-screen.tsx
@@ -31,6 +31,7 @@ type PolicyDraft = {
   priority: number;
   onboardingPromptsEnabled: boolean;
   onboardingPromptTexts: string[];
+  onboardingPromptDescriptions: string[];
   memberIds: string[];
   teamIds: string[];
 };
@@ -41,11 +42,13 @@ const EMPTY_DRAFT: PolicyDraft = {
   priority: 0,
   onboardingPromptsEnabled: false,
   onboardingPromptTexts: ["", "", ""],
+  onboardingPromptDescriptions: ["", "", ""],
   memberIds: [],
   teamIds: [],
 };
 
 const ONBOARDING_PROMPT_LABELS = ["First prompt", "Second prompt", "Optional third prompt"];
+const ONBOARDING_PROMPT_DESCRIPTION_MAX_LENGTH = 120;
 const MAX_POLICY_PRIORITY = 1_000_000;
 const PRIORITY_HELP_ID = "desktop-policy-priority-help";
 const PRIORITY_ERROR_ID = "desktop-policy-priority-error";
@@ -58,6 +61,7 @@ function requiredPolicyValue(value: DesktopPolicyValue): Required<DesktopPolicyV
 
 function draftFromPolicy(policy: DenDesktopPolicy): PolicyDraft {
   const onboardingPrompts = policy.policy.onboardingPrompts ?? [];
+  const onboardingPromptDescriptions = policy.policy.onboardingPromptDescriptions ?? [];
   return {
     policyName: policy.policyName,
     policy: requiredPolicyValue(policy.policy),
@@ -67,6 +71,11 @@ function draftFromPolicy(policy: DenDesktopPolicy): PolicyDraft {
       onboardingPrompts[0] ?? "",
       onboardingPrompts[1] ?? "",
       onboardingPrompts[2] ?? "",
+    ],
+    onboardingPromptDescriptions: [
+      onboardingPromptDescriptions[0] ?? "",
+      onboardingPromptDescriptions[1] ?? "",
+      onboardingPromptDescriptions[2] ?? "",
     ],
     memberIds: policy.assignments.flatMap((assignment) => (assignment.orgMemberId ? [assignment.orgMemberId] : [])),
     teamIds: policy.assignments.flatMap((assignment) => (assignment.teamId ? [assignment.teamId] : [])),
@@ -88,6 +97,10 @@ function updateOnboardingPromptText(values: string[], index: number, nextValue: 
   return values.map((value, valueIndex) => (valueIndex === index ? nextValue : value));
 }
 
+function updateOnboardingPromptDescription(values: string[], index: number, nextValue: string) {
+  return values.map((value, valueIndex) => (valueIndex === index ? nextValue : value));
+}
+
 function getOnboardingPrompts(draft: PolicyDraft): string[] | undefined {
   if (!draft.onboardingPromptsEnabled) return undefined;
 
@@ -97,6 +110,14 @@ function getOnboardingPrompts(draft: PolicyDraft): string[] | undefined {
   if (prompts.some((prompt) => prompt.length > 500)) return undefined;
 
   return prompts[2] ? [...requiredPrompts, prompts[2]] : requiredPrompts;
+}
+
+function getOnboardingPromptDescriptions(draft: PolicyDraft, promptCount: number): string[] | undefined {
+  const descriptions = draft.onboardingPromptDescriptions
+    .slice(0, promptCount)
+    .map((description) => description.trim());
+  if (descriptions.some((description) => description.length > ONBOARDING_PROMPT_DESCRIPTION_MAX_LENGTH)) return undefined;
+  return descriptions.some((description) => description.length > 0) ? descriptions : undefined;
 }
 
 function getPriorityError(draft: PolicyDraft, isDefault: boolean) {
@@ -117,12 +138,30 @@ function getPromptError(draft: PolicyDraft, index: number) {
   return null;
 }
 
+function getPromptDescriptionError(draft: PolicyDraft, index: number) {
+  if (!draft.onboardingPromptsEnabled) return null;
+  const description = draft.onboardingPromptDescriptions[index] ?? "";
+  const trimmed = description.trim();
+  if (trimmed.length > ONBOARDING_PROMPT_DESCRIPTION_MAX_LENGTH) {
+    return `Description must be ${ONBOARDING_PROMPT_DESCRIPTION_MAX_LENGTH} characters or less.`;
+  }
+  return null;
+}
+
 function getPromptHelpId(index: number) {
   return `desktop-policy-onboarding-prompt-${index}-help`;
 }
 
 function getPromptErrorId(index: number) {
   return `desktop-policy-onboarding-prompt-${index}-error`;
+}
+
+function getPromptDescriptionHelpId(index: number) {
+  return `desktop-policy-onboarding-prompt-${index}-description-help`;
+}
+
+function getPromptDescriptionErrorId(index: number) {
+  return `desktop-policy-onboarding-prompt-${index}-description-error`;
 }
 
 function getDisabledPromptCopy(isDefault: boolean) {
@@ -133,13 +172,21 @@ function getDisabledPromptCopy(isDefault: boolean) {
 
 function policyDocumentFromDraft(draft: PolicyDraft): DesktopPolicyDocumentWrite {
   const onboardingPrompts = getOnboardingPrompts(draft);
+  const onboardingPromptDescriptions = onboardingPrompts !== undefined
+    ? getOnboardingPromptDescriptions(draft, onboardingPrompts.length)
+    : undefined;
   return {
     ...draft.policy,
     ...(draft.onboardingPromptsEnabled
       ? onboardingPrompts !== undefined
-        ? { onboardingPrompts }
+        ? {
+            onboardingPrompts,
+            ...(onboardingPromptDescriptions !== undefined
+              ? { onboardingPromptDescriptions }
+              : {}),
+          }
         : {}
-      : { onboardingPrompts: null }),
+      : { onboardingPrompts: null, onboardingPromptDescriptions: null }),
   };
 }
 
@@ -191,7 +238,7 @@ export function DesktopPolicyEditorScreen({ desktopPolicyId }: { desktopPolicyId
     }
     if (draft.onboardingPromptsEnabled) {
       const promptError = ONBOARDING_PROMPT_LABELS
-        .map((_, index) => getPromptError(draft, index))
+        .map((_, index) => getPromptError(draft, index) ?? getPromptDescriptionError(draft, index))
         .find((error) => error !== null);
       if (promptError) {
         setPageError(promptError);
@@ -387,31 +434,58 @@ export function DesktopPolicyEditorScreen({ desktopPolicyId }: { desktopPolicyId
               <div className="grid gap-3">
                 {ONBOARDING_PROMPT_LABELS.map((label, index) => {
                   const promptError = getPromptError(draft, index);
+                  const promptDescriptionError = getPromptDescriptionError(draft, index);
                   const promptHelpId = getPromptHelpId(index);
                   const promptErrorId = getPromptErrorId(index);
+                  const promptDescriptionHelpId = getPromptDescriptionHelpId(index);
+                  const promptDescriptionErrorId = getPromptDescriptionErrorId(index);
                   return (
-                    <label key={label} className="grid gap-2">
-                      <span className="text-[13px] font-medium text-gray-700">{label}</span>
-                      <DenTextarea
-                        rows={2}
-                        maxLength={500}
-                        value={draft.onboardingPromptTexts[index] ?? ""}
-                        aria-invalid={promptError ? true : undefined}
-                        aria-describedby={promptError ? `${promptHelpId} ${promptErrorId}` : promptHelpId}
-                        onChange={(event) => setDraft({
-                          ...draft,
-                          onboardingPromptTexts: updateOnboardingPromptText(draft.onboardingPromptTexts, index, event.target.value),
-                        })}
-                        disabled={saving || togglingEnabled}
-                        placeholder={index === 2 ? "Optional" : "Enter a suggested prompt"}
-                      />
-                      <span id={promptHelpId} className="text-[12px] text-gray-500">
-                        {(draft.onboardingPromptTexts[index] ?? "").trim().length}/500 characters
-                      </span>
-                      {promptError ? (
-                        <span id={promptErrorId} className="text-[12px] text-red-600">{promptError}</span>
-                      ) : null}
-                    </label>
+                    <div key={label} className="grid gap-3 rounded-[18px] border border-gray-200 bg-white px-4 py-3">
+                      <p className="text-[13px] font-medium text-gray-700">{label}</p>
+                      <label className="grid gap-2">
+                        <span className="text-[12px] font-medium text-gray-600">Description</span>
+                        <DenInput
+                          maxLength={ONBOARDING_PROMPT_DESCRIPTION_MAX_LENGTH}
+                          value={draft.onboardingPromptDescriptions[index] ?? ""}
+                          aria-invalid={promptDescriptionError ? true : undefined}
+                          aria-describedby={promptDescriptionError ? `${promptDescriptionHelpId} ${promptDescriptionErrorId}` : promptDescriptionHelpId}
+                          onChange={(event) => setDraft({
+                            ...draft,
+                            onboardingPromptDescriptions: updateOnboardingPromptDescription(draft.onboardingPromptDescriptions, index, event.target.value),
+                          })}
+                          disabled={saving || togglingEnabled}
+                          placeholder="Card title shown in the desktop app"
+                        />
+                        <span id={promptDescriptionHelpId} className="text-[12px] text-gray-500">
+                          {(draft.onboardingPromptDescriptions[index] ?? "").trim().length}/{ONBOARDING_PROMPT_DESCRIPTION_MAX_LENGTH} characters
+                        </span>
+                        {promptDescriptionError ? (
+                          <span id={promptDescriptionErrorId} className="text-[12px] text-red-600">{promptDescriptionError}</span>
+                        ) : null}
+                      </label>
+                      <label className="grid gap-2">
+                        <span className="text-[12px] font-medium text-gray-600">Prompt</span>
+                        <DenTextarea
+                          rows={2}
+                          maxLength={500}
+                          value={draft.onboardingPromptTexts[index] ?? ""}
+                          aria-invalid={promptError ? true : undefined}
+                          aria-describedby={promptError ? `${promptHelpId} ${promptErrorId}` : promptHelpId}
+                          onChange={(event) => setDraft({
+                            ...draft,
+                            onboardingPromptTexts: updateOnboardingPromptText(draft.onboardingPromptTexts, index, event.target.value),
+                          })}
+                          disabled={saving || togglingEnabled}
+                          placeholder={index === 2 ? "Optional" : "Enter a suggested prompt"}
+                        />
+                        <span id={promptHelpId} className="text-[12px] text-gray-500">
+                          {(draft.onboardingPromptTexts[index] ?? "").trim().length}/500 characters
+                        </span>
+                        {promptError ? (
+                          <span id={promptErrorId} className="text-[12px] text-red-600">{promptError}</span>
+                        ) : null}
+                      </label>
+                    </div>
                   );
                 })}
               </div>

--- a/evals/flows/org-custom-prompt-descriptions.flow.mjs
+++ b/evals/flows/org-custom-prompt-descriptions.flow.mjs
@@ -1,0 +1,559 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import {
+  adminEnsureFreshAuth,
+  denFetch,
+  ensureRendererMounted,
+  ensureWorkspaceReady,
+  getPanelTargetId,
+  memberRefresh,
+  openAdminPanel,
+  panelEval,
+  sleep,
+  waitForDesktopConfig,
+  waitForPanel,
+  waitUntil,
+} from "./desktop-brand-icon.flow.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/org-custom-prompt-descriptions.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("org-custom-prompt-descriptions");
+
+const DESKTOP_POLICIES_PATH = "/dashboard/desktop-policies";
+const PROMPTS = [
+  "Analyze the latest churn feedback and summarize the top three risks.",
+  "Draft a launch-readiness brief for support, sales, and leadership.",
+];
+const DESCRIPTIONS = ["Review churn feedback", "Prepare launch brief"];
+
+const state = {
+  adminPanelTargetId: null,
+  defaultPolicy: null,
+  originalDefaultPolicy: null,
+};
+
+function denWebBase(ctx) {
+  return ctx.env.OPENWORK_EVAL_DEN_WEB_URL.replace(/\/$/, "");
+}
+
+function desktopPoliciesUrl(ctx) {
+  return `${denWebBase(ctx)}${DESKTOP_POLICIES_PATH}`;
+}
+
+function defaultPolicyEditorUrl(ctx) {
+  if (!state.defaultPolicy?.id) throw new Error("Default desktop policy was not loaded.");
+  return `${desktopPoliciesUrl(ctx)}/${encodeURIComponent(state.defaultPolicy.id)}`;
+}
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function arrayEquals(left, right) {
+  if (!Array.isArray(left) || !Array.isArray(right)) return false;
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => value === right[index]);
+}
+
+function promptConfigEquals(value, prompts, descriptions) {
+  const document = value?.policy ?? value ?? {};
+  return arrayEquals(document.onboardingPrompts, prompts) && arrayEquals(document.onboardingPromptDescriptions, descriptions);
+}
+
+function originalPromptConfigEquals(policy, originalPolicy) {
+  const current = policy?.policy ?? {};
+  const original = originalPolicy?.policy ?? {};
+  const currentPrompts = Array.isArray(current.onboardingPrompts) ? current.onboardingPrompts : null;
+  const originalPrompts = Array.isArray(original.onboardingPrompts) ? original.onboardingPrompts : null;
+  const currentDescriptions = Array.isArray(current.onboardingPromptDescriptions) ? current.onboardingPromptDescriptions : null;
+  const originalDescriptions = Array.isArray(original.onboardingPromptDescriptions) ? original.onboardingPromptDescriptions : null;
+  return JSON.stringify(currentPrompts) === JSON.stringify(originalPrompts) &&
+    JSON.stringify(currentDescriptions) === JSON.stringify(originalDescriptions);
+}
+
+function policyPayloadFromSavedPolicy(policy) {
+  const savedPolicy = policy.policy ?? {};
+  const nextPolicy = { ...savedPolicy };
+  if (Array.isArray(savedPolicy.onboardingPrompts)) {
+    nextPolicy.onboardingPrompts = savedPolicy.onboardingPrompts;
+    nextPolicy.onboardingPromptDescriptions = Array.isArray(savedPolicy.onboardingPromptDescriptions)
+      ? savedPolicy.onboardingPromptDescriptions
+      : null;
+  } else {
+    nextPolicy.onboardingPrompts = null;
+    nextPolicy.onboardingPromptDescriptions = null;
+  }
+  return {
+    policyName: policy.policyName,
+    policy: nextPolicy,
+    priority: policy.priority ?? 0,
+    isEnabled: policy.isEnabled !== false,
+    memberIds: (policy.assignments ?? []).flatMap((assignment) => assignment.orgMemberId ? [assignment.orgMemberId] : []),
+    teamIds: (policy.assignments ?? []).flatMap((assignment) => assignment.teamId ? [assignment.teamId] : []),
+  };
+}
+
+async function loadDefaultPolicy(ctx) {
+  const { body } = await denFetch(ctx, "/v1/desktop-policies");
+  const policies = Array.isArray(body?.desktopPolicies) ? body.desktopPolicies : [];
+  const defaultPolicy = policies.find((policy) => policy?.isDefault === true);
+  ctx.assert(defaultPolicy?.id, "The seeded Den org does not have a default desktop policy.");
+  return defaultPolicy;
+}
+
+async function waitForDefaultPolicyPromptConfig(ctx, label, prompts, descriptions) {
+  return waitUntil(ctx, label, async () => {
+    const policy = await loadDefaultPolicy(ctx);
+    return promptConfigEquals(policy, prompts, descriptions) ? policy : null;
+  }, { timeoutMs: 30_000, intervalMs: 750 });
+}
+
+async function waitForDesktopPromptConfig(ctx, label, prompts, descriptions) {
+  return waitForDesktopConfig(ctx, label, (config) => promptConfigEquals(config, prompts, descriptions), 30_000);
+}
+
+async function cleanupDefaultPolicy(ctx) {
+  if (!state.originalDefaultPolicy?.id) {
+    ctx.log("No original default desktop policy captured; skipping cleanup.");
+    return null;
+  }
+  await denFetch(ctx, `/v1/desktop-policies/${state.originalDefaultPolicy.id}`, {
+    method: "PATCH",
+    body: JSON.stringify(policyPayloadFromSavedPolicy(state.originalDefaultPolicy)),
+  });
+  const restored = await waitUntil(ctx, "default desktop policy cleanup restore", async () => {
+    const policy = await loadDefaultPolicy(ctx);
+    return originalPromptConfigEquals(policy, state.originalDefaultPolicy) ? policy : null;
+  }, { timeoutMs: 30_000, intervalMs: 750 });
+  await memberRefresh(ctx).catch((error) => ctx.log(`Desktop refresh after cleanup failed: ${errorMessage(error)}`));
+  return restored;
+}
+
+async function runWithErrorCleanup(ctx, callback) {
+  try {
+    return await callback();
+  } catch (error) {
+    await cleanupDefaultPolicy(ctx).catch((cleanupError) => {
+      ctx.log(`Cleanup after failed frame also failed: ${errorMessage(cleanupError)}`);
+    });
+    throw error;
+  }
+}
+
+async function ensureDesktopSession(ctx) {
+  const { body } = await denFetch(ctx, "/v1/me/orgs");
+  const organizations = Array.isArray(body?.orgs) ? body.orgs : [];
+  const activeOrg = organizations.find((organization) => organization?.id === body?.activeOrgId) ?? organizations[0];
+  ctx.assert(activeOrg?.id, "The eval token does not have an active organization.");
+
+  await ctx.control("eval.auth.set-base-url", { baseUrl: ctx.env.OPENWORK_EVAL_DEN_WEB_URL });
+  await ctx.eval(`(() => {
+    localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(ctx.env.OPENWORK_EVAL_DEN_WEB_URL)});
+    localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(ctx.env.OPENWORK_EVAL_DEN_API_URL)});
+    localStorage.setItem('openwork.den.authToken', ${JSON.stringify(ctx.env.OPENWORK_EVAL_DEN_TOKEN)});
+    localStorage.setItem('openwork.den.activeOrgId', ${JSON.stringify(activeOrg.id)});
+    localStorage.setItem('openwork.den.activeOrgSlug', ${JSON.stringify(activeOrg.slug ?? "example-corp")});
+    localStorage.setItem('openwork.den.activeOrgName', ${JSON.stringify(activeOrg.name ?? "Example Corp")});
+    window.dispatchEvent(new CustomEvent('openwork-den-settings-changed', { detail: {} }));
+    window.dispatchEvent(new CustomEvent('openwork-den-session-updated', { detail: { token: ${JSON.stringify(ctx.env.OPENWORK_EVAL_DEN_TOKEN)} } }));
+    return true;
+  })()`);
+
+  await waitUntil(ctx, "desktop Den session", async () => {
+    const status = await ctx.control("auth.status", {}).catch(() => null);
+    return status?.status === "signed_in" ? status : null;
+  }, { timeoutMs: 30_000 });
+}
+
+async function dismissDesktopOverlays(ctx) {
+  await ctx.eval(`(() => {
+    const continueButton = Array.from(document.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Continue without OpenWork Models')
+    );
+    if (continueButton) {
+      continueButton.click();
+      return 'continued-without-models';
+    }
+    const dialog = document.querySelector('[role="dialog"]');
+    const closeButton = dialog?.querySelector('button[aria-label="Close"], button');
+    if (closeButton) {
+      closeButton.click();
+      return 'closed-dialog';
+    }
+    return 'no-overlay';
+  })()`);
+  await sleep(300);
+}
+
+async function navigateAdminUrl(ctx, url, readyExpression, label) {
+  await panelEval(ctx, `location.replace(${JSON.stringify(url)})`).catch(() => undefined);
+  await sleep(500);
+  try {
+    await waitForPanel(ctx, readyExpression, { timeoutMs: 45_000, label });
+  } catch {
+    ctx.log(`${label} was not ready after first navigation; reloading once.`);
+    await panelEval(ctx, "location.reload()").catch(() => undefined);
+    await waitForPanel(ctx, readyExpression, { timeoutMs: 60_000, label: `${label} after reload` });
+  }
+}
+
+async function waitForAdminSession(ctx) {
+  return waitUntil(ctx, "Den admin browser session", async () => {
+    const session = await panelEval(ctx, `fetch('/api/auth/get-session', { credentials: 'include' })
+      .then((response) => response.ok ? response.json() : null)
+      .catch(() => null)`, { awaitPromise: true });
+    return session?.session?.userId ? session : null;
+  }, { timeoutMs: 15_000, intervalMs: 250 });
+}
+
+async function navigateDefaultPolicyEditor(ctx) {
+  await navigateAdminUrl(
+    ctx,
+    defaultPolicyEditorUrl(ctx),
+    `document.body.innerText.includes('Edit desktop policy') && document.body.innerText.includes('Organization prompt suggestions')`,
+    "default desktop policy editor",
+  );
+}
+
+async function reloadDefaultPolicyEditor(ctx) {
+  await navigateDefaultPolicyEditor(ctx);
+  await panelEval(ctx, "location.reload()").catch(() => undefined);
+  await waitForPanel(ctx, `document.body.innerText.includes('Edit desktop policy') && document.body.innerText.includes('Organization prompt suggestions')`, {
+    timeoutMs: 60_000,
+    label: "reloaded default desktop policy editor",
+  });
+}
+
+async function ensurePromptEditorOpen(ctx) {
+  await waitForPanel(ctx, `Boolean(Array.from(document.querySelectorAll('label')).find((label) =>
+    label.textContent?.includes('Organization prompt suggestions')
+  ))`, { timeoutMs: 20_000, label: "Organization prompt suggestions toggle" });
+  await panelEval(ctx, `(() => {
+    const label = Array.from(document.querySelectorAll('label')).find((entry) =>
+      entry.textContent?.includes('Organization prompt suggestions')
+    );
+    const checkbox = label?.querySelector('input[type="checkbox"]');
+    if (!checkbox) throw new Error('Organization prompt suggestions checkbox not found');
+    if (!checkbox.checked) checkbox.click();
+    label.scrollIntoView({ block: 'center' });
+    return checkbox.checked;
+  })()`);
+  await waitForPanel(ctx, `document.querySelectorAll('input[placeholder="Card title shown in the desktop app"]').length === 3 && document.querySelectorAll('textarea').length === 3`, {
+    timeoutMs: 15_000,
+    label: "prompt and description fields",
+  });
+}
+
+async function setPromptFieldValue(ctx, selector, index, value, label) {
+  await panelEval(ctx, `(() => {
+    const field = Array.from(document.querySelectorAll(${JSON.stringify(selector)}))[${index}];
+    if (!field) throw new Error(${JSON.stringify(`${label} field not found`)});
+    const prototype = field instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const setter = Object.getOwnPropertyDescriptor(prototype, 'value')?.set;
+    if (!setter) throw new Error('Native value setter not found');
+    if (field._valueTracker) field._valueTracker.setValue(${JSON.stringify(value ? "" : "__previous_value__")});
+    field.focus();
+    setter.call(field, ${JSON.stringify(value)});
+    field.dispatchEvent(new Event('input', { bubbles: true }));
+    field.dispatchEvent(new Event('change', { bubbles: true }));
+    field.scrollIntoView({ block: 'center' });
+    return field.value;
+  })()`);
+  await waitForPanel(ctx, `Array.from(document.querySelectorAll(${JSON.stringify(selector)}))[${index}]?.value === ${JSON.stringify(value)}`, {
+    timeoutMs: 5_000,
+    label,
+  });
+}
+
+async function setPromptFields(ctx) {
+  await ensurePromptEditorOpen(ctx);
+  const descriptionSelector = 'input[placeholder="Card title shown in the desktop app"]';
+  const promptSelector = "textarea";
+  for (const [index, value] of [...DESCRIPTIONS, ""].entries()) {
+    await setPromptFieldValue(ctx, descriptionSelector, index, value, `description ${index + 1}`);
+  }
+  for (const [index, value] of [...PROMPTS, ""].entries()) {
+    await setPromptFieldValue(ctx, promptSelector, index, value, `prompt ${index + 1}`);
+  }
+  await waitForAdminPromptValues(ctx, PROMPTS, DESCRIPTIONS);
+}
+
+async function readAdminPromptValues(ctx) {
+  return panelEval(ctx, `(() => {
+    const descriptions = Array.from(document.querySelectorAll('input[placeholder="Card title shown in the desktop app"]')).map((field) => field.value);
+    const prompts = Array.from(document.querySelectorAll('textarea')).map((field) => field.value);
+    const label = Array.from(document.querySelectorAll('label')).find((entry) => entry.textContent?.includes('Organization prompt suggestions'));
+    const enabled = label?.querySelector('input[type="checkbox"]')?.checked === true;
+    return { enabled, descriptions, prompts };
+  })()`);
+}
+
+async function waitForAdminPromptValues(ctx, prompts, descriptions) {
+  return waitUntil(ctx, "admin prompt input values", async () => {
+    const values = await readAdminPromptValues(ctx);
+    return values?.enabled && arrayEquals(values.prompts.slice(0, prompts.length), prompts) &&
+      arrayEquals(values.descriptions.slice(0, descriptions.length), descriptions)
+      ? values
+      : null;
+  }, { timeoutMs: 10_000, intervalMs: 250 });
+}
+
+async function scrollPromptCard(ctx, index) {
+  await panelEval(ctx, `(() => {
+    const prompts = Array.from(document.querySelectorAll('textarea'));
+    const prompt = prompts[${index}];
+    prompt?.closest('.grid')?.scrollIntoView({ block: 'center' });
+    prompt?.focus();
+    prompt?.setSelectionRange(prompt.value.length, prompt.value.length);
+    return true;
+  })()`).catch(() => undefined);
+  await sleep(300);
+}
+
+async function clickSaveChanges(ctx) {
+  await waitForPanel(ctx, `Boolean(Array.from(document.querySelectorAll('button')).find((button) =>
+    button.textContent?.trim() === 'Save changes' && !button.disabled
+  ))`, { timeoutMs: 15_000, label: "enabled Save changes button" });
+  await panelEval(ctx, `(() => {
+    const button = Array.from(document.querySelectorAll('button')).find((candidate) =>
+      candidate.textContent?.trim() === 'Save changes' && !candidate.disabled
+    );
+    if (!button) throw new Error('Save changes button not found');
+    button.scrollIntoView({ block: 'center' });
+    button.click();
+    return true;
+  })()`);
+}
+
+async function waitForPoliciesList(ctx) {
+  await waitForPanel(ctx, `document.body.innerText.includes('Desktop policies') && document.body.innerText.includes('Default desktop policy')`, {
+    timeoutMs: 45_000,
+    label: "desktop policies list after save",
+  });
+}
+
+async function readPromptCardState(ctx) {
+  return ctx.eval(`(() => {
+    const cards = Array.from(document.querySelectorAll('button')).map((button) => {
+      const spans = Array.from(button.querySelectorAll('span')).map((span) => (span.textContent ?? '').trim()).filter(Boolean);
+      return { title: spans[0] ?? '', description: spans[1] ?? '', text: (button.textContent ?? '').trim() };
+    });
+    const card = cards.find((entry) => entry.title === ${JSON.stringify(DESCRIPTIONS[0])} && entry.description === ${JSON.stringify(PROMPTS[0])}) ?? null;
+    return { card, cards };
+  })()`);
+}
+
+async function waitForPromptCard(ctx) {
+  return waitUntil(ctx, "desktop organization prompt card", async () => {
+    const stateValue = await readPromptCardState(ctx);
+    return stateValue?.card ? stateValue : null;
+  }, { timeoutMs: 60_000, intervalMs: 500 });
+}
+
+async function openFreshDesktopSession(ctx) {
+  await ensureWorkspaceReady(ctx);
+  await ctx.waitFor(
+    "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+    { timeoutMs: 60_000, label: "new session action" },
+  );
+  await ctx.control("session.create_task");
+  await ctx.waitFor(
+    "Boolean(document.querySelector('[contenteditable=\"true\"][data-lexical-editor=\"true\"]') || document.querySelector('[contenteditable=\"true\"]'))",
+    { timeoutMs: 30_000, label: "new-session composer" },
+  );
+}
+
+async function markPromptCardForClick(ctx) {
+  return ctx.eval(`(() => {
+    for (const button of Array.from(document.querySelectorAll('button'))) {
+      const spans = Array.from(button.querySelectorAll('span')).map((span) => (span.textContent ?? '').trim()).filter(Boolean);
+      if (spans[0] === ${JSON.stringify(DESCRIPTIONS[0])} && spans[1] === ${JSON.stringify(PROMPTS[0])}) {
+        button.setAttribute('data-eval-org-prompt-card', 'true');
+        button.scrollIntoView({ block: 'center', inline: 'center' });
+        return { title: spans[0], description: spans[1] };
+      }
+    }
+    return null;
+  })()`);
+}
+
+async function readComposerState(ctx) {
+  return ctx.eval(`(() => {
+    const composer = window.__openwork?.slice?.('composer');
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]') || document.querySelector('[contenteditable="true"]');
+    return {
+      draft: composer?.draft ?? null,
+      draftLength: composer?.draftLength ?? null,
+      editorText: editor?.innerText ?? '',
+    };
+  })()`);
+}
+
+export default {
+  id: "org-custom-prompt-descriptions",
+  title: "Organization prompt descriptions persist and become desktop suggestion card titles",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "setup",
+      run: async (ctx) => {
+        await ensureRendererMounted(ctx);
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 30_000, label: "window.__openworkControl" });
+        await ctx.ensureLightMode();
+        await ensureDesktopSession(ctx);
+        await ensureWorkspaceReady(ctx);
+        await dismissDesktopOverlays(ctx);
+        state.defaultPolicy = cloneJson(await loadDefaultPolicy(ctx));
+        state.originalDefaultPolicy = cloneJson(state.defaultPolicy);
+        await openAdminPanel(ctx);
+        await adminEnsureFreshAuth(ctx);
+        await waitForAdminSession(ctx);
+        await navigateDefaultPolicyEditor(ctx);
+        state.adminPanelTargetId = await getPanelTargetId(ctx);
+        ctx.log(`Captured original default desktop policy ${state.defaultPolicy.id}.`);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await runWithErrorCleanup(ctx, async () => {
+          await ctx.prove("Admin enters prompt descriptions beside prompt fields in the default desktop policy", {
+            voiceover: vo[0],
+            action: async () => {
+              await navigateDefaultPolicyEditor(ctx);
+              state.adminPanelTargetId = await getPanelTargetId(ctx);
+              await setPromptFields(ctx);
+              await scrollPromptCard(ctx, 0);
+            },
+            assert: async () => {
+              const values = await readAdminPromptValues(ctx);
+              ctx.assert(values?.enabled === true, "Organization prompt suggestions were not enabled in the admin editor.");
+              ctx.assert(arrayEquals(values.prompts.slice(0, PROMPTS.length), PROMPTS), `Prompt inputs did not contain the seeded prompts: ${JSON.stringify(values)}`);
+              ctx.assert(arrayEquals(values.descriptions.slice(0, DESCRIPTIONS.length), DESCRIPTIONS), `Description inputs did not contain the seeded descriptions: ${JSON.stringify(values)}`);
+              ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Admin editor input values include two prompts and their descriptions", actual: values });
+            },
+            screenshot: {
+              name: "frame-1-admin-description-inputs",
+              sandboxCapture: true,
+              targetId: state.adminPanelTargetId,
+              textTargetId: state.adminPanelTargetId,
+              requireText: ["Edit desktop policy", "Organization prompt suggestions", "Description", "Prompt", "Save changes"],
+              rejectText: ["Something went wrong", "Failed to load", "Description must be"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await runWithErrorCleanup(ctx, async () => {
+          await ctx.prove("Saving and reloading preserves prompt descriptions in Den and in the editor", {
+            voiceover: vo[1],
+            action: async () => {
+              await waitForAdminPromptValues(ctx, PROMPTS, DESCRIPTIONS);
+              await clickSaveChanges(ctx);
+              await waitForPoliciesList(ctx);
+              state.defaultPolicy = cloneJson(await waitForDefaultPolicyPromptConfig(ctx, "Den default policy prompt descriptions", PROMPTS, DESCRIPTIONS));
+              await waitForDesktopPromptConfig(ctx, "effective desktop config prompt descriptions", PROMPTS, DESCRIPTIONS);
+              await reloadDefaultPolicyEditor(ctx);
+              await waitForAdminPromptValues(ctx, PROMPTS, DESCRIPTIONS);
+              await scrollPromptCard(ctx, 1);
+            },
+            assert: async () => {
+              const policy = await loadDefaultPolicy(ctx);
+              const config = await waitForDesktopPromptConfig(ctx, "effective desktop config still has prompt descriptions", PROMPTS, DESCRIPTIONS);
+              const values = await readAdminPromptValues(ctx);
+              ctx.assert(promptConfigEquals(policy, PROMPTS, DESCRIPTIONS), `Desktop policy API did not persist prompt descriptions: ${JSON.stringify(policy?.policy)}`);
+              ctx.assert(promptConfigEquals(config, PROMPTS, DESCRIPTIONS), `Desktop config API did not expose prompt descriptions: ${JSON.stringify(config)}`);
+              ctx.assert(arrayEquals(values.prompts.slice(0, PROMPTS.length), PROMPTS), `Reloaded prompt fields did not keep values: ${JSON.stringify(values)}`);
+              ctx.assert(arrayEquals(values.descriptions.slice(0, DESCRIPTIONS.length), DESCRIPTIONS), `Reloaded description fields did not keep values: ${JSON.stringify(values)}`);
+              ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Den API and the reloaded admin form preserve prompts and descriptions", actual: { policy: policy.policy, config, values } });
+            },
+            screenshot: {
+              name: "frame-2-admin-reloaded-values",
+              sandboxCapture: true,
+              targetId: state.adminPanelTargetId,
+              textTargetId: state.adminPanelTargetId,
+              requireText: ["Edit desktop policy", "Organization prompt suggestions", "Second prompt", "Description", "Save changes"],
+              rejectText: ["Something went wrong", "Failed to load", "Description must be"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await runWithErrorCleanup(ctx, async () => {
+          await ctx.prove("The desktop new-session screen renders the saved description as the organization prompt card title", {
+            voiceover: vo[2],
+            action: async () => {
+              const config = await waitForDesktopPromptConfig(ctx, "member effective prompt descriptions before opening session", PROMPTS, DESCRIPTIONS);
+              await ctx.eval(`(() => {
+                const applyDesktopConfig = window.__openworkApplyDesktopConfig;
+                if (typeof applyDesktopConfig !== 'function') throw new Error('Desktop config eval bridge is unavailable');
+                applyDesktopConfig(${JSON.stringify(config)});
+                return true;
+              })()`);
+              await openFreshDesktopSession(ctx);
+              await waitForPromptCard(ctx);
+            },
+            assert: async () => {
+              const cardState = await readPromptCardState(ctx);
+              ctx.assert(cardState?.card?.title === DESCRIPTIONS[0], `Desktop card title did not use the saved description: ${JSON.stringify(cardState)}`);
+              ctx.assert(cardState?.card?.description === PROMPTS[0], `Desktop card description did not contain the full prompt: ${JSON.stringify(cardState)}`);
+              ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Desktop suggestion card title is the saved Description and its body is the full Prompt", actual: cardState.card });
+            },
+            screenshot: {
+              name: "frame-3-desktop-description-card",
+              requireText: [DESCRIPTIONS[0], PROMPTS[0]],
+              rejectText: ["Organization prompt 1", "Something went wrong"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await runWithErrorCleanup(ctx, async () => {
+          await ctx.prove("Clicking the description-titled card inserts the full custom prompt into the composer", {
+            voiceover: vo[3],
+            action: async () => {
+              const marked = await markPromptCardForClick(ctx);
+              ctx.assert(marked?.title === DESCRIPTIONS[0], `Could not mark the organization prompt card for click: ${JSON.stringify(marked)}`);
+              await ctx.trustedClick('[data-eval-org-prompt-card="true"]', { timeoutMs: 10_000 });
+              await ctx.waitFor(
+                `window.__openwork?.slice?.('composer')?.draft === ${JSON.stringify(PROMPTS[0])}`,
+                { timeoutMs: 10_000, label: "composer draft after organization prompt card click" },
+              );
+            },
+            assert: async () => {
+              const composer = await readComposerState(ctx);
+              ctx.assert(composer?.draft === PROMPTS[0], `Composer draft did not equal the full prompt after card click: ${JSON.stringify(composer)}`);
+              ctx.assert(composer?.editorText?.includes(PROMPTS[0]), `Composer DOM did not render the full prompt after card click: ${JSON.stringify(composer)}`);
+              ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "A trusted card click placed the full prompt into the composer", actual: composer });
+            },
+            screenshot: {
+              name: "frame-4-composer-full-prompt",
+              requireText: [PROMPTS[0]],
+              rejectText: ["Organization prompt 1", "Something went wrong"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "cleanup",
+      run: async (ctx) => {
+        const restored = await cleanupDefaultPolicy(ctx);
+        ctx.recordEvidence({ type: "assertion", status: "passed", assertion: "Non-narrated cleanup restored the original default desktop policy prompt configuration", actual: restored?.policy ?? null });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/org-custom-prompt-descriptions.md
+++ b/evals/voiceovers/org-custom-prompt-descriptions.md
@@ -1,0 +1,9 @@
+# org-custom-prompt-descriptions — Organization custom prompts have descriptive card titles
+
+1. An organization admin opens Desktop Policies and adds a custom prompt. Alongside the existing Prompt field, they enter a clear Description.
+
+2. The admin saves the policy, reloads the page, and sees both the prompt and its description preserved.
+
+3. A member opens the desktop client and starts a new session. The organization’s custom prompt appears as a card whose title is the saved Description.
+
+4. The member selects the card, and the full custom prompt is inserted into the new-session composer, ready to run.

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -107,15 +107,29 @@ export const onboardingPromptsSchema = z
   .min(2)
   .max(3);
 
+export const onboardingPromptDescriptionsSchema = z
+  .array(z.string().trim().max(120))
+  .min(2)
+  .max(3);
+
+export type OnboardingPromptConfig = {
+  onboardingPrompts: string[];
+  onboardingPromptDescriptions?: string[];
+};
+
 export const desktopPolicyDocumentSchema = desktopPolicyValueSchema
   .extend({
     onboardingPrompts: onboardingPromptsSchema.optional(),
+    onboardingPromptDescriptions: onboardingPromptDescriptionsSchema.optional(),
   })
   .meta({ ref: "DenDesktopPolicyDocument" });
 
 export const desktopPolicyDocumentWriteSchema = desktopPolicyValueSchema
   .extend({
     onboardingPrompts: onboardingPromptsSchema.nullable().optional(),
+    onboardingPromptDescriptions: onboardingPromptDescriptionsSchema
+      .nullable()
+      .optional(),
   })
   .meta({ ref: "DenDesktopPolicyDocumentWrite" });
 
@@ -125,6 +139,7 @@ export type DesktopPolicyDocumentWrite = z.infer<
 >;
 export type DefaultDesktopPolicyDocument = Required<DesktopPolicyValue> & {
   onboardingPrompts?: string[];
+  onboardingPromptDescriptions?: string[];
 };
 
 export const desktopPolicyKeys = desktopPolicyDefinitions.map(
@@ -179,6 +194,7 @@ export const desktopConfigSchema = desktopPolicyValueSchema
     brandAccentColor: z.enum(brandAccentColorValues).optional(),
     connectEnabled: z.boolean().optional(),
     onboardingPrompts: onboardingPromptsSchema.optional(),
+    onboardingPromptDescriptions: onboardingPromptDescriptionsSchema.optional(),
   })
   .meta({ ref: "DenDesktopConfig" });
 
@@ -220,6 +236,40 @@ export function normalizeOnboardingPrompts(value: unknown): string[] | undefined
   return parsed.success ? parsed.data : undefined;
 }
 
+export function normalizeOnboardingPromptDescriptions(
+  value: unknown,
+  promptCount?: number,
+): string[] | undefined {
+  const parsed = onboardingPromptDescriptionsSchema.safeParse(value);
+  if (!parsed.success) return undefined;
+  if (promptCount !== undefined && parsed.data.length !== promptCount) {
+    return undefined;
+  }
+  return parsed.data.some((description) => description.length > 0)
+    ? parsed.data
+    : undefined;
+}
+
+export function normalizeOnboardingPromptConfig(
+  value: unknown,
+): OnboardingPromptConfig | undefined {
+  const raw = isRecord(value) ? value : null;
+  const onboardingPrompts = normalizeOnboardingPrompts(raw?.onboardingPrompts);
+  if (onboardingPrompts === undefined) return undefined;
+
+  const onboardingPromptDescriptions = normalizeOnboardingPromptDescriptions(
+    raw?.onboardingPromptDescriptions,
+    onboardingPrompts.length,
+  );
+
+  return {
+    onboardingPrompts,
+    ...(onboardingPromptDescriptions !== undefined
+      ? { onboardingPromptDescriptions }
+      : {}),
+  };
+}
+
 export function normalizeDesktopPolicyValue(
   value: unknown,
 ): DesktopPolicyValue {
@@ -253,12 +303,11 @@ export function normalizeDesktopPolicyDocument(
   value: unknown,
 ): DesktopPolicyDocument {
   const policy = normalizeDesktopPolicyValue(value);
-  const raw = isRecord(value) ? value : null;
-  const onboardingPrompts = normalizeOnboardingPrompts(raw?.onboardingPrompts);
+  const onboardingPromptConfig = normalizeOnboardingPromptConfig(value);
 
   return {
     ...policy,
-    ...(onboardingPrompts !== undefined ? { onboardingPrompts } : {}),
+    ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
   };
 }
 
@@ -268,14 +317,24 @@ export function normalizeDesktopPolicyDocumentWrite(
   const policy = normalizeDesktopPolicyValue(value);
   const raw = isRecord(value) ? value : null;
   const rawPrompts = raw?.onboardingPrompts;
+  const rawDescriptions = raw?.onboardingPromptDescriptions;
   const onboardingPrompts = normalizeOnboardingPrompts(rawPrompts);
+  const onboardingPromptDescriptions = normalizeOnboardingPromptDescriptions(
+    rawDescriptions,
+    onboardingPrompts?.length,
+  );
 
   return {
     ...policy,
     ...(rawPrompts === null
-      ? { onboardingPrompts: null }
+      ? { onboardingPrompts: null, onboardingPromptDescriptions: null }
       : onboardingPrompts !== undefined
         ? { onboardingPrompts }
+        : {}),
+    ...(rawPrompts !== null && rawDescriptions === null
+      ? { onboardingPromptDescriptions: null }
+      : onboardingPromptDescriptions !== undefined
+        ? { onboardingPromptDescriptions }
         : {}),
   };
 }
@@ -290,16 +349,37 @@ export function resolveDesktopPolicyDocumentWrite(input: {
   const policy = input.isDefault === true
     ? normalizeDefaultDesktopPolicyValue(write)
     : normalizeDesktopPolicyValue(write);
+  const existingDocument = input.preserveExistingOnboardingPrompts === true
+    ? normalizeDesktopPolicyDocument(input.existingPolicy ?? {})
+    : undefined;
   const onboardingPrompts = Array.isArray(write.onboardingPrompts)
     ? write.onboardingPrompts
     : write.onboardingPrompts === undefined &&
         input.preserveExistingOnboardingPrompts === true
-      ? normalizeDesktopPolicyDocument(input.existingPolicy ?? {}).onboardingPrompts
+      ? existingDocument?.onboardingPrompts
       : undefined;
+  const onboardingPromptDescriptions = onboardingPrompts === undefined
+    ? undefined
+    : Array.isArray(write.onboardingPromptDescriptions)
+      ? normalizeOnboardingPromptDescriptions(
+          write.onboardingPromptDescriptions,
+          onboardingPrompts.length,
+        )
+      : write.onboardingPromptDescriptions === undefined &&
+          write.onboardingPrompts === undefined &&
+          input.preserveExistingOnboardingPrompts === true
+        ? normalizeOnboardingPromptDescriptions(
+            existingDocument?.onboardingPromptDescriptions,
+            onboardingPrompts.length,
+          )
+        : undefined;
 
   return {
     ...policy,
     ...(onboardingPrompts !== undefined ? { onboardingPrompts } : {}),
+    ...(onboardingPromptDescriptions !== undefined
+      ? { onboardingPromptDescriptions }
+      : {}),
   };
 }
 
@@ -307,12 +387,11 @@ export function normalizeDefaultDesktopPolicyDocument(
   value: unknown,
 ): DefaultDesktopPolicyDocument {
   const policy = normalizeDefaultDesktopPolicyValue(value);
-  const raw = isRecord(value) ? value : null;
-  const onboardingPrompts = normalizeOnboardingPrompts(raw?.onboardingPrompts);
+  const onboardingPromptConfig = normalizeOnboardingPromptConfig(value);
 
   return {
     ...policy,
-    ...(onboardingPrompts !== undefined ? { onboardingPrompts } : {}),
+    ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
   };
 }
 
@@ -384,6 +463,13 @@ export function selectEffectiveOnboardingPrompts(input: {
   defaultPolicy?: unknown;
   assignedPolicies: DesktopPolicyPromptCandidate[];
 }): string[] | undefined {
+  return selectEffectiveOnboardingPromptConfig(input)?.onboardingPrompts;
+}
+
+export function selectEffectiveOnboardingPromptConfig(input: {
+  defaultPolicy?: unknown;
+  assignedPolicies: DesktopPolicyPromptCandidate[];
+}): OnboardingPromptConfig | undefined {
   const candidatesById = new Map<string, DesktopPolicyPromptCandidate>();
   for (const candidate of input.assignedPolicies) {
     if (!candidatesById.has(candidate.id)) {
@@ -394,17 +480,16 @@ export function selectEffectiveOnboardingPrompts(input: {
   const targetedCandidates = [...candidatesById.values()]
     .filter(
       (candidate) =>
-        normalizeDesktopPolicyDocument(candidate.policy).onboardingPrompts !==
-        undefined,
+        normalizeOnboardingPromptConfig(candidate.policy) !== undefined,
     )
     .sort(comparePromptCandidates);
-  const targetedPolicy = targetedCandidates[0]
-    ? normalizeDesktopPolicyDocument(targetedCandidates[0].policy)
-    : null;
+  const targetedConfig = targetedCandidates[0]
+    ? normalizeOnboardingPromptConfig(targetedCandidates[0].policy)
+    : undefined;
 
   return (
-    targetedPolicy?.onboardingPrompts ??
-    normalizeDesktopPolicyDocument(input.defaultPolicy ?? {}).onboardingPrompts
+    targetedConfig ??
+    normalizeOnboardingPromptConfig(input.defaultPolicy ?? {})
   );
 }
 
@@ -444,7 +529,7 @@ export function normalizeDesktopConfig(value: unknown): DesktopConfig {
   const brandAccentColor = normalizeBrandAccentColor(raw?.brandAccentColor);
   const connectEnabled =
     typeof raw?.connectEnabled === "boolean" ? raw.connectEnabled : undefined;
-  const onboardingPrompts = normalizeOnboardingPrompts(raw?.onboardingPrompts);
+  const onboardingPromptConfig = normalizeOnboardingPromptConfig(raw);
 
   return {
     ...policy,
@@ -454,6 +539,6 @@ export function normalizeDesktopConfig(value: unknown): DesktopConfig {
     ...(brandIconUrl !== undefined ? { brandIconUrl } : {}),
     ...(brandAccentColor !== undefined ? { brandAccentColor } : {}),
     ...(connectEnabled !== undefined ? { connectEnabled } : {}),
-    ...(onboardingPrompts !== undefined ? { onboardingPrompts } : {}),
+    ...(onboardingPromptConfig !== undefined ? onboardingPromptConfig : {}),
   };
 }


### PR DESCRIPTION
## Summary
- add Description fields to organization custom prompts in Desktop Policies
- persist prompt descriptions through Den policy and desktop config APIs
- render descriptions as new-session card titles while inserting the full prompt on selection
- add focused unit coverage and a four-frame fraimz flow

## Validation
No additional tests were run while opening this PR, per request. Earlier implementation validation completed:
- `pnpm --filter @openwork/app exec bun test tests/den-desktop-config.test.ts tests/task-suggestions.test.ts` — 7 passed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm fraimz --flow org-custom-prompt-descriptions --stack den --cdp-url http://127.0.0.1:9844` — passed all four frames

Fraimz artifact: `evals/results/2026-07-15T19-41-46-216Z/fraimz.html` (local, gitignored).

The focused Den API DB test was not runnable because the local `openwork_test` database was absent.