### PR TITLE
fix(cloud): dedupe plugin listings and auto-install on sync

### DIFF
--- a/apps/app/src/app/cloud/desktop-cloud-sync.ts
+++ b/apps/app/src/app/cloud/desktop-cloud-sync.ts
@@ -9,7 +9,7 @@ import type {
   OpenworkServerClient,
 } from "../lib/openwork-server";
 
-export type PendingCloudPluginChange = "modified" | "removed";
+export type PendingCloudPluginChange = "new" | "modified" | "removed";
 
 type InstalledCloudPluginLike = {
   updatedAt: string | null;

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -581,12 +581,23 @@ export function isLegacyWebAppMcpUrl(input: string | null | undefined): boolean 
  * them verbatim. Returns null when the resource is unusable so callers
  * can keep their bootstrap-derived URL.
  */
+function isLocalhostHostname(hostname: string): boolean {
+  const normalized = hostname.trim().toLowerCase();
+  return (
+    normalized === "localhost" ||
+    normalized === "127.0.0.1" ||
+    normalized === "::1" ||
+    normalized === "[::1]"
+  );
+}
+
 export function resolveCloudMcpResourceUrl(resource: string | null | undefined): string | null {
   const trimmed = resource?.trim() ?? "";
   if (!trimmed) return null;
   try {
     const url = new URL(trimmed);
     if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+    if (isLocalhostHostname(url.hostname)) return null;
     if (isLegacyWebAppMcpUrl(trimmed)) {
       url.pathname = "/api/den/mcp";
     }

--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -177,7 +177,18 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
     };
   });
 
