### PR TITLE
fix(app): refresh artifact panel when agent modifies the open file

### DIFF
--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -109,7 +109,7 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
   });
 
   const { data, error, isError, isLoading } = useQuery<ArtifactQueryState>({
-    queryKey: ["artifact-panel", workspaceId, target.id] as const,
+    queryKey: ["artifact-panel", workspaceId, target.id, target.updatedAt ?? null] as const,
     queryFn: async () => {
       if (target.kind === "url") {
         throw new Error("URLs open in browser tabs.");
@@ -120,7 +120,7 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
 
       if (isTextContent(target)) {
         const result = await client.readWorkspaceFile(workspaceId, target.value);
-        
+
         return { kind: "text", data: result.content, updatedAt: result.updatedAt ?? null };
       }
 
@@ -131,6 +131,7 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
     refetchOnReconnect: false,
     refetchOnWindowFocus: false,
     staleTime: Infinity,
+    gcTime: 0,
   });
 
   const [binaryObjectUrl, setBinaryObjectUrl] = useState<string | null>(null);
@@ -175,7 +176,7 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
     },
     onSuccess: (result, input) => {
       queryClient.setQueryData<ArtifactQueryState>(
-        ["artifact-panel", workspaceId, target.id] as const,
+        ["artifact-panel", workspaceId, target.id, target.updatedAt ?? null] as const,
         input.kind === "text"
           ? { kind: "text", data: input.data, updatedAt: result.updatedAt ?? null }
           : { kind: "binary", data: input.data, contentType: data?.kind === "binary" ? data.contentType : null, updatedAt: result.updatedAt ?? null },

--- a/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
+++ b/apps/app/src/react-app/domains/session/panel/panel-tab-store.ts
@@ -111,7 +111,10 @@ function reconcileOpenArtifactTabs(
 function isSameTranscriptArtifactTargets(left: OpenTarget[], right: OpenTarget[]) {
   return (
     left.length === right.length &&
-    left.every((target, index) => target.id === right[index]?.id)
+    left.every((target, index) => {
+      const other = right[index];
+      return other && target.id === other.id && target.updatedAt === other.updatedAt;
+    })
   );
 }
 


### PR DESCRIPTION
## Summary
- Artifact preview panel showed stale content after the agent modified the open file — only a full app restart cleared it.
- `isSameTranscriptArtifactTargets` compared targets only by `id`, ignoring mtime changes, so the Zustand store never propagated file updates to the panel.
- `staleTime: Infinity` with no cache invalidation meant React Query served the initial fetch indefinitely.
- Fix: include `target.updatedAt` (file mtime already returned by `resolveArtifacts`) in the React Query cache key and in the transcript-targets equality check. Add `gcTime: 0` so close/reopen also fetches fresh.

## Why
When the agent writes a file, the server already returns the updated mtime via `resolveArtifacts`. That signal existed in the pipeline but was never used to bust the cache or notify the panel.

## Issue
Closes #2924

## Scope
- `apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx` — add `target.updatedAt` to query key and `setQueryData` key; add `gcTime: 0`
- `apps/app/src/react-app/domains/session/panel/panel-tab-store.ts` — include `updatedAt` in `isSameTranscriptArtifactTargets`

## Testing
### Ran
- `pnpm typecheck` — pass

### Manual
1. Ask agent to create a `.md` file, open preview panel, ask agent to modify it — panel updates automatically ✓
2. Close preview panel while agent modifies file, reopen — shows latest content ✓
3. Edit file manually via in-panel editor and save — content correct after save ✓
4. Open non-markdown artifact (image, PDF) — no regression ✓

## Evidence

<img width="1476" height="835" alt="Screenshot 2026-07-21 at 10 01 31 AM" src="https://github.com/user-attachments/assets/211a7973-2d0a-42b2-9beb-b385d35e074d" />

