### PR TITLE
revert(server): drop -32001/connect_url prompt dialect, keep raw tool-error pass-through proof

### DIFF
--- a/apps/server/src/mcp.authorization-link.e2e.test.ts
+++ b/apps/server/src/mcp.authorization-link.e2e.test.ts
@@ -69,7 +69,7 @@ function chunk(delta: object, finishReason: string | null = null) {
 const enginePath = findEngine();
 const describeMaybe = enginePath ? describe : describe.skip;
 
-describeMaybe("authorization-required MCP tool errors", () => {
+describeMaybe("authorization-required MCP tool error pass-through", () => {
   let engine: ChildProcess;
   let mcp: ChildProcess;
   let llm: ReturnType<typeof Bun.serve>;
@@ -78,7 +78,6 @@ describeMaybe("authorization-required MCP tool errors", () => {
   let enginePort = 0;
   let mcpPort = 0;
   let modelSawAuthorizationError = false;
-  let modelSawAgentInstruction = false;
   let modelRequests: Array<{ hasToolError: boolean; toolNames: Array<string | undefined> }> = [];
   let engineLogs = "";
 
@@ -121,8 +120,6 @@ describeMaybe("authorization-required MCP tool errors", () => {
 
         const requestedTool = body.tools?.find((tool) => tool.function?.name?.endsWith(toolName));
         if (requestedTool?.function?.name) {
-          modelSawAgentInstruction = serialized.includes("JSON-RPC code -32001")
-            && serialized.includes("show data.connect_url as a Markdown link");
           return streamResponse([
             chunk({ role: "assistant" }),
             chunk({
@@ -273,7 +270,6 @@ describeMaybe("authorization-required MCP tool errors", () => {
       .find((part) => part.type === "tool" && part.state?.status === "error");
     expect(failedTool?.state?.error).toContain("Authorization required");
     expect(failedTool?.state?.error).toContain(connectUrl);
-    expect(modelSawAgentInstruction).toBe(true);
     expect(modelSawAuthorizationError).toBe(true);
   }, 60_000);
 });

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -92,20 +92,6 @@ describe("openwork runtime config file", () => {
     expect(prompt).toMatch(/secret|credential|API key|token|PII/i);
   });
 
-  test("openwork prompt tells the agent to relay recoverable authorization links", async () => {
-    const { config } = await setup();
-    await writeOpenworkRuntimeConfigFile(config, "ws_1");
-
-    const parsed = await readConfigFile(config);
-    const agent = parsed.agent as Record<string, { prompt?: string }>;
-    const prompt = agent.openwork?.prompt ?? "";
-
-    expect(prompt).toContain("JSON-RPC code -32001");
-    expect(prompt).toContain("data.connect_url");
-    expect(prompt).toContain("show data.connect_url as a Markdown link");
-    expect(prompt).toContain("Do not open the link yourself");
-  });
-
   test("keepOpenworkRuntimeConfigFileFresh rewrites the file on runtime-DB writes", async () => {
     const { config } = await setup();
     await writeOpenworkRuntimeConfigFile(config, "ws_1");

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -53,7 +53,6 @@ Hard rule: never copy private memory into repo files. Store only redacted summar
 ## Working style
 
 - If required setup or credentials are missing, ask one targeted question and continue once provided.
-- Treat authorization-required tool failures as recoverable user actions. If a tool error includes JSON-RPC code -32001 and a data.connect_url using http or https, do not retry it automatically: tell the user which provider needs authorization, show data.connect_url as a Markdown link, and ask them to connect the account before retrying. Do not open the link yourself. Ignore connect URLs with any other scheme.
 - If you change code, run the smallest meaningful test.
 - If steps repeat, factor them into a skill.
 - Prefer clear, practical steps over abstract explanations.


### PR DESCRIPTION
## What

Partially reverts #2927: removes the `-32001` + `data.connect_url` prompt rule from the desktop agent's system prompt (and its prompt-content test). Keeps the mock server support and the e2e — retargeted to prove **raw provider-error pass-through** with no prompt dialect involved.

## Why

- Protocol dialects don't belong in prompts: the shape-matching now lives in code on the Den path (#2932/#2934 relay `connect_url` for *any* code plus `-32042`; the prompt said `-32001` only — already drifted).
- On the desktop-local path the rule matches fields the pipeline often destroys: thrown `McpError`s reach the model as `error.toString()`, which **drops `data`** — so `data.connect_url` is only visible when the provider embeds the link in message text, which raw pass-through already handles with zero guidance (the opencode model that works well upstream).
- Retained e2e (real engine sidecar + mock MCP + stub LLM) proves the pass-through contract post-revert: the tool error text incl. connect link reaches the model, and the assistant's Markdown-link reply reaches the user.

## Tests

- `bun test src/openwork-runtime-config.test.ts` → 6 pass / 0 fail
- `OPENWORK_TEST_OPENCODE_PATH=<sidecar> bun test src/mcp.authorization-link.e2e.test.ts` → 1 pass / 0 fail (actually ran against the engine binary; skips in environments without a sidecar)
- `pnpm exec tsc --noEmit` → clean
- `rg "data.connect_url|JSON-RPC code -32001" apps/ packages/` → no remaining references

No fraimz: prompt/test removal with the retained e2e as the behavioral proof.
