### PR TITLE
feat(evals): tag cloud nightly suites (cloud-admin, cloud-member, den-web, membership)

### DIFF
--- a/evals/flows/admin-mcp-connect.flow.mjs
+++ b/evals/flows/admin-mcp-connect.flow.mjs
@@ -44,6 +44,8 @@ const ADMIN_CONNECTED_EXPR = `(() => {
 export default {
   id: "admin-mcp-connect",
   title: "Admin MCP connects end-to-end after OAuth discovery fix",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 1,
   spec: "evals/cloud-mcp-agent-flows.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
   steps: [

--- a/evals/flows/admin-to-member-marketplace.flow.mjs
+++ b/evals/flows/admin-to-member-marketplace.flow.mjs
@@ -13,6 +13,8 @@
 export default {
   id: "admin-to-member-marketplace",
   title: "Owner creates skill, shares via MCP, member discovers and installs from marketplace",
+  suite: "nightly-cloud-member",
+  suiteOrder: 21,
   spec: "evals/react-session-flows.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_WORKSPACE_PATH"],
   steps: [

--- a/evals/flows/approved-desktop-update-targeting.flow.mjs
+++ b/evals/flows/approved-desktop-update-targeting.flow.mjs
@@ -180,6 +180,8 @@ export default {
   id: FLOW_ID,
   title: "Automatic stable desktop checks install the highest approved published release",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 11,
   requiredEnv: ["OPENWORK_EVAL_WEB_CDP_ADMIN"],
   steps: [
     {

--- a/evals/flows/brand-icon-validation.flow.mjs
+++ b/evals/flows/brand-icon-validation.flow.mjs
@@ -92,6 +92,8 @@ export default {
   id: "brand-icon-validation",
   title: "Brand Icon URL rejects web pages loudly and accepts real logo image links",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 18,
   spec: "evals/voiceovers/brand-icon-validation.md",
   // OPENWORK_EVAL_DAYTONA_SANDBOX is required (not optional, unlike
   // desktop-brand-icon): the admin panel's Icon URL field lives in an

--- a/evals/flows/cloud-account-renders.flow.mjs
+++ b/evals/flows/cloud-account-renders.flow.mjs
@@ -6,6 +6,8 @@
 export default {
   id: "cloud-account-renders",
   title: "Cloud Account settings renders signed-in or signed-out state",
+  suite: "nightly-cloud-member",
+  suiteOrder: 6,
   spec: "evals/cloud-auth-flows.md",
   steps: [
     {

--- a/evals/flows/cloud-mcp-auto-config.flow.mjs
+++ b/evals/flows/cloud-mcp-auto-config.flow.mjs
@@ -21,6 +21,8 @@ const revealHidden = async (ctx) => {
 export default {
   id: "cloud-mcp-auto-config",
   title: "Cloud MCP auto-configures with first-party token on sign-in",
+  suite: "nightly-cloud-member",
+  suiteOrder: 7,
   spec: "evals/cloud-auth-flows.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
   steps: [

--- a/evals/flows/cloud-mcp-base-url.flow.mjs
+++ b/evals/flows/cloud-mcp-base-url.flow.mjs
@@ -34,6 +34,8 @@ export default {
   id: FLOW_ID,
   title: "Cloud MCP tokens follow the desktop base URL",
   kind: "internal",
+  suite: "nightly-cloud-member",
+  suiteOrder: 8,
   requiresApp: false,
   steps: [
     {

--- a/evals/flows/cloud-mcp-disable-sticks.flow.mjs
+++ b/evals/flows/cloud-mcp-disable-sticks.flow.mjs
@@ -87,6 +87,8 @@ const scrollCloudRowExpr = `(() => {
 export default {
   id: "cloud-mcp-disable-sticks",
   title: "Disabling the OpenWork Cloud Control MCP sticks across sync",
+  suite: "nightly-cloud-member",
+  suiteOrder: 10,
   spec: "evals/cloud-mcp-agent-flows.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
   steps: [

--- a/evals/flows/cloud-mcp-reliability.flow.mjs
+++ b/evals/flows/cloud-mcp-reliability.flow.mjs
@@ -1348,6 +1348,8 @@ export default {
   id: FLOW_ID,
   title: "Users can verify, repair, diagnose, and use Cloud agent access per workspace",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 9,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
   steps: [
     {

--- a/evals/flows/cloud-plugin-mcp-warning.flow.mjs
+++ b/evals/flows/cloud-plugin-mcp-warning.flow.mjs
@@ -425,6 +425,8 @@ export default {
   id: FLOW_ID,
   title: "Cloud marketplace plugins warn on malformed MCP payloads and hot-sync valid MCPs",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 22,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_WORKSPACE_PATH"],
   steps: [
     {

--- a/evals/flows/cloud-runtime-provider-config.flow.mjs
+++ b/evals/flows/cloud-runtime-provider-config.flow.mjs
@@ -164,6 +164,8 @@ async function clickProviderRowButton(ctx, label) {
 export default {
   id: "cloud-runtime-provider-config",
   title: "Cloud provider import/sync lives in runtime config, not opencode.jsonc",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 11,
   spec: "evals/cloud-provider-sync-flows.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
   steps: [

--- a/evals/flows/cloud-signin-go-to-dashboard.flow.mjs
+++ b/evals/flows/cloud-signin-go-to-dashboard.flow.mjs
@@ -88,6 +88,8 @@ export default {
   id: "cloud-signin-go-to-dashboard",
   title: "Cloud sign-in: \"Go to dashboard\" navigates while a desktop handoff is pending",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 2,
   spec: "evals/voiceovers/cloud-signin-go-to-dashboard.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/cloud-signin-handoff.flow.mjs
+++ b/evals/flows/cloud-signin-handoff.flow.mjs
@@ -10,6 +10,8 @@
 export default {
   id: "cloud-signin-handoff",
   title: "Cloud sign-in via desktop handoff paste code",
+  suite: "nightly-cloud-member",
+  suiteOrder: 1,
   spec: "evals/cloud-auth-flows.md#flow-1-cloud-sign-in-happy-path",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
   steps: [

--- a/evals/flows/cloud-workers-removed.flow.mjs
+++ b/evals/flows/cloud-workers-removed.flow.mjs
@@ -13,6 +13,8 @@ export default {
   id: "cloud-workers-removed",
   title: "Cloud Workers tab removed: sidebar, Account copy, legacy redirect",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 11,
   steps: [
     {
       name: "App booted",

--- a/evals/flows/connections-beta-desktop.flow.mjs
+++ b/evals/flows/connections-beta-desktop.flow.mjs
@@ -226,6 +226,8 @@ export default {
   id: "connections-beta-desktop",
   title: "Desktop Marketplace: alpha org connections are labeled and last",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 31,
   spec: "evals/voiceovers/connections-beta-desktop.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [

--- a/evals/flows/connections-beta.flow.mjs
+++ b/evals/flows/connections-beta.flow.mjs
@@ -185,6 +185,8 @@ export default {
   id: "connections-beta",
   title: "Connections alpha treatment: visible, black, and last",
   kind: "user-facing",
+  suite: "nightly-den-web",
+  suiteOrder: 6,
   spec: "evals/voiceovers/connections-beta.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/create-plugin-single-request.flow.mjs
+++ b/evals/flows/create-plugin-single-request.flow.mjs
@@ -208,6 +208,8 @@ export default {
   id: "create-plugin-single-request",
   title: "Create plugin: one save request preserves sharing and publish side effects",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 25,
   spec: "evals/voiceovers/create-plugin-single-request.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/den-download-link-match-allowed-versions.flow.mjs
+++ b/evals/flows/den-download-link-match-allowed-versions.flow.mjs
@@ -140,6 +140,8 @@ export default {
   id: FLOW_ID,
   title: "Organization install links download the highest allowed desktop version",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 7,
   requiresApp: false,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
   steps: [

--- a/evals/flows/den-reauth-pending-action.flow.mjs
+++ b/evals/flows/den-reauth-pending-action.flow.mjs
@@ -254,6 +254,8 @@ export default {
   id: FLOW_ID,
   title: "Den reauth keeps the pending install-link action alive",
   kind: "user-facing",
+  suite: "nightly-den-web",
+  suiteOrder: 12,
   spec: "evals/README.md",
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MYSQL_CONTAINER"],

--- a/evals/flows/den-reauth-popup-social.flow.mjs
+++ b/evals/flows/den-reauth-popup-social.flow.mjs
@@ -46,6 +46,8 @@ export default {
   id: FLOW_ID,
   title: "Den social reauth completes in a popup and retries the queued action",
   kind: "user-facing",
+  suite: "nightly-den-web",
+  suiteOrder: 13,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MYSQL_CONTAINER"],
   steps: [

--- a/evals/flows/den-sidebar-brand-icon.flow.mjs
+++ b/evals/flows/den-sidebar-brand-icon.flow.mjs
@@ -120,6 +120,8 @@ export default {
   id: "den-sidebar-brand-icon",
   title: "Den uses the managed organization square icon in its sidebar without flashes or broken images",
   kind: "user-facing",
+  suite: "nightly-den-web",
+  suiteOrder: 3,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [
     {

--- a/evals/flows/den-sidebar-simplified.flow.mjs
+++ b/evals/flows/den-sidebar-simplified.flow.mjs
@@ -176,6 +176,8 @@ export default {
   id: "den-sidebar-simplified",
   title: "Den sidebar: sixteen rows become seven — tools, models, people, settings",
   kind: "user-facing",
+  suite: "nightly-den-web",
+  suiteOrder: 2,
   spec: "evals/voiceovers/den-sidebar-simplified.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/den-single-org-mode.flow.mjs
+++ b/evals/flows/den-single-org-mode.flow.mjs
@@ -1,6 +1,8 @@
 export default {
   id: "den-single-org-mode",
   title: "Den web renders single-org auth mode",
+  suite: "nightly-den-web",
+  suiteOrder: 9,
   spec: "docs/single-org-mode-plan.md",
   preserveTheme: true,
   steps: [

--- a/evals/flows/den-single-org-sso-mode.flow.mjs
+++ b/evals/flows/den-single-org-sso-mode.flow.mjs
@@ -1,6 +1,8 @@
 export default {
   id: "den-single-org-sso-mode",
   title: "Den web renders SSO-only auth when singleton SSO is configured",
+  suite: "nightly-den-web",
+  suiteOrder: 10,
   spec: "docs/single-org-mode-plan.md",
   preserveTheme: true,
   steps: [

--- a/evals/flows/den-ui-consistency.flow.mjs
+++ b/evals/flows/den-ui-consistency.flow.mjs
@@ -277,6 +277,8 @@ export default {
   id: FLOW_ID,
   title: "Den stays responsive and coherent across catalogs, member access, settings, security, and Stripe",
   kind: "user-facing",
+  suite: "nightly-den-web",
+  suiteOrder: 5,
   preserveTheme: true,
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",

--- a/evals/flows/den-web-sidebar-logout.flow.mjs
+++ b/evals/flows/den-web-sidebar-logout.flow.mjs
@@ -87,6 +87,8 @@ export default {
   id: "den-web-sidebar-logout",
   title: "Den Web organization controls stay at the viewport bottom on long dashboard pages",
   kind: "user-facing",
+  suite: "nightly-den-web",
+  suiteOrder: 4,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MULTI_ORG"],
   steps: [
     {

--- a/evals/flows/desktop-brand-icon.flow.mjs
+++ b/evals/flows/desktop-brand-icon.flow.mjs
@@ -467,6 +467,8 @@ export default {
   id: "desktop-brand-icon",
   title: "Org Icon URL updates the desktop OS icon live, persists through relaunch, and can be cleared",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 17,
   spec: "evals/voiceovers/desktop-brand-icon.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/desktop-org-mcp-consolidation.flow.mjs
+++ b/evals/flows/desktop-org-mcp-consolidation.flow.mjs
@@ -4,4 +4,8 @@ export default {
   ...demo,
   id: "desktop-org-mcp-consolidation",
   title: "Desktop app: member discovers and connects an org MCP connection through the Extensions Marketplace",
+  // Alias of desktop-org-mcp-demo: keep it out of that flow's suite so the
+  // journey does not run the same coverage twice.
+  suite: undefined,
+  suiteOrder: undefined,
 };

--- a/evals/flows/desktop-org-mcp-demo.flow.mjs
+++ b/evals/flows/desktop-org-mcp-demo.flow.mjs
@@ -308,6 +308,8 @@ export default {
   id: "desktop-org-mcp-demo",
   title: "Desktop app: org MCP connections appear in Marketplace, connect through browser OAuth, and work in chat",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 12,
   spec: "evals/desktop-org-mcp-demo.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [

--- a/evals/flows/desktop-policies-demo.flow.mjs
+++ b/evals/flows/desktop-policies-demo.flow.mjs
@@ -54,6 +54,8 @@ async function syncConfigToApp(ctx) {
 export default {
   id: "desktop-policies-demo",
   title: "Admin configures desktop policies → member app reacts in real-time",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 15,
   spec: "evals/desktop-policy-white-label.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
   steps: [

--- a/evals/flows/desktop-upgrade-preserves-server-url.flow.mjs
+++ b/evals/flows/desktop-upgrade-preserves-server-url.flow.mjs
@@ -247,6 +247,8 @@ export default {
   id: FLOW_ID,
   title: "Windows upgrades preserve organization bootstrap URLs across canonical, legacy, restart, and air-gapped paths",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 10,
   preserveTheme: true,
   requiredEnv: [
     "DAYTONA_API_KEY",

--- a/evals/flows/durable-auth-mcp.flow.mjs
+++ b/evals/flows/durable-auth-mcp.flow.mjs
@@ -653,6 +653,8 @@ export default {
   id: FLOW_ID,
   title: "Active OpenWork and MCP sessions renew silently while real security boundaries still hold",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 18,
   spec: "evals/voiceovers/durable-auth-mcp.md",
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",

--- a/evals/flows/email-invites-remove-download-link.flow.mjs
+++ b/evals/flows/email-invites-remove-download-link.flow.mjs
@@ -357,6 +357,8 @@ export default {
   id: FLOW_ID,
   title: "Invitation emails stay focused on joining the workspace",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 4,
   requiresApp: false,
   preserveTheme: true,
   requiredEnv: [

--- a/evals/flows/exa-connection.flow.mjs
+++ b/evals/flows/exa-connection.flow.mjs
@@ -60,6 +60,8 @@ export default {
   id: "exa-connection",
   title: "Exa is a quick-add Cloud Connection with org API-key setup",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 6,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   spec: "evals/org-mcp-connections-ux.md",

--- a/evals/flows/google-slack-oauth-ux.flow.mjs
+++ b/evals/flows/google-slack-oauth-ux.flow.mjs
@@ -489,6 +489,8 @@ export default {
   id: FLOW_ID,
   title: "Google and Slack OAuth setup tells admins exactly what to do next",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 4,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MYSQL_CONTAINER"],
   spec: "evals/voiceovers/google-slack-oauth-ux.md",
   steps: [

--- a/evals/flows/google-workspace-gmail-draft-attachments.flow.mjs
+++ b/evals/flows/google-workspace-gmail-draft-attachments.flow.mjs
@@ -60,6 +60,8 @@ export default {
   id: FLOW_ID,
   title: "Google Workspace Gmail drafts accept bounded workspace-file attachments for new messages and threaded replies",
   kind: "internal",
+  suite: "nightly-cloud-member",
+  suiteOrder: 28,
   requiresApp: false,
   steps: [
     {

--- a/evals/flows/install-download-feedback.flow.mjs
+++ b/evals/flows/install-download-feedback.flow.mjs
@@ -30,6 +30,8 @@ export default {
   id: "install-download-feedback",
   title: "Installer downloads stay clear while the bundle is prepared",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 8,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [
     {

--- a/evals/flows/invite-adoption-no-duplicates.flow.mjs
+++ b/evals/flows/invite-adoption-no-duplicates.flow.mjs
@@ -532,6 +532,8 @@ export default {
   id: FLOW_ID,
   title: "Pending invitations are adopted without duplicate organization members",
   kind: "internal",
+  suite: "nightly-membership",
+  suiteOrder: 2,
   requiresApp: false,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_WEB_CDP_ADMIN"],
   steps: [

--- a/evals/flows/invite-to-desktop.flow.mjs
+++ b/evals/flows/invite-to-desktop.flow.mjs
@@ -44,6 +44,8 @@ export default {
   id: "invite-to-desktop",
   title: "Invited teammates join Acme, get a desktop handoff, and receive mobile-safe download guidance",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 1,
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",
     "OPENWORK_EVAL_DEN_WEB_URL",

--- a/evals/flows/llm-provider-azure-catalog-deployments.flow.mjs
+++ b/evals/flows/llm-provider-azure-catalog-deployments.flow.mjs
@@ -50,6 +50,8 @@ async function denApiDelete(ctx, name) {
 export default {
   id: "llm-provider-azure-catalog-deployments",
   title: "Catalog Azure provider offers only the resource's real deployments",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 13,
   spec: "evals/cloud-provider-sync-flows.md",
   requiredEnv: [
     "OPENWORK_EVAL_DEN_WEB_URL",

--- a/evals/flows/llm-provider-azure-foundry.flow.mjs
+++ b/evals/flows/llm-provider-azure-foundry.flow.mjs
@@ -53,6 +53,8 @@ async function denApiDelete(ctx, name) {
 export default {
   id: "llm-provider-azure-foundry",
   title: "Azure Foundry sets up gpt-5-mini with only name + URL + key",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 14,
   spec: "evals/cloud-provider-sync-flows.md",
   requiredEnv: [
     "OPENWORK_EVAL_DEN_WEB_URL",

--- a/evals/flows/llm-provider-probe-picker.flow.mjs
+++ b/evals/flows/llm-provider-probe-picker.flow.mjs
@@ -73,6 +73,8 @@ async function denApiDelete(ctx, name) {
 export default {
   id: "llm-provider-probe-picker",
   title: "Editor probes the endpoint, heals the URL, and offers real models to pick",
+  suite: "nightly-den-web",
+  suiteOrder: 14,
   spec: "evals/cloud-provider-sync-flows.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_EMAIL", "OPENWORK_EVAL_DEN_PASSWORD"],
   steps: [

--- a/evals/flows/llm-provider-test-connection-api.flow.mjs
+++ b/evals/flows/llm-provider-test-connection-api.flow.mjs
@@ -61,6 +61,8 @@ const probeExpr = (body) => `(async () => {
 export default {
   id: "llm-provider-test-connection-api",
   title: "Provider test-connection probe returns real models and heals URLs",
+  suite: "nightly-den-web",
+  suiteOrder: 15,
   spec: "evals/cloud-provider-sync-flows.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_EMAIL", "OPENWORK_EVAL_DEN_PASSWORD"],
   steps: [

--- a/evals/flows/managed-brand-asset-uploads.flow.mjs
+++ b/evals/flows/managed-brand-asset-uploads.flow.mjs
@@ -217,6 +217,8 @@ export default {
   id: "managed-brand-asset-uploads",
   title: "Owners upload durable, versioned brand assets that member desktops load from their Den",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 21,
   spec: "evals/voiceovers/managed-brand-asset-uploads.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/marketplace-plugin-mcp-auth.flow.mjs
+++ b/evals/flows/marketplace-plugin-mcp-auth.flow.mjs
@@ -73,6 +73,8 @@ export default {
   id: FLOW_ID,
   title: "Assigned marketplace plugin skills guide each member through their required MCP connection",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 19,
   preserveTheme: true,
   spec: "evals/voiceovers/marketplace-plugin-mcp-auth.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],

--- a/evals/flows/mcp-connection-diagnostics.flow.mjs
+++ b/evals/flows/mcp-connection-diagnostics.flow.mjs
@@ -37,6 +37,8 @@ export default {
   id: "mcp-connection-diagnostics",
   title: "A failed MCP connection identifies its exact layer",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 3,
   spec: "evals/voiceovers/mcp-connection-diagnostics.md",
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],

--- a/evals/flows/mcp-connection-editing.flow.mjs
+++ b/evals/flows/mcp-connection-editing.flow.mjs
@@ -263,6 +263,8 @@ export default {
   id: FLOW_ID,
   title: "Admins safely edit existing MCP connections",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 2,
   preserveTheme: true,
   spec: "evals/voiceovers/mcp-connection-editing.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],

--- a/evals/flows/mcp-connections-cloud-oauth.flow.mjs
+++ b/evals/flows/mcp-connections-cloud-oauth.flow.mjs
@@ -51,6 +51,8 @@ const ECHO_TEXT = "search and execute in the cloud proof";
 export default {
   id: "mcp-connections-cloud-oauth",
   title: "Admin adds an MCP connection in Den; search_capabilities/execute_capability use it for real",
+  suite: "nightly-cloud-member",
+  suiteOrder: 15,
   spec: "evals/cloud-mcp-agent-flows.md",
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],

--- a/evals/flows/mcp-connections-desktop-e2e.flow.mjs
+++ b/evals/flows/mcp-connections-desktop-e2e.flow.mjs
@@ -86,6 +86,8 @@ async function signIn(email, password) {
 export default {
   id: "mcp-connections-desktop-e2e",
   title: "Desktop app: the member's agent finds and executes an org MCP connection as them, in real chat",
+  suite: "nightly-cloud-member",
+  suiteOrder: 13,
   spec: "evals/cloud-mcp-agent-flows.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [

--- a/evals/flows/mcp-connections-member-scoped.flow.mjs
+++ b/evals/flows/mcp-connections-member-scoped.flow.mjs
@@ -60,6 +60,8 @@ const state = {
 export default {
   id: "mcp-connections-member-scoped",
   title: "Per-member MCP connections: admin publishes, employee connects their own account, agent acts as them, grants enforced",
+  suite: "nightly-cloud-member",
+  suiteOrder: 14,
   spec: "evals/cloud-mcp-agent-flows.md",
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],

--- a/evals/flows/mcp-external-client-connect.flow.mjs
+++ b/evals/flows/mcp-external-client-connect.flow.mjs
@@ -474,6 +474,8 @@ export default {
   id: FLOW_ID,
   title: "A URL-only MCP client connects to the API origin end to end",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 29,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/mcp-oauth-conformance.flow.mjs
+++ b/evals/flows/mcp-oauth-conformance.flow.mjs
@@ -173,6 +173,8 @@ export default {
   id: FLOW_ID,
   title: "URL discovery, shared callback OAuth, and MCP tool use succeed end to end",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 16,
   spec: "docs/external-mcp-oauth.md",
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],

--- a/evals/flows/mcp-search-capabilities.flow.mjs
+++ b/evals/flows/mcp-search-capabilities.flow.mjs
@@ -81,6 +81,8 @@ async function mcpAgentCall(ctx, mcpToken, method, params) {
 export default {
   id: "mcp-search-capabilities",
   title: "search_capabilities ranks the real Den MCP catalog and the matched tool executes for real",
+  suite: "nightly-cloud-member",
+  suiteOrder: 23,
   spec: "evals/cloud-mcp-agent-flows.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_WORKSPACE_PATH"],
   steps: [

--- a/evals/flows/mcp-tool-catalog.flow.mjs
+++ b/evals/flows/mcp-tool-catalog.flow.mjs
@@ -248,6 +248,8 @@ export default {
   id: FLOW_ID,
   title: "Admins can inspect a connected MCP's live tools, inputs, and schemas without executing anything",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 24,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/memory-save-recall.flow.mjs
+++ b/evals/flows/memory-save-recall.flow.mjs
@@ -73,6 +73,8 @@ const MEMORY_CONTENT = `User's Acme account renews in Q3 at 5000 per month — m
 export default {
   id: "memory-save-recall",
   title: "Agent discovers the memory capability, saves a memory, and recalls it in a fresh session via natural language",
+  suite: "nightly-cloud-member",
+  suiteOrder: 25,
   spec: "docs/memory-bank-architecture.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_WORKSPACE_PATH"],
   steps: [

--- a/evals/flows/microsoft-365-cloud-connect.flow.mjs
+++ b/evals/flows/microsoft-365-cloud-connect.flow.mjs
@@ -222,6 +222,8 @@ export default {
   id: "microsoft-365-cloud-connect",
   title: "Admins choose delegated Microsoft 365 capabilities; members connect, use them, reconnect for changes, and disconnect safely",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 7,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/new-signin-flow.flow.mjs
+++ b/evals/flows/new-signin-flow.flow.mjs
@@ -8,6 +8,8 @@ export default {
   id: FLOW_ID,
   title: "Den Web resolves sign-in from email first",
   kind: "user-facing",
+  suite: "nightly-den-web",
+  suiteOrder: 1,
   preserveTheme: true,
   steps: [
     {

--- a/evals/flows/oauth-mcp-install.flow.mjs
+++ b/evals/flows/oauth-mcp-install.flow.mjs
@@ -108,6 +108,8 @@ async function handleOnboarding(ctx) {
 export default {
   id: "oauth-mcp-install",
   title: "Member installs the plugin; OAuth MCP arrives sign-in-required, secret never travels",
+  suite: "nightly-cloud-member",
+  suiteOrder: 20,
   spec: "apps/server/src/extensions-export.ts",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [

--- a/evals/flows/oauth-mcp-publish.flow.mjs
+++ b/evals/flows/oauth-mcp-publish.flow.mjs
@@ -147,6 +147,8 @@ let exportedBundle = null;
 export default {
   id: "oauth-mcp-publish",
   title: "Owner exports skill + OAuth MCP (secret redacted) and publishes to a marketplace",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 24,
   spec: "apps/server/src/extensions-export.ts",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [

--- a/evals/flows/on-sign-in-verify-name.flow.mjs
+++ b/evals/flows/on-sign-in-verify-name.flow.mjs
@@ -165,6 +165,8 @@ export default {
   id: "on-sign-in-verify-name",
   title: "Default-name users are prompted to update their profile from the dashboard",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 5,
   spec: "evals/voiceovers/on-sign-in-verify-name.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/onprem-server-url.flow.mjs
+++ b/evals/flows/onprem-server-url.flow.mjs
@@ -147,6 +147,8 @@ export default {
   id: "onprem-server-url",
   title: "Self-hosted users can set their organization server URL from welcome and Advanced settings",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 9,
   steps: [
     {
       name: "Frame 1",

--- a/evals/flows/org-aware-dashboard-downloads.flow.mjs
+++ b/evals/flows/org-aware-dashboard-downloads.flow.mjs
@@ -259,6 +259,8 @@ export default {
   id: FLOW_ID,
   title: "Every Acme member gets the configured desktop installer without invalidating earlier links",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 6,
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",
     "OPENWORK_EVAL_DEN_WEB_URL",

--- a/evals/flows/org-capability-flags.flow.mjs
+++ b/evals/flows/org-capability-flags.flow.mjs
@@ -32,6 +32,8 @@ export default {
   id: "org-capability-flags",
   title: "Platform admins flip per-org capability flags from /admin; every org starts dark and reports its own state through /v1/org",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 22,
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",
     "OPENWORK_EVAL_DEN_TOKEN",

--- a/evals/flows/org-connections-capability.flow.mjs
+++ b/evals/flows/org-connections-capability.flow.mjs
@@ -31,6 +31,8 @@ export default {
   id: "org-connections-capability",
   title: "Platform admins flip the mcpConnections org capability from /admin; den-web nav and the desktop react uniformly",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 23,
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",
     "OPENWORK_EVAL_DEN_TOKEN",

--- a/evals/flows/org-google-workspace-demo.flow.mjs
+++ b/evals/flows/org-google-workspace-demo.flow.mjs
@@ -265,6 +265,8 @@ export default {
   id: "org-google-workspace-demo",
   title: "Org Google Workspace: admin sets it up once, members connect their own account, the agent drafts Gmail as them",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 26,
   spec: "evals/voiceovers/org-google-workspace-demo.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [

--- a/evals/flows/org-google-workspace-reconnect.flow.mjs
+++ b/evals/flows/org-google-workspace-reconnect.flow.mjs
@@ -268,6 +268,8 @@ export default {
   id: "org-google-workspace-reconnect",
   title: "Org Google Workspace prompts members to reconnect after selected scopes drift",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 27,
   spec: "evals/voiceovers/org-google-workspace-reconnect.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/org-google-workspace-scopes.flow.mjs
+++ b/evals/flows/org-google-workspace-scopes.flow.mjs
@@ -297,6 +297,8 @@ export default {
   id: "org-google-workspace-scopes",
   title: "Org Google Workspace asks for desktop-parity scopes and admin-selected extras",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 10,
   spec: "evals/voiceovers/org-google-workspace-scopes.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/org-google-workspace-setup-guide.flow.mjs
+++ b/evals/flows/org-google-workspace-setup-guide.flow.mjs
@@ -189,6 +189,8 @@ export default {
   id: "org-google-workspace-setup-guide",
   title: "Google Workspace setup guides admins through OAuth client registration",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 9,
   spec: "evals/voiceovers/org-google-workspace-setup-guide.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/org-install-link.flow.mjs
+++ b/evals/flows/org-install-link.flow.mjs
@@ -58,6 +58,8 @@ export default {
   id: "org-install-link",
   title: "Organization install links stamp Acme into the download, installer, and first desktop sign-in",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 5,
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",
     "OPENWORK_EVAL_DEN_TOKEN",

--- a/evals/flows/org-mcp-agent-config-demo.flow.mjs
+++ b/evals/flows/org-mcp-agent-config-demo.flow.mjs
@@ -200,6 +200,8 @@ export default {
   id: FLOW_ID,
   title: "Org admins can publish an MCP connection through the agent surface, hand members the existing connect path, and members cannot exceed their role",
   kind: "internal",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 26,
   requiresApp: false,
   spec: "evals/voiceovers/org-mcp-agent-config-demo.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],

--- a/evals/flows/org-scope-dashboard-pinning.flow.mjs
+++ b/evals/flows/org-scope-dashboard-pinning.flow.mjs
@@ -98,6 +98,8 @@ export default {
   id: "org-scope-dashboard-pinning",
   title: "Dashboard settings writes stay pinned to the org on screen when the session's active org drifts",
   kind: "user-facing",
+  suite: "nightly-den-web",
+  suiteOrder: 8,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MULTI_ORG"],
   steps: [

--- a/evals/flows/org-scope-pinning.flow.mjs
+++ b/evals/flows/org-scope-pinning.flow.mjs
@@ -91,6 +91,8 @@ export default {
   id: "org-scope-pinning",
   title: "Connections requests stay pinned to the org on screen when the session's active org drifts",
   kind: "user-facing",
+  suite: "nightly-den-web",
+  suiteOrder: 7,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MULTI_ORG"],
   spec: "evals/org-mcp-connections-ux.md",

--- a/evals/flows/organization-branding-upload-layout.flow.mjs
+++ b/evals/flows/organization-branding-upload-layout.flow.mjs
@@ -145,6 +145,8 @@ export default {
   id: "organization-branding-upload-layout",
   title: "Branding uploads stay contained and desktop wordmarks align without adjacent text",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 20,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [
     {

--- a/evals/flows/organization-display-branding.flow.mjs
+++ b/evals/flows/organization-display-branding.flow.mjs
@@ -186,6 +186,8 @@ export default {
   id: "organization-display-branding",
   title: "Organization display branding reaches download, setup, and desktop while OpenWork's signed identity stays stable",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 19,
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",
     "OPENWORK_EVAL_DEN_TOKEN",

--- a/evals/flows/paste-signin-code.flow.mjs
+++ b/evals/flows/paste-signin-code.flow.mjs
@@ -8,6 +8,8 @@ export default {
   id: "paste-signin-code",
   title: "A prepared development build can sign in with a copied one-time code",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 4,
   requiredEnv: ["OPENWORK_EVAL_HANDOFF_GRANT"],
   steps: [
     {

--- a/evals/flows/policy-onboarding-prompts.flow.mjs
+++ b/evals/flows/policy-onboarding-prompts.flow.mjs
@@ -82,6 +82,8 @@ export default {
   id: "policy-onboarding-prompts",
   title: "Desktop policies replace OpenWork starter suggestions for assigned teams",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 16,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
   steps: [
     {

--- a/evals/flows/provider-sync-stable-engine.flow.mjs
+++ b/evals/flows/provider-sync-stable-engine.flow.mjs
@@ -150,6 +150,8 @@ export default {
   id: "provider-sync-stable-engine",
   title: "Org cloud providers import once and the engine connection stays stable",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 12,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
   steps: [
     {

--- a/evals/flows/signin-browser-open-fallback.flow.mjs
+++ b/evals/flows/signin-browser-open-fallback.flow.mjs
@@ -2,6 +2,8 @@ export default {
   id: "signin-browser-open-fallback",
   title: "Cloud sign-in surfaces browser open failure with copy-link fallback",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 3,
   requiredEnv: ["OPENWORK_SIMULATE_OPEN_EXTERNAL_FAILURE"],
   steps: [
     {

--- a/evals/flows/single-org-invite-beyond-free-seats.flow.mjs
+++ b/evals/flows/single-org-invite-beyond-free-seats.flow.mjs
@@ -359,6 +359,8 @@ export default {
   id: FLOW_ID,
   title: "Single-org self-hosted deployments can invite members past the hosted free seat count",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 3,
   requiresApp: false,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_WEB_CDP_ADMIN"],
   steps: [

--- a/evals/flows/single-org-signup-policy.flow.mjs
+++ b/evals/flows/single-org-signup-policy.flow.mjs
@@ -48,6 +48,8 @@ export default {
   id: FLOW_ID,
   title: "Single-org deployments block private email signup and enforce singleton email domains before account creation",
   kind: "internal",
+  suite: "nightly-den-web",
+  suiteOrder: 11,
   requiresApp: false,
   steps: [
     {

--- a/evals/flows/slack-org-connection.flow.mjs
+++ b/evals/flows/slack-org-connection.flow.mjs
@@ -85,6 +85,8 @@ export default {
   id: "slack-org-connection",
   title: "Slack-style Cloud Connection uses a pre-registered OAuth client instead of DCR",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 5,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   spec: "evals/org-mcp-connections-ux.md",

--- a/evals/flows/standardized-workspace-reauth.flow.mjs
+++ b/evals/flows/standardized-workspace-reauth.flow.mjs
@@ -424,6 +424,8 @@ export default {
   id: FLOW_ID,
   title: "Workspace re-authentication keeps multi-org settings actions on the same route and org",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 30,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_MULTI_ORG"],
   steps: [

--- a/evals/flows/telegram-cloud-connect.flow.mjs
+++ b/evals/flows/telegram-cloud-connect.flow.mjs
@@ -201,6 +201,8 @@ export default {
   id: "telegram-cloud-connect",
   title: "An admin securely pairs one private Telegram chat to one healthy OpenWork Cloud worker and can disconnect it fail-closed",
   kind: "user-facing",
+  suite: "nightly-cloud-admin",
+  suiteOrder: 8,
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [

--- a/evals/flows/windows-organization-install-branding.flow.mjs
+++ b/evals/flows/windows-organization-install-branding.flow.mjs
@@ -55,6 +55,8 @@ export default {
   id: "windows-organization-install-branding",
   title: "Organization installs converge Windows Search, Start Menu, and shortcuts without losing server configuration",
   kind: "user-facing",
+  suite: "nightly-membership",
+  suiteOrder: 12,
   requiresApp: false,
   requiredEnv: ["DAYTONA_API_KEY", "OPENWORK_EVAL_DAYTONA_SANDBOX"],
   steps: [

--- a/evals/flows/your-connections-admin-shared-connect.flow.mjs
+++ b/evals/flows/your-connections-admin-shared-connect.flow.mjs
@@ -80,6 +80,8 @@ export default {
   id: "your-connections-admin-shared-connect",
   title: "Shared MCP connection: an admin connects the org account right on Your Connections",
   kind: "user-facing",
+  suite: "nightly-cloud-member",
+  suiteOrder: 17,
   spec: "evals/org-mcp-connections-ux.md",
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],


### PR DESCRIPTION
## What

Part 4 of the nightly-suites series (#2814 runner + `nightly-connect`, #2815 local suites, #2816 den-web stack env). Tags the cloud/Den flows into four journey suites:

- **`nightly-cloud-admin`** (26) — the org owner sets everything up: MCP connections (editing, diagnostics, Google/Slack OAuth UX, Slack/Exa/Microsoft 365/Telegram), Google Workspace setup guide + scopes, provider import/sync + Azure catalog/Foundry editors, desktop policies + starter-prompt policies, branding (desktop icon, display branding, upload layout, managed assets), per-org capability flags, and publishing skills/plugins to the marketplace.
- **`nightly-cloud-member`** (31) — the member receives it all and the agent acts: desktop sign-in funnel (handoff, dashboard, open-fallback, paste-code, profile-name prompt), cloud MCP auto-config/base-url/reliability/disable-sticks, org MCP connect journeys incl. member-scoped grants and shared admin connections, OAuth conformance + durable auth, marketplace plugin installs with secret boundaries, `search_capabilities`/tool catalog/memory, Google Workspace acting as the member (+ Gmail draft attachments), external MCP clients, workspace reauth, connections treatment on desktop.
- **`nightly-den-web`** (15) — dashboard UX: sign-in resolution, simplified sidebar + brand icon + logout placement, UI consistency, connections alpha treatment, org-scope pinning (both surfaces), single-org/SSO/signup-policy modes, reauth pending-action + popup-social, provider probe/test-connection editors.
- **`nightly-membership`** (12) — invites & install funnel: invite to desktop, adoption without duplicates, beyond-free-seats, focused invite emails, org install links, org-aware downloads, allowed-version matching, download feedback, on-prem server URL, upgrade URL persistence, update targeting, Windows install branding.

Also: `desktop-org-mcp-consolidation` (a spread alias of `desktop-org-mcp-demo`) explicitly clears `suite`/`suiteOrder` so the inherited tag doesn't run the same coverage twice in one journey.

Tag-only change — inert until #2814 merges; merge order flexible.

## Tests run

Validated against the #2814 runner via `OPENWORK_EVAL_FLOWS_DIR`:

- `--list --suite <each of the four>` prints all 84 flows in the journey order above (suiteOrder respected) ✅
- `desktop-org-mcp-consolidation` lists with **no** suite tag (alias guard works) ✅
- All 170 flow modules load with no validation errors ✅

These flows are env-gated; they run for real under `--stack den` (#2816) / Daytona in the nightly orchestrator (next PR) and skip cleanly elsewhere.
