### PR TITLE
fix(mcp): separate connection issues from capabilities

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -94,8 +94,16 @@ const capabilityMatchOutputSchema = z.object({
   connectionStatus: connectionStatusOutputSchema.optional(),
 }).passthrough()
 
+const connectionIssueOutputSchema = capabilityMatchOutputSchema.extend({
+  kind: z.literal("connection_status"),
+  status: z.enum(["needs_connection", "error"]),
+  connectionStatus: connectionStatusOutputSchema,
+})
+
 export const SEARCH_CAPABILITIES_OUTPUT_SCHEMA = z.object({
+  availability: z.enum(["available", "available_with_issues", "unavailable", "no_matches"]),
   matches: z.array(capabilityMatchOutputSchema),
+  connectionIssues: z.array(connectionIssueOutputSchema),
   hint: z.string().optional(),
 })
 
@@ -112,7 +120,8 @@ export const AGENT_MCP_INSTRUCTIONS = [
   "External MCP matches include the provider-advertised argumentsSchema, schemaDigest, and invocation.argumentsField. Put an object matching argumentsSchema in execute_capability.body and copy schemaDigest into execute_capability.schemaDigest.",
   "OpenWork always attempts the downstream provider call when local schema checks find a mismatch. schemaGuidance is advisory and appears alongside the provider result: if the provider succeeded, accept that result and do not retry solely because of the warning; if it failed, use the warning to correct the arguments or search again.",
   "If the provider returns invalid_capability_arguments, correct the listed issues and retry once with changed arguments; never retry the same arguments unchanged. If it returns unknown_capability, call search_capabilities again before retrying.",
-  "When a match has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly. Distinguish the member's Your Connections page, the organization Connections dashboard, and the provider's own admin console.",
+  "search_capabilities returns callable matches separately from connectionIssues. available_with_issues means at least one matching capability is usable: use the callable match and do not claim the provider is unavailable because another connection needs attention.",
+  "For each connectionIssues entry that affects the request, name connectionStatus.connectionName and relay connectionStatus.action exactly. Distinguish the member's Your Connections page, the organization Connections dashboard, and the provider's own admin console.",
   "Connection probes are live. After the requested human fixes that connector, search again in the same task; otherwise do not retry unchanged or improvise workarounds through other tools.",
 ].join("\n")
 
@@ -149,12 +158,21 @@ export function externalCapabilityErrorToolResult(
   }
 }
 
