### PR TITLE
feat(den-web): simplify organization invites

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-panel.tsx
@@ -95,6 +95,7 @@ export function AuthPanel({
   lockEmail = false,
   hideSocialAuth = false,
   hideEmailField = false,
+  hideLockedEmailSummary = false,
   emailFirstFlow = false,
   eyebrow = "Account",
   bare = false,
@@ -108,6 +109,7 @@ export function AuthPanel({
   lockEmail?: boolean;
   hideSocialAuth?: boolean;
   hideEmailField?: boolean;
+  hideLockedEmailSummary?: boolean;
   emailFirstFlow?: boolean;
   eyebrow?: string;
   // When true the panel renders without its own `den-frame`/padding, so a parent
@@ -269,7 +271,7 @@ export function AuthPanel({
       : visibleAuthMode === "sign-in"
       ? resolvedSignInContent
       : resolvedSignUpContent;
-  const showLockedEmailSummary = Boolean(prefilledEmail && lockEmail && hideEmailField);
+  const showLockedEmailSummary = Boolean(prefilledEmail && lockEmail && hideEmailField && !hideLockedEmailSummary);
   const shellClass = (gap: string, padding: string) =>
     bare ? `grid ${gap}` : `den-frame grid ${gap} ${padding}`;
   // The segmented tabs are the primary sign-in/sign-up switch. Hide them for the

--- a/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
@@ -1,8 +1,9 @@
 "use client";
 
+import { Dithering } from "@paper-design/shaders-react";
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState } from "react";
+import { useEffect, useState, useSyncExternalStore, type ReactNode } from "react";
 import { getErrorMessage, requestJson } from "../_lib/den-flow";
 import {
   PENDING_ORG_INVITATION_STORAGE_KEY,
@@ -17,25 +18,162 @@ import { useDenFlow } from "../_providers/den-flow-provider";
 import { AuthPanel } from "./auth-panel";
 import { JoinOrgSuccess } from "./join-org-success";
 
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
 type JoinedOrg = {
   name: string;
   slug: string;
 };
 
-function LoadingCard({ title, body }: { title: string; body: string }) {
+type AccountSummary = {
+  email: string;
+} | null;
+
+function subscribeToReducedMotion(onStoreChange: () => void) {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+  mediaQuery.addEventListener("change", onStoreChange);
+
+  return () => mediaQuery.removeEventListener("change", onStoreChange);
+}
+
+function getReducedMotionSnapshot() {
+  return typeof window === "undefined" ? true : window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function getReducedMotionServerSnapshot() {
+  return true;
+}
+
+function useReducedMotion() {
+  return useSyncExternalStore(subscribeToReducedMotion, getReducedMotionSnapshot, getReducedMotionServerSnapshot);
+}
+
+function JoinOrgShell({
+  children,
+  shaderSpeed,
+  state,
+}: {
+  children: ReactNode;
+  shaderSpeed: number;
+  state: string;
+}) {
   return (
-    <section className="den-page py-4 lg:py-6">
-      <div className="den-frame grid max-w-[44rem] gap-4 p-6 md:p-7">
-        <p className="den-eyebrow">OpenWork Cloud</p>
-        <div className="grid gap-2">
-          <h1 className="den-title-lg">{title}</h1>
-          <p className="den-copy">{body}</p>
-        </div>
-        <div className="h-2 overflow-hidden rounded-full bg-[var(--dls-hover)]">
-          <div className="h-full w-1/3 animate-pulse rounded-full bg-[var(--dls-accent)]" />
+    <div className="relative isolate min-h-dvh overflow-y-auto bg-[#f8fbff] px-4 py-8 text-slate-950 sm:py-12" data-testid="join-org-root" data-state={state}>
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#f8fbff] opacity-[0.09]"
+        data-motion={shaderSpeed === 0 ? "reduced" : "ambient"}
+        data-shader-speed={shaderSpeed}
+        data-testid="join-org-background"
+      >
+        <Dithering
+          speed={shaderSpeed}
+          shape="warp"
+          type="4x4"
+          size={2.4}
+          scale={0.9}
+          frame={24017.6}
+          colorBack="#F8FBFF"
+          colorFront="#8FB7E8"
+          style={{ backgroundColor: "#F8FBFF", width: "100%", height: "100%" }}
+        />
+      </div>
+
+      <main className="relative z-10 mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-md flex-col justify-center sm:min-h-[calc(100dvh-6rem)]" data-testid="join-org-foreground">
+        {children}
+      </main>
+    </div>
+  );
+}
+
+function DetailRow({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <div className="grid gap-1 py-2.5 sm:grid-cols-[8.5rem_minmax(0,1fr)] sm:gap-4">
+      <dt className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-500">{label}</dt>
+      <dd className="m-0 min-w-0 text-sm font-medium leading-6 text-slate-900 [overflow-wrap:anywhere]">{children}</dd>
+    </div>
+  );
+}
+
+function InvitationDetails({
+  preview,
+  account,
+  roleLabel,
+}: {
+  preview: DenInvitationPreview;
+  account: AccountSummary;
+  roleLabel: string;
+}) {
+  return (
+    <dl className="divide-y divide-slate-200/80 border-y border-slate-200/80" data-testid="join-org-invitation-details">
+      <DetailRow label="Organization">{preview.organization.name}</DetailRow>
+      <DetailRow label="Invited email">{preview.invitation.email}</DetailRow>
+      <DetailRow label="Role">{roleLabel}</DetailRow>
+      <DetailRow label="Account">{account ? account.email : "Not signed in"}</DetailRow>
+    </dl>
+  );
+}
+
+function InvitationHeading({
+  eyebrow = "OpenWork Cloud",
+  title,
+  copy,
+}: {
+  eyebrow?: string;
+  title: string;
+  copy: string;
+}) {
+  return (
+    <div className="grid gap-2">
+      <p className="m-0 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">{eyebrow}</p>
+      <h1 className="m-0 text-balance text-[2rem] font-semibold leading-[0.98] tracking-[-0.055em] text-slate-950 sm:text-[2.6rem]">{title}</h1>
+      <p className="m-0 text-sm leading-6 text-slate-600">{copy}</p>
+    </div>
+  );
+}
+
+function ActionGroup({ children }: { children: ReactNode }) {
+  return (
+    <div className="flex flex-col gap-2 sm:flex-row sm:items-center" data-testid="join-org-actions">
+      {children}
+    </div>
+  );
+}
+
+function NotNowButton({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      className="inline-flex min-h-10 items-center justify-center rounded-full px-3 text-sm font-medium text-slate-500 transition hover:text-slate-950 focus:outline-none focus:ring-4 focus:ring-slate-950/10"
+      onClick={onClick}
+    >
+      Not now
+    </button>
+  );
+}
+
+function InlineAlert({ children }: { children: ReactNode }) {
+  return (
+    <div className="rounded-2xl border border-rose-200 bg-white px-4 py-3 text-sm font-medium leading-6 text-rose-700" role="alert">
+      {children}
+    </div>
+  );
+}
+
+function LoadingState({ shaderSpeed }: { shaderSpeed: number }) {
+  return (
+    <JoinOrgShell shaderSpeed={shaderSpeed} state="loading">
+      <div className="grid gap-5" aria-busy="true">
+        <InvitationHeading title="Loading invite." copy="Checking the invite details and your account state..." />
+        <div className="h-1.5 overflow-hidden rounded-full bg-white shadow-[inset_0_0_0_1px_rgba(148,163,184,0.18)]">
+          <div className="h-full w-1/3 animate-pulse rounded-full bg-slate-900" />
         </div>
       </div>
-    </section>
+    </JoinOrgShell>
   );
 }
 
@@ -84,6 +222,8 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
   const [joinBusy, setJoinBusy] = useState(false);
   const [joinError, setJoinError] = useState<string | null>(null);
   const [joinedOrg, setJoinedOrg] = useState<JoinedOrg | null>(null);
+  const reducedMotion = useReducedMotion();
+  const shaderSpeed = reducedMotion ? 0 : 0.012;
 
   const invitedEmailMatches = preview && user
     ? preview.invitation.email.trim().toLowerCase() === user.email.trim().toLowerCase()
@@ -159,6 +299,17 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
     };
   }, [invitationId]);
 
+  function clearPendingInvitation() {
+    if (typeof window !== "undefined") {
+      window.sessionStorage.removeItem(PENDING_ORG_INVITATION_STORAGE_KEY);
+    }
+  }
+
+  function handleNotNow() {
+    clearPendingInvitation();
+    router.replace("/");
+  }
+
   async function handleAcceptInvitation() {
     if (!invitationId) {
       setJoinError("Missing invitation link.");
@@ -183,9 +334,7 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
         return;
       }
 
-      if (typeof window !== "undefined") {
-        window.sessionStorage.removeItem(PENDING_ORG_INVITATION_STORAGE_KEY);
-      }
+      clearPendingInvitation();
 
       const organizationSlug = getStringProperty(payload, "organizationSlug")?.trim() || preview?.organization.slug || "";
       setJoinedOrg({
@@ -208,7 +357,7 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
   }
 
   if (!sessionHydrated || previewBusy) {
-    return <LoadingCard title="Loading invite." body="Checking the invite details and your account state..." />;
+    return <LoadingState shaderSpeed={shaderSpeed} />;
   }
 
   if (joinedOrg) {
@@ -222,192 +371,169 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
 
   if (!preview) {
     return (
-      <section className="den-page py-4 lg:py-6">
-        <div className="den-frame grid max-w-[44rem] gap-6 p-6 md:p-8">
-          <div className="grid gap-2">
-            <p className="den-eyebrow">OpenWork Cloud</p>
-            <h1 className="den-title-lg">This invite can't be opened.</h1>
-            <p className="den-copy">{previewError ?? "This invite could not be loaded."}</p>
-          </div>
-          <div className="flex flex-wrap gap-3">
-            <Link href="/" className="den-button-primary w-full sm:w-auto">
+      <JoinOrgShell shaderSpeed={shaderSpeed} state="invalid">
+        <div className="grid gap-5">
+          <InvitationHeading title="This invite can't be opened." copy={previewError ?? "This invite could not be loaded."} />
+          <ActionGroup>
+            <button type="button" className="den-button-primary w-full focus:outline-none focus:ring-4 focus:ring-slate-950/10 sm:w-auto" onClick={handleNotNow}>
               Back to OpenWork Cloud
-            </Link>
-          </div>
+            </button>
+          </ActionGroup>
         </div>
-      </section>
+      </JoinOrgShell>
     );
   }
 
+  const account = user ? { email: user.email } : null;
+  const showAcceptAction = preview.invitation.status === "pending" && Boolean(user) && invitedEmailMatches;
+
   if (preview.invitation.status === "pending" && !invitedEmailAllowed) {
     return (
-      <section className="den-page py-4 lg:py-6">
-        <div className="den-frame grid max-w-[44rem] gap-6 p-6 md:p-8">
-          <div className="grid gap-2">
-            <p className="den-eyebrow">OpenWork Cloud</p>
-            <h1 className="den-title-lg">This invite needs a different email domain.</h1>
-            <p className="den-copy">
-              {preview.organization.name} now only accepts accounts from {allowedDomainsLabel}. Ask a workspace owner to update the allowlist or send a new invite.
-            </p>
-          </div>
-          <div className="flex flex-wrap gap-3">
-            <Link href="/" className="den-button-primary w-full sm:w-auto">
+      <JoinOrgShell shaderSpeed={shaderSpeed} state="domain-blocked">
+        <div className="grid gap-5">
+          <InvitationHeading
+            title="This invite needs a different email domain."
+            copy={`${preview.organization.name} now only accepts accounts from ${allowedDomainsLabel}. Ask a workspace owner to update the allowlist or send a new invite.`}
+          />
+          <InvitationDetails preview={preview} account={account} roleLabel={roleLabel} />
+          <ActionGroup>
+            <button type="button" className="den-button-primary w-full focus:outline-none focus:ring-4 focus:ring-slate-950/10 sm:w-auto" onClick={handleNotNow}>
               Back to OpenWork Cloud
-            </Link>
-          </div>
+            </button>
+          </ActionGroup>
         </div>
-      </section>
+      </JoinOrgShell>
     );
   }
 
   if (preview.invitation.status === "pending" && !user) {
     return (
-      <section className="den-page grid gap-6 py-4 lg:grid-cols-[minmax(0,1fr)_minmax(360px,440px)] lg:py-6">
-        <div className="den-frame grid gap-6 p-6 md:p-8">
-          <div className="grid gap-3">
-            <p className="den-eyebrow">OpenWork Cloud</p>
-            <div className="grid gap-2">
-              <p className="den-copy">You've been invited to</p>
-              <h1 className="den-title-xl max-w-[12ch]">{preview.organization.name}</h1>
-            </div>
+      <JoinOrgShell shaderSpeed={shaderSpeed} state="signed-out">
+        <div className="grid gap-4">
+          <div className="grid gap-4">
+            <InvitationHeading title={`Join ${preview.organization.name}.`} copy="Your invitation is ready. Review the details, then sign in or create an account to join." />
+            <InvitationDetails preview={preview} account={account} roleLabel={roleLabel} />
+            {preview.organization.allowedEmailDomains?.length ? (
+              <p className="m-0 text-sm leading-6 text-slate-600">
+                This workspace only accepts {allowedDomainsLabel} accounts.
+              </p>
+            ) : null}
           </div>
 
-          <div className="den-meta-row">
-            <span className="den-kicker">Role · {roleLabel}</span>
+          <div data-testid="join-org-auth">
+            <AuthPanel
+              bare
+              eyebrow="Invite"
+              prefilledEmail={preview.invitation.email}
+              prefillKey={preview.invitation.id}
+              initialMode="sign-up"
+              lockEmail
+              hideEmailField
+              hideLockedEmailSummary
+              hideSocialAuth
+              signUpContent={{
+                title: "Create your account.",
+                copy: "Choose a password for your invited email.",
+                submitLabel: `Join ${preview.organization.name}`,
+              }}
+              signInContent={{
+                title: "Sign in to continue.",
+                copy: "Use the invited account to accept this invite.",
+                submitLabel: "Sign in to join",
+              }}
+              verificationContent={{
+                title: "Check your inbox.",
+                copy: `Enter the six-digit code sent to ${preview.invitation.email}.`,
+                submitLabel: "Verify and join",
+              }}
+            />
           </div>
 
-          <div className="den-frame-inset grid gap-3 rounded-[1.5rem] p-5">
-            <p className="m-0 text-base font-medium text-[var(--dls-text-primary)]">
-              Your team is already set up and waiting.
-            </p>
-            <p className="den-copy">
-              Member access is ready as soon as you join.
-              {preview.organization.allowedEmailDomains?.length
-                ? ` This workspace only accepts ${allowedDomainsLabel} accounts.`
-                : ""}
-            </p>
-          </div>
+          <ActionGroup>
+            <NotNowButton onClick={handleNotNow} />
+          </ActionGroup>
         </div>
-
-        <AuthPanel
-          eyebrow="Invite"
-          prefilledEmail={preview.invitation.email}
-          prefillKey={preview.invitation.id}
-          initialMode="sign-up"
-          lockEmail
-          hideSocialAuth
-          hideEmailField
-          signUpContent={{
-            title: `Join ${preview.organization.name}.`,
-            copy: "Pick a password and you're in.",
-            submitLabel: `Join ${preview.organization.name}`,
-          }}
-          signInContent={{
-            title: `Join ${preview.organization.name}.`,
-            copy: `Sign in as ${preview.invitation.email} to accept this invite.`,
-            submitLabel: "Sign in to join",
-          }}
-          verificationContent={{
-            title: "Check your inbox.",
-            copy: `Enter the six-digit code sent to ${preview.invitation.email}.`,
-            submitLabel: "Verify and join",
-          }}
-        />
-      </section>
+      </JoinOrgShell>
     );
   }
 
-  const showAcceptAction = preview.invitation.status === "pending" && Boolean(user) && invitedEmailMatches;
-
   return (
-    <section className="den-page py-4 lg:py-6">
-      <div className="den-frame grid max-w-[44rem] gap-6 p-6 md:p-8">
-        <div className="grid gap-3">
-          <p className="den-eyebrow">OpenWork Cloud</p>
-          <div className="grid gap-2">
-            <p className="den-copy">You've been invited to</p>
-            <h1 className="den-title-xl max-w-[12ch]">{preview.organization.name}</h1>
-          </div>
-        </div>
-
-        <div className="den-meta-row">
-          <span className="den-kicker">Role · {roleLabel}</span>
-          {user ? <span>{user.email}</span> : null}
-        </div>
-
-        {user ? (
-          <div className="den-frame-inset grid gap-1 rounded-[1.5rem] px-4 py-3">
-            <p className="den-label">Signed in as</p>
-            <p className="m-0 text-sm font-medium text-[var(--dls-text-primary)]">{user.email}</p>
-          </div>
-        ) : null}
+    <JoinOrgShell shaderSpeed={shaderSpeed} state="signed-in">
+      <div className="grid gap-5">
+        <InvitationHeading title={`Join ${preview.organization.name}.`} copy="Review the invitation and continue with the right account." />
+        <InvitationDetails preview={preview} account={account} roleLabel={roleLabel} />
 
         {preview.invitation.status !== "pending" ? (
           <div className="grid gap-4">
-            <p className="den-copy">{statusMessage(preview)}</p>
-            <div className="flex flex-wrap gap-3">
+            <p className="m-0 text-sm leading-6 text-slate-600">{statusMessage(preview)}</p>
+            <ActionGroup>
               <Link
                 href={user && invitedEmailMatches ? getOrgDashboardRoute(preview.organization.slug) : "/"}
-                className="den-button-primary w-full sm:w-auto"
+                className="den-button-primary w-full focus:outline-none focus:ring-4 focus:ring-slate-950/10 sm:w-auto"
+                onClick={clearPendingInvitation}
               >
                 {user && invitedEmailMatches ? "Open team" : "Back to OpenWork Cloud"}
               </Link>
-            </div>
+              <NotNowButton onClick={handleNotNow} />
+            </ActionGroup>
           </div>
         ) : user && !signedInEmailAllowed ? (
           <div className="grid gap-4">
-            <p className="den-copy">
-              {preview.organization.name} only accepts accounts from <span className="font-medium text-[var(--dls-text-primary)]">{allowedDomainsLabel}</span>. You are signed in as <span className="font-medium text-[var(--dls-text-primary)]">{user.email}</span>, so this account cannot join.
+            <p className="m-0 text-sm leading-6 text-slate-600">
+              {preview.organization.name} only accepts accounts from <span className="font-medium text-slate-950">{allowedDomainsLabel}</span>. You are signed in as <span className="font-medium text-slate-950">{user.email}</span>, so this account cannot join.
             </p>
-            <p className="text-sm text-gray-500">
+            <p className="m-0 text-sm leading-6 text-slate-500">
               Log out, then create a new account or sign in with an allowed email address.
             </p>
-            <div className="flex flex-wrap gap-3">
+            <ActionGroup>
               <button
                 type="button"
-                className="den-button-primary w-full sm:w-auto"
+                className="den-button-primary w-full focus:outline-none focus:ring-4 focus:ring-slate-950/10 sm:w-auto"
                 onClick={() => void handleSwitchAccount()}
                 disabled={joinBusy}
               >
                 Log out
               </button>
-            </div>
+              <NotNowButton onClick={handleNotNow} />
+            </ActionGroup>
           </div>
         ) : !invitedEmailMatches ? (
           <div className="grid gap-4">
-            <p className="den-copy">
-              This invite is for <span className="font-medium text-[var(--dls-text-primary)]">{preview.invitation.email}</span>. Switch accounts to continue.
+            <p className="m-0 text-sm leading-6 text-slate-600">
+              This invite is for <span className="font-medium text-slate-950">{preview.invitation.email}</span>. Switch accounts to continue.
             </p>
-            <div className="flex flex-wrap gap-3">
+            <ActionGroup>
               <button
                 type="button"
-                className="den-button-primary w-full sm:w-auto"
+                className="den-button-primary w-full focus:outline-none focus:ring-4 focus:ring-slate-950/10 sm:w-auto"
                 onClick={() => void handleSwitchAccount()}
                 disabled={joinBusy}
               >
                 Use a different account
               </button>
-            </div>
+              <NotNowButton onClick={handleNotNow} />
+            </ActionGroup>
           </div>
         ) : (
           <div className="grid gap-4">
-            <p className="den-copy">You're one click away from the team workspace.</p>
-            <div className="flex flex-wrap gap-3">
+            <p className="m-0 text-sm leading-6 text-slate-600">You're one click away from the team workspace.</p>
+            <ActionGroup>
               <button
                 type="button"
-                className="den-button-primary w-full sm:w-auto"
+                className="den-button-primary w-full focus:outline-none focus:ring-4 focus:ring-slate-950/10 sm:w-auto"
                 onClick={() => void handleAcceptInvitation()}
                 disabled={!showAcceptAction || joinBusy}
               >
                 {joinBusy ? "Joining..." : `Join ${preview.organization.name}`}
               </button>
-            </div>
+              <NotNowButton onClick={handleNotNow} />
+            </ActionGroup>
           </div>
         )}
 
-        {joinError ? <div className="den-notice is-error">{joinError}</div> : null}
-        {previewError ? <div className="den-notice is-error">{previewError}</div> : null}
+        {joinError ? <InlineAlert>{joinError}</InlineAlert> : null}
+        {previewError ? <InlineAlert>{previewError}</InlineAlert> : null}
       </div>
-    </section>
+    </JoinOrgShell>
   );
 }

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/org-selection-background.test.ts app/api/_lib/upstream-proxy.test.mjs",
+    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/join-org-invite-clean.test.ts
+++ b/ee/apps/den-web/tests/join-org-invite-clean.test.ts
@@ -1,0 +1,95 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const joinOrgScreenPath = fileURLToPath(
+  new URL("../app/(den)/_components/join-org-screen.tsx", import.meta.url),
+);
+
+function readJoinOrgScreenSource() {
+  return readFileSync(joinOrgScreenPath, "utf8");
+}
+
+describe("join organization invite clean layout contract", () => {
+  test("uses one light Dithering layer and no mesh gradient", () => {
+    const source = readJoinOrgScreenSource();
+    const ditheringImports = source.match(/import \{ Dithering \} from "@paper-design\/shaders-react"/g) ?? [];
+    const ditheringUses = source.match(/<Dithering\b/g) ?? [];
+
+    expect(ditheringImports).toHaveLength(1);
+    expect(ditheringUses).toHaveLength(1);
+    expect(source).not.toContain("PaperMeshGradient");
+    expect(source).toContain("colorBack=\"#F8FBFF\"");
+    expect(source).toContain("colorFront=\"#8FB7E8\"");
+    expect(source).toContain('style={{ backgroundColor: "#F8FBFF", width: "100%", height: "100%" }}');
+  });
+
+  test("keeps the decorative background separate, restrained, and reduced-motion aware", () => {
+    const source = readJoinOrgScreenSource();
+
+    expect(source).toContain("min-h-dvh overflow-y-auto bg-[#f8fbff]");
+    expect(source).toContain("pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#f8fbff] opacity-[0.09]");
+    expect(source).toContain('aria-hidden="true"');
+    expect(source).toContain('data-testid="join-org-background"');
+    expect(source).toContain('data-testid="join-org-foreground"');
+    expect(source).toContain("relative z-10");
+    expect(source).toContain("useSyncExternalStore");
+    expect(source).toContain('const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";');
+    expect(source).toContain("function getReducedMotionServerSnapshot()");
+    expect(source).toContain("const shaderSpeed = reducedMotion ? 0 : 0.012;");
+    expect(source).toContain("speed={shaderSpeed}");
+    expect(source).toContain('data-shader-speed={shaderSpeed}');
+  });
+
+  test("removes stacked frames while keeping a compact centered hierarchy", () => {
+    const source = readJoinOrgScreenSource();
+
+    expect(source).not.toContain("den-frame");
+    expect(source).not.toContain("den-frame-inset");
+    expect(source).toContain("w-full max-w-md");
+    expect(source).toContain('data-testid="join-org-root"');
+    expect(source).toContain('data-testid="join-org-invitation-details"');
+    expect(source).toContain('data-testid="join-org-actions"');
+    expect(source).toContain('data-testid="join-org-auth"');
+    expect(source).toContain("Organization");
+    expect(source).toContain("Invited email");
+    expect(source).toContain("Role");
+    expect(source).toContain("Account");
+    expect(source).not.toMatch(/\binviter\b/i);
+  });
+
+  test("uses bare invite auth and a non-destructive Not now dismissal", () => {
+    const source = readJoinOrgScreenSource();
+
+    expect(source).toMatch(/<AuthPanel[\s\S]*?\bbare\b/);
+    expect(source).toMatch(/<AuthPanel[\s\S]*?\blockEmail\b/);
+    expect(source).toMatch(/<AuthPanel[\s\S]*?\bhideEmailField\b/);
+    expect(source).toMatch(/<AuthPanel[\s\S]*?\bhideLockedEmailSummary\b/);
+    expect(source).toContain('title: "Create your account."');
+    expect(source).toContain('title: "Sign in to continue."');
+    expect(source).not.toContain("title: `Join ${preview.organization.name}.`");
+    expect(source).toContain("Not now");
+    expect(source).toContain("function handleNotNow()");
+    expect(source).toContain("window.sessionStorage.removeItem(PENDING_ORG_INVITATION_STORAGE_KEY);");
+    expect(source).toContain('router.replace("/");');
+    expect(source).not.toContain("Decline invitation");
+    expect(source).not.toContain("Cancel invitation");
+  });
+
+  test("preserves invitation preview, account switching, status, and accept behavior", () => {
+    const source = readJoinOrgScreenSource();
+
+    expect(source).toContain("/v1/orgs/invitations/preview?id=");
+    expect(source).toContain("/v1/orgs/invitations/accept");
+    expect(source).toContain("parseInvitationPreviewPayload(payload)");
+    expect(source).toContain("isEmailAllowedForOrganization");
+    expect(source).toContain("statusMessage(preview)");
+    expect(source).toContain("handleSwitchAccount");
+    expect(source).toContain("window.sessionStorage.setItem(PENDING_ORG_INVITATION_STORAGE_KEY, invitationId);");
+    expect(source).toContain("This invite needs a different email domain.");
+    expect(source).toContain("This invite is for");
+    expect(source).toContain("Use a different account");
+    expect(source).toContain("Log out");
+    expect(source).toContain("Join ${preview.organization.name}");
+  });
+});

--- a/evals/flows/join-org-invite-clean.flow.mjs
+++ b/evals/flows/join-org-invite-clean.flow.mjs
@@ -1,0 +1,502 @@
+import { randomBytes } from "node:crypto";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, denWebUrl, signInApi } from "./lib/den-web.mjs";
+
+const FLOW_ID = "join-org-invite-clean";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const DEFAULT_INVITEE_EMAIL = "join-org-invite-clean@acme.test";
+const RUN_TAG = `${Date.now().toString(36)}-${randomBytes(2).toString("hex")}`;
+const FALLBACK_INVITEE_EMAIL = `join-org-invite-clean+${RUN_TAG}@acme.test`;
+const PENDING_INVITE_STORAGE_KEY = "openwork:web:pending-org-invitation";
+const AUTH_TOKEN_STORAGE_KEY = "openwork:web:auth-token";
+
+const state = {
+  adminToken: "",
+  inviteeEmail: process.env.OPENWORK_EVAL_JOIN_ORG_INVITEE_EMAIL?.trim() || DEFAULT_INVITEE_EMAIL,
+  invitationId: "",
+  inviteToken: "",
+  organizationId: "",
+  organizationName: "",
+  organizationSlug: "",
+  role: "member",
+  roleLabel: "Member",
+};
+
+function authHeaders() {
+  return { authorization: `Bearer ${state.adminToken}` };
+}
+
+function orgHeaders() {
+  const headers = authHeaders();
+  if (state.organizationId) {
+    headers["x-openwork-org-id"] = state.organizationId;
+    headers["x-openwork-legacy-org-id"] = state.organizationId;
+  }
+  return headers;
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : typeof actual === "string" ? actual : JSON.stringify(actual).slice(0, 900),
+  });
+  ctx.assert(condition, assertion + (actual === undefined ? "" : ` (actual: ${JSON.stringify(actual).slice(0, 500)})`));
+}
+
+function roleLabel(role) {
+  return String(role)
+    .split(/[-_\s]+/)
+    .filter(Boolean)
+    .map((part) => `${part.slice(0, 1).toUpperCase()}${part.slice(1)}`)
+    .join(" ");
+}
+
+function denWebRoute(path) {
+  return new URL(path, `${denWebUrl()}/`).toString();
+}
+
+function cacheBustedJoinUrl(label) {
+  const url = new URL(denWebRoute(`/join-org?invite=${encodeURIComponent(state.inviteToken)}`));
+  url.searchParams.set("joinOrgInviteClean", `${label}-${Date.now()}`);
+  return url.toString();
+}
+
+async function applyViewport(ctx, width, height, mobile) {
+  if (!ctx.client?.send) {
+    ctx.log("Viewport emulation skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+    width,
+    height,
+    deviceScaleFactor: 1,
+    mobile,
+  }).catch((error) => {
+    ctx.log(`Viewport emulation skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+async function setReducedMotion(ctx, enabled) {
+  if (!ctx.client?.send) {
+    ctx.log("Reduced-motion emulation skipped: no raw CDP send method on context.");
+    return;
+  }
+
+  await ctx.client.send("Emulation.setEmulatedMedia", {
+    features: [{ name: "prefers-reduced-motion", value: enabled ? "reduce" : "no-preference" }],
+  }).catch((error) => {
+    ctx.log(`Reduced-motion emulation skipped: ${error instanceof Error ? error.message : String(error)}`);
+  });
+}
+
+async function ensureAdminToken(ctx) {
+  if (state.adminToken) return;
+  const token = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
+  witness(ctx, Boolean(token), `Admin API sign-in succeeds for ${ADMIN_EMAIL}`, token ? "<token present>" : "missing token");
+  state.adminToken = token;
+}
+
+async function listOrgs(ctx) {
+  const { response, body } = await denApiFetch("/v1/me/orgs", { headers: authHeaders() });
+  witness(ctx, response.ok, "The admin account can list organizations through the local Den API", {
+    status: response.status,
+    count: Array.isArray(body?.orgs) ? body.orgs.length : null,
+  });
+  return Array.isArray(body?.orgs) ? body.orgs : [];
+}
+
+function chooseInviteOrganization(orgs) {
+  return orgs.find((org) => String(org?.name ?? "") === "Acme Robotics")
+    ?? orgs.find((org) => String(org?.slug ?? "").toLowerCase().startsWith("acme"))
+    ?? orgs[0]
+    ?? null;
+}
+
+async function setActiveOrganization(ctx) {
+  const active = await denApiFetch("/v1/me/active-organization", {
+    method: "POST",
+    headers: authHeaders(),
+    body: JSON.stringify({ organizationId: state.organizationId }),
+  });
+  witness(ctx, active.response.ok, "The eval sets the selected organization active for the bearer session", {
+    status: active.response.status,
+    organizationId: state.organizationId,
+    body: active.body,
+  });
+}
+
+async function ensureMultiOrgApi(ctx) {
+  await ensureAdminToken(ctx);
+  let orgs = await listOrgs(ctx);
+  if (orgs.length < 2) {
+    const created = await denApiFetch("/v1/org", {
+      method: "POST",
+      headers: authHeaders(),
+      body: JSON.stringify({ name: "Join Org Invite Clean Eval" }),
+    });
+    witness(ctx, created.response.ok, "The local Den API can create a second organization for the multi-org invite flow", {
+      status: created.response.status,
+      organization: created.body?.organization,
+    });
+    orgs = await listOrgs(ctx);
+  }
+  witness(ctx, orgs.length >= 2, "The invite proof is running against a real multi-org Den account", orgs.map((org) => org?.name ?? org?.slug ?? "unknown"));
+
+  const selected = chooseInviteOrganization(orgs);
+  witness(ctx, typeof selected?.id === "string" && selected.id.length > 0, "The eval selected a healthy seeded organization for the invitation", selected);
+  state.organizationId = selected.id;
+  state.organizationName = typeof selected.name === "string" ? selected.name : "";
+  state.organizationSlug = typeof selected.slug === "string" ? selected.slug : "";
+  await setActiveOrganization(ctx);
+}
+
+async function loadOrgContext(ctx) {
+  const org = await denApiFetch("/v1/org", { headers: orgHeaders() });
+  witness(ctx, org.response.ok && typeof org.body?.organization?.name === "string", "The active organization context is available", {
+    status: org.response.status,
+    scopedOrganizationId: state.organizationId,
+    organization: org.body?.organization,
+  });
+  state.organizationName = org.body.organization.name;
+  state.organizationId = org.body.organization.id;
+  state.organizationSlug = org.body.organization.slug;
+  return org.body;
+}
+
+function invitationForEmail(orgBody, email) {
+  const invitations = Array.isArray(orgBody?.invitations) ? orgBody.invitations : [];
+  return invitations.find((entry) => entry?.email === email && entry?.status === "pending" && typeof entry?.inviteToken === "string") ?? null;
+}
+
+async function createInvitation(ctx, email) {
+  const created = await denApiFetch("/v1/invitations", {
+    method: "POST",
+    headers: orgHeaders(),
+    body: JSON.stringify({ email, role: state.role }),
+  });
+
+  if (created.response.status === 409 && created.body?.error === "member_exists" && email === DEFAULT_INVITEE_EMAIL) {
+    state.inviteeEmail = FALLBACK_INVITEE_EMAIL;
+    return createInvitation(ctx, state.inviteeEmail);
+  }
+
+  witness(ctx, created.response.ok || created.response.status === 502, "The local Den API creates or refreshes a real pending invitation", {
+    status: created.response.status,
+    body: created.body,
+  });
+  return created.body;
+}
+
+async function ensureInvitation(ctx) {
+  if (state.inviteToken) return;
+  await ensureMultiOrgApi(ctx);
+  let orgBody = await loadOrgContext(ctx);
+  let invitation = invitationForEmail(orgBody, state.inviteeEmail);
+
+  if (!invitation) {
+    const created = await createInvitation(ctx, state.inviteeEmail);
+    if (typeof created?.inviteToken === "string") {
+      state.inviteToken = created.inviteToken;
+      state.invitationId = typeof created.invitationId === "string" ? created.invitationId : "";
+    }
+    orgBody = await loadOrgContext(ctx);
+    invitation = invitationForEmail(orgBody, state.inviteeEmail);
+  }
+
+  if (invitation) {
+    state.invitationId = typeof invitation.id === "string" ? invitation.id : state.invitationId;
+    state.inviteToken = invitation.inviteToken;
+    state.role = typeof invitation.role === "string" ? invitation.role : state.role;
+    state.roleLabel = roleLabel(state.role);
+  }
+
+  witness(ctx, Boolean(state.inviteToken), "A valid opaque invite token exists for the join route", {
+    email: state.inviteeEmail,
+    invitationId: state.invitationId,
+    inviteTokenLength: state.inviteToken.length,
+  });
+
+  const preview = await denApiFetch(`/v1/orgs/invitations/preview?id=${encodeURIComponent(state.inviteToken)}`);
+  witness(ctx, preview.response.ok, "The public invitation preview resolves real organization, email, and role fields", {
+    status: preview.response.status,
+    preview: preview.body,
+  });
+  witness(ctx, preview.body?.organization?.name === state.organizationName, "The preview organization name matches the active organization", preview.body?.organization);
+  witness(ctx, preview.body?.invitation?.email === state.inviteeEmail, "The preview invited email matches the created invitation", preview.body?.invitation);
+  witness(ctx, preview.body?.invitation?.role === state.role, "The preview role matches the created invitation", preview.body?.invitation);
+}
+
+async function hardNavigate(ctx, url, label) {
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(url)}; return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label });
+}
+
+async function clearDenWebSession(ctx) {
+  await hardNavigate(ctx, denWebRoute("/"), "den-web root before sign-out");
+  await ctx.eval(
+    `(() => {
+      localStorage.removeItem(${JSON.stringify(AUTH_TOKEN_STORAGE_KEY)});
+      sessionStorage.clear();
+      return fetch('/api/auth/sign-out', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: '{}',
+        credentials: 'include'
+      }).catch(() => null).then(() => {
+        localStorage.clear();
+        sessionStorage.clear();
+        return true;
+      });
+    })()`,
+    { awaitPromise: true },
+  );
+  if (ctx.client?.send) {
+    await ctx.client.send("Network.clearBrowserCookies", {}).catch((error) => {
+      ctx.log(`Cookie clear skipped: ${error instanceof Error ? error.message : String(error)}`);
+    });
+    await ctx.client.send("Network.clearBrowserCache", {}).catch((error) => {
+      ctx.log(`Cache clear skipped: ${error instanceof Error ? error.message : String(error)}`);
+    });
+  }
+}
+
+async function openSignedOutInvite(ctx, label) {
+  await hardNavigate(ctx, cacheBustedJoinUrl(label), `signed-out join route ${label}`);
+  await ctx.waitFor(
+    `(() => {
+      const root = document.querySelector('[data-testid="join-org-root"]');
+      const text = document.body?.innerText ?? '';
+      return root?.getAttribute('data-state') === 'signed-out'
+        && text.includes(${JSON.stringify(state.organizationName)})
+        && text.includes(${JSON.stringify(state.inviteeEmail)})
+        && text.includes(${JSON.stringify(state.roleLabel)})
+        && Boolean(document.querySelector('[data-testid="join-org-auth"]'));
+    })()`,
+    { timeoutMs: 45_000, label: "signed-out invitation screen" },
+  );
+  await ctx.waitFor(
+    "Boolean(document.querySelector('[data-testid=\"join-org-background\"] canvas'))",
+    { timeoutMs: 30_000, label: "join invitation Dithering canvas" },
+  );
+}
+
+async function inviteVisualState(ctx) {
+  return ctx.eval(`(() => {
+    const root = document.querySelector('[data-testid="join-org-root"]');
+    const background = document.querySelector('[data-testid="join-org-background"]');
+    const foreground = document.querySelector('[data-testid="join-org-foreground"]');
+    const details = document.querySelector('[data-testid="join-org-invitation-details"]');
+    const actions = document.querySelector('[data-testid="join-org-actions"]');
+    const auth = document.querySelector('[data-testid="join-org-auth"]');
+    const rootStyle = root ? getComputedStyle(root) : null;
+    const backgroundStyle = background ? getComputedStyle(background) : null;
+    const foregroundStyle = foreground ? getComputedStyle(foreground) : null;
+    const foregroundRect = foreground?.getBoundingClientRect();
+    const detailsRect = details?.getBoundingClientRect();
+    const actionsRect = actions?.getBoundingClientRect();
+    const authRect = auth?.getBoundingClientRect();
+    const rootFrames = root?.querySelectorAll('.den-frame, .den-frame-inset').length ?? 0;
+    const authSubmit = auth?.querySelector('button[type="submit"]');
+    const authSubmitRect = authSubmit?.getBoundingClientRect();
+    const emailInput = auth?.querySelector('input[type="email"]');
+    return {
+      path: window.location.pathname,
+      viewportWidth: window.innerWidth,
+      viewportHeight: window.innerHeight,
+      rootState: root?.getAttribute('data-state') ?? null,
+      rootBackgroundColor: rootStyle?.backgroundColor ?? null,
+      rootMinHeight: rootStyle?.minHeight ?? null,
+      rootOverflowY: rootStyle?.overflowY ?? null,
+      backgroundAriaHidden: background?.getAttribute('aria-hidden') ?? null,
+      backgroundPointerEvents: backgroundStyle?.pointerEvents ?? null,
+      backgroundOpacity: backgroundStyle?.opacity ?? null,
+      backgroundPosition: backgroundStyle?.position ?? null,
+      backgroundZIndex: backgroundStyle?.zIndex ?? null,
+      backgroundShaderSpeed: background?.getAttribute('data-shader-speed') ?? null,
+      backgroundMotion: background?.getAttribute('data-motion') ?? null,
+      foregroundZIndex: foregroundStyle?.zIndex ?? null,
+      foregroundMaxWidth: foregroundStyle?.maxWidth ?? null,
+      rootCanvasCount: root?.querySelectorAll('canvas').length ?? 0,
+      backgroundCanvasCount: background?.querySelectorAll('canvas').length ?? 0,
+      rootFrames,
+      foregroundWithinViewport: Boolean(foregroundRect && foregroundRect.left >= 0 && foregroundRect.right <= window.innerWidth + 1),
+      detailsWithinViewport: Boolean(detailsRect && detailsRect.left >= 0 && detailsRect.right <= window.innerWidth + 1),
+      actionsWithinViewport: Boolean(actionsRect && actionsRect.left >= 0 && actionsRect.right <= window.innerWidth + 1 && actionsRect.top >= 0 && actionsRect.bottom <= window.innerHeight + 1),
+      authWithinViewport: Boolean(authRect && authRect.left >= 0 && authRect.right <= window.innerWidth + 1),
+      authSubmitWithinViewport: Boolean(authSubmitRect && authSubmitRect.left >= 0 && authSubmitRect.right <= window.innerWidth + 1 && authSubmitRect.top >= 0 && authSubmitRect.bottom <= window.innerHeight + 1),
+      foregroundCenterOffset: foregroundRect ? Math.abs((foregroundRect.left + foregroundRect.right) / 2 - window.innerWidth / 2) : null,
+      detailsText: details?.innerText ?? '',
+      actionsText: actions?.innerText ?? '',
+      authText: auth?.innerText ?? '',
+      authSubmitText: authSubmit?.textContent?.trim() ?? '',
+      emailInputPresent: Boolean(emailInput),
+      emailInputValue: emailInput?.value ?? '',
+      emailInputDisabled: emailInput instanceof HTMLInputElement ? emailInput.disabled : null,
+      bodyText: document.body.innerText,
+    };
+  })()`);
+}
+
+async function clickNotNowAndReturn(ctx) {
+  const clicked = await ctx.clickText("Not now", { selector: "button" });
+  witness(ctx, clicked === "Not now", "The visible Not now control is clickable", clicked);
+  await ctx.waitFor(
+    `(() => {
+      const pending = sessionStorage.getItem(${JSON.stringify(PENDING_INVITE_STORAGE_KEY)});
+      return pending === null && window.location.pathname !== '/join-org';
+    })()`,
+    { timeoutMs: 30_000, label: "Not now dismissed the invite locally" },
+  );
+  const dismissed = await ctx.eval(`(() => ({
+    path: window.location.pathname,
+    pendingInvite: sessionStorage.getItem(${JSON.stringify(PENDING_INVITE_STORAGE_KEY)}),
+    text: document.body.innerText,
+  }))()`);
+  witness(ctx, dismissed.pendingInvite === null, "Not now clears only the local pending invitation marker", dismissed);
+
+  const preview = await denApiFetch(`/v1/orgs/invitations/preview?id=${encodeURIComponent(state.inviteToken)}`);
+  witness(ctx, preview.response.ok && preview.body?.invitation?.status === "pending", "Not now does not permanently cancel the server invitation", {
+    status: preview.response.status,
+    invitation: preview.body?.invitation,
+  });
+
+  await openSignedOutInvite(ctx, "after-not-now");
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Organization invitations use a compact light Dithering join experience",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MULTI_ORG"],
+  steps: [
+    {
+      name: "Setup: real multi-org invitation exists",
+      run: async (ctx) => {
+        witness(ctx, denWebUrl().length > 0, "OPENWORK_EVAL_DEN_WEB_URL points at den-web", denWebUrl());
+        await ensureInvitation(ctx);
+        ctx.output("join-org-invite-clean-setup", JSON.stringify({
+          organizationName: state.organizationName,
+          inviteeEmail: state.inviteeEmail,
+          role: state.role,
+          invitationId: state.invitationId,
+          inviteTokenLength: state.inviteToken.length,
+        }, null, 2));
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The organization invitation opens as a compact centered light Dithering screen", {
+          voiceover: vo[0],
+          action: async () => {
+            await applyViewport(ctx, 1280, 900, false);
+            await setReducedMotion(ctx, false);
+            await clearDenWebSession(ctx);
+            await openSignedOutInvite(ctx, "desktop");
+          },
+          assert: async () => {
+            const visual = await inviteVisualState(ctx);
+            witness(ctx, visual.rootState === "signed-out", "The join route is showing the signed-out invitation state", visual);
+            witness(ctx, visual.rootCanvasCount === 1 && visual.backgroundCanvasCount === 1, "The invite screen has exactly one Dithering canvas", visual);
+            witness(ctx, visual.backgroundAriaHidden === "true" && visual.backgroundPointerEvents === "none", "The shader background is decorative and non-interactive", visual);
+            witness(ctx, visual.backgroundPosition === "fixed" && visual.backgroundZIndex === "0" && visual.foregroundZIndex === "10", "The shader sits behind the foreground hierarchy", visual);
+            witness(ctx, visual.backgroundOpacity === "0.09" && visual.rootBackgroundColor === "rgb(248, 251, 255)", "The invitation uses the approved pale light background and low opacity", visual);
+            witness(ctx, visual.foregroundMaxWidth === "448px" && visual.foregroundCenterOffset !== null && visual.foregroundCenterOffset < 2, "The invitation content is compact and centered", visual);
+            witness(ctx, visual.authSubmitWithinViewport && visual.actionsWithinViewport, "The primary join button and Not now action are visible in the desktop viewport", visual);
+          },
+          screenshot: {
+            name: "join-invite-light-dithering",
+            claim: "The organization invitation opens as a compact centered light Dithering experience.",
+            requireText: [state.organizationName, state.inviteeEmail, state.roleLabel],
+            rejectText: ["Something went wrong", "Inviter", "den-frame"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("The invitation fields are real and presented in one compact hierarchy", {
+          voiceover: vo[1],
+          action: async () => {
+            await openSignedOutInvite(ctx, "hierarchy");
+          },
+          assert: async () => {
+            const visual = await inviteVisualState(ctx);
+            const detailsText = visual.detailsText.toLowerCase().replace(/\s+/g, " ");
+            witness(ctx, visual.rootFrames === 0, "The invitation DOM has no den-frame or den-frame-inset stacked card shells", visual);
+            witness(ctx, detailsText.includes("organization") && detailsText.includes(state.organizationName.toLowerCase()), "The hierarchy shows the real organization name", visual.detailsText);
+            witness(ctx, detailsText.includes("invited email") && detailsText.includes(state.inviteeEmail.toLowerCase()), "The hierarchy shows the real invited email", visual.detailsText);
+            witness(ctx, detailsText.includes("role") && detailsText.includes(state.roleLabel.toLowerCase()), "The hierarchy shows the real invitation role", visual.detailsText);
+            witness(ctx, detailsText.includes("account") && detailsText.includes("not signed in"), "The hierarchy shows the signed-out account state without inventing unavailable inviter data", visual.detailsText);
+            witness(ctx, !visual.bodyText.toLowerCase().includes("inviter"), "The UI does not fabricate an inviter field that the preview API does not expose", visual.bodyText);
+          },
+          screenshot: {
+            name: "join-invite-real-hierarchy",
+            claim: "The real organization, invited email, role, and account state are readable in one compact hierarchy.",
+            requireText: ["ORGANIZATION", "INVITED EMAIL", "ROLE", "ACCOUNT", state.organizationName, state.inviteeEmail, state.roleLabel],
+            rejectText: ["Inviter", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Primary join auth and non-destructive Not now actions are clear", {
+          voiceover: vo[2],
+          action: async () => {
+            await openSignedOutInvite(ctx, "actions");
+          },
+          assert: async () => {
+            const visual = await inviteVisualState(ctx);
+            witness(ctx, visual.authText.includes(`Join ${state.organizationName}`) || visual.authSubmitText.includes(`Join ${state.organizationName}`), "The primary join/auth action is visible", visual);
+            witness(ctx, visual.actionsText.includes("Not now"), "The secondary dismissal is labeled Not now", visual.actionsText);
+            witness(ctx, visual.emailInputPresent === false && visual.detailsText.includes(state.inviteeEmail), "The auth form hides the duplicate email field while the invitation details show the invited email", visual);
+            await clickNotNowAndReturn(ctx);
+          },
+          screenshot: {
+            name: "join-invite-actions",
+            claim: "The join action and non-destructive Not now dismissal are clear without extra panels.",
+            requireText: [`Join ${state.organizationName}`, "Not now", state.inviteeEmail],
+            rejectText: ["Decline invitation", "Cancel invitation", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("The layout stays centered on mobile and honors reduced motion", {
+          voiceover: vo[3],
+          action: async () => {
+            await applyViewport(ctx, 390, 900, true);
+            await setReducedMotion(ctx, true);
+            await openSignedOutInvite(ctx, "mobile-reduced-motion");
+          },
+          assert: async () => {
+            const visual = await inviteVisualState(ctx);
+            witness(ctx, visual.viewportWidth <= 430, "The mobile viewport was applied", visual);
+            witness(ctx, visual.rootOverflowY === "auto" && typeof visual.rootMinHeight === "string" && visual.rootMinHeight.endsWith("px"), "The invitation shell is scroll-safe on small screens", visual);
+            witness(ctx, visual.foregroundWithinViewport && visual.detailsWithinViewport && visual.authWithinViewport, "Foreground, details, and auth remain inside the mobile viewport", visual);
+            witness(ctx, visual.authSubmitWithinViewport && visual.actionsWithinViewport, "The mobile screenshot includes the primary join button and Not now action", visual);
+            witness(ctx, visual.backgroundShaderSpeed === "0" && visual.backgroundMotion === "reduced", "Reduced motion sets the shader speed to zero", visual);
+            witness(ctx, visual.rootCanvasCount === 1 && visual.rootFrames === 0, "Mobile keeps one Dithering canvas and no stacked frames", visual);
+          },
+          screenshot: {
+            name: "join-invite-mobile-reduced-motion",
+            claim: "On a phone-sized viewport with reduced motion, the same focused invitation remains centered and readable.",
+            requireText: [state.organizationName, state.inviteeEmail, state.roleLabel, "Not now"],
+            rejectText: ["Inviter", "Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/join-org-invite-clean.md
+++ b/evals/voiceovers/join-org-invite-clean.md
@@ -1,0 +1,9 @@
+# join-org-invite-clean — Clean organization invitation
+
+1. “The organization invitation opens as a small, centered experience on a subtle light Dithering background.”
+
+2. “The stacked cards are gone. The organization name, inviter, and account details appear in one clean, compact hierarchy.”
+
+3. “I can accept or decline the invitation with clear actions, without unnecessary panels or visual noise.”
+
+4. “The same focused layout remains centered and readable on smaller screens, with motion disabled when reduced motion is preferred.”


### PR DESCRIPTION
## Summary
- replace the stacked invitation cards with one compact, centered hierarchy
- add a single low-opacity light Dithering background with reduced-motion support
- preserve real invitation, account, authentication, and acceptance behavior
- add a non-destructive **Not now** dismissal and responsive coverage

## Validation
- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm --filter @openwork-ee/den-web test` — 49 passed
- `pnpm --filter @openwork-ee/den-web build` — passed
- `OPENWORK_EVAL_DEN_API_URL=http://127.0.0.1:34133 OPENWORK_EVAL_DEN_WEB_URL=http://127.0.0.1:34132 OPENWORK_EVAL_DEN_MULTI_ORG=1 pnpm fraimz --flow join-org-invite-clean --cdp-url http://127.0.0.1:9333` — passed, 4/4 frames
- screenshot pixel verification — passed at 1280×900 with no detected defects

## Design
- one light Dithering canvas
- opacity `0.09`; ambient speed `0.012`; speed `0` for reduced motion
- compact `max-w-md` foreground with no `den-frame` or `den-frame-inset` shells

## Screenshot
A verified screenshot will be attached in the first PR comment.