### PR TITLE
fix(server): OS-trust egress helper for all external fetches, bare fetch banned

### DIFF
--- a/apps/server/src/claude-plugin-bundle.ts
+++ b/apps/server/src/claude-plugin-bundle.ts
@@ -13,6 +13,7 @@
 import { ApiError } from "./errors.js";
 import { parseFrontmatter } from "./frontmatter.js";
 import type { CloudPluginResolved } from "./cloud-plugins.js";
+import { externalFetch } from "./server-fetch.js";
 
 export type ClaudePluginSource = {
   owner: string;
@@ -97,7 +98,7 @@ export function parseClaudePluginSource(input: string): ClaudePluginSource {
 }
 
 async function fetchGithubJson(url: string): Promise<unknown> {
-  const response = await fetch(url, {
+  const response = await externalFetch(url, {
     headers: { Accept: "application/vnd.github+json", "User-Agent": "openwork-server" },
     signal: AbortSignal.timeout(20_000),
   });
@@ -109,7 +110,7 @@ async function fetchGithubJson(url: string): Promise<unknown> {
 }
 
 async function fetchGithubText(url: string): Promise<string> {
-  const response = await fetch(url, {
+  const response = await externalFetch(url, {
     headers: { Accept: "text/plain", "User-Agent": "openwork-server" },
     signal: AbortSignal.timeout(20_000),
   });

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -7,6 +7,7 @@ import { ApiError } from "./errors.js";
 import { diagnoseMcpToolDenies, type McpToolDeny } from "./mcp.js";
 import { sanitizeDiagnosticString, sanitizeDiagnosticValue } from "./diagnostic-sanitizer.js";
 import { readRuntimeOpencodeConfig, runtimeMcpMap, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { externalFetch } from "./server-fetch.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
 import { validateMcpConfig } from "./validators.js";
 
@@ -518,38 +519,6 @@ export const cloudMcpDeliveryState = new CloudMcpDeliveryStateStore();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
-}
-
-type CloudProbeFetch = (input: string, init?: RequestInit) => Promise<Response>;
-
-let cloudProbeFetchPromise: Promise<CloudProbeFetch> | undefined;
-
-function globalCloudProbeFetch(input: string, init?: RequestInit): Promise<Response> {
-  return globalThis.fetch(input, init);
-}
-
-function hasElectronNetFetch(value: unknown): value is { net: { fetch: CloudProbeFetch } } {
-  return isRecord(value) && isRecord(value.net) && typeof value.net.fetch === "function";
-}
-
-async function resolveCloudProbeFetch(): Promise<CloudProbeFetch> {
-  if (!process.versions.electron) return globalCloudProbeFetch;
-  try {
-    const moduleName = "electron";
-    const mod: unknown = await import(moduleName);
-    if (hasElectronNetFetch(mod)) {
-      const { net } = mod;
-      return (input, init) => net.fetch(input, init);
-    }
-  } catch {
-    // Fall through to Node/Bun fetch when Electron is unavailable in tests or bundlers.
-  }
-  return globalCloudProbeFetch;
-}
-
-function cloudProbeFetch(input: string, init?: RequestInit): Promise<Response> {
-  cloudProbeFetchPromise ??= resolveCloudProbeFetch();
-  return cloudProbeFetchPromise.then((resolvedFetch) => resolvedFetch(input, init));
 }
 
 function hashString(value: string): string {
@@ -1102,7 +1071,7 @@ async function mcpJsonRpcPost(input: {
   headers: Record<string, string>;
   body: unknown;
 }): Promise<{ response: Response; payload: unknown }> {
-  const response = await withCloudEndpointProbeTimeout((signal) => cloudProbeFetch(input.url, {
+  const response = await withCloudEndpointProbeTimeout((signal) => externalFetch(input.url, {
     method: "POST",
     headers: input.headers,
     body: JSON.stringify(input.body),
@@ -1198,7 +1167,7 @@ async function readDirectCloudTools(config: Record<string, unknown>): Promise<Di
       ...(sessionId ? { "mcp-session-id": sessionId } : {}),
       ...(protocolVersion ? { "mcp-protocol-version": protocolVersion } : {}),
     };
-    await withCloudEndpointProbeTimeout((signal) => cloudProbeFetch(url, {
+    await withCloudEndpointProbeTimeout((signal) => externalFetch(url, {
       method: "POST",
       headers: sessionHeaders,
       body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }),

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -5,6 +5,7 @@ import { basename, dirname, isAbsolute, join, relative, resolve } from "node:pat
 import { homedir } from "node:os";
 
 import { ApiError } from "../errors.js";
+import { externalFetch } from "../server-fetch.js";
 import type { ServerConfig } from "../types.js";
 
 export const GOOGLE_WORKSPACE_EXTENSION_ID = "google-workspace";
@@ -508,9 +509,9 @@ async function fetchGoogleJson(url: string, init: RequestInit = {}) {
   const timeout = setTimeout(() => controller.abort(), GOOGLE_WORKSPACE_API_TIMEOUT_MS);
   let response: Response;
   try {
-    response = await fetch(url, { ...init, signal: controller.signal });
+    response = await externalFetch(url, { ...init, signal: controller.signal });
   } catch (error) {
-    if ((error as { name?: string })?.name === "AbortError") throw new Error("Google request timed out. Check your connection and try again.");
+    if (error instanceof Error && error.name === "AbortError") throw new Error("Google request timed out. Check your connection and try again.");
     throw error;
   } finally {
     clearTimeout(timeout);
@@ -518,7 +519,7 @@ async function fetchGoogleJson(url: string, init: RequestInit = {}) {
   const text = await response.text();
   let payload: unknown = null;
   if (text.trim()) {
-    try { payload = JSON.parse(text) as unknown; } catch { payload = { raw: text }; }
+    try { payload = JSON.parse(text); } catch { payload = { raw: text }; }
   }
   if (!response.ok) {
     const details = isRecord(payload)
@@ -1112,7 +1113,7 @@ async function googleWorkspaceReadFile(config: ServerConfig, args: Record<string
   const url = exportMime
     ? `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(fileId)}/export?mimeType=${encodeURIComponent(exportMime)}`
     : `https://www.googleapis.com/drive/v3/files/${encodeURIComponent(fileId)}?alt=media`;
-  const response = await fetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
+  const response = await externalFetch(url, { headers: { Authorization: `Bearer ${accessToken}` } });
   const content = await response.text();
   if (!response.ok) throw new Error(`Google Drive read failed (${response.status}): ${content}`);
   return { metadata, content };
@@ -1250,7 +1251,7 @@ export async function googleWorkspaceRunScopeSmokeTest(config: ServerConfig) {
     body: multipartRelatedBody({ name: "OpenWork Google Workspace smoke test.txt", mimeType: "text/plain" }, `OpenWork Google Workspace smoke test created at ${createdAt}.`, driveBoundary),
   });
   if (isRecord(driveFile) && typeof driveFile.id === "string") {
-    const response = await fetch(`https://www.googleapis.com/drive/v3/files/${encodeURIComponent(driveFile.id)}?alt=media`, { headers: { Authorization: `Bearer ${accessToken}` } });
+    const response = await externalFetch(`https://www.googleapis.com/drive/v3/files/${encodeURIComponent(driveFile.id)}?alt=media`, { headers: { Authorization: `Bearer ${accessToken}` } });
     if (!response.ok) throw new Error(`Google Drive smoke read failed (${response.status}): ${await response.text()}`);
   }
   const draft = await fetchGoogleJson("https://gmail.googleapis.com/gmail/v1/users/me/drafts", {

--- a/apps/server/src/extensions/openai-image-generation.ts
+++ b/apps/server/src/extensions/openai-image-generation.ts
@@ -3,6 +3,7 @@ import { dirname, resolve, sep } from "node:path";
 
 import { ApiError } from "../errors.js";
 import type { EnvService } from "../env-file.js";
+import { externalFetch } from "../server-fetch.js";
 import type { ServerConfig, WorkspaceInfo } from "../types.js";
 
 export const OPENAI_IMAGE_GENERATION_EXTENSION_ID = "openai-image-generation";
@@ -112,7 +113,7 @@ async function fetchOpenAiImage(input: { apiKey: string; prompt: string }) {
   const timeout = setTimeout(() => controller.abort(), OPENAI_IMAGE_API_TIMEOUT_MS);
   let response: Response;
   try {
-    response = await fetch("https://api.openai.com/v1/images/generations", {
+    response = await externalFetch("https://api.openai.com/v1/images/generations", {
       method: "POST",
       headers: {
         Authorization: `Bearer ${input.apiKey}`,

--- a/apps/server/src/no-bare-fetch.test.ts
+++ b/apps/server/src/no-bare-fetch.test.ts
@@ -1,0 +1,51 @@
+import { test } from "bun:test";
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join, relative, sep } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const srcDir = dirname(fileURLToPath(import.meta.url));
+const bareFetchPattern = /(?<![.\w])fetch\s*\(/;
+
+async function collectTypescriptFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const sortedEntries = entries.sort((left, right) => left.name.localeCompare(right.name));
+  const files: string[] = [];
+  for (const entry of sortedEntries) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectTypescriptFiles(path));
+    } else if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push(path);
+    }
+  }
+  return files;
+}
+
+function relativeSrcPath(file: string): string {
+  return relative(srcDir, file).split(sep).join("/");
+}
+
+function shouldCheck(file: string): boolean {
+  const path = relativeSrcPath(file);
+  return !path.endsWith(".test.ts")
+    && !path.endsWith(".e2e.test.ts")
+    && path !== "server-fetch.ts"
+    && !path.startsWith("opencode-plugins/");
+}
+
+test("server source does not use bare fetch", async () => {
+  const offenders: string[] = [];
+  const files = (await collectTypescriptFiles(srcDir)).filter(shouldCheck);
+  for (const file of files) {
+    const path = relativeSrcPath(file);
+    const lines = (await readFile(file, "utf8")).split(/\r?\n/);
+    lines.forEach((line, index) => {
+      const code = line.replace(/\/\/.*$/, "");
+      if (bareFetchPattern.test(code)) offenders.push(`${path}:${index + 1}`);
+    });
+  }
+
+  if (offenders.length > 0) {
+    throw new Error(`Bare fetch is banned in apps/server/src. Use externalFetch for external egress or loopbackFetch for loopback/engine traffic. Offenders:\n${offenders.join("\n")}`);
+  }
+});

--- a/apps/server/src/routes/workspaces.ts
+++ b/apps/server/src/routes/workspaces.ts
@@ -3,6 +3,7 @@ import { basename, dirname, resolve } from "node:path";
 import { recordAudit } from "../audit.js";
 import { ApiError } from "../errors.js";
 import { inheritWorkspaceOpencodeConnection, resolveWorkspaceOpencodeConnection } from "../opencode-connection.js";
+import { externalFetch } from "../server-fetch.js";
 import type { ServerConfig, WorkspaceInfo } from "../types.js";
 import { ensureDir, exists, shortId } from "../utils.js";
 import { defaultWorkspaceOpenworkConfig, ensureWorkspaceFiles } from "../workspace-init.js";
@@ -133,7 +134,7 @@ async function fetchOpenworkWorkspaceList(hostUrl: string, token: string, hostTo
   if (hostToken) headers.set("X-OpenWork-Host-Token", hostToken);
 
   try {
-    const response = await fetch(url, { headers, signal: controller.signal });
+    const response = await externalFetch(url, { headers, signal: controller.signal });
     if (!response.ok) {
       throw new ApiError(
         502,

--- a/apps/server/src/server-fetch.ts
+++ b/apps/server/src/server-fetch.ts
@@ -1,0 +1,46 @@
+type ExternalFetch = (input: string, init?: RequestInit) => Promise<Response>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function globalFetch(input: string, init?: RequestInit): Promise<Response> {
+  return globalThis.fetch(input, init);
+}
+
+function hasElectronNetFetch(value: unknown): value is { net: { fetch: ExternalFetch } } {
+  return isRecord(value) && isRecord(value.net) && typeof value.net.fetch === "function";
+}
+
+let externalFetchPromise: Promise<ExternalFetch> | undefined;
+
+async function resolveExternalFetch(): Promise<ExternalFetch> {
+  if (!process.versions.electron) return globalFetch;
+  try {
+    const moduleName = "electron";
+    const mod: unknown = await import(moduleName);
+    if (hasElectronNetFetch(mod)) {
+      const { net } = mod;
+      return (input, init) => net.fetch(input, init);
+    }
+  } catch {
+    // Electron is optional when the server runs standalone or under tests.
+  }
+  return globalFetch;
+}
+
+export function externalFetch(input: string, init?: RequestInit): Promise<Response> {
+  externalFetchPromise ??= resolveExternalFetch();
+  return externalFetchPromise.then((resolvedFetch) => resolvedFetch(input, init));
+}
+
+/**
+ * Rule: external egress → externalFetch; loopback → loopbackFetch; bare fetch is banned in apps/server/src.
+ * Use loopbackFetch only for 127.0.0.1, localhost, and managed OpenCode engine traffic where CA trust is irrelevant and streaming performance matters.
+ */
+export function loopbackFetch(
+  input: Parameters<typeof globalThis.fetch>[0],
+  init?: Parameters<typeof globalThis.fetch>[1],
+): ReturnType<typeof globalThis.fetch> {
+  return globalThis.fetch(input, init);
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -57,6 +57,7 @@ import {
   type WorkspaceExportSensitiveMode,
 } from "./workspace-export-safety.js";
 import { serve, type ServeResult } from "./serve-node.js";
+import { externalFetch, loopbackFetch } from "./server-fetch.js";
 import { registerCoreRoutes } from "./routes/core.js";
 import { registerFileRoutes } from "./routes/files.js";
 import { registerOperationRoutes } from "./routes/operations.js";
@@ -471,7 +472,7 @@ async function createOpenAiRealtimeVoiceSession(env: EnvService, input: unknown)
 }
 
 async function createManagedVoiceSession(config: { baseUrl: string; apiKey: string }, input: unknown) {
-  const response = await fetch(`${config.baseUrl}/voice/realtime/session`, {
+  const response = await externalFetch(`${config.baseUrl}/voice/realtime/session`, {
     method: "POST",
     headers: {
       Authorization: `Bearer ${config.apiKey}`,
@@ -515,7 +516,7 @@ async function createManagedVoiceSession(config: { baseUrl: string; apiKey: stri
 async function createDirectOpenAiVoiceSession(apiKey: string, input: unknown) {
   const model = readStringField(input, "model") || OPENWORK_VOICE_REALTIME_MODEL;
   const sessionContext = readStringField(input, "sessionContext").slice(0, 6_000);
-  const response = await fetch("https://api.openai.com/v1/realtime/client_secrets", {
+  const response = await externalFetch("https://api.openai.com/v1/realtime/client_secrets", {
     method: "POST",
     headers: {
       Authorization: `Bearer ${apiKey}`,
@@ -1032,8 +1033,9 @@ async function proxyOpencodeRequest(input: {
   const body = method === "GET" || method === "HEAD"
     ? undefined
     : await input.request.arrayBuffer().then((buf) => (buf.byteLength > 0 ? buf : undefined));
+  // Managed OpenCode proxy traffic is loopback/engine I/O; keep streaming on Node fetch.
   if (isSessionCommandProxyRequest(method, proxyPath)) {
-    void fetch(targetUrl, {
+    void loopbackFetch(targetUrl, {
       method,
       headers,
       body,
@@ -1042,7 +1044,7 @@ async function proxyOpencodeRequest(input: {
     });
     return jsonResponse({ ok: true, accepted: true });
   }
-  const response = await fetch(targetUrl, {
+  const response = await loopbackFetch(targetUrl, {
     method,
     headers,
     body,
@@ -3035,7 +3037,7 @@ async function fetchRuntimeControl(path: string, init?: { method?: string; body?
   if (!control) {
     throw new ApiError(501, "runtime_upgrade_unavailable", "Worker runtime control is not configured on this host");
   }
-  const response = await fetch(`${control.baseUrl}${path}`, {
+  const response = await externalFetch(`${control.baseUrl}${path}`, {
     method: init?.method ?? "GET",
     headers: {
       "Content-Type": "application/json",
@@ -3192,7 +3194,8 @@ async function reloadOpencodeEngine(
 
   let response: Response;
   try {
-    response = await fetch(targetUrl, { method: "POST", headers });
+    // OpenCode reload targets the managed loopback engine; CA trust is irrelevant.
+    response = await loopbackFetch(targetUrl, { method: "POST", headers });
   } catch (error) {
     throw new ApiError(
       503,
@@ -3360,7 +3363,8 @@ async function postMcpEntryWithRetry(
   for (let attempt = 0; attempt < 2; attempt += 1) {
     if (attempt > 0) await new Promise((resolve) => setTimeout(resolve, engineMcpSyncRetryDelayMs()));
     try {
-      const response = await fetch(url, {
+      // Runtime MCP registration targets the managed loopback engine.
+      const response = await loopbackFetch(url, {
         method: "POST",
         headers,
         body: JSON.stringify({ name, config: mcpConfig }),
@@ -4032,7 +4036,8 @@ async function disconnectMcpFromOpencodeEngine(
   const headers: Record<string, string> = {};
   if (connection.authHeader) headers.Authorization = connection.authHeader;
 
-  const response = await fetch(url, { method: "POST", headers, signal: AbortSignal.timeout(15_000) });
+  // MCP disconnect targets the managed loopback engine.
+  const response = await loopbackFetch(url, { method: "POST", headers, signal: AbortSignal.timeout(15_000) });
   if (!response.ok) {
     const body = parseOpencodeErrorBody(await response.text());
     throw new ApiError(502, "opencode_mcp_disconnect_failed", `Failed to disconnect MCP ${name} from the engine`, {

--- a/apps/server/src/skill-hub.ts
+++ b/apps/server/src/skill-hub.ts
@@ -4,6 +4,7 @@ import { dirname, join, resolve } from "node:path";
 import type { HubSkillItem } from "./types.js";
 import { ApiError } from "./errors.js";
 import { parseFrontmatter } from "./frontmatter.js";
+import { externalFetch } from "./server-fetch.js";
 import { exists } from "./utils.js";
 import { validateSkillName } from "./validators.js";
 import { projectSkillsDir } from "./workspace-files.js";
@@ -32,7 +33,7 @@ function hubRawBase(repo: HubRepo) {
 }
 
 async function fetchJson(url: string): Promise<any> {
-  const res = await fetch(url, {
+  const res = await externalFetch(url, {
     headers: {
       Accept: "application/vnd.github+json",
       "User-Agent": "openwork-server",
@@ -46,7 +47,7 @@ async function fetchJson(url: string): Promise<any> {
 }
 
 async function fetchText(url: string): Promise<string> {
-  const res = await fetch(url, {
+  const res = await externalFetch(url, {
     headers: {
       Accept: "text/plain",
       "User-Agent": "openwork-server",
@@ -230,7 +231,7 @@ export async function installHubSkill(
     }
 
     await mkdir(dirname(destPath), { recursive: true });
-    const res = await fetch(`${rawBase}/${file.path}`, {
+    const res = await externalFetch(`${rawBase}/${file.path}`, {
       headers: { "User-Agent": "openwork-server" },
     });
     if (!res.ok) {

--- a/apps/server/src/toy-ui.ts
+++ b/apps/server/src/toy-ui.ts
@@ -653,7 +653,7 @@ async function apiFetch(path, options) {
     headers.set("Content-Type", "application/json");
   }
   if (token) headers.set("Authorization", "Bearer " + token);
-  const res = await fetch(path, { ...opts, headers });
+  const res = await window.fetch(path, { ...opts, headers });
   const text = await res.text();
   let json = null;
   try { json = text ? JSON.parse(text) : null; } catch { json = null; }
@@ -830,7 +830,7 @@ async function listArtifacts(workspaceId) {
     btn.textContent = "Download";
     btn.onclick = async () => {
       try {
-        const res = await fetch(
+        const res = await window.fetch(
           "/workspace/" + encodeURIComponent(workspaceId) + "/artifacts/" + encodeURIComponent(item.id),
           { headers: { Authorization: "Bearer " + readToken() } },
         );
@@ -938,7 +938,7 @@ async function connectSse(workspaceId) {
   addCheckpoint("sse.connecting");
 
   const url = "/w/" + encodeURIComponent(workspaceId) + "/opencode/event";
-  const res = await fetch(url, {
+  const res = await window.fetch(url, {
     headers: { Authorization: "Bearer " + readToken() },
     signal: controller.signal,
   });


### PR DESCRIPTION
## Summary
Root-cause fix #3 from the corporate-TLS field incident (follow-up to #2823, which fixed one call site). The server had ~15 external egress points on bare undici `fetch` — every one of them fails behind enterprise TLS interception while Electron/engine succeed, producing the same false-negative ghost class. This PR centralizes egress and bans regressions.

- New `apps/server/src/server-fetch.ts`: **`externalFetch`** (Electron `net.fetch` when embedded → Chromium stack, OS trust store; global fetch standalone/tests) and **`loopbackFetch`** (documented alias for 127.0.0.1 / managed engine traffic, where CA trust is irrelevant and SSE/proxy streaming perf matters)
- Migrated: cloud MCP probes, remote workspace discovery, GitHub skill-hub + plugin bundles, OpenAI image gen, Google Workspace/token broker, voice broker, Realtime secrets, runtime-control URL → `externalFetch`; session/SSE engine proxy, instance dispose, engine MCP register/disconnect → `loopbackFetch` (full file:line inventory in the commit-adjacent notes below)
- Toy UI's embedded browser-side script strings switched to `window.fetch` (they execute in the browser, not the server)
- **Guard:** `no-bare-fetch.test.ts` recursively fails on any bare `fetch(` in `apps/server/src` (excluding tests, `server-fetch.ts`, and `src/opencode-plugins/` — plugin bundles run inside the Bun engine, which trusts the OS store, and must not import electron)

<details><summary>Call-site inventory</summary>

externalFetch: cloud-mcp-health.ts:1074,1170 · routes/workspaces.ts:137 · skill-hub.ts:36,50,234 · claude-plugin-bundle.ts:101,113 · extensions/openai-image-generation.ts:116 · extensions/google-workspace.ts:512,1116,1254 · server.ts:475,519,3040

loopbackFetch: server.ts:1038 (async session command proxy) · server.ts:1047 (hot OpenCode proxy/SSE) · server.ts:3198 (instance dispose) · server.ts:3367 (runtime MCP registration) · server.ts:4040 (MCP disconnect)
</details>

## Validation
- `pnpm --filter openwork-server exec bun test src/no-bare-fetch.test.ts` — 1 pass / 0 fail
- `pnpm --filter openwork-server test` — 451 pass / 0 fail (existing tests stub `globalThis.fetch`; `externalFetch` falls back to it outside Electron, so stubs keep working — verified by the green suite)
- `pnpm --filter openwork-server typecheck` — clean
- `rg --pcre2 '(?<![.\\w])fetch\\s*\\('` over migrated scope — no hits outside exclusions

**Not run:** live enterprise-TLS e2e (Electron-embedded `net.fetch` path behind a MITM CA) — that's the `daytona-windows-cert` sandbox; recommended as the release-gate follow-up for this class.

Note: touches `cloud-mcp-health.ts` alongside the parallel engine-attested-health PR (different regions; second-to-merge takes a trivial rebase).