### PR TITLE
feat(gmail): reply drafts keep the thread — quoted history, draft links, orphan-reply guard

### DIFF
--- a/apps/server/src/extensions/google-workspace.test.ts
+++ b/apps/server/src/extensions/google-workspace.test.ts
@@ -57,6 +57,10 @@ function accountRecord(email: string, sub: string, scopes: string[] = ["openid"]
   };
 }
 
+function base64Url(text: string): string {
+  return Buffer.from(text, "utf8").toString("base64url");
+}
+
 const previousEnv = {
   devMode: process.env.OPENWORK_DEV_MODE,
   plaintextVault: process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT,
@@ -298,6 +302,7 @@ describe("Google Workspace extension", () => {
     }, { directory: workspaceRoot });
     expect(result?.ok).toBe(true);
     expect(result?.result).toMatchObject({ id: "draft-1" });
+    expect(result?.result).toMatchObject({ draftUrl: "https://mail.google.com/mail/u/0/#drafts?compose=draft-message-1", threadUrl: null });
     expect(requests[0]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/drafts");
     const raw = requests[0]?.body.match(/"raw":"([^"]+)"/)?.[1] ?? "";
     const decoded = Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
@@ -309,6 +314,66 @@ describe("Google Workspace extension", () => {
     expect(decoded).toContain("Content-Type: application/pdf; name=\"acme-invoice-2026-001.pdf\"");
     expect(decoded).toContain("Content-Disposition: attachment; filename=\"acme-invoice-2026-001.pdf\"");
     expect(decoded).toContain(Buffer.from("%PDF-1.4\ninvoice bytes\n", "utf8").toString("base64"));
+  });
+
+  test("gmail_create_draft rejects reply-looking subjects", async () => {
+    await expect(callGoogleWorkspaceExtensionAction(createTestConfig(), "gmail_create_draft", {
+      to: ["sam@acme.test"],
+      subject: "Re: Project update",
+      body: "Thanks",
+    }, {})).rejects.toThrow(
+      new ApiError(400, "invalid_payload", "Subject looks like a reply. Use gmail_create_reply_draft instead so the Gmail thread is preserved."),
+    );
+  });
+
+  test("gmail_create_draft strips conservative markdown from prose", async () => {
+    process.env.OPENWORK_DEV_MODE = "1";
+    process.env.OPENWORK_GOOGLE_WORKSPACE_ALLOW_PLAINTEXT_VAULT = "1";
+    process.env.GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET = "secret";
+    const config = createTestConfig();
+    await writePlaintextVault(config, {
+      version: 2,
+      activeAccountId: "sub-one",
+      accounts: [accountRecord("one@example.com", "sub-one")],
+    });
+    const requests: { url: string; body: string }[] = [];
+    globalThis.fetch = Object.assign(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        requests.push({ url: String(input instanceof Request ? input.url : input), body: typeof init?.body === "string" ? init.body : "" });
+        return new Response(JSON.stringify({ id: "draft-1", message: { id: "draft-message-1" } }), { status: 200 });
+      },
+      { preconnect: previousFetch.preconnect },
+    );
+
+    await callGoogleWorkspaceExtensionAction(config, "gmail_create_draft", {
+      to: ["sam@acme.test"],
+      subject: "Project update",
+      body: [
+        "# Status update",
+        "",
+        "Please **review** the __terms__ and `confirm` before launch.",
+        "",
+        "- **Keep list marker**",
+        "> **Keep quoted text**",
+        "```",
+        "# keep fenced heading",
+        "```",
+      ].join("\n"),
+    }, {});
+
+    const raw = requests[0]?.body.match(/"raw":"([^"]+)"/)?.[1] ?? "";
+    const decoded = Buffer.from(raw.replace(/-/g, "+").replace(/_/g, "/"), "base64").toString("utf8");
+    expect(decoded).toContain([
+      "Status update",
+      "",
+      "Please review the terms and confirm before launch.",
+      "",
+      "- **Keep list marker**",
+      "> **Keep quoted text**",
+      "```",
+      "# keep fenced heading",
+      "```",
+    ].join("\n"));
   });
 
   test("gmail_create_reply_draft rejects accounts without the gmail.readonly scope", async () => {
@@ -342,6 +407,7 @@ describe("Google Workspace extension", () => {
       async (input: string | URL | Request, init?: RequestInit) => {
         const url = String(input instanceof Request ? input.url : input);
         if (url.includes("/messages/m1")) {
+          expect(url).toContain("format=full");
           return new Response(JSON.stringify({
             id: "m1",
             threadId: "thread-1",
@@ -353,7 +419,9 @@ describe("Google Workspace extension", () => {
                 { name: "From", value: "Alice <alice@example.com>" },
                 { name: "To", value: "One <one@example.com>, Bob <bob@example.com>" },
                 { name: "Cc", value: "Carol <carol@example.com>" },
+                { name: "Date", value: "Thu, 16 Jul 2026 15:21:00 +0000" },
               ],
+              parts: [{ mimeType: "text/plain", body: { data: base64Url("Original line\n> previous quote") } }],
             },
           }), { status: 200 });
         }
@@ -365,7 +433,11 @@ describe("Google Workspace extension", () => {
 
     const result = await callGoogleWorkspaceExtensionAction(config, "gmail_create_reply_draft", { messageId: "m1", body: "Thanks for the update.", replyAll: true }, {});
     expect(result?.ok).toBe(true);
-    expect(result?.result).toMatchObject({ id: "draft-1" });
+    expect(result?.result).toMatchObject({
+      id: "draft-1",
+      draftUrl: "https://mail.google.com/mail/u/0/#drafts?compose=draft-message-1",
+      threadUrl: "https://mail.google.com/mail/u/0/#all/thread-1",
+    });
     expect(requests[0]?.url).toBe("https://gmail.googleapis.com/gmail/v1/users/me/drafts");
     expect(requests[0]?.body).toContain('"threadId":"thread-1"');
     const raw = requests[0]?.body.match(/"raw":"([^"]+)"/)?.[1] ?? "";
@@ -375,7 +447,13 @@ describe("Google Workspace extension", () => {
     expect(decoded).toContain("Subject: Re: Project update");
     expect(decoded).toContain("In-Reply-To: <message-1@example.com>");
     expect(decoded).toContain("References: <root@example.com> <message-1@example.com>");
-    expect(decoded).toContain("Thanks for the update.");
+    expect(decoded).toContain([
+      "Thanks for the update.",
+      "",
+      "On Thu, 16 Jul 2026 at 15:21 UTC, Alice <alice@example.com> wrote:",
+      "> Original line",
+      "> > previous quote",
+    ].join("\n"));
     expect(decoded).not.toContain("one@example.com");
   });
 

--- a/apps/server/src/extensions/google-workspace.ts
+++ b/apps/server/src/extensions/google-workspace.ts
@@ -11,6 +11,10 @@ import type { ServerConfig } from "../types.js";
 export const GOOGLE_WORKSPACE_EXTENSION_ID = "google-workspace";
 
 const GMAIL_HARD_WRAP_MIN_LINE_LENGTH = 50;
+const GMAIL_QUOTE_BODY_LIMIT = 10_000;
+const GMAIL_REPLY_SUBJECT_RE = /^\s*(re|fwd?)\s*:/i;
+const UTC_WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
+const UTC_MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
 const GOOGLE_WORKSPACE_DESKTOP_CLIENT_ID = "929071212606-pmkqimjhm2tnp68kbklnout0irllj99h.apps.googleusercontent.com";
 const GOOGLE_WORKSPACE_CLIENT_ID_ENV = "OPENWORK_GOOGLE_WORKSPACE_OAUTH_CLIENT_ID";
 const GOOGLE_WORKSPACE_CLIENT_SECRET_ENV = "GOOGLE_WORKSPACE_OAUTH_CLIENT_SECRET";
@@ -75,15 +79,15 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
     extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
     action: "gmail_create_draft",
     title: "Create Gmail draft",
-    description: "Create a Gmail draft for the connected account. This does not send email.",
+    description: "Create a brand-new Gmail draft for the connected account. This does not send email. Returns draftUrl; always share it with the user so they can review and send in Gmail. Subjects starting with Re: or Fwd: are rejected here — use gmail_create_reply_draft so the thread is preserved.",
     inputSchema: {
       type: "object",
       properties: {
         to: { type: "array", items: { type: "string" }, description: "Recipient email addresses." },
         cc: { type: "array", items: { type: "string" }, description: "Optional CC recipients." },
         bcc: { type: "array", items: { type: "string" }, description: "Optional BCC recipients." },
-        subject: { type: "string", description: "Draft subject." },
-        body: { type: "string", description: "Plain text draft body. Separate paragraphs with blank lines and do not hard-wrap prose." },
+        subject: { type: "string", description: "Draft subject. Do not use Re: or Fwd: here; use gmail_create_reply_draft for replies." },
+        body: { type: "string", description: "Plain text draft body. Write plain prose with no markdown syntax, separate paragraphs with blank lines, and do not hard-wrap prose." },
         attachments: {
           type: "array",
           description: "Optional local files to attach. Paths may be relative to the active workspace/directory or absolute under an authorized workspace root.",
@@ -107,12 +111,12 @@ export const GOOGLE_WORKSPACE_EXTENSION_ACTIONS = [
     extensionId: GOOGLE_WORKSPACE_EXTENSION_ID,
     action: "gmail_create_reply_draft",
     title: "Create Gmail reply draft",
-    description: "Create a Gmail draft reply in an existing thread. This does not send email. Requires Gmail read access (gmail.readonly scope).",
+    description: "Create a Gmail draft reply in an existing thread. This does not send email. Requires Gmail read access (gmail.readonly scope). OpenWork appends the quoted conversation automatically; do not include quoted history. Returns draftUrl and threadUrl; always share draftUrl with the user so they can review and send in Gmail.",
     inputSchema: {
       type: "object",
       properties: {
         messageId: { type: "string", description: "Gmail message id to reply to." },
-        body: { type: "string", description: "Plain text reply body." },
+        body: { type: "string", description: "Plain text reply body. Write plain prose with no markdown syntax; do not include quoted history because OpenWork appends it automatically." },
         replyAll: { type: "boolean", description: "Reply to everyone on the original message. Defaults to true." },
       },
       required: ["messageId", "body"],
@@ -808,14 +812,21 @@ function gmailRawMessage(input: { to: string[]; cc?: string[]; bcc?: string[]; s
 // Generated prose is sometimes hard-wrapped before it reaches Gmail. Those
 // literal breaks become visible after send, especially on narrow screens.
 function normalizeGmailDraftBody(body: string): string {
-  return body.replace(/\r\n?/g, "\n").replace(/[^\n]+(?:\n[^\n]+)+/g, (block) => {
+  return body.replace(/\r\n?/g, "\n").replace(/[^\n]+(?:\n[^\n]+)*/g, (block) => {
     const lines = block.split("\n");
     const hasStructure = lines.some((line) => {
       const trimmed = line.trimStart();
       return trimmed.length !== line.length || /^(?:[-*+•]\s|\d+[.)]\s|>|```|~~~)/.test(trimmed);
     });
+    if (hasStructure) return block;
+
+    const cleanedLines = lines.map((line) => line
+      .replace(/^#{1,6}\s+/, "")
+      .replace(/\*\*([^*\n]+)\*\*/g, "$1")
+      .replace(/__([^_\n]+)__/g, "$1")
+      .replace(/`([^`\n]+)`/g, "$1"));
     const looksHardWrapped = lines.slice(0, -1).every((line) => line.trimEnd().length >= GMAIL_HARD_WRAP_MIN_LINE_LENGTH);
-    return hasStructure || !looksHardWrapped ? block : lines.map((line) => line.trim()).join(" ");
+    return lines.length > 1 && looksHardWrapped ? cleanedLines.map((line) => line.trim()).join(" ") : cleanedLines.join("\n");
   });
 }
 
@@ -878,6 +889,44 @@ function gmailReplySubject(subject: string): string {
 function gmailReplyReferences(references: string, messageId: string): string {
   const entries = references.trim().split(/\s+/).filter(Boolean);
   return entries.includes(messageId) ? entries.join(" ") : [...entries, messageId].join(" ");
+}
+
+function formatGmailQuoteDate(value: string): string {
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return `${UTC_WEEKDAYS[date.getUTCDay()]}, ${String(date.getUTCDate()).padStart(2, "0")} ${UTC_MONTHS[date.getUTCMonth()]} ${date.getUTCFullYear()} at ${String(date.getUTCHours()).padStart(2, "0")}:${String(date.getUTCMinutes()).padStart(2, "0")} UTC`;
+}
+
+function gmailBodyHasQuotedHistory(body: string): boolean {
+  return /^>\s?/m.test(body) && /^.*wrote:\s*$/m.test(body);
+}
+
+function buildGmailQuoteBlock(input: { from: string; date: string; body: string }): string {
+  const header = input.date ? `On ${formatGmailQuoteDate(input.date)}, ${input.from} wrote:` : `${input.from} wrote:`;
+  const truncated = input.body.length > GMAIL_QUOTE_BODY_LIMIT;
+  const quotedLines = input.body.slice(0, GMAIL_QUOTE_BODY_LIMIT).replace(/\r\n?/g, "\n").split("\n").map((line) => `> ${line}`);
+  if (truncated) quotedLines.push("> [message trimmed]");
+  return [header, ...quotedLines].join("\n");
+}
+
+function gmailDraftMessageId(value: unknown): string | null {
+  if (!isRecord(value)) return null;
+  const message = isRecord(value.message) ? value.message : null;
+  return typeof message?.id === "string" ? message.id : null;
+}
+
+function gmailDraftThreadId(value: unknown): string | null {
+  if (!isRecord(value)) return null;
+  const message = isRecord(value.message) ? value.message : null;
+  return typeof message?.threadId === "string" ? message.threadId : null;
+}
+
+function gmailDraftUrl(messageId: string | null): string | null {
+  return messageId ? `https://mail.google.com/mail/u/0/#drafts?compose=${encodeURIComponent(messageId)}` : null;
+}
+
+function gmailThreadUrl(threadId: string | null): string | null {
+  return threadId ? `https://mail.google.com/mail/u/0/#all/${encodeURIComponent(threadId)}` : null;
 }
 
 function requireScope(record: Record<string, unknown>, scope: string, code: string, message: string) {
@@ -1038,13 +1087,19 @@ async function googleWorkspaceCreateDraft(config: ServerConfig, args: Record<str
   const subject = readStringField(args, "subject");
   const body = typeof args.body === "string" ? args.body : "";
   if (!to.length || !subject || !body.trim()) throw new ApiError(400, "invalid_payload", "to, subject, and body are required");
+  if (GMAIL_REPLY_SUBJECT_RE.test(subject)) throw new ApiError(400, "invalid_payload", "Subject looks like a reply. Use gmail_create_reply_draft instead so the Gmail thread is preserved.");
   const attachments = await loadGmailDraftAttachments(config, context, gmailDraftAttachmentRequests(args.attachments));
   const { accessToken } = await googleWorkspaceAccessToken(config);
-  return fetchGoogleJson("https://gmail.googleapis.com/gmail/v1/users/me/drafts", {
+  const draft = await fetchGoogleJson("https://gmail.googleapis.com/gmail/v1/users/me/drafts", {
     method: "POST",
     headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
     body: JSON.stringify({ message: { raw: base64UrlString(gmailRawMessage({ to, cc, bcc, subject, body, attachments })) } }),
   });
+  return {
+    ...(isRecord(draft) ? draft : {}),
+    draftUrl: gmailDraftUrl(gmailDraftMessageId(draft)),
+    threadUrl: gmailThreadUrl(gmailDraftThreadId(draft)),
+  };
 }
 
 async function googleWorkspaceCreateReplyDraft(config: ServerConfig, args: Record<string, unknown>) {
@@ -1055,8 +1110,7 @@ async function googleWorkspaceCreateReplyDraft(config: ServerConfig, args: Recor
   const { record, accessToken } = await googleWorkspaceAccessToken(config);
   requireGmailReadScope(record);
   const url = new URL(`https://gmail.googleapis.com/gmail/v1/users/me/messages/${encodeURIComponent(messageId)}`);
-  url.searchParams.set("format", "metadata");
-  for (const header of ["Message-ID", "References", "Reply-To", "Subject", "From", "To", "Cc"]) url.searchParams.append("metadataHeaders", header);
+  url.searchParams.set("format", "full");
   const message = await fetchGoogleJson(url.toString(), { headers: { Authorization: `Bearer ${accessToken}` } });
   const payload = isRecord(message) ? message.payload : null;
   const threadId = isRecord(message) && typeof message.threadId === "string" ? message.threadId : "";
@@ -1068,7 +1122,11 @@ async function googleWorkspaceCreateReplyDraft(config: ServerConfig, args: Recor
   const to = uniqueEmailHeaders(replyAll ? [replyTarget, gmailHeader(payload, "To")] : [replyTarget], [ownEmail]);
   const cc = replyAll ? uniqueEmailHeaders([gmailHeader(payload, "Cc")], [ownEmail, ...to.map(emailHeaderKey)]) : [];
   if (!to.length) throw new ApiError(400, "invalid_payload", "Original message does not include reply recipients");
-  return fetchGoogleJson("https://gmail.googleapis.com/gmail/v1/users/me/drafts", {
+  const originalBody = gmailMessageText(payload);
+  const quotedBody = originalBody && !gmailBodyHasQuotedHistory(body)
+    ? `${body}\n\n${buildGmailQuoteBlock({ from: gmailHeader(payload, "From"), date: gmailHeader(payload, "Date"), body: originalBody })}`
+    : body;
+  const draft = await fetchGoogleJson("https://gmail.googleapis.com/gmail/v1/users/me/drafts", {
     method: "POST",
     headers: { Authorization: `Bearer ${accessToken}`, "Content-Type": "application/json" },
     body: JSON.stringify({
@@ -1078,7 +1136,7 @@ async function googleWorkspaceCreateReplyDraft(config: ServerConfig, args: Recor
           to,
           cc,
           subject: gmailReplySubject(gmailHeader(payload, "Subject")),
-          body,
+          body: quotedBody,
           headers: [
             { name: "In-Reply-To", value: originalMessageId },
             { name: "References", value: gmailReplyReferences(gmailHeader(payload, "References"), originalMessageId) },
@@ -1087,6 +1145,11 @@ async function googleWorkspaceCreateReplyDraft(config: ServerConfig, args: Recor
       },
     }),
   });
+  return {
+    ...(isRecord(draft) ? draft : {}),
+    draftUrl: gmailDraftUrl(gmailDraftMessageId(draft)),
+    threadUrl: gmailThreadUrl(threadId),
+  };
 }
 
 async function googleWorkspaceSearchFiles(config: ServerConfig, args: Record<string, unknown>) {

--- a/ee/apps/den-api/src/capability-sources/gmail.ts
+++ b/ee/apps/den-api/src/capability-sources/gmail.ts
@@ -32,14 +32,21 @@ function base64MimeContent(content: Buffer): string {
 // Generated prose is sometimes hard-wrapped before it reaches Gmail. Those
 // literal breaks become visible after send, especially on narrow screens.
 function normalizeDraftBody(body: string): string {
-  return body.replace(/\r\n?/g, "\n").replace(/[^\n]+(?:\n[^\n]+)+/g, (block) => {
+  return body.replace(/\r\n?/g, "\n").replace(/[^\n]+(?:\n[^\n]+)*/g, (block) => {
     const lines = block.split("\n")
     const hasStructure = lines.some((line) => {
       const trimmed = line.trimStart()
       return trimmed.length !== line.length || /^(?:[-*+•]\s|\d+[.)]\s|>|```|~~~)/.test(trimmed)
     })
+    if (hasStructure) return block
+
+    const cleanedLines = lines.map((line) => line
+      .replace(/^#{1,6}\s+/, "")
+      .replace(/\*\*([^*\n]+)\*\*/g, "$1")
+      .replace(/__([^_\n]+)__/g, "$1")
+      .replace(/`([^`\n]+)`/g, "$1"))
     const looksHardWrapped = lines.slice(0, -1).every((line) => line.trimEnd().length >= HARD_WRAP_MIN_LINE_LENGTH)
-    return hasStructure || !looksHardWrapped ? block : lines.map((line) => line.trim()).join(" ")
+    return lines.length > 1 && looksHardWrapped ? cleanedLines.map((line) => line.trim()).join(" ") : cleanedLines.join("\n")
   })
 }
 

--- a/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
+++ b/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
@@ -50,6 +50,10 @@ type GmailBodyState = {
   attachments: GoogleWorkspaceAttachment[]
 }
 
+const GMAIL_QUOTE_BODY_LIMIT = 10_000
+const UTC_WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"]
+const UTC_MONTHS = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"]
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
@@ -159,6 +163,45 @@ export function extractGmailThreadReplyContext(json: unknown): { lastMessageId: 
 
   const references = `${headers.get("references")?.trim() ?? ""} ${lastMessageId}`.trim()
   return { lastMessageId, references }
+}
+
+function formatGmailQuoteDate(value: string): string {
+  const date = new Date(value)
+  if (Number.isNaN(date.getTime())) return value
+  return `${UTC_WEEKDAYS[date.getUTCDay()]}, ${String(date.getUTCDate()).padStart(2, "0")} ${UTC_MONTHS[date.getUTCMonth()]} ${date.getUTCFullYear()} at ${String(date.getUTCHours()).padStart(2, "0")}:${String(date.getUTCMinutes()).padStart(2, "0")} UTC`
+}
+
+export function gmailBodyHasQuotedHistory(body: string): boolean {
+  return /^>\s?/m.test(body) && /^.*wrote:\s*$/m.test(body)
+}
+
+export function buildGmailQuoteBlock(input: { from: string; date: string; body: string }): string {
+  const header = input.date ? `On ${formatGmailQuoteDate(input.date)}, ${input.from} wrote:` : `${input.from} wrote:`
+  const truncated = input.body.length > GMAIL_QUOTE_BODY_LIMIT
+  const quotedLines = input.body.slice(0, GMAIL_QUOTE_BODY_LIMIT).replace(/\r\n?/g, "\n").split("\n").map((line) => `> ${line}`)
+  if (truncated) quotedLines.push("> [message trimmed]")
+  return [header, ...quotedLines].join("\n")
+}
+
+export function extractGmailThreadQuoteInput(json: unknown): { from: string; date: string; body: string } | null {
+  const root = isRecord(json) ? json : {}
+  const messages = readArray(root, "messages")
+  const lastMessage = messages.at(-1)
+  if (!isRecord(lastMessage)) return null
+
+  const payload = readRecord(lastMessage, "payload")
+  if (!payload) return null
+
+  const headers = readGmailHeaders(payload)
+  const state: GmailBodyState = { plain: null, html: null, attachments: [] }
+  collectGmailPart(payload, state)
+  if (!state.plain) return null
+
+  return {
+    from: headers.get("from") ?? "",
+    date: headers.get("date") ?? "",
+    body: state.plain,
+  }
 }
 
 export function truncateText(text: string, maxCharacters: number): { text: string; truncated: boolean } {

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -5,18 +5,21 @@ import { z } from "zod"
 import type { DenTypeId } from "@openwork-ee/utils/typeid"
 import { env } from "../../env.js"
 import { jsonValidator, orgMemberRoute, paramValidator, queryValidator } from "../../middleware/index.js"
-import { jsonResponse, unauthorizedSchema } from "../../openapi.js"
+import { invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import { buildGmailDraftRaw, readGmailDraftIds } from "../../capability-sources/gmail.js"
 import type { GmailDraftAttachment } from "../../capability-sources/gmail.js"
 import { getValidAccessToken } from "../../capability-sources/generic-oauth.js"
 import {
+  buildGmailQuoteBlock,
   buildDriveSearchQuery,
   extractCalendarEvents,
   extractDriveFiles,
   extractGmailAttachmentData,
   extractGmailMessage,
   extractGmailMessageIds,
+  extractGmailThreadQuoteInput,
   extractGmailThreadReplyContext,
+  gmailBodyHasQuotedHistory,
   truncateText,
 } from "../../capability-sources/google-workspace-api.js"
 import type { ConnectedAccountRow } from "../../capability-sources/oauth-credentials.js"
@@ -33,6 +36,7 @@ const GOOGLE_WORKSPACE_API_TIMEOUT_MS = 30_000
 const MAX_GMAIL_ATTACHMENT_BYTES = 10 * 1024 * 1024
 const MAX_GMAIL_ATTACHMENTS_TOTAL_BYTES = 20 * 1024 * 1024
 const MAX_GMAIL_ATTACHMENT_BASE64_LENGTH = Math.ceil(MAX_GMAIL_ATTACHMENT_BYTES / 3) * 4
+const GMAIL_REPLY_SUBJECT_RE = /^\s*(re|fwd?)\s*:/i
 
 const CONNECT_GOOGLE_ACCOUNT_MESSAGE = "Connect your Google account first: open Settings > Connect and use Connect your account on the Google Workspace row, or connect from the OpenWork Cloud dashboard."
 
@@ -46,9 +50,9 @@ const createDraftBodySchema = z.object({
   to: z.string().trim().min(3).max(320).describe("Recipient email address."),
   cc: z.string().trim().min(3).max(1_000).optional().describe("Optional comma-separated Cc email addresses."),
   bcc: z.string().trim().min(3).max(1_000).optional().describe("Optional comma-separated Bcc email addresses."),
-  subject: z.string().trim().min(1).max(500).describe("Draft subject line."),
-  body: z.string().min(1).max(50_000).describe("Plain-text draft body. Separate paragraphs with blank lines and do not hard-wrap prose."),
-  threadId: z.string().trim().min(1).max(512).optional().describe("Optional Gmail thread id to reply on. Get it from the gmail-messages capability. When set, the draft is attached to that thread as a reply — keep the thread's subject (e.g. 'Re: …')."),
+  subject: z.string().trim().min(1).max(500).describe("Draft subject line. For replies or forwards, include threadId; subjects starting with Re: or Fwd: are rejected without threadId so the draft stays on the existing conversation."),
+  body: z.string().min(1).max(50_000).describe("Plain-text draft body. Write plain prose with no markdown syntax, separate paragraphs with blank lines, and do not hard-wrap prose. For threaded drafts, the server appends the quoted conversation automatically; do not include quoted history."),
+  threadId: z.string().trim().min(1).max(512).optional().describe("Gmail thread id to reply on. Required for replies and forwards; get it from the gmail-messages capability. When set, the draft is attached to that thread as a reply — keep the thread's subject (e.g. 'Re: …')."),
   attachments: z.array(gmailDraftAttachmentSchema).min(1).max(10).optional().describe("Optional files from the active workspace to attach to this draft."),
 }).strict().superRefine((input, context) => {
   const totalBytes = (input.attachments ?? []).reduce((total, attachment) => total + Buffer.byteLength(attachment.dataBase64, "base64"), 0)
@@ -65,9 +69,12 @@ const createDraftResponseSchema = z.object({
   ok: z.literal(true),
   draftId: z.string(),
   messageId: z.string().nullable(),
+  draftUrl: z.string().nullable().describe("Gmail URL for the ready-to-send draft. Always share draftUrl with the user so they can open the draft in Gmail for review and send."),
+  threadUrl: z.string().nullable().describe("Gmail URL for the conversation thread when this draft is a threaded reply."),
   to: z.string(),
   subject: z.string(),
   threadId: z.string().nullable(),
+  quotedHistoryIncluded: z.boolean().describe("True when quoted conversation history was included by the server or already present in the request body."),
   attachments: z.array(z.object({
     filename: z.string(),
     mimeType: z.string(),
@@ -80,10 +87,23 @@ const needsConnectionSchema = z.object({
   message: z.string(),
 }).meta({ ref: "GoogleWorkspaceNeedsConnectionError" })
 
+const missingThreadIdSchema = z.object({
+  error: z.literal("missing_thread_id"),
+  message: z.string(),
+}).meta({ ref: "GoogleWorkspaceMissingThreadIdError" })
+
 const upstreamErrorSchema = z.object({
   error: z.literal("google_api_error"),
   message: z.string(),
 }).meta({ ref: "GoogleWorkspaceUpstreamError" })
+
+function gmailDraftUrl(messageId: string | null): string | null {
+  return messageId ? `https://mail.google.com/mail/u/0/#drafts?compose=${encodeURIComponent(messageId)}` : null
+}
+
+function gmailThreadUrl(threadId: string | undefined): string | null {
+  return threadId ? `https://mail.google.com/mail/u/0/#all/${encodeURIComponent(threadId)}` : null
+}
 
 const gmailMessagesQuerySchema = z.object({
   q: z.string().trim().min(1).max(1_000).optional().describe("Optional Gmail search query, using Gmail's search syntax."),
@@ -830,9 +850,10 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     describeRoute({
       tags: ["Capability Sources"],
       summary: "Create a Gmail draft or threaded reply draft; attach workspace files with body.attachments: [{ filename, mimeType, dataBase64 }], where dataBase64 is each attachment's file bytes encoded as standard base64",
-      description: "Creates a plain-text Gmail draft in the calling member own mailbox, with optional Cc/Bcc recipients and files read from the active workspace. Set threadId to attach the draft to an existing Gmail thread as a reply using the thread's matching subject. Returns needs_connection when the member has not connected their Google account yet or when a threaded reply needs Gmail read permission.",
+      description: "Creates a plain-text Gmail draft in the calling member own mailbox, with optional Cc/Bcc recipients and files read from the active workspace. Set threadId to attach the draft to an existing Gmail thread as a reply using the thread's matching subject; threadId is required for replies and forwards. For threaded drafts, OpenWork appends the quoted conversation automatically. Always share the returned draftUrl with the user because it opens the ready-to-send draft in Gmail for review and send. Returns needs_connection when the member has not connected their Google account yet or when a threaded reply needs Gmail read permission.",
       responses: {
         200: jsonResponse("Draft created.", createDraftResponseSchema),
+        400: jsonResponse("The draft request was invalid.", z.union([invalidRequestSchema, missingThreadIdSchema])),
         401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
         409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
         502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
@@ -841,6 +862,14 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     orgMemberRoute(),
     jsonValidator(createDraftBodySchema),
     async (c) => {
+      const { to, cc, bcc, subject, body, threadId, attachments: attachmentInputs } = c.req.valid("json")
+      if (!threadId && GMAIL_REPLY_SUBJECT_RE.test(subject)) {
+        return c.json({
+          error: "missing_thread_id",
+          message: "Subject looks like a reply but threadId is missing. Fetch the thread with the gmail-messages capability and pass threadId so the draft stays on the conversation. Only omit threadId for brand-new emails.",
+        }, 400)
+      }
+
       const payload = c.get("organizationContext")
       const token = await googleWorkspaceToken({
         organizationId: payload.organization.id,
@@ -853,23 +882,21 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         return c.json({ error: "needs_connection", message: token.message }, 409)
       }
 
-      const { to, cc, bcc, subject, body, threadId, attachments: attachmentInputs } = c.req.valid("json")
       const attachments: GmailDraftAttachment[] = (attachmentInputs ?? []).map((attachment) => ({
         filename: attachment.filename,
         mimeType: attachment.mimeType,
         content: Buffer.from(attachment.dataBase64, "base64"),
       }))
       const headers: { name: string; value: string }[] = []
+      let draftBody = body
+      let quotedHistoryIncluded = false
       if (threadId) {
         if (missingScope(token.account, [GMAIL_READ_SCOPE])) {
           return c.json({ error: "needs_connection", message: missingPermissionMessage("Gmail read") }, 409)
         }
 
         const threadUrl = new URL(`${gmailApiBase()}/gmail/v1/users/me/threads/${encodeURIComponent(threadId)}`)
-        threadUrl.searchParams.set("format", "metadata")
-        threadUrl.searchParams.append("metadataHeaders", "Message-ID")
-        threadUrl.searchParams.append("metadataHeaders", "References")
-        threadUrl.searchParams.append("metadataHeaders", "Subject")
+        threadUrl.searchParams.set("format", "full")
         const threadResponse = await googleWorkspaceApiFetch(threadUrl, {
           headers: { authorization: `Bearer ${token.accessToken}` },
         })
@@ -877,7 +904,8 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
           return c.json(await googleApiError("Gmail thread read", threadResponse), 502)
         }
 
-        const replyContext = extractGmailThreadReplyContext(await readJson(threadResponse))
+        const thread = await readJson(threadResponse)
+        const replyContext = extractGmailThreadReplyContext(thread)
         if (!replyContext) {
           return c.json({ error: "google_api_error", message: "Gmail thread has no Message-ID metadata; cannot build a threaded reply draft." }, 502)
         }
@@ -885,9 +913,19 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
           { name: "In-Reply-To", value: replyContext.lastMessageId },
           { name: "References", value: replyContext.references },
         )
+
+        if (gmailBodyHasQuotedHistory(body)) {
+          quotedHistoryIncluded = true
+        } else {
+          const quote = extractGmailThreadQuoteInput(thread)
+          if (quote) {
+            draftBody = `${body}\n\n${buildGmailQuoteBlock(quote)}`
+            quotedHistoryIncluded = true
+          }
+        }
       }
 
-      const message: { raw: string; threadId?: string } = { raw: buildGmailDraftRaw({ to, cc, bcc, subject, body, headers, attachments }) }
+      const message: { raw: string; threadId?: string } = { raw: buildGmailDraftRaw({ to, cc, bcc, subject, body: draftBody, headers, attachments }) }
       if (threadId) {
         message.threadId = threadId
       }
@@ -913,9 +951,12 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
         ok: true,
         draftId,
         messageId,
+        draftUrl: gmailDraftUrl(messageId),
+        threadUrl: gmailThreadUrl(threadId),
         to,
         subject,
         threadId: threadId ?? null,
+        quotedHistoryIncluded,
       }
       if (attachments.length === 0) {
         return c.json(result)

--- a/ee/apps/den-api/test/gmail-draft.test.ts
+++ b/ee/apps/den-api/test/gmail-draft.test.ts
@@ -21,6 +21,11 @@ function decodeRaw(raw: string): string {
   return Buffer.from(raw, "base64url").toString("utf8")
 }
 
+function decodeRawBody(raw: string): string {
+  const encoded = decodeRaw(raw).match(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+)/)?.[1] ?? ""
+  return Buffer.from(encoded.replace(/\r\n/g, ""), "base64").toString("utf8")
+}
+
 describe("buildGmailDraftRaw", () => {
   test("encodes a plain-ASCII draft as base64url RFC 822 with the body base64-encoded", () => {
     const raw = gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Follow up", body: "Hello Sam" })
@@ -71,6 +76,40 @@ describe("buildGmailDraftRaw", () => {
       "Thanks again!",
       "",
       "Ben",
+    ].join("\n"))
+  })
+
+  test("strips conservative markdown from prose while preserving structure", () => {
+    const hardWrapped = [
+      "This generated sentence is intentionally long enough to look like it",
+      "was hard-wrapped before reaching Gmail and should become one line.",
+    ].join("\n")
+    const body = [
+      "# Status update",
+      "",
+      "Please **review** the __terms__ and `confirm` before launch.",
+      "",
+      "- **Keep list marker**",
+      "> **Keep quoted text**",
+      "```",
+      "# keep fenced heading",
+      "```",
+      "",
+      hardWrapped,
+    ].join("\n")
+
+    expect(decodeRawBody(gmail.buildGmailDraftRaw({ to: "sam@acme.test", subject: "Follow up", body }))).toBe([
+      "Status update",
+      "",
+      "Please review the terms and confirm before launch.",
+      "",
+      "- **Keep list marker**",
+      "> **Keep quoted text**",
+      "```",
+      "# keep fenced heading",
+      "```",
+      "",
+      "This generated sentence is intentionally long enough to look like it was hard-wrapped before reaching Gmail and should become one line.",
     ].join("\n"))
   })
 

--- a/ee/apps/den-api/test/google-workspace-api.test.ts
+++ b/ee/apps/den-api/test/google-workspace-api.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  buildGmailQuoteBlock,
   buildDriveSearchQuery,
   extractCalendarEvents,
   extractDriveFiles,
@@ -11,6 +12,37 @@ import {
 function base64Url(text: string): string {
   return Buffer.from(text, "utf8").toString("base64url")
 }
+
+describe("buildGmailQuoteBlock", () => {
+  test("formats parsed dates in UTC and prefixes every line", () => {
+    expect(buildGmailQuoteBlock({
+      from: "Ada <ada@example.com>",
+      date: "Thu, 16 Jul 2026 15:21:00 +0000",
+      body: "First line\n> nested quote",
+    })).toBe([
+      "On Thu, 16 Jul 2026 at 15:21 UTC, Ada <ada@example.com> wrote:",
+      "> First line",
+      "> > nested quote",
+    ].join("\n"))
+  })
+
+  test("uses raw invalid dates and omits the date header when absent", () => {
+    expect(buildGmailQuoteBlock({ from: "Ada", date: "not a date", body: "Hi" })).toBe([
+      "On not a date, Ada wrote:",
+      "> Hi",
+    ].join("\n"))
+    expect(buildGmailQuoteBlock({ from: "Ada", date: "", body: "Hi" })).toBe([
+      "Ada wrote:",
+      "> Hi",
+    ].join("\n"))
+  })
+
+  test("truncates quoted bodies and appends a trim marker", () => {
+    const quote = buildGmailQuoteBlock({ from: "Ada", date: "", body: "x".repeat(10_001) })
+    expect(quote).toContain(`> ${"x".repeat(10_000)}`)
+    expect(quote.endsWith("\n> [message trimmed]")).toBe(true)
+  })
+})
 
 describe("extractGmailMessage", () => {
   test("reads headers, nested plain-text body, and attachment metadata", () => {

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -66,6 +66,11 @@ function decodeDraftRaw(): string {
   return Buffer.from(raw, "base64url").toString("utf8")
 }
 
+function decodeDraftTextBody(): string {
+  const encoded = decodeDraftRaw().match(/Content-Transfer-Encoding: base64\r\n\r\n([A-Za-z0-9+/=\r\n]+)/)?.[1] ?? ""
+  return Buffer.from(encoded.replace(/\r\n/g, ""), "base64").toString("utf8")
+}
+
 const GMAIL_READ_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
 const CALENDAR_READ_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
 const CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
@@ -174,7 +179,10 @@ const fakeGoogleServer = Bun.serve({
                 { name: "Message-ID", value: "<orig-2@mail.gmail.com>" },
                 { name: "References", value: "<orig-1@mail.gmail.com>" },
                 { name: "Subject", value: "Quarterly plan" },
+                { name: "From", value: "Ada <ada@example.com>" },
+                { name: "Date", value: "Thu, 16 Jul 2026 15:21:00 +0000" },
               ],
+              parts: [{ mimeType: "text/plain", body: { data: base64Url("Original line\n> previous quote") } }],
             },
           },
         ],
@@ -583,7 +591,17 @@ test("gmail plain draft supports cc without requiring a thread", async () => {
   expect(decoded).toContain("Cc: ada@acme.test, grace@acme.test\r\n")
   expect(decoded).toContain("Subject: Quarterly plan\r\n")
   const body: unknown = await response.json()
-  expect(body).toEqual({ ok: true, draftId: "draft_1", messageId: "draft_msg_1", to, subject, threadId: null })
+  expect(body).toEqual({
+    ok: true,
+    draftId: "draft_1",
+    messageId: "draft_msg_1",
+    draftUrl: "https://mail.google.com/mail/u/0/#drafts?compose=draft_msg_1",
+    threadUrl: null,
+    to,
+    subject,
+    threadId: null,
+    quotedHistoryIncluded: false,
+  })
 })
 
 test("gmail plain draft attaches active workspace file bytes with filename and MIME type", async () => {
@@ -636,8 +654,8 @@ test("gmail threaded reply draft reads thread metadata and sends reply headers",
   expect(googleCallCount).toBe(2)
   const firstUrl = new URL(expectString(googleCallUrls[0], "first Google URL"))
   expect(firstUrl.pathname).toBe("/gmail/v1/users/me/threads/thread_1")
-  expect(firstUrl.searchParams.get("format")).toBe("metadata")
-  expect(firstUrl.searchParams.getAll("metadataHeaders")).toEqual(["Message-ID", "References", "Subject"])
+  expect(firstUrl.searchParams.get("format")).toBe("full")
+  expect(firstUrl.searchParams.getAll("metadataHeaders")).toEqual([])
   const secondUrl = new URL(expectString(googleCallUrls[1], "second Google URL"))
   expect(secondUrl.pathname).toBe("/gmail/v1/users/me/drafts")
   expect(lastGmailThreadUrl).toBe(expectString(googleCallUrls[0], "first Google URL"))
@@ -646,11 +664,39 @@ test("gmail threaded reply draft reads thread metadata and sends reply headers",
   const decoded = decodeDraftRaw()
   expect(decoded).toContain("In-Reply-To: <orig-2@mail.gmail.com>\r\n")
   expect(decoded).toContain("References: <orig-1@mail.gmail.com> <orig-2@mail.gmail.com>\r\n")
+  expect(decodeDraftTextBody()).toBe([
+    "Reply body",
+    "",
+    "On Thu, 16 Jul 2026 at 15:21 UTC, Ada <ada@example.com> wrote:",
+    "> Original line",
+    "> > previous quote",
+  ].join("\n"))
   expect(decoded).toContain('Content-Disposition: attachment; filename="notes.txt"')
   expect(decoded).toContain(Buffer.from("workspace notes", "utf8").toString("base64"))
   const body: unknown = await response.json()
   const responseBody = expectRecord(body, "threaded draft response")
   expect(responseBody.threadId).toBe("thread_1")
+  expect(responseBody.draftUrl).toBe("https://mail.google.com/mail/u/0/#drafts?compose=draft_msg_1")
+  expect(responseBody.threadUrl).toBe("https://mail.google.com/mail/u/0/#all/thread_1")
+  expect(responseBody.quotedHistoryIncluded).toBe(true)
+})
+
+test("gmail reply-looking draft requires threadId before calling Google", async () => {
+  const response = await request("/v1/capabilities/google-workspace/gmail-drafts", {
+    method: "POST",
+    body: {
+      to: "sam@acme.test",
+      subject: "Re: Quarterly plan",
+      body: "Reply body",
+    },
+  })
+  expect(response.status).toBe(400)
+  expect(googleCallCount).toBe(0)
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    error: "missing_thread_id",
+    message: "Subject looks like a reply but threadId is missing. Fetch the thread with the gmail-messages capability and pass threadId so the draft stays on the conversation. Only omit threadId for brand-new emails.",
+  })
 })
 
 test("gmail draft rejects invalid attachment encoding and MIME type without calling Google", async () => {

--- a/evals/flows/gmail-reply-draft-integrity.flow.mjs
+++ b/evals/flows/gmail-reply-draft-integrity.flow.mjs
@@ -1,0 +1,115 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/gmail-reply-draft-integrity.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("gmail-reply-draft-integrity");
+
+export default {
+  id: "gmail-reply-draft-integrity",
+  title: "TODO: one-line claim — user can do X and sees Y",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 1", {
+          voiceover: vo[0],
+          // "I'm in OpenWork, and Sarah's thread about the Q3 launch has been going back "
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 1 not implemented yet");
+          },
+          screenshot: { name: "frame-1", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 2", {
+          voiceover: vo[1],
+          // "OpenWork reads the thread through my connected Google account first, so the "
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 2 not implemented yet");
+          },
+          screenshot: { name: "frame-2", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 3", {
+          voiceover: vo[2],
+          // "It stages my reply as a draft on the same thread — same \"Re: Q3 launch\" subj"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 3 not implemented yet");
+          },
+          screenshot: { name: "frame-3", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 4", {
+          voiceover: vo[3],
+          // "When I look at the draft, my reply sits on top and the entire conversation t"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 4 not implemented yet");
+          },
+          screenshot: { name: "frame-4", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 5", {
+          voiceover: vo[4],
+          // "The text reads like an email a person wrote: real paragraphs, no weird mid-s"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 5 not implemented yet");
+          },
+          screenshot: { name: "frame-5", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 6", {
+          voiceover: vo[5],
+          // "And OpenWork finishes by handing me the link — one click opens the ready-to-"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 6 not implemented yet");
+          },
+          screenshot: { name: "frame-6", requireText: [] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/gmail-reply-draft-integrity.flow.mjs
+++ b/evals/flows/gmail-reply-draft-integrity.flow.mjs
@@ -1,113 +1,651 @@
+import { execSync } from "node:child_process";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
 // Narration is loaded from the approved script (evals/voiceovers/gmail-reply-draft-integrity.md).
 // The runner fails this flow if the narration drifts from that script.
 const vo = await loadVoiceoverParagraphs("gmail-reply-draft-integrity");
 
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? DEN_API_URL.replace("127.0.0.1", "localhost")).trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MEMBER_EMAIL = process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "jordan.demo@acme.test";
+const MEMBER_PASSWORD = process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const MOCK_SERVER_URL = (process.env.MOCK_OAUTH_MCP_URL ?? "http://127.0.0.1:3978").trim().replace(/\/+$/, "");
+const RUN_TAG = Date.now();
+const WORKSPACE_PATH = `/tmp/openwork-gmail-reply-draft-integrity-${RUN_TAG}`;
+const GMAIL_THREAD_ID = "thread-q3-launch";
+const PROMPT = `Use the OpenWork Cloud connection: find the Gmail thread about "Q3 launch" (call search_capabilities, then the Gmail messages capability), then create a reply draft on that thread with subject "Re: Q3 launch" confirming Thursday works, addressed to sarah@acme.test. Do not include quoted history yourself; pass the threadId so OpenWork can append it. When done, reply with the draft link the tool returned.`;
+const PROMPT_FRAGMENT = 'find the Gmail thread about "Q3 launch"';
+const GOOGLE_CARD_EXPR = (needle) =>
+  `[...document.querySelectorAll("button")].some((el) => el.textContent.includes("Google Workspace") && el.textContent.includes(${JSON.stringify(needle)}))`;
+
+const state = {
+  adminSession: null,
+  memberSession: null,
+  workspaceId: null,
+  clickedAt: null,
+  chatStartedAt: null,
+  draftEntry: null,
+  decodedDraft: null,
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+const revealHidden = async (ctx) => {
+  const showing = await ctx.eval("document.body.innerText.includes('Showing hidden')");
+  if (!showing) await ctx.clickText("Show hidden", { timeoutMs: 30_000 });
+};
+
+async function denApiFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: { "content-type": "application/json", origin: DEN_WEB_URL, ...(options.headers ?? {}) },
+  });
+  const text = await response.text();
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+async function signIn(email, password) {
+  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  if (!response.ok) return null;
+  return body.token;
+}
+
+async function ensureVerifiedUser(ctx, email, name, password) {
+  let token = await signIn(email, password);
+  if (token) return token;
+
+  const signUp = await denApiFetch("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email, name, password }),
+  });
+  ctx.assert(signUp.response.ok, `Sign-up failed for ${email}: ${signUp.response.status}`);
+  ctx.assert(MARK_VERIFIED_CMD.length > 0, "Set OPENWORK_EVAL_MARK_VERIFIED_CMD to verify eval accounts.");
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", email), { stdio: "ignore" });
+  token = await signIn(email, password);
+  ctx.assert(Boolean(token), `Sign-in still failing for ${email} after sign-up.`);
+  return token;
+}
+
+async function ensureMember(ctx) {
+  state.memberSession = await ensureVerifiedUser(ctx, MEMBER_EMAIL, "Jordan Demo", MEMBER_PASSWORD);
+  const orgs = await denApiFetch("/v1/me/orgs", { headers: { authorization: `Bearer ${state.memberSession}` } });
+  const inAcme = (orgs.body.orgs ?? []).some((org) => org.slug === "acme-robotics-demo");
+  if (inAcme) return;
+
+  const invite = await denApiFetch("/v1/invitations", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.adminSession}` },
+    body: JSON.stringify({ email: MEMBER_EMAIL, role: "member" }),
+  });
+  ctx.assert(invite.response.ok, `Invitation failed: ${invite.response.status}`);
+  const accept = await denApiFetch("/v1/orgs/invitations/accept", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.memberSession}` },
+    body: JSON.stringify({ id: invite.body.inviteToken }),
+  });
+  ctx.assert(accept.response.ok && accept.body.accepted, "Invitation accept failed.");
+}
+
+async function memberUsableConnections() {
+  const { body } = await denApiFetch("/v1/mcp-connections?scope=usable", {
+    headers: { authorization: `Bearer ${state.memberSession}` },
+  });
+  return body.connections ?? [];
+}
+
+async function ensureWorkspace(ctx) {
+  const ready = await ctx.eval(`(() => {
+    const text = document.body.innerText;
+    return window.location.hash.includes('/workspace/')
+      && !text.includes('Choose your organization')
+      && !Boolean(document.querySelector('input[placeholder="/workspace/my-project"]'));
+  })()`);
+  if (ready) return;
+
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const step = await ctx.eval(`(() => {
+      const text = document.body.innerText;
+      const hasFolderInput = Boolean(document.querySelector('input[placeholder="/workspace/my-project"]'));
+      const hasWorkspaceRoute = window.location.hash.includes('/workspace/') && !text.includes('Choose your organization') && !hasFolderInput;
+      const hasOnboardingStep = text.includes('Choose your organization') || text.includes('Continue to workspace') || text.includes('Loading available resources');
+      const hasCreateAction = !hasOnboardingStep && window.__openworkControl?.listActions?.().find((a) => a.id === 'workspace.create')?.disabled === false;
+      return { hasFolderInput, hasWorkspaceRoute, hasCreateAction };
+    })()`);
+    if (step.hasWorkspaceRoute || step.hasCreateAction) break;
+    if (step.hasFolderInput) {
+      await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_PATH);
+      await ctx.clickText("Use this folder", { timeoutMs: 20_000 });
+      await sleep(750);
+      continue;
+    }
+    await ctx.eval(`(() => {
+      const labels = ['Continue with organization', 'Continue to workspace', 'Continue'];
+      const buttons = [...document.querySelectorAll('button')].filter((button) => !button.disabled);
+      const button = buttons.find((candidate) => labels.includes(candidate.textContent.trim()));
+      button?.scrollIntoView({ block: 'center' });
+      button?.click();
+      return Boolean(button);
+    })()`);
+    await sleep(1_000);
+  }
+  await ctx.eval(`(() => {
+    const btn = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === 'Continue without OpenWork Models');
+    btn?.click();
+    return true;
+  })()`, { awaitPromise: true });
+}
+
+async function createFreshEvalWorkspace(ctx) {
+  await ensureWorkspace(ctx);
+  await ctx.waitFor(
+    "Boolean(localStorage.getItem('openwork.server.port') && localStorage.getItem('openwork.server.token') && localStorage.getItem('openwork.server.hostToken'))",
+    { timeoutMs: 30_000, label: "OpenWork server auth for workspace setup" },
+  );
+  let created = null;
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    created = await ctx.eval(`(async () => {
+      try {
+        const port = localStorage.getItem('openwork.server.port');
+        const token = localStorage.getItem('openwork.server.token');
+        const hostToken = localStorage.getItem('openwork.server.hostToken');
+        const base = 'http://127.0.0.1:' + port;
+        const headers = {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer ' + token,
+          'X-OpenWork-Host-Token': hostToken,
+        };
+        const response = await fetch(base + '/workspaces/local', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ folderPath: ${JSON.stringify(WORKSPACE_PATH)}, name: 'gmail-reply-draft-integrity', preset: 'starter' }),
+        });
+        const text = await response.text();
+        let payload = null;
+        try { payload = JSON.parse(text); } catch {}
+        if (!response.ok) return { ok: false, status: response.status, text };
+        const workspaceId = payload?.activeId ?? payload?.workspaces?.find((workspace) => workspace.path === ${JSON.stringify(WORKSPACE_PATH)})?.id;
+        if (!workspaceId) return { ok: false, status: response.status, text: 'workspace id missing' };
+        const activate = await fetch(base + '/workspaces/' + workspaceId + '/activate?persist=true', { method: 'POST', headers });
+        if (!activate.ok) return { ok: false, status: activate.status, text: await activate.text() };
+        localStorage.setItem('openwork.react.activeWorkspace', workspaceId);
+        return { ok: true, workspaceId };
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    })()`, { awaitPromise: true });
+    if (created?.ok) break;
+    await sleep(1_000);
+  }
+  ctx.assert(created?.ok && created.workspaceId, `Workspace setup failed: ${JSON.stringify(created)}`);
+  state.workspaceId = created.workspaceId;
+  await ctx.navigateHash(`/workspace/${created.workspaceId}/session`);
+  await sleep(2_000);
+  if (await ctx.eval("window.location.hash.includes('/onboarding')")) {
+    await ensureWorkspace(ctx);
+    await ctx.navigateHash(`/workspace/${created.workspaceId}/session`);
+  }
+  await ctx.waitFor("window.location.hash.includes('/workspace/')", { timeoutMs: 60_000, label: "fresh eval workspace selected" });
+}
+
+async function openMcpSettings(ctx) {
+  const workspaceId = state.workspaceId;
+  let last = null;
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    await ctx.navigateHash(`/workspace/${workspaceId}/settings/extensions/mcp`);
+    await sleep(1_000);
+    last = await ctx.eval(`(() => {
+      const text = document.body.innerText;
+      return {
+        hash: window.location.hash,
+        onOnboarding: window.location.hash.includes('/onboarding') || text.includes('Continue with organization') || text.includes('Continue to workspace'),
+        hasTabs: text.includes('My Extensions') && text.includes('Marketplace'),
+      };
+    })()`);
+    if (last.onOnboarding) {
+      await ensureWorkspace(ctx);
+      await sleep(500);
+      continue;
+    }
+    if (last.hash.includes('/settings/extensions/mcp') && last.hasTabs) return;
+    await sleep(1_000);
+  }
+  ctx.assert(false, `MCP settings never became ready: ${JSON.stringify(last)}`);
+}
+
+async function clickTab(ctx, label) {
+  await ctx.waitFor(
+    `(() => {
+      const button = [...document.querySelectorAll('button')].find((candidate) => candidate.textContent.trim() === ${JSON.stringify(label)} && !candidate.disabled);
+      button?.click();
+      return Boolean(button);
+    })()`,
+    { timeoutMs: 30_000, label: `${label} tab` },
+  );
+}
+
+async function bootstrapDesktopToDen(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 120_000 });
+  await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", { timeoutMs: 30_000, label: "desktop bridge" });
+  const bootstrap = { baseUrl: DEN_API_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
+  const written = await ctx.eval(`(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (!bridge) return { ok: false };
+    await bridge("setDesktopBootstrapConfig", ${JSON.stringify(bootstrap)});
+    return { ok: true };
+  })()`, { awaitPromise: true });
+  ctx.assert(written?.ok, "Failed to write desktop bootstrap config.");
+  await ctx.eval(`(() => {
+    localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_API_URL)});
+    localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(DEN_API_URL)});
+    const prefs = JSON.parse(localStorage.getItem('openwork.preferences') || '{}');
+    localStorage.setItem('openwork.preferences', JSON.stringify({ ...prefs, selectedAgent: 'openwork' }));
+    return true;
+  })()`);
+  await ctx.eval("location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after bootstrap reload" });
+
+  const handoff = await denApiFetch("/v1/auth/desktop-handoff", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.memberSession}` },
+    body: JSON.stringify({ desktopScheme: "openwork" }),
+  });
+  ctx.assert(handoff.response.ok, `Handoff create failed: ${handoff.response.status}`);
+  await ctx.control("auth.exchange-grant", { grant: handoff.body.grant, baseUrl: DEN_API_URL });
+  await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", { timeoutMs: 45_000, label: "persisted den auth token" });
+  await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", { timeoutMs: 60_000, label: "active org resolved" });
+}
+
+async function mockRequests() {
+  const { requests } = await fetch(`${MOCK_SERVER_URL}/requests`).then((response) => response.json());
+  return requests;
+}
+
+async function mockDrafts() {
+  const { drafts } = await fetch(`${MOCK_SERVER_URL}/gmail/drafts-log`).then((response) => response.json());
+  return drafts;
+}
+
+async function connectGoogleWorkspace(ctx) {
+  await openMcpSettings(ctx);
+  await ctx.clickText("Refresh", { timeoutMs: 15_000 }).catch(() => {});
+  await clickTab(ctx, "Marketplace");
+
+  let connected = await ctx.eval(`(() => {
+    const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('Google Workspace'));
+    return Boolean(card?.textContent.includes('Connected with your own account'));
+  })()`);
+  if (!connected) {
+    await ctx.waitFor(GOOGLE_CARD_EXPR("Connect your account"), { timeoutMs: 60_000, label: "org Google Workspace connect card" });
+    const opened = await ctx.eval(`(() => {
+      const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('Google Workspace') && el.textContent.includes('Connect your account'));
+      card?.scrollIntoView({ block: 'center' });
+      card?.click();
+      return Boolean(card);
+    })()`);
+    ctx.assert(opened, "Could not open the org Google Workspace card.");
+    await ctx.expectText("OpenWork stores this sign-in", { timeoutMs: 15_000 });
+    state.clickedAt = new Date().toISOString();
+    const clicked = await ctx.eval(`(() => {
+      const dialog = document.querySelector('[role="dialog"]');
+      const button = [...(dialog?.querySelectorAll('button') ?? [])].find((el) => el.textContent.trim() === 'Connect your account' && !el.disabled);
+      button?.click();
+      return Boolean(button);
+    })()`);
+    ctx.assert(clicked, "Could not click the modal Connect your account button.");
+
+    let authorize = null;
+    const deadline = Date.now() + 30_000;
+    while (Date.now() < deadline && !authorize) {
+      const requests = await mockRequests();
+      authorize = requests.find((entry) => entry.method === "GET" && entry.path === "/authorize" && entry.at >= state.clickedAt) ?? null;
+      if (!authorize) await sleep(500);
+    }
+    ctx.assert(Boolean(authorize), "No GET /authorize reached the mock Google IdP after the connect click.");
+    const tokenExchange = (await mockRequests()).some((entry) => entry.method === "POST" && entry.path === "/token" && entry.at >= state.clickedAt);
+    ctx.assert(tokenExchange, "The auto-approved Google consent should complete a code-for-token exchange.");
+  }
+
+  await openMcpSettings(ctx);
+  await clickTab(ctx, "My Extensions");
+  await ctx.waitFor(
+    `(() => {
+      const card = [...document.querySelectorAll("button")].find((el) => el.textContent.includes("Google Workspace") && el.textContent.includes("Connected with your own account"));
+      return Boolean(card && !card.textContent.includes("Connect your account"));
+    })()`,
+    { timeoutMs: 90_000, label: "org Google Workspace card connected in My Extensions" },
+  );
+  const server = await memberUsableConnections();
+  const entry = server.find((candidate) => candidate.id === "google-workspace");
+  connected = entry?.connectedForMe === true;
+  ctx.assert(connected, "Server-side connectedForMe should be true after the Google round trip.");
+}
+
+async function ensureOpenWorkCloudControl(ctx) {
+  await openMcpSettings(ctx);
+  await revealHidden(ctx);
+  await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 30_000 });
+  const alreadyConnected = await ctx.eval(`(() => {
+    const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('OpenWork Cloud Control'));
+    return Boolean(card?.textContent.includes('Connected'));
+  })()`);
+  if (!alreadyConnected) {
+    const openedCard = await ctx.eval(`(() => {
+      const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('OpenWork Cloud Control'));
+      card?.scrollIntoView({ block: 'center' });
+      card?.click();
+      return Boolean(card);
+    })()`);
+    ctx.assert(openedCard, "Could not open the OpenWork Cloud Control card.");
+    await ctx.expectText("Manage your org", { timeoutMs: 15_000 });
+    const clicked = await ctx.eval(`(() => {
+      const dialog = document.querySelector('[role="dialog"]');
+      const button = [...(dialog?.querySelectorAll('button') ?? [])].find((el) => el.textContent.trim() === 'Connect' && !el.disabled);
+      button?.click();
+      return Boolean(button);
+    })()`);
+    ctx.assert(clicked, "Could not click Connect for OpenWork Cloud Control.");
+  }
+  await ctx.waitFor(
+    `(() => {
+      const card = [...document.querySelectorAll('button')].find((el) => el.textContent.includes('OpenWork Cloud Control'));
+      return Boolean(card?.textContent.includes('Connected'));
+    })()`,
+    { timeoutMs: 60_000, label: "OpenWork Cloud Control connected card" },
+  );
+  await ctx.clickText("Refresh", { timeoutMs: 15_000 }).catch(() => {});
+}
+
+async function ensureRuntimeCloudMcp(ctx) {
+  let runtime = null;
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    runtime = await ctx.eval(`(async () => {
+      const workspaceId = ${JSON.stringify(state.workspaceId)};
+      const port = localStorage.getItem('openwork.server.port');
+      const token = localStorage.getItem('openwork.server.token');
+      const hostToken = localStorage.getItem('openwork.server.hostToken');
+      if (!workspaceId || !port || !token) return { ok: false, reason: 'missing workspace/server auth' };
+      const headers = { Authorization: 'Bearer ' + token };
+      if (hostToken) headers['X-OpenWork-Host-Token'] = hostToken;
+      const response = await fetch('http://127.0.0.1:' + port + '/workspace/' + workspaceId + '/mcp', { headers });
+      if (!response.ok) return { ok: false, status: response.status };
+      const payload = await response.json();
+      const entry = (payload?.items ?? []).find((item) => item.name === 'openwork-cloud');
+      return { ok: Boolean(entry?.config?.url?.includes('/mcp/agent') && payload?.engineSync?.status === 'ok') };
+    })()`, { awaitPromise: true });
+    if (runtime?.ok) break;
+    await sleep(1_000);
+  }
+  ctx.assert(runtime?.ok, `Runtime OpenWork Cloud Control MCP never became ready: ${JSON.stringify(runtime)}`);
+}
+
+async function resetChatState(ctx) {
+  await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+  await ctx.waitFor("window.location.hash.includes('/session')", { timeoutMs: 20_000 });
+  await ctx.waitFor(
+    "window.__openworkControl?.listActions?.().find((a) => a.id === 'session.create_task')?.disabled === false",
+    { timeoutMs: 30_000, label: "session.create_task enabled" },
+  );
+  await ctx.control("session.create_task");
+  await ctx.waitFor("window.location.hash.includes('/session/ses_')", { timeoutMs: 30_000, label: "fresh task session" });
+  await ctx.waitFor("Boolean(document.querySelector('[contenteditable=\"true\"][data-lexical-editor=\"true\"]'))", { timeoutMs: 30_000, label: "composer" });
+}
+
+async function pollForGmailRead(ctx) {
+  let recent = [];
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    const requests = await mockRequests();
+    recent = requests.filter((entry) => entry.at >= state.chatStartedAt);
+    const read = recent.find((entry) =>
+      entry.method === "GET" && (entry.path === "/gmail/v1/users/me/messages" || entry.path === `/gmail/v1/users/me/threads/${GMAIL_THREAD_ID}`)
+    );
+    if (read) return read;
+    await sleep(2_000);
+  }
+  ctx.assert(false, `No Gmail read reached the mock after ${state.chatStartedAt}. Recent requests: ${JSON.stringify(recent.slice(-12))}`);
+}
+
+function decodeDraft(raw) {
+  const rfc822 = Buffer.from(raw, "base64url").toString("utf8");
+  const normalized = rfc822.replace(/\r\n/g, "\n");
+  const separator = normalized.indexOf("\n\n");
+  const headerText = separator === -1 ? normalized : normalized.slice(0, separator);
+  const bodyText = separator === -1 ? "" : normalized.slice(separator + 2);
+  const transfer = headerText.split("\n").find((line) => /^Content-Transfer-Encoding:/i.test(line)) ?? "";
+  const body = /base64/i.test(transfer)
+    ? Buffer.from(bodyText.replace(/\s+/g, ""), "base64").toString("utf8").replace(/\r\n?/g, "\n")
+    : bodyText.replace(/\r\n?/g, "\n");
+  return { rfc822, headers: headerText, body };
+}
+
+async function pollForThreadedDraft(ctx) {
+  let recent = [];
+  const deadline = Date.now() + 180_000;
+  while (Date.now() < deadline) {
+    const drafts = await mockDrafts();
+    recent = drafts.filter((draft) => draft.at >= state.chatStartedAt);
+    const draft = recent.find((entry) => entry.threadId === GMAIL_THREAD_ID) ?? recent[0];
+    if (draft) return draft;
+    await sleep(2_000);
+  }
+  ctx.assert(false, `No Gmail draft reached the mock after ${state.chatStartedAt}. Recent drafts: ${JSON.stringify(recent)}`);
+}
+
+function requireDecodedDraft(ctx) {
+  ctx.assert(Boolean(state.decodedDraft), "No decoded draft is available; frame 3 must pass before inspecting the body.");
+  return state.decodedDraft;
+}
+
+function quoteIndex(body) {
+  const match = body.match(/^On .*Sarah.*wrote:$/m);
+  return match?.index ?? -1;
+}
+
 export default {
   id: "gmail-reply-draft-integrity",
-  title: "TODO: one-line claim — user can do X and sees Y",
+  title: "Gmail reply drafts stay threaded, quote history, keep clean prose, and return the Gmail draft link",
   kind: "user-facing",
+  spec: "evals/voiceovers/gmail-reply-draft-integrity.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
   steps: [
+    {
+      name: "Setup",
+      run: async (ctx) => {
+        const health = await fetch(`${MOCK_SERVER_URL}/health`).then((response) => response.json()).catch(() => null);
+        ctx.assert(Boolean(health?.ok), `Mock Google IdP not reachable at ${MOCK_SERVER_URL}.`);
+        ctx.assert(health.autoApprove !== false, "Mock server must auto-approve for this flow.");
+
+        state.adminSession = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+        ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+
+        const saved = await denApiFetch("/v1/oauth-providers/google-workspace/client", {
+          method: "POST",
+          headers: { authorization: `Bearer ${state.adminSession}` },
+          body: JSON.stringify({
+            clientId: `acme-google-client-${RUN_TAG}`,
+            clientSecret: "acme-google-secret",
+            features: ["calendarRead", "gmailDraft", "gmailRead", "driveFile"],
+          }),
+        });
+        ctx.assert(saved.response.ok, `Saving the org Google client failed: ${saved.response.status} ${JSON.stringify(saved.body)}`);
+
+        await ensureMember(ctx);
+        await denApiFetch("/v1/oauth-providers/google-workspace/disconnect", {
+          method: "POST",
+          headers: { authorization: `Bearer ${state.memberSession}` },
+        }).catch(() => {});
+
+        await bootstrapDesktopToDen(ctx);
+        await createFreshEvalWorkspace(ctx);
+        await connectGoogleWorkspace(ctx);
+        await ensureOpenWorkCloudControl(ctx);
+        await ensureRuntimeCloudMcp(ctx);
+        await resetChatState(ctx);
+      },
+    },
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 1", {
+        await ctx.prove("The user asks OpenWork to reply to Sarah's Q3 launch thread", {
           voiceover: vo[0],
           // "I'm in OpenWork, and Sarah's thread about the Q3 launch has been going back "
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await ctx.control("composer.set_text", { text: PROMPT });
+            await ctx.waitFor(
+              "window.__openworkControl?.listActions?.().find((a) => a.id === 'composer.send')?.disabled === false",
+              { timeoutMs: 15_000, label: "composer.send enabled" },
+            );
+            state.chatStartedAt = new Date().toISOString();
+            await ctx.control("composer.send");
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 1 not implemented yet");
+            await ctx.waitForText(PROMPT_FRAGMENT, { timeoutMs: 30_000 });
           },
-          screenshot: { name: "frame-1", requireText: [] },
+          screenshot: {
+            name: "gmail-reply-request",
+            claim: "The transcript shows the user asking for a threaded Q3 launch reply draft.",
+            requireText: ["find the Gmail thread", "Q3 launch"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 2",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 2", {
+        await ctx.prove("OpenWork reads Gmail before drafting the reply", {
           voiceover: vo[1],
           // "OpenWork reads the thread through my connected Google account first, so the "
-          action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
-          },
+          action: async () => {},
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 2 not implemented yet");
+            const read = await pollForGmailRead(ctx);
+            ctx.log(`Observed Gmail read: ${read.method} ${read.url}`);
           },
-          screenshot: { name: "frame-2", requireText: [] },
+          screenshot: {
+            name: "gmail-reply-reading-thread",
+            claim: "While the chat turn is working, the mock Google request log has a Gmail read for this turn.",
+            requireText: ["Q3 launch"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 3",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 3", {
+        await ctx.prove("The created draft is attached to the original Gmail thread", {
           voiceover: vo[2],
           // "It stages my reply as a draft on the same thread — same \"Re: Q3 launch\" subj"
-          action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
-          },
+          action: async () => {},
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 3 not implemented yet");
+            const draft = await pollForThreadedDraft(ctx);
+            state.draftEntry = draft;
+            ctx.assert(draft.threadId === GMAIL_THREAD_ID, `Draft threadId should be ${GMAIL_THREAD_ID}, got ${JSON.stringify(draft.threadId)}.`);
+            const decoded = decodeDraft(draft.raw);
+            state.decodedDraft = decoded;
+            ctx.assert(decoded.headers.includes("In-Reply-To: <sarah-2@acme.test>"), `Draft missing In-Reply-To header. Headers: ${decoded.headers}`);
+            ctx.assert(decoded.headers.includes("Subject: Re: Q3 launch"), `Draft missing reply subject. Headers: ${decoded.headers}`);
           },
-          screenshot: { name: "frame-3", requireText: [] },
+          screenshot: {
+            name: "gmail-reply-threaded-draft",
+            claim: "The mock Gmail draft log proves the draft used thread-q3-launch with reply headers.",
+            requireText: ["Q3 launch"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 4",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 4", {
+        await ctx.prove("The draft body appends Sarah's quoted thread history below the new reply", {
           voiceover: vo[3],
           // "When I look at the draft, my reply sits on top and the entire conversation t"
-          action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
-          },
+          action: async () => {},
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 4 not implemented yet");
+            const decoded = requireDecodedDraft(ctx);
+            const index = quoteIndex(decoded.body);
+            ctx.assert(index >= 0, `Draft body missing Sarah quote header. Body: ${decoded.body}`);
+            ctx.assert(/^> Are we still on for Thursday\?$/m.test(decoded.body), `Draft body missing quoted fixture line. Body: ${decoded.body}`);
+            const thursdayIndex = decoded.body.toLowerCase().indexOf("thursday");
+            ctx.assert(thursdayIndex >= 0 && thursdayIndex < index, `The new reply text should mention Thursday before the quote block. Body: ${decoded.body}`);
           },
-          screenshot: { name: "frame-4", requireText: [] },
+          screenshot: {
+            name: "gmail-reply-quoted-history",
+            claim: "The decoded draft has the new reply first and Sarah's quoted history immediately below it.",
+            requireText: ["Q3 launch"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 5",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 5", {
+        await ctx.prove("The new reply segment uses clean email formatting", {
           voiceover: vo[4],
           // "The text reads like an email a person wrote: real paragraphs, no weird mid-s"
-          action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
-          },
+          action: async () => {},
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 5 not implemented yet");
+            const decoded = requireDecodedDraft(ctx);
+            const index = quoteIndex(decoded.body);
+            ctx.assert(index >= 0, `Draft body missing quote delimiter. Body: ${decoded.body}`);
+            const newSegment = decoded.body.slice(0, index).trim();
+            const lines = newSegment.split("\n");
+            for (let i = 0; i < lines.length - 1; i += 1) {
+              const current = lines[i].trim();
+              const next = lines[i + 1].trim();
+              ctx.assert(!current || !next, `New reply has consecutive non-empty lines (hard wrap) around line ${i + 1}: ${JSON.stringify(newSegment)}`);
+            }
+            ctx.assert(!newSegment.includes("**"), `New reply still contains markdown bold tokens: ${JSON.stringify(newSegment)}`);
+            ctx.assert(!/^#{1,6}\s/m.test(newSegment), `New reply still contains markdown heading tokens: ${JSON.stringify(newSegment)}`);
+            ctx.assert(!newSegment.includes("`"), `New reply still contains markdown code tokens: ${JSON.stringify(newSegment)}`);
           },
-          screenshot: { name: "frame-5", requireText: [] },
+          screenshot: {
+            name: "gmail-reply-clean-formatting",
+            claim: "The decoded new reply segment has paragraphs, not hard-wrapped markdown.",
+            requireText: ["Q3 launch"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },
     {
       name: "Frame 6",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 6", {
+        await ctx.prove("OpenWork relays the Gmail draft link back to the user", {
           voiceover: vo[5],
           // "And OpenWork finishes by handing me the link — one click opens the ready-to-"
-          action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
-          },
+          action: async () => {},
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 6 not implemented yet");
+            await ctx.waitForText("mail.google.com", { timeoutMs: 240_000 });
+            const transcript = await ctx.eval("document.body.innerText");
+            ctx.assert(transcript.includes("mail.google.com"), "The chat transcript never showed the Gmail draft URL.");
           },
-          screenshot: { name: "frame-6", requireText: [] },
+          screenshot: {
+            name: "gmail-reply-draft-link",
+            claim: "The chat ends with the Gmail draftUrl that opens the ready-to-send draft.",
+            requireText: ["mail.google.com"],
+            rejectText: ["Something went wrong"],
+          },
         });
       },
     },

--- a/evals/voiceovers/gmail-reply-draft-integrity.md
+++ b/evals/voiceovers/gmail-reply-draft-integrity.md
@@ -1,0 +1,15 @@
+# gmail-reply-draft-integrity — Reply drafts keep the whole thread, read cleanly, and end with a one-click link to the ready-to-send draft in Gmail.
+
+Exercised against a connected Google account; the agent stages the draft, the user always sends from Gmail.
+
+1. I'm in OpenWork, and Sarah's thread about the Q3 launch has been going back and forth for days. I ask OpenWork to reply to her latest email and confirm that Thursday works.
+
+2. OpenWork reads the thread through my connected Google account first, so the reply is written in context — it knows who said what and where the conversation left off.
+
+3. It stages my reply as a draft on the same thread — same "Re: Q3 launch" subject, threaded onto the conversation, not a new orphaned email.
+
+4. When I look at the draft, my reply sits on top and the entire conversation trail is quoted right below it — "On Tuesday, Sarah wrote:" and everything that came before. Nothing from the thread is lost.
+
+5. The text reads like an email a person wrote: real paragraphs, no weird mid-sentence line breaks, no stray markdown symbols.
+
+6. And OpenWork finishes by handing me the link — one click opens the ready-to-send draft in Gmail, and I hit send myself.

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -31,6 +31,73 @@ const refreshTokens = new Set();
 const requests = [];
 const drafts = [];
 
+const gmailThreadId = "thread-q3-launch";
+
+function gmailBodyData(value) {
+  return Buffer.from(value, "utf8").toString("base64url");
+}
+
+const gmailThreadMessages = [
+  {
+    id: "msg-q3-kickoff",
+    threadId: gmailThreadId,
+    snippet: "Hi Sarah, Thursday still works for the Q3 launch prep.",
+    payload: {
+      headers: [
+        { name: "From", value: "Jordan Demo <jordan.demo@acme.test>" },
+        { name: "To", value: "Sarah Chen <sarah@acme.test>" },
+        { name: "Subject", value: "Q3 launch" },
+        { name: "Date", value: "Mon, 13 Jul 2026 16:30:00 -0700" },
+        { name: "Message-ID", value: "<kickoff-1@acme.test>" },
+      ],
+      mimeType: "text/plain",
+      body: {
+        data: gmailBodyData([
+          "Hi Sarah,",
+          "Thursday still works for the Q3 launch prep.",
+          "I am checking the final room details now.",
+          "Jordan",
+        ].join("\n")),
+      },
+    },
+  },
+  {
+    id: "msg-q3-sarah-2",
+    threadId: gmailThreadId,
+    snippet: "Are we still on for Thursday? I need to confirm the room booking by Wednesday.",
+    payload: {
+      headers: [
+        { name: "From", value: "Sarah Chen <sarah@acme.test>" },
+        { name: "To", value: "Jordan Demo <jordan.demo@acme.test>" },
+        { name: "Subject", value: "Re: Q3 launch" },
+        { name: "Date", value: "Tue, 14 Jul 2026 09:15:00 -0700" },
+        { name: "Message-ID", value: "<sarah-2@acme.test>" },
+        { name: "References", value: "<kickoff-1@acme.test>" },
+      ],
+      mimeType: "text/plain",
+      body: {
+        data: gmailBodyData([
+          "Are we still on for Thursday?",
+          "I need to confirm the room booking by Wednesday.",
+          "Also bringing the updated launch checklist.",
+          "Sarah",
+        ].join("\n")),
+      },
+    },
+  },
+];
+
+const gmailMessagesById = new Map(gmailThreadMessages.map((message) => [message.id, message]));
+
+function gmailMessageShape(message, format) {
+  return {
+    id: message.id,
+    threadId: message.threadId,
+    snippet: message.snippet,
+    payload: format === "full" ? message.payload : { headers: message.payload.headers },
+  };
+}
+
 function json(res, status, body, headers = {}) {
   res.writeHead(status, {
     "access-control-allow-origin": "*",
@@ -506,6 +573,50 @@ const server = http.createServer(async (req, res) => {
       return;
     }
 
+    if (url.pathname === "/gmail/v1/users/me/messages" && req.method === "GET") {
+      if (!isAuthorized(req)) {
+        json(res, 401, { error: { code: 401, message: "Invalid Credentials" } });
+        return;
+      }
+      const messages = [...gmailThreadMessages].reverse().map((message) => ({
+        id: message.id,
+        threadId: message.threadId,
+      }));
+      json(res, 200, { messages, resultSizeEstimate: messages.length });
+      return;
+    }
+
+    const gmailMessageMatch = url.pathname.match(/^\/gmail\/v1\/users\/me\/messages\/([^/]+)$/);
+    if (gmailMessageMatch && req.method === "GET") {
+      if (!isAuthorized(req)) {
+        json(res, 401, { error: { code: 401, message: "Invalid Credentials" } });
+        return;
+      }
+      const message = gmailMessagesById.get(decodeURIComponent(gmailMessageMatch[1]));
+      if (!message) {
+        json(res, 404, { error: { code: 404, message: "Message not found" } });
+        return;
+      }
+      json(res, 200, gmailMessageShape(message, url.searchParams.get("format")));
+      return;
+    }
+
+    if (url.pathname === `/gmail/v1/users/me/threads/${gmailThreadId}` && req.method === "GET") {
+      if (!isAuthorized(req)) {
+        json(res, 401, { error: { code: 401, message: "Invalid Credentials" } });
+        return;
+      }
+      json(res, 200, {
+        id: gmailThreadId,
+        messages: gmailThreadMessages.map((message) => ({
+          id: message.id,
+          threadId: message.threadId,
+          payload: message.payload,
+        })),
+      });
+      return;
+    }
+
     // Minimal Gmail drafts.create stand-in so the org Google Workspace flow
     // can be proven end-to-end: requires a token this mock issued, records
     // the request (external witness), returns Gmail-shaped ids.
@@ -516,10 +627,11 @@ const server = http.createServer(async (req, res) => {
       }
       const body = await readJson(req).catch(() => ({}));
       const raw = typeof body?.message?.raw === "string" ? body.message.raw : "";
-      drafts.push({ raw, at: new Date().toISOString() });
+      const threadId = typeof body?.message?.threadId === "string" ? body.message.threadId : null;
+      drafts.push({ raw, threadId, at: new Date().toISOString() });
       json(res, 200, {
         id: `draft-${randomUUID()}`,
-        message: { id: `msg-${randomUUID()}`, threadId: `thread-${randomUUID()}` },
+        message: { id: `msg-${randomUUID()}`, threadId: threadId || `thread-${randomUUID()}` },
       });
       return;
     }


### PR DESCRIPTION
## What

Fixes the three user-facing Gmail draft defects reported against OpenWork Connect (real production specimen: a reply sent to a customer with the entire conversation trail missing):

1. **Quoted history on reply drafts** (den-api + local extension): threaded drafts now fetch the thread (`format=full`) and append the Gmail-convention quote block — `On <date>, <sender> wrote:` + `> `-prefixed lines (10k cap, `[message trimmed]` marker, double-quote guard, graceful degradation if the original body can't be extracted).
2. **Draft discoverability**: responses now include `draftUrl` (`https://mail.google.com/mail/u/0/#drafts?compose=<messageId>`) + `threadUrl`; schema instructs the agent to always hand the user the link.
3. **Orphan-reply guard**: `Re:`/`Fwd:` subjects without `threadId` are rejected with 400 `missing_thread_id` + actionable remediation (before this, a forgetful model silently produced an unthreaded draft = "thread deleted"). Zero Google calls on the guard path.
4. **Markdown stripping** in both draft-body normalizers (headings/`**`/`__`/backticks; lists, blockquotes, fenced code untouched; hard-wrap unwrap behavior preserved).

Response shape adds `draftUrl`, `threadUrl`, `quotedHistoryIncluded`.

## Tests run (all pass)

- `ee/apps/den-api`: `bun test test/gmail-draft.test.ts test/google-workspace-capabilities.test.ts test/google-workspace-api.test.ts` — **51 pass / 0 fail** (+15 new: quote builder units, markdown normalization, threaded-draft integration incl. decoded RFC-822 body, Re-guard with `googleCallCount === 0`, link fields)
- `ee/apps/den-api`: `bun test test/mcp-tool-name-length.test.ts test/route-access-policy.test.ts test/route-guard-policy.test.ts test/agent-mcp-routes.test.ts` — 13 pass (catalog/policy unaffected)
- `apps/server`: full `bun test` — **467 pass / 7 skip / 0 fail** (extension suite 16 → 18)
- Typecheck: `tsc --noEmit` clean for both packages

## E2E proof status — honest disclosure

The fraimz flow is **coded but not executed**: `evals/flows/gmail-reply-draft-integrity.flow.mjs` (6 frames from the approved voiceover `evals/voiceovers/gmail-reply-draft-integrity.md`) + mock Gmail thread/messages endpoints in `scripts/mock-oauth-mcp-server.mjs` (curl-verified shapes). Local execution was blocked: this session runs in a launchd Background domain, so Electron cannot create windows (verified `launchctl managername` = Background; `open`/`osascript` denied); the requester waived the live run to unblock the merge.

To reproduce:
```
PORT=3978 AUTO_APPROVE=1 node scripts/mock-oauth-mcp-server.mjs &
OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9826 pnpm dev &
OPENWORK_EVAL_DEN_PORT=8990 DEN_GOOGLE_OAUTH_AUTHORIZE_URL=http://127.0.0.1:3978/authorize \
DEN_GOOGLE_OAUTH_TOKEN_URL=http://127.0.0.1:3978/token DEN_GOOGLE_API_BASE_URL=http://127.0.0.1:3978 \
MOCK_OAUTH_MCP_URL=http://127.0.0.1:3978 pnpm fraimz --flow gmail-reply-draft-integrity --stack den --cdp-url http://127.0.0.1:9826
```