### PR TITLE
fix(app): gate starter-card provider auth behind allowCustomProviders policy

### DIFF
--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1086,6 +1086,18 @@ export function SessionRoute() {
     setCreateWorkspaceOpen(true);
   }, [checkDesktopRestriction, restrictionNotice, workspaces.length]);
 
+  const handleOpenProviderAuth = useCallback(() => {
+    // Keep the starter-card provider auth gate in parity with Settings.
+    if (checkDesktopRestriction({ restriction: "allowCustomProviders" })) {
+      restrictionNotice.show({
+        title: "Adding custom providers is disabled",
+        message: "Your organization administrator has disabled adding custom providers.",
+      });
+      return;
+    }
+    void sessionProviderAuthStore.openProviderAuthModal({ returnFocusTarget: "composer" });
+  }, [checkDesktopRestriction, restrictionNotice, sessionProviderAuthStore]);
+
   const handleOpenRenameWorkspace = useCallback((workspaceId: string) => {
     const workspace = workspaces.find((item) => item.id === workspaceId);
     if (!workspace) return;
@@ -1902,7 +1914,7 @@ export function SessionRoute() {
         );
       }}
       onOpenSettings={() => handleOpenSettings("/settings/general")}
-      onOpenProviderAuth={() => sessionProviderAuthStore.openProviderAuthModal({ returnFocusTarget: "composer" })}
+      onOpenProviderAuth={handleOpenProviderAuth}
       providerAuthModal={sessionProviderAuthSnapshot.providerAuthModalOpen ? {
         open: true,
         loading: false,

--- a/evals/flows/desktop-policy-starter-provider-gate.flow.mjs
+++ b/evals/flows/desktop-policy-starter-provider-gate.flow.mjs
@@ -1,0 +1,200 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "desktop-policy-starter-provider-gate";
+const STARTER_CARD = "Connect a model provider";
+const PROVIDER_DIALOG = "Connect providers";
+const RESTRICTION_TITLE = "Adding custom providers is disabled";
+const POLICY_ACTIVE = "Organization policies active";
+const CLOSE_LABEL = "Close";
+
+// Narration is loaded from the approved script (evals/voiceovers/desktop-policy-starter-provider-gate.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+async function applyDesktopConfig(ctx, config) {
+  await ctx.eval(`(() => {
+    const bridge = window.__openworkApplyDesktopConfig;
+    if (typeof bridge !== 'function') throw new Error('Desktop config bridge not available');
+    bridge(${JSON.stringify(config)});
+    return true;
+  })()`);
+}
+
+async function closeProviderDialog(ctx) {
+  const isOpen = await ctx.hasText(PROVIDER_DIALOG);
+  if (!isOpen) return;
+  await ctx.eval(`(() => {
+    const target = document.querySelector('[role="dialog"]') ?? document;
+    target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true, cancelable: true }));
+    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true, cancelable: true }));
+    return true;
+  })()`);
+  await ctx.waitFor(
+    `!document.body.innerText.includes(${JSON.stringify(PROVIDER_DIALOG)})`,
+    { timeoutMs: 5_000, label: "provider dialog closed" },
+  );
+}
+
+async function closeRestrictionNotice(ctx) {
+  const isOpen = await ctx.hasText(RESTRICTION_TITLE);
+  if (!isOpen) return;
+  await ctx.clickText(CLOSE_LABEL, { timeoutMs: 5_000 });
+  await ctx.waitFor(
+    `!document.body.innerText.includes(${JSON.stringify(RESTRICTION_TITLE)})`,
+    { timeoutMs: 5_000, label: "restriction notice closed" },
+  );
+}
+
+async function closeStaleDialogs(ctx) {
+  await closeRestrictionNotice(ctx);
+  await closeProviderDialog(ctx);
+}
+
+async function closeNotificationCenter(ctx) {
+  await ctx.eval("document.body.click()");
+  await ctx.waitFor(
+    `!document.body.innerText.includes(${JSON.stringify(POLICY_ACTIVE)})`,
+    { timeoutMs: 5_000, label: "notification center closed" },
+  );
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Starter card honors the org provider policy",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Setup",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 30_000,
+          label: "window.__openworkControl",
+        });
+        await ctx.eval(`(() => {
+          localStorage.setItem('openwork.react.settings.theme-mode', 'light');
+          const bridge = window.__openworkApplyDesktopConfig;
+          if (typeof bridge === 'function') bridge({});
+          return true;
+        })()`);
+        await ctx.eval("location.reload()");
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 30_000,
+          label: "control API after reload",
+        });
+        await ctx.navigateHash("/session");
+        await ctx.waitFor("document.body.innerText.trim().length > 40", {
+          label: "rendered body text",
+        });
+      },
+    },
+    {
+      name: "Starter card is visible before providers are connected",
+      run: async (ctx) => {
+        await ctx.prove("Fresh empty session shows the provider starter card", {
+          claim: "With no connected providers and no active policy, the empty session screen offers a Connect a model provider card.",
+          voiceover: vo[0],
+          assert: async () => {
+            await ctx.expectText(STARTER_CARD);
+          },
+          screenshot: {
+            name: "starter-card-visible",
+            requireText: [STARTER_CARD],
+          },
+        });
+      },
+    },
+    {
+      name: "Provider dialog opens when no policy is active",
+      run: async (ctx) => {
+        await ctx.prove("Starter card opens the provider dialog when allowed", {
+          claim: "Clicking the starter card opens the provider connection dialog while custom providers are allowed.",
+          voiceover: vo[1],
+          action: async () => {
+            await closeStaleDialogs(ctx);
+            await ctx.clickText(STARTER_CARD);
+          },
+          assert: async () => {
+            await ctx.expectText(PROVIDER_DIALOG);
+          },
+          screenshot: {
+            name: "provider-dialog-allowed",
+            requireText: [PROVIDER_DIALOG],
+          },
+        });
+        await closeProviderDialog(ctx);
+      },
+    },
+    {
+      name: "Policy injection is visible in the notification center",
+      run: async (ctx) => {
+        await ctx.prove("Organization policy activation is surfaced to the user", {
+          claim: "When custom providers are disabled by policy, the notification center tells the user organization policies are active.",
+          voiceover: vo[2],
+          action: async () => {
+            await closeStaleDialogs(ctx);
+            await applyDesktopConfig(ctx, { allowCustomProviders: false });
+            await ctx.waitFor(`(() => {
+              const bell = document.querySelector('[title="Notifications"]');
+              if (!bell) return false;
+              bell.click();
+              return true;
+            })()`, { timeoutMs: 5_000, label: "notification button" });
+          },
+          assert: async () => {
+            await ctx.expectText(POLICY_ACTIVE);
+          },
+          screenshot: {
+            name: "policy-active-notification",
+            requireText: [POLICY_ACTIVE],
+          },
+        });
+        await closeNotificationCenter(ctx);
+      },
+    },
+    {
+      name: "Restricted policy blocks the starter-card provider dialog",
+      run: async (ctx) => {
+        await ctx.prove("Starter card shows the restriction notice instead of the provider dialog", {
+          claim: "With custom providers disabled, clicking the starter card shows the same restriction notice as Settings and does not open the provider dialog.",
+          voiceover: vo[3],
+          action: async () => {
+            await closeStaleDialogs(ctx);
+            await ctx.clickText(STARTER_CARD);
+          },
+          assert: async () => {
+            await ctx.expectText(RESTRICTION_TITLE);
+            await ctx.expectNoText(PROVIDER_DIALOG);
+          },
+          screenshot: {
+            name: "starter-card-restricted",
+            requireText: [RESTRICTION_TITLE],
+            rejectText: [PROVIDER_DIALOG],
+          },
+        });
+        await closeRestrictionNotice(ctx);
+      },
+    },
+    {
+      name: "Clearing the policy restores the provider dialog",
+      run: async (ctx) => {
+        await ctx.prove("Starter card opens the provider dialog again after the policy is lifted", {
+          claim: "After the organization policy is cleared, the same starter card opens the provider connection dialog again.",
+          voiceover: vo[4],
+          action: async () => {
+            await closeStaleDialogs(ctx);
+            await applyDesktopConfig(ctx, {});
+            await ctx.clickText(STARTER_CARD);
+          },
+          assert: async () => {
+            await ctx.expectText(PROVIDER_DIALOG);
+          },
+          screenshot: {
+            name: "provider-dialog-restored",
+            requireText: [PROVIDER_DIALOG],
+          },
+        });
+        await closeProviderDialog(ctx);
+      },
+    },
+  ],
+};

