### PR TITLE
fix(den): use OpenWork models catalog

### DIFF
--- a/ee/apps/den-api/src/llm/models-dev.ts
+++ b/ee/apps/den-api/src/llm/models-dev.ts
@@ -1,4 +1,4 @@
-const MODELS_DEV_API_URL = "https://models.dev/api.json"
+const MODELS_DEV_API_URL = "https://models.openworklabs.com/api.json"
 const MODELS_DEV_CACHE_TTL_MS = 1000 * 60 * 10
 
 type JsonRecord = Record<string, unknown>


### PR DESCRIPTION
## Summary
- load the Den LLM provider catalog from `https://models.openworklabs.com/api.json`
- preserve the existing normalization and 10-minute cache behavior

## Validation
- `pnpm --filter @openwork-ee/den-api build`
- fetched the new endpoint and validated a non-empty provider/model catalog: HTTP 200, 155 providers, 5,435 models

## Proof
- Direct endpoint validation completed; no UI screenshots captured for this server-side source URL change.