### PR TITLE
feat: safely delete custom marketplaces

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
@@ -531,11 +531,11 @@ export const pluginArchEndpointContracts: Record<string, EndpointContract> = {
   },
   deleteMarketplace: {
     audience: "admin",
-    description: "Soft-delete a custom marketplace while preserving its plugins and membership history.",
+    description: "Permanently delete a custom marketplace and its access and plugin relationships.",
     method: "POST",
     path: pluginArchRoutePaths.marketplaceDelete,
     request: { params: marketplaceParamsSchema },
-    response: { description: "Deleted marketplace detail.", schema: marketplaceMutationResponseSchema, status: 200 },
+    response: { description: "Snapshot of the deleted marketplace.", schema: marketplaceMutationResponseSchema, status: 200 },
     tag: "Marketplaces",
   },
   restoreMarketplace: {

--- a/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
@@ -173,6 +173,7 @@ export const pluginArchRoutePaths = {
   marketplace: `${orgBasePath}/marketplaces/:marketplaceId`,
   marketplaceResolved: `${orgBasePath}/marketplaces/:marketplaceId/resolved`,
   marketplaceArchive: `${orgBasePath}/marketplaces/:marketplaceId/archive`,
+  marketplaceDelete: `${orgBasePath}/marketplaces/:marketplaceId/delete`,
   marketplaceRestore: `${orgBasePath}/marketplaces/:marketplaceId/restore`,
   marketplacePlugins: `${orgBasePath}/marketplaces/:marketplaceId/plugins`,
   marketplacePlugin: `${orgBasePath}/marketplaces/:marketplaceId/plugins/:pluginId`,
@@ -526,6 +527,15 @@ export const pluginArchEndpointContracts: Record<string, EndpointContract> = {
     path: pluginArchRoutePaths.marketplaceArchive,
     request: { params: marketplaceParamsSchema },
     response: { description: "Archived marketplace detail.", schema: marketplaceMutationResponseSchema, status: 200 },
+    tag: "Marketplaces",
+  },
+  deleteMarketplace: {
+    audience: "admin",
+    description: "Soft-delete a custom marketplace while preserving its plugins and membership history.",
+    method: "POST",
+    path: pluginArchRoutePaths.marketplaceDelete,
+    request: { params: marketplaceParamsSchema },
+    response: { description: "Deleted marketplace detail.", schema: marketplaceMutationResponseSchema, status: 200 },
     tag: "Marketplaces",
   },
   restoreMarketplace: {

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -1144,7 +1144,9 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
       describeRoute({
         tags: ["Marketplaces"],
         summary: `${action} marketplace`,
-        description: `${action} a marketplace without deleting its plugins or membership history.`,
+        description: action === "delete"
+          ? "Permanently deletes a custom marketplace and its relationships."
+          : `${action} a marketplace without deleting its plugins.`,
         responses: {
           200: jsonResponse("Marketplace lifecycle updated successfully.", marketplaceMutationResponseSchema),
           400: jsonResponse("The marketplace lifecycle path parameters were invalid.", invalidRequestSchema),

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -1,6 +1,6 @@
 import type { Context, Hono } from "hono"
 import { describeRoute } from "hono-openapi"
-import type { z } from "zod"
+import { z } from "zod"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { queryValidator, jsonValidator, orgMemberRoute, paramValidator, resolveMemberTeamsMiddleware } from "../../../middleware/index.js"
 import { emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../../openapi.js"
@@ -184,6 +184,11 @@ import {
 
 type OrgContext = Context<{ Variables: OrgRouteVariables }>
 type PluginCreateBody = z.infer<typeof pluginCreateSchema>
+
+const marketplaceConflictSchema = z.object({
+  error: z.string(),
+  message: z.string().optional(),
+}).meta({ ref: "PluginArchMarketplaceConflictError" })
 
 function validRequestPart<T>(c: OrgContext, target: "json" | "param" | "query") {
   return (c.req as unknown as { valid: (part: typeof target) => unknown }).valid(target) as T
@@ -1129,19 +1134,26 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
       }
     })
 
-  for (const [path, action] of [[pluginArchRoutePaths.marketplaceArchive, "archive"], [pluginArchRoutePaths.marketplaceRestore, "restore"]] as const) {
+  for (const [path, action] of [
+    [pluginArchRoutePaths.marketplaceArchive, "archive"],
+    [pluginArchRoutePaths.marketplaceDelete, "delete"],
+    [pluginArchRoutePaths.marketplaceRestore, "restore"],
+  ] as const) {
     withPluginArchOrgContext(app, "post", path,
       paramValidator(marketplaceParamsSchema),
       describeRoute({
         tags: ["Marketplaces"],
         summary: `${action} marketplace`,
-        description: `${action} a marketplace without touching membership history.`,
+        description: `${action} a marketplace without deleting its plugins or membership history.`,
         responses: {
           200: jsonResponse("Marketplace lifecycle updated successfully.", marketplaceMutationResponseSchema),
           400: jsonResponse("The marketplace lifecycle path parameters were invalid.", invalidRequestSchema),
           401: jsonResponse("The caller must be signed in to manage marketplaces.", unauthorizedSchema),
           403: jsonResponse("The caller lacks permission to manage this marketplace.", forbiddenSchema),
           404: jsonResponse("The marketplace could not be found.", notFoundSchema),
+          ...(action === "delete" ? {
+            409: jsonResponse("A built-in or connector-managed marketplace cannot be deleted.", marketplaceConflictSchema),
+          } : {}),
         },
       }),
       async (c: OrgContext) => {

--- a/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
@@ -813,7 +813,9 @@ export const marketplaceMutationResponseSchema = pluginArchMutationResponseSchem
 export const marketplaceResolvedResponseSchema = pluginArchMutationResponseSchema(
   "PluginArchMarketplaceResolvedResponse",
   z.object({
-    marketplace: marketplaceSchema,
+    marketplace: marketplaceSchema.extend({
+      canDelete: z.boolean(),
+    }),
     plugins: z.array(pluginSchema.extend({
       componentCounts: z.record(z.string(), z.number().int().nonnegative()).default({}),
       cloudReadiness: pluginCloudReadinessSchema.optional(),

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -2339,24 +2339,30 @@ export async function setMarketplaceLifecycle(input: { action: "archive" | "dele
   await requirePluginArchResourceRole({ context: input.context, resourceId: row.id, resourceKind: "marketplace", role: "manager" })
   const updatedAt = new Date()
   if (input.action === "delete") {
-    const managedMembership = (await db
-      .select({ id: MarketplacePluginTable.id })
+    const memberships = await db
+      .select()
       .from(MarketplacePluginTable)
-      .where(and(
-        eq(MarketplacePluginTable.marketplaceId, row.id),
-        inArray(MarketplacePluginTable.membershipSource, ["system", "connector"]),
-        isNull(MarketplacePluginTable.removedAt),
-      ))
-      .limit(1))[0]
-    if (managedMembership) {
+      .where(eq(MarketplacePluginTable.marketplaceId, row.id))
+    if (memberships.some((membership) => membership.removedAt === null && (membership.membershipSource === "system" || membership.membershipSource === "connector"))) {
       throw new PluginArchRouteFailure(409, "managed_marketplace_cannot_be_deleted", "Built-in and connected marketplaces cannot be deleted here.")
     }
+    await db.transaction(async (tx) => {
+      await tx.delete(MarketplaceAccessGrantTable).where(eq(MarketplaceAccessGrantTable.marketplaceId, row.id))
+      await tx.delete(MarketplacePluginTable).where(eq(MarketplacePluginTable.marketplaceId, row.id))
+      await tx.delete(MarketplaceTable).where(eq(MarketplaceTable.id, row.id))
+    })
+    for (const pluginId of new Set(memberships.map((membership) => membership.pluginId))) {
+      await syncPluginMcpRequirementAccessForResource({ context: input.context, resourceId: pluginId, resourceKind: "plugin" })
+    }
+    return serializeMarketplace({ ...row, deletedAt: updatedAt, status: "deleted", updatedAt }, memberships.filter((membership) => membership.removedAt === null).length)
   }
-  await db.update(MarketplaceTable).set({
-    deletedAt: input.action === "delete" ? updatedAt : input.action === "restore" ? null : row.deletedAt,
-    status: input.action === "archive" ? "archived" : input.action === "delete" ? "deleted" : "active",
-    updatedAt,
-  }).where(eq(MarketplaceTable.id, row.id))
+  await db.transaction(async (tx) => {
+    await tx.update(MarketplaceTable).set({
+      deletedAt: input.action === "restore" ? null : row.deletedAt,
+      status: input.action === "archive" ? "archived" : "active",
+      updatedAt,
+    }).where(eq(MarketplaceTable.id, row.id))
+  })
   await syncPluginMcpRequirementAccessForResource({
     context: input.context,
     resourceId: row.id,

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -2334,13 +2334,27 @@ export async function updateMarketplace(input: { context: PluginArchActorContext
   return getMarketplaceDetail(input.context, row.id)
 }
 
-export async function setMarketplaceLifecycle(input: { action: "archive" | "restore"; context: PluginArchActorContext; marketplaceId: MarketplaceId }) {
+export async function setMarketplaceLifecycle(input: { action: "archive" | "delete" | "restore"; context: PluginArchActorContext; marketplaceId: MarketplaceId }) {
   const row = await ensureVisibleMarketplace(input.context, input.marketplaceId)
   await requirePluginArchResourceRole({ context: input.context, resourceId: row.id, resourceKind: "marketplace", role: "manager" })
   const updatedAt = new Date()
+  if (input.action === "delete") {
+    const managedMembership = (await db
+      .select({ id: MarketplacePluginTable.id })
+      .from(MarketplacePluginTable)
+      .where(and(
+        eq(MarketplacePluginTable.marketplaceId, row.id),
+        inArray(MarketplacePluginTable.membershipSource, ["system", "connector"]),
+        isNull(MarketplacePluginTable.removedAt),
+      ))
+      .limit(1))[0]
+    if (managedMembership) {
+      throw new PluginArchRouteFailure(409, "managed_marketplace_cannot_be_deleted", "Built-in and connected marketplaces cannot be deleted here.")
+    }
+  }
   await db.update(MarketplaceTable).set({
-    deletedAt: input.action === "archive" ? row.deletedAt : null,
-    status: input.action === "archive" ? "archived" : "active",
+    deletedAt: input.action === "delete" ? updatedAt : input.action === "restore" ? null : row.deletedAt,
+    status: input.action === "archive" ? "archived" : input.action === "delete" ? "deleted" : "active",
     updatedAt,
   }).where(eq(MarketplaceTable.id, row.id))
   await syncPluginMcpRequirementAccessForResource({
@@ -2496,7 +2510,10 @@ export async function getMarketplaceResolved(input: { context: PluginArchActorCo
   }
 
   return {
-    marketplace: serializeMarketplace(marketplaceRow, plugins.length),
+    marketplace: {
+      ...serializeMarketplace(marketplaceRow, plugins.length),
+      canDelete: memberships.every((membership) => membership.membershipSource === "manual"),
+    },
     plugins,
     source,
   }

--- a/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
+++ b/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
@@ -1180,7 +1180,7 @@ describe("marketplace cloud readiness payload", () => {
     expect(await listUsableConnectionIds({ org, memberId: member.memberId, teamIds: [team.teamId] })).toContain(connectionId)
   })
 
-  test("marketplace lifecycle archives only that marketplace's sourced MCP audience and restores it", async () => {
+  test("marketplace lifecycle archives or soft-deletes only that marketplace's sourced MCP audience and restores it", async () => {
     const org = await seedOrg({ marketplaceGrant: "none" })
     const archivedMarketplaceTeam = await addTeam({ org, name: "Archived Marketplace Team" })
     const otherMarketplaceTeam = await addTeam({ org, name: "Other Marketplace Team" })
@@ -1305,6 +1305,38 @@ describe("marketplace cloud readiness payload", () => {
     await store.setMarketplaceLifecycle({ action: "restore", context: org.context, marketplaceId: org.marketplaceId })
     expect(await sourceGrantCount(bindingId)).toBe(4)
     expect(await listUsableConnectionIds({ org, memberId: archivedMarketplaceMember.memberId, teamIds: [archivedMarketplaceTeam.teamId] })).toContain(connectionId)
+
+    const deleted = await store.setMarketplaceLifecycle({ action: "delete", context: org.context, marketplaceId: org.marketplaceId })
+    expect(deleted.status).toBe("deleted")
+    expect(deleted.deletedAt).not.toBeNull()
+    expect(await db.select().from(MarketplacePluginTable).where(eq(MarketplacePluginTable.marketplaceId, org.marketplaceId))).toHaveLength(1)
+    expect(await sourceGrantCount(bindingId)).toBe(3)
+    expect(await listUsableConnectionIds({ org, memberId: archivedMarketplaceMember.memberId, teamIds: [archivedMarketplaceTeam.teamId] })).not.toContain(connectionId)
+
+    await store.setMarketplaceLifecycle({ action: "restore", context: org.context, marketplaceId: org.marketplaceId })
+    expect(await sourceGrantCount(bindingId)).toBe(4)
+  })
+
+  test("marketplace lifecycle refuses to delete a managed marketplace", async () => {
+    const org = await seedOrg()
+    await seedPlugin({ org, name: "Built-in Plugin" })
+    await db
+      .update(MarketplacePluginTable)
+      .set({ membershipSource: "system" })
+      .where(eq(MarketplacePluginTable.marketplaceId, org.marketplaceId))
+
+    await expect(store.setMarketplaceLifecycle({
+      action: "delete",
+      context: org.context,
+      marketplaceId: org.marketplaceId,
+    })).rejects.toMatchObject({
+      error: "managed_marketplace_cannot_be_deleted",
+      status: 409,
+    })
+
+    const [marketplace] = await db.select().from(MarketplaceTable).where(eq(MarketplaceTable.id, org.marketplaceId))
+    expect(marketplace?.status).toBe("active")
+    expect(marketplace?.deletedAt).toBeNull()
   })
 
   test("plugin lifecycle archives sourced MCP access without deleting bindings and restores it", async () => {

--- a/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
+++ b/ee/apps/den-api/test/marketplace-cloud-readiness.test.ts
@@ -1180,7 +1180,7 @@ describe("marketplace cloud readiness payload", () => {
     expect(await listUsableConnectionIds({ org, memberId: member.memberId, teamIds: [team.teamId] })).toContain(connectionId)
   })
 
-  test("marketplace lifecycle archives or soft-deletes only that marketplace's sourced MCP audience and restores it", async () => {
+  test("marketplace lifecycle archives or deletes only that marketplace's sourced MCP audience", async () => {
     const org = await seedOrg({ marketplaceGrant: "none" })
     const archivedMarketplaceTeam = await addTeam({ org, name: "Archived Marketplace Team" })
     const otherMarketplaceTeam = await addTeam({ org, name: "Other Marketplace Team" })
@@ -1309,12 +1309,12 @@ describe("marketplace cloud readiness payload", () => {
     const deleted = await store.setMarketplaceLifecycle({ action: "delete", context: org.context, marketplaceId: org.marketplaceId })
     expect(deleted.status).toBe("deleted")
     expect(deleted.deletedAt).not.toBeNull()
-    expect(await db.select().from(MarketplacePluginTable).where(eq(MarketplacePluginTable.marketplaceId, org.marketplaceId))).toHaveLength(1)
+    expect(await db.select().from(MarketplaceTable).where(eq(MarketplaceTable.id, org.marketplaceId))).toHaveLength(0)
+    expect(await db.select().from(MarketplacePluginTable).where(eq(MarketplacePluginTable.marketplaceId, org.marketplaceId))).toHaveLength(0)
+    expect(await db.select().from(MarketplaceAccessGrantTable).where(eq(MarketplaceAccessGrantTable.marketplaceId, org.marketplaceId))).toHaveLength(0)
+    expect(await db.select().from(PluginTable).where(eq(PluginTable.id, plugin.pluginId))).toHaveLength(1)
     expect(await sourceGrantCount(bindingId)).toBe(3)
     expect(await listUsableConnectionIds({ org, memberId: archivedMarketplaceMember.memberId, teamIds: [archivedMarketplaceTeam.teamId] })).not.toContain(connectionId)
-
-    await store.setMarketplaceLifecycle({ action: "restore", context: org.context, marketplaceId: org.marketplaceId })
-    expect(await sourceGrantCount(bindingId)).toBe(4)
   })
 
   test("marketplace lifecycle refuses to delete a managed marketplace", async () => {

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-data.tsx
@@ -459,6 +459,39 @@ export function useCreateMarketplace() {
   });
 }
 
+export function useUpdateMarketplace() {
+  const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (input: { marketplaceId: string; name: string; description: string | null }): Promise<DenMarketplace> => {
+      let updated: DenMarketplace | null = null;
+      await runReauthableAction("update-marketplace", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/marketplaces/${encodeURIComponent(input.marketplaceId)}`,
+          {
+            method: "PATCH",
+            body: JSON.stringify({ name: input.name, description: input.description }),
+          },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to update marketplace (${response.status}).`);
+        }
+        updated = isRecord(payload) && isRecord(payload.item) ? parseMarketplace(payload.item) : null;
+      });
+      if (!updated) {
+        throw new Error("Marketplace update response was incomplete.");
+      }
+      return updated;
+    },
+    onSuccess: (marketplace) => {
+      queryClient.invalidateQueries({ queryKey: marketplaceQueryKeys.list() });
+      queryClient.invalidateQueries({ queryKey: marketplaceQueryKeys.resolved(marketplace.id) });
+    },
+  });
+}
+
 export function useDeleteMarketplace() {
   const queryClient = useQueryClient();
   const { runReauthableAction } = useOrgDashboard();

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-data.tsx
@@ -13,6 +13,7 @@ export type DenMarketplace = {
   pluginCount: number;
   createdAt: string;
   updatedAt: string;
+  canDelete?: boolean;
 };
 
 export const marketplaceQueryKeys = {
@@ -105,6 +106,7 @@ function parseMarketplace(entry: unknown): DenMarketplace | null {
     pluginCount: typeof entry.pluginCount === "number" ? entry.pluginCount : 0,
     createdAt,
     updatedAt,
+    ...(typeof entry.canDelete === "boolean" ? { canDelete: entry.canDelete } : {}),
   };
 }
 
@@ -453,6 +455,31 @@ export function useCreateMarketplace() {
     },
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: marketplaceQueryKeys.all });
+    },
+  });
+}
+
+export function useDeleteMarketplace() {
+  const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (marketplaceId: string): Promise<string> => {
+      await runReauthableAction("delete-marketplace", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/marketplaces/${encodeURIComponent(marketplaceId)}/delete`,
+          { method: "POST" },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to delete marketplace (${response.status}).`);
+        }
+      });
+      return marketplaceId;
+    },
+    onSuccess: (marketplaceId) => {
+      queryClient.removeQueries({ queryKey: marketplaceQueryKeys.resolved(marketplaceId) });
+      queryClient.invalidateQueries({ queryKey: marketplaceQueryKeys.list() });
     },
   });
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -3,11 +3,12 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState, useEffect } from "react";
-import { ArrowLeft, Check, ChevronDown, GitBranch, Github, Globe, Loader2, Plug, Plus, Puzzle, Trash2, Users, X } from "lucide-react";
+import { ArrowLeft, Check, ChevronDown, GitBranch, Github, Globe, Loader2, MoreHorizontal, Pencil, Plug, Plus, Puzzle, Trash2, Users, X } from "lucide-react";
 import { PaperMeshGradient, StaticSeededGradient } from "@openwork/ui/react";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
 import { DenSelect } from "../../_components/ui/select";
+import { DenTextarea } from "../../_components/ui/textarea";
 import { type TabItem, UnderlineTabs } from "../../_components/ui/tabs";
 import {
   getGithubIntegrationSetupRoute,
@@ -29,6 +30,7 @@ import {
   useMarketplace,
   useMarketplaceAccess,
   useRevokeMarketplaceAccess,
+  useUpdateMarketplace,
 } from "./marketplace-data";
 import { IntegrationIcon } from "./integration-icon";
 import { McpCredentialInput } from "./mcp-credential-input";
@@ -86,6 +88,10 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
   const { data: presets = [] } = useMcpConnectionPresets();
   const [setupTarget, setSetupTarget] = useState<PluginMcpSetupTarget | null>(null);
   const [activeTab, setActiveTab] = useState<MarketplaceDetailTab>("plugins");
+  const [actionsOpen, setActionsOpen] = useState(false);
+  const [editMarketplace, setEditMarketplace] = useState<{ name: string; description: string | null } | null>(null);
+  const [deleteOpen, setDeleteOpen] = useState(false);
+  const actionsRef = useRef<HTMLDivElement | null>(null);
   const deleteMarketplace = useDeleteMarketplace();
   const authorization = useMcpAccountAuthorization(() => {
     void refetch();
@@ -105,6 +111,17 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
         .map((connection) => ({ plugin, connection })) ?? []
     )) ?? []
   ), [access.isAdmin, data]);
+
+  useEffect(() => {
+    if (!actionsOpen) return;
+    function handlePointerDown(event: MouseEvent) {
+      if (actionsRef.current && !event.composedPath().includes(actionsRef.current)) {
+        setActionsOpen(false);
+      }
+    }
+    document.addEventListener("mousedown", handlePointerDown);
+    return () => document.removeEventListener("mousedown", handlePointerDown);
+  }, [actionsOpen]);
 
   if (isLoading && !data) {
     return (
@@ -128,12 +145,9 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
 
   const { marketplace, plugins, source } = data;
   async function handleDeleteMarketplace() {
-    const confirmed = window.confirm(
-      `Delete ${marketplace.name}? It will disappear from your organization and stop granting plugin access. The plugins themselves will not be deleted.`,
-    );
-    if (!confirmed) return;
     try {
       await deleteMarketplace.mutateAsync(marketplace.id);
+      setDeleteOpen(false);
       router.push(getMarketplacesRoute(orgSlug));
       router.refresh();
     } catch {
@@ -156,23 +170,61 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
           <ArrowLeft className="h-4 w-4" />
           Back
         </Link>
-        {access.isAdmin && marketplace.canDelete ? (
-          <DenButton
-            variant="destructive"
-            loading={deleteMarketplace.isPending}
-            onClick={() => void handleDeleteMarketplace()}
-          >
-            <Trash2 className="h-4 w-4" aria-hidden />
-            Delete marketplace
-          </DenButton>
+        {access.isAdmin ? (
+          <div ref={actionsRef} className="relative">
+            <button
+              type="button"
+              onClick={() => setActionsOpen((current) => !current)}
+              className="flex h-8 w-8 items-center justify-center rounded-lg border border-gray-200 bg-white text-gray-500 transition hover:border-gray-300 hover:bg-gray-50 hover:text-gray-900"
+              aria-label={`More actions for ${marketplace.name}`}
+              aria-haspopup="menu"
+              aria-expanded={actionsOpen}
+              data-testid="marketplace-actions-trigger"
+            >
+              <MoreHorizontal className="h-4 w-4" aria-hidden />
+            </button>
+            {actionsOpen ? (
+              <div
+                role="menu"
+                aria-label={`Actions for ${marketplace.name}`}
+                className="absolute right-0 top-10 z-30 w-44 overflow-hidden rounded-2xl border border-gray-100 bg-white p-1.5 text-[13px] shadow-xl shadow-gray-900/10"
+              >
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setActionsOpen(false);
+                    setEditMarketplace({ name: marketplace.name, description: marketplace.description });
+                  }}
+                  className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-gray-600 transition hover:bg-gray-50 hover:text-gray-900"
+                >
+                  <Pencil className="h-3.5 w-3.5" aria-hidden />
+                  Edit
+                </button>
+                {marketplace.canDelete ? (
+                  <>
+                    <div className="my-1 border-t border-gray-100" />
+                    <button
+                      type="button"
+                      role="menuitem"
+                      onClick={() => {
+                        setActionsOpen(false);
+                        deleteMarketplace.reset();
+                        setDeleteOpen(true);
+                      }}
+                      className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-red-600 transition hover:bg-red-50"
+                      data-testid="delete-marketplace-action"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" aria-hidden />
+                      Delete
+                    </button>
+                  </>
+                ) : null}
+              </div>
+            ) : null}
+          </div>
         ) : null}
       </div>
-
-      {deleteMarketplace.error ? (
-        <div className="mb-6 rounded-2xl border border-red-100 bg-red-50 px-5 py-3.5 text-[13px] text-red-600">
-          {deleteMarketplace.error instanceof Error ? deleteMarketplace.error.message : "Failed to delete marketplace."}
-        </div>
-      ) : null}
 
       <article className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
         <div className="flex items-stretch">
@@ -320,6 +372,188 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
         presets={presets}
         onClose={() => setSetupTarget(null)}
       />
+      {editMarketplace ? (
+        <EditMarketplaceDialog
+          marketplaceId={marketplace.id}
+          initialName={editMarketplace.name}
+          initialDescription={editMarketplace.description}
+          onClose={() => setEditMarketplace(null)}
+          onSaved={() => {
+            setEditMarketplace(null);
+            void refetch();
+          }}
+        />
+      ) : null}
+      <DeleteMarketplaceDialog
+        open={deleteOpen}
+        marketplaceName={marketplace.name}
+        busy={deleteMarketplace.isPending}
+        error={deleteMarketplace.error}
+        onClose={() => {
+          if (!deleteMarketplace.isPending) setDeleteOpen(false);
+        }}
+        onConfirm={() => void handleDeleteMarketplace()}
+      />
+    </div>
+  );
+}
+
+function EditMarketplaceDialog({
+  marketplaceId,
+  initialName,
+  initialDescription,
+  onClose,
+  onSaved,
+}: {
+  marketplaceId: string;
+  initialName: string;
+  initialDescription: string | null;
+  onClose: () => void;
+  onSaved: () => void;
+}) {
+  const updateMarketplace = useUpdateMarketplace();
+  const [name, setName] = useState(initialName);
+  const [description, setDescription] = useState(initialDescription ?? "");
+  const trimmedName = name.trim();
+  const trimmedDescription = description.trim();
+  const unchanged = trimmedName === initialName && trimmedDescription === (initialDescription ?? "");
+
+  async function handleSave() {
+    try {
+      await updateMarketplace.mutateAsync({
+        marketplaceId,
+        name: trimmedName,
+        description: trimmedDescription || null,
+      });
+      onSaved();
+    } catch {
+      // The mutation error is rendered in the dialog.
+    }
+  }
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6"
+      onClick={updateMarketplace.isPending ? undefined : onClose}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="edit-marketplace-title"
+        className="w-full max-w-[440px] rounded-2xl border border-gray-100 bg-white p-6 shadow-[0_24px_60px_-24px_rgba(15,23,42,0.4)]"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 id="edit-marketplace-title" className="text-[16px] font-semibold tracking-[-0.01em] text-gray-950">
+          Edit marketplace
+        </h2>
+        <p className="mt-1 text-[13px] leading-6 text-gray-500">
+          Update how this marketplace appears to your organization.
+        </p>
+
+        <label className="mt-4 block">
+          <span className="mb-1.5 block text-[12px] font-medium text-gray-700">Name</span>
+          <DenInput
+            value={name}
+            onChange={(event) => setName(event.target.value)}
+            disabled={updateMarketplace.isPending}
+            data-testid="marketplace-edit-name"
+            autoFocus
+          />
+        </label>
+        <label className="mt-3 block">
+          <span className="mb-1.5 block text-[12px] font-medium text-gray-700">Description (optional)</span>
+          <DenTextarea
+            value={description}
+            onChange={(event) => setDescription(event.target.value)}
+            disabled={updateMarketplace.isPending}
+            rows={3}
+            data-testid="marketplace-edit-description"
+          />
+        </label>
+
+        {updateMarketplace.error ? (
+          <p className="mt-3 text-[12.5px] text-red-600">
+            {updateMarketplace.error instanceof Error ? updateMarketplace.error.message : "Failed to update marketplace."}
+          </p>
+        ) : null}
+
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <DenButton variant="secondary" onClick={onClose} disabled={updateMarketplace.isPending}>
+            Cancel
+          </DenButton>
+          <DenButton
+            loading={updateMarketplace.isPending}
+            disabled={!trimmedName || unchanged}
+            onClick={() => void handleSave()}
+            data-testid="marketplace-edit-save"
+          >
+            Save changes
+          </DenButton>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function DeleteMarketplaceDialog({
+  open,
+  marketplaceName,
+  busy,
+  error,
+  onClose,
+  onConfirm,
+}: {
+  open: boolean;
+  marketplaceName: string;
+  busy: boolean;
+  error: unknown;
+  onClose: () => void;
+  onConfirm: () => void;
+}) {
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={busy ? undefined : onClose}>
+      <div
+        role="alertdialog"
+        aria-modal="true"
+        aria-labelledby="delete-marketplace-title"
+        aria-describedby="delete-marketplace-description"
+        className="w-full max-w-md rounded-[28px] border border-gray-200 bg-white p-6 shadow-[0_24px_80px_-32px_rgba(15,23,42,0.45)]"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <div className="flex items-start gap-3">
+          <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-full bg-red-50 text-red-600">
+            <Trash2 className="h-5 w-5" aria-hidden />
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 id="delete-marketplace-title" className="text-[18px] font-semibold tracking-[-0.02em] text-gray-950">
+              Delete {marketplaceName}?
+            </h2>
+            <p id="delete-marketplace-description" className="mt-1 text-[13px] leading-6 text-gray-600">
+              This marketplace will disappear from your organization and stop granting plugin access. Its plugins and membership history will be preserved.
+            </p>
+            <p className="mt-3 text-[12px] leading-5 text-gray-500">
+              You can restore the marketplace later through the lifecycle API.
+            </p>
+          </div>
+        </div>
+
+        {error ? (
+          <p className="mt-4 rounded-xl bg-red-50 px-3 py-2 text-[12.5px] text-red-600">
+            {error instanceof Error ? error.message : "Failed to delete marketplace."}
+          </p>
+        ) : null}
+
+        <div className="mt-6 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <DenButton variant="secondary" onClick={onClose} disabled={busy}>
+            Cancel
+          </DenButton>
+          <DenButton variant="destructive" icon={Trash2} loading={busy} onClick={onConfirm} data-testid="confirm-delete-marketplace">
+            Delete marketplace
+          </DenButton>
+        </div>
+      </div>
     </div>
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -170,7 +170,7 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
           <ArrowLeft className="h-4 w-4" />
           Back
         </Link>
-        {access.isAdmin ? (
+        {access.isAdmin && marketplace.canDelete ? (
           <div ref={actionsRef} className="relative">
             <button
               type="button"
@@ -201,25 +201,21 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
                   <Pencil className="h-3.5 w-3.5" aria-hidden />
                   Edit
                 </button>
-                {marketplace.canDelete ? (
-                  <>
-                    <div className="my-1 border-t border-gray-100" />
-                    <button
-                      type="button"
-                      role="menuitem"
-                      onClick={() => {
-                        setActionsOpen(false);
-                        deleteMarketplace.reset();
-                        setDeleteOpen(true);
-                      }}
-                      className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-red-600 transition hover:bg-red-50"
-                      data-testid="delete-marketplace-action"
-                    >
-                      <Trash2 className="h-3.5 w-3.5" aria-hidden />
-                      Delete
-                    </button>
-                  </>
-                ) : null}
+                <div className="my-1 border-t border-gray-100" />
+                <button
+                  type="button"
+                  role="menuitem"
+                  onClick={() => {
+                    setActionsOpen(false);
+                    deleteMarketplace.reset();
+                    setDeleteOpen(true);
+                  }}
+                  className="flex w-full items-center gap-2 rounded-xl px-3 py-2 text-left text-red-600 transition hover:bg-red-50"
+                  data-testid="delete-marketplace-action"
+                >
+                  <Trash2 className="h-3.5 w-3.5" aria-hidden />
+                  Delete
+                </button>
               </div>
             ) : null}
           </div>

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -1,8 +1,9 @@
 "use client";
 
 import Link from "next/link";
+import { useRouter } from "next/navigation";
 import { useMemo, useRef, useState, useEffect } from "react";
-import { ArrowLeft, Check, ChevronDown, GitBranch, Github, Globe, Loader2, Plug, Plus, Puzzle, Users, X } from "lucide-react";
+import { ArrowLeft, Check, ChevronDown, GitBranch, Github, Globe, Loader2, Plug, Plus, Puzzle, Trash2, Users, X } from "lucide-react";
 import { PaperMeshGradient, StaticSeededGradient } from "@openwork/ui/react";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
@@ -23,6 +24,7 @@ import {
   type MarketplacePluginCloudReadinessState,
   type MarketplacePluginSummary,
   useConfigurePluginMcpConnection,
+  useDeleteMarketplace,
   useGrantMarketplaceAccess,
   useMarketplace,
   useMarketplaceAccess,
@@ -78,11 +80,13 @@ function authTypeFromSelect(value: string): ExternalMcpAuthType {
 }
 
 export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: string }) {
+  const router = useRouter();
   const { orgContext, orgSlug } = useOrgDashboard();
   const { data, isLoading, error, refetch } = useMarketplace(marketplaceId);
   const { data: presets = [] } = useMcpConnectionPresets();
   const [setupTarget, setSetupTarget] = useState<PluginMcpSetupTarget | null>(null);
   const [activeTab, setActiveTab] = useState<MarketplaceDetailTab>("plugins");
+  const deleteMarketplace = useDeleteMarketplace();
   const authorization = useMcpAccountAuthorization(() => {
     void refetch();
   });
@@ -123,6 +127,19 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
   }
 
   const { marketplace, plugins, source } = data;
+  async function handleDeleteMarketplace() {
+    const confirmed = window.confirm(
+      `Delete ${marketplace.name}? It will disappear from your organization and stop granting plugin access. The plugins themselves will not be deleted.`,
+    );
+    if (!confirmed) return;
+    try {
+      await deleteMarketplace.mutateAsync(marketplace.id);
+      router.push(getMarketplacesRoute(orgSlug));
+      router.refresh();
+    } catch {
+      // The mutation error is rendered below the action.
+    }
+  }
   const tabs: readonly TabItem<MarketplaceDetailTab>[] = [
     { value: "plugins", label: "Plugins", icon: Puzzle },
     { value: "members", label: "Members", icon: Users },
@@ -139,7 +156,23 @@ export function MarketplaceDetailScreen({ marketplaceId }: { marketplaceId: stri
           <ArrowLeft className="h-4 w-4" />
           Back
         </Link>
+        {access.isAdmin && marketplace.canDelete ? (
+          <DenButton
+            variant="destructive"
+            loading={deleteMarketplace.isPending}
+            onClick={() => void handleDeleteMarketplace()}
+          >
+            <Trash2 className="h-4 w-4" aria-hidden />
+            Delete marketplace
+          </DenButton>
+        ) : null}
       </div>
+
+      {deleteMarketplace.error ? (
+        <div className="mb-6 rounded-2xl border border-red-100 bg-red-50 px-5 py-3.5 text-[13px] text-red-600">
+          {deleteMarketplace.error instanceof Error ? deleteMarketplace.error.message : "Failed to delete marketplace."}
+        </div>
+      ) : null}
 
       <article className="overflow-hidden rounded-2xl border border-gray-100 bg-white">
         <div className="flex items-stretch">

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-detail-screen.tsx
@@ -527,10 +527,7 @@ function DeleteMarketplaceDialog({
               Delete {marketplaceName}?
             </h2>
             <p id="delete-marketplace-description" className="mt-1 text-[13px] leading-6 text-gray-600">
-              This marketplace will disappear from your organization and stop granting plugin access. Its plugins and membership history will be preserved.
-            </p>
-            <p className="mt-3 text-[12px] leading-5 text-gray-500">
-              You can restore the marketplace later through the lifecycle API.
+              This action cannot be undone.
             </p>
           </div>
         </div>

--- a/evals/flows/delete-custom-marketplace.flow.mjs
+++ b/evals/flows/delete-custom-marketplace.flow.mjs
@@ -1,0 +1,174 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+import { denApiFetch, denApiUrl, denWebUrl, signInApi, signInViaBrowser } from "./lib/den-web.mjs";
+
+const FLOW_ID = "delete-custom-marketplace";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const OWNER_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const OWNER_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MARKETPLACE_NAME = `Fraimz Custom Marketplace ${Date.now()}`;
+
+const state = {
+  marketplaceId: "",
+  builtInMarketplaceId: "",
+  token: "",
+};
+
+function authHeaders() {
+  return { authorization: `Bearer ${state.token}` };
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : JSON.stringify(actual).slice(0, 1_200),
+  });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : `. Actual: ${JSON.stringify(actual).slice(0, 600)}`}`);
+}
+
+async function navigateTo(ctx, path) {
+  const url = new URL(path, denWebUrl()).toString();
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${path}` });
+}
+
+function screenshot(name, claim, requireText, rejectText = []) {
+  return {
+    name,
+    claim,
+    requireText,
+    rejectText: ["Something went wrong", ...rejectText],
+  };
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Admins safely delete custom marketplaces while managed catalogs stay protected",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Setup",
+      run: async (ctx) => {
+        await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+          width: 1440,
+          height: 1000,
+          deviceScaleFactor: 1,
+          mobile: false,
+        });
+
+        state.token = await signInApi(OWNER_EMAIL, OWNER_PASSWORD) ?? "";
+        witness(ctx, state.token.length > 0, "The seeded workspace owner can sign in", { email: OWNER_EMAIL });
+
+        const created = await denApiFetch("/v1/marketplaces", {
+          method: "POST",
+          headers: authHeaders(),
+          body: JSON.stringify({
+            name: MARKETPLACE_NAME,
+            description: "A temporary custom marketplace created for deletion proof.",
+          }),
+        });
+        state.marketplaceId = created.body?.item?.id ?? "";
+        witness(ctx, created.response.status === 201 && state.marketplaceId.length > 0, "A custom marketplace is created through the real Den API", {
+          status: created.response.status,
+          marketplaceId: state.marketplaceId,
+        });
+
+        const marketplaces = await denApiFetch("/v1/marketplaces?status=active&limit=100", { headers: authHeaders() });
+        state.builtInMarketplaceId = marketplaces.body?.items?.find((item) => item?.name === "OpenWork Marketplace")?.id ?? "";
+        witness(ctx, state.builtInMarketplaceId.length > 0, "The built-in OpenWork Marketplace is available for the protection check");
+
+        await signInViaBrowser(ctx, OWNER_EMAIL, OWNER_PASSWORD);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("The custom marketplace exposes a clear destructive action", {
+          voiceover: vo[0],
+          action: async () => {
+            await navigateTo(ctx, `/dashboard/marketplaces/${encodeURIComponent(state.marketplaceId)}`);
+            await ctx.waitForText("Delete marketplace", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText(MARKETPLACE_NAME);
+            await ctx.expectText("Delete marketplace");
+            await ctx.expectText("0 plugins");
+          },
+          screenshot: screenshot(
+            "custom-marketplace-delete-action",
+            "A custom marketplace visibly offers Delete marketplace without implying that its plugins will be deleted.",
+            [MARKETPLACE_NAME, "Delete marketplace", "0 plugins"],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("Confirming deletion removes the marketplace from the active organization list", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.eval("window.confirm = () => true");
+            await ctx.clickText("Delete marketplace", { selector: "button", timeoutMs: 10_000 });
+            await ctx.waitFor("location.pathname === '/dashboard/marketplaces'", { timeoutMs: 30_000, label: "marketplace list after deletion" });
+            await ctx.waitForText("Marketplaces", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectNoText(MARKETPLACE_NAME);
+            const detail = await denApiFetch(`/v1/marketplaces/${encodeURIComponent(state.marketplaceId)}`, { headers: authHeaders() });
+            witness(ctx, detail.response.ok && detail.body?.item?.status === "deleted" && Boolean(detail.body?.item?.deletedAt), "The API records a reversible soft-delete", {
+              status: detail.response.status,
+              marketplaceStatus: detail.body?.item?.status,
+              deletedAt: detail.body?.item?.deletedAt,
+            });
+            witness(ctx, detail.body?.item?.pluginCount === 0, "Deletion preserves marketplace membership history instead of cascading into plugins", {
+              pluginCount: detail.body?.item?.pluginCount,
+            });
+          },
+          screenshot: screenshot(
+            "custom-marketplace-removed",
+            "The deleted custom marketplace is absent from the active marketplace list.",
+            ["Marketplaces", "OpenWork Marketplace"],
+            [MARKETPLACE_NAME],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Built-in marketplaces remain protected from deletion", {
+          voiceover: vo[2],
+          action: async () => {
+            await navigateTo(ctx, `/dashboard/marketplaces/${encodeURIComponent(state.builtInMarketplaceId)}`);
+            await ctx.waitForText("OpenWork Marketplace", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("OpenWork Marketplace");
+            const deleteButtonVisible = await ctx.eval(`(() => [...document.querySelectorAll('button')]
+              .some((button) => (button.textContent ?? '').includes('Delete marketplace')))()`);
+            witness(ctx, deleteButtonVisible === false, "The built-in marketplace does not expose the delete action", { deleteButtonVisible });
+            const directDelete = await denApiFetch(`/v1/marketplaces/${encodeURIComponent(state.builtInMarketplaceId)}/delete`, {
+              method: "POST",
+              headers: authHeaders(),
+            });
+            witness(ctx, directDelete.response.status === 409, "The API independently refuses deletion of a managed marketplace", {
+              status: directDelete.response.status,
+              body: directDelete.body,
+              apiUrl: denApiUrl(),
+            });
+          },
+          screenshot: screenshot(
+            "built-in-marketplace-protected",
+            "The built-in marketplace remains available without a destructive delete action.",
+            ["OpenWork Marketplace", "Add a plugin"],
+            ["Delete marketplace"],
+          ),
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/delete-custom-marketplace.flow.mjs
+++ b/evals/flows/delete-custom-marketplace.flow.mjs
@@ -204,14 +204,11 @@ export default {
           action: async () => {
             await navigateTo(ctx, `/dashboard/marketplaces/${encodeURIComponent(state.builtInMarketplaceId)}`);
             await ctx.waitForText("OpenWork Marketplace", { timeoutMs: 30_000 });
-            await ctx.eval(`document.querySelector('[data-testid="marketplace-actions-trigger"]')?.click()`);
-            await ctx.waitForText("Edit", { timeoutMs: 10_000 });
           },
           assert: async () => {
             await ctx.expectText("OpenWork Marketplace");
-            await ctx.expectText("Edit");
-            const deleteMenuItemVisible = await ctx.eval(`Boolean(document.querySelector('[data-testid="delete-marketplace-action"]'))`);
-            witness(ctx, deleteMenuItemVisible === false, "The built-in marketplace menu does not expose the delete action", { deleteMenuItemVisible });
+            const actionsTriggerVisible = await ctx.eval(`Boolean(document.querySelector('[data-testid="marketplace-actions-trigger"]'))`);
+            witness(ctx, actionsTriggerVisible === false, "The built-in marketplace exposes no edit or delete menu", { actionsTriggerVisible });
             const directDelete = await denApiFetch(`/v1/marketplaces/${encodeURIComponent(state.builtInMarketplaceId)}/delete`, {
               method: "POST",
               headers: authHeaders(),
@@ -224,9 +221,9 @@ export default {
           },
           screenshot: screenshot(
             "built-in-marketplace-protected",
-            "The built-in marketplace remains editable but its action menu has no destructive option.",
-            ["OpenWork Marketplace", "Edit", "Add a plugin"],
-            ["Delete"],
+            "The built-in marketplace remains available without edit or delete controls.",
+            ["OpenWork Marketplace", "Add a plugin"],
+            ["Edit", "Delete"],
           ),
         });
       },

--- a/evals/flows/delete-custom-marketplace.flow.mjs
+++ b/evals/flows/delete-custom-marketplace.flow.mjs
@@ -151,7 +151,7 @@ export default {
           },
           assert: async () => {
             await ctx.expectText(`Delete ${UPDATED_MARKETPLACE_NAME}?`);
-            await ctx.expectText("Its plugins and membership history will be preserved.");
+            await ctx.expectText("This action cannot be undone.");
             await ctx.expectText("Cancel");
             await ctx.expectText("Delete marketplace");
             const alertDialogVisible = await ctx.eval(`Boolean(document.querySelector('[role="alertdialog"][aria-modal="true"]'))`);
@@ -159,8 +159,8 @@ export default {
           },
           screenshot: screenshot(
             "custom-marketplace-delete-confirmation",
-            "A dedicated confirmation modal explains the soft-delete and requires an explicit destructive confirmation.",
-            [`Delete ${UPDATED_MARKETPLACE_NAME}?`, "Cancel", "Delete marketplace", "membership history will be preserved"],
+            "A dedicated confirmation modal requires an explicit destructive confirmation without exposing implementation details.",
+            [`Delete ${UPDATED_MARKETPLACE_NAME}?`, "This action cannot be undone.", "Cancel", "Delete marketplace"],
           ),
         });
       },
@@ -178,13 +178,9 @@ export default {
           assert: async () => {
             await ctx.expectNoText(UPDATED_MARKETPLACE_NAME);
             const detail = await denApiFetch(`/v1/marketplaces/${encodeURIComponent(state.marketplaceId)}`, { headers: authHeaders() });
-            witness(ctx, detail.response.ok && detail.body?.item?.status === "deleted" && Boolean(detail.body?.item?.deletedAt), "The API records a reversible soft-delete", {
+            witness(ctx, detail.response.status === 404, "The deleted marketplace no longer exists in the API", {
               status: detail.response.status,
-              marketplaceStatus: detail.body?.item?.status,
-              deletedAt: detail.body?.item?.deletedAt,
-            });
-            witness(ctx, detail.body?.item?.pluginCount === 0, "Deletion preserves marketplace membership history instead of cascading into plugins", {
-              pluginCount: detail.body?.item?.pluginCount,
+              body: detail.body,
             });
           },
           screenshot: screenshot(

--- a/evals/flows/delete-custom-marketplace.flow.mjs
+++ b/evals/flows/delete-custom-marketplace.flow.mjs
@@ -6,6 +6,7 @@ const vo = await loadVoiceoverParagraphs(FLOW_ID);
 const OWNER_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
 const OWNER_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
 const MARKETPLACE_NAME = `Fraimz Custom Marketplace ${Date.now()}`;
+const UPDATED_MARKETPLACE_NAME = `${MARKETPLACE_NAME} Edited`;
 
 const state = {
   marketplaceId: "",
@@ -44,7 +45,7 @@ function screenshot(name, claim, requireText, rejectText = []) {
 
 export default {
   id: FLOW_ID,
-  title: "Admins safely delete custom marketplaces while managed catalogs stay protected",
+  title: "Admins discreetly edit and safely delete custom marketplaces while managed catalogs stay protected",
   kind: "user-facing",
   preserveTheme: true,
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
@@ -86,21 +87,24 @@ export default {
     {
       name: "Frame 1",
       run: async (ctx) => {
-        await ctx.prove("The custom marketplace exposes a clear destructive action", {
+        await ctx.prove("Marketplace management actions stay in a discreet overflow menu", {
           voiceover: vo[0],
           action: async () => {
             await navigateTo(ctx, `/dashboard/marketplaces/${encodeURIComponent(state.marketplaceId)}`);
-            await ctx.waitForText("Delete marketplace", { timeoutMs: 30_000 });
+            await ctx.waitForText(MARKETPLACE_NAME, { timeoutMs: 30_000 });
+            await ctx.eval(`document.querySelector('[data-testid="marketplace-actions-trigger"]')?.click()`);
+            await ctx.waitForText("Edit", { timeoutMs: 10_000 });
           },
           assert: async () => {
             await ctx.expectText(MARKETPLACE_NAME);
-            await ctx.expectText("Delete marketplace");
+            await ctx.expectText("Edit");
+            await ctx.expectText("Delete");
             await ctx.expectText("0 plugins");
           },
           screenshot: screenshot(
-            "custom-marketplace-delete-action",
-            "A custom marketplace visibly offers Delete marketplace without implying that its plugins will be deleted.",
-            [MARKETPLACE_NAME, "Delete marketplace", "0 plugins"],
+            "custom-marketplace-actions-menu",
+            "A compact overflow menu contains Edit and Delete without promoting the destructive action.",
+            [MARKETPLACE_NAME, "Edit", "Delete", "0 plugins"],
           ),
         });
       },
@@ -108,16 +112,71 @@ export default {
     {
       name: "Frame 2",
       run: async (ctx) => {
-        await ctx.prove("Confirming deletion removes the marketplace from the active organization list", {
+        await ctx.prove("Admins can edit custom marketplace metadata", {
           voiceover: vo[1],
           action: async () => {
-            await ctx.eval("window.confirm = () => true");
-            await ctx.clickText("Delete marketplace", { selector: "button", timeoutMs: 10_000 });
+            await ctx.clickText("Edit", { selector: '[role="menuitem"]', timeoutMs: 10_000 });
+            await ctx.waitForText("Edit marketplace", { timeoutMs: 10_000 });
+            await ctx.fill('[data-testid="marketplace-edit-name"]', UPDATED_MARKETPLACE_NAME);
+            await ctx.fill('[data-testid="marketplace-edit-description"]', "Updated through the marketplace actions menu.");
+            await ctx.clickText("Save changes", { selector: "button", timeoutMs: 10_000 });
+            await ctx.waitForText(UPDATED_MARKETPLACE_NAME, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText(UPDATED_MARKETPLACE_NAME);
+            await ctx.expectText("Updated through the marketplace actions menu.");
+            const detail = await denApiFetch(`/v1/marketplaces/${encodeURIComponent(state.marketplaceId)}`, { headers: authHeaders() });
+            witness(ctx, detail.response.ok && detail.body?.item?.name === UPDATED_MARKETPLACE_NAME, "The edit persists through the real marketplace API", {
+              status: detail.response.status,
+              name: detail.body?.item?.name,
+            });
+          },
+          screenshot: screenshot(
+            "custom-marketplace-edited",
+            "The marketplace detail immediately reflects the saved name and description.",
+            [UPDATED_MARKETPLACE_NAME, "Updated through the marketplace actions menu."],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("Deletion requires an explicit modal confirmation", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.eval(`document.querySelector('[data-testid="marketplace-actions-trigger"]')?.click()`);
+            await ctx.clickText("Delete", { selector: '[role="menuitem"]', timeoutMs: 10_000 });
+            await ctx.waitForText(`Delete ${UPDATED_MARKETPLACE_NAME}?`, { timeoutMs: 10_000 });
+          },
+          assert: async () => {
+            await ctx.expectText(`Delete ${UPDATED_MARKETPLACE_NAME}?`);
+            await ctx.expectText("Its plugins and membership history will be preserved.");
+            await ctx.expectText("Cancel");
+            await ctx.expectText("Delete marketplace");
+            const alertDialogVisible = await ctx.eval(`Boolean(document.querySelector('[role="alertdialog"][aria-modal="true"]'))`);
+            witness(ctx, alertDialogVisible === true, "The destructive action opens a modal alert dialog before making the request", { alertDialogVisible });
+          },
+          screenshot: screenshot(
+            "custom-marketplace-delete-confirmation",
+            "A dedicated confirmation modal explains the soft-delete and requires an explicit destructive confirmation.",
+            [`Delete ${UPDATED_MARKETPLACE_NAME}?`, "Cancel", "Delete marketplace", "membership history will be preserved"],
+          ),
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("Confirming deletion removes the marketplace from the active organization list", {
+          voiceover: vo[3],
+          action: async () => {
+            await ctx.clickText("Delete marketplace", { selector: '[role="alertdialog"] button', timeoutMs: 10_000 });
             await ctx.waitFor("location.pathname === '/dashboard/marketplaces'", { timeoutMs: 30_000, label: "marketplace list after deletion" });
             await ctx.waitForText("Marketplaces", { timeoutMs: 30_000 });
           },
           assert: async () => {
-            await ctx.expectNoText(MARKETPLACE_NAME);
+            await ctx.expectNoText(UPDATED_MARKETPLACE_NAME);
             const detail = await denApiFetch(`/v1/marketplaces/${encodeURIComponent(state.marketplaceId)}`, { headers: authHeaders() });
             witness(ctx, detail.response.ok && detail.body?.item?.status === "deleted" && Boolean(detail.body?.item?.deletedAt), "The API records a reversible soft-delete", {
               status: detail.response.status,
@@ -132,25 +191,27 @@ export default {
             "custom-marketplace-removed",
             "The deleted custom marketplace is absent from the active marketplace list.",
             ["Marketplaces", "OpenWork Marketplace"],
-            [MARKETPLACE_NAME],
+            [UPDATED_MARKETPLACE_NAME],
           ),
         });
       },
     },
     {
-      name: "Frame 3",
+      name: "Frame 5",
       run: async (ctx) => {
         await ctx.prove("Built-in marketplaces remain protected from deletion", {
-          voiceover: vo[2],
+          voiceover: vo[4],
           action: async () => {
             await navigateTo(ctx, `/dashboard/marketplaces/${encodeURIComponent(state.builtInMarketplaceId)}`);
             await ctx.waitForText("OpenWork Marketplace", { timeoutMs: 30_000 });
+            await ctx.eval(`document.querySelector('[data-testid="marketplace-actions-trigger"]')?.click()`);
+            await ctx.waitForText("Edit", { timeoutMs: 10_000 });
           },
           assert: async () => {
             await ctx.expectText("OpenWork Marketplace");
-            const deleteButtonVisible = await ctx.eval(`(() => [...document.querySelectorAll('button')]
-              .some((button) => (button.textContent ?? '').includes('Delete marketplace')))()`);
-            witness(ctx, deleteButtonVisible === false, "The built-in marketplace does not expose the delete action", { deleteButtonVisible });
+            await ctx.expectText("Edit");
+            const deleteMenuItemVisible = await ctx.eval(`Boolean(document.querySelector('[data-testid="delete-marketplace-action"]'))`);
+            witness(ctx, deleteMenuItemVisible === false, "The built-in marketplace menu does not expose the delete action", { deleteMenuItemVisible });
             const directDelete = await denApiFetch(`/v1/marketplaces/${encodeURIComponent(state.builtInMarketplaceId)}/delete`, {
               method: "POST",
               headers: authHeaders(),
@@ -163,9 +224,9 @@ export default {
           },
           screenshot: screenshot(
             "built-in-marketplace-protected",
-            "The built-in marketplace remains available without a destructive delete action.",
-            ["OpenWork Marketplace", "Add a plugin"],
-            ["Delete marketplace"],
+            "The built-in marketplace remains editable but its action menu has no destructive option.",
+            ["OpenWork Marketplace", "Edit", "Add a plugin"],
+            ["Delete"],
           ),
         });
       },

--- a/evals/voiceovers/delete-custom-marketplace.md
+++ b/evals/voiceovers/delete-custom-marketplace.md
@@ -1,7 +1,11 @@
 # delete-custom-marketplace — Safe custom marketplace deletion
 
-1. As a workspace owner, I can identify a custom marketplace and find one explicit Delete marketplace action on its detail page.
+1. Marketplace management stays out of the way until I open the compact actions menu, where Edit and Delete are easy to find.
 
-2. After I confirm, the custom marketplace leaves the active organization list while the API records a reversible soft-delete and keeps plugin history intact.
+2. Edit opens a focused form, and saving updates the marketplace name and description through the existing API.
 
-3. OpenWork's built-in marketplace stays protected in both the interface and API, so the destructive action applies only to manually managed catalogs.
+3. Delete never happens immediately. A dedicated confirmation modal explains exactly what changes and what OpenWork preserves.
+
+4. Only after I explicitly confirm does the marketplace leave the active list, while the API records a reversible soft-delete and keeps plugin history intact.
+
+5. OpenWork's built-in marketplace stays protected in both the interface and API, so the destructive action applies only to manually managed catalogs.

--- a/evals/voiceovers/delete-custom-marketplace.md
+++ b/evals/voiceovers/delete-custom-marketplace.md
@@ -8,4 +8,4 @@
 
 4. Only after I explicitly confirm does the marketplace leave the active list, while the API records a reversible soft-delete and keeps plugin history intact.
 
-5. OpenWork's built-in marketplace stays protected in both the interface and API, so the destructive action applies only to manually managed catalogs.
+5. OpenWork's built-in marketplace has no edit or delete menu and stays protected by the API, so management actions apply only to custom catalogs.

--- a/evals/voiceovers/delete-custom-marketplace.md
+++ b/evals/voiceovers/delete-custom-marketplace.md
@@ -4,8 +4,8 @@
 
 2. Edit opens a focused form, and saving updates the marketplace name and description through the existing API.
 
-3. Delete never happens immediately. A dedicated confirmation modal explains exactly what changes and what OpenWork preserves.
+3. Delete never happens immediately. A dedicated confirmation modal gives a clear, neutral warning without exposing implementation details.
 
-4. Only after I explicitly confirm does the marketplace leave the active list, while the API records a reversible soft-delete and keeps plugin history intact.
+4. Only after I explicitly confirm does the marketplace leave the active list and disappear from the API.
 
 5. OpenWork's built-in marketplace has no edit or delete menu and stays protected by the API, so management actions apply only to custom catalogs.

--- a/evals/voiceovers/delete-custom-marketplace.md
+++ b/evals/voiceovers/delete-custom-marketplace.md
@@ -1,0 +1,7 @@
+# delete-custom-marketplace — Safe custom marketplace deletion
+
+1. As a workspace owner, I can identify a custom marketplace and find one explicit Delete marketplace action on its detail page.
+
+2. After I confirm, the custom marketplace leaves the active organization list while the API records a reversible soft-delete and keeps plugin history intact.
+
+3. OpenWork's built-in marketplace stays protected in both the interface and API, so the destructive action applies only to manually managed catalogs.


### PR DESCRIPTION
## Summary

- place marketplace management in a discreet admin-only overflow menu
- add an edit dialog backed by the existing marketplace metadata API
- require a dedicated confirmation modal before deleting a custom marketplace
- permanently delete the custom marketplace, its access grants, and its marketplace-plugin relationships while retaining the plugin records
- protect built-in and connector-managed marketplaces in both the UI and API
- add focused lifecycle coverage and a Fraimz evidence flow

## Verification

- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm exec bun test ee/apps/den-api/test/marketplace-cloud-readiness.test.ts -t 'marketplace lifecycle'` — 2 passed, 0 failed
- `pnpm fraimz --flow delete-custom-marketplace` — 1 passed, 0 failed, 0 skipped
- agent-observed in an isolated Chrome session; not yet manually confirmed by the requester

## Fraimz evidence

[Open the complete interactive Fraimz report](https://openwork-delete-marketplace-fraimz.vercel.app)

### Management stays in a compact actions menu

![Custom marketplace actions menu with Edit and Delete](https://openwork-delete-marketplace-fraimz.vercel.app/delete-custom-marketplace-01-custom-marketplace-actions-menu.png)

### Marketplace metadata can be edited

![Marketplace detail after editing](https://openwork-delete-marketplace-fraimz.vercel.app/delete-custom-marketplace-02-custom-marketplace-edited.png)

### Deletion requires explicit modal confirmation

![Marketplace delete confirmation modal](https://openwork-delete-marketplace-fraimz.vercel.app/delete-custom-marketplace-03-custom-marketplace-delete-confirmation.png)

### Confirmed deletion removes it from the active list

![Marketplace list after deletion](https://openwork-delete-marketplace-fraimz.vercel.app/delete-custom-marketplace-04-custom-marketplace-removed.png)

### Built-in marketplaces expose no management actions

![Built-in marketplace without Edit or Delete controls](https://openwork-delete-marketplace-fraimz.vercel.app/delete-custom-marketplace-05-built-in-marketplace-protected.png)

## Risks and remaining gaps

- deletion is irreversible for the marketplace and its relationships; plugin records are not cascaded
- no database schema change or migration is required
- direct deletion attempts against built-in or connector-managed marketplaces return `409 managed_marketplace_cannot_be_deleted`
- the focused API tests, Den Web typecheck, and Chrome evidence flow passed; the full repository suite and additional browser/platform combinations were not run
