### PR TITLE
fix(den-web): add light paper chooser motion

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-selection-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-selection-screen.tsx
@@ -1,9 +1,42 @@
 "use client";
 
+import { Dithering } from "@paper-design/shaders-react";
 import Link from "next/link";
 import { Building2, ChevronRight, LogOut, Plus } from "lucide-react";
+import { useSyncExternalStore } from "react";
 import { formatRoleLabel, type DenOrgSummary } from "../../_lib/den-org";
 import { useOrgListWindow } from "../../_lib/use-org-list-window";
+
+const REDUCED_MOTION_QUERY = "(prefers-reduced-motion: reduce)";
+
+function subscribeToReducedMotion(onStoreChange: () => void) {
+  if (typeof window === "undefined") {
+    return () => {};
+  }
+
+  const mediaQuery = window.matchMedia(REDUCED_MOTION_QUERY);
+  mediaQuery.addEventListener("change", onStoreChange);
+
+  return () => mediaQuery.removeEventListener("change", onStoreChange);
+}
+
+function getReducedMotionSnapshot() {
+  return typeof window === "undefined"
+    ? true
+    : window.matchMedia(REDUCED_MOTION_QUERY).matches;
+}
+
+function getReducedMotionServerSnapshot() {
+  return true;
+}
+
+function useReducedMotion() {
+  return useSyncExternalStore(
+    subscribeToReducedMotion,
+    getReducedMotionSnapshot,
+    getReducedMotionServerSnapshot,
+  );
+}
 
 export function OrgSelectionScreen({
   orgs,
@@ -27,88 +60,135 @@ export function OrgSelectionScreen({
     showMore,
     showSearch,
   } = useOrgListWindow(orgs);
+  const reducedMotion = useReducedMotion();
+  const shaderSpeed = reducedMotion ? 0 : 0.012;
+
   return (
-    <section className="den-page flex min-h-[calc(100vh-2.5rem)] w-full items-center py-6" data-testid="org-chooser-root">
-      <div className="den-frame mx-auto w-full max-w-md p-6 md:p-8" data-testid="org-chooser-foreground">
-        <div className="mb-6 text-center">
-          <h1 className="den-title-lg">Choose an organization</h1>
-          <p className="mt-2 text-[13px] text-[var(--dls-text-secondary)]">
-            You belong to {orgs.length} organizations. Select one to continue.
-          </p>
-        </div>
+    <section
+      className="relative isolate min-h-dvh overflow-y-auto bg-[#f8fbff] px-4 py-8 text-slate-950 sm:py-12"
+      data-testid="org-chooser-root"
+    >
+      <div
+        aria-hidden="true"
+        className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#f8fbff] opacity-[0.09]"
+        data-motion={shaderSpeed === 0 ? "reduced" : "ambient"}
+        data-shader-speed={shaderSpeed}
+        data-testid="org-chooser-background"
+      >
+        <Dithering
+          speed={shaderSpeed}
+          shape="warp"
+          type="4x4"
+          size={2.4}
+          scale={0.9}
+          frame={24017.6}
+          colorBack="#F8FBFF"
+          colorFront="#8FB7E8"
+          style={{ backgroundColor: "#F8FBFF", width: "100%", height: "100%" }}
+        />
+      </div>
 
-        {showSearch ? (
-          <input
-            type="search"
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Search organizations"
-            className="den-input mb-3 px-3 py-2.5 text-[13px]"
-          />
-        ) : null}
+      <div
+        className="relative z-10 mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-md flex-col justify-center sm:min-h-[calc(100dvh-6rem)]"
+        data-testid="org-chooser-foreground"
+      >
+        <div className="den-frame w-full p-6 md:p-8">
+          <div className="mb-6 text-center">
+            <h1 className="den-title-lg">Choose an organization</h1>
+            <p className="mt-2 text-[13px] text-[var(--dls-text-secondary)]">
+              You belong to {orgs.length} organizations. Select one to continue.
+            </p>
+          </div>
 
-        <div className="den-frame-inset grid gap-2 rounded-[1.5rem] p-2" data-testid="org-chooser-list">
-          {visible.map((org) => (
-            <button
-              key={org.id}
-              type="button"
-              disabled={busy}
-              onClick={() => onSelect(org.slug)}
-              className="flex items-center justify-between gap-3 rounded-[1rem] px-3 py-2.5 text-left transition-colors hover:bg-white focus:outline-none focus:ring-4 focus:ring-slate-950/5 disabled:cursor-not-allowed disabled:bg-white"
-            >
-              <span className="flex min-w-0 items-center gap-3">
-                <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white text-[var(--dls-text-secondary)] shadow-sm">
-                  <Building2 className="h-4 w-4" strokeWidth={1.8} />
-                </span>
-                <span className="min-w-0">
-                  <span className="block truncate text-[14px] font-medium text-gray-900">{org.name}</span>
-                  <span className="block truncate text-[12px] text-gray-500">
-                    {formatRoleLabel(org.role)} • {org.memberCount} {org.memberCount === 1 ? "member" : "members"}
+          {showSearch ? (
+            <input
+              type="search"
+              value={query}
+              onChange={(event) => setQuery(event.target.value)}
+              placeholder="Search organizations"
+              className="den-input mb-3 px-3 py-2.5 text-[13px]"
+            />
+          ) : null}
+
+          <div
+            className="den-frame-inset grid gap-2 rounded-[1.5rem] p-2"
+            data-testid="org-chooser-list"
+          >
+            {visible.map((org) => (
+              <button
+                key={org.id}
+                type="button"
+                disabled={busy}
+                onClick={() => onSelect(org.slug)}
+                className="flex items-center justify-between gap-3 rounded-[1rem] px-3 py-2.5 text-left transition-colors hover:bg-white focus:outline-none focus:ring-4 focus:ring-slate-950/5 disabled:cursor-not-allowed disabled:bg-white"
+              >
+                <span className="flex min-w-0 items-center gap-3">
+                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white text-[var(--dls-text-secondary)] shadow-sm">
+                    <Building2 className="h-4 w-4" strokeWidth={1.8} />
+                  </span>
+                  <span className="min-w-0">
+                    <span className="block truncate text-[14px] font-medium text-gray-900">
+                      {org.name}
+                    </span>
+                    <span className="block truncate text-[12px] text-gray-500">
+                      {formatRoleLabel(org.role)} • {org.memberCount}{" "}
+                      {org.memberCount === 1 ? "member" : "members"}
+                    </span>
                   </span>
                 </span>
-              </span>
-              <ChevronRight className="h-4 w-4 shrink-0 text-gray-300" strokeWidth={2} />
-            </button>
-          ))}
-        </div>
+                <ChevronRight
+                  className="h-4 w-4 shrink-0 text-gray-300"
+                  strokeWidth={2}
+                />
+              </button>
+            ))}
+          </div>
 
-        {filteredCount === 0 && query ? (
-          <p className="mt-3 px-1 text-[13px] text-[var(--dls-text-secondary)]">No organizations match your search.</p>
-        ) : null}
-
-        {hasMore ? (
-          <div className="mt-3 flex items-center justify-between gap-3 px-1">
-            <p className="text-[12px] text-[var(--dls-text-secondary)]">
-              Showing {visible.length} of {filteredCount} organizations
+          {filteredCount === 0 && query ? (
+            <p className="mt-3 px-1 text-[13px] text-[var(--dls-text-secondary)]">
+              No organizations match your search.
             </p>
+          ) : null}
+
+          {hasMore ? (
+            <div className="mt-3 flex items-center justify-between gap-3 px-1">
+              <p className="text-[12px] text-[var(--dls-text-secondary)]">
+                Showing {visible.length} of {filteredCount} organizations
+              </p>
+              <button
+                type="button"
+                onClick={showMore}
+                className="shrink-0 rounded-full border border-[var(--dls-border)] bg-white px-3 py-1.5 text-[12px] font-medium text-gray-700 transition-colors hover:bg-slate-50"
+              >
+                Show more
+              </button>
+            </div>
+          ) : null}
+
+          {error ? (
+            <p className="mt-3 px-1 text-[12px] font-medium text-rose-600">
+              {error}
+            </p>
+          ) : null}
+
+          <div
+            className="mt-4 flex items-center justify-between gap-3 px-1"
+            data-testid="org-chooser-actions"
+          >
+            <Link
+              href="/organization"
+              className="flex items-center gap-1.5 text-[13px] font-medium text-[var(--dls-text-secondary)] transition-colors hover:text-[var(--dls-text-primary)] focus:outline-none focus:ring-4 focus:ring-slate-950/5"
+            >
+              <Plus className="h-4 w-4" /> Create or join
+            </Link>
             <button
               type="button"
-              onClick={showMore}
-              className="shrink-0 rounded-full border border-[var(--dls-border)] bg-white px-3 py-1.5 text-[12px] font-medium text-gray-700 transition-colors hover:bg-slate-50"
+              onClick={onSignOut}
+              className="flex items-center gap-1.5 text-[13px] font-medium text-[var(--dls-text-secondary)] transition-colors hover:text-[var(--dls-text-primary)] focus:outline-none focus:ring-4 focus:ring-slate-950/5"
             >
-              Show more
+              <LogOut className="h-4 w-4" /> Sign out
             </button>
           </div>
-        ) : null}
-
-        {error ? (
-          <p className="mt-3 px-1 text-[12px] font-medium text-rose-600">{error}</p>
-        ) : null}
-
-        <div className="mt-4 flex items-center justify-between gap-3 px-1" data-testid="org-chooser-actions">
-          <Link
-            href="/organization"
-            className="flex items-center gap-1.5 text-[13px] font-medium text-[var(--dls-text-secondary)] transition-colors hover:text-[var(--dls-text-primary)] focus:outline-none focus:ring-4 focus:ring-slate-950/5"
-          >
-            <Plus className="h-4 w-4" /> Create or join
-          </Link>
-          <button
-            type="button"
-            onClick={onSignOut}
-            className="flex items-center gap-1.5 text-[13px] font-medium text-[var(--dls-text-secondary)] transition-colors hover:text-[var(--dls-text-primary)] focus:outline-none focus:ring-4 focus:ring-slate-950/5"
-          >
-            <LogOut className="h-4 w-4" /> Sign out
-          </button>
         </div>
       </div>
     </section>

--- a/ee/apps/den-web/tests/org-selection-background.test.ts
+++ b/ee/apps/den-web/tests/org-selection-background.test.ts
@@ -11,14 +11,17 @@ function readOrgSelectionSource() {
 }
 
 describe("org selection paper contract", () => {
-  test("uses the same paper page and frame surfaces as the join flow", () => {
+  test("uses the same light Dithering layer as the join flow", () => {
     const source = readOrgSelectionSource();
 
-    expect(source).toContain('className="den-page flex min-h-[calc(100vh-2.5rem)] w-full items-center py-6"');
-    expect(source).toContain('className="den-frame mx-auto w-full max-w-md p-6 md:p-8"');
+    expect(source).toContain('className="relative isolate min-h-dvh overflow-y-auto bg-[#f8fbff] px-4 py-8 text-slate-950 sm:py-12"');
+    expect(source).toContain('className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#f8fbff] opacity-[0.09]"');
+    expect(source).toContain('colorBack="#F8FBFF"');
+    expect(source).toContain('colorFront="#8FB7E8"');
+    expect(source).toContain("const shaderSpeed = reducedMotion ? 0 : 0.012;");
+    expect(source).toContain('data-shader-speed={shaderSpeed}');
     expect(source).toContain('className="den-frame-inset grid gap-2 rounded-[1.5rem] p-2"');
     expect(source).not.toContain("bg-[#0f1d31]");
-    expect(source).not.toContain("Dithering");
     expect(source).not.toContain("PaperMeshGradient");
   });
 

--- a/evals/flows/org-chooser-background.flow.mjs
+++ b/evals/flows/org-chooser-background.flow.mjs
@@ -203,6 +203,10 @@ async function waitForChooser(ctx) {
     `Boolean(document.querySelector('[data-testid="org-chooser-root"]')) && document.body.innerText.includes('Choose an organization')`,
     { timeoutMs: 60_000, label: "organization chooser" },
   );
+  await ctx.waitFor(
+    `Boolean(document.querySelector('[data-testid="org-chooser-background"] canvas'))`,
+    { timeoutMs: 30_000, label: "light Dithering canvas" },
+  );
 }
 
 async function forceChooser(ctx) {
@@ -236,10 +240,12 @@ async function openFreshChooser(ctx) {
 async function chooserVisualState(ctx) {
   return ctx.eval(`(() => {
     const root = document.querySelector('[data-testid="org-chooser-root"]');
+    const background = document.querySelector('[data-testid="org-chooser-background"]');
     const foreground = document.querySelector('[data-testid="org-chooser-foreground"]');
     const list = document.querySelector('[data-testid="org-chooser-list"]');
     const actions = document.querySelector('[data-testid="org-chooser-actions"]');
     const rootStyle = root ? getComputedStyle(root) : null;
+    const backgroundStyle = background ? getComputedStyle(background) : null;
     const foregroundStyle = foreground ? getComputedStyle(foreground) : null;
     const listStyle = list ? getComputedStyle(list) : null;
     const foregroundRect = foreground?.getBoundingClientRect();
@@ -252,6 +258,12 @@ async function chooserVisualState(ctx) {
       rootMinHeight: rootStyle?.minHeight ?? null,
       rootOverflowY: rootStyle?.overflowY ?? null,
       rootBackgroundColor: rootStyle?.backgroundColor ?? null,
+      backgroundAriaHidden: background?.getAttribute('aria-hidden') ?? null,
+      backgroundPointerEvents: backgroundStyle?.pointerEvents ?? null,
+      backgroundOpacity: backgroundStyle?.opacity ?? null,
+      backgroundMotion: background?.getAttribute('data-motion') ?? null,
+      backgroundShaderSpeed: background?.getAttribute('data-shader-speed') ?? null,
+      backgroundCanvasCount: background?.querySelectorAll('canvas').length ?? 0,
       rootCanvasCount: root?.querySelectorAll('canvas').length ?? 0,
       foregroundBackgroundColor: foregroundStyle?.backgroundColor ?? null,
       foregroundBorderRadius: foregroundStyle?.borderRadius ?? null,
@@ -310,7 +322,7 @@ async function selectTargetOrg(ctx) {
 
 export default {
   id: "org-chooser-background",
-  title: "Organization chooser uses the join flow's light-paper treatment",
+  title: "Organization chooser uses the join flow's light-paper Dithering treatment",
   kind: "user-facing",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_DEN_MULTI_ORG"],
   steps: [
@@ -323,7 +335,7 @@ export default {
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("The real organization chooser opens on the join flow's light-paper surface", {
+        await ctx.prove("The real organization chooser opens on the join flow's light-paper Dithering surface", {
           voiceover: vo[0],
           action: async () => {
             await openFreshChooser(ctx);
@@ -331,13 +343,14 @@ export default {
           assert: async () => {
             await ctx.expectText("Choose an organization");
             const visual = await chooserVisualState(ctx);
-            ctx.assert(visual.rootCanvasCount === 0, `The chooser should not render a separate shader: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.backgroundCanvasCount === 1 && visual.rootCanvasCount === 1, `Expected one light paper shader canvas: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.rootBackgroundColor === "rgb(248, 251, 255)", `Unexpected light paper background: ${JSON.stringify(visual)}`);
             ctx.assert(visual.foregroundBackgroundColor.startsWith("rgba(255, 255, 255,"), `The chooser is not using the light paper frame: ${JSON.stringify(visual)}`);
             ctx.assert(visual.foregroundBorderRadius === "32px", `The chooser frame does not match the join flow radius: ${JSON.stringify(visual)}`);
           },
           screenshot: {
             name: "chooser-light-paper",
-            claim: "The organization chooser opens on the same light-paper card treatment as the join flow.",
+            claim: "The organization chooser opens on the same light-paper Dithering treatment as the join flow.",
             requireText: ["Choose an organization", state.targetOrg?.name ?? EVAL_ORG_NAME],
             rejectText: ["Something went wrong"],
           },
@@ -354,12 +367,14 @@ export default {
           },
           assert: async () => {
             const visual = await chooserVisualState(ctx);
+            ctx.assert(visual.backgroundAriaHidden === "true" && visual.backgroundPointerEvents === "none", `The paper shader should remain decorative: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.backgroundOpacity === "0.09" && visual.backgroundMotion === "ambient" && visual.backgroundShaderSpeed === "0.012", `The paper shader should stay subtle and slow: ${JSON.stringify(visual)}`);
             ctx.assert(visual.foregroundOpacity === "1" && visual.listOpacity === "1", `Foreground/list opacity should stay fully legible: ${JSON.stringify(visual)}`);
             ctx.assert(visual.listBackgroundColor.startsWith("rgba(248, 250, 252,"), `Org list is not using the light inset surface: ${JSON.stringify(visual)}`);
           },
           screenshot: {
             name: "chooser-readable-list",
-            claim: "The light paper frame contains a crisp, readable inset organization list.",
+            claim: "The subtle light-paper animation sits behind a crisp, readable inset organization list.",
             requireText: ["Choose an organization", "member"],
             rejectText: ["Something went wrong"],
           },
@@ -407,7 +422,7 @@ export default {
           assert: async () => {
             const visual = await chooserVisualState(ctx);
             ctx.assert(visual.viewportWidth <= 430, `Mobile viewport was not applied: ${JSON.stringify(visual)}`);
-            ctx.assert(typeof visual.rootMinHeight === "string" && visual.rootMinHeight.endsWith("px"), `Chooser shell is not tall enough for the viewport: ${JSON.stringify(visual)}`);
+            ctx.assert(visual.rootOverflowY === "auto" && typeof visual.rootMinHeight === "string" && visual.rootMinHeight.endsWith("px"), `Chooser shell is not scroll-safe: ${JSON.stringify(visual)}`);
             ctx.assert(visual.foregroundWithinViewport && visual.listWithinViewport, `Chooser content overflowed the mobile viewport: ${JSON.stringify(visual)}`);
             ctx.assert(visual.listBackgroundColor.startsWith("rgba(248, 250, 252,"), `Mobile org list is not using the readable inset surface: ${JSON.stringify(visual)}`);
             ctx.assert(visual.actionsText.includes("Create or join") && visual.actionsText.includes("Sign out"), `Mobile actions are not visible: ${JSON.stringify(visual)}`);

--- a/evals/voiceovers/org-chooser-background.md
+++ b/evals/voiceovers/org-chooser-background.md
@@ -1,6 +1,6 @@
 # org-chooser-background — Organization chooser paper surface
 
-1. “The organization chooser opens on the same calm light-paper surface as the join flow, so moving between account steps feels seamless.”
+1. “The organization chooser opens on the same calm light-paper Dithering surface as the join flow, so moving between account steps feels seamless.”
 
 2. “The organization list sits inside a soft inset card, keeping the choices crisp, readable, and accessible.”
 


### PR DESCRIPTION
## Summary\n- apply the join screen's pale Dithering palette and restrained animation to the organization chooser\n- preserve readable light paper cards and disable animation for reduced-motion users\n- update the chooser contract and frame proof\n\n## Tests\n- pnpm --dir "ee/apps/den-web" typecheck\n- pnpm --dir "packages/ui" build && pnpm --dir "ee/packages/utils" build && pnpm --dir "ee/apps/den-web" test