-export function capabilitySearchToolResult<T extends CapabilityMatch>(matches: T[], coverageHint?: string) {
+export function capabilitySearchToolResult<T extends CapabilityMatch, I extends CapabilityMatch>(
+  matches: T[],
+  connectionIssues: I[] = [],
+  coverageHint?: string,
+) {
+  const availability = matches.length > 0
+    ? connectionIssues.length > 0 ? "available_with_issues" : "available"
+    : connectionIssues.length > 0 ? "unavailable" : "no_matches"
   const hint = [
-    ...(matches.length === 0 ? ["No matches. Try broader or different keywords."] : []),
+    ...(availability === "no_matches" ? ["No matches. Try broader or different keywords."] : []),
     ...(coverageHint ? [coverageHint] : []),
   ].join(" ")
-  const result = hint ? { matches, hint } : { matches }
+  const result = hint
+    ? { availability, matches, connectionIssues, hint }
+    : { availability, matches, connectionIssues }
   return {
     content: textContent(JSON.stringify(result, null, 2)),
     structuredContent: result,
@@ -323,13 +341,14 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
           "there is no list of individually-named tools to browse. Always search first.",
           "Search covers native Google Workspace capabilities (Gmail, Calendar, Drive, Gmail drafts), org-connected external MCPs, and namespaced OpenWork Admin tools for allowlisted platform admins.",
           "Try 2-4 keyword variants before deciding a capability is unavailable.",
+          "Callable results are returned in matches; unhealthy connectors are returned separately in connectionIssues, so one disconnected account cannot hide a usable duplicate.",
           "Native API matches include pathParams, queryParams, hasBody, and bodySchema. External MCP matches include argumentsSchema, schemaDigest, and invocation.argumentsField.",
           "Skill matches use method SKILL and return stored SKILL.md content when executed.",
         ].join(" "),
         annotations: SEARCH_CAPABILITIES_ANNOTATIONS,
         inputSchema: z.object({
           query: z.string().min(1).describe("Keywords describing the capability you need, e.g. \"create organization\" or \"list workers\"."),
-          limit: z.number().int().min(1).max(20).optional().describe("Max number of matches to return. Defaults to 5."),
+          limit: z.number().int().min(1).max(20).optional().describe("Max number of callable matches to return. Connection issues are capped separately at the same limit. Defaults to 5."),
           type: searchCapabilityTypeSchema.optional().describe("Optional source filter. all searches every available source; api searches Den API capabilities; admin searches allowlisted platform-admin tools; mcp searches connected external MCP tools; marketplace searches marketplace plugin capabilities; skills searches native skills and marketplace skill objects. Defaults to all."),
         }),
         outputSchema: SEARCH_CAPABILITIES_OUTPUT_SCHEMA,
@@ -347,7 +366,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         // Notion/Linear/Stripe/... connection an admin added in Den shows
         // up here exactly like any native capability, ranked together.
         let externalCoverageHint: string | undefined
-        const externalMatches = sourceFilter.mcp && externalMcpConnectionsEnabled
+        const externalSearch = sourceFilter.mcp && externalMcpConnectionsEnabled
           ? await searchExternalCapabilities({
             organizationId: principal.organizationId,
             member: memberIdentity,
@@ -358,7 +377,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
               externalCoverageHint = externalMcpSearchCoverageHint(coverage)
             },
           })
-          : []
+          : { matches: [], connectionIssues: [] }
         const marketplaceMatches = sourceFilter.marketplace && externalMcpConnectionsEnabled
           ? await searchMarketplaceCapabilities({
             organizationId: principal.organizationId,
@@ -377,10 +396,10 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
             limit: boundedLimit,
           })
           : []
-        const matches = [...restMatches, ...adminMatches, ...externalMatches, ...marketplaceMatches, ...skillMatches]
+        const matches = [...restMatches, ...adminMatches, ...externalSearch.matches, ...marketplaceMatches, ...skillMatches]
           .sort(compareCapabilityMatches)
           .slice(0, boundedLimit)
-        return capabilitySearchToolResult(matches, externalCoverageHint)
+        return capabilitySearchToolResult(matches, externalSearch.connectionIssues, externalCoverageHint)
       },
     )
 

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -169,6 +169,11 @@ export type ExternalCapabilityMatch = CapabilityMatch & {
   connectionStatus?: ExternalConnectionStatus
 }
 
