### PR TITLE
fix(server): propagate client disconnects to request cancellation

### DIFF
--- a/apps/server/src/serve-node.test.ts
+++ b/apps/server/src/serve-node.test.ts
@@ -1,6 +1,37 @@
 import { describe, expect, test } from "bun:test";
+import { request as requestHttp, type ClientRequest } from "node:http";
+import { createConnection } from "node:net";
 import { setTimeout as delay } from "node:timers/promises";
 import { serve } from "./serve-node.js";
+
+function waitForAbort(signal: AbortSignal): Promise<void> {
+  if (signal.aborted) return Promise.resolve();
+  return new Promise((resolve) => {
+    signal.addEventListener("abort", () => resolve(), { once: true });
+  });
+}
+
+function ignoreClientError(request: ClientRequest): ClientRequest {
+  request.on("error", () => undefined);
+  return request;
+}
+
+async function startAbortObservingServer() {
+  let observeRequest: ((request: Request) => void) | undefined;
+  const requestObserved = new Promise<Request>((resolve) => {
+    observeRequest = resolve;
+  });
+  const server = await serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: async (request) => {
+      observeRequest?.(request);
+      await waitForAbort(request.signal);
+      return Response.json({ aborted: true });
+    },
+  });
+  return { requestObserved, server };
+}
 
 describe("serve", () => {
   test("does not write an error response after a streaming response has ended", async () => {
@@ -119,5 +150,115 @@ describe("serve", () => {
       console.error = originalError;
       await server.stop();
     }
+  });
+
+  test("aborts the Web request when a client disconnects before the response", async () => {
+    const { requestObserved, server } = await startAbortObservingServer();
+    const clientRequest = ignoreClientError(
+      requestHttp({
+        hostname: "127.0.0.1",
+        port: server.port,
+        path: "/wait-for-response",
+      }),
+    );
+
+    try {
+      clientRequest.end();
+      const webRequest = await requestObserved;
+      const requestAborted = waitForAbort(webRequest.signal);
+      expect(webRequest.signal.aborted).toBe(false);
+
+      clientRequest.destroy();
+
+      await requestAborted;
+      expect(webRequest.signal.aborted).toBe(true);
+    } finally {
+      clientRequest.destroy();
+      await server.stop();
+    }
+  });
+
+  test("aborts the Web request when a client disconnects during the request body", async () => {
+    const { requestObserved, server } = await startAbortObservingServer();
+    const clientSocket = createConnection({
+      host: "127.0.0.1",
+      port: server.port,
+    });
+    clientSocket.on("error", () => undefined);
+
+    try {
+      await new Promise<void>((resolve) => {
+        clientSocket.once("connect", () => resolve());
+      });
+      clientSocket.write(
+        [
+          "POST /partial-upload HTTP/1.1",
+          `Host: 127.0.0.1:${server.port}`,
+          "Content-Length: 16",
+          "Connection: close",
+          "",
+          "partial",
+        ].join("\r\n"),
+      );
+      const webRequest = await requestObserved;
+      const requestAborted = waitForAbort(webRequest.signal);
+      expect(webRequest.signal.aborted).toBe(false);
+
+      clientSocket.destroy();
+
+      await requestAborted;
+      expect(webRequest.signal.aborted).toBe(true);
+    } finally {
+      clientSocket.destroy();
+      await server.stop();
+    }
+  });
+
+  test("does not abort the Web request after a normal response completes", async () => {
+    let requestSignal: AbortSignal | undefined;
+    const server = await serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => {
+        requestSignal = request.signal;
+        return Response.json({ ok: true });
+      },
+    });
+
+    try {
+      const response = await fetch(`http://127.0.0.1:${server.port}/complete`);
+      expect(await response.json()).toEqual({ ok: true });
+      expect(requestSignal?.aborted).toBe(false);
+    } finally {
+      await server.stop();
+    }
+
+    expect(requestSignal?.aborted).toBe(false);
+  });
+
+  test("stops tracking disconnects when the handler rejects", async () => {
+    let requestSignal: AbortSignal | undefined;
+    const originalError = console.error;
+    const server = await serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: (request) => {
+        requestSignal = request.signal;
+        throw new Error("handler failed");
+      },
+    });
+
+    try {
+      console.error = () => undefined;
+      const response = await fetch(`http://127.0.0.1:${server.port}/reject`);
+      expect(response.status).toBe(500);
+      expect(await response.json()).toEqual({ error: "internal_error" });
+      expect(requestSignal?.aborted).toBe(false);
+    } finally {
+      console.error = originalError;
+      await server.stop();
+    }
+
+    expect(requestSignal?.aborted).toBe(false);
   });
 });

--- a/apps/server/src/serve-node.ts
+++ b/apps/server/src/serve-node.ts
@@ -48,6 +48,40 @@ function endResponse(nodeRes: ServerResponse, chunk?: string): void {
   nodeRes.end(chunk);
 }
 
