### PR TITLE
feat(den): polish dashboard admin surfaces

### DIFF
--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -2,6 +2,7 @@ import os from "node:os"
 import path from "node:path"
 import { DEN_WORKER_POLL_INTERVAL_MS } from "./CONSTS.js"
 import { normalizeConfiguredPublicApiBaseUrl } from "./request-url.js"
+import { resolveDenServiceVersion } from "./service-version.js"
 import { denApiAppVersion } from "./version.js"
 import { z } from "zod"
 
@@ -59,6 +60,7 @@ const EnvSchema = z.object({
   CORS_ORIGINS: z.string().optional(),
   DEN_API_PUBLIC_URL: z.string().optional(),
   DEN_API_VERSION: z.string().optional(),
+  RENDER_GIT_COMMIT: z.string().optional(),
   OPENWORK_INSTALLER_ARTIFACTS_DIR: z.string().optional(),
   OPENWORK_INSTALLER_RELEASE_TAG: z.string().optional(),
   OPENWORK_INSTALLER_RELEASE_REPO: z.string().optional(),
@@ -450,7 +452,10 @@ export const env = {
   workerProxyPort: Number(parsed.WORKER_PROXY_PORT ?? "8789"),
   corsOrigins,
   apiPublicUrl,
-  serviceVersion: parsed.DEN_API_VERSION?.trim() || "dev",
+  serviceVersion: resolveDenServiceVersion({
+    configuredVersion: parsed.DEN_API_VERSION,
+    renderGitCommit: parsed.RENDER_GIT_COMMIT,
+  }),
   publicUrlTrustedOrigins,
   installerArtifactsDir: optionalString(parsed.OPENWORK_INSTALLER_ARTIFACTS_DIR),
   // Standard desktop release assets: the release tag to download from,

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -569,7 +569,7 @@ async function probeExternalMcpConnection(input: {
         score,
         summary: `[${connection.name}] OAuth provider settings changed and require administrator review.`,
         status: "error",
-        hint: `Ask an org admin to open OpenWork Cloud -> Connections, review the live OAuth issuer for "${connection.name}", and reconnect if requested.`,
+        hint: `Ask an org admin to open OpenWork Cloud -> Connectors, review the live OAuth issuer for "${connection.name}", and reconnect if requested.`,
         connectionStatus: buildExternalConnectionStatus({
           connection,
           state: "reauth_required",

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -1104,7 +1104,7 @@ async function mcpHint(input: {
 
   return {
     status: "needs_connection",
-    hint: `This plugin declares an MCP server but OpenWork will not auto-provision it. Ask an org admin to add it in OpenWork Cloud -> Connections, or install "${input.row.plugin.name}" locally.`,
+    hint: `This plugin declares an MCP server but OpenWork will not auto-provision it. Ask an org admin to add it in OpenWork Cloud -> Connectors, or install "${input.row.plugin.name}" locally.`,
   }
 }
 

--- a/ee/apps/den-api/src/organization-settings-permissions.ts
+++ b/ee/apps/den-api/src/organization-settings-permissions.ts
@@ -1,0 +1,23 @@
+export type OrganizationSettingsUpdate = {
+  name?: unknown
+  allowedEmailDomains?: unknown
+  allowedDesktopVersions?: unknown
+  requireSso?: unknown
+  brandAppName?: unknown
+  brandLogoUrl?: unknown
+  brandIconUrl?: unknown
+  brandAccentColor?: unknown
+}
+
+export function isDesktopVersionOnlyOrganizationUpdate(
+  input: OrganizationSettingsUpdate,
+) {
+  return input.allowedDesktopVersions !== undefined
+    && input.name === undefined
+    && input.allowedEmailDomains === undefined
+    && input.requireSso === undefined
+    && input.brandAppName === undefined
+    && input.brandLogoUrl === undefined
+    && input.brandIconUrl === undefined
+    && input.brandAccentColor === undefined
+}

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -17,6 +17,7 @@ import { denTypeIdSchema, enterprisePlanRequiredSchema, forbiddenSchema, invalid
 import { normalizeOrganizationCapabilities } from "../../organization-capabilities.js"
 import { validateInvitationAcceptVerification } from "../../organization-join-verification.js"
 import { normalizeOrganizationMetadata } from "../../organization-limits.js"
+import { isDesktopVersionOnlyOrganizationUpdate } from "../../organization-settings-permissions.js"
 import {
   acceptInvitationForUser,
   createOrganizationForUser,
@@ -335,26 +336,32 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
     describeRoute({
       tags: ["Organizations"],
       summary: "Update organization",
-      description: "Updates organization fields that workspace owners are allowed to change, including the display name, allowed invitation email domains, and allowed desktop versions. The slug is immutable to avoid breaking dashboard URLs.",
+      description: "Updates organization fields. Workspace admins can change allowed desktop versions; all other fields remain owner-only. The slug is immutable to avoid breaking dashboard URLs.",
       responses: {
         200: jsonResponse("Organization updated successfully.", organizationResponseSchema),
         400: jsonResponse("The organization update request body was invalid, contained malformed email domains, or contained an invalid brand icon URL.", updateOrganizationBadRequestSchema),
         401: jsonResponse("The caller must be signed in to update an organization.", unauthorizedSchema),
         402: jsonResponse("Enabling enforced SSO or desktop version controls requires an Enterprise plan.", enterprisePlanRequiredSchema),
-        403: jsonResponse("Only workspace owners can update the organization.", forbiddenSchema),
+        403: jsonResponse("The caller does not have permission to update the requested organization fields.", forbiddenSchema),
         404: jsonResponse("The organization could not be found.", notFoundSchema),
       },
     }),
-    orgRoleRoute(["owner"]),
+    orgRoleRoute(["admin"]),
     jsonValidator(updateOrganizationSchema),
     async (c) => {
-      const permission = ensureOwner(c)
-      if (!permission.ok) {
-        return c.json(permission.response, 403)
-      }
-
       const payload = c.get("organizationContext")
       const input = c.req.valid("json")
+      if (payload.currentMember.isOwner) {
+        const permission = ensureOwner(c)
+        if (!permission.ok) {
+          return c.json(permission.response, 403)
+        }
+      } else if (!isDesktopVersionOnlyOrganizationUpdate(input)) {
+        return c.json({
+          error: "forbidden",
+          message: "Workspace admins can only change allowed desktop versions.",
+        }, 403)
+      }
 
       const normalizedDomains: { domains: string[] | null | undefined; invalidDomains: string[] } = input.allowedEmailDomains === undefined
         ? { domains: undefined, invalidDomains: [] }

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -351,7 +351,7 @@ export function missingScope(account: ConnectedAccountRow, anyOf: string[]): boo
 }
 
 function missingPermissionMessage(label: string): string {
-  return `Your connected Google account is missing the ${label} permission. An admin can enable it on the Google Workspace connection in OpenWork Cloud -> Connections; then reconnect your account in Settings -> Extensions.`
+  return `Your connected Google account is missing the ${label} permission. An admin can enable it on the Google Workspace connector in OpenWork Cloud -> Connectors; then reconnect your account in Settings -> Extensions.`
 }
 
 async function googleWorkspaceToken(input: {

--- a/ee/apps/den-api/src/routes/org/microsoft-365.ts
+++ b/ee/apps/den-api/src/routes/org/microsoft-365.ts
@@ -279,7 +279,7 @@ function featureGranted(token: Extract<Microsoft365AccessToken, { kind: "ok" }>,
 }
 
 function missingPermissionMessage(label: string): string {
-  return `Your connected Microsoft account is missing the ${label} permission. An admin can enable it on the Microsoft 365 connection in OpenWork Cloud -> Connections; then reconnect your account.`
+  return `Your connected Microsoft account is missing the ${label} permission. An admin can enable it on the Microsoft 365 connector in OpenWork Cloud -> Connectors; then reconnect your account.`
 }
 
 function disabledFeatureMessage(label: string): string {

--- a/ee/apps/den-api/src/service-version.ts
+++ b/ee/apps/den-api/src/service-version.ts
@@ -1,0 +1,27 @@
+function normalizedVersion(value: string | undefined) {
+  const normalized = value?.trim()
+  return normalized ? normalized : null
+}
+
+function displayVersion(value: string) {
+  return /^[a-f0-9]{7,64}$/i.test(value)
+    ? `commit ${value.slice(0, 7).toLowerCase()}`
+    : value
+}
+
+export function resolveDenServiceVersion(input: {
+  configuredVersion?: string
+  renderGitCommit?: string
+}) {
+  const configuredVersion = normalizedVersion(input.configuredVersion)
+  if (configuredVersion && configuredVersion.toLowerCase() !== "dev") {
+    return displayVersion(configuredVersion)
+  }
+
+  const renderGitCommit = normalizedVersion(input.renderGitCommit)
+  if (renderGitCommit) {
+    return displayVersion(renderGitCommit)
+  }
+
+  return "dev"
+}

--- a/ee/apps/den-api/test/marketplace-capabilities.test.ts
+++ b/ee/apps/den-api/test/marketplace-capabilities.test.ts
@@ -538,7 +538,7 @@ describe("marketplace capabilities source", () => {
     if (!missingConnection.ok) throw new Error(missingConnection.message)
     expect(missingConnection.result.serverSpec).toEqual(serverSpec)
     expect(missingConnection.result.status).toBe("needs_connection")
-    expect(missingConnection.result.hint).toContain("OpenWork Cloud -> Connections")
+    expect(missingConnection.result.hint).toContain("OpenWork Cloud -> Connectors")
 
     const connectionId = createDenTypeId("externalMcpConnection")
     await db.insert(ExternalMcpConnectionTable).values({

--- a/ee/apps/den-api/test/microsoft-365-routes.test.ts
+++ b/ee/apps/den-api/test/microsoft-365-routes.test.ts
@@ -128,7 +128,7 @@ describe("Microsoft 365 injected routes", () => {
     expect(missingScopeResponse.status).toBe(409)
     expect(await missingScopeResponse.json()).toEqual({
       error: "needs_connection",
-      message: "Your connected Microsoft account is missing the Outlook mail read permission. An admin can enable it on the Microsoft 365 connection in OpenWork Cloud -> Connections; then reconnect your account.",
+      message: "Your connected Microsoft account is missing the Outlook mail read permission. An admin can enable it on the Microsoft 365 connector in OpenWork Cloud -> Connectors; then reconnect your account.",
     })
     expect(graphCalls).toBe(1)
 
@@ -295,7 +295,7 @@ describe("Microsoft 365 injected routes", () => {
     expect(denied.status).toBe(409)
     expect(await denied.json()).toEqual({
       error: "needs_connection",
-      message: "Your connected Microsoft account is missing the Outlook mail read/write permission. An admin can enable it on the Microsoft 365 connection in OpenWork Cloud -> Connections; then reconnect your account.",
+      message: "Your connected Microsoft account is missing the Outlook mail read/write permission. An admin can enable it on the Microsoft 365 connector in OpenWork Cloud -> Connectors; then reconnect your account.",
     })
     expect(graphCalls).toBe(1)
   })

--- a/ee/apps/den-api/test/organization-settings-permissions.test.ts
+++ b/ee/apps/den-api/test/organization-settings-permissions.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from "bun:test"
+import { isDesktopVersionOnlyOrganizationUpdate } from "../src/organization-settings-permissions.js"
+
+describe("organization settings permissions", () => {
+  test("recognizes the desktop-version-only update allowed for admins", () => {
+    expect(isDesktopVersionOnlyOrganizationUpdate({
+      allowedDesktopVersions: ["0.17.32"],
+    })).toBe(true)
+    expect(isDesktopVersionOnlyOrganizationUpdate({
+      allowedDesktopVersions: null,
+    })).toBe(true)
+  })
+
+  test("keeps all other organization fields owner-only", () => {
+    expect(isDesktopVersionOnlyOrganizationUpdate({
+      allowedDesktopVersions: ["0.17.32"],
+      name: "Renamed workspace",
+    })).toBe(false)
+    expect(isDesktopVersionOnlyOrganizationUpdate({
+      requireSso: true,
+    })).toBe(false)
+  })
+})

--- a/ee/apps/den-api/test/service-version.test.ts
+++ b/ee/apps/den-api/test/service-version.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test"
+import { resolveDenServiceVersion } from "../src/service-version.js"
+
+describe("Den service version", () => {
+  test("prefers an explicitly configured release version", () => {
+    expect(resolveDenServiceVersion({
+      configuredVersion: "1.4.2",
+      renderGitCommit: "0123456789abcdef0123456789abcdef01234567",
+    })).toBe("1.4.2")
+  })
+
+  test("shows the short commit when Render only receives the Docker dev placeholder", () => {
+    expect(resolveDenServiceVersion({
+      configuredVersion: "dev",
+      renderGitCommit: "0123456789abcdef0123456789abcdef01234567",
+    })).toBe("commit 0123456")
+  })
+
+  test("formats an explicitly injected commit and retains a local fallback", () => {
+    expect(resolveDenServiceVersion({
+      configuredVersion: "ABCDEF0123456789ABCDEF0123456789ABCDEF01",
+    })).toBe("commit abcdef0")
+    expect(resolveDenServiceVersion({})).toBe("dev")
+  })
+})

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -491,6 +491,10 @@ export function getOrgSettingsRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/org-settings`;
 }
 
+export function getDiagnosticsRoute(orgSlug?: string | null): string {
+  return `${getOrgDashboardRoute(orgSlug)}/diagnostics`;
+}
+
 export function getBrandAppearanceRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/brand-appearance`;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/diagnostics/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/diagnostics/page.tsx
@@ -1,0 +1,5 @@
+import { DiagnosticsScreen } from "../../_components/diagnostics-screen";
+
+export default function DiagnosticsPage() {
+  return <DiagnosticsScreen />;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/brand-appearance-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/brand-appearance-screen.tsx
@@ -304,7 +304,6 @@ export function BrandAppearanceScreen() {
                       <p className="truncate text-[15px] font-medium">{appNameDraft.trim() || "OpenWork"}</p>
                     </div>
                   </div>
-                  <div className="mt-8 h-2 rounded-full bg-white/10"><div className="h-full w-2/3 rounded-full bg-violet-400" data-brand-accent={accentColorDraft || "default"} /></div>
                 </div>
               </div>
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/connector-quick-add-grid.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/connector-quick-add-grid.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import type { ExternalMcpConnection, ExternalMcpPreset } from "./mcp-connections-data";
+import { IntegrationIcon } from "./integration-icon";
+
+export const GOOGLE_WORKSPACE_QUICK_ADD_ID = "google-workspace";
+export const MICROSOFT_365_QUICK_ADD_ID = "microsoft-365";
+export const TELEGRAM_QUICK_ADD_ID = "telegram";
+
+export function ConnectorQuickAddGrid({
+  connections,
+  presets,
+  telegramConnected,
+  onSelect,
+}: {
+  connections: ExternalMcpConnection[];
+  presets: ExternalMcpPreset[];
+  telegramConnected: boolean;
+  onSelect: (id: string) => void;
+}) {
+  const googleConfigured = connections.some((connection) => connection.id === GOOGLE_WORKSPACE_QUICK_ADD_ID);
+  const microsoftConfigured = connections.some((connection) => connection.id === MICROSOFT_365_QUICK_ADD_ID);
+
+  return (
+    <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3" data-testid="connector-quick-add-grid">
+      <button
+        type="button"
+        onClick={() => onSelect(GOOGLE_WORKSPACE_QUICK_ADD_ID)}
+        className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
+      >
+        <div className="flex items-start gap-3">
+          <IntegrationIcon name="Google Workspace" iconUrl="/integrations/google.svg" />
+          <div className="min-w-0 flex-1">
+            <p className="text-[14px] font-semibold text-gray-900">Google Workspace</p>
+            <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">
+              Your company&apos;s Google. Set it up once — every member connects their own account.
+            </p>
+          </div>
+        </div>
+        <p className="mt-2 text-[12px] font-medium text-gray-900">
+          {googleConfigured ? "Configured — tap to update" : "Tap to set up"}
+        </p>
+      </button>
+
+      <button
+        type="button"
+        data-testid="quick-add-microsoft-365"
+        onClick={() => onSelect(MICROSOFT_365_QUICK_ADD_ID)}
+        className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
+      >
+        <div className="flex items-start gap-3">
+          <IntegrationIcon name="Microsoft 365" simpleIconSlug="microsoft" />
+          <div className="min-w-0 flex-1">
+            <p className="text-[14px] font-semibold text-gray-900">Microsoft 365</p>
+            <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">
+              Outlook mail, calendar, and OneDrive. Each teammate connects their own work account.
+            </p>
+          </div>
+        </div>
+        <p className="mt-2 text-[12px] font-medium text-gray-900">
+          {microsoftConfigured ? "Configured — tap to update" : "Tap to set up"}
+        </p>
+      </button>
+
+      <button
+        type="button"
+        data-testid="quick-add-telegram"
+        onClick={() => onSelect(TELEGRAM_QUICK_ADD_ID)}
+        className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
+      >
+        <div className="flex items-start gap-3">
+          <IntegrationIcon name="Telegram" simpleIconSlug="telegram" />
+          <div className="min-w-0 flex-1">
+            <p className="text-[14px] font-semibold text-gray-900">Telegram</p>
+            <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">
+              Pair a private Telegram chat to a cloud worker for tasks and replies.
+            </p>
+          </div>
+        </div>
+        <p className="mt-2 text-[12px] font-medium text-gray-900">
+          {telegramConnected ? "Connected — tap to manage" : "Tap to set up"}
+        </p>
+      </button>
+
+      {presets.map((preset) => {
+        const alreadyAdded = connections.some((connection) => connection.url === preset.url);
+        return (
+          <button
+            key={preset.presetId}
+            type="button"
+            disabled={alreadyAdded}
+            onClick={() => onSelect(preset.presetId)}
+            className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <div className="flex items-start gap-3">
+              <IntegrationIcon name={preset.displayName} serviceUrl={preset.url} />
+              <div className="min-w-0 flex-1">
+                <p className="text-[14px] font-semibold text-gray-900">{preset.displayName}</p>
+                <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">{preset.description}</p>
+              </div>
+            </div>
+            <p className="mt-2 text-[12px] font-medium text-gray-900">
+              {alreadyAdded ? "Already added" : "Tap to add"}
+            </p>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-overview-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/dashboard-overview-screen.tsx
@@ -6,10 +6,14 @@ import {
   Gauge,
   Users,
 } from "lucide-react";
+import { useRouter } from "next/navigation";
 import { useQuery } from "@tanstack/react-query";
 import { requestJson } from "../../_lib/den-flow";
+import { getMcpConnectionsRoute } from "../../_lib/den-org";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import { ConnectorQuickAddGrid } from "./connector-quick-add-grid";
+import { useMcpConnectionPresets, useMcpConnections, useTelegramConnection } from "./mcp-connections-data";
 import { OrganizationDownloadCard } from "./organization-download-card";
 
 /* ── Types ── */
@@ -79,8 +83,12 @@ function StatCard({ icon, title, value, sub, tone }: {
 /* ── Main screen ── */
 
 export function DashboardOverviewScreen() {
+  const router = useRouter();
   const { activeOrg, orgContext } = useOrgDashboard();
   const { user } = useDenFlow();
+  const { data: connections = [] } = useMcpConnections();
+  const { data: presets = [] } = useMcpConnectionPresets();
+  const telegramConnection = useTelegramConnection(true);
 
   const { data: adoption } = useQuery({
     queryKey: ["telemetry", "adoption"],
@@ -118,6 +126,21 @@ export function DashboardOverviewScreen() {
         <StatCard icon={<Users className="h-5 w-5 text-[#6F3DFF]" />} title="OpenWork users" value={`${members}`} sub="Current workspace members" tone="violet" />
         <StatCard icon={<Gauge className="h-5 w-5 text-[#1D63FF]" />} title="Pending invites" value={`${pending}`} sub="Awaiting activation" tone="blue" />
       </div>
+
+      <section className="mt-7" aria-labelledby="dashboard-quick-add-heading">
+        <div className="mb-3">
+          <h2 id="dashboard-quick-add-heading" className="text-[16px] font-semibold tracking-[-0.02em] text-gray-950">Quick add</h2>
+          <p className="mt-0.5 text-[13px] text-gray-500">Add a connector your whole team can use.</p>
+        </div>
+        <ConnectorQuickAddGrid
+          connections={connections}
+          presets={presets}
+          telegramConnected={Boolean(telegramConnection.data)}
+          onSelect={(id) => {
+            router.push(`${getMcpConnectionsRoute(activeOrg?.slug)}?quickAdd=${encodeURIComponent(id)}`);
+          }}
+        />
+      </section>
     </div>
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/diagnostics-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/diagnostics-screen.tsx
@@ -1,0 +1,18 @@
+"use client";
+
+import { Activity } from "lucide-react";
+import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { EgressDiagnosticsCard } from "./egress-diagnostics-card";
+
+export function DiagnosticsScreen() {
+  return (
+    <DashboardPageTemplate
+      icon={Activity}
+      title="Diagnostics"
+      description="Run controlled support checks from the same network path used by enterprise connectors."
+      colors={["#CFFAFE", "#0F172A", "#0E7490", "#F0FDFA"]}
+    >
+      <EgressDiagnosticsCard canRun />
+    </DashboardPageTemplate>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -11,6 +11,7 @@ import { type TabItem, UnderlineTabs } from "../../_components/ui/tabs";
 import {
   getGithubIntegrationSetupRoute,
   getMarketplacesRoute,
+  getNewPluginRoute,
   getOrgAccessFlags,
   getPluginRoute,
 } from "../../_lib/den-org";
@@ -219,13 +220,24 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
             ) : null}
 
             <section>
-              <div className="mb-3 flex items-baseline justify-between gap-3">
+              <div className="mb-3 flex flex-wrap items-center justify-between gap-3">
                 <h2 className="text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-400">
                   Plugins
                 </h2>
-                <p className="text-[11px] text-gray-400">
-                  {plugins.length} plugin{plugins.length === 1 ? "" : "s"}
-                </p>
+                <div className="flex items-center gap-3">
+                  <p className="text-[11px] text-gray-400">
+                    {plugins.length} plugin{plugins.length === 1 ? "" : "s"}
+                  </p>
+                  {access.isAdmin ? (
+                    <Link
+                      href={`${getNewPluginRoute(orgSlug)}?marketplaceId=${encodeURIComponent(marketplace.id)}`}
+                      className={buttonVariants({ variant: "primary", size: "sm" })}
+                    >
+                      <Plus className="h-4 w-4" aria-hidden />
+                      Add a plugin
+                    </Link>
+                  ) : null}
+                </div>
               </div>
 
               {plugins.length === 0 ? (

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-data.tsx
@@ -462,7 +462,7 @@ async function fetchConnections(scope: ExternalMcpConnectionScope, orgId: string
     15000,
   );
   if (!response.ok) {
-    throw getRequestError(payload, response, `Failed to load MCP connections (${response.status}).`);
+    throw getRequestError(payload, response, `Failed to load MCP connectors (${response.status}).`);
   }
   const record = payload as { connections?: ExternalMcpConnection[] };
   return (record.connections ?? []).map((connection) => ({

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, ArrowLeft, Check, ChevronDown, ChevronRight, Loader2, Minus, MoreHorizontal, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
@@ -73,6 +74,12 @@ import {
 } from "./mcp-scope-selection";
 import { getPluginPartsSummary, pluginQueryKeys, usePlugins } from "./plugin-data";
 import { TelegramDialog } from "./telegram-dialog";
+import {
+  ConnectorQuickAddGrid,
+  GOOGLE_WORKSPACE_QUICK_ADD_ID,
+  MICROSOFT_365_QUICK_ADD_ID,
+  TELEGRAM_QUICK_ADD_ID,
+} from "./connector-quick-add-grid";
 
 const OAUTH_POLL_INTERVAL_MS = 2000;
 const OAUTH_POLL_TIMEOUT_MS = 90_000;
@@ -242,9 +249,9 @@ function importServerStatus(server: GithubPluginImportServer): string {
 }
 
 export function McpConnectionsScreen() {
+  const searchParams = useSearchParams();
   const { orgContext, orgSlug } = useOrgDashboard();
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
-  const { data: usableConnections = [] } = useMcpConnections("usable");
   const { data: presets = [] } = useMcpConnectionPresets();
   const createConnection = useCreateMcpConnection();
   const updateConnection = useUpdateMcpConnection();
@@ -260,12 +267,9 @@ export function McpConnectionsScreen() {
   const [configuringOAuthClient, setConfiguringOAuthClient] = useState(false);
   const [issuerReviewConnection, setIssuerReviewConnection] = useState<ExternalMcpConnection | null>(null);
   const [issuerReviewPreview, setIssuerReviewPreview] = useState<McpIssuerReview | null>(null);
-  const [pluginDialogOpen, setPluginDialogOpen] = useState(false);
   const [googleDialogOpen, setGoogleDialogOpen] = useState(false);
   const [microsoftDialogOpen, setMicrosoftDialogOpen] = useState(false);
   const [telegramDialogOpen, setTelegramDialogOpen] = useState(false);
-  const googleConfigured = usableConnections.some((connection) => connection.id === "google-workspace");
-  const microsoftConfigured = usableConnections.some((connection) => connection.id === "microsoft-365");
   const telegramConnection = useTelegramConnection(true);
   const showStagingBanner = orgContext ? shouldShowMcpConnectionsStagingBanner(orgContext.capabilities) : false;
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
@@ -274,6 +278,39 @@ export function McpConnectionsScreen() {
   const [connectionActionNotice, setConnectionActionNotice] = useState<string | null>(null);
   const [toolsConnectionId, setToolsConnectionId] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
+  const handledQuickAddId = useRef<string | null>(null);
+
+  function openQuickAdd(id: string) {
+    if (id === GOOGLE_WORKSPACE_QUICK_ADD_ID) {
+      setGoogleDialogOpen(true);
+      return;
+    }
+    if (id === MICROSOFT_365_QUICK_ADD_ID) {
+      setMicrosoftDialogOpen(true);
+      return;
+    }
+    if (id === TELEGRAM_QUICK_ADD_ID) {
+      setTelegramDialogOpen(true);
+      return;
+    }
+
+    const preset = presets.find((entry) => entry.presetId === id);
+    if (!preset) return;
+    setFormPreset(preset);
+    setFormOpen(true);
+  }
+
+  useEffect(() => {
+    const quickAddId = searchParams.get("quickAdd");
+    if (!quickAddId || handledQuickAddId.current === quickAddId) return;
+    const isKnownTarget = quickAddId === GOOGLE_WORKSPACE_QUICK_ADD_ID
+      || quickAddId === MICROSOFT_365_QUICK_ADD_ID
+      || quickAddId === TELEGRAM_QUICK_ADD_ID
+      || presets.some((preset) => preset.presetId === quickAddId);
+    if (!isKnownTarget) return;
+    handledQuickAddId.current = quickAddId;
+    openQuickAdd(quickAddId);
+  }, [presets, searchParams]);
 
   useEffect(() => {
     return () => {
@@ -435,23 +472,23 @@ export function McpConnectionsScreen() {
   return (
     <DashboardPageTemplate
       icon={Plug}
-      title="Connections"
-      badgeLabel="Alpha"
-      description="Connect any MCP server — Notion, Linear, Stripe, or a custom URL — once for the whole org. search_capabilities and execute_capability pick these up automatically."
+      title="Connectors"
+      badgeLabel="Beta"
+      description="Connectors is where you can add MCP servers that your whole team can use."
       colors={["#E2E8F0", "#020617", "#0F172A", "#94A3B8"]}
     >
       {showStagingBanner ? (
         <div data-testid="mcp-connections-staging-banner" className="mb-6 rounded-[24px] border border-amber-200 bg-amber-50 px-5 py-4 text-[14px] leading-6 text-amber-800">
-          <p className="font-semibold text-amber-900">OpenWork Connect (alpha) is staged for this org.</p>
+          <p className="font-semibold text-amber-900">OpenWork Connect (beta) is staged for this org.</p>
           <p className="mt-1">
-            Connections and marketplace capabilities you set up here stay staged and invisible to members until a platform admin enables OpenWork Connect (alpha) for this org. Admin management remains fully usable.
+            Connectors and marketplace capabilities you set up here stay staged and invisible to members until a platform admin enables OpenWork Connect (beta) for this org. Admin management remains fully usable.
           </p>
         </div>
       ) : null}
 
       {error ? (
         <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">
-          {error instanceof Error ? error.message : "Failed to load MCP connections."}
+          {error instanceof Error ? error.message : "Failed to load MCP connectors."}
         </div>
       ) : null}
 
@@ -467,140 +504,37 @@ export function McpConnectionsScreen() {
         </div>
       ) : null}
 
-      <div className="mb-6 rounded-2xl border border-gray-100 bg-white px-6 py-5">
-        <div>
-          <h2 className="text-[15px] font-semibold text-gray-900">Add a connection</h2>
-          <p className="mt-1 text-[13px] text-gray-500">
-            Add a single MCP server, or import a plugin bundle so its MCPs and skills become available through capabilities.
-          </p>
-        </div>
-        <div className="mt-4 grid gap-3 sm:grid-cols-2">
-          <button
-            type="button"
-            onClick={() => {
-              setFormPreset(null);
-              setFormOpen(true);
-            }}
-            className="flex items-start gap-3 rounded-2xl border border-gray-100 px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
-          >
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gray-900 text-white">
-              <Server className="h-4 w-4" />
-            </span>
-            <span>
-              <span className="block text-[14px] font-semibold text-gray-900">MCP server</span>
-              <span className="mt-1 block text-[12px] leading-5 text-gray-500">Paste a server URL and we&apos;ll check it for you.</span>
-            </span>
-          </button>
-          <button
-            type="button"
-            onClick={() => setPluginDialogOpen(true)}
-            className="flex items-start gap-3 rounded-2xl border border-gray-100 px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
-          >
-            <span className="flex h-10 w-10 shrink-0 items-center justify-center rounded-xl bg-gray-900 text-white">
-              <Puzzle className="h-4 w-4" />
-            </span>
-            <span>
-              <span className="block text-[14px] font-semibold text-gray-900">Plugin bundle</span>
-              <span className="mt-1 block text-[12px] leading-5 text-gray-500">Import from GitHub or choose from your plugin library.</span>
-            </span>
-          </button>
-        </div>
+      <div className="mb-6">
+        <DenButton
+          type="button"
+          icon={Server}
+          onClick={() => {
+            setFormPreset(null);
+            setFormOpen(true);
+          }}
+        >
+          Add MCP
+        </DenButton>
       </div>
 
       <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Quick add</h3>
-      <div className="mb-8 grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
-        <button
-          type="button"
-          onClick={() => setGoogleDialogOpen(true)}
-          className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
-        >
-          <div className="flex items-start gap-3">
-            <IntegrationIcon name="Google Workspace" iconUrl="/integrations/google.svg" />
-            <div className="min-w-0 flex-1">
-              <p className="text-[14px] font-semibold text-gray-900">Google Workspace</p>
-              <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">
-                Your company&apos;s Google. Set it up once — every member connects their own account.
-              </p>
-            </div>
-          </div>
-          <p className="mt-2 text-[12px] font-medium text-gray-900">
-            {googleConfigured ? "Configured — tap to update" : "Tap to set up"}
-          </p>
-        </button>
-        <button
-          type="button"
-          data-testid="quick-add-microsoft-365"
-          onClick={() => setMicrosoftDialogOpen(true)}
-          className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
-        >
-          <div className="flex items-start gap-3">
-            <IntegrationIcon name="Microsoft 365" simpleIconSlug="microsoft" />
-            <div className="min-w-0 flex-1">
-              <p className="text-[14px] font-semibold text-gray-900">Microsoft 365</p>
-              <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">
-                Outlook mail, calendar, and OneDrive. Each teammate connects their own work account.
-              </p>
-            </div>
-          </div>
-          <p className="mt-2 text-[12px] font-medium text-gray-900">
-            {microsoftConfigured ? "Configured — tap to update" : "Tap to set up"}
-          </p>
-        </button>
-        <button
-          type="button"
-          data-testid="quick-add-telegram"
-          onClick={() => setTelegramDialogOpen(true)}
-          className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm"
-        >
-          <div className="flex items-start gap-3">
-            <IntegrationIcon name="Telegram" simpleIconSlug="telegram" />
-            <div className="min-w-0 flex-1">
-              <p className="text-[14px] font-semibold text-gray-900">Telegram</p>
-              <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">
-                Pair a private Telegram chat to a cloud worker for tasks and replies.
-              </p>
-            </div>
-          </div>
-          <p className="mt-2 text-[12px] font-medium text-gray-900">
-            {telegramConnection.data ? "Connected — tap to manage" : "Tap to set up"}
-          </p>
-        </button>
-        {presets.map((preset) => {
-          const alreadyAdded = connections.some((connection) => connection.url === preset.url);
-          return (
-            <button
-              key={preset.presetId}
-              type="button"
-              disabled={alreadyAdded}
-              onClick={() => {
-                setFormPreset(preset);
-                setFormOpen(true);
-              }}
-              className="rounded-2xl border border-gray-100 bg-white px-4 py-4 text-left transition hover:border-gray-300 hover:shadow-sm disabled:cursor-not-allowed disabled:opacity-50"
-            >
-              <div className="flex items-start gap-3">
-                <IntegrationIcon name={preset.displayName} serviceUrl={preset.url} />
-                <div className="min-w-0 flex-1">
-                  <p className="text-[14px] font-semibold text-gray-900">{preset.displayName}</p>
-                  <p className="mt-1 text-[12px] leading-[1.5] text-gray-500">{preset.description}</p>
-                </div>
-              </div>
-              <p className="mt-2 text-[12px] font-medium text-gray-900">
-                {alreadyAdded ? "Already added" : "Tap to add"}
-              </p>
-            </button>
-          );
-        })}
+      <div className="mb-8">
+        <ConnectorQuickAddGrid
+          connections={connections}
+          presets={presets}
+          telegramConnected={Boolean(telegramConnection.data)}
+          onSelect={openQuickAdd}
+        />
       </div>
 
-      <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Your connections</h3>
+      <h3 className="mb-3 text-[11px] font-semibold uppercase tracking-[0.14em] text-gray-400">Your connectors</h3>
       {isLoading ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
-          Loading MCP connections…
+          Loading MCP connectors…
         </div>
       ) : connections.length === 0 ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-center text-[14px] text-gray-500">
-          No MCP connections yet.
+          No MCP connectors yet.
         </div>
       ) : (
         <div className="divide-y divide-gray-100 rounded-2xl border border-gray-100 bg-white">
@@ -683,12 +617,6 @@ export function McpConnectionsScreen() {
           reviewIssuer.reset();
         }}
         onConfirm={(issuer) => void handleConfirmIssuer(issuer)}
-      />
-
-      <ImportPluginConnectionDialog
-        open={pluginDialogOpen}
-        onClose={() => setPluginDialogOpen(false)}
-        onImported={() => void refetch()}
       />
 
       <GoogleWorkspaceDialog

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   BarChart3,
   ChevronDown,
@@ -30,6 +30,7 @@ import {
   getBrandAppearanceRoute,
   getBillingRoute,
   getCustomLlmProvidersRoute,
+  getDiagnosticsRoute,
   getDesktopPoliciesRoute,
   getOrgAccessFlags,
   getIntegrationsRoute,
@@ -135,7 +136,7 @@ export function SidebarBrandMark({
   if (metadata === undefined) {
     return (
       <div
-        className="h-10 w-10 rounded-xl bg-gray-100"
+        className="h-10 w-10 rounded-xl"
         aria-label="Loading organization icon"
         data-sidebar-brand-icon="loading"
       />
@@ -153,18 +154,67 @@ export function SidebarBrandMark({
 
   return (
     <div
-      className="h-10 w-10 overflow-hidden rounded-xl bg-gray-100"
+      className="h-10 w-10 overflow-hidden rounded-xl"
       data-sidebar-brand-icon={loadedUrl === iconUrl ? "ready" : "loading"}
     >
       <img
         src={iconUrl}
         alt={`${organizationName} icon`}
-        className={`h-full w-full object-cover transition-opacity ${loadedUrl === iconUrl ? "opacity-100" : "opacity-0"}`}
+        className={`h-full w-full object-contain transition-opacity ${loadedUrl === iconUrl ? "opacity-100" : "opacity-0"}`}
         onLoad={() => setLoadedUrl(iconUrl)}
         onError={() => setFailedUrl(iconUrl)}
       />
     </div>
   );
+}
+
+export function WorkspaceFavicon({
+  metadata,
+}: {
+  metadata: string | null | undefined;
+}) {
+  const iconUrl = getManagedBrandIconUrl(metadata ?? null);
+
+  useEffect(() => {
+    if (!iconUrl) {
+      return;
+    }
+
+    let favicon = document.head.querySelector<HTMLLinkElement>('link[rel="icon"]');
+    const created = favicon === null;
+    if (!favicon) {
+      favicon = document.createElement("link");
+      favicon.rel = "icon";
+      document.head.appendChild(favicon);
+    }
+
+    const previousHref = favicon.getAttribute("href");
+    const previousType = favicon.getAttribute("type");
+    favicon.href = iconUrl;
+    favicon.type = iconUrl.toLowerCase().endsWith(".jpg")
+      || iconUrl.toLowerCase().endsWith(".jpeg")
+      ? "image/jpeg"
+      : "image/png";
+
+    return () => {
+      if (created) {
+        favicon.remove();
+        return;
+      }
+      if (previousHref === null) {
+        favicon.removeAttribute("href");
+      } else {
+        favicon.setAttribute("href", previousHref);
+      }
+      if (previousType === null) {
+        favicon.removeAttribute("type");
+      } else {
+        favicon.setAttribute("type", previousType);
+      }
+    };
+  }, [iconUrl]);
+
+  return null;
 }
 
 function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
@@ -201,6 +251,9 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
   if (pathname.startsWith(getDesktopPoliciesRoute(orgSlug))) {
     return "Desktop Policies";
   }
+  if (pathname.startsWith(getDiagnosticsRoute(orgSlug))) {
+    return "Diagnostics";
+  }
   if (pathname.startsWith(getInferenceRoute(orgSlug))) {
     return "OpenWork Models";
   }
@@ -208,13 +261,13 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
     return "Plugins";
   }
   if (pathname.startsWith(getMarketplacesRoute(orgSlug))) {
-    return "Marketplaces";
+    return "Marketplace";
   }
   if (pathname.startsWith(getIntegrationsRoute(orgSlug))) {
     return "Sources";
   }
   if (pathname.startsWith(getMcpConnectionsRoute(orgSlug))) {
-    return "Connections";
+    return "Connectors";
   }
   if (pathname.startsWith(getYourConnectionsRoute(orgSlug))) {
     return "Your Connections";
@@ -292,19 +345,19 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
 
   // Top-level rows: Dashboard, optional Your Connections, Extensions, Models,
   // Members, Analytics, Settings. Everything tool-shaped groups under
-  // Extensions (in pipeline order: Sources feed Plugins, share via
-  // Marketplaces, alpha Connections last); model config groups under
+  // Extensions starts with the Marketplace, followed by its source and
+  // management surfaces; model config groups under
   // Models; set-once governance groups under Settings.
   const extensionsGroup: DashboardNavItem | null = access.isAdmin && activeOrg
     ? {
-        href: getIntegrationsRoute(activeOrg.slug),
+        href: getMarketplacesRoute(activeOrg.slug),
         label: "Extensions",
         icon: Puzzle,
         children: [
+          { href: getMarketplacesRoute(activeOrg.slug), label: "Marketplace" },
           { href: getIntegrationsRoute(activeOrg.slug), label: "Sources" },
           { href: getPluginsRoute(activeOrg.slug), label: "Plugins" },
-          { href: getMarketplacesRoute(activeOrg.slug), label: "Marketplaces" },
-          { href: getMcpConnectionsRoute(activeOrg.slug), label: "Connections", badge: "Alpha" },
+          { href: getMcpConnectionsRoute(activeOrg.slug), label: "Connectors", badge: "Beta" },
         ],
       }
     : null;
@@ -332,6 +385,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
         ...(access.isAdmin
           ? [
               { href: getOrgSettingsRoute(activeOrg.slug), label: "General" },
+              { href: getDiagnosticsRoute(activeOrg.slug), label: "Diagnostics" },
               { href: getBrandAppearanceRoute(activeOrg.slug), label: "Brand appearance" },
               { href: getDesktopPoliciesRoute(activeOrg.slug), label: "Desktop Policies" },
               { href: getBillingRoute(activeOrg.slug), label: "Stripe" },
@@ -364,7 +418,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
           href: activeOrg ? getYourConnectionsRoute(activeOrg.slug) : "#",
           label: "Your Connections",
           icon: Plug,
-          badge: "Alpha",
+          badge: "Beta",
         }]
       : []),
     ...(extensionsGroup ? [extensionsGroup] : []),
@@ -639,6 +693,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
 
   return (
     <div className="flex min-h-screen flex-col bg-[#fafafa] md:h-screen md:flex-row">
+      <WorkspaceFavicon metadata={orgContext?.organization.metadata} />
       {/* Desktop sidebar — always visible at md+ */}
       <aside className="hidden shrink-0 border-r border-gray-100 bg-white md:flex md:min-h-screen md:w-[260px] md:flex-col">
         {sidebarContent}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-settings-screen.tsx
@@ -3,7 +3,11 @@
 import { Check, Copy, Pencil, SlidersHorizontal } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import { getErrorMessage, requestJson } from "../../_lib/den-flow";
-import { getAllowedDesktopVersionsFromMetadata, getRequireSsoFromMetadata } from "../../_lib/den-org";
+import {
+  getAllowedDesktopVersionsFromMetadata,
+  getOrgAccessFlags,
+  getRequireSsoFromMetadata,
+} from "../../_lib/den-org";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
 import { DenButton } from "../../_components/ui/button";
 import { DenCard } from "../../_components/ui/card";
@@ -12,7 +16,6 @@ import { DenTextarea } from "../../_components/ui/textarea";
 import { DenNotice } from "../../_components/ui/notice";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { EnterprisePlanNotice } from "./enterprise-plan-notice";
-import { EgressDiagnosticsCard } from "./egress-diagnostics-card";
 import {
   allPublishedDesktopVersionsAllowed,
   compareDesktopVersions,
@@ -121,10 +124,12 @@ export function OrgSettingsScreen() {
   const currentAllowedDomains =
     orgContext?.organization.allowedEmailDomains ?? null;
   const isOwner = orgContext?.currentMember.isOwner ?? false;
-  const canRunEgressDiagnostics = isOwner || (orgContext?.currentMember.role ?? "")
-    .split(",")
-    .map((role) => role.trim())
-    .includes("admin");
+  const access = getOrgAccessFlags(
+    orgContext?.currentMember.role ?? "member",
+    isOwner,
+    orgContext?.roles,
+  );
+  const canManageDesktopVersions = access.isAdmin;
   const draftAllowedDomains = useMemo(
     () => normalizeAllowedEmailDomainsInput(allowedDomainsDraft),
     [allowedDomainsDraft],
@@ -321,10 +326,15 @@ export function OrgSettingsScreen() {
 
     try {
       await updateOrganizationSettings({
-        name: orgNameDraft,
-        allowedEmailDomains: domainRestrictionsEnabled
-          ? draftAllowedDomains
-          : null,
+        ...(isOwner
+          ? {
+              name: orgNameDraft,
+              allowedEmailDomains: domainRestrictionsEnabled
+                ? draftAllowedDomains
+                : null,
+              requireSso: requireSsoEnabled,
+            }
+          : {}),
         ...(supportedDesktopVersionOptions.length > 0
           ? {
               allowedDesktopVersions: allDesktopVersionsAllowed
@@ -334,7 +344,6 @@ export function OrgSettingsScreen() {
                   ),
             }
           : {}),
-        requireSso: requireSsoEnabled,
       });
       setDomainEditModeEnabled(false);
     } catch (error) {
@@ -624,7 +633,7 @@ export function OrgSettingsScreen() {
                       <input
                         type="checkbox"
                         checked={checked}
-                        disabled={!isOwner || requiresServerUpgrade}
+                        disabled={!canManageDesktopVersions || requiresServerUpgrade}
                         aria-label={`Allow desktop version v${version}`}
                         onChange={(event) =>
                           setAllowedDesktopVersionsDraft((current) =>
@@ -644,13 +653,15 @@ export function OrgSettingsScreen() {
           ) : null}
         </DenCard>
 
-        <EgressDiagnosticsCard canRun={canRunEgressDiagnostics} />
-
         <div className="flex min-w-0 flex-wrap items-center justify-between gap-3">
           <p className="text-[13px] text-gray-500">
-            {!isOwner && "Only workspace owners can change these settings."}
+            {!isOwner && canManageDesktopVersions
+              ? "Admins can change allowed desktop versions. Other settings require a workspace owner."
+              : !isOwner
+                ? "Only workspace owners and admins can change these settings."
+                : null}
           </p>
-          {isOwner ? (
+          {access.isAdmin ? (
             <DenButton
               type="submit"
               loading={mutationBusy === "update-organization-settings"}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-editor-screen.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useEffect, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft, Download, FileText, Plus, Server, Terminal, Trash2 } from "lucide-react";
@@ -129,6 +129,7 @@ function createdItemId(payload: unknown): string | null {
 
 export function PluginEditorScreen() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const queryClient = useQueryClient();
   const { orgContext, orgSlug, runReauthableAction } = useOrgDashboard();
   const { data: marketplaces = [] } = useMarketplaces();
@@ -145,12 +146,13 @@ export function PluginEditorScreen() {
   const [saveError, setSaveError] = useState<string | null>(null);
 
   // Publishing is the happy path for non-technical creators: pre-select the
-  // first marketplace once the list loads, unless the user chose otherwise.
+  // requested marketplace, or the first marketplace when opened elsewhere.
   useEffect(() => {
-    if (!marketplaceTouched && !marketplaceId && marketplaces.length > 0) {
-      setMarketplaceId(marketplaces[0].id);
-    }
-  }, [marketplaceId, marketplaceTouched, marketplaces]);
+    if (marketplaceTouched || marketplaceId || marketplaces.length === 0) return;
+    const requestedMarketplaceId = searchParams.get("marketplaceId");
+    const requestedMarketplace = marketplaces.find((marketplace) => marketplace.id === requestedMarketplaceId);
+    setMarketplaceId(requestedMarketplace?.id ?? marketplaces[0].id);
+  }, [marketplaceId, marketplaceTouched, marketplaces, searchParams]);
 
   useEffect(() => {
     const draft = loadPluginImportDraft();

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -82,7 +82,7 @@ export function YourConnectionsScreen() {
     <DashboardPageTemplate
       icon={Plug}
       title="Your Connections"
-      badgeLabel="Alpha"
+      badgeLabel="Beta"
       description="Tools your organization has made available to you. Connect your own account where needed; workspace admins can test tools directly, and your AI coworker uses them with your permissions."
       colors={["#DBEAFE", "#1E3A8A", "#2563EB", "#93C5FD"]}
     >

--- a/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
+++ b/ee/apps/den-web/tests/connector-marketplace-polish.test.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+function readDashboardComponent(name: string) {
+  return readFileSync(
+    fileURLToPath(new URL(`../app/(den)/dashboard/_components/${name}`, import.meta.url)),
+    "utf8",
+  );
+}
+
+describe("connector and marketplace polish", () => {
+  test("puts Marketplace first and renames the org connection surface to Connectors beta", () => {
+    const shell = readDashboardComponent("org-dashboard-shell.tsx");
+    const marketplaceIndex = shell.indexOf('{ href: getMarketplacesRoute(activeOrg.slug), label: "Marketplace" }');
+    const sourcesIndex = shell.indexOf('{ href: getIntegrationsRoute(activeOrg.slug), label: "Sources" }');
+    const pluginsIndex = shell.indexOf('{ href: getPluginsRoute(activeOrg.slug), label: "Plugins" }');
+    const connectorsIndex = shell.indexOf('{ href: getMcpConnectionsRoute(activeOrg.slug), label: "Connectors", badge: "Beta" }');
+
+    expect(marketplaceIndex).toBeGreaterThan(-1);
+    expect(marketplaceIndex).toBeLessThan(sourcesIndex);
+    expect(sourcesIndex).toBeLessThan(pluginsIndex);
+    expect(pluginsIndex).toBeLessThan(connectorsIndex);
+  });
+
+  test("uses one Add MCP action and the approved connector copy", () => {
+    const screen = readDashboardComponent("mcp-connections-screen.tsx");
+
+    expect(screen).toContain('title="Connectors"');
+    expect(screen).toContain('badgeLabel="Beta"');
+    expect(screen).toContain('description="Connectors is where you can add MCP servers that your whole team can use."');
+    expect(screen).toContain("Add MCP");
+    expect(screen).not.toContain("<ImportPluginConnectionDialog");
+  });
+
+  test("adds plugins from a marketplace and carries that marketplace into the editor", () => {
+    const detail = readDashboardComponent("marketplace-detail-screen.tsx");
+    const editor = readDashboardComponent("plugin-editor-screen.tsx");
+
+    expect(detail).toContain("Add a plugin");
+    expect(detail).toContain("?marketplaceId=${encodeURIComponent(marketplace.id)}");
+    expect(editor).toContain('searchParams.get("marketplaceId")');
+  });
+
+  test("reuses Quick add on the admin dashboard and opens the selected connector flow", () => {
+    const home = readDashboardComponent("dashboard-home-screen.tsx");
+    const overview = readDashboardComponent("dashboard-overview-screen.tsx");
+    const connectorScreen = readDashboardComponent("mcp-connections-screen.tsx");
+
+    expect(home).toContain("return access.isAdmin ? <DashboardOverviewScreen /> : <MemberDashboardScreen />");
+    expect(overview).toContain("<ConnectorQuickAddGrid");
+    expect(overview).toContain("?quickAdd=${encodeURIComponent(id)}");
+    expect(connectorScreen).toContain('searchParams.get("quickAdd")');
+  });
+});

--- a/ee/apps/den-web/tests/egress-diagnostics-layout.test.ts
+++ b/ee/apps/den-web/tests/egress-diagnostics-layout.test.ts
@@ -8,16 +8,26 @@ const cardPath = fileURLToPath(
 const settingsPath = fileURLToPath(
   new URL("../app/(den)/dashboard/_components/org-settings-screen.tsx", import.meta.url),
 );
+const diagnosticsPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/diagnostics-screen.tsx", import.meta.url),
+);
+const shellPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/org-dashboard-shell.tsx", import.meta.url),
+);
 const routePath = fileURLToPath(
   new URL("../../den-api/src/routes/org/egress-diagnostics.ts", import.meta.url),
 );
 
 describe("Den egress diagnostic settings flow", () => {
-  test("presents the controlled multi-step run in Org settings", () => {
+  test("presents the controlled multi-step run on the dedicated Diagnostics page", () => {
     const card = readFileSync(cardPath, "utf8");
     const settings = readFileSync(settingsPath, "utf8");
+    const diagnostics = readFileSync(diagnosticsPath, "utf8");
+    const shell = readFileSync(shellPath, "utf8");
 
-    expect(settings).toContain("<EgressDiagnosticsCard canRun={canRunEgressDiagnostics} />");
+    expect(settings).not.toContain("EgressDiagnosticsCard");
+    expect(diagnostics).toContain("<EgressDiagnosticsCard canRun />");
+    expect(shell).toContain('{ href: getDiagnosticsRoute(activeOrg.slug), label: "Diagnostics" }');
     expect(card).toContain("Run egress diagnostic");
     expect(card).toContain("Open support trace");
     expect(card).toContain("Suggested owner:");

--- a/ee/apps/den-web/tests/org-dashboard-sidebar-brand-icon.test.tsx
+++ b/ee/apps/den-web/tests/org-dashboard-sidebar-brand-icon.test.tsx
@@ -37,7 +37,9 @@ describe("Den dashboard sidebar brand icon", () => {
     expect(markup).toContain(`src="${managedIconUrl}"`);
     expect(markup).toContain('alt="Acme icon"');
     expect(markup).toContain('data-sidebar-brand-icon="loading"');
+    expect(markup).toContain("object-contain");
     expect(markup).toContain("opacity-0");
+    expect(markup).not.toContain("bg-gray-100");
     expect(markup).not.toContain("<svg");
   });
 

--- a/ee/apps/den-web/tests/org-settings-desktop-versions.test.ts
+++ b/ee/apps/den-web/tests/org-settings-desktop-versions.test.ts
@@ -20,7 +20,15 @@ describe("organization desktop version settings", () => {
     const source = readFileSync(settingsPath, "utf8");
 
     expect(source).toContain("requiresServerUpgrade");
-    expect(source).toContain("disabled={!isOwner || requiresServerUpgrade}");
+    expect(source).toContain("disabled={!canManageDesktopVersions || requiresServerUpgrade}");
     expect(source).toContain("Upgrade server to allow this version");
+  });
+
+  test("allows workspace admins to save desktop version settings", () => {
+    const source = readFileSync(settingsPath, "utf8");
+
+    expect(source).toContain("const canManageDesktopVersions = access.isAdmin");
+    expect(source).toContain("Admins can change allowed desktop versions");
+    expect(source).toContain("{access.isAdmin ? (");
   });
 });

--- a/ee/apps/den-web/tests/workspace-branding-polish.test.ts
+++ b/ee/apps/den-web/tests/workspace-branding-polish.test.ts
@@ -1,0 +1,27 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const shellPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/org-dashboard-shell.tsx", import.meta.url),
+);
+const appearancePath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/brand-appearance-screen.tsx", import.meta.url),
+);
+
+describe("workspace branding polish", () => {
+  test("uses the canonical managed square icon for the workspace favicon", () => {
+    const source = readFileSync(shellPath, "utf8");
+
+    expect(source).toContain("export function WorkspaceFavicon");
+    expect(source).toContain("getManagedBrandIconUrl(metadata ?? null)");
+    expect(source).toContain('<WorkspaceFavicon metadata={orgContext?.organization.metadata} />');
+  });
+
+  test("does not show the artificial loading line in the desktop identity preview", () => {
+    const source = readFileSync(appearancePath, "utf8");
+
+    expect(source).not.toContain("data-brand-accent");
+    expect(source).not.toContain("w-2/3 rounded-full bg-violet-400");
+  });
+});

--- a/evals/flows/den-dashboard-polish.flow.mjs
+++ b/evals/flows/den-dashboard-polish.flow.mjs
@@ -1,0 +1,540 @@
+import { execFileSync } from "node:child_process";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { signInViaBrowser } from "./lib/den-web.mjs";
+
+const FLOW_ID = "den-dashboard-polish";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+const OWNER_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const ADMIN_EMAIL = "riley.dashboard-polish@acme.test";
+const EXPECTED_VERSION = process.env.OPENWORK_EVAL_DEN_EXPECTED_VERSION?.trim() || "commit 8c412db";
+
+const state = {
+  ownerToken: "",
+  adminToken: "",
+  organizationId: "",
+  marketplaceId: "",
+  marketplaceName: "",
+  iconUrl: "",
+};
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : JSON.stringify(actual).slice(0, 1_200),
+  });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : `. Actual: ${JSON.stringify(actual).slice(0, 600)}`}`);
+}
+
+async function denFetch(path, options = {}) {
+  const authPath = path.startsWith("/api/auth/");
+  const response = await fetch(`${authPath ? DEN_WEB_URL : DEN_API_URL}${path}`, {
+    ...options,
+    headers: {
+      accept: "application/json",
+      origin: DEN_WEB_URL,
+      ...(options.body instanceof FormData || options.body === undefined ? {} : { "content-type": "application/json" }),
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+function authHeaders(token) {
+  return { authorization: `Bearer ${token}` };
+}
+
+async function signInApi(email, password) {
+  const result = await denFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  return result.response.ok && typeof result.body?.token === "string" ? result.body.token : "";
+}
+
+function runMysql(sql) {
+  const container = process.env.OPENWORK_EVAL_DEN_MYSQL_CONTAINER?.trim() || "openwork-web-local-mysql";
+  const database = process.env.OPENWORK_EVAL_DEN_DATABASE_NAME?.trim() || "openwork_den";
+  execFileSync("docker", [
+    "exec",
+    container,
+    "mysql",
+    "-uroot",
+    "-ppassword",
+    database,
+    "-e",
+    sql,
+  ], { stdio: "ignore" });
+}
+
+async function ensureAccount(ctx, { email, name }) {
+  let token = await signInApi(email, PASSWORD);
+  if (!token) {
+    const signUp = await denFetch("/api/auth/sign-up/email", {
+      method: "POST",
+      body: JSON.stringify({ email, name, password: PASSWORD }),
+    });
+    witness(ctx, signUp.response.ok || [400, 409, 422].includes(signUp.response.status), `${name}'s account exists or was created`, {
+      status: signUp.response.status,
+      body: signUp.body,
+    });
+    runMysql(`UPDATE user SET email_verified = 1 WHERE email = '${email.replaceAll("'", "''")}';`);
+    token = await signInApi(email, PASSWORD);
+  }
+  witness(ctx, token.length > 0, `${name} can sign in through Den`, { email });
+  return token;
+}
+
+async function ensureSetup(ctx) {
+  state.ownerToken = await ensureAccount(ctx, { email: OWNER_EMAIL, name: "Alex Chen" });
+  const ownerOrg = await denFetch("/v1/org", { headers: authHeaders(state.ownerToken) });
+  witness(ctx, ownerOrg.response.ok && typeof ownerOrg.body?.organization?.id === "string", "The demo owner can load the active workspace", {
+    status: ownerOrg.response.status,
+    currentMember: ownerOrg.body?.currentMember,
+  });
+  state.organizationId = ownerOrg.body.organization.id;
+
+  state.adminToken = await ensureAccount(ctx, { email: ADMIN_EMAIL, name: "Riley Admin" });
+  let adminOrgs = await denFetch("/v1/me/orgs", { headers: authHeaders(state.adminToken) });
+  const alreadyMember = () => Array.isArray(adminOrgs.body?.orgs)
+    && adminOrgs.body.orgs.some((entry) => entry?.id === state.organizationId);
+  if (!alreadyMember()) {
+    const invitation = await denFetch("/v1/invitations", {
+      method: "POST",
+      headers: authHeaders(state.ownerToken),
+      body: JSON.stringify({ email: ADMIN_EMAIL, role: "admin" }),
+    });
+    witness(ctx, invitation.response.ok && typeof invitation.body?.inviteToken === "string", "The owner can invite the proof account as an admin", {
+      status: invitation.response.status,
+      body: invitation.body,
+    });
+    const accepted = await denFetch("/v1/orgs/invitations/accept", {
+      method: "POST",
+      headers: authHeaders(state.adminToken),
+      body: JSON.stringify({ id: invitation.body.inviteToken }),
+    });
+    witness(ctx, accepted.response.ok && accepted.body?.accepted === true, "The admin accepts the active workspace invitation", {
+      status: accepted.response.status,
+      body: accepted.body,
+    });
+    adminOrgs = await denFetch("/v1/me/orgs", { headers: authHeaders(state.adminToken) });
+  }
+  witness(ctx, alreadyMember(), "The proof account belongs to the active workspace", adminOrgs.body?.orgs);
+
+  const adminOrg = await denFetch("/v1/org", { headers: authHeaders(state.adminToken) });
+  witness(
+    ctx,
+    adminOrg.response.ok && adminOrg.body?.currentMember?.role === "admin" && adminOrg.body?.currentMember?.isOwner === false,
+    "The proof user is an admin but not the workspace owner",
+    adminOrg.body?.currentMember,
+  );
+
+  const marketplaces = await denFetch("/v1/marketplaces?limit=50", { headers: authHeaders(state.adminToken) });
+  const preferred = marketplaces.body?.items?.find((item) => item?.name === "Anthropic Knowledge Work Plugins")
+    ?? marketplaces.body?.items?.[0];
+  witness(ctx, marketplaces.response.ok && typeof preferred?.id === "string", "A real seeded marketplace is available", preferred);
+  state.marketplaceId = preferred.id;
+  state.marketplaceName = preferred.name;
+}
+
+async function navigateTo(ctx, path) {
+  const url = new URL(path, DEN_WEB_URL).toString();
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${path}` });
+}
+
+async function uploadManagedIcon(ctx) {
+  const result = await ctx.eval(`new Promise((resolve) => {
+    const canvas = document.createElement('canvas');
+    canvas.width = 128;
+    canvas.height = 128;
+    const context = canvas.getContext('2d');
+    context.fillStyle = '#172554';
+    context.fillRect(0, 0, 128, 128);
+    context.fillStyle = '#dbeafe';
+    context.beginPath();
+    context.roundRect(24, 24, 80, 80, 20);
+    context.fill();
+    context.strokeStyle = '#2563eb';
+    context.lineWidth = 12;
+    context.lineCap = 'round';
+    context.beginPath();
+    context.moveTo(43, 66);
+    context.lineTo(58, 81);
+    context.lineTo(88, 46);
+    context.stroke();
+    canvas.toBlob(async (blob) => {
+      if (!blob) return resolve({ status: 0, body: { error: 'canvas_blob_failed' } });
+      const form = new FormData();
+      form.set('icon', blob, 'den-dashboard-polish-icon.png');
+      const response = await fetch('/api/den/v1/org/brand-assets', { method: 'POST', body: form });
+      resolve({ status: response.status, body: await response.json() });
+    }, 'image/png');
+  })`, { awaitPromise: true });
+  witness(ctx, result.status === 200, "The owner can upload a square managed icon", result);
+  state.iconUrl = result.body?.assets?.icon?.url ?? "";
+  witness(ctx, state.iconUrl.length > 0, "The brand upload returns a managed icon URL", result.body?.assets?.icon);
+}
+
+function screenshot(name, claim, requireText) {
+  return {
+    name,
+    claim,
+    requireText,
+    rejectText: ["Something went wrong", "Plugin bundle"],
+  };
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Den dashboard polish keeps the admin journey simple and truthful",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Setup",
+      run: async (ctx) => {
+        await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+          width: 1440,
+          height: 1000,
+          deviceScaleFactor: 1,
+          mobile: false,
+        });
+        await ensureSetup(ctx);
+        await signInViaBrowser(ctx, ADMIN_EMAIL, PASSWORD);
+        await navigateTo(ctx, "/dashboard");
+        await ctx.waitForText("Quick add", { timeoutMs: 30_000 });
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The admin dashboard exposes Quick add and Extensions defaults to Marketplace", {
+          voiceover: vo[0],
+          assert: async () => {
+            await ctx.expectText("Google Workspace");
+            await ctx.expectText("Microsoft 365");
+            await ctx.expectText("Telegram");
+            const extensionsHref = await ctx.eval(`(() => {
+              const link = [...document.querySelectorAll('nav a')]
+                .find((entry) => (entry.textContent ?? '').trim().startsWith('Extensions'));
+              return link?.getAttribute('href') ?? null;
+            })()`);
+            witness(ctx, extensionsHref === "/dashboard/marketplaces", "Extensions points to Marketplace first", { extensionsHref });
+          },
+          screenshot: screenshot(
+            "dashboard-quick-add",
+            "The admin dashboard visibly offers reusable connector Quick add choices.",
+            ["Dashboard", "Quick add", "Google Workspace", "Microsoft 365", "Telegram"],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("Marketplace is first in Extensions and offers Add a plugin", {
+          voiceover: vo[1],
+          action: async () => {
+            await navigateTo(ctx, `/dashboard/marketplaces/${encodeURIComponent(state.marketplaceId)}`);
+            await ctx.waitForText("Add a plugin", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const nav = await ctx.eval(`(() => [...document.querySelectorAll('nav a')]
+              .map((entry) => (entry.textContent ?? '').replace(/\\s+/g, ' ').trim())
+              .filter((label) => ['Marketplace', 'Sources', 'Plugins'].includes(label) || label.startsWith('Connectors')))()`);
+            witness(
+              ctx,
+              nav.length >= 4
+                && nav[0] === "Marketplace"
+                && nav[1] === "Sources"
+                && nav[2] === "Plugins"
+                && nav[3].startsWith("Connectors")
+                && nav[3].includes("Beta"),
+              "Extensions is ordered Marketplace, Sources, Plugins, Connectors Beta",
+              nav,
+            );
+          },
+          screenshot: screenshot(
+            "marketplace-add-plugin",
+            "Marketplace is the first Extensions destination and shows Add a plugin.",
+            [state.marketplaceName, "Add a plugin", "Marketplace", "Sources", "Plugins", "Connectors", "BETA"],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Add a plugin carries the current marketplace into the creator", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.clickText("Add a plugin", { selector: "a", timeoutMs: 15_000 });
+            await ctx.waitFor("location.pathname === '/dashboard/plugins/new'", { timeoutMs: 30_000, label: "plugin creator route" });
+            await ctx.waitFor(`(() => {
+              const query = new URLSearchParams(location.search).get('marketplaceId');
+              const control = [...document.querySelectorAll('button')].find((entry) =>
+                (entry.textContent ?? '').trim() === ${JSON.stringify(state.marketplaceName)}
+              );
+              return query === ${JSON.stringify(state.marketplaceId)} && Boolean(control);
+            })()`, { timeoutMs: 30_000, label: "marketplace preselected" });
+            await ctx.eval(`(() => {
+              const label = [...document.querySelectorAll('label')].find((entry) =>
+                (entry.textContent ?? '').trim() === 'Marketplace'
+              );
+              label?.parentElement?.scrollIntoView({ block: 'center' });
+              return true;
+            })()`);
+          },
+          assert: async () => {
+            const selected = await ctx.eval(`(() => ({
+              label: [...document.querySelectorAll('button')].find((entry) =>
+                (entry.textContent ?? '').trim() === ${JSON.stringify(state.marketplaceName)}
+              )?.textContent?.trim() ?? null,
+              query: new URLSearchParams(location.search).get('marketplaceId'),
+            }))()`);
+            witness(
+              ctx,
+              selected.query === state.marketplaceId
+                && selected.label === state.marketplaceName,
+              "The plugin creator preselects the marketplace from the Add a plugin action",
+              selected,
+            );
+          },
+          screenshot: screenshot(
+            "plugin-marketplace-preselected",
+            "The plugin creator visibly preselects the marketplace that launched it.",
+            ["Create a plugin", "Share", "Marketplace", state.marketplaceName],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Connectors has one Add MCP action and no plugin-bundle import path", {
+          voiceover: vo[3],
+          action: async () => {
+            await navigateTo(ctx, "/dashboard/mcp-connections");
+            await ctx.waitForText("Connectors is where you can add MCP servers", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const state = await ctx.eval(`(() => ({
+              addMcpButtons: [...document.querySelectorAll('button')]
+                .filter((entry) => (entry.textContent ?? '').trim() === 'Add MCP').length,
+              betaVisible: document.body.innerText.toLowerCase().includes('beta'),
+              pluginBundleVisible: document.body.innerText.includes('Plugin bundle'),
+            }))()`);
+            witness(ctx, state.addMcpButtons === 1, "Connectors presents exactly one Add MCP button", state);
+            witness(ctx, state.betaVisible, "Connectors is visibly marked Beta", state);
+            witness(ctx, !state.pluginBundleVisible, "The plugin-bundle import source is absent", state);
+          },
+          screenshot: screenshot(
+            "connectors-beta-add-mcp",
+            "Connectors is a Beta team MCP surface with one Add MCP action and reusable Quick add.",
+            ["Connectors", "BETA", "Add MCP", "QUICK ADD", "Google Workspace", "Microsoft 365"],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("General settings shows the deployed commit and keeps owner-only controls disabled for admins", {
+          voiceover: vo[4],
+          action: async () => {
+            await navigateTo(ctx, "/dashboard/org-settings");
+            await ctx.waitFor(`Boolean(document.querySelector('[data-den-runtime-version]'))`, {
+              timeoutMs: 30_000,
+              label: "Den runtime version",
+            });
+          },
+          assert: async () => {
+            const general = await ctx.eval(`(() => {
+              const nameLabel = [...document.querySelectorAll('label')].find((entry) =>
+                [...entry.children].some((child) => (child.textContent ?? '').trim() === 'Name')
+              );
+              return {
+                version: document.querySelector('[data-den-runtime-version]')?.getAttribute('data-den-runtime-version') ?? null,
+                versionText: document.querySelector('[data-den-runtime-version]')?.textContent?.trim() ?? null,
+                nameDisabled: nameLabel?.querySelector('input')?.disabled ?? null,
+                hasDiagnostics: document.body.innerText.includes('Den egress diagnostic'),
+              };
+            })()`);
+            witness(
+              ctx,
+              general.version === EXPECTED_VERSION && general.versionText === `Den ${EXPECTED_VERSION}`,
+              "General settings shows the actual Den deployment version",
+              general,
+            );
+            witness(ctx, general.nameDisabled === true, "Organization identity remains owner-only for an admin", general);
+            witness(ctx, general.hasDiagnostics === false, "General settings no longer embeds egress diagnostics", general);
+          },
+          screenshot: screenshot(
+            "general-settings-deployed-commit",
+            "General settings visibly reports the actual Den commit while owner-only identity stays disabled.",
+            ["Org settings", `Den ${EXPECTED_VERSION}`, "Organization Identity", "Name"],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("Admins can save desktop-version policy but cannot mutate owner-only organization fields", {
+          voiceover: vo[5],
+          action: async () => {
+            await ctx.waitFor(`Boolean([...document.querySelectorAll('input[type="checkbox"]')].find((entry) =>
+              entry.getAttribute('aria-label')?.startsWith('Allow desktop version') && !entry.disabled
+            ))`, { timeoutMs: 30_000, label: "enabled desktop version checkbox" });
+            await ctx.eval(`(() => {
+              const checkbox = [...document.querySelectorAll('input[type="checkbox"]')].find((entry) =>
+                entry.getAttribute('aria-label')?.startsWith('Allow desktop version') && !entry.disabled
+              );
+              checkbox?.scrollIntoView({ block: 'center' });
+              checkbox?.click();
+              return Boolean(checkbox);
+            })()`);
+            await ctx.clickText("Save settings", { selector: "button", timeoutMs: 15_000 });
+            await ctx.waitForText("Workspace settings updated.", { timeoutMs: 30_000 });
+            await ctx.eval(`(() => {
+              const heading = [...document.querySelectorAll('h2')].find((entry) =>
+                (entry.textContent ?? '').trim() === 'Allowed Desktop Versions'
+              );
+              heading?.scrollIntoView({ block: 'start' });
+              return Boolean(heading);
+            })()`);
+          },
+          assert: async () => {
+            const versionControl = await ctx.eval(`(() => {
+              const checkbox = [...document.querySelectorAll('input[type="checkbox"]')].find((entry) =>
+                entry.getAttribute('aria-label')?.startsWith('Allow desktop version')
+              );
+              return {
+                enabled: checkbox ? !checkbox.disabled : false,
+                hasSave: [...document.querySelectorAll('button')].some((entry) => (entry.textContent ?? '').includes('Save settings')),
+                adminCopy: document.body.innerText.includes('Admins can change allowed desktop versions'),
+              };
+            })()`);
+            witness(ctx, versionControl.enabled && versionControl.hasSave && versionControl.adminCopy, "Desktop version controls are editable and saveable for an admin", versionControl);
+
+            const rejected = await denFetch("/v1/org", {
+              method: "PATCH",
+              headers: authHeaders(state.adminToken),
+              body: JSON.stringify({ name: "This admin must not rename the workspace" }),
+            });
+            witness(ctx, rejected.response.status === 403, "The API rejects an admin's owner-only organization-name change", {
+              status: rejected.response.status,
+              body: rejected.body,
+            });
+          },
+          screenshot: screenshot(
+            "admin-desktop-version-controls",
+            "Allowed Desktop Versions is enabled for admins and retains a Save settings action.",
+            ["Allowed Desktop Versions", "Admins can change allowed desktop versions", "Save settings"],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 7",
+      run: async (ctx) => {
+        await ctx.prove("Egress diagnostics lives on its own Settings page", {
+          voiceover: vo[6],
+          action: async () => {
+            await navigateTo(ctx, "/dashboard/diagnostics");
+            await ctx.waitForText("Den egress diagnostic", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Run egress diagnostic");
+            const route = await ctx.eval("location.pathname");
+            witness(ctx, route === "/dashboard/diagnostics", "Diagnostics has a dedicated route", { route });
+          },
+          screenshot: screenshot(
+            "settings-diagnostics",
+            "Settings contains a dedicated Diagnostics page with the existing egress support action.",
+            ["Diagnostics", "Den egress diagnostic", "Run egress diagnostic"],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 8",
+      run: async (ctx) => {
+        await ctx.prove("The managed square icon drives the sidebar and favicon without gray or loading artifacts", {
+          voiceover: vo[7],
+          action: async () => {
+            await signInViaBrowser(ctx, OWNER_EMAIL, PASSWORD);
+            await navigateTo(ctx, "/dashboard");
+            await ctx.waitForText("Quick add", { timeoutMs: 30_000 });
+            await uploadManagedIcon(ctx);
+            await ctx.eval("location.reload()");
+            await ctx.waitFor(`Boolean(document.querySelector('[data-sidebar-brand-icon="ready"]'))`, {
+              timeoutMs: 30_000,
+              label: "managed sidebar icon",
+            });
+            await navigateTo(ctx, "/dashboard/brand-appearance");
+            await ctx.waitForText("Stored in this Den", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const branding = await ctx.eval(`(() => {
+              const mark = document.querySelector('[data-sidebar-brand-icon]');
+              const image = mark?.querySelector('img');
+              const favicon = document.head.querySelector('link[rel="icon"]');
+              const previewLabel = [...document.querySelectorAll('p')].find((entry) =>
+                (entry.textContent ?? '').trim() === 'Preview'
+              );
+              const preview = previewLabel?.parentElement ?? null;
+              const hasThinLoadingLine = preview ? [...preview.querySelectorAll('div')].some((entry) => {
+                const rect = entry.getBoundingClientRect();
+                const style = getComputedStyle(entry);
+                return rect.width > 80
+                  && rect.height > 0
+                  && rect.height <= 6
+                  && style.backgroundColor !== 'rgba(0, 0, 0, 0)'
+                  && style.backgroundColor !== 'transparent';
+              }) : null;
+              return {
+                state: mark?.getAttribute('data-sidebar-brand-icon') ?? null,
+                src: image?.getAttribute('src') ?? null,
+                background: mark ? getComputedStyle(mark).backgroundColor : null,
+                favicon: favicon?.href ?? null,
+                expectedFavicon: new URL(${JSON.stringify(state.iconUrl)}, location.origin).href,
+                naturalWidth: image?.naturalWidth ?? 0,
+                hasThinLoadingLine,
+              };
+            })()`);
+            witness(
+              ctx,
+              branding.state === "ready"
+                && branding.src === state.iconUrl
+                && branding.background === "rgba(0, 0, 0, 0)"
+                && branding.naturalWidth === 128,
+              "The sidebar uses the square managed icon with a transparent wrapper",
+              branding,
+            );
+            witness(ctx, branding.favicon === branding.expectedFavicon, "The browser favicon uses the same managed square icon", branding);
+            witness(ctx, branding.hasThinLoadingLine === false, "The brand preview contains no stray loading line", branding);
+          },
+          screenshot: screenshot(
+            "brand-icon-favicon-preview",
+            "The saved square icon appears cleanly in the sidebar and brand preview with no gray tile or loading line.",
+            ["Brand appearance", "Desktop identity", "Preview", "Square app icon", "Stored in this Den"],
+          ),
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/den-dashboard-polish.md
+++ b/evals/voiceovers/den-dashboard-polish.md
@@ -1,0 +1,17 @@
+# den-dashboard-polish — Admin navigation, connectors, settings, and branding
+
+1. As a workspace admin, I land on the dashboard and can immediately use Quick add for the team’s most common connectors. Extensions now points to the Marketplace instead of the connector setup page.
+
+2. Opening Extensions lands on Marketplace first. The navigation order is Marketplace, Sources, Plugins, and Connectors, with Connectors clearly marked Beta, and each marketplace offers an Add a plugin action.
+
+3. Add a plugin opens the normal plugin creator with the marketplace I came from already selected, so the new plugin is published to the intended catalog without another lookup.
+
+4. Connectors is labeled Beta and explains that this is where the team adds shared MCP servers. There is one clear Add MCP button, the reusable Quick add choices, and no plugin-bundle import path.
+
+5. General settings reports the actual deployed Den commit instead of a generic development label. An admin can view the page while owner-only identity controls remain disabled.
+
+6. The same admin can change Allowed Desktop Versions and save the policy, while an attempted owner-only organization-name change is rejected by the API.
+
+7. The egress support check now has its own Settings → Diagnostics page, keeping General settings focused while preserving the Run egress diagnostic action.
+
+8. After the owner uploads a square workspace icon, the same managed image appears in the sidebar and browser favicon with no gray tile behind it. The brand preview is clean and no longer shows the stray loading line.


### PR DESCRIPTION
## Summary

- make Marketplace the first Extensions destination, rename shared Connections to Connectors Beta, add contextual plugin creation, and reuse Quick add on the admin dashboard
- let admins manage Allowed Desktop Versions while keeping every other organization setting owner-only, move egress support into Settings → Diagnostics, and surface the deployed Den release or commit
- clean up workspace branding by removing the preview loading line and using the managed square icon for the sidebar and favicon
- add an eight-frame Fraimz regression flow with narrated, assertion-backed screenshots

## Verification

- Den web focused tests: 17 passed
- Den API focused tests: 5 passed
- Den web TypeScript check: passed
- Den API TypeScript check: passed
- Den web production build: passed
- Den API production build: passed
- `den-dashboard-polish` Fraimz flow: 8/8 frames passed in an isolated multi-org Den stack
- live permission boundary: admin desktop-version save succeeded; admin organization-name update returned 403
- live Render-style version proof: General settings displayed `Den commit 8c412db`

## User journey covered

1. Admin dashboard Quick add and Extensions default
2. Marketplace-first navigation and Add a plugin
3. Marketplace preselection in plugin creation
4. Connectors Beta copy, one Add MCP action, and no Plugin bundle
5. Real deployed commit in General settings
6. Admin desktop-version controls with owner-only API enforcement
7. Dedicated Diagnostics page
8. Managed sidebar icon, favicon, transparent tile, and clean brand preview

## Risks and remaining gaps

- The deployed version label uses `DEN_API_VERSION` when it is a real release and falls back to Render’s `RENDER_GIT_COMMIT` when the configured value is `dev`.
- No known verification gaps remain for the requested surfaces.