### PR TITLE
fix(mcp): handle provider OAuth interoperability gaps

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
@@ -22,11 +22,46 @@ export function safeMcpAuthorizationUrl(rawUrl: string): string {
   return url.toString()
 }
 
+export function mcpAuthorizationPendingDocument(): string {
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light" />
+    <title>Connecting — OpenWork</title>
+    <style>
+      :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      * { box-sizing: border-box; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 32px; color: #182033; background: #f7f7f4; }
+      .card { width: min(100%, 440px); padding: 48px 40px; text-align: center; background: rgba(255, 255, 255, .9); border: 1px solid #e6e7e2; border-radius: 28px; box-shadow: 0 22px 70px rgba(24, 32, 51, .09); }
+      .mark { position: relative; width: 64px; height: 64px; margin: 0 auto 28px; display: grid; place-items: center; }
+      .core { width: 34px; height: 34px; border-radius: 12px; background: #182033; box-shadow: inset 0 0 0 7px #fff; }
+      .orbit { position: absolute; inset: 0; border: 2px solid #dfe3da; border-top-color: #76966f; border-radius: 50%; animation: connect 1.15s cubic-bezier(.55, .15, .45, .85) infinite; }
+      h1 { margin: 0; font-size: 25px; line-height: 1.2; letter-spacing: -.025em; }
+      p { max-width: 330px; margin: 14px auto 0; color: #667085; font-size: 15px; line-height: 1.6; }
+      @keyframes connect { to { transform: rotate(360deg); } }
+      @media (prefers-reduced-motion: reduce) { .orbit { animation: none; border-color: #76966f; } }
+    </style>
+  </head>
+  <body>
+    <main class="card" role="status" aria-live="polite">
+      <div class="mark" aria-hidden="true"><div class="orbit"></div><div class="core"></div></div>
+      <h1>Preparing your connection</h1>
+      <p>OpenWork is checking the provider. You’ll be redirected to sign in shortly.</p>
+    </main>
+  </body>
+</html>`
+}
+
 export function openMcpAuthorizationWindow(): Window {
   const popup = window.open("", "openwork-mcp-authorization", "popup,width=600,height=760")
   if (!popup) {
     throw new Error("OpenWork could not open the sign-in window. Allow popups for OpenWork, then try again.")
   }
   popup.opener = null
+  popup.document.open()
+  popup.document.write(mcpAuthorizationPendingDocument())
+  popup.document.close()
   return popup
 }

--- a/ee/apps/den-web/tests/mcp-authorization-url.test.ts
+++ b/ee/apps/den-web/tests/mcp-authorization-url.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from "bun:test"
-import { safeMcpAuthorizationUrl } from "../app/(den)/dashboard/_components/mcp-authorization-url"
+import {
+  mcpAuthorizationPendingDocument,
+  safeMcpAuthorizationUrl,
+} from "../app/(den)/dashboard/_components/mcp-authorization-url"
 
 describe("safeMcpAuthorizationUrl", () => {
   test("allows provider HTTPS and loopback HTTP authorization URLs", () => {
@@ -20,4 +23,16 @@ describe("safeMcpAuthorizationUrl", () => {
     "rejects unsafe provider authorization URL %s",
     (url) => expect(() => safeMcpAuthorizationUrl(url)).toThrow(),
   )
+})
+
+describe("mcpAuthorizationPendingDocument", () => {
+  test("renders a concise accessible connection screen before provider redirect", () => {
+    const document = mcpAuthorizationPendingDocument()
+
+    expect(document).toContain("Preparing your connection")
+    expect(document).toContain("You’ll be redirected to sign in shortly.")
+    expect(document).toContain('role="status"')
+    expect(document).toContain('aria-live="polite"')
+    expect(document).toContain("prefers-reduced-motion: reduce")
+  })
 })

--- a/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
+++ b/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
@@ -363,6 +363,10 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
               requestPhase: "mcp-initialize",
               outcome: "succeeded",
             })
+            // Some providers allow initialize before challenging on tools/list.
+            // Verify the first tool page so "connected" means the connection is
+            // authorized for the capability OpenWork will actually use.
+            await session.client.listTools(undefined, session.requestOptions)
             try {
               await closeWithinDeadline(() => session.client.close(), closeTimeoutMs)
             } catch (error) {
@@ -414,6 +418,7 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
               requestPhase: "mcp-initialize",
               outcome: "succeeded",
             })
+            await session.client.listTools(undefined, session.requestOptions)
           } catch (error) {
             operationFailed = true
             if (exchangedTokens && credentialPort) {

--- a/packages/enterprise-mcp-client/src/oauth-discovery-binding.ts
+++ b/packages/enterprise-mcp-client/src/oauth-discovery-binding.ts
@@ -1,4 +1,5 @@
 import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
+import { isEquivalentOAuthResourceAlias } from "./oauth-resource-alias.js"
 
 type OAuthDiscoveryBindingState = Pick<OAuthDiscoveryState, "authorizationServerUrl"> & {
   authorizationServerMetadata?: { issuer?: string }
@@ -9,8 +10,8 @@ function isResourceScopedDiscoveryAlias(state: OAuthDiscoveryBindingState, expec
   const advertisedIssuers = state.resourceMetadata?.authorization_servers
   return state.authorizationServerUrl !== expectedIssuer
     && state.authorizationServerMetadata?.issuer === expectedIssuer
-    && state.resourceMetadata?.resource === state.authorizationServerUrl
-    && advertisedIssuers?.includes(state.authorizationServerUrl) === true
+    && isEquivalentOAuthResourceAlias(state.resourceMetadata?.resource, state.authorizationServerUrl)
+    && advertisedIssuers?.some((issuer) => isEquivalentOAuthResourceAlias(issuer, state.authorizationServerUrl)) === true
 }
 
 /**

--- a/packages/enterprise-mcp-client/src/oauth-resource-alias.ts
+++ b/packages/enterprise-mcp-client/src/oauth-resource-alias.ts
@@ -1,0 +1,24 @@
+/**
+ * Protected resources may advertise their HTTP(S) origin as an OAuth discovery
+ * alias with or without the otherwise equivalent trailing root slash.
+ *
+ * This intentionally does not normalize non-root paths, query strings, or
+ * fragments, and must not be used for authorization-response issuer checks.
+ */
+export function isEquivalentOAuthResourceAlias(left: string | undefined, right: string | undefined): boolean {
+  if (!left || !right) return false
+  if (left === right) return true
+
+  try {
+    const leftUrl = new URL(left)
+    const rightUrl = new URL(right)
+    const supportedProtocol = (protocol: string) => protocol === "http:" || protocol === "https:"
+    if (!supportedProtocol(leftUrl.protocol) || !supportedProtocol(rightUrl.protocol)) return false
+    if (leftUrl.search || rightUrl.search || leftUrl.hash || rightUrl.hash) return false
+    return leftUrl.origin === rightUrl.origin
+      && leftUrl.pathname === "/"
+      && rightUrl.pathname === "/"
+  } catch {
+    return false
+  }
+}

--- a/packages/enterprise-mcp-client/src/requirements-discovery.ts
+++ b/packages/enterprise-mcp-client/src/requirements-discovery.ts
@@ -12,6 +12,7 @@ import type {
   EnterpriseMcpConnectionRequirements,
   EnterpriseMcpFetch,
 } from "./contracts.js"
+import { isEquivalentOAuthResourceAlias } from "./oauth-resource-alias.js"
 
 const DEFAULT_TIMEOUT_MS = 15_000
 const DEFAULT_MAX_AUTHORIZATION_SERVERS = 5
@@ -76,9 +77,10 @@ function metadataRequirement(
   resource: string | undefined,
 ): EnterpriseMcpAuthorizationServerRequirement | null {
   // Some providers advertise the protected resource itself as a scoped
-  // metadata discovery alias. Accept that exact alias while retaining the
-  // metadata issuer as the canonical issuer used by the OAuth flow.
-  if (metadata.issuer !== advertisedIssuer && advertisedIssuer !== resource) return null
+  // metadata discovery alias. Accept that alias, including the equivalent
+  // trailing root slash form, while retaining the metadata issuer as the
+  // canonical issuer used by the OAuth flow.
+  if (metadata.issuer !== advertisedIssuer && !isEquivalentOAuthResourceAlias(advertisedIssuer, resource)) return null
   return {
     issuer: metadata.issuer,
     authorizationEndpoint: metadata.authorization_endpoint,

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -107,7 +107,7 @@ function sendJson(response: ServerResponse, status: number, body: unknown, heade
   response.end(JSON.stringify(body))
 }
 
-async function sendMcpResponse(request: IncomingMessage, response: ServerResponse): Promise<void> {
+async function sendMcpResponse(request: IncomingMessage, response: ServerResponse, options: { rejectToolsList?: boolean } = {}): Promise<void> {
   const parsed: unknown = JSON.parse(await requestBody(request))
   const rpc = rpcRequestSchema.parse(parsed)
   if (rpc.method === "notifications/initialized") {
@@ -128,6 +128,10 @@ async function sendMcpResponse(request: IncomingMessage, response: ServerRespons
     return
   }
   if (rpc.method === "tools/list") {
+    if (options.rejectToolsList) {
+      sendJson(response, 403, { error: "provider_tool_policy_denied" })
+      return
+    }
     sendJson(response, 200, {
       jsonrpc: "2.0",
       id: rpc.id,
@@ -142,6 +146,7 @@ async function sendMcpResponse(request: IncomingMessage, response: ServerRespons
 
 async function startOAuthMcpServer(options: {
   rejectAuthenticatedMcp?: boolean
+  rejectAuthenticatedToolsList?: boolean
   clientMetadataSupported?: boolean
   scopeLessChallenge?: boolean
 } = {}) {
@@ -222,7 +227,7 @@ async function startOAuthMcpServer(options: {
           sendJson(response, 403, { error: "provider_policy_denied" })
           return
         }
-        await sendMcpResponse(request, response)
+        await sendMcpResponse(request, response, { rejectToolsList: options.rejectAuthenticatedToolsList })
         return
       }
       sendJson(response, 404, { error: "not_found" })
@@ -1115,6 +1120,33 @@ describe("enterprise MCP OAuth persistence contract", () => {
         redirectUri,
         code: "approved-code",
         authorizationId: "signed-state",
+      }))
+      assert.equal(persistence.credential, undefined)
+      assert.equal(persistence.invalidationCount, 1)
+    } finally {
+      await server.close()
+    }
+  })
+
+  it("invalidates exchanged tokens when callback initialization succeeds but tool discovery fails", async () => {
+    const server = await startOAuthMcpServer({ rejectAuthenticatedToolsList: true })
+    try {
+      const persistence = new MemoryOAuthPersistence()
+      const client = createEnterpriseMcpClient({ fetch, operationTimeoutMs: 5_000 })
+      const connection: EnterpriseMcpConnection = {
+        id: "oauth-tool-validation-failure",
+        serverUrl: `${server.origin}/mcp`,
+        authorization: { type: "oauth", persistence },
+      }
+      const redirectUri = "https://den.example.test/oauth-tool-validation-failure"
+      const started = await client.connect({ connection, redirectUri, authorizationId: "signed-tool-state" })
+      assert.equal(started.status, "needs_auth")
+
+      await assert.rejects(client.completeAuthorization({
+        connection,
+        redirectUri,
+        code: "approved-code",
+        authorizationId: "signed-tool-state",
       }))
       assert.equal(persistence.credential, undefined)
       assert.equal(persistence.invalidationCount, 1)

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -658,6 +658,52 @@ describe("enterprise MCP OAuth persistence contract", () => {
     }))
   })
 
+  it("binds an equivalent root discovery alias while keeping callback issuer checks exact", async () => {
+    const canonicalIssuer = "https://vercel.example"
+    const discoveryState: OAuthDiscoveryState = {
+      authorizationServerUrl: "https://mcp.vercel.example",
+      authorizationServerMetadata: {
+        issuer: canonicalIssuer,
+        authorization_endpoint: `${canonicalIssuer}/oauth/authorize`,
+        token_endpoint: `${canonicalIssuer}/oauth/token`,
+        response_types_supported: ["code"],
+      },
+      resourceMetadata: {
+        resource: "https://mcp.vercel.example/",
+        authorization_servers: ["https://mcp.vercel.example"],
+      },
+    }
+    const persistence = new MemoryOAuthPersistence()
+    const provider = new EnterpriseMcpOAuthProvider({
+      redirectUri: "https://den.example.test/v1/mcp-connections/oauth/callback",
+      connectionId: "connection-1",
+      persistence,
+      flow: { kind: "connect", authorizationId: "signed-state" },
+      clientName: "OpenWork",
+      clock: { now: () => Date.now() },
+      lifecycle: { expiresAt: Date.now() + 30_000, signal: new AbortController().signal },
+      authorizationTransactionTtlMs: 600_000,
+      expirationSkewMs: 0,
+      oauthConfiguration: {
+        applicationType: "web",
+        authorizationServerIssuer: canonicalIssuer,
+      },
+    })
+
+    await assert.doesNotReject(provider.saveDiscoveryState(discoveryState))
+    assert.doesNotThrow(() => validateMcpAuthorizationResponseIssuer({
+      expectedIssuer: canonicalIssuer,
+      discoveryState,
+      responseIssuer: canonicalIssuer,
+    }))
+    assert.throws(() => validateMcpAuthorizationResponseIssuer({
+      expectedIssuer: canonicalIssuer,
+      discoveryState,
+      responseIssuer: `${canonicalIssuer}/`,
+    }), (error: unknown) => error instanceof EnterpriseMcpOAuthContractError
+      && error.code === "MCP_OAUTH_ISSUER_MISMATCH")
+  })
+
   it("rejects a non-HTTPS client metadata document before OAuth performs network work", async () => {
     let fetchCount = 0
     const client = createEnterpriseMcpClient({
@@ -913,6 +959,83 @@ describe("enterprise MCP OAuth persistence contract", () => {
     } finally {
       await server.close()
     }
+  })
+
+  it("starts OAuth when initialize is public but tool discovery requires authorization", async () => {
+    const origin = "https://api.descript.example"
+    const metadataUrl = "https://den.example.test/oauth/client-metadata.json"
+    const fetch: EnterpriseMcpFetch = async (url, init) => {
+      const target = new URL(url)
+      if (target.pathname === "/.well-known/oauth-protected-resource/v2/mcp") {
+        return Response.json({
+          resource: `${origin}/v2/mcp`,
+          authorization_servers: [origin],
+        })
+      }
+      if (target.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          issuer: origin,
+          authorization_endpoint: `${origin}/oauth/authorize`,
+          token_endpoint: `${origin}/oauth/token`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["none"],
+          code_challenge_methods_supported: ["S256"],
+          client_id_metadata_document_supported: true,
+        })
+      }
+      if (target.pathname === "/v2/mcp") {
+        const body = typeof init?.body === "string" ? init.body : ""
+        if (!body) return new Response(null, { status: 202 })
+        const request = rpcRequestSchema.parse(JSON.parse(body))
+        if (request.method === "initialize") {
+          return Response.json({
+            jsonrpc: "2.0",
+            id: request.id,
+            result: {
+              protocolVersion: "2025-06-18",
+              capabilities: { tools: {} },
+              serverInfo: { name: "descript-style-test", version: "1.0.0" },
+            },
+          })
+        }
+        if (request.method === "notifications/initialized") return new Response(null, { status: 202 })
+        if (request.method === "tools/list") {
+          return new Response(null, {
+            status: 401,
+            headers: {
+              "www-authenticate": `Bearer resource_metadata=\"${origin}/.well-known/oauth-protected-resource/v2/mcp\"`,
+            },
+          })
+        }
+      }
+      return new Response(null, { status: 404 })
+    }
+    const persistence = new MemoryOAuthPersistence()
+    const client = createEnterpriseMcpClient({ fetch })
+    const connection: EnterpriseMcpConnection = {
+      id: "oauth-public-initialize",
+      serverUrl: `${origin}/v2/mcp`,
+      authorization: {
+        type: "oauth",
+        persistence,
+        configuration: {
+          applicationType: "web",
+          clientMetadataUrl: metadataUrl,
+        },
+      },
+    }
+
+    const started = await client.connect({
+      connection,
+      redirectUri: "https://den.example.test/v1/mcp-connections/oauth/callback",
+      authorizationId: "signed-descript-state",
+    })
+
+    assert.equal(started.status, "needs_auth")
+    if (started.status !== "needs_auth") throw new Error("Expected OAuth authorization to be required.")
+    assert.equal(new URL(started.authorizeUrl).searchParams.get("client_id"), metadataUrl)
+    assert.equal(persistence.registration?.source, "client-metadata")
   })
 
   it("refreshes an expired enterprise OAuth credential and persists the replacement", async () => {

--- a/packages/enterprise-mcp-client/test/requirements-discovery.test.ts
+++ b/packages/enterprise-mcp-client/test/requirements-discovery.test.ts
@@ -180,4 +180,43 @@ describe("enterprise MCP requirements discovery", () => {
     assert.equal(result.authentication.recommendedRegistrationMethod, "pre_registered")
     assert.equal(result.warnings.some((warning) => warning.code === "oauth_issuer_mismatch"), false)
   })
+
+  it("accepts a root resource discovery alias with an equivalent trailing slash", async () => {
+    const fetch: EnterpriseMcpFetch = async (url) => {
+      const target = new URL(url)
+      if (target.origin === "https://mcp.vercel.example" && target.pathname === "/.well-known/oauth-protected-resource") {
+        return Response.json({
+          resource: "https://mcp.vercel.example/",
+          authorization_servers: ["https://mcp.vercel.example"],
+        })
+      }
+      if (target.origin === "https://mcp.vercel.example" && target.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          issuer: "https://vercel.example",
+          authorization_endpoint: "https://vercel.example/oauth/authorize",
+          token_endpoint: "https://vercel.example/oauth/token",
+          registration_endpoint: "https://vercel.example/oauth/register",
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code", "refresh_token"],
+          token_endpoint_auth_methods_supported: ["none"],
+          code_challenge_methods_supported: ["S256"],
+        })
+      }
+      return new Response(null, {
+        status: 401,
+        headers: {
+          "www-authenticate": "Bearer resource_metadata=\"https://mcp.vercel.example/.well-known/oauth-protected-resource\"",
+        },
+      })
+    }
+
+    const result = await discoverConnectionRequirements({
+      serverUrl: "https://mcp.vercel.example",
+      fetch,
+    })
+
+    assert.equal(result.authentication.authorizationServers[0]?.issuer, "https://vercel.example")
+    assert.equal(result.authentication.recommendedRegistrationMethod, "dynamic")
+    assert.equal(result.warnings.some((warning) => warning.code === "oauth_issuer_mismatch"), false)
+  })
 })


