### PR TITLE
fix(den): connect marketplace remote MCPs

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -642,7 +642,7 @@ function MarketplacePluginCard({
   });
 
   return (
-    <div className="group block self-start overflow-hidden rounded-2xl border border-gray-100 bg-white transition hover:-translate-y-0.5 hover:border-gray-200 hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)]">
+    <div id={`plugin-${plugin.id}`} className="group block self-start scroll-mt-6 overflow-hidden rounded-2xl border border-gray-100 bg-white transition hover:-translate-y-0.5 hover:border-gray-200 hover:shadow-[0_8px_24px_-12px_rgba(15,23,42,0.12)]">
       <div className="flex items-stretch">
         <div className="relative w-[64px] shrink-0 overflow-hidden">
           <StaticSeededGradient seed={plugin.id} className="absolute inset-0" />

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-data.tsx
@@ -62,11 +62,14 @@ export type PluginHook = {
 export type PluginMcpTransport = "stdio" | "http" | "sse";
 
 export type PluginMcp = {
+  configObjectId?: string;
   id: string;
   name: string;
   description: string;
   transport: PluginMcpTransport;
   toolCount: number;
+  serverName?: string;
+  url?: string | null;
 };
 
 export type PluginAgent = {
@@ -450,6 +453,40 @@ function asString(value: unknown): string | null {
   return typeof value === "string" && value.trim().length > 0 ? value.trim() : null;
 }
 
+function pluginMcpTransport(config: Record<string, unknown>): PluginMcpTransport {
+  const type = asString(config.type)?.toLowerCase();
+  if (type === "sse") return "sse";
+  return asString(config.url) ? "http" : "stdio";
+}
+
+export function pluginMcpEntries(item: {
+  description: string;
+  id: string;
+  normalizedPayload: Record<string, unknown> | null;
+  title: string;
+}): PluginMcp[] {
+  const payload = item.normalizedPayload ?? {};
+  const entries = [payload.mcpServers, payload.mcp].flatMap((container) => (
+    isRecord(container)
+      ? Object.entries(container).filter((entry): entry is [string, Record<string, unknown>] => isRecord(entry[1]))
+      : []
+  ));
+  const servers = entries.length > 0
+    ? entries
+    : [[item.title, payload] satisfies [string, Record<string, unknown>]];
+
+  return servers.map(([serverName, config], index) => ({
+    configObjectId: item.id,
+    description: item.description,
+    id: servers.length === 1 ? item.id : `${item.id}:${index}`,
+    name: servers.length === 1 ? item.title : serverName,
+    serverName,
+    toolCount: typeof config.toolCount === "number" ? config.toolCount : 0,
+    transport: pluginMcpTransport(config),
+    url: asString(config.url),
+  }));
+}
+
 function parseMembershipConfigObject(entry: unknown) {
   if (!isRecord(entry) || !isRecord(entry.configObject)) {
     return null;
@@ -552,13 +589,7 @@ async function fetchResolvedPlugin(id: string): Promise<DenPlugin | null> {
     } satisfies PluginHook));
   const mcps = membershipItems
     .filter((item) => item.objectType === "mcp")
-    .map((item) => ({
-      description: item.description,
-      id: item.id,
-      name: item.title,
-      toolCount: typeof item.normalizedPayload?.toolCount === "number" ? item.normalizedPayload.toolCount : 0,
-      transport: (asString(item.normalizedPayload?.transport) as PluginMcpTransport | null) ?? "stdio",
-    } satisfies PluginMcp));
+    .flatMap(pluginMcpEntries);
 
   const marketplaces = Array.isArray(pluginItem.marketplaces)
     ? pluginItem.marketplaces.flatMap((entry) => {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-detail-screen.tsx
@@ -1,10 +1,11 @@
 "use client";
 
 import Link from "next/link";
-import { ArrowLeft, FileText, Puzzle, Server, Store, Terminal, Users, Webhook } from "lucide-react";
+import { ArrowLeft, FileText, Plug, Puzzle, Server, Store, Terminal, Users, Webhook } from "lucide-react";
 import { PaperMeshGradient } from "@openwork/ui/react";
 
-import { getPluginsRoute } from "../../_lib/den-org";
+import { buttonVariants } from "../../_components/ui/button";
+import { getMarketplaceRoute, getOrgAccessFlags, getPluginsRoute, getYourConnectionsRoute } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
   type DenPlugin,
@@ -16,10 +17,14 @@ import {
   formatPluginTimestamp,
   usePlugin,
 } from "./plugin-data";
+import { useMarketplace, type MarketplacePluginCloudReadinessConnection } from "./marketplace-data";
+import { pluginReadinessConnectionAction, pluginRequirementNeedsAdminSetup } from "./marketplace-mcp-setup";
 
 export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
-  const { orgSlug } = useOrgDashboard();
+  const { orgContext, orgSlug } = useOrgDashboard();
   const { data: plugin, isLoading, error } = usePlugin(pluginId);
+  const marketplaceId = plugin?.marketplaces?.[0]?.id ?? null;
+  const { data: marketplace } = useMarketplace(marketplaceId);
 
   if (isLoading && !plugin) {
     return (
@@ -42,6 +47,18 @@ export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
   }
 
   const marketplaces = plugin.marketplaces ?? [];
+  const access = getOrgAccessFlags(
+    orgContext?.currentMember.role ?? "member",
+    orgContext?.currentMember.isOwner ?? false,
+    orgContext?.roles ?? [],
+  );
+  const readiness = marketplace?.plugins.find((entry) => entry.id === plugin.id)?.cloudReadiness;
+  const readinessConnection = (mcp: PluginMcp): MarketplacePluginCloudReadinessConnection | null => (
+    readiness?.connections.find((connection) => (
+      connection.configObjectId === (mcp.configObjectId ?? mcp.id)
+        && connection.serverName === (mcp.serverName ?? mcp.name)
+    )) ?? null
+  );
   const missingLabels: string[] = [];
   if (plugin.skills.length === 0) missingLabels.push("skills");
   if (plugin.agents.length === 0) missingLabels.push("agents");
@@ -115,7 +132,17 @@ export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
         <PrimitiveSection icon={Users} label="Agents" items={plugin.agents} render={renderAgentRow} />
         <PrimitiveSection icon={Terminal} label="Commands" items={plugin.commands} render={renderCommandRow} />
         <PrimitiveSection icon={Webhook} label="Hooks" items={plugin.hooks} render={renderHookRow} />
-        <PrimitiveSection icon={Server} label="MCP Servers" items={plugin.mcps} render={renderMcpRow} />
+        <PrimitiveSection
+          icon={Server}
+          label="MCP Servers"
+          items={plugin.mcps}
+          render={(mcp) => renderMcpRow(mcp, {
+            isAdmin: access.isAdmin,
+            marketplaceHref: marketplaceId ? `${getMarketplaceRoute(orgSlug, marketplaceId)}#plugin-${encodeURIComponent(plugin.id)}` : null,
+            orgSlug,
+            readiness: readinessConnection(mcp),
+          })}
+        />
       </div>
 
       {missingLabels.length > 0 ? (
@@ -201,7 +228,21 @@ function renderHookRow(hook: PluginHook) {
   );
 }
 
-function renderMcpRow(mcp: PluginMcp) {
+function renderMcpRow(mcp: PluginMcp, input: {
+  isAdmin: boolean;
+  marketplaceHref: string | null;
+  orgSlug: string | null;
+  readiness: MarketplacePluginCloudReadinessConnection | null;
+}) {
+  const readinessAction = input.readiness
+    ? pluginReadinessConnectionAction(input.readiness, input.isAdmin)
+    : null;
+  const setupHref = input.readiness && pluginRequirementNeedsAdminSetup(input.readiness)
+    ? input.marketplaceHref
+    : readinessAction
+      ? `${getYourConnectionsRoute(input.orgSlug)}?connectionId=${encodeURIComponent(readinessAction.connectionId)}`
+      : null;
+
   return (
     <div
       key={mcp.id}
@@ -213,9 +254,17 @@ function renderMcpRow(mcp: PluginMcp) {
           <p className="mt-0.5 line-clamp-2 text-[12.5px] leading-[1.55] text-gray-500">{mcp.description}</p>
         ) : null}
       </div>
-      <span className="shrink-0 rounded-full bg-gray-50 px-2 py-0.5 text-[11px] text-gray-500">
-        {mcp.transport} · {mcp.toolCount} tool{mcp.toolCount === 1 ? "" : "s"}
-      </span>
+      <div className="flex shrink-0 items-center gap-2">
+        <span className="rounded-full bg-gray-50 px-2 py-0.5 text-[11px] text-gray-500">
+          {mcp.transport === "stdio" ? "Desktop only" : "Remote"} · {mcp.toolCount} tool{mcp.toolCount === 1 ? "" : "s"}
+        </span>
+        {setupHref ? (
+          <Link href={setupHref} className={buttonVariants({ variant: "secondary", size: "sm", className: "h-8 px-3 text-[12px]" })}>
+            <Plug className="h-3.5 w-3.5" aria-hidden />
+            Connect
+          </Link>
+        ) : null}
+      </div>
     </div>
   );
 }

--- a/ee/apps/den-web/tests/marketplace-mcp-readiness.test.ts
+++ b/ee/apps/den-web/tests/marketplace-mcp-readiness.test.ts
@@ -4,6 +4,7 @@ import { formatRequiredBy, sortConnectionsForFocus, trustedConnectionFocusId } f
 import { marketplaceConnectionNeedsAdminSetup } from "../app/(den)/dashboard/_components/mcp-connection-setup";
 import type { ExternalMcpConnection, ExternalMcpPreset, ExternalMcpRequiredBy } from "../app/(den)/dashboard/_components/mcp-connections-data";
 import { parseMarketplaceResolvedPayload, type MarketplacePluginCloudReadinessConnection } from "../app/(den)/dashboard/_components/marketplace-data";
+import { pluginMcpEntries } from "../app/(den)/dashboard/_components/plugin-data";
 import {
   findPresetForRequirement,
   pluginReadinessConnectionAction,
@@ -42,6 +43,37 @@ function requirement(url: string): MarketplacePluginCloudReadinessConnection {
 }
 
 describe("marketplace MCP readiness parsing", () => {
+  test("treats marketplace-created URL MCPs as remote", () => {
+    expect(pluginMcpEntries({
+      description: "Linear",
+      id: "cfg_linear",
+      normalizedPayload: {
+        mcpServers: {
+          linear: { type: "remote", url: "https://mcp.linear.app/mcp" },
+        },
+      },
+      title: "Linear",
+    })).toEqual([{
+      configObjectId: "cfg_linear",
+      description: "Linear",
+      id: "cfg_linear",
+      name: "Linear",
+      serverName: "linear",
+      toolCount: 0,
+      transport: "http",
+      url: "https://mcp.linear.app/mcp",
+    }]);
+  });
+
+  test("keeps command-based MCPs desktop only", () => {
+    expect(pluginMcpEntries({
+      description: "Local Linear",
+      id: "cfg_local_linear",
+      normalizedPayload: { command: "npx" },
+      title: "Linear",
+    })[0]?.transport).toBe("stdio");
+  });
+
   test("preserves cloud readiness connection provenance fields", () => {
     const parsed = parseMarketplaceResolvedPayload({
       item: {


### PR DESCRIPTION
## Summary

- recognize marketplace-created MCP components with a URL as remote instead of defaulting them to `stdio`
- surface a compact **Connect** action on the plugin detail MCP row when Den readiness requires setup or sign-in
- route setup to the exact plugin card in its marketplace, while existing connections continue through **Your Connections**
- keep command-based `stdio` MCPs explicitly desktop-only

## Root cause

The marketplace plugin editor already stores MCPs correctly as `{ type: "remote", url }` inside `mcpServers`. The plugin detail parser only inspected top-level `transport`, did not read the nested server declaration, and therefore defaulted every created MCP to `stdio`. The detail screen also rendered static MCP metadata without consuming the marketplace readiness projection.

## Scope

Den Web presentation and navigation only. This does not change MCP discovery, OAuth, credentials, connection storage, SSRF policy, or runtime capability behavior.

## Validation

- `pnpm --dir ee/apps/den-web typecheck` — passed
- `pnpm --dir ee/apps/den-web exec bun test tests/marketplace-mcp-readiness.test.ts` — 14 passed
- `git diff --check` — passed

## Manual verification

1. Create a marketplace plugin with an MCP server URL.
2. Open the created plugin detail page.
3. Confirm the MCP is labeled **Remote**, not **Desktop only**.
4. Confirm **Connect** appears when marketplace readiness requires action and opens the exact marketplace plugin setup card.
5. Confirm a command-based MCP remains **Desktop only** and does not receive a cloud Connect action.

## Not run

- Full Den browser journey and screenshot proof were not run for this narrow follow-up.