+export type ExternalMcpSearchResult = {
+  matches: ExternalCapabilityMatch[]
+  connectionIssues: ExternalCapabilityMatch[]
+}
+
 export type ExternalConnectionStatus = {
   version: typeof OPENWORK_CLOUD_MCP_CONNECTION_ACTION_VERSION
   kind: typeof OPENWORK_CLOUD_MCP_CONNECTION_ACTION_KIND
@@ -504,8 +509,8 @@ export async function collectBoundedExternalMcpSearchMatches<T>(input: {
   limit: number
   concurrency?: number
   probe: (connection: T, deadline: ExternalMcpLifecycleDeadline) => Promise<ExternalCapabilityMatch[]>
-}): Promise<ExternalCapabilityMatch[]> {
-  const retained: ExternalCapabilityMatch[] = []
+}): Promise<ExternalMcpSearchResult> {
+  const retained: ExternalMcpSearchResult = { matches: [], connectionIssues: [] }
   const boundedLimit = Number.isFinite(input.limit)
     ? Math.max(0, Math.min(Math.floor(input.limit), EXTERNAL_MCP_SEARCH_MATCH_LIMIT))
     : 0
@@ -524,7 +529,17 @@ export async function collectBoundedExternalMcpSearchMatches<T>(input: {
       nextIndex += 1
       if (index >= input.connections.length) return
       const candidates = await input.probe(input.connections[index]!, input.deadline)
-      if (acceptingResults) mergeBoundedExternalCapabilityMatches(retained, candidates, boundedLimit)
+      if (!acceptingResults) continue
+      mergeBoundedExternalCapabilityMatches(
+        retained.matches,
+        candidates.filter((candidate) => candidate.kind !== "connection_status"),
+        boundedLimit,
+      )
+      mergeBoundedExternalCapabilityMatches(
+        retained.connectionIssues,
+        candidates.filter((candidate) => candidate.kind === "connection_status"),
+        boundedLimit,
+      )
     }
   }
   const workers = Promise.all(Array.from({ length: concurrency }, () => worker()))
@@ -707,7 +722,7 @@ async function probeExternalMcpConnection(input: {
  * Live-lists tools for a bounded set of external MCP connections the calling
  * member has been granted. All probes share one absolute deadline and run in
  * a small worker pool; one unreachable server cannot serialize the latency of
- * every other provider or let matches grow beyond the requested top-K.
+ * every other provider or consume the requested callable-match budget.
  */
 export async function searchExternalCapabilities(input: {
   organizationId: string
@@ -716,12 +731,12 @@ export async function searchExternalCapabilities(input: {
   redirectUriBase: string
   limit?: number
   reportCoverage?: (coverage: ExternalMcpSearchCoverage) => void
-}): Promise<ExternalCapabilityMatch[]> {
-  if (!input.member) return []
+}): Promise<ExternalMcpSearchResult> {
+  if (!input.member) return { matches: [], connectionIssues: [] }
   const queryTokens = tokenize(input.query)
-  if (queryTokens.length === 0) return []
+  if (queryTokens.length === 0) return { matches: [], connectionIssues: [] }
   const requestedLimit = input.limit ?? 5
-  if (!Number.isFinite(requestedLimit) || requestedLimit <= 0) return []
+  if (!Number.isFinite(requestedLimit) || requestedLimit <= 0) return { matches: [], connectionIssues: [] }
   const limit = Math.min(Math.max(1, Math.trunc(requestedLimit)), EXTERNAL_MCP_SEARCH_MATCH_LIMIT)
   const deadline = createExternalMcpLifecycleDeadline()
   const connections = await listUsableExternalMcpConnections({

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -36,9 +36,7 @@ export type CapabilityMatch = {
 }
 
 export function compareCapabilityMatches(a: CapabilityMatch, b: CapabilityMatch): number {
-  const statusPriority = Number("kind" in b && b.kind === "connection_status")
-    - Number("kind" in a && a.kind === "connection_status")
-  return statusPriority || (b.score - a.score) || a.name.localeCompare(b.name)
+  return (b.score - a.score) || a.name.localeCompare(b.name)
 }
 
 export function searchCapabilitySourceFilter(type?: SearchCapabilityType) {

--- a/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
+++ b/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
@@ -60,6 +60,8 @@ let listUsableExternalMcpConnections: typeof import("../src/capability-sources/e
 let saveExternalMcpTokens: typeof import("../src/capability-sources/external-mcp-connections.js").saveExternalMcpTokens
 let searchExternalCapabilities: typeof import("../src/mcp/external-capabilities.js").searchExternalCapabilities
 let executeExternalCapability: typeof import("../src/mcp/external-capabilities.js").executeExternalCapability
+let capabilitySearchToolResult: typeof import("../src/mcp/agent.js").capabilitySearchToolResult
+let searchCapabilitiesOutputSchema: typeof import("../src/mcp/agent.js").SEARCH_CAPABILITIES_OUTPUT_SCHEMA
 let slackServer: FakeMcpServer | undefined
 let authedSlackServer: FakeMcpServer | undefined
 let notionServer: FakeMcpServer | undefined
@@ -338,14 +340,19 @@ async function expectConnectionListed(seed: SeededOrganization, connectionId: De
   expect(connections.map((connection) => connection.id)).toContain(connectionId)
 }
 
-function search(seed: SeededOrganization, query: string) {
+function searchResult(seed: SeededOrganization, query: string, limit = 10) {
   return searchExternalCapabilities({
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     query,
     redirectUriBase,
-    limit: 10,
+    limit,
   })
+}
+
+async function search(seed: SeededOrganization, query: string) {
+  const result = await searchResult(seed, query)
+  return [...result.connectionIssues, ...result.matches]
 }
 
 function toolNames(tools: { name: string }[]): string[] {
@@ -361,12 +368,13 @@ beforeAll(async () => {
   }).db
   mock.module("../src/db.js", () => ({ db: realDb }))
 
-  const [dbMod, schemaMod, clientMod, connectionsMod, capabilitiesMod, envMod] = await Promise.all([
+  const [dbMod, schemaMod, clientMod, connectionsMod, capabilitiesMod, agentMod, envMod] = await Promise.all([
     import("../src/db.js"),
     import("@openwork-ee/den-db/schema"),
     import("../src/capability-sources/external-mcp-client.js"),
     import("../src/capability-sources/external-mcp-connections.js"),
     import("../src/mcp/external-capabilities.js"),
+    import("../src/mcp/agent.js"),
     import("../src/env.js"),
   ])
   // Another co-run test file's static src import may have parsed env.ts before
@@ -383,6 +391,8 @@ beforeAll(async () => {
   saveExternalMcpTokens = connectionsMod.saveExternalMcpTokens
   searchExternalCapabilities = capabilitiesMod.searchExternalCapabilities
   executeExternalCapability = capabilitiesMod.executeExternalCapability
+  capabilitySearchToolResult = agentMod.capabilitySearchToolResult
+  searchCapabilitiesOutputSchema = agentMod.SEARCH_CAPABILITIES_OUTPUT_SCHEMA
   slackServer = startFakeMcpServer("fake-slack", slackTools)
   authedSlackServer = startFakeMcpServer("fake-authed-slack", slackTools, "valid-key")
   notionServer = startFakeMcpServer("fake-notion", notionTools)
@@ -434,6 +444,44 @@ test("control-healthy: Connections list and search_capabilities both see Slack t
   if (process.env.OPENWORK_EVAL_VERBOSE === "1") {
     console.log("E2E_HEALTHY_DISCOVERY", JSON.stringify({ connectionName: "Slack", toolCount: matches.length, status: "available" }))
   }
+})
+
+test("duplicate provider keeps a healthy capability separate from a disconnected connection", async () => {
+  if (!slackServer) throw new Error("Slack MCP server was not started")
+
+  const seed = await seedOrganization("duplicate-provider-partial-availability")
+  const connected = await createGrantedConnection(seed, {
+    name: "Slack",
+    authType: "none",
+    credentialMode: "shared",
+    url: slackServer.url,
+  })
+  const disconnected = await createGrantedConnection(seed, {
+    name: "Slack",
+    authType: "oauth",
+    credentialMode: "shared",
+    url: slackServer.url,
+  })
+
+  const result = await searchResult(seed, "slack", 1)
+
+  expect(result.matches).toHaveLength(1)
+  expect(result.matches[0]?.name.startsWith(`mcp:${connected.id}:`)).toBe(true)
+  expect(result.connectionIssues).toHaveLength(1)
+  expect(result.connectionIssues[0]).toMatchObject({
+    name: `mcp:${disconnected.id}:*`,
+    kind: "connection_status",
+    status: "needs_connection",
+    connectionStatus: {
+      connectionId: disconnected.id,
+      connectionName: "Slack",
+      state: "needs_connection",
+    },
+  })
+
+  const response = capabilitySearchToolResult(result.matches, result.connectionIssues)
+  expect(response.structuredContent.availability).toBe("available_with_issues")
+  expect(searchCapabilitiesOutputSchema.safeParse(response.structuredContent).success).toBe(true)
 })
 
 test("external capability execution reports schema guidance but always attempts tools/call", async () => {
@@ -757,7 +805,7 @@ test("the 16-connection fanout reports incomplete coverage when the only match i
     })
   }
   let coverage: Parameters<typeof externalMcpSearchCoverageHint>[0] | undefined
-  const matches = await searchExternalCapabilities({
+  const result = await searchExternalCapabilities({
     organizationId: seed.organizationId,
     member: { orgMembershipId: seed.memberId, teamIds: [] },
     query: "needle",
@@ -768,7 +816,7 @@ test("the 16-connection fanout reports incomplete coverage when the only match i
     },
   })
 
-  expect(matches).toEqual([])
+  expect(result).toEqual({ matches: [], connectionIssues: [] })
   expect(coverage).toEqual({ eligibleConnections: 17, probedConnections: 16, truncated: true })
   if (!coverage) throw new Error("External MCP search did not report coverage")
   expect(externalMcpSearchCoverageHint(coverage)).toContain("16 of 17")
@@ -1031,7 +1079,7 @@ test("per-member-name-mismatch: needs_connection only appears when query matches
   expect(matches[0]?.status).toBe("needs_connection")
 })
 
-test("user-transcript-repro: Slack connection status ranks above Notion's summary-only Slack hit", async () => {
+test("user-transcript-repro: Slack connection status stays separate from Notion's callable Slack hit", async () => {
   if (!notionServer) throw new Error("Notion MCP server was not started")
   if (!slackServer) throw new Error("Slack MCP server was not started")
 
@@ -1051,11 +1099,12 @@ test("user-transcript-repro: Slack connection status ranks above Notion's summar
 
   await expectConnectionListed(seed, notionConnection.id)
   await expectConnectionListed(seed, slackConnection.id)
-  const matches = await search(seed, "slack")
-  expect(matches.length).toBe(2)
-  expect(matches[0]?.name).toBe(`mcp:${slackConnection.id}:*`)
-  expect(matches[0]?.status).toBe("needs_connection")
-  expect(matches[0]?.score).toBeGreaterThanOrEqual(7)
-  expect(matches[1]?.name).toBe(`mcp:${notionConnection.id}:notion-search`)
-  expect(matches[1]?.score).toBe(2)
+  const result = await searchResult(seed, "slack")
+  expect(result.connectionIssues).toHaveLength(1)
+  expect(result.connectionIssues[0]?.name).toBe(`mcp:${slackConnection.id}:*`)
+  expect(result.connectionIssues[0]?.status).toBe("needs_connection")
+  expect(result.connectionIssues[0]?.score).toBeGreaterThanOrEqual(7)
+  expect(result.matches).toHaveLength(1)
+  expect(result.matches[0]?.name).toBe(`mcp:${notionConnection.id}:notion-search`)
+  expect(result.matches[0]?.score).toBe(2)
 })

--- a/ee/apps/den-api/test/marketplace-capabilities.test.ts
+++ b/ee/apps/den-api/test/marketplace-capabilities.test.ts
@@ -1235,18 +1235,19 @@ describe("marketplace capabilities source", () => {
       createdByOrgMembershipId: owner.memberId,
     })
 
-    const matches = await externalCapabilities.searchExternalCapabilities({
+    const result = await externalCapabilities.searchExternalCapabilities({
       organizationId: owner.organizationId,
       member: owner.member,
       query: "calendar",
       redirectUriBase: "http://127.0.0.1:8790",
       limit: 5,
     })
-    expect(matches).toHaveLength(1)
-    expect(matches[0]?.name).toBe(externalCapabilities.buildExternalCapabilityName(connectionId, "*"))
-    expect(matches[0]?.method).toBe("MCP")
-    expect(matches[0]?.status).toBe("needs_connection")
-    expectYourConnectionsUrl(matches[0]?.connectionStatus?.action.url, connectionId)
+    expect(result.matches).toEqual([])
+    expect(result.connectionIssues).toHaveLength(1)
+    expect(result.connectionIssues[0]?.name).toBe(externalCapabilities.buildExternalCapabilityName(connectionId, "*"))
+    expect(result.connectionIssues[0]?.method).toBe("MCP")
+    expect(result.connectionIssues[0]?.status).toBe("needs_connection")
+    expectYourConnectionsUrl(result.connectionIssues[0]?.connectionStatus?.action.url, connectionId)
 
     const executeResult = await externalCapabilities.executeExternalCapability({
       organizationId: owner.organizationId,

--- a/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
@@ -115,6 +115,8 @@ test("agent MCP server exposes steering instructions during initialize", async (
   expect(client.getInstructions()).toContain("Settings > Connect")
   expect(client.getInstructions()).toContain("Never tell the user to reconnect OpenWork Cloud")
   expect(client.getInstructions()).toContain("connectionStatus.connectionName")
+  expect(client.getInstructions()).toContain("available_with_issues")
+  expect(client.getInstructions()).toContain("do not claim the provider is unavailable")
   expect(client.getInstructions()).toContain("schemaGuidance is advisory")
   expect(client.getInstructions()).toContain("always attempts the downstream provider call")
   expect(client.getInstructions()).toContain("invalid_capability_arguments")
@@ -137,16 +139,62 @@ test("capability search results include structured output alongside text compati
   }]
   const result = agentModule.capabilitySearchToolResult(matches)
 
-  expect(result.structuredContent).toEqual({ matches })
-  expect(JSON.parse(result.content[0]?.text ?? "{}")).toEqual({ matches })
+  expect(result.structuredContent).toEqual({
+    availability: "available",
+    matches,
+    connectionIssues: [],
+  })
+  expect(JSON.parse(result.content[0]?.text ?? "{}")).toEqual(result.structuredContent)
+})
+
+test("capability search keeps callable matches usable when another connection has an issue", () => {
+  const matches = [{
+    name: "mcp:connected:slack-search",
+    method: "MCP",
+    path: "https://mcp.slack.test",
+    score: 10,
+    summary: "[Slack] Search messages",
+    pathParams: [],
+    queryParams: [],
+    hasBody: true,
+  }]
+  const connectionIssues = [{
+    name: "mcp:disconnected:*",
+    method: "MCP",
+    path: "https://mcp.slack.test",
+    score: 7,
+    summary: "[Slack] Connection required",
+    pathParams: [],
+    queryParams: [],
+    hasBody: false,
+    kind: "connection_status",
+    status: "needs_connection",
+  }]
+  const result = agentModule.capabilitySearchToolResult(matches, connectionIssues)
+
+  expect(result.structuredContent).toEqual({
+    availability: "available_with_issues",
+    matches,
+    connectionIssues,
+  })
+  expect(JSON.parse(result.content[0]?.text ?? "{}")).toEqual(result.structuredContent)
+
+  const unavailable = agentModule.capabilitySearchToolResult([], connectionIssues)
+  expect(unavailable.structuredContent).toEqual({
+    availability: "unavailable",
+    matches: [],
+    connectionIssues,
+  })
 })
 
 test("capability search preserves the bounded-fanout coverage warning", () => {
-  const result = agentModule.capabilitySearchToolResult([], "External MCP search inspected 16 of 17 eligible connections. Results may be incomplete.")
+  const result = agentModule.capabilitySearchToolResult([], [], "External MCP search inspected 16 of 17 eligible connections. Results may be incomplete.")
   const structured = result.structuredContent
 
   expect(structured).toEqual({
+    availability: "no_matches",
     matches: [],
+    connectionIssues: [],
     hint: "No matches. Try broader or different keywords. External MCP search inspected 16 of 17 eligible connections. Results may be incomplete.",
   })
   expect(JSON.parse(result.content[0]?.text ?? "{}")).toEqual(structured)
@@ -277,6 +325,7 @@ test("successful provider output preserves advisory schema guidance as additiona
 
 test("structured search output remains compatible with marketplace match kinds and statuses", () => {
   const result = agentModule.SEARCH_CAPABILITIES_OUTPUT_SCHEMA.safeParse({
+    availability: "available",
     matches: [{
       name: "marketplace:plugin:skill",
       method: "MARKETPLACE",
@@ -289,6 +338,7 @@ test("structured search output remains compatible with marketplace match kinds a
       kind: "skill",
       status: "needs_install",
     }],
+    connectionIssues: [],
   })
 
   expect(result.success).toBe(true)
@@ -306,7 +356,7 @@ test("capability discovery is marked read-only while generic execution remains g
   })
 })
 
-test("connection status ranks above unrelated callable tools without distorting relevance scores", () => {
+test("connection status does not outrank a more relevant callable tool", () => {
   type ConnectionStatusMatch = CapabilityMatch & { kind: "connection_status" }
   const callableMatch: CapabilityMatch = {
     name: "slack_search_emojis",
@@ -333,6 +383,6 @@ test("connection status ranks above unrelated callable tools without distorting 
 
   matches.sort(compareCapabilityMatches)
 
-  expect(matches[0]?.kind).toBe("connection_status")
-  expect(matches[0]?.score).toBe(7)
+  expect(matches[0]?.name).toBe("slack_search_emojis")
+  expect(matches[0]?.score).toBe(20)
 })

--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -165,6 +165,14 @@ Clients normally refresh automatically. The values matter when diagnosing reconn
 
 Search can include OpenWork Cloud resources such as config objects, connectors, plugins, marketplaces, skills, workers, members, roles, teams, model providers, and org-connected external MCP tools when those capabilities are enabled and shared with the member.
 
+Search results keep usable capabilities and connector health separate:
+
+- `availability` is `available`, `available_with_issues`, `unavailable`, or `no_matches`.
+- `matches` contains only callable capabilities.
+- `connectionIssues` contains matching downstream connections that need setup or returned an error, including their specific recovery action.
+
+`available_with_issues` means at least one matching capability is callable even though another matching connection needs attention. Clients should use the callable match and present the separate connection action without describing the provider as unavailable. The requested search limit applies independently to `matches` and `connectionIssues`, so an unhealthy duplicate connection cannot consume the callable-result budget.
+
 Availability is governed by organization membership, role, policy, and exposure allowlists. It intentionally does not expose authentication internals, admin-only system routes, webhooks, API-key creation or deletion, or credential-returning endpoints.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- separate callable MCP capabilities from downstream connection health in `search_capabilities`
- return an explicit `availability` state plus independent `matches` and `connectionIssues` collections
- keep a healthy duplicate provider usable when another connection for the same provider is disconnected or erroring
- document the response contract and agent behavior

## Root cause

External MCP search previously mixed `connection_status` pseudo-matches into the same ranked, bounded array as callable tools. Status entries received global priority, so a disconnected Slack connection could consume the result budget or rank ahead of tools from a healthy Slack connection. The agent then had no unambiguous query-level signal that the provider was still available.

## Behavior

`search_capabilities` now reports:

- `available`: callable matches, no matching connection issues
- `available_with_issues`: callable matches and separate matching connection issues
- `unavailable`: matching connection issues, no callable match
- `no_matches`: neither collection has a result

Callable matches and connection issues each have an independent bounded limit. Existing connection-action details, tenant/member scoping, live probes, diagnostic redaction, and execution behavior are unchanged.

## Verification

- `@openwork-ee/den-api` affected MCP/marketplace/diagnostic suite: 110 passing
- duplicate-provider database integration: live healthy Slack MCP plus disconnected Slack connection returns one callable match, one connection issue, and `available_with_issues`
- `@openwork-ee/den-api` build: passing
- `openwork-server` Cloud MCP health and reconcile E2E suites: 27 passing
- final focused agent response tests: 12 passing
- `git diff --check`: passing

The aggregate `bun test` invocation for all 129 Den API test files in one process is not a clean repository gate: it produced 793 passes and 122 unrelated failures from shared module mocks/environment state, including files that pass in the focused invocation above. A standalone Den API `tsc` command is also not exposed because that workspace does not install `tsc`; the package build completed successfully.

## Risk and compatibility

This intentionally changes the `search_capabilities` response contract: connection-status pseudo-matches move out of `matches` into `connectionIssues`, and `availability` is required. Repository consumers that parse callable `matches` remain compatible; the agent instructions and public Cloud MCP documentation now describe the new fields. No application or server consumer in this repository depended on status pseudo-matches being in `matches`.

No credential ownership, OAuth, authorization, tenant filtering, provider execution, or diagnostic payload behavior changed. No UI surface changed, so no screenshot/video proof was collected.
