### PR TITLE
feat(den-web): simplify cloud landing page

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -221,7 +221,7 @@ export function AuthPanel({
   const emailFirstContent: PanelContent =
     emailFirstStep === "email"
       ? {
-          title: "Continue to OpenWork.",
+          title: "Start using OpenWork",
           copy: "Enter your email and we'll send you to the right sign-in step.",
           submitLabel: "Next",
         }

--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { PaperMeshGradient } from "@openwork/ui/react";
 import { Dithering } from "@paper-design/shaders-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
@@ -77,7 +76,7 @@ export function AuthScreen() {
   return (
     <section className="den-page flex min-h-[calc(100vh-2.5rem)] w-full items-center justify-center py-3 sm:py-4">
       <div className="den-frame relative mx-auto w-full max-w-[600px] overflow-hidden" data-testid="auth-landing-frame">
-        <div className="grid lg:grid-cols-[2fr_1fr]">
+        <div className="grid lg:grid-cols-[1fr_5fr]">
           <div className="relative hidden min-h-[520px] overflow-hidden lg:block" data-testid="auth-landing-visual">
             <div className="absolute inset-0 z-0">
               <Dithering
@@ -90,18 +89,7 @@ export function AuthScreen() {
                 colorBack="#00000000"
                 colorFront="#FEFEFE"
                 style={{ backgroundColor: "#142033", width: "100%", height: "100%" }}
-              >
-                <PaperMeshGradient
-                  speed={0.1}
-                  distortion={0.8}
-                  swirl={0.1}
-                  grainMixer={0}
-                  grainOverlay={0}
-                  frame={176868.9}
-                  colors={["#0F172A", "#1E40AF", "#4C1D95", "#0F766E"]}
-                  style={{ width: "100%", height: "100%" }}
-                />
-              </Dithering>
+              />
             </div>
           </div>
 

--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -2,27 +2,12 @@
 
 import { PaperMeshGradient } from "@openwork/ui/react";
 import { Dithering } from "@paper-design/shaders-react";
-import { Bot, Boxes, Share, type LucideIcon } from "lucide-react";
 import { usePathname, useRouter } from "next/navigation";
 import { useEffect, useRef } from "react";
 import { isSamePathname } from "../_lib/client-route";
 import { getMcpOAuthSelectOrganizationRoute } from "../_lib/mcp-oauth-route";
 import { useDenFlow } from "../_providers/den-flow-provider";
 import { AuthPanel } from "./auth-panel";
-
-function Feature({ icon: Icon, title, body }: { icon: LucideIcon; title: string; body: string }) {
-  return (
-    <div className="flex flex-col items-start gap-3.5 px-4 py-5 sm:px-5">
-      <span className="flex h-9 w-9 items-center justify-center rounded-xl border border-white/15 bg-white/10 shadow-[inset_0_1px_0_rgba(255,255,255,0.12)] backdrop-blur-md">
-        <Icon className="h-[18px] w-[18px] text-white" strokeWidth={1.75} />
-      </span>
-      <div className="min-w-0">
-        <p className="m-0 text-[13px] font-medium leading-tight text-white">{title}</p>
-        <p className="m-0 mt-1 text-[11.5px] leading-snug text-white/60">{body}</p>
-      </div>
-    </div>
-  );
-}
 
 function SessionStatusPanel({ mode }: { mode: "checking" | "redirecting" }) {
   const status = mode === "checking"
@@ -90,11 +75,10 @@ export function AuthScreen() {
   }, [hasResolvedSession, pathname, resolveUserLandingRoute, router]);
 
   return (
-    <section className="den-page flex w-full items-start py-3 sm:py-4 lg:min-h-[calc(100vh-2.5rem)] lg:items-center">
-      <div className="den-frame relative w-full overflow-hidden">
+    <section className="den-page flex min-h-[calc(100vh-2.5rem)] w-full items-center justify-center py-3 sm:py-4">
+      <div className="den-frame relative mx-auto w-full max-w-[600px] overflow-hidden" data-testid="auth-landing-frame">
         <div className="grid lg:grid-cols-[2fr_1fr]">
-          {/* Brand panel — hidden on mobile; form-only on small screens */}
-          <div className="relative hidden min-h-[220px] overflow-hidden px-6 py-7 sm:px-8 sm:py-9 md:px-10 md:py-10 lg:block lg:min-h-[560px]">
+          <div className="relative hidden min-h-[520px] overflow-hidden lg:block" data-testid="auth-landing-visual">
             <div className="absolute inset-0 z-0">
               <Dithering
                 speed={0}
@@ -119,55 +103,10 @@ export function AuthScreen() {
                 />
               </Dithering>
             </div>
-
-            <div className="relative z-10 flex h-full flex-col">
-              <div className="flex items-center gap-3">
-                <img src="/openwork-logo-transparent.svg" alt="OpenWork" className="h-9 w-auto" />
-                <span className="text-[13px] font-medium text-white/80">OpenWork Cloud</span>
-              </div>
-
-              {/* Spacers split the space below the logo ~1:2, so the headline
-                  starts about a third of the way down and the features sit at
-                  the bottom. */}
-              <div className="flex-[1]" aria-hidden />
-
-              <div className="grid gap-3 sm:gap-4">
-                <h1 className="max-w-[13ch] text-[2rem] font-semibold leading-[0.95] tracking-[-0.06em] text-white sm:text-[2.35rem] md:text-[3rem]">
-                  One setup, every seat.
-                </h1>
-                <p className="max-w-[34rem] text-[14px] leading-6 text-white/80 sm:text-[15px] sm:leading-7">
-                  Configure once. Your whole team gets the same tools, agents, and providers.
-                </p>
-              </div>
-
-              <div className="flex-[2]" aria-hidden />
-
-              <div className="overflow-hidden rounded-[1.5rem] border border-white/10 bg-white/[0.06] backdrop-blur-md">
-                <div className="grid divide-y divide-white/10 sm:grid-cols-3 sm:divide-x sm:divide-y-0">
-                  <Feature
-                    icon={Share}
-                    title="Shared config"
-                    body="Set once, push to the org."
-                  />
-                  <Feature
-                    icon={Bot}
-                    title="Cloud agents"
-                    body="Keep running while you're away."
-                  />
-                  <Feature
-                    icon={Boxes}
-                    title="Your models"
-                    body="Bring your own provider."
-                  />
-                </div>
-              </div>
-            </div>
           </div>
 
-          {/* Auth form */}
-          <div className="flex flex-col justify-center border-[var(--dls-border)] px-5 py-6 sm:px-7 sm:py-8 md:px-9 md:py-10 lg:border-l">
-            {/* Mobile-only brand header — desktop shows the logo in the gradient panel */}
-            <div className="mb-6 flex items-center gap-2 lg:hidden">
+          <div className="flex flex-col justify-center border-[var(--dls-border)] px-5 py-6 sm:px-7 sm:py-8 md:px-9 md:py-10 lg:border-l" data-testid="auth-landing-form">
+            <div className="mb-6 flex items-center gap-2 lg:hidden" data-testid="auth-landing-mobile-brand">
               <img src="/openwork-mark.svg" alt="OpenWork" className="h-7 w-auto" />
               <span className="text-[1.15rem] font-semibold tracking-tight text-[var(--dls-text-primary)]">
                 OpenWork

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts app/api/_lib/upstream-proxy.test.mjs",
+    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/auth-landing-contract.test.ts
+++ b/ee/apps/den-web/tests/auth-landing-contract.test.ts
@@ -1,0 +1,44 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const authScreenPath = fileURLToPath(
+  new URL("../app/(den)/_components/auth-screen.tsx", import.meta.url),
+);
+const authPanelPath = fileURLToPath(
+  new URL("../app/(den)/_components/auth-panel.tsx", import.meta.url),
+);
+
+describe("Den auth landing contract", () => {
+  test("keeps the simple bounded split layout and mobile logo", () => {
+    const source = readFileSync(authScreenPath, "utf8");
+
+    expect(source).toContain("max-w-[600px]");
+    expect(source).toContain("lg:grid-cols-[2fr_1fr]");
+    expect(source).toContain('data-testid="auth-landing-visual"');
+    expect(source).toContain('data-testid="auth-landing-form"');
+    expect(source).toContain('data-testid="auth-landing-mobile-brand"');
+    expect(source).toContain("lg:hidden");
+    expect(source).toContain('src="/openwork-mark.svg"');
+  });
+
+  test("removes the old marketing panel content from the shader side", () => {
+    const source = readFileSync(authScreenPath, "utf8");
+
+    expect(source).not.toContain("openwork-logo-transparent.svg");
+    expect(source).not.toContain("OpenWork Cloud");
+    expect(source).not.toContain("One setup, every seat.");
+    expect(source).not.toContain("Configure once. Your whole team gets the same tools, agents, and providers.");
+    expect(source).not.toContain("Shared config");
+    expect(source).not.toContain("Cloud agents");
+    expect(source).not.toContain("Your models");
+  });
+
+  test("starts the email-first panel with the approved heading", () => {
+    const source = readFileSync(authPanelPath, "utf8");
+
+    expect(source).toContain('title: "Start using OpenWork"');
+    expect(source).toContain("Enter your email and we'll send you to the right sign-in step.");
+    expect(source).not.toContain("Continue to OpenWork.");
+  });
+});

--- a/ee/apps/den-web/tests/auth-landing-contract.test.ts
+++ b/ee/apps/den-web/tests/auth-landing-contract.test.ts
@@ -14,7 +14,8 @@ describe("Den auth landing contract", () => {
     const source = readFileSync(authScreenPath, "utf8");
 
     expect(source).toContain("max-w-[600px]");
-    expect(source).toContain("lg:grid-cols-[2fr_1fr]");
+    expect(source).toContain("lg:grid-cols-[1fr_5fr]");
+    expect(source).not.toContain("lg:grid-cols-[2fr_1fr]");
     expect(source).toContain('data-testid="auth-landing-visual"');
     expect(source).toContain('data-testid="auth-landing-form"');
     expect(source).toContain('data-testid="auth-landing-mobile-brand"');
@@ -32,6 +33,15 @@ describe("Den auth landing contract", () => {
     expect(source).not.toContain("Shared config");
     expect(source).not.toContain("Cloud agents");
     expect(source).not.toContain("Your models");
+  });
+
+  test("keeps the visual panel as Dithering only", () => {
+    const source = readFileSync(authScreenPath, "utf8");
+
+    expect(source).toContain('import { Dithering } from "@paper-design/shaders-react"');
+    expect(source).not.toContain("PaperMeshGradient");
+    expect(source).toContain('style={{ backgroundColor: "#142033", width: "100%", height: "100%" }}');
+    expect(source).toContain('data-testid="auth-landing-visual"');
   });
 
   test("starts the email-first panel with the approved heading", () => {

--- a/evals/flows/new-signin-flow.flow.mjs
+++ b/evals/flows/new-signin-flow.flow.mjs
@@ -19,7 +19,7 @@ export default {
             await openSignedOutRoot(ctx);
           },
           assert: async () => {
-            await ctx.expectText("Continue to OpenWork.", { timeoutMs: 30_000 });
+            await ctx.expectText("Start using OpenWork", { timeoutMs: 30_000 });
             const actual = await readAuthSurface(ctx);
             ctx.assert(actual.emailInputs === 1, `Expected one email field, got ${JSON.stringify(actual)}`);
             ctx.assert(actual.passwordInputs === 0, `Expected no password field, got ${JSON.stringify(actual)}`);
@@ -29,7 +29,7 @@ export default {
           },
           screenshot: {
             name: "email-first-start",
-            requireText: ["Continue to OpenWork.", "EMAIL", "Next"],
+            requireText: ["Start using OpenWork", "EMAIL", "Next"],
             rejectText: ["Password", "Continue with Google", "Create account"],
           },
         });
@@ -204,7 +204,7 @@ async function openSignedOutRoot(ctx) {
     return true;
   })()`);
   await ctx.waitFor(
-    `(() => document.body.innerText.includes('Continue to OpenWork.') && Boolean(document.querySelector('input[type="email"]')))()`,
+    `(() => document.body.innerText.includes('Start using OpenWork') && Boolean(document.querySelector('input[type="email"]')))()`,
     { timeoutMs: 30_000, label: "email-first auth panel" },
   );
 }

--- a/evals/flows/sen-api-desktop-versions.flow.mjs
+++ b/evals/flows/sen-api-desktop-versions.flow.mjs
@@ -28,7 +28,7 @@ async function openDesktopVersionSettings(ctx) {
     location.reload();
     return true;
   }).catch(() => true)`, { awaitPromise: true });
-  await ctx.waitFor(`document.body.innerText.includes('Continue to OpenWork.') && Boolean(document.querySelector('input[type="email"]'))`, {
+  await ctx.waitFor(`document.body.innerText.includes('Start using OpenWork') && Boolean(document.querySelector('input[type="email"]'))`, {
     timeoutMs: 30_000,
     label: "email-first sign-in",
   });

--- a/evals/flows/simple-cloud-landing.flow.mjs
+++ b/evals/flows/simple-cloud-landing.flow.mjs
@@ -1,0 +1,256 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "simple-cloud-landing";
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL?.trim() || "http://localhost:3005").replace(/\/+$/, "");
+const TEST_EMAIL = "pat@openwork.test";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function recordAssertion(ctx, assertion, passed, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: passed ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(passed, `${assertion}. Actual: ${JSON.stringify(actual)}`);
+}
+
+async function applyViewport(ctx, width, height, mobile) {
+  if (!ctx.client?.send) {
+    ctx.log("Viewport emulation skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+    width,
+    height,
+    deviceScaleFactor: 1,
+    mobile,
+  });
+}
+
+async function openSignedOutRoot(ctx) {
+  await ctx.eval(`(() => {
+    window.location.href = ${JSON.stringify(DEN_WEB_URL)};
+    return true;
+  })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "Den web loaded" });
+  await ctx.eval(`(() => {
+    window.localStorage.removeItem('openwork:web:auth-token');
+    window.sessionStorage.clear();
+    return fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' })
+      .then(() => true)
+      .catch(() => true);
+  })()`, { awaitPromise: true });
+  await ctx.eval(`(() => {
+    window.location.href = ${JSON.stringify(DEN_WEB_URL)};
+    return true;
+  })()`);
+  await ctx.waitFor(
+    `document.body.innerText.includes('Start using OpenWork') && Boolean(document.querySelector('input[type="email"]'))`,
+    { timeoutMs: 30_000, label: "simple email-first auth panel" },
+  );
+}
+
+async function installDeferredLoginOptionsMock(ctx, responsePayload) {
+  await ctx.eval(`((payload) => {
+    const originalFetch = window.__openworkOriginalFetch ?? window.fetch.bind(window);
+    window.__openworkOriginalFetch = originalFetch;
+    window.__openworkLoginOptionRequests = [];
+    window.__openworkResolveLoginOptions = null;
+    window.fetch = (input, init) => {
+      const rawUrl = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+      const url = new URL(rawUrl, window.location.origin);
+      if (url.pathname === '/v1/auth/login-options' || url.pathname === '/api/den/v1/auth/login-options') {
+        window.__openworkLoginOptionRequests.push(url.pathname + url.search);
+        return new Promise((resolve) => {
+          window.__openworkResolveLoginOptions = () => {
+            resolve(new Response(JSON.stringify({ email: url.searchParams.get('email') ?? '', ...payload }), {
+              status: 200,
+              headers: { 'content-type': 'application/json' },
+            }));
+            return true;
+          };
+        });
+      }
+      return originalFetch(input, init);
+    };
+    return true;
+  })(${JSON.stringify(responsePayload)})`);
+}
+
+async function fillEmailAndClickNext(ctx) {
+  await ctx.fill('input[type="email"]', TEST_EMAIL);
+  const clicked = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')].find((entry) => (entry.textContent ?? '').trim() === 'Next');
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked, "Could not find the Next button.");
+}
+
+async function resolveLoginOptions(ctx) {
+  const resolved = await ctx.eval(`(() => {
+    if (typeof window.__openworkResolveLoginOptions !== 'function') return false;
+    return window.__openworkResolveLoginOptions();
+  })()`);
+  ctx.assert(resolved, "Login-options mock was not waiting to resolve.");
+}
+
+async function readLandingState(ctx) {
+  return ctx.eval(`(() => {
+    const rectFor = (element) => {
+      if (!element) return null;
+      const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      return {
+        left: Math.round(rect.left),
+        right: Math.round(rect.right),
+        top: Math.round(rect.top),
+        bottom: Math.round(rect.bottom),
+        width: Math.round(rect.width),
+        height: Math.round(rect.height),
+        display: style.display,
+        visibility: style.visibility,
+        visible: rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden',
+      };
+    };
+    const visibleButtons = [...document.querySelectorAll('button')]
+      .filter((button) => {
+        const rect = button.getBoundingClientRect();
+        const style = getComputedStyle(button);
+        return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
+      })
+      .map((button) => (button.textContent ?? '').replace(/\s+/g, ' ').trim())
+      .filter(Boolean);
+    const visual = document.querySelector('[data-testid="auth-landing-visual"]');
+    const mobileBrand = document.querySelector('[data-testid="auth-landing-mobile-brand"]');
+    return {
+      text: document.body.innerText,
+      url: location.href,
+      hostname: location.hostname,
+      viewport: { width: window.innerWidth, height: window.innerHeight },
+      frame: rectFor(document.querySelector('[data-testid="auth-landing-frame"]')),
+      visual: rectFor(visual),
+      form: rectFor(document.querySelector('[data-testid="auth-landing-form"]')),
+      mobileBrand: rectFor(mobileBrand),
+      mobileBrandText: mobileBrand?.textContent?.replace(/\s+/g, ' ').trim() ?? '',
+      visualCanvasCount: visual?.querySelectorAll('canvas').length ?? 0,
+      emailInputs: document.querySelectorAll('input[type="email"]').length,
+      passwordInputs: document.querySelectorAll('input[type="password"]').length,
+      visibleButtons,
+    };
+  })()`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Den web root auth landing keeps a focused split layout and email-first behavior",
+  kind: "user-facing",
+  preserveTheme: true,
+  steps: [
+    {
+      name: "Focused split layout",
+      run: async (ctx) => {
+        await ctx.prove("The root auth page opens as a compact split card with only the shader visual and account form", {
+          voiceover: vo[0],
+          action: async () => {
+            await applyViewport(ctx, 1280, 900, false);
+            await openSignedOutRoot(ctx);
+            await ctx.waitFor(`Boolean(document.querySelector('[data-testid="auth-landing-visual"] canvas'))`, {
+              timeoutMs: 30_000,
+              label: "desktop shader canvas",
+            });
+          },
+          assert: async () => {
+            const state = await readLandingState(ctx);
+            recordAssertion(ctx, "The frame is centered and bounded to 600px", Boolean(state.frame) && state.frame.width <= 604 && Math.abs((state.frame.left + state.frame.right) / 2 - state.viewport.width / 2) <= 4, state);
+            recordAssertion(ctx, "Desktop shows the visual panel and form side by side, with the visual panel larger", Boolean(state.visual?.visible && state.form?.visible) && state.visual.width > state.form.width && state.visual.left < state.form.left, state);
+            recordAssertion(ctx, "The left panel is shader-only and the old marketing content is absent", state.visualCanvasCount > 0 && !state.text.includes("OpenWork Cloud") && !state.text.includes("One setup, every seat.") && !state.text.includes("Shared config"), state);
+            recordAssertion(ctx, "The initial form is email-first with one Next button", state.emailInputs === 1 && state.passwordInputs === 0 && state.visibleButtons.length === 1 && state.visibleButtons[0] === "Next", state);
+          },
+          screenshot: {
+            name: "desktop-focused-split-layout",
+            requireText: ["Start using OpenWork", "EMAIL", "Next"],
+            rejectText: ["OpenWork Cloud", "One setup, every seat.", "Shared config", "Cloud agents", "Your models"],
+          },
+        });
+      },
+    },
+    {
+      name: "Email and Next action",
+      run: async (ctx) => {
+        await ctx.prove("The only required action is entering an email and selecting Next", {
+          voiceover: vo[1],
+          action: async () => {
+            await installDeferredLoginOptionsMock(ctx, { nextStep: "password" });
+            await fillEmailAndClickNext(ctx);
+            await ctx.waitFor("document.body.innerText.includes('Checking...')", {
+              timeoutMs: 10_000,
+              label: "checking login options",
+            });
+          },
+          assert: async () => {
+            const requests = await ctx.eval("window.__openworkLoginOptionRequests ?? []");
+            const state = await readLandingState(ctx);
+            recordAssertion(ctx, "Next calls login-options exactly once with the entered email", requests.length === 1 && requests[0]?.endsWith("email=pat%40openwork.test"), { requests, state });
+            recordAssertion(ctx, "No extra sign-in choices appear during the email-first action", state.visibleButtons.length === 1 && state.visibleButtons[0] === "Checking..." && !state.text.includes("Continue with Google") && !state.text.includes("Create account"), state);
+          },
+          screenshot: {
+            name: "email-next-action",
+            requireText: ["Start using OpenWork", "EMAIL", "Checking..."],
+            rejectText: ["Password", "Continue with Google", "Create account"],
+          },
+        });
+      },
+    },
+    {
+      name: "Preserved existing sign-in step",
+      run: async (ctx) => {
+        await ctx.prove("The backend-selected existing sign-in step renders without completing external auth", {
+          voiceover: vo[2],
+          action: async () => {
+            await resolveLoginOptions(ctx);
+            await ctx.waitFor("document.body.innerText.includes('Enter your password.')", {
+              timeoutMs: 30_000,
+              label: "password step after login-options response",
+            });
+          },
+          assert: async () => {
+            const state = await readLandingState(ctx);
+            recordAssertion(ctx, "The password step is selected for the existing email", state.passwordInputs === 1 && state.text.includes(`Sign in as ${TEST_EMAIL}.`) && state.visibleButtons.includes("Sign in"), state);
+            recordAssertion(ctx, "The flow stays inside Den web and does not complete external auth", state.hostname.length > 0 && !state.text.includes("Choose an account"), state);
+          },
+          screenshot: {
+            name: "existing-password-step",
+            requireText: ["Enter your password.", `Sign in as ${TEST_EMAIL}.`, "PASSWORD", "Sign in"],
+            rejectText: ["Sign in with Google", "Sign in with SSO", "Create your account."],
+          },
+        });
+      },
+    },
+    {
+      name: "Responsive mobile state",
+      run: async (ctx) => {
+        await ctx.prove("On mobile the decorative panel disappears and the compact OpenWork logo leads the form", {
+          voiceover: vo[3],
+          action: async () => {
+            await applyViewport(ctx, 390, 820, true);
+            await openSignedOutRoot(ctx);
+          },
+          assert: async () => {
+            const state = await readLandingState(ctx);
+            recordAssertion(ctx, "The decorative shader panel is hidden on mobile", Boolean(state.visual) && state.visual.visible === false, state);
+            recordAssertion(ctx, "The compact OpenWork mobile brand and account form are centered", Boolean(state.mobileBrand?.visible && state.form?.visible && state.frame) && state.mobileBrandText.includes("OpenWork") && state.frame.width <= state.viewport.width && Math.abs((state.frame.left + state.frame.right) / 2 - state.viewport.width / 2) <= 4, state);
+            recordAssertion(ctx, "Mobile remains the same email-first form", state.emailInputs === 1 && state.passwordInputs === 0 && state.visibleButtons.length === 1 && state.visibleButtons[0] === "Next", state);
+          },
+          screenshot: {
+            name: "mobile-centered-form",
+            requireText: ["OpenWork", "Start using OpenWork", "EMAIL", "Next"],
+            rejectText: ["OpenWork Cloud", "One setup, every seat.", "Shared config", "Cloud agents", "Your models"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/simple-cloud-landing.flow.mjs
+++ b/evals/flows/simple-cloud-landing.flow.mjs
@@ -165,8 +165,8 @@ export default {
           assert: async () => {
             const state = await readLandingState(ctx);
             recordAssertion(ctx, "The frame is centered and bounded to 600px", Boolean(state.frame) && state.frame.width <= 604 && Math.abs((state.frame.left + state.frame.right) / 2 - state.viewport.width / 2) <= 4, state);
-            recordAssertion(ctx, "Desktop shows the visual panel and form side by side, with the visual panel larger", Boolean(state.visual?.visible && state.form?.visible) && state.visual.width > state.form.width && state.visual.left < state.form.left, state);
-            recordAssertion(ctx, "The left panel is shader-only and the old marketing content is absent", state.visualCanvasCount > 0 && !state.text.includes("OpenWork Cloud") && !state.text.includes("One setup, every seat.") && !state.text.includes("Shared config"), state);
+            recordAssertion(ctx, "Desktop shows the visual panel and form side by side, with the form wider", Boolean(state.visual?.visible && state.form?.visible) && state.form.width > state.visual.width && state.visual.left < state.form.left, state);
+            recordAssertion(ctx, "The left panel has exactly one shader canvas and the old marketing content is absent", state.visualCanvasCount === 1 && !state.text.includes("OpenWork Cloud") && !state.text.includes("One setup, every seat.") && !state.text.includes("Shared config"), state);
             recordAssertion(ctx, "The initial form is email-first with one Next button", state.emailInputs === 1 && state.passwordInputs === 0 && state.visibleButtons.length === 1 && state.visibleButtons[0] === "Next", state);
           },
           screenshot: {

--- a/evals/voiceovers/simple-cloud-landing.md
+++ b/evals/voiceovers/simple-cloud-landing.md
@@ -1,0 +1,9 @@
+# simple-cloud-landing — Simple Cloud landing
+
+1. The landing page opens with a focused split layout: OpenWork’s visual identity on the left and a simple account form on the right.
+
+2. There’s one clear action. I enter my email and select Next, without navigating through extra choices or explanations.
+
+3. OpenWork uses my email to continue to the correct existing sign-in step, so authentication behavior stays unchanged.
+
+4. On a smaller screen, the decorative panel disappears and the compact OpenWork logo and account form take center stage.


### PR DESCRIPTION
## Summary
- simplify the OpenWork Cloud landing page into a compact 600px split card
- keep the desktop shader panel visual-only and show compact branding on mobile
- preserve the existing email-first auth routing with clearer copy
- add landing-page contract coverage and a demo flow

## Validation
- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm --filter @openwork-ee/den-web test` — 39 passed
- `pnpm --filter @openwork-ee/den-web build` — passed

## Fraimz
- Local CDP validation loaded the new experience and exposed an overly strict pixel-ratio assertion in the new flow. The assertion was corrected before push; the final proof rerun was skipped at the requester’s direction to push immediately.