### PR TITLE
fix(app): retry Cloud agent access after reconnect

### DIFF
--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -316,6 +316,45 @@ function AgentAccessCard(props: {
     };
   }, [props.client, props.currentModel, props.workspaceId, signedIn]);
 
+  useEffect(() => {
+    if (!props.client || !context || !signedIn || typeof window === "undefined") return;
+    const client = props.client;
+    let cancelled = false;
+    const retryAfterReconnect = () => {
+      if (window.navigator.onLine === false) return;
+      void runOpenworkCloudMcpReconciler({
+        mode: "repair",
+        client,
+        context: { ...context, trigger: "desktop-connect-online-retry" },
+        mintToken: mintCloudControlMcpToken,
+        refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+      })
+        .then((result) => {
+          if (cancelled || !result.health) return;
+          updateHealth(result.health);
+          if (result.health.usable) setError(null);
+        })
+        .catch((nextError) => {
+          if (!cancelled) setError(nextError instanceof Error ? nextError.message : "Could not restore agent access.");
+        });
+    };
+
+    window.addEventListener("online", retryAfterReconnect);
+    return () => {
+      cancelled = true;
+      window.removeEventListener("online", retryAfterReconnect);
+    };
+  }, [
+    context?.denAuthToken,
+    context?.denBaseUrl,
+    context?.orgId,
+    context?.serverBaseUrl,
+    props.client,
+    props.currentModel,
+    props.workspaceId,
+    signedIn,
+  ]);
+
   const canRun = Boolean(props.client && context && signedIn);
   const readyTools = readyCloudMcpToolIds(health);
 

--- a/apps/app/tests/connect-view.test.ts
+++ b/apps/app/tests/connect-view.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { describe, expect, test } from "bun:test";
 
 import type { OpenworkCloudMcpHealth } from "../src/app/lib/openwork-server";
@@ -13,6 +15,11 @@ import {
   resolveConnectionRowGroup,
   resolveConnectRowGroup,
 } from "../src/react-app/domains/settings/connect-cloud-readiness";
+
+const connectViewSource = readFileSync(
+  fileURLToPath(new URL("../src/react-app/domains/settings/pages/connect-view.tsx", import.meta.url)),
+  "utf8",
+);
 
 describe("resolveConnectViewState", () => {
   test("shows loading while auth is being checked", () => {
@@ -76,6 +83,13 @@ describe("Agent access card helpers", () => {
       "openwork-cloud_search_capabilities",
       "openwork-cloud_execute_capability",
     ]);
+  });
+
+  test("retries Agent access through the repair reconciler when connectivity returns", () => {
+    expect(connectViewSource).toContain('window.addEventListener("online", retryAfterReconnect)');
+    expect(connectViewSource).toContain('window.removeEventListener("online", retryAfterReconnect)');
+    expect(connectViewSource).toContain('mode: "repair"');
+    expect(connectViewSource).toContain('trigger: "desktop-connect-online-retry"');
   });
 });
 


### PR DESCRIPTION
## Summary

- retry the workspace-wide OpenWork Cloud MCP repair when the desktop browser reports that network connectivity has returned
- refresh the visible Agent access health state after that retry, clearing the stale error when access is usable again
- reuse the existing reconciler's prerequisite checks, user-disabled intent, health probe, and in-flight repair deduplication

## Scope

This is intentionally limited to automatic recovery for the Agent access card. It does not change individual MCP connection OAuth, connector sign-in state, Den APIs, retry polling, or the Connect UI layout.

## Validation

- `pnpm --dir apps/app exec bun test --isolate tests/connect-view.test.ts` — 17 passed
- `pnpm --dir apps/app typecheck` — passed
- branch updated to the latest `upstream/dev`

## Manual verification

Not run in this PR preparation pass. Suggested desktop check:

1. Sign in and confirm Agent access is healthy.
2. Disconnect the VPN or network until Agent access becomes degraded.
3. Restore the VPN or network.
4. Confirm OpenWork automatically repairs and refreshes Agent access without clicking **Repair and test**.

## Risk

Low and localized. The listener only runs for signed-in users with a valid Cloud MCP context, is removed when the card unmounts, and delegates repair behavior to the existing reconciler.
