### PR TITLE
fix(den): restart Daytona workers with sandbox

### DIFF
--- a/ee/apps/den-api/src/workers/daytona-runtime-env.ts
+++ b/ee/apps/den-api/src/workers/daytona-runtime-env.ts
@@ -1,0 +1,68 @@
+export const daytonaWorkerStartupScriptPath = "/usr/local/bin/openwork-daytona-worker-start"
+export const daytonaWorkerStartupLogPath = "/tmp/openwork-daytona-worker-start.log"
+export const daytonaWorkerAutostartMarkerPath = "/usr/local/share/openwork/daytona-worker-entrypoint"
+
+export type DaytonaWorkerRuntimeEnv = Record<string, string>
+
+export type DaytonaWorkerRuntimeEnvInput = {
+  workerId: string
+  hostToken: string
+  clientToken: string
+  activityToken: string
+  activityHeartbeatUrl: string
+  workspaceMountPath: string
+  dataMountPath: string
+  runtimeWorkspacePath: string
+  runtimeDataPath: string
+  sidecarDir: string
+  openworkPort: number
+  opencodePort: number
+}
+
+export const daytonaWorkerRuntimeEnvKeys = [
+  "DEN_RUNTIME_PROVIDER",
+  "DEN_WORKER_ID",
+  "DEN_ACTIVITY_HEARTBEAT_ENABLED",
+  "DEN_ACTIVITY_HEARTBEAT_URL",
+  "DEN_ACTIVITY_HEARTBEAT_TOKEN",
+  "OPENWORK_TOKEN",
+  "OPENWORK_HOST_TOKEN",
+  "OPENWORK_DATA_DIR",
+  "OPENWORK_SIDECAR_DIR",
+  "OPENWORK_WORKSPACE",
+  "OPENWORK_PORT",
+  "OPENWORK_OPENCODE_HOST",
+  "OPENWORK_OPENCODE_PORT",
+  "OPENWORK_CONNECT_HOST",
+  "OPENWORK_CORS",
+  "OPENWORK_APPROVAL",
+  "OPENWORK_OPENCODE_SOURCE",
+  "DAYTONA_WORKSPACE_MOUNT_PATH",
+  "DAYTONA_DATA_MOUNT_PATH",
+]
+
+export function buildDaytonaWorkerRuntimeEnv(
+  input: DaytonaWorkerRuntimeEnvInput,
+): DaytonaWorkerRuntimeEnv {
+  return {
+    DEN_RUNTIME_PROVIDER: "daytona",
+    DEN_WORKER_ID: input.workerId,
+    DEN_ACTIVITY_HEARTBEAT_ENABLED: "1",
+    DEN_ACTIVITY_HEARTBEAT_URL: input.activityHeartbeatUrl,
+    DEN_ACTIVITY_HEARTBEAT_TOKEN: input.activityToken,
+    OPENWORK_TOKEN: input.clientToken,
+    OPENWORK_HOST_TOKEN: input.hostToken,
+    OPENWORK_DATA_DIR: input.runtimeDataPath,
+    OPENWORK_SIDECAR_DIR: input.sidecarDir,
+    OPENWORK_WORKSPACE: input.runtimeWorkspacePath,
+    OPENWORK_PORT: String(input.openworkPort),
+    OPENWORK_OPENCODE_HOST: "127.0.0.1",
+    OPENWORK_OPENCODE_PORT: String(input.opencodePort),
+    OPENWORK_CONNECT_HOST: "127.0.0.1",
+    OPENWORK_CORS: "*",
+    OPENWORK_APPROVAL: "manual",
+    OPENWORK_OPENCODE_SOURCE: "external",
+    DAYTONA_WORKSPACE_MOUNT_PATH: input.workspaceMountPath,
+    DAYTONA_DATA_MOUNT_PATH: input.dataMountPath,
+  }
+}

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -5,6 +5,13 @@ import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "../db.js"
 import { env } from "../env.js"
 import { appLogger } from "../observability/logger.js"
+import {
+  buildDaytonaWorkerRuntimeEnv,
+  daytonaWorkerAutostartMarkerPath,
+  daytonaWorkerStartupLogPath,
+  daytonaWorkerStartupScriptPath,
+  type DaytonaWorkerRuntimeEnv,
+} from "./daytona-runtime-env.js"
 
 type WorkerId = typeof DaytonaSandboxTable.$inferSelect.worker_id
 
@@ -194,58 +201,68 @@ function sharedVolumeMounts(workerId: WorkerId, volumeId: string) {
   ]
 }
 
