### PR TITLE
feat(desktop): allow policies to disable Alpha updates

### DIFF
--- a/apps/app/src/app/lib/version-gate.ts
+++ b/apps/app/src/app/lib/version-gate.ts
@@ -10,6 +10,7 @@ import {
   type DenAppVersionMetadata,
   type DenDesktopConfig,
 } from "./den";
+import type { ReleaseChannel } from "../types";
 
 declare global {
   interface Window {
@@ -123,6 +124,21 @@ export function isUpdateAllowedByDesktopConfig(
   return desktopConfig.allowedDesktopVersions.some(
     (allowedVersion) => compareVersions(updateVersion, allowedVersion) === 0,
   );
+}
+
+export function isAlphaChannelAllowedByDesktopConfig(
+  desktopConfig: DenDesktopConfig | null | undefined,
+): boolean {
+  return desktopConfig?.allowAlphaUpdates !== false;
+}
+
+export function resolveDesktopUpdateChannel(
+  channel: ReleaseChannel,
+  desktopConfig: DenDesktopConfig | null | undefined,
+): ReleaseChannel {
+  return channel === "alpha" && !isAlphaChannelAllowedByDesktopConfig(desktopConfig)
+    ? "stable"
+    : channel;
 }
 
 function maxAllowedDesktopVersion(desktopConfig: DenDesktopConfig | null | undefined): string | null {
@@ -313,6 +329,7 @@ export async function isAlphaUpdateAllowed(
   updateVersion: string,
   desktopConfig: DenDesktopConfig | null | undefined,
 ): Promise<boolean> {
+  if (!isAlphaChannelAllowedByDesktopConfig(desktopConfig)) return false;
   const latestAppVersion = await readDenLatestAppVersion();
   if (!latestAppVersion) return false;
   const effectiveMaxVersion = effectiveMaxDesktopVersion(latestAppVersion, desktopConfig);

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -28,7 +28,11 @@ import {
   type DenOrgSummary,
 } from "@/app/lib/den";
 import { applyBrandAppName, applyBrandIcon, relaunchDesktopApp } from "@/app/lib/desktop";
-import { isAlphaUpdateAllowed, resolveFreshStableDesktopUpdate } from "@/app/lib/version-gate";
+import {
+  isAlphaChannelAllowedByDesktopConfig,
+  isAlphaUpdateAllowed,
+  resolveFreshStableDesktopUpdate,
+} from "@/app/lib/version-gate";
 import { exchangeHandoffAndSignIn } from "@/app/lib/den-handoff";
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
 import { usePlatform } from "../../kernel/platform";
@@ -108,6 +112,13 @@ async function stageOnboardingUpdate(
   if (!updater?.getChannel || !updater.check || !updater.download) return false;
 
   const channelState = await updater.getChannel();
+  if (
+    channelState.channel === "alpha" &&
+    !isAlphaChannelAllowedByDesktopConfig(desktopConfig)
+  ) {
+    await updater.setChannel?.("stable");
+    return false;
+  }
   let targetVersion: string | undefined;
   if (channelState.channel === "stable") {
     const selection = await resolveFreshStableDesktopUpdate({

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -3,10 +3,12 @@ import { useCallback, useEffect, useReducer, useRef, useState } from "react";
 
 import type { DenDesktopConfig } from "../../../../app/lib/den";
 import {
+  isAlphaChannelAllowedByDesktopConfig,
   isAlphaUpdateAllowed,
   isUpdateAllowed,
   isUpdateAllowedByDesktopConfig,
   resolveAutomaticStableDesktopUpdate,
+  resolveDesktopUpdateChannel,
   resolveFreshStableDesktopUpdate,
 } from "../../../../app/lib/version-gate";
 import type { ReleaseChannel } from "../../../../app/types";
@@ -128,6 +130,55 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
   });
   const { appVersion, updateEnv } = envState;
   const autoCheckKeyRef = useRef<string | null>(null);
+  const availableReleaseChannelRef = useRef<ReleaseChannel | null>(null);
+  const downloadedReleaseChannelRef = useRef<ReleaseChannel | null>(null);
+  const desktopConfigRef = useRef(desktopConfig);
+  desktopConfigRef.current = desktopConfig;
+  const policyReleaseChannel = resolveDesktopUpdateChannel(
+    releaseChannel,
+    desktopConfig,
+  );
+
+  const resolvePolicyReleaseChannel = useCallback(
+    async (channel: ReleaseChannel) => {
+      if (
+        channel !== "alpha" ||
+        !isAlphaChannelAllowedByDesktopConfig(desktopConfig)
+      ) {
+        return {
+          channel: resolveDesktopUpdateChannel(channel, desktopConfig),
+          desktopConfig,
+        };
+      }
+
+      const freshDesktopConfig = await refreshDesktopConfig();
+      return {
+        channel: resolveDesktopUpdateChannel(channel, freshDesktopConfig),
+        desktopConfig: freshDesktopConfig,
+      };
+    },
+    [desktopConfig, refreshDesktopConfig],
+  );
+
+  useEffect(() => {
+    if (policyReleaseChannel !== releaseChannel) {
+      onReleaseChannelChange(policyReleaseChannel);
+    }
+    if (isAlphaChannelAllowedByDesktopConfig(desktopConfig)) return;
+    if (
+      availableReleaseChannelRef.current === "alpha" ||
+      downloadedReleaseChannelRef.current === "alpha"
+    ) {
+      availableReleaseChannelRef.current = null;
+      downloadedReleaseChannelRef.current = null;
+      setUpdateStatus(null);
+    }
+  }, [
+    desktopConfig,
+    onReleaseChannelChange,
+    policyReleaseChannel,
+    releaseChannel,
+  ]);
 
   useEffect(() => {
     if (!isElectronRuntime()) return;
@@ -142,11 +193,11 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       .then(async (state) => {
         if (cancelled) return;
         dispatchEnvState({ type: "app-version", appVersion: state.currentVersion ?? null });
-        if (state.channel && state.channel !== releaseChannel && bridge.setChannel) {
-          const nextState = await bridge.setChannel(releaseChannel);
+        if (state.channel && state.channel !== policyReleaseChannel && bridge.setChannel) {
+          const nextState = await bridge.setChannel(policyReleaseChannel);
           if (cancelled) return;
           dispatchEnvState({ type: "app-version", appVersion: nextState.currentVersion ?? null });
-          if (nextState.channel && nextState.channel !== releaseChannel) {
+          if (nextState.channel && nextState.channel !== policyReleaseChannel) {
             onReleaseChannelChange(nextState.channel);
           }
         }
@@ -159,7 +210,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     return () => {
       cancelled = true;
     };
-  }, [onReleaseChannelChange, releaseChannel]);
+  }, [onReleaseChannelChange, policyReleaseChannel]);
 
   const downloadUpdate = useCallback(async (channelOverride?: ReleaseChannel) => {
     const bridge = electronUpdaterBridge();
@@ -167,6 +218,26 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       const message = "Electron updater downloads are available only in the Electron desktop app.";
       setUpdateStatus({ state: "error", message });
       setError(message);
+      return;
+    }
+
+    const requestedReleaseChannel =
+      channelOverride ??
+      availableReleaseChannelRef.current ??
+      releaseChannel;
+    const releaseChannelResolution = await resolvePolicyReleaseChannel(
+      requestedReleaseChannel,
+    ).catch((error: unknown) => {
+      setUpdateStatus({ state: "error", message: describeError(error) });
+      return null;
+    });
+    if (!releaseChannelResolution) return;
+    if (releaseChannelResolution.channel !== requestedReleaseChannel) {
+      onReleaseChannelChange(releaseChannelResolution.channel);
+      await bridge.setChannel?.(releaseChannelResolution.channel);
+      availableReleaseChannelRef.current = null;
+      downloadedReleaseChannelRef.current = null;
+      setUpdateStatus(null);
       return;
     }
 
@@ -196,20 +267,40 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         setUpdateStatus({ state: "error", message: result?.reason ?? "Update download failed." });
         return;
       }
+      if (
+        releaseChannelResolution.channel === "alpha" &&
+        !isAlphaChannelAllowedByDesktopConfig(desktopConfigRef.current)
+      ) {
+        onReleaseChannelChange("stable");
+        await bridge.setChannel?.("stable");
+        availableReleaseChannelRef.current = null;
+        downloadedReleaseChannelRef.current = null;
+        setUpdateStatus(null);
+        return;
+      }
+      availableReleaseChannelRef.current = null;
+      downloadedReleaseChannelRef.current = releaseChannelResolution.channel;
       setUpdateStatus((current) => ({
         ...(current ?? {}),
         state: "ready",
       }));
+    } catch (error) {
+      setUpdateStatus({ state: "error", message: describeError(error) });
     } finally {
       unsubProgress?.();
     }
-  }, [desktopConfig, releaseChannel, setError]);
+  }, [
+    onReleaseChannelChange,
+    releaseChannel,
+    resolvePolicyReleaseChannel,
+    setError,
+  ]);
 
   const runCheckForUpdates = useCallback(async (
     channelOverride?: ReleaseChannel,
     manual = false,
   ) => {
-    const activeReleaseChannel = channelOverride ?? releaseChannel;
+    const requestedReleaseChannel = channelOverride ?? releaseChannel;
     const bridge = electronUpdaterBridge();
     if (!bridge?.check) {
       const message = "Electron update checks are available only in the Electron desktop app.";
@@ -221,7 +312,15 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     setUpdateStatus({ state: "checking" });
     try {
       let targetVersion: string | undefined;
-      const freshDesktopConfig = desktopConfig;
+      const releaseChannelResolution = await resolvePolicyReleaseChannel(
+        requestedReleaseChannel,
+      );
+      const activeReleaseChannel = releaseChannelResolution.channel;
+      const freshDesktopConfig = releaseChannelResolution.desktopConfig;
+      if (activeReleaseChannel !== requestedReleaseChannel) {
+        onReleaseChannelChange(activeReleaseChannel);
+        await bridge.setChannel?.(activeReleaseChannel);
+      }
       if (manual && activeReleaseChannel === "stable") {
         const channelState = await bridge.getChannel?.();
         const currentVersion = channelState?.currentVersion ?? appVersion;
@@ -302,12 +401,15 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
         setUpdateStatus({ state: "error", message: result.reason });
         return;
       }
+      const latestDesktopConfig = checkedReleaseChannel === "alpha"
+        ? desktopConfigRef.current
+        : freshDesktopConfig;
       const availableAllowed = result.available && result.latestVersion
         ? targetVersion
           ? result.latestVersion === targetVersion
           : checkedReleaseChannel === "alpha"
-            ? await isAlphaUpdateAllowed(result.latestVersion, freshDesktopConfig)
-            : await isUpdateAllowed(result.latestVersion, freshDesktopConfig)
+            ? await isAlphaUpdateAllowed(result.latestVersion, latestDesktopConfig)
+            : await isUpdateAllowed(result.latestVersion, latestDesktopConfig)
         : result.available;
       const nextStatus: Exclude<SettingsUpdateStatus, null> = availableAllowed
         ? {
@@ -324,6 +426,10 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
             date: result.releaseDate ?? undefined,
             notes: releaseNotesToText(result.releaseNotes),
           };
+      availableReleaseChannelRef.current = availableAllowed
+        ? checkedReleaseChannel
+        : null;
+      downloadedReleaseChannelRef.current = null;
       setUpdateStatus(nextStatus);
       if (availableAllowed && updateAutoDownload) {
         await downloadUpdate(checkedReleaseChannel);
@@ -331,7 +437,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     } catch (error) {
       setUpdateStatus({ state: "error", message: describeError(error) });
     }
-  }, [appVersion, desktopConfig, downloadUpdate, onReleaseChannelChange, refreshDesktopConfig, releaseChannel, setError, updateAutoDownload]);
+  }, [appVersion, downloadUpdate, onReleaseChannelChange, refreshDesktopConfig, releaseChannel, resolvePolicyReleaseChannel, setError, updateAutoDownload]);
 
   const checkForUpdates = useCallback(
     (channelOverride?: ReleaseChannel) => runCheckForUpdates(channelOverride, true),
@@ -340,11 +446,11 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
 
   useEffect(() => {
     if (!updateAutoCheck || updateEnv?.supported === false) return;
-    const key = `${releaseChannel}:${appVersion ?? "unknown"}`;
+    const key = `${policyReleaseChannel}:${appVersion ?? "unknown"}`;
     if (autoCheckKeyRef.current === key) return;
     autoCheckKeyRef.current = key;
     void runCheckForUpdates(undefined, false);
-  }, [appVersion, releaseChannel, runCheckForUpdates, updateAutoCheck, updateEnv?.supported]);
+  }, [appVersion, policyReleaseChannel, runCheckForUpdates, updateAutoCheck, updateEnv?.supported]);
 
   // Run a check when the native "Check for Updates..." menu item was used.
   const updateCheckRequestedAt = useUpdateCheckRequestStore((state) => state.requestedAt);
@@ -362,29 +468,45 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       setError(message);
       return;
     }
-    const result = await bridge.installAndRestart();
-    if (!result?.ok) {
-      setUpdateStatus({ state: "error", message: result?.reason ?? "Update install failed." });
+    try {
+      if (downloadedReleaseChannelRef.current === "alpha") {
+        const releaseChannelResolution = await resolvePolicyReleaseChannel("alpha");
+        if (releaseChannelResolution.channel !== "alpha") {
+          onReleaseChannelChange(releaseChannelResolution.channel);
+          await bridge.setChannel?.(releaseChannelResolution.channel);
+          downloadedReleaseChannelRef.current = null;
+          setUpdateStatus(null);
+          return;
+        }
+      }
+      const result = await bridge.installAndRestart();
+      if (!result?.ok) {
+        setUpdateStatus({ state: "error", message: result?.reason ?? "Update install failed." });
+      }
+    } catch (error) {
+      setUpdateStatus({ state: "error", message: describeError(error) });
     }
-  }, [setError]);
+  }, [onReleaseChannelChange, resolvePolicyReleaseChannel, setError]);
 
   const setReleaseChannel = useCallback(
     async (next: ReleaseChannel) => {
-      onReleaseChannelChange(next);
       const bridge = electronUpdaterBridge();
-      if (!bridge?.setChannel) return;
       try {
-        const state = await bridge.setChannel(next);
+        const releaseChannelResolution = await resolvePolicyReleaseChannel(next);
+        const allowedReleaseChannel = releaseChannelResolution.channel;
+        onReleaseChannelChange(allowedReleaseChannel);
+        if (!bridge?.setChannel) return;
+        const state = await bridge.setChannel(allowedReleaseChannel);
         dispatchEnvState({ type: "app-version", appVersion: state.currentVersion ?? null });
-        if (state.channel && state.channel !== next) {
+        if (state.channel && state.channel !== allowedReleaseChannel) {
           onReleaseChannelChange(state.channel);
         }
-        await checkForUpdates(state.channel ?? next);
+        await checkForUpdates(state.channel ?? allowedReleaseChannel);
       } catch (error) {
         setUpdateStatus({ state: "error", message: describeError(error) });
       }
     },
-    [checkForUpdates, onReleaseChannelChange],
+    [checkForUpdates, onReleaseChannelChange, resolvePolicyReleaseChannel],
   );
 
   return {

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2430,7 +2430,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             installUpdateAndRestart={electronUpdaterState.installUpdateAndRestart}
             releaseChannel={local.prefs.releaseChannel ?? "stable"}
             onReleaseChannelChange={electronUpdaterState.setReleaseChannel}
-            alphaChannelSupported={isElectronRuntime() && isMacPlatform()}
+            alphaChannelSupported={
+              isElectronRuntime() &&
+              isMacPlatform() &&
+              desktopConfig.config.allowAlphaUpdates !== false
+            }
           />
         );
       case "recovery":

--- a/apps/app/tests/den-desktop-config.test.ts
+++ b/apps/app/tests/den-desktop-config.test.ts
@@ -80,6 +80,15 @@ describe("Den desktop config client", () => {
     }).onboardingPromptDescriptions).toBeUndefined();
   });
 
