### PR TITLE
feat(den-api): Drive upload + share capabilities (gmail attachment → Drive → share with a person or the whole org)

### DIFF
--- a/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
+++ b/ee/apps/den-api/src/capability-sources/google-workspace-api.ts
@@ -44,6 +44,17 @@ export type GoogleWorkspaceDriveFile = {
   size: string | null
 }
 
+export type GoogleWorkspaceDriveUploadMetadata = {
+  name: string
+  parents?: string[]
+}
+
+export type GoogleWorkspaceDrivePermission = {
+  id: string
+  type: string
+  role: string
+}
+
 type GmailBodyState = {
   plain: string | null
   html: string | null
@@ -216,6 +227,24 @@ export function buildDriveSearchQuery(text: string): string {
   return `trashed = false and (name contains '${escaped}' or fullText contains '${escaped}')`
 }
 
+export function buildDriveMultipartUpload(input: { metadata: GoogleWorkspaceDriveUploadMetadata; content: Buffer; mimeType: string; boundary: string }): Buffer {
+  const metadataPart = Buffer.from(`--${input.boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${JSON.stringify(input.metadata)}\r\n`, "utf8")
+  const contentHeader = Buffer.from(`--${input.boundary}\r\nContent-Type: ${input.mimeType}\r\n\r\n`, "utf8")
+  const footer = Buffer.from(`\r\n--${input.boundary}--\r\n`, "utf8")
+  const body = Buffer.alloc(metadataPart.byteLength + contentHeader.byteLength + input.content.byteLength + footer.byteLength)
+  let offset = 0
+  for (const chunk of [metadataPart, contentHeader, input.content, footer]) {
+    for (let index = 0; index < chunk.byteLength; index += 1) {
+      const byte = chunk[index]
+      if (byte !== undefined) {
+        body[offset + index] = byte
+      }
+    }
+    offset += chunk.byteLength
+  }
+  return body
+}
+
 export function extractGmailMessage(payloadJson: unknown): GoogleWorkspaceGmailMessage {
   const message = isRecord(payloadJson) ? payloadJson : {}
   const payload = readRecord(message, "payload") ?? {}
@@ -333,4 +362,13 @@ export function extractDriveFiles(json: unknown): GoogleWorkspaceDriveFile[] {
     })
   }
   return files
