### PR TITLE
feat(app): add Connect skills to slash search

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -91,7 +91,7 @@ export default {
   "composer.attachments_unavailable": "Attachments are unavailable.",
   "composer.behavior_label": "Behavior",
   "composer.configure": "Configure",
-  "composer.connect_skill_prompt": "Use the \"{name}\" skill from the \"{marketplace}\" marketplace to ",
+  "composer.connect_skill_prompt": "Use the \"{name}\" skill from the \"{marketplace}\" marketplace. Find it with openwork-cloud_search_capabilities, then call openwork-cloud_execute_capability with the exact capability name \"{capability}\", follow the returned skill content, and use it to ",
   "composer.default_agent": "Default agent",
   "composer.file_exceeds_limit": "{name} exceeds the 8MB limit.",
   "composer.file_kind": "File",

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -21,6 +21,7 @@ import type { ComposerMentionKind } from "./mention-encoding";
 import {
   connectSkillSlashCommandOptions,
   getSlashCommandQuery,
+  skillMenuSlashCommandName,
   skillSlashCommandName,
   type ComposerSlashCommandOption,
 } from "./slash-command";
@@ -1521,7 +1522,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                                     <div className="min-w-0 flex-1">
                                       <div className="flex items-center justify-between gap-3">
                                         <div className="min-w-0 flex-1 truncate text-xs font-semibold text-gray-11">
-                                          /{skillSlashCommandName(skill)}
+                                          /{skillMenuSlashCommandName(skill)}
                                         </div>
                                         {isLocalCapability(skill.origin) ? (
                                           <span className="shrink-0 rounded-full bg-gray-3 px-2 py-0.5 text-[10px] font-medium text-gray-11">

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -18,7 +18,12 @@ import { ModelSelect } from "@/components/model-select";
 import { LexicalPromptEditor, type LexicalPromptEditorHandle } from "./editor";
 import { listRunningAppsForMention } from "./app-mentions";
 import type { ComposerMentionKind } from "./mention-encoding";
-import { getSlashCommandQuery } from "./slash-command";
+import {
+  connectSkillSlashCommandOptions,
+  getSlashCommandQuery,
+  skillSlashCommandName,
+  type ComposerSlashCommandOption,
+} from "./slash-command";
 import { FILE_URL_RE, HTTP_URL_RE } from "./pasted-text";
 
 type MentionItem = {
@@ -298,6 +303,7 @@ export function ReactSessionComposer(props: ComposerProps) {
   const menuItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
   const commandsCacheRef = useRef<SlashCommandOption[] | null>(null);
   const commandsRequestRef = useRef<Promise<SlashCommandOption[]> | null>(null);
+  const skillsRequestRef = useRef<Promise<SkillCard[]> | null>(null);
   const commandsLoadVersionRef = useRef(0);
   const listCommandsRef = useRef(props.listCommands);
   const listSkillsRef = useRef(props.listSkills);
@@ -495,6 +501,17 @@ export function ReactSessionComposer(props: ComposerProps) {
     return request;
   }, []);
 
+  const loadSkills = useCallback(() => {
+    if (skillsRequestRef.current) return skillsRequestRef.current;
+    const listSkills = listSkillsRef.current;
+    if (!listSkills) return Promise.resolve([]);
+    const request = listSkills().finally(() => {
+      if (skillsRequestRef.current === request) skillsRequestRef.current = null;
+    });
+    skillsRequestRef.current = request;
+    return request;
+  }, []);
+
   useEffect(() => {
     const refresh = () => setExtensionStateVersion((value) => value + 1);
     window.addEventListener(OPENWORK_EXTENSION_STATE_CHANGED, refresh);
@@ -641,32 +658,34 @@ export function ReactSessionComposer(props: ComposerProps) {
   }, [toolMenuOpen]);
 
   useEffect(() => {
-    if (!toolMenuOpen) return;
+    if (!slashOpen && !toolMenuOpen) return;
     const openId = toolMenuLoadRef.current.openId;
-    const listSkills = listSkillsRef.current;
     const listMcp = listMcpRef.current;
-    if (toolMenuSection === "skills" && listSkills && !toolMenuLoadRef.current.skills) {
+    if ((slashOpen || toolMenuSection === "skills") && (!toolMenuOpen || !toolMenuLoadRef.current.skills)) {
       let cancelled = false;
-      toolMenuLoadRef.current.skills = true;
+      if (toolMenuOpen) toolMenuLoadRef.current.skills = true;
       setSkillsLoading(true);
-      void listSkills()
+      void loadSkills()
         .then((next) => {
-          if (!cancelled && toolMenuLoadRef.current.openId === openId) {
+          if (!cancelled && (!toolMenuOpen || toolMenuLoadRef.current.openId === openId)) {
             setSkills(next);
             setSkillsLoaded(true);
           }
         })
         .catch(() => {
-          if (!cancelled && toolMenuLoadRef.current.openId === openId) {
+          if (!cancelled && (!toolMenuOpen || toolMenuLoadRef.current.openId === openId)) {
             setSkills([]);
             setSkillsLoaded(true);
           }
         })
         .finally(() => {
-          if (!cancelled && toolMenuLoadRef.current.openId === openId) setSkillsLoading(false);
+          if (!cancelled && (!toolMenuOpen || toolMenuLoadRef.current.openId === openId)) setSkillsLoading(false);
         });
       return () => {
         cancelled = true;
+        if (toolMenuOpen && toolMenuLoadRef.current.openId === openId) {
+          toolMenuLoadRef.current.skills = false;
+        }
       };
     }
     if (toolMenuSection === "mcps" && listMcp && !toolMenuLoadRef.current.mcps) {
@@ -695,13 +714,17 @@ export function ReactSessionComposer(props: ComposerProps) {
       };
     }
     return undefined;
-  }, [toolMenuOpen, toolMenuSection]);
+  }, [loadSkills, slashOpen, toolMenuOpen, toolMenuSection]);
 
+  const slashItems = useMemo<ComposerSlashCommandOption[]>(
+    () => [...commands, ...connectSkillSlashCommandOptions(skills)],
+    [commands, skills],
+  );
   const slashFiltered = useMemo(() => {
     if (!slashOpen) return [];
-    if (!slashQuery) return commands.slice(0, 8);
-    return fuzzysort.go(slashQuery, commands, { keys: ["name", "description"], limit: 8 }).map((entry) => entry.obj);
-  }, [commands, slashOpen, slashQuery]);
+    if (!slashQuery) return slashItems.slice(0, 8);
+    return fuzzysort.go(slashQuery, slashItems, { keys: ["name", "description"], limit: 8 }).map((entry) => entry.obj);
+  }, [slashItems, slashOpen, slashQuery]);
   const mentionFiltered = useMemo(() => {
     if (!mentionOpen) return [];
     if (!mentionQuery) return mentionItems.slice(0, 8);
@@ -768,7 +791,11 @@ export function ReactSessionComposer(props: ComposerProps) {
     target?.scrollIntoView({ block: "nearest" });
   }, [menuIndex, activeItems.length]);
 
-  const applyCommandSelection = (command: SlashCommandOption, options?: { replaceSkillDraft?: boolean }) => {
+  const applyCommandSelection = (command: ComposerSlashCommandOption, options?: { replaceSkillDraft?: boolean }) => {
+    if (command.skill) {
+      applySkillSelection(command.skill, options);
+      return;
+    }
     if (command.source === "skill") {
       applySkillSelection(command.name, options);
       return;
@@ -786,6 +813,7 @@ export function ReactSessionComposer(props: ComposerProps) {
       const prompt = t("composer.connect_skill_prompt", {
         name: skill.name,
         marketplace: skill.marketplaceName ?? "assigned",
+        capability: skill.connectCapabilityName ?? skill.name,
       });
       if (options?.replaceSkillDraft) {
         props.onDraftChange(prompt);
@@ -1106,7 +1134,7 @@ export function ReactSessionComposer(props: ComposerProps) {
               </div>
             ) : (
               <div className="px-3 py-2 text-xs text-gray-10">
-                {!commandsLoaded && commandsLoading ? t("composer.loading_commands") : t("composer.no_commands")}
+                {(!commandsLoaded && commandsLoading) || skillsLoading ? t("composer.loading_commands") : t("composer.no_commands")}
               </div>
             )}
           </div>
@@ -1493,7 +1521,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                                     <div className="min-w-0 flex-1">
                                       <div className="flex items-center justify-between gap-3">
                                         <div className="min-w-0 flex-1 truncate text-xs font-semibold text-gray-11">
-                                          {skill.origin === "openwork-connect" ? skill.name : `/${skill.name}`}
+                                          /{skillSlashCommandName(skill)}
                                         </div>
                                         {isLocalCapability(skill.origin) ? (
                                           <span className="shrink-0 rounded-full bg-gray-3 px-2 py-0.5 text-[10px] font-medium text-gray-11">

--- a/apps/app/src/react-app/domains/session/surface/composer/slash-command.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/slash-command.ts
@@ -1,5 +1,38 @@
+import type { SkillCard, SlashCommandOption } from "@/app/types";
+
 const SLASH_COMMAND_QUERY_RE = /^\/([A-Za-z0-9_-]*)$/;
 const SLASH_COMMAND_INVOCATION_RE = /^\/([A-Za-z0-9_-]+)(?:[ \t]+([\s\S]*))?$/;
+
+export type ComposerSlashCommandOption = SlashCommandOption & {
+  skill?: SkillCard;
+};
+
+export function skillSlashCommandName(skill: Pick<SkillCard, "name" | "trigger">) {
+  const trigger = skill.trigger?.trim();
+  if (trigger && /^[A-Za-z0-9_-]+$/.test(trigger)) return trigger;
+  const slug = skill.name
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return slug || "skill";
+}
+
+export function connectSkillSlashCommandOptions(skills: SkillCard[]): ComposerSlashCommandOption[] {
+  return skills.flatMap((skill) => {
+    if (skill.origin !== "openwork-connect" || !skill.connectCapabilityName) return [];
+    return [{
+      id: `connect-skill:${skill.connectCapabilityName}`,
+      name: skillSlashCommandName(skill),
+      description: [
+        skill.description,
+        [skill.marketplaceName, skill.pluginName].filter(Boolean).join(" · "),
+      ].filter(Boolean).join(" — "),
+      source: "skill",
+      skill,
+    }];
+  });
+}
 
 export function getSlashCommandQuery(value: string) {
   const match = value.match(SLASH_COMMAND_QUERY_RE);

--- a/apps/app/src/react-app/domains/session/surface/composer/slash-command.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/slash-command.ts
@@ -18,6 +18,10 @@ export function skillSlashCommandName(skill: Pick<SkillCard, "name" | "trigger">
   return slug || "skill";
 }
 
+export function skillMenuSlashCommandName(skill: Pick<SkillCard, "name" | "trigger" | "origin">) {
+  return skill.origin === "openwork-connect" ? skillSlashCommandName(skill) : skill.name;
+}
+
 export function connectSkillSlashCommandOptions(skills: SkillCard[]): ComposerSlashCommandOption[] {
   return skills.flatMap((skill) => {
     if (skill.origin !== "openwork-connect" || !skill.connectCapabilityName) return [];

--- a/apps/app/src/react-app/domains/session/surface/connect-capability-inventory.ts
+++ b/apps/app/src/react-app/domains/session/surface/connect-capability-inventory.ts
@@ -49,6 +49,11 @@ function marketplaceCapabilityName(pluginId: string, configObjectId: string) {
   return `plugin:${pluginId}:${configObjectId}`;
 }
 
+function skillTrigger(object: DenPluginConfigObject) {
+  const path = object.currentRelativePath?.replaceAll("\\", "/");
+  return path?.match(/(?:^|\/)skills?\/([^/]+)\/SKILL\.md$/i)?.[1];
+}
+
 function remoteMcpSpecs(object: DenPluginConfigObject): RemoteMcpSpec[] {
   const payload = object.latestVersion?.normalizedPayloadJson;
   if (!payload) return [{ name: object.title, url: "" }];
@@ -105,6 +110,7 @@ function toSkill(
     name: object.title,
     path: `openwork-connect://${marketplace.id}/${plugin.id}/${object.id}`,
     description: object.description ?? undefined,
+    trigger: skillTrigger(object),
     origin: "openwork-connect",
     marketplaceName: marketplace.name,
     pluginName: plugin.name,

--- a/apps/app/tests/connect-capability-inventory.test.ts
+++ b/apps/app/tests/connect-capability-inventory.test.ts
@@ -119,6 +119,7 @@ describe("assigned OpenWork Connect capability inventory", () => {
     expect(inventory.skills).toEqual([
       expect.objectContaining({
         name: "Escalate ticket",
+        trigger: "escalate-ticket",
         origin: "openwork-connect",
         marketplaceName: "Team tools",
         pluginName: "Support kit",

--- a/apps/app/tests/connect-capability-inventory.test.ts
+++ b/apps/app/tests/connect-capability-inventory.test.ts
@@ -217,4 +217,64 @@ describe("assigned OpenWork Connect capability inventory", () => {
     expect(inventory.skills).toEqual([]);
     expect(inventory.mcpServers).toEqual([]);
   });
+
+  test("derives the trigger from Windows-style skill paths and omits it when the path is not a SKILL.md", async () => {
+    const marketplace = {
+      id: "marketplace_1",
+      name: "Team tools",
+      description: null,
+      status: "active" as const,
+      pluginCount: 1,
+      updatedAt: null,
+    };
+    const makeSkill = (id: string, title: string, currentRelativePath: string | null) => ({
+      id: `membership_${id}`,
+      pluginId: "plugin_1",
+      configObjectId: id,
+      configObject: {
+        id,
+        objectType: "skill" as const,
+        title,
+        description: null,
+        currentFileName: null,
+        currentFileExtension: null,
+        currentRelativePath,
+        status: "active" as const,
+        updatedAt: null,
+        latestVersion: null,
+      },
+    });
+
+    const inventory = await listAssignedConnectCapabilities({
+      organizationId: "org_1",
+      client: {
+        listOrgMarketplaces: async () => [marketplace],
+        getOrgMarketplaceResolved: async () => ({
+          marketplace,
+          plugins: [
+            {
+              id: "plugin_1",
+              name: "Support kit",
+              description: null,
+              status: "active",
+              memberCount: 2,
+              updatedAt: null,
+              componentCounts: { skill: 2 },
+            },
+          ],
+        }),
+        getOrgPluginResolved: async (_organizationId, plugin) => ({
+          plugin,
+          memberships: [
+            makeSkill("skill_win", "Windows skill", "skills\\escalate-ticket\\SKILL.md"),
+            makeSkill("skill_nomatch", "Loose skill", "docs/escalate-ticket/README.md"),
+          ],
+        }),
+      },
+    });
+
+    const byName = Object.fromEntries(inventory.skills.map((skill) => [skill.name, skill]));
+    expect(byName["Windows skill"]?.trigger).toBe("escalate-ticket");
+    expect(byName["Loose skill"]?.trigger).toBeUndefined();
+  });
 });

--- a/apps/app/tests/prompt-file-parts.test.ts
+++ b/apps/app/tests/prompt-file-parts.test.ts
@@ -5,6 +5,7 @@ import {
   connectSkillSlashCommandOptions,
   getSlashCommandQuery,
   parseSlashCommandInvocation,
+  skillMenuSlashCommandName,
   skillSlashCommandName,
 } from "../src/react-app/domains/session/surface/composer/slash-command";
 
@@ -102,5 +103,13 @@ describe("Connect skill slash commands", () => {
 
   test("falls back to a slash-safe slug when a skill has no trigger", () => {
     expect(skillSlashCommandName({ name: "Renewal Playbook" })).toBe("renewal-playbook");
+  });
+
+  test("does not normalize local skill labels", () => {
+    expect(skillMenuSlashCommandName({
+      name: "Local Playbook",
+      trigger: "local-playbook",
+      origin: "local",
+    })).toBe("Local Playbook");
   });
 });

--- a/apps/app/tests/prompt-file-parts.test.ts
+++ b/apps/app/tests/prompt-file-parts.test.ts
@@ -1,7 +1,12 @@
 import { describe, expect, test } from "bun:test";
 
 import { firstLineLocalFileParts } from "../src/react-app/domains/session/sync/prompt-file-parts";
-import { getSlashCommandQuery, parseSlashCommandInvocation } from "../src/react-app/domains/session/surface/composer/slash-command";
+import {
+  connectSkillSlashCommandOptions,
+  getSlashCommandQuery,
+  parseSlashCommandInvocation,
+  skillSlashCommandName,
+} from "../src/react-app/domains/session/surface/composer/slash-command";
 
 describe("first-line local file parts", () => {
   test("detects tilde paths in the first line", () => {
@@ -68,5 +73,34 @@ describe("slash-command parsing", () => {
   test("does not parse absolute file paths as commands", () => {
     expect(parseSlashCommandInvocation("/Users/omar/code/openwork/apps/app/src/file.ts\nwhy does this fail?")).toBeNull();
     expect(getSlashCommandQuery("/Users/omar/code/file.ts")).toBeNull();
+  });
+});
+
+describe("Connect skill slash commands", () => {
+  test("uses the skill trigger and preserves the remote capability identity", () => {
+    const [option] = connectSkillSlashCommandOptions([{
+      name: "Escalate ticket",
+      trigger: "escalate-ticket",
+      description: "Prepare a support escalation.",
+      path: "openwork-connect://marketplace_1/plugin_1/skill_1",
+      origin: "openwork-connect",
+      marketplaceName: "Team tools",
+      pluginName: "Support kit",
+      connectCapabilityName: "plugin:plugin_1:skill_1",
+    }]);
+
+    expect(option).toMatchObject({
+      id: "connect-skill:plugin:plugin_1:skill_1",
+      name: "escalate-ticket",
+      description: "Prepare a support escalation. — Team tools · Support kit",
+      source: "skill",
+      skill: {
+        connectCapabilityName: "plugin:plugin_1:skill_1",
+      },
+    });
+  });
+
+  test("falls back to a slash-safe slug when a skill has no trigger", () => {
+    expect(skillSlashCommandName({ name: "Renewal Playbook" })).toBe("renewal-playbook");
   });
 });

--- a/apps/app/tests/prompt-file-parts.test.ts
+++ b/apps/app/tests/prompt-file-parts.test.ts
@@ -112,4 +112,51 @@ describe("Connect skill slash commands", () => {
       origin: "local",
     })).toBe("Local Playbook");
   });
+
+  test("excludes local skills and Connect skills missing a capability identity", () => {
+    expect(
+      connectSkillSlashCommandOptions([
+        {
+          name: "Local Playbook",
+          trigger: "local-playbook",
+          path: "skill://local",
+          origin: "local",
+          connectCapabilityName: "plugin:plugin_1:skill_1",
+        },
+        {
+          name: "Unresolved",
+          trigger: "unresolved",
+          path: "openwork-connect://marketplace_1/plugin_1/skill_2",
+          origin: "openwork-connect",
+        },
+      ]),
+    ).toEqual([]);
+  });
+
+  test("falls back to a slug when the trigger contains slash-unsafe characters", () => {
+    expect(skillSlashCommandName({ name: "Escalate Ticket", trigger: "escalate ticket" })).toBe("escalate-ticket");
+    expect(skillSlashCommandName({ name: "Escalate Ticket", trigger: "skills/escalate" })).toBe("escalate-ticket");
+  });
+
+  test("keeps the provenance line usable when the skill has no description", () => {
+    const [withProvenance] = connectSkillSlashCommandOptions([{
+      name: "Escalate ticket",
+      trigger: "escalate-ticket",
+      path: "openwork-connect://marketplace_1/plugin_1/skill_1",
+      origin: "openwork-connect",
+      marketplaceName: "Team tools",
+      pluginName: "Support kit",
+      connectCapabilityName: "plugin:plugin_1:skill_1",
+    }]);
+    expect(withProvenance?.description).toBe("Team tools · Support kit");
+
+    const [withoutProvenance] = connectSkillSlashCommandOptions([{
+      name: "Escalate ticket",
+      trigger: "escalate-ticket",
+      path: "openwork-connect://marketplace_1/plugin_1/skill_1",
+      origin: "openwork-connect",
+      connectCapabilityName: "plugin:plugin_1:skill_1",
+    }]);
+    expect(withoutProvenance?.description).toBe("");
+  });
 });


### PR DESCRIPTION
## Summary

- load assigned marketplace skills when the slash palette opens, without requiring a prior visit to the Skills panel
- derive slash-safe names from each remote `skills/<name>/SKILL.md` path and show them as `/skill-name` in both skill surfaces
- preserve the exact marketplace capability ID when selected and direct the agent through `openwork-cloud_search_capabilities` and `openwork-cloud_execute_capability`
- keep workspace-local skill labels unchanged and limit the `Local` badge to local workspace capabilities

## Checks

- `pnpm --filter @openwork/app exec bun test --isolate tests/connect-capability-inventory.test.ts tests/prompt-file-parts.test.ts` — 11 passed, 18 assertions
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/app build` — passed
- `git diff --check` — passed
- GitHub Actions: i18n audit, Linux tests, and macOS tests — passed
- merge-tree against current `upstream/dev` — clean

## Manual verification

- Local app boot smoke passed: the Vite app reached `/welcome` with no browser console warnings or errors.
- The assigned-organization slash journey was not exercised in the isolated merge-readiness profile because it has no configured workspace or Den organization session.

Suggested reviewer journey:

1. Sign in to an organization with an assigned marketplace skill.
2. Start a task and type `/` followed by the skill trigger.
3. Confirm the remote skill appears as `/skill-name` with its marketplace/plugin context.
4. Confirm workspace-local skill labels remain unchanged and carry the `Local` badge.
5. Select the remote skill and confirm the composer creates the remote execution prompt containing the exact assigned capability identity.

## Risk and remaining gaps

- Remote execution still requires a healthy `openwork-cloud` MCP connection and valid organization access.
- Three Vercel project statuses report `Authorization required to deploy`; this is team authorization, not a code/build failure.
- No Den schema, credential, OAuth, or server configuration behavior changes.