### PR TITLE
feat(den): support non-destructive MCP disconnect

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-client.ts
@@ -185,6 +185,7 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
   private readonly member?: ExternalMcpMemberContext
   private readonly diagnostic: ExternalMcpDiagnosticTracker
   private readonly lifecycleDeadline?: ExternalMcpLifecycleDeadline
+  private tokenExchangeCodeVerifier: string | null = null
   /** Captured by redirectToAuthorization so the HTTP route can hand it back to the admin's browser instead of actually redirecting anything server-side. */
   lastAuthorizeUrl: string | null = null
 
@@ -319,6 +320,7 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
       const saved = await upsertConnectedAccountForExternalMcpIdentity({
         connection: this.connection,
         orgMembershipId: this.member.orgMembershipId,
+        ...(this.tokenExchangeCodeVerifier ? { expectedPendingCodeVerifier: this.tokenExchangeCodeVerifier } : {}),
         changes: {
           accessToken: tokens.access_token,
           // Most providers omit refresh_token on refresh responses; keep the existing one.
@@ -330,6 +332,7 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
         },
       })
       if (!saved) throw new Error("The external MCP connection identity changed during token persistence.")
+      this.tokenExchangeCodeVerifier = null
       this.diagnostic.passed("AUTH_TOKEN_ACQUISITION")
       return
     }
@@ -341,8 +344,10 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
       tokenType: tokens.token_type ?? null,
       scope: tokens.scope ?? null,
       expiresAt,
+      ...(this.tokenExchangeCodeVerifier ? { expectedPendingCodeVerifier: this.tokenExchangeCodeVerifier } : {}),
     })
     if (!saved) throw new Error("The external MCP connection identity changed during token persistence.")
