### PR TITLE
fix(den): prevent MCP credential autofill

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -27,6 +27,7 @@ import {
   useRevokeMarketplaceAccess,
 } from "./marketplace-data";
 import { IntegrationIcon } from "./integration-icon";
+import { McpCredentialInput } from "./mcp-credential-input";
 import { type ExternalMcpAuthType, type ExternalMcpCredentialMode, type ExternalMcpPreset, useMcpConnectionPresets } from "./mcp-connections-data";
 import {
   findPresetForRequirement,
@@ -1011,7 +1012,13 @@ export function PluginMcpSetupDialog({
               {authType === "apikey" ? (
                 <div>
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">{serviceName} API key</label>
-                  <DenInput type="password" value={apiKey} onChange={(event) => setApiKey(event.target.value)} placeholder="API key" autoComplete="off" />
+                  <McpCredentialInput
+                    kind="secret"
+                    name="marketplace-mcp-api-key"
+                    value={apiKey}
+                    onChange={(event) => setApiKey(event.target.value)}
+                    placeholder="API key"
+                  />
                   <p className="mt-1.5 text-[11.5px] leading-4 text-gray-500">
                     Stored securely as a shared marketplace credential.
                   </p>
@@ -1043,11 +1050,23 @@ export function PluginMcpSetupDialog({
                   <div className="mt-3 space-y-3">
                     <div>
                       <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID</label>
-                      <DenInput value={clientId} onChange={(event) => setClientId(event.target.value)} placeholder="Client ID" />
+                      <McpCredentialInput
+                        kind="identifier"
+                        name="marketplace-mcp-oauth-client-id"
+                        value={clientId}
+                        onChange={(event) => setClientId(event.target.value)}
+                        placeholder="Client ID"
+                      />
                     </div>
                     <div>
                       <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client secret</label>
-                      <DenInput type="password" value={clientSecret} onChange={(event) => setClientSecret(event.target.value)} placeholder="Client secret" />
+                      <McpCredentialInput
+                        kind="secret"
+                        name="marketplace-mcp-oauth-client-secret"
+                        value={clientSecret}
+                        onChange={(event) => setClientSecret(event.target.value)}
+                        placeholder="Client secret"
+                      />
                     </div>
                   </div>
                 </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -25,6 +25,7 @@ import {
   connectionNeedsOAuthClientConfiguration,
   marketplaceConnectionNeedsAdminSetup,
 } from "./mcp-connection-setup";
+import { McpCredentialInput } from "./mcp-credential-input";
 import { shouldShowMcpConnectionsStagingBanner } from "./mcp-connections-capability";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { marketplaceQueryKeys, useMarketplaces } from "./marketplace-data";
@@ -1217,7 +1218,9 @@ function GoogleWorkspaceDialog({
               <div className="mt-3 space-y-3">
                 <div>
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID</label>
-                  <DenInput
+                  <McpCredentialInput
+                    kind="identifier"
+                    name="google-workspace-oauth-client-id"
                     value={clientId}
                     onChange={(event) => setClientId(event.target.value)}
                     placeholder="1234567890-abc.apps.googleusercontent.com"
@@ -1225,8 +1228,9 @@ function GoogleWorkspaceDialog({
                 </div>
                 <div>
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client secret</label>
-                  <DenInput
-                    type="password"
+                  <McpCredentialInput
+                    kind="secret"
+                    name="google-workspace-oauth-client-secret"
                     value={clientSecret}
                     onChange={(event) => setClientSecret(event.target.value)}
                     placeholder="GOCSPX-…"
@@ -2046,8 +2050,9 @@ function EditConnectionDialog({
               <label className="mb-1.5 block text-[12px] font-medium text-gray-700">
                 {identityChanged ? "Replacement API key (required)" : "Replacement API key (optional)"}
               </label>
-              <DenInput
-                type="password"
+              <McpCredentialInput
+                kind="secret"
+                name="mcp-replacement-api-key"
                 value={apiKey}
                 onChange={(event) => {
                   setApiKey(event.target.value);
@@ -2087,7 +2092,9 @@ function EditConnectionDialog({
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">
                     Client ID{configureOAuthClient ? " (required)" : ""}
                   </label>
-                  <DenInput
+                  <McpCredentialInput
+                    kind="identifier"
+                    name="mcp-oauth-client-id"
                     value={oauthClientId}
                     onChange={(event) => {
                       setOAuthClientId(event.target.value);
@@ -2099,8 +2106,9 @@ function EditConnectionDialog({
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">
                     {connection.oauthClientId ? "Replacement client secret (optional)" : "Client secret (optional)"}
                   </label>
-                  <DenInput
-                    type="password"
+                  <McpCredentialInput
+                    kind="secret"
+                    name="mcp-replacement-oauth-client-secret"
                     value={oauthClientSecret}
                     onChange={(event) => {
                       setOAuthClientSecret(event.target.value);
@@ -2723,7 +2731,13 @@ function AddConnectionDialog({
           {authType === "apikey" ? (
             <div>
               <label className="mb-1.5 block text-[12px] font-medium text-gray-700">API key</label>
-              <DenInput type="password" value={apiKey} onChange={(event) => setApiKey(event.target.value)} placeholder="sk-..." />
+              <McpCredentialInput
+                kind="secret"
+                name="mcp-api-key"
+                value={apiKey}
+                onChange={(event) => setApiKey(event.target.value)}
+                placeholder="sk-..."
+              />
             </div>
           ) : null}
 
@@ -2751,7 +2765,9 @@ function AddConnectionDialog({
               <div className="mt-3 space-y-3">
                 <div>
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client ID (optional for now)</label>
-                  <DenInput
+                  <McpCredentialInput
+                    kind="identifier"
+                    name="mcp-oauth-client-id"
                     value={oauthClientId}
                     onChange={(event) => setOAuthClientId(event.target.value)}
                     placeholder="1234567890.1234567890123"
@@ -2759,8 +2775,9 @@ function AddConnectionDialog({
                 </div>
                 <div>
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client secret (optional for now)</label>
-                  <DenInput
-                    type="password"
+                  <McpCredentialInput
+                    kind="secret"
+                    name="mcp-oauth-client-secret"
                     value={oauthClientSecret}
                     onChange={(event) => setOAuthClientSecret(event.target.value)}
                     placeholder="Client secret"

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-credential-input.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-credential-input.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import type { DenInputProps } from "../../_components/ui/input";
+import { DenInput } from "../../_components/ui/input";
+
+type McpCredentialInputProps = Omit<
+  DenInputProps,
+  "autoCapitalize" | "autoComplete" | "autoCorrect" | "name" | "spellCheck" | "type"
+> & {
+  kind: "identifier" | "secret";
+  name: string;
+};
+
+/**
+ * Machine credentials must never be inferred from the Den account that is
+ * signed in on this origin. The standard autocomplete hint covers browser
+ * autofill; the data attributes cover common password-manager extensions.
+ */
+export function McpCredentialInput({
+  kind,
+  ...props
+}: McpCredentialInputProps) {
+  return (
+    <DenInput
+      {...props}
+      type={kind === "secret" ? "password" : "text"}
+      autoComplete={kind === "secret" ? "new-password" : "off"}
+      autoCapitalize="none"
+      autoCorrect="off"
+      spellCheck={false}
+      data-1p-ignore="true"
+      data-lpignore="true"
+      data-bwignore="true"
+    />
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/microsoft-365-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/microsoft-365-dialog.tsx
@@ -3,8 +3,8 @@
 import { useEffect, useRef, useState } from "react";
 import { Check } from "lucide-react";
 import { DenButton } from "../../_components/ui/button";
-import { DenInput } from "../../_components/ui/input";
 import { DenNotice } from "../../_components/ui/notice";
+import { McpCredentialInput } from "./mcp-credential-input";
 import { useNativeProviderClient } from "./mcp-connections-data";
 import {
   MICROSOFT_365_DEFAULT_FEATURES,
@@ -204,15 +204,34 @@ export function Microsoft365Dialog({
               <div className="mt-3 space-y-3">
                 <div>
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Directory (tenant) ID</label>
-                  <DenInput data-testid="microsoft-tenant-id" value={tenantId} onChange={(event) => setTenantId(event.target.value)} placeholder="00000000-0000-0000-0000-000000000000" />
+                  <McpCredentialInput
+                    kind="identifier"
+                    name="microsoft-365-tenant-id"
+                    data-testid="microsoft-tenant-id"
+                    value={tenantId}
+                    onChange={(event) => setTenantId(event.target.value)}
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                  />
                 </div>
                 <div>
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Application (client) ID</label>
-                  <DenInput value={clientId} onChange={(event) => setClientId(event.target.value)} placeholder="00000000-0000-0000-0000-000000000000" />
+                  <McpCredentialInput
+                    kind="identifier"
+                    name="microsoft-365-oauth-client-id"
+                    value={clientId}
+                    onChange={(event) => setClientId(event.target.value)}
+                    placeholder="00000000-0000-0000-0000-000000000000"
+                  />
                 </div>
                 <div>
                   <label className="mb-1.5 block text-[12px] font-medium text-gray-700">Client secret value</label>
-                  <DenInput type="password" value={clientSecret} onChange={(event) => setClientSecret(event.target.value)} placeholder="Paste the secret value, not its ID" />
+                  <McpCredentialInput
+                    kind="secret"
+                    name="microsoft-365-oauth-client-secret"
+                    value={clientSecret}
+                    onChange={(event) => setClientSecret(event.target.value)}
+                    placeholder="Paste the secret value, not its ID"
+                  />
                 </div>
               </div>
               {replacingCredentials ? (

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts app/api/_lib/upstream-proxy.test.mjs",
+    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/mcp-credential-autofill.test.ts
+++ b/ee/apps/den-web/tests/mcp-credential-autofill.test.ts
@@ -1,0 +1,51 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, expect, test } from "bun:test";
+
+import { McpCredentialInput } from "../app/(den)/dashboard/_components/mcp-credential-input";
+
+const credentialConsumers = [
+  "../app/(den)/dashboard/_components/mcp-connections-screen.tsx",
+  "../app/(den)/dashboard/_components/marketplace-detail-screen.tsx",
+  "../app/(den)/dashboard/_components/microsoft-365-dialog.tsx",
+];
+
+describe("MCP credential autofill protection", () => {
+  test("marks secrets as machine credentials instead of account passwords", () => {
+    const html = renderToStaticMarkup(createElement(McpCredentialInput, {
+      kind: "secret",
+      name: "mcp-oauth-client-secret",
+      value: "",
+      readOnly: true,
+    }));
+
+    expect(html).toContain('type="password"');
+    expect(html).toContain('autoComplete="new-password"');
+    expect(html).toContain('data-1p-ignore="true"');
+    expect(html).toContain('data-lpignore="true"');
+    expect(html).toContain('data-bwignore="true"');
+  });
+
+  test("does not present client and tenant identifiers as usernames", () => {
+    const html = renderToStaticMarkup(createElement(McpCredentialInput, {
+      kind: "identifier",
+      name: "mcp-oauth-client-id",
+      value: "",
+      readOnly: true,
+    }));
+
+    expect(html).toContain('type="text"');
+    expect(html).toContain('autoComplete="off"');
+    expect(html).toContain('autoCapitalize="none"');
+    expect(html).toContain('spellCheck="false"');
+  });
+
+  test("routes every MCP password field through the protected input", () => {
+    for (const relativePath of credentialConsumers) {
+      const source = readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), "utf8");
+      expect(source).not.toContain('type="password"');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- add a shared MCP credential input that prevents Den account credentials from being inferred for machine-credential fields
- apply the protected input to generic MCP add/edit, marketplace MCP setup, Google Workspace, and Microsoft 365
- cover OAuth client IDs, tenant IDs, client secrets, and API keys
- add a focused regression test and include it in the Den Web test command

## Root cause

MCP credential fields used generic text/password inputs without stable machine-credential names or an autofill policy. Because Den authentication lives on the same origin, browsers and password-manager extensions could interpret an OAuth client ID/secret pair as the Den username/password pair and sometimes insert the wrong values.

Den's API does not return stored client secrets, and the dialogs already reset their React secret state when opened. This change closes the browser-side presentation boundary.

## Validation

- `pnpm --dir ee/apps/den-web exec bun test tests/mcp-credential-autofill.test.ts` — passed, 3 tests
- `pnpm --dir ee/apps/den-web typecheck` — passed
- `git diff --check` — passed

## Security and risk

- no API, persistence, authorization, tenant-scope, or network behavior changes
- stored secrets remain write-only and are not returned to the UI
- browser autofill uses `new-password` for machine secrets and `off` for machine identifiers, with ignore markers for common password-manager extensions
- rollback is limited to reverting the shared input and its call sites

## Manual verification

Not yet confirmed with a real saved Den login/password-manager profile. Verify that Add/Edit MCP Connection, Marketplace MCP Setup, Google Workspace, and Microsoft 365 credential fields remain empty and do not offer or insert Den login credentials.

Fraimz and full dashboard end-to-end verification were not run.
