### PR TITLE
feat(diagnostics): add mock MCP authorization flow

### DIFF
--- a/ee/apps/diagnostics/README.md
+++ b/ee/apps/diagnostics/README.md
@@ -30,6 +30,19 @@ Open `http://localhost:3010` and sign in with:
 The local MCP endpoint is `http://localhost:3010/mcp` with synthetic bearer
 token `OpenWorkDiagnosticsToken!`. Local history is process-memory only.
 
+The MCP catalog also contains two diagnostics-only authorization tools:
+
+- `diagnostics_authorization_check` returns JSON-RPC `-32001` with a same-origin
+  `data.connect_url` until the user opens that mock verification link. A
+  successful verification lasts five minutes and survives MCP reconnects.
+- `diagnostics_reset_authorization` immediately clears that state so the link
+  flow can be repeated without waiting for its automatic expiry.
+
+The state is keyed by a one-way identity derived from the already-valid
+synthetic MCP bearer token. Hosted deployments keep only that derived identity
+in Redis with a five-minute TTL; local development keeps it in process memory.
+The mock verification page never asks for or stores provider credentials.
+
 To expose the controlled run in a local Den, set:
 
 ```dotenv

--- a/ee/apps/diagnostics/app/mcp/mock-auth/route.ts
+++ b/ee/apps/diagnostics/app/mcp/mock-auth/route.ts
@@ -1,0 +1,46 @@
+import { diagnosticsConfig, validateProductionConfig } from "../../../src/config"
+import { authorizeMockSubject, verifyMockAuthorizationChallenge } from "../../../src/mock-authorization"
+
+export const dynamic = "force-dynamic"
+export const maxDuration = 10
+
+function html(status: number, title: string, message: string): Response {
+  return new Response(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>${title}</title>
+  </head>
+  <body>
+    <main>
+      <h1>${title}</h1>
+      <p>${message}</p>
+    </main>
+  </body>
+</html>`, {
+    headers: {
+      "cache-control": "no-store",
+      "content-security-policy": "default-src 'none'; style-src 'unsafe-inline'; base-uri 'none'; form-action 'none'",
+      "content-type": "text/html; charset=utf-8",
+      "referrer-policy": "no-referrer",
+      "x-content-type-options": "nosniff",
+    },
+    status,
+  })
+}
+
+export async function GET(request: Request): Promise<Response> {
+  const missing = validateProductionConfig()
+  if (missing.length > 0) return html(503, "Diagnostics unavailable", "The diagnostics service is not configured.")
+  const config = diagnosticsConfig()
+  const challenge = new URL(request.url).searchParams.get("challenge") ?? ""
+  const subject = verifyMockAuthorizationChallenge(challenge, config.signingSecret)
+  if (!subject) return html(400, "Verification link expired", "Return to OpenWork and run the diagnostics authorization check again to receive a fresh link.")
+  try {
+    await authorizeMockSubject(subject)
+  } catch {
+    return html(503, "Verification unavailable", "The diagnostics authorization store is unavailable. Try again later.")
+  }
+  return html(200, "Diagnostics authorization complete", "Return to OpenWork and ask the agent to retry the diagnostics authorization check. This mock authorization resets automatically after five minutes.")
+}

