### PR TITLE
fix(devcontainer): daytona den server restarts actually restart + seedable org mode

### DIFF
--- a/.devcontainer/start-daytona-server.sh
+++ b/.devcontainer/start-daytona-server.sh
@@ -119,7 +119,10 @@ echo "==> Pushing Den DB schema..."
 pnpm --filter @openwork-ee/den-db db:push > /tmp/den-db-push.log 2>&1
 
 echo "==> Starting Den API on :$DEN_API_PORT..."
-pkill -f "ee/apps/den-api/src/main.ts" >/dev/null 2>&1 || true
+# The den-api process cmdline is "tsx watch src/main.ts" (cwd-relative), so a
+# pattern anchored on the repo path never matches and restarts silently keep
+# the old server alive on the port. main.ts is unique to den-api here.
+pkill -f "tsx watch src/main.ts" >/dev/null 2>&1 || true
 nohup env \
   PORT="$DEN_API_PORT" \
   DATABASE_URL="$DATABASE_URL" \
@@ -133,6 +136,7 @@ nohup env \
   PROVISIONER_MODE="$DEN_PROVISIONER_MODE" \
   WORKER_URL_TEMPLATE="$DEN_WORKER_URL_TEMPLATE" \
   DAYTONA_WORKER_PROXY_BASE_URL="$DAYTONA_WORKER_PROXY_BASE_URL" \
+  DEN_ORG_MODE="${DEN_ORG_MODE:-multi_org}" \
   OPENWORK_DEV_MODE="$OPENWORK_DEV_MODE" \
   NODE_OPTIONS="--conditions=development" \
   pnpm --filter @openwork-ee/den-api exec tsx watch src/main.ts > /tmp/den-api.log 2>&1 &
@@ -140,7 +144,7 @@ nohup env \
 wait_for_http "http://127.0.0.1:$DEN_API_PORT/health" "Den API" 180
 
 echo "==> Starting worker proxy on :$DEN_WORKER_PROXY_PORT..."
-pkill -f "ee/apps/den-worker-proxy/src/server.ts" >/dev/null 2>&1 || true
+pkill -f "tsx watch src/server.ts" >/dev/null 2>&1 || true
 nohup env \
   PORT="$DEN_WORKER_PROXY_PORT" \
   DATABASE_URL="$DATABASE_URL" \


### PR DESCRIPTION
## What

Two real failures hit while running the nightly eval suites against a Daytona den server sandbox (`openwork-server-20260715-154537`):

1. **Restarts silently did nothing.** The `pkill -f "ee/apps/den-api/src/main.ts"` pattern never matches the actual cmdline (`tsx watch src/main.ts` — cwd-relative), so re-running `start-daytona-server.sh` left the old den-api holding the port; `wait_for_http` then passed against the stale process and env changes never took effect. Same for the worker proxy pattern. Now matched on the cwd-relative cmdline (`main.ts`/`server.ts` are unique per app in this script).
2. **Fresh sandboxes could not seed.** den-api's `DEN_ORG_MODE` defaults to `single_org`, which blocks the email signups `scripts/seed-demo-org.ts` performs ("Email signup is disabled for this deployment"). The server now defaults to `multi_org` (overridable via env) to match the Acme demo it exists to serve.

Sibling fix for the local eval harness: `DEN_ORG_MODE=multi_org` added to `--stack den` in #2816.

## Tests run

Reproduced + verified on the live sandbox: after killing the stale pids and re-running the script with `DEN_ORG_MODE=multi_org` exported, the new den-api process env shows `DEN_ORG_MODE=multi_org` (checked via /proc/<pid>/environ) and `seed-demo-org.ts --reset` completes: **17 members · 12 teams · 14 plugins**, alex@acme.test sign-in mints a session token. `bash -n` passes. The stale-pkill failure mode was observed live before the fix (old pid kept serving /health after 'restart').