### PR TITLE
fix(evals): bound desktop route waits

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -126,6 +126,9 @@ jobs:
       - name: Run desktop unit tests
         run: pnpm --filter @openwork/desktop test
 
+      - name: Run eval runner unit tests
+        run: pnpm test:eval-runner
+
       - name: Typecheck Electron main against the IPC contract
         run: pnpm --filter @openwork/desktop typecheck:electron
 

--- a/evals/flows/command-k-settings.flow.mjs
+++ b/evals/flows/command-k-settings.flow.mjs
@@ -70,14 +70,10 @@ export default {
               label: "control API",
             });
             await ctx.control("route.settings.general");
-            await ctx.waitFor("location.pathname.endsWith('/settings/general')", {
-              timeoutMs: 30_000,
-              label: "settings route",
-            });
+            await ctx.waitForRoute("/settings/general");
           },
           assert: async () => {
-            const pathname = await ctx.eval("location.pathname");
-            ctx.assert(pathname.endsWith("/settings/general"), `Expected settings pathname, got ${pathname}`);
+            await ctx.expectRoute("/settings/general");
             await ctx.expectText("Settings");
           },
           screenshot: {
@@ -98,11 +94,9 @@ export default {
               timeoutMs: 15_000,
               label: "command palette input",
             });
-            await new Promise((resolve) => setTimeout(resolve, 300));
           },
           assert: async () => {
-            const pathname = await ctx.eval("location.pathname");
-            ctx.assert(pathname.endsWith("/settings/general"), `Command palette left Settings for ${pathname}`);
+            await ctx.expectRoute("/settings/general");
             await ctx.expectText("Create new session");
             await ctx.expectText("Search sessions");
           },

--- a/evals/runner/context.mjs
+++ b/evals/runner/context.mjs
@@ -9,9 +9,42 @@ import { captureDaytonaComputerUseScreenshot } from "./daytona-computer-use.mjs"
 const execFileAsync = promisify(execFile);
 
 const DEFAULT_TIMEOUT_MS = 20_000;
+const DEFAULT_ROUTE_TIMEOUT_MS = 5_000;
 const POLL_INTERVAL_MS = 250;
