### PR TITLE
fix(app): layer global cursor defaults

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -340,25 +340,6 @@ body {
   box-shadow: inset 0 0 0 1px rgba(var(--dls-accent-rgb), 0.28), 0 0 0 3px rgba(var(--dls-accent-rgb), 0.08);
 }
 
-/* Global clickable elements pointer */
-button,
-[role="button"],
-a,
-input[type="submit"],
-input[type="button"],
-input[type="checkbox"],
-input[type="radio"],
-select {
-  cursor: pointer;
-}
-
-button:disabled,
-[role="button"][aria-disabled="true"],
-input:disabled,
-select:disabled {
-  cursor: not-allowed;
-}
-
 @utility animate-spin-slow {
   animation: spin 3s linear infinite;
 }
@@ -535,5 +516,24 @@ select:disabled {
   }
   html {
     @apply font-sans;
+  }
+
+  /* Clickable defaults stay below utilities so interaction-specific cursors can override them. */
+  button,
+  [role="button"],
+  a,
+  input[type="submit"],
+  input[type="button"],
+  input[type="checkbox"],
+  input[type="radio"],
+  select {
+    cursor: pointer;
+  }
+
+  button:disabled,
+  [role="button"][aria-disabled="true"],
+  input:disabled,
+  select:disabled {
+    cursor: not-allowed;
   }
 }

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -841,7 +841,6 @@ export function AppSidebar(props: AppSidebarProps) {
         </SidebarFooter>
         <SidebarRail
           className="before:pointer-events-none before:absolute before:inset-y-0 before:left-[calc(50%+1px)] before:right-0 before:content-[''] group-data-[state=expanded]:before:bg-sidebar"
-          style={{ cursor: "col-resize" }}
           aria-label={props.onStartResize ? t("session.resize_workspace_column") : undefined}
           title={props.onStartResize ? t("session.resize_workspace_column") : undefined}
           onClick={props.onStartResize ? (event) => {


### PR DESCRIPTION
## Summary

- move the global clickable-element cursor defaults into Tailwind's `base` layer
- remove the workspace rail's inline cursor workaround from #2942
- restore the intended styling contract: base defaults apply normally, while interaction-specific Tailwind cursor utilities can override them

## Root cause

The app declared `cursor: pointer` for buttons, links, and related controls outside any cascade layer. Unlayered author CSS outranks Tailwind's layered utilities, so the SidebarRail's existing directional resize classes could not win while the pointer was directly over the button. The inline cursor from #2942 fixed that one rail but left the underlying cascade problem in place.

## Styling audit

- Reviewed the app's global cursor declarations and 72 cursor-utility usages.
- Confirmed the global clickable rule was the active unlayered rule defeating interaction-specific cursor utilities.
- Verified the SidebarRail already owns directional `w-resize` / `e-resize` utilities for side, collapse state, and RTL behavior.
- Found legacy `.ow-*` component classes that are also unlayered. Their only current panel usages are on the Den sign-in surface, where changing layers would alter panel radii. This PR deliberately leaves those visuals unchanged for a separate, explicit migration/review.
- Left the unlayered `html`, `body`, and `#root` shell sizing/overflow rules unchanged because they are app-shell invariants rather than component defaults.

## Validation

- `./bin/openwork-hub run desktop cursor-style-layering -- pnpm --filter @openwork/app typecheck`
- `./bin/openwork-hub run desktop cursor-style-layering -- pnpm --filter @openwork/app build:web`
- Launched the Electron development app through the isolated desktop worktree.
- Rendered the React UI against an isolated local workspace and checked computed cursors:
  - ordinary button: `pointer`
  - disabled button: `not-allowed`
  - workspace drag target: `grab`
  - workspace resize rail: `w-resize`, with no inline cursor
- Dragged the real workspace divider from 219px to 259px; the resize cursor remained `w-resize` and the sidebar width updated.
- Browser console review: no warnings or errors from the rendered UI.

The production build passed with the existing bundle-size warning and existing ignored `use memo` directive warnings.

## Manual UI review

From the Hub root:

```bash
./bin/openwork-hub run desktop cursor-style-layering -- pnpm dev
```

1. Open a workspace and hover the left workspace divider. Confirm the directional resize cursor remains stable.
2. Drag the divider in both directions and confirm resizing remains smooth.
3. Hover ordinary buttons and links; confirm they retain the pointing-hand cursor.
4. Hover disabled controls; confirm they retain the not-allowed cursor.
5. Drag a workspace or session-group title; confirm grab/grabbing cursors still appear.
6. Collapse and expand the sidebar and repeat the divider check.
7. Review both light and dark themes. RTL-specific cursor direction was audited in source but not exercised manually.

## Risk and remaining gaps

- The cascade change applies to all elements covered by the global clickable selector, allowing their explicit cursor utilities to work as intended.
- No unrelated component geometry or legacy `.ow-*` layering was changed.
- The isolated browser fixture did not run an OpenCode engine, so session/provider endpoints were outside this styling-only journey.
- No fraimz or screenshot artifact was produced; the PR remains draft for UI review.