+function trackClientDisconnect(
+  nodeReq: IncomingMessage,
+  nodeRes: ServerResponse,
+  abortController: AbortController,
+): () => void {
+  const abortRequest = () => {
+    if (!abortController.signal.aborted) {
+      abortController.abort();
+    }
+  };
+  const abortIncompleteRequest = () => {
+    if (!nodeReq.complete) {
+      abortRequest();
+    }
+  };
+  const abortIncompleteResponse = () => {
+    if (!nodeRes.writableFinished) {
+      abortRequest();
+    }
+  };
+
+  nodeReq.once("aborted", abortRequest);
+  nodeReq.once("error", abortRequest);
+  nodeReq.once("close", abortIncompleteRequest);
+  nodeRes.once("close", abortIncompleteResponse);
+
+  return () => {
+    nodeReq.off("aborted", abortRequest);
+    nodeReq.off("error", abortRequest);
+    nodeReq.off("close", abortIncompleteRequest);
+    nodeRes.off("close", abortIncompleteResponse);
+  };
+}
+
 async function waitForDrainOrClose(nodeRes: ServerResponse): Promise<void> {
   if (!isResponseWritable(nodeRes)) return;
 
@@ -79,7 +113,12 @@ async function waitForDrainOrClose(nodeRes: ServerResponse): Promise<void> {
 /**
  * Convert a Node.js IncomingMessage into a Web API Request.
  */
-function toWebRequest(nodeReq: IncomingMessage, hostname: string, port: number): Request {
+function toWebRequest(
+  nodeReq: IncomingMessage,
+  hostname: string,
+  port: number,
+  signal: AbortSignal,
+): Request {
   const url = `http://${hostname}:${port}${nodeReq.url ?? "/"}`;
   const method = nodeReq.method ?? "GET";
   const headers = new Headers();
@@ -106,6 +145,7 @@ function toWebRequest(nodeReq: IncomingMessage, hostname: string, port: number):
     method,
     headers,
     body,
+    signal,
     // @ts-expect-error duplex is required for streaming request bodies in Node
     duplex: hasBody ? "half" : undefined,
   });
@@ -167,8 +207,11 @@ export function serve(options: ServeOptions): Promise<ServeResult> {
       console.error("[serve-node] Response stream error:", error);
     });
 
+    const abortController = new AbortController();
+    const stopTrackingClient = trackClientDisconnect(nodeReq, nodeRes, abortController);
+
     try {
-      const webReq = toWebRequest(nodeReq, hostname, boundPort);
+      const webReq = toWebRequest(nodeReq, hostname, boundPort, abortController.signal);
       const webRes = await fetchHandler(webReq);
       await writeWebResponse(webRes, nodeRes);
     } catch (error) {
@@ -184,6 +227,8 @@ export function serve(options: ServeOptions): Promise<ServeResult> {
         nodeRes.writeHead(500, { "Content-Type": "application/json" });
       }
       endResponse(nodeRes, JSON.stringify({ error: "internal_error" }));
+    } finally {
+      stopTrackingClient();
     }
   });
 


### PR DESCRIPTION
## Summary

- create one `AbortController` for every request handled by the Node HTTP adapter
- forward aborted/erroring request streams, incomplete request closes, and premature response closes into the Web `Request.signal`
- remove all socket lifecycle listeners after the handler/response path settles
- add real socket regression coverage for both a completed request whose client leaves before the response and an upload disconnected mid-body
- verify normal responses and rejected handlers do not retain listeners or spuriously abort their request signal

## Why

The Node adapter previously constructed Web `Request` objects without a signal. Downstream handlers could compose timeouts with `request.signal`, but a vanished HTTP caller was never observable, so cancellation-aware work could continue after the client had gone away.


## Tangible value

This closes the lifecycle gap between the network connection and the application handler. When a caller disappears, cancellation-aware handlers can stop supported upstream HTTP calls, streams, and timers immediately instead of consuming a worker slot until their own timeout expires. That reduces orphaned work, releases capacity sooner during unreliable-network or high-concurrency periods, and gives every route served by this adapter the standard Web API cancellation contract through `request.signal`.

The change provides the cancellation signal at the adapter boundary; downstream work stops only when the handler and the libraries it calls observe that signal.

## Real-world example

A user starts a long-running streamed agent operation through an OpenWork Server, then closes their laptop or changes networks while the request is still running. The TCP connection disappears, so there is no client left to receive the result.

Before this change, the Node adapter created a Web `Request` with no signal. Even cancellation-aware downstream code could not learn that the caller had gone away, so an upstream provider request or response stream could continue until completion or timeout, occupying capacity for a result that would be discarded.

After this change, the socket closure aborts `request.signal`. A handler that passes that signal into its upstream calls can stop promptly, release its resources, and leave the worker available for active users.

## Validation

- `./bin/openwork-hub check server node-request-cancellation` — passed
- `pnpm --filter openwork-server exec bun test src/serve-node.test.ts` — 8 passed, 0 failed, 19 assertions
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm --filter openwork-server build` — passed
- native Node smoke against the compiled adapter using real HTTP/TCP clients — 4/4 lifecycle scenarios passed: completed-request disconnect, incomplete-body disconnect, normal completion, and rejected-handler cleanup
- GitHub Actions — `openwork-tests` passed on Ubuntu and macOS; `i18n-audit` passed
- `git diff --check` — passed

## Risk and scope

This is limited to `apps/server/src/serve-node.ts` and its focused integration test. It changes no route, response, schema, public package, credential, or cloud contract. Cancellation remains cooperative: handlers must observe `request.signal` to stop their own work.

## Manual and deferred evidence

The actual changed boundary was exercised locally with native Node and real loopback sockets. No UI flow exists for this adapter-only change.

- Not run locally — full `openwork-server` test suite; repository CI passed on both Ubuntu and macOS.
- Not run — fraimz, screenshots, or video; no user-visible UI changed and visual evidence was not requested.

## External check note

The remaining red Vercel app/Den/diagnostics preview checks report fork authorization requirements. The affected landing preview deployed successfully; these authorization failures are external to this two-file server change.
