### PR TITLE
fix(den): show reconnect status in green

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -215,7 +215,7 @@ function YourConnectionRow({
             <div className="flex flex-wrap items-center gap-2">
               <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
               {needsReconnect ? (
-                <span className="inline-flex items-center gap-1 rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
                   <AlertTriangle className="h-3 w-3" />
                   Reconnect to grant new permissions
                 </span>


### PR DESCRIPTION
## Summary

- use the emerald status treatment for the “Reconnect to grant new permissions” pill in My connections
- keep the reconnect behavior and surrounding connection states unchanged

## Why

The reconnect prompt was rendered with the amber warning palette even though this state should use the green connection treatment.

## Checks

- `pnpm --filter @openwork-ee/den-web exec tsc --noEmit` — passed
- `git diff --check` — passed

## Manual verification

Not run — dashboard launch and visual verification deferred. To verify, open My connections with a Microsoft 365 connection that requires newly requested permissions and confirm the reconnect pill uses the green palette.

## Risk

Low. This changes two Tailwind color classes on one status pill and does not change connection, OAuth, or permission behavior.
