### PR TITLE
fix(orchestrator): wait through slow startup health

### DIFF
--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -12,6 +12,7 @@
     "build:bin:bundled": "node scripts/clean-dist.mjs && node ../desktop/scripts/prepare-sidecar.mjs --outdir dist && bun ./script/build.ts --outdir dist --filename openwork && bun scripts/build-bin.ts",
     "build:sidecars": "node scripts/build-sidecars.mjs",
     "typecheck": "tsc -p tsconfig.typecheck.json",
+    "test": "bun test test/startup-health.test.ts",
     "test:files": "pnpm build && node scripts/files-session.mjs",
     "prepublishOnly": "node -e \"console.error('openwork-orchestrator is published via apps/orchestrator/scripts/publish-npm.mjs (meta + platform packages)'); process.exit(1);\""
   },

--- a/apps/orchestrator/src/cli.ts
+++ b/apps/orchestrator/src/cli.ts
@@ -39,6 +39,11 @@ import { createRequire } from "node:module";
 import { once } from "node:events";
 
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
+import {
+  waitForHealthy,
+  waitForHealthyViaProxy,
+  waitForOpencodeHealthy,
+} from "./startup-health.js";
 import type { TuiHandle } from "./tui/app.js";
 
 type ApprovalMode = "manual" | "auto";
@@ -2847,108 +2852,6 @@ function resolveSelfCommand(): { command: string; prefixArgs: string[] } {
     return { command: process.argv[0], prefixArgs: [arg1] };
   }
   return { command: process.argv[0], prefixArgs: [] };
