### PR TITLE
feat(onboarding): invite a teammate before entering the workspace

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -178,6 +178,13 @@ export type DenMcpToken = {
   resource: string;
 };
 
+export type DenOrgInvitation = {
+  invitationId: string;
+  email: string;
+  role: string;
+  expiresAt: string | null;
+};
+
 export type DenOrgLlmProviderModel = {
   id: string;
   name: string;
@@ -996,6 +1003,24 @@ function getOrgList(payload: unknown): DenOrgSummary[] {
       } satisfies DenOrgSummary,
     ];
   });
+}
+
+function getDenOrgInvitation(payload: unknown): DenOrgInvitation | null {
+  if (
+    !isRecord(payload) ||
+    typeof payload.invitationId !== "string" ||
+    typeof payload.email !== "string" ||
+    typeof payload.role !== "string"
+  ) {
+    return null;
+  }
+
+  return {
+    invitationId: payload.invitationId,
+    email: payload.email,
+    role: payload.role,
+    expiresAt: typeof payload.expiresAt === "string" ? payload.expiresAt : null,
+  };
 }
 
 function getWorkers(payload: unknown): DenWorkerSummary[] {
@@ -2128,6 +2153,20 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
         throw new DenApiError(500, "invalid_skill_payload", "Skill response was missing id.");
       }
       return { id };
