### PR TITLE
feat(den-api): Connect rail default-on with org-level kill switch (drain D1)

### DIFF
--- a/docs/marketplace-capabilities-architecture.md
+++ b/docs/marketplace-capabilities-architecture.md
@@ -200,35 +200,43 @@ Scope note: these are `mcp:read`-class operations; nothing on this path writes; 
 
 ---
 
-## 7. Rollout gate
+## 7. Org kill switch
 
-New module: `ee/apps/den-api/src/capability-sources/marketplace-capabilities-rollout.ts`, mirroring `ee/apps/den-api/src/capability-sources/external-mcp-rollout.ts`.
+Marketplace capability search/execute uses the same effective Connect rail check
+as External MCP connections: `memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled })`
+in `ee/apps/den-api/src/capability-sources/external-mcp-rollout.ts`.
+`gatingEnabled` and `DEN_MCP_CONNECTIONS_GATING_ENABLED` are deprecated and
+inert; they stay wired only so existing deployment configs and call sites keep
+working.
 
-Function: `marketplaceCapabilitiesEnabled(metadata, { gatingEnabled })`.
-
-Environment variable: `DEN_MARKETPLACE_CAPABILITIES_GATING_ENABLED`, wired in `ee/apps/den-api/src/env.ts` like `mcpConnectionsGatingEnabled`.
-
-Org metadata opt-in key:
+Org metadata kill-switch key:
 
 ```json
-{ "marketplaceCapabilitiesEnabled": true }
+{ "capabilities": { "mcpConnections": false } }
 ```
 
-Gating is off by default, so local dev, self-hosted, and evals get the feature immediately. Hosted production deploys with gating ON, so no org sees any change until opted in.
+Connect is default-on, so local dev, self-hosted, evals, and hosted production
+get the feature immediately unless an org explicitly opts out. The backoffice
+capability value outranks legacy flat aliases (`connectEnabled` and
+`mcpConnectionsEnabled`).
 
-Check the gate in both paths: search returns an empty marketplace merge; execute returns `unknown_capability`. Gated-off is byte-identical to nonexistence.
+Check the kill switch in both paths: disabled orgs get an empty marketplace
+merge; execute returns `unknown_capability`. Opted-out is byte-identical to
+nonexistence.
 
 ### Additive invariants
 
 1. Desktop users without the cloud connection: this code is unreachable; zero change.
-2. Cloud-connected users in non-opted orgs: byte-identical search results and execute behavior.
+2. Cloud-connected users in opted-out orgs: byte-identical search results and execute behavior.
 3. Tool surface unchanged: still exactly `search_capabilities` + `execute_capability`.
 4. The desktop install flow (`apps/server/src/cloud-plugins.ts`) is untouched; installed plugins keep working identically; nothing migrates, nothing is deprecated in Phase 1.
 5. The rich `/mcp` endpoint and `/mcp/admin` are untouched. External connections also merged only into `/mcp/agent`.
 6. No schema changes, no migrations, no new tables in Phase 1; everything derives from existing plugin-arch tables in `ee/packages/den-db/src/schema/sharables/plugin-arch.ts`.
 7. No prompt changes and no tool-description changes in Phase 1; results are self-describing via `summary`, `status`, and `hint`.
 
-Kill switch uses the same two layers as connections: flip org metadata through an ops script following `ee/apps/den-api/scripts/mcp-connections-rollout.ts`, or flip the env gate at deploy time following `scripts/revert-org-mcp-connections.sh`.
+Kill switch uses the same layer as connections: flip org metadata in /admin (or
+an ops script) by setting `metadata.capabilities.mcpConnections` to `false`.
+The old deployment-level env gate is deprecated and inert.
 
 ---
 
@@ -236,12 +244,11 @@ Kill switch uses the same two layers as connections: flip org metadata through a
 
 ### Phase 1: this document's scope, Den-only, additive
 
-Build the marketplace search source, the execute branch for all classes with honest statuses, the rollout gate, tests, and eval flow. There are zero desktop changes and zero behavior changes for anyone until an org is opted in when hosted gating is enabled.
+Build the marketplace search source, the execute branch for all classes with honest statuses, the org kill switch, tests, and eval flow. There are zero desktop changes; member-facing Connect rail behavior is default-on unless an org explicitly opts out.
 
 Deliverables:
 
 - New: `ee/apps/den-api/src/mcp/marketplace-capabilities.ts`.
