### PR TITLE
fix: keep sign-in URL visible

### DIFF
--- a/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
+++ b/apps/app/src/react-app/domains/cloud/den-signin-surface.tsx
@@ -228,10 +228,6 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
         <div className={softNoticeClass}>{props.statusMessage}</div>
       ) : null}
 
-      {props.signinFallbackUrl ? (
-        <SignInFallbackNotice url={props.signinFallbackUrl} />
-      ) : null}
-
       <div className="space-y-2">
         <div className="max-w-[54ch] text-sm text-dls-secondary">
           {t("den.auto_reconnect_hint")}
@@ -262,6 +258,10 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
             : t("den.paste_signin_code")}
         </Button>
       </div>
+
+      {props.signinFallbackUrl ? (
+        <SignInFallbackNotice url={props.signinFallbackUrl} />
+      ) : null}
 
       {props.manualAuthOpen ? (
         <div className={`${settingsPanelSoftClass} space-y-3`}>
@@ -346,6 +346,10 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
                 <ArrowUpRight size={15} />
               </button>
 
+              {props.signinFallbackUrl ? (
+                <SignInFallbackNotice url={props.signinFallbackUrl} />
+              ) : null}
+
               {props.onOrganizationServerSave ? (
                 <OrganizationServerAffordance
                   busy={props.organizationServerBusy === true}
@@ -357,10 +361,6 @@ export function DenSignInSurface(props: DenSignInSurfaceProps) {
 
               {props.statusMessage && !props.authError ? (
                 <div className={softNoticeClass}>{props.statusMessage}</div>
-              ) : null}
-
-              {props.signinFallbackUrl ? (
-                <SignInFallbackNotice url={props.signinFallbackUrl} />
               ) : null}
 
               {props.authError ? (

--- a/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
@@ -108,7 +108,7 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
   const openBrowserAuth = useCallback(
     (mode: "sign-in" | "sign-up") => {
       const url = buildDenAuthUrl(baseUrl, mode);
-      setSigninFallbackUrl(null);
+      setSigninFallbackUrl(url);
       setStatusMessage(
         mode === "sign-up"
           ? t("den.status_browser_signup")
@@ -118,7 +118,6 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
       void tryOpenBrowserAuthUrl(url).then((opened) => {
         if (opened) return;
         setStatusMessage(null);
-        setSigninFallbackUrl(url);
         setManualAuthOpen(true);
       });
     },

--- a/apps/app/src/react-app/domains/cloud/signin-fallback-notice.tsx
+++ b/apps/app/src/react-app/domains/cloud/signin-fallback-notice.tsx
@@ -18,11 +18,18 @@ export function SignInFallbackNotice({ url }: { url: string }) {
   };
 
   return (
-    <div className="rounded-xl border border-red-7/30 bg-red-1/40 px-3 py-2 text-xs text-red-11">
+    <div className="rounded-xl border border-dls-border bg-dls-surface px-3 py-2 text-xs text-dls-secondary">
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-        <div className="space-y-1">
-          <div>{t("den.error_browser_open_failed")}</div>
+        <div className="min-w-0 space-y-1">
           <div>{t("den.browser_open_failed_hint")}</div>
+          <a
+            href={url}
+            target="_blank"
+            rel="noreferrer"
+            className="block break-all font-mono text-[11px] text-blue-11 underline underline-offset-2"
+          >
+            {url}
+          </a>
         </div>
         <Button variant="outline" size="sm" onClick={copyLink}>
           {copied ? t("den.signin_link_copied") : t("den.copy_signin_link")}

--- a/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/use-den-session.tsx
@@ -241,7 +241,7 @@ export function useDenSession({
   const openBrowserAuth = React.useCallback(
     (mode: "sign-in" | "sign-up") => {
       const url = buildDenAuthUrl(baseUrl, mode);
-      setSigninFallbackUrl(null);
+      setSigninFallbackUrl(url);
       setStatusMessage(
         mode === "sign-up"
           ? t("den.status_browser_signup")
@@ -251,7 +251,6 @@ export function useDenSession({
       void tryOpenBrowserAuthUrl(url).then((opened) => {
         if (opened) return;
         setStatusMessage(null);
-        setSigninFallbackUrl(url);
       });
     },
     [baseUrl, setStatusMessage],

--- a/apps/app/tests/signin-fallback-notice.test.tsx
+++ b/apps/app/tests/signin-fallback-notice.test.tsx
@@ -1,0 +1,13 @@
+import { expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { SignInFallbackNotice } from "../src/react-app/domains/cloud/signin-fallback-notice";
+
+test("sign-in fallback shows the complete URL as a clickable link", () => {
+  const url = "https://example.com/sign-in?state=visible";
+  const html = renderToStaticMarkup(<SignInFallbackNotice url={url} />);
+
+  expect(html).toContain(`href="${url}"`);
+  expect(html).toContain(url);
+  expect(html).toContain("Copy sign-in link");
+});

--- a/evals/flows/signin-browser-open-fallback.flow.mjs
+++ b/evals/flows/signin-browser-open-fallback.flow.mjs
@@ -1,6 +1,6 @@
 export default {
   id: "signin-browser-open-fallback",
-  title: "Cloud sign-in surfaces browser open failure with copy-link fallback",
+  title: "Cloud sign-in keeps the exact URL visible as a fallback",
   kind: "user-facing",
   requiredEnv: ["OPENWORK_SIMULATE_OPEN_EXTERNAL_FAILURE"],
   steps: [
@@ -32,25 +32,47 @@ export default {
           await ctx.clickText("Sign out");
           await ctx.expectText("Sign in", { timeoutMs: 15_000 });
         }
+        await ctx.waitFor(
+          "window.__openworkControl.execute('auth.status').then((result) => result.result?.status === 'signed_out').catch(() => false)",
+          { timeoutMs: 15_000, label: "stable signed-out state" },
+        );
       },
     },
     {
-      name: "Browser open failure shows fallback",
+      name: "Sign in keeps the exact URL visible",
       run: async (ctx) => {
-        await ctx.clickText("Sign in");
-        await ctx.expectText("We couldn't open your browser automatically.", { timeoutMs: 10_000 });
+        await ctx.eval(`(() => {
+          const button = [...document.querySelectorAll("button")].find(
+            (entry) => entry.textContent?.trim() === "Sign in" && !entry.disabled,
+          );
+          button?.setAttribute("data-eval-cloud-signin", "true");
+          return Boolean(button);
+        })()`);
+        await ctx.trustedClick('[data-eval-cloud-signin="true"]');
+        await ctx.expectText("Copy the sign-in link and open it in any browser", { timeoutMs: 10_000 });
         await ctx.expectText("Copy sign-in link");
         await ctx.expectText("Sign-in link or one-time code");
+        const signInUrl = await ctx.eval(`(() => {
+          const link = [...document.querySelectorAll("a")].find((entry) =>
+            entry.href.includes("desktopAuth=1") && entry.href.includes("mode=sign-in")
+          );
+          return link?.href ?? "";
+        })()`);
+        ctx.assert(
+          typeof signInUrl === "string" && signInUrl.includes("desktopScheme=openwork"),
+          "The complete desktop sign-in URL should be visible as a clickable link.",
+        );
         await ctx.screenshot("browser-open-fallback", {
-          claim: "When the system browser cannot be opened, Cloud sign-in shows a copy-link fallback and keeps paste-code auth reachable.",
+          claim: "After Sign in is clicked, the exact Cloud URL stays visible and clickable even when the automatic browser launch fails.",
           voiceover:
-            "I click Sign in, but this machine refuses to open a browser. Instead of pretending everything worked, OpenWork tells me right away and offers to copy the sign-in link — and the paste-code box is already open for when I come back.",
+            "I click Sign in, and OpenWork keeps the exact Cloud URL directly below the button. Even when this machine cannot launch a browser, I can open or copy the link and finish signing in.",
           requireText: [
-            "We couldn't open your browser automatically.",
+            "Copy the sign-in link and open it in any browser",
+            "desktopAuth=1",
             "Copy sign-in link",
             "Sign-in link or one-time code",
           ],
-          rejectText: ["Finish signing in"],
+          rejectText: ["We couldn't open your browser automatically."],
           hashIncludes: "/settings/cloud-account",
         });
       },
@@ -84,10 +106,12 @@ export default {
           voiceover:
             "One click copies the real sign-in link, so I can open it in any browser I like, sign in there, and paste the code back here to finish.",
           requireText: [
-            "We couldn't open your browser automatically.",
+            "Copy the sign-in link and open it in any browser",
+            "desktopAuth=1",
+            "Copied",
             "Sign-in link or one-time code",
           ],
-          rejectText: ["Finish signing in"],
+          rejectText: ["We couldn't open your browser automatically."],
           hashIncludes: "/settings/cloud-account",
         });
       },


### PR DESCRIPTION
## Summary

- keep the exact sign-in URL visible directly below the sign-in controls
- make the URL clickable and selectable while preserving the existing copy action
- show the fallback regardless of whether the automatic browser launch succeeds

## Checks

- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app test` — 370 passed
- `OPENWORK_SIMULATE_OPEN_EXTERNAL_FAILURE=1 pnpm fraimz --flow signin-browser-open-fallback --cdp-url <local-electron-cdp>` — passed (1 flow, 2 validated frames)

## UI proof

[Fraimz screenshots and assertions](https://github.com/different-ai/openwork/pull/2948#issuecomment-5032075676)

The live Electron run forced the automatic browser launch to fail, then verified that the complete clickable URL remained visible and that the copy action produced a usable desktop sign-in URL.

## Limitation

The operating system can still block opening a browser and clipboard permissions can block copying. The complete URL remains visible, clickable, and selectable as the final fallback.