-function buildOpenWorkStartCommand(input: ProvisionInput) {
+function buildOpenWorkStartCommand() {
   const verifyRuntimeStep = [
     "if ! command -v openwork >/dev/null 2>&1; then echo 'openwork binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
     "if ! command -v opencode >/dev/null 2>&1; then echo 'opencode binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
   ].join("; ")
+  const requiredRuntimeEnvStep = `
+require_env() {
+  name="$1"
+  if value="$(printenv "$name")"; then
+    :
+  else
+    value=""
+  fi
+  if [ -z "$value" ]; then
+    echo "$name is required when DEN_WORKER_ID is set" >&2
+    exit 1
+  fi
+}
+require_number_env() {
+  require_env "$1"
+  case "$value" in
+    *[!0-9]*) echo "$name must be numeric" >&2; exit 1 ;;
+  esac
+}
+for name in DEN_RUNTIME_PROVIDER DEN_WORKER_ID DEN_ACTIVITY_HEARTBEAT_ENABLED DEN_ACTIVITY_HEARTBEAT_URL DEN_ACTIVITY_HEARTBEAT_TOKEN OPENWORK_TOKEN OPENWORK_HOST_TOKEN OPENWORK_DATA_DIR OPENWORK_SIDECAR_DIR OPENWORK_WORKSPACE OPENWORK_OPENCODE_HOST OPENWORK_CONNECT_HOST OPENWORK_CORS OPENWORK_APPROVAL OPENWORK_OPENCODE_SOURCE DAYTONA_WORKSPACE_MOUNT_PATH DAYTONA_DATA_MOUNT_PATH; do
+  require_env "$name"
+done
+require_number_env OPENWORK_PORT
+require_number_env OPENWORK_OPENCODE_PORT
+`.trim()
   const openworkServe = [
-    "OPENWORK_DATA_DIR=",
-    shellQuote(env.daytona.runtimeDataPath),
-    " OPENWORK_SIDECAR_DIR=",
-    shellQuote(env.daytona.sidecarDir),
-    " OPENWORK_TOKEN=",
-    shellQuote(input.clientToken),
-    " OPENWORK_HOST_TOKEN=",
-    shellQuote(input.hostToken),
-    " DEN_RUNTIME_PROVIDER=",
-    shellQuote("daytona"),
-    " DEN_WORKER_ID=",
-    shellQuote(input.workerId),
-    " DEN_ACTIVITY_HEARTBEAT_ENABLED=",
-    shellQuote("1"),
-    " DEN_ACTIVITY_HEARTBEAT_URL=",
-    shellQuote(workerActivityHeartbeatUrl(input.workerId)),
-    " DEN_ACTIVITY_HEARTBEAT_TOKEN=",
-    shellQuote(input.activityToken),
-    " openwork serve",
-    ` --workspace ${shellQuote(env.daytona.runtimeWorkspacePath)}`,
+    "openwork serve",
+    ` --workspace "$OPENWORK_WORKSPACE"`,
     ` --remote-access`,
-    ` --openwork-port ${env.daytona.openworkPort}`,
-    ` --opencode-host 127.0.0.1`,
-    ` --opencode-port ${env.daytona.opencodePort}`,
-    ` --connect-host 127.0.0.1`,
-    ` --cors '*'`,
-    ` --approval manual`,
+    ` --openwork-port "$OPENWORK_PORT"`,
+    ` --opencode-host "$OPENWORK_OPENCODE_HOST"`,
+    ` --opencode-port "$OPENWORK_OPENCODE_PORT"`,
+    ` --connect-host "$OPENWORK_CONNECT_HOST"`,
+    ` --cors "$OPENWORK_CORS"`,
+    ` --approval "$OPENWORK_APPROVAL"`,
     ` --allow-external`,
-    ` --opencode-source external`,
-    ` --opencode-bin $(command -v opencode)`,
+    ` --opencode-source "$OPENWORK_OPENCODE_SOURCE"`,
+    ` --opencode-bin "$opencode_bin"`,
     ` --verbose`,
   ].join("")
 
   const script = `
 set -u
-mkdir -p ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(env.daytona.runtimeWorkspacePath)} ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(env.daytona.sidecarDir)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)}
-ln -sfn ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/workspace`) }
-ln -sfn ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/data`) }
+${requiredRuntimeEnvStep}
+mkdir -p "$DAYTONA_WORKSPACE_MOUNT_PATH" "$DAYTONA_DATA_MOUNT_PATH" "$OPENWORK_WORKSPACE" "$OPENWORK_DATA_DIR" "$OPENWORK_SIDECAR_DIR" "$OPENWORK_WORKSPACE/volumes"
+ln -sfn "$DAYTONA_WORKSPACE_MOUNT_PATH" "$OPENWORK_WORKSPACE/volumes/workspace"
+ln -sfn "$DAYTONA_DATA_MOUNT_PATH" "$OPENWORK_WORKSPACE/volumes/data"
 ${verifyRuntimeStep}
+opencode_bin="$(command -v opencode)"
 attempt=0
 while [ "$attempt" -lt 3 ]; do
   attempt=$((attempt + 1))
   if ${openworkServe}; then
     exit 0
+  else
+    status=$?
   fi
-  status=$?
   echo "openwork serve failed (attempt $attempt, exit $status); retrying in 3s"
   sleep 3
 done
@@ -350,54 +367,144 @@ async function cleanupWorkerDataOnDaytona(daytona: Daytona, workerId: WorkerId) 
   }
 }
 
-async function waitForHealth(url: string, timeoutMs: number, sandbox: Sandbox, sessionId: string, commandId: string) {
+type HealthWaitMode =
+  | { kind: "container-startup" }
+  | { kind: "legacy-session"; sessionId: string; commandId: string }
+
+const maxHealthProbeRequestMs = 10_000
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+async function fetchHealthWithTimeout(url: string, timeoutMs: number) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetch(url, { method: "GET", signal: controller.signal })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function throwIfLegacySessionExited(sandbox: Sandbox, mode: HealthWaitMode) {
+  if (mode.kind !== "legacy-session") {
+    return
+  }
+
+  try {
+    const command = await sandbox.process.getSessionCommand(mode.sessionId, mode.commandId)
+    if (typeof command.exitCode === "number" && command.exitCode !== 0) {
+      const logs = await sandbox.process.getSessionCommandLogs(mode.sessionId, mode.commandId)
+      throw new Error(
+        [
+          `openwork session exited with ${command.exitCode}`,
+          logs.stdout?.trim() ? `stdout:\n${logs.stdout.trim().slice(-4000)}` : "",
+          logs.stderr?.trim() ? `stderr:\n${logs.stderr.trim().slice(-4000)}` : "",
+        ]
+          .filter(Boolean)
+          .join("\n\n"),
+      )
+    }
+  } catch (error) {
+    if (error instanceof Error && error.message.startsWith("openwork session exited")) {
+      throw error
+    }
+  }
+}
+
+async function legacySessionLogs(sandbox: Sandbox, mode: HealthWaitMode) {
+  if (mode.kind !== "legacy-session") {
+    return null
+  }
+
+  return await sandbox.process.getSessionCommandLogs(mode.sessionId, mode.commandId).catch(
+    () => null,
+  )
+}
+
+async function containerStartupDiagnostics(sandbox: Sandbox) {
+  const scriptCheck = await sandbox.process.executeCommand(
+    `test -x ${shellQuote(daytonaWorkerStartupScriptPath)} && echo 'startup script present' || echo 'startup script missing'`,
+    undefined,
+    undefined,
+    10,
+  ).catch(() => null)
+  const startupLogTail = await sandbox.process.executeCommand(
+    [
+      "node -e",
+      shellQuote(
+        [
+          'const fs = require("node:fs")',
+          'const path = process.argv[1]',
+          'if (!fs.existsSync(path)) { console.log(`startup log missing: ${path}`); process.exit(0) }',
+          'const text = fs.readFileSync(path, "utf8")',
+          'process.stdout.write(text.slice(-4000))',
+        ].join("; "),
+      ),
+      shellQuote(daytonaWorkerStartupLogPath),
+    ].join(" "),
+    undefined,
+    undefined,
+    10,
+  ).catch(() => null)
+
+  return [
+    scriptCheck?.result?.trim() ? `startup script check:\n${scriptCheck.result.trim().slice(-4000)}` : "",
+    startupLogTail?.result?.trim() ? `startup log tail (${daytonaWorkerStartupLogPath}):\n${startupLogTail.result.trim().slice(-4000)}` : "",
+  ].filter(Boolean)
+}
+
+async function waitForHealth(url: string, timeoutMs: number, sandbox: Sandbox, mode: HealthWaitMode) {
   const startedAt = Date.now()
+  const healthUrl = `${url.replace(/\/$/, "")}/health`
+  let lastProbe = "no health probe completed"
 
   while (Date.now() - startedAt < timeoutMs) {
+    const remainingMs = Math.max(1, timeoutMs - (Date.now() - startedAt))
+    const requestTimeoutMs = Math.min(maxHealthProbeRequestMs, remainingMs)
     try {
-      const response = await fetch(`${url.replace(/\/$/, "")}/health`, { method: "GET" })
+      const response = await fetchHealthWithTimeout(healthUrl, requestTimeoutMs)
       if (response.ok) {
         return
       }
-    } catch {
-      // ignore transient startup failures
-    }
-
-    try {
-      const command = await sandbox.process.getSessionCommand(sessionId, commandId)
-      if (typeof command.exitCode === "number" && command.exitCode !== 0) {
-        const logs = await sandbox.process.getSessionCommandLogs(sessionId, commandId)
-        throw new Error(
-          [
-            `openwork session exited with ${command.exitCode}`,
-            logs.stdout?.trim() ? `stdout:\n${logs.stdout.trim().slice(-4000)}` : "",
-            logs.stderr?.trim() ? `stderr:\n${logs.stderr.trim().slice(-4000)}` : "",
-          ]
-            .filter(Boolean)
-            .join("\n\n"),
-        )
-      }
+      lastProbe = `health returned HTTP ${response.status}`
     } catch (error) {
-      if (error instanceof Error && error.message.startsWith("openwork session exited")) {
-        throw error
-      }
+      lastProbe = `health probe failed or timed out after ${requestTimeoutMs}ms: ${errorMessage(error)}`
     }
 
-    await sleep(env.daytona.pollIntervalMs)
+    await throwIfLegacySessionExited(sandbox, mode)
+
+    await sleep(Math.min(env.daytona.pollIntervalMs, Math.max(0, timeoutMs - (Date.now() - startedAt))))
   }
 
-  const logs = await sandbox.process.getSessionCommandLogs(sessionId, commandId).catch(
-    () => null,
-  )
+  const logs = await legacySessionLogs(sandbox, mode)
+  const diagnostics = mode.kind === "container-startup"
+    ? await containerStartupDiagnostics(sandbox)
+    : []
   throw new Error(
     [
-      `Timed out waiting for Daytona worker health at ${url.replace(/\/$/, "")}/health`,
+      `Timed out waiting for Daytona worker health at ${healthUrl}`,
+      `startup mode: ${mode.kind}`,
+      `last probe: ${lastProbe}`,
       logs?.stdout?.trim() ? `stdout:\n${logs.stdout.trim().slice(-4000)}` : "",
       logs?.stderr?.trim() ? `stderr:\n${logs.stderr.trim().slice(-4000)}` : "",
+      ...diagnostics,
     ]
       .filter(Boolean)
       .join("\n\n"),
   )
+}
+
+async function hasDaytonaWorkerStartupScript(sandbox: Sandbox) {
+  const result = await sandbox.process.executeCommand(
+    `test -x ${shellQuote(daytonaWorkerStartupScriptPath)} && test -f ${shellQuote(daytonaWorkerAutostartMarkerPath)}`,
+    undefined,
+    undefined,
+    10,
+  )
+
+  return result.exitCode === 0
 }
 
 async function upsertDaytonaSandbox(input: {
@@ -513,6 +620,20 @@ export async function provisionWorkerOnDaytona(
     sharedVolumeNameValue,
     env.daytona.createTimeoutSeconds * 1000,
   )
+  const runtimeEnv: DaytonaWorkerRuntimeEnv = buildDaytonaWorkerRuntimeEnv({
+    workerId: input.workerId,
+    hostToken: input.hostToken,
+    clientToken: input.clientToken,
+    activityToken: input.activityToken,
+    activityHeartbeatUrl: workerActivityHeartbeatUrl(input.workerId),
+    workspaceMountPath: env.daytona.workspaceMountPath,
+    dataMountPath: env.daytona.dataMountPath,
+    runtimeWorkspacePath: env.daytona.runtimeWorkspacePath,
+    runtimeDataPath: env.daytona.runtimeDataPath,
+    sidecarDir: env.daytona.sidecarDir,
+    openworkPort: env.daytona.openworkPort,
+    opencodePort: env.daytona.opencodePort,
+  })
   let sandbox: Awaited<ReturnType<typeof daytona.create>> | null = null
 
   try {
@@ -526,10 +647,7 @@ export async function provisionWorkerOnDaytona(
             autoDeleteInterval: env.daytona.autoDeleteInterval,
             public: env.daytona.public,
             labels,
-            envVars: {
-              DEN_WORKER_ID: input.workerId,
-              DEN_RUNTIME_PROVIDER: "daytona",
-            },
+            envVars: runtimeEnv,
             volumes: sharedVolumeMounts(input.workerId, sharedVolume.id),
           },
           { timeout: env.daytona.createTimeoutSeconds },
@@ -543,10 +661,7 @@ export async function provisionWorkerOnDaytona(
             autoDeleteInterval: env.daytona.autoDeleteInterval,
             public: env.daytona.public,
             labels,
-            envVars: {
-              DEN_WORKER_ID: input.workerId,
-              DEN_RUNTIME_PROVIDER: "daytona",
-            },
+            envVars: runtimeEnv,
             resources: {
               cpu: env.daytona.resources.cpu,
               memory: env.daytona.resources.memory,
@@ -557,20 +672,30 @@ export async function provisionWorkerOnDaytona(
           { timeout: env.daytona.createTimeoutSeconds },
         )
 
-    const sessionId = `openwork-${workerHint(input.workerId)}`
-    await sandbox.process.createSession(sessionId)
-    const command = await sandbox.process.executeSessionCommand(
-      sessionId,
-      {
-        command: buildOpenWorkStartCommand(input),
-        runAsync: true,
-      },
-      0,
-    )
+    let healthMode: HealthWaitMode
+    if (await hasDaytonaWorkerStartupScript(sandbox)) {
+      healthMode = { kind: "container-startup" }
+    } else {
+      logger.info("Daytona image lacks entrypoint autostart marker; using legacy session fallback", {
+        worker_id: input.workerId,
+        sandbox_id: sandbox.id,
+      })
+      const sessionId = `openwork-${workerHint(input.workerId)}`
+      await sandbox.process.createSession(sessionId)
+      const command = await sandbox.process.executeSessionCommand(
+        sessionId,
+        {
+          command: buildOpenWorkStartCommand(),
+          runAsync: true,
+        },
+        0,
+      )
+      healthMode = { kind: "legacy-session", sessionId, commandId: command.cmdId }
+    }
 
     const expiresInSeconds = normalizedSignedPreviewExpirySeconds()
     const preview = await sandbox.getSignedPreviewUrl(env.daytona.openworkPort, expiresInSeconds)
-    await waitForHealth(preview.url, env.daytona.healthcheckTimeoutMs, sandbox, sessionId, command.cmdId)
+    await waitForHealth(preview.url, env.daytona.healthcheckTimeoutMs, sandbox, healthMode)
     await upsertDaytonaSandbox({
       workerId: input.workerId,
       sandboxId: sandbox.id,

--- a/ee/apps/den-api/test/daytona-runtime-env.test.ts
+++ b/ee/apps/den-api/test/daytona-runtime-env.test.ts
@@ -1,0 +1,284 @@
+import { describe, expect, test } from "bun:test"
+import { spawnSync } from "node:child_process"
+import {
+  chmod,
+  lstat,
+  mkdir,
+  mkdtemp,
+  readFile,
+  readlink,
+  rm,
+  writeFile,
+} from "node:fs/promises"
+import { tmpdir } from "node:os"
+import { dirname, join } from "node:path"
+import { fileURLToPath } from "node:url"
+import {
+  buildDaytonaWorkerRuntimeEnv,
+  daytonaWorkerAutostartMarkerPath,
+  daytonaWorkerRuntimeEnvKeys,
+  daytonaWorkerStartupScriptPath,
+} from "../src/workers/daytona-runtime-env.js"
+
+const rootDir = join(dirname(fileURLToPath(import.meta.url)), "..", "..", "..", "..")
+const startupScript = join(rootDir, "ee", "apps", "den-worker-runtime", "openwork-daytona-worker-start")
+const snapshotDockerfile = join(rootDir, "ee", "apps", "den-worker-runtime", "Dockerfile.daytona-snapshot")
+
+async function writeExecutable(path: string, contents: string) {
+  await writeFile(path, contents)
+  await chmod(path, 0o755)
+}
+
+function runStartupScript(env: Record<string, string>, args: string[] = []) {
+  return spawnSync("sh", [startupScript, ...args], {
+    encoding: "utf8",
+    env,
+    timeout: 20_000,
+  })
+}
+
+describe("Daytona snapshot Dockerfile contract", () => {
+  test("uses the startup script as ENTRYPOINT and marks corrected autostart images", async () => {
+    const dockerfile = await readFile(snapshotDockerfile, "utf8")
+
+    expect(dockerfile).toContain(`ENTRYPOINT ["${daytonaWorkerStartupScriptPath}"]`)
+    expect(dockerfile).not.toContain(`CMD ["${daytonaWorkerStartupScriptPath}"]`)
+    expect(dockerfile).toContain(daytonaWorkerAutostartMarkerPath)
+  })
+})
+
+describe("Daytona worker runtime env contract", () => {
+  test("contains every value needed to recreate openwork serve after a restart", () => {
+    const runtimeEnv = buildDaytonaWorkerRuntimeEnv({
+      workerId: "worker_123",
+      hostToken: "host-secret",
+      clientToken: "client-secret",
+      activityToken: "activity-secret",
+      activityHeartbeatUrl: "https://den.example/v1/workers/worker_123/activity-heartbeat",
+      workspaceMountPath: "/workspace",
+      dataMountPath: "/persist/openwork",
+      runtimeWorkspacePath: "/tmp/openwork-workspace",
+      runtimeDataPath: "/tmp/openwork-data",
+      sidecarDir: "/tmp/openwork-sidecars",
+      openworkPort: 8787,
+      opencodePort: 4096,
+    })
+
+    for (const key of daytonaWorkerRuntimeEnvKeys) {
+      expect(runtimeEnv[key]).toBeTruthy()
+    }
+    expect(runtimeEnv).toMatchObject({
+      DEN_RUNTIME_PROVIDER: "daytona",
+      DEN_WORKER_ID: "worker_123",
+      DEN_ACTIVITY_HEARTBEAT_ENABLED: "1",
+      DEN_ACTIVITY_HEARTBEAT_TOKEN: "activity-secret",
+      OPENWORK_TOKEN: "client-secret",
+      OPENWORK_HOST_TOKEN: "host-secret",
+      OPENWORK_WORKSPACE: "/tmp/openwork-workspace",
+      OPENWORK_DATA_DIR: "/tmp/openwork-data",
+      OPENWORK_PORT: "8787",
+      OPENWORK_OPENCODE_HOST: "127.0.0.1",
+      OPENWORK_OPENCODE_PORT: "4096",
+      OPENWORK_CONNECT_HOST: "127.0.0.1",
+      OPENWORK_CORS: "*",
+      OPENWORK_APPROVAL: "manual",
+      OPENWORK_OPENCODE_SOURCE: "external",
+      DAYTONA_WORKSPACE_MOUNT_PATH: "/workspace",
+      DAYTONA_DATA_MOUNT_PATH: "/persist/openwork",
+    })
+  })
+})
+
+describe("openwork-daytona-worker-start", () => {
+  test("keeps snapshot validation containers alive when no worker id is configured", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "daytona-startup-no-worker-"))
+    try {
+      const binDir = join(tempDir, "bin")
+      const capture = join(tempDir, "sleep.txt")
+      await mkdir(binDir)
+      await writeExecutable(join(binDir, "sleep"), `#!/usr/bin/env sh
+printf '%s\n' "$*" > "$OPENWORK_TEST_CAPTURE"
+exit 0
+`)
+
+      const result = runStartupScript({
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        OPENWORK_TEST_CAPTURE: capture,
+      }, ["node"])
+
+      expect(result.status).toBe(0)
+      expect(result.stderr).toContain("DEN_WORKER_ID not set")
+      expect((await readFile(capture, "utf8")).trim()).toBe("infinity")
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test("fails clearly when a configured worker is missing required runtime config", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "daytona-startup-missing-config-"))
+    try {
+      const binDir = join(tempDir, "bin")
+      await mkdir(binDir)
+      const result = runStartupScript({
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        DEN_WORKER_ID: "worker_123",
+      })
+
+      expect(result.status).toBe(1)
+      expect(result.stderr).toContain("DEN_RUNTIME_PROVIDER is required when DEN_WORKER_ID is set")
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test("logs the real failing openwork status before retrying", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "daytona-startup-retry-"))
+    try {
+      const binDir = join(tempDir, "bin")
+      const countFile = join(tempDir, "openwork-count.txt")
+      const sleepCapture = join(tempDir, "sleep.txt")
+      const startupLog = join(tempDir, "startup.log")
+      await mkdir(binDir)
+      await writeExecutable(join(binDir, "opencode"), `#!/usr/bin/env sh
+printf 'fake opencode\n'
+`)
+      await writeExecutable(join(binDir, "sleep"), `#!/usr/bin/env sh
+printf '%s\n' "$*" >> "$OPENWORK_TEST_SLEEP_CAPTURE"
+exit 0
+`)
+      await writeExecutable(join(binDir, "openwork"), `#!/usr/bin/env sh
+count=0
+if [ -f "$OPENWORK_TEST_COUNT" ]; then
+  IFS= read -r count < "$OPENWORK_TEST_COUNT"
+fi
+count=$((count + 1))
+printf '%s\n' "$count" > "$OPENWORK_TEST_COUNT"
+printf 'openwork attempt %s\n' "$count"
+if [ "$count" -eq 1 ]; then
+  exit 7
+fi
+exit 0
+`)
+
+      const result = runStartupScript({
+        ...buildDaytonaWorkerRuntimeEnv({
+          workerId: "worker_123",
+          hostToken: "host-secret",
+          clientToken: "client-secret",
+          activityToken: "activity-secret",
+          activityHeartbeatUrl: "https://den.example/v1/workers/worker_123/activity-heartbeat",
+          workspaceMountPath: join(tempDir, "mounted-workspace"),
+          dataMountPath: join(tempDir, "mounted-data"),
+          runtimeWorkspacePath: join(tempDir, "runtime-workspace"),
+          runtimeDataPath: join(tempDir, "runtime-data"),
+          sidecarDir: join(tempDir, "sidecars"),
+          openworkPort: 8787,
+          opencodePort: 4096,
+        }),
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        OPENWORK_STARTUP_LOG: startupLog,
+        OPENWORK_TEST_COUNT: countFile,
+        OPENWORK_TEST_SLEEP_CAPTURE: sleepCapture,
+      })
+
+      expect(result.status).toBe(0)
+      expect(result.stderr).toContain("OpenWork output will append to")
+      expect(result.stderr).toContain("openwork serve failed (attempt 1, exit 7)")
+      expect((await readFile(countFile, "utf8")).trim()).toBe("2")
+      expect((await readFile(sleepCapture, "utf8")).trim()).toBe("3")
+      expect(await readFile(startupLog, "utf8")).toContain("openwork attempt 2")
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+
+  test("starts openwork with the restart-safe env contract and volume symlinks", async () => {
+    const tempDir = await mkdtemp(join(tmpdir(), "daytona-startup-worker-"))
+    try {
+      const binDir = join(tempDir, "bin")
+      const capture = join(tempDir, "openwork.txt")
+      const workspaceMount = join(tempDir, "mounted-workspace")
+      const dataMount = join(tempDir, "mounted-data")
+      const runtimeWorkspace = join(tempDir, "runtime-workspace")
+      const runtimeData = join(tempDir, "runtime-data")
+      const sidecarDir = join(tempDir, "sidecars")
+      const injectionMarker = join(tempDir, "should-not-exist")
+      const clientToken = `client-$(touch ${injectionMarker})-literal`
+      await mkdir(binDir)
+      await writeExecutable(join(binDir, "opencode"), `#!/usr/bin/env sh
+printf 'fake opencode\n'
+`)
+      await writeExecutable(join(binDir, "openwork"), `#!/usr/bin/env sh
+: > "$OPENWORK_TEST_CAPTURE"
+i=0
+for arg in "$@"; do
+  printf 'ARG_%s=%s\n' "$i" "$arg" >> "$OPENWORK_TEST_CAPTURE"
+  i=$((i + 1))
+done
+for name in DEN_RUNTIME_PROVIDER DEN_WORKER_ID DEN_ACTIVITY_HEARTBEAT_ENABLED DEN_ACTIVITY_HEARTBEAT_URL DEN_ACTIVITY_HEARTBEAT_TOKEN OPENWORK_TOKEN OPENWORK_HOST_TOKEN OPENWORK_DATA_DIR OPENWORK_SIDECAR_DIR OPENWORK_WORKSPACE OPENWORK_PORT OPENWORK_OPENCODE_HOST OPENWORK_OPENCODE_PORT OPENWORK_CONNECT_HOST OPENWORK_CORS OPENWORK_APPROVAL OPENWORK_OPENCODE_SOURCE DAYTONA_WORKSPACE_MOUNT_PATH DAYTONA_DATA_MOUNT_PATH; do
+  value="$(printenv "$name")"
+  printf 'ENV_%s=%s\n' "$name" "$value" >> "$OPENWORK_TEST_CAPTURE"
+done
+exit 0
+`)
+
+      const result = runStartupScript({
+        ...buildDaytonaWorkerRuntimeEnv({
+          workerId: "worker_123",
+          hostToken: "host-secret",
+          clientToken,
+          activityToken: "activity-secret",
+          activityHeartbeatUrl: "https://den.example/v1/workers/worker_123/activity-heartbeat",
+          workspaceMountPath: workspaceMount,
+          dataMountPath: dataMount,
+          runtimeWorkspacePath: runtimeWorkspace,
+          runtimeDataPath: runtimeData,
+          sidecarDir,
+          openworkPort: 8787,
+          opencodePort: 4096,
+        }),
+        PATH: `${binDir}:${process.env.PATH ?? ""}`,
+        OPENWORK_STARTUP_LOG: join(tempDir, "startup.log"),
+        OPENWORK_TEST_CAPTURE: capture,
+      })
+
+      expect(result.status).toBe(0)
+      const captured = await readFile(capture, "utf8")
+      const opencodePath = join(binDir, "opencode")
+      expect(captured).toContain("ARG_0=serve")
+      expect(captured).toContain(`ARG_2=${runtimeWorkspace}`)
+      expect(captured).toContain("ARG_3=--remote-access")
+      expect(captured).toContain("ARG_4=--openwork-port")
+      expect(captured).toContain("ARG_5=8787")
+      expect(captured).toContain("ARG_6=--opencode-host")
+      expect(captured).toContain("ARG_7=127.0.0.1")
+      expect(captured).toContain("ARG_8=--opencode-port")
+      expect(captured).toContain("ARG_9=4096")
+      expect(captured).toContain("ARG_10=--connect-host")
+      expect(captured).toContain("ARG_11=127.0.0.1")
+      expect(captured).toContain("ARG_12=--cors")
+      expect(captured).toContain("ARG_13=*")
+      expect(captured).toContain("ARG_14=--approval")
+      expect(captured).toContain("ARG_15=manual")
+      expect(captured).toContain("ARG_16=--allow-external")
+      expect(captured).toContain("ARG_17=--opencode-source")
+      expect(captured).toContain("ARG_18=external")
+      expect(captured).toContain("ARG_19=--opencode-bin")
+      expect(captured).toContain(`ARG_20=${opencodePath}`)
+      expect(captured).toContain("ARG_21=--verbose")
+      expect(captured).toContain("ENV_DEN_ACTIVITY_HEARTBEAT_TOKEN=activity-secret")
+      expect(captured).toContain(`ENV_OPENWORK_TOKEN=${clientToken}`)
+      expect(captured).toContain("ENV_OPENWORK_HOST_TOKEN=host-secret")
+      expect(captured).toContain(`ENV_OPENWORK_DATA_DIR=${runtimeData}`)
+      expect(captured).toContain(`ENV_OPENWORK_SIDECAR_DIR=${sidecarDir}`)
+      expect(await lstat(injectionMarker).then(() => true, () => false)).toBe(false)
+
+      expect((await lstat(join(runtimeWorkspace, "volumes", "workspace"))).isSymbolicLink()).toBe(true)
+      expect(await readlink(join(runtimeWorkspace, "volumes", "workspace"))).toBe(workspaceMount)
+      expect((await lstat(join(runtimeWorkspace, "volumes", "data"))).isSymbolicLink()).toBe(true)
+      expect(await readlink(join(runtimeWorkspace, "volumes", "data"))).toBe(dataMount)
+    } finally {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
+++ b/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
@@ -25,6 +25,11 @@ RUN apt-get update \
 
 COPY --from=openwork-builder /src/apps/orchestrator/dist/bin/openwork /usr/local/bin/openwork
 COPY --from=openwork-builder /src/constants.json /usr/local/constants.json
+COPY ee/apps/den-worker-runtime/openwork-daytona-worker-start /usr/local/bin/openwork-daytona-worker-start
+
+RUN chmod 0755 /usr/local/bin/openwork-daytona-worker-start \
+  && mkdir -p /usr/local/share/openwork \
+  && touch /usr/local/share/openwork/daytona-worker-entrypoint
 
 RUN set -eux; \
   test -n "$OPENCODE_VERSION"; \
@@ -49,4 +54,5 @@ RUN set -eux; \
 RUN test "$(openwork --version)" = "$OPENWORK_ORCHESTRATOR_VERSION" \
   && opencode --version
 
-CMD ["sleep", "infinity"]
+# Daytona runs the image ENTRYPOINT on sandbox start; startup is env-driven.
+ENTRYPOINT ["/usr/local/bin/openwork-daytona-worker-start"]

--- a/ee/apps/den-worker-runtime/openwork-daytona-worker-start
+++ b/ee/apps/den-worker-runtime/openwork-daytona-worker-start
@@ -1,0 +1,117 @@
+#!/usr/bin/env sh
+set -eu
+
+# Daytona runs this image ENTRYPOINT on sandbox start; startup is env-driven and
+# intentionally ignores positional args.
+
+log() {
+  printf '%s\n' "openwork-daytona-worker-start: $*" >&2
+}
+
+fail() {
+  log "ERROR: $*"
+  exit 1
+}
+
+require_env() {
+  name="$1"
+  if value="$(printenv "$name")"; then
+    :
+  else
+    value=""
+  fi
+  if [ -z "$value" ]; then
+    fail "$name is required when DEN_WORKER_ID is set"
+  fi
+}
+
+require_number_env() {
+  require_env "$1"
+  case "$value" in
+    *[!0-9]*) fail "$name must be numeric" ;;
+  esac
+}
+
+if [ -z "${DEN_WORKER_ID:-}" ]; then
+  log "DEN_WORKER_ID not set; keeping snapshot container alive"
+  exec sleep infinity
+fi
+
+for name in \
+  DEN_RUNTIME_PROVIDER \
+  DEN_ACTIVITY_HEARTBEAT_ENABLED \
+  DEN_ACTIVITY_HEARTBEAT_URL \
+  DEN_ACTIVITY_HEARTBEAT_TOKEN \
+  OPENWORK_TOKEN \
+  OPENWORK_HOST_TOKEN \
+  OPENWORK_DATA_DIR \
+  OPENWORK_SIDECAR_DIR \
+  OPENWORK_WORKSPACE \
+  OPENWORK_OPENCODE_HOST \
+  OPENWORK_CONNECT_HOST \
+  OPENWORK_CORS \
+  OPENWORK_APPROVAL \
+  OPENWORK_OPENCODE_SOURCE \
+  DAYTONA_WORKSPACE_MOUNT_PATH \
+  DAYTONA_DATA_MOUNT_PATH
+do
+  require_env "$name"
+done
+
+require_number_env OPENWORK_PORT
+require_number_env OPENWORK_OPENCODE_PORT
+
+if ! command -v openwork >/dev/null 2>&1; then
+  fail "openwork binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot"
+fi
+
+if ! command -v opencode >/dev/null 2>&1; then
+  fail "opencode binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot"
+fi
+
+mkdir -p \
+  "$DAYTONA_WORKSPACE_MOUNT_PATH" \
+  "$DAYTONA_DATA_MOUNT_PATH" \
+  "$OPENWORK_WORKSPACE" \
+  "$OPENWORK_DATA_DIR" \
+  "$OPENWORK_SIDECAR_DIR" \
+  "$OPENWORK_WORKSPACE/volumes"
+ln -sfn "$DAYTONA_WORKSPACE_MOUNT_PATH" "$OPENWORK_WORKSPACE/volumes/workspace"
+ln -sfn "$DAYTONA_DATA_MOUNT_PATH" "$OPENWORK_WORKSPACE/volumes/data"
+
+opencode_bin="$(command -v opencode)"
+startup_log="${OPENWORK_STARTUP_LOG:-/tmp/openwork-daytona-worker-start.log}"
+: >> "$startup_log"
+start_attempts="${OPENWORK_START_ATTEMPTS:-3}"
+case "$start_attempts" in
+  *[!0-9]*) fail "OPENWORK_START_ATTEMPTS must be numeric" ;;
+esac
+
+log "starting OpenWork Daytona worker $DEN_WORKER_ID on port $OPENWORK_PORT"
+log "OpenWork output will append to $startup_log"
+attempt=0
+while [ "$attempt" -lt "$start_attempts" ]; do
+  attempt=$((attempt + 1))
+  if openwork serve \
+    --workspace "$OPENWORK_WORKSPACE" \
+    --remote-access \
+    --openwork-port "$OPENWORK_PORT" \
+    --opencode-host "$OPENWORK_OPENCODE_HOST" \
+    --opencode-port "$OPENWORK_OPENCODE_PORT" \
+    --connect-host "$OPENWORK_CONNECT_HOST" \
+    --cors "$OPENWORK_CORS" \
+    --approval "$OPENWORK_APPROVAL" \
+    --allow-external \
+    --opencode-source "$OPENWORK_OPENCODE_SOURCE" \
+    --opencode-bin "$opencode_bin" \
+    --verbose >> "$startup_log" 2>&1; then
+    exit 0
+  else
+    status="$?"
+  fi
+
+  log "openwork serve failed (attempt $attempt, exit $status); retrying in 3s"
+  sleep 3
+done
+
+exit 1

--- a/evals/flows/daytona-worker-restart-readiness.flow.mjs
+++ b/evals/flows/daytona-worker-restart-readiness.flow.mjs
@@ -1,0 +1,264 @@
+/**
+ * Internal Daytona proof: a configured worker returns after Daytona stop/start.
+ *
+ * Requires a disposable fixed sandbox created from the new snapshot. The flow is
+ * app-less: evidence is command output plus bounded public /health probes.
+ */
+import { spawnSync } from "node:child_process";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "daytona-worker-restart-readiness";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const requiredEnv = [
+  ["DAYTONA_WORKER_RESTART_SANDBOX_NAME", "Daytona sandbox name or id to stop/start"],
+  ["DAYTONA_WORKER_RESTART_HEALTH_URL", "Public Daytona worker /health URL to poll"],
+];
+
+function requireFlowEnv() {
+  const values = new Map();
+  const missing = [];
+  for (const [name, description] of requiredEnv) {
+    const value = process.env[name]?.trim();
+    if (!value) {
+      missing.push(`- ${name}: ${description}`);
+    } else {
+      values.set(name, value);
+    }
+  }
+  if (missing.length > 0) {
+    throw new Error(`Missing env for ${FLOW_ID}:\n${missing.join("\n")}`);
+  }
+
+  return {
+    sandboxName: values.get("DAYTONA_WORKER_RESTART_SANDBOX_NAME"),
+    healthUrl: normalizeHealthUrl(values.get("DAYTONA_WORKER_RESTART_HEALTH_URL")),
+  };
+}
+
+function normalizeHealthUrl(value) {
+  return value.replace(/\/+$/, "").endsWith("/health") ? value.replace(/\/+$/, "") : `${value.replace(/\/+$/, "")}/health`;
+}
+
+function runCommand(command, args, timeout = 120_000) {
+  const result = spawnSync(command, args, {
+    encoding: "utf8",
+    env: process.env,
+    timeout,
+  });
+  return {
+    command: [command, ...args].join(" "),
+    status: result.status,
+    stdout: result.stdout.trim(),
+    stderr: result.stderr.trim(),
+    error: result.error?.message ?? "",
+  };
+}
+
+function commandOutput(result) {
+  return [
+    `$ ${result.command}`,
+    `status: ${result.status}`,
+    result.stdout ? `stdout:\n${result.stdout}` : "stdout: <empty>",
+    result.stderr ? `stderr:\n${result.stderr}` : "stderr: <empty>",
+    result.error ? `error: ${result.error}` : "",
+  ].filter(Boolean).join("\n");
+}
+
+function witness(ctx, condition, assertion, actual) {
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual });
+    ctx.assert(false, assertion + (actual ? ` (actual: ${actual})` : ""));
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual });
+}
+
+async function fetchHealth(url, requestTimeoutMs) {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), requestTimeoutMs);
+  try {
+    return await fetch(url, { method: "GET", signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function pollHealth(url, timeoutMs) {
+  const startedAt = Date.now();
+  let last = "no probe completed";
+  while (Date.now() - startedAt < timeoutMs) {
+    const requestTimeoutMs = Math.min(10_000, Math.max(1, timeoutMs - (Date.now() - startedAt)));
+    try {
+      const response = await fetchHealth(url, requestTimeoutMs);
+      last = `HTTP ${response.status}`;
+      if (response.ok) {
+        return { ok: true, last, elapsedMs: Date.now() - startedAt };
+      }
+    } catch (error) {
+      last = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+  }
+  return { ok: false, last, elapsedMs: Date.now() - startedAt };
+}
+
+function sandboxState(record) {
+  if (!record) {
+    return "missing";
+  }
+  if (typeof record.state === "string") {
+    return record.state.toLowerCase();
+  }
+  if (typeof record.status === "string") {
+    return record.status.toLowerCase();
+  }
+  return "unknown";
+}
+
+function summaryField(record, key) {
+  const value = record?.[key];
+  if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+    return String(value);
+  }
+  return "<unset>";
+}
+
+function snapshotSummary(record) {
+  const snapshot = record?.snapshot;
+  if (typeof snapshot === "string" || typeof snapshot === "number") {
+    return String(snapshot);
+  }
+  if (snapshot && typeof snapshot === "object") {
+    const name = summaryField(snapshot, "name");
+    const id = summaryField(snapshot, "id");
+    return name !== "<unset>" ? name : id;
+  }
+  return "<unset>";
+}
+
+function sanitizeWarning(value) {
+  return value
+    .replace(/["']?(?:OPENWORK_TOKEN|OPENWORK_HOST_TOKEN|DEN_ACTIVITY_HEARTBEAT_TOKEN)["']?\s*[:=]\s*["']?[^"',\s}]+["']?/g, "[redacted-secret]")
+    .replace(/OPENWORK_TOKEN|OPENWORK_HOST_TOKEN|DEN_ACTIVITY_HEARTBEAT_TOKEN/g, "[redacted-secret-key]")
+    .slice(0, 1000);
+}
+
+function sanitizedInfoOutput(result, record, parseError = "") {
+  const lines = [
+    `$ ${result.command}`,
+    `status: ${result.status}`,
+    `sandbox: id=${summaryField(record, "id")} name=${summaryField(record, "name")} state=${summaryField(record, "state")} desiredState=${summaryField(record, "desiredState")} snapshot=${snapshotSummary(record)}`,
+  ];
+  if (result.stderr) {
+    lines.push(`warnings:\n${sanitizeWarning(result.stderr)}`);
+  }
+  if (result.error) {
+    lines.push(`error: ${sanitizeWarning(result.error)}`);
+  }
+  if (parseError) {
+    lines.push(`parse_error: ${sanitizeWarning(parseError)}`);
+    lines.push(`stdout: <unparsed redacted JSON; ${result.stdout.length} chars>`);
+  } else if (result.stdout) {
+    lines.push(`stdout: <parsed and sanitized; ${result.stdout.length} chars>`);
+  } else {
+    lines.push("stdout: <empty>");
+  }
+  return lines.join("\n");
+}
+
+function assertInfoOutputStaysSanitized() {
+  const output = sanitizedInfoOutput(
+    {
+      command: "daytona info sandbox --format json",
+      status: 0,
+      stdout: JSON.stringify({ id: "sandbox", name: "sandbox", state: "stopped", env: { PRIVATE: "secret-value" } }),
+      stderr: "",
+      error: "",
+    },
+    { id: "sandbox", name: "sandbox", state: "stopped", env: { PRIVATE: "secret-value" } },
+  );
+  if (output.includes("PRIVATE") || output.includes("secret-value") || output.includes("env")) {
+    throw new Error("Daytona info evidence sanitizer leaked an unknown field");
+  }
+}
+
+assertInfoOutputStaysSanitized();
+
+function infoSandbox(sandboxName) {
+  const result = runCommand("daytona", ["info", sandboxName, "--format", "json"], 60_000);
+  if (result.status !== 0 || !result.stdout) {
+    return { record: null, output: sanitizedInfoOutput(result, null) };
+  }
+  try {
+    const record = JSON.parse(result.stdout);
+    return { record, output: sanitizedInfoOutput(result, record) };
+  } catch (error) {
+    return { record: null, output: sanitizedInfoOutput(result, null, error instanceof Error ? error.message : String(error)) };
+  }
+}
+
+async function pollStopped(sandboxName, timeoutMs) {
+  const startedAt = Date.now();
+  let lastState = "unknown";
+  const evidence = [];
+  while (Date.now() - startedAt < timeoutMs) {
+    const info = infoSandbox(sandboxName);
+    evidence.push(info.output);
+    lastState = sandboxState(info.record);
+    if (lastState.includes("stopped")) {
+      return { stopped: true, lastState, elapsedMs: Date.now() - startedAt, evidence };
+    }
+    await new Promise((resolve) => setTimeout(resolve, 5_000));
+  }
+  return { stopped: false, lastState, elapsedMs: Date.now() - startedAt, evidence };
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Daytona production worker restarts from container startup",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Initial worker health is served publicly",
+      run: async (ctx) => {
+        const { healthUrl } = requireFlowEnv();
+        await ctx.prove("The configured Daytona worker is healthy before restart", {
+          voiceover: vo[0],
+          assert: async () => {
+            const health = await pollHealth(healthUrl, 60_000);
+            witness(ctx, health.ok, "Public Daytona /health returned 2xx before stop/start", `${health.last} after ${health.elapsedMs}ms`);
+            ctx.output("initial-health", `GET ${healthUrl}\n${health.last}\nelapsed_ms=${health.elapsedMs}`);
+          },
+        });
+      },
+    },
+    {
+      name: "Same worker returns after Daytona stop/start without manual relaunch",
+      run: async (ctx) => {
+        const { sandboxName, healthUrl } = requireFlowEnv();
+        await ctx.prove("The worker returns automatically after Daytona stop/start", {
+          voiceover: vo[1],
+          action: async () => {
+            const stop = runCommand("daytona", ["stop", sandboxName], 120_000);
+            ctx.output("daytona-stop", commandOutput(stop));
+            witness(ctx, stop.status === 0, "daytona stop exited 0", String(stop.status));
+
+            const stopped = await pollStopped(sandboxName, 180_000);
+            ctx.output("daytona-stopped-poll", stopped.evidence.slice(-6).join("\n\n"));
+            witness(ctx, stopped.stopped, "Daytona reported the sandbox fully stopped", `${stopped.lastState} after ${stopped.elapsedMs}ms`);
+
+            const start = runCommand("daytona", ["start", sandboxName], 120_000);
+            ctx.output("daytona-start", commandOutput(start));
+            witness(ctx, start.status === 0, "daytona start exited 0", String(start.status));
+          },
+          assert: async () => {
+            const health = await pollHealth(healthUrl, 240_000);
+            witness(ctx, health.ok, "Public Daytona /health returned 2xx after start without a manual openwork relaunch", `${health.last} after ${health.elapsedMs}ms`);
+            ctx.output("post-start-health", `GET ${healthUrl}\n${health.last}\nelapsed_ms=${health.elapsedMs}\nmanual_relaunch_command=<none>`);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/daytona-worker-restart-readiness.md
+++ b/evals/voiceovers/daytona-worker-restart-readiness.md
@@ -1,0 +1,5 @@
+# daytona-worker-restart-readiness — approved internal proof
+
+1. We start with the worker already healthy through its public Daytona health URL. This proves the sandbox is configured and the official runtime has OpenWork serving before we touch the instance.
+
+2. We stop and start that same Daytona sandbox, then only poll the public health URL. When health returns without any manual relaunch command, the frame proves the worker came back from the container startup path.


### PR DESCRIPTION
## Summary

- start Daytona-hosted OpenWork workers from the runtime image ENTRYPOINT so they return after sandbox stop/start
- persist the complete worker runtime contract in sandbox env and retain a marker-gated legacy fallback for older/custom images
- bound startup health probes, preserve useful diagnostics, and add restart-safe tests plus an internal fraimz flow

## Root cause

The provisioner launched `openwork serve` as a one-off async Daytona session. Stopping the sandbox killed that process, and starting it again only ran the image entrypoint; the worker server never returned. On the current `openwork-0.17.30` snapshot, `/health` stayed at HTTP 502 for 67 seconds after stop/start and the internal port refused connections.

## Validation

- `bun test ee/apps/den-api/test/daytona-runtime-env.test.ts` — 6 passed, 0 failed
- `bash -n ee/apps/den-worker-runtime/openwork-daytona-worker-start` — passed
- `node --check evals/flows/daytona-worker-restart-readiness.flow.mjs` — passed
- `DEN_API_LATEST_APP_VERSION=0.17.1 pnpm --filter @openwork-ee/den-api build` — passed
- built and published a fresh amd64 Daytona snapshot from this branch
- real Daytona stop/start: worker `/health` returned HTTP 200 automatically about 6 seconds after start, with no manual relaunch
- `pnpm fraimz --flow daytona-worker-restart-readiness` — PASSED; proof will be posted below

## Rollout note

Hosted Den must point `DAYTONA_SNAPSHOT` at a snapshot built from this change before newly provisioned workers gain restart-safe autostart.