-- New: `ee/apps/den-api/src/capability-sources/marketplace-capabilities-rollout.ts`.
 - Touched: `ee/apps/den-api/src/mcp/agent.ts` at the two merge points.
 - Touched: `ee/apps/den-api/src/env.ts`.
 - New: `ee/apps/den-api/test/marketplace-capabilities.test.ts`.

--- a/ee/apps/den-api/src/capability-sources/external-mcp-rollout.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-rollout.ts
@@ -1,22 +1,18 @@
 /**
- * Staged-rollout gate for member-facing org MCP connections.
+ * Kill switch for member-facing org MCP connections.
  *
- * When a deployment enables gating (DEN_MCP_CONNECTIONS_GATING_ENABLED=true,
- * see env.ts), members of an organization only discover connections once the
- * org opted in via the `mcpConnections` organization capability controlled from
- * the /admin backoffice. Flat `metadata.mcpConnectionsEnabled: true`
- * (historical) and `metadata.connectEnabled: true` (forward-compat) are honored
- * aliases, while the wire name exposed to clients is `connectEnabled`.
- * Non-opted-in orgs get an empty list — byte-identical to an org with no
- * published connections, on every desktop version in the field. Admin
+ * Connect is default-on for every org. Platform admins can explicitly disable
+ * the member-facing rail with `metadata.capabilities.mcpConnections: false`;
+ * that backoffice capability outranks the historical flat aliases
+ * (`metadata.mcpConnectionsEnabled` and `metadata.connectEnabled`). Admin
  * management (scope=manageable, create, access grants) stays available so orgs
- * can stage connections before the capability flips.
+ * can stage or repair connections while members see an empty list.
  *
- * Gating is off by default so local dev, evals, and self-hosted deployments
- * keep the feature working out of the box.
+ * DEN_MCP_CONNECTIONS_GATING_ENABLED is deprecated and inert. env.ts still
+ * accepts it, and callers still pass `options.gatingEnabled`, so existing
+ * deployment configs and call sites continue to work while this helper ignores
+ * the deployment-level gate.
  */
-
-import { organizationHasCapability } from "../organization-capabilities.js"
 
 type MetadataInput = Record<string, unknown> | string | null | undefined
 
@@ -45,11 +41,20 @@ export function memberFacingMcpConnectionsEnabled(
   metadata: MetadataInput,
   options: { gatingEnabled: boolean },
 ): boolean {
-  if (!options.gatingEnabled) {
+  const parsed = parseMetadata(metadata)
+  const capabilities = isRecord(parsed.capabilities) ? parsed.capabilities : {}
+
+  if (capabilities.mcpConnections === true) {
     return true
   }
-  const parsed = parseMetadata(metadata)
-  return organizationHasCapability(metadata, "mcpConnections") ||
-    parsed.mcpConnectionsEnabled === true ||
-    parsed.connectEnabled === true
+  if (capabilities.mcpConnections === false) {
+    return false
+  }
+  if (parsed.connectEnabled === true || parsed.mcpConnectionsEnabled === true) {
+    return true
+  }
+  if (parsed.connectEnabled === false || parsed.mcpConnectionsEnabled === false) {
+    return false
+  }
+  return true
 }

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -325,11 +325,10 @@ const connectLink = connectLinkMode === "signed" && connectLinkPrivateKeyPem && 
   ? { privateKeyPem: connectLinkPrivateKeyPem, kid: connectLinkKid }
   : null
 
-// Staged rollout for member-facing org MCP connections: when gating is
-// enabled (hosted deployments), GET /v1/mcp-connections?scope=usable returns
-// an empty list unless the organization opted in via the mcpConnections
-// organization capability. Off by default so local dev, evals, and self-hosted
-// deployments keep the feature working out of the box.
+// Deprecated compatibility knob for member-facing org MCP connections. The
+// environment variable is still parsed so existing deployment configs keep
+// starting, but memberFacingMcpConnectionsEnabled ignores this value: Connect is
+// default-on unless org metadata explicitly disables it.
 const mcpConnectionsGatingEnabled =
   (parsed.DEN_MCP_CONNECTIONS_GATING_ENABLED ?? "false").toLowerCase() === "true"
 

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -522,8 +522,8 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         capabilities: {
           ...capabilities,
           // Expose the effective value, not the raw stored flag: org context
-          // answers whether the feature exists for this org on this deployment;
-          // /admin reads the raw capability from its own endpoint.
+          // answers whether the feature exists for this org; /admin reads the
+          // raw capability from its own endpoint.
           mcpConnections: memberFacingMcpConnectionsEnabled(payload.organization.metadata, {
             gatingEnabled: env.mcpConnectionsGatingEnabled,
           }),

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -1175,9 +1175,9 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         return c.json({ connections })
       }
 
-      // Staged rollout: gated deployments return an empty list for
-      // non-opted-in orgs — indistinguishable from "nothing published", on
-      // every desktop version in the field (see external-mcp-rollout.ts).
+      // Org-level kill switch: explicitly opted-out orgs return an empty list —
+      // indistinguishable from "nothing published", on every desktop version in
+      // the field (see external-mcp-rollout.ts).
       if (!memberFacingMcpConnectionsEnabled(payload.organization.metadata, { gatingEnabled: env.mcpConnectionsGatingEnabled })) {
         return c.json({ connections: [] })
       }
@@ -1198,7 +1198,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         })))
       // Native providers (e.g. google-workspace) join the same list once the
       // org saved an OAuth client for them — same card, same connect flow,
