### PR TITLE
fix(desktop): apply branded name to macOS menu bar

### DIFF
--- a/apps/desktop/electron/brand-app-name.mjs
+++ b/apps/desktop/electron/brand-app-name.mjs
@@ -1,0 +1,31 @@
+const MAX_APP_NAME_LENGTH = 64;
+
+/**
+ * Apply a branded display name to Electron and every native surface that
+ * derives from it. The macOS menu-bar label follows the process title, while
+ * Electron-owned labels follow app.getName(), so both must change before the
+ * application menu rebuilds.
+ *
+ * @param {unknown} requestedName
+ * @param {{
+ *   fallbackName: string,
+ *   platform: string,
+ *   runtimeProcess: { title: string },
+ *   app: { setName: (name: string) => void },
+ *   applicationMenu: { setAppName: (name: string) => unknown },
+ *   window?: { setTitle: (name: string) => void } | null,
+ * }} dependencies
+ */
+export function applyBrandAppName(requestedName, dependencies) {
+  const requested = requestedName === null ? "" : String(requestedName ?? "").trim();
+  const appName = requested.slice(0, MAX_APP_NAME_LENGTH) || dependencies.fallbackName;
+
+  if (dependencies.platform === "darwin") {
+    dependencies.runtimeProcess.title = appName;
+  }
+  dependencies.app.setName(appName);
+  dependencies.applicationMenu.setAppName(appName);
+  dependencies.window?.setTitle(appName);
+
+  return appName;
+}

--- a/apps/desktop/electron/brand-app-name.test.mjs
+++ b/apps/desktop/electron/brand-app-name.test.mjs
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { applyBrandAppName } from "./brand-app-name.mjs";
+
+test("updates the macOS process and Electron application name before rebuilding the native menu", () => {
+  const calls = [];
+  const appName = applyBrandAppName("  Acme Work  ", {
+    fallbackName: "OpenWork",
+    platform: "darwin",
+    runtimeProcess: {
+      get title() { return ""; },
+      set title(name) { calls.push(["process", name]); },
+    },
+    app: { setName: (name) => calls.push(["app", name]) },
+    applicationMenu: { setAppName: (name) => calls.push(["menu", name]) },
+    window: { setTitle: (name) => calls.push(["window", name]) },
+  });
+
+  assert.equal(appName, "Acme Work");
+  assert.deepEqual(calls, [
+    ["process", "Acme Work"],
+    ["app", "Acme Work"],
+    ["menu", "Acme Work"],
+    ["window", "Acme Work"],
+  ]);
+});
+
+test("falls back to the signed application name and caps branded names", () => {
+  const appliedNames = [];
+  const dependencies = {
+    fallbackName: "OpenWork",
+    platform: "win32",
+    runtimeProcess: {
+      get title() { return ""; },
+      set title(name) { appliedNames.push(`process:${name}`); },
+    },
+    app: { setName: (name) => appliedNames.push(name) },
+    applicationMenu: { setAppName: () => undefined },
+  };
+
+  assert.equal(applyBrandAppName(null, dependencies), "OpenWork");
+  assert.equal(applyBrandAppName("A".repeat(80), dependencies), "A".repeat(64));
+  assert.deepEqual(appliedNames, ["OpenWork", "A".repeat(64)]);
+});

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -29,6 +29,7 @@ import {
 } from "./computer-use.mjs";
 import { createUiControlServer } from "./ui-control-server.mjs";
 import { createApplicationMenu } from "./app-menu.mjs";
+import { applyBrandAppName } from "./brand-app-name.mjs";
 import { createBrowserPanel } from "./browser-panel.mjs";
 import { createWorkspaceStore } from "./workspace-store.mjs";
 import {
@@ -1927,10 +1928,14 @@ const desktopCommandHandlers = {
       }
   },
   "__applyBrandAppName": async (event, ...args) => {
-      const requested = args[0] === null ? "" : String(args[0] ?? "").trim();
-      currentDisplayAppName = requested.slice(0, 64) || APP_NAME;
-    applicationMenu.setAppName(currentDisplayAppName);
-    mainWindow?.setTitle(currentDisplayAppName);
+    currentDisplayAppName = applyBrandAppName(args[0], {
+      fallbackName: APP_NAME,
+      platform: process.platform,
+      runtimeProcess: process,
+      app,
+      applicationMenu,
+      window: mainWindow,
+    });
     if (process.platform === "win32") {
       await registerWindowsDisplayShortcut();
     }
@@ -2413,9 +2418,13 @@ if (!app.requestSingleInstanceLock()) {
     });
     await workspaceStore.importBundledDesktopBootstrapConfigIfPreferred();
     const bootstrapConfig = await workspaceStore.getDesktopBootstrapConfig();
-    currentDisplayAppName = bootstrapConfig.brandAppName?.slice(0, 64) || APP_NAME;
-    app.setName(currentDisplayAppName);
-    applicationMenu.setAppName(currentDisplayAppName);
+    currentDisplayAppName = applyBrandAppName(bootstrapConfig.brandAppName, {
+      fallbackName: APP_NAME,
+      platform: process.platform,
+      runtimeProcess: process,
+      app,
+      applicationMenu,
+    });
     if (process.platform === "win32") {
       await registerWindowsDisplayShortcut();
     }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.11",


### PR DESCRIPTION
## Summary

- apply the organization-branded app name to the macOS process title before rebuilding the native application menu
- keep Electron's internal app name, native window title, and startup bootstrap path aligned on macOS through one helper
- preserve the existing Windows/Linux live-update sequence and add explicit Windows regression coverage

## Root cause

The live `brandAppName` handler rebuilt the Electron menu and changed the window title, but the macOS menu-bar label continued to use the process title. As a result, signed-in users could see organization branding inside the app while the native application menu still said `OpenWork`.

The startup path still sets Electron's application name on every platform. During live updates, only macOS additionally changes `process.title` and Electron's internal application name before rebuilding the menu. Windows and Linux retain their previous live-update sequence, and the signed bundle identifier and updater identity remain unchanged.

## Verification

- `./bin/openwork-hub run desktop macos-brand-menu-name -- pnpm --filter @openwork/desktop typecheck:electron` — passed
- `./bin/openwork-hub run desktop macos-brand-menu-name -- pnpm --filter @openwork/desktop check:electron` — passed; 56 renderer methods covered
- `./bin/openwork-hub run desktop macos-brand-menu-name -- pnpm --dir apps/desktop exec node --test electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs` — passed; 13 tests passed, including Windows live-name and taskbar/shortcut behavior
- `./bin/openwork-hub run desktop macos-brand-menu-name -- pnpm --filter @openwork/desktop test` — passed; 103 tests passed, 1 platform-specific test skipped
- isolated macOS desktop journey on the assigned Electron CDP port — passed:
  - baseline native menu: `Apple, OpenWork - Dev, File, Edit, View, Window, Help`
  - after live `brandAppName = "Acme Work"`: `Apple, Acme Work, File, Edit, View, Window, Help`
  - after persisting the branded bootstrap and cold-relaunching: `Apple, Acme Work, File, Edit, View, Window, Help`

The native menu assertions were read through macOS Accessibility/System Events against the isolated Electron process.

## Risks and remaining checks

- The process-title and live Electron app-name mutations are gated to macOS; Windows and Linux retain their existing behavior.
- A native Windows runtime was not available locally; Windows behavior is covered through dependency-injected name tests and the existing taskbar/shortcut suite.
- A signed packaged artifact build was not run.
- Fraimz, screenshots, and video were not produced because they were not requested.
