### PR TITLE
feat(den): stateful auth-recovery scenario in the mock gateway + end-to-end recovery tests

### DIFF
--- a/ee/apps/den-api/test/external-mcp-provider-auth-recovery.test.ts
+++ b/ee/apps/den-api/test/external-mcp-provider-auth-recovery.test.ts
@@ -1,0 +1,418 @@
+import { spawn, type ChildProcessWithoutNullStreams } from "node:child_process"
+import { once } from "node:events"
+import { createServer } from "node:net"
+import { fileURLToPath } from "node:url"
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import type { DenTypeId } from "@openwork-ee/utils/typeid"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890"
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "local-dev-secret-not-for-production-use!!"
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.DEN_ALLOW_PRIVATE_MCP_URLS = "1"
+}
+
+seedRequiredEnv()
+
+const redirectUriBase = "http://127.0.0.1:8790"
+const guardedToolName = "search_servicenow_incidents"
+const providerName = "Northwind"
+const antiRegressionStrings = ["check provider latency", "protocol lifecycle", "MCP transport"]
+
+type SeededOrganization = {
+  organizationId: DenTypeId<"organization">
+  memberId: DenTypeId<"member">
+}
+
+type MockScenarioServer = {
+  origin: string
+  mcpUrl: string
+  stop: () => Promise<void>
+  logs: () => string
+}
+
+let db: typeof import("../src/db.js").db
+let schema: typeof import("@openwork-ee/den-db/schema")
+let createDenTypeId: typeof import("@openwork-ee/utils/typeid").createDenTypeId
+let createExternalMcpConnection: typeof import("../src/capability-sources/external-mcp-connections.js").createExternalMcpConnection
+let searchExternalCapabilities: typeof import("../src/mcp/external-capabilities.js").searchExternalCapabilities
+let executeExternalCapability: typeof import("../src/mcp/external-capabilities.js").executeExternalCapability
+
+const activeServers: MockScenarioServer[] = []
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function own(value: unknown, key: string): unknown {
+  if (!isRecord(value)) return undefined
+  return value[key]
+}
+
+async function fetchJson(url: string, options?: RequestInit): Promise<{ response: Response; body: unknown; text: string }> {
+  const response = await fetch(url, options)
+  const text = await response.text()
+  let body: unknown = text
+  try {
+    body = text ? JSON.parse(text) : null
+  } catch {}
+  return { response, body, text }
+}
+
+async function getAvailablePort(): Promise<number> {
+  const server = createServer()
+  return await new Promise((resolve, reject) => {
+    server.once("error", reject)
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address()
+      if (typeof address === "object" && address !== null) {
+        const port = address.port
+        server.close((error) => {
+          if (error) reject(error)
+          else resolve(port)
+        })
+        return
+      }
+      server.close(() => reject(new Error("Could not reserve a TCP port for the mock MCP server")))
+    })
+  })
+}
+
+async function waitForMockServer(origin: string, logs: () => string): Promise<void> {
+  for (let attempt = 0; attempt < 80; attempt += 1) {
+    const result = await fetch(`${origin}/health`).catch(() => null)
+    if (result?.ok) return
+    await new Promise((resolve) => setTimeout(resolve, 50))
+  }
+  throw new Error(`Mock MCP server did not become healthy at ${origin}. Logs:\n${logs()}`)
+}
+
+async function waitForExit(child: ChildProcessWithoutNullStreams): Promise<void> {
+  await Promise.race([
+    once(child, "exit"),
+    new Promise((resolve) => setTimeout(resolve, 1_000)),
+  ])
+}
+
+async function stopChild(child: ChildProcessWithoutNullStreams, exited: () => boolean): Promise<void> {
+  if (exited()) return
+  child.kill("SIGTERM")
+  await waitForExit(child)
+  if (exited()) return
+  child.kill("SIGKILL")
+  await waitForExit(child)
+}
+
+async function startMockScenario(input: {
+  mode: "authorization_required" | "authorization_required_uncorrelated"
+  getStream?: "reset" | "405"
+}): Promise<MockScenarioServer> {
+  const port = await getAvailablePort()
+  const origin = `http://127.0.0.1:${port}`
+  const scriptPath = fileURLToPath(new URL("../../../../scripts/mock-oauth-mcp-server.mjs", import.meta.url))
+  const child = spawn("node", [scriptPath], {
+    env: {
+      ...process.env,
+      HOST: "127.0.0.1",
+      PORT: String(port),
+      MOCK_ALLOW_UNAUTHENTICATED_MCP: "1",
+      MOCK_ERROR_TOOL_NAME: guardedToolName,
+      MOCK_ERROR_TOOL_TITLE: "Search ServiceNow incidents",
+      MOCK_ERROR_TOOL_DESCRIPTION: "Search ServiceNow-style incidents after provider authorization.",
+      MOCK_ERROR_TOOL_MODE: input.mode,
+      MOCK_ERROR_TOOL_PROVIDER: providerName,
+      MOCK_GET_STREAM: input.getStream ?? "405",
+    },
+  })
+  let output = ""
+  let hasExited = false
+  child.stdout.setEncoding("utf8")
+  child.stderr.setEncoding("utf8")
+  child.stdout.on("data", (chunk: string | Buffer) => {
+    output += String(chunk)
+  })
+  child.stderr.on("data", (chunk: string | Buffer) => {
+    output += String(chunk)
+  })
+  child.on("exit", (code: number | null, signal: string | null) => {
+    hasExited = true
+    output += `[mock exited code=${code ?? "null"} signal=${signal ?? "null"}]\n`
+  })
+  const server = {
+    origin,
+    mcpUrl: `${origin}/mcp`,
+    stop: () => stopChild(child, () => hasExited),
+    logs: () => output,
+  }
+  activeServers.push(server)
+  await waitForMockServer(origin, () => output)
+  return server
+}
+
+async function seedOrganization(label: string): Promise<SeededOrganization> {
+  const userId = createDenTypeId("user")
+  const organizationId = createDenTypeId("organization")
+  const memberId = createDenTypeId("member")
+  await db.insert(schema.AuthUserTable).values({
+    id: userId,
+    name: `${label} User`,
+    email: `${label}+${userId}@test.local`,
+  })
+  await db.insert(schema.OrganizationTable).values({
+    id: organizationId,
+    name: `${label} Org`,
+    slug: `${label}-${organizationId}`,
+  })
+  await db.insert(schema.MemberTable).values({
+    id: memberId,
+    organizationId,
+    userId,
+    role: "member",
+  })
+  return { organizationId, memberId }
+}
+
+async function createGrantedConnection(seed: SeededOrganization, server: MockScenarioServer, label: string) {
+  return createExternalMcpConnection({
+    organizationId: seed.organizationId,
+    name: `${label} ServiceNow Gateway`,
+    url: server.mcpUrl,
+    authType: "none",
+    credentialMode: "shared",
+    apiKey: null,
+    createdByOrgMembershipId: seed.memberId,
+    access: { orgWide: true, memberIds: [], teamIds: [] },
+  })
+}
+
+async function discoverCapability(seed: SeededOrganization, connectionId: string, connectionName: string) {
+  const matches = await searchExternalCapabilities({
+    organizationId: seed.organizationId,
+    member: { orgMembershipId: seed.memberId, teamIds: [] },
+    query: `${connectionName} incidents`,
+    redirectUriBase,
+    limit: 10,
+  })
+  const capabilityName = `mcp:${connectionId}:${guardedToolName}`
+  const match = matches.find((candidate) => candidate.name === capabilityName)
+  if (!match) throw new Error(`Capability ${capabilityName} was not discovered`)
+  if (typeof match.schemaDigest !== "string") throw new Error(`Capability ${capabilityName} did not include a schema digest`)
+  return { capabilityName, schemaDigest: match.schemaDigest }
+}
+
+function assertNoTransportWording(message: string): void {
+  const lower = message.toLowerCase()
+  for (const phrase of antiRegressionStrings) {
+    expect(lower).not.toContain(phrase.toLowerCase())
+  }
+}
+
+async function executeNeedsConnection(input: {
+  seed: SeededOrganization
+  connectionId: string
+  toolName: string
+  schemaDigest: string
+  server: MockScenarioServer
+}) {
+  const result = await executeExternalCapability({
+    organizationId: input.seed.organizationId,
+    member: { orgMembershipId: input.seed.memberId, teamIds: [] },
+    connectionId: input.connectionId,
+    toolName: input.toolName,
+    args: {},
+    schemaDigest: input.schemaDigest,
+    redirectUriBase,
+  })
+
+  expect(result.ok).toBe(false)
+  if (result.ok) throw new Error("Provider auth-required execution unexpectedly succeeded")
+  expect(result.error).toBe("needs_connection")
+  expect(result.retryable).toBe(false)
+  expect(result.providerError?.jsonRpcCode).toBe(-32001)
+  expect(result.providerError?.message).toContain("Authorization required")
+  expect(result.providerError?.message).toContain(providerName)
+  if (typeof result.referenceId !== "string") throw new Error("Provider auth-required result did not include a referenceId")
+  expect(result.referenceId.length).toBeGreaterThan(0)
+  assertNoTransportWording(result.message)
+
+  const connectionStatus = result.connectionStatus
+  if (!connectionStatus) throw new Error("Provider auth-required result did not include connectionStatus")
+  const actionUrl = connectionStatus.action.url
+  if (typeof actionUrl !== "string") throw new Error("Provider auth-required result did not include a connect action URL")
+  const parsedActionUrl = new URL(actionUrl)
+  expect(parsedActionUrl.origin).toBe(input.server.origin)
+  expect(parsedActionUrl.pathname).toBe("/connect/start")
+  expect(connectionStatus).toMatchObject({
+    layer: "downstream_provider",
+    state: "needs_connection",
+    errorCode: "not_connected",
+    action: {
+      type: "connect",
+      surface: "openwork_your_connections",
+      retry: "search_capabilities",
+      url: actionUrl,
+    },
+  })
+  expect("diagnostic" in result).toBe(false)
+  expect("actionOwner" in result).toBe(false)
+  expect("operatorAction" in result).toBe(false)
+  expect("diagnostic" in connectionStatus).toBe(false)
+  return { result, actionUrl }
+}
+
+async function completeConnectFlow(actionUrl: string): Promise<void> {
+  const start = await fetch(actionUrl)
+  expect(start.status).toBe(200)
+  expect(start.headers.get("content-type") ?? "").toContain("text/html")
+  expect(await start.text()).toContain("Sign in and authorize")
+
+  const completeUrl = new URL("/connect/complete", actionUrl).toString()
+  const complete = await fetch(completeUrl, { method: "POST" })
+  expect(complete.status).toBe(200)
+  expect(complete.headers.get("content-type") ?? "").toContain("text/html")
+  expect(await complete.text()).toContain("Connected — return to the app")
+}
+
+async function executeSucceeds(input: {
+  seed: SeededOrganization
+  connectionId: string
+  toolName: string
+  schemaDigest: string
+}) {
+  const result = await executeExternalCapability({
+    organizationId: input.seed.organizationId,
+    member: { orgMembershipId: input.seed.memberId, teamIds: [] },
+    connectionId: input.connectionId,
+    toolName: input.toolName,
+    args: {},
+    schemaDigest: input.schemaDigest,
+    redirectUriBase,
+  })
+  expect(result.ok).toBe(true)
+  if (!result.ok) throw new Error(`Provider auth-recovery execution failed: ${result.message}`)
+  expect(String(JSON.stringify(result.result))).toContain("INC0010023")
+  return result
+}
+
+async function assertScenarioState(server: MockScenarioServer, connected: boolean): Promise<void> {
+  const state = await fetchJson(`${server.origin}/__scenario/state`)
+  expect(state.response.status).toBe(200)
+  expect(own(state.body, "connected")).toBe(connected)
+}
+
+async function resetScenario(server: MockScenarioServer): Promise<void> {
+  const reset = await fetchJson(`${server.origin}/__scenario/reset`, { method: "POST" })
+  expect(reset.response.status).toBe(200)
+  expect(own(reset.body, "connected")).toBe(false)
+}
+
+async function runRecoveryScenario(input: {
+  label: string
+  mode: "authorization_required" | "authorization_required_uncorrelated"
+  getStream?: "reset" | "405"
+}): Promise<void> {
+  const server = await startMockScenario({ mode: input.mode, getStream: input.getStream })
+  try {
+    const seed = await seedOrganization(input.label)
+    const connection = await createGrantedConnection(seed, server, input.label)
+    const discovered = await discoverCapability(seed, connection.id, connection.name)
+
+    const blocked = await executeNeedsConnection({
+      seed,
+      connectionId: connection.id,
+      toolName: guardedToolName,
+      schemaDigest: discovered.schemaDigest,
+      server,
+    })
+    await completeConnectFlow(blocked.actionUrl)
+    await assertScenarioState(server, true)
+    await executeSucceeds({
+      seed,
+      connectionId: connection.id,
+      toolName: guardedToolName,
+      schemaDigest: discovered.schemaDigest,
+    })
+
+    await resetScenario(server)
+    await assertScenarioState(server, false)
+    await executeNeedsConnection({
+      seed,
+      connectionId: connection.id,
+      toolName: guardedToolName,
+      schemaDigest: discovered.schemaDigest,
+      server,
+    })
+  } finally {
+    await server.stop()
+  }
+}
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  mock.restore()
+  const realDb = (await import("@openwork-ee/den-db")).createDenDb({
+    databaseUrl: process.env.DATABASE_URL,
+    mode: "mysql",
+  }).db
+  mock.module("../src/db.js", () => ({ db: realDb }))
+
+  const [dbMod, schemaMod, typeIdMod, connectionsMod, capabilitiesMod, envMod] = await Promise.all([
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/schema"),
+    import("@openwork-ee/utils/typeid"),
+    import("../src/capability-sources/external-mcp-connections.js"),
+    import("../src/mcp/external-capabilities.js"),
+    import("../src/env.js"),
+  ])
+  envMod.env.allowPrivateMcpUrls = true
+  db = dbMod.db
+  schema = schemaMod
+  createDenTypeId = typeIdMod.createDenTypeId
+  createExternalMcpConnection = connectionsMod.createExternalMcpConnection
+  searchExternalCapabilities = capabilitiesMod.searchExternalCapabilities
+  executeExternalCapability = capabilitiesMod.executeExternalCapability
+})
+
+afterAll(async () => {
+  await Promise.all(activeServers.map((server) => server.stop()))
+  mock.restore()
+})
+
+test("uncorrelated provider auth-required errors recover through connect and retry despite reset background streams", async () => {
+  await runRecoveryScenario({
+    label: "auth-recovery-uncorrelated",
+    mode: "authorization_required_uncorrelated",
+    getStream: "reset",
+  })
+})
+
+test("correlated provider auth-required errors recover through the same connect and retry loop", async () => {
+  await runRecoveryScenario({
+    label: "auth-recovery-correlated",
+    mode: "authorization_required",
+  })
+})
+
+test("uncorrelated auth-required errors are never swallowed by reset background stream noise", async () => {
+  const server = await startMockScenario({ mode: "authorization_required_uncorrelated", getStream: "reset" })
+  try {
+    const seed = await seedOrganization("auth-recovery-swallowed-regression")
+    const connection = await createGrantedConnection(seed, server, "auth-recovery-swallowed-regression")
+    const discovered = await discoverCapability(seed, connection.id, connection.name)
+    for (let index = 0; index < 5; index += 1) {
+      const { result } = await executeNeedsConnection({
+        seed,
+        connectionId: connection.id,
+        toolName: guardedToolName,
+        schemaDigest: discovered.schemaDigest,
+        server,
+      })
+      expect(result.error).not.toBe("connection_failed")
+      assertNoTransportWording(result.message)
+    }
+  } finally {
+    await server.stop()
+  }
+})

