### PR TITLE
fix(den): relay downstream provider authorization links instead of masking them as timeouts

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
@@ -54,6 +54,7 @@ export type ExternalMcpDiagnostic = {
   providerCode?: string
   payloadBytes?: number
   jsonRpcCode?: number
+  connectUrl?: string
 }
 
 export type ExternalMcpSafeOutbound = {
@@ -164,6 +165,7 @@ const SAFE_PROVIDER_REQUEST_ID_PATTERN = /^[A-Za-z0-9][A-Za-z0-9_.:/-]*$/
 const PROVIDER_STATUS_FIELDS = ["status", "statusCode", "httpStatus"]
 const PROVIDER_CODE_FIELDS = ["code", "error"]
 const PROVIDER_REQUEST_ID_FIELDS = ["requestId", "request_id", "transactionId", "transaction_id"]
+const URL_ELICITATION_REQUIRED_JSON_RPC_CODE = -32042
 
 const TYPED_OAUTH_ERROR_NAMES = new Set([
   "InvalidClientError",
@@ -226,6 +228,46 @@ function numericErrorCode(value: unknown): number | undefined {
     current = errorCause(current)
   }
   return undefined
+}
+
+type ProviderAuthorizationRequired = {
+  connectUrl: string
+  provider?: string
+}
+
+function validatedProviderConnectUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined
+  try {
+    const url = new URL(value)
+    return url.protocol === "http:" || url.protocol === "https:" ? url.toString() : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function providerAuthorizationRequired(value: unknown): ProviderAuthorizationRequired | null {
+  let current: unknown = value
+  for (let depth = 0; depth < 5 && current; depth += 1) {
+    const data = isRecord(current) ? current.data : undefined
+    if (isRecord(data)) {
+      const connectUrl = validatedProviderConnectUrl(stringProperty(data, "connect_url"))
+      if (connectUrl) {
+        const provider = stringProperty(data, "provider")
+        return { connectUrl, ...(provider ? { provider } : {}) }
+      }
+
+      const code = isRecord(current) ? current.code : undefined
+      if (code === URL_ELICITATION_REQUIRED_JSON_RPC_CODE) {
+        const url = validatedProviderConnectUrl(stringProperty(data, "url"))
+        if (url) {
+          const provider = stringProperty(data, "provider")
+          return { connectUrl: url, ...(provider ? { provider } : {}) }
+        }
+      }
+    }
+    current = errorCause(current)
+  }
+  return null
 }
 
 function safeNativeToken(value: string | undefined, pattern: RegExp, maxLength = 64): string | undefined {
@@ -452,6 +494,9 @@ function safeBaseMessageFor(input: {
   }
   if (input.code === "MCP_REQUEST_TIMEOUT") {
     return "The MCP server did not answer the current protocol request within its bounded timeout."
+  }
+  if (input.code === "MCP_PROVIDER_AUTH_REQUIRED") {
+    return "The provider answered but requires this user to authorize the downstream account before the tool can run."
   }
   if (input.code === "MCP_RESPONSE_BODY_LIMIT") {
     return "The MCP server returned a response body larger than OpenWork can safely process."
@@ -862,6 +907,19 @@ function classifyError(error: unknown, fallbackPhase: ExternalMcpDiagnosticPhase
   if (code) {
     const classified = classifyByCode(code)
     if (classified) return classified
+  }
+
+  const providerAuthorization = providerAuthorizationRequired(error)
+  if (providerAuthorization) {
+    return {
+      phase: "PROVIDER_AUTHORIZATION",
+      category: "provider_authorization_required",
+      code: "MCP_PROVIDER_AUTH_REQUIRED",
+      retryable: false,
+      actionOwner: "member",
+      operatorAction: "Connect your account for this provider using its sign-in link, then retry this capability.",
+      connectUrl: providerAuthorization.connectUrl,
+    }
   }
 
   if (numericErrorCode(error) === -32001) {

--- a/ee/apps/den-api/src/capability-sources/external-mcp-tool-inspection.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-tool-inspection.ts
@@ -377,6 +377,13 @@ export function diagnoseExternalMcpToolCall(input: {
         summary: "OpenWork's outbound network safety policy blocked this tools/call request, so it was not sent to the remote MCP.",
       }
     }
+    if (input.diagnostic?.code === "MCP_PROVIDER_AUTH_REQUIRED") {
+      return {
+        status: "failed",
+        layer: "mcp_tool",
+        summary: "The remote MCP responded and requires user authorization for the downstream provider.",
+      }
+    }
     if (input.diagnostic?.code === "MCP_LIFECYCLE_DEADLINE" || input.diagnostic?.code === "MCP_REQUEST_TIMEOUT") {
       return {
         status: "failed",
@@ -400,7 +407,9 @@ export function diagnoseExternalMcpToolCall(input: {
   return {
     status: "failed",
     layer: "mcp_tool",
-    summary: input.diagnostic?.phase === "PROVIDER_AUTHORIZATION" || input.diagnostic?.phase === "PROVIDER_EXECUTION"
+    summary: input.diagnostic?.code === "MCP_PROVIDER_AUTH_REQUIRED"
+      ? "The remote MCP responded and requires user authorization for the downstream provider."
+      : input.diagnostic?.phase === "PROVIDER_AUTHORIZATION" || input.diagnostic?.phase === "PROVIDER_EXECUTION"
       ? "The remote MCP responded, but the downstream provider rejected the operation."
       : input.diagnostic?.phase === "MCP_TOOL_EXECUTION"
         ? "The remote MCP responded, but the MCP tool returned an error."

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -59,6 +59,7 @@ const externalMcpDiagnosticOutputSchema = z.object({
   providerCode: z.string().optional(),
   payloadBytes: z.number().int().optional(),
   jsonRpcCode: z.number().int().optional(),
+  connectUrl: z.string().url().optional(),
 })
 
 const connectionStatusOutputSchema = openworkCloudMcpConnectionActionSchema.extend({

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -357,6 +357,61 @@ function addConnectionActionUrl(input: {
   return url ? { ...input.action, url } : input.action
 }
 
+function relayableProviderConnectUrl(connectUrl: string | undefined, connectionUrl: string): string | undefined {
+  if (!connectUrl) return undefined
+  try {
+    const candidate = new URL(connectUrl)
+    const connection = new URL(connectionUrl)
+    if (candidate.host !== connection.host) return undefined
+    return candidate.protocol === "http:" || candidate.protocol === "https:" ? candidate.toString() : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function providerAuthorizationDiagnosticForConnection(input: {
+  diagnostic: ExternalMcpDiagnostic
+  connectionUrl: string
+}): ExternalMcpDiagnostic {
+  if (!input.diagnostic.connectUrl) return input.diagnostic
+  const connectUrl = relayableProviderConnectUrl(input.diagnostic.connectUrl, input.connectionUrl)
+  if (!connectUrl) {
+    const diagnostic = { ...input.diagnostic }
+    delete diagnostic.connectUrl
+    return diagnostic
+  }
+  return connectUrl === input.diagnostic.connectUrl
+    ? input.diagnostic
+    : { ...input.diagnostic, connectUrl }
+}
+
+function providerAuthorizationConnectionStatus(input: {
+  connection: Pick<ExternalMcpConnectionRow, "id" | "name" | "authType" | "credentialMode">
+  diagnostic: ExternalMcpDiagnostic
+  message: string
+}): ExternalConnectionStatus {
+  const status = buildExternalConnectionStatus({
+    connection: input.connection,
+    state: "needs_connection",
+    errorCode: "not_connected",
+    message: input.message,
+    diagnostic: input.diagnostic,
+    actionOwner: "member",
+    layer: "downstream_provider",
+  })
+  return {
+    ...status,
+    actor: "member",
+    action: {
+      type: "connect",
+      label: "Connect your provider account",
+      surface: "openwork_your_connections",
+      retry: "search_capabilities",
+      ...(input.diagnostic.connectUrl ? { url: input.diagnostic.connectUrl } : {}),
+    },
+  }
+}
+
 export function buildExternalConnectionStatus(input: {
   connection: Pick<ExternalMcpConnectionRow, "id" | "name" | "authType" | "credentialMode">
   state: ExternalConnectionStatus["state"]
@@ -364,6 +419,7 @@ export function buildExternalConnectionStatus(input: {
   message: string
   diagnostic?: ExternalMcpDiagnostic
   actionOwner?: "member" | "organization_admin"
+  layer?: ExternalConnectionStatus["layer"]
 }): ExternalConnectionStatus {
   const connectionName = input.connection.name
   const actionContract = {
@@ -383,7 +439,7 @@ export function buildExternalConnectionStatus(input: {
     const providerAdminAction = PROVIDER_ADMIN_ACTION_PATTERN.test(input.message)
     return {
       ...actionContract,
-      layer: input.diagnostic ? "mcp_connection" : "downstream_provider",
+      layer: input.layer ?? (input.diagnostic ? "mcp_connection" : "downstream_provider"),
       connectionId: input.connection.id,
       connectionName,
       authType: input.connection.authType,
@@ -430,7 +486,7 @@ export function buildExternalConnectionStatus(input: {
         : "Inspect"
   return {
     ...actionContract,
-    layer: input.diagnostic ? "mcp_connection" : "downstream_provider",
+    layer: input.layer ?? (input.diagnostic ? "mcp_connection" : "downstream_provider"),
     connectionId: input.connection.id,
     connectionName,
     authType: input.connection.authType,
@@ -1027,29 +1083,51 @@ export async function executeExternalCapability(input: {
     const message = upstreamErrorMessage(error)
     const authErrorCode = externalMcpAuthErrorCode(error, message)
     if (error instanceof ExternalMcpDiagnosticError) {
+      const diagnostic = error.diagnostic.code === "MCP_PROVIDER_AUTH_REQUIRED"
+        ? providerAuthorizationDiagnosticForConnection({ diagnostic: error.diagnostic, connectionUrl: connection.url })
+        : error.diagnostic
+      const log = externalMcpDiagnosticForLog(error, error.diagnostic.referenceId, "MCP_TOOL_EXECUTION")
       console.error("external_mcp_capability_execute_failed", {
         connectionId: connection.id,
         organizationId: connection.organizationId,
         connectionEndpoint: safeExternalMcpEndpointForLog(connection.url),
-        ...externalMcpDiagnosticForLog(error, error.diagnostic.referenceId, "MCP_TOOL_EXECUTION"),
+        ...log,
+        diagnostic,
       })
-      if (error.diagnostic.code === "MCP_INVALID_PARAMS" || error.diagnostic.code === "MCP_PROVIDER_INVALID_PARAMS") {
+      if (diagnostic.code === "MCP_INVALID_PARAMS" || diagnostic.code === "MCP_PROVIDER_INVALID_PARAMS") {
         return invalidCapabilityArguments({
           capability: buildExternalCapabilityName(connection.id, input.toolName),
           schemaDigest: currentSchemaDigest ?? input.schemaDigest,
-          diagnostic: error.diagnostic,
+          diagnostic,
           schemaGuidance,
         })
       }
+      if (diagnostic.code === "MCP_PROVIDER_AUTH_REQUIRED") {
+        const resultMessage = `${diagnostic.message} ${diagnostic.operatorAction} Diagnostic reference: ${diagnostic.referenceId}.`
+        return {
+          ok: false,
+          error: "needs_connection",
+          message: resultMessage,
+          diagnostic,
+          actionOwner: diagnostic.actionOwner,
+          operatorAction: diagnostic.operatorAction,
+          connectionStatus: providerAuthorizationConnectionStatus({
+            connection,
+            diagnostic,
+            message: resultMessage,
+          }),
+          ...(schemaGuidance ? { schemaGuidance } : {}),
+        }
+      }
       return {
         ok: false,
-        error: error.diagnostic.phase === "PROVIDER_EXECUTION" || error.diagnostic.phase === "PROVIDER_AUTHORIZATION"
+        error: diagnostic.phase === "PROVIDER_EXECUTION" || diagnostic.phase === "PROVIDER_AUTHORIZATION"
           ? "provider_error"
           : "connection_failed",
-        message: `${error.diagnostic.message} ${error.diagnostic.operatorAction} Diagnostic reference: ${error.diagnostic.referenceId}.`,
-        diagnostic: error.diagnostic,
-        actionOwner: error.diagnostic.actionOwner,
-        operatorAction: error.diagnostic.operatorAction,
+        message: `${diagnostic.message} ${diagnostic.operatorAction} Diagnostic reference: ${diagnostic.referenceId}.`,
+        diagnostic,
+        actionOwner: diagnostic.actionOwner,
+        operatorAction: diagnostic.operatorAction,
         ...(schemaGuidance ? { schemaGuidance } : {}),
         ...(authErrorCode
           ? {
@@ -1058,7 +1136,7 @@ export async function executeExternalCapability(input: {
                 state: "reauth_required",
                 errorCode: authErrorCode,
                 message,
-                diagnostic: error.diagnostic,
+                diagnostic,
               }),
             }
           : {}),

--- a/ee/apps/den-api/src/routes/org/mcp-connections.ts
+++ b/ee/apps/den-api/src/routes/org/mcp-connections.ts
@@ -551,6 +551,7 @@ const externalMcpDiagnosticSchema = z.object({
   providerCode: z.string().optional(),
   payloadBytes: z.number().int().optional(),
   jsonRpcCode: z.number().int().optional(),
+  connectUrl: z.string().url().optional(),
 }).meta({ ref: "ExternalMcpDiagnostic" })
 
 const connectionToolListFailedSchema = z.object({

--- a/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
+++ b/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
@@ -87,6 +87,15 @@ function textContent(text: string): { type: "text"; text: string }[] {
   return [{ type: "text", text }]
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function requestIdFromPayload(payload: unknown): string | number | null {
+  if (!isRecord(payload)) return null
+  return typeof payload.id === "string" || typeof payload.id === "number" ? payload.id : null
+}
+
 function startFakeMcpServer(name: string, tools: FakeTool[], requiredBearer?: string): FakeMcpServer {
   const app = new Hono()
   app.all("/mcp", async (c) => {
@@ -182,6 +191,47 @@ function startProviderErrorMcpServer(): FakeMcpServer {
   })
   const server = Bun.serve({ port: 0, fetch: app.fetch })
   return { url: `http://127.0.0.1:${server.port}/mcp`, stop: () => server.stop(true) }
+}
+
+function startProviderAuthorizationRequiredMcpServer(foreignOrigin?: string): FakeMcpServer & { connectUrl: string } {
+  const app = new Hono()
+  let connectUrl = ""
+  app.all("/mcp", async (c) => {
+    const payload: unknown = await c.req.raw.clone().json().catch(() => null)
+    const method = isRecord(payload) ? payload.method : undefined
+    if (method === "tools/call") {
+      return c.json({
+        jsonrpc: "2.0",
+        id: requestIdFromPayload(payload),
+        error: {
+          code: -32001,
+          message: `Authorization required — connect your salesforce account to use this connector. Open ${connectUrl} in a browser, sign in, then retry this request.`,
+          data: {
+            connect_url: connectUrl,
+            provider: "salesforce",
+          },
+        },
+      })
+    }
+
+    const mcpServer = new McpServer({ name: "provider-auth-required", version: "1.0.0" })
+    mcpServer.registerTool(
+      "sync_salesforce_account",
+      { description: "Sync a Salesforce account", inputSchema: z.object({}) },
+      async () => ({ content: textContent("sync ok") }),
+    )
+    const transport = new StreamableHTTPTransport()
+    await mcpServer.connect(transport)
+    const response = await transport.handleRequest(c)
+    return response ?? new Response(null, { status: 204 })
+  })
+  const server = Bun.serve({ port: 0, fetch: app.fetch })
+  connectUrl = `${foreignOrigin ?? `http://127.0.0.1:${server.port}`}/servers/salesforce/connect/start`
+  return {
+    url: `http://127.0.0.1:${server.port}/mcp`,
+    connectUrl,
+    stop: () => server.stop(true),
+  }
 }
 
 function startMutableSchemaMcpServer(): MutableSchemaMcpServer {
@@ -877,6 +927,102 @@ test("structured provider denial keeps connection health separate and names the 
   expect(result.message).toContain("Diagnostic reference")
   expect(JSON.stringify(result)).not.toContain("Sensitive provider policy detail")
   expect(JSON.stringify(result)).not.toContain("sensitive_acl_code")
+})
+
+test("downstream provider authorization links are relayed as needs_connection", async () => {
+  const providerAuthServer = startProviderAuthorizationRequiredMcpServer()
+  try {
+    const seed = await seedOrganization("provider-auth-required")
+    const connection = await createGrantedConnection(seed, {
+      name: "Salesforce Gateway",
+      authType: "none",
+      credentialMode: "shared",
+      url: providerAuthServer.url,
+    })
+
+    const result = await executeExternalCapability({
+      organizationId: seed.organizationId,
+      member: { orgMembershipId: seed.memberId, teamIds: [] },
+      connectionId: connection.id,
+      toolName: "sync_salesforce_account",
+      args: {},
+      redirectUriBase,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error("Provider authorization requirement unexpectedly returned success")
+    expect(result).toMatchObject({
+      error: "needs_connection",
+      actionOwner: "member",
+      diagnostic: {
+        phase: "PROVIDER_AUTHORIZATION",
+        category: "provider_authorization_required",
+        code: "MCP_PROVIDER_AUTH_REQUIRED",
+        actionOwner: "member",
+        retryable: false,
+        connectUrl: providerAuthServer.connectUrl,
+      },
+      connectionStatus: {
+        layer: "downstream_provider",
+        state: "needs_connection",
+        errorCode: "not_connected",
+        actor: "member",
+        action: {
+          type: "connect",
+          surface: "openwork_your_connections",
+          retry: "search_capabilities",
+          url: providerAuthServer.connectUrl,
+        },
+      },
+    })
+    expect(result.message.toLowerCase()).not.toContain("latency")
+    expect(result.message.toLowerCase()).not.toContain("timeout")
+  } finally {
+    providerAuthServer.stop()
+  }
+})
+
+test("foreign-origin downstream authorization links are dropped but still surfaced as needs_connection", async () => {
+  const providerAuthServer = startProviderAuthorizationRequiredMcpServer("https://foreign-gateway.fixture.test")
+  try {
+    const seed = await seedOrganization("provider-auth-foreign-origin")
+    const connection = await createGrantedConnection(seed, {
+      name: "Salesforce Gateway Foreign",
+      authType: "none",
+      credentialMode: "shared",
+      url: providerAuthServer.url,
+    })
+
+    const result = await executeExternalCapability({
+      organizationId: seed.organizationId,
+      member: { orgMembershipId: seed.memberId, teamIds: [] },
+      connectionId: connection.id,
+      toolName: "sync_salesforce_account",
+      args: {},
+      redirectUriBase,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error("Provider authorization requirement unexpectedly returned success")
+    expect(result).toMatchObject({
+      error: "needs_connection",
+      diagnostic: {
+        code: "MCP_PROVIDER_AUTH_REQUIRED",
+      },
+      connectionStatus: {
+        layer: "downstream_provider",
+        state: "needs_connection",
+        action: { type: "connect", surface: "openwork_your_connections" },
+      },
+    })
+    expect(result.diagnostic?.connectUrl).toBeUndefined()
+    expect(result.connectionStatus?.diagnostic?.connectUrl).toBeUndefined()
+    expect(result.connectionStatus?.action.url).toBeUndefined()
+    expect(result.message.toLowerCase()).not.toContain("latency")
+    expect(result.message.toLowerCase()).not.toContain("timeout")
+  } finally {
+    providerAuthServer.stop()
+  }
 })
 
 test("stale-apikey-looks-connected: stored API key looks connected and search returns an error status", async () => {

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -30,6 +30,13 @@ function networkError(code: string, secret = "Bearer super-secret-token") {
   return new Error("fetch failed", { cause })
 }
 
+function jsonRpcError(code: number, data?: Record<string, unknown>) {
+  const error = new Error(`MCP error ${code}: synthetic provider detail`)
+  Object.defineProperty(error, "code", { value: code, enumerable: true })
+  if (data) Object.defineProperty(error, "data", { value: data, enumerable: true })
+  return error
+}
+
 function captureConsoleError<T>(run: () => T): { result: T; errors: unknown[][] } {
   const errors: unknown[][] = []
   const originalError = console.error
@@ -451,6 +458,80 @@ describe("external MCP diagnostics", () => {
     })
     expect(error.diagnostic.operatorAction).toContain("do not retry the same arguments")
     expect(JSON.stringify(error.diagnostic)).not.toContain("private argument detail")
+  })
+
+  test("classifies downstream provider authorization links without treating -32001 as a timeout", () => {
+    const connectUrl = "https://mcp-gateway.fixture.test/servers/salesforce/connect/start"
+    const tracker = new ExternalMcpDiagnosticTracker("req_provider_auth")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const error = tracker.error(new Error("wrapped SDK error", {
+      cause: jsonRpcError(-32001, { connect_url: connectUrl, provider: "salesforce" }),
+    }))
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "PROVIDER_AUTHORIZATION",
+      category: "provider_authorization_required",
+      code: "MCP_PROVIDER_AUTH_REQUIRED",
+      retryable: false,
+      actionOwner: "member",
+      connectUrl,
+      jsonRpcCode: -32001,
+    })
+    expect(error.diagnostic.message).not.toContain("timeout")
+    expect(error.diagnostic.operatorAction).not.toContain("salesforce")
+  })
+
+  test("classifies URL elicitation as downstream provider authorization", () => {
+    const connectUrl = "https://mcp-gateway.fixture.test/servers/salesforce/connect/start"
+    const tracker = new ExternalMcpDiagnosticTracker("req_url_elicitation")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const error = tracker.error(jsonRpcError(-32042, { url: connectUrl }))
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "PROVIDER_AUTHORIZATION",
+      category: "provider_authorization_required",
+      code: "MCP_PROVIDER_AUTH_REQUIRED",
+      retryable: false,
+      actionOwner: "member",
+      connectUrl,
+      jsonRpcCode: -32042,
+    })
+  })
+
+  test.each([
+    ["local request timeout", { timeout: 30000 }],
+    ["maximum total timeout", { maxTotalTimeout: 90000, totalElapsed: 90001 }],
+    ["bare remote -32001", undefined],
+    ["unsafe connect_url scheme", { connect_url: "javascript:alert(1)" }],
+    ["non-http connect_url scheme", { connect_url: "ftp://mcp-gateway.fixture.test/servers/salesforce/connect/start" }],
+  ])("keeps %s classified as request timeout", (_name, data) => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_timeout")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const error = tracker.error(jsonRpcError(-32001, data))
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "MCP_TOOL_EXECUTION",
+      category: "request_timeout",
+      code: "MCP_REQUEST_TIMEOUT",
+      retryable: true,
+      actionOwner: "provider_admin",
+      jsonRpcCode: -32001,
+    })
+    expect(error.diagnostic.connectUrl).toBeUndefined()
+  })
+
+  test("keeps unknown remote JSON-RPC errors generic while preserving the code", () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_remote_generic")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const error = tracker.error(jsonRpcError(-32050, { provider_detail: "must-not-surface" }))
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "MCP_TOOL_EXECUTION",
+      category: "mcp_protocol_failure",
+      code: "MCP_MCP_TOOL_EXECUTION",
+      jsonRpcCode: -32050,
+    })
+    expect(JSON.stringify(error.diagnostic)).not.toContain("must-not-surface")
   })
 
   test("classifies structured provider validation errors as correctable tool input", () => {

--- a/ee/apps/den-api/test/external-mcp-tool-inspection.test.ts
+++ b/ee/apps/den-api/test/external-mcp-tool-inspection.test.ts
@@ -211,6 +211,15 @@ test("attributes a blocked or deadline-stopped tools/call to the right layer", (
     layer: "network",
     summary: "OpenWork sent the request, but the remote MCP did not respond before OpenWork’s deadline.",
   })
+  expect(diagnoseExternalMcpToolCall({
+    inspection: { request: { method: "POST", url: "https://mcp.example.test/rpc", startedAt: new Date().toISOString(), headers: [], body: { text: "{}", bytes: 2, truncated: false } } },
+    succeeded: false,
+    diagnostic: { phase: "PROVIDER_AUTHORIZATION", category: "provider_authorization_required", code: "MCP_PROVIDER_AUTH_REQUIRED" },
+  })).toEqual({
+    status: "failed",
+    layer: "mcp_tool",
+    summary: "The remote MCP responded and requires user authorization for the downstream provider.",
+  })
 })
 
 test("attributes remote HTTP and downstream provider failures without crossing evidence boundaries", () => {
@@ -244,6 +253,15 @@ test("attributes remote HTTP and downstream provider failures without crossing e
     status: "failed",
     layer: "mcp_tool",
     summary: "The remote MCP responded, but the downstream provider rejected the operation.",
+  })
+  expect(diagnoseExternalMcpToolCall({
+    inspection: { request, response: { ...response, status: 200, statusText: "OK" } },
+    succeeded: false,
+    diagnostic: { phase: "PROVIDER_AUTHORIZATION", code: "MCP_PROVIDER_AUTH_REQUIRED" },
+  })).toEqual({
+    status: "failed",
+    layer: "mcp_tool",
+    summary: "The remote MCP responded and requires user authorization for the downstream provider.",
   })
 })
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-error-attribution.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-tool-error-attribution.ts
@@ -13,6 +13,7 @@ export type ExternalMcpDiagnostic = {
   providerStatus?: number;
   providerRequestId?: string;
   providerCode?: string;
+  connectUrl?: string;
 };
 
 type InspectionEvidence = {
@@ -95,6 +96,7 @@ export function parseExternalMcpDiagnostic(value: unknown): ExternalMcpDiagnosti
   const providerStatus = optionalNumber(value.providerStatus);
   const providerRequestId = optionalString(value.providerRequestId);
   const providerCode = optionalString(value.providerCode);
+  const connectUrl = optionalString(value.connectUrl);
   const diagnostic: ExternalMcpDiagnostic = {
     ...(referenceId ? { referenceId } : {}),
     // Keep unknown future phases/categories as safe strings so an older
@@ -112,6 +114,7 @@ export function parseExternalMcpDiagnostic(value: unknown): ExternalMcpDiagnosti
     ...(providerStatus !== undefined ? { providerStatus } : {}),
     ...(providerRequestId ? { providerRequestId } : {}),
     ...(providerCode ? { providerCode } : {}),
+    ...(connectUrl ? { connectUrl } : {}),
   };
 
   return Object.keys(diagnostic).length > 0 ? diagnostic : null;
@@ -222,6 +225,19 @@ export function attributeExternalMcpToolFailure(input: {
   const providerFailure = diagnostic?.phase?.startsWith("PROVIDER_")
     || diagnostic?.providerStatus !== undefined
     || diagnostic?.providerCode !== undefined;
+  if (diagnostic?.code === "MCP_PROVIDER_AUTH_REQUIRED") {
+    return {
+      summary: "The remote MCP responded and requires user authorization for the downstream provider.",
+      lastConfirmedBoundary: responseStatus !== undefined
+        ? `Remote MCP returned HTTP ${responseStatus} with an authorization request`
+        : "Remote MCP returned an authorization request",
+      likelySource: "Downstream provider authorization",
+      confidence: "Confirmed",
+      retryGuidance: diagnostic.operatorAction ?? "Connect the provider account, then retry.",
+      outcome: "failed",
+      ...details,
+    };
+  }
   if (providerFailure) {
     return {
       summary: "The remote MCP responded, but the downstream provider rejected the operation.",

--- a/ee/apps/den-web/tests/mcp-tool-error-attribution.test.ts
+++ b/ee/apps/den-web/tests/mcp-tool-error-attribution.test.ts
@@ -136,6 +136,33 @@ describe("MCP failure attribution", () => {
     });
   });
 
+  test("attributes downstream provider authorization as a confirmed provider response", () => {
+    const attribution = attributeExternalMcpToolFailure({
+      diagnostic: {
+        referenceId: "req_provider_auth",
+        phase: "PROVIDER_AUTHORIZATION",
+        category: "provider_authorization_required",
+        code: "MCP_PROVIDER_AUTH_REQUIRED",
+        retryable: false,
+        actionOwner: "member",
+        operatorAction: "Connect your account for this provider using its sign-in link, then retry this capability.",
+      },
+      inspection: { request: {} },
+      browserTimeout: null,
+      mayHaveSideEffects: false,
+    });
+
+    expect(attribution).toMatchObject({
+      summary: "The remote MCP responded and requires user authorization for the downstream provider.",
+      lastConfirmedBoundary: "Remote MCP returned an authorization request",
+      likelySource: "Downstream provider authorization",
+      confidence: "Confirmed",
+      outcome: "failed",
+      diagnosticReference: "req_provider_auth",
+      diagnosticCode: "MCP_PROVIDER_AUTH_REQUIRED",
+    });
+  });
+
   test("attributes an OpenWork block before send as confirmed", () => {
     const attribution = attributeExternalMcpToolFailure({
       diagnostic: {
@@ -193,6 +220,7 @@ describe("MCP failure attribution", () => {
       providerStatus: 403,
       providerRequestId: "provider-request-456",
       providerCode: "access_denied",
+      connectUrl: "https://mcp-gateway.fixture.test/servers/salesforce/connect/start",
     })).toEqual({
       referenceId: "req_full",
       phase: "FUTURE_PROVIDER_PHASE",
@@ -208,6 +236,7 @@ describe("MCP failure attribution", () => {
       providerStatus: 403,
       providerRequestId: "provider-request-456",
       providerCode: "access_denied",
+      connectUrl: "https://mcp-gateway.fixture.test/servers/salesforce/connect/start",
     });
 
     const attribution = attributeExternalMcpToolFailure({

--- a/evals/flows/den-provider-auth-relay.flow.mjs
+++ b/evals/flows/den-provider-auth-relay.flow.mjs
@@ -1,0 +1,601 @@
+/**
+ * Internal proof for Den's downstream-provider authorization relay.
+ *
+ * Runs app-less against a real Den API and two public mock OAuth MCP gateways
+ * supplied by the orchestrator through OPENWORK_EVAL_* environment variables.
+ */
+import { createRequire } from "node:module";
+import { randomBytes } from "node:crypto";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const requireFromDenApi = createRequire(new URL("../../ee/apps/den-api/package.json", import.meta.url));
+const { Client } = await import(requireFromDenApi.resolve("@modelcontextprotocol/sdk/client/index.js"));
+const { StreamableHTTPClientTransport } = await import(requireFromDenApi.resolve("@modelcontextprotocol/sdk/client/streamableHttp.js"));
+
+const FLOW_ID = "den-provider-auth-relay";
+const TOOL_NAME = "query_salesforce_records";
+const REQUIRED_ENV = [
+  "OPENWORK_EVAL_DEN_API_URL",
+  "OPENWORK_EVAL_GATEWAY_MCP_URL",
+  "OPENWORK_EVAL_GATEWAY_MCP_URL_FOREIGN",
+];
+const RUN_TAG = `${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`;
+const ADMIN_EMAIL = `den-provider-auth-${RUN_TAG}@acme.test`;
+const ADMIN_PASSWORD = `OpenWork-${RUN_TAG}-Provider-Auth!`;
+const CONNECTION_A_NAME = `Salesforce Gateway Auth Required ${RUN_TAG}`;
+const CONNECTION_B_NAME = `Salesforce Gateway Foreign Link ${RUN_TAG}`;
+const TIMEOUT_WORDING = /latency|timed? ?out/i;
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const envSnapshot = readEvalEnv();
+
+const state = {
+  adminToken: null,
+  mcpToken: null,
+  organization: null,
+  currentMember: null,
+  orgMode: null,
+  gatewayA: null,
+  gatewayB: null,
+  rawGatewayA: null,
+  rawGatewayB: null,
+  health: null,
+};
+
+function readEvalEnv() {
+  const values = {};
+  const missing = [];
+  for (const name of REQUIRED_ENV) {
+    const value = (process.env[name] ?? "").trim();
+    if (!value) {
+      missing.push(name);
+    }
+    values[name] = value;
+  }
+  return { values, missing };
+}
+
+function missingEnvMessage() {
+  return `Missing required environment variables for ${FLOW_ID}: ${envSnapshot.missing.join(", ")}. Set OPENWORK_EVAL_DEN_API_URL, OPENWORK_EVAL_GATEWAY_MCP_URL, and OPENWORK_EVAL_GATEWAY_MCP_URL_FOREIGN to the Daytona Den API and mock gateway MCP URLs.`;
+}
+
+function requiredEnv(ctx) {
+  if (envSnapshot.missing.length > 0) {
+    const message = missingEnvMessage();
+    if (ctx) {
+      witness(ctx, false, message);
+    }
+    throw new Error(message);
+  }
+  return {
+    denApiUrl: stripTrailingSlashes(envSnapshot.values.OPENWORK_EVAL_DEN_API_URL),
+    gatewayMcpUrl: stripTrailingSlashes(envSnapshot.values.OPENWORK_EVAL_GATEWAY_MCP_URL),
+    foreignGatewayMcpUrl: stripTrailingSlashes(envSnapshot.values.OPENWORK_EVAL_GATEWAY_MCP_URL_FOREIGN),
+  };
+}
+
+function stripTrailingSlashes(value) {
+  return value.replace(/\/+$/, "");
+}
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function own(value, key) {
+  if (!isRecord(value)) return undefined;
+  return Object.getOwnPropertyDescriptor(value, key)?.value;
+}
+
+function compactActual(actual) {
+  if (actual === undefined) return undefined;
+  if (typeof actual === "string") return actual.slice(0, 900);
+  try {
+    return JSON.stringify(actual).slice(0, 900);
+  } catch {
+    return String(actual).slice(0, 900);
+  }
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: compactActual(actual),
+  });
+  ctx.assert(condition, assertion + (actual === undefined ? "" : ` (actual: ${compactActual(actual)})`));
+}
+
+function authOrigins(denApiUrl) {
+  const url = new URL(denApiUrl);
+  const origins = [url.origin];
+  if (url.hostname === "127.0.0.1") {
+    const localhost = new URL(url.toString());
+    localhost.hostname = "localhost";
+    origins.push(localhost.origin);
+  } else if (url.hostname === "localhost") {
+    const loopback = new URL(url.toString());
+    loopback.hostname = "127.0.0.1";
+    origins.push(loopback.origin);
+  }
+  return [...new Set(origins)];
+}
+
+async function fetchJson(url, options = {}) {
+  const { ctx: _ctx, ...requestOptions } = options;
+  const headers = {
+    accept: "application/json",
+    ...(requestOptions.body ? { "content-type": "application/json" } : {}),
+    ...(requestOptions.headers ?? {}),
+  };
+  const response = await fetch(url, { ...requestOptions, headers });
+  const text = await response.text();
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {}
+  return { response, body, text };
+}
+
+async function denFetch(path, options = {}) {
+  const { denApiUrl } = requiredEnv(options.ctx);
+  return fetchJson(`${denApiUrl}${path}`, options);
+}
+
+async function denAuthFetch(path, options = {}) {
+  const { denApiUrl } = requiredEnv(options.ctx);
+  let last = null;
+  for (const origin of authOrigins(denApiUrl)) {
+    const result = await fetchJson(`${denApiUrl}${path}`, {
+      ...options,
+      headers: {
+        origin,
+        ...(options.headers ?? {}),
+      },
+    });
+    last = result;
+    if (!(result.response.status === 403 && own(result.body, "code") === "INVALID_ORIGIN")) {
+      return result;
+    }
+  }
+  return last;
+}
+
+async function authedDenFetch(ctx, path, token, options = {}) {
+  return denFetch(path, {
+    ...options,
+    ctx,
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(options.headers ?? {}),
+    },
+  });
+}
+
+function summarizeAuthResult(result) {
+  const body = isRecord(result.body) ? result.body : null;
+  const user = isRecord(own(body, "user")) ? own(body, "user") : null;
+  const session = isRecord(own(body, "session")) ? own(body, "session") : null;
+  return {
+    status: result.response.status,
+    ok: result.response.ok,
+    token: typeof own(body, "token") === "string" ? "<redacted>" : null,
+    user: user ? {
+      id: own(user, "id"),
+      email: own(user, "email"),
+      name: own(user, "name"),
+      emailVerified: own(user, "emailVerified"),
+    } : null,
+    session: session ? {
+      id: own(session, "id"),
+      activeOrganizationId: own(session, "activeOrganizationId"),
+    } : null,
+    body: body && typeof own(body, "token") !== "string" ? body : undefined,
+  };
+}
+
+async function signUpAndSignInAdmin(ctx) {
+  const signUp = await denAuthFetch("/api/auth/sign-up/email", {
+    ctx,
+    method: "POST",
+    body: JSON.stringify({ email: ADMIN_EMAIL, name: "Provider Auth Admin", password: ADMIN_PASSWORD }),
+  });
+  witness(ctx, signUp.response.ok, "Admin email sign-up succeeds through the real Den auth API", summarizeAuthResult(signUp));
+
+  const signIn = await denAuthFetch("/api/auth/sign-in/email", {
+    ctx,
+    method: "POST",
+    body: JSON.stringify({ email: ADMIN_EMAIL, password: ADMIN_PASSWORD }),
+  });
+  const token = isRecord(signIn.body) && typeof own(signIn.body, "token") === "string" ? own(signIn.body, "token") : null;
+  witness(ctx, signIn.response.ok && typeof token === "string", "Admin email sign-in returns a bearer session token", summarizeAuthResult(signIn));
+  state.adminToken = token;
+  return token;
+}
+
+function currentMemberCanAdmin(currentMember) {
+  if (!isRecord(currentMember)) return false;
+  if (own(currentMember, "isOwner") === true) return true;
+  const roles = String(own(currentMember, "role") ?? "").split(",").map((role) => role.trim());
+  return roles.includes("admin") || roles.includes("owner");
+}
+
+function compactOrganizationContext(body) {
+  const organization = isRecord(own(body, "organization")) ? own(body, "organization") : null;
+  const currentMember = isRecord(own(body, "currentMember")) ? own(body, "currentMember") : null;
+  return {
+    organization: organization ? {
+      id: own(organization, "id"),
+      name: own(organization, "name"),
+      slug: own(organization, "slug"),
+    } : null,
+    currentMember: currentMember ? {
+      id: own(currentMember, "id"),
+      role: own(currentMember, "role"),
+      isOwner: own(currentMember, "isOwner"),
+      userId: own(currentMember, "userId"),
+    } : null,
+  };
+}
+
+async function loadOrgContext(ctx, token, label) {
+  const result = await authedDenFetch(ctx, "/v1/org", token);
+  witness(ctx, result.response.ok, label, { status: result.response.status, body: compactOrganizationContext(result.body) });
+  const organization = isRecord(own(result.body, "organization")) ? own(result.body, "organization") : null;
+  const currentMember = isRecord(own(result.body, "currentMember")) ? own(result.body, "currentMember") : null;
+  witness(ctx, typeof own(organization, "id") === "string", "Active organization id is present", compactOrganizationContext(result.body));
+  witness(ctx, currentMemberCanAdmin(currentMember), "The signed-in member can administer MCP connections", compactOrganizationContext(result.body));
+  state.organization = organization;
+  state.currentMember = currentMember;
+  return result.body;
+}
+
+async function ensureWorkspace(ctx, token) {
+  const existing = await authedDenFetch(ctx, "/v1/org", token);
+  if (existing.response.ok) {
+    state.orgMode = "existing_or_single_org";
+    const body = existing.body;
+    const currentMember = isRecord(own(body, "currentMember")) ? own(body, "currentMember") : null;
+    witness(ctx, currentMemberCanAdmin(currentMember), "Existing active organization grants admin rights", compactOrganizationContext(body));
+    state.organization = isRecord(own(body, "organization")) ? own(body, "organization") : null;
+    state.currentMember = currentMember;
+    return body;
+  }
+
+  witness(ctx, existing.response.status === 404, "New admin starts without an active organization before bootstrap in multi-org mode", { status: existing.response.status, body: existing.body });
+  const created = await authedDenFetch(ctx, "/v1/org", token, {
+    method: "POST",
+    body: JSON.stringify({ name: `Provider Auth Relay ${RUN_TAG}` }),
+  });
+  if (created.response.status === 409 && own(created.body, "error") === "single_org_mode") {
+    state.orgMode = "single_org";
+    return loadOrgContext(ctx, token, "Single-org deployment resolves the admin's singleton workspace");
+  }
+
+  state.orgMode = "multi_org";
+  witness(ctx, created.response.status === 201, "Multi-org deployment creates a new workspace for the admin", { status: created.response.status, body: created.body });
+  return loadOrgContext(ctx, token, "The newly created workspace is active for the admin session");
+}
+
+function compactConnection(connection) {
+  return {
+    id: own(connection, "id"),
+    name: own(connection, "name"),
+    url: own(connection, "url"),
+    authType: own(connection, "authType"),
+    credentialMode: own(connection, "credentialMode"),
+    connected: own(connection, "connected"),
+    connectedForMe: own(connection, "connectedForMe"),
+    access: own(connection, "access"),
+  };
+}
+
+async function createGatewayConnection(ctx, input) {
+  const result = await authedDenFetch(ctx, "/v1/mcp-connections", state.adminToken, {
+    method: "POST",
+    body: JSON.stringify({
+      name: input.name,
+      url: input.url,
+      authType: "none",
+      credentialMode: "shared",
+      access: { orgWide: true, memberIds: [], teamIds: [] },
+    }),
+  });
+  witness(ctx, result.response.ok, `${input.name} is registered through POST /v1/mcp-connections`, { status: result.response.status, body: compactConnection(result.body) });
+  witness(ctx, own(result.body, "authType") === "none", `${input.name} uses no-auth gateway credentials`, compactConnection(result.body));
+  witness(ctx, own(result.body, "credentialMode") === "shared", `${input.name} uses one shared org connection`, compactConnection(result.body));
+  witness(ctx, own(result.body, "connected") === true, `${input.name} validated and is marked connected`, compactConnection(result.body));
+  return result.body;
+}
+
+async function gatewayRpc(endpoint, payload) {
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: { "content-type": "application/json", accept: "application/json, text/event-stream" },
+    body: JSON.stringify(payload),
+  });
+  const text = await response.text();
+  let body = text;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {}
+  return { response, body, text };
+}
+
+function toolListIncludes(body, toolName) {
+  const result = isRecord(own(body, "result")) ? own(body, "result") : null;
+  const tools = Array.isArray(own(result, "tools")) ? own(result, "tools") : [];
+  return tools.some((tool) => isRecord(tool) && own(tool, "name") === toolName);
+}
+
+function jsonRpcError(body) {
+  return isRecord(own(body, "error")) ? own(body, "error") : null;
+}
+
+function jsonRpcConnectUrl(body) {
+  const error = jsonRpcError(body);
+  const data = isRecord(own(error, "data")) ? own(error, "data") : null;
+  return typeof own(data, "connect_url") === "string" ? own(data, "connect_url") : null;
+}
+
+async function captureRawGatewayAuthRequired(ctx, endpoint, label) {
+  const initialize = await gatewayRpc(endpoint, {
+    jsonrpc: "2.0",
+    id: `${label}-initialize`,
+    method: "initialize",
+    params: { protocolVersion: "2025-06-18", capabilities: {}, clientInfo: { name: FLOW_ID, version: "1.0.0" } },
+  });
+  witness(ctx, initialize.response.status === 200, `${label} initialize returns HTTP 200`, { status: initialize.response.status, body: initialize.body });
+
+  const tools = await gatewayRpc(endpoint, { jsonrpc: "2.0", id: `${label}-tools`, method: "tools/list", params: {} });
+  witness(ctx, tools.response.status === 200, `${label} tools/list returns HTTP 200`, { status: tools.response.status, body: tools.body });
+  witness(ctx, toolListIncludes(tools.body, TOOL_NAME), `${label} tools/list advertises ${TOOL_NAME}`, tools.body);
+
+  const call = await gatewayRpc(endpoint, {
+    jsonrpc: "2.0",
+    id: `${label}-call`,
+    method: "tools/call",
+    params: { name: TOOL_NAME, arguments: {} },
+  });
+  const error = jsonRpcError(call.body);
+  const connectUrl = jsonRpcConnectUrl(call.body);
+  witness(ctx, call.response.status === 200, `${label} tools/call returns HTTP 200 even though the provider requires auth`, { status: call.response.status, body: call.body });
+  witness(ctx, own(error, "code") === -32001, `${label} tools/call body carries JSON-RPC -32001`, call.body);
+  witness(ctx, typeof connectUrl === "string", `${label} tools/call body carries error.data.connect_url`, call.body);
+  witness(ctx, String(own(error, "message") ?? "").includes("Authorization required"), `${label} tools/call message says authorization is required`, call.body);
+  return { initialize, tools, call, connectUrl };
+}
+
+async function mintMcpToken(ctx) {
+  const result = await authedDenFetch(ctx, "/v1/mcp/token", state.adminToken, {
+    method: "POST",
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  });
+  const token = isRecord(result.body) && typeof own(result.body, "token") === "string" ? own(result.body, "token") : null;
+  witness(ctx, result.response.ok && typeof token === "string", "A session bearer mints an org-scoped MCP bearer token", {
+    status: result.response.status,
+    body: {
+      token: token ? "<redacted>" : null,
+      expiresAt: own(result.body, "expiresAt"),
+      organizationId: own(result.body, "organizationId"),
+      scopes: own(result.body, "scopes"),
+      resource: own(result.body, "resource"),
+    },
+  });
+  state.mcpToken = token;
+  return token;
+}
+
+async function withAgentClient(ctx, callback) {
+  const { denApiUrl } = requiredEnv(ctx);
+  const token = state.mcpToken ?? await mintMcpToken(ctx);
+  const transport = new StreamableHTTPClientTransport(new URL(`${denApiUrl}/mcp/agent`), {
+    requestInit: {
+      headers: { authorization: `Bearer ${token}` },
+    },
+  });
+  const client = new Client({ name: `${FLOW_ID}-client`, version: "1.0.0" });
+  try {
+    await client.connect(transport);
+    return await callback(client);
+  } finally {
+    await client.close().catch(() => undefined);
+  }
+}
+
+function firstText(result) {
+  const content = Array.isArray(own(result, "content")) ? own(result, "content") : [];
+  const entry = content.find((item) => isRecord(item) && own(item, "type") === "text" && typeof own(item, "text") === "string");
+  return entry ? own(entry, "text") : null;
+}
+
+function parseToolTextJson(ctx, result, label) {
+  const text = firstText(result);
+  witness(ctx, typeof text === "string", `${label} returned text content`, result);
+  try {
+    return JSON.parse(text);
+  } catch {
+    witness(ctx, false, `${label} returned parseable JSON text`, text);
+    return null;
+  }
+}
+
+function findMatch(ctx, searchBody, expectedName) {
+  const matches = Array.isArray(own(searchBody, "matches")) ? own(searchBody, "matches") : [];
+  const match = matches.find((entry) => isRecord(entry) && own(entry, "name") === expectedName) ?? null;
+  witness(ctx, Boolean(match), `search_capabilities returns ${expectedName}`, { expectedName, matches });
+  witness(ctx, typeof own(match, "schemaDigest") === "string", `${expectedName} includes schemaDigest`, match);
+  witness(ctx, isRecord(own(match, "argumentsSchema")), `${expectedName} includes provider argumentsSchema`, match);
+  return match;
+}
+
+async function searchAndExecuteGateway(ctx, connection, query) {
+  const expectedName = `mcp:${own(connection, "id")}:${TOOL_NAME}`;
+  return withAgentClient(ctx, async (client) => {
+    const search = await client.callTool({
+      name: "search_capabilities",
+      arguments: { query, limit: 10, type: "mcp" },
+    });
+    const searchBody = parseToolTextJson(ctx, search, "search_capabilities");
+    const match = findMatch(ctx, searchBody, expectedName);
+    const execute = await client.callTool({
+      name: "execute_capability",
+      arguments: { name: expectedName, schemaDigest: own(match, "schemaDigest"), body: {} },
+    });
+    witness(ctx, own(execute, "isError") === true, "execute_capability returns an MCP tool error envelope", execute);
+    const envelope = parseToolTextJson(ctx, execute, "execute_capability");
+    return { searchBody, match, execute, envelope };
+  });
+}
+
+function assertSameHostConnectUrl(ctx, connectUrl, connectionUrl) {
+  const connect = new URL(connectUrl);
+  const connection = new URL(connectionUrl);
+  witness(ctx, connect.host === connection.host, "The provider connect link is on the same host as gateway A", { connectUrl, connectionUrl });
+}
+
+function assertForeignHostConnectUrl(ctx, connectUrl, connectionUrl) {
+  const connect = new URL(connectUrl);
+  const connection = new URL(connectionUrl);
+  witness(ctx, connect.host !== connection.host, "The foreign provider connect link is on a different host than gateway B", { connectUrl, connectionUrl });
+}
+
+function assertProviderAuthEnvelope(ctx, envelope, expectedConnectUrl) {
+  const diagnostic = isRecord(own(envelope, "diagnostic")) ? own(envelope, "diagnostic") : null;
+  const connectionStatus = isRecord(own(envelope, "connectionStatus")) ? own(envelope, "connectionStatus") : null;
+  const action = isRecord(own(connectionStatus, "action")) ? own(connectionStatus, "action") : null;
+  witness(ctx, own(envelope, "error") === "needs_connection", "execute_capability error is needs_connection", envelope);
+  witness(ctx, own(diagnostic, "code") === "MCP_PROVIDER_AUTH_REQUIRED", "diagnostic.code is MCP_PROVIDER_AUTH_REQUIRED", diagnostic);
+  witness(ctx, own(diagnostic, "retryable") === false, "diagnostic.retryable is false", diagnostic);
+  witness(ctx, own(diagnostic, "connectUrl") === expectedConnectUrl, "diagnostic.connectUrl relays the gateway connect link", diagnostic);
+  witness(ctx, own(connectionStatus, "layer") === "downstream_provider", "connectionStatus.layer is downstream_provider", connectionStatus);
+  witness(ctx, own(connectionStatus, "state") === "needs_connection", "connectionStatus.state is needs_connection", connectionStatus);
+  witness(ctx, own(action, "type") === "connect", "connectionStatus.action.type is connect", action);
+  witness(ctx, own(action, "url") === expectedConnectUrl, "connectionStatus.action.url is exactly the gateway connect link", action);
+  witness(ctx, !TIMEOUT_WORDING.test(String(own(envelope, "message") ?? "")), "execute_capability message contains no latency or timeout wording", own(envelope, "message"));
+}
+
+function assertForeignLinkStrippedEnvelope(ctx, envelope) {
+  const diagnostic = isRecord(own(envelope, "diagnostic")) ? own(envelope, "diagnostic") : null;
+  const connectionStatus = isRecord(own(envelope, "connectionStatus")) ? own(envelope, "connectionStatus") : null;
+  const action = isRecord(own(connectionStatus, "action")) ? own(connectionStatus, "action") : null;
+  witness(ctx, own(envelope, "error") === "needs_connection", "foreign-host execute_capability error is still needs_connection", envelope);
+  witness(ctx, own(diagnostic, "code") === "MCP_PROVIDER_AUTH_REQUIRED", "foreign-host diagnostic.code is MCP_PROVIDER_AUTH_REQUIRED", diagnostic);
+  witness(ctx, own(connectionStatus, "layer") === "downstream_provider", "foreign-host connectionStatus.layer is downstream_provider", connectionStatus);
+  witness(ctx, own(connectionStatus, "state") === "needs_connection", "foreign-host connectionStatus.state is needs_connection", connectionStatus);
+  witness(ctx, own(action, "type") === "connect", "foreign-host action still tells the member to connect", action);
+  witness(ctx, own(diagnostic, "connectUrl") === undefined, "foreign-host diagnostic.connectUrl is stripped", diagnostic);
+  witness(ctx, own(action, "url") === undefined, "foreign-host connectionStatus.action.url is stripped", action);
+  witness(ctx, !TIMEOUT_WORDING.test(String(own(envelope, "message") ?? "")), "foreign-host message contains no latency or timeout wording", own(envelope, "message"));
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Den relays downstream provider authorization links without masking them as timeouts",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Frame 1 — The fixed Den API is reachable on Daytona",
+      run: async (ctx) => {
+        await ctx.prove("A real Den API answers health checks from the configured Daytona URL", {
+          voiceover: vo[0],
+          action: async () => {
+            const { denApiUrl } = requiredEnv(ctx);
+            state.health = await fetchJson(`${denApiUrl}/health`);
+          },
+          assert: async () => {
+            const { denApiUrl } = requiredEnv(ctx);
+            witness(ctx, state.health.response.ok, "GET /health returns HTTP 200", { status: state.health.response.status, body: state.health.body });
+            witness(ctx, own(state.health.body, "ok") === true, "Health payload reports ok: true", state.health.body);
+            witness(ctx, own(state.health.body, "service") === "den-api", "Health payload identifies den-api", state.health.body);
+            witness(ctx, typeof own(state.health.body, "version") === "string", "Health payload exposes the configured service version", state.health.body);
+            const version = String(own(state.health.body, "version") ?? "");
+            if (/commit [a-f0-9]{7}/i.test(version)) {
+              witness(ctx, true, "Health payload includes a commit-shaped service version", version);
+            }
+            ctx.output("den-api-health", JSON.stringify({ baseUrl: denApiUrl, health: state.health.body }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2 — Admin registers gateway A and captures the raw provider auth payload",
+      run: async (ctx) => {
+        await ctx.prove("The admin publishes a no-auth gateway MCP connection and the gateway returns structured downstream authorization", {
+          voiceover: vo[1],
+          action: async () => {
+            const { gatewayMcpUrl } = requiredEnv(ctx);
+            const adminToken = await signUpAndSignInAdmin(ctx);
+            await ensureWorkspace(ctx, adminToken);
+            state.gatewayA = await createGatewayConnection(ctx, { name: CONNECTION_A_NAME, url: gatewayMcpUrl });
+            state.rawGatewayA = await captureRawGatewayAuthRequired(ctx, gatewayMcpUrl, "gateway A");
+          },
+          assert: async () => {
+            const { gatewayMcpUrl } = requiredEnv(ctx);
+            assertSameHostConnectUrl(ctx, state.rawGatewayA.connectUrl, gatewayMcpUrl);
+            ctx.output("workspace-and-gateway-a", JSON.stringify({
+              runTag: RUN_TAG,
+              admin: { email: ADMIN_EMAIL, sessionToken: "<redacted>" },
+              orgMode: state.orgMode,
+              organization: compactOrganizationContext({ organization: state.organization, currentMember: state.currentMember }),
+              connection: compactConnection(state.gatewayA),
+            }, null, 2));
+            ctx.output("raw-gateway-a-auth-required-json-rpc", JSON.stringify({
+              endpoint: gatewayMcpUrl,
+              initialize: { httpStatus: state.rawGatewayA.initialize.response.status, body: state.rawGatewayA.initialize.body },
+              toolsList: { httpStatus: state.rawGatewayA.tools.response.status, body: state.rawGatewayA.tools.body },
+              toolsCall: { httpStatus: state.rawGatewayA.call.response.status, body: state.rawGatewayA.call.body },
+            }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — Agent execute relays the provider sign-in link",
+      run: async (ctx) => {
+        await ctx.prove("The agent-facing MCP surface returns needs_connection with the downstream provider connect URL", {
+          voiceover: vo[2],
+          action: async () => {
+            await mintMcpToken(ctx);
+            state.gatewayA.agentResult = await searchAndExecuteGateway(ctx, state.gatewayA, `${CONNECTION_A_NAME} ${TOOL_NAME}`);
+          },
+          assert: async () => {
+            assertProviderAuthEnvelope(ctx, state.gatewayA.agentResult.envelope, state.rawGatewayA.connectUrl);
+            ctx.output("agent-gateway-a-search-and-execute", JSON.stringify({
+              search: state.gatewayA.agentResult.searchBody,
+              selectedMatch: state.gatewayA.agentResult.match,
+              executeEnvelope: state.gatewayA.agentResult.envelope,
+            }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4 — Foreign-host provider links are stripped",
+      run: async (ctx) => {
+        await ctx.prove("Den keeps the downstream needs_connection state but strips a foreign-host connect URL", {
+          voiceover: vo[3],
+          action: async () => {
+            const { foreignGatewayMcpUrl } = requiredEnv(ctx);
+            state.gatewayB = await createGatewayConnection(ctx, { name: CONNECTION_B_NAME, url: foreignGatewayMcpUrl });
+            state.rawGatewayB = await captureRawGatewayAuthRequired(ctx, foreignGatewayMcpUrl, "gateway B");
+            state.gatewayB.agentResult = await searchAndExecuteGateway(ctx, state.gatewayB, `${CONNECTION_B_NAME} ${TOOL_NAME}`);
+          },
+          assert: async () => {
+            const { foreignGatewayMcpUrl } = requiredEnv(ctx);
+            assertForeignHostConnectUrl(ctx, state.rawGatewayB.connectUrl, foreignGatewayMcpUrl);
+            assertForeignLinkStrippedEnvelope(ctx, state.gatewayB.agentResult.envelope);
+            ctx.output("raw-gateway-b-and-stripped-agent-envelope", JSON.stringify({
+              endpoint: foreignGatewayMcpUrl,
+              rawToolsCall: { httpStatus: state.rawGatewayB.call.response.status, body: state.rawGatewayB.call.body },
+              selectedMatch: state.gatewayB.agentResult.match,
+              executeEnvelope: state.gatewayB.agentResult.envelope,
+            }, null, 2));
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/den-provider-auth-relay.md
+++ b/evals/voiceovers/den-provider-auth-relay.md
@@ -1,0 +1,11 @@
+# den-provider-auth-relay — Den relays downstream provider sign-in links safely
+
+This internal proof follows a live Den server and two gateway-style MCP servers in the same isolated Daytona sandbox. The reviewer sees the health evidence, the raw gateway authorization payload, the agent-facing response, and the host-binding safety check.
+
+1. The opening frame shows a live Den API in an isolated Daytona sandbox. The health check answers from the public URL, and the service's build version is displayed so the reviewer can tell which server is responding.
+
+2. Next, the admin creates a workspace and publishes a Salesforce gateway connection. Beside it, the gateway's own raw response shows HTTP 200 with JSON-RPC -32001, authorization required, and a provider connect link on the same gateway host.
+
+3. Now the agent uses the Cloud Control surface just like a real worker would. Search finds the Salesforce tool, execute returns needs_connection, the downstream-provider status carries the exact sign-in link, and the old latency or timeout wording is nowhere in the answer.
+
+4. The final frame checks the safety rail. A second gateway asks for connection too, but because its link points at a different host, Den still reports needs_connection while removing the untrusted URL from both the diagnostic and the action.

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -507,7 +507,7 @@ function mcpResponse(message) {
         code: -32001,
         message: `Authorization required — connect your ${errorToolProvider} account to use this connector. Open ${connectLink} in a browser, sign in, then retry this request.`,
         data: {
-          connect_url: connectLink,
+          connect_url: errorToolConnectUrl,
           provider: errorToolProvider,
         },
       },


### PR DESCRIPTION
## Problem

When a downstream MCP gateway answers a tool call with HTTP 200 + JSON-RPC error `-32001` meaning **authorization required** (message + structured `data.connect_url`), Den classified it as a **request timeout**: the member was told to "Check provider latency and retry the MCP request", the sign-in link was discarded by the diagnostics redaction layer, and `retryable: true` invited retries that can never succeed. Observed live by a customer pilot (the user could only find the connect link by reading server logs).

## Root cause

`ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts` classified errors by numeric JSON-RPC code alone: every `-32001` → `MCP_REQUEST_TIMEOUT`. But `-32001` is only the MCP SDK's **client-side** `RequestTimeout`; it sits in the JSON-RPC server-defined range, and real gateways use it for auth-required. A remote payload error and a local timeout were indistinguishable because the classifier never looked at the error shape (`data.timeout` vs `data.connect_url`).

## Fix (kept generic on purpose)

- **Classify by shape, not code**: a structured auth-required error (`data.connect_url` on any code, or spec-track `-32042 UrlElicitationRequired` with `data.url`) now classifies as `MCP_PROVIDER_AUTH_REQUIRED` (`retryable: false`, `actionOwner: member`). No message-text heuristics. Bare/local `-32001` (SDK timeouts carry `data.timeout`/`data.maxTotalTimeout`) keeps the existing timeout classification.
- **Reuse the existing vocabulary**: `execute_capability` returns `error: "needs_connection"` with `connectionStatus.layer: "downstream_provider"`, `state: "needs_connection"`, `action.type: "connect"` and `action.url` = the provider link — the same stop-and-relay contract agents already follow (#2614).
- **Safety**: connect URLs are relayed only when http(s) **and host-bound** to the connection's own host; foreign-host links are stripped (`diagnostic.connectUrl` and `action.url` omitted) while the needs-connection state is kept. Provider-supplied strings are never interpolated into safe messages.
- Tool-call inspection no longer blames the network for these responses.
- Mock gateway fidelity: `data.connect_url` is now a bare URL (matches real gateway payloads).

Known tradeoff: `connectionStatus.action.surface` reuses `openwork_your_connections` rather than a new enum value — smallest diff; open to adding `provider_signin` in a follow-up.

## Tests

- Unit (new): remote `-32001`+`connect_url` → auth-required; `-32042`+`data.url` → auth-required; SDK timeout shapes (`data.timeout`, `maxTotalTimeout`) → timeout (this branch previously had **zero** coverage); bare `-32001` → timeout; non-http(s) schemes rejected; unknown codes unchanged. `pnpm exec bun test ee/apps/den-api/test/external-mcp-diagnostics.test.ts` → **69 pass**.
- Integration (new, real in-process MCP servers): same-host relay + foreign-host strip through `executeExternalCapability`. Divergence suite: **19 pass / 2 fail — both failures pre-exist on `origin/dev` baseline** (verified by running the same file at the merge-base: 14 pass / 5 fail; our branch introduces no new failures).
- Also green: `external-mcp-tool-inspection` (8), `external-capability-errors` + `mcp-agent-timeouts` (24), den-web `mcp-tool-error-attribution` (10), `tsc --noEmit` (den-api), den-web typecheck.

## Live proof (Daytona, not local)

Fraimz flow `den-provider-auth-relay` (internal kind) against a **real Den API on a Daytona sandbox** running this branch, with two mock gateways behind public HTTPS preview URLs replaying the customer gateway's exact payload shape (HTTP 200, `-32001`, bare same-host `connect_url`):

1. Den API health on Daytona ✓
2. Admin bootstraps org + registers gateway connection via real API; raw `-32001` payload captured ✓
3. `search_capabilities` → `execute_capability` via `@modelcontextprotocol/sdk` client against `/mcp/agent`: **`needs_connection`, `diagnostic.code: MCP_PROVIDER_AUTH_REQUIRED`, `action.url` = exact connect link, no latency/timeout wording** ✓
4. Foreign-host gateway: state kept, **link stripped** ✓

Full artifact posted as a follow-up comment (`pnpm fraimz --flow den-provider-auth-relay --pr`). Honesty note: one earlier run hit a transient `MCP_MCP_TRANSPORT` lifecycle flake on the second gateway's first agent call (Daytona proxy cold path); rerun was fully green — unrelated to the classification change.

Repro: `bash .devcontainer/test-server-on-daytona.sh fix/den-provider-auth-required`, start two `scripts/mock-oauth-mcp-server.mjs` instances (`MOCK_ERROR_TOOL_MODE=authorization_required`, `MOCK_ALLOW_UNAUTHENTICATED_MCP=1`), then run the flow with `OPENWORK_EVAL_DEN_API_URL` + `OPENWORK_EVAL_GATEWAY_MCP_URL(_FOREIGN)`.