### PR TITLE
fix(app): never restore the side panel on app load

### DIFF
--- a/apps/app/src/react-app/shell/ui-state-store.ts
+++ b/apps/app/src/react-app/shell/ui-state-store.ts
@@ -18,27 +18,7 @@ export const SIDE_PANEL_ITEMS = ["panel", "extensions", "voice"] as const;
 export type SidePanelItem = (typeof SIDE_PANEL_ITEMS)[number];
 export type SidePanelState = Record<string, SidePanelItem | null>;
 
-const LEGACY_UNIFIED_PANEL_ITEMS = ["browser", "artifacts"] as const;
-type LegacyUnifiedPanelItem = (typeof LEGACY_UNIFIED_PANEL_ITEMS)[number];
-
-function normalizeSidePanelItem(value: unknown): SidePanelItem | null {
-  if (value === null) {
-    return null;
-  }
-
-  if (isSidePanelItem(value)) {
-    return value;
-  }
-
-  if (LEGACY_UNIFIED_PANEL_ITEMS.includes(value as LegacyUnifiedPanelItem)) {
-    return "panel";
-  }
-
-  return null;
-}
-
 export type PersistedUiState = {
-  sidePanelState?: SidePanelState;
   applicationMenuVisible?: boolean;
   workspaceLeftSidebarWidth?: number;
   workspaceRightSidebarExpanded?: boolean;
@@ -47,6 +27,7 @@ export type PersistedUiState = {
 
 export type UiState = {
   sidebarOpen: boolean;
+  // Deliberately not persisted so each app load starts with only chat visible.
   sidePanelState: SidePanelState;
   applicationMenuVisible: boolean;
   workspaceLeftSidebarWidth: number;
@@ -112,31 +93,6 @@ function readLegacyWorkspaceLayoutState() {
   } satisfies Partial<PersistedUiState>;
 }
 
-function isSidePanelItem(value: unknown): value is SidePanelItem {
-  return SIDE_PANEL_ITEMS.includes(value as SidePanelItem);
-}
-
-function normalizeSidePanelState(value: unknown): SidePanelState {
-  if (!value || typeof value !== "object" || Array.isArray(value)) {
-    return initialState.sidePanelState;
-  }
-
-  return Object.fromEntries(
-    Object.entries(value).flatMap(([sessionId, panel]) => {
-      if (typeof sessionId !== "string") {
-        return [];
-      }
-
-      const normalized = normalizeSidePanelItem(panel);
-      if (normalized === null && panel !== null) {
-        return [];
-      }
-
-      return [[sessionId, normalized] as const];
-    }),
-  );
-}
-
 function readSidebarCookieOpen(): boolean | null {
   if (globalThis.window === undefined) {
     return null;
@@ -178,12 +134,10 @@ function readPersistedUiState(): UiState {
     }
 
     const parsed: PersistedUiState = JSON.parse(raw);
-    const sidePanelState = normalizeSidePanelState(parsed.sidePanelState);
 
     return {
       ...initialState,
       sidebarOpen,
-      sidePanelState,
       applicationMenuVisible: parsed.applicationMenuVisible ?? initialState.applicationMenuVisible,
       workspaceLeftSidebarWidth: normalizeNumber(
         parsed.workspaceLeftSidebarWidth,
@@ -214,7 +168,6 @@ export function persistUiState(state: UiState): void {
     window.localStorage.setItem(
       PERSISTED_UI_STATE_KEY,
       JSON.stringify({
-        sidePanelState: state.sidePanelState,
         applicationMenuVisible: state.applicationMenuVisible,
         workspaceLeftSidebarWidth: state.workspaceLeftSidebarWidth,
         workspaceRightSidebarExpanded: state.workspaceRightSidebarExpanded,

--- a/apps/app/tests/ui-state-store.test.ts
+++ b/apps/app/tests/ui-state-store.test.ts
@@ -1,0 +1,121 @@
+import { afterAll, describe, expect, test } from "bun:test";
+
+import type { UiState } from "../src/react-app/shell/ui-state-store";
+
+const PERSISTED_UI_STATE_KEY = "openwork:ui-state:v1";
+const originalWindow = globalThis.window;
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+function requireJsonObject(raw: string | null): object {
+  expect(raw).not.toBeNull();
+  if (raw === null) {
+    throw new Error("Expected persisted UI state JSON");
+  }
+
+  const parsed: unknown = JSON.parse(raw);
+  expect(parsed).not.toBeNull();
+  expect(typeof parsed).toBe("object");
+  if (parsed === null || typeof parsed !== "object") {
+    throw new Error("Expected persisted UI state object");
+  }
+
+  return parsed;
+}
+
+function objectValue(object: object, key: string): unknown {
+  return Object.entries(object).find(([entryKey]) => entryKey === key)?.[1];
+}
+
+const storage = memoryStorage();
+storage.setItem(
+  PERSISTED_UI_STATE_KEY,
+  JSON.stringify({ sidePanelState: { ses_1: "extensions" }, workspaceRightSidebarExpanded: true }),
+);
+
+Object.defineProperty(globalThis, "window", {
+  configurable: true,
+  value: {
+    document: { cookie: "" },
+    localStorage: storage,
+  },
+});
+
+const { persistUiState, toggleSidePanelState, useUiStateStore } = await import(
+  "../src/react-app/shell/ui-state-store"
+);
+
+const importedSidePanelState = useUiStateStore.getState().sidePanelState;
+const importedWorkspaceRightSidebarExpanded = useUiStateStore.getState().workspaceRightSidebarExpanded;
+
+afterAll(() => {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: originalWindow,
+  });
+});
+
+describe("ui state store", () => {
+  test("persists UI state without side panel state", () => {
+    const state: UiState = {
+      sidebarOpen: true,
+      sidePanelState: { ses_1: "extensions" },
+      applicationMenuVisible: false,
+      workspaceLeftSidebarWidth: 260,
+      workspaceLeftSidebarResizing: false,
+      workspaceRightSidebarExpanded: true,
+      workspaceRightSidebarExpandedWidth: 520,
+    };
+
+    persistUiState(state);
+
+    const parsed = requireJsonObject(storage.getItem(PERSISTED_UI_STATE_KEY));
+    expect("sidePanelState" in parsed).toBe(false);
+    expect(objectValue(parsed, "workspaceRightSidebarExpanded")).toBe(true);
+  });
+
+  test("ignores legacy persisted side panel state on startup", () => {
+    expect(importedSidePanelState).toEqual({});
+    expect(importedWorkspaceRightSidebarExpanded).toBe(true);
+  });
+
+  test("keeps side panel toggles in memory", () => {
+    const state: UiState = {
+      sidebarOpen: true,
+      sidePanelState: {},
+      applicationMenuVisible: false,
+      workspaceLeftSidebarWidth: 260,
+      workspaceLeftSidebarResizing: false,
+      workspaceRightSidebarExpanded: false,
+      workspaceRightSidebarExpandedWidth: 520,
+    };
+
+    const opened = toggleSidePanelState(state, "ses_1", "extensions");
+    expect(opened.sidePanelState).toEqual({ ses_1: "extensions" });
+
+    const closed = toggleSidePanelState(opened, "ses_1", "extensions");
+    expect(closed.sidePanelState).toEqual({ ses_1: null });
+  });
+});

--- a/evals/flows/side-panel-not-restored-on-load.flow.mjs
+++ b/evals/flows/side-panel-not-restored-on-load.flow.mjs
@@ -1,0 +1,222 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("side-panel-not-restored-on-load");
+
+const EXTENSIONS_TOGGLE = 'button[aria-label="Extensions"][aria-pressed]';
+const EXTENSIONS_MARKER = "Apps (MCP) and OpenCode plugins live in one place.";
+const UI_STATE_KEY = "openwork:ui-state:v1";
+
+async function waitForControl(ctx, label = "control API") {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label,
+  });
+}
+
+async function waitForRenderedBody(ctx) {
+  await ctx.waitFor("document.body.innerText.trim().length > 40", {
+    label: "rendered body text",
+  });
+}
+
+async function waitForActiveSessionId(ctx) {
+  return ctx.waitFor(
+    `(() => {
+      const route = window.__openworkControl.snapshot().route || "";
+      const match = route.match(/ses_[A-Za-z0-9]+/);
+      return match ? match[0] : null;
+    })()`,
+    { timeoutMs: 30_000, label: "active session id in route" },
+  );
+}
+
+async function readRouteSessionId(ctx) {
+  return ctx.eval(`(() => {
+    const route = window.__openworkControl.snapshot().route || "";
+    const match = route.match(/ses_[A-Za-z0-9]+/);
+    return match ? match[0] : null;
+  })()`);
+}
+
+async function readExtensionsToggle(ctx) {
+  return ctx.eval(`(() => {
+    const toggle = document.querySelector(${JSON.stringify(EXTENSIONS_TOGGLE)});
+    return toggle ? toggle.getAttribute("aria-pressed") : null;
+  })()`);
+}
+
+async function clickExtensionsToggle(ctx) {
+  const clicked = await ctx.eval(`(() => {
+    const toggle = document.querySelector(${JSON.stringify(EXTENSIONS_TOGGLE)});
+    if (!toggle) return false;
+    toggle.click();
+    return true;
+  })()`);
+  ctx.assert(clicked === true, "Extensions rail toggle was not found.");
+}
+
+async function closeExtensionsPanelIfOpen(ctx) {
+  const pressed = await readExtensionsToggle(ctx);
+  ctx.assert(pressed !== null, "Extensions rail toggle was not found.");
+  if (pressed === "true") {
+    await clickExtensionsToggle(ctx);
+    await ctx.waitFor(
+      `document.querySelector(${JSON.stringify(EXTENSIONS_TOGGLE)})?.getAttribute("aria-pressed") === "false"`,
+      { label: "Extensions panel closed" },
+    );
+    await ctx.waitFor(
+      `!document.body.innerText.includes(${JSON.stringify(EXTENSIONS_MARKER)})`,
+      { label: "Extensions panel marker gone" },
+    );
+  }
+}
+
+async function readPersistedUiState(ctx) {
+  return ctx.eval(`(() => {
+    const raw = localStorage.getItem(${JSON.stringify(UI_STATE_KEY)}) ?? "{}";
+    const parsed = JSON.parse(raw);
+    return {
+      raw,
+      keys: Object.keys(parsed),
+      hasSidePanelState: "sidePanelState" in parsed,
+    };
+  })()`);
+}
+
+export default {
+  id: "side-panel-not-restored-on-load",
+  kind: "user-facing",
+  title: "Reloading the app shows only the chat — the side panel is never restored on launch",
+  precondition: async (ctx) => {
+    await waitForControl(ctx);
+    const state = await ctx.waitFor(
+      `(() => {
+        const control = window.__openworkControl;
+        const route = control.snapshot().route;
+        if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+        const action = control.listActions().find((a) => a.id === "session.create_task");
+        if (action && !action.disabled) return "ready";
+        return null;
+      })()`,
+      { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+    );
+    return state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); side panel reload flow requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "Fresh task shows only the chat",
+      run: async (ctx) => {
+        await ctx.prove("A fresh task opens with the chat only and the Extensions side panel closed", {
+          voiceover: vo[0],
+          action: async () => {
+            await waitForControl(ctx);
+            await waitForRenderedBody(ctx);
+            await ctx.control("session.create_task");
+            const sessionId = await waitForActiveSessionId(ctx);
+            ctx.log(`active session: ${sessionId}`);
+            await closeExtensionsPanelIfOpen(ctx);
+          },
+          assert: async () => {
+            const sessionId = await readRouteSessionId(ctx);
+            ctx.assert(Boolean(sessionId), "No active session id after create_task.");
+            const pressed = await readExtensionsToggle(ctx);
+            ctx.assert(pressed === "false", `Expected Extensions toggle to be closed, got ${pressed}.`);
+            const hasComposer = await ctx.eval("Boolean(document.querySelector('[contenteditable=\"true\"]'))");
+            ctx.assert(hasComposer === true, "Composer was not present on the fresh task.");
+            await ctx.expectNoText(EXTENSIONS_MARKER);
+          },
+          screenshot: {
+            name: "chat-only",
+            rejectText: [EXTENSIONS_MARKER],
+          },
+        });
+      },
+    },
+    {
+      name: "Extensions rail button opens the panel",
+      run: async (ctx) => {
+        await ctx.prove("Clicking the Extensions rail button opens the panel next to the chat", {
+          voiceover: vo[1],
+          action: async () => {
+            await clickExtensionsToggle(ctx);
+            await ctx.waitFor(
+              `document.querySelector(${JSON.stringify(EXTENSIONS_TOGGLE)})?.getAttribute("aria-pressed") === "true"`,
+              { label: "Extensions toggle pressed" },
+            );
+            await ctx.waitForText(EXTENSIONS_MARKER, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText(EXTENSIONS_MARKER);
+            const pressed = await readExtensionsToggle(ctx);
+            ctx.assert(pressed === "true", `Expected Extensions toggle to be open, got ${pressed}.`);
+            const persisted = await readPersistedUiState(ctx);
+            ctx.assert(
+              persisted.hasSidePanelState === false,
+              `Persisted UI state still included sidePanelState after toggling Extensions: ${persisted.raw}`,
+            );
+            ctx.log(`persisted ui-state keys after opening Extensions: ${JSON.stringify(persisted.keys)}`);
+          },
+          screenshot: {
+            name: "extensions-open",
+            requireText: [EXTENSIONS_MARKER],
+          },
+        });
+      },
+    },
+    {
+      name: "Reload returns to the same task with chat only",
+      run: async (ctx) => {
+        let sessionId = null;
+
+        await ctx.prove("Reloading the app returns to the same task without restoring the side panel", {
+          voiceover: vo[2],
+          action: async () => {
+            sessionId = await readRouteSessionId(ctx);
+            ctx.assert(Boolean(sessionId), "No active session id before reload.");
+            ctx.log(`session before reload: ${sessionId}`);
+            await ctx.eval("(() => { window.__sidePanelReloadSentinel = true; window.location.reload(); return true; })()");
+            await ctx.waitFor("Boolean(window.__openworkControl) && !window.__sidePanelReloadSentinel", {
+              timeoutMs: 60_000,
+              label: "control API after reload",
+            });
+            await waitForRenderedBody(ctx);
+            const routeHasSession = await ctx.eval(
+              `window.__openworkControl.snapshot().route.includes(${JSON.stringify(sessionId)})`,
+            );
+            if (!routeHasSession) {
+              await ctx.waitFor(
+                `window.__openworkControl.listActions().some((a) => a.id === "session.open" && !a.disabled)`,
+                { timeoutMs: 45_000, label: "session.open available after reload" },
+              );
+              await ctx.control("session.open", { sessionId });
+            }
+            await ctx.waitFor(
+              `window.__openworkControl.snapshot().route.includes(${JSON.stringify(sessionId)})`,
+              { timeoutMs: 30_000, label: "same session route after reload" },
+            );
+          },
+          assert: async () => {
+            const pressed = await readExtensionsToggle(ctx);
+            ctx.assert(pressed === "false", `Expected Extensions toggle to be closed after reload, got ${pressed}.`);
+            await ctx.expectNoText(EXTENSIONS_MARKER);
+            const hasComposer = await ctx.eval("Boolean(document.querySelector('[contenteditable=\"true\"]'))");
+            ctx.assert(hasComposer === true, "Composer was not present after reload.");
+            const persisted = await readPersistedUiState(ctx);
+            ctx.assert(
+              persisted.hasSidePanelState === false,
+              `Persisted UI state included sidePanelState after reload: ${persisted.raw}`,
+            );
+            ctx.log(`persisted ui-state raw after reload: ${persisted.raw}`);
+            ctx.log(`persisted ui-state keys after reload: ${JSON.stringify(persisted.keys)}`);
+          },
+          screenshot: {
+            name: "chat-after-reload",
+            rejectText: [EXTENSIONS_MARKER],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/side-panel-not-restored-on-load.flow.mjs
+++ b/evals/flows/side-panel-not-restored-on-load.flow.mjs
@@ -3,7 +3,7 @@ import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 const vo = await loadVoiceoverParagraphs("side-panel-not-restored-on-load");
 
 const EXTENSIONS_TOGGLE = 'button[aria-label="Extensions"][aria-pressed]';
-const EXTENSIONS_MARKER = "Apps (MCP) and OpenCode plugins live in one place.";
+const EXTENSIONS_MARKER = "Extensions (Legacy)";
 const UI_STATE_KEY = "openwork:ui-state:v1";
 
 async function waitForControl(ctx, label = "control API") {
@@ -71,6 +71,26 @@ async function closeExtensionsPanelIfOpen(ctx) {
   }
 }
 
+async function dismissPromoDialogs(ctx) {
+  for (let index = 0; index < 3; index += 1) {
+    const foundDialog = await ctx.eval(`(() => {
+      const dialog = document.querySelector('[role="dialog"]');
+      if (!dialog) return false;
+      const closeButton = Array.from(dialog.querySelectorAll("button")).find(
+        (button) => button.textContent.trim() === "Close",
+      );
+      if (closeButton) {
+        closeButton.click();
+      } else {
+        document.body.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+      }
+      return true;
+    })()`);
+    if (!foundDialog) return;
+    await ctx.waitFor("!document.querySelector('[role=\"dialog\"]')", { label: "promo dialog dismissed" });
+  }
+}
+
 async function readPersistedUiState(ctx) {
   return ctx.eval(`(() => {
     const raw = localStorage.getItem(${JSON.stringify(UI_STATE_KEY)}) ?? "{}";
@@ -117,6 +137,7 @@ export default {
             const sessionId = await waitForActiveSessionId(ctx);
             ctx.log(`active session: ${sessionId}`);
             await closeExtensionsPanelIfOpen(ctx);
+            await dismissPromoDialogs(ctx);
           },
           assert: async () => {
             const sessionId = await readRouteSessionId(ctx);
@@ -146,6 +167,7 @@ export default {
               { label: "Extensions toggle pressed" },
             );
             await ctx.waitForText(EXTENSIONS_MARKER, { timeoutMs: 30_000 });
+            await dismissPromoDialogs(ctx);
           },
           assert: async () => {
             await ctx.expectText(EXTENSIONS_MARKER);
@@ -160,7 +182,8 @@ export default {
           },
           screenshot: {
             name: "extensions-open",
-            requireText: [EXTENSIONS_MARKER],
+            requireText: ["Extensions (Legacy)"],
+            rejectText: ["Use OpenWork Models without API keys"],
           },
         });
       },
@@ -196,6 +219,7 @@ export default {
               `window.__openworkControl.snapshot().route.includes(${JSON.stringify(sessionId)})`,
               { timeoutMs: 30_000, label: "same session route after reload" },
             );
+            await dismissPromoDialogs(ctx);
           },
           assert: async () => {
             const pressed = await readExtensionsToggle(ctx);

--- a/evals/voiceovers/side-panel-not-restored-on-load.md
+++ b/evals/voiceovers/side-panel-not-restored-on-load.md
@@ -1,0 +1,9 @@
+# side-panel-not-restored-on-load — Reloading OpenWork always lands on just the chat
+
+Before this fix, OpenWork remembered the right-hand side panel for every conversation — so anyone who once peeked at Extensions got that panel splashed over the app again on every launch. This proof drives the real desktop app: Alex opens the Extensions panel, the app reloads, and only the chat comes back.
+
+1. Alex is working in a task in OpenWork. It is just the conversation: the composer at the bottom, the tool rail on the right edge, and no side panel taking up half the window.
+
+2. Alex clicks the Extensions button on the rail, and the Extensions panel opens next to the chat — handy for a quick look at apps and plugins.
+
+3. The app reloads, just like quitting and reopening OpenWork. The same task comes back — but the Extensions panel does not. It is just the chat again, and the app's saved layout no longer remembers any side panel at all.


### PR DESCRIPTION
## Problem

On every app launch/reload, the right side panel came back in whatever state you last left it — anyone who once opened the **Extensions** panel got it splashed over the app on every reload, instead of landing on the chat.

## Fix

`sidePanelState` (the per-session `panel | extensions | voice` choice) is now **in-memory only**: it is no longer written to or restored from the persisted UI state (`openwork:ui-state:v1`). Every app load starts with just the chat. In-app toggling behaves exactly as before, and legacy `sidePanelState` entries already in localStorage are ignored and dropped on the next persist. All other persisted layout state (sidebar widths, right-sidebar expansion, menu visibility) is untouched.

- `apps/app/src/react-app/shell/ui-state-store.ts`: stop persisting/restoring `sidePanelState`; delete the now-dead legacy normalization helpers.
- `apps/app/tests/ui-state-store.test.ts`: regression tests — persisted JSON contains no `sidePanelState`; a seeded legacy `sidePanelState` in localStorage is ignored at startup while other fields still restore; in-memory toggling still works.
- `evals/`: voiceover + coded fraimz flow `side-panel-not-restored-on-load`.

## Tests

- `pnpm --filter @openwork/app typecheck` — passed
- `bun test tests/` (apps/app) — 369 pass, 0 fail
- `pnpm fraimz --flow side-panel-not-restored-on-load` against the real Electron app in a Daytona sandbox — **PASSED** (proof posted below): open Extensions → reload → same task returns with chat only, and the persisted UI state no longer contains any side panel entry.