### PR TITLE
fix(app): never render the 'Empty message' placeholder in the transcript

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -281,23 +281,6 @@ function FileMessage({ part }: FileMessageProps) {
   )
 }
 
-function EmptyMessage({
-  className,
-  ...props
-}: React.ComponentProps<"div">) {
-  return (
-    <div
-      className={cn(
-        "mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10 text-muted-foreground",
-        className
-      )}
-      {...props}
-    >
-      Empty message
-    </div>
-  )
-}
-
 interface CopyMessageButtonProps {
   messages: UIMessage[]
 }
@@ -584,13 +567,8 @@ const MessageComponent = React.memo(
       return <ErrorMessage error={getMessagesText([message]) || "Session failed"} />
     }
 
-    if (isEmptyMessage(message) && !isStreaming) {
-      return (
-        <EmptyMessage
-          data-message-id={message.id}
-          data-message-role={message.role}
-        />
-      )
+    if (isEmptyMessage(message)) {
+      return null
     }
 
     if (message.role === "assistant") {
@@ -765,11 +743,7 @@ function MessageGroup({
   })
 
   if (!lastItem || isMessageEmptyGroup(items)) {
-    if (isStreaming) {
-      return null;
-    }
-
-    return <EmptyMessage />
+    return null;
   }
 
   const renderableItems = getRenderableMessages(items)
@@ -842,7 +816,6 @@ function MessageGroup({
           {/* <MessageSources messages={items.map((item) => item.message)} /> */}
         </div>
       )}
-      {renderableItems.length === 0 && !isStreaming ? <EmptyMessage /> : null}
       </div>
   )
 }

