### PR TITLE
fix(den): relay provider-declared MCP errors as agent-readable evidence instead of transport noise

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
@@ -55,6 +55,8 @@ export type ExternalMcpDiagnostic = {
   payloadBytes?: number
   jsonRpcCode?: number
   connectUrl?: string
+  providerErrorMessage?: string
+  providerErrorData?: string
 }
 
 export type ExternalMcpSafeOutbound = {
@@ -77,6 +79,7 @@ type FetchLike = (url: string | URL, init?: RequestInit) => Promise<Response>
 // without bound.
 export const EXTERNAL_MCP_JSON_RESPONSE_LIMIT_BYTES = 4 * 1024 * 1024
 export const EXTERNAL_MCP_SSE_RESPONSE_LIMIT_BYTES = 16 * 1024 * 1024
+const EXTERNAL_MCP_PROVIDER_DECLARED_ERROR_SNIFF_LIMIT_BYTES = 64 * 1024
 
 export class ExternalMcpLifecycleDeadlineError extends Error {
   constructor() {
@@ -235,6 +238,15 @@ type ProviderAuthorizationRequired = {
   provider?: string
 }
 
+type ProviderDeclaredErrorEvidence = {
+  phase: ExternalMcpDiagnosticPhase
+  jsonRpcCode: number
+  connectUrl?: string
+  provider?: string
+  message?: string
+  dataExcerpt?: string
+}
+
 function validatedProviderConnectUrl(value: string | undefined): string | undefined {
   if (!value) return undefined
   try {
@@ -268,6 +280,143 @@ function providerAuthorizationRequired(value: unknown): ProviderAuthorizationReq
     current = errorCause(current)
   }
   return null
+}
+
+function localRequestTimeout(value: unknown): boolean {
+  let current: unknown = value
+  for (let depth = 0; depth < 5 && current; depth += 1) {
+    const data = isRecord(current) ? current.data : undefined
+    if (isRecord(data) && typeof data.timeout === "number") return true
+    current = errorCause(current)
+  }
+  return false
+}
+
+function validProviderDeclaredJsonRpcId(envelope: Record<string, unknown>): boolean {
+  if (!("id" in envelope)) return true
+  const id = envelope.id
+  return id === null || typeof id === "string" || typeof id === "number"
+}
+
+function providerDeclaredDataExcerpt(data: Record<string, unknown> | null, connectUrl: string | undefined): string | undefined {
+  if (!data) return undefined
+  const entries = Object.entries(data)
+  if (connectUrl && entries.length === 1) {
+    const onlyEntry = entries[0]
+    if (onlyEntry) {
+      const [key, value] = onlyEntry
+      if ((key === "connect_url" || key === "url") && validatedProviderConnectUrl(typeof value === "string" ? value : undefined) === connectUrl) {
+        return undefined
+      }
+    }
+  }
+  try {
+    const serialized = JSON.stringify(data)
+    return typeof serialized === "string" ? sanitizedProviderTextExcerpt(serialized) : undefined
+  } catch {
+    return undefined
+  }
+}
+
+function providerDeclaredErrorFromEnvelope(
+  value: unknown,
+  phase: ExternalMcpDiagnosticPhase,
+): ProviderDeclaredErrorEvidence | null {
+  if (!isRecord(value) || !validProviderDeclaredJsonRpcId(value)) return null
+  const error = value.error
+  if (!isRecord(error) || typeof error.code !== "number" || !Number.isSafeInteger(error.code)) return null
+  const jsonRpcCode = error.code
+  const data = isRecord(error.data) ? error.data : null
+  const provider = data ? stringProperty(data, "provider") : undefined
+  const message = sanitizedProviderTextExcerpt(stringProperty(error, "message") ?? "")
+
+  const connectUrl = data ? validatedProviderConnectUrl(stringProperty(data, "connect_url")) : undefined
+  const elicitedUrl = jsonRpcCode === URL_ELICITATION_REQUIRED_JSON_RPC_CODE && data
+    ? validatedProviderConnectUrl(stringProperty(data, "url"))
+    : undefined
+  const dataExcerpt = providerDeclaredDataExcerpt(data, connectUrl ?? elicitedUrl)
+  const evidence = {
+    phase,
+    jsonRpcCode,
+    ...(provider ? { provider } : {}),
+    ...(message ? { message } : {}),
+    ...(dataExcerpt ? { dataExcerpt } : {}),
+  }
+  if (connectUrl) return { ...evidence, connectUrl }
+  if (elicitedUrl) return { ...evidence, connectUrl: elicitedUrl }
+
+  if (value.jsonrpc === "2.0" && jsonRpcCode < 0) {
+    return evidence
+  }
+  return null
+}
+
+function providerDeclaredErrorFromError(
+  value: unknown,
+  phase: ExternalMcpDiagnosticPhase,
+): ProviderDeclaredErrorEvidence | null {
+  let current: unknown = value
+  for (let depth = 0; depth < 5 && current; depth += 1) {
+    const code = isRecord(current) ? current.code : undefined
+    if (typeof code === "number" && Number.isSafeInteger(code) && code < 0) {
+      const data = isRecord(current) && isRecord(current.data) ? current.data : null
+      const connectUrl = data ? validatedProviderConnectUrl(stringProperty(data, "connect_url")) : undefined
+      const elicitedUrl = code === URL_ELICITATION_REQUIRED_JSON_RPC_CODE && data
+        ? validatedProviderConnectUrl(stringProperty(data, "url"))
+        : undefined
+      const dataExcerpt = providerDeclaredDataExcerpt(data, connectUrl ?? elicitedUrl)
+      const message = current instanceof Error
+        ? sanitizedProviderTextExcerpt(current.message)
+        : sanitizedProviderTextExcerpt(stringProperty(current, "message") ?? "")
+      const providerConnectUrl = connectUrl ?? elicitedUrl
+      return {
+        phase,
+        jsonRpcCode: code,
+        ...(providerConnectUrl ? { connectUrl: providerConnectUrl } : {}),
+        ...(message ? { message } : {}),
+        ...(dataExcerpt ? { dataExcerpt } : {}),
+      }
+    }
+    current = errorCause(current)
+  }
+  return null
+}
+
+function providerDeclaredErrorFromJson(
+  value: unknown,
+  phase: ExternalMcpDiagnosticPhase,
+): ProviderDeclaredErrorEvidence | null {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      const evidence = providerDeclaredErrorFromEnvelope(item, phase)
+      if (evidence) return evidence
+    }
+    return null
+  }
+  return providerDeclaredErrorFromEnvelope(value, phase)
+}
+
+function providerAuthorizationClassification(connectUrl: string): Classification {
+  return {
+    phase: "PROVIDER_AUTHORIZATION",
+    category: "provider_authorization_required",
+    code: "MCP_PROVIDER_AUTH_REQUIRED",
+    retryable: false,
+    actionOwner: "member",
+    operatorAction: "Connect your account for this provider using its sign-in link, then retry this capability.",
+    connectUrl,
+  }
+}
+
+function providerDeclaredErrorClassification(): Classification {
+  return {
+    phase: "PROVIDER_EXECUTION",
+    category: "provider_declared_error",
+    code: "MCP_PROVIDER_DECLARED_ERROR",
+    retryable: false,
+    actionOwner: "provider_admin",
+    operatorAction: "Look up the provider-declared JSON-RPC error code with the provider, then correct the downstream condition and retry.",
+  }
 }
 
 function safeNativeToken(value: string | undefined, pattern: RegExp, maxLength = 64): string | undefined {
@@ -348,14 +497,17 @@ function serializedContentPayloadBytes(content: unknown[] | null): number {
   }
 }
 
-function sanitizedProviderToolExcerpt(texts: string[]): string | undefined {
-  const sanitized = texts
-    .join("\n")
+function sanitizedProviderTextExcerpt(text: string): string | undefined {
+  const sanitized = text
     .replace(/[\u0000-\u001F\u007F-\u009F]/g, " ")
     .replace(/\s+/g, " ")
     .trim()
   if (!sanitized) return undefined
   return sanitized.length > 512 ? sanitized.slice(0, 512) : sanitized
+}
+
+function sanitizedProviderToolExcerpt(texts: string[]): string | undefined {
+  return sanitizedProviderTextExcerpt(texts.join("\n"))
 }
 
 type ProviderToolContentEvidence = {
@@ -473,8 +625,11 @@ function safeMessageFor(input: {
   phase: ExternalMcpDiagnosticPhase
   category: string
   code: string
+  highestPassed?: ExternalMcpHealthLevel
   providerStatus?: number
   providerCode?: string
+  jsonRpcCode?: number
+  providerErrorMessage?: string
 }): string {
   const message = safeBaseMessageFor(input)
   const details = [
@@ -488,6 +643,9 @@ function safeBaseMessageFor(input: {
   phase: ExternalMcpDiagnosticPhase
   category: string
   code: string
+  highestPassed?: ExternalMcpHealthLevel
+  jsonRpcCode?: number
+  providerErrorMessage?: string
 }): string {
   if (input.code === "MCP_LIFECYCLE_DEADLINE") {
     return "The MCP lifecycle exceeded OpenWork's bounded diagnostic deadline."
@@ -496,10 +654,24 @@ function safeBaseMessageFor(input: {
     return "The MCP server did not answer the current protocol request within its bounded timeout."
   }
   if (input.code === "MCP_PROVIDER_AUTH_REQUIRED") {
-    return "The provider answered but requires this user to authorize the downstream account before the tool can run."
+    const message = "The provider answered but requires this user to authorize the downstream account before the tool can run."
+    return input.providerErrorMessage
+      ? `${message} Provider-declared message (untrusted): "${input.providerErrorMessage}".`
+      : message
+  }
+  if (input.code === "MCP_PROVIDER_DECLARED_ERROR") {
+    const message = input.jsonRpcCode === undefined
+      ? "The provider answered with a JSON-RPC error OpenWork does not recognize."
+      : `The provider answered with a JSON-RPC error OpenWork does not recognize (code ${input.jsonRpcCode}).`
+    return input.providerErrorMessage
+      ? `${message} Provider-declared message (untrusted): "${input.providerErrorMessage}".`
+      : message
   }
   if (input.code === "MCP_RESPONSE_BODY_LIMIT") {
     return "The MCP server returned a response body larger than OpenWork can safely process."
+  }
+  if (input.highestPassed && HEALTH_RANK[input.highestPassed] >= HEALTH_RANK.protocol_ready && isUninformativeClassification(input)) {
+    return "The MCP server answered, but OpenWork could not interpret its response for the current request."
   }
   if (input.category === "security_blocked") {
     return "Den blocked the MCP URL because it violates the outbound network safety policy."
@@ -563,6 +735,14 @@ function safeBaseMessageFor(input: {
 }
 
 type Classification = Omit<ExternalMcpDiagnostic, "referenceId" | "highestPassed" | "message">
+
+function isUninformativeClassification(input: Pick<Classification, "phase" | "category" | "code">): boolean {
+  return input.code === `MCP_${input.phase}` && (
+    input.category === "oauth_failure"
+    || input.category === "mcp_protocol_failure"
+    || input.category === "connection_failure"
+  )
+}
 
 function logProviderToolEvidence(input: {
   referenceId: string
@@ -911,18 +1091,12 @@ function classifyError(error: unknown, fallbackPhase: ExternalMcpDiagnosticPhase
 
   const providerAuthorization = providerAuthorizationRequired(error)
   if (providerAuthorization) {
-    return {
-      phase: "PROVIDER_AUTHORIZATION",
-      category: "provider_authorization_required",
-      code: "MCP_PROVIDER_AUTH_REQUIRED",
-      retryable: false,
-      actionOwner: "member",
-      operatorAction: "Connect your account for this provider using its sign-in link, then retry this capability.",
-      connectUrl: providerAuthorization.connectUrl,
-    }
+    return providerAuthorizationClassification(providerAuthorization.connectUrl)
   }
 
-  if (numericErrorCode(error) === -32001) {
+  const numericCode = numericErrorCode(error)
+  if (numericCode === -32001) {
+    if (!localRequestTimeout(error)) return providerDeclaredErrorClassification()
     return {
       phase: fallbackPhase,
       category: "request_timeout",
@@ -932,7 +1106,7 @@ function classifyError(error: unknown, fallbackPhase: ExternalMcpDiagnosticPhase
       operatorAction: "Check provider latency and retry after the current MCP request can complete within its bounded timeout.",
     }
   }
-  if (numericErrorCode(error) === -32602 && fallbackPhase === "MCP_TOOL_EXECUTION") {
+  if (numericCode === -32602 && fallbackPhase === "MCP_TOOL_EXECUTION") {
     return {
       phase: "MCP_TOOL_EXECUTION",
       category: "mcp_tool_input_invalid",
@@ -942,6 +1116,7 @@ function classifyError(error: unknown, fallbackPhase: ExternalMcpDiagnosticPhase
       operatorAction: "Correct the tool arguments using the latest advertised input schema; do not retry the same arguments unchanged.",
     }
   }
+  if (numericCode !== undefined) return providerDeclaredErrorClassification()
 
   const name = errorName(error)
   if (name === "InvalidClientError" || name === "UnauthorizedClientError" || name === "InvalidClientMetadataError") {
@@ -1123,6 +1298,8 @@ export class ExternalMcpDiagnosticTracker {
   private forcedClassification: Classification | null = null
   private outbound: ExternalMcpSafeOutbound | null = null
   private providerRequestId: string | null = null
+  private providerDeclaredError: ProviderDeclaredErrorEvidence | null = null
+  private backgroundFailure: { phase: ExternalMcpDiagnosticPhase; error: unknown } | null = null
 
   constructor(referenceId: string, credentialContext?: {
     authType: "oauth" | "apikey" | "none"
@@ -1143,6 +1320,8 @@ export class ExternalMcpDiagnosticTracker {
     this.lastHttpStatus = null
     this.forcedClassification = null
     this.providerRequestId = null
+    this.providerDeclaredError = null
+    this.backgroundFailure = null
   }
 
   passed(phase: ExternalMcpDiagnosticPhase, health?: ExternalMcpHealthLevel): void {
@@ -1166,10 +1345,18 @@ export class ExternalMcpDiagnosticTracker {
     this.capturedFailure = { phase, error }
   }
 
+  captureBackgroundFailure(phase: ExternalMcpDiagnosticPhase, error: unknown): void {
+    this.backgroundFailure = { phase, error }
+  }
+
   captureResponseBodyLimit(phase: ExternalMcpDiagnosticPhase, error: unknown): void {
     const classification = classifyError(error, phase)
     this.failed(phase, classification)
     this.capturedFailure = { phase, error }
+  }
+
+  captureBackgroundResponseBodyLimit(phase: ExternalMcpDiagnosticPhase, error: unknown): void {
+    this.backgroundFailure = { phase, error }
   }
 
   recordHttpStatus(status: number): void {
@@ -1196,6 +1383,10 @@ export class ExternalMcpDiagnosticTracker {
         return
       }
     }
+  }
+
+  recordProviderDeclaredError(evidence: ProviderDeclaredErrorEvidence): void {
+    this.providerDeclaredError = evidence
   }
 
   providerToolError(result?: unknown): ExternalMcpDiagnosticError {
@@ -1258,6 +1449,7 @@ export class ExternalMcpDiagnosticTracker {
       ...(providerStatus === undefined ? {} : { providerStatus }),
       ...(providerCode ? { providerCode } : {}),
       payloadBytes: evidence.payloadBytes,
+      ...(evidence.excerpt ? { providerErrorMessage: evidence.excerpt } : {}),
     }
     logProviderToolEvidence({
       referenceId: this.referenceId,
@@ -1273,8 +1465,26 @@ export class ExternalMcpDiagnosticTracker {
 
   error(error: unknown, fallbackPhase = this.lastFailedPhase ?? this.phase): ExternalMcpDiagnosticError {
     if (error instanceof ExternalMcpDiagnosticError) return error
-    const source = errorCode(error) || !this.capturedFailure ? { phase: fallbackPhase, error } : this.capturedFailure
-    const inferredClassification = classifyError(source.error, source.phase)
+    let source = { phase: fallbackPhase, error }
+    let inferredClassification = classifyError(error, fallbackPhase)
+    const thrownProviderEvidence = providerDeclaredErrorFromError(error, fallbackPhase)
+    const thrownClassificationIsUninformative = isUninformativeClassification(inferredClassification)
+    if (thrownClassificationIsUninformative && this.providerDeclaredError) {
+      const evidence = this.providerDeclaredError
+      source = { phase: evidence.phase, error }
+      inferredClassification = evidence.connectUrl
+        ? providerAuthorizationClassification(evidence.connectUrl)
+        : providerDeclaredErrorClassification()
+    } else if (thrownClassificationIsUninformative && this.capturedFailure) {
+      const capturedClassification = classifyError(this.capturedFailure.error, this.capturedFailure.phase)
+      if (!isUninformativeClassification(capturedClassification)) {
+        source = this.capturedFailure
+        inferredClassification = capturedClassification
+      } else if (this.backgroundFailure) {
+        source = this.backgroundFailure
+        inferredClassification = classifyError(this.backgroundFailure.error, this.backgroundFailure.phase)
+      }
+    }
     const classified = this.forcedClassification
       && !TYPED_OAUTH_ERROR_NAMES.has(errorName(source.error))
       && inferredClassification.phase !== "MCP_VERSION"
@@ -1292,10 +1502,21 @@ export class ExternalMcpDiagnosticTracker {
             : "Reconnect the organization-managed provider account, then retry.",
         }
       : classified
+    const jsonRpcCode = numericErrorCode(error)
+      ?? this.providerDeclaredError?.jsonRpcCode
+      ?? numericErrorCode(source.error)
+    const providerEvidence = this.providerDeclaredError
+      ?? thrownProviderEvidence
+      ?? providerDeclaredErrorFromError(source.error, source.phase)
+    const providerErrorMessage = providerEvidence?.message
+    const providerErrorData = providerEvidence?.dataExcerpt
     const diagnosticWithoutMessage = {
       referenceId: this.referenceId,
       highestPassed: this.highestPassed,
       ...classification,
+      ...(jsonRpcCode === undefined ? {} : { jsonRpcCode }),
+      ...(providerErrorMessage ? { providerErrorMessage } : {}),
+      ...(providerErrorData ? { providerErrorData } : {}),
     }
     const diagnostic: ExternalMcpDiagnostic = {
       ...diagnosticWithoutMessage,
@@ -1304,7 +1525,6 @@ export class ExternalMcpDiagnosticTracker {
       ...(classification.phase === source.phase ? {} : { operationPhase: source.phase }),
       ...(this.outbound ? { outbound: this.outbound } : {}),
       ...(this.providerRequestId ? { providerRequestId: this.providerRequestId } : {}),
-      ...(numericErrorCode(source.error) === undefined ? {} : { jsonRpcCode: numericErrorCode(source.error) }),
     }
     return new ExternalMcpDiagnosticError(diagnostic, error)
   }
@@ -1389,22 +1609,123 @@ function preserveResponseMetadata(target: Response, source: Response): void {
   }
 }
 
-function boundedExternalMcpResponse(input: {
+function requestMethod(init: RequestInit | undefined): string {
+  return (init?.method ?? "GET").toUpperCase()
+}
+
+function isMcpEndpointRequest(input: string | URL, endpoint: URL): boolean {
+  const url = new URL(String(input))
+  return url.origin === endpoint.origin && url.pathname === endpoint.pathname
+}
+
+function isBackgroundMcpEndpointRequest(input: string | URL, init: RequestInit | undefined, endpoint: URL): boolean {
+  if (!isMcpEndpointRequest(input, endpoint)) return false
+  const method = requestMethod(init)
+  return (method === "GET" || method === "DELETE") && jsonRpcMethod(requestBodyText(init)) === null
+}
+
+function isProviderDeclaredErrorSniffEligible(input: {
+  url: string | URL
+  init: RequestInit | undefined
+  endpoint: URL
+  phase: ExternalMcpDiagnosticPhase
+  response: Response
+  contentType: string
+}): boolean {
+  return input.phase.startsWith("MCP_")
+    && requestMethod(input.init) === "POST"
+    && isMcpEndpointRequest(input.url, input.endpoint)
+    && input.response.ok
+    && input.contentType === "application/json"
+}
+
+function advertisedContentLength(response: Response): number | null {
+  const advertisedLength = response.headers.get("content-length")
+  if (!advertisedLength || !/^\d+$/.test(advertisedLength)) return null
+  const length = Number(advertisedLength)
+  return Number.isSafeInteger(length) ? length : null
+}
+
+async function responseTextWithinLimit(response: Response, limit: number): Promise<string | null> {
+  if (!response.body) return null
+  const reader = response.body.getReader()
+  const chunks: Uint8Array[] = []
+  let bytesRead = 0
+  try {
+    while (true) {
+      const next = await reader.read()
+      if (next.done) break
+      bytesRead += next.value.byteLength
+      if (bytesRead > limit) {
+        void reader.cancel().catch(() => undefined)
+        return null
+      }
+      chunks.push(next.value)
+    }
+  } catch {
+    return null
+  }
+  const bytes = new Uint8Array(bytesRead)
+  let offset = 0
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset)
+    offset += chunk.byteLength
+  }
+  return new TextDecoder().decode(bytes)
+}
+
+async function sniffProviderDeclaredError(input: {
+  response: Response
+  phase: ExternalMcpDiagnosticPhase
+  tracker: ExternalMcpDiagnosticTracker
+}): Promise<void> {
+  const contentLength = advertisedContentLength(input.response)
+  if (contentLength !== null && contentLength > EXTERNAL_MCP_PROVIDER_DECLARED_ERROR_SNIFF_LIMIT_BYTES) return
+  let clone: Response
+  try {
+    clone = input.response.clone()
+  } catch {
+    return
+  }
+  const text = await responseTextWithinLimit(clone, EXTERNAL_MCP_PROVIDER_DECLARED_ERROR_SNIFF_LIMIT_BYTES)
+  if (text === null) return
+  try {
+    const parsed: unknown = JSON.parse(text)
+    const evidence = providerDeclaredErrorFromJson(parsed, input.phase)
+    if (evidence) input.tracker.recordProviderDeclaredError(evidence)
+  } catch {
+    // Sniffing is best-effort diagnostic evidence; the SDK still receives the original body.
+  }
+}
+
+async function boundedExternalMcpResponse(input: {
   response: Response
   contentType: string
   phase: ExternalMcpDiagnosticPhase
   tracker: ExternalMcpDiagnosticTracker
-}): Response {
+  background: boolean
+  sniffProviderDeclaredError: boolean
+}): Promise<Response> {
+  if (input.sniffProviderDeclaredError) {
+    // Clone before any original .body getter access. Bun breaks the tee if the
+    // original body getter is touched before clone(), which would empty the SDK body.
+    await sniffProviderDeclaredError({
+      response: input.response,
+      phase: input.phase,
+      tracker: input.tracker,
+    })
+  }
   if (!input.response.body) return input.response
   const limit = responseBodyLimit(input.contentType)
-  const advertisedLength = input.response.headers.get("content-length")
-  if (advertisedLength && /^\d+$/.test(advertisedLength)) {
-    const length = Number(advertisedLength)
-    if (Number.isSafeInteger(length) && length > limit) {
-      const error = new ExternalMcpResponseBodyLimitError()
-      input.tracker.captureResponseBodyLimit(input.phase, error)
-      throw input.tracker.error(error, input.phase)
+  const contentLength = advertisedContentLength(input.response)
+  if (contentLength !== null && contentLength > limit) {
+    const error = new ExternalMcpResponseBodyLimitError()
+    if (input.background) {
+      input.tracker.captureBackgroundResponseBodyLimit(input.phase, error)
+      throw error
     }
+    input.tracker.captureResponseBodyLimit(input.phase, error)
+    throw input.tracker.error(error, input.phase)
   }
 
   const reader = input.response.body.getReader()
@@ -1420,7 +1741,11 @@ function boundedExternalMcpResponse(input: {
         bytesRead += next.value.byteLength
         if (bytesRead > limit) {
           const error = new ExternalMcpResponseBodyLimitError()
-          input.tracker.captureResponseBodyLimit(input.phase, error)
+          if (input.background) {
+            input.tracker.captureBackgroundResponseBodyLimit(input.phase, error)
+          } else {
+            input.tracker.captureResponseBodyLimit(input.phase, error)
+          }
           await reader.cancel(error).catch(() => undefined)
           controller.error(error)
           return
@@ -1457,10 +1782,24 @@ export function createExternalMcpDiagnosticFetch(input: {
       input.tracker.failed("CONFIGURATION")
       throw input.tracker.error(error, "CONFIGURATION")
     }
-    input.tracker.begin(phase)
-    input.tracker.recordOutbound(url)
+    const background = isBackgroundMcpEndpointRequest(url, init, endpoint)
+    if (!background) {
+      input.tracker.begin(phase)
+      input.tracker.recordOutbound(url)
+    }
     try {
       const response = await input.fetch(url, init)
+      const contentType = (response.headers.get("content-type") ?? "").split(";", 1)[0]?.trim().toLowerCase() ?? ""
+      if (background) {
+        return await boundedExternalMcpResponse({
+          response,
+          contentType,
+          phase,
+          tracker: input.tracker,
+          background,
+          sniffProviderDeclaredError: false,
+        })
+      }
       input.tracker.recordHttpStatus(response.status)
       input.tracker.recordProviderRequestId(response.headers)
       const challenge = response.headers.get("www-authenticate") ?? ""
@@ -1469,7 +1808,6 @@ export function createExternalMcpDiagnosticFetch(input: {
         && response.status === 401
         && !hasAuthorization
         && /\bbearer\b/i.test(challenge)
-      const contentType = (response.headers.get("content-type") ?? "").split(";", 1)[0]?.trim().toLowerCase() ?? ""
       const classification = unauthenticatedChallenge
         ? null
         : httpClassification({
@@ -1492,9 +1830,27 @@ export function createExternalMcpDiagnosticFetch(input: {
       } else {
         input.tracker.failed(phase)
       }
-      return boundedExternalMcpResponse({ response, contentType, phase, tracker: input.tracker })
+      return await boundedExternalMcpResponse({
+        response,
+        contentType,
+        phase,
+        tracker: input.tracker,
+        background,
+        sniffProviderDeclaredError: isProviderDeclaredErrorSniffEligible({
+          url,
+          init,
+          endpoint,
+          phase,
+          response,
+          contentType,
+        }),
+      })
     } catch (error) {
-      input.tracker.captureFailure(phase, error)
+      if (background) {
+        input.tracker.captureBackgroundFailure(phase, error)
+      } else {
+        input.tracker.captureFailure(phase, error)
+      }
       throw error
     }
   }

--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -60,6 +60,8 @@ const externalMcpDiagnosticOutputSchema = z.object({
   payloadBytes: z.number().int().optional(),
   jsonRpcCode: z.number().int().optional(),
   connectUrl: z.string().url().optional(),
+  providerErrorMessage: z.string().optional(),
+  providerErrorData: z.string().optional(),
 })
 
 const connectionStatusOutputSchema = openworkCloudMcpConnectionActionSchema.extend({

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -37,6 +37,37 @@ function jsonRpcError(code: number, data?: Record<string, unknown>) {
   return error
 }
 
+async function wrappedMcpJsonResponse(input: {
+  responseText: string
+  contentLength?: string
+}) {
+  const tracker = new ExternalMcpDiagnosticTracker("req_provider_declared_body")
+  const headers = new Headers({ "content-type": "application/json" })
+  if (input.contentLength) headers.set("content-length", input.contentLength)
+  const diagnosticFetch = createExternalMcpDiagnosticFetch({
+    endpoint: "https://gateway.example.com/mcp",
+    tracker,
+    fetch: async () => new Response(input.responseText, {
+      status: 200,
+      headers,
+    }),
+  })
+  const response = await diagnosticFetch("https://gateway.example.com/mcp", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: {} }),
+  })
+  return { tracker, response }
+}
+
+async function diagnosticForMcpJsonResponse(input: {
+  responseBody: unknown
+  thrownError?: Error
+}) {
+  const { tracker } = await wrappedMcpJsonResponse({ responseText: JSON.stringify(input.responseBody) })
+  return tracker.error(input.thrownError ?? new Error("SDK rejected provider response")).diagnostic
+}
+
 function captureConsoleError<T>(run: () => T): { result: T; errors: unknown[][] } {
   const errors: unknown[][] = []
   const originalError = console.error
@@ -311,7 +342,13 @@ describe("external MCP diagnostics", () => {
 
     const error = tracker.error(new Error("initialize failed"))
     expect(error.diagnostic.highestPassed).toBe("reachable")
-    expect(error.diagnostic).not.toHaveProperty("jsonRpcCode")
+    expect(error.diagnostic).toMatchObject({
+      phase: "PROVIDER_EXECUTION",
+      operationPhase: "MCP_INITIALIZE",
+      category: "provider_declared_error",
+      code: "MCP_PROVIDER_DECLARED_ERROR",
+      jsonRpcCode: -32603,
+    })
     expect(JSON.stringify(error)).not.toContain("must-not-be-retained")
   })
 
@@ -371,7 +408,7 @@ describe("external MCP diagnostics", () => {
     })
   })
 
-  test("classifies allowlisted provider tool results without exposing provider content", () => {
+  test("classifies allowlisted provider tool results with bounded provider text", () => {
     const makeToolError = (referenceId: string, structuredContent: Record<string, unknown>) => {
       const tracker = new ExternalMcpDiagnosticTracker(referenceId)
       tracker.passed("MCP_INITIALIZED", "protocol_ready")
@@ -411,6 +448,7 @@ describe("external MCP diagnostics", () => {
       retryable: false,
       actionOwner: "provider_admin",
       providerRequestId: "provider-request-403",
+      providerErrorMessage: "provider-secret-message",
     })
 
     expect(throttled.diagnostic).toMatchObject({
@@ -421,6 +459,7 @@ describe("external MCP diagnostics", () => {
       retryable: true,
       actionOwner: "provider_admin",
       providerRequestId: "provider-request-429",
+      providerErrorMessage: "provider-secret-message",
     })
 
     expect(unknown.diagnostic).toMatchObject({
@@ -430,11 +469,12 @@ describe("external MCP diagnostics", () => {
       highestPassed: "protocol_ready",
       retryable: false,
       actionOwner: "provider_admin",
+      providerErrorMessage: "provider-secret-message",
     })
     expect(unknown.diagnostic.providerRequestId).toBeUndefined()
 
     const serialized = JSON.stringify([denied, throttled, unknown])
-    expect(serialized).not.toContain("provider-secret-message")
+    expect(serialized).toContain("provider-secret-message")
     expect(serialized).not.toContain("sensitive-provider-code")
     expect(serialized).not.toContain("provider-secret-retry-value")
     expect(serialized).not.toContain("sensitive-unknown-code")
@@ -455,9 +495,9 @@ describe("external MCP diagnostics", () => {
       actionOwner: "openwork",
       retryable: false,
       jsonRpcCode: -32602,
+      providerErrorMessage: "Provider rejected private argument detail",
     })
     expect(error.diagnostic.operatorAction).toContain("do not retry the same arguments")
-    expect(JSON.stringify(error.diagnostic)).not.toContain("private argument detail")
   })
 
   test("classifies downstream provider authorization links without treating -32001 as a timeout", () => {
@@ -498,16 +538,87 @@ describe("external MCP diagnostics", () => {
     })
   })
 
-  test.each([
-    ["local request timeout", { timeout: 30000 }],
-    ["maximum total timeout", { maxTotalTimeout: 90000, totalElapsed: 90001 }],
-    ["bare remote -32001", undefined],
-    ["unsafe connect_url scheme", { connect_url: "javascript:alert(1)" }],
-    ["non-http connect_url scheme", { connect_url: "ftp://mcp-gateway.fixture.test/servers/salesforce/connect/start" }],
-  ])("keeps %s classified as request timeout", (_name, data) => {
+  test("captures provider-declared connect_url from 200 JSON-RPC error bodies with null ids", async () => {
+    const connectUrl = "https://gateway.example.com/auth/connect?tenant=t1"
+    const responseBody = {
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32001,
+        message: "Authorization required. Visit the connect portal.",
+        data: { connect_url: connectUrl, provider: "blueyonder" },
+      },
+    }
+    const responseText = JSON.stringify(responseBody)
+    const { tracker, response } = await wrappedMcpJsonResponse({ responseText })
+    expect(await response.text()).toBe(responseText)
+
+    const diagnostic = tracker.error(new Error("ZodError: invalid input")).diagnostic
+
+    expect(diagnostic).toMatchObject({
+      phase: "PROVIDER_AUTHORIZATION",
+      category: "provider_authorization_required",
+      code: "MCP_PROVIDER_AUTH_REQUIRED",
+      retryable: false,
+      actionOwner: "member",
+      connectUrl,
+      jsonRpcCode: -32001,
+      providerErrorMessage: "Authorization required. Visit the connect portal.",
+    })
+    expect(diagnostic.message).toContain("Provider-declared message (untrusted): \"Authorization required. Visit the connect portal.\"")
+  })
+
+  test("leaves sniff-eligible JSON-RPC success bodies intact without recording error evidence", async () => {
+    const responseText = JSON.stringify({ jsonrpc: "2.0", id: 3, result: { content: [] } })
+    const { tracker, response } = await wrappedMcpJsonResponse({ responseText })
+    expect(await response.text()).toBe(responseText)
+
+    const diagnostic = tracker.error(new Error("later SDK failure")).diagnostic
+    expect(diagnostic).toMatchObject({
+      phase: "MCP_TOOL_EXECUTION",
+      category: "mcp_protocol_failure",
+      code: "MCP_MCP_TOOL_EXECUTION",
+      retryable: false,
+      actionOwner: "provider_admin",
+    })
+    expect(diagnostic.connectUrl).toBeUndefined()
+    expect(diagnostic.jsonRpcCode).toBeUndefined()
+  })
+
+  test("skips provider-declared sniffing above the 64KB cap while preserving the body", async () => {
+    const connectUrl = "https://gateway.example.com/auth/connect?tenant=large"
+    const responseText = JSON.stringify({
+      jsonrpc: "2.0",
+      id: null,
+      error: {
+        code: -32001,
+        message: "Authorization required",
+        data: { connect_url: connectUrl },
+      },
+      padding: "x".repeat(70 * 1024),
+    })
+    const { tracker, response } = await wrappedMcpJsonResponse({
+      responseText,
+      contentLength: String(Buffer.byteLength(responseText, "utf8")),
+    })
+    expect(await response.text()).toBe(responseText)
+
+    const diagnostic = tracker.error(new Error("later SDK failure")).diagnostic
+    expect(diagnostic).toMatchObject({
+      phase: "MCP_TOOL_EXECUTION",
+      category: "mcp_protocol_failure",
+      code: "MCP_MCP_TOOL_EXECUTION",
+      retryable: false,
+      actionOwner: "provider_admin",
+    })
+    expect(diagnostic.connectUrl).toBeUndefined()
+    expect(diagnostic.jsonRpcCode).toBeUndefined()
+  })
+
+  test("keeps local SDK request timeouts classified as request timeouts", () => {
     const tracker = new ExternalMcpDiagnosticTracker("req_timeout")
     tracker.begin("MCP_TOOL_EXECUTION")
-    const error = tracker.error(jsonRpcError(-32001, data))
+    const error = tracker.error(jsonRpcError(-32001, { timeout: 30000 }))
 
     expect(error.diagnostic).toMatchObject({
       phase: "MCP_TOOL_EXECUTION",
@@ -520,18 +631,227 @@ describe("external MCP diagnostics", () => {
     expect(error.diagnostic.connectUrl).toBeUndefined()
   })
 
-  test("keeps unknown remote JSON-RPC errors generic while preserving the code", () => {
+  test("classifies remote -32001 without local timeout data as provider-declared", () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_remote_32001")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const error = tracker.error(jsonRpcError(-32001, { provider_detail: "must-not-surface" }))
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "PROVIDER_EXECUTION",
+      category: "provider_declared_error",
+      code: "MCP_PROVIDER_DECLARED_ERROR",
+      retryable: false,
+      actionOwner: "provider_admin",
+      jsonRpcCode: -32001,
+      providerErrorMessage: "MCP error -32001: synthetic provider detail",
+      providerErrorData: '{"provider_detail":"must-not-surface"}',
+    })
+  })
+
+  test("captures URL elicitation links from 200 JSON-RPC error bodies with null ids", async () => {
+    const connectUrl = "https://gateway.example.com/auth/url-elicitation"
+    const diagnostic = await diagnosticForMcpJsonResponse({
+      responseBody: {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32042, message: "URL required", data: { url: connectUrl } },
+      },
+    })
+
+    expect(diagnostic).toMatchObject({
+      phase: "PROVIDER_AUTHORIZATION",
+      category: "provider_authorization_required",
+      code: "MCP_PROVIDER_AUTH_REQUIRED",
+      retryable: false,
+      actionOwner: "member",
+      connectUrl,
+      jsonRpcCode: -32042,
+    })
+  })
+
+  test("classifies unknown server-range JSON-RPC body codes as provider-declared with sanitized text and data", async () => {
+    const diagnostic = await diagnosticForMcpJsonResponse({
+      responseBody: {
+        jsonrpc: "2.0",
+        id: null,
+        error: {
+          code: -32050,
+          message: "boom\u0007\n\nline2   spaced",
+          data: { reason: "tenant_suspended", ticket: "T-123" },
+        },
+      },
+    })
+
+    expect(diagnostic).toMatchObject({
+      phase: "PROVIDER_EXECUTION",
+      category: "provider_declared_error",
+      code: "MCP_PROVIDER_DECLARED_ERROR",
+      retryable: false,
+      actionOwner: "provider_admin",
+      jsonRpcCode: -32050,
+      providerErrorMessage: "boom line2 spaced",
+      providerErrorData: '{"reason":"tenant_suspended","ticket":"T-123"}',
+    })
+    expect(diagnostic.message).toContain("code -32050")
+    expect(diagnostic.message).toContain('Provider-declared message (untrusted): "boom line2 spaced"')
+  })
+
+  test("caps provider-declared messages at 512 characters", async () => {
+    const longMessage = "x".repeat(700)
+    const diagnostic = await diagnosticForMcpJsonResponse({
+      responseBody: {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32051, message: longMessage },
+      },
+    })
+
+    expect(diagnostic).toMatchObject({
+      phase: "PROVIDER_EXECUTION",
+      category: "provider_declared_error",
+      code: "MCP_PROVIDER_DECLARED_ERROR",
+      retryable: false,
+      actionOwner: "provider_admin",
+      jsonRpcCode: -32051,
+      providerErrorMessage: "x".repeat(512),
+    })
+    expect(diagnostic.providerErrorMessage).toHaveLength(512)
+  })
+
+  test("keeps free-text provider URLs non-actionable", async () => {
+    const diagnostic = await diagnosticForMcpJsonResponse({
+      responseBody: {
+        jsonrpc: "2.0",
+        id: null,
+        error: { code: -32052, message: "Open https://gateway.example.com/auth/free-text to connect" },
+      },
+    })
+
+    expect(diagnostic).toMatchObject({
+      phase: "PROVIDER_EXECUTION",
+      category: "provider_declared_error",
+      code: "MCP_PROVIDER_DECLARED_ERROR",
+      retryable: false,
+      actionOwner: "provider_admin",
+      jsonRpcCode: -32052,
+      providerErrorMessage: "Open https://gateway.example.com/auth/free-text to connect",
+    })
+    expect(diagnostic.connectUrl).toBeUndefined()
+  })
+
+  test("relays correlated McpError-like provider messages and data", () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_correlated_provider_declared")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const providerError = new Error("Quota exceeded for tenant")
+    Object.defineProperty(providerError, "code", { value: -32055, enumerable: true })
+    Object.defineProperty(providerError, "data", { value: { limit: 100 }, enumerable: true })
+
+    const diagnostic = tracker.error(providerError).diagnostic
+    expect(diagnostic).toMatchObject({
+      phase: "PROVIDER_EXECUTION",
+      category: "provider_declared_error",
+      code: "MCP_PROVIDER_DECLARED_ERROR",
+      retryable: false,
+      actionOwner: "provider_admin",
+      jsonRpcCode: -32055,
+      providerErrorMessage: "Quota exceeded for tenant",
+      providerErrorData: '{"limit":100}',
+    })
+    expect(diagnostic.message).toContain("code -32055")
+    expect(diagnostic.message).toContain('Provider-declared message (untrusted): "Quota exceeded for tenant"')
+  })
+
+  test("does not treat REST error bodies as provider-declared JSON-RPC evidence", async () => {
+    const diagnostic = await diagnosticForMcpJsonResponse({
+      responseBody: { error: { code: 500, message: "boom" } },
+    })
+
+    expect(diagnostic).toMatchObject({
+      phase: "MCP_TOOL_EXECUTION",
+      category: "mcp_protocol_failure",
+      code: "MCP_MCP_TOOL_EXECUTION",
+      retryable: false,
+      actionOwner: "provider_admin",
+    })
+    expect(diagnostic.jsonRpcCode).toBeUndefined()
+  })
+
+  test("background MCP endpoint failures do not pollute authoritative tool-call state", async () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_background_pollution")
+    const diagnosticFetch = createExternalMcpDiagnosticFetch({
+      endpoint: "https://gateway.example.com/mcp",
+      tracker,
+      fetch: async (_url, init) => {
+        if ((init?.method ?? "GET").toUpperCase() === "GET") throw new Error("background SSE failed")
+        return new Response(JSON.stringify({ jsonrpc: "2.0", id: 1, result: {} }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        })
+      },
+    })
+    await diagnosticFetch("https://gateway.example.com/mcp", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "tools/call", params: {} }),
+    })
+    await expect(diagnosticFetch("https://gateway.example.com/mcp", { method: "GET" })).rejects.toThrow("background SSE failed")
+
+    const diagnostic = tracker.error(new Error("SDK rejected response")).diagnostic
+    expect(diagnostic).toMatchObject({
+      phase: "MCP_TOOL_EXECUTION",
+      category: "mcp_protocol_failure",
+      code: "MCP_MCP_TOOL_EXECUTION",
+      retryable: false,
+      actionOwner: "provider_admin",
+      httpStatus: 200,
+    })
+  })
+
+  test("captured noise does not shadow an informative provider authorization error", () => {
+    const connectUrl = "https://gateway.example.com/auth/x"
+    const tracker = new ExternalMcpDiagnosticTracker("req_shadow_provider_auth")
+    tracker.captureFailure("MCP_TRANSPORT", new Error("background noise"))
+    const error = tracker.error(jsonRpcError(-32001, { connect_url: connectUrl }), "MCP_TOOL_EXECUTION")
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "PROVIDER_AUTHORIZATION",
+      category: "provider_authorization_required",
+      code: "MCP_PROVIDER_AUTH_REQUIRED",
+      retryable: false,
+      actionOwner: "member",
+      connectUrl,
+      jsonRpcCode: -32001,
+    })
+  })
+
+  test("uses an honest fallback message after MCP protocol readiness", () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_honest_fallback")
+    tracker.passed("MCP_INITIALIZED", "protocol_ready")
+    const diagnostic = tracker.error(new Error("SDK could not parse response")).diagnostic
+
+    expect(diagnostic).toMatchObject({
+      phase: "MCP_INITIALIZED",
+      category: "mcp_protocol_failure",
+      code: "MCP_MCP_INITIALIZED",
+      retryable: false,
+      actionOwner: "provider_admin",
+    })
+    expect(diagnostic.message).toBe("The MCP server answered, but OpenWork could not interpret its response for the current request.")
+  })
+
+  test("classifies unknown correlated JSON-RPC errors as provider-declared while preserving the code", () => {
     const tracker = new ExternalMcpDiagnosticTracker("req_remote_generic")
     tracker.begin("MCP_TOOL_EXECUTION")
     const error = tracker.error(jsonRpcError(-32050, { provider_detail: "must-not-surface" }))
 
     expect(error.diagnostic).toMatchObject({
-      phase: "MCP_TOOL_EXECUTION",
-      category: "mcp_protocol_failure",
-      code: "MCP_MCP_TOOL_EXECUTION",
+      phase: "PROVIDER_EXECUTION",
+      category: "provider_declared_error",
+      code: "MCP_PROVIDER_DECLARED_ERROR",
       jsonRpcCode: -32050,
+      providerErrorData: '{"provider_detail":"must-not-surface"}',
     })
-    expect(JSON.stringify(error.diagnostic)).not.toContain("must-not-surface")
+    expect(error.diagnostic.message).toContain("code -32050")
   })
 
   test("classifies structured provider validation errors as correctable tool input", () => {
@@ -551,11 +871,11 @@ describe("external MCP diagnostics", () => {
       code: "MCP_PROVIDER_INVALID_PARAMS",
       actionOwner: "openwork",
       retryable: false,
+      providerErrorMessage: "private provider validation detail",
     })
-    expect(JSON.stringify(error.diagnostic)).not.toContain("private provider validation detail")
   })
 
-  test("classifies standardized MCP SDK input-validation tool errors without exposing their text", () => {
+  test("classifies standardized MCP SDK input-validation tool errors with provider text", () => {
     const { result: error } = captureConsoleError(() => {
       const tracker = new ExternalMcpDiagnosticTracker("req_sdk_invalid_params")
       tracker.passed("MCP_INITIALIZED", "protocol_ready")
@@ -574,8 +894,8 @@ describe("external MCP diagnostics", () => {
       code: "MCP_PROVIDER_INVALID_PARAMS",
       actionOwner: "openwork",
       retryable: false,
+      providerErrorMessage: "Input validation error: Invalid arguments for tool lookup_incident: private provider detail",
     })
-    expect(JSON.stringify(error.diagnostic)).not.toContain("private provider detail")
   })
 
   test("derives allowlisted provider evidence from ServiceNow-style text JSON", () => {
@@ -597,6 +917,7 @@ describe("external MCP diagnostics", () => {
       providerCode: "insufficient_acl",
       providerRequestId: "TXN-abc-123",
       highestPassed: "protocol_ready",
+      providerErrorMessage: providerText,
     })
     expect(error.diagnostic.payloadBytes ?? 0).toBeGreaterThan(0)
     expect(error.diagnostic.message).toContain("provider status 403")
@@ -604,7 +925,7 @@ describe("external MCP diagnostics", () => {
     expect(error.diagnostic.message).not.toContain(providerText)
   })
 
-  test("logs Redis-style provider text evidence without surfacing it in the diagnostic", () => {
+  test("logs Redis-style provider text evidence while relaying the bounded excerpt", () => {
     const providerText = "All slots are not covered by nodes. 0 of 16384 covered."
     const { result: error, errors } = captureConsoleError(() => {
       const tracker = new ExternalMcpDiagnosticTracker("req_redis_text")
@@ -619,6 +940,7 @@ describe("external MCP diagnostics", () => {
       phase: "PROVIDER_EXECUTION",
       category: "provider_tool_error",
       code: "MCP_PROVIDER_TOOL_ERROR",
+      providerErrorMessage: providerText,
     })
     expect(error.diagnostic.payloadBytes ?? 0).toBeGreaterThan(0)
     expect(error.diagnostic.message).not.toContain(providerText)
@@ -643,6 +965,7 @@ describe("external MCP diagnostics", () => {
       phase: "PROVIDER_EXECUTION",
       category: "provider_tool_error",
       code: "MCP_PROVIDER_TOOL_ERROR",
+      providerErrorMessage: "we found 403 records",
     })
     expect(error.diagnostic.providerStatus).toBeUndefined()
   })


### PR DESCRIPTION
## Problem

After #2932 shipped, a real tool call through a partner enterprise gateway still dead-ended (production diagnostic `8d63f8d7-302d-46fb-9363-3dd4939e50e6`):

```
code: MCP_MCP_TRANSPORT, category: mcp_protocol_failure, phase: MCP_TRANSPORT,
retryable: true, actionOwner: provider_admin, httpStatus: 200,
highestPassed: protocol_ready  — no jsonRpcCode, no connectUrl
```

Root causes (verified against `@modelcontextprotocol/sdk@1.29.0`):

1. **The gateway mints auth errors with `"id": null`.** The SDK's `RequestIdSchema` rejects `null`, so `JSONRPCMessageSchema.parse` throws a ZodError inside `send()` — the `-32001` + `data.connect_url` payload never becomes an `McpError`, so the #2932 adapter never sees it. (Reproduced: `id:null → ZodError`, `id:3 → parses`, which is why the mock-backed fraimz passed while production failed.)
2. **Background-stream tracker pollution.** The SDK's standalone GET SSE stream (and its reconnects) shares the one mutable diagnostic tracker with the actual request; its `begin()/passed()/captureFailure()` overwrite phase/httpStatus, which is where `MCP_TRANSPORT` + `httpStatus: 200` came from.
3. **Captured-failure shadowing.** In `error()`, a captured background-fetch failure replaced the thrown error whenever the thrown error had no *string* `code` — every `McpError` (numeric code) qualifies, so even correctly-shaped auth errors could be discarded for GET-stream noise.
4. **Remote `-32001` was trusted to mean "our timeout"** ("check provider latency") — the origenal confident wrong answer.

## Fix (generic, no provider matching)

- **Evidence capture below the SDK parse layer**: bounded (64KB) sniff of 2xx `application/json` POST responses on MCP phases; recognizes JSON-RPC error envelopes regardless of `id` (echoed / `null` / missing). Structured-only: `error.data.connect_url` or `-32042` + `data.url` → relayable connect evidence; code-only evidence additionally requires `jsonrpc: "2.0"` + negative integer code (REST lookalikes like `{"error":{"code":500}}` are explicitly not misread).
- **Fail open into agent-readable honesty**: `providerErrorMessage` / `providerErrorData` (sanitized, 512-char capped, provenance-labeled "untrusted") now flow to the agent on every failure path — including `isError` tool results, whose text was previously only server-logged. Unknown codes read: *"provider answered with a JSON-RPC error OpenWork does not recognize (code N). Provider-declared message (untrusted): '…'"* — the agent can figure out the next step itself.
- **Actionable vs readable stays strict**: `connectUrl` remains the only actionable link — validated http(s), host-bound to the connection origin downstream, `retryable: false`, never auto-opened. URLs inside free text are quoted material only.
- **Origin-aware `-32001`**: "request timeout" now requires structural proof of our own SDK timeout (`data.timeout`); remote `-32001` without `connect_url` is a provider-declared error, not "check provider latency".
- **Background isolation + precedence**: endpoint GET/DELETE (SSE stream, session teardown) no longer mutate operation state; captured noise can never shadow an informative thrown error; most-specific classification wins.
- Honest fallback message when the protocol was already ready ("answered, but OpenWork could not interpret its response") instead of the contradictory "failed before completing the protocol lifecycle".

## What the agent sees now (verification matrix, real tracker + fetch wrapper)

| Failure class | Agent-visible result |
| --- | --- |
| `id:null` + `-32001` + `connect_url` (production shape) | `MCP_PROVIDER_AUTH_REQUIRED`, `actionOwner: member`, `retryable: false`, host-bound `connectUrl`, `jsonRpcCode: -32001`, provider message quoted |
| Unknown `-32050`, URL only in text | `MCP_PROVIDER_DECLARED_ERROR`, code + quoted message + `{"reason":"tenant_suspended","ticket":"T-123"}`, **no** `connectUrl` |
| Correlated remote `-32055` | `MCP_PROVIDER_DECLARED_ERROR`, message + data (`limit/used`) relayed |
| Provider `isError` tool result | `MCP_PROVIDER_TOOL_ERROR` + the provider's error text (previously server-log only) |
| Local SDK timeout | `MCP_REQUEST_TIMEOUT`, unchanged contract |

## Tests / evidence

- `bun test test/external-mcp-diagnostics.test.ts test/external-mcp-tool-inspection.test.ts test/external-capability-errors.test.ts test/mcp-agent-timeouts.test.ts` → **110 pass / 0 fail (315 expect)**
- `pnpm exec tsc --noEmit` → clean
- Replay harness of the exact production sequence (authoritative POST returning the `id:null` envelope + concurrent background GET failure + SDK ZodError) → relays the connect link with all fields above; also asserts the SDK-delivered body stays intact (verification caught a Bun `.body`-getter-before-`clone()` tee bug in an intermediate version of the sniffer; regression tests added: delivered body intact for error/success/oversized bodies).
- New fixtures pin: id:null relay, `-32042`, unknown-code honesty, REST false-positive guard, background pollution, shadowing precedence, sanitization/truncation of provider text, free-text URLs staying non-actionable.

No fraimz run for this PR: server-side classifier change with no UI surface of its own; behavior is proven by the unit fixtures + replay harness above. Reviewer repro: run the two commands above from `ee/apps/den-api`.

Upstream (tracked separately): asking the gateway vendor to echo the request `id` (or emit `-32042 UrlElicitationRequired`) — with this change that's hardening, no longer load-bearing.

