### PR TITLE
fix(desktop): apply connect link brand icon

### DIFF
--- a/apps/desktop/electron/connect-link-branding.mjs
+++ b/apps/desktop/electron/connect-link-branding.mjs
@@ -1,0 +1,26 @@
+import { desktopBootstrapFromConnectClaims } from "./connect-link.mjs";
+
+/**
+ * @param {Partial<import("@openwork/types/desktop-ipc").DesktopBootstrapConfig>} config
+ * @param {(iconUrl: string) => Promise<unknown>} applyBrandIconUrl
+ */
+export async function applyDesktopBootstrapBrandIcon(config, applyBrandIconUrl) {
+  const iconUrl = typeof config.brandIconUrl === "string" ? config.brandIconUrl.trim() : "";
+  if (!iconUrl) return null;
+  return applyBrandIconUrl(iconUrl);
+}
+
+/**
+ * @param {import("@openwork/types/connect-link").ConnectLinkClaims} claims
+ * @param {{
+ *   persistBootstrap: (
+ *     config: Partial<import("@openwork/types/desktop-ipc").DesktopBootstrapConfig>
+ *   ) => Promise<import("@openwork/types/desktop-ipc").DesktopBootstrapConfig>,
+ *   applyBrandIconUrl: (iconUrl: string) => Promise<unknown>,
+ * }} dependencies
+ */
+export async function persistConnectLinkBranding(claims, dependencies) {
+  const config = await dependencies.persistBootstrap(desktopBootstrapFromConnectClaims(claims));
+  await applyDesktopBootstrapBrandIcon(config, dependencies.applyBrandIconUrl);
+  return config;
+}

--- a/apps/desktop/electron/connect-link.test.mjs
+++ b/apps/desktop/electron/connect-link.test.mjs
@@ -14,6 +14,10 @@ import {
   verifyConnectLinkToken,
   verifyConnectLinkUrl,
 } from "./connect-link.mjs";
+import {
+  applyDesktopBootstrapBrandIcon,
+  persistConnectLinkBranding,
+} from "./connect-link-branding.mjs";
 
 const NOW = 1_783_000_000;
 const KID = "owc-test";
@@ -23,6 +27,10 @@ const { publicKey: publicKeyPem, privateKey: privateKeyPem } = generateKeyPairSy
 });
 const publicKeys = { [KID]: publicKeyPem };
 