### PR DESCRIPTION
## What this fixes

This is a focused follow-up to #2810 for OAuth interoperability gaps found against live remote MCP providers. The implementation is provider-neutral and applies to Den-managed OpenWork Connect.

### Resource discovery aliases

Some protected-resource metadata identifies a resource as an origin with a trailing `/`, while advertising the same origin without `/` as its OAuth discovery alias. OpenWork previously rejected that constrained equivalence and then incorrectly fell back to asking for a pre-registered client ID and secret.

This PR accepts only HTTP(S) root-origin equivalence for a resource-scoped discovery alias. The authorization-server metadata issuer remains canonical, and authorization-response issuer validation remains exact.

For `https://mcp.vercel.com`, discovery now resolves the advertised dynamic-registration flow without asking the administrator for a client ID or secret.

### Deferred OAuth challenges

Some MCP servers allow unauthenticated `initialize` and challenge only on `tools/list`. OpenWork previously treated initialize alone as a usable connection, closed the authorization window, and left the connection without credentials.

This PR requests one bounded tool page before returning `connected`, both during initial connection and after the OAuth callback. A late challenge now starts the normal OAuth flow. If token exchange succeeds but initialize or tool discovery then fails, the newly exchanged credential is invalidated through the existing cleanup path.

For `https://api.descript.com/v2/mcp`, this means the OAuth challenge raised at tool discovery is no longer missed.