-      // same rollout gate (this sits after the gate check on purpose).
+      // same org kill switch (this sits after the check on purpose).
       const nativeEntries = await listNativeProviderUsableEntries({
         organizationId: payload.organization.id,
         orgMembershipId: payload.currentMember.id,

--- a/ee/apps/den-api/test/brand-icon-validation.test.ts
+++ b/ee/apps/den-api/test/brand-icon-validation.test.ts
@@ -1,6 +1,6 @@
 import { deflateSync } from "node:zlib"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
-import { afterEach, beforeAll, expect, mock, test } from "bun:test"
+import { afterAll, afterEach, beforeAll, expect, mock, test } from "bun:test"
 import { Hono } from "hono"
 import { BRAND_ICON_FETCH_USER_AGENT, validateBrandIconUrl } from "../src/brand-icon-validation.js"
 
@@ -48,10 +48,6 @@ mock.module("../src/auth.js", () => ({
       setActiveOrganization: () => Promise.resolve(),
     },
   },
-}))
-
-mock.module("../src/capability-sources/external-mcp-rollout.js", () => ({
-  memberFacingMcpConnectionsEnabled: () => true,
 }))
 
 mock.module("../src/db.js", () => ({
@@ -147,6 +143,10 @@ afterEach(() => {
   })
   fetchCalls = []
   updateOrganizationSettingsCalls.length = 0
+})
+
+afterAll(() => {
+  mock.restore()
 })
 
 function installFetchResponse(response: Response) {

--- a/ee/apps/den-api/test/external-mcp-rollout.test.ts
+++ b/ee/apps/den-api/test/external-mcp-rollout.test.ts
@@ -1,79 +1,76 @@
 import { describe, expect, test } from "bun:test"
 import { memberFacingMcpConnectionsEnabled } from "../src/capability-sources/external-mcp-rollout.js"
 
+type MetadataInput = Parameters<typeof memberFacingMcpConnectionsEnabled>[0]
+
+function expectWithDeprecatedGate(metadata: MetadataInput, expected: boolean) {
+  for (const gatingEnabled of [false, true]) {
+    expect(memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled })).toBe(expected)
+  }
+}
+
 describe("memberFacingMcpConnectionsEnabled", () => {
-  test("gating disabled: enabled for every org, regardless of metadata", () => {
-    for (const metadata of [
-      null,
-      undefined,
-      "",
-      "{}",
-      "not json",
-      { capabilities: { mcpConnections: false } },
-      { connectEnabled: false },
-      { mcpConnectionsEnabled: false },
-    ]) {
-      expect(memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: false })).toBe(true)
+  test("C1: absent, empty, and unparseable metadata are enabled by default", () => {
+    for (const metadata of [null, undefined, "", "{}", "not json", "[]", {}, JSON.stringify({ limits: { members: 5 } })]) {
+      expectWithDeprecatedGate(metadata, true)
     }
   })
 
-  test("gating enabled: disabled unless the org has connect enabled", () => {
+  test("C2/C3: capability true enables and capability false disables", () => {
     for (const metadata of [
-      null,
-      undefined,
-      "",
-      "{}",
-      "not json",
-      "[]",
-      JSON.stringify({ limits: { members: 5 } }),
+      { capabilities: { mcpConnections: true } },
+      JSON.stringify({ capabilities: { mcpConnections: true } }),
+      JSON.stringify({ limits: { members: 100 }, plan: { tier: "team" }, capabilities: { mcpConnections: true } }),
+    ]) {
+      expectWithDeprecatedGate(metadata, true)
+    }
+
+    for (const metadata of [
+      { capabilities: { mcpConnections: false } },
       JSON.stringify({ capabilities: { mcpConnections: false } }),
-      JSON.stringify({ capabilities: { mcpConnections: "true" } }),
-      JSON.stringify({ connectEnabled: false }),
-      JSON.stringify({ connectEnabled: "yes" }),
-      JSON.stringify({ mcpConnectionsEnabled: false }),
-      JSON.stringify({ mcpConnectionsEnabled: "yes" }),
-      { capabilities: { mcpConnections: false } },
-      { capabilities: { mcpConnections: "true" } },
-      { connectEnabled: false },
-      { connectEnabled: "yes" },
-      { mcpConnectionsEnabled: false },
-      { mcpConnectionsEnabled: "yes" },
-      {},
     ]) {
-      expect(memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: true })).toBe(false)
+      expectWithDeprecatedGate(metadata, false)
     }
   })
 
-  test("gating enabled: orgs with the mcpConnections capability are enabled", () => {
-    expect(memberFacingMcpConnectionsEnabled(JSON.stringify({ capabilities: { mcpConnections: true } }), { gatingEnabled: true })).toBe(true)
-    expect(memberFacingMcpConnectionsEnabled({ capabilities: { mcpConnections: true } }, { gatingEnabled: true })).toBe(true)
-    expect(
-      memberFacingMcpConnectionsEnabled(
-        JSON.stringify({ limits: { members: 100 }, plan: { tier: "team" }, capabilities: { mcpConnections: true } }),
-        { gatingEnabled: true },
-      ),
-    ).toBe(true)
+  test("C4: alias false disables when capability is absent", () => {
+    for (const metadata of [
+      { connectEnabled: false },
+      { mcpConnectionsEnabled: false },
+      { connectEnabled: false, mcpConnectionsEnabled: false },
+      JSON.stringify({ connectEnabled: false }),
+      JSON.stringify({ mcpConnectionsEnabled: false }),
+    ]) {
+      expectWithDeprecatedGate(metadata, false)
+    }
   })
 
-  test("gating enabled: orgs with connectEnabled are enabled", () => {
-    expect(memberFacingMcpConnectionsEnabled(JSON.stringify({ connectEnabled: true }), { gatingEnabled: true })).toBe(true)
-    expect(memberFacingMcpConnectionsEnabled({ connectEnabled: true }, { gatingEnabled: true })).toBe(true)
-    expect(
-      memberFacingMcpConnectionsEnabled(
-        JSON.stringify({ limits: { members: 100 }, plan: { tier: "team" }, connectEnabled: true }),
-        { gatingEnabled: true },
-      ),
-    ).toBe(true)
+  test("C5: alias true enables", () => {
+    for (const metadata of [
+      { connectEnabled: true },
+      { mcpConnectionsEnabled: true },
+      JSON.stringify({ connectEnabled: true }),
+      JSON.stringify({ mcpConnectionsEnabled: true }),
+    ]) {
+      expectWithDeprecatedGate(metadata, true)
+    }
   })
 
-  test("gating enabled: orgs with the legacy mcpConnectionsEnabled alias are enabled", () => {
-    expect(memberFacingMcpConnectionsEnabled(JSON.stringify({ mcpConnectionsEnabled: true }), { gatingEnabled: true })).toBe(true)
-    expect(memberFacingMcpConnectionsEnabled({ mcpConnectionsEnabled: true }, { gatingEnabled: true })).toBe(true)
-    expect(
-      memberFacingMcpConnectionsEnabled(
-        JSON.stringify({ limits: { members: 100 }, plan: { tier: "team" }, mcpConnectionsEnabled: true }),
-        { gatingEnabled: true },
-      ),
-    ).toBe(true)
+  test("C6: capability outranks aliases, and any alias true outranks alias false", () => {
+    expectWithDeprecatedGate({ capabilities: { mcpConnections: true }, connectEnabled: false }, true)
+    expectWithDeprecatedGate({ capabilities: { mcpConnections: false }, connectEnabled: true }, false)
+    expectWithDeprecatedGate({ connectEnabled: true, mcpConnectionsEnabled: false }, true)
+  })
+
+  test("C7: non-boolean values are ignored and fall through to default on", () => {
+    for (const metadata of [
+      { capabilities: { mcpConnections: "true" } },
+      { connectEnabled: "yes" },
+      { mcpConnectionsEnabled: "true" },
+      JSON.stringify({ capabilities: { mcpConnections: "true" }, connectEnabled: "yes", mcpConnectionsEnabled: "false" }),
+      JSON.stringify({ capabilities: { mcpConnections: 1 }, connectEnabled: 0, mcpConnectionsEnabled: null }),
+    ]) {
+      expectWithDeprecatedGate(metadata, true)
+    }
   })
 })

--- a/ee/apps/den-api/test/marketplace-capabilities.test.ts
+++ b/ee/apps/den-api/test/marketplace-capabilities.test.ts
@@ -610,46 +610,46 @@ describe("marketplace capabilities source", () => {
     expect(result.result.hint).toContain("has not synced content")
   })
 
-  test("rollout gating hides marketplace search and makes execute unknown until mcpConnections is enabled", async () => {
-    const gatedOff = await seedMember()
-    const gatedOffCapability = await seedCapability({
-      owner: gatedOff,
+  test("org kill switch hides marketplace search and makes execute unknown", async () => {
+    const disabledMetadata = { capabilities: { mcpConnections: false } }
+    const disabledOrg = await seedMember({ metadata: disabledMetadata })
+    const disabledCapability = await seedCapability({
+      owner: disabledOrg,
       objectType: "skill",
       title: "Hidden Capability",
-      rawSourceText: "Do not expose while gated.",
+      rawSourceText: "Do not expose while disabled.",
     })
-    const disabled = memberFacingMcpConnectionsEnabled(null, { gatingEnabled: true })
+    const disabled = memberFacingMcpConnectionsEnabled(disabledMetadata, { gatingEnabled: true })
     expect(disabled).toBe(false)
     expect(await marketplaceCapabilities.searchMarketplaceCapabilities({
-      organizationId: gatedOff.organizationId,
-      member: gatedOff.member,
+      organizationId: disabledOrg.organizationId,
+      member: disabledOrg.member,
       query: "hidden",
       enabled: disabled,
     })).toEqual([])
-    const gatedExecute = await marketplaceCapabilities.executeMarketplaceCapability({
-      organizationId: gatedOff.organizationId,
-      member: gatedOff.member,
-      pluginId: gatedOffCapability.pluginId,
-      configObjectId: gatedOffCapability.configObjectId,
+    const disabledExecute = await marketplaceCapabilities.executeMarketplaceCapability({
+      organizationId: disabledOrg.organizationId,
+      member: disabledOrg.member,
+      pluginId: disabledCapability.pluginId,
+      configObjectId: disabledCapability.configObjectId,
       enabled: disabled,
     })
-    expect(gatedExecute.ok).toBe(false)
-    if (gatedExecute.ok) throw new Error("expected gated execute to fail")
-    expect(gatedExecute.error).toBe("unknown_capability")
+    expect(disabledExecute.ok).toBe(false)
+    if (disabledExecute.ok) throw new Error("expected disabled execute to fail")
+    expect(disabledExecute.error).toBe("unknown_capability")
 
-    const metadata = { capabilities: { mcpConnections: true } }
-    const gatedOn = await seedMember({ metadata })
+    const defaultOn = await seedMember()
     const visibleCapability = await seedCapability({
-      owner: gatedOn,
+      owner: defaultOn,
       objectType: "skill",
       title: "Visible Capability",
-      rawSourceText: "Expose while gated on.",
+      rawSourceText: "Expose by default.",
     })
-    const enabled = memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: true })
+    const enabled = memberFacingMcpConnectionsEnabled(null, { gatingEnabled: true })
     expect(enabled).toBe(true)
     const matches = await marketplaceCapabilities.searchMarketplaceCapabilities({
-      organizationId: gatedOn.organizationId,
-      member: gatedOn.member,
+      organizationId: defaultOn.organizationId,
+      member: defaultOn.member,
       query: "visible",
       enabled,
     })

--- a/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
+++ b/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
@@ -90,7 +90,7 @@ beforeAll(async () => {
       betterAuthUrl: "http://127.0.0.1:3005",
       betterAuthSecret: "test-secret",
       githubConnectorApp: {},
-      mcpConnectionsGatingEnabled: true,
+      mcpConnectionsGatingEnabled: true, // Deprecated gate remains inert.
     },
   }))
   mock.module("../src/capability-sources/external-mcp-client-runtime.js", () => ({
@@ -144,7 +144,7 @@ afterEach(async () => {
 })
 
 function orgMetadata(enabled = true) {
-  return enabled ? { capabilities: { mcpConnections: true } } : null
+  return enabled ? null : { capabilities: { mcpConnections: false } }
 }
 
 function contextFor(input: {
@@ -583,7 +583,7 @@ describe("marketplace cloud readiness payload", () => {
     expect(resolved.cloudReadiness).toMatchObject({ state: "not_synced", hasInstructional: true })
   })
 
-  test("gated-off organizations omit cloudReadiness for old-client compatibility", async () => {
+  test("kill-switched organizations omit cloudReadiness for old-client compatibility", async () => {
     const org = await seedOrg({ enabled: false })
     const plugin = await seedPlugin({
       org,

--- a/ee/apps/den-api/test/mcp-connections-required-by.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-required-by.test.ts
@@ -65,7 +65,7 @@ beforeAll(async () => {
     id: organizationId,
     name: "Required By Org",
     slug: `required-by-${organizationId}`,
-    metadata: { capabilities: { mcpConnections: true } },
+    metadata: null,
   })
   await db.insert(schema.MemberTable).values([
     { id: adminMemberId, organizationId, userId: adminUserId, role: "admin" },

--- a/ee/apps/den-api/test/me-desktop-config.test.ts
+++ b/ee/apps/den-api/test/me-desktop-config.test.ts
@@ -27,6 +27,8 @@ const organizationId = createDenTypeId("organization")
 const memberId = createDenTypeId("member")
 const capabilityOrganizationId = createDenTypeId("organization")
 const capabilityMemberId = createDenTypeId("member")
+const disabledOrganizationId = createDenTypeId("organization")
+const disabledMemberId = createDenTypeId("member")
 const onboardingOrganizationId = createDenTypeId("organization")
 const onboardingMemberId = createDenTypeId("member")
 const onboardingTeamId = createDenTypeId("team")
@@ -44,6 +46,7 @@ const flatConnectMetadata = {
   brandIconUrl: "https://den.example-corp.internal/assets/icon.png",
 }
 const capabilityMetadata = { capabilities: { mcpConnections: true } }
+const disabledMetadata = { capabilities: { mcpConnections: false } }
 const defaultOnboardingPrompts = ["Default onboarding task", "Default onboarding follow-up"]
 const highPriorityOnboardingPrompts = ["High priority task", "High priority follow-up", "High priority optional"]
 const defaultOnboardingPromptDescriptions = ["Default onboarding", "Default follow-up"]
@@ -87,6 +90,12 @@ beforeAll(async () => {
     metadata: capabilityMetadata,
   })
   await db.insert(schema.OrganizationTable).values({
+    id: disabledOrganizationId,
+    name: "Desktop Config Disabled Org",
+    slug: `desktop-config-disabled-${disabledOrganizationId}`,
+    metadata: disabledMetadata,
+  })
+  await db.insert(schema.OrganizationTable).values({
     id: onboardingOrganizationId,
     name: "Desktop Config Onboarding Org",
     slug: `desktop-config-onboarding-${onboardingOrganizationId}`,
@@ -101,6 +110,12 @@ beforeAll(async () => {
     {
       id: capabilityMemberId,
       organizationId: capabilityOrganizationId,
+      userId,
+      role: "owner",
+    },
+    {
+      id: disabledMemberId,
+      organizationId: disabledOrganizationId,
       userId,
       role: "owner",
     },
@@ -184,8 +199,8 @@ beforeAll(async () => {
 })
 
 afterAll(async () => {
-  const memberIds = [memberId, capabilityMemberId, onboardingMemberId]
-  const organizationIds = [organizationId, capabilityOrganizationId, onboardingOrganizationId]
+  const memberIds = [memberId, capabilityMemberId, disabledMemberId, onboardingMemberId]
+  const organizationIds = [organizationId, capabilityOrganizationId, disabledOrganizationId, onboardingOrganizationId]
   if (crudDesktopPolicyId) {
     await db.delete(schema.DesktopPolicyMemberTable).where(drizzle.eq(schema.DesktopPolicyMemberTable.desktopPolicyId, crudDesktopPolicyId))
     await db.delete(schema.DesktopPolicyTable).where(drizzle.eq(schema.DesktopPolicyTable.id, crudDesktopPolicyId))
@@ -295,6 +310,13 @@ test("GET /v1/me/desktop-config exposes the effective connectEnabled org flag", 
   expectConnectEnabled(capabilityBody, capabilityMetadata)
   expect(capabilityBody.connectEnabled).toBe(true)
   expect(capabilityBody.onboardingPrompts).toBeUndefined()
+
+  const defaultBody = await requestDesktopConfig(onboardingOrganizationId)
+  expect(defaultBody.connectEnabled).toBe(true)
+
+  const disabledBody = await requestDesktopConfig(disabledOrganizationId)
+  expectConnectEnabled(disabledBody, disabledMetadata)
+  expect(disabledBody.connectEnabled).toBe(false)
 })
 
 test("GET /v1/me/desktop-config returns the effective onboarding prompts", async () => {

--- a/evals/org-mcp-agent-config-ux.md
+++ b/evals/org-mcp-agent-config-ux.md
@@ -29,8 +29,8 @@ Mechanics, all server-side:
    the entire member half is the shipped #2451/#2455 machinery.
 4. Invoke-time safety is unchanged: the agent's ceiling is the signed-in
    human's real org role (a member's agent gets a clean 403), the desktop
-   Cloud Control token is already `mcp:read mcp:write`, and the staged
-   rollout gate + ops/revert tooling apply because it is the same table.
+   Cloud Control token is already `mcp:read mcp:write`, and the org-level
+   kill switch + ops/revert tooling apply because it is the same table.
 
 ## Path B — new wave (mapped, next PR)
 
@@ -55,7 +55,7 @@ Mechanics, building on precedent that already exists:
    poll loop proven in #2451/#2455, now mounted inside a chat bubble. No new
    connect logic; the component is fed, not rebuilt.
 4. Same governance: the card renders from the member's own `scope=usable`
-   view, so grants and the rollout gate hold automatically.
+   view, so grants and the org-level kill switch hold automatically.
 
 Path B risk notes: keep the envelope out of model-visible text (structured
 result metadata, not prose) so prompts cannot forge it; the renderer must

--- a/evals/voiceovers/org-connections-capability.md
+++ b/evals/voiceovers/org-connections-capability.md
@@ -1,20 +1,17 @@
 # org-connections-capability — One /admin switch decides whether org connections exist for an org, consistently on every surface
 
-Org-level External MCP Connections were gated by a bespoke org-metadata flag
-(`mcpConnectionsEnabled`) that only an ops script with direct database access
-could flip — and it only gated the member-facing list, so an org admin could
-publish connections that members (and their desktops) silently never saw.
-This flow proves the gate is now a first-class organization capability
-(`metadata.capabilities.mcpConnections`), controlled from the /admin
-backoffice, and enforced uniformly: dashboard navigation, member surfaces,
-and the agent's search/execute capabilities all read the same switch.
-Gating posture matches hosted production (`DEN_MCP_CONNECTIONS_GATING_ENABLED=true`).
+Org-level External MCP Connections used to require a staged rollout flag. Now
+Connect is default-on, and the emergency brake is a first-class organization
+capability (`metadata.capabilities.mcpConnections`), controlled from the
+/admin backoffice and enforced uniformly: dashboard navigation, member
+surfaces, and the agent's search/execute capabilities all read the same switch.
+The old `DEN_MCP_CONNECTIONS_GATING_ENABLED` deployment flag is inert.
 
-1. This org hasn't been enabled for organization connections yet — and you can tell, because there's nothing to tell: no Connections section in the dashboard sidebar at all.
+1. This org has explicitly disabled organization connections — and you can tell, because there's nothing to tell: no Connections section in the dashboard sidebar at all.
 
 2. The desktop app agrees — a member's extensions view shows just their own apps, no org connections, no dead ends.
 
-3. I'm a platform operator, so I open the admin backoffice, find the org, and turn on the MCP connections capability — one checkbox, no database scripts.
+3. I'm a platform operator, so I open the admin backoffice, find the org, and restore the MCP connections capability — one checkbox, no database scripts.
 
 4. The org dashboard now has Connections in the sidebar, and I publish the Notion preset for the whole team in a couple of clicks.
 

--- a/scripts/revert-org-mcp-connections.sh
+++ b/scripts/revert-org-mcp-connections.sh
@@ -4,9 +4,9 @@ set -euo pipefail
 # Layered rollback runbook for org MCP connections (PRs #2406 + #2451 (desktop PR #2439 was superseded by #2451)).
 #
 # Layer 0 — instant, no deploy (prefer this): in /admin, disable the
-# mcpConnections capability for affected organizations. This requires
-# DEN_MCP_CONNECTIONS_GATING_ENABLED=true on the deployment; every desktop
-# version in the field goes dark on its next poll.
+# mcpConnections capability for affected organizations. The deprecated
+# DEN_MCP_CONNECTIONS_GATING_ENABLED env var is inert; every desktop version in
+# the field goes dark on its next poll from the org-level kill switch.
 #
 # Layer 1 — code revert (this script): builds a revert branch from the squash
 # commits on origin/dev, newest first, and opens a PR. Desktop app code is
@@ -74,7 +74,7 @@ if [ "$PUSH" -eq 1 ]; then
   git push origin "$BRANCH"
   gh pr create --base dev --head "$BRANCH" \
     --title "revert: org MCP connections (${PRS[*]/#/#})" \
-    --body "Emergency revert of the org MCP connections stack. Layer-0 kill switch (mcpConnections org capability / DEN_MCP_CONNECTIONS_GATING_ENABLED) should already be active; this removes the code. Additive DB tables are intentionally left in place."
+    --body "Emergency revert of the org MCP connections stack. Layer-0 kill switch (mcpConnections org capability set to false) should already be active; this removes the code. Additive DB tables are intentionally left in place."
 else
   echo "Next: git push origin $BRANCH && gh pr create --base dev --head $BRANCH"
 fi


### PR DESCRIPTION
## What

Phase D (extensions drain) **PR D1**: the member-facing Connect rail (marketplace + external-MCP capability injection on `/mcp/agent`, usable connections list, desktop-config `connectEnabled`) flips from **staged opt-in** to **default-ON with an org-level kill switch**.

New `memberFacingMcpConnectionsEnabled` precedence (backoffice capability outranks legacy flat aliases):
1. `capabilities.mcpConnections === true` → enabled
2. `capabilities.mcpConnections === false` → **disabled (kill switch)**
3. alias `connectEnabled`/`mcpConnectionsEnabled` `true` → enabled
4. alias `false` → disabled
5. absent / non-boolean → **enabled (default)**

`DEN_MCP_CONNECTIONS_GATING_ENABLED` is now **inert** (still parsed so deployment configs don't break; docblocks + runbook updated).

## Behavior change note (hosted)

Orgs that were never opted in (capability absent) get the rail on deploy — that's the approved product decision (Connect delivery becomes the default path; desktop import hard-flip lands next in D2, app-side). Orgs explicitly toggled OFF in /admin stay off. Ops invariant: **this deploys before D2 reaches users** (inject before import-off), same rule as Phase-1 PR3/PR4.

## Tests run

den-api tests are not in CI, so evidence is the local suite with a baseline diff (method from the Connect rollout plan):
- `pnpm --filter '@openwork-ee/den-api...' build` — pass
- `bun --conditions=development test test/external-mcp-rollout.test.ts` — 6/6 pass
- **Full suite failure-set diff vs pristine origin/dev worktree (same env/DB): 0 new failures**; 3 baseline failures *fixed* (a leaking `mock.module` of the rollout helper in `brand-icon-validation.test.ts` was polluting unrelated files — now restored after the file).
- Coverage was flipped, not deleted: gating tests now prove *explicitly-opted-out org gets empty search / unknown_capability execute*, desktop-config test proves default-on + kill-switch-off, cloud-readiness omission test keyed to explicit opt-out.

fraimz: N/A — den-api-only change with no app-visible surface (per the rollout plan's merge policy). The `org-connections-capability` den-stack flow remains valid: it explicitly seeds `mcpConnections:false` (now the kill switch) before asserting the dark state; its voiceover was updated to the new story.

Part of the Phase D plan in `docs/connect-rollout-plan.md` (D1 → D2 app hard-flip → D3 provider split → D4 sync deletion → D5 prune).