--- a/ee/apps/diagnostics/src/auth.ts
+++ b/ee/apps/diagnostics/src/auth.ts
@@ -1,4 +1,4 @@
-import { timingSafeEqual } from "node:crypto"
+import { createHmac, timingSafeEqual } from "node:crypto"
 import { verifyAccessToken } from "./session"
 
 function constantTimeEqual(left: string, right: string): boolean {
@@ -15,10 +15,15 @@ export function bearerAuthorized(request: Request, expectedToken: string): boole
 }
 
 export function mcpBearerAuthorized(request: Request, expectedToken: string, signingSecret: string): boolean {
+  return mcpAuthorizationSubject(request, expectedToken, signingSecret) !== null
+}
+
+export function mcpAuthorizationSubject(request: Request, expectedToken: string, signingSecret: string): string | null {
   const authorization = request.headers.get("authorization") ?? ""
-  if (!authorization.startsWith("Bearer ")) return false
+  if (!authorization.startsWith("Bearer ")) return null
   const token = authorization.slice(7)
-  return constantTimeEqual(token, expectedToken) || verifyAccessToken(token, signingSecret)
+  if (!constantTimeEqual(token, expectedToken) && !verifyAccessToken(token, signingSecret)) return null
+  return createHmac("sha256", signingSecret).update(`diagnostics-mock-authorization:${token}`).digest("hex")
 }
 
 export function oauthBasicAuthorized(request: Request, expectedSecret: string): boolean {

--- a/ee/apps/diagnostics/src/mcp.ts
+++ b/ee/apps/diagnostics/src/mcp.ts
@@ -1,10 +1,18 @@
+import { EGRESS_DIAGNOSTIC_RUN_HEADER } from "@openwork/types/den/egress-diagnostics"
 import { diagnosticsConfig, validateProductionConfig } from "./config"
-import { mcpBearerAuthorized } from "./auth"
+import { mcpAuthorizationSubject } from "./auth"
+import {
+  createMockAuthorizationUrl,
+  mockSubjectIsAuthorized,
+  resetMockAuthorization,
+} from "./mock-authorization"
 import { emptyResponse as empty, jsonResponse as json, type HandledResponse } from "./recorded-route"
 import { createSessionToken, verifySessionToken } from "./session"
 
 const supportedVersions = ["2025-11-25", "2025-06-18", "2025-03-26"] as const
 export const maximumRequestBytes = 64 * 1024
+export const mockAuthorizationToolName = "diagnostics_authorization_check"
+export const resetMockAuthorizationToolName = "diagnostics_reset_authorization"
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
@@ -51,6 +59,37 @@ function toolDefinition(profile: ReturnType<typeof diagnosticsConfig>["profile"]
   }
 }
 
+function mockAuthorizationToolDefinition(): Record<string, unknown> {
+  return {
+    description: "Exercises an authorization-required MCP tool response. Before browser verification, it returns JSON-RPC -32001 with data.connect_url. Verification lasts five minutes.",
+    inputSchema: { additionalProperties: false, properties: {}, type: "object" },
+    name: mockAuthorizationToolName,
+    title: "Diagnostics authorization check",
+  }
+}
+
+function resetMockAuthorizationToolDefinition(): Record<string, unknown> {
+  return {
+    description: "Immediately clears the five-minute mock authorization so the authorization-link flow can be tested again.",
+    inputSchema: { additionalProperties: false, properties: {}, type: "object" },
+    name: resetMockAuthorizationToolName,
+    title: "Reset diagnostics authorization",
+  }
+}
+
+function toolName(message: Record<string, unknown>): string | null {
+  const params = isRecord(message.params) ? message.params : null
+  return params && typeof params.name === "string" ? params.name : null
+}
+
+function syntheticToolResult(profile: ReturnType<typeof diagnosticsConfig>["profile"]): unknown {
+  return {
+    content: [{ text: "The Diagnostics endpoint received and safely handled the synthetic tool request.", type: "text" }],
+    isError: false,
+    structuredContent: { connected: true, profile },
+  }
+}
+
 function validateSession(request: Request, signingSecret: string): boolean {
   const token = request.headers.get("mcp-session-id") ?? ""
   return Boolean(token) && verifySessionToken(token, signingSecret)
@@ -67,7 +106,8 @@ export async function handleMcpRequest(request: Request, rawBody: string): Promi
       : json(404, { error: "mcp_session_not_found" })
   }
   if (request.method !== "POST") return empty(405, { allow: "POST, DELETE" })
