### PR TITLE
fix(app): avoid transient unavailable model prompt

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -633,8 +633,9 @@ export function SessionRoute() {
           checkRestriction: checkDesktopRestriction,
         }) ||
         (
+          providerListQuery.data &&
           checkDesktopRestriction({ restriction: "allowCustomProviders" }) &&
-          !providerConnectedIds.some(
+          !providerListQuery.data.connected.some(
             (providerId) => providerId.trim() === local.prefs.defaultModel?.providerID.trim(),
           )
         ) ||


### PR DESCRIPTION
## Summary
- wait for provider-list hydration before treating a policy-limited selected provider as disconnected
- use the provider query snapshot instead of the initially empty mirrored connected-provider state
- prevent the replacement-model picker from opening transiently during desktop startup

## Tests
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/app exec bun test --isolate tests/model-picker-modal.test.ts` — 2 passed

## Proof
Fraimz: Incomplete. The exact signed-in, admin-assigned-provider desktop-policy fixture was not available locally, so no screenshot/video proof was captured.