### PR TITLE
feat(session): show context usage in composer

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -20,6 +20,7 @@ import { listRunningAppsForMention } from "./app-mentions";
 import type { ComposerMentionKind } from "./mention-encoding";
 import { getSlashCommandQuery } from "./slash-command";
 import { FILE_URL_RE, HTTP_URL_RE } from "./pasted-text";
+import type { ContextUsage } from "../context-usage";
 
 type MentionItem = {
   id: string;
@@ -60,6 +61,7 @@ type ComposerProps = {
   disabled: boolean;
   modelUnavailable?: boolean;
   statusLabel: string;
+  contextUsage: ContextUsage | null;
   modelPickerOpen: boolean;
   selectedModel: ModelRef;
   onModelPickerOpenChange: (open: boolean) => void;
@@ -115,6 +117,18 @@ const DEFAULT_AGENT_NAME = "openwork";
 
 function isNonDefaultAgent(agent: Agent) {
   return agent.name !== DEFAULT_AGENT_NAME;
+}
+
+function contextUsageTextClass(tone: ContextUsage["tone"]) {
+  if (tone === "danger") return "text-red-10";
+  if (tone === "warning") return "text-amber-10";
+  return "text-gray-10";
+}
+
+function contextUsageBarClass(tone: ContextUsage["tone"]) {
+  if (tone === "danger") return "bg-red-9";
+  if (tone === "warning") return "bg-amber-9";
+  return "bg-gray-9";
 }
 
 /**
@@ -1642,6 +1656,27 @@ export function ReactSessionComposer(props: ComposerProps) {
                   onChange={props.onModelVariantChange}
                   disabled={props.busy}
                 />
+
+                {props.contextUsage ? (
+                  <div
+                    className="flex min-w-0 items-center gap-2 text-[11px]"
+                    data-testid="composer-context-usage"
+                    aria-label={`Context usage ${props.contextUsage.label}`}
+                  >
+                    <div className="h-1 w-16 shrink-0 overflow-hidden rounded-full bg-gray-4" aria-hidden>
+                      <div
+                        className={`h-full rounded-full ${contextUsageBarClass(props.contextUsage.tone)}`}
+                        style={{ width: `${props.contextUsage.percent}%` }}
+                      />
+                    </div>
+                    <span className={`truncate font-medium ${contextUsageTextClass(props.contextUsage.tone)}`}>
+                      {props.contextUsage.label}
+                    </span>
+                    {props.contextUsage.showCompactionHint ? (
+                      <span className="hidden shrink-0 font-medium text-red-10 sm:inline">Auto-compaction soon</span>
+                    ) : null}
+                  </div>
+                ) : null}
               </div>
 
               {/*

--- a/apps/app/src/react-app/domains/session/surface/context-usage.ts
+++ b/apps/app/src/react-app/domains/session/surface/context-usage.ts
@@ -4,6 +4,7 @@ import type { UIMessage } from "ai";
 import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
 import type { ModelRef } from "@/app/types";
 
+// UI-only fallback: real tokenization varies by model, especially for code-heavy transcripts.
 const ESTIMATED_CHARS_PER_TOKEN = 4;
 const WARNING_THRESHOLD = 70;
 const DANGER_THRESHOLD = 90;
@@ -31,6 +32,11 @@ export type ContextUsage = {
   tone: ContextUsageTone;
   isEstimate: boolean;
   showCompactionHint: boolean;
+};
+
+export type ContextTranscriptUsage = {
+  tokens: number;
+  isEstimate: boolean;
 };
 
 function positiveInteger(value: number | null | undefined) {
@@ -122,26 +128,37 @@ function compactTokenCount(tokens: number) {
   return String(tokens);
 }
 
-export function buildContextUsage(input: {
-  contextLimit: number | null | undefined;
+export function buildContextTranscriptUsage(input: {
   snapshot: OpenworkSessionSnapshot | null | undefined;
   renderedMessages?: UIMessage[] | null | undefined;
-  draftText: string;
-}): ContextUsage | null {
-  const limitTokens = positiveInteger(input.contextLimit);
-  if (limitTokens === null) return null;
-
+}): ContextTranscriptUsage {
   const reportedTokens = getLatestReportedContextTokens(input.snapshot);
-  const draftTokens = estimateTextTokens(input.draftText);
   const renderedEstimate = estimateRenderedMessageTokens(input.renderedMessages);
   const snapshotEstimate = estimateSnapshotTokens(input.snapshot);
   const liveTokensAfterSnapshot = estimateRenderedMessagesAfterSnapshot(input.snapshot, input.renderedMessages);
   const transcriptTokens = reportedTokens !== null
     ? reportedTokens + liveTokensAfterSnapshot
     : Math.max(snapshotEstimate, renderedEstimate);
+
+  return {
+    tokens: transcriptTokens,
+    isEstimate: liveTokensAfterSnapshot > 0 || (reportedTokens === null && transcriptTokens > 0),
+  };
+}
+
+export function buildContextUsage(input: {
+  contextLimit: number | null | undefined;
+  transcriptUsage: ContextTranscriptUsage;
+  draftText: string;
+}): ContextUsage | null {
+  const limitTokens = positiveInteger(input.contextLimit);
+  if (limitTokens === null) return null;
+
+  const draftTokens = estimateTextTokens(input.draftText);
+  const transcriptTokens = input.transcriptUsage.tokens;
   const usedTokens = Math.min(limitTokens, transcriptTokens + draftTokens);
   const percent = Math.min(100, Math.round((usedTokens / limitTokens) * 100));
-  const isEstimate = draftTokens > 0 || liveTokensAfterSnapshot > 0 || (reportedTokens === null && usedTokens > 0);
+  const isEstimate = draftTokens > 0 || input.transcriptUsage.isEstimate;
   const label = `ctx ${isEstimate ? "~" : ""}${compactTokenCount(usedTokens)} / ${compactTokenCount(limitTokens)} - ${percent}%`;
 
   return {

--- a/apps/app/src/react-app/domains/session/surface/context-usage.ts
+++ b/apps/app/src/react-app/domains/session/surface/context-usage.ts
@@ -1,0 +1,156 @@
+import type { Part } from "@opencode-ai/sdk/v2/client";
+import type { UIMessage } from "ai";
+
+import type { OpenworkSessionSnapshot } from "@/app/lib/openwork-server";
+import type { ModelRef } from "@/app/types";
+
+const ESTIMATED_CHARS_PER_TOKEN = 4;
+const WARNING_THRESHOLD = 70;
+const DANGER_THRESHOLD = 90;
+
+type ModelCatalog = {
+  all: readonly {
+    id: string;
+    models: {
+      readonly [modelId: string]: {
+        readonly limit?: {
+          readonly context: number;
+        };
+      } | undefined;
+    };
+  }[];
+};
+
+export type ContextUsageTone = "neutral" | "warning" | "danger";
+
+export type ContextUsage = {
+  usedTokens: number;
+  limitTokens: number;
+  percent: number;
+  label: string;
+  tone: ContextUsageTone;
+  isEstimate: boolean;
+  showCompactionHint: boolean;
+};
+
+function positiveInteger(value: number | null | undefined) {
+  if (typeof value !== "number" || !Number.isFinite(value) || value <= 0) return null;
+  return Math.ceil(value);
+}
+
+export function estimateTextTokens(text: string) {
+  const trimmed = text.trim();
+  if (!trimmed) return 0;
+  return Math.max(1, Math.ceil(trimmed.length / ESTIMATED_CHARS_PER_TOKEN));
+}
+
+function partText(part: Part) {
+  if (part.type === "text" && !part.synthetic && !part.ignored) return part.text;
+  if (part.type === "reasoning") return part.text;
+  if (part.type === "agent") return part.name;
+  if (part.type === "file") return [part.filename, part.mime].filter(Boolean).join(" ");
+  return "";
+}
+
+function estimateSnapshotTokens(snapshot: OpenworkSessionSnapshot | null | undefined) {
+  if (!snapshot) return 0;
+  const text = snapshot.messages
+    .flatMap((message) => message.parts.map(partText))
+    .filter(Boolean)
+    .join("\n");
+  return estimateTextTokens(text);
+}
+
+function uiPartText(part: UIMessage["parts"][number]) {
+  if ("text" in part && typeof part.text === "string") return part.text;
+  if (part.type === "file") return [part.filename, part.mediaType].filter(Boolean).join(" ");
+  if (part.type === "source-url") return [part.title, part.url].filter(Boolean).join(" ");
+  if (part.type === "source-document") return [part.title, part.filename, part.mediaType].filter(Boolean).join(" ");
+  return "";
+}
+
+function estimateRenderedMessageTokens(messages: UIMessage[] | null | undefined) {
+  if (!messages) return 0;
+  const text = messages
+    .flatMap((message) => message.parts.map(uiPartText))
+    .filter(Boolean)
+    .join("\n");
+  return estimateTextTokens(text);
+}
+
+function estimateRenderedMessagesAfterSnapshot(snapshot: OpenworkSessionSnapshot | null | undefined, messages: UIMessage[] | null | undefined) {
+  if (!snapshot || !messages) return 0;
+  const snapshotMessageIds = new Set(snapshot.messages.map((message) => message.info.id));
+  const liveMessages = messages.filter((message) => !snapshotMessageIds.has(message.id));
+  return estimateRenderedMessageTokens(liveMessages);
+}
+
+export function getLatestReportedContextTokens(snapshot: OpenworkSessionSnapshot | null | undefined) {
+  if (!snapshot) return null;
+  for (let index = snapshot.messages.length - 1; index >= 0; index -= 1) {
+    const message = snapshot.messages[index];
+    if (!message || message.info.role !== "assistant") continue;
+
+    const total = positiveInteger(message.info.tokens.total);
+    if (total !== null) return total;
+
+    const input = positiveInteger(message.info.tokens.input) ?? 0;
+    const output = positiveInteger(message.info.tokens.output) ?? 0;
+    const reasoning = positiveInteger(message.info.tokens.reasoning) ?? 0;
+    const combined = input + output + reasoning;
+    if (combined > 0) return combined;
+  }
+  return null;
+}
+
+export function getSelectedModelContextLimit(providerList: ModelCatalog | null | undefined, selectedModel: ModelRef | null | undefined) {
+  if (!providerList || !selectedModel) return null;
+  const provider = providerList.all.find((item) => item.id === selectedModel.providerID);
+  const context = provider?.models[selectedModel.modelID]?.limit?.context;
+  return positiveInteger(context);
+}
+
+export function getContextUsageTone(percent: number): ContextUsageTone {
+  if (percent >= DANGER_THRESHOLD) return "danger";
+  if (percent >= WARNING_THRESHOLD) return "warning";
+  return "neutral";
+}
+
+function compactTokenCount(tokens: number) {
+  if (tokens >= 1_000_000) return `${Number((tokens / 1_000_000).toFixed(1))}M`;
+  if (tokens >= 1_000) return `${Number((tokens / 1_000).toFixed(1))}k`;
+  return String(tokens);
+}
+
+export function buildContextUsage(input: {
+  contextLimit: number | null | undefined;
+  snapshot: OpenworkSessionSnapshot | null | undefined;
+  renderedMessages?: UIMessage[] | null | undefined;
+  draftText: string;
+}): ContextUsage | null {
+  const limitTokens = positiveInteger(input.contextLimit);
+  if (limitTokens === null) return null;
+
+  const reportedTokens = getLatestReportedContextTokens(input.snapshot);
+  const draftTokens = estimateTextTokens(input.draftText);
+  const renderedEstimate = estimateRenderedMessageTokens(input.renderedMessages);
+  const snapshotEstimate = estimateSnapshotTokens(input.snapshot);
+  const liveTokensAfterSnapshot = estimateRenderedMessagesAfterSnapshot(input.snapshot, input.renderedMessages);
+  const transcriptTokens = reportedTokens !== null
+    ? reportedTokens + liveTokensAfterSnapshot
+    : Math.max(snapshotEstimate, renderedEstimate);
+  const usedTokens = Math.min(limitTokens, transcriptTokens + draftTokens);
+  const percent = Math.min(100, Math.round((usedTokens / limitTokens) * 100));
+  const isEstimate = draftTokens > 0 || liveTokensAfterSnapshot > 0 || (reportedTokens === null && usedTokens > 0);
+  const label = `ctx ${isEstimate ? "~" : ""}${compactTokenCount(usedTokens)} / ${compactTokenCount(limitTokens)} - ${percent}%`;
+
+  return {
+    usedTokens,
+    limitTokens,
+    percent,
+    label,
+    tone: getContextUsageTone(percent),
+    isEstimate,
+    showCompactionHint: percent >= DANGER_THRESHOLD,
+  };
+}

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -52,7 +52,7 @@ import { deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from ".
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { isAttachmentFileReadable, resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/attachment-file-part";
 import { deriveSessionRenderModel } from "@/react-app/domains/session/sync/transition-controller";
-import { buildContextUsage } from "./context-usage";
+import { buildContextTranscriptUsage, buildContextUsage } from "./context-usage";
 import { useSessionScrollController } from "./scroll-controller";
 import { SessionScrollOverlay } from "./scroll-overlay";
 import { SessionFindBar } from "./find-bar";
@@ -799,14 +799,26 @@ export function SessionSurface(props: SessionSurfaceProps) {
     };
   }, [mentions, pasteParts]);
 
+  const contextTranscriptUsage = useMemo(
+    () => buildContextTranscriptUsage({
+      snapshot,
+      renderedMessages,
+    }),
+    [renderedMessages, snapshot],
+  );
+
+  const contextDraftText = useMemo(
+    () => resolveDraftContextText(draft, pasteParts, mentions),
+    [draft, mentions, pasteParts],
+  );
+
   const contextUsage = useMemo(
     () => buildContextUsage({
       contextLimit: props.selectedModelContextLimit,
-      snapshot,
-      renderedMessages,
-      draftText: resolveDraftContextText(draft, pasteParts, mentions),
+      transcriptUsage: contextTranscriptUsage,
+      draftText: contextDraftText,
     }),
-    [draft, mentions, pasteParts, props.selectedModelContextLimit, renderedMessages, snapshot],
+    [contextDraftText, contextTranscriptUsage, props.selectedModelContextLimit],
   );
 
   const handleComposerDraftChange = useCallback((value: string) => {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -52,6 +52,7 @@ import { deriveRenderedSessionMessages, resolveRenderedSessionSnapshot } from ".
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { isAttachmentFileReadable, resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/attachment-file-part";
 import { deriveSessionRenderModel } from "@/react-app/domains/session/sync/transition-controller";
+import { buildContextUsage } from "./context-usage";
 import { useSessionScrollController } from "./scroll-controller";
 import { SessionScrollOverlay } from "./scroll-overlay";
 import { SessionFindBar } from "./find-bar";
@@ -126,6 +127,7 @@ export type SessionSurfaceProps = {
   modelPickerOpen: boolean;
   modelUnavailable?: boolean;
   selectedModel: ModelRef;
+  selectedModelContextLimit: number | null;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
   onSendDraft: (draft: ComposerDraft, sessionId: string) => Promise<CloudMcpSubmissionResult>;
@@ -446,6 +448,18 @@ function mergeDrafts(drafts: ComposerDraft[]): ComposerDraft | null {
     resolvedText: resolvedTexts.join("\n\n"),
     command: undefined,
   };
+}
+
+function resolveDraftContextText(text: string, pasteParts: { label: string; text: string }[], mentions: Record<string, ComposerMentionKind>) {
+  let resolved = text;
+  for (const part of pasteParts) {
+    resolved = resolved.replace(`[pasted text ${part.label}]`, part.text);
+  }
+  resolved = resolved.replace(/\[skill ([^\]]+)\]/g, (_match, name: string) => `the \"${name}\" skill`);
+  for (const value of Object.keys(mentions)) {
+    resolved = resolved.replaceAll(`@${encodeComposerMentionValue(value)}`, `@${value}`);
+  }
+  return resolved;
 }
 
 export function SessionSurface(props: SessionSurfaceProps) {
@@ -784,6 +798,16 @@ export function SessionSurface(props: SessionSurfaceProps) {
       command: slashCommand ?? undefined,
     };
   }, [mentions, pasteParts]);
+
+  const contextUsage = useMemo(
+    () => buildContextUsage({
+      contextLimit: props.selectedModelContextLimit,
+      snapshot,
+      renderedMessages,
+      draftText: resolveDraftContextText(draft, pasteParts, mentions),
+    }),
+    [draft, mentions, pasteParts, props.selectedModelContextLimit, renderedMessages, snapshot],
+  );
 
   const handleComposerDraftChange = useCallback((value: string) => {
     setComposerDraft(props.sessionId, value);
@@ -1645,6 +1669,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         disabled={model.transitionState !== "idle" || Boolean(props.modelUnavailable)}
         modelUnavailable={Boolean(props.modelUnavailable)}
         statusLabel={statusLabel(snapshot ?? undefined, chatStreaming)}
+        contextUsage={contextUsage}
         modelPickerOpen={props.modelPickerOpen}
         selectedModel={props.selectedModel}
         onModelPickerOpenChange={props.onModelPickerOpenChange}

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -105,6 +105,7 @@ import { firstLineLocalFileParts, joinWorkspaceRelativePath, toFileUrl } from "@
 import { composerAttachmentsToWorkspaceFileParts } from "@/react-app/domains/session/sync/attachment-file-part";
 import { useSessionInteractions } from "@/react-app/domains/session/sync/use-session-interactions";
 import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-behavior";
+import { getSelectedModelContextLimit } from "@/react-app/domains/session/surface/context-usage";
 import { useSessionFindStore } from "@/react-app/domains/session/surface/find-store";
 import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
 import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
@@ -652,6 +653,10 @@ export function SessionRoute() {
   const selectedModelProviderList = selectedModelUsesCloudProvider
     ? cloudProviderList
     : providerListQuery.data;
+  const selectedModelContextLimit = useMemo(
+    () => getSelectedModelContextLimit(selectedModelProviderList, local.prefs.defaultModel),
+    [local.prefs.defaultModel, selectedModelProviderList],
+  );
   const selectedModelUnavailable = Boolean(
     selectedWorkspaceId &&
       opencodeClient &&
@@ -866,6 +871,7 @@ export function SessionRoute() {
       modelPickerOpen: modelPicker.compactOpen,
       modelUnavailable: selectedModelUnavailable,
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
+      selectedModelContextLimit,
       onModelPickerOpenChange: modelPicker.setCompactOpen,
       onModelChange: (model: ModelRef) => {
         local.setPrefs((previous) => ({
@@ -1060,6 +1066,7 @@ export function SessionRoute() {
     providerConnectedIds,
     selectedAgent,
     selectedSessionId,
+    selectedModelContextLimit,
     selectedModelUnavailable,
     selectedWorkspace,
     selectedWorkspaceId,

--- a/apps/app/tests/session-context-usage.test.ts
+++ b/apps/app/tests/session-context-usage.test.ts
@@ -1,0 +1,189 @@
+import { describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+
+import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
+import {
+  buildContextUsage,
+  estimateTextTokens,
+  getLatestReportedContextTokens,
+  getSelectedModelContextLimit,
+} from "../src/react-app/domains/session/surface/context-usage";
+
+function snapshot(messages: OpenworkSessionSnapshot["messages"]): OpenworkSessionSnapshot {
+  return {
+    session: {
+      id: "session-1",
+      slug: "session-1",
+      projectID: "project-1",
+      directory: "/workspace",
+      title: "Session",
+      version: "1.0.0",
+      time: { created: 1, updated: 1 },
+    },
+    messages,
+    todos: [],
+    status: { type: "idle" },
+  };
+}
+
+function assistantMessage(id: string, tokens: { total?: number; input: number; output: number; reasoning: number }): OpenworkSessionSnapshot["messages"][number] {
+  return {
+    info: {
+      id,
+      sessionID: "session-1",
+      role: "assistant",
+      time: { created: 1, completed: 2 },
+      parentID: "user-1",
+      modelID: "model-a",
+      providerID: "provider-a",
+      mode: "chat",
+      agent: "openwork",
+      path: { cwd: "/workspace", root: "/workspace" },
+      cost: 0,
+      tokens: {
+        ...tokens,
+        cache: { read: 0, write: 0 },
+      },
+    },
+    parts: [],
+  };
+}
+
+function uiTextMessage(id: string, role: UIMessage["role"], text: string): UIMessage {
+  return {
+    id,
+    role,
+    parts: [{
+      type: "text",
+      text,
+      state: "done",
+    }],
+  };
+}
+
+describe("session context usage", () => {
+  test("does not render usage without a known context limit", () => {
+    const usage = buildContextUsage({
+      contextLimit: null,
+      snapshot: snapshot([assistantMessage("assistant-1", { input: 60, output: 8, reasoning: 0 })]),
+      draftText: "abcdefgh",
+    });
+
+    expect(usage).toBeNull();
+  });
+
+  test("looks up the selected model context limit", () => {
+    const limit = getSelectedModelContextLimit({
+      all: [{
+        id: "provider-a",
+        models: {
+          "model-a": { limit: { context: 128_000 } },
+        },
+      }],
+    }, { providerID: "provider-a", modelID: "model-a" });
+
+    expect(limit).toBe(128_000);
+  });
+
+  test("uses the latest reported assistant token load instead of summing every turn", () => {
+    const contextSnapshot = snapshot([
+      assistantMessage("assistant-old", { input: 800, output: 100, reasoning: 0 }),
+      assistantMessage("assistant-new", { input: 450, output: 50, reasoning: 0 }),
+    ]);
+    const usage = buildContextUsage({
+      contextLimit: 1_000,
+      snapshot: contextSnapshot,
+      draftText: "",
+    });
+
+    expect(getLatestReportedContextTokens(contextSnapshot)).toBe(500);
+    expect(usage?.usedTokens).toBe(500);
+    expect(usage?.label).toBe("ctx 500 / 1k - 50%");
+    expect(usage?.isEstimate).toBe(false);
+  });
+
+  test("adds live rendered messages after the latest exact snapshot token load", () => {
+    const contextSnapshot = snapshot([
+      assistantMessage("assistant-old", { input: 450, output: 50, reasoning: 0 }),
+    ]);
+    const usage = buildContextUsage({
+      contextLimit: 1_000,
+      snapshot: contextSnapshot,
+      renderedMessages: [
+        uiTextMessage("assistant-old", "assistant", "already persisted"),
+        uiTextMessage("assistant-live", "assistant", "abcdefgh"),
+      ],
+      draftText: "",
+    });
+
+    expect(usage?.usedTokens).toBe(502);
+    expect(usage?.label).toBe("ctx ~502 / 1k - 50%");
+    expect(usage?.isEstimate).toBe(true);
+  });
+
+  test("uses rendered transcript estimate when the snapshot is behind", () => {
+    const usage = buildContextUsage({
+      contextLimit: 1_000,
+      snapshot: snapshot([]),
+      renderedMessages: [
+        uiTextMessage("user-live", "user", "abcdefghijkl"),
+        uiTextMessage("assistant-live", "assistant", "abcdefghijkl"),
+      ],
+      draftText: "",
+    });
+
+    expect(usage?.usedTokens).toBe(7);
+    expect(usage?.label).toBe("ctx ~7 / 1k - 1%");
+  });
+
+  test("marks draft text as estimated and moves into warning state", () => {
+    const usage = buildContextUsage({
+      contextLimit: 100,
+      snapshot: snapshot([assistantMessage("assistant-1", { input: 60, output: 8, reasoning: 0 })]),
+      draftText: "abcdefgh",
+    });
+
+    expect(estimateTextTokens("abcdefgh")).toBe(2);
+    expect(usage?.usedTokens).toBe(70);
+    expect(usage?.label).toBe("ctx ~70 / 100 - 70%");
+    expect(usage?.tone).toBe("warning");
+  });
+
+  test("falls back to visible text estimate when no reported assistant tokens exist", () => {
+    const usage = buildContextUsage({
+      contextLimit: 1_000,
+      snapshot: snapshot([{
+        info: {
+          id: "user-1",
+          sessionID: "session-1",
+          role: "user",
+          time: { created: 1 },
+          agent: "openwork",
+          model: { providerID: "provider-a", modelID: "model-a" },
+        },
+        parts: [{
+          id: "part-1",
+          sessionID: "session-1",
+          messageID: "user-1",
+          type: "text",
+          text: "abcdefghijkl",
+        }],
+      }]),
+      draftText: "",
+    });
+
+    expect(usage?.usedTokens).toBe(3);
+    expect(usage?.label).toBe("ctx ~3 / 1k - 0%");
+  });
+
+  test("warns about compaction near the model limit", () => {
+    const usage = buildContextUsage({
+      contextLimit: 100,
+      snapshot: snapshot([assistantMessage("assistant-1", { total: 95, input: 0, output: 0, reasoning: 0 })]),
+      draftText: "",
+    });
+
+    expect(usage?.tone).toBe("danger");
+    expect(usage?.showCompactionHint).toBe(true);
+  });
+});

--- a/apps/app/tests/session-context-usage.test.ts
+++ b/apps/app/tests/session-context-usage.test.ts
@@ -3,6 +3,7 @@ import type { UIMessage } from "ai";
 
 import type { OpenworkSessionSnapshot } from "../src/app/lib/openwork-server";
 import {
+  buildContextTranscriptUsage,
   buildContextUsage,
   estimateTextTokens,
   getLatestReportedContextTokens,
@@ -61,9 +62,25 @@ function uiTextMessage(id: string, role: UIMessage["role"], text: string): UIMes
   };
 }
 
+function buildUsage(input: {
+  contextLimit: number | null;
+  snapshot: OpenworkSessionSnapshot | null;
+  renderedMessages?: UIMessage[];
+  draftText: string;
+}) {
+  return buildContextUsage({
+    contextLimit: input.contextLimit,
+    transcriptUsage: buildContextTranscriptUsage({
+      snapshot: input.snapshot,
+      renderedMessages: input.renderedMessages,
+    }),
+    draftText: input.draftText,
+  });
+}
+
 describe("session context usage", () => {
   test("does not render usage without a known context limit", () => {
-    const usage = buildContextUsage({
+    const usage = buildUsage({
       contextLimit: null,
       snapshot: snapshot([assistantMessage("assistant-1", { input: 60, output: 8, reasoning: 0 })]),
       draftText: "abcdefgh",
@@ -90,7 +107,7 @@ describe("session context usage", () => {
       assistantMessage("assistant-old", { input: 800, output: 100, reasoning: 0 }),
       assistantMessage("assistant-new", { input: 450, output: 50, reasoning: 0 }),
     ]);
-    const usage = buildContextUsage({
+    const usage = buildUsage({
       contextLimit: 1_000,
       snapshot: contextSnapshot,
       draftText: "",
@@ -106,7 +123,7 @@ describe("session context usage", () => {
     const contextSnapshot = snapshot([
       assistantMessage("assistant-old", { input: 450, output: 50, reasoning: 0 }),
     ]);
-    const usage = buildContextUsage({
+    const usage = buildUsage({
       contextLimit: 1_000,
       snapshot: contextSnapshot,
       renderedMessages: [
@@ -122,7 +139,7 @@ describe("session context usage", () => {
   });
 
   test("uses rendered transcript estimate when the snapshot is behind", () => {
-    const usage = buildContextUsage({
+    const usage = buildUsage({
       contextLimit: 1_000,
       snapshot: snapshot([]),
       renderedMessages: [
@@ -137,7 +154,7 @@ describe("session context usage", () => {
   });
 
   test("marks draft text as estimated and moves into warning state", () => {
-    const usage = buildContextUsage({
+    const usage = buildUsage({
       contextLimit: 100,
       snapshot: snapshot([assistantMessage("assistant-1", { input: 60, output: 8, reasoning: 0 })]),
       draftText: "abcdefgh",
@@ -149,8 +166,30 @@ describe("session context usage", () => {
     expect(usage?.tone).toBe("warning");
   });
 
+  test("reuses transcript usage while only adding the current draft estimate", () => {
+    const transcriptUsage = buildContextTranscriptUsage({
+      snapshot: snapshot([assistantMessage("assistant-1", { input: 40, output: 10, reasoning: 0 })]),
+    });
+
+    const emptyDraftUsage = buildContextUsage({
+      contextLimit: 100,
+      transcriptUsage,
+      draftText: "",
+    });
+    const nextDraftUsage = buildContextUsage({
+      contextLimit: 100,
+      transcriptUsage,
+      draftText: "abcdefgh",
+    });
+
+    expect(transcriptUsage.tokens).toBe(50);
+    expect(emptyDraftUsage?.usedTokens).toBe(50);
+    expect(nextDraftUsage?.usedTokens).toBe(52);
+    expect(nextDraftUsage?.isEstimate).toBe(true);
+  });
+
   test("falls back to visible text estimate when no reported assistant tokens exist", () => {
-    const usage = buildContextUsage({
+    const usage = buildUsage({
       contextLimit: 1_000,
       snapshot: snapshot([{
         info: {
@@ -177,7 +216,7 @@ describe("session context usage", () => {
   });
 
   test("warns about compaction near the model limit", () => {
-    const usage = buildContextUsage({
+    const usage = buildUsage({
       contextLimit: 100,
       snapshot: snapshot([assistantMessage("assistant-1", { total: 95, input: 0, output: 0, reasoning: 0 })]),
       draftText: "",


### PR DESCRIPTION
Fixes #2724

Summary
- Adds a compact context usage indicator to the session composer using the selected model's `limit.context`.
- Uses the latest reported assistant message tokens as the completed-turn baseline, then estimates the unsent draft text.
- Shows warning/danger styling and an `Auto-compaction soon` hint near the context limit.

Verification
- `pnpm --filter @openwork/app exec bun test tests/session-context-usage.test.ts`
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app test`
- `git diff --check`

Manual UI note
- The local session composer now shows a `ctx ...` usage row for models with a known context limit.
- Browser automation was not available in my local Codex session, so I will attach a screenshot/video after manual browser verification.