--- a/evals/flows/den-provider-auth-relay.flow.mjs
+++ b/evals/flows/den-provider-auth-relay.flow.mjs
@@ -1,7 +1,7 @@
 /**
  * Internal proof for Den's downstream-provider authorization relay.
  *
- * Runs app-less against a real Den API and two public mock OAuth MCP gateways
+ * Runs app-less against a real Den API and three public mock OAuth MCP gateways
  * supplied by the orchestrator through OPENWORK_EVAL_* environment variables.
  */
 import { createRequire } from "node:module";
@@ -18,12 +18,14 @@ const REQUIRED_ENV = [
   "OPENWORK_EVAL_DEN_API_URL",
   "OPENWORK_EVAL_GATEWAY_MCP_URL",
   "OPENWORK_EVAL_GATEWAY_MCP_URL_FOREIGN",
+  "OPENWORK_EVAL_GATEWAY_MCP_URL_UNCORRELATED",
 ];
 const RUN_TAG = `${Date.now().toString(36)}-${randomBytes(3).toString("hex")}`;
 const ADMIN_EMAIL = `den-provider-auth-${RUN_TAG}@acme.test`;
 const ADMIN_PASSWORD = `OpenWork-${RUN_TAG}-Provider-Auth!`;
 const CONNECTION_A_NAME = `Salesforce Gateway Auth Required ${RUN_TAG}`;
 const CONNECTION_B_NAME = `Salesforce Gateway Foreign Link ${RUN_TAG}`;
