### PR TITLE
fix(app): cloud session survives control-plane outages and proxy 401s

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -324,6 +324,17 @@ export class DenApiError extends Error {
   }
 }
 
+/**
+ * True only for 401s that actually came from the Den API (its JSON error
+ * envelope parsed into a code). A bare/foreign 401 from a corporate proxy,
+ * captive portal, or LB while the control plane is unreachable must be
+ * treated as "unavailable", not as a revoked session — otherwise a VPN blip
+ * signs the user out and destroys the stored token.
+ */
+export function isDenSessionRevokedError(error: unknown): boolean {
+  return error instanceof DenApiError && error.status === 401 && error.code !== "request_failed";
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
@@ -774,6 +785,34 @@ export function readDenSettings(): DenSettings {
     activeOrgId: (window.localStorage.getItem(STORAGE_ACTIVE_ORG_ID) ?? "").trim() || null,
     activeOrgSlug: (window.localStorage.getItem(STORAGE_ACTIVE_ORG_SLUG) ?? "").trim() || null,
     activeOrgName: (window.localStorage.getItem(STORAGE_ACTIVE_ORG_NAME) ?? "").trim() || null,
+  };
+}
+
+function mergePassiveDenField(
+  current: string | null | undefined,
+  next: string | null | undefined,
+): string | null {
+  const trimmed = next?.trim() ?? "";
+  return trimmed || current || null;
+}
+
+/**
+ * Merge an in-memory den-session snapshot over the persisted settings for the
+ * PASSIVE state->storage mirror. A passive sync must never delete persisted
+ * credentials just because in-memory state has not (or could not) load them —
+ * e.g. while the control plane is unreachable the org list never loads, and
+ * mirroring `activeOrg: null` used to erase the stored org (and, after a
+ * remount race, the auth token), permanently signing the user out on a
+ * transient VPN/network outage. Explicit sign-out/change-server flows clear
+ * storage through clearDenSession()/saveControlPlaneUrl() instead.
+ */
+export function mergePassiveDenSettings(current: DenSettings, next: DenSettings): DenSettings {
+  return {
+    ...resolveDenBaseUrls(next),
+    authToken: mergePassiveDenField(current.authToken, next.authToken),
+    activeOrgId: mergePassiveDenField(current.activeOrgId, next.activeOrgId),
+    activeOrgSlug: mergePassiveDenField(current.activeOrgSlug, next.activeOrgSlug),
+    activeOrgName: mergePassiveDenField(current.activeOrgName, next.activeOrgName),
   };
 }
 

