### PR TITLE
refactor(den): agent-facing MCP errors carry provider words, not internal taxonomy

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -8,7 +8,6 @@ import { openworkCloudMcpConnectionActionSchema } from "@openwork/types/den/mcp-
 import type { Hono } from "hono"
 import { z } from "zod"
 import { memberFacingMcpConnectionsEnabled } from "../capability-sources/external-mcp-rollout.js"
-import { EXTERNAL_MCP_DIAGNOSTIC_PHASES } from "../capability-sources/external-mcp-diagnostics.js"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
 import { db } from "../db.js"
 import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
@@ -41,27 +40,10 @@ export const EXECUTE_CAPABILITY_ANNOTATIONS: ToolAnnotations = {
   openWorldHint: true,
 }
 
-const externalMcpDiagnosticOutputSchema = z.object({
-  referenceId: z.string(),
-  phase: z.enum(EXTERNAL_MCP_DIAGNOSTIC_PHASES),
-  category: z.string(),
-  code: z.string(),
-  highestPassed: z.enum(["configured", "reachable", "authorized", "protocol_ready", "catalog_ready", "operation_ready"]),
-  retryable: z.boolean(),
-  actionOwner: z.enum(["openwork", "network_admin", "provider_admin", "organization_admin", "member"]),
-  operatorAction: z.string(),
-  message: z.string(),
-  httpStatus: z.number().int().optional(),
-  operationPhase: z.enum(EXTERNAL_MCP_DIAGNOSTIC_PHASES).optional(),
-  outbound: z.object({ origin: z.string(), pathHash: z.string() }).optional(),
-  providerRequestId: z.string().optional(),
-  providerStatus: z.number().int().optional(),
-  providerCode: z.string().optional(),
-  payloadBytes: z.number().int().optional(),
+const externalMcpProviderErrorOutputSchema = z.object({
   jsonRpcCode: z.number().int().optional(),
-  connectUrl: z.string().url().optional(),
-  providerErrorMessage: z.string().optional(),
-  providerErrorData: z.string().optional(),
+  message: z.string().optional(),
+  data: z.string().optional(),
 })
 
 const connectionStatusOutputSchema = openworkCloudMcpConnectionActionSchema.extend({
@@ -75,7 +57,6 @@ const connectionStatusOutputSchema = openworkCloudMcpConnectionActionSchema.exte
     retry: z.literal("search_capabilities"),
     url: z.string().url().optional(),
   }),
-  diagnostic: externalMcpDiagnosticOutputSchema.optional(),
 })
 
 const capabilityMatchOutputSchema = z.object({
@@ -100,6 +81,28 @@ const capabilityMatchOutputSchema = z.object({
 export const SEARCH_CAPABILITIES_OUTPUT_SCHEMA = z.object({
   matches: z.array(capabilityMatchOutputSchema),
   hint: z.string().optional(),
+})
+
+const externalCapabilityErrorPayloadSchema = z.object({
+  error: z.string(),
+  message: z.string(),
+  referenceId: z.string().optional(),
+  retryable: z.boolean().optional(),
+  providerError: externalMcpProviderErrorOutputSchema.optional(),
+  connectionStatus: connectionStatusOutputSchema.optional(),
+  capability: z.string().optional(),
+  issues: z.array(z.object({
+    path: z.string(),
+    keyword: z.string(),
+    message: z.string(),
+  })).optional(),
+  schemaDigest: z.string().optional(),
+  sameArgumentsRetryable: z.literal(false).optional(),
+  retry: z.object({
+    action: z.enum(["correct_arguments", "search_capabilities"]),
+    searchRequired: z.boolean(),
+  }).optional(),
+  schemaGuidance: z.unknown().optional(),
 })
 
 export const AGENT_MCP_INSTRUCTIONS = [
@@ -133,22 +136,23 @@ function textContent(text: string): { text: string; type: "text" }[] {
 export function externalCapabilityErrorToolResult(
   result: Exclude<ExternalCapabilityExecuteResult, { ok: true }>,
 ): ExecuteCapabilityToolResult {
+  const payload = externalCapabilityErrorPayloadSchema.parse({
+    error: result.error,
+    message: result.message,
+    ...(result.referenceId === undefined ? {} : { referenceId: result.referenceId }),
+    ...(result.retryable === undefined ? {} : { retryable: result.retryable }),
+    ...(result.providerError ? { providerError: result.providerError } : {}),
+    ...(result.connectionStatus ? { connectionStatus: result.connectionStatus } : {}),
+    ...(result.capability ? { capability: result.capability } : {}),
+    ...(result.issues ? { issues: result.issues } : {}),
+    ...(result.schemaDigest ? { schemaDigest: result.schemaDigest } : {}),
+    ...(result.sameArgumentsRetryable === false ? { sameArgumentsRetryable: false } : {}),
+    ...(result.retry ? { retry: result.retry } : {}),
+    ...(result.schemaGuidance ? { schemaGuidance: result.schemaGuidance } : {}),
+  })
   return {
     isError: true,
-    content: textContent(JSON.stringify({
-      error: result.error,
-      message: result.message,
-      ...(result.diagnostic ? { diagnostic: result.diagnostic } : {}),
-      ...(result.actionOwner ? { actionOwner: result.actionOwner } : {}),
-      ...(result.operatorAction ? { operatorAction: result.operatorAction } : {}),
-      ...(result.connectionStatus ? { connectionStatus: result.connectionStatus } : {}),
-      ...(result.capability ? { capability: result.capability } : {}),
-      ...(result.issues ? { issues: result.issues } : {}),
-      ...(result.schemaDigest ? { schemaDigest: result.schemaDigest } : {}),
-      ...(result.sameArgumentsRetryable === false ? { sameArgumentsRetryable: false } : {}),
-      ...(result.retry ? { retry: result.retry } : {}),
-      ...(result.schemaGuidance ? { schemaGuidance: result.schemaGuidance } : {}),
-    })),
+    content: textContent(JSON.stringify(payload)),
   }
 }
 

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -189,7 +189,6 @@ export type ExternalConnectionStatus = {
     retry: "search_capabilities"
     url?: string
   }
-  diagnostic?: ExternalMcpDiagnostic
 }
 
 const ERROR_MESSAGE_LIMIT = 300
@@ -461,7 +460,6 @@ export function buildExternalConnectionStatus(input: {
             retry: "search_capabilities",
           },
         }),
-      ...(input.diagnostic ? { diagnostic: input.diagnostic } : {}),
     }
   }
 
@@ -506,7 +504,6 @@ export function buildExternalConnectionStatus(input: {
           retry: "search_capabilities",
         },
       }),
-    ...(input.diagnostic ? { diagnostic: input.diagnostic } : {}),
   }
 }
 
