### PR TITLE
fix(mcp): make connected-tool schema checks advisory

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
@@ -356,6 +356,12 @@ function providerToolContentEvidence(result: unknown): ProviderToolContentEviden
   }
 }
 
+function isProviderInputValidationExcerpt(value: string | undefined): boolean {
+  if (!value) return false
+  return /^Input validation error:\s*Invalid arguments for tool\b/i.test(value)
+    || /^Invalid (?:tool )?(?:arguments|params)\b/i.test(value)
+}
+
 function errorName(value: unknown): string {
   const name = value instanceof Error ? value.name : stringProperty(value, "name")
   return name && SAFE_ERROR_NAMES.has(name) ? name : "Error"
@@ -868,6 +874,16 @@ function classifyError(error: unknown, fallbackPhase: ExternalMcpDiagnosticPhase
       operatorAction: "Check provider latency and retry after the current MCP request can complete within its bounded timeout.",
     }
   }
+  if (numericErrorCode(error) === -32602 && fallbackPhase === "MCP_TOOL_EXECUTION") {
+    return {
+      phase: "MCP_TOOL_EXECUTION",
+      category: "mcp_tool_input_invalid",
+      code: "MCP_INVALID_PARAMS",
+      retryable: false,
+      actionOwner: "openwork",
+      operatorAction: "Correct the tool arguments using the latest advertised input schema; do not retry the same arguments unchanged.",
+    }
+  }
 
   const name = errorName(error)
   if (name === "InvalidClientError" || name === "UnauthorizedClientError" || name === "InvalidClientMetadataError") {
@@ -1136,10 +1152,24 @@ export class ExternalMcpDiagnosticTracker {
     const requestId = safeProviderRequestId(structuredContent?.requestId) ?? evidence.providerRequestId
     if (requestId) this.providerRequestId = requestId
 
+    const providerInvalidArguments = [
+      "invalid_arguments",
+      "invalid_params",
+      "validation_error",
+    ].includes(providerCategory ?? "") || isProviderInputValidationExcerpt(evidence.excerpt)
     const providerPolicyDenied = structuredProviderStatus === 403
       ? providerCategory === "provider_policy"
       : evidence.providerStatus === 403
-    const classificationBase: Classification = providerPolicyDenied
+    const classificationBase: Classification = providerInvalidArguments
+      ? {
+          phase: "MCP_TOOL_EXECUTION",
+          category: "mcp_tool_input_invalid",
+          code: "MCP_PROVIDER_INVALID_PARAMS",
+          retryable: false,
+          actionOwner: "openwork",
+          operatorAction: "Correct the tool arguments using the latest advertised input schema; do not retry the same arguments unchanged.",
+        }
+      : providerPolicyDenied
       ? {
           phase: "PROVIDER_AUTHORIZATION",
           category: "provider_policy_denied",

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -109,8 +109,9 @@ export const AGENT_MCP_INSTRUCTIONS = [
   "After importing, retrieve the resolved marketplace detail and report each plugin's cloudReadiness. An import or plugin binding is not proof that an MCP connection is usable. Relay needs_admin_setup or needs_signin as the next human action instead of claiming the connection is ready.",
   "Do not invent OAuth-client, credential, or local-extension setup. Organization connections are managed in the OpenWork Cloud dashboard / Settings > Connect. When a returned connection or marketplace readiness state requires administrator setup or member sign-in, relay that exact action.",
   "A successful search_capabilities call proves this OpenWork Cloud MCP connection is authorized. Never tell the user to reconnect OpenWork Cloud because a downstream connector failed.",
-  "External MCP matches include argumentsSchema, schemaDigest, and invocation.argumentsField. Put an object matching argumentsSchema in execute_capability.body and copy schemaDigest into execute_capability.schemaDigest.",
-  "If execute_capability returns invalid_capability_arguments, correct the listed issues and retry once with changed arguments; never retry the same arguments unchanged. If it returns capability_schema_changed or unknown_capability, call search_capabilities again before retrying.",
+  "External MCP matches include the provider-advertised argumentsSchema, schemaDigest, and invocation.argumentsField. Put an object matching argumentsSchema in execute_capability.body and copy schemaDigest into execute_capability.schemaDigest.",
+  "OpenWork always attempts the downstream provider call when local schema checks find a mismatch. schemaGuidance is advisory and appears alongside the provider result: if the provider succeeded, accept that result and do not retry solely because of the warning; if it failed, use the warning to correct the arguments or search again.",
+  "If the provider returns invalid_capability_arguments, correct the listed issues and retry once with changed arguments; never retry the same arguments unchanged. If it returns unknown_capability, call search_capabilities again before retrying.",
   "When a match has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly. Distinguish the member's Your Connections page, the organization Connections dashboard, and the provider's own admin console.",
   "Connection probes are live. After the requested human fixes that connector, search again in the same task; otherwise do not retry unchanged or improvise workarounds through other tools.",
 ].join("\n")
@@ -143,6 +144,7 @@ export function externalCapabilityErrorToolResult(
       ...(result.schemaDigest ? { schemaDigest: result.schemaDigest } : {}),
       ...(result.sameArgumentsRetryable === false ? { sameArgumentsRetryable: false } : {}),
       ...(result.retry ? { retry: result.retry } : {}),
+      ...(result.schemaGuidance ? { schemaGuidance: result.schemaGuidance } : {}),
     })),
   }
 }
@@ -180,6 +182,19 @@ function externalToolContent(result: unknown): { type: "text"; text: string }[] 
     return result.content
   }
   return textContent(JSON.stringify(result))
+}
+
+export function externalCapabilitySuccessToolResult(
+  result: Extract<ExternalCapabilityExecuteResult, { ok: true }>,
+): ExecuteCapabilityToolResult {
+  const content = externalToolContent(result.result)
+  if (!result.schemaGuidance) return { content }
+  return {
+    content: [
+      ...content,
+      ...textContent(JSON.stringify({ schemaGuidance: result.schemaGuidance })),
+    ],
+  }
 }
 
 function capabilityTimeoutResult(capability: string): ExecuteCapabilityToolResult {
@@ -376,13 +391,14 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         description: [
           "Call a capability found via search_capabilities, by its exact name.",
           "Pass path/query/body only as described by that match's pathParams/queryParams/hasBody.",
+          "For external MCP capabilities, provider-advertised schema mismatches are returned as advisory schemaGuidance alongside the provider result; they do not block the downstream call.",
           "For skill:<id> matches, this returns that skill's stored SKILL.md content.",
           "Returns unknown_capability if name doesn't match a current capability — call search_capabilities again.",
         ].join(" "),
         annotations: EXECUTE_CAPABILITY_ANNOTATIONS,
         inputSchema: z.object({
           name: z.string().min(1).describe("The exact tool name returned by search_capabilities."),
-          schemaDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/).optional().describe("For an external MCP match, copy the exact schemaDigest returned by search_capabilities so schema drift is detected."),
+          schemaDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/).optional().describe("For an external MCP match, copy the exact schemaDigest returned by search_capabilities so schema drift can be reported as advisory guidance without blocking the provider call."),
           path: z.union([z.record(z.string(), z.unknown()), z.string()]).optional().describe("Path parameters, only if the match's pathParams is non-empty."),
           query: z.union([z.record(z.string(), z.unknown()), z.string()]).optional().describe("Query parameters, only if the match's queryParams is non-empty."),
           body: z.unknown().optional().describe("For native API capabilities, the JSON body. For external MCP capabilities, the arguments object matching argumentsSchema."),
@@ -423,7 +439,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
               // The SDK's callTool() can return either the standard {content:[...]}
               // shape or a legacy-compatibility {toolResult} shape; normalize to
               // what McpServer's own tool callback contract requires.
-              return { content: externalToolContent(result.result) }
+              return externalCapabilitySuccessToolResult(result)
             }
 
             const marketplace = parseMarketplaceCapabilityName(name)

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -85,6 +85,9 @@ const capabilityMatchOutputSchema = z.object({
   queryParams: z.array(z.string()),
   hasBody: z.boolean(),
   bodySchema: z.unknown().optional(),
+  argumentsSchema: z.unknown().optional(),
+  schemaDigest: z.string().optional(),
+  invocation: z.object({ argumentsField: z.literal("body") }).optional(),
   kind: z.string().optional(),
   status: z.string().optional(),
   hint: z.string().optional(),
@@ -106,6 +109,8 @@ export const AGENT_MCP_INSTRUCTIONS = [
   "After importing, retrieve the resolved marketplace detail and report each plugin's cloudReadiness. An import or plugin binding is not proof that an MCP connection is usable. Relay needs_admin_setup or needs_signin as the next human action instead of claiming the connection is ready.",
   "Do not invent OAuth-client, credential, or local-extension setup. Organization connections are managed in the OpenWork Cloud dashboard / Settings > Connect. When a returned connection or marketplace readiness state requires administrator setup or member sign-in, relay that exact action.",
   "A successful search_capabilities call proves this OpenWork Cloud MCP connection is authorized. Never tell the user to reconnect OpenWork Cloud because a downstream connector failed.",
+  "External MCP matches include argumentsSchema, schemaDigest, and invocation.argumentsField. Put an object matching argumentsSchema in execute_capability.body and copy schemaDigest into execute_capability.schemaDigest.",
+  "If execute_capability returns invalid_capability_arguments, correct the listed issues and retry once with changed arguments; never retry the same arguments unchanged. If it returns capability_schema_changed or unknown_capability, call search_capabilities again before retrying.",
   "When a match has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly. Distinguish the member's Your Connections page, the organization Connections dashboard, and the provider's own admin console.",
   "Connection probes are live. After the requested human fixes that connector, search again in the same task; otherwise do not retry unchanged or improvise workarounds through other tools.",
 ].join("\n")
@@ -133,6 +138,11 @@ export function externalCapabilityErrorToolResult(
       ...(result.actionOwner ? { actionOwner: result.actionOwner } : {}),
       ...(result.operatorAction ? { operatorAction: result.operatorAction } : {}),
       ...(result.connectionStatus ? { connectionStatus: result.connectionStatus } : {}),
+      ...(result.capability ? { capability: result.capability } : {}),
+      ...(result.issues ? { issues: result.issues } : {}),
+      ...(result.schemaDigest ? { schemaDigest: result.schemaDigest } : {}),
+      ...(result.sameArgumentsRetryable === false ? { sameArgumentsRetryable: false } : {}),
+      ...(result.retry ? { retry: result.retry } : {}),
     })),
   }
 }