+  test("normalizes the alpha update desktop policy", () => {
+    expect(normalizeDenDesktopConfig({
+      allowAlphaUpdates: false,
+    }).allowAlphaUpdates).toBe(false);
+    expect(normalizeDenDesktopConfig({
+      allowAlphaUpdates: "false",
+    }).allowAlphaUpdates).toBeUndefined();
+  });
+
   test("selects targeted onboarding prompts by priority before default fallback", () => {
     const defaultPrompts = ["Default task one", "Default task two"];
 

--- a/apps/app/tests/version-gate.test.ts
+++ b/apps/app/tests/version-gate.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from "bun:test";
 import {
+  isAlphaChannelAllowedByDesktopConfig,
+  isAlphaUpdateAllowed,
   resolveAutomaticStableDesktopUpdate,
+  resolveDesktopUpdateChannel,
   resolveFreshStableDesktopUpdate,
   selectStableDesktopUpdate,
 } from "../src/app/lib/version-gate";
@@ -10,6 +13,28 @@ const metadata = {
   latestAppVersion: "0.17.24",
   publishedDesktopVersions: ["0.17.22", "0.17.23", "0.17.24"],
 };
+
+describe("alpha desktop update policy", () => {
+  test("keeps alpha available when the policy is missing or enabled", () => {
+    expect(isAlphaChannelAllowedByDesktopConfig({})).toBe(true);
+    expect(isAlphaChannelAllowedByDesktopConfig({ allowAlphaUpdates: true })).toBe(true);
+    expect(resolveDesktopUpdateChannel("alpha", {})).toBe("alpha");
+  });
+
+  test("forces policy-disabled alpha selections back to stable", () => {
+    const desktopConfig = { allowAlphaUpdates: false };
+
+    expect(isAlphaChannelAllowedByDesktopConfig(desktopConfig)).toBe(false);
+    expect(resolveDesktopUpdateChannel("alpha", desktopConfig)).toBe("stable");
+    expect(resolveDesktopUpdateChannel("stable", desktopConfig)).toBe("stable");
+  });
+
+  test("blocks policy-disabled alpha builds before consulting Den", async () => {
+    await expect(
+      isAlphaUpdateAllowed("999.0.0-alpha.1", { allowAlphaUpdates: false }),
+    ).resolves.toBe(false);
+  });
+});
 
 describe("selectStableDesktopUpdate", () => {
   test("selects the highest approved published release above the installed version", () => {

--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -242,6 +242,10 @@ async function cleanStaleUpdaterState(app) {
 
 // electron-updater wiring. Packaged-only; dev builds skip this so the
 // updater doesn't try to probe a non-existent release channel.
+export function preventPendingUpdaterInstall(updater) {
+  if (updater) updater.autoInstallOnAppQuit = false;
+}
+
 export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
   let autoUpdaterInstance = null;
   let autoUpdaterLoaded = false;
@@ -318,6 +322,10 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
     updateDownloaded = false;
     const updater = await ensureAutoUpdater();
     if (updater) {
+      // A channel change invalidates any previously downloaded update. This
+      // also prevents an Alpha build from installing automatically on quit
+      // after an organization policy moves the desktop back to Stable.
+      preventPendingUpdaterInstall(updater);
       return applyElectronUpdaterFeed(app, updater);
     }
     return updaterChannelState(app, channel);
@@ -395,6 +403,7 @@ export function registerUpdaterIpc({ app, ipcMain, getMainWindow }) {
       // Clear any stuck ShipIt state from a prior aborted install so this
       // download applies cleanly on quit.
       await cleanStaleUpdaterState(app);
+      updater.autoInstallOnAppQuit = true;
       await updater.downloadUpdate();
       updateDownloaded = true;
       return { ok: true };

--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -1,7 +1,12 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
 
-import { registerUpdaterIpc, staleUpdaterStatePaths, targetedStableUpdaterFeed } from "./updater.mjs";
+import {
+  preventPendingUpdaterInstall,
+  registerUpdaterIpc,
+  staleUpdaterStatePaths,
+  targetedStableUpdaterFeed,
+} from "./updater.mjs";
 
 const fakeApp = { getPath: (key) => (key === "home" ? "/Users/test" : `/Users/test/${key}`) };
 
@@ -70,5 +75,14 @@ describe("installAndRestart", () => {
       ok: false,
       reason: "update-not-downloaded",
     });
+  });
+});
+
+describe("release channel changes", () => {
+  it("prevents a previously downloaded update from installing on quit", () => {
+    const updater = { autoInstallOnAppQuit: true };
+
+    preventPendingUpdaterInstall(updater);
+    assert.equal(updater.autoInstallOnAppQuit, false);
   });
 });

--- a/ee/apps/den-api/test/me-desktop-config.test.ts
+++ b/ee/apps/den-api/test/me-desktop-config.test.ts
@@ -144,6 +144,7 @@ beforeAll(async () => {
       isDefault: true,
       isEnabled: true,
       policy: {
+        allowAlphaUpdates: false,
         onboardingPrompts: defaultOnboardingPrompts,
         onboardingPromptDescriptions: defaultOnboardingPromptDescriptions,
       },
@@ -313,6 +314,7 @@ test("GET /v1/me/desktop-config exposes the effective connectEnabled org flag", 
 
   const defaultBody = await requestDesktopConfig(onboardingOrganizationId)
   expect(defaultBody.connectEnabled).toBe(true)
+  expect(defaultBody.allowAlphaUpdates).toBe(false)
 
   const disabledBody = await requestDesktopConfig(disabledOrganizationId)
   expectConnectEnabled(disabledBody, disabledMetadata)
@@ -334,6 +336,7 @@ test("desktop policy CRUD preserves, replaces, and clears onboarding prompts and
       policyName: "CRUD onboarding policy",
       priority: 3,
       policy: {
+        allowAlphaUpdates: false,
         allowZenModel: true,
         onboardingPrompts: ["CRUD prompt one", "CRUD prompt two"],
         onboardingPromptDescriptions: ["CRUD card one", "CRUD card two"],
@@ -346,6 +349,7 @@ test("desktop policy CRUD preserves, replaces, and clears onboarding prompts and
   const created = expectDesktopPolicy(createPayload)
   crudDesktopPolicyId = expectString(created.id, "Created desktop policy was missing id")
   expect(created.priority).toBe(3)
+  expect(expectRecord(created.policy, "Created desktop policy was missing policy").allowAlphaUpdates).toBe(false)
   expect(expectRecord(created.policy, "Created desktop policy was missing policy").onboardingPrompts).toEqual(["CRUD prompt one", "CRUD prompt two"])
   expect(expectRecord(created.policy, "Created desktop policy was missing policy").onboardingPromptDescriptions).toEqual(["CRUD card one", "CRUD card two"])
 
@@ -355,6 +359,8 @@ test("desktop policy CRUD preserves, replaces, and clears onboarding prompts and
     expectedStatus: 200,
   })
   if (!listPayload) throw new Error("List response was empty")
+  const definitions = Array.isArray(listPayload.definitions) ? listPayload.definitions : []
+  expect(definitions.some((definition) => isRecord(definition) && definition.id === "allowAlphaUpdates")).toBe(true)
   const listed = findListedDesktopPolicy(listPayload, crudDesktopPolicyId)
   expect(listed.priority).toBe(3)
   expect(expectRecord(listed.policy, "Listed desktop policy was missing policy").onboardingPrompts).toEqual(["CRUD prompt one", "CRUD prompt two"])

--- a/packages/types/src/den/desktop-policies.ts
+++ b/packages/types/src/den/desktop-policies.ts
@@ -75,6 +75,15 @@ export const desktopPolicyDefinitions = [
     defaultValue: true,
   },
   {
+    id: "allowAlphaUpdates",
+    name: "Alpha updates",
+    description:
+      "Allow users to opt into experimental Alpha desktop updates.",
+    userNotice:
+      "Your organization administrator has disabled Alpha desktop updates.",
+    defaultValue: true,
+  },
+  {
     id: "showWelcomePage",
     name: "Welcome Page",
     description: "Show the Getting Started page to new users.",


### PR DESCRIPTION
## Summary

- add an `allowAlphaUpdates` desktop policy, enabled by default for backward compatibility
- expose the policy through the existing Den policy definition, persistence, and effective desktop-config flow
- hide Alpha selection and reconcile managed desktops back to Stable when the policy is disabled
- refresh policy before Alpha checks, downloads, onboarding staging, and installation
- prevent an already-downloaded Alpha update from auto-installing after the channel is revoked

## End-to-end behavior

An isolated current-schema MySQL database was used to exercise the Den admin policy CRUD and member desktop-config endpoints. The test persisted `allowAlphaUpdates: false`, returned the new policy definition to the admin surface, and returned the effective disabled value to the desktop consumer.

The desktop policy normalization and channel-selection tests then verified that missing/enabled policies preserve Alpha access while a disabled policy resolves Alpha to Stable and blocks Alpha builds before consulting release metadata. Electron updater coverage verifies that a channel change prevents a previously downloaded update from installing on quit.

## Checks

- `pnpm --filter @openwork/types build` — passed
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/app test` — passed, 354 tests
- `pnpm --filter @openwork-ee/den-api build` — passed
- isolated Den DB schema push plus `bun test test/me-desktop-config.test.ts` — passed, 3 tests / 72 assertions
- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm --filter @openwork/desktop typecheck:electron` — passed
- `pnpm --filter @openwork/desktop check:electron` — passed
- `node --test apps/desktop/electron/updater.test.mjs` — passed, 7 tests / 1 platform skip
- focused app typecheck, policy tests, and updater tests repeated after rebasing onto `upstream/dev` — passed

## Remaining evidence

- Not run: a signed, packaged macOS Alpha artifact download/install. The repository test environment does not publish or sign release artifacts.
- Not run: fraimz/video/screenshots; no visual evidence was requested.
- Manual behavior has not yet been user-confirmed.
