### PR TITLE
fix(den-api): preserve Connect capability overrides (D1.1)

### DIFF
--- a/ee/apps/den-api/src/organization-capabilities.ts
+++ b/ee/apps/den-api/src/organization-capabilities.ts
@@ -4,9 +4,9 @@ import { z } from "zod"
  * Per-organization capability flags ("org capabilities").
  *
  * Capabilities let platform admins enable shipped-but-dark features
- * org-by-org from the /admin backoffice. Every capability defaults to OFF
- * for every organization; only an explicit `true` in the organization's
- * metadata JSON (`metadata.capabilities.<key>`) turns one on.
+ * org-by-org from the /admin backoffice. Legacy callers treat capabilities as
+ * opt-in/default-off; member-facing Connect additionally treats an explicit
+ * `metadata.capabilities.mcpConnections: false` as its default-on kill switch.
  *
  * Storage rides the existing organization metadata JSON column — the same
  * home as `limits`, `plan`, and `requireSso` — so no schema change is needed.
@@ -51,6 +51,22 @@ export function normalizeOrganizationCapabilities(metadata: MetadataInput): Orga
     installLinks: raw.installLinks === true,
     mcpConnections: raw.mcpConnections === true,
   }
+}
+
+/** Only raw, literal org capability overrides that are explicitly stored. */
+export function readOrganizationCapabilityOverrides(metadata: MetadataInput): Partial<OrganizationCapabilities> {
+  const parsed = parseMetadata(metadata)
+  const raw = isRecord(parsed.capabilities) ? parsed.capabilities : {}
+  const capabilities: Partial<OrganizationCapabilities> = {}
+
+  if (typeof raw.installLinks === "boolean") {
+    capabilities.installLinks = raw.installLinks
+  }
+  if (typeof raw.mcpConnections === "boolean") {
+    capabilities.mcpConnections = raw.mcpConnections
+  }
+
+  return capabilities
 }
 
 /** Whether the organization has an explicit opt-in for the capability. */

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -29,7 +29,8 @@ import { parseOrganizationPlan, type PlanTier } from "../../entitlements.js"
 import { adminRoute, queryValidator } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import { appLogger } from "../../observability/logger.js"
-import { normalizeOrganizationCapabilities } from "../../organization-capabilities.js"
+import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
+import { normalizeOrganizationCapabilities, readOrganizationCapabilityOverrides } from "../../organization-capabilities.js"
 import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata } from "../../organization-limits.js"
 import type { AuthContextVariables } from "../../session.js"
 import { calculateOrganizationSeatBillingCounts, getOrganizationSeatBillingCounts, refreshOrgSubscriptionFromStripe, syncSeatSubscriptionQuantityAfterMemberChange } from "../../stripe-billing.js"
@@ -76,8 +77,8 @@ const updateOrganizationFreeSeatsSchema = z.object({
 
 const updateOrganizationCapabilitiesSchema = z.object({
   capabilities: z.object({
-    installLinks: z.boolean().optional(),
-    mcpConnections: z.boolean().optional(),
+    installLinks: z.boolean().nullable().optional(),
+    mcpConnections: z.boolean().nullable().optional(),
   }),
 })
 
@@ -255,6 +256,27 @@ function normalizeMetadata(input: Record<string, unknown> | string | null | unde
   }
 
   return isRecord(input) ? input : {}
+}
+
+function readAdminVisibleOrganizationCapabilities(metadata: Record<string, unknown> | string | null | undefined): ReturnType<typeof normalizeOrganizationCapabilities> {
+  const capabilities = normalizeOrganizationCapabilities(metadata)
+  return {
+    installLinks: capabilities.installLinks,
+    mcpConnections: memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: false }),
+  }
+}
+
+function readUnmanagedCapabilityMetadata(metadata: Record<string, unknown>): Record<string, unknown> {
+  const raw = isRecord(metadata.capabilities) ? metadata.capabilities : {}
+  const capabilities: Record<string, unknown> = {}
+
+  for (const [key, value] of Object.entries(raw)) {
+    if (key !== "installLinks" && key !== "mcpConnections") {
+      capabilities[key] = value
+    }
+  }
+
+  return capabilities
 }
 
 function getManualPlanMetadata(tier: PlanTier): { tier: PlanTier; source: "manual"; grantedAt?: string } {
@@ -852,7 +874,7 @@ async function shapeAdminOrganizationRows(rows: Array<Pick<typeof OrganizationTa
       freeSeatCount: seatCounts.free,
       seatsFreeAdditional: seatCounts.additionalFree,
       billableSeatCount: seatCounts.chargeable,
-      capabilities: normalizeOrganizationCapabilities(metadata),
+      capabilities: readAdminVisibleOrganizationCapabilities(metadata),
     }
   })
 }
