### PR TITLE
feat(den): separate MCP service selection from custom URLs

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { ArrowLeft, Check, ChevronDown, ChevronRight, Loader2, MoreHorizontal, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Sparkles, Trash2, Users, Wrench } from "lucide-react";
+import { ArrowLeft, Check, ChevronDown, ChevronRight, Loader2, MoreHorizontal, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenNotice } from "../../_components/ui/notice";
@@ -55,7 +55,6 @@ import {
 } from "./mcp-connections-data";
 import {
   classifySmartAddInput,
-  filterPresetSuggestions,
   planSmartAdd,
   smartAddAuthLabel,
 } from "./mcp-connection-smart-add";
@@ -571,11 +570,16 @@ export function McpConnectionsScreen() {
         open={formOpen}
         preset={formPreset}
         presets={presets}
+        existingConnectionUrls={connections.map((connection) => connection.url)}
         submitting={createConnection.isPending}
         error={createConnection.error}
         onClose={() => {
           setFormOpen(false);
           setFormPreset(null);
+        }}
+        onSelectPreset={(selectedPreset) => {
+          createConnection.reset();
+          setFormPreset(selectedPreset);
         }}
         onSubmit={handleCreate}
       />
@@ -1992,17 +1996,21 @@ function AddConnectionDialog({
   open,
   preset,
   presets,
+  existingConnectionUrls,
   submitting,
   error,
   onClose,
+  onSelectPreset,
   onSubmit,
 }: {
   open: boolean;
   preset: ExternalMcpPreset | null;
   presets: ExternalMcpPreset[];
+  existingConnectionUrls: string[];
   submitting: boolean;
   error: unknown;
   onClose: () => void;
+  onSelectPreset: (preset: ExternalMcpPreset | null) => void;
   onSubmit: (
     input: CreateMcpConnectionInput,
     options: { startOAuth: boolean },
@@ -2011,10 +2019,9 @@ function AddConnectionDialog({
   const { orgContext } = useOrgDashboard();
   const discoverRequirements = useDiscoverMcpConnectionRequirements();
   const resolveConnection = useResolveMcpConnection();
-  // "smart": one input, we find and check the server. "advanced": the full
-  // form — reachable any time through the Advanced setup link, and the
-  // landing view for preset tiles (they arrive prefilled already).
-  const [view, setView] = useState<"smart" | "advanced">(preset ? "advanced" : "smart");
+  // The picker keeps known services separate from the custom URL path.
+  // Presets land in their prefilled form; Custom MCP uses discovery first.
+  const [view, setView] = useState<"picker" | "smart" | "advanced">(preset ? "advanced" : "picker");
   const [smartQuery, setSmartQuery] = useState("");
   const [smartState, setSmartState] = useState<"idle" | "waiting" | "resolving" | "done" | "error">("idle");
   const [smartError, setSmartError] = useState<unknown>(null);
@@ -2042,7 +2049,7 @@ function AddConnectionDialog({
 
   useEffect(() => {
     if (!open) return;
-    setView(preset ? "advanced" : "smart");
+    setView(preset ? "advanced" : "picker");
     setSmartQuery("");
     setSmartState("idle");
     setSmartError(null);
@@ -2168,7 +2175,7 @@ function AddConnectionDialog({
     setResolution(null);
     setSmartError(null);
     const kind = classifySmartAddInput(smartQuery);
-    if (kind === "empty" || kind === "invalid") {
+    if (kind !== "url" && kind !== "domain") {
       setSmartState("idle");
       return;
     }
@@ -2180,19 +2187,6 @@ function AddConnectionDialog({
     }, delay);
     return () => window.clearTimeout(timer);
   }, [open, view, smartQuery]);
-
-  // Suggestions stay visible until a concrete match card renders — after a
-  // not_found in particular, "noti" should still offer Notion.
-  const presetSuggestions = useMemo(
-    () => (view === "smart" && !(smartState === "done" && resolution?.match) ? filterPresetSuggestions(presets, smartQuery) : []),
-    [presets, smartQuery, view, smartState, resolution],
-  );
-
-  function selectPresetSuggestion(suggestion: ExternalMcpPreset) {
-    // Suggestion taps resolve immediately — the debounce exists for typing.
-    smartResolveDelayRef.current = 0;
-    setSmartQuery(suggestion.displayName);
-  }
 
   const smartMatch = smartState === "done" ? resolution?.match ?? null : null;
   const smartPlan = smartMatch
@@ -2298,14 +2292,82 @@ function AddConnectionDialog({
         className="max-h-[calc(100dvh-3rem)] w-full max-w-md overflow-y-auto overscroll-contain rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
         onClick={(event) => event.stopPropagation()}
       >
-        {view === "smart" ? (
+        {view === "picker" ? (
           <>
-            <h2 className="flex items-center gap-2 text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
-              <Sparkles className="h-4 w-4 text-gray-400" />
+            <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
               Add a connection
             </h2>
             <p className="mt-1.5 text-[13px] leading-5 text-gray-500">
-              Paste a server URL — or just type a name like <span className="font-medium text-gray-700">vercel</span> — and we&apos;ll find and check it for you.
+              Choose a service, or connect an MCP server by URL.
+            </p>
+
+            <div
+              className="mt-5 max-h-[min(55vh,440px)] space-y-2 overflow-y-auto overscroll-contain pr-1"
+              data-testid="mcp-service-picker"
+            >
+              <button
+                type="button"
+                onClick={() => setView("smart")}
+                className="group flex w-full items-center gap-3 rounded-2xl border border-gray-200 px-3.5 py-3 text-left transition hover:border-gray-400 hover:bg-gray-50"
+                data-testid="select-custom-mcp"
+              >
+                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gray-900 text-white">
+                  <Server className="h-4 w-4" />
+                </span>
+                <span className="min-w-0 flex-1">
+                  <span className="block text-[14px] font-semibold text-gray-950">Custom MCP</span>
+                  <span className="mt-0.5 block truncate text-[12px] text-gray-500">Connect with a server URL</span>
+                </span>
+                <span className="shrink-0 rounded-xl border border-gray-200 bg-white px-3 py-2 text-[12px] font-semibold text-gray-800 shadow-sm transition group-hover:border-gray-300">
+                  Connect
+                </span>
+              </button>
+
+              {presets.map((service) => {
+                const alreadyAdded = existingConnectionUrls.includes(service.url);
+                return (
+                  <button
+                    key={service.presetId}
+                    type="button"
+                    disabled={alreadyAdded}
+                    onClick={() => onSelectPreset(service)}
+                    className="group flex w-full items-center gap-3 rounded-2xl border border-gray-200 px-3.5 py-3 text-left transition hover:border-gray-400 hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-50"
+                  >
+                    <IntegrationIcon name={service.displayName} serviceUrl={service.url} className="h-10 w-10 rounded-xl" />
+                    <span className="min-w-0 flex-1">
+                      <span className="block text-[14px] font-semibold text-gray-950">{service.displayName}</span>
+                      <span className="mt-0.5 block truncate text-[12px] text-gray-500">{service.description}</span>
+                    </span>
+                    <span className="shrink-0 rounded-xl border border-gray-200 bg-white px-3 py-2 text-[12px] font-semibold text-gray-800 shadow-sm transition group-hover:border-gray-300">
+                      {alreadyAdded ? "Added" : "Connect"}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+
+            <div className="mt-5 flex justify-end">
+              <DenButton variant="secondary" onClick={onClose}>
+                Cancel
+              </DenButton>
+            </div>
+          </>
+        ) : view === "smart" ? (
+          <>
+            <button
+              type="button"
+              onClick={() => setView("picker")}
+              className="mb-2 flex items-center gap-1 text-[12px] font-medium text-gray-500 transition hover:text-gray-900"
+            >
+              <ArrowLeft className="h-3.5 w-3.5" />
+              All connections
+            </button>
+            <h2 className="flex items-center gap-2 text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
+              <Server className="h-4 w-4 text-gray-400" />
+              Custom MCP
+            </h2>
+            <p className="mt-1.5 text-[13px] leading-5 text-gray-500">
+              Paste the MCP server URL and we&apos;ll find and check its authentication requirements.
             </p>
 
             <div className="mt-5">
@@ -2313,26 +2375,10 @@ function AddConnectionDialog({
                 autoFocus
                 value={smartQuery}
                 onChange={(event) => setSmartQuery(event.target.value)}
-                placeholder="vercel — or https://mcp.vercel.com/mcp"
+                placeholder="https://mcp.example.com/mcp"
                 data-testid="smart-add-query-input"
               />
             </div>
-
-            {presetSuggestions.length > 0 ? (
-              <div className="mt-3 flex flex-wrap gap-2">
-                {presetSuggestions.map((suggestion) => (
-                  <button
-                    key={suggestion.presetId}
-                    type="button"
-                    onClick={() => selectPresetSuggestion(suggestion)}
-                    className="flex items-center gap-2 rounded-full border border-gray-200 py-1.5 pl-2 pr-3 text-[12px] font-medium text-gray-700 transition hover:border-gray-400 hover:text-gray-950"
-                  >
-                    <IntegrationIcon name={suggestion.displayName} serviceUrl={suggestion.url} className="h-5 w-5 rounded-md" imageClassName="h-3.5 w-3.5" />
-                    {suggestion.displayName}
-                  </button>
-                ))}
-              </div>
-            ) : null}
 
             {smartState === "waiting" || smartState === "resolving" ? (
               <div className="mt-4 flex items-center gap-2.5 rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3.5 text-[13px] text-gray-500" role="status">
@@ -2448,16 +2494,17 @@ function AddConnectionDialog({
           </>
         ) : (
           <>
-        {!preset ? (
-          <button
-            type="button"
-            onClick={() => setView("smart")}
-            className="mb-2 flex items-center gap-1 text-[12px] font-medium text-gray-500 transition hover:text-gray-900"
-          >
-            <ArrowLeft className="h-3.5 w-3.5" />
-            Quick add
-          </button>
-        ) : null}
+        <button
+          type="button"
+          onClick={() => {
+            if (preset) onSelectPreset(null);
+            else setView("smart");
+          }}
+          className="mb-2 flex items-center gap-1 text-[12px] font-medium text-gray-500 transition hover:text-gray-900"
+        >
+          <ArrowLeft className="h-3.5 w-3.5" />
+          {preset ? "All connections" : "Custom MCP"}
+        </button>
         <h2 className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
           {preset ? `Add ${preset.displayName}` : "Add a custom MCP server"}
         </h2>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -2022,6 +2022,7 @@ function AddConnectionDialog({
   // The picker keeps known services separate from the custom URL path.
   // Presets land in their prefilled form; Custom MCP uses discovery first.
   const [view, setView] = useState<"picker" | "smart" | "advanced">(preset ? "advanced" : "picker");
+  const [presetFilter, setPresetFilter] = useState("");
   const [smartQuery, setSmartQuery] = useState("");
   const [smartState, setSmartState] = useState<"idle" | "waiting" | "resolving" | "done" | "error">("idle");
   const [smartError, setSmartError] = useState<unknown>(null);
@@ -2050,6 +2051,7 @@ function AddConnectionDialog({
   useEffect(() => {
     if (!open) return;
     setView(preset ? "advanced" : "picker");
+    setPresetFilter("");
     setSmartQuery("");
     setSmartState("idle");
     setSmartError(null);
@@ -2082,6 +2084,15 @@ function AddConnectionDialog({
     () => (orgContext?.members ?? []).filter((member) => Boolean(member.userId)),
     [orgContext?.members],
   );
+  const filteredPresets = useMemo(() => {
+    const query = presetFilter.trim().toLowerCase();
+    if (!query) return presets;
+    return presets.filter((service) => (
+      service.displayName.toLowerCase().includes(query)
+      || service.description.toLowerCase().includes(query)
+      || service.url.toLowerCase().includes(query)
+    ));
+  }, [presetFilter, presets]);
 
   function toggle(list: string[], id: string): string[] {
     return list.includes(id) ? list.filter((entry) => entry !== id) : [...list, id];
@@ -2301,29 +2312,42 @@ function AddConnectionDialog({
               Choose a service, or connect an MCP server by URL.
             </p>
 
+            <button
+              type="button"
+              onClick={() => setView("smart")}
+              className="group mt-5 flex w-full items-center gap-3 rounded-2xl border border-gray-200 px-3.5 py-3 text-left transition hover:border-gray-400 hover:bg-gray-50"
+              data-testid="select-custom-mcp"
+            >
+              <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gray-900 text-white">
+                <Server className="h-4 w-4" />
+              </span>
+              <span className="min-w-0 flex-1">
+                <span className="block text-[14px] font-semibold text-gray-950">Custom MCP</span>
+                <span className="mt-0.5 block truncate text-[12px] text-gray-500">Connect with a server URL</span>
+              </span>
+              <span className="shrink-0 rounded-xl border border-gray-200 bg-white px-3 py-2 text-[12px] font-semibold text-gray-800 shadow-sm transition group-hover:border-gray-300">
+                Add
+              </span>
+            </button>
+
+            <div className="mt-5">
+              <label className="mb-2 block text-[11px] font-semibold uppercase tracking-[0.12em] text-gray-400">
+                Services
+              </label>
+              <DenInput
+                aria-label="Filter services"
+                icon={Search}
+                value={presetFilter}
+                onChange={(event) => setPresetFilter(event.target.value)}
+                placeholder="Search services"
+              />
+            </div>
+
             <div
-              className="mt-5 max-h-[min(55vh,440px)] space-y-2 overflow-y-auto overscroll-contain pr-1"
+              className="mt-3 max-h-[min(42vh,340px)] space-y-2 overflow-y-auto overscroll-contain pr-1"
               data-testid="mcp-service-picker"
             >
-              <button
-                type="button"
-                onClick={() => setView("smart")}
-                className="group flex w-full items-center gap-3 rounded-2xl border border-gray-200 px-3.5 py-3 text-left transition hover:border-gray-400 hover:bg-gray-50"
-                data-testid="select-custom-mcp"
-              >
-                <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gray-900 text-white">
-                  <Server className="h-4 w-4" />
-                </span>
-                <span className="min-w-0 flex-1">
-                  <span className="block text-[14px] font-semibold text-gray-950">Custom MCP</span>
-                  <span className="mt-0.5 block truncate text-[12px] text-gray-500">Connect with a server URL</span>
-                </span>
-                <span className="shrink-0 rounded-xl border border-gray-200 bg-white px-3 py-2 text-[12px] font-semibold text-gray-800 shadow-sm transition group-hover:border-gray-300">
-                  Connect
-                </span>
-              </button>
-
-              {presets.map((service) => {
+              {filteredPresets.map((service) => {
                 const alreadyAdded = existingConnectionUrls.includes(service.url);
                 return (
                   <button
@@ -2339,11 +2363,16 @@ function AddConnectionDialog({
                       <span className="mt-0.5 block truncate text-[12px] text-gray-500">{service.description}</span>
                     </span>
                     <span className="shrink-0 rounded-xl border border-gray-200 bg-white px-3 py-2 text-[12px] font-semibold text-gray-800 shadow-sm transition group-hover:border-gray-300">
-                      {alreadyAdded ? "Added" : "Connect"}
+                      {alreadyAdded ? "Added" : "Add"}
                     </span>
                   </button>
                 );
               })}
+              {filteredPresets.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-gray-200 px-4 py-6 text-center text-[13px] text-gray-500">
+                  No services match “{presetFilter.trim()}”.
+                </p>
+              ) : null}
             </div>
 
             <div className="mt-5 flex justify-end">

--- a/ee/apps/den-web/tests/mcp-connection-picker.test.ts
+++ b/ee/apps/den-web/tests/mcp-connection-picker.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const screenPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/mcp-connections-screen.tsx", import.meta.url),
+);
+
+describe("MCP connection picker UI contract", () => {
+  test("shows a scrollable service picker before the custom URL flow", () => {
+    const screen = readFileSync(screenPath, "utf8");
+    const customMcp = screen.indexOf('data-testid="select-custom-mcp"');
+    const presetList = screen.indexOf("{presets.map((service)");
+
+    expect(screen).toContain('useState<"picker" | "smart" | "advanced">');
+    expect(screen).toContain('data-testid="mcp-service-picker"');
+    expect(screen).toContain("max-h-[min(55vh,440px)]");
+    expect(screen).toContain("overflow-y-auto");
+    expect(customMcp).toBeGreaterThan(-1);
+    expect(presetList).toBeGreaterThan(customMcp);
+  });
+
+  test("keeps known services separate from custom URL discovery", () => {
+    const screen = readFileSync(screenPath, "utf8");
+
+    expect(screen).toContain("Choose a service, or connect an MCP server by URL.");
+    expect(screen).toContain("Connect with a server URL");
+    expect(screen).toContain("Paste the MCP server URL");
+    expect(screen).toContain('placeholder="https://mcp.example.com/mcp"');
+    expect(screen).toContain('onClick={() => onSelectPreset(service)}');
+    expect(screen).toContain('if (kind !== "url" && kind !== "domain")');
+    expect(screen).not.toContain("or just type a name like");
+  });
+});

--- a/ee/apps/den-web/tests/mcp-connection-picker.test.ts
+++ b/ee/apps/den-web/tests/mcp-connection-picker.test.ts
@@ -7,17 +7,22 @@ const screenPath = fileURLToPath(
 );
 
 describe("MCP connection picker UI contract", () => {
-  test("shows a scrollable service picker before the custom URL flow", () => {
+  test("pins Custom MCP above a filterable, scrollable service list", () => {
     const screen = readFileSync(screenPath, "utf8");
     const customMcp = screen.indexOf('data-testid="select-custom-mcp"');
+    const servicePicker = screen.indexOf('data-testid="mcp-service-picker"');
     const presetList = screen.indexOf("{presets.map((service)");
 
     expect(screen).toContain('useState<"picker" | "smart" | "advanced">');
+    expect(screen).toContain('aria-label="Filter services"');
+    expect(screen).toContain('placeholder="Search services"');
+    expect(screen).toContain("filteredPresets.map((service)");
     expect(screen).toContain('data-testid="mcp-service-picker"');
-    expect(screen).toContain("max-h-[min(55vh,440px)]");
+    expect(screen).toContain("max-h-[min(42vh,340px)]");
     expect(screen).toContain("overflow-y-auto");
     expect(customMcp).toBeGreaterThan(-1);
-    expect(presetList).toBeGreaterThan(customMcp);
+    expect(servicePicker).toBeGreaterThan(customMcp);
+    expect(presetList).toBe(-1);
   });
 
   test("keeps known services separate from custom URL discovery", () => {
@@ -25,6 +30,7 @@ describe("MCP connection picker UI contract", () => {
 
     expect(screen).toContain("Choose a service, or connect an MCP server by URL.");
     expect(screen).toContain("Connect with a server URL");
+    expect(screen).toContain('{alreadyAdded ? "Added" : "Add"}');
     expect(screen).toContain("Paste the MCP server URL");
     expect(screen).toContain('placeholder="https://mcp.example.com/mcp"');
     expect(screen).toContain('onClick={() => onSelectPreset(service)}');


### PR DESCRIPTION
## Summary

- open the MCP add flow on a service picker instead of mixing known services into the custom URL input
- pin **Custom MCP** above a filterable, independently scrollable provider list
- let curated providers open their existing prefilled setup directly
- use **Add** for selectable rows and **Added** when a provider URL is already configured
- preserve the existing discovery, OAuth, credential, access, and connection-creation behavior
- disable picker rows for provider URLs that are already configured

## Why

The previous modal combined two different decisions in one input: selecting a known provider and entering an arbitrary MCP server URL. This made the custom path look like the primary path and required admins to know what to type even when OpenWork already had a curated provider.

The new flow makes the initial decision concrete and non-technical: choose a service, or choose **Custom MCP** to paste a URL.

## UI proof

### Service picker

The picker is the first screen. **Custom MCP** remains pinned above the search field while only the curated provider list filters and scrolls.

![Scrollable MCP service picker](https://uqab8d1w4ih8j7ev.public.blob.vercel-storage.com/mcp-connection-picker/service-picker.png)

### Custom MCP URL

The custom path is now explicitly URL-only and retains the existing automatic requirements discovery and advanced setup.

![Custom MCP URL step](https://uqab8d1w4ih8j7ev.public.blob.vercel-storage.com/mcp-connection-picker/custom-mcp-url.png)

### Curated service setup

Selecting a listed provider opens its existing prefilled configuration without passing through the URL screen.

![Notion prefilled service setup](https://uqab8d1w4ih8j7ev.public.blob.vercel-storage.com/mcp-connection-picker/notion-service-setup.png)

## Validation

- `pnpm --dir ee/apps/den-web exec bun test tests/mcp-connection-picker.test.ts` — 2 passed
- `pnpm --dir ee/apps/den-web typecheck` — passed
- `git diff --check` — passed
- GitHub Linux and macOS test jobs — passed
- Den API, Den Web, and inference artifact builds — passed
- i18n audit and Helm chart validation — passed

## Merge readiness

- [x] Branch is current with upstream `dev`.
- [x] GitHub reports no merge conflict.
- [x] The PR is marked ready for review.
- [x] User reviewed the final picker and confirmed it looks good.

The `Vercel – openwork-app`, `Vercel – openwork-den`, and `Vercel – openwork-den-worker-proxy` contexts link to Vercel GitHub authorization for the fork; they did not run a deployment build. The repository’s OpenWork test and artifact-build jobs passed.

## Browser verification

- [x] Opened **Connections → MCP server** and confirmed the service picker appears first.
- [x] Confirmed **Custom MCP** stays pinned above the provider search and scroll area.
- [x] Filtered the provider list to Notion and confirmed unrelated providers were removed.
- [x] Confirmed a no-results message for a filter with no matching provider.
- [x] Confirmed selectable rows use **Add**.
- [x] Opened **Custom MCP** and confirmed the URL-only discovery screen.
- [x] Returned to the picker and opened Notion’s prefilled setup.
- [x] Selected Context7 at the end of the scrollable list and confirmed its setup opened.
- [x] Returned to the picker without creating or modifying a connection.

## Risk and rollback

- No API, schema, OAuth, credential-storage, or connection-creation contract changes.
- The existing quick-add cards outside the modal remain unchanged.
- Rollback is the single commit in this PR; no migration is included.