+}
+
+export function extractDrivePermission(json: unknown): GoogleWorkspaceDrivePermission {
+  const root = isRecord(json) ? json : {}
+  return {
+    id: readString(root, "id"),
+    type: readString(root, "type"),
+    role: readString(root, "role"),
+  }
 }

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -10,10 +10,12 @@ import { buildGmailDraftRaw, readGmailDraftIds } from "../../capability-sources/
 import type { GmailDraftAttachment } from "../../capability-sources/gmail.js"
 import { getValidAccessToken } from "../../capability-sources/generic-oauth.js"
 import {
-  buildGmailQuoteBlock,
+  buildDriveMultipartUpload,
   buildDriveSearchQuery,
+  buildGmailQuoteBlock,
   extractCalendarEvents,
   extractDriveFiles,
+  extractDrivePermission,
   extractGmailAttachmentData,
   extractGmailMessage,
   extractGmailMessageIds,
@@ -227,9 +229,47 @@ const driveFilesQuerySchema = z.object({
   maxResults: z.coerce.number().int().min(1).max(25).default(10).describe("Maximum files to return, capped at 25."),
 }).meta({ ref: "GoogleWorkspaceDriveFilesQuery" })
 
+const uploadDriveFileBodySchema = z.object({
+  filename: z.string().trim().min(1).max(255).refine((value) => !/[\r\n]/.test(value), "Filename must not contain line breaks.").describe("Filename to create in Google Drive."),
+  mimeType: z.string().trim().regex(/^[!#$%&'*+.^_`|~0-9A-Za-z-]+\/[!#$%&'*+.^_`|~0-9A-Za-z-]+$/).describe("File MIME type."),
+  dataBase64: z.string().min(1).max(MAX_GMAIL_ATTACHMENT_BASE64_LENGTH).regex(/^(?:[A-Za-z0-9+/]{4})*(?:[A-Za-z0-9+/]{2}==|[A-Za-z0-9+/]{3}=)?$/).describe("File bytes as standard base64. The gmail-attachment capability returns dataBase64 in this exact encoding — pass it through directly to save an email attachment to Drive. Maximum decoded size: 10 MiB."),
+  folderId: z.string().trim().min(1).max(512).optional().describe("Optional Google Drive parent folder id."),
+}).strict().superRefine((input, context) => {
+  if (Buffer.byteLength(input.dataBase64, "base64") > MAX_GMAIL_ATTACHMENT_BYTES) {
+    context.addIssue({
+      code: "custom",
+      path: ["dataBase64"],
+      message: "File must be 10 MiB or less.",
+    })
+  }
+}).meta({ ref: "GoogleWorkspaceUploadDriveFileBody" })
+
 const driveFileParamSchema = z.object({
   fileId: z.string().trim().min(1).max(512).describe("Google Drive file id."),
 }).meta({ ref: "GoogleWorkspaceDriveFileParams" })
+
+const shareDriveFileBodySchema = z.object({
+  type: z.enum(["user", "domain"]).describe("Use type=user to share with one person, or type=domain to share with the entire organization."),
+  emailAddress: z.string().trim().email().max(320).optional().describe("Required when type=user; pass the person's email address, for example raghav@openworklabs.com."),
+  domain: z.string().trim().min(1).max(255).optional().describe("Required when type=domain; pass the organization's Google Workspace domain, for example openworklabs.com."),
+  role: z.enum(["reader", "commenter", "writer"]).default("reader").describe("Drive permission role to grant."),
+  sendNotificationEmail: z.boolean().default(true).describe("Whether Google should email the recipient about the new access."),
+}).strict().superRefine((input, context) => {
+  if (input.type === "user" && !input.emailAddress) {
+    context.addIssue({
+      code: "custom",
+      path: ["emailAddress"],
+      message: "emailAddress is required when type is user.",
+    })
+  }
+  if (input.type === "domain" && !input.domain) {
+    context.addIssue({
+      code: "custom",
+      path: ["domain"],
+      message: "domain is required when type is domain.",
+    })
+  }
+}).meta({ ref: "GoogleWorkspaceShareDriveFileBody" })
 
 const driveFileSummarySchema = z.object({
   id: z.string(),
@@ -245,6 +285,11 @@ const driveFilesResponseSchema = z.object({
   files: z.array(driveFileSummarySchema),
 }).meta({ ref: "GoogleWorkspaceDriveFilesResponse" })
 
+const uploadDriveFileResponseSchema = z.object({
+  ok: z.literal(true),
+  file: driveFileSummarySchema,
+}).meta({ ref: "GoogleWorkspaceUploadDriveFileResponse" })
+
 const driveFileResponseSchema = z.object({
   ok: z.literal(true),
   file: driveFileSummarySchema.extend({
@@ -252,6 +297,14 @@ const driveFileResponseSchema = z.object({
     truncated: z.boolean(),
   }),
 }).meta({ ref: "GoogleWorkspaceDriveFileResponse" })
+
+const shareDriveFileResponseSchema = z.object({
+  ok: z.literal(true),
+  fileId: z.string(),
+  permissionId: z.string(),
+  type: z.string(),
+  role: z.string(),
+}).meta({ ref: "GoogleWorkspaceShareDriveFileResponse" })
 
 type GoogleWorkspaceAccessToken =
   | { kind: "ok"; accessToken: string; account: ConnectedAccountRow }
@@ -771,6 +824,76 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
     },
   )
 
+  app.post(
+    "/v1/capabilities/google-workspace/drive-files",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "Upload file bytes to Google Drive as the calling member",
+      description: "Creates a file in the calling member's Google Drive using standard base64 bytes. The gmail-attachment capability returns dataBase64 in this exact encoding — pass it through directly to save an email attachment to Drive. The response file.webViewLink is the user-facing link — share it with the user.",
+      responses: {
+        200: jsonResponse("Google Drive file uploaded. The file.webViewLink is the user-facing link — share it with the user.", uploadDriveFileResponseSchema),
+        400: jsonResponse("The upload request was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
+        502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
+      },
+    }),
+    orgMemberRoute(),
+    jsonValidator(uploadDriveFileBodySchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const token = await googleWorkspaceToken({
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if (token.kind === "google_api_error") {
+        return c.json({ error: "google_api_error", message: token.message }, 502)
+      }
+      if (token.kind === "needs_connection") {
+        return c.json({ error: "needs_connection", message: token.message }, 409)
+      }
+      if (missingScope(token.account, [DRIVE_FILE_SCOPE, DRIVE_FULL_SCOPE])) {
+        return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Drive write") }, 409)
+      }
+
+      const input = c.req.valid("json")
+      const metadata: { name: string; parents?: string[] } = { name: input.filename }
+      if (input.folderId) {
+        metadata.parents = [input.folderId]
+      }
+      const boundary = `openwork-${randomUUID()}`
+      const url = new URL(`${driveApiBase()}/upload/drive/v3/files`)
+      url.searchParams.set("uploadType", "multipart")
+      url.searchParams.set("fields", "id,name,mimeType,modifiedTime,webViewLink,size")
+      const uploadBody = buildDriveMultipartUpload({
+        metadata,
+        content: Buffer.from(input.dataBase64, "base64"),
+        mimeType: input.mimeType,
+        boundary,
+      })
+      const uploadBodyBytes = new Uint8Array(uploadBody.byteLength)
+      uploadBodyBytes.set(uploadBody)
+      const response = await googleWorkspaceApiFetch(url, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token.accessToken}`,
+          "content-type": `multipart/related; boundary=${boundary}`,
+        },
+        body: uploadBodyBytes,
+      })
+      if (!response.ok) {
+        return c.json(await googleApiError("Google Drive file upload", response), 502)
+      }
+
+      const file = extractDriveFiles({ files: [await readJson(response)] })[0]
+      if (!file?.id) {
+        return c.json({ error: "google_api_error", message: "Google Drive returned no file id." }, 502)
+      }
+
+      return c.json({ ok: true, file })
+    },
+  )
+
   app.get(
     "/v1/capabilities/google-workspace/drive-file/:fileId",
     describeRoute({
@@ -842,6 +965,74 @@ export function registerGoogleWorkspaceRoutes<T extends { Variables: OrgRouteVar
           truncated: content.truncated,
         },
       })
+    },
+  )
+
+  app.post(
+    "/v1/capabilities/google-workspace/drive-file-share/:fileId",
+    describeRoute({
+      tags: ["Capability Sources"],
+      summary: "Share a Google Drive file with a person or the organization",
+      description: "Creates a Drive permission for one file using the calling member's Google Workspace account. To share with one person pass type=user plus emailAddress; to share with the entire organization pass type=domain plus the org's Google Workspace domain (e.g. openworklabs.com). Sharing files not created through OpenWork needs the Full Drive access feature enabled by an admin.",
+      responses: {
+        200: jsonResponse("Google Drive file shared.", shareDriveFileResponseSchema),
+        400: jsonResponse("The share request was invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in.", unauthorizedSchema),
+        409: jsonResponse("The calling member has not connected their Google account or is missing permission.", needsConnectionSchema),
+        502: jsonResponse("Google rejected the request.", upstreamErrorSchema),
+      },
+    }),
+    orgMemberRoute(),
+    paramValidator(driveFileParamSchema),
+    jsonValidator(shareDriveFileBodySchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const token = await googleWorkspaceToken({
+        organizationId: payload.organization.id,
+        orgMembershipId: payload.currentMember.id,
+      })
+      if (token.kind === "google_api_error") {
+        return c.json({ error: "google_api_error", message: token.message }, 502)
+      }
+      if (token.kind === "needs_connection") {
+        return c.json({ error: "needs_connection", message: token.message }, 409)
+      }
+      if (missingScope(token.account, [DRIVE_FILE_SCOPE, DRIVE_FULL_SCOPE])) {
+        return c.json({ error: "needs_connection", message: missingPermissionMessage("Google Drive write") }, 409)
+      }
+
+      const { fileId } = c.req.valid("param")
+      const input = c.req.valid("json")
+      const permissionPayload = input.type === "user" && input.emailAddress
+        ? { type: input.type, role: input.role, emailAddress: input.emailAddress }
+        : input.type === "domain" && input.domain
+          ? { type: input.type, role: input.role, domain: input.domain }
+          : null
+      if (!permissionPayload) {
+        return c.json({ error: "invalid_request", details: "emailAddress is required for user shares and domain is required for domain shares." }, 400)
+      }
+
+      const url = new URL(`${driveApiBase()}/drive/v3/files/${encodeURIComponent(fileId)}/permissions`)
+      url.searchParams.set("sendNotificationEmail", String(input.sendNotificationEmail))
+      url.searchParams.set("fields", "id,type,role")
+      const response = await googleWorkspaceApiFetch(url, {
+        method: "POST",
+        headers: {
+          authorization: `Bearer ${token.accessToken}`,
+          "content-type": "application/json",
+        },
+        body: JSON.stringify(permissionPayload),
+      })
+      if (!response.ok) {
+        return c.json(await googleApiError("Google Drive file share", response), 502)
+      }
+
+      const permission = extractDrivePermission(await readJson(response))
+      if (!permission.id) {
+        return c.json({ error: "google_api_error", message: "Google Drive returned no permission id." }, 502)
+      }
+
+      return c.json({ ok: true, fileId, permissionId: permission.id, type: permission.type, role: permission.role })
     },
   )
 

--- a/ee/apps/den-api/test/google-workspace-api.test.ts
+++ b/ee/apps/den-api/test/google-workspace-api.test.ts
@@ -1,9 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import {
-  buildGmailQuoteBlock,
+  buildDriveMultipartUpload,
   buildDriveSearchQuery,
+  buildGmailQuoteBlock,
   extractCalendarEvents,
   extractDriveFiles,
+  extractDrivePermission,
   extractGmailAttachmentData,
   extractGmailMessage,
   truncateText,
@@ -181,6 +183,18 @@ describe("Drive helpers", () => {
     expect(buildDriveSearchQuery("it's \\ tricky")).toBe("trashed = false and (name contains 'it\\'s \\\\ tricky' or fullText contains 'it\\'s \\\\ tricky')")
   })
 
+  test("buildDriveMultipartUpload frames metadata and preserves binary bytes", () => {
+    const boundary = "openwork-test-boundary"
+    const content = Buffer.from([0x00, 0xfb, 0xef, 0xbe, 0xff, 0x61])
+    const metadata = { name: "Résumé.txt", parents: ["folder_1"] }
+    const body = buildDriveMultipartUpload({ metadata, content, mimeType: "text/plain", boundary })
+    const prefix = Buffer.from(`--${boundary}\r\nContent-Type: application/json; charset=UTF-8\r\n\r\n${JSON.stringify(metadata)}\r\n--${boundary}\r\nContent-Type: text/plain\r\n\r\n`, "utf8")
+    const suffix = Buffer.from(`\r\n--${boundary}--\r\n`, "utf8")
+
+    expect(body.equals(Buffer.concat([prefix, content, suffix]))).toBe(true)
+    expect(body.subarray(prefix.byteLength, prefix.byteLength + content.byteLength).equals(content)).toBe(true)
+  })
+
   test("extractDriveFiles maps file metadata and preserves absent size as null", () => {
     expect(extractDriveFiles({
       files: [
@@ -218,6 +232,14 @@ describe("Drive helpers", () => {
         size: null,
       },
     ])
+  })
+
+  test("extractDrivePermission maps permission fields", () => {
+    expect(extractDrivePermission({ id: "perm_1", type: "domain", role: "reader", ignored: true })).toEqual({
+      id: "perm_1",
+      type: "domain",
+      role: "reader",
+    })
   })
 })
 

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -55,6 +55,11 @@ function expectString(value: unknown, label: string): string {
   return value
 }
 
+function readString(record: Record<string, unknown>, key: string): string {
+  const value = record[key]
+  return typeof value === "string" ? value : ""
+}
+
 function expectDraftMessage(): Record<string, unknown> {
   const payload = expectRecord(lastDraftPayload, "Gmail draft payload")
   return expectRecord(payload.message, "Gmail draft message")
@@ -74,8 +79,10 @@ function decodeDraftTextBody(): string {
 const GMAIL_READ_SCOPE = "https://www.googleapis.com/auth/gmail.readonly"
 const CALENDAR_READ_SCOPE = "https://www.googleapis.com/auth/calendar.readonly"
 const CALENDAR_EVENTS_SCOPE = "https://www.googleapis.com/auth/calendar.events"
+const DRIVE_FILE_SCOPE = "https://www.googleapis.com/auth/drive.file"
 const DRIVE_READ_SCOPE = "https://www.googleapis.com/auth/drive.readonly"
-const FULL_SCOPES = [GMAIL_READ_SCOPE, CALENDAR_READ_SCOPE, CALENDAR_EVENTS_SCOPE, DRIVE_READ_SCOPE]
+const DRIVE_FULL_SCOPE = "https://www.googleapis.com/auth/drive"
+const FULL_SCOPES = [GMAIL_READ_SCOPE, CALENDAR_READ_SCOPE, CALENDAR_EVENTS_SCOPE, DRIVE_READ_SCOPE, DRIVE_FILE_SCOPE]
 
 let lastAuthorization: string | null = null
 let googleCallCount = 0
@@ -83,12 +90,17 @@ let googleCallUrls: string[] = []
 let forceGoogleError = false
 let forceGmailThreadError = false
 let lastDriveQuery: string | null = null
+let lastDriveUploadContentType: string | null = null
+let lastDriveUploadBody: Buffer | null = null
+let lastDriveSharePayload: unknown = null
+let lastDriveShareUrl: string | null = null
 let lastCalendarEventPayload: unknown = null
 let lastCalendarUrl: string | null = null
 let lastCalendarMethod: string | null = null
 let calendarCreateCount = 0
 let lastDraftPayload: unknown = null
 let lastGmailThreadUrl: string | null = null
+let forceDriveUploadError = false
 
 function resetFakeGoogle() {
   lastAuthorization = null
@@ -97,12 +109,17 @@ function resetFakeGoogle() {
   forceGoogleError = false
   forceGmailThreadError = false
   lastDriveQuery = null
+  lastDriveUploadContentType = null
+  lastDriveUploadBody = null
+  lastDriveSharePayload = null
+  lastDriveShareUrl = null
   lastCalendarEventPayload = null
   lastCalendarUrl = null
   lastCalendarMethod = null
   calendarCreateCount = 0
   lastDraftPayload = null
   lastGmailThreadUrl = null
+  forceDriveUploadError = false
 }
 
 // Trailing high bytes force base64url output ("-"/"_") to differ from standard base64 ("+"/"/").
@@ -259,6 +276,32 @@ const fakeGoogleServer = Bun.serve({
             size: "42",
           },
         ],
+      })
+    }
+    if (url.pathname === "/upload/drive/v3/files" && request.method === "POST") {
+      lastDriveUploadContentType = request.headers.get("content-type")
+      lastDriveUploadBody = Buffer.from(await request.arrayBuffer())
+      if (forceDriveUploadError) {
+        return new Response("upload exploded", { status: 500 })
+      }
+      return json({
+        id: "uploaded_file_1",
+        name: "plan.pdf",
+        mimeType: "application/pdf",
+        modifiedTime: "2026-07-08T12:00:00Z",
+        webViewLink: "https://drive.google.com/file/d/uploaded_file_1/view",
+        size: "28",
+      })
+    }
+    if (url.pathname === "/drive/v3/files/file_1/permissions" && request.method === "POST") {
+      const body: unknown = await request.json()
+      lastDriveSharePayload = body
+      lastDriveShareUrl = request.url
+      const payload = isRecord(body) ? body : {}
+      return json({
+        id: readString(payload, "type") === "domain" ? "perm_domain_1" : "perm_user_1",
+        type: readString(payload, "type"),
+        role: readString(payload, "role"),
       })
     }
     if (url.pathname === "/drive/v3/files/file_1" && url.searchParams.get("alt") === "media") {
@@ -848,6 +891,128 @@ test("drive search returns mapped files", async () => {
   })
 })
 
+test("drive upload stores decoded bytes as multipart and returns the user-facing Drive link", async () => {
+  await seedConnectedAccount([DRIVE_FILE_SCOPE])
+  resetFakeGoogle()
+  const uploadBytes = Buffer.from("%PDF-1.4\nDrive upload bytes\n", "utf8")
+  const response = await request("/v1/capabilities/google-workspace/drive-files", {
+    method: "POST",
+    body: {
+      filename: "plan.pdf",
+      mimeType: "application/pdf",
+      dataBase64: uploadBytes.toString("base64"),
+      folderId: "folder_1",
+    },
+  })
+  expect(response.status).toBe(200)
+  expect(lastAuthorization).toBe("Bearer gws-token")
+  const contentType = expectString(lastDriveUploadContentType, "drive upload content type")
+  const boundary = contentType.match(/boundary=(.+)$/)?.[1]
+  if (!boundary) {
+    throw new Error("Expected multipart boundary")
+  }
+  expect(contentType).toBe(`multipart/related; boundary=${boundary}`)
+  if (!lastDriveUploadBody) {
+    throw new Error("Expected drive upload body")
+  }
+  expect(lastDriveUploadBody.includes(Buffer.from(`--${boundary}\r\n`, "utf8"))).toBe(true)
+  expect(lastDriveUploadBody.includes(Buffer.from('{"name":"plan.pdf","parents":["folder_1"]}', "utf8"))).toBe(true)
+  expect(lastDriveUploadBody.includes(uploadBytes)).toBe(true)
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    ok: true,
+    file: {
+      id: "uploaded_file_1",
+      name: "plan.pdf",
+      mimeType: "application/pdf",
+      modifiedTime: "2026-07-08T12:00:00Z",
+      webViewLink: "https://drive.google.com/file/d/uploaded_file_1/view",
+      size: "28",
+    },
+  })
+})
+
+test("drive upload requires Drive write scope before calling Google", async () => {
+  await seedConnectedAccount([DRIVE_READ_SCOPE])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/drive-files", {
+    method: "POST",
+    body: {
+      filename: "plan.pdf",
+      mimeType: "application/pdf",
+      dataBase64: Buffer.from("drive bytes", "utf8").toString("base64"),
+    },
+  })
+  expect(response.status).toBe(409)
+  expect(googleCallCount).toBe(0)
+  const body: unknown = await response.json()
+  expect(expectMessage(body)).toContain("missing the Google Drive write permission")
+})
+
+test("drive share grants user access and sends notification by default", async () => {
+  await seedConnectedAccount([DRIVE_FILE_SCOPE])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/drive-file-share/file_1", {
+    method: "POST",
+    body: { type: "user", emailAddress: "raghav@openworklabs.com" },
+  })
+  expect(response.status).toBe(200)
+  expect(lastDriveSharePayload).toEqual({ type: "user", role: "reader", emailAddress: "raghav@openworklabs.com" })
+  const url = new URL(expectString(lastDriveShareUrl, "drive share URL"))
+  expect(url.pathname).toBe("/drive/v3/files/file_1/permissions")
+  expect(url.searchParams.get("sendNotificationEmail")).toBe("true")
+  expect(url.searchParams.get("fields")).toBe("id,type,role")
+  const body: unknown = await response.json()
+  expect(body).toEqual({ ok: true, fileId: "file_1", permissionId: "perm_user_1", type: "user", role: "reader" })
+})
+
+test("drive share grants domain access", async () => {
+  await seedConnectedAccount([DRIVE_FULL_SCOPE])
+  resetFakeGoogle()
+  const response = await request("/v1/capabilities/google-workspace/drive-file-share/file_1", {
+    method: "POST",
+    body: { type: "domain", domain: "openworklabs.com", sendNotificationEmail: false },
+  })
+  expect(response.status).toBe(200)
+  expect(lastDriveSharePayload).toEqual({ type: "domain", role: "reader", domain: "openworklabs.com" })
+  const url = new URL(expectString(lastDriveShareUrl, "drive share URL"))
+  expect(url.searchParams.get("sendNotificationEmail")).toBe("false")
+  const body: unknown = await response.json()
+  expect(body).toEqual({ ok: true, fileId: "file_1", permissionId: "perm_domain_1", type: "domain", role: "reader" })
+})
+
+test("drive share validates user email before calling Google", async () => {
+  const response = await request("/v1/capabilities/google-workspace/drive-file-share/file_1", {
+    method: "POST",
+    body: { type: "user" },
+  })
+  expect(response.status).toBe(400)
+  expect(googleCallCount).toBe(0)
+  const body: unknown = await response.json()
+  expect(expectRecord(body, "invalid share response").error).toBe("invalid_request")
+})
+
+test("drive upload returns google_api_error when Google rejects the upload", async () => {
+  await seedConnectedAccount([DRIVE_FILE_SCOPE])
+  resetFakeGoogle()
+  forceDriveUploadError = true
+  const response = await request("/v1/capabilities/google-workspace/drive-files", {
+    method: "POST",
+    body: {
+      filename: "plan.pdf",
+      mimeType: "application/pdf",
+      dataBase64: Buffer.from("drive bytes", "utf8").toString("base64"),
+    },
+  })
+  expect(response.status).toBe(502)
+  expect(googleCallCount).toBe(1)
+  const body: unknown = await response.json()
+  expect(body).toEqual({
+    error: "google_api_error",
+    message: "Google Drive file upload failed: 500 upload exploded",
+  })
+})
+
 test("no connected account returns needs_connection", async () => {
   await db.delete(schema.ConnectedAccountTable).where(drizzle.eq(schema.ConnectedAccountTable.organizationId, organizationId))
   const response = await request("/v1/capabilities/google-workspace/calendar-events?timeMin=2026-07-08T00%3A00%3A00Z&timeMax=2026-07-11T00%3A00%3A00Z")
@@ -893,6 +1058,8 @@ test("Google Workspace capability tools are discoverable and keep readable names
   expect(searchCapabilities(catalog, "calendar events list", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceCalendarEvents")
   expect(searchCapabilities(catalog, "add meet link existing event", 10)[0]?.name).toBe("patchCapabilitiesGoogleWorkspaceCalendarEvent")
   expect(searchCapabilities(catalog, "drive files", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceDriveFiles")
+  expect(searchCapabilities(catalog, "drive upload", 10)[0]?.name).toBe("postCapabilitiesGoogleWorkspaceDriveFiles")
+  expect(searchCapabilities(catalog, "share drive file", 10)[0]?.name).toBe("postCapabilitiesGoogleWorkspaceDriveFileShare")
   expect(searchCapabilities(catalog, "gmail search read messages", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceGmailMessages")
   const draftMatch = searchCapabilities(catalog, "gmail draft workspace attachment", 10)[0]
   expect(draftMatch?.name).toBe("postCapabilitiesGoogleWorkspaceGmailDrafts")
@@ -908,7 +1075,9 @@ test("Google Workspace capability tools are discoverable and keep readable names
     "postCapabilitiesGoogleWorkspaceCalendarEvents",
     "patchCapabilitiesGoogleWorkspaceCalendarEvent",
     "getCapabilitiesGoogleWorkspaceDriveFiles",
+    "postCapabilitiesGoogleWorkspaceDriveFiles",
     "getCapabilitiesGoogleWorkspaceDriveFile",
+    "postCapabilitiesGoogleWorkspaceDriveFileShare",
     "postCapabilitiesGoogleWorkspaceGmailDrafts",
   ]
   const catalogNames = new Set(catalog.map((tool) => tool.name))


### PR DESCRIPTION
## What

Drive was read-only in den-api. This adds the two missing capabilities so an agent can complete: *"take this Gmail attachment, add it to Drive, and give access to raghav@… or the entire org"* — with zero MCP/policy/OAuth/UI changes (routes tagged `Capability Sources` are auto-discovered; all needed scopes/features already exist — `driveFile` is a default org-connection feature).

1. **`POST /v1/capabilities/google-workspace/drive-files`** — upload (multipart/related to Drive v3). Body `{filename, mimeType, dataBase64, folderId?}`; `dataBase64` uses the same standard base64 as the gmail-attachment capability's output, so the agent pipes download → upload directly (schema says so). 10 MiB cap. Returns `{ok, file:{id,…,webViewLink}}` with webViewLink as the user-facing link.
2. **`POST /v1/capabilities/google-workspace/drive-file-share/:fileId`** — permissions.create. `{type:"user", emailAddress}` for one person, `{type:"domain", domain}` for the entire org; role reader/commenter/writer (default reader); `sendNotificationEmail` (default true). Tool name `postCapabilitiesGoogleWorkspaceDriveFileShare` (45 chars, under the 49-char Bedrock guard — deliberately not "…Permissions", 51).

Both gated on `drive.file` OR full `drive` scope with the standard 409 `needs_connection` remediation (zero Google calls when missing). Pure helpers (`buildDriveMultipartUpload`, `extractDrivePermission`) kept HTTP-free for unit testing.

## Tests run (all pass)

- `bun test test/google-workspace-capabilities.test.ts test/google-workspace-api.test.ts test/gmail-draft.test.ts test/mcp-tool-name-length.test.ts` — **67 pass / 0 fail** (new: multipart round-trip incl. binary bytes, share user + share domain payload capture, 409 without write scope with `googleCallCount === 0`, share validation 400, 502 passthrough, catalog discoverability + name-length for both new tools)
- `bun test test/route-access-policy.test.ts test/route-guard-policy.test.ts test/agent-mcp-routes.test.ts` — 5 pass
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` — clean

## E2E status — honest disclosure

API-level capability work validated by integration tests against a fake Google server (request payloads + auth asserted). No fraimz run for this PR (requester waived live e2e for now; the agent-visible chain is exercised end-to-end at the API layer in the integration tests).