-}
-
-async function waitForHealthy(
-  url: string,
-  timeoutMs = 10_000,
-  pollMs = 250,
-): Promise<void> {
-  const start = Date.now();
-  let lastError: string | null = null;
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const response = await fetch(`${url.replace(/\/$/, "")}/health`);
-      if (response.ok) return;
-      lastError = `HTTP ${response.status}`;
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
-    }
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-  }
-  throw new Error(lastError ?? "Timed out waiting for health check");
-}
-
-async function waitForOpencodeHealthy(
-  client: ReturnType<typeof createOpencodeClient>,
-  timeoutMs = 10_000,
-  pollMs = 250,
-) {
-  const start = Date.now();
-  let lastError: string | null = null;
-  while (Date.now() - start < timeoutMs) {
-    try {
-      const health = unwrap(await client.global.health());
-      if (health?.healthy) return health;
-      lastError = "Server reported unhealthy";
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
-    }
-
-    try {
-      // Some environments have a broken OpenCode /health probe even while the
-      // core API surface is already usable. Accept a successful path lookup as
-      // readiness so session APIs can come up in those runtimes.
-      unwrap(await client.path.get());
-      return { healthy: true, degraded: true, reason: lastError ?? undefined };
-    } catch (error) {
-      if (!lastError) {
-        lastError = error instanceof Error ? error.message : String(error);
-      }
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-  }
-  throw new Error(lastError ?? "Timed out waiting for OpenCode health");
-}
-
-/**
- * In sandbox mode the released openwork-server binary may not have our latest
- * token/proxy changes.  Instead of relying on the OpenCode SDK client (which
- * sends Bearer auth that the proxy may not understand yet), we do a simple
- * HTTP fetch through the proxy path.  The server's /opencode/* proxy already
- * forwards to the internal opencode port; we just need to check that it
- * returns a 2xx from /opencode/health (or falls through to opencode's own
- * /health endpoint).
- *
- * We try multiple path patterns because:
- * - `/opencode/health` — most common OpenCode health endpoint proxied by the
- *   server's catch-all /opencode/* route.
- * - `/health` on the openwork-server itself — already verified by the caller,
- *   but serves as a fallback signal.
- */
-async function waitForHealthyViaProxy(
-  proxyBaseUrl: string,
-  token: string,
-  timeoutMs = 10_000,
-  pollMs = 250,
-): Promise<void> {
-  const start = Date.now();
-  let lastError: string | null = null;
-  const headers: Record<string, string> = {};
-  if (token) headers.Authorization = `Bearer ${token}`;
-
-  while (Date.now() - start < timeoutMs) {
-    try {
-      // Try the proxied opencode health endpoint.
-      const res = await fetch(`${proxyBaseUrl}/health`, {
-        headers,
-        signal: AbortSignal.timeout(2000),
-      });
-      if (res.ok) return;
-      // Some older server versions may return 401/403 on the proxy but that
-      // still proves the server is up and proxying.  Accept any non-5xx as
-      // "alive" — the real auth validation happens in verifyOpenworkServer.
-      if (res.status < 500) return;
-      lastError = `Proxy returned ${res.status}`;
-    } catch (error) {
-      lastError = error instanceof Error ? error.message : String(error);
-    }
-    await new Promise((resolve) => setTimeout(resolve, pollMs));
-  }
-  throw new Error(
-    lastError ?? "Timed out waiting for OpenCode health via proxy",
-  );
 }
 
 function printHelp(): void {

--- a/apps/orchestrator/src/startup-health.ts
+++ b/apps/orchestrator/src/startup-health.ts
@@ -1,0 +1,209 @@
+export const DEFAULT_STARTUP_HEALTH_TIMEOUT_MS = 60_000;
+export const DEFAULT_HEALTH_ATTEMPT_TIMEOUT_MS = 2_000;
+const DEFAULT_HEALTH_POLL_MS = 250;
+
+type StartupFieldsResult<T> = {
+  data?: T;
+  error?: unknown;
+  request?: Request;
+  response?: Response;
+};
+
+type StartupOpencodeHealth = {
+  healthy?: boolean;
+  degraded?: boolean;
+  reason?: string;
+};
+
+type StartupOpencodeClient = {
+  global: {
+    health: () => Promise<StartupFieldsResult<StartupOpencodeHealth | undefined>>;
+  };
+  path: {
+    get: () => Promise<StartupFieldsResult<unknown>>;
+  };
+};
+
+type HealthResponse = Pick<Response, "ok" | "status">;
+type HealthFetch = (
+  url: string,
+  init: { headers?: Record<string, string>; signal: AbortSignal },
+) => Promise<HealthResponse>;
+
+class StartupProbeTimeoutError extends Error {
+  constructor(timeoutMs: number) {
+    super(`Probe timed out after ${timeoutMs}ms`);
+    this.name = "StartupProbeTimeoutError";
+  }
+}
+
+const defaultHealthFetch: HealthFetch = (url, init) => fetch(url, init);
+
+function unwrapResult<T>(result: StartupFieldsResult<T>): T {
+  if (result.data !== undefined) return result.data;
+  const message =
+    result.error instanceof Error
+      ? result.error.message
+      : typeof result.error === "string"
+        ? result.error
+        : JSON.stringify(result.error);
+  throw new Error(message || "Unknown error");
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function remainingTime(deadline: number): number {
+  return Math.max(0, deadline - Date.now());
+}
+
+function attemptTimeout(deadline: number, attemptTimeoutMs: number): number {
+  const remainingMs = remainingTime(deadline);
+  if (remainingMs <= 0) return 0;
+  return Math.max(1, Math.min(attemptTimeoutMs, remainingMs));
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_resolve, reject) => {
+        timer = setTimeout(
+          () => reject(new StartupProbeTimeoutError(timeoutMs)),
+          timeoutMs,
+        );
+      }),
+    ]);
+  } finally {
+    if (timer) clearTimeout(timer);
+  }
+}
+
+function timeoutError(message: string, lastError: string | null): Error {
+  return new Error(lastError ? `${message}: ${lastError}` : message);
+}
+
+async function sleepUntilNextPoll(deadline: number, pollMs: number): Promise<void> {
+  const sleepMs = Math.min(pollMs, remainingTime(deadline));
+  if (sleepMs > 0) await wait(sleepMs);
+}
+
+export async function waitForHealthy(
+  url: string,
+  timeoutMs = DEFAULT_STARTUP_HEALTH_TIMEOUT_MS,
+  pollMs = DEFAULT_HEALTH_POLL_MS,
+  attemptTimeoutMs = DEFAULT_HEALTH_ATTEMPT_TIMEOUT_MS,
+  fetchImpl: HealthFetch = defaultHealthFetch,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: string | null = null;
+  const healthUrl = `${url.replace(/\/$/, "")}/health`;
+
+  while (remainingTime(deadline) > 0) {
+    const timeout = attemptTimeout(deadline, attemptTimeoutMs);
+    try {
+      const response = await withTimeout(
+        fetchImpl(healthUrl, { signal: AbortSignal.timeout(timeout) }),
+        timeout,
+      );
+      if (response.ok) return;
+      lastError = `HTTP ${response.status}`;
+    } catch (error) {
+      lastError = errorMessage(error);
+    }
+    await sleepUntilNextPoll(deadline, pollMs);
+  }
+
+  throw timeoutError("Timed out waiting for health check", lastError);
+}
+
+export async function waitForOpencodeHealthy(
+  client: StartupOpencodeClient,
+  timeoutMs = DEFAULT_STARTUP_HEALTH_TIMEOUT_MS,
+  pollMs = DEFAULT_HEALTH_POLL_MS,
+  attemptTimeoutMs = DEFAULT_HEALTH_ATTEMPT_TIMEOUT_MS,
+) {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: string | null = null;
+
+  while (remainingTime(deadline) > 0) {
+    try {
+      const health = unwrapResult(
+        await withTimeout(
+          client.global.health(),
+          attemptTimeout(deadline, attemptTimeoutMs),
+        ),
+      );
+      if (health?.healthy) return health;
+      lastError = "Server reported unhealthy";
+    } catch (error) {
+      lastError = errorMessage(error);
+    }
+
+    if (remainingTime(deadline) > 0) {
+      try {
+        // Some environments have a broken OpenCode /health probe even while the
+        // core API surface is already usable. Accept a successful path lookup as
+        // readiness so session APIs can come up in those runtimes.
+        unwrapResult(
+          await withTimeout(
+            client.path.get(),
+            attemptTimeout(deadline, attemptTimeoutMs),
+          ),
+        );
+        return { healthy: true, degraded: true, reason: lastError ?? undefined };
+      } catch (error) {
+        if (!lastError) lastError = errorMessage(error);
+      }
+    }
+
+    await sleepUntilNextPoll(deadline, pollMs);
+  }
+
+  throw timeoutError("Timed out waiting for OpenCode health", lastError);
+}
+
+export async function waitForHealthyViaProxy(
+  proxyBaseUrl: string,
+  token: string,
+  timeoutMs = DEFAULT_STARTUP_HEALTH_TIMEOUT_MS,
+  pollMs = DEFAULT_HEALTH_POLL_MS,
+  attemptTimeoutMs = DEFAULT_HEALTH_ATTEMPT_TIMEOUT_MS,
+  fetchImpl: HealthFetch = defaultHealthFetch,
+): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: string | null = null;
+  const healthUrl = `${proxyBaseUrl.replace(/\/$/, "")}/health`;
+  const headers: Record<string, string> = {};
+  if (token) headers.Authorization = `Bearer ${token}`;
+
+  while (remainingTime(deadline) > 0) {
+    const timeout = attemptTimeout(deadline, attemptTimeoutMs);
+    try {
+      const response = await withTimeout(
+        fetchImpl(healthUrl, {
+          headers,
+          signal: AbortSignal.timeout(timeout),
+        }),
+        timeout,
+      );
+      if (response.ok) return;
+      // Some older server versions may return 401/403 on the proxy but that
+      // still proves the server is up and proxying. Accept any non-5xx as
+      // "alive" — the real auth validation happens in verifyOpenworkServer.
+      if (response.status < 500) return;
+      lastError = `Proxy returned ${response.status}`;
+    } catch (error) {
+      lastError = errorMessage(error);
+    }
+    await sleepUntilNextPoll(deadline, pollMs);
+  }
+
+  throw timeoutError("Timed out waiting for OpenCode health via proxy", lastError);
+}