-  if (!mcpBearerAuthorized(request, config.bearerToken, config.signingSecret)) {
+  const authorizationSubject = mcpAuthorizationSubject(request, config.bearerToken, config.signingSecret)
+  if (!authorizationSubject) {
     return json(401, { error: "unauthorized" }, {
       "www-authenticate": `Bearer resource_metadata="${config.publicOrigin}/.well-known/oauth-protected-resource/mcp", scope="diagnostics:connectivity"`,
     })
@@ -113,13 +153,63 @@ export async function handleMcpRequest(request: Request, rawBody: string): Promi
   if (value.method === "notifications/initialized") return empty(202)
   if (id === null) return empty(202)
   if (value.method === "ping") return json(200, rpcResult(id, {}))
-  if (value.method === "tools/list") return json(200, rpcResult(id, { tools: [toolDefinition(config.profile)] }))
-  if (value.method === "tools/call") {
+  if (value.method === "tools/list") {
+    // The existing private-cloud egress conformance probe intentionally pins a
+    // one-tool catalog. Keep that signed diagnostic run stable while regular
+    // MCP clients receive the interactive authorization fixtures.
+    const tools = request.headers.has(EGRESS_DIAGNOSTIC_RUN_HEADER)
+      ? [toolDefinition(config.profile)]
+      : [
+          toolDefinition(config.profile),
+          mockAuthorizationToolDefinition(),
+          resetMockAuthorizationToolDefinition(),
+        ]
     return json(200, rpcResult(id, {
-      content: [{ text: "The Diagnostics endpoint received and safely handled the synthetic tool request.", type: "text" }],
-      isError: false,
-      structuredContent: { connected: true, profile: config.profile },
+      tools,
     }))
+  }
+  if (value.method === "tools/call") {
+    const requestedTool = toolName(value)
+    if (!requestedTool) return json(200, rpcError(id, -32602, "Tool name is required"))
+    if (requestedTool === resetMockAuthorizationToolName) {
+      try {
+        await resetMockAuthorization(authorizationSubject)
+      } catch {
+        return json(200, rpcError(id, -32603, "Mock authorization state is unavailable"))
+      }
+      return json(200, rpcResult(id, {
+        content: [{ text: "Mock authorization was reset. The next diagnostics authorization check will require the browser verification link again.", type: "text" }],
+        isError: false,
+        structuredContent: { authorized: false, reset: true },
+      }))
+    }
+    if (requestedTool === mockAuthorizationToolName) {
+      let authorized: boolean
+      try {
+        authorized = await mockSubjectIsAuthorized(authorizationSubject)
+      } catch {
+        return json(200, rpcError(id, -32603, "Mock authorization state is unavailable"))
+      }
+      if (!authorized) {
+        const connectUrl = createMockAuthorizationUrl({
+          publicOrigin: config.publicOrigin,
+          signingSecret: config.signingSecret,
+          subject: authorizationSubject,
+        })
+        return json(200, rpcError(id, -32001, "Authorization required. Open the mock verification link, authorize this diagnostics tool for five minutes, then retry.", {
+          connect_url: connectUrl,
+          provider: "openwork-diagnostics",
+        }))
+      }
+      return json(200, rpcResult(id, {
+        content: [{ text: "Mock authorization is active. The diagnostics authorization-required flow completed successfully.", type: "text" }],
+        isError: false,
+        structuredContent: { authorized: true, expiresAutomatically: true, lifetimeSeconds: 300 },
+      }))
+    }
+    const profileTool = toolDefinition(config.profile)
+    if (requestedTool === profileTool.name) return json(200, rpcResult(id, syntheticToolResult(config.profile)))
+    return json(200, rpcError(id, -32602, `Unknown tool: ${requestedTool}`))
   }
   return json(200, rpcError(id, -32601, "Method not found"))
 }

--- a/ee/apps/diagnostics/src/mock-authorization.ts
+++ b/ee/apps/diagnostics/src/mock-authorization.ts
@@ -1,0 +1,131 @@
+import { createHmac, timingSafeEqual } from "node:crypto"
+import { diagnosticsRedisConfig } from "./config"
+
+export const mockAuthorizationLifetimeMs = 5 * 60 * 1000
+export const mockAuthorizationChallengeLifetimeMs = 2 * 60 * 1000
+
+const redisKeyPrefix = "openwork:diagnostics:mock-authorization:v1"
+const subjectPattern = /^[a-f0-9]{64}$/u
+
+declare global {
+  var __openworkDiagnosticsMockAuthorizations: Map<string, number> | undefined
+}
+
+const localAuthorizations = globalThis.__openworkDiagnosticsMockAuthorizations ??= new Map()
+
+type RedisReply = { result?: unknown; error?: string }
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function isRedisReply(value: unknown): value is RedisReply {
+  return isRecord(value)
+}
+
+function mockAuthorizationKey(subject: string): string {
+  return `${redisKeyPrefix}:${subject}`
+}
+
+async function redisCommand(command: readonly (string | number)[]): Promise<unknown> {
+  const config = diagnosticsRedisConfig()
+  if (!config) return null
+  const response = await fetch(config.url, {
+    body: JSON.stringify(command),
+    headers: { authorization: `Bearer ${config.token}`, "content-type": "application/json" },
+    method: "POST",
+    cache: "no-store",
+  })
+  const reply: unknown = await response.json()
+  if (!response.ok || !isRedisReply(reply) || reply.error) {
+    throw new Error("The diagnostics mock authorization store rejected the operation.")
+  }
+  return reply.result
+}
+
+function challengeSignature(payload: string, signingSecret: string): string {
+  return createHmac("sha256", signingSecret).update(payload).digest("base64url")
+}
+
+function signaturesMatch(left: string, right: string): boolean {
+  const supplied = Buffer.from(left)
+  const expected = Buffer.from(right)
+  return supplied.length === expected.length && timingSafeEqual(supplied, expected)
+}
+
+export function createMockAuthorizationChallenge(subject: string, signingSecret: string, now = Date.now()): string {
+  if (!subjectPattern.test(subject)) throw new Error("Invalid diagnostics mock authorization subject.")
+  const payload = Buffer.from(JSON.stringify({
+    exp: now + mockAuthorizationChallengeLifetimeMs,
+    kind: "diagnostics-mock-authorization",
+    subject,
+    version: 1,
+  }), "utf8").toString("base64url")
+  return `${payload}.${challengeSignature(payload, signingSecret)}`
+}
+
+export function verifyMockAuthorizationChallenge(
+  challenge: string,
+  signingSecret: string,
+  now = Date.now(),
+): string | null {
+  const [payload, suppliedSignature, extra] = challenge.split(".")
+  if (!payload || !suppliedSignature || extra !== undefined) return null
+  if (!signaturesMatch(suppliedSignature, challengeSignature(payload, signingSecret))) return null
+  try {
+    const value: unknown = JSON.parse(Buffer.from(payload, "base64url").toString("utf8"))
+    if (!isRecord(value)
+      || value.version !== 1
+      || value.kind !== "diagnostics-mock-authorization"
+      || typeof value.exp !== "number"
+      || value.exp <= now
+      || typeof value.subject !== "string"
+      || !subjectPattern.test(value.subject)) return null
+    return value.subject
+  } catch {
+    return null
+  }
+}
+
+export function createMockAuthorizationUrl(input: {
+  publicOrigin: string
+  signingSecret: string
+  subject: string
+  now?: number
+}): string {
+  const url = new URL("/mcp/mock-auth", input.publicOrigin)
+  url.searchParams.set("challenge", createMockAuthorizationChallenge(input.subject, input.signingSecret, input.now))
+  return url.toString()
+}
+
+export async function authorizeMockSubject(subject: string, now = Date.now()): Promise<number> {
+  if (!subjectPattern.test(subject)) throw new Error("Invalid diagnostics mock authorization subject.")
+  const expiresAt = now + mockAuthorizationLifetimeMs
+  if (!diagnosticsRedisConfig()) {
+    localAuthorizations.set(subject, expiresAt)
+    return expiresAt
+  }
+  await redisCommand(["SET", mockAuthorizationKey(subject), expiresAt, "PX", mockAuthorizationLifetimeMs])
+  return expiresAt
+}
+
+export async function mockSubjectIsAuthorized(subject: string, now = Date.now()): Promise<boolean> {
+  if (!subjectPattern.test(subject)) return false
+  if (!diagnosticsRedisConfig()) {
+    const expiresAt = localAuthorizations.get(subject)
+    if (expiresAt === undefined) return false
+    if (expiresAt > now) return true
+    localAuthorizations.delete(subject)
+    return false
+  }
+  const result = await redisCommand(["GET", mockAuthorizationKey(subject)])
+  if (typeof result !== "string") return false
+  const expiresAt = Number(result)
+  return Number.isFinite(expiresAt) && expiresAt > now
+}
+
+export async function resetMockAuthorization(subject: string): Promise<void> {
+  if (!subjectPattern.test(subject)) return
+  localAuthorizations.delete(subject)
+  if (diagnosticsRedisConfig()) await redisCommand(["DEL", mockAuthorizationKey(subject)])
+}

--- a/ee/apps/diagnostics/test/mcp.test.ts
+++ b/ee/apps/diagnostics/test/mcp.test.ts
@@ -5,8 +5,20 @@ import {
   EGRESS_DIAGNOSTIC_STEP_HEADER,
 } from "@openwork/types/den/egress-diagnostics"
 import { randomUUID } from "node:crypto"
+import { GET as completeMockAuthorization } from "../app/mcp/mock-auth/route"
+import { mcpAuthorizationSubject } from "../src/auth"
 import { clearWireHistory, listWireHistory, recordWireExchange } from "../src/history-store"
-import { handleMcpRequest } from "../src/mcp"
+import {
+  handleMcpRequest,
+  mockAuthorizationToolName,
+  resetMockAuthorizationToolName,
+} from "../src/mcp"
+import {
+  authorizeMockSubject,
+  mockAuthorizationLifetimeMs,
+  mockSubjectIsAuthorized,
+  resetMockAuthorization,
+} from "../src/mock-authorization"
 import { createDiagnosticRunSignature } from "../src/run-correlation"
 import { createWireExchange } from "../src/wire"
 import { createAccessToken, createSessionToken, verifyAccessToken, verifySessionToken } from "../src/session"
@@ -35,6 +47,36 @@ function mcpRequest(body: unknown, headers: Readonly<Record<string, string>> = {
     },
     method: "POST",
   })
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function mockAuthorizationSubject(): string {
+  const subject = mcpAuthorizationSubject(
+    mcpRequest({}),
+    "OpenWorkDiagnosticsToken!",
+    "local-diagnostics-signing-secret-change-me",
+  )
+  if (!subject) throw new Error("Expected a mock authorization subject")
+  return subject
+}
+
+async function initializeMcpSession(id: number): Promise<string> {
+  const body = { id, jsonrpc: "2.0", method: "initialize", params: { protocolVersion: "2025-11-25" } }
+  const initialized = await handleMcpRequest(mcpRequest(body), JSON.stringify(body))
+  const session = initialized.response.headers.get("mcp-session-id")
+  if (!session) throw new Error("Expected an MCP session")
+  return session
+}
+
+async function callMcpTool(id: number, session: string, name: string) {
+  const body = { id, jsonrpc: "2.0", method: "tools/call", params: { arguments: {}, name } }
+  return await handleMcpRequest(mcpRequest(body, {
+    "mcp-protocol-version": "2025-11-25",
+    "mcp-session-id": session,
+  }), JSON.stringify(body))
 }
 
 describe("OpenWork Diagnostics MCP endpoint", () => {
@@ -81,6 +123,54 @@ describe("OpenWork Diagnostics MCP endpoint", () => {
     }), JSON.stringify({ id: 3, jsonrpc: "2.0", method: "tools/call", params: { arguments: { query: "customer confidential content" } } }))
     expect(tool.response.status).toBe(200)
     expect(tool.body).not.toContain("customer confidential content")
+  })
+
+  test("returns a browser verification link, survives reconnect, resets, and expires after five minutes", async () => {
+    const subject = mockAuthorizationSubject()
+    await resetMockAuthorization(subject)
+
+    const firstSession = await initializeMcpSession(10)
+    const catalogBody = { id: 11, jsonrpc: "2.0", method: "tools/list", params: {} }
+    const catalog = await handleMcpRequest(mcpRequest(catalogBody, {
+      "mcp-protocol-version": "2025-11-25",
+      "mcp-session-id": firstSession,
+    }), JSON.stringify(catalogBody))
+    expect(catalog.body).toContain(mockAuthorizationToolName)
+    expect(catalog.body).toContain(resetMockAuthorizationToolName)
+
+    const required = await callMcpTool(12, firstSession, mockAuthorizationToolName)
+    const envelope: unknown = JSON.parse(required.body)
+    if (!isRecord(envelope) || !isRecord(envelope.error) || !isRecord(envelope.error.data)) {
+      throw new Error("Expected an authorization-required JSON-RPC error")
+    }
+    expect(envelope.error.code).toBe(-32001)
+    expect(envelope.error.data.provider).toBe("openwork-diagnostics")
+    const connectUrl = envelope.error.data.connect_url
+    expect(typeof connectUrl).toBe("string")
+    if (typeof connectUrl !== "string") throw new Error("Expected a mock authorization link")
+    expect(connectUrl).toStartWith("http://localhost:3010/mcp/mock-auth?challenge=")
+
+    const verified = await completeMockAuthorization(new Request(connectUrl))
+    expect(verified.status).toBe(200)
+    expect(await verified.text()).toContain("Return to OpenWork")
+
+    // A fresh MCP session models the reconnect/retry performed after the
+    // browser action. Authorization is bound to the synthetic bearer identity,
+    // not the disposable MCP session id.
+    const reconnectedSession = await initializeMcpSession(13)
+    const authorized = await callMcpTool(14, reconnectedSession, mockAuthorizationToolName)
+    expect(authorized.body).toContain('"authorized":true')
+
+    const reset = await callMcpTool(15, reconnectedSession, resetMockAuthorizationToolName)
+    expect(reset.body).toContain('"reset":true')
+    const requiredAgain = await callMcpTool(16, reconnectedSession, mockAuthorizationToolName)
+    expect(requiredAgain.body).toContain('"code":-32001')
+
+    const now = 1_000_000
+    await authorizeMockSubject(subject, now)
+    expect(await mockSubjectIsAuthorized(subject, now + mockAuthorizationLifetimeMs - 1)).toBe(true)
+    expect(await mockSubjectIsAuthorized(subject, now + mockAuthorizationLifetimeMs)).toBe(false)
+    await resetMockAuthorization(subject)
   })
 
   test("returns specific transport errors instead of a generic connection failure", async () => {


### PR DESCRIPTION
## Summary

- add a diagnostics-only MCP tool that returns JSON-RPC -32001 with a same-origin data.connect_url until mock browser verification completes
- add a signed mock verification route and five-minute authorization TTL backed by hosted Redis or local in-memory state
- add an idempotent MCP reset tool so the authorization-link journey can be repeated immediately
- preserve the existing one-tool private-cloud egress conformance catalog

## Checks

- pnpm --filter @openwork-ee/diagnostics test — 29 passed, 0 failed
- pnpm --filter @openwork-ee/diagnostics build — passed

## Verification

The focused test exercises the complete fixture lifecycle: authorization-required error, connect link, browser verification route, fresh MCP session retry, reset tool, and simulated five-minute expiry.

Real desktop interaction was not completed before publication at the requester’s direction to keep verification proportionate for this diagnostics-only change. The preview deployment should be used to run the final OpenWork app link-click journey.

## Risk and boundaries

- scoped to ee/apps/diagnostics; no product connection, Den schema, or provider credential changes
- mock authorization is keyed to a one-way HMAC identity derived from the already-valid synthetic bearer token
- no provider/customer credentials are requested or stored
- the verification challenge expires after two minutes; successful mock authorization expires after five minutes