### PR TITLE
fix: include x64 node-pty native dep in cross-compiled macOS builds

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -362,6 +362,11 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+        env:
+          # Cross-compilation: x64 build on ARM runner — install x64 optional deps too.
+          # Without this, @lydell/node-pty-darwin-x64 (a transitive optionalDependency)
+          # is skipped because the host arch is arm64, causing a crash on Intel Macs.
+          npm_config_supported_architectures_cpu: "x64,arm64"
 
       - name: Write Electron notary API key (macOS)
         if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -33,6 +33,10 @@
     "yaml": "^2.6.1",
     "zod": "^4.3.6"
   },
+  "optionalDependencies": {
+    "@lydell/node-pty-darwin-arm64": "1.2.0-beta.12",
+    "@lydell/node-pty-darwin-x64": "1.2.0-beta.12"
+  },
   "devDependencies": {
     "@openwork/types": "workspace:*",
     "electron": "^35.0.0",


### PR DESCRIPTION
## Problem

The x64 macOS release DMG crashes on Intel Macs because `@lydell/node-pty-darwin-x64` is missing from the packaged app.

**Root cause:** The release workflow builds both macOS archs on `macos-14` (ARM) runners. pnpm only installs optionalDependencies matching the host architecture, so the x64 binary (a transitive optionalDependency of `@lydell/node-pty`) is never installed during cross-compilation.

The `asarUnpack` config was correct — there was simply no x64 binary to unpack.

## Fix

Two changes:

1. **CI workflow** (`.github/workflows/release-macos-aarch64.yml`): Set `supportedArchitectures.cpu` to `"x64,arm64"` during CI dependency install so pnpm resolves optionalDeps for both architectures on the ARM runner.

2. **Desktop package.json**: Add platform-specific binaries as direct `optionalDependencies` for defense-in-depth.

## Verification

I built v0.17.32 from source on an Intel Mac (not cross-compiled). The resulting DMG contains the missing native module and launches correctly:

```
# Before (official v0.17.32 x64 release): crash on launch
# After (local build):
OpenWork.app/Contents/Resources/app.asar.unpacked/node_modules/@lydell/node-pty-darwin-x64/... ✅
```

The Electron process runs, the opencode sidecar (`x86_64-apple-darwin`) loads, and the UI renders without error.

Fixes #___ (add issue number if one exists)