### PR TITLE
fix(den-web): prevent SSO reauth provider loop

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
+++ b/ee/apps/den-web/app/(den)/_components/reauth-dialog.tsx
@@ -1,12 +1,13 @@
 "use client";
 
 import { ShieldCheck, X } from "lucide-react";
-import { useEffect, useMemo, useRef, useState, type FormEvent } from "react";
+import { useEffect, useRef, useState, type FormEvent } from "react";
 import { DenButton, buttonVariants } from "./ui/button";
 import { DenInput } from "./ui/input";
 import { DenNotice } from "./ui/notice";
 import { type AuthUser, getErrorMessage, getUser, requestJson, type SocialAuthProvider, WORKSPACE_REAUTH_SECURITY_MESSAGE } from "../_lib/den-flow";
 import { type DenOrgContext, getRequireSsoFromMetadata } from "../_lib/den-org";
+import { resolveReauthMethods } from "../_lib/reauth-method-policy";
 
 function getSocialLabel(provider: SocialAuthProvider) {
   return provider === "google" ? "Google" : "GitHub";
@@ -50,8 +51,6 @@ function getReauthCompleteMessage(data: unknown): ReauthCompleteMessage | null {
   return { type: "openwork:reauth-complete", nonce: data.nonce, error };
 }
 
-const REAUTH_SOCIAL_PROVIDERS: readonly SocialAuthProvider[] = ["google", "github"];
-
 export function ReauthDialog({
   open,
   user,
@@ -78,11 +77,11 @@ export function ReauthDialog({
   const popupClosedIntervalRef = useRef<number | null>(null);
 
   const effectiveProviders = providers.length > 0 ? providers : user?.authProviders ?? [];
-  const hasPassword = !loadingMethods && (effectiveProviders.length === 0 || effectiveProviders.includes("email"));
-  const socialProviders = useMemo(
-    () => REAUTH_SOCIAL_PROVIDERS.filter((provider) => effectiveProviders.includes(provider)),
-    [effectiveProviders],
-  );
+  const { hasPassword, socialProviders } = resolveReauthMethods({
+    providers: effectiveProviders,
+    loading: loadingMethods,
+    requiresSso: Boolean(ssoUrl),
+  });
   const hasManagedOrgSignIn = Boolean(
     ssoUrl ||
       getRequireSsoFromMetadata(orgContext?.organization.metadata ?? null) ||
@@ -125,6 +124,8 @@ export function ReauthDialog({
       setError(null);
       setBusy(false);
       setLoadingMethods(false);
+      setProviders([]);
+      setSsoUrl(null);
       return;
     }
 
@@ -134,6 +135,7 @@ export function ReauthDialog({
     }
 
     let cancelled = false;
+    setSsoUrl(null);
     setLoadingMethods(true);
 
     void (async () => {
@@ -147,11 +149,11 @@ export function ReauthDialog({
         const email = refreshedUser?.email ?? user?.email ?? "";
         if (email) {
           const ssoResult = await requestJson(`/v1/orgs/sso/resolve?email=${encodeURIComponent(email)}`, { method: "GET" }, 12000);
-          if (!cancelled && ssoResult.response.ok) {
-            const payload = ssoResult.payload;
-            const nextUrl = payload && typeof payload === "object" && "signInUrl" in payload && typeof payload.signInUrl === "string"
-              ? payload.signInUrl
-              : null;
+          const payload = ssoResult.payload;
+          const nextUrl = ssoResult.response.ok && payload && typeof payload === "object" && "signInUrl" in payload && typeof payload.signInUrl === "string"
+            ? payload.signInUrl
+            : null;
+          if (!cancelled) {
             setSsoUrl(nextUrl);
           }
         }

--- a/ee/apps/den-web/app/(den)/_lib/reauth-method-policy.ts
+++ b/ee/apps/den-web/app/(den)/_lib/reauth-method-policy.ts
@@ -1,0 +1,21 @@
+import type { SocialAuthProvider } from "./den-flow";
+
+const REAUTH_SOCIAL_PROVIDERS: readonly SocialAuthProvider[] = ["google", "github"];
+
+export function resolveReauthMethods(input: {
+  providers: readonly string[];
+  loading: boolean;
+  requiresSso: boolean;
+}) {
+  if (input.loading || input.requiresSso) {
+    return {
+      hasPassword: false,
+      socialProviders: [] satisfies SocialAuthProvider[],
+    };
+  }
+
+  return {
+    hasPassword: input.providers.length === 0 || input.providers.includes("email"),
+    socialProviders: REAUTH_SOCIAL_PROVIDERS.filter((provider) => input.providers.includes(provider)),
+  };
+}

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts tests/scim-sso-readiness.test.ts app/api/_lib/upstream-proxy.test.mjs",
+    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts tests/scim-sso-readiness.test.ts tests/reauth-method-policy.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/reauth-method-policy.test.ts
+++ b/ee/apps/den-web/tests/reauth-method-policy.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { resolveReauthMethods } from "../app/(den)/_lib/reauth-method-policy";
+
+describe("reauthentication method policy", () => {
+  test("offers only organization SSO when an SSO requirement is resolved", () => {
+    expect(resolveReauthMethods({
+      providers: ["google", "email"],
+      loading: false,
+      requiresSso: true,
+    })).toEqual({
+      hasPassword: false,
+      socialProviders: [],
+    });
+  });
+
+  test("does not expose a social provider before SSO resolution completes", () => {
+    expect(resolveReauthMethods({
+      providers: ["google"],
+      loading: true,
+      requiresSso: false,
+    })).toEqual({
+      hasPassword: false,
+      socialProviders: [],
+    });
+  });
+
+  test("preserves linked methods when organization SSO is not required", () => {
+    expect(resolveReauthMethods({
+      providers: ["google", "email"],
+      loading: false,
+      requiresSso: false,
+    })).toEqual({
+      hasPassword: true,
+      socialProviders: ["google"],
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- keep reauthentication provider choices aligned with the server's enterprise SSO policy
- hide Google, GitHub, and password reauthentication while method discovery is running
- once organization SSO resolves as required, offer only organization SSO
- reset resolved provider state when the security dialog closes
- cover SSO-required, discovery-pending, and normal Google-linked accounts with focused tests

## Root cause

The security-check dialog could show both **Continue with organization SSO** and **Continue with Google** for the same managed account. If the user chose Google, Better Auth created a Google session, but the enterprise-auth callback hook correctly rejected it, deleted that session cookie, and redirected the popup to organization SSO.

That produced a Google → Microsoft SSO loop. If the Microsoft step was then canceled, the shared browser session cookie had already been cleared, so the dashboard appeared logged out.

## What this PR changes

This PR keeps the server's SSO enforcement intact and fixes the conflicting UI contract:

1. While OpenWork is checking the available methods, alternate providers are not actionable.
2. When `/v1/orgs/sso/resolve` returns an organization SSO URL, Google, GitHub, and password are removed from the reauthentication choices.
3. Accounts without required SSO keep their existing linked-provider behavior.
4. Provider and SSO resolution state is cleared when the dialog closes so it cannot leak into a later security check.

The provider-selection rules live in a small pure policy helper so the conflict is directly testable without weakening authentication enforcement.

## User impact

SSO-managed users now see one valid path through a sensitive-action security check: their organization SSO. They can no longer select Google and be redirected into Microsoft after Google completes. Non-SSO Google users continue to see **Continue with Google**.

## Validation

- `pnpm --filter @openwork-ee/den-web typecheck`
- `pnpm --dir ee/packages/utils build`
- `pnpm --filter @openwork-ee/den-web test` — 64 passed, 0 failed
- focused regression test — 3 passed, 0 failed
- `git diff --check`

## Risk and limitations

- Identity and authorization policy are unchanged; this only removes methods the server would reject for an SSO-managed user.
- No secrets, tenant data, network policy, database schema, or session lifetime behavior changes.
- Rollback is the single commit in this PR.
- Not run: a live Microsoft Entra SSO journey, because this worktree does not have an organization IdP configured. The reported production sequence and the provider-selection policy are covered by code tracing and unit tests, but the final popup journey still needs manual confirmation in an SSO-enabled workspace.

## Manual verification

1. Use a Google-linked account that belongs to a workspace with enabled organization SSO.
2. Make its session stale, then trigger a sensitive workspace action.
3. Confirm the dialog shows the loading state and then only **Continue with organization SSO**—not Google or password.
4. Close the SSO popup and confirm the dashboard remains signed in.
5. Complete organization SSO and confirm the pending action retries automatically.
6. Repeat with a non-SSO Google-linked account and confirm **Continue with Google** is still offered.
