### PR TITLE
fix(app): sidebar spinner clears task titles; scope Select All to the conversation

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -38,6 +38,7 @@ import { WebfetchTool } from "@/components/tools/webfetch"
 import { WebsearchTool } from "@/components/tools/websearch"
 import { useMessageList, useSessionErrorMessage } from "@/components/chat/message-list-provider"
 import { ArtifactList } from "@/components/chat/artifact"
+import { useChatSelectAll } from "@/components/chat/use-chat-select-all"
 import { TaskSuggestions } from "@/components/chat/task-suggestions"
 import {
   DescriptiveButtonContent,
@@ -854,6 +855,8 @@ interface MessageListProps {
 }
 
 export function MessageList({ messages, status, retryStatus }: MessageListProps) {
+  useChatSelectAll()
+
   const isStreaming = status === "streaming" || status === "retrying"
   const items = React.useMemo(() => groupMessages(messages, status), [messages, status]);
   const error = useSessionErrorMessage();
@@ -863,7 +866,7 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
     : null
 
   return (
-    <div className={cn("flex flex-col gap-2 @container/message-list")}>
+    <div data-chat-transcript className={cn("flex flex-col gap-2 @container/message-list")}>
       {messages.length === 0 && <TaskSuggestions className="mx-auto w-full max-w-3xl shrink-0 px-3 pb-3 md:px-5 md:pb-5 grow" />}
 
       {items.map((item) => {

--- a/apps/app/src/components/chat/use-chat-select-all.ts
+++ b/apps/app/src/components/chat/use-chat-select-all.ts
@@ -1,0 +1,99 @@
+import { useEffect } from "react"
+
+declare global {
+  interface Window {
+    __openworkChatSelectAll?: () => boolean
+  }
+}
+
+let mountedTranscriptCount = 0
+
+function isEditableElement(element: Element | null) {
+  if (!element) return false
+
+  return element instanceof HTMLInputElement
+    || element instanceof HTMLTextAreaElement
+    || Boolean(element.closest('[contenteditable="true"]'))
+}
+
+function isVisible(element: Element) {
+  return element.getBoundingClientRect().width > 0
+}
+
+function findTranscriptRoot(activeElement: Element | null) {
+  const containingRoot = activeElement?.closest("[data-chat-transcript]")
+
+  if (containingRoot) {
+    return containingRoot
+  }
+
+  for (const root of document.querySelectorAll("[data-chat-transcript]")) {
+    if (isVisible(root)) {
+      return root
+    }
+  }
+
+  return null
+}
+
+function isSelectAllShortcut(event: KeyboardEvent) {
+  return (event.metaKey || event.ctrlKey)
+    && !event.shiftKey
+    && !event.altKey
+    && event.key.toLowerCase() === "a"
+}
+
+export function scopedChatSelectAll(): boolean {
+  const activeElement = document.activeElement
+
+  if (isEditableElement(activeElement)) {
+    return false
+  }
+
+  const root = findTranscriptRoot(activeElement)
+
+  if (!root) {
+    return false
+  }
+
+  const selection = window.getSelection()
+
+  if (!selection) {
+    return false
+  }
+
+  selection.removeAllRanges()
+  const range = document.createRange()
+  range.selectNodeContents(root)
+  selection.addRange(range)
+
+  return true
+}
+
+export function useChatSelectAll() {
+  useEffect(() => {
+    mountedTranscriptCount += 1
+    window.__openworkChatSelectAll = scopedChatSelectAll
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.defaultPrevented || !isSelectAllShortcut(event)) {
+        return
+      }
+
+      if (scopedChatSelectAll()) {
+        event.preventDefault()
+      }
+    }
+
+    document.addEventListener("keydown", onKeyDown, true)
+
+    return () => {
+      mountedTranscriptCount -= 1
+      document.removeEventListener("keydown", onKeyDown, true)
+
+      if (mountedTranscriptCount === 0 && window.__openworkChatSelectAll === scopedChatSelectAll) {
+        delete window.__openworkChatSelectAll
+      }
+    }
+  }, [])
+}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1816,7 +1816,7 @@ function SessionMenuItem({
               >
                 <PinnedIndicator isPinned={isPinned} />
                 <span
-                  className={cn("min-w-0 flex-1 truncate transition-[padding] duration-75 group-hover/menu-sub-item:pe-12 group-has-data-popup-open/menu-sub-item:pe-12 pe-4", isSessionStreaming || isSessionActive && "pe-12")}
+                  className={cn("min-w-0 flex-1 truncate transition-[padding] duration-75 group-hover/menu-sub-item:pe-12 group-has-data-popup-open/menu-sub-item:pe-12 pe-4", (isSessionStreaming || isSessionActive) && "pe-12")}
                   title={displayTitle}
                 >
                   {displayTitle}
@@ -1846,7 +1846,7 @@ function SessionMenuItem({
           onClick={openSession}
           onPointerEnter={prefetchSession}
           onFocus={prefetchSession}
-          className={cn("transition-[padding] duration-75 group-hover/menu-sub-item:pe-8 group-has-data-popup-open/menu-sub-item:pe-8", depth > 0 && "ps-13", isSessionStreaming || isSessionActive && "pe-8")}
+          className={cn("transition-[padding] duration-75 group-hover/menu-sub-item:pe-8 group-has-data-popup-open/menu-sub-item:pe-8", depth > 0 && "ps-13", (isSessionStreaming || isSessionActive) && "pe-8")}
         >
           <PinnedIndicator isPinned={isPinned} />
           <span className="truncate" title={displayTitle}>{displayTitle}</span>

--- a/apps/desktop/electron/app-menu.mjs
+++ b/apps/desktop/electron/app-menu.mjs
@@ -3,12 +3,26 @@
 // and Windows/Linux menu-bar visibility. Extracted from main.mjs as a
 // factory (createRuntimeManager pattern); the NATIVE_MENU_* channels are
 // consumed by the preload bridge.
-import { BrowserWindow, Menu, shell } from "electron";
+import { BrowserWindow, Menu, shell, webContents } from "electron";
 
 const NATIVE_MENU_OPEN_SETTINGS_EVENT = "openwork:native-menu:open-settings";
 const NATIVE_MENU_TOGGLE_SIDEBAR_EVENT = "openwork:native-menu:toggle-sidebar";
 const NATIVE_MENU_CHECK_UPDATES_EVENT = "openwork:native-menu:check-updates";
 const NATIVE_MENU_ZOOM_EVENT = "openwork:native-menu:zoom";
+const SELECT_ALL_SCRIPT = '(() => typeof window.__openworkChatSelectAll === "function" ? window.__openworkChatSelectAll() : false)()';
+
+async function selectAllFromNativeMenu(_item, browserWindow) {
+  const wc = webContents.getFocusedWebContents() ?? browserWindow?.webContents;
+
+  if (!wc) return;
+
+  try {
+    const handled = await wc.executeJavaScript(SELECT_ALL_SCRIPT, true);
+    if (handled !== true) wc.selectAll();
+  } catch {
+    wc.selectAll();
+  }
+}
 
 export function createApplicationMenu({ appName, docsUrl, getWindow }) {
   let applicationMenuVisible = process.platform === "darwin";
@@ -110,7 +124,11 @@ export function createApplicationMenu({ appName, docsUrl, getWindow }) {
             ? [
                 { role: "pasteAndMatchStyle" },
                 { role: "delete" },
-                { role: "selectAll" },
+                {
+                  label: "Select All",
+                  accelerator: "CmdOrCtrl+A",
+                  click: selectAllFromNativeMenu,
+                },
                 { type: "separator" },
                 {
                   label: "Speech",
@@ -130,7 +148,11 @@ export function createApplicationMenu({ appName, docsUrl, getWindow }) {
             : [
                 { role: "delete" },
                 { type: "separator" },
-                { role: "selectAll" },
+                {
+                  label: "Select All",
+                  accelerator: "CmdOrCtrl+A",
+                  click: selectAllFromNativeMenu,
+                },
               ]),
         ],
       },

--- a/evals/flows/chat-select-all-scoped.flow.mjs
+++ b/evals/flows/chat-select-all-scoped.flow.mjs
@@ -1,0 +1,325 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "chat-select-all-scoped";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const EDITOR_SELECTOR = '[contenteditable="true"][data-lexical-editor="true"], [contenteditable="true"]';
+const PROMPT = "Reply with exactly: select-scope ok";
+const REPLY = "select-scope ok";
+const DRAFT = "draft only selection probe";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function waitForReadySession(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API",
+  });
+  return ctx.waitFor(
+    `(() => {
+      const control = window.__openworkControl;
+      const route = control.snapshot().route;
+      if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+      const action = control.listActions().find((item) => item.id === "session.create_task");
+      if (action && !action.disabled) return "ready";
+      return null;
+    })()`,
+    { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+  );
+}
+
+async function closeStaleDialogs(ctx) {
+  await ctx.eval(`(() => {
+    for (let index = 0; index < 3; index += 1) {
+      const event = new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true, cancelable: true });
+      (document.activeElement || document.body).dispatchEvent(event);
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true, cancelable: true }));
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true, cancelable: true }));
+    }
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    return true;
+  })()`);
+  await sleep(300);
+}
+
+async function pasteComposer(ctx, text) {
+  const result = await ctx.eval(
+    `(() => {
+      const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+      if (!editor) return { ok: false, reason: "composer not found" };
+      editor.focus();
+      const data = new DataTransfer();
+      data.setData("text/plain", ${JSON.stringify(text)});
+      const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data });
+      editor.dispatchEvent(event);
+      return { ok: true, text: editor.innerText };
+    })()`,
+  );
+  ctx.assert(result?.ok === true, `Could not paste into composer: ${result?.reason ?? "unknown"}`);
+  return result;
+}
+
+async function submitComposer(ctx) {
+  const submitted = await ctx.eval(`(() => {
+    const byLabel = Array.from(document.querySelectorAll("button"))
+      .find((button) => /run task|send|run/i.test((button.textContent || "").trim()) && !button.disabled);
+    if (byLabel) {
+      byLabel.click();
+      return "clicked";
+    }
+    const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+    if (editor) {
+      editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true, cancelable: true }));
+      return "enter";
+    }
+    return "none";
+  })()`);
+  ctx.assert(submitted !== "none", "Could not submit the composer message.");
+  ctx.log(`submit: ${submitted}`);
+  return submitted;
+}
+
+async function currentRouteSessionId(ctx) {
+  return ctx.eval(`(() => {
+    const route = window.__openworkControl.snapshot().route || "";
+    const match = route.match(/ses_[A-Za-z0-9]+/);
+    return match ? match[0] : null;
+  })()`);
+}
+
+async function waitForActiveSessionId(ctx, { previousId = null, timeoutMs = 30_000, label = "active session id in route" } = {}) {
+  return ctx.waitFor(
+    `(() => {
+      const route = window.__openworkControl.snapshot().route || "";
+      const match = route.match(/ses_[A-Za-z0-9]+/);
+      if (!match) return null;
+      if (${JSON.stringify(previousId)} && match[0] === ${JSON.stringify(previousId)}) return null;
+      return match[0];
+    })()`,
+    { timeoutMs, label },
+  );
+}
+
+async function createFreshTask(ctx) {
+  const previousId = await currentRouteSessionId(ctx);
+  await ctx.control("session.create_task");
+  const sessionId = await waitForActiveSessionId(ctx, {
+    previousId,
+    timeoutMs: 30_000,
+    label: "fresh active session id in route",
+  });
+  ctx.assert(Boolean(sessionId), "No active session id after create_task.");
+  ctx.log(`active session: ${sessionId}`);
+  await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)}))`, {
+    timeoutMs: 30_000,
+    label: "composer editor",
+  });
+  return sessionId;
+}
+
+async function dispatchCtrlA(ctx) {
+  await ctx.client.send("Input.dispatchKeyEvent", {
+    type: "keyDown",
+    key: "a",
+    code: "KeyA",
+    modifiers: 2,
+    windowsVirtualKeyCode: 65,
+  });
+  await ctx.client.send("Input.dispatchKeyEvent", {
+    type: "keyUp",
+    key: "a",
+    code: "KeyA",
+    modifiers: 2,
+    windowsVirtualKeyCode: 65,
+  });
+}
+
+async function clearSelectionAndBlur(ctx) {
+  await ctx.eval(`(() => {
+    window.getSelection()?.removeAllRanges();
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    return true;
+  })()`);
+}
+
+async function clearComposer(ctx) {
+  const result = await ctx.eval(`(() => {
+    const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+    if (!editor) return { ok: false, reason: "composer not found" };
+    editor.focus();
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    document.execCommand("delete");
+    editor.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "deleteContentBackward" }));
+    window.getSelection()?.removeAllRanges();
+    return { ok: true, text: editor.innerText };
+  })()`);
+  ctx.assert(result?.ok === true, `Could not clear composer: ${result?.reason ?? "unknown"}`);
+  return result;
+}
+
+function selectAllReportExpression() {
+  return `(() => {
+    const bodyText = document.body.innerText || "";
+    const preferredAnchors = ["Add workspace", "Ready for new tasks", "Search sessions"];
+    const fallbackAnchors = ["Add workspace", "New session", "Docs", "Feedback"];
+    const pickedAnchors = [];
+    const substitutions = [];
+    for (const preferred of preferredAnchors) {
+      if (bodyText.includes(preferred)) {
+        pickedAnchors.push(preferred);
+        substitutions.push({ preferred, actual: preferred, fallback: false });
+        continue;
+      }
+      const fallback = fallbackAnchors.find((candidate) => bodyText.includes(candidate) && !pickedAnchors.includes(candidate));
+      if (fallback) {
+        pickedAnchors.push(fallback);
+        substitutions.push({ preferred, actual: fallback, fallback: true });
+      } else {
+        pickedAnchors.push(preferred);
+        substitutions.push({ preferred, actual: preferred, fallback: true, missing: true });
+      }
+    }
+    const reportSelection = (label) => {
+      const selection = window.getSelection();
+      const text = selection ? selection.toString() : "";
+      return {
+        label,
+        text,
+        length: text.length,
+        includesPrompt: text.includes(${JSON.stringify(PROMPT)}),
+        includesReply: text.includes(${JSON.stringify(REPLY)}),
+        excludedHits: pickedAnchors.filter((anchor) => text.includes(anchor)),
+      };
+    };
+    const shortcut = reportSelection("shortcut");
+    const globalType = typeof window.__openworkChatSelectAll;
+    window.getSelection()?.removeAllRanges();
+    const directReturn = globalType === "function" ? window.__openworkChatSelectAll() : null;
+    const direct = reportSelection("renderer-global");
+    return {
+      transcriptExists: Boolean(document.querySelector('[data-chat-transcript]')),
+      globalType,
+      directReturn,
+      anchors: substitutions,
+      missingAnchors: substitutions.filter((entry) => entry.missing).map((entry) => entry.preferred),
+      shortcut,
+      direct,
+    };
+  })()`;
+}
+
+function composerSelectionExpression() {
+  return `(() => {
+    const composer = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+    const selection = window.getSelection();
+    const text = selection ? selection.toString() : "";
+    return {
+      composerExists: Boolean(composer),
+      text,
+      anchorInsideComposer: Boolean(selection?.anchorNode && composer?.contains(selection.anchorNode)),
+      focusInsideComposer: Boolean(selection?.focusNode && composer?.contains(selection.focusNode)),
+      activeElementInsideComposer: Boolean(composer && (document.activeElement === composer || composer.contains(document.activeElement))),
+    };
+  })()`;
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Select All is scoped to chat transcripts and editable composer drafts",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    const state = await waitForReadySession(ctx);
+    return state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); chat Select All proof requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "Create a transcript with prompt and answer",
+      run: async (ctx) => {
+        await ctx.prove("A fresh chat contains the exact prompt and assistant reply", {
+          voiceover: vo[0],
+          action: async () => {
+            await closeStaleDialogs(ctx);
+            await createFreshTask(ctx);
+            await clearComposer(ctx);
+            await pasteComposer(ctx, PROMPT);
+            await submitComposer(ctx);
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `(() => Array.from(document.querySelectorAll('[data-message-role="assistant"]'))
+                .some((element) => (element.innerText || "").includes(${JSON.stringify(REPLY)})))()`,
+              { timeoutMs: 90_000, label: "assistant reply select-scope ok" },
+            );
+            await ctx.expectNoText("Something went wrong");
+          },
+          screenshot: { name: "select-scope-transcript", requireText: [REPLY], rejectText: ["Something went wrong"] },
+        });
+      },
+    },
+    {
+      name: "Select All outside the composer selects only chat messages",
+      run: async (ctx) => {
+        await ctx.prove("Plain Ctrl+A outside editable fields selects the visible chat transcript and excludes shell chrome", {
+          voiceover: vo[1],
+          action: async () => {
+            await clearSelectionAndBlur(ctx);
+            await dispatchCtrlA(ctx);
+          },
+          assert: async () => {
+            const report = await ctx.eval(selectAllReportExpression());
+            ctx.output("chat-select-all-selection", report.shortcut.text.slice(0, 300));
+            ctx.output("chat-select-all-report", JSON.stringify({ ...report, shortcut: { ...report.shortcut, text: report.shortcut.text.slice(0, 300) }, direct: { ...report.direct, text: report.direct.text.slice(0, 300) } }, null, 2));
+            ctx.assert(report.transcriptExists === true, "No [data-chat-transcript] root was visible.");
+            ctx.assert(report.globalType === "function", `Expected window.__openworkChatSelectAll to be a function, got ${report.globalType}.`);
+            ctx.assert(report.missingAnchors.length === 0, `No live shell anchor was available for: ${report.missingAnchors.join(", ")}`);
+            ctx.assert(report.shortcut.includesReply === true, "Ctrl+A selection did not include the assistant reply.");
+            ctx.assert(report.shortcut.includesPrompt === true, "Ctrl+A selection did not include the original prompt.");
+            ctx.assert(report.shortcut.excludedHits.length === 0, `Ctrl+A selection leaked shell text: ${report.shortcut.excludedHits.join(", ")}`);
+            ctx.assert(report.directReturn === true, `Renderer global returned ${JSON.stringify(report.directReturn)} instead of true.`);
+            ctx.assert(report.direct.includesReply === true, "Renderer global selection did not include the assistant reply.");
+            ctx.assert(report.direct.includesPrompt === true, "Renderer global selection did not include the original prompt.");
+            ctx.assert(report.direct.excludedHits.length === 0, `Renderer global selection leaked shell text: ${report.direct.excludedHits.join(", ")}`);
+          },
+          screenshot: { name: "chat-transcript-selected", requireText: [REPLY], rejectText: ["Something went wrong"] },
+        });
+      },
+    },
+    {
+      name: "Select All inside the composer stays scoped to draft text",
+      run: async (ctx) => {
+        await ctx.prove("Ctrl+A in the composer selects only the editable draft", {
+          voiceover: vo[2],
+          action: async () => {
+            await clearComposer(ctx);
+            await pasteComposer(ctx, DRAFT);
+            await ctx.waitFor(
+              `(() => {
+                const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+                return Boolean(editor && (editor.innerText || "").includes(${JSON.stringify(DRAFT)}));
+              })()`,
+              { timeoutMs: 10_000, label: "draft text in composer" },
+            );
+            await dispatchCtrlA(ctx);
+          },
+          assert: async () => {
+            const report = await ctx.eval(composerSelectionExpression());
+            ctx.output("composer-select-all-report", JSON.stringify(report, null, 2));
+            ctx.assert(report.composerExists === true, "Composer was not visible.");
+            ctx.assert(report.text.trim() === DRAFT || report.text.includes(DRAFT), `Composer selection was ${JSON.stringify(report.text)}.`);
+            ctx.assert(!report.text.includes(REPLY), "Composer Select All leaked transcript text into the selection.");
+            ctx.assert(report.anchorInsideComposer === true, `Selection anchor was not inside the composer: ${JSON.stringify(report)}`);
+          },
+          screenshot: { name: "composer-draft-selected", requireText: [DRAFT], rejectText: ["Something went wrong"] },
+        });
+        await clearComposer(ctx);
+        await clearSelectionAndBlur(ctx);
+      },
+    },
+  ],
+};

--- a/evals/flows/chat-select-all-scoped.flow.mjs
+++ b/evals/flows/chat-select-all-scoped.flow.mjs
@@ -279,11 +279,13 @@ export default {
             ctx.assert(report.globalType === "function", `Expected window.__openworkChatSelectAll to be a function, got ${report.globalType}.`);
             ctx.assert(report.missingAnchors.length === 0, `No live shell anchor was available for: ${report.missingAnchors.join(", ")}`);
             ctx.assert(report.shortcut.includesReply === true, "Ctrl+A selection did not include the assistant reply.");
-            ctx.assert(report.shortcut.includesPrompt === true, "Ctrl+A selection did not include the original prompt.");
+            // User bubbles are user-select:none on this base branch (a separate PR makes them selectable),
+            // and Selection.toString() omits user-select:none text, so prompt inclusion is intentionally not asserted here.
             ctx.assert(report.shortcut.excludedHits.length === 0, `Ctrl+A selection leaked shell text: ${report.shortcut.excludedHits.join(", ")}`);
             ctx.assert(report.directReturn === true, `Renderer global returned ${JSON.stringify(report.directReturn)} instead of true.`);
             ctx.assert(report.direct.includesReply === true, "Renderer global selection did not include the assistant reply.");
-            ctx.assert(report.direct.includesPrompt === true, "Renderer global selection did not include the original prompt.");
+            // User bubbles are user-select:none on this base branch (a separate PR makes them selectable),
+            // and Selection.toString() omits user-select:none text, so prompt inclusion is intentionally not asserted here.
             ctx.assert(report.direct.excludedHits.length === 0, `Renderer global selection leaked shell text: ${report.direct.excludedHits.join(", ")}`);
           },
           screenshot: { name: "chat-transcript-selected", requireText: [REPLY], rejectText: ["Something went wrong"] },

--- a/evals/flows/sidebar-spinner-clear-of-title.flow.mjs
+++ b/evals/flows/sidebar-spinner-clear-of-title.flow.mjs
@@ -1,0 +1,417 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "sidebar-spinner-clear-of-title";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const EDITOR_SELECTOR = '[contenteditable="true"][data-lexical-editor="true"], [contenteditable="true"]';
+const PROMPT = "Write a 150-word overview of planning a quarterly robotics offsite, thinking step by step before you answer.";
+const PROMPT_MARKER = "quarterly robotics offsite";
+const CONTINUE_PROMPT = "continue";
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+let activeSessionId = null;
+let measuredSidebarTitle = "";
+
+async function waitForReadySession(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API",
+  });
+  return ctx.waitFor(
+    `(() => {
+      const control = window.__openworkControl;
+      const route = control.snapshot().route;
+      if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+      const action = control.listActions().find((item) => item.id === "session.create_task");
+      if (action && !action.disabled) return "ready";
+      return null;
+    })()`,
+    { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+  );
+}
+
+async function closeStaleDialogs(ctx) {
+  await ctx.eval(`(() => {
+    for (let index = 0; index < 3; index += 1) {
+      const event = new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true, cancelable: true });
+      (document.activeElement || document.body).dispatchEvent(event);
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true, cancelable: true }));
+      window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", code: "Escape", bubbles: true, cancelable: true }));
+    }
+    if (document.activeElement instanceof HTMLElement) document.activeElement.blur();
+    return true;
+  })()`);
+  await sleep(300);
+}
+
+async function pasteComposer(ctx, text) {
+  const result = await ctx.eval(
+    `(() => {
+      const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+      if (!editor) return { ok: false, reason: "composer not found" };
+      editor.focus();
+      const data = new DataTransfer();
+      data.setData("text/plain", ${JSON.stringify(text)});
+      const event = new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data });
+      editor.dispatchEvent(event);
+      return { ok: true, text: editor.innerText };
+    })()`,
+  );
+  ctx.assert(result?.ok === true, `Could not paste into composer: ${result?.reason ?? "unknown"}`);
+  return result;
+}
+
+async function submitComposer(ctx) {
+  const submitted = await ctx.eval(`(() => {
+    const byLabel = Array.from(document.querySelectorAll("button"))
+      .find((button) => /run task|send|run/i.test((button.textContent || "").trim()) && !button.disabled);
+    if (byLabel) {
+      byLabel.click();
+      return "clicked";
+    }
+    const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+    if (editor) {
+      editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", code: "Enter", bubbles: true, cancelable: true }));
+      return "enter";
+    }
+    return "none";
+  })()`);
+  ctx.assert(submitted !== "none", "Could not submit the composer message.");
+  ctx.log(`submit: ${submitted}`);
+  return submitted;
+}
+
+async function currentRouteSessionId(ctx) {
+  return ctx.eval(`(() => {
+    const route = window.__openworkControl.snapshot().route || "";
+    const match = route.match(/ses_[A-Za-z0-9]+/);
+    return match ? match[0] : null;
+  })()`);
+}
+
+async function waitForActiveSessionId(ctx, { previousId = null, timeoutMs = 30_000, label = "active session id in route" } = {}) {
+  return ctx.waitFor(
+    `(() => {
+      const route = window.__openworkControl.snapshot().route || "";
+      const match = route.match(/ses_[A-Za-z0-9]+/);
+      if (!match) return null;
+      if (${JSON.stringify(previousId)} && match[0] === ${JSON.stringify(previousId)}) return null;
+      return match[0];
+    })()`,
+    { timeoutMs, label },
+  );
+}
+
+async function createFreshTask(ctx) {
+  const previousId = await currentRouteSessionId(ctx);
+  await ctx.control("session.create_task");
+  activeSessionId = await waitForActiveSessionId(ctx, {
+    previousId,
+    timeoutMs: 30_000,
+    label: "fresh active session id in route",
+  });
+  ctx.assert(Boolean(activeSessionId), "No active session id after create_task.");
+  ctx.log(`active session: ${activeSessionId}`);
+  await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)}))`, {
+    timeoutMs: 30_000,
+    label: "composer editor",
+  });
+  return activeSessionId;
+}
+
+function userBubbleExpression(text) {
+  return `(() => Array.from(document.querySelectorAll('[data-message-role="user"]'))
+    .some((element) => (element.innerText || "").includes(${JSON.stringify(text)})))()`;
+}
+
+async function sendPrompt(ctx, text) {
+  const pasted = await pasteComposer(ctx, text);
+  ctx.assert(pasted?.ok === true, `Composer not ready: ${pasted?.reason ?? "unknown"}`);
+  await submitComposer(ctx);
+  await ctx.waitFor(userBubbleExpression(text === PROMPT ? PROMPT_MARKER : text), {
+    timeoutMs: 20_000,
+    label: `user bubble for ${JSON.stringify(text)}`,
+  });
+}
+
+function sidebarRowStateExpression(expectedTitle = "") {
+  return `(() => {
+    const expectedTitle = ${JSON.stringify(expectedTitle)};
+    const route = window.__openworkControl?.snapshot?.().route || window.location.hash || "";
+    const activeSessionId = (route.match(/ses_[A-Za-z0-9]+/) || [])[0] || "";
+    const sidebarContent = document.querySelector('[data-slot="sidebar-content"]');
+    const sidebar = sidebarContent?.closest('[data-slot="sidebar"]')
+      || sidebarContent
+      || document.querySelector('[data-sidebar="sidebar"]')
+      || document.body;
+    const isVisible = (element) => {
+      if (!element) return false;
+      const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      return rect.width > 0 && rect.height > 0 && style.display !== "none" && style.visibility !== "hidden";
+    };
+    const rows = Array.from(sidebar.querySelectorAll('[data-slot="sidebar-menu-sub-item"], li'));
+    const candidates = [];
+    for (const row of rows) {
+      const title = row.querySelector('.truncate[title]');
+      if (!title) continue;
+      const button = title.closest('a,button') || title.closest('[data-slot="sidebar-menu-sub-button"]') || row.querySelector('[data-slot="sidebar-menu-sub-button"], a, button');
+      const spinner = row.querySelector('svg.animate-spin');
+      const dataActive = button ? button.getAttribute("data-active") : null;
+      const isActive = Boolean(button && (
+        dataActive === ""
+        || dataActive === "true"
+        || button.getAttribute("aria-current") === "page"
+        || button.getAttribute("aria-selected") === "true"
+        || button.getAttribute("data-state") === "active"
+      ));
+      const titleText = (title.textContent || "").trim();
+      const titleAttr = title.getAttribute("title") || titleText;
+      candidates.push({
+        row,
+        button,
+        title,
+        spinner,
+        titleText,
+        titleAttr,
+        isActive,
+        hasSpinner: Boolean(spinner && isVisible(spinner)),
+        truncated: title.scrollWidth > title.clientWidth,
+        titleClientWidth: title.clientWidth,
+        titleScrollWidth: title.scrollWidth,
+      });
+    }
+    const picked = candidates.find((candidate) => candidate.isActive && (!expectedTitle || candidate.titleAttr === expectedTitle))
+      || candidates.find((candidate) => expectedTitle && candidate.titleAttr === expectedTitle)
+      || candidates.find((candidate) => candidate.isActive)
+      || candidates.find((candidate) => candidate.hasSpinner && candidate.truncated)
+      || candidates.find((candidate) => candidate.hasSpinner)
+      || null;
+    if (!picked) {
+      return {
+        found: false,
+        activeSessionId,
+        expectedTitle,
+        candidates: candidates.slice(-6).map((candidate) => ({
+          title: candidate.titleAttr,
+          isActive: candidate.isActive,
+          hasSpinner: candidate.hasSpinner,
+          truncated: candidate.truncated,
+          titleClientWidth: candidate.titleClientWidth,
+          titleScrollWidth: candidate.titleScrollWidth,
+        })),
+      };
+    }
+    return {
+      found: true,
+      ready: picked.hasSpinner && picked.truncated,
+      activeSessionId,
+      expectedTitle,
+      title: picked.titleAttr,
+      titleText: picked.titleText,
+      isActive: picked.isActive,
+      hasSpinner: picked.hasSpinner,
+      truncated: picked.truncated,
+      titleClientWidth: picked.titleClientWidth,
+      titleScrollWidth: picked.titleScrollWidth,
+    };
+  })()`;
+}
+
+function sidebarMeasurementExpression(expectedTitle = "") {
+  return `(() => {
+    const expectedTitle = ${JSON.stringify(expectedTitle)};
+    const sidebarContent = document.querySelector('[data-slot="sidebar-content"]');
+    const sidebar = sidebarContent?.closest('[data-slot="sidebar"]')
+      || sidebarContent
+      || document.querySelector('[data-sidebar="sidebar"]')
+      || document.body;
+    const isVisible = (element) => {
+      if (!element) return false;
+      const rect = element.getBoundingClientRect();
+      const style = getComputedStyle(element);
+      return rect.width > 0 && rect.height > 0 && style.display !== "none" && style.visibility !== "hidden";
+    };
+    const rows = Array.from(sidebar.querySelectorAll('[data-slot="sidebar-menu-sub-item"], li'));
+    const candidates = [];
+    for (const row of rows) {
+      const title = row.querySelector('.truncate[title]');
+      if (!title) continue;
+      const closestButton = title.closest('a,button');
+      const slotButton = title.closest('[data-slot="sidebar-menu-sub-button"]') || row.querySelector('[data-slot="sidebar-menu-sub-button"]');
+      const button = closestButton || slotButton;
+      const spinnerSvg = row.querySelector('svg.animate-spin');
+      const dataActive = button ? button.getAttribute("data-active") : null;
+      const isActive = Boolean(button && (
+        dataActive === ""
+        || dataActive === "true"
+        || button.getAttribute("aria-current") === "page"
+        || button.getAttribute("aria-selected") === "true"
+        || button.getAttribute("data-state") === "active"
+      ));
+      const titleText = (title.textContent || "").trim();
+      const titleAttr = title.getAttribute("title") || titleText;
+      candidates.push({ row, title, button, closestButton, slotButton, spinnerSvg, titleText, titleAttr, isActive, hasSpinner: Boolean(spinnerSvg && isVisible(spinnerSvg)), truncated: title.scrollWidth > title.clientWidth });
+    }
+    const picked = candidates.find((candidate) => candidate.isActive && (!expectedTitle || candidate.titleAttr === expectedTitle))
+      || candidates.find((candidate) => expectedTitle && candidate.titleAttr === expectedTitle)
+      || candidates.find((candidate) => candidate.isActive)
+      || candidates.find((candidate) => candidate.hasSpinner && candidate.truncated)
+      || candidates.find((candidate) => candidate.hasSpinner)
+      || null;
+    if (!picked) {
+      return { ok: false, reason: "No sidebar row with a titled truncated span was found.", expectedTitle, candidates: candidates.map((candidate) => ({ title: candidate.titleAttr, isActive: candidate.isActive, hasSpinner: candidate.hasSpinner, truncated: candidate.truncated })).slice(-8) };
+    }
+    if (!picked.spinnerSvg || !isVisible(picked.spinnerSvg)) {
+      return { ok: false, reason: "The picked sidebar row does not contain a visible animate-spin svg.", title: picked.titleAttr, isActive: picked.isActive, hasSpinner: false };
+    }
+    const spinnerElement = picked.spinnerSvg.closest('span') || picked.spinnerSvg;
+    const titleRect = picked.title.getBoundingClientRect();
+    const spinnerRect = spinnerElement.getBoundingClientRect();
+    const computed = picked.button ? getComputedStyle(picked.button) : null;
+    const buttonPaddingRight = computed ? parseFloat(computed.paddingRight) : 0;
+    const buttonSource = picked.closestButton
+      ? "title.closest('a,button')"
+      : picked.slotButton
+        ? "data-slot=sidebar-menu-sub-button"
+        : "not found";
+    return {
+      ok: true,
+      title: picked.titleAttr,
+      titleText: picked.titleText,
+      rowTag: picked.row.tagName.toLowerCase(),
+      buttonTag: picked.button ? picked.button.tagName.toLowerCase() : null,
+      buttonSource,
+      isActive: picked.isActive,
+      hasSpinner: true,
+      truncated: picked.title.scrollWidth > picked.title.clientWidth,
+      titleScrollWidth: picked.title.scrollWidth,
+      titleClientWidth: picked.title.clientWidth,
+      titleRect: { left: titleRect.left, right: titleRect.right, width: titleRect.width },
+      spinnerRect: { left: spinnerRect.left, right: spinnerRect.right, width: spinnerRect.width },
+      buttonPaddingRight,
+      noOverlap: titleRect.right <= spinnerRect.left + 0.5,
+      hasReservedPadding: buttonPaddingRight >= 32,
+    };
+  })()`;
+}
+
+async function sendContinue(ctx) {
+  ctx.log("Streaming ended before the long title and spinner held together; sending follow-up 'continue'.");
+  await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)}))`, {
+    timeoutMs: 30_000,
+    label: "composer editor for continue follow-up",
+  });
+  await sendPrompt(ctx, CONTINUE_PROMPT);
+}
+
+async function waitForStreamingTruncatedSidebarRow(ctx) {
+  let followUps = 0;
+  let lastState = null;
+  while (followUps <= 2) {
+    let sawSpinner = false;
+    const deadline = Date.now() + 120_000;
+    while (Date.now() < deadline) {
+      const state = await ctx.eval(sidebarRowStateExpression(measuredSidebarTitle));
+      lastState = state;
+      if (state?.ready) {
+        measuredSidebarTitle = state.title || measuredSidebarTitle;
+        ctx.log(`sidebar row ready after ${followUps} follow-up(s): ${JSON.stringify(state)}`);
+        return state;
+      }
+      if (state?.hasSpinner) sawSpinner = true;
+      if (sawSpinner && state?.found && !state.hasSpinner) break;
+      await sleep(500);
+    }
+    if (followUps >= 2) break;
+    followUps += 1;
+    await sendContinue(ctx);
+  }
+  ctx.assert(false, `Timed out waiting for the active sidebar row to show both a visible spinner and a truncated title. Last state: ${JSON.stringify(lastState)}`);
+  return null;
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Sidebar streaming spinner stays clear of long task titles",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    const state = await waitForReadySession(ctx);
+    return state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); sidebar spinner proof requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "Create a fresh streaming task",
+      run: async (ctx) => {
+        await ctx.prove("A fresh task starts running and renders the user's prompt", {
+          voiceover: vo[0],
+          action: async () => {
+            await closeStaleDialogs(ctx);
+            await createFreshTask(ctx);
+            await sendPrompt(ctx, PROMPT);
+          },
+          assert: async () => {
+            await ctx.waitFor(userBubbleExpression(PROMPT_MARKER), {
+              timeoutMs: 20_000,
+              label: "robotics offsite prompt in a user bubble",
+            });
+            ctx.assert(Boolean(activeSessionId), "No active session id was captured for the streaming task.");
+            await ctx.expectNoText("Something went wrong");
+          },
+          screenshot: { name: "streaming-task-started", rejectText: ["Something went wrong"] },
+        });
+      },
+    },
+    {
+      name: "Measure title and spinner separation while streaming",
+      run: async (ctx) => {
+        await ctx.prove("The active sidebar row reserves enough end padding for the streaming spinner", {
+          voiceover: vo[1],
+          action: async () => {
+            await waitForStreamingTruncatedSidebarRow(ctx);
+          },
+          assert: async () => {
+            const measurement = await ctx.eval(sidebarMeasurementExpression(measuredSidebarTitle));
+            ctx.output("sidebar-spinner-measurement", JSON.stringify(measurement, null, 2));
+            ctx.log(`sidebar measurement: ${JSON.stringify(measurement)}`);
+            ctx.assert(measurement?.ok === true, measurement?.reason ?? "Sidebar row measurement failed.");
+            ctx.assert(measurement.hasSpinner === true, "The measured row did not contain the streaming spinner.");
+            ctx.assert(measurement.truncated === true, `The title was not actually truncated: ${JSON.stringify(measurement)}`);
+            ctx.assert(measurement.noOverlap === true, `Title overlapped the spinner: ${JSON.stringify(measurement)}`);
+            ctx.assert(measurement.hasReservedPadding === true, `Expected at least 32px right padding, got ${measurement.buttonPaddingRight}.`);
+            measuredSidebarTitle = measurement.title || measuredSidebarTitle;
+          },
+          screenshot: { name: "spinner-clear-of-title", rejectText: ["Something went wrong"] },
+        });
+      },
+    },
+    {
+      name: "Spinner clears when the run finishes",
+      run: async (ctx) => {
+        await ctx.prove("The same sidebar row removes the spinner after the task finishes", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.waitFor(
+              `(() => {
+                const state = ${sidebarRowStateExpression(measuredSidebarTitle)};
+                return state.found && !state.hasSpinner ? state : null;
+              })()`,
+              { timeoutMs: 120_000, label: "active sidebar row spinner to disappear" },
+            );
+          },
+          assert: async () => {
+            const state = await ctx.eval(sidebarRowStateExpression(measuredSidebarTitle));
+            ctx.output("sidebar-spinner-finished-state", JSON.stringify(state, null, 2));
+            ctx.assert(state?.found === true, `Could not find the measured sidebar row after streaming: ${JSON.stringify(state)}`);
+            ctx.assert(state.hasSpinner === false, `Spinner was still visible in the measured row: ${JSON.stringify(state)}`);
+            await ctx.expectNoText("Something went wrong");
+          },
+          screenshot: { name: "spinner-cleared", rejectText: ["Something went wrong"] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/chat-select-all-scoped.md
+++ b/evals/voiceovers/chat-select-all-scoped.md
@@ -1,0 +1,9 @@
+# chat-select-all-scoped — Select All selects the conversation, not the whole app
+
+Pressing Select All used to sweep the entire interface — sidebar labels, tabs, status bar — into one giant selection. Now it is scoped: from the conversation it selects just the chat messages, and inside the composer it keeps behaving like a normal text field.
+
+1. Alex opens a chat that already has a question and an answer in the transcript.
+
+2. Alex presses Select All from the conversation. The highlight covers the chat messages and only the chat messages — the sidebar, tabs, and status bar stay out of the copied text.
+
+3. With the cursor in the composer, Select All behaves like a text field and selects only the draft text.

--- a/evals/voiceovers/sidebar-spinner-clear-of-title.md
+++ b/evals/voiceovers/sidebar-spinner-clear-of-title.md
@@ -1,0 +1,9 @@
+# sidebar-spinner-clear-of-title — The sidebar spinner never covers the task name
+
+While a task runs, its sidebar row shows a small spinner. A class-precedence bug dropped the row's end padding exactly in the streaming state, so long task names ran underneath the spinner and the two rendered on top of each other. This proof runs a real task and measures the row.
+
+1. Alex kicks off a task and the sidebar row shows a spinner while the agent works.
+
+2. Even with a long task name, the title now truncates before the spinner instead of running underneath it — the spinner never covers the letters.
+
+3. When the run finishes, the spinner clears and the row reads normally again.


### PR DESCRIPTION
## What

Two chat-shell UX fixes:

1. **Sidebar spinner no longer covers the task title.** The session row
   reserves end padding for the absolutely-positioned status spinner, but
   `isSessionStreaming || isSessionActive && "pe-8"` parses as
   `isSessionStreaming || (isSessionActive && "pe-8")` — while **streaming**
   it yields `true`, which `cn()` ignores, so the padding was dropped exactly
   when the spinner is shown and long titles rendered underneath it. Fixed the
   precedence in both row variants (`pe-8` / `pe-12`); titles now truncate
   before the spinner, so nothing needs a masking background.

   | Before (dev) | After (this PR) |
   |---|---|
   | ![before](https://b8tgacyg507ru26g.public.blob.vercel-storage.com/pr-sidebar-spinner/sidebar-spinner-clear-of-title-02-failure-FuxXkpEzMLckOWhp1ZRxkTrePEhe4q.png) | ![after](https://b8tgacyg507ru26g.public.blob.vercel-storage.com/pr-sidebar-spinner/sidebar-spinner-clear-of-title-02-spinner-clear-of-title-3USzEIIj1LiD3HywBEgwK5RfJuiJJv.png) |

   Measured on dev during streaming: `titleRect.right=199` vs `spinnerRect.left=186`
   (13px of title under the spinner), `paddingRight=12`. With the fix:
   no overlap and `paddingRight≥32` (assertions in the fraimz flow).

2. **Select All is scoped to the conversation.** Cmd/Ctrl+A used to sweep the
   entire UI (sidebar labels, tabs, status bar) into the selection. Now, when
   focus is not in an editable element and a transcript is visible, Select All
   selects only the chat messages. Two trigger paths are wired:
   - renderer keydown (capture) — covers web mode;
   - the Electron **Edit ▸ Select All** menu item (which intercepts the
     accelerator before any DOM event): it now calls the renderer's scoped
     handler and falls back to native `webContents.selectAll()` for editable
     focus, the built-in browser panel, devtools, and non-chat surfaces —
     so composer/inputs keep behaving like normal text fields.

   Note: on this base branch user bubbles are still `user-select: none`; once
   #2886 lands, Select All includes your own bubbles too. The two PRs are
   independent and merge in any order.

## Validation (fraimz)

Two voiceover-first flows on a Daytona Electron sandbox (real desktop build,
real GPT-5.5):

- `sidebar-spinner-clear-of-title` — runs a real task with a long
  auto-generated title and measures, mid-stream, that the title box ends
  before the spinner box and the padding reservation is applied; also run
  against dev's sidebar file in the same sandbox to reproduce the failure
  (numbers above).
- `chat-select-all-scoped` — real CDP Ctrl+A: selection includes the
  assistant reply and none of the shell strings ("Add workspace",
  "Ready for new tasks", "Search sessions"); the same scoped call the menu
  executes is asserted directly; with the cursor in the composer, Ctrl+A
  selects only the draft text (anchorNode inside the composer).

Combined `fraimz.html` posted as a comment below.

## Tests

- `pnpm --filter @openwork/app typecheck` — clean
- `pnpm --filter @openwork/app test` — 350 pass, 0 fail
- `node --check apps/desktop/electron/app-menu.mjs` — clean
- `pnpm fraimz --flow sidebar-spinner-clear-of-title --flow chat-select-all-scoped --cdp-url <daytona>` — PASSED (comment below)

Known gap: the OS-level menu accelerator itself can't be triggered via CDP;
the menu's exact renderer call (`window.__openworkChatSelectAll()`) is
asserted instead, and the menu change is a 12-line reviewed diff with native
fallback.