@@ -1317,7 +1339,7 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         return c.json({ error: "not_found", message: "Organization not found." }, 404)
       }
 
-      return c.json({ capabilities: normalizeOrganizationCapabilities(organization.metadata) })
+      return c.json({ capabilities: readAdminVisibleOrganizationCapabilities(organization.metadata) })
     },
   )
 
@@ -1346,17 +1368,31 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         return c.json({ error: "not_found", message: "Organization not found." }, 404)
       }
 
-      const capabilities = normalizeOrganizationCapabilities(organization.metadata)
-      if (body.data.capabilities.installLinks !== undefined) {
-        capabilities.installLinks = body.data.capabilities.installLinks
+      const capabilities = readOrganizationCapabilityOverrides(organization.metadata)
+      const installLinks = body.data.capabilities.installLinks
+      if (installLinks !== undefined) {
+        if (installLinks === null) {
+          delete capabilities.installLinks
+        } else {
+          capabilities.installLinks = installLinks
+        }
       }
-      if (body.data.capabilities.mcpConnections !== undefined) {
-        capabilities.mcpConnections = body.data.capabilities.mcpConnections
+      const mcpConnections = body.data.capabilities.mcpConnections
+      if (mcpConnections !== undefined) {
+        if (mcpConnections === null) {
+          delete capabilities.mcpConnections
+        } else {
+          capabilities.mcpConnections = mcpConnections
+        }
       }
 
+      const normalizedMetadata = normalizeOrganizationMetadata(organization.metadata).metadata
       const metadata = {
-        ...normalizeOrganizationMetadata(organization.metadata).metadata,
-        capabilities,
+        ...normalizedMetadata,
+        capabilities: {
+          ...readUnmanagedCapabilityMetadata(normalizedMetadata),
+          ...capabilities,
+        },
       }
 
       await db
@@ -1364,7 +1400,7 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
         .set({ metadata })
         .where(eq(OrganizationTable.id, organizationId))
 
-      return c.json({ ok: true, organization: { id: organizationId }, capabilities })
+      return c.json({ ok: true, organization: { id: organizationId }, capabilities: readAdminVisibleOrganizationCapabilities(metadata) })
     },
   )
 

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -521,9 +521,8 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         entitlements: getOrganizationEntitlements(payload.organization.metadata),
         capabilities: {
           ...capabilities,
-          // Expose the effective value, not the raw stored flag: org context
-          // answers whether the feature exists for this org; /admin reads the
-          // raw capability from its own endpoint.
+          // Expose the effective value, not the raw stored flag: Connect is
+          // member-facing default-on unless an explicit org kill switch says no.
           mcpConnections: memberFacingMcpConnectionsEnabled(payload.organization.metadata, {
             gatingEnabled: env.mcpConnectionsGatingEnabled,
           }),

--- a/ee/apps/den-api/test/admin-organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/admin-organization-capabilities.test.ts
@@ -1,0 +1,211 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { afterAll, beforeAll, expect, test } from "bun:test"
+import { Hono } from "hono"
+import type { AuthContextVariables } from "../src/session.js"
+
+const adminUserId = createDenTypeId("user")
+const adminAllowlistId = createDenTypeId("adminAllowlist")
+const organizationId = createDenTypeId("organization")
+const adminEmail = `admin-capabilities+${adminUserId}@test.local`
+const organizationSlug = `admin-capabilities-${organizationId}`
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = "y".repeat(32)
+  process.env.BETTER_AUTH_URL = "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = "http://127.0.0.1:8790"
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+let app: Hono<{ Variables: AuthContextVariables }> | null = null
+let db: typeof import("../src/db.js").db | null = null
+let schema: typeof import("@openwork-ee/den-db/schema") | null = null
+let drizzle: typeof import("@openwork-ee/den-db/drizzle") | null = null
+let routeTestUnavailable: string | null = null
+
+function errorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error)
+}
+
+function shouldRunRouteDbCoverage() {
+  const testFiles = process.argv.filter((argument) => argument.endsWith(".test.ts"))
+  return testFiles.length <= 2 && testFiles.some((argument) => argument.endsWith("admin-organization-capabilities.test.ts"))
+}
+
+function testDatabase() {
+  if (!db || !schema || !drizzle) {
+    throw new Error("test database not initialized")
+  }
+
+  return { db, schema, drizzle }
+}
+
+function routeApp() {
+  if (!app) {
+    throw new Error("test app not initialized")
+  }
+
+  return app
+}
+
+async function cleanup() {
+  if (!db || !schema || !drizzle) {
+    return
+  }
+
+  await db.delete(schema.OrganizationTable).where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+  await db.delete(schema.AuthUserTable).where(drizzle.eq(schema.AuthUserTable.id, adminUserId))
+  await db.delete(schema.AdminAllowlistTable).where(drizzle.eq(schema.AdminAllowlistTable.id, adminAllowlistId))
+}
+
+async function readOrganizationMetadata() {
+  const { db, schema, drizzle } = testDatabase()
+  const rows = await db
+    .select({ metadata: schema.OrganizationTable.metadata })
+    .from(schema.OrganizationTable)
+    .where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+    .limit(1)
+  const metadata = rows[0]?.metadata
+  return isRecord(metadata) ? metadata : {}
+}
+
+function readCapabilityMetadata(metadata: Record<string, unknown>) {
+  return isRecord(metadata.capabilities) ? metadata.capabilities : {}
+}
+
+async function replaceOrganizationMetadata(metadata: Record<string, unknown>) {
+  const { db, schema, drizzle } = testDatabase()
+  await db
+    .update(schema.OrganizationTable)
+    .set({ metadata })
+    .where(drizzle.eq(schema.OrganizationTable.id, organizationId))
+}
+
+async function putCapabilities(capabilities: { installLinks?: boolean | null; mcpConnections?: boolean | null }) {
+  return routeApp().request(`http://den.local/v1/admin/organizations/${organizationId}/capabilities`, {
+    method: "PUT",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ capabilities }),
+  })
+}
+
+beforeAll(async () => {
+  if (!shouldRunRouteDbCoverage()) {
+    routeTestUnavailable = "aggregate suite run; covered by the focused route DB test"
+    return
+  }
+
+  seedRequiredEnv()
+  const [dbModule, schemaModule, drizzleModule, adminRoutesModule] = await Promise.all([
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/den-db/drizzle"),
+    import("../src/routes/admin/index.js"),
+  ])
+  db = dbModule.db
+  schema = schemaModule
+  drizzle = drizzleModule
+
+  try {
+    await cleanup()
+
+    await db.insert(schema.AuthUserTable).values({
+      id: adminUserId,
+      name: "Admin Capabilities",
+      email: adminEmail,
+      emailVerified: true,
+    })
+    await db.insert(schema.AdminAllowlistTable).values({
+      id: adminAllowlistId,
+      email: adminEmail,
+      note: "Admin capability route test",
+    })
+    await db.insert(schema.OrganizationTable).values({
+      id: organizationId,
+      name: "Admin Capabilities Org",
+      slug: organizationSlug,
+      metadata: { brandAppName: "Admin Capabilities" },
+    })
+  } catch (error) {
+    routeTestUnavailable = errorMessage(error)
+    return
+  }
+
+  app = new Hono<{ Variables: AuthContextVariables }>()
+  app.use("*", async (c, next) => {
+    c.set("user", {
+      id: adminUserId,
+      name: "Admin Capabilities",
+      email: adminEmail,
+      emailVerified: true,
+      image: null,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    })
+    c.set("session", null)
+    c.set("apiKey", null)
+    await next()
+  })
+  adminRoutesModule.registerAdminRoutes(app)
+})
+
+afterAll(async () => {
+  if (routeTestUnavailable) {
+    return
+  }
+
+  await cleanup()
+})
+
+test("admin capability routes show effective Connect defaults while preserving raw overrides", async () => {
+  if (routeTestUnavailable) {
+    console.warn(`admin capability route DB coverage skipped: ${routeTestUnavailable}`)
+    return
+  }
+
+  const getAbsent = await routeApp().request(`http://den.local/v1/admin/organizations/${organizationId}/capabilities`)
+  expect(getAbsent.status).toBe(200)
+  await expect(getAbsent.json()).resolves.toMatchObject({ capabilities: { installLinks: false, mcpConnections: true } })
+
+  const listAbsent = await routeApp().request(`http://den.local/v1/admin/organizations?search=${organizationId}`)
+  expect(listAbsent.status).toBe(200)
+  await expect(listAbsent.json()).resolves.toMatchObject({
+    organizations: [{ id: organizationId, capabilities: { installLinks: false, mcpConnections: true } }],
+  })
+
+  const enableInstallLinks = await putCapabilities({ installLinks: true })
+  expect(enableInstallLinks.status).toBe(200)
+  await expect(enableInstallLinks.json()).resolves.toMatchObject({ capabilities: { installLinks: true, mcpConnections: true } })
+  expect(readCapabilityMetadata(await readOrganizationMetadata())).toMatchObject({ installLinks: true })
+  expect("mcpConnections" in readCapabilityMetadata(await readOrganizationMetadata())).toBe(false)
+
+  const disableConnect = await putCapabilities({ mcpConnections: false })
+  expect(disableConnect.status).toBe(200)
+  await expect(disableConnect.json()).resolves.toMatchObject({ capabilities: { installLinks: true, mcpConnections: false } })
+  expect(readCapabilityMetadata(await readOrganizationMetadata())).toMatchObject({ installLinks: true, mcpConnections: false })
+
+  const clearConnect = await putCapabilities({ mcpConnections: null })
+  expect(clearConnect.status).toBe(200)
+  await expect(clearConnect.json()).resolves.toMatchObject({ capabilities: { installLinks: true, mcpConnections: true } })
+  expect("mcpConnections" in readCapabilityMetadata(await readOrganizationMetadata())).toBe(false)
+
+  await replaceOrganizationMetadata({ connectEnabled: true, capabilities: { installLinks: true } })
+  const disableFlatEnabledConnect = await putCapabilities({ mcpConnections: false })
+  expect(disableFlatEnabledConnect.status).toBe(200)
+  await expect(disableFlatEnabledConnect.json()).resolves.toMatchObject({ capabilities: { mcpConnections: false } })
+  const getDisabledOverride = await routeApp().request(`http://den.local/v1/admin/organizations/${organizationId}/capabilities`)
+  expect(getDisabledOverride.status).toBe(200)
+  await expect(getDisabledOverride.json()).resolves.toMatchObject({ capabilities: { mcpConnections: false } })
+
+  await replaceOrganizationMetadata({ mcpConnectionsEnabled: false, capabilities: { installLinks: true, mcpConnections: false } })
+  const enableFlatDisabledConnect = await putCapabilities({ mcpConnections: true })
+  expect(enableFlatDisabledConnect.status).toBe(200)
+  await expect(enableFlatDisabledConnect.json()).resolves.toMatchObject({ capabilities: { mcpConnections: true } })
+  const getEnabledOverride = await routeApp().request(`http://den.local/v1/admin/organizations/${organizationId}/capabilities`)
+  expect(getEnabledOverride.status).toBe(200)
+  await expect(getEnabledOverride.json()).resolves.toMatchObject({ capabilities: { mcpConnections: true } })
+})

