### PR TITLE
fix(server): cloud MCP probe transport failures fail open, never manufacture an outage

### DIFF
--- a/apps/server/src/cloud-mcp-health.test.ts
+++ b/apps/server/src/cloud-mcp-health.test.ts
@@ -1,12 +1,20 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import {
+  cloudMcpDeliveryState,
   CloudMcpDeliveryStateStore,
   calculateCloudMcpDesiredRevision,
   OPENWORK_CLOUD_EXPECTED_TOOLS,
+  OPENWORK_CLOUD_PLUGIN_CANARIES,
+  readOpenworkCloudMcpHealth,
 } from "./cloud-mcp-health.js";
 import { sanitizeDiagnosticValue } from "./diagnostic-sanitizer.js";
 import { diagnoseMcpToolDeniesFromConfigs } from "./mcp.js";
-import type { WorkspaceInfo } from "./types.js";
+import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import type { ServerConfig, WorkspaceInfo } from "./types.js";
 
 const workspace: WorkspaceInfo = {
   id: "ws_1",
@@ -15,6 +23,145 @@ const workspace: WorkspaceInfo = {
   preset: "starter",
   workspaceType: "local",
 };
+
+const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+const previousFetch = globalThis.fetch;
+const roots: string[] = [];
+const stops: Array<() => void> = [];
+
+type DirectProbeMode = "ok" | "missing" | "unauthorized";
+
+afterEach(async () => {
+  globalThis.fetch = previousFetch;
+  cloudMcpDeliveryState.clear();
+  while (stops.length) stops.pop()?.();
+  while (roots.length) await rm(roots.pop() ?? "", { recursive: true, force: true });
+  if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+});
+
+async function createRoot(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  roots.push(root);
+  return root;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function startMockOpencode(mode: DirectProbeMode) {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === "/global/health") return Response.json({ healthy: true, version: "1.17.11" });
+      if (url.pathname === "/mcp" && request.method === "GET") return Response.json({ "openwork-cloud": { status: "connected" } });
+      if (url.pathname === "/experimental/tool/ids") return Response.json([...OPENWORK_CLOUD_EXPECTED_TOOLS, ...OPENWORK_CLOUD_PLUGIN_CANARIES]);
+      if (url.pathname === "/cloud-mcp/mcp/agent" && request.method === "POST") {
+        if (mode === "unauthorized") return Response.json({ error: "invalid token" }, { status: 401 });
+        const body: unknown = await request.json();
+        const id = isRecord(body) && (typeof body.id === "string" || typeof body.id === "number" || body.id === null) ? body.id : 1;
+        if (isRecord(body) && body.method === "notifications/initialized") return new Response(null, { status: 202 });
+        if (isRecord(body) && body.method === "initialize") {
+          return Response.json({
+            id,
+            jsonrpc: "2.0",
+            result: {
+              capabilities: { tools: {} },
+              protocolVersion: "2025-06-18",
+              serverInfo: { name: "openwork-cloud-test", version: "1.0.0" },
+            },
+          });
+        }
+        if (isRecord(body) && body.method === "tools/list") {
+          const tools = mode === "missing"
+            ? [{ name: "search_capabilities", inputSchema: {} }]
+            : [
+                { name: "search_capabilities", inputSchema: {} },
+                { name: "execute_capability", inputSchema: {} },
+              ];
+          return Response.json({ id, jsonrpc: "2.0", result: { tools } });
+        }
+        return Response.json({ id, jsonrpc: "2.0", result: {} });
+      }
+      return Response.json({ code: "not_found" }, { status: 404 });
+    },
+  });
+  stops.push(() => server.stop(true));
+  return server;
+}
+
+function serverConfig(root: string, testWorkspace: WorkspaceInfo): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_health_client",
+    hostToken: "owt_health_host",
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [testWorkspace],
+    authorizedRoots: [testWorkspace.path],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  } satisfies ServerConfig;
+}
+
+async function readHealthForDirectProbe(mode: DirectProbeMode, beforeRead?: (directUrl: string) => void) {
+  const root = await createRoot("openwork-cloud-health-");
+  const engine = startMockOpencode(mode);
+  const baseUrl = `http://127.0.0.1:${engine.port}`;
+  const directUrl = `${baseUrl}/cloud-mcp/mcp/agent`;
+  const testWorkspace: WorkspaceInfo = {
+    id: `ws_${mode}`,
+    name: `Workspace ${mode}`,
+    path: root,
+    preset: "starter",
+    workspaceType: "local",
+    baseUrl,
+  };
+  const config = serverConfig(root, testWorkspace);
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  await writeRuntimeOpencodeConfig(config, testWorkspace.id, (current) => ({
+    ...current,
+    mcp: {
+      ...current.mcp,
+      "openwork-cloud": {
+        type: "remote",
+        url: directUrl,
+        enabled: true,
+        headers: { Authorization: "Bearer owt_health_cloud_token" },
+        oauth: false,
+      },
+    },
+  }));
+  beforeRead?.(directUrl);
+  const health = await readOpenworkCloudMcpHealth({
+    config,
+    workspace: testWorkspace,
+    directory: root,
+    createWorkspaceOpencodeClient: () => createOpencodeClient({ baseUrl }),
+  });
+  return { health, directUrl };
+}
+
+function makeDirectProbeThrow(directUrl: string): void {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = Object.assign(
+    (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === directUrl) return Promise.reject(new Error("fetch failed"));
+      return originalFetch(input, init);
+    },
+    { preconnect: originalFetch.preconnect },
+  );
+}
 
 describe("cloud MCP health foundation", () => {
   test("sanitizes nested diagnostics and never returns raw authorization tokens", () => {
@@ -132,5 +279,34 @@ describe("cloud MCP health foundation", () => {
     });
 
     expect(denies).toEqual([]);
+  });
+
+  test("keeps Cloud usable when only the direct probe transport is unreachable", async () => {
+    const { health } = await readHealthForDirectProbe("ok", makeDirectProbeThrow);
+
+    expect(health.usable).toBe(true);
+    expect(health.phase).toBe("ready");
+    expect(health.firstFailure).toBeNull();
+    expect(health.tools.missing).toEqual([]);
+    expect(health.tools.direct.checked).toBe(false);
+    expect(health.tools.direct.missing).toEqual([]);
+    expect(health.tools.direct.failure?.code).toBe("probe_unreachable");
+    expect(health.delivery.appliedRevision).toBe(health.desired.revision);
+  });
+
+  test("still fails closed when the direct probe receives HTTP 401", async () => {
+    const { health } = await readHealthForDirectProbe("unauthorized");
+
+    expect(health.usable).toBe(false);
+    expect(health.firstFailure?.code).toBe("invalid_mcp_token");
+  });
+
+  test("still reports missing Cloud tools when tools/list completes without required tools", async () => {
+    const { health } = await readHealthForDirectProbe("missing");
+
+    expect(health.usable).toBe(false);
+    expect(health.firstFailure?.code).toBe("cloud_tools_missing");
+    expect(health.tools.direct.checked).toBe(true);
+    expect(health.tools.direct.missing).toEqual(["execute_capability"]);
   });
 });

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -81,6 +81,7 @@ export type CloudMcpFailureCode =
   | "cloud_tools_denied"
   | "opencode_tool_ids_unsupported"
   | "opencode_tool_ids_unavailable"
