### PR TITLE
feat: add resilient browser handoff fallbacks

### DIFF
--- a/apps/app/src/app/lib/browser-handoff.ts
+++ b/apps/app/src/app/lib/browser-handoff.ts
@@ -1,0 +1,139 @@
+import { openDesktopUrl } from "./desktop";
+import { isDesktopRuntime } from "../utils";
+
+export type BrowserHandoffResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+export type BrowserHandoffOverrides = {
+  desktopRuntime?: boolean;
+  openDesktop?: (url: string) => Promise<void>;
+  openWindow?: (url: string) => Window | null;
+};
+
+export const browserHandoffRequiredEvent = "openwork:browser-handoff-required";
+
+export type BrowserHandoffRequiredDetail = {
+  url: string;
+  error: string;
+};
+
+type ClipboardOverrides = {
+  writeClipboard?: (text: string) => Promise<void>;
+  legacyCopy?: (text: string) => boolean;
+};
+
+function errorMessage(error: unknown, fallback: string) {
+  return error instanceof Error && error.message.trim() ? error.message : fallback;
+}
+
+/**
+ * Best-effort browser launch. Callers must keep the URL visible while the
+ * handoff is pending because even a successful OS response cannot prove that
+ * a browser became visible to the user.
+ */
+export async function tryOpenBrowserUrl(
+  url: string,
+  overrides: BrowserHandoffOverrides = {},
+): Promise<BrowserHandoffResult> {
+  if (!url.trim()) {
+    return { ok: false, error: "The browser link is unavailable." };
+  }
+
+  try {
+    const desktopRuntime = overrides.desktopRuntime ?? isDesktopRuntime();
+    if (desktopRuntime) {
+      await (overrides.openDesktop ?? openDesktopUrl)(url);
+      return { ok: true };
+    }
+
+    const openWindow = overrides.openWindow ?? ((target: string) => {
+      if (typeof window === "undefined") return null;
+      return window.open(target, "_blank", "noopener,noreferrer");
+    });
+    if (!openWindow(url)) {
+      return { ok: false, error: "The browser blocked the new window." };
+    }
+    return { ok: true };
+  } catch (error) {
+    return { ok: false, error: errorMessage(error, "The browser could not be opened.") };
+  }
+}
+
+export function showGlobalBrowserHandoffFallback(detail: BrowserHandoffRequiredDetail) {
+  if (typeof window === "undefined") return;
+  window.dispatchEvent(new CustomEvent<BrowserHandoffRequiredDetail>(
+    browserHandoffRequiredEvent,
+    { detail },
+  ));
+}
+
+export async function openBrowserUrlWithGlobalFallback(
+  url: string,
+  overrides: BrowserHandoffOverrides = {},
+  showFallback: (detail: BrowserHandoffRequiredDetail) => void = showGlobalBrowserHandoffFallback,
+): Promise<BrowserHandoffResult> {
+  const result = await tryOpenBrowserUrl(url, overrides);
+  if (!result.ok) {
+    showFallback({ url, error: result.error });
+  }
+  return result;
+}
+
+function legacyCopyText(text: string): boolean {
+  if (typeof document === "undefined" || typeof document.execCommand !== "function") {
+    return false;
+  }
+
+  const field = document.createElement("textarea");
+  field.value = text;
+  field.setAttribute("readonly", "");
+  field.style.position = "fixed";
+  field.style.left = "-9999px";
+  field.style.opacity = "0";
+  document.body.appendChild(field);
+  field.focus();
+  field.select();
+
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    field.remove();
+  }
+}
+
+/**
+ * Tries both the modern Clipboard API and the older selection-based copy
+ * command. The visible field in BrowserHandoffFallback remains the final,
+ * dependency-free manual path if both are unavailable.
+ */
+export async function copyBrowserHandoffUrl(
+  url: string,
+  overrides: ClipboardOverrides = {},
+): Promise<BrowserHandoffResult> {
+  const writeClipboard = overrides.writeClipboard ?? (
+    typeof navigator !== "undefined" && navigator.clipboard?.writeText
+      ? (text: string) => navigator.clipboard.writeText(text)
+      : undefined
+  );
+
+  if (writeClipboard) {
+    try {
+      await writeClipboard(url);
+      return { ok: true };
+    } catch {
+      // Fall through to the legacy selection-based copy path.
+    }
+  }
+
+  try {
+    const copied = (overrides.legacyCopy ?? legacyCopyText)(url);
+    return copied
+      ? { ok: true }
+      : { ok: false, error: "Automatic copy was blocked." };
+  } catch (error) {
+    return { ok: false, error: errorMessage(error, "Automatic copy was blocked.") };
+  }
+}

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -360,7 +360,8 @@ export async function openDesktopUrl(url: string): Promise<void> {
     return;
   }
   if (typeof window !== "undefined") {
-    window.open(url, "_blank", "noopener,noreferrer");
+    const opened = window.open(url, "_blank", "noopener,noreferrer");
+    if (!opened) throw new Error("The browser blocked the new window.");
   }
 }
 