+const CONNECTION_C_NAME = `Northwind Gateway Uncorrelated ${RUN_TAG}`;
 const TIMEOUT_WORDING = /latency|timed? ?out/i;
 
 const vo = await loadVoiceoverParagraphs(FLOW_ID);
@@ -37,8 +39,10 @@ const state = {
   orgMode: null,
   gatewayA: null,
   gatewayB: null,
+  gatewayC: null,
   rawGatewayA: null,
   rawGatewayB: null,
+  rawGatewayC: null,
   health: null,
 };
 
@@ -56,7 +60,7 @@ function readEvalEnv() {
 }
 
 function missingEnvMessage() {
-  return `Missing required environment variables for ${FLOW_ID}: ${envSnapshot.missing.join(", ")}. Set OPENWORK_EVAL_DEN_API_URL, OPENWORK_EVAL_GATEWAY_MCP_URL, and OPENWORK_EVAL_GATEWAY_MCP_URL_FOREIGN to the Daytona Den API and mock gateway MCP URLs.`;
+  return `Missing required environment variables for ${FLOW_ID}: ${envSnapshot.missing.join(", ")}. Set OPENWORK_EVAL_DEN_API_URL, OPENWORK_EVAL_GATEWAY_MCP_URL, OPENWORK_EVAL_GATEWAY_MCP_URL_FOREIGN, and OPENWORK_EVAL_GATEWAY_MCP_URL_UNCORRELATED to the Daytona Den API and mock gateway MCP URLs.`;
 }
 
 function requiredEnv(ctx) {
@@ -71,6 +75,7 @@ function requiredEnv(ctx) {
     denApiUrl: stripTrailingSlashes(envSnapshot.values.OPENWORK_EVAL_DEN_API_URL),
     gatewayMcpUrl: stripTrailingSlashes(envSnapshot.values.OPENWORK_EVAL_GATEWAY_MCP_URL),
     foreignGatewayMcpUrl: stripTrailingSlashes(envSnapshot.values.OPENWORK_EVAL_GATEWAY_MCP_URL_FOREIGN),
+    uncorrelatedGatewayMcpUrl: stripTrailingSlashes(envSnapshot.values.OPENWORK_EVAL_GATEWAY_MCP_URL_UNCORRELATED),
   };
 }
 
