### PR TITLE
feat(evals): add enterprise gateway first-run demo

### DIFF
--- a/evals/flows/enterprise-first-auth.flow.mjs
+++ b/evals/flows/enterprise-first-auth.flow.mjs
@@ -1,0 +1,270 @@
+/**
+ * Enterprise new-member first run — factory-fresh desktop app first auth.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL: Den API base URL for the enterprise sandbox.
+ * - OPENWORK_EVAL_DEN_WEB_URL: Den Web origin used by the desktop handoff link.
+ *
+ * Optional env:
+ * - OPENWORK_EVAL_CDP_URL or --cdp-url: CDP endpoint for a factory-fresh Electron app.
+ * - OPENWORK_EVAL_ENTERPRISE_ORG_NAME: organization display name (default Example Organization).
+ * - OPENWORK_EVAL_ENTERPRISE_NEW_MEMBER_EMAIL: signed-in member email (default new.member@example.com).
+ * - OPENWORK_EVAL_ENTERPRISE_NEW_MEMBER_WORKSPACE: workspace folder (default /workspace/enterprise-first-auth).
+ * - OPENWORK_EVAL_ENTERPRISE_GATEWAY_URL: gateway base URL used if the transcript asks for JIT login without a full link.
+ * - OPENWORK_EVAL_ENTERPRISE_NEW_MEMBER_GATEWAY_USER: gateway login user override (default signed-in member email).
+ * - OPENWORK_EVAL_ENTERPRISE_PASSWORD: account password (default TutorialDemo123!).
+ * - OPENWORK_EVAL_ENTERPRISE_TASK_TIMEOUT_MS: chat turn timeout in milliseconds.
+ *
+ * Runner note: evals/runner/run.mjs chooses one CDP endpoint for a run. Point
+ * OPENWORK_EVAL_CDP_URL (or --cdp-url) at the freshly installed sandbox/app.
+ */
+
+import {
+  assertEvidence,
+  configureDesktopForDen,
+  createDesktopHandoff,
+  deliverDesktopDeepLink,
+  ensureLocalWorkspace,
+  ensureLocalWorkspaceBeforeConnectPollIfNeeded,
+  enterpriseOrgName,
+  envText,
+  resetDesktopDenSession,
+  retryAfterGatewayLoginIfNeeded,
+  sendPromptAndWait,
+  signInByEmail,
+  timeoutMs,
+  waitForOpenWorkConnectReady,
+  workspaceFolder,
+} from "./enterprise-gateway-common.mjs";
+
+const DEFAULT_NEW_MEMBER_EMAIL = "new.member@example.com";
+const WORKSPACE_ENV = "OPENWORK_EVAL_ENTERPRISE_NEW_MEMBER_WORKSPACE";
+const DEFAULT_WORKSPACE = "/workspace/enterprise-first-auth";
+const PROMPT = "Use OpenWork Cloud capabilities to find and use the `my-incidents` skill, then report the open incidents assigned to me.";
+const PROMPT_AFTER_JIT = "The enterprise incident gateway sign-in is complete. Start fresh without reusing prior results: find and use `my-incidents` / `enterprise_graph_query` with `assigned_to: me` and `status: open`, then report my open incidents.";
+const JIT_COMPLETE_SENTINEL = "OPENWORK_ENTERPRISE_JIT_COMPLETE_SENTINEL";
+
+const state = {
+  newMemberToken: "",
+  workspaceId: "",
+  latestTranscript: "",
+};
+
+export default {
+  id: "enterprise-first-auth",
+  title: "Enterprise factory-fresh desktop first auth provisions org resources and discovers my-incidents",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Frame: first open",
+      run: async (ctx) => {
+        await ctx.prove("A just-installed enterprise desktop app opens to the OpenWork welcome screen", {
+          action: async () => {
+            await ctx.waitForText("Welcome to OpenWork", { timeoutMs: 90_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Welcome to OpenWork");
+          },
+          screenshot: {
+            name: "enterprise-first-open",
+            claim: "The first launch starts from the generic OpenWork welcome screen before the member signs in.",
+            requireText: ["Welcome to OpenWork"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Dispatch new member's Den desktop handoff",
+      run: async (ctx) => {
+        state.newMemberToken = await dispatchDesktopHandoff(ctx, newMemberEmail(ctx));
+      },
+    },
+    {
+      name: "Frame: choose org",
+      run: async (ctx) => {
+        await ctx.prove("New member chooses the organization during first desktop auth", {
+          action: async () => {
+            await waitForChooseOrg(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText("Choose your organization");
+            await ctx.expectText(enterpriseOrgName(ctx));
+            await ctx.expectText("Continue with organization");
+            const signedIn = await desktopAuthState(ctx);
+            assertEvidence(ctx, signedIn.hasToken, "The desktop handoff persisted a Den auth token before org selection", signedIn);
+          },
+          screenshot: {
+            name: "enterprise-choose-org",
+            claim: "Before anything is clicked, the app asks the member which organization to connect.",
+            requireText: ["Choose your organization", enterpriseOrgName(ctx), "Continue with organization"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Click Continue with organization",
+      run: async (ctx) => {
+        await clickTextStartingWith(ctx, "Continue with organization", "button, [role=button]", 30_000);
+      },
+    },
+    {
+      name: "Frame: org provisioned",
+      run: async (ctx) => {
+        await ctx.prove("Organization resources are provisioned before the member enters the workspace", {
+          action: async () => {
+            await waitForOrgResources(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText(enterpriseOrgName(ctx));
+            await ctx.expectText("You have access to the following resources.");
+            await ctx.expectText("Continue to workspace");
+          },
+          screenshot: {
+            name: "enterprise-org-provisioned",
+            claim: "Before Continue to workspace is clicked, the app shows organization resources are ready.",
+            requireText: [enterpriseOrgName(ctx), "You have access to the following resources.", "Continue to workspace"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Continue to workspace and wait for OpenWork Connect",
+      run: async (ctx) => {
+        await clickTextStartingWith(ctx, "Continue to workspace", "button, [role=button]", 30_000);
+        await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", { timeoutMs: 60_000, label: "desktop Den auth token" });
+        const shell = await ctx.waitFor(`(() => {
+          const text = document.body.innerText || '';
+          return text.includes('OpenWork Connect') || text.includes('Run task') || location.hash.includes('/workspace') || location.hash.includes('/welcome');
+        })()`, { timeoutMs: 90_000, label: "desktop app shell after org provisioning" });
+        assertEvidence(ctx, Boolean(shell), "The signed-in desktop app shell is visible after org provisioning", await desktopAuthState(ctx));
+        const folder = workspaceFolder(ctx, WORKSPACE_ENV, DEFAULT_WORKSPACE);
+        state.workspaceId = await ensureLocalWorkspaceBeforeConnectPollIfNeeded(ctx, folder);
+        if (state.workspaceId) {
+          assertEvidence(ctx, true, "A local workspace is created from the welcome route before polling OpenWork Connect", {
+            folder,
+            workspaceId: state.workspaceId,
+          });
+        }
+        const ready = await waitForOpenWorkConnectReady(ctx);
+        assertEvidence(ctx, ready.ready, "OpenWork Connect reaches Ready on the factory-fresh app", ready);
+      },
+    },
+    {
+      name: "Create new member's fresh workspace",
+      run: async (ctx) => {
+        const folder = workspaceFolder(ctx, WORKSPACE_ENV, DEFAULT_WORKSPACE);
+        if (state.workspaceId) {
+          assertEvidence(ctx, true, "A local workspace is available for the member's first run", {
+            folder,
+            workspaceId: state.workspaceId,
+          });
+          return;
+        }
+        state.workspaceId = await ensureLocalWorkspace(ctx, folder);
+        assertEvidence(ctx, state.workspaceId.length > 0, "A local workspace is created for the member's first run", {
+          folder,
+          workspaceId: state.workspaceId,
+        });
+      },
+    },
+    {
+      name: "Frame: org skill on fresh machine",
+      run: async (ctx) => {
+        await ctx.prove("Member's first task discovers the my-incidents org skill on a fresh machine", {
+          action: async () => {
+            const timeout = timeoutMs(ctx, "OPENWORK_EVAL_ENTERPRISE_FIRST_AUTH_TIMEOUT_MS", 300_000);
+            const first = await sendPromptAndWait(ctx, PROMPT, { timeout });
+            state.latestTranscript = await retryAfterGatewayLoginIfNeeded(
+              ctx,
+              newMemberEmail(ctx),
+              first,
+              JIT_COMPLETE_SENTINEL,
+              PROMPT_AFTER_JIT,
+              { timeout, gatewayUserEnvName: "OPENWORK_EVAL_ENTERPRISE_NEW_MEMBER_GATEWAY_USER" },
+            );
+          },
+          assert: async () => {
+            const transcript = state.latestTranscript;
+            assertEvidence(ctx, transcript.toLowerCase().includes("my-incidents"), "Transcript mentions the cloud-delivered my-incidents skill", transcript);
+          },
+          screenshot: {
+            name: "enterprise-org-skill-on-fresh-machine",
+            claim: "The first chat on a brand-new desktop discovers and uses the my-incidents skill.",
+            requireText: ["my-incidents"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};
+
+function newMemberEmail(ctx) {
+  return envText(ctx, "OPENWORK_EVAL_ENTERPRISE_NEW_MEMBER_EMAIL") || DEFAULT_NEW_MEMBER_EMAIL;
+}
+
+async function dispatchDesktopHandoff(ctx, email) {
+  await configureDesktopForDen(ctx);
+  await resetDesktopDenSession(ctx);
+  const token = await signInByEmail(ctx, email);
+  const openworkUrl = await createDesktopHandoff(ctx, token);
+  await deliverDesktopDeepLink(ctx, openworkUrl);
+  await waitForDesktopToken(ctx, openworkUrl);
+  return token;
+}
+
+async function waitForDesktopToken(ctx, openworkUrl) {
+  try {
+    await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", { timeoutMs: 60_000, label: "desktop Den token after handoff" });
+  } catch (error) {
+    const diagnostics = await desktopAuthState(ctx);
+    const redactedUrl = openworkUrl.replace(/([?&]grant=)[^&]+/, "$1<redacted>");
+    throw new Error(`Timed out waiting for desktop Den token after deep-link handoff ${redactedUrl}. Diagnostics: ${JSON.stringify(diagnostics)}. ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+async function waitForChooseOrg(ctx) {
+  const orgName = enterpriseOrgName(ctx);
+  await ctx.waitFor(`(() => {
+    const orgName = ${JSON.stringify(orgName)};
+    const text = document.body.innerText || '';
+    const buttons = [...document.querySelectorAll('button, [role=button]')].map((entry) => (entry.textContent ?? '').replace(/\\s+/g, ' ').trim());
+    return text.includes('Choose your organization') && text.includes(orgName) && buttons.some((button) => button.startsWith('Continue with organization'));
+  })()`, { timeoutMs: 90_000, label: "enterprise organization chooser" });
+}
+
+async function waitForOrgResources(ctx) {
+  const orgName = enterpriseOrgName(ctx);
+  await ctx.waitFor(`(() => {
+    const orgName = ${JSON.stringify(orgName)};
+    const text = document.body.innerText || '';
+    return text.includes(orgName) && text.includes('You have access to the following resources.') && text.includes('Continue to workspace');
+  })()`, { timeoutMs: 90_000, label: "enterprise provisioned resources screen" });
+}
+
+async function clickTextStartingWith(ctx, prefix, selector, timeoutMs) {
+  await ctx.waitFor(`(() => {
+    const normalize = (value) => (value ?? '').replace(/\\s+/g, ' ').trim();
+    const element = [...document.querySelectorAll(${JSON.stringify(selector)})]
+      .find((entry) => normalize(entry.textContent).startsWith(${JSON.stringify(prefix)}) && entry.disabled !== true && entry.getAttribute('aria-disabled') !== 'true');
+    element?.scrollIntoView({ block: 'center', inline: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs, label: `clickable text starting with ${JSON.stringify(prefix)}` });
+}
+
+async function desktopAuthState(ctx) {
+  return ctx.eval(`(() => ({
+    hasToken: Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim()),
+    activeOrgId: localStorage.getItem('openwork.den.activeOrgId') || '',
+    activeOrgName: localStorage.getItem('openwork.den.activeOrgName') || '',
+    hash: location.hash,
+    visibleText: (document.body.innerText || '').slice(0, 1_000),
+    handoffEvents: window.__enterpriseHandoffDiagnostics?.events ?? [],
+    handoffExchanges: window.__enterpriseHandoffDiagnostics?.exchanges ?? [],
+  }))()`);
+}

--- a/evals/flows/enterprise-gateway-admin.flow.mjs
+++ b/evals/flows/enterprise-gateway-admin.flow.mjs
@@ -1,0 +1,172 @@
+/**
+ * Enterprise incident gateway demo — Admin machine.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL: Den API base URL for the enterprise sandbox.
+ * - OPENWORK_EVAL_DEN_WEB_URL: Den web origin used by the desktop handoff deep link.
+ *
+ * Optional env:
+ * - OPENWORK_EVAL_CDP_URL or --cdp-url: CDP endpoint for the admin desktop app.
+ * - OPENWORK_EVAL_ENTERPRISE_ADMIN_EMAIL: admin email (default admin@example.com).
+ * - OPENWORK_EVAL_ENTERPRISE_MEMBER_EMAIL: member email used to verify sharing (default member@example.com).
+ * - OPENWORK_EVAL_ENTERPRISE_ADMIN_WORKSPACE: workspace folder (default /workspace/enterprise-admin).
+ * - OPENWORK_EVAL_ENTERPRISE_GATEWAY_URL: gateway base URL used only if the transcript asks for JIT login without a full link.
+ * - OPENWORK_EVAL_ENTERPRISE_ADMIN_GATEWAY_USER: gateway login user override (default admin email).
+ * - OPENWORK_EVAL_ENTERPRISE_PASSWORD: account password override (default TutorialDemo123!).
+ * - OPENWORK_EVAL_ENTERPRISE_TASK_TIMEOUT_MS: chat turn timeout in milliseconds.
+ * - OPENWORK_EVAL_ENTERPRISE_SHARE_TIMEOUT_MS: marketplace/share chat timeout in milliseconds.
+ *
+ * Runner note: evals/runner/run.mjs currently chooses one CDP endpoint for a run.
+ * To run the member flow on a second desktop, run it in a separate command with
+ * OPENWORK_EVAL_CDP_URL (or --cdp-url) pointed at that second app instance.
+ */
+
+import {
+  assertEvidence,
+  clickThroughLingeringOnboarding,
+  desktopHandoffSignIn,
+  ensureLocalWorkspace,
+  ensureLocalWorkspaceBeforeConnectPollIfNeeded,
+  envText,
+  listSkillsFor,
+  retryAfterGatewayLoginIfNeeded,
+  sendPromptAndWait,
+  signInByEmail,
+  timeoutMs,
+  waitForOpenWorkConnectReady,
+  workspaceFolder,
+} from "./enterprise-gateway-common.mjs";
+
+const DEFAULT_ADMIN_EMAIL = "admin@example.com";
+const DEFAULT_MEMBER_EMAIL = "member@example.com";
+const WORKSPACE_ENV = "OPENWORK_EVAL_ENTERPRISE_ADMIN_WORKSPACE";
+const DEFAULT_WORKSPACE = "/workspace/enterprise-admin";
+
+const PROMPT_INCIDENTS = "Use OpenWork Connect capabilities to find the enterprise incident gateway. Search for the right capability, then ask the gateway for my open incidents assigned to me using its enterprise graph query capability. Do not use lookup_incident_records. I need the incident numbers, priorities, and short descriptions.";
+const PROMPT_INCIDENTS_RETRY = "I completed the enterprise incident gateway sign-in. Retry the same enterprise graph query for my open incidents assigned to me, still without using lookup_incident_records.";
+const PROMPT_CREATE_SKILL = "Create a skill from what we just learned and save it to our org: whenever I ask about my incidents, always use enterprise_graph_query scoped to assigned_to=me (never lookup_incident_records), default to open status, and present a table with number, priority, and short description. Name it my-incidents.";
+
+const state = {
+  workspaceId: "",
+  latestTranscript: "",
+};
+
+export default {
+  id: "enterprise-gateway-admin",
+  title: "Enterprise gateway demo: Admin creates and shares the my-incidents skill",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Desktop handoff signs in Admin to the organization",
+      run: async (ctx) => {
+        await desktopHandoffSignIn(ctx, adminEmail(ctx));
+      },
+    },
+    {
+      name: "Create Admin's fresh workspace with OpenWork Connect ready",
+      run: async (ctx) => {
+        await clickThroughLingeringOnboarding(ctx);
+        const folder = workspaceFolder(ctx, WORKSPACE_ENV, DEFAULT_WORKSPACE);
+        state.workspaceId = await ensureLocalWorkspaceBeforeConnectPollIfNeeded(ctx, folder);
+        await waitForOpenWorkConnectReady(ctx);
+        if (!state.workspaceId) state.workspaceId = await ensureLocalWorkspace(ctx, folder);
+      },
+    },
+    {
+      name: "Prompt 1: Admin asks the gateway for open incidents with JIT auth",
+      run: async (ctx) => {
+        await ctx.prove("Admin's agent uses the enterprise incident gateway and resolves the JIT sign-in path", {
+          action: async () => {
+            const timeout = timeoutMs(ctx, "OPENWORK_EVAL_ENTERPRISE_INCIDENT_TIMEOUT_MS", 300_000);
+            const first = await sendPromptAndWait(ctx, PROMPT_INCIDENTS, { timeout });
+            state.latestTranscript = await retryAfterGatewayLoginIfNeeded(
+              ctx,
+              adminEmail(ctx),
+              first,
+              "INC0012341",
+              PROMPT_INCIDENTS_RETRY,
+              { timeout, gatewayUserEnvName: "OPENWORK_EVAL_ENTERPRISE_ADMIN_GATEWAY_USER" },
+            );
+          },
+          assert: async () => {
+            const text = state.latestTranscript;
+            assertEvidence(ctx, text.includes("enterprise_graph_query"), "Transcript shows the enterprise_graph_query capability/tool name", text);
+            assertEvidence(ctx, text.includes("Authorization required") || /\blogin\b/i.test(text), "Transcript shows JIT authorization required or a login link", text);
+            assertEvidence(ctx, text.includes("INC0012341"), "Transcript includes Admin's incident INC0012341", text);
+          },
+          screenshot: {
+            name: "admin-gateway-incidents",
+            claim: "Admin's chat shows the gateway-backed incident result after the JIT auth path.",
+            requireText: ["INC0012341"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Prompt 2: Admin saves the my-incidents skill to the org",
+      run: async (ctx) => {
+        await ctx.prove("Admin turns the learned gateway pattern into an org skill", {
+          action: async () => {
+            state.latestTranscript = await sendPromptAndWait(ctx, PROMPT_CREATE_SKILL, {
+              timeout: timeoutMs(ctx, "OPENWORK_EVAL_ENTERPRISE_SKILL_TIMEOUT_MS", 300_000),
+            });
+          },
+          assert: async () => {
+            assertEvidence(ctx, /skl_|created.*skill|saved.*org/i.test(state.latestTranscript), "Transcript confirms a cloud skill was created or saved to the org", state.latestTranscript);
+          },
+          screenshot: {
+            name: "admin-created-my-incidents-skill",
+            claim: "The chat confirms my-incidents was saved as an organization skill.",
+            requireText: ["my-incidents"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Prompt 3: Admin shares my-incidents to the member through the marketplace",
+      run: async (ctx) => {
+        await ctx.prove("Admin assigns the org skill to the member through the organization marketplace", {
+          action: async () => {
+            state.latestTranscript = await sendPromptAndWait(ctx, shareSkillPrompt(ctx), {
+              timeout: timeoutMs(ctx, "OPENWORK_EVAL_ENTERPRISE_SHARE_TIMEOUT_MS", 420_000),
+            });
+          },
+          assert: async () => {
+            assertEvidence(ctx, /granted|access/i.test(state.latestTranscript), "Transcript confirms the member was granted access", state.latestTranscript);
+            assertEvidence(ctx, /marketplace|hub/i.test(state.latestTranscript), "Transcript mentions marketplace or hub sharing", state.latestTranscript);
+          },
+          screenshot: {
+            name: "admin-shared-my-incidents",
+            claim: "The chat confirms my-incidents was shared through the marketplace/hub to the member.",
+            requireText: ["my-incidents"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Server-side assert: member can list my-incidents",
+      run: async (ctx) => {
+        const memberToken = await signInByEmail(ctx, memberEmail(ctx));
+        const skills = await listSkillsFor(ctx, memberToken);
+        const found = skills.some((skill) => String(skill.title ?? "").trim().toLowerCase() === "my-incidents");
+        assertEvidence(ctx, found, "GET /v1/skills as member includes a skill titled my-incidents", skills.map((skill) => ({ id: skill.id, title: skill.title })));
+      },
+    },
+  ],
+};
+
+function adminEmail(ctx) {
+  return envText(ctx, "OPENWORK_EVAL_ENTERPRISE_ADMIN_EMAIL") || DEFAULT_ADMIN_EMAIL;
+}
+
+function memberEmail(ctx) {
+  return envText(ctx, "OPENWORK_EVAL_ENTERPRISE_MEMBER_EMAIL") || DEFAULT_MEMBER_EMAIL;
+}
+
+function shareSkillPrompt(ctx) {
+  return `Add the my-incidents skill to our organization marketplace and assign it to ${memberEmail(ctx)} so the member gets it too.`;
+}

--- a/evals/flows/enterprise-gateway-common.mjs
+++ b/evals/flows/enterprise-gateway-common.mjs
@@ -1,0 +1,689 @@
+const CLICKABLE_SELECTOR = "button, [role=button], a, div, article, li, label";
+const EDITOR_SELECTOR = '[contenteditable="true"][data-lexical-editor="true"]';
+const WELCOME_FOLDER_INPUT_SELECTOR = 'input[placeholder="/workspace/my-project"]';
+const DEFAULT_PASSWORD = "TutorialDemo123!";
+
+export function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export function envText(ctx, name) {
+  return (ctx.env[name] ?? "").trim();
+}
+
+export function enterpriseOrgName(ctx) {
+  return envText(ctx, "OPENWORK_EVAL_ENTERPRISE_ORG_NAME") || "Example Organization";
+}
+
+export function cleanBase(value) {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+export function denApiBase(ctx) {
+  const value = cleanBase(envText(ctx, "OPENWORK_EVAL_DEN_API_URL"));
+  ctx.assert(Boolean(value), "Missing OPENWORK_EVAL_DEN_API_URL for the enterprise eval flow.");
+  return value;
+}
+
+export function denWebBase(ctx) {
+  const value = cleanBase(envText(ctx, "OPENWORK_EVAL_DEN_WEB_URL"));
+  ctx.assert(Boolean(value), "Missing OPENWORK_EVAL_DEN_WEB_URL for the enterprise desktop handoff deep link.");
+  return value;
+}
+
+export function workspaceFolder(ctx, envName, fallback) {
+  return envText(ctx, envName) || fallback;
+}
+
+export function timeoutMs(ctx, envName, fallback) {
+  const raw = envText(ctx, envName) || envText(ctx, "OPENWORK_EVAL_ENTERPRISE_TASK_TIMEOUT_MS");
+  if (!raw) return fallback;
+  const value = Number(raw);
+  ctx.assert(Number.isFinite(value) && value > 0, `${envName} must be a positive millisecond timeout.`);
+  return value;
+}
+
+function actualText(value) {
+  if (typeof value === "string") return value.slice(0, 2_000);
+  try {
+    return JSON.stringify(value).slice(0, 2_000);
+  } catch {
+    return String(value).slice(0, 2_000);
+  }
+}
+
+export function assertEvidence(ctx, condition, assertion, actual = "") {
+  ctx.recordEvidence({ type: "assertion", status: condition ? "passed" : "failed", assertion, actual: actualText(actual) });
+  ctx.assert(condition, `${assertion}${actual ? `. Actual: ${actualText(actual)}` : ""}`);
+}
+
+async function denApiFetch(ctx, pathname, init = {}) {
+  const url = `${denApiBase(ctx)}${pathname}`;
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      Origin: denWebBase(ctx),
+      ...(init.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body, text, url };
+}
+
+function httpFailureMessage(label, result) {
+  return `${label}: ${result.response.status} ${result.response.statusText} ${result.text.slice(0, 1_000)} (url: ${result.url})`;
+}
+
+export async function signInByEmail(ctx, email) {
+  const result = await denApiFetch(ctx, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password: envText(ctx, "OPENWORK_EVAL_ENTERPRISE_PASSWORD") || DEFAULT_PASSWORD }),
+  });
+  ctx.assert(result.response.ok, httpFailureMessage(`Enterprise sign-in failed for ${email}`, result));
+  const token = result.body?.token;
+  ctx.assert(typeof token === "string" && token.trim().length > 0, `Enterprise sign-in for ${email} returned no bearer token.`);
+  return token.trim();
+}
+
+export async function createDesktopHandoff(ctx, token) {
+  const result = await denApiFetch(ctx, "/v1/auth/desktop-handoff", {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({ desktopScheme: "openwork" }),
+  });
+  ctx.assert(result.response.ok, httpFailureMessage("Desktop handoff create failed", result));
+  const openworkUrl = result.body?.openworkUrl;
+  ctx.assert(typeof openworkUrl === "string" && openworkUrl.length > 0, "Desktop handoff response did not include openworkUrl.");
+  const url = new URL(openworkUrl);
+  url.searchParams.set("denBaseUrl", denWebBase(ctx));
+  return url.toString();
+}
+
+export async function configureDesktopForDen(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 120_000, label: "OpenWork control API" });
+  const apiBase = denApiBase(ctx);
+  const webBase = denWebBase(ctx);
+  const result = await ctx.eval(`(async () => {
+    const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+    if (bridge) {
+      await bridge("setDesktopBootstrapConfig", { baseUrl: ${JSON.stringify(webBase)}, apiBaseUrl: ${JSON.stringify(apiBase)}, requireSignin: false, handoff: null });
+    }
+    localStorage.setItem("openwork.den.baseUrl", ${JSON.stringify(webBase)});
+    localStorage.setItem("openwork.den.apiBaseUrl", ${JSON.stringify(apiBase)});
+    let prefs = {};
+    try { prefs = JSON.parse(localStorage.getItem("openwork.preferences") || "{}"); } catch {}
+    localStorage.setItem("openwork.preferences", JSON.stringify({ ...prefs, selectedAgent: "openwork" }));
+    return { bridge: Boolean(bridge) };
+  })()`, { awaitPromise: true });
+  ctx.log(`Configured Den base for desktop (${result?.bridge ? "desktop bridge" : "renderer only"}).`);
+}
+
+export async function resetDesktopDenSession(ctx) {
+  await ctx.eval(`(() => {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith("openwork.den.mcp")) localStorage.removeItem(key);
+    }
+    for (const key of ["openwork.den.authToken", "openwork.den.activeOrgId", "openwork.den.activeOrgSlug", "openwork.den.activeOrgName"]) {
+      localStorage.removeItem(key);
+    }
+    window.dispatchEvent(new CustomEvent("openwork-den-session-updated", { detail: { status: "signed_out" } }));
+    return true;
+  })()`);
+}
+
+export async function deliverDesktopDeepLink(ctx, openworkUrl) {
+  const webBase = denWebBase(ctx);
+  await ctx.eval(`(() => {
+    const url = ${JSON.stringify(openworkUrl)};
+    const redact = (value) => String(value ?? "")
+      .replace(/("token"\\s*:\\s*")[^"]+/gi, "$1<redacted>")
+      .replace(/Bearer\\s+[A-Za-z0-9._~+/-]+=*/gi, "Bearer <redacted>");
+    window.__enterpriseHandoffDiagnostics = { events: [], exchanges: [] };
+    window.addEventListener("openwork-den-session-updated", (event) => {
+      const detail = event.detail ?? null;
+      window.__enterpriseHandoffDiagnostics.events.push(detail?.token ? { ...detail, token: "<redacted>" } : detail);
+    });
+    if (!window.__enterpriseFetchWrapped) {
+      window.__enterpriseFetchWrapped = true;
+      const originalFetch = window.fetch.bind(window);
+      window.fetch = async (...args) => {
+        const response = await originalFetch(...args);
+        const requestUrl = typeof args[0] === "string" ? args[0] : args[0] instanceof URL ? args[0].toString() : args[0]?.url;
+        if (typeof requestUrl === "string" && requestUrl.includes("/v1/auth/desktop-handoff/exchange")) {
+          response.clone().text().then((text) => {
+            window.__enterpriseHandoffDiagnostics.exchanges.push({ status: response.status, statusText: response.statusText, url: requestUrl, body: redact(text).slice(0, 1_000) });
+          }).catch((error) => {
+            window.__enterpriseHandoffDiagnostics.exchanges.push({ status: response.status, statusText: response.statusText, url: requestUrl, body: error instanceof Error ? error.message : String(error) });
+          });
+        }
+        return response;
+      };
+    }
+    window.__OPENWORK__ = window.__OPENWORK__ || {};
+    window.__OPENWORK__.deepLinks = [...(window.__OPENWORK__.deepLinks || []), url];
+    window.dispatchEvent(new CustomEvent("openwork:deep-link", { detail: { urls: [url], denBaseUrl: ${JSON.stringify(webBase)} } }));
+    return true;
+  })()`);
+}
+
+async function waitForDesktopDenToken(ctx, openworkUrl) {
+  try {
+    await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", { timeoutMs: 60_000, label: "desktop Den token" });
+  } catch (error) {
+    const diagnostics = await ctx.eval(`(() => ({
+      authToken: Boolean((localStorage.getItem("openwork.den.authToken") ?? "").trim()),
+      baseUrl: localStorage.getItem("openwork.den.baseUrl") || "",
+      apiBaseUrl: localStorage.getItem("openwork.den.apiBaseUrl") || "",
+      activeOrgId: localStorage.getItem("openwork.den.activeOrgId") || "",
+      events: window.__enterpriseHandoffDiagnostics?.events ?? [],
+      exchanges: window.__enterpriseHandoffDiagnostics?.exchanges ?? [],
+    }))()`);
+    const redactedUrl = openworkUrl.replace(/([?&]grant=)[^&]+/, "$1<redacted>");
+    throw new Error(`Timed out waiting for desktop Den token after deep-link handoff ${redactedUrl}. Diagnostics: ${JSON.stringify(diagnostics)}. ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+export async function clickExactText(ctx, text, selector = "button, [role=button], a", timeout = 20_000) {
+  await ctx.waitFor(`(() => {
+    const normalize = (value) => (value ?? "").replace(/\\s+/g, " ").trim();
+    const visibleEnabled = (entry) => {
+      entry.scrollIntoView({ block: "center", inline: "center" });
+      const rect = entry.getBoundingClientRect();
+      const style = window.getComputedStyle(entry);
+      const top = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+      return entry.disabled !== true
+        && entry.getAttribute("aria-disabled") !== "true"
+        && rect.width > 0
+        && rect.height > 0
+        && style.visibility !== "hidden"
+        && style.display !== "none"
+        && Boolean(top && (top === entry || entry.contains(top)));
+    };
+    const element = [...document.querySelectorAll(${JSON.stringify(selector)})]
+      .find((entry) => normalize(entry.textContent) === ${JSON.stringify(text)} && visibleEnabled(entry));
+    element?.scrollIntoView({ block: "center", inline: "center" });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: timeout, label: `exact clickable text ${JSON.stringify(text)}` });
+}
+
+export async function clickExactIfVisible(ctx, text, selector = "button, [role=button], a") {
+  return Boolean(await ctx.eval(`(() => {
+    const normalize = (value) => (value ?? "").replace(/\\s+/g, " ").trim();
+    const visibleEnabled = (entry) => {
+      entry.scrollIntoView({ block: "center", inline: "center" });
+      const rect = entry.getBoundingClientRect();
+      const style = window.getComputedStyle(entry);
+      const top = document.elementFromPoint(rect.left + rect.width / 2, rect.top + rect.height / 2);
+      return entry.disabled !== true
+        && entry.getAttribute("aria-disabled") !== "true"
+        && rect.width > 0
+        && rect.height > 0
+        && style.visibility !== "hidden"
+        && style.display !== "none"
+        && Boolean(top && (top === entry || entry.contains(top)));
+    };
+    const element = [...document.querySelectorAll(${JSON.stringify(selector)})]
+      .find((entry) => normalize(entry.textContent) === ${JSON.stringify(text)} && visibleEnabled(entry));
+    element?.scrollIntoView({ block: "center", inline: "center" });
+    element?.click();
+    return Boolean(element);
+  })()`));
+}
+
+export async function clickThroughLingeringOnboarding(ctx) {
+  return ctx.eval(`(() => {
+    const normalize = (value) => (value ?? "").replace(/\\s+/g, " ").trim();
+    const click = (element) => {
+      element.scrollIntoView({ block: "center", inline: "center" });
+      element.click();
+      return true;
+    };
+    const findButton = (predicate) => [...document.querySelectorAll("button, [role=button]")]
+      .find((entry) => predicate(normalize(entry.textContent)) && entry.disabled !== true && entry.getAttribute("aria-disabled") !== "true");
+    const continueOrg = findButton((text) => text.startsWith("Continue with organization"));
+    const clickedContinueOrg = continueOrg ? click(continueOrg) : false;
+    const continueWorkspace = findButton((text) => text === "Continue to workspace");
+    const clickedContinueWorkspace = continueWorkspace ? click(continueWorkspace) : false;
+    return {
+      hash: window.location.hash,
+      hasContinueOrg: Boolean(continueOrg),
+      hasContinueWorkspace: Boolean(continueWorkspace),
+      clickedContinueOrg,
+      clickedContinueWorkspace,
+    };
+  })()`);
+}
+
+async function clickNearestExactIfVisible(ctx, text) {
+  return Boolean(await ctx.eval(`(() => {
+    const normalize = (value) => (value ?? "").replace(/\\s+/g, " ").trim();
+    const labels = [...document.querySelectorAll("*")].filter((entry) => normalize(entry.textContent) === ${JSON.stringify(text)});
+    labels.sort((a, b) => (a.textContent ?? "").length - (b.textContent ?? "").length);
+    const target = labels[0]?.closest(${JSON.stringify(CLICKABLE_SELECTOR)}) || labels[0];
+    target?.scrollIntoView({ block: "center", inline: "center" });
+    target?.click();
+    return Boolean(target);
+  })()`));
+}
+
+export async function completeEnterpriseOrgOnboarding(ctx) {
+  const orgName = enterpriseOrgName(ctx);
+  const deadline = Date.now() + 90_000;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await ctx.eval(`(() => {
+      const orgName = ${JSON.stringify(orgName)};
+      const text = document.body.innerText || "";
+      const buttons = [...document.querySelectorAll("button, [role=button]")].map((entry) => (entry.textContent ?? "").replace(/\\s+/g, " ").trim());
+      return {
+        hash: window.location.hash,
+        activeOrgName: localStorage.getItem("openwork.den.activeOrgName") || "",
+        hasChoose: text.includes("Choose your organization"),
+        hasOrgName: text.includes(orgName),
+        hasContinueOrg: buttons.some((button) => button.startsWith("Continue with organization")),
+        hasContinueWorkspace: buttons.includes("Continue to workspace"),
+        hasFolderInput: Boolean(document.querySelector('input[placeholder="/workspace/my-project"]')),
+      };
+    })()`);
+    if (last.hasFolderInput || last.hash.includes("/welcome")) return;
+    if (last.activeOrgName === orgName && !last.hasChoose && !last.hasContinueOrg && !last.hasContinueWorkspace) return;
+    const onboardingClick = await clickThroughLingeringOnboarding(ctx);
+    if (onboardingClick.clickedContinueOrg || onboardingClick.clickedContinueWorkspace) {
+      await sleep(1_000);
+      continue;
+    }
+    if (last.hasChoose && last.hasOrgName && await clickNearestExactIfVisible(ctx, orgName)) {
+      await sleep(750);
+      continue;
+    }
+    if (last.activeOrgName === orgName) return;
+    await sleep(750);
+  }
+  throw new Error(`Enterprise org onboarding did not settle: ${JSON.stringify(last)}`);
+}
+
+export async function desktopHandoffSignIn(ctx, email) {
+  await configureDesktopForDen(ctx);
+  await resetDesktopDenSession(ctx);
+  const token = await signInByEmail(ctx, email);
+  const openworkUrl = await createDesktopHandoff(ctx, token);
+  await deliverDesktopDeepLink(ctx, openworkUrl);
+  await waitForDesktopDenToken(ctx, openworkUrl);
+  await completeEnterpriseOrgOnboarding(ctx);
+  await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", { timeoutMs: 60_000, label: "desktop active organization" });
+  return token;
+}
+
+function localServerExpr() {
+  return `(() => {
+    const urlOverride = (localStorage.getItem("openwork.server.urlOverride") || "").trim();
+    const port = (localStorage.getItem("openwork.server.port") || "").trim();
+    const token = (localStorage.getItem("openwork.server.token") || "").trim();
+    const hostToken = (localStorage.getItem("openwork.server.hostToken") || "").trim();
+    const base = urlOverride.replace(/\\/+$/, "") || (port ? "http://127.0.0.1:" + port : "");
+    return { base, token, hostToken };
+  })()`;
+}
+
+export async function waitForOpenWorkConnectReady(ctx, timeout = 90_000) {
+  let last = null;
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    const onboardingClick = await clickThroughLingeringOnboarding(ctx);
+    if (onboardingClick.clickedContinueOrg || onboardingClick.clickedContinueWorkspace) await sleep(1_000);
+    last = await ctx.eval(`(() => {
+      const text = document.body.innerText || "";
+      const match = text.match(/OpenWork Connect: (Ready|Checking|Needs attention)/);
+      return { ready: text.includes("OpenWork Connect: Ready"), status: match?.[0] || "", hash: window.location.hash };
+    })()`);
+    if ((last.hash === "#/onboarding" || last.hash === "#/welcome") && !onboardingClick.hasContinueOrg && !onboardingClick.hasContinueWorkspace) {
+      await ctx.eval("window.dispatchEvent(new Event('focus'))").catch(() => undefined);
+      await sleep(1_000);
+      continue;
+    }
+    if (last?.ready) return last;
+    await ctx.eval("window.dispatchEvent(new Event('focus'))").catch(() => undefined);
+    await sleep(1_000);
+  }
+  throw new Error(`OpenWork Connect did not become Ready in the status bar within ${timeout}ms: ${JSON.stringify(last)}`);
+}
+
+export async function ensureLocalWorkspaceBeforeConnectPollIfNeeded(ctx, folderPath) {
+  const existing = await workspaceSessionState(ctx);
+  if (existing.hasConcreteSession) {
+    await clickThroughWorkspaceOnboarding(ctx, folderPath);
+    await ensureComposerReady(ctx);
+    const ready = await workspaceSessionState(ctx);
+    ctx.assert(Boolean(ready.workspaceId), `Existing workspace route lost its workspace id before Connect polling: ${JSON.stringify(ready)}`);
+    return ready.workspaceId;
+  }
+  return ensureLocalWorkspace(ctx, folderPath);
+}
+
+export async function ensureLocalWorkspace(ctx, folderPath) {
+  await ctx.waitFor(`(() => { const s = ${localServerExpr()}; return Boolean(s.base && s.token); })()`, { timeoutMs: 60_000, label: "local OpenWork server URL/token" });
+  let last = null;
+  const deadline = Date.now() + 120_000;
+  while (Date.now() < deadline) {
+    await clickThroughWorkspaceOnboarding(ctx, folderPath);
+    last = await workspaceSessionState(ctx);
+    if (last.hasConcreteSession) {
+      await ensureComposerReady(ctx);
+      const ready = await workspaceSessionState(ctx);
+      ctx.assert(Boolean(ready.workspaceId), `Workspace route did not include a workspace id after onboarding: ${JSON.stringify(ready)}`);
+      return ready.workspaceId;
+    }
+    if (!last.hasFolderInput && !last.hasWelcome) {
+      await ctx.eval(`(() => { window.location.hash = "#/welcome"; return window.location.hash; })()`);
+    }
+    await sleep(1_000);
+  }
+  throw new Error(`Workspace setup through the visible welcome flow did not reach /workspace/<id>/session/ses_* for ${folderPath}. Last state: ${JSON.stringify(last)}`);
+}
+
+async function clickThroughWorkspaceOnboarding(ctx, folderPath) {
+  const onboardingClick = await clickThroughLingeringOnboarding(ctx);
+  if (onboardingClick.clickedContinueOrg || onboardingClick.clickedContinueWorkspace) return true;
+  for (const text of ["Skip and use the free model", "Continue without OpenWork Models", "Skip"]) {
+    if (await clickExactIfVisible(ctx, text, "button, [role=button]")) return true;
+  }
+  const state = await workspaceSessionState(ctx);
+  if (state.hasFolderInput) {
+    if (!folderPath || state.workspaceCreateBusy) return false;
+    await ctx.fill(WELCOME_FOLDER_INPUT_SELECTOR, folderPath);
+    return clickExactIfVisible(ctx, "Use this folder", "button");
+  }
+  return false;
+}
+
+async function workspaceSessionState(ctx) {
+  return ctx.eval(`(() => {
+    const hash = window.location.hash;
+    const match = hash.match(/^#\\/workspace\\/([^/?#]+)\\/session\\/(ses_[^/?#]+)/);
+    const decode = (value) => {
+      try { return decodeURIComponent(value); } catch { return value; }
+    };
+    const text = document.body.innerText || "";
+    const input = document.querySelector(${JSON.stringify(WELCOME_FOLDER_INPUT_SELECTOR)});
+    const inputRect = input?.getBoundingClientRect();
+    return {
+      hash,
+      workspaceId: match ? decode(match[1]) : "",
+      sessionId: match ? decode(match[2]) : "",
+      hasConcreteSession: Boolean(match),
+      hasComposer: Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)})),
+      hasFolderInput: Boolean(input && inputRect && inputRect.width > 0 && inputRect.height > 0),
+      hasWelcome: text.includes("Welcome to OpenWork"),
+      workspaceCreateBusy: text.includes("Creating workspace"),
+      hasConnectStatus: /OpenWork Connect: (Ready|Checking|Needs attention)/.test(text),
+      opencodeUnavailable: text.includes("OpenCode unavailable") || text.includes("opencode_unconfigured") || text.includes("OpenCode base URL is missing"),
+      text: text.slice(0, 1_000),
+    };
+  })()`);
+}
+
+export async function ensureComposerReady(ctx, timeout = 90_000) {
+  let last = null;
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    await clickThroughWorkspaceOnboarding(ctx, "");
+    last = await workspaceSessionState(ctx);
+    if (last?.hasConcreteSession && last.hasComposer && !last.opencodeUnavailable) break;
+    await sleep(1_000);
+  }
+  if (last?.opencodeUnavailable) throw new Error(`OpenCode unavailable — the workspace OpenCode base URL is still missing while waiting for the composer. Restart the app and rerun this eval so the welcome flow can spawn the managed engine. Last state: ${JSON.stringify(last)}`);
+  if (!last?.hasConcreteSession) throw new Error(`Workspace did not reach a concrete /workspace/<id>/session/ses_* route within ${timeout}ms: ${JSON.stringify(last)}`);
+  if (!last?.hasComposer) throw new Error(`Workspace composer did not become ready within ${timeout}ms: ${JSON.stringify(last)}`);
+  await ctx.waitFor("document.body.innerText.includes('Run task')", { timeoutMs: 60_000, label: "Run task button" });
+}
+
+export async function readTranscriptSnapshot(ctx) {
+  return ctx.eval(`(async () => {
+    const normalize = (value) => String(value ?? "").replace(/\\s+/g, " ").trim();
+    const substantive = (value) => {
+      const text = normalize(value);
+      return text.length > 0 && text !== "OpenWork";
+    };
+    const bodyText = document.body.innerText || "";
+    let transcript = null;
+    try {
+      const result = await window.__openworkControl?.execute?.("session.read_transcript", { count: 30 });
+      if (result?.ok && result.result?.messages) transcript = result.result;
+    } catch {}
+    const messages = transcript?.messages ?? [];
+    const transcriptText = messages.length ? messages.map((message) => String(message.role || "") + ": " + String(message.text || "")).join("\\n\\n") : "";
+    const markdownTexts = [...document.querySelectorAll(".markdown-content")]
+      .map((element) => element.innerText || element.textContent || "")
+      .filter((value) => normalize(value).length > 0);
+    const latestRenderedMarkdown = markdownTexts.at(-1) || "";
+    const textParts = transcriptText ? [transcriptText] : [];
+    if (latestRenderedMarkdown && !normalize(transcriptText).includes(normalize(latestRenderedMarkdown))) textParts.push(latestRenderedMarkdown);
+    const text = textParts.join("\\n\\n") || bodyText;
+    const activeLabels = ["Thinking", "Responding", "Waiting", "Compacting", "Session streaming", "Session active"];
+    const activityLabels = [...document.querySelectorAll("[aria-label]")]
+      .map((element) => element.getAttribute("aria-label") || "")
+      .filter((label) => activeLabels.includes(label));
+    const assistantTexts = messages.filter((message) => message.role !== "user").map((message) => String(message.text || ""));
+    const substantiveAssistantTexts = assistantTexts.filter((value) => substantive(value));
+    return { bodyText, transcriptText, text, messages, length: text.length, messageCount: transcript?.messageCount ?? messages.length, ready: bodyText.includes("Ready for new tasks"), stop: [...document.querySelectorAll("button")].some((button) => (button.textContent ?? "").trim() === "Stop"), activityActive: activityLabels.length > 0, activityLabels, latestRenderedMarkdown, latestAssistantText: latestRenderedMarkdown || substantiveAssistantTexts.at(-1) || "" };
+  })()`, { awaitPromise: true });
+}
+
+function normalizeSnapshotText(value) {
+  return String(value ?? "").replace(/\s+/g, " ").trim();
+}
+
+function isSubstantiveAssistantText(value) {
+  const text = normalizeSnapshotText(value);
+  return text.length > 0 && text !== "OpenWork";
+}
+
+function hasAssistantAfter(snapshot, initialMessageCount) {
+  const start = typeof initialMessageCount === "number" ? initialMessageCount : 0;
+  return (snapshot.messages ?? []).some((message, index) => {
+    const messageIndex = typeof message.index === "number" ? message.index : index;
+    return messageIndex >= start
+      && message.role !== "user"
+      && isSubstantiveAssistantText(message.text);
+  });
+}
+
+function snapshotChangedAfterSubmit(snapshot, before) {
+  const beforeMessageCount = before.messageCount ?? 0;
+  return (snapshot.messageCount ?? 0) > beforeMessageCount
+    || normalizeSnapshotText(snapshot.transcriptText) !== normalizeSnapshotText(before.transcriptText)
+    || normalizeSnapshotText(snapshot.latestRenderedMarkdown) !== normalizeSnapshotText(before.latestRenderedMarkdown);
+}
+
+function hasSubstantivePostSubmitOutput(snapshot, before) {
+  return hasAssistantAfter(snapshot, before.messageCount ?? 0)
+    || (
+      isSubstantiveAssistantText(snapshot.latestRenderedMarkdown)
+      && normalizeSnapshotText(snapshot.latestRenderedMarkdown) !== normalizeSnapshotText(before.latestRenderedMarkdown)
+    );
+}
+
+function snapshotSignature(snapshot) {
+  return [
+    snapshot.messageCount ?? 0,
+    normalizeSnapshotText(snapshot.transcriptText),
+    normalizeSnapshotText(snapshot.latestRenderedMarkdown),
+    snapshot.activityActive ? "active" : "idle",
+    snapshot.stop ? "stop" : "run",
+  ].join("|");
+}
+
+async function insertPromptWithSyntheticPaste(ctx, prompt) {
+  const result = await ctx.eval(`(async () => {
+    const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+    if (!editor) return { ok: false, reason: "composer not found" };
+    const prompt = ${JSON.stringify(prompt)};
+    const normalize = (value) => (value ?? "").replace(/\\s+/g, " ").trim();
+    const readText = () => editor.innerText || editor.textContent || "";
+    const visiblePastedChips = () => [...document.querySelectorAll("button[data-pasted-expand-label]")]
+      .filter((button) => {
+        const rect = button.getBoundingClientRect();
+        const style = window.getComputedStyle(button);
+        return rect.width > 0
+          && rect.height > 0
+          && style.visibility !== "hidden"
+          && style.display !== "none"
+          && button.disabled !== true;
+      })
+      .map((button) => ({
+        label: button.dataset.pastedExpandLabel || "",
+        text: normalize(button.closest("span")?.textContent || button.textContent || ""),
+        ariaLabel: button.getAttribute("aria-label") || "",
+      }));
+    const selectEditorContents = () => {
+      const selection = window.getSelection();
+      const range = document.createRange();
+      range.selectNodeContents(editor);
+      selection.removeAllRanges();
+      selection.addRange(range);
+    };
+    const waitFrame = () => new Promise((resolve) => requestAnimationFrame(() => resolve()));
+    editor.focus();
+    const before = readText();
+    const initialChips = visiblePastedChips();
+    if (normalize(before) || initialChips.length > 0) {
+      selectEditorContents();
+      const selectAll = { bubbles: true, cancelable: true, key: "a", code: "KeyA", metaKey: navigator.platform.includes("Mac"), ctrlKey: !navigator.platform.includes("Mac") };
+      editor.dispatchEvent(new KeyboardEvent("keydown", selectAll));
+      editor.dispatchEvent(new KeyboardEvent("keyup", selectAll));
+      const deleteKey = { bubbles: true, cancelable: true, key: "Backspace", code: "Backspace" };
+      editor.dispatchEvent(new KeyboardEvent("keydown", deleteKey));
+      editor.dispatchEvent(new InputEvent("beforeinput", { bubbles: true, cancelable: true, inputType: "deleteContentBackward", data: null }));
+      editor.dispatchEvent(new InputEvent("input", { bubbles: true, inputType: "deleteContentBackward", data: null }));
+      editor.dispatchEvent(new KeyboardEvent("keyup", deleteKey));
+      await waitFrame();
+    }
+    const chipsBefore = visiblePastedChips();
+    selectEditorContents();
+    const data = new DataTransfer();
+    data.setData("text/plain", prompt);
+    const accepted = editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+    await waitFrame();
+    await waitFrame();
+    const text = readText();
+    const chipsAfter = visiblePastedChips();
+    const inlineMatched = normalize(text).includes(normalize(prompt));
+    const newPastedChip = chipsAfter.length > chipsBefore.length;
+    return {
+      ok: inlineMatched || newPastedChip,
+      representation: inlineMatched ? "inline" : newPastedChip ? "pasted-chip" : "missing",
+      inlineMatched,
+      newPastedChip,
+      text: text.slice(0, 1_000),
+      before: before.slice(0, 1_000),
+      accepted,
+      chipCountBefore: chipsBefore.length,
+      chipCountAfter: chipsAfter.length,
+      chipLabelsBefore: chipsBefore.map((chip) => chip.text || chip.ariaLabel || chip.label),
+      chipLabelsAfter: chipsAfter.map((chip) => chip.text || chip.ariaLabel || chip.label),
+    };
+  })()`, { awaitPromise: true });
+  ctx.assert(result?.ok, `Failed to paste prompt into Lexical composer with synthetic ClipboardEvent('paste'): ${JSON.stringify(result)}`);
+}
+
+export async function sendPromptAndWait(ctx, prompt, { timeout = 300_000 } = {}) {
+  await ensureComposerReady(ctx);
+  const before = await readTranscriptSnapshot(ctx).catch(() => ({ messageCount: 0, length: 0 }));
+  await insertPromptWithSyntheticPaste(ctx, prompt);
+  await clickExactText(ctx, "Run task", "button", 30_000);
+  let last = null;
+  let lastSignature = "";
+  let stableTicks = 0;
+  let transitionSeen = false;
+  const deadline = Date.now() + timeout;
+  while (Date.now() < deadline) {
+    last = await readTranscriptSnapshot(ctx);
+    const changed = snapshotChangedAfterSubmit(last, before);
+    if (last.activityActive || changed) transitionSeen = true;
+    const signature = snapshotSignature(last);
+    if (signature === lastSignature && !last.activityActive) stableTicks += 1;
+    else stableTicks = 0;
+    lastSignature = signature;
+    if (transitionSeen && !last.activityActive && !last.stop && hasSubstantivePostSubmitOutput(last, before) && stableTicks >= 4) {
+      await ctx.control("session.scroll_bottom").catch(() => undefined);
+      await sleep(500);
+      return last.text;
+    }
+    await sleep(750);
+  }
+  throw new Error(`Task did not complete and quiesce before timeout. Last snapshot: ${JSON.stringify(last).slice(0, 1_500)}`);
+}
+
+function authNeeded(text) {
+  return /Authorization required|\/login\?|\blogin\b/i.test(text);
+}
+
+function extractLoginUrl(text) {
+  const match = text.match(/https?:\/\/[^\s"'<>]+\/login\?user=[^\s"'<>]+/i);
+  if (!match) return "";
+  const cleaned = match[0].replace(/[)\].,;]+$/, "");
+  try {
+    return new URL(cleaned).toString();
+  } catch {
+    return "";
+  }
+}
+
+function normalizeGatewayPrincipal(value) {
+  const normalized = value.trim().toLowerCase();
+  const at = normalized.indexOf("@");
+  return at > 0 ? normalized.slice(0, at) : normalized;
+}
+
+function gatewayLoginUrl(ctx, transcript, desiredUser) {
+  const principal = normalizeGatewayPrincipal(desiredUser);
+  const fromTranscript = extractLoginUrl(transcript);
+  const gatewayBase = cleanBase(envText(ctx, "OPENWORK_EVAL_ENTERPRISE_GATEWAY_URL"));
+  let loginUrl = fromTranscript;
+  try {
+    if (!loginUrl && gatewayBase) loginUrl = new URL("/login", gatewayBase).toString();
+  } catch {
+    return "";
+  }
+  if (!loginUrl) return "";
+  try {
+    const url = new URL(loginUrl);
+    url.searchParams.set("user", principal);
+    return url.toString();
+  } catch {
+    return "";
+  }
+}
+
+export async function completeGatewayLogin(ctx, email, transcript, gatewayUserEnvName) {
+  const desiredUser = normalizeGatewayPrincipal(envText(ctx, gatewayUserEnvName) || email);
+  const loginUrl = gatewayLoginUrl(ctx, transcript, desiredUser);
+  ctx.assert(Boolean(loginUrl), "Gateway requested login but no login URL was visible. Set OPENWORK_EVAL_ENTERPRISE_GATEWAY_URL or expose the gateway login link in the transcript.");
+  const response = await fetch(loginUrl);
+  const text = await response.text().catch(() => "");
+  ctx.assert(response.status < 400, `Gateway login failed at ${loginUrl}: ${response.status} ${text.slice(0, 300)}`);
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion: `Gateway login completed for ${desiredUser}`, actual: loginUrl.replace(/user=[^&]+/, "user=<redacted>") });
+}
+
+export async function retryAfterGatewayLoginIfNeeded(ctx, email, transcript, expectedText, retryPrompt, options = {}) {
+  if (transcript.includes(expectedText)) return transcript;
+  const gatewayUserEnvName = options.gatewayUserEnvName ?? "OPENWORK_EVAL_ENTERPRISE_GATEWAY_USER";
+  const desiredUser = normalizeGatewayPrincipal(envText(ctx, gatewayUserEnvName) || email);
+  if (!gatewayLoginUrl(ctx, transcript, desiredUser) && !authNeeded(transcript)) return transcript;
+  await completeGatewayLogin(ctx, email, transcript, gatewayUserEnvName);
+  return sendPromptAndWait(ctx, retryPrompt, { timeout: options.timeout ?? 300_000 });
+}
+
+export async function listSkillsFor(ctx, token) {
+  const result = await denApiFetch(ctx, "/v1/skills", { headers: { authorization: `Bearer ${token}` } });
+  ctx.assert(result.response.ok, httpFailureMessage("GET /v1/skills failed", result));
+  return result.body?.skills ?? [];
+}

--- a/evals/flows/enterprise-gateway-member.flow.mjs
+++ b/evals/flows/enterprise-gateway-member.flow.mjs
@@ -1,0 +1,110 @@
+/**
+ * Enterprise incident gateway demo — member machine.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL: Den API base URL for the enterprise sandbox.
+ * - OPENWORK_EVAL_DEN_WEB_URL: Den web origin used by the desktop handoff deep link.
+ *
+ * Optional env:
+ * - OPENWORK_EVAL_CDP_URL or --cdp-url: CDP endpoint for the member desktop app.
+ *   This should be the SECOND app instance when run after the admin flow.
+ * - OPENWORK_EVAL_ENTERPRISE_MEMBER_EMAIL: member email (default member@example.com).
+ * - OPENWORK_EVAL_ENTERPRISE_MEMBER_WORKSPACE: workspace folder (default /workspace/enterprise-member).
+ * - OPENWORK_EVAL_ENTERPRISE_GATEWAY_URL: gateway base URL used only if the transcript asks for JIT login without a full link.
+ * - OPENWORK_EVAL_ENTERPRISE_MEMBER_GATEWAY_USER: gateway login user override (default member email).
+ * - OPENWORK_EVAL_ENTERPRISE_PASSWORD: account password override (default TutorialDemo123!).
+ * - OPENWORK_EVAL_ENTERPRISE_TASK_TIMEOUT_MS: chat turn timeout in milliseconds.
+ *
+ * Runner note: evals/runner/run.mjs has one selected CDP endpoint per process.
+ * Run this flow separately from the admin flow and point OPENWORK_EVAL_CDP_URL
+ * (or --cdp-url) at the member app instance.
+ */
+
+import {
+  assertEvidence,
+  clickThroughLingeringOnboarding,
+  desktopHandoffSignIn,
+  ensureLocalWorkspace,
+  ensureLocalWorkspaceBeforeConnectPollIfNeeded,
+  envText,
+  readTranscriptSnapshot,
+  retryAfterGatewayLoginIfNeeded,
+  sendPromptAndWait,
+  timeoutMs,
+  waitForOpenWorkConnectReady,
+  workspaceFolder,
+} from "./enterprise-gateway-common.mjs";
+
+const DEFAULT_MEMBER_EMAIL = "member@example.com";
+const WORKSPACE_ENV = "OPENWORK_EVAL_ENTERPRISE_MEMBER_WORKSPACE";
+const DEFAULT_WORKSPACE = "/workspace/enterprise-member";
+const PROMPT = "How many incidents do I have?";
+const PROMPT_RETRY = "I completed the enterprise incident gateway sign-in. Retry my question using the my-incidents skill.";
+
+const state = {
+  workspaceId: "",
+  latestTranscript: "",
+  finalAnswer: "",
+};
+
+export default {
+  id: "enterprise-gateway-member",
+  title: "Enterprise gateway demo: member receives and uses the my-incidents skill",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Desktop handoff signs in member to the organization",
+      run: async (ctx) => {
+        await desktopHandoffSignIn(ctx, memberEmail(ctx));
+      },
+    },
+    {
+      name: "Create member's fresh workspace with OpenWork Connect ready",
+      run: async (ctx) => {
+        await clickThroughLingeringOnboarding(ctx);
+        const folder = workspaceFolder(ctx, WORKSPACE_ENV, DEFAULT_WORKSPACE);
+        state.workspaceId = await ensureLocalWorkspaceBeforeConnectPollIfNeeded(ctx, folder);
+        await waitForOpenWorkConnectReady(ctx);
+        if (!state.workspaceId) state.workspaceId = await ensureLocalWorkspace(ctx, folder);
+      },
+    },
+    {
+      name: "Member asks for incidents and the shared skill scopes the answer",
+      run: async (ctx) => {
+        await ctx.prove("Member's agent discovers my-incidents from cloud capabilities and answers with the member's own incident", {
+          action: async () => {
+            const timeout = timeoutMs(ctx, "OPENWORK_EVAL_ENTERPRISE_MEMBER_TIMEOUT_MS", 300_000);
+            const first = await sendPromptAndWait(ctx, PROMPT, { timeout });
+            state.latestTranscript = await retryAfterGatewayLoginIfNeeded(
+              ctx,
+              memberEmail(ctx),
+              first,
+              "INC0012338",
+              PROMPT_RETRY,
+              { timeout, gatewayUserEnvName: "OPENWORK_EVAL_ENTERPRISE_MEMBER_GATEWAY_USER" },
+            );
+            const snapshot = await readTranscriptSnapshot(ctx);
+            state.finalAnswer = snapshot.latestAssistantText || "";
+          },
+          assert: async () => {
+            assertEvidence(ctx, state.latestTranscript.includes("my-incidents"), "Transcript shows the my-incidents skill was discovered or used", state.latestTranscript);
+            assertEvidence(ctx, state.latestTranscript.includes("INC0012338"), "Transcript includes the member's own incident INC0012338", state.latestTranscript);
+            assertEvidence(ctx, state.finalAnswer.trim().length > 0, "Final assistant answer is present", state.finalAnswer);
+            assertEvidence(ctx, !state.finalAnswer.includes("INC0012341"), "Final answer does not include the admin incident INC0012341", state.finalAnswer);
+          },
+          screenshot: {
+            name: "member-my-incidents-answer",
+            claim: "Member's chat uses the cloud-delivered my-incidents skill and answers with the member's own incident, not the admin's.",
+            requireText: ["INC0012338"],
+            rejectText: ["INC0012341", "Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};
+
+function memberEmail(ctx) {
+  return envText(ctx, "OPENWORK_EVAL_ENTERPRISE_MEMBER_EMAIL") || DEFAULT_MEMBER_EMAIL;
+}

--- a/evals/flows/enterprise-join-web.flow.mjs
+++ b/evals/flows/enterprise-join-web.flow.mjs
@@ -1,0 +1,403 @@
+/**
+ * Enterprise new-member first run — Den Web invite join + installer handoff.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DEN_API_URL: Den API base URL for the enterprise sandbox.
+ * - OPENWORK_EVAL_DEN_WEB_URL: Den Web origin opened in the browser CDP target.
+ *
+ * Optional env:
+ * - OPENWORK_EVAL_CDP_URL or --cdp-url: CDP endpoint for a headless Chrome page target.
+ * - OPENWORK_EVAL_ENTERPRISE_ORG_NAME: organization display name (default Example Organization).
+ * - OPENWORK_EVAL_ENTERPRISE_ADMIN_EMAIL: inviter/admin email (default admin@example.com).
+ * - OPENWORK_EVAL_ENTERPRISE_NEW_MEMBER_EMAIL: invited member email (default new.member@example.com).
+ * - OPENWORK_EVAL_ENTERPRISE_NEW_MEMBER_DISPLAY_NAME: invited member display name (default Alex).
+ * - OPENWORK_EVAL_ENTERPRISE_PASSWORD: account password (default TutorialDemo123!).
+ *
+ * Runner note: evals/runner/run.mjs selects one CDP page per run. For this web
+ * flow, point OPENWORK_EVAL_CDP_URL (or --cdp-url) at a clean headless Chrome
+ * endpoint; the runner is otherwise CDP-agnostic and this flow navigates the
+ * selected page to Den Web.
+ */
+
+import {
+  assertEvidence,
+  denApiBase,
+  denWebBase,
+  enterpriseOrgName,
+  envText,
+  signInByEmail,
+} from "./enterprise-gateway-common.mjs";
+
+const DEFAULT_ADMIN_EMAIL = "admin@example.com";
+const DEFAULT_NEW_MEMBER_EMAIL = "new.member@example.com";
+const DEFAULT_NEW_MEMBER_DISPLAY_NAME = "Alex";
+const DEFAULT_PASSWORD = "TutorialDemo123!";
+
+const state = {
+  adminToken: "",
+  inviteToken: "",
+  inviteUrl: "",
+  installerUrl: "",
+  newMemberToken: "",
+};
+
+export default {
+  id: "enterprise-join-web",
+  title: "Enterprise new member joins in Den Web and gets the desktop installer",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "API invite new member to the organization",
+      run: async (ctx) => {
+        const email = newMemberEmail(ctx);
+        state.adminToken = await signInByEmail(ctx, adminEmail(ctx));
+
+        const invite = await denApiFetch(ctx, "/v1/invitations", {
+          method: "POST",
+          headers: { authorization: `Bearer ${state.adminToken}` },
+          body: JSON.stringify({ email, role: "member" }),
+        });
+
+        if (invite.response.ok) {
+          const token = typeof invite.body?.inviteToken === "string" ? invite.body.inviteToken.trim() : "";
+          if (token) state.inviteToken = token;
+          ctx.log(`Invitation request for ${email} returned ${invite.response.status}.`);
+        } else if (invite.response.status === 400 || invite.response.status === 409) {
+          ctx.log(`Invitation request for ${email} returned ${invite.response.status}; looking for an existing pending invitation in /v1/org.`);
+        } else {
+          failHttp(ctx, `Invitation request failed for ${email}`, invite);
+        }
+
+        if (!state.inviteToken) {
+          state.inviteToken = await findPendingInviteToken(ctx, state.adminToken, email);
+        }
+        state.inviteUrl = new URL(`/join-org?invite=${encodeURIComponent(state.inviteToken)}`, denWebBase(ctx)).toString();
+
+        assertEvidence(ctx, Boolean(state.inviteToken), "A pending organization invitation exposes inviteToken", {
+          email,
+          inviteToken: redactSecret(state.inviteToken),
+        });
+      },
+    },
+    {
+      name: "Frame: join screen",
+      run: async (ctx) => {
+        await ctx.prove("New member opens the organization join screen from the invite", {
+          action: async () => {
+            await clearDenWebSession(ctx);
+            await navigateAbsolute(ctx, requireState(state.inviteUrl, "invite URL"));
+            await ctx.waitForText(joinTitle(ctx), { timeoutMs: 45_000 });
+          },
+          assert: async () => {
+            await ctx.expectText(joinTitle(ctx));
+            await ctx.expectText(newMemberEmail(ctx));
+          },
+          screenshot: {
+            name: "enterprise-join-screen",
+            claim: "The brand-new invitee sees the organization invite join screen before creating the account.",
+            requireText: [joinTitle(ctx), newMemberEmail(ctx)],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame: joined welcome",
+      run: async (ctx) => {
+        await ctx.prove("New member joins the organization and lands on the welcome step", {
+          action: async () => {
+            await fillPasswordAndJoin(ctx, password(ctx));
+          },
+          assert: async () => {
+            await ctx.expectText(joinedWelcomeTitle(ctx), { timeoutMs: 45_000 });
+          },
+          screenshot: {
+            name: "enterprise-joined-welcome",
+            claim: "The invite acceptance completes and welcomes the new member to the organization.",
+            requireText: [joinedWelcomeTitle(ctx)],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame: installer download",
+      run: async (ctx) => {
+        await ctx.prove("New member can get the desktop app installer from the welcome screen", {
+          action: async () => {
+            const cta = await getInstallerCta(ctx);
+            assertEvidence(ctx, cta.exists, "The joined welcome screen exposes a Get the desktop app CTA", cta);
+            const installer = await captureInstallerTarget(ctx);
+            state.installerUrl = installer.url.trim();
+            assertEvidence(ctx, state.installerUrl.length > 0, "The installer/download action produced a non-empty URL", installer);
+            ctx.output("installer-download-url", JSON.stringify({ url: state.installerUrl, source: installer.source }, null, 2));
+            ctx.log(`Installer/download URL: ${state.installerUrl}`);
+          },
+          assert: async () => {
+            assertEvidence(ctx, state.installerUrl.length > 0, "Installer/download URL captured for the desktop app", state.installerUrl);
+          },
+          screenshot: {
+            name: "enterprise-installer-download",
+            claim: "The desktop-app CTA yields an installer or guided-install URL for this organization.",
+            requireText: ["OpenWork"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "API sanity fixes new member's display name",
+      run: async (ctx) => {
+        const displayName = newMemberDisplayName(ctx);
+        state.newMemberToken = await signInByEmail(ctx, newMemberEmail(ctx));
+        const patched = await denApiFetch(ctx, "/v1/me/profile", {
+          method: "PATCH",
+          headers: { authorization: `Bearer ${state.newMemberToken}` },
+          body: JSON.stringify({ firstName: displayName, lastName: "" }),
+        });
+        assertHttpOk(ctx, "PATCH /v1/me/profile failed for the joined user", patched);
+
+        const me = await denApiFetch(ctx, "/v1/me", {
+          headers: { authorization: `Bearer ${state.newMemberToken}` },
+        });
+        assertHttpOk(ctx, "GET /v1/me failed for the joined user", me);
+        const name = typeof me.body?.user?.name === "string" ? me.body.user.name : "";
+        assertEvidence(ctx, name.includes(displayName), "GET /v1/me returns the updated display name", {
+          email: me.body?.user?.email,
+          name,
+        });
+      },
+    },
+  ],
+};
+
+function adminEmail(ctx) {
+  return envText(ctx, "OPENWORK_EVAL_ENTERPRISE_ADMIN_EMAIL") || DEFAULT_ADMIN_EMAIL;
+}
+
+function newMemberEmail(ctx) {
+  return envText(ctx, "OPENWORK_EVAL_ENTERPRISE_NEW_MEMBER_EMAIL") || DEFAULT_NEW_MEMBER_EMAIL;
+}
+
+function newMemberDisplayName(ctx) {
+  return envText(ctx, "OPENWORK_EVAL_ENTERPRISE_NEW_MEMBER_DISPLAY_NAME") || DEFAULT_NEW_MEMBER_DISPLAY_NAME;
+}
+
+function password(ctx) {
+  return envText(ctx, "OPENWORK_EVAL_ENTERPRISE_PASSWORD") || DEFAULT_PASSWORD;
+}
+
+function joinTitle(ctx) {
+  return `Join ${enterpriseOrgName(ctx)}`;
+}
+
+function joinedWelcomeTitle(ctx) {
+  return `You're in, welcome to ${enterpriseOrgName(ctx)}`;
+}
+
+async function denApiFetch(ctx, pathname, init = {}) {
+  const url = `${denApiBase(ctx)}${pathname}`;
+  const response = await fetch(url, {
+    ...init,
+    headers: {
+      "content-type": "application/json",
+      Origin: denWebBase(ctx),
+      ...(init.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body, text, url };
+}
+
+function httpMessage(label, result) {
+  return `${label}: ${result.response.status} ${result.response.statusText} ${result.text.slice(0, 1_000)} (url: ${result.url})`;
+}
+
+function assertHttpOk(ctx, label, result) {
+  ctx.assert(result.response.ok, httpMessage(label, result));
+}
+
+function failHttp(ctx, label, result) {
+  ctx.assert(false, httpMessage(label, result));
+}
+
+async function findPendingInviteToken(ctx, bearer, email) {
+  const org = await denApiFetch(ctx, "/v1/org", {
+    headers: { authorization: `Bearer ${bearer}` },
+  });
+  assertHttpOk(ctx, "GET /v1/org failed while looking for the existing invitation", org);
+
+  const invitations = Array.isArray(org.body?.invitations) ? org.body.invitations : [];
+  const match = invitations.find((entry) => {
+    const entryEmail = typeof entry?.email === "string" ? entry.email.trim().toLowerCase() : "";
+    const inviteToken = typeof entry?.inviteToken === "string" ? entry.inviteToken.trim() : "";
+    const status = typeof entry?.status === "string" ? entry.status : "";
+    return entryEmail === email.trim().toLowerCase() && inviteToken.length > 0 && status === "pending";
+  });
+  const inviteToken = typeof match?.inviteToken === "string" ? match.inviteToken.trim() : "";
+  ctx.assert(inviteToken.length > 0, `No reusable pending invitation with inviteToken found for ${email} in GET /v1/org. Invitations: ${JSON.stringify(redactInvitations(invitations))}`);
+  return inviteToken;
+}
+
+function redactInvitations(invitations) {
+  return invitations.map((entry) => ({
+    email: entry?.email,
+    status: entry?.status,
+    role: entry?.role,
+    inviteToken: typeof entry?.inviteToken === "string" && entry.inviteToken ? "[redacted]" : entry?.inviteToken,
+  }));
+}
+
+async function clearDenWebSession(ctx) {
+  await ctx.client.send("Network.clearBrowserCookies").catch(() => undefined);
+  await navigateAbsolute(ctx, denWebBase(ctx));
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: "Den Web root loaded" });
+  await ctx.eval(`(async () => {
+    try {
+      await fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
+    } catch {}
+    localStorage.clear();
+    sessionStorage.clear();
+    return true;
+  })()`, { awaitPromise: true });
+}
+
+async function navigateAbsolute(ctx, url) {
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+}
+
+async function fillPasswordAndJoin(ctx, value) {
+  const join = joinTitle(ctx);
+  const welcome = joinedWelcomeTitle(ctx);
+  await fillReactInput(ctx, 'input[type="password"]', value);
+  await clickButtonStartingWith(ctx, join, 30_000);
+  await ctx.waitFor(`(() => {
+    const text = document.body.innerText || "";
+    const buttons = [...document.querySelectorAll("button")].map((button) => (button.textContent ?? "").replace(/\\s+/g, " ").trim());
+    const passwordVisible = Boolean(document.querySelector('input[type="password"]'));
+    return text.includes(${JSON.stringify(welcome)}) || text.includes("You're one click away from the team workspace.") || (!passwordVisible && buttons.some((button) => button.startsWith(${JSON.stringify(join)})));
+  })()`, { timeoutMs: 60_000, label: "join success or signed-in confirmation" });
+  const clickedConfirm = await clickButtonStartingWithIfVisible(ctx, join);
+  if (clickedConfirm) {
+    ctx.log("Clicked the signed-in organization join confirmation button.");
+  }
+  await ctx.waitForText(welcome, { timeoutMs: 60_000 });
+}
+
+async function fillReactInput(ctx, selector, value) {
+  const result = await ctx.waitFor(`(() => {
+    const input = document.querySelector(${JSON.stringify(selector)});
+    if (!input) return null;
+    const prototype = input instanceof HTMLTextAreaElement ? HTMLTextAreaElement.prototype : HTMLInputElement.prototype;
+    const descriptor = Object.getOwnPropertyDescriptor(prototype, 'value');
+    if (!descriptor?.set) return { ok: false, reason: 'native value setter missing' };
+    descriptor.set.call(input, ${JSON.stringify(value)});
+    input.dispatchEvent(new Event('input', { bubbles: true }));
+    input.dispatchEvent(new Event('change', { bubbles: true }));
+    return { ok: true, valueLength: input.value.length };
+  })()`, { timeoutMs: 30_000, label: `React-safe fill ${selector}` });
+  ctx.assert(result?.ok, `Could not React-fill ${selector}: ${JSON.stringify(result)}`);
+}
+
+async function clickButtonStartingWith(ctx, prefix, timeoutMs) {
+  await ctx.waitFor(`(() => {
+    const normalize = (value) => (value ?? '').replace(/\\s+/g, ' ').trim();
+    const button = [...document.querySelectorAll('button')]
+      .find((entry) => normalize(entry.textContent).startsWith(${JSON.stringify(prefix)}) && entry.disabled !== true && entry.getAttribute('aria-disabled') !== 'true');
+    button?.scrollIntoView({ block: 'center', inline: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`, { timeoutMs, label: `button starting with ${JSON.stringify(prefix)}` });
+}
+
+async function clickButtonStartingWithIfVisible(ctx, prefix) {
+  return Boolean(await ctx.eval(`(() => {
+    const normalize = (value) => (value ?? '').replace(/\\s+/g, ' ').trim();
+    const button = [...document.querySelectorAll('button')]
+      .find((entry) => normalize(entry.textContent).startsWith(${JSON.stringify(prefix)}) && entry.disabled !== true && entry.getAttribute('aria-disabled') !== 'true');
+    button?.scrollIntoView({ block: 'center', inline: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`));
+}
+
+async function getInstallerCta(ctx) {
+  return ctx.eval(`(() => {
+    const normalize = (value) => (value ?? '').replace(/\\s+/g, ' ').trim();
+    const element = [...document.querySelectorAll('a, button, [role="button"]')]
+      .find((entry) => normalize(entry.textContent) === 'Get the desktop app');
+    return {
+      exists: Boolean(element),
+      tagName: element?.tagName ?? '',
+      text: element ? normalize(element.textContent) : '',
+      href: element instanceof HTMLAnchorElement ? element.href : '',
+      testId: element?.getAttribute('data-testid') ?? '',
+    };
+  })()`);
+}
+
+async function captureInstallerTarget(ctx) {
+  const before = await ctx.eval("location.href");
+  const href = await ctx.eval(`(() => {
+    const normalize = (value) => (value ?? '').replace(/\\s+/g, ' ').trim();
+    const element = [...document.querySelectorAll('a, button, [role="button"]')]
+      .find((entry) => normalize(entry.textContent) === 'Get the desktop app');
+    const anchor = element instanceof HTMLAnchorElement ? element : element?.closest?.('a[href]') ?? element?.querySelector?.('a[href]') ?? null;
+    if (!anchor) return '';
+    return anchor.href || anchor.getAttribute('href') || '';
+  })()`);
+  if (typeof href === "string" && href.trim()) {
+    return { url: href.trim(), source: "href", before, after: before };
+  }
+
+  await ctx.eval(`(() => {
+    const normalize = (value) => (value ?? '').replace(/\\s+/g, ' ').trim();
+    const element = [...document.querySelectorAll('a, button, [role="button"]')]
+      .find((entry) => normalize(entry.textContent) === 'Get the desktop app');
+    if (!element) return false;
+    window.__enterpriseDownloadCapture = { opened: '', downloadHref: '', before: ${JSON.stringify(before)} };
+    if (!window.__enterpriseOriginalOpen) window.__enterpriseOriginalOpen = window.open;
+    window.open = function (url, ...rest) {
+      window.__enterpriseDownloadCapture.opened = String(url ?? '');
+      return window.__enterpriseOriginalOpen.call(window, url, ...rest);
+    };
+    document.addEventListener('click', (event) => {
+      const anchor = event.target?.closest?.('a[download], a[href]');
+      if (anchor) window.__enterpriseDownloadCapture.downloadHref = anchor.href || anchor.getAttribute('href') || '';
+    }, { capture: true });
+    element.scrollIntoView({ block: 'center', inline: 'center' });
+    element.click();
+    return true;
+  })()`);
+
+  const url = await ctx.waitFor(`(() => {
+    const capture = window.__enterpriseDownloadCapture;
+    if (capture?.opened) return capture.opened;
+    if (capture?.downloadHref) return capture.downloadHref;
+    if (location.href !== ${JSON.stringify(before)}) return location.href;
+    return '';
+  })()`, { timeoutMs: 30_000, label: "installer/download URL after Get the desktop app" });
+  const after = await ctx.eval("location.href").catch(() => "");
+  await ctx.eval(`(() => {
+    if (window.__enterpriseOriginalOpen) window.open = window.__enterpriseOriginalOpen;
+    return true;
+  })()`).catch(() => undefined);
+  return { url: String(url), source: after && after !== before ? "navigation" : "click-capture", before, after };
+}
+
+function requireState(value, label) {
+  if (typeof value === "string" && value.trim()) return value;
+  throw new Error(`${label} was not prepared by an earlier step.`);
+}
+
+function redactSecret(value) {
+  return value ? "[redacted]" : "";
+}


### PR DESCRIPTION
## Summary

- add an enterprise admin flow that discovers an incident gateway, creates `my-incidents`, and grants it to another member through the organization marketplace
- add a separate-member flow proving the cloud-delivered skill returns only that member’s scoped incident
- add the invited-member web journey from invitation through organization installer resolution
- add a factory-fresh desktop journey covering organization handoff, visible onboarding, real workspace/session creation, OpenWork Connect readiness, gateway login, and cloud capability execution
- keep private organization names, accounts, principals, workspaces, and timeouts injectable through `OPENWORK_EVAL_ENTERPRISE_*`; public defaults use example values

## Validation

- `node --check evals/flows/enterprise-gateway-common.mjs`
- `node --check evals/flows/enterprise-gateway-admin.flow.mjs`
- `node --check evals/flows/enterprise-gateway-member.flow.mjs`
- `node --check evals/flows/enterprise-join-web.flow.mjs`
- `node --check evals/flows/enterprise-first-auth.flow.mjs`
- `pnpm evals --list` — all four enterprise flow IDs registered; legacy IDs absent
- anonymization grep across the commit and tracked eval files — passed with no partner/person matches
- `pnpm fraimz --flow enterprise-first-auth` with private seed values supplied only through environment variables — **Passed** on a factory-fresh isolated Electron profile

## Visual proof

**Factory-fresh app**

![Factory-fresh OpenWork](https://b8tgacyg507ru26g.public.blob.vercel-storage.com/enterprise-gateway/first-run-2026-07-21/enterprise-first-auth-01-enterprise-first-open.png)

**Cloud-delivered member-scoped result**

![Member-scoped incident result](https://b8tgacyg507ru26g.public.blob.vercel-storage.com/enterprise-gateway/first-run-2026-07-21/enterprise-first-auth-04-enterprise-org-skill-on-fresh-machine.png)

The incident backend is a minimal in-memory demo MCP gateway implementing real initialize, tool-list, tool-call, and sign-in protocol behavior. Den authentication, organization provisioning, local workspace/session startup, OpenWork Connect, capability search/execute, skill sharing, and member scoping execute through their real surfaces.