### PR TITLE
fix(plugins): steer Cloud tool availability from the engine's own MCP state

### DIFF
--- a/apps/server/src/connect-state.ts
+++ b/apps/server/src/connect-state.ts
@@ -99,8 +99,8 @@ export function googleWorkspaceConnectGuidance(cloudHealthOrReady: CloudMcpHealt
   }
   if (cloudHealthOrReady && typeof cloudHealthOrReady !== "boolean" && cloudHealthOrReady.desired.present) {
     const failure = cloudHealthOrReady.firstFailure;
-    const suffix = failure ? ` Current health check: ${failure.code}; ${failure.recommendedAction}.` : "";
-    return `Google Workspace is connected through OpenWork Connect, but agent access is not ready for this exact workspace. Direct the user to Settings > Connect > Repair and test. Do not substitute docs, browser tools, or Settings > Extensions for the connected-service action.${suffix}`;
+    const suffix = failure ? ` Current health check: ${failure.code}.` : "";
+    return `Google Workspace is connected through OpenWork Connect, but agent access needs attention for this workspace. Direct the user to Settings > Connect.${suffix}`;
   }
   return "Google Workspace is not connected on this device. Direct the user to Settings > Connect to connect their account. Do not direct them to Settings > Extensions.";
 }

--- a/apps/server/src/extensions-connect-gating.test.ts
+++ b/apps/server/src/extensions-connect-gating.test.ts
@@ -293,8 +293,9 @@ describe("Connect-aware legacy extension gating", () => {
 
     const cloudGated = await callCalendarListEvents(base);
     const cloudBody = await readSchema(cloudGated, gatedCallSchema);
-    expect(cloudBody.message).toContain("agent access is not ready for this exact workspace");
-    expect(cloudBody.message).toContain("Repair and test");
+    expect(cloudBody.message).toContain("agent access needs attention for this workspace");
+    expect(cloudBody.message).not.toContain("not ready");
+    expect(cloudBody.message).not.toContain("Repair and test");
     expect(cloudBody.message).toContain("Settings > Connect");
 
     const cloudStatus = await readSchema(

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
@@ -4,7 +4,6 @@ import {
   composeOpenWorkExtensionDiscoveryInstruction,
   composeSteeringFromEngineMcpStatus,
   OPENWORK_CLOUD_CONNECTION_INSTRUCTION,
-  OPENWORK_CONNECT_DEGRADED_INSTRUCTION,
   OPENWORK_CONNECT_DISABLED_INSTRUCTION,
   OPENWORK_CONNECT_SIGN_IN_INSTRUCTION,
   OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION,
@@ -13,6 +12,9 @@ import {
   type OpenWorkEngineMcpStatusClient,
   type OpenWorkExtensionConnectState,
 } from "./openwork-extensions-preview-steering.js";
+
+type CloudHealth = NonNullable<OpenWorkExtensionConnectState["cloudHealth"]>;
+type CloudFailure = NonNullable<CloudHealth["firstFailure"]>;
 
 const originalServerUrl = process.env.OPENWORK_SERVER_URL;
 const originalServerToken = process.env.OPENWORK_SERVER_TOKEN;
@@ -44,6 +46,25 @@ function health(overrides: Partial<NonNullable<OpenWorkExtensionConnectState["cl
   };
 }
 
+function failure(code: string, overrides: Partial<CloudFailure> = {}): CloudFailure {
+  return {
+    code,
+    stage: overrides.stage ?? "test",
+    recommendedAction: overrides.recommendedAction ?? "Check Settings → Connect.",
+    message: overrides.message ?? "test failure",
+  };
+}
+
+function expectNoDegradedSteering(instruction: string): void {
+  expect(instruction).not.toMatch(/not ready/i);
+  expect(instruction).not.toContain("Repair and test");
+  expect(instruction).not.toContain("Do not use OpenWork documentation tools");
+  expect(instruction).not.toContain("Do not substitute docs");
+  expect(instruction).not.toContain("as a substitute for performing an action against a connected service");
+  expect(instruction).not.toMatch(/do NOT use/i);
+  expect(instruction).not.toMatch(/Do not try/);
+}
+
 function state(cloudHealth: OpenWorkExtensionConnectState["cloudHealth"]): OpenWorkExtensionConnectState {
   return {
     connectEnabled: true,
@@ -72,8 +93,9 @@ describe("composeSteeringFromEngineMcpStatus", () => {
     expect(composeSteeringFromEngineMcpStatus("disabled")).toBe(OPENWORK_CONNECT_DISABLED_INSTRUCTION);
     expect(composeSteeringFromEngineMcpStatus("needs_auth")).toBe(OPENWORK_CONNECT_SIGN_IN_INSTRUCTION);
     expect(composeSteeringFromEngineMcpStatus("needs_client_registration")).toBe(OPENWORK_CONNECT_SIGN_IN_INSTRUCTION);
-    expect(composeSteeringFromEngineMcpStatus("failed")).toBe(OPENWORK_CONNECT_DEGRADED_INSTRUCTION);
-    expect(composeSteeringFromEngineMcpStatus(undefined)).toBeNull();
+    expect(composeSteeringFromEngineMcpStatus("failed")).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(composeSteeringFromEngineMcpStatus("starting")).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(composeSteeringFromEngineMcpStatus(undefined)).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
   });
 });
 
@@ -98,7 +120,7 @@ describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
     expect(composeOpenWorkExtensionDiscoveryInstruction({ ...state(health()), googleWorkspace: { legacyConfigured: true } })).toBe(OPENWORK_CLOUD_CONNECTION_INSTRUCTION);
   });
 
-  test("does not claim Cloud readiness when provider projection is missing", () => {
+  test("keeps neutral steering when provider projection is missing", () => {
     const instruction = composeOpenWorkExtensionDiscoveryInstruction(state(health({
       usable: true,
       usableByCurrentModel: false,
@@ -111,12 +133,11 @@ describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
       },
     })));
 
-    expect(instruction).not.toBe(OPENWORK_CLOUD_CONNECTION_INSTRUCTION);
-    expect(instruction).toContain("Settings → Connect → Repair and test");
+    expect(instruction).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
   });
 
-  test("uses degraded, signed-out, and disabled branches", () => {
-    const degraded = composeOpenWorkExtensionDiscoveryInstruction({ ...state(health({
+  test("uses neutral, signed-out, and disabled branches", () => {
+    const neutral = composeOpenWorkExtensionDiscoveryInstruction({ ...state(health({
       usable: false,
       phase: "cloud_tools_missing",
       firstFailure: {
@@ -126,9 +147,7 @@ describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
         message: "missing",
       },
     })), connectCatalogEnabled: false });
-    expect(degraded).toContain("Do not use OpenWork documentation tools, browser tools, or OpenWork UI tools as a substitute");
-    expect(degraded).toContain("Settings → Connect → Repair and test");
-    expect(degraded).toContain("cloud_tools_missing");
+    expect(neutral).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
 
     expect(composeOpenWorkExtensionDiscoveryInstruction({ ...state(health({
       usable: false,
@@ -154,7 +173,7 @@ describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
     })), connectCatalogEnabled: false })).toBe(OPENWORK_CONNECT_DISABLED_INSTRUCTION);
   });
 
-  test("fails open for probe-side failures when the engine is connected", () => {
+  test("keeps neutral steering for probe-side server failures", () => {
     expect(composeOpenWorkExtensionDiscoveryInstruction(state(health({
       usable: false,
       phase: "ready",
@@ -180,7 +199,7 @@ describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
     })))).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
   });
 
-  test("keeps degraded steering for cloud_tools_missing unless the engine is connected", () => {
+  test("keeps neutral steering for cloud_tools_missing regardless of server engine health", () => {
     const withoutEngine = composeOpenWorkExtensionDiscoveryInstruction(state(health({
       usable: false,
       phase: "cloud_tools_missing",
@@ -203,18 +222,74 @@ describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
       },
     })));
 
-    expect(withoutEngine).toContain("Settings → Connect → Repair and test");
-    expect(withoutEngine).toContain("cloud_tools_missing");
-    expect(failedEngine).toContain("Settings → Connect → Repair and test");
-    expect(failedEngine).toContain("cloud_tools_missing");
+    expect(withoutEngine).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(failedEngine).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
   });
 
-  test("treats unknown workspace as degraded instead of borrowing another workspace", () => {
+  test("treats unknown workspace as neutral instead of borrowing another workspace", () => {
     const instruction = composeOpenWorkExtensionDiscoveryInstruction({
       ...state(null),
       workspace: { resolution: "unknown", id: null, directory: "/tmp/unknown", reason: "No workspace has this exact OpenCode directory" },
     });
-    expect(instruction).toBe(OPENWORK_CONNECT_DEGRADED_INSTRUCTION);
+    expect(instruction).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
+  });
+
+  test("never emits degraded wording or no-tool-use guidance", () => {
+    const engineStatuses: Array<string | undefined> = [
+      "connected",
+      "disabled",
+      "needs_auth",
+      "needs_client_registration",
+      "failed",
+      "starting",
+      undefined,
+    ];
+    for (const status of engineStatuses) {
+      expectNoDegradedSteering(composeSteeringFromEngineMcpStatus(status));
+    }
+
+    const fallbackStates: OpenWorkExtensionConnectState[] = [
+      state(health()),
+      state(health({ usableByCurrentModel: null })),
+      state(health({
+        usableByCurrentModel: false,
+        phase: "provider_projection_missing",
+        firstFailure: failure("provider_tool_projection_missing"),
+      })),
+      state(health({
+        usable: false,
+        phase: "engine_disabled",
+        firstFailure: failure("cloud_mcp_disabled"),
+      })),
+      state(health({
+        usable: false,
+        phase: "missing_desired",
+        desired: { present: false, revision: null },
+        firstFailure: failure("cloud_desired_missing"),
+      })),
+      state(health({
+        usable: false,
+        phase: "missing_mcp",
+        firstFailure: failure("cloud_mcp_missing"),
+      })),
+      state(health({
+        usable: false,
+        phase: "probe_unreachable",
+        firstFailure: failure("probe_unreachable"),
+      })),
+      state(health({
+        usable: false,
+        phase: "cloud_tools_missing",
+        firstFailure: failure("cloud_tools_missing"),
+      })),
+      { ...state(null), workspace: { resolution: "unknown", id: null, directory: "/tmp/unknown" } },
+      { ...state(null), connectCatalogEnabled: false },
+      { ...state(null), googleWorkspace: { legacyConfigured: true } },
+      state(null),
+    ];
+    for (const fallbackState of fallbackStates) {
+      expectNoDegradedSteering(composeOpenWorkExtensionDiscoveryInstruction(fallbackState));
+    }
   });
 });
 
@@ -339,7 +414,7 @@ describe("resolveOpenWorkExtensionDiscoveryInstruction", () => {
       context: { directory: "/tmp/ws_1" },
       model: { providerID: "anthropic", modelID: "claude-sonnet-4" },
     };
-    expect(await resolveOpenWorkExtensionDiscoveryInstruction(input, fakeFetch)).toContain("cloud_tools_missing");
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction(input, fakeFetch)).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
     expect(await resolveOpenWorkExtensionDiscoveryInstruction(input, fakeFetch)).toBe(OPENWORK_CLOUD_CONNECTION_INSTRUCTION);
     expect(calls).toBe(2);
     expect(urls).toEqual([

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
@@ -2,6 +2,7 @@ import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
 import {
   composeOpenWorkExtensionDiscoveryInstruction,
+  composeSteeringFromEngineMcpStatus,
   OPENWORK_CLOUD_CONNECTION_INSTRUCTION,
   OPENWORK_CONNECT_DEGRADED_INSTRUCTION,
   OPENWORK_CONNECT_DISABLED_INSTRUCTION,
@@ -9,6 +10,7 @@ import {
   OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION,
   resetOpenWorkExtensionDiscoveryInstructionCacheForTests,
   resolveOpenWorkExtensionDiscoveryInstruction,
+  type OpenWorkEngineMcpStatusClient,
   type OpenWorkExtensionConnectState,
 } from "./openwork-extensions-preview-steering.js";
 
@@ -52,6 +54,28 @@ function state(cloudHealth: OpenWorkExtensionConnectState["cloudHealth"]): OpenW
     googleWorkspace: { legacyConfigured: false },
   };
 }
+
+function engineMcpClient(result: unknown, requests: unknown[] = []): OpenWorkEngineMcpStatusClient {
+  return {
+    mcp: {
+      status: async (request) => {
+        requests.push(request);
+        return result;
+      },
+    },
+  };
+}
+
+describe("composeSteeringFromEngineMcpStatus", () => {
+  test("maps engine MCP statuses to steering instructions", () => {
+    expect(composeSteeringFromEngineMcpStatus("connected")).toBe(OPENWORK_CLOUD_CONNECTION_INSTRUCTION);
+    expect(composeSteeringFromEngineMcpStatus("disabled")).toBe(OPENWORK_CONNECT_DISABLED_INSTRUCTION);
+    expect(composeSteeringFromEngineMcpStatus("needs_auth")).toBe(OPENWORK_CONNECT_SIGN_IN_INSTRUCTION);
+    expect(composeSteeringFromEngineMcpStatus("needs_client_registration")).toBe(OPENWORK_CONNECT_SIGN_IN_INSTRUCTION);
+    expect(composeSteeringFromEngineMcpStatus("failed")).toBe(OPENWORK_CONNECT_DEGRADED_INSTRUCTION);
+    expect(composeSteeringFromEngineMcpStatus(undefined)).toBeNull();
+  });
+});
 
 describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
   test("keeps the fallback instruction byte-identical when state is unavailable or generic discovery is gated", () => {
@@ -195,6 +219,79 @@ describe("composeOpenWorkExtensionDiscoveryInstruction", () => {
 });
 
 describe("resolveOpenWorkExtensionDiscoveryInstruction", () => {
+  test("uses engine connected status without fetching server connect state", async () => {
+    const requests: unknown[] = [];
+    const client = engineMcpClient({ data: { "openwork-cloud": { status: "connected" } } }, requests);
+    let serverFetchCalls = 0;
+    const serverFetch = async (): Promise<Response> => {
+      serverFetchCalls += 1;
+      return Response.json({ message: "unexpected" }, { status: 500 });
+    };
+
+    const instruction = await resolveOpenWorkExtensionDiscoveryInstruction(
+      { context: { directory: "/tmp/ws_1" } },
+      serverFetch,
+      { client, directory: "/tmp/factory" },
+    );
+
+    expect(instruction).toBe(OPENWORK_CLOUD_CONNECTION_INSTRUCTION);
+    expect(requests).toEqual([{ query: { directory: "/tmp/ws_1" } }]);
+    expect(serverFetchCalls).toBe(0);
+  });
+
+  test("uses engine auth-needed status without fetching server connect state", async () => {
+    const client = engineMcpClient({ data: { "openwork-cloud": { status: "needs_auth" } } });
+    let serverFetchCalls = 0;
+    const serverFetch = async (): Promise<Response> => {
+      serverFetchCalls += 1;
+      return Response.json({ message: "unexpected" }, { status: 500 });
+    };
+
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction({}, serverFetch, { client })).toBe(OPENWORK_CONNECT_SIGN_IN_INSTRUCTION);
+    expect(serverFetchCalls).toBe(0);
+  });
+
+  test("fails open without server fetch when engine status lookup errors", async () => {
+    const client: OpenWorkEngineMcpStatusClient = {
+      mcp: {
+        status: async () => {
+          throw new Error("engine unavailable");
+        },
+      },
+    };
+    let serverFetchCalls = 0;
+    const serverFetch = async (): Promise<Response> => {
+      serverFetchCalls += 1;
+      return Response.json({ message: "unexpected" }, { status: 500 });
+    };
+
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction({}, serverFetch, { client })).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(serverFetchCalls).toBe(0);
+  });
+
+  test("falls back to server connect state when engine has no openwork-cloud entry", async () => {
+    process.env.OPENWORK_SERVER_URL = "http://openwork.test";
+    process.env.OPENWORK_SERVER_TOKEN = "test-token";
+    const client = engineMcpClient({ data: { other: { status: "connected" } } });
+    let serverFetchCalls = 0;
+    const serverFetch = async (): Promise<Response> => {
+      serverFetchCalls += 1;
+      return Response.json({
+        ok: true,
+        schemaVersion: 1,
+        connectEnabled: true,
+        connectCatalogEnabled: true,
+        cloudMcpPresent: true,
+        cloudHealth: health(),
+        workspace: { resolution: "resolved", id: "ws_1", directory: "/tmp/ws_1" },
+        googleWorkspace: { legacyConfigured: false },
+      });
+    };
+
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction({ context: { directory: "/tmp/ws_1" } }, serverFetch, { client })).toBe(OPENWORK_CLOUD_CONNECTION_INSTRUCTION);
+    expect(serverFetchCalls).toBe(1);
+  });
+
   test("fetches verified health for the current directory/model without caching stale failures", async () => {
     process.env.OPENWORK_SERVER_URL = "http://openwork.test/";
     process.env.OPENWORK_SERVER_TOKEN = "test-token";

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts
@@ -269,6 +269,18 @@ describe("resolveOpenWorkExtensionDiscoveryInstruction", () => {
     expect(serverFetchCalls).toBe(0);
   });
 
+  test("fails open without server fetch when engine has an unknown openwork-cloud status", async () => {
+    const client = engineMcpClient({ data: { "openwork-cloud": { status: "starting" } } });
+    let serverFetchCalls = 0;
+    const serverFetch = async (): Promise<Response> => {
+      serverFetchCalls += 1;
+      return Response.json({ message: "unexpected" }, { status: 500 });
+    };
+
+    expect(await resolveOpenWorkExtensionDiscoveryInstruction({}, serverFetch, { client })).toBe(UNCHANGED_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(serverFetchCalls).toBe(0);
+  });
+
   test("falls back to server connect state when engine has no openwork-cloud entry", async () => {
     process.env.OPENWORK_SERVER_URL = "http://openwork.test";
     process.env.OPENWORK_SERVER_TOKEN = "test-token";

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
@@ -132,16 +132,13 @@ export const OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION =
   "If the user asks for something you cannot do with obvious built-in tools, check OpenWork extensions before saying the capability is unavailable. Use openwork_extension_list_actions to inspect available extension actions, then call the matching action with openwork_extension_call.";
 
 export const OPENWORK_CLOUD_CONNECTION_INSTRUCTION =
-  "The OpenWork Cloud connection is verified ready for this exact workspace/model. For email (Gmail), calendar, Google Drive, and org-connected services such as Notion, Linear, Slack, etc., FIRST call openwork-cloud_search_capabilities with 2-4 keyword variants, then call openwork-cloud_execute_capability with an exact returned name. Do not claim these are unavailable without searching. OpenWork extensions (openwork_extension_list_actions / openwork_extension_call) remain available for other local actions such as image generation, but do NOT use them for Google Workspace, and never direct the user to Settings > Extensions for Google Workspace; use Settings > Connect. A successful search proves OpenWork Cloud itself is authorized, so never tell the user to reconnect OpenWork Cloud because a downstream connector failed. If a result has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly: use Your Connections for the member, the organization Connections dashboard for an org admin, or the provider admin console for a provider-side failure. After the requested human fixes that connector, search again in the same task. Do not try browser_* or openwork_ui_* workarounds or repeat the same call unchanged; results are live, not cached, so unchanged retries return the same error.";
-
-export const OPENWORK_CONNECT_DEGRADED_INSTRUCTION =
-  `${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION} OpenWork Cloud agent access is not ready for this exact workspace/model. Do not use OpenWork documentation tools, browser tools, or OpenWork UI tools as a substitute for performing an action against a connected service. Direct the user to Settings → Connect → Repair and test.`;
+  "The OpenWork Cloud connection is verified ready for this exact workspace/model. For email (Gmail), calendar, Google Drive, and org-connected services such as Notion, Linear, Slack, etc., FIRST call openwork-cloud_search_capabilities with 2-4 keyword variants, then call openwork-cloud_execute_capability with an exact returned name. Search before claiming these are unavailable. OpenWork extensions (openwork_extension_list_actions / openwork_extension_call) remain available for other local actions such as image generation; use OpenWork Cloud capabilities for Google Workspace. Settings > Connect is the relevant settings surface for Google Workspace. A successful search proves OpenWork Cloud itself is authorized, so a downstream connector failure does not mean OpenWork Cloud needs to be reconnected. If a result has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly: use Your Connections for the member, the organization Connections dashboard for an org admin, or the provider admin console for a provider-side failure. After the requested human fixes that connector, search again in the same task because results are live, not cached, so unchanged retries return the same error.";
 
 export const OPENWORK_CONNECT_SIGN_IN_INSTRUCTION =
   `${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION} OpenWork Cloud is not signed in or no desired agent access configuration exists for this workspace. Direct the user to sign in to OpenWork and connect the service in Settings → Connect.`;
 
 export const OPENWORK_CONNECT_DISABLED_INSTRUCTION =
-  `${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION} OpenWork Cloud agent access is explicitly disabled for this workspace. Explain that the user can enable agent access in Settings → Connect, then use Repair and test.`;
+  `${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION} OpenWork Cloud agent access is explicitly disabled for this workspace. Explain that the user can enable agent access in Settings → Connect.`;
 
 const OPENWORK_CLOUD_MCP_NAME = "openwork-cloud";
 
@@ -288,35 +285,25 @@ async function fetchOpenWorkConnectState(input: unknown, fetcher: OpenWorkFetch)
   };
 }
 
-function degradedInstruction(health: OpenWorkCloudHealthSummary | null): string {
-  if (!health?.firstFailure) return OPENWORK_CONNECT_DEGRADED_INSTRUCTION;
-  return `${OPENWORK_CONNECT_DEGRADED_INSTRUCTION} Current verified health: ${health.firstFailure.code}; ${health.firstFailure.recommendedAction}.`;
-}
-
 export function composeOpenWorkExtensionDiscoveryInstruction(state: OpenWorkExtensionConnectState | null): string {
   if (!state) return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
-  if (state.workspace?.resolution && state.workspace.resolution !== "resolved") return degradedInstruction(null);
+  if (state.workspace?.resolution && state.workspace.resolution !== "resolved") return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
   const health = state.cloudHealth;
   if (health?.usable === true && health.usableByCurrentModel !== false) return OPENWORK_CLOUD_CONNECTION_INSTRUCTION;
-  if (health?.phase === "engine_disabled" || health?.firstFailure?.code === "cloud_mcp_disabled") return OPENWORK_CONNECT_DISABLED_INSTRUCTION;
+  if (health?.phase === "engine_disabled" || health?.firstFailure?.code === "engine_disabled" || health?.firstFailure?.code === "cloud_mcp_disabled") return OPENWORK_CONNECT_DISABLED_INSTRUCTION;
   if (health) {
     if (!health.desired.present || health.firstFailure?.code === "cloud_mcp_missing") return OPENWORK_CONNECT_SIGN_IN_INSTRUCTION;
-    if (health.engine?.status === "connected" && (health.firstFailure?.code === "probe_unreachable" || health.firstFailure?.code === "cloud_tools_missing")) {
-      // Field incident: the server probe may lack corporate CA trust, so fail open when the engine says MCP is connected.
-      return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
-    }
-    return degradedInstruction(health);
+    return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
   }
   if (!state.connectCatalogEnabled || state.googleWorkspace.legacyConfigured) return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
   return OPENWORK_CONNECT_SIGN_IN_INSTRUCTION;
 }
 
-export function composeSteeringFromEngineMcpStatus(status: string | undefined): string | null {
+export function composeSteeringFromEngineMcpStatus(status: string | undefined): string {
   if (status === "connected") return OPENWORK_CLOUD_CONNECTION_INSTRUCTION;
   if (status === "disabled") return OPENWORK_CONNECT_DISABLED_INSTRUCTION;
   if (status === "needs_auth" || status === "needs_client_registration") return OPENWORK_CONNECT_SIGN_IN_INSTRUCTION;
-  if (status === "failed") return OPENWORK_CONNECT_DEGRADED_INSTRUCTION;
-  return null;
+  return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
 }
 
 export function resetOpenWorkExtensionDiscoveryInstructionCacheForTests(): void {
@@ -335,10 +322,7 @@ export async function resolveOpenWorkExtensionDiscoveryInstruction(
       // same in-process MCP state. Server health probes may fail for reasons
       // (for example corporate TLS trust) that do not affect engine tools.
       const engineStatus = await fetchEngineMcpStatus(input, engine);
-      const instruction = engineStatus.found
-        ? composeSteeringFromEngineMcpStatus(engineStatus.status) ?? OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION
-        : null;
-      if (instruction) return instruction;
+      if (engineStatus.found) return composeSteeringFromEngineMcpStatus(engineStatus.status);
     } catch {
       return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
     }

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
@@ -72,6 +72,10 @@ export type OpenWorkEngineMcpStatusSource = {
   directory?: string;
 };
 
+type EngineMcpStatusResult =
+  | { found: true; status: string | undefined }
+  | { found: false };
+
 type ProviderModel = {
   provider: string;
   model: string;
@@ -238,15 +242,15 @@ function engineStatusPayload(result: unknown): unknown {
   return result;
 }
 
-function readEngineMcpStatus(result: unknown): string | undefined {
+function readEngineMcpStatus(result: unknown): EngineMcpStatusResult {
   const entry = getRecordProperty(engineStatusPayload(result), OPENWORK_CLOUD_MCP_NAME);
-  if (entry === undefined) return undefined;
-  if (typeof entry === "string") return readString(entry);
-  return readNestedString(entry, ["status"]);
+  if (entry === undefined) return { found: false };
+  if (typeof entry === "string") return { found: true, status: readString(entry) };
+  return { found: true, status: readNestedString(entry, ["status"]) };
 }
 
-async function fetchEngineMcpStatus(input: unknown, engine: OpenWorkEngineMcpStatusSource): Promise<string | undefined> {
-  if (!engine.client) return undefined;
+async function fetchEngineMcpStatus(input: unknown, engine: OpenWorkEngineMcpStatusSource): Promise<EngineMcpStatusResult> {
+  if (!engine.client) return { found: false };
   const directory = readEngineDirectory(input, engine.directory);
   const request = directory ? { query: { directory } } : undefined;
   return readEngineMcpStatus(await engine.client.mcp.status(request));
@@ -330,7 +334,10 @@ export async function resolveOpenWorkExtensionDiscoveryInstruction(
       // prompt tool list, so tool-availability steering must come from that
       // same in-process MCP state. Server health probes may fail for reasons
       // (for example corporate TLS trust) that do not affect engine tools.
-      const instruction = composeSteeringFromEngineMcpStatus(await fetchEngineMcpStatus(input, engine));
+      const engineStatus = await fetchEngineMcpStatus(input, engine);
+      const instruction = engineStatus.found
+        ? composeSteeringFromEngineMcpStatus(engineStatus.status) ?? OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION
+        : null;
       if (instruction) return instruction;
     } catch {
       return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
@@ -55,6 +55,23 @@ export type OpenWorkCloudHealthSummary = {
 
 type OpenWorkFetch = (url: string, init?: RequestInit) => Promise<Response>;
 
+type EngineMcpStatusRequest = {
+  query?: {
+    directory?: string;
+  };
+};
+
+export type OpenWorkEngineMcpStatusClient = {
+  mcp: {
+    status: (request?: EngineMcpStatusRequest) => Promise<unknown>;
+  };
+};
+
+export type OpenWorkEngineMcpStatusSource = {
+  client?: OpenWorkEngineMcpStatusClient;
+  directory?: string;
+};
+
 type ProviderModel = {
   provider: string;
   model: string;
@@ -121,6 +138,8 @@ export const OPENWORK_CONNECT_SIGN_IN_INSTRUCTION =
 
 export const OPENWORK_CONNECT_DISABLED_INSTRUCTION =
   `${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION} OpenWork Cloud agent access is explicitly disabled for this workspace. Explain that the user can enable agent access in Settings → Connect, then use Repair and test.`;
+
+const OPENWORK_CLOUD_MCP_NAME = "openwork-cloud";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -204,6 +223,35 @@ function errorMessage(payload: unknown, fallback: string): string {
   return getStringProperty(payload, "message") ?? getStringProperty(payload, "code") ?? fallback;
 }
 
+function readEngineDirectory(input: unknown, fallback?: string): string | undefined {
+  const context = readContext(input);
+  return context.directory ?? context.worktree ?? readString(fallback);
+}
+
+function engineStatusPayload(result: unknown): unknown {
+  if (!isRecord(result)) return result;
+  const data = result.data;
+  if (data !== undefined) return data;
+  if (result.error !== undefined) throw new Error("OpenCode MCP status request failed");
+  const responseOk = getRecordProperty(result.response, "ok");
+  if (responseOk === false) throw new Error("OpenCode MCP status request failed");
+  return result;
+}
+
+function readEngineMcpStatus(result: unknown): string | undefined {
+  const entry = getRecordProperty(engineStatusPayload(result), OPENWORK_CLOUD_MCP_NAME);
+  if (entry === undefined) return undefined;
+  if (typeof entry === "string") return readString(entry);
+  return readNestedString(entry, ["status"]);
+}
+
+async function fetchEngineMcpStatus(input: unknown, engine: OpenWorkEngineMcpStatusSource): Promise<string | undefined> {
+  if (!engine.client) return undefined;
+  const directory = readEngineDirectory(input, engine.directory);
+  const request = directory ? { query: { directory } } : undefined;
+  return readEngineMcpStatus(await engine.client.mcp.status(request));
+}
+
 async function fetchOpenWorkConnectState(input: unknown, fetcher: OpenWorkFetch): Promise<OpenWorkExtensionConnectState> {
   const { url, token } = requireOpenWorkServer();
   const context = readContext(input);
@@ -259,11 +307,35 @@ export function composeOpenWorkExtensionDiscoveryInstruction(state: OpenWorkExte
   return OPENWORK_CONNECT_SIGN_IN_INSTRUCTION;
 }
 
+export function composeSteeringFromEngineMcpStatus(status: string | undefined): string | null {
+  if (status === "connected") return OPENWORK_CLOUD_CONNECTION_INSTRUCTION;
+  if (status === "disabled") return OPENWORK_CONNECT_DISABLED_INSTRUCTION;
+  if (status === "needs_auth" || status === "needs_client_registration") return OPENWORK_CONNECT_SIGN_IN_INSTRUCTION;
+  if (status === "failed") return OPENWORK_CONNECT_DEGRADED_INSTRUCTION;
+  return null;
+}
+
 export function resetOpenWorkExtensionDiscoveryInstructionCacheForTests(): void {
   // Retained for older tests; steering is deliberately uncached so repair is observed immediately.
 }
 
-export async function resolveOpenWorkExtensionDiscoveryInstruction(input?: unknown, fetcher: OpenWorkFetch = fetch): Promise<string> {
+export async function resolveOpenWorkExtensionDiscoveryInstruction(
+  input?: unknown,
+  fetcher: OpenWorkFetch = fetch,
+  engine: OpenWorkEngineMcpStatusSource = {},
+): Promise<string> {
+  if (engine.client) {
+    try {
+      // Invariant: the OpenCode engine owns MCP registration and builds the
+      // prompt tool list, so tool-availability steering must come from that
+      // same in-process MCP state. Server health probes may fail for reasons
+      // (for example corporate TLS trust) that do not affect engine tools.
+      const instruction = composeSteeringFromEngineMcpStatus(await fetchEngineMcpStatus(input, engine));
+      if (instruction) return instruction;
+    } catch {
+      return OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION;
+    }
+  }
   try {
     return composeOpenWorkExtensionDiscoveryInstruction(await fetchOpenWorkConnectState(input, fetcher));
   } catch {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -190,6 +190,24 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     expect(output.system.join("\n")).toContain("verified ready for this exact workspace/model");
   });
 
+  test("uses the factory engine client as transform steering source of truth", async () => {
+    const requests: unknown[] = [];
+    const mcp = {
+      result: { data: { "openwork-cloud": { status: "connected" } } },
+      async status(request: unknown) {
+        requests.push(request);
+        return this.result;
+      },
+    };
+    const plugin = await OpenWorkExtensionsPreview({ client: { mcp }, directory: "/tmp/archive" });
+    const output: { system: string[] } = { system: [] };
+
+    await plugin["experimental.chat.system.transform"]({}, output);
+
+    expect(requests).toEqual([{ query: { directory: "/tmp/archive" } }]);
+    expect(output.system.join("\n")).toContain("verified ready for this exact workspace/model");
+  });
+
   test("reads a transcript by session id without opening the UI", async () => {
     startFakeOpenWorkServer();
     const plugin = await OpenWorkExtensionsPreview();

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 
 import { OpenWorkExtensionsPreview } from "./openwork-extensions-preview.js";
 import * as OpenWorkExtensionsPreviewEntry from "./openwork-extensions-preview.js";
+import { OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION } from "./openwork-extensions-preview-steering.js";
 
 const originalServerUrl = process.env.OPENWORK_SERVER_URL;
 const originalServerToken = process.env.OPENWORK_SERVER_TOKEN;
@@ -206,6 +207,27 @@ describe("OpenWorkExtensionsPreview session tools", () => {
 
     expect(requests).toEqual([{ query: { directory: "/tmp/archive" } }]);
     expect(output.system.join("\n")).toContain("verified ready for this exact workspace/model");
+  });
+
+  test("uses neutral transform steering when the engine reports failed Cloud status", async () => {
+    const requests: unknown[] = [];
+    const mcp = {
+      result: { data: { "openwork-cloud": { status: "failed" } } },
+      async status(request: unknown) {
+        requests.push(request);
+        return this.result;
+      },
+    };
+    const plugin = await OpenWorkExtensionsPreview({ client: { mcp }, directory: "/tmp/archive" });
+    const output: { system: string[] } = { system: [] };
+
+    await plugin["experimental.chat.system.transform"]({}, output);
+
+    expect(requests).toEqual([{ query: { directory: "/tmp/archive" } }]);
+    expect(output.system[0]).toBe(OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION);
+    expect(output.system[0]).not.toContain("not ready");
+    expect(output.system[0]).not.toContain("Repair and test");
+    expect(output.system[0]).not.toContain("Do not use OpenWork documentation tools");
   });
 
   test("reads a transcript by session id without opening the UI", async () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -6,6 +6,7 @@ import {
   OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION,
   resolveOpenWorkExtensionDiscoveryInstruction,
   type OpenCodeContext,
+  type OpenWorkEngineMcpStatusClient,
 } from "./openwork-extensions-preview-steering.js";
 
 type ExtensionActionPayload = {
@@ -164,6 +165,20 @@ function optionalStringProperty(value: unknown, key: string): string | undefined
   if (!isRecord(value)) return undefined;
   const property = value[key];
   return typeof property === "string" && property.trim().length > 0 ? property : undefined;
+}
+
+type OpenWorkEngineMcpStatusFunction = OpenWorkEngineMcpStatusClient["mcp"]["status"];
+
+function isOpenWorkEngineMcpStatusFunction(value: unknown): value is OpenWorkEngineMcpStatusFunction {
+  return typeof value === "function";
+}
+
+function readEngineMcpStatusClient(value: unknown): OpenWorkEngineMcpStatusClient | undefined {
+  const client = isRecord(value) ? value.client : undefined;
+  const mcp = isRecord(client) ? client.mcp : undefined;
+  const status = isRecord(mcp) ? mcp.status : undefined;
+  if (!isOpenWorkEngineMcpStatusFunction(status)) return undefined;
+  return { mcp: { status: (request) => status.call(mcp, request) } };
 }
 
 function normalizeOpenCodeContext(value: unknown): OpenCodeContext {
@@ -650,9 +665,15 @@ function contextPayload(context: OpenCodeContext) {
 export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
   const uiControlEnabled = uiControlToolsEnabled();
   const factoryContext = normalizeOpenCodeContext(factoryInput);
+  const engineMcpStatusClient = readEngineMcpStatusClient(factoryInput);
+  const engineMcpStatusDirectory = factoryContext.directory ?? factoryContext.worktree;
   return {
   "experimental.chat.system.transform": async (input: unknown, output: { system: string[] }) => {
-    output.system.push(await resolveOpenWorkExtensionDiscoveryInstruction(mergeTransformInputWithFactoryContext(input, factoryContext)));
+    const mergedInput = mergeTransformInputWithFactoryContext(input, factoryContext);
+    output.system.push(await resolveOpenWorkExtensionDiscoveryInstruction(mergedInput, fetch, {
+      client: engineMcpStatusClient,
+      directory: engineMcpStatusDirectory,
+    }));
     output.system.push(OPENWORK_SESSION_MEMORY_INSTRUCTION);
     output.system.push(OPENWORK_BROWSER_INSTRUCTION);
     if (uiControlEnabled) output.system.push(OPENWORK_UI_CONTROL_INSTRUCTION);


### PR DESCRIPTION
## Summary
Root-cause fix #1 from the corporate-TLS field incident (follow-up to #2823) **plus removal of degraded steering entirely** (maintainer decision after a second live incident where a false server verdict suppressed Cloud tool use while the engine was connected).

Steering now has exactly four outcomes — **ready / sign-in / disabled / neutral** — and is derived from the **engine's own MCP state, in-process** (`client.mcp.status`, directory-scoped):

- `connected` → ready instruction (the only instruction that tells the model to call `openwork-cloud_search_capabilities` / `execute_capability`)
- `needs_auth` / `needs_client_registration` → sign-in
- `disabled` → disabled
- `failed` / unknown / engine error → **neutral** (fail open — never tell the model tools are unavailable based on a derived opinion)
- Engine has no `openwork-cloud` entry → server `/experimental/connect/state` fallback, mapped with the same four outcomes; every non-ready/sign-in/disabled health state → neutral
- `OPENWORK_CONNECT_DEGRADED_INSTRUCTION` ("not ready… Repair and test") is **deleted**; no steering output can ever instruct against tool use. The #2823 probe_unreachable/cloud_tools_missing special-case is subsumed and removed.

## Validation
- `pnpm --filter openwork-server exec bun test src/opencode-plugins/` — 26 pass / 0 fail (all four mappings; connected → ready with zero server fetches; failed/unknown/thrown → neutral; regression test iterates every composed output asserting no 'not ready' / anti-tool-use text)
- `pnpm --filter openwork-server test` — 452 pass / 7 skip / 0 fail; typecheck clean
- Windows enterprise-CA e2e proof (packaged app, real engine, fake corporate CA): see fraimz comment below — packaged steering smoke validated engine-first selection with zero server fetches for engine-known states

Parallel siblings: #2834 (engine-attested health), #2835 (OS-trust egress).