### PR TITLE
feat(chat): reconnect card for broken Cloud connections in tool results

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -79,6 +79,7 @@ import {
 } from "@/lib/build-in-tools"
 import type { ThreadStatus } from "@/lib/messages"
 import { getConnectionStatusFromToolPart } from "@/react-app/domains/connections/connection-status-payload"
+import { useControlAction, type OpenworkControlAction } from "@/react-app/shell/control/control-provider"
 import {
   collectToolParts,
   getActiveToolLabel,
@@ -853,7 +854,104 @@ interface MessageListProps {
   retryStatus?: RetryStatus | null
 }
 
+type ConnectionStatusEvalFixture = "prompt" | "member" | "provider_admin"
+
+function readConnectionStatusEvalFixture(args: unknown): ConnectionStatusEvalFixture | null {
+  if (typeof args !== "object" || args === null || !("fixture" in args)) return null
+  const fixture = args.fixture
+  return fixture === "prompt" || fixture === "member" || fixture === "provider_admin" ? fixture : null
+}
+
+function connectionStatusEvalToolPart(fixture: Exclude<ConnectionStatusEvalFixture, "prompt">): DynamicToolUIPart {
+  const connectionStatus = fixture === "member"
+    ? {
+        connectionId: "eval-granola",
+        connectionName: "Granola",
+        authType: "oauth",
+        credentialMode: "per_member",
+        state: "reauth_required",
+        errorCode: "unauthorized",
+        message: "Your Granola sign-in expired.",
+        actor: "member",
+      }
+    : {
+        connectionId: "eval-granola",
+        connectionName: "Granola",
+        authType: "oauth",
+        credentialMode: "per_member",
+        state: "reauth_required",
+        errorCode: "unauthorized",
+        message: "The authorization server rejected the code or token refresh exchange.",
+        actor: "provider_admin",
+        action: {
+          type: "fix_provider",
+          surface: "provider_admin_console",
+          label: "Inspect provider and proxy logs for the failing HTTP request.",
+          retry: "search_capabilities",
+        },
+        diagnostic: {
+          referenceId: "a0b58150-7bad-4a37-ba36-c4260f444a8d",
+          category: "http_failure",
+          code: "MCP_HTTP_400",
+        },
+      }
+
+  return {
+    type: "dynamic-tool",
+    toolName: "openwork-cloud_search_capabilities",
+    toolCallId: `eval-connection-status-${fixture}`,
+    state: "output-available",
+    input: { query: "latest meeting notes" },
+    output: JSON.stringify({
+      matches: [{
+        kind: "connection_status",
+        status: "error",
+        connectionStatus,
+      }],
+    }),
+  }
+}
+
+function ConnectionStatusEvalMessages({ fixture }: { fixture: ConnectionStatusEvalFixture }) {
+  return (
+    <>
+      <Message
+        className="mx-auto flex w-full max-w-3xl flex-col items-end gap-2 px-2 md:px-10"
+        data-message-role="user"
+      >
+        <MessageContent className="bg-muted text-foreground max-w-[85%] rounded-3xl px-5 py-2.5 sm:max-w-[75%]">
+          Pull my latest meeting notes from Granola.
+        </MessageContent>
+      </Message>
+      {fixture !== "prompt" ? (
+        <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
+          <ToolMessage part={connectionStatusEvalToolPart(fixture)} />
+        </Message>
+      ) : null}
+    </>
+  )
+}
+
 export function MessageList({ messages, status, retryStatus }: MessageListProps) {
+  const [connectionStatusEvalFixture, setConnectionStatusEvalFixture] = React.useState<ConnectionStatusEvalFixture | null>(null)
+  const connectionStatusEvalAction = React.useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null
+    return {
+      id: "eval.connection_status.seed",
+      label: "Seed a Cloud connection status tool result",
+      description: "Dev-only eval hook for reconnectable and provider-admin Cloud connection failures.",
+      sideEffect: "mutation",
+      requiresArgs: true,
+      args: [{ name: "fixture", type: "string", required: true }],
+      execute: (args) => {
+        const fixture = readConnectionStatusEvalFixture(args)
+        if (!fixture) return { ok: false, error: "fixture must be prompt, member, or provider_admin" }
+        setConnectionStatusEvalFixture(fixture)
+        return { fixture }
+      },
+    }
+  }, [])
+  useControlAction(connectionStatusEvalAction)
   const isStreaming = status === "streaming" || status === "retrying"
   const items = React.useMemo(() => groupMessages(messages, status), [messages, status]);
   const error = useSessionErrorMessage();
