### PR TITLE
fix(app): refresh assigned models on user actions

### DIFF
--- a/apps/app/src/app/cloud/sync/constants.ts
+++ b/apps/app/src/app/cloud/sync/constants.ts
@@ -1,1 +1,0 @@
-export const CLOUD_SYNC_INTERVAL_MS = 5 * 60 * 1000;

--- a/apps/app/src/react-app/domains/cloud/use-cloud-provider-auto-sync.ts
+++ b/apps/app/src/react-app/domains/cloud/use-cloud-provider-auto-sync.ts
@@ -1,32 +1,58 @@
 /** @jsxImportSource react */
 import { useEffect, useRef } from "react";
 
-import { CLOUD_SYNC_INTERVAL_MS } from "../../../app/cloud/sync/constants";
 import { denSettingsChangedEvent } from "../../../app/lib/den-session-events";
 import { useDenAuth } from "./den-auth-provider";
 
-type CloudProviderSyncReason = "sign_in" | "app_launch" | "interval" | "settings_cloud_opened";
+type CloudProviderSyncReason = "sign_in" | "app_resume";
 type SyncFn = (reason: CloudProviderSyncReason) => Promise<unknown>;
 
+export function subscribeCloudProviderSyncTriggers(input: {
+  windowTarget: EventTarget;
+  documentTarget: EventTarget;
+  isDocumentVisible: () => boolean;
+  sync: (reason: CloudProviderSyncReason) => void;
+}) {
+  const handleDenSettingsChanged = () => {
+    input.sync("sign_in");
+  };
+  const handleAppResume = () => {
+    input.sync("app_resume");
+  };
+  const handleVisibilityChange = () => {
+    if (input.isDocumentVisible()) {
+      handleAppResume();
+    }
+  };
+
+  input.windowTarget.addEventListener(denSettingsChangedEvent, handleDenSettingsChanged);
+  input.windowTarget.addEventListener("focus", handleAppResume);
+  input.windowTarget.addEventListener("online", handleAppResume);
+  input.documentTarget.addEventListener("visibilitychange", handleVisibilityChange);
+
+  return () => {
+    input.windowTarget.removeEventListener(denSettingsChangedEvent, handleDenSettingsChanged);
+    input.windowTarget.removeEventListener("focus", handleAppResume);
+    input.windowTarget.removeEventListener("online", handleAppResume);
+    input.documentTarget.removeEventListener("visibilitychange", handleVisibilityChange);
+  };
+}
+
 /**
-  * Periodic cloud-provider reconciliation, ported from dev #1509 "auto-sync
-  * cloud providers". Runs the provided sync function immediately, whenever Den
-  * settings change (for example active-org selection), and every
-  * `CLOUD_SYNC_INTERVAL_MS` while the Den session is signed-in; suspends while
-  * signed-out and lets the provider-auth store own user-visible errors.
+ * Event-driven cloud-provider reconciliation. Runs immediately after sign-in,
+ * whenever Den settings change (for example active-org selection), and when
+ * the user returns to the app or reconnects to the network. Workspace gate
+ * transitions and explicit product actions are handled by the provider store.
  *
- * Mount once (e.g. from the settings route) — the hook is idempotent
- * within a single mount, and avoids overlapping ticks using an in-flight
- * ref guard.
+ * Mount once — the provider store coalesces overlapping triggers.
  */
 export function useCloudProviderAutoSync(sync: SyncFn) {
   const denAuth = useDenAuth();
   const syncRef = useRef(sync);
-  const inFlightRef = useRef(false);
 
   // Keep the ref current so we always call the latest closure (store
-  // identity can change between mounts and we don't want to restart the
-  // timer just because the parent re-rendered).
+  // identity can change between mounts and we don't want to restart event
+  // subscriptions just because the parent re-rendered).
   useEffect(() => {
     syncRef.current = sync;
   }, [sync]);
@@ -36,36 +62,32 @@ export function useCloudProviderAutoSync(sync: SyncFn) {
 
     let cancelled = false;
 
-    const tick = async (reason: CloudProviderSyncReason = "interval") => {
-      if (inFlightRef.current || cancelled) return;
-      inFlightRef.current = true;
+    const tick = async (reason: CloudProviderSyncReason) => {
+      if (cancelled) return;
       try {
         await syncRef.current(reason);
       } catch {
-        // Network errors, org misconfig, etc. are non-fatal — we'll try
-        // again on the next interval. The refresh function owns surfacing
-        // any user-visible error state.
-      } finally {
-        inFlightRef.current = false;
+        // Network errors, org misconfig, etc. are non-fatal — the next user
+        // or lifecycle trigger retries. The refresh function owns surfacing
+        // user-visible error state.
       }
     };
 
     // Immediate pass so users see server state quickly after sign-in.
     void tick("sign_in");
 
-    const handleDenSettingsChanged = () => {
-      void tick("sign_in");
-    };
-    window.addEventListener(denSettingsChangedEvent, handleDenSettingsChanged);
-
-    const interval = window.setInterval(() => {
-      void tick();
-    }, CLOUD_SYNC_INTERVAL_MS);
+    const unsubscribe = subscribeCloudProviderSyncTriggers({
+      windowTarget: window,
+      documentTarget: document,
+      isDocumentVisible: () => document.visibilityState === "visible",
+      sync: (reason) => {
+        void tick(reason);
+      },
+    });
 
     return () => {
       cancelled = true;
-      window.removeEventListener(denSettingsChangedEvent, handleDenSettingsChanged);
-      window.clearInterval(interval);
+      unsubscribe();
     };
   }, [denAuth.isSignedIn]);
 }

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -76,7 +76,13 @@ import {
 } from "../../../../app/cloud/desktop-app-restrictions";
 
 type ProviderReturnFocusTarget = "none" | "composer";
