### PR TITLE
fix(app): keep resize cursor on workspace rail

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -841,6 +841,7 @@ export function AppSidebar(props: AppSidebarProps) {
         </SidebarFooter>
         <SidebarRail
           className="before:pointer-events-none before:absolute before:inset-y-0 before:left-[calc(50%+1px)] before:right-0 before:content-[''] group-data-[state=expanded]:before:bg-sidebar"
+          style={{ cursor: "col-resize" }}
           aria-label={props.onStartResize ? t("session.resize_workspace_column") : undefined}
           title={props.onStartResize ? t("session.resize_workspace_column") : undefined}
           onClick={props.onStartResize ? (event) => {


### PR DESCRIPTION
## Summary

- keep the column-resize cursor stable over the workspace sidebar resize rail

## Root cause

The resize rail is rendered as a button, so the app's global button cursor rule displayed the pointing-hand cursor while the pointer was directly over the rail. The drag handler briefly restored the resize cursor during movement.

## Validation

- `./bin/openwork-hub run desktop resize-cursor -- pnpm --filter @openwork/app typecheck`
- Launched the Electron app through the isolated desktop worktree; the user confirmed the divider now keeps the resize cursor while hovering and dragging.

## Risk and remaining gaps

- Low risk: the change is limited to the workspace resize rail's cursor style.
- No automated visual cursor assertion; native cursor behavior was verified manually in the desktop app.
