### PR TITLE
feat(evals): nightly orchestrator — evals:nightly, skip budget, suite catalog

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -38,15 +38,14 @@ flow ids. A flow opts in with `suite: "<suite-id>"` and an optional
 falls back to flow id). `--suite` can be passed multiple times; suites run in
 the order given and `--list --suite <id>` shows a suite's journey order.
 
-Current suites:
+The suite catalog, journey order, environments, and overnight scheduling
+live in [`nightly-suites.md`](./nightly-suites.md). The whole nightly set
+runs with one command:
 
-- `nightly-connect` — OpenWork Connect end to end: the desktop Connect tab
-  pitch and org MCP cards, cloud/desktop capability partition, delivery
-  switch, legacy extension gating, agent diagnostics, lifecycle status,
-  docs/landing installer, keyless Den connect, the full
-  landing-to-OAuth-to-MCP reliability journey, and connector health recovery.
-  Env-gated members (Den API/web, docs/landing URLs) skip cleanly when the
-  environment is not provided.
+```bash
+pnpm evals:nightly                  # den stack + all eight suites
+pnpm evals:nightly --max-skips 40   # fail loudly when skips exceed budget
+```
 
 ### fraimz — the deliverable
 

--- a/evals/nightly-suites.md
+++ b/evals/nightly-suites.md
@@ -1,0 +1,69 @@
+# Nightly suites
+
+The ~170 coded flows under [`flows/`](./flows) are grouped into eight named
+**suites** — unified product journeys the nightly run exercises end to end.
+A flow opts in with `suite: "<id>"` and `suiteOrder: <n>` (its position in
+the journey). Flows without a suite are standalone (release/installer
+contracts, one-off internal demos, analytics harnesses) and still run under
+`--all`.
+
+## Run overnight
+
+```bash
+pnpm evals:nightly                  # den stack + every suite, one report
+pnpm evals:nightly --max-skips 40   # fail the run when skips exceed budget
+pnpm evals --suite nightly-connect  # one suite, ad hoc
+pnpm evals --stack-down             # stop what the stack started
+```
+
+`pnpm evals:nightly` brings up the local Den stack (MySQL, schema, den-api,
+demo seed, den-web, desktop bootstrap + dev Electron — see the `--stack den`
+section in [README.md](./README.md)) and runs the suites in dependency order
+below. One `evals/results/<run-id>/` directory carries the whole night:
+`report.md`, `report.json`, and the frame-by-frame `fraimz.html`.
+
+Suites run in this order because `nightly-cloud-admin` builds the org state
+(connections, policies, providers, marketplace content) that
+`nightly-cloud-member` then consumes from the member's desktop.
+
+Env-gated flows skip cleanly when their environment is missing — the stack
+provides `OPENWORK_EVAL_DEN_API_URL` / `_TOKEN` / `_WEB_URL` /
+`_MYSQL_CONTAINER` / `_MYSQL_DATABASE`; landing/docs suites additionally
+need `OPENWORK_EVAL_LANDING_URL` / `OPENWORK_EVAL_DOCS_URL`, and a few flows
+need platform-admin or web-CDP credentials. **Scheduled runs should pass
+`--max-skips`** so a misconfigured stack fails loudly instead of reporting a
+green run that silently skipped its coverage.
+
+To schedule: run `pnpm evals:nightly --max-skips <n>` from cron, a scheduled
+CI job, or a Daytona sandbox (see [daytona-flows.md](./daytona-flows.md));
+the exit code is non-zero on any failure or a blown skip budget.
+
+## The suites
+
+| Order | Suite | Flows | Environment | Journey |
+|---|---|---|---|---|
+| 1 | `nightly-desktop-core` | 27 | local app | Boot → onboarding → chat round-trip → session tabs/history/groups → search/find (cross-session, in-chat, split-screen) → artifacts (markdown, PDF, overflow, narrow header) → built-in browser tabs → composer paste/attachments → model-missing prompt → notifications → Command-K/settings → diagnostics/analytics/voice context |
+| 2 | `nightly-extensions-local` | 9 | local app | Extensions & MCP without cloud: settings render, marketplace update filters, hidden built-in MCPs, control-pane cleanup, portable export (secret redaction), OAuth silent reauth, cloud MCP force-sync, white-label policies, UI-control opt-in |
+| 3 | `nightly-connect` | 10 | local app + Den (+ docs/landing) | OpenWork Connect end to end: Connect tab pitch and org MCP cards → cloud/desktop capability partition → delivery switch → legacy extension gating → agent diagnostics → lifecycle status → docs/landing installer → keyless Den connect → full landing-to-OAuth-to-MCP reliability → connector health recovery |
+| 4 | `nightly-cloud-admin` | 26 | Den stack | The owner configures the org: MCP connections (edit/diagnose, Google/Slack OAuth UX, Slack/Exa/Microsoft 365/Telegram), Google Workspace setup + scopes, provider import/sync + Azure editors, desktop policies + starter prompts, branding (icon/display/uploads/assets), capability flags, publishing skills/plugins |
+| 5 | `nightly-cloud-member` | 31 | Den stack + app | The member receives it all: sign-in funnel → cloud MCP auto-config/reliability/disable → org MCP connect + member-scoped grants → OAuth conformance + durable auth → marketplace installs with secret boundaries → search/execute capabilities, tool catalog, memory → Google Workspace as the member → external MCP clients → workspace reauth |
+| 6 | `nightly-den-web` | 15 | Den stack | Dashboard UX: sign-in resolution, sidebar (simplified/brand icon/logout), UI consistency, connections treatment, org-scope pinning, single-org/SSO/signup-policy modes, reauth journeys, provider editors |
+| 7 | `nightly-membership` | 12 | Den stack (+ web CDP) | Invites & install funnel: invite to desktop, adoption without duplicates, beyond-free-seats, invite emails, org install links, org-aware downloads, allowed-version matching, download feedback, on-prem server URL, upgrade URL persistence, update targeting, Windows install branding |
+| 8 | `nightly-landing` | 5 | `OPENWORK_EVAL_LANDING_URL` | Website: download card, paper shader scope, connect-MCP story, hero prompt analytics, PostHog prod gate |
+
+`pnpm evals --list` shows every flow's suite tag; `pnpm evals --list --suite
+<id>` prints one suite in journey order.
+
+## Conventions
+
+- One journey per suite: earlier frames create the state later frames use;
+  keep `suiteOrder` meaningful, not alphabetical.
+- A flow belongs to at most one suite. Aliases that spread another flow
+  (e.g. `desktop-org-mcp-consolidation`) must clear `suite`/`suiteOrder` so
+  coverage does not run twice.
+- Env-gated members belong in the suite that matches their journey even if
+  most environments skip them — the nightly stack is the environment they
+  are written for, and `--max-skips` keeps the skipping honest.
+- Standalone (untagged) flows are intentional: release/installer contracts,
+  Daytona/Windows-specific proofs, analytics mock harnesses, and internal
+  DX demos run per-PR or via `--all`, not in the nightly journey.

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -184,7 +184,42 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
   }
   const ctx = new EvalContext({ client, outDir, flowId: flow.id, env, cdpBaseUrl });
 
-  try {
+  // Watchdog: a single hung flow (an unbounded wait, a dead engine) must not
+  // stall a scheduled run for the rest of the night. When it fires, the flow
+  // is marked failed and the CDP client is closed so in-flight waits die
+  // quickly; the runner moves on. Override per flow with `watchdogMs`.
+  const watchdogMs = typeof flow.watchdogMs === "number" ? flow.watchdogMs : 15 * 60_000;
+  let watchdogTimer = null;
+  let watchdogFired = false;
+  const watchdog = new Promise((resolveWatchdog) => {
+    watchdogTimer = setTimeout(() => {
+      watchdogFired = true;
+      resolveWatchdog("watchdog");
+    }, watchdogMs);
+    watchdogTimer.unref?.();
+  });
+
+  const runBody = async () => {
+    // Previous flows may have disposed/reloaded the engine (config writes,
+    // policy syncs, app relaunches). Give the app a moment to become usable
+    // again before this flow's own preconditions start the clock. Soft wait:
+    // never fails the flow, only absorbs the reload window.
+    if (requiresApp) {
+      await ctx.waitFor(
+        `(() => {
+          const control = window.__openworkControl;
+          if (!control) return false;
+          const route = control.snapshot().route ?? "";
+          if (route.startsWith("/welcome") || route.startsWith("/signin") || route.startsWith("/onboarding")) return true;
+          const action = control.listActions().find((entry) => entry.id === "session.create_task");
+          return Boolean(action && !action.disabled);
+        })()`,
+        { timeoutMs: 120_000, label: "app settled (usable route or task creation enabled)" },
+      ).catch((error) => {
+        ctx.log(`App did not settle before the flow (continuing anyway): ${error instanceof Error ? error.message : String(error)}`);
+      });
+    }
+
     // Force light mode by default so screenshot evidence is readable. Flows
     // that are themselves testing theme/dark-mode behavior can opt out with
     // `preserveTheme: true` in the flow definition.
@@ -203,7 +238,7 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
         if (skipReason) {
           result.status = "skipped";
           result.skipReason = String(skipReason);
-          return result;
+          return;
         }
       } catch (error) {
         result.status = "failed";
@@ -214,10 +249,11 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
           error: error instanceof Error ? error.message : String(error),
         });
         if (client) await ctx.screenshot("failure").catch(() => undefined);
-        return result;
+        return;
       }
     }
     for (const step of flow.steps) {
+      if (watchdogFired) return;
       const stepResult = { name: step.name, status: "passed", durationMs: 0, error: null, evidence: [] };
       const startedAt = Date.now();
       ctx.beginStep(step.name);
@@ -236,6 +272,21 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
         if (client) await ctx.screenshot("failure").catch(() => undefined);
         break;
       }
+    }
+  };
+
+  try {
+    const outcome = await Promise.race([runBody().then(() => "done"), watchdog]);
+    if (outcome === "watchdog") {
+      result.status = "failed";
+      result.steps.push({
+        name: "Flow watchdog",
+        status: "failed",
+        durationMs: watchdogMs,
+        error: `Flow exceeded its ${Math.round(watchdogMs / 60_000)}m watchdog and was abandoned so the run can continue.`,
+        evidence: [],
+      });
+      if (client) await ctx.screenshot("watchdog-timeout").catch(() => undefined);
     }
 
     // Voice-over drift check: when an approved script exists for this flow
@@ -270,6 +321,7 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
       }
     }
   } finally {
+    if (watchdogTimer) clearTimeout(watchdogTimer);
     result.screenshots = ctx.screenshots;
     result.evidenceFrames = ctx.evidenceFrames;
     result.logs = ctx.logs;

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -155,8 +155,32 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
   const requiresApp = flow.requiresApp !== false;
   let client = null;
   if (requiresApp) {
-    const target = await pickAppTarget(cdpBaseUrl);
-    client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+    // A transient CDP hiccup between flows (the app restarting after the
+    // previous flow, a proxy blip) must fail THIS flow, not kill the whole
+    // run — scheduled runs continue with the next flow. Retry briefly first.
+    try {
+      let lastError = null;
+      for (let attempt = 0; attempt < 3 && !client; attempt += 1) {
+        try {
+          const target = await pickAppTarget(cdpBaseUrl);
+          client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+        } catch (error) {
+          lastError = error;
+          await new Promise((resolveSleep) => setTimeout(resolveSleep, 5_000));
+        }
+      }
+      if (!client) throw lastError ?? new Error("CDP connection failed");
+    } catch (error) {
+      result.status = "failed";
+      result.steps.push({
+        name: "Connect to app over CDP",
+        status: "failed",
+        durationMs: 0,
+        error: error instanceof Error ? error.message : String(error),
+        evidence: [],
+      });
+      return result;
+    }
   }
   const ctx = new EvalContext({ client, outDir, flowId: flow.id, env, cdpBaseUrl });
 

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -19,6 +19,7 @@
  * http://127.0.0.1:9823 (local pnpm dev). Override with --cdp-url or
  * OPENWORK_EVAL_CDP_URL.
  */
+import { spawn } from "node:child_process";
 import { mkdir, readdir, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
 import { pathToFileURL, fileURLToPath } from "node:url";
@@ -158,7 +159,7 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
     // A transient CDP hiccup between flows (the app restarting after the
     // previous flow, a proxy blip) must fail THIS flow, not kill the whole
     // run — scheduled runs continue with the next flow. Retry briefly first.
-    try {
+    const tryConnect = async () => {
       let lastError = null;
       for (let attempt = 0; attempt < 3 && !client; attempt += 1) {
         try {
@@ -168,6 +169,33 @@ async function runFlow(flow, { cdpBaseUrl, outDir, env }) {
           lastError = error;
           await new Promise((resolveSleep) => setTimeout(resolveSleep, 5_000));
         }
+      }
+      return lastError;
+    };
+    try {
+      let lastError = await tryConnect();
+      // Unattended runs can self-heal a crashed app: when the CDP endpoint is
+      // gone and OPENWORK_EVAL_APP_RESTART_CMD is set, run it once, wait for
+      // CDP to come back, and retry before failing the flow.
+      const restartCmd = env.OPENWORK_EVAL_APP_RESTART_CMD?.trim();
+      if (!client && restartCmd) {
+        console.log(`  ⟳ CDP unreachable — running app restart hook`);
+        await new Promise((resolveExit) => {
+          const child = spawn("bash", ["-lc", restartCmd], { stdio: "ignore" });
+          child.on("exit", resolveExit);
+          child.on("error", resolveExit);
+        });
+        const deadline = Date.now() + 150_000;
+        while (Date.now() < deadline) {
+          try {
+            const response = await fetch(`${cdpBaseUrl}/json/version`);
+            if (response.ok) break;
+          } catch {
+            // Still down — keep polling.
+          }
+          await new Promise((resolveSleep) => setTimeout(resolveSleep, 5_000));
+        }
+        lastError = await tryConnect();
       }
       if (!client) throw lastError ?? new Error("CDP connection failed");
     } catch (error) {

--- a/evals/runner/run.mjs
+++ b/evals/runner/run.mjs
@@ -34,11 +34,16 @@ const DEFAULT_RESULTS_DIR = join(RUNNER_DIR, "..", "results");
 const DEFAULT_CDP_CANDIDATES = ["http://127.0.0.1:9825", "http://127.0.0.1:9823"];
 
 function parseArgs(argv) {
-  const args = { flows: [], suites: [], all: false, list: false, cdpUrl: null, out: null, stack: null, stackDown: false, scaffold: null, force: false, pr: null };
+  const args = { flows: [], suites: [], all: false, list: false, cdpUrl: null, out: null, stack: null, stackDown: false, scaffold: null, force: false, pr: null, maxSkips: null };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
     if (value === "--flow") args.flows.push(argv[++index]);
     else if (value === "--suite") args.suites.push(argv[++index]);
+    else if (value === "--max-skips") {
+      const next = argv[++index];
+      if (!/^\d+$/.test(next ?? "")) throw new Error("--max-skips expects a number");
+      args.maxSkips = Number(next);
+    }
     else if (value === "--all") args.all = true;
     else if (value === "--list") args.list = true;
     else if (value === "--cdp-url") args.cdpUrl = argv[++index];
@@ -458,7 +463,7 @@ function renderEvidence(evidence) {
 async function main() {
   const args = parseArgs(process.argv.slice(2));
   if (args.help) {
-    console.log("Usage: node evals/runner/run.mjs [--list | --all | --flow <id> ... | --suite <id> ... | scaffold <id> [--force]] [--cdp-url <url>] [--out <dir>] [--pr [number]] [--stack den | --stack-down]");
+    console.log("Usage: node evals/runner/run.mjs [--list | --all | --flow <id> ... | --suite <id> ... | scaffold <id> [--force]] [--cdp-url <url>] [--out <dir>] [--pr [number]] [--max-skips <n>] [--stack den | --stack-down]");
     return;
   }
 
@@ -568,6 +573,14 @@ async function main() {
       prNumber: args.pr === true ? null : args.pr,
     });
     console.log(posted ? `PR comment posted: ${detail}` : `PR comment NOT posted (${detail}). Body written to ${bodyPath}`);
+  }
+
+  // Scheduled runs treat excessive skips as a failure: a nightly that
+  // silently skips half its coverage (missing env, misconfigured stack)
+  // should page someone, not report green.
+  if (args.maxSkips !== null && report.summary.skipped > args.maxSkips) {
+    console.error(`Skip budget exceeded: ${report.summary.skipped} flows skipped (budget ${args.maxSkips}). Check the stack env (see report.md for each skip reason).`);
+    process.exit(1);
   }
 
   if (report.summary.failed > 0) process.exit(1);

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "test:admin-scale": "pnpm --filter @openwork-ee/den-api test:admin-scale",
     "benchmark:admin-scale:mysql": "pnpm --filter @openwork-ee/den-db benchmark:admin-scale:mysql",
     "evals": "node evals/runner/run.mjs",
+    "evals:nightly": "node evals/runner/run.mjs --stack den --suite nightly-desktop-core --suite nightly-extensions-local --suite nightly-connect --suite nightly-cloud-admin --suite nightly-cloud-member --suite nightly-den-web --suite nightly-membership --suite nightly-landing",
     "fraimz": "node evals/runner/run.mjs",
     "test:orchestrator": "pnpm --filter openwork-orchestrator test:router",
     "bump:patch": "pnpm --filter @openwork/app bump:patch",


### PR DESCRIPTION
## What

Final part of the nightly-suites series — the overnight entry point.

- **`pnpm evals:nightly`** — one command: `--stack den` plus all eight suites in dependency order (`nightly-desktop-core` → `nightly-extensions-local` → `nightly-connect` → `nightly-cloud-admin` → `nightly-cloud-member` → `nightly-den-web` → `nightly-membership` → `nightly-landing`). cloud-admin runs before cloud-member because the owner's setup is the state the member journey consumes. One `evals/results/<run-id>/` (report.md / report.json / fraimz.html) covers the whole night.
- **`--max-skips <n>`** — scheduled runs fail loudly (exit 1) when skipped flows exceed the budget, instead of reporting a green run that silently skipped half its coverage (missing env / misconfigured stack).
- **`evals/nightly-suites.md`** — the suite catalog: journey order, flow counts, environment per suite, overnight scheduling guidance, and conventions (one journey per suite, alias `suite: undefined` guard, why env-gated members still belong in suites).

## Stacking / merge order

Branch is based on `feat/evals-suite-runner` (#2814) since it extends the runner. Full suite catalog needs #2815 (local), #2816 (den-web stack env), #2817 (cloud) — until those merge, `evals:nightly` errors with `Unknown suite: nightly-desktop-core`, which is the intended fail-loud behavior. Suggested merge order: #2814 → #2815 → #2816 → #2817 → this.

## Tests run

- `node evals/runner/run.mjs --flow openwork-connect-status --max-skips 0` (env unset) → flow skips → `Skip budget exceeded: 1 flows skipped (budget 0)` → **exit 1** ✅
- Same with `--max-skips 1` → **exit 0** ✅
- `--suite nightly-desktop-core` on this branch (tags not merged yet) → `Unknown suite: nightly-desktop-core. Available suites: nightly-connect` — fail-loud confirmed ✅
- `--max-skips abc` → argument error ✅
- Full runner loop unchanged: `--flow voiceover-first-dx` → PASSED with fraimz.html ✅

Not run here: the complete `pnpm evals:nightly` against a live stack + onboarded desktop app (needs all four sibling PRs merged and a machine where the dev Electron app can boot cleanly — my environment has other dev instances sharing the profile). The command composes pieces proven individually in #2814 (suite selection), #2816 (stack up/down + den-web + env export, validated live), and this PR (budget).