@@ -850,9 +847,9 @@ export type ExternalCapabilityExecuteResult =
         | "provider_error"
         | "invalid_capability_arguments"
       message: string
-      diagnostic?: ExternalMcpDiagnostic
-      actionOwner?: ExternalMcpDiagnostic["actionOwner"]
-      operatorAction?: string
+      referenceId?: string
+      retryable?: boolean
+      providerError?: ExternalMcpProviderError
       connectionStatus?: ExternalConnectionStatus
       capability?: string
       issues?: ExternalMcpArgumentIssue[]
@@ -864,6 +861,38 @@ export type ExternalCapabilityExecuteResult =
       }
       schemaGuidance?: ExternalMcpSchemaGuidance
     }
+
+export type ExternalMcpProviderError = {
+  jsonRpcCode?: number
+  message?: string
+  data?: string
+}
+
+function providerErrorFromDiagnostic(diagnostic: ExternalMcpDiagnostic): ExternalMcpProviderError | undefined {
+  if (
+    diagnostic.jsonRpcCode === undefined
+    && !diagnostic.providerErrorMessage
+    && !diagnostic.providerErrorData
+  ) return undefined
+  return {
+    ...(diagnostic.jsonRpcCode === undefined ? {} : { jsonRpcCode: diagnostic.jsonRpcCode }),
+    ...(diagnostic.providerErrorMessage ? { message: diagnostic.providerErrorMessage } : {}),
+    ...(diagnostic.providerErrorData ? { data: diagnostic.providerErrorData } : {}),
+  }
+}
+
+function diagnosticAgentMessage(diagnostic: ExternalMcpDiagnostic): string {
+  return `${diagnostic.message} ${diagnostic.operatorAction} Diagnostic reference: ${diagnostic.referenceId}.`
+}
+
+function diagnosticAgentFields(diagnostic: ExternalMcpDiagnostic) {
+  const providerError = providerErrorFromDiagnostic(diagnostic)
+  return {
+    referenceId: diagnostic.referenceId,
+    retryable: diagnostic.retryable,
+    ...(providerError ? { providerError } : {}),
+  }
+}
 
 function invalidCapabilityArguments(input: {
   capability: string
@@ -877,7 +906,7 @@ function invalidCapabilityArguments(input: {
     error: "invalid_capability_arguments",
     capability: input.capability,
     message: input.diagnostic
-      ? `The remote MCP rejected the capability arguments as invalid. Correct them using the latest argumentsSchema. Diagnostic reference: ${input.diagnostic.referenceId}.`
+      ? diagnosticAgentMessage(input.diagnostic)
       : "The capability arguments do not match the remote MCP tool's advertised argumentsSchema.",
     issues: input.issues ?? [{
       path: "/",
@@ -888,13 +917,7 @@ function invalidCapabilityArguments(input: {
     sameArgumentsRetryable: false,
     retry: { action: "correct_arguments", searchRequired: false },
     ...(input.schemaGuidance ? { schemaGuidance: input.schemaGuidance } : {}),
-    ...(input.diagnostic
-      ? {
-          diagnostic: input.diagnostic,
-          actionOwner: input.diagnostic.actionOwner,
-          operatorAction: input.diagnostic.operatorAction,
-        }
-      : {}),
+    ...(input.diagnostic ? diagnosticAgentFields(input.diagnostic) : {}),
   }
 }
 
@@ -1103,14 +1126,12 @@ export async function executeExternalCapability(input: {
         })
       }
       if (diagnostic.code === "MCP_PROVIDER_AUTH_REQUIRED") {
-        const resultMessage = `${diagnostic.message} ${diagnostic.operatorAction} Diagnostic reference: ${diagnostic.referenceId}.`
+        const resultMessage = diagnosticAgentMessage(diagnostic)
         return {
           ok: false,
           error: "needs_connection",
           message: resultMessage,
-          diagnostic,
-          actionOwner: diagnostic.actionOwner,
-          operatorAction: diagnostic.operatorAction,
+          ...diagnosticAgentFields(diagnostic),
           connectionStatus: providerAuthorizationConnectionStatus({
             connection,
             diagnostic,
@@ -1124,10 +1145,8 @@ export async function executeExternalCapability(input: {
         error: diagnostic.phase === "PROVIDER_EXECUTION" || diagnostic.phase === "PROVIDER_AUTHORIZATION"
           ? "provider_error"
           : "connection_failed",
-        message: `${diagnostic.message} ${diagnostic.operatorAction} Diagnostic reference: ${diagnostic.referenceId}.`,
-        diagnostic,
-        actionOwner: diagnostic.actionOwner,
-        operatorAction: diagnostic.operatorAction,
+        message: diagnosticAgentMessage(diagnostic),
+        ...diagnosticAgentFields(diagnostic),
         ...(schemaGuidance ? { schemaGuidance } : {}),
         ...(authErrorCode
           ? {

--- a/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
+++ b/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
@@ -1,5 +1,6 @@
 import { StreamableHTTPTransport } from "@hono/mcp"
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
+import { eq } from "@openwork-ee/den-db/drizzle"
 import { createDenTypeId, type DenTypeId } from "@openwork-ee/utils/typeid"
 import { afterAll, beforeAll, expect, mock, test } from "bun:test"
 import { Hono } from "hono"
@@ -98,9 +99,32 @@ function requestIdFromPayload(payload: unknown): string | number | null {
 
 function startFakeMcpServer(name: string, tools: FakeTool[], requiredBearer?: string): FakeMcpServer {
   const app = new Hono()
+  app.get("/.well-known/oauth-protected-resource/mcp", (c) => {
+    const origin = new URL(c.req.url).origin
+    return c.json({
+      resource: `${origin}/mcp`,
+      authorization_servers: [origin],
+    })
+  })
+  app.get("/.well-known/oauth-authorization-server", (c) => {
+    const origin = new URL(c.req.url).origin
+    return c.json({
+      issuer: origin,
+      authorization_endpoint: `${origin}/authorize`,
+      token_endpoint: `${origin}/token`,
+      response_types_supported: ["code"],
+      grant_types_supported: ["authorization_code", "refresh_token"],
+      code_challenge_methods_supported: ["S256"],
+    })
+  })
   app.all("/mcp", async (c) => {
     if (requiredBearer && c.req.header("authorization") !== `Bearer ${requiredBearer}`) {
-      return c.json({ error: "invalid_token" }, 401)
+      const origin = new URL(c.req.url).origin
+      return c.json(
+        { error: "invalid_token" },
+        401,
+        { "www-authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"` },
+      )
     }
     const server = new McpServer({ name, version: "1.0.0" })
     for (const tool of tools) {
@@ -232,6 +256,41 @@ function startProviderAuthorizationRequiredMcpServer(foreignOrigin?: string): Fa
     connectUrl,
     stop: () => server.stop(true),
   }
+}
+
+function startProviderDeclaredUnknownCodeMcpServer(): FakeMcpServer {
+  const app = new Hono()
+  app.all("/mcp", async (c) => {
+    const payload: unknown = await c.req.raw.clone().json().catch(() => null)
+    const method = isRecord(payload) ? payload.method : undefined
+    if (method === "tools/call") {
+      return c.json({
+        jsonrpc: "2.0",
+        id: requestIdFromPayload(payload),
+        error: {
+          code: -32050,
+          message: "Quota exceeded for tenant alpha.",
+          data: {
+            provider: "billing",
+            reason: "quota_exceeded",
+          },
+        },
+      })
+    }
+
+    const mcpServer = new McpServer({ name: "provider-declared-error", version: "1.0.0" })
+    mcpServer.registerTool(
+      "export_billing_report",
+      { description: "Export a billing report", inputSchema: z.object({}) },
+      async () => ({ content: textContent("export ok") }),
+    )
+    const transport = new StreamableHTTPTransport()
+    await mcpServer.connect(transport)
+    const response = await transport.handleRequest(c)
+    return response ?? new Response(null, { status: 204 })
+  })
+  const server = Bun.serve({ port: 0, fetch: app.fetch })
+  return { url: `http://127.0.0.1:${server.port}/mcp`, stop: () => server.stop(true) }
 }
 
 function startMutableSchemaMcpServer(): MutableSchemaMcpServer {
@@ -711,16 +770,14 @@ test("dead-url execution returns a structured connection diagnostic instead of t
   if (result.ok) throw new Error("Dead MCP execution unexpectedly succeeded")
   expect(result).toMatchObject({
     error: "connection_failed",
-    actionOwner: "network_admin",
-    diagnostic: {
-      phase: "NETWORK_TCP",
-      category: "network_failure",
-      code: "MCP_ECONNREFUSED",
-      actionOwner: "network_admin",
-    },
+    retryable: false,
   })
+  expect(typeof result.referenceId).toBe("string")
+  expect("diagnostic" in result).toBe(false)
+  expect("actionOwner" in result).toBe(false)
+  expect("operatorAction" in result).toBe(false)
   expect(result.message).toContain("Diagnostic reference")
-  if (!result.ok) expect(result.operatorAction).toBe(result.diagnostic?.operatorAction)
+  expect(result.message).toContain("Verify provider allowlists, firewall rules, proxy requirements, and service availability from Den.")
 })
 
 test("shared invalid_grant recovery cannot reuse the cleared in-memory refresh token", async () => {
@@ -846,16 +903,52 @@ test("MCP tool isError is surfaced as a provider failure, not transport success"
   if (result.ok) throw new Error("Provider isError unexpectedly returned success")
   expect(result).toMatchObject({
     error: "provider_error",
-    diagnostic: {
-      phase: "PROVIDER_EXECUTION",
-      category: "provider_tool_error",
-      code: "MCP_PROVIDER_TOOL_ERROR",
-      highestPassed: "protocol_ready",
-      providerRequestId: "sn-request-provider-error-123",
-      httpStatus: 200,
-    },
+    retryable: false,
   })
+  expect(typeof result.referenceId).toBe("string")
+  expect("diagnostic" in result).toBe(false)
+  expect("actionOwner" in result).toBe(false)
+  expect("operatorAction" in result).toBe(false)
   expect(result.message).not.toContain("internal detail")
+})
+
+test("provider-declared unknown JSON-RPC errors expose provider words without internal diagnostics", async () => {
+  const providerDeclaredErrorServer = startProviderDeclaredUnknownCodeMcpServer()
+  try {
+    const seed = await seedOrganization("provider-declared-json-rpc")
+    const connection = await createGrantedConnection(seed, {
+      name: "Billing MCP",
+      authType: "none",
+      credentialMode: "shared",
+      url: providerDeclaredErrorServer.url,
+    })
+    const result = await executeExternalCapability({
+      organizationId: seed.organizationId,
+      member: { orgMembershipId: seed.memberId, teamIds: [] },
+      connectionId: connection.id,
+      toolName: "export_billing_report",
+      args: {},
+      redirectUriBase,
+    })
+
+    expect(result.ok).toBe(false)
+    if (result.ok) throw new Error("Provider-declared JSON-RPC error unexpectedly returned success")
+    expect(result.error).toBe("provider_error")
+    expect(typeof result.referenceId).toBe("string")
+    expect(result.retryable).toBe(false)
+    expect(result.providerError).toMatchObject({
+      jsonRpcCode: -32050,
+      message: "Quota exceeded for tenant alpha.",
+    })
+    expect(result.providerError?.data).toContain("quota_exceeded")
+    expect(result.message).toContain("Look up the provider-declared JSON-RPC error code with the provider")
+    expect(result.message).toContain(`Diagnostic reference: ${result.referenceId}.`)
+    expect("diagnostic" in result).toBe(false)
+    expect("actionOwner" in result).toBe(false)
+    expect("operatorAction" in result).toBe(false)
+  } finally {
+    providerDeclaredErrorServer.stop()
+  }
 })
 
 test("standard MCP SDK invalid-argument tool errors become a corrective execution result", async () => {
@@ -881,14 +974,16 @@ test("standard MCP SDK invalid-argument tool errors become a corrective executio
     error: "invalid_capability_arguments",
     sameArgumentsRetryable: false,
     retry: { action: "correct_arguments", searchRequired: false },
-    diagnostic: {
-      phase: "MCP_TOOL_EXECUTION",
-      category: "mcp_tool_input_invalid",
-      code: "MCP_PROVIDER_INVALID_PARAMS",
-      actionOwner: "openwork",
-      retryable: false,
-    },
+    retryable: false,
   })
+  if (result.ok) throw new Error("Invalid argument rejection unexpectedly returned success")
+  expect(typeof result.referenceId).toBe("string")
+  expect(result.message).toContain("Diagnostic reference")
+  expect(result.message).toContain("Correct the tool arguments")
+  expect("diagnostic" in result).toBe(false)
+  expect("actionOwner" in result).toBe(false)
+  expect("operatorAction" in result).toBe(false)
+  expect(result.providerError).toBeUndefined()
   expect(JSON.stringify(result)).not.toContain("sensitive provider detail")
 })
 
@@ -914,17 +1009,15 @@ test("structured provider denial keeps connection health separate and names the 
   if (result.ok) throw new Error("Provider policy denial unexpectedly returned success")
   expect(result).toMatchObject({
     error: "provider_error",
-    actionOwner: "provider_admin",
-    diagnostic: {
-      phase: "PROVIDER_AUTHORIZATION",
-      category: "provider_policy_denied",
-      code: "MCP_PROVIDER_HTTP_403",
-      highestPassed: "protocol_ready",
-      actionOwner: "provider_admin",
-      providerRequestId: "provider-operation-403",
-    },
+    retryable: false,
   })
+  expect(typeof result.referenceId).toBe("string")
   expect(result.message).toContain("Diagnostic reference")
+  expect(result.message).toContain("Grant the provider role, ACL, or application permission required for this operation.")
+  expect("diagnostic" in result).toBe(false)
+  expect("actionOwner" in result).toBe(false)
+  expect("operatorAction" in result).toBe(false)
+  expect(result.providerError).toBeUndefined()
   expect(JSON.stringify(result)).not.toContain("Sensitive provider policy detail")
   expect(JSON.stringify(result)).not.toContain("sensitive_acl_code")
 })
@@ -953,14 +1046,9 @@ test("downstream provider authorization links are relayed as needs_connection", 
     if (result.ok) throw new Error("Provider authorization requirement unexpectedly returned success")
     expect(result).toMatchObject({
       error: "needs_connection",
-      actionOwner: "member",
-      diagnostic: {
-        phase: "PROVIDER_AUTHORIZATION",
-        category: "provider_authorization_required",
-        code: "MCP_PROVIDER_AUTH_REQUIRED",
-        actionOwner: "member",
-        retryable: false,
-        connectUrl: providerAuthServer.connectUrl,
+      retryable: false,
+      providerError: {
+        jsonRpcCode: -32001,
       },
       connectionStatus: {
         layer: "downstream_provider",
@@ -975,6 +1063,16 @@ test("downstream provider authorization links are relayed as needs_connection", 
         },
       },
     })
+    expect(typeof result.referenceId).toBe("string")
+    expect(result.providerError?.message).toContain("Authorization required")
+    expect(result.providerError?.data).toContain(providerAuthServer.connectUrl)
+    expect(result.message).toContain("Connect your account for this provider using its sign-in link, then retry this capability.")
+    expect(result.message).toContain(`Diagnostic reference: ${result.referenceId}.`)
+    expect("diagnostic" in result).toBe(false)
+    expect("actionOwner" in result).toBe(false)
+    expect("operatorAction" in result).toBe(false)
+    if (!result.connectionStatus) throw new Error("Provider authorization result omitted connectionStatus")
+    expect("diagnostic" in result.connectionStatus).toBe(false)
     expect(result.message.toLowerCase()).not.toContain("latency")
     expect(result.message.toLowerCase()).not.toContain("timeout")
   } finally {
@@ -1006,8 +1104,9 @@ test("foreign-origin downstream authorization links are dropped but still surfac
     if (result.ok) throw new Error("Provider authorization requirement unexpectedly returned success")
     expect(result).toMatchObject({
       error: "needs_connection",
-      diagnostic: {
-        code: "MCP_PROVIDER_AUTH_REQUIRED",
+      retryable: false,
+      providerError: {
+        jsonRpcCode: -32001,
       },
       connectionStatus: {
         layer: "downstream_provider",
@@ -1015,8 +1114,13 @@ test("foreign-origin downstream authorization links are dropped but still surfac
         action: { type: "connect", surface: "openwork_your_connections" },
       },
     })
-    expect(result.diagnostic?.connectUrl).toBeUndefined()
-    expect(result.connectionStatus?.diagnostic?.connectUrl).toBeUndefined()
+    expect(typeof result.referenceId).toBe("string")
+    expect(result.providerError?.message).toContain("Authorization required")
+    expect("diagnostic" in result).toBe(false)
+    expect("actionOwner" in result).toBe(false)
+    expect("operatorAction" in result).toBe(false)
+    if (!result.connectionStatus) throw new Error("Foreign provider authorization result omitted connectionStatus")
+    expect("diagnostic" in result.connectionStatus).toBe(false)
     expect(result.connectionStatus?.action.url).toBeUndefined()
     expect(result.message.toLowerCase()).not.toContain("latency")
     expect(result.message.toLowerCase()).not.toContain("timeout")
@@ -1115,15 +1219,10 @@ test("JSON-RPC initialize errors are not mislabeled as OAuth refresh failures", 
         surface: "provider_admin_console",
         retry: "search_capabilities",
       },
-      diagnostic: {
-        phase: "MCP_INITIALIZE",
-        category: "mcp_protocol_failure",
-        code: "MCP_MCP_INITIALIZE",
-        highestPassed: "reachable",
-        jsonRpcCode: -32603,
-      },
     },
   })
+  if (!matches[0]?.connectionStatus) throw new Error("Connection status missing for JSON-RPC initialize error")
+  expect("diagnostic" in matches[0].connectionStatus).toBe(false)
   expect(matches[0]?.hint).toContain("Diagnostic reference")
   expect(matches[0]?.hint).not.toContain("Reconnect")
   if (process.env.OPENWORK_EVAL_VERBOSE === "1") {
@@ -1137,17 +1236,20 @@ test("repairing a connector credential makes its live tools discoverable on retr
   const seed = await seedOrganization("repair-and-retry")
   const connection = await createGrantedConnection(seed, {
     name: "Team Chat",
-    authType: "oauth",
+    authType: "apikey",
     credentialMode: "shared",
     url: authedSlackServer.url,
+    apiKey: "expired-token",
   })
-  await saveExternalMcpTokens({ connectionId: connection.id, accessToken: "expired-token" })
 
   const beforeRepair = await search(seed, "team chat")
   expect(beforeRepair[0]?.kind).toBe("connection_status")
   expect(beforeRepair[0]?.status).toBe("error")
 
-  await saveExternalMcpTokens({ connectionId: connection.id, accessToken: "valid-key" })
+  await db
+    .update(schema.ExternalMcpConnectionTable)
+    .set({ apiKey: "valid-key" })
+    .where(eq(schema.ExternalMcpConnectionTable.id, connection.id))
   const afterRepair = await search(seed, "team chat")
 
   expect(afterRepair.some((match) => match.kind === "connection_status")).toBe(false)

--- a/ee/apps/den-api/test/external-capability-errors.test.ts
+++ b/ee/apps/den-api/test/external-capability-errors.test.ts
@@ -7,6 +7,7 @@ function seedRequiredEnv() {
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
   process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.DEN_ALLOW_PRIVATE_MCP_URLS = process.env.DEN_ALLOW_PRIVATE_MCP_URLS ?? "1"
 }
 
 seedRequiredEnv()
@@ -139,6 +140,7 @@ test("reauth-required overrides generic provider ownership from a refresh diagno
       surface: "openwork_your_connections",
     },
   })
+  expect("diagnostic" in status).toBe(false)
 })
 
 test("provider installation failures route to the provider admin console", () => {
@@ -179,6 +181,7 @@ test("structured diagnostics remain the single source of truth for fix ownership
       surface: "network_infrastructure",
     },
   })
+  expect("diagnostic" in status).toBe(false)
 })
 
 test("generic provider failures route to connector inspection instead of cloud reauthorization", () => {

--- a/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
@@ -11,6 +11,7 @@ function seedRequiredEnv() {
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
   process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.DEN_ALLOW_PRIVATE_MCP_URLS = process.env.DEN_ALLOW_PRIVATE_MCP_URLS ?? "1"
 }
 
 class MemoryTransport implements Transport {
@@ -152,13 +153,18 @@ test("capability search preserves the bounded-fanout coverage warning", () => {
   expect(JSON.parse(result.content[0]?.text ?? "{}")).toEqual(structured)
 })
 
-test("external capability failures preserve the safe MCP diagnostic envelope", () => {
+test("external capability failures preserve the slim agent-facing MCP error envelope", () => {
   const result = agentModule.externalCapabilityErrorToolResult({
     ok: false,
     error: "connection_failed",
     message: "Connection failed. Diagnostic reference: req_test.",
-    actionOwner: "network_admin",
-    operatorAction: "Repair the certificate chain.",
+    referenceId: "req_test",
+    retryable: false,
+    providerError: {
+      jsonRpcCode: -32050,
+      message: "Provider quota exceeded.",
+      data: '{"reason":"quota"}',
+    },
     connectionStatus: {
       version: 1,
       kind: "connection_action",
@@ -179,27 +185,17 @@ test("external capability failures preserve the safe MCP diagnostic envelope", (
         retry: "search_capabilities",
       },
     },
-    diagnostic: {
-      referenceId: "req_test",
-      phase: "NETWORK_TLS",
-      category: "tls_failure",
-      code: "MCP_CERT_HAS_EXPIRED",
-      highestPassed: "reachable",
-      retryable: false,
-      actionOwner: "network_admin",
-      operatorAction: "Repair the certificate chain.",
-      message: "TLS validation failed.",
-    },
   })
   expect(result.isError).toBe(true)
-  expect(JSON.parse(result.content[0]?.text ?? "{}")).toMatchObject({
+  const payload = JSON.parse(result.content[0]?.text ?? "{}")
+  expect(payload).toMatchObject({
     error: "connection_failed",
-    actionOwner: "network_admin",
-    operatorAction: "Repair the certificate chain.",
-    diagnostic: {
-      referenceId: "req_test",
-      phase: "NETWORK_TLS",
-      actionOwner: "network_admin",
+    referenceId: "req_test",
+    retryable: false,
+    providerError: {
+      jsonRpcCode: -32050,
+      message: "Provider quota exceeded.",
+      data: '{"reason":"quota"}',
     },
     connectionStatus: {
       connectionId: "emc_test",
@@ -207,6 +203,10 @@ test("external capability failures preserve the safe MCP diagnostic envelope", (
       action: { type: "reconnect" },
     },
   })
+  expect("diagnostic" in payload).toBe(false)
+  expect("actionOwner" in payload).toBe(false)
+  expect("operatorAction" in payload).toBe(false)
+  expect("diagnostic" in payload.connectionStatus).toBe(false)
 })
 
 test("invalid capability arguments preserve corrective retry instructions", () => {

--- a/evals/flows/den-provider-auth-relay.flow.mjs
+++ b/evals/flows/den-provider-auth-relay.flow.mjs
@@ -462,30 +462,39 @@ function assertForeignHostConnectUrl(ctx, connectUrl, connectionUrl) {
 }
 
 function assertProviderAuthEnvelope(ctx, envelope, expectedConnectUrl) {
-  const diagnostic = isRecord(own(envelope, "diagnostic")) ? own(envelope, "diagnostic") : null;
+  const providerError = isRecord(own(envelope, "providerError")) ? own(envelope, "providerError") : null;
   const connectionStatus = isRecord(own(envelope, "connectionStatus")) ? own(envelope, "connectionStatus") : null;
   const action = isRecord(own(connectionStatus, "action")) ? own(connectionStatus, "action") : null;
   witness(ctx, own(envelope, "error") === "needs_connection", "execute_capability error is needs_connection", envelope);
-  witness(ctx, own(diagnostic, "code") === "MCP_PROVIDER_AUTH_REQUIRED", "diagnostic.code is MCP_PROVIDER_AUTH_REQUIRED", diagnostic);
-  witness(ctx, own(diagnostic, "retryable") === false, "diagnostic.retryable is false", diagnostic);
-  witness(ctx, own(diagnostic, "connectUrl") === expectedConnectUrl, "diagnostic.connectUrl relays the gateway connect link", diagnostic);
+  witness(ctx, typeof own(envelope, "referenceId") === "string", "execute_capability exposes a diagnostic referenceId", envelope);
+  witness(ctx, own(envelope, "retryable") === false, "execute_capability retryable is false", envelope);
+  witness(ctx, own(providerError, "jsonRpcCode") === -32001, "providerError.jsonRpcCode carries the provider JSON-RPC code", providerError);
+  witness(ctx, String(own(providerError, "message") ?? "").includes("Authorization required"), "providerError.message carries the provider authorization wording", providerError);
+  witness(ctx, String(own(providerError, "data") ?? "").includes(expectedConnectUrl), "providerError.data includes the provider connect-link declaration", providerError);
   witness(ctx, own(connectionStatus, "layer") === "downstream_provider", "connectionStatus.layer is downstream_provider", connectionStatus);
   witness(ctx, own(connectionStatus, "state") === "needs_connection", "connectionStatus.state is needs_connection", connectionStatus);
   witness(ctx, own(action, "type") === "connect", "connectionStatus.action.type is connect", action);
   witness(ctx, own(action, "url") === expectedConnectUrl, "connectionStatus.action.url is exactly the gateway connect link", action);
+  witness(ctx, own(envelope, "diagnostic") === undefined, "execute_capability does not expose the internal diagnostic object", envelope);
+  witness(ctx, own(envelope, "actionOwner") === undefined, "execute_capability does not expose actionOwner", envelope);
+  witness(ctx, own(envelope, "operatorAction") === undefined, "execute_capability does not expose operatorAction", envelope);
+  witness(ctx, own(connectionStatus, "diagnostic") === undefined, "connectionStatus does not embed the internal diagnostic object", connectionStatus);
   witness(ctx, !TIMEOUT_WORDING.test(String(own(envelope, "message") ?? "")), "execute_capability message contains no latency or timeout wording", own(envelope, "message"));
 }
 
 function assertForeignLinkStrippedEnvelope(ctx, envelope) {
-  const diagnostic = isRecord(own(envelope, "diagnostic")) ? own(envelope, "diagnostic") : null;
+  const providerError = isRecord(own(envelope, "providerError")) ? own(envelope, "providerError") : null;
   const connectionStatus = isRecord(own(envelope, "connectionStatus")) ? own(envelope, "connectionStatus") : null;
   const action = isRecord(own(connectionStatus, "action")) ? own(connectionStatus, "action") : null;
   witness(ctx, own(envelope, "error") === "needs_connection", "foreign-host execute_capability error is still needs_connection", envelope);
-  witness(ctx, own(diagnostic, "code") === "MCP_PROVIDER_AUTH_REQUIRED", "foreign-host diagnostic.code is MCP_PROVIDER_AUTH_REQUIRED", diagnostic);
+  witness(ctx, typeof own(envelope, "referenceId") === "string", "foreign-host envelope exposes a diagnostic referenceId", envelope);
+  witness(ctx, own(envelope, "retryable") === false, "foreign-host envelope retryable is false", envelope);
+  witness(ctx, own(providerError, "jsonRpcCode") === -32001, "foreign-host providerError.jsonRpcCode carries the provider JSON-RPC code", providerError);
   witness(ctx, own(connectionStatus, "layer") === "downstream_provider", "foreign-host connectionStatus.layer is downstream_provider", connectionStatus);
   witness(ctx, own(connectionStatus, "state") === "needs_connection", "foreign-host connectionStatus.state is needs_connection", connectionStatus);
   witness(ctx, own(action, "type") === "connect", "foreign-host action still tells the member to connect", action);
-  witness(ctx, own(diagnostic, "connectUrl") === undefined, "foreign-host diagnostic.connectUrl is stripped", diagnostic);
+  witness(ctx, own(envelope, "diagnostic") === undefined, "foreign-host envelope does not expose the internal diagnostic object", envelope);
+  witness(ctx, own(connectionStatus, "diagnostic") === undefined, "foreign-host connectionStatus does not embed diagnostics", connectionStatus);
   witness(ctx, own(action, "url") === undefined, "foreign-host connectionStatus.action.url is stripped", action);
   witness(ctx, !TIMEOUT_WORDING.test(String(own(envelope, "message") ?? "")), "foreign-host message contains no latency or timeout wording", own(envelope, "message"));
 }


### PR DESCRIPTION
## What

Makes Den's agent-facing MCP error results match opencode's contract philosophy: **the agent gets the provider's words, not our internal taxonomy.** The error taxonomy (phase/category/code/highestPassed/actionOwner/operatorAction/httpStatus/outbound/…) becomes a backend-only concept — it keeps powering server logs, org routes, and the dashboard, but no longer ships to agents.

Agent-facing `execute_capability` failures now carry:

```
error            — coarse kind (needs_connection | provider_error | connection_failed | invalid_capability_arguments)
message          — honest prose incl. operator guidance + "Diagnostic reference: <id>." (unchanged composition, no info loss)
referenceId      — support handle (new top-level)
retryable        — decision hint (new top-level)
providerError    — { jsonRpcCode?, message?, data? } — the provider's own declaration, sanitized/capped/untrusted-labeled
connectionStatus — unchanged product concept (needs_signin etc.) with the host-bound action.url; no embedded diagnostic
```

Removed from the agent surface: the `diagnostic` object and top-level `actionOwner`/`operatorAction` (their content remains in `message` prose).

## Why

- Models reason better from the provider's actual error than from our enum machinery; the taxonomy in agent context invited jargon-parroting and consumed tokens.
- Agents should branch on the coarse `error` kind + `connectionStatus` — the API we want to commit to — not on internal codes that must stay free to evolve.
- Follows #2934: pass-through of provider-declared evidence stays; safety contract (host-bound actionable links, sanitization, bounded excerpts) stays; org routes/dashboard keep full diagnostics (verified: `routes/org/mcp-connections.ts` untouched, no consumer of the embedded connectionStatus diagnostic outside the agent surface).

## Tests

From `ee/apps/den-api`:
- `bun test test/external-mcp-diagnostics.test.ts test/external-mcp-tool-inspection.test.ts test/external-capability-errors.test.ts test/mcp-agent-timeouts.test.ts test/external-capabilities-search-divergence.test.ts` → **132 pass / 0 fail (471 expect)**
- `pnpm exec tsc --noEmit` → clean
- New assertions: needs_connection results expose `referenceId`/`retryable:false`/`providerError`/host-bound `connectionStatus.action.url` and contain **no** `diagnostic`/`actionOwner`/`operatorAction` keys; provider-declared unknown codes expose the `providerError` trio; eval flow `den-provider-auth-relay.flow.mjs` assertions updated to the new contract.

No fraimz: agent-payload contract change covered by the updated eval flow assertions + unit fixtures above; repro commands included.