-type CloudProviderSyncReason = "sign_in" | "app_launch" | "interval" | "settings_cloud_opened";
+type CloudProviderSyncReason =
+  | "sign_in"
+  | "app_launch"
+  | "app_resume"
+  | "model_picker_open"
+  | "new_chat"
+  | "settings_cloud_opened";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -150,6 +156,7 @@ type CreateProviderAuthStoreOptions = {
   disabledProviders: () => string[];
   checkDesktopAppRestriction: DesktopAppRestrictionChecker;
   selectedWorkspaceDisplay: () => WorkspaceDisplay;
+  providerBaseUrl: () => string;
   selectedWorkspaceRoot: () => string;
   runtimeWorkspaceId: () => string | null;
   ensureRuntimeWorkspaceId?: () => Promise<string | null | undefined>;
@@ -1215,6 +1222,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       const updated = filterProviderList(
         await ensureProviderListQuery(getReactQueryClient(), {
           client: activeClient,
+          baseUrl: options.providerBaseUrl(),
           directory: options.selectedWorkspaceRoot(),
           force: Boolean(optionsArg?.dispose || optionsArg?.force),
         }),

--- a/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
@@ -23,6 +23,7 @@ const emptyWorkspaceDisplay: WorkspaceDisplay = {
 
 export type UseSessionProviderAuthInput = {
   opencodeClient: Client | null;
+  opencodeBaseUrl: string;
   providers: ProviderListItem[];
   providerDefaults: Record<string, string>;
   providerConnectedIds: string[];
@@ -40,6 +41,7 @@ export type UseSessionProviderAuthInput = {
 export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
   const {
     opencodeClient,
+    opencodeBaseUrl,
     providers,
     providerDefaults,
     providerConnectedIds,
@@ -60,6 +62,7 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
 
   const stateRef = useRef({
     opencodeClient,
+    opencodeBaseUrl,
     providers,
     providerDefaults,
     providerConnectedIds,
@@ -70,6 +73,7 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
   });
   stateRef.current = {
     opencodeClient,
+    opencodeBaseUrl,
     providers,
     providerDefaults,
     providerConnectedIds,
@@ -92,6 +96,7 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
         providerConnectedIds: () => stateRef.current.providerConnectedIds,
         disabledProviders: () => stateRef.current.disabledProviderIds,
         checkDesktopAppRestriction: checkDesktopRestriction,
+        providerBaseUrl: () => stateRef.current.opencodeBaseUrl,
         selectedWorkspaceDisplay: () =>
           stateRef.current.selectedWorkspace
             ? ({

--- a/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
+++ b/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
@@ -3,16 +3,14 @@
 // toast, and org-restriction filtering. Extracted verbatim from
 // session-route.tsx; settings-route carries a sibling copy that should adopt
 // this hook next.
-import { useEffect, useMemo, useState } from "react";
-
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
 import type { Client, ModelOption } from "@/app/types";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import {
-  ensureProviderListQuery,
   getConnectedProviderItems,
+  useProviderListQuery,
 } from "@/react-app/infra/provider-list-query";
-import { getReactQueryClient } from "@/react-app/infra/query-client";
 import {
   openModelPickerEvent,
   pendingModelPickerProviderIdsKey,
@@ -22,22 +20,35 @@ export type UseModelPickerInput = {
   client: Client | null;
   baseUrl: string;
   workspaceRoot: string;
+  /** Called when the picker opens so callers can reconcile remote assignments. */
+  onOpen?: () => void;
   /** Optional: surface option-load failures (settings shows a toast; the session route stays silent). */
   onLoadError?: (error: unknown) => void;
 };
 
 export function useModelPicker(input: UseModelPickerInput) {
-  const { client, baseUrl, workspaceRoot, onLoadError } = input;
+  const { client, baseUrl, workspaceRoot, onOpen, onLoadError } = input;
   const checkDesktopRestriction = useCheckDesktopRestriction();
 
-  const [open, setOpen] = useState(false);
+  const [open, setOpenState] = useState(false);
   const [compactOpen, setCompactOpen] = useState(false);
   const [query, setQuery] = useState("");
-  const [modelOptions, setModelOptions] = useState<ModelOption[]>([]);
   // Provider IDs that were just added — used to highlight them as
   // "Recently added" in the model picker even after they've been
   // marked as seen in localStorage.
   const [recentProviderIds, setRecentProviderIds] = useState<Set<string>>(new Set());
+  const providerListQuery = useProviderListQuery({
+    client,
+    baseUrl,
+    directory: workspaceRoot || undefined,
+    enabled: open,
+  });
+  const setOpen = useCallback((nextOpen: boolean) => {
+    setOpenState(nextOpen);
+    if (nextOpen) {
+      onOpen?.();
+    }
+  }, [onOpen]);
 
   // Open model picker when the global toast's "Pick a new default?" is clicked
   useEffect(() => {
@@ -72,63 +83,55 @@ export function useModelPicker(input: UseModelPickerInput) {
     }
   }, []);
 
-  // Load the picker list lazily the first time the modal opens. Uses the
-  // cached catalog when available, otherwise re-fetches.
+  // Surface option-load failures when requested. The provider query remains
+  // subscribed while the picker is open, so a startup cloud import updates an
+  // already-open picker instead of leaving it on the pre-import snapshot.
   useEffect(() => {
-    if (!open || !client) return;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const data = await ensureProviderListQuery(getReactQueryClient(), {
-          client,
-          baseUrl,
-          directory: workspaceRoot || undefined,
+    if (providerListQuery.error) {
+      onLoadError?.(providerListQuery.error);
+    }
+  }, [onLoadError, providerListQuery.error]);
+
+  const modelOptions = useMemo(() => {
+    const data = providerListQuery.data;
+    if (!data?.all) return [];
+
+    // Flag models from recently-added providers so they appear in the
+    // "Recently added" section at the top of the picker.
+    // Two sources: (1) providers not yet in the localStorage seen-set,
+    // (2) providers passed via the openModelPickerEvent from the toast.
+    let seenIds: Set<string>;
+    try {
+      const raw = window.localStorage.getItem("openwork.seenProviderIds");
+      seenIds = new Set(raw ? JSON.parse(raw) : []);
+    } catch {
+      seenIds = new Set();
+    }
+
+    const next: ModelOption[] = [];
+    for (const provider of getConnectedProviderItems(data)) {
+      const modelIds = Object.keys(provider.models);
+      const isNew = !seenIds.has(provider.id) || recentProviderIds.has(provider.id);
+      for (const id of modelIds) {
+        const model = provider.models[id];
+        next.push({
+          providerID: provider.id,
+          modelID: id,
+          title: model.name || id,
+          description: provider.name,
+          behaviorTitle: "Reasoning",
+          behaviorLabel: "Default",
+          behaviorDescription: "",
+          behaviorValue: null,
+          isFree: false,
+          isConnected: true,
+          isRecommended: isNew,
+          source: /^lpr_/i.test(provider.id) ? "cloud" as const : undefined,
         });
-        if (cancelled || !data?.all) return;
-        // Flag models from recently-added providers so they appear in
-        // the "Recently added" section at the top of the picker.
-        // Two sources: (1) providers not yet in the localStorage seen-set,
-        // (2) providers passed via the openModelPickerEvent from the toast.
-        let seenIds: Set<string>;
-        try {
-          const raw = window.localStorage.getItem("openwork.seenProviderIds");
-          seenIds = new Set(raw ? JSON.parse(raw) : []);
-        } catch {
-          seenIds = new Set();
-        }
-        const options: ModelOption[] = [];
-        for (const provider of getConnectedProviderItems(data)) {
-          const modelIds = Object.keys(provider.models);
-          const isNew = !seenIds.has(provider.id) || recentProviderIds.has(provider.id);
-          for (const id of modelIds) {
-            const model = provider.models[id];
-            options.push({
-              providerID: provider.id,
-              modelID: id,
-              title: model.name || id,
-              description: provider.name,
-              behaviorTitle: "Reasoning",
-              behaviorLabel: "Default",
-              behaviorDescription: "",
-              behaviorValue: null,
-              isFree: false,
-              isConnected: true,
-              isRecommended: isNew,
-              source: /^lpr_/i.test(provider.id) ? "cloud" as const : undefined,
-            });
-          }
-        }
-        setModelOptions(options);
-      } catch (error) {
-        // Default: silent — the picker surfaces an empty list rather than
-        // blocking the UI. Callers can opt into surfacing the failure.
-        onLoadError?.(error);
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [open, baseUrl, client, recentProviderIds, workspaceRoot]);
+    }
+    return next;
+  }, [providerListQuery.data, recentProviderIds]);
 
   // Apply org-level restrictions (dev #1505) on top of the raw model list
   // so the picker never surfaces blocked options:

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -621,11 +621,6 @@ export function SessionRoute() {
       defaultModel: local.prefs.defaultModel,
       modelVariant: local.prefs.modelVariant ?? null,
     });
-  const modelPicker = useModelPicker({
-    client: opencodeClient,
-    baseUrl: opencodeBaseUrl,
-    workspaceRoot: selectedWorkspaceRoot,
-  });
   const {
     store: sessionProviderAuthStore,
     snapshot: sessionProviderAuthSnapshot,
@@ -633,6 +628,7 @@ export function SessionRoute() {
     cloudProviderList,
   } = useSessionProviderAuth({
     opencodeClient,
+    opencodeBaseUrl,
     providers,
     providerDefaults,
     providerConnectedIds,
@@ -645,6 +641,15 @@ export function SessionRoute() {
     setProviderDefaults,
     setProviderConnectedIds,
     setDisabledProviderIds,
+  });
+  const handleModelPickerOpen = useCallback(() => {
+    void sessionProviderAuthStore.runCloudProviderSync("model_picker_open");
+  }, [sessionProviderAuthStore]);
+  const modelPicker = useModelPicker({
+    client: opencodeClient,
+    baseUrl: opencodeBaseUrl,
+    workspaceRoot: selectedWorkspaceRoot,
+    onOpen: handleModelPickerOpen,
   });
   const selectedModelUsesCloudProvider = Boolean(
     local.prefs.defaultModel && isCloudManagedProviderKey(local.prefs.defaultModel.providerID),
@@ -1215,6 +1220,9 @@ export function SessionRoute() {
       const session = unwrap(
         await workspaceClient.session.create({ directory: workspace.path?.trim() || undefined }),
       );
+      if (workspaceId === selectedWorkspaceId) {
+        void sessionProviderAuthStore.runCloudProviderSync("new_chat");
+      }
       captureAnalyticsEvent("task_created", {
         source: "new_task",
         workspace_type: workspace.workspaceType ?? "unknown",
@@ -1262,7 +1270,7 @@ export function SessionRoute() {
       }
       return null;
     }
-  }, [baseUrl, loading, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, token, workspaces]);
+  }, [baseUrl, loading, navigateToWorkspaceSession, refreshRouteState, rememberPendingCreatedSession, retryingWorkspaceIds, selectedWorkspaceId, sessionProviderAuthStore, token, workspaces]);
 
   // Latest session-list state for prev/next session tab navigation. The
   // `options` field is updated by `onSessionTabsChange` from SessionPage so we
@@ -2043,6 +2051,9 @@ export function SessionRoute() {
               const session = unwrap(
                 await workspaceClient.session.create({ directory: workspace.path?.trim() || undefined }),
               );
+              if (workspaceId === selectedWorkspaceId) {
+                void sessionProviderAuthStore.runCloudProviderSync("new_chat");
+              }
               saveSessionDraft(workspaceId, session.id, { text: prompt, mode: "prompt" });
               writeActiveWorkspaceId(workspaceId || null);
               writeLastSessionFor(workspaceId, session.id);

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -469,6 +469,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
 
   const routeStateRef = useRef({
     activeClient: null as Client | null,
+    providerBaseUrl: "",
     selectedWorkspaceId: "",
     selectedWorkspaceRoot: "",
     selectedWorkspaceType: "local" as "local" | "remote",
@@ -519,9 +520,15 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         : emptyWorkspaceDisplay,
     [emptyWorkspaceDisplay, selectedWorkspace],
   );
+  const selectedWorkspaceEndpoint = useMemo(
+    () => resolveWorkspaceEndpoint(selectedWorkspace, { baseUrl, token }),
+    [baseUrl, selectedWorkspace, token],
+  );
+  const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
 
   routeStateRef.current = {
     activeClient,
+    providerBaseUrl: opencodeBaseUrl,
     selectedWorkspaceId,
     selectedWorkspaceRoot,
     selectedWorkspaceType: selectedWorkspace?.workspaceType ?? "local",
@@ -621,6 +628,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         providerConnectedIds: () => routeStateRef.current.providerConnectedIds,
         disabledProviders: () => routeStateRef.current.disabledProviders,
         checkDesktopAppRestriction: checkDesktopRestriction,
+        providerBaseUrl: () => routeStateRef.current.providerBaseUrl,
         selectedWorkspaceDisplay: () => routeStateRef.current.selectedWorkspaceDisplay,
         selectedWorkspaceRoot: () => routeStateRef.current.selectedWorkspaceRoot,
         runtimeWorkspaceId: () => routeStateRef.current.runtimeWorkspaceId,
@@ -839,11 +847,6 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     [errorsByWorkspaceId, sessionsByWorkspaceId, workspaces],
   );
 
-  const selectedWorkspaceEndpoint = useMemo(
-    () => resolveWorkspaceEndpoint(selectedWorkspace, { baseUrl, token }),
-    [baseUrl, selectedWorkspace, token],
-  );
-  const opencodeBaseUrl = selectedWorkspaceEndpoint?.opencodeBaseUrl ?? "";
   const runtimeWorkspaceId = selectedWorkspaceEndpoint?.workspaceId ?? selectedWorkspace?.id ?? null;
   routeStateRef.current.runtimeWorkspaceId = runtimeWorkspaceId;
   routeStateRef.current.selectedWorkspaceOpenworkClient = selectedWorkspaceEndpoint?.client ?? openworkClient;
@@ -867,10 +870,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   const handleModelPickerLoadError = useCallback((error: unknown) => {
     toast.error(error instanceof Error ? error.message : t("app.unknown_error"));
   }, []);
+  const handleModelPickerOpen = useCallback(() => {
+    void providerAuthStore.runCloudProviderSync("model_picker_open");
+  }, [providerAuthStore]);
   const modelPicker = useModelPicker({
     client: opencodeClient,
     baseUrl: opencodeBaseUrl,
     workspaceRoot: selectedWorkspaceRoot,
+    onOpen: handleModelPickerOpen,
     onLoadError: handleModelPickerLoadError,
   });
   const currentCloudMcpModel = useMemo<OpenworkCloudMcpProviderModelContext | null>(() => {

--- a/apps/app/tests/cloud-provider-sync-triggers.test.ts
+++ b/apps/app/tests/cloud-provider-sync-triggers.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+
+import { denSettingsChangedEvent } from "../src/app/lib/den-session-events";
+import { subscribeCloudProviderSyncTriggers } from "../src/react-app/domains/cloud/use-cloud-provider-auto-sync";
+
+describe("cloud provider sync triggers", () => {
+  test("reconciles on settings, focus, online, and visible transitions", () => {
+    const windowTarget = new EventTarget();
+    const documentTarget = new EventTarget();
+    const reasons: string[] = [];
+    let visible = false;
+    const unsubscribe = subscribeCloudProviderSyncTriggers({
+      windowTarget,
+      documentTarget,
+      isDocumentVisible: () => visible,
+      sync: (reason) => reasons.push(reason),
+    });
+
+    windowTarget.dispatchEvent(new Event(denSettingsChangedEvent));
+    windowTarget.dispatchEvent(new Event("focus"));
+    windowTarget.dispatchEvent(new Event("online"));
+    documentTarget.dispatchEvent(new Event("visibilitychange"));
+    visible = true;
+    documentTarget.dispatchEvent(new Event("visibilitychange"));
+
+    expect(reasons).toEqual(["sign_in", "app_resume", "app_resume", "app_resume"]);
+
+    unsubscribe();
+    windowTarget.dispatchEvent(new Event("focus"));
+    expect(reasons).toHaveLength(4);
+  });
+});


### PR DESCRIPTION
## Summary

- Replace timer-based cloud provider polling with event-driven reconciliation on sign-in, organization or settings changes, app resume, network reconnection, model-picker open, and new task creation.
- Keep overlapping sync requests coalesced in the provider store and refresh the endpoint-scoped provider query used by the UI.
- Make the model picker reactively observe provider-list changes so models assigned before a first desktop login appear when startup reconciliation completes.

## Root cause

The startup reconciliation and model picker could use different provider-list cache keys, while the picker copied a one-time pre-sync snapshot. The server-side assignment could therefore be correct even though an already-open picker remained stale.

## Checks

- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app test` — 359 passed, 0 failed
- Focused cloud provider sync and re-import tests are included in the full suite

## Manual verification

Not run in this pass; the full desktop plus Den journey requires a configured organization account.

Suggested verification:

1. Assign a model or provider before the user first signs into the desktop app.
2. Sign in and open the model picker immediately; verify it updates when startup reconciliation completes without closing and reopening.
3. Assign another model while the app is open; return focus, open the picker, or create a new task and verify the assignment appears.

## Risks and gaps

- Periodic polling is intentionally removed; reconciliation now depends on lifecycle and meaningful user-action triggers.
- The authenticated desktop plus Den journey was not exercised locally.