--- a/evals/flows/desktop-policy-starter-provider-gate.flow.mjs
+++ b/evals/flows/desktop-policy-starter-provider-gate.flow.mjs
@@ -2,14 +2,22 @@ import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
 const FLOW_ID = "desktop-policy-starter-provider-gate";
 const STARTER_CARD = "Connect a model provider";
+const STARTER_CARD_DESCRIPTION = "Add an API key for Anthropic, OpenAI, Google, or other providers";
 const PROVIDER_DIALOG = "Connect providers";
 const RESTRICTION_TITLE = "Adding custom providers is disabled";
 const POLICY_ACTIVE = "Organization policies active";
-const CLOSE_LABEL = "Close";
+const SETTINGS_POLICY_COPY = "managed by your organization";
+const SETTINGS_POLICY_BANNER = '[data-testid="desktop-policy-banner"]';
+const NEW_SESSION_TITLE = "New session";
+const DELETE_SESSION_LABEL = "Delete session";
+const DELETE_SESSION_DIALOG = "Delete session?";
+const DELETE_LABEL = "Delete";
 
 // Narration is loaded from the approved script (evals/voiceovers/desktop-policy-starter-provider-gate.md).
 // The runner fails this flow if the narration drifts from that script.
 const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const settle = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
 async function applyDesktopConfig(ctx, config) {
   await ctx.eval(`(() => {
@@ -20,34 +28,56 @@ async function applyDesktopConfig(ctx, config) {
   })()`);
 }
 