-  const cloudPluginItems = input.cloudMarketplaces.flatMap((marketplace) => marketplace.plugins.map((plugin): ExtensionItem => {
+  // Dedupe plugins that appear in multiple marketplaces — same plugin id should
+  // render once in the Connect panel. Iterate newest marketplace first so the most
+  // recently updated copy of the plugin wins when duplicated across marketplaces.
+  const seenCloudPluginIds = new Set<string>();
+  const marketplacesByRecency = [...input.cloudMarketplaces].sort((a, b) => {
+    const aUpdatedAt = a.marketplace.updatedAt ? Date.parse(a.marketplace.updatedAt) : 0;
+    const bUpdatedAt = b.marketplace.updatedAt ? Date.parse(b.marketplace.updatedAt) : 0;
+    return bUpdatedAt - aUpdatedAt;
+  });
+  const cloudPluginItems = marketplacesByRecency.flatMap((marketplace) => marketplace.plugins.flatMap((plugin): ExtensionItem[] => {
+    if (seenCloudPluginIds.has(plugin.id)) return [];
+    seenCloudPluginIds.add(plugin.id);
     const imported = input.importedCloudPlugins[plugin.id] ?? null;
     const manifest = plugin.extension?.manifest ?? undefined;
     const enablement = manifest?.enablement ? evaluateEnablement(manifest.enablement, input.enablementContext) : null;
@@ -193,7 +204,7 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
       : connectionStates.every(Boolean)
         ? "ready"
         : "needs_setup";
-    return {
+    return [{
       id: `marketplace:${marketplace.marketplace.id}:${plugin.id}`,
       source: "marketplace",
       name: plugin.extension?.name ?? plugin.name,
@@ -211,7 +222,7 @@ export function buildExtensionItems(input: ExtensionItemBuildInput) {
       marketplaceName: marketplace.marketplace.name,
       plugin,
       importedPlugin: imported,
-    };
+    }];
   }));
 
   const importedPluginItems = Object.values(input.importedCloudPlugins).flatMap((plugin): ExtensionItem[] => {

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -243,8 +243,11 @@ export function CloudMarketplacesView({
   ), [extensionItems]);
   const lastRowsRef = React.useRef<MarketplaceRow[]>([]);
   const cloudRows = React.useMemo<MarketplacePackageRow[]>(() => {
+    const seenIds = new Set<string>();
     return marketplaces.flatMap((marketplace) => marketplace.plugins.flatMap((plugin) => {
       if (!includeCloudMarketplaceRows) return [];
+      if (seenIds.has(plugin.id)) return [];
+      seenIds.add(plugin.id);
       const imported = importedPlugins[plugin.id] ?? null;
       const composition = pluginComposition(plugin);
       const counts = pluginCounts(plugin);

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -516,9 +516,12 @@ export function buildConnectRows(input: {
     connection,
   }));
 
+  const pluginSeenIds = new Set<string>();
   const pluginRows: ConnectOrganizationRow[] = marketplaceItems.flatMap((item) => {
     const group = resolveConnectRowGroup(item.plugin.cloudReadiness, input.role, item.plugin.componentCounts);
     if (group === "excluded") return [];
+    if (pluginSeenIds.has(item.plugin.id)) return [];
+    pluginSeenIds.add(item.plugin.id);
     return [{
       kind: "plugin",
       id: item.plugin.id,

--- a/apps/app/src/react-app/domains/settings/state/extensions-store.ts
+++ b/apps/app/src/react-app/domains/settings/state/extensions-store.ts
@@ -420,6 +420,7 @@ export function createExtensionsStore(options: {
   let refreshCloudOrgMarketplacesInFlight = false;
   let refreshCloudOrgSkillsInFlightKey = "";
   let refreshCloudOrgMarketplacesInFlightKey = "";
+  let autoInstallNewPluginsInFlight = false;
   let refreshSkillsAborted = false;
   let refreshPluginsAborted = false;
   let refreshHubSkillsAborted = false;
@@ -706,8 +707,66 @@ export function createExtensionsStore(options: {
           });
         }
       }
+
+      // ponytail: auto-install new cloud plugins detected by sync.
+      // Runs silently (no busy/error UI). Once installed, the next sync
+      // no longer marks the plugin as "new", so this is self-deduping.
+      const installedMap = installedPlugins ?? snapshot.importedCloudPlugins;
+      const newPluginChanges = changes.filter(
+        (c): c is typeof c & { marketplaceId: string } =>
+          c.resourceKind === "plugin"
+          && c.kind === "new"
+          && typeof c.marketplaceId === "string"
+          && c.marketplaceId.length > 0
+          && !installedMap[c.id],
+      );
+      if (newPluginChanges.length > 0) {
+        void autoInstallNewCloudPlugins(newPluginChanges);
+      }
     } catch {
       // keep previous pending state on failure
+    }
+  };
+
+  // ponytail: silent bulk-installer for new cloud plugins detected by sync.
+  // Mirrors importCloudOrgPlugin's inner install call but skips busy/error UI.
+  const autoInstallNewCloudPlugins = async (
+    newChanges: Array<{ id: string; marketplaceId: string }>,
+  ) => {
+    if (autoInstallNewPluginsInFlight) return;
+    autoInstallNewPluginsInFlight = true;
+    try {
+      const settings = readDenSettings();
+      const token = settings.authToken?.trim() ?? "";
+      const orgId = settings.activeOrgId?.trim() ?? "";
+      if (!token || !orgId) return;
+      const target = await resolveWorkspaceServerTarget();
+      if (!target.openworkClient || !target.openworkWorkspaceId) return;
+      const denClient = createDenClient({ baseUrl: settings.baseUrl, token });
+
+      for (const change of newChanges) {
+        // Re-check installed state; a prior iteration may have just installed it.
+        if (snapshot.importedCloudPlugins[change.id]) continue;
+        const marketplaceResolved = snapshot.cloudOrgMarketplaces.find(
+          (entry) => entry.marketplace.id === change.marketplaceId,
+        );
+        const plugin = marketplaceResolved?.plugins.find((p) => p.id === change.id);
+        if (!plugin) continue;
+        try {
+          const resolved = await denClient.getOrgPluginResolved(orgId, plugin);
+          const marketplace = marketplaceResolved?.marketplace ?? null;
+          await target.openworkClient.installCloudPlugin(target.openworkWorkspaceId, {
+            marketplaceId: change.marketplaceId,
+            marketplace,
+            resolved,
+          });
+        } catch {
+          // continue with the next plugin; failure is non-fatal
+        }
+      }
+      await refreshImportedCloudPlugins();
+    } finally {
+      autoInstallNewPluginsInFlight = false;
     }
   };
 

--- a/apps/app/tests/extension-items.test.ts
+++ b/apps/app/tests/extension-items.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from "bun:test";
 
 import type { McpDirectoryInfo } from "../src/app/constants";
-import type { DenExternalMcpConnection } from "../src/app/lib/den";
+import type { DenExternalMcpConnection, DenOrgPlugin } from "../src/app/lib/den";
 import type { McpServerEntry } from "../src/app/types";
 import { buildExtensionItems } from "../src/react-app/domains/settings/extension-items";
 
@@ -72,7 +72,59 @@ function orgMcpConnection(input: Partial<DenExternalMcpConnection> = {}): DenExt
   };
 }
 
+function marketplace(input: Partial<{ id: string; name: string; updatedAt: string; plugins: DenOrgPlugin[] }> = {}) {
+  return {
+    marketplace: {
+      id: input.id ?? "mkt_test",
+      name: input.name ?? "Test Marketplace",
+      description: null,
+      status: "active",
+      pluginCount: input.plugins?.length ?? 0,
+      updatedAt: input.updatedAt ?? "2026-07-19T00:00:00.000Z",
+    },
+    plugins: input.plugins ?? [],
+  };
+}
+
+function plugin(input: Partial<DenOrgPlugin> = {}): DenOrgPlugin {
+  return {
+    id: input.id ?? "plg_test",
+    name: input.name ?? "Test Plugin",
+    description: input.description ?? null,
+    status: input.status ?? "active",
+    memberCount: input.memberCount ?? 0,
+    updatedAt: input.updatedAt ?? "2026-07-19T00:00:00.000Z",
+    componentCounts: input.componentCounts ?? {},
+    extension: input.extension ?? null,
+    cloudReadiness: input.cloudReadiness,
+  };
+}
+
 describe("extension item projection", () => {
+  test("dedupes cloud plugins that appear in multiple marketplaces", () => {
+    const benhvienPhuTho = plugin({
+      id: "plg_benhvienphutho",
+      name: "benhvienphutho-skills",
+      memberCount: 12,
+      componentCounts: { skill: 12 },
+    });
+    const result = buildExtensionItems({
+      quickConnect: [],
+      mcpServers: [],
+      installedSkills: [],
+      importedCloudPlugins: {},
+      cloudMarketplaces: [
+        marketplace({ id: "mkt_old", name: "Old Marketplace", updatedAt: "2026-07-15T00:00:00.000Z", plugins: [benhvienPhuTho] }),
+        marketplace({ id: "mkt_new", name: "New Marketplace", updatedAt: "2026-07-19T00:00:00.000Z", plugins: [benhvienPhuTho] }),
+      ],
+      enablementContext: {},
+      isBuiltInConnected: () => false,
+    });
+
+    const cloudItems = result.items.filter((item) => item.source === "marketplace");
+    expect(cloudItems.map((item) => item.marketplaceId)).toEqual(["mkt_new"]);
+  });
+
   test("keeps unconnected built-ins out of My Extensions quick connect", () => {
     const result = buildExtensionItems({
       quickConnect: [connectedBuiltIn, availableBuiltIn],

--- a/apps/server/src/desktop-cloud-sync.ts
+++ b/apps/server/src/desktop-cloud-sync.ts
@@ -426,6 +426,8 @@ function diffInstalledCloudResources(
     });
   }
 
+  const installedPluginIds = new Set(Object.keys(cloudImports.plugins));
+
   for (const plugin of Object.values(cloudImports.plugins)) {
     const remote = findRemotePlugin(snapshot, { marketplaceId: plugin.marketplaceId, pluginId: plugin.pluginId });
     queueInstalledChange({
@@ -449,6 +451,23 @@ function diffInstalledCloudResources(
         queuedAt,
         remoteLastUpdatedAt: remoteConfigItem?.lastUpdatedAt ?? null,
         resourceKind: "configItem",
+      });
+    }
+  }
+
+  // Also detect remote plugins that aren't installed yet — surface them as "new"
+  // so the client can prompt the user to install.
+  for (const [marketplaceId, marketplace] of Object.entries(snapshot.resources.marketplaces)) {
+    for (const remotePlugin of marketplace.plugins) {
+      if (installedPluginIds.has(remotePlugin.pluginId)) continue;
+      queueInstalledChange({
+        changes,
+        id: remotePlugin.pluginId,
+        installedLastUpdatedAt: null,
+        marketplaceId,
+        queuedAt,
+        remoteLastUpdatedAt: remotePlugin.lastUpdatedAt,
+        resourceKind: "plugin",
       });
     }
   }

--- a/apps/server/src/skills.ts
+++ b/apps/server/src/skills.ts
@@ -1,4 +1,4 @@
-import { readdir, readFile, writeFile, mkdir, rm } from "node:fs/promises";
+import { readdir, readFile, writeFile, mkdir, rm, stat } from "node:fs/promises";
 import type { Dirent } from "node:fs";
 import { dirname, join, resolve } from "node:path";
 import { homedir } from "node:os";
@@ -8,6 +8,17 @@ import { exists } from "./utils.js";
 import { validateDescription, validateSkillName } from "./validators.js";
 import { ApiError } from "./errors.js";
 import { projectSkillsDir } from "./workspace-files.js";
+
+async function isDir(entry: Dirent, parent: string): Promise<boolean> {
+  if (entry.isDirectory()) return true;
+  if (entry.isSymbolicLink()) {
+    try {
+      const s = await stat(join(parent, entry.name));
+      return s.isDirectory();
+    } catch { return false; }
+  }
+  return false;
+}
 
 async function findWorkspaceRoots(workspaceRoot: string): Promise<string[]> {
   const roots: string[] = [];
@@ -86,7 +97,7 @@ async function listSkillsInDir(dir: string, scope: "project" | "global"): Promis
   const entries = await readdir(dir, { withFileTypes: true });
   const items: SkillItem[] = [];
   for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
+    if (!(await isDir(entry, dir))) continue;
     const skillPath = join(dir, entry.name, "SKILL.md");
     if (await exists(skillPath)) {
       // Direct skill: <dir>/<name>/SKILL.md
@@ -105,7 +116,7 @@ async function listSkillsInDir(dir: string, scope: "project" | "global"): Promis
         continue;
       }
       for (const subEntry of subEntries) {
-        if (!subEntry.isDirectory()) continue;
+        if (!(await isDir(subEntry, domainDir))) continue;
         const subSkillPath = join(domainDir, subEntry.name, "SKILL.md");
         if (!(await exists(subSkillPath))) continue;
         const item = await parseSkillEntry(subSkillPath, subEntry.name, scope);


### PR DESCRIPTION
## Summary
- Dedupe cloud plugins across marketplaces in the Connect panel, marketplace view, and extension items
- Auto-install new cloud plugins detected by desktop-cloud-sync, silently in the background
- Reject localhost hostnames in `resolveCloudMcpResourceUrl` to stop persisting dev URLs (e.g. `http://127.0.0.1:8788`) as the cloud MCP endpoint
- Surface uninstalled remote plugins as `kind: "new"` pending changes in the snapshot diff
- Make skill directory detection symlink-aware so symlinked skill dirs are listed

## Why
Cloud plugin sync had four rough edges:
1. The same plugin would appear multiple times in Connect when listed under multiple marketplaces.
2. New plugins detected by sync required a manual click to install — even though the user joined the org that provides them, which is already an opt-in.
3. A misconfigured Den token resource (localhost URL from dev environments) could get persisted as the production cloud MCP endpoint, breaking Agent access with a confusing "Degraded" status.
4. Symlinked skill directories (common in dotfile-managed setups) were silently dropped from the skill list.

## Issue
- N/A (no tracking issue)

## Scope
- `apps/app/src/app/lib/den.ts` — `resolveCloudMcpResourceUrl` rejects localhost hostnames
- `apps/app/src/app/cloud/desktop-cloud-sync.ts` — `PendingCloudPluginChange` type gains `"new"`
- `apps/app/src/react-app/domains/settings/state/extensions-store.ts` — `autoInstallNewCloudPlugins` runs after sync detects new plugins
- `apps/app/src/react-app/domains/settings/extension-items.ts` — dedupe by plugin id, marketplaces iterated newest-first
- `apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx` — `seenIds` dedupe in `cloudRows`
- `apps/app/src/react-app/domains/settings/pages/connect-view.tsx` — `pluginSeenIds` dedupe in `buildConnectRows`
- `apps/app/tests/extension-items.test.ts` — coverage for dedupe behavior
- `apps/server/src/desktop-cloud-sync.ts` — detect uninstalled remote plugins in snapshot diff
- `apps/server/src/skills.ts` — `isDir()` helper follows symlinks

## Out of scope
- Auto-handling of `"modified"` and `"removed"` pending changes (still surface as notifications with a manual action)
- Per-plugin opt-in for auto-install (currently unconditional for signed-in org members)
- Server-side validation that rejects localhost URLs during reconcile (intentionally not added — breaks mock-engine e2e tests; client-side guard is sufficient)

## Testing
### Ran
- `pnpm --filter @openwork/app typecheck`
- `bun test apps/app/src/ apps/server/src/cloud-mcp-health.test.ts apps/server/src/cloud-mcp-reconcile.e2e.test.ts apps/server/src/desktop-cloud-sync.test.ts apps/app/src/app/lib/den-endpoint-sources.test.ts apps/app/src/react-app/domains/settings/pages/connect-view.test.ts apps/app/src/react-app/domains/settings/extension-items.test.ts`
- Pre-push hook ran the full app build (typecheck + vite build + electron build)

### Result
- pass: typecheck, build, and all targeted tests
- 4 pre-existing failures in `apps/server/src/extensions-export.test.ts` unrelated to this change (token redaction shape mismatch)

## CI status
- pass: pending CI run
- code-related failures: none expected
- external/env blockers: none

## Manual verification
1. Sign in to a cloud org with marketplace plugins
2. Confirm plugins install automatically shortly after sign-in (no manual click needed)
3. Confirm a plugin listed in multiple marketplaces shows once in Connect → Organization
4. Confirm a Den token with a `127.0.0.1` resource no longer overwrites the cloud MCP URL
5. Confirm a symlinked `~/.config/opencode/skills/<name>` directory appears in the skill list

## Evidence
- N/A (code-only; manual verification steps above)

## Risk
- **Auto-install changes user behavior**: users who previously relied on the click-to-install prompt will see plugins appear automatically. Mitigation: only runs for plugins already visible in the user's org marketplaces (i.e. admin-approved). Failures are silent and non-blocking.
- **Localhost rejection is one-way**: any environment currently relying on a localhost MCP resource URL will stop working. Mitigation: only affects dev/test setups; production cloud URLs are not localhost.

## Rollback
Revert this commit. Each change is isolated to its own file/function and does not migrate persisted state.