### PR TITLE
feat(app): Den marketplace delivery through OpenWork Connect only (D2)

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -611,7 +611,7 @@ export default {
   "extensions.filter_apps": "Apps",
   "extensions.filter_plugins": "Plugins",
   "extensions.marketplace_active_cloud_label": "Active · runs in cloud",
-  "extensions.marketplace_description": "Browse built-in OpenWork extensions and organization marketplace extensions. Claude-compatible plugins are normalized into OpenWork extensions with installable resources such as skills, MCPs, commands, or tools.",
+  "extensions.marketplace_description": "Browse OpenWork built-ins and organization marketplace extensions. Built-ins stay local; organization marketplace extensions run through OpenWork Connect, while GitHub and Claude plugin imports live in local Extensions.",
   "extensions.marketplace_local_description": "Desktop-only and unsynced marketplace items stay installable here. Cloud-runnable apps are listed in Connect.",
   "extensions.marketplace_local_title": "From your marketplace — installs on this machine",
   "extensions.marketplace_runs_in_cloud": "Runs in cloud",

--- a/apps/app/src/react-app/domains/settings/connect-delivery.ts
+++ b/apps/app/src/react-app/domains/settings/connect-delivery.ts
@@ -1,13 +1,11 @@
-export type MarketplaceDeliveryActionKind = "install" | "cloud_active" | "cloud_active_local_copy";
+export type MarketplaceDeliveryActionKind = "cloud_active" | "cloud_active_local_copy";
 
-export function shouldShowExtensionsMarketplacePane(_connectEnabled?: boolean) {
+export function shouldShowExtensionsMarketplacePane() {
   return true;
 }
 
 export function resolveMarketplaceDeliveryAction(input: {
-  connectEnabled?: boolean;
   importedLocally: boolean;
 }): MarketplaceDeliveryActionKind {
-  if (input.connectEnabled !== true) return "install";
   return input.importedLocally ? "cloud_active_local_copy" : "cloud_active";
 }

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -10,12 +10,10 @@ import type { DenExternalMcpConnection, DenOrgMarketplaceResolved, DenOrgPlugin,
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { t } from "@/i18n";
-import { useConnectEnabled } from "@/react-app/domains/cloud/desktop-config-provider";
 import { canDisconnectNativeProviderAccount } from "@/react-app/domains/connections/native-provider-connections";
 import { ExtensionCard } from "@/react-app/design-system/extension-card";
 import { ExtensionDetailModal } from "@/react-app/design-system/extension-detail-modal";
 import { resolveMarketplaceDeliveryAction } from "@/react-app/domains/settings/connect-delivery";
-import { isDesktopInstallableMarketplacePlugin } from "@/react-app/domains/settings/connect-cloud-readiness";
 import {
   isOrgMcpConnectionItem,
   isOrgMcpConnectionReady,
@@ -61,7 +59,6 @@ type DenSettingsExtensionsStore = {
   importedCloudPlugins: () => Record<string, CloudImportedPlugin>;
   pendingCloudPluginChanges: () => Record<string, PendingCloudPluginChange>;
   refreshCloudOrgMarketplaces: (options?: { force?: boolean }) => Promise<unknown>;
-  importCloudOrgPlugin: (marketplaceId: string | null, plugin: DenOrgPlugin) => Promise<AsyncResult>;
   removeCloudOrgPlugin: (pluginId: string) => Promise<AsyncResult>;
 };
 
@@ -102,6 +99,14 @@ type MarketplaceRow = MarketplacePackageRow | BuiltInMarketplaceRow | OrgMcpMark
 
 export function shouldShowMarketplaceRows(isSignedIn: boolean, activeOrgId: string) {
   return isSignedIn && activeOrgId.trim().length > 0;
+}
+
+export function shouldIncludeCloudMarketplacePluginRow(input: { embedded?: boolean }) {
+  return input.embedded !== true;
+}
+
+export function shouldIncludeOrgMcpConnectionMarketplaceRow(_input: { embedded?: boolean }) {
+  return false;
 }
 
 export type CloudMarketplacesViewProps = {
@@ -172,28 +177,6 @@ function pluginStatus(imported: CloudImportedPlugin | null, plugin: DenOrgPlugin
   return "installed";
 }
 
-function statusLabel(status: MarketplacePackageStatus) {
-  switch (status) {
-    case "installed":
-      return t("den.imported_badge");
-    case "update_available":
-      return t("den.out_of_sync_badge");
-    default:
-      return "Available";
-  }
-}
-
-function statusClass(status: MarketplacePackageStatus) {
-  switch (status) {
-    case "installed":
-      return "border-green-7/30 bg-green-3/20 text-green-11";
-    case "update_available":
-      return "border-amber-7/30 bg-amber-3/20 text-amber-11";
-    default:
-      return "border-gray-6/60 bg-gray-3/20 text-gray-11";
-  }
-}
-
 export function CloudMarketplacesView({
   extensions,
   embedded = false,
@@ -215,7 +198,6 @@ export function CloudMarketplacesView({
   setBuiltInEnabled,
 }: CloudMarketplacesViewProps) {
   const { activeOrganization: activeOrg, authToken, client, isSignedIn, user } = useCloudSession();
-  const connectEnabled = useConnectEnabled();
   const [busy, setBusy] = React.useState(false);
   const [actionId, setActionId] = React.useState<string | null>(null);
   const [actionError, setActionError] = React.useState<string | null>(null);
@@ -223,13 +205,14 @@ export function CloudMarketplacesView({
   const [statusFilter, setStatusFilter] = React.useState<MarketplaceStatusFilter>("all");
   const [marketplaceFilter, setMarketplaceFilter] = React.useState("all");
   const [detailRow, setDetailRow] = React.useState<MarketplaceRow | null>(null);
-  const [updateAllProgress, setUpdateAllProgress] = React.useState<{ current: number; total: number } | null>(null);
   const [resolvedPlugins, setResolvedPlugins] = React.useState<Record<string, DenOrgPluginResolved>>({});
   const [detailLoadingId, setDetailLoadingId] = React.useState<string | null>(null);
   const [detailError, setDetailError] = React.useState<string | null>(null);
   const [highlightPluginName, setHighlightPluginName] = React.useState<string | null>(null);
   const activeOrgId = activeOrg?.id ?? "";
   const canShowRows = shouldShowMarketplaceRows(isSignedIn, activeOrgId);
+  const includeCloudMarketplaceRows = shouldIncludeCloudMarketplacePluginRow({ embedded });
+  const includeOrgMcpRows = shouldIncludeOrgMcpConnectionMarketplaceRow({ embedded });
 
   // Listen for "open marketplace plugin" requests from notifications.
   React.useEffect(() => {
@@ -261,7 +244,7 @@ export function CloudMarketplacesView({
   const lastRowsRef = React.useRef<MarketplaceRow[]>([]);
   const cloudRows = React.useMemo<MarketplacePackageRow[]>(() => {
     return marketplaces.flatMap((marketplace) => marketplace.plugins.flatMap((plugin) => {
-      if (connectEnabled === true && !isDesktopInstallableMarketplacePlugin(plugin)) return [];
+      if (!includeCloudMarketplaceRows) return [];
       const imported = importedPlugins[plugin.id] ?? null;
       const composition = pluginComposition(plugin);
       const counts = pluginCounts(plugin);
@@ -289,7 +272,7 @@ export function CloudMarketplacesView({
         ].join(" ").toLowerCase(),
       }];
     }));
-  }, [connectEnabled, extensionItemsByPluginId, importedPlugins, marketplaces, pendingChanges]);
+  }, [extensionItemsByPluginId, importedPlugins, includeCloudMarketplaceRows, marketplaces, pendingChanges]);
 
   const builtInRows = React.useMemo<BuiltInMarketplaceRow[]>(() => {
     return builtInEntries.map((entry) => {
@@ -316,7 +299,7 @@ export function CloudMarketplacesView({
   }, [builtInEntries, enablementContext, extensionItemsByBuiltInId, isBuiltInConnected]);
 
   const orgMcpRows = React.useMemo<OrgMcpMarketplaceRow[]>(() => {
-    if (connectEnabled === true) return [];
+    if (!includeOrgMcpRows) return [];
     return extensionItems.flatMap((item) => {
       if (!isOrgMcpConnectionItem(item) || item.installState !== "available") return [];
       const connection = item.orgMcpConnection;
@@ -336,7 +319,7 @@ export function CloudMarketplacesView({
         ].join(" ").toLowerCase(),
       }];
     });
-  }, [connectEnabled, extensionItems]);
+  }, [extensionItems, includeOrgMcpRows]);
 
   const rows = React.useMemo<MarketplaceRow[]>(() => canShowRows ? [...builtInRows, ...cloudRows, ...orgMcpRows] : [], [builtInRows, canShowRows, cloudRows, orgMcpRows]);
 
@@ -359,10 +342,10 @@ export function CloudMarketplacesView({
   const marketplaceOptions = React.useMemo(
     () => canShowRows ? [
       ...(builtInRows.length > 0 ? [{ id: "openwork-builtins", name: "OpenWork Built-ins" }] : []),
-      ...marketplaces.map((marketplace) => ({ id: marketplace.marketplace.id, name: marketplace.marketplace.name })),
+      ...(includeCloudMarketplaceRows ? marketplaces.map((marketplace) => ({ id: marketplace.marketplace.id, name: marketplace.marketplace.name })) : []),
       ...(orgMcpRows.length > 0 ? [{ id: "org-mcp-connections", name: "Organization MCP Connections" }] : []),
     ] : [],
-    [builtInRows.length, canShowRows, marketplaces, orgMcpRows.length],
+    [builtInRows.length, canShowRows, includeCloudMarketplaceRows, marketplaces, orgMcpRows.length],
   );
 
   const visibleRows = React.useMemo(() => {
@@ -441,29 +424,6 @@ export function CloudMarketplacesView({
     };
   }, [activeOrgId, client, detailRow, isSignedIn, resolvedPlugins]);
 
-  const importPlugin = React.useCallback(
-    async (marketplaceId: string | null, plugin: DenOrgPlugin) => {
-      if (connectEnabled === true && !isDesktopInstallableMarketplacePlugin(plugin)) return;
-      if (actionId) return;
-
-      setActionId(plugin.id);
-      setActionError(null);
-
-      try {
-        const result = await extensions.importCloudOrgPlugin(marketplaceId, plugin);
-        if (!result.ok) throw new Error(result.message);
-        if (result.warnings?.length) toast.warning(result.message);
-        else toast.success(result.message);
-        setDetailRow(null);
-      } catch (error) {
-        setActionError(error instanceof Error ? error.message : `Failed to add ${plugin.name}.`);
-      } finally {
-        setActionId(null);
-      }
-    },
-    [actionId, connectEnabled, extensions],
-  );
-
   const removePlugin = React.useCallback(
     async (pluginId: string, pluginName: string) => {
       if (actionId) return;
@@ -485,63 +445,21 @@ export function CloudMarketplacesView({
     [actionId, extensions],
   );
 
-  const updatableRows = React.useMemo(
-    () => cloudRows.filter((row) => row.status === "update_available" && !isCloudBuiltInPlugin(row.plugin)),
-    [cloudRows],
-  );
-
   const removedUpstreamPlugins = React.useMemo(
     () => Object.values(importedPlugins).filter((plugin) => pendingChanges[plugin.pluginId] === "removed"),
     [importedPlugins, pendingChanges],
   );
 
-  const updateAll = React.useCallback(async () => {
-    if (actionId || updateAllProgress) return;
-
-    setActionError(null);
-    const targets = [...updatableRows];
-    let failed = 0;
-    const warnings: string[] = [];
-    // Sequential on purpose: avoid hammering the install routes.
-    for (let index = 0; index < targets.length; index += 1) {
-      const target = targets[index];
-      setUpdateAllProgress({ current: index + 1, total: targets.length });
-      const result = await extensions.importCloudOrgPlugin(target.marketplaceId, target.plugin);
-      if (!result.ok) failed += 1;
-      else warnings.push(...(result.warnings ?? []));
-    }
-    setUpdateAllProgress(null);
-    if (failed > 0) {
-      setActionError(`Failed to update ${failed} extension${failed === 1 ? "" : "s"}.`);
-    } else if (warnings.length > 0) {
-      toast.warning(`Updated ${targets.length} extension${targets.length === 1 ? "" : "s"}. ${warnings.join(" ")}`);
-    } else if (targets.length > 0) {
-      toast.success(`Updated ${targets.length} extension${targets.length === 1 ? "" : "s"}.`);
-    }
-  }, [actionId, extensions, updatableRows, updateAllProgress]);
-
   const content = (
     <SettingsSection>
       <SettingsSectionHeader>
         <SettingsSectionHeaderContent>
-          <SettingsSectionHeaderTitle>{connectEnabled === true ? t("extensions.marketplace_local_title") : t("extensions.marketplace_title")}</SettingsSectionHeaderTitle>
+          <SettingsSectionHeaderTitle>{t("extensions.marketplace_title")}</SettingsSectionHeaderTitle>
           <SettingsSectionHeaderDescription>
-            {connectEnabled === true ? t("extensions.marketplace_local_description") : t("extensions.marketplace_description")}
+            {t("extensions.marketplace_description")}
           </SettingsSectionHeaderDescription>
         </SettingsSectionHeaderContent>
         <SettingsSectionHeaderActions>
-          {updatableRows.length >= 2 ? (
-            <Button
-              size="sm"
-              variant="secondary"
-              disabled={busy || Boolean(actionId) || Boolean(updateAllProgress)}
-              onClick={() => void updateAll()}
-            >
-              {updateAllProgress
-                ? t("extensions.update_all_progress", { current: updateAllProgress.current, total: updateAllProgress.total })
-                : t("extensions.update_all_button")}
-            </Button>
-          ) : null}
           <RefreshButton
             busy={busy}
             disabled={busy || !canShowRows}
@@ -648,8 +566,6 @@ export function CloudMarketplacesView({
                 actionId={actionId}
                 row={row}
                 onOpenDetail={setDetailRow}
-                onUpdatePlugin={importPlugin}
-                connectEnabled={connectEnabled}
                 orgMcpConnectingId={orgMcpConnectingId}
                 orgMcpDisconnectingId={orgMcpDisconnectingId}
                 onDisconnectOrgMcp={onDisconnectOrgMcp}
@@ -673,8 +589,6 @@ export function CloudMarketplacesView({
           orgMcpConnectingId={orgMcpConnectingId}
           onClose={() => setDetailRow(null)}
           onConnectOrgMcp={onConnectOrgMcp}
-          onImportPlugin={importPlugin}
-          connectEnabled={connectEnabled}
           onRemovePlugin={removePlugin}
         />
       ) : detailRow?.source === "built-in" ? (
@@ -707,23 +621,16 @@ export function CloudMarketplacesView({
   );
 }
 
-function actionLabelForStatus(status: MarketplacePackageStatus) {
-  switch (status) {
-    case "installed":
-      return "View details";
-    case "update_available":
-      return "Update available";
-    default:
-      return "Add";
-  }
+function marketplaceDeliveryLabel(action: ReturnType<typeof resolveMarketplaceDeliveryAction>) {
+  return action === "cloud_active_local_copy"
+    ? t("connect.marketplace_local_copy_badge")
+    : t("extensions.marketplace_active_cloud_label");
 }
 
 function MarketplaceCard(props: {
   actionId: string | null;
   row: MarketplaceRow;
   onOpenDetail: (row: MarketplaceRow) => void;
-  onUpdatePlugin: (marketplaceId: string | null, plugin: DenOrgPlugin) => void | Promise<void>;
-  connectEnabled?: boolean;
   orgMcpConnectingId: string | null;
   orgMcpDisconnectingId: string | null;
   onDisconnectOrgMcp?: (connectionId: string) => void;
@@ -731,7 +638,7 @@ function MarketplaceCard(props: {
   builtInConnectingName: string | null;
   highlighted?: boolean;
 }) {
-  const { actionId, row, onOpenDetail, onUpdatePlugin } = props;
+  const { actionId, row, onOpenDetail } = props;
   const highlightRef = React.useRef<HTMLDivElement>(null);
 
   React.useEffect(() => {
@@ -806,13 +713,10 @@ function MarketplaceCard(props: {
   const actionBusy = actionId === row.plugin.id;
   const manifest = row.plugin.extension?.manifest;
   const cloudBuiltIn = isCloudBuiltInPlugin(row.plugin);
-  const updateAvailable = !cloudBuiltIn && row.status === "update_available";
   const deliveryAction = resolveMarketplaceDeliveryAction({
-    connectEnabled: props.connectEnabled === true && !isDesktopInstallableMarketplacePlugin(row.plugin),
     importedLocally: Boolean(row.imported),
   });
-  const cloudDelivery = deliveryAction !== "install";
-  const needsSetup = Boolean(row.imported && row.item?.setupState === "needs_setup");
+  const deliveryLabel = marketplaceDeliveryLabel(deliveryAction);
 
   return (
     <div ref={highlightRef} className={`flex flex-col gap-2 ${highlightClass}`}>
@@ -822,22 +726,12 @@ function MarketplaceCard(props: {
         iconSlug={manifest?.icon?.simpleIconSlug}
         iconSrc={manifest?.icon?.src}
         kind="extension"
-        connected={cloudBuiltIn || (cloudDelivery && !needsSetup) || (Boolean(row.imported) && !needsSetup)}
-        connectedLabel={cloudDelivery && !needsSetup ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : updateAvailable ? t("extensions.update_available") : "Installed"}
+        connected
+        connectedLabel={cloudBuiltIn ? "Built-in" : deliveryLabel}
         connecting={actionBusy}
-        actionLabel={needsSetup ? "View setup" : cloudDelivery ? t("extensions.marketplace_runs_in_cloud") : cloudBuiltIn ? "View details" : actionBusy ? "Working..." : actionLabelForStatus(row.status)}
+        actionLabel={cloudBuiltIn ? "View details" : t("extensions.marketplace_runs_in_cloud")}
         onClick={() => onOpenDetail(row)}
       />
-      {updateAvailable && !cloudDelivery ? (
-        <Button
-          size="xs"
-          variant="secondary"
-          disabled={Boolean(actionId)}
-          onClick={() => void onUpdatePlugin(row.marketplaceId, row.plugin)}
-        >
-          {actionBusy ? t("extensions.updating") : t("extensions.update_button")}
-        </Button>
-      ) : null}
     </div>
   );
 }
@@ -935,12 +829,10 @@ function MarketplacePackageDetailModal(props: {
   resolved: DenOrgPluginResolved | null;
   resolving: boolean;
   resolveError: string | null;
-  connectEnabled?: boolean;
   orgMcpConnections: DenExternalMcpConnection[];
   orgMcpConnectingId: string | null;
   onClose: () => void;
   onConnectOrgMcp?: (connectionId: string) => void;
-  onImportPlugin: (marketplaceId: string | null, plugin: DenOrgPlugin) => void | Promise<void>;
   onRemovePlugin: (pluginId: string, pluginName: string) => void | Promise<void>;
 }) {
   const {
@@ -953,19 +845,15 @@ function MarketplacePackageDetailModal(props: {
     orgMcpConnectingId,
     onClose,
     onConnectOrgMcp,
-    onImportPlugin,
     onRemovePlugin,
   } = props;
   const actionBusy = actionId === row.plugin.id;
   const cloudBuiltIn = isCloudBuiltInPlugin(row.plugin);
   const manifest = row.plugin.extension?.manifest;
   const deliveryAction = resolveMarketplaceDeliveryAction({
-    connectEnabled: props.connectEnabled === true && !isDesktopInstallableMarketplacePlugin(row.plugin),
     importedLocally: Boolean(row.imported),
   });
-  const cloudDelivery = deliveryAction !== "install";
-  const needsSetup = Boolean(row.imported && row.item?.setupState === "needs_setup");
-  const canAddOrUpdate = !cloudDelivery && !cloudBuiltIn && (row.status === "available" || row.status === "update_available");
+  const deliveryLabel = marketplaceDeliveryLabel(deliveryAction);
   const importedExternalConnectionIds = row.imported?.files.flatMap((file) => file.externalMcpConnectionId ? [file.externalMcpConnectionId] : []) ?? [];
   const importedConnections = [...new Set(importedExternalConnectionIds)].flatMap((connectionId) => {
     const connection = orgMcpConnections.find((entry) => entry.id === connectionId);
@@ -982,28 +870,29 @@ function MarketplacePackageDetailModal(props: {
       iconSlug={manifest?.icon?.simpleIconSlug}
       iconSrc={manifest?.icon?.src}
       kind="extension"
-      connected={cloudBuiltIn || (cloudDelivery && !needsSetup) || (Boolean(row.imported) && !needsSetup)}
-      connectedLabel={cloudDelivery && !needsSetup ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : "Installed"}
-      disconnectedLabel={needsSetup ? "Needs setup" : undefined}
+      connected
+      connectedLabel={cloudBuiltIn ? "Built-in" : deliveryLabel}
       connecting={actionBusy}
-      connectLabel={needsSetup ? "View setup" : row.status === "update_available" ? "Update" : "Add"}
-      connectingLabel={row.status === "update_available" ? "Updating..." : "Adding..."}
+      connectLabel={t("extensions.marketplace_runs_in_cloud")}
+      connectingLabel="Working..."
       uninstallLabel="Remove"
       showEnablementCard={false}
       setupInstructions={manifest?.setup?.instructions}
       resourceLabels={manifest?.resources.map((resource) => resource.label ?? resource.id) ?? []}
       contributionLabels={manifest?.contributions?.map((contribution) => contribution.label ?? contribution.ref ?? contribution.type) ?? []}
-      onConnect={canAddOrUpdate ? () => void onImportPlugin(row.marketplaceId, row.plugin) : undefined}
       onUninstall={!cloudBuiltIn && row.imported ? () => void onRemovePlugin(row.plugin.id, row.plugin.name) : undefined}
       configSlot={(
         <div className="space-y-4">
           <div className="flex flex-wrap gap-2">
-            <SettingsPill className={needsSetup ? "border-amber-7/30 bg-amber-3/20 text-amber-11" : statusClass(row.status)}>
-              {needsSetup ? "Needs setup" : cloudDelivery ? t("extensions.marketplace_active_cloud_label") : cloudBuiltIn ? "Built-in" : statusLabel(row.status)}
+            <SettingsPill>
+              {cloudBuiltIn ? "Built-in" : deliveryLabel}
             </SettingsPill>
             <SettingsPill>{row.marketplaceName}</SettingsPill>
             {row.counts.map((label) => <SettingsPill key={label}>{label}</SettingsPill>)}
           </div>
+          {deliveryAction === "cloud_active_local_copy" ? (
+            <SettingsNotice>{t("connect.marketplace_local_copy_note")}</SettingsNotice>
+          ) : null}
           <div className="rounded-xl border border-dls-border bg-dls-hover px-3 py-3">
             <div className="text-xs font-semibold uppercase tracking-[0.14em] text-muted-foreground">Composition</div>
             <div className="mt-2 grid gap-2">

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -499,6 +499,7 @@ type ConnectOrganizationRow =
       name: string;
       description: string;
       meta: string;
+      importedLocally: boolean;
       plugin: DenOrgPlugin;
     };
 
@@ -566,6 +567,7 @@ export function buildConnectRows(input: {
       name: item.plugin.name,
       description: item.plugin.description ?? "",
       meta: formatPluginConnectRowMeta(item.plugin),
+      importedLocally: Boolean(item.importedPlugin),
       plugin: item.plugin,
     }];
   });
@@ -608,7 +610,14 @@ function ConnectOrganizationRow(props: {
         iconSrc={pluginManifest?.icon?.src}
       />
       <div className="min-w-0 flex-1">
-        <div className="truncate text-sm font-semibold text-dls-text">{row.name}</div>
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <span className="truncate text-sm font-semibold text-dls-text">{row.name}</span>
+          {row.kind === "plugin" && row.importedLocally ? (
+            <span className="shrink-0 rounded-md border border-amber-6/40 bg-amber-3/40 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+              {t("connect.marketplace_local_copy_badge")}
+            </span>
+          ) : null}
+        </div>
         <div className="truncate text-xs text-dls-secondary">{row.meta}</div>
       </div>
       {row.group === "needs_signin" && connectableConnectionId ? (
@@ -619,7 +628,7 @@ function ConnectOrganizationRow(props: {
             className={needsReconnect ? "border border-amber-6 bg-amber-2 text-amber-11 hover:bg-amber-3" : undefined}
             onClick={() => props.onConnect(connectableConnectionId)}
           >
-            {connecting ? t("connect.waiting_for_browser") : needsReconnect ? t("mcp.org_connection_reconnect_action") : t("connect.row_action_connect")}
+            {connecting ? t("connect.waiting_for_browser") : needsReconnect ? t("mcp.org_connection_reconnect_action") : t("mcp.org_connection_connect_action")}
           </Button>
           {disconnectableConnectionId ? (
             <Button size="sm" variant="destructive" disabled={disconnecting} onClick={() => props.onDisconnect(disconnectableConnectionId)}>

--- a/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
@@ -4,7 +4,6 @@ import { Cpu } from "lucide-react";
 
 import { t } from "../../../../i18n";
 import { Button } from "@/components/ui/button";
-import { useConnectEnabled } from "@/react-app/domains/cloud/desktop-config-provider";
 import { shouldShowExtensionsMarketplacePane } from "@/react-app/domains/settings/connect-delivery";
 
 import { PluginsView, type PluginsExtensionsStore } from "./plugins-view";
@@ -51,8 +50,7 @@ export type ExtensionsViewProps = {
 
 export function ExtensionsView(props: ExtensionsViewProps) {
   const [view, setView] = useState<"my" | "marketplace">("my");
-  const connectEnabled = useConnectEnabled();
-  const showMarketplacePane = shouldShowExtensionsMarketplacePane(connectEnabled);
+  const showMarketplacePane = shouldShowExtensionsMarketplacePane();
   const activeView = showMarketplacePane ? view : "my";
   const pluginCount = useMemo(
     () => props.extensions.pluginList().length,
@@ -76,15 +74,6 @@ export function ExtensionsView(props: ExtensionsViewProps) {
           {t("common.refresh")}
         </Button>
       </div>
-
-      {connectEnabled === true ? (
-        <div className="flex flex-col gap-2 rounded-xl border border-dls-border bg-dls-surface px-4 py-3 text-sm text-dls-secondary sm:flex-row sm:items-center sm:justify-between">
-          <span>{t("extensions.connect_marketplace_split_hint")}</span>
-          <Button size="sm" variant="outline" className="w-fit" onClick={props.onOpenConnect}>
-            {t("extensions.open_connect")}
-          </Button>
-        </div>
-      ) : null}
 
       {showMarketplacePane ? (
         <div className="flex w-fit rounded-xl border border-dls-border bg-dls-surface p-1">

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -1616,8 +1616,8 @@ export function createExtensionsStore(options: {
                 title: "New extension available",
                 body: `${plugin.name ?? plugin.id} was added to ${marketplaceName}`,
                 dedupeKey: `new-marketplace-plugin:${plugin.id}`,
-                action: { type: "install-marketplace-plugin", pluginName: plugin.name ?? plugin.id },
-                actionLabel: "View and install",
+                action: { type: "open-extensions-marketplace", pluginName: plugin.name ?? plugin.id },
+                actionLabel: "View in Marketplace",
               });
             }
           }

--- a/apps/app/src/react-app/shell/notification-center.tsx
+++ b/apps/app/src/react-app/shell/notification-center.tsx
@@ -119,7 +119,6 @@ export function NotificationBell() {
         }
         navigate("/settings/cloud-marketplaces");
       } else if (action.type === "install-marketplace-plugin") {
-        requestOpenMarketplacePlugin(action.pluginName);
         navigate("/settings/cloud-marketplaces");
       }
     },

--- a/apps/app/tests/cloud-marketplaces-view.test.ts
+++ b/apps/app/tests/cloud-marketplaces-view.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { shouldShowMarketplaceRows } from "../src/react-app/domains/settings/pages/cloud-marketplaces-view";
+import {
+  shouldIncludeCloudMarketplacePluginRow,
+  shouldIncludeOrgMcpConnectionMarketplaceRow,
+  shouldShowMarketplaceRows,
+} from "../src/react-app/domains/settings/pages/cloud-marketplaces-view";
 
 describe("Cloud marketplace row visibility", () => {
   test("hides marketplace rows until a signed-in org is available", () => {
@@ -8,5 +12,15 @@ describe("Cloud marketplace row visibility", () => {
     expect(shouldShowMarketplaceRows(true, "")).toBe(false);
     expect(shouldShowMarketplaceRows(true, "   ")).toBe(false);
     expect(shouldShowMarketplaceRows(true, "org_1")).toBe(true);
+  });
+
+  test("keeps Den organization plugins out of the embedded Extensions Marketplace pane", () => {
+    expect(shouldIncludeCloudMarketplacePluginRow({ embedded: false })).toBe(true);
+    expect(shouldIncludeCloudMarketplacePluginRow({ embedded: true })).toBe(false);
+  });
+
+  test("keeps organization MCP connections out of both Marketplace surfaces", () => {
+    expect(shouldIncludeOrgMcpConnectionMarketplaceRow({ embedded: false })).toBe(false);
+    expect(shouldIncludeOrgMcpConnectionMarketplaceRow({ embedded: true })).toBe(false);
   });
 });

--- a/apps/app/tests/connect-delivery.test.ts
+++ b/apps/app/tests/connect-delivery.test.ts
@@ -8,17 +8,10 @@ import {
 describe("Connect delivery switch decisions", () => {
   test("keeps the Extensions marketplace pane in both rollout modes", () => {
     expect(shouldShowExtensionsMarketplacePane()).toBe(true);
-    expect(shouldShowExtensionsMarketplacePane(false)).toBe(true);
-    expect(shouldShowExtensionsMarketplacePane(true)).toBe(true);
   });
 
-  test("keeps desktop import actions outside Connect mode", () => {
-    expect(resolveMarketplaceDeliveryAction({ importedLocally: false })).toBe("install");
-    expect(resolveMarketplaceDeliveryAction({ connectEnabled: false, importedLocally: true })).toBe("install");
-  });
-
-  test("moves marketplace cards to cloud-active states in Connect mode", () => {
-    expect(resolveMarketplaceDeliveryAction({ connectEnabled: true, importedLocally: false })).toBe("cloud_active");
-    expect(resolveMarketplaceDeliveryAction({ connectEnabled: true, importedLocally: true })).toBe("cloud_active_local_copy");
+  test("always delivers organization marketplace cards through Connect", () => {
+    expect(resolveMarketplaceDeliveryAction({ importedLocally: false })).toBe("cloud_active");
+    expect(resolveMarketplaceDeliveryAction({ importedLocally: true })).toBe("cloud_active_local_copy");
   });
 });

--- a/apps/app/tests/connect-view.test.ts
+++ b/apps/app/tests/connect-view.test.ts
@@ -191,7 +191,7 @@ describe("Connect cloud-readiness row resolution", () => {
     })).toBe("needs_signin");
   });
 
-  test("filters Extensions marketplace rows to desktop-installable plugins in Connect mode", () => {
+  test("classifies desktop-only marketplace plugins for Connect exclusion", () => {
     expect(isDesktopInstallableMarketplacePlugin({ componentCounts: {}, cloudReadiness: { state: "desktop_only", hasInstructional: false, connections: [] } })).toBe(true);
     expect(isDesktopInstallableMarketplacePlugin({ componentCounts: {}, cloudReadiness: { state: "ready", hasInstructional: true, connections: [] } })).toBe(false);
     expect(isDesktopInstallableMarketplacePlugin({ componentCounts: { tool: 1 } })).toBe(true);

--- a/evals/browser-extension-flows.md
+++ b/evals/browser-extension-flows.md
@@ -273,28 +273,28 @@ Known regressions this catches:
 - Hidden state not re-rendering after the custom extension-state event.
 - `Show hidden` acting like a destructive uninstall instead of a reversible view preference.
 
-## Flow 9 — Cloud marketplace appears in Extensions Marketplace
+## Flow 9 — Organization marketplace is Connect-only
 
-**Why**: Organization marketplaces are now reached from Extensions ->
-Marketplace, not Cloud settings. This flow verifies the marketplace import path
-still works from the new IA.
+**Why**: Organization marketplace extensions now run through OpenWork Connect,
+not local marketplace installs. This flow verifies cloud delivery stays visible
+without exposing the retired Add/import path.
 
 Steps:
 1. Sign in to OpenWork Cloud with an org that has a marketplace plugin.
-2. Open Settings -> Extensions.
-3. Click `Marketplace`.
-4. Verify marketplace packages are visible in one searchable list.
-5. Click `Refresh` in the Marketplace view.
-6. Add an available package.
+2. Open Settings -> Connect and verify the org extension appears under From your organization.
+3. Open Settings -> Marketplace and verify the same package says `Runs in cloud`.
+4. Confirm no `Add`, `Install`, or `Update` action is shown for the org package.
+5. Open Settings -> Extensions -> Marketplace.
+6. Confirm the org package is absent there.
 
 Pass criteria:
-- Cloud sidebar does not show a separate Marketplace item.
-- The marketplace package is visible from Settings -> Extensions -> Marketplace.
-- Add succeeds and reports the number of imported files.
-- The imported package appears in My Extensions.
+- The marketplace package is visible in Connect as organization cloud content.
+- The organization Marketplace presents the package as cloud-active.
+- No local Add/Install/Update action is available for the org package.
+- Extensions Marketplace stays local-only and does not list the org package.
 - Existing Cloud Account, Providers, and Workers settings remain available.
 
 Known regressions this catches:
-- Marketplace still only reachable through Cloud settings.
-- Marketplace import losing the active org context after moving into Extensions.
-- Extensions refresh not refreshing cloud marketplace data.
+- Org marketplace packages leaking back into local Extensions.
+- The retired local marketplace import path reappearing.
+- Connect delivery losing the active org context.

--- a/evals/desktop-org-mcp-demo.md
+++ b/evals/desktop-org-mcp-demo.md
@@ -34,10 +34,9 @@ per-member credentials, org-wide access.
 *Assert:* connection listed in the admin screen with credential mode and
 access visible; API `scope=manageable` contains it.
 
-**2. ★ Member discovers it in Marketplace** (`desktop-org-mcp-marketplace.png`)
-Jordan's desktop, `Settings -> Extensions -> Marketplace`: the connection
-appears in the same catalog as marketplace plugins, action
-`Connect your account`, provenance "Shared by your organization".
+**2. ★ Member discovers it in OpenWork Connect** (`desktop-org-mcp-connect.png`)
+Jordan's desktop, `Settings -> Connect`: the connection appears under
+Needs your sign-in with action `Connect your account`.
 *Assert:* card text present; `My Extensions` does NOT list it yet.
 
 **3. Real click, real OAuth**
@@ -48,10 +47,10 @@ after the click, carrying a signed `state`, a dynamically-registered
 `client_id`, and a `redirect_uri` scoped to this connection. No client-side
 stubs — Electron's contextBridge freezes exposed APIs, so nothing is faked.
 
-**4. ★ Card flips, no reload** (`desktop-org-mcp-connected.png`)
-Without navigation, the same card flips to `Connected` (the app's own
-polling loop) and the item now renders under `My Extensions`.
-*Assert:* "Connect your account" gone; "Connected" present; server-side
+**4. ★ Connect row flips, no reload** (`desktop-org-mcp-connected.png`)
+Without navigation, the same Connect row flips to `Ready` (the app's own
+polling loop).
+*Assert:* "Connect your account" gone; "Ready" present; server-side
 `connectedForMe: true` for Jordan.
 
 **5. ★ The agent uses it in real chat** (`desktop-org-mcp-chat.png`)
@@ -87,9 +86,8 @@ Extensions with zero org items and zero errors.
 From `evals/org-mcp-connections-ux.md` Phase 1, on top of what #2439 already
 has:
 
-1. Rework: org connections merge into the Extensions catalog tabs as
-   `ExtensionItem` source `org-connection` (replaces the interim
-   "From your organization" section). Frames 2 and 4 depend on this.
+1. Rework: org connections render in OpenWork Connect as organization rows.
+   Frames 2 and 4 depend on this.
 2. Dedup-with-degradation-guard for static suggestions. Frame 6 asserts the
    static grid — with the mock connection there's no name collision, so the
    rule is exercised by a unit test rather than this demo.

--- a/evals/flows/admin-to-member-marketplace.flow.mjs
+++ b/evals/flows/admin-to-member-marketplace.flow.mjs
@@ -1,9 +1,9 @@
 /**
  * End-to-end: owner creates a skill, shares it to the org marketplace via MCP,
- * and the member discovers it via notification and installs it.
+ * and the member discovers it through the cloud-delivered marketplace surface.
  *
  * Uses control actions wherever possible; falls back to ctx.clickText for the
- * few steps that should go through the real UI (marketplace install dialog).
+ * few steps that should go through the real UI.
  *
  * Required env:
  * - OPENWORK_EVAL_DEN_API_URL    Den API base (e.g. http://localhost:8788)
@@ -12,7 +12,7 @@
  */
 export default {
   id: "admin-to-member-marketplace",
-  title: "Owner creates skill, shares via MCP, member discovers and installs from marketplace",
+  title: "Owner creates skill, shares via MCP, member discovers it from the marketplace",
   spec: "evals/react-session-flows.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_WORKSPACE_PATH"],
   steps: [

--- a/evals/flows/cloud-plugin-mcp-warning.flow.mjs
+++ b/evals/flows/cloud-plugin-mcp-warning.flow.mjs
@@ -281,22 +281,9 @@ async function ensureRenderedApp(ctx) {
   });
 }
 
-async function useMarketplaceImportMode(ctx) {
-  await ctx.waitFor(
-    `(() => {
-      const bridge = window.__openworkApplyDesktopConfig;
-      if (typeof bridge !== "function") return false;
-      bridge({ connectEnabled: false });
-      return document.body.innerText.includes("Extension Marketplace");
-    })()`,
-    { timeoutMs: 20_000, label: "marketplace import mode" },
-  );
-}
-
 async function openMarketplace(ctx) {
   await ensureRenderedApp(ctx);
   await openWorkspaceSettings(ctx, "cloud-marketplaces");
-  await useMarketplaceImportMode(ctx);
   await ctx.waitForText("Marketplace", { timeoutMs: 30_000 });
   const hasRefresh = await ctx.eval(
     "Boolean(window.__openworkControl?.listActions().find(a => a.id === 'extensions.refresh-marketplace'))",
@@ -304,7 +291,6 @@ async function openMarketplace(ctx) {
   if (hasRefresh) {
     await ctx.control("extensions.refresh-marketplace");
   }
-  await useMarketplaceImportMode(ctx);
   await ctx.waitForText(BROKEN_PLUGIN_NAME, { timeoutMs: 45_000 });
   await ctx.waitForText(VALID_PLUGIN_NAME, { timeoutMs: 45_000 });
 }
@@ -317,11 +303,26 @@ async function searchMarketplace(ctx, value) {
   );
 }
 
-async function installMarketplacePlugin(ctx, pluginName) {
+async function openMarketplacePluginDetail(ctx, pluginName) {
   await searchMarketplace(ctx, pluginName);
   await ctx.clickText(pluginName, { selector: "button", timeoutMs: 20_000 });
   await ctx.waitForText("COMPOSITION", { timeoutMs: 20_000 });
-  await ctx.clickText("Add", { selector: '[role="dialog"] button', timeoutMs: 20_000 });
+}
+
+async function readMarketplacePluginDialog(ctx) {
+  return ctx.eval(`(() => {
+    const compact = (entry) => (entry?.innerText ?? entry?.textContent ?? '').replace(/\\s+/g, ' ').trim();
+    const dialog = document.querySelector('[role="dialog"]');
+    return {
+      text: compact(dialog),
+      buttonTexts: [...(dialog?.querySelectorAll('button') ?? [])].map(compact),
+    };
+  })()`);
+}
+
+function assertNoDialogInstallButtons(ctx, state) {
+  const forbidden = state.buttonTexts.filter((text) => ["Add", "Install", "Update"].includes(text));
+  ctx.assert(forbidden.length === 0, `Removed marketplace install/update buttons rendered in dialog: ${JSON.stringify(forbidden)}`);
 }
 
 async function workspaceServerJson(ctx, path) {
@@ -344,30 +345,6 @@ async function workspaceServerJson(ctx, path) {
   })()`, { awaitPromise: true });
 }
 
-async function waitForSkill(ctx, skillName) {
-  await ctx.waitFor(
-    `window.__OPENWORK_ELECTRON__?.invokeDesktop ? true : false`,
-    { timeoutMs: 15_000, label: "Electron bridge for skill check" },
-  );
-  await ctx.waitFor(
-    `(async () => {
-      const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
-      const info = await bridge("openworkServerInfo");
-      const baseUrl = String(info?.baseUrl ?? "").replace(/\\/+$/, "");
-      const token = String(info?.ownerToken || info?.clientToken || "").trim();
-      const workspaceId = (location.hash.match(/\\/workspace\\/([^/]+)/) || [])[1] || localStorage.getItem("openwork.react.activeWorkspace") || "";
-      if (!baseUrl || !token || !workspaceId) return false;
-      const response = await fetch(baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/skills", {
-        headers: { authorization: "Bearer " + token },
-      });
-      if (!response.ok) return false;
-      const body = await response.json();
-      return Array.isArray(body.items) && body.items.some((item) => item.name === ${JSON.stringify(skillName)});
-    })()`,
-    { timeoutMs: 45_000, label: `workspace skill ${skillName}` },
-  );
-}
-
 async function readMcpState(ctx) {
   const body = await workspaceServerJson(ctx, "/mcp");
   const names = Array.isArray(body.items) ? body.items.map((item) => item.name) : [];
@@ -380,28 +357,10 @@ async function assertNoBrokenMcp(ctx) {
   ctx.log(`MCP servers after broken install: ${JSON.stringify(mcp.names)}`);
 }
 
-async function assertLinearMcpSynced(ctx) {
-  await ctx.waitFor(
-    `(async () => {
-      const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
-      if (!bridge) return false;
-      const info = await bridge("openworkServerInfo");
-      const baseUrl = String(info?.baseUrl ?? "").replace(/\\/+$/, "");
-      const token = String(info?.ownerToken || info?.clientToken || "").trim();
-      const workspaceId = (location.hash.match(/\\/workspace\\/([^/]+)/) || [])[1] || localStorage.getItem("openwork.react.activeWorkspace") || "";
-      if (!baseUrl || !token || !workspaceId) return false;
-      const response = await fetch(baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/mcp", {
-        headers: { authorization: "Bearer " + token },
-      });
-      if (!response.ok) return false;
-      const body = await response.json();
-      return Array.isArray(body.items) && body.items.some((item) => item.name === "linear") && body.engineSync?.status === "ok";
-    })()`,
-    { timeoutMs: 45_000, label: "linear MCP in server list with ok engine sync" },
-  );
-  const mcp = await readMcpState(ctx);
-  ctx.assert(mcp.engineSync?.status === "ok", `Expected engine sync ok, got ${JSON.stringify(mcp.engineSync)}`);
-  ctx.log(`MCP servers after valid install: ${JSON.stringify(mcp)}`);
+async function assertNoSkill(ctx, skillName) {
+  const body = await workspaceServerJson(ctx, "/skills");
+  const names = Array.isArray(body.items) ? body.items.map((item) => item.name) : [];
+  ctx.assert(!names.includes(skillName), `Skill ${skillName} should not have been installed locally: ${JSON.stringify(names)}`);
 }
 
 async function openMcpSettings(ctx) {
@@ -412,18 +371,9 @@ async function openMcpSettings(ctx) {
   await ctx.clickText("Refresh", { selector: "button", timeoutMs: 10_000 }).catch(() => {});
 }
 
-async function scrollConfiguredServer(ctx, text) {
-  await ctx.eval(`(() => {
-    const rows = [...document.querySelectorAll("button")];
-    const target = rows.find((button) => (button.textContent ?? "").toLowerCase().includes(${JSON.stringify(text.toLowerCase())}));
-    if (target) target.scrollIntoView({ block: "center" });
-    return Boolean(target);
-  })()`);
-}
-
 export default {
   id: FLOW_ID,
-  title: "Cloud marketplace plugins warn on malformed MCP payloads and hot-sync valid MCPs",
+  title: "Retired local import warning path: marketplace plugins are cloud-delivered only",
   kind: "user-facing",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_WORKSPACE_PATH"],
   steps: [
@@ -441,7 +391,7 @@ export default {
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("Signed-in user sees both org marketplace plugins", {
+        await ctx.prove("Signed-in user sees both org marketplace plugins as cloud-delivered", {
           voiceover: vo[0],
           action: async () => {
             await openMarketplace(ctx);
@@ -450,10 +400,11 @@ export default {
           assert: async () => {
             await ctx.expectText(BROKEN_PLUGIN_NAME);
             await ctx.expectText(VALID_PLUGIN_NAME);
+            await ctx.expectText("Runs in cloud");
           },
           screenshot: {
             name: "marketplace-shows-bundles",
-            requireText: ["Marketplace", BROKEN_PLUGIN_NAME, VALID_PLUGIN_NAME],
+            requireText: ["Marketplace", BROKEN_PLUGIN_NAME, VALID_PLUGIN_NAME, "Runs in cloud"],
             rejectText: ["Something went wrong"],
             hashIncludes: "/settings/cloud-marketplaces",
           },
@@ -463,20 +414,22 @@ export default {
     {
       name: "Frame 2",
       run: async (ctx) => {
-        await ctx.prove("Broken MCP bundle imports the skill and surfaces a warning", {
+        await ctx.prove("The old broken-bundle import path is retired and exposes no Add action", {
           voiceover: vo[1],
           action: async () => {
-            await installMarketplacePlugin(ctx, BROKEN_PLUGIN_NAME);
-            await ctx.waitForText("could not be installed", { timeoutMs: 20_000 });
+            await openMarketplacePluginDetail(ctx, BROKEN_PLUGIN_NAME);
           },
           assert: async () => {
-            await ctx.expectText(VALID_WARNING, { timeoutMs: 5_000 });
-            await waitForSkill(ctx, BROKEN_SKILL_NAME);
+            const dialog = await readMarketplacePluginDialog(ctx);
+            ctx.assert(dialog.text.includes("Active · runs in cloud"), `Cloud-active status missing: ${dialog.text}`);
+            assertNoDialogInstallButtons(ctx, dialog);
+            await ctx.expectNoText(VALID_WARNING);
+            await assertNoSkill(ctx, BROKEN_SKILL_NAME);
             await assertNoBrokenMcp(ctx);
           },
           screenshot: {
-            name: "broken-install-warning-toast",
-            requireText: ["could not be installed"],
+            name: "broken-bundle-cloud-only-detail",
+            requireText: [BROKEN_PLUGIN_NAME, "Active · runs in cloud"],
             rejectText: ["Something went wrong"],
             hashIncludes: "/settings/cloud-marketplaces",
           },
@@ -486,23 +439,17 @@ export default {
     {
       name: "Frame 3",
       run: async (ctx) => {
-        await ctx.prove("Persistent state shows skill installed and no broken MCP row", {
+        await ctx.prove("Persistent local state stays untouched after viewing the broken bundle", {
           voiceover: vo[2],
           action: async () => {
-            await ctx.waitFor(
-              `!document.body.innerText.includes(${JSON.stringify("could not be installed")})`,
-              { timeoutMs: 15_000, label: "warning toast dismissed" },
-            );
-            await openWorkspaceSettings(ctx, "extensions/skills");
-            await ctx.waitForText(BROKEN_PLUGIN_NAME, { timeoutMs: 30_000 });
             await openMcpSettings(ctx);
           },
           assert: async () => {
-            await waitForSkill(ctx, BROKEN_SKILL_NAME);
+            await assertNoSkill(ctx, BROKEN_SKILL_NAME);
             await assertNoBrokenMcp(ctx);
           },
           screenshot: {
-            name: "mcp-settings-no-broken-row",
+            name: "mcp-settings-still-no-broken-row",
             requireText: ["Add Custom App", "MCPs", "YOUR APPS"],
             rejectText: ["Something went wrong", BROKEN_PLUGIN_NAME, "Broken MCP"],
             hashIncludes: "/settings/extensions/mcp",
@@ -513,30 +460,25 @@ export default {
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("Valid remote MCP installs and appears without manual reload", {
+        await ctx.prove("The valid remote MCP bundle is also cloud-only with no local install", {
           voiceover: vo[3],
           action: async () => {
             await openMarketplace(ctx);
-            await installMarketplacePlugin(ctx, VALID_PLUGIN_NAME);
-            await ctx.waitForText(`Imported ${VALID_PLUGIN_NAME}`, { timeoutMs: 30_000 });
-            await openMcpSettings(ctx);
-            await ctx.waitForText("linear", { timeoutMs: 45_000 });
-            await scrollConfiguredServer(ctx, "linear");
+            await openMarketplacePluginDetail(ctx, VALID_PLUGIN_NAME);
           },
           assert: async () => {
-            await waitForSkill(ctx, slugify(VALID_SKILL_TITLE));
-            await assertLinearMcpSynced(ctx);
-            const visible = await ctx.eval(`(() => {
-              const text = document.body.innerText.toLowerCase();
-              return text.includes("linear") && text.includes("your apps");
-            })()`);
-            ctx.assert(visible, "Linear MCP is not visible in the MCP settings view.");
+            const dialog = await readMarketplacePluginDialog(ctx);
+            ctx.assert(dialog.text.includes("Active · runs in cloud"), `Cloud-active status missing: ${dialog.text}`);
+            assertNoDialogInstallButtons(ctx, dialog);
+            await assertNoSkill(ctx, slugify(VALID_SKILL_TITLE));
+            const mcp = await readMcpState(ctx);
+            ctx.assert(!mcp.names.includes("linear"), `Linear MCP should not have been installed locally: ${JSON.stringify(mcp.names)}`);
           },
           screenshot: {
-            name: "linear-mcp-hot-synced",
-            requireText: ["Add Custom App", "linear"],
+            name: "valid-bundle-cloud-only-detail",
+            requireText: [VALID_PLUGIN_NAME, "Active · runs in cloud"],
             rejectText: ["Something went wrong"],
-            hashIncludes: "/settings/extensions/mcp",
+            hashIncludes: "/settings/cloud-marketplaces",
           },
         });
       },

--- a/evals/flows/connect-cloud-partition.flow.mjs
+++ b/evals/flows/connect-cloud-partition.flow.mjs
@@ -121,24 +121,23 @@ export default {
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("Extensions Marketplace in Connect mode shows only desktop-installable marketplace content", {
+        await ctx.prove("Extensions Marketplace keeps organization marketplace plugins out of the legacy pane", {
           voiceover: vo[3],
           action: async () => {
             await openExtensionsMarketplace(ctx);
-            await waitForMarketplacePlugin(ctx, DESKTOP_PLUGIN_NAME);
           },
           assert: async () => {
             const proof = await readExtensionsMarketplaceState(ctx, DESKTOP_PLUGIN_NAME);
-            ctx.assert(proof.pageText.includes("installs on this machine"), "Filtered marketplace heading missing.");
-            ctx.assert(proof.pluginCardText.includes(DESKTOP_PLUGIN_NAME), `Desktop-only plugin missing: ${proof.pluginCardText}`);
-            ctx.assert(proof.pluginCardText.includes("Add"), `Install action missing: ${proof.pluginCardText}`);
+            ctx.assert(proof.pageText.includes("Extension Marketplace"), "Extensions Marketplace heading missing.");
             ctx.assert(!proof.pageText.includes(READY_PLUGIN_NAME), `Ready cloud plugin leaked into Extensions marketplace: ${proof.pageText}`);
+            ctx.assert(!proof.pageText.includes(NEEDS_SETUP_PLUGIN_NAME), `Needs-setup plugin leaked into Extensions marketplace: ${proof.pageText}`);
+            ctx.assert(!proof.pageText.includes(DESKTOP_PLUGIN_NAME), `Desktop-only plugin leaked into Extensions marketplace: ${proof.pageText}`);
           },
           screenshot: {
-            name: "connect-partition-extensions-desktop-filter",
-            claim: "Extensions Marketplace shows only desktop-installable marketplace content in Connect mode.",
-            requireText: ["installs on this machine", DESKTOP_PLUGIN_NAME, "Add"],
-            rejectText: [READY_PLUGIN_NAME, "Something went wrong"],
+            name: "connect-partition-extensions-no-den-plugins",
+            claim: "Extensions Marketplace no longer renders organization marketplace plugins as local installs.",
+            requireText: ["Extension Marketplace"],
+            rejectText: [READY_PLUGIN_NAME, NEEDS_SETUP_PLUGIN_NAME, DESKTOP_PLUGIN_NAME, "Something went wrong"],
           },
         });
       },
@@ -559,7 +558,7 @@ async function openExtensionsMarketplace(ctx) {
   await navigateToSettingsTab(ctx, "extensions");
   await ctx.waitForText("My Extensions", { timeoutMs: 30_000 });
   await ctx.clickText("Marketplace", { selector: "button", timeoutMs: 30_000 });
-  await ctx.waitForText("installs on this machine", { timeoutMs: 30_000 });
+  await ctx.waitForText("Extension Marketplace", { timeoutMs: 30_000 });
   await ctx.control("extensions.refresh-marketplace").catch(() => {});
 }
 
@@ -569,22 +568,11 @@ async function waitForConnectText(ctx, text) {
     const found = await ctx.eval(`document.body.innerText.includes(${JSON.stringify(text)})`);
     if (found) return;
     // The marketplace store serves a cached snapshot after remounts — force a
-    // refetch while polling, mirroring waitForMarketplacePlugin.
+    // refetch while polling.
     await ctx.control("extensions.refresh-marketplace").catch(() => {});
     await sleep(2_000);
   }
   ctx.assert(false, `Connect text did not render: ${text}`);
-}
-
-async function waitForMarketplacePlugin(ctx, name) {
-  const deadline = Date.now() + 90_000;
-  while (Date.now() < deadline) {
-    const found = await ctx.eval(`document.body.innerText.includes(${JSON.stringify(name)})`);
-    if (found) return;
-    await ctx.control("extensions.refresh-marketplace").catch(() => {});
-    await sleep(2_000);
-  }
-  ctx.assert(false, `Marketplace plugin did not render: ${name}`);
 }
 
 async function scrollConnectGroup(ctx, group) {

--- a/evals/flows/connect-delivery-switch.flow.mjs
+++ b/evals/flows/connect-delivery-switch.flow.mjs
@@ -30,7 +30,7 @@ const state = {
 
 export default {
   id: FLOW_ID,
-  title: "Connect-mode delivery switch moves marketplace plugins from desktop import to the cloud rail",
+  title: "Retired delivery switch: marketplace plugins stay cloud-delivered regardless of the Connect flag",
   kind: "user-facing",
   spec: "evals/voiceovers/connect-delivery-switch.md",
   requiredEnv: [
@@ -43,27 +43,26 @@ export default {
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("With Connect off, Extensions still exposes the installable Marketplace pane", {
+        await ctx.prove("With Connect off, the organization marketplace still shows cloud delivery only", {
           voiceover: vo[0],
           action: async () => {
             await prepareSignedInDesktopWithConnectOff(ctx);
-            await openExtensionsMarketplace(ctx);
+            await navigateToSettingsTab(ctx, "cloud-marketplaces");
             await waitForMarketplacePlugin(ctx, PLUGIN_NAME);
           },
           assert: async () => {
             const proof = await readExtensionsMarketplaceState(ctx, PLUGIN_NAME);
-            ctx.assert(proof.buttonTexts.includes("My Extensions"), `My Extensions toggle missing: ${JSON.stringify(proof.buttonTexts)}`);
-            ctx.assert(proof.buttonTexts.includes("Marketplace"), `Marketplace toggle missing: ${JSON.stringify(proof.buttonTexts)}`);
             ctx.assert(proof.pageText.includes("Extension Marketplace"), "Marketplace pane did not render.");
             ctx.assert(proof.pluginCardText.includes(PLUGIN_NAME), `Seed plugin card missing: ${proof.pluginCardText}`);
-            ctx.assert(proof.pluginCardText.includes("Add"), `Seed plugin was not installable: ${proof.pluginCardText}`);
-            ctx.assert(!proof.pluginCardText.includes("Runs in cloud"), `Connect cloud label leaked with flag off: ${proof.pluginCardText}`);
+            ctx.assert(proof.pluginCardText.includes("Runs in cloud"), `Cloud delivery action missing with flag off: ${proof.pluginCardText}`);
+            ctx.assert(!proof.pluginCardText.includes("Add"), `Seed plugin exposed Add with flag off: ${proof.pluginCardText}`);
+            assertNoMarketplaceInstallButtons(ctx, proof);
           },
           screenshot: {
-            name: "connect-delivery-flag-off-marketplace-installable",
-            claim: "Flag off keeps the Extensions Marketplace toggle and an installable marketplace plugin.",
-            requireText: ["My Extensions", "Marketplace", PLUGIN_NAME, "Add"],
-            rejectText: ["Cloud-runnable marketplace apps live in Connect.", "Runs in cloud", "Something went wrong"],
+            name: "connect-delivery-flag-off-cloud-only",
+            claim: "Flag off no longer restores the desktop install action; the marketplace row runs in cloud.",
+            requireText: ["Extension Marketplace", PLUGIN_NAME, "Runs in cloud"],
+            rejectText: ["Something went wrong"],
           },
         });
       },
@@ -71,30 +70,24 @@ export default {
     {
       name: "Frame 2",
       run: async (ctx) => {
-        await ctx.prove("With Connect on, the Extensions Marketplace tab filters to machine-installable items and points cloud content at Connect", {
+        await ctx.prove("With Connect on, Extensions Marketplace still excludes organization plugins", {
           voiceover: vo[1],
           action: async () => {
             await setCapabilityViaAdminApi(ctx, { mcpConnections: true });
             await remountDesktop(ctx);
-            await navigateToSettingsTab(ctx, "extensions");
-            await ctx.waitForText("Cloud-runnable marketplace apps live in Connect.", { timeoutMs: 60_000 });
             await openExtensionsMarketplace(ctx);
-            await ctx.waitForText("installs on this machine", { timeoutMs: 30_000 });
           },
           assert: async () => {
             const proof = await readExtensionsMarketplaceState(ctx, PLUGIN_NAME);
-            ctx.assert(proof.pageText.includes("Cloud-runnable marketplace apps live in Connect."), "Runtime-split hint missing.");
-            ctx.assert(proof.buttonTexts.includes("Open Connect"), `Open Connect button missing: ${JSON.stringify(proof.buttonTexts)}`);
             ctx.assert(proof.buttonTexts.includes("My Extensions"), `My Extensions toggle should stay: ${JSON.stringify(proof.buttonTexts)}`);
             ctx.assert(proof.buttonTexts.includes("Marketplace"), `Marketplace toggle should stay: ${JSON.stringify(proof.buttonTexts)}`);
-            ctx.assert(proof.pageText.includes("installs on this machine"), "Filtered marketplace heading missing.");
-            ctx.assert(!proof.pluginCardText.includes(PLUGIN_NAME), `Cloud-runnable plugin leaked into the machine pane: ${proof.pluginCardText}`);
+            ctx.assert(proof.pageText.includes("Extension Marketplace"), "Extensions Marketplace heading missing.");
             ctx.assert(!proof.pageText.includes(PLUGIN_NAME), "Cloud-runnable plugin name rendered in Extensions marketplace pane.");
           },
           screenshot: {
-            name: "connect-delivery-flag-on-extensions-hint",
-            claim: "Flag on keeps the Marketplace tab but filters it to items that install on this machine.",
-            requireText: ["installs on this machine", "Open Connect"],
+            name: "connect-delivery-extensions-no-org-plugin",
+            claim: "Extensions Marketplace is local-only and excludes organization marketplace plugins.",
+            requireText: ["My Extensions", "Marketplace", "Extension Marketplace"],
             rejectText: [PLUGIN_NAME, "Something went wrong"],
           },
         });
@@ -106,8 +99,7 @@ export default {
         await ctx.prove("Connect active state lists the seeded marketplace plugin as cloud-run with no install action", {
           voiceover: vo[2],
           action: async () => {
-            await ctx.clickText("Open Connect", { selector: "button", timeoutMs: 30_000 });
-            await ctx.waitFor("window.location.hash.includes('/settings/connect')", { timeoutMs: 30_000, label: "connect settings route" });
+            await navigateToSettingsTab(ctx, "connect");
             await waitForConnectOrganizationRow(ctx, PLUGIN_NAME);
             await ctx.eval("document.querySelector('[data-testid=\"connect-organization-section\"]')?.scrollIntoView({ block: 'center' })");
           },
@@ -133,26 +125,25 @@ export default {
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("Turning Connect back off restores the Extensions Marketplace toggle and install action", {
+        await ctx.prove("Turning Connect back off does not restore the removed install action", {
           voiceover: vo[3],
           action: async () => {
             await setCapabilityViaAdminApi(ctx, { mcpConnections: false });
             await remountDesktop(ctx);
-            await openExtensionsMarketplace(ctx);
+            await navigateToSettingsTab(ctx, "cloud-marketplaces");
             await waitForMarketplacePlugin(ctx, PLUGIN_NAME);
           },
           assert: async () => {
             const proof = await readExtensionsMarketplaceState(ctx, PLUGIN_NAME);
-            ctx.assert(proof.buttonTexts.includes("My Extensions"), `My Extensions toggle did not return: ${JSON.stringify(proof.buttonTexts)}`);
-            ctx.assert(proof.buttonTexts.includes("Marketplace"), `Marketplace toggle did not return: ${JSON.stringify(proof.buttonTexts)}`);
-            ctx.assert(proof.pluginCardText.includes("Add"), `Seed plugin was not installable after restore: ${proof.pluginCardText}`);
-            ctx.assert(!proof.pageText.includes("Cloud-runnable marketplace apps live in Connect."), "Runtime-split hint persisted after capability off.");
+            ctx.assert(proof.pluginCardText.includes("Runs in cloud"), `Cloud delivery action missing after flag restore: ${proof.pluginCardText}`);
+            ctx.assert(!proof.pluginCardText.includes("Add"), `Seed plugin exposed Add after flag restore: ${proof.pluginCardText}`);
+            assertNoMarketplaceInstallButtons(ctx, proof);
           },
           screenshot: {
-            name: "connect-delivery-flag-off-restored",
-            claim: "Flag off restores the old Extensions Marketplace pane with the install action.",
-            requireText: ["Extension Marketplace", PLUGIN_NAME, "Add"],
-            rejectText: ["Cloud-runnable marketplace apps live in Connect.", "Runs in cloud", "Something went wrong"],
+            name: "connect-delivery-flag-off-still-cloud-only",
+            claim: "Flag off still leaves organization marketplace delivery on the cloud rail only.",
+            requireText: ["Extension Marketplace", PLUGIN_NAME, "Runs in cloud"],
+            rejectText: ["Something went wrong"],
           },
         });
       },
@@ -506,12 +497,7 @@ async function openExtensionsMarketplace(ctx) {
   await navigateToSettingsTab(ctx, "extensions");
   await ctx.waitForText("My Extensions", { timeoutMs: 30_000 });
   await ctx.clickText("Marketplace", { selector: "button", timeoutMs: 30_000 });
-  // Heading differs by mode: flag off = "Extension Marketplace", flag on =
-  // "From your marketplace — installs on this machine".
-  await ctx.waitFor(
-    "(document.body?.innerText ?? '').includes('Extension Marketplace') || (document.body?.innerText ?? '').includes('installs on this machine')",
-    { timeoutMs: 30_000, label: "marketplace pane heading" },
-  );
+  await ctx.waitForText("Extension Marketplace", { timeoutMs: 30_000 });
   await ctx.control("extensions.refresh-marketplace").catch(() => {});
 }
 
@@ -568,29 +554,7 @@ async function readExtensionsMarketplaceState(ctx, name) {
   })()`);
 }
 
-async function readExtensionsHintState(ctx) {
-  return ctx.eval(`(() => {
-    const compact = (entry) => (entry?.innerText ?? entry?.textContent ?? '').replace(/\\s+/g, ' ').trim();
-    const buttons = [...document.querySelectorAll('button')];
-    return {
-      text: document.body.innerText,
-      buttonTexts: buttons.map(compact),
-    };
-  })()`);
-}
-
-async function readConnectMarketplaceState(ctx, name) {
-  return ctx.eval(`(() => {
-    const compact = (entry) => (entry?.innerText ?? entry?.textContent ?? '').replace(/\\s+/g, ' ').trim();
-    const section = document.querySelector('[data-testid="connect-marketplace-section"]');
-    const card = [...document.querySelectorAll('[data-testid="connect-marketplace-plugin-card"]')]
-      .find((entry) => compact(entry).includes(${JSON.stringify(name)}));
-    return {
-      pageText: document.body.innerText,
-      statusText: compact(document.querySelector('[data-testid="connect-org-status-row"]')),
-      sectionText: compact(section),
-      cardText: compact(card),
-      cardButtons: [...(card?.querySelectorAll('button') ?? [])].map(compact),
-    };
-  })()`);
+function assertNoMarketplaceInstallButtons(ctx, proof) {
+  const forbidden = proof.buttonTexts.filter((text) => ["Add", "Install", "Update"].includes(text));
+  ctx.assert(forbidden.length === 0, `Removed marketplace install/update buttons rendered: ${JSON.stringify(forbidden)}`);
 }

--- a/evals/flows/connections-beta-desktop.flow.mjs
+++ b/evals/flows/connections-beta-desktop.flow.mjs
@@ -187,6 +187,15 @@ async function navigateToExtensionsMarketplace(ctx) {
   await ctx.waitFor("document.body.innerText.includes('Extension Marketplace')", { timeoutMs: 20_000, label: "marketplace view" });
 }
 
+async function navigateToConnectSettings(ctx) {
+  await closeStaleDialogs(ctx);
+  const workspaceId = await ctx.eval("(window.location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? null");
+  ctx.assert(Boolean(workspaceId), "No workspace id in URL.");
+  await ctx.navigateHash(`/workspace/${workspaceId}/settings/connect`);
+  await ctx.waitFor("window.location.hash.includes('/settings/connect')", { timeoutMs: 30_000, label: "connect settings route" });
+  await ctx.waitFor("document.body.innerText.includes('Connect')", { timeoutMs: 30_000, label: "connect settings view" });
+}
+
 async function clickRefreshIfAvailable(ctx) {
   const clicked = await ctx.eval(`(() => {
     const buttons = [...document.querySelectorAll('button')].filter((button) => button.textContent.trim() === 'Refresh' && !button.disabled);
@@ -196,12 +205,13 @@ async function clickRefreshIfAvailable(ctx) {
   if (clicked) await sleep(2_000);
 }
 
-async function waitForMarketplaceCard(ctx, name) {
+async function waitForConnectConnectionRow(ctx, name) {
   const deadline = Date.now() + 90_000;
   let refreshed = false;
   while (Date.now() < deadline) {
     const found = await ctx.eval(`(() => {
-      return [...document.querySelectorAll('button')].some((button) => button.querySelector('h4')?.textContent.trim() === ${JSON.stringify(name)});
+      return [...document.querySelectorAll('[data-testid="connect-organization-row"]')]
+        .some((row) => (row.textContent ?? '').includes(${JSON.stringify(name)}));
     })()`);
     if (found) return;
     if (!refreshed && Date.now() > deadline - 60_000) {
@@ -210,21 +220,36 @@ async function waitForMarketplaceCard(ctx, name) {
     }
     await sleep(2_000);
   }
-  ctx.assert(false, `Marketplace card did not render: ${name}`);
+  ctx.assert(false, `Connect organization row did not render: ${name}`);
 }
 
-async function clickExtensionCard(ctx, name) {
-  const clicked = await ctx.eval(`(() => {
-    const button = [...document.querySelectorAll('button')].find((entry) => entry.querySelector('h4')?.textContent.trim() === ${JSON.stringify(name)});
-    button?.click();
-    return Boolean(button);
+async function readConnectConnectionState(ctx, name) {
+  return ctx.eval(`(() => {
+    const compact = (entry) => (entry?.textContent ?? '').replace(/\\s+/g, ' ').trim();
+    const row = [...document.querySelectorAll('[data-testid="connect-organization-row"]')]
+      .find((entry) => compact(entry).includes(${JSON.stringify(name)}));
+    return {
+      pageText: document.body.innerText,
+      rowText: compact(row),
+    };
   })()`);
-  ctx.assert(clicked, `Extension card not found: ${name}`);
+}
+
+async function readExtensionsMarketplaceState(ctx, name) {
+  return ctx.eval(`(() => {
+    const text = document.body.innerText;
+    const filterOptions = [...document.querySelectorAll('select option')].map((option) => option.textContent.trim());
+    return {
+      text,
+      hasConnection: text.includes(${JSON.stringify(name)}),
+      filterOptions,
+    };
+  })()`);
 }
 
 export default {
   id: "connections-beta-desktop",
-  title: "Desktop Marketplace: alpha org connections are labeled and last",
+  title: "Desktop Connect: alpha org connections appear only in Connect",
   kind: "user-facing",
   spec: "evals/voiceovers/connections-beta-desktop.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
@@ -262,46 +287,30 @@ export default {
     {
       name: "Frame 2",
       run: async (ctx) => {
-        await ctx.prove("The org tool appears in the Marketplace, last and wearing Alpha", {
+        await ctx.prove("The org tool appears in Connect as needing the member's sign-in", {
           voiceover: vo[1],
           action: async () => {
-            await navigateToExtensionsMarketplace(ctx);
-            await waitForMarketplaceCard(ctx, CONNECTION_NAME);
-            // The claim is about the LAST card: scroll it into the picture and
-            // let the marketplace load toast clear so the frame shows it.
+            await navigateToConnectSettings(ctx);
+            await waitForConnectConnectionRow(ctx, CONNECTION_NAME);
             await ctx.eval(`(() => {
-              const card = [...document.querySelectorAll('button')].find((button) => button.querySelector('h4')?.textContent.trim() === ${JSON.stringify(CONNECTION_NAME)});
-              card?.scrollIntoView({ block: 'center' });
-              return true;
+              const row = [...document.querySelectorAll('[data-testid="connect-organization-row"]')]
+                .find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(CONNECTION_NAME)}));
+              row?.scrollIntoView({ block: 'center' });
+              return Boolean(row);
             })()`);
-            await ctx.waitFor(
-              "!document.body.innerText.includes('marketplace extensions for')",
-              { timeoutMs: 10_000, label: "marketplace load toast cleared" },
-            ).catch(() => {});
             await sleep(500);
           },
           assert: async () => {
-            const proof = await ctx.eval(`(() => {
-              const compact = (entry) => (entry?.textContent ?? '').replace(/\\s+/g, ' ').trim();
-              const card = [...document.querySelectorAll('button')].find((button) => button.querySelector('h4')?.textContent.trim() === ${JSON.stringify(CONNECTION_NAME)});
-              const grid = card?.closest('.grid') ?? null;
-              const cards = grid ? [...grid.querySelectorAll('button')].filter((button) => button.querySelector('h4')) : [];
-              const select = [...document.querySelectorAll('select')].find((entry) => [...entry.options].some((option) => option.textContent.trim() === 'Organization MCP Connections'));
-              return {
-                cardText: compact(card),
-                lastCardText: compact(cards[cards.length - 1]),
-                filterOptions: select ? [...select.options].map((option) => option.textContent.trim()) : [],
-              };
-            })()`);
-            ctx.assert(proof.cardText.includes(CONNECTION_NAME), `Marketplace card not found: ${JSON.stringify(proof)}`);
-            ctx.assert(proof.cardText.includes("Alpha"), `Marketplace card must include the Alpha pill: ${proof.cardText}`);
-            ctx.assert(proof.lastCardText.includes(CONNECTION_NAME), `Org connection must be the last marketplace card: ${proof.lastCardText}`);
-            ctx.assert(proof.filterOptions[proof.filterOptions.length - 1] === "Organization MCP Connections", `Marketplace filter order was wrong: ${JSON.stringify(proof.filterOptions)}`);
+            const proof = await readConnectConnectionState(ctx, CONNECTION_NAME);
+            ctx.assert(proof.pageText.includes("From your organization"), "Connect organization section missing.");
+            ctx.assert(proof.pageText.includes("NEEDS YOUR SIGN-IN"), `Needs-your-sign-in group missing: ${proof.pageText.slice(0, 300)}`);
+            ctx.assert(proof.rowText.includes(CONNECTION_NAME), `Connect row not found: ${JSON.stringify(proof)}`);
+            ctx.assert(proof.rowText.includes("Connect your account"), `Connect row action missing: ${proof.rowText}`);
           },
           screenshot: {
-            name: "connections-beta-desktop-marketplace-last",
-            claim: "The Marketplace shows the alpha org MCP connection as the last card and the last marketplace filter option.",
-            requireText: [CONNECTION_NAME, "Alpha"],
+            name: "connections-beta-desktop-connect-row",
+            claim: "OpenWork Connect shows the org MCP connection under Needs your sign-in with Connect your account.",
+            requireText: ["From your organization", "NEEDS YOUR SIGN-IN", CONNECTION_NAME, "Connect your account"],
             rejectText: ["Something went wrong"],
           },
         });
@@ -310,31 +319,22 @@ export default {
     {
       name: "Frame 3",
       run: async (ctx) => {
-        await ctx.prove("The detail modal says Alpha before anyone connects", {
+        await ctx.prove("Extensions Marketplace no longer lists org MCP connections", {
           voiceover: vo[2],
           action: async () => {
-            await clickExtensionCard(ctx, CONNECTION_NAME);
-            await ctx.waitFor("document.body.innerText.includes('Release stage')", { timeoutMs: 15_000, label: "detail modal release stage" });
+            await navigateToExtensionsMarketplace(ctx);
           },
           assert: async () => {
-            const modal = await ctx.eval(`(() => {
-              const roots = [...document.querySelectorAll('[role="dialog"], [data-slot="dialog-content"]')];
-              const root = roots.find((entry) => entry.textContent.includes(${JSON.stringify(CONNECTION_NAME)}))
-                ?? [...document.querySelectorAll('div')].find((entry) => entry.textContent.includes(${JSON.stringify(CONNECTION_NAME)}) && entry.textContent.includes('Release stage'));
-              const text = (root?.textContent ?? '').replace(/\\s+/g, ' ').trim();
-              const betaPill = root ? [...root.querySelectorAll('span')].some((span) => span.textContent.trim() === 'Alpha') : false;
-              return { text, betaPill };
-            })()`);
-            ctx.assert(modal.text.includes(CONNECTION_NAME), `Detail modal missing connection name: ${modal.text}`);
-            ctx.assert(modal.betaPill, "Detail modal missing Alpha pill.");
-            ctx.assert(/Release stage\s*Alpha/.test(modal.text), `Detail modal missing Release stage Alpha row: ${modal.text}`);
-            ctx.assert(modal.text.includes("Connect your account"), `Detail modal missing connect label: ${modal.text}`);
+            const proof = await readExtensionsMarketplaceState(ctx, CONNECTION_NAME);
+            ctx.assert(proof.text.includes("Extension Marketplace"), "Extensions Marketplace did not render.");
+            ctx.assert(!proof.hasConnection, `Extensions Marketplace rendered org connection: ${proof.text}`);
+            ctx.assert(!proof.filterOptions.includes("Organization MCP Connections"), `Org MCP filter leaked: ${JSON.stringify(proof.filterOptions)}`);
           },
           screenshot: {
-            name: "connections-beta-desktop-detail-modal",
-            claim: "The org MCP connection detail modal shows Alpha, Release stage, and Connect your account before authorization.",
-            requireText: [CONNECTION_NAME, "Release stage", "Alpha"],
-            rejectText: ["Something went wrong"],
+            name: "connections-beta-desktop-extensions-absent",
+            claim: "Extensions Marketplace stays local-only and has no org MCP connection card or filter.",
+            requireText: ["Extension Marketplace"],
+            rejectText: [CONNECTION_NAME, "Organization MCP Connections", "Something went wrong"],
           },
         });
         await closeStaleDialogs(ctx);

--- a/evals/flows/desktop-org-mcp-consolidation.flow.mjs
+++ b/evals/flows/desktop-org-mcp-consolidation.flow.mjs
@@ -3,5 +3,5 @@ import demo from "./desktop-org-mcp-demo.flow.mjs";
 export default {
   ...demo,
   id: "desktop-org-mcp-consolidation",
-  title: "Desktop app: member discovers and connects an org MCP connection through the Extensions Marketplace",
+  title: "Desktop app: member discovers and connects an org MCP connection through OpenWork Connect",
 };

--- a/evals/flows/desktop-org-mcp-demo.flow.mjs
+++ b/evals/flows/desktop-org-mcp-demo.flow.mjs
@@ -4,10 +4,10 @@
  * - Admin setup creates a per-member org MCP connection in Den (the den-web
  *   admin screen is proven separately by mcp-connections-cloud-oauth).
  * - Jordan signs the desktop into the same org.
- * - The connection appears in the existing Extensions Marketplace as an org
- *   MCP item, not in a special section.
- * - Jordan clicks through the desktop UI, the OS browser completes a real OAuth
- *   round trip, and the item moves to My Extensions as Connected.
+ * - The connection appears in OpenWork Connect as an org MCP item that needs
+ *   Jordan's sign-in.
+ * - Jordan clicks through Connect, the OS browser completes a real OAuth
+ *   round trip, and the item becomes Ready in Connect.
  * - A real chat turn executes the external MCP tool through OpenWork Cloud
  *   Control; the mock server log is the external witness.
  */
@@ -289,6 +289,61 @@ async function openMcpSettings(ctx) {
   ctx.assert(false, `MCP settings never became ready: ${JSON.stringify(last)}`);
 }
 
+async function openConnectSettings(ctx) {
+  const workspaceId = await currentWorkspaceId(ctx);
+  let last = null;
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    await ctx.navigateHash(`/workspace/${workspaceId}/settings/connect`);
+    await sleep(1_000);
+    last = await ctx.eval(`(() => {
+      const text = document.body.innerText;
+      return {
+        hash: window.location.hash,
+        onOnboarding: window.location.hash.includes('/onboarding') || text.includes('Continue with organization') || text.includes('Continue to workspace'),
+        hasConnect: text.includes('Connect'),
+      };
+    })()`);
+    if (last.onOnboarding) {
+      await ensureWorkspace(ctx);
+      await sleep(500);
+      continue;
+    }
+    if (last.hash.includes('/settings/connect') && last.hasConnect) return workspaceId;
+    await sleep(1_000);
+  }
+  ctx.assert(false, `Connect settings never became ready: ${JSON.stringify(last)}`);
+}
+
+async function waitForConnectOrgRow(ctx, name) {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const found = await ctx.eval(`(() => {
+      return [...document.querySelectorAll('[data-testid="connect-organization-row"]')]
+        .some((row) => (row.textContent ?? '').includes(${JSON.stringify(name)}));
+    })()`);
+    if (found) return;
+    await ctx.control("extensions.refresh-marketplace").catch(() => {});
+    await sleep(2_000);
+  }
+  ctx.assert(false, `Connect org row did not render: ${name}`);
+}
+
+async function waitForConnectReadyRow(ctx, name) {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const found = await ctx.eval(`(() => {
+      const row = [...document.querySelectorAll('[data-testid="connect-organization-row"]')]
+        .find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(name)}));
+      return Boolean(row && (row.textContent ?? '').includes('Ready') && !(row.textContent ?? '').includes('Connect your account'));
+    })()`);
+    if (found) return;
+    await ctx.control("extensions.refresh-marketplace").catch(() => {});
+    await sleep(2_000);
+  }
+  ctx.assert(false, `Connect org row did not become ready: ${name}`);
+}
+
 async function waitForMockAuthorizeRequest(ctx) {
   let authorizeRequest = null;
   const deadline = Date.now() + 30_000;
@@ -306,7 +361,7 @@ async function waitForMockAuthorizeRequest(ctx) {
 
 export default {
   id: "desktop-org-mcp-demo",
-  title: "Desktop app: org MCP connections appear in Marketplace, connect through browser OAuth, and work in chat",
+  title: "Desktop app: org MCP connections appear in Connect, connect through browser OAuth, and work in chat",
   kind: "user-facing",
   spec: "evals/desktop-org-mcp-demo.md",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
@@ -393,32 +448,24 @@ export default {
       },
     },
     {
-      name: "Jordan discovers the org MCP connection in Marketplace",
+      name: "Jordan discovers the org MCP connection in OpenWork Connect",
       run: async (ctx) => {
-        await openMcpSettings(ctx);
-        await ctx.expectHashIncludes("/settings/extensions/mcp", { timeoutMs: 20_000 });
-        await ctx.clickText("Refresh", { timeoutMs: 15_000 }).catch(() => {});
-        await ctx.waitFor(
-          `(() => {
-            const button = [...document.querySelectorAll('button')].find((candidate) => candidate.textContent.trim() === 'Marketplace' && !candidate.disabled);
-            button?.click();
-            return Boolean(button);
-          })()`,
-          { timeoutMs: 30_000, label: "Marketplace tab" },
-        );
+        await openConnectSettings(ctx);
+        await ctx.expectHashIncludes("/settings/connect", { timeoutMs: 20_000 });
+        await waitForConnectOrgRow(ctx, CONNECTION_NAME);
 
-        await ctx.prove("Jordan sees the org MCP connection in the existing Marketplace tab, with a connect action", {
-          voiceover: "Jordan does not see a special org-only panel. The org-shared MCP connection is just another catalog card in Marketplace, clearly marked as something they can connect with their own account.",
+        await ctx.prove("Jordan sees the org MCP connection in OpenWork Connect, with a connect action", {
+          voiceover: "Jordan opens OpenWork Connect and sees the org-shared MCP connection under Needs your sign-in, clearly marked as something they can connect with their own account.",
           assert: async () => {
-            await ctx.expectText("Extension Marketplace", { timeoutMs: 30_000 });
             await ctx.expectText(CONNECTION_NAME, { timeoutMs: 60_000 });
+            await ctx.expectText("NEEDS YOUR SIGN-IN", { timeoutMs: 30_000 });
             await ctx.expectText("Connect your account", { timeoutMs: 30_000 });
           },
           screenshot: {
-            name: "desktop-org-mcp-marketplace",
-            claim: "The desktop Extensions Marketplace shows the org-published MCP connection with a 'Connect your account' action.",
-            requireText: ["Extension Marketplace", CONNECTION_NAME, "Connect your account"],
-            rejectText: ["From your organization", "Something went wrong"],
+            name: "desktop-org-mcp-connect",
+            claim: "OpenWork Connect shows the org-published MCP connection with a 'Connect your account' action.",
+            requireText: ["From your organization", "NEEDS YOUR SIGN-IN", CONNECTION_NAME, "Connect your account"],
+            rejectText: ["Something went wrong"],
           },
         });
       },
@@ -426,49 +473,40 @@ export default {
     {
       name: "Jordan connects through real browser OAuth",
       run: async (ctx) => {
-        await ctx.clickText(CONNECTION_NAME, { timeoutMs: 20_000 });
-        await ctx.expectText("OpenWork stores this sign-in", { timeoutMs: 15_000 });
         state.clickedAt = new Date().toISOString();
         const clicked = await ctx.eval(`(() => {
-          const dialog = document.querySelector('[role="dialog"]');
-          const button = [...(dialog?.querySelectorAll('button') ?? [])].find((el) => el.textContent.trim() === 'Connect your account' && !el.disabled);
+          const row = [...document.querySelectorAll('[data-testid="connect-organization-row"]')]
+            .find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(CONNECTION_NAME)}));
+          const button = [...(row?.querySelectorAll('button') ?? [])].find((el) => el.textContent.trim() === 'Connect your account' && !el.disabled);
           button?.click();
           return Boolean(button);
         })()`);
-        ctx.assert(clicked, "Could not click the modal's Connect your account button.");
+        ctx.assert(clicked, "Could not click the Connect row's Connect your account button.");
         await waitForMockAuthorizeRequest(ctx);
       },
     },
     {
-      name: "The item moves to My Extensions as connected",
+      name: "The item becomes ready in OpenWork Connect",
       run: async (ctx) => {
-        await openMcpSettings(ctx);
-        await ctx.expectText("My Extensions", { timeoutMs: 30_000 });
-        await ctx.waitFor(
-          `(() => {
-            const button = [...document.querySelectorAll('button')].find((candidate) => candidate.textContent.trim() === 'My Extensions' && !candidate.disabled);
-            button?.click();
-            return Boolean(button);
-          })()`,
-          { timeoutMs: 30_000, label: "My Extensions tab" },
-        );
-        await ctx.prove("After the browser sign-in completes, the same org MCP item appears in My Extensions as connected", {
-          voiceover: "The OAuth callback completed in the browser, and the desktop did not need a manual reload. Jordan's card is now in My Extensions as a connected MCP integration.",
+        await openConnectSettings(ctx);
+        await waitForConnectReadyRow(ctx, CONNECTION_NAME);
+        await ctx.prove("After the browser sign-in completes, the same org MCP item is ready in OpenWork Connect", {
+          voiceover: "The OAuth callback completed in the browser, and the desktop did not need a manual reload. Jordan's row is now ready in OpenWork Connect as a connected MCP integration.",
           assert: async () => {
             await ctx.waitFor(
               `(() => {
-                const buttons = [...document.querySelectorAll("button")];
-                const card = buttons.find((el) => el.textContent.includes(${JSON.stringify(CONNECTION_NAME)}));
-                return Boolean(card && card.textContent.includes("Connected") && !card.textContent.includes("Connect your account"));
+                const row = [...document.querySelectorAll('[data-testid="connect-organization-row"]')]
+                  .find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(CONNECTION_NAME)}));
+                return Boolean(row && (row.textContent ?? '').includes("Ready") && !(row.textContent ?? '').includes("Connect your account"));
               })()`,
-              { timeoutMs: 90_000, label: "org MCP card connected in My Extensions" },
+              { timeoutMs: 90_000, label: "org MCP row ready in Connect" },
             );
           },
           screenshot: {
             name: "desktop-org-mcp-connected",
-            claim: "The org MCP connection moved to My Extensions and is marked Connected after the browser OAuth round trip.",
-            requireText: [CONNECTION_NAME, "Connected"],
-            rejectText: ["From your organization", "Something went wrong"],
+            claim: "The org MCP connection is marked Ready in OpenWork Connect after the browser OAuth round trip.",
+            requireText: [CONNECTION_NAME, "Ready"],
+            rejectText: ["Connect your account", "Something went wrong"],
           },
         });
       },

--- a/evals/flows/marketplace-connect-only-delivery.flow.mjs
+++ b/evals/flows/marketplace-connect-only-delivery.flow.mjs
@@ -37,6 +37,7 @@ export default {
   kind: "user-facing",
   requiredEnv: [
     "OPENWORK_EVAL_DEN_API_URL",
+    "OPENWORK_EVAL_DEN_WEB_URL",
     "OPENWORK_EVAL_PLATFORM_ADMIN_EMAIL",
     "OPENWORK_EVAL_PLATFORM_ADMIN_PASSWORD",
     "OPENWORK_EVAL_MARK_VERIFIED_CMD",
@@ -441,12 +442,12 @@ async function prepareSignedInDesktop(ctx) {
 async function signDesktopIntoCloud(ctx) {
   await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 120_000, label: "desktop control API" });
   await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", { timeoutMs: 30_000, label: "desktop bridge" });
-  const bootstrap = { baseUrl: DEN_API_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
+  const bootstrap = { baseUrl: DEN_WEB_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
   const written = await ctx.eval(`(async () => {
     const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
     if (!bridge) return { ok: false };
     await bridge("setDesktopBootstrapConfig", ${JSON.stringify(bootstrap)});
-    localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_API_URL)});
+    localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_WEB_URL)});
     localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(DEN_API_URL)});
     localStorage.removeItem('openwork.den.authToken');
     localStorage.removeItem('openwork.den.activeOrgId');
@@ -467,7 +468,11 @@ async function signDesktopIntoCloud(ctx) {
     body: JSON.stringify({ desktopScheme: "openwork" }),
   });
   ctx.assert(handoff.response.ok, `Handoff create failed: ${handoff.response.status} ${handoff.text.slice(0, 300)}`);
-  await ctx.control("auth.exchange-grant", { grant: handoff.body.grant, baseUrl: DEN_API_URL });
+  await ctx.waitFor(
+    "Boolean(window.__openworkControl?.listActions().some((action) => action.id === 'auth.exchange-grant'))",
+    { timeoutMs: 30_000, label: "auth.exchange-grant control action" },
+  );
+  await ctx.control("auth.exchange-grant", { grant: handoff.body.grant, baseUrl: DEN_WEB_URL });
   await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", {
     timeoutMs: 45_000,
     label: "persisted den auth token",
@@ -495,13 +500,23 @@ async function completeDesktopCloudOnboardingIfNeeded(ctx) {
   if (needsFolder) {
     await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_PATH);
     await ctx.clickText("Use this folder", { timeoutMs: 10_000 });
-    await ctx.waitFor("window.location.hash.includes('/workspace/')", { timeoutMs: 60_000, label: "workspace open after folder selection" });
   }
-  await ctx.eval(`(() => {
-    const button = [...document.querySelectorAll('button')].find((candidate) => (candidate.textContent ?? '').trim() === 'Continue without OpenWork Models');
-    button?.click();
-    return true;
-  })()`);
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const routeReady = await ctx.eval("window.location.hash.includes('/workspace/')");
+    if (routeReady) return;
+    await ctx.eval(`(() => {
+      const buttons = [...document.querySelectorAll('button')];
+      const modelSkip = buttons.find((candidate) => ['Skip and use the free model', 'Continue without OpenWork Models'].includes((candidate.textContent ?? '').trim()));
+      if (modelSkip instanceof HTMLElement && !modelSkip.hasAttribute('disabled')) modelSkip.click();
+      const surveySkip = buttons.find((candidate) => (candidate.textContent ?? '').trim() === 'Skip');
+      if (surveySkip instanceof HTMLElement && !surveySkip.hasAttribute('disabled')) surveySkip.click();
+      return true;
+    })()`);
+    await sleep(1_000);
+  }
+  if (needsFolder) {
+    await ctx.waitFor("window.location.hash.includes('/workspace/')", { timeoutMs: 60_000, label: "workspace open after onboarding" });
+  }
 }
 
 async function remountDesktop(ctx) {
@@ -522,8 +537,8 @@ async function remountDesktop(ctx) {
 
 async function waitForCloudMcpSync(ctx) {
   await ctx.waitFor(
-    "Boolean(localStorage.getItem('openwork.den.mcp.sync'))",
-    { timeoutMs: 180_000, label: "openwork.den.mcp.sync marker" },
+    "Boolean(localStorage.getItem('openwork.den.mcp.lastMaintenanceOutcome')) || (document.body?.innerText ?? '').includes('OpenWork Connect: Ready')",
+    { timeoutMs: 180_000, label: "OpenWork Connect maintenance ready" },
   );
 }
 

--- a/evals/flows/marketplace-connect-only-delivery.flow.mjs
+++ b/evals/flows/marketplace-connect-only-delivery.flow.mjs
@@ -1,0 +1,750 @@
+import { execSync } from "node:child_process";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/marketplace-connect-only-delivery.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("marketplace-connect-only-delivery");
+
+const FLOW_ID = "marketplace-connect-only-delivery";
+const DEN_API_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_API_URL);
+const DEN_WEB_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_WEB_URL || DEN_API_URL);
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const PLATFORM_ADMIN_EMAIL = process.env.OPENWORK_EVAL_PLATFORM_ADMIN_EMAIL?.trim() || "";
+const PLATFORM_ADMIN_PASSWORD = process.env.OPENWORK_EVAL_PLATFORM_ADMIN_PASSWORD?.trim() || "";
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const WORKSPACE_PATH = process.env.OPENWORK_EVAL_WORKSPACE_PATH?.trim() || "/tmp/openwork-marketplace-connect-only-delivery";
+const RUN_TAG = Date.now();
+const SEED_PREFIX = "marketplace-connect-only-delivery";
+const MARKETPLACE_NAME = `${SEED_PREFIX}-${RUN_TAG}`;
+const PLUGIN_NAME = `Connect Only Delivery ${RUN_TAG}`;
+const SKILL_NAME = `connect-only-delivery-proof-${RUN_TAG}`;
+const PROOF_PHRASE = `cloud-orbit-${RUN_TAG}`;
+
+const state = {
+  orgAdminToken: null,
+  platformAdminToken: null,
+  orgId: null,
+  marketplace: null,
+  marketplaceId: null,
+  plugin: null,
+  pluginId: null,
+};
+
+export default {
+  id: FLOW_ID,
+  title: "Organization marketplace plugins are delivered through OpenWork Connect only",
+  kind: "user-facing",
+  requiredEnv: [
+    "OPENWORK_EVAL_DEN_API_URL",
+    "OPENWORK_EVAL_PLATFORM_ADMIN_EMAIL",
+    "OPENWORK_EVAL_PLATFORM_ADMIN_PASSWORD",
+    "OPENWORK_EVAL_MARK_VERIFIED_CMD",
+    "OPENWORK_EVAL_WORKSPACE_PATH",
+  ],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("A newly published marketplace plugin appears in Connect as ready cloud content", {
+          voiceover: vo[0],
+          // "My organization publishes a plugin to its marketplace, and on my desktop it "
+          action: async () => {
+            await prepareSignedInDesktop(ctx);
+            await navigateToSettingsTab(ctx, "connect");
+            await waitForConnectOrganizationRow(ctx, PLUGIN_NAME);
+            await scrollConnectGroup(ctx, "ready");
+          },
+          assert: async () => {
+            const proof = await readConnectState(ctx, PLUGIN_NAME);
+            const readyGroup = proof.groups.ready ?? "";
+            ctx.assert(proof.pageText.includes("From your organization"), "Connect organization section missing.");
+            ctx.assert(readyGroup.includes(PLUGIN_NAME), `Seeded plugin missing from Ready group: ${readyGroup}`);
+            ctx.assert(readyGroup.includes("Ready"), `Ready chip missing from seeded plugin row: ${readyGroup}`);
+            ctx.assert(!readyGroup.includes("Add") && !readyGroup.includes("Install"), `Connect row exposed an install action: ${readyGroup}`);
+          },
+          screenshot: { name: "frame-1-connect-ready", requireText: ["From your organization", "READY TO USE", PLUGIN_NAME] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The organization marketplace has no Den plugin Install or Update action", {
+          voiceover: vo[1],
+          // "The old install path is really gone: the organization marketplace shows ever"
+          action: async () => {
+            await navigateToSettingsTab(ctx, "cloud-marketplaces");
+            await waitForMarketplacePlugin(ctx, PLUGIN_NAME);
+          },
+          assert: async () => {
+            const proof = await readMarketplaceState(ctx, PLUGIN_NAME);
+            ctx.assert(proof.pluginCardText.includes("Runs in cloud"), `Runs-in-cloud affordance missing: ${proof.pluginCardText}`);
+            ctx.assert(proof.pageText.includes("Active · runs in cloud"), "Cloud-active label missing from marketplace page.");
+            assertNoMarketplaceInstallButtons(ctx, proof);
+          },
+          screenshot: { name: "frame-2-marketplace-cloud-only", requireText: ["Extension Marketplace", PLUGIN_NAME, "Runs in cloud"] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Extensions Legacy remains local and excludes Den organization plugin rows", {
+          voiceover: vo[2],
+          // "Extensions (Legacy) is purely local territory now: my MCPs, skills, and GitH"
+          action: async () => {
+            await dismissStaleDialogs(ctx);
+            await navigateToSettingsTab(ctx, "extensions");
+            await ctx.waitForText("My Extensions", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const proof = await readExtensionsLegacyState(ctx);
+            ctx.assert(proof.pageText.includes("Add Custom App"), "Add Custom App affordance missing.");
+            ctx.assert(proof.pageText.includes("From GitHub"), "From GitHub import affordance missing.");
+            ctx.assert(!proof.pageText.includes(PLUGIN_NAME), "Seeded Den marketplace plugin leaked into My Extensions.");
+            await ctx.clickText("Marketplace", { selector: "button", timeoutMs: 30_000 });
+            await ctx.waitForText("Extension Marketplace", { timeoutMs: 30_000 });
+            const marketplaceText = await ctx.eval("document.body.innerText");
+            ctx.assert(!marketplaceText.includes(PLUGIN_NAME), "Seeded Den marketplace plugin leaked into Extensions Marketplace.");
+            await ctx.clickText("My Extensions", { selector: "button", timeoutMs: 30_000 });
+            await ctx.waitForText("Add Custom App", { timeoutMs: 30_000 });
+          },
+          screenshot: { name: "frame-3-extensions-local", requireText: ["My Extensions", "Add Custom App", "From GitHub"], rejectText: [PLUGIN_NAME] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("A real agent turn discovers and executes the seeded cloud capability", {
+          voiceover: vo[3],
+          // "When I ask the agent to use the capability, it discovers it with search and "
+          action: async () => {
+            await runSeededCapabilityAgentTurn(ctx);
+          },
+          assert: async () => {
+            await ctx.waitForText("search capabilities", { timeoutMs: 90_000 });
+            await ctx.waitForText("execute capability", { timeoutMs: 90_000 });
+            await ctx.waitForText(PROOF_PHRASE, { timeoutMs: 90_000 });
+          },
+          screenshot: { name: "frame-4-agent-cloud-capability", requireText: ["search capabilities", "execute capability", PROOF_PHRASE] },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("A legacy local import remains intact and is marked as a local copy", {
+          voiceover: vo[4],
+          // "And the plugin I imported back in the old days keeps working untouched — it "
+          action: async () => {
+            await seedLegacyLocalImport(ctx);
+            await navigateToSettingsTab(ctx, "cloud-marketplaces");
+            await waitForMarketplacePlugin(ctx, PLUGIN_NAME);
+            await ctx.clickText(PLUGIN_NAME, { selector: "button", timeoutMs: 20_000 });
+            await ctx.waitForText("Local copy installed — still works, runs from this machine.", { timeoutMs: 20_000 });
+          },
+          assert: async () => {
+            const proof = await readMarketplaceState(ctx, PLUGIN_NAME);
+            ctx.assert(proof.pageText.includes("Local copy installed"), "Local-copy badge missing from marketplace row.");
+            ctx.assert(proof.pageText.includes("Local copy installed — still works, runs from this machine."), "Local-copy note missing from marketplace detail/page state.");
+            await assertLegacyImportArtifacts(ctx);
+          },
+          screenshot: { name: "frame-5-local-copy", requireText: [PLUGIN_NAME, "Local copy installed"] },
+        });
+      },
+    },
+  ],
+};
+
+function cleanBaseUrl(value) {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function requireStateValue(value, label) {
+  if (typeof value === "string" && value.trim()) return value;
+  throw new Error(`${label} was not prepared by an earlier frame.`);
+}
+
+async function denApiFetch(pathname, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${pathname}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      origin: DEN_WEB_URL,
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+async function signIn(email, password) {
+  return denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+}
+
+function markEmailVerified(ctx, email) {
+  ctx.assert(
+    MARK_VERIFIED_CMD.length > 0,
+    "Platform-admin provisioning requires OPENWORK_EVAL_MARK_VERIFIED_CMD with an {email} placeholder.",
+  );
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", email), { stdio: "ignore" });
+}
+
+async function ensurePlatformAdmin(ctx) {
+  if (state.platformAdminToken) return state.platformAdminToken;
+
+  const signup = await denApiFetch("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ name: "Priya Platform", email: PLATFORM_ADMIN_EMAIL, password: PLATFORM_ADMIN_PASSWORD }),
+  });
+  const signupAccepted = signup.response.ok || [400, 403, 409, 422].includes(signup.response.status);
+  ctx.assert(signupAccepted, `Platform admin sign-up failed: ${signup.response.status} ${signup.text.slice(0, 300)}`);
+  markEmailVerified(ctx, PLATFORM_ADMIN_EMAIL);
+
+  const signedIn = await signIn(PLATFORM_ADMIN_EMAIL, PLATFORM_ADMIN_PASSWORD);
+  ctx.assert(
+    signedIn.response.ok && typeof signedIn.body?.token === "string",
+    `Platform admin sign-in failed: ${signedIn.response.status} ${signedIn.text.slice(0, 300)}`,
+  );
+  state.platformAdminToken = signedIn.body.token;
+
+  const probe = await denApiFetch("/v1/admin/overview", {
+    headers: { authorization: `Bearer ${state.platformAdminToken}` },
+  });
+  ctx.assert(probe.response.ok, `${PLATFORM_ADMIN_EMAIL} is not a platform admin (overview probe ${probe.response.status}).`);
+  return state.platformAdminToken;
+}
+
+async function ensureOrgAdminContext(ctx) {
+  if (state.orgAdminToken && state.orgId) return;
+
+  const signedIn = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+  ctx.assert(
+    signedIn.response.ok && typeof signedIn.body?.token === "string",
+    `Org admin sign-in failed for ${ADMIN_EMAIL}: ${signedIn.response.status} ${signedIn.text.slice(0, 300)}`,
+  );
+  state.orgAdminToken = signedIn.body.token;
+
+  const listed = await denApiFetch("/v1/me/orgs", {
+    headers: { authorization: `Bearer ${state.orgAdminToken}` },
+  });
+  ctx.assert(listed.response.ok, `Could not list orgs: ${listed.response.status} ${listed.text.slice(0, 300)}`);
+  const orgs = listed.body?.orgs;
+  ctx.assert(Array.isArray(orgs), "Current user organizations payload was missing orgs.");
+  const activeOrgId = typeof listed.body?.activeOrgId === "string" ? listed.body.activeOrgId : null;
+  const activeOrg = orgs.find((org) => org.id === activeOrgId) ?? orgs[0];
+  ctx.assert(activeOrg && typeof activeOrg.id === "string", `Could not resolve an organization for ${ADMIN_EMAIL}.`);
+  state.orgId = activeOrg.id;
+
+  const active = await denApiFetch("/v1/me/active-organization", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.orgAdminToken}` },
+    body: JSON.stringify({ organizationId: state.orgId }),
+  });
+  ctx.assert(active.response.ok, `Could not switch active organization: ${active.response.status} ${active.text.slice(0, 300)}`);
+}
+
+async function setCapabilityViaAdminApi(ctx, capabilities) {
+  const token = requireStateValue(state.platformAdminToken, "platform admin token");
+  const orgId = requireStateValue(state.orgId, "organization id");
+  const updated = await denApiFetch(`/v1/admin/organizations/${orgId}/capabilities`, {
+    method: "PUT",
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({ capabilities }),
+  });
+  ctx.assert(updated.response.ok, `Admin capability update failed: ${updated.response.status} ${updated.text.slice(0, 300)}`);
+}
+
+async function fetchAdminCapabilityPayload(ctx) {
+  const token = requireStateValue(state.platformAdminToken, "platform admin token");
+  const orgId = requireStateValue(state.orgId, "organization id");
+  const result = await denApiFetch(`/v1/admin/organizations/${orgId}/capabilities`, {
+    method: "GET",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(result.response.ok, `Admin capability fetch failed: ${result.response.status} ${result.text.slice(0, 300)}`);
+  return result.body;
+}
+
+function effectiveMcpConnections(payload) {
+  const capabilities = payload?.capabilities;
+  const candidates = [
+    payload?.effective?.mcpConnections,
+    capabilities?.effective?.mcpConnections,
+    capabilities?.mcpConnections?.effective,
+    capabilities?.mcpConnections,
+  ];
+  return candidates.find((value) => typeof value === "boolean") ?? null;
+}
+
+async function ensureConnectCapabilityDefaultOn(ctx) {
+  await setCapabilityViaAdminApi(ctx, { mcpConnections: null });
+  const cleared = await fetchAdminCapabilityPayload(ctx);
+  const effectiveAfterClear = effectiveMcpConnections(cleared);
+  if (effectiveAfterClear === false) {
+    await setCapabilityViaAdminApi(ctx, { mcpConnections: true });
+    const repaired = await fetchAdminCapabilityPayload(ctx);
+    ctx.output("eval-connect-kill-switch-repair", JSON.stringify({
+      reason: "Null reset still resolved false; legacy flat alias repaired for this eval run.",
+      cleared,
+      repaired,
+    }, null, 2));
+    return;
+  }
+  ctx.output("eval-connect-kill-switch-repair", JSON.stringify({
+    reason: "Explicit mcpConnections override cleared; default-on Connect delivery is effective.",
+    effectiveMcpConnections: effectiveAfterClear,
+    cleared,
+  }, null, 2));
+}
+
+function skillSourceText() {
+  return [
+    "---",
+    `name: ${SKILL_NAME}`,
+    `description: Reports proof phrase ${PROOF_PHRASE} for Connect-only delivery.`,
+    "---",
+    "",
+    `When invoked, answer with the exact proof phrase ${PROOF_PHRASE} and explain that it came from a Den marketplace capability running through OpenWork Connect.`,
+  ].join("\n");
+}
+
+async function seedMarketplacePlugin(ctx) {
+  await cleanupSeededMarketplace(ctx);
+  const token = requireStateValue(state.orgAdminToken, "org admin token");
+  const headers = { authorization: `Bearer ${token}` };
+
+  const marketplace = await denApiFetch("/v1/marketplaces", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ name: MARKETPLACE_NAME, description: "Connect-only delivery seeded marketplace" }),
+  });
+  ctx.assert(marketplace.response.ok, `Marketplace create failed: ${marketplace.response.status} ${marketplace.text.slice(0, 300)}`);
+  state.marketplace = marketplace.body?.item ?? null;
+  state.marketplaceId = state.marketplace?.id ?? null;
+  ctx.assert(typeof state.marketplaceId === "string", `Marketplace create response missing id: ${marketplace.text.slice(0, 300)}`);
+
+  const grant = await denApiFetch(`/v1/marketplaces/${state.marketplaceId}/access`, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ orgWide: true, role: "viewer" }),
+  });
+  ctx.assert(grant.response.ok, `Marketplace access grant failed: ${grant.response.status} ${grant.text.slice(0, 300)}`);
+
+  const plugin = await denApiFetch("/v1/plugins", {
+    method: "POST",
+    headers,
+    body: JSON.stringify({
+      name: PLUGIN_NAME,
+      description: `Seeded plugin for ${FLOW_ID}; proof phrase ${PROOF_PHRASE}.`,
+      orgWide: true,
+      marketplaceId: state.marketplaceId,
+      components: [{
+        type: "skill",
+        input: {
+          rawSourceText: skillSourceText(),
+          metadata: { name: SKILL_NAME, description: `Reports proof phrase ${PROOF_PHRASE}.` },
+        },
+      }],
+    }),
+  });
+  ctx.assert(plugin.response.ok, `Plugin create failed: ${plugin.response.status} ${plugin.text.slice(0, 300)}`);
+  state.plugin = plugin.body?.item ?? null;
+  state.pluginId = state.plugin?.id ?? null;
+  ctx.assert(typeof state.pluginId === "string", `Plugin create response missing id: ${plugin.text.slice(0, 300)}`);
+}
+
+async function cleanupSeededMarketplace(ctx) {
+  if (!state.orgAdminToken) return;
+  const token = state.orgAdminToken;
+  const headers = { authorization: `Bearer ${token}` };
+
+  const marketplaces = await denApiFetch("/v1/marketplaces?limit=100", { headers });
+  if (marketplaces.response.ok && Array.isArray(marketplaces.body?.items)) {
+    for (const marketplace of marketplaces.body.items) {
+      if (typeof marketplace.name !== "string" || !marketplace.name.startsWith(SEED_PREFIX)) continue;
+      await cleanupMarketplacePlugins(ctx, marketplace.id, token);
+      await denApiFetch(`/v1/marketplaces/${marketplace.id}/archive`, { method: "POST", headers });
+    }
+  }
+
+  const plugins = await denApiFetch(`/v1/plugins?limit=100&q=${encodeURIComponent("Connect Only Delivery")}`, { headers });
+  if (plugins.response.ok && Array.isArray(plugins.body?.items)) {
+    for (const plugin of plugins.body.items) {
+      if (typeof plugin.name !== "string" || !plugin.name.startsWith("Connect Only Delivery")) continue;
+      await cleanupPlugin(ctx, plugin.id, token);
+    }
+  }
+
+  state.marketplace = null;
+  state.marketplaceId = null;
+  state.plugin = null;
+  state.pluginId = null;
+}
+
+async function cleanupMarketplacePlugins(ctx, marketplaceId, token) {
+  if (typeof marketplaceId !== "string") return;
+  const headers = { authorization: `Bearer ${token}` };
+  const memberships = await denApiFetch(`/v1/marketplaces/${marketplaceId}/plugins`, { headers });
+  if (!memberships.response.ok || !Array.isArray(memberships.body?.items)) return;
+  for (const membership of memberships.body.items) {
+    if (typeof membership.pluginId !== "string") continue;
+    await denApiFetch(`/v1/marketplaces/${marketplaceId}/plugins/${membership.pluginId}`, { method: "DELETE", headers });
+    await cleanupPlugin(ctx, membership.pluginId, token);
+  }
+}
+
+async function cleanupPlugin(ctx, pluginId, token) {
+  if (typeof pluginId !== "string") return;
+  const headers = { authorization: `Bearer ${token}` };
+  const memberships = await denApiFetch(`/v1/plugins/${pluginId}/config-objects`, { headers });
+  if (memberships.response.ok && Array.isArray(memberships.body?.items)) {
+    for (const membership of memberships.body.items) {
+      if (typeof membership.configObjectId !== "string") continue;
+      await denApiFetch(`/v1/plugins/${pluginId}/config-objects/${membership.configObjectId}`, { method: "DELETE", headers });
+      await denApiFetch(`/v1/config-objects/${membership.configObjectId}/delete`, { method: "POST", headers });
+    }
+  }
+  const archived = await denApiFetch(`/v1/plugins/${pluginId}/archive`, { method: "POST", headers });
+  if (!archived.response.ok && archived.response.status !== 404) {
+    ctx.log(`Plugin archive returned ${archived.response.status}: ${archived.text.slice(0, 200)}`);
+  }
+}
+
+async function prepareSignedInDesktop(ctx) {
+  await ensurePlatformAdmin(ctx);
+  await ensureOrgAdminContext(ctx);
+  await ensureConnectCapabilityDefaultOn(ctx);
+  await seedMarketplacePlugin(ctx);
+  await signDesktopIntoCloud(ctx);
+  await clearDesktopConfigCache(ctx);
+  await completeDesktopCloudOnboardingIfNeeded(ctx);
+  await remountDesktop(ctx);
+  await waitForCloudMcpSync(ctx);
+}
+
+async function signDesktopIntoCloud(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 120_000, label: "desktop control API" });
+  await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", { timeoutMs: 30_000, label: "desktop bridge" });
+  const bootstrap = { baseUrl: DEN_API_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
+  const written = await ctx.eval(`(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!bridge) return { ok: false };
+    await bridge("setDesktopBootstrapConfig", ${JSON.stringify(bootstrap)});
+    localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_API_URL)});
+    localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(DEN_API_URL)});
+    localStorage.removeItem('openwork.den.authToken');
+    localStorage.removeItem('openwork.den.activeOrgId');
+    localStorage.removeItem('openwork.den.activeOrgSlug');
+    localStorage.removeItem('openwork.den.activeOrgName');
+    localStorage.removeItem('openwork.den.mcp.sync');
+    return { ok: true };
+  })()`, { awaitPromise: true });
+  ctx.assert(written?.ok, "Failed to write desktop bootstrap config.");
+  await clearDesktopConfigCache(ctx);
+  await ctx.eval("location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after bootstrap reload" });
+  await ctx.waitFor("(document.getElementById('root')?.childElementCount ?? 0) > 0", { timeoutMs: 60_000, label: "react root mounted after bootstrap reload" });
+
+  const handoff = await denApiFetch("/v1/auth/desktop-handoff", {
+    method: "POST",
+    headers: { authorization: `Bearer ${requireStateValue(state.orgAdminToken, "org admin token")}` },
+    body: JSON.stringify({ desktopScheme: "openwork" }),
+  });
+  ctx.assert(handoff.response.ok, `Handoff create failed: ${handoff.response.status} ${handoff.text.slice(0, 300)}`);
+  await ctx.control("auth.exchange-grant", { grant: handoff.body.grant, baseUrl: DEN_API_URL });
+  await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", {
+    timeoutMs: 45_000,
+    label: "persisted den auth token",
+  });
+  await ctx.waitFor(`localStorage.getItem('openwork.den.activeOrgId') === ${JSON.stringify(requireStateValue(state.orgId, "organization id"))}`, {
+    timeoutMs: 60_000,
+    label: "active org resolved",
+  });
+}
+
+async function clearDesktopConfigCache(ctx) {
+  await ctx.eval(`(() => {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith('openwork.den.desktopConfig:')) localStorage.removeItem(key);
+    }
+    return true;
+  })()`);
+}
+
+async function completeDesktopCloudOnboardingIfNeeded(ctx) {
+  await dismissStaleDialogs(ctx);
+  await ctx.clickText("Continue with organization", { timeoutMs: 5_000 }).catch(() => {});
+  await ctx.clickText("Continue to workspace", { timeoutMs: 8_000 }).catch(() => {});
+  const needsFolder = await ctx.eval("Boolean(document.querySelector('input[placeholder=\"/workspace/my-project\"]'))").catch(() => false);
+  if (needsFolder) {
+    await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_PATH);
+    await ctx.clickText("Use this folder", { timeoutMs: 10_000 });
+    await ctx.waitFor("window.location.hash.includes('/workspace/')", { timeoutMs: 60_000, label: "workspace open after folder selection" });
+  }
+  await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')].find((candidate) => (candidate.textContent ?? '').trim() === 'Continue without OpenWork Models');
+    button?.click();
+    return true;
+  })()`);
+}
+
+async function remountDesktop(ctx) {
+  await clearDesktopConfigCache(ctx);
+  let remountReady = false;
+  for (let attempt = 0; attempt < 3 && !remountReady; attempt += 1) {
+    await ctx.eval("location.reload()");
+    try {
+      await ctx.waitFor("Boolean(window.__openworkControl) && (document.getElementById('root')?.childElementCount ?? 0) > 0", { timeoutMs: 45_000, label: `desktop alive after reload (attempt ${attempt + 1})` });
+      remountReady = true;
+    } catch {
+      // Retry a blank renderer boot.
+    }
+  }
+  ctx.assert(remountReady, "Desktop never became interactive after remount reloads.");
+  await completeDesktopCloudOnboardingIfNeeded(ctx);
+}
+
+async function waitForCloudMcpSync(ctx) {
+  await ctx.waitFor(
+    "Boolean(localStorage.getItem('openwork.den.mcp.sync'))",
+    { timeoutMs: 180_000, label: "openwork.den.mcp.sync marker" },
+  );
+}
+
+async function navigateToSettingsTab(ctx, tab) {
+  await dismissStaleDialogs(ctx);
+  const workspaceId = await ctx.eval("(window.location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? localStorage.getItem('openwork.react.activeWorkspace') ?? ''");
+  await ctx.navigateHash(workspaceId ? `/workspace/${workspaceId}/settings/${tab}` : `/settings/${tab}`);
+  await ctx.waitFor(`window.location.hash.includes('/settings/${tab}')`, { timeoutMs: 30_000, label: `${tab} settings route` });
+  try {
+    await ctx.waitFor("(document.body?.innerText ?? '').includes('Back to app')", { timeoutMs: 10_000, label: "settings surface mounted" });
+  } catch {
+    await ctx.eval("location.reload()");
+    await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after settings recovery reload" });
+    await ctx.waitFor("(document.body?.innerText ?? '').includes('Back to app')", { timeoutMs: 60_000, label: "settings surface mounted after reload" });
+  }
+}
+
+async function dismissStaleDialogs(ctx) {
+  await ctx.eval(`(() => {
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true }));
+    for (const button of document.querySelectorAll('[aria-label="Close"], [data-dialog-close]')) {
+      if (button instanceof HTMLElement) button.click();
+    }
+    return true;
+  })()`).catch(() => {});
+  await sleep(150);
+}
+
+async function waitForConnectOrganizationRow(ctx, name) {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const found = await ctx.eval(`(() => {
+      const rows = [...document.querySelectorAll('[data-testid="connect-organization-row"]')];
+      return rows.some((row) => (row.innerText ?? '').includes(${JSON.stringify(name)}));
+    })()`);
+    if (found) return;
+    await ctx.control("extensions.refresh-marketplace").catch(() => {});
+    await sleep(2_000);
+  }
+  ctx.assert(false, `Connect organization row did not render: ${name}`);
+}
+
+async function waitForMarketplacePlugin(ctx, name) {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const found = await ctx.eval(`document.body.innerText.includes(${JSON.stringify(name)})`);
+    if (found) return;
+    await ctx.control("extensions.refresh-marketplace").catch(() => {});
+    await sleep(2_000);
+  }
+  ctx.assert(false, `Marketplace plugin did not render: ${name}`);
+}
+
+async function scrollConnectGroup(ctx, group) {
+  await ctx.eval(`(() => {
+    const group = document.querySelector('[data-connect-group=${JSON.stringify(group)}]');
+    group?.scrollIntoView({ block: 'center' });
+    return Boolean(group);
+  })()`);
+  await sleep(300);
+}
+
+async function readConnectState(ctx, name) {
+  return ctx.eval(`(() => {
+    const compact = (entry) => (entry?.innerText ?? entry?.textContent ?? '').replace(/\\s+/g, ' ').trim();
+    const groups = {};
+    for (const group of document.querySelectorAll('[data-connect-group]')) {
+      groups[group.getAttribute('data-connect-group')] = compact(group);
+    }
+    const row = [...document.querySelectorAll('[data-testid="connect-organization-row"]')]
+      .find((entry) => compact(entry).includes(${JSON.stringify(name)}));
+    return {
+      pageText: document.body.innerText,
+      groups,
+      rowText: compact(row),
+      rowButtons: [...(row?.querySelectorAll('button') ?? [])].map(compact),
+    };
+  })()`);
+}
+
+async function readMarketplaceState(ctx, name) {
+  return ctx.eval(`(() => {
+    const compact = (entry) => (entry?.innerText ?? entry?.textContent ?? '').replace(/\\s+/g, ' ').trim();
+    const buttons = [...document.querySelectorAll('button')];
+    const pluginCard = buttons.find((button) => compact(button).includes(${JSON.stringify(name)}));
+    return {
+      pageText: document.body.innerText,
+      buttonTexts: buttons.map(compact),
+      pluginCardText: compact(pluginCard),
+    };
+  })()`);
+}
+
+function assertNoMarketplaceInstallButtons(ctx, proof) {
+  const forbidden = proof.buttonTexts.filter((text) => ["Add", "Install", "Update"].includes(text));
+  ctx.assert(forbidden.length === 0, `Removed marketplace install/update buttons rendered: ${JSON.stringify(forbidden)}`);
+}
+
+async function readExtensionsLegacyState(ctx) {
+  return ctx.eval(`(() => ({ pageText: document.body.innerText }))()`);
+}
+
+async function runSeededCapabilityAgentTurn(ctx) {
+  await navigateToSession(ctx);
+  await ctx.waitFor(
+    "Boolean(window.__openworkControl?.listActions().find((action) => action.id === 'session.create_task' && !action.disabled))",
+    { timeoutMs: 20_000, label: "session.create_task available" },
+  );
+  await ctx.control("session.create_task");
+  await ctx.waitFor(
+    `(() => {
+      const route = window.__openworkControl.snapshot().route || "";
+      return /ses_[A-Za-z0-9]+/.test(route);
+    })()`,
+    { timeoutMs: 30_000, label: "new session active" },
+  );
+
+  const prompt = `Use the OpenWork Cloud Control capability named ${SKILL_NAME}. Search for it first, execute the matched capability, and tell me the exact proof phrase.`;
+  const pasted = await ctx.eval(`(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
+      || document.querySelector('[contenteditable="true"]');
+    if (!editor) return { ok: false, reason: "composer not found" };
+    editor.focus();
+    const data = new DataTransfer();
+    data.setData('text/plain', ${JSON.stringify(prompt)});
+    editor.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data }));
+    return { ok: true };
+  })()`);
+  ctx.assert(pasted?.ok, `Composer not ready: ${pasted?.reason ?? "unknown"}`);
+
+  await ctx.waitFor(`(() => {
+    const button = Array.from(document.querySelectorAll('button'))
+      .find((entry) => /run task|send|run/i.test((entry.textContent || '').trim()) && !entry.disabled);
+    if (button) { button.click(); return true; }
+    return false;
+  })()`, { timeoutMs: 10_000, label: "submit button enabled" });
+}
+
+async function navigateToSession(ctx) {
+  const workspaceId = await ctx.eval("(window.location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? localStorage.getItem('openwork.react.activeWorkspace') ?? ''");
+  await ctx.navigateHash(workspaceId ? `/workspace/${workspaceId}/session` : "/session");
+  await ctx.waitFor("window.location.hash.includes('/session')", { timeoutMs: 30_000, label: "session route" });
+}
+
+async function seedLegacyLocalImport(ctx) {
+  const pluginId = requireStateValue(state.pluginId, "plugin id");
+  const token = requireStateValue(state.orgAdminToken, "org admin token");
+  const resolvedResponse = await denApiFetch(`/v1/plugins/${encodeURIComponent(pluginId)}/resolved`, {
+    headers: { authorization: `Bearer ${token}` },
+  });
+  ctx.assert(resolvedResponse.response.ok, `Plugin resolved fetch failed: ${resolvedResponse.response.status} ${resolvedResponse.text.slice(0, 300)}`);
+  const resolved = { plugin: state.plugin, memberships: resolvedResponse.body?.items ?? [] };
+
+  // Eval-only seeding: call the still-alive local OpenWork server cloud-plugin
+  // install route directly to simulate a pre-D2 legacy import. No UI path should
+  // call this route for Den marketplace plugins anymore.
+  const result = await ctx.eval(`(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!bridge) return { ok: false, reason: "Electron bridge unavailable" };
+    const info = await bridge("openworkServerInfo");
+    const baseUrl = String(info?.baseUrl ?? "").replace(/\\/+$/, "");
+    const token = String(info?.ownerToken || info?.clientToken || "").trim();
+    const workspaceId = (location.hash.match(/\\/workspace\\/([^/]+)/) || [])[1] || localStorage.getItem("openwork.react.activeWorkspace") || "";
+    if (!baseUrl || !token || !workspaceId) return { ok: false, reason: "Missing OpenWork server connection" };
+    const response = await fetch(baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/cloud-plugins", {
+      method: "POST",
+      headers: { authorization: "Bearer " + token, "content-type": "application/json" },
+      body: JSON.stringify({
+        marketplaceId: ${JSON.stringify(state.marketplaceId)},
+        marketplace: ${JSON.stringify(state.marketplace)},
+        resolved: ${JSON.stringify(resolved)},
+      }),
+    });
+    const text = await response.text();
+    let body;
+    try { body = JSON.parse(text); } catch { body = text; }
+    return { ok: response.ok, status: response.status, body, text };
+  })()`, { awaitPromise: true });
+  ctx.assert(result?.ok, `Legacy local import seeding failed: ${result?.status ?? "n/a"} ${String(result?.text ?? result?.reason ?? "").slice(0, 300)}`);
+  await ctx.control("extensions.refresh-marketplace").catch(() => {});
+}
+
+async function workspaceServerJson(ctx, path) {
+  return ctx.eval(`(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!bridge) throw new Error("Electron bridge unavailable");
+    const info = await bridge("openworkServerInfo");
+    const baseUrl = String(info?.baseUrl ?? "").replace(/\\/+$/, "");
+    const token = String(info?.ownerToken || info?.clientToken || "").trim();
+    const workspaceId = (location.hash.match(/\\/workspace\\/([^/]+)/) || [])[1] || localStorage.getItem("openwork.react.activeWorkspace") || "";
+    if (!baseUrl || !token || !workspaceId) throw new Error("Missing OpenWork server connection");
+    const response = await fetch(baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + ${JSON.stringify(path)}, {
+      headers: { authorization: "Bearer " + token },
+    });
+    const text = await response.text();
+    let body;
+    try { body = JSON.parse(text); } catch { body = text; }
+    if (!response.ok) throw new Error(${JSON.stringify(path)} + " -> " + response.status + " " + text.slice(0, 200));
+    return body;
+  })()`, { awaitPromise: true });
+}
+
+async function assertLegacyImportArtifacts(ctx) {
+  await ctx.waitFor(
+    `(async () => {
+      const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+      if (!bridge) return false;
+      const info = await bridge("openworkServerInfo");
+      const baseUrl = String(info?.baseUrl ?? "").replace(/\\/+$/, "");
+      const token = String(info?.ownerToken || info?.clientToken || "").trim();
+      const workspaceId = (location.hash.match(/\\/workspace\\/([^/]+)/) || [])[1] || localStorage.getItem("openwork.react.activeWorkspace") || "";
+      if (!baseUrl || !token || !workspaceId) return false;
+      const response = await fetch(baseUrl + "/workspace/" + encodeURIComponent(workspaceId) + "/skills", {
+        headers: { authorization: "Bearer " + token },
+      });
+      if (!response.ok) return false;
+      const body = await response.json();
+      return Array.isArray(body.items) && body.items.some((item) => item.name === ${JSON.stringify(SKILL_NAME)});
+    })()`,
+    { timeoutMs: 45_000, label: `legacy imported skill ${SKILL_NAME}` },
+  );
+  const imports = await workspaceServerJson(ctx, "/cloud-plugins");
+  ctx.assert(Boolean(imports.plugins?.[requireStateValue(state.pluginId, "plugin id")]), "Imported cloud plugin record missing after legacy seed.");
+}

--- a/evals/flows/org-connections-capability.flow.mjs
+++ b/evals/flows/org-connections-capability.flow.mjs
@@ -182,26 +182,23 @@ export default {
     {
       name: "Frame 5",
       run: async (ctx) => {
-        await ctx.prove("The desktop extensions view shows Acme's Notion org connection as available to connect", {
+        await ctx.prove("OpenWork Connect shows Acme's Notion org connection as available to connect", {
           voiceover: vo[4],
           action: async () => {
-            await remountDesktopExtensions(ctx);
-            await openDesktopMarketplace(ctx);
-            await clickDesktopRefreshIfAvailable(ctx);
-            await waitForDesktopOrgConnection(ctx, NOTION_NAME);
-            // The org card renders below the built-in extensions; bring it
-            // into the viewport so the frame visually shows the claim.
+            await remountDesktopConnect(ctx);
+            await waitForDesktopConnectOrgConnection(ctx, NOTION_NAME);
             await ctx.eval(`(() => {
-              const leaf = [...document.querySelectorAll("*")]
-                .find((el) => el.children.length === 0 && (el.textContent ?? "").includes("Available from your organization"));
-              leaf?.scrollIntoView({ block: "center" });
-              return Boolean(leaf);
+              const row = [...document.querySelectorAll('[data-testid="connect-organization-row"]')]
+                .find((entry) => (entry.textContent ?? '').includes(${JSON.stringify(NOTION_NAME)}));
+              row?.scrollIntoView({ block: "center" });
+              return Boolean(row);
             })()`);
             await new Promise((resolve) => setTimeout(resolve, 500));
           },
           assert: async () => {
             await ctx.expectText(NOTION_NAME, { timeoutMs: 30_000 });
-            await ctx.expectText("Available from your organization", { timeoutMs: 30_000 });
+            await ctx.expectText("NEEDS YOUR SIGN-IN", { timeoutMs: 30_000 });
+            await ctx.expectText("Connect your account", { timeoutMs: 30_000 });
 
             const usable = await fetchMcpConnections(ctx, "usable");
             const notion = usable.find((connection) => connection.name === NOTION_NAME);
@@ -210,8 +207,8 @@ export default {
             ctx.output("desktop-usable-notion", JSON.stringify({ notion }, null, 2));
           },
           screenshot: {
-            name: "desktop-shows-notion-org-connection",
-            requireText: ["Notion", "Available from your organization"],
+            name: "desktop-connect-shows-notion-org-connection",
+            requireText: ["From your organization", "NEEDS YOUR SIGN-IN", "Notion", "Connect your account"],
           },
         });
       },
@@ -219,10 +216,10 @@ export default {
     {
       name: "Frame 6",
       run: async (ctx) => {
-        await withClient(ctx, ADMIN_CDP_URL, async () => {
-          await ctx.prove("Turning the capability back off removes Connections from den-web again", {
-            voiceover: vo[5],
-            action: async () => {
+        await ctx.prove("Turning the capability back off removes Notion from OpenWork Connect", {
+          voiceover: vo[5],
+          action: async () => {
+            await withClient(ctx, ADMIN_CDP_URL, async () => {
               await signInToDenWebWithoutOrg(ctx, PLATFORM_ADMIN_EMAIL, PLATFORM_ADMIN_PASSWORD);
               await openAdminOrganizationsForAcme(ctx);
               const checked = await readAcmeMcpConnectionsCheckbox(ctx);
@@ -239,34 +236,29 @@ export default {
                 const links = [...nav.querySelectorAll('a')];
                 return !links.some((link) => (link.textContent ?? '').includes('Your Connections') || (link.getAttribute('href') ?? '').includes('/mcp-connections'));
               })()`, { timeoutMs: 30_000, label: "Connections nav removed" });
-            },
-            assert: async () => {
-              const admin = await fetchAdminCapabilities(ctx);
-              ctx.assert(admin.mcpConnections === false, "Admin API still reported mcpConnections on after turning it off.");
+            });
+            await remountDesktopConnect(ctx);
+            await waitForDesktopConnectOrgConnectionGone(ctx, NOTION_NAME);
+          },
+          assert: async () => {
+            const admin = await fetchAdminCapabilities(ctx);
+            ctx.assert(admin.mcpConnections === false, "Admin API still reported mcpConnections on after turning it off.");
 
-              const orgView = await fetchOrgCapabilities(ctx);
-              ctx.assert(orgView.mcpConnections === false, "/v1/org still reported mcpConnections on after turning it off.");
+            const orgView = await fetchOrgCapabilities(ctx);
+            ctx.assert(orgView.mcpConnections === false, "/v1/org still reported mcpConnections on after turning it off.");
 
-              const nav = await readDashboardNav(ctx);
-              assertNoConnectionsNav(ctx, nav);
-              ctx.output("mcp-connections-off-again", JSON.stringify({ admin, orgView, nav }, null, 2));
-            },
-            screenshot: {
-              name: "dashboard-mcp-connections-off-again",
-              requireText: ["Dashboard"],
-              rejectText: ["Your Connections"],
-            },
-          });
+            const visible = await desktopConnectOrgConnectionVisible(ctx, NOTION_NAME);
+            ctx.assert(!visible, "Notion org connection row still rendered in OpenWork Connect after disabling the capability.");
+            const usable = await fetchMcpConnections(ctx, "usable");
+            ctx.assert(usable.length === 0, `Usable MCP connections were still visible after turning the capability off: ${JSON.stringify(usable)}`);
+            ctx.output("mcp-connections-off-again", JSON.stringify({ admin, orgView, usable }, null, 2));
+          },
+          screenshot: {
+            name: "desktop-connect-notion-off-again",
+            requireText: ["Connect"],
+            rejectText: [NOTION_NAME, "NEEDS YOUR SIGN-IN", "Something went wrong"],
+          },
         });
-
-        await remountDesktopExtensions(ctx);
-        await clickDesktopRefreshIfAvailable(ctx);
-        await waitForDesktopOrgCardsGone(ctx);
-        await ctx.expectNoText("Available from your organization");
-
-        const usable = await fetchMcpConnections(ctx, "usable");
-        ctx.assert(usable.length === 0, `Usable MCP connections were still visible after turning the capability off: ${JSON.stringify(usable)}`);
-        ctx.output("desktop-usable-off-again", JSON.stringify({ connections: usable }, null, 2));
       },
     },
   ],
@@ -841,20 +833,19 @@ async function openDesktopExtensions(ctx) {
   );
 }
 
-async function openDesktopMarketplace(ctx) {
-  await ctx.clickText("Marketplace", { selector: "button", timeoutMs: 30_000 });
-  await ctx.waitFor("document.body.innerText.includes('Extension Marketplace')", {
-    timeoutMs: 30_000,
-    label: "desktop extension marketplace",
-  });
+async function openDesktopConnect(ctx) {
+  await closeDesktopDialogs(ctx);
+  await ctx.navigateHash("/settings/connect");
+  await ctx.waitFor("window.location.hash.includes('/settings/connect')", { timeoutMs: 30_000, label: "desktop connect route" });
+  await ctx.waitFor("document.body.innerText.includes('Connect')", { timeoutMs: 60_000, label: "desktop connect view" });
 }
 
-async function remountDesktopExtensions(ctx) {
+async function remountDesktopConnect(ctx) {
   await closeDesktopDialogs(ctx);
   await ctx.eval("location.reload()");
   await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 120_000, label: "desktop control API after reload" });
   await completeDesktopCloudOnboardingIfNeeded(ctx);
-  await openDesktopExtensions(ctx);
+  await openDesktopConnect(ctx);
 }
 
 async function clickDesktopRefreshIfAvailable(ctx) {
@@ -885,18 +876,29 @@ async function waitForDesktopOrgCardsGone(ctx) {
   ctx.assert(false, "Organization MCP cards did not disappear from desktop extensions.");
 }
 
-async function waitForDesktopOrgConnection(ctx, name) {
+async function desktopConnectOrgConnectionVisible(ctx, name) {
+  return ctx.eval(`(() => {
+    return [...document.querySelectorAll('[data-testid="connect-organization-row"]')]
+      .some((row) => (row.textContent ?? '').includes(${JSON.stringify(name)}));
+  })()`);
+}
+
+async function waitForDesktopConnectOrgConnection(ctx, name) {
   const deadline = Date.now() + 90_000;
   while (Date.now() < deadline) {
-    const found = await ctx.eval(`(() => {
-      const text = document.body.innerText;
-      return text.includes(${JSON.stringify(name)}) && text.includes('Available from your organization');
-    })()`);
-    if (found) {
-      return;
-    }
-    await clickDesktopRefreshIfAvailable(ctx);
+    if (await desktopConnectOrgConnectionVisible(ctx, name)) return;
+    await ctx.control("extensions.refresh-marketplace").catch(() => {});
     await sleep(2_000);
   }
-  ctx.assert(false, `${name} org MCP connection did not render in desktop extensions.`);
+  ctx.assert(false, `${name} org MCP connection did not render in OpenWork Connect.`);
+}
+
+async function waitForDesktopConnectOrgConnectionGone(ctx, name) {
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    if (!(await desktopConnectOrgConnectionVisible(ctx, name))) return;
+    await ctx.control("extensions.refresh-marketplace").catch(() => {});
+    await sleep(1_000);
+  }
+  ctx.assert(false, `${name} org MCP connection did not disappear from OpenWork Connect.`);
 }

--- a/evals/voiceovers/cloud-plugin-mcp-warning.md
+++ b/evals/voiceovers/cloud-plugin-mcp-warning.md
@@ -1,11 +1,11 @@
-# Cloud plugin MCP warnings
+# Cloud plugin MCP warning path retired
 
-This demo proves that marketplace plugins can bundle both skills and MCP servers, and that a bad MCP payload no longer disappears silently.
+This demo used to prove local marketplace import warnings. It now proves the retired path stays retired: Den marketplace plugins are shown as cloud-delivered, so malformed bundles cannot partially install local files from the desktop marketplace.
 
-1. I’m signed in to the local Acme cloud org and open the Extension Marketplace. Two fresh org plugins are visible side by side: one intentionally broken MCP bundle and one valid Linear MCP bundle.
+1. I’m signed in to the local Acme cloud org and open the Extension Marketplace. Two fresh org plugins are visible side by side: one intentionally broken MCP bundle and one valid Linear MCP bundle, both marked as running in the cloud.
 
-2. I install the broken bundle first. The skill still imports, but OpenWork now warns me that the Broken MCP component could not be installed because no server config with a url or command was found.
+2. I open the broken bundle first. The old Add action is gone, the row is Active · runs in cloud, and no local warning or partial skill import happens.
 
-3. I check the durable state after that warning. The skill is listed for this workspace, while the MCP settings page has no broken server row, so the app is honest about the partial install.
+3. I check durable local state after viewing that bundle. The broken skill was not installed and the MCP settings page has no broken server row, because viewing cloud-delivered marketplace content is non-destructive.
 
-4. I install the valid bundle next and return to MCP settings without reloading the engine. The Linear MCP appears in Your apps immediately, proving the valid remote server was installed and hot-synced.
+4. I open the valid bundle next. It also stays Active · runs in cloud with no Add action, and the Linear MCP is not written into local MCP settings from the marketplace UI.

--- a/evals/voiceovers/connect-cloud-partition.md
+++ b/evals/voiceovers/connect-cloud-partition.md
@@ -1,4 +1,4 @@
-# connect-cloud-partition — Connect lists cloud-runnable capabilities and Extensions keeps desktop installs
+# connect-cloud-partition — Connect lists cloud-runnable capabilities and Extensions stays local
 
 Cast is Alex, the Acme Robotics admin, using the OpenWork desktop app against the local Den stack. The proof seeds one organization marketplace with a ready cloud skill, one plugin that still needs an admin MCP connection, one desktop-only plugin, and one per-member team connection.
 
@@ -8,4 +8,4 @@ Cast is Alex, the Acme Robotics admin, using the OpenWork desktop app against th
 
 3. Because Alex is an admin, Connect also shows Needs admin setup. The plugin with an unmatched MCP dependency appears with the setup affordance that sends admins to Cloud connection management.
 
-4. Alex switches to Extensions and opens Marketplace while Connect mode is still on. The filtered marketplace shows only the desktop-only seeded plugin with its install action; the cloud-ready plugin is absent because it lives in Connect.
+4. Alex switches to Extensions and opens Marketplace. Organization marketplace plugins are absent there now — including the desktop-only seed — because legacy Extensions only keeps local/built-in affordances while marketplace delivery runs through Connect.

--- a/evals/voiceovers/connect-delivery-switch.md
+++ b/evals/voiceovers/connect-delivery-switch.md
@@ -1,11 +1,11 @@
-# connect-delivery-switch — Marketplace delivery moves to Connect
+# connect-delivery-switch — retired switch now proves Connect-only delivery
 
-Cast is Alex, the Acme Robotics admin, using the OpenWork desktop app against the local Den stack. The proof toggles Acme's Connect capability around one seeded marketplace plugin so the old desktop import path and the new cloud rail can be compared directly.
+Cast is Alex, the Acme Robotics admin, using the OpenWork desktop app against the local Den stack. This older switch proof is now retired into the new contract: toggling Acme's Connect capability must not bring back desktop imports for Den marketplace plugins.
 
-1. With Connect turned off, Alex opens Extensions and switches to Marketplace. The familiar My Extensions / Marketplace toggle is still present, and the seeded marketplace plugin is installable just like today's desktop import flow.
+1. With Connect turned off, Alex opens the organization Marketplace. The seeded plugin is already Active · runs in cloud, and there is no Add, Install, or Update button.
 
-2. The platform admin enables Acme's Connect capability. Back in Extensions, Marketplace is no longer a tab; Alex sees a short hint that marketplace content now lives in Connect, with a button to open it.
+2. The platform admin enables Acme's Connect capability. Back in Extensions, the Marketplace tab still exists for local/built-in affordances, but the seeded organization plugin is absent.
 
-3. Alex opens Connect. In the active Connect state, a From your marketplace section lists the same seeded plugin as Active · runs in cloud, with no install button because delivery now happens through the cloud rail.
+3. Alex opens Connect. In the active Connect state, From your organization lists the same seeded plugin as ready, with no install button because delivery happens through the cloud rail.
 
-4. The platform admin turns Connect back off. Extensions restores the Marketplace toggle and the seeded plugin is installable again, proving the rollout switch is reversible.
+4. The platform admin turns Connect back off. The organization Marketplace still shows the seeded plugin as cloud-delivered only, proving the old reversible desktop-install path is gone.

--- a/evals/voiceovers/connections-beta-desktop.md
+++ b/evals/voiceovers/connections-beta-desktop.md
@@ -1,9 +1,9 @@
-# connections-beta-desktop — Desktop Marketplace shows alpha org connections last
+# connections-beta-desktop — Desktop Connect owns alpha org connections
 
 Cast is Alex, the Acme Robotics admin, using the OpenWork desktop app. This demo covers only display and navigation: the admin has published a per-member org MCP connection, but nobody connects a real account during the proof.
 
 1. Setup happens first: Alex publishes a beta-proof per-member tool for the org, then signs this desktop app into Acme through the real cloud handoff. The workspace opens cleanly, so the desktop is ready to show exactly what members will see.
 
-2. In Settings, Alex switches from My Extensions to Marketplace. The org tool appears with an Alpha pill, it sits as the last card in the grid, and the filter menu lists Organization MCP Connections last — alpha means available, but deliberately out of the default path.
+2. In Settings, Alex opens OpenWork Connect. The org tool appears under Needs your sign-in with Connect your account, so alpha org connections live in the Connect rail.
 
-3. Alex opens the tool details before anyone connects. The modal repeats the Alpha label, includes a Release stage row, and the action says Connect your account, so the desktop explains the untested per-member state before any authorization begins.
+3. Alex checks Extensions Marketplace next. The org tool is absent there, and the Organization MCP Connections filter is gone, proving Extensions stays local-only.

--- a/evals/voiceovers/marketplace-connect-only-delivery.md
+++ b/evals/voiceovers/marketplace-connect-only-delivery.md
@@ -1,0 +1,20 @@
+# marketplace-connect-only-delivery — org marketplace plugins arrive through OpenWork Connect, with nothing to install
+
+Context (not narrated): Phase D / PR D2 of the extensions drain. Den marketplace
+content is cloud-delivered unconditionally — the app no longer consults the org
+`connectEnabled` flag for delivery (the flag survives only as the rail kill
+switch). Extensions (Legacy) stays purely local (local MCPs, skills,
+GitHub/Claude plugin imports). Pre-existing imports keep working untouched.
+Frame 5 seeds a legacy import through the still-alive server install route to
+simulate pre-flip state; frame 4 runs a real agent turn on the seeded Den eval
+stack.
+
+1. My organization publishes a plugin to its marketplace, and on my desktop it simply appears in OpenWork Connect — already active, running in the cloud, with nothing to install.
+
+2. The old install path is really gone: the organization marketplace shows everything as running in the cloud — no Install buttons anywhere — and nobody had to flip a switch to get here.
+
+3. Extensions (Legacy) is purely local territory now: my MCPs, skills, and GitHub plugin imports, with no organization content mixed in.
+
+4. When I ask the agent to use the capability, it discovers it with search and executes it in the cloud — no files ever landed on my machine.
+
+5. And the plugin I imported back in the old days keeps working untouched — it just carries a local-copy badge now, managed through Connect.

--- a/evals/voiceovers/org-connections-capability.md
+++ b/evals/voiceovers/org-connections-capability.md
@@ -15,6 +15,6 @@ The old `DEN_MCP_CONNECTIONS_GATING_ENABLED` deployment flag is inert.
 
 4. The org dashboard now has Connections in the sidebar, and I publish the Notion preset for the whole team in a couple of clicks.
 
-5. On the member's desktop, the organization's Notion connection appears under extensions, ready to use.
+5. On the member's desktop, OpenWork Connect shows the organization's Notion connection under Needs your sign-in, ready for that member to connect.
 
-6. Uncheck the capability and everything goes uniformly dark again — dashboard and desktop agree, because every surface reads the same switch.
+6. Uncheck the capability and everything goes uniformly dark again — dashboard navigation disappears and the Connect org row is gone, because every surface reads the same switch.


### PR DESCRIPTION
## What

Phase D / PR D2: the desktop no longer offers local Install or Update actions for Den organization marketplace plugins, regardless of `connectEnabled`.

- Den marketplace plugins are always `cloud_active` or `cloud_active_local_copy`
- standalone Marketplace shows organization plugins as **Active · runs in cloud** / **Runs in cloud**
- embedded Extensions Marketplace excludes all Den plugin rows
- org MCP connection rows are removed from both Marketplace surfaces; OpenWork Connect is their only desktop home
- Extensions (Legacy) remains local: built-ins, local MCPs/skills, GitHub + Claude plugin imports
- old persisted install notifications navigate only; they can no longer trigger an import
- pre-existing imported copies are never removed, can still be uninstalled locally, and carry **Local copy installed** in Connect + Marketplace
- local setup state can no longer make the organization cloud capability appear unavailable

The Connect active-vs-pitch UI still honors `connectEnabled` as the org kill switch. D1 (#2843) and D1.1 (#2854) are already merged/deployed in merge order.

## Eval migrations

Legacy executable proofs that expected organization content in Extensions were rewritten/retired to the new contract, including delivery-switch, cloud partition, MCP warning, org capability, connections-beta desktop, and desktop org-MCP demos. Built-in/local Google Workspace Marketplace coverage remains unchanged.

## Verification

- `pnpm --filter @openwork/app typecheck` — pass
- `pnpm --filter @openwork/app test` — **322 pass / 0 fail** (63 files; existing zustand storage warnings only)
- all changed/new flow files `node --check` — pass
- `git diff --check` — pass
- Daytona two-sandbox proof (Den + Electron, exact branch revision): `marketplace-connect-only-delivery` — **PASSED, 5/5 frames + voiceover coverage**
  1. published plugin appears Ready in OpenWork Connect, no install action
  2. Marketplace shows Runs in cloud, no Add/Install/Update
  3. Extensions (Legacy) shows local MCP/GitHub affordances and no Den plugin
  4. real agent turn visibly calls `search_capabilities` then `execute_capability` and returns a unique proof phrase
  5. eval-seeded pre-D2 import retains skill + registry artifacts and shows Local copy installed

The flow also asserts the D1.1 null-reset contract to clean kill-switch state left by other long-lived eval flows; it records any fallback repair as explicit eval output.

Proof will be posted below with `pnpm fraimz --flow marketplace-connect-only-delivery --pr`.