### PR TITLE
feat(evals): suite runner support + nightly-connect suite

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -22,11 +22,31 @@ reports with screenshots. The runner also writes a browseable frame-by-frame
 `index.html` in each result directory.
 
 ```bash
-pnpm evals --list                 # show available coded flows
+pnpm evals --list                 # show available coded flows and suites
 pnpm evals --all                  # run everything runnable
 pnpm evals --flow app-smoke       # run one flow
+pnpm evals --suite nightly-connect  # run a named suite in journey order
 pnpm evals --all --cdp-url http://127.0.0.1:9825   # explicit CDP endpoint
 ```
+
+### Suites — unified journeys for scheduled runs
+
+Related flows are grouped into named **suites** so scheduled (e.g. nightly)
+runs exercise a whole product journey in one command instead of cherry-picking
+flow ids. A flow opts in with `suite: "<suite-id>"` and an optional
+`suiteOrder: <number>` that fixes its position in the journey (untagged order
+falls back to flow id). `--suite` can be passed multiple times; suites run in
+the order given and `--list --suite <id>` shows a suite's journey order.
+
+Current suites:
+
+- `nightly-connect` — OpenWork Connect end to end: the desktop Connect tab
+  pitch and org MCP cards, cloud/desktop capability partition, delivery
+  switch, legacy extension gating, agent diagnostics, lifecycle status,
+  docs/landing installer, keyless Den connect, the full
+  landing-to-OAuth-to-MCP reliability journey, and connector health recovery.
+  Env-gated members (Den API/web, docs/landing URLs) skip cleanly when the
+  environment is not provided.
 
 ### fraimz — the deliverable
 

