### PR TITLE
feat(den): simplify MCP action cards

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useRef, useState, useEffect } from "react";
-import { ArrowLeft, Check, GitBranch, Github, Globe, Loader2, Plus, Puzzle, Users, X } from "lucide-react";
+import { ArrowLeft, Check, ChevronDown, GitBranch, Github, Globe, Loader2, Plus, Puzzle, Users, X } from "lucide-react";
 import { PaperMeshGradient, StaticSeededGradient } from "@openwork/ui/react";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
@@ -643,30 +643,22 @@ function MarketplacePluginCard({
                 {cloudReadinessLabel(plugin.cloudReadiness.state)}
               </span>
               {actionableConnections.length > 0 ? (
-                <div className="mt-2 space-y-2">
+                <div className="mt-2 space-y-1.5">
                   {actionableConnections.map((connection) => {
                     const preset = findPresetForRequirement(presets, connection);
                     const serviceName = serviceNameForRequirement(connection, preset);
                     const needsAdminSetup = pluginRequirementNeedsAdminSetup(connection);
                     const readinessAction = needsAdminSetup ? null : pluginReadinessConnectionAction(connection, isAdmin);
                     return (
-                      <div key={`${connection.configObjectId}:${connection.serverName}`} className="rounded-xl border border-amber-100 bg-amber-50/60 p-3">
-                        <div className="flex items-start gap-2.5">
+                      <div key={`${connection.configObjectId}:${connection.serverName}`} className="rounded-xl border border-amber-100 bg-amber-50/60 px-3 py-2.5">
+                        <div className="flex flex-wrap items-center gap-2.5">
                           <IntegrationIcon name={serviceName} serviceUrl={connection.url} className="h-8 w-8 rounded-[10px]" imageClassName="h-4 w-4" />
                           <div className="min-w-0 flex-1">
                             <div className="flex flex-wrap items-center gap-1.5">
                               <p className="truncate text-[12.5px] font-semibold text-gray-900">{serviceName}</p>
                               <span className="rounded-full bg-white px-2 py-0.5 text-[10.5px] font-medium text-amber-700">Needs connection</span>
                             </div>
-                            <p className="mt-1 break-all font-mono text-[11px] leading-4 text-gray-500">
-                              Plugin-declared URL (read-only): {connection.url}
-                            </p>
-                            {readinessAction ? (
-                              <p className="mt-1 text-[11.5px] leading-4 text-amber-700">{readinessAction.note}</p>
-                            ) : null}
                           </div>
-                        </div>
-                        <div className="mt-2 flex justify-end">
                           {needsAdminSetup ? (
                             isAdmin ? (
                               <DenButton variant="secondary" size="sm" onClick={() => onSetup(connection)}>
@@ -684,6 +676,20 @@ function MarketplacePluginCard({
                             </Link>
                           ) : null}
                         </div>
+                        <details className="group/connection mt-2 border-t border-amber-100 pt-2">
+                          <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-[11px] font-medium text-amber-800 transition hover:text-amber-950 [&::-webkit-details-marker]:hidden">
+                            Connection details
+                            <ChevronDown className="h-3 w-3 transition-transform group-open/connection:rotate-180" aria-hidden="true" />
+                          </summary>
+                          <div className="mt-2 rounded-lg border border-amber-100 bg-white/70 px-2.5 py-2">
+                            <p className="break-all font-mono text-[10.5px] leading-4 text-gray-500">
+                              Plugin-declared URL (read-only): {connection.url}
+                            </p>
+                            {readinessAction ? (
+                              <p className="mt-1 text-[11.5px] leading-4 text-amber-700">{readinessAction.note}</p>
+                            ) : null}
+                          </div>
+                        </details>
                       </div>
                     );
                   })}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useMemo, useRef, useState, useEffect } from "react";
-import { ArrowLeft, Check, ChevronDown, GitBranch, Github, Globe, Loader2, Plus, Puzzle, Users, X } from "lucide-react";
+import { ArrowLeft, Check, ChevronDown, GitBranch, Github, Globe, Loader2, Plug, Plus, Puzzle, Users, X } from "lucide-react";
 import { PaperMeshGradient, StaticSeededGradient } from "@openwork/ui/react";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
@@ -213,7 +213,7 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
               </p>
             </div>
           ) : (
-            <div className="grid gap-3 md:grid-cols-2">
+            <div className="grid items-start gap-3 md:grid-cols-2">
               {plugins.map((plugin) => (
                 <MarketplacePluginCard
                   key={plugin.id}
@@ -589,9 +589,60 @@ function MarketplacePluginCard({
   const actionableConnections = plugin.cloudReadiness?.connections.filter((connection) => (
     pluginRequirementNeedsAdminSetup(connection) || pluginReadinessConnectionAction(connection, isAdmin) !== null
   )) ?? [];
+  const connectionRows = actionableConnections.map((connection) => {
+    const preset = findPresetForRequirement(presets, connection);
+    const serviceName = serviceNameForRequirement(connection, preset);
+    const needsAdminSetup = pluginRequirementNeedsAdminSetup(connection);
+    const readinessAction = needsAdminSetup ? null : pluginReadinessConnectionAction(connection, isAdmin);
+    return (
+      <div key={`${connection.configObjectId}:${connection.serverName}`} className="px-3 py-2.5">
+        <div className="flex items-center gap-2">
+          <IntegrationIcon name={serviceName} serviceUrl={connection.url} className="h-7 w-7 rounded-lg" imageClassName="h-3.5 w-3.5" />
+          <p className="min-w-0 flex-1 truncate text-[12.5px] font-semibold text-gray-900">{serviceName}</p>
+          {needsAdminSetup ? (
+            isAdmin ? (
+              <DenButton
+                variant="secondary"
+                size="sm"
+                icon={Plug}
+                className="h-7 shrink-0 px-2.5 text-[11px]"
+                onClick={() => onSetup(connection)}
+              >
+                Connect
+              </DenButton>
+            ) : (
+              <span className="shrink-0 text-[11px] font-medium text-gray-500">Admin setup needed</span>
+            )
+          ) : readinessAction ? (
+            <Link
+              href={yourConnectionsFocusRoute(orgSlug, readinessAction.connectionId)}
+              className={buttonVariants({ variant: "secondary", size: "sm", className: "h-7 shrink-0 px-2.5 text-[11px]" })}
+            >
+              <Plug className="h-3 w-3" aria-hidden="true" />
+              Connect
+            </Link>
+          ) : null}
+        </div>
+        <details className="group/connection ml-9 mt-1">
+          <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-[10.5px] text-gray-400 transition hover:text-gray-600 [&::-webkit-details-marker]:hidden">
+            Details
+            <ChevronDown className="h-2.5 w-2.5 transition-transform group-open/connection:rotate-180" aria-hidden="true" />
+          </summary>
+          <div className="mt-1.5 rounded-lg bg-gray-50 px-2.5 py-2">
+            <p className="break-all font-mono text-[10px] leading-4 text-gray-500">
+              Plugin-declared URL (read-only): {connection.url}
+            </p>
+            {readinessAction ? (
+              <p className="mt-1 text-[11px] leading-4 text-gray-600">{readinessAction.note}</p>
+            ) : null}
+          </div>
+        </details>
+      </div>
+    );
+  });
 
   return (
-    <div className="group block overflow-hidden rounded-2xl border border-gray-100 bg-white transition hover:-translate-y-0.5 hover:border-gray-200 hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)]">
+    <div className="group block self-start overflow-hidden rounded-2xl border border-gray-100 bg-white transition hover:-translate-y-0.5 hover:border-gray-200 hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)]">
       <div className="flex items-stretch">
         <div className="relative w-[64px] shrink-0 overflow-hidden">
           <StaticSeededGradient seed={plugin.id} className="absolute inset-0" />
@@ -639,62 +690,36 @@ function MarketplacePluginCard({
 
           {plugin.cloudReadiness ? (
             <div className="mt-3 border-t border-gray-50 pt-3">
-              <span className={`inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium ${plugin.cloudReadiness.state === "ready" ? "bg-emerald-50 text-emerald-700" : plugin.cloudReadiness.state === "needs_admin_setup" ? "bg-amber-50 text-amber-700" : "bg-gray-50 text-gray-600"}`}>
-                {cloudReadinessLabel(plugin.cloudReadiness.state)}
-              </span>
               {actionableConnections.length > 0 ? (
-                <div className="mt-2 space-y-1.5">
-                  {actionableConnections.map((connection) => {
-                    const preset = findPresetForRequirement(presets, connection);
-                    const serviceName = serviceNameForRequirement(connection, preset);
-                    const needsAdminSetup = pluginRequirementNeedsAdminSetup(connection);
-                    const readinessAction = needsAdminSetup ? null : pluginReadinessConnectionAction(connection, isAdmin);
-                    return (
-                      <div key={`${connection.configObjectId}:${connection.serverName}`} className="rounded-xl border border-amber-100 bg-amber-50/60 px-3 py-2.5">
-                        <div className="flex flex-wrap items-center gap-2.5">
-                          <IntegrationIcon name={serviceName} serviceUrl={connection.url} className="h-8 w-8 rounded-[10px]" imageClassName="h-4 w-4" />
-                          <div className="min-w-0 flex-1">
-                            <div className="flex flex-wrap items-center gap-1.5">
-                              <p className="truncate text-[12.5px] font-semibold text-gray-900">{serviceName}</p>
-                              <span className="rounded-full bg-white px-2 py-0.5 text-[10.5px] font-medium text-amber-700">Needs connection</span>
-                            </div>
-                          </div>
-                          {needsAdminSetup ? (
-                            isAdmin ? (
-                              <DenButton variant="secondary" size="sm" onClick={() => onSetup(connection)}>
-                                {pluginSetupActionLabel(preset)}
-                              </DenButton>
-                            ) : (
-                              <span className="text-[12px] font-medium text-amber-700">Ask an admin to configure</span>
-                            )
-                          ) : readinessAction ? (
-                            <Link
-                              href={yourConnectionsFocusRoute(orgSlug, readinessAction.connectionId)}
-                              className={buttonVariants({ variant: "secondary", size: "sm" })}
-                            >
-                              {readinessAction.label}
-                            </Link>
-                          ) : null}
-                        </div>
-                        <details className="group/connection mt-2 border-t border-amber-100 pt-2">
-                          <summary className="inline-flex cursor-pointer list-none items-center gap-1 text-[11px] font-medium text-amber-800 transition hover:text-amber-950 [&::-webkit-details-marker]:hidden">
-                            Connection details
-                            <ChevronDown className="h-3 w-3 transition-transform group-open/connection:rotate-180" aria-hidden="true" />
-                          </summary>
-                          <div className="mt-2 rounded-lg border border-amber-100 bg-white/70 px-2.5 py-2">
-                            <p className="break-all font-mono text-[10.5px] leading-4 text-gray-500">
-                              Plugin-declared URL (read-only): {connection.url}
-                            </p>
-                            {readinessAction ? (
-                              <p className="mt-1 text-[11.5px] leading-4 text-amber-700">{readinessAction.note}</p>
-                            ) : null}
-                          </div>
-                        </details>
+                actionableConnections.length > 1 ? (
+                  <details className="group/actions overflow-hidden rounded-xl border border-gray-100 bg-gray-50/70">
+                    <summary className="flex cursor-pointer list-none items-center justify-between gap-3 px-3 py-2.5 [&::-webkit-details-marker]:hidden">
+                      <div className="min-w-0">
+                        <p className="text-[12px] font-semibold text-gray-900">{actionableConnections.length} MCPs require action</p>
+                        <p className="mt-0.5 text-[10.5px] text-gray-500">Connect these services to use this plugin.</p>
                       </div>
-                    );
-                  })}
-                </div>
-              ) : null}
+                      <span className="inline-flex shrink-0 items-center gap-1 text-[10.5px] font-medium text-gray-600">
+                        <span className="group-open/actions:hidden">Show MCPs</span>
+                        <span className="hidden group-open/actions:inline">Hide MCPs</span>
+                        <ChevronDown className="h-3 w-3 transition-transform group-open/actions:rotate-180" aria-hidden="true" />
+                      </span>
+                    </summary>
+                    <div className="divide-y divide-gray-100 border-t border-gray-100 bg-white">{connectionRows}</div>
+                  </details>
+                ) : (
+                  <div className="overflow-hidden rounded-xl border border-gray-100 bg-gray-50/70">
+                    <div className="px-3 py-2.5">
+                      <p className="text-[12px] font-semibold text-gray-900">MCP requires action</p>
+                      <p className="mt-0.5 text-[10.5px] text-gray-500">Connect this service to use this plugin.</p>
+                    </div>
+                    <div className="border-t border-gray-100 bg-white">{connectionRows}</div>
+                  </div>
+                )
+              ) : (
+                <span className={`inline-flex rounded-full px-2 py-0.5 text-[11px] font-medium ${plugin.cloudReadiness.state === "ready" ? "bg-emerald-50 text-emerald-700" : plugin.cloudReadiness.state === "needs_admin_setup" ? "bg-amber-50 text-amber-700" : "bg-gray-50 text-gray-600"}`}>
+                  {cloudReadinessLabel(plugin.cloudReadiness.state)}
+                </span>
+              )}
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
## Summary

Follow-up to #2851 that keeps imported MCP recovery clear without making marketplace cards visually heavy when a plugin declares several MCP servers.

- group multiple unresolved MCP requirements behind one compact **MCPs require action** disclosure
- show a clean provider row with a small icon-led **Connect** action for each MCP after expansion
- keep a single unresolved MCP visible without adding an unnecessary disclosure step
- prevent plugin cards from stretching to match taller cards in the marketplace grid
- collapse the plugin-declared URL and recovery explanation behind a quiet per-connection **Details** disclosure
- preserve the existing admin/member actions and authentication recovery behavior from #2851

## Why

#2851 intentionally exposes the configuration provenance needed to recover imported MCP authentication. Showing every provider, URL, and explanation at once makes plugin cards grow quickly and becomes difficult to scan as the number of MCP requirements increases. This change uses progressive disclosure so the connection actions and operational details remain available without dominating the default view.

## Scope

Den marketplace presentation only. This does not change MCP discovery, credentials, OAuth, connection ownership, readiness calculation, schemas, or runtime behavior.

## UI proof

Multiple unresolved MCPs use one compact summary by default, and the marketplace grid no longer stretches the neighboring card.

![Collapsed MCP action summary](https://uqab8d1w4ih8j7ev.public.blob.vercel-storage.com/pr-2863/mcp-action-collapsed.png)

Expanding the summary reveals a clean provider row and small icon-led **Connect** action for each MCP.

![Expanded MCP action rows](https://uqab8d1w4ih8j7ev.public.blob.vercel-storage.com/pr-2863/mcp-actions-expanded.png)

## Validation

- `pnpm --dir ee/apps/den-web exec bun test tests/marketplace-mcp-readiness.test.ts` — 12 passed
- `pnpm --dir ee/apps/den-web typecheck` — passed
- `git diff --check` — passed

The default Den web test command was also attempted, but two unrelated observability tests could not resolve the freshly installed `@openwork-ee/utils/observability` build artifact. The focused MCP readiness suite above passed independently.

## Manual review

- [x] Marketplace plugin cards remain compact and do not stretch to match taller grid neighbors.
- [x] Multiple unresolved MCPs are collapsed under **MCPs require action** by default.
- [x] Expanding the MCP summary reveals one compact **Connect** action per provider.
- [x] **Details** remains available independently for each requirement.