+    this.tokenExchangeCodeVerifier = null
     // Refresh the in-memory row so a subsequent tokens()/refresh in the same
     // connection attempt sees the just-saved values.
     const refreshed = await getExternalMcpConnection({
@@ -425,11 +430,13 @@ export class ExternalMcpOAuthProvider implements OAuthClientProvider {
       if (!account?.pendingCodeVerifier) {
         throw new Error("No pending PKCE code verifier for this member on this external MCP connection.")
       }
+      this.tokenExchangeCodeVerifier = account.pendingCodeVerifier
       return account.pendingCodeVerifier
     }
     if (!this.connection.pendingCodeVerifier) {
       throw new Error("No pending PKCE code verifier for this external MCP connection.")
     }
+    this.tokenExchangeCodeVerifier = this.connection.pendingCodeVerifier
     return this.connection.pendingCodeVerifier
   }
 }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -1285,6 +1285,7 @@ export async function upsertConnectedAccountForExternalMcpIdentity(input: {
   connection: ExternalMcpConnectionRow
   orgMembershipId: OrgMembershipId
   changes: ExternalMcpConnectedAccountChanges
+  expectedPendingCodeVerifier?: string
 }): Promise<boolean> {
   return db.transaction(async (tx) => {
     if (!await lockExternalMcpIdentity(tx, input.connection)) return false
@@ -1299,6 +1300,12 @@ export async function upsertConnectedAccountForExternalMcpIdentity(input: {
       .limit(1)
       .for("update")
     const existing = rows[0]
+    if (
+      input.expectedPendingCodeVerifier !== undefined
+      && existing?.pendingCodeVerifier !== input.expectedPendingCodeVerifier
+    ) {
+      return false
+    }
     if (existing) {
       await tx
         .update(ConnectedAccountTable)
@@ -1347,9 +1354,17 @@ export async function saveExternalMcpTokensForIdentity(input: {
   tokenType?: string | null
   scope?: string | null
   expiresAt?: Date | null
+  expectedPendingCodeVerifier?: string
 }): Promise<boolean> {
   return db.transaction(async (tx) => {
-    if (!await lockExternalMcpIdentity(tx, input.connection)) return false
+    const current = await lockExternalMcpIdentity(tx, input.connection)
+    if (!current) return false
+    if (
+      input.expectedPendingCodeVerifier !== undefined
+      && current.pendingCodeVerifier !== input.expectedPendingCodeVerifier
+    ) {
+      return false
+    }
     await tx
       .update(ExternalMcpConnectionTable)
       .set({
@@ -1455,14 +1470,83 @@ export async function disconnectExternalMcpConnection(input: {
   organizationId: OrganizationId
   connectionId: ExternalMcpConnectionId
 }): Promise<boolean> {
-  const existing = await getExternalMcpConnection(input)
-  if (!existing) return false
-  await clearExternalMcpTokens(input)
-  await db
-    .update(ExternalMcpConnectionTable)
-    .set({
-      pendingCodeVerifier: null,
-    })
-    .where(eq(ExternalMcpConnectionTable.id, existing.id))
-  return true
+  return db.transaction(async (tx) => {
+    const rows = await tx
+      .select()
+      .from(ExternalMcpConnectionTable)
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionTable.id, input.connectionId),
+      ))
+      .limit(1)
+      .for("update")
+    const existing = rows[0]
+    if (!existing) return false
+
+    await tx.delete(ConnectedAccountTable).where(and(
+      eq(ConnectedAccountTable.organizationId, input.organizationId),
+      eq(ConnectedAccountTable.providerId, existing.id),
+    ))
+    await tx
+      .update(ExternalMcpConnectionTable)
+      .set({
+        ...(existing.authType === "apikey" ? { apiKey: null } : {}),
+        accessToken: null,
+        refreshToken: null,
+        tokenType: null,
+        scope: null,
+        expiresAt: null,
+        pendingCodeVerifier: null,
+        connectedAt: null,
+        updatedAt: new Date(Math.max(Date.now(), existing.updatedAt.getTime() + 1)),
+      })
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionTable.id, existing.id),
+      ))
+    return true
+  })
+}
+
+export type DisconnectExternalMcpMemberAccountResult =
+  | { status: "not_found" }
+  | { status: "not_per_member" }
+  | { status: "not_connected" }
+  | { status: "disconnected" }
+
+export async function disconnectExternalMcpMemberAccount(input: {
+  organizationId: OrganizationId
+  connectionId: ExternalMcpConnectionId
+  orgMembershipId: OrgMembershipId
+}): Promise<DisconnectExternalMcpMemberAccountResult> {
+  return db.transaction(async (tx) => {
+    const rows = await tx
+      .select()
+      .from(ExternalMcpConnectionTable)
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionTable.id, input.connectionId),
+      ))
+      .limit(1)
+      .for("update")
+    const connection = rows[0]
+    if (!connection) return { status: "not_found" }
+    if (connection.credentialMode !== "per_member") return { status: "not_per_member" }
+
+    const accountRows = await tx
+      .select({ id: ConnectedAccountTable.id })
+      .from(ConnectedAccountTable)
+      .where(and(
+        eq(ConnectedAccountTable.organizationId, input.organizationId),
+        eq(ConnectedAccountTable.orgMembershipId, input.orgMembershipId),
+        eq(ConnectedAccountTable.providerId, input.connectionId),
+      ))
+      .limit(1)
+      .for("update")
+    const account = accountRows[0]
+    if (!account) return { status: "not_connected" }
+
+    await tx.delete(ConnectedAccountTable).where(eq(ConnectedAccountTable.id, account.id))
+    return { status: "disconnected" }
+  })
 }

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -9,6 +9,7 @@ import {
 } from "@openwork/enterprise-mcp-client"
 import { and, desc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
 import {
+  ConnectedAccountTable,
   ConfigObjectTable,
   ConfigObjectVersionTable,
   MemberTable,
@@ -45,6 +46,7 @@ import {
   createExternalMcpConnection,
   deleteExternalMcpConnection,
   disconnectExternalMcpConnection,
+  disconnectExternalMcpMemberAccount,
   externalMcpIdentityBinding,
   getExternalMcpConnection,
   listActiveExternalMcpConnectionBindings,
@@ -277,6 +279,8 @@ const connectionResponseSchema = z.object({
   credentialMode: z.enum(["shared", "per_member"]),
   connected: z.boolean(),
   connectedAt: z.string().nullable(),
+  /** Safe creator display label for admin/manageable rows. */
+  createdByName: z.string().nullable().optional(),
   updatedAt: z.string().datetime().optional(),
   /** For per_member connections: whether the CALLING member has connected their own account. Always true for connected shared connections. */
   connectedForMe: z.boolean(),
@@ -539,6 +543,24 @@ function isConnectionConnected(row: ExternalMcpConnectionRow): boolean {
   return Boolean(row.accessToken || row.apiKey || (row.authType === "none" && row.connectedAt))
 }
 
+async function connectedAccountStateForConnection(input: {
+  organizationId: DenTypeId<"organization">
+  providerId: DenTypeId<"externalMcpConnection">
+}): Promise<{ connected: boolean; connectedAt: Date | null }> {
+  const rows = await db
+    .select({ accessToken: ConnectedAccountTable.accessToken, connectedAt: ConnectedAccountTable.connectedAt })
+    .from(ConnectedAccountTable)
+    .where(and(
+      eq(ConnectedAccountTable.organizationId, input.organizationId),
+      eq(ConnectedAccountTable.providerId, input.providerId),
+    ))
+  const connectedRows = rows.filter((row) => Boolean(row.accessToken))
+  const connectedAt = connectedRows
+    .map((row) => row.connectedAt)
+    .sort((left, right) => right.getTime() - left.getTime())[0] ?? null
+  return { connected: connectedRows.length > 0, connectedAt }
+}
+
 type ExternalMcpToolCredentialContext =
   | { ok: true; member?: { orgMembershipId: DenTypeId<"member"> } }
   | { ok: false; message: string }
@@ -580,6 +602,11 @@ function parseJsonObject(value: string | null): Record<string, unknown> | null {
   } catch {
     return null
   }
+}
+
+function resolveCreatorName(context: PluginArchActorContext["organizationContext"], memberId: string): string | null {
+  const member = context.members.find((entry) => entry.id === memberId)
+  return member?.user.name.trim() || member?.user.email || null
 }
 
 function legacyExternalMcpConnectionIdsFromPayload(payload: Record<string, unknown> | null): string[] {
@@ -741,12 +768,15 @@ async function toConnectionResponse(
   row: ExternalMcpConnectionRow,
   options: {
     callerOrgMembershipId: DenTypeId<"member">
+    createdByName?: string | null
     includeAccess: boolean
     identityManagedBy: ConnectionRequiredBy[]
     requiredBy: ConnectionRequiredBy[]
   },
 ) {
-  let connectedForMe = isConnectionConnected(row) && row.credentialMode === "shared"
+  let connected = isConnectionConnected(row)
+  let connectedAt = row.connectedAt
+  let connectedForMe = connected && row.credentialMode === "shared"
   let grantedScopes = row.scope?.split(/\s+/).filter(Boolean) ?? []
   if (row.credentialMode === "per_member") {
     const account = await getConnectedAccount({
@@ -756,6 +786,17 @@ async function toConnectionResponse(
     })
     connectedForMe = Boolean(account?.accessToken)
     grantedScopes = account?.scopes ?? []
+    if (options.includeAccess) {
+      const accountState = await connectedAccountStateForConnection({
+        organizationId: row.organizationId,
+        providerId: row.id,
+      })
+      connected = accountState.connected
+      connectedAt = accountState.connectedAt
+    } else {
+      connected = connectedForMe
+      connectedAt = account?.accessToken ? account.connectedAt : null
+    }
   }
 
   let access: { orgWide: boolean; memberIds: string[]; teamIds: string[] } | null = null
@@ -794,8 +835,9 @@ async function toConnectionResponse(
     url: row.url,
     authType: row.authType,
     credentialMode: row.credentialMode,
-    connected: isConnectionConnected(row),
-    connectedAt: row.connectedAt ? row.connectedAt.toISOString() : null,
+    connected,
+    connectedAt: connectedAt ? connectedAt.toISOString() : null,
+    ...(options.includeAccess ? { createdByName: options.createdByName ?? null } : {}),
     updatedAt: row.updatedAt.toISOString(),
     connectedForMe,
     requiredBy: options.requiredBy,
@@ -1140,6 +1182,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         const connections = await Promise.all(rows.map((row) =>
           toConnectionResponse(row, {
             callerOrgMembershipId: payload.currentMember.id,
+            createdByName: resolveCreatorName(payload, row.createdByOrgMembershipId),
             includeAccess: true,
             requiredBy: provenance.requiredBy.get(row.id) ?? [],
             identityManagedBy: provenance.identityManagedBy.get(row.id) ?? [],
@@ -1163,6 +1206,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       const connections = await Promise.all(rows.map((row) =>
         toConnectionResponse(row, {
           callerOrgMembershipId: payload.currentMember.id,
+          createdByName: resolveCreatorName(payload, row.createdByOrgMembershipId),
           includeAccess: false,
           requiredBy: provenance.requiredBy.get(row.id) ?? [],
           identityManagedBy: provenance.identityManagedBy.get(row.id) ?? [],
@@ -1505,6 +1549,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       const refreshed = await getExternalMcpConnection({ organizationId: payload.organization.id, connectionId: created.id })
       const response = await toConnectionResponse(refreshed ?? created, {
         callerOrgMembershipId: payload.currentMember.id,
+        createdByName: resolveCreatorName(payload, (refreshed ?? created).createdByOrgMembershipId),
         includeAccess: true,
         requiredBy: [],
         identityManagedBy: [],
@@ -1738,6 +1783,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       })
       const response = await toConnectionResponse(result.connection, {
         callerOrgMembershipId: payload.currentMember.id,
+        createdByName: resolveCreatorName(payload, result.connection.createdByOrgMembershipId),
         includeAccess: true,
         requiredBy: provenance.requiredBy.get(result.connection.id) ?? [],
         identityManagedBy: provenance.identityManagedBy.get(result.connection.id) ?? [],
@@ -1799,6 +1845,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       })
       return c.json(await toConnectionResponse(connection, {
         callerOrgMembershipId: payload.currentMember.id,
+        createdByName: resolveCreatorName(payload, connection.createdByOrgMembershipId),
         includeAccess: true,
         requiredBy: provenance.requiredBy.get(connection.id) ?? [],
         identityManagedBy: provenance.identityManagedBy.get(connection.id) ?? [],
@@ -1849,6 +1896,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       })
       return c.json(await toConnectionResponse(result.connection, {
         callerOrgMembershipId: payload.currentMember.id,
+        createdByName: resolveCreatorName(payload, result.connection.createdByOrgMembershipId),
         includeAccess: true,
         requiredBy: provenance.requiredBy.get(result.connection.id) ?? [],
         identityManagedBy: provenance.identityManagedBy.get(result.connection.id) ?? [],
@@ -1890,6 +1938,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
     describeRoute({
       tags: ["Authentication"],
       summary: "Disconnect (clear credentials for) an External MCP Connection without removing it",
+      description: "Admin-only. Signs out every shared or per-member account stored for this connection, while preserving the connection row, access grants, OAuth client configuration, and plugin bindings.",
       responses: {
         200: emptyResponse("Disconnected."),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
@@ -1909,6 +1958,43 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       const removed = await disconnectExternalMcpConnection({ organizationId: payload.organization.id, connectionId: externalMcpConnectionId })
       if (!removed) {
         return c.json({ error: "connection_not_found", message: "Unknown connection." }, 404)
+      }
+      return c.json({ ok: true })
+    },
+  )
+
+  app.post(
+    "/v1/mcp-connections/:connectionId/disconnect-my-account",
+    describeRoute({
+      tags: ["Authentication"],
+      summary: "Disconnect the calling member's account for a per-member External MCP Connection",
+      description: "Removes only the caller's connected account for this MCP connection. The org-level connection, access grants, OAuth client configuration, and other members' accounts are preserved.",
+      responses: {
+        200: emptyResponse("Disconnected."),
+        400: jsonResponse("This connection does not use per-member credentials.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        404: jsonResponse("Unknown connection or nothing was connected.", connectionNotFoundSchema),
+      },
+    }),
+    orgMemberRoute(),
+    paramValidator(connectionParamsSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const { connectionId } = c.req.valid("param")
+      const externalMcpConnectionId = normalizeDenTypeId("externalMcpConnection", connectionId)
+      const result = await disconnectExternalMcpMemberAccount({
+        organizationId: payload.organization.id,
+        connectionId: externalMcpConnectionId,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if (result.status === "not_found") {
+        return c.json({ error: "connection_not_found", message: "Unknown connection." }, 404)
+      }
+      if (result.status === "not_per_member") {
+        return c.json({ error: "invalid_request", message: "Only per-member MCP connections can be disconnected from Your Connections." }, 400)
+      }
+      if (result.status === "not_connected") {
+        return c.json({ error: "connection_not_found", message: "Nothing was connected." }, 404)
       }
       return c.json({ ok: true })
     },

--- a/ee/apps/den-api/test/mcp-connections-edit.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-edit.test.ts
@@ -630,3 +630,150 @@ describe.serial("PUT /v1/mcp-connections/:connectionId", () => {
     })
   })
 })
+
+describe.serial("MCP connection disconnect", () => {
+  function postDisconnect(connectionId: string, suffix = "/disconnect", token = adminToken) {
+    return app.fetch(new Request(`http://den-api.local/v1/mcp-connections/${connectionId}${suffix}`, {
+      method: "POST",
+      headers: { authorization: `Bearer ${token}` },
+    }))
+  }
+
+  test("manageable lists expose safe creator attribution", async () => {
+    const created = await createConnection({ name: "Creator Attribution MCP", authType: "oauth", credentialMode: "per_member" })
+    const response = await app.fetch(new Request("http://den-api.local/v1/mcp-connections?scope=manageable", {
+      headers: { authorization: `Bearer ${adminToken}` },
+    }))
+    expect(response.status).toBe(200)
+    const body = await responseRecord(response)
+    const list = body.connections
+    if (!Array.isArray(list)) throw new Error("Manageable MCP list did not include connections")
+    const row = list.find((entry) => isRecord(entry) && entry.id === created.id)
+    if (!isRecord(row)) throw new Error("Created MCP connection was missing from manageable list")
+    expect(row.createdByName).toBe("MCP Edit Admin")
+  })
+
+  test("admin disconnect clears credentials without removing configuration or grants", async () => {
+    const shared = await createConnection({ name: "Disconnect Shared OAuth", authType: "oauth", credentialMode: "shared" })
+    await db.update(schema.ExternalMcpConnectionTable).set({
+      accessToken: "shared-access",
+      refreshToken: "shared-refresh",
+      tokenType: "Bearer",
+      scope: "read write",
+      expiresAt: new Date(Date.now() + 60_000),
+      pendingCodeVerifier: "shared-pkce",
+      connectedAt: new Date(),
+    }).where(drizzle.eq(schema.ExternalMcpConnectionTable.id, shared.id))
+    await oauthCredentials.upsertOrgOAuthClient({
+      organizationId,
+      providerId: shared.id,
+      clientId: "disconnect-shared-client",
+      clientSecret: "disconnect-shared-secret",
+      extra: { enterpriseMcpRegistrationSource: "pre-registered" },
+      createdByOrgMembershipId: adminMemberId,
+    })
+
+    const apiKey = await createConnection({ name: "Disconnect API Key", authType: "apikey", credentialMode: "shared", apiKey: "disconnect-api-key" })
+    const perMember = await createConnection({ name: "Disconnect Members", authType: "oauth", credentialMode: "per_member" })
+    await oauthCredentials.upsertConnectedAccount({
+      organizationId,
+      orgMembershipId: adminMemberId,
+      providerId: perMember.id,
+      accessToken: "admin-access",
+      refreshToken: "admin-refresh",
+      pendingCodeVerifier: "admin-pkce",
+    })
+    await oauthCredentials.upsertConnectedAccount({
+      organizationId,
+      orgMembershipId: memberId,
+      providerId: perMember.id,
+      accessToken: "member-access",
+      refreshToken: "member-refresh",
+      pendingCodeVerifier: "member-pkce",
+    })
+
+    expect((await postDisconnect(shared.id)).status).toBe(200)
+    expect((await postDisconnect(apiKey.id)).status).toBe(200)
+    expect((await postDisconnect(perMember.id)).status).toBe(200)
+
+    const sharedAfter = await currentConnection(shared.id)
+    expect(sharedAfter.accessToken).toBeNull()
+    expect(sharedAfter.refreshToken).toBeNull()
+    expect(sharedAfter.tokenType).toBeNull()
+    expect(sharedAfter.scope).toBeNull()
+    expect(sharedAfter.expiresAt).toBeNull()
+    expect(sharedAfter.pendingCodeVerifier).toBeNull()
+    expect(sharedAfter.connectedAt).toBeNull()
+    expect(await oauthCredentials.getOrgOAuthClient(organizationId, shared.id)).toMatchObject({ clientId: "disconnect-shared-client" })
+
+    expect((await currentConnection(apiKey.id)).apiKey).toBeNull()
+    const accounts = await db.select().from(schema.ConnectedAccountTable).where(drizzle.and(
+      drizzle.eq(schema.ConnectedAccountTable.organizationId, organizationId),
+      drizzle.eq(schema.ConnectedAccountTable.providerId, perMember.id),
+    ))
+    expect(accounts).toEqual([])
+    for (const connection of [shared, apiKey, perMember]) {
+      const grants = await connections.listExternalMcpConnectionAccess({ organizationId, connectionId: connection.id })
+      expect(grants.length).toBeGreaterThan(0)
+      expect(await currentConnection(connection.id)).toMatchObject({ name: connection.name, url: connection.url })
+    }
+  })
+
+  test("member disconnect removes only that member's per-member external MCP account", async () => {
+    const connection = await createConnection({ name: "Disconnect Mine", authType: "oauth", credentialMode: "per_member" })
+    await oauthCredentials.upsertConnectedAccount({
+      organizationId,
+      orgMembershipId: adminMemberId,
+      providerId: connection.id,
+      accessToken: "admin-stays",
+    })
+    await oauthCredentials.upsertConnectedAccount({
+      organizationId,
+      orgMembershipId: memberId,
+      providerId: connection.id,
+      accessToken: "member-goes",
+    })
+
+    const response = await postDisconnect(connection.id, "/disconnect-my-account", memberToken)
+    expect(response.status).toBe(200)
+    expect(await oauthCredentials.getConnectedAccount({ organizationId, orgMembershipId: memberId, providerId: connection.id })).toBeNull()
+    expect(await oauthCredentials.getConnectedAccount({ organizationId, orgMembershipId: adminMemberId, providerId: connection.id })).toMatchObject({
+      accessToken: "admin-stays",
+    })
+  })
+
+  test("late OAuth callbacks cannot recreate credentials after disconnect clears pending authorization", async () => {
+    const shared = await createConnection({ name: "Late Shared OAuth", authType: "oauth", credentialMode: "shared" })
+    await db.update(schema.ExternalMcpConnectionTable).set({ pendingCodeVerifier: "shared-late-pkce" }).where(drizzle.eq(schema.ExternalMcpConnectionTable.id, shared.id))
+    const staleShared = await currentConnection(shared.id)
+    expect((await postDisconnect(shared.id)).status).toBe(200)
+    await expect(connections.saveExternalMcpTokensForIdentity({
+      connection: staleShared,
+      accessToken: "late-shared-access",
+      expectedPendingCodeVerifier: "shared-late-pkce",
+    })).resolves.toBe(false)
+    expect((await currentConnection(shared.id)).accessToken).toBeNull()
+
+    const perMember = await createConnection({ name: "Late Member OAuth", authType: "oauth", credentialMode: "per_member" })
+    await oauthCredentials.upsertConnectedAccount({
+      organizationId,
+      orgMembershipId: memberId,
+      providerId: perMember.id,
+      pendingCodeVerifier: "member-late-pkce",
+    })
+    const stalePerMember = await currentConnection(perMember.id)
+    const disconnected = await connections.disconnectExternalMcpMemberAccount({
+      organizationId,
+      connectionId: perMember.id,
+      orgMembershipId: memberId,
+    })
+    expect(disconnected).toEqual({ status: "disconnected" })
+    await expect(connections.upsertConnectedAccountForExternalMcpIdentity({
+      connection: stalePerMember,
+      orgMembershipId: memberId,
+      expectedPendingCodeVerifier: "member-late-pkce",
+      changes: { accessToken: "late-member-access" },
+    })).resolves.toBe(false)
+    expect(await oauthCredentials.getConnectedAccount({ organizationId, orgMembershipId: memberId, providerId: perMember.id })).toBeNull()
+  })
+})

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connection-display.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connection-display.ts
@@ -8,6 +8,11 @@ export function formatRequiredBy(requiredBy: ExternalMcpRequiredBy[]): string | 
   return `Required by ${names.slice(0, -1).join(", ")}, and ${names[names.length - 1]}`;
 }
 
+export function formatConnectionCreatorAttribution(createdByName: string | null | undefined): string | null {
+  const name = createdByName?.trim();
+  return name ? `Added by ${name}` : null;
+}
+
 export function trustedConnectionFocusId(connections: ExternalMcpConnection[], requestedConnectionId: string | null): string | null {
   if (!requestedConnectionId) return null;
   return connections.some((connection) => connection.id === requestedConnectionId) ? requestedConnectionId : null;

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -44,6 +44,7 @@ export type ExternalMcpConnection = {
   credentialMode: ExternalMcpCredentialMode;
   connected: boolean;
   connectedAt: string | null;
+  createdByName?: string | null;
   updatedAt: string | null;
   connectedForMe: boolean;
   needsReconnect?: boolean;
@@ -200,8 +201,8 @@ export function isNativeProviderConnectionId(id: string): boolean {
   return id === "google-workspace" || id === "microsoft-365";
 }
 
-export function canDisconnectNativeProviderAccount(connection: Pick<ExternalMcpConnection, "id" | "connectedForMe">): boolean {
-  return connection.connectedForMe && isNativeProviderConnectionId(connection.id);
+export function canDisconnectMyConnectionAccount(connection: Pick<ExternalMcpConnection, "id" | "credentialMode" | "connectedForMe">): boolean {
+  return connection.connectedForMe && (isNativeProviderConnectionId(connection.id) || connection.credentialMode === "per_member");
 }
 
 export const mcpConnectionQueryKeys = {
@@ -390,6 +391,7 @@ async function fetchConnections(scope: ExternalMcpConnectionScope, orgId: string
     requiredBy: parseRequiredBy(connection.requiredBy),
     identityManagedBy: parseRequiredBy(connection.identityManagedBy),
     updatedAt: typeof connection.updatedAt === "string" ? connection.updatedAt : null,
+    ...(typeof connection.createdByName === "string" || connection.createdByName === null ? { createdByName: connection.createdByName } : {}),
     ...(typeof connection.needsReconnect === "boolean" ? { needsReconnect: connection.needsReconnect } : {}),
     ...(isStringArray(connection.missingFeatures) ? { missingFeatures: connection.missingFeatures } : {}),
     ...(typeof connection.externalAccountId === "string" || connection.externalAccountId === null
@@ -617,8 +619,11 @@ export function useDisconnectMyProviderAccount() {
 
   return useMutation({
     mutationFn: async (providerId: string): Promise<string> => {
+      const path = isNativeProviderConnectionId(providerId)
+        ? `/v1/oauth-providers/${encodeURIComponent(providerId)}/disconnect`
+        : `/v1/mcp-connections/${encodeURIComponent(providerId)}/disconnect-my-account`;
       const { response, payload } = await requestJson(
-        `/v1/oauth-providers/${encodeURIComponent(providerId)}/disconnect`,
+        path,
         { method: "POST", headers: getOrgScopeHeaders(requireOrgId(orgId)) },
         15000,
       );
@@ -626,6 +631,33 @@ export function useDisconnectMyProviderAccount() {
         throw getRequestError(payload, response, `Failed to disconnect account (${response.status}).`);
       }
       return providerId;
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });
+    },
+  });
+}
+
+export function useDisconnectMcpConnection() {
+  const queryClient = useQueryClient();
+  const { orgId, runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (connectionId: string): Promise<string> => {
+      let result: string | null = null;
+      await runReauthableAction("disconnect-mcp-connection", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/mcp-connections/${encodeURIComponent(connectionId)}/disconnect`,
+          { method: "POST", headers: getOrgScopeHeaders(requireOrgId(orgId)) },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to disconnect MCP connection (${response.status}).`);
+        }
+        result = connectionId;
+      });
+      if (!result) throw new Error("Disconnect MCP connection response was incomplete.");
+      return result;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -20,6 +20,7 @@ import {
   mcpAccessMode,
   type McpConnectionAccessMode,
 } from "./mcp-connection-editing";
+import { formatConnectionCreatorAttribution } from "./mcp-connection-display";
 import { shouldShowMcpConnectionsStagingBanner } from "./mcp-connections-capability";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { marketplaceQueryKeys, useMarketplaces } from "./marketplace-data";
@@ -39,6 +40,7 @@ import {
   mcpConnectionQueryKeys,
   useCreateMcpConnection,
   useDeleteMcpConnection,
+  useDisconnectMcpConnection,
   useDiscoverMcpConnectionRequirements,
   useMcpConnectionPresets,
   useMcpConnections,
@@ -215,6 +217,7 @@ export function McpConnectionsScreen() {
   const updateConnection = useUpdateMcpConnection();
   const startOAuth = useStartMcpConnectionOAuth();
   const migrateCallback = useMigrateMcpConnectionCallback();
+  const disconnectConnection = useDisconnectMcpConnection();
   const deleteConnection = useDeleteMcpConnection();
   const saveNativeClient = useSaveNativeProviderClient();
 
@@ -343,6 +346,24 @@ export function McpConnectionsScreen() {
       `Delete ${connection.name}? This can remove access grants, per-member authorization state, and plugin or marketplace bindings. Reconnecting with the shared callback is the safer migration path.`,
     );
     if (confirmed) deleteConnection.mutate(connection.id);
+  }
+
+  async function handleDisconnect(connection: ExternalMcpConnection) {
+    const confirmed = window.confirm(
+      `Disconnect ${connection.name}? This signs out every associated account for this connection, but keeps the MCP server setup, access rules, and plugin or marketplace bindings so you can reconnect later.`,
+    );
+    if (!confirmed) return;
+    setConnectionActionError(null);
+    setConnectionActionNotice(null);
+    try {
+      await disconnectConnection.mutateAsync(connection.id);
+      setConnectionActionNotice(`${connection.name} was disconnected. Its setup, access rules, and bindings were kept.`);
+    } catch (disconnectError) {
+      setConnectionActionError({
+        connectionId: connection.id,
+        message: disconnectError instanceof Error ? disconnectError.message : "Failed to disconnect the MCP connection.",
+      });
+    }
   }
 
   return (
@@ -529,7 +550,9 @@ export function McpConnectionsScreen() {
                 setEditingConnection(connection);
               }}
               onConnect={() => void handleConnectOAuth(connection.id)}
+              onDisconnect={() => void handleDisconnect(connection)}
               onRemove={() => handleRemove(connection)}
+              disconnecting={disconnectConnection.isPending && disconnectConnection.variables === connection.id}
               removing={deleteConnection.isPending && deleteConnection.variables === connection.id}
               toolsOpen={toolsConnectionId === connection.id}
               onToggleTools={() => setToolsConnectionId((current) => current === connection.id ? null : connection.id)}
@@ -1163,7 +1186,9 @@ function ConnectionRow({
   errorMessage,
   onEdit,
   onConnect,
+  onDisconnect,
   onRemove,
+  disconnecting,
   removing,
   toolsOpen,
   onToggleTools,
@@ -1176,7 +1201,9 @@ function ConnectionRow({
   errorMessage: string | null;
   onEdit: () => void;
   onConnect: () => void;
+  onDisconnect: () => void;
   onRemove: () => void;
+  disconnecting: boolean;
   removing: boolean;
   toolsOpen: boolean;
   onToggleTools: () => void;
@@ -1187,6 +1214,7 @@ function ConnectionRow({
   const isPerMember = connection.credentialMode === "per_member";
   const callbackUpdateRequired = connection.oauthMigrationStatus === "legacy_manual_client";
   const automaticCallbackMigrationPending = connection.oauthMigrationStatus === "unclassified";
+  const creatorAttribution = formatConnectionCreatorAttribution(connection.createdByName);
   const needsOAuthConnect = connection.authType === "oauth"
     && (!connection.connected || automaticCallbackMigrationPending)
     && !callbackUpdateRequired
@@ -1195,7 +1223,7 @@ function ConnectionRow({
   const canInspectTools = connection.credentialMode === "shared" ? connection.connected : connection.connectedForMe;
 
   return (
-    <div>
+    <div data-testid={`mcp-connection-row-${connection.id}`}>
       <div className="flex flex-col gap-4 px-6 py-4 sm:flex-row sm:items-center sm:justify-between">
         <div className="flex min-w-0 flex-1 items-center gap-3">
           <IntegrationIcon name={connection.name} serviceUrl={connection.url} />
@@ -1203,9 +1231,9 @@ function ConnectionRow({
             <div className="flex flex-wrap items-center gap-2">
               <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
               {isPerMember ? (
-                <span className="inline-flex items-center gap-1 rounded-full bg-gray-900 px-2 py-0.5 text-[11px] font-medium text-white">
+                <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${connection.connected ? "bg-emerald-50 text-emerald-700" : "bg-gray-100 text-gray-500"}`}>
                   <Users className="h-3 w-3" />
-                  Individual accounts
+                  {connection.connected ? "Individual accounts connected" : "Not connected"}
                 </span>
               ) : connection.connected ? (
                 <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
@@ -1229,7 +1257,7 @@ function ConnectionRow({
               ) : null}
             </div>
             <p className="mt-0.5 truncate text-[12px] text-gray-500">
-              {connection.url} · {formatMcpConnectedTimestamp(connection.connectedAt)}
+              {connection.url} · {formatMcpConnectedTimestamp(connection.connectedAt)}{creatorAttribution ? ` · ${creatorAttribution}` : ""}
             </p>
             {connection.authType === "oauth" ? (
               <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-gray-500">
@@ -1273,6 +1301,18 @@ function ConnectionRow({
               onClick={automaticCallbackMigrationPending ? onMigrateCallback : onConnect}
             >
               {automaticCallbackMigrationPending ? "Reconnect with shared callback" : "Connect"}
+            </DenButton>
+          ) : null}
+          {connection.connected ? (
+            <DenButton
+              variant="secondary"
+              size="sm"
+              loading={disconnecting}
+              onClick={onDisconnect}
+              aria-label={`Disconnect ${connection.name}`}
+              data-testid={`disconnect-mcp-connection-${connection.id}`}
+            >
+              Disconnect
             </DenButton>
           ) : null}
           <DenButton

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -12,7 +12,7 @@ import { formatRequiredBy, sortConnectionsForFocus, trustedConnectionFocusId } f
 import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl } from "./mcp-authorization-url";
 import { MICROSOFT_365_DISPLAY_SCOPES } from "./microsoft-365-permissions";
 import {
-  canDisconnectNativeProviderAccount,
+  canDisconnectMyConnectionAccount,
   type ExternalMcpConnection,
   isNativeProviderConnectionId,
   useDisconnectMyProviderAccount,
@@ -194,7 +194,7 @@ function YourConnectionRow({
   const needsReconnect = connection.connectedForMe && connection.needsReconnect === true;
   const needsMyConnect = isPerMember && !connection.connectedForMe;
   const needsAdminConnect = isAdmin && !isPerMember && connection.authType === "oauth" && !connection.connectedForMe;
-  const canDisconnect = canDisconnectNativeProviderAccount(connection);
+  const canDisconnect = canDisconnectMyConnectionAccount(connection);
   const canTestTools = isAdmin && !isNativeProviderConnectionId(connection.id) && connection.connectedForMe && !needsReconnect;
   const [toolRunnerOpen, setToolRunnerOpen] = useState(false);
   const microsoftScopes = connection.id === "microsoft-365"
@@ -279,7 +279,7 @@ function YourConnectionRow({
             />
           ) : null}
           {canDisconnect ? (
-            <DenButton variant="destructive" size="sm" loading={disconnecting} onClick={onDisconnect}>
+            <DenButton variant="destructive" size="sm" loading={disconnecting} onClick={onDisconnect} data-testid={`disconnect-my-mcp-account-${connection.id}`}>
               Disconnect
             </DenButton>
           ) : null}

--- a/ee/apps/den-web/tests/mcp-connection-display.test.ts
+++ b/ee/apps/den-web/tests/mcp-connection-display.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, test } from "bun:test";
+
+import { formatConnectionCreatorAttribution } from "../app/(den)/dashboard/_components/mcp-connection-display";
+
+describe("MCP connection display helpers", () => {
+  test("formats safe creator attribution when an admin manages connections", () => {
+    expect(formatConnectionCreatorAttribution("Alex Admin")).toBe("Added by Alex Admin");
+    expect(formatConnectionCreatorAttribution("  Alex Admin  ")).toBe("Added by Alex Admin");
+  });
+
+  test("omits creator attribution when the API has no safe display name", () => {
+    expect(formatConnectionCreatorAttribution(null)).toBeNull();
+    expect(formatConnectionCreatorAttribution("   ")).toBeNull();
+  });
+});

--- a/evals/flows/disconnect-cloud-connections.flow.mjs
+++ b/evals/flows/disconnect-cloud-connections.flow.mjs
@@ -1,0 +1,414 @@
+import { createServer } from "node:http";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, openAdminConnections, openYourConnections, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/disconnect-cloud-connections.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("disconnect-cloud-connections");
+
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MEMBER_EMAIL = process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || ADMIN_EMAIL;
+const MEMBER_PASSWORD = process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || ADMIN_PASSWORD;
+const MOCK_OAUTH_MCP_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:3978").trim().replace(/\/+$/, "");
+const MOCK_PORT = Number(process.env.OPENWORK_EVAL_DISCONNECT_MCP_PORT ?? 4552);
+const MOCK_ORIGIN = `http://127.0.0.1:${MOCK_PORT}`;
+const RUN_TAG = Date.now().toString(36);
+const API_KEY_NAME = `Disconnect API key ${RUN_TAG}`;
+const MEMBER_NAME = `Disconnect member MCP ${RUN_TAG}`;
+const SHARED_OAUTH_NAME = `Disconnect shared OAuth ${RUN_TAG}`;
+
+const state = {
+  adminSession: null,
+  memberSession: null,
+  orgId: null,
+  apiKeyConnectionId: null,
+  memberConnectionId: null,
+  sharedOAuthConnectionId: null,
+};
+
+let mockServer = null;
+
+function requireState(value, label) {
+  if (typeof value === "string" && value.trim()) return value;
+  throw new Error(`${label} was not prepared.`);
+}
+
+function authHeaders(token = requireState(state.adminSession, "admin session")) {
+  const headers = { authorization: `Bearer ${token}` };
+  if (state.orgId) {
+    headers["x-openwork-org-id"] = state.orgId;
+    headers["x-openwork-legacy-org-id"] = state.orgId;
+  }
+  return headers;
+}
+
+async function orgApi(ctx, path, init = {}, token) {
+  const response = await denApiFetch(path, {
+    ...init,
+    headers: { ...authHeaders(token), ...(init.headers ?? {}) },
+  });
+  ctx.assert(response.response.ok || response.response.status === 204, `${path} failed: ${response.response.status} ${JSON.stringify(response.body).slice(0, 500)}`);
+  return response.body;
+}
+
+function jsonResponse(response, status, body) {
+  response.writeHead(status, { "content-type": "application/json" });
+  response.end(JSON.stringify(body));
+}
+
+async function readRequestBody(request) {
+  let raw = "";
+  for await (const chunk of request) raw += chunk;
+  return raw.trim() ? JSON.parse(raw) : {};
+}
+
+async function startApiKeyMock(ctx) {
+  if (mockServer) return;
+  mockServer = createServer(async (request, response) => {
+    const url = new URL(request.url ?? "/", MOCK_ORIGIN);
+    if (url.pathname === "/health") return jsonResponse(response, 200, { ok: true });
+    if (!url.pathname.endsWith("mcp")) return jsonResponse(response, 404, { error: "not_found" });
+    const authorization = request.headers.authorization ?? null;
+    const payload = await readRequestBody(request).catch(() => ({}));
+    if (!authorization?.startsWith("Bearer ")) return jsonResponse(response, 401, { error: "missing_api_key" });
+    if (payload?.id === undefined) {
+      response.writeHead(202);
+      response.end();
+      return;
+    }
+    if (payload.method === "initialize") {
+      return jsonResponse(response, 200, {
+        jsonrpc: "2.0",
+        id: payload.id,
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name: "disconnect-cloud-connections-proof", version: "1.0.0" },
+        },
+      });
+    }
+    if (payload.method === "tools/list") {
+      return jsonResponse(response, 200, { jsonrpc: "2.0", id: payload.id, result: { tools: [] } });
+    }
+    return jsonResponse(response, 200, { jsonrpc: "2.0", id: payload.id, result: {} });
+  });
+  await new Promise((resolve, reject) => {
+    mockServer.once("error", reject);
+    mockServer.listen(MOCK_PORT, "127.0.0.1", resolve);
+  });
+  mockServer.unref();
+  const health = await fetch(`${MOCK_ORIGIN}/health`, { signal: AbortSignal.timeout(2_000) });
+  ctx.assert(health.ok, "The local disconnect MCP mock did not become healthy.");
+}
+
+async function ensureAdminContext(ctx) {
+  state.adminSession = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
+  ctx.assert(Boolean(state.adminSession), `Den API sign-in failed for ${ADMIN_EMAIL}.`);
+  const listed = await denApiFetch("/v1/me/orgs", { headers: { authorization: `Bearer ${state.adminSession}` } });
+  ctx.assert(listed.response.ok, `Could not list admin organizations: ${listed.response.status}`);
+  const orgs = Array.isArray(listed.body?.orgs) ? listed.body.orgs : [];
+  const selected = orgs.find((org) => String(org.name ?? "").includes("Acme Robotics"))
+    ?? orgs.find((org) => ["owner", "admin"].includes(String(org.role ?? "").toLowerCase()))
+    ?? orgs[0];
+  ctx.assert(selected && typeof selected.id === "string", `No organization found for ${ADMIN_EMAIL}.`);
+  state.orgId = selected.id;
+  await orgApi(ctx, "/v1/me/active-organization", { method: "POST", body: JSON.stringify({ organizationId: state.orgId }) });
+}
+
+async function ensureMemberContext(ctx) {
+  state.memberSession = await signInApi(MEMBER_EMAIL, MEMBER_PASSWORD);
+  ctx.assert(Boolean(state.memberSession), `Member sign-in failed for ${MEMBER_EMAIL}. Set OPENWORK_EVAL_MEMBER_EMAIL/PASSWORD to an existing member or omit them to reuse the admin account.`);
+  await orgApi(ctx, "/v1/me/active-organization", { method: "POST", body: JSON.stringify({ organizationId: requireState(state.orgId, "organization id") }) }, state.memberSession);
+}
+
+async function cleanupNamedConnections(ctx) {
+  const listed = await orgApi(ctx, "/v1/mcp-connections?scope=manageable");
+  for (const connection of listed.connections ?? []) {
+    if (![API_KEY_NAME, MEMBER_NAME, SHARED_OAUTH_NAME].includes(connection.name)) continue;
+    await denApiFetch(`/v1/mcp-connections/${connection.id}`, { method: "DELETE", headers: authHeaders() });
+  }
+}
+
+async function seedApiKeyConnection(ctx) {
+  if (state.apiKeyConnectionId) return;
+  const created = await orgApi(ctx, "/v1/mcp-connections", {
+    method: "POST",
+    body: JSON.stringify({
+      name: API_KEY_NAME,
+      url: `${MOCK_ORIGIN}/apikey-mcp`,
+      authType: "apikey",
+      credentialMode: "shared",
+      apiKey: `fraimz-api-key-${RUN_TAG}`,
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    }),
+  });
+  state.apiKeyConnectionId = created.id ?? null;
+  ctx.assert(Boolean(state.apiKeyConnectionId), "API-key connection creation did not return an id.");
+}
+
+async function createOAuthConnection(ctx, name, credentialMode) {
+  const created = await orgApi(ctx, "/v1/mcp-connections", {
+    method: "POST",
+    body: JSON.stringify({
+      name,
+      url: `${MOCK_OAUTH_MCP_URL}/mcp`,
+      authType: "oauth",
+      credentialMode,
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    }),
+  });
+  ctx.assert(typeof created.id === "string", `${name} creation did not return an id.`);
+  return created.id;
+}
+
+async function completeOAuth(ctx, connectionId, token) {
+  const start = await orgApi(ctx, `/v1/mcp-connections/${connectionId}/connect/start`, {}, token);
+  ctx.assert(start.status === "needs_auth" && typeof start.authorizeUrl === "string", `OAuth did not return an authorize URL: ${JSON.stringify(start).slice(0, 300)}`);
+  const authorizeResponse = await fetch(start.authorizeUrl, { redirect: "manual" });
+  const callbackUrl = authorizeResponse.headers.get("location");
+  ctx.assert(Boolean(callbackUrl), "OAuth authorize did not redirect to the callback.");
+  const callback = await fetch(callbackUrl);
+  ctx.assert(callback.ok, `OAuth callback failed: ${callback.status}`);
+}
+
+async function seedMemberConnection(ctx) {
+  const health = await fetch(`${MOCK_OAUTH_MCP_URL}/health`).catch(() => null);
+  ctx.assert(Boolean(health?.ok), `Mock OAuth MCP server not reachable at ${MOCK_OAUTH_MCP_URL}.`);
+  if (!state.memberConnectionId) state.memberConnectionId = await createOAuthConnection(ctx, MEMBER_NAME, "per_member");
+  const connection = await usableConnection(ctx, requireState(state.memberConnectionId, "member connection id"));
+  if (!connection.connectedForMe) {
+    await completeOAuth(ctx, requireState(state.memberConnectionId, "member connection id"), requireState(state.memberSession, "member session"));
+  }
+}
+
+async function seedSharedOAuthConnection(ctx) {
+  const health = await fetch(`${MOCK_OAUTH_MCP_URL}/health`).catch(() => null);
+  ctx.assert(Boolean(health?.ok), `Mock OAuth MCP server not reachable at ${MOCK_OAUTH_MCP_URL}.`);
+  if (!state.sharedOAuthConnectionId) state.sharedOAuthConnectionId = await createOAuthConnection(ctx, SHARED_OAUTH_NAME, "shared");
+  const connection = await manageableConnection(ctx, requireState(state.sharedOAuthConnectionId, "shared OAuth connection id"));
+  if (!connection.connected) {
+    await completeOAuth(ctx, requireState(state.sharedOAuthConnectionId, "shared OAuth connection id"), requireState(state.adminSession, "admin session"));
+  }
+}
+
+async function setBrowserActiveOrganization(ctx) {
+  await ctx.eval(`fetch('/api/den/v1/me/active-organization', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify({ organizationId: ${JSON.stringify(requireState(state.orgId, "organization id"))} }),
+  }).then((response) => response.ok)`, { awaitPromise: true });
+}
+
+async function rowTextByName(ctx, name, connectionId) {
+  return ctx.eval(`(() => {
+    const row = document.querySelector('[data-testid="mcp-connection-row-${connectionId}"]');
+    if (row) return row.innerText ?? '';
+    const target = ${JSON.stringify(name)};
+    const rows = [...document.querySelectorAll('[data-testid^="mcp-connection-row-"]')].filter((node) => (node.innerText ?? '').includes(target));
+    return rows[0]?.innerText ?? '';
+  })()`);
+}
+
+async function clickConnectionAction(ctx, connectionId, action) {
+  const clicked = await ctx.eval(`(() => {
+    const button = document.querySelector('[data-testid="${action}-mcp-connection-${connectionId}"]');
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked, `Could not click ${action} for connection ${connectionId}.`);
+}
+
+async function manageableConnection(ctx, connectionId) {
+  const listed = await orgApi(ctx, "/v1/mcp-connections?scope=manageable");
+  const connection = (listed.connections ?? []).find((entry) => entry.id === connectionId);
+  ctx.assert(Boolean(connection), `Manageable list did not include ${connectionId}.`);
+  return connection;
+}
+
+async function usableConnection(ctx, connectionId) {
+  const listed = await orgApi(ctx, "/v1/mcp-connections?scope=usable", {}, requireState(state.memberSession, "member session"));
+  const connection = (listed.connections ?? []).find((entry) => entry.id === connectionId);
+  ctx.assert(Boolean(connection), `Usable list did not include ${connectionId}.`);
+  return connection;
+}
+
+async function waitForUsableConnectedForMe(ctx, connectionId, connectedForMe) {
+  const deadline = Date.now() + 30_000;
+  let connection = await usableConnection(ctx, connectionId);
+  while (connection.connectedForMe !== connectedForMe && Date.now() < deadline) {
+    await new Promise((resolve) => setTimeout(resolve, 500));
+    connection = await usableConnection(ctx, connectionId);
+  }
+  ctx.assert(connection.connectedForMe === connectedForMe, `Usable connection ${connectionId} connectedForMe remained ${connection.connectedForMe}.`);
+  return connection;
+}
+
+export default {
+  id: "disconnect-cloud-connections",
+  title: "Cloud connector disconnect signs accounts out without deleting setup",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("Admins see connected external MCP rows with creator attribution", {
+          voiceover: vo[0],
+          action: async () => {
+            await ensureAdminContext(ctx);
+            await cleanupNamedConnections(ctx);
+            await seedSharedOAuthConnection(ctx);
+            await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await setBrowserActiveOrganization(ctx);
+            await openAdminConnections(ctx);
+            await ctx.waitForText(SHARED_OAUTH_NAME, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const rowText = await rowTextByName(ctx, SHARED_OAUTH_NAME, requireState(state.sharedOAuthConnectionId, "shared OAuth connection id"));
+            ctx.assert(rowText.includes("Connected"), `Shared OAuth row was not connected: ${rowText}`);
+            ctx.assert(rowText.includes("Added by"), `Shared OAuth row did not show creator attribution: ${rowText}`);
+            const connection = await manageableConnection(ctx, requireState(state.sharedOAuthConnectionId, "shared OAuth connection id"));
+            ctx.assert(typeof connection.createdByName === "string" && connection.createdByName.length > 0, `API did not return createdByName: ${JSON.stringify(connection)}`);
+          },
+          screenshot: { name: "admin-connections-creator", requireText: [SHARED_OAUTH_NAME, "Added by", "Connected"] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("A connected row offers Disconnect separately from Remove", {
+          voiceover: vo[1],
+          action: async () => {
+            await openAdminConnections(ctx);
+            await ctx.waitForText(SHARED_OAUTH_NAME, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const rowText = await rowTextByName(ctx, SHARED_OAUTH_NAME, requireState(state.sharedOAuthConnectionId, "shared OAuth connection id"));
+            ctx.assert(rowText.includes("Disconnect"), `Disconnect action missing: ${rowText}`);
+            ctx.assert(rowText.includes("Remove"), `Remove action missing: ${rowText}`);
+          },
+          screenshot: { name: "admin-disconnect-and-remove", requireText: [SHARED_OAUTH_NAME, "Disconnect", "Remove"] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Disconnect confirmation explains accounts are signed out while setup is kept", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.eval("window.__disconnectConfirmMessage = null; window.__originalConfirm = window.confirm; window.confirm = (message) => { window.__disconnectConfirmMessage = String(message); return false; };");
+            await clickConnectionAction(ctx, requireState(state.sharedOAuthConnectionId, "shared OAuth connection id"), "disconnect");
+          },
+          assert: async () => {
+            const message = await ctx.eval("window.__disconnectConfirmMessage || ''");
+            ctx.assert(message.includes("signs out every associated account"), `Confirmation did not explain sign-out: ${message}`);
+            ctx.assert(message.includes("keeps the MCP server setup"), `Confirmation did not explain retained setup: ${message}`);
+            ctx.assert(message.includes("access rules"), `Confirmation did not mention access rules: ${message}`);
+            ctx.assert(message.includes("bindings"), `Confirmation did not mention bindings: ${message}`);
+          },
+          screenshot: { name: "disconnect-confirmation-copy", requireText: [SHARED_OAUTH_NAME, "Disconnect"] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("After disconnect the row remains not connected with creator attribution and reconnect affordance where applicable", {
+          voiceover: vo[3],
+          action: async () => {
+            const connectionId = requireState(state.sharedOAuthConnectionId, "shared OAuth connection id");
+            await ctx.eval("window.confirm = () => true;");
+            await clickConnectionAction(ctx, connectionId, "disconnect");
+            await ctx.waitFor(`(() => {
+              return !document.querySelector('[data-testid="disconnect-mcp-connection-${connectionId}"]');
+            })()`, { timeoutMs: 30_000, label: "disconnect action removed from shared OAuth row" });
+            await ctx.eval("if (window.__originalConfirm) window.confirm = window.__originalConfirm;");
+          },
+          assert: async () => {
+            const rowText = await rowTextByName(ctx, SHARED_OAUTH_NAME, requireState(state.sharedOAuthConnectionId, "shared OAuth connection id"));
+            ctx.assert(rowText.includes("Not connected"), `Disconnected row did not show Not connected: ${rowText}`);
+            ctx.assert(rowText.includes("Added by"), `Creator attribution disappeared: ${rowText}`);
+            ctx.assert(rowText.includes("Connect"), `Disconnected row did not offer Connect: ${rowText}`);
+            const connection = await manageableConnection(ctx, requireState(state.sharedOAuthConnectionId, "shared OAuth connection id"));
+            ctx.assert(connection.connected === false, `Shared OAuth connection still reported connected: ${JSON.stringify(connection)}`);
+            ctx.assert(typeof connection.createdByName === "string" && connection.createdByName.length > 0, "Creator attribution was not retained in the API response.");
+          },
+          screenshot: { name: "admin-row-after-disconnect", requireText: [SHARED_OAUTH_NAME, "Not connected", "Added by", "Connect"] },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("Members can disconnect their own per-member external MCP account only", {
+          voiceover: vo[4],
+          action: async () => {
+            await ensureMemberContext(ctx);
+            await seedMemberConnection(ctx);
+            await signInViaBrowser(ctx, MEMBER_EMAIL, MEMBER_PASSWORD);
+            await setBrowserActiveOrganization(ctx);
+            await openYourConnections(ctx);
+            await ctx.waitForText(MEMBER_NAME, { timeoutMs: 30_000 });
+            await ctx.waitForText("Connected as you", { timeoutMs: 30_000 });
+            const connectionId = requireState(state.memberConnectionId, "member connection id");
+            const selector = `[data-testid="disconnect-my-mcp-account-${connectionId}"]`;
+            await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(selector)}))`, { timeoutMs: 30_000, label: "member disconnect action" });
+            const clicked = await ctx.eval(`(() => {
+              const button = document.querySelector(${JSON.stringify(selector)});
+              button?.click();
+              return Boolean(button);
+            })()`);
+            ctx.assert(clicked, `Could not click member disconnect action for ${connectionId}.`);
+            await waitForUsableConnectedForMe(ctx, connectionId, false);
+            await ctx.waitFor(`!document.querySelector(${JSON.stringify(selector)})`, { timeoutMs: 30_000, label: "member disconnect action removed" });
+          },
+          assert: async () => {
+            const connection = await usableConnection(ctx, requireState(state.memberConnectionId, "member connection id"));
+            ctx.assert(connection.connectedForMe === false, `Member account still reported connected: ${JSON.stringify(connection)}`);
+            const selector = `[data-testid="disconnect-my-mcp-account-${requireState(state.memberConnectionId, "member connection id")}"]`;
+            const disconnectButtonGone = await ctx.eval(`!document.querySelector(${JSON.stringify(selector)})`);
+            ctx.assert(disconnectButtonGone, "Member disconnect action was still visible after disconnect.");
+          },
+          screenshot: { name: "member-disconnected-own-account", requireText: [MEMBER_NAME, "Connect your account", "Connect"] },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("API-key, shared OAuth, and per-member disconnects preserve rows and setup", {
+          voiceover: vo[5],
+          action: async () => {
+            await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await setBrowserActiveOrganization(ctx);
+            await startApiKeyMock(ctx);
+            await seedApiKeyConnection(ctx);
+            await seedSharedOAuthConnection(ctx);
+            await ensureMemberContext(ctx);
+            await seedMemberConnection(ctx);
+            await orgApi(ctx, `/v1/mcp-connections/${requireState(state.apiKeyConnectionId, "API-key connection id")}/disconnect`, { method: "POST" });
+            await orgApi(ctx, `/v1/mcp-connections/${requireState(state.sharedOAuthConnectionId, "shared OAuth connection id")}/disconnect`, { method: "POST" });
+            await orgApi(ctx, `/v1/mcp-connections/${requireState(state.memberConnectionId, "member connection id")}/disconnect`, { method: "POST" });
+            await openAdminConnections(ctx);
+            await ctx.waitForText(SHARED_OAUTH_NAME, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const apiKey = await manageableConnection(ctx, requireState(state.apiKeyConnectionId, "API-key connection id"));
+            const shared = await manageableConnection(ctx, requireState(state.sharedOAuthConnectionId, "shared OAuth connection id"));
+            const member = await manageableConnection(ctx, requireState(state.memberConnectionId, "member connection id"));
+            ctx.assert(apiKey.authType === "apikey" && apiKey.connected === false, `API-key disconnect did not hold: ${JSON.stringify(apiKey)}`);
+            ctx.assert(shared.authType === "oauth" && shared.credentialMode === "shared" && shared.connected === false, `Shared OAuth disconnect did not hold: ${JSON.stringify(shared)}`);
+            ctx.assert(member.credentialMode === "per_member" && member.connected === false, `Per-member aggregate disconnect did not hold: ${JSON.stringify(member)}`);
+            ctx.assert(apiKey.access?.orgWide === true && shared.access?.orgWide === true && member.access?.orgWide === true, "Access grants were not retained for every connection.");
+            ctx.output("disconnect-rules-summary", JSON.stringify({ apiKey, shared, member }, null, 2));
+          },
+          screenshot: { name: "all-disconnect-rules", requireText: [API_KEY_NAME, SHARED_OAUTH_NAME, MEMBER_NAME, "Not connected"] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/disconnect-cloud-connections.md
+++ b/evals/voiceovers/disconnect-cloud-connections.md
@@ -1,0 +1,13 @@
+# disconnect-cloud-connections — Disconnect cloud connections without losing their setup
+
+1. An organization owner or admin opens Connections and sees each connector's status and who added it.
+
+2. A connected connector offers Disconnect separately from the destructive Remove action.
+
+3. The confirmation explains that disconnecting signs out every associated account while preserving configuration, access rules, and bindings.
+
+4. After confirmation, the connector remains listed as Disconnected, retains its creator attribution, and offers Connect.
+
+5. A member opens Your Connections and disconnects their own Notion, Linear, or other per-member account without affecting anyone else.
+
+6. API-key, shared OAuth, and per-member connectors follow these same disconnect rules without losing their saved setup.


### PR DESCRIPTION
## Summary
- add non-destructive admin disconnect while preserving MCP configuration, grants, OAuth clients, and bindings
- let members disconnect only their own per-member MCP account
- show connector creator attribution and disconnected status in den-web
- clear API-key/shared/per-member credentials and fence late OAuth callbacks without a database migration

## Validation
- `pnpm --filter @openwork-ee/den-api build` — passed
- `pnpm --filter @openwork-ee/den-web exec tsc --noEmit --pretty false --skipLibCheck` — passed
- `bun test ee/apps/den-web/tests/mcp-connection-display.test.ts` — 2 passed
- `DEN_API_PUBLIC_URL=http://127.0.0.1:8790 pnpm --filter @openwork-ee/den-api exec bun test --timeout 60000 test/mcp-connections-edit.test.ts` — 14 passed
- `pnpm fraimz --flow disconnect-cloud-connections --stack den` — 6/6 frames passed, 0 failed, 0 skipped

Validation was completed before the final rebase onto `dev`; it was not rerun afterward per request.

## Proof
- committed flow: `evals/flows/disconnect-cloud-connections.flow.mjs`
- approved narration: `evals/voiceovers/disconnect-cloud-connections.md`
- local passed artifact: `evals/results/2026-07-15T20-16-16-043Z/fraimz.html`