### PR TITLE
feat(den-web): style organization chooser

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-selection-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-selection-screen.tsx
@@ -1,9 +1,36 @@
 "use client";
 
+import { Dithering } from "@paper-design/shaders-react";
 import Link from "next/link";
 import { Building2, ChevronRight, LogOut, Plus } from "lucide-react";
+import { useSyncExternalStore } from "react";
 import { formatRoleLabel, type DenOrgSummary } from "../../_lib/den-org";
 import { useOrgListWindow } from "../../_lib/use-org-list-window";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribeToReducedMotion(onStoreChange: () => void) {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+  mediaQuery.addEventListener("change", onStoreChange);
+
+  return () => mediaQuery.removeEventListener("change", onStoreChange);
+}
+
+function getReducedMotionSnapshot() {
+  return typeof window === "undefined" ? true : window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function getReducedMotionServerSnapshot() {
+  return true;
+}
+
+function useReducedMotion() {
+  return useSyncExternalStore(subscribeToReducedMotion, getReducedMotionSnapshot, getReducedMotionServerSnapshot);
+}
 
 export function OrgSelectionScreen({
   orgs,
@@ -27,15 +54,35 @@ export function OrgSelectionScreen({
     showMore,
     showSearch,
   } = useOrgListWindow(orgs);
+  const reducedMotion = useReducedMotion();
+  const shaderSpeed = reducedMotion ? 0 : 0.012;
 
   return (
-    <div className="flex min-h-screen items-center justify-center bg-[#fafafa] px-4 py-12">
-      <div className="w-full max-w-md">
+    <div className="relative isolate min-h-dvh overflow-y-auto bg-[#0f1d31] px-4 py-8 sm:py-12" data-testid="org-chooser-root">
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#0f1d31] opacity-[0.10]"
+        data-testid="org-chooser-background"
+      >
+        <Dithering
+          speed={shaderSpeed}
+          shape="warp"
+          type="4x4"
+          size={2.4}
+          scale={0.9}
+          frame={24017.6}
+          colorBack="#09182C"
+          colorFront="#A7C4E8"
+          style={{ backgroundColor: "#142033", width: "100%", height: "100%" }}
+        />
+      </div>
+
+      <div className="relative z-10 mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-md flex-col justify-center sm:min-h-[calc(100dvh-6rem)]" data-testid="org-chooser-foreground">
         <div className="mb-6 text-center">
-          <h1 className="text-[18px] font-semibold tracking-[-0.2px] text-gray-900">
+          <h1 className="text-[18px] font-semibold tracking-[-0.2px] text-white">
             Choose an organization
           </h1>
-          <p className="mt-1 text-[13px] text-gray-500">
+          <p className="mt-1 text-[13px] text-slate-300">
             You belong to {orgs.length} organizations. Select one to continue.
           </p>
         </div>
@@ -46,21 +93,21 @@ export function OrgSelectionScreen({
             value={query}
             onChange={(event) => setQuery(event.target.value)}
             placeholder="Search organizations"
-            className="mb-3 w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-[13px] text-gray-900 outline-none transition focus:border-gray-400 focus:ring-4 focus:ring-gray-900/5"
+            className="mb-3 w-full rounded-xl border border-gray-200 bg-white px-3 py-2.5 text-[13px] text-gray-900 shadow-[0_18px_45px_-32px_rgba(3,10,24,0.9)] outline-none transition focus:border-gray-400 focus:ring-4 focus:ring-sky-950/10"
           />
         ) : null}
 
-        <div className="grid gap-2 rounded-xl border border-gray-200 bg-white p-2 shadow-[0_12px_24px_-16px_rgba(0,0,0,0.15)]">
+        <div className="grid gap-2 rounded-xl border border-gray-200 bg-white p-2 shadow-[0_20px_60px_-30px_rgba(3,10,24,0.75)]" data-testid="org-chooser-list">
           {visible.map((org) => (
             <button
               key={org.id}
               type="button"
               disabled={busy}
               onClick={() => onSelect(org.slug)}
-              className="flex items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60"
+              className="flex items-center justify-between gap-3 rounded-lg px-3 py-2.5 text-left transition-colors hover:bg-gray-50 focus:outline-none focus:ring-4 focus:ring-sky-950/10 disabled:cursor-not-allowed disabled:bg-gray-50"
             >
               <span className="flex min-w-0 items-center gap-3">
-                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-gray-100 text-gray-500">
+                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-[#eef3f8] text-[#41566f]">
                   <Building2 className="h-4 w-4" strokeWidth={1.8} />
                 </span>
                 <span className="min-w-0">
@@ -76,12 +123,12 @@ export function OrgSelectionScreen({
         </div>
 
         {filteredCount === 0 && query ? (
-          <p className="mt-3 px-1 text-[13px] text-gray-500">No organizations match your search.</p>
+          <p className="mt-3 px-1 text-[13px] text-slate-300">No organizations match your search.</p>
         ) : null}
 
         {hasMore ? (
           <div className="mt-3 flex items-center justify-between gap-3 px-1">
-            <p className="text-[12px] text-gray-500">
+            <p className="text-[12px] text-slate-300">
               Showing {visible.length} of {filteredCount} organizations
             </p>
             <button
@@ -95,22 +142,22 @@ export function OrgSelectionScreen({
         ) : null}
 
         {error ? (
-          <p className="mt-3 px-1 text-[12px] font-medium text-rose-600">{error}</p>
+          <p className="mt-3 px-1 text-[12px] font-medium text-rose-200">{error}</p>
         ) : null}
 
-        <div className="mt-4 flex items-center justify-between px-1">
+        <div className="mt-4 flex items-center justify-between gap-3 px-1" data-testid="org-chooser-actions">
           <Link
             href="/organization"
-            className="flex items-center gap-1.5 text-[13px] font-medium text-gray-600 transition-colors hover:text-gray-900"
+            className="flex items-center gap-1.5 text-[13px] font-medium text-slate-200 transition-colors hover:text-white focus:outline-none focus:ring-4 focus:ring-white/15"
           >
-            <Plus className="h-4 w-4 text-gray-400" /> Create or join
+            <Plus className="h-4 w-4 text-slate-300" /> Create or join
           </Link>
           <button
             type="button"
             onClick={onSignOut}
-            className="flex items-center gap-1.5 text-[13px] font-medium text-gray-600 transition-colors hover:text-gray-900"
+            className="flex items-center gap-1.5 text-[13px] font-medium text-slate-200 transition-colors hover:text-white focus:outline-none focus:ring-4 focus:ring-white/15"
           >
-            <LogOut className="h-4 w-4 text-gray-400" /> Sign out
+            <LogOut className="h-4 w-4 text-slate-300" /> Sign out
           </button>
         </div>
       </div>

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts app/api/_lib/upstream-proxy.test.mjs",
+    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/org-selection-background.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/org-selection-background.test.ts
+++ b/ee/apps/den-web/tests/org-selection-background.test.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const orgSelectionPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/org-selection-screen.tsx", import.meta.url),
+);
+
+function readOrgSelectionSource() {
+  return readFileSync(orgSelectionPath, "utf8");
+}
+
+describe("org selection background contract", () => {
+  test("uses one scoped Dithering layer and no Paper mesh", () => {
+    const source = readOrgSelectionSource();
+    const ditheringImports = source.match(/import \{ Dithering \} from "@paper-design\/shaders-react"/g) ?? [];
+    const ditheringUses = source.match(/<Dithering\b/g) ?? [];
+
+    expect(ditheringImports).toHaveLength(1);
+    expect(ditheringUses).toHaveLength(1);
+    expect(source).not.toContain("PaperMeshGradient");
+    expect(source).toContain('data-testid="org-chooser-background"');
+    expect(source).toContain('aria-hidden="true"');
+  });
+
+  test("keeps the shader decorative, low-opacity, and behind readable content", () => {
+    const source = readOrgSelectionSource();
+
+    expect(source).toContain("pointer-events-none fixed inset-0 z-0");
+    expect(source).toContain("opacity-[0.10]");
+    expect(source).not.toContain("-z-10");
+    expect(source).toContain('data-testid="org-chooser-foreground"');
+    expect(source).toContain("relative z-10");
+    expect(source).toMatch(/className="[^"]*\bbg-white\b[^"]*" data-testid="org-chooser-list"/);
+    expect(source).not.toContain("disabled:opacity");
+  });
+
+  test("runs almost still unless reduced motion is requested", () => {
+    const source = readOrgSelectionSource();
+
+    expect(source).toContain("useSyncExternalStore");
+    expect(source).toContain('const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";');
+    expect(source).toContain("function getReducedMotionServerSnapshot()");
+    expect(source).toContain('mediaQuery.addEventListener("change", onStoreChange)');
+    expect(source).toContain('mediaQuery.removeEventListener("change", onStoreChange)');
+    expect(source).toContain("const shaderSpeed = reducedMotion ? 0 : 0.012;");
+    expect(source).toContain("speed={shaderSpeed}");
+  });
+
+  test("keeps the shell scroll-safe and actions stable on small screens", () => {
+    const source = readOrgSelectionSource();
+
+    expect(source).toContain("min-h-dvh overflow-y-auto bg-[#0f1d31]");
+    expect(source).toContain("min-h-[calc(100dvh-4rem)]");
+    expect(source).toContain('data-testid="org-chooser-root"');
+    expect(source).toContain('data-testid="org-chooser-actions"');
+    expect(source).toContain("Create or join");
+    expect(source).toContain("Sign out");
+  });
+});

--- a/evals/flows/org-chooser-background.flow.mjs
+++ b/evals/flows/org-chooser-background.flow.mjs
@@ -1,0 +1,443 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, denWebUrl, signInApi as signIn } from "./lib/den-web.mjs";
+
+const vo = await loadVoiceoverParagraphs("org-chooser-background");
+
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const EVAL_ORG_NAME = "Chooser Background Eval Org";
+const PENDING_ORG_SELECTION_KEY = "openwork:web:pending-org-selection";
+const AUTH_TOKEN_KEY = "openwork:web:auth-token";
+
+const state = {
+  token: null,
+  orgs: [],
+  targetOrg: null,
+};
+
+function authHeaders() {
+  return { authorization: `Bearer ${state.token}` };
+}
+
+function denWebRoute(path) {
+  return new URL(path, `${denWebUrl()}/`).toString();
+}
+
+function cacheBustedUrl(path, label) {
+  const url = new URL(denWebRoute(path));
+  url.searchParams.set("orgChooserBackground", `${label}-${Date.now()}`);
+  return url.toString();
+}
+
+async function applyViewport(ctx, width, height, mobile) {
+  if (!ctx.client?.send) {
+    ctx.log("Viewport emulation skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+    width,
+    height,
+    deviceScaleFactor: 1,
+    mobile,
+  }).catch((error) => {
+    ctx.log(`Viewport emulation skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+async function listOrgs(ctx) {
+  const { response, body } = await denApiFetch("/v1/me/orgs", {
+    headers: authHeaders(),
+  });
+  ctx.assert(response.ok, `Listing organizations failed (${response.status}): ${JSON.stringify(body)}`);
+  const orgs = body.orgs ?? [];
+  ctx.assert(Array.isArray(orgs), `Organization list response was not an array: ${JSON.stringify(body)}`);
+  return orgs;
+}
+
+async function ensureMultiOrgAccount(ctx) {
+  state.token = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+  ctx.assert(Boolean(state.token), `API sign-in failed for ${ADMIN_EMAIL}.`);
+
+  let orgs = await listOrgs(ctx);
+  if (orgs.length < 2) {
+    const existingEvalOrg = orgs.find((org) => org.name === EVAL_ORG_NAME) ?? null;
+    if (!existingEvalOrg) {
+      const created = await denApiFetch("/v1/org", {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify({ name: EVAL_ORG_NAME }),
+      });
+      ctx.assert(
+        created.response.ok,
+        `Creating the chooser eval org failed (${created.response.status}): ${JSON.stringify(created.body)} — this flow needs DEN_ORG_MODE=multi_org.`,
+      );
+    }
+    orgs = await listOrgs(ctx);
+  }
+
+  ctx.assert(orgs.length >= 2, `Expected a multi-org account, found ${orgs.length} organization(s).`);
+  state.orgs = orgs;
+  state.targetOrg = orgs.find((org) => org.name === "Acme Robotics" || org.slug?.startsWith("acme"))
+    ?? orgs.find((org) => org.slug === "default")
+    ?? orgs[0];
+  ctx.assert(Boolean(state.targetOrg), "No organization was available to select.");
+}
+
+async function hardNavigateToDen(ctx, path, label) {
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(cacheBustedUrl(path, label))}; return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `Den web loaded ${path}` });
+}
+
+async function waitForEmailFirstRoot(ctx) {
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body?.innerText ?? '';
+      return location.pathname === '/'
+        && !document.querySelector('[data-testid="org-chooser-root"]')
+        && !text.includes('Dashboard')
+        && text.includes('Start using OpenWork')
+        && Boolean(document.querySelector('input[type="email"]'))
+        && localStorage.getItem(${JSON.stringify(AUTH_TOKEN_KEY)}) === null;
+    })()`,
+    { timeoutMs: 45_000, label: "email-first signed-out root" },
+  );
+}
+
+async function clearDenWebSession(ctx) {
+  await hardNavigateToDen(ctx, "/", "pre-signout");
+  await ctx.eval(
+    `(() => {
+      localStorage.removeItem(${JSON.stringify(AUTH_TOKEN_KEY)});
+      sessionStorage.clear();
+      return fetch('/api/auth/sign-out', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+        credentials: 'include',
+      }).catch(() => null).then(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        return true;
+      });
+    })()`,
+    { awaitPromise: true },
+  );
+  if (ctx.client?.send) {
+    await ctx.client.send("Network.clearBrowserCookies", {}).catch((error) => {
+      ctx.log(`Cookie clear skipped: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    await ctx.client.send("Network.clearBrowserCache", {}).catch((error) => {
+      ctx.log(`Cache clear skipped: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }
+  await hardNavigateToDen(ctx, "/", "signed-out-root");
+  await waitForEmailFirstRoot(ctx);
+}
+
+function chooserOrLoadedDashboardExpression() {
+  return `(() => {
+    const text = document.body?.innerText ?? '';
+    if (document.querySelector('[data-testid="org-chooser-root"]')) return true;
+    return location.pathname.startsWith('/dashboard')
+      && Boolean(document.querySelector('aside nav'))
+      && Boolean(document.querySelector('main.overflow-y-auto'))
+      && (text.includes('Feedback') || text.includes('Docs'))
+      && !text.includes('Refreshing workspace')
+      && !text.includes('No active session found')
+      && !text.includes('Failed to load')
+      && !text.includes('Start using OpenWork');
+  })()`;
+}
+
+async function submitSignIn(ctx) {
+  await ctx.waitFor(
+    "Boolean(document.querySelector('input[type=\"email\"]'))",
+    { timeoutMs: 30_000, label: "email field" },
+  );
+
+  const passwordAlreadyVisible = await ctx.eval("Boolean(document.querySelector('input[type=\"password\"]'))");
+  if (!passwordAlreadyVisible) {
+    await ctx.fill('input[type="email"]', ADMIN_EMAIL);
+    const advanced = await ctx.eval(`(() => {
+      const form = document.querySelector('input[type="email"]')?.closest('form');
+      const button = form?.querySelector('button[type="submit"]');
+      button?.click();
+      return Boolean(button);
+    })()`);
+    ctx.assert(advanced, "No Next button found on the email-first sign-in card.");
+    await ctx.waitFor(
+      "Boolean(document.querySelector('input[type=\"password\"]'))",
+      { timeoutMs: 20_000, label: "password step" },
+    );
+  } else {
+    const switchedToSignIn = await ctx.eval(`(() => {
+      const button = [...document.querySelectorAll('button[type="button"]')]
+        .find((entry) => (entry.textContent ?? '').trim() === 'Sign in');
+      button?.click();
+      return Boolean(button);
+    })()`);
+    if (switchedToSignIn) {
+      await ctx.waitFor(
+        `(() => {
+          const submit = document.querySelector('button[type="submit"]');
+          return (submit?.textContent ?? '').includes('Sign in');
+        })()`,
+        { timeoutMs: 10_000, label: "sign-in form selected" },
+      );
+    }
+    await ctx.fill('input[type="email"]', ADMIN_EMAIL);
+  }
+
+  await ctx.fill('input[type="password"]', ADMIN_PASSWORD);
+  const submitted = await ctx.eval(`(() => {
+    const button = document.querySelector('button[type="submit"]');
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(submitted, "No submit button found on the sign-in card.");
+}
+
+async function waitForChooser(ctx) {
+  await ctx.waitFor(
+    `Boolean(document.querySelector('[data-testid="org-chooser-root"]')) && document.body.innerText.includes('Choose an organization')`,
+    { timeoutMs: 60_000, label: "organization chooser" },
+  );
+  await ctx.waitFor(
+    `Boolean(document.querySelector('[data-testid="org-chooser-background"] canvas'))`,
+    { timeoutMs: 30_000, label: "Dithering shader canvas" },
+  );
+}
+
+async function forceChooser(ctx) {
+  const chooserUrl = cacheBustedUrl("/dashboard", "force-chooser");
+  await ctx.eval(`(() => {
+    window.sessionStorage.setItem(${JSON.stringify(PENDING_ORG_SELECTION_KEY)}, '1');
+    window.location.href = ${JSON.stringify(chooserUrl)};
+    return true;
+  })()`);
+  await waitForChooser(ctx);
+}
+
+async function openFreshChooser(ctx) {
+  await applyViewport(ctx, 1280, 900, false);
+  await clearDenWebSession(ctx);
+  await submitSignIn(ctx);
+  await ctx.waitFor(
+    chooserOrLoadedDashboardExpression(),
+    { timeoutMs: 60_000, label: "chooser or loaded dashboard after sign-in" },
+  );
+
+  const chooserVisible = await ctx.eval(`Boolean(document.querySelector('[data-testid="org-chooser-root"]'))`);
+  if (!chooserVisible) {
+    await forceChooser(ctx);
+    return;
+  }
+
+  await waitForChooser(ctx);
+}
+
+async function chooserVisualState(ctx) {
+  return ctx.eval(`(() => {
+    const root = document.querySelector('[data-testid="org-chooser-root"]');
+    const background = document.querySelector('[data-testid="org-chooser-background"]');
+    const foreground = document.querySelector('[data-testid="org-chooser-foreground"]');
+    const list = document.querySelector('[data-testid="org-chooser-list"]');
+    const actions = document.querySelector('[data-testid="org-chooser-actions"]');
+    const rootStyle = root ? getComputedStyle(root) : null;
+    const backgroundStyle = background ? getComputedStyle(background) : null;
+    const foregroundStyle = foreground ? getComputedStyle(foreground) : null;
+    const listStyle = list ? getComputedStyle(list) : null;
+    const backgroundRect = background?.getBoundingClientRect();
+    const foregroundRect = foreground?.getBoundingClientRect();
+    const listRect = list?.getBoundingClientRect();
+
+    return {
+      path: window.location.pathname,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      rootMinHeight: rootStyle?.minHeight ?? null,
+      rootOverflowY: rootStyle?.overflowY ?? null,
+      rootBackgroundColor: rootStyle?.backgroundColor ?? null,
+      backgroundAriaHidden: background?.getAttribute('aria-hidden') ?? null,
+      backgroundPointerEvents: backgroundStyle?.pointerEvents ?? null,
+      backgroundOpacity: backgroundStyle?.opacity ?? null,
+      backgroundPosition: backgroundStyle?.position ?? null,
+      backgroundZIndex: backgroundStyle?.zIndex ?? null,
+      backgroundCanvasCount: background?.querySelectorAll('canvas').length ?? 0,
+      rootCanvasCount: root?.querySelectorAll('canvas').length ?? 0,
+      backgroundCoversViewport: Boolean(backgroundRect && backgroundRect.width >= window.innerWidth && backgroundRect.height >= window.innerHeight),
+      foregroundZIndex: foregroundStyle?.zIndex ?? null,
+      foregroundOpacity: foregroundStyle?.opacity ?? null,
+      foregroundWithinViewport: Boolean(foregroundRect && foregroundRect.left >= 0 && foregroundRect.right <= window.innerWidth + 1),
+      listBackgroundColor: listStyle?.backgroundColor ?? null,
+      listOpacity: listStyle?.opacity ?? null,
+      listWithinViewport: Boolean(listRect && listRect.left >= 0 && listRect.right <= window.innerWidth + 1),
+      actionsText: actions?.innerText ?? '',
+      documentText: document.body.innerText,
+    };
+  })()`);
+}
+
+async function orgListState(ctx) {
+  return ctx.eval(`(() => {
+    const list = document.querySelector('[data-testid="org-chooser-list"]');
+    const buttons = [...(list?.querySelectorAll('button') ?? [])].map((button) => ({
+      text: button.innerText,
+      disabled: button.disabled,
+      rect: (() => {
+        const box = button.getBoundingClientRect();
+        return { width: box.width, height: box.height };
+      })(),
+    }));
+    const metadataRows = buttons.filter((button) => {
+      const text = button.text.replace(/\\s+/g, ' ');
+      const bulletIndex = text.indexOf('•');
+      const hasRole = bulletIndex > 0 && text.slice(0, bulletIndex).trim().length > 0;
+      return hasRole && /\\d+ members?/.test(text);
+    });
+
+    return {
+      count: buttons.length,
+      metadataCount: metadataRows.length,
+      firstRowText: buttons[0]?.text ?? null,
+      targetRowText: buttons.find((button) => button.text.includes(${JSON.stringify(state.targetOrg?.name ?? "")}))?.text ?? null,
+      allEnabled: buttons.every((button) => !button.disabled),
+    };
+  })()`);
+}
+
+async function selectTargetOrg(ctx) {
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body?.innerText ?? '';
+      if (text.includes('Dashboard') && !document.querySelector('[data-testid="org-chooser-root"]')) return true;
+      const button = [...document.querySelectorAll('[data-testid="org-chooser-list"] button')]
+        .find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(state.targetOrg?.name ?? "")}));
+      button?.click();
+      return false;
+    })()`,
+    { timeoutMs: 60_000, label: `select ${state.targetOrg?.name ?? "organization"}` },
+  );
+}
+
+export default {
+  id: "org-chooser-background",
+  title: "Organization chooser uses a restrained Dithering background without sacrificing readability",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MULTI_ORG"],
+  steps: [
+    {
+      name: "Setup: seeded user has a real multi-org chooser",
+      run: async (ctx) => {
+        await ensureMultiOrgAccount(ctx);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The real organization chooser opens on a calm Dithering background", {
+          voiceover: vo[0],
+          action: async () => {
+            await openFreshChooser(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("Choose an organization");
+            const visual = await chooserVisualState(ctx);
+            ctx.assert(visual.backgroundCanvasCount === 1 && visual.rootCanvasCount === 1, `Expected exactly one chooser shader canvas: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.backgroundCoversViewport, `Background did not cover the viewport: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.rootBackgroundColor === "rgb(15, 29, 49)", `Unexpected root background color: ${JSON.stringify(visual)}`);
+          },
+          screenshot: {
+            name: "chooser-calm-background",
+            claim: "The organization chooser opens on the new navy Dithering treatment with the chooser content in front.",
+            requireText: ["Choose an organization", state.targetOrg?.name ?? EVAL_ORG_NAME],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The decorative texture is separate and low-opacity while the list stays readable", {
+          voiceover: vo[1],
+          action: async () => {
+            await waitForChooser(ctx);
+          },
+          assert: async () => {
+            const visual = await chooserVisualState(ctx);
+            const opacity = Number.parseFloat(visual.backgroundOpacity ?? "1");
+            ctx.assert(visual.backgroundAriaHidden === "true", `Background is not aria-hidden: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.backgroundPointerEvents === "none", `Background can receive pointer events: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.backgroundPosition === "fixed" && visual.backgroundZIndex === "0" && visual.foregroundZIndex === "10", `Background/foreground stacking changed: ${JSON.stringify(visual)}`);
+            ctx.assert(opacity > 0 && opacity <= 0.12, `Background opacity is not restrained: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.foregroundOpacity === "1" && visual.listOpacity === "1", `Foreground/list opacity should stay fully legible: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.listBackgroundColor === "rgb(255, 255, 255)", `Org list is not an opaque white surface: ${JSON.stringify(visual)}`);
+          },
+          screenshot: {
+            name: "chooser-readable-list",
+            claim: "The low-opacity decorative shader sits behind a crisp white organization list.",
+            requireText: ["Choose an organization", "member"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Role and member metadata are readable, and selecting an org continues to the dashboard", {
+          voiceover: vo[2],
+          action: async () => {
+            await waitForChooser(ctx);
+            const list = await orgListState(ctx);
+            ctx.assert(list.count >= 2, `Chooser did not show multiple organizations: ${JSON.stringify(list)}`);
+            ctx.assert(list.metadataCount >= 1, `Chooser rows did not expose role/member metadata: ${JSON.stringify(list)}`);
+            ctx.assert(Boolean(list.targetRowText), `Target organization row was missing: ${JSON.stringify(list)}`);
+            await selectTargetOrg(ctx);
+          },
+          assert: async () => {
+            await ctx.waitForText("Dashboard", { timeoutMs: 30_000 });
+            const chooserStillVisible = await ctx.eval(`Boolean(document.querySelector('[data-testid="org-chooser-root"]'))`);
+            ctx.assert(!chooserStillVisible, "The chooser remained visible after selecting an organization.");
+            const pathname = await ctx.eval("window.location.pathname");
+            ctx.assert(pathname === "/dashboard", `Selecting an organization landed on ${pathname} instead of /dashboard.`);
+          },
+          screenshot: {
+            name: "org-selected-dashboard",
+            claim: "After the user picks an organization, Den continues into the dashboard.",
+            requireText: ["Dashboard"],
+            rejectText: ["Choose an organization", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("The actions and readable list remain intact on a small screen", {
+          voiceover: vo[3],
+          action: async () => {
+            await applyViewport(ctx, 390, 780, true);
+            await forceChooser(ctx);
+          },
+          assert: async () => {
+            const visual = await chooserVisualState(ctx);
+            ctx.assert(visual.viewportWidth <= 430, `Mobile viewport was not applied: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.rootOverflowY === "auto" && typeof visual.rootMinHeight === "string" && visual.rootMinHeight.endsWith("px"), `Chooser shell is not scroll-safe: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.foregroundWithinViewport && visual.listWithinViewport, `Chooser content overflowed the mobile viewport: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.listBackgroundColor === "rgb(255, 255, 255)", `Mobile org list is not readable white: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.actionsText.includes("Create or join") && visual.actionsText.includes("Sign out"), `Mobile actions are not visible: ${JSON.stringify(visual)}`);
+          },
+          screenshot: {
+            name: "chooser-mobile-actions",
+            claim: "On a phone-sized viewport, the same restrained background stays behind the readable chooser and its account actions.",
+            requireText: ["Choose an organization", "Create or join", "Sign out"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/org-chooser-background.md
+++ b/evals/voiceovers/org-chooser-background.md
@@ -1,0 +1,9 @@
+# org-chooser-background — Organization chooser background
+
+1. “The organization chooser opens on a calm, subtly animated background that matches the new sign-in aesthetic without competing with the content.”
+
+2. “The low-opacity texture moves almost imperceptibly, while the organization list remains crisp, readable, and accessible.”
+
+3. “I can clearly scan my role and member count, then select an organization to continue.”
+
+4. “Create or join and Sign out remain easy to find, and the same restrained background treatment works on smaller screens.”


### PR DESCRIPTION
## Summary
- add a single low-opacity Dithering background to the organization chooser
- animate it very slowly and disable movement for reduced-motion preferences
- preserve an opaque, readable organization list and responsive account actions
- add contract coverage and an end-to-end multi-org fraimz flow

## Validation
- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm --filter @openwork-ee/den-web test` — 44 passed
- `pnpm --filter @openwork-ee/den-web build` — passed
- `OPENWORK_EVAL_DEN_API_URL=http://127.0.0.1:34131 OPENWORK_EVAL_DEN_WEB_URL=http://127.0.0.1:34128 OPENWORK_EVAL_DEN_MULTI_ORG=1 pnpm fraimz --flow org-chooser-background --cdp-url http://127.0.0.1:9333` — passed, 4/4 frames

## Design
- Dithering speed: `0.012` (`0` with reduced motion)
- decorative opacity: `0.10`
- one canvas, pointer-events disabled, content kept on an opaque foreground surface