--- a/apps/app/src/components/browser-handoff-fallback.tsx
+++ b/apps/app/src/components/browser-handoff-fallback.tsx
@@ -1,0 +1,110 @@
+/** @jsxImportSource react */
+import { useEffect, useRef, useState } from "react";
+import { Copy, ExternalLink, Loader2 } from "lucide-react";
+
+import {
+  copyBrowserHandoffUrl,
+  tryOpenBrowserUrl,
+  type BrowserHandoffResult,
+} from "@/app/lib/browser-handoff";
+import { Button } from "@/components/ui/button";
+import { Textarea } from "@/components/ui/textarea";
+import { cn } from "@/lib/utils";
+
+export type BrowserHandoffFallbackProps = {
+  url: string;
+  title?: string;
+  description?: string;
+  openLabel?: string;
+  className?: string;
+  onOpenResult?: (result: BrowserHandoffResult) => void;
+};
+
+export function BrowserHandoffFallback({
+  url,
+  title = "Open this link in your browser",
+  description = "If the browser did not open, copy this link or select it below and copy it manually.",
+  openLabel = "Open again",
+  className,
+  onOpenResult,
+}: BrowserHandoffFallbackProps) {
+  const fieldRef = useRef<HTMLTextAreaElement | null>(null);
+  const [opening, setOpening] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "manual">("idle");
+  const [openError, setOpenError] = useState<string | null>(null);
+
+  useEffect(() => {
+    setCopyStatus("idle");
+    setOpenError(null);
+  }, [url]);
+
+  const selectUrl = () => {
+    fieldRef.current?.focus();
+    fieldRef.current?.select();
+  };
+
+  const openUrl = async () => {
+    if (opening) return;
+    setOpening(true);
+    setOpenError(null);
+    const result = await tryOpenBrowserUrl(url);
+    if (!result.ok) setOpenError(result.error);
+    setOpening(false);
+    onOpenResult?.(result);
+  };
+
+  const copyUrl = async () => {
+    const result = await copyBrowserHandoffUrl(url);
+    if (result.ok) {
+      setCopyStatus("copied");
+      window.setTimeout(() => setCopyStatus("idle"), 2_000);
+      return;
+    }
+
+    setCopyStatus("manual");
+    selectUrl();
+  };
+
+  return (
+    <div
+      data-testid="browser-handoff-fallback"
+      className={cn("space-y-3 rounded-xl border border-amber-7/40 bg-amber-2/50 p-3 text-left", className)}
+    >
+      <div className="space-y-1">
+        <div className="text-xs font-semibold text-amber-12">{title}</div>
+        <div className="text-xs leading-relaxed text-amber-11">{description}</div>
+      </div>
+      <Textarea
+        ref={fieldRef}
+        readOnly
+        aria-label="Browser link"
+        data-testid="browser-handoff-url"
+        value={url}
+        rows={2}
+        onClick={(event) => event.currentTarget.select()}
+        onFocus={(event) => event.currentTarget.select()}
+        className="max-h-28 resize-y font-mono text-[11px] leading-relaxed"
+      />
+      <div className="flex flex-wrap items-center gap-2">
+        <Button variant="outline" size="sm" onClick={() => void openUrl()} disabled={opening}>
+          {opening ? <Loader2 className="size-3.5 animate-spin" /> : <ExternalLink className="size-3.5" />}
+          {openLabel}
+        </Button>
+        <Button variant="outline" size="sm" onClick={() => void copyUrl()}>
+          <Copy className="size-3.5" />
+          {copyStatus === "copied" ? "Copied" : "Copy link"}
+        </Button>
+        {copyStatus === "manual" ? (
+          <span role="status" className="text-xs text-amber-11">
+            Copy was blocked. The full link is selected; use your keyboard or Edit menu to copy it.
+          </span>
+        ) : null}
+        {openError ? (
+          <span role="status" className="text-xs text-amber-11">
+            {openError} Use the link above instead.
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -21,7 +21,7 @@ import {
   type UIMessage,
 } from "ai"
 import type { SessionStatus } from "@opencode-ai/sdk/v2/client"
-import { openDesktopUrl } from "@/app/lib/desktop"
+import { openBrowserUrlWithGlobalFallback } from "@/app/lib/browser-handoff"
 import { SYNTHETIC_SESSION_ERROR_MESSAGE_PREFIX } from "@/app/types"
 import { ApplyPatchTool } from "@/components/tools/apply-patch"
 import { BashTool } from "@/components/tools/bash"
@@ -644,7 +644,7 @@ function RetryActionButton(props: { link: string; label: string }) {
       variant="outline"
       size="sm"
       className="h-7 border-amber-500/70 bg-amber-50 text-xs text-amber-950 hover:bg-amber-100"
-      onClick={() => void openDesktopUrl(props.link)}
+      onClick={() => void openBrowserUrlWithGlobalFallback(props.link)}
     >
       {props.label}
     </Button>

--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -5,6 +5,7 @@ import {
   CollapsibleContent,
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
+import { BrowserHandoffFallback } from "@/components/browser-handoff-fallback"
 import { Button } from "@/components/ui/button"
 import {
   attributeChatToolError,
@@ -234,9 +235,9 @@ const Tool = ({
         })
       } catch (error) {
         setReconnectRecord(reconnectKey, {
-          phase: "failed",
+          phase: "authorization_opened",
           error: error instanceof Error ? error.message : "Could not reopen sign-in.",
-          authorizeUrl: null,
+          authorizeUrl: reconnectAuthorizeUrl,
         })
       }
       return
@@ -356,6 +357,14 @@ const Tool = ({
       </div>
       {reconnectError ? (
         <p className="mt-1 text-xs text-destructive" role="alert">{reconnectError}</p>
+      ) : null}
+      {reconnectAuthorizeUrl ? (
+        <BrowserHandoffFallback
+          url={reconnectAuthorizeUrl}
+          title={`Finish reconnecting ${reconnectAction?.connectionName ?? "this account"}`}
+          description="OpenWork is waiting for authorization. If the browser did not appear, open or copy the full link below."
+          className="mt-2"
+        />
       ) : null}
       <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden text-sm transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
         <div className="bg-muted mt-2 flex flex-col gap-2 rounded-lg p-2 text-xs">

--- a/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
@@ -108,7 +108,9 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
   const openBrowserAuth = useCallback(
     (mode: "sign-in" | "sign-up") => {
       const url = buildDenAuthUrl(baseUrl, mode);
-      setSigninFallbackUrl(null);
+      // Keep the link visible even when the OS reports a successful launch:
+      // the app cannot verify that a usable browser window appeared.
+      setSigninFallbackUrl(url);
       setStatusMessage(
         mode === "sign-up"
           ? t("den.status_browser_signup")
@@ -118,7 +120,6 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
       void tryOpenBrowserAuthUrl(url).then((opened) => {
         if (opened) return;
         setStatusMessage(null);
-        setSigninFallbackUrl(url);
         setManualAuthOpen(true);
       });
     },

--- a/apps/app/src/react-app/domains/cloud/open-browser-auth.ts
+++ b/apps/app/src/react-app/domains/cloud/open-browser-auth.ts
@@ -1,16 +1,5 @@
-import { openDesktopUrl } from "../../../app/lib/desktop";
-import { isDesktopRuntime } from "../../../app/utils";
+import { tryOpenBrowserUrl } from "../../../app/lib/browser-handoff";
 
 export async function tryOpenBrowserAuthUrl(url: string): Promise<boolean> {
-  if (isDesktopRuntime()) {
-    try {
-      await openDesktopUrl(url);
-      return true;
-    } catch (error) {
-      console.error("[den-auth] failed to open browser:", error);
-      return false;
-    }
-  }
-
-  return window.open(url, "_blank") !== null;
+  return (await tryOpenBrowserUrl(url)).ok;
 }

--- a/apps/app/src/react-app/domains/cloud/signin-fallback-notice.tsx
+++ b/apps/app/src/react-app/domains/cloud/signin-fallback-notice.tsx
@@ -1,33 +1,15 @@
 /** @jsxImportSource react */
-import { useState } from "react";
-
-import { Button } from "@/components/ui/button";
+import { BrowserHandoffFallback } from "@/components/browser-handoff-fallback";
 import { t } from "../../../i18n";
 
 export function SignInFallbackNotice({ url }: { url: string }) {
-  // Presentation-only copy feedback; DenSignInSurface stays stateless.
-  const [copied, setCopied] = useState(false);
-
-  const copyLink = () => {
-    void navigator.clipboard.writeText(url).then(() => {
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    }).catch((error) => {
-      console.error("[den-auth] failed to copy sign-in link:", error);
-    });
-  };
-
   return (
-    <div className="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="space-y-1">
-          <div>{t("den.error_browser_open_failed")}</div>
-          <div>{t("den.browser_open_failed_hint")}</div>
-        </div>
-        <Button variant="outline" size="sm" onClick={copyLink}>
-          {copied ? t("den.signin_link_copied") : t("den.copy_signin_link")}
-        </Button>
-      </div>
-    </div>
+    <BrowserHandoffFallback
+      url={url}
+      title="Continue in your browser"
+      description={`${t("den.browser_open_failed_hint")} The full link stays available here even if browser launch or copy is blocked.`}
+      openLabel="Open sign-in again"
+      className="border-red-7/30 bg-red-1/40"
+    />
   );
 }

--- a/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
@@ -12,13 +12,17 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { McpDirectoryInfo } from "@/app/constants";
-import { openDesktopUrl, opencodeMcpAuth } from "@/app/lib/desktop";
+import { tryOpenBrowserUrl } from "@/app/lib/browser-handoff";
+import { opencodeMcpAuth } from "@/app/lib/desktop";
 import { unwrap } from "@/app/lib/opencode";
 import { validateMcpServerName } from "@/app/mcp";
 import type { Client } from "@/app/types";
 import { isDesktopRuntime, normalizeDirectoryPath } from "@/app/utils";
 import { t } from "@/i18n";
+import { BrowserHandoffFallback } from "@/components/browser-handoff-fallback";
 import { Button } from "@/components/ui/button";
+import { useGlobalSDK } from "@/react-app/kernel/global-sdk-provider";
+import { mcpBrowserOpenFailedUrl } from "./mcp-browser-handoff";
 import { TextInput } from "../../design-system/text-input";
 
 const MCP_AUTH_POLL_INTERVAL_MS = 2_000;
@@ -55,6 +59,7 @@ export type McpAuthModalProps = {
 };
 
 export function McpAuthModal(props: McpAuthModalProps) {
+  const globalSDK = useGlobalSDK();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [needsReload, setNeedsReload] = useState(false);
@@ -67,7 +72,6 @@ export function McpAuthModal(props: McpAuthModalProps) {
   const [manualAuthBusy, setManualAuthBusy] = useState(false);
   const [cliAuthBusy, setCliAuthBusy] = useState(false);
   const [cliAuthResult, setCliAuthResult] = useState<string | null>(null);
-  const [authUrlCopied, setAuthUrlCopied] = useState(false);
   const [resolvedDir, setResolvedDir] = useState("");
   const [awaitingReload, setAwaitingReload] = useState(false);
   const [reloadStarting, setReloadStarting] = useState(false);
@@ -75,7 +79,6 @@ export function McpAuthModal(props: McpAuthModalProps) {
   const [forceStopBusySessionID, setForceStopBusySessionID] = useState<string | null>(null);
 
   const statusPollRef = useRef<number | null>(null);
-  const authCopyTimeoutRef = useRef<number | null>(null);
   const previousOpenRef = useRef(false);
   const previousEntryNameRef = useRef<string | null>(null);
   const reloadAuthRunRef = useRef(false);
@@ -94,43 +97,45 @@ export function McpAuthModal(props: McpAuthModalProps) {
   }, [props.projectDir]);
 
   useEffect(() => {
-    return () => {
-      stopStatusPolling();
-      if (authCopyTimeoutRef.current !== null) {
-        window.clearTimeout(authCopyTimeoutRef.current);
-        authCopyTimeoutRef.current = null;
-      }
-    };
-  }, []);
+    if (!props.open || props.isRemoteWorkspace || !props.entry) return;
 
-  const openAuthorizationUrl = async (url: string) => {
-    if (isDesktopRuntime()) {
-      await openDesktopUrl(url);
+    let slug = "";
+    try {
+      slug = validateMcpServerName(props.entry.name).toLowerCase().replace(/[^a-z0-9]+/g, "-");
+    } catch {
       return;
     }
 
-    if (typeof window !== "undefined") {
-      window.open(url, "_blank", "noopener,noreferrer");
-    }
-  };
+    const onEvent = (payload: unknown) => {
+      const url = mcpBrowserOpenFailedUrl(payload, slug);
+      if (url) setAuthorizationUrl(url);
+    };
 
-  const handleCopyAuthorizationUrl = async () => {
-    if (!authorizationUrl) return;
+    const keys = new Set([
+      resolvedDir.trim(),
+      normalizeDirectoryPath(props.projectDir ?? "").trim(),
+      "global",
+    ]);
+    const unsubscribers = [...keys]
+      .filter(Boolean)
+      .map((key) => globalSDK.event.on(key, onEvent));
+    return () => {
+      for (const unsubscribe of unsubscribers) unsubscribe();
+    };
+  }, [
+    globalSDK.event,
+    props.entry,
+    props.isRemoteWorkspace,
+    props.open,
+    props.projectDir,
+    resolvedDir,
+  ]);
 
-    try {
-      await navigator.clipboard.writeText(authorizationUrl);
-      setAuthUrlCopied(true);
-      if (authCopyTimeoutRef.current !== null) {
-        window.clearTimeout(authCopyTimeoutRef.current);
-      }
-      authCopyTimeoutRef.current = window.setTimeout(() => {
-        setAuthUrlCopied(false);
-        authCopyTimeoutRef.current = null;
-      }, 2_000);
-    } catch {
-      // ignore clipboard failures
-    }
-  };
+  useEffect(() => {
+    return () => {
+      stopStatusPolling();
+    };
+  }, []);
 
   const fetchMcpStatus = async (slug: string) => {
     if (!props.entry || !props.client) return null;
@@ -290,7 +295,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
       }
 
       setAuthorizationUrl(auth.authorizationUrl);
-      await openAuthorizationUrl(auth.authorizationUrl);
+      await tryOpenBrowserUrl(auth.authorizationUrl);
       startStatusPolling(slug);
     } catch (err) {
       const message = err instanceof Error ? err.message : t("mcp.auth.failed_to_start_oauth");
@@ -784,37 +789,35 @@ export function McpAuthModal(props: McpAuthModalProps) {
             </div>
           ) : null}
 
-          {!isBusy && authorizationUrl && props.isRemoteWorkspace && !alreadyConnected ? (
+          {authorizationUrl && !alreadyConnected ? (
             <div className="space-y-3 rounded-xl border border-gray-6/60 bg-gray-1/40 p-4">
-              <div className="text-xs font-medium text-gray-12">{t("mcp.auth.manual_finish_title")}</div>
-              <div className="text-xs text-gray-10">{t("mcp.auth.manual_finish_hint")}</div>
-              <div className="flex items-center gap-3 rounded-xl border border-gray-6/70 bg-gray-2/40 px-3 py-2">
-                <div className="min-w-0 flex-1">
-                  <div className="text-[10px] uppercase tracking-wide text-gray-8">
-                    {t("mcp.auth.authorization_link")}
-                  </div>
-                  <div className="truncate font-mono text-[11px] text-gray-11">{authorizationUrl}</div>
-                </div>
-                <Button variant="outline" size="sm" onClick={() => void handleCopyAuthorizationUrl()}>
-                  {authUrlCopied ? t("mcp.auth.copied") : t("mcp.auth.copy_link")}
-                </Button>
-              </div>
-              <TextInput
-                label={t("mcp.auth.callback_label")}
-                placeholder={t("mcp.auth.callback_placeholder")}
-                value={callbackInput}
-                onChange={(event) => setCallbackInput(event.currentTarget.value)}
+              <BrowserHandoffFallback
+                url={authorizationUrl}
+                title={t("mcp.auth.manual_finish_title")}
+                description={props.isRemoteWorkspace
+                  ? t("mcp.auth.manual_finish_hint")
+                  : "Keep this authorization link available while OpenWork waits. Open it again or copy it below whenever needed."}
               />
-              <div className="text-[11px] text-gray-9">{t("mcp.auth.port_forward_hint")}</div>
-              <div className="flex justify-end">
-                <Button
-                  onClick={() => void handleManualComplete()}
-                  disabled={manualAuthBusy || !callbackInput.trim()}
-                >
-                  {manualAuthBusy ? <Loader2 size={14} className="animate-spin" /> : null}
-                  {t("mcp.auth.complete_connection")}
-                </Button>
-              </div>
+              {props.isRemoteWorkspace ? (
+                <>
+                  <TextInput
+                    label={t("mcp.auth.callback_label")}
+                    placeholder={t("mcp.auth.callback_placeholder")}
+                    value={callbackInput}
+                    onChange={(event) => setCallbackInput(event.currentTarget.value)}
+                  />
+                  <div className="text-[11px] text-gray-9">{t("mcp.auth.port_forward_hint")}</div>
+                  <div className="flex justify-end">
+                    <Button
+                      onClick={() => void handleManualComplete()}
+                      disabled={manualAuthBusy || !callbackInput.trim()}
+                    >
+                      {manualAuthBusy ? <Loader2 size={14} className="animate-spin" /> : null}
+                      {t("mcp.auth.complete_connection")}
+                    </Button>
+                  </div>
+                </>
+              ) : null}
             </div>
           ) : null}
 

--- a/apps/app/src/react-app/domains/connections/mcp-browser-handoff.ts
+++ b/apps/app/src/react-app/domains/connections/mcp-browser-handoff.ts
@@ -1,0 +1,20 @@
+type McpBrowserHandoffEvent = {
+  type: "mcp.browser.open.failed";
+  properties: {
+    mcpName: string;
+    url: string;
+  };
+};
+
+export function mcpBrowserOpenFailedUrl(payload: unknown, expectedMcpName: string): string | null {
+  if (!payload || typeof payload !== "object") return null;
+  const event = payload as Partial<McpBrowserHandoffEvent>;
+  const properties = event.properties;
+  if (
+    event.type !== "mcp.browser.open.failed"
+    || properties?.mcpName !== expectedMcpName
+    || typeof properties.url !== "string"
+    || !properties.url.trim()
+  ) return null;
+  return properties.url;
+}

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -22,8 +22,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { openDesktopUrl } from "@/app/lib/desktop";
-import { isDesktopRuntime } from "@/app/utils";
+import { tryOpenBrowserUrl } from "@/app/lib/browser-handoff";
+import { BrowserHandoffFallback } from "@/components/browser-handoff-fallback";
 import { compareProviders } from "@/app/utils/providers";
 import { Button } from "@/components/ui/button";
 import { ProviderIcon } from "../../../design-system/provider-icon";
@@ -155,11 +155,8 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
 
   const openExternalUrl = async (url: string) => {
     if (!url) return;
-    if (isDesktopRuntime()) {
-      await openDesktopUrl(url);
-      return;
-    }
-    window.open(url, "_blank", "noopener,noreferrer");
+    const result = await tryOpenBrowserUrl(url);
+    setLocalError(result.ok ? null : result.error);
   };
 
   const isClaudeProMaxMethod = (method: ProviderAuthMethod) => {
@@ -237,8 +234,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
   const shouldStartOauthAutoPolling =
     props.open &&
     resolvedView === "oauth-auto" &&
-    oauthSession &&
-    (!isOpenAiHeadlessSession || oauthBrowserOpened);
+    oauthSession;
 
   const oauthDisplayCode = useMemo(() => {
     if (!oauthInstructions) return "";
@@ -391,13 +387,9 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
 
   const openOauthUrl = async (url: string) => {
     if (!url) return;
-    if (isDesktopRuntime()) {
-      await openDesktopUrl(url);
-      setOauthBrowserOpened(true);
-      return;
-    }
-    window.open(url, "_blank", "noopener,noreferrer");
-    setOauthBrowserOpened(true);
+    const result = await tryOpenBrowserUrl(url);
+    setOauthBrowserOpened(result.ok);
+    setLocalError(result.ok ? null : `${result.error} Use the authorization link shown below.`);
   };
 
   const copyOauthDisplayCode = async () => {
@@ -488,16 +480,15 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
       setOauthSession(nextSession);
 
       if (started.authorization.method === "code") {
-        await openOauthUrl(started.authorization.url);
         setView("oauth-code");
+        await openOauthUrl(started.authorization.url);
         return;
       }
 
+      setView("oauth-auto");
       if (!isOpenAiHeadlessMethod(selectedMethod)) {
         await openOauthUrl(started.authorization.url);
       }
-
-      setView("oauth-auto");
     } catch (error) {
       const message = error instanceof Error ? error.message : "Failed to start OAuth";
       setLocalError(message);
@@ -982,6 +973,16 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       {oauthInstructions}
                     </div>
                   ) : null}
+                  <BrowserHandoffFallback
+                    url={oauthSession.authorization.url}
+                    title={`Finish connecting ${selectedEntry.name}`}
+                    description="Open the authorization page, then return here and paste the code. The full link stays available if browser launch or copy is blocked."
+                    openLabel="Open browser"
+                    onOpenResult={(result) => {
+                      setOauthBrowserOpened(result.ok);
+                      setLocalError(result.ok ? null : result.error);
+                    }}
+                  />
                   <TextInput
                     label="Authorization code"
                     type="text"
@@ -1001,15 +1002,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                     spellCheck={false}
                     disabled={actionDisabled}
                   />
-                  <div className="flex items-center justify-between gap-3">
-                    <Button
-                      variant="outline"
-                      onClick={() => {
-                        void openOauthUrl(oauthSession.authorization.url ?? "");
-                      }}
-                    >
-                      Open browser again
-                    </Button>
+                  <div className="flex items-center justify-end">
                     <Button
                       onClick={() => void handleOauthCodeSubmit()}
                       disabled={actionDisabled || !oauthCodeInput.trim()}
@@ -1054,9 +1047,19 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       </Button>
                     </div>
                   ) : null}
+                  <BrowserHandoffFallback
+                    url={oauthSession.authorization.url}
+                    title={`Finish connecting ${selectedEntry.name}`}
+                    description="Keep this dialog open while you authorize in the browser. The full link stays available if browser launch or copy is blocked."
+                    openLabel={isOpenAiHeadlessSession && !oauthBrowserOpened ? "Open browser" : "Open browser again"}
+                    onOpenResult={(result) => {
+                      setOauthBrowserOpened(result.ok);
+                      setLocalError(result.ok ? null : result.error);
+                    }}
+                  />
                   {isOpenAiHeadlessSession && !oauthBrowserOpened ? (
                     <div className="flex items-center gap-2 text-xs text-gray-9">
-                      <span>Authorization checks will start after you click Open Browser.</span>
+                      <span>Use the browser link above. OpenWork is already checking for completion.</span>
                     </div>
                   ) : (
                     <div className="flex items-center gap-2 text-xs text-gray-9">
@@ -1064,19 +1067,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       <span>Checking connection status automatically…</span>
                     </div>
                   )}
-                  <div className="flex items-center justify-between gap-3">
-                    <Button
-                      variant="outline"
-                      onClick={() => {
-                        void openOauthUrl(oauthSession.authorization.url ?? "");
-                      }}
-                    >
-                      {isOpenAiHeadlessSession
-                        ? oauthBrowserOpened
-                          ? "Reopen Browser"
-                          : "Open Browser"
-                        : "Open browser again"}
-                    </Button>
+                  <div className="flex items-center justify-end">
                     <div className="text-[11px] text-gray-9 text-right">
                       This window will close once the provider is connected.
                     </div>

--- a/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
+++ b/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
@@ -1,9 +1,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
+import { tryOpenBrowserUrl } from "@/app/lib/browser-handoff";
 import { createDenClient, readDenSettings, type DenExternalMcpConnection } from "@/app/lib/den";
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
-import { openDesktopUrl } from "@/app/lib/desktop";
-import { isDesktopRuntime } from "@/app/utils";
 import { connectionNeedsReconnect, isNativeProviderConnectionId } from "./native-provider-connections";
 
 // Mirrors the poll-until-connected pattern used for local MCP OAuth
@@ -14,15 +13,10 @@ import { connectionNeedsReconnect, isNativeProviderConnectionId } from "./native
 const CONNECT_POLL_INTERVAL_MS = 2_000;
 const CONNECT_TIMEOUT_MS = 90_000;
 
-async function openAuthorizationUrl(url: string) {
-  if (isDesktopRuntime()) {
-    await openDesktopUrl(url);
-    return;
-  }
-  if (typeof window !== "undefined") {
-    window.open(url, "_blank", "noopener,noreferrer");
-  }
-}
+export type PendingOrgMcpAuthorization = {
+  connectionId: string;
+  url: string;
+};
 
 export type OrgMcpConnectionCardState = {
   connected: boolean;
@@ -105,6 +99,7 @@ export function useOrgMcpConnections() {
   const [error, setError] = useState<string | null>(null);
   const [connectingId, setConnectingId] = useState<string | null>(null);
   const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
+  const [pendingAuthorization, setPendingAuthorization] = useState<PendingOrgMcpAuthorization | null>(null);
   const pollRef = useRef<number | null>(null);
   const pollGenerationRef = useRef(0);
   const refreshRunRef = useRef(0);
@@ -134,6 +129,7 @@ export function useOrgMcpConnections() {
     const orgId = settings.activeOrgId?.trim() ?? "";
     if (!token || !orgId) {
       setConnections([]);
+      setPendingAuthorization(null);
       setError(null);
       setLoading(false);
       setLoaded(true);
@@ -180,22 +176,30 @@ export function useOrgMcpConnections() {
     };
     setDisconnectingId(null);
     setConnectingId(connectionId);
+    setPendingAuthorization(null);
+    setError(null);
     try {
       const client = createDenClient({ baseUrl: settings.baseUrl, token });
       const result = await client.startMcpConnectionConnect(orgId, connectionId);
       if (!isActionScopeCurrent(pollScope)) return;
       if (result.status === "connected") {
+        setPendingAuthorization(null);
         await refresh(pollScope);
         if (!isActionScopeCurrent(pollScope)) return;
         setConnectingId(null);
         return;
       }
       if (!result.authorizeUrl) {
+        setPendingAuthorization(null);
         setConnectingId(null);
         return;
       }
 
-      await openAuthorizationUrl(result.authorizeUrl);
+      // Preserve the URL before attempting the browser handoff. Browser launch
+      // can fail or report a false success, so the UI remains the source of
+      // truth while authorization is pending.
+      setPendingAuthorization({ connectionId, url: result.authorizeUrl });
+      await tryOpenBrowserUrl(result.authorizeUrl);
 
       if (!isActionScopeCurrent(pollScope)) return;
       const startedAt = Date.now();
@@ -204,6 +208,7 @@ export function useOrgMcpConnections() {
         if (Date.now() - startedAt >= CONNECT_TIMEOUT_MS) {
           stopPolling();
           setConnectingId(null);
+          setError("Authorization is still incomplete. Use the link below or reconnect to start a new attempt.");
           return;
         }
         const refreshedSettings = readDenSettings();
@@ -215,6 +220,7 @@ export function useOrgMcpConnections() {
           refreshedOrgId,
         )) {
           stopPolling();
+          setPendingAuthorization(null);
           setConnectingId(null);
           return;
         }
@@ -229,6 +235,7 @@ export function useOrgMcpConnections() {
           const match = polled.find((entry) => entry.id === connectionId);
           if (match?.connectedForMe && !connectionNeedsReconnect(match)) {
             stopPolling();
+            setPendingAuthorization(null);
             setConnectingId(null);
           }
         } catch {
@@ -238,6 +245,7 @@ export function useOrgMcpConnections() {
     } catch (connectError) {
       if (!isActionScopeCurrent(pollScope)) return;
       setError(connectError instanceof Error ? connectError.message : "Failed to start the connection.");
+      setPendingAuthorization(null);
       setConnectingId(null);
     }
   }, [isActionScopeCurrent, refresh, stopPolling]);
@@ -256,6 +264,7 @@ export function useOrgMcpConnections() {
       organizationId: orgId,
     };
     setConnectingId(null);
+    setPendingAuthorization(null);
     setDisconnectingId(connectionId);
     setError(null);
     try {
@@ -281,6 +290,7 @@ export function useOrgMcpConnections() {
       setLoaded(false);
       setConnectingId(null);
       setDisconnectingId(null);
+      setPendingAuthorization(null);
       void refresh();
     };
     window.addEventListener(denSettingsChangedEvent, handleSettingsChanged);
@@ -291,5 +301,16 @@ export function useOrgMcpConnections() {
     };
   }, [refresh, stopPolling]);
 
-  return { connections, loading, loaded, error, connectingId, disconnectingId, refresh, connect, disconnect };
+  return {
+    connections,
+    loading,
+    loaded,
+    error,
+    connectingId,
+    disconnectingId,
+    pendingAuthorization,
+    refresh,
+    connect,
+    disconnect,
+  };
 }

--- a/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
+++ b/apps/app/src/react-app/domains/onboarding/welcome-page.tsx
@@ -13,6 +13,7 @@ import {
   PageTitlebarRegion,
 } from "@/components/page";
 import { Button } from "@/components/ui/button";
+import { BrowserHandoffFallback } from "@/components/browser-handoff-fallback";
 import { ScrollArea, ScrollAreaViewport } from "@/components/ui/scroll-area";
 import { cn } from "@/lib/utils";
 import { OrganizationServerAffordance } from "../settings/cloud/organization-server-affordance";
@@ -129,6 +130,7 @@ type WelcomePageProps = {
   onUseManualFolder?: () => void;
   showManualFolder?: boolean;
   onTeamSignIn?: () => void;
+  teamSignInUrl?: string | null;
   organizationServerBusy: boolean;
   organizationServerError: string | null;
   organizationServerUrl: string;
@@ -165,6 +167,7 @@ export function WelcomePage({
   onUseManualFolder,
   showManualFolder,
   onTeamSignIn,
+  teamSignInUrl,
   organizationServerBusy,
   organizationServerError,
   organizationServerUrl,
@@ -231,6 +234,14 @@ export function WelcomePage({
                     >
                       {t("welcome.team_signin")}
                     </Button>
+                  ) : null}
+                  {teamSignInUrl ? (
+                    <BrowserHandoffFallback
+                      url={teamSignInUrl}
+                      title="Continue team sign-in"
+                      description="If the browser did not appear, open or copy the complete sign-in link below."
+                      openLabel="Open sign-in again"
+                    />
                   ) : null}
                   {error ? (
                     <p className="text-center text-xs text-destructive">{error}</p>

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -4,6 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Download, ExternalLink, FolderOpen, X } from "lucide-react";
 
 import type { OpenworkServerClient } from "@/app/lib/openwork-server";
+import { openBrowserUrlWithGlobalFallback } from "@/app/lib/browser-handoff";
 import { getDesktopFileIcon, openDesktopPath, revealDesktopItemInDir } from "@/app/lib/desktop";
 import { isElectronRuntime } from "@/app/utils";
 import { Button } from "@/components/ui/button";
@@ -192,7 +193,7 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
 
   const openExternal = async () => {
     if (target.kind === "url") {
-      window.open(target.value, "_blank", "noopener,noreferrer");
+      await openBrowserUrlWithGlobalFallback(target.value);
 
       return;
     }

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -8,6 +8,10 @@ import { resolveExtensionIconSrc } from "@/react-app/design-system/extension-ico
 import { t } from "../../../../i18n";
 import { OPENWORK_EXTENSION_CATALOG } from "../../../../app/constants";
 import { buildDenAuthUrl, readDenBootstrapConfig } from "../../../../app/lib/den";
+import {
+  openBrowserUrlWithGlobalFallback,
+  tryOpenBrowserUrl,
+} from "../../../../app/lib/browser-handoff";
 import { type OpenworkServerClient, type OpenworkServerStatus } from "../../../../app/lib/openwork-server";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
@@ -22,6 +26,7 @@ import type {
 } from "../../../../app/types";
 import type { ShareWorkspaceModalProps } from "../../workspace/types";
 import { Button } from "@/components/ui/button";
+import { BrowserHandoffFallback } from "@/components/browser-handoff-fallback";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import {
   Dialog,
@@ -33,7 +38,6 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
-import { usePlatform } from "../../../kernel/platform";
 import { useDenAuth } from "../../cloud/den-auth-provider";
 import ProviderAuthModal, { type ProviderAuthModalProps } from "../../connections/provider-auth/provider-auth-modal";
 import { RenameSessionModal } from "../modals/rename-session-modal";
@@ -307,7 +311,6 @@ function controlStringArg(args: unknown, key: string) {
 
 export function SessionPage(props: SessionPageProps) {
   const { config: shellConfig } = useShellConfig();
-  const platform = usePlatform();
   const denAuth = useDenAuth();
   const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
   const setSidebarOpen = useUiStateStore((state) => state.setSidebarOpen);
@@ -349,11 +352,18 @@ export function SessionPage(props: SessionPageProps) {
   );
   const voiceExtensionEnabled = voiceExtension ? isOpenWorkExtensionEnabled(voiceExtension) : false;
   const showCloudSignIn = shellConfig.cloudSignin && !denAuth.isSignedIn && denAuth.status !== "checking";
+  const [cloudSignInUrl, setCloudSignInUrl] = useState<string | null>(null);
   const openCloudSignIn = useCallback(() => {
     const baseUrl = readDenBootstrapConfig().baseUrl;
     // Label stays "Sign in"; opens the sign-up tab so new users aren't defaulted into sign-in.
-    platform.openLink(buildDenAuthUrl(baseUrl, "sign-up"));
-  }, [platform]);
+    const url = buildDenAuthUrl(baseUrl, "sign-up");
+    setCloudSignInUrl(url);
+    void tryOpenBrowserUrl(url);
+  }, []);
+
+  useEffect(() => {
+    if (denAuth.isSignedIn) setCloudSignInUrl(null);
+  }, [denAuth.isSignedIn]);
 
   useReactRenderWatchdog("SessionPage", {
     selectedSessionId: props.selectedSessionId,
@@ -464,9 +474,14 @@ export function SessionPage(props: SessionPageProps) {
       const url = browserUrlForTarget(target);
       if (isElectronRuntime()) {
         setCurrentSidePanel("panel");
-        void window.__OPENWORK_ELECTRON__?.browser?.createTab?.(url);
+        const createTab = window.__OPENWORK_ELECTRON__?.browser?.createTab;
+        if (createTab) {
+          void createTab(url).catch(() => openBrowserUrlWithGlobalFallback(url));
+        } else {
+          void openBrowserUrlWithGlobalFallback(url);
+        }
       } else {
-        window.open(url, "_blank", "noopener,noreferrer");
+        void openBrowserUrlWithGlobalFallback(url);
       }
       return;
     }
@@ -1053,6 +1068,16 @@ export function SessionPage(props: SessionPageProps) {
               ) : null}
             </div>
           </header>
+          {cloudSignInUrl && showCloudSignIn ? (
+            <div className="shrink-0 border-b border-border bg-background px-4 py-3 md:px-6">
+              <BrowserHandoffFallback
+                url={cloudSignInUrl}
+                title="Continue OpenWork sign-in"
+                description="If the browser did not appear, open or copy the complete sign-in link below."
+                openLabel="Open sign-in again"
+              />
+            </div>
+          ) : null}
 
           <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 overflow-hidden">
             <ResizablePanel minSize="180px" className="min-h-0">

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -7,6 +7,7 @@ import { Check, Minimize2 } from "lucide-react";
 import { toast } from "@/components/ui/sonner";
 
 import { captureAnalyticsEvent } from "@/app/lib/analytics";
+import { tryOpenBrowserUrl } from "@/app/lib/browser-handoff";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import { abortSessionSafe } from "@/app/lib/opencode-session";
 import { t } from "@/i18n";
@@ -41,7 +42,7 @@ import type {
 } from "@/react-app/domains/connections/cloud-mcp-submit-readiness";
 import { ReactSessionComposer } from "./composer/composer";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./composer/mention-encoding";
-import { desktopBridge, openDesktopUrl } from "@/app/lib/desktop";
+import { desktopBridge } from "@/app/lib/desktop";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
 import { DevProfiler } from "@/react-app/shell/dev-profiler";
 import { PaperGrainGradient } from "@openwork/ui/react";
@@ -1394,8 +1395,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
       }
       if (!result.authorizeUrl) throw new Error(`Could not start ${action.connectionName} authorization.`);
 
-      await openDesktopUrl(result.authorizeUrl);
       onProgress({ phase: "authorization_opened", authorizeUrl: result.authorizeUrl });
+      await tryOpenBrowserUrl(result.authorizeUrl);
       await waitForFreshMcpAuthorization({
         connectionId: action.connectionId,
         connectionName: action.connectionName,
@@ -1425,7 +1426,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     action: ChatToolReconnectAction,
     authorizeUrl: string,
   ) => {
-    await openDesktopUrl(authorizeUrl);
+    await tryOpenBrowserUrl(authorizeUrl);
     recordInspectorEvent("mcp.chat_reconnect.authorization_reopened", {
       workspaceId: props.workspaceId,
       sessionId: props.sessionId,

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -241,7 +241,9 @@ export function useDenSession({
   const openBrowserAuth = React.useCallback(
     (mode: "sign-in" | "sign-up") => {
       const url = buildDenAuthUrl(baseUrl, mode);
-      setSigninFallbackUrl(null);
+      // Keep the link visible for the entire browser handoff. A successful OS
+      // response cannot prove that a browser became visible to the user.
+      setSigninFallbackUrl(url);
       setStatusMessage(
         mode === "sign-up"
           ? t("den.status_browser_signup")
@@ -251,7 +253,6 @@ export function useDenSession({
       void tryOpenBrowserAuthUrl(url).then((opened) => {
         if (opened) return;
         setStatusMessage(null);
-        setSigninFallbackUrl(url);
       });
     },
     [baseUrl, setStatusMessage],

--- a/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
+++ b/apps/app/src/react-app/domains/settings/google-workspace-config.tsx
@@ -15,8 +15,9 @@ import {
 } from "@/components/ui/card";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Input } from "@/components/ui/input";
+import { BrowserHandoffFallback } from "@/components/browser-handoff-fallback";
+import { tryOpenBrowserUrl } from "@/app/lib/browser-handoff";
 import type { GoogleWorkspaceAuthStatus, OpenworkServerClient } from "../../../app/lib/openwork-server";
-import { usePlatform } from "../../kernel/platform";
 import type { ExtensionConfigContext } from "./extension-registry";
 import { registerExtensionRuntime } from "./extension-registry";
 
@@ -108,10 +109,10 @@ async function waitForGoogleWorkspaceConnection(client: OpenworkServerClient, fl
 }
 
 function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient, onExtensionConnectionChange, restartLocalServer }: ExtensionConfigContext) {
-  const platform = usePlatform();
   const [status, setStatus] = useState<GoogleWorkspaceAuthStatus | null>(null);
   const [busyAction, setBusyAction] = useState<BusyAction | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [pendingAuthUrl, setPendingAuthUrl] = useState<string | null>(null);
   const [clientSecret, setClientSecret] = useState("");
   const [customClientId, setCustomClientId] = useState("");
   const [customClientSecret, setCustomClientSecret] = useState("");
@@ -142,6 +143,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
 
   const runDesktopAction = async (action: Exclude<BusyAction, "status">, command: GoogleWorkspaceCommand) => {
     if (!openworkServerClient) return;
+    if (action === "connect") setPendingAuthUrl(null);
     setBusyAction(action);
     setError(null);
     try {
@@ -154,6 +156,7 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
       const next = normalizeGoogleWorkspaceAuthStatus(result);
       setStatus(next);
       onExtensionConnectionChange?.("google-workspace", next.connected);
+      if (action === "connect" && next.connected) setPendingAuthUrl(null);
     } catch (err) {
       setError(err instanceof Error ? err.message : `Google Workspace ${action} failed.`);
       await loadStatus({ clearError: false });
@@ -166,7 +169,8 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
     if (!openworkServerClient) return null;
     const features = status?.customClient === true ? OPTIONAL_FEATURES.filter((feature) => optionalFeatures[feature.id]).map((feature) => feature.id) : [];
     const flow = await openworkServerClient.googleWorkspaceConnectStart({ features });
-    platform.openLink(flow.authUrl);
+    setPendingAuthUrl(flow.authUrl);
+    await tryOpenBrowserUrl(flow.authUrl);
     return waitForGoogleWorkspaceConnection(openworkServerClient, flow.flowId, flow.expiresAt);
   };
 
@@ -374,6 +378,14 @@ function GoogleWorkspaceConfig({ openworkServerClient, hostOpenworkServerClient,
           </CardContent>
         ) : null}
         <CardFooter className="flex-wrap gap-2 justify-between">
+          {pendingAuthUrl ? (
+            <BrowserHandoffFallback
+              url={pendingAuthUrl}
+              title="Finish connecting Google Workspace"
+              description="OpenWork is waiting for Google authorization. If the browser did not appear, use this link while the connection remains pending."
+              className="basis-full"
+            />
+          ) : null}
           <div className="flex flex-wrap gap-2">
             <Button disabled={Boolean(busyAction) || !canConnect} onClick={() => void runDesktopAction("connect", connectGoogleWorkspace)}>
               {busyAction === "connect" ? <Loader2 className="size-4 animate-spin" /> : null}

--- a/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-marketplaces-view.tsx
@@ -7,6 +7,8 @@ import type { CloudImportedPlugin } from "@/app/cloud/import-state";
 import type { PendingCloudPluginChange } from "@/app/cloud/desktop-cloud-sync";
 import { evaluateEnablement, type EnablementContext } from "@/app/enablement";
 import type { DenExternalMcpConnection, DenOrgMarketplaceResolved, DenOrgPlugin, DenOrgPluginResolved } from "@/app/lib/den";
+import type { PendingOrgMcpAuthorization } from "@/react-app/domains/connections/use-org-mcp-connections";
+import { BrowserHandoffFallback } from "@/components/browser-handoff-fallback";
 import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { t } from "@/i18n";
@@ -124,6 +126,7 @@ export type CloudMarketplacesViewProps = {
   orgMcpConnections?: DenExternalMcpConnection[];
   orgMcpConnectingId?: string | null;
   orgMcpDisconnectingId?: string | null;
+  orgMcpPendingAuthorization?: PendingOrgMcpAuthorization | null;
   onConnectOrgMcp?: (connectionId: string) => void;
   onDisconnectOrgMcp?: (connectionId: string) => void;
   refreshOrgMcpConnections?: () => Promise<unknown> | void;
@@ -192,6 +195,7 @@ export function CloudMarketplacesView({
   orgMcpConnections = [],
   orgMcpConnectingId = null,
   orgMcpDisconnectingId = null,
+  orgMcpPendingAuthorization = null,
   onConnectOrgMcp,
   onDisconnectOrgMcp,
   refreshOrgMcpConnections,
@@ -483,6 +487,14 @@ export function CloudMarketplacesView({
 
       {actionError ?? extensions.cloudOrgMarketplacesStatus() ? (
         <SettingsNotice tone="error">{actionError ?? extensions.cloudOrgMarketplacesStatus()}</SettingsNotice>
+      ) : null}
+
+      {orgMcpPendingAuthorization ? (
+        <BrowserHandoffFallback
+          url={orgMcpPendingAuthorization.url}
+          title="Finish connecting your account"
+          description="OpenWork is waiting for authorization. If the browser did not appear, open or copy the full link below."
+        />
       ) : null}
 
       {busy ? (

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -4,8 +4,9 @@ import { ArrowUpRight } from "lucide-react";
 
 import type { DenExternalMcpConnection, DenOrgPlugin } from "@/app/lib/den";
 import { mintCloudControlMcpToken, readDenSettings } from "@/app/lib/den";
-import { openDesktopUrl } from "@/app/lib/desktop";
+import { tryOpenBrowserUrl } from "@/app/lib/browser-handoff";
 import type { OpenworkCloudMcpHealth, OpenworkCloudMcpProviderModelContext, OpenworkServerClient } from "@/app/lib/openwork-server";
+import { BrowserHandoffFallback } from "@/components/browser-handoff-fallback";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
@@ -104,16 +105,33 @@ function denManageConnectionsUrl() {
 }
 
 function ManageInDenButton() {
+  const [handoffUrl, setHandoffUrl] = useState<string | null>(null);
+
+  const openManageConnections = () => {
+    const url = denManageConnectionsUrl();
+    setHandoffUrl(url);
+    void tryOpenBrowserUrl(url);
+  };
+
   return (
-    <Button
-      variant="outline"
-      size="sm"
-      className="w-fit"
-      onClick={() => void openDesktopUrl(denManageConnectionsUrl())}
-    >
-      {t("connect.manage_in_den_web")}
-      <ArrowUpRight size={13} />
-    </Button>
+    <div className="w-full space-y-2">
+      <Button
+        variant="outline"
+        size="sm"
+        className="w-fit"
+        onClick={openManageConnections}
+      >
+        {t("connect.manage_in_den_web")}
+        <ArrowUpRight size={13} />
+      </Button>
+      {handoffUrl ? (
+        <BrowserHandoffFallback
+          url={handoffUrl}
+          title="Manage connections in your browser"
+          description="If the browser did not appear, open or copy the complete management link below."
+        />
+      ) : null}
+    </div>
   );
 }
 
@@ -537,6 +555,7 @@ export function buildConnectRows(input: {
 function ConnectOrganizationRow(props: {
   connectingId: string | null;
   disconnectingId: string | null;
+  pendingAuthorization: ReturnType<typeof useOrgMcpConnections>["pendingAuthorization"];
   onConnect: (connectionId: string) => void;
   onDisconnect: (connectionId: string) => void;
   row: ConnectOrganizationRow;
@@ -554,70 +573,99 @@ function ConnectOrganizationRow(props: {
   const connecting = connectableConnectionId ? props.connectingId === connectableConnectionId : false;
   const disconnectableConnectionId = row.kind === "connection" && canDisconnectNativeProviderAccount(row.connection) ? row.connection.id : null;
   const disconnecting = disconnectableConnectionId ? props.disconnectingId === disconnectableConnectionId : false;
+  const pendingAuthorization = props.pendingAuthorization?.connectionId === connectableConnectionId
+    ? props.pendingAuthorization
+    : null;
+  const [setupUrl, setSetupUrl] = useState<string | null>(null);
 
   return (
-    <div
-      data-testid="connect-organization-row"
-      data-connect-row-kind={row.kind}
-      className="flex items-center gap-3 rounded-xl border border-dls-border bg-dls-surface px-3 py-3"
-    >
-      <ConnectRowIcon
-        name={row.name}
-        serviceUrl={row.kind === "connection" ? row.connection.url : undefined}
-        iconSlug={pluginManifest?.icon?.simpleIconSlug}
-        iconSrc={pluginManifest?.icon?.src}
-      />
-      <div className="min-w-0 flex-1">
-        <div className="flex min-w-0 flex-wrap items-center gap-2">
-          <span className="truncate text-sm font-semibold text-dls-text">{row.name}</span>
-          {row.kind === "plugin" && row.importedLocally ? (
-            <span className="shrink-0 rounded-md border border-amber-6/40 bg-amber-3/40 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
-              {t("connect.marketplace_local_copy_badge")}
-            </span>
-          ) : null}
+    <div className="space-y-2">
+      <div
+        data-testid="connect-organization-row"
+        data-connect-row-kind={row.kind}
+        className="flex items-center gap-3 rounded-xl border border-dls-border bg-dls-surface px-3 py-3"
+      >
+        <ConnectRowIcon
+          name={row.name}
+          serviceUrl={row.kind === "connection" ? row.connection.url : undefined}
+          iconSlug={pluginManifest?.icon?.simpleIconSlug}
+          iconSrc={pluginManifest?.icon?.src}
+        />
+        <div className="min-w-0 flex-1">
+          <div className="flex min-w-0 flex-wrap items-center gap-2">
+            <span className="truncate text-sm font-semibold text-dls-text">{row.name}</span>
+            {row.kind === "plugin" && row.importedLocally ? (
+              <span className="shrink-0 rounded-md border border-amber-6/40 bg-amber-3/40 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+                {t("connect.marketplace_local_copy_badge")}
+              </span>
+            ) : null}
+          </div>
+          <div className="truncate text-xs text-dls-secondary">{row.meta}</div>
         </div>
-        <div className="truncate text-xs text-dls-secondary">{row.meta}</div>
-      </div>
-      {row.group === "needs_signin" && connectableConnectionId ? (
-        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-          <Button
-            size="sm"
-            disabled={connecting}
-            className={needsReconnect ? "border border-amber-6 bg-amber-2 text-amber-11 hover:bg-amber-3" : undefined}
-            onClick={() => props.onConnect(connectableConnectionId)}
-          >
-            {connecting ? t("connect.waiting_for_browser") : needsReconnect ? t("mcp.org_connection_reconnect_action") : t("mcp.org_connection_connect_action")}
-          </Button>
-          {disconnectableConnectionId ? (
+        {row.group === "needs_signin" && connectableConnectionId ? (
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+            <Button
+              size="sm"
+              disabled={connecting}
+              className={needsReconnect ? "border border-amber-6 bg-amber-2 text-amber-11 hover:bg-amber-3" : undefined}
+              onClick={() => props.onConnect(connectableConnectionId)}
+            >
+              {connecting ? t("connect.waiting_for_browser") : needsReconnect ? t("mcp.org_connection_reconnect_action") : t("mcp.org_connection_connect_action")}
+            </Button>
+            {disconnectableConnectionId ? (
+              <Button size="sm" variant="destructive" disabled={disconnecting} onClick={() => props.onDisconnect(disconnectableConnectionId)}>
+                {disconnecting ? t("mcp.org_connection_disconnecting_action") : t("mcp.org_connection_disconnect_action")}
+              </Button>
+            ) : null}
+          </div>
+        ) : row.group === "needs_admin_setup" ? (
+          row.kind === "connection" && !row.canManage ? (
+            <span className="shrink-0 rounded-md bg-amber-3 px-2 py-1 text-xs font-medium text-amber-11">
+              {t("connect.group_needs_admin_setup")}
+            </span>
+          ) : (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => {
+                const url = denManageConnectionsUrl();
+                setSetupUrl(url);
+                void tryOpenBrowserUrl(url);
+              }}
+              title={setupNames.join(t("connect.row_meta_list_separator"))}
+            >
+              {t("connect.row_action_set_up_connection")}
+            </Button>
+          )
+        ) : disconnectableConnectionId ? (
+          <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+            <span className="rounded-md bg-green-3 px-2 py-1 text-xs font-medium text-green-11">
+              {t("connect.row_chip_ready")}
+            </span>
             <Button size="sm" variant="destructive" disabled={disconnecting} onClick={() => props.onDisconnect(disconnectableConnectionId)}>
               {disconnecting ? t("mcp.org_connection_disconnecting_action") : t("mcp.org_connection_disconnect_action")}
             </Button>
-          ) : null}
-        </div>
-      ) : row.group === "needs_admin_setup" ? (
-        row.kind === "connection" && !row.canManage ? (
-          <span className="shrink-0 rounded-md bg-amber-3 px-2 py-1 text-xs font-medium text-amber-11">
-            {t("connect.group_needs_admin_setup")}
-          </span>
+          </div>
         ) : (
-          <Button size="sm" variant="outline" onClick={() => void openDesktopUrl(denManageConnectionsUrl())} title={setupNames.join(t("connect.row_meta_list_separator"))}>
-            {t("connect.row_action_set_up_connection")}
-          </Button>
-        )
-      ) : disconnectableConnectionId ? (
-        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
-          <span className="rounded-md bg-green-3 px-2 py-1 text-xs font-medium text-green-11">
+          <span className="shrink-0 rounded-md bg-green-3 px-2 py-1 text-xs font-medium text-green-11">
             {t("connect.row_chip_ready")}
           </span>
-          <Button size="sm" variant="destructive" disabled={disconnecting} onClick={() => props.onDisconnect(disconnectableConnectionId)}>
-            {disconnecting ? t("mcp.org_connection_disconnecting_action") : t("mcp.org_connection_disconnect_action")}
-          </Button>
-        </div>
-      ) : (
-        <span className="shrink-0 rounded-md bg-green-3 px-2 py-1 text-xs font-medium text-green-11">
-          {t("connect.row_chip_ready")}
-        </span>
-      )}
+        )}
+      </div>
+      {pendingAuthorization ? (
+        <BrowserHandoffFallback
+          url={pendingAuthorization.url}
+          title={`Finish connecting ${row.name}`}
+          description="Keep this page open while OpenWork waits for authorization. If the browser did not appear, use the link below."
+        />
+      ) : null}
+      {setupUrl ? (
+        <BrowserHandoffFallback
+          url={setupUrl}
+          title={`Set up ${row.name} in your browser`}
+          description="If the browser did not appear, open or copy the complete setup link below."
+        />
+      ) : null}
     </div>
   );
 }
@@ -625,6 +673,7 @@ function ConnectOrganizationRow(props: {
 function ConnectOrganizationList(props: {
   connectingId: string | null;
   disconnectingId: string | null;
+  pendingAuthorization: ReturnType<typeof useOrgMcpConnections>["pendingAuthorization"];
   connections: DenExternalMcpConnection[];
   items: ExtensionItem[];
   onConnect: (connectionId: string) => void;
@@ -684,6 +733,7 @@ function ConnectOrganizationList(props: {
                       row={row}
                       connectingId={props.connectingId}
                       disconnectingId={props.disconnectingId}
+                      pendingAuthorization={props.pendingAuthorization}
                       onConnect={props.onConnect}
                       onDisconnect={props.onDisconnect}
                     />
@@ -709,6 +759,7 @@ function ConnectActivePanel(props: {
   error: string | null;
   connectingId: string | null;
   disconnectingId: string | null;
+  pendingAuthorization: ReturnType<typeof useOrgMcpConnections>["pendingAuthorization"];
   onConnect: (connectionId: string) => void;
   onDisconnect: (connectionId: string) => void;
 }) {
@@ -743,6 +794,7 @@ function ConnectActivePanel(props: {
         role={activeOrganization?.role}
         connectingId={props.connectingId}
         disconnectingId={props.disconnectingId}
+        pendingAuthorization={props.pendingAuthorization}
         onConnect={props.onConnect}
         onDisconnect={props.onDisconnect}
       />
@@ -814,6 +866,7 @@ export function ConnectView(props: ConnectViewProps) {
           error={orgMcpConnections.error}
           connectingId={orgMcpConnections.connectingId}
           disconnectingId={orgMcpConnections.disconnectingId}
+          pendingAuthorization={orgMcpConnections.pendingAuthorization}
           onConnect={orgMcpConnections.connect}
           onDisconnect={orgMcpConnections.disconnect}
         />

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -1,6 +1,7 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
+import { openBrowserUrlWithGlobalFallback } from "../../../../app/lib/browser-handoff";
 import {
   appBuildInfo as appBuildInfoCmd,
   engineInfo as engineInfoCmd,
@@ -8,7 +9,6 @@ import {
   getDesktopBootstrapConfig,
   debugDesktopBootstrapConfig,
   nukeOpenworkAndOpencodeConfigAndExit,
-  openDesktopUrl,
   openworkServerInfo as openworkServerInfoCmd,
   openworkServerRestart as openworkServerRestartCmd,
   pickFile,
@@ -511,11 +511,11 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
   }, [developerLog]);
 
   const onOpenElectronPreviewRelease = useCallback(async () => {
-    try {
-      await openDesktopUrl(ELECTRON_ALPHA_RELEASE_PAGE_URL);
+    const result = await openBrowserUrlWithGlobalFallback(ELECTRON_ALPHA_RELEASE_PAGE_URL);
+    if (result.ok) {
       setElectronMigrationStatus("Opened the rolling Electron alpha release. Download links live there after dev builds finish.");
-    } catch (error) {
-      setElectronMigrationStatus(error instanceof Error ? error.message : safeStringify(error));
+    } else {
+      setElectronMigrationStatus(`${result.error} The release URL is available in the fallback panel.`);
     }
   }, []);
 

--- a/apps/app/src/react-app/kernel/platform.tsx
+++ b/apps/app/src/react-app/kernel/platform.tsx
@@ -1,8 +1,14 @@
 /** @jsxImportSource react */
-import { createContext, use, type ReactNode } from "react";
+import { createContext, use, useEffect, useState, type ReactNode } from "react";
 
-import { desktopNotificationShow, openDesktopUrl, relaunchDesktopApp } from "../../app/lib/desktop";
+import {
+  browserHandoffRequiredEvent,
+  openBrowserUrlWithGlobalFallback,
+  type BrowserHandoffRequiredDetail,
+} from "../../app/lib/browser-handoff";
+import { desktopNotificationShow, relaunchDesktopApp } from "../../app/lib/desktop";
 import { isDesktopRuntime } from "../../app/utils";
+import { BrowserHandoffFallback } from "../../components/browser-handoff-fallback";
 
 export type SyncStorage = {
   getItem(key: string): string | null;
@@ -39,9 +45,37 @@ type PlatformProviderProps = {
 };
 
 export function PlatformProvider({ value, children }: PlatformProviderProps) {
+  const [browserHandoff, setBrowserHandoff] = useState<BrowserHandoffRequiredDetail | null>(null);
+
+  useEffect(() => {
+    const handleBrowserHandoff = (event: Event) => {
+      setBrowserHandoff((event as CustomEvent<BrowserHandoffRequiredDetail>).detail);
+    };
+    window.addEventListener(browserHandoffRequiredEvent, handleBrowserHandoff);
+    return () => window.removeEventListener(browserHandoffRequiredEvent, handleBrowserHandoff);
+  }, []);
+
   return (
     <PlatformContext.Provider value={value}>
       {children}
+      {browserHandoff ? (
+        <div className="fixed inset-x-4 bottom-4 z-[250] ml-auto max-w-2xl">
+          <button
+            type="button"
+            aria-label="Dismiss browser link"
+            className="absolute right-2 top-2 z-10 rounded-md px-2 py-1 text-xs text-amber-11 hover:bg-amber-3"
+            onClick={() => setBrowserHandoff(null)}
+          >
+            Dismiss
+          </button>
+          <BrowserHandoffFallback
+            url={browserHandoff.url}
+            title="Open this link manually"
+            description={`${browserHandoff.error} The complete link remains available here to copy or select.`}
+            className="pr-20 shadow-2xl"
+          />
+        </div>
+      ) : null}
     </PlatformContext.Provider>
   );
 }
@@ -62,23 +96,12 @@ export function createDefaultPlatform(): Platform {
   return {
     platform: isDesktopRuntime() ? "desktop" : "web",
     openLink(url: string) {
-      if (isDesktopRuntime()) {
-        void openDesktopUrl(url).catch(() => {
-          if (shouldOpenInCurrentTab(url)) {
-            window.location.href = url;
-            return;
-          }
-          window.open(url, "_blank");
-        });
-        return;
-      }
-
       if (shouldOpenInCurrentTab(url)) {
         window.location.href = url;
         return;
       }
 
-      window.open(url, "_blank");
+      void openBrowserUrlWithGlobalFallback(url);
     },
     restart: async () => {
       if (isDesktopRuntime()) {

--- a/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
+++ b/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useReducer, type ReactNode } from "react";
 
+import { tryOpenBrowserUrl } from "../../app/lib/browser-handoff";
 import { isDesktopRuntime } from "../../app/utils";
+import { BrowserHandoffFallback } from "../../components/browser-handoff-fallback";
 import { useBootState } from "./boot-state";
 
 type ArchitectureInfo = {
@@ -86,12 +88,12 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
   const openDownload = useCallback(() => {
     const url = info?.downloadUrl || info?.releaseUrl;
     if (!url) return;
-    void window.__OPENWORK_ELECTRON__?.shell?.openExternal?.(url);
+    void tryOpenBrowserUrl(url);
   }, [info?.downloadUrl, info?.releaseUrl]);
 
   const openRelease = useCallback(() => {
     if (!info?.releaseUrl) return;
-    void window.__OPENWORK_ELECTRON__?.shell?.openExternal?.(info.releaseUrl);
+    void tryOpenBrowserUrl(info.releaseUrl);
   }, [info?.releaseUrl]);
 
   if (!checked) return null;
@@ -144,6 +146,22 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
                   Open release page
                 </button>
               </div>
+              <BrowserHandoffFallback
+                url={info.downloadUrl || info.releaseUrl}
+                title="Download link"
+                description="If neither download button opens a browser, copy or select this complete link."
+                openLabel="Open download again"
+                className="border-white/15 bg-white/[0.06] [&_div]:text-white/80 [&_span]:text-white/80"
+              />
+              {info.releaseUrl !== (info.downloadUrl || info.releaseUrl) ? (
+                <BrowserHandoffFallback
+                  url={info.releaseUrl}
+                  title="Release page link"
+                  description="Use this complete release-page URL if the browser button is blocked."
+                  openLabel="Open release page again"
+                  className="border-white/15 bg-white/[0.06] [&_div]:text-white/80 [&_span]:text-white/80"
+                />
+              ) : null}
             </div>
 
             <aside className="border-t border-white/10 bg-gradient-to-br from-emerald-300/12 via-sky-300/8 to-transparent p-8 sm:p-10 lg:border-l lg:border-t-0 lg:p-12">

--- a/apps/app/src/react-app/shell/command-palette.tsx
+++ b/apps/app/src/react-app/shell/command-palette.tsx
@@ -8,6 +8,7 @@ import {
 } from "react";
 import type { Agent } from "@opencode-ai/sdk/v2/client";
 
+import { openBrowserUrlWithGlobalFallback } from "@/app/lib/browser-handoff";
 import { t } from "@/i18n";
 import {
   Command,
@@ -148,7 +149,7 @@ export function CommandPalette(props: CommandPaletteProps) {
     if (props.onOpenUrl) {
       props.onOpenUrl(url);
     } else {
-      window.open(url, "_blank", "noopener");
+      void openBrowserUrlWithGlobalFallback(url);
     }
   };
 

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2294,6 +2294,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 orgMcpConnections={orgMcpConnections.connections}
                 orgMcpConnectingId={orgMcpConnections.connectingId}
                 orgMcpDisconnectingId={orgMcpConnections.disconnectingId}
+                orgMcpPendingAuthorization={orgMcpConnections.pendingAuthorization}
                 onConnectOrgMcp={(connectionId) => {
                   void orgMcpConnections.connect(connectionId);
                 }}
@@ -2343,6 +2344,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             orgMcpConnections={orgMcpConnections.connections}
             orgMcpConnectingId={orgMcpConnections.connectingId}
             orgMcpDisconnectingId={orgMcpConnections.disconnectingId}
+            orgMcpPendingAuthorization={orgMcpConnections.pendingAuthorization}
             onConnectOrgMcp={(connectionId) => {
               void orgMcpConnections.connect(connectionId);
             }}

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -30,6 +30,7 @@ import {
 import { useDenAuth } from "../domains/cloud/den-auth-provider";
 import { resolveOpenworkConnection } from "./openwork-connection";
 import { captureAnalyticsEvent } from "../../app/lib/analytics";
+import { tryOpenBrowserUrl } from "../../app/lib/browser-handoff";
 import { buildOpenworkWorkspaceBaseUrl, createOpenworkServerClient } from "../../app/lib/openwork-server";
 import { buildDenAuthUrl, clearDenSession, DEFAULT_DEN_BASE_URL, readDenSettings } from "../../app/lib/den";
 import {
@@ -131,6 +132,7 @@ export function WelcomeRoute() {
   const denAuth = useDenAuth();
   const [state, dispatch] = useReducer(welcomeReducer, initialWelcomeState);
   const [manualFolder, setManualFolder] = useState("");
+  const [teamSignInUrl, setTeamSignInUrl] = useState<string | null>(null);
   const [organizationServerUrl, setOrganizationServerUrl] = useState(() => readDenSettings().baseUrl);
   const [organizationServerBusy, setOrganizationServerBusy] = useState(false);
   const [organizationServerError, setOrganizationServerError] = useState<string | null>(null);
@@ -359,8 +361,10 @@ export function WelcomeRoute() {
 
   const handleTeamSignIn = useCallback(() => {
     const settings = readDenSettings();
-    platform.openLink(buildDenAuthUrl(settings.baseUrl || DEFAULT_DEN_BASE_URL, "sign-in"));
-  }, [platform]);
+    const url = buildDenAuthUrl(settings.baseUrl || DEFAULT_DEN_BASE_URL, "sign-in");
+    setTeamSignInUrl(url);
+    void tryOpenBrowserUrl(url);
+  }, []);
 
   const finishOnboarding = useCallback(() => {
     markOnboardingComplete();
@@ -399,6 +403,7 @@ export function WelcomeRoute() {
         onUseManualFolder={handleUseManualFolder}
         showManualFolder={import.meta.env.DEV && isDesktopRuntime()}
         onTeamSignIn={handleTeamSignIn}
+        teamSignInUrl={teamSignInUrl}
         organizationServerBusy={organizationServerBusy}
         organizationServerError={organizationServerError}
         organizationServerUrl={organizationServerUrl}

--- a/apps/app/tests/browser-handoff.test.tsx
+++ b/apps/app/tests/browser-handoff.test.tsx
@@ -1,0 +1,90 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  copyBrowserHandoffUrl,
+  openBrowserUrlWithGlobalFallback,
+  tryOpenBrowserUrl,
+} from "../src/app/lib/browser-handoff";
+import { BrowserHandoffFallback } from "../src/components/browser-handoff-fallback";
+
+describe("tryOpenBrowserUrl", () => {
+  test("reports a desktop shell failure without throwing", async () => {
+    const result = await tryOpenBrowserUrl("https://example.com/oauth?state=secret", {
+      desktopRuntime: true,
+      openDesktop: async () => {
+        throw new Error("No browser is available");
+      },
+    });
+
+    expect(result).toEqual({ ok: false, error: "No browser is available" });
+  });
+
+  test("treats a blocked web popup as a failed handoff", async () => {
+    const result = await tryOpenBrowserUrl("https://example.com/oauth", {
+      desktopRuntime: false,
+      openWindow: () => null,
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("announces a durable app-level fallback for generic link failures", async () => {
+    let fallbackUrl = "";
+    const result = await openBrowserUrlWithGlobalFallback(
+      "https://example.com/docs",
+      {
+        desktopRuntime: false,
+        openWindow: () => null,
+      },
+      (detail) => {
+        fallbackUrl = detail.url;
+      },
+    );
+
+    expect(result.ok).toBe(false);
+    expect(fallbackUrl).toBe("https://example.com/docs");
+  });
+});
+
+describe("copyBrowserHandoffUrl", () => {
+  test("uses the legacy copy path when Clipboard API access is rejected", async () => {
+    let legacyValue = "";
+    const result = await copyBrowserHandoffUrl("https://example.com/oauth", {
+      writeClipboard: async () => {
+        throw new Error("Clipboard permission denied");
+      },
+      legacyCopy: (value) => {
+        legacyValue = value;
+        return true;
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(legacyValue).toBe("https://example.com/oauth");
+  });
+
+  test("reports failure when both copy mechanisms are blocked", async () => {
+    const result = await copyBrowserHandoffUrl("https://example.com/oauth", {
+      writeClipboard: async () => {
+        throw new Error("Clipboard permission denied");
+      },
+      legacyCopy: () => false,
+    });
+
+    expect(result).toEqual({ ok: false, error: "Automatic copy was blocked." });
+  });
+});
+
+describe("BrowserHandoffFallback", () => {
+  test("always renders the complete URL in a selectable readonly field", () => {
+    const url = "https://example.com/oauth?state=keep-this-visible";
+    const markup = renderToStaticMarkup(<BrowserHandoffFallback url={url} />);
+
+    expect(markup).toContain('data-testid="browser-handoff-url"');
+    expect(markup).toContain('readOnly=""');
+    expect(markup).toContain("keep-this-visible");
+    expect(markup).toContain("Copy link");
+    expect(markup).toContain("Open again");
+  });
+});

--- a/apps/app/tests/mcp-browser-handoff.test.ts
+++ b/apps/app/tests/mcp-browser-handoff.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from "bun:test";
+
+import { mcpBrowserOpenFailedUrl } from "../src/react-app/domains/connections/mcp-browser-handoff";
+
+describe("mcpBrowserOpenFailedUrl", () => {
+  const url = "https://provider.example/authorize?state=visible";
+
+  test("accepts the existing browser-open failure event", () => {
+    expect(mcpBrowserOpenFailedUrl({
+      type: "mcp.browser.open.failed",
+      properties: { mcpName: "notion", url },
+    }, "notion")).toBe(url);
+  });
+
+  test("ignores another MCP or an unrelated event", () => {
+    expect(mcpBrowserOpenFailedUrl({
+      type: "mcp.browser.open.failed",
+      properties: { mcpName: "slack", url },
+    }, "notion")).toBeNull();
+    expect(mcpBrowserOpenFailedUrl({
+      type: "mcp.tools.changed",
+      properties: { mcpName: "notion", url },
+    }, "notion")).toBeNull();
+  });
+});

--- a/ee/apps/den-web/app/(den)/_components/browser-handoff-fallback.tsx
+++ b/ee/apps/den-web/app/(den)/_components/browser-handoff-fallback.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useRef, useState } from "react";
+import { DenButton } from "./ui/button";
+
+type BrowserHandoffFallbackProps = {
+  url: string;
+  title: string;
+  description: string;
+  openLabel?: string;
+  sanitizeUrl?: (url: string) => string;
+  onOpen?: (url: string) => boolean | Promise<boolean>;
+};
+
+export type DenBrowserHandoffResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
+function safeBrowserUrl(value: string) {
+  const url = new URL(value, window.location.origin);
+  if (!["http:", "https:"].includes(url.protocol) || url.username || url.password) {
+    throw new Error("This browser link is not safe to open.");
+  }
+  return url.toString();
+}
+
+export async function tryOpenDenBrowserHandoff(
+  url: string,
+  options: {
+    sanitizeUrl?: (url: string) => string;
+    open?: (url: string) => boolean | Promise<boolean>;
+  } = {},
+): Promise<DenBrowserHandoffResult> {
+  try {
+    const safeUrl = (options.sanitizeUrl ?? safeBrowserUrl)(url);
+    const opened = options.open
+      ? await options.open(safeUrl)
+      : window.open(safeUrl, "_blank", "noopener,noreferrer") !== null;
+    return opened
+      ? { ok: true }
+      : { ok: false, error: "The browser blocked the window. Copy or select the full link below." };
+  } catch (openError) {
+    return {
+      ok: false,
+      error: openError instanceof Error ? openError.message : "The browser could not be opened.",
+    };
+  }
+}
+
+function legacyCopyUrl(url: string) {
+  if (typeof document === "undefined" || typeof document.execCommand !== "function") return false;
+  const field = document.createElement("textarea");
+  field.value = url;
+  field.setAttribute("readonly", "");
+  field.style.position = "fixed";
+  field.style.left = "-9999px";
+  document.body.appendChild(field);
+  field.focus();
+  field.select();
+  try {
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    field.remove();
+  }
+}
+
+export async function copyDenBrowserHandoffUrl(
+  url: string,
+  options: {
+    writeClipboard?: (url: string) => Promise<void>;
+    legacyCopy?: (url: string) => boolean;
+  } = {},
+): Promise<DenBrowserHandoffResult> {
+  const writeClipboard = options.writeClipboard ?? (
+    typeof navigator !== "undefined"
+      ? navigator.clipboard?.writeText?.bind(navigator.clipboard)
+      : undefined
+  );
+  if (writeClipboard) {
+    try {
+      await writeClipboard(url);
+      return { ok: true };
+    } catch {
+      // Fall through to the selection-based copy path.
+    }
+  }
+
+  try {
+    return (options.legacyCopy ?? legacyCopyUrl)(url)
+      ? { ok: true }
+      : { ok: false, error: "Automatic copy was blocked." };
+  } catch {
+    return { ok: false, error: "Automatic copy was blocked." };
+  }
+}
+
+export function DenBrowserHandoffFallback({
+  url,
+  title,
+  description,
+  openLabel = "Open again",
+  sanitizeUrl = safeBrowserUrl,
+  onOpen,
+}: BrowserHandoffFallbackProps) {
+  const fieldRef = useRef<HTMLTextAreaElement | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+
+  function selectUrl() {
+    fieldRef.current?.focus();
+    fieldRef.current?.select();
+  }
+
+  async function openAgain() {
+    const result = await tryOpenDenBrowserHandoff(url, { sanitizeUrl, open: onOpen });
+    setStatus(result.ok ? null : result.error);
+  }
+
+  async function copyUrl() {
+    const result = await copyDenBrowserHandoffUrl(url);
+    if (result.ok) {
+      setStatus("Link copied.");
+      return;
+    }
+
+    selectUrl();
+    setStatus(`${result.error} The full link is selected; use your keyboard or Edit menu to copy it.`);
+  }
+
+  return (
+    <div
+      data-testid="browser-handoff-fallback"
+      className="rounded-2xl border border-amber-200 bg-amber-50 p-4"
+    >
+      <p className="text-[13px] font-semibold text-amber-950">{title}</p>
+      <p className="mt-1 text-[12px] leading-5 text-amber-800">{description}</p>
+      <textarea
+        ref={fieldRef}
+        readOnly
+        aria-label={title}
+        value={url}
+        rows={2}
+        onClick={(event) => event.currentTarget.select()}
+        onFocus={(event) => event.currentTarget.select()}
+        className="mt-3 w-full resize-y rounded-xl border border-amber-200 bg-white px-3 py-2 font-mono text-[11px] leading-5 text-gray-800 outline-none focus:border-amber-400 focus:ring-2 focus:ring-amber-200"
+      />
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <DenButton variant="secondary" size="sm" onClick={() => void openAgain()}>
+          {openLabel}
+        </DenButton>
+        <DenButton variant="secondary" size="sm" onClick={() => void copyUrl()}>
+          Copy link
+        </DenButton>
+        {status ? <span role="status" className="text-[12px] text-amber-800">{status}</span> : null}
+      </div>
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
@@ -2,6 +2,7 @@
 
 import { ShieldCheck, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { DenBrowserHandoffFallback } from "./browser-handoff-fallback";
 import { DenButton, buttonVariants } from "./ui/button";
 import { DenInput } from "./ui/input";
 import { DenNotice } from "./ui/notice";
@@ -69,6 +70,7 @@ export function ReauthDialog({
   const [busy, setBusy] = useState(false);
   const [loadingMethods, setLoadingMethods] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [pendingBrowserUrl, setPendingBrowserUrl] = useState<string | null>(null);
   const [providers, setProviders] = useState<string[]>([]);
   const [ssoUrl, setSsoUrl] = useState<string | null>(null);
   const [nonce, setNonce] = useState("");
@@ -123,6 +125,7 @@ export function ReauthDialog({
       stopPopupWatcher();
       setPassword("");
       setError(null);
+      setPendingBrowserUrl(null);
       setBusy(false);
       setLoadingMethods(false);
       return;
@@ -192,6 +195,7 @@ export function ReauthDialog({
       // the server-side freshness check, so a forged message cannot bypass reauth.
       setBusy(true);
       setError(null);
+      setPendingBrowserUrl(null);
       void (async () => {
         try {
           await onVerifiedRef.current();
@@ -240,13 +244,10 @@ export function ReauthDialog({
 
   async function continueSocial(provider: SocialAuthProvider) {
     const popup = window.open("", "openwork-reauth", "popup,width=480,height=640");
-    if (!popup) {
-      setError("OpenWork could not open the sign-in window. Allow popups for OpenWork, then try again.");
-      return;
-    }
 
     setBusy(true);
     setError(null);
+    setPendingBrowserUrl(null);
     try {
       const callbackURL = getReauthCompleteUrl(nonce);
       const errorCallbackURL = getReauthCompleteUrl(nonce, true);
@@ -269,8 +270,15 @@ export function ReauthDialog({
         return;
       }
 
-      popup.location.href = redirectUrl;
-      startPopupWatcher(popup);
+      const browserUrl = new URL(redirectUrl, window.location.origin).toString();
+      setPendingBrowserUrl(browserUrl);
+      if (popup) {
+        popup.location.href = browserUrl;
+        startPopupWatcher(popup);
+      } else {
+        setError("The sign-in window was blocked. Use the full link below.");
+        setBusy(false);
+      }
     } catch (nextError) {
       popup?.close();
       setError(nextError instanceof Error ? nextError.message : `${getSocialLabel(provider)} sign-in failed.`);
@@ -284,24 +292,54 @@ export function ReauthDialog({
       return;
     }
 
-    const popup = window.open("", "openwork-reauth", "popup,width=480,height=640");
-    if (!popup) {
-      setError("OpenWork could not open the sign-in window. Allow popups for OpenWork, then try again.");
-      return;
-    }
-
-    setBusy(true);
-    setError(null);
+    let popup: Window | null = null;
     try {
       const nextUrl = new URL(ssoUrl, window.location.origin);
       nextUrl.searchParams.set("callbackURL", getReauthCompleteUrl(nonce));
       nextUrl.searchParams.set("loginHint", user.email);
 
-      popup.location.href = nextUrl.toString();
+      const browserUrl = nextUrl.toString();
+      setPendingBrowserUrl(browserUrl);
+      popup = window.open("", "openwork-reauth", "popup,width=480,height=640");
+      if (!popup) {
+        setError("The sign-in window was blocked. Use the full link below.");
+        setBusy(false);
+        return;
+      }
+
+      setBusy(true);
+      setError(null);
+      popup.location.href = browserUrl;
       startPopupWatcher(popup);
     } catch (nextError) {
       popup?.close();
       setError(nextError instanceof Error ? nextError.message : "Organization SSO sign-in failed.");
+      setBusy(false);
+    }
+  }
+
+  function openPendingBrowser(url: string) {
+    const popup = window.open("", "openwork-reauth", "popup,width=480,height=640");
+    if (!popup) return false;
+    try {
+      popup.location.href = url;
+      setBusy(true);
+      setError(null);
+      startPopupWatcher(popup);
+      return true;
+    } catch {
+      popup.close();
+      return false;
+    }
+  }
+
+  async function verifyPendingBrowserSignIn() {
+    setBusy(true);
+    setError(null);
+    try {
+      await onVerifiedRef.current();
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Re-authentication failed.");
       setBusy(false);
     }
   }
@@ -359,6 +397,27 @@ export function ReauthDialog({
 
           {error ? (
             <DenNotice message={error} tone="error" className="mb-5" />
+          ) : null}
+
+          {pendingBrowserUrl ? (
+            <div className="mb-5 space-y-3">
+              <DenBrowserHandoffFallback
+                url={pendingBrowserUrl}
+                title="Continue the security check in your browser"
+                description="If the sign-in window did not appear, open or copy this complete link. It remains available until verification succeeds or you cancel."
+                openLabel="Open sign-in again"
+                onOpen={openPendingBrowser}
+              />
+              <DenButton
+                className="w-full"
+                variant="secondary"
+                loading={busy}
+                disabled={busy}
+                onClick={() => void verifyPendingBrowserSignIn()}
+              >
+                I completed sign-in
+              </DenButton>
+            </div>
           ) : null}
 
           <div className="grid gap-4">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-fallback.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-fallback.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { DenBrowserHandoffFallback } from "../../_components/browser-handoff-fallback";
+import { safeMcpAuthorizationUrl } from "./mcp-authorization-url";
+
+export function McpAuthorizationFallback({
+  url,
+  connectionName,
+}: {
+  url: string;
+  connectionName: string;
+}) {
+  return (
+    <div data-testid="mcp-authorization-fallback" className="mx-6 mb-4">
+      <DenBrowserHandoffFallback
+        url={url}
+        title={`Finish connecting ${connectionName}`}
+        description="Keep this page open while OpenWork waits. If the sign-in window did not appear, use the full link below."
+        sanitizeUrl={safeMcpAuthorizationUrl}
+      />
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-authorization-url.ts
@@ -224,12 +224,12 @@ export function showMcpAuthorizationError(
   }
 }
 
-export function openMcpAuthorizationWindow(): Window {
+export function openMcpAuthorizationWindow(
+  openWindow: (url?: string | URL, target?: string, features?: string) => Window | null = (...args) => window.open(...args),
+): Window | null {
   const popupName = `openwork-mcp-authorization-${crypto.randomUUID()}`
-  const popup = window.open("", popupName, "popup,width=600,height=760")
-  if (!popup) {
-    throw new Error("OpenWork could not open the sign-in window. Allow popups for OpenWork, then try again.")
-  }
+  const popup = openWindow("", popupName, "popup,width=600,height=760")
+  if (!popup) return null
   try {
     popup.opener = null
     popup.document.open()

--- a/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/mcp-connections-screen.tsx
@@ -13,6 +13,7 @@ import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-templ
 import { getPluginRoute } from "../../_lib/den-org";
 import { getRequestError, requestJson } from "../../_lib/den-flow";
 import { IntegrationIcon } from "./integration-icon";
+import { McpAuthorizationFallback } from "./mcp-authorization-fallback";
 import { Microsoft365Dialog } from "./microsoft-365-dialog";
 import { openMcpAuthorizationWindow, safeMcpAuthorizationUrl, showMcpAuthorizationError } from "./mcp-authorization-url";
 import {
@@ -275,6 +276,7 @@ export function McpConnectionsScreen() {
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
   const [oauthClientConfigurationRequiredIds, setOAuthClientConfigurationRequiredIds] = useState<string[]>([]);
   const [connectionActionError, setConnectionActionError] = useState<{ connectionId: string; message: string } | null>(null);
+  const [pendingAuthorization, setPendingAuthorization] = useState<{ connectionId: string; url: string } | null>(null);
   const [connectionActionNotice, setConnectionActionNotice] = useState<string | null>(null);
   const [toolsConnectionId, setToolsConnectionId] = useState<string | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
@@ -327,30 +329,49 @@ export function McpConnectionsScreen() {
   }
 
   function pollUntilConnected(connectionId: string) {
+    stopPolling();
     setPollingConnectionId(connectionId);
     const startedAt = Date.now();
     pollTimer.current = setInterval(async () => {
       const result = await refetch();
       const connection = result.data?.find((entry) => entry.id === connectionId);
-      if (connection?.connected || Date.now() - startedAt > OAUTH_POLL_TIMEOUT_MS) {
+      if (connection?.connected) {
         stopPolling();
+        setPendingAuthorization(null);
+        return;
+      }
+      if (Date.now() - startedAt > OAUTH_POLL_TIMEOUT_MS) {
+        stopPolling();
+        setConnectionActionError({
+          connectionId,
+          message: "Authorization is still incomplete. Use the link below or reconnect to start a new attempt.",
+        });
       }
     }, OAUTH_POLL_INTERVAL_MS);
   }
 
-  async function handleConnectOAuth(connectionId: string, pendingAuthorizationWindow?: Window) {
+  async function handleConnectOAuth(connectionId: string, pendingAuthorizationWindow?: Window | null) {
+    stopPolling();
     setConnectionActionError(null);
+    setPendingAuthorization(null);
     let authorizationWindow: Window | null = pendingAuthorizationWindow ?? null;
     try {
       authorizationWindow = authorizationWindow ?? openMcpAuthorizationWindow();
       const result = await startOAuth.mutateAsync(connectionId);
       if (result.status === "connected") {
-        authorizationWindow.close();
+        authorizationWindow?.close();
         void refetch();
         return;
       }
       if (!result.authorizeUrl) throw new Error("The MCP provider did not return an authorization URL.");
-      authorizationWindow.location.href = safeMcpAuthorizationUrl(result.authorizeUrl);
+      const authorizationUrl = safeMcpAuthorizationUrl(result.authorizeUrl);
+      setPendingAuthorization({ connectionId, url: authorizationUrl });
+      try {
+        if (authorizationWindow) authorizationWindow.location.href = authorizationUrl;
+      } catch {
+        // The durable URL below the row remains available when popup
+        // navigation is blocked or the popup was closed.
+      }
       pollUntilConnected(connectionId);
     } catch (connectError) {
       const message = connectError instanceof Error ? connectError.message : "Failed to connect the MCP server.";
@@ -555,6 +576,9 @@ export function McpConnectionsScreen() {
               setupHref={needsPluginSetup && setupPluginId ? getPluginRoute(orgSlug, setupPluginId) : null}
               polling={pollingConnectionId === connection.id}
               connecting={startOAuth.isPending && startOAuth.variables === connection.id}
+              authorizationUrl={pendingAuthorization?.connectionId === connection.id
+                ? pendingAuthorization.url
+                : null}
               errorMessage={connectionActionError?.connectionId === connection.id ? connectionActionError.message : null}
               onEdit={() => {
                 updateConnection.reset();
@@ -1329,6 +1353,7 @@ function ConnectionRow({
   setupHref,
   polling,
   connecting,
+  authorizationUrl,
   errorMessage,
   onEdit,
   onConfigure,
@@ -1347,6 +1372,7 @@ function ConnectionRow({
   setupHref: string | null;
   polling: boolean;
   connecting: boolean;
+  authorizationUrl: string | null;
   errorMessage: string | null;
   onEdit: () => void;
   onConfigure: () => void;
@@ -1556,6 +1582,9 @@ function ConnectionRow({
           </div>
         </div>
       </div>
+      {authorizationUrl ? (
+        <McpAuthorizationFallback url={authorizationUrl} connectionName={connection.name} />
+      ) : null}
       {toolsOpen && canInspectTools ? <McpToolCatalog connection={connection} /> : null}
     </div>
   );

--- a/ee/apps/den-web/app/(den)/dashboard/_components/use-mcp-account-authorization.ts
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/use-mcp-account-authorization.ts
@@ -16,6 +16,7 @@ export function useMcpAccountAuthorization(onConnected?: () => void) {
   const startOAuth = useStartMcpConnectionOAuth();
   const [pollingConnectionId, setPollingConnectionId] = useState<string | null>(null);
   const [error, setError] = useState<{ connectionId: string; message: string } | null>(null);
+  const [pendingAuthorization, setPendingAuthorization] = useState<{ connectionId: string; url: string } | null>(null);
   const pollTimer = useRef<ReturnType<typeof setInterval> | null>(null);
   const onConnectedRef = useRef(onConnected);
 
@@ -39,6 +40,7 @@ export function useMcpAccountAuthorization(onConnected?: () => void) {
 
   function finishConnected() {
     stopPolling();
+    setPendingAuthorization(null);
     onConnectedRef.current?.();
   }
 
@@ -55,18 +57,24 @@ export function useMcpAccountAuthorization(onConnected?: () => void) {
       }
       if (Date.now() - startedAt > OAUTH_POLL_TIMEOUT_MS) {
         stopPolling();
+        setError({
+          connectionId,
+          message: "Authorization is still incomplete. Use the link below or reconnect to start a new attempt.",
+        });
       }
     }, OAUTH_POLL_INTERVAL_MS);
   }
 
   async function connect(connectionId: string) {
+    stopPolling();
     setError(null);
+    setPendingAuthorization(null);
     let authorizationWindow: Window | null = null;
     try {
       authorizationWindow = openMcpAuthorizationWindow();
       const result = await startOAuth.mutateAsync(connectionId);
       if (result.status === "connected") {
-        authorizationWindow.close();
+        authorizationWindow?.close();
         void refetch();
         finishConnected();
         return;
@@ -74,7 +82,14 @@ export function useMcpAccountAuthorization(onConnected?: () => void) {
       if (!result.authorizeUrl) {
         throw new Error("The MCP provider did not return an authorization URL.");
       }
-      authorizationWindow.location.href = safeMcpAuthorizationUrl(result.authorizeUrl);
+      const authorizationUrl = safeMcpAuthorizationUrl(result.authorizeUrl);
+      setPendingAuthorization({ connectionId, url: authorizationUrl });
+      try {
+        if (authorizationWindow) authorizationWindow.location.href = authorizationUrl;
+      } catch {
+        // The durable URL below the row remains available when popup
+        // navigation is blocked or the popup was closed.
+      }
       pollUntilConnected(connectionId);
     } catch (connectError) {
       const message = connectError instanceof Error ? connectError.message : "Failed to connect account.";
@@ -95,6 +110,7 @@ export function useMcpAccountAuthorization(onConnected?: () => void) {
     connect,
     connectingConnectionId: startOAuth.isPending ? startOAuth.variables ?? null : null,
     error,
+    pendingAuthorization,
     pollingConnectionId,
   };
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/your-connections-screen.tsx
@@ -26,6 +26,7 @@ import {
   useMcpConnectionPresets,
 } from "./mcp-connections-data";
 import { McpToolRunner } from "./mcp-tool-runner";
+import { McpAuthorizationFallback } from "./mcp-authorization-fallback";
 import { usePlugin } from "./plugin-data";
 import { useMcpAccountAuthorization } from "./use-mcp-account-authorization";
 
@@ -118,6 +119,9 @@ export function YourConnectionsScreen() {
               polling={authorization.pollingConnectionId === connection.id}
               connecting={authorization.connectingConnectionId === connection.id}
               disconnecting={disconnectProvider.isPending && disconnectProvider.variables === connection.id}
+              authorizationUrl={authorization.pendingAuthorization?.connectionId === connection.id
+                ? authorization.pendingAuthorization.url
+                : null}
               errorMessage={
                 rowError?.connectionId === connection.id
                   ? rowError.message
@@ -153,6 +157,7 @@ function YourConnectionRow({
   polling,
   connecting,
   disconnecting,
+  authorizationUrl,
   errorMessage,
   highlighted,
   rowRef,
@@ -170,6 +175,7 @@ function YourConnectionRow({
   polling: boolean;
   connecting: boolean;
   disconnecting: boolean;
+  authorizationUrl: string | null;
   errorMessage: string | null;
   onConnect: () => void;
   onDisconnect: () => void;
@@ -306,6 +312,9 @@ function YourConnectionRow({
           ) : null}
         </div>
       </div>
+      {authorizationUrl ? (
+        <McpAuthorizationFallback url={authorizationUrl} connectionName={connection.name} />
+      ) : null}
       {toolRunnerOpen && canTestTools ? <McpToolRunner connection={connection} /> : null}
     </div>
   );

--- a/ee/apps/den-web/tests/mcp-authorization-fallback.test.tsx
+++ b/ee/apps/den-web/tests/mcp-authorization-fallback.test.tsx
@@ -1,0 +1,61 @@
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import {
+  copyDenBrowserHandoffUrl,
+  tryOpenDenBrowserHandoff,
+} from "../app/(den)/_components/browser-handoff-fallback";
+import { McpAuthorizationFallback } from "../app/(den)/dashboard/_components/mcp-authorization-fallback";
+
+describe("Den browser handoff", () => {
+  test("reports a blocked popup without throwing", async () => {
+    const result = await tryOpenDenBrowserHandoff("https://provider.example/authorize", {
+      sanitizeUrl: (url) => url,
+      open: () => false,
+    });
+
+    expect(result.ok).toBe(false);
+  });
+
+  test("uses selection-based copy when Clipboard API access is rejected", async () => {
+    let legacyValue = "";
+    const result = await copyDenBrowserHandoffUrl("https://provider.example/authorize", {
+      writeClipboard: async () => {
+        throw new Error("Clipboard permission denied");
+      },
+      legacyCopy: (url) => {
+        legacyValue = url;
+        return true;
+      },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(legacyValue).toBe("https://provider.example/authorize");
+  });
+
+  test("reports failure when browser-managed and selection-based copy are both blocked", async () => {
+    const result = await copyDenBrowserHandoffUrl("https://provider.example/authorize", {
+      writeClipboard: async () => {
+        throw new Error("Clipboard permission denied");
+      },
+      legacyCopy: () => false,
+    });
+
+    expect(result).toEqual({ ok: false, error: "Automatic copy was blocked." });
+  });
+});
+
+describe("McpAuthorizationFallback", () => {
+  test("keeps the complete authorization URL visible and selectable", () => {
+    const url = "https://provider.example/authorize?state=keep-this-visible";
+    const markup = renderToStaticMarkup(
+      <McpAuthorizationFallback url={url} connectionName="Example" />,
+    );
+
+    expect(markup).toContain('data-testid="mcp-authorization-fallback"');
+    expect(markup).toContain('readOnly=""');
+    expect(markup).toContain("keep-this-visible");
+    expect(markup).toContain("Open again");
+    expect(markup).toContain("Copy link");
+  });
+});

--- a/ee/apps/den-web/tests/mcp-authorization-url.test.ts
+++ b/ee/apps/den-web/tests/mcp-authorization-url.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, test } from "bun:test"
 import {
   mcpAuthorizationErrorDocument,
   mcpAuthorizationPendingDocument,
+  openMcpAuthorizationWindow,
   safeMcpAuthorizationUrl,
 } from "../app/(den)/dashboard/_components/mcp-authorization-url"
 
@@ -24,6 +25,12 @@ describe("safeMcpAuthorizationUrl", () => {
     "rejects unsafe provider authorization URL %s",
     (url) => expect(() => safeMcpAuthorizationUrl(url)).toThrow(),
   )
+})
+
+describe("openMcpAuthorizationWindow", () => {
+  test("returns null instead of aborting OAuth when the popup is blocked", () => {
+    expect(openMcpAuthorizationWindow(() => null)).toBeNull()
+  })
 })
 
 describe("mcpAuthorizationPendingDocument", () => {


### PR DESCRIPTION
## Summary

- add a shared OpenWork browser-handoff component with retry, Clipboard API copy, legacy copy, and always-selectable full URL paths
- keep authorization URLs visible throughout sign-in, provider OAuth, MCP Connect/reconnect, Google Workspace, and privileged Den Web re-authentication
- add an app-level fallback panel for ordinary external links that fail to open
- keep pending authorization links available after polling timeouts instead of removing the user's recovery path

## Why

Browser and popup launches can fail because of missing URL handlers, popup policy, managed-device restrictions, or desktop shell errors. Previously, several flows either swallowed that failure or left the user without the URL needed to continue.

OpenWork now stores the URL before attempting the browser handoff wherever OpenWork owns the flow. A failed browser or clipboard operation no longer blocks the underlying authorization polling, and the URL remains available for manual selection and copy.

## Validation

- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app test` — 366 passed
- `pnpm --filter @openwork/desktop typecheck:electron`
- `pnpm --filter @openwork/desktop check:electron` — 55 renderer bridge methods covered
- `pnpm --filter @openwork/desktop test` — 79 passed, 1 skipped
- `pnpm --dir ee/packages/utils build`
- `pnpm --filter @openwork-ee/den-web typecheck`
- `pnpm --filter @openwork-ee/den-web test` — 61 passed
- `pnpm --filter @openwork-ee/den-web exec bun test tests/mcp-authorization-url.test.ts tests/mcp-authorization-fallback.test.tsx` — 15 passed
- `git diff --check`

## Risk and limitations

- OAuth URLs may contain short-lived state parameters. They are displayed only in the local user interface and are not logged or persisted by this change.
- Direct local MCP authentication can show the fallback when the existing runtime explicitly reports a browser-launch failure. If the operating system reports success but no usable browser appears, OpenWork does not receive that authorization URL and cannot display it.
- No Den API, database, migration, or credential-storage behavior changes.

## Manual verification

Not run — no real external provider credentials or packaged desktop browser-policy environment were used. The automated tests simulate blocked popups, desktop launch failures, Clipboard API denial, legacy-copy failure, URL retention, and MCP reconnect polling.