--- a/evals/flows/connect-agent-diagnostics.flow.mjs
+++ b/evals/flows/connect-agent-diagnostics.flow.mjs
@@ -220,6 +220,8 @@ export default {
   id: FLOW_ID,
   title: "Settings Connect audits effective agent and MCP injection with a reality-backed bounded diagnostics report",
   kind: "user-facing",
+  suite: "nightly-connect",
+  suiteOrder: 5,
   spec: "evals/voiceovers/connect-agent-diagnostics.md",
   steps: [
     {

--- a/evals/flows/connect-aware-extension-gating.flow.mjs
+++ b/evals/flows/connect-aware-extension-gating.flow.mjs
@@ -73,6 +73,8 @@ export default {
   id: FLOW_ID,
   title: "Connect flag gates dead legacy Google Workspace actions and redirects the agent to OpenWork Cloud",
   kind: "internal",
+  suite: "nightly-connect",
+  suiteOrder: 4,
   spec: "evals/voiceovers/connect-aware-extension-gating.md",
   steps: [
     {

--- a/evals/flows/connect-cloud-partition.flow.mjs
+++ b/evals/flows/connect-cloud-partition.flow.mjs
@@ -35,6 +35,8 @@ export default {
   id: FLOW_ID,
   title: "Connect partitions cloud-runnable organization capabilities from desktop marketplace installs",
   kind: "user-facing",
+  suite: "nightly-connect",
+  suiteOrder: 2,
   spec: "evals/voiceovers/connect-cloud-partition.md",
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",

--- a/evals/flows/connect-delivery-switch.flow.mjs
+++ b/evals/flows/connect-delivery-switch.flow.mjs
@@ -32,6 +32,8 @@ export default {
   id: FLOW_ID,
   title: "Connect-mode delivery switch moves marketplace plugins from desktop import to the cloud rail",
   kind: "user-facing",
+  suite: "nightly-connect",
+  suiteOrder: 3,
   spec: "evals/voiceovers/connect-delivery-switch.md",
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",

--- a/evals/flows/connect-tab-beta.flow.mjs
+++ b/evals/flows/connect-tab-beta.flow.mjs
@@ -27,6 +27,8 @@ export default {
   id: FLOW_ID,
   title: "Desktop Connect tab alpha shell shows pitch, active org MCP cards, and leaves Extensions local-only",
   kind: "user-facing",
+  suite: "nightly-connect",
+  suiteOrder: 1,
   spec: "evals/voiceovers/connect-tab-beta.md",
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",

--- a/evals/flows/connector-health-recovery.flow.mjs
+++ b/evals/flows/connector-health-recovery.flow.mjs
@@ -53,6 +53,8 @@ export default {
   id: FLOW_ID,
   title: "OpenWork Cloud identifies and recovers any unhealthy downstream connector",
   kind: "internal",
+  suite: "nightly-connect",
+  suiteOrder: 10,
   requiresApp: false,
   steps: [
     {

--- a/evals/flows/docs-openwork-connect.flow.mjs
+++ b/evals/flows/docs-openwork-connect.flow.mjs
@@ -69,6 +69,8 @@ export default {
   id: "docs-openwork-connect",
   title: "Use the OpenWork Connect installer from the docs or landing page",
   kind: "user-facing",
+  suite: "nightly-connect",
+  suiteOrder: 7,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DOCS_URL", "OPENWORK_EVAL_LANDING_URL"],
   steps: [

--- a/evals/flows/keyless-den-connect.flow.mjs
+++ b/evals/flows/keyless-den-connect.flow.mjs
@@ -195,6 +195,8 @@ export default {
   id: FLOW_ID,
   title: "A Den user installs and connects the standard app without deployment keys",
   kind: "user-facing",
+  suite: "nightly-connect",
+  suiteOrder: 8,
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",
     "OPENWORK_EVAL_DEN_TOKEN",

--- a/evals/flows/openwork-connect-status.flow.mjs
+++ b/evals/flows/openwork-connect-status.flow.mjs
@@ -226,6 +226,8 @@ export default {
   id: FLOW_ID,
   title: "Signed-in users see non-blocking OpenWork Connect lifecycle health",
   kind: "user-facing",
+  suite: "nightly-connect",
+  suiteOrder: 6,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [
     { name: "Setup signed-in Connect status", run: setup },

--- a/evals/flows/reliable-openwork-connect.flow.mjs
+++ b/evals/flows/reliable-openwork-connect.flow.mjs
@@ -1860,6 +1860,8 @@ export default {
   id: FLOW_ID,
   title: "Reliable OpenWork Connect is proven from landing page to OAuth, MCP tools, errors, and docs",
   kind: "user-facing",
+  suite: "nightly-connect",
+  suiteOrder: 9,
   preserveTheme: true,
   requiredEnv: [
     "OPENWORK_EVAL_LANDING_URL",

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -8,6 +8,7 @@
  * Usage:
  *   node evals/runner/run.mjs --list
  *   node evals/runner/run.mjs --flow app-smoke [--flow another]
+ *   node evals/runner/run.mjs --suite nightly-connect [--suite another]
  *   node evals/runner/run.mjs --all
  *   node evals/runner/run.mjs --all --cdp-url http://127.0.0.1:9825
  *   node evals/runner/run.mjs --all --stack den   # bring up MySQL + den-api +
@@ -18,7 +19,7 @@
  * http://127.0.0.1:9823 (local pnpm dev). Override with --cdp-url or
  * OPENWORK_EVAL_CDP_URL.
  */
-import { mkdir, readFile, readdir, writeFile } from "node:fs/promises";
+import { mkdir, readdir, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
 import { connect, debuggerUrlFor, pickAppTarget, resolveCdpBaseUrl } from "./cdp.mjs";
@@ -33,10 +34,11 @@ const DEFAULT_RESULTS_DIR = join(RUNNER_DIR, "..", "results");
 const DEFAULT_CDP_CANDIDATES = ["http://127.0.0.1:9825", "http://127.0.0.1:9823"];
 
 function parseArgs(argv) {
-  const args = { flows: [], all: false, list: false, cdpUrl: null, out: null, stack: null, stackDown: false, scaffold: null, force: false, pr: null };
+  const args = { flows: [], suites: [], all: false, list: false, cdpUrl: null, out: null, stack: null, stackDown: false, scaffold: null, force: false, pr: null };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     if (value === "--flow") args.flows.push(argv[++index]);
+    else if (value === "--suite") args.suites.push(argv[++index]);
     else if (value === "--all") args.all = true;
     else if (value === "--list") args.list = true;
     else if (value === "--cdp-url") args.cdpUrl = argv[++index];
@@ -72,23 +74,51 @@ async function loadFlows() {
     if (flow.kind !== undefined && flow.kind !== "user-facing" && flow.kind !== "internal") {
       throw new Error(`Flow file ${entry} has invalid kind ${JSON.stringify(flow.kind)}. Use "user-facing" (flow demo) or "internal" (internal demo, e.g. perf).`);
     }
+    if (flow.suite != null && (typeof flow.suite !== "string" || !flow.suite.trim())) {
+      throw new Error(`Flow file ${entry} has invalid suite ${JSON.stringify(flow.suite)}. Use a non-empty string (e.g. "nightly-connect").`);
+    }
+    if (flow.suiteOrder !== undefined && typeof flow.suiteOrder !== "number") {
+      throw new Error(`Flow file ${entry} has invalid suiteOrder ${JSON.stringify(flow.suiteOrder)}. Use a number.`);
+    }
     flows.push({ ...flow, file: entry });
   }
   return flows;
 }
 
-async function selectedStackNeedsApp(args) {
-  if (args.list) return false;
-  if (args.all || args.flows.length === 0) return true;
-  for (const flowId of args.flows) {
-    try {
-      const source = await readFile(join(FLOWS_DIR, `${flowId}.flow.mjs`), "utf8");
-      if (!/requiresApp\s*:\s*false/.test(source)) return true;
-    } catch {
-      return true;
+function suiteFlows(flows, suite) {
+  // Journey order within a suite: explicit suiteOrder first, then id.
+  return flows
+    .filter((flow) => flow.suite === suite)
+    .sort((a, b) =>
+      (a.suiteOrder ?? Number.MAX_SAFE_INTEGER) - (b.suiteOrder ?? Number.MAX_SAFE_INTEGER)
+      || a.id.localeCompare(b.id));
+}
+
+function selectFlows(flows, args) {
+  if (args.all) return flows;
+  const known = new Set(flows.map((flow) => flow.suite).filter(Boolean));
+  for (const suite of args.suites) {
+    if (!known.has(suite)) {
+      throw new Error(`Unknown suite: ${suite}. Available suites: ${[...known].sort().join(", ") || "(none tagged yet)"}`);
     }
   }
-  return false;
+  const selected = [];
+  const seen = new Set();
+  for (const suite of args.suites) {
+    for (const flow of suiteFlows(flows, suite)) {
+      if (!seen.has(flow.id)) {
+        seen.add(flow.id);
+        selected.push(flow);
+      }
+    }
+  }
+  for (const flow of flows) {
+    if (args.flows.includes(flow.id) && !seen.has(flow.id)) {
+      seen.add(flow.id);
+      selected.push(flow);
+    }
+  }
+  return selected;
 }
 
 function missingEnv(flow, env) {
@@ -101,6 +131,7 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
     title: flow.title,
     spec: flow.spec ?? null,
     kind: flow.kind ?? null,
+    suite: flow.suite ?? null,
     status: "passed",
     skipReason: null,
     steps: [],
@@ -233,6 +264,7 @@ function renderMarkdown(report) {
     const icon = flow.status === "passed" ? "✅" : flow.status === "skipped" ? "⏭️" : "❌";
     lines.push(`## ${icon} ${flow.id} — ${flow.title}`);
     if (flow.kind) lines.push(`Kind: ${flow.kind === "user-facing" ? "user-facing flow demo" : "internal demo"}`);
+    if (flow.suite) lines.push(`Suite: ${flow.suite}`);
     if (flow.spec) lines.push(`Spec: ${flow.spec}`);
     if (flow.skipReason) lines.push(`Skipped: ${flow.skipReason}`);
     lines.push("");
@@ -284,6 +316,7 @@ function renderFrameIndex(report) {
       <section data-flow="${escapeHtml(flow.id)}">
         <h2>${escapeHtml(flow.id)} - ${escapeHtml(flow.title)}</h2>
         <p>${flowKindBadge(flow.kind)} <button type="button" class="speak-all" data-flow-id="${escapeHtml(flow.id)}">▶ Play full voiceover</button></p>
+        ${flow.suite ? `<p class="muted">Suite: ${escapeHtml(flow.suite)}</p>` : ""}
         ${flow.spec ? `<p class="muted">Spec: ${escapeHtml(flow.spec)}</p>` : ""}
         ${flow.skipReason ? `<p class="skipped">Skipped: ${escapeHtml(flow.skipReason)}</p>` : ""}
         <div class="steps">${steps}</div>
@@ -425,7 +458,7 @@ function renderEvidence(evidence) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
-    console.log("Usage: node evals/runner/run.mjs [--list | --all | --flow <id> ... | scaffold <id> [--force]] [--cdp-url <url>] [--out <dir>] [--pr [number]] [--stack den | --stack-down]");
+    console.log("Usage: node evals/runner/run.mjs [--list | --all | --flow <id> ... | --suite <id> ... | scaffold <id> [--force]] [--cdp-url <url>] [--out <dir>] [--pr [number]] [--stack den | --stack-down]");
     return;
   }
 
@@ -441,35 +474,42 @@ async function main() {
     return;
   }
 
-  if (args.stack === "den") {
-    await ensureDenStack({
-      log: (msg) => console.log(`▸ ${msg}`),
-      cdpCandidates: args.cdpUrl ? [args.cdpUrl] : DEFAULT_CDP_CANDIDATES,
-      skipApp: !(await selectedStackNeedsApp(args)),
-    });
-  } else if (args.stack) {
-    throw new Error(`Unknown stack: ${args.stack}. Supported: den`);
-  }
-
   const flows = await loadFlows();
 
   if (args.list) {
-    for (const flow of flows) {
+    const listed = args.suites.length > 0
+      ? [...new Set(args.suites.flatMap((suite) => suiteFlows(flows, suite)))]
+      : flows;
+    for (const flow of listed) {
+      const suite = flow.suite ? ` [suite: ${flow.suite}]` : "";
       const gates = flow.requiredEnv?.length ? ` (requires env: ${flow.requiredEnv.join(", ")})` : "";
-      console.log(`${flow.id} — ${flow.title}${gates}`);
+      console.log(`${flow.id} — ${flow.title}${suite}${gates}`);
+    }
+    const suites = [...new Set(flows.map((flow) => flow.suite).filter(Boolean))].sort();
+    if (args.suites.length === 0 && suites.length > 0) {
+      console.log("");
+      console.log(`Suites: ${suites.join(", ")}`);
     }
     return;
   }
 
-  const selected = args.all
-    ? flows
-    : flows.filter((flow) => args.flows.includes(flow.id));
+  const selected = selectFlows(flows, args);
   if (selected.length === 0) {
     throw new Error(
-      args.flows.length > 0
-        ? `No flows matched: ${args.flows.join(", ")}. Use --list to see available flows.`
-        : "Nothing to run. Pass --all, or --flow <id>. Use --list to see available flows.",
+      args.flows.length > 0 || args.suites.length > 0
+        ? `No flows matched: ${[...args.flows, ...args.suites].join(", ")}. Use --list to see available flows and suites.`
+        : "Nothing to run. Pass --all, --suite <id>, or --flow <id>. Use --list to see available flows.",
     );
+  }
+
+  if (args.stack === "den") {
+    await ensureDenStack({
+      log: (msg) => console.log(`▸ ${msg}`),
+      cdpCandidates: args.cdpUrl ? [args.cdpUrl] : DEFAULT_CDP_CANDIDATES,
+      skipApp: !selected.some((flow) => flow.requiresApp !== false),
+    });
+  } else if (args.stack) {
+    throw new Error(`Unknown stack: ${args.stack}. Supported: den`);
   }
 
   // App-less flows (requiresApp: false) don't need a CDP endpoint; only probe


### PR DESCRIPTION
## What

First step of unifying our ~170 coded eval flows into a few named journeys we can run overnight (analysis in the tracking discussion; suites follow in stacked PRs).

- Adds a **suite** concept to the eval runner: flows opt in with `suite: "<id>"` and optional `suiteOrder` (journey position; falls back to flow id).
- `pnpm evals --suite <id>` runs a suite in journey order; repeatable and deduped; unknown suites error with the available list.
- `pnpm evals --list` shows suite tags plus a suite summary; `--list --suite <id>` prints a suite's journey order.
- `report.md` / `report.json` / `fraimz.html` now carry each flow's suite.
- Replaces the `selectedStackNeedsApp` source-regex sniffing with real flow metadata (selection now happens before `--stack den` boots, so `--list` no longer brings the stack up).

## First suite: `nightly-connect`

Tags the ten OpenWork Connect flows as one journey: `connect-tab-beta` → `connect-cloud-partition` → `connect-delivery-switch` → `connect-aware-extension-gating` → `connect-agent-diagnostics` → `openwork-connect-status` → `docs-openwork-connect` → `keyless-den-connect` → `reliable-openwork-connect` → `connector-health-recovery`. Env-gated members skip cleanly when the nightly environment does not provide their env.

## Tests run

- `node evals/runner/run.mjs --list --suite nightly-connect` — prints the 10 flows in journey order with suite tags and env gates. ✅
- `node evals/runner/run.mjs --list` — all flows plus `Suites: nightly-connect` summary. ✅
- `node evals/runner/run.mjs --suite nope` — errors with `Unknown suite: nope. Available suites: nightly-connect`. ✅
- Dedup: `--list --suite nightly-connect --suite nightly-connect` → 10 (not 20); `--flow voiceover-first-dx --flow voiceover-first-dx` → runs once. ✅
- Full runner loop through the new selection path: `node evals/runner/run.mjs --flow voiceover-first-dx` → PASSED, `fraimz.html` written. ✅
- `node evals/runner/run.mjs --flow connector-health-recovery` — runs (fails on its own DB-backed integration dependency on this machine; unrelated to the selection change). ⚠️

**Honest limitation:** I could not run the full `nightly-connect` suite against a live onboarded desktop app from this environment — the dev Electron app stalls before window creation here (shared `com.differentai.openwork.dev` profile with several other running dev sidecars; CDP comes up with zero page targets). Repro for a reviewer with a clean dev app:

```bash
pnpm dev   # wait for the window
node evals/runner/run.mjs --suite nightly-connect --cdp-url http://127.0.0.1:9823
```

Env-gated members will skip unless `OPENWORK_EVAL_DEN_*` / docs / landing env is provided (the upcoming den-stack PR wires those in).

Part of the nightly-suites series: runner+connect (this PR) → local suites → den-stack web env → cloud suites → nightly orchestrator.
