### PR TITLE
fix(app): show tool result copy action only when expanded

### DIFF
--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -340,25 +340,26 @@ const Tool = ({
             {reconnectPresentation?.buttonLabel}
           </Button>
         ) : null}
-        {resultText !== null ? (
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            data-testid="tool-result-copy-action"
-            title={copied ? "Copied" : "Copy tool result"}
-            aria-label={copied ? "Tool result copied" : "Copy tool result"}
-            onClick={() => void handleCopyResult()}
-          >
-            {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
-          </Button>
-        ) : null}
       </div>
       {reconnectError ? (
         <p className="mt-1 text-xs text-destructive" role="alert">{reconnectError}</p>
       ) : null}
       <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden text-sm transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
-        <div className="bg-muted mt-2 flex flex-col gap-2 rounded-lg p-2 text-xs">
+        <div className="bg-muted relative mt-2 flex flex-col gap-2 rounded-lg p-2 pr-10 text-xs">
+          {resultText !== null ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className="absolute right-2 top-2"
+              data-testid="tool-result-copy-action"
+              title={copied ? "Copied" : "Copy tool result"}
+              aria-label={copied ? "Tool result copied" : "Copy tool result"}
+              onClick={() => void handleCopyResult()}
+            >
+              {copied ? <Check aria-hidden="true" /> : <Copy aria-hidden="true" />}
+            </Button>
+          ) : null}
           {hasInput ? (
             inputDiff !== null ? (
               <DiffLines diff={inputDiff} />

--- a/apps/app/tests/tool-error-attribution-ui.test.tsx
+++ b/apps/app/tests/tool-error-attribution-ui.test.tsx
@@ -65,7 +65,7 @@ test("renders an inline reconnect button when Cloud capability discovery finds e
   expect(html).toContain('data-testid="chat-mcp-reconnect-action"')
 })
 
-test("renders a copy action when a tool result is available", () => {
+test("renders a copy action inside the expanded tool result", () => {
   const toolPart: DynamicToolUIPart = {
     type: "dynamic-tool",
     toolName: "openwork-cloud_search_capabilities",
@@ -75,9 +75,12 @@ test("renders a copy action when a tool result is available", () => {
     output: { matches: [{ name: "searchPages" }] },
   }
 
-  const html = renderToStaticMarkup(<Tool toolPart={toolPart} />)
+  const html = renderToStaticMarkup(<Tool toolPart={toolPart} defaultOpen />)
+  const contentIndex = html.indexOf('data-slot="collapsible-content"')
+  const copyActionIndex = html.indexOf('data-testid="tool-result-copy-action"')
 
-  expect(html).toContain('data-testid="tool-result-copy-action"')
+  expect(contentIndex).toBeGreaterThan(-1)
+  expect(copyActionIndex).toBeGreaterThan(contentIndex)
   expect(html).toContain('aria-label="Copy tool result"')
 })
 


### PR DESCRIPTION
## Summary

- move the tool-result copy action out of the always-visible tool header
- place the action inside the expanded result container at the top-right
- reserve content space so the action does not cover the tool payload
- update the focused rendering test to assert that the action is inside the collapsible content

## Why

Completed tool rows currently show a copy icon even while collapsed. In sessions with several tool calls, the repeated controls add visual clutter before the user has chosen to inspect a result. The copy action now appears with the content it operates on.

## Checks

- `./bin/openwork-hub run desktop tool-result-copy-placement -- pnpm --filter @openwork/app typecheck` — passed
- `./bin/openwork-hub run desktop tool-result-copy-placement -- pnpm --filter @openwork/app exec bun test --isolate tests/tool-error-attribution-ui.test.tsx` — passed (4 tests, 0 failures)

## Manual verification

Not run — developer verification deferred.

1. Open a session containing several completed tool calls.
2. Confirm collapsed tool rows do not show copy controls.
3. Expand a completed tool call and confirm the copy action appears inside the result panel at the top-right.
4. Click the action and confirm the clipboard contains the complete tool result and the icon briefly changes to its copied state.

## Risk and evidence

This is a presentation-only change in the existing tool result component; it does not change tool data, clipboard serialization, or runtime contracts. Video, screenshots, and fraimz evidence were not captured.