--- a/evals/flows/chat-no-empty-message-placeholder.flow.mjs
+++ b/evals/flows/chat-no-empty-message-placeholder.flow.mjs
@@ -1,0 +1,209 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/chat-no-empty-message-placeholder.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("chat-no-empty-message-placeholder");
+
+const PROMPT = "Reply with exactly: empty-message-probe ok";
+const REPLY = "empty-message-probe ok";
+
+async function closeStaleDialogs(ctx) {
+  await ctx.eval(`(() => {
+    for (let index = 0; index < 3; index += 1) {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    }
+    const active = document.activeElement;
+    if (active && typeof active.blur === "function") active.blur();
+    return true;
+  })()`);
+}
+
+async function bootPrecondition(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API",
+  });
+  await closeStaleDialogs(ctx);
+  const state = await ctx.waitFor(
+    `(() => {
+      const control = window.__openworkControl;
+      const route = String(control.snapshot().route || "");
+      if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+      const action = control.listActions().find((item) => item.id === "session.create_task");
+      if (action && !action.disabled) return "ready";
+      return null;
+    })()`,
+    { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+  );
+  return state === "blocked"
+    ? "Profile is not onboarded (welcome/signin); chat placeholder flow requires a workspace."
+    : null;
+}
+
+async function waitForActiveSessionId(ctx) {
+  return ctx.waitFor(
+    `(() => {
+      const route = String(window.__openworkControl.snapshot().route || "");
+      const match = route.match(/ses_[A-Za-z0-9]+/);
+      return match ? match[0] : null;
+    })()`,
+    { timeoutMs: 30_000, label: "active session id in route" },
+  );
+}
+
+async function pasteComposer(ctx, text) {
+  return ctx.eval(
+    `(() => {
+      const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
+        || document.querySelector('[contenteditable="true"]');
+      if (!editor) return { ok: false, reason: 'composer not found' };
+      editor.focus();
+      const data = new DataTransfer();
+      data.setData('text/plain', ${JSON.stringify(text)});
+      editor.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data }));
+      return { ok: true, text: editor.innerText };
+    })()`,
+  );
+}
+
+async function submitComposer(ctx) {
+  const ran = await ctx.eval(`(() => {
+    const byLabel = Array.from(document.querySelectorAll('button'))
+      .find((button) => /run task|send|run/i.test((button.textContent || "").trim()) && !button.disabled);
+    if (byLabel) { byLabel.click(); return "clicked"; }
+    const editor = document.querySelector('[contenteditable="true"]');
+    if (editor) {
+      editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
+      return "enter";
+    }
+    return "none";
+  })()`);
+  ctx.assert(ran !== "none", "Could not submit the composer message.");
+  ctx.log(`submit: ${ran}`);
+  return ran;
+}
+
+async function installEmptyMessageProbe(ctx) {
+  const seen = await ctx.eval(`(() => {
+    if (window.__emptyMessageProbeObserver) window.__emptyMessageProbeObserver.disconnect();
+    window.__emptyMessageProbe = { seen: false };
+    const check = () => {
+      if (document.body.innerText.includes("Empty message")) window.__emptyMessageProbe.seen = true;
+    };
+    const observer = new MutationObserver(check);
+    observer.observe(document.body, { childList: true, subtree: true, characterData: true });
+    window.__emptyMessageProbeObserver = observer;
+    check();
+    return window.__emptyMessageProbe.seen;
+  })()`);
+  ctx.assert(seen === false, "The page already contained the literal Empty message placeholder before submit.");
+}
+
+async function readEmptyMessageProbe(ctx) {
+  return ctx.eval(`(() => ({
+    seen: Boolean(window.__emptyMessageProbe?.seen),
+    bodyHasEmptyMessage: document.body.innerText.includes("Empty message"),
+  }))()`);
+}
+
+async function hoverAssistantReply(ctx) {
+  const point = await ctx.eval(`(() => {
+    const message = Array.from(document.querySelectorAll('[data-message-role="assistant"]'))
+      .find((candidate) => candidate.innerText.includes(${JSON.stringify(REPLY)}));
+    if (!message) return null;
+    message.scrollIntoView({ block: "center", inline: "center" });
+    const rect = message.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+  })()`);
+  if (point) {
+    await ctx.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: point.x, y: point.y });
+  }
+}
+
+export default {
+  id: "chat-no-empty-message-placeholder",
+  title: "Sending a prompt never shows Empty message placeholder debris",
+  kind: "user-facing",
+  precondition: bootPrecondition,
+  steps: [
+    {
+      name: "Fresh task is ready for chat",
+      run: async (ctx) => {
+        await ctx.prove("A fresh task opens on a real session route", {
+          voiceover: vo[0],
+          action: async () => {
+            await closeStaleDialogs(ctx);
+            await ctx.control("session.create_task");
+          },
+          assert: async () => {
+            const sessionId = await waitForActiveSessionId(ctx);
+            ctx.assert(Boolean(sessionId), "No active session id after create_task.");
+            ctx.log(`active session: ${sessionId}`);
+          },
+          screenshot: { name: "fresh-task", hashIncludes: "ses_", rejectText: ["Something went wrong"] },
+        });
+      },
+    },
+    {
+      name: "Prompt submits without placeholder flash",
+      run: async (ctx) => {
+        await ctx.prove("The submit window is continuously watched and never shows Empty message", {
+          voiceover: vo[1],
+          action: async () => {
+            await installEmptyMessageProbe(ctx);
+            const pasted = await pasteComposer(ctx, PROMPT);
+            ctx.assert(pasted?.ok, `Composer not ready: ${pasted?.reason ?? "unknown"}`);
+            await submitComposer(ctx);
+          },
+          assert: async () => {
+            await ctx.waitForText(PROMPT, { timeoutMs: 30_000 });
+            await ctx.waitFor(
+              `(() => Array.from(document.querySelectorAll('[data-message-role="user"]'))
+                .some((message) => message.innerText.includes(${JSON.stringify(PROMPT)})))()`,
+              { timeoutMs: 30_000, label: "submitted user bubble" },
+            );
+            const probe = await readEmptyMessageProbe(ctx);
+            ctx.assert(probe?.seen === false, "The Empty message placeholder appeared during submit.");
+            await ctx.expectNoText("Empty message");
+            ctx.log(`empty message probe after submit: ${JSON.stringify(probe)}`);
+          },
+          screenshot: {
+            name: "submitted-without-empty-placeholder",
+            requireText: [PROMPT],
+            rejectText: ["Empty message", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Completed reply stays clean",
+      run: async (ctx) => {
+        await ctx.prove("The completed transcript has the reply and still no placeholder text", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.waitFor(
+              `(() => Array.from(document.querySelectorAll('[data-message-role="assistant"]'))
+                .some((message) => message.innerText.includes(${JSON.stringify(REPLY)})))()`,
+              { timeoutMs: 90_000, label: "assistant reply text" },
+            );
+            await hoverAssistantReply(ctx);
+          },
+          assert: async () => {
+            await ctx.waitForText(REPLY, { timeoutMs: 90_000 });
+            const probe = await readEmptyMessageProbe(ctx);
+            ctx.assert(probe?.seen === false, "The Empty message placeholder appeared before the reply completed.");
+            ctx.assert(probe?.bodyHasEmptyMessage === false, "document.body still contains Empty message.");
+            await ctx.expectNoText("Empty message");
+            ctx.log(`empty message probe final: ${JSON.stringify(probe)}`);
+            ctx.output("empty-message-probe", JSON.stringify(probe, null, 2));
+          },
+          screenshot: {
+            name: "reply-complete-no-empty-placeholder",
+            requireText: [REPLY],
+            rejectText: ["Empty message", "Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/chat-no-empty-message-placeholder.md
+++ b/evals/voiceovers/chat-no-empty-message-placeholder.md
@@ -1,0 +1,9 @@
+# chat-no-empty-message-placeholder — Sending a prompt never leaves "Empty message" debris in the chat
+
+Before this fix, triggering a prompt could flash a literal "Empty message" placeholder in the transcript — and when a run ended before the assistant produced anything, the placeholder stuck around forever. This proof drives the real desktop app: Alex sends a prompt, watches the whole send-to-response window, and the transcript stays clean throughout.
+
+1. Alex opens OpenWork on a fresh task, ready to chat.
+
+2. Alex types a short prompt and sends it. While the app hands the prompt to the agent — the exact window where the placeholder used to flash — the transcript shows Alex's bubble and never the words "Empty message".
+
+3. The agent's reply streams in and completes. The finished transcript holds just the conversation — still no placeholder text anywhere, and the placeholder is gone from the app for good.


### PR DESCRIPTION
## What

Removes the literal **"Empty message"** placeholder from the chat transcript.

`message-list.tsx` rendered it for any zero-part message. Two visible failure modes:

- **Flash on every prompt send**: thread status is `submitted` before `streaming`, so `isStreaming` is false while the just-created assistant message still has zero parts → placeholder flickers in, then vanishes when parts arrive.
- **Stuck forever**: aborted/errored runs leave a zero-part assistant message → the placeholder rendered permanently in history.

Empty messages now render nothing (`null`); the session surface's existing wait-state indicator already covers send feedback. The string is gone from the app entirely (`rg "Empty message" apps/` → 0).

Split out of #2886 per review — this PR is the display fix only (3 insertions, 30 deletions in one file, plus the proof flow).

## Validation (fraimz)

`chat-no-empty-message-placeholder` flow on a Daytona Electron sandbox (real desktop build, real GPT-5.5): installs a MutationObserver before submitting, watches the entire submitted→streaming→ready window, and asserts the placeholder never appears — mid-send, mid-stream, and after the reply completes. Proof comment below.

## Tests

- `pnpm --filter @openwork/app test` — 350 pass, 0 fail
- `pnpm --filter @openwork/app typecheck` — clean
- `pnpm fraimz --flow chat-no-empty-message-placeholder --cdp-url <daytona>` — PASSED (comment below)