+const ROUTE_POLL_INTERVAL_MS = 50;
+
+const ROUTE_EXPRESSION = `(() => {
+  try {
+    const route = window.__openworkControl?.snapshot?.().route;
+    if (typeof route === "string" && route.length > 0) return route;
+  } catch {
+    // Fall through to the browser URL while the control surface initializes.
+  }
+  return window.location.hash.replace(/^#/, "") || window.location.pathname;
+})()`;
 
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+async function within(promise, timeoutMs, message) {
+  let timer;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise((_, reject) => {
+        timer = setTimeout(() => reject(new EvalError(message)), timeoutMs);
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function normalizeRoute(route) {
+  if (typeof route !== "string") return null;
+  const value = route.trim().replace(/^#/, "");
+  if (!value) return "/";
+  return value.startsWith("/") ? value : `/${value}`;
+}
 
 export class EvalError extends Error {}
 
@@ -203,6 +236,16 @@ export class EvalContext {
     if (!passed) throw new EvalError(`Expected URL hash to include ${fragment}, got ${hash}`);
   }
 
+  async expectRoute(expected, options = {}) {
+    const actual = await this.waitForRoute(expected, options);
+    return this.recordEvidence({
+      type: "assertion",
+      status: "passed",
+      assertion: `App route equals ${JSON.stringify(normalizeRoute(expected))}`,
+      actual,
+    });
+  }
+
   async prove(name, options) {
     const claim = options?.claim ?? name;
     const voiceover = typeof options?.voiceover === "string" ? options.voiceover.trim() : "";
@@ -245,6 +288,48 @@ export class EvalContext {
     const what = label ?? expression;
     throw new EvalError(
       `Timed out after ${timeoutMs}ms waiting for: ${what}` +
+        (lastError ? ` (last error: ${lastError.message})` : ""),
+    );
+  }
+
+  /**
+   * Poll the app's canonical route, preferring the control snapshot and
+   * falling back to the URL hash used by the Electron app. Each probe is
+   * capped by the remaining deadline so a stalled CDP call cannot turn a
+   * short route wait into the client's longer transport timeout.
+   */
+  async waitForRoute(expected, { timeoutMs = DEFAULT_ROUTE_TIMEOUT_MS } = {}) {
+    const expectedRoute = normalizeRoute(expected);
+    if (!expectedRoute) {
+      throw new EvalError(`Expected a non-empty app route, got ${JSON.stringify(expected)}.`);
+    }
+
+    const deadline = Date.now() + timeoutMs;
+    let lastRoute = null;
+    let lastError = null;
+
+    while (Date.now() < deadline) {
+      const remainingMs = deadline - Date.now();
+      try {
+        const route = await within(
+          this.eval(ROUTE_EXPRESSION),
+          remainingMs,
+          `Route probe timed out after ${remainingMs}ms.`,
+        );
+        lastRoute = normalizeRoute(route);
+        lastError = null;
+        if (lastRoute === expectedRoute) return lastRoute;
+      } catch (error) {
+        lastError = error;
+      }
+
+      const delayMs = Math.min(ROUTE_POLL_INTERVAL_MS, Math.max(0, deadline - Date.now()));
+      if (delayMs > 0) await sleep(delayMs);
+    }
+
+    throw new EvalError(
+      `Timed out after ${timeoutMs}ms waiting for app route ${JSON.stringify(expectedRoute)}; ` +
+        `last observed route: ${JSON.stringify(lastRoute)}` +
         (lastError ? ` (last error: ${lastError.message})` : ""),
     );
   }

--- a/evals/runner/context.test.mjs
+++ b/evals/runner/context.test.mjs
@@ -1,0 +1,77 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { EvalContext, EvalError } from "./context.mjs";
+
+function createContext(send) {
+  return new EvalContext({
+    client: { send },
+    outDir: "/tmp/openwork-eval-context-test",
+    flowId: "context-test",
+    env: {},
+  });
+}
+
+function evaluated(value) {
+  return { result: { value } };
+}
+
+function evaluateInPage(expression, window) {
+  return Function("window", `return ${expression}`)(window);
+}
+
+test("waitForRoute prefers the canonical control route immediately", async () => {
+  let calls = 0;
+  const ctx = createContext(async (method, params) => {
+    calls += 1;
+    assert.equal(method, "Runtime.evaluate");
+    assert.match(params.expression, /__openworkControl/);
+    assert.match(params.expression, /location\.hash/);
+    return evaluated(evaluateInPage(params.expression, {
+      __openworkControl: { snapshot: () => ({ route: "/settings/general" }) },
+      location: { hash: "#/settings/advanced", pathname: "/" },
+    }));
+  });
+
+  assert.equal(await ctx.waitForRoute("#/settings/general"), "/settings/general");
+  assert.equal(calls, 1);
+});
+
+test("waitForRoute falls back to the Electron URL hash", async () => {
+  const ctx = createContext(async (_method, params) => evaluated(evaluateInPage(params.expression, {
+    location: { hash: "#/settings/general", pathname: "/" },
+  })));
+
+  assert.equal(await ctx.waitForRoute("/settings/general"), "/settings/general");
+});
+
+test("waitForRoute reports the last observed route at the configured deadline", async () => {
+  const ctx = createContext(async () => evaluated("/settings/advanced"));
+  const startedAt = Date.now();
+
+  await assert.rejects(
+    ctx.waitForRoute("/settings/general", { timeoutMs: 30 }),
+    (error) => {
+      assert(error instanceof EvalError);
+      assert.match(error.message, /Timed out after 30ms/);
+      assert.match(error.message, /last observed route: "\/settings\/advanced"/);
+      return true;
+    },
+  );
+  assert(Date.now() - startedAt < 1_000, "route wait fell through to the 20-second CDP timeout");
+});
+
+test("waitForRoute bounds a browser probe that never resolves", async () => {
+  const ctx = createContext(async () => new Promise(() => {}));
+  const startedAt = Date.now();
+
+  await assert.rejects(
+    ctx.waitForRoute("/settings/general", { timeoutMs: 30 }),
+    (error) => {
+      assert(error instanceof EvalError);
+      assert.match(error.message, /Route probe timed out/);
+      return true;
+    },
+  );
+  assert(Date.now() - startedAt < 1_000, "stalled route probe fell through to the 20-second CDP timeout");
+});

--- a/package.json
+++ b/package.json
@@ -50,6 +50,7 @@
     "test:session-scope": "pnpm --filter @openwork/app test:session-scope",
     "test:session-switch": "pnpm --filter @openwork/app test:session-switch",
     "test:fs-engine": "pnpm --filter @openwork/app test:fs-engine",
+    "test:eval-runner": "node --test evals/runner/*.test.mjs",
     "test:e2e": "pnpm --filter @openwork/app test:e2e",
     "test:admin-scale": "pnpm --filter @openwork-ee/den-api test:admin-scale",
     "benchmark:admin-scale:mysql": "pnpm --filter @openwork-ee/den-db benchmark:admin-scale:mysql",


### PR DESCRIPTION
## Summary
- add a canonical `waitForRoute`/`expectRoute` eval helper that reads the OpenWork control snapshot and falls back to Electron's hash route
- cap every route probe by the remaining 5-second route deadline, including a CDP call that never resolves
- migrate `command-k-settings` off `location.pathname`, remove its fixed 300 ms sleep, and run the new regression tests in CI

## Why
- Electron was already at `#/settings/general`, but the flow waited 30 seconds for `location.pathname` to end with `/settings/general`; `pathname` stays `/` under hash routing, so a healthy app false-failed after about 31 seconds
- a single stalled CDP probe could otherwise inherit the transport's longer 20-second timeout instead of respecting a shorter route budget

## Issue
- N/A

## Scope
- eval-runner route detection, bounded route deadlines, targeted regression coverage, and the affected Command-K settings flow

## Out of scope
- broad migration of existing flows to the new helper
- desktop startup/build optimization and general eval import/startup performance

## Testing
### Ran
- `pnpm test:eval-runner`
- `pnpm --filter @openwork/desktop test`
- `pnpm typecheck`
- `node --check evals/runner/context.mjs`
- `node --check evals/flows/command-k-settings.flow.mjs`
- `node --check evals/runner/context.test.mjs`
- `pnpm evals --cdp-url http://127.0.0.1:23703 --flow app-smoke --flow command-k-settings --flow bare-settings-route-redirect` against an isolated desktop on current `upstream/dev`

### Result
- eval runner: 4 passed, 0 failed; the never-resolving probe test exits in about 31 ms with a 30 ms budget
- desktop: 100 passed, 0 failed, 1 expected platform skip
- app typecheck and syntax checks: passed
- live eval batch: 3 passed, 0 failed, 0 skipped in 2.30 seconds
- `command-k-settings`: both steps passed in about 650 ms total, down from a false failure after about 31 seconds

## CI status
- pass: OpenWork Tests on Linux and macOS (including app, server, desktop, eval runner, Electron typecheck, and e2e); Enterprise MCP contract/security; i18n audit; Helm validation; Den API/web/inference image builds and smoke checks
- code-related failures: none observed
- external/env/auth blockers: Vercel previews for app, Den, worker proxy, and diagnostics report fork authorization failures; the landing preview passes

## Manual verification
1. Start the desktop with `pnpm dev`.
2. In another shell, run `pnpm evals --flow app-smoke --flow command-k-settings --flow bare-settings-route-redirect`.
3. Confirm all three flows pass and Command-K opens the palette while the canonical route remains `/settings/general`.

## Evidence
- Local assertion-backed fraimz generated at `evals/results/2026-07-21T11-17-01-369Z/fraimz.html`; no video or screenshot was uploaded.

## Risk
- Low: the helper is additive and currently adopted by one flow. Unit coverage exercises control-route preference, hash fallback, wrong-route diagnostics, and a never-resolving browser probe. The CI job runs on both Linux and macOS.

## Rollback
- Revert commit `93dc998fc1b8d4ed3eceeb5e3f32b1a451e276c4`.