--- a/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-auth-provider.tsx
@@ -13,8 +13,8 @@ import {
 import {
   clearDenSession,
   createDenClient,
-  DenApiError,
   ensureDenActiveOrganization,
+  isDenSessionRevokedError,
   readDenBootstrapConfig,
   readDenSettings,
   setDenBootstrapConfig,
@@ -45,9 +45,7 @@ export const DEN_AUTH_UNAVAILABLE_RETRY_INTERVAL_MS = 30_000;
 export function resolveDenAuthFailureStatus(
   error: unknown,
 ): Extract<DenAuthStatus, "signed_out" | "unavailable"> {
-  return error instanceof DenApiError && error.status === 401
-    ? "signed_out"
-    : "unavailable";
+  return isDenSessionRevokedError(error) ? "signed_out" : "unavailable";
 }
 
 export function hasRetainedDenSession(status: DenAuthStatus): boolean {

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -10,6 +10,8 @@ import {
   DenApiError,
   ensureDenActiveOrganization,
   initializeDenBootstrapConfig,
+  isDenSessionRevokedError,
+  mergePassiveDenSettings,
   normalizeDenBaseUrl,
   readDenSettings,
   resolveDenBaseUrls,
@@ -150,13 +152,15 @@ export function useDenSession({
 
   const syncCurrentDenSettings = React.useCallback(() => {
     const resolved = resolveDenBaseUrls(baseUrl);
-    writeDenSettings({
-      baseUrl: resolved.baseUrl,
-      authToken: authToken || null,
-      activeOrgId: activeOrgId || null,
-      activeOrgSlug: activeOrg?.slug ?? null,
-      activeOrgName: activeOrg?.name ?? null,
-    });
+    writeDenSettings(
+      mergePassiveDenSettings(readDenSettings(), {
+        baseUrl: resolved.baseUrl,
+        authToken: authToken || null,
+        activeOrgId: activeOrgId || null,
+        activeOrgSlug: activeOrg?.slug ?? null,
+        activeOrgName: activeOrg?.name ?? null,
+      }),
+    );
   }, [activeOrg, activeOrgId, authToken, baseUrl]);
 
   React.useEffect(() => {
@@ -366,7 +370,7 @@ export function useDenSession({
       })
       .catch(async (error) => {
         if (cancelled) return;
-        if (error instanceof DenApiError && error.status === 401) {
+        if (isDenSessionRevokedError(error)) {
           await clearSignedInState();
         }
         // A timeout, offline state, or server failure does not invalidate the

--- a/apps/app/tests/den-session-offline-resilience.test.ts
+++ b/apps/app/tests/den-session-offline-resilience.test.ts
@@ -1,0 +1,178 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  DenApiError,
+  isDenSessionRevokedError,
+  mergePassiveDenSettings,
+  readDenSettings,
+  writeDenSettings,
+} from "../src/app/lib/den";
+import { resolveDenAuthFailureStatus } from "../src/react-app/domains/cloud/den-auth-provider";
+
+const originalWindow = globalThis.window;
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+afterEach(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+});
+
+describe("mergePassiveDenSettings", () => {
+  test("preserves stored credentials and org when in-memory state is empty", () => {
+    const result = mergePassiveDenSettings(
+      {
+        baseUrl: "https://stored.example.com",
+        authToken: "tok_stored",
+        activeOrgId: "org_stored",
+        activeOrgSlug: "stored-org",
+        activeOrgName: "Stored Org",
+      },
+      {
+        baseUrl: "https://next.example.com",
+        authToken: null,
+        activeOrgId: null,
+        activeOrgSlug: null,
+        activeOrgName: null,
+      },
+    );
+
+    expect(result).toEqual({
+      baseUrl: "https://next.example.com",
+      apiBaseUrl: "https://next.example.com/api/den",
+      authToken: "tok_stored",
+      activeOrgId: "org_stored",
+      activeOrgSlug: "stored-org",
+      activeOrgName: "Stored Org",
+    });
+  });
+
+  test("uses fresh in-memory values when they are present", () => {
+    const result = mergePassiveDenSettings(
+      {
+        baseUrl: "https://stored.example.com",
+        authToken: "tok_stored",
+        activeOrgId: "org_stored",
+        activeOrgSlug: "stored-org",
+        activeOrgName: "Stored Org",
+      },
+      {
+        baseUrl: "https://next.example.com",
+        authToken: " tok_fresh ",
+        activeOrgId: " org_fresh ",
+        activeOrgSlug: " fresh-org ",
+        activeOrgName: " Fresh Org ",
+      },
+    );
+
+    expect(result.authToken).toBe("tok_fresh");
+    expect(result.activeOrgId).toBe("org_fresh");
+    expect(result.activeOrgSlug).toBe("fresh-org");
+    expect(result.activeOrgName).toBe("Fresh Org");
+  });
+
+  test("keeps empty storage empty when in-memory state is empty", () => {
+    const result = mergePassiveDenSettings(
+      {
+        baseUrl: "https://stored.example.com",
+        authToken: null,
+        activeOrgId: null,
+        activeOrgSlug: null,
+        activeOrgName: null,
+      },
+      {
+        baseUrl: "https://next.example.com",
+        authToken: null,
+        activeOrgId: null,
+        activeOrgSlug: null,
+        activeOrgName: null,
+      },
+    );
+
+    expect(result.authToken).toBeNull();
+    expect(result.activeOrgId).toBeNull();
+    expect(result.activeOrgSlug).toBeNull();
+    expect(result.activeOrgName).toBeNull();
+  });
+
+  test("passive write leaves stored session keys intact", () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: {
+        localStorage: memoryStorage(),
+        dispatchEvent: () => true,
+      },
+    });
+
+    window.localStorage.setItem("openwork.den.authToken", "tok_stored");
+    window.localStorage.setItem("openwork.den.activeOrgId", "org_stored");
+    window.localStorage.setItem("openwork.den.activeOrgSlug", "stored-org");
+    window.localStorage.setItem("openwork.den.activeOrgName", "Stored Org");
+
+    writeDenSettings(
+      mergePassiveDenSettings(readDenSettings(), {
+        baseUrl: "https://next.example.com",
+        authToken: null,
+        activeOrgId: null,
+        activeOrgSlug: null,
+        activeOrgName: null,
+      }),
+    );
+
+    expect(window.localStorage.getItem("openwork.den.authToken")).toBe("tok_stored");
+    expect(window.localStorage.getItem("openwork.den.activeOrgId")).toBe("org_stored");
+    expect(window.localStorage.getItem("openwork.den.activeOrgSlug")).toBe("stored-org");
+    expect(window.localStorage.getItem("openwork.den.activeOrgName")).toBe("Stored Org");
+  });
+});
+
+describe("isDenSessionRevokedError", () => {
+  test("only treats Den-shaped 401s as revoked sessions", () => {
+    expect(isDenSessionRevokedError(new DenApiError(401, "unauthorized", "Unauthorized"))).toBe(
+      true,
+    );
+    expect(isDenSessionRevokedError(new DenApiError(401, "request_failed", "Proxy 401"))).toBe(
+      false,
+    );
+    expect(isDenSessionRevokedError(new DenApiError(500, "server_error", "Server error"))).toBe(
+      false,
+    );
+    expect(isDenSessionRevokedError(new Error("Request timed out."))).toBe(false);
+  });
+});
+
+describe("resolveDenAuthFailureStatus", () => {
+  test("keeps proxy-shaped 401s unavailable while Den-shaped 401s sign out", () => {
+    expect(resolveDenAuthFailureStatus(new DenApiError(401, "request_failed", "Proxy 401"))).toBe(
+      "unavailable",
+    );
+    expect(resolveDenAuthFailureStatus(new DenApiError(401, "unauthorized", "Unauthorized"))).toBe(
+      "signed_out",
+    );
+    expect(resolveDenAuthFailureStatus(new Error("Request timed out."))).toBe("unavailable");
+  });
+});


### PR DESCRIPTION
## What

A transient control-plane outage (VPN drop, unreachable Den) could permanently destroy the stored OpenWork Cloud session. Two mechanisms, both fixed:

1. **Passive mirror erased credentials during outages.** `useDenSession` mirrors in-memory state to storage on every dep change (`syncCurrentDenSettings`), and `writeDenSettings` deletes the localStorage key for every null field. While the Den is unreachable the org list can never load, so the mirror wrote `activeOrgSlug/activeOrgName: null` (deleting them), and on remount races the token and org id too. The mirror now merges over `readDenSettings()` via a new `mergePassiveDenSettings` helper: a passive sync can no longer delete persisted credentials; explicit sign-out/change-server flows still clear through `clearDenSession()`/`saveControlPlaneUrl()` unchanged.

2. **Any bare 401 signed the user out.** Both 401 gates (`resolveDenAuthFailureStatus` in den-auth-provider, and the `getSession` catch in use-den-session) treated *any* `DenApiError` 401 as a revoked session. A corporate proxy, captive portal, or LB answering with a bare 401 while the VPN is down wiped the session instantly. New shared `isDenSessionRevokedError` treats a 401 as revocation only when it carries the Den JSON error envelope (`code !== "request_failed"`); foreign/bare 401s now resolve to `"unavailable"`, which retains the session and keeps the existing auto-retry (online/focus/30s interval) armed.

## How this was found

Live two-sandbox e2e on Daytona (real Electron + real Den): signed-in baseline, then all TCP to the Den severed (`ss -K`) plus DNS blackholed to simulate VPN loss. On dev, the Connect screen deterministically erased the stored org keys during the outage; combined with remount races the token followed, and the user came back signed out with no self-heal after the network returned.

## Verification

- `pnpm --filter @openwork/app typecheck` — clean.
- `pnpm --filter @openwork/app test` — 349 pass / 0 fail (includes new `apps/app/tests/den-session-offline-resilience.test.ts`: merge semantics incl. localStorage-survival behavioral test, revoked-error classification, failure-status mapping).
- E2E re-run of the same Daytona VPN-loss scenario on this branch: with the Connect screen open, "Test again" clicked, and navigation/remount stress during a 2+ minute hard outage, all four `openwork.den.*` keys and the signed-in status survived (previously the org keys were erased within seconds and the session followed). Evidence: CDP assertions `{"status":"signed_in","token":true,"orgId":true,"orgSlug":"acme-robotics-demo","orgName":"Acme Robotics"}` mid-outage.

## Known follow-up (separate defect, isolated during testing)

App relaunch can lose *recent* localStorage writes entirely: a neutral canary key (`openwork.test.canary`) written ~8s before `eval.app.relaunch` did not survive the relaunch on the Daytona dev sandbox, despite the existing `flushStorageData()` calls in `__evalRelaunch`. That storage-flush loss (not app logic) can also present as "signed out after restart" and likely explains the remainder of the original field report. Recommended direction: persist the cloud session through the shell desktop-config file (atomic disk write over IPC, like the bootstrap config) instead of renderer localStorage. Happy to file/split this as its own issue.

Also noted during testing (not addressed here): "Run agent diagnostics" reports the trust-policy skip of self-hosted/dev Den origins as "Failed" — misleading for self-hosted customers; should read as "Skipped (policy)".
