### PR TITLE
fix(mcp): keep OAuth failures visible with diagnostics

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
@@ -31,13 +31,35 @@ export function safeMcpAuthorizationUrl(rawUrl: string): string {
   return url.toString()
 }
 
+export type McpAuthorizationDebugDetails = {
+  httpStatus: number
+  errorCode?: string
+  redirectUri?: string
+  clientMetadataUrl?: string
+  diagnosticReference?: string
+  phase?: string
+  category?: string
+  highestPassed?: string
+  retryable?: boolean
+  actionOwner?: string
+  operatorAction?: string
+  providerStatus?: number
+  providerRequestId?: string
+  providerCode?: string
+  responseJson: string
+}
+
 const authorizationDocumentStyles = `
       :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
       * { box-sizing: border-box; }
-      body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 32px; color: #182033; background: #f7f7f4; }
-      .card { width: min(100%, 440px); padding: 48px 40px; text-align: center; background: rgba(255, 255, 255, .9); border: 1px solid #e6e7e2; border-radius: 28px; box-shadow: 0 22px 70px rgba(24, 32, 51, .09); }
-      h1 { margin: 0; font-size: 25px; line-height: 1.2; letter-spacing: -.025em; }
-      p { max-width: 360px; margin: 14px auto 0; color: #667085; font-size: 15px; line-height: 1.6; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 28px; color: #172033; background: radial-gradient(circle at 14% 8%, rgba(122, 156, 114, .15), transparent 35%), radial-gradient(circle at 92% 92%, rgba(100, 116, 139, .11), transparent 38%), #f5f6f2; }
+      .card { position: relative; width: min(100%, 480px); overflow: hidden; background: rgba(255, 255, 255, .94); border: 1px solid rgba(216, 220, 211, .92); border-radius: 28px; box-shadow: 0 24px 80px rgba(24, 32, 51, .12), 0 2px 8px rgba(24, 32, 51, .04); }
+      .card::before { position: absolute; inset: 0 0 auto; height: 4px; content: ""; background: linear-gradient(90deg, #90ad87, #c9d8c2 50%, #90ad87); }
+      .brand { display: inline-flex; align-items: center; gap: 9px; color: #475467; font-size: 12px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+      .brand-mark { width: 24px; height: 24px; display: grid; place-items: center; border-radius: 8px; color: #fff; background: #172033; box-shadow: 0 4px 12px rgba(23, 32, 51, .18); font-size: 11px; letter-spacing: -.03em; }
+      h1 { margin: 0; color: #172033; font-size: 26px; line-height: 1.2; letter-spacing: -.03em; }
+      p { margin: 12px 0 0; color: #667085; font-size: 15px; line-height: 1.6; }
+      @media (max-width: 480px) { body { padding: 16px; } }
 `
 
 export function mcpAuthorizationPendingDocument(): string {
@@ -50,30 +72,81 @@ export function mcpAuthorizationPendingDocument(): string {
     <title>Connecting — OpenWork</title>
     <style>
 ${authorizationDocumentStyles}
-      .mark { position: relative; width: 64px; height: 64px; margin: 0 auto 28px; display: grid; place-items: center; }
-      .core { width: 34px; height: 34px; border-radius: 12px; background: #182033; box-shadow: inset 0 0 0 7px #fff; }
-      .orbit { position: absolute; inset: 0; border: 2px solid #dfe3da; border-top-color: #76966f; border-radius: 50%; animation: connect 1.15s cubic-bezier(.55, .15, .45, .85) infinite; }
+      .loading-card { padding: 40px 40px 34px; text-align: center; }
+      .brand { margin-bottom: 34px; }
+      .mark { position: relative; width: 82px; height: 82px; margin: 0 auto 28px; display: grid; place-items: center; }
+      .mark::before { position: absolute; inset: 10px; content: ""; border-radius: 24px; background: #f0f4ed; transform: rotate(8deg); }
+      .core { position: relative; width: 38px; height: 38px; display: grid; place-items: center; border-radius: 13px; color: #fff; background: #172033; box-shadow: 0 8px 22px rgba(23, 32, 51, .22); font-size: 12px; font-weight: 800; }
+      .orbit { position: absolute; inset: 0; border: 2px solid rgba(128, 157, 120, .18); border-top-color: #76966f; border-right-color: #9db894; border-radius: 50%; animation: connect 1.15s cubic-bezier(.55, .15, .45, .85) infinite; }
+      .progress { height: 5px; margin: 30px 0 0; overflow: hidden; border-radius: 999px; background: #eef0eb; }
+      .progress span { display: block; width: 42%; height: 100%; border-radius: inherit; background: linear-gradient(90deg, #64845d, #a8c29f); animation: progress 1.4s ease-in-out infinite alternate; }
+      .footnote { display: flex; align-items: center; justify-content: center; gap: 7px; margin-top: 16px; color: #98a2b3; font-size: 12px; }
+      .footnote-dot { width: 6px; height: 6px; border-radius: 50%; background: #76966f; box-shadow: 0 0 0 4px rgba(118, 150, 111, .12); }
       @keyframes connect { to { transform: rotate(360deg); } }
-      @media (prefers-reduced-motion: reduce) { .orbit { animation: none; border-color: #76966f; } }
+      @keyframes progress { from { transform: translateX(-15%); } to { transform: translateX(155%); } }
+      @media (prefers-reduced-motion: reduce) { .orbit, .progress span { animation: none; } .orbit { border-color: #76966f; } .progress span { width: 100%; } }
     </style>
   </head>
   <body>
-    <main class="card" role="status" aria-live="polite">
-      <div class="mark" aria-hidden="true"><div class="orbit"></div><div class="core"></div></div>
+    <main class="card loading-card" role="status" aria-live="polite">
+      <div class="brand"><span class="brand-mark">OW</span>OpenWork Connect</div>
+      <div class="mark" aria-hidden="true"><div class="orbit"></div><div class="core">OW</div></div>
       <h1>Preparing your connection</h1>
-      <p>OpenWork is checking the provider. You’ll be redirected to sign in shortly.</p>
+      <p>OpenWork is securely checking the provider and preparing your sign-in.</p>
+      <div class="progress" aria-hidden="true"><span></span></div>
+      <div class="footnote"><span class="footnote-dot" aria-hidden="true"></span>Keep this window open</div>
     </main>
   </body>
 </html>`
 }
 
-export function mcpAuthorizationErrorDocument(input: { message: string; redirectUri?: string }): string {
-  const redirectUri = input.redirectUri
-    ? `<section aria-labelledby="redirect-uri-label">
-        <h2 id="redirect-uri-label">Redirect URI used</h2>
-        <code>${escapeHtml(input.redirectUri)}</code>
-      </section>`
-    : ""
+function debugDetailRow(label: string, value: string | number | boolean | undefined, code = false): string {
+  if (value === undefined) return ""
+  const renderedValue = escapeHtml(String(value))
+  return `<div class="detail-row">
+              <dt>${escapeHtml(label)}</dt>
+              <dd${code ? ' class="mono"' : ""}>${renderedValue}</dd>
+            </div>`
+}
+
+function technicalDetails(details: McpAuthorizationDebugDetails | undefined): string {
+  if (!details) return ""
+  const rows = [
+    debugDetailRow("HTTP status", details.httpStatus),
+    debugDetailRow("Error code", details.errorCode, true),
+    debugDetailRow("Diagnostic reference", details.diagnosticReference, true),
+    debugDetailRow("Redirect URI", details.redirectUri, true),
+    debugDetailRow("Client metadata URL", details.clientMetadataUrl, true),
+    debugDetailRow("Handshake phase", details.phase, true),
+    debugDetailRow("Highest step passed", details.highestPassed),
+    debugDetailRow("Category", details.category, true),
+    debugDetailRow("Retryable", details.retryable),
+    debugDetailRow("Action owner", details.actionOwner),
+    debugDetailRow("Recommended action", details.operatorAction),
+    debugDetailRow("Provider status", details.providerStatus),
+    debugDetailRow("Provider request ID", details.providerRequestId, true),
+    debugDetailRow("Provider code", details.providerCode, true),
+  ].join("")
+
+  return `<details>
+          <summary>
+            <span class="summary-icon" aria-hidden="true">›</span>
+            <span><strong>Technical details</strong><small>Redirect, status, and safe error response</small></span>
+          </summary>
+          <div class="details-content">
+            <dl>${rows}</dl>
+            <section aria-labelledby="response-payload-label">
+              <h2 id="response-payload-label">Response payload</h2>
+              <pre><code>${escapeHtml(details.responseJson)}</code></pre>
+            </section>
+          </div>
+        </details>`
+}
+
+export function mcpAuthorizationErrorDocument(input: {
+  message: string
+  details?: McpAuthorizationDebugDetails
+}): string {
   return `<!doctype html>
 <html lang="en">
   <head>
@@ -83,18 +156,54 @@ export function mcpAuthorizationErrorDocument(input: { message: string; redirect
     <title>Connection failed — OpenWork</title>
     <style>
 ${authorizationDocumentStyles}
-      .error-mark { width: 56px; height: 56px; margin: 0 auto 24px; display: grid; place-items: center; border-radius: 50%; color: #b42318; background: #fef3f2; font-size: 30px; font-weight: 700; }
-      section { margin-top: 24px; text-align: left; }
-      h2 { margin: 0 0 8px; color: #475467; font-size: 12px; letter-spacing: .04em; text-transform: uppercase; }
-      code { display: block; overflow-wrap: anywhere; padding: 12px; border: 1px solid #e6e7e2; border-radius: 10px; color: #344054; background: #f9fafb; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; user-select: all; }
+      body { align-items: start; }
+      .error-card { width: min(100%, 520px); margin: auto; }
+      .error-header { padding: 30px 34px 28px; }
+      .brand { margin-bottom: 30px; }
+      .status { display: flex; align-items: flex-start; gap: 16px; }
+      .error-mark { flex: 0 0 auto; width: 48px; height: 48px; display: grid; place-items: center; border: 1px solid #fecdca; border-radius: 15px; color: #b42318; background: linear-gradient(145deg, #fff7f6, #feeceb); box-shadow: 0 7px 20px rgba(180, 35, 24, .09); font-size: 23px; font-weight: 800; }
+      .message { margin-top: 24px; padding: 15px 16px; border: 1px solid #fecdca; border-radius: 14px; color: #7a271a; background: #fff7f6; font-size: 14px; line-height: 1.55; }
+      .stay-open { display: flex; gap: 9px; margin-top: 18px; color: #667085; font-size: 13px; line-height: 1.5; }
+      .stay-open span { flex: 0 0 auto; width: 18px; height: 18px; display: grid; place-items: center; margin-top: 1px; border-radius: 50%; color: #52704c; background: #eaf2e7; font-size: 12px; font-weight: 800; }
+      details { border-top: 1px solid #e7e9e3; background: #fafbf8; }
+      summary { display: flex; align-items: center; gap: 12px; padding: 19px 34px; cursor: pointer; color: #344054; list-style: none; user-select: none; }
+      summary::-webkit-details-marker { display: none; }
+      summary:focus-visible { outline: 3px solid rgba(118, 150, 111, .3); outline-offset: -3px; }
+      summary strong, summary small { display: block; }
+      summary strong { font-size: 14px; }
+      summary small { margin-top: 2px; color: #98a2b3; font-size: 12px; font-weight: 400; }
+      .summary-icon { width: 25px; height: 25px; display: grid; place-items: center; border: 1px solid #dfe3da; border-radius: 8px; background: #fff; font-size: 22px; line-height: 1; transition: transform .16s ease; }
+      details[open] .summary-icon { transform: rotate(90deg); }
+      .details-content { padding: 0 34px 30px; }
+      dl { margin: 0; overflow: hidden; border: 1px solid #e2e5de; border-radius: 14px; background: #fff; }
+      .detail-row { display: grid; grid-template-columns: minmax(118px, .7fr) minmax(0, 1.3fr); gap: 16px; padding: 11px 13px; border-bottom: 1px solid #eef0eb; font-size: 12px; line-height: 1.45; }
+      .detail-row:last-child { border-bottom: 0; }
+      dt { color: #667085; }
+      dd { min-width: 0; margin: 0; overflow-wrap: anywhere; color: #344054; font-weight: 600; user-select: all; }
+      .mono { font: 11px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; }
+      section { margin-top: 18px; }
+      h2 { margin: 0 0 8px; color: #667085; font-size: 11px; letter-spacing: .06em; text-transform: uppercase; }
+      pre { max-height: 240px; margin: 0; overflow: auto; padding: 13px; border: 1px solid #e2e5de; border-radius: 12px; color: #344054; background: #f4f6f2; white-space: pre-wrap; overflow-wrap: anywhere; user-select: all; }
+      pre code { font: 11px/1.55 ui-monospace, SFMono-Regular, Menlo, monospace; }
+      @media (max-width: 480px) { .error-header { padding: 26px 24px 24px; } summary { padding: 18px 24px; } .details-content { padding: 0 24px 24px; } .detail-row { grid-template-columns: 1fr; gap: 3px; } }
+      @media (prefers-reduced-motion: reduce) { .summary-icon { transition: none; } }
     </style>
   </head>
   <body>
-    <main class="card" role="alert" aria-live="assertive">
-      <div class="error-mark" aria-hidden="true">!</div>
-      <h1>Connection failed</h1>
-      <p>${escapeHtml(input.message)}</p>
-      ${redirectUri}
+    <main class="card error-card" role="alert" aria-live="assertive">
+      <div class="error-header">
+        <div class="brand"><span class="brand-mark">OW</span>OpenWork Connect</div>
+        <div class="status">
+          <div class="error-mark" aria-hidden="true">!</div>
+          <div>
+            <h1>Connection failed</h1>
+            <p>OpenWork couldn’t start the provider sign-in.</p>
+          </div>
+        </div>
+        <div class="message">${escapeHtml(input.message)}</div>
+        <div class="stay-open"><span aria-hidden="true">i</span><div>This window will stay open so you can inspect and copy the details below.</div></div>
+      </div>
+      ${technicalDetails(input.details)}
     </main>
   </body>
 </html>`
@@ -102,7 +211,7 @@ ${authorizationDocumentStyles}
 
 export function showMcpAuthorizationError(
   popup: Window | null,
-  input: { message: string; redirectUri?: string },
+  input: { message: string; details?: McpAuthorizationDebugDetails },
 ): void {
   if (!popup || popup.closed) return
   try {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
@@ -7,6 +7,15 @@ function isLoopbackHostname(hostname: string): boolean {
     && Number(octets[0]) === 127
 }
 
+function escapeHtml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;")
+}
+
 export function safeMcpAuthorizationUrl(rawUrl: string): string {
   let url: URL
   try {
@@ -22,6 +31,15 @@ export function safeMcpAuthorizationUrl(rawUrl: string): string {
   return url.toString()
 }
 
+const authorizationDocumentStyles = `
+      :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+      * { box-sizing: border-box; }
+      body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 32px; color: #182033; background: #f7f7f4; }
+      .card { width: min(100%, 440px); padding: 48px 40px; text-align: center; background: rgba(255, 255, 255, .9); border: 1px solid #e6e7e2; border-radius: 28px; box-shadow: 0 22px 70px rgba(24, 32, 51, .09); }
+      h1 { margin: 0; font-size: 25px; line-height: 1.2; letter-spacing: -.025em; }
+      p { max-width: 360px; margin: 14px auto 0; color: #667085; font-size: 15px; line-height: 1.6; }
+`
+
 export function mcpAuthorizationPendingDocument(): string {
   return `<!doctype html>
 <html lang="en">
@@ -31,15 +49,10 @@ export function mcpAuthorizationPendingDocument(): string {
     <meta name="color-scheme" content="light" />
     <title>Connecting — OpenWork</title>
     <style>
-      :root { color-scheme: light; font-family: Inter, ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
-      * { box-sizing: border-box; }
-      body { margin: 0; min-height: 100vh; display: grid; place-items: center; padding: 32px; color: #182033; background: #f7f7f4; }
-      .card { width: min(100%, 440px); padding: 48px 40px; text-align: center; background: rgba(255, 255, 255, .9); border: 1px solid #e6e7e2; border-radius: 28px; box-shadow: 0 22px 70px rgba(24, 32, 51, .09); }
+${authorizationDocumentStyles}
       .mark { position: relative; width: 64px; height: 64px; margin: 0 auto 28px; display: grid; place-items: center; }
       .core { width: 34px; height: 34px; border-radius: 12px; background: #182033; box-shadow: inset 0 0 0 7px #fff; }
       .orbit { position: absolute; inset: 0; border: 2px solid #dfe3da; border-top-color: #76966f; border-radius: 50%; animation: connect 1.15s cubic-bezier(.55, .15, .45, .85) infinite; }
-      h1 { margin: 0; font-size: 25px; line-height: 1.2; letter-spacing: -.025em; }
-      p { max-width: 330px; margin: 14px auto 0; color: #667085; font-size: 15px; line-height: 1.6; }
       @keyframes connect { to { transform: rotate(360deg); } }
       @media (prefers-reduced-motion: reduce) { .orbit { animation: none; border-color: #76966f; } }
     </style>
@@ -52,6 +65,54 @@ export function mcpAuthorizationPendingDocument(): string {
     </main>
   </body>
 </html>`
+}
+
+export function mcpAuthorizationErrorDocument(input: { message: string; redirectUri?: string }): string {
+  const redirectUri = input.redirectUri
+    ? `<section aria-labelledby="redirect-uri-label">
+        <h2 id="redirect-uri-label">Redirect URI used</h2>
+        <code>${escapeHtml(input.redirectUri)}</code>
+      </section>`
+    : ""
+  return `<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="color-scheme" content="light" />
+    <title>Connection failed — OpenWork</title>
+    <style>
+${authorizationDocumentStyles}
+      .error-mark { width: 56px; height: 56px; margin: 0 auto 24px; display: grid; place-items: center; border-radius: 50%; color: #b42318; background: #fef3f2; font-size: 30px; font-weight: 700; }
+      section { margin-top: 24px; text-align: left; }
+      h2 { margin: 0 0 8px; color: #475467; font-size: 12px; letter-spacing: .04em; text-transform: uppercase; }
+      code { display: block; overflow-wrap: anywhere; padding: 12px; border: 1px solid #e6e7e2; border-radius: 10px; color: #344054; background: #f9fafb; font: 12px/1.5 ui-monospace, SFMono-Regular, Menlo, monospace; user-select: all; }
+    </style>
+  </head>
+  <body>
+    <main class="card" role="alert" aria-live="assertive">
+      <div class="error-mark" aria-hidden="true">!</div>
+      <h1>Connection failed</h1>
+      <p>${escapeHtml(input.message)}</p>
+      ${redirectUri}
+    </main>
+  </body>
+</html>`
+}
+
+export function showMcpAuthorizationError(
+  popup: Window | null,
+  input: { message: string; redirectUri?: string },
+): void {
+  if (!popup || popup.closed) return
+  try {
+    popup.document.open()
+    popup.document.write(mcpAuthorizationErrorDocument(input))
+    popup.document.close()
+  } catch {
+    // If browser isolation made the document inaccessible, leave the popup
+    // open so the browser/provider error remains available for diagnosis.
+  }
 }
 
 export function openMcpAuthorizationWindow(): Window {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -308,17 +308,25 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export class McpOAuthConfigurationRequiredError extends Error {
-  constructor(message: string) {
+  readonly callbackUrl: string | null;
+
+  constructor(message: string, callbackUrl: string | null) {
     super(message);
     this.name = "McpOAuthConfigurationRequiredError";
+    this.callbackUrl = callbackUrl;
   }
 }
 
-function oauthConfigurationRequiredMessage(payload: unknown): string | null {
+function oauthConfigurationRequiredDetails(payload: unknown): { message: string; callbackUrl: string | null } | null {
   if (!isRecord(payload) || payload.error !== "mcp_oauth_configuration_required") return null;
-  return typeof payload.message === "string" && payload.message.trim()
-    ? payload.message
-    : "This MCP server requires a pre-registered OAuth client before it can connect.";
+  return {
+    message: typeof payload.message === "string" && payload.message.trim()
+      ? payload.message
+      : "This MCP server requires a pre-registered OAuth client before it can connect.",
+    callbackUrl: typeof payload.callbackUrl === "string" && payload.callbackUrl.trim()
+      ? payload.callbackUrl
+      : null,
+  };
 }
 
 function parseInspectionHeaders(value: unknown): ExternalMcpInspectionHeader[] | null {
@@ -704,9 +712,12 @@ export function useStartMcpConnectionOAuth() {
         20000,
       );
       if (!response.ok) {
-        const configurationRequiredMessage = oauthConfigurationRequiredMessage(payload);
-        if (configurationRequiredMessage) {
-          throw new McpOAuthConfigurationRequiredError(configurationRequiredMessage);
+        const configurationRequired = oauthConfigurationRequiredDetails(payload);
+        if (configurationRequired) {
+          throw new McpOAuthConfigurationRequiredError(
+            configurationRequired.message,
+            configurationRequired.callbackUrl,
+          );
         }
         throw getRequestError(payload, response, `Failed to start OAuth (${response.status}).`);
       }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -7,6 +7,7 @@ import {
   type ExternalMcpDiagnostic,
   parseExternalMcpDiagnostic,
 } from "./mcp-tool-error-attribution";
+import type { McpAuthorizationDebugDetails } from "./mcp-authorization-url";
 
 const ORG_SCOPE_HEADER = "x-openwork-org-id";
 
@@ -307,25 +308,62 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-export class McpOAuthConfigurationRequiredError extends Error {
-  readonly callbackUrl: string | null;
+export class McpOAuthStartError extends Error {
+  readonly details: McpAuthorizationDebugDetails;
 
-  constructor(message: string, callbackUrl: string | null) {
+  constructor(message: string, details: McpAuthorizationDebugDetails) {
     super(message);
-    this.name = "McpOAuthConfigurationRequiredError";
-    this.callbackUrl = callbackUrl;
+    this.name = "McpOAuthStartError";
+    this.details = details;
   }
 }
 
-function oauthConfigurationRequiredDetails(payload: unknown): { message: string; callbackUrl: string | null } | null {
-  if (!isRecord(payload) || payload.error !== "mcp_oauth_configuration_required") return null;
+export class McpOAuthConfigurationRequiredError extends McpOAuthStartError {
+  constructor(message: string, details: McpAuthorizationDebugDetails) {
+    super(message, details);
+    this.name = "McpOAuthConfigurationRequiredError";
+  }
+}
+
+function nonEmptyString(value: unknown): string | undefined {
+  return typeof value === "string" && value.trim() ? value : undefined;
+}
+
+function mcpOAuthStartDebugDetails(payload: unknown, httpStatus: number): McpAuthorizationDebugDetails {
+  const record = isRecord(payload) ? payload : null;
+  const errorCode = nonEmptyString(record?.error);
+  const message = nonEmptyString(record?.message);
+  const redirectUri = nonEmptyString(record?.callbackUrl);
+  const clientMetadataUrl = nonEmptyString(record?.clientMetadataUrl);
+  const manualRequirements = isStringArray(record?.manualRequirements)
+    ? record.manualRequirements
+    : undefined;
+  const diagnostic = parseExternalMcpDiagnostic(record?.diagnostic);
+  const responsePayload: Record<string, unknown> = {
+    ...(errorCode ? { error: errorCode } : {}),
+    ...(redirectUri ? { callbackUrl: redirectUri } : {}),
+    ...(clientMetadataUrl ? { clientMetadataUrl } : {}),
+    ...(message ? { message } : {}),
+    ...(manualRequirements ? { manualRequirements } : {}),
+    ...(diagnostic ? { diagnostic } : {}),
+  };
+
   return {
-    message: typeof payload.message === "string" && payload.message.trim()
-      ? payload.message
-      : "This MCP server requires a pre-registered OAuth client before it can connect.",
-    callbackUrl: typeof payload.callbackUrl === "string" && payload.callbackUrl.trim()
-      ? payload.callbackUrl
-      : null,
+    httpStatus,
+    ...(errorCode ? { errorCode } : {}),
+    ...(redirectUri ? { redirectUri } : {}),
+    ...(clientMetadataUrl ? { clientMetadataUrl } : {}),
+    ...(diagnostic?.referenceId ? { diagnosticReference: diagnostic.referenceId } : {}),
+    ...(diagnostic?.phase ? { phase: diagnostic.phase } : {}),
+    ...(diagnostic?.category ? { category: diagnostic.category } : {}),
+    ...(diagnostic?.highestPassed ? { highestPassed: diagnostic.highestPassed } : {}),
+    ...(diagnostic?.retryable !== undefined ? { retryable: diagnostic.retryable } : {}),
+    ...(diagnostic?.actionOwner ? { actionOwner: diagnostic.actionOwner } : {}),
+    ...(diagnostic?.operatorAction ? { operatorAction: diagnostic.operatorAction } : {}),
+    ...(diagnostic?.providerStatus !== undefined ? { providerStatus: diagnostic.providerStatus } : {}),
+    ...(diagnostic?.providerRequestId ? { providerRequestId: diagnostic.providerRequestId } : {}),
+    ...(diagnostic?.providerCode ? { providerCode: diagnostic.providerCode } : {}),
+    responseJson: JSON.stringify(responsePayload, null, 2),
   };
 }
 
@@ -712,14 +750,15 @@ export function useStartMcpConnectionOAuth() {
         20000,
       );
       if (!response.ok) {
-        const configurationRequired = oauthConfigurationRequiredDetails(payload);
-        if (configurationRequired) {
+        const details = mcpOAuthStartDebugDetails(payload, response.status);
+        const requestError = getRequestError(payload, response, `Failed to start OAuth (${response.status}).`);
+        if (details.errorCode === "mcp_oauth_configuration_required") {
           throw new McpOAuthConfigurationRequiredError(
-            configurationRequired.message,
-            configurationRequired.callbackUrl,
+            requestError.message,
+            details,
           );
         }
-        throw getRequestError(payload, response, `Failed to start OAuth (${response.status}).`);
+        throw new McpOAuthStartError(requestError.message, details);
       }
       return payload as { status: "connected" | "needs_auth"; authorizeUrl: string | null };
     },

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -40,6 +40,7 @@ import {
   type McpRequirementsDiscovery,
   type McpConnectionAccessInput,
   McpOAuthConfigurationRequiredError,
+  McpOAuthStartError,
   type UpdatedMcpConnection,
   type UpdateMcpConnectionInput,
   formatMcpConnectedTimestamp,
@@ -317,8 +318,8 @@ export function McpConnectionsScreen() {
       const message = connectError instanceof Error ? connectError.message : "Failed to connect the MCP server.";
       showMcpAuthorizationError(authorizationWindow, {
         message,
-        ...(connectError instanceof McpOAuthConfigurationRequiredError && connectError.callbackUrl
-          ? { redirectUri: connectError.callbackUrl }
+        ...(connectError instanceof McpOAuthStartError
+          ? { details: connectError.details }
           : {}),
       });
       if (connectError instanceof McpOAuthConfigurationRequiredError) {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -13,7 +13,7 @@ import { getPluginRoute } from "../../_lib/den-org";
 import { getRequestError, requestJson } from "../../_lib/den-flow";
 import { IntegrationIcon } from "./integration-icon";
 import { Microsoft365Dialog } from "./microsoft-365-dialog";
-import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl } from "./mcp-authorization-url";
+import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl, showMcpAuthorizationError } from "./mcp-authorization-url";
 import {
   editableMcpIdentityChanged,
   marketplaceIdentityOwnerNames,
@@ -314,7 +314,13 @@ export function McpConnectionsScreen() {
       authorizationWindow.location.href = safeMcpAuthorizationUrl(result.authorizeUrl);
       pollUntilConnected(connectionId);
     } catch (connectError) {
-      authorizationWindow?.close();
+      const message = connectError instanceof Error ? connectError.message : "Failed to connect the MCP server.";
+      showMcpAuthorizationError(authorizationWindow, {
+        message,
+        ...(connectError instanceof McpOAuthConfigurationRequiredError && connectError.callbackUrl
+          ? { redirectUri: connectError.callbackUrl }
+          : {}),
+      });
       if (connectError instanceof McpOAuthConfigurationRequiredError) {
         setOAuthClientConfigurationRequiredIds((current) => current.includes(connectionId)
           ? current
@@ -323,7 +329,7 @@ export function McpConnectionsScreen() {
       }
       setConnectionActionError({
         connectionId,
-        message: connectError instanceof Error ? connectError.message : "Failed to connect the MCP server.",
+        message,
       });
     }
   }
@@ -346,7 +352,9 @@ export function McpConnectionsScreen() {
         await handleConnectOAuth(created.id, authorizationWindow);
       }
     } catch (createError) {
-      authorizationWindow?.close();
+      showMcpAuthorizationError(authorizationWindow ?? null, {
+        message: createError instanceof Error ? createError.message : "Failed to create the MCP connection.",
+      });
       throw createError;
     }
   }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/use-mcp-account-authorization.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/use-mcp-account-authorization.ts
@@ -2,7 +2,11 @@
 
 import { useEffect, useRef, useState } from "react";
 import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl, showMcpAuthorizationError } from "./mcp-authorization-url";
-import { McpOAuthConfigurationRequiredError, useMcpConnections, useStartMcpConnectionOAuth } from "./mcp-connections-data";
+import {
+  McpOAuthStartError,
+  useMcpConnections,
+  useStartMcpConnectionOAuth,
+} from "./mcp-connections-data";
 
 const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
@@ -76,8 +80,8 @@ export function useMcpAccountAuthorization(onConnected?: () => void) {
       const message = connectError instanceof Error ? connectError.message : "Failed to connect account.";
       showMcpAuthorizationError(authorizationWindow, {
         message,
-        ...(connectError instanceof McpOAuthConfigurationRequiredError && connectError.callbackUrl
-          ? { redirectUri: connectError.callbackUrl }
+        ...(connectError instanceof McpOAuthStartError
+          ? { details: connectError.details }
           : {}),
       });
       setError({

--- a/ee/apps/den-web/app/(den)/dashboard/_components/use-mcp-account-authorization.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/use-mcp-account-authorization.ts
@@ -1,8 +1,8 @@
 "use client";
 
 import { useEffect, useRef, useState } from "react";
-import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl } from "./mcp-authorization-url";
-import { useMcpConnections, useStartMcpConnectionOAuth } from "./mcp-connections-data";
+import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl, showMcpAuthorizationError } from "./mcp-authorization-url";
+import { McpOAuthConfigurationRequiredError, useMcpConnections, useStartMcpConnectionOAuth } from "./mcp-connections-data";
 
 const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
@@ -73,10 +73,16 @@ export function useMcpAccountAuthorization(onConnected?: () => void) {
       authorizationWindow.location.href = safeMcpAuthorizationUrl(result.authorizeUrl);
       pollUntilConnected(connectionId);
     } catch (connectError) {
-      authorizationWindow?.close();
+      const message = connectError instanceof Error ? connectError.message : "Failed to connect account.";
+      showMcpAuthorizationError(authorizationWindow, {
+        message,
+        ...(connectError instanceof McpOAuthConfigurationRequiredError && connectError.callbackUrl
+          ? { redirectUri: connectError.callbackUrl }
+          : {}),
+      });
       setError({
         connectionId,
-        message: connectError instanceof Error ? connectError.message : "Failed to connect account.",
+        message,
       });
     }
   }

--- a/ee/apps/den-web/tests/mcp-authorization-url.test.ts
+++ b/ee/apps/den-web/tests/mcp-authorization-url.test.ts
@@ -31,7 +31,9 @@ describe("mcpAuthorizationPendingDocument", () => {
     const document = mcpAuthorizationPendingDocument()
 
     expect(document).toContain("Preparing your connection")
-    expect(document).toContain("You’ll be redirected to sign in shortly.")
+    expect(document).toContain("securely checking the provider")
+    expect(document).toContain("Keep this window open")
+    expect(document).toContain("OpenWork Connect")
     expect(document).toContain('role="status"')
     expect(document).toContain('aria-live="polite"')
     expect(document).toContain("prefers-reduced-motion: reduce")
@@ -42,13 +44,30 @@ describe("mcpAuthorizationErrorDocument", () => {
   test("keeps OAuth failures visible with the exact redirect URI", () => {
     const document = mcpAuthorizationErrorDocument({
       message: "A pre-registered OAuth client is required.",
-      redirectUri: "https://api.openwork.example/v1/mcp-connections/oauth/callback",
+      details: {
+        httpStatus: 409,
+        errorCode: "mcp_oauth_configuration_required",
+        redirectUri: "https://api.openwork.example/v1/mcp-connections/oauth/callback",
+        clientMetadataUrl: "https://api.openwork.example/.well-known/oauth-client",
+        responseJson: JSON.stringify({
+          error: "mcp_oauth_configuration_required",
+          callbackUrl: "https://api.openwork.example/v1/mcp-connections/oauth/callback",
+        }, null, 2),
+      },
     })
 
     expect(document).toContain("Connection failed")
     expect(document).toContain("A pre-registered OAuth client is required.")
-    expect(document).toContain("Redirect URI used")
+    expect(document).toContain("Technical details")
+    expect(document).toContain("Redirect URI")
     expect(document).toContain("https://api.openwork.example/v1/mcp-connections/oauth/callback")
+    expect(document).toContain("HTTP status")
+    expect(document).toContain("409")
+    expect(document).toContain("Error code")
+    expect(document).toContain("mcp_oauth_configuration_required")
+    expect(document).toContain("Response payload")
+    expect(document).toContain("<details>")
+    expect(document).not.toContain("<details open")
     expect(document).toContain('role="alert"')
     expect(document).not.toContain("window.close")
   })
@@ -56,11 +75,16 @@ describe("mcpAuthorizationErrorDocument", () => {
   test("escapes API error details before writing them into the popup", () => {
     const document = mcpAuthorizationErrorDocument({
       message: '<script>alert("message")</script>',
-      redirectUri: 'https://example.com/callback?next=<script>alert("uri")</script>',
+      details: {
+        httpStatus: 502,
+        redirectUri: 'https://example.com/callback?next=<script>alert("uri")</script>',
+        responseJson: '<script>alert("response")</script>',
+      },
     })
 
     expect(document).not.toContain("<script>alert")
     expect(document).toContain("&lt;script&gt;alert(&quot;message&quot;)&lt;/script&gt;")
     expect(document).toContain("next=&lt;script&gt;alert(&quot;uri&quot;)&lt;/script&gt;")
+    expect(document).toContain("&lt;script&gt;alert(&quot;response&quot;)&lt;/script&gt;")
   })
 })

--- a/ee/apps/den-web/tests/mcp-authorization-url.test.ts
+++ b/ee/apps/den-web/tests/mcp-authorization-url.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, test } from "bun:test"
 import {
+  mcpAuthorizationErrorDocument,
   mcpAuthorizationPendingDocument,
   safeMcpAuthorizationUrl,
 } from "../app/(den)/dashboard/_components/mcp-authorization-url"
@@ -34,5 +35,32 @@ describe("mcpAuthorizationPendingDocument", () => {
     expect(document).toContain('role="status"')
     expect(document).toContain('aria-live="polite"')
     expect(document).toContain("prefers-reduced-motion: reduce")
+  })
+})
+
+describe("mcpAuthorizationErrorDocument", () => {
+  test("keeps OAuth failures visible with the exact redirect URI", () => {
+    const document = mcpAuthorizationErrorDocument({
+      message: "A pre-registered OAuth client is required.",
+      redirectUri: "https://api.openwork.example/v1/mcp-connections/oauth/callback",
+    })
+
+    expect(document).toContain("Connection failed")
+    expect(document).toContain("A pre-registered OAuth client is required.")
+    expect(document).toContain("Redirect URI used")
+    expect(document).toContain("https://api.openwork.example/v1/mcp-connections/oauth/callback")
+    expect(document).toContain('role="alert"')
+    expect(document).not.toContain("window.close")
+  })
+
+  test("escapes API error details before writing them into the popup", () => {
+    const document = mcpAuthorizationErrorDocument({
+      message: '<script>alert("message")</script>',
+      redirectUri: 'https://example.com/callback?next=<script>alert("uri")</script>',
+    })
+
+    expect(document).not.toContain("<script>alert")
+    expect(document).toContain("&lt;script&gt;alert(&quot;message&quot;)&lt;/script&gt;")
+    expect(document).toContain("next=&lt;script&gt;alert(&quot;uri&quot;)&lt;/script&gt;")
   })
 })

--- a/evals/flows/mcp-oauth-popup-error-details.flow.mjs
+++ b/evals/flows/mcp-oauth-popup-error-details.flow.mjs
@@ -1,0 +1,146 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import {
+  denApiFetch,
+  openAdminConnections,
+  signInApi,
+  signInViaBrowser,
+} from "./lib/den-web.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/mcp-oauth-popup-error-details.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("mcp-oauth-popup-error-details");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MOCK_SERVER_URL = (process.env.MOCK_DCRLESS_MCP_URL ?? "http://127.0.0.1:3979").trim().replace(/\/+$/, "");
+const CONNECTION_NAME = `oauth-popup-error-${Date.now()}`;
+const state = {
+  adminSession: null,
+  connectionId: null,
+  callbackUrl: null,
+};
+
+function clickConnectionButtonScript() {
+  return `(() => {
+    const leaves = [...document.querySelectorAll('*')].filter(
+      (element) => element.children.length === 0
+        && (element.textContent ?? '').trim() === ${JSON.stringify(CONNECTION_NAME)}
+    );
+    for (const leaf of leaves) {
+      let element = leaf;
+      for (let depth = 0; depth < 7 && element; depth += 1) {
+        const button = [...element.querySelectorAll('button')].find(
+          (candidate) => (candidate.textContent ?? '').trim() === 'Connect'
+        );
+        if (button) {
+          element.scrollIntoView({ block: 'center' });
+          button.click();
+          return true;
+        }
+        element = element.parentElement;
+      }
+    }
+    return false;
+  })()`;
+}
+
+export default {
+  id: "mcp-oauth-popup-error-details",
+  title: "Failed MCP OAuth starts keep the popup open with the exact redirect URI",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  spec: "evals/voiceovers/mcp-oauth-popup-error-details.md",
+  steps: [
+    {
+      name: "Setup a DCR-less OAuth connection without a pre-registered client",
+      run: async (ctx) => {
+        const health = await fetch(`${MOCK_SERVER_URL}/health`).catch(() => null);
+        ctx.assert(Boolean(health?.ok), `DCR-less mock OAuth+MCP server not reachable at ${MOCK_SERVER_URL}.`);
+        const healthBody = await health.json();
+        ctx.assert(healthBody.disableDcr === true, `Mock server at ${MOCK_SERVER_URL} must run with DISABLE_DCR=1.`);
+
+        state.adminSession = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
+        ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+
+        const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+          headers: { authorization: `Bearer ${state.adminSession}` },
+        });
+        ctx.assert(existing.response.ok, `Listing manageable connections failed: ${existing.response.status}`);
+        for (const connection of existing.body.connections ?? []) {
+          if (connection.name.startsWith("oauth-popup-error-")) {
+            await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+              method: "DELETE",
+              headers: { authorization: `Bearer ${state.adminSession}` },
+            });
+          }
+        }
+
+        const created = await denApiFetch("/v1/mcp-connections", {
+          method: "POST",
+          headers: { authorization: `Bearer ${state.adminSession}` },
+          body: JSON.stringify({
+            name: CONNECTION_NAME,
+            url: `${MOCK_SERVER_URL}/mcp`,
+            authType: "oauth",
+            credentialMode: "shared",
+            access: { orgWide: true },
+          }),
+        });
+        ctx.assert(
+          created.response.ok,
+          `Creating DCR-less connection failed: ${created.response.status} ${JSON.stringify(created.body).slice(0, 300)}`,
+        );
+        state.connectionId = created.body.id;
+        state.callbackUrl = created.body.links?.oauthCallback;
+        ctx.assert(Boolean(state.connectionId), "Created connection did not return an id.");
+        ctx.assert(Boolean(state.callbackUrl), "Created connection did not return its OAuth callback URL.");
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("A failed OAuth start stays open and shows the exact redirect URI", {
+          voiceover: vo[0],
+          action: async () => {
+            await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+            await openAdminConnections(ctx);
+            await ctx.waitForText(CONNECTION_NAME, { timeoutMs: 20_000 });
+            await ctx.switchToNewTab({
+              timeoutMs: 20_000,
+              label: "OAuth error popup",
+              trigger: async () => {
+                const clicked = await ctx.eval(clickConnectionButtonScript());
+                ctx.assert(clicked, `No Connect button found for ${CONNECTION_NAME}.`);
+              },
+            });
+            await ctx.waitForText("Connection failed", { timeoutMs: 20_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("REDIRECT URI USED");
+            await ctx.expectText(state.callbackUrl);
+            const stillOpen = await ctx.eval("!window.closed");
+            ctx.assert(stillOpen, "The OAuth popup closed after the start error.");
+          },
+          screenshot: {
+            name: "oauth-error-popup-with-redirect-uri",
+            claim: "The failed OAuth popup remains visible with the exact redirect URI OpenWork sent.",
+            requireText: ["Connection failed", "REDIRECT URI USED", state.callbackUrl],
+            rejectText: ["Preparing your connection"],
+          },
+        });
+        await ctx.switchBack();
+      },
+    },
+    {
+      name: "Cleanup the test connection",
+      run: async (ctx) => {
+        if (!state.connectionId || !state.adminSession) return;
+        const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+          method: "DELETE",
+          headers: { authorization: `Bearer ${state.adminSession}` },
+        });
+        ctx.assert(removed.response.ok, `Cleanup failed for ${state.connectionId}: ${removed.response.status}`);
+      },
+    },
+  ],
+};

--- a/evals/flows/mcp-oauth-popup-error-details.flow.mjs
+++ b/evals/flows/mcp-oauth-popup-error-details.flow.mjs
@@ -45,7 +45,7 @@ function clickConnectionButtonScript() {
 
 export default {
   id: "mcp-oauth-popup-error-details",
-  title: "Failed MCP OAuth starts keep the popup open with the exact redirect URI",
+  title: "Failed MCP OAuth starts keep the popup open with expandable diagnostics",
   kind: "user-facing",
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
@@ -116,15 +116,32 @@ export default {
             await ctx.waitForText("Connection failed", { timeoutMs: 20_000 });
           },
           assert: async () => {
-            await ctx.expectText("REDIRECT URI USED");
-            await ctx.expectText(state.callbackUrl);
+            await ctx.expectText("Technical details");
+            const expanded = await ctx.eval(`(() => {
+              const details = document.querySelector('details');
+              details?.querySelector('summary')?.click();
+              return details?.open === true;
+            })()`);
+            ctx.assert(expanded, "Technical details did not expand.");
+            const debugText = await ctx.eval("document.querySelector('.details-content')?.textContent ?? ''");
+            ctx.assert(debugText.includes("HTTP status") && debugText.includes("409"), "HTTP 409 was missing from the expanded details.");
+            ctx.assert(
+              debugText.includes("Error code") && debugText.includes("mcp_oauth_configuration_required"),
+              "The OAuth error code was missing from the expanded details.",
+            );
+            ctx.assert(debugText.includes("Response payload"), "The safe response payload was missing from the expanded details.");
+            ctx.assert(debugText.includes(state.callbackUrl), "The exact redirect URI was missing from the expanded details.");
+            await ctx.eval(`(() => {
+              document.querySelector('#response-payload-label')?.scrollIntoView({ block: 'start' });
+              return true;
+            })()`);
             const stillOpen = await ctx.eval("!window.closed");
             ctx.assert(stillOpen, "The OAuth popup closed after the start error.");
           },
           screenshot: {
             name: "oauth-error-popup-with-redirect-uri",
-            claim: "The failed OAuth popup remains visible with the exact redirect URI OpenWork sent.",
-            requireText: ["Connection failed", "REDIRECT URI USED", state.callbackUrl],
+            claim: "The failed OAuth popup remains visible with expandable, safe debugging details.",
+            requireText: ["RESPONSE PAYLOAD", "mcp_oauth_configuration_required", state.callbackUrl],
             rejectText: ["Preparing your connection"],
           },
         });

--- a/evals/voiceovers/mcp-oauth-popup-error-details.md
+++ b/evals/voiceovers/mcp-oauth-popup-error-details.md
@@ -1,0 +1,3 @@
+# mcp-oauth-popup-error-details — OAuth failures stay open with the redirect URI
+
+1. Alex clicks Connect on an MCP server that needs a pre-registered OAuth client. Instead of disappearing, the sign-in window stays open on a clear error and shows the exact redirect URI OpenWork used, so he can fix the provider configuration without guessing.

--- a/evals/voiceovers/mcp-oauth-popup-error-details.md
+++ b/evals/voiceovers/mcp-oauth-popup-error-details.md
@@ -1,3 +1,3 @@
-# mcp-oauth-popup-error-details — OAuth failures stay open with the redirect URI
+# mcp-oauth-popup-error-details — OAuth failures stay open with expandable diagnostics
 
-1. Alex clicks Connect on an MCP server that needs a pre-registered OAuth client. Instead of disappearing, the sign-in window stays open on a clear error and shows the exact redirect URI OpenWork used, so he can fix the provider configuration without guessing.
+1. Alex clicks Connect on an MCP server that needs a pre-registered OAuth client. The polished sign-in window stays open on a clear error, and he expands Technical details to see the exact redirect URI, status, error code, and safe response payload needed to fix the provider configuration.


### PR DESCRIPTION
## Summary

- keep MCP OAuth popups open when connection startup fails across both admin-managed and member account flows
- polish the loading state with an intentional OpenWork Connect card, secure-connection progress treatment, and reduced-motion support
- replace the raw failure page with a clearer error layout that explains the window will remain open
- add a collapsed **Technical details** section with the exact redirect URI, HTTP status, error code, client metadata URL, diagnostic reference and phase fields when available, and a sanitized response payload
- add focused popup coverage plus a deterministic real-browser regression flow and voiceover

## Root cause

Both Den Web OAuth launch paths explicitly closed the authorization window in their error handlers. The Den API already returned useful troubleshooting context, including the public `callbackUrl` for `mcp_oauth_configuration_required`, but the client reduced the response to a message and discarded the remaining fields.

## Validation

- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm --filter @openwork-ee/den-web exec bun test tests/mcp-authorization-url.test.ts` — 10 passed
- `pnpm --filter @openwork-ee/den-web test` — 57 passed
- `pnpm fraimz --flow mcp-oauth-popup-error-details --cdp-url http://127.0.0.1:33329` against isolated Den Web, Den API, MySQL, and a DCR-less OAuth/MCP provider — passed; the real popup stayed open, expanded Technical details, and showed HTTP 409, `mcp_oauth_configuration_required`, the exact callback URI, client metadata URI, and safe response payload

Additional check from the initial implementation: `bun test tests/mcp-authorization-url.test.ts tests/mcp-oauth-bootstrap.test.ts tests/mcp-oauth-callback-migration.test.ts` produced 17 passes and 1 unrelated failure. The failing callback-migration assertion expects a `canConnectOAuth` source string that is already absent at this branch's `upstream/dev` base; this PR does not modify that row predicate.

## Security and risk

- only allowlisted fields from known Den API error envelopes are copied into the debug payload; arbitrary response data is not exposed
- API messages, URLs, diagnostic values, and JSON are HTML-escaped before being written into the popup
- no credentials, tokens, secrets, or tenant-private request data are added to the UI
- successful already-connected paths still close the temporary popup
- technical details are collapsed by default, keeping the primary error approachable for non-technical users
- if browser isolation prevents rewriting the popup document, it remains open so the browser/provider error is still inspectable

## Manual behavior

The automated browser journey was observed end to end. The loading document is covered by the focused rendering test; it transitions too quickly in the live DCR-less journey to capture as a stable frame. No separate user-confirmed manual run was performed.