### PR TITLE
fix(server): engine-attested Cloud MCP health; network probe becomes on-demand

### DIFF
--- a/apps/server/src/cloud-mcp-health.test.ts
+++ b/apps/server/src/cloud-mcp-health.test.ts
@@ -27,6 +27,7 @@ const workspace: WorkspaceInfo = {
 const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
 const previousFetch = globalThis.fetch;
 const roots: string[] = [];
+const runtimeDbRoots: string[] = [];
 const stops: Array<() => void> = [];
 
 type DirectProbeMode = "ok" | "missing" | "unauthorized";
@@ -40,6 +41,13 @@ afterEach(async () => {
   cloudMcpDeliveryState.clear();
   while (stops.length) stops.pop()?.();
   while (roots.length) await rm(roots.pop() ?? "", { recursive: true, force: true });
+  if (process.platform === "win32") {
+    // Bun keeps runtime-opencode-config-store SQLite handles open for the process lifetime on Windows.
+    // Skip only those DB temp dirs; workspace roots and mock servers are still cleaned every test.
+    runtimeDbRoots.length = 0;
+  } else {
+    while (runtimeDbRoots.length) await rm(runtimeDbRoots.pop() ?? "", { recursive: true, force: true });
+  }
   if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
   else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
 });
@@ -48,6 +56,12 @@ async function createRoot(prefix: string): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), prefix));
   roots.push(root);
   return root;
+}
+
+async function createRuntimeDbPath(prefix: string): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), prefix));
+  runtimeDbRoots.push(root);
+  return join(root, "runtime.sqlite");
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -131,7 +145,7 @@ async function readHealthForDirectProbe(mode: DirectProbeMode, options: ReadHeal
     baseUrl,
   };
   const config = serverConfig(root, testWorkspace);