-async function closeProviderDialog(ctx) {
-  const isOpen = await ctx.hasText(PROVIDER_DIALOG);
-  if (!isOpen) return;
-  await ctx.eval(`(() => {
-    const target = document.querySelector('[role="dialog"]') ?? document;
-    target.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true, cancelable: true }));
-    document.dispatchEvent(new KeyboardEvent('keydown', { key: 'Escape', code: 'Escape', bubbles: true, cancelable: true }));
-    return true;
-  })()`);
-  await ctx.waitFor(
-    `!document.body.innerText.includes(${JSON.stringify(PROVIDER_DIALOG)})`,
-    { timeoutMs: 5_000, label: "provider dialog closed" },
-  );
-}
-
-async function closeRestrictionNotice(ctx) {
-  const isOpen = await ctx.hasText(RESTRICTION_TITLE);
-  if (!isOpen) return;
-  await ctx.clickText(CLOSE_LABEL, { timeoutMs: 5_000 });
-  await ctx.waitFor(
-    `!document.body.innerText.includes(${JSON.stringify(RESTRICTION_TITLE)})`,
-    { timeoutMs: 5_000, label: "restriction notice closed" },
-  );
-}
-
 async function closeStaleDialogs(ctx) {
-  await closeRestrictionNotice(ctx);
-  await closeProviderDialog(ctx);
+  for (let attempt = 0; attempt < 6; attempt += 1) {
+    const state = await ctx.eval(`(() => {
+      const dialogs = [...document.querySelectorAll('[role="dialog"], [role="alertdialog"]')];
+      return {
+        count: dialogs.length,
+        restrictionOpen: dialogs.some((dialog) => dialog.innerText.includes(${JSON.stringify(RESTRICTION_TITLE)})),
+        providerOpen: dialogs.some((dialog) => dialog.innerText.includes(${JSON.stringify(PROVIDER_DIALOG)})),
+        modelUnavailableOpen: dialogs.some((dialog) => dialog.innerText.includes('no longer available')),
+      };
+    })()`);
+    if (state.count === 0) return;
+
+    if (state.restrictionOpen) {
+      await ctx.eval(`(() => {
+        const dialogs = [...document.querySelectorAll('[role="dialog"], [role="alertdialog"]')];
+        const dialog = dialogs.find((entry) => entry.innerText.includes(${JSON.stringify(RESTRICTION_TITLE)}));
+        if (!dialog) return false;
+        const buttons = [...dialog.querySelectorAll('button')];
+        const closeButton = buttons.find((button) => button.textContent.trim() === 'Close');
+        if (!closeButton) return false;
+        closeButton.click();
+        return true;
+      })()`);
+    } else {
+      await ctx.eval(`(() => {
+        const eventInit = { key: 'Escape', code: 'Escape', bubbles: true, cancelable: true };
+        document.dispatchEvent(new KeyboardEvent('keydown', eventInit));
+        const dialogs = [...document.querySelectorAll('[role="dialog"], [role="alertdialog"]')];
+        for (const dialog of dialogs) {
+          dialog.dispatchEvent(new KeyboardEvent('keydown', eventInit));
+        }
+        return true;
+      })()`);
+    }
+
+    await settle(200);
+  }
+
+  const remaining = await ctx.eval("document.querySelectorAll('[role=\"dialog\"], [role=\"alertdialog\"]').length");
+  ctx.assert(remaining === 0, `Expected stale dialogs to close; ${remaining} dialog(s) remain.`);
+}
+
+async function openNotificationCenter(ctx) {
+  await ctx.waitFor(`(() => {
+    const bell = document.querySelector('[title="Notifications"]');
+    if (!bell) return false;
+    bell.click();
+    return true;
+  })()`, { timeoutMs: 5_000, label: "notification button" });
 }
 
 async function closeNotificationCenter(ctx) {
@@ -55,6 +85,87 @@ async function closeNotificationCenter(ctx) {
   await ctx.waitFor(
     `!document.body.innerText.includes(${JSON.stringify(POLICY_ACTIVE)})`,
     { timeoutMs: 5_000, label: "notification center closed" },
+  );
+}
+
+async function reachEmptyStateStarterCard(ctx) {
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    await ctx.navigateHash("/session");
+    await ctx.waitFor("document.body.innerText.trim().length > 40", {
+      label: "session page rendered",
+    });
+    await closeStaleDialogs(ctx);
+
+    const sessionSelected = await ctx.eval("location.hash.includes('/session/ses_')");
+    if (!sessionSelected) break;
+
+    const foundSidebarRow = await ctx.eval(`(() => {
+      const link = [...document.querySelectorAll('a')]
+        .find((entry) => entry.textContent.trim() === ${JSON.stringify(NEW_SESSION_TITLE)});
+      if (!link) return false;
+      link.scrollIntoView({ block: 'center' });
+      const rect = link.getBoundingClientRect();
+      link.dispatchEvent(new MouseEvent('contextmenu', {
+        bubbles: true,
+        cancelable: true,
+        clientX: rect.x + 20,
+        clientY: rect.y + 5,
+        button: 2,
+      }));
+      return true;
+    })()`);
+
+    if (foundSidebarRow) {
+      await ctx.waitFor("Boolean(document.querySelector('[role=\"menu\"]'))", {
+        timeoutMs: 5_000,
+        label: "session context menu",
+      });
+      await ctx.waitFor(`(() => {
+        const item = [...document.querySelectorAll('[role="menuitem"]')]
+          .find((entry) => entry.textContent.trim() === ${JSON.stringify(DELETE_SESSION_LABEL)});
+        if (!item) return false;
+        item.click();
+        return true;
+      })()`, { timeoutMs: 5_000, label: "delete session menu item" });
+      await ctx.waitFor(`(() => {
+        const dialogs = [...document.querySelectorAll('[role="dialog"], [role="alertdialog"]')];
+        return dialogs.some((dialog) => dialog.innerText.includes(${JSON.stringify(DELETE_SESSION_DIALOG)}));
+      })()`, { timeoutMs: 5_000, label: "delete session confirmation" });
+      await ctx.waitFor(`(() => {
+        const dialogs = [...document.querySelectorAll('[role="dialog"], [role="alertdialog"]')];
+        const dialog = dialogs.find((entry) => entry.innerText.includes(${JSON.stringify(DELETE_SESSION_DIALOG)}));
+        if (!dialog) return false;
+        const button = [...dialog.querySelectorAll('button')]
+          .find((entry) => entry.textContent.trim() === ${JSON.stringify(DELETE_LABEL)});
+        if (!button) return false;
+        button.click();
+        return true;
+      })()`, { timeoutMs: 5_000, label: "delete session confirm button" });
+      await ctx.waitFor("!location.hash.includes('/session/ses_')", {
+        timeoutMs: 20_000,
+        label: "draft session removed from route",
+      });
+      break;
+    }
+
+    ctx.log("Selected draft session is not listed in the sidebar; reloading to clear it.");
+    await ctx.eval("location.reload()");
+    await ctx.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 30_000,
+      label: "control API after clearing draft session",
+    });
+    await applyDesktopConfig(ctx, { allowZenModel: false, allowCustomProviders: false });
+    await settle(800);
+    await closeStaleDialogs(ctx);
+  }
+
+  await ctx.waitFor(
+    `document.body.innerText.includes(${JSON.stringify(STARTER_CARD)})`,
+    { timeoutMs: 20_000, label: "starter provider card title" },
+  );
+  await ctx.waitFor(
+    `document.body.innerText.includes(${JSON.stringify(STARTER_CARD_DESCRIPTION)})`,
+    { timeoutMs: 20_000, label: "starter provider card description" },
   );
 }
 
