### PR TITLE
fix(desktop): preserve non-mac branding behavior

### DIFF
--- a/apps/desktop/electron/brand-app-name.mjs
+++ b/apps/desktop/electron/brand-app-name.mjs
@@ -10,6 +10,7 @@ const MAX_APP_NAME_LENGTH = 64;
  * @param {{
  *   fallbackName: string,
  *   platform: string,
+ *   updateElectronAppName: boolean,
  *   runtimeProcess: { title: string },
  *   app: { setName: (name: string) => void },
  *   applicationMenu: { setAppName: (name: string) => unknown },
@@ -23,7 +24,9 @@ export function applyBrandAppName(requestedName, dependencies) {
   if (dependencies.platform === "darwin") {
     dependencies.runtimeProcess.title = appName;
   }
-  dependencies.app.setName(appName);
+  if (dependencies.updateElectronAppName) {
+    dependencies.app.setName(appName);
+  }
   dependencies.applicationMenu.setAppName(appName);
   dependencies.window?.setTitle(appName);
 

--- a/apps/desktop/electron/brand-app-name.test.mjs
+++ b/apps/desktop/electron/brand-app-name.test.mjs
@@ -8,6 +8,7 @@ test("updates the macOS process and Electron application name before rebuilding 
   const appName = applyBrandAppName("  Acme Work  ", {
     fallbackName: "OpenWork",
     platform: "darwin",
+    updateElectronAppName: true,
     runtimeProcess: {
       get title() { return ""; },
       set title(name) { calls.push(["process", name]); },
@@ -26,11 +27,34 @@ test("updates the macOS process and Electron application name before rebuilding 
   ]);
 });
 
-test("falls back to the signed application name and caps branded names", () => {
+test("preserves the existing Windows live-update behavior", () => {
+  const calls = [];
+  const appName = applyBrandAppName("Acme Work", {
+    fallbackName: "OpenWork",
+    platform: "win32",
+    updateElectronAppName: false,
+    runtimeProcess: {
+      get title() { return ""; },
+      set title(name) { calls.push(["process", name]); },
+    },
+    app: { setName: (name) => calls.push(["app", name]) },
+    applicationMenu: { setAppName: (name) => calls.push(["menu", name]) },
+    window: { setTitle: (name) => calls.push(["window", name]) },
+  });
+
+  assert.equal(appName, "Acme Work");
+  assert.deepEqual(calls, [
+    ["menu", "Acme Work"],
+    ["window", "Acme Work"],
+  ]);
+});
+
+test("keeps the startup fallback and branded-name limit on every platform", () => {
   const appliedNames = [];
   const dependencies = {
     fallbackName: "OpenWork",
     platform: "win32",
+    updateElectronAppName: true,
     runtimeProcess: {
       get title() { return ""; },
       set title(name) { appliedNames.push(`process:${name}`); },

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1931,6 +1931,7 @@ const desktopCommandHandlers = {
     currentDisplayAppName = applyBrandAppName(args[0], {
       fallbackName: APP_NAME,
       platform: process.platform,
+      updateElectronAppName: process.platform === "darwin",
       runtimeProcess: process,
       app,
       applicationMenu,
@@ -2421,6 +2422,7 @@ if (!app.requestSingleInstanceLock()) {
     currentDisplayAppName = applyBrandAppName(bootstrapConfig.brandAppName, {
       fallbackName: APP_NAME,
       platform: process.platform,
+      updateElectronAppName: true,
       runtimeProcess: process,
       app,
       applicationMenu,


### PR DESCRIPTION
## Summary

- scope live Electron app-name mutation to macOS, where it is required for the branded native application menu
- preserve the pre-existing Windows and Linux live branding sequence
- add a Windows regression test that fails if a live name update mutates the process title or Electron app name

## Context

This is a follow-up to #2960. That PR fixed the macOS menu-bar label by updating `process.title` and Electron's application name before rebuilding the native menu. Its initial helper also expanded the live `app.setName()` call to Windows and Linux, although those platforms did not require it.

Startup behavior remains unchanged on every platform: Electron's application name is still initialized from branding. During live updates, macOS keeps the new native-name sequence while Windows and Linux retain their previous menu/window update path. Windows shortcut and taskbar identity registration are unchanged.

## Verification

- `./bin/openwork-hub run desktop macos-brand-menu-platform-safety -- pnpm --dir apps/desktop exec node --test electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs` — passed; 13 tests
- `./bin/openwork-hub run desktop macos-brand-menu-platform-safety -- pnpm --filter @openwork/desktop typecheck:electron` — passed
- `./bin/openwork-hub run desktop macos-brand-menu-platform-safety -- pnpm --filter @openwork/desktop check:electron` — passed; 56 renderer methods covered
- `./bin/openwork-hub run desktop macos-brand-menu-platform-safety -- pnpm --filter @openwork/desktop test` — passed; 103 tests passed, 1 platform-specific test skipped
- GitHub Actions `openwork-tests` — passed on Ubuntu 22.04 and macOS 14
- GitHub Actions `i18n-audit` — passed

## Risks and remaining checks

- A native Windows runtime was not available locally. Windows behavior is covered through dependency-injected name tests and the existing taskbar/shortcut suite.
- No packaged application build was run.
- This follow-up does not change the macOS branch exercised end to end in #2960.
- Vercel app/Den preview statuses require deployment authorization for the fork; the applicable landing preview passed and diagnostics was skipped as unaffected.