--- a/apps/orchestrator/test/startup-health.test.ts
+++ b/apps/orchestrator/test/startup-health.test.ts
@@ -1,0 +1,96 @@
+import { expect, test } from "bun:test";
+import {
+  DEFAULT_STARTUP_HEALTH_TIMEOUT_MS,
+  waitForHealthy,
+  waitForHealthyViaProxy,
+  waitForOpencodeHealthy,
+} from "../src/startup-health";
+
+test("delayed OpenWork health eventually succeeds within the startup window", async () => {
+  const startedAt = Date.now();
+  let attempts = 0;
+
+  await waitForHealthy(
+    "http://openwork.test",
+    150,
+    5,
+    20,
+    async () => {
+      attempts += 1;
+      const ready = Date.now() - startedAt >= 30;
+      return { ok: ready, status: ready ? 200 : 503 };
+    },
+  );
+
+  expect(attempts).toBeGreaterThan(1);
+  expect(Date.now() - startedAt).toBeGreaterThanOrEqual(30);
+});
+
+test("never-resolving OpenCode SDK probes are bounded by the overall timeout", async () => {
+  const startedAt = Date.now();
+  const client = {
+    global: { health: () => new Promise<never>(() => undefined) },
+    path: { get: () => new Promise<never>(() => undefined) },
+  };
+
+  await expect(waitForOpencodeHealthy(client, 45, 5, 20)).rejects.toThrow(
+    "Timed out waiting for OpenCode health",
+  );
+
+  expect(Date.now() - startedAt).toBeLessThan(200);
+});
+
+test("OpenCode path fallback still marks readiness as degraded", async () => {
+  const health = await waitForOpencodeHealthy(
+    {
+      global: { health: async () => ({ data: { healthy: false } }) },
+      path: { get: async () => ({ data: { cwd: "/workspace" } }) },
+    },
+    100,
+    5,
+    20,
+  );
+
+  expect(health).toEqual({
+    healthy: true,
+    degraded: true,
+    reason: "Server reported unhealthy",
+  });
+});
+
+test("proxy health accepts non-5xx readiness with an explicit short timeout", async () => {
+  let attempts = 0;
+
+  await waitForHealthyViaProxy(
+    "http://openwork.test/opencode",
+    "proxy-token",
+    25,
+    100,
+    10,
+    async (url, init) => {
+      attempts += 1;
+      expect(url).toBe("http://openwork.test/opencode/health");
+      expect(init.headers?.Authorization).toBe("Bearer proxy-token");
+      return { ok: false, status: 403 };
+    },
+  );
+
+  expect(attempts).toBe(1);
+});
+
+test("explicit short timeouts remain honored and production default exceeds ten seconds", async () => {
+  expect(DEFAULT_STARTUP_HEALTH_TIMEOUT_MS).toBeGreaterThan(10_000);
+
+  const startedAt = Date.now();
+  await expect(
+    waitForHealthy(
+      "http://openwork.test",
+      25,
+      100,
+      1_000,
+      () => new Promise<never>(() => undefined),
+    ),
+  ).rejects.toThrow("Timed out waiting for health check");
+
+  expect(Date.now() - startedAt).toBeLessThan(200);
+});