### Connection handoff screen

The shared OAuth popup immediately renders a small OpenWork-styled **Preparing your connection** screen while Den performs discovery. It provides an accessible live status, subtle animation, and a reduced-motion fallback before the same window navigates to the provider.

## Callback compatibility and rollout

- The deployment-wide callback is the default for new OAuth setup.
- Existing connections that were created with a connection-specific callback keep that callback on reconnect; there is no migration toggle and no credential rewrite.
- In-flight version-one signed state remains accepted only by the legacy callback route for its existing ten-minute lifetime.
- Shared-callback state is rejected by legacy routes, even when a path ID matches.
- Pre-registered OAuth clients, client metadata documents, and dynamic client registration remain supported.
- Local/direct engine MCP and the engine-to-Den meta-MCP are unchanged.

## Relationship to #2851

- **This PR (#2853)** owns generic provider OAuth discovery, callback validation, first-tool-page usability, and the pre-redirect popup.
- **#2851** owns plugin/chat import classification, marketplace readiness, binding preservation, and administrator/member recovery.
- Merge **#2853 first**, then #2851. #2851 deliberately reuses the runtime validation implemented here instead of adding provider logic to the import path.

## Visual walkthrough

### Add the Vercel MCP server

Entering `https://mcp.vercel.com` completes OAuth discovery automatically. The form shows provider-advertised permissions and does not ask for a client ID or secret.

![Vercel MCP setup after automatic OAuth discovery](https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/fraimz/mcp-provider-oauth-fixes/vercel-mcp-setup.png)

### Start the OAuth handoff

Clicking **Connect** opens this lightweight status screen immediately, then navigates the same popup to the provider.

![OpenWork preparing the OAuth connection](https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/fraimz/mcp-provider-oauth-fixes/oauth-connection-handoff.png)

## Security boundaries

- No provider-specific runtime branch was added.
- Root alias equivalence is limited to HTTP(S), the same origin, the root path, and no query or fragment.
- Authorization-response issuer checks remain exact.
- Tokens and client secrets remain Den-owned.
- Declaring a connection usable now includes one bounded first-page `tools/list` request because tool access is the capability OpenWork exposes and where compliant servers may issue the OAuth challenge.

## Validation

Branch head: `8a42366c`, rebased onto current `upstream/dev` at `55033420`.

- `@openwork/enterprise-mcp-client`: typecheck passed.
- `@openwork/enterprise-mcp-client`: build passed.
- `@openwork/enterprise-mcp-client`: **40 passed**, including post-callback rollback when initialize succeeds but tool discovery fails.
- Den API connection/callback compatibility suite: **15 passed** against an isolated current-schema database.
- Den Web OAuth popup and authorization-URL suite: **8 passed**.
- Combined with #2851 in a fresh isolated worktree:
  - enterprise MCP client: **40 passed**
  - import/readiness API suites: **34 passed**
  - connection/callback API suite: **15 passed**
  - combined Web suites: **20 passed**
  - enterprise client build and both affected TypeScript checks passed
  - `git diff --check` passed
- GitHub Actions passed: Den API, Den Web, and inference builds; Linux and macOS test matrices; Helm validation; and i18n audit.
- Live requirements discovery:
  - `https://mcp.vercel.com`: ready; issuer `https://vercel.com`; dynamic registration; no warnings.
  - `https://api.descript.com/v2/mcp`: ready; issuer `https://api.descript.com`; client-metadata registration; no warnings.
- During local iteration, a pre-registered OAuth provider completed both the existing connection-specific callback and the deployment-wide callback after the provider allowlist change propagated.

## Not run / external limits

- A full live OAuth consent and tool call was not completed against Vercel or Descript because that requires provider accounts and consent.
- Fork Vercel preview contexts can report deployment-authorization failures because the fork cannot deploy to Different AI's projects. Those permissions are separate from the MCP provider behavior and repository checks covered here.

## Review map

- Usability and callback validation: `packages/enterprise-mcp-client/src/enterprise-mcp-client.ts`
- Constrained alias comparison: `packages/enterprise-mcp-client/src/oauth-resource-alias.ts`
- Discovery and canonical issuer binding: `packages/enterprise-mcp-client/src/requirements-discovery.ts` and `oauth-discovery-binding.ts`
- Callback compatibility routes: `ee/apps/den-api/src/routes/org/mcp-connections.ts`
- Pre-redirect popup: `ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts`
