### PR TITLE
feat(app): add copy action to tool results

### DIFF
--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -23,8 +23,10 @@ import { getToolActivityLabel, isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
 import {
   Bot,
+  Check,
   ChevronDown,
   CircleAlert,
+  Copy,
   ExternalLink,
   FilePen,
   KeyRound,
@@ -37,6 +39,7 @@ import {
   SquareCode,
   Wrench,
 } from "lucide-react"
+import { useCallback, useState } from "react"
 import type { DynamicToolUIPart, ToolUIPart } from "ai"
 
 function toolIcon(part: ToolPart) {
@@ -192,8 +195,14 @@ const Tool = ({
   const label = title ?? getToolActivityLabel(toolPart)
   const hasInput = input !== null && input !== undefined
   const hasOutput = "output" in toolPart && toolPart.output !== undefined
+  const resultText = hasOutput
+    ? formatValue(toolPart.output)
+    : isError && toolPart.errorText
+      ? toolPart.errorText
+      : null
   const inputDiff = getInputDiff(input)
   const Icon = toolIcon(toolPart)
+  const [copied, setCopied] = useState(false)
   const ReconnectIcon = reconnectState === "opening"
     ? LoaderCircle
     : reconnectState === "authorization_opened"
@@ -251,6 +260,17 @@ const Tool = ({
       })
     }
   }
+
+  const handleCopyResult = useCallback(async () => {
+    if (resultText === null) return
+    try {
+      await navigator.clipboard.writeText(resultText)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Clipboard access can be unavailable outside a secure browser context.
+    }
+  }, [resultText])
 
   return (
     <Collapsible className={className} defaultOpen={defaultOpen}>
@@ -318,6 +338,19 @@ const Tool = ({
               aria-hidden="true"
             />
             {reconnectPresentation?.buttonLabel}
+          </Button>
+        ) : null}
+        {resultText !== null ? (
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            data-testid="tool-result-copy-action"
+            title={copied ? "Copied" : "Copy tool result"}
+            aria-label={copied ? "Tool result copied" : "Copy tool result"}
+            onClick={() => void handleCopyResult()}
+          >
+            {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
           </Button>
         ) : null}
       </div>

--- a/apps/app/tests/tool-error-attribution-ui.test.tsx
+++ b/apps/app/tests/tool-error-attribution-ui.test.tsx
@@ -64,3 +64,33 @@ test("renders an inline reconnect button when Cloud capability discovery finds e
   expect(html).toContain("bg-amber-3/60")
   expect(html).toContain('data-testid="chat-mcp-reconnect-action"')
 })
+
+test("renders a copy action when a tool result is available", () => {
+  const toolPart: DynamicToolUIPart = {
+    type: "dynamic-tool",
+    toolName: "openwork-cloud_search_capabilities",
+    toolCallId: "call-copy",
+    state: "output-available",
+    input: { query: "Notion pages" },
+    output: { matches: [{ name: "searchPages" }] },
+  }
+
+  const html = renderToStaticMarkup(<Tool toolPart={toolPart} />)
+
+  expect(html).toContain('data-testid="tool-result-copy-action"')
+  expect(html).toContain('aria-label="Copy tool result"')
+})
+
+test("does not render a copy action before a tool has a result", () => {
+  const toolPart: DynamicToolUIPart = {
+    type: "dynamic-tool",
+    toolName: "openwork-cloud_search_capabilities",
+    toolCallId: "call-running",
+    state: "input-available",
+    input: { query: "Notion pages" },
+  }
+
+  const html = renderToStaticMarkup(<Tool toolPart={toolPart} />)
+
+  expect(html).not.toContain('data-testid="tool-result-copy-action"')
+})


### PR DESCRIPTION
## Summary

- add a copy-to-clipboard action at the right edge of completed tool rows
- copy the exact displayed result, including pretty-printed object output or error text
- show a temporary checkmark and accessible copied label after success
- hide the action until a result or error is available

## Why

Tool results can be long and difficult to select manually. This gives users a fast, consistent way to reuse the complete result.

## Checks

- `pnpm --filter @openwork/app exec bun test --isolate tests/tool-error-attribution-ui.test.tsx` — passed (4 tests)
- `pnpm --filter @openwork/app typecheck` — passed
- `git diff --check` — passed

## Manual verification

Not run — no screenshot, video, or fraimz proof was requested. Reviewer steps:

1. Open a conversation containing a completed tool call.
2. Expand the tool row and confirm the copy icon appears at the far right.
3. Click it and confirm it changes to a checkmark with an accessible copied label.
4. Paste into a text editor and confirm the full displayed tool result is present.
5. Confirm an in-progress tool without output does not show the copy action.

## Risk

Low and UI-only. Clipboard failures are handled without disrupting the tool row.