### PR TITLE
fix(landing): ignore generic org installer in public downloads

### DIFF
--- a/ee/apps/landing/app/install-manifest.json/route.ts
+++ b/ee/apps/landing/app/install-manifest.json/route.ts
@@ -1,3 +1,5 @@
+import { isStandardDesktopAssetName } from "../../lib/desktop-release-assets";
+
 // GET /install-manifest.json
 //
 // Resolves the latest OpenWork desktop release on GitHub and returns an install
@@ -26,22 +28,8 @@ type ManifestArtifact = {
   appName?: string;
 };
 
-// Only treat OpenWork desktop-app installers as artifacts. The orchestrator
-// release ships sidecar/CLI binaries (openwork-server-*.exe,
-// openwork-bun-*) that must NOT be treated as the desktop app, so we positively
-// require the desktop app's OS-tagged naming (openwork-mac / openwork-linux /
-// openwork-win + an installer extension).
-const SIDECAR_HINTS = ["orchestrator", "server", "bun-", "sidecar", "opencode"];
-
 function isDesktopAppAsset(name: string): boolean {
-  const lower = name.toLowerCase();
-  if (!lower.startsWith("openwork")) return false;
-  // exclude update metadata / checksums
-  if (/\.(blockmap|yml|yaml|json|txt|sig|sha256)$/i.test(lower)) return false;
-  // exclude any sidecar/CLI binary that also happens to start with "openwork".
-  if (SIDECAR_HINTS.some((hint) => lower.includes(hint))) return false;
-  // require a desktop OS tag so we never pick up a stray asset.
-  return /(mac|darwin|osx|linux|win)/.test(lower);
+  return isStandardDesktopAssetName(name);
 }
 
 function artifactTypeFor(name: string): ManifestArtifact["type"] | null {

--- a/ee/apps/landing/lib/desktop-release-assets.ts
+++ b/ee/apps/landing/lib/desktop-release-assets.ts
@@ -1,0 +1,19 @@
+export type ReleaseAsset = {
+  name?: string;
+  browser_download_url?: string;
+};
+
+const DESKTOP_ASSET_PREFIXES = ["openwork-mac-", "openwork-win-", "openwork-linux-"];
+const NON_INSTALLER_EXTENSIONS = /\.(blockmap|yml|yaml|json|txt|sig|sha256)$/i;
+
+export function isStandardDesktopAssetName(name: string): boolean {
+  const lower = name.toLowerCase();
+  if (!DESKTOP_ASSET_PREFIXES.some((prefix) => lower.startsWith(prefix))) {
+    return false;
+  }
+  return !NON_INSTALLER_EXTENSIONS.test(lower);
+}
+
+export function isStandardDesktopAsset(asset: ReleaseAsset): asset is Required<ReleaseAsset> {
+  return Boolean(asset.name && asset.browser_download_url && isStandardDesktopAssetName(asset.name));
+}

--- a/ee/apps/landing/lib/github.ts
+++ b/ee/apps/landing/lib/github.ts
@@ -1,7 +1,4 @@
-type ReleaseAsset = {
-  name?: string;
-  browser_download_url?: string;
-};
+import { isStandardDesktopAsset, isStandardDesktopAssetName, type ReleaseAsset } from "./desktop-release-assets";
 
 type Release = {
   draft?: boolean;
@@ -31,11 +28,13 @@ const formatCompact = (value: number) => {
 const selectAsset = (
   assets: ReleaseAsset[],
   extensions: string[],
-  keywords: string[] = []
+  keywords: string[] = [],
+  options: { desktopOnly?: boolean } = {},
 ) => {
   const matches = assets.filter((asset) => {
     if (!asset?.name || !asset?.browser_download_url) return false;
     const name = asset.name.toLowerCase();
+    if (options.desktopOnly && !isStandardDesktopAssetName(name)) return false;
     const extensionMatch = extensions.some((ext) => name.endsWith(ext));
     const keywordMatch =
       keywords.length === 0 || keywords.some((key) => name.includes(key));
@@ -90,24 +89,16 @@ export const getGithubData = async () => {
       : "—";
 
   const releaseList = Array.isArray(releases) ? releases : [];
-  const isElectronDesktopAsset = (name: string) =>
-    name.startsWith("openwork-mac-") ||
-    name.startsWith("openwork-win-") ||
-    name.startsWith("openwork-linux-");
-
   const hasElectronDesktopAsset = (release: Release) => {
     const assets = Array.isArray(release?.assets) ? release.assets : [];
-    return assets.some((asset) => {
-      const name = String(asset?.name || "").toLowerCase();
-      return isElectronDesktopAsset(name);
-    });
+    return assets.some(isStandardDesktopAsset);
   };
 
   const hasWindowsDesktopAsset = (release: Release) => {
     const assets = Array.isArray(release?.assets) ? release.assets : [];
     return assets.some((asset) => {
       const name = String(asset?.name || "").toLowerCase();
-      return name.startsWith("openwork-win-x64-") && name.endsWith(".exe");
+      return isStandardDesktopAssetName(name) && name.startsWith("openwork-win-x64-") && name.endsWith(".exe");
     });
   };
 
@@ -133,20 +124,20 @@ export const getGithubData = async () => {
   const releaseUrl = pick?.html_url || FALLBACK_RELEASE;
   const windowsAssets = Array.isArray(windowsPick?.assets) ? windowsPick.assets : assets;
   const windowsReleaseUrl = windowsPick?.html_url || releaseUrl;
-  const dmg = selectAsset(assets, [".dmg"], ["openwork-mac-"]);
-  const exe = selectAsset(windowsAssets, [".exe"], ["openwork-win-"]);
-  const macosApple = selectAsset(assets, [".dmg"], ["mac-arm64"]);
-  const macosIntel = selectAsset(assets, [".dmg"], ["mac-x64"]);
+  const dmg = selectAsset(assets, [".dmg"], ["openwork-mac-"], { desktopOnly: true });
+  const exe = selectAsset(windowsAssets, [".exe"], ["openwork-win-"], { desktopOnly: true });
+  const macosApple = selectAsset(assets, [".dmg"], ["mac-arm64"], { desktopOnly: true });
+  const macosIntel = selectAsset(assets, [".dmg"], ["mac-x64"], { desktopOnly: true });
   const windowsX64 =
-    selectAsset(windowsAssets, [".exe"], ["win-x64"]) || exe;
-  const windowsArm64 = selectAsset(windowsAssets, [".exe"], ["win-arm64"]);
+    selectAsset(windowsAssets, [".exe"], ["win-x64"], { desktopOnly: true }) || exe;
+  const windowsArm64 = selectAsset(windowsAssets, [".exe"], ["win-arm64"], { desktopOnly: true });
 
   const linuxAppImageX64 =
-    selectAsset(assets, [".appimage"], ["linux-x86_64"]) ||
-    selectAsset(assets, [".appimage"], ["linux-x64"]);
-  const linuxAppImageArm64 = selectAsset(assets, [".appimage"], ["linux-arm64"]);
-  const linuxTarX64 = selectAsset(assets, [".tar.gz"], ["linux-x64"]);
-  const linuxTarArm64 = selectAsset(assets, [".tar.gz"], ["linux-arm64"]);
+    selectAsset(assets, [".appimage"], ["linux-x86_64"], { desktopOnly: true }) ||
+    selectAsset(assets, [".appimage"], ["linux-x64"], { desktopOnly: true });
+  const linuxAppImageArm64 = selectAsset(assets, [".appimage"], ["linux-arm64"], { desktopOnly: true });
+  const linuxTarX64 = selectAsset(assets, [".tar.gz"], ["linux-x64"], { desktopOnly: true });
+  const linuxTarArm64 = selectAsset(assets, [".tar.gz"], ["linux-arm64"], { desktopOnly: true });
 
   return {
     stars,

--- a/ee/apps/landing/tests/desktop-release-assets.test.ts
+++ b/ee/apps/landing/tests/desktop-release-assets.test.ts
@@ -1,0 +1,87 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import { GET } from "../app/install-manifest.json/route";
+import { isStandardDesktopAssetName } from "../lib/desktop-release-assets";
+import { getGithubData } from "../lib/github";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+function asset(name: string, url = `https://downloads.example.test/${name}`) {
+  return { name, browser_download_url: url };
+}
+
+function jsonResponse(payload: unknown) {
+  return new Response(JSON.stringify(payload), {
+    headers: { "content-type": "application/json" },
+  });
+}
+
+describe("desktop release asset selection", () => {
+  test("distinguishes public desktop installers from generic organization installers", () => {
+    expect(isStandardDesktopAssetName("openwork-win-x64-0.17.1.exe")).toBe(true);
+    expect(isStandardDesktopAssetName("openwork-mac-arm64-0.17.1.dmg")).toBe(true);
+    expect(isStandardDesktopAssetName("openwork-linux-x86_64-0.17.1.AppImage")).toBe(true);
+
+    expect(isStandardDesktopAssetName("openwork-installer-win-x64.exe")).toBe(false);
+    expect(isStandardDesktopAssetName("openwork-server-win-x64.exe")).toBe(false);
+    expect(isStandardDesktopAssetName("openwork-win-x64-0.17.1.exe.blockmap")).toBe(false);
+  });
+
+  test("landing downloads ignore generic installers even when GitHub lists them first", async () => {
+    const standardWindows = asset("openwork-win-x64-0.17.1.exe");
+    globalThis.fetch = async (input) => {
+      const url = String(input);
+      if (url.endsWith("/repos/different-ai/openwork")) {
+        return jsonResponse({ stargazers_count: 16200 });
+      }
+      if (url.endsWith("/releases/latest")) {
+        return jsonResponse({
+          draft: false,
+          prerelease: false,
+          tag_name: "v0.17.1",
+          html_url: "https://github.com/different-ai/openwork/releases/tag/v0.17.1",
+          assets: [
+            asset("openwork-installer-win-x64.exe"),
+            standardWindows,
+            asset("openwork-mac-arm64-0.17.1.dmg"),
+            asset("openwork-linux-x86_64-0.17.1.AppImage"),
+          ],
+        });
+      }
+      if (url.includes("/releases?")) {
+        return jsonResponse([]);
+      }
+      return new Response(null, { status: 404 });
+    };
+
+    const data = await getGithubData();
+
+    expect(data.downloads.windows).toBe(standardWindows.browser_download_url);
+    expect(data.installers.windows.x64).toBe(standardWindows.browser_download_url);
+  });
+
+  test("install manifest ignores generic installers when resolving Windows artifacts", async () => {
+    const standardWindows = asset("openwork-win-x64-0.17.1.exe");
+    globalThis.fetch = async () => jsonResponse([{
+      draft: false,
+      prerelease: false,
+      tag_name: "v0.17.1",
+      name: "v0.17.1",
+      assets: [
+        asset("openwork-installer-win-x64.exe"),
+        standardWindows,
+        asset("openwork-linux-x86_64-0.17.1.AppImage"),
+      ],
+    }]);
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.artifacts.win32.x64.url).toBe(standardWindows.browser_download_url);
+  });
+});

--- a/ee/apps/landing/tsconfig.json
+++ b/ee/apps/landing/tsconfig.json
@@ -30,6 +30,7 @@
     ".next/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "tests"
   ]
 }


### PR DESCRIPTION
Fixes #2695

## Summary
- Prevent public download surfaces from selecting the generic organization installer (`openwork-installer-win-x64.exe`) as a Windows desktop app installer
- Share one desktop release asset predicate between the landing download data and install manifest
- Add regression coverage for the case where GitHub lists the generic installer before the standard Windows installer

## Verification
- `pnpm --filter @openwork-ee/landing exec bun test tests/desktop-release-assets.test.ts`
- `pnpm --filter @openwork-ee/landing exec tsc -p tsconfig.json --noEmit`
- `git diff --check`

## Note
I could not reproduce the live /download page selecting the generic installer today because the current release data already points Windows downloads at `openwork-win-x64-0.17.32.exe`. This PR locks down the risky asset-selection path so public downloads and the install manifest ignore generic org installers even if asset ordering changes.