### PR TITLE
Clarify OAuth client setup docs link

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -2011,7 +2011,7 @@ function EditConnectionDialog({
               <div className="flex items-center justify-between gap-3">
                 <p className="text-[13px] font-semibold text-gray-900">OAuth app</p>
                 <Link href={MCP_OAUTH_REDIRECT_DOCS_URL} target="_blank" rel="noreferrer" className="text-[11px] font-medium text-gray-500 underline underline-offset-2 hover:text-gray-900">
-                  How redirect URLs work
+                  Learn about OAuth client setup
                 </Link>
               </div>
               <p className="mt-1 text-[12px] leading-5 text-gray-500">Add the provider credentials here. The saved client secret remains hidden.</p>
@@ -2684,7 +2684,7 @@ function AddConnectionDialog({
               <div className="flex items-center justify-between gap-3">
                 <p className="text-[13px] font-semibold text-gray-900">OAuth app</p>
                 <Link href={MCP_OAUTH_REDIRECT_DOCS_URL} target="_blank" rel="noreferrer" className="text-[11px] font-medium text-gray-500 underline underline-offset-2 hover:text-gray-900">
-                  How redirect URLs work
+                  Learn about OAuth client setup
                 </Link>
               </div>
               <p className="mt-1 text-[12px] leading-5 text-gray-500">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -2011,7 +2011,7 @@ function EditConnectionDialog({
               <div className="flex items-center justify-between gap-3">
                 <p className="text-[13px] font-semibold text-gray-900">OAuth app</p>
                 <Link href={MCP_OAUTH_REDIRECT_DOCS_URL} target="_blank" rel="noreferrer" className="text-[11px] font-medium text-gray-500 underline underline-offset-2 hover:text-gray-900">
-                  Learn about OAuth client setup
+                  OAuth setup
                 </Link>
               </div>
               <p className="mt-1 text-[12px] leading-5 text-gray-500">Add the provider credentials here. The saved client secret remains hidden.</p>
@@ -2684,7 +2684,7 @@ function AddConnectionDialog({
               <div className="flex items-center justify-between gap-3">
                 <p className="text-[13px] font-semibold text-gray-900">OAuth app</p>
                 <Link href={MCP_OAUTH_REDIRECT_DOCS_URL} target="_blank" rel="noreferrer" className="text-[11px] font-medium text-gray-500 underline underline-offset-2 hover:text-gray-900">
-                  Learn about OAuth client setup
+                  OAuth setup
                 </Link>
               </div>
               <p className="mt-1 text-[12px] leading-5 text-gray-500">

--- a/ee/apps/den-web/tests/mcp-oauth-bootstrap.test.ts
+++ b/ee/apps/den-web/tests/mcp-oauth-bootstrap.test.ts
@@ -12,7 +12,7 @@ describe("pre-registered MCP OAuth bootstrap UI contract", () => {
 
     expect(screen).toContain("Client ID (optional for now)")
     expect(screen).toContain("Add the pre-registered OAuth app")
-    expect(screen).toContain("How redirect URLs work")
+    expect(screen).toContain("Learn about OAuth client setup")
     expect(screen).toContain("#oauth-redirect-url")
     expect(screen).toContain("Register this Den instance's redirect URL with the provider")
     expect(screen).not.toContain("keepOpenForRedirect")

--- a/ee/apps/den-web/tests/mcp-oauth-bootstrap.test.ts
+++ b/ee/apps/den-web/tests/mcp-oauth-bootstrap.test.ts
@@ -12,7 +12,7 @@ describe("pre-registered MCP OAuth bootstrap UI contract", () => {
 
     expect(screen).toContain("Client ID (optional for now)")
     expect(screen).toContain("Add the pre-registered OAuth app")
-    expect(screen).toContain("Learn about OAuth client setup")
+    expect(screen).toContain("OAuth setup")
     expect(screen).toContain("#oauth-redirect-url")
     expect(screen).toContain("Register this Den instance's redirect URL with the provider")
     expect(screen).not.toContain("keepOpenForRedirect")


### PR DESCRIPTION
## Summary

- rename the OAuth app help link from “How redirect URLs work” to “OAuth setup”
- apply the shorter, broader label in both the add and edit connection flows
- update the focused UI contract test

## Why

The existing label describes only redirect URLs, while the linked documentation also explains the broader pre-registered OAuth client setup. “OAuth setup” keeps that broader meaning in a compact label.

## Checks

- `pnpm exec bun test tests/mcp-oauth-bootstrap.test.ts` — passed (2 tests)
- `pnpm typecheck` — passed
- `git diff --check` — passed

## Manual verification

Not run — developer verification deferred. Open Den Web, expand the OAuth app fields in both Add Connection and Edit Connection, confirm the link reads “OAuth setup,” and verify it opens the shared MCP connections OAuth guidance in a new tab.

## Risk

Low. This changes link copy and the matching source-contract assertion only; the existing documentation URL and behavior are unchanged.