@@ -85,60 +196,20 @@ export default {
         await ctx.waitFor("document.body.innerText.trim().length > 40", {
           label: "rendered body text",
         });
+        await closeStaleDialogs(ctx);
       },
     },
     {
-      name: "Starter card is visible before providers are connected",
+      name: "Policy activation is announced",
       run: async (ctx) => {
-        await ctx.prove("Fresh empty session shows the provider starter card", {
-          claim: "With no connected providers and no active policy, the empty session screen offers a Connect a model provider card.",
+        await ctx.prove("Policy activation appears in the notification center", {
+          claim: "When the admin disables Zen models and custom providers, OpenWork announces active organization policies.",
           voiceover: vo[0],
-          assert: async () => {
-            await ctx.expectText(STARTER_CARD);
-          },
-          screenshot: {
-            name: "starter-card-visible",
-            requireText: [STARTER_CARD],
-          },
-        });
-      },
-    },
-    {
-      name: "Provider dialog opens when no policy is active",
-      run: async (ctx) => {
-        await ctx.prove("Starter card opens the provider dialog when allowed", {
-          claim: "Clicking the starter card opens the provider connection dialog while custom providers are allowed.",
-          voiceover: vo[1],
           action: async () => {
+            await applyDesktopConfig(ctx, { allowZenModel: false, allowCustomProviders: false });
+            await settle(1_000);
             await closeStaleDialogs(ctx);
-            await ctx.clickText(STARTER_CARD);
-          },
-          assert: async () => {
-            await ctx.expectText(PROVIDER_DIALOG);
-          },
-          screenshot: {
-            name: "provider-dialog-allowed",
-            requireText: [PROVIDER_DIALOG],
-          },
-        });
-        await closeProviderDialog(ctx);
-      },
-    },
-    {
-      name: "Policy injection is visible in the notification center",
-      run: async (ctx) => {
-        await ctx.prove("Organization policy activation is surfaced to the user", {
-          claim: "When custom providers are disabled by policy, the notification center tells the user organization policies are active.",
-          voiceover: vo[2],
-          action: async () => {
-            await closeStaleDialogs(ctx);
-            await applyDesktopConfig(ctx, { allowCustomProviders: false });
-            await ctx.waitFor(`(() => {
-              const bell = document.querySelector('[title="Notifications"]');
-              if (!bell) return false;
-              bell.click();
-              return true;
-            })()`, { timeoutMs: 5_000, label: "notification button" });
+            await openNotificationCenter(ctx);
           },
           assert: async () => {
             await ctx.expectText(POLICY_ACTIVE);
@@ -152,10 +223,57 @@ export default {
       },
     },
     {
+      name: "Settings confirms managed policies",
+      run: async (ctx) => {
+        await ctx.prove("Settings shows the managed-by-organization policy banner", {
+          claim: "Settings confirms that organization policy is managing this install.",
+          voiceover: vo[1],
+          action: async () => {
+            await closeStaleDialogs(ctx);
+            await ctx.navigateHash("/settings/general");
+            await ctx.waitForText("Settings", { timeoutMs: 10_000 });
+            await ctx.waitFor(
+              `Boolean(document.querySelector(${JSON.stringify(SETTINGS_POLICY_BANNER)}))`,
+              { timeoutMs: 5_000, label: "desktop policy banner" },
+            );
+            await settle(2_000);
+            await closeStaleDialogs(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText(SETTINGS_POLICY_COPY);
+          },
+          screenshot: {
+            name: "settings-policy-banner",
+            requireText: [SETTINGS_POLICY_COPY],
+          },
+        });
+      },
+    },
+    {
+      name: "Empty workspace reveals the starter card",
+      run: async (ctx) => {
+        await ctx.prove("No usable model leaves the workspace get-started provider card visible", {
+          claim: "With Zen models blocked and no other providers connected, the empty workspace shows the provider starter card.",
+          voiceover: vo[2],
+          action: async () => {
+            await reachEmptyStateStarterCard(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText(STARTER_CARD);
+            await ctx.expectText(STARTER_CARD_DESCRIPTION);
+          },
+          screenshot: {
+            name: "empty-state-provider-card",
+            requireText: [STARTER_CARD, STARTER_CARD_DESCRIPTION],
+          },
+        });
+      },
+    },
+    {
       name: "Restricted policy blocks the starter-card provider dialog",
       run: async (ctx) => {
         await ctx.prove("Starter card shows the restriction notice instead of the provider dialog", {
-          claim: "With custom providers disabled, clicking the starter card shows the same restriction notice as Settings and does not open the provider dialog.",
+          claim: "With custom providers disabled by org policy, the starter card shows the same restriction notice as Settings instead of opening the provider dialog.",
           voiceover: vo[3],
           action: async () => {
             await closeStaleDialogs(ctx);
@@ -171,18 +289,18 @@ export default {
             rejectText: [PROVIDER_DIALOG],
           },
         });
-        await closeRestrictionNotice(ctx);
+        await closeStaleDialogs(ctx);
       },
     },
     {
       name: "Clearing the policy restores the provider dialog",
       run: async (ctx) => {
-        await ctx.prove("Starter card opens the provider dialog again after the policy is lifted", {
-          claim: "After the organization policy is cleared, the same starter card opens the provider connection dialog again.",
+        await ctx.prove("Starter card opens the provider dialog again after custom providers are allowed", {
+          claim: "When the admin lifts the custom-provider restriction, the same starter card opens the provider dialog again.",
           voiceover: vo[4],
           action: async () => {
-            await closeStaleDialogs(ctx);
             await applyDesktopConfig(ctx, {});
+            await settle(800);
             await ctx.clickText(STARTER_CARD);
           },
           assert: async () => {
@@ -193,7 +311,11 @@ export default {
             requireText: [PROVIDER_DIALOG],
           },
         });
-        await closeProviderDialog(ctx);
+        await closeStaleDialogs(ctx);
+        await ctx.navigateHash("/settings/general");
+        await ctx.waitForText("Settings", { timeoutMs: 10_000 });
+        await settle(2_000);
+        await ctx.navigateHash("/session");
       },
     },
   ],

--- a/evals/voiceovers/desktop-policy-starter-provider-gate.md
+++ b/evals/voiceovers/desktop-policy-starter-provider-gate.md
@@ -1,0 +1,11 @@
+# desktop-policy-starter-provider-gate — Starter card honors the org provider policy
+
+1. "I open OpenWork on a fresh machine with no model providers connected. The get-started screen offers a Connect a model provider card."
+
+2. "I click the card and the provider connection dialog opens. No organization policy is active, so nothing is restricted."
+
+3. "My organization's admin now disables custom providers by policy. OpenWork signals the change: organization policies are active on this device."
+
+4. "I click Connect a model provider again. Instead of the provider dialog, OpenWork tells me my administrator has disabled adding custom providers, the same message Settings shows."
+
+5. "The admin lifts the policy and I click the card once more. The provider dialog opens again, so the starter screen follows organization policy exactly like the rest of the app."

--- a/evals/voiceovers/desktop-policy-starter-provider-gate.md
+++ b/evals/voiceovers/desktop-policy-starter-provider-gate.md
@@ -1,11 +1,11 @@
 # desktop-policy-starter-provider-gate — Starter card honors the org provider policy
 
-1. "I open OpenWork on a fresh machine with no model providers connected. The get-started screen offers a Connect a model provider card."
+1. "My organization manages this OpenWork install. The admin disables OpenCode Zen models and custom providers, and OpenWork announces that organization policies are active on this device."
 
-2. "I click the card and the provider connection dialog opens. No organization policy is active, so nothing is restricted."
+2. "Settings confirms it: some features and appearance settings are managed by my organization."
 
-3. "My organization's admin now disables custom providers by policy. OpenWork signals the change: organization policies are active on this device."
+3. "With Zen models blocked and no other providers connected, the workspace get-started screen invites me to connect a model provider."
 
-4. "I click Connect a model provider again. Instead of the provider dialog, OpenWork tells me my administrator has disabled adding custom providers, the same message Settings shows."
+4. "I click Connect a model provider. Instead of the provider dialog, OpenWork shows the same restriction message as Settings: my administrator has disabled adding custom providers."
 
-5. "The admin lifts the policy and I click the card once more. The provider dialog opens again, so the starter screen follows organization policy exactly like the rest of the app."
+5. "When the admin lifts the restriction, the very same card opens the provider dialog again. The get-started screen follows organization policy exactly like the rest of the app."


### PR DESCRIPTION
## What

The **"Connect a model provider"** starter card on the session get-started screen (\`session-page.tsx\` empty state) opened the provider-connection modal **without checking the \`allowCustomProviders\` desktop policy** — letting members of managed orgs bypass the restriction that Settings (\`settings-route.tsx\` \`handleOpenProviderAuth\`) and the AI control action \`settings.provider.add\` already enforce.

**Fix**: \`session-route.tsx\` wires the card through a gated \`handleOpenProviderAuth\` that mirrors the Settings pattern exactly — same restriction check, same notice copy ("Adding custom providers is disabled").

## Why it matters

This state is reachable in the real enterprise journey: when an org policy disables OpenCode Zen models (\`allowZenModel: false\`), the member's default model becomes unavailable and the zen provider gets disabled server-side — the get-started screen then shows the "Connect a model provider" card. Before this fix, clicking it opened the modal even when the org had also disabled custom providers.

## Proof (fraimz)

New coded flow \`desktop-policy-starter-provider-gate\` (+ approved voiceover) drives the full journey on a fresh Daytona sandbox via CDP:

1. Policy \`{ allowZenModel: false, allowCustomProviders: false }\` injected → "Organization policies active" notification
2. Settings shows the managed-by-organization banner (zen provider disabled server-side by the sync effect)
3. Get-started screen shows the "Connect a model provider" card (no usable model, zero connected providers)
4. **Click card → restriction notice, provider dialog does NOT open** (the fix)
5. Policy lifted → same card opens the "Connect providers" dialog again

## Tests run

- \`pnpm typecheck\` — passed
- \`pnpm fraimz --flow desktop-policy-starter-provider-gate --cdp-url <daytona-sandbox>\` — **PASSED (7/7 steps), twice consecutively (idempotent)**; validated frame-by-frame proof posted below via \`pnpm fraimz --flow <id> --pr\`

## Out of scope (reported)

- \`allowManageExtensions\` / \`allowControlSettings\` / \`showWelcomePage\` are enforced nowhere in the app UI today; gating only the "Connect an extension" starter card would be inconsistent, so it is left ungated.
- The onboarding welcome/provider-selection steps don't check desktop policies either (pre-existing).