### PR TITLE
fix(app): await cloud models before validation

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1152,7 +1152,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
   }
 
-  async function refreshProviders(optionsArg?: { dispose?: boolean }) {
+  async function refreshProviders(optionsArg?: { dispose?: boolean; force?: boolean }) {
     const c = options.client();
     if (!c) return null;
 
@@ -1222,7 +1222,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
         await ensureProviderListQuery(getReactQueryClient(), {
           client: activeClient,
           directory: options.selectedWorkspaceRoot(),
-          force: Boolean(optionsArg?.dispose),
+          force: Boolean(optionsArg?.dispose || optionsArg?.force),
         }),
         disabledProviders,
       );

--- a/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
@@ -2,7 +2,8 @@
 // fed by a latest-values ref, lifecycle (start/dispose), Zen-restriction sync,
 // workspace-change resync, the post-onboarding auto-open latch, and cloud
 // provider auto-sync. Extracted verbatim from session-route.tsx.
-import { useEffect, useMemo, useRef } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { ProviderListResponse } from "@opencode-ai/sdk/v2/client";
 
 import type { Client, ProviderListItem, WorkspaceDisplay } from "@/app/types";
 import type { ResolvedWorkspaceEndpoint } from "@/app/lib/workspace-endpoint";
@@ -125,6 +126,15 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
       }),
     [checkDesktopRestriction, markReloadRequired],
   );
+  const cloudProviderSyncContext = useMemo(() => ({
+    client: opencodeClient,
+    workspaceId: selectedWorkspaceEndpoint?.workspaceId ?? null,
+    workspaceRoot: selectedWorkspaceRoot,
+  }), [opencodeClient, selectedWorkspaceEndpoint?.workspaceId, selectedWorkspaceRoot]);
+  const [completedCloudProviderSync, setCompletedCloudProviderSync] = useState<{
+    context: typeof cloudProviderSyncContext;
+    providerList: ProviderListResponse | null;
+  } | null>(null);
 
   useEffect(() => {
     store.start();
@@ -157,6 +167,22 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
     store,
   ]);
 
+  useEffect(() => {
+    if (!cloudProviderSyncContext.client || !cloudProviderSyncContext.workspaceId) return;
+
+    let cancelled = false;
+    void (async () => {
+      await store.runCloudProviderSync("app_launch");
+      const providerList = await store.refreshProviders({ force: true });
+      if (!cancelled) {
+        setCompletedCloudProviderSync({ context: cloudProviderSyncContext, providerList });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [cloudProviderSyncContext, store]);
+
   // After onboarding, auto-open the provider modal if no providers are connected.
   // The welcome route appends ?onboarding=1 to the session URL after workspace creation.
   useEffect(() => {
@@ -178,6 +204,15 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
   // sync here so sign-in applies opencode.json changes before Settings opens.
   useCloudProviderAutoSync(store.runCloudProviderSync);
   const snapshot = useProviderAuthStoreSnapshot(store);
+  const currentCloudProviderSync =
+    completedCloudProviderSync?.context === cloudProviderSyncContext
+      ? completedCloudProviderSync
+      : null;
 
-  return { store, snapshot };
+  return {
+    store,
+    snapshot,
+    cloudProviderSyncReady: Boolean(currentCloudProviderSync),
+    cloudProviderList: currentCloudProviderSync?.providerList ?? null,
+  };
 }

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -111,6 +111,7 @@ import { appMentionInstruction } from "@/react-app/domains/session/surface/compo
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
 import type { CreateWorkspaceOptions } from "@/react-app/domains/workspace/types";
+import { isCloudManagedProviderKey } from "@/react-app/domains/connections/provider-auth/cloud-provider-config";
 import { useSessionProviderAuth } from "@/react-app/domains/connections/provider-auth/use-session-provider-auth";
 import {
   disabledProvidersFromConfig,
@@ -625,23 +626,50 @@ export function SessionRoute() {
     baseUrl: opencodeBaseUrl,
     workspaceRoot: selectedWorkspaceRoot,
   });
+  const {
+    store: sessionProviderAuthStore,
+    snapshot: sessionProviderAuthSnapshot,
+    cloudProviderSyncReady,
+    cloudProviderList,
+  } = useSessionProviderAuth({
+    opencodeClient,
+    providers,
+    providerDefaults,
+    providerConnectedIds,
+    disabledProviderIds,
+    selectedWorkspace,
+    selectedWorkspaceEndpoint,
+    selectedWorkspaceRoot,
+    selectedWorkspaceId,
+    setProviders,
+    setProviderDefaults,
+    setProviderConnectedIds,
+    setDisabledProviderIds,
+  });
+  const selectedModelUsesCloudProvider = Boolean(
+    local.prefs.defaultModel && isCloudManagedProviderKey(local.prefs.defaultModel.providerID),
+  );
+  const selectedModelProviderList = selectedModelUsesCloudProvider
+    ? cloudProviderList
+    : providerListQuery.data;
   const selectedModelUnavailable = Boolean(
     local.prefs.defaultModel &&
+      (!selectedModelUsesCloudProvider || cloudProviderSyncReady) &&
       (
         isDesktopProviderBlocked({
           providerId: local.prefs.defaultModel.providerID,
           checkRestriction: checkDesktopRestriction,
         }) ||
         (
-          providerListQuery.data &&
+          selectedModelProviderList &&
           checkDesktopRestriction({ restriction: "allowCustomProviders" }) &&
-          !providerListQuery.data.connected.some(
+          !selectedModelProviderList.connected.some(
             (providerId) => providerId.trim() === local.prefs.defaultModel?.providerID.trim(),
           )
         ) ||
         (
-          providerListQuery.data &&
-          !isModelAvailableInConnectedProviders(providerListQuery.data, local.prefs.defaultModel)
+          selectedModelProviderList &&
+          !isModelAvailableInConnectedProviders(selectedModelProviderList, local.prefs.defaultModel)
         )
       ),
   );
@@ -675,22 +703,6 @@ export function SessionRoute() {
     providerConnectedIds,
   });
 
-  const { store: sessionProviderAuthStore, snapshot: sessionProviderAuthSnapshot } =
-    useSessionProviderAuth({
-      opencodeClient,
-      providers,
-      providerDefaults,
-      providerConnectedIds,
-      disabledProviderIds,
-      selectedWorkspace,
-      selectedWorkspaceEndpoint,
-      selectedWorkspaceRoot,
-      selectedWorkspaceId,
-      setProviders,
-      setProviderDefaults,
-      setProviderConnectedIds,
-      setDisabledProviderIds,
-    });
   const {
     activePermission,
     permissionReplyBusy,


### PR DESCRIPTION
## Summary
- stack on #2844 and wait for the initial cloud-provider reconciliation before validating a persisted cloud model
- force one post-sync provider refresh and keep that provider snapshot atomic with the sync-ready state
- only show the unavailable-model recovery flow after the reconciled cloud snapshot confirms the model is absent

## Tests
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/app exec bun test --isolate tests/model-picker-modal.test.ts` — 2 passed

## Proof
Fraimz: Incomplete. The exact signed-in, admin-assigned-provider desktop-policy fixture was not available locally, so no screenshot/video proof was captured.

## Dependency
Stacked on #2844; merge that PR first.