### PR TITLE
fix(mcp): isolate callbacks for OAuth servers without response issuers

### DIFF
--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
@@ -45,6 +45,8 @@ function toEnterpriseConnection(
           // CIMD client identifiers must be HTTPS URLs. Local HTTP development
           // still exposes the document for inspection, but falls back to DCR
           // or pre-registration instead of advertising a non-conforming ID.
+          // Client metadata has one fixed redirect URI, so scoped callback
+          // modes must use DCR or a pre-registered client bound to that URI.
           clientMetadataUrl: connection.oauthConfiguration?.callbackMode === "shared-v1"
             && new URL(metadataUrl).protocol === "https:"
             ? metadataUrl

--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
@@ -203,6 +203,22 @@ export class DenEnterpriseMcpOAuthPersistence implements EnterpriseMcpOAuthPersi
       const row = rows[0]
       if (!row) return undefined
       const extra = normalizeOAuthClientExtra(row.extra)
+      const registeredRedirectUri = typeof extra?.registeredRedirectUri === "string"
+        ? extra.registeredRedirectUri
+        : undefined
+      const currentRedirectUri = externalMcpCallbackUrl({
+        connectionId: this.connection.id,
+        callbackMode: this.connection.oauthConfiguration?.callbackMode ?? "legacy-v1",
+      })
+      if (
+        extra?.enterpriseMcpRegistrationSource === "pre-registered"
+        && registeredRedirectUri !== currentRedirectUri
+      ) {
+        throw new EnterpriseMcpOAuthContractError(
+          "MCP_OAUTH_CONFIGURATION_REQUIRED",
+          `The pre-registered OAuth client must allowlist the callback URL ${currentRedirectUri}.`,
+        )
+      }
       const clientInformation = restoredClientInformation({ ...row, extra })
       return {
         clientInformation,

--- a/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-connections.ts
@@ -464,6 +464,102 @@ export async function createExternalMcpConnection(input: {
   return created
 }
 
+/**
+ * Move a discovered OAuth connection from the shared callback to a callback
+ * unique to this connection. The caller must first verify that the server did
+ * not advertise RFC 9207 response issuers and that PKCE S256 is available.
+ */
+export async function isolateExternalMcpOAuthCallback(input: {
+  organizationId: OrganizationId
+  connectionId: ExternalMcpConnectionId
+}): Promise<ExternalMcpConnectionRow> {
+  return db.transaction(async (tx) => {
+    const rows = await tx
+      .select()
+      .from(ExternalMcpConnectionTable)
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionTable.id, input.connectionId),
+      ))
+      .limit(1)
+      .for("update")
+    const connection = rows[0]
+    if (!connection || connection.authType !== "oauth" || !connection.oauthConfiguration) {
+      throw new Error("The OAuth connection no longer exists.")
+    }
+    if (connection.oauthConfiguration.callbackMode !== "shared-v1") return connection
+    const discovery = connection.oauthConfiguration.discovery
+    const metadata = isRecord(discovery) && isRecord(discovery.authorizationServerMetadata)
+      ? discovery.authorizationServerMetadata
+      : undefined
+    const pkceMethods = metadata?.code_challenge_methods_supported
+    if (
+      metadata === undefined
+      || metadata.authorization_response_iss_parameter_supported === true
+      || !Array.isArray(pkceMethods)
+      || !pkceMethods.includes("S256")
+    ) {
+      throw new Error("The OAuth discovery state does not permit an issuer-isolated callback.")
+    }
+
+    const clients = await tx
+      .select()
+      .from(OrgOAuthClientTable)
+      .where(and(
+        eq(OrgOAuthClientTable.organizationId, input.organizationId),
+        eq(OrgOAuthClientTable.providerId, input.connectionId),
+      ))
+      .limit(1)
+      .for("update")
+    const clientExtra = normalizeOAuthClientExtra(clients[0]?.extra)
+    if (clients[0] && isSdkRegisteredOAuthClient(clientExtra)) {
+      await tx.delete(OrgOAuthClientTable).where(eq(OrgOAuthClientTable.id, clients[0].id))
+    }
+
+    await tx.delete(ConnectedAccountTable).where(and(
+      eq(ConnectedAccountTable.organizationId, input.organizationId),
+      eq(ConnectedAccountTable.providerId, input.connectionId),
+    ))
+    const updatedAt = new Date(Math.max(Date.now(), connection.updatedAt.getTime() + 1))
+    await tx
+      .update(ExternalMcpConnectionTable)
+      .set({
+        oauthConfiguration: {
+          ...connection.oauthConfiguration,
+          callbackMode: "isolated-v1",
+        },
+        accessToken: null,
+        refreshToken: null,
+        tokenType: null,
+        scope: null,
+        expiresAt: null,
+        pendingCodeVerifier: null,
+        connectedAt: null,
+        updatedAt,
+      })
+      .where(and(
+        eq(ExternalMcpConnectionTable.organizationId, input.organizationId),
+        eq(ExternalMcpConnectionTable.id, input.connectionId),
+      ))
+
+    return {
+      ...connection,
+      oauthConfiguration: {
+        ...connection.oauthConfiguration,
+        callbackMode: "isolated-v1",
+      },
+      accessToken: null,
+      refreshToken: null,
+      tokenType: null,
+      scope: null,
+      expiresAt: null,
+      pendingCodeVerifier: null,
+      connectedAt: null,
+      updatedAt,
+    }
+  })
+}
+
 export async function listExternalMcpConnectionAccess(input: {
   organizationId: OrganizationId
   connectionId: ExternalMcpConnectionId
@@ -777,9 +873,11 @@ export async function updateExternalMcpConnection(
       input.oauthClient?.clientSecret !== undefined
       && existingClient?.clientSecret !== input.oauthClient.clientSecret,
     )
+    const clientExtraChanged = input.oauthClient?.extra !== undefined
+      && !isDeepStrictEqual(existingClientExtra, normalizeOAuthClientExtra(input.oauthClient.extra))
     const oauthClientChanged = identityChanged
       ? Boolean(existingClient || input.oauthClient)
-      : Boolean(input.oauthClient && (!existingClient || clientIdChanged || clientSecretChanged))
+      : Boolean(input.oauthClient && (!existingClient || clientIdChanged || clientSecretChanged || clientExtraChanged))
     const apiKeyChanged = input.apiKey !== undefined && existing.apiKey !== input.apiKey
     const rowFieldsChanged = existing.name !== input.name
       || existing.url !== input.url

--- a/ee/apps/den-api/src/capability-sources/generic-oauth.ts
+++ b/ee/apps/den-api/src/capability-sources/generic-oauth.ts
@@ -64,7 +64,7 @@ export type OAuthStatePayload = {
   orgMembershipId: DenTypeId<"member">
   providerId: string
   binding?: string
-  callbackMode?: "shared-v1" | "legacy-v1"
+  callbackMode?: "shared-v1" | "isolated-v1" | "legacy-v1"
   authorizationServerIssuer?: string
   nonce: string
   iat?: number
@@ -77,7 +77,7 @@ export function createOAuthStateToken(input: {
   providerId: string
   binding?: string
   version?: 1 | 2
-  callbackMode?: "shared-v1" | "legacy-v1"
+  callbackMode?: "shared-v1" | "isolated-v1" | "legacy-v1"
   authorizationServerIssuer?: string
   secret: string
   ttlSeconds?: number
@@ -122,7 +122,7 @@ export function verifyOAuthStateToken(input: { token: string; secret: string; no
       || typeof payload.providerId !== "string"
       || (payload.binding !== undefined && typeof payload.binding !== "string")
       || (payload.version !== undefined && payload.version !== 1 && payload.version !== 2)
-      || (payload.callbackMode !== undefined && payload.callbackMode !== "shared-v1" && payload.callbackMode !== "legacy-v1")
+      || (payload.callbackMode !== undefined && payload.callbackMode !== "shared-v1" && payload.callbackMode !== "isolated-v1" && payload.callbackMode !== "legacy-v1")
       || (payload.authorizationServerIssuer !== undefined && typeof payload.authorizationServerIssuer !== "string")
       || typeof payload.nonce !== "string"
       || (payload.iat !== undefined && typeof payload.iat !== "number")
@@ -130,7 +130,7 @@ export function verifyOAuthStateToken(input: { token: string; secret: string; no
       || payload.exp < nowSeconds
       || (payload.version === 2 && (
         typeof payload.binding !== "string"
-        || (payload.callbackMode !== "shared-v1" && payload.callbackMode !== "legacy-v1")
+        || (payload.callbackMode !== "shared-v1" && payload.callbackMode !== "isolated-v1" && payload.callbackMode !== "legacy-v1")
         || typeof payload.iat !== "number"
       ))
     ) {

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -5,6 +5,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import {
   discoverConnectionRequirements,
+  EnterpriseMcpOAuthContractError,
   validateMcpAuthorizationResponseIssuer,
 } from "@openwork/enterprise-mcp-client"
 import { and, desc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
@@ -49,6 +50,7 @@ import {
   disconnectExternalMcpMemberAccount,
   externalMcpIdentityBinding,
   getExternalMcpConnection,
+  isolateExternalMcpOAuthCallback,
   listActiveExternalMcpConnectionBindings,
   listDirectExternalMcpConnectionAccess,
   listExternalMcpConnections,
@@ -315,7 +317,7 @@ const connectionResponseSchema = z.object({
   oauthCallbackUrl: z.string().nullable().optional(),
   oauthSharedCallbackUrl: z.string().nullable().optional(),
   oauthClientMetadataUrl: z.string().nullable().optional(),
-  oauthCallbackMode: z.enum(["shared-v1", "legacy-v1"]).nullable().optional(),
+  oauthCallbackMode: z.enum(["shared-v1", "isolated-v1", "legacy-v1"]).nullable().optional(),
   oauthRegistrationSource: z.enum(["pre-registered", "client-metadata", "dynamic"]).nullable().optional(),
   authorizationServerIssuer: z.string().nullable().optional(),
   requestedScopes: z.array(z.string()).optional(),
@@ -594,6 +596,29 @@ type ConnectionRequiredBy = {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function oauthAuthorizationServerMetadata(connection: ExternalMcpConnectionRow): Record<string, unknown> | undefined {
+  const discovery = connection.oauthConfiguration?.discovery
+  if (!isRecord(discovery) || !isRecord(discovery.authorizationServerMetadata)) return undefined
+  return discovery.authorizationServerMetadata
+}
+
+function requiresIsolatedOAuthCallback(connection: ExternalMcpConnectionRow): boolean {
+  const metadata = oauthAuthorizationServerMetadata(connection)
+  return connection.oauthConfiguration?.callbackMode === "shared-v1"
+    && metadata !== undefined
+    && metadata.authorization_response_iss_parameter_supported !== true
+}
+
+function assertIsolatedOAuthCallbackSafety(connection: ExternalMcpConnectionRow): void {
+  const methods = oauthAuthorizationServerMetadata(connection)?.code_challenge_methods_supported
+  if (!Array.isArray(methods) || !methods.includes("S256")) {
+    throw new EnterpriseMcpOAuthContractError(
+      "MCP_OAUTH_CONFIGURATION_REQUIRED",
+      "This authorization server omits response issuers and cannot use the isolated callback because it does not advertise PKCE S256.",
+    )
+  }
 }
 
 function parseJsonObject(value: string | null): Record<string, unknown> | null {
@@ -911,7 +936,7 @@ function mcpOAuthCallbackHtml(html: string, status = 200): Response {
 async function handleExternalMcpOAuthCallback(input: {
   request: Request
   requestId: string
-  legacyConnectionId?: string
+  scopedConnectionId?: string
 }): Promise<Response> {
   const url = new URL(input.request.url)
   const state = url.searchParams.get("state")
@@ -924,17 +949,17 @@ async function handleExternalMcpOAuthCallback(input: {
     return invalidMcpOAuthCallback("Invalid or expired state.")
   }
 
-  const isLegacyRoute = input.legacyConnectionId !== undefined
+  const isScopedRoute = input.scopedConnectionId !== undefined
   const callbackMode = statePayload.version === 2 ? statePayload.callbackMode : "legacy-v1"
   // Version-two transactions can use either callback, but the route and the
   // signed callback mode must agree. Version-one transactions remain bound to
   // the legacy runtime and per-connection compatibility route.
-  if (!isLegacyRoute && (statePayload.version !== 2 || callbackMode !== "shared-v1")) {
+  if (!isScopedRoute && (statePayload.version !== 2 || callbackMode !== "shared-v1")) {
     return invalidMcpOAuthCallback("This authorization callback must use the shared callback selected when authorization started.")
   }
-  if (isLegacyRoute && (
-    statePayload.providerId !== input.legacyConnectionId
-    || (statePayload.version === 2 && callbackMode !== "legacy-v1")
+  if (isScopedRoute && (
+    statePayload.providerId !== input.scopedConnectionId
+    || (statePayload.version === 2 && callbackMode !== "isolated-v1" && callbackMode !== "legacy-v1")
   )) {
     return invalidMcpOAuthCallback("Invalid or expired state.")
   }
@@ -997,11 +1022,23 @@ async function handleExternalMcpOAuthCallback(input: {
       ? (url.searchParams.get("iss") ?? "")
       : undefined
     try {
-      validateMcpAuthorizationResponseIssuer({
+      const validation = validateMcpAuthorizationResponseIssuer({
         expectedIssuer: configuredIssuer,
         discoveryState: connection.oauthConfiguration?.discovery,
         responseIssuer,
+        mixUpDefense: callbackMode === "isolated-v1"
+          ? "distinct-redirect-uri"
+          : callbackMode === "legacy-v1"
+            ? "legacy"
+            : "response-issuer",
       })
+      if (validation.ignoredResponseIssuer !== undefined) {
+        logger.warn("external_mcp_connect_callback_untrusted_issuer_ignored", {
+          connection_id: connection.id,
+          organization_id: statePayload.organizationId,
+          mix_up_defense: validation.defense,
+        })
+      }
     } catch (error) {
       try {
         await abandonAuthorization(connection, state, member, input.requestId)
@@ -2034,22 +2071,54 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
         // any spec-compliant authorization server (see ExternalMcpOAuthProvider.state()).
         // New rows store shared-v1. Existing rows keep legacy-v1 so reconnects
         // continue using the callback already registered with the provider.
-        const callbackMode = connection.oauthConfiguration?.callbackMode ?? "legacy-v1"
-        const signedState = createOAuthStateToken({
-          organizationId: payload.organization.id,
-          orgMembershipId: payload.currentMember.id,
-          providerId: connectionId,
-          binding: externalMcpIdentityBinding(connection),
-          version: 2,
-          callbackMode,
-          authorizationServerIssuer: connection.oauthConfiguration?.authorizationServerIssuer ?? undefined,
-          secret: env.betterAuthSecret,
-        })
-        const redirectUri = callbackRedirectUri(connection)
         const member = connection.credentialMode === "per_member"
           ? { orgMembershipId: payload.currentMember.id }
           : undefined
-        const result = await connectExternalMcp(connection, redirectUri, signedState, member, c.get("requestId"))
+        const beginAuthorization = async (target: ExternalMcpConnectionRow) => {
+          const callbackMode = target.oauthConfiguration?.callbackMode ?? "legacy-v1"
+          const signedState = createOAuthStateToken({
+            organizationId: payload.organization.id,
+            orgMembershipId: payload.currentMember.id,
+            providerId: connectionId,
+            binding: externalMcpIdentityBinding(target),
+            version: 2,
+            callbackMode,
+            authorizationServerIssuer: target.oauthConfiguration?.authorizationServerIssuer ?? undefined,
+            secret: env.betterAuthSecret,
+          })
+          const result = await connectExternalMcp(
+            target,
+            callbackRedirectUri(target),
+            signedState,
+            member,
+            c.get("requestId"),
+          )
+          return { result, signedState }
+        }
+
+        let started = await beginAuthorization(connection)
+        if (started.result.status === "needs_auth" && connection.oauthConfiguration?.callbackMode === "shared-v1") {
+          const discovered = await getExternalMcpConnection({
+            organizationId: payload.organization.id,
+            connectionId: externalMcpConnectionId,
+          })
+          if (discovered && requiresIsolatedOAuthCallback(discovered)) {
+            assertIsolatedOAuthCallbackSafety(discovered)
+            await abandonExternalMcpAuth(discovered, started.signedState, member, c.get("requestId"))
+            connection = await isolateExternalMcpOAuthCallback({
+              organizationId: payload.organization.id,
+              connectionId: externalMcpConnectionId,
+            })
+            logger.info("external_mcp_oauth_isolated_callback_selected", {
+              connection_id: connection.id,
+              organization_id: payload.organization.id,
+              authorization_server_issuer: connection.oauthConfiguration?.authorizationServerIssuer,
+            })
+            started = await beginAuthorization(connection)
+          }
+        }
+
+        const { result } = started
         if (result.status === "connected") {
           return c.json({ status: "connected" as const, authorizeUrl: null })
         }
@@ -2124,7 +2193,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
     async (c) => handleExternalMcpOAuthCallback({
       request: c.req.raw,
       requestId: c.get("requestId"),
-      legacyConnectionId: c.req.valid("param").connectionId,
+      scopedConnectionId: c.req.valid("param").connectionId,
     }),
   )
 }

--- a/ee/apps/den-api/test/generic-oauth-state.test.ts
+++ b/ee/apps/den-api/test/generic-oauth-state.test.ts
@@ -34,8 +34,9 @@ function versionTwoState(callbackMode?: string) {
 }
 
 describe("version-two OAuth state validation", () => {
-  test("accepts only the two supported callback modes", () => {
+  test("accepts only the supported callback modes", () => {
     expect(verifyOAuthStateToken({ token: versionTwoState("shared-v1"), secret, now: 1_700_000_100 })).not.toBeNull()
+    expect(verifyOAuthStateToken({ token: versionTwoState("isolated-v1"), secret, now: 1_700_000_100 })).not.toBeNull()
     expect(verifyOAuthStateToken({ token: versionTwoState("legacy-v1"), secret, now: 1_700_000_100 })).not.toBeNull()
     expect(verifyOAuthStateToken({ token: versionTwoState("future-v1"), secret, now: 1_700_000_100 })).toBeNull()
     expect(verifyOAuthStateToken({ token: versionTwoState(), secret, now: 1_700_000_100 })).toBeNull()

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -15,6 +15,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
+function isStringArray(value: unknown): value is string[] {
+  return Array.isArray(value) && value.every((entry) => typeof entry === "string")
+}
+
 let app: typeof import("../src/app.js").default
 let db: typeof import("../src/db.js").db
 let schema: typeof import("@openwork-ee/den-db/schema")
@@ -22,6 +26,7 @@ let drizzle: typeof import("@openwork-ee/den-db/drizzle")
 let session: typeof import("../src/session.js")
 let createExternalMcpConnection: typeof import("../src/capability-sources/external-mcp-connections.js").createExternalMcpConnection
 let externalMcpIdentityBinding: typeof import("../src/capability-sources/external-mcp-connections.js").externalMcpIdentityBinding
+let isolateExternalMcpOAuthCallback: typeof import("../src/capability-sources/external-mcp-connections.js").isolateExternalMcpOAuthCallback
 let createOAuthStateToken: typeof import("../src/capability-sources/generic-oauth.js").createOAuthStateToken
 let upsertOrgOAuthClient: typeof import("../src/capability-sources/oauth-credentials.js").upsertOrgOAuthClient
 let getOrgOAuthClient: typeof import("../src/capability-sources/oauth-credentials.js").getOrgOAuthClient
@@ -62,6 +67,7 @@ beforeAll(async () => {
   session = sessionMod
   createExternalMcpConnection = connectionsMod.createExternalMcpConnection
   externalMcpIdentityBinding = connectionsMod.externalMcpIdentityBinding
+  isolateExternalMcpOAuthCallback = connectionsMod.isolateExternalMcpOAuthCallback
   createOAuthStateToken = genericOAuthMod.createOAuthStateToken
   upsertOrgOAuthClient = oauthCredentialsMod.upsertOrgOAuthClient
   getOrgOAuthClient = oauthCredentialsMod.getOrgOAuthClient
@@ -279,6 +285,204 @@ test("public client metadata exposes only the deployment-wide web callback", asy
   })
 })
 
+test("callback isolation replaces SDK registration state and exposes the scoped callback", async () => {
+  const issuer = "https://legacy-issuer.example.test"
+  const connection = await createExternalMcpConnection({
+    organizationId,
+    name: "Issuer-isolated OAuth MCP",
+    url: "http://127.0.0.1:9/isolated-mcp",
+    authType: "oauth",
+    credentialMode: "shared",
+    createdByOrgMembershipId: memberId,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+  })
+  await db
+    .update(schema.ExternalMcpConnectionTable)
+    .set({
+      oauthConfiguration: {
+        version: 1,
+        authorizationServerIssuer: issuer,
+        requestedScopes: [],
+        callbackMode: "shared-v1",
+        discovery: {
+          authorizationServerUrl: issuer,
+          authorizationServerMetadata: {
+            issuer,
+            authorization_response_iss_parameter_supported: false,
+            code_challenge_methods_supported: ["S256"],
+          },
+          resourceMetadata: { authorization_servers: [issuer] },
+        },
+      },
+    })
+    .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connection.id))
+  await upsertOrgOAuthClient({
+    organizationId,
+    providerId: connection.id,
+    clientId: "https://den.example.test/oauth/client-metadata.json",
+    clientSecret: null,
+    extra: {
+      enterpriseMcpRegistrationSource: "client-metadata",
+      registrationContractVersion: 2,
+    },
+    createdByOrgMembershipId: memberId,
+  })
+
+  const isolated = await isolateExternalMcpOAuthCallback({
+    organizationId,
+    connectionId: connection.id,
+  })
+  expect(isolated.oauthConfiguration?.callbackMode).toBe("isolated-v1")
+  expect(await getOrgOAuthClient(organizationId, connection.id)).toBeNull()
+
+  const response = await request("/v1/mcp-connections?scope=manageable")
+  expect(response.status).toBe(200)
+  const body: unknown = await response.json()
+  if (!isRecord(body) || !Array.isArray(body.connections)) throw new Error("Expected manageable connections.")
+  const listed = body.connections.find((entry) => isRecord(entry) && entry.id === connection.id)
+  expect(listed).toMatchObject({
+    oauthCallbackMode: "isolated-v1",
+    oauthCallbackUrl: new URL(
+      `/v1/mcp-connections/${connection.id}/connect/callback`,
+      process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790",
+    ).toString(),
+  })
+})
+
+test("connect start selects an isolated callback before sending the user to a legacy authorization server", async () => {
+  let origin = ""
+  const registeredRedirects: string[][] = []
+  const server = Bun.serve({
+    port: 0,
+    async fetch(incoming) {
+      const url = new URL(incoming.url)
+      if (url.pathname === "/.well-known/oauth-protected-resource/mcp") {
+        return Response.json({
+          resource: `${origin}/mcp`,
+          authorization_servers: [origin],
+        })
+      }
+      if (url.pathname === "/.well-known/oauth-authorization-server") {
+        return Response.json({
+          issuer: origin,
+          authorization_endpoint: `${origin}/authorize`,
+          token_endpoint: `${origin}/token`,
+          registration_endpoint: `${origin}/register`,
+          response_types_supported: ["code"],
+          grant_types_supported: ["authorization_code"],
+          code_challenge_methods_supported: ["S256"],
+          token_endpoint_auth_methods_supported: ["none"],
+        })
+      }
+      if (url.pathname === "/register") {
+        const metadata: unknown = await incoming.json()
+        const redirectUris = isRecord(metadata) && isStringArray(metadata.redirect_uris)
+          ? metadata.redirect_uris
+          : []
+        registeredRedirects.push(redirectUris)
+        return Response.json({
+          client_id: `dynamic-client-${registeredRedirects.length}`,
+          token_endpoint_auth_method: "none",
+          redirect_uris: redirectUris,
+        }, { status: 201 })
+      }
+      if (url.pathname === "/token") {
+        const form = new URLSearchParams(await incoming.text())
+        expect(form.get("grant_type")).toBe("authorization_code")
+        expect(form.get("code")).toBe("isolated-authorization-code")
+        expect(form.get("code_verifier")?.length).toBeGreaterThanOrEqual(43)
+        return Response.json({
+          access_token: "isolated-access-token",
+          refresh_token: "isolated-refresh-token",
+          token_type: "Bearer",
+          expires_in: 3_600,
+        })
+      }
+      if (url.pathname === "/mcp") {
+        if (incoming.headers.get("authorization") === "Bearer isolated-access-token") {
+          if (incoming.method !== "POST") return new Response(null, { status: 405 })
+          const rpc: unknown = await incoming.json()
+          if (!isRecord(rpc)) return Response.json({ error: "invalid_request" }, { status: 400 })
+          if (rpc.method === "notifications/initialized") return new Response(null, { status: 202 })
+          const id = typeof rpc.id === "string" || typeof rpc.id === "number" ? rpc.id : null
+          if (rpc.method === "tools/list") {
+            return Response.json({ jsonrpc: "2.0", id, result: { tools: [] } })
+          }
+          return Response.json({
+            jsonrpc: "2.0",
+            id,
+            result: {
+              protocolVersion: "2025-06-18",
+              capabilities: { tools: {} },
+              serverInfo: { name: "isolated-callback-test", version: "1.0.0" },
+            },
+          })
+        }
+        return new Response(null, {
+          status: 401,
+          headers: {
+            "www-authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,
+          },
+        })
+      }
+      return new Response(null, { status: 404 })
+    },
+  })
+  origin = `http://127.0.0.1:${server.port}`
+
+  try {
+    const connection = await createExternalMcpConnection({
+      organizationId,
+      name: "Automatic isolated callback MCP",
+      url: `${origin}/mcp`,
+      authType: "oauth",
+      credentialMode: "shared",
+      createdByOrgMembershipId: memberId,
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    })
+    const response = await request(`/v1/mcp-connections/${connection.id}/connect/start`)
+    expect(response.status).toBe(200)
+    const body: unknown = await response.json()
+    if (!isRecord(body) || typeof body.authorizeUrl !== "string") throw new Error("Expected an OAuth authorize URL.")
+    const authorizeUrl = new URL(body.authorizeUrl)
+    const isolatedCallback = new URL(
+      `/v1/mcp-connections/${connection.id}/connect/callback`,
+      process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790",
+    ).toString()
+    expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(isolatedCallback)
+    expect(registeredRedirects).toHaveLength(2)
+    expect(registeredRedirects[0]).toEqual([
+      new URL("/v1/mcp-connections/oauth/callback", process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790").toString(),
+    ])
+    expect(registeredRedirects[1]).toEqual([isolatedCallback])
+
+    const rows = await db
+      .select()
+      .from(schema.ExternalMcpConnectionTable)
+      .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connection.id))
+      .limit(1)
+    expect(rows[0]?.oauthConfiguration?.callbackMode).toBe("isolated-v1")
+
+    const callbackUrl = new URL(isolatedCallback)
+    callbackUrl.searchParams.set("code", "isolated-authorization-code")
+    callbackUrl.searchParams.set("state", authorizeUrl.searchParams.get("state") ?? "")
+    callbackUrl.searchParams.set("iss", "stytch.com/project-live-provider-value")
+    const callbackResponse = await app.fetch(new Request(callbackUrl))
+    expect(callbackResponse.status).toBe(200)
+    expect(await callbackResponse.text()).toContain("You're connected")
+
+    const connectedRows = await db
+      .select()
+      .from(schema.ExternalMcpConnectionTable)
+      .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connection.id))
+      .limit(1)
+    expect(connectedRows[0]?.accessToken).toBe("isolated-access-token")
+    expect(connectedRows[0]?.refreshToken).toBe("isolated-refresh-token")
+  } finally {
+    server.stop(true)
+  }
+})
+
 test("shared callback rejects missing or tampered state before routing", async () => {
   const missing = await app.fetch(new Request("http://den-api.local/v1/mcp-connections/oauth/callback?code=unused"))
   expect(missing.status).toBe(400)
@@ -391,6 +595,54 @@ test("shared callback validates a required response issuer before acting on prov
   expect(html).toContain("authorization server")
   expect(html).not.toContain("must-not-be-rendered")
   expect(html).not.toContain("did not grant authorization")
+})
+
+test("issuer-isolated callback tolerates an unadvertised provider issuer without trusting it", async () => {
+  const issuer = "https://api.provider.example"
+  await db
+    .update(schema.ExternalMcpConnectionTable)
+    .set({
+      oauthConfiguration: {
+        version: 1,
+        authorizationServerIssuer: issuer,
+        requestedScopes: [],
+        callbackMode: "isolated-v1",
+        discovery: {
+          authorizationServerUrl: issuer,
+          authorizationServerMetadata: {
+            issuer,
+            authorization_response_iss_parameter_supported: false,
+            code_challenge_methods_supported: ["S256"],
+          },
+          resourceMetadata: { authorization_servers: [issuer] },
+        },
+      },
+    })
+    .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, seededConnectionId()))
+  const state = createOAuthStateToken({
+    organizationId,
+    orgMembershipId: memberId,
+    providerId: seededConnectionId(),
+    binding: externalMcpIdentityBinding({
+      url: "http://127.0.0.1:9/mcp",
+      authType: "oauth",
+      credentialMode: "per_member",
+    }),
+    version: 2,
+    callbackMode: "isolated-v1",
+    authorizationServerIssuer: issuer,
+    secret: process.env.BETTER_AUTH_SECRET ?? "",
+  })
+  const callbackUrl = new URL(`http://den-api.local/v1/mcp-connections/${seededConnectionId()}/connect/callback`)
+  callbackUrl.searchParams.set("error", "access_denied")
+  callbackUrl.searchParams.set("iss", "stytch.com/project-live-provider-value")
+  callbackUrl.searchParams.set("state", state)
+
+  const response = await app.fetch(new Request(callbackUrl))
+  expect(response.status).toBe(400)
+  const html = await response.text()
+  expect(html).toContain("The provider did not grant authorization")
+  expect(html).not.toContain("does not match the issuer")
 })
 
 test("version-one state remains temporarily valid only through the legacy callback route", async () => {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -65,7 +65,7 @@ export type ExternalMcpConnection = {
   oauthCallbackUrl?: string | null;
   oauthSharedCallbackUrl?: string | null;
   oauthClientMetadataUrl?: string | null;
-  oauthCallbackMode?: "shared-v1" | "legacy-v1" | null;
+  oauthCallbackMode?: "shared-v1" | "isolated-v1" | "legacy-v1" | null;
   oauthRegistrationSource?: "pre-registered" | "client-metadata" | "dynamic" | null;
   authorizationServerIssuer?: string | null;
   requestedScopes?: string[];

--- a/ee/packages/den-db/src/schema/sharables/capability-credentials.ts
+++ b/ee/packages/den-db/src/schema/sharables/capability-credentials.ts
@@ -113,7 +113,7 @@ export type ExternalMcpAuthType = (typeof externalMcpAuthTypeValues)[number]
 export const externalMcpCredentialModeValues = ["shared", "per_member"] as const
 export type ExternalMcpCredentialMode = (typeof externalMcpCredentialModeValues)[number]
 
-export const externalMcpOAuthCallbackModeValues = ["shared-v1", "legacy-v1"] as const
+export const externalMcpOAuthCallbackModeValues = ["shared-v1", "isolated-v1", "legacy-v1"] as const
 export type ExternalMcpOAuthCallbackMode = (typeof externalMcpOAuthCallbackModeValues)[number]
 
 export type ExternalMcpOAuthConfiguration = {

--- a/packages/enterprise-mcp-client/src/authorization-response.ts
+++ b/packages/enterprise-mcp-client/src/authorization-response.ts
@@ -9,18 +9,30 @@ function optionalString(value: unknown): string | undefined {
   return typeof value === "string" && value.length > 0 ? value : undefined
 }
 
+export type McpAuthorizationResponseMixUpDefense =
+  | "response-issuer"
+  | "distinct-redirect-uri"
+  | "legacy"
+
+export type McpAuthorizationResponseIssuerValidation = {
+  defense: McpAuthorizationResponseMixUpDefense
+  ignoredResponseIssuer?: string
+}
+
 /**
- * Validate the RFC 9207 issuer on an OAuth authorization response before a
- * code is sent to a token endpoint or a provider error is acted upon.
- * Comparisons are deliberately exact: issuer identifiers must not be URL
- * normalized before comparison.
+ * Validate the OAuth mix-up defense before a code is sent to a token endpoint
+ * or a provider error is acted upon. Shared callbacks require RFC 9207 issuer
+ * identification. A caller may instead prove an issuer-specific redirect URI
+ * per RFC 9700; only then may an unadvertised provider `iss` be treated as
+ * untrusted compatibility data. Exact issuer comparisons are never normalized.
  */
 export function validateMcpAuthorizationResponseIssuer(input: {
   expectedIssuer?: string | null
   discoveryState?: unknown
   /** Undefined means the response omitted `iss`; an empty value is present and invalid. */
   responseIssuer?: string
-}): void {
+  mixUpDefense?: McpAuthorizationResponseMixUpDefense
+}): McpAuthorizationResponseIssuerValidation {
   const discovery = isRecord(input.discoveryState) ? input.discoveryState : undefined
   const authorizationServerMetadata = isRecord(discovery?.authorizationServerMetadata)
     ? discovery.authorizationServerMetadata
@@ -64,12 +76,21 @@ export function validateMcpAuthorizationResponseIssuer(input: {
 
   if (input.responseIssuer !== undefined) {
     if (input.responseIssuer !== expectedIssuer) {
+      if (
+        input.mixUpDefense === "distinct-redirect-uri"
+        && authorizationServerMetadata?.authorization_response_iss_parameter_supported !== true
+      ) {
+        return {
+          defense: "distinct-redirect-uri",
+          ignoredResponseIssuer: input.responseIssuer,
+        }
+      }
       throw new EnterpriseMcpOAuthContractError(
         "MCP_OAUTH_ISSUER_MISMATCH",
         "The OAuth authorization response issuer does not match the issuer selected for this MCP connection.",
       )
     }
-    return
+    return { defense: input.mixUpDefense ?? "response-issuer" }
   }
 
   if (authorizationServerMetadata?.authorization_response_iss_parameter_supported === true) {
@@ -78,4 +99,13 @@ export function validateMcpAuthorizationResponseIssuer(input: {
       "The OAuth authorization response omitted the issuer required by the authorization-server metadata.",
     )
   }
+
+  if ((input.mixUpDefense ?? "response-issuer") === "response-issuer") {
+    throw new EnterpriseMcpOAuthContractError(
+      "MCP_OAUTH_ISSUER_MISMATCH",
+      "The shared OAuth callback requires an authorization-response issuer.",
+    )
+  }
+
+  return { defense: input.mixUpDefense ?? "legacy" }
 }

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -653,6 +653,54 @@ describe("enterprise MCP OAuth persistence contract", () => {
       && error.code === "MCP_OAUTH_ISSUER_MISMATCH")
   })
 
+  it("uses a distinct redirect URI as the mix-up defense for servers that do not advertise response issuers", () => {
+    const expectedIssuer = "https://identity.example.test/tenant"
+    const discoveryState = {
+      authorizationServerUrl: expectedIssuer,
+      authorizationServerMetadata: {
+        issuer: expectedIssuer,
+        authorization_response_iss_parameter_supported: false,
+      },
+      resourceMetadata: { authorization_servers: [expectedIssuer] },
+    }
+
+    assert.deepEqual(validateMcpAuthorizationResponseIssuer({
+      expectedIssuer,
+      discoveryState,
+      mixUpDefense: "distinct-redirect-uri",
+    }), { defense: "distinct-redirect-uri" })
+    assert.deepEqual(validateMcpAuthorizationResponseIssuer({
+      expectedIssuer,
+      discoveryState,
+      responseIssuer: "stytch.com/project-live-provider-value",
+      mixUpDefense: "distinct-redirect-uri",
+    }), {
+      defense: "distinct-redirect-uri",
+      ignoredResponseIssuer: "stytch.com/project-live-provider-value",
+    })
+  })
+
+  it("never lets PKCE or an isolated callback override advertised RFC 9207 support", () => {
+    const expectedIssuer = "https://identity.example.test/tenant"
+    const discoveryState = {
+      authorizationServerUrl: expectedIssuer,
+      authorizationServerMetadata: {
+        issuer: expectedIssuer,
+        authorization_response_iss_parameter_supported: true,
+        code_challenge_methods_supported: ["S256"],
+      },
+      resourceMetadata: { authorization_servers: [expectedIssuer] },
+    }
+
+    assert.throws(() => validateMcpAuthorizationResponseIssuer({
+      expectedIssuer,
+      discoveryState,
+      responseIssuer: "https://attacker.example.test",
+      mixUpDefense: "distinct-redirect-uri",
+    }), (error: unknown) => error instanceof EnterpriseMcpOAuthContractError
+      && error.code === "MCP_OAUTH_ISSUER_MISMATCH")
+  })
+
   it("binds a resource-scoped discovery alias to its canonical callback issuer", async () => {
     const alias = "https://api.salesforce.example:443/platform/mcp/v1/platform/sobject-all"
     const canonicalIssuer = "https://login.salesforce.example"


### PR DESCRIPTION
## Summary

- keep the deployment-wide shared callback strict for authorization servers that advertise RFC 9207 response issuers
- automatically switch an OAuth connection to a connection-specific callback when discovery does not advertise response-issuer support and does advertise PKCE S256
- treat an unexpected `iss` as untrusted compatibility data only after the distinct redirect URI is active; it is never used to select an issuer or token endpoint
- restart dynamic client registration before opening the authorization page so the registered and requested redirect URIs remain exact
- require pre-registered clients to allowlist and persist the exact connection-specific callback before reconnecting

This is a general protocol-level follow-up to #2853. It does not contain a provider hostname allowlist or a user-facing security toggle.

## Problem

Some authorization servers do not advertise RFC 9207 authorization-response issuer support, but still return a malformed or provider-internal `iss` value. Exact issuer validation correctly stops those callbacks before token exchange, while globally ignoring issuer mismatches would weaken OAuth mix-up protection.

PKCE and signed state are retained, but neither is treated as a replacement for mix-up protection.

## Security model

- **RFC 9207 path:** shared callback, exact issuer match, fail closed on missing or mismatched `iss`
- **RFC 9700 fallback:** redirect URI unique to the MCP connection, signed state bound to organization/member/connection/issuer/callback mode, and PKCE S256
- an isolated callback is selected only from discovered authorization-server metadata; providers advertising response-issuer support remain on the strict path
- malformed or mismatched response issuers are ignored only on the isolated path and are logged without recording their raw value
- token exchange continues against the issuer and endpoints selected during validated discovery, never against response parameters

## Connection lifecycle

1. Start with the normal shared callback and perform MCP/OAuth discovery.
2. If response-issuer support is absent and PKCE S256 is available, abandon that pending transaction.
3. Persist `isolated-v1`, invalidate incompatible SDK registration/token state, and restart registration using the connection-specific callback.
4. Complete the callback using the signed state and isolated redirect as the mix-up defense.

For a pre-registered OAuth client, the administrator must add the exact connection-specific callback and re-save the client configuration. Existing legacy callback connections remain unchanged.

## Validation

- `pnpm --dir packages/enterprise-mcp-client test` — 44 passed
- `pnpm --dir ee/apps/den-api exec bun test test/generic-oauth-state.test.ts test/mcp-connections-connect-start.test.ts` — 19 passed, 111 assertions
- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit --pretty false` — passed
- `pnpm --dir ee/apps/den-web exec tsc -p tsconfig.json --noEmit --pretty false` — passed
- `git diff --check upstream/dev...HEAD` — passed

The Den route test exercises discovery, two registrations, isolated redirect selection, signed state, malformed provider `iss`, PKCE token exchange, authenticated MCP initialization/tool discovery, and encrypted credential persistence. Strict shared and existing legacy callback coverage also passes.

## CI status

The initial GitHub Actions attempt and one failed-job retry both stopped before project code ran because `api.github.com` returned HTTP 503. Test runners failed while fetching Bun; image builds failed in Docker metadata with GitHub's 503 response. Schema/migration, Helm, and i18n checks pass. No code change was made for this external failure.

## Risks and limits

- selecting the isolated mode invalidates incompatible SDK registration and connected-account credentials for that connection because the OAuth client redirect contract changes
- providers without dynamic registration require administrator action to allowlist the scoped callback
- the deterministic end-to-end provider simulation passes; a live Descript consent flow was not run because it requires an external user authorization session
- no database migration is required; callback mode is stored in the existing OAuth configuration JSON