### PR TITLE
fix(mcp): keep browser sign-in reusable

### DIFF
--- a/apps/app/src/components/chat/message-list-provider.tsx
+++ b/apps/app/src/components/chat/message-list-provider.tsx
@@ -25,6 +25,7 @@ interface MessageListContextValue {
     action: ChatToolReconnectAction,
     onProgress: (progress: ChatToolReconnectProgress) => void,
   ) => Promise<ChatToolReconnectResult>
+  onMcpReopenAuthorization: (action: ChatToolReconnectAction, authorizeUrl: string) => Promise<void>
   onMcpRetry: (action: ChatToolReconnectAction) => void | Promise<void>
 }
 
@@ -44,6 +45,7 @@ interface MessageListProviderProps {
     action: ChatToolReconnectAction,
     onProgress: (progress: ChatToolReconnectProgress) => void,
   ) => Promise<ChatToolReconnectResult>
+  onMcpReopenAuthorization: (action: ChatToolReconnectAction, authorizeUrl: string) => Promise<void>
   onMcpRetry: (action: ChatToolReconnectAction) => void | Promise<void>
   displaySuggestions: boolean
   providerConnectedCount: number
@@ -72,6 +74,7 @@ export function MessageListProvider({
   onForkAtMessage,
   onEditUserMessage,
   onMcpReconnect,
+  onMcpReopenAuthorization,
   onMcpRetry,
 }: MessageListProviderProps) {
   const value = React.useMemo(
@@ -89,6 +92,7 @@ export function MessageListProvider({
       onForkAtMessage,
       onEditUserMessage,
       onMcpReconnect,
+      onMcpReopenAuthorization,
       onMcpRetry,
     }),
     [
@@ -105,6 +109,7 @@ export function MessageListProvider({
       onForkAtMessage,
       onEditUserMessage,
       onMcpReconnect,
+      onMcpReopenAuthorization,
       onMcpRetry,
     ],
   )

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -136,7 +136,7 @@ class ToolMessage extends React.Component<ToolMessageProps, { failed: boolean }>
 }
 
 const ToolMessageInner = ({ part }: ToolMessageProps) => {
-  const { onMcpReconnect, onMcpRetry } = useMessageList()
+  const { onMcpReconnect, onMcpReopenAuthorization, onMcpRetry } = useMessageList()
 
   if (isBashToolPart(part)) {
     return <BashTool part={part} />
@@ -194,7 +194,14 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
     return <EnvVarRequestTool part={part} />
   }
 
-  return <Tool toolPart={part} onReconnect={onMcpReconnect} onRetry={onMcpRetry} />
+  return (
+    <Tool
+      toolPart={part}
+      onReconnect={onMcpReconnect}
+      onReopenAuthorization={onMcpReopenAuthorization}
+      onRetry={onMcpRetry}
+    />
+  )
 }
 
 const isEmptyMessage = (message: UIMessage): boolean => message.parts.length === 0

--- a/apps/app/src/components/tools/error-attribution.ts
+++ b/apps/app/src/components/tools/error-attribution.ts
@@ -12,7 +12,9 @@ export type ChatToolReconnectAction = {
   label: string
 }
 
-export type ChatToolReconnectProgress = "opening" | "authorization_opened"
+export type ChatToolReconnectProgress =
+  | { phase: "opening" }
+  | { phase: "authorization_opened"; authorizeUrl: string }
 export type ChatToolReconnectResult = "connected"
 
 const OPENWORK_CLOUD_CAPABILITY_TOOLS = new Set([

--- a/apps/app/src/components/tools/mcp-reconnect-state.ts
+++ b/apps/app/src/components/tools/mcp-reconnect-state.ts
@@ -12,6 +12,7 @@ export type ChatMcpReconnectPhase =
 export type ChatMcpReconnectRecord = {
   phase: ChatMcpReconnectPhase
   error: string | null
+  authorizeUrl: string | null
 }
 
 type ChatMcpReconnectStore = {
@@ -20,7 +21,7 @@ type ChatMcpReconnectStore = {
   reset: () => void
 }
 
-const READY_RECORD: ChatMcpReconnectRecord = { phase: "ready", error: null }
+const READY_RECORD: ChatMcpReconnectRecord = { phase: "ready", error: null, authorizeUrl: null }
 
 export function chatMcpReconnectKey(toolCallId: string, connectionId: string): string {
   return `${toolCallId}:${connectionId}`
@@ -52,7 +53,7 @@ export function chatMcpReconnectPresentation(
     case "opening":
       return { badgeLabel: "Reconnect required", buttonLabel: "Opening sign-in…", disabled: true }
     case "authorization_opened":
-      return { badgeLabel: "Reconnect required", buttonLabel: "Finish in browser", disabled: true }
+      return { badgeLabel: "Reconnect required", buttonLabel: "Open sign-in again", disabled: false }
     case "connected":
       return { badgeLabel: "Reconnected", buttonLabel: "Try again", disabled: false }
     case "failed":

--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -78,6 +78,7 @@ export type ToolProps = {
     action: ChatToolReconnectAction,
     onProgress: (progress: ChatToolReconnectProgress) => void,
   ) => Promise<ChatToolReconnectResult>
+  onReopenAuthorization?: (action: ChatToolReconnectAction, authorizeUrl: string) => Promise<void>
   onRetry?: (action: ChatToolReconnectAction) => void | Promise<void>
 }
 
@@ -147,7 +148,15 @@ function reconnectAttribution(action: ChatToolReconnectAction, label: string): T
   }
 }
 
-const Tool = ({ title, toolPart, defaultOpen = false, className, onReconnect, onRetry }: ToolProps) => {
+const Tool = ({
+  title,
+  toolPart,
+  defaultOpen = false,
+  className,
+  onReconnect,
+  onReopenAuthorization,
+  onRetry,
+}: ToolProps) => {
   const { state, input } = toolPart
   const inFlight = isToolPartInFlight(toolPart)
   const isError = state === "output-error"
@@ -167,6 +176,9 @@ const Tool = ({ title, toolPart, defaultOpen = false, className, onReconnect, on
   ))
   const reconnectError = useChatMcpReconnectStore((store) => (
     reconnectKey ? store.records[reconnectKey]?.error ?? null : null
+  ))
+  const reconnectAuthorizeUrl = useChatMcpReconnectStore((store) => (
+    reconnectKey ? store.records[reconnectKey]?.authorizeUrl ?? null : null
   ))
   const setReconnectRecord = useChatMcpReconnectStore((store) => store.setRecord)
   const reconnectPresentation = reconnectAction
@@ -194,17 +206,48 @@ const Tool = ({ title, toolPart, defaultOpen = false, className, onReconnect, on
       await onRetry?.(reconnectAction)
       return
     }
-    if (reconnectState === "opening" || reconnectState === "authorization_opened") return
-    setReconnectRecord(reconnectKey, { phase: "opening", error: null })
+    if (reconnectState === "authorization_opened") {
+      if (!onReopenAuthorization) return
+      if (!reconnectAuthorizeUrl) {
+        setReconnectRecord(reconnectKey, {
+          phase: "failed",
+          error: `${reconnectAction.connectionName} sign-in is no longer pending. Try reconnecting again.`,
+          authorizeUrl: null,
+        })
+        return
+      }
+      try {
+        await onReopenAuthorization(reconnectAction, reconnectAuthorizeUrl)
+        setReconnectRecord(reconnectKey, {
+          phase: "authorization_opened",
+          error: null,
+          authorizeUrl: reconnectAuthorizeUrl,
+        })
+      } catch (error) {
+        setReconnectRecord(reconnectKey, {
+          phase: "failed",
+          error: error instanceof Error ? error.message : "Could not reopen sign-in.",
+          authorizeUrl: null,
+        })
+      }
+      return
+    }
+    if (reconnectState === "opening") return
+    setReconnectRecord(reconnectKey, { phase: "opening", error: null, authorizeUrl: null })
     try {
       const result = await onReconnect(reconnectAction, (progress) => {
-        setReconnectRecord(reconnectKey, { phase: progress, error: null })
+        setReconnectRecord(reconnectKey, {
+          phase: progress.phase,
+          error: null,
+          authorizeUrl: progress.phase === "authorization_opened" ? progress.authorizeUrl : null,
+        })
       })
-      setReconnectRecord(reconnectKey, { phase: result, error: null })
+      setReconnectRecord(reconnectKey, { phase: result, error: null, authorizeUrl: null })
     } catch (error) {
       setReconnectRecord(reconnectKey, {
         phase: "failed",
         error: error instanceof Error ? error.message : "Could not reconnect this account.",
+        authorizeUrl: null,
       })
     }
   }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1319,7 +1319,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         sessionId: props.sessionId,
         connectionId: action.connectionId,
       });
-      onProgress("opening");
+      onProgress({ phase: "opening" });
       const result = await denClient.startMcpConnectionConnect(organizationId, action.connectionId);
       if (result.status === "connected") {
         recordInspectorEvent("mcp.chat_reconnect.completed", {
@@ -1333,7 +1333,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       if (!result.authorizeUrl) throw new Error(`Could not start ${action.connectionName} authorization.`);
 
       await openDesktopUrl(result.authorizeUrl);
-      onProgress("authorization_opened");
+      onProgress({ phase: "authorization_opened", authorizeUrl: result.authorizeUrl });
       await waitForFreshMcpAuthorization({
         connectionId: action.connectionId,
         connectionName: action.connectionName,
@@ -1358,6 +1358,18 @@ export function SessionSurface(props: SessionSurfaceProps) {
       throw error;
     }
   }, [props.onOpenConnect, props.sessionId, props.workspaceId]);
+
+  const handleMcpReopenAuthorization = useCallback(async (
+    action: ChatToolReconnectAction,
+    authorizeUrl: string,
+  ) => {
+    await openDesktopUrl(authorizeUrl);
+    recordInspectorEvent("mcp.chat_reconnect.authorization_reopened", {
+      workspaceId: props.workspaceId,
+      sessionId: props.sessionId,
+      connectionId: action.connectionId,
+    });
+  }, [props.sessionId, props.workspaceId]);
 
   const handleMcpRetry = useCallback(async (action: ChatToolReconnectAction) => {
     const prompt = `The ${action.connectionName} connection is restored. Search for the capability again and retry the previous request. Before repeating any write action, confirm it did not already complete.`;
@@ -1560,6 +1572,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
                       onForkAtMessage={handleForkAtMessage}
                       onEditUserMessage={handleEditUserMessage}
                       onMcpReconnect={handleMcpReconnect}
+                      onMcpReopenAuthorization={handleMcpReopenAuthorization}
                       onMcpRetry={handleMcpRetry}
                     >
                       <MessageList

--- a/apps/app/tests/mcp-reconnect-state.test.ts
+++ b/apps/app/tests/mcp-reconnect-state.test.ts
@@ -18,13 +18,33 @@ beforeEach(() => useChatMcpReconnectStore.getState().reset())
 describe("chat MCP reconnect state", () => {
   test("keeps completion by tool call and connection across component remounts", () => {
     const key = chatMcpReconnectKey("call-1", action.connectionId)
-    useChatMcpReconnectStore.getState().setRecord(key, { phase: "connected", error: null })
+    useChatMcpReconnectStore.getState().setRecord(key, { phase: "connected", error: null, authorizeUrl: null })
 
-    expect(chatMcpReconnectRecord(key)).toEqual({ phase: "connected", error: null })
+    expect(chatMcpReconnectRecord(key)).toEqual({ phase: "connected", error: null, authorizeUrl: null })
     expect(chatMcpReconnectRecord(chatMcpReconnectKey("call-2", action.connectionId))).toEqual({
       phase: "ready",
       error: null,
+      authorizeUrl: null,
     })
+  })
+
+  test("keeps the pending browser continuation across chat row remounts", () => {
+    const key = chatMcpReconnectKey("call-1", action.connectionId)
+    const authorizeUrl = "https://provider.example/authorize?state=pending"
+    useChatMcpReconnectStore.getState().setRecord(key, {
+      phase: "authorization_opened",
+      error: null,
+      authorizeUrl,
+    })
+
+    expect(chatMcpReconnectRecord(key)).toEqual({
+      phase: "authorization_opened",
+      error: null,
+      authorizeUrl,
+    })
+
+    useChatMcpReconnectStore.getState().reset()
+    expect(chatMcpReconnectRecord(key)).toEqual({ phase: "ready", error: null, authorizeUrl: null })
   })
 
   test("presents a safe retry only after reconnection completes", () => {
@@ -35,8 +55,8 @@ describe("chat MCP reconnect state", () => {
     })
     expect(chatMcpReconnectPresentation(action, "authorization_opened")).toEqual({
       badgeLabel: "Reconnect required",
-      buttonLabel: "Finish in browser",
-      disabled: true,
+      buttonLabel: "Open sign-in again",
+      disabled: false,
     })
     expect(chatMcpReconnectPresentation(action, "connected")).toEqual({
       badgeLabel: "Reconnected",

--- a/evals/flows/chat-mcp-reconnect.flow.mjs
+++ b/evals/flows/chat-mcp-reconnect.flow.mjs
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process";
+import { mkdir } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
@@ -24,6 +25,7 @@ const state = {
   connectionId: null,
   workspaceId: null,
   reconnectBaselineConnectedAt: null,
+  pendingAuthorizeUrl: null,
   mockChild: null,
   mockOutput: "",
 };
@@ -55,7 +57,7 @@ function startMockServer() {
       HOST: "127.0.0.1",
       PORT: String(MOCK_PORT),
       ISSUER: MOCK_SERVER_URL,
-      AUTO_APPROVE: "1",
+      AUTO_APPROVE: "0",
       STRICT_REFRESH_TOKENS: "1",
       MOCK_ERROR_TOOL_NAME: PROVIDER_ERROR_TOOL,
       MOCK_ERROR_TOOL_TITLE: "Provider Policy Check",
@@ -120,8 +122,25 @@ async function completeConnectionAuthorization() {
     throw new Error(`connect/start failed: ${start.response.status} ${JSON.stringify(start.body).slice(0, 400)}`);
   }
   const authorize = await fetch(start.body.authorizeUrl, { redirect: "manual" });
-  const callbackUrl = authorize.headers.get("location");
+  let callbackUrl = authorize.headers.get("location");
+  if (!callbackUrl) {
+    const approveUrl = new URL(`${MOCK_SERVER_URL}/approve`);
+    approveUrl.search = new URL(start.body.authorizeUrl).search;
+    const approve = await fetch(approveUrl, { method: "POST", redirect: "manual" });
+    callbackUrl = approve.headers.get("location");
+  }
   if (!callbackUrl) throw new Error("Mock provider did not return the Den OAuth callback URL.");
+  const callback = await fetch(callbackUrl);
+  if (!callback.ok) throw new Error(`Den OAuth callback failed: ${callback.status}`);
+}
+
+async function approvePendingAuthorization() {
+  if (!state.pendingAuthorizeUrl) throw new Error("The pending provider authorization URL was not captured.");
+  const approveUrl = new URL(`${MOCK_SERVER_URL}/approve`);
+  approveUrl.search = new URL(state.pendingAuthorizeUrl, MOCK_SERVER_URL).search;
+  const approve = await fetch(approveUrl, { method: "POST", redirect: "manual" });
+  const callbackUrl = approve.headers.get("location");
+  if (!callbackUrl) throw new Error("Mock provider approval did not return the Den OAuth callback URL.");
   const callback = await fetch(callbackUrl);
   if (!callback.ok) throw new Error(`Den OAuth callback failed: ${callback.status}`);
 }
@@ -130,6 +149,96 @@ async function usableConnection() {
   const result = await denApiFetch("/v1/mcp-connections?scope=usable");
   if (!result.response.ok) throw new Error(`Connection list failed: ${result.response.status}`);
   return (result.body.connections ?? []).find((entry) => entry.id === state.connectionId) ?? null;
+}
+
+async function readRuntimeCloudControlMcp(ctx) {
+  return ctx.eval(`(async () => {
+    const port = localStorage.getItem('openwork.server.port');
+    const token = localStorage.getItem('openwork.server.token');
+    const hostToken = localStorage.getItem('openwork.server.hostToken');
+    if (!port || !token) return { ok: false, reason: 'missing server auth' };
+    const headers = { Authorization: 'Bearer ' + token };
+    if (hostToken) headers['X-OpenWork-Host-Token'] = hostToken;
+    const base = 'http://127.0.0.1:' + port + '/workspace/' + ${JSON.stringify(state.workspaceId ?? "")};
+    const [response, healthResponse] = await Promise.all([
+      fetch(base + '/mcp', { headers }),
+      fetch(base + '/mcp/openwork-cloud/health?probe=1', { headers }),
+    ]);
+    const [text, healthText] = await Promise.all([response.text(), healthResponse.text()]);
+    let payload = null;
+    try { payload = JSON.parse(text); } catch {}
+    let health = null;
+    try { health = JSON.parse(healthText); } catch {}
+    if (!response.ok) return { ok: false, reason: 'mcp endpoint failed', status: response.status, text };
+    if (!healthResponse.ok) return { ok: false, reason: 'health endpoint failed', status: healthResponse.status, text: healthText };
+    const items = payload?.items ?? [];
+    const entry = items.find((item) => item.name === 'openwork-cloud');
+    const engineSync = payload?.engineSync?.status ?? null;
+    const directTools = health?.tools?.direct?.present ?? [];
+    return {
+      ok: Boolean(
+        entry?.config?.url?.includes('/mcp/agent')
+          && entry?.config?.headers?.Authorization
+          && entry?.config?.oauth === false
+          && engineSync === 'ok'
+          && health?.usable === true
+          && health?.engine?.status === 'connected'
+          && directTools.includes('search_capabilities')
+          && directTools.includes('execute_capability')
+      ),
+      names: items.map((item) => item.name),
+      engineSync,
+      engineFailures: payload?.engineSync?.failures ?? [],
+      health: {
+        usable: health?.usable ?? null,
+        firstFailure: health?.firstFailure ?? null,
+        engine: health?.engine?.status ?? null,
+        directTools,
+      },
+      entry,
+    };
+  })()`, { awaitPromise: true });
+}
+
+async function ensureCloudControlReady(ctx) {
+  await openMcpSettings(ctx);
+  await revealHidden(ctx);
+  await ctx.expectText("OpenWork Cloud Control", { timeoutMs: 60_000 });
+
+  const alreadyConnected = await ctx.eval(`(() => {
+    const card = [...document.querySelectorAll('button')].find((entry) => entry.textContent.includes('OpenWork Cloud Control'));
+    return Boolean(card?.textContent.includes('Connected'));
+  })()`);
+  if (!alreadyConnected) {
+    const opened = await ctx.eval(`(() => {
+      const card = [...document.querySelectorAll('button')].find((entry) => entry.textContent.includes('OpenWork Cloud Control'));
+      card?.scrollIntoView({ block: 'center' });
+      card?.click();
+      return Boolean(card);
+    })()`);
+    ctx.assert(opened, "Could not open the OpenWork Cloud Control card.");
+    await ctx.expectText("Manage your org", { timeoutMs: 15_000 });
+    const connected = await ctx.eval(`(() => {
+      const dialog = document.querySelector('[role="dialog"]');
+      const button = [...(dialog?.querySelectorAll('button') ?? [])]
+        .find((entry) => entry.textContent.trim() === 'Connect' && !entry.disabled);
+      button?.click();
+      return Boolean(button);
+    })()`);
+    ctx.assert(connected, "Could not connect OpenWork Cloud Control for the eval workspace.");
+  }
+
+  await ctx.waitFor(`(() => {
+    const card = [...document.querySelectorAll('button')].find((entry) => entry.textContent.includes('OpenWork Cloud Control'));
+    return Boolean(card?.textContent.includes('Connected'));
+  })()`, { timeoutMs: 60_000, label: "OpenWork Cloud Control connected card" });
+  await ctx.control("extensions.refresh-marketplace").catch(() => undefined);
+
+  const runtime = await waitFor(async () => {
+    const current = await readRuntimeCloudControlMcp(ctx);
+    return current?.ok ? current : null;
+  }, "Runtime OpenWork Cloud Control MCP config never became ready.", 60_000);
+  ctx.log(`Runtime Cloud Control ready: ${JSON.stringify({ names: runtime.names, engineSync: runtime.engineSync, health: runtime.health })}`);
 }
 
 async function revealHidden(ctx) {
@@ -171,22 +280,61 @@ async function advanceVisibleOnboarding(ctx) {
 }
 
 async function ensureWorkspace(ctx) {
-  const deadline = Date.now() + 180_000;
-  let stableWorkspaceSince = null;
-  while (Date.now() < deadline) {
-    const advanced = await advanceVisibleOnboarding(ctx);
-    const hash = await ctx.eval("window.location.hash");
-    if (advanced || !windowLocationHasWorkspace(hash)) {
-      stableWorkspaceSince = null;
-    } else {
-      stableWorkspaceSince ??= Date.now();
-      if (Date.now() - stableWorkspaceSince >= 3_000) break;
-    }
-    await sleep(500);
-  }
-  ctx.assert(windowLocationHasWorkspace(await ctx.eval("window.location.hash")), "Onboarding did not open a workspace within three minutes.");
-  state.workspaceId = await ctx.eval("(window.location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? null");
-  ctx.assert(Boolean(state.workspaceId), "Could not resolve the active workspace ID.");
+  await mkdir(WORKSPACE_PATH, { recursive: true });
+  await ctx.waitFor(
+    "Boolean(localStorage.getItem('openwork.server.port') && localStorage.getItem('openwork.server.token') && localStorage.getItem('openwork.server.hostToken'))",
+    { timeoutMs: 60_000, label: "OpenWork server auth for eval workspace" },
+  );
+  const created = await ctx.eval(`(async () => {
+    const port = localStorage.getItem('openwork.server.port');
+    const token = localStorage.getItem('openwork.server.token');
+    const hostToken = localStorage.getItem('openwork.server.hostToken');
+    const headers = {
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer ' + token,
+      'X-OpenWork-Host-Token': hostToken,
+    };
+    const response = await fetch('http://127.0.0.1:' + port + '/workspaces/local', {
+      method: 'POST',
+      headers,
+      body: JSON.stringify({
+        folderPath: ${JSON.stringify(WORKSPACE_PATH)},
+        name: 'chat-mcp-reconnect',
+        preset: 'starter',
+      }),
+    });
+    const text = await response.text();
+    let payload = null;
+    try { payload = JSON.parse(text); } catch {}
+    if (!response.ok) return { ok: false, status: response.status, text };
+    const workspaceId = payload?.activeId
+      ?? payload?.selectedId
+      ?? payload?.workspaces?.find((workspace) => workspace.path === ${JSON.stringify(WORKSPACE_PATH)})?.id;
+    if (!workspaceId) return { ok: false, status: response.status, text: 'workspace id missing' };
+    const activate = await fetch('http://127.0.0.1:' + port + '/workspaces/' + workspaceId + '/activate?persist=true', {
+      method: 'POST',
+      headers,
+    });
+    if (!activate.ok) return { ok: false, status: activate.status, text: await activate.text() };
+    await window.__OPENWORK_ELECTRON__?.invokeDesktop('workspaceSetSelected', workspaceId);
+    await window.__OPENWORK_ELECTRON__?.invokeDesktop('workspaceSetRuntimeActive', workspaceId);
+    localStorage.setItem('openwork.react.activeWorkspace', workspaceId);
+    let prefs = {};
+    try { prefs = JSON.parse(localStorage.getItem('openwork.preferences') || '{}'); } catch {}
+    localStorage.setItem('openwork.preferences', JSON.stringify({
+      ...prefs,
+      hasCompletedOnboarding: true,
+      providerStepCompleted: true,
+    }));
+    return { ok: true, workspaceId };
+  })()`, { awaitPromise: true });
+  ctx.assert(created?.ok && created.workspaceId, `Could not prepare the eval workspace: ${JSON.stringify(created)}`);
+  state.workspaceId = created.workspaceId;
+  await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+  await ctx.waitFor(`window.location.hash.includes(${JSON.stringify(`/workspace/${state.workspaceId}`)})`, {
+    timeoutMs: 60_000,
+    label: "eval workspace route",
+  });
 }
 
 async function openMcpSettings(ctx) {
@@ -209,10 +357,6 @@ async function openMcpSettings(ctx) {
     await sleep(500);
   }
   throw new Error("MCP settings did not become available after completing visible onboarding.");
-}
-
-function windowLocationHasWorkspace(hash) {
-  return typeof hash === "string" && hash.includes("/workspace/");
 }
 
 async function createFreshTask(ctx) {
@@ -334,10 +478,7 @@ export default {
         await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", { timeoutMs: 60_000, label: "desktop active org" });
 
         await ensureWorkspace(ctx);
-        await openMcpSettings(ctx);
-        await revealHidden(ctx);
-        await ctx.clickText("Refresh", { timeoutMs: 20_000 });
-        await ctx.waitForText("OpenWork Cloud Control", { timeoutMs: 60_000 });
+        await ensureCloudControlReady(ctx);
         await ctx.expectNoText("Something went wrong");
       },
     },
@@ -381,21 +522,66 @@ export default {
       },
     },
     {
-      name: "Frame 2 — the chat button completes the real Den OAuth reconnect flow",
+      name: "Frame 2 — pending browser sign-in can be reopened immediately",
       run: async (ctx) => {
-        await ctx.prove("Clicking the chat action completes authorization for the exact Den connection", {
+        await ctx.prove("Pending browser authorization remains an enabled, repeatable action", {
           voiceover: vo[1],
           action: async () => {
+            await ctx.eval("window.__openwork?.clearEvents()");
             const clickedAt = new Date().toISOString();
             await ctx.trustedClick('[data-testid="chat-mcp-reconnect-action"]', { timeoutMs: 20_000 });
-            await ctx.waitForText("Finish in browser", { timeoutMs: 30_000 });
+            await ctx.waitForText("Open sign-in again", { timeoutMs: 30_000 });
+            await waitFor(async () => {
+              const entries = await recentMockRequests();
+              return entries.some((entry) => entry.at >= clickedAt && entry.method === "GET" && entry.path === "/authorize");
+            }, "The initial chat action did not open the provider authorization page.", 45_000);
+            await ctx.trustedClick('[data-testid="chat-mcp-reconnect-action"]', { timeoutMs: 20_000 });
             const requests = await waitFor(async () => {
               const entries = await recentMockRequests();
-              const authorize = entries.some((entry) => entry.at >= clickedAt && entry.method === "GET" && entry.path === "/authorize");
-              const token = entries.some((entry) => entry.at >= clickedAt && entry.method === "POST" && entry.path === "/token");
-              return authorize && token ? entries : null;
-            }, "The clicked chat action did not reach the provider authorize and token endpoints.", 45_000);
-            ctx.log(`Reconnect provider requests: ${requests.filter((entry) => entry.at >= clickedAt).map((entry) => `${entry.method} ${entry.path}`).join(", ")}`);
+              const authorize = entries.filter((entry) => entry.at >= clickedAt && entry.method === "GET" && entry.path === "/authorize");
+              return authorize.length >= 2 ? entries : null;
+            }, "Open sign-in again did not reopen the same provider authorization.", 45_000);
+            const authorizeRequests = requests.filter((entry) => entry.at >= clickedAt && entry.method === "GET" && entry.path === "/authorize");
+            state.pendingAuthorizeUrl = authorizeRequests.at(-1)?.url ?? null;
+            ctx.assert(Boolean(state.pendingAuthorizeUrl), "The reopened provider authorization URL was not captured.");
+            ctx.assert(!requests.some((entry) => entry.at >= clickedAt && entry.method === "POST" && entry.path === "/token"), "Reopening sign-in unexpectedly completed authorization without consent.");
+            ctx.log(`Pending authorization opened ${authorizeRequests.length} times without starting a second chat reconnect transaction.`);
+          },
+          assert: async () => {
+            const action = await ctx.eval(`(() => {
+              const button = document.querySelector('[data-testid="chat-mcp-reconnect-action"]');
+              return button ? { label: (button.textContent ?? '').trim(), disabled: button.disabled } : null;
+            })()`);
+            ctx.assert(action?.label === "Open sign-in again", `Expected a reusable sign-in action, received ${JSON.stringify(action)}.`);
+            ctx.assert(action?.disabled === false, "Pending sign-in must not lock the user out of reopening authorization.");
+            const events = await ctx.eval("window.__openwork?.events(20) ?? []");
+            const started = events.filter((entry) => entry.name === "mcp.chat_reconnect.started");
+            const reopened = events.filter((entry) => entry.name === "mcp.chat_reconnect.authorization_reopened");
+            ctx.assert(started.length === 1, `Expected one reconnect transaction, observed ${started.length}.`);
+            ctx.assert(reopened.length === 1, `Expected one authorization reopen event, observed ${reopened.length}.`);
+          },
+          screenshot: {
+            name: "chat-mcp-reconnect-sign-in-reopen",
+            claim: "While browser authorization is pending, the chat row stays usable and offers Open sign-in again instead of a disabled 90-second wait.",
+            requireText: ["Reconnect required", "Open sign-in again"],
+            rejectText: ["Opening sign-in", "Could not start", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — provider consent completes the real Den OAuth reconnect flow",
+      run: async (ctx) => {
+        await ctx.prove("The reusable sign-in action still completes only after real provider consent", {
+          voiceover: vo[2],
+          action: async () => {
+            const approvedAt = new Date().toISOString();
+            await approvePendingAuthorization();
+            const requests = await waitFor(async () => {
+              const entries = await recentMockRequests();
+              return entries.some((entry) => entry.at >= approvedAt && entry.method === "POST" && entry.path === "/token") ? entries : null;
+            }, "Provider approval did not reach the token endpoint.", 45_000);
+            ctx.log(`Reconnect completion requests: ${requests.filter((entry) => entry.at >= approvedAt).map((entry) => `${entry.method} ${entry.path}`).join(", ")}`);
             await ctx.waitForText("Reconnected", { timeoutMs: 45_000 });
             await ctx.waitForText("Try again", { timeoutMs: 10_000 });
           },
@@ -414,18 +600,18 @@ export default {
           },
           screenshot: {
             name: "chat-mcp-reconnect-completed",
-            claim: "The inline action called the exact connection-specific Den route and changed to Reconnected only after Den persisted a newer member authorization.",
+            claim: "The reused browser authorization changes to Reconnected only after Den persists a newer member authorization.",
             requireText: ["Reconnected", "Try again"],
-            rejectText: ["Finish in browser", "Could not start", "Something went wrong"],
+            rejectText: ["Open sign-in again", "Could not start", "Something went wrong"],
           },
         });
       },
     },
     {
-      name: "Frame 3 — retry is prepared safely without auto-replaying a tool",
+      name: "Frame 4 — retry is prepared safely without auto-replaying a tool",
       run: async (ctx) => {
         await ctx.prove("Try again drafts a guarded retry instead of auto-replaying a possible write", {
-          voiceover: vo[2],
+          voiceover: vo[3],
           action: async () => {
             const sessionHash = await ctx.eval("window.location.hash");
             await ctx.navigateHash(`/workspace/${state.workspaceId}/settings/extensions/mcp`);
@@ -455,10 +641,10 @@ export default {
       },
     },
     {
-      name: "Frame 4 — the same real capability succeeds after reconnect",
+      name: "Frame 5 — the same real capability succeeds after reconnect",
       run: async (ctx) => {
         await ctx.prove("Fresh authorization repairs the capability used by desktop chat", {
-          voiceover: vo[3],
+          voiceover: vo[4],
           action: async () => {
             await createFreshTask(ctx);
             const exactCapability = `mcp:${state.connectionId}:mock_echo`;
@@ -483,10 +669,10 @@ export default {
       },
     },
     {
-      name: "Frame 5 — provider failures remain non-reconnect errors",
+      name: "Frame 6 — provider failures remain non-reconnect errors",
       run: async (ctx) => {
         await ctx.prove("A provider policy denial is attributed without creating a misleading reconnect action", {
-          voiceover: vo[4],
+          voiceover: vo[5],
           action: async () => {
             await createFreshTask(ctx);
             const exactCapability = `mcp:${state.connectionId}:${PROVIDER_ERROR_TOOL}`;

--- a/evals/voiceovers/chat-mcp-reconnect.md
+++ b/evals/voiceovers/chat-mcp-reconnect.md
@@ -2,10 +2,12 @@
 
 1. A connected Research Vault account expires before a requested capability runs. The normal capability search performs a live probe, identifies the exact connection, and puts a concise Reconnect Research Vault button beside the result, so the user does not have to translate setup instructions into another navigation journey.
 
-2. Selecting Reconnect starts the real OpenWork Cloud flow for that exact connection. The row says Finish in browser while authorization is pending, then changes to Reconnected only after Den records a newer member authorization timestamp.
+2. Selecting Reconnect starts the real OpenWork Cloud flow for that exact connection. While provider consent is pending, the row stays usable and offers Open sign-in again. Reopening uses the same pending authorization instead of starting a duplicate reconnect or forcing the user to wait for a timeout.
 
-3. Returning to the task preserves its Reconnected state. Try again does not silently replay the previous tool; it prepares a visible draft that searches live capabilities again and warns the user to confirm a write did not already complete before repeating it.
+3. After real provider consent, the row changes to Reconnected only when Den records a newer member authorization timestamp. The reusable browser action does not treat opening a page as successful sign-in.
 
-4. A new task then runs the same Research Vault capability successfully and returns its exact result. This proves the inline action repairs the credential used by the real desktop-to-Den-to-provider execution path.
+4. Returning to the task preserves its Reconnected state. Try again does not silently replay the previous tool; it prepares a visible draft that searches live capabilities again and warns the user to confirm a write did not already complete before repeating it.
 
-5. A different failure from the provider itself is labeled Provider error and does not receive a reconnect action. Only the canonical OpenWork Cloud capability tools with one unambiguous, versioned, member-owned reauthorization target can create the button; ordinary provider failures, shared credentials, ambiguous results, and untrusted tool output stay non-actionable.
+5. A new task then runs the same Research Vault capability successfully and returns its exact result. This proves the inline action repairs the credential used by the real desktop-to-Den-to-provider execution path.
+
+6. A different failure from the provider itself is labeled Provider error and does not receive a reconnect action. Only the canonical OpenWork Cloud capability tools with one unambiguous, versioned, member-owned reauthorization target can create the button; ordinary provider failures, shared credentials, ambiguous results, and untrusted tool output stay non-actionable.


### PR DESCRIPTION
## Summary

- keep the inline browser authorization action usable after the provider page opens by changing the pending state to **Open sign-in again**
- reopen the same pending authorization URL without creating a second Den reconnect transaction
- retain the pending action across chat-row remounts, then clear its continuation URL on completion, failure, or Cloud account/settings changes
- extend the real desktop → Den → provider Fraimz journey with a dedicated pending-consent frame and duplicate-transaction assertions

Follow-up to #2859.

## Why the action disappeared

#2859 intentionally changed the reconnect row to a disabled **Finish in browser** status immediately after opening the provider. That represented the pending callback, but it also removed the user's recovery path when the browser was hidden, closed, or failed to take focus. The user could see that sign-in was pending but could not reopen it from chat.

This follow-up treats pending browser authorization as a continuation, not a terminal loading state. The chat row stores the authorization URL in a non-persisted in-memory record and renders an enabled **Open sign-in again** action until the existing callback completes.

## Reusable sign-in pattern

1. **Start:** the trusted structured action renders **Reconnect**.
2. **Opening:** only that button briefly shows **Opening sign-in…** while Den creates or resumes authorization.
3. **Pending:** chat renders **Open sign-in again** and keeps it enabled.
4. **Reopen:** the same URL is opened again; Den is not asked to start a duplicate transaction.
5. **Complete:** a fresh authorization timestamp changes the row to **Reconnected** and **Try again**.
6. **Retry:** the app drafts a visible, mutation-safe retry; it never automatically replays the failed tool.

## Non-blocking and security guarantees

- the rest of the task and app remain usable while browser consent is pending
- only the reconnect button is briefly disabled during its initial start request
- reopening records a separate inspector event and does not emit a second `mcp.chat_reconnect.started` event
- the authorization continuation is memory-only and is cleared on success, failure, or Den account/organization/settings changes
- no access token, refresh token, authorization code, or PKCE verifier enters chat state or inspector events
- the fail-closed action contract from #2859 is unchanged: ordinary provider failures, shared credentials, ambiguous targets, unversioned output, and arbitrary tools remain non-actionable

## End-to-end evidence

Fraimz run `2026-07-16T23-44-05-555Z` passed setup, all six user-facing frames, cleanup, and voiceover coverage.

### Pending sign-in stays actionable

![Open sign-in again remains enabled in the chat tool row](https://openwork-chat-mcp-reconnect-proof.vercel.app/chat-mcp-reconnect-02-chat-mcp-reconnect-sign-in-reopen.png)

The proof also verifies the initial reconnect action, real provider consent and callback completion, safe retry preparation, successful post-reconnect capability execution, and the provider-error negative control:

- [Reconnect required](https://openwork-chat-mcp-reconnect-proof.vercel.app/chat-mcp-reconnect-01-chat-mcp-reconnect-required.png)
- [Reconnected after consent](https://openwork-chat-mcp-reconnect-proof.vercel.app/chat-mcp-reconnect-03-chat-mcp-reconnect-completed.png)
- [Safe retry draft](https://openwork-chat-mcp-reconnect-proof.vercel.app/chat-mcp-reconnect-04-chat-mcp-reconnect-safe-retry.png)
- [Recovered capability](https://openwork-chat-mcp-reconnect-proof.vercel.app/chat-mcp-reconnect-05-chat-mcp-reconnect-recovered.png)
- [Provider error without reconnect UI](https://openwork-chat-mcp-reconnect-proof.vercel.app/chat-mcp-reconnect-06-chat-mcp-provider-error-no-reconnect.png)

The Vercel project contains only these six PNG files. Its root returns `404`; no application or Fraimz HTML is deployed.

## Verification

- app focused tests: 9 passed, 0 failed (`mcp-reconnect-state`, `tool-error-attribution-ui`, `mcp-chat-reconnect`)
- app typecheck: passed
- Fraimz real desktop → Den → provider journey: passed, 6/6 frames
- Vercel proof host: all six images return `200 image/png`; root returns `404`
- `git diff --check`: passed