@@ -154,18 +164,6 @@ function unknownCapabilityText(name: string): string {
     error: "unknown_capability",
     message: `No capability named "${name}". Call search_capabilities to find a valid name.`,
   })
-}
-
-function normalizedExternalArgs(body: unknown): Record<string, unknown> {
-  const normalizedBody = normalizeToolBody(body)
-  if (typeof normalizedBody !== "object" || normalizedBody === null || Array.isArray(normalizedBody)) {
-    return {}
-  }
-  const args: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(normalizedBody)) {
-    args[key] = value
-  }
-  return args
 }
 
 function isTextContent(value: unknown): value is { type: "text"; text: string } {
@@ -310,7 +308,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
           "there is no list of individually-named tools to browse. Always search first.",
           "Search covers native Google Workspace capabilities (Gmail, Calendar, Drive, Gmail drafts), org-connected external MCPs, and namespaced OpenWork Admin tools for allowlisted platform admins.",
           "Try 2-4 keyword variants before deciding a capability is unavailable.",
-          "Each match includes pathParams, queryParams, hasBody, and the exact bodySchema for JSON mutations, describing what execute_capability needs.",
+          "Native API matches include pathParams, queryParams, hasBody, and bodySchema. External MCP matches include argumentsSchema, schemaDigest, and invocation.argumentsField.",
           "Skill matches use method SKILL and return stored SKILL.md content when executed.",
         ].join(" "),
         annotations: SEARCH_CAPABILITIES_ANNOTATIONS,
@@ -384,12 +382,13 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         annotations: EXECUTE_CAPABILITY_ANNOTATIONS,
         inputSchema: z.object({
           name: z.string().min(1).describe("The exact tool name returned by search_capabilities."),
+          schemaDigest: z.string().regex(/^sha256:[a-f0-9]{64}$/).optional().describe("For an external MCP match, copy the exact schemaDigest returned by search_capabilities so schema drift is detected."),
           path: z.union([z.record(z.string(), z.unknown()), z.string()]).optional().describe("Path parameters, only if the match's pathParams is non-empty."),
           query: z.union([z.record(z.string(), z.unknown()), z.string()]).optional().describe("Query parameters, only if the match's queryParams is non-empty."),
-          body: z.unknown().optional().describe("JSON body, only if the match's hasBody is true."),
+          body: z.unknown().optional().describe("For native API capabilities, the JSON body. For external MCP capabilities, the arguments object matching argumentsSchema."),
         }),
       },