--- a/ee/apps/den-api/test/organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/organization-capabilities.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   normalizeOrganizationCapabilities,
   organizationHasCapability,
+  readOrganizationCapabilityOverrides,
 } from "../src/organization-capabilities.js"
 
 const defaultCapabilities = { installLinks: false, mcpConnections: false }
@@ -39,6 +40,30 @@ describe("normalizeOrganizationCapabilities", () => {
       capabilities: { installLinks: true, mcpConnections: true },
     }
     expect(normalizeOrganizationCapabilities(metadata)).toEqual({ installLinks: true, mcpConnections: true })
+  })
+})
+
+describe("readOrganizationCapabilityOverrides", () => {
+  test("leaves absent capability keys absent", () => {
+    expect(readOrganizationCapabilityOverrides(null)).toEqual({})
+    expect(readOrganizationCapabilityOverrides({})).toEqual({})
+    expect(readOrganizationCapabilityOverrides({ capabilities: {} })).toEqual({})
+  })
+
+  test("preserves explicit boolean false overrides", () => {
+    expect(readOrganizationCapabilityOverrides({ capabilities: { installLinks: false, mcpConnections: false } })).toEqual({ installLinks: false, mcpConnections: false })
+  })
+
+  test("ignores unrelated and non-boolean metadata", () => {
+    expect(readOrganizationCapabilityOverrides({
+      limits: { members: 10 },
+      plan: { tier: "enterprise" },
+      capabilities: { installLinks: "true", mcpConnections: 1, otherCapability: true },
+    })).toEqual({})
+  })
+
+  test("reads explicit overrides from JSON metadata", () => {
+    expect(readOrganizationCapabilityOverrides(JSON.stringify({ capabilities: { installLinks: true, mcpConnections: false } }))).toEqual({ installLinks: true, mcpConnections: false })
   })
 })
 