+/**
+ * @param {Record<string, unknown>} [overrides]
+ * @returns {import("@openwork/types/connect-link").ConnectLinkClaims}
+ */
 function claims(overrides = {}) {
   return {
     iss: "https://api.openwork.acme.example.com",
@@ -129,6 +137,49 @@ test("resolves a keyless exchange through the exact HTTPS Den endpoint", async (
     brandLogoUrl: "https://assets.acme.example.com/wordmark.svg",
     brandIconUrl: "https://assets.acme.example.com/icon.png",
   });
+});
+
+test("persists accepted connect branding before applying its icon", async () => {
+  const expectedClaims = claims({
+    brand: {
+      appName: "Acme Work",
+      logoUrl: null,
+      iconUrl: "https://assets.acme.example.com/icon.png",
+    },
+  });
+  const calls = [];
+  const config = await persistConnectLinkBranding(expectedClaims, {
+    persistBootstrap: async (nextConfig) => {
+      calls.push({ type: "persist", config: nextConfig });
+      return {
+        ...nextConfig,
+        baseUrl: expectedClaims.den.baseUrl,
+        requireSignin: expectedClaims.requireSignin,
+        writtenAt: "2026-07-15T12:00:00.000Z",
+      };
+    },
+    applyBrandIconUrl: async (iconUrl) => {
+      calls.push({ type: "apply", iconUrl });
+      return { ok: true };
+    },
+  });
+
+  assert.deepEqual(calls.map((call) => call.type), ["persist", "apply"]);
+  assert.equal(calls[1].iconUrl, expectedClaims.brand.iconUrl);
+  assert.equal(config.writtenAt, "2026-07-15T12:00:00.000Z");
+});
+
+test("startup branding applies a saved icon and skips an absent one", async () => {
+  const applied = [];
+  const applyBrandIconUrl = async (iconUrl) => {
+    applied.push(iconUrl);
+    return { ok: true };
+  };
+
+  await applyDesktopBootstrapBrandIcon({ brandIconUrl: "https://assets.acme.example.com/icon.png" }, applyBrandIconUrl);
+  await applyDesktopBootstrapBrandIcon({}, applyBrandIconUrl);
+
+  assert.deepEqual(applied, ["https://assets.acme.example.com/icon.png"]);
 });
 
 test("fails closed for ambiguous, insecure, mismatched, expired, and replayed exchanges", async () => {

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -33,11 +33,14 @@ import { createBrowserPanel } from "./browser-panel.mjs";
 import { createWorkspaceStore } from "./workspace-store.mjs";
 import {
   createConnectLinkReplayGuard,
-  desktopBootstrapFromConnectClaims,
   extractConnectExchange,
   resolveConnectExchangeUrl,
   verifyConnectLinkUrl,
 } from "./connect-link.mjs";
+import {
+  applyDesktopBootstrapBrandIcon,
+  persistConnectLinkBranding,
+} from "./connect-link-branding.mjs";
 import { resolveConnectLinkPublicKeys } from "./connect-link-keys.mjs";
 import { openExternalUrl } from "./open-external.mjs";
 import { fetchAgentContextDiagnosticsResponse } from "./agent-context-diagnostics-fetch.mjs";
@@ -966,7 +969,11 @@ async function acceptConnectLink(rawUrl) {
 }
 
 async function persistConnectLinkClaims(claims) {
-  return workspaceStore.setDesktopBootstrapConfig(desktopBootstrapFromConnectClaims(claims));
+  return persistConnectLinkBranding(claims, {
+    persistBootstrap: (config) => workspaceStore.setDesktopBootstrapConfig(config),
+    applyBrandIconUrl: (iconUrl) => applyBrandIconUrl(iconUrl).catch((error) =>
+      brandIconFailure("connect-apply-failed", error)),
+  });
 }
 
 function normalizePlatform(value) {
@@ -2386,8 +2393,8 @@ if (!app.requestSingleInstanceLock()) {
     if (process.platform === "win32") {
       await registerWindowsDisplayShortcut();
     }
-    if (process.platform === "win32" && bootstrapConfig.brandIconUrl) {
-      await applyBrandIconUrl(bootstrapConfig.brandIconUrl);
+    if (process.platform !== "linux") {
+      await applyDesktopBootstrapBrandIcon(bootstrapConfig, applyBrandIconUrl);
     }
     applicationMenu.install();
     await runtimeManager.prepareFreshRuntime().catch(() => undefined);
@@ -2406,6 +2413,9 @@ if (!app.requestSingleInstanceLock()) {
 
     queueDeepLinks(forwardedDeepLinks(process.argv));
     const win = await createMainWindow();
+    if (process.platform === "linux") {
+      await applyDesktopBootstrapBrandIcon(bootstrapConfig, applyBrandIconUrl);
+    }
     win.webContents.on("did-finish-load", () => {
       flushPendingDeepLinks();
     });


### PR DESCRIPTION
## Summary

- apply an organization icon immediately after a signed or exchange connect link is accepted
- restore a persisted organization icon during macOS startup
- apply persisted Linux branding after the window exists while preserving Windows shortcut setup ordering
- add regression coverage for connect-link persistence/application ordering and startup icon restoration

## Root cause

The connect-link handler persisted `brandIconUrl` into `desktop-bootstrap.json` but never called the desktop icon application path. Startup only restored persisted icons on Windows, so macOS kept the stock Dock icon even after a successful organization handoff.

## User impact

Organization installers now update the running desktop icon as soon as the user confirms the organization link. The saved icon is also restored on the next macOS launch.

## Validation

- `pnpm --filter @openwork/desktop typecheck:electron` — passed
- `pnpm --filter @openwork/desktop check:electron` — passed; 55 renderer methods covered
- `pnpm --filter @openwork/desktop test` — passed; 75 passed, 1 platform-specific skip
- macOS signed-link journey through the real renderer/Electron bridge — passed: link accepted, bootstrap persisted, 460×460 PNG cache created, and Electron reported `applied: true` with no reason
- macOS restart journey with a persisted bootstrap icon — passed: cached icon and sidecar were created before the branded sign-in window opened
- user reproduced the original issue with the signed 0.17.29 installer flow: organization configuration persisted but the Dock icon remained stock

## Risks and gaps

- Windows and Linux were covered by typechecks and desktop tests but were not manually exercised on those operating systems.
- No screenshot or video is attached; the macOS runtime assertions and exact automated checks are recorded above.
