### PR TITLE
feat(inference): add Kimi K3 model

### DIFF
--- a/ee/apps/inference/src/models/openwork-models.json
+++ b/ee/apps/inference/src/models/openwork-models.json
@@ -257,5 +257,45 @@
       "output": 4.4,
       "cache_read": 0.26
     }
+  },
+  "moonshotai/kimi-k3": {
+    "id": "moonshotai/kimi-k3",
+    "name": "Kimi K3",
+    "description": "Kimi multimodal agent model for visual understanding, coding, and planning",
+    "family": "kimi-k3",
+    "attachment": true,
+    "reasoning": true,
+    "reasoning_options": [
+      {
+        "type": "effort",
+        "values": [
+          "max"
+        ]
+      }
+    ],
+    "tool_call": true,
+    "structured_output": true,
+    "temperature": false,
+    "release_date": "2026-07-16",
+    "last_updated": "2026-07-16",
+    "modalities": {
+      "input": [
+        "text",
+        "image"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "limit": {
+      "context": 1048576,
+      "output": 1048576
+    },
+    "cost": {
+      "input": 3,
+      "output": 15,
+      "cache_read": 0.3
+    }
   }
 }

--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -54,6 +54,12 @@ export const INFERENCE_WINDOW_DURATIONS_MS: Record<
 // For upstreamModel values, please get from models.dev/api.json provider = openrouter.models.id
 
 export const INFERENCE_MODEL_ALIASES = {
+  "moonshotai/kimi-k3": {
+    upstreamModel: "moonshotai/kimi-k3",
+    displayName: "OpenWork: Kimi K3",
+    enabled: true,
+    usageFactor: 1,
+  },
   "z-ai/glm-5.2": {
     upstreamModel: "z-ai/glm-5.2",
     displayName: "OpenWork: GLM-5.2",


### PR DESCRIPTION
## Summary

- add MoonshotAI Kimi K3 to the OpenWork model catalog
- expose the enabled Kimi K3 inference alias at standard pricing
- preserve upstream multimodal, reasoning, context, and cost metadata from models.dev

## Validation

- `node .opencode/skills/openwork-models/scripts/openwork-models.mjs validate` (passed: 9 models)
- `node ee/apps/inference/scripts/build-models.mjs` (passed)
- `pnpm --filter @openwork-ee/inference build` (passed)
- `pnpm --filter @openwork/types build` (passed)
- targeted inference catalog tests (passed: 2/2)
- `git diff --check` (passed)

## Fraimz

Incomplete: `pnpm fraimz --flow inference-model-routing-hardening` produced `evals/results/2026-07-17T18-46-51-052Z/fraimz.html`, but the existing full inference suite fails 10 tests because they still request the removed `openrouter/fusion` alias and receive 404 responses. The catalog-specific tests pass, including local catalog exposure and alias coverage.