### PR TITLE
fix(server): kill child process on spawn failure to prevent orphaned processes

### DIFF
--- a/apps/server/src/managed-opencode.ts
+++ b/apps/server/src/managed-opencode.ts
@@ -101,7 +101,10 @@ export async function createManagedOpencodeServer(options: {
   });
 
   const url = await new Promise<string>((resolve, reject) => {
-    const timeout = setTimeout(() => reject(new Error(`Timeout waiting for OpenCode server after ${options.timeoutMs ?? 15000}ms`)), options.timeoutMs ?? 15000);
+    const timeout = setTimeout(() => {
+      try { child.kill("SIGTERM"); } catch { /* already exited */ }
+      reject(new Error(`Timeout waiting for OpenCode server after ${options.timeoutMs ?? 15000}ms`));
+    }, options.timeoutMs ?? 15000);
     let output = "";
     const done = (value: string) => {
       clearTimeout(timeout);
@@ -109,6 +112,7 @@ export async function createManagedOpencodeServer(options: {
     };
     const fail = (error: Error) => {
       clearTimeout(timeout);
+      try { child.kill("SIGTERM"); } catch { /* already exited */ }
       reject(error);
     };
     child.stdout?.on("data", (chunk) => {


### PR DESCRIPTION
## Summary

When `createManagedOpencodeServer` spawns a child process, three failure paths reject the promise but never kill the child:

1. **Timeout** (line 103): The setTimeout fires, rejects the promise, but the child process continues running
2. **Error event** (line 125): The child emits an error, `fail()` is called, but the child is not killed
3. **Premature exit** (line 126): The child exits early, `fail()` is called, but no cleanup happens

In all three cases, the child process handle is lost — the caller never receives the `ManagedOpencodeServer` object with its `close()` method. The orphaned `opencode serve` process continues holding a port and consuming memory until manually killed.

**Fix**: Added `child.kill("SIGTERM")` to both the timeout handler and the `fail()` function to ensure the spawned process is cleaned up on all failure paths.