### PR TITLE
fix(evals): org-capability-flags — drive den-web email-first sign-in

### DIFF
--- a/evals/flows/org-capability-flags.flow.mjs
+++ b/evals/flows/org-capability-flags.flow.mjs
@@ -438,12 +438,12 @@ async function signInToDenWebWithoutOrg(ctx, email, password) {
 async function submitDenWebSignIn(ctx, email, password) {
   await clearDenWebSession(ctx);
   await goToDenWeb(ctx, "/");
-  await ctx.waitFor("document.body.innerText.includes('Sign in')", { timeoutMs: 30_000, label: "sign-in screen" });
-  await clickExactText(ctx, "Sign in", "button, a");
-  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]'))", { timeoutMs: 15_000, label: "email input" });
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"], input[name=\"email\"]'))", { timeoutMs: 30_000, label: "email-first sign-in form" });
   await ctx.fill('input[type="email"], input[name="email"]', email);
+  await clickExactText(ctx, "Next", "button");
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 15_000, label: "password input" });
   await ctx.fill('input[type="password"]', password);
-  await clickLastExactText(ctx, "Sign in", "button");
+  await clickExactText(ctx, "Sign in", "button");
 }
 
 async function waitForDenWebSession(ctx, email) {


### PR DESCRIPTION
## What

`evals/flows/org-capability-flags.flow.mjs`'s `submitDenWebSignIn` still expected the old den-web landing ("Sign in" button on `/`). The simplified cloud landing (#2833) replaced it with an email-first step, so the flow timed out at 'sign-in screen'. The helper now drives the real sequence: email → **Next** → password → **Sign in** (session polling unchanged).

## How it was verified

Full live run on a Daytona sandbox — real den-api (MariaDB, seeded Acme, `DEN_BOOTSTRAP_ADMIN_EMAILS` platform admin) + real den-web dev server + headless Chrome admin browser:

`pnpm evals --flow org-capability-flags --cdp-url http://127.0.0.1:9825` → **PASSED, all 4 frames + narration coverage** (fraimz comment below).

This is also the first live post-merge proof of #2839's install-links **default-on + kill-switch** story: frame 1 shows /admin with Install links already checked (no stored override) and `/v1/org` reporting true; frames 2–4 exercise the reversible kill switch.

Honest note: the demo seed creates a single organization, so the 'other orgs unchanged' assertion compared an empty set in this run (it is still exercised).

## Repro

Same sandbox recipe as #2866 plus: restart den-api with `DEN_BOOTSTRAP_ADMIN_EMAILS=priya.platform@acme.test`, launch `chromium --headless=new --remote-debugging-port=9333`, export `OPENWORK_EVAL_WEB_CDP_ADMIN`, `OPENWORK_EVAL_PLATFORM_ADMIN_EMAIL/PASSWORD`, `OPENWORK_EVAL_MARK_VERIFIED_CMD`.