@@ -449,16 +454,52 @@ async function searchAndExecuteGateway(ctx, connection, query) {
   });
 }
 
+async function executeGatewayMatchSuccessfully(ctx, connection, match) {
+  const expectedName = `mcp:${own(connection, "id")}:${TOOL_NAME}`;
+  return withAgentClient(ctx, async (client) => {
+    const execute = await client.callTool({
+      name: "execute_capability",
+      arguments: { name: expectedName, schemaDigest: own(match, "schemaDigest"), body: {} },
+    });
+    witness(ctx, own(execute, "isError") !== true, "retried execute_capability succeeds after the provider connect flow", execute);
+    const text = firstText(execute);
+    witness(ctx, typeof text === "string" && text.includes("INC0010023"), "retried execute_capability returns the recovered incident content", execute);
+    return { execute, text };
+  });
+}
+
 function assertSameHostConnectUrl(ctx, connectUrl, connectionUrl) {
   const connect = new URL(connectUrl);
   const connection = new URL(connectionUrl);
-  witness(ctx, connect.host === connection.host, "The provider connect link is on the same host as gateway A", { connectUrl, connectionUrl });
+  witness(ctx, connect.host === connection.host, "The provider connect link is on the same host as its gateway", { connectUrl, connectionUrl });
 }
 
 function assertForeignHostConnectUrl(ctx, connectUrl, connectionUrl) {
   const connect = new URL(connectUrl);
   const connection = new URL(connectionUrl);
   witness(ctx, connect.host !== connection.host, "The foreign provider connect link is on a different host than gateway B", { connectUrl, connectionUrl });
+}
+
+function assertUncorrelatedGatewayBody(ctx, rawGateway, label) {
+  const error = jsonRpcError(rawGateway.call.body);
+  const connectUrl = jsonRpcConnectUrl(rawGateway.call.body);
+  witness(ctx, own(rawGateway.call.body, "id") === null, `${label} raw tools/call body uses id: null`, rawGateway.call.body);
+  witness(ctx, own(error, "code") === -32001, `${label} raw tools/call body carries JSON-RPC -32001`, rawGateway.call.body);
+  witness(ctx, typeof connectUrl === "string", `${label} raw tools/call body carries error.data.connect_url`, rawGateway.call.body);
+}
+
+async function completeGatewayConnectFlow(ctx, connectUrl, label) {
+  const start = await fetch(connectUrl);
+  const startText = await start.text();
+  witness(ctx, start.status === 200, `${label} connect/start returns HTTP 200`, { status: start.status, body: startText.slice(0, 300) });
+  witness(ctx, (start.headers.get("content-type") ?? "").includes("text/html"), `${label} connect/start returns HTML`, start.headers.get("content-type"));
+  witness(ctx, startText.includes("Sign in and authorize"), `${label} connect/start renders the authorize button`, startText.slice(0, 300));
+
+  const completeUrl = new URL("/connect/complete", connectUrl);
+  const complete = await fetch(completeUrl, { method: "POST" });
+  const completeText = await complete.text();
+  witness(ctx, complete.status === 200, `${label} connect/complete POST returns HTTP 200`, { status: complete.status, body: completeText.slice(0, 300) });
+  witness(ctx, completeText.includes("Connected — return to the app"), `${label} connect/complete marks the provider connected`, completeText.slice(0, 300));
 }
 
 function assertProviderAuthEnvelope(ctx, envelope, expectedConnectUrl) {
@@ -601,6 +642,51 @@ export default {
               rawToolsCall: { httpStatus: state.rawGatewayB.call.response.status, body: state.rawGatewayB.call.body },
               selectedMatch: state.gatewayB.agentResult.match,
               executeEnvelope: state.gatewayB.agentResult.envelope,
+            }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5 — The uncorrelated production dialect still relays as needs_connection",
+      run: async (ctx) => {
+        await ctx.prove("A raw id:null provider authorization error survives the real Den agent execute pipeline", {
+          voiceover: vo[4],
+          action: async () => {
+            const { uncorrelatedGatewayMcpUrl } = requiredEnv(ctx);
+            state.gatewayC = await createGatewayConnection(ctx, { name: CONNECTION_C_NAME, url: uncorrelatedGatewayMcpUrl });
+            state.rawGatewayC = await captureRawGatewayAuthRequired(ctx, uncorrelatedGatewayMcpUrl, "gateway C");
+            state.gatewayC.agentResult = await searchAndExecuteGateway(ctx, state.gatewayC, `${CONNECTION_C_NAME} ${TOOL_NAME}`);
+          },
+          assert: async () => {
+            const { uncorrelatedGatewayMcpUrl } = requiredEnv(ctx);
+            assertSameHostConnectUrl(ctx, state.rawGatewayC.connectUrl, uncorrelatedGatewayMcpUrl);
+            assertUncorrelatedGatewayBody(ctx, state.rawGatewayC, "gateway C");
+            assertProviderAuthEnvelope(ctx, state.gatewayC.agentResult.envelope, state.rawGatewayC.connectUrl);
+            ctx.output("uncorrelated-gateway-c-needs-connection", JSON.stringify({
+              endpoint: uncorrelatedGatewayMcpUrl,
+              rawToolsCall: { httpStatus: state.rawGatewayC.call.response.status, body: state.rawGatewayC.call.body },
+              selectedMatch: state.gatewayC.agentResult.match,
+              executeEnvelope: state.gatewayC.agentResult.envelope,
+            }, null, 2));
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 6 — Provider sign-in recovers the same capability on retry",
+      run: async (ctx) => {
+        await ctx.prove("Completing the mock provider connect flow makes the retried Den execute succeed", {
+          voiceover: vo[5],
+          action: async () => {
+            await completeGatewayConnectFlow(ctx, state.rawGatewayC.connectUrl, "gateway C");
+            state.gatewayC.retryResult = await executeGatewayMatchSuccessfully(ctx, state.gatewayC, state.gatewayC.agentResult.match);
+          },
+          assert: async () => {
+            witness(ctx, String(state.gatewayC.retryResult.text ?? "").includes("INC0010023"), "The retried execute returns INC0010023 from the recovered provider", state.gatewayC.retryResult);
+            ctx.output("uncorrelated-gateway-c-recovered-retry", JSON.stringify({
+              connection: compactConnection(state.gatewayC),
+              retryText: state.gatewayC.retryResult.text,
             }, null, 2));
           },
         });

--- a/evals/voiceovers/den-provider-auth-relay.md
+++ b/evals/voiceovers/den-provider-auth-relay.md
@@ -1,6 +1,6 @@
 # den-provider-auth-relay — Den relays downstream provider sign-in links safely
 
-This internal proof follows a live Den server and two gateway-style MCP servers in the same isolated Daytona sandbox. The reviewer sees the health evidence, the raw gateway authorization payload, the agent-facing response, and the host-binding safety check.
+This internal proof follows a live Den server and three gateway-style MCP servers in the same isolated Daytona sandbox. The reviewer sees the health evidence, the raw gateway authorization payload, the agent-facing response, the host-binding safety check, and the recovered retry.
 
 1. The opening frame shows a live Den API in an isolated Daytona sandbox. The health check answers from the public URL, and the service's build version is displayed so the reviewer can tell which server is responding.
 
@@ -8,4 +8,8 @@ This internal proof follows a live Den server and two gateway-style MCP servers 
 
 3. Now the agent uses the Cloud Control surface just like a real worker would. Search finds the Salesforce tool, execute returns needs_connection, the downstream-provider status carries the exact sign-in link, and the old latency or timeout wording is nowhere in the answer.
 
-4. The final frame checks the safety rail. A second gateway asks for connection too, but because its link points at a different host, Den still reports needs_connection while removing the untrusted URL from both the diagnostic and the action.
+4. The fourth frame checks the safety rail. A second gateway asks for connection too, but because its link points at a different host, Den still reports needs_connection while removing the untrusted URL from both the diagnostic and the action.
+
+5. The next frame replays the production dialect: the raw gateway body uses id null with JSON-RPC -32001 and a same-host connect URL, and Den still returns needs_connection with that sign-in link instead of transport wording.
+
+6. The recovery frame posts through the mock provider sign-in page, retries the same capability, and proves the incident result now comes back successfully.

--- a/scripts/mock-oauth-mcp-server.mjs
+++ b/scripts/mock-oauth-mcp-server.mjs
@@ -28,8 +28,9 @@ const errorToolTitle = (process.env.MOCK_ERROR_TOOL_TITLE || errorToolName).trim
 const errorToolDescription = (process.env.MOCK_ERROR_TOOL_DESCRIPTION || "Returns a provider policy error from the mock OAuth MCP server.").trim();
 const errorToolStatus = Number(process.env.MOCK_ERROR_TOOL_STATUS || 403);
 const errorToolMode = (process.env.MOCK_ERROR_TOOL_MODE || "result").trim();
-const errorToolConnectUrl = (process.env.MOCK_ERROR_TOOL_CONNECT_URL || "https://connect.example.test/salesforce/start").trim();
+const errorToolConnectUrl = (process.env.MOCK_ERROR_TOOL_CONNECT_URL || "").trim();
 const errorToolProvider = (process.env.MOCK_ERROR_TOOL_PROVIDER || "salesforce").trim();
+const getStreamMode = (process.env.MOCK_GET_STREAM || "405").trim();
 const allowUnauthenticatedMcp = process.env.MOCK_ALLOW_UNAUTHENTICATED_MCP === "1";
 
 const clients = new Map();
@@ -38,6 +39,7 @@ const tokens = new Set();
 const refreshTokens = new Set();
 const requests = [];
 const drafts = [];
+let connected = false;
 
 const gmailThreadId = "thread-q3-launch";
 
@@ -177,6 +179,74 @@ function protectedResourceMetadata() {
     scopes_supported: advertisedScopes,
     bearer_methods_supported: ["header"],
   };
+}
+
+function isAuthorizationRequiredMode() {
+  return errorToolMode === "authorization_required" || errorToolMode === "authorization_required_uncorrelated";
+}
+
+function currentErrorToolConnectUrl() {
+  if (errorToolConnectUrl) return errorToolConnectUrl;
+  const url = new URL(`${issuer}/connect/start`);
+  url.searchParams.set("provider", errorToolProvider);
+  return url.toString();
+}
+
+function providerAuthRequiredResponse(message) {
+  const connectUrl = currentErrorToolConnectUrl();
+  const connectLink = `[${connectUrl}](${connectUrl})`;
+  return {
+    jsonrpc: "2.0",
+    id: errorToolMode === "authorization_required_uncorrelated" ? null : message.id,
+    error: {
+      code: -32001,
+      message: `Authorization required — connect your ${errorToolProvider} account to use this connector. Open ${connectLink} in a browser, sign in, then retry this request.`,
+      data: {
+        connect_url: connectUrl,
+        provider: errorToolProvider,
+      },
+    },
+  };
+}
+
+function providerConnectedResult() {
+  return {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify([
+          { id: "INC0010023", short_description: "printer down", priority: "P3" },
+          { id: "INC0010024", short_description: "badge reader offline", priority: "P2" },
+        ]),
+      },
+    ],
+  };
+}
+
+function connectStartPage(url) {
+  const provider = url.searchParams.get("provider") || errorToolProvider;
+  return `<!doctype html>
+<html>
+  <head><title>Connect ${escapeHtml(provider)}</title></head>
+  <body style="font-family: system-ui, sans-serif; max-width: 560px; margin: 48px auto;">
+    <h1>Connect ${escapeHtml(provider)}</h1>
+    <p>Sign in to authorize OpenWork to use this mock provider account.</p>
+    <form method="post" action="/connect/complete">
+      <button style="font: inherit; padding: 10px 14px;">Sign in and authorize</button>
+    </form>
+  </body>
+</html>`;
+}
+
+function connectCompletePage() {
+  return `<!doctype html>
+<html>
+  <head><title>Connected</title></head>
+  <body style="font-family: system-ui, sans-serif; max-width: 560px; margin: 48px auto;">
+    <h1>Connected — return to the app</h1>
+    <p>The mock provider account is now authorized. Return to OpenWork and retry the capability.</p>
+  </body>
+</html>`;
 }
 
 function authorizationServerMetadata() {
@@ -454,6 +524,9 @@ function mcpResult(message) {
       };
     case "tools/call":
       if (errorToolName && message.params?.name === errorToolName) {
+        if (isAuthorizationRequiredMode() && connected) {
+          return providerConnectedResult();
+        }
         return {
           isError: true,
           structuredContent: {
@@ -494,24 +567,13 @@ function mcpResult(message) {
 
 function mcpResponse(message) {
   if (
-    errorToolMode === "authorization_required"
+    isAuthorizationRequiredMode()
     && errorToolName
     && message.method === "tools/call"
     && message.params?.name === errorToolName
   ) {
-    const connectLink = `[${errorToolConnectUrl}](${errorToolConnectUrl})`;
-    return {
-      jsonrpc: "2.0",
-      id: message.id,
-      error: {
-        code: -32001,
-        message: `Authorization required — connect your ${errorToolProvider} account to use this connector. Open ${connectLink} in a browser, sign in, then retry this request.`,
-        data: {
-          connect_url: errorToolConnectUrl,
-          provider: errorToolProvider,
-        },
-      },
-    };
+    if (!connected) return providerAuthRequiredResponse(message);
+    return { jsonrpc: "2.0", id: message.id, result: providerConnectedResult() };
   }
 
   return { jsonrpc: "2.0", id: message.id, result: mcpResult(message) };
@@ -527,6 +589,10 @@ async function handleMcp(req, res) {
   }
 
   if (req.method === "GET") {
+    if (getStreamMode === "reset") {
+      req.socket.destroy();
+      return;
+    }
     json(res, 405, { error: "method_not_allowed" });
     return;
   }
@@ -574,6 +640,28 @@ const server = http.createServer(async (req, res) => {
 
     if (url.pathname === "/requests") {
       json(res, 200, { requests });
+      return;
+    }
+
+    if (url.pathname === "/__scenario/state" && req.method === "GET") {
+      json(res, 200, { connected, mode: errorToolMode });
+      return;
+    }
+
+    if (url.pathname === "/__scenario/reset" && req.method === "POST") {
+      connected = false;
+      json(res, 200, { connected, mode: errorToolMode });
+      return;
+    }
+
+    if (url.pathname === "/connect/start" && req.method === "GET") {
+      text(res, 200, connectStartPage(url));
+      return;
+    }
+
+    if (url.pathname === "/connect/complete" && (req.method === "GET" || req.method === "POST")) {
+      connected = true;
+      text(res, 200, connectCompletePage());
       return;
     }
 


### PR DESCRIPTION
## What

Turns the production partner-gateway auth incident into a permanently reproducible scenario, end to end. **Stacked on #2936** (asserts the slim `providerError` contract) — merge that first.

### The mock gateway (`scripts/mock-oauth-mcp-server.mjs`) becomes a stateful scenario server

- `MOCK_ERROR_TOOL_MODE=authorization_required_uncorrelated` — the **exact production wire shape**: HTTP 200 + JSON-RPC error `-32001` with **`"id": null`** + `data.connect_url` (the variant that defeats SDK correlation and used to get swallowed).
- `MOCK_GET_STREAM=reset|405` — hostile background GET stream (socket destroy), reproducing the tracker-pollution conditions from production.
- **Working connect flow**: `connect_url` → `/connect/start` (sign-in page) → `/connect/complete` flips server state → the same tool call now returns real data (`INC0010023 — printer down — P3`).
- `/__scenario/reset` re-arms, `/__scenario/state` introspects. Existing env API untouched (desktop e2e keeps working); explicit `MOCK_ERROR_TOOL_CONNECT_URL` override preserved.

### End-to-end recovery test through the real Den pipeline

`ee/apps/den-api/test/external-mcp-provider-auth-recovery.test.ts` spawns the real mock script and drives the real execute pipeline:

- **Scenario A (the incident, recovered)**: uncorrelated mode + hostile GET → `needs_connection`, `retryable: false`, `providerError.jsonRpcCode: -32001`, provider message quoted, host-bound `connectionStatus.action.url`, and **none of the anti-regression strings** ("check provider latency", "protocol lifecycle", "MCP transport") → fetch connect URL + complete → re-execute → success → reset → error re-arms.
- **Scenario B**: same loop with the correlated (id-echoed) dialect.
- **Scenario C**: 5× execute loop under the swallowed-error conditions — every run must classify `needs_connection` (pins the fix against interleaving flakiness).

### Eval flow

`den-provider-auth-relay.flow.mjs` gains frames: raw `id:null` gateway payload witness → agent-facing needs_connection → connect flow completion over HTTP → recovered retry success. Voiceover updated.

## Tests

From `ee/apps/den-api`:
- `bun test test/external-mcp-provider-auth-recovery.test.ts` → **3 pass / 0 fail (201 expect)**
- Full set incl. existing suites → **135 pass / 0 fail (672 expect)**
- `pnpm exec tsc --noEmit` → clean; `node --check` on both .mjs files → clean
- Mock smoke via curl: id:null error → sign-in page → complete → `INC0010023` → reset re-arms (outputs in commit/task log)

## Why

"Then we will be able to test this error state reliably" — the incident's exact wire behavior (both dialects + stream hostility) and its full human recovery loop are now a fixture, not a memory.

