### PR TITLE
fix(server): heal stale engine-MCP registration evidence and report it honestly

### DIFF
--- a/apps/app/src/app/lib/diagnostics-bundle.ts
+++ b/apps/app/src/app/lib/diagnostics-bundle.ts
@@ -84,6 +84,7 @@ function pickEngineInfo(info: EngineInfo | null) {
   return {
     running: info.running,
     runtime: info.runtime,
+    managedByServer: info.managedByServer,
     baseUrl: info.baseUrl,
     projectDir: info.projectDir,
     hostname: info.hostname,

--- a/apps/app/tests/diagnostics-bundle.test.ts
+++ b/apps/app/tests/diagnostics-bundle.test.ts
@@ -66,6 +66,7 @@ describe("diagnostics bundle", () => {
     input.engineInfo = {
       running: true,
       runtime: "direct",
+      managedByServer: true,
       baseUrl: "http://127.0.0.1:4097",
       projectDir: "/tmp/openwork",
       hostname: "127.0.0.1",

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -871,6 +871,7 @@ function envFlagEnabled(name) {
 const IDLE_ENGINE_INFO = Object.freeze({
   running: false,
   runtime: "direct",
+  managedByServer: false,
   baseUrl: null,
   projectDir: null,
   hostname: null,

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -112,17 +112,30 @@ function createEngineState() {
     opencodePassword: null,
     opencodeBinPath: null,
     opencodeBinSource: null,
+    managedByServer: false,
+    managedPid: null,
+    managedIsAlive: null,
     lastStdout: null,
     lastStderr: null,
     execution: null,
   };
 }
 
-function snapshotEngineState(state) {
+export function snapshotEngineState(state) {
   const child = state.childExited ? null : state.child;
+  let managedRunning = false;
+  if (state.managedByServer && typeof state.managedIsAlive === "function") {
+    try {
+      managedRunning = state.managedIsAlive() === true;
+    } catch {
+      managedRunning = false;
+    }
+  }
+  const childRunning = Boolean(child && child.exitCode === null && !child.killed);
   return {
-    running: Boolean(child && child.exitCode === null && !child.killed),
+    running: managedRunning || childRunning,
     runtime: state.runtime,
+    managedByServer: state.managedByServer === true,
     baseUrl: state.baseUrl,
     projectDir: state.projectDir,
     hostname: state.hostname,
@@ -131,7 +144,7 @@ function snapshotEngineState(state) {
     opencodePassword: state.opencodePassword,
     opencodeBinPath: state.opencodeBinPath,
     opencodeBinSource: state.opencodeBinSource,
-    pid: child?.pid ?? null,
+    pid: state.managedByServer ? state.managedPid ?? null : child?.pid ?? null,
     lastStdout: state.lastStdout,
     lastStderr: state.lastStderr,
     execution: state.execution,
@@ -1221,6 +1234,9 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     });
     inProcessServer = handle;
     openworkServerState.managedOpencodeExecution = handle.managedOpencodeExecution ?? null;
+    engineState.managedByServer = Boolean(handle.managedOpencode);
+    engineState.managedPid = handle.managedOpencode?.pid ?? null;
+    engineState.managedIsAlive = handle.managedOpencode?.isAlive ?? null;
 
     const boundPort = handle.port;
     const baseUrl = handle.url;
@@ -1368,6 +1384,9 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     engineState.opencodePassword = password;
     engineState.opencodeBinPath = opencodeBinary.path;
     engineState.opencodeBinSource = opencodeBinary.source;
+    engineState.managedByServer = false;
+    engineState.managedPid = null;
+    engineState.managedIsAlive = null;
 
     return snapshotEngineState(engineState);
   }
@@ -1410,6 +1429,9 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     engineState.opencodePassword = password;
     engineState.opencodeBinPath = opencodeBinary.path;
     engineState.opencodeBinSource = opencodeBinary.source;
+    engineState.managedByServer = false;
+    engineState.managedPid = null;
+    engineState.managedIsAlive = null;
 
     await waitForHttpOk(`${engineState.baseUrl}/health`, 10_000).catch(() => undefined);
     return snapshotEngineState(engineState);

--- a/apps/desktop/electron/runtime.test.mjs
+++ b/apps/desktop/electron/runtime.test.mjs
@@ -12,6 +12,7 @@ import {
   resolveOpenworkServerConfigPath,
   seedWorkspacePathsForEmbeddedServer,
   selectStickyOpenworkPortWorkspace,
+  snapshotEngineState,
 } from "./runtime.mjs";
 
 describe("prioritizeWorkspacePaths", () => {
@@ -141,5 +142,32 @@ describe("resolveOpenworkServerConfigPath", () => {
       resolveOpenworkServerConfigPath({ XDG_CONFIG_HOME: "/tmp/xdg" }),
       "/tmp/xdg/openwork/server.json",
     );
+  });
+});
+
+describe("snapshotEngineState", () => {
+  it("reports server-managed OpenCode liveness and pid without a child handle", () => {
+    const snapshot = snapshotEngineState({
+      child: null,
+      childExited: false,
+      runtime: "direct",
+      projectDir: "/workspace/current",
+      hostname: "127.0.0.1",
+      port: 4097,
+      baseUrl: "http://127.0.0.1:4097",
+      opencodeUsername: null,
+      opencodePassword: null,
+      opencodeBinPath: null,
+      opencodeBinSource: null,
+      managedByServer: true,
+      managedPid: 12345,
+      managedIsAlive: () => true,
+      lastStdout: null,
+      lastStderr: null,
+      execution: null,
+    });
+    assert.equal(snapshot.running, true);
+    assert.equal(snapshot.managedByServer, true);
+    assert.equal(snapshot.pid, 12345);
   });
 });

--- a/apps/server/src/agent-context-diagnostics-schema.ts
+++ b/apps/server/src/agent-context-diagnostics-schema.ts
@@ -165,6 +165,13 @@ const safeTextSchema = z.string()
     isAgentContextDiagnosticTextSafe,
     "diagnostic text cannot contain controls, credentials, URLs, or absolute paths",
   );
+const registrationFailureDetailSchema = z.object({
+  name: safeTextSchema.min(1).max(160),
+  status: z.enum(["connected", "disabled", "failed", "needs-auth", "needs-client-registration", "not-recorded"]),
+  source: z.enum(["transport_failure", "engine_status"]).nullable(),
+  recordAgeMs: z.number().int().nonnegative().nullable(),
+  engineReachableNow: z.boolean(),
+}).strict();
 const organizationConnectionNameSchema = z.string()
   .min(1)
   .max(160)
@@ -179,6 +186,7 @@ const safeDetailValueSchema = z.union([
   z.boolean(),
   z.null(),
   z.array(safeTextSchema).max(100),
+  z.array(registrationFailureDetailSchema).max(100),
 ]);
 const toolIdSchema = z.string().min(1).max(160).regex(/^[A-Za-z][A-Za-z0-9_.:-]*$/);
 

--- a/apps/server/src/agent-context-diagnostics.test.ts
+++ b/apps/server/src/agent-context-diagnostics.test.ts
@@ -1164,6 +1164,64 @@ describe("agent context diagnostics analyzer", () => {
     expect(fetchCalls).toEqual([]);
   });
 
+  test("downgrades stale failed registration evidence when the engine is reachable", async () => {
+    const fixture = await createFixture();
+    const fetchCalls: CatalogFetchCall[] = [];
+    const report = await runAgentContextDiagnostics({
+      config: fixture.config,
+      workspace: fixture.workspace,
+      request: emptyObservedRequest,
+      inspectRegistration: () => ({
+        status: "failed",
+        source: "transport_failure",
+        recordAgeMs: 61_000,
+      }),
+      dependencies: {
+        fetchImpl: catalogFetch(["search_capabilities", "execute_capability"], fetchCalls),
+        inspectEffectiveEngine: effectiveEngineInspection(),
+      },
+    });
+
+    const check = checkById(report, "engine-mcp-sync");
+    expect(check).toMatchObject({
+      status: "warning",
+      code: "mcp_registration_stale_failure",
+      details: { engineReachableNow: true, failedCount: 3 },
+    });
+    expect(check.details.failedRegistrations).toEqual([
+      { name: "openwork-cloud", status: "failed", source: "transport_failure", recordAgeMs: 61_000, engineReachableNow: true },
+      { name: "non-cloud-canary", status: "failed", source: "transport_failure", recordAgeMs: 61_000, engineReachableNow: true },
+      { name: "[redacted-sensitive-label]", status: "failed", source: "transport_failure", recordAgeMs: 61_000, engineReachableNow: true },
+    ]);
+    expect(fetchCalls).toEqual([]);
+  });
+
+  test("keeps fresh failed registration evidence as a failed check", async () => {
+    const fixture = await createFixture();
+    const fetchCalls: CatalogFetchCall[] = [];
+    const report = await runAgentContextDiagnostics({
+      config: fixture.config,
+      workspace: fixture.workspace,
+      request: emptyObservedRequest,
+      inspectRegistration: () => ({
+        status: "failed",
+        source: "engine_status",
+        recordAgeMs: 1_000,
+      }),
+      dependencies: {
+        fetchImpl: catalogFetch(["search_capabilities", "execute_capability"], fetchCalls),
+        inspectEffectiveEngine: effectiveEngineInspection(),
+      },
+    });
+
+    expect(checkById(report, "engine-mcp-sync")).toMatchObject({
+      status: "failed",
+      code: "mcp_registration_not_connected",
+      details: { engineReachableNow: true, failedCount: 3 },
+    });
+    expect(fetchCalls).toEqual([]);
+  });
+
   test("reports a missing credential without putting authorization-shaped text in the report", async () => {
     const runtime = diagnosticRuntimeConfig();
     if (!runtime.mcp) throw new Error("Expected the diagnostics MCP fixture.");

--- a/apps/server/src/agent-context-diagnostics.ts
+++ b/apps/server/src/agent-context-diagnostics.ts
@@ -63,10 +63,24 @@ export type McpRegistrationStatus =
   | "needs-auth"
   | "needs-client-registration"
   | "not-recorded";
+export type McpRegistrationSource = "transport_failure" | "engine_status";
+export type McpRegistrationInspection = {
+  status: McpRegistrationStatus;
+  source?: McpRegistrationSource | null;
+  recordAgeMs?: number | null;
+};
 export type InspectMcpRegistration = (
   name: string,
   config: Record<string, unknown>,
-) => McpRegistrationStatus;
+) => McpRegistrationStatus | McpRegistrationInspection;
+
+type FailedRegistrationDetail = {
+  name: string;
+  status: McpRegistrationStatus;
+  source: McpRegistrationSource | null;
+  recordAgeMs: number | null;
+  engineReachableNow: boolean;
+};
 
 type ProjectAgentInspection = {
   available: boolean;
@@ -379,9 +393,22 @@ function cloudTerminalPathEvidence(
   }
 }
 
+function normalizeRegistrationInspection(
+  value: McpRegistrationStatus | McpRegistrationInspection,
+): McpRegistrationInspection {
+  if (typeof value === "string") return { status: value, source: null, recordAgeMs: null };
+  return {
+    status: value.status,
+    source: value.source ?? null,
+    recordAgeMs: typeof value.recordAgeMs === "number" && Number.isFinite(value.recordAgeMs)
+      ? Math.max(0, Math.round(value.recordAgeMs))
+      : null,
+  };
+}
+
 function mcpEvidence(
   item: DiagnosticMcpItem,
-  registration: InspectMcpRegistration,
+  syncStatus: AgentContextMcpEvidence["syncStatus"],
   managedMcpNames: ReadonlySet<string>,
 ): AgentContextMcpEvidence {
   const type = mcpType(item.config);
@@ -395,9 +422,7 @@ function mcpEvidence(
     path: cloudTerminalPathEvidence(item.name, item.source, item.config),
     hasHeaders: isRecord(item.config.headers) && Object.keys(item.config.headers).length > 0,
     oauthMode: mcpOauthMode(type, item.config),
-    syncStatus: item.source === "config.remote" && managedMcpNames.has(item.name)
-      ? registration(item.name, item.config)
-      : "not-applicable",
+    syncStatus: item.source === "config.remote" && managedMcpNames.has(item.name) ? syncStatus : "not-applicable",
     liveEngineStatus: "unavailable",
   };
 }
@@ -1011,7 +1036,17 @@ export async function runAgentContextDiagnostics(input: {
     inventoryItems[199] = runtimeCloudItem;
   }
   const managedMcpNames = new Set(Object.keys(runtimeMcpMap(runtime)));
-  const mcps = inventoryItems.map((item) => mcpEvidence(item, input.inspectRegistration, managedMcpNames));
+  const registrationByItem = new Map<DiagnosticMcpItem, McpRegistrationInspection>();
+  const registrationForItem = (item: DiagnosticMcpItem): McpRegistrationInspection => {
+    const existing = registrationByItem.get(item);
+    if (existing) return existing;
+    const inspection: McpRegistrationInspection = item.source === "config.remote" && managedMcpNames.has(item.name)
+      ? normalizeRegistrationInspection(input.inspectRegistration(item.name, item.config))
+      : { status: "not-recorded", source: null, recordAgeMs: null };
+    registrationByItem.set(item, inspection);
+    return inspection;
+  };
+  const mcps = inventoryItems.map((item) => mcpEvidence(item, registrationForItem(item).status, managedMcpNames));
   const runtimeCloudConfig = runtimeMcpMap(runtime)[OPENWORK_CLOUD_MCP_NAME] ?? null;
   const staticallyDeniedCloudAgentToolIds = new Set(inventory.toolPolicy.deniedToolIds);
   const effectiveToolPolicy = assessEffectiveToolPolicy(effectiveEngine);
@@ -1058,8 +1093,8 @@ export async function runAgentContextDiagnostics(input: {
       : staticallyDeniedCloudAgentToolIds.size > 0
         ? "passive-static-subset"
         : "unavailable",
-    registrationStatus: runtimeCloudConfig
-      ? input.inspectRegistration(OPENWORK_CLOUD_MCP_NAME, runtimeCloudConfig)
+    registrationStatus: runtimeCloudItem && runtimeCloudConfig
+      ? registrationForItem(runtimeCloudItem).status
       : "not-recorded",
     requestId: runId,
     fetchImpl,
@@ -1069,22 +1104,47 @@ export async function runAgentContextDiagnostics(input: {
   input.dependencies?.signal?.throwIfAborted();
 
   const remoteMcps = inventory.items.filter((item) => item.source === "config.remote");
-  const registrationStatuses = remoteMcps.map((item) => input.inspectRegistration(item.name, item.config));
+  const engineReachableNow = engineInspectionStatus === "observed" || engineInspectionStatus === "invalid";
+  const registrationInspections = remoteMcps.map((item) => registrationForItem(item));
   const enabledRemoteMcps = remoteMcps.filter((item) => item.config.enabled !== false);
   const disabledRemoteMcps = remoteMcps.filter((item) => item.config.enabled === false);
-  const enabledRegistrationStatuses = enabledRemoteMcps.map(
-    (item) => input.inspectRegistration(item.name, item.config),
-  );
-  const disabledRegistrationStatuses = disabledRemoteMcps.map(
-    (item) => input.inspectRegistration(item.name, item.config),
-  );
+  const enabledRegistrationInspections = enabledRemoteMcps.map((item) => registrationForItem(item));
+  const disabledRegistrationInspections = disabledRemoteMcps.map((item) => registrationForItem(item));
+  const enabledRegistrationStatuses = enabledRegistrationInspections.map((inspection) => inspection.status);
+  const disabledRegistrationStatuses = disabledRegistrationInspections.map((inspection) => inspection.status);
   const connectedRegistrationCount = enabledRegistrationStatuses.filter((status) => status === "connected").length;
   const missingRegistrationCount = enabledRegistrationStatuses.filter((status) => status === "not-recorded").length;
-  const failedRegistrationCount = enabledRegistrationStatuses.filter(
-    (status) => status !== "connected" && status !== "not-recorded",
-  ).length + disabledRegistrationStatuses.filter(
-    (status) => status !== "disabled" && status !== "not-recorded",
-  ).length;
+  const enabledFailedRegistrationDetails = enabledRemoteMcps.flatMap((item): FailedRegistrationDetail[] => {
+    const inspection = registrationForItem(item);
+    if (inspection.status === "connected" || inspection.status === "not-recorded") return [];
+    return [{
+      name: safeText(item.name, 160, "unnamed-mcp"),
+      status: inspection.status,
+      source: inspection.source ?? null,
+      recordAgeMs: inspection.recordAgeMs ?? null,
+      engineReachableNow,
+    }];
+  });
+  const disabledFailedRegistrationDetails = disabledRemoteMcps.flatMap((item): FailedRegistrationDetail[] => {
+    const inspection = registrationForItem(item);
+    if (inspection.status === "disabled" || inspection.status === "not-recorded") return [];
+    return [{
+      name: safeText(item.name, 160, "unnamed-mcp"),
+      status: inspection.status,
+      source: inspection.source ?? null,
+      recordAgeMs: inspection.recordAgeMs ?? null,
+      engineReachableNow,
+    }];
+  });
+  const failedRegistrationDetails = [
+    ...enabledFailedRegistrationDetails,
+    ...disabledFailedRegistrationDetails,
+  ];
+  const failedRegistrationCount = failedRegistrationDetails.length;
+  const staleRegistrationFailure = failedRegistrationDetails.length > 0
+    && failedRegistrationDetails.every((failure) =>
+      failure.engineReachableNow && failure.recordAgeMs !== null && failure.recordAgeMs > 60_000,
+    );
   const layerHealthProblem = inventory.layerStatus.project === "invalid"
     || inventory.layerStatus.project === "unreadable"
     || inventory.layerStatus.global === "invalid"
@@ -1379,7 +1439,7 @@ export async function runAgentContextDiagnostics(input: {
     diagnosticCheck({
       id: "engine-mcp-sync",
       status: failedRegistrationCount > 0
-        ? "failed"
+        ? staleRegistrationFailure ? "warning" : "failed"
         : missingRegistrationCount > 0
           ? "warning"
           : remoteMcps.length > 0
@@ -1387,14 +1447,16 @@ export async function runAgentContextDiagnostics(input: {
             : "skipped",
       evidenceKind: "derived",
       code: failedRegistrationCount > 0
-        ? "mcp_registration_not_connected"
+        ? staleRegistrationFailure ? "mcp_registration_stale_failure" : "mcp_registration_not_connected"
         : missingRegistrationCount > 0
           ? "mcp_registration_not_recorded"
           : remoteMcps.length > 0
             ? "managed_mcp_registration_states_healthy"
             : "no_managed_mcp_registration",
       message: failedRegistrationCount > 0
-        ? "One or more enabled managed MCPs are not connected, or a disabled managed MCP has an unexpected engine state."
+        ? staleRegistrationFailure
+          ? "Managed MCP registration failure evidence is stale while the engine is reachable."
+          : "One or more enabled managed MCPs are not connected, or a disabled managed MCP has an unexpected engine state."
         : missingRegistrationCount > 0
           ? "One or more enabled managed MCPs do not have a current engine registration record."
           : remoteMcps.length > 0
@@ -1402,20 +1464,24 @@ export async function runAgentContextDiagnostics(input: {
             : "No server-managed MCP registration was available to inspect.",
       owner: failedRegistrationCount > 0 || missingRegistrationCount > 0 ? "opencode-engine" : "openwork-server",
       action: failedRegistrationCount > 0 || missingRegistrationCount > 0
-        ? "Start or repair the workspace runtime and rerun diagnostics."
+        ? staleRegistrationFailure
+          ? "The engine is reachable and this evidence is stale; rerun diagnostics. No repair is needed unless it persists."
+          : "Start or repair the workspace runtime and rerun diagnostics."
         : "No action is required.",
       details: {
         managedMcpCount: remoteMcps.length,
         enabledManagedMcpCount: enabledRemoteMcps.length,
         disabledManagedMcpCount: disabledRemoteMcps.length,
         connectedCount: connectedRegistrationCount,
-        disabledCount: registrationStatuses.filter((status) => status === "disabled").length,
+        disabledCount: registrationInspections.filter((inspection) => inspection.status === "disabled").length,
         failedCount: failedRegistrationCount,
-        needsAuthCount: registrationStatuses.filter((status) => status === "needs-auth").length,
-        needsClientRegistrationCount: registrationStatuses.filter(
-          (status) => status === "needs-client-registration",
+        needsAuthCount: registrationInspections.filter((inspection) => inspection.status === "needs-auth").length,
+        needsClientRegistrationCount: registrationInspections.filter(
+          (inspection) => inspection.status === "needs-client-registration",
         ).length,
         notRecordedCount: missingRegistrationCount,
+        engineReachableNow,
+        failedRegistrations: failedRegistrationDetails,
         registrationConnectionEvidenceClaimed: connectedRegistrationCount > 0,
         completeLiveToolRegistryClaimed: false,
       },

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -138,6 +138,14 @@ export type CloudMcpRuntimeRegistrar = (
   options?: { throwOnFailure?: boolean },
 ) => Promise<CloudMcpRuntimeRegistrationResult>;
 
+export type CloudMcpLiveStatusObserver = (
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  name: string,
+  mcpConfig: Record<string, unknown>,
+  status: string,
+) => void;
+
 export type CloudMcpServerMetadata = {
   serverVersion?: string;
   expectedOpencodeVersion?: string;
@@ -1517,10 +1525,13 @@ async function readOpencodeVersion(opencode: WorkspaceOpencodeClient): Promise<C
 
 async function inspectOpenworkCloud(input: {
   opencode: WorkspaceOpencodeClient;
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
   directory: string | null;
   desiredConfig: Record<string, unknown>;
   providerModel?: CloudMcpProviderModelContext;
   probe: boolean;
+  refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
 }): Promise<Inspection> {
   const failures: CloudMcpFailure[] = [];
   const emptyTools = splitPresentMissing([], expectedTools());
@@ -1546,6 +1557,15 @@ async function inspectOpenworkCloud(input: {
   }
 
   const cloudStatus = statusResult.data?.[OPENWORK_CLOUD_MCP_NAME];
+  if (cloudStatus) {
+    input.refreshRegistrationFromLiveStatus?.(
+      input.config,
+      input.workspace,
+      OPENWORK_CLOUD_MCP_NAME,
+      input.desiredConfig,
+      cloudStatus.status,
+    );
+  }
   const engine = engineStatusFromMcpStatus(cloudStatus);
   if (cloudStatus?.status !== "connected") {
     failures.push(statusFailure(cloudStatus));
@@ -1795,6 +1815,7 @@ export async function readOpenworkCloudMcpHealth(input: {
   serverMetadata?: CloudMcpServerMetadata;
   probe?: boolean;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
+  refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
 }): Promise<CloudMcpHealth> {
   const checkedAt = new Date().toISOString();
   const desired = await readDesiredState({ config: input.config, workspace: input.workspace, directory: input.directory });
@@ -1852,10 +1873,13 @@ export async function readOpenworkCloudMcpHealth(input: {
   if (desired.present && desired.config && !desired.validationProblem && input.directory && baseUrlConfigured(input.config, input.workspace)) {
     inspection = await inspectOpenworkCloud({
       opencode: input.createWorkspaceOpencodeClient(input.config, input.workspace),
+      config: input.config,
+      workspace: input.workspace,
       directory: input.directory,
       desiredConfig: desired.config,
       providerModel: input.providerModel,
       probe: input.probe === true,
+      refreshRegistrationFromLiveStatus: input.refreshRegistrationFromLiveStatus,
     });
     failures.push(...inspection.failures);
   }
@@ -1960,7 +1984,11 @@ async function wait(ms: number): Promise<void> {
 
 async function pollConnected(input: {
   opencode: WorkspaceOpencodeClient;
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
   directory: string | null;
+  desiredConfig: Record<string, unknown>;
+  refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
 }): Promise<CloudMcpFailure | null> {
   let lastFailure: CloudMcpFailure | null = null;
   for (const delay of POLL_DELAYS_MS) {
@@ -1971,6 +1999,15 @@ async function pollConnected(input: {
       continue;
     }
     const cloudStatus = statusResult.data?.[OPENWORK_CLOUD_MCP_NAME];
+    if (cloudStatus) {
+      input.refreshRegistrationFromLiveStatus?.(
+        input.config,
+        input.workspace,
+        OPENWORK_CLOUD_MCP_NAME,
+        input.desiredConfig,
+        cloudStatus.status,
+      );
+    }
     if (cloudStatus?.status === "connected") return null;
     lastFailure = statusFailure(cloudStatus);
     if (cloudStatus?.status === "disabled" || cloudStatus?.status === "needs_auth" || cloudStatus?.status === "needs_client_registration" || cloudStatus?.status === "failed") {
@@ -1999,6 +2036,7 @@ export async function reconcileOpenworkCloudMcp(input: {
   serverMetadata?: CloudMcpServerMetadata;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   registerRuntimeMcp: CloudMcpRuntimeRegistrar;
+  refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
 }): Promise<CloudMcpHealth> {
   const readHealth = () => readOpenworkCloudMcpHealth({
     config: input.config,
@@ -2008,6 +2046,7 @@ export async function reconcileOpenworkCloudMcp(input: {
     serverMetadata: input.serverMetadata,
     createWorkspaceOpencodeClient: input.createWorkspaceOpencodeClient,
     probe: true,
+    refreshRegistrationFromLiveStatus: input.refreshRegistrationFromLiveStatus,
   });
   const configBody = input.body.config ?? input.body;
   const desiredConfig = canonicalizeCloudMcpConfig(normalizeCloudMcpConfig(configBody));
@@ -2054,7 +2093,14 @@ export async function reconcileOpenworkCloudMcp(input: {
   }
 
   const opencode = input.createWorkspaceOpencodeClient(input.config, input.workspace);
-  const connectedFailure = await pollConnected({ opencode, directory: input.directory });
+  const connectedFailure = await pollConnected({
+    opencode,
+    config: input.config,
+    workspace: input.workspace,
+    directory: input.directory,
+    desiredConfig,
+    refreshRegistrationFromLiveStatus: input.refreshRegistrationFromLiveStatus,
+  });
   if (connectedFailure) {
     cloudMcpDeliveryState.markFailed(input.workspace, input.directory, desiredRevision, connectedFailure);
     return healthWithFailure(await readHealth(), connectedFailure);
@@ -2078,6 +2124,7 @@ export async function reconcilePersistedOpenworkCloudMcp(input: {
   serverMetadata?: CloudMcpServerMetadata;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   registerRuntimeMcp: CloudMcpRuntimeRegistrar;
+  refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
   trigger?: string;
 }): Promise<CloudMcpHealth> {
   const runtimeConfig = await readRuntimeOpencodeConfig(input.config, input.workspace.id);

--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -5,7 +5,7 @@ import { join } from "node:path";
 
 import { OPENWORK_CLOUD_EXPECTED_TOOLS, OPENWORK_CLOUD_PLUGIN_CANARIES, cloudMcpDeliveryState } from "./cloud-mcp-health.js";
 import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
-import { startServer } from "./server.js";
+import { inspectEngineMcpRegistration, registerTrustedOpencodeProcess, startServer } from "./server.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
 
 type EngineRequest = {
@@ -24,6 +24,7 @@ type MockOpencodeOptions = {
   providerModelExists?: boolean;
   unsupportedToolIds?: boolean;
   initialConnected?: boolean;
+  connectAfterStatusReads?: number;
   hangHealth?: boolean;
   delayMcpStatusMs?: number;
   postFailure?: { status: number; body: unknown };
@@ -80,6 +81,7 @@ function allReadyToolIds(): string[] {
 function startMockOpencode(options: MockOpencodeOptions = {}) {
   const requests: EngineRequest[] = [];
   let registerCount = 0;
+  let statusReads = 0;
   const server = Bun.serve({
     hostname: "127.0.0.1",
     port: 0,
@@ -99,7 +101,11 @@ function startMockOpencode(options: MockOpencodeOptions = {}) {
         return Response.json({});
       }
       if (url.pathname === "/mcp" && request.method === "GET") {
+        statusReads += 1;
         if (options.delayMcpStatusMs) await new Promise((resolve) => setTimeout(resolve, options.delayMcpStatusMs));
+        if (options.connectAfterStatusReads && statusReads < options.connectAfterStatusReads) {
+          return Response.json({ "openwork-cloud": { status: "failed", error: "slow connect" } });
+        }
         return Response.json(registerCount > 0 || options.initialConnected ? { "openwork-cloud": { status: "connected" } } : {});
       }
       if (url.pathname === "/experimental/tool/ids") {
@@ -311,6 +317,34 @@ describe("openwork-cloud MCP strict reconcile", () => {
     const mcpPosts = mock.requests.filter((request) => request.method === "POST" && request.pathname === "/mcp");
     expect(mcpPosts.length).toBe(1);
     expectDirectoryQuery(mcpPosts[0]?.search, root);
+  });
+
+  test("live status read heals a failed registration record after reconcile returns early", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ connectAfterStatusReads: 2 });
+    const baseUrl = `http://127.0.0.1:${mock.server.port}`;
+    const openwork = await startOpenwork([workspace("ws_1", root, baseUrl)]);
+    registerTrustedOpencodeProcess(openwork.config, {
+      baseUrl,
+      identity: "cloud-reconcile-live-heal",
+      isAlive: () => true,
+    });
+
+    const response = await reconcile(openwork.base);
+    const body = await responseRecord(response);
+    expect(response.status).toBe(200);
+    expect(firstFailure(body).code).toBe("opencode_mcp_sync_failed");
+    expect(inspectEngineMcpRegistration(
+      openwork.config,
+      openwork.config.workspaces[0]!,
+      "openwork-cloud",
+      cloudConfigForOpenwork(openwork.base),
+    )).toBe("connected");
+
+    const health = await responseRecord(await getHealth(openwork.base));
+    expect(health.phase).toBe("ready");
+    expect(health.usable).toBe(true);
+    expect(mock.requests.filter((request) => request.method === "POST" && request.pathname === "/mcp").length).toBe(1);
   });
 
   test("rejects malformed desired config without persisting or registering it", async () => {

--- a/apps/server/src/connect-state.ts
+++ b/apps/server/src/connect-state.ts
@@ -5,6 +5,7 @@ import type { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 import {
   readOpenworkCloudMcpHealth,
   type CloudMcpHealth,
+  type CloudMcpLiveStatusObserver,
   type CloudMcpProviderModelContext,
   type CloudMcpServerMetadata,
 } from "./cloud-mcp-health.js";
@@ -59,6 +60,7 @@ export type ConnectSnapshotOptions = {
   serverMetadata?: CloudMcpServerMetadata;
   resolveOpencodeDirectory?: (workspace: WorkspaceInfo) => string | null;
   createWorkspaceOpencodeClient?: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
+  refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
 };
 
 export type ConnectSnapshotInspection = {
@@ -222,6 +224,7 @@ async function resolveCloudHealth(config: ServerConfig, options: ConnectSnapshot
     serverMetadata: options.serverMetadata,
     probe: false,
     createWorkspaceOpencodeClient: options.createWorkspaceOpencodeClient,
+    refreshRegistrationFromLiveStatus: options.refreshRegistrationFromLiveStatus,
   });
   return {
     cloudHealth,

--- a/apps/server/src/embedded.ts
+++ b/apps/server/src/embedded.ts
@@ -39,6 +39,8 @@ export type EmbeddedServerHandle = {
   config: ServerConfig;
   /** Redacted details for the managed OpenCode child process, when spawned. */
   managedOpencodeExecution: OpencodeExecutionSnapshot | null;
+  /** Liveness for the managed OpenCode child process, when spawned. */
+  managedOpencode: { pid: number | null; isAlive: () => boolean } | null;
   /** Stop the HTTP server and managed OpenCode (if any). */
   stop: () => Promise<void>;
 };
@@ -129,6 +131,9 @@ export async function startEmbeddedServer(options: EmbeddedServerOptions): Promi
     url: `http://${config.host === "0.0.0.0" ? "127.0.0.1" : config.host}:${server.port}`,
     config,
     managedOpencodeExecution: managedOpencode?.execution ?? null,
+    managedOpencode: managedOpencode
+      ? { pid: managedOpencode.pid ?? null, isAlive: managedOpencode.isAlive }
+      : null,
     async stop() {
       if (managedOpencodeIdentity) {
         clearTrustedOpencodeProcess(config, managedOpencodeIdentity);

--- a/apps/server/src/mcp.engine-sync.e2e.test.ts
+++ b/apps/server/src/mcp.engine-sync.e2e.test.ts
@@ -5,7 +5,9 @@ import { join } from "node:path";
 
 import {
   inspectEngineMcpRegistration,
+  inspectEngineMcpRegistrationDetails,
   registerTrustedOpencodeProcess,
+  refreshEngineMcpRegistrationFromLiveStatus,
   startServer,
   syncAllWorkspacesRuntimeMcpToEngine,
 } from "./server.js";
@@ -42,6 +44,7 @@ async function createWorkspaceRoot() {
 function startMockOpencode(options?: {
   failMcpNames?: string[];
   mcpStatusByName?: Record<string, unknown>;
+  liveMcpStatusByName?: () => Record<string, unknown>;
   mcpResponseForName?: (name: string) => Response | null;
   disposeResponse?: () => Response | null;
 }) {
@@ -69,6 +72,9 @@ function startMockOpencode(options?: {
           ? options?.mcpStatusByName?.[name]
           : "connected";
         return Response.json({ [name]: { status } });
+      }
+      if (url.pathname === "/mcp" && request.method === "GET") {
+        return Response.json(options?.liveMcpStatusByName?.() ?? {});
       }
       if (url.pathname.match(/^\/mcp\/[^/]+\/disconnect$/) && request.method === "POST") return Response.json({});
       return Response.json({ code: "not_found", message: "Not found" }, { status: 404 });
@@ -125,6 +131,19 @@ async function startOpenworkServer(
 
 function auth(token: string) {
   return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+async function waitForRegistration(
+  read: () => string,
+  expected: string,
+  timeoutMs = 1_000,
+): Promise<void> {
+  const startedAt = Date.now();
+  while (Date.now() - startedAt < timeoutMs) {
+    if (read() === expected) return;
+    await Bun.sleep(10);
+  }
+  expect(read()).toBe(expected);
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -256,6 +275,12 @@ describe("runtime MCP engine sync", () => {
       expect(inspectRegistration("connected", configs.get("connected")!)).toBe("connected");
       expect(inspectRegistration("disabled", configs.get("disabled")!)).toBe("disabled");
       expect(inspectRegistration("failed", configs.get("failed")!)).toBe("failed");
+      expect(inspectEngineMcpRegistrationDetails(
+        openwork.config,
+        openwork.config.workspaces[0]!,
+        "failed",
+        configs.get("failed")!,
+      ).source).toBe("engine_status");
       expect(inspectRegistration("auth", configs.get("auth")!)).toBe("needs-auth");
       expect(inspectRegistration(
         "client-registration",
@@ -263,6 +288,14 @@ describe("runtime MCP engine sync", () => {
       )).toBe("needs-client-registration");
       expect(inspectRegistration("invalid", configs.get("invalid")!)).toBe("not-recorded");
       expect(inspectRegistration("oversized", configs.get("oversized")!)).toBe("not-recorded");
+      expect(refreshEngineMcpRegistrationFromLiveStatus(
+        openwork.config,
+        openwork.config.workspaces[0]!,
+        "failed",
+        configs.get("failed")!,
+        "connected",
+      )).toBe(true);
+      expect(inspectRegistration("failed", configs.get("failed")!)).toBe("connected");
 
       const listResponse = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
         headers: auth(openwork.token),
@@ -284,6 +317,51 @@ describe("runtime MCP engine sync", () => {
     } finally {
       if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
       else process.env.OPENWORK_RUNTIME_DB = previousDb;
+    }
+  });
+
+  test("records transport-failure provenance and performs one deferred re-sync", async () => {
+    const workspaceRoot = await createWorkspaceRoot();
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    const previousDeferredDelay = process.env.OPENWORK_MCP_SYNC_DEFERRED_DELAY_MS;
+    process.env.OPENWORK_RUNTIME_DB = join(workspaceRoot, "runtime.sqlite");
+    process.env.OPENWORK_MCP_SYNC_DEFERRED_DELAY_MS = "50";
+    let posthogPosts = 0;
+    try {
+      const mock = startMockOpencode({
+        mcpResponseForName: (name) => {
+          if (name !== "posthog") return null;
+          posthogPosts += 1;
+          return posthogPosts <= 2
+            ? Response.json({ code: "temporarily_unavailable" }, { status: 503 })
+            : null;
+        },
+      });
+      const openwork = await startOpenworkServer(workspaceRoot, `http://127.0.0.1:${mock.server.port}`);
+      const workspace = openwork.config.workspaces[0]!;
+
+      const response = await fetch(`${openwork.base}/workspace/ws_1/mcp`, {
+        method: "POST",
+        headers: auth(openwork.token),
+        body: JSON.stringify({ name: "posthog", config: POSTHOG_CONFIG }),
+      });
+      expect(response.status).toBe(200);
+      expect(inspectEngineMcpRegistration(openwork.config, workspace, "posthog", POSTHOG_CONFIG)).toBe("failed");
+      expect(inspectEngineMcpRegistrationDetails(openwork.config, workspace, "posthog", POSTHOG_CONFIG).source)
+        .toBe("transport_failure");
+
+      await waitForRegistration(
+        () => inspectEngineMcpRegistration(openwork.config, workspace, "posthog", POSTHOG_CONFIG),
+        "connected",
+      );
+      expect(posthogPosts).toBe(3);
+      expect(inspectEngineMcpRegistrationDetails(openwork.config, workspace, "posthog", POSTHOG_CONFIG).source)
+        .toBe("engine_status");
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+      if (previousDeferredDelay === undefined) delete process.env.OPENWORK_MCP_SYNC_DEFERRED_DELAY_MS;
+      else process.env.OPENWORK_MCP_SYNC_DEFERRED_DELAY_MS = previousDeferredDelay;
     }
   });
 

--- a/apps/server/src/routes/cloud-mcp.ts
+++ b/apps/server/src/routes/cloud-mcp.ts
@@ -6,6 +6,7 @@ import {
   type CloudMcpServerMetadata,
   type CloudMcpProviderModelContext,
   type CloudMcpRuntimeRegistrar,
+  type CloudMcpLiveStatusObserver,
 } from "../cloud-mcp-health.js";
 import { ApiError } from "../errors.js";
 import type { ServerConfig, TokenScope, WorkspaceInfo } from "../types.js";
@@ -26,6 +27,7 @@ export type RegisterCloudMcpRoutesOptions = {
   resolveOpencodeDirectory: (workspace: WorkspaceInfo) => string | null;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   registerRuntimeMcp: CloudMcpRuntimeRegistrar;
+  refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
   serverMetadata?: CloudMcpServerMetadata;
 };
 
@@ -86,6 +88,7 @@ export function registerCloudMcpRoutes(options: RegisterCloudMcpRoutesOptions): 
     resolveOpencodeDirectory,
     createWorkspaceOpencodeClient,
     registerRuntimeMcp,
+    refreshRegistrationFromLiveStatus,
     serverMetadata,
   } = options;
 
@@ -100,6 +103,7 @@ export function registerCloudMcpRoutes(options: RegisterCloudMcpRoutesOptions): 
       serverMetadata,
       probe: probeFromQuery(ctx.url),
       createWorkspaceOpencodeClient,
+      refreshRegistrationFromLiveStatus,
     });
     return jsonResponse(health);
   });
@@ -123,6 +127,7 @@ export function registerCloudMcpRoutes(options: RegisterCloudMcpRoutesOptions): 
       serverMetadata,
       createWorkspaceOpencodeClient,
       registerRuntimeMcp,
+      refreshRegistrationFromLiveStatus,
     });
     return jsonResponse(health);
   });

--- a/apps/server/src/routes/core.ts
+++ b/apps/server/src/routes/core.ts
@@ -7,6 +7,7 @@ import {
   googleWorkspaceStatusConnectExtra,
   writeConnectState,
 } from "../connect-state.js";
+import type { CloudMcpLiveStatusObserver } from "../cloud-mcp-health.js";
 import { EnvStoreReadError, InvalidEnvKeyError, isValidEnvKey, type EnvService } from "../env-file.js";
 import { ApiError } from "../errors.js";
 import {
@@ -55,6 +56,7 @@ interface RegisterCoreRoutesOptions {
   resolveWorkspace: (config: ServerConfig, id: string) => Promise<WorkspaceInfo>;
   resolveOpencodeDirectory: (workspace: WorkspaceInfo) => string | null;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
+  refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
   serializeWorkspace: (workspace: ServerConfig["workspaces"][number]) => unknown;
   resolveToyUiEnabled: () => boolean;
   resolveDevLogPath: () => string | null;
@@ -112,6 +114,7 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
     resolveWorkspace,
     resolveOpencodeDirectory,
     createWorkspaceOpencodeClient,
+    refreshRegistrationFromLiveStatus,
     serializeWorkspace,
     resolveToyUiEnabled,
     resolveDevLogPath,
@@ -123,6 +126,7 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
   const connectSnapshotBaseOptions = {
     resolveOpencodeDirectory,
     createWorkspaceOpencodeClient,
+    refreshRegistrationFromLiveStatus,
     serverMetadata: { serverVersion, expectedOpencodeVersion: opencodeVersion },
   };
 

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1500,6 +1500,7 @@ function createRoutes(
     resolveWorkspace,
     resolveOpencodeDirectory,
     createWorkspaceOpencodeClient,
+    refreshRegistrationFromLiveStatus: refreshEngineMcpRegistrationFromLiveStatus,
     serializeWorkspace,
     resolveToyUiEnabled,
     resolveDevLogPath,
@@ -1547,6 +1548,7 @@ function createRoutes(
     resolveWorkspace,
     resolveOpencodeDirectory,
     createWorkspaceOpencodeClient,
+    refreshRegistrationFromLiveStatus: refreshEngineMcpRegistrationFromLiveStatus,
     registerRuntimeMcp: (routeConfig, workspace, onlyNames, options) =>
       syncRuntimeMcpToOpencodeEngine(
         routeConfig,
@@ -3334,6 +3336,7 @@ async function reloadOpencodeEngine(
       directory,
       serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
       createWorkspaceOpencodeClient,
+      refreshRegistrationFromLiveStatus: refreshEngineMcpRegistrationFromLiveStatus,
       registerRuntimeMcp: (routeConfig, routeWorkspace, onlyNames, options) =>
         syncRuntimeMcpToOpencodeEngine(
           routeConfig,
@@ -3359,7 +3362,7 @@ async function syncRuntimeMcpToOpencodeEngine(
   config: ServerConfig,
   workspace: WorkspaceInfo,
   onlyNames?: string[],
-  options?: { throwOnFailure?: boolean },
+  options?: { throwOnFailure?: boolean; deferred?: boolean },
   serverState?: EngineMcpServerState | null,
 ): Promise<EngineMcpSyncResult> {
   const activeState = activeEngineMcpServerState(config, serverState);
@@ -3368,6 +3371,7 @@ async function syncRuntimeMcpToOpencodeEngine(
   const connectionIdentity = engineMcpConnectionIdentity(config, workspace);
   const registrationIdentity = engineMcpRegistrationIdentity(config, workspace);
   if (activeState) reconcileEngineMcpWorkspaceIdentity(activeState, workspace.id, connectionIdentity);
+  if (activeState && !options?.deferred) cancelDeferredEngineMcpSync(activeState, workspace.id);
   if (!baseUrl || !connectionIdentity) {
     return { status: "skipped", syncedNames: [], failures: [] };
   }
@@ -3430,6 +3434,15 @@ async function syncRuntimeMcpToOpencodeEngine(
   );
 
   if (failures.length > 0) {
+    if (activeState && !options?.deferred && hasRetryableMcpSyncFailure(failures)) {
+      scheduleDeferredEngineMcpSync({
+        config,
+        state: activeState,
+        workspace,
+        connectionIdentity,
+        onlyNames,
+      });
+    }
     const names = failures.map((failure) => failure.name).join(", ");
     createServerLogger(config).log("warn", `Engine MCP sync failed for workspace ${workspace.id}: ${names}`, {
       "workspace.id": workspace.id,
@@ -3479,6 +3492,7 @@ async function postMcpEntryWithRetry(
         return {
           name,
           status,
+          source: status ? "engine_status" : null,
           failure: null,
         };
       }
@@ -3489,7 +3503,7 @@ async function postMcpEntryWithRetry(
         registrationStatus: "failed",
         message: "OpenCode rejected the MCP registration request",
       };
-      if (response.status < 500) return { name, status: "failed", failure };
+      if (response.status < 500) return { name, status: "failed", source: "transport_failure", failure };
     } catch {
       failure = {
         name,
@@ -3501,6 +3515,7 @@ async function postMcpEntryWithRetry(
   return {
     name,
     status: "failed",
+    source: "transport_failure",
     failure: failure ?? {
       name,
       registrationStatus: "failed",
@@ -3517,11 +3532,26 @@ export type EngineMcpRegistrationStatus =
   | "failed"
   | "needs-auth"
   | "needs-client-registration";
+export type EngineMcpRegistrationSource = "transport_failure" | "engine_status";
+
+export type EngineMcpRegistrationInspection = {
+  status: EngineMcpRegistrationStatus | "not-recorded";
+  source: EngineMcpRegistrationSource | null;
+  recordAgeMs: number | null;
+};
 
 type EngineMcpRegistrationResult = {
   name: string;
   status: EngineMcpRegistrationStatus | null;
+  source: EngineMcpRegistrationSource | null;
   failure: EngineMcpSyncFailure | null;
+};
+
+type EngineMcpDeferredSync = {
+  timer: ReturnType<typeof setTimeout>;
+  connectionIdentity: string;
+  generation: number;
+  onlyNames?: string[];
 };
 
 async function parseEngineMcpRegistrationStatus(
@@ -3544,11 +3574,15 @@ async function parseEngineMcpRegistrationStatus(
   if (!isRecord(body) || !Object.hasOwn(body, name)) return null;
   const entry = body[name];
   if (!isRecord(entry)) return null;
-  switch (entry.status) {
+  return normalizeEngineMcpRegistrationStatus(entry.status);
+}
+
+function normalizeEngineMcpRegistrationStatus(status: unknown): EngineMcpRegistrationStatus | null {
+  switch (status) {
     case "connected":
     case "disabled":
     case "failed":
-      return entry.status;
+      return status;
     case "needs_auth":
       return "needs-auth";
     case "needs_client_registration":
@@ -3597,6 +3631,71 @@ function engineMcpSyncRetryDelayMs(): number {
   return Number.isFinite(parsed) && parsed >= 0 ? parsed : 750;
 }
 
+function engineMcpDeferredSyncDelayMs(): number {
+  const parsed = Number(process.env.OPENWORK_MCP_SYNC_DEFERRED_DELAY_MS ?? "12000");
+  return Number.isFinite(parsed) && parsed >= 0 ? parsed : 12_000;
+}
+
+function hasRetryableMcpSyncFailure(failures: EngineMcpSyncFailure[]): boolean {
+  return failures.some((failure) => failure.status === undefined || failure.status >= 500);
+}
+
+function cancelDeferredEngineMcpSync(state: EngineMcpServerState, workspaceId: string): void {
+  const previous = state.deferredSyncByWorkspace.get(workspaceId);
+  if (!previous) return;
+  clearTimeout(previous.timer);
+  state.deferredSyncByWorkspace.delete(workspaceId);
+}
+
+function scheduleDeferredEngineMcpSync(input: {
+  config: ServerConfig;
+  state: EngineMcpServerState;
+  workspace: WorkspaceInfo;
+  connectionIdentity: string;
+  onlyNames?: string[];
+}): void {
+  cancelDeferredEngineMcpSync(input.state, input.workspace.id);
+  const generation = input.state.generation;
+  const onlyNames = input.onlyNames ? [...input.onlyNames] : undefined;
+  const timer = setTimeout(() => {
+    const state = activeEngineMcpServerState(input.config, input.state);
+    if (!state || state.generation !== generation) return;
+    const current = state.deferredSyncByWorkspace.get(input.workspace.id);
+    if (!current || current.generation !== generation) return;
+    state.deferredSyncByWorkspace.delete(input.workspace.id);
+    if (engineMcpConnectionIdentity(input.config, input.workspace) !== input.connectionIdentity) return;
+    if (state.syncStateByWorkspace.get(input.workspace.id)?.status === "ok") return;
+    createServerLogger(input.config).log(
+      "info",
+      `Running deferred engine MCP sync for workspace ${input.workspace.id}.`,
+      { "workspace.id": input.workspace.id },
+    );
+    void syncRuntimeMcpToOpencodeEngine(
+      input.config,
+      input.workspace,
+      current.onlyNames,
+      { throwOnFailure: false, deferred: true },
+      state,
+    ).catch((error) => {
+      createServerLogger(input.config).log(
+        "warn",
+        `Deferred engine MCP sync failed for workspace ${input.workspace.id}.`,
+        {
+          "workspace.id": input.workspace.id,
+          "mcp.failure.code": "deferred_runtime_mcp_sync_failed",
+          "mcp.failure.message": error instanceof Error ? error.message : String(error),
+        },
+      );
+    });
+  }, engineMcpDeferredSyncDelayMs());
+  input.state.deferredSyncByWorkspace.set(input.workspace.id, {
+    timer,
+    connectionIdentity: input.connectionIdentity,
+    generation,
+    ...(onlyNames ? { onlyNames } : {}),
+  });
+}
+
 export type EngineMcpSyncFailure = {
   name: string;
   status?: number;
@@ -3613,6 +3712,7 @@ export type EngineMcpSyncState = { status: "ok" | "failed"; at: number; failures
 type EngineMcpRegistrationRecord = {
   fingerprint: string;
   status: EngineMcpRegistrationStatus;
+  source: EngineMcpRegistrationSource;
   registrationIdentity: string;
   generation: number;
   recordedAt: number;
@@ -3630,6 +3730,7 @@ type EngineMcpServerState = {
   syncStateByWorkspace: Map<string, EngineMcpSyncState>;
   registrationByWorkspace: Map<string, Map<string, EngineMcpRegistrationRecord>>;
   engineIdentityByWorkspace: Map<string, string>;
+  deferredSyncByWorkspace: Map<string, EngineMcpDeferredSync>;
 };
 
 const ENGINE_MCP_REGISTRATION_MAX_AGE_MS = 15 * 60_000;
@@ -3654,9 +3755,11 @@ function normalizedOpencodeProcessEndpoint(baseUrl: string): string | null {
 }
 
 function clearEngineMcpServerEvidence(state: EngineMcpServerState): void {
+  for (const deferred of state.deferredSyncByWorkspace.values()) clearTimeout(deferred.timer);
   state.syncStateByWorkspace.clear();
   state.registrationByWorkspace.clear();
   state.engineIdentityByWorkspace.clear();
+  state.deferredSyncByWorkspace.clear();
 }
 
 /**
@@ -3710,6 +3813,7 @@ function beginEngineMcpServerState(config: ServerConfig): EngineMcpServerState {
     syncStateByWorkspace: new Map(),
     registrationByWorkspace: new Map(),
     engineIdentityByWorkspace: new Map(),
+    deferredSyncByWorkspace: new Map(),
   };
   engineMcpServerStateByConfig.set(config, state);
   return state;
@@ -3733,9 +3837,12 @@ function invalidateEngineMcpServerState(config: ServerConfig, state: EngineMcpSe
 }
 
 function invalidateEngineMcpWorkspace(state: EngineMcpServerState, workspaceId: string): void {
+  const deferred = state.deferredSyncByWorkspace.get(workspaceId);
+  if (deferred) clearTimeout(deferred.timer);
   state.syncStateByWorkspace.delete(workspaceId);
   state.registrationByWorkspace.delete(workspaceId);
   state.engineIdentityByWorkspace.delete(workspaceId);
+  state.deferredSyncByWorkspace.delete(workspaceId);
 }
 
 function reconcileEngineMcpWorkspaceIdentity(
@@ -3921,17 +4028,18 @@ function recordEngineMcpSyncResult(
   const registrations = result.replace
     ? new Map<string, EngineMcpRegistrationRecord>()
     : new Map(state.registrationByWorkspace.get(workspaceId) ?? []);
-  const statusByName = new Map(result.registrations?.map((registration) => [registration.name, registration.status]));
+  const registrationByName = new Map(result.registrations?.map((registration) => [registration.name, registration]));
   for (const [name, mcpConfig] of result.entries) {
     const fingerprint = mcpRegistrationFingerprint(mcpConfig);
-    const status = statusByName.get(name);
-    if (fingerprint === null || !status) {
+    const registration = registrationByName.get(name);
+    if (fingerprint === null || !registration?.status || !registration.source) {
       registrations.delete(name);
       continue;
     }
     registrations.set(name, {
       fingerprint,
-      status,
+      status: registration.status,
+      source: registration.source,
       registrationIdentity,
       generation: state.generation,
       recordedAt,
@@ -3959,20 +4067,20 @@ function inspectEngineMcpRegistrationInState(
   workspace: WorkspaceInfo,
   name: string,
   mcpConfig: Record<string, unknown>,
-): EngineMcpRegistrationStatus | "not-recorded" {
+): EngineMcpRegistrationInspection {
   const state = activeEngineMcpServerState(config, serverState);
-  if (!state) return "not-recorded";
+  if (!state) return notRecordedEngineMcpRegistration();
   const connectionIdentity = engineMcpConnectionIdentity(config, workspace);
   reconcileEngineMcpWorkspaceIdentity(state, workspace.id, connectionIdentity);
-  if (!connectionIdentity) return "not-recorded";
+  if (!connectionIdentity) return notRecordedEngineMcpRegistration();
   const registrationIdentity = engineMcpRegistrationIdentity(config, workspace);
   if (!registrationIdentity) {
     state.registrationByWorkspace.delete(workspace.id);
-    return "not-recorded";
+    return notRecordedEngineMcpRegistration();
   }
   const registrations = state.registrationByWorkspace.get(workspace.id);
   const registration = registrations?.get(name);
-  if (!registration) return "not-recorded";
+  if (!registration) return notRecordedEngineMcpRegistration();
   const currentFingerprint = mcpRegistrationFingerprint(mcpConfig);
   const ageMs = Date.now() - registration.recordedAt;
   if (
@@ -3985,9 +4093,13 @@ function inspectEngineMcpRegistrationInState(
     || registration.fingerprint !== currentFingerprint
   ) {
     registrations?.delete(name);
-    return "not-recorded";
+    return notRecordedEngineMcpRegistration();
   }
-  return registration.status;
+  return { status: registration.status, source: registration.source, recordAgeMs: Math.round(ageMs) };
+}
+
+function notRecordedEngineMcpRegistration(): EngineMcpRegistrationInspection {
+  return { status: "not-recorded", source: null, recordAgeMs: null };
 }
 
 export function inspectEngineMcpRegistration(
@@ -3996,9 +4108,55 @@ export function inspectEngineMcpRegistration(
   name: string,
   mcpConfig: Record<string, unknown>,
 ): EngineMcpRegistrationStatus | "not-recorded" {
+  return inspectEngineMcpRegistrationDetails(config, workspace, name, mcpConfig).status;
+}
+
+export function inspectEngineMcpRegistrationDetails(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  name: string,
+  mcpConfig: Record<string, unknown>,
+): EngineMcpRegistrationInspection {
   const state = activeEngineMcpServerState(config);
-  if (!state) return "not-recorded";
+  if (!state) return notRecordedEngineMcpRegistration();
   return inspectEngineMcpRegistrationInState(config, state, workspace, name, mcpConfig);
+}
+
+export function refreshEngineMcpRegistrationFromLiveStatus(
+  config: ServerConfig,
+  workspace: WorkspaceInfo,
+  name: string,
+  mcpConfig: Record<string, unknown>,
+  liveStatus: unknown,
+): boolean {
+  const status = normalizeEngineMcpRegistrationStatus(liveStatus);
+  if (!status) return false;
+  const state = activeEngineMcpServerState(config);
+  if (!state) return false;
+  const connectionIdentity = engineMcpConnectionIdentity(config, workspace);
+  reconcileEngineMcpWorkspaceIdentity(state, workspace.id, connectionIdentity);
+  if (!connectionIdentity) return false;
+  const registrationIdentity = engineMcpRegistrationIdentity(config, workspace);
+  if (!registrationIdentity) {
+    state.registrationByWorkspace.delete(workspace.id);
+    return false;
+  }
+  const fingerprint = mcpRegistrationFingerprint(mcpConfig);
+  if (fingerprint === null) {
+    state.registrationByWorkspace.get(workspace.id)?.delete(name);
+    return false;
+  }
+  const registrations = new Map(state.registrationByWorkspace.get(workspace.id) ?? []);
+  registrations.set(name, {
+    fingerprint,
+    status,
+    source: "engine_status",
+    registrationIdentity,
+    generation: state.generation,
+    recordedAt: Date.now(),
+  });
+  state.registrationByWorkspace.set(workspace.id, registrations);
+  return true;
 }
 
 function deleteEngineMcpRegistration(
@@ -4098,6 +4256,7 @@ export async function syncAllWorkspacesRuntimeMcpToEngine(config: ServerConfig):
         directory: resolveOpencodeDirectory(workspace),
         serverMetadata: { serverVersion: SERVER_VERSION, expectedOpencodeVersion: OPENCODE_VERSION },
         createWorkspaceOpencodeClient,
+        refreshRegistrationFromLiveStatus: refreshEngineMcpRegistrationFromLiveStatus,
         registerRuntimeMcp: (routeConfig, routeWorkspace, onlyNames, options) =>
           syncRuntimeMcpToOpencodeEngine(
             routeConfig,

--- a/evals/flows/engine-mcp-evidence-heal.flow.mjs
+++ b/evals/flows/engine-mcp-evidence-heal.flow.mjs
@@ -1,0 +1,272 @@
+/**
+ * Internal proof that stale engine-MCP failure evidence heals when live engine
+ * status shows the managed cloud connection is already connected.
+ *
+ * The orchestrator supplies OPENWORK_EVAL_REPRO_COMMAND. That command runs the
+ * real repro driver on the target environment and prints its final JSON as the
+ * last stdout line.
+ */
+import { spawnSync } from "node:child_process";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "engine-mcp-evidence-heal";
+const DEFAULT_REPRO_TIMEOUT_MS = 300_000;
+const REQUIRED_ENV = ["OPENWORK_EVAL_REPRO_COMMAND"];
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const state = {
+  evidence: null,
+  reproRun: null,
+};
+
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function own(value, key) {
+  if (!isRecord(value)) return undefined;
+  return Object.getOwnPropertyDescriptor(value, key)?.value;
+}
+
+function compactActual(actual) {
+  if (actual === undefined) return undefined;
+  if (typeof actual === "string") return actual.slice(0, 1_200);
+  try {
+    return JSON.stringify(actual).slice(0, 1_200);
+  } catch {
+    return String(actual).slice(0, 1_200);
+  }
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: compactActual(actual),
+  });
+  ctx.assert(condition, assertion + (actual === undefined ? "" : ` (actual: ${compactActual(actual)})`));
+}
+
+function textTail(value, max = 4_000) {
+  const text = String(value ?? "").trimEnd();
+  return text.length > max ? text.slice(-max) : text;
+}
+
+function parseTimeoutMs() {
+  const raw = process.env.OPENWORK_EVAL_REPRO_TIMEOUT_MS?.trim();
+  if (!raw) return DEFAULT_REPRO_TIMEOUT_MS;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`OPENWORK_EVAL_REPRO_TIMEOUT_MS must be a positive number of milliseconds (got ${raw}).`);
+  }
+  return Math.round(value);
+}
+
+function readEvalEnv() {
+  const values = {};
+  const missing = [];
+  for (const name of REQUIRED_ENV) {
+    const value = process.env[name]?.trim() ?? "";
+    if (!value) missing.push(name);
+    values[name] = value;
+  }
+  return { values, missing };
+}
+
+function requiredEnv() {
+  const snapshot = readEvalEnv();
+  if (snapshot.missing.length > 0) {
+    throw new Error(
+      `Missing required environment variables for ${FLOW_ID}: ${snapshot.missing.join(", ")}. `
+      + "Set OPENWORK_EVAL_REPRO_COMMAND to a shell command that runs scripts/repro-engine-mcp-evidence.mjs on the target environment and prints the driver's final JSON as the last stdout line.",
+    );
+  }
+  return { command: snapshot.values.OPENWORK_EVAL_REPRO_COMMAND, timeoutMs: parseTimeoutMs() };
+}
+
+function parseLastStdoutJson(stdout, stderr) {
+  const trimmed = String(stdout ?? "").trimEnd();
+  if (!trimmed) {
+    throw new Error(`Repro command produced no stdout JSON. Stderr tail:\n${textTail(stderr)}`);
+  }
+  const lines = trimmed.split(/\r?\n/);
+  const lastLine = lines[lines.length - 1]?.trim() ?? "";
+  try {
+    return JSON.parse(lastLine);
+  } catch (error) {
+    throw new Error(
+      `Could not parse the repro command's last stdout line as JSON: ${error instanceof Error ? error.message : String(error)}\n`
+      + `Last stdout line:\n${lastLine.slice(0, 2_000)}\n`
+      + `Stderr tail:\n${textTail(stderr)}`,
+    );
+  }
+}
+
+function runReproOnce() {
+  if (state.evidence) return;
+  const { command, timeoutMs } = requiredEnv();
+  const startedAt = Date.now();
+  const result = spawnSync(command, {
+    shell: true,
+    encoding: "utf8",
+    timeout: timeoutMs,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+  state.reproRun = {
+    status: result.status,
+    signal: result.signal,
+    durationMs: Date.now() - startedAt,
+    stdoutTail: textTail(result.stdout),
+    stderrTail: textTail(result.stderr),
+  };
+  if (result.error || result.status !== 0) {
+    const reason = result.error instanceof Error ? result.error.message : `exit status ${String(result.status)}`;
+    throw new Error(`Repro command failed (${reason}). Stderr tail:\n${textTail(result.stderr)}`);
+  }
+  state.evidence = parseLastStdoutJson(result.stdout, result.stderr);
+}
+
+function evidence() {
+  if (!state.evidence) throw new Error("Repro evidence was not captured before the frame ran.");
+  return state.evidence;
+}
+
+function phases() {
+  return own(evidence(), "phases");
+}
+
+function seedPhase() {
+  return own(phases(), "seed");
+}
+
+function healedPhase() {
+  return own(phases(), "healed");
+}
+
+function diagnosticsPhase() {
+  return own(phases(), "diagnostics");
+}
+
+function proxyHolds() {
+  const holds = own(evidence(), "proxyHolds");
+  return Array.isArray(holds) ? holds : [];
+}
+
+function isHealthConnected(health) {
+  return own(health, "usable") === true
+    || own(health, "phase") === "ready"
+    || own(own(health, "engine"), "status") === "connected";
+}
+
+function engineSyncFailed(mcpBody) {
+  const sync = own(mcpBody, "engineSync");
+  const failures = own(sync, "failures");
+  return own(sync, "status") === "failed"
+    && Array.isArray(failures)
+    && failures.some((failure) => own(failure, "name") === "openwork-cloud");
+}
+
+function initialReconcileFailed(reconcile) {
+  const firstFailure = own(reconcile, "firstFailure");
+  const delivery = own(reconcile, "delivery");
+  return own(firstFailure, "code") === "opencode_mcp_sync_failed"
+    || own(delivery, "state") === "failed"
+    || own(own(delivery, "failure"), "code") === "opencode_mcp_sync_failed";
+}
+
+function openworkCloudConnectedStatus(diagnostics) {
+  const statuses = own(diagnostics, "openworkCloudSyncStatuses");
+  if (!Array.isArray(statuses)) return null;
+  return statuses.find((status) => own(status, "name") === "openwork-cloud" && own(status, "source") === "config.remote" && own(status, "syncStatus") === "connected") ?? null;
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Engine-MCP diagnostics heal stale registration evidence without opening a chat",
+  kind: "internal",
+  requiresApp: false,
+  precondition: async () => {
+    runReproOnce();
+  },
+  steps: [
+    {
+      name: "Frame 1 — The repro seeds the slow first handshake and records the original failure",
+      run: async (ctx) => {
+        await ctx.prove("The repro run forced the first OpenWork Cloud handshake past the registration window and captured the initial failure evidence", {
+          voiceover: vo[0],
+          assert: async () => {
+            const seed = seedPhase();
+            const seedReconcile = own(seed, "reconcile");
+            const seedMcp = own(seed, "mcp");
+            const holds = proxyHolds();
+            ctx.output("seed-evidence-and-proxy-holds", JSON.stringify({
+              reproRun: state.reproRun,
+              seed,
+              proxyHolds: holds,
+            }, null, 2));
+            witness(ctx, isRecord(seed), "The repro evidence includes phases.seed", seed);
+            witness(ctx, holds.length > 0, "The delay proxy recorded at least one held engine-to-Den request", holds);
+            witness(ctx, holds.some((hold) => Number(own(hold, "heldMs")) >= 15_000), "At least one proxy hold outlasted the 15 second registration window", holds);
+            witness(ctx, initialReconcileFailed(seedReconcile), "The seed reconcile response recorded the initial opencode_mcp_sync_failed failure", {
+              firstFailure: own(seedReconcile, "firstFailure"),
+              delivery: own(seedReconcile, "delivery"),
+            });
+            witness(ctx, engineSyncFailed(seedMcp), "The immediate MCP inventory recorded engineSync failed for openwork-cloud", own(seedMcp, "engineSync"));
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2 — Live engine health heals without a chat",
+      run: async (ctx) => {
+        await ctx.prove("After the delayed handshake completes, live health shows the managed cloud connection is usable", {
+          voiceover: vo[1],
+          assert: async () => {
+            const healed = healedPhase();
+            const health = own(healed, "health");
+            ctx.output("healed-health", JSON.stringify(health ?? null, null, 2));
+            witness(ctx, isRecord(healed), "The repro evidence includes phases.healed", healed);
+            witness(ctx, isHealthConnected(health), "The driver's healed health poll observed a usable or connected OpenWork Cloud MCP", health);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — Agent-context diagnostics report the healed truth",
+      run: async (ctx) => {
+        await ctx.prove("Agent-context diagnostics no longer report registration_not_connected for a healthy managed cloud MCP", {
+          voiceover: vo[2],
+          assert: async () => {
+            const diagnostics = diagnosticsPhase();
+            const check = own(diagnostics, "engineMcpSyncCheck");
+            const details = own(check, "details");
+            const staleWarning = own(check, "status") === "warning" && own(check, "code") === "mcp_registration_stale_failure";
+            const passed = own(check, "status") === "passed";
+            const connectedStatus = openworkCloudConnectedStatus(diagnostics);
+
+            ctx.output("diagnostics-check-and-verdict", JSON.stringify({
+              engineMcpSyncCheck: check,
+              openworkCloudSyncStatuses: own(diagnostics, "openworkCloudSyncStatuses"),
+              firstFailedCheck: own(diagnostics, "firstFailedCheck") ?? null,
+              contradictionReproduced: own(evidence(), "contradictionReproduced"),
+            }, null, 2));
+            witness(ctx, isRecord(diagnostics), "The repro evidence includes phases.diagnostics", diagnostics);
+            witness(ctx, passed || staleWarning, "engine-mcp-sync passed, or explicitly downgraded stale failure evidence to a warning", check);
+            witness(ctx, own(details, "connectedCount") === 1, "engine-mcp-sync details.connectedCount is 1", details);
+            if (staleWarning) {
+              witness(ctx, Number(own(details, "failedCount")) > 0, "Stale-warning alternative exposes stale failed registrations instead of a hard failure", details);
+            } else {
+              witness(ctx, own(details, "failedCount") === 0, "engine-mcp-sync details.failedCount is 0", details);
+            }
+            witness(ctx, own(details, "engineReachableNow") === true, "engine-mcp-sync details.engineReachableNow is true", details);
+            witness(ctx, Boolean(connectedStatus), "openworkCloudSyncStatuses includes config.remote openwork-cloud with syncStatus connected", own(diagnostics, "openworkCloudSyncStatuses"));
+            witness(ctx, own(diagnostics, "firstFailedCheck") == null, "firstFailedCheck is null or absent", own(diagnostics, "firstFailedCheck"));
+            witness(ctx, own(evidence(), "contradictionReproduced") === false, "The historical healthy-system contradiction is not reproduced", own(evidence(), "contradictionReproduced"));
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/engine-mcp-evidence-heal.md
+++ b/evals/voiceovers/engine-mcp-evidence-heal.md
@@ -1,0 +1,9 @@
+# engine-mcp-evidence-heal — Diagnostics follow live engine reality
+
+This internal proof follows one isolated repro run from the forced slow first handshake through healed live engine health and the final diagnostics verdict.
+
+1. On an isolated Daytona sandbox, we recreate the customer's trap against a real OpenWork server, real engine, and real Den: the very first cloud connection attempt is forced to outlast the registration window, so the system records a failure — exactly what a slow first handshake does in the field.
+
+2. Reality heals itself: without anyone opening a chat or repairing anything, the engine finishes connecting on its own and live health shows the cloud connection working.
+
+3. And now the diagnostics tell the truth: the same report that used to cry "registration not connected" on a healthy system shows the managed connection as connected, with fresh evidence that the engine is reachable — the "open a chat so it works" ritual is gone.

--- a/packages/types/src/agent-context-diagnostics.ts
+++ b/packages/types/src/agent-context-diagnostics.ts
@@ -172,6 +172,13 @@ const safeTextSchema = z.string()
     isAgentContextDiagnosticTextSafe,
     "diagnostic text cannot contain controls, credentials, URLs, or absolute paths",
   )
+const registrationFailureDetailSchema = z.object({
+  name: safeTextSchema.min(1).max(160),
+  status: z.enum(["connected", "disabled", "failed", "needs-auth", "needs-client-registration", "not-recorded"]),
+  source: z.enum(["transport_failure", "engine_status"]).nullable(),
+  recordAgeMs: z.number().int().nonnegative().nullable(),
+  engineReachableNow: z.boolean(),
+}).strict()
 const organizationConnectionNameSchema = z.string()
   .min(1)
   .max(160)
@@ -186,6 +193,7 @@ const safeDetailValueSchema = z.union([
   z.boolean(),
   z.null(),
   z.array(safeTextSchema).max(100),
+  z.array(registrationFailureDetailSchema).max(100),
 ])
 const toolIdSchema = z.string().min(1).max(160).regex(/^[A-Za-z][A-Za-z0-9_.:-]*$/)
 

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -36,6 +36,7 @@ export type OpencodeExecutionSnapshot = {
 export type EngineInfo = {
   running: boolean;
   runtime: "direct";
+  managedByServer: boolean;
   baseUrl: string | null;
   projectDir: string | null;
   hostname: string | null;

--- a/scripts/repro-engine-mcp-evidence.mjs
+++ b/scripts/repro-engine-mcp-evidence.mjs
@@ -1,0 +1,449 @@
+#!/usr/bin/env node
+import { spawn } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { createWriteStream } from "node:fs";
+import { mkdir } from "node:fs/promises";
+import http from "node:http";
+import { join } from "node:path";
+
+const REPO_ROOT = "/workspace";
+const SERVER_TOKEN = "repro-token";
+
+const runTag = `${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`;
+const children = new Set();
+const logStreams = new Set();
+let proxyServer = null;
+let cleanupStarted = false;
+
+function log(message) {
+  process.stderr.write(`[repro-engine-mcp-evidence] ${message}\n`);
+}
+function writeLog(stream, chunk) {
+  if (!stream.writableEnded && !stream.destroyed) stream.write(chunk);
+}
+
+function envString(name) {
+  const value = process.env[name]?.trim();
+  if (!value) throw new Error(`Missing required environment variable ${name}`);
+  return value;
+}
+
+function envPort(name, fallback) {
+  const raw = process.env[name]?.trim();
+  if (!raw) return fallback;
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < 1 || value > 65535) {
+    throw new Error(`${name} must be an integer TCP port (got ${raw})`);
+  }
+  return value;
+}
+
+function envDelayMs() {
+  const raw = process.env.DELAY_MS?.trim();
+  if (!raw) return 9000;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value < 0) {
+    throw new Error(`DELAY_MS must be a non-negative number of milliseconds (got ${raw})`);
+  }
+  return Math.round(value);
+}
+
+function stripTrailingSlashes(value) {
+  return value.replace(/\/+$/, "");
+}
+function isRecord(value) {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+function own(value, key) {
+  return isRecord(value) ? Object.getOwnPropertyDescriptor(value, key)?.value : undefined;
+}
+function parseJsonText(text) {
+  if (!text) return null;
+  try {
+    return JSON.parse(text);
+  } catch {
+    return text;
+  }
+}
+
+async function fetchJson(url, options = {}) {
+  const headers = new Headers(options.headers ?? {});
+  if (!headers.has("accept")) headers.set("accept", "application/json");
+  if (options.body && !headers.has("content-type")) headers.set("content-type", "application/json");
+  const response = await fetch(url, { ...options, headers });
+  const text = await response.text();
+  return { response, body: parseJsonText(text), text };
+}
+function authOrigins(denApiUrl) {
+  const url = new URL(denApiUrl);
+  const origins = [url.origin];
+  if (url.hostname === "127.0.0.1") {
+    const localhost = new URL(url.toString());
+    localhost.hostname = "localhost";
+    origins.push(localhost.origin);
+  } else if (url.hostname === "localhost") {
+    const loopback = new URL(url.toString());
+    loopback.hostname = "127.0.0.1";
+    origins.push(loopback.origin);
+  }
+  return [...new Set(origins)];
+}
+async function denAuthFetch(denApiUrl, path, options = {}) {
+  let last = null;
+  for (const origin of authOrigins(denApiUrl)) {
+    const result = await fetchJson(`${denApiUrl}${path}`, {
+      ...options,
+      headers: { origin, ...(options.headers ?? {}) },
+    });
+    last = result;
+    if (!(result.response.status === 403 && own(result.body, "code") === "INVALID_ORIGIN")) return result;
+  }
+  return last;
+}
+async function denFetch(denApiUrl, path, token, options = {}) {
+  return fetchJson(`${denApiUrl}${path}`, {
+    ...options,
+    headers: { authorization: `Bearer ${token}`, ...(options.headers ?? {}) },
+  });
+}
+function assertOk(result, label) {
+  if (!result.response.ok) throw new Error(`${label} failed with HTTP ${result.response.status}: ${JSON.stringify(result.body)}`);
+}
+function organizationFromBody(body) {
+  const nested = own(body, "organization");
+  const organization = isRecord(nested) ? nested : isRecord(body) && typeof own(body, "id") === "string" ? body : null;
+  if (!organization || typeof own(organization, "id") !== "string") {
+    throw new Error(`Unable to resolve organization id from /v1/org response: ${JSON.stringify(body)}`);
+  }
+  return organization;
+}
+async function ensureOrganization(denApiUrl, sessionToken) {
+  const existing = await denFetch(denApiUrl, "/v1/org", sessionToken);
+  if (existing.response.ok) return organizationFromBody(existing.body);
+  if (existing.response.status !== 404) {
+    throw new Error(`GET /v1/org failed with HTTP ${existing.response.status}: ${JSON.stringify(existing.body)}`);
+  }
+
+  const created = await denFetch(denApiUrl, "/v1/org", sessionToken, {
+    method: "POST",
+    body: JSON.stringify({ name: `Engine MCP Evidence ${runTag}` }),
+  });
+  const singleOrgMode = created.response.status === 409
+    && (own(created.body, "error") === "single_org_mode" || own(created.body, "code") === "single_org_mode");
+  if (!created.response.ok && !singleOrgMode) {
+    throw new Error(`POST /v1/org failed with HTTP ${created.response.status}: ${JSON.stringify(created.body)}`);
+  }
+
+  const reread = await denFetch(denApiUrl, "/v1/org", sessionToken);
+  assertOk(reread, "GET /v1/org after organization bootstrap");
+  return organizationFromBody(reread.body);
+}
+async function bootstrapDen(denApiUrl) {
+  const email = `engine-mcp-evidence-${runTag}@acme.test`;
+  const password = `OpenWork-${runTag}-Evidence!`;
+  log(`Signing up Den admin ${email}`);
+  const signUp = await denAuthFetch(denApiUrl, "/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email, name: "Engine MCP Evidence Admin", password }),
+  });
+  assertOk(signUp, "POST /api/auth/sign-up/email");
+
+  const signIn = await denAuthFetch(denApiUrl, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  assertOk(signIn, "POST /api/auth/sign-in/email");
+  const sessionToken = own(signIn.body, "token");
+  if (typeof sessionToken !== "string" || !sessionToken) throw new Error("Den sign-in did not return a bearer token");
+
+  log("Resolving Den organization");
+  const organization = await ensureOrganization(denApiUrl, sessionToken);
+
+  log("Minting Den MCP token");
+  const minted = await denFetch(denApiUrl, "/v1/mcp/token", sessionToken, {
+    method: "POST",
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  });
+  assertOk(minted, "POST /v1/mcp/token");
+  const token = own(minted.body, "token");
+  if (typeof token !== "string" || !token) throw new Error("POST /v1/mcp/token did not return token");
+  return { sessionToken, organization, mcpToken: token, mcpTokenBody: minted.body };
+}
+function startDelayProxy(targetBase, port, delayMs) {
+  const targetOrigin = stripTrailingSlashes(targetBase);
+  let t0 = Date.now();
+  let delayUntil = t0 + delayMs;
+
+  const server = http.createServer((request, response) => {
+    const requestUrl = request.url ?? "/";
+    const remaining = requestUrl.startsWith("/mcp/agent") ? delayUntil - Date.now() : 0;
+    const forward = () => {
+      const targetUrl = new URL(`${targetOrigin}${requestUrl}`);
+      const headers = { ...request.headers };
+      delete headers.host;
+      const proxyRequest = http.request(targetUrl, { method: request.method, headers }, (proxyResponse) => {
+        response.writeHead(proxyResponse.statusCode ?? 502, proxyResponse.statusMessage, proxyResponse.headers);
+        proxyResponse.pipe(response);
+      });
+      proxyRequest.on("error", (error) => {
+        if (response.headersSent) {
+          response.destroy(error);
+          return;
+        }
+        response.writeHead(502, { "content-type": "application/json" });
+        response.end(JSON.stringify({ code: "proxy_forward_failed", message: error.message }));
+      });
+      request.pipe(proxyRequest);
+    };
+    if (remaining > 0) {
+      log(`Delaying ${request.method ?? ""} ${requestUrl} for ${Math.ceil(remaining)}ms`);
+      setTimeout(forward, remaining);
+      return;
+    }
+    forward();
+  });
+
+  return new Promise((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(port, "127.0.0.1", () => {
+      server.off("error", reject);
+      proxyServer = server;
+      const arm = () => {
+        t0 = Date.now();
+        delayUntil = t0 + delayMs;
+        log(`Delay proxy armed until ${new Date(delayUntil).toISOString()}`);
+        return { t0, delayUntil };
+      };
+      log(`Delay proxy listening on http://127.0.0.1:${port}, forwarding to ${targetOrigin}`);
+      resolve({ arm });
+    });
+  });
+}
+
+async function waitForServerListening(child, logStream) {
+  let stdout = "";
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("Timed out waiting for OpenWork server listening log")), 90_000);
+    const finish = (value) => {
+      clearTimeout(timeout);
+      resolve(value);
+    };
+    const fail = (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    };
+    child.stdout.on("data", (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      writeLog(logStream, text);
+      if (stdout.includes("OpenWork server listening")) finish();
+    });
+    child.stderr.on("data", (chunk) => writeLog(logStream, chunk));
+    child.once("error", fail);
+    child.once("exit", (code, signal) => fail(new Error(`OpenWork server exited before listening (code ${code}, signal ${signal})`)));
+  });
+}
+
+async function startOpenworkServer(paths, serverPort, opencodeBin) {
+  await mkdir(paths.workspaceRoot, { recursive: true });
+  await mkdir(paths.xdgOpenwork, { recursive: true });
+  await mkdir(paths.home, { recursive: true });
+  await mkdir(paths.logs, { recursive: true });
+  const serverLog = join(paths.logs, "server.log");
+  const logStream = createWriteStream(serverLog, { flags: "a" });
+  logStreams.add(logStream);
+  const args = ["apps/server/src/cli.ts", "--host", "127.0.0.1", "--port", String(serverPort), "--token", SERVER_TOKEN, "--workspace", paths.workspaceRoot];
+  log(`Starting OpenWork server on 127.0.0.1:${serverPort}`);
+  const child = spawn("bun", args, {
+    cwd: REPO_ROOT,
+    env: {
+      ...process.env,
+      OPENWORK_MANAGE_OPENCODE: "1",
+      OPENWORK_OPENCODE_BIN: opencodeBin,
+      OPENWORK_SERVER_CONFIG: join(paths.xdgOpenwork, "server.json"),
+      XDG_CONFIG_HOME: paths.xdg,
+      HOME: paths.home,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  children.add(child);
+  try {
+    await waitForServerListening(child, logStream);
+  } catch (error) {
+    logStream.end();
+    throw error;
+  }
+  log(`OpenWork server log: ${serverLog}`);
+  return { baseUrl: `http://127.0.0.1:${serverPort}` };
+}
+
+async function serverJson(baseUrl, path, options = {}) {
+  const result = await fetchJson(`${baseUrl}${path}`, {
+    ...options,
+    headers: { authorization: `Bearer ${SERVER_TOKEN}`, ...(options.headers ?? {}) },
+  });
+  assertOk(result, `${options.method ?? "GET"} ${path}`);
+  return result.body;
+}
+
+function firstWorkspaceId(workspacesBody) {
+  const activeId = own(workspacesBody, "activeId");
+  if (typeof activeId === "string" && activeId) return activeId;
+  const items = Array.isArray(own(workspacesBody, "items")) ? own(workspacesBody, "items") : own(workspacesBody, "workspaces");
+  const id = own(Array.isArray(items) ? items[0] : null, "id");
+  if (typeof id === "string" && id) return id;
+  throw new Error(`Unable to discover workspace id from /workspaces: ${JSON.stringify(workspacesBody)}`);
+}
+
+function isHealthConnected(health) {
+  return own(health, "usable") === true
+    || own(health, "phase") === "ready"
+    || own(own(health, "engine"), "status") === "connected";
+}
+
+async function sleep(ms) {
+  if (ms <= 0) return;
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function pollHealedHealth(baseUrl, workspaceId) {
+  const started = Date.now();
+  let last = null;
+  while (Date.now() - started < 30_000) {
+    last = await serverJson(baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/mcp/openwork-cloud/health`);
+    if (isHealthConnected(last)) return last;
+    await sleep(1000);
+  }
+  return last;
+}
+
+function redact(value, secrets) {
+  if (typeof value === "string") {
+    let output = value;
+    for (const secret of secrets) {
+      if (secret) output = output.split(secret).join("<redacted>");
+    }
+    return output.replace(/Bearer\s+[^\s"',)}\]]+/gi, "Bearer <redacted>");
+  }
+  if (Array.isArray(value)) return value.map((item) => redact(item, secrets));
+  if (!isRecord(value)) return value;
+  const output = {};
+  for (const [key, child] of Object.entries(value)) {
+    const lower = key.toLowerCase();
+    output[key] = typeof child === "string" && (lower === "authorization" || lower === "token")
+      ? "<redacted>"
+      : redact(child, secrets);
+  }
+  return output;
+}
+
+async function cleanup() {
+  if (cleanupStarted) return;
+  cleanupStarted = true;
+  const closeProxy = proxyServer
+    ? new Promise((resolve) => proxyServer.close(() => resolve()))
+    : Promise.resolve();
+  for (const child of children) {
+    if (child.exitCode === null) child.kill("SIGTERM");
+  }
+  await Promise.race([closeProxy, sleep(1000)]);
+  await sleep(1200);
+  for (const child of children) {
+    if (child.exitCode === null) child.kill("SIGKILL");
+  }
+  for (const stream of logStreams) stream.end();
+}
+
+async function main() {
+  for (const name of ["DEN_API_LOCAL", "OPENWORK_OPENCODE_BIN", "REPRO_DIR"]) envString(name);
+  const denApiUrl = stripTrailingSlashes(envString("DEN_API_LOCAL"));
+  const opencodeBin = envString("OPENWORK_OPENCODE_BIN");
+  const reproDir = envString("REPRO_DIR");
+  const delayMs = envDelayMs();
+  const serverPort = envPort("SERVER_PORT", 8790);
+  const proxyPort = envPort("PROXY_PORT", 8791);
+  const paths = { workspaceRoot: join(reproDir, "ws"), xdg: join(reproDir, "xdg"), xdgOpenwork: join(reproDir, "xdg", "openwork"), home: join(reproDir, "home"), logs: join(reproDir, "logs") };
+
+  const den = await bootstrapDen(denApiUrl);
+  const proxy = await startDelayProxy(denApiUrl, proxyPort, delayMs);
+  const openwork = await startOpenworkServer(paths, serverPort, opencodeBin);
+  const workspaces = await serverJson(openwork.baseUrl, "/workspaces");
+  const workspaceId = firstWorkspaceId(workspaces);
+  log(`Using workspace ${workspaceId}`);
+
+  const reconcilePayload = {
+    workspaceId,
+    name: "openwork-cloud",
+    config: {
+      type: "remote",
+      url: `http://127.0.0.1:${proxyPort}/mcp/agent`,
+      enabled: true,
+      headers: { Authorization: `Bearer ${den.mcpToken}` },
+      oauth: false,
+    },
+    tokenMetadata: {
+      expiresAt: own(den.mcpTokenBody, "expiresAt") ?? null,
+      organizationId: own(den.mcpTokenBody, "organizationId") ?? own(den.organization, "id"),
+      resource: own(den.mcpTokenBody, "resource") ?? null,
+      scopes: Array.isArray(own(den.mcpTokenBody, "scopes")) ? own(den.mcpTokenBody, "scopes") : ["mcp:read", "mcp:write"],
+    },
+    org: { id: own(den.organization, "id"), name: own(den.organization, "name") ?? null, slug: own(den.organization, "slug") ?? null },
+    trigger: "repro-engine-mcp-evidence",
+  };
+
+  log("PHASE 1: seeding delayed openwork-cloud reconcile");
+  const armed = proxy.arm();
+  const seedReconcile = await serverJson(openwork.baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/mcp/openwork-cloud/reconcile`, {
+    method: "POST",
+    body: JSON.stringify(reconcilePayload),
+  });
+  const seedMcp = await serverJson(openwork.baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/mcp`);
+  const seedHealth = await serverJson(openwork.baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/mcp/openwork-cloud/health`);
+
+  log("PHASE 2: waiting for delayed Den MCP handshake to heal live engine state");
+  await sleep(armed.delayUntil + 8000 - Date.now());
+  const healedHealth = await pollHealedHealth(openwork.baseUrl, workspaceId);
+  const healedMcp = await serverJson(openwork.baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/mcp`);
+
+  log("PHASE 3: collecting agent-context diagnostics");
+  const diagnosticsRequest = {
+    organizationConnectionsProbe: { status: "observed", code: null, totalCount: 0, truncated: false },
+    organizationConnections: [],
+  };
+  const diagnosticsReport = await serverJson(openwork.baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/diagnostics/agent-context`, {
+    method: "POST",
+    body: JSON.stringify(diagnosticsRequest),
+  });
+  const checks = Array.isArray(own(diagnosticsReport, "checks")) ? own(diagnosticsReport, "checks") : [];
+  const engineMcpSyncCheck = checks.find((check) => own(check, "id") === "engine-mcp-sync") ?? null;
+  const mcps = Array.isArray(own(diagnosticsReport, "mcps")) ? own(diagnosticsReport, "mcps") : [];
+  const openworkCloudSyncStatuses = mcps.filter((mcp) => own(mcp, "name") === "openwork-cloud").map((mcp) => ({
+    name: own(mcp, "name"), source: own(mcp, "source"), type: own(mcp, "type"), enabled: own(mcp, "enabled"),
+    syncStatus: own(mcp, "syncStatus"), liveEngineStatus: own(mcp, "liveEngineStatus"),
+  }));
+  const contradictionReproduced = isHealthConnected(healedHealth)
+    && own(engineMcpSyncCheck, "status") === "failed"
+    && own(engineMcpSyncCheck, "code") === "mcp_registration_not_connected";
+
+  const evidence = {
+    runTag,
+    phases: {
+      seed: { reconcile: seedReconcile, mcp: seedMcp, health: seedHealth },
+      healed: { mcp: healedMcp, health: healedHealth },
+      diagnostics: { engineMcpSyncCheck, openworkCloudSyncStatuses, firstFailedCheck: own(diagnosticsReport, "firstFailedCheck") ?? null, overall: own(diagnosticsReport, "overall") ?? null },
+    },
+    contradictionReproduced,
+  };
+
+  await cleanup();
+  console.log(JSON.stringify(redact(evidence, [den.mcpToken, den.sessionToken])));
+}
+
+process.once("SIGINT", () => void cleanup().finally(() => process.exit(130)));
+process.once("SIGTERM", () => void cleanup().finally(() => process.exit(143)));
+
+main().catch(async (error) => {
+  process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
+  await cleanup();
+  process.exitCode = 1;
+});

--- a/scripts/repro-engine-mcp-evidence.mjs
+++ b/scripts/repro-engine-mcp-evidence.mjs
@@ -50,7 +50,13 @@ function envDelayMs() {
   return Math.round(value);
 }
 function windowMs() {
-  return 15000;
+  const raw = process.env.WINDOW_MS?.trim();
+  if (!raw) return 15000;
+  const value = Number(raw);
+  if (!Number.isFinite(value) || value <= 0) {
+    throw new Error(`WINDOW_MS must be a positive number of milliseconds (got ${raw})`);
+  }
+  return Math.round(value);
 }
 
 function stripTrailingSlashes(value) {

--- a/scripts/repro-engine-mcp-evidence.mjs
+++ b/scripts/repro-engine-mcp-evidence.mjs
@@ -12,6 +12,8 @@ const SERVER_TOKEN = "repro-token";
 const runTag = `${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`;
 const children = new Set();
 const logStreams = new Set();
+const proxySockets = new Set();
+const proxyHoldTimers = new Set();
 let proxyServer = null;
 let cleanupStarted = false;
 
@@ -47,6 +49,9 @@ function envDelayMs() {
   }
   return Math.round(value);
 }
+function windowMs() {
+  return 15000;
+}
 
 function stripTrailingSlashes(value) {
   return value.replace(/\/+$/, "");
@@ -73,6 +78,11 @@ async function fetchJson(url, options = {}) {
   const response = await fetch(url, { ...options, headers });
   const text = await response.text();
   return { response, body: parseJsonText(text), text };
+}
+async function readNodeRequestJson(request) {
+  let body = "";
+  for await (const chunk of request) body += chunk.toString();
+  return parseJsonText(body);
 }
 function authOrigins(denApiUrl) {
   const url = new URL(denApiUrl);
@@ -169,14 +179,29 @@ async function bootstrapDen(denApiUrl) {
   if (typeof token !== "string" || !token) throw new Error("POST /v1/mcp/token did not return token");
   return { sessionToken, organization, mcpToken: token, mcpTokenBody: minted.body };
 }
-function startDelayProxy(targetBase, port, delayMs) {
+function startDelayProxy(targetBase, port) {
   const targetOrigin = stripTrailingSlashes(targetBase);
-  let t0 = Date.now();
-  let delayUntil = t0 + delayMs;
+  let armedUntilMs = 0;
+  let activeDelayMs = 0;
+  const holds = [];
 
-  const server = http.createServer((request, response) => {
+  const server = http.createServer(async (request, response) => {
     const requestUrl = request.url ?? "/";
-    const remaining = requestUrl.startsWith("/mcp/agent") ? delayUntil - Date.now() : 0;
+    const requestPath = new URL(requestUrl, "http://127.0.0.1").pathname;
+    if (request.method === "POST" && requestPath === "/__repro/arm") {
+      const body = await readNodeRequestJson(request);
+      const nextDelayMs = Number(own(body, "delayMs"));
+      const nextWindowMs = Number(own(body, "windowMs"));
+      activeDelayMs = Number.isFinite(nextDelayMs) && nextDelayMs >= 0 ? Math.round(nextDelayMs) : 9000;
+      const activeWindowMs = Number.isFinite(nextWindowMs) && nextWindowMs > 0 ? Math.round(nextWindowMs) : windowMs();
+      const armedAtMs = Date.now();
+      armedUntilMs = armedAtMs + activeWindowMs;
+      response.writeHead(200, { "content-type": "application/json" });
+      response.end(JSON.stringify({ armedAtMs, armedUntilMs, delayMs: activeDelayMs, windowMs: activeWindowMs }));
+      log(`Delay proxy armed for ${activeWindowMs}ms with per-request hold ${activeDelayMs}ms`);
+      return;
+    }
+
     const forward = () => {
       const targetUrl = new URL(`${targetOrigin}${requestUrl}`);
       const headers = { ...request.headers };
@@ -195,12 +220,24 @@ function startDelayProxy(targetBase, port, delayMs) {
       });
       request.pipe(proxyRequest);
     };
-    if (remaining > 0) {
-      log(`Delaying ${request.method ?? ""} ${requestUrl} for ${Math.ceil(remaining)}ms`);
-      setTimeout(forward, remaining);
+    if (requestPath.startsWith("/mcp/agent") && Date.now() <= armedUntilMs) {
+      const arrivedAtMs = Date.now();
+      log(`Delaying ${request.method ?? ""} ${requestUrl} for ${activeDelayMs}ms`);
+      const timer = setTimeout(() => {
+        proxyHoldTimers.delete(timer);
+        const heldMs = Date.now() - arrivedAtMs;
+        holds.push({ path: requestUrl, heldMs, at: new Date(arrivedAtMs).toISOString() });
+        log(`Forwarding held ${request.method ?? ""} ${requestUrl} after ${heldMs}ms`);
+        forward();
+      }, activeDelayMs);
+      proxyHoldTimers.add(timer);
       return;
     }
     forward();
+  });
+  server.on("connection", (socket) => {
+    proxySockets.add(socket);
+    socket.on("close", () => proxySockets.delete(socket));
   });
 
   return new Promise((resolve, reject) => {
@@ -208,14 +245,8 @@ function startDelayProxy(targetBase, port, delayMs) {
     server.listen(port, "127.0.0.1", () => {
       server.off("error", reject);
       proxyServer = server;
-      const arm = () => {
-        t0 = Date.now();
-        delayUntil = t0 + delayMs;
-        log(`Delay proxy armed until ${new Date(delayUntil).toISOString()}`);
-        return { t0, delayUntil };
-      };
       log(`Delay proxy listening on http://127.0.0.1:${port}, forwarding to ${targetOrigin}`);
-      resolve({ arm });
+      resolve({ holds });
     });
   });
 }
@@ -265,6 +296,7 @@ async function startOpenworkServer(paths, serverPort, opencodeBin) {
       HOME: paths.home,
     },
     stdio: ["ignore", "pipe", "pipe"],
+    detached: true,
   });
   children.add(child);
   try {
@@ -283,6 +315,14 @@ async function serverJson(baseUrl, path, options = {}) {
     headers: { authorization: `Bearer ${SERVER_TOKEN}`, ...(options.headers ?? {}) },
   });
   assertOk(result, `${options.method ?? "GET"} ${path}`);
+  return result.body;
+}
+async function armProxy(proxyPort, delayMs, activeWindowMs) {
+  const result = await fetchJson(`http://127.0.0.1:${proxyPort}/__repro/arm`, {
+    method: "POST",
+    body: JSON.stringify({ delayMs, windowMs: activeWindowMs }),
+  });
+  assertOk(result, "POST /__repro/arm");
   return result.body;
 }
 
@@ -337,21 +377,40 @@ function redact(value, secrets) {
   return output;
 }
 
+function killProcessGroup(child, signal) {
+  if (typeof child.pid === "number") {
+    try {
+      process.kill(-child.pid, signal);
+      return;
+    } catch {}
+  }
+  child.kill(signal);
+}
+
 async function cleanup() {
   if (cleanupStarted) return;
   cleanupStarted = true;
+  for (const timer of proxyHoldTimers) clearTimeout(timer);
+  proxyHoldTimers.clear();
+  proxyServer?.unref();
+  proxyServer?.closeAllConnections?.();
+  for (const socket of proxySockets) socket.destroy();
   const closeProxy = proxyServer
     ? new Promise((resolve) => proxyServer.close(() => resolve()))
     : Promise.resolve();
   for (const child of children) {
-    if (child.exitCode === null) child.kill("SIGTERM");
+    if (child.exitCode === null) killProcessGroup(child, "SIGTERM");
   }
   await Promise.race([closeProxy, sleep(1000)]);
   await sleep(1200);
   for (const child of children) {
-    if (child.exitCode === null) child.kill("SIGKILL");
+    if (child.exitCode === null) killProcessGroup(child, "SIGKILL");
   }
   for (const stream of logStreams) stream.end();
+}
+
+async function writeFinalJson(value) {
+  await new Promise((resolve) => process.stdout.write(`${JSON.stringify(value)}\n`, resolve));
 }
 
 async function main() {
@@ -360,12 +419,13 @@ async function main() {
   const opencodeBin = envString("OPENWORK_OPENCODE_BIN");
   const reproDir = envString("REPRO_DIR");
   const delayMs = envDelayMs();
+  const activeWindowMs = windowMs();
   const serverPort = envPort("SERVER_PORT", 8790);
   const proxyPort = envPort("PROXY_PORT", 8791);
   const paths = { workspaceRoot: join(reproDir, "ws"), xdg: join(reproDir, "xdg"), xdgOpenwork: join(reproDir, "xdg", "openwork"), home: join(reproDir, "home"), logs: join(reproDir, "logs") };
 
   const den = await bootstrapDen(denApiUrl);
-  const proxy = await startDelayProxy(denApiUrl, proxyPort, delayMs);
+  const proxy = await startDelayProxy(denApiUrl, proxyPort);
   const openwork = await startOpenworkServer(paths, serverPort, opencodeBin);
   const workspaces = await serverJson(openwork.baseUrl, "/workspaces");
   const workspaceId = firstWorkspaceId(workspaces);
@@ -392,7 +452,9 @@ async function main() {
   };
 
   log("PHASE 1: seeding delayed openwork-cloud reconcile");
-  const armed = proxy.arm();
+  const armed = await armProxy(proxyPort, delayMs, activeWindowMs);
+  const armedUntilMs = Number(own(armed, "armedUntilMs"));
+  if (!Number.isFinite(armedUntilMs)) throw new Error(`Proxy arm response did not include armedUntilMs: ${JSON.stringify(armed)}`);
   const seedReconcile = await serverJson(openwork.baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/mcp/openwork-cloud/reconcile`, {
     method: "POST",
     body: JSON.stringify(reconcilePayload),
@@ -401,7 +463,7 @@ async function main() {
   const seedHealth = await serverJson(openwork.baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/mcp/openwork-cloud/health`);
 
   log("PHASE 2: waiting for delayed Den MCP handshake to heal live engine state");
-  await sleep(armed.delayUntil + 8000 - Date.now());
+  await sleep(armedUntilMs + 8000 - Date.now());
   const healedHealth = await pollHealedHealth(openwork.baseUrl, workspaceId);
   const healedMcp = await serverJson(openwork.baseUrl, `/workspace/${encodeURIComponent(workspaceId)}/mcp`);
 
@@ -432,11 +494,16 @@ async function main() {
       healed: { mcp: healedMcp, health: healedHealth },
       diagnostics: { engineMcpSyncCheck, openworkCloudSyncStatuses, firstFailedCheck: own(diagnosticsReport, "firstFailedCheck") ?? null, overall: own(diagnosticsReport, "overall") ?? null },
     },
+    proxyHolds: proxy.holds,
     contradictionReproduced,
   };
 
+  await writeFinalJson(redact(evidence, [den.mcpToken, den.sessionToken]));
+  const forcedExit = setTimeout(() => process.exit(0), 2000);
+  forcedExit.unref();
   await cleanup();
-  console.log(JSON.stringify(redact(evidence, [den.mcpToken, den.sessionToken])));
+  clearTimeout(forcedExit);
+  process.exit(0);
 }
 
 process.once("SIGINT", () => void cleanup().finally(() => process.exit(130)));
@@ -445,5 +512,5 @@ process.once("SIGTERM", () => void cleanup().finally(() => process.exit(143)));
 main().catch(async (error) => {
   process.stderr.write(`${error instanceof Error ? error.stack ?? error.message : String(error)}\n`);
   await cleanup();
-  process.exitCode = 1;
+  process.exit(1);
 });


### PR DESCRIPTION
## Problem (customer-reported, reproduced live)

When the openwork-cloud managed MCP registers while the downstream connect is slow (first Den handshake outlasting the 15s registration POST + 750ms retry + ~5.5s connect poll), apps/server records a **failed** registration bound to the live engine generation — and never corrects it for up to **15 minutes**, even though the engine finishes connecting **by itself** seconds later (desired config is persisted before any engine contact; the engine re-reads `OPENCODE_CONFIG` and its in-flight connect survives the caller timeout). Every self-heal path missed the record: the maintenance loop skips re-POST when live health is usable, and the health-read self-heal updates only the delivery store. Result: **agent-context diagnostics report `engine-mcp-sync: failed / mcp_registration_not_connected` on a healthy system**, and users learn the ritual "open a chat so the cloud connection works." A support bundle artifact made it worse: the embedded runtime always reported `engine.running: false, pid: null` on healthy systems, sending investigations toward "the engine was down."

## Live reproduction (Daytona, real server + real engine + real Den)

Deterministic driver `scripts/repro-engine-mcp-evidence.mjs` (in this PR): boots the real `apps/server` CLI with a managed opencode engine (1.17.11) against a real Den API, arms a delay proxy **at reconcile time** so the first `/mcp/agent` handshakes are held 20s (outlasting the registration window), then captures three phases: seeded failure → self-healed live health → agent-context diagnostics.

- **Unfixed code** (same base, run `repro-out4`): `contradictionReproduced: true` — record `failed`, live health connected, diagnostics `overall: failed`, `firstFailedCheck: engine-mcp-sync`, `failedCount: 1, needsAuthCount: 0` — byte-for-byte the customer's report shape.
- **This branch** (same seed, three 20s holds): `contradictionReproduced: false` — diagnostics `connectedCount: 1, failedCount: 0`, new `engineReachableNow: true`, `syncStatus: connected`, `firstFailedCheck: null`.

## Fix (four small interventions)

1. **Live-status heal**: live engine `GET /mcp` observations (health reads / connect polls) now refresh the registration record under the exact trust rules writes use (trusted live process, identity + generation + config fingerprint) — mirror of the existing delivery-store self-heal. Stale evidence dies the moment reality is observed.
2. **One-shot deferred re-sync**: a retryable registration failure schedules exactly one deferred re-sync (default 12s, env `OPENWORK_MCP_SYNC_DEFERRED_DELAY_MS`), single-flight per workspace, generation/identity-guarded, cancelled by any newer sync. No intervals.
3. **Honest diagnostics**: records carry provenance (`transport_failure` vs `engine_status`); the engine-mcp-sync check surfaces `engineReachableNow`, per-failure `recordAgeMs`/source, and downgrades to `warning: mcp_registration_stale_failure` when every failure is old evidence on a currently-reachable engine. Additive schema change (v1 kept).
4. **Truthful debug bundle**: the embedded runtime now reports the server-managed engine's real pid/liveness (`managedByServer: true`) instead of `running: false, pid: null` on healthy systems. No credentials added to bundles.

## Tests

- `mcp.engine-sync.e2e.test.ts` — live-status heal after 2xx-body-failed; deferred re-sync; provenance for both failure kinds; full existing invalidation matrix (trust generations, endpoint change, TTL, liveness revocation) green → **20 pass**.
- `cloud-mcp-reconcile.e2e.test.ts` — failed→connected heals without a second reconcile → **17 pass**.
- `agent-context-diagnostics.test.ts` — stale-failure downgrade + fresh-failure unchanged → **43 pass**; schema suites **7 pass**; `cloud-mcp-health.test.ts` **11 pass**; electron `runtime.test.mjs` **14 pass**; app `diagnostics-bundle.test.ts` **3 pass**.
- Full `apps/server` suite: **474 pass, 10 skip, 0 fail**. Typechecks: openwork-server, @openwork/app, desktop electron — pass.

## Proof

Fraimz flow `engine-mcp-evidence-heal` (internal kind) executes the live driver on a Daytona sandbox and asserts the three-phase evidence — all frames passed; artifact posted as a follow-up comment via `pnpm fraimz --flow engine-mcp-evidence-heal --pr`. Sandbox `openwork-server-20260720-143157` left running for reviewers (auto-stops when idle).

## Honesty notes

- The repro driver needed two iterations to seed correctly (delay must be armed at reconcile time and exceed the 15s registration timeout — a 9s delay just produces a slow-but-truthful `connected`); the committed driver embeds the actual hold durations in its evidence.
- The stale-failure `warning` downgrade path is covered by unit tests, not the live flow (the live flow heals before the 60s staleness threshold — which is the point of the fix).