+    },
+
+    async inviteOrgMember(input: { organizationId: string; email: string; role: string }): Promise<DenOrgInvitation> {
+      const payload = await requestJson<unknown>(baseUrls, "/v1/invitations", {
+        method: "POST",
+        token,
+        organizationId: input.organizationId,
+        body: { email: input.email, role: input.role },
+      });
+      const invitation = getDenOrgInvitation(payload);
+      if (!invitation) {
+        throw new DenApiError(500, "invalid_invitation_payload", "Invitation response was missing required values.");
+      }
+      return invitation;
     },
 
     async listOrgLlmProviders(orgId: string): Promise<DenOrgLlmProvider[]> {

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore, type FormEvent } from "react";
 import { useMutation, useQueries, useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
 import {
@@ -17,6 +17,7 @@ import {
 
 import {
   createDenClient,
+  DenApiError,
   readDenBootstrapConfig,
   readDenSettings,
   resolveDenBaseUrls,
@@ -320,6 +321,28 @@ function markProvidersSeen(providers: DenOrgLlmProvider[]) {
   } catch {}
 }
 
+type InviteStep = "hidden" | "form" | "sent";
+
+function inviteErrorMessage(error: unknown) {
+  if (error instanceof DenApiError) {
+    if (error.status === 402) {
+      return "Your plan is out of seats — you can add more from the web dashboard.";
+    }
+    if (error.status === 409 && error.code === "member_exists") {
+      return "That person is already a member.";
+    }
+    if (error.status === 409 && error.code === "invite_email_domain_not_allowed") {
+      return "That email domain isn't allowed for this organization.";
+    }
+    if (error.status === 502 && error.code === "invitation_email_failed") {
+      return "The invitation was created but the email could not be sent. You can manage invitations from the web dashboard.";
+    }
+    return error.message;
+  }
+
+  return error instanceof Error ? error.message : "Unable to send the invitation.";
+}
+
 /**
  * Full-screen onboarding page shown after sign-in + org selection.
  * Fetches all org resources (providers, marketplaces, skills)
@@ -452,6 +475,10 @@ export function ResourceSelectionPage() {
   } | null>(null);
   const [preparingBranding, setPreparingBranding] = useState(false);
   const [brandingRestart, setBrandingRestart] = useState<BrandingRestartState | null>(null);
+  const [inviteStep, setInviteStep] = useState<InviteStep>("hidden");
+  const [inviteEmail, setInviteEmail] = useState("");
+  const [sentInviteEmail, setSentInviteEmail] = useState("");
+  const [inviteError, setInviteError] = useState<string | null>(null);
 
   // Redirect if no auth or no org — can't show onboarding without them
   useEffect(() => {
@@ -483,6 +510,30 @@ export function ResourceSelectionPage() {
       loading: providersQuery.isPending || marketplacesQuery.isPending,
       error: providersQuery.error?.message ?? marketplacesQuery.error?.message ?? null,
     }),
+  });
+
+  const { data: orgsData } = useQuery({
+    queryKey: ["den-org-onboarding", settings.baseUrl, "orgs"],
+    enabled: Boolean(authToken),
+    queryFn: () => denClient.listOrgs(),
+  });
+  const role = orgsData?.orgs.find((org) => org.id === orgId)?.role ?? null;
+  const canInvite = role === "owner" || role === "admin";
+
+  const { isPending: inviteBusy, mutate: sendInvite } = useMutation({
+    mutationFn: (email: string) => denClient.inviteOrgMember({
+      organizationId: orgId,
+      email,
+      role: "member",
+    }),
+    onSuccess: (invitation) => {
+      setInviteError(null);
+      setSentInviteEmail(invitation.email);
+      setInviteStep("sent");
+    },
+    onError: (nextError) => {
+      setInviteError(inviteErrorMessage(nextError));
+    },
   });
 
   const finishOnboarding = useCallback(() => {
@@ -557,6 +608,23 @@ export function ResourceSelectionPage() {
     }
   }, [finishOnboarding, orgId, refreshFresh]);
 
+  const handleFooterContinue = useCallback(() => {
+    if (canInvite && inviteStep === "hidden") {
+      setInviteError(null);
+      setInviteStep("form");
+      return;
+    }
+    void handleContinue();
+  }, [canInvite, handleContinue, inviteStep]);
+
+  const submitInvite = useCallback((event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    const email = inviteEmail.trim();
+    if (!email || inviteBusy) return;
+    setInviteError(null);
+    sendInvite(email);
+  }, [inviteBusy, inviteEmail, sendInvite]);
+
   const restartWithBranding = useCallback(async () => {
     if (!brandingRestart) return;
     window.localStorage.setItem(APPLIED_BRANDING_FINGERPRINT_KEY, brandingRestart.fingerprint);
@@ -577,6 +645,7 @@ export function ResourceSelectionPage() {
 
   const totalModels = providers.reduce((sum, provider) => sum + provider.models.length, 0);
   const hasResources = providers.length > 0 || marketplaces.length > 0;
+  const inviteOrgName = orgName || "your organization";
 
   if (preparingBranding) {
     return (
@@ -650,6 +719,99 @@ export function ResourceSelectionPage() {
               <ArrowRight data-icon="inline-end" />
             </Button>
           </PageFooter>
+        </PageContainer>
+      </Page>
+    );
+  }
+
+  if (inviteStep !== "hidden") {
+    return (
+      <Page>
+        <PageBackground />
+        <PageTitlebarRegion />
+        <PageContainer>
+          <PageHeader>
+            <div className="mx-auto flex size-14 items-center justify-center rounded-2xl border border-dls-border bg-dls-hover">
+              <BuildingOffice2Icon className="size-7 text-foreground" />
+            </div>
+            <PageTitle>Invite a teammate</PageTitle>
+            <PageDescription>
+              OpenWork is better together. Send an invitation to join {inviteOrgName}.
+            </PageDescription>
+          </PageHeader>
+
+          {inviteStep === "sent" ? (
+            <>
+              <PageContent>
+                <div
+                  data-testid="invite-teammate-success"
+                  className="mx-auto flex w-full max-w-md flex-col items-center gap-3 rounded-2xl border border-green-6/30 bg-green-2/30 px-5 py-6 text-center"
+                >
+                  <CheckCircle2 className="size-8 text-green-11" />
+                  <div className="text-base font-semibold text-green-11">
+                    Invitation sent to {sentInviteEmail}
+                  </div>
+                  <p className="text-sm text-muted-foreground">
+                    They&apos;ll get an email with everything they need to join.
+                  </p>
+                </div>
+              </PageContent>
+              <PageFooter>
+                <Button type="button" size="lg" onClick={() => void handleContinue()}>
+                  Continue to workspace
+                  <ArrowRight data-icon="inline-end" />
+                </Button>
+              </PageFooter>
+            </>
+          ) : (
+            <form className="contents" onSubmit={submitInvite}>
+              <PageContent>
+                <div className="mx-auto grid w-full max-w-md gap-4">
+                  <Field>
+                    <FieldLabel htmlFor="invite-teammate-email">Email address</FieldLabel>
+                    <Input
+                      id="invite-teammate-email"
+                      data-testid="invite-teammate-email"
+                      type="email"
+                      placeholder="teammate@company.com"
+                      value={inviteEmail}
+                      onChange={(event) => {
+                        setInviteEmail(event.target.value);
+                        if (inviteError) setInviteError(null);
+                      }}
+                      disabled={inviteBusy}
+                      aria-invalid={Boolean(inviteError)}
+                    />
+                  </Field>
+                  {inviteError ? (
+                    <Alert variant="destructive">
+                      <CircleAlert />
+                      <AlertDescription>{inviteError}</AlertDescription>
+                    </Alert>
+                  ) : null}
+                </div>
+              </PageContent>
+              <PageFooter>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  data-testid="invite-teammate-skip"
+                  onClick={() => void handleContinue()}
+                >
+                  Skip for now
+                </Button>
+                <Button
+                  type="submit"
+                  size="lg"
+                  data-testid="invite-teammate-send"
+                  disabled={!inviteEmail.trim() || inviteBusy}
+                >
+                  {inviteBusy ? "Sending..." : "Send invitation"}
+                  <ArrowRight data-icon="inline-end" />
+                </Button>
+              </PageFooter>
+            </form>
+          )}
         </PageContainer>
       </Page>
     );
@@ -784,7 +946,7 @@ export function ResourceSelectionPage() {
             className="w-fit"
             type="button"
             size="lg"
-            onClick={() => void handleContinue()}
+            onClick={handleFooterContinue}
             disabled={loading || preparingBranding}
           >
             {preparingBranding

--- a/evals/flows/onboarding-invite-teammate.flow.mjs
+++ b/evals/flows/onboarding-invite-teammate.flow.mjs
@@ -65,6 +65,16 @@ async function completeLocalFirstRun(ctx) {
   // welcome-route marks local first-run complete when a real user signs in from
   // /welcome; this flow signs in through settings, so it records the same
   // preference before driving /onboarding (fixture, not product behavior).
+  const state = await ctx.eval(`(() => {
+    const raw = localStorage.getItem("openwork.preferences");
+    const prefs = raw ? JSON.parse(raw) : {};
+    return {
+      completed: prefs.hasCompletedOnboarding === true,
+      onWelcome: location.hash.includes("/welcome"),
+    };
+  })()`);
+  if (state?.completed === true && state.onWelcome !== true) return;
+
   const completed = await ctx.eval(`(() => {
     const raw = localStorage.getItem("openwork.preferences");
     const prefs = raw ? JSON.parse(raw) : {};
@@ -73,6 +83,11 @@ async function completeLocalFirstRun(ctx) {
     return prefs.hasCompletedOnboarding;
   })()`);
   ctx.assert(completed === true, "Local first-run preference was not recorded.");
+  await ctx.eval("location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API after first-run reload",
+  });
 }
 
 async function clickAcmeOrganization(ctx) {

--- a/evals/flows/onboarding-invite-teammate.flow.mjs
+++ b/evals/flows/onboarding-invite-teammate.flow.mjs
@@ -1,0 +1,282 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("onboarding-invite-teammate");
+const RUN_TAG = Date.now().toString(36);
+
+async function denRequest(ctx, path, init = {}) {
+  const apiBase = ctx.env.OPENWORK_EVAL_DEN_API_URL.trim().replace(/\/+$/, "");
+  const webBase = ctx.env.OPENWORK_EVAL_DEN_WEB_URL.trim().replace(/\/+$/, "");
+  const response = await fetch(`${apiBase}${path}`, {
+    ...init,
+    headers: {
+      authorization: `Bearer ${ctx.env.OPENWORK_EVAL_DEN_TOKEN.trim()}`,
+      "content-type": "application/json",
+      origin: webBase || apiBase,
+      ...(init.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  ctx.assert(response.ok, `${init.method ?? "GET"} ${path} failed: ${response.status} ${text.slice(0, 200)}`);
+  return body;
+}
+
+async function signInWithDesktopHandoff(ctx) {
+  const payload = await denRequest(ctx, "/v1/auth/desktop-handoff", {
+    method: "POST",
+    body: JSON.stringify({ desktopScheme: "openwork" }),
+  });
+  ctx.assert(
+    typeof payload?.openworkUrl === "string" && payload.openworkUrl.length > 0,
+    "No openworkUrl in handoff response.",
+  );
+  const handoffUrl = new URL(payload.openworkUrl);
+  handoffUrl.searchParams.set("denBaseUrl", ctx.env.OPENWORK_EVAL_DEN_WEB_URL.trim().replace(/\/+$/, ""));
+
+  await ctx.navigateHash("/settings/cloud-account");
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body.innerText;
+      return text.includes("Paste sign-in code") || text.includes("Sign out");
+    })()`,
+    { timeoutMs: 30_000, label: "cloud account state" },
+  );
+
+  if (await ctx.hasText("Sign out")) {
+    ctx.log("Already signed in — skipping paste flow.");
+    return;
+  }
+
+  await ctx.clickText("Paste sign-in code", { timeoutMs: 30_000 });
+  await ctx.fill("#den-signin-link", handoffUrl.toString());
+  await ctx.clickText("Finish sign-in", { timeoutMs: 30_000 });
+  await ctx.waitFor(
+    "Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())",
+    { timeoutMs: 60_000, label: "persisted den auth token" },
+  );
+}
+
+async function clickAcmeOrganization(ctx) {
+  await ctx.clickText("Acme Robotics", {
+    selector: "label, button, [role=button], [role=radio]",
+    timeoutMs: 30_000,
+  });
+}
+
+async function chooseAcmeIfPickerVisible(ctx) {
+  if (!(await ctx.hasText("Choose your organization"))) return false;
+  await clickAcmeOrganization(ctx);
+  await ctx.clickText("Continue with organization", { selector: "button", timeoutMs: 30_000 });
+  return true;
+}
+
+async function ensureAcmeResources(ctx) {
+  await ctx.navigateHash("/onboarding");
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body.innerText;
+      if (text.includes("Choose your organization") && text.includes("Acme Robotics")) return "picker";
+      if (!text.includes("Choose your organization") && text.includes("Acme Robotics") && (text.includes("Continue to workspace") || text.includes("Continue"))) return "resources";
+      return null;
+    })()`,
+    { timeoutMs: 60_000, label: "Acme picker or resources screen" },
+  );
+  await chooseAcmeIfPickerVisible(ctx);
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body.innerText;
+      return !text.includes("Choose your organization") && text.includes("Acme Robotics") && (text.includes("You have access to the following resources") || text.includes("Continue to workspace") || text.includes("Continue"));
+    })()`,
+    { timeoutMs: 60_000, label: "Acme resources screen" },
+  );
+}
+
+async function clickFooterContinue(ctx) {
+  if (await ctx.hasText("Continue to workspace")) {
+    await ctx.clickText("Continue to workspace", { selector: "button", timeoutMs: 30_000 });
+    return;
+  }
+  await ctx.clickText("Continue", { selector: "button", timeoutMs: 30_000 });
+}
+
+async function waitForInviteScreen(ctx) {
+  await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"invite-teammate-email\"]'))", {
+    timeoutMs: 30_000,
+    label: "invite teammate email field",
+  });
+}
+
+async function continueFromInviteSuccess(ctx) {
+  await ctx.clickText("Continue to workspace", { selector: "button", timeoutMs: 30_000 });
+  const next = await ctx.waitFor(
+    `(() => {
+      const text = document.body.innerText;
+      if (window.location.hash.includes("/session")) return "session";
+      if (text.includes("Workspace identity is ready")) return "branding";
+      return null;
+    })()`,
+    { timeoutMs: 60_000, label: "workspace route or branding restart" },
+  );
+  if (next === "branding") {
+    await ctx.clickText("Continue without restarting", { selector: "button", timeoutMs: 30_000 });
+    await ctx.waitFor("window.location.hash.includes('/session')", {
+      timeoutMs: 60_000,
+      label: "workspace session route after branding restart skip",
+    });
+  }
+}
+
+function orgInvitations(org) {
+  return Array.isArray(org?.invitations) ? org.invitations : [];
+}
+
+function pendingInvitationsForEmail(org, email) {
+  return orgInvitations(org).filter((entry) => entry?.email === email && entry?.status === "pending");
+}
+
+function pendingInvitationCount(org) {
+  return orgInvitations(org).filter((entry) => entry?.status === "pending").length;
+}
+
+export default {
+  id: "onboarding-invite-teammate",
+  title: "Cloud onboarding invites a teammate before entering the workspace",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("Alex signs in, chooses Acme Robotics, and reviews the workspace resources", {
+          voiceover: vo[0],
+          action: async () => {
+            await ctx.waitFor("Boolean(window.__openworkControl)", {
+              timeoutMs: 60_000,
+              label: "control API",
+            });
+            await signInWithDesktopHandoff(ctx);
+            await ensureAcmeResources(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("Acme Robotics", { timeoutMs: 5_000 });
+            const hasResourcesText = await ctx.hasText("You have access to the following resources");
+            ctx.assert(hasResourcesText || await ctx.hasText("Continue"), "Onboarding did not show the Acme resources step.");
+          },
+          screenshot: {
+            name: "acme-onboarding-resources",
+            requireText: ["Acme Robotics", "resources"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("Continuing from resources offers a skippable teammate invite", {
+          voiceover: vo[1],
+          action: async () => {
+            await clickFooterContinue(ctx);
+            await waitForInviteScreen(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("Invite a teammate", { timeoutMs: 5_000 });
+            await ctx.expectText("Skip for now", { timeoutMs: 5_000 });
+          },
+          screenshot: {
+            name: "invite-teammate-form",
+            requireText: ["Invite a teammate"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Sending the invitation confirms it in the UI and in the organization payload", {
+          voiceover: vo[2],
+          action: async () => {
+            ctx.inviteEmail = `taylor.invite+${RUN_TAG}@acme.test`;
+            ctx.skipEmail = `taylor.skip+${RUN_TAG}@acme.test`;
+            await ctx.fill('[data-testid="invite-teammate-email"]', ctx.inviteEmail);
+            await ctx.clickText("Send invitation", { selector: "button", timeoutMs: 30_000 });
+            await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"invite-teammate-success\"]'))", {
+              timeoutMs: 60_000,
+              label: "invite teammate success",
+            });
+          },
+          assert: async () => {
+            await ctx.expectText("Invitation sent", { timeoutMs: 5_000 });
+            const org = await denRequest(ctx, "/v1/org", { method: "GET" });
+            const invitations = pendingInvitationsForEmail(org, ctx.inviteEmail);
+            ctx.assert(invitations.length > 0, `No pending invitation found for ${ctx.inviteEmail}.`);
+            ctx.pendingInvitationCountAfterSend = pendingInvitationCount(org);
+            ctx.output("pending-invitation", JSON.stringify(invitations[0], null, 2));
+          },
+          screenshot: {
+            name: "invite-teammate-sent",
+            requireText: ["Invitation sent"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Alex continues from the confirmation into the workspace", {
+          voiceover: vo[3],
+          action: async () => {
+            await continueFromInviteSuccess(ctx);
+          },
+          assert: async () => {
+            await ctx.waitFor("window.location.hash.includes('/session')", {
+              timeoutMs: 60_000,
+              label: "workspace session route",
+            });
+          },
+          screenshot: {
+            name: "workspace-after-invite",
+            hashIncludes: "/session",
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("Coming back later, Alex skips the invite without creating another pending invitation", {
+          voiceover: vo[4],
+          action: async () => {
+            await ensureAcmeResources(ctx);
+            await clickFooterContinue(ctx);
+            await waitForInviteScreen(ctx);
+            await ctx.clickText("Skip for now", { selector: "button", timeoutMs: 30_000 });
+            await ctx.waitFor("window.location.hash.includes('/session')", {
+              timeoutMs: 60_000,
+              label: "workspace session route after skipping invite",
+            });
+          },
+          assert: async () => {
+            const org = await denRequest(ctx, "/v1/org", { method: "GET" });
+            const skipInvitations = pendingInvitationsForEmail(org, ctx.skipEmail);
+            const pendingCount = pendingInvitationCount(org);
+            ctx.assert(skipInvitations.length === 0, `Skip created an invitation for ${ctx.skipEmail}.`);
+            ctx.assert(
+              pendingCount === ctx.pendingInvitationCountAfterSend,
+              `Pending invitations changed after skip: before=${ctx.pendingInvitationCountAfterSend} after=${pendingCount}.`,
+            );
+            ctx.output("skip-created-no-invitation", JSON.stringify({ skippedEmail: ctx.skipEmail, pendingCount }, null, 2));
+          },
+          screenshot: {
+            name: "workspace-after-skip",
+            hashIncludes: "/session",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/onboarding-invite-teammate.flow.mjs
+++ b/evals/flows/onboarding-invite-teammate.flow.mjs
@@ -61,6 +61,20 @@ async function signInWithDesktopHandoff(ctx) {
   );
 }
 
+async function completeLocalFirstRun(ctx) {
+  // welcome-route marks local first-run complete when a real user signs in from
+  // /welcome; this flow signs in through settings, so it records the same
+  // preference before driving /onboarding (fixture, not product behavior).
+  const completed = await ctx.eval(`(() => {
+    const raw = localStorage.getItem("openwork.preferences");
+    const prefs = raw ? JSON.parse(raw) : {};
+    prefs.hasCompletedOnboarding = true;
+    localStorage.setItem("openwork.preferences", JSON.stringify(prefs));
+    return prefs.hasCompletedOnboarding;
+  })()`);
+  ctx.assert(completed === true, "Local first-run preference was not recorded.");
+}
+
 async function clickAcmeOrganization(ctx) {
   await ctx.clickText("Acme Robotics", {
     selector: "label, button, [role=button], [role=radio]",
@@ -77,6 +91,13 @@ async function chooseAcmeIfPickerVisible(ctx) {
 
 async function ensureAcmeResources(ctx) {
   await ctx.navigateHash("/onboarding");
+  const landedOnWelcome = await ctx.eval(`new Promise((resolve) => {
+    setTimeout(() => resolve(location.hash.includes("/welcome")), 500);
+  })`, { awaitPromise: true });
+  if (landedOnWelcome) {
+    await completeLocalFirstRun(ctx);
+    await ctx.navigateHash("/onboarding");
+  }
   await ctx.waitFor(
     `(() => {
       const text = document.body.innerText;
@@ -160,6 +181,7 @@ export default {
               label: "control API",
             });
             await signInWithDesktopHandoff(ctx);
+            await completeLocalFirstRun(ctx);
             await ensureAcmeResources(ctx);
           },
           assert: async () => {

--- a/evals/voiceovers/onboarding-invite-teammate.md
+++ b/evals/voiceovers/onboarding-invite-teammate.md
@@ -1,0 +1,15 @@
+# onboarding-invite-teammate — Invite a teammate during cloud onboarding
+
+Cloud onboarding ends in a working workspace, but work is better together.
+Owners and admins now get one gentle prompt to bring a teammate along —
+one email field, one send button, and skipping never blocks the way in.
+
+1. Alex signs in to OpenWork Cloud on the desktop and lands on onboarding — he confirms his organization, Acme Robotics, and reviews the resources his workspace gets.
+
+2. Continuing on, OpenWork now offers one more step before the workspace: invite a teammate. The screen asks for an email address, and skipping is always allowed.
+
+3. Alex types his teammate's email and sends the invitation — OpenWork confirms it is on its way, and the organization now shows a pending invitation for that address.
+
+4. From the confirmation, Alex continues into his ready-to-use workspace.
+
+5. Coming back to onboarding later, Alex can skip the invite step entirely — it never blocks the way into the workspace.


### PR DESCRIPTION
## What

Cloud org onboarding (`/onboarding`) now ends with an **"Invite a teammate"** step for owners and admins — one email field, one send button, always skippable:

- After confirming the organization and reviewing resources, "Continue to workspace" shows the invite screen (owners/admins only; members and unresolved roles go straight through — the step never blocks anyone).
- Sending calls the existing `POST /v1/invitations` (role `member`) through a new `denClient.inviteOrgMember` and shows a confirmation ("Invitation sent to …") before continuing into the workspace.
- Friendly error mapping: out of seats (402), already a member / domain not allowed (409), invitation-created-but-email-failed (502) — with retry or skip, never a dead end.
- "Skip for now" goes straight to the workspace; revisiting `/onboarding` later still allows skipping without creating anything.

No den-api changes — the endpoint, permissions (owner/admin enforced server-side), and seat/domain policies already exist.

## Voiceover / spec

`evals/voiceovers/onboarding-invite-teammate.md` — 5 frames, enforced by the runner's narration drift check.

## How it was verified

- `pnpm --filter @openwork/app typecheck` — pass
- `pnpm --filter @openwork/app test` — 323 pass
- **End-to-end fraimz (all 5 frames + narration coverage): PASSED** — real Electron + real Den stack (MariaDB, `DEN_ORG_MODE=multi_org`, seeded Acme Robotics) on a Daytona VNC sandbox:
  `pnpm evals --flow onboarding-invite-teammate --cdp-url http://127.0.0.1:9825`
  - Frame 3's assertion is server truth: `GET /v1/org` lists the pending invitation (`status: "pending"`, role `member`, 7-day expiry) for the exact email typed in the UI.
  - Frame 5 witnesses that skipping creates nothing (pending-invitation count unchanged).
  - Frame-by-frame proof posted as a comment below; full artifact `evals/results/2026-07-16T22-50-03-634Z/fraimz.html`.

Local-machine note: this Mac had no active GUI session (Electron `app.whenReady()` never fires), so the desktop flow was proven on Daytona — same setup as #2839.

## Repro

```
# in a Daytona electron sandbox (or any machine with a GUI):
bash .devcontainer/test-on-daytona.sh feat/onboarding-invite-teammate --artifacts-volume
# in-sandbox: apt-get install -y default-mysql-server && bash .devcontainer/start-daytona-server.sh
#             seed: pnpm --filter @openwork/email build && (cd ee/apps/den-api && ... tsx scripts/seed-demo-org.ts)
OPENWORK_EVAL_DEN_API_URL=http://localhost:8788 OPENWORK_EVAL_DEN_WEB_URL=http://localhost:3005 \
OPENWORK_EVAL_DEN_TOKEN=<alex token> pnpm evals --flow onboarding-invite-teammate --cdp-url http://127.0.0.1:9825
```