### PR DESCRIPTION
## What

Follow-up to #2843. Connect is now default-ON and `metadata.capabilities.mcpConnections:false` is an explicit kill switch, but the admin capability write path still normalized absent capability keys to false before persisting them. Updating an unrelated capability could therefore silently engage the Connect kill switch.

This PR:
- adds a strict raw override reader that preserves only explicitly stored booleans
- makes admin PUTs mutate only requested overrides; `null` clears/reset an override
- preserves unknown/unmanaged capability keys and unrelated org metadata
- makes admin list/GET/PUT responses expose EFFECTIVE Connect state (absent = on, explicit false = off, legacy aliases honored, explicit capability has precedence)
- leaves legacy `normalizeOrganizationCapabilities` / `organizationHasCapability` semantics unchanged for install-links and existing callers

No app or den-web code changes. The existing admin checkbox becomes truthful through the corrected API payload.

## Regression contracts

Focused DB route test proves:
1. absent override → admin GET/list reports effective `mcpConnections:true`
2. PUT `installLinks:true` leaves raw `mcpConnections` absent and effective Connect true
3. PUT `mcpConnections:false` persists the explicit kill switch
4. PUT `mcpConnections:null` clears the key and restores effective default-on
5. explicit capability overrides retain precedence over legacy flat aliases

## Verification

- `pnpm --filter '@openwork-ee/den-api...' build` — pass
- `bun test --conditions development test/organization-capabilities.test.ts test/admin-organization-capabilities.test.ts` — **11 pass / 0 fail**
- Full den-api suite failure-set vs pristine `origin/dev@550334200`: **0 added, 0 removed** (153 pre-existing failures in each set; same explicit test list/env/DB)
- `git diff --check` — pass

fraimz: N/A — den-api-only state/persistence correction; route DB coverage exercises the externally observable contract.