-  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  process.env.OPENWORK_RUNTIME_DB = await createRuntimeDbPath("openwork-cloud-health-runtime-");
   await writeRuntimeOpencodeConfig(config, testWorkspace.id, (current) => ({
     ...current,
     mcp: {

--- a/apps/server/src/cloud-mcp-health.test.ts
+++ b/apps/server/src/cloud-mcp-health.test.ts
@@ -30,6 +30,10 @@ const roots: string[] = [];
 const stops: Array<() => void> = [];
 
 type DirectProbeMode = "ok" | "missing" | "unauthorized";
+type ReadHealthOptions = {
+  probe?: boolean;
+  beforeRead?: (directUrl: string) => void;
+};
 
 afterEach(async () => {
   globalThis.fetch = previousFetch;
@@ -113,7 +117,7 @@ function serverConfig(root: string, testWorkspace: WorkspaceInfo): ServerConfig 
   } satisfies ServerConfig;
 }
 
-async function readHealthForDirectProbe(mode: DirectProbeMode, beforeRead?: (directUrl: string) => void) {
+async function readHealthForDirectProbe(mode: DirectProbeMode, options: ReadHealthOptions = {}) {
   const root = await createRoot("openwork-cloud-health-");
   const engine = startMockOpencode(mode);
   const baseUrl = `http://127.0.0.1:${engine.port}`;
@@ -141,14 +145,27 @@ async function readHealthForDirectProbe(mode: DirectProbeMode, beforeRead?: (dir
       },
     },
   }));
-  beforeRead?.(directUrl);
+  options.beforeRead?.(directUrl);
   const health = await readOpenworkCloudMcpHealth({
     config,
     workspace: testWorkspace,
     directory: root,
+    probe: options.probe,
     createWorkspaceOpencodeClient: () => createOpencodeClient({ baseUrl }),
   });
   return { health, directUrl };
+}
+
+function watchDirectFetches(directUrl: string, onFetch: () => void): void {
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = Object.assign(
+    (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+      const url = input instanceof Request ? input.url : String(input);
+      if (url === directUrl) onFetch();
+      return originalFetch(input, init);
+    },
+    { preconnect: originalFetch.preconnect },
+  );
 }
 
 function makeDirectProbeThrow(directUrl: string): void {
@@ -281,8 +298,31 @@ describe("cloud MCP health foundation", () => {
     expect(denies).toEqual([]);
   });
 
+  test("uses engine-attested tools by default without direct Cloud endpoint fetch", async () => {
+    let directFetchCount = 0;
+    const { health } = await readHealthForDirectProbe("ok", {
+      beforeRead: (directUrl) => watchDirectFetches(directUrl, () => {
+        directFetchCount += 1;
+      }),
+    });
+
+    expect(health.usable).toBe(true);
+    expect(health.phase).toBe("ready");
+    expect(health.tools.present.sort()).toEqual([...OPENWORK_CLOUD_EXPECTED_TOOLS].sort());
+    expect(health.tools.missing).toEqual([]);
+    expect(health.tools.direct.checked).toBe(false);
+    expect(directFetchCount).toBe(0);
+  });
+
+  test("default engine-attested health marks delivery applied", async () => {
+    const { health } = await readHealthForDirectProbe("ok");
+
+    expect(health.delivery.state).toBe("ready");
+    expect(health.delivery.appliedRevision).toBe(health.desired.revision);
+  });
+
   test("keeps Cloud usable when only the direct probe transport is unreachable", async () => {
-    const { health } = await readHealthForDirectProbe("ok", makeDirectProbeThrow);
+    const { health } = await readHealthForDirectProbe("ok", { probe: true, beforeRead: makeDirectProbeThrow });
 
     expect(health.usable).toBe(true);
     expect(health.phase).toBe("ready");
@@ -295,14 +335,14 @@ describe("cloud MCP health foundation", () => {
   });
 
   test("still fails closed when the direct probe receives HTTP 401", async () => {
-    const { health } = await readHealthForDirectProbe("unauthorized");
+    const { health } = await readHealthForDirectProbe("unauthorized", { probe: true });
 
     expect(health.usable).toBe(false);
     expect(health.firstFailure?.code).toBe("invalid_mcp_token");
   });
 
   test("still reports missing Cloud tools when tools/list completes without required tools", async () => {
-    const { health } = await readHealthForDirectProbe("missing");
+    const { health } = await readHealthForDirectProbe("missing", { probe: true });
 
     expect(health.usable).toBe(false);
     expect(health.firstFailure?.code).toBe("cloud_tools_missing");

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -1148,6 +1148,11 @@ function toolsFromDirectCloudTools(directTools: DirectCloudToolsSnapshot): ToolS
   return splitPresentMissing([], expectedTools());
 }
 
+function toolsFromEngineAttestation(): ToolSnapshot {
+  const expected = expectedTools();
+  return { expected, present: [...expected], missing: [] };
+}
+
 async function readDirectCloudTools(config: Record<string, unknown>): Promise<DirectCloudToolsSnapshot> {
   const url = readString(config.url);
   const authorization = authorizationHeader(config);
@@ -1546,6 +1551,7 @@ async function inspectOpenworkCloud(input: {
   directory: string | null;
   desiredConfig: Record<string, unknown>;
   providerModel?: CloudMcpProviderModelContext;
+  probe: boolean;
 }): Promise<Inspection> {
   const failures: CloudMcpFailure[] = [];
   const emptyTools = splitPresentMissing([], expectedTools());
@@ -1605,12 +1611,16 @@ async function inspectOpenworkCloud(input: {
   const ids = idsResult.data ?? [];
   const experimentalToolIds = experimentalToolIdsFromSplit(splitPresentMissing(ids, expectedTools()));
   const pluginCanaries = splitPresentMissing(ids, expectedCanaries());
-  const directTools = await readDirectCloudTools(input.desiredConfig);
-  // The engine is authoritative; a probe-only transport failure must stay diagnostic and not veto steering/delivery.
-  if (directTools.failure && directTools.failure.code !== "probe_unreachable") {
-    failures.push(directTools.failure);
+  const directTools = input.probe ? await readDirectCloudTools(input.desiredConfig) : emptyDirectTools;
+  if (input.probe) {
+    // The engine is authoritative; a probe-only transport failure must stay diagnostic and not veto steering/delivery.
+    if (directTools.failure && directTools.failure.code !== "probe_unreachable") {
+      failures.push(directTools.failure);
+    }
   }
-  const tools = toolsFromDirectCloudTools(directTools);
+  // OpenCode >=1.17 reports MCP "connected" only after initial tools/list succeeds;
+  // the engine is the single source of truth unless an on-demand probe is requested.
+  const tools = input.probe ? toolsFromDirectCloudTools(directTools) : toolsFromEngineAttestation();
 
   const providerProjection = input.providerModel
     ? await readProviderProjection({
@@ -1814,6 +1824,7 @@ export async function readOpenworkCloudMcpHealth(input: {
   directory: string | null;
   providerModel?: CloudMcpProviderModelContext;
   serverMetadata?: CloudMcpServerMetadata;
+  probe?: boolean;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
 }): Promise<CloudMcpHealth> {
   const checkedAt = new Date().toISOString();
@@ -1875,6 +1886,7 @@ export async function readOpenworkCloudMcpHealth(input: {
       directory: input.directory,
       desiredConfig: desired.config,
       providerModel: input.providerModel,
+      probe: input.probe === true,
     });
     failures.push(...inspection.failures);
   }
@@ -2019,13 +2031,22 @@ export async function reconcileOpenworkCloudMcp(input: {
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   registerRuntimeMcp: CloudMcpRuntimeRegistrar;
 }): Promise<CloudMcpHealth> {
+  const readHealth = () => readOpenworkCloudMcpHealth({
+    config: input.config,
+    workspace: input.workspace,
+    directory: input.directory,
+    providerModel: input.providerModel,
+    serverMetadata: input.serverMetadata,
+    createWorkspaceOpencodeClient: input.createWorkspaceOpencodeClient,
+    probe: true,
+  });
   const configBody = input.body.config ?? input.body;
   const desiredConfig = canonicalizeCloudMcpConfig(normalizeCloudMcpConfig(configBody));
   const metadata = extractDesiredMetadata(input.body, desiredConfig);
   const validationProblem = strictCloudMcpDesiredConfigProblem(desiredConfig, metadata);
   if (validationProblem) {
     const validationFailure = failureFromValidationProblem(validationProblem);
-    return healthWithFailure(await readOpenworkCloudMcpHealth(input), validationFailure);
+    return healthWithFailure(await readHealth(), validationFailure);
   }
   const desiredRevision = calculateCloudMcpDesiredRevision(desiredConfig, metadata);
   await persistDesiredConfig(input.config, input.workspace.id, desiredConfig);
@@ -2040,7 +2061,7 @@ export async function reconcileOpenworkCloudMcp(input: {
       message: "Remote workspace has no exact OpenCode directory, so Cloud MCP readiness cannot be claimed.",
     });
     cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, directoryFailure);
-    return healthWithFailure(await readOpenworkCloudMcpHealth(input), directoryFailure);
+    return healthWithFailure(await readHealth(), directoryFailure);
   }
 
   if (!baseUrlConfigured(input.config, input.workspace)) {
@@ -2052,7 +2073,7 @@ export async function reconcileOpenworkCloudMcp(input: {
       message: "OpenCode base URL is missing for this workspace.",
     });
     cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, unconfiguredFailure);
-    return healthWithFailure(await readOpenworkCloudMcpHealth(input), unconfiguredFailure);
+    return healthWithFailure(await readHealth(), unconfiguredFailure);
   }
 
   cloudMcpDeliveryState.markRegistering(input.workspace, input.directory, desiredRevision);
@@ -2060,25 +2081,25 @@ export async function reconcileOpenworkCloudMcp(input: {
   if (registration.failures.length > 0) {
     const registrationError = registrationFailure(registration.failures);
     cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, registrationError);
-    return healthWithFailure(await readOpenworkCloudMcpHealth(input), registrationError);
+    return healthWithFailure(await readHealth(), registrationError);
   }
 
   const opencode = input.createWorkspaceOpencodeClient(input.config, input.workspace);
   const connectedFailure = await pollConnected({ opencode, directory: input.directory });
   if (connectedFailure) {
     cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, connectedFailure);
-    return healthWithFailure(await readOpenworkCloudMcpHealth(input), connectedFailure);
+    return healthWithFailure(await readHealth(), connectedFailure);
   }
 
-  const health = await readOpenworkCloudMcpHealth(input);
+  const health = await readHealth();
 
   if (health.firstFailure) {
     cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, health.firstFailure);
-    return healthWithFailure(await readOpenworkCloudMcpHealth(input), health.firstFailure);
+    return healthWithFailure(await readHealth(), health.firstFailure);
   }
 
   cloudMcpDeliveryState.markReady(input.workspace, input.directory, desiredRevision);
-  return readOpenworkCloudMcpHealth(input);
+  return readHealth();
 }
 
 export async function reconcilePersistedOpenworkCloudMcp(input: {

--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -243,8 +243,8 @@ async function reconcile(base: string, workspaceId = "ws_1", body: Record<string
   });
 }
 
-async function getHealth(base: string, workspaceId = "ws_1"): Promise<Response> {
-  return fetch(`${base}/workspace/${workspaceId}/mcp/openwork-cloud/health`, { headers: headers() });
+async function getHealth(base: string, workspaceId = "ws_1", query = ""): Promise<Response> {
+  return fetch(`${base}/workspace/${workspaceId}/mcp/openwork-cloud/health${query}`, { headers: headers() });
 }
 
 describe("openwork-cloud MCP strict reconcile", () => {
@@ -363,6 +363,24 @@ describe("openwork-cloud MCP strict reconcile", () => {
     expect(body.phase).toBe("ready");
     expect(body.usable).toBe(true);
     expect(delivery(body).appliedRevision).toBe(delivery(body).desiredRevision);
+  });
+
+  test("GET health runs the direct Cloud endpoint probe only when requested", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ initialConnected: true });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
+      ...current,
+      mcp: { "openwork-cloud": cloudConfigForOpenwork(openwork.base) },
+    }));
+
+    const defaultBody = await responseRecord(await getHealth(openwork.base));
+    expect(defaultBody.phase).toBe("ready");
+    expect(mock.requests.filter((request) => request.pathname.endsWith("/mcp/agent")).length).toBe(0);
+
+    const probedBody = await responseRecord(await getHealth(openwork.base, "ws_1", "?probe=1"));
+    expect(probedBody.phase).toBe("ready");
+    expect(mock.requests.filter((request) => request.pathname.endsWith("/mcp/agent")).length).toBeGreaterThan(0);
   });
 
   test("health probe timeout is bounded", async () => {

--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -42,12 +42,20 @@ const HOST_TOKEN = "owt_cloud_mcp_host";
 const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
 const stops: Array<() => void | Promise<void>> = [];
 const roots: string[] = [];
+const runtimeDbRoots: string[] = [];
 const cloudConfigsByOpenworkBase = new Map<string, CloudConfig>();
 
 afterEach(async () => {
   cloudMcpDeliveryState.clear();
   while (stops.length) await stops.pop()?.();
-  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+  while (roots.length) await rm(roots.pop() ?? "", { recursive: true, force: true });
+  if (process.platform === "win32") {
+    // Bun keeps runtime-opencode-config-store SQLite handles open for the process lifetime on Windows.
+    // Skip only those DB temp dirs; workspace roots and mock servers are still cleaned every test.
+    runtimeDbRoots.length = 0;
+  } else {
+    while (runtimeDbRoots.length) await rm(runtimeDbRoots.pop() ?? "", { recursive: true, force: true });
+  }
   cloudConfigsByOpenworkBase.clear();
   if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
   else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
@@ -56,6 +64,12 @@ afterEach(async () => {
 async function createRoot(prefix = "openwork-cloud-mcp-"): Promise<string> {
   const root = await mkdtemp(join(tmpdir(), prefix));
   roots.push(root);
+  return root;
+}
+
+async function createRuntimeDbRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-cloud-mcp-runtime-"));
+  runtimeDbRoots.push(root);
   return root;
 }
 
@@ -157,7 +171,8 @@ function workspace(id: string, path: string, baseUrl: string, extra?: Partial<Wo
   };
 }
 
-async function startOpenwork(workspaces: WorkspaceInfo[], runtimeRoot: string): Promise<{ base: string; config: ServerConfig }> {
+async function startOpenwork(workspaces: WorkspaceInfo[]): Promise<{ base: string; config: ServerConfig }> {
+  const runtimeRoot = await createRuntimeDbRoot();
   process.env.OPENWORK_RUNTIME_DB = join(runtimeRoot, "runtime.sqlite");
   const config: ServerConfig = {
     host: "127.0.0.1",
@@ -203,6 +218,11 @@ function requireArray(value: unknown, label: string): unknown[] {
 
 async function responseRecord(response: Response): Promise<Record<string, unknown>> {
   return requireRecord(await response.json(), "response");
+}
+
+function expectDirectoryQuery(search: string | undefined, directory: string): void {
+  if (search === undefined) throw new Error("request search was missing");
+  expect(new URLSearchParams(search).getAll("directory")).toEqual([directory]);
 }
 
 function firstFailure(body: Record<string, unknown>): Record<string, unknown> {
@@ -251,7 +271,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
   test("clean ready persists desired config, verifies tools, and redacts the token", async () => {
     const root = await createRoot();
     const mock = startMockOpencode();
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
 
     const response = await reconcile(openwork.base, "ws_1", {
       tokenMetadata: { expiresAt: "2026-07-13T00:00:00.000Z" },
@@ -290,13 +310,13 @@ describe("openwork-cloud MCP strict reconcile", () => {
 
     const mcpPosts = mock.requests.filter((request) => request.method === "POST" && request.pathname === "/mcp");
     expect(mcpPosts.length).toBe(1);
-    expect(mcpPosts[0]?.search).toContain(`directory=${encodeURIComponent(root)}`);
+    expectDirectoryQuery(mcpPosts[0]?.search, root);
   });
 
   test("rejects malformed desired config without persisting or registering it", async () => {
     const root = await createRoot();
     const mock = startMockOpencode();
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
 
     const cases: Array<{ config: Record<string, unknown>; code: string }> = [
       { config: { ...CLOUD_CONFIG, url: "https://api.openworklabs.com/mcp" }, code: "cloud_endpoint_invalid" },
@@ -325,7 +345,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
   test("normalizes a harmless trailing slash on the Cloud MCP endpoint", async () => {
     const root = await createRoot();
     const mock = startMockOpencode();
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
     const url = `http://127.0.0.1:${mock.server.port}/api/den/mcp/agent/`;
 
     const body = await responseRecord(await reconcile(openwork.base, "ws_1", {
@@ -338,7 +358,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
   test("GET health reports persisted malformed desired config even when the engine looks live", async () => {
     const root = await createRoot();
     const mock = startMockOpencode({ initialConnected: true });
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
     await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
       ...current,
       mcp: { "openwork-cloud": { ...CLOUD_CONFIG, url: "https://api.openworklabs.com/mcp" } },
@@ -353,7 +373,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
   test("GET health safely adopts a live exact match before reporting ready", async () => {
     const root = await createRoot();
     const mock = startMockOpencode({ initialConnected: true });
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
     await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
       ...current,
       mcp: { "openwork-cloud": cloudConfigForOpenwork(openwork.base) },
@@ -368,7 +388,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
   test("GET health runs the direct Cloud endpoint probe only when requested", async () => {
     const root = await createRoot();
     const mock = startMockOpencode({ initialConnected: true });
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
     await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
       ...current,
       mcp: { "openwork-cloud": cloudConfigForOpenwork(openwork.base) },
@@ -389,7 +409,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
     try {
       const root = await createRoot();
       const mock = startMockOpencode({ initialConnected: true, delayMcpStatusMs: 100 });
-      const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+      const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
       await writeRuntimeOpencodeConfig(openwork.config, "ws_1", (current) => ({
         ...current,
         mcp: { "openwork-cloud": cloudConfigForOpenwork(openwork.base) },
@@ -406,7 +426,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
 
   test("unreachable engine leaves desired config persisted but not applied", async () => {
     const root = await createRoot();
-    const openwork = await startOpenwork([workspace("ws_1", root, "http://127.0.0.1:9")], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, "http://127.0.0.1:9")]);
 
     const response = await reconcile(openwork.base);
     const body = await responseRecord(response);
@@ -424,13 +444,13 @@ describe("openwork-cloud MCP strict reconcile", () => {
     const openwork = await startOpenwork([
       workspace("ws_1", rootA, baseUrl),
       workspace("ws_2", rootB, baseUrl),
-    ], rootA);
+    ]);
 
     const response = await reconcile(openwork.base, "ws_2");
     const body = await responseRecord(response);
     expect(body.phase).toBe("ready");
     const post = mock.requests.find((request) => request.method === "POST" && request.pathname === "/mcp");
-    expect(post?.search).toContain(`directory=${encodeURIComponent(rootB)}`);
+    expectDirectoryQuery(post?.search, rootB);
   });
 
   test("uses an explicit remote workspace directory and refuses ambiguous remotes", async () => {
@@ -441,12 +461,11 @@ describe("openwork-cloud MCP strict reconcile", () => {
     const openwork = await startOpenwork([
       workspace("ws_remote", root, baseUrl, { workspaceType: "remote", directory: explicitDirectory }),
       workspace("ws_ambiguous", root, baseUrl, { workspaceType: "remote" }),
-    ], root);
+    ]);
 
     const ready = await reconcile(openwork.base, "ws_remote");
     expect((await responseRecord(ready)).phase).toBe("ready");
-    expect(mock.requests.find((request) => request.method === "POST" && request.pathname === "/mcp")?.search)
-      .toContain(`directory=${encodeURIComponent(explicitDirectory)}`);
+    expectDirectoryQuery(mock.requests.find((request) => request.method === "POST" && request.pathname === "/mcp")?.search, explicitDirectory);
 
     const ambiguous = await reconcile(openwork.base, "ws_ambiguous");
     const body = await responseRecord(ambiguous);
@@ -457,7 +476,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
   test("connected engine with direct Cloud endpoint missing a tool reports cloud_tools_missing without re-registering", async () => {
     const root = await createRoot();
     const mock = startMockOpencode({ cloudToolNames: ["search_capabilities"] });
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
 
     const body = await responseRecord(await reconcile(openwork.base));
     expect(firstFailure(body).code).toBe("cloud_tools_missing");
@@ -473,7 +492,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
       providerToolIds: [...OPENWORK_CLOUD_PLUGIN_CANARIES],
       cloudToolsAsSse: true,
     });
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
 
     const body = await responseRecord(await reconcile(openwork.base, "ws_1", { provider: "anthropic", model: "claude" }));
     expect(body.phase).toBe("ready");
@@ -497,7 +516,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
       providerToolIds: [...OPENWORK_CLOUD_PLUGIN_CANARIES],
       providerToolCalling: false,
     });
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
 
     const body = await responseRecord(await reconcile(openwork.base, "ws_1", { provider: "anthropic", model: "claude" }));
     expect(firstFailure(body).code).toBe("provider_tool_projection_missing");
@@ -513,7 +532,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
   test("reports extension canary missing when docs canary is present but extension canary is absent", async () => {
     const root = await createRoot();
     const mock = startMockOpencode({ toolIds: [...OPENWORK_CLOUD_EXPECTED_TOOLS, "openwork_docs_search"] });
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
 
     const body = await responseRecord(await reconcile(openwork.base));
     expect(firstFailure(body).code).toBe("extensions_plugin_missing");
@@ -523,7 +542,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
   test("old engines without tool.ids return Update OpenWork guidance", async () => {
     const root = await createRoot();
     const mock = startMockOpencode({ unsupportedToolIds: true });
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
 
     const body = await responseRecord(await reconcile(openwork.base));
     expect(firstFailure(body).code).toBe("opencode_tool_ids_unsupported");
@@ -534,7 +553,7 @@ describe("openwork-cloud MCP strict reconcile", () => {
     const root = await createRoot();
     await writeFile(join(root, "opencode.jsonc"), JSON.stringify({ tools: { deny: ["openwork-cloud_*"] } }), "utf8");
     const mock = startMockOpencode();
-    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)], root);
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
 
     const strictBody = await responseRecord(await reconcile(openwork.base));
     expect(firstFailure(strictBody).code).toBe("cloud_tools_denied");

--- a/apps/server/src/connect-state.ts
+++ b/apps/server/src/connect-state.ts
@@ -220,6 +220,7 @@ async function resolveCloudHealth(config: ServerConfig, options: ConnectSnapshot
     directory: resolved.directory,
     providerModel: options.providerModel,
     serverMetadata: options.serverMetadata,
+    probe: false,
     createWorkspaceOpencodeClient: options.createWorkspaceOpencodeClient,
   });
   return {

--- a/apps/server/src/routes/cloud-mcp.ts
+++ b/apps/server/src/routes/cloud-mcp.ts
@@ -47,6 +47,11 @@ function providerModelFromQuery(url: URL): CloudMcpProviderModelContext | undefi
   return providerModelFromValues(url.searchParams.get("provider"), url.searchParams.get("model"));
 }
 
+function probeFromQuery(url: URL): boolean {
+  const value = url.searchParams.get("probe")?.toLowerCase();
+  return value === "1" || value === "true";
+}
+
 function providerModelFromBody(body: Record<string, unknown>): CloudMcpProviderModelContext | undefined {
   const direct = providerModelFromValues(body.provider, body.model);
   if (direct) return direct;
@@ -93,6 +98,7 @@ export function registerCloudMcpRoutes(options: RegisterCloudMcpRoutesOptions): 
       directory: resolveOpencodeDirectory(workspace),
       providerModel: providerModelFromQuery(ctx.url),
       serverMetadata,
+      probe: probeFromQuery(ctx.url),
       createWorkspaceOpencodeClient,
     });
     return jsonResponse(health);


### PR DESCRIPTION
## Summary
Root-cause fix #2 from the corporate-TLS field incident (follow-up to #2823). The architecture problem: background health **re-verified** what the engine already attested, over a different network stack — two verifiers, guaranteed eventual disagreement. This PR makes the engine the single authority for background health and demotes the network probe to an on-demand diagnostic.

- `readOpenworkCloudMcpHealth` gains `probe?: boolean` (default **false**)
- Default path: no network probe at all; `tools` attested from engine status (`connected` ⇒ initial tools/list succeeded, opencode ≥1.17 semantics); `tools.direct.checked: false`
- `GET …/health?probe=1` → full direct-probe verification (for the Advanced diagnostics Refresh / support)
- `POST …/reconcile` keeps `probe: true` (explicit repair wants full verification)
- `/experimental/connect/state` (per-prompt, feeds steering) pinned to `probe: false` — cheap and engine-attested

## Validation
- `pnpm --filter openwork-server exec bun test src/cloud-mcp-health.test.ts src/cloud-mcp-reconcile.e2e.test.ts` — 27 pass / 0 fail (new: default path makes **zero** fetches to the cloud endpoint, tools attested, delivery applied; route-level default vs `?probe=1`; existing probe tests opt in via `probe:true`)
- `pnpm --filter openwork-server test` — 453 pass / 0 fail (one earlier run had 2 unrelated reload-watcher flakes that passed on rerun and reproduce on clean dev)
- `pnpm --filter openwork-server typecheck` — clean

Note: touches `cloud-mcp-health.ts` alongside the parallel egress PR (different regions; whichever merges second takes a trivial rebase). App-side follow-up (optional): Advanced diagnostics Refresh can pass `probe=1` to keep its deep-verification behavior explicit.