### PR TITLE
refactor(app): decouple provider sync from marketplace snapshots (D3)

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -68,7 +68,6 @@ import {
   isCloudProviderOutOfSync,
   resolveCloudProviderCredentials,
 } from "./cloud-provider-config";
-import { refreshDesktopCloudSync } from "../../../../app/cloud/desktop-cloud-sync";
 import { dispatchNewProviders } from "../../../../app/lib/provider-events";
 import { updateManagedDisabledProviders } from "../managed-engine-config";
 import {
@@ -432,11 +431,6 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       );
     }
     setStateField("importedCloudProviders", nextProviders);
-    const target = await resolveOpenworkConfigTarget("write");
-    void refreshDesktopCloudSync({
-      openworkClient: target.openworkClient,
-      workspaceId: target.openworkWorkspaceId,
-    }).catch(() => null);
   };
 
   const readProjectConfigFile = async () => {

--- a/apps/app/tests/cloud-provider-reimport.test.ts
+++ b/apps/app/tests/cloud-provider-reimport.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test";
-import { parse } from "jsonc-parser";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
 
 import type {
   DenOrgLlmProviderConnection,
@@ -15,6 +16,17 @@ import {
 } from "../src/react-app/domains/connections/provider-auth/cloud-provider-config";
 
 const LPR_ID = "lpr_openrouter";
+
+const providerAuthStoreSourcePath = join(
+  import.meta.dir,
+  "..",
+  "src",
+  "react-app",
+  "domains",
+  "connections",
+  "provider-auth",
+  "store.ts",
+);
 
 const makeModel = (id: string, name = id): DenOrgLlmProviderModel => ({
   id,
@@ -118,5 +130,22 @@ describe("cloud provider runtime patch (re-import diff #2346)", () => {
 
     // After re-import the baseline advances -> in sync again.
     expect(isCloudProviderOutOfSync(updated, importedFrom(updated))).toBe(false);
+  });
+
+  test("provider baseline persistence does not refresh the desktop cloud snapshot", () => {
+    const source = readFileSync(providerAuthStoreSourcePath, "utf8");
+    const persistStart = source.indexOf("const persistImportedCloudProviders = async");
+    const persistEnd = source.indexOf("const readProjectConfigFile", persistStart);
+    expect(persistStart).toBeGreaterThanOrEqual(0);
+    expect(persistEnd).toBeGreaterThan(persistStart);
+
+    const persistSource = source.slice(persistStart, persistEnd);
+    expect(persistSource).toContain("const config = await readWorkspaceOpenworkConfigRecord();");
+    expect(persistSource).toContain("const cloudImports = readWorkspaceCloudImports(config);");
+    expect(persistSource).toContain("const nextConfig = withWorkspaceCloudImports(config");
+    expect(persistSource).toContain("const persisted = await writeWorkspaceOpenworkConfigRecord(nextConfig);");
+    expect(persistSource).toContain('setStateField("importedCloudProviders", nextProviders);');
+    expect(source).not.toContain("refreshDesktop" + "CloudSync");
+    expect(source).not.toContain("getResource" + "Snapshot");
   });
 });

--- a/evals/flows/provider-sync-stable-engine.flow.mjs
+++ b/evals/flows/provider-sync-stable-engine.flow.mjs
@@ -150,7 +150,7 @@ export default {
   id: "provider-sync-stable-engine",
   title: "Org cloud providers import once and the engine connection stays stable",
   kind: "user-facing",
-  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN"],
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [
     {
       name: "Frame 1",
@@ -194,7 +194,9 @@ export default {
               typeof payload?.openworkUrl === "string" && payload.openworkUrl.length > 0,
               "No openworkUrl in handoff response.",
             );
-            ctx.handoffUrl = payload.openworkUrl;
+            const handoffUrl = new URL(payload.openworkUrl);
+            handoffUrl.searchParams.set("denBaseUrl", ctx.env.OPENWORK_EVAL_DEN_WEB_URL.trim().replace(/\/+$/, ""));
+            ctx.handoffUrl = handoffUrl.toString();
 
             await ctx.navigateHash("/settings/cloud-account");
             await ctx.waitFor(


### PR DESCRIPTION
## What

Phase D / PR D3 removes provider reconciliation's last dependency on the shared Den marketplace snapshot pipeline.

Provider sync already:
- lists live providers through `GET /v1/llm-providers`
- compares them directly with `cloudImports.providers`
- imports/removes/updates runtime config and disposes the engine through its own store

After persisting that provider baseline, it also fired an ignored `refreshDesktopCloudSync` call to `/v1/resources` + `/workspace/:id/desktop-cloud-sync`. Provider pending changes from that route are never consumed; only the marketplace/extensions store consumes the shared result.

This PR removes that post-persist side effect and import. No Den API, local-server, type, persisted format, migration, credentials, model-comparison, or engine-reload changes.

This is the prerequisite that lets D4 delete the marketplace snapshot pipeline without provider risk.

## Verification

- `pnpm --filter @openwork/app typecheck` — pass
- focused provider tests — **15 pass / 0 fail**
- full app tests — **323 pass / 0 fail**
- `pnpm --filter @openwork/app test:desktop-cloud-sync` — **8 pass / 0 fail**
- source contract proves provider persistence still reads/writes `cloudImports.providers` and has no `refreshDesktopCloudSync` / `getResourceSnapshot` dependency
- repo grep: the only remaining production caller of `refreshDesktopCloudSync` is `extensions-store.ts` (removed in D4)
- `git diff --check` — pass

## End-to-end proof

Existing approved flow `provider-sync-stable-engine` ran on Daytona (exact branch Electron against the seeded Den sandbox): **PASSED, 5/5 frames + voiceover coverage**.

It proves:
1. clean stable workspace
2. real desktop handoff + Acme selection
3. org AI provider visible before workspace entry
4. exactly one provider import baseline and matching runtime provider
5. 60 seconds in session with zero "Reloading OpenCode config" flashes

The proof flow received a test-only fix: its pasted handoff URL now carries Den Web as `denBaseUrl` instead of the direct API origin, preventing the stale `API/api/den` 404.

Proof will be posted below.