### PR TITLE
fix(updater): resolve stable updates from prerelease builds instead of blaming Den's inventory

### DIFF
--- a/apps/app/src/app/lib/version-gate.ts
+++ b/apps/app/src/app/lib/version-gate.ts
@@ -85,6 +85,12 @@ function normalizeStableDesktopVersion(value: string): string | null {
   return /^\d+\.\d+\.\d+$/.test(normalized) ? normalized : null;
 }
 
+function normalizeCurrentDesktopVersion(value: string): string | null {
+  const normalized = value.trim().replace(/^v/i, "");
+  if (normalizeStableDesktopVersion(normalized)) return normalized;
+  return parseComparableVersion(normalized) ? normalized : null;
+}
+
 /**
  * Compare two version strings. Returns -1 / 0 / 1 as usual, or null if
  * either side fails to parse. Accepts an optional leading `v` and handles
@@ -211,8 +217,11 @@ export function selectStableDesktopUpdate(input: {
   metadata: DenAppVersionMetadata;
   desktopConfig: DenDesktopConfig | null | undefined;
 }): StableDesktopUpdateSelection | null {
-  const currentVersion = normalizeStableDesktopVersion(input.currentVersion);
+  const currentVersion = normalizeCurrentDesktopVersion(input.currentVersion);
   if (!currentVersion) return null;
+  const currentRelease = releasePart(currentVersion);
+  if (!currentRelease) return null;
+  const currentReleaseVersion = currentRelease.join(".");
 
   const publishedVersions = [...new Set(input.metadata.publishedDesktopVersions.flatMap((version) => {
     const normalized = normalizeStableDesktopVersion(version);
@@ -235,14 +244,14 @@ export function selectStableDesktopUpdate(input: {
         restrictedVersions.some((allowedVersion) => compareVersions(publishedVersion, allowedVersion) === 0),
       );
   const targetVersion = approvedPublishedVersions
-    .filter((version) => compareVersions(version, currentVersion) === 1)
+    .filter((version) => compareVersions(version, currentReleaseVersion) === 1)
     .at(-1);
 
   if (targetVersion) {
     return { kind: "update", targetVersion, latestPublishedVersion };
   }
 
-  if (compareVersions(latestPublishedVersion, currentVersion) === 1 && restrictedVersions !== null) {
+  if (compareVersions(latestPublishedVersion, currentReleaseVersion) === 1 && restrictedVersions !== null) {
     return { kind: "blocked", latestPublishedVersion };
   }
 

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -234,7 +234,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
           refreshDesktopConfig,
         });
         if (!selection) {
-          throw new Error("Den returned an invalid desktop release inventory.");
+          throw new Error("Could not resolve a stable update for this build.");
         }
         if (selection.kind === "blocked") {
           setUpdateStatus({

--- a/apps/app/tests/version-gate.test.ts
+++ b/apps/app/tests/version-gate.test.ts
@@ -11,6 +11,12 @@ const metadata = {
   publishedDesktopVersions: ["0.17.22", "0.17.23", "0.17.24"],
 };
 
+const stableDesktopMetadata = {
+  minAppVersion: "0.17.0",
+  latestAppVersion: "0.17.32",
+  publishedDesktopVersions: ["0.17.32", "0.17.31", "0.17.19"],
+};
+
 describe("selectStableDesktopUpdate", () => {
   test("selects the highest approved published release above the installed version", () => {
     expect(selectStableDesktopUpdate({
@@ -58,6 +64,68 @@ describe("selectStableDesktopUpdate", () => {
       metadata,
       desktopConfig: {},
     })).toEqual({ kind: "current", latestPublishedVersion: "0.17.24" });
+  });
+
+  test("treats a prerelease on the latest release line as current", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.32-alpha.1691",
+      metadata: stableDesktopMetadata,
+      desktopConfig: {},
+    })).toEqual({ kind: "current", latestPublishedVersion: "0.17.32" });
+  });
+
+  test("updates older prerelease builds to the latest stable release", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.19-alpha.3",
+      metadata: stableDesktopMetadata,
+      desktopConfig: {},
+    })).toEqual({
+      kind: "update",
+      targetVersion: "0.17.32",
+      latestPublishedVersion: "0.17.32",
+    });
+  });
+
+  test("returns null for unparseable installed versions", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "dev",
+      metadata: stableDesktopMetadata,
+      desktopConfig: {},
+    })).toBeNull();
+    expect(selectStableDesktopUpdate({
+      currentVersion: "garbage",
+      metadata: stableDesktopMetadata,
+      desktopConfig: {},
+    })).toBeNull();
+  });
+
+  test("preserves stable installed version selection behavior", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.31",
+      metadata: stableDesktopMetadata,
+      desktopConfig: {},
+    })).toEqual({
+      kind: "update",
+      targetVersion: "0.17.32",
+      latestPublishedVersion: "0.17.32",
+    });
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.32",
+      metadata: stableDesktopMetadata,
+      desktopConfig: {},
+    })).toEqual({ kind: "current", latestPublishedVersion: "0.17.32" });
+  });
+
+  test("respects restricted published versions for prerelease builds", () => {
+    expect(selectStableDesktopUpdate({
+      currentVersion: "0.17.19-alpha.1",
+      metadata: stableDesktopMetadata,
+      desktopConfig: { allowedDesktopVersions: ["0.17.31"] },
+    })).toEqual({
+      kind: "update",
+      targetVersion: "0.17.31",
+      latestPublishedVersion: "0.17.32",
+    });
   });
 
   test("uses the config returned by the manual refresh instead of a stale cached policy", async () => {


### PR DESCRIPTION
## What

Users on **prerelease builds** (alpha/dev) who click **Check for updates** with the stable channel selected get:

> Den returned an invalid desktop release inventory.

Den is innocent: `GET /v1/app-version` returns a perfectly valid inventory (verified live against production — `latestAppVersion 0.17.32`, full published list). The bug is client-side, shipped in #2722 (v0.17.25): `selectStableDesktopUpdate` normalizes the **installed** version with a strict `X.Y.Z` regex, so `0.17.32-alpha.1691` → `null` → the caller throws the misleading Den-blaming error. It got noticed now because v0.17.32 just shipped and prerelease users went to check for it.

## Fix

- Parse the installed version leniently (`parseComparableVersion` already understands `-alpha.N`); compare by its release part:
  - `0.17.32-alpha.1691` vs stable `0.17.32` → **"You're up to date"** (no same-version reinstall offer)
  - `0.17.19-alpha.3` → offered the newest approved stable (`0.17.32`)
  - `allowedDesktopVersions` restrictions still respected
- The strict `X.Y.Z` gate stays for the **published inventory** entries (the trust boundary is unchanged).
- The remaining truly-unparseable case ("dev") now says "Could not resolve a stable update for this build." instead of blaming Den.

## Tests run

- `pnpm --filter @openwork/app exec bun test --isolate tests/version-gate.test.ts` → **16 pass / 0 fail** (6 new cases: prerelease-on-latest-line → current, older prerelease → update, unparseable → null, stable behavior unchanged, restricted-versions interplay)
- `pnpm --filter @openwork/app typecheck` → clean
- Verified against the **live production inventory** by importing the patched module and feeding real `/v1/app-version` data:
  ```
  0.17.32-alpha.1691 -> {"kind":"current","latestPublishedVersion":"0.17.32"}   (was: null → error)
  0.17.31            -> {"kind":"update","targetVersion":"0.17.32", ...}        (unchanged)
  0.18.0-dev         -> {"kind":"current", ...}
  dev                -> null (honest message now)
  ```

## Evidence note

No fraimz for this one, stated explicitly: driving the real Updates panel through the failing path requires a packaged prerelease build (the installed-version string comes from the Electron updater bridge, not anything a dev-mode flow can inject). The behavior is a pure selector covered by the unit tests above plus the live-data run. Repro for a reviewer on any alpha build: Settings → Updates → channel "stable" → Check for updates (errors before, resolves after).
