### PR TITLE
fix(app): clarify OpenWork Connect attention tooltip

### DIFF
--- a/apps/app/src/react-app/domains/connections/openwork-connect-status.ts
+++ b/apps/app/src/react-app/domains/connections/openwork-connect-status.ts
@@ -6,6 +6,10 @@ export type OpenWorkConnectStatus = {
   description: string;
 };
 
+export function openWorkConnectAttentionTitle(description: string): string {
+  return `One possible issue: ${description}`;
+}
+
 export function resolveOpenWorkConnectStatus(
   signedIn: boolean,
   maintenance: SessionCloudMcpMaintenanceState | undefined,

--- a/apps/app/src/react-app/domains/session/chat/status-bar.tsx
+++ b/apps/app/src/react-app/domains/session/chat/status-bar.tsx
@@ -22,6 +22,7 @@ import { useShellConfig } from "../../../shell/shell-config";
 import type { OpenworkServerStatus } from "../../../../app/lib/openwork-server";
 import { readDenSettings } from "../../../../app/lib/den";
 import {
+  openWorkConnectAttentionTitle,
   resolveOpenWorkConnectStatus,
   type OpenWorkConnectStatus,
 } from "../../connections/openwork-connect-status";
@@ -102,6 +103,7 @@ function OpenWorkConnectIndicator(props: {
           <button
             type="button"
             data-testid="openwork-connect-status"
+            title={openWorkConnectAttentionTitle(props.status.description)}
             className="rounded-md px-1.5 py-1 transition-colors hover:bg-muted"
           />
         )}

--- a/apps/app/tests/openwork-connect-status.test.ts
+++ b/apps/app/tests/openwork-connect-status.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 
-import { resolveOpenWorkConnectStatus } from "../src/react-app/domains/connections/openwork-connect-status";
+import {
+  openWorkConnectAttentionTitle,
+  resolveOpenWorkConnectStatus,
+} from "../src/react-app/domains/connections/openwork-connect-status";
 import type { SessionCloudMcpMaintenanceState } from "../src/react-app/domains/connections/use-session-mcp-maintenance";
 
 function maintenance(
@@ -23,6 +26,11 @@ function maintenance(
 }
 
 describe("OpenWork Connect status", () => {
+  test("labels the diagnosed message as one possible issue for native tooltips", () => {
+    expect(openWorkConnectAttentionTitle("Connected service tools could not be verified."))
+      .toBe("One possible issue: Connected service tools could not be verified.");
+  });
+
   test("is hidden while signed out", () => {
     expect(resolveOpenWorkConnectStatus(false, maintenance("ready"))).toBeNull();
   });


### PR DESCRIPTION
## Summary

- add a native `title` tooltip to the OpenWork Connect “Needs attention” indicator
- prefix the diagnosed message with “One possible issue” so the status does not imply every connected service is broken
- preserve the existing click-to-open diagnostics popover

## Why

The attention state exposed the diagnostic only through the custom popover and presented it without clarifying that it is one possible cause. Users hovering the status now receive that context through the platform-native tooltip.

## Checks

- `pnpm --filter @openwork/app exec bun test --isolate tests/openwork-connect-status.test.ts` — passed (3 tests)
- `pnpm --filter @openwork/app typecheck` — passed
- `git diff --check` — passed

## Manual verification

Not user-confirmed. Reviewer steps:
1. Sign in to OpenWork Cloud.
2. Put OpenWork Connect into a “Needs attention” state.
3. Hover the footer status and confirm the native tooltip reads `One possible issue: <diagnostic message>`.
4. Click the status and confirm the existing diagnostics popover still opens.

## Risk and untested paths

Low risk: presentation-only change with no MCP, token, server, or cloud-contract behavior changes. A live desktop/fraimz run and screenshots were not captured because visual proof was not separately requested.