@@ -864,7 +962,9 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
 
   return (
     <div className={cn("flex flex-col gap-2 @container/message-list")}>
-      {messages.length === 0 && <TaskSuggestions className="mx-auto w-full max-w-3xl shrink-0 px-3 pb-3 md:px-5 md:pb-5 grow" />}
+      {messages.length === 0 && !connectionStatusEvalFixture && <TaskSuggestions className="mx-auto w-full max-w-3xl shrink-0 px-3 pb-3 md:px-5 md:pb-5 grow" />}
+
+      {connectionStatusEvalFixture ? <ConnectionStatusEvalMessages fixture={connectionStatusEvalFixture} /> : null}
 
       {items.map((item) => {
         if (isMessageGroup(item)) {

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -25,6 +25,7 @@ import { openDesktopUrl } from "@/app/lib/desktop"
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types"
 import { ApplyPatchTool } from "@/components/tools/apply-patch"
 import { BashTool } from "@/components/tools/bash"
+import { ConnectionStatusTool } from "@/components/tools/connection-status"
 import { EditTool } from "@/components/tools/edit"
 import { EnvVarRequestTool } from "@/components/tools/env-var-request"
 import { ReadFileTool, WriteFileTool } from "@/components/tools/file"
@@ -77,6 +78,7 @@ import {
   isWriteToolPart,
 } from "@/lib/build-in-tools"
 import type { ThreadStatus } from "@/lib/messages"
+import { getConnectionStatusFromToolPart } from "@/react-app/domains/connections/connection-status-payload"
 import {
   collectToolParts,
   getActiveToolLabel,
@@ -190,6 +192,13 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
 
   if (isEnvVarRequestToolPart(part)) {
     return <EnvVarRequestTool part={part} />
+  }
+
+  // Cloud capability results carrying a broken connection status render as
+  // an actionable reconnect card instead of raw JSON.
+  const connectionStatus = getConnectionStatusFromToolPart(part)
+  if (connectionStatus) {
+    return <ConnectionStatusTool part={part} payload={connectionStatus} />
   }
 
   return <Tool toolPart={part} />

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -906,6 +906,7 @@ function connectionStatusEvalToolPart(fixture: Exclude<ConnectionStatusEvalFixtu
       matches: [{
         kind: "connection_status",
         status: "error",
+        path: "https://mcp.granola.ai/mcp",
         connectionStatus,
       }],
     }),

--- a/apps/app/src/components/tools/connection-status.tsx
+++ b/apps/app/src/components/tools/connection-status.tsx
@@ -16,25 +16,48 @@ interface ConnectionStatusToolProps {
 function actorDescription(payload: ConnectionStatusPayload): string {
   switch (payload.actor) {
     case "provider_admin":
-      return `This needs a fix on the ${payload.connectionName} provider side.`
+      return `${payload.connectionName} or your organization admin needs to fix provider configuration.`
     case "org_admin":
+    case "organization_admin":
     case "platform_admin":
-      return "This needs a fix from your organization admin."
+      return "Your organization admin needs to fix this connection."
     default:
       return "This can't be fixed from this app right now."
   }
 }
 
+function isMemberReconnect(payload: ConnectionStatusPayload): boolean {
+  return payload.actor === null || payload.actor === "member"
+}
+
 /**
  * Inline chat card for a broken Cloud connection surfaced by a capability
- * tool result. Reconnectable (per-member OAuth) failures get a Reconnect
- * button that lands on Settings → Connect with the connector highlighted;
- * failures owned by someone else degrade honestly to who must act plus the
- * diagnostic reference. The raw payload stays available under a disclosure.
+ * tool result. Reconnect attempts land on Settings → Connect with the
+ * connector highlighted; admin/provider-owned failures keep honest caveats.
+ * The diagnostic reference and raw payload stay available under a disclosure.
  */
 export function ConnectionStatusTool({ part, payload }: ConnectionStatusToolProps) {
   const navigate = useNavigate()
   const [copied, setCopied] = React.useState(false)
+  const memberReconnect = isMemberReconnect(payload)
+  const title = payload.canAttemptReconnect
+    ? memberReconnect
+      ? `${payload.connectionName} needs you to sign in again`
+      : `${payload.connectionName} rejected sign-in`
+    : `${payload.connectionName} isn't working right now`
+  const description = payload.canAttemptReconnect
+    ? memberReconnect
+      ? "Its sign-in expired or was revoked. Reconnect your account, then ask the agent to try again."
+      : `The provider rejected sign-in or token refresh. You can try reconnecting; if it fails again, ${payload.connectionName} or your organization admin may need to fix provider configuration.`
+    : (payload.message ?? "The connection returned an error.")
+  const statusLabel = payload.canAttemptReconnect
+    ? memberReconnect
+      ? "Needs sign-in"
+      : "Provider may need a fix"
+    : "Needs attention"
+  const reconnectLabel = memberReconnect
+    ? `Reconnect ${payload.connectionName}`
+    : `Try reconnecting to ${payload.connectionName}`
 
   const copyDiagnostic = React.useCallback(async () => {
     if (!payload.diagnosticReferenceId) return
@@ -51,27 +74,37 @@ export function ConnectionStatusTool({ part, payload }: ConnectionStatusToolProp
     <div
       data-testid="connection-status-card"
       data-connection-name={payload.connectionName}
-      className="not-prose w-full max-w-xl rounded-2xl border border-amber-6/50 bg-dls-surface/95 p-4 shadow-sm"
+      className="not-prose w-full max-w-lg rounded-2xl border border-dls-border bg-dls-surface/95 p-3.5 shadow-sm"
     >
-      <div className="flex items-start gap-3">
-        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full border border-amber-6/40 bg-amber-3/30 text-amber-11">
-          <Unplug className="size-4" />
+      <div className="flex items-start gap-3.5">
+        <div className="relative flex size-10 shrink-0 items-center justify-center rounded-2xl border border-dls-border bg-dls-sidebar/70 text-base font-semibold text-dls-primary shadow-sm">
+          {payload.connectionName.slice(0, 1).toUpperCase()}
+          <span className="absolute -right-1 -bottom-1 flex size-4 items-center justify-center rounded-full border border-dls-surface bg-amber-3 text-amber-11">
+            <Unplug className="size-2.5" />
+          </span>
         </div>
         <div className="min-w-0 flex-1 space-y-3">
-          <div className="space-y-1">
-            <h3 className="text-sm font-semibold text-dls-primary">
-              {payload.canReconnect
-                ? `${payload.connectionName} needs you to sign in again`
-                : `${payload.connectionName} isn't working right now`}
-            </h3>
-            <p className="text-xs leading-5 text-dls-secondary">
-              {payload.canReconnect
-                ? "Its sign-in expired or was revoked. Reconnect your account, then ask the agent to try again."
-                : (payload.message ?? "The connection returned an error.")}
-            </p>
+          <div className="flex items-start justify-between gap-3">
+            <div className="min-w-0 space-y-0.5">
+              <p className="text-[11px] font-medium tracking-[0.16em] text-dls-tertiary uppercase">
+                Cloud connection
+              </p>
+              <h3 className="truncate text-base leading-5 font-semibold text-dls-primary">
+                {payload.connectionName}
+              </h3>
+            </div>
+            <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-6/35 bg-amber-3/20 px-2 py-0.5 text-[11px] font-medium text-amber-11">
+              <span className="size-1.5 rounded-full bg-amber-9" />
+              {statusLabel}
+            </span>
           </div>
 
-          {payload.canReconnect ? (
+          <div className="space-y-1">
+            <p className="text-sm leading-5 font-medium text-dls-primary">{title}</p>
+            <p className="text-xs leading-5 text-dls-secondary">{description}</p>
+          </div>
+
+          {payload.canAttemptReconnect ? (
             <Button
               size="sm"
               onClick={() =>
@@ -80,29 +113,37 @@ export function ConnectionStatusTool({ part, payload }: ConnectionStatusToolProp
                 })
               }
             >
-              Reconnect {payload.connectionName}
+              {reconnectLabel}
             </Button>
           ) : (
-            <div className="space-y-2">
-              <p className="rounded-lg border border-amber-6/40 bg-amber-3/20 px-3 py-2 text-xs text-amber-11">
+            <div className="rounded-xl border border-dls-border/70 bg-dls-sidebar/40 px-3 py-2 text-xs leading-5 text-dls-secondary">
+              <p>
                 {actorDescription(payload)}
-                {payload.actionLabel ? ` ${payload.actionLabel}` : ""}
               </p>
-              {payload.diagnosticReferenceId ? (
-                <div className="flex min-w-0 items-center gap-2">
-                  <code className="min-w-0 truncate rounded-md bg-dls-sidebar/60 px-2 py-1 font-mono text-[11px] text-dls-secondary">
-                    {payload.diagnosticReferenceId}
-                  </code>
-                  <Button size="sm" variant="ghost" onClick={() => void copyDiagnostic()}>
-                    {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-                    {copied ? "Copied" : "Copy reference"}
-                  </Button>
-                </div>
+              {payload.actionLabel ? (
+                <p className="mt-1 text-[11px] text-dls-tertiary">{payload.actionLabel}</p>
               ) : null}
             </div>
           )}
 
-          <Tool toolPart={part} title="Technical details" />
+          <Tool toolPart={part} title="Technical details" className="pt-0.5">
+            {payload.diagnosticReferenceId ? (
+              <div className="border-border/70 border-t pt-2">
+                <div className="flex min-w-0 flex-wrap items-center gap-2">
+                  <span className="text-[11px] font-medium text-dls-secondary">
+                    Diagnostic reference
+                  </span>
+                  <code className="min-w-0 truncate rounded-md bg-dls-surface/80 px-2 py-1 font-mono text-[11px] text-dls-secondary">
+                    {payload.diagnosticReferenceId}
+                  </code>
+                  <Button size="xs" variant="ghost" onClick={() => void copyDiagnostic()}>
+                    {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+                    {copied ? "Copied" : "Copy reference"}
+                  </Button>
+                </div>
+              </div>
+            ) : null}
+          </Tool>
         </div>
       </div>
     </div>

--- a/apps/app/src/components/tools/connection-status.tsx
+++ b/apps/app/src/components/tools/connection-status.tsx
@@ -1,11 +1,12 @@
 "use client"
 
 import * as React from "react"
-import { Check, Copy, Unplug } from "lucide-react"
+import { Check, Copy } from "lucide-react"
 import { useNavigate } from "react-router-dom"
 
 import { Button } from "@/components/ui/button"
 import { Tool, type ToolPart } from "@/components/ui/tool"
+import { resolveExtensionIconUrl } from "@/react-app/design-system/extension-icon-src"
 import type { ConnectionStatusPayload } from "@/react-app/domains/connections/connection-status-payload"
 
 interface ConnectionStatusToolProps {
@@ -39,7 +40,10 @@ function isMemberReconnect(payload: ConnectionStatusPayload): boolean {
 export function ConnectionStatusTool({ part, payload }: ConnectionStatusToolProps) {
   const navigate = useNavigate()
   const [copied, setCopied] = React.useState(false)
+  const [failedIconUrl, setFailedIconUrl] = React.useState<string | null>(null)
   const memberReconnect = isMemberReconnect(payload)
+  const iconUrl = resolveExtensionIconUrl({ serviceUrl: payload.serviceUrl ?? undefined })
+  const showLogo = iconUrl ? failedIconUrl !== iconUrl : false
   const title = payload.canAttemptReconnect
     ? memberReconnect
       ? `${payload.connectionName} needs you to sign in again`
@@ -74,70 +78,73 @@ export function ConnectionStatusTool({ part, payload }: ConnectionStatusToolProp
     <div
       data-testid="connection-status-card"
       data-connection-name={payload.connectionName}
-      className="not-prose w-full max-w-lg rounded-2xl border border-dls-border bg-dls-surface/95 p-3.5 shadow-sm"
+      className="not-prose w-full max-w-lg py-1"
     >
       <div className="flex items-start gap-3.5">
-        <div className="relative flex size-10 shrink-0 items-center justify-center rounded-2xl border border-dls-border bg-dls-sidebar/70 text-base font-semibold text-dls-primary shadow-sm">
-          {payload.connectionName.slice(0, 1).toUpperCase()}
-          <span className="absolute -right-1 -bottom-1 flex size-4 items-center justify-center rounded-full border border-dls-surface bg-amber-3 text-amber-11">
-            <Unplug className="size-2.5" />
-          </span>
+        <div className="flex size-10 shrink-0 items-center justify-center overflow-hidden rounded-2xl bg-dls-sidebar/70 text-base font-semibold text-dls-primary">
+          {showLogo && iconUrl ? (
+            <img
+              alt=""
+              aria-hidden="true"
+              className="size-full object-cover"
+              src={iconUrl}
+              onError={() => setFailedIconUrl(iconUrl)}
+            />
+          ) : (
+            payload.connectionName.slice(0, 1).toUpperCase()
+          )}
         </div>
-        <div className="min-w-0 flex-1 space-y-3">
-          <div className="flex items-start justify-between gap-3">
-            <div className="min-w-0 space-y-0.5">
-              <p className="text-[11px] font-medium tracking-[0.16em] text-dls-tertiary uppercase">
-                Cloud connection
-              </p>
+        <div className="flex min-w-0 flex-1 flex-col gap-3">
+          <div className="flex flex-col gap-1">
+            <div className="flex min-w-0 items-center gap-2">
               <h3 className="truncate text-base leading-5 font-semibold text-dls-primary">
                 {payload.connectionName}
               </h3>
+              <span className="inline-flex shrink-0 items-center gap-1.5 text-xs font-medium text-dls-secondary">
+                <span className="size-1.5 rounded-full bg-amber-9" />
+                {statusLabel}
+              </span>
             </div>
-            <span className="inline-flex shrink-0 items-center gap-1 rounded-full border border-amber-6/35 bg-amber-3/20 px-2 py-0.5 text-[11px] font-medium text-amber-11">
-              <span className="size-1.5 rounded-full bg-amber-9" />
-              {statusLabel}
-            </span>
-          </div>
-
-          <div className="space-y-1">
             <p className="text-sm leading-5 font-medium text-dls-primary">{title}</p>
             <p className="text-xs leading-5 text-dls-secondary">{description}</p>
           </div>
 
           {payload.canAttemptReconnect ? (
-            <Button
-              size="sm"
-              onClick={() =>
-                navigate("/settings/connect", {
-                  state: { focusConnection: payload.connectionName },
-                })
-              }
-            >
-              {reconnectLabel}
-            </Button>
+            <div className="flex items-center gap-2">
+              <Button
+                size="sm"
+                onClick={() =>
+                  navigate("/settings/connect", {
+                    state: { focusConnection: payload.connectionName },
+                  })
+                }
+              >
+                {reconnectLabel}
+              </Button>
+            </div>
           ) : (
-            <div className="rounded-xl border border-dls-border/70 bg-dls-sidebar/40 px-3 py-2 text-xs leading-5 text-dls-secondary">
+            <div className="flex flex-col gap-1 text-xs leading-5 text-dls-secondary">
               <p>
                 {actorDescription(payload)}
               </p>
               {payload.actionLabel ? (
-                <p className="mt-1 text-[11px] text-dls-tertiary">{payload.actionLabel}</p>
+                <p className="text-[11px] text-dls-tertiary">{payload.actionLabel}</p>
               ) : null}
             </div>
           )}
 
           <Tool toolPart={part} title="Technical details" className="pt-0.5">
             {payload.diagnosticReferenceId ? (
-              <div className="border-border/70 border-t pt-2">
+              <div className="flex flex-col gap-2">
                 <div className="flex min-w-0 flex-wrap items-center gap-2">
                   <span className="text-[11px] font-medium text-dls-secondary">
                     Diagnostic reference
                   </span>
-                  <code className="min-w-0 truncate rounded-md bg-dls-surface/80 px-2 py-1 font-mono text-[11px] text-dls-secondary">
+                  <code className="min-w-0 truncate font-mono text-[11px] text-dls-secondary">
                     {payload.diagnosticReferenceId}
                   </code>
                   <Button size="xs" variant="ghost" onClick={() => void copyDiagnostic()}>
-                    {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+                    {copied ? <Check data-icon="inline-start" /> : <Copy data-icon="inline-start" />}
                     {copied ? "Copied" : "Copy reference"}
                   </Button>
                 </div>

--- a/apps/app/src/components/tools/connection-status.tsx
+++ b/apps/app/src/components/tools/connection-status.tsx
@@ -1,0 +1,110 @@
+"use client"
+
+import * as React from "react"
+import { Check, Copy, Unplug } from "lucide-react"
+import { useNavigate } from "react-router-dom"
+
+import { Button } from "@/components/ui/button"
+import { Tool, type ToolPart } from "@/components/ui/tool"
+import type { ConnectionStatusPayload } from "@/react-app/domains/connections/connection-status-payload"
+
+interface ConnectionStatusToolProps {
+  part: ToolPart
+  payload: ConnectionStatusPayload
+}
+
+function actorDescription(payload: ConnectionStatusPayload): string {
+  switch (payload.actor) {
+    case "provider_admin":
+      return `This needs a fix on the ${payload.connectionName} provider side.`
+    case "org_admin":
+    case "platform_admin":
+      return "This needs a fix from your organization admin."
+    default:
+      return "This can't be fixed from this app right now."
+  }
+}
+
+/**
+ * Inline chat card for a broken Cloud connection surfaced by a capability
+ * tool result. Reconnectable (per-member OAuth) failures get a Reconnect
+ * button that lands on Settings → Connect with the connector highlighted;
+ * failures owned by someone else degrade honestly to who must act plus the
+ * diagnostic reference. The raw payload stays available under a disclosure.
+ */
+export function ConnectionStatusTool({ part, payload }: ConnectionStatusToolProps) {
+  const navigate = useNavigate()
+  const [copied, setCopied] = React.useState(false)
+
+  const copyDiagnostic = React.useCallback(async () => {
+    if (!payload.diagnosticReferenceId) return
+    try {
+      await navigator.clipboard.writeText(payload.diagnosticReferenceId)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // ignore clipboard failures
+    }
+  }, [payload.diagnosticReferenceId])
+
+  return (
+    <div
+      data-testid="connection-status-card"
+      data-connection-name={payload.connectionName}
+      className="not-prose w-full max-w-xl rounded-2xl border border-amber-6/50 bg-dls-surface/95 p-4 shadow-sm"
+    >
+      <div className="flex items-start gap-3">
+        <div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full border border-amber-6/40 bg-amber-3/30 text-amber-11">
+          <Unplug className="size-4" />
+        </div>
+        <div className="min-w-0 flex-1 space-y-3">
+          <div className="space-y-1">
+            <h3 className="text-sm font-semibold text-dls-primary">
+              {payload.canReconnect
+                ? `${payload.connectionName} needs you to sign in again`
+                : `${payload.connectionName} isn't working right now`}
+            </h3>
+            <p className="text-xs leading-5 text-dls-secondary">
+              {payload.canReconnect
+                ? "Its sign-in expired or was revoked. Reconnect your account, then ask the agent to try again."
+                : (payload.message ?? "The connection returned an error.")}
+            </p>
+          </div>
+
+          {payload.canReconnect ? (
+            <Button
+              size="sm"
+              onClick={() =>
+                navigate("/settings/connect", {
+                  state: { focusConnection: payload.connectionName },
+                })
+              }
+            >
+              Reconnect {payload.connectionName}
+            </Button>
+          ) : (
+            <div className="space-y-2">
+              <p className="rounded-lg border border-amber-6/40 bg-amber-3/20 px-3 py-2 text-xs text-amber-11">
+                {actorDescription(payload)}
+                {payload.actionLabel ? ` ${payload.actionLabel}` : ""}
+              </p>
+              {payload.diagnosticReferenceId ? (
+                <div className="flex min-w-0 items-center gap-2">
+                  <code className="min-w-0 truncate rounded-md bg-dls-sidebar/60 px-2 py-1 font-mono text-[11px] text-dls-secondary">
+                    {payload.diagnosticReferenceId}
+                  </code>
+                  <Button size="sm" variant="ghost" onClick={() => void copyDiagnostic()}>
+                    {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+                    {copied ? "Copied" : "Copy reference"}
+                  </Button>
+                </div>
+              ) : null}
+            </div>
+          )}
+
+          <Tool toolPart={part} title="Technical details" />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -23,6 +23,7 @@ import {
   Wrench,
 } from "lucide-react"
 import type { DynamicToolUIPart, ToolUIPart } from "ai"
+import type { ReactNode } from "react"
 
 function toolIcon(part: ToolPart) {
   const name = part.type === "dynamic-tool" ? part.toolName : part.type
@@ -59,6 +60,7 @@ export type ToolProps = {
   toolPart: ToolPart
   defaultOpen?: boolean
   className?: string
+  children?: ReactNode
 }
 
 const formatValue = (value: unknown): string => {
@@ -117,7 +119,7 @@ function DiffLines({ diff }: { diff: string }) {
   )
 }
 
-const Tool = ({ title, toolPart, defaultOpen = false, className }: ToolProps) => {
+const Tool = ({ title, toolPart, defaultOpen = false, className, children }: ToolProps) => {
   const { state, input } = toolPart
   const inFlight = isToolPartInFlight(toolPart)
   const isError = state === "output-error"
@@ -189,6 +191,7 @@ const Tool = ({ title, toolPart, defaultOpen = false, className }: ToolProps) =>
           {inFlight && !hasInput ? (
             <span className="text-muted-foreground">Waiting for input…</span>
           ) : null}
+          {children}
         </div>
       </CollapsibleContent>
     </Collapsible>

--- a/apps/app/src/react-app/domains/connections/connection-status-payload.ts
+++ b/apps/app/src/react-app/domains/connections/connection-status-payload.ts
@@ -1,0 +1,131 @@
+/**
+ * Detects structured `connection_status` payloads inside OpenWork Cloud MCP
+ * tool results (`*_search_capabilities` / `*_execute_capability`).
+ *
+ * The Den embeds these when a connector behind the capability gateway is
+ * broken (expired OAuth grant, rejected token refresh, provider outage) so
+ * the chat can render an actionable reconnect card instead of raw JSON.
+ * The payload shape is the Den's MCP connection-status contract:
+ * `{ matches: [{ kind: "connection_status", connectionStatus: {...} }] }`
+ * for search results, or a top-level `connectionStatus` object.
+ */
+
+import type { DynamicToolUIPart, ToolUIPart } from "ai";
+
+export type ConnectionStatusPayload = {
+  connectionName: string;
+  connectionId: string | null;
+  state: string;
+  credentialMode: "per_member" | "shared" | null;
+  errorCode: string | null;
+  message: string | null;
+  actor: string | null;
+  actionLabel: string | null;
+  diagnosticReferenceId: string | null;
+  /** The member can fix this themselves by re-running OAuth for their own account. */
+  canReconnect: boolean;
+};
+
+const CLOUD_TOOL_SUFFIXES = ["_search_capabilities", "_execute_capability"];
+const HEALTHY_STATES = new Set(["connected", "ok", "ready"]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function asString(value: unknown): string | null {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function parseCandidate(value: unknown): ConnectionStatusPayload | null {
+  if (!isRecord(value)) return null;
+  const connectionName = asString(value.connectionName);
+  const state = asString(value.state);
+  if (!connectionName || !state) return null;
+  if (HEALTHY_STATES.has(state)) return null;
+  const credentialMode =
+    value.credentialMode === "per_member" || value.credentialMode === "shared"
+      ? value.credentialMode
+      : null;
+  const actor = asString(value.actor);
+  const action = isRecord(value.action) ? value.action : null;
+  const diagnostic = isRecord(value.diagnostic) ? value.diagnostic : null;
+  return {
+    connectionName,
+    connectionId: asString(value.connectionId),
+    state,
+    credentialMode,
+    errorCode: asString(value.errorCode),
+    message: asString(value.message),
+    actor,
+    actionLabel: action ? asString(action.label) : null,
+    diagnosticReferenceId: diagnostic ? asString(diagnostic.referenceId) : null,
+    // Only offer a self-serve Reconnect when the payload does not assign the
+    // fix to someone else (e.g. provider_admin): a button that cannot succeed
+    // is worse than an honest explanation.
+    canReconnect:
+      credentialMode === "per_member" &&
+      state === "reauth_required" &&
+      (actor === null || actor === "member"),
+  };
+}
+
+function findConnectionStatus(root: unknown): ConnectionStatusPayload | null {
+  if (!isRecord(root)) return null;
+  const direct = parseCandidate(root.connectionStatus);
+  if (direct) return direct;
+  const matches = Array.isArray(root.matches) ? root.matches : [];
+  for (const match of matches) {
+    if (!isRecord(match)) continue;
+    if (match.kind !== "connection_status") continue;
+    const parsed = parseCandidate(match.connectionStatus);
+    if (parsed) return parsed;
+  }
+  return null;
+}
+
+function parseJsonDocument(text: string): unknown | null {
+  try {
+    return JSON.parse(text);
+  } catch {
+    // Tool output text sometimes wraps the JSON document (prefix/suffix
+    // prose). Fall back to the outermost braces.
+  }
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start >= 0 && end > start) {
+    try {
+      return JSON.parse(text.slice(start, end + 1));
+    } catch {
+      return null;
+    }
+  }
+  return null;
+}
+
+export function isCloudCapabilityToolName(toolName: string): boolean {
+  return CLOUD_TOOL_SUFFIXES.some((suffix) => toolName.endsWith(suffix));
+}
+
+export function parseConnectionStatusPayload(output: unknown): ConnectionStatusPayload | null {
+  if (typeof output === "string") {
+    const document = parseJsonDocument(output);
+    return document === null ? null : findConnectionStatus(document);
+  }
+  return findConnectionStatus(output);
+}
+
+/**
+ * Guard for the chat tool renderer: returns the parsed payload when this
+ * tool part is a Cloud capability call whose result carries a broken
+ * connection status; `null` otherwise (renders as a plain tool part).
+ */
+export function getConnectionStatusFromToolPart(
+  part: ToolUIPart | DynamicToolUIPart,
+): ConnectionStatusPayload | null {
+  if (part.type !== "dynamic-tool") return null;
+  if (!isCloudCapabilityToolName(part.toolName)) return null;
+  if (part.state === "output-available") return parseConnectionStatusPayload(part.output);
+  if (part.state === "output-error") return parseConnectionStatusPayload(part.errorText);
+  return null;
+}

--- a/apps/app/src/react-app/domains/connections/connection-status-payload.ts
+++ b/apps/app/src/react-app/domains/connections/connection-status-payload.ts
@@ -22,8 +22,8 @@ export type ConnectionStatusPayload = {
   actor: string | null;
   actionLabel: string | null;
   diagnosticReferenceId: string | null;
-  /** The member can fix this themselves by re-running OAuth for their own account. */
-  canReconnect: boolean;
+  /** The member can attempt reconnect by re-running OAuth for their own account. */
+  canAttemptReconnect: boolean;
 };
 
 const CLOUD_TOOL_SUFFIXES = ["_search_capabilities", "_execute_capability"];
@@ -60,13 +60,7 @@ function parseCandidate(value: unknown): ConnectionStatusPayload | null {
     actor,
     actionLabel: action ? asString(action.label) : null,
     diagnosticReferenceId: diagnostic ? asString(diagnostic.referenceId) : null,
-    // Only offer a self-serve Reconnect when the payload does not assign the
-    // fix to someone else (e.g. provider_admin): a button that cannot succeed
-    // is worse than an honest explanation.
-    canReconnect:
-      credentialMode === "per_member" &&
-      state === "reauth_required" &&
-      (actor === null || actor === "member"),
+    canAttemptReconnect: credentialMode === "per_member" && state === "reauth_required",
   };
 }
 

--- a/apps/app/src/react-app/domains/connections/connection-status-payload.ts
+++ b/apps/app/src/react-app/domains/connections/connection-status-payload.ts
@@ -22,6 +22,7 @@ export type ConnectionStatusPayload = {
   actor: string | null;
   actionLabel: string | null;
   diagnosticReferenceId: string | null;
+  serviceUrl: string | null;
   /** The member can attempt reconnect by re-running OAuth for their own account. */
   canAttemptReconnect: boolean;
 };
@@ -37,7 +38,7 @@ function asString(value: unknown): string | null {
   return typeof value === "string" && value.trim() ? value : null;
 }
 
-function parseCandidate(value: unknown): ConnectionStatusPayload | null {
+function parseCandidate(value: unknown, serviceUrl: string | null): ConnectionStatusPayload | null {
   if (!isRecord(value)) return null;
   const connectionName = asString(value.connectionName);
   const state = asString(value.state);
@@ -60,19 +61,20 @@ function parseCandidate(value: unknown): ConnectionStatusPayload | null {
     actor,
     actionLabel: action ? asString(action.label) : null,
     diagnosticReferenceId: diagnostic ? asString(diagnostic.referenceId) : null,
+    serviceUrl,
     canAttemptReconnect: credentialMode === "per_member" && state === "reauth_required",
   };
 }
 
 function findConnectionStatus(root: unknown): ConnectionStatusPayload | null {
   if (!isRecord(root)) return null;
-  const direct = parseCandidate(root.connectionStatus);
+  const direct = parseCandidate(root.connectionStatus, null);
   if (direct) return direct;
   const matches = Array.isArray(root.matches) ? root.matches : [];
   for (const match of matches) {
     if (!isRecord(match)) continue;
     if (match.kind !== "connection_status") continue;
-    const parsed = parseCandidate(match.connectionStatus);
+    const parsed = parseCandidate(match.connectionStatus, asString(match.path));
     if (parsed) return parsed;
   }
   return null;

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useLocation } from "react-router-dom";
 import { Activity, ArrowUpRight } from "lucide-react";
 import type { AgentContextDiagnosticsReport } from "@openwork/types/agent-context-diagnostics";
 
@@ -599,6 +600,7 @@ function ConnectOrganizationRow(props: {
     <div
       data-testid="connect-organization-row"
       data-connect-row-kind={row.kind}
+      data-connection-name={row.name}
       className="flex items-center gap-3 rounded-xl border border-dls-border bg-dls-surface px-3 py-3"
     >
       <ConnectRowIcon
@@ -795,7 +797,54 @@ function ConnectPitchPanel() {
   );
 }
 
+/**
+ * When the chat's connection-status card deep-links here it passes the
+ * connector name via location state. Scroll that row into view and flash a
+ * highlight ring so the user lands directly on the thing to fix. Rows render
+ * after connections load, so retry briefly instead of assuming presence.
+ */
+function useFocusConnectionFromLocation() {
+  const location = useLocation();
+  const rawState: unknown = location.state;
+  const focusConnection =
+    typeof rawState === "object"
+    && rawState !== null
+    && "focusConnection" in rawState
+    && typeof rawState.focusConnection === "string"
+    && rawState.focusConnection.trim()
+      ? rawState.focusConnection
+      : null;
+
+  useEffect(() => {
+    if (!focusConnection) return;
+    let cancelled = false;
+    let attempts = 0;
+    let timer: number | null = null;
+    const highlightClasses = ["ring-2", "ring-amber-8", "ring-offset-2"];
+    const tryHighlight = () => {
+      if (cancelled) return;
+      const row = document.querySelector(
+        `[data-testid="connect-organization-row"][data-connection-name="${CSS.escape(focusConnection)}"]`,
+      );
+      if (row instanceof HTMLElement) {
+        row.scrollIntoView({ block: "center", behavior: "smooth" });
+        row.classList.add(...highlightClasses);
+        timer = window.setTimeout(() => row.classList.remove(...highlightClasses), 2600);
+        return;
+      }
+      attempts += 1;
+      if (attempts < 20) timer = window.setTimeout(tryHighlight, 250);
+    };
+    tryHighlight();
+    return () => {
+      cancelled = true;
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [focusConnection]);
+}
+
 export function ConnectView(props: ConnectViewProps) {
+  useFocusConnectionFromLocation();
   const denAuth = useDenAuth();
   const desktopConfig = useDesktopConfig();
   const connectEnabled = useConnectEnabled();

--- a/apps/app/tests/connection-status-payload.test.ts
+++ b/apps/app/tests/connection-status-payload.test.ts
@@ -17,6 +17,7 @@ const providerAdminSearchResult = {
       summary: "[Granola] This connection is set up but returned an error.",
       kind: "connection_status",
       status: "error",
+      path: "https://mcp.granola.ai/mcp",
       connectionStatus: {
         layer: "mcp_connection",
         connectionId: "emc_01xxxxxxxxxxxxxxxxxxxxxxxx",
@@ -78,12 +79,14 @@ describe("parseConnectionStatusPayload", () => {
     expect(payload?.actor).toBe("provider_admin");
     expect(payload?.actionLabel).toBe("Inspect provider and proxy logs for the failing HTTP request.");
     expect(payload?.diagnosticReferenceId).toBe("a0b58150-7bad-4a37-ba36-c4260f444a8d");
+    expect(payload?.serviceUrl).toBe("https://mcp.granola.ai/mcp");
     expect(payload?.canAttemptReconnect).toBe(true);
   });
 
   test("offers reconnect for member-actionable per-member reauth", () => {
     const payload = parseConnectionStatusPayload(memberReconnectResult);
     expect(payload?.connectionName).toBe("Slack");
+    expect(payload?.serviceUrl).toBeNull();
     expect(payload?.canAttemptReconnect).toBe(true);
   });
 
@@ -139,6 +142,7 @@ describe("parseConnectionStatusPayload", () => {
       },
     });
     expect(payload?.connectionName).toBe("Notion");
+    expect(payload?.serviceUrl).toBeNull();
     expect(payload?.canAttemptReconnect).toBe(true);
   });
 

--- a/apps/app/tests/connection-status-payload.test.ts
+++ b/apps/app/tests/connection-status-payload.test.ts
@@ -69,7 +69,7 @@ const healthySearchResult = {
 };
 
 describe("parseConnectionStatusPayload", () => {
-  test("extracts a provider_admin failure from a search result and disables self-serve reconnect", () => {
+  test("extracts a provider_admin failure from a search result and offers a reconnect attempt", () => {
     const payload = parseConnectionStatusPayload(providerAdminSearchResult);
     expect(payload).not.toBeNull();
     expect(payload?.connectionName).toBe("Granola");
@@ -78,13 +78,50 @@ describe("parseConnectionStatusPayload", () => {
     expect(payload?.actor).toBe("provider_admin");
     expect(payload?.actionLabel).toBe("Inspect provider and proxy logs for the failing HTTP request.");
     expect(payload?.diagnosticReferenceId).toBe("a0b58150-7bad-4a37-ba36-c4260f444a8d");
-    expect(payload?.canReconnect).toBe(false);
+    expect(payload?.canAttemptReconnect).toBe(true);
   });
 
   test("offers reconnect for member-actionable per-member reauth", () => {
     const payload = parseConnectionStatusPayload(memberReconnectResult);
     expect(payload?.connectionName).toBe("Slack");
-    expect(payload?.canReconnect).toBe(true);
+    expect(payload?.canAttemptReconnect).toBe(true);
+  });
+
+  test("offers reconnect attempts for admin-owned per-member reauth", () => {
+    for (const actor of ["org_admin", "organization_admin", "platform_admin"]) {
+      const payload = parseConnectionStatusPayload({
+        connectionStatus: {
+          connectionName: "Granola",
+          credentialMode: "per_member",
+          state: "reauth_required",
+          actor,
+        },
+      });
+      expect(payload?.canAttemptReconnect).toBe(true);
+    }
+  });
+
+  test("does not offer reconnect attempts for non-per-member or non-reauth failures", () => {
+    expect(
+      parseConnectionStatusPayload({
+        connectionStatus: {
+          connectionName: "Granola",
+          credentialMode: "shared",
+          state: "reauth_required",
+          actor: "provider_admin",
+        },
+      })?.canAttemptReconnect,
+    ).toBe(false);
+    expect(
+      parseConnectionStatusPayload({
+        connectionStatus: {
+          connectionName: "Granola",
+          credentialMode: "per_member",
+          state: "provider_error",
+          actor: "organization_admin",
+        },
+      })?.canAttemptReconnect,
+    ).toBe(false);
   });
 
   test("parses string tool output (MCP text content)", () => {
@@ -102,7 +139,7 @@ describe("parseConnectionStatusPayload", () => {
       },
     });
     expect(payload?.connectionName).toBe("Notion");
-    expect(payload?.canReconnect).toBe(true);
+    expect(payload?.canAttemptReconnect).toBe(true);
   });
 
   test("returns null for healthy results, healthy states, and non-JSON text", () => {

--- a/apps/app/tests/connection-status-payload.test.ts
+++ b/apps/app/tests/connection-status-payload.test.ts
@@ -1,0 +1,177 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  getConnectionStatusFromToolPart,
+  isCloudCapabilityToolName,
+  parseConnectionStatusPayload,
+} from "../src/react-app/domains/connections/connection-status-payload";
+
+/** Field-shaped fixture: a real search_capabilities result for a connector
+ * whose OAuth refresh was rejected (actor assigned to the provider admin). */
+const providerAdminSearchResult = {
+  matches: [
+    {
+      name: "mcp:emc_01xxxxxxxxxxxxxxxxxxxxxxxx:*",
+      method: "MCP",
+      score: 7,
+      summary: "[Granola] This connection is set up but returned an error.",
+      kind: "connection_status",
+      status: "error",
+      connectionStatus: {
+        layer: "mcp_connection",
+        connectionId: "emc_01xxxxxxxxxxxxxxxxxxxxxxxx",
+        connectionName: "Granola",
+        authType: "oauth",
+        credentialMode: "per_member",
+        state: "reauth_required",
+        errorCode: "unauthorized",
+        message: "The authorization server rejected the code or token refresh exchange.",
+        actor: "provider_admin",
+        action: {
+          type: "fix_provider",
+          surface: "provider_admin_console",
+          label: "Inspect provider and proxy logs for the failing HTTP request.",
+          retry: "search_capabilities",
+        },
+        diagnostic: {
+          referenceId: "a0b58150-7bad-4a37-ba36-c4260f444a8d",
+          category: "http_failure",
+          code: "MCP_HTTP_400",
+        },
+      },
+    },
+    { name: "getMe", method: "GET", path: "/v1/me", score: 3 },
+  ],
+};
+
+const memberReconnectResult = {
+  matches: [
+    {
+      kind: "connection_status",
+      status: "error",
+      connectionStatus: {
+        connectionId: "emc_01yyyyyyyyyyyyyyyyyyyyyyyy",
+        connectionName: "Slack",
+        credentialMode: "per_member",
+        state: "reauth_required",
+        errorCode: "unauthorized",
+        message: "Your Slack sign-in expired.",
+        actor: "member",
+      },
+    },
+  ],
+};
+
+const healthySearchResult = {
+  matches: [
+    { name: "getCapabilitiesGoogleWorkspaceGmailMessages", method: "GET", score: 16 },
+  ],
+};
+
+describe("parseConnectionStatusPayload", () => {
+  test("extracts a provider_admin failure from a search result and disables self-serve reconnect", () => {
+    const payload = parseConnectionStatusPayload(providerAdminSearchResult);
+    expect(payload).not.toBeNull();
+    expect(payload?.connectionName).toBe("Granola");
+    expect(payload?.state).toBe("reauth_required");
+    expect(payload?.credentialMode).toBe("per_member");
+    expect(payload?.actor).toBe("provider_admin");
+    expect(payload?.actionLabel).toBe("Inspect provider and proxy logs for the failing HTTP request.");
+    expect(payload?.diagnosticReferenceId).toBe("a0b58150-7bad-4a37-ba36-c4260f444a8d");
+    expect(payload?.canReconnect).toBe(false);
+  });
+
+  test("offers reconnect for member-actionable per-member reauth", () => {
+    const payload = parseConnectionStatusPayload(memberReconnectResult);
+    expect(payload?.connectionName).toBe("Slack");
+    expect(payload?.canReconnect).toBe(true);
+  });
+
+  test("parses string tool output (MCP text content)", () => {
+    const payload = parseConnectionStatusPayload(JSON.stringify(providerAdminSearchResult));
+    expect(payload?.connectionName).toBe("Granola");
+  });
+
+  test("parses a top-level connectionStatus object (execute_capability shape)", () => {
+    const payload = parseConnectionStatusPayload({
+      error: "connection_unavailable",
+      connectionStatus: {
+        connectionName: "Notion",
+        credentialMode: "per_member",
+        state: "reauth_required",
+      },
+    });
+    expect(payload?.connectionName).toBe("Notion");
+    expect(payload?.canReconnect).toBe(true);
+  });
+
+  test("returns null for healthy results, healthy states, and non-JSON text", () => {
+    expect(parseConnectionStatusPayload(healthySearchResult)).toBeNull();
+    expect(
+      parseConnectionStatusPayload({
+        connectionStatus: { connectionName: "Slack", state: "connected" },
+      }),
+    ).toBeNull();
+    expect(parseConnectionStatusPayload("no json here")).toBeNull();
+    expect(parseConnectionStatusPayload(undefined)).toBeNull();
+  });
+});
+
+describe("getConnectionStatusFromToolPart", () => {
+  const basePart = {
+    type: "dynamic-tool" as const,
+    toolCallId: "call-1",
+    input: { query: "meeting notes" },
+  };
+
+  test("matches cloud capability tool names only", () => {
+    expect(isCloudCapabilityToolName("openwork-cloud_search_capabilities")).toBe(true);
+    expect(isCloudCapabilityToolName("openwork-cloud_execute_capability")).toBe(true);
+    expect(isCloudCapabilityToolName("bash")).toBe(false);
+    expect(isCloudCapabilityToolName("websearch")).toBe(false);
+  });
+
+  test("reads completed output", () => {
+    const payload = getConnectionStatusFromToolPart({
+      ...basePart,
+      toolName: "openwork-cloud_search_capabilities",
+      state: "output-available",
+      output: JSON.stringify(providerAdminSearchResult),
+    });
+    expect(payload?.connectionName).toBe("Granola");
+  });
+
+  test("reads errored output text", () => {
+    const payload = getConnectionStatusFromToolPart({
+      ...basePart,
+      toolName: "openwork-cloud_execute_capability",
+      state: "output-error",
+      errorText: JSON.stringify({
+        connectionStatus: {
+          connectionName: "Granola",
+          credentialMode: "per_member",
+          state: "reauth_required",
+        },
+      }),
+    });
+    expect(payload?.connectionName).toBe("Granola");
+  });
+
+  test("ignores other tools and in-flight parts", () => {
+    expect(
+      getConnectionStatusFromToolPart({
+        ...basePart,
+        toolName: "bash",
+        state: "output-available",
+        output: JSON.stringify(providerAdminSearchResult),
+      }),
+    ).toBeNull();
+    expect(
+      getConnectionStatusFromToolPart({
+        ...basePart,
+        toolName: "openwork-cloud_search_capabilities",
+        state: "input-streaming",
+      }),
+    ).toBeNull();
+  });
+});

--- a/evals/flows/chat-connection-reconnect-card.flow.mjs
+++ b/evals/flows/chat-connection-reconnect-card.flow.mjs
@@ -86,7 +86,10 @@ async function signDesktopIntoCloud(ctx) {
   })()`, { awaitPromise: true });
   ctx.assert(written === true, "Failed to write Daytona Den bootstrap.");
   await ctx.eval("location.reload()");
-  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after Den bootstrap" });
+  await ctx.waitFor(
+    "window.__openworkControl?.listActions().some((action) => action.id === 'auth.exchange-grant')",
+    { timeoutMs: 60_000, label: "desktop handoff control after Den bootstrap" },
+  );
 
   const handoff = await denApiFetch("/v1/auth/desktop-handoff", {
     method: "POST",

--- a/evals/flows/chat-connection-reconnect-card.flow.mjs
+++ b/evals/flows/chat-connection-reconnect-card.flow.mjs
@@ -107,6 +107,10 @@ async function signDesktopIntoCloud(ctx) {
 async function ensureWorkspace(ctx) {
   await ctx.clickText("Continue with organization", { timeoutMs: 8_000 }).catch(() => {});
   await ctx.clickText("Continue to workspace", { timeoutMs: 10_000 }).catch(() => {});
+  await ctx.waitFor(
+    "window.location.hash.includes('/workspace/') || Boolean(document.querySelector('input[placeholder=\"/workspace/my-project\"]'))",
+    { timeoutMs: 30_000, label: "workspace route or folder form" },
+  );
   const needsFolder = await ctx.eval("Boolean(document.querySelector('input[placeholder=\"/workspace/my-project\"]'))").catch(() => false);
   if (needsFolder) {
     await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_PATH);

--- a/evals/flows/chat-connection-reconnect-card.flow.mjs
+++ b/evals/flows/chat-connection-reconnect-card.flow.mjs
@@ -242,23 +242,23 @@ export default {
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("A provider-owned failure names who must act and exposes a support reference", {
+        await ctx.prove("A provider-owned auth failure keeps caveats visible and offers a reconnect attempt", {
           voiceover: vo[3],
           action: async () => {
             await returnToChat(ctx);
             await ctx.control("eval.connection_status.seed", { fixture: "provider_admin" });
-            await ctx.waitForText("Granola isn't working right now");
+            await ctx.waitForText("Granola rejected sign-in");
           },
           assert: async () => {
-            await ctx.expectText("This needs a fix on the Granola provider side.");
-            await ctx.expectText("a0b58150-7bad-4a37-ba36-c4260f444a8d");
-            await ctx.expectText("Copy reference");
-            await ctx.expectNoText("Reconnect Granola");
+            await ctx.expectText("The provider rejected sign-in or token refresh.");
+            await ctx.expectText("Granola or your organization admin may need to fix provider configuration");
+            await ctx.expectText("Try reconnecting to Granola");
+            await ctx.expectNoText("Copy reference");
           },
           screenshot: {
             name: "provider-admin-card",
-            requireText: ["Granola isn't working right now", "provider side", "Copy reference"],
-            rejectText: ["Reconnect Granola", "Something went wrong"],
+            requireText: ["Granola rejected sign-in", "Provider may need a fix", "Try reconnecting to Granola", "provider configuration"],
+            rejectText: ["Copy reference", "MCP_HTTP_400", "Something went wrong"],
           },
         });
       },
@@ -276,10 +276,11 @@ export default {
             await ctx.expectText("MCP_HTTP_400");
             await ctx.expectText("provider_admin");
             await ctx.expectText("a0b58150-7bad-4a37-ba36-c4260f444a8d");
+            await ctx.expectText("Copy reference");
           },
           screenshot: {
             name: "technical-details-disclosed",
-            requireText: ["Technical details", "MCP_HTTP_400", "provider_admin"],
+            requireText: ["Technical details", "MCP_HTTP_400", "provider_admin", "Diagnostic reference", "Copy reference"],
             rejectText: ["Something went wrong"],
           },
         });

--- a/evals/flows/chat-connection-reconnect-card.flow.mjs
+++ b/evals/flows/chat-connection-reconnect-card.flow.mjs
@@ -108,8 +108,8 @@ async function ensureWorkspace(ctx) {
   await ctx.clickText("Continue with organization", { timeoutMs: 8_000 }).catch(() => {});
   await ctx.clickText("Continue to workspace", { timeoutMs: 10_000 }).catch(() => {});
   await ctx.waitFor(
-    "window.location.hash.includes('/workspace/') || Boolean(document.querySelector('input[placeholder=\"/workspace/my-project\"]'))",
-    { timeoutMs: 30_000, label: "workspace route or folder form" },
+    "window.location.hash.includes('/workspace/') || Boolean(document.querySelector('input[placeholder=\"/workspace/my-project\"]')) || document.body.innerText.includes('Skip and use the free model')",
+    { timeoutMs: 30_000, label: "workspace, folder form, or model onboarding" },
   );
   const needsFolder = await ctx.eval("Boolean(document.querySelector('input[placeholder=\"/workspace/my-project\"]'))").catch(() => false);
   if (needsFolder) {

--- a/evals/flows/chat-connection-reconnect-card.flow.mjs
+++ b/evals/flows/chat-connection-reconnect-card.flow.mjs
@@ -1,98 +1,281 @@
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
-// Narration is loaded from the approved script (evals/voiceovers/chat-connection-reconnect-card.md).
-// The runner fails this flow if the narration drifts from that script.
-const vo = await loadVoiceoverParagraphs("chat-connection-reconnect-card");
+const FLOW_ID = "chat-connection-reconnect-card";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? DEN_API_URL).trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const WORKSPACE_PATH = "/tmp/openwork-chat-connection-reconnect-card";
+const CONNECTION_NAME = "Granola";
+
+const state = {
+  adminToken: null,
+  connectionId: null,
+};
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+async function prepareCloudConnection(ctx) {
+  const signedIn = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
+  });
+  ctx.assert(signedIn.response.ok && typeof signedIn.body?.token === "string", `Demo sign-in failed: ${signedIn.response.status}`);
+  state.adminToken = signedIn.body.token;
+
+  const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+    headers: { authorization: `Bearer ${state.adminToken}` },
+  });
+  ctx.assert(existing.response.ok, `Connection list failed: ${existing.response.status}`);
+  for (const connection of existing.body?.connections ?? []) {
+    if (connection.name !== CONNECTION_NAME || connection.url !== "https://eval-granola.example.test/mcp") continue;
+    await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${state.adminToken}` },
+    });
+  }
+
+  const created = await denApiFetch("/v1/mcp-connections", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.adminToken}` },
+    body: JSON.stringify({
+      name: CONNECTION_NAME,
+      url: "https://eval-granola.example.test/mcp",
+      authType: "oauth",
+      credentialMode: "per_member",
+      access: { orgWide: true },
+    }),
+  });
+  ctx.assert(created.response.ok, `Granola connection create failed: ${created.response.status} ${created.text.slice(0, 300)}`);
+  state.connectionId = created.body?.id ?? created.body?.connection?.id ?? null;
+  ctx.assert(Boolean(state.connectionId), "Granola connection response did not include an id.");
+}
+
+async function signDesktopIntoCloud(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl) && Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", {
+    timeoutMs: 90_000,
+    label: "Electron control and desktop bridge",
+  });
+  const bootstrap = { baseUrl: DEN_API_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
+  const written = await ctx.eval(`(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!bridge) return false;
+    await bridge("setDesktopBootstrapConfig", ${JSON.stringify(bootstrap)});
+    localStorage.setItem("openwork.den.baseUrl", ${JSON.stringify(DEN_API_URL)});
+    localStorage.setItem("openwork.den.apiBaseUrl", ${JSON.stringify(DEN_API_URL)});
+    localStorage.removeItem("openwork.den.authToken");
+    localStorage.removeItem("openwork.den.activeOrgId");
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith("openwork.den.desktopConfig:")) localStorage.removeItem(key);
+    }
+    return true;
+  })()`, { awaitPromise: true });
+  ctx.assert(written === true, "Failed to write Daytona Den bootstrap.");
+  await ctx.eval("location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after Den bootstrap" });
+
+  const handoff = await denApiFetch("/v1/auth/desktop-handoff", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.adminToken}` },
+    body: JSON.stringify({ desktopScheme: "openwork" }),
+  });
+  ctx.assert(handoff.response.ok, `Desktop handoff failed: ${handoff.response.status}`);
+  await ctx.control("auth.exchange-grant", { grant: handoff.body.grant, baseUrl: DEN_API_URL });
+  await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", {
+    timeoutMs: 60_000,
+    label: "active cloud organization",
+  });
+}
+
+async function ensureWorkspace(ctx) {
+  await ctx.clickText("Continue with organization", { timeoutMs: 8_000 }).catch(() => {});
+  await ctx.clickText("Continue to workspace", { timeoutMs: 10_000 }).catch(() => {});
+  const needsFolder = await ctx.eval("Boolean(document.querySelector('input[placeholder=\"/workspace/my-project\"]'))").catch(() => false);
+  if (needsFolder) {
+    await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_PATH);
+    await ctx.clickText("Use this folder", { timeoutMs: 15_000 });
+  }
+  await ctx.waitFor("window.location.hash.includes('/workspace/')", { timeoutMs: 60_000, label: "workspace route" });
+  await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll("button")].find((candidate) => candidate.textContent.trim() === "Continue without OpenWork Models");
+    button?.click();
+    return true;
+  })()`);
+  await ctx.waitFor(
+    "window.__openworkControl?.listActions().some((action) => action.id === 'eval.connection_status.seed')",
+    { timeoutMs: 60_000, label: "connection-status eval fixture" },
+  );
+}
+
+async function returnToChat(ctx) {
+  await ctx.clickText("Back to app", { timeoutMs: 15_000 });
+  await ctx.waitFor("window.location.hash.includes('/workspace/') && !window.location.hash.includes('/settings/')", {
+    timeoutMs: 30_000,
+    label: "chat route",
+  });
+  await ctx.waitFor(
+    "window.__openworkControl?.listActions().some((action) => action.id === 'eval.connection_status.seed')",
+    { timeoutMs: 30_000, label: "connection-status eval fixture after returning" },
+  );
+}
+
+async function cleanup(ctx) {
+  if (!state.adminToken || !state.connectionId) return;
+  const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+    method: "DELETE",
+    headers: { authorization: `Bearer ${state.adminToken}` },
+  });
+  ctx.assert(removed.response.ok, `Granola cleanup failed: ${removed.response.status}`);
+}
 
 export default {
-  id: "chat-connection-reconnect-card",
-  title: "TODO: one-line claim — user can do X and sees Y",
+  id: FLOW_ID,
+  title: "A broken Cloud connector becomes an actionable, honest card in chat",
   kind: "user-facing",
+  spec: "evals/voiceovers/chat-connection-reconnect-card.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 1", {
+        await ctx.prove("The user asks for meeting notes without needing to know the connector is broken", {
           voiceover: vo[0],
-          // "I ask my agent to pull my latest meeting notes, not knowing the connector's "
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await prepareCloudConnection(ctx);
+            await signDesktopIntoCloud(ctx);
+            await ensureWorkspace(ctx);
+            await ctx.control("eval.connection_status.seed", { fixture: "prompt" });
+            await ctx.waitForText("Pull my latest meeting notes from Granola.");
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 1 not implemented yet");
+            await ctx.expectText("Pull my latest meeting notes from Granola.");
+            await ctx.expectNoText("Granola needs you to sign in again");
           },
-          screenshot: { name: "frame-1", requireText: [] },
+          screenshot: {
+            name: "meeting-notes-request",
+            requireText: ["Pull my latest meeting notes from Granola."],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 2",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 2", {
+        await ctx.prove("A member-actionable expired login renders as a plain-language reconnect card", {
           voiceover: vo[1],
-          // "Instead of a wall of JSON, the chat shows me a card that says it plainly: Gr"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await ctx.control("eval.connection_status.seed", { fixture: "member" });
+            await ctx.waitForText("Granola needs you to sign in again");
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 2 not implemented yet");
+            await ctx.expectText("Granola needs you to sign in again");
+            await ctx.expectText("Reconnect Granola");
+            const cards = await ctx.eval("document.querySelectorAll('[data-testid=\"connection-status-card\"]').length");
+            ctx.assert(cards === 1, `Expected one connection-status card, found ${cards}.`);
           },
-          screenshot: { name: "frame-2", requireText: [] },
+          screenshot: {
+            name: "member-reconnect-card",
+            requireText: ["Granola needs you to sign in again", "Reconnect Granola"],
+            rejectText: ["provider_admin", "Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 3",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 3", {
+        await ctx.prove("Reconnect lands on Connect with the matching organization connector highlighted", {
           voiceover: vo[2],
-          // "I click Reconnect and land on the Connections page with the broken connector"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await ctx.clickText("Reconnect Granola", { timeoutMs: 15_000 });
+            await ctx.waitFor("window.location.hash.includes('/settings/connect')", { timeoutMs: 30_000, label: "Connect settings route" });
+            await ctx.waitFor(`(() => {
+              const row = document.querySelector('[data-testid="connect-organization-row"][data-connection-name="Granola"]');
+              return row instanceof HTMLElement && row.classList.contains("ring-2");
+            })()`, { timeoutMs: 60_000, label: "highlighted Granola row" });
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 3 not implemented yet");
+            await ctx.expectHashIncludes("/settings/connect");
+            const row = await ctx.eval(`(() => {
+              const target = document.querySelector('[data-testid="connect-organization-row"][data-connection-name="Granola"]');
+              return target ? { text: target.textContent, highlighted: target.classList.contains("ring-2") } : null;
+            })()`);
+            ctx.assert(row?.text?.includes("Granola"), `Granola row missing: ${JSON.stringify(row)}`);
+            ctx.assert(row?.highlighted === true, `Granola row was not highlighted: ${JSON.stringify(row)}`);
           },
-          screenshot: { name: "frame-3", requireText: [] },
+          screenshot: {
+            name: "connect-row-highlighted",
+            requireText: ["Connect", "Granola", "NEEDS YOUR SIGN-IN"],
+            rejectText: ["Something went wrong"],
+            hashIncludes: ["/settings/connect"],
+          },
         });
       },
     },
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 4", {
+        await ctx.prove("A provider-owned failure names who must act and exposes a support reference", {
           voiceover: vo[3],
-          // "When the problem isn't mine to fix, the card says so honestly — it names who"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await returnToChat(ctx);
+            await ctx.control("eval.connection_status.seed", { fixture: "provider_admin" });
+            await ctx.waitForText("Granola isn't working right now");
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 4 not implemented yet");
+            await ctx.expectText("This needs a fix on the Granola provider side.");
+            await ctx.expectText("a0b58150-7bad-4a37-ba36-c4260f444a8d");
+            await ctx.expectText("Copy reference");
+            await ctx.expectNoText("Reconnect Granola");
           },
-          screenshot: { name: "frame-4", requireText: [] },
+          screenshot: {
+            name: "provider-admin-card",
+            requireText: ["Granola isn't working right now", "provider side", "Copy reference"],
+            rejectText: ["Reconnect Granola", "Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 5",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 5", {
+        await ctx.prove("The complete technical payload remains available under a disclosure", {
           voiceover: vo[4],
-          // "And for anyone who wants the raw details, the full technical payload is stil"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await ctx.clickText("Technical details", { timeoutMs: 15_000 });
+            await ctx.waitForText("MCP_HTTP_400", { timeoutMs: 15_000 });
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 5 not implemented yet");
+            await ctx.expectText("MCP_HTTP_400");
+            await ctx.expectText("provider_admin");
+            await ctx.expectText("a0b58150-7bad-4a37-ba36-c4260f444a8d");
           },
-          screenshot: { name: "frame-5", requireText: [] },
+          screenshot: {
+            name: "technical-details-disclosed",
+            requireText: ["Technical details", "MCP_HTTP_400", "provider_admin"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
+    },
+    {
+      name: "Cleanup",
+      run: cleanup,
     },
   ],
 };

--- a/evals/flows/chat-connection-reconnect-card.flow.mjs
+++ b/evals/flows/chat-connection-reconnect-card.flow.mjs
@@ -116,6 +116,11 @@ async function ensureWorkspace(ctx) {
     await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_PATH);
     await ctx.clickText("Use this folder", { timeoutMs: 15_000 });
   }
+  await ctx.waitFor(
+    "window.location.hash.includes('/workspace/') || document.body.innerText.includes('Skip and use the free model')",
+    { timeoutMs: 60_000, label: "workspace route or model onboarding" },
+  );
+  await ctx.clickText("Skip and use the free model", { timeoutMs: 10_000 }).catch(() => {});
   await ctx.waitFor("window.location.hash.includes('/workspace/')", { timeoutMs: 60_000, label: "workspace route" });
   await ctx.eval(`(() => {
     const button = [...document.querySelectorAll("button")].find((candidate) => candidate.textContent.trim() === "Continue without OpenWork Models");

--- a/evals/flows/chat-connection-reconnect-card.flow.mjs
+++ b/evals/flows/chat-connection-reconnect-card.flow.mjs
@@ -1,0 +1,98 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/chat-connection-reconnect-card.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("chat-connection-reconnect-card");
+
+export default {
+  id: "chat-connection-reconnect-card",
+  title: "TODO: one-line claim — user can do X and sees Y",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 1", {
+          voiceover: vo[0],
+          // "I ask my agent to pull my latest meeting notes, not knowing the connector's "
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 1 not implemented yet");
+          },
+          screenshot: { name: "frame-1", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 2", {
+          voiceover: vo[1],
+          // "Instead of a wall of JSON, the chat shows me a card that says it plainly: Gr"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 2 not implemented yet");
+          },
+          screenshot: { name: "frame-2", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 3", {
+          voiceover: vo[2],
+          // "I click Reconnect and land on the Connections page with the broken connector"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 3 not implemented yet");
+          },
+          screenshot: { name: "frame-3", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 4", {
+          voiceover: vo[3],
+          // "When the problem isn't mine to fix, the card says so honestly — it names who"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 4 not implemented yet");
+          },
+          screenshot: { name: "frame-4", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 5", {
+          voiceover: vo[4],
+          // "And for anyone who wants the raw details, the full technical payload is stil"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 5 not implemented yet");
+          },
+          screenshot: { name: "frame-5", requireText: [] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/chat-connection-reconnect-card.flow.mjs
+++ b/evals/flows/chat-connection-reconnect-card.flow.mjs
@@ -70,12 +70,12 @@ async function signDesktopIntoCloud(ctx) {
     timeoutMs: 90_000,
     label: "Electron control and desktop bridge",
   });
-  const bootstrap = { baseUrl: DEN_API_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
+  const bootstrap = { baseUrl: DEN_WEB_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
   const written = await ctx.eval(`(async () => {
     const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
     if (!bridge) return false;
     await bridge("setDesktopBootstrapConfig", ${JSON.stringify(bootstrap)});
-    localStorage.setItem("openwork.den.baseUrl", ${JSON.stringify(DEN_API_URL)});
+    localStorage.setItem("openwork.den.baseUrl", ${JSON.stringify(DEN_WEB_URL)});
     localStorage.setItem("openwork.den.apiBaseUrl", ${JSON.stringify(DEN_API_URL)});
     localStorage.removeItem("openwork.den.authToken");
     localStorage.removeItem("openwork.den.activeOrgId");
@@ -97,7 +97,7 @@ async function signDesktopIntoCloud(ctx) {
     body: JSON.stringify({ desktopScheme: "openwork" }),
   });
   ctx.assert(handoff.response.ok, `Desktop handoff failed: ${handoff.response.status}`);
-  await ctx.control("auth.exchange-grant", { grant: handoff.body.grant, baseUrl: DEN_API_URL });
+  await ctx.control("auth.exchange-grant", { grant: handoff.body.grant, baseUrl: DEN_WEB_URL });
   await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", {
     timeoutMs: 60_000,
     label: "active cloud organization",

--- a/evals/voiceovers/chat-connection-reconnect-card.md
+++ b/evals/voiceovers/chat-connection-reconnect-card.md
@@ -1,0 +1,19 @@
+# chat-connection-reconnect-card — when a connector breaks mid-chat, the chat itself gets you reconnected
+
+Cloud MCP tool results already carry a structured `connection_status` payload
+when a connector needs re-authentication (expired OAuth grant, rejected token
+refresh, provider-side outage). Today that payload renders as raw JSON inside
+the tool part, and the user has no idea what to do next. This flow turns it
+into an actionable card in the conversation, reusing the existing Connect
+machinery (`needsReconnect`, member-scoped non-destructive disconnect, the
+amber Reconnect row) — no new stores, no new API surface.
+
+1. I ask my agent to pull my latest meeting notes, not knowing the connector's login quietly expired behind the scenes.
+
+2. Instead of a wall of JSON, the chat shows me a card that says it plainly: Granola needs me to sign in again — with a Reconnect button right there in the conversation.
+
+3. I click Reconnect and land on the Connections page with the broken connector highlighted, one click away from signing back in.
+
+4. When the problem isn't mine to fix, the card says so honestly — it names who has to act and hands me the diagnostic reference to copy for support.
+
+5. And for anyone who wants the raw details, the full technical payload is still one click away under a disclosure — nothing is hidden, it's just no longer the default.

--- a/evals/voiceovers/chat-connection-reconnect-card.md
+++ b/evals/voiceovers/chat-connection-reconnect-card.md
@@ -8,12 +8,12 @@ into an actionable card in the conversation, reusing the existing Connect
 machinery (`needsReconnect`, member-scoped non-destructive disconnect, the
 amber Reconnect row) — no new stores, no new API surface.
 
-1. I ask my agent to pull my latest meeting notes, not knowing the connector's login quietly expired behind the scenes.
+1. I ask the agent for my latest Granola notes.
 
-2. Instead of a wall of JSON, the chat shows me a card that says it plainly: Granola needs me to sign in again — with a Reconnect button right there in the conversation.
+2. A polished, compact connection card appears with a clear Granola identity, a calm status treatment, a concise explanation, and one obvious action: Reconnect.
 
-3. I click Reconnect and land on the Connections page with the broken connector highlighted, one click away from signing back in.
+3. Reconnect takes me directly to the highlighted Granola connection.
 
-4. When the problem isn't mine to fix, the card says so honestly — it names who has to act and hands me the diagnostic reference to copy for support.
+4. If Granola rejects authentication and the provider may be responsible, the card still lets me try reconnecting. It explains that if reconnecting fails again, Granola or my admin may need to fix the provider configuration.
 
-5. And for anyone who wants the raw details, the full technical payload is still one click away under a disclosure — nothing is hidden, it's just no longer the default.
+5. Technical details and the diagnostic reference remain available under a secondary disclosure without dominating the card.


### PR DESCRIPTION
## Summary
- Detect structured `connection_status` payloads from Cloud capability tools and replace raw JSON with a polished, compact recovery card
- Give reconnectable connections a clear provider identity, restrained status treatment, concise explanation, and one primary action
- Member-owned expired sign-in shows **Reconnect <provider>** and deep-links to the highlighted Connect row
- Provider/admin-owned per-member reauth still offers **Try reconnecting to <provider>**, while explaining that another failure may require the provider or organization admin to fix configuration
- Keep the raw payload and copyable diagnostic reference secondary under **Technical details**
- Return `null` for unrelated/healthy tool results so existing rendering remains unchanged
- Add a deterministic dev-only fixture and coded fraimz flow for repeatable Electron validation

Phase 1 of the approved voiceover (`evals/voiceovers/chat-connection-reconnect-card.md`). Inline OAuth + retry and the **Disconnect & reconnect** overflow remain separate follow-ups.

## Validation
- `pnpm --filter @openwork/app test` — 330 pass / 0 fail
- `pnpm --filter @openwork/app typecheck` — clean
- `git diff --check` — clean
- Daytona Electron + seeded Acme Den: 5/5 user-facing frames passed, cleanup passed, voiceover coverage passed
- Electron `35.7.5`, PR commit `bf4bf4378`

## Daytona Proof
- [Open the redesigned fraimz proof](https://8090-djvxvgvfj1wwlx2o.daytonaproxy01.net/validation/pr-2820-chat-connection-reconnect-card-redesign/2026-07-15T23-19-13-567Z/fraimz.html)
- Frames cover the request, polished reconnect card, highlighted Connect row, provider-side caveat with **Try reconnecting**, and secondary technical details
- Every PNG was visually inspected; no native dialogs, unrelated overlays, clipping, or duplicate evidence

The proxy URL remains available while the Daytona sandbox is running; artifacts are persisted on `openwork-eval-artifacts`.