### PR TITLE
feat(app): streamline branded onboarding restart

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -112,6 +112,7 @@ export type DenBootstrapConfig = DenBaseUrls & {
   requireSignin: boolean;
   brandAppName?: string | null;
   brandLogoUrl?: string | null;
+  brandIconUrl?: string | null;
   claimLinks?: Array<{
     id: string;
     role: string;
@@ -589,6 +590,7 @@ function resolveDenBootstrapConfig(
     requireSignin?: boolean | null;
     brandAppName?: string | null;
     brandLogoUrl?: string | null;
+    brandIconUrl?: string | null;
     claimLinks?: DenBootstrapConfig["claimLinks"];
     handoff?: DenBootstrapHandoff | null;
     prepared?: DenBootstrapPrepared | null;
@@ -599,6 +601,7 @@ function resolveDenBootstrapConfig(
     requireSignin: input.requireSignin === true,
     ...(input.brandAppName?.trim() ? { brandAppName: input.brandAppName.trim().slice(0, 64) } : {}),
     ...(input.brandLogoUrl?.trim() ? { brandLogoUrl: input.brandLogoUrl.trim() } : {}),
+    ...(input.brandIconUrl?.trim() ? { brandIconUrl: input.brandIconUrl.trim() } : {}),
     ...(input.claimLinks ? { claimLinks: input.claimLinks } : {}),
     ...(input.handoff ? { handoff: input.handoff } : {}),
     ...(input.prepared ? { prepared: input.prepared } : {}),
@@ -616,6 +619,7 @@ function getPendingBootstrapConfig(next: DenSettings): DenBootstrapConfig | null
     requireSignin: previous.requireSignin,
     brandAppName: previous.brandAppName,
     brandLogoUrl: previous.brandLogoUrl,
+    brandIconUrl: previous.brandIconUrl,
     claimLinks: previous.claimLinks,
     handoff: previous.handoff,
     prepared: previous.prepared,
@@ -716,6 +720,7 @@ export async function setDenBootstrapConfig(
       requireSignin: normalized.requireSignin,
       ...(normalized.brandAppName ? { brandAppName: normalized.brandAppName } : {}),
       ...(normalized.brandLogoUrl ? { brandLogoUrl: normalized.brandLogoUrl } : {}),
+      ...(normalized.brandIconUrl ? { brandIconUrl: normalized.brandIconUrl } : {}),
       ...(normalized.handoff ? { handoff: normalized.handoff } : {}),
       ...(normalized.prepared ? { prepared: normalized.prepared } : {}),
     }) as ShellDesktopBootstrapConfig;
@@ -841,6 +846,7 @@ export function writeDenSettings(next: DenSettings, options?: { persistBootstrap
         requireSignin: currentBootstrap.requireSignin,
         brandAppName: currentBootstrap.brandAppName,
         brandLogoUrl: currentBootstrap.brandLogoUrl,
+        brandIconUrl: currentBootstrap.brandIconUrl,
       }).catch(() => undefined);
     }
   }

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -221,6 +221,7 @@ export function DenAuthProvider({ children }: DenAuthProviderProps) {
       requireSignin: bootstrap.requireSignin,
       ...(bootstrap.brandAppName ? { brandAppName: bootstrap.brandAppName } : {}),
       ...(bootstrap.brandLogoUrl ? { brandLogoUrl: bootstrap.brandLogoUrl } : {}),
+      ...(bootstrap.brandIconUrl ? { brandIconUrl: bootstrap.brandIconUrl } : {}),
       ...(bootstrap.claimLinks ? { claimLinks: bootstrap.claimLinks } : {}),
       handoff: null,
       ...(bootstrap.prepared ? { prepared: bootstrap.prepared } : {}),

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -20,11 +20,15 @@ import {
   readDenBootstrapConfig,
   readDenSettings,
   resolveDenBaseUrls,
+  setDenBootstrapConfig,
   writeDenSettings,
+  type DenDesktopConfig,
   type DenOrgLlmProvider,
   type DenOrgMarketplace,
   type DenOrgSummary,
 } from "@/app/lib/den";
+import { applyBrandAppName, applyBrandIcon, relaunchDesktopApp } from "@/app/lib/desktop";
+import { isAlphaUpdateAllowed, resolveFreshStableDesktopUpdate } from "@/app/lib/version-gate";
 import { exchangeHandoffAndSignIn } from "@/app/lib/den-handoff";
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
 import { usePlatform } from "../../kernel/platform";
@@ -66,8 +70,67 @@ import {
   RadioGroupItem,
 } from "@/components/ui/radio-group"
 import { useOrgListWindow } from "./use-org-list-window";
+import { useDesktopConfig } from "./desktop-config-provider";
+import {
+  hasWorkspaceBranding,
+  workspaceBrandingFingerprint,
+} from "./workspace-branding-restart";
 
 const RELOAD_AFTER_ONBOARDING_KEY = "openwork.reloadAfterOrgOnboarding";
+const APPLIED_BRANDING_FINGERPRINT_KEY = "openwork.den.appliedBrandingFingerprint";
+const BRANDING_RESTART_RESUME_KEY = "openwork.den.brandingRestartResume";
+
+type BrandingRestartState = {
+  fingerprint: string;
+  updateReady: boolean;
+  warning: string | null;
+};
+
+type OnboardingUpdaterBridge = NonNullable<Window["__OPENWORK_ELECTRON__"]>["updater"];
+
+declare global {
+  interface Window {
+    __openworkOnboardingUpdaterEvalBridge?: OnboardingUpdaterBridge;
+  }
+}
+
+function onboardingUpdaterBridge(): OnboardingUpdaterBridge | undefined {
+  if (import.meta.env.DEV && window.__openworkOnboardingUpdaterEvalBridge) {
+    return window.__openworkOnboardingUpdaterEvalBridge;
+  }
+  return window.__OPENWORK_ELECTRON__?.updater;
+}
+
+async function stageOnboardingUpdate(
+  desktopConfig: DenDesktopConfig,
+): Promise<boolean> {
+  const updater = onboardingUpdaterBridge();
+  if (!updater?.getChannel || !updater.check || !updater.download) return false;
+
+  const channelState = await updater.getChannel();
+  let targetVersion: string | undefined;
+  if (channelState.channel === "stable") {
+    const selection = await resolveFreshStableDesktopUpdate({
+      currentVersion: channelState.currentVersion,
+      refreshDesktopConfig: async () => desktopConfig,
+    });
+    if (selection?.kind !== "update") return false;
+    targetVersion = selection.targetVersion;
+  }
+
+  const update = await updater.check(channelState.channel, targetVersion);
+  if (!update.available || update.reason) return false;
+  if (
+    channelState.channel === "alpha" &&
+    update.latestVersion &&
+    !(await isAlphaUpdateAllowed(update.latestVersion, desktopConfig))
+  ) {
+    return false;
+  }
+
+  const download = await updater.download();
+  return download.ok;
+}
 
 function subscribeToDenSettings(onStoreChange: () => void) {
   window.addEventListener(denSettingsChangedEvent, onStoreChange);
@@ -294,6 +357,13 @@ export function OrgOnboardingPage() {
     }
   }, [authToken, navigate, orgId, prepared]);
 
+  useEffect(() => {
+    if (!authToken || !orgId) return;
+    if (window.localStorage.getItem(BRANDING_RESTART_RESUME_KEY) !== orgId) return;
+    window.localStorage.removeItem(BRANDING_RESTART_RESUME_KEY);
+    navigate("/session", { replace: true });
+  }, [authToken, navigate, orgId]);
+
   const { data, error, isPending } = useQuery({
     queryKey: ["den-org-onboarding", settings.baseUrl, "orgs"],
     enabled: Boolean(authToken),
@@ -371,6 +441,7 @@ export function ResourceSelectionPage() {
   const platform = usePlatform();
   const { markRouteReady } = useBootState();
   const { authToken, denClient, orgId, orgName, settings } = useDenClient();
+  const { refreshFresh } = useDesktopConfig();
 
   const prepared = usePreparedBootstrap();
 
@@ -379,6 +450,8 @@ export function ResourceSelectionPage() {
     modelId: string;
     label: string;
   } | null>(null);
+  const [preparingBranding, setPreparingBranding] = useState(false);
+  const [brandingRestart, setBrandingRestart] = useState<BrandingRestartState | null>(null);
 
   // Redirect if no auth or no org — can't show onboarding without them
   useEffect(() => {
@@ -412,7 +485,7 @@ export function ResourceSelectionPage() {
     }),
   });
 
-  const handleContinue = useCallback(() => {
+  const finishOnboarding = useCallback(() => {
     // If user picked a default model, write it
     if (selectedDefault) {
       writeStoredDefaultModel({
@@ -431,8 +504,156 @@ export function ResourceSelectionPage() {
     navigate("/session", { replace: true });
   }, [navigate, providers, selectedDefault]);
 
+  const handleContinue = useCallback(async () => {
+    if (!window.__OPENWORK_ELECTRON__?.shell?.relaunch) {
+      finishOnboarding();
+      return;
+    }
+
+    setPreparingBranding(true);
+    try {
+      const desktopConfig = await refreshFresh();
+      if (!hasWorkspaceBranding(desktopConfig)) {
+        finishOnboarding();
+        return;
+      }
+
+      const fingerprint = workspaceBrandingFingerprint(orgId, desktopConfig);
+      if (window.localStorage.getItem(APPLIED_BRANDING_FINGERPRINT_KEY) === fingerprint) {
+        finishOnboarding();
+        return;
+      }
+
+      const bootstrap = readDenBootstrapConfig();
+      await setDenBootstrapConfig({
+        ...bootstrap,
+        brandAppName: desktopConfig.brandAppName ?? null,
+        brandLogoUrl: desktopConfig.brandLogoUrl ?? null,
+        brandIconUrl: desktopConfig.brandIconUrl ?? null,
+      });
+      const [, iconResult] = await Promise.all([
+        applyBrandAppName(desktopConfig.brandAppName ?? null),
+        applyBrandIcon(desktopConfig.brandIconUrl ?? null),
+      ]);
+
+      let updateReady = false;
+      let warning = desktopConfig.brandIconUrl && !iconResult.ok
+        ? "The workspace app icon could not be prepared."
+        : null;
+      try {
+        updateReady = await stageOnboardingUpdate(desktopConfig);
+      } catch (error) {
+        warning ??= error instanceof Error ? error.message : "The application update could not be prepared.";
+      }
+      setBrandingRestart({ fingerprint, updateReady, warning });
+    } catch (error) {
+      setBrandingRestart({
+        fingerprint: workspaceBrandingFingerprint(orgId, {}),
+        updateReady: false,
+        warning: error instanceof Error ? error.message : "Workspace branding could not be prepared.",
+      });
+    } finally {
+      setPreparingBranding(false);
+    }
+  }, [finishOnboarding, orgId, refreshFresh]);
+
+  const restartWithBranding = useCallback(async () => {
+    if (!brandingRestart) return;
+    window.localStorage.setItem(APPLIED_BRANDING_FINGERPRINT_KEY, brandingRestart.fingerprint);
+    window.localStorage.setItem(BRANDING_RESTART_RESUME_KEY, orgId);
+    if (brandingRestart.updateReady) {
+      const result = await onboardingUpdaterBridge()?.installAndRestart?.();
+      if (result?.ok) return;
+    }
+    await relaunchDesktopApp();
+  }, [brandingRestart, orgId]);
+
+  const continueWithoutRestart = useCallback(() => {
+    if (brandingRestart) {
+      window.localStorage.setItem(APPLIED_BRANDING_FINGERPRINT_KEY, brandingRestart.fingerprint);
+    }
+    finishOnboarding();
+  }, [brandingRestart, finishOnboarding]);
+
   const totalModels = providers.reduce((sum, provider) => sum + provider.models.length, 0);
   const hasResources = providers.length > 0 || marketplaces.length > 0;
+
+  if (preparingBranding) {
+    return (
+      <Page>
+        <PageBackground />
+        <PageTitlebarRegion />
+        <PageContainer>
+          <PageHeader>
+            <div className="mx-auto flex size-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-hover">
+              <BuildingOffice2Icon className="size-7 text-foreground" />
+            </div>
+            <PageTitle>Preparing workspace identity</PageTitle>
+            <PageDescription>
+              Applying {orgName || "your workspace"}&apos;s branding and checking for an application update.
+            </PageDescription>
+          </PageHeader>
+          <PageContent>
+            <PageLoading>
+              <PageLoadingSpinner />
+              <PageLoadingDescription>Preparing workspace...</PageLoadingDescription>
+            </PageLoading>
+          </PageContent>
+        </PageContainer>
+      </Page>
+    );
+  }
+
+  if (brandingRestart) {
+    return (
+      <Page>
+        <PageBackground />
+        <PageTitlebarRegion />
+        <PageContainer>
+          <PageHeader>
+            <div className="mx-auto flex size-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-hover">
+              <BuildingOffice2Icon className="size-7 text-foreground" />
+            </div>
+            <PageTitle>Workspace identity is ready</PageTitle>
+            <PageDescription>
+              Restart OpenWork once to finish applying {orgName || "your workspace"}&apos;s name and app icon everywhere.
+            </PageDescription>
+            {brandingRestart.updateReady ? (
+              <div className="mx-auto flex w-fit items-center gap-2 rounded-full border border-green-6/30 bg-green-2/30 px-3 py-1 text-xs font-semibold text-green-11">
+                <CheckCircle2 className="size-3.5" />
+                Application update downloaded
+              </div>
+            ) : null}
+            {brandingRestart.warning ? (
+              <Alert>
+                <CircleAlert />
+                <AlertDescription>
+                  {brandingRestart.warning} You can still continue to the workspace.
+                </AlertDescription>
+              </Alert>
+            ) : null}
+          </PageHeader>
+          <PageContent>
+            <details className="mx-auto w-full max-w-md rounded-xl border border-dls-border bg-dls-surface px-4 py-3 text-sm">
+              <summary className="cursor-pointer font-medium">Why restart?</summary>
+              <p className="mt-2 text-muted-foreground">
+                Restarting refreshes the workspace name and icon across your operating system and installs the prepared application update.
+              </p>
+            </details>
+          </PageContent>
+          <PageFooter>
+            <Button type="button" variant="outline" onClick={continueWithoutRestart}>
+              Continue without restarting
+            </Button>
+            <Button type="button" size="lg" onClick={() => void restartWithBranding()}>
+              Restart OpenWork
+              <ArrowRight data-icon="inline-end" />
+            </Button>
+          </PageFooter>
+        </PageContainer>
+      </Page>
+    );
+  }
 
   return (
     <Page>
@@ -563,10 +784,14 @@ export function ResourceSelectionPage() {
             className="w-fit"
             type="button"
             size="lg"
-            onClick={handleContinue}
-            disabled={loading}
+            onClick={() => void handleContinue()}
+            disabled={loading || preparingBranding}
           >
-            {hasResources ? "Continue to workspace" : "Continue"}
+            {preparingBranding
+              ? "Preparing workspace..."
+              : hasResources
+                ? "Continue to workspace"
+                : "Continue"}
             <ArrowRight data-icon="inline-end" />
           </Button>
         </PageFooter>

--- a/apps/app/src/react-app/domains/cloud/workspace-branding-restart.test.ts
+++ b/apps/app/src/react-app/domains/cloud/workspace-branding-restart.test.ts
@@ -1,0 +1,30 @@
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toBe: (expected: unknown) => void;
+  not: { toBe: (expected: unknown) => void };
+};
+
+import {
+  hasWorkspaceBranding,
+  workspaceBrandingFingerprint,
+} from "./workspace-branding-restart";
+
+describe("workspace branding restart", () => {
+  test("detects every supported branding field", () => {
+    expect(hasWorkspaceBranding({ brandAppName: "Acme" })).toBe(true);
+    expect(hasWorkspaceBranding({ brandLogoUrl: "https://example.com/logo.png" })).toBe(true);
+    expect(hasWorkspaceBranding({ brandIconUrl: "https://example.com/icon.png" })).toBe(true);
+    expect(hasWorkspaceBranding({ brandAccentColor: "blue" })).toBe(true);
+    expect(hasWorkspaceBranding({})).toBe(false);
+  });
+
+  test("fingerprints the organization and all branding fields", () => {
+    const first = workspaceBrandingFingerprint("org-1", { brandIconUrl: "https://example.com/one.png" });
+    const repeated = workspaceBrandingFingerprint("org-1", { brandIconUrl: "https://example.com/one.png" });
+    const changed = workspaceBrandingFingerprint("org-1", { brandIconUrl: "https://example.com/two.png" });
+
+    expect(first).toBe(repeated);
+    expect(first).not.toBe(changed);
+  });
+});

--- a/apps/app/src/react-app/domains/cloud/workspace-branding-restart.ts
+++ b/apps/app/src/react-app/domains/cloud/workspace-branding-restart.ts
@@ -1,0 +1,28 @@
+import type { DenDesktopConfig } from "../../../app/lib/den";
+
+const BRANDING_KEYS = [
+  "brandAppName",
+  "brandLogoUrl",
+  "brandIconUrl",
+  "brandAccentColor",
+] as const satisfies readonly (keyof DenDesktopConfig)[];
+
+export function hasWorkspaceBranding(config: DenDesktopConfig): boolean {
+  return BRANDING_KEYS.some((key) => {
+    const value = config[key];
+    return typeof value === "string" && value.trim().length > 0;
+  });
+}
+
+export function workspaceBrandingFingerprint(
+  orgId: string,
+  config: DenDesktopConfig,
+): string {
+  return JSON.stringify([
+    orgId,
+    config.brandAppName ?? null,
+    config.brandLogoUrl ?? null,
+    config.brandIconUrl ?? null,
+    config.brandAccentColor ?? null,
+  ]);
+}

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2286,7 +2286,7 @@ ipcMain.handle("openwork:shell:openExternal", async (_event, url) => {
 });
 ipcMain.handle("openwork:shell:relaunch", async () => {
   app.relaunch();
-  app.exit(0);
+  app.quit();
 });
 ipcMain.handle("openwork:system:architecture", async () => resolveArchitectureInfo());
 ipcMain.handle("openwork:system:microphoneStatus", async () => {

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -247,6 +247,7 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
   let autoUpdaterLoaded = false;
   let checkedUpdateVersion = null;
   let checkedUpdateTargetVersion = null;
+  let updateDownloaded = false;
 
   function sendToRenderer(channel, data) {
     try {
@@ -279,7 +280,11 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
         // bundles (see enableSquirrelDirectContentsWrite for why).
         await enableSquirrelDirectContentsWrite();
         autoUpdaterInstance.on("error", (err) => {
+          updateDownloaded = false;
           console.warn("[updater] error", err);
+        });
+        autoUpdaterInstance.on("update-downloaded", () => {
+          updateDownloaded = true;
         });
         // Forward download progress to the renderer so the UI can show
         // incremental bytes instead of staying stuck at 0.
@@ -310,6 +315,7 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     const channel = await writeElectronUpdaterChannel(app, rawChannel);
     checkedUpdateVersion = null;
     checkedUpdateTargetVersion = null;
+    updateDownloaded = false;
     const updater = await ensureAutoUpdater();
     if (updater) {
       return applyElectronUpdaterFeed(app, updater);
@@ -343,6 +349,7 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
       const available = Boolean(info?.version && isVersionNewer(info.version, currentVersion));
       checkedUpdateVersion = available ? info.version : null;
       checkedUpdateTargetVersion = available ? targetVersion : null;
+      if (!available) updateDownloaded = false;
       return {
         available,
         currentVersion,
@@ -354,6 +361,7 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     } catch (error) {
       checkedUpdateVersion = null;
       checkedUpdateTargetVersion = null;
+      updateDownloaded = false;
       return {
         available: false,
         reason: String(error?.message ?? error),
@@ -388,13 +396,16 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
       // download applies cleanly on quit.
       await cleanStaleUpdaterState(app);
       await updater.downloadUpdate();
+      updateDownloaded = true;
       return { ok: true };
     } catch (error) {
+      updateDownloaded = false;
       return { ok: false, reason: String(error?.message ?? error) };
     }
   });
 
   ipcMain.handle("openwork:updater:installAndRestart", async () => {
+    if (!updateDownloaded) return { ok: false, reason: "update-not-downloaded" };
     const updater = await ensureAutoUpdater();
     if (!updater) return { ok: false, reason: "unavailable" };
     try {

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -1,7 +1,7 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { staleUpdaterStatePaths, targetedStableUpdaterFeed } from "./updater.mjs";
+import { registerUpdaterIpc, staleUpdaterStatePaths, targetedStableUpdaterFeed } from "./updater.mjs";
 
 const fakeApp = { getPath: (key) => (key === "home" ? "/Users/test" : `/Users/test/${key}`) };
 
@@ -52,5 +52,23 @@ describe("targetedStableUpdaterFeed", () => {
       () => targetedStableUpdaterFeed("unknown", "0.17.23"),
       /could not be validated/,
     );
+  });
+});
+
+describe("installAndRestart", () => {
+  it("refuses to invoke the installer before an update is downloaded", async () => {
+    const handlers = new Map();
+    registerUpdaterIpc({
+      app: { isPackaged: false },
+      ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
+      getMainWindow: () => null,
+    });
+
+    const install = handlers.get("openwork:updater:installAndRestart");
+    assert.equal(typeof install, "function");
+    assert.deepEqual(await install(), {
+      ok: false,
+      reason: "update-not-downloaded",
+    });
   });
 });

--- a/evals/flows/app-icon-auto-reload.flow.mjs
+++ b/evals/flows/app-icon-auto-reload.flow.mjs
@@ -1,0 +1,277 @@
+import http from "node:http";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("app-icon-auto-reload");
+const ICON_BASE64 = "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAmElEQVR4nO3QMREAIBDAsDeGA9wiEGRkoEP2Xmevc382OkBrgA7QGqADtAboAK0BOkBrgA7QGqADtAboAK0BOkBrgA7QGqADtAboAK0BOkBrgA7QGqADtAboAK0BOkBrgA7QGqADtAboAK0BOkBrgA7QGqADtAboAK0BOkBrgA7QGqADtAboAK0BOkBrgA7QGqADtAboAO0B99yyDomP74MAAAAASUVORK5CYII=";
+const ORG = { id: "org_eval_branding", name: "Acme Robotics", slug: "acme-robotics", role: "owner" };
+
+function json(response, body) {
+  response.writeHead(200, {
+    "access-control-allow-headers": "authorization,content-type,x-openwork-legacy-org-id",
+    "access-control-allow-methods": "GET,POST,OPTIONS",
+    "access-control-allow-origin": "*",
+    "content-type": "application/json",
+  });
+  response.end(JSON.stringify(body));
+}
+
+async function startBrandingServer(ctx) {
+  const icon = Buffer.from(ICON_BASE64, "base64");
+  const server = http.createServer((request, response) => {
+    const requestPath = request.url?.replace(/^\/api\/den/, "") ?? "";
+    if (request.method === "OPTIONS") {
+      response.writeHead(204, {
+        "access-control-allow-headers": "authorization,content-type,x-openwork-legacy-org-id",
+        "access-control-allow-methods": "GET,POST,OPTIONS",
+        "access-control-allow-origin": "*",
+      });
+      response.end();
+      return;
+    }
+    if (requestPath === "/icon.png") {
+      response.writeHead(200, { "access-control-allow-origin": "*", "content-type": "image/png" });
+      response.end(icon);
+      return;
+    }
+    if (requestPath === "/v1/me") {
+      json(response, { user: { id: "usr_eval", email: "alex@acme.test", name: "Alex Chen" } });
+      return;
+    }
+    if (requestPath === "/v1/me/orgs") {
+      json(response, { orgs: [ORG], activeOrgId: ORG.id, activeOrgSlug: ORG.slug });
+      return;
+    }
+    if (requestPath === "/v1/me/desktop-config") {
+      const iconUrl = `http://127.0.0.1:${server.address().port}/icon.png`;
+      json(response, {
+        brandAppName: "Acme Work",
+        brandLogoUrl: iconUrl,
+        brandIconUrl: iconUrl,
+        brandAccentColor: "violet",
+      });
+      return;
+    }
+    if (requestPath === "/v1/llm-providers") {
+      json(response, { llmProviders: [] });
+      return;
+    }
+    if (requestPath.startsWith("/v1/marketplaces")) {
+      json(response, {
+        items: [{
+          id: "marketplace_eval",
+          name: "Acme Extensions",
+          description: "Organization-provided tools",
+          status: "active",
+          pluginCount: 3,
+        }],
+      });
+      return;
+    }
+    if (requestPath === "/v1/app-version") {
+      json(response, { minAppVersion: "0.17.1", latestAppVersion: "0.17.30", publishedDesktopVersions: ["0.17.30"] });
+      return;
+    }
+    if (requestPath === "/v1/me/active-organization" && request.method === "POST") {
+      json(response, { ok: true });
+      return;
+    }
+    json(response, {});
+  });
+  await new Promise((resolve) => server.listen(0, "127.0.0.1", resolve));
+  server.unref();
+  ctx.brandingServer = server;
+  ctx.denBaseUrl = `http://127.0.0.1:${server.address().port}`;
+  ctx.org = ORG;
+}
+
+async function seedDesktopSession(ctx) {
+  await ctx.eval(`(() => {
+    localStorage.setItem('openwork.den.authToken', 'eval-token');
+    localStorage.setItem('openwork.den.activeOrgId', ${JSON.stringify(ctx.org.id)});
+    localStorage.setItem('openwork.den.activeOrgSlug', ${JSON.stringify(ctx.org.slug)});
+    localStorage.setItem('openwork.den.activeOrgName', ${JSON.stringify(ctx.org.name)});
+    localStorage.removeItem('openwork.den.appliedBrandingFingerprint');
+    localStorage.removeItem('openwork.den.brandingRestartResume');
+    return true;
+  })()`);
+  await ctx.control("eval.auth.set-base-url", { baseUrl: ctx.denBaseUrl });
+  await ctx.eval("location.hash = '/onboarding'; location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 45_000, label: "control API after onboarding reload" });
+  await ctx.eval(`(() => {
+    window.__openworkUpdateDownloadedForOnboarding = false;
+    window.__openworkOnboardingInstallCalled = false;
+    window.__openworkReadDesktopVersionMetadataEval = async () => ({
+      minAppVersion: '0.17.1',
+      latestAppVersion: '0.17.30',
+      publishedDesktopVersions: ['0.17.30'],
+    });
+    window.__openworkOnboardingUpdaterEvalBridge = {
+      getChannel: async () => ({ channel: 'stable', feedUrl: 'eval', currentVersion: '0.17.29' }),
+      check: async () => ({
+        available: true,
+        currentVersion: '0.17.29',
+        latestVersion: '0.17.30',
+        channel: 'stable',
+        feedUrl: 'eval',
+      }),
+      download: async () => {
+        await new Promise((resolve) => setTimeout(resolve, 1500));
+        window.__openworkUpdateDownloadedForOnboarding = true;
+        return { ok: true };
+      },
+      installAndRestart: async () => {
+        window.__openworkOnboardingInstallCalled = true;
+        return { ok: true };
+      },
+    };
+    window.dispatchEvent(new CustomEvent('openwork-den-settings-changed', { detail: {} }));
+    window.dispatchEvent(new CustomEvent('openwork-den-session-updated', { detail: { token: 'eval-token' } }));
+    return true;
+  })()`);
+}
+
+export default {
+  id: "app-icon-auto-reload",
+  title: "Branded cloud onboarding prepares one restart before entering the workspace",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Organization resources",
+      run: async (ctx) => {
+        await ctx.prove("A signed-in member chooses the branded organization and reviews its resources", {
+          voiceover: vo[0],
+          action: async () => {
+            await startBrandingServer(ctx);
+            await seedDesktopSession(ctx);
+            await ctx.waitForText("Choose your organization", { timeoutMs: 45_000 });
+            await ctx.clickText(ctx.org.name, { selector: "label, [role=radio]", timeoutMs: 10_000 });
+            await ctx.clickText("Continue with organization", { timeoutMs: 10_000 });
+            await ctx.waitForText("Continue to workspace", { timeoutMs: 45_000 });
+            await ctx.waitFor("document.body.innerText.trim() !== 'Preparing workspace'", {
+              timeoutMs: 45_000,
+              label: "resource page visible after workspace preparation",
+            });
+            await ctx.waitFor(`(() => {
+              const overlay = document.querySelector('[role="status"][aria-live="polite"]');
+              return !overlay || getComputedStyle(overlay).opacity === '0';
+            })()`, { timeoutMs: 45_000, label: "boot overlay hidden" });
+          },
+          assert: async () => {
+            await ctx.expectText("You have access to the following resources");
+            await ctx.expectText("Continue to workspace");
+          },
+          screenshot: {
+            name: "organization-resources",
+            requireText: ["Acme Robotics", "You have access to the following resources", "Continue to workspace"],
+            hashIncludes: "/onboarding",
+          },
+        });
+      },
+    },
+    {
+      name: "Brand identity prepared",
+      run: async (ctx) => {
+        await ctx.prove("OpenWork fetches and prepares the selected organization's desktop identity", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.clickText("Continue to workspace", { timeoutMs: 10_000 });
+            await ctx.waitForText("Preparing workspace identity", { timeoutMs: 10_000 });
+            await ctx.waitFor("document.body.innerText.trim() !== 'Preparing workspace'", {
+              timeoutMs: 45_000,
+              label: "branding preparation page visible",
+            });
+            await ctx.waitFor(`(() => {
+              const overlay = document.querySelector('[role="status"][aria-live="polite"]');
+              return !overlay || getComputedStyle(overlay).opacity === '0';
+            })()`, { timeoutMs: 45_000, label: "boot overlay hidden during branding preparation" });
+          },
+          assert: async () => {
+            await ctx.expectText("Preparing workspace identity");
+            const config = await ctx.eval(`(() => {
+              const suffix = '::' + ${JSON.stringify(ctx.org.id)};
+              const key = Object.keys(localStorage).find((candidate) => candidate.startsWith('openwork.den.desktopConfig:') && candidate.endsWith(suffix));
+              return JSON.parse(key ? localStorage.getItem(key) ?? '{}' : '{}');
+            })()`);
+            ctx.assert(config.brandAppName === "Acme Work", "Fresh desktop config did not cache the branded app name.");
+            ctx.assert(typeof config.brandIconUrl === "string", "Fresh desktop config did not cache the app icon.");
+          },
+          screenshot: {
+            name: "brand-identity-ready",
+            requireText: ["Preparing workspace identity", "checking for an application update"],
+          },
+        });
+      },
+    },
+    {
+      name: "Update staged",
+      run: async (ctx) => {
+        await ctx.prove("An eligible application update is downloaded before restart is offered", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.waitForText("Workspace identity is ready", { timeoutMs: 60_000 });
+          },
+          assert: async () => {
+            ctx.assert(await ctx.eval("window.__openworkUpdateDownloadedForOnboarding === true"), "The update was not downloaded.");
+            await ctx.expectText("Application update downloaded");
+          },
+          screenshot: {
+            name: "application-update-downloaded",
+            requireText: ["Application update downloaded", "Restart OpenWork"],
+          },
+        });
+      },
+    },
+    {
+      name: "One restart choice",
+      run: async (ctx) => {
+        await ctx.prove("The member gets one clear restart choice without being trapped", {
+          voiceover: vo[3],
+          action: async () => {
+            await ctx.clickText("Why restart?", { selector: "summary", timeoutMs: 10_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Restart OpenWork");
+            await ctx.expectText("Continue without restarting");
+            await ctx.expectText("refreshes the workspace name and icon");
+          },
+          screenshot: {
+            name: "one-restart-choice",
+            requireText: ["Restart OpenWork", "Continue without restarting", "refreshes the workspace name and icon"],
+          },
+        });
+      },
+    },
+    {
+      name: "Direct workspace resume",
+      run: async (ctx) => {
+        await ctx.prove("The coordinated restart resumes directly into the selected branded workspace", {
+          voiceover: vo[4],
+          action: async () => {
+            await ctx.clickText("Restart OpenWork", { timeoutMs: 10_000 });
+            await ctx.waitFor("window.__openworkOnboardingInstallCalled === true", {
+              timeoutMs: 10_000,
+              label: "coordinated updater install",
+            });
+            await ctx.eval("location.reload()");
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 45_000, label: "app after restart" });
+            await ctx.waitFor("location.hash.includes('/session')", { timeoutMs: 45_000, label: "workspace session route" });
+          },
+          assert: async () => {
+            await ctx.expectNoText("Choose your organization");
+            await ctx.expectNoText("Workspace identity is ready");
+            ctx.assert(
+              await ctx.eval("localStorage.getItem('openwork.den.brandingRestartResume') === null"),
+              "The one-shot restart resume marker was not consumed.",
+            );
+            await new Promise((resolve) => ctx.brandingServer.close(resolve));
+          },
+          screenshot: {
+            name: "workspace-after-one-restart",
+            rejectText: ["Choose your organization", "Workspace identity is ready"],
+            hashIncludes: "/session",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/app-icon-auto-reload.md
+++ b/evals/voiceovers/app-icon-auto-reload.md
@@ -1,0 +1,11 @@
+# app-icon-auto-reload — Workspace changes require one restart
+
+1. The member signs in, chooses their organization, and reviews the resources their workspace provides.
+
+2. OpenWork detects that the organization has a custom desktop identity and prepares its name, wordmark, icon, and accent color.
+
+3. If an application update is available, OpenWork downloads it before asking the member to continue.
+
+4. OpenWork explains that one restart will finish applying the organization's desktop identity. The member can restart now or continue if preparation failed.
+
+5. OpenWork restarts once, installs any staged update, and opens directly into the selected workspace with its branding applied.


### PR DESCRIPTION
## Summary
- prepare organization branding during post-sign-in resource onboarding
- stage eligible desktop updates and offer one coordinated restart
- persist app-icon bootstrap state and resume directly into the selected workspace
- prevent updater installation before a download is staged

## Validation
Previously completed before this PR request; not rerun per request:
- `pnpm --filter @openwork/app typecheck`
- focused branding and Electron updater tests
- Electron typecheck
- fraimz passed: `evals/results/2026-07-16T13-57-49-067Z/fraimz.html`

## Evidence
The local fraimz run passed all five user-facing frames. No additional recording or test run was performed while opening this PR.