### PR TITLE
fix(app): keep session spinner clear of title

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1850,7 +1850,7 @@ function SessionMenuItem({
           className={cn("transition-[padding] duration-75 group-hover/menu-sub-item:pe-8 group-has-data-popup-open/menu-sub-item:pe-8", depth > 0 && "ps-13", isSessionStreaming || isSessionActive && "pe-8")}
         >
           <PinnedIndicator isPinned={isPinned} />
-          <span className="truncate" title={displayTitle}>{displayTitle}</span>
+          <span className="min-w-0 flex-1 truncate" title={displayTitle}>{displayTitle}</span>
         </SidebarMenuSubButton>
       </SessionContextMenu>
       <SessionActions

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1817,7 +1817,7 @@ function SessionMenuItem({
               >
                 <PinnedIndicator isPinned={isPinned} />
                 <span
-                  className={cn("min-w-0 flex-1 truncate transition-[padding] duration-75 group-hover/menu-sub-item:pe-12 group-has-data-popup-open/menu-sub-item:pe-12 pe-4", isSessionStreaming || isSessionActive && "pe-12")}
+                  className={cn("min-w-0 flex-1 truncate transition-[padding] duration-75 group-hover/menu-sub-item:pe-12 group-has-data-popup-open/menu-sub-item:pe-12 pe-4", (isSessionStreaming || isSessionActive) && "pe-12")}
                   title={displayTitle}
                 >
                   {displayTitle}
@@ -1847,7 +1847,7 @@ function SessionMenuItem({
           onClick={openSession}
           onPointerEnter={prefetchSession}
           onFocus={prefetchSession}
-          className={cn("transition-[padding] duration-75 group-hover/menu-sub-item:pe-8 group-has-data-popup-open/menu-sub-item:pe-8", depth > 0 && "ps-13", isSessionStreaming || isSessionActive && "pe-8")}
+          className={cn("transition-[padding] duration-75 group-hover/menu-sub-item:pe-8 group-has-data-popup-open/menu-sub-item:pe-8", depth > 0 && "ps-13", (isSessionStreaming || isSessionActive) && "pe-12")}
         >
           <PinnedIndicator isPinned={isPinned} />
           <span className="min-w-0 flex-1 truncate" title={displayTitle}>{displayTitle}</span>

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1414,6 +1414,25 @@ export function SessionRoute() {
   }, [checkDesktopRestriction, disabledProviderIds, local, modelPicker.setQuery, modelPicker.setRecentProviderIds, opencodeBaseUrl, opencodeClient, selectedSessionId, selectedWorkspaceId, selectedWorkspaceRoot]);
   useControlAction(seedUnavailableModelControlAction);
 
+  const seedActiveSessionSidebarControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+    return {
+      id: "eval.session_sidebar.seed_active",
+      label: "Show the selected session as active",
+      description: "Dev-only eval hook that displays the selected session activity spinner.",
+      sideEffect: "mutation",
+      disabled: !selectedWorkspaceId || !selectedSessionId,
+      execute: () => {
+        if (!selectedWorkspaceId || !selectedSessionId) {
+          return { ok: false, error: "No session is selected." };
+        }
+        useSessionActivityStore.getState().setRunStatus(selectedWorkspaceId, selectedSessionId, "running");
+        return { workspaceId: selectedWorkspaceId, sessionId: selectedSessionId };
+      },
+    };
+  }, [selectedSessionId, selectedWorkspaceId]);
+  useControlAction(seedActiveSessionSidebarControlAction);
+
   const commandPaletteControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "command_palette.open",
     label: "Open the command palette",

--- a/evals/flows/session-sidebar-spinner-spacing.flow.mjs
+++ b/evals/flows/session-sidebar-spinner-spacing.flow.mjs
@@ -1,0 +1,125 @@
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("session-sidebar-spinner-spacing");
+const LONG_TITLE = "OpenWork diagnostics authorization with a deliberately long session title";
+const FIXTURE_WORKSPACE = resolve(
+  process.env.OPENWORK_EVAL_ARTIFACTS_DIR ?? "evals/results",
+  "..",
+  "session-sidebar-spinner-workspace",
+);
+
+const MEASURE_SESSION_ROW = `(() => {
+  const title = document.querySelector(${JSON.stringify(`span[title="${LONG_TITLE}"]`)});
+  const row = title?.closest('[data-sidebar="menu-sub-button"]');
+  const indicator = row?.parentElement?.querySelector('[aria-label="Thinking"]');
+  if (!title || !row || !indicator) return null;
+  const titleRect = title.getBoundingClientRect();
+  const indicatorRect = indicator.getBoundingClientRect();
+  const rowRect = row.getBoundingClientRect();
+  const style = getComputedStyle(title);
+  const rowStyle = getComputedStyle(row);
+  return {
+    titleClientWidth: title.clientWidth,
+    titleScrollWidth: title.scrollWidth,
+    whiteSpace: style.whiteSpace,
+    overflow: style.overflow,
+    textOverflow: style.textOverflow,
+    titleRight: Math.round(titleRect.right),
+    indicatorLeft: Math.round(indicatorRect.left),
+    rowRight: Math.round(rowRect.right),
+    rowPaddingInlineEnd: rowStyle.paddingInlineEnd,
+    rowClassName: row.className,
+    overlap: titleRect.right > indicatorRect.left,
+  };
+})()`;
+
+export default {
+  id: "session-sidebar-spinner-spacing",
+  title: "Long active session titles truncate before the activity spinner",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Long active session title remains readable without spinner overlap",
+      run: async (ctx) => {
+        await ctx.eval("location.reload()");
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+        const choosingModel = await ctx.hasText("Skip and use the free model");
+        if (choosingModel) {
+          await ctx.clickText("Skip and use the free model", { selector: "button", timeoutMs: 10_000 });
+        }
+        const surveySkip = await ctx.eval(`Boolean([...document.querySelectorAll('button')]
+          .find((button) => button.textContent?.trim() === 'Skip'))`);
+        if (surveySkip) await ctx.clickText("Skip", { selector: "button", timeoutMs: 10_000 });
+        if (choosingModel || surveySkip) {
+          await ctx.waitFor("location.hash.includes('/workspace/')", { timeoutMs: 60_000, label: "workspace after onboarding" });
+          await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after onboarding" });
+        }
+        const canCreateTask = await ctx.eval(
+          "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+        );
+        if (!canCreateTask) {
+          await mkdir(FIXTURE_WORKSPACE, { recursive: true });
+          const welcomeInput = 'input[placeholder="/workspace/my-project"]';
+          const onWelcome = await ctx.eval(`Boolean(document.querySelector(${JSON.stringify(welcomeInput)}))`);
+          if (onWelcome) {
+            await ctx.fill(welcomeInput, FIXTURE_WORKSPACE);
+            await ctx.clickText("Use this folder", { selector: "button", timeoutMs: 10_000 });
+            await ctx.clickText("Skip and use the free model", { selector: "button", timeoutMs: 30_000 }).catch(() => {});
+            await ctx.clickText("Skip", { selector: "button", timeoutMs: 10_000 }).catch(() => {});
+            await ctx.waitFor("location.hash.includes('/workspace/')", {
+              timeoutMs: 60_000,
+              label: "workspace route after folder selection",
+            });
+          } else {
+            await ctx.waitFor(
+              "window.__openworkControl.listActions().some((action) => action.id === 'workspace.create' && !action.disabled)",
+              { timeoutMs: 30_000, label: "workspace creation control" },
+            );
+            await ctx.control("workspace.create", { path: FIXTURE_WORKSPACE });
+          }
+        }
+        await ctx.waitFor(
+          "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+          { timeoutMs: 60_000, label: "enabled task creation" },
+        );
+
+        await ctx.control("session.create_task");
+        const sessionId = await ctx.waitFor(`(() => {
+          const match = /session\\/([^/?#]+)/.exec(window.__openworkControl.snapshot().route);
+          return match ? decodeURIComponent(match[1]) : null;
+        })()`, { timeoutMs: 30_000, label: "created session" });
+        await ctx.waitFor(
+          "window.__openworkControl.listActions().some((action) => action.id === 'session.rename' && !action.disabled)",
+          { timeoutMs: 30_000, label: "enabled session rename" },
+        );
+        await ctx.control("session.rename", { sessionId, title: LONG_TITLE });
+        await ctx.control("eval.session_sidebar.seed_active");
+        await ctx.client.send("Input.dispatchMouseEvent", { type: "mouseMoved", x: 900, y: 400 });
+        await ctx.waitFor(`${MEASURE_SESSION_ROW}?.titleScrollWidth > ${MEASURE_SESSION_ROW}?.titleClientWidth`, {
+          timeoutMs: 30_000,
+          label: "truncated active session title",
+        });
+
+        await ctx.prove("A long active session title truncates before its spinner", {
+          voiceover: vo[0],
+          assert: async () => {
+            const metrics = await ctx.eval(MEASURE_SESSION_ROW);
+            ctx.assert(metrics, "Could not measure the active session row.");
+            ctx.assert(metrics.whiteSpace === "nowrap", `Expected nowrap, got ${metrics.whiteSpace}.`);
+            ctx.assert(metrics.overflow === "hidden", `Expected hidden overflow, got ${metrics.overflow}.`);
+            ctx.assert(metrics.textOverflow === "ellipsis", `Expected ellipsis, got ${metrics.textOverflow}.`);
+            ctx.assert(metrics.titleScrollWidth > metrics.titleClientWidth, "The long title was not truncated.");
+            ctx.assert(!metrics.overlap, `Title and spinner overlap: ${JSON.stringify(metrics)}.`);
+          },
+          screenshot: {
+            name: "session-title-truncates-before-spinner",
+            requireText: ["OpenWork diagnostics authorization"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/session-sidebar-spinner-spacing.md
+++ b/evals/voiceovers/session-sidebar-spinner-spacing.md
@@ -1,0 +1,3 @@
+# session-sidebar-spinner-spacing — Long active titles stay clear of the spinner
+
+1. I start a task with a long name while it is active. The sidebar keeps the full name available, truncates it cleanly with an ellipsis, and gives the activity spinner its own space instead of drawing the two on top of each other.


### PR DESCRIPTION
## Summary

- constrain leaf session titles to the available flex width
- correctly apply active-session spacing for both parent and leaf session rows
- preserve ellipsis truncation while reserving the spinner footprint
- add a reproducible user-facing fraimz flow

## Root cause

Leaf session title spans did not flex or allow their minimum width to shrink. In addition, the active-spacing condition relied on operator precedence: streaming sessions returned boolean `true` instead of the intended Tailwind padding class, so no spinner spacing was applied.

## Before — reported overlap

The session title and activity spinner intersect:

<img src="https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/codex-clipboard-a2d41727-fee1-46dc-bdba-382375fa7c2f.png" alt="Reported session title and spinner overlap" width="700">

[Open the reported screenshot directly](https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/codex-clipboard-a2d41727-fee1-46dc-bdba-382375fa7c2f.png)

## After — fraimz verification

The long title remains ellipsis-truncated and ends before the spinner begins:

<img src="https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/session-sidebar-spinner-spacing-01-session-title-truncates-before-spinner.png" alt="Verified long session title truncating before the activity spinner" width="700">

[Open the verification screenshot directly](https://tfcecv4wsuiv5ctw.public.blob.vercel-storage.com/session-sidebar-spinner-spacing-01-session-title-truncates-before-spinner.png)

Fraimz run `2026-07-21T12-26-41-363Z` proves that the title uses nowrap/hidden/ellipsis truncation, has `scrollWidth > clientWidth`, and its right edge ends before the spinner left edge.

## Checks

- `./bin/openwork-hub run desktop session-list-spinner-overlap -- pnpm --filter @openwork/app typecheck` — passed
- `pnpm fraimz --flow session-sidebar-spinner-spacing --cdp-url http://127.0.0.1:24503` — passed (1 passed, 0 failed, 0 skipped)
- `git diff --check` — passed

## Risk

Low. The production change is limited to flex sizing and active-state padding in session sidebar rows. The dev-only seed action exists solely to make the spinner state deterministic in the coded eval.