### PR TITLE
feat(app,den-web): hide OpenWork Models surfaces on self-hosted deployments

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -466,6 +466,19 @@ export function denOriginComparisonKey(input: string | null | undefined): string
   }
 }
 
+/**
+ * True when the effective Den control plane is not the hosted OpenWork Cloud
+ * (app.openworklabs.com). Self-hosted deployments point the app at their own
+ * control plane via VITE_DEN_BASE_URL or the desktop bootstrap config, so
+ * hosted-only surfaces (e.g. OpenWork Models upsells) should stay hidden.
+ */
+export function isSelfHostedControlPlane(): boolean {
+  return (
+    denOriginComparisonKey(readDenSettings().baseUrl) !==
+    denOriginComparisonKey(HOSTED_DEFAULT_DEN_BASE_URL)
+  );
+}
+
 export function getDenInferenceUrl(baseUrl?: string | null): string {
   const normalized = normalizeDenBaseUrl(baseUrl ?? readDenSettings().baseUrl) ?? DEFAULT_DEN_BASE_URL;
   return `${normalized}${DEN_INFERENCE_PATH}`;

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
@@ -3,6 +3,7 @@ import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
 import {
   buildDenAuthUrl,
   getDenInferenceUrl,
+  isSelfHostedControlPlane,
   readDenBootstrapConfig,
   readDenSettings,
 } from "../../../app/lib/den";
@@ -18,7 +19,12 @@ export const OPENWORK_MODELS_PROMO_VISIBLE_MS = 14_000;
 export const OPENWORK_MODELS_PROMO_REPEAT_MS = 6 * 60 * 60 * 1000;
 
 export function areOpenWorkModelsPromosDisabled() {
-  return /^(1|true|yes|on)$/i.test(String(import.meta.env.VITE_DISABLE_OPENWORK_MODELS ?? "").trim());
+  if (/^(1|true|yes|on)$/i.test(String(import.meta.env.VITE_DISABLE_OPENWORK_MODELS ?? "").trim())) {
+    return true;
+  }
+  // OpenWork Models are a hosted OpenWork Cloud offering; self-hosted
+  // deployments should never see the upsell surfaces.
+  return isSelfHostedControlPlane();
 }
 
 export type OpenWorkModelPreview = {

--- a/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
+++ b/apps/app/src/react-app/domains/onboarding/provider-selection-step.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/page";
 import { Button } from "@/components/ui/button";
 import { KeyRoundIcon, SkipForwardIcon, SparklesIcon } from "lucide-react";
+import { areOpenWorkModelsPromosDisabled } from "@/react-app/domains/cloud/openwork-models-promo";
 
 type ProviderSelectionStepProps = {
   onOpenWorkModels: () => void;
@@ -21,6 +22,7 @@ export function ProviderSelectionStep({
   onBringYourOwn,
   onSkip,
 }: ProviderSelectionStepProps) {
+  const showOpenWorkModels = !areOpenWorkModelsPromosDisabled();
   return (
     <div className="fixed inset-0 z-50 flex items-center justify-center bg-background">
       <PageBackground />
@@ -35,21 +37,23 @@ export function ProviderSelectionStep({
         </PageHeader>
 
         <div className="space-y-3">
-          <button
-            type="button"
-            className="flex w-full items-start gap-4 rounded-xl border border-blue-7/50 bg-blue-2/30 p-4 text-left transition-colors hover:bg-blue-3/40"
-            onClick={onOpenWorkModels}
-          >
-            <SparklesIcon className="mt-0.5 size-5 shrink-0 text-blue-10" />
-            <div>
-              <div className="text-sm font-medium text-foreground">
-                Use OpenWork Models
+          {showOpenWorkModels ? (
+            <button
+              type="button"
+              className="flex w-full items-start gap-4 rounded-xl border border-blue-7/50 bg-blue-2/30 p-4 text-left transition-colors hover:bg-blue-3/40"
+              onClick={onOpenWorkModels}
+            >
+              <SparklesIcon className="mt-0.5 size-5 shrink-0 text-blue-10" />
+              <div>
+                <div className="text-sm font-medium text-foreground">
+                  Use OpenWork Models
+                </div>
+                <div className="mt-0.5 text-xs text-muted-foreground">
+                  Pay through OpenWork Cloud and skip API key setup.
+                </div>
               </div>
-              <div className="mt-0.5 text-xs text-muted-foreground">
-                Pay through OpenWork Cloud and skip API key setup.
-              </div>
-            </div>
-          </button>
+            </button>
+          ) : null}
 
           <button
             type="button"

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -130,6 +130,7 @@ import { useCheckDesktopRestriction, useDesktopConfig } from "@/react-app/domain
 import { useRestrictionNotice } from "@/react-app/domains/cloud/restriction-notice-provider";
 import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-provider-auto-sync";
 import {
+  areOpenWorkModelsPromosDisabled,
   hasOpenWorkModelsProvider,
   hideOpenWorkModelsPromo,
   isOpenWorkModelsPromoHidden,
@@ -734,7 +735,8 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     (cloudSession.isSignedIn && hasOpenWorkCloudProvider) ||
     hasOpenWorkModelsProvider(providerConnectedIds);
   const showOpenWorkModelsSubscribe = !openWorkModelsConnected && !openWorkModelsPromoHidden;
-  const showOpenWorkModelsConnect = !openWorkModelsConnected && openWorkModelsPromoHidden;
+  const showOpenWorkModelsConnect =
+    !openWorkModelsConnected && openWorkModelsPromoHidden && !areOpenWorkModelsPromosDisabled();
 
   useEffect(() => {
     const handlePromoChanged = () => setOpenWorkModelsPromoHidden(isOpenWorkModelsPromoHidden());

--- a/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
@@ -7,7 +7,8 @@ import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
 import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
-import { getBillingRoute } from "../../_lib/den-org";
+import { getBillingRoute, getCustomLlmProvidersRoute } from "../../_lib/den-org";
+import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 
 type InferenceWindowType = "five_hour" | "weekly" | "monthly";
@@ -226,6 +227,7 @@ function ModelsValueProp(props: {
 
 export function InferenceScreen() {
   const router = useRouter();
+  const { runtimeConfig, runtimeConfigLoaded } = useDenFlow();
   const { activeOrg, orgContext, refreshOrgData, runReauthableAction } = useOrgDashboard();
   const [status, setStatus] = useState<InferenceStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -234,6 +236,15 @@ export function InferenceScreen() {
   const [error, setError] = useState<string | null>(null);
 
   const isOwner = orgContext?.currentMember.isOwner === true;
+  // OpenWork Models are a hosted OpenWork Cloud offering; self-hosted
+  // (single-org) deployments manage their own LLM providers instead.
+  const isSelfHosted = runtimeConfigLoaded && runtimeConfig.orgMode === "single_org";
+  const activeOrgSlug = activeOrg?.slug ?? null;
+
+  useEffect(() => {
+    if (!isSelfHosted) return;
+    router.replace(getCustomLlmProvidersRoute(activeOrgSlug));
+  }, [isSelfHosted, activeOrgSlug, router]);
 
   async function loadStatus() {
     setLoading(true);
@@ -322,6 +333,10 @@ export function InferenceScreen() {
     } catch (saveError) {
       setError(saveError instanceof Error ? saveError.message : "Failed to update inference settings.");
     }
+  }
+
+  if (isSelfHosted) {
+    return null;
   }
 
   const enabled = status?.enabled === true;

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -308,13 +308,21 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
         ],
       }
     : null;
+  // OpenWork Models are a hosted OpenWork Cloud offering; self-hosted
+  // (single-org) deployments only manage their own LLM providers. Default
+  // hidden until the runtime config confirms a hosted (multi-org) deployment.
+  const showOpenWorkModels = runtimeConfigLoaded && runtimeConfig.orgMode === "multi_org";
   const modelsGroup: DashboardNavItem | null = access.isAdmin && activeOrg
     ? {
-        href: getInferenceRoute(activeOrg.slug),
+        href: showOpenWorkModels
+          ? getInferenceRoute(activeOrg.slug)
+          : getCustomLlmProvidersRoute(activeOrg.slug),
         label: "Models",
         icon: Sparkles,
         children: [
-          { href: getInferenceRoute(activeOrg.slug), label: "OpenWork Models" },
+          ...(showOpenWorkModels
+            ? [{ href: getInferenceRoute(activeOrg.slug), label: "OpenWork Models" }]
+            : []),
           { href: getCustomLlmProvidersRoute(activeOrg.slug), label: "LLM Providers" },
         ],
       }

--- a/evals/flows/openwork-models-hidden-self-hosted.flow.mjs
+++ b/evals/flows/openwork-models-hidden-self-hosted.flow.mjs
@@ -10,7 +10,6 @@ const SELF_HOSTED_BASE_URL = "https://den.internal.acme.test";
 const STARTUP_DIALOG_TITLE = "Use OpenWork Models without API keys";
 const DEFAULT_ORG_SERVER_TEXT = "Using standard OpenWork Cloud.";
 const EDITOR_SELECTOR = '[contenteditable="true"][data-lexical-editor="true"]';
-const MSG = "Summarize the quarterly report";
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
@@ -25,6 +24,46 @@ async function reloadApp(ctx) {
 }
 
 /**
+ * Click a button by exact trimmed text through its React onClick prop.
+ * Base UI buttons do not always react to bare DOM .click() under CDP.
+ */
+async function clickReact(ctx, text) {
+  const result = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll("button")].find((el) => (el.textContent ?? "").trim() === ${JSON.stringify(text)} && !el.disabled);
+    if (!button) return "not found";
+    const propsKey = Object.keys(button).find((k) => k.startsWith("__reactProps$"));
+    if (propsKey && button[propsKey]?.onClick) {
+      button[propsKey].onClick({ preventDefault: () => {}, stopPropagation: () => {}, currentTarget: button, target: button });
+      return "react";
+    }
+    button.click();
+    return "dom";
+  })()`);
+  ctx.assert(result !== "not found", `Button not found: ${text}`);
+}
+
+/** Skip through first-run onboarding overlays (provider step + attribution). */
+async function dismissOnboardingOverlays(ctx) {
+  const ATTRIBUTION_TITLE = "How did you hear about OpenWork?";
+  if (await ctx.hasText("Skip and use the free model")) {
+    await clickReact(ctx, "Skip and use the free model");
+    // The attribution step follows the provider choice; wait for it (or for
+    // onboarding to finish straight into a session route).
+    await ctx.waitFor(
+      `document.body.innerText.includes(${JSON.stringify(ATTRIBUTION_TITLE)}) || location.hash.includes("/session") || location.hash.includes("/workspace/")`,
+      { timeoutMs: 20_000, label: "attribution step or session after provider skip" },
+    ).catch(() => {});
+  }
+  if (await ctx.hasText(ATTRIBUTION_TITLE)) {
+    await clickReact(ctx, "Skip");
+    await ctx.waitFor(`!document.body.innerText.includes(${JSON.stringify(ATTRIBUTION_TITLE)})`, {
+      timeoutMs: 15_000,
+      label: "attribution step dismissed",
+    }).catch(() => {});
+  }
+}
+
+/**
  * Idempotent workspace/session bootstrap. Fresh sandboxes land on the welcome
  * route; reruns land straight in a session. Creating through the real modal
  * uses the documented React-fiber folder injection (native pickers cannot run
@@ -34,75 +73,35 @@ async function ensureWorkspaceSession(ctx) {
   await waitForControl(ctx);
   const workspaceDir = ctx.env.OPENWORK_EVAL_WORKSPACE_DIR?.trim() || "/workspace/hello";
 
+  // A previous (failed) run can leave the first-run overlays open; clear them
+  // before deciding which route we are on.
+  await dismissOnboardingOverlays(ctx);
+
   const onWelcome = await ctx.eval(`(() => {
     const text = document.body.innerText;
     return location.hash.includes("/welcome") || text.includes("Pick a folder to get started");
   })()`);
 
   if (onWelcome) {
-    await ctx.clickText("Pick a folder to get started", { timeoutMs: 15_000 });
-    if (await ctx.hasText("Local workspace")) {
-      await ctx.clickText("Local workspace", { timeoutMs: 10_000 });
-    }
-    await sleep(500);
-    const injected = await ctx.eval(`(() => {
-      function fiberOf(el) {
-        const key = Object.keys(el).find((k) => k.startsWith("__reactFiber$"));
-        return key ? el[key] : null;
-      }
-      const scope = document.querySelector('[role="dialog"], [class*="modal" i], [class*="dialog" i]') ?? document.body;
-      let fiber = fiberOf(scope);
-      while (fiber) {
-        const name = (fiber.elementType && fiber.elementType.name) || (fiber.type && fiber.type.name) || "";
-        if (name === "CreateWorkspaceModal") break;
-        fiber = fiber.return;
-      }
-      if (!fiber) {
-        const all = document.querySelectorAll("span,div,p");
-        for (const el of all) {
-          if ((el.textContent || "").includes("No folder")) { fiber = fiberOf(el); break; }
-        }
-        while (fiber) {
-          const name = (fiber.elementType && fiber.elementType.name) || (fiber.type && fiber.type.name) || "";
-          if (name === "CreateWorkspaceModal") break;
-          fiber = fiber.return;
-        }
-      }
-      if (!fiber) return "no CreateWorkspaceModal fiber";
-      let hook = fiber.memoizedState;
-      while (hook) {
-        if (hook.queue && hook.queue.dispatch) {
-          hook.queue.dispatch({ key: "selectedFolder", value: ${JSON.stringify(workspaceDir)} });
-          hook.queue.dispatch({ key: "pickingFolder", value: false });
-          return "injected";
-        }
-        hook = hook.next;
-      }
-      return "no dispatch hook";
-    })()`);
-    ctx.assert(injected === "injected", `Folder injection failed: ${injected}`);
+    // Dev builds expose a manual folder input on the welcome page exactly for
+    // headless/sandbox runs where the native folder picker cannot open.
+    await ctx.waitFor(`Boolean(document.querySelector('input[placeholder="/workspace/my-project"]'))`, {
+      timeoutMs: 15_000,
+      label: "manual folder input on welcome page",
+    });
+    await ctx.fill('input[placeholder="/workspace/my-project"]', workspaceDir);
     await ctx.waitFor(`(() => {
-      const button = [...document.querySelectorAll("button")].find((el) => (el.textContent ?? "").trim().startsWith("Create"));
+      const button = [...document.querySelectorAll("button")].find((el) => (el.textContent ?? "").trim() === "Use this folder");
       return Boolean(button && !button.disabled);
-    })()`, { timeoutMs: 10_000, label: "enabled Create button" });
-    await ctx.eval(`(() => {
-      const button = [...document.querySelectorAll("button")].find((el) => (el.textContent ?? "").trim().startsWith("Create") && !el.disabled);
-      button.click();
-      return true;
-    })()`);
+    })()`, { timeoutMs: 10_000, label: "enabled Use this folder button" });
+    await clickReact(ctx, "Use this folder");
 
     // First-run onboarding after creation: provider step, then attribution.
     await ctx.waitFor(`(() => {
       const text = document.body.innerText;
-      return text.includes("Power your first task") || text.includes("How did you hear") || location.hash.includes("/session");
+      return text.includes("Power your first task") || text.includes("Skip this part") || location.hash.includes("/session");
     })()`, { timeoutMs: 120_000, label: "post-create onboarding surface" });
-    if (await ctx.hasText("Skip and use the free model")) {
-      await ctx.clickText("Skip and use the free model", { selector: "button", timeoutMs: 10_000 });
-    }
-    await sleep(1_000);
-    if (await ctx.hasText("Skip this part")) {
-      await ctx.clickText("Skip", { selector: "button", timeoutMs: 10_000 });
-    }
+    await dismissOnboardingOverlays(ctx);
   }
 
   await ctx.waitFor('location.hash.includes("/session") || location.hash.includes("/workspace/")', {
@@ -166,26 +165,48 @@ async function closeModelPicker(ctx) {
   await sleep(500);
 }
 
-async function openProviderStepViaFirstSend(ctx) {
+/**
+ * Open the provider choice step through the real user journey: reset the
+ * one-shot onboarding latch (labeled setup shortcut), then create a workspace
+ * from the welcome page. The step renders right after creation.
+ */
+async function openProviderStepViaWorkspaceSetup(ctx, workspaceDir) {
+  // Reset the one-shot onboarding latch, then reload so the in-memory
+  // preferences store re-reads it — otherwise the welcome route immediately
+  // redirects back to the session. Navigate to the welcome page only after
+  // boot settles (the boot sequence restores the last session route and would
+  // otherwise race the hash we set).
   await ctx.eval(`(() => {
-    const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
-    if (!editor) throw new Error("composer editor missing");
-    editor.focus();
-    const data = new DataTransfer();
-    data.setData("text/plain", ${JSON.stringify(MSG)});
-    editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+    const raw = localStorage.getItem("openwork.preferences");
+    const prefs = raw ? JSON.parse(raw) : {};
+    prefs.hasCompletedOnboarding = false;
+    localStorage.setItem("openwork.preferences", JSON.stringify(prefs));
     return true;
   })()`);
+  await reloadApp(ctx);
+  await ctx.waitFor('location.hash.includes("/session") || location.hash.includes("/workspace/") || location.hash.includes("/welcome")', {
+    timeoutMs: 60_000,
+    label: "app settled after onboarding-latch reload",
+  });
+  await sleep(2_000);
+  await ctx.navigateHash("/welcome");
+  await ctx.waitFor(`Boolean(document.querySelector('input[placeholder="/workspace/my-project"]'))`, {
+    timeoutMs: 30_000,
+    label: "manual folder input on welcome page",
+  });
+  await sleep(1_000);
+  try {
+    await ctx.fill('input[placeholder="/workspace/my-project"]', workspaceDir);
+  } catch {
+    await sleep(1_500);
+    await ctx.fill('input[placeholder="/workspace/my-project"]', workspaceDir);
+  }
   await ctx.waitFor(`(() => {
-    const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
-    return Boolean(editor && editor.innerText.includes(${JSON.stringify(MSG)}));
-  })()`, { timeoutMs: 30_000, label: "pasted draft in composer" });
-  await ctx.waitFor(`(() => {
-    const buttons = Array.from(document.querySelectorAll("button"));
-    return buttons.some((button) => (button.textContent ?? "").includes("Run task") && !button.disabled);
-  })()`, { timeoutMs: 30_000, label: "enabled Run task button" });
-  await ctx.clickText("Run task", { selector: "button", timeoutMs: 30_000 });
-  await ctx.waitForText("Power your first task", { timeoutMs: 30_000 });
+    const button = [...document.querySelectorAll("button")].find((el) => (el.textContent ?? "").trim() === "Use this folder");
+    return Boolean(button && !button.disabled);
+  })()`, { timeoutMs: 10_000, label: "enabled Use this folder button" });
+  await clickReact(ctx, "Use this folder");
+  await ctx.waitForText("Power your first task", { timeoutMs: 120_000 });
 }
 
 /** Setup shortcut (labeled): reset the one-shot latches this flow proves. */
@@ -274,14 +295,12 @@ export default {
       },
     },
     {
-      name: "Frame 3 — hosted first send offers Use OpenWork Models",
+      name: "Frame 3 — hosted workspace setup offers Use OpenWork Models",
       run: async (ctx) => {
-        await ctx.prove("On the hosted control plane the first-send provider step includes the Use OpenWork Models option", {
+        await ctx.prove("On the hosted control plane the workspace-setup provider step includes the Use OpenWork Models option", {
           voiceover: vo[2],
           action: async () => {
-            await ctx.navigateHash("/");
-            await ensureWorkspaceSession(ctx);
-            await openProviderStepViaFirstSend(ctx);
+            await openProviderStepViaWorkspaceSetup(ctx, "/workspace/hello-hosted");
           },
           assert: async () => {
             await ctx.expectText("Power your first task");
@@ -294,9 +313,7 @@ export default {
             requireText: ["Power your first task", "Use OpenWork Models", "Skip and use the free model"],
           },
         });
-        // Dismiss the step without completing it (keeps providerStepCompleted
-        // unset for the self-hosted phase) by reloading the app.
-        await reloadApp(ctx);
+        await dismissOnboardingOverlays(ctx);
         await ensureWorkspaceSession(ctx);
       },
     },
@@ -382,10 +399,10 @@ export default {
     {
       name: "Frame 7 — self-hosted provider step has no OpenWork Models option",
       run: async (ctx) => {
-        await ctx.prove("Self-hosted: the first-send provider step only offers BYO key and the free model", {
+        await ctx.prove("Self-hosted: the workspace-setup provider step only offers BYO key and the free model", {
           voiceover: vo[6],
           action: async () => {
-            await openProviderStepViaFirstSend(ctx);
+            await openProviderStepViaWorkspaceSetup(ctx, "/workspace/hello-selfhosted");
           },
           assert: async () => {
             await ctx.expectText("Power your first task");
@@ -399,7 +416,7 @@ export default {
             rejectText: ["Use OpenWork Models"],
           },
         });
-        await reloadApp(ctx);
+        await dismissOnboardingOverlays(ctx);
         await ensureWorkspaceSession(ctx);
       },
     },

--- a/evals/flows/openwork-models-hidden-self-hosted.flow.mjs
+++ b/evals/flows/openwork-models-hidden-self-hosted.flow.mjs
@@ -109,6 +109,13 @@ async function ensureWorkspaceSession(ctx) {
     timeoutMs: 120_000,
     label: "workspace session route",
   });
+  if (await ctx.eval('location.hash.includes("/settings")')) {
+    await ctx.navigateHash("/");
+    await ctx.waitFor('location.hash.includes("/session") || location.hash.includes("/workspace/")', {
+      timeoutMs: 60_000,
+      label: "session route after leaving settings",
+    });
+  }
   if (!(await ctx.eval(`Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)}))`))) {
     if (await ctx.hasText("New session")) {
       await ctx.clickText("New session", { timeoutMs: 10_000 });
@@ -365,7 +372,7 @@ export default {
           },
           screenshot: {
             name: "self-hosted-model-picker-clean",
-            requireText: ["Search models..."],
+            requireText: ["All models"],
             rejectText: ["OpenWork Models", "OpenWork hosted"],
           },
         });

--- a/evals/flows/openwork-models-hidden-self-hosted.flow.mjs
+++ b/evals/flows/openwork-models-hidden-self-hosted.flow.mjs
@@ -1,0 +1,428 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script
+// (evals/voiceovers/openwork-models-hidden-self-hosted.md).
+// The runner fails this flow if the narration drifts from that script.
+const FLOW_ID = "openwork-models-hidden-self-hosted";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const SELF_HOSTED_BASE_URL = "https://den.internal.acme.test";
+const STARTUP_DIALOG_TITLE = "Use OpenWork Models without API keys";
+const DEFAULT_ORG_SERVER_TEXT = "Using standard OpenWork Cloud.";
+const EDITOR_SELECTOR = '[contenteditable="true"][data-lexical-editor="true"]';
+const MSG = "Summarize the quarterly report";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForControl(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 90_000, label: "OpenWork control API" });
+}
+
+async function reloadApp(ctx) {
+  await ctx.eval("(() => { location.reload(); return true; })()");
+  await sleep(1_500);
+  await waitForControl(ctx);
+}
+
+/**
+ * Idempotent workspace/session bootstrap. Fresh sandboxes land on the welcome
+ * route; reruns land straight in a session. Creating through the real modal
+ * uses the documented React-fiber folder injection (native pickers cannot run
+ * headless) — labeled as setup, all proof frames afterwards are user-visible.
+ */
+async function ensureWorkspaceSession(ctx) {
+  await waitForControl(ctx);
+  const workspaceDir = ctx.env.OPENWORK_EVAL_WORKSPACE_DIR?.trim() || "/workspace/hello";
+
+  const onWelcome = await ctx.eval(`(() => {
+    const text = document.body.innerText;
+    return location.hash.includes("/welcome") || text.includes("Pick a folder to get started");
+  })()`);
+
+  if (onWelcome) {
+    await ctx.clickText("Pick a folder to get started", { timeoutMs: 15_000 });
+    if (await ctx.hasText("Local workspace")) {
+      await ctx.clickText("Local workspace", { timeoutMs: 10_000 });
+    }
+    await sleep(500);
+    const injected = await ctx.eval(`(() => {
+      function fiberOf(el) {
+        const key = Object.keys(el).find((k) => k.startsWith("__reactFiber$"));
+        return key ? el[key] : null;
+      }
+      const scope = document.querySelector('[role="dialog"], [class*="modal" i], [class*="dialog" i]') ?? document.body;
+      let fiber = fiberOf(scope);
+      while (fiber) {
+        const name = (fiber.elementType && fiber.elementType.name) || (fiber.type && fiber.type.name) || "";
+        if (name === "CreateWorkspaceModal") break;
+        fiber = fiber.return;
+      }
+      if (!fiber) {
+        const all = document.querySelectorAll("span,div,p");
+        for (const el of all) {
+          if ((el.textContent || "").includes("No folder")) { fiber = fiberOf(el); break; }
+        }
+        while (fiber) {
+          const name = (fiber.elementType && fiber.elementType.name) || (fiber.type && fiber.type.name) || "";
+          if (name === "CreateWorkspaceModal") break;
+          fiber = fiber.return;
+        }
+      }
+      if (!fiber) return "no CreateWorkspaceModal fiber";
+      let hook = fiber.memoizedState;
+      while (hook) {
+        if (hook.queue && hook.queue.dispatch) {
+          hook.queue.dispatch({ key: "selectedFolder", value: ${JSON.stringify(workspaceDir)} });
+          hook.queue.dispatch({ key: "pickingFolder", value: false });
+          return "injected";
+        }
+        hook = hook.next;
+      }
+      return "no dispatch hook";
+    })()`);
+    ctx.assert(injected === "injected", `Folder injection failed: ${injected}`);
+    await ctx.waitFor(`(() => {
+      const button = [...document.querySelectorAll("button")].find((el) => (el.textContent ?? "").trim().startsWith("Create"));
+      return Boolean(button && !button.disabled);
+    })()`, { timeoutMs: 10_000, label: "enabled Create button" });
+    await ctx.eval(`(() => {
+      const button = [...document.querySelectorAll("button")].find((el) => (el.textContent ?? "").trim().startsWith("Create") && !el.disabled);
+      button.click();
+      return true;
+    })()`);
+
+    // First-run onboarding after creation: provider step, then attribution.
+    await ctx.waitFor(`(() => {
+      const text = document.body.innerText;
+      return text.includes("Power your first task") || text.includes("How did you hear") || location.hash.includes("/session");
+    })()`, { timeoutMs: 120_000, label: "post-create onboarding surface" });
+    if (await ctx.hasText("Skip and use the free model")) {
+      await ctx.clickText("Skip and use the free model", { selector: "button", timeoutMs: 10_000 });
+    }
+    await sleep(1_000);
+    if (await ctx.hasText("Skip this part")) {
+      await ctx.clickText("Skip", { selector: "button", timeoutMs: 10_000 });
+    }
+  }
+
+  await ctx.waitFor('location.hash.includes("/session") || location.hash.includes("/workspace/")', {
+    timeoutMs: 120_000,
+    label: "workspace session route",
+  });
+  if (!(await ctx.eval(`Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)}))`))) {
+    if (await ctx.hasText("New session")) {
+      await ctx.clickText("New session", { timeoutMs: 10_000 });
+    }
+  }
+  await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)}))`, {
+    timeoutMs: 90_000,
+    label: "composer editor",
+  });
+}
+
+/** Idempotent: make sure the app points at the default hosted control plane. */
+async function ensureHostedControlPlane(ctx) {
+  await ctx.navigateHash("/settings/advanced");
+  await ctx.waitForText("Organization server URL", { timeoutMs: 30_000 });
+  if (!(await ctx.hasText(DEFAULT_ORG_SERVER_TEXT))) {
+    await ctx.clickText("Clear server configuration", { selector: "button", timeoutMs: 10_000 });
+    await ctx.waitForText("Click again to clear", { timeoutMs: 10_000 });
+    await ctx.clickText("Click again to clear", { selector: "button", timeoutMs: 10_000 });
+    await ctx.waitForText(DEFAULT_ORG_SERVER_TEXT, { timeoutMs: 15_000 });
+    await reloadApp(ctx);
+    await ctx.navigateHash("/settings/advanced");
+    await ctx.waitForText(DEFAULT_ORG_SERVER_TEXT, { timeoutMs: 30_000 });
+  }
+}
+
+async function openModelPicker(ctx) {
+  await ctx.waitFor(`Boolean(document.querySelector('button[aria-label="Change model"]'))`, {
+    timeoutMs: 30_000,
+    label: "model picker trigger",
+  });
+  await ctx.eval(`(() => {
+    document.querySelector('button[aria-label="Change model"]').click();
+    return true;
+  })()`);
+  await ctx.waitFor(`Boolean(document.querySelector('input[placeholder="Search models..."]'))`, {
+    timeoutMs: 15_000,
+    label: "model picker popover",
+  });
+}
+
+async function closeModelPicker(ctx) {
+  await ctx.eval(`(() => {
+    const input = document.querySelector('input[placeholder="Search models..."]');
+    (input ?? document.body).dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    return true;
+  })()`);
+  await sleep(500);
+}
+
+async function openProviderStepViaFirstSend(ctx) {
+  await ctx.eval(`(() => {
+    const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+    if (!editor) throw new Error("composer editor missing");
+    editor.focus();
+    const data = new DataTransfer();
+    data.setData("text/plain", ${JSON.stringify(MSG)});
+    editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+    return true;
+  })()`);
+  await ctx.waitFor(`(() => {
+    const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+    return Boolean(editor && editor.innerText.includes(${JSON.stringify(MSG)}));
+  })()`, { timeoutMs: 30_000, label: "pasted draft in composer" });
+  await ctx.waitFor(`(() => {
+    const buttons = Array.from(document.querySelectorAll("button"));
+    return buttons.some((button) => (button.textContent ?? "").includes("Run task") && !button.disabled);
+  })()`, { timeoutMs: 30_000, label: "enabled Run task button" });
+  await ctx.clickText("Run task", { selector: "button", timeoutMs: 30_000 });
+  await ctx.waitForText("Power your first task", { timeoutMs: 30_000 });
+}
+
+/** Setup shortcut (labeled): reset the one-shot latches this flow proves. */
+async function resetPromoLatches(ctx, { startupShown }) {
+  await ctx.eval(`(() => {
+    const raw = localStorage.getItem("openwork.preferences");
+    const prefs = raw ? JSON.parse(raw) : {};
+    delete prefs.providerStepCompleted;
+    localStorage.setItem("openwork.preferences", JSON.stringify(prefs));
+    if (${JSON.stringify(Boolean(startupShown))}) {
+      localStorage.setItem("openwork.openworkModelsPromo.startupShown", "1");
+    } else {
+      localStorage.removeItem("openwork.openworkModelsPromo.startupShown");
+    }
+    localStorage.removeItem("openwork.openworkModelsPromo.hidden");
+    localStorage.removeItem("openwork.openworkModelsPromo.lastShownAt");
+    return true;
+  })()`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Self-hosted control planes hide every OpenWork Models upsell surface; hosted keeps them",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Setup — session ready on the hosted control plane",
+      run: async (ctx) => {
+        await ensureWorkspaceSession(ctx);
+        await ensureHostedControlPlane(ctx);
+        // Labeled setup: pre-mark the startup dialog as shown so it cannot
+        // cover the hosted baseline frames (it gets its own negative proof on
+        // the self-hosted side); reset the promo + provider-step latches this
+        // flow is about to prove.
+        await resetPromoLatches(ctx, { startupShown: true });
+        await reloadApp(ctx);
+        await ensureWorkspaceSession(ctx);
+        ctx.recordEvidence({
+          type: "assertion",
+          status: "passed",
+          assertion: "Setup: session is ready on the default hosted OpenWork Cloud control plane with promo latches reset (startup dialog latch pre-marked for the baseline phase).",
+        });
+      },
+    },
+    {
+      name: "Frame 1 — hosted model picker pitches OpenWork Models",
+      run: async (ctx) => {
+        await ctx.prove("On the hosted control plane the model picker shows the OpenWork Models promo group", {
+          voiceover: vo[0],
+          action: async () => {
+            await openModelPicker(ctx);
+            await ctx.waitForText("OpenWork hosted", { timeoutMs: 15_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("OpenWork Models");
+            await ctx.expectText("OpenWork hosted");
+          },
+          screenshot: {
+            name: "hosted-model-picker-promo",
+            requireText: ["OpenWork Models", "OpenWork hosted"],
+          },
+        });
+        await closeModelPicker(ctx);
+      },
+    },
+    {
+      name: "Frame 2 — hosted Settings > AI shows the subscribe banner",
+      run: async (ctx) => {
+        await ctx.prove("On the hosted control plane Settings > AI offers the OpenWork Models subscription", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.navigateHash("/settings/ai");
+            await ctx.waitForText("OpenWork Models", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("OpenWork Models");
+            await ctx.expectText("Subscribe");
+            await ctx.expectText("Hosted frontier models for OpenWork tasks without managing provider API keys.");
+          },
+          screenshot: {
+            name: "hosted-settings-ai-subscribe",
+            requireText: ["OpenWork Models", "Subscribe"],
+            hashIncludes: "/settings/ai",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — hosted first send offers Use OpenWork Models",
+      run: async (ctx) => {
+        await ctx.prove("On the hosted control plane the first-send provider step includes the Use OpenWork Models option", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.navigateHash("/");
+            await ensureWorkspaceSession(ctx);
+            await openProviderStepViaFirstSend(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("Power your first task");
+            await ctx.expectText("Use OpenWork Models");
+            await ctx.expectText("Bring your own API key");
+            await ctx.expectText("Skip and use the free model");
+          },
+          screenshot: {
+            name: "hosted-provider-step-openwork-models",
+            requireText: ["Power your first task", "Use OpenWork Models", "Skip and use the free model"],
+          },
+        });
+        // Dismiss the step without completing it (keeps providerStepCompleted
+        // unset for the self-hosted phase) by reloading the app.
+        await reloadApp(ctx);
+        await ensureWorkspaceSession(ctx);
+      },
+    },
+    {
+      name: "Frame 4 — point the desktop at a self-hosted organization server",
+      run: async (ctx) => {
+        await ctx.prove("Saving a self-hosted organization server URL switches the desktop's control plane", {
+          voiceover: vo[3],
+          action: async () => {
+            await ctx.navigateHash("/settings/advanced");
+            await ctx.waitForText("Organization server URL", { timeoutMs: 30_000 });
+            await ctx.fill("label input", SELF_HOSTED_BASE_URL);
+            await ctx.clickText("Save", { selector: "button" });
+            await ctx.waitForText(`Current organization server: ${SELF_HOSTED_BASE_URL}`, { timeoutMs: 15_000 });
+          },
+          assert: async () => {
+            await ctx.expectText(`Current organization server: ${SELF_HOSTED_BASE_URL}`);
+          },
+          screenshot: {
+            name: "self-hosted-server-saved",
+            requireText: ["Organization server URL", `Current organization server: ${SELF_HOSTED_BASE_URL}`],
+            hashIncludes: "/settings/advanced",
+          },
+        });
+        // Labeled setup: clear the startup-dialog latch so the self-hosted
+        // phase proves it never auto-opens, then reload so every surface
+        // re-reads the control plane.
+        await resetPromoLatches(ctx, { startupShown: false });
+        await ctx.eval(`(() => { window.location.hash = "#/"; return true; })()`);
+        await reloadApp(ctx);
+      },
+    },
+    {
+      name: "Frame 5 — no startup pitch and no OpenWork Models in Settings > AI",
+      run: async (ctx) => {
+        await ctx.prove("Self-hosted: the startup dialog never auto-opens and Settings > AI drops every OpenWork Models row", {
+          voiceover: vo[4],
+          action: async () => {
+            await ensureWorkspaceSession(ctx);
+            // The startup promo schedules ~900ms after the workspace is ready;
+            // give it several seconds to (not) appear before witnessing.
+            await sleep(6_000);
+            await ctx.expectNoText(STARTUP_DIALOG_TITLE);
+            await ctx.navigateHash("/settings/ai");
+            await ctx.waitForText("Connect provider", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectNoText("OpenWork Models");
+            await ctx.expectNoText("Hosted frontier models");
+          },
+          screenshot: {
+            name: "self-hosted-settings-ai-clean",
+            requireText: ["Connect provider"],
+            rejectText: ["OpenWork Models", "Subscribe"],
+            hashIncludes: "/settings/ai",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 6 — self-hosted model picker has no promo group",
+      run: async (ctx) => {
+        await ctx.prove("Self-hosted: the model picker lists only real providers, no OpenWork Models group", {
+          voiceover: vo[5],
+          action: async () => {
+            await ctx.navigateHash("/");
+            await ensureWorkspaceSession(ctx);
+            await openModelPicker(ctx);
+          },
+          assert: async () => {
+            await ctx.expectNoText("OpenWork hosted");
+            await ctx.expectNoText("OpenWork Models");
+          },
+          screenshot: {
+            name: "self-hosted-model-picker-clean",
+            requireText: ["Search models..."],
+            rejectText: ["OpenWork Models", "OpenWork hosted"],
+          },
+        });
+        await closeModelPicker(ctx);
+      },
+    },
+    {
+      name: "Frame 7 — self-hosted provider step has no OpenWork Models option",
+      run: async (ctx) => {
+        await ctx.prove("Self-hosted: the first-send provider step only offers BYO key and the free model", {
+          voiceover: vo[6],
+          action: async () => {
+            await openProviderStepViaFirstSend(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("Power your first task");
+            await ctx.expectText("Bring your own API key");
+            await ctx.expectText("Skip and use the free model");
+            await ctx.expectNoText("Use OpenWork Models");
+          },
+          screenshot: {
+            name: "self-hosted-provider-step-clean",
+            requireText: ["Power your first task", "Bring your own API key", "Skip and use the free model"],
+            rejectText: ["Use OpenWork Models"],
+          },
+        });
+        await reloadApp(ctx);
+        await ensureWorkspaceSession(ctx);
+      },
+    },
+    {
+      name: "Frame 8 — clearing the server restores the hosted offer",
+      run: async (ctx) => {
+        await ctx.prove("Clearing the server configuration returns to OpenWork Cloud and the subscribe banner comes back", {
+          voiceover: vo[7],
+          action: async () => {
+            await ctx.navigateHash("/settings/advanced");
+            await ctx.waitForText("Clear server configuration", { timeoutMs: 30_000 });
+            await ctx.clickText("Clear server configuration", { selector: "button" });
+            await ctx.waitForText("Click again to clear", { timeoutMs: 10_000 });
+            await ctx.clickText("Click again to clear", { selector: "button" });
+            await ctx.waitForText(DEFAULT_ORG_SERVER_TEXT, { timeoutMs: 15_000 });
+            await reloadApp(ctx);
+            await ctx.navigateHash("/settings/ai");
+            await ctx.waitForText("OpenWork Models", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("OpenWork Models");
+            await ctx.expectText("Subscribe");
+          },
+          screenshot: {
+            name: "hosted-restored-settings-ai",
+            requireText: ["OpenWork Models", "Subscribe"],
+            hashIncludes: "/settings/ai",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/openwork-models-hidden-single-org-dashboard.flow.mjs
+++ b/evals/flows/openwork-models-hidden-single-org-dashboard.flow.mjs
@@ -1,0 +1,115 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denWebUrl, signInViaBrowser } from "./lib/den-web.mjs";
+
+// Narration is loaded from the approved script
+// (evals/voiceovers/openwork-models-hidden-single-org-dashboard.md).
+// The runner fails this flow if the narration drifts from that script.
+const FLOW_ID = "openwork-models-hidden-single-org-dashboard";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const DEMO_EMAIL = process.env.DEN_DEMO_OWNER_EMAIL ?? "alex@acme.test";
+const DEMO_PASSWORD = process.env.DEN_DEMO_OWNER_PASSWORD ?? "OpenWorkDemo123!";
+
+export default {
+  id: FLOW_ID,
+  title: "Single-org (self-hosted) dashboard hides the OpenWork Models nav and page",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Frame 1 — sign in to the self-hosted dashboard",
+      run: async (ctx) => {
+        await ctx.prove("The dashboard is a single-org (self-hosted) deployment and the admin can sign in", {
+          voiceover: vo[0],
+          action: async () => {
+            await signInViaBrowser(ctx, DEMO_EMAIL, DEMO_PASSWORD);
+          },
+          assert: async () => {
+            const config = await ctx.eval(
+              "fetch('/api/runtime-config').then((response) => response.json())",
+              { awaitPromise: true },
+            );
+            ctx.assert(config?.orgMode === "single_org", `Expected single_org runtime config, got ${config?.orgMode}`);
+            ctx.log(`runtime config: ${JSON.stringify(config)}`);
+            await ctx.expectText("Dashboard");
+          },
+          screenshot: {
+            name: "single-org-dashboard-signed-in",
+            requireText: ["Dashboard"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2 — Models nav goes straight to LLM Providers",
+      run: async (ctx) => {
+        await ctx.prove("The Models nav group contains no OpenWork Models entry and lands on LLM Providers", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.waitFor(`(() => {
+              const nav = document.querySelector('nav');
+              if (!nav) return false;
+              const entry = [...nav.querySelectorAll('a, button')].find((el) => (el.textContent ?? '').trim().startsWith('Models'));
+              if (!entry) return false;
+              if (window.location.pathname.includes('custom-llm-providers')) return true;
+              entry.click();
+              return false;
+            })()`, { timeoutMs: 30_000, label: "Models nav clicked -> LLM Providers route" });
+            await ctx.waitForText("LLM Providers", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const nav = await ctx.eval(`(() => {
+              const nav = document.querySelector('nav');
+              const links = [...(nav?.querySelectorAll('a') ?? [])].map((a) => ({
+                text: (a.textContent ?? '').trim(),
+                href: a.getAttribute('href') ?? '',
+              }));
+              return {
+                pathname: window.location.pathname,
+                hasOpenWorkModels: links.some((l) => l.text.includes('OpenWork Models')) || (nav?.innerText ?? '').includes('OpenWork Models'),
+                hasInferenceLink: links.some((l) => l.href.includes('/dashboard/inference')),
+                hasLlmProvidersLink: links.some((l) => l.text.includes('LLM Providers')),
+              };
+            })()`);
+            ctx.assert(nav.pathname.includes("custom-llm-providers"), `Models nav should land on LLM Providers, got ${nav.pathname}`);
+            ctx.assert(nav.hasLlmProvidersLink, "The Models group should still offer LLM Providers.");
+            ctx.assert(!nav.hasOpenWorkModels, "The navigation must not mention OpenWork Models on a self-hosted deployment.");
+            ctx.assert(!nav.hasInferenceLink, "The navigation must not link to /dashboard/inference on a self-hosted deployment.");
+          },
+          screenshot: {
+            name: "single-org-models-nav-llm-providers-only",
+            requireText: ["LLM Providers"],
+            rejectText: ["OpenWork Models"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — direct inference URL bounces to LLM Providers",
+      run: async (ctx) => {
+        await ctx.prove("Visiting /dashboard/inference directly redirects to LLM Providers", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.eval(`(() => { window.location.href = ${JSON.stringify(`${denWebUrl()}/dashboard/inference`)}; return true; })()`);
+            await ctx.waitFor("window.location.pathname.includes('custom-llm-providers')", {
+              timeoutMs: 30_000,
+              label: "redirect to the LLM Providers route",
+            });
+            await ctx.waitForText("LLM Providers", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const pathname = await ctx.eval("window.location.pathname");
+            ctx.assert(pathname.includes("custom-llm-providers"), `Expected the LLM Providers route, got ${pathname}`);
+            await ctx.expectNoText("Subscribe with Stripe");
+            await ctx.expectNoText("The best open-source models, ready for your whole team.");
+          },
+          screenshot: {
+            name: "single-org-inference-redirected",
+            requireText: ["LLM Providers"],
+            rejectText: ["Subscribe with Stripe", "OpenWork Models"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/openwork-models-hidden-self-hosted.md
+++ b/evals/voiceovers/openwork-models-hidden-self-hosted.md
@@ -9,7 +9,7 @@ of those surfaces disappears, and clearing the configuration brings them back.
 
 2. In Settings, the AI page shows the OpenWork Models banner with a Subscribe button.
 
-3. Alex types a first task and presses Run task. The provider choice step opens and offers Use OpenWork Models next to bring-your-own-key and the free model.
+3. When Alex sets up a new workspace, the provider choice step opens and offers Use OpenWork Models next to bring-your-own-key and the free model.
 
 4. Alex goes to Settings Advanced and points the desktop at the company's own self-hosted organization server. The app saves the URL and reloads against the new control plane.
 
@@ -17,6 +17,6 @@ of those surfaces disappears, and clearing the configuration brings them back.
 
 6. The model picker now lists only connected providers. The OpenWork Models group is gone.
 
-7. Pressing Run task on a first message still opens the provider step, but it only offers bring-your-own-key and the free model — no OpenWork Models option.
+7. Setting up another workspace on the self-hosted server still opens the provider step, but it only offers bring-your-own-key and the free model — no OpenWork Models option.
 
 8. Alex clears the server configuration to return to OpenWork Cloud. After a reload, the OpenWork Models subscribe banner is back, confirming hosted deployments are unchanged.

--- a/evals/voiceovers/openwork-models-hidden-self-hosted.md
+++ b/evals/voiceovers/openwork-models-hidden-self-hosted.md
@@ -1,0 +1,22 @@
+# openwork-models-hidden-self-hosted — Self-hosted desktops never see OpenWork Models upsells
+
+This proof runs the real desktop app in a disposable sandbox. On the hosted
+OpenWork Cloud control plane the OpenWork Models offer is visible on every
+surface; after pointing the app at a self-hosted organization server, every one
+of those surfaces disappears, and clearing the configuration brings them back.
+
+1. On OpenWork Cloud, Alex opens the model picker in the composer. The OpenWork Models group sits at the top of the list, pitching hosted frontier models.
+
+2. In Settings, the AI page shows the OpenWork Models banner with a Subscribe button.
+
+3. Alex types a first task and presses Run task. The provider choice step opens and offers Use OpenWork Models next to bring-your-own-key and the free model.
+
+4. Alex goes to Settings Advanced and points the desktop at the company's own self-hosted organization server. The app saves the URL and reloads against the new control plane.
+
+5. Back in the session, the OpenWork Models startup pitch never appears, and the AI settings page no longer mentions OpenWork Models at all — self-hosted deployments only see real providers.
+
+6. The model picker now lists only connected providers. The OpenWork Models group is gone.
+
+7. Pressing Run task on a first message still opens the provider step, but it only offers bring-your-own-key and the free model — no OpenWork Models option.
+
+8. Alex clears the server configuration to return to OpenWork Cloud. After a reload, the OpenWork Models subscribe banner is back, confirming hosted deployments are unchanged.

--- a/evals/voiceovers/openwork-models-hidden-single-org-dashboard.md
+++ b/evals/voiceovers/openwork-models-hidden-single-org-dashboard.md
@@ -1,0 +1,11 @@
+# openwork-models-hidden-single-org-dashboard — Self-hosted dashboard hides OpenWork Models
+
+Runs against the local single-org Den stack (the self-hosted deployment shape):
+den-api plus the den-web dashboard on port 3005, seeded with the Acme Robotics
+demo organization.
+
+1. Alex signs in to the self-hosted OpenWork dashboard. The runtime config reports single-org mode — this is a self-hosted deployment, not OpenWork Cloud.
+
+2. Alex opens the Models section in the sidebar. It goes straight to LLM Providers, and there is no OpenWork Models entry anywhere in the navigation.
+
+3. Even typing the old OpenWork Models address directly bounces Alex to LLM Providers — the hosted-only subscribe page simply does not exist on a self-hosted deployment.


### PR DESCRIPTION
## What

Self-hosted (non-OpenWork-Cloud) deployments no longer see any OpenWork Models upsell surfaces. OpenWork Models are a hosted OpenWork Cloud offering; a deployment pointed at its own control plane should only see real providers.

**Desktop app** — self-hosted = effective Den control-plane origin ≠ `app.openworklabs.com` (new `isSelfHostedControlPlane()` in `den.ts`, folded into the existing `areOpenWorkModelsPromosDisabled()` choke point):
- Model picker promo group, model-picker-modal card, status-bar hint, startup dialog — all silenced via the choke point
- Onboarding "Power your first task" step drops the "Use OpenWork Models" option
- Settings > AI drops both the subscribe banner and the "Not connected / Connect" row (closes a gap where the row showed whenever promos were disabled)

**den-web dashboard** — self-hosted = `runtime-config` `orgMode === "single_org"`:
- "Models" nav group offers only "LLM Providers" (no OpenWork Models child); group href points at LLM Providers
- `/dashboard/inference` redirects to LLM Providers

Genuinely connected `openwork` providers are intentionally **not** filtered from model lists — a self-hosted Den that deliberately provisions the inference proxy keeps working. Only upsells/promos are hidden. The `VITE_DISABLE_OPENWORK_MODELS` build flag still works independently.

## Proof (fraimz)

Two new coded flows + approved voiceovers (posted as comments below, one frame per claim):

- `openwork-models-hidden-self-hosted` — real Electron in a Daytona sandbox: hosted baseline shows the promo group / subscribe banner / "Use OpenWork Models" option; saving a self-hosted Organization server URL in Settings > Advanced hides all of them (incl. startup dialog never auto-opening); clearing the config restores the hosted offer.
- `openwork-models-hidden-single-org-dashboard` — local single-org Den stack (den-api + den-web + seeded Acme org) via headless Chrome: signed-in dashboard, Models nav has no OpenWork Models entry, direct `/dashboard/inference` bounces to LLM Providers.

## Tests run

- `pnpm typecheck` (apps/app) — pass
- `pnpm test` (apps/app) — 320 pass / 0 fail
- `tsc --noEmit` (ee/apps/den-web) — pass
- `pnpm evals --flow openwork-models-hidden-self-hosted --cdp-url <daytona>` — PASSED (8 frames + voiceover coverage)
- `pnpm evals --flow openwork-models-hidden-single-org-dashboard --cdp-url <headless-chrome>` — PASSED (3 frames + voiceover coverage)

Both flows re-run against this exact rebased head; proof comments below.