--- a/evals/flows/production-server-restart-readiness.flow.mjs
+++ b/evals/flows/production-server-restart-readiness.flow.mjs
@@ -1,0 +1,237 @@
+/**
+ * Internal demo: production `openwork serve` keeps waiting through a slow
+ * OpenCode cold start. Daytona is only the execution environment; this flow
+ * does not provision or mutate Daytona images.
+ */
+import { spawnSync } from "node:child_process";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "production-server-restart-readiness";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const OLD_STARTUP_BOUNDARY_SECONDS = 10;
+const DELAYED_OPENCODE_SECONDS = 12;
+const POST_SERVE_DELAY_CHECK_SECONDS = OLD_STARTUP_BOUNDARY_SECONDS + 1;
+
+function redact(text) {
+  return String(text)
+    .replace(/(Authorization:\s*(?:Bearer|Basic)\s+)[^\s]+/gi, "$1<redacted>")
+    .replace(/(OPENWORK_(?:HOST_)?TOKEN=)[^\s]+/g, "$1<redacted>")
+    .replace(/([?&](?:token|access_token|ownerToken|hostToken)=)[^&\s]+/gi, "$1<redacted>");
+}
+
+function runInSandbox(ctx, script, timeout = 120_000) {
+  const encoded = Buffer.from(script, "utf8").toString("base64");
+  const result = spawnSync(
+    "daytona",
+    [
+      "exec",
+      ctx.env.OPENWORK_EVAL_DAYTONA_SANDBOX,
+      "--",
+      "echo",
+      encoded,
+      "|",
+      "base64",
+      "-d",
+      "|",
+      "bash",
+    ],
+    { encoding: "utf8", timeout },
+  );
+  const output = redact(`${result.stdout || ""}${result.stderr || ""}`);
+  if (result.status !== 0) {
+    throw new Error(`Daytona command failed (${result.status ?? "signal"}): ${output.trim()}`);
+  }
+  if (!output.trim()) {
+    throw new Error("Daytona command produced no output");
+  }
+  return output;
+}
+
+function record(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: redact(actual),
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${redact(actual)})` : ""}`);
+}
+
+function healthUrl(value) {
+  const trimmed = value.trim().replace(/\/$/, "");
+  return trimmed.endsWith("/health") ? trimmed : `${trimmed}/health`;
+}
+
+async function waitForPublicHealth(url, timeoutMs = 75_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = "not checked";
+  while (Date.now() < deadline) {
+    const remaining = Math.max(1, Math.min(2_000, deadline - Date.now()));
+    try {
+      const response = await fetch(url, { signal: AbortSignal.timeout(remaining) });
+      last = `HTTP ${response.status}`;
+      if (response.ok) return last;
+    } catch (error) {
+      last = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolve) => setTimeout(resolve, Math.min(1_000, Math.max(0, deadline - Date.now()))));
+  }
+  throw new Error(`Public health never became ready: ${redact(last)}`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Production openwork serve waits through slow OpenCode readiness",
+  kind: "internal",
+  requiresApp: false,
+  requiredEnv: [
+    "OPENWORK_EVAL_DAYTONA_SANDBOX",
+    "OPENWORK_EVAL_OPENWORK_BIN",
+    "OPENWORK_EVAL_OPENWORK_PUBLIC_HEALTH_URL",
+  ],
+  steps: [
+    {
+      name: "The production process is alive after the old ten-second boundary",
+      run: async (ctx) => {
+        await ctx.prove("A twelve-second OpenCode cold start no longer exits `openwork serve` at ten seconds", {
+          voiceover: vo[0],
+          assert: async () => {
+            const port = ctx.env.OPENWORK_EVAL_OPENWORK_PORT || "8787";
+            const opencodeBin = ctx.env.OPENWORK_EVAL_OPENCODE_BIN || "opencode";
+            const output = runInSandbox(ctx, `
+set -euo pipefail
+RUN_DIR=/tmp/openwork-production-server-restart-readiness
+OPENWORK_BIN=${JSON.stringify(ctx.env.OPENWORK_EVAL_OPENWORK_BIN)}
+OPENCODE_BIN_INPUT=${JSON.stringify(opencodeBin)}
+PORT=${JSON.stringify(port)}
+if [ -f "$RUN_DIR/openwork.pid" ]; then
+  OLD_PID="$(cat "$RUN_DIR/openwork.pid" || true)"
+  if [ -n "$OLD_PID" ] && kill -0 "$OLD_PID" 2>/dev/null; then kill "$OLD_PID" 2>/dev/null || true; fi
+fi
+rm -rf "$RUN_DIR"
+mkdir -p "$RUN_DIR/workspace"
+test -x "$OPENWORK_BIN"
+if [[ "$OPENCODE_BIN_INPUT" = */* ]]; then
+  REAL_OPENCODE="$OPENCODE_BIN_INPUT"
+else
+  REAL_OPENCODE="$(command -v "$OPENCODE_BIN_INPUT")"
+fi
+test -x "$REAL_OPENCODE"
+cat > "$RUN_DIR/slow-opencode" <<'WRAPPER'
+#!/usr/bin/env bash
+set -euo pipefail
+MARKER="\${OPENWORK_EVAL_WRAPPER_MARKER:?}"
+REAL_OPENCODE="\${OPENWORK_EVAL_REAL_OPENCODE:?}"
+DELAY_SECONDS="\${OPENWORK_EVAL_OPENCODE_DELAY_SECONDS:?}"
+FIRST="\${1:-<none>}"
+if [ "$FIRST" = "serve" ]; then
+  START_TS="$(date +%s)"
+  printf 'CALL first=serve delay=%s\n' "$DELAY_SECONDS" >> "$MARKER"
+  sleep "$DELAY_SECONDS"
+  END_TS="$(date +%s)"
+  printf 'DELAYED first=serve requested=%s elapsed=%s\n' "$DELAY_SECONDS" "$((END_TS - START_TS))" >> "$MARKER"
+else
+  printf 'CALL first=%s delay=0\n' "$FIRST" >> "$MARKER"
+fi
+exec "$REAL_OPENCODE" "$@"
+WRAPPER
+chmod +x "$RUN_DIR/slow-opencode"
+OPENWORK_EVAL_WRAPPER_MARKER="$RUN_DIR/wrapper-invocations.log" \
+OPENWORK_EVAL_REAL_OPENCODE="$REAL_OPENCODE" \
+OPENWORK_EVAL_OPENCODE_DELAY_SECONDS="${DELAYED_OPENCODE_SECONDS}" \
+OPENWORK_TOKEN=eval-client-token OPENWORK_HOST_TOKEN=eval-host-token nohup "$OPENWORK_BIN" serve \
+  --workspace "$RUN_DIR/workspace" \
+  --no-tui \
+  --allow-external \
+  --opencode-source external \
+  --opencode-bin "$RUN_DIR/slow-opencode" \
+  --openwork-port "$PORT" \
+  --remote-access \
+  --run-id production-server-restart-readiness \
+  > "$RUN_DIR/openwork.log" 2>&1 &
+PID="$!"
+printf '%s' "$PID" > "$RUN_DIR/openwork.pid"
+MARKER="$RUN_DIR/wrapper-invocations.log"
+SERVE_DELAY_SEEN=0
+for _ in $(seq 1 150); do
+  if ! kill -0 "$PID" 2>/dev/null; then
+    printf 'OPENWORK_PID_DIED_BEFORE_SERVE_DELAY_MARKER=yes\n'
+    exit 1
+  fi
+  if [ -f "$MARKER" ] && grep -q '^CALL first=serve delay=${DELAYED_OPENCODE_SECONDS}$' "$MARKER"; then
+    SERVE_DELAY_SEEN=1
+    break
+  fi
+  sleep 0.2
+done
+if [ "$SERVE_DELAY_SEEN" != "1" ]; then
+  printf 'SERVE_DELAY_MARKER_FOUND=no\n'
+  exit 1
+fi
+printf 'SERVE_DELAY_MARKER_FOUND=yes\n'
+sleep ${POST_SERVE_DELAY_CHECK_SECONDS}
+kill -0 "$PID"
+printf 'OPENWORK_PID=%s\n' "$PID"
+printf 'ALIVE_AFTER_SERVE_DELAY_BOUNDARY=yes\n'
+printf 'OLD_BOUNDARY_SECONDS=${OLD_STARTUP_BOUNDARY_SECONDS}\n'
+printf 'CHECK_AFTER_SERVE_DELAY_SECONDS=${POST_SERVE_DELAY_CHECK_SECONDS}\n'
+printf 'OPENCODE_DELAY_SECONDS=${DELAYED_OPENCODE_SECONDS}\n'
+printf 'WRAPPER_USES_REAL_OPENCODE=yes\n'
+printf 'WRAPPER_INVOCATIONS_BEGIN\n'
+cat "$RUN_DIR/wrapper-invocations.log"
+printf 'WRAPPER_INVOCATIONS_END\n'
+`, 45_000);
+
+            record(ctx, output.includes("SERVE_DELAY_MARKER_FOUND=yes"), "The opencode serve delay marker appeared before checking the old boundary");
+            record(ctx, output.includes("ALIVE_AFTER_SERVE_DELAY_BOUNDARY=yes"), "The production openwork process is still alive 11 seconds after the serve delay began");
+            record(ctx, output.includes("CHECK_AFTER_SERVE_DELAY_SECONDS=11"), "The old-boundary check ran 11 seconds after opencode serve delay began");
+            record(ctx, output.includes("OPENCODE_DELAY_SECONDS=12"), "The OpenCode wrapper delays the real binary for 12 seconds");
+            record(ctx, output.includes("CALL first=--version delay=0"), "The OpenCode --version preflight was not delayed by the wrapper");
+            record(ctx, output.includes("CALL first=serve delay=12"), "The 12-second delay was applied specifically to opencode serve");
+            record(ctx, output.includes("WRAPPER_USES_REAL_OPENCODE=yes"), "The wrapper execs the sandbox's real OpenCode binary after the delay");
+            ctx.output("Daytona production process check", output.trim());
+          },
+        });
+      },
+    },
+    {
+      name: "The shared public health endpoint becomes ready automatically",
+      run: async (ctx) => {
+        await ctx.prove("OpenWork server health reaches 2xx after the delayed OpenCode startup completes", {
+          voiceover: vo[1],
+          assert: async () => {
+            const url = healthUrl(ctx.env.OPENWORK_EVAL_OPENWORK_PUBLIC_HEALTH_URL);
+            const startedAt = Date.now();
+            try {
+              const status = await waitForPublicHealth(url);
+              const elapsedMs = Date.now() - startedAt;
+              record(ctx, status.startsWith("HTTP 2"), "The public OpenWork /health endpoint returns a 2xx status", status);
+              const marker = runInSandbox(ctx, `
+set -euo pipefail
+RUN_DIR=/tmp/openwork-production-server-restart-readiness
+test -f "$RUN_DIR/wrapper-invocations.log"
+cat "$RUN_DIR/wrapper-invocations.log"
+`, 20_000);
+              record(ctx, marker.includes("DELAYED first=serve requested=12"), "The serve-only 12-second delay completed before OpenWork became healthy");
+              ctx.output("Public health readiness", `PUBLIC_HEALTH_STATUS=${status}\nELAPSED_MS=${elapsedMs}\n${marker.trim()}`);
+            } finally {
+              try {
+                runInSandbox(ctx, `
+set -euo pipefail
+RUN_DIR=/tmp/openwork-production-server-restart-readiness
+if [ -f "$RUN_DIR/openwork.pid" ]; then
+  PID="$(cat "$RUN_DIR/openwork.pid" || true)"
+  if [ -n "$PID" ] && kill -0 "$PID" 2>/dev/null; then kill "$PID" 2>/dev/null || true; fi
+fi
+printf 'CLEANUP=done\n'
+`, 20_000);
+              } catch (error) {
+                ctx.output("Cleanup warning", redact(error instanceof Error ? error.message : String(error)));
+              }
+            }
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/production-server-restart-readiness.md
+++ b/evals/voiceovers/production-server-restart-readiness.md
@@ -1,0 +1,5 @@
+# production-server-restart-readiness — Shared production startup waits through slow OpenCode cold starts
+
+1. In an already running Daytona sandbox, we start the current-branch `openwork serve` binary with a wrapper that delays the real OpenCode server by twelve seconds. The important signal is that OpenWork is still running after the old ten-second boundary instead of exiting early.
+
+2. Without touching sandbox images or provisioning, we keep polling the shared public `/health` endpoint. Once the delayed OpenCode becomes healthy, OpenWork brings up its own server and the health check turns green automatically.


### PR DESCRIPTION
## Summary

- extend shared production startup health waits from 10 seconds to 60 seconds so slow OpenCode and OpenWork cold starts do not terminate the orchestrator
- bound each individual health probe to 2 seconds while preserving explicit short call-site timeouts, OpenCode path fallback, and proxy readiness semantics
- add focused regression tests plus an internal voiceover/fraimz flow for the real production `openwork serve` path

## Root cause

`openwork serve` waited only 10 seconds for OpenCode health. A legitimate cold start beyond that boundary rejected startup before `openwork-server` could spawn, shutting down the full production process.

## Validation

- `pnpm --filter openwork-orchestrator test` — passed (5 tests)
- `pnpm --filter openwork-orchestrator typecheck` — passed
- `pnpm --filter openwork-orchestrator build:bin` — passed
- Daytona Linux bundled build — passed after `pnpm --filter openwork-server build:bin` and `pnpm --filter openwork-orchestrator build:bin:bundled`
- `pnpm fraimz --flow production-server-restart-readiness` — Passed, run `2026-07-16T14-14-45-623Z`

## End-to-end proof

Using the official `openwork-0.17.30` Daytona snapshot as the runtime environment, the current-branch Linux binary stayed alive 11 seconds after a real `opencode serve` delay began, completed the full 12-second delay, and brought the public OpenWork `/health` endpoint to HTTP 200 without image or provisioning changes. The frame-by-frame proof will be posted below.