### PR TITLE
fix(den): recover imported MCP authentication setup

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-auth-policy.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-auth-policy.ts
@@ -1,6 +1,6 @@
-import { EXTERNAL_MCP_PRESETS } from "../../../capability-sources/external-mcp-presets.js"
+import { EXTERNAL_MCP_PRESETS } from "./external-mcp-presets.js"
 
-export type GithubPluginMcpImportAuthType = "apikey" | "none" | "oauth"
+export type PluginMcpAuthType = "apikey" | "none" | "oauth"
 
 function normalizedRemoteMcpUrl(value: string) {
   try {
@@ -12,19 +12,26 @@ function normalizedRemoteMcpUrl(value: string) {
   }
 }
 
-export function declaredGithubPluginMcpAuthType(config: Record<string, unknown>): "oauth" | null {
+export function declaredPluginMcpAuthType(config: Record<string, unknown>): "oauth" | null {
   const oauth = config.oauth
   return oauth !== undefined && oauth !== null && oauth !== false ? "oauth" : null
+}
+
+export function requiredPluginMcpAuthType(input: {
+  declaredAuthType: "oauth" | null
+  url: string
+}): PluginMcpAuthType | null {
+  const normalizedUrl = normalizedRemoteMcpUrl(input.url)
+  const preset = normalizedUrl
+    ? EXTERNAL_MCP_PRESETS.find((candidate) => normalizedRemoteMcpUrl(candidate.url) === normalizedUrl)
+    : null
+  return preset?.authType ?? input.declaredAuthType
 }
 
 export function resolveGithubPluginMcpImportAuthType(input: {
   declaredAuthType: "oauth" | null
   requestedAuthType: "none" | "oauth"
   url: string
-}): GithubPluginMcpImportAuthType {
-  const normalizedUrl = normalizedRemoteMcpUrl(input.url)
-  const preset = normalizedUrl
-    ? EXTERNAL_MCP_PRESETS.find((candidate) => normalizedRemoteMcpUrl(candidate.url) === normalizedUrl)
-    : null
-  return preset?.authType ?? input.declaredAuthType ?? input.requestedAuthType
+}): PluginMcpAuthType {
+  return requiredPluginMcpAuthType(input) ?? input.requestedAuthType
 }

--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -20,6 +20,7 @@ import {
 } from "@openwork-ee/den-db/schema"
 import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "../db.js"
+import { declaredPluginMcpAuthType, requiredPluginMcpAuthType } from "./external-mcp-auth-policy.js"
 import { normalizeConnectedAccountScopes, normalizeOAuthClientExtra } from "./oauth-credentials.js"
 
 /**
@@ -352,6 +353,10 @@ async function sourcedUsableExternalMcpConnections(input: {
       .find((candidate) => candidate.name === row.binding.serverName)
     const declaredUrl = readString(entry?.config.url)
     if (!declaredUrl) return []
+    const requiredAuthType = entry
+      ? requiredPluginMcpAuthType({ declaredAuthType: declaredPluginMcpAuthType(entry.config), url: declaredUrl })
+      : null
+    if (requiredAuthType && row.connection.authType !== requiredAuthType) return []
     return normalizeExternalMcpIdentityUrl(row.connection.url) === normalizeExternalMcpIdentityUrl(declaredUrl)
       ? [row.connection]
       : []

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -17,6 +17,11 @@ import {
   listUsableExternalMcpConnections,
   type ExternalMcpConnectionRow,
 } from "../capability-sources/external-mcp-connections.js"
+import {
+  declaredPluginMcpAuthType,
+  requiredPluginMcpAuthType,
+  type PluginMcpAuthType,
+} from "../capability-sources/external-mcp-auth-policy.js"
 import { EXTERNAL_MCP_PRESETS } from "../capability-sources/external-mcp-presets.js"
 import { getConnectedAccount, getOrgOAuthClient } from "../capability-sources/oauth-credentials.js"
 import { db } from "../db.js"
@@ -116,6 +121,7 @@ export type MarketplaceCloudReadinessState = "ready" | "needs_signin" | "needs_a
 
 export type MarketplaceCloudReadinessConnection = {
   authType?: "apikey" | "none" | "oauth"
+  authTypeMismatch?: boolean
   configObjectId: string
   id: string | null
   name: string
@@ -125,6 +131,7 @@ export type MarketplaceCloudReadinessConnection = {
   connectedForMe?: boolean
   oauthClientConfigured?: boolean
   oauthClientRequired?: boolean
+  requiredAuthType?: "apikey" | "none" | "oauth"
 }
 
 export type MarketplacePluginCloudReadiness = {
@@ -145,6 +152,7 @@ type MarketplaceMcpDependency = {
   externalMcpConnectionId: string | null
   name: string
   pluginId: PluginId
+  requiredAuthType: PluginMcpAuthType | null
   serverName: string
   url: string
 }
@@ -155,6 +163,7 @@ type MarketplacePluginMcpRequirement = {
   name: string
   pluginId: PluginId
   pluginName: string
+  requiredAuthType: PluginMcpAuthType | null
   serverName: string
   url: string
 }
@@ -559,17 +568,21 @@ function mcpDependenciesForObject(input: {
   version: ConfigObjectVersionRow
 }): MarketplaceMcpDependency[] {
   const spec = versionServerSpec(input.version)
-  const dependencies = marketplaceMcpServerEntries(spec, input.object.title).map((entry) => ({
-    configObjectId: input.object.id,
-    externalMcpConnectionId: readExternalMcpConnectionId({ config: entry.config, spec }),
-    name: entry.name,
-    pluginId: input.object.pluginId,
-    serverName: entry.name,
-    url: readString(entry.config.url) ?? "",
-  }))
+  const dependencies = marketplaceMcpServerEntries(spec, input.object.title).map((entry) => {
+    const url = readString(entry.config.url) ?? ""
+    return {
+      configObjectId: input.object.id,
+      externalMcpConnectionId: readExternalMcpConnectionId({ config: entry.config, spec }),
+      name: entry.name,
+      pluginId: input.object.pluginId,
+      requiredAuthType: requiredPluginMcpAuthType({ declaredAuthType: declaredPluginMcpAuthType(entry.config), url }),
+      serverName: entry.name,
+      url,
+    }
+  })
   return dependencies.length > 0
     ? dependencies
-    : [{ configObjectId: input.object.id, externalMcpConnectionId: null, name: input.object.title, pluginId: input.object.pluginId, serverName: input.object.title, url: "" }]
+    : [{ configObjectId: input.object.id, externalMcpConnectionId: null, name: input.object.title, pluginId: input.object.pluginId, requiredAuthType: null, serverName: input.object.title, url: "" }]
 }
 
 export function isSharedConnectionReady(connection: ExternalMcpConnectionRow): boolean {
@@ -701,7 +714,10 @@ async function statusForRequirement(input: {
   usableConnections: ExternalMcpConnectionRow[]
 }): Promise<MarketplaceMcpRequirementStatus> {
   const connection = matchingConnectionForRequirement(input)
-  const usable = connection ? connectionIsUsable({ connectionId: connection.id, usableConnections: input.usableConnections }) : false
+  const authTypeMismatch = Boolean(connection && input.requirement.requiredAuthType && connection.authType !== input.requirement.requiredAuthType)
+  const usable = connection && !authTypeMismatch
+    ? connectionIsUsable({ connectionId: connection.id, usableConnections: input.usableConnections })
+    : false
   const base = {
     configObjectId: input.requirement.configObjectId,
     pluginId: input.requirement.pluginId,
@@ -770,6 +786,7 @@ function requirementsForMcpObject(input: {
         name: entry.name,
         pluginId: input.pluginId,
         pluginName: input.pluginName,
+        requiredAuthType: requiredPluginMcpAuthType({ declaredAuthType: declaredPluginMcpAuthType(entry.config), url }),
         serverName: entry.name,
         url,
       }]
@@ -862,6 +879,7 @@ async function marketplacePluginMcpRequirementStatuses(input: {
 }
 
 async function resolveMcpReadinessConnections(input: {
+  allConnections: ExternalMcpConnectionRow[]
   connections: UsableExternalMcpConnection[]
   dependencies: MarketplaceMcpDependency[]
   member: McpMemberIdentity
@@ -879,7 +897,7 @@ async function resolveMcpReadinessConnections(input: {
     const binding = bindings.get(requirementKey(dependency))
     const explicitConnectionId = binding?.externalMcpConnectionId ?? dependency.externalMcpConnectionId
     const matched = explicitConnectionId
-      ? input.connections.find((connection) => connection.id === explicitConnectionId && comparablePluginMcpRequirementUrl(connection.url) === comparablePluginMcpRequirementUrl(dependency.url))
+      ? input.allConnections.find((connection) => connection.id === explicitConnectionId && comparablePluginMcpRequirementUrl(connection.url) === comparablePluginMcpRequirementUrl(dependency.url))
       : dependency.url
         ? input.connections.find((connection) => comparablePluginMcpRequirementUrl(connection.url) === comparablePluginMcpRequirementUrl(dependency.url))
         : null
@@ -895,8 +913,9 @@ async function resolveMcpReadinessConnections(input: {
     }
     let oauthClientConfigured: boolean | undefined
     const preset = EXTERNAL_MCP_PRESETS.find((candidate) => comparablePluginMcpRequirementUrl(candidate.url) === comparablePluginMcpRequirementUrl(matched.url))
-    const oauthClientRequired = matched.authType === "oauth" && preset?.requiresOAuthClient === true
-    if (matched.authType === "oauth") {
+    const authTypeMismatch = Boolean(dependency.requiredAuthType && matched.authType !== dependency.requiredAuthType)
+    const oauthClientRequired = dependency.requiredAuthType === "oauth" && preset?.requiresOAuthClient === true
+    if (dependency.requiredAuthType === "oauth" || matched.authType === "oauth") {
       oauthClientConfigured = oauthClientConfiguredCache.get(matched.id)
       if (oauthClientConfigured === undefined) {
         oauthClientConfigured = Boolean(await getOrgOAuthClient(input.organizationId, matched.id))
@@ -905,6 +924,7 @@ async function resolveMcpReadinessConnections(input: {
     }
     output.push({
       authType: matched.authType,
+      authTypeMismatch,
       configObjectId: dependency.configObjectId,
       id: matched.id,
       name: matched.name,
@@ -913,7 +933,8 @@ async function resolveMcpReadinessConnections(input: {
       credentialMode: matched.credentialMode,
       connectedForMe,
       ...(oauthClientConfigured === undefined ? {} : { oauthClientConfigured }),
-      ...(matched.authType === "oauth" ? { oauthClientRequired } : {}),
+      ...(dependency.requiredAuthType ? { requiredAuthType: dependency.requiredAuthType } : {}),
+      ...(dependency.requiredAuthType === "oauth" || matched.authType === "oauth" ? { oauthClientRequired } : {}),
     })
   }
 
@@ -982,6 +1003,7 @@ export async function resolveMarketplacePluginCloudReadiness(input: {
     orgMembershipId: input.member.orgMembershipId,
     teamIds: input.member.teamIds,
   })
+  const allConnections = await listExternalMcpConnections(input.organizationId)
   const desktopManifestPluginIds = new Set(input.desktopManifestPluginIds ?? [])
 
   for (const pluginId of pluginIds) {
@@ -1015,8 +1037,9 @@ export async function resolveMarketplacePluginCloudReadiness(input: {
       const version = latestVersions.get(object.id)
       return version ? mcpDependenciesForObject({ object, version }) : []
     })
-    const connections = await resolveMcpReadinessConnections({ connections: usableConnections, dependencies, member: input.member, organizationId: input.organizationId })
+    const connections = await resolveMcpReadinessConnections({ allConnections, connections: usableConnections, dependencies, member: input.member, organizationId: input.organizationId })
     const state = connections.some((connection) => connection.id === null
+      || connection.authTypeMismatch === true
       || (connection.oauthClientRequired === true && connection.oauthClientConfigured === false)
       || (connection.credentialMode === "shared" && connection.connectedForMe === false))
       ? "needs_admin_setup"

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -17,7 +17,8 @@ import {
   listUsableExternalMcpConnections,
   type ExternalMcpConnectionRow,
 } from "../capability-sources/external-mcp-connections.js"
-import { getConnectedAccount } from "../capability-sources/oauth-credentials.js"
+import { EXTERNAL_MCP_PRESETS } from "../capability-sources/external-mcp-presets.js"
+import { getConnectedAccount, getOrgOAuthClient } from "../capability-sources/oauth-credentials.js"
 import { db } from "../db.js"
 import { resolvePluginArchGrantRole } from "../routes/org/plugin-system/access.js"
 import { openworkOrganizationConnectionsUrl, openworkYourConnectionsUrl } from "./connection-navigation.js"
@@ -114,6 +115,7 @@ export type MarketplaceConfigObjectExecutionMode = "desktop_only" | "instruction
 export type MarketplaceCloudReadinessState = "ready" | "needs_signin" | "needs_admin_setup" | "desktop_only" | "not_synced"
 
 export type MarketplaceCloudReadinessConnection = {
+  authType?: "apikey" | "none" | "oauth"
   configObjectId: string
   id: string | null
   name: string
@@ -121,6 +123,8 @@ export type MarketplaceCloudReadinessConnection = {
   url: string
   credentialMode?: "shared" | "per_member"
   connectedForMe?: boolean
+  oauthClientConfigured?: boolean
+  oauthClientRequired?: boolean
 }
 
 export type MarketplacePluginCloudReadiness = {
@@ -864,6 +868,7 @@ async function resolveMcpReadinessConnections(input: {
   organizationId: OrganizationId
 }): Promise<MarketplaceCloudReadinessConnection[]> {
   const connectedCache = new Map<string, boolean>()
+  const oauthClientConfiguredCache = new Map<string, boolean>()
   const output: MarketplaceCloudReadinessConnection[] = []
   const bindings = bindingByRequirement(await listPluginMcpRequirementBindings({
     organizationId: input.organizationId,
@@ -888,7 +893,18 @@ async function resolveMcpReadinessConnections(input: {
       connectedForMe = await connectedForMember({ connection: matched, member: input.member })
       connectedCache.set(matched.id, connectedForMe)
     }
+    let oauthClientConfigured: boolean | undefined
+    const preset = EXTERNAL_MCP_PRESETS.find((candidate) => comparablePluginMcpRequirementUrl(candidate.url) === comparablePluginMcpRequirementUrl(matched.url))
+    const oauthClientRequired = matched.authType === "oauth" && preset?.requiresOAuthClient === true
+    if (matched.authType === "oauth") {
+      oauthClientConfigured = oauthClientConfiguredCache.get(matched.id)
+      if (oauthClientConfigured === undefined) {
+        oauthClientConfigured = Boolean(await getOrgOAuthClient(input.organizationId, matched.id))
+        oauthClientConfiguredCache.set(matched.id, oauthClientConfigured)
+      }
+    }
     output.push({
+      authType: matched.authType,
       configObjectId: dependency.configObjectId,
       id: matched.id,
       name: matched.name,
@@ -896,6 +912,8 @@ async function resolveMcpReadinessConnections(input: {
       url: matched.url,
       credentialMode: matched.credentialMode,
       connectedForMe,
+      ...(oauthClientConfigured === undefined ? {} : { oauthClientConfigured }),
+      ...(matched.authType === "oauth" ? { oauthClientRequired } : {}),
     })
   }
 
@@ -998,7 +1016,9 @@ export async function resolveMarketplacePluginCloudReadiness(input: {
       return version ? mcpDependenciesForObject({ object, version }) : []
     })
     const connections = await resolveMcpReadinessConnections({ connections: usableConnections, dependencies, member: input.member, organizationId: input.organizationId })
-    const state = connections.some((connection) => connection.id === null || (connection.credentialMode === "shared" && connection.connectedForMe === false))
+    const state = connections.some((connection) => connection.id === null
+      || (connection.oauthClientRequired === true && connection.oauthClientConfigured === false)
+      || (connection.credentialMode === "shared" && connection.connectedForMe === false))
       ? "needs_admin_setup"
       : connections.some((connection) => connection.credentialMode === "per_member" && connection.connectedForMe === false)
         ? "needs_signin"

--- a/ee/apps/den-api/src/routes/org/plugin-system/github-plugin-mcp-auth.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/github-plugin-mcp-auth.ts
@@ -1,0 +1,30 @@
+import { EXTERNAL_MCP_PRESETS } from "../../../capability-sources/external-mcp-presets.js"
+
+export type GithubPluginMcpImportAuthType = "apikey" | "none" | "oauth"
+
+function normalizedRemoteMcpUrl(value: string) {
+  try {
+    const url = new URL(value)
+    const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, "") : url.pathname
+    return `${url.protocol.toLowerCase()}//${url.host.toLowerCase()}${pathname}${url.search}`
+  } catch {
+    return null
+  }
+}
+
+export function declaredGithubPluginMcpAuthType(config: Record<string, unknown>): "oauth" | null {
+  const oauth = config.oauth
+  return oauth !== undefined && oauth !== null && oauth !== false ? "oauth" : null
+}
+
+export function resolveGithubPluginMcpImportAuthType(input: {
+  declaredAuthType: "oauth" | null
+  requestedAuthType: "none" | "oauth"
+  url: string
+}): GithubPluginMcpImportAuthType {
+  const normalizedUrl = normalizedRemoteMcpUrl(input.url)
+  const preset = normalizedUrl
+    ? EXTERNAL_MCP_PRESETS.find((candidate) => normalizedRemoteMcpUrl(candidate.url) === normalizedUrl)
+    : null
+  return preset?.authType ?? input.declaredAuthType ?? input.requestedAuthType
+}

--- a/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
@@ -573,6 +573,7 @@ const pluginCloudReadinessSchema = z.object({
   hasInstructional: z.boolean(),
   connections: z.array(z.object({
     authType: z.enum(["oauth", "apikey", "none"]).optional(),
+    authTypeMismatch: z.boolean().optional(),
     configObjectId: configObjectIdSchema,
     id: z.string().nullable(),
     name: z.string(),
@@ -582,6 +583,7 @@ const pluginCloudReadinessSchema = z.object({
     connectedForMe: z.boolean().optional(),
     oauthClientConfigured: z.boolean().optional(),
     oauthClientRequired: z.boolean().optional(),
+    requiredAuthType: z.enum(["oauth", "apikey", "none"]).optional(),
   })),
 }).meta({ ref: "PluginArchPluginCloudReadiness" })
 

--- a/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
@@ -572,6 +572,7 @@ const pluginCloudReadinessSchema = z.object({
   state: z.enum(["ready", "needs_signin", "needs_admin_setup", "desktop_only", "not_synced"]),
   hasInstructional: z.boolean(),
   connections: z.array(z.object({
+    authType: z.enum(["oauth", "apikey", "none"]).optional(),
     configObjectId: configObjectIdSchema,
     id: z.string().nullable(),
     name: z.string(),
@@ -579,6 +580,8 @@ const pluginCloudReadinessSchema = z.object({
     url: z.string(),
     credentialMode: z.enum(["shared", "per_member"]).optional(),
     connectedForMe: z.boolean().optional(),
+    oauthClientConfigured: z.boolean().optional(),
+    oauthClientRequired: z.boolean().optional(),
   })),
 }).meta({ ref: "PluginArchPluginCloudReadiness" })
 
@@ -822,7 +825,7 @@ export const marketplaceResolvedResponseSchema = pluginArchMutationResponseSchem
 )
 
 const githubPluginMcpImportServerSchema = z.object({
-  authType: z.literal("oauth"),
+  authType: z.literal("oauth").nullable(),
   connectionId: z.string().nullable(),
   name: z.string(),
   pluginKey: z.string(),

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -91,10 +91,16 @@ import { getOrgOAuthClient, upsertOrgOAuthClient } from "../../../capability-sou
 import {
   deletePluginMcpRequirementBindingsByIds,
   deletePluginMcpRequirementBindingsForPluginConfigObject,
+  listPluginMcpRequirementBindings,
   upsertPluginMcpRequirementBinding,
   type PluginMcpRequirementBindingRow,
 } from "../../../mcp/plugin-mcp-requirement-bindings.js"
 import { openworkYourConnectionsUrl } from "../../../mcp/connection-navigation.js"
+import {
+  declaredGithubPluginMcpAuthType,
+  resolveGithubPluginMcpImportAuthType,
+  type GithubPluginMcpImportAuthType,
+} from "./github-plugin-mcp-auth.js"
 
 type OrganizationId = PluginArchActorContext["organizationContext"]["organization"]["id"]
 const logger = appLogger.child({ component: "plugin_system_store" })
@@ -220,7 +226,7 @@ type PluginMcpRequirementServer = {
 }
 
 type GithubPluginMcpImportServer = {
-  authType: "oauth"
+  authType: "oauth" | null
   connectionId: string | null
   name: string
   pluginKey: string
@@ -3454,7 +3460,7 @@ function mcpServerEntriesFromPayload(input: {
     parsed = JSON.parse(input.rawSourceText)
   } catch {
     return [githubPluginMcpImportServer({
-      authType: "oauth",
+      authType: null,
       connectionId: null,
       name: input.sourcePath,
       pluginKey: input.plugin.key,
@@ -3487,7 +3493,7 @@ function mcpServerEntriesFromPayload(input: {
 
     if (!url) {
       return githubPluginMcpImportServer({
-        authType: "oauth",
+        authType: null,
         connectionId: null,
         name,
         pluginKey: input.plugin.key,
@@ -3504,7 +3510,7 @@ function mcpServerEntriesFromPayload(input: {
       parsedUrl = new URL(url)
     } catch {
       return githubPluginMcpImportServer({
-        authType: "oauth",
+        authType: null,
         connectionId: null,
         name,
         pluginKey: input.plugin.key,
@@ -3518,7 +3524,7 @@ function mcpServerEntriesFromPayload(input: {
 
     if (parsedUrl.protocol !== "http:" && parsedUrl.protocol !== "https:") {
       return githubPluginMcpImportServer({
-        authType: "oauth",
+        authType: null,
         connectionId: null,
         name,
         pluginKey: input.plugin.key,
@@ -3532,7 +3538,7 @@ function mcpServerEntriesFromPayload(input: {
 
     if (type && type !== "http" && type !== "remote" && type !== "streamable-http" && type !== "sse") {
       return githubPluginMcpImportServer({
-        authType: "oauth",
+        authType: null,
         connectionId: null,
         name,
         pluginKey: input.plugin.key,
@@ -3545,7 +3551,7 @@ function mcpServerEntriesFromPayload(input: {
     }
 
     return githubPluginMcpImportServer({
-      authType: "oauth",
+      authType: declaredGithubPluginMcpAuthType(config),
       connectionId: null,
       name,
       pluginKey: input.plugin.key,
@@ -3801,6 +3807,13 @@ function mcpRequirementServerFromVersion(input: {
   }
 
   return { config: entry.config, name: entry.name, url }
+}
+
+function configVersionOwnsImportedExternalMcpConnection(version: ConfigObjectVersionRow) {
+  const spec = parseConfigObjectVersionSpec(version)
+  if (spec.externalMcpConnectionOwnedByPlugin === true) return true
+  const metadata = isRecord(spec.metadata) ? spec.metadata : null
+  return metadata?.externalMcpConnectionOwnedByPlugin === true
 }
 
 async function assertRemotePluginMcpUrl(url: string) {
@@ -4160,12 +4173,12 @@ function sortedUnique<TValue extends string>(values: TValue[]): TValue[] {
 }
 
 async function requireExistingExternalMcpConnectionMatchesImport(input: {
-  authType: "none" | "oauth"
+  authType: GithubPluginMcpImportAuthType
   credentialMode: "per_member" | "shared"
   existingAuthType: "apikey" | "none" | "oauth"
   existingCredentialMode: "per_member" | "shared"
 }) {
-  const expectedCredentialMode = input.authType === "none" ? "shared" : input.credentialMode
+  const expectedCredentialMode = input.authType === "oauth" ? input.credentialMode : "shared"
   if (input.existingAuthType !== input.authType || input.existingCredentialMode !== expectedCredentialMode) {
     throw new PluginArchRouteFailure(
       409,
@@ -4177,7 +4190,7 @@ async function requireExistingExternalMcpConnectionMatchesImport(input: {
 
 async function ensureImportedExternalMcpConnection(input: {
   access: GithubPluginMcpImportAccess
-  authType: "none" | "oauth"
+  authType: GithubPluginMcpImportAuthType
   context: PluginArchActorContext
   credentialMode: "per_member" | "shared"
   server: GithubPluginMcpImportServer
@@ -4199,9 +4212,7 @@ async function ensureImportedExternalMcpConnection(input: {
       existingAuthType: existing.authType,
       existingCredentialMode: existing.credentialMode,
     })
-    if (input.authType === "none") {
-      await markImportedExternalMcpConnectionConnected(existing.id)
-    }
+    if (input.authType === "none") await validateConfiguredPluginMcpConnection({ authType: input.authType, connection: existing })
     return { connection: existing, ownedByImportedPlugin: false }
   }
 
@@ -4209,13 +4220,18 @@ async function ensureImportedExternalMcpConnection(input: {
     access: { memberIds: [], orgWide: false, teamIds: [] },
     authType: input.authType,
     createdByOrgMembershipId: input.context.organizationContext.currentMember.id,
-    credentialMode: input.authType === "none" ? "shared" : input.credentialMode,
+    credentialMode: input.authType === "oauth" ? input.credentialMode : "shared",
     name: externalMcpConnectionName({ pluginName: input.server.pluginName, serverName: input.server.name }),
     organizationId,
     url: serverUrl,
   })
   if (input.authType === "none") {
-    await markImportedExternalMcpConnectionConnected(created.id)
+    try {
+      await validateConfiguredPluginMcpConnection({ authType: input.authType, connection: created })
+    } catch (error) {
+      await deleteExternalMcpConnection({ connectionId: created.id, organizationId })
+      throw error
+    }
   }
   return { connection: created, ownedByImportedPlugin: true }
 }
@@ -4393,6 +4409,10 @@ export async function configureMarketplacePluginMcpRequirement(input: {
     organizationId,
     pluginId: requirement.plugin.id,
   })
+  const previousBinding = (await listPluginMcpRequirementBindings({
+    configObjectIds: [requirement.configObject.id],
+    organizationId,
+  })).find((candidate) => candidate.pluginId === requirement.plugin.id && candidate.serverName === server.name)
   const connectionResult = await createOrReusePluginMcpRequirementConnection({
     access,
     apiKey,
@@ -4436,6 +4456,33 @@ export async function configureMarketplacePluginMcpRequirement(input: {
     serverName: server.name,
   })
   await syncPluginMcpRequirementBindingAccess(binding)
+  const replacedOwnedConnectionId = previousBinding
+    && previousBinding.externalMcpConnectionId !== connection.id
+    && configVersionOwnsImportedExternalMcpConnection(version)
+    ? previousBinding.externalMcpConnectionId
+    : null
+  if (replacedOwnedConnectionId) {
+    const remainingBinding = await db
+      .select({ id: PluginMcpRequirementBindingTable.id })
+      .from(PluginMcpRequirementBindingTable)
+      .where(and(
+        eq(PluginMcpRequirementBindingTable.organizationId, organizationId),
+        eq(PluginMcpRequirementBindingTable.externalMcpConnectionId, replacedOwnedConnectionId),
+      ))
+      .limit(1)
+    const directAccess = await db
+      .select({ id: ExternalMcpConnectionAccessGrantTable.id })
+      .from(ExternalMcpConnectionAccessGrantTable)
+      .where(and(
+        eq(ExternalMcpConnectionAccessGrantTable.organizationId, organizationId),
+        eq(ExternalMcpConnectionAccessGrantTable.externalMcpConnectionId, replacedOwnedConnectionId),
+        isNull(ExternalMcpConnectionAccessGrantTable.pluginMcpRequirementBindingId),
+      ))
+      .limit(1)
+    if (!remainingBinding[0] && !directAccess[0]) {
+      await deleteExternalMcpConnection({ connectionId: replacedOwnedConnectionId, organizationId })
+    }
+  }
   const refreshedConnection = await getExternalMcpConnection({ connectionId: connection.id, organizationId })
 
   return {
@@ -4540,9 +4587,14 @@ export async function importGithubPluginMcps(input: {
   const imported: Array<{ connectionId: string; name: string; url: string }> = []
   const importedSkills: Array<{ name: string; skillId: SkillId; sourcePath: string }> = []
   for (const server of supportedServers) {
+    const authType = resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: server.authType,
+      requestedAuthType: input.authType,
+      url: server.url ?? "",
+    })
     const importedConnection = await ensureImportedExternalMcpConnection({
       access,
-      authType: input.authType,
+      authType,
       context: input.context,
       credentialMode: input.credentialMode,
       server,

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -97,10 +97,10 @@ import {
 } from "../../../mcp/plugin-mcp-requirement-bindings.js"
 import { openworkYourConnectionsUrl } from "../../../mcp/connection-navigation.js"
 import {
-  declaredGithubPluginMcpAuthType,
+  declaredPluginMcpAuthType,
   resolveGithubPluginMcpImportAuthType,
-  type GithubPluginMcpImportAuthType,
-} from "./github-plugin-mcp-auth.js"
+  type PluginMcpAuthType,
+} from "../../../capability-sources/external-mcp-auth-policy.js"
 
 type OrganizationId = PluginArchActorContext["organizationContext"]["organization"]["id"]
 const logger = appLogger.child({ component: "plugin_system_store" })
@@ -3551,7 +3551,7 @@ function mcpServerEntriesFromPayload(input: {
     }
 
     return githubPluginMcpImportServer({
-      authType: declaredGithubPluginMcpAuthType(config),
+      authType: declaredPluginMcpAuthType(config),
       connectionId: null,
       name,
       pluginKey: input.plugin.key,
@@ -4173,7 +4173,7 @@ function sortedUnique<TValue extends string>(values: TValue[]): TValue[] {
 }
 
 async function requireExistingExternalMcpConnectionMatchesImport(input: {
-  authType: GithubPluginMcpImportAuthType
+  authType: PluginMcpAuthType
   credentialMode: "per_member" | "shared"
   existingAuthType: "apikey" | "none" | "oauth"
   existingCredentialMode: "per_member" | "shared"
@@ -4190,7 +4190,7 @@ async function requireExistingExternalMcpConnectionMatchesImport(input: {
 
 async function ensureImportedExternalMcpConnection(input: {
   access: GithubPluginMcpImportAccess
-  authType: GithubPluginMcpImportAuthType
+  authType: PluginMcpAuthType
   context: PluginArchActorContext
   credentialMode: "per_member" | "shared"
   server: GithubPluginMcpImportServer

--- a/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
+++ b/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+import {
+  declaredGithubPluginMcpAuthType,
+  resolveGithubPluginMcpImportAuthType,
+} from "../src/routes/org/plugin-system/github-plugin-mcp-auth.js"
+
+describe("GitHub plugin MCP authentication", () => {
+  test("preserves an explicit OAuth declaration from the plugin", () => {
+    const declaredAuthType = declaredGithubPluginMcpAuthType({ oauth: { clientId: "public-client" } })
+
+    expect(declaredAuthType).toBe("oauth")
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType,
+      requestedAuthType: "none",
+      url: "https://unknown.example.test/mcp",
+    })).toBe("oauth")
+  })
+
+  test("known server presets override a mistaken global no-auth choice", () => {
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: null,
+      requestedAuthType: "none",
+      url: "https://mcp.slack.com/mcp/",
+    })).toBe("oauth")
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: null,
+      requestedAuthType: "oauth",
+      url: "https://mcp.exa.ai/mcp",
+    })).toBe("apikey")
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: null,
+      requestedAuthType: "oauth",
+      url: "https://mcp.context7.com/mcp",
+    })).toBe("none")
+  })
+
+  test("uses the requested fallback only when the plugin and presets are silent", () => {
+    expect(declaredGithubPluginMcpAuthType({})).toBeNull()
+    expect(resolveGithubPluginMcpImportAuthType({
+      declaredAuthType: null,
+      requestedAuthType: "none",
+      url: "https://public.example.test/mcp",
+    })).toBe("none")
+  })
+})

--- a/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
+++ b/ee/apps/den-api/test/github-plugin-mcp-auth.test.ts
@@ -1,12 +1,12 @@
 import { describe, expect, test } from "bun:test"
 import {
-  declaredGithubPluginMcpAuthType,
+  declaredPluginMcpAuthType,
   resolveGithubPluginMcpImportAuthType,
-} from "../src/routes/org/plugin-system/github-plugin-mcp-auth.js"
+} from "../src/capability-sources/external-mcp-auth-policy.js"
 
 describe("GitHub plugin MCP authentication", () => {
   test("preserves an explicit OAuth declaration from the plugin", () => {
-    const declaredAuthType = declaredGithubPluginMcpAuthType({ oauth: { clientId: "public-client" } })
+    const declaredAuthType = declaredPluginMcpAuthType({ oauth: { clientId: "public-client" } })
 
     expect(declaredAuthType).toBe("oauth")
     expect(resolveGithubPluginMcpImportAuthType({
@@ -35,7 +35,7 @@ describe("GitHub plugin MCP authentication", () => {
   })
 
   test("uses the requested fallback only when the plugin and presets are silent", () => {
-    expect(declaredGithubPluginMcpAuthType({})).toBeNull()
+    expect(declaredPluginMcpAuthType({})).toBeNull()
     expect(resolveGithubPluginMcpImportAuthType({
       declaredAuthType: null,
       requestedAuthType: "none",

--- a/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
+++ b/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
@@ -525,6 +525,74 @@ describe("marketplace cloud readiness payload", () => {
     expect(resolved.cloudReadiness?.connections[0]).toMatchObject({ id: connectionId, credentialMode: "shared", connectedForMe: true })
   })
 
+  test("misclassified Slack bindings stay blocked until an admin repairs OAuth setup", async () => {
+    const org = await seedOrg()
+    const url = "https://mcp.slack.com/mcp"
+    const plugin = await seedPlugin({
+      org,
+      name: "Imported Slack Plugin",
+      components: [{
+        objectType: "mcp",
+        title: "Slack MCP",
+        normalizedPayloadJson: {
+          externalMcpConnectionOwnedByPlugin: true,
+          mcpServers: { slack: { url } },
+        },
+      }],
+    })
+    const configObjectId = plugin.configObjectIds[0]
+    if (!configObjectId) throw new Error("missing config object")
+
+    const misclassified = await configurePluginMcp({
+      authType: "none",
+      configObjectId,
+      credentialMode: "shared",
+      org,
+      pluginId: plugin.pluginId,
+    })
+    const oldConnectionId = normalizeDenTypeId("externalMcpConnection", misclassified.connection.id)
+    expect(misclassified.connection).toMatchObject({ authType: "none", connected: true })
+    expect(await listUsableConnectionIds({ org, memberId: org.memberId })).not.toContain(oldConnectionId)
+
+    const before = await resolvedPlugin({ context: org.context, marketplaceId: org.marketplaceId, pluginId: plugin.pluginId })
+    expect(before.cloudReadiness).toMatchObject({
+      state: "needs_admin_setup",
+      connections: [{
+        authType: "none",
+        authTypeMismatch: true,
+        id: oldConnectionId,
+        oauthClientConfigured: false,
+        oauthClientRequired: true,
+        requiredAuthType: "oauth",
+      }],
+    })
+
+    const repaired = await store.configureMarketplacePluginMcpRequirement({
+      authType: "oauth",
+      configObjectId,
+      context: org.context,
+      credentialMode: "per_member",
+      oauthClient: { clientId: "slack-client", clientSecret: "slack-secret" },
+      pluginId: plugin.pluginId,
+      serverName: "slack",
+    })
+    expect(repaired.connection.id).not.toBe(oldConnectionId)
+    expect(await db.select().from(ExternalMcpConnectionTable).where(eq(ExternalMcpConnectionTable.id, oldConnectionId))).toHaveLength(0)
+
+    const after = await resolvedPlugin({ context: org.context, marketplaceId: org.marketplaceId, pluginId: plugin.pluginId })
+    expect(after.cloudReadiness).toMatchObject({
+      state: "needs_signin",
+      connections: [{
+        authType: "oauth",
+        authTypeMismatch: false,
+        id: repaired.connection.id,
+        oauthClientConfigured: true,
+        oauthClientRequired: true,
+        requiredAuthType: "oauth",
+      }],
+    })
+  })
+
   test("unmatched MCP dependencies need admin setup and include declared connection details", async () => {
     const org = await seedOrg()
     const url = "https://missing.example.test/mcp"

--- a/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
+++ b/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
@@ -95,10 +95,13 @@ beforeAll(async () => {
   }))
   mock.module("../src/capability-sources/external-mcp-client-runtime.js", () => ({
     abandonExternalMcpAuth: unsupportedExternalMcpRuntimeMock,
+    abandonLegacyExternalMcpAuth: unsupportedExternalMcpRuntimeMock,
     callExternalMcpTool: unsupportedExternalMcpRuntimeMock,
     connectExternalMcp: connectExternalMcpMock,
     completeExternalMcpAuth: unsupportedExternalMcpRuntimeMock,
+    completeLegacyExternalMcpAuth: unsupportedExternalMcpRuntimeMock,
     externalMcpClientRuntimeName: "test external MCP runtime",
+    inspectExternalMcpToolCall: unsupportedExternalMcpRuntimeMock,
     listExternalMcpTools: unsupportedExternalMcpRuntimeMock,
   }))
   store = await import("../src/routes/org/plugin-system/store.js")

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-data.tsx
@@ -56,6 +56,7 @@ export type MarketplacePluginSummary = {
 export type MarketplacePluginCloudReadinessState = "ready" | "needs_signin" | "needs_admin_setup" | "desktop_only" | "not_synced";
 
 export type MarketplacePluginCloudReadinessConnection = {
+  authType?: ExternalMcpAuthType;
   configObjectId: string;
   id: string | null;
   name: string;
@@ -63,6 +64,8 @@ export type MarketplacePluginCloudReadinessConnection = {
   url: string;
   credentialMode?: "shared" | "per_member";
   connectedForMe?: boolean;
+  oauthClientConfigured?: boolean;
+  oauthClientRequired?: boolean;
 };
 
 export type MarketplacePluginCloudReadiness = {
@@ -123,7 +126,11 @@ function parseCloudReadinessConnection(entry: unknown): MarketplacePluginCloudRe
   const url = asString(entry.url);
   if (!configObjectId || !name || !serverName || !url) return null;
   const credentialMode = parseCredentialMode(entry.credentialMode);
+  const authType = entry.authType === "oauth" || entry.authType === "apikey" || entry.authType === "none"
+    ? entry.authType
+    : null;
   return {
+    ...(authType ? { authType } : {}),
     configObjectId,
     id: typeof entry.id === "string" ? entry.id : null,
     name,
@@ -131,6 +138,8 @@ function parseCloudReadinessConnection(entry: unknown): MarketplacePluginCloudRe
     url,
     ...(credentialMode ? { credentialMode } : {}),
     ...(typeof entry.connectedForMe === "boolean" ? { connectedForMe: entry.connectedForMe } : {}),
+    ...(typeof entry.oauthClientConfigured === "boolean" ? { oauthClientConfigured: entry.oauthClientConfigured } : {}),
+    ...(typeof entry.oauthClientRequired === "boolean" ? { oauthClientRequired: entry.oauthClientRequired } : {}),
   };
 }
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-data.tsx
@@ -57,6 +57,7 @@ export type MarketplacePluginCloudReadinessState = "ready" | "needs_signin" | "n
 
 export type MarketplacePluginCloudReadinessConnection = {
   authType?: ExternalMcpAuthType;
+  authTypeMismatch?: boolean;
   configObjectId: string;
   id: string | null;
   name: string;
@@ -66,6 +67,7 @@ export type MarketplacePluginCloudReadinessConnection = {
   connectedForMe?: boolean;
   oauthClientConfigured?: boolean;
   oauthClientRequired?: boolean;
+  requiredAuthType?: ExternalMcpAuthType;
 };
 
 export type MarketplacePluginCloudReadiness = {
@@ -129,8 +131,12 @@ function parseCloudReadinessConnection(entry: unknown): MarketplacePluginCloudRe
   const authType = entry.authType === "oauth" || entry.authType === "apikey" || entry.authType === "none"
     ? entry.authType
     : null;
+  const requiredAuthType = entry.requiredAuthType === "oauth" || entry.requiredAuthType === "apikey" || entry.requiredAuthType === "none"
+    ? entry.requiredAuthType
+    : null;
   return {
     ...(authType ? { authType } : {}),
+    ...(typeof entry.authTypeMismatch === "boolean" ? { authTypeMismatch: entry.authTypeMismatch } : {}),
     configObjectId,
     id: typeof entry.id === "string" ? entry.id : null,
     name,
@@ -140,6 +146,7 @@ function parseCloudReadinessConnection(entry: unknown): MarketplacePluginCloudRe
     ...(typeof entry.connectedForMe === "boolean" ? { connectedForMe: entry.connectedForMe } : {}),
     ...(typeof entry.oauthClientConfigured === "boolean" ? { oauthClientConfigured: entry.oauthClientConfigured } : {}),
     ...(typeof entry.oauthClientRequired === "boolean" ? { oauthClientRequired: entry.oauthClientRequired } : {}),
+    ...(requiredAuthType ? { requiredAuthType } : {}),
   };
 }
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -32,6 +32,7 @@ import { type ExternalMcpAuthType, type ExternalMcpCredentialMode, type External
 import {
   findPresetForRequirement,
   pluginReadinessConnectionAction,
+  pluginRequirementNeedsAdminSetup,
   pluginSetupActionLabel,
   pluginSetupAuthLabel,
   pluginSetupCredentialMode,
@@ -586,7 +587,7 @@ function MarketplacePluginCard({
     .filter(([, count]) => count > 0)
     .sort((a, b) => b[1] - a[1]);
   const actionableConnections = plugin.cloudReadiness?.connections.filter((connection) => (
-    connection.id === null || pluginReadinessConnectionAction(connection, isAdmin) !== null
+    pluginRequirementNeedsAdminSetup(connection) || pluginReadinessConnectionAction(connection, isAdmin) !== null
   )) ?? [];
 
   return (
@@ -646,7 +647,8 @@ function MarketplacePluginCard({
                   {actionableConnections.map((connection) => {
                     const preset = findPresetForRequirement(presets, connection);
                     const serviceName = serviceNameForRequirement(connection, preset);
-                    const readinessAction = pluginReadinessConnectionAction(connection, isAdmin);
+                    const needsAdminSetup = pluginRequirementNeedsAdminSetup(connection);
+                    const readinessAction = needsAdminSetup ? null : pluginReadinessConnectionAction(connection, isAdmin);
                     return (
                       <div key={`${connection.configObjectId}:${connection.serverName}`} className="rounded-xl border border-amber-100 bg-amber-50/60 p-3">
                         <div className="flex items-start gap-2.5">
@@ -665,7 +667,7 @@ function MarketplacePluginCard({
                           </div>
                         </div>
                         <div className="mt-2 flex justify-end">
-                          {connection.id === null ? (
+                          {needsAdminSetup ? (
                             isAdmin ? (
                               <DenButton variant="secondary" size="sm" onClick={() => onSetup(connection)}>
                                 {pluginSetupActionLabel(preset)}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-mcp-setup.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-mcp-setup.ts
@@ -139,6 +139,7 @@ export function pluginReadinessConnectionAction(
 
 export function pluginRequirementNeedsAdminSetup(connection: MarketplacePluginCloudReadinessConnection): boolean {
   if (connection.id === null) return true;
+  if (connection.authTypeMismatch === true) return true;
   if (connection.oauthClientRequired === true && connection.oauthClientConfigured === false) return true;
   return connection.connectedForMe === false && (connection.authType === "apikey" || connection.authType === "none");
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-mcp-setup.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-mcp-setup.ts
@@ -137,6 +137,12 @@ export function pluginReadinessConnectionAction(
   return null;
 }
 
+export function pluginRequirementNeedsAdminSetup(connection: MarketplacePluginCloudReadinessConnection): boolean {
+  if (connection.id === null) return true;
+  if (connection.oauthClientRequired === true && connection.oauthClientConfigured === false) return true;
+  return connection.connectedForMe === false && (connection.authType === "apikey" || connection.authType === "none");
+}
+
 export function pluginSetupActionLabel(preset: ExternalMcpPreset | null): string {
   return preset ? "Quick connect" : "Configure connection";
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connection-setup.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connection-setup.ts
@@ -1,0 +1,25 @@
+import type { ExternalMcpConnection, ExternalMcpPreset } from "./mcp-connections-data";
+
+function normalizeMcpUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    const pathname = url.pathname.length > 1 ? url.pathname.replace(/\/+$/, "") : url.pathname;
+    return `${url.protocol.toLowerCase()}//${url.host.toLowerCase()}${pathname}${url.search}`;
+  } catch {
+    return null;
+  }
+}
+
+export function marketplaceConnectionNeedsAdminSetup(
+  connection: ExternalMcpConnection,
+  presets: ExternalMcpPreset[],
+): boolean {
+  if (connection.identityManagedBy.length === 0) return false;
+  const normalizedUrl = normalizeMcpUrl(connection.url);
+  const preset = normalizedUrl
+    ? presets.find((candidate) => normalizeMcpUrl(candidate.url) === normalizedUrl)
+    : null;
+  if (preset && preset.authType !== connection.authType) return true;
+  if (connection.authType === "oauth" && preset?.requiresOAuthClient === true && !connection.oauthClientId) return true;
+  return !connection.connected && (connection.authType === "apikey" || connection.authType === "none");
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { Check, ChevronDown, ChevronRight, Loader2, MoreHorizontal, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
-import { DenButton } from "../../_components/ui/button";
+import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenNotice } from "../../_components/ui/notice";
 import { DenSelect } from "../../_components/ui/select";
@@ -21,6 +21,7 @@ import {
   type McpConnectionAccessMode,
 } from "./mcp-connection-editing";
 import { formatConnectionCreatorAttribution } from "./mcp-connection-display";
+import { marketplaceConnectionNeedsAdminSetup } from "./mcp-connection-setup";
 import { shouldShowMcpConnectionsStagingBanner } from "./mcp-connections-capability";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { marketplaceQueryKeys, useMarketplaces } from "./marketplace-data";
@@ -218,7 +219,7 @@ function importServerStatus(server: GithubPluginImportServer): string {
 }
 
 export function McpConnectionsScreen() {
-  const { orgContext } = useOrgDashboard();
+  const { orgContext, orgSlug } = useOrgDashboard();
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
   const { data: usableConnections = [] } = useMcpConnections("usable");
   const { data: presets = [] } = useMcpConnectionPresets();
@@ -528,10 +529,14 @@ export function McpConnectionsScreen() {
         </div>
       ) : (
         <div className="divide-y divide-gray-100 rounded-2xl border border-gray-100 bg-white">
-          {connections.map((connection) => (
-            <ConnectionRow
+          {connections.map((connection) => {
+            const needsAdminSetup = marketplaceConnectionNeedsAdminSetup(connection, presets);
+            const setupPluginId = connection.identityManagedBy[0]?.pluginId;
+            return <ConnectionRow
               key={connection.id}
               connection={connection}
+              needsAdminSetup={needsAdminSetup}
+              setupHref={needsAdminSetup && setupPluginId ? getPluginRoute(orgSlug, setupPluginId) : null}
               polling={pollingConnectionId === connection.id}
               connecting={startOAuth.isPending && startOAuth.variables === connection.id}
               errorMessage={connectionActionError?.connectionId === connection.id ? connectionActionError.message : null}
@@ -546,8 +551,8 @@ export function McpConnectionsScreen() {
               removing={deleteConnection.isPending && deleteConnection.variables === connection.id}
               toolsOpen={toolsConnectionId === connection.id}
               onToggleTools={() => setToolsConnectionId((current) => current === connection.id ? null : connection.id)}
-            />
-          ))}
+            />;
+          })}
         </div>
       )}
 
@@ -1169,6 +1174,8 @@ function accessSummaryLabel(connection: ExternalMcpConnection): string {
 
 function ConnectionRow({
   connection,
+  needsAdminSetup,
+  setupHref,
   polling,
   connecting,
   errorMessage,
@@ -1182,6 +1189,8 @@ function ConnectionRow({
   onToggleTools,
 }: {
   connection: ExternalMcpConnection;
+  needsAdminSetup: boolean;
+  setupHref: string | null;
   polling: boolean;
   connecting: boolean;
   errorMessage: string | null;
@@ -1199,9 +1208,10 @@ function ConnectionRow({
   const [actionsOpen, setActionsOpen] = useState(false);
   const actionsMenuRef = useRef<HTMLDivElement>(null);
   const actionsTriggerRef = useRef<HTMLButtonElement>(null);
-  const canConnectOAuth = connection.authType === "oauth"
+  const displayedConnected = connection.connected && !needsAdminSetup;
+  const canConnectOAuth = !needsAdminSetup && connection.authType === "oauth"
     && (isPerMember ? !connection.connectedForMe : !connection.connected);
-  const canInspectTools = connection.credentialMode === "shared" ? connection.connected : connection.connectedForMe;
+  const canInspectTools = !needsAdminSetup && (connection.credentialMode === "shared" ? connection.connected : connection.connectedForMe);
 
   useEffect(() => {
     if (!actionsOpen) return;
@@ -1234,12 +1244,16 @@ function ConnectionRow({
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
-              {isPerMember ? (
+              {needsAdminSetup ? (
+                <span className="inline-flex rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                  Setup required
+                </span>
+              ) : isPerMember ? (
                 <span className={`inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium ${connection.connected ? "bg-emerald-50 text-emerald-700" : "bg-gray-100 text-gray-500"}`}>
                   <Users className="h-3 w-3" />
                   {connection.connected ? "Individual accounts connected" : "Not connected"}
                 </span>
-              ) : connection.connected ? (
+              ) : displayedConnected ? (
                 <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
                   <Check className="h-3 w-3" />
                   Connected
@@ -1274,6 +1288,11 @@ function ConnectionRow({
         </div>
 
         <div className="flex flex-wrap items-center gap-2 sm:shrink-0 sm:flex-nowrap">
+          {setupHref ? (
+            <Link href={setupHref} className={buttonVariants({ variant: "primary", size: "sm" })}>
+              Set up
+            </Link>
+          ) : null}
           {canConnectOAuth ? (
             <DenButton
               variant="secondary"

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -1275,7 +1275,7 @@ function ConnectionRow({
               ) : null}
             </div>
             <p className="mt-0.5 truncate text-[12px] text-gray-500">
-              {connection.url} · {formatMcpConnectedTimestamp(connection.connectedAt)}{creatorAttribution ? ` · ${creatorAttribution}` : ""}
+              {connection.url}{needsAdminSetup ? "" : ` · ${formatMcpConnectedTimestamp(connection.connectedAt)}`}{creatorAttribution ? ` · ${creatorAttribution}` : ""}
             </p>
             {connection.authType === "oauth" ? (
               <div className="mt-1 flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] text-gray-500">
@@ -1303,7 +1303,7 @@ function ConnectionRow({
               Connect
             </DenButton>
           ) : null}
-          {connection.connected ? (
+          {displayedConnected ? (
             <DenButton
               variant="secondary"
               size="sm"

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -2,13 +2,15 @@
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
+import Link from "next/link";
 import { AlertTriangle, Check, Loader2, Plug, Wrench } from "lucide-react";
-import { DenButton } from "../../_components/ui/button";
+import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
-import { getOrgAccessFlags } from "../../_lib/den-org";
+import { getOrgAccessFlags, getPluginRoute } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { IntegrationIcon } from "./integration-icon";
 import { formatRequiredBy, sortConnectionsForFocus, trustedConnectionFocusId } from "./mcp-connection-display";
+import { marketplaceConnectionNeedsAdminSetup } from "./mcp-connection-setup";
 import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl } from "./mcp-authorization-url";
 import { MICROSOFT_365_DISPLAY_SCOPES } from "./microsoft-365-permissions";
 import {
@@ -17,6 +19,7 @@ import {
   isNativeProviderConnectionId,
   useDisconnectMyProviderAccount,
   useMcpConnections,
+  useMcpConnectionPresets,
   useStartMcpConnectionOAuth,
 } from "./mcp-connections-data";
 import { McpToolRunner } from "./mcp-tool-runner";
@@ -35,7 +38,8 @@ const OAUTH_POLL_TIMEOUT_MS = 90_000;
  */
 export function YourConnectionsScreen() {
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections("usable");
-  const { orgContext } = useOrgDashboard();
+  const { data: presets = [] } = useMcpConnectionPresets();
+  const { orgContext, orgSlug } = useOrgDashboard();
   const searchParams = useSearchParams();
   const access = getOrgAccessFlags(
     orgContext?.currentMember.role ?? "member",
@@ -146,11 +150,15 @@ export function YourConnectionsScreen() {
         </div>
       ) : (
         <div className="divide-y divide-gray-100 rounded-2xl border border-gray-100 bg-white">
-          {visibleConnections.map((connection) => (
-            <YourConnectionRow
+          {visibleConnections.map((connection) => {
+            const needsAdminSetup = marketplaceConnectionNeedsAdminSetup(connection, presets);
+            const setupPluginId = connection.identityManagedBy[0]?.pluginId;
+            return <YourConnectionRow
               key={connection.id}
               connection={connection}
               isAdmin={access.isAdmin}
+              needsAdminSetup={needsAdminSetup}
+              setupHref={access.isAdmin && needsAdminSetup && setupPluginId ? getPluginRoute(orgSlug, setupPluginId) : null}
               highlighted={focusConnectionId === connection.id}
               rowRef={focusConnectionId === connection.id ? focusedRowRef : undefined}
               polling={pollingConnectionId === connection.id}
@@ -159,8 +167,8 @@ export function YourConnectionsScreen() {
               errorMessage={rowError?.connectionId === connection.id ? rowError.message : null}
               onConnect={() => void handleConnectMyAccount(connection.id)}
               onDisconnect={() => void handleDisconnectMyAccount(connection.id)}
-            />
-          ))}
+            />;
+          })}
         </div>
       )}
     </DashboardPageTemplate>
@@ -170,6 +178,8 @@ export function YourConnectionsScreen() {
 function YourConnectionRow({
   connection,
   isAdmin,
+  needsAdminSetup,
+  setupHref,
   polling,
   connecting,
   disconnecting,
@@ -181,6 +191,8 @@ function YourConnectionRow({
 }: {
   connection: ExternalMcpConnection;
   isAdmin: boolean;
+  needsAdminSetup: boolean;
+  setupHref: string | null;
   highlighted: boolean;
   rowRef?: React.Ref<HTMLDivElement>;
   polling: boolean;
@@ -191,11 +203,11 @@ function YourConnectionRow({
   onDisconnect: () => void;
 }) {
   const isPerMember = connection.credentialMode === "per_member";
-  const needsReconnect = connection.connectedForMe && connection.needsReconnect === true;
-  const needsMyConnect = isPerMember && !connection.connectedForMe;
-  const needsAdminConnect = isAdmin && !isPerMember && connection.authType === "oauth" && !connection.connectedForMe;
-  const canDisconnect = canDisconnectMyConnectionAccount(connection);
-  const canTestTools = isAdmin && !isNativeProviderConnectionId(connection.id) && connection.connectedForMe && !needsReconnect;
+  const needsReconnect = !needsAdminSetup && connection.connectedForMe && connection.needsReconnect === true;
+  const needsMyConnect = !needsAdminSetup && isPerMember && !connection.connectedForMe;
+  const needsAdminConnect = !needsAdminSetup && isAdmin && !isPerMember && connection.authType === "oauth" && !connection.connectedForMe;
+  const canDisconnect = !needsAdminSetup && canDisconnectMyConnectionAccount(connection);
+  const canTestTools = !needsAdminSetup && isAdmin && !isNativeProviderConnectionId(connection.id) && connection.connectedForMe && !needsReconnect;
   const [toolRunnerOpen, setToolRunnerOpen] = useState(false);
   const microsoftScopes = connection.id === "microsoft-365"
     ? (connection.grantedScopes ?? []).filter((scope) => MICROSOFT_365_DISPLAY_SCOPES.has(scope))
@@ -214,7 +226,11 @@ function YourConnectionRow({
           <div className="min-w-0 flex-1">
             <div className="flex flex-wrap items-center gap-2">
               <p className="truncate text-[14px] font-semibold text-gray-900">{connection.name}</p>
-              {needsReconnect ? (
+              {needsAdminSetup ? (
+                <span className="inline-flex rounded-full bg-amber-50 px-2 py-0.5 text-[11px] font-medium text-amber-700">
+                  Waiting for an admin to finish setup
+                </span>
+              ) : needsReconnect ? (
                 <span className="inline-flex items-center gap-1 rounded-full bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
                   <AlertTriangle className="h-3 w-3" />
                   Reconnect to grant new permissions
@@ -265,6 +281,11 @@ function YourConnectionRow({
         </div>
 
         <div className="flex shrink-0 flex-wrap items-center gap-2">
+          {setupHref ? (
+            <Link href={setupHref} className={buttonVariants({ variant: "primary", size: "sm" })}>
+              Set up
+            </Link>
+          ) : null}
           {canTestTools ? (
             <DenButton
               variant="secondary"

--- a/ee/apps/den-web/tests/marketplace-mcp-readiness.test.ts
+++ b/ee/apps/den-web/tests/marketplace-mcp-readiness.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, test } from "bun:test";
 
 import { formatRequiredBy, sortConnectionsForFocus, trustedConnectionFocusId } from "../app/(den)/dashboard/_components/mcp-connection-display";
+import { marketplaceConnectionNeedsAdminSetup } from "../app/(den)/dashboard/_components/mcp-connection-setup";
 import type { ExternalMcpConnection, ExternalMcpPreset, ExternalMcpRequiredBy } from "../app/(den)/dashboard/_components/mcp-connections-data";
 import { parseMarketplaceResolvedPayload, type MarketplacePluginCloudReadinessConnection } from "../app/(den)/dashboard/_components/marketplace-data";
 import {
   findPresetForRequirement,
   pluginReadinessConnectionAction,
+  pluginRequirementNeedsAdminSetup,
   pluginSetupAuthType,
   pluginSetupCredentialMode,
   pluginSetupInitialState,
@@ -24,6 +26,7 @@ function connection(input: { id: string; name: string; requiredBy?: ExternalMcpR
     connectedAt: null,
     connectedForMe: false,
     requiredBy: input.requiredBy ?? [],
+    identityManagedBy: [],
     access: null,
   };
 }
@@ -62,11 +65,14 @@ describe("marketplace MCP readiness parsing", () => {
             state: "needs_admin_setup",
             hasInstructional: true,
             connections: [{
+              authType: "oauth",
               configObjectId: "cfg_slack",
               id: null,
               name: "slack",
               serverName: "slack",
               url: "https://mcp.slack.com/mcp",
+              oauthClientConfigured: false,
+              oauthClientRequired: true,
             }],
           },
         }],
@@ -75,11 +81,14 @@ describe("marketplace MCP readiness parsing", () => {
     });
 
     expect(parsed.plugins[0]?.cloudReadiness?.connections[0]).toEqual({
+      authType: "oauth",
       configObjectId: "cfg_slack",
       id: null,
       name: "slack",
       serverName: "slack",
       url: "https://mcp.slack.com/mcp",
+      oauthClientConfigured: false,
+      oauthClientRequired: true,
     });
   });
 
@@ -182,6 +191,24 @@ describe("marketplace MCP readiness parsing", () => {
     expect(pluginReadinessConnectionAction(requirement, false)).toBeNull();
   });
 
+  test("keeps imported OAuth requirements in admin setup until their required client exists", () => {
+    const requirement: MarketplacePluginCloudReadinessConnection = {
+      authType: "oauth",
+      configObjectId: "cfg_slack",
+      id: "emc_shared_slack",
+      name: "Support Operations / slack",
+      serverName: "slack",
+      url: "https://mcp.slack.com/mcp",
+      credentialMode: "per_member",
+      connectedForMe: false,
+      oauthClientConfigured: false,
+      oauthClientRequired: true,
+    };
+
+    expect(pluginRequirementNeedsAdminSetup(requirement)).toBe(true);
+    expect(pluginRequirementNeedsAdminSetup({ ...requirement, oauthClientConfigured: true })).toBe(false);
+  });
+
   test("projects existing per-member disconnected requirements as Your Connections handoffs", () => {
     const requirement: MarketplacePluginCloudReadinessConnection = {
       configObjectId: "cfg_slack",
@@ -209,6 +236,29 @@ describe("marketplace MCP readiness parsing", () => {
 });
 
 describe("Your Connections focus and provenance helpers", () => {
+  test("blocks member OAuth until an admin repairs a marketplace-managed Slack connection", () => {
+    const slackPreset: ExternalMcpPreset = {
+      presetId: "slack",
+      displayName: "Slack",
+      description: "Slack",
+      url: "https://mcp.slack.com/mcp",
+      authType: "oauth",
+      requiresOAuthClient: true,
+    };
+    const imported = connection({ id: "emc_slack", name: "Anthropic Engineering / slack" });
+    imported.authType = "none";
+    imported.connected = true;
+    imported.identityManagedBy = [{ pluginId: "plg_engineering", name: "Anthropic Engineering" }];
+
+    expect(marketplaceConnectionNeedsAdminSetup(imported, [slackPreset])).toBe(true);
+    expect(marketplaceConnectionNeedsAdminSetup({
+      ...imported,
+      authType: "oauth",
+      connected: false,
+      oauthClientId: "configured-client",
+    }, [slackPreset])).toBe(false);
+  });
+
   test("focuses only authorized returned connection ids", () => {
     const connections = [
       connection({ id: "emc_one", name: "Support Operations / slack" }),

--- a/ee/apps/den-web/tests/marketplace-mcp-readiness.test.ts
+++ b/ee/apps/den-web/tests/marketplace-mcp-readiness.test.ts
@@ -66,6 +66,7 @@ describe("marketplace MCP readiness parsing", () => {
             hasInstructional: true,
             connections: [{
               authType: "oauth",
+              authTypeMismatch: false,
               configObjectId: "cfg_slack",
               id: null,
               name: "slack",
@@ -73,6 +74,7 @@ describe("marketplace MCP readiness parsing", () => {
               url: "https://mcp.slack.com/mcp",
               oauthClientConfigured: false,
               oauthClientRequired: true,
+              requiredAuthType: "oauth",
             }],
           },
         }],
@@ -82,6 +84,7 @@ describe("marketplace MCP readiness parsing", () => {
 
     expect(parsed.plugins[0]?.cloudReadiness?.connections[0]).toEqual({
       authType: "oauth",
+      authTypeMismatch: false,
       configObjectId: "cfg_slack",
       id: null,
       name: "slack",
@@ -89,6 +92,7 @@ describe("marketplace MCP readiness parsing", () => {
       url: "https://mcp.slack.com/mcp",
       oauthClientConfigured: false,
       oauthClientRequired: true,
+      requiredAuthType: "oauth",
     });
   });
 
@@ -207,6 +211,13 @@ describe("marketplace MCP readiness parsing", () => {
 
     expect(pluginRequirementNeedsAdminSetup(requirement)).toBe(true);
     expect(pluginRequirementNeedsAdminSetup({ ...requirement, oauthClientConfigured: true })).toBe(false);
+    expect(pluginRequirementNeedsAdminSetup({
+      ...requirement,
+      authType: "none",
+      authTypeMismatch: true,
+      oauthClientConfigured: true,
+      requiredAuthType: "oauth",
+    })).toBe(true);
   });
 
   test("projects existing per-member disconnected requirements as Your Connections handoffs", () => {

--- a/evals/flows/marketplace-plugin-mcp-auth.flow.mjs
+++ b/evals/flows/marketplace-plugin-mcp-auth.flow.mjs
@@ -275,7 +275,7 @@ export default {
               trigger: () => clickFocusedConnect(ctx),
             });
             await routeLocalSplitOriginCallback(ctx);
-            await ctx.waitForText("Connected", { timeoutMs: 30_000 });
+            await ctx.waitForText("You're connected", { timeoutMs: 30_000 });
             await ctx.switchBack();
             await waitForConnectedAsMaya(ctx);
           },
@@ -1135,7 +1135,10 @@ async function clickFocusedConnect(ctx) {
 }
 
 async function routeLocalSplitOriginCallback(ctx) {
-  await ctx.waitFor("window.location.pathname.includes('/connect/callback')", { timeoutMs: 30_000, label: "provider redirect to OpenWork callback" });
+  await ctx.waitFor(`(() => {
+    const path = window.location.pathname;
+    return path.includes('/connect/callback') || path === '/v1/mcp-connections/oauth/callback';
+  })()`, { timeoutMs: 30_000, label: "provider redirect to OpenWork callback" });
   const location = await ctx.eval(`({ origin: window.location.origin, pathname: window.location.pathname, search: window.location.search })`);
   if (!String(location.pathname).includes("/connect/callback") || location.origin === new URL(DEN_API_URL).origin) return;
   const callbackUrl = new URL(`${location.pathname}${location.search}`, DEN_API_URL).toString();


### PR DESCRIPTION
## Summary

This PR repairs MCP connections imported through plugins/chat without moving provider-specific behavior into the import path.

- Derive required authentication from the plugin declaration and OpenWork's known-server presets before using the import-wide fallback.
- Use one shared required-auth policy for import, marketplace readiness, and runtime admission.
- Keep a stale or misclassified binding out of runtime capability use even when its stored record says `connected`.
- Surface the mismatch as administrator setup, then move the existing plugin binding to the repaired connection without losing unrelated bindings or direct grants.
- Validate public/no-auth MCPs through the shared live MCP runtime before recording `connectedAt`.
- Keep pre-registered OAuth MCPs in administrator setup until the organization's client credentials exist; after that, members get the normal **Connect your account** flow.
- Remove an obsolete server-created record only after its binding moves and only when no other binding or direct access grant remains.

## Root cause

The GitHub/chat import accepted one authentication choice for every selected MCP. That choice could override a plugin's declared OAuth requirement. The no-auth path then wrote `connectedAt` without contacting the MCP endpoint.

The UI could partially mask this state, but server-side readiness and capability lookup still trusted the stale stored authentication type. That allowed a misclassified connection to appear usable and left administrators and members without a reliable recovery path.

## End state

- Plugin and preset authentication requirements win over a broad import choice.
- A stored authentication mismatch is explicit in the readiness payload as `authTypeMismatch` with `requiredAuthType`.
- Misclassified marketplace bindings are excluded from runtime use until repaired.
- Administrators see **Setup required** rather than a stale connected timestamp or Disconnect action.
- Members wait for administrator setup; after setup, individual-account OAuth remains member-owned.
- For marketplace MCPs requiring a pre-registered OAuth client—currently Slack—members can connect their accounts after an administrator configures the organization's OAuth app.
- No database migration or destructive bulk conversion is introduced.

## Relationship to #2853

- **#2853** owns generic provider OAuth discovery, callback validation, first-tool-page usability, and the pre-redirect popup.
- **This PR (#2851)** owns plugin/chat import classification, marketplace readiness, binding preservation, and administrator/member recovery.
- Merge **#2853 first**, then this PR. The import validator deliberately calls the shared runtime; after #2853, that proof includes initialize plus the first bounded `tools/list` page.
- There is no duplicated provider-specific runtime branch in this PR.

## Security and data boundaries

- OAuth tokens, API keys, and client secrets remain Den-owned and are not returned to agents or members.
- Existing tenant scoping, SSRF checks, access grants, and administrator-only marketplace setup remain in force.
- Repair preserves compatible bindings and grants.
- Cleanup is narrowly limited to an unreferenced server-created record after replacement.

## Validation

Branch head: `bd52b98ea`, based on `upstream/dev` at `55033420`.

- Den API TypeScript check passed.
- Den Web TypeScript check passed.
- Import/auth and marketplace cloud-readiness suites: **34 passed**.
- Den Web marketplace readiness suite: **12 passed**.
- `git diff --check` passed.
- Full local admin-to-member Fraimz journey: **7 visual frames passed**, plus cleanup and approved voice-over coverage.
  - Admin assigns the marketplace and configures its pre-registered OAuth client.
  - Member execution returns structured `needs_connection` without calling the provider.
  - The focused Your Connections URL opens the correct row.
  - The shared callback completes, the row becomes **Connected as you**, and no dynamic client registration occurs.
  - Retrying discovers and executes the authenticated MCP tool, returning `SHIFT_HANDOFF_READY`.
  - [Vercel-hosted screenshots and frame assertions](https://github.com/different-ai/openwork/pull/2851#issuecomment-4996946909).
- Combined with #2853 in a fresh isolated worktree:
  - enterprise MCP client: **40 passed**
  - import/readiness API suites: **34 passed**
  - connection/callback API suite: **15 passed**
  - combined Web suites: **20 passed**
  - enterprise client build and both affected TypeScript checks passed
- The combined verification also caught and fixed the shared runtime mock export contract before publication.
- GitHub Actions passed at `bd52b98ea`: Den API, Den Web, and inference builds; Linux and macOS test matrices; Helm validation; and i18n audit.

## Reviewer flow

1. Import a plugin containing an MCP whose declared/preset auth differs from the import-wide selection.
2. Confirm the MCP is not exposed as ready or connected solely from the stale stored record.
3. As an administrator, use the setup action to configure the required authentication.
4. Confirm the plugin binding moves to the repaired connection and unrelated grants remain.
5. For individual-account OAuth, confirm an assigned member sees **Connect your account** only after the organization client is configured.
6. Disconnect/reconnect and confirm the marketplace binding remains recoverable.

## Not run / external limits

- Live Slack OAuth was not completed because it requires an organization-owned provider client and consent. The end-to-end OAuth proof uses the repository's pre-registered local MCP provider with dynamic client registration disabled.
- No new video was captured; the PR comment contains the complete Vercel-hosted screenshot sequence and machine-checked assertions.
