### PR TITLE
fix(chat): allow partial selection of user messages

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -483,6 +483,7 @@ const UserMessage = React.memo(
       >
         <ContextMenu>
           <ContextMenuTrigger
+            className="select-text"
             render={
               <div className="group flex w-full flex-col items-end gap-1">
                 {message.parts.filter(isFileUIPart).map((part, index) => (
@@ -491,7 +492,7 @@ const UserMessage = React.memo(
                 {message.parts.some((part) => part.type === "text" && part.text) ? (
                   <MessageContent
                     layoutId={message.id}
-                    className="bg-muted text-foreground max-w-[85%] rounded-3xl px-5 py-2.5 whitespace-pre-wrap sm:max-w-[75%]"
+                    className="bg-muted text-foreground max-w-[85%] select-text rounded-3xl px-5 py-2.5 whitespace-pre-wrap sm:max-w-[75%]"
                   >
                     {renderUserTextWithSkillChips(message.parts.map((part) => (part.type === "text" ? part.text : "")).join(""), highlightQuery)}
                   </MessageContent>


### PR DESCRIPTION
## Summary

Fixes partial text selection for sent user messages in chat.

User messages were wrapped by the message context-menu trigger, which applies `select-none`. This made it impossible to select/copy only part of a sent prompt. The fix overrides that behavior for user-message text while keeping the existing right-click menu and whole-message copy actions.

## Testing

- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/app test` — passed, 350 tests
- `git diff --check` — passed

## Manual verification

Verified locally by sending a long prompt and selecting only part of the rendered user message. Partial selection now works, and the existing copy/context-menu actions still work.

## Rollback

Revert this PR.