### PR TITLE
fix(mcp): keep one callback for non-iss OAuth providers

### DIFF
--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-oauth-persistence.ts
@@ -140,10 +140,18 @@ function restoredClientInformation(input: {
   extra: Record<string, unknown> | null
 }): OAuthClientInformationMixed {
   const candidate = input.extra?.clientInformation
+  const tokenEndpointAuthMethod = input.extra?.tokenEndpointAuthMethod
+  const registeredRedirectUri = input.extra?.registeredRedirectUri
   const full = OAuthClientInformationFullSchema.safeParse({
     ...(typeof candidate === "object" && candidate !== null ? candidate : {}),
     client_id: input.clientId,
     client_secret: input.clientSecret ?? undefined,
+    ...(tokenEndpointAuthMethod === "client_secret_basic" || tokenEndpointAuthMethod === "client_secret_post"
+      ? {
+          token_endpoint_auth_method: tokenEndpointAuthMethod,
+          ...(typeof registeredRedirectUri === "string" ? { redirect_uris: [registeredRedirectUri] } : {}),
+        }
+      : {}),
   })
   if (full.success) return full.data
   return OAuthClientInformationSchema.parse({

--- a/ee/apps/den-api/src/capability-sources/generic-oauth.ts
+++ b/ee/apps/den-api/src/capability-sources/generic-oauth.ts
@@ -66,6 +66,7 @@ export type OAuthStatePayload = {
   binding?: string
   callbackMode?: "shared-v1" | "isolated-v1" | "legacy-v1"
   authorizationServerIssuer?: string
+  authorizationResponseIssuerRequired?: boolean
   nonce: string
   iat?: number
   exp: number
@@ -79,6 +80,7 @@ export function createOAuthStateToken(input: {
   version?: 1 | 2
   callbackMode?: "shared-v1" | "isolated-v1" | "legacy-v1"
   authorizationServerIssuer?: string
+  authorizationResponseIssuerRequired?: boolean
   secret: string
   ttlSeconds?: number
   now?: number
@@ -92,6 +94,9 @@ export function createOAuthStateToken(input: {
     ...(input.binding ? { binding: input.binding } : {}),
     ...(input.callbackMode ? { callbackMode: input.callbackMode } : {}),
     ...(input.authorizationServerIssuer ? { authorizationServerIssuer: input.authorizationServerIssuer } : {}),
+    ...(input.authorizationResponseIssuerRequired !== undefined
+      ? { authorizationResponseIssuerRequired: input.authorizationResponseIssuerRequired }
+      : {}),
     nonce: randomUUID(),
     iat: Math.floor(nowMs / 1000),
     exp: Math.floor(nowMs / 1000) + (input.ttlSeconds ?? 10 * 60),
@@ -124,6 +129,7 @@ export function verifyOAuthStateToken(input: { token: string; secret: string; no
       || (payload.version !== undefined && payload.version !== 1 && payload.version !== 2)
       || (payload.callbackMode !== undefined && payload.callbackMode !== "shared-v1" && payload.callbackMode !== "isolated-v1" && payload.callbackMode !== "legacy-v1")
       || (payload.authorizationServerIssuer !== undefined && typeof payload.authorizationServerIssuer !== "string")
+      || (payload.authorizationResponseIssuerRequired !== undefined && typeof payload.authorizationResponseIssuerRequired !== "boolean")
       || typeof payload.nonce !== "string"
       || (payload.iat !== undefined && typeof payload.iat !== "number")
       || typeof payload.exp !== "number"

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -52,7 +52,6 @@ import {
   disconnectExternalMcpMemberAccount,
   externalMcpIdentityBinding,
   getExternalMcpConnection,
-  isolateExternalMcpOAuthCallback,
   listActiveExternalMcpConnectionBindings,
   listDirectExternalMcpConnectionAccess,
   listExternalMcpConnections,
@@ -672,21 +671,11 @@ function oauthAuthorizationServerMetadata(connection: ExternalMcpConnectionRow):
   return discovery.authorizationServerMetadata
 }
 
-function requiresIsolatedOAuthCallback(connection: ExternalMcpConnectionRow): boolean {
+function usesPinnedSharedOAuthCallback(connection: ExternalMcpConnectionRow): boolean {
   const metadata = oauthAuthorizationServerMetadata(connection)
   return connection.oauthConfiguration?.callbackMode === "shared-v1"
     && metadata !== undefined
     && metadata.authorization_response_iss_parameter_supported !== true
-}
-
-function assertIsolatedOAuthCallbackSafety(connection: ExternalMcpConnectionRow): void {
-  const methods = oauthAuthorizationServerMetadata(connection)?.code_challenge_methods_supported
-  if (!Array.isArray(methods) || !methods.includes("S256")) {
-    throw new EnterpriseMcpOAuthContractError(
-      "MCP_OAUTH_CONFIGURATION_REQUIRED",
-      "This authorization server omits response issuers and cannot use the isolated callback because it does not advertise PKCE S256.",
-    )
-  }
 }
 
 function parseJsonObject(value: string | null): Record<string, unknown> | null {
@@ -1106,6 +1095,7 @@ async function handleExternalMcpOAuthCallback(input: {
       ? (url.searchParams.get("iss") ?? "")
       : undefined
     try {
+      const usesPinnedSharedCallback = usesPinnedSharedOAuthCallback(connection)
       const validation = validateMcpAuthorizationResponseIssuer({
         expectedIssuer: configuredIssuer,
         discoveryState: connection.oauthConfiguration?.discovery,
@@ -1114,7 +1104,9 @@ async function handleExternalMcpOAuthCallback(input: {
           ? "distinct-redirect-uri"
           : callbackMode === "legacy-v1"
             ? "legacy"
-            : "response-issuer",
+            : usesPinnedSharedCallback
+              ? "pinned-transaction"
+              : "response-issuer",
       })
       if (validation.ignoredResponseIssuer !== undefined) {
         logger.warn("external_mcp_connect_callback_untrusted_issuer_ignored", {
@@ -2340,7 +2332,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
             member,
             c.get("requestId"),
           )
-          return { result, signedState }
+          return { result }
         }
 
         let started: Awaited<ReturnType<typeof beginAuthorization>>
@@ -2414,19 +2406,13 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
             organizationId: payload.organization.id,
             connectionId: externalMcpConnectionId,
           })
-          if (discovered && requiresIsolatedOAuthCallback(discovered)) {
-            assertIsolatedOAuthCallbackSafety(discovered)
-            await abandonExternalMcpAuth(discovered, started.signedState, member, c.get("requestId"))
-            connection = await isolateExternalMcpOAuthCallback({
-              organizationId: payload.organization.id,
-              connectionId: externalMcpConnectionId,
-            })
-            logger.info("external_mcp_oauth_isolated_callback_selected", {
+          if (discovered && usesPinnedSharedOAuthCallback(discovered)) {
+            connection = discovered
+            logger.info("external_mcp_oauth_pinned_shared_callback_selected", {
               connection_id: connection.id,
               organization_id: payload.organization.id,
               authorization_server_issuer: connection.oauthConfiguration?.authorizationServerIssuer,
             })
-            started = await beginAuthorization(connection)
           }
         }
 

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -249,6 +249,7 @@ const createConnectionBodySchema = z.object({
   oauthClient: z.object({
     clientId: z.string().trim().min(1).max(512),
     clientSecret: z.string().trim().min(1).max(4096).optional(),
+    tokenEndpointAuthMethod: z.enum(["client_secret_basic", "client_secret_post"]).optional(),
   }).optional(),
   authorizationServerIssuer: z.string().trim().url().max(2048).nullable().optional(),
   requestedScopes: z.array(z.string().trim().min(1).max(255)).max(100).optional().default([]),
@@ -268,6 +269,7 @@ const updateConnectionBodySchema = z.object({
     clientId: z.string().trim().min(1).max(512),
     /** Omitted preserves the secret only when both identity and client id are unchanged. */
     clientSecret: z.string().trim().min(1).max(4096).optional(),
+    tokenEndpointAuthMethod: z.enum(["client_secret_basic", "client_secret_post"]).optional(),
   }).optional(),
   authorizationServerIssuer: z.string().trim().url().max(2048).nullable().optional(),
   requestedScopes: z.array(z.string().trim().min(1).max(255)).max(100).optional(),
@@ -678,6 +680,13 @@ function usesPinnedSharedOAuthCallback(connection: ExternalMcpConnectionRow): bo
     && metadata.authorization_response_iss_parameter_supported !== true
 }
 
+function authorizationResponseIssuerRequired(connection: ExternalMcpConnectionRow): boolean | undefined {
+  const metadata = oauthAuthorizationServerMetadata(connection)
+  return metadata === undefined
+    ? undefined
+    : metadata.authorization_response_iss_parameter_supported === true
+}
+
 function parseJsonObject(value: string | null): Record<string, unknown> | null {
   if (!value) return null
   try {
@@ -686,6 +695,10 @@ function parseJsonObject(value: string | null): Record<string, unknown> | null {
   } catch {
     return null
   }
+}
+
+function tokenEndpointAuthMethod(value: unknown): "client_secret_basic" | "client_secret_post" | undefined {
+  return value === "client_secret_basic" || value === "client_secret_post" ? value : undefined
 }
 
 function resolveCreatorName(context: PluginArchActorContext["organizationContext"], memberId: string): string | null {
@@ -1062,6 +1075,7 @@ async function handleExternalMcpOAuthCallback(input: {
   }
   const configuredIssuer = connection.oauthConfiguration?.authorizationServerIssuer ?? null
   const discovery = connection.oauthConfiguration?.discovery
+  const currentResponseIssuerRequired = authorizationResponseIssuerRequired(connection)
   const autoSelectedIssuer = statePayload.version === 2
     && statePayload.authorizationServerIssuer === undefined
     && configuredIssuer !== null
@@ -1077,6 +1091,9 @@ async function handleExternalMcpOAuthCallback(input: {
       && (statePayload.authorizationServerIssuer ?? null)
         !== configuredIssuer
       && !autoSelectedIssuer)
+    || (statePayload.version === 2
+      && statePayload.authorizationResponseIssuerRequired !== undefined
+      && statePayload.authorizationResponseIssuerRequired !== currentResponseIssuerRequired)
   ) {
     return invalidMcpOAuthCallback("This connection changed after authorization started. Start the connection flow again.")
   }
@@ -1095,7 +1112,8 @@ async function handleExternalMcpOAuthCallback(input: {
       ? (url.searchParams.get("iss") ?? "")
       : undefined
     try {
-      const usesPinnedSharedCallback = usesPinnedSharedOAuthCallback(connection)
+      const usesPinnedSharedCallback = statePayload.authorizationResponseIssuerRequired === false
+        && usesPinnedSharedOAuthCallback(connection)
       const validation = validateMcpAuthorizationResponseIssuer({
         expectedIssuer: configuredIssuer,
         discoveryState: connection.oauthConfiguration?.discovery,
@@ -1166,6 +1184,15 @@ async function handleExternalMcpOAuthCallback(input: {
 
   const code = url.searchParams.get("code")
   if (!code) {
+    try {
+      await abandonAuthorization(connection, state, member, input.requestId)
+    } catch (error) {
+      logger.error("external_mcp_connect_callback_missing_code_cleanup_failed", {
+        connection_id: connection.id,
+        organization_id: statePayload.organizationId,
+        ...externalMcpDiagnosticForLog(error, input.requestId, "AUTH_USER_OR_WORKLOAD"),
+      })
+    }
     return invalidMcpOAuthCallback("Missing authorization code.")
   }
   try {
@@ -1178,6 +1205,15 @@ async function handleExternalMcpOAuthCallback(input: {
       state,
     )
   } catch (error) {
+    try {
+      await abandonAuthorization(connection, state, member, input.requestId)
+    } catch (cleanupError) {
+      logger.error("external_mcp_connect_callback_token_cleanup_failed", {
+        connection_id: connection.id,
+        organization_id: statePayload.organizationId,
+        ...externalMcpDiagnosticForLog(cleanupError, input.requestId, "AUTH_TOKEN_ACQUISITION"),
+      })
+    }
     const diagnostic = externalMcpDiagnosticForResponse(error, input.requestId, "AUTH_TOKEN_ACQUISITION")
     logger.error("external_mcp_connect_callback_token_exchange_failed", {
       connection_id: connection.id,
@@ -1816,6 +1852,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
             registrationContractVersion: 2,
             registeredRedirectUri: externalMcpCallbackUrl({ connectionId: created.id, callbackMode }),
             authorizationServerIssuer: body.authorizationServerIssuer ?? undefined,
+            tokenEndpointAuthMethod: body.oauthClient.tokenEndpointAuthMethod,
           },
           createdByOrgMembershipId: payload.currentMember.id,
         })
@@ -1954,6 +1991,13 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
       if (body.oauthClient && body.authType !== "oauth") {
         return c.json({ error: "invalid_request", message: "oauthClient is only allowed when authType is oauth." }, 400)
       }
+      const existingOAuthClient = body.oauthClient
+        ? await getOrgOAuthClient(payload.organization.id, externalMcpConnectionId)
+        : null
+      const preservedTokenEndpointAuthMethod = body.oauthClient
+        && existingOAuthClient?.clientId === body.oauthClient.clientId
+        ? tokenEndpointAuthMethod(existingOAuthClient.extra?.tokenEndpointAuthMethod)
+        : undefined
       if (body.authType !== "oauth" && (
         body.authorizationServerIssuer !== undefined
         || body.requestedScopes !== undefined
@@ -2051,6 +2095,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
                   ?? (connection.authType === "oauth" ? "legacy-v1" : "shared-v1"),
               }),
               authorizationServerIssuer: oauthConfiguration?.authorizationServerIssuer ?? undefined,
+              tokenEndpointAuthMethod: body.oauthClient.tokenEndpointAuthMethod ?? preservedTokenEndpointAuthMethod,
             },
           },
         } : {}),
@@ -2315,6 +2360,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
           : undefined
         const beginAuthorization = async (target: ExternalMcpConnectionRow) => {
           const callbackMode = target.oauthConfiguration?.callbackMode ?? "legacy-v1"
+          const responseIssuerRequired = authorizationResponseIssuerRequired(target)
           const signedState = createOAuthStateToken({
             organizationId: payload.organization.id,
             orgMembershipId: payload.currentMember.id,
@@ -2323,6 +2369,7 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
             version: 2,
             callbackMode,
             authorizationServerIssuer: target.oauthConfiguration?.authorizationServerIssuer ?? undefined,
+            authorizationResponseIssuerRequired: responseIssuerRequired,
             secret: env.betterAuthSecret,
           })
           const result = await connectExternalMcp(
@@ -2332,7 +2379,12 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
             member,
             c.get("requestId"),
           )
-          return { result }
+          return {
+            result,
+            signedState,
+            authorizationServerIssuer: target.oauthConfiguration?.authorizationServerIssuer,
+            authorizationResponseIssuerRequired: responseIssuerRequired,
+          }
         }
 
         let started: Awaited<ReturnType<typeof beginAuthorization>>
@@ -2406,13 +2458,23 @@ export function registerMcpConnectionRoutes<T extends { Variables: OrgRouteVaria
             organizationId: payload.organization.id,
             connectionId: externalMcpConnectionId,
           })
-          if (discovered && usesPinnedSharedOAuthCallback(discovered)) {
+          if (discovered) {
+            const discoveredResponseIssuerRequired = authorizationResponseIssuerRequired(discovered)
+            const signedBindingChanged = started.authorizationServerIssuer
+              !== discovered.oauthConfiguration?.authorizationServerIssuer
+              || started.authorizationResponseIssuerRequired !== discoveredResponseIssuerRequired
+            if (signedBindingChanged) {
+              await abandonExternalMcpAuth(discovered, started.signedState, member, c.get("requestId"))
+              started = await beginAuthorization(discovered)
+            }
             connection = discovered
-            logger.info("external_mcp_oauth_pinned_shared_callback_selected", {
-              connection_id: connection.id,
-              organization_id: payload.organization.id,
-              authorization_server_issuer: connection.oauthConfiguration?.authorizationServerIssuer,
-            })
+            if (usesPinnedSharedOAuthCallback(discovered)) {
+              logger.info("external_mcp_oauth_pinned_shared_callback_selected", {
+                connection_id: connection.id,
+                organization_id: payload.organization.id,
+                authorization_server_issuer: connection.oauthConfiguration?.authorizationServerIssuer,
+              })
+            }
           }
         }
 

--- a/ee/apps/den-api/test/generic-oauth-state.test.ts
+++ b/ee/apps/den-api/test/generic-oauth-state.test.ts
@@ -19,7 +19,7 @@ function signedState(payload: Record<string, unknown>) {
   return `${encodedPayload}.${signature}`
 }
 
-function versionTwoState(callbackMode?: string) {
+function versionTwoState(callbackMode?: string, authorizationResponseIssuerRequired: unknown = undefined) {
   return signedState({
     version: 2,
     organizationId: "org_test",
@@ -27,6 +27,7 @@ function versionTwoState(callbackMode?: string) {
     providerId: "xmcp_test",
     binding: "binding",
     ...(callbackMode ? { callbackMode } : {}),
+    ...(authorizationResponseIssuerRequired !== undefined ? { authorizationResponseIssuerRequired } : {}),
     nonce: "nonce",
     iat: 1_700_000_000,
     exp: 1_700_000_600,
@@ -35,10 +36,14 @@ function versionTwoState(callbackMode?: string) {
 
 describe("version-two OAuth state validation", () => {
   test("accepts only the supported callback modes", () => {
-    expect(verifyOAuthStateToken({ token: versionTwoState("shared-v1"), secret, now: 1_700_000_100 })).not.toBeNull()
-    expect(verifyOAuthStateToken({ token: versionTwoState("isolated-v1"), secret, now: 1_700_000_100 })).not.toBeNull()
-    expect(verifyOAuthStateToken({ token: versionTwoState("legacy-v1"), secret, now: 1_700_000_100 })).not.toBeNull()
-    expect(verifyOAuthStateToken({ token: versionTwoState("future-v1"), secret, now: 1_700_000_100 })).toBeNull()
-    expect(verifyOAuthStateToken({ token: versionTwoState(), secret, now: 1_700_000_100 })).toBeNull()
+    expect(verifyOAuthStateToken({ token: versionTwoState("shared-v1"), secret, now: 1_700_000_100_000 })).not.toBeNull()
+    expect(verifyOAuthStateToken({ token: versionTwoState("isolated-v1"), secret, now: 1_700_000_100_000 })).not.toBeNull()
+    expect(verifyOAuthStateToken({ token: versionTwoState("legacy-v1"), secret, now: 1_700_000_100_000 })).not.toBeNull()
+    expect(verifyOAuthStateToken({ token: versionTwoState("future-v1"), secret, now: 1_700_000_100_000 })).toBeNull()
+    expect(verifyOAuthStateToken({ token: versionTwoState(), secret, now: 1_700_000_100_000 })).toBeNull()
+    expect(verifyOAuthStateToken({ token: versionTwoState("shared-v1", false), secret, now: 1_700_000_100_000 }))
+      .toMatchObject({ authorizationResponseIssuerRequired: false })
+    expect(verifyOAuthStateToken({ token: versionTwoState("shared-v1", "false"), secret, now: 1_700_000_100_000 })).toBeNull()
+    expect(verifyOAuthStateToken({ token: versionTwoState("shared-v1", false), secret, now: 1_700_000_601_000 })).toBeNull()
   })
 })

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -349,9 +349,8 @@ test("callback isolation replaces SDK registration state and exposes the scoped 
   })
 })
 
-test("connect start selects an isolated callback before sending the user to a legacy authorization server", async () => {
+test("connect start keeps the shared callback for a pre-registered confidential client without response issuer support", async () => {
   let origin = ""
-  const registeredRedirects: string[][] = []
   const server = Bun.serve({
     port: 0,
     async fetch(incoming) {
@@ -367,39 +366,26 @@ test("connect start selects an isolated callback before sending the user to a le
           issuer: origin,
           authorization_endpoint: `${origin}/authorize`,
           token_endpoint: `${origin}/token`,
-          registration_endpoint: `${origin}/register`,
           response_types_supported: ["code"],
           grant_types_supported: ["authorization_code"],
-          code_challenge_methods_supported: ["S256"],
-          token_endpoint_auth_methods_supported: ["none"],
+          token_endpoint_auth_methods_supported: ["client_secret_basic"],
         })
-      }
-      if (url.pathname === "/register") {
-        const metadata: unknown = await incoming.json()
-        const redirectUris = isRecord(metadata) && isStringArray(metadata.redirect_uris)
-          ? metadata.redirect_uris
-          : []
-        registeredRedirects.push(redirectUris)
-        return Response.json({
-          client_id: `dynamic-client-${registeredRedirects.length}`,
-          token_endpoint_auth_method: "none",
-          redirect_uris: redirectUris,
-        }, { status: 201 })
       }
       if (url.pathname === "/token") {
         const form = new URLSearchParams(await incoming.text())
+        expect(incoming.headers.get("authorization")).toBe(`Basic ${btoa("confidential-client:confidential-secret")}`)
         expect(form.get("grant_type")).toBe("authorization_code")
-        expect(form.get("code")).toBe("isolated-authorization-code")
+        expect(form.get("code")).toBe("shared-authorization-code")
         expect(form.get("code_verifier")?.length).toBeGreaterThanOrEqual(43)
         return Response.json({
-          access_token: "isolated-access-token",
-          refresh_token: "isolated-refresh-token",
+          access_token: "shared-access-token",
+          refresh_token: "shared-refresh-token",
           token_type: "Bearer",
           expires_in: 3_600,
         })
       }
       if (url.pathname === "/mcp") {
-        if (incoming.headers.get("authorization") === "Bearer isolated-access-token") {
+        if (incoming.headers.get("authorization") === "Bearer shared-access-token") {
           if (incoming.method !== "POST") return new Response(null, { status: 405 })
           const rpc: unknown = await incoming.json()
           if (!isRecord(rpc)) return Response.json({ error: "invalid_request" }, { status: 400 })
@@ -414,7 +400,7 @@ test("connect start selects an isolated callback before sending the user to a le
             result: {
               protocolVersion: "2025-06-18",
               capabilities: { tools: {} },
-              serverInfo: { name: "isolated-callback-test", version: "1.0.0" },
+              serverInfo: { name: "shared-callback-test", version: "1.0.0" },
             },
           })
         }
@@ -433,40 +419,48 @@ test("connect start selects an isolated callback before sending the user to a le
   try {
     const connection = await createExternalMcpConnection({
       organizationId,
-      name: "Automatic isolated callback MCP",
+      name: "Pinned shared callback MCP",
       url: `${origin}/mcp`,
       authType: "oauth",
       credentialMode: "shared",
       createdByOrgMembershipId: memberId,
       access: { orgWide: true, memberIds: [], teamIds: [] },
     })
+    const sharedCallback = new URL(
+      "/v1/mcp-connections/oauth/callback",
+      process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790",
+    ).toString()
+    await upsertOrgOAuthClient({
+      organizationId,
+      providerId: connection.id,
+      clientId: "confidential-client",
+      clientSecret: "confidential-secret",
+      extra: {
+        enterpriseMcpRegistrationSource: "pre-registered",
+        registrationContractVersion: 2,
+        registeredRedirectUri: sharedCallback,
+      },
+      createdByOrgMembershipId: memberId,
+    })
     const response = await request(`/v1/mcp-connections/${connection.id}/connect/start`)
     expect(response.status).toBe(200)
     const body: unknown = await response.json()
     if (!isRecord(body) || typeof body.authorizeUrl !== "string") throw new Error("Expected an OAuth authorize URL.")
     const authorizeUrl = new URL(body.authorizeUrl)
-    const isolatedCallback = new URL(
-      `/v1/mcp-connections/${connection.id}/connect/callback`,
-      process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790",
-    ).toString()
-    expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(isolatedCallback)
-    expect(registeredRedirects).toHaveLength(2)
-    expect(registeredRedirects[0]).toEqual([
-      new URL("/v1/mcp-connections/oauth/callback", process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790").toString(),
-    ])
-    expect(registeredRedirects[1]).toEqual([isolatedCallback])
+    expect(authorizeUrl.searchParams.get("client_id")).toBe("confidential-client")
+    expect(authorizeUrl.searchParams.get("code_challenge_method")).toBe("S256")
+    expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(sharedCallback)
 
     const rows = await db
       .select()
       .from(schema.ExternalMcpConnectionTable)
       .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connection.id))
       .limit(1)
-    expect(rows[0]?.oauthConfiguration?.callbackMode).toBe("isolated-v1")
+    expect(rows[0]?.oauthConfiguration?.callbackMode).toBe("shared-v1")
 
-    const callbackUrl = new URL(isolatedCallback)
-    callbackUrl.searchParams.set("code", "isolated-authorization-code")
+    const callbackUrl = new URL(sharedCallback)
+    callbackUrl.searchParams.set("code", "shared-authorization-code")
     callbackUrl.searchParams.set("state", authorizeUrl.searchParams.get("state") ?? "")
-    callbackUrl.searchParams.set("iss", "stytch.com/project-live-provider-value")
     const callbackResponse = await app.fetch(new Request(callbackUrl))
     expect(callbackResponse.status).toBe(200)
     expect(await callbackResponse.text()).toContain("You're connected")
@@ -476,8 +470,8 @@ test("connect start selects an isolated callback before sending the user to a le
       .from(schema.ExternalMcpConnectionTable)
       .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connection.id))
       .limit(1)
-    expect(connectedRows[0]?.accessToken).toBe("isolated-access-token")
-    expect(connectedRows[0]?.refreshToken).toBe("isolated-refresh-token")
+    expect(connectedRows[0]?.accessToken).toBe("shared-access-token")
+    expect(connectedRows[0]?.refreshToken).toBe("shared-refresh-token")
   } finally {
     server.stop(true)
   }

--- a/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-connect-start.test.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto"
 import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { afterAll, beforeAll, expect, mock, test } from "bun:test"
 
@@ -28,6 +29,7 @@ let createExternalMcpConnection: typeof import("../src/capability-sources/extern
 let externalMcpIdentityBinding: typeof import("../src/capability-sources/external-mcp-connections.js").externalMcpIdentityBinding
 let isolateExternalMcpOAuthCallback: typeof import("../src/capability-sources/external-mcp-connections.js").isolateExternalMcpOAuthCallback
 let createOAuthStateToken: typeof import("../src/capability-sources/generic-oauth.js").createOAuthStateToken
+let verifyOAuthStateToken: typeof import("../src/capability-sources/generic-oauth.js").verifyOAuthStateToken
 let upsertOrgOAuthClient: typeof import("../src/capability-sources/oauth-credentials.js").upsertOrgOAuthClient
 let getOrgOAuthClient: typeof import("../src/capability-sources/oauth-credentials.js").getOrgOAuthClient
 
@@ -69,6 +71,7 @@ beforeAll(async () => {
   externalMcpIdentityBinding = connectionsMod.externalMcpIdentityBinding
   isolateExternalMcpOAuthCallback = connectionsMod.isolateExternalMcpOAuthCallback
   createOAuthStateToken = genericOAuthMod.createOAuthStateToken
+  verifyOAuthStateToken = genericOAuthMod.verifyOAuthStateToken
   upsertOrgOAuthClient = oauthCredentialsMod.upsertOrgOAuthClient
   getOrgOAuthClient = oauthCredentialsMod.getOrgOAuthClient
 
@@ -351,6 +354,9 @@ test("callback isolation replaces SDK registration state and exposes the scoped 
 
 test("connect start keeps the shared callback for a pre-registered confidential client without response issuer support", async () => {
   let origin = ""
+  let expectedCodeChallenge = ""
+  let initializeRequests = 0
+  let toolsListRequests = 0
   const server = Bun.serve({
     port: 0,
     async fetch(incoming) {
@@ -359,6 +365,7 @@ test("connect start keeps the shared callback for a pre-registered confidential 
         return Response.json({
           resource: `${origin}/mcp`,
           authorization_servers: [origin],
+          scopes_supported: ["mcp_server"],
         })
       }
       if (url.pathname === "/.well-known/oauth-authorization-server") {
@@ -368,20 +375,27 @@ test("connect start keeps the shared callback for a pre-registered confidential 
           token_endpoint: `${origin}/token`,
           response_types_supported: ["code"],
           grant_types_supported: ["authorization_code"],
-          token_endpoint_auth_methods_supported: ["client_secret_basic"],
+          token_endpoint_auth_methods_supported: ["client_secret_post"],
+          scopes_supported: ["mcp_server"],
         })
       }
       if (url.pathname === "/token") {
         const form = new URLSearchParams(await incoming.text())
-        expect(incoming.headers.get("authorization")).toBe(`Basic ${btoa("confidential-client:confidential-secret")}`)
+        expect(incoming.headers.get("authorization")).toBeNull()
+        expect(form.get("client_id")).toBe("confidential-client")
+        expect(form.get("client_secret")).toBe("confidential-secret")
         expect(form.get("grant_type")).toBe("authorization_code")
         expect(form.get("code")).toBe("shared-authorization-code")
-        expect(form.get("code_verifier")?.length).toBeGreaterThanOrEqual(43)
+        expect(form.get("resource")).toBe(`${origin}/mcp`)
+        const verifier = form.get("code_verifier")
+        expect(verifier?.length).toBeGreaterThanOrEqual(43)
+        expect(createHash("sha256").update(verifier ?? "").digest("base64url")).toBe(expectedCodeChallenge)
         return Response.json({
           access_token: "shared-access-token",
           refresh_token: "shared-refresh-token",
           token_type: "Bearer",
           expires_in: 3_600,
+          scope: "mcp_server",
         })
       }
       if (url.pathname === "/mcp") {
@@ -392,8 +406,20 @@ test("connect start keeps the shared callback for a pre-registered confidential 
           if (rpc.method === "notifications/initialized") return new Response(null, { status: 202 })
           const id = typeof rpc.id === "string" || typeof rpc.id === "number" ? rpc.id : null
           if (rpc.method === "tools/list") {
-            return Response.json({ jsonrpc: "2.0", id, result: { tools: [] } })
+            toolsListRequests += 1
+            return Response.json({
+              jsonrpc: "2.0",
+              id,
+              result: {
+                tools: [{
+                  name: "list-scoped-records",
+                  description: "Lists records available to the required MCP scope.",
+                  inputSchema: { type: "object", properties: {} },
+                }],
+              },
+            })
           }
+          if (rpc.method === "initialize") initializeRequests += 1
           return Response.json({
             jsonrpc: "2.0",
             id,
@@ -407,7 +433,7 @@ test("connect start keeps the shared callback for a pre-registered confidential 
         return new Response(null, {
           status: 401,
           headers: {
-            "www-authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,
+            "www-authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp", scope="mcp_server"`,
           },
         })
       }
@@ -447,9 +473,25 @@ test("connect start keeps the shared callback for a pre-registered confidential 
     const body: unknown = await response.json()
     if (!isRecord(body) || typeof body.authorizeUrl !== "string") throw new Error("Expected an OAuth authorize URL.")
     const authorizeUrl = new URL(body.authorizeUrl)
+    const signedState = authorizeUrl.searchParams.get("state") ?? ""
     expect(authorizeUrl.searchParams.get("client_id")).toBe("confidential-client")
     expect(authorizeUrl.searchParams.get("code_challenge_method")).toBe("S256")
+    expectedCodeChallenge = authorizeUrl.searchParams.get("code_challenge") ?? ""
+    expect(expectedCodeChallenge.length).toBeGreaterThan(0)
     expect(authorizeUrl.searchParams.get("redirect_uri")).toBe(sharedCallback)
+    expect(authorizeUrl.searchParams.get("scope")).toBe("mcp_server")
+    expect(authorizeUrl.searchParams.get("resource")).toBe(`${origin}/mcp`)
+    expect(verifyOAuthStateToken({
+      token: signedState,
+      secret: process.env.BETTER_AUTH_SECRET ?? "",
+    })).toMatchObject({
+      organizationId,
+      orgMembershipId: memberId,
+      providerId: connection.id,
+      callbackMode: "shared-v1",
+      authorizationServerIssuer: origin,
+      authorizationResponseIssuerRequired: false,
+    })
 
     const rows = await db
       .select()
@@ -457,10 +499,15 @@ test("connect start keeps the shared callback for a pre-registered confidential 
       .where(drizzle.eq(schema.ExternalMcpConnectionTable.id, connection.id))
       .limit(1)
     expect(rows[0]?.oauthConfiguration?.callbackMode).toBe("shared-v1")
+    expect(rows[0]?.pendingCodeVerifier).not.toContain(signedState)
+    const pendingAuthorizations: unknown = JSON.parse(rows[0]?.pendingCodeVerifier ?? "{}")
+    expect(isRecord(pendingAuthorizations) && Array.isArray(pendingAuthorizations.transactions)
+      ? pendingAuthorizations.transactions
+      : []).toHaveLength(1)
 
     const callbackUrl = new URL(sharedCallback)
     callbackUrl.searchParams.set("code", "shared-authorization-code")
-    callbackUrl.searchParams.set("state", authorizeUrl.searchParams.get("state") ?? "")
+    callbackUrl.searchParams.set("state", signedState)
     const callbackResponse = await app.fetch(new Request(callbackUrl))
     expect(callbackResponse.status).toBe(200)
     expect(await callbackResponse.text()).toContain("You're connected")
@@ -472,6 +519,9 @@ test("connect start keeps the shared callback for a pre-registered confidential 
       .limit(1)
     expect(connectedRows[0]?.accessToken).toBe("shared-access-token")
     expect(connectedRows[0]?.refreshToken).toBe("shared-refresh-token")
+    expect(connectedRows[0]?.scope).toBe("mcp_server")
+    expect(initializeRequests).toBeGreaterThan(0)
+    expect(toolsListRequests).toBeGreaterThan(0)
   } finally {
     server.stop(true)
   }

--- a/ee/apps/den-api/test/mcp-connections-edit.test.ts
+++ b/ee/apps/den-api/test/mcp-connections-edit.test.ts
@@ -19,6 +19,7 @@ let session: typeof import("../src/session.js")
 let connections: typeof import("../src/capability-sources/external-mcp-connections.js")
 let genericOAuth: typeof import("../src/capability-sources/generic-oauth.js")
 let oauthCredentials: typeof import("../src/capability-sources/oauth-credentials.js")
+let DenEnterpriseMcpOAuthPersistence: typeof import("../src/capability-sources/enterprise-mcp-oauth-persistence.js").DenEnterpriseMcpOAuthPersistence
 let fakeServer: ReturnType<typeof Bun.serve> | undefined
 
 const adminUserId = createDenTypeId("user")
@@ -59,7 +60,7 @@ beforeAll(async () => {
   }).db
   mock.module("../src/db.js", () => ({ db: realDb }))
 
-  const [appMod, dbMod, schemaMod, drizzleMod, sessionMod, connectionsMod, genericOAuthMod, oauthCredentialsMod] = await Promise.all([
+  const [appMod, dbMod, schemaMod, drizzleMod, sessionMod, connectionsMod, genericOAuthMod, oauthCredentialsMod, enterprisePersistenceMod] = await Promise.all([
     import("../src/app.js"),
     import("../src/db.js"),
     import("@openwork-ee/den-db/schema"),
@@ -68,6 +69,7 @@ beforeAll(async () => {
     import("../src/capability-sources/external-mcp-connections.js"),
     import("../src/capability-sources/generic-oauth.js"),
     import("../src/capability-sources/oauth-credentials.js"),
+    import("../src/capability-sources/enterprise-mcp-oauth-persistence.js"),
   ])
   app = appMod.default
   db = dbMod.db
@@ -77,6 +79,7 @@ beforeAll(async () => {
   connections = connectionsMod
   genericOAuth = genericOAuthMod
   oauthCredentials = oauthCredentialsMod
+  DenEnterpriseMcpOAuthPersistence = enterprisePersistenceMod.DenEnterpriseMcpOAuthPersistence
 
   await db.insert(schema.AuthUserTable).values([
     { id: adminUserId, name: "MCP Edit Admin", email: `mcp-edit-admin+${adminUserId}@test.local` },
@@ -585,7 +588,11 @@ describe.serial("PUT /v1/mcp-connections/:connectionId", () => {
     const configuredClient = await humanRequest({
       connectionId: connection.id,
       body: updateBody(beforeClientConfiguration, {
-        oauthClient: { clientId: "marketplace-client", clientSecret: "marketplace-secret" },
+        oauthClient: {
+          clientId: "marketplace-client",
+          clientSecret: "marketplace-secret",
+          tokenEndpointAuthMethod: "client_secret_post",
+        },
       }),
     })
     expect(configuredClient.status).toBe(200)
@@ -593,6 +600,20 @@ describe.serial("PUT /v1/mcp-connections/:connectionId", () => {
     expect(await oauthCredentials.getOrgOAuthClient(organizationId, connection.id)).toMatchObject({
       clientId: "marketplace-client",
       clientSecret: "marketplace-secret",
+      extra: { tokenEndpointAuthMethod: "client_secret_post" },
+    })
+    const persistedRegistration = await new DenEnterpriseMcpOAuthPersistence(
+      await currentConnection(connection.id),
+      { orgMembershipId: adminMemberId },
+    ).clientRegistrations.load({
+      connectionId: connection.id,
+      commitExpiresAt: Date.now() + 30_000,
+      signal: new AbortController().signal,
+    })
+    expect(persistedRegistration?.clientInformation).toMatchObject({
+      client_id: "marketplace-client",
+      client_secret: "marketplace-secret",
+      token_endpoint_auth_method: "client_secret_post",
     })
 
     const fresh = await currentConnection(connection.id)

--- a/packages/enterprise-mcp-client/src/authorization-response.ts
+++ b/packages/enterprise-mcp-client/src/authorization-response.ts
@@ -12,6 +12,7 @@ function optionalString(value: unknown): string | undefined {
 export type McpAuthorizationResponseMixUpDefense =
   | "response-issuer"
   | "distinct-redirect-uri"
+  | "pinned-transaction"
   | "legacy"
 
 export type McpAuthorizationResponseIssuerValidation = {
@@ -21,10 +22,13 @@ export type McpAuthorizationResponseIssuerValidation = {
 
 /**
  * Validate the OAuth mix-up defense before a code is sent to a token endpoint
- * or a provider error is acted upon. Shared callbacks require RFC 9207 issuer
- * identification. A caller may instead prove an issuer-specific redirect URI
- * per RFC 9700; only then may an unadvertised provider `iss` be treated as
- * untrusted compatibility data. Exact issuer comparisons are never normalized.
+ * or a provider error is acted upon. Shared callbacks normally use RFC 9207
+ * issuer identification. A caller may instead prove an issuer-specific
+ * redirect URI per RFC 9700, or explicitly select the narrower
+ * pinned-transaction compatibility posture after verifying a signed,
+ * expiring state token that binds the connection, callback mode, and selected
+ * issuer to a single-use server-side authorization record. Exact issuer
+ * comparisons are never normalized.
  */
 export function validateMcpAuthorizationResponseIssuer(input: {
   expectedIssuer?: string | null

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -22,7 +22,7 @@ import { EnterpriseMcpOAuthProvider } from "../src/oauth-provider.js"
 import { createEnterpriseMcpRequestObserver } from "../src/request-observer.js"
 import { collectEnterpriseMcpTools } from "../src/tool-catalog.js"
 import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
-import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
+import { selectClientAuthMethod, type OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
 
 const rpcRequestSchema = z.object({
   id: z.union([z.string(), z.number()]).optional(),
@@ -623,6 +623,20 @@ function oauthProvider(input: {
 }
 
 describe("enterprise MCP OAuth persistence contract", () => {
+  it("uses discovery or an explicit registration hint to select confidential-client authentication", () => {
+    const confidentialClient = {
+      client_id: "confidential-client",
+      client_secret: "confidential-secret",
+    }
+    assert.equal(selectClientAuthMethod(confidentialClient, ["client_secret_post"]), "client_secret_post")
+    assert.equal(selectClientAuthMethod(confidentialClient, []), "client_secret_basic")
+    assert.equal(selectClientAuthMethod({
+      ...confidentialClient,
+      redirect_uris: ["https://den.example.test/v1/mcp-connections/oauth/callback"],
+      token_endpoint_auth_method: "client_secret_post",
+    }, []), "client_secret_post")
+  })
+
   it("validates authorization-response issuers exactly before token exchange", () => {
     const discoveryState = {
       authorizationServerUrl: "https://identity.example.test/tenant",

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -680,6 +680,31 @@ describe("enterprise MCP OAuth persistence contract", () => {
     })
   })
 
+  it("supports a pinned authorization transaction when a provider omits response issuers", () => {
+    const expectedIssuer = "https://identity.example.test/tenant"
+    const discoveryState = {
+      authorizationServerUrl: expectedIssuer,
+      authorizationServerMetadata: {
+        issuer: expectedIssuer,
+        authorization_response_iss_parameter_supported: false,
+      },
+      resourceMetadata: { authorization_servers: [expectedIssuer] },
+    }
+
+    assert.deepEqual(validateMcpAuthorizationResponseIssuer({
+      expectedIssuer,
+      discoveryState,
+      mixUpDefense: "pinned-transaction",
+    }), { defense: "pinned-transaction" })
+    assert.throws(() => validateMcpAuthorizationResponseIssuer({
+      expectedIssuer,
+      discoveryState,
+      responseIssuer: "https://attacker.example.test",
+      mixUpDefense: "pinned-transaction",
+    }), (error: unknown) => error instanceof EnterpriseMcpOAuthContractError
+      && error.code === "MCP_OAUTH_ISSUER_MISMATCH")
+  })
+
   it("never lets PKCE or an isolated callback override advertised RFC 9207 support", () => {
     const expectedIssuer = "https://identity.example.test/tenant"
     const discoveryState = {


### PR DESCRIPTION
## Problem

Some OAuth authorization servers do not return the RFC 9207 `iss` parameter. OpenWork previously switched those connections from the deployment-wide callback to a connection-specific callback, which breaks pre-registered clients that allowlist only the shared callback.

## What changed

- Keep new `shared-v1` connections on the deployment-wide callback when authorization-server metadata does not advertise response-issuer support.
- Use a signed, expiring, single-use, issuer-pinned authorization transaction when the callback omits `iss`.
- After first discovery, abandon and reissue the pending authorization only when needed so the returned state binds the selected issuer and whether RFC 9207 `iss` is required.
- Reject a callback-supplied issuer that does not exactly match the selected issuer.
- Continue requiring `iss` when the authorization server advertises `authorization_response_iss_parameter_supported: true`.
- Preserve existing `isolated-v1` and `legacy-v1` callback records without migration.
- Allow a manually pre-registered confidential client to persist an explicit provider-neutral `client_secret_basic` or `client_secret_post` token-endpoint authentication method in the existing OAuth client metadata. No database migration, UI change, or provider-specific branch is added.
- Abandon pending transactions on malformed callbacks and failed token completion.

## Security model

1. Den verifies the HMAC signature and expiry before trusting state.
2. State binds organization, member, connection identity, callback mode/derived redirect URI, selected authorization-server issuer, and the response-issuer posture.
3. The server-side transaction stores only a SHA-256 state hash, expiry, client-registration revision, transaction revision, and encrypted PKCE verifier.
4. Callback handling reloads the tenant-scoped connection and checks the signed bindings against current state before code exchange.
5. Discovery remains pinned to the selected issuer; authorization codes are sent only to the discovered token endpoint for that issuer.
6. A successful token commit atomically validates and consumes the transaction, preventing replay or concurrent double-commit.
7. Failed callbacks abandon the transaction; exchanged credentials are invalidated if authenticated MCP initialization or tool discovery fails.
8. Secrets, authorization codes, PKCE verifiers, and tokens are excluded from diagnostics and API responses.

## Confidential-client compatibility covered

The focused Den integration fixture proves:

- one pre-registered shared callback;
- authorization-code grant;
- metadata-advertised `client_secret_post`;
- client ID and secret in the token request body and no Basic authorization header;
- required `mcp_server` scope in the challenge and authorization request;
- canonical MCP `resource` in authorization and token requests;
- PKCE S256 with the token verifier hashing to the original authorization challenge;
- callback with `code` and `state` but no `iss`;
- successful token exchange, authenticated MCP `initialize`, and `tools/list`;
- persisted token scope only after post-callback MCP validation.

The SDK contract test also documents that omitted `token_endpoint_auth_methods_supported` defaults a confidential client to Basic, and that an explicitly persisted `client_secret_post` registration hint selects POST in that case.

## Discovery and deployment boundary

The shared callback does not bypass discovery. The MCP server must expose usable protected-resource and authorization-server metadata that binds the resource to the selected issuer, or the issuer must already be explicitly and safely configured. The deployed server version must support the required MCP/OAuth discovery endpoints, PKCE S256, the registered redirect URI, requested scope, and chosen token-endpoint authentication method.

Missing discovery support is a deployment/version prerequisite, not a reason to weaken state validation, remove PKCE, or introduce arbitrary callback URLs.

## Verification

- `pnpm --filter @openwork/enterprise-mcp-client test` — 51 passed
- `pnpm --filter @openwork/enterprise-mcp-client typecheck` — passed
- `bun test test/mcp-connections-connect-start.test.ts` — 20 passed
- `bun test test/mcp-connections-edit.test.ts` — 15 passed
- `bun test test/enterprise-mcp-oauth-persistence.test.ts` — 11 passed
- `bun test test/generic-oauth-state.test.ts` — 1 passed
- Den API TypeScript check — passed
- Den API production build — passed
- `git diff --check upstream/dev` — passed
- Fresh GitHub Actions run on `1eca372c` — all 11 applicable product, test, build, packaging, and audit checks passed; 1 optional review check skipped

The three red Vercel preview contexts are fork-preview authorization gates for `openwork-app`, `openwork-den`, and `openwork-den-worker-proxy`, not product test or build failures.

## Remaining conformance boundary

This deterministic fixture covers the documented protocol profile, but it does not guarantee a particular enterprise deployment. Real-instance verification is still required for that server version's discovery documents, authorization/consent, token exchange, token audience and scope enforcement, authenticated `initialize`, and `tools/list`.