### PR TITLE
feat(mcp): add bulk toggle for optional permissions

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -64,6 +64,11 @@ import {
   planSmartAdd,
   smartAddAuthLabel,
 } from "./mcp-connection-smart-add";
+import {
+  areAllOptionalScopesSelected,
+  OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD,
+  toggleAllOptionalScopes,
+} from "./mcp-scope-selection";
 import { getPluginPartsSummary, pluginQueryKeys, usePlugins } from "./plugin-data";
 import { TelegramDialog } from "./telegram-dialog";
 
@@ -2311,6 +2316,7 @@ function AddConnectionDialog({
     ?? authorizationServers[0]?.scopesSupported
     ?? [];
   const optionalScopes = availableScopes.filter((scope) => !requiredScopes.includes(scope));
+  const allOptionalScopesSelected = areAllOptionalScopesSelected(requestedScopes, optionalScopes);
   const access: McpConnectionAccessInput = accessMode === "everyone"
     ? { orgWide: true, memberIds: [], teamIds: [] }
     : { orgWide: false, memberIds: accessMode === "people" ? selectedMemberIds : [], teamIds: accessMode === "teams" ? selectedTeamIds : [] };
@@ -2780,7 +2786,34 @@ function AddConnectionDialog({
 
           {authType === "oauth" && requirements && (requiredScopes.length > 0 || optionalScopes.length > 0) ? (
             <div>
-              <p className="mb-1.5 text-[12px] font-medium text-gray-700">Permissions</p>
+              <div className="mb-1.5 flex items-center justify-between gap-3">
+                <p className="text-[12px] font-medium text-gray-700">Permissions</p>
+                {optionalScopes.length > OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD ? (
+                  <button
+                    type="button"
+                    role="switch"
+                    aria-checked={allOptionalScopesSelected}
+                    aria-label="All optional permissions"
+                    data-testid="toggle-all-optional-permissions"
+                    onClick={() => setRequestedScopes((current) => toggleAllOptionalScopes(current, optionalScopes))}
+                    className="inline-flex shrink-0 items-center gap-2 rounded-full border border-gray-200 bg-white px-2.5 py-1.5 text-[11px] font-medium text-gray-600 shadow-sm transition hover:border-gray-300 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/10"
+                  >
+                    <span>All optional</span>
+                    <span
+                      aria-hidden="true"
+                      className={`relative h-5 w-9 rounded-full transition-colors ${
+                        allOptionalScopesSelected ? "bg-gray-900" : "bg-gray-200"
+                      }`}
+                    >
+                      <span
+                        className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
+                          allOptionalScopesSelected ? "translate-x-4" : "translate-x-0"
+                        }`}
+                      />
+                    </span>
+                  </button>
+                ) : null}
+              </div>
               <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 p-3 text-[12px]">
                 {requiredScopes.map((scope) => (
                   <label key={scope} className="flex items-center gap-2 text-gray-700">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ArrowLeft, Check, ChevronDown, ChevronRight, Loader2, MoreHorizontal, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
+import { AlertTriangle, ArrowLeft, Check, ChevronDown, ChevronRight, Loader2, Minus, MoreHorizontal, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenNotice } from "../../_components/ui/notice";
@@ -65,7 +65,7 @@ import {
   smartAddAuthLabel,
 } from "./mcp-connection-smart-add";
 import {
-  areAllOptionalScopesSelected,
+  getOptionalScopeSelectionState,
   OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD,
   toggleAllOptionalScopes,
 } from "./mcp-scope-selection";
@@ -2316,7 +2316,7 @@ function AddConnectionDialog({
     ?? authorizationServers[0]?.scopesSupported
     ?? [];
   const optionalScopes = availableScopes.filter((scope) => !requiredScopes.includes(scope));
-  const allOptionalScopesSelected = areAllOptionalScopesSelected(requestedScopes, optionalScopes);
+  const optionalScopeSelectionState = getOptionalScopeSelectionState(requestedScopes, optionalScopes);
   const access: McpConnectionAccessInput = accessMode === "everyone"
     ? { orgWide: true, memberIds: [], teamIds: [] }
     : { orgWide: false, memberIds: accessMode === "people" ? selectedMemberIds : [], teamIds: accessMode === "teams" ? selectedTeamIds : [] };
@@ -2786,35 +2786,31 @@ function AddConnectionDialog({
 
           {authType === "oauth" && requirements && (requiredScopes.length > 0 || optionalScopes.length > 0) ? (
             <div>
-              <div className="mb-1.5 flex items-center justify-between gap-3">
-                <p className="text-[12px] font-medium text-gray-700">Permissions</p>
+              <p className="mb-1.5 text-[12px] font-medium text-gray-700">Permissions</p>
+              <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 p-3 text-[12px]">
                 {optionalScopes.length > OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD ? (
                   <button
                     type="button"
-                    role="switch"
-                    aria-checked={allOptionalScopesSelected}
-                    aria-label="All optional permissions"
+                    role="checkbox"
+                    aria-checked={optionalScopeSelectionState === "some" ? "mixed" : optionalScopeSelectionState === "all"}
                     data-testid="toggle-all-optional-permissions"
                     onClick={() => setRequestedScopes((current) => toggleAllOptionalScopes(current, optionalScopes))}
-                    className="inline-flex shrink-0 items-center gap-2 rounded-full border border-gray-200 bg-white px-2.5 py-1.5 text-[11px] font-medium text-gray-600 shadow-sm transition hover:border-gray-300 hover:text-gray-900 focus:outline-none focus:ring-2 focus:ring-gray-900/10"
+                    className="flex w-full items-center gap-2 border-b border-gray-200 pb-2 text-left font-medium text-gray-700 transition hover:text-gray-950 focus:outline-none focus:ring-2 focus:ring-gray-900/10"
                   >
-                    <span>All optional</span>
                     <span
                       aria-hidden="true"
-                      className={`relative h-5 w-9 rounded-full transition-colors ${
-                        allOptionalScopesSelected ? "bg-gray-900" : "bg-gray-200"
+                      className={`flex h-4 w-4 items-center justify-center rounded border transition ${
+                        optionalScopeSelectionState === "none"
+                          ? "border-gray-300 bg-white"
+                          : "border-blue-600 bg-blue-600 text-white"
                       }`}
                     >
-                      <span
-                        className={`absolute left-0.5 top-0.5 h-4 w-4 rounded-full bg-white shadow-sm transition-transform ${
-                          allOptionalScopesSelected ? "translate-x-4" : "translate-x-0"
-                        }`}
-                      />
+                      {optionalScopeSelectionState === "all" ? <Check className="h-3 w-3" strokeWidth={3} /> : null}
+                      {optionalScopeSelectionState === "some" ? <Minus className="h-3 w-3" strokeWidth={3} /> : null}
                     </span>
+                    <span>{optionalScopeSelectionState === "all" ? "Deselect all" : "Select all"}</span>
                   </button>
                 ) : null}
-              </div>
-              <div className="space-y-2 rounded-2xl border border-gray-100 bg-gray-50 p-3 text-[12px]">
                 {requiredScopes.map((scope) => (
                   <label key={scope} className="flex items-center gap-2 text-gray-700">
                     <input type="checkbox" checked disabled />

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-scope-selection.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-scope-selection.ts
@@ -1,18 +1,21 @@
 export const OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD = 5;
 
-export function areAllOptionalScopesSelected(
+export type OptionalScopeSelectionState = "none" | "some" | "all";
+
+export function getOptionalScopeSelectionState(
   requestedScopes: readonly string[],
   optionalScopes: readonly string[],
-): boolean {
-  return optionalScopes.length > 0
-    && optionalScopes.every((scope) => requestedScopes.includes(scope));
+): OptionalScopeSelectionState {
+  const selectedCount = optionalScopes.filter((scope) => requestedScopes.includes(scope)).length;
+  if (selectedCount === 0) return "none";
+  return selectedCount === optionalScopes.length ? "all" : "some";
 }
 
 export function toggleAllOptionalScopes(
   requestedScopes: readonly string[],
   optionalScopes: readonly string[],
 ): string[] {
-  if (areAllOptionalScopesSelected(requestedScopes, optionalScopes)) {
+  if (getOptionalScopeSelectionState(requestedScopes, optionalScopes) === "all") {
     return requestedScopes.filter((scope) => !optionalScopes.includes(scope));
   }
   return [...new Set([...requestedScopes, ...optionalScopes])];

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-scope-selection.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-scope-selection.ts
@@ -1,0 +1,19 @@
+export const OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD = 5;
+
+export function areAllOptionalScopesSelected(
+  requestedScopes: readonly string[],
+  optionalScopes: readonly string[],
+): boolean {
+  return optionalScopes.length > 0
+    && optionalScopes.every((scope) => requestedScopes.includes(scope));
+}
+
+export function toggleAllOptionalScopes(
+  requestedScopes: readonly string[],
+  optionalScopes: readonly string[],
+): string[] {
+  if (areAllOptionalScopesSelected(requestedScopes, optionalScopes)) {
+    return requestedScopes.filter((scope) => !optionalScopes.includes(scope));
+  }
+  return [...new Set([...requestedScopes, ...optionalScopes])];
+}

--- a/ee/apps/den-web/tests/mcp-connection-url-entry.test.ts
+++ b/ee/apps/den-web/tests/mcp-connection-url-entry.test.ts
@@ -37,7 +37,9 @@ describe("MCP URL entry UI contract", () => {
     const screen = readFileSync(screenPath, "utf8");
 
     expect(screen).toContain("optionalScopes.length > OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD");
-    expect(screen).toContain('aria-label="All optional permissions"');
+    expect(screen).toContain('role="checkbox"');
+    expect(screen).toContain('"mixed"');
+    expect(screen).toContain('"Deselect all" : "Select all"');
     expect(screen).toContain('data-testid="toggle-all-optional-permissions"');
     expect(screen).toContain("toggleAllOptionalScopes(current, optionalScopes)");
   });

--- a/ee/apps/den-web/tests/mcp-connection-url-entry.test.ts
+++ b/ee/apps/den-web/tests/mcp-connection-url-entry.test.ts
@@ -32,4 +32,13 @@ describe("MCP URL entry UI contract", () => {
     expect(screen).not.toContain("existingConnectionUrls");
     expect(screen).not.toContain("onSelectPreset");
   });
+
+  test("offers one compact bulk control for long optional permission lists", () => {
+    const screen = readFileSync(screenPath, "utf8");
+
+    expect(screen).toContain("optionalScopes.length > OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD");
+    expect(screen).toContain('aria-label="All optional permissions"');
+    expect(screen).toContain('data-testid="toggle-all-optional-permissions"');
+    expect(screen).toContain("toggleAllOptionalScopes(current, optionalScopes)");
+  });
 });

--- a/ee/apps/den-web/tests/mcp-scope-selection.test.ts
+++ b/ee/apps/den-web/tests/mcp-scope-selection.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  areAllOptionalScopesSelected,
+  OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD,
+  toggleAllOptionalScopes,
+} from "../app/(den)/dashboard/_components/mcp-scope-selection";
+
+describe("MCP optional scope selection", () => {
+  test("shows the bulk control only beyond five optional scopes", () => {
+    expect(OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD).toBe(5);
+  });
+
+  test("selects every optional scope without duplicating or removing required scopes", () => {
+    expect(toggleAllOptionalScopes(
+      ["required", "optional.one"],
+      ["optional.one", "optional.two", "optional.three"],
+    )).toEqual(["required", "optional.one", "optional.two", "optional.three"]);
+  });
+
+  test("clears optional scopes while preserving required and unrelated scopes", () => {
+    const optionalScopes = ["optional.one", "optional.two"];
+    const selectedScopes = ["required", "optional.one", "optional.two", "provider.default"];
+
+    expect(areAllOptionalScopesSelected(selectedScopes, optionalScopes)).toBe(true);
+    expect(toggleAllOptionalScopes(selectedScopes, optionalScopes)).toEqual([
+      "required",
+      "provider.default",
+    ]);
+  });
+
+  test("treats a partial selection as not all selected", () => {
+    expect(areAllOptionalScopesSelected(
+      ["optional.one"],
+      ["optional.one", "optional.two"],
+    )).toBe(false);
+  });
+});

--- a/ee/apps/den-web/tests/mcp-scope-selection.test.ts
+++ b/ee/apps/den-web/tests/mcp-scope-selection.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import {
-  areAllOptionalScopesSelected,
+  getOptionalScopeSelectionState,
   OPTIONAL_SCOPE_BULK_TOGGLE_THRESHOLD,
   toggleAllOptionalScopes,
 } from "../app/(den)/dashboard/_components/mcp-scope-selection";
@@ -22,17 +22,24 @@ describe("MCP optional scope selection", () => {
     const optionalScopes = ["optional.one", "optional.two"];
     const selectedScopes = ["required", "optional.one", "optional.two", "provider.default"];
 
-    expect(areAllOptionalScopesSelected(selectedScopes, optionalScopes)).toBe(true);
+    expect(getOptionalScopeSelectionState(selectedScopes, optionalScopes)).toBe("all");
     expect(toggleAllOptionalScopes(selectedScopes, optionalScopes)).toEqual([
       "required",
       "provider.default",
     ]);
   });
 
-  test("treats a partial selection as not all selected", () => {
-    expect(areAllOptionalScopesSelected(
+  test("reports a mixed state for partial selections", () => {
+    expect(getOptionalScopeSelectionState(
       ["optional.one"],
       ["optional.one", "optional.two"],
-    )).toBe(false);
+    )).toBe("some");
+  });
+
+  test("reports an empty state when no optional scopes are selected", () => {
+    expect(getOptionalScopeSelectionState(
+      ["required"],
+      ["optional.one", "optional.two"],
+    )).toBe("none");
   });
 });


### PR DESCRIPTION
## Summary

- add a compact **All optional** switch above long MCP permission lists
- show the switch only when a provider advertises more than five optional scopes
- select or clear every optional scope together while preserving required and unrelated scopes
- keep short permission lists unchanged

## User impact

Providers such as Slack can advertise dozens of optional OAuth scopes. Admins can now enable or clear the full optional set with one action instead of clicking every permission individually.

## Validation

- `pnpm --filter @openwork-ee/den-web exec bun test tests/mcp-scope-selection.test.ts tests/mcp-connection-url-entry.test.ts` — 7 passed
- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- local Den dashboard with Slack — rendered 26 optional scopes; bulk switch changed 26 selected → 0 selected → 26 selected

## Risk and scope

- Den Web UI only; no API, database, OAuth discovery, or token-storage changes
- required scopes remain immutable and are never removed by the bulk control
- short lists with five or fewer optional scopes retain the existing UI

## Remaining verification

- no cross-browser visual evidence attached
