### PR TITLE
fix(app): keep model controls available during generation

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -61,6 +61,7 @@ type ComposerProps = {
   onQueue: () => void | Promise<void>;
   onStop: () => void | Promise<void>;
   busy: boolean;
+  steering: boolean;
   submissionPreparing: boolean;
   queuedCount: number;
   disabled: boolean;
@@ -359,6 +360,12 @@ export function ReactSessionComposer(props: ComposerProps) {
   useEffect(() => {
     if (!props.busy) disarmEscape();
   }, [props.busy, disarmEscape]);
+
+  useEffect(() => {
+    if (props.steering && props.modelPickerOpen) {
+      props.onModelPickerOpenChange(false);
+    }
+  }, [props.modelPickerOpen, props.onModelPickerOpenChange, props.steering]);
 
   // Input history recall (#2012): ArrowUp on an empty composer recalls the
   // previous sent prompt; repeated ArrowUp/ArrowDown walk the history.
@@ -1721,8 +1728,10 @@ export function ReactSessionComposer(props: ComposerProps) {
                   open={props.modelPickerOpen}
                   value={props.selectedModel}
                   onOpenChange={props.onModelPickerOpenChange}
-                  onChange={props.onModelChange}
-                  disabled={props.busy}
+                  onChange={(model) => {
+                    if (!props.steering) props.onModelChange(model);
+                  }}
+                  disabled={props.steering}
                 />
                 {props.modelUnavailable ? (
                   <span className="text-xs font-medium text-red-10">Model no longer available</span>
@@ -1732,8 +1741,10 @@ export function ReactSessionComposer(props: ComposerProps) {
                   value={props.modelVariant}
                   label={props.modelVariantLabel}
                   options={props.modelBehaviorOptions}
-                  onChange={props.onModelVariantChange}
-                  disabled={props.busy}
+                  onChange={(value) => {
+                    if (!props.steering) props.onModelVariantChange(value);
+                  }}
+                  disabled={props.steering}
                 />
               </div>
 

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -495,6 +495,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [toolMcpStatus, setToolMcpStatus] = useState<string | null>(null);
   const [toolMcpStatuses, setToolMcpStatuses] = useState<McpStatusMap>({});
   const [toolImportedPlugins, setToolImportedPlugins] = useState<CloudImportedPlugin[]>([]);
+  const [steering, setSteering] = useState(false);
   const connectInventoryCacheRef = useRef<{
     scope: string;
     promise: Promise<ConnectCapabilityInventory>;
@@ -541,6 +542,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   useEffect(() => {
     hydratedKeyRef.current = null;
+    setSteering(false);
     setError(null);
     setShowDelayedLoading(false);
     setAwaitingAssistantBaseline(null);
@@ -624,6 +626,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const preparingCloudTools = props.cloudMcpSubmissionState.status === "checking" ||
     props.cloudMcpSubmissionState.status === "repairing";
   const chatStreaming = sending || liveStatus.type === "busy" || liveStatus.type === "retry";
+
+  useEffect(() => {
+    if (!chatStreaming) setSteering(false);
+  }, [chatStreaming]);
   const status = useMemo((): ThreadStatus => {
     if (sending) {
       return "submitted";
@@ -862,7 +868,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
   }, [attachments, buildDraft, clearComposer, draft, props.sessionId, sendDraft]);
 
-  const handleSteer = handleSend;
+  const handleSteer = useCallback(async () => {
+    setSteering(true);
+    await handleSend();
+  }, [handleSend]);
 
   const handleRetryCloudSubmission = useCallback(() => {
     if (draft.trim() || attachments.length > 0) {
@@ -1702,6 +1711,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         onQueue={handleQueue}
         onStop={handleAbort}
         busy={chatStreaming}
+        steering={steering}
         submissionPreparing={preparingCloudTools}
         queuedCount={queuedMessages.length}
         disabled={model.transitionState !== "idle" || Boolean(props.modelUnavailable)}

--- a/apps/app/tests/composer-model-controls.test.ts
+++ b/apps/app/tests/composer-model-controls.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { describe, expect, test } from "bun:test";
+
+const composerPath = fileURLToPath(
+  new URL("../src/react-app/domains/session/surface/composer/composer.tsx", import.meta.url),
+);
+const sessionSurfacePath = fileURLToPath(
+  new URL("../src/react-app/domains/session/surface/session-surface.tsx", import.meta.url),
+);
+
+describe("composer model controls", () => {
+  test("stay enabled during ordinary generation and disable during steering", () => {
+    const composerSource = readFileSync(composerPath, "utf8");
+    const modelSelectStart = composerSource.indexOf("<ModelSelect");
+    const behaviorSelectStart = composerSource.indexOf("<ModelBehaviorSelect");
+    const modelControls = [
+      composerSource.slice(modelSelectStart, composerSource.indexOf("/>", modelSelectStart) + 2),
+      composerSource.slice(behaviorSelectStart, composerSource.indexOf("/>", behaviorSelectStart) + 2),
+    ].join("\n");
+
+    expect(modelControls.match(/disabled=\{props\.steering\}/g)).toHaveLength(2);
+    expect(modelControls).not.toContain("disabled={props.busy}");
+  });
+
+  test("tracks steering until the active run stops streaming", () => {
+    const sessionSurfaceSource = readFileSync(sessionSurfacePath, "utf8");
+
+    expect(sessionSurfaceSource).toContain("setSteering(true);\n    await handleSend();");
+    expect(sessionSurfaceSource).toContain("if (!chatStreaming) setSteering(false);");
+    expect(sessionSurfaceSource).toContain("steering={steering}");
+  });
+});


### PR DESCRIPTION
## Summary

- keep the composer model and thinking-mode selectors available during ordinary assistant generation
- track steered runs separately and disable both selectors from steer submission until the run returns idle
- close/guard the compact model picker while steering
- add regression coverage for the normal-generation versus steering distinction

## Why

The composer previously disabled model and thinking selection for every busy session. That prevented users from preparing the next run while an ordinary response was loading. Steering remains protected because changing execution settings during an active steer can cause inconsistent behavior.

## Checks

- `pnpm --filter @openwork/app exec bun test tests/composer-model-controls.test.ts` — passed (2 tests)
- `pnpm --filter @openwork/app test` — passed (372 tests)
- `pnpm --filter @openwork/app typecheck` — passed
- isolated Electron `app-smoke` eval on the Hub-assigned CDP port — passed

## Manual verification

Not run — the isolated merge-readiness profile was fresh and had no onboarded workspace or usable model, so a real generation/steer journey was unavailable.

Reviewer steps:

1. Start a task with a configured model.
2. While the first response is generating, confirm model and thinking selectors remain usable.
3. Submit a steering follow-up while that response is active.
4. Confirm both selectors disable for the steered run and re-enable when the run returns idle.

## Risk

Low and UI-local. No API, IPC, persistence, or model request shape changes.