### PR TITLE
feat(den-web): run connector tools from admin page

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -1562,6 +1562,7 @@ function ConnectionRow({
                   disabled={!canInspectTools}
                   title={canInspectTools ? "Inspect the tools this MCP exposes" : "Connect this account before inspecting tools"}
                   className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
+                  data-testid={`toggle-managed-mcp-tool-catalog-${connection.id}`}
                 >
                   {toolsOpen ? <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" /> : <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />}
                   {toolsOpen ? "Hide tools" : "View tools"}
@@ -1601,7 +1602,13 @@ function ConnectionRow({
           </div>
         </div>
       </div>
-      {toolsOpen && canInspectTools ? <McpToolCatalog connection={connection} /> : null}
+      {toolsOpen && canInspectTools ? (
+        <McpToolCatalog
+          connection={connection}
+          canRunTools={canRunTools}
+          onRunTool={onToggleToolRunner}
+        />
+      ) : null}
       {toolRunnerOpen && canRunTools ? <McpToolRunner connection={connection} /> : null}
     </div>
   );
@@ -1628,7 +1635,15 @@ function toolHints(tool: ExternalMcpTool): Array<{ label: string; className: str
   ].filter((hint): hint is { label: string; className: string } => hint !== null);
 }
 
-function McpToolCatalog({ connection }: { connection: ExternalMcpConnection }) {
+function McpToolCatalog({
+  connection,
+  canRunTools,
+  onRunTool,
+}: {
+  connection: ExternalMcpConnection;
+  canRunTools: boolean;
+  onRunTool: () => void;
+}) {
   const catalog = useMcpConnectionTools(connection.id, true);
   const [toolSearch, setToolSearch] = useState("");
   const [visibleToolLimit, setVisibleToolLimit] = useState(MCP_TOOL_PAGE_SIZE);
@@ -1655,10 +1670,22 @@ function McpToolCatalog({ connection }: { connection: ExternalMcpConnection }) {
             Live from {connection.name}. Inspecting this list does not run a tool. Provider annotations are hints, not guarantees.
           </p>
         </div>
-        <DenButton variant="secondary" size="sm" loading={catalog.isFetching} onClick={() => void catalog.refetch()}>
-          <RefreshCw className="h-3.5 w-3.5" />
-          Refresh
-        </DenButton>
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          <DenButton
+            size="sm"
+            icon={Play}
+            disabled={!canRunTools}
+            title={canRunTools ? "Open the manual tool runner" : "Connect or regain access before running tools"}
+            onClick={onRunTool}
+            data-testid={`run-from-managed-mcp-tool-catalog-${connection.id}`}
+          >
+            Run a tool
+          </DenButton>
+          <DenButton variant="secondary" size="sm" loading={catalog.isFetching} onClick={() => void catalog.refetch()}>
+            <RefreshCw className="h-3.5 w-3.5" />
+            Refresh
+          </DenButton>
+        </div>
       </div>
 
       {catalog.data && catalog.data.length > 0 ? (

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -4,7 +4,7 @@ import Link from "next/link";
 import { useSearchParams } from "next/navigation";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, ArrowLeft, Check, ChevronDown, ChevronRight, Loader2, Minus, MoreHorizontal, Pencil, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
+import { AlertTriangle, ArrowLeft, Check, ChevronDown, ChevronRight, Loader2, Minus, MoreHorizontal, Pencil, Play, Plug, Puzzle, RefreshCw, Search, Server, Trash2, Users, Wrench } from "lucide-react";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenNotice } from "../../_components/ui/notice";
@@ -62,6 +62,7 @@ import {
   useTelegramConnection,
   useUpdateMcpConnection,
 } from "./mcp-connections-data";
+import { McpToolRunner } from "./mcp-tool-runner";
 import {
   classifySmartAddInput,
   planSmartAdd,
@@ -252,6 +253,7 @@ export function McpConnectionsScreen() {
   const searchParams = useSearchParams();
   const { orgContext, orgSlug } = useOrgDashboard();
   const { data: connections = [], isLoading, error, refetch } = useMcpConnections();
+  const { data: usableConnections = [] } = useMcpConnections("usable");
   const { data: presets = [] } = useMcpConnectionPresets();
   const createConnection = useCreateMcpConnection();
   const updateConnection = useUpdateMcpConnection();
@@ -270,6 +272,10 @@ export function McpConnectionsScreen() {
   const [googleDialogOpen, setGoogleDialogOpen] = useState(false);
   const [microsoftDialogOpen, setMicrosoftDialogOpen] = useState(false);
   const [telegramDialogOpen, setTelegramDialogOpen] = useState(false);
+  const usableConnectionIds = useMemo(
+    () => new Set(usableConnections.map((connection) => connection.id)),
+    [usableConnections],
+  );
   const telegramConnection = useTelegramConnection(true);
   const showStagingBanner = orgContext ? shouldShowMcpConnectionsStagingBanner(orgContext.capabilities) : false;
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
@@ -277,6 +283,7 @@ export function McpConnectionsScreen() {
   const [connectionActionError, setConnectionActionError] = useState<{ connectionId: string; message: string } | null>(null);
   const [connectionActionNotice, setConnectionActionNotice] = useState<string | null>(null);
   const [toolsConnectionId, setToolsConnectionId] = useState<string | null>(null);
+  const [toolRunnerConnectionId, setToolRunnerConnectionId] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const handledQuickAddId = useRef<string | null>(null);
 
@@ -405,6 +412,8 @@ export function McpConnectionsScreen() {
     setOAuthClientConfigurationRequiredIds((current) => current.filter((connectionId) => connectionId !== input.connectionId));
     setEditingConnection(null);
     setConfiguringOAuthClient(false);
+    setToolsConnectionId(null);
+    setToolRunnerConnectionId(null);
     setConnectionActionNotice(updated.reconnectionRequired
       ? `${updated.name} was saved securely. Reconnect it before the new identity can be used.`
       : updated.identityChanged
@@ -417,7 +426,11 @@ export function McpConnectionsScreen() {
     const confirmed = window.confirm(
       `Delete ${connection.name}? This can remove access grants, per-member authorization state, and plugin or marketplace bindings.`,
     );
-    if (confirmed) deleteConnection.mutate(connection.id);
+    if (confirmed) {
+      setToolsConnectionId(null);
+      setToolRunnerConnectionId(null);
+      deleteConnection.mutate(connection.id);
+    }
   }
 
   async function handleDisconnect(connection: ExternalMcpConnection) {
@@ -425,6 +438,8 @@ export function McpConnectionsScreen() {
       `Disconnect ${connection.name}? This signs out every associated account for this connection, but keeps the MCP server setup, access rules, and plugin or marketplace bindings so you can reconnect later.`,
     );
     if (!confirmed) return;
+    setToolsConnectionId(null);
+    setToolRunnerConnectionId(null);
     setConnectionActionError(null);
     setConnectionActionNotice(null);
     try {
@@ -572,8 +587,17 @@ export function McpConnectionsScreen() {
               onRemove={() => handleRemove(connection)}
               disconnecting={disconnectConnection.isPending && disconnectConnection.variables === connection.id}
               removing={deleteConnection.isPending && deleteConnection.variables === connection.id}
+              canRunTools={usableConnectionIds.has(connection.id) && connection.needsReconnect !== true}
               toolsOpen={toolsConnectionId === connection.id}
-              onToggleTools={() => setToolsConnectionId((current) => current === connection.id ? null : connection.id)}
+              onToggleTools={() => {
+                setToolRunnerConnectionId(null);
+                setToolsConnectionId((current) => current === connection.id ? null : connection.id);
+              }}
+              toolRunnerOpen={toolRunnerConnectionId === connection.id}
+              onToggleToolRunner={() => {
+                setToolsConnectionId(null);
+                setToolRunnerConnectionId((current) => current === connection.id ? null : connection.id);
+              }}
             />;
           })}
         </div>
@@ -1338,8 +1362,11 @@ function ConnectionRow({
   onRemove,
   disconnecting,
   removing,
+  canRunTools,
   toolsOpen,
   onToggleTools,
+  toolRunnerOpen,
+  onToggleToolRunner,
 }: {
   connection: ExternalMcpConnection;
   needsPluginSetup: boolean;
@@ -1356,8 +1383,11 @@ function ConnectionRow({
   onRemove: () => void;
   disconnecting: boolean;
   removing: boolean;
+  canRunTools: boolean;
   toolsOpen: boolean;
   onToggleTools: () => void;
+  toolRunnerOpen: boolean;
+  onToggleToolRunner: () => void;
 }) {
   const isPerMember = connection.credentialMode === "per_member";
   const creatorAttribution = formatConnectionCreatorAttribution(connection.createdByName);
@@ -1536,6 +1566,21 @@ function ConnectionRow({
                   {toolsOpen ? <ChevronDown className="h-3.5 w-3.5" aria-hidden="true" /> : <ChevronRight className="h-3.5 w-3.5" aria-hidden="true" />}
                   {toolsOpen ? "Hide tools" : "View tools"}
                 </button>
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setActionsOpen(false);
+                    onToggleToolRunner();
+                  }}
+                  disabled={!canRunTools && !toolRunnerOpen}
+                  title={canRunTools ? "Run a tool with this MCP connection" : "Connect or regain access before running tools"}
+                  className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50 hover:text-gray-900 disabled:cursor-not-allowed disabled:opacity-50"
+                  data-testid={`toggle-managed-mcp-tool-runner-${connection.id}`}
+                >
+                  <Play className="h-3.5 w-3.5" aria-hidden="true" />
+                  {toolRunnerOpen ? "Hide tool runner" : "Run a tool"}
+                </button>
                 <div className="my-1 border-t border-gray-100" />
                 <button
                   type="button"
@@ -1557,6 +1602,7 @@ function ConnectionRow({
         </div>
       </div>
       {toolsOpen && canInspectTools ? <McpToolCatalog connection={connection} /> : null}
+      {toolRunnerOpen && canRunTools ? <McpToolRunner connection={connection} /> : null}
     </div>
   );
 }

--- a/ee/apps/den-web/tests/mcp-oauth-callback-migration.test.ts
+++ b/ee/apps/den-web/tests/mcp-oauth-callback-migration.test.ts
@@ -28,12 +28,13 @@ describe("MCP OAuth callback compatibility UI contract", () => {
   test("keeps connection rows focused on connect, disconnect, and a compact actions menu", () => {
     const screen = readFileSync(screenPath, "utf8")
 
-    expect(screen).toContain('const canConnectOAuth = !needsAdminSetup && !connection.issuerReviewRequired && connection.authType === "oauth"')
+    expect(screen).toContain('const canConnectOAuth = !setupRequired && !connection.issuerReviewRequired && connection.authType === "oauth"')
     expect(screen).toContain('isPerMember ? !connection.connectedForMe : !connection.connected')
     expect(screen).toContain('aria-haspopup="menu"')
     expect(screen).toContain('role="menu"')
     expect(screen).toContain('More actions for ${connection.name}')
     expect(screen).toContain('{toolsOpen ? "Hide tools" : "View tools"}')
+    expect(screen).toContain('{toolRunnerOpen ? "Hide tool runner" : "Run a tool"}')
   })
 
   test("requires explicit administrator confirmation when live issuer metadata changes", () => {

--- a/ee/apps/den-web/tests/mcp-tool-runner-surfaces.test.ts
+++ b/ee/apps/den-web/tests/mcp-tool-runner-surfaces.test.ts
@@ -1,0 +1,26 @@
+import { readFileSync } from "node:fs"
+import { fileURLToPath } from "node:url"
+import { describe, expect, test } from "bun:test"
+
+const managedConnectionsPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/mcp-connections-screen.tsx", import.meta.url),
+)
+const yourConnectionsPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/_components/your-connections-screen.tsx", import.meta.url),
+)
+
+describe("MCP tool runner surfaces", () => {
+  test("keeps manual tool calling available from member and admin connection screens", () => {
+    const managedConnections = readFileSync(managedConnectionsPath, "utf8")
+    const yourConnections = readFileSync(yourConnectionsPath, "utf8")
+
+    expect(managedConnections).toContain('import { McpToolRunner } from "./mcp-tool-runner"')
+    expect(managedConnections).toContain("canRunTools={usableConnectionIds.has(connection.id) && connection.needsReconnect !== true}")
+    expect(managedConnections).toContain('{toolRunnerOpen ? "Hide tool runner" : "Run a tool"}')
+    expect(managedConnections).toContain("disabled={!canRunTools && !toolRunnerOpen}")
+    expect(managedConnections).toContain("toolRunnerOpen && canRunTools ? <McpToolRunner connection={connection} />")
+
+    expect(yourConnections).toContain('import { McpToolRunner } from "./mcp-tool-runner"')
+    expect(yourConnections).toContain("toolRunnerOpen && canTestTools ? <McpToolRunner connection={connection} />")
+  })
+})

--- a/ee/apps/den-web/tests/mcp-tool-runner-surfaces.test.ts
+++ b/ee/apps/den-web/tests/mcp-tool-runner-surfaces.test.ts
@@ -18,6 +18,9 @@ describe("MCP tool runner surfaces", () => {
     expect(managedConnections).toContain("canRunTools={usableConnectionIds.has(connection.id) && connection.needsReconnect !== true}")
     expect(managedConnections).toContain('{toolRunnerOpen ? "Hide tool runner" : "Run a tool"}')
     expect(managedConnections).toContain("disabled={!canRunTools && !toolRunnerOpen}")
+    expect(managedConnections).toContain("data-testid={`toggle-managed-mcp-tool-catalog-${connection.id}`}")
+    expect(managedConnections).toContain("onRunTool={onToggleToolRunner}")
+    expect(managedConnections).toContain("data-testid={`run-from-managed-mcp-tool-catalog-${connection.id}`}")
     expect(managedConnections).toContain("toolRunnerOpen && canRunTools ? <McpToolRunner connection={connection} />")
 
     expect(yourConnections).toContain('import { McpToolRunner } from "./mcp-tool-runner"')

--- a/evals/flows/mcp-tool-calling-surfaces.flow.mjs
+++ b/evals/flows/mcp-tool-calling-surfaces.flow.mjs
@@ -240,17 +240,37 @@ async function openManagedToolRunner(ctx) {
   })()`);
   ctx.assert(menuOpened, "Could not open the managed connection actions menu.");
   await ctx.waitFor(
-    `Boolean(document.querySelector('[data-testid="toggle-managed-mcp-tool-runner-${state.connectionId}"]'))`,
-    { timeoutMs: 10_000, label: "managed Run a tool action" },
+    `Boolean(
+      document.querySelector('[data-testid="toggle-managed-mcp-tool-runner-${state.connectionId}"]')
+      && document.querySelector('[data-testid="toggle-managed-mcp-tool-catalog-${state.connectionId}"]')
+    )`,
+    { timeoutMs: 10_000, label: "managed tool actions" },
   );
 
-  const runnerOpened = await ctx.eval(`(() => {
-    const button = document.querySelector('[data-testid="toggle-managed-mcp-tool-runner-${state.connectionId}"]');
+  const catalogOpened = await ctx.eval(`(() => {
+    const directRunner = document.querySelector('[data-testid="toggle-managed-mcp-tool-runner-${state.connectionId}"]');
+    const button = document.querySelector('[data-testid="toggle-managed-mcp-tool-catalog-${state.connectionId}"]');
+    if (!(directRunner instanceof HTMLButtonElement) || directRunner.disabled) return false;
     if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
     button.click();
     return true;
   })()`);
-  ctx.assert(runnerOpened, "The managed connection's Run a tool action was unavailable.");
+  ctx.assert(catalogOpened, "The managed connection's tool catalog was unavailable.");
+  await ctx.waitFor(
+    `Boolean(
+      document.querySelector('[data-mcp-tool-catalog="${state.connectionId}"]')
+      && document.querySelector('[data-testid="run-from-managed-mcp-tool-catalog-${state.connectionId}"]')
+    )`,
+    { timeoutMs: 30_000, label: "Run a tool action inside the managed tool catalog" },
+  );
+
+  const runnerOpened = await ctx.eval(`(() => {
+    const button = document.querySelector('[data-testid="run-from-managed-mcp-tool-catalog-${state.connectionId}"]');
+    if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(runnerOpened, "The tool catalog's Run a tool action was unavailable.");
   await waitForRunner(ctx);
 }
 

--- a/evals/flows/mcp-tool-calling-surfaces.flow.mjs
+++ b/evals/flows/mcp-tool-calling-surfaces.flow.mjs
@@ -1,0 +1,428 @@
+import http from "node:http";
+import {
+  denApiFetch,
+  denWebUrl,
+  openAdminConnections,
+  openYourConnections,
+  signInApi,
+  signInViaBrowser,
+} from "./lib/den-web.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "mcp-tool-calling-surfaces";
+const CONNECTION_PREFIX = "Route Verification MCP — manual calling proof";
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const state = {
+  adminToken: "",
+  connectionId: "",
+  connectionName: "",
+  observedCalls: [],
+  observedMethods: [],
+  server: null,
+};
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : JSON.stringify(actual).slice(0, 1_200),
+  });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : `. Actual: ${JSON.stringify(actual).slice(0, 600)}`}`);
+}
+
+function json(response, status, body) {
+  response.writeHead(status, {
+    "access-control-allow-origin": "*",
+    "content-type": "application/json",
+  });
+  response.end(JSON.stringify(body));
+}
+
+function readJson(request) {
+  return new Promise((resolve, reject) => {
+    let raw = "";
+    request.on("data", (chunk) => { raw += chunk; });
+    request.on("end", () => {
+      try {
+        resolve(raw.trim() ? JSON.parse(raw) : {});
+      } catch (error) {
+        reject(error);
+      }
+    });
+    request.on("error", reject);
+  });
+}
+
+function toolResult(message) {
+  if (message.method === "initialize") {
+    return {
+      protocolVersion: "2025-06-18",
+      capabilities: { tools: {} },
+      serverInfo: { name: "route-verification-proof", version: "1.0.0" },
+    };
+  }
+  if (message.method === "tools/list") {
+    return {
+      tools: [{
+        name: "verify_connection_route",
+        title: "Verify connection route",
+        description: "Returns which Den connection screen invoked this safe test tool.",
+        inputSchema: {
+          type: "object",
+          properties: {
+            surface: {
+              type: "string",
+              enum: ["Connectors", "Your Connections"],
+              description: "The Den screen running this proof.",
+            },
+          },
+          required: ["surface"],
+          additionalProperties: false,
+        },
+        outputSchema: {
+          type: "object",
+          properties: {
+            surface: { type: "string" },
+            verified: { type: "boolean" },
+          },
+          required: ["surface", "verified"],
+          additionalProperties: false,
+        },
+        annotations: {
+          readOnlyHint: true,
+          destructiveHint: false,
+          idempotentHint: true,
+          openWorldHint: false,
+        },
+      }],
+    };
+  }
+  if (message.method === "tools/call") {
+    const surface = message.params?.arguments?.surface;
+    return {
+      content: [{ type: "text", text: `Verified manual tool call from ${surface}.` }],
+      structuredContent: { surface, verified: true },
+    };
+  }
+  return {};
+}
+
+async function startMcpServer() {
+  if (state.server) return;
+  state.server = http.createServer(async (request, response) => {
+    try {
+      const url = new URL(request.url || "/", "http://127.0.0.1");
+      if (url.pathname !== "/mcp" || request.method !== "POST") {
+        json(response, 404, { error: "not_found" });
+        return;
+      }
+
+      const body = await readJson(request);
+      const messages = Array.isArray(body) ? body : [body];
+      const replies = [];
+      for (const message of messages) {
+        if (message && typeof message === "object" && typeof message.method === "string") {
+          state.observedMethods.push(message.method);
+          if (message.method === "tools/call") {
+            state.observedCalls.push({
+              name: message.params?.name,
+              arguments: message.params?.arguments,
+            });
+          }
+        }
+        if (message && typeof message === "object" && message.id !== undefined) {
+          replies.push({ jsonrpc: "2.0", id: message.id, result: toolResult(message) });
+        }
+      }
+
+      if (replies.length === 0) {
+        response.writeHead(202, { "access-control-allow-origin": "*" });
+        response.end();
+        return;
+      }
+      json(response, 200, Array.isArray(body) ? replies : replies[0]);
+    } catch (error) {
+      json(response, 500, { error: error instanceof Error ? error.message : String(error) });
+    }
+  });
+
+  await new Promise((resolve, reject) => {
+    state.server.once("error", reject);
+    state.server.listen(0, "127.0.0.1", resolve);
+  });
+  state.server.unref();
+}
+
+function mcpUrl() {
+  const address = state.server?.address();
+  if (!address || typeof address === "string") throw new Error("MCP proof server has no TCP address.");
+  return `http://127.0.0.1:${address.port}/mcp`;
+}
+
+async function prepareSharedConnection(ctx) {
+  await startMcpServer();
+  state.adminToken = await signInApi(ADMIN_EMAIL, ADMIN_PASSWORD);
+  witness(ctx, Boolean(state.adminToken), `The demo owner can sign in as ${ADMIN_EMAIL}.`);
+
+  const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+    headers: { authorization: `Bearer ${state.adminToken}` },
+  });
+  witness(ctx, existing.response.ok, "The admin can read the manageable MCP connections.", { status: existing.response.status });
+  for (const connection of existing.body.connections ?? []) {
+    if (!connection.name.startsWith(CONNECTION_PREFIX)) continue;
+    await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+      method: "DELETE",
+      headers: { authorization: `Bearer ${state.adminToken}` },
+    });
+  }
+
+  state.connectionName = `${CONNECTION_PREFIX} ${Date.now()}`;
+  const created = await denApiFetch("/v1/mcp-connections", {
+    method: "POST",
+    headers: { authorization: `Bearer ${state.adminToken}` },
+    body: JSON.stringify({
+      name: state.connectionName,
+      url: mcpUrl(),
+      authType: "none",
+      credentialMode: "shared",
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    }),
+  });
+  witness(
+    ctx,
+    created.response.ok && typeof created.body?.id === "string" && created.body?.connected === true,
+    "Den validates, connects, and shares the protocol-compatible MCP with the organization.",
+    {
+      access: created.body?.access,
+      connected: created.body?.connected,
+      id: created.body?.id,
+      status: created.response.status,
+    },
+  );
+  state.connectionId = created.body.id;
+  state.observedCalls.length = 0;
+  state.observedMethods.length = 0;
+
+  const usable = await denApiFetch("/v1/mcp-connections?scope=usable", {
+    headers: { authorization: `Bearer ${state.adminToken}` },
+  });
+  const visibleToCaller = (usable.body.connections ?? []).some((connection) => connection.id === state.connectionId);
+  witness(ctx, usable.response.ok && visibleToCaller, "The org-wide connection is available under the rollout and use-grant policy.", {
+    status: usable.response.status,
+    visibleToCaller,
+  });
+}
+
+async function openConnectors(ctx) {
+  const currentUrl = await ctx.eval("window.location.href");
+  if (!currentUrl.includes(new URL(denWebUrl()).host)) {
+    await ctx.eval(`(() => { window.location.href = ${JSON.stringify(denWebUrl())}; return true; })()`);
+  }
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "Den web loaded" });
+  await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+  await openAdminConnections(ctx);
+  await ctx.waitFor(
+    `Boolean(document.querySelector('[data-testid="mcp-connection-row-${state.connectionId}"]'))`,
+    { timeoutMs: 30_000, label: "shared MCP connection row" },
+  );
+}
+
+async function openManagedToolRunner(ctx) {
+  const menuOpened = await ctx.eval(`(() => {
+    const button = document.querySelector('[data-testid="mcp-connection-more-${state.connectionId}"]');
+    if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(menuOpened, "Could not open the managed connection actions menu.");
+  await ctx.waitFor(
+    `Boolean(document.querySelector('[data-testid="toggle-managed-mcp-tool-runner-${state.connectionId}"]'))`,
+    { timeoutMs: 10_000, label: "managed Run a tool action" },
+  );
+
+  const runnerOpened = await ctx.eval(`(() => {
+    const button = document.querySelector('[data-testid="toggle-managed-mcp-tool-runner-${state.connectionId}"]');
+    if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(runnerOpened, "The managed connection's Run a tool action was unavailable.");
+  await waitForRunner(ctx);
+}
+
+async function openPersonalToolRunner(ctx) {
+  const runnerOpened = await ctx.eval(`(() => {
+    const button = document.querySelector('[data-testid="toggle-mcp-tool-runner-${state.connectionId}"]');
+    if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(runnerOpened, "The Your Connections tool runner action was unavailable.");
+  await waitForRunner(ctx);
+}
+
+async function waitForRunner(ctx) {
+  await ctx.waitFor(`(() => {
+    const runner = document.querySelector('[data-testid="mcp-tool-runner-${state.connectionId}"]');
+    return (runner?.textContent ?? '').includes('Run a tool manually')
+      && (runner?.textContent ?? '').includes('verify_connection_route');
+  })()`, { timeoutMs: 30_000, label: "manual MCP tool runner" });
+}
+
+async function runToolFromSurface(ctx, surface) {
+  const runnerSelector = `[data-testid="mcp-tool-runner-${state.connectionId}"]`;
+  await ctx.fill(
+    `${runnerSelector} textarea`,
+    JSON.stringify({ surface }, null, 2),
+  );
+  const clicked = await ctx.eval(`(() => {
+    const runner = document.querySelector(${JSON.stringify(runnerSelector)});
+    const button = [...(runner?.querySelectorAll('button') ?? [])]
+      .find((entry) => (entry.textContent ?? '').trim() === 'Run tool');
+    if (!(button instanceof HTMLButtonElement) || button.disabled) return false;
+    button.click();
+    return true;
+  })()`);
+  ctx.assert(clicked, `Could not run the verification tool from ${surface}.`);
+
+  const resultText = `Verified manual tool call from ${surface}.`;
+  await ctx.waitFor(`(() => {
+    const runner = document.querySelector(${JSON.stringify(runnerSelector)});
+    const text = runner?.textContent ?? '';
+    return text.includes('Tool completed') && text.includes(${JSON.stringify(resultText)});
+  })()`, { timeoutMs: 30_000, label: `${surface} tool result` });
+}
+
+function callsForSurface(surface) {
+  return state.observedCalls.filter((call) => (
+    call.name === "verify_connection_route"
+    && call.arguments?.surface === surface
+  ));
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Admins can call the same Den-managed MCP tool from Connectors and Your Connections",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Prepare a connected MCP shared with the organization",
+      run: async (ctx) => {
+        if (ctx.client?.send) {
+          await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+            width: 1440,
+            height: 1050,
+            deviceScaleFactor: 1,
+            mobile: false,
+          });
+        }
+        await prepareSharedConnection(ctx);
+        await openConnectors(ctx);
+      },
+    },
+    {
+      name: "Run the shared tool from Connectors",
+      run: async (ctx) => {
+        await ctx.prove("An admin can call an org-wide connected MCP from Connectors", {
+          voiceover: vo[0],
+          action: async () => {
+            await openManagedToolRunner(ctx);
+            await runToolFromSurface(ctx, "Connectors");
+            await ctx.eval(`(() => {
+              const runner = document.querySelector('[data-testid="mcp-tool-runner-${state.connectionId}"]');
+              runner?.scrollIntoView({ block: 'center' });
+              return Boolean(runner);
+            })()`);
+          },
+          assert: async () => {
+            const connectorCalls = callsForSurface("Connectors");
+            witness(ctx, connectorCalls.length === 1, "The mock MCP received one real tools/call from Connectors.", {
+              connectorCalls,
+              observedMethods: state.observedMethods,
+            });
+            witness(ctx, state.observedCalls.length === 1, "No extra MCP tool call was made while testing the shared connection from Connectors.", state.observedCalls);
+            await ctx.expectText("Tool completed");
+            await ctx.expectText("Verified manual tool call from Connectors.");
+          },
+          screenshot: {
+            name: "connectors-manual-tool-completed",
+            claim: "The admin-only Connectors screen can execute a safe MCP tool that the caller is granted to use.",
+            requireText: [
+              "Run a tool manually",
+              "verify_connection_route",
+              "Provider marks this tool as read-only.",
+              "Tool completed",
+              "Verified manual tool call from Connectors.",
+            ],
+            rejectText: ["Tool call failed", "Could not run", "Something went wrong"],
+            hashIncludes: "/dashboard/mcp-connections",
+          },
+        });
+      },
+    },
+    {
+      name: "Run the same shared connection from Your Connections",
+      run: async (ctx) => {
+        await ctx.prove("The same org-wide tool runs from Your Connections", {
+          voiceover: vo[1],
+          action: async () => {
+            await openYourConnections(ctx);
+            await ctx.waitFor(
+              `Boolean(document.querySelector('[data-testid="toggle-mcp-tool-runner-${state.connectionId}"]'))`,
+              { timeoutMs: 30_000, label: "shared connection in Your Connections" },
+            );
+            await openPersonalToolRunner(ctx);
+            await runToolFromSurface(ctx, "Your Connections");
+            await ctx.eval(`(() => {
+              const runner = document.querySelector('[data-testid="mcp-tool-runner-${state.connectionId}"]');
+              runner?.scrollIntoView({ block: 'center' });
+              return Boolean(runner);
+            })()`);
+          },
+          assert: async () => {
+            const connectorCalls = callsForSurface("Connectors");
+            const personalCalls = callsForSurface("Your Connections");
+            witness(ctx, connectorCalls.length === 1, "The original Connectors tools/call remains accounted for.", connectorCalls);
+            witness(ctx, personalCalls.length === 1, "The mock MCP received one real tools/call from Your Connections.", personalCalls);
+            witness(ctx, state.observedCalls.length === 2, "Exactly two upstream tools/call requests were made across both screens.", state.observedCalls);
+            await ctx.expectText("Tool completed");
+            await ctx.expectText("Verified manual tool call from Your Connections.");
+          },
+          screenshot: {
+            name: "your-connections-manual-tool-completed",
+            claim: "After sharing, Your Connections invokes the same safe MCP tool and shows its deterministic result.",
+            requireText: [
+              "Your Connections",
+              "Run a tool manually",
+              "verify_connection_route",
+              "Provider marks this tool as read-only.",
+              "Tool completed",
+              "Verified manual tool call from Your Connections.",
+            ],
+            rejectText: ["Tool call failed", "Could not run", "Something went wrong"],
+            hashIncludes: "/dashboard/your-connections",
+          },
+        });
+      },
+    },
+    {
+      name: "Clean up the proof connection",
+      run: async (ctx) => {
+        if (state.connectionId) {
+          const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+            method: "DELETE",
+            headers: { authorization: `Bearer ${state.adminToken}` },
+          });
+          ctx.assert(removed.response.ok || removed.response.status === 404, `Cleanup failed: ${removed.response.status}`);
+        }
+        state.server?.close();
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/mcp-tool-calling-surfaces.md
+++ b/evals/voiceovers/mcp-tool-calling-surfaces.md
@@ -5,6 +5,6 @@ Verification MCP is a real protocol-compatible local test server with one safe,
 read-only tool and a deterministic response. It is connected and shared
 org-wide, so both screens operate within the same rollout and use-grant policy.
 
-1. Alex opens Connectors with the org-wide MCP already connected. From the existing connection row he opens Run a tool, sends a safe verification call, and sees the completed result from the real upstream server.
+1. Alex opens Connectors with the org-wide MCP already connected. The connection menu still offers Run a tool directly; he opens View tools instead, uses the Run a tool button inside that catalog, sends a safe verification call, and sees the completed result from the real upstream server.
 
 2. Alex opens Your Connections, where the same org-wide connector is available under his use grant. The same manual runner invokes the same MCP tool again, and its result confirms both entry points reach the real upstream tools/call path without bypassing connection access policy.

--- a/evals/voiceovers/mcp-tool-calling-surfaces.md
+++ b/evals/voiceovers/mcp-tool-calling-surfaces.md
@@ -1,0 +1,10 @@
+# mcp-tool-calling-surfaces — Run the same MCP tool wherever an admin finds the connection
+
+Cast: Alex, an Acme Robotics workspace admin, in OpenWork Cloud. The Route
+Verification MCP is a real protocol-compatible local test server with one safe,
+read-only tool and a deterministic response. It is connected and shared
+org-wide, so both screens operate within the same rollout and use-grant policy.
+
+1. Alex opens Connectors with the org-wide MCP already connected. From the existing connection row he opens Run a tool, sends a safe verification call, and sees the completed result from the real upstream server.
+
+2. Alex opens Your Connections, where the same org-wide connector is available under his use grant. The same manual runner invokes the same MCP tool again, and its result confirms both entry points reach the real upstream tools/call path without bypassing connection access policy.


### PR DESCRIPTION
## Summary

- add a separate **Run a tool** action to managed MCP connection rows
- keep the direct menu shortcut and add **Run a tool** inside **View tools**
- reuse the existing manual runner while keeping catalog inspection non-executing
- restrict execution to connections returned by `scope=usable` and not marked reconnect-required
- clear open tool panels after edit, disconnect, or removal
- add focused UI coverage and an end-to-end Fraimz flow covering both connection surfaces

## Why

Manual tool calling was available from **Your connections**, but the admin **Connections / Connectors** screen could only inspect a connection's tool catalog. This composes the same runner into the managed connection screen.

## Security and trust boundaries

- no Den API, schema, or credential-storage changes
- existing owner/admin POST authorization remains unchanged
- existing rollout and use-grant filtering is reused through `scope=usable`
- reconnect-required connections remain non-executable
- tenant scoping, per-member credential selection, redaction, payload limits, and destructive-tool confirmation remain enforced by the existing server and runner paths

## Validation

- Den Web TypeScript check — passed
- latest focused Den Web tests — 8 passed, 0 failed
- focused Den API MCP tool regression tests — 16 passed, 0 failed
- Fraimz `mcp-tool-calling-surfaces` — passed on the initial runner entry point, exercising both routes and asserting exactly two upstream `tools/call` requests
- visually reviewed both Fraimz screenshots

## Notes

The Fraimz flow now enters the runner through **View tools**, but that updated click path has not been rerun yet. The previous browser proof uses a deterministic local read-only MCP fixture. Native Google and Microsoft tool execution remains intentionally outside this external-MCP runner.
