### PR TITLE
chore: neutralize partner-identifying fixture names in tests and evals

### DIFF
--- a/apps/desktop/electron/brand-icon-windows.test.mjs
+++ b/apps/desktop/electron/brand-icon-windows.test.mjs
@@ -181,7 +181,7 @@ test("anchors a packaged shortcut target to the active Windows user profile", ()
     packaged: true,
     execPath: "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Programs\\@openworkdesktop\\OpenWork.exe",
     resourcesPath: "C:\\Windows\\System32\\config\\systemprofile\\AppData\\Local\\Programs\\@openworkdesktop\\resources",
-    shortcutPath: "C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Blue Yonder.lnk",
+    shortcutPath: "C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs\\Northwind.lnk",
   }), "C:\\Users\\Administrator\\AppData\\Local\\Programs\\@openworkdesktop\\OpenWork.exe");
 });
 

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -546,7 +546,7 @@ describe("external MCP diagnostics", () => {
       error: {
         code: -32001,
         message: "Authorization required. Visit the connect portal.",
-        data: { connect_url: connectUrl, provider: "blueyonder" },
+        data: { connect_url: connectUrl, provider: "northwind" },
       },
     }
     const responseText = JSON.stringify(responseBody)

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -29,8 +29,8 @@ const connectKeyId = "owc-route-test"
 function defaultOrganizationMetadata(): Record<string, unknown> {
   return {
     brandAppName: "Acme Work",
-    brandLogoUrl: "https://assets.blueyonder.test/wordmark.svg",
-    brandIconUrl: "https://assets.blueyonder.test/icon.png",
+    brandLogoUrl: "https://assets.northwind.test/wordmark.svg",
+    brandIconUrl: "https://assets.northwind.test/icon.png",
   }
 }
 
@@ -478,8 +478,8 @@ test("zero-config install config mints a short-lived exchange without storing th
       org: { name: "Acme Robotics" },
       brand: {
         appName: "Acme Work",
-        logoUrl: "https://assets.blueyonder.test/wordmark.svg",
-        iconUrl: "https://assets.blueyonder.test/icon.png",
+        logoUrl: "https://assets.northwind.test/wordmark.svg",
+        iconUrl: "https://assets.northwind.test/icon.png",
       },
       requireSignin: true,
     },
@@ -563,8 +563,8 @@ test("install config includes a fresh signed organization handoff while preservi
   expect(verified.claims.org.name).toBe("Acme Robotics")
   expect(verified.claims.brand).toEqual({
     appName: "Acme Work",
-    logoUrl: "https://assets.blueyonder.test/wordmark.svg",
-    iconUrl: "https://assets.blueyonder.test/icon.png",
+    logoUrl: "https://assets.northwind.test/wordmark.svg",
+    iconUrl: "https://assets.northwind.test/icon.png",
   })
   expect(verified.claims.den.baseUrl).toBe(process.env.BETTER_AUTH_URL)
   expect(verified.claims.den.apiBaseUrl).toBe("http://127.0.0.1:8790")

--- a/evals/flows/invite-adoption-no-duplicates.flow.mjs
+++ b/evals/flows/invite-adoption-no-duplicates.flow.mjs
@@ -35,17 +35,17 @@ const TYPE_ID_PREFIXES = {
   orgSubscription: "osub",
 };
 const RUN_TAG = `${Date.now().toString(36)}-${randomBytes(2).toString("hex")}`;
-const RASHMI_EMAIL = `rashmi+${RUN_TAG}@acme.test`;
-const RASHMI_JIT_EMAIL = `rashmi+jit-${RUN_TAG}@acme.test`;
-const RASHMI_PASSWORD = `OpenWork-${RUN_TAG}!`;
+const RILEY_EMAIL = `riley+${RUN_TAG}@acme.test`;
+const RILEY_JIT_EMAIL = `riley+jit-${RUN_TAG}@acme.test`;
+const RILEY_PASSWORD = `OpenWork-${RUN_TAG}!`;
 
 const state = {
   organization: null,
   adminMemberId: null,
   orgMode: null,
   adminBrowserSignedIn: false,
-  rashmiToken: null,
-  rashmiUserId: null,
+  rileyToken: null,
+  rileyUserId: null,
   reconcileEmail: null,
   reconcileUserId: null,
 };
@@ -468,7 +468,7 @@ async function inviteAsAdmin(ctx, email) {
 async function signUpEmail(ctx, email, name) {
   const result = await denAuthFetch("/api/auth/sign-up/email", {
     method: "POST",
-    body: JSON.stringify({ email, name, password: RASHMI_PASSWORD }),
+    body: JSON.stringify({ email, name, password: RILEY_PASSWORD }),
   });
   witness(ctx, result.response.ok, `Sign-up succeeds for ${email}`, redactAuthResult(result));
   return result;
@@ -477,7 +477,7 @@ async function signUpEmail(ctx, email, name) {
 async function signInEmail(ctx, email) {
   const result = await denAuthFetch("/api/auth/sign-in/email", {
     method: "POST",
-    body: JSON.stringify({ email, password: RASHMI_PASSWORD }),
+    body: JSON.stringify({ email, password: RILEY_PASSWORD }),
   });
   witness(ctx, result.response.ok && typeof result.body?.token === "string", `Sign-in returns a session token for ${email}`, redactAuthResult(result));
   return result;
@@ -536,7 +536,7 @@ export default {
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL", "OPENWORK_EVAL_WEB_CDP_ADMIN"],
   steps: [
     {
-      name: "Frame 1 — The admin invites Rashmi as an admin",
+      name: "Frame 1 — The admin invites Riley as an admin",
       run: async (ctx) => {
         await withClient(ctx, ADMIN_CDP_URL, async () => {
         await ctx.prove("The admin invite creates one pending admin invitation and one invited placeholder", {
@@ -544,23 +544,23 @@ export default {
           assert: async () => {
             await loadOrg(ctx);
             const cleanupOutput = cleanupPriorEvalArtifacts();
-            const invite = await inviteAsAdmin(ctx, RASHMI_EMAIL);
+            const invite = await inviteAsAdmin(ctx, RILEY_EMAIL);
             const org = await loadOrg(ctx);
-            assertPendingInviteAndGhost(ctx, org, RASHMI_EMAIL);
+            assertPendingInviteAndGhost(ctx, org, RILEY_EMAIL);
             ctx.output("invite-response-and-org-listing", JSON.stringify({
               runTag: RUN_TAG,
-              email: RASHMI_EMAIL,
+              email: RILEY_EMAIL,
               cleanup: cleanupOutput || "removed prior eval-only seat rows if present",
               inviteResponse: { status: invite.result.response.status, body: invite.result.body },
               seatSetupApplied: Boolean(invite.seatSql),
-              org: summarizeOrg(org, [RASHMI_EMAIL]),
+              org: summarizeOrg(org, [RILEY_EMAIL]),
             }, null, 2));
             await openMembersPage(ctx);
-            await assertPendingInviteUi(ctx, RASHMI_EMAIL);
+            await assertPendingInviteUi(ctx, RILEY_EMAIL);
           },
           screenshot: {
-            name: "rashmi-pending-admin-invite",
-            requireText: [RASHMI_EMAIL, "Pending", "Admin"],
+            name: "riley-pending-admin-invite",
+            requireText: [RILEY_EMAIL, "Pending", "Admin"],
             rejectText: ["Something went wrong"],
           },
         });
@@ -568,40 +568,40 @@ export default {
       },
     },
     {
-      name: "Frame 2 — Rashmi signs up and the stack's org mode decides the first-sign-in boundary",
+      name: "Frame 2 — Riley signs up and the stack's org mode decides the first-sign-in boundary",
       run: async (ctx) => {
-        await ctx.prove("Rashmi's first sign-in either stays outside the org or adopts the invite in single-org mode", {
+        await ctx.prove("Riley's first sign-in either stays outside the org or adopts the invite in single-org mode", {
           voiceover: vo[1],
           action: async () => {
-            state.rashmiSignUp = await signUpEmail(ctx, RASHMI_EMAIL, "Rashmi Shah");
-            const signedIn = await signInEmail(ctx, RASHMI_EMAIL);
-            state.rashmiToken = signedIn.body.token;
-            const me = await loadMe(ctx, state.rashmiToken, "Rashmi");
-            state.rashmiUserId = me.user.id;
+            state.rileySignUp = await signUpEmail(ctx, RILEY_EMAIL, "Riley Shah");
+            const signedIn = await signInEmail(ctx, RILEY_EMAIL);
+            state.rileyToken = signedIn.body.token;
+            const me = await loadMe(ctx, state.rileyToken, "Riley");
+            state.rileyUserId = me.user.id;
           },
           assert: async () => {
             const org = await loadOrg(ctx);
-            const active = activeMembersForEmail(org, RASHMI_EMAIL);
-            const invitations = invitationsForEmail(org, RASHMI_EMAIL);
-            const ghosts = invitedGhostsForEmail(org, RASHMI_EMAIL);
+            const active = activeMembersForEmail(org, RILEY_EMAIL);
+            const invitations = invitationsForEmail(org, RILEY_EMAIL);
+            const ghosts = invitedGhostsForEmail(org, RILEY_EMAIL);
             if (active.length === 1 && invitations[0]?.status === "accepted") {
               state.orgMode = "single_org";
-              assertReconciled(ctx, org, RASHMI_EMAIL);
+              assertReconciled(ctx, org, RILEY_EMAIL);
             } else {
               state.orgMode = "multi_org";
-              witness(ctx, active.length === 0, "Rashmi is not yet an active member of the invited organization", active.map(compactMember));
-              witness(ctx, invitations[0]?.status === "pending", "Rashmi's invitation is still pending", invitations.map(compactInvitation));
-              witness(ctx, ghosts.length === 1, "Rashmi's invited placeholder still exists", ghosts.map(compactMember));
+              witness(ctx, active.length === 0, "Riley is not yet an active member of the invited organization", active.map(compactMember));
+              witness(ctx, invitations[0]?.status === "pending", "Riley's invitation is still pending", invitations.map(compactInvitation));
+              witness(ctx, ghosts.length === 1, "Riley's invited placeholder still exists", ghosts.map(compactMember));
             }
-            ctx.output("rashmi-first-signin-and-org-mode", JSON.stringify({
+            ctx.output("riley-first-signin-and-org-mode", JSON.stringify({
               runTag: RUN_TAG,
               inferredOrgMode: state.orgMode,
               auth: {
-                signUp: redactAuthResult(state.rashmiSignUp),
-                signInToken: state.rashmiToken ? "<present>" : null,
-                userId: state.rashmiUserId,
+                signUp: redactAuthResult(state.rileySignUp),
+                signInToken: state.rileyToken ? "<present>" : null,
+                userId: state.rileyUserId,
               },
-              org: summarizeOrg(org, [RASHMI_EMAIL]),
+              org: summarizeOrg(org, [RILEY_EMAIL]),
             }, null, 2));
           },
         });
@@ -615,18 +615,18 @@ export default {
           voiceover: vo[2],
           action: async () => {
             if (state.orgMode === "single_org") {
-              state.reconcileEmail = RASHMI_JIT_EMAIL;
+              state.reconcileEmail = RILEY_JIT_EMAIL;
               const invite = await inviteAsAdmin(ctx, state.reconcileEmail);
-              const signUp = await signUpEmail(ctx, state.reconcileEmail, "Rashmi JIT");
+              const signUp = await signUpEmail(ctx, state.reconcileEmail, "Riley JIT");
               state.reconcileUserId = userIdForEmail(ctx, state.reconcileEmail);
               state.jitSetup = { invite, signUp };
             } else {
-              state.reconcileEmail = RASHMI_EMAIL;
-              state.reconcileUserId = state.rashmiUserId;
+              state.reconcileEmail = RILEY_EMAIL;
+              state.reconcileUserId = state.rileyUserId;
             }
             const orgId = state.organization?.id;
             witness(ctx, typeof orgId === "string", "Raw member insert has an organization id", state.organization);
-            witness(ctx, typeof state.reconcileUserId === "string" && state.reconcileUserId.startsWith("usr_"), "Raw member insert has a Rashmi user id", state.reconcileUserId);
+            witness(ctx, typeof state.reconcileUserId === "string" && state.reconcileUserId.startsWith("usr_"), "Raw member insert has a Riley user id", state.reconcileUserId);
             state.rawInsert = insertRawJitMember(ctx, {
               email: state.reconcileEmail,
               organizationId: orgId,
@@ -658,7 +658,7 @@ export default {
             await assertDuplicateUi(ctx, state.reconcileEmail);
           },
           screenshot: {
-            name: "rashmi-duplicate-raw-member-and-pending-invite",
+            name: "riley-duplicate-raw-member-and-pending-invite",
             requireText: ["Member", "Pending", "INVITED", "Admin"],
             rejectText: ["Something went wrong"],
           },
@@ -667,7 +667,7 @@ export default {
       },
     },
     {
-      name: "Frame 4 — Rashmi signs in again and the app reconciles",
+      name: "Frame 4 — Riley signs in again and the app reconciles",
       run: async (ctx) => {
         await withClient(ctx, ADMIN_CDP_URL, async () => {
         await ctx.prove("The next sign-in merges the active member with the invite and deletes the invited ghost", {
@@ -675,7 +675,7 @@ export default {
           action: async () => {
             const signedIn = await signInEmail(ctx, state.reconcileEmail);
             state.reconciledToken = signedIn.body.token;
-            state.reconciledMe = await loadMe(ctx, state.reconciledToken, "Reconciled Rashmi");
+            state.reconciledMe = await loadMe(ctx, state.reconciledToken, "Reconciled Riley");
             await openMembersPage(ctx);
           },
           assert: async () => {
@@ -694,7 +694,7 @@ export default {
             await assertReconciledUi(ctx, state.reconcileEmail);
           },
           screenshot: {
-            name: "rashmi-reconciled-single-admin-row",
+            name: "riley-reconciled-single-admin-row",
             requireText: ["Admin"],
             rejectText: ["Something went wrong"],
           },

--- a/evals/flows/oauth-mcp-install.flow.mjs
+++ b/evals/flows/oauth-mcp-install.flow.mjs
@@ -1,7 +1,7 @@
 /**
  * Member side of the marketplace lifecycle — the "other side" proof.
  *
- * Rashmi (org member, SECOND isolated app instance) installs the plugin the
+ * Riley (org member, SECOND isolated app instance) installs the plugin the
  * owner published in oauth-mcp-publish.flow.mjs:
  *   1. Signs in to OpenWork Cloud via desktop handoff on App B.
  *   2. Finds "Laptop Refresh Policy" in the Extension Marketplace and
@@ -17,14 +17,14 @@
  *
  * Required env:
  * - OPENWORK_EVAL_DEN_API_URL  local Den API (e.g. http://127.0.0.1:8790)
- * Prereqs: member rashmi@acme.test / OpenWorkDemo123! exists in the org.
+ * Prereqs: member riley@acme.test / OpenWorkDemo123! exists in the org.
  */
 import { mkdir } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 
 const SHARED = {
-  MEMBER_EMAIL: "rashmi@acme.test",
+  MEMBER_EMAIL: "riley@acme.test",
   PASSWORD: "OpenWorkDemo123!",
   SKILL_NAME: "laptop-refresh-policy",
   MCP_NAME: "acme-servicenow",
@@ -114,7 +114,7 @@ export default {
     {
       name: "App B boots; member signs in via desktop handoff",
       run: async (ctx) => {
-        await ctx.prove("Member (Rashmi) is signed in on her own app instance", {
+        await ctx.prove("Member (Riley) is signed in on her own app instance", {
           action: async () => {
             await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 90_000, label: "control API" });
             const status = await authStatus(ctx);
@@ -143,7 +143,7 @@ export default {
           assert: async () => {
             const status = await authStatus(ctx);
             ctx.assert(status?.status === "signed_in", "Not signed in after handoff exchange.");
-            ctx.assert(String(status?.user?.email ?? "").includes("rashmi@"), `Unexpected user: ${status?.user?.email}`);
+            ctx.assert(String(status?.user?.email ?? "").includes("riley@"), `Unexpected user: ${status?.user?.email}`);
           },
           screenshot: { name: "member-signed-in", rejectText: ["Something went wrong"] },
         });

--- a/evals/flows/windows-organization-install-branding.flow.mjs
+++ b/evals/flows/windows-organization-install-branding.flow.mjs
@@ -6,7 +6,7 @@ import {
 import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
 
 const vo = await loadVoiceoverParagraphs("windows-organization-install-branding");
-const BUNDLE_DIR = "C:\\Users\\Administrator\\Downloads\\BlueYonder";
+const BUNDLE_DIR = "C:\\Users\\Administrator\\Downloads\\Northwind";
 const INSTALLER = `${BUNDLE_DIR}\\openwork-win-x64-0.17.20.exe`;
 const START_MENU = "C:\\Users\\Administrator\\AppData\\Roaming\\Microsoft\\Windows\\Start Menu\\Programs";
 const CONFIG = "C:\\Users\\Administrator\\AppData\\Local\\openwork\\desktop-bootstrap.json";
@@ -87,8 +87,8 @@ export default {
         await ctx.prove("First launch imports the organization bootstrap before showing the branded window", {
           voiceover: vo[1],
           action: async () => {
-            await windowsExec(ctx, "install Blue Yonder", `
-$cmd = 'C:\\ow\\install-blue-yonder-proof.cmd'
+            await windowsExec(ctx, "install Northwind", `
+$cmd = 'C:\\ow\\install-northwind-proof.cmd'
 [IO.File]::WriteAllLines($cmd, @('@echo off', '${INSTALLER} /S'))
 schtasks /create /tn OWBrandProofInstall /tr $cmd /sc once /st 00:00 /ru Administrator /it /rl HIGHEST /f | Out-Null
 schtasks /run /tn OWBrandProofInstall | Out-Null
@@ -107,15 +107,15 @@ $config = Get-Content '${CONFIG}' -Raw | ConvertFrom-Json
 [pscustomobject]@{
   AppName = $config.brandAppName
   BaseUrl = $config.baseUrl
-  Shortcut = Test-Path '${START_MENU}\\Blue Yonder.lnk'
+  Shortcut = Test-Path '${START_MENU}\\Northwind.lnk'
   StaleShortcut = Test-Path '${START_MENU}\\OpenWork.lnk'
 } | ConvertTo-Json
 `);
-            ctx.assert(result.includes('"AppName":  "Blue Yonder"'), result);
-            ctx.assert(result.includes('"BaseUrl":  "https://onprem.blueyonder.test"'), result);
+            ctx.assert(result.includes('"AppName":  "Northwind"'), result);
+            ctx.assert(result.includes('"BaseUrl":  "https://onprem.northwind.test"'), result);
             ctx.assert(result.includes('"Shortcut":  true') && result.includes('"StaleShortcut":  false'), result);
           },
-          screenshot: { name: "blue-yonder-first-window", sandboxCapture: "computer-use" },
+          screenshot: { name: "northwind-first-window", sandboxCapture: "computer-use" },
         });
       },
     },
@@ -127,19 +127,19 @@ $config = Get-Content '${CONFIG}' -Raw | ConvertFrom-Json
           action: async () => {
             await daytonaComputerUsePress(sandboxId(ctx), "cmd");
             await new Promise((resolve) => setTimeout(resolve, 500));
-            await daytonaComputerUseType(sandboxId(ctx), "Blue Yonder");
+            await daytonaComputerUseType(sandboxId(ctx), "Northwind");
             await new Promise((resolve) => setTimeout(resolve, 1_500));
           },
           assert: async () => {
             const result = await windowsExec(ctx, "inspect branded shortcut", `
 $shell = New-Object -ComObject WScript.Shell
-$link = $shell.CreateShortcut('${START_MENU}\\Blue Yonder.lnk')
+$link = $shell.CreateShortcut('${START_MENU}\\Northwind.lnk')
 [pscustomobject]@{ Target = $link.TargetPath; TargetExists = Test-Path $link.TargetPath; Icon = $link.IconLocation } | ConvertTo-Json
 `);
             ctx.assert(result.includes('"TargetExists":  true'), result);
             ctx.assert(result.includes("brand-icon.ico"), result);
           },
-          screenshot: { name: "blue-yonder-windows-search", sandboxCapture: "computer-use" },
+          screenshot: { name: "northwind-windows-search", sandboxCapture: "computer-use" },
         });
       },
     },
@@ -151,11 +151,11 @@ $link = $shell.CreateShortcut('${START_MENU}\\Blue Yonder.lnk')
           action: async () => {
             await windowsExec(ctx, "prepare newer managed config", `
 $config = Get-Content '${CONFIG}' -Raw | ConvertFrom-Json
-$config.baseUrl = 'https://existing-onprem.blueyonder.test'
-$config.apiBaseUrl = 'https://api.existing-onprem.blueyonder.test'
+$config.baseUrl = 'https://existing-onprem.northwind.test'
+$config.apiBaseUrl = 'https://api.existing-onprem.northwind.test'
 $config.writtenAt = (Get-Date).ToUniversalTime().AddMinutes(5).ToString('o')
 [IO.File]::WriteAllText('${CONFIG}', ($config | ConvertTo-Json), (New-Object Text.UTF8Encoding($false)))
-Remove-Item '${START_MENU}\\Blue Yonder.lnk' -Force
+Remove-Item '${START_MENU}\\Northwind.lnk' -Force
 Get-Process OpenWork -ErrorAction SilentlyContinue | Stop-Process -Force
 `);
             await launchInstalledApp(ctx);
@@ -163,12 +163,12 @@ Get-Process OpenWork -ErrorAction SilentlyContinue | Stop-Process -Force
           assert: async () => {
             const result = await windowsExec(ctx, "inspect upgrade convergence", `
 $config = Get-Content '${CONFIG}' -Raw | ConvertFrom-Json
-[pscustomobject]@{ BaseUrl = $config.baseUrl; Shortcut = Test-Path '${START_MENU}\\Blue Yonder.lnk'; Stale = Test-Path '${START_MENU}\\OpenWork.lnk' } | ConvertTo-Json
+[pscustomobject]@{ BaseUrl = $config.baseUrl; Shortcut = Test-Path '${START_MENU}\\Northwind.lnk'; Stale = Test-Path '${START_MENU}\\OpenWork.lnk' } | ConvertTo-Json
 `);
-            ctx.assert(result.includes('"BaseUrl":  "https://existing-onprem.blueyonder.test"'), result);
+            ctx.assert(result.includes('"BaseUrl":  "https://existing-onprem.northwind.test"'), result);
             ctx.assert(result.includes('"Shortcut":  true') && result.includes('"Stale":  false'), result);
           },
-          screenshot: { name: "blue-yonder-after-upgrade", sandboxCapture: "computer-use" },
+          screenshot: { name: "northwind-after-upgrade", sandboxCapture: "computer-use" },
         });
       },
     },
@@ -178,9 +178,9 @@ $config = Get-Content '${CONFIG}' -Raw | ConvertFrom-Json
         await ctx.prove("Uninstall removes the managed organization shortcut without leaving stale OpenWork entries", {
           voiceover: vo[4],
           action: async () => {
-            await windowsExec(ctx, "uninstall Blue Yonder", `
+            await windowsExec(ctx, "uninstall Northwind", `
 Get-Process OpenWork -ErrorAction SilentlyContinue | Stop-Process -Force
-$cmd = 'C:\\ow\\uninstall-blue-yonder-proof.cmd'
+$cmd = 'C:\\ow\\uninstall-northwind-proof.cmd'
 [IO.File]::WriteAllLines($cmd, @('@echo off', '"C:\\Users\\Administrator\\AppData\\Local\\Programs\\@openworkdesktop\\Uninstall OpenWork.exe" /S'))
 schtasks /create /tn OWBrandProofUninstall /tr $cmd /sc once /st 00:00 /ru Administrator /it /rl HIGHEST /f | Out-Null
 schtasks /run /tn OWBrandProofUninstall | Out-Null
@@ -188,17 +188,17 @@ Start-Sleep -Seconds 15
 `);
             await daytonaComputerUsePress(sandboxId(ctx), "cmd");
             await new Promise((resolve) => setTimeout(resolve, 500));
-            await daytonaComputerUseType(sandboxId(ctx), "Blue Yonder");
+            await daytonaComputerUseType(sandboxId(ctx), "Northwind");
           },
           assert: async () => {
             const result = await windowsExec(ctx, "inspect uninstall cleanup", `
 [pscustomobject]@{
-  BlueYonder = Test-Path '${START_MENU}\\Blue Yonder.lnk'
+  Northwind = Test-Path '${START_MENU}\\Northwind.lnk'
   OpenWork = Test-Path '${START_MENU}\\OpenWork.lnk'
   Marker = Test-Path 'C:\\Users\\Administrator\\AppData\\Roaming\\com.differentai.openwork\\windows-brand-shortcut.txt'
 } | ConvertTo-Json
 `);
-            ctx.assert(result.includes('"BlueYonder":  false'), result);
+            ctx.assert(result.includes('"Northwind":  false'), result);
             ctx.assert(result.includes('"OpenWork":  false'), result);
             ctx.assert(result.includes('"Marker":  false'), result);
           },

--- a/evals/voiceovers/approved-desktop-update-targeting.md
+++ b/evals/voiceovers/approved-desktop-update-targeting.md
@@ -1,9 +1,9 @@
 # approved-desktop-update-targeting — Automatic update checks select the highest organization-approved published release
 
-Rashmi uses an organization-managed Windows desktop where administrators approve which OpenWork releases members can install.
+Riley uses an organization-managed Windows desktop where administrators approve which OpenWork releases members can install.
 
-1. Rashmi is running OpenWork 0.17.0. Den shows the actual published versions 0.17.0, 0.17.1, and 0.17.2; her administrator approves 0.17.1, while 0.17.2 remains unapproved and disabled until the server allows it.
+1. Riley is running OpenWork 0.17.0. Den shows the actual published versions 0.17.0, 0.17.1, and 0.17.2; her administrator approves 0.17.1, while 0.17.2 remains unapproved and disabled until the server allows it.
 
-2. Rashmi enables automatic checks. OpenWork first sees the normal stable latest release, then reads Den's published release inventory after her organization's policy blocks that latest version.
+2. Riley enables automatic checks. OpenWork first sees the normal stable latest release, then reads Den's published release inventory after her organization's policy blocks that latest version.
 
-3. OpenWork performs an exact-target check for the highest approved published version newer than Rashmi's installation. It offers 0.17.1—not the unapproved latest release, 0.17.2.
+3. OpenWork performs an exact-target check for the highest approved published version newer than Riley's installation. It offers 0.17.1—not the unapproved latest release, 0.17.2.

--- a/evals/voiceovers/invite-adoption-no-duplicates.md
+++ b/evals/voiceovers/invite-adoption-no-duplicates.md
@@ -1,11 +1,11 @@
 # invite-adoption-no-duplicates — Invites become one member, never a duplicate
 
-This internal proof follows the Den API outputs and the den-web Members page for a tagged Rashmi invite. The reviewer sees the same table states an admin would see: pending invite, duplicate bug shape, and the final clean row.
+This internal proof follows the Den API outputs and the den-web Members page for a tagged Riley invite. The reviewer sees the same table states an admin would see: pending invite, duplicate bug shape, and the final clean row.
 
-1. The first frame shows Alex's Members page after inviting Rashmi as an admin. Rashmi is visible as a pending invite, and the API output beside the screenshot confirms the invitation and invited placeholder both carry the admin role.
+1. The first frame shows Alex's Members page after inviting Riley as an admin. Riley is visible as a pending invite, and the API output beside the screenshot confirms the invitation and invited placeholder both carry the admin role.
 
-2. The next frame shows Rashmi's account creation and first sign-in, then names the org mode the local stack is running. In single-org mode the first sign-in already becomes the headline proof: one active Rashmi member with role admin, the invite accepted, and no invited ghost; in multi-org mode Rashmi is still outside the workspace and the admin invite remains pending.
+2. The next frame shows Riley's account creation and first sign-in, then names the org mode the local stack is running. In single-org mode the first sign-in already becomes the headline proof: one active Riley member with role admin, the invite accepted, and no invited ghost; in multi-org mode Riley is still outside the workspace and the admin invite remains pending.
 
-3. The third frame is the customer-reported bad state on the Members page. One Rashmi row is an active member with the wrong member role, while the pending invited admin row is still visible beside it.
+3. The third frame is the customer-reported bad state on the Members page. One Riley row is an active member with the wrong member role, while the pending invited admin row is still visible beside it.
 
-4. The final frame is the repaired Members page after Rashmi signs in again. The duplicate is gone: there is one Rashmi row, the role is admin, and the API output confirms the invitation is accepted with no invited placeholder left behind.
+4. The final frame is the repaired Members page after Riley signs in again. The duplicate is gone: there is one Riley row, the role is admin, and the API output confirms the invitation is accepted with no invited placeholder left behind.

--- a/evals/voiceovers/windows-organization-install-branding.md
+++ b/evals/voiceovers/windows-organization-install-branding.md
@@ -1,11 +1,11 @@
 # windows-organization-install-branding — Organization branding replaces stale Windows install identity
 
-1. A Blue Yonder teammate extracts the organization download and runs the standard signed Windows installer beside its setup file.
+1. A Northwind teammate extracts the organization download and runs the standard signed Windows installer beside its setup file.
 
-2. On first launch, the app connects to Blue Yonder's configured server and appears with the Blue Yonder name and icon, without exposing a stale OpenWork shortcut as the user-facing entry.
+2. On first launch, the app connects to Northwind's configured server and appears with the Northwind name and icon, without exposing a stale OpenWork shortcut as the user-facing entry.
 
-3. In Windows Search and the Start Menu, the installed app is listed as Blue Yonder with the organization icon, and launching it opens the same configured desktop.
+3. In Windows Search and the Start Menu, the installed app is listed as Northwind with the organization icon, and launching it opens the same configured desktop.
 
-4. An existing OpenWork installation upgrades through the same organization package. Its shortcut converges to Blue Yonder branding while its existing on-prem server configuration remains intact.
+4. An existing OpenWork installation upgrades through the same organization package. Its shortcut converges to Northwind branding while its existing on-prem server configuration remains intact.
 
-5. After another launch, Windows Search, Start Menu, taskbar, and Alt-Tab consistently show Blue Yonder; uninstall removes the managed shortcuts cleanly without leaving duplicate organization or OpenWork entries.
+5. After another launch, Windows Search, Start Menu, taskbar, and Alt-Tab consistently show Northwind; uninstall removes the managed shortcuts cleanly without leaving duplicate organization or OpenWork entries.


### PR DESCRIPTION
Replaces partner-identifying names in test fixtures, eval flows, and voiceovers with neutral synthetic ones (Northwind / Riley). Pure renames, zero behavior change.

Verified: repo-wide grep for the removed names returns zero hits; `bun test test/external-mcp-diagnostics.test.ts test/install-link-access.test.ts` → 102 pass / 0 fail; `node --check` on all touched flows; `node --test electron/brand-icon-windows.test.mjs` → 10 pass / 0 fail. 9 files, 91 insertions / 91 deletions (symmetric rename).