+  | "probe_unreachable"
   | "cloud_tools_missing"
   | "provider_projection_unavailable"
   | "provider_projection_missing"
@@ -228,6 +229,7 @@ export type CloudMcpHealth = {
       present: string[];
       missing: string[];
       error?: unknown;
+      failure?: CloudMcpFailure;
     };
     providerProjection: {
       checked: boolean;
@@ -516,6 +518,38 @@ export const cloudMcpDeliveryState = new CloudMcpDeliveryStateStore();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+type CloudProbeFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+let cloudProbeFetchPromise: Promise<CloudProbeFetch> | undefined;
+
+function globalCloudProbeFetch(input: string, init?: RequestInit): Promise<Response> {
+  return globalThis.fetch(input, init);
+}
+
+function hasElectronNetFetch(value: unknown): value is { net: { fetch: CloudProbeFetch } } {
+  return isRecord(value) && isRecord(value.net) && typeof value.net.fetch === "function";
+}
+
+async function resolveCloudProbeFetch(): Promise<CloudProbeFetch> {
+  if (!process.versions.electron) return globalCloudProbeFetch;
+  try {
+    const moduleName = "electron";
+    const mod: unknown = await import(moduleName);
+    if (hasElectronNetFetch(mod)) {
+      const { net } = mod;
+      return (input, init) => net.fetch(input, init);
+    }
+  } catch {
+    // Fall through to Node/Bun fetch when Electron is unavailable in tests or bundlers.
+  }
+  return globalCloudProbeFetch;
+}
+
+function cloudProbeFetch(input: string, init?: RequestInit): Promise<Response> {
+  cloudProbeFetchPromise ??= resolveCloudProbeFetch();
+  return cloudProbeFetchPromise.then((resolvedFetch) => resolvedFetch(input, init));
 }
 
 function hashString(value: string): string {
@@ -1068,7 +1102,7 @@ async function mcpJsonRpcPost(input: {
   headers: Record<string, string>;
   body: unknown;
 }): Promise<{ response: Response; payload: unknown }> {
-  const response = await withCloudEndpointProbeTimeout((signal) => fetch(input.url, {
+  const response = await withCloudEndpointProbeTimeout((signal) => cloudProbeFetch(input.url, {
     method: "POST",
     headers: input.headers,
     body: JSON.stringify(input.body),
@@ -1107,7 +1141,8 @@ function directToolsNotChecked(): DirectCloudToolsSnapshot {
 }
 
 function toolsFromDirectCloudTools(directTools: DirectCloudToolsSnapshot): ToolSnapshot {
-  if (directTools.checked && directTools.missing.length === 0) {
+  if (!directTools.checked) return { expected: expectedTools(), present: [], missing: [] };
+  if (directTools.missing.length === 0) {
     return splitPresentMissing(directTools.present.map(prefixedCloudToolId), expectedTools());
   }
   return splitPresentMissing([], expectedTools());
@@ -1163,7 +1198,7 @@ async function readDirectCloudTools(config: Record<string, unknown>): Promise<Di
       ...(sessionId ? { "mcp-session-id": sessionId } : {}),
       ...(protocolVersion ? { "mcp-protocol-version": protocolVersion } : {}),
     };
-    await withCloudEndpointProbeTimeout((signal) => fetch(url, {
+    await withCloudEndpointProbeTimeout((signal) => cloudProbeFetch(url, {
       method: "POST",
       headers: sessionHeaders,
       body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }),
@@ -1194,12 +1229,18 @@ async function readDirectCloudTools(config: Record<string, unknown>): Promise<Di
     }
     return directToolsFromNames(toolNames.names);
   } catch (error) {
-    const failureResult = directCloudToolsFailure({
+    // Field incident (corporate Windows, TLS interception): a probe transport
+    // failure must never be reported as missing tools — the engine's own MCP
+    // connection uses a different network stack and is authoritative.
+    const failureResult = failure({
+      code: "probe_unreachable",
+      stage: "tool_registration",
       retryable: true,
-      message: "The OpenWork Cloud MCP endpoint direct tools/list probe did not complete.",
+      recommendedAction: "Check this machine's network path (proxy/TLS trust) to the Cloud MCP endpoint. The engine's own MCP connection is authoritative.",
+      message: "The OpenWork server could not reach the Cloud MCP endpoint for direct verification (transport error before any HTTP response). This does not indicate missing tools.",
       details: { endpoint, error: error instanceof Error ? error.message : String(error) },
     });
-    return { ...directToolsNotChecked(), checked: true, missing: expectedDirectToolNames(), error: failureResult.details, failure: failureResult };
+    return { ...directToolsNotChecked(), checked: false, missing: [], error: failureResult.details, failure: failureResult };
   }
 }
 
@@ -1565,7 +1606,10 @@ async function inspectOpenworkCloud(input: {
   const experimentalToolIds = experimentalToolIdsFromSplit(splitPresentMissing(ids, expectedTools()));
   const pluginCanaries = splitPresentMissing(ids, expectedCanaries());
   const directTools = await readDirectCloudTools(input.desiredConfig);
-  if (directTools.failure) failures.push(directTools.failure);
+  // The engine is authoritative; a probe-only transport failure must stay diagnostic and not veto steering/delivery.
+  if (directTools.failure && directTools.failure.code !== "probe_unreachable") {
+    failures.push(directTools.failure);
+  }
   const tools = toolsFromDirectCloudTools(directTools);
 
   const providerProjection = input.providerModel
@@ -1883,6 +1927,7 @@ export async function readOpenworkCloudMcpHealth(input: {
         present: inspection.directTools.present,
         missing: inspection.directTools.missing,
         ...(inspection.directTools.error ? { error: inspection.directTools.error } : {}),
+        ...(inspection.directTools.failure ? { failure: inspection.directTools.failure } : {}),
       },
       providerProjection: {
         checked: inspection.providerProjection.checked,

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
@@ -130,6 +130,61 @@ describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
     })), connectCatalogEnabled: false })).toBe(OPENWORK_CONNECT_DISABLED_INSTRUCTION);
   });
 
+  test("fails open for probe-side failures when the engine is connected", () => {
+    expect(composeOpenWorkExtensionDiscoveryInstruction(state(health({
+      usable: false,
+      phase: "ready",
+      engine: { status: "connected" },
+      firstFailure: {
+        code: "probe_unreachable",
+        stage: "tool_registration",
+        recommendedAction: "Check network",
+        message: "probe failed",
+      },
+    })))).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
+
+    expect(composeOpenWorkExtensionDiscoveryInstruction(state(health({
+      usable: false,
+      phase: "cloud_tools_missing",
+      engine: { status: "connected" },
+      firstFailure: {
+        code: "cloud_tools_missing",
+        stage: "tool_registration",
+        recommendedAction: "Run reconcile",
+        message: "missing",
+      },
+    })))).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
+  });
+
+  test("keeps degraded steering for cloud_tools_missing unless the engine is connected", () => {
+    const withoutEngine = composeOpenWorkExtensionDiscoveryInstruction(state(health({
+      usable: false,
+      phase: "cloud_tools_missing",
+      firstFailure: {
+        code: "cloud_tools_missing",
+        stage: "tool_registration",
+        recommendedAction: "Run reconcile",
+        message: "missing",
+      },
+    })));
+    const failedEngine = composeOpenWorkExtensionDiscoveryInstruction(state(health({
+      usable: false,
+      phase: "cloud_tools_missing",
+      engine: { status: "failed" },
+      firstFailure: {
+        code: "cloud_tools_missing",
+        stage: "tool_registration",
+        recommendedAction: "Run reconcile",
+        message: "missing",
+      },
+    })));
+
+    expect(withoutEngine).toContain("Settings → Connect → Repair and test");
+    expect(withoutEngine).toContain("cloud_tools_missing");
+    expect(failedEngine).toContain("Settings → Connect → Repair and test");
+    expect(failedEngine).toContain("cloud_tools_missing");
+  });
+
   test("treats unknown workspace as degraded instead of borrowing another workspace", () => {
     const instruction = composeOpenWorkExtensionDiscoveryInstruction({
       ...state(null),

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
@@ -42,6 +42,9 @@ export type OpenWorkCloudHealthSummary = {
   delivery?: {
     appliedRevision?: string | null;
   };
+  engine?: {
+    status?: string;
+  };
   firstFailure: {
     code: string;
     stage: string;
@@ -79,6 +82,9 @@ const cloudHealthSchema = z.object({
   }).passthrough(),
   delivery: z.object({
     appliedRevision: z.string().nullable().optional(),
+  }).passthrough().optional(),
+  engine: z.object({
+    status: z.string().optional(),
   }).passthrough().optional(),
   firstFailure: cloudFailureSchema.nullable(),
 }).passthrough();
@@ -243,6 +249,10 @@ export function composeOpenWorkExtensionDiscoveryInstruction(state: OpenWorkExte
   if (health?.phase === "engine_disabled" || health?.firstFailure?.code === "cloud_mcp_disabled") return OPENWORK_CONNECT_DISABLED_INSTRUCTION;
   if (health) {
     if (!health.desired.present || health.firstFailure?.code === "cloud_mcp_missing") return OPENWORK_CONNECT_SIGN_IN_INSTRUCTION;
+    if (health.engine?.status === "connected" && (health.firstFailure?.code === "probe_unreachable" || health.firstFailure?.code === "cloud_tools_missing")) {
+      // Field incident: the server probe may lack corporate CA trust, so fail open when the engine says MCP is connected.
+      return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
+    }
     return degradedInstruction(health);
   }
   if (!state.connectCatalogEnabled || state.googleWorkspace.legacyConfigured) return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;


### PR DESCRIPTION
## Summary
Root-cause fix for the field incident where a healthy Cloud MCP appeared broken on a corporate Windows machine and the agent refused to use its tools.

**The chain:** the health check's direct `tools/list` probe uses Node fetch (undici), which lacks the OS trust store — behind corporate TLS interception it throws `fetch failed`. That transport error was misclassified as `cloud_tools_missing`, which (a) flipped `usable` to false, (b) kept `delivery.appliedRevision` at `null` forever, and (c) fed the `extensions-preview` steering plugin the degraded per-prompt instruction ('OpenWork Cloud agent access is not ready… Direct the user to Settings → Connect → Repair and test'). The model obeyed our own steering and refused MCP tools that the engine (Bun, OS trust store) had connected and could call the whole time — verified in the field by running the same engine standalone (no `OPENWORK_SERVER_URL` env → neutral steering → tool calls succeeded against the same endpoint, same bearer, same workspace).

## Changes
- `cloud-mcp-health.ts`: transport-thrown probes now produce `probe_unreachable` (new failure code), kept **diagnostic-only** when the engine reports the MCP connected — the engine is authoritative; `usable`/`phase`/delivery now reflect engine reality. Probe failures remain visible in the health JSON (`tools.direct.failure`) for support.
- Probe fetch prefers **Electron `net.fetch`** (Chromium stack, OS trust) when embedded in the desktop app; falls back to global fetch standalone/tests.
- `extensions-preview-steering.ts`: **fail-open guard** — engine connected + probe-side failure (`probe_unreachable`/`cloud_tools_missing`) returns the neutral instruction, never the degraded 'Repair and test' steering. A probe on a different network stack must never talk the model out of tools the engine owns.

## Validation
- `pnpm --filter openwork-server exec bun test src/cloud-mcp-health.test.ts src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts` — 20 pass / 0 fail (new: transport-throw → usable:true + phase:ready + delivery applied + probe_unreachable surfaced; 401 → invalid_mcp_token unchanged; genuine missing tools → cloud_tools_missing unchanged; steering fail-open matrix)
- `pnpm --filter openwork-server test` — full suite 450 tests, 0 fail, 7 skip
- `pnpm --filter openwork-server typecheck` — clean

**Not run:** end-to-end fraimz on a corporate-TLS Windows machine — reproducing the MITM trust condition needs the Daytona Windows cert sandbox (`daytona-windows-cert` skill) or the affected field machine; unit fixtures replicate the exact observed failure mode instead. Field verification plan: install on the affected machine → Advanced diagnostics should show usable with `probe_unreachable` noted under direct tools → the previously refused prompt ('call openwork-cloud_search_capabilities…') should execute without any reconnect/reset.

## Reviewer repro
1. Stub the direct probe fetch to throw + engine mcp status connected → health is usable, delivery applied, probe failure diagnostic-only (see new tests).
2. `composeOpenWorkExtensionDiscoveryInstruction` with engine connected + cloud_tools_missing → neutral instruction (previously degraded).