-      async ({ name, path, query, body }) => {
+      async ({ name, schemaDigest, path, query, body }) => {
         return executeCapabilityWithBudget({
           capability: name,
           invoke: async (): Promise<ExecuteCapabilityToolResult> => {
@@ -414,7 +413,8 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
                 member: memberIdentity,
                 connectionId: external.connectionId,
                 toolName: external.toolName,
-                args: normalizedExternalArgs(body),
+                args: normalizeToolBody(body),
+                schemaDigest,
                 redirectUriBase: resolvePublicOrigin(c.req.raw, env.apiPublicUrl),
               })
               if (!result.ok) {

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -750,8 +750,39 @@ export async function searchExternalCapabilities(input: {
   })
 }
 
+export type ExternalMcpSchemaWarning =
+  | {
+      code: "arguments_schema_mismatch"
+      message: string
+      issues: ExternalMcpArgumentIssue[]
+      suggestedAction: string
+    }
+  | {
+      code: "arguments_schema_unavailable"
+      message: string
+      suggestedAction: string
+    }
+  | {
+      code: "capability_schema_changed"
+      message: string
+      searchedSchemaDigest: string
+      currentSchemaDigest: string
+      suggestedAction: string
+    }
+
+export type ExternalMcpSchemaGuidance = {
+  advisory: true
+  providerCallAttempted: true
+  message: string
+  warnings: ExternalMcpSchemaWarning[]
+}
+
 export type ExternalCapabilityExecuteResult =
-  | { ok: true; result: Awaited<ReturnType<typeof callExternalMcpTool>> }
+  | {
+      ok: true
+      result: Awaited<ReturnType<typeof callExternalMcpTool>>
+      schemaGuidance?: ExternalMcpSchemaGuidance
+    }
   | {
       ok: false
       error:
@@ -762,7 +793,6 @@ export type ExternalCapabilityExecuteResult =
         | "connection_failed"
         | "provider_error"
         | "invalid_capability_arguments"
-        | "capability_schema_changed"
       message: string
       diagnostic?: ExternalMcpDiagnostic
       actionOwner?: ExternalMcpDiagnostic["actionOwner"]
@@ -776,6 +806,7 @@ export type ExternalCapabilityExecuteResult =
         action: "correct_arguments" | "search_capabilities"
         searchRequired: boolean
       }
+      schemaGuidance?: ExternalMcpSchemaGuidance
     }
 
 function invalidCapabilityArguments(input: {
@@ -783,6 +814,7 @@ function invalidCapabilityArguments(input: {
   schemaDigest?: string
   issues?: ExternalMcpArgumentIssue[]
   diagnostic?: ExternalMcpDiagnostic
+  schemaGuidance?: ExternalMcpSchemaGuidance
 }): Exclude<ExternalCapabilityExecuteResult, { ok: true }> {
   return {
     ok: false,
@@ -799,6 +831,7 @@ function invalidCapabilityArguments(input: {
     ...(input.schemaDigest ? { schemaDigest: input.schemaDigest } : {}),
     sameArgumentsRetryable: false,
     retry: { action: "correct_arguments", searchRequired: false },
+    ...(input.schemaGuidance ? { schemaGuidance: input.schemaGuidance } : {}),
     ...(input.diagnostic
       ? {
           diagnostic: input.diagnostic,
@@ -806,6 +839,18 @@ function invalidCapabilityArguments(input: {
           operatorAction: input.diagnostic.operatorAction,
         }
       : {}),
+  }
+}
+
+function advisorySchemaGuidance(
+  warnings: ExternalMcpSchemaWarning[],
+): ExternalMcpSchemaGuidance | undefined {
+  if (warnings.length === 0) return undefined
+  return {
+    advisory: true,
+    providerCallAttempted: true,
+    message: "OpenWork forwarded the call to the provider. These local schema checks are guidance only; use the provider result as the source of truth.",
+    warnings,
   }
 }
 
@@ -914,6 +959,7 @@ export async function executeExternalCapability(input: {
   }
 
   let currentSchemaDigest: string | undefined
+  let schemaGuidance: ExternalMcpSchemaGuidance | undefined
   try {
     const redirectUri = redirectUriFor(input.redirectUriBase, connection.id)
     const tools = await listExternalMcpTools(connection, redirectUri, member)
@@ -931,45 +977,52 @@ export async function executeExternalCapability(input: {
 
     const schemaDigest = externalMcpToolSchemaDigest(tool.inputSchema)
     currentSchemaDigest = schemaDigest
+    const schemaWarnings: ExternalMcpSchemaWarning[] = []
     if (input.schemaDigest && input.schemaDigest !== schemaDigest) {
-      return {
-        ok: false,
-        error: "capability_schema_changed",
-        capability: buildExternalCapabilityName(connection.id, input.toolName),
-        message: "The capability schema changed after discovery. Call search_capabilities again before executing it.",
-        schemaDigest,
-        sameArgumentsRetryable: false,
-        retry: { action: "search_capabilities", searchRequired: true },
-      }
-    }
-
-    const validation = validateExternalMcpToolArguments(tool.inputSchema, input.args)
-    if (!validation.ok && validation.error === "invalid_arguments") {
-      return invalidCapabilityArguments({
-        capability: buildExternalCapabilityName(connection.id, input.toolName),
-        schemaDigest,
-        issues: validation.issues,
+      schemaWarnings.push({
+        code: "capability_schema_changed",
+        message: "The provider advertised a different capability schema after discovery, but OpenWork still forwarded the call.",
+        searchedSchemaDigest: input.schemaDigest,
+        currentSchemaDigest: schemaDigest,
+        suggestedAction: "If the provider call failed, call search_capabilities again and retry with the latest argumentsSchema. Do not retry solely because of this warning when the provider call succeeded.",
       })
     }
-    if (!validation.ok) {
-      return {
-        ok: false,
-        error: "provider_error",
-        capability: buildExternalCapabilityName(connection.id, input.toolName),
-        message: validation.message,
-        actionOwner: "provider_admin",
-        operatorAction: "Repair the remote MCP tool's advertised inputSchema before retrying.",
-      }
-    }
 
-    const result = await callExternalMcpTool({
+    // MCP tool arguments are always an object at the protocol boundary. Start
+    // the provider call before advisory validation so a provider with an
+    // inaccurate or unsupported advertised schema still gets the request.
+    const forwardedArguments = isRecord(input.args) ? input.args : {}
+    const providerCall = callExternalMcpTool({
       connection,
       redirectUri,
       toolName: input.toolName,
-      args: validation.arguments,
+      args: forwardedArguments,
       member,
     })
-    return { ok: true, result }
+
+    const validation = validateExternalMcpToolArguments(tool.inputSchema, input.args)
+    if (!validation.ok && validation.error === "invalid_arguments") {
+      schemaWarnings.push({
+        code: "arguments_schema_mismatch",
+        message: "The arguments do not match the provider's advertised argumentsSchema, but OpenWork still forwarded the call because the provider may accept them.",
+        issues: validation.issues,
+        suggestedAction: "If the provider call failed, correct the listed issues and retry with changed arguments. Do not retry solely because of this warning when the provider call succeeded.",
+      })
+    } else if (!validation.ok) {
+      schemaWarnings.push({
+        code: "arguments_schema_unavailable",
+        message: validation.message,
+        suggestedAction: "Use the provider result as the source of truth. If the call failed, the provider administrator may need to repair the advertised inputSchema.",
+      })
+    }
+
+    schemaGuidance = advisorySchemaGuidance(schemaWarnings)
+    const result = await providerCall
+    return {
+      ok: true,
+      result,
+      ...(schemaGuidance ? { schemaGuidance } : {}),
+    }
   } catch (error) {
     const message = upstreamErrorMessage(error)
     const authErrorCode = externalMcpAuthErrorCode(error, message)
@@ -985,6 +1038,7 @@ export async function executeExternalCapability(input: {
           capability: buildExternalCapabilityName(connection.id, input.toolName),
           schemaDigest: currentSchemaDigest ?? input.schemaDigest,
           diagnostic: error.diagnostic,
+          schemaGuidance,
         })
       }
       return {
@@ -996,6 +1050,7 @@ export async function executeExternalCapability(input: {
         diagnostic: error.diagnostic,
         actionOwner: error.diagnostic.actionOwner,
         operatorAction: error.diagnostic.operatorAction,
+        ...(schemaGuidance ? { schemaGuidance } : {}),
         ...(authErrorCode
           ? {
               connectionStatus: buildExternalConnectionStatus({
@@ -1014,6 +1069,7 @@ export async function executeExternalCapability(input: {
         ok: false,
         error: "connection_failed",
         message,
+        ...(schemaGuidance ? { schemaGuidance } : {}),
         connectionStatus: buildExternalConnectionStatus({
           connection,
           state: "reauth_required",

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -29,6 +29,11 @@ import { getConnectedAccount } from "../capability-sources/oauth-credentials.js"
 import { db } from "../db.js"
 import { listTeamsForMember } from "../orgs.js"
 import { openworkOrganizationConnectionsUrl, openworkYourConnectionsUrl } from "./connection-navigation.js"
+import {
+  externalMcpToolSchemaDigest,
+  validateExternalMcpToolArguments,
+  type ExternalMcpArgumentIssue,
+} from "./external-mcp-tool-arguments.js"
 import { compareCapabilityMatches, tokenize } from "./search.js"
 import type { CapabilityMatch } from "./search.js"
 
@@ -150,6 +155,12 @@ export function selectExternalMcpSearchConnections<T extends { name: string }>(
 }
 
 export type ExternalCapabilityMatch = CapabilityMatch & {
+  /** Exact MCP arguments schema returned by the provider's live tools/list. */
+  argumentsSchema?: unknown
+  /** Stable digest used to detect a schema change between search and execute. */
+  schemaDigest?: string
+  /** Tells the generic execute facade where MCP arguments must be supplied. */
+  invocation?: { argumentsField: "body" }
   /** Distinguishes a connection-health result from a callable capability. */
   kind?: "connection_status"
   /** Set for connection-level status rows: the tool exists but needs a human/admin fix before real tools can be listed. */
@@ -684,6 +695,9 @@ async function probeExternalMcpConnection(input: {
       pathParams: [],
       queryParams: [],
       hasBody: true,
+      argumentsSchema: tool.inputSchema,
+      schemaDigest: externalMcpToolSchemaDigest(tool.inputSchema),
+      invocation: { argumentsField: "body" },
     })
   }
   return matches
@@ -740,13 +754,60 @@ export type ExternalCapabilityExecuteResult =
   | { ok: true; result: Awaited<ReturnType<typeof callExternalMcpTool>> }
   | {
       ok: false
-      error: "unknown_capability" | "forbidden" | "connection_not_connected" | "needs_connection" | "connection_failed" | "provider_error"
+      error:
+        | "unknown_capability"
+        | "forbidden"
+        | "connection_not_connected"
+        | "needs_connection"
+        | "connection_failed"
+        | "provider_error"
+        | "invalid_capability_arguments"
+        | "capability_schema_changed"
       message: string
       diagnostic?: ExternalMcpDiagnostic
       actionOwner?: ExternalMcpDiagnostic["actionOwner"]
       operatorAction?: string
       connectionStatus?: ExternalConnectionStatus
+      capability?: string
+      issues?: ExternalMcpArgumentIssue[]
+      schemaDigest?: string
+      sameArgumentsRetryable?: false
+      retry?: {
+        action: "correct_arguments" | "search_capabilities"
+        searchRequired: boolean
+      }
     }
+
+function invalidCapabilityArguments(input: {
+  capability: string
+  schemaDigest?: string
+  issues?: ExternalMcpArgumentIssue[]
+  diagnostic?: ExternalMcpDiagnostic
+}): Exclude<ExternalCapabilityExecuteResult, { ok: true }> {
+  return {
+    ok: false,
+    error: "invalid_capability_arguments",
+    capability: input.capability,
+    message: input.diagnostic
+      ? `The remote MCP rejected the capability arguments as invalid. Correct them using the latest argumentsSchema. Diagnostic reference: ${input.diagnostic.referenceId}.`
+      : "The capability arguments do not match the remote MCP tool's advertised argumentsSchema.",
+    issues: input.issues ?? [{
+      path: "/",
+      keyword: "schema_validation",
+      message: "The remote MCP rejected these arguments as invalid. Correct them using the latest argumentsSchema.",
+    }],
+    ...(input.schemaDigest ? { schemaDigest: input.schemaDigest } : {}),
+    sameArgumentsRetryable: false,
+    retry: { action: "correct_arguments", searchRequired: false },
+    ...(input.diagnostic
+      ? {
+          diagnostic: input.diagnostic,
+          actionOwner: input.diagnostic.actionOwner,
+          operatorAction: input.diagnostic.operatorAction,
+        }
+      : {}),
+  }
+}
 
 /**
  * Executes a namespaced external capability, scoped to the calling
@@ -759,7 +820,8 @@ export async function executeExternalCapability(input: {
   member: McpMemberIdentity | null
   connectionId: string
   toolName: string
-  args: Record<string, unknown>
+  args: unknown
+  schemaDigest?: string
   redirectUriBase: string
 }): Promise<ExternalCapabilityExecuteResult> {
   if (!input.member) {
@@ -851,12 +913,60 @@ export async function executeExternalCapability(input: {
     }
   }
 
+  let currentSchemaDigest: string | undefined
   try {
+    const redirectUri = redirectUriFor(input.redirectUriBase, connection.id)
+    const tools = await listExternalMcpTools(connection, redirectUri, member)
+    const tool = tools.find((candidate) => candidate.name === input.toolName)
+    if (!tool) {
+      return {
+        ok: false,
+        error: "unknown_capability",
+        capability: buildExternalCapabilityName(connection.id, input.toolName),
+        message: `No current tool named "${input.toolName}" exists on "${connection.name}". Call search_capabilities again.`,
+        sameArgumentsRetryable: false,
+        retry: { action: "search_capabilities", searchRequired: true },
+      }
+    }
+
+    const schemaDigest = externalMcpToolSchemaDigest(tool.inputSchema)
+    currentSchemaDigest = schemaDigest
+    if (input.schemaDigest && input.schemaDigest !== schemaDigest) {
+      return {
+        ok: false,
+        error: "capability_schema_changed",
+        capability: buildExternalCapabilityName(connection.id, input.toolName),
+        message: "The capability schema changed after discovery. Call search_capabilities again before executing it.",
+        schemaDigest,
+        sameArgumentsRetryable: false,
+        retry: { action: "search_capabilities", searchRequired: true },
+      }
+    }
+
+    const validation = validateExternalMcpToolArguments(tool.inputSchema, input.args)
+    if (!validation.ok && validation.error === "invalid_arguments") {
+      return invalidCapabilityArguments({
+        capability: buildExternalCapabilityName(connection.id, input.toolName),
+        schemaDigest,
+        issues: validation.issues,
+      })
+    }
+    if (!validation.ok) {
+      return {
+        ok: false,
+        error: "provider_error",
+        capability: buildExternalCapabilityName(connection.id, input.toolName),
+        message: validation.message,
+        actionOwner: "provider_admin",
+        operatorAction: "Repair the remote MCP tool's advertised inputSchema before retrying.",
+      }
+    }
+
     const result = await callExternalMcpTool({
       connection,
-      redirectUri: redirectUriFor(input.redirectUriBase, connection.id),
+      redirectUri,
       toolName: input.toolName,
-      args: input.args,
+      args: validation.arguments,
       member,
     })
     return { ok: true, result }
@@ -870,6 +980,13 @@ export async function executeExternalCapability(input: {
         connectionEndpoint: safeExternalMcpEndpointForLog(connection.url),
         ...externalMcpDiagnosticForLog(error, error.diagnostic.referenceId, "MCP_TOOL_EXECUTION"),
       })
+      if (error.diagnostic.code === "MCP_INVALID_PARAMS" || error.diagnostic.code === "MCP_PROVIDER_INVALID_PARAMS") {
+        return invalidCapabilityArguments({
+          capability: buildExternalCapabilityName(connection.id, input.toolName),
+          schemaDigest: currentSchemaDigest ?? input.schemaDigest,
+          diagnostic: error.diagnostic,
+        })
+      }
       return {
         ok: false,
         error: error.diagnostic.phase === "PROVIDER_EXECUTION" || error.diagnostic.phase === "PROVIDER_AUTHORIZATION"

--- a/ee/apps/den-api/src/mcp/external-mcp-tool-arguments.ts
+++ b/ee/apps/den-api/src/mcp/external-mcp-tool-arguments.ts
@@ -1,0 +1,80 @@
+import { createHash } from "node:crypto"
+import type { Tool } from "@modelcontextprotocol/sdk/types.js"
+import { AjvJsonSchemaValidator } from "@modelcontextprotocol/sdk/validation/ajv"
+
+export type ExternalMcpArgumentIssue = {
+  path: string
+  keyword: "schema_validation" | "type"
+  message: string
+}
+
+export type ExternalMcpArgumentValidation =
+  | { ok: true; arguments: Record<string, unknown> }
+  | { ok: false; error: "invalid_arguments"; issues: ExternalMcpArgumentIssue[] }
+  | { ok: false; error: "invalid_schema"; message: string }
+
+const validatorProvider = new AjvJsonSchemaValidator()
+const VALIDATION_MESSAGE_LIMIT = 1_000
+
+function canonicalJson(value: unknown): string {
+  if (value === null) return "null"
+  if (Array.isArray(value)) return `[${value.map(canonicalJson).join(",")}]`
+  if (typeof value === "object") {
+    const entries = Object.entries(value)
+      .filter(([, entry]) => entry !== undefined)
+      .sort(([left], [right]) => left.localeCompare(right))
+    return `{${entries.map(([key, entry]) => `${JSON.stringify(key)}:${canonicalJson(entry)}`).join(",")}}`
+  }
+  return JSON.stringify(value) ?? "null"
+}
+
+function boundedMessage(message: string): string {
+  return message.length > VALIDATION_MESSAGE_LIMIT
+    ? `${message.slice(0, VALIDATION_MESSAGE_LIMIT)}...`
+    : message
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+export function externalMcpToolSchemaDigest(schema: Tool["inputSchema"]): string {
+  return `sha256:${createHash("sha256").update(canonicalJson(schema)).digest("hex")}`
+}
+
+export function validateExternalMcpToolArguments(
+  schema: Tool["inputSchema"],
+  value: unknown,
+): ExternalMcpArgumentValidation {
+  if (!isRecord(value)) {
+    return {
+      ok: false,
+      error: "invalid_arguments",
+      issues: [{
+        path: "/",
+        keyword: "type",
+        message: "Remote MCP capability arguments must be a JSON object.",
+      }],
+    }
+  }
+
+  try {
+    const result = validatorProvider.getValidator<Record<string, unknown>>(schema)(value)
+    if (result.valid) return { ok: true, arguments: value }
+    return {
+      ok: false,
+      error: "invalid_arguments",
+      issues: [{
+        path: "/",
+        keyword: "schema_validation",
+        message: boundedMessage(result.errorMessage),
+      }],
+    }
+  } catch {
+    return {
+      ok: false,
+      error: "invalid_schema",
+      message: "The remote MCP tool advertised an input schema that OpenWork could not compile.",
+    }
+  }
+}

--- a/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
+++ b/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
@@ -33,6 +33,11 @@ type FakeMcpServer = {
   stop: () => void
 }
 
+type MutableSchemaMcpServer = FakeMcpServer & {
+  toolCalls: () => number
+  useSchema: (schema: "query" | "incidentId") => void
+}
+
 type SeededOrganization = {
   organizationId: DenTypeId<"organization">
   memberId: DenTypeId<"member">
@@ -61,6 +66,7 @@ let notionServer: FakeMcpServer | undefined
 let refreshErrorServer: FakeMcpServer | undefined
 let providerErrorServer: FakeMcpServer | undefined
 let needleServer: FakeMcpServer | undefined
+let mutableSchemaServer: MutableSchemaMcpServer | undefined
 
 const slackTools: FakeTool[] = [
   { name: "slack-send-message", description: "Send a message to a Slack channel or DM." },
@@ -157,6 +163,17 @@ function startProviderErrorMcpServer(): FakeMcpServer {
         },
       }),
     )
+    server.registerTool(
+      "runtime_reject",
+      {
+        description: "Reject a schema-valid request using the standard MCP SDK validation error shape.",
+        inputSchema: z.object({ query: z.string() }),
+      },
+      async () => ({
+        isError: true,
+        content: textContent("Input validation error: Invalid arguments for tool runtime_reject: sensitive provider detail"),
+      }),
+    )
     const transport = new StreamableHTTPTransport()
     await server.connect(transport)
     const response = await transport.handleRequest(c) ?? new Response(null, { status: 204 })
@@ -165,6 +182,50 @@ function startProviderErrorMcpServer(): FakeMcpServer {
   })
   const server = Bun.serve({ port: 0, fetch: app.fetch })
   return { url: `http://127.0.0.1:${server.port}/mcp`, stop: () => server.stop(true) }
+}
+
+function startMutableSchemaMcpServer(): MutableSchemaMcpServer {
+  let currentSchema: "query" | "incidentId" = "query"
+  let toolCalls = 0
+  const app = new Hono()
+  app.all("/mcp", async (c) => {
+    const payload: unknown = await c.req.raw.clone().json().catch(() => null)
+    if (typeof payload === "object" && payload !== null && "method" in payload && payload.method === "tools/call") {
+      toolCalls += 1
+    }
+    const server = new McpServer({ name: "mutable-schema", version: "1.0.0" })
+    if (currentSchema === "query") {
+      server.registerTool(
+        "lookup_incident",
+        {
+          description: "Look up an incident using a search query.",
+          inputSchema: z.object({ query: z.string() }),
+        },
+        async ({ query }) => ({ content: textContent(`Found ${query}`) }),
+      )
+    } else {
+      server.registerTool(
+        "lookup_incident",
+        {
+          description: "Look up an incident using its identifier.",
+          inputSchema: z.object({ incidentId: z.string() }),
+        },
+        async ({ incidentId }) => ({ content: textContent(`Found ${incidentId}`) }),
+      )
+    }
+    const transport = new StreamableHTTPTransport()
+    await server.connect(transport)
+    return await transport.handleRequest(c) ?? new Response(null, { status: 204 })
+  })
+  const server = Bun.serve({ port: 0, fetch: app.fetch })
+  return {
+    url: `http://127.0.0.1:${server.port}/mcp`,
+    stop: () => server.stop(true),
+    toolCalls: () => toolCalls,
+    useSchema: (schema) => {
+      currentSchema = schema
+    },
+  }
 }
 
 function standaloneConnection(
@@ -294,6 +355,7 @@ beforeAll(async () => {
     name: "needle-only-tool",
     description: "The only catalog entry matching the coverage test keyword.",
   }])
+  mutableSchemaServer = startMutableSchemaMcpServer()
 })
 
 afterAll(() => {
@@ -303,6 +365,7 @@ afterAll(() => {
   refreshErrorServer?.stop()
   providerErrorServer?.stop()
   needleServer?.stop()
+  mutableSchemaServer?.stop()
   mock.restore()
 })
 
@@ -334,6 +397,92 @@ test("control-healthy: Connections list and search_capabilities both see Slack t
   if (process.env.OPENWORK_EVAL_VERBOSE === "1") {
     console.log("E2E_HEALTHY_DISCOVERY", JSON.stringify({ connectionName: "Slack", toolCount: matches.length, status: "available" }))
   }
+})
+
+test("external capability execution validates the live schema before tools/call", async () => {
+  if (!mutableSchemaServer) throw new Error("Mutable-schema MCP server was not started")
+  const seed = await seedOrganization("deterministic-arguments")
+  const connection = await createGrantedConnection(seed, {
+    name: "Incident service",
+    authType: "none",
+    credentialMode: "shared",
+    url: mutableSchemaServer.url,
+  })
+
+  const matches = await search(seed, "lookup incident")
+  const match = matches.find((candidate) => candidate.name === `mcp:${connection.id}:lookup_incident`)
+  if (!match?.schemaDigest) throw new Error("Search did not return the external capability schema digest")
+  expect(match).toMatchObject({
+    argumentsSchema: {
+      type: "object",
+      required: ["query"],
+    },
+    invocation: { argumentsField: "body" },
+  })
+
+  const invalid = await executeExternalCapability({
+    organizationId: seed.organizationId,
+    member: { orgMembershipId: seed.memberId, teamIds: [] },
+    connectionId: connection.id,
+    toolName: "lookup_incident",
+    args: {},
+    schemaDigest: match.schemaDigest,
+    redirectUriBase,
+  })
+  expect(invalid).toMatchObject({
+    ok: false,
+    error: "invalid_capability_arguments",
+    sameArgumentsRetryable: false,
+    retry: { action: "correct_arguments", searchRequired: false },
+    schemaDigest: match.schemaDigest,
+  })
+  expect(mutableSchemaServer.toolCalls()).toBe(0)
+
+  const invalidShape = await executeExternalCapability({
+    organizationId: seed.organizationId,
+    member: { orgMembershipId: seed.memberId, teamIds: [] },
+    connectionId: connection.id,
+    toolName: "lookup_incident",
+    args: ["query"],
+    schemaDigest: match.schemaDigest,
+    redirectUriBase,
+  })
+  expect(invalidShape).toMatchObject({
+    ok: false,
+    error: "invalid_capability_arguments",
+    issues: [{ path: "/", keyword: "type" }],
+  })
+  expect(mutableSchemaServer.toolCalls()).toBe(0)
+
+  const valid = await executeExternalCapability({
+    organizationId: seed.organizationId,
+    member: { orgMembershipId: seed.memberId, teamIds: [] },
+    connectionId: connection.id,
+    toolName: "lookup_incident",
+    args: { query: "INC0001" },
+    schemaDigest: match.schemaDigest,
+    redirectUriBase,
+  })
+  expect(valid.ok).toBe(true)
+  expect(mutableSchemaServer.toolCalls()).toBe(1)
+
+  mutableSchemaServer.useSchema("incidentId")
+  const stale = await executeExternalCapability({
+    organizationId: seed.organizationId,
+    member: { orgMembershipId: seed.memberId, teamIds: [] },
+    connectionId: connection.id,
+    toolName: "lookup_incident",
+    args: { query: "INC0001" },
+    schemaDigest: match.schemaDigest,
+    redirectUriBase,
+  })
+  expect(stale).toMatchObject({
+    ok: false,
+    error: "capability_schema_changed",
+    sameArgumentsRetryable: false,
+    retry: { action: "search_capabilities", searchRequired: true },
+  })
+  expect(mutableSchemaServer.toolCalls()).toBe(1)
 })
 
 test("shared-oauth-never-connected: Connections list sees Slack and search returns needs_connection", async () => {
@@ -584,6 +733,40 @@ test("MCP tool isError is surfaced as a provider failure, not transport success"
     },
   })
   expect(result.message).not.toContain("internal detail")
+})
+
+test("standard MCP SDK invalid-argument tool errors become a corrective execution result", async () => {
+  if (!providerErrorServer) throw new Error("Provider-error MCP server was not started")
+  const seed = await seedOrganization("provider-invalid-arguments")
+  const connection = await createGrantedConnection(seed, {
+    name: "ServiceNow",
+    authType: "none",
+    credentialMode: "shared",
+    url: providerErrorServer.url,
+  })
+  const result = await executeExternalCapability({
+    organizationId: seed.organizationId,
+    member: { orgMembershipId: seed.memberId, teamIds: [] },
+    connectionId: connection.id,
+    toolName: "runtime_reject",
+    args: { query: "INC0001" },
+    redirectUriBase,
+  })
+
+  expect(result).toMatchObject({
+    ok: false,
+    error: "invalid_capability_arguments",
+    sameArgumentsRetryable: false,
+    retry: { action: "correct_arguments", searchRequired: false },
+    diagnostic: {
+      phase: "MCP_TOOL_EXECUTION",
+      category: "mcp_tool_input_invalid",
+      code: "MCP_PROVIDER_INVALID_PARAMS",
+      actionOwner: "openwork",
+      retryable: false,
+    },
+  })
+  expect(JSON.stringify(result)).not.toContain("sensitive provider detail")
 })
 
 test("structured provider denial keeps connection health separate and names the provider admin", async () => {

--- a/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
+++ b/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
@@ -190,7 +190,10 @@ function startMutableSchemaMcpServer(): MutableSchemaMcpServer {
   const app = new Hono()
   app.all("/mcp", async (c) => {
     const payload: unknown = await c.req.raw.clone().json().catch(() => null)
-    if (typeof payload === "object" && payload !== null && "method" in payload && payload.method === "tools/call") {
+    const method = typeof payload === "object" && payload !== null && "method" in payload
+      ? payload.method
+      : null
+    if (method === "tools/call") {
       toolCalls += 1
     }
     const server = new McpServer({ name: "mutable-schema", version: "1.0.0" })
@@ -215,7 +218,41 @@ function startMutableSchemaMcpServer(): MutableSchemaMcpServer {
     }
     const transport = new StreamableHTTPTransport()
     await server.connect(transport)
-    return await transport.handleRequest(c) ?? new Response(null, { status: 204 })
+    const response = await transport.handleRequest(c) ?? new Response(null, { status: 204 })
+    if (method === "tools/list" && currentSchema === "query") {
+      const responseText = await response.text()
+      const dataLine = responseText.split("\n").find((line) => line.startsWith("data:"))
+      if (!dataLine) {
+        return new Response(responseText, { status: response.status, headers: response.headers })
+      }
+      const body = JSON.parse(dataLine.slice("data:".length).trim()) as {
+        result?: {
+          tools?: Array<{
+            name?: string
+            inputSchema?: {
+              properties?: Record<string, unknown>
+              required?: string[]
+            }
+          }>
+        }
+      }
+      const lookupTool = body.result?.tools?.find((tool) => tool.name === "lookup_incident")
+      if (lookupTool?.inputSchema) {
+        // Deliberately model a real-world provider bug: tools/list claims an
+        // extra required argument, while tools/call still accepts the actual
+        // implementation's simpler {query} input.
+        lookupTool.inputSchema.properties = {
+          ...lookupTool.inputSchema.properties,
+          providerExtension: { type: "string" },
+        }
+        lookupTool.inputSchema.required = ["query", "providerExtension"]
+      }
+      const headers = new Headers(response.headers)
+      headers.delete("content-length")
+      const rewritten = responseText.replace(dataLine, `data: ${JSON.stringify(body)}`)
+      return new Response(rewritten, { status: response.status, headers })
+    }
+    return response
   })
   const server = Bun.serve({ port: 0, fetch: app.fetch })
   return {
@@ -399,7 +436,7 @@ test("control-healthy: Connections list and search_capabilities both see Slack t
   }
 })
 
-test("external capability execution validates the live schema before tools/call", async () => {
+test("external capability execution reports schema guidance but always attempts tools/call", async () => {
   if (!mutableSchemaServer) throw new Error("Mutable-schema MCP server was not started")
   const seed = await seedOrganization("deterministic-arguments")
   const connection = await createGrantedConnection(seed, {
@@ -415,12 +452,33 @@ test("external capability execution validates the live schema before tools/call"
   expect(match).toMatchObject({
     argumentsSchema: {
       type: "object",
-      required: ["query"],
+      required: ["query", "providerExtension"],
     },
     invocation: { argumentsField: "body" },
   })
 
-  const invalid = await executeExternalCapability({
+  const providerAccepted = await executeExternalCapability({
+    organizationId: seed.organizationId,
+    member: { orgMembershipId: seed.memberId, teamIds: [] },
+    connectionId: connection.id,
+    toolName: "lookup_incident",
+    args: { query: "INC0001" },
+    schemaDigest: match.schemaDigest,
+    redirectUriBase,
+  })
+  expect(providerAccepted).toMatchObject({
+    ok: true,
+    schemaGuidance: {
+      advisory: true,
+      providerCallAttempted: true,
+      warnings: [{
+        code: "arguments_schema_mismatch",
+      }],
+    },
+  })
+  expect(mutableSchemaServer.toolCalls()).toBe(1)
+
+  const providerRejected = await executeExternalCapability({
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
@@ -429,14 +487,18 @@ test("external capability execution validates the live schema before tools/call"
     schemaDigest: match.schemaDigest,
     redirectUriBase,
   })
-  expect(invalid).toMatchObject({
+  expect(providerRejected).toMatchObject({
     ok: false,
-    error: "invalid_capability_arguments",
-    sameArgumentsRetryable: false,
-    retry: { action: "correct_arguments", searchRequired: false },
-    schemaDigest: match.schemaDigest,
+    error: "provider_error",
+    schemaGuidance: {
+      advisory: true,
+      providerCallAttempted: true,
+      warnings: [{
+        code: "arguments_schema_mismatch",
+      }],
+    },
   })
-  expect(mutableSchemaServer.toolCalls()).toBe(0)
+  expect(mutableSchemaServer.toolCalls()).toBe(2)
 
   const invalidShape = await executeExternalCapability({
     organizationId: seed.organizationId,
@@ -449,22 +511,28 @@ test("external capability execution validates the live schema before tools/call"
   })
   expect(invalidShape).toMatchObject({
     ok: false,
-    error: "invalid_capability_arguments",
-    issues: [{ path: "/", keyword: "type" }],
+    error: "provider_error",
+    schemaGuidance: {
+      warnings: [{
+        code: "arguments_schema_mismatch",
+        issues: [{ path: "/", keyword: "type" }],
+      }],
+    },
   })
-  expect(mutableSchemaServer.toolCalls()).toBe(0)
+  expect(mutableSchemaServer.toolCalls()).toBe(3)
 
   const valid = await executeExternalCapability({
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
     toolName: "lookup_incident",
-    args: { query: "INC0001" },
+    args: { query: "INC0001", providerExtension: "compatibility-value" },
     schemaDigest: match.schemaDigest,
     redirectUriBase,
   })
-  expect(valid.ok).toBe(true)
-  expect(mutableSchemaServer.toolCalls()).toBe(1)
+  expect(valid).toMatchObject({ ok: true })
+  if (valid.ok) expect(valid.schemaGuidance).toBeUndefined()
+  expect(mutableSchemaServer.toolCalls()).toBe(4)
 
   mutableSchemaServer.useSchema("incidentId")
   const stale = await executeExternalCapability({
@@ -472,17 +540,22 @@ test("external capability execution validates the live schema before tools/call"
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     connectionId: connection.id,
     toolName: "lookup_incident",
-    args: { query: "INC0001" },
+    args: { incidentId: "INC0001" },
     schemaDigest: match.schemaDigest,
     redirectUriBase,
   })
   expect(stale).toMatchObject({
-    ok: false,
-    error: "capability_schema_changed",
-    sameArgumentsRetryable: false,
-    retry: { action: "search_capabilities", searchRequired: true },
+    ok: true,
+    schemaGuidance: {
+      advisory: true,
+      providerCallAttempted: true,
+      warnings: [{
+        code: "capability_schema_changed",
+        searchedSchemaDigest: match.schemaDigest,
+      }],
+    },
   })
-  expect(mutableSchemaServer.toolCalls()).toBe(1)
+  expect(mutableSchemaServer.toolCalls()).toBe(5)
 })
 
 test("shared-oauth-never-connected: Connections list sees Slack and search returns needs_connection", async () => {

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -434,6 +434,69 @@ describe("external MCP diagnostics", () => {
     expect(serialized).not.toContain("invalid request id with spaces")
   })
 
+  test("classifies remote invalid params as correctable tool input", () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_invalid_params")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const invalidParams = new Error("Provider rejected private argument detail")
+    Object.defineProperty(invalidParams, "code", { value: -32602 })
+
+    const error = tracker.error(invalidParams)
+    expect(error.diagnostic).toMatchObject({
+      phase: "MCP_TOOL_EXECUTION",
+      category: "mcp_tool_input_invalid",
+      code: "MCP_INVALID_PARAMS",
+      actionOwner: "openwork",
+      retryable: false,
+      jsonRpcCode: -32602,
+    })
+    expect(error.diagnostic.operatorAction).toContain("do not retry the same arguments")
+    expect(JSON.stringify(error.diagnostic)).not.toContain("private argument detail")
+  })
+
+  test("classifies structured provider validation errors as correctable tool input", () => {
+    const { result: error } = captureConsoleError(() => {
+      const tracker = new ExternalMcpDiagnosticTracker("req_provider_invalid_params")
+      tracker.passed("MCP_INITIALIZED", "protocol_ready")
+      return tracker.providerToolError({
+        isError: true,
+        content: [{ type: "text", text: "private provider validation detail" }],
+        structuredContent: { category: "invalid_arguments" },
+      })
+    })
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "MCP_TOOL_EXECUTION",
+      category: "mcp_tool_input_invalid",
+      code: "MCP_PROVIDER_INVALID_PARAMS",
+      actionOwner: "openwork",
+      retryable: false,
+    })
+    expect(JSON.stringify(error.diagnostic)).not.toContain("private provider validation detail")
+  })
+
+  test("classifies standardized MCP SDK input-validation tool errors without exposing their text", () => {
+    const { result: error } = captureConsoleError(() => {
+      const tracker = new ExternalMcpDiagnosticTracker("req_sdk_invalid_params")
+      tracker.passed("MCP_INITIALIZED", "protocol_ready")
+      return tracker.providerToolError({
+        isError: true,
+        content: [{
+          type: "text",
+          text: "Input validation error: Invalid arguments for tool lookup_incident: private provider detail",
+        }],
+      })
+    })
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "MCP_TOOL_EXECUTION",
+      category: "mcp_tool_input_invalid",
+      code: "MCP_PROVIDER_INVALID_PARAMS",
+      actionOwner: "openwork",
+      retryable: false,
+    })
+    expect(JSON.stringify(error.diagnostic)).not.toContain("private provider detail")
+  })
+
   test("derives allowlisted provider evidence from ServiceNow-style text JSON", () => {
     const providerText = '{"status":403,"error":"insufficient_acl","requestId":"TXN-abc-123"}'
     const { result: error } = captureConsoleError(() => {

--- a/ee/apps/den-api/test/external-mcp-tool-arguments.test.ts
+++ b/ee/apps/den-api/test/external-mcp-tool-arguments.test.ts
@@ -1,0 +1,64 @@
+import { expect, test } from "bun:test"
+import {
+  externalMcpToolSchemaDigest,
+  validateExternalMcpToolArguments,
+} from "../src/mcp/external-mcp-tool-arguments.js"
+
+test("schema digests are stable across object key order", () => {
+  const first = externalMcpToolSchemaDigest({
+    type: "object",
+    properties: {
+      query: { type: "string" },
+      limit: { type: "number" },
+    },
+    required: ["query"],
+  })
+  const second = externalMcpToolSchemaDigest({
+    required: ["query"],
+    properties: {
+      limit: { type: "number" },
+      query: { type: "string" },
+    },
+    type: "object",
+  })
+
+  expect(first).toBe(second)
+  expect(first).toMatch(/^sha256:[a-f0-9]{64}$/)
+})
+
+test("invalid remote MCP arguments return corrective schema details", () => {
+  const result = validateExternalMcpToolArguments({
+    type: "object",
+    properties: {
+      query: { type: "string" },
+    },
+    required: ["query"],
+    additionalProperties: false,
+  }, {})
+
+  expect(result).toMatchObject({
+    ok: false,
+    error: "invalid_arguments",
+    issues: [{
+      path: "/",
+      keyword: "schema_validation",
+    }],
+  })
+  if (!result.ok && result.error === "invalid_arguments") {
+    expect(result.issues[0]?.message).toContain("query")
+  }
+})
+
+test("remote MCP arguments must be an object before schema validation", () => {
+  const result = validateExternalMcpToolArguments({ type: "object" }, ["not", "an", "object"])
+
+  expect(result).toEqual({
+    ok: false,
+    error: "invalid_arguments",
+    issues: [{
+      path: "/",
+      keyword: "type",
+      message: "Remote MCP capability arguments must be a JSON object.",
+    }],
+  })
+})

--- a/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
@@ -115,6 +115,8 @@ test("agent MCP server exposes steering instructions during initialize", async (
   expect(client.getInstructions()).toContain("Settings > Connect")
   expect(client.getInstructions()).toContain("Never tell the user to reconnect OpenWork Cloud")
   expect(client.getInstructions()).toContain("connectionStatus.connectionName")
+  expect(client.getInstructions()).toContain("invalid_capability_arguments")
+  expect(client.getInstructions()).toContain("never retry the same arguments unchanged")
 
   await client.close()
   await server.close()
@@ -202,6 +204,38 @@ test("external capability failures preserve the safe MCP diagnostic envelope", (
       state: "reauth_required",
       action: { type: "reconnect" },
     },
+  })
+})
+
+test("invalid capability arguments preserve corrective retry instructions", () => {
+  const result = agentModule.externalCapabilityErrorToolResult({
+    ok: false,
+    error: "invalid_capability_arguments",
+    capability: "mcp:emc_test:lookup_incident",
+    message: "The capability arguments do not match its advertised schema.",
+    issues: [{
+      path: "/query",
+      keyword: "schema_validation",
+      message: "Required property query is missing.",
+    }],
+    schemaDigest: `sha256:${"a".repeat(64)}`,
+    sameArgumentsRetryable: false,
+    retry: { action: "correct_arguments", searchRequired: false },
+  })
+
+  expect(result.isError).toBe(true)
+  expect(JSON.parse(result.content[0]?.text ?? "{}")).toEqual({
+    error: "invalid_capability_arguments",
+    message: "The capability arguments do not match its advertised schema.",
+    capability: "mcp:emc_test:lookup_incident",
+    issues: [{
+      path: "/query",
+      keyword: "schema_validation",
+      message: "Required property query is missing.",
+    }],
+    schemaDigest: `sha256:${"a".repeat(64)}`,
+    sameArgumentsRetryable: false,
+    retry: { action: "correct_arguments", searchRequired: false },
   })
 })
 

--- a/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
@@ -115,6 +115,8 @@ test("agent MCP server exposes steering instructions during initialize", async (
   expect(client.getInstructions()).toContain("Settings > Connect")
   expect(client.getInstructions()).toContain("Never tell the user to reconnect OpenWork Cloud")
   expect(client.getInstructions()).toContain("connectionStatus.connectionName")
+  expect(client.getInstructions()).toContain("schemaGuidance is advisory")
+  expect(client.getInstructions()).toContain("always attempts the downstream provider call")
   expect(client.getInstructions()).toContain("invalid_capability_arguments")
   expect(client.getInstructions()).toContain("never retry the same arguments unchanged")
 
@@ -236,6 +238,40 @@ test("invalid capability arguments preserve corrective retry instructions", () =
     schemaDigest: `sha256:${"a".repeat(64)}`,
     sameArgumentsRetryable: false,
     retry: { action: "correct_arguments", searchRequired: false },
+  })
+})
+
+test("successful provider output preserves advisory schema guidance as additional content", () => {
+  const result = agentModule.externalCapabilitySuccessToolResult({
+    ok: true,
+    result: {
+      content: [{ type: "text", text: "Provider accepted the request." }],
+    },
+    schemaGuidance: {
+      advisory: true,
+      providerCallAttempted: true,
+      message: "OpenWork forwarded the call to the provider. Use the provider result as the source of truth.",
+      warnings: [{
+        code: "arguments_schema_mismatch",
+        message: "The arguments did not match the advertised schema.",
+        issues: [{
+          path: "/",
+          keyword: "schema_validation",
+          message: "Unexpected providerExtension property.",
+        }],
+        suggestedAction: "Do not retry because the provider succeeded.",
+      }],
+    },
+  })
+
+  expect(result.isError).toBeUndefined()
+  expect(result.content[0]).toEqual({ type: "text", text: "Provider accepted the request." })
+  expect(JSON.parse(result.content[1]?.text ?? "{}")).toMatchObject({
+    schemaGuidance: {
+      advisory: true,
+      providerCallAttempted: true,
+      warnings: [{ code: "arguments_schema_mismatch" }],
+    },
   })
 })
 

--- a/packages/enterprise-mcp-client/src/errors.ts
+++ b/packages/enterprise-mcp-client/src/errors.ts
@@ -99,16 +99,28 @@ export class EnterpriseMcpToolResultError extends Error {
       && typeof result.structuredContent === "object" && result.structuredContent !== null
       ? result.structuredContent
       : null
-    if (!structuredContent) return
-    const providerStatus = "providerStatus" in structuredContent && typeof structuredContent.providerStatus === "number"
+    const content = typeof result === "object" && result !== null && "content" in result && Array.isArray(result.content)
+      ? result.content
+      : []
+    const hasStandardInputValidationError = content.some((item) => {
+      if (typeof item !== "object" || item === null || !("type" in item) || item.type !== "text" || !("text" in item) || typeof item.text !== "string") {
+        return false
+      }
+      return /^Input validation error:\s*Invalid arguments for tool\b/i.test(item.text)
+        || /^Invalid (?:tool )?(?:arguments|params)\b/i.test(item.text)
+    })
+    const providerStatus = structuredContent && "providerStatus" in structuredContent && typeof structuredContent.providerStatus === "number"
       ? structuredContent.providerStatus
       : undefined
-    const category = "category" in structuredContent && typeof structuredContent.category === "string"
+    const category = structuredContent && "category" in structuredContent && typeof structuredContent.category === "string"
       ? structuredContent.category
-      : undefined
-    const requestId = "requestId" in structuredContent && typeof structuredContent.requestId === "string"
+      : hasStandardInputValidationError
+        ? "invalid_arguments"
+        : undefined
+    const requestId = structuredContent && "requestId" in structuredContent && typeof structuredContent.requestId === "string"
       ? structuredContent.requestId
       : undefined
+    if (providerStatus === undefined && category === undefined && requestId === undefined) return
     this.providerSignal = {
       ...(providerStatus !== undefined ? { providerStatus } : {}),
       ...(category !== undefined ? { category } : {}),

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -31,6 +31,7 @@ const rpcRequestSchema = z.object({
 
 type MockMcpOptions = {
   toolError?: boolean
+  toolErrorText?: string
   expectedApiKey?: string
 }
 
@@ -84,7 +85,7 @@ function mockMcpFetch(options: MockMcpOptions = {}): EnterpriseMcpFetch {
         jsonrpc: "2.0",
         id: request.id,
         result: {
-          content: [{ type: "text", text: options.toolError ? "Provider rejected the operation" : "Record found" }],
+          content: [{ type: "text", text: options.toolError ? (options.toolErrorText ?? "Provider rejected the operation") : "Record found" }],
           isError: options.toolError ?? false,
         },
       })
@@ -428,6 +429,28 @@ describe("enterprise MCP client", () => {
         assert.ok(error instanceof EnterpriseMcpClientError)
         assert.equal(error.code, "MCP_TOOL_EXECUTION_FAILED")
         assert.ok(error.cause instanceof EnterpriseMcpToolResultError)
+        return true
+      },
+    )
+  })
+
+  it("retains only a safe invalid-argument signal from standardized MCP SDK tool errors", async () => {
+    const privateText = "Input validation error: Invalid arguments for tool lookup-record: private provider detail"
+    const client = createEnterpriseMcpClient({
+      fetch: mockMcpFetch({ toolError: true, toolErrorText: privateText }),
+    })
+    await assert.rejects(
+      client.callTool({
+        connection: noAuthConnection(),
+        redirectUri: "https://den.example.test/callback",
+        toolName: "lookup-record",
+        arguments: {},
+      }),
+      (error: unknown) => {
+        assert.ok(error instanceof EnterpriseMcpClientError)
+        assert.ok(error.cause instanceof EnterpriseMcpToolResultError)
+        assert.deepEqual(error.cause.providerSignal, { category: "invalid_arguments" })
+        assert.doesNotMatch(JSON.stringify(error.cause), /private provider detail/)
         return true
       },
     )


### PR DESCRIPTION
## Summary

This PR adds **optional schema guidance** for connected MCP tools without turning OpenWork's local validation into a new execution gate.

Once the existing authentication, access, connection, and tool-existence checks pass, OpenWork **always attempts the downstream provider call**. The provider remains the source of truth: if it accepts a call that does not match its advertised schema, OpenWork returns that success. If it rejects the call, OpenWork returns the real provider error together with guidance that can help the agent correct and retry.

## How this avoids additional failures

The provider call is started **before** advisory validation. Local schema checking cannot reject, delay, or replace that call.

| Situation | Behavior |
| --- | --- |
| No schema digest supplied | Call proceeds normally |
| Provider schema changed after discovery | Call proceeds; optional drift guidance is attached |
| Arguments do not match the advertised schema | Call proceeds; optional issue guidance is attached |
| Provider advertises a malformed or unsupported schema | Call proceeds; OpenWork explains that local guidance was unavailable |
| Provider accepts the call | Provider success is returned; guidance does not trigger a retry |
| Provider rejects the call | Real provider failure is returned with guidance for a possible correction |
| Authentication, access, connection, or tool lookup fails | Existing hard failure remains unchanged |

`schemaDigest` is optional, and `schemaGuidance` is only present when OpenWork has something useful to report. This allows imperfect or unusually implemented MCP servers to keep working.

## Evidence that this does not introduce regressions

In the matched benchmark, there were **32 cases where only the PR succeeded and zero cases where only the base succeeded**. The PR therefore introduced no new failed matched outcome in this test matrix.

- Exact successful tasks: **13/48 without the PR → 45/48 with it**.
- Crowded 229-tool context: **2/9 → 9/9**.
- Deliberately incomplete first-call recovery: **0/9 → 9/9**.
- The nine invalid PR-side provider calls were intentional—one in each recovery test—and all nine corrected successfully. The other 39 PR sessions produced **zero unintended invalid provider calls**.
- Average completion time: **46.4 seconds → 21.1 seconds**.

The comparison used **96 fresh OpenWork sessions / 48 matched A/B pairs** with real GPT-5.4-mini, GPT-5.4, and GPT-5.5. Prompts, models, OpenWork agent configuration, OpenCode `1.17.11`, Den connection, provider state, expected answers, timeouts, grading, and tool context were identical. Only the OpenWork commit changed: base `b22399a` versus PR `8052abb`.

## Verification

- Exact-product benchmark: **15/15 integrity checks passed**; all 96 sessions completed and were independently regraded from provider events.
- Den API focused tests: **111 passed, 0 failed**.
- Enterprise MCP client tests: **46 passed, 0 failed**.
- Den API production build: passed.

The focused tests specifically cover provider success despite a local mismatch, provider rejection with guidance, schema drift, unavailable schema validation, authorization boundaries, and timeouts.

## Remaining limits

Keep this PR in draft. The PR still missed three of 48 benchmark tasks. Unusual JSON Schema dialects and very large schemas can make the optional guidance incomplete or expensive, but they no longer prevent a valid provider call. Electron UI/OAuth onboarding and remote-network provider behavior were not part of this benchmark.