### PR TITLE
feat(desktop): make bootstrap preservation optional

### DIFF
--- a/apps/app/src/app/lib/desktop-types.ts
+++ b/apps/app/src/app/lib/desktop-types.ts
@@ -25,6 +25,7 @@ export type {
   LocalSkillCard,
   LocalSkillContent,
   NukeManifestPreview,
+  NukeOptions,
   NukeReceipt,
   NukeReceiptError,
   OpencodeCommandDraft,

--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -23,6 +23,7 @@ export type {
   LocalSkillCard,
   LocalSkillContent,
   NukeManifestPreview,
+  NukeOptions,
   NukeReceipt,
   NukeReceiptError,
   OpencodeConfigFile,
@@ -39,6 +40,7 @@ import type {
   DesktopCommandResult,
   EvalRelaunchResult,
   NukeManifestPreview,
+  NukeOptions,
   NukeReceipt,
   WorkspaceList,
 } from "./desktop-types";
@@ -104,8 +106,8 @@ declare global {
         evalRelaunch?: () => Promise<EvalRelaunchResult>;
       };
       nuke?: {
-        preview?: () => Promise<NukeManifestPreview>;
-        execute?: () => Promise<NukeReceipt>;
+        preview?: (options?: NukeOptions) => Promise<NukeManifestPreview>;
+        execute?: (options?: NukeOptions) => Promise<NukeReceipt>;
       };
       updater?: {
         getChannel?: () => Promise<{

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1255,6 +1255,8 @@ export default {
   "settings.no_custom_path_set": "No custom path set",
   "settings.nuke_hint": "Use this only when you want to fully reset the desktop app and its OpenCode runtime state.",
   "settings.nuke_cancel": "Cancel",
+  "settings.nuke_bootstrap_toggle_desc": "Keep {path} to stay connected to the same organization server. Turn this off to remove it too.",
+  "settings.nuke_bootstrap_toggle_label": "Keep bootstrap / organization server",
   "settings.nuke_confirmation_hint": "OpenWork will revoke your cloud session best-effort, wipe local state, then relaunch.",
   "settings.nuke_confirmation_label": "Type NUKE to confirm",
   "settings.nuke_confirmation_placeholder": "Type NUKE",

--- a/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/debug-view.tsx
@@ -35,6 +35,7 @@ import {
   AlertDialogTitle,
 } from "@/components/ui/alert-dialog";
 import { Button } from "@/components/ui/button";
+import { Switch } from "@/components/ui/switch";
 import {
   AgentContextDiagnosticsSection,
   type AgentContextDiagnosticsSectionProps,
@@ -175,10 +176,12 @@ export type DebugViewProps = {
   nukePreviewBusy: boolean;
   nukeDialogOpen: boolean;
   nukeConfirmationText: string;
+  nukePreserveBootstrap: boolean;
   nukeManifestPreview: NukeManifestPreview | null;
   onOpenNukeDialog: () => void | Promise<void>;
   onCloseNukeDialog: () => void;
   onSetNukeConfirmationText: (value: string) => void;
+  onSetNukePreserveBootstrap: (value: boolean) => void | Promise<void>;
   onConfirmNukeOpenworkAndOpencodeConfig: () => void | Promise<void>;
 };
 
@@ -469,7 +472,9 @@ export function DebugView(props: DebugViewProps) {
     : props.anyActiveRuns
       ? t("settings.sandbox_stop_runs_hint")
       : "";
-  const canConfirmNuke = props.nukeConfirmationText.trim().toUpperCase() === "NUKE" && !props.nukeConfigBusy;
+  const canConfirmNuke = props.nukeConfirmationText.trim().toUpperCase() === "NUKE"
+    && !props.nukeConfigBusy
+    && !props.nukePreviewBusy;
   const nukeDeletePaths = props.nukeManifestPreview?.deletePaths ?? [];
   const nukePartitions = props.nukeManifestPreview?.partitions.join(", ") || "default";
 
@@ -1268,13 +1273,13 @@ export function DebugView(props: DebugViewProps) {
         if (!open) props.onCloseNukeDialog();
       }}
     >
-      <AlertDialogContent className="w-full max-w-2xl overflow-hidden sm:max-w-2xl">
+      <AlertDialogContent className="grid max-h-[calc(100dvh-2rem)] w-full max-w-2xl grid-rows-[auto_minmax(0,1fr)_auto] overflow-hidden sm:max-w-2xl">
         <AlertDialogHeader>
           <AlertDialogTitle>{t("settings.nuke_dialog_title")}</AlertDialogTitle>
           <AlertDialogDescription>{t("settings.nuke_dialog_desc")}</AlertDialogDescription>
         </AlertDialogHeader>
 
-        <div className="space-y-4 text-sm">
+        <div className="space-y-4 overflow-y-auto pr-1 text-sm">
           <div className="rounded-xl border border-red-7/30 bg-red-3/10 p-3">
             <div className="mb-2 text-[12px] font-semibold uppercase tracking-wider text-red-11">
               {t("settings.nuke_deleted_title")}
@@ -1302,14 +1307,35 @@ export function DebugView(props: DebugViewProps) {
               {t("settings.nuke_survives_title")}
             </div>
             <ul className="list-disc space-y-1 pl-5 text-[12px] text-dls-secondary">
-              <li>
-                {t("settings.nuke_survives_bootstrap", {
-                  path: props.nukeManifestPreview?.preserveBootstrapPath ?? t("settings.nuke_no_bootstrap_path"),
-                })}
-              </li>
+              {props.nukePreserveBootstrap ? (
+                <li>
+                  {t("settings.nuke_survives_bootstrap", {
+                    path: props.nukeManifestPreview?.bootstrapPath ?? t("settings.nuke_no_bootstrap_path"),
+                  })}
+                </li>
+              ) : null}
               <li>{t("settings.nuke_survives_app")}</li>
               <li>{t("settings.nuke_survives_workspaces")}</li>
             </ul>
+          </div>
+
+          <div className="flex items-center justify-between gap-4 rounded-xl border border-dls-border bg-dls-surface p-3">
+            <div className="min-w-0">
+              <div className="text-[13px] font-medium text-dls-text">
+                {t("settings.nuke_bootstrap_toggle_label")}
+              </div>
+              <div className="mt-1 break-all text-[11px] text-dls-secondary">
+                {t("settings.nuke_bootstrap_toggle_desc", {
+                  path: props.nukeManifestPreview?.bootstrapPath ?? t("settings.nuke_no_bootstrap_path"),
+                })}
+              </div>
+            </div>
+            <Switch
+              checked={props.nukePreserveBootstrap}
+              disabled={props.nukeConfigBusy || props.nukePreviewBusy}
+              onCheckedChange={(checked) => void props.onSetNukePreserveBootstrap(checked)}
+              aria-label={t("settings.nuke_bootstrap_toggle_label")}
+            />
           </div>
 
           <label className="block">
@@ -1321,7 +1347,7 @@ export function DebugView(props: DebugViewProps) {
               value={props.nukeConfirmationText}
               placeholder={t("settings.nuke_confirmation_placeholder")}
               onChange={(event) => props.onSetNukeConfirmationText(event.currentTarget.value)}
-              disabled={props.nukeConfigBusy}
+              disabled={props.nukeConfigBusy || props.nukePreviewBusy}
               className="w-full rounded-xl border border-dls-border bg-dls-surface px-4 py-3 text-[14px] text-dls-text placeholder:text-dls-secondary focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.12)] disabled:cursor-not-allowed disabled:opacity-60"
             />
             <span className="mt-1.5 block text-[11px] text-dls-secondary">

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -299,6 +299,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
   const [nukePreviewBusy, setNukePreviewBusy] = useState(false);
   const [nukeDialogOpen, setNukeDialogOpen] = useState(false);
   const [nukeConfirmationText, setNukeConfirmationText] = useState("");
+  const [nukePreserveBootstrap, setNukePreserveBootstrap] = useState(true);
   const [nukeManifestPreview, setNukeManifestPreview] = useState<NukeManifestPreview | null>(null);
   const [engineSource, setEngineSourceState] = useState<"path" | "sidecar" | "custom">(readEngineSource);
   const [engineCustomBinPath, setEngineCustomBinPath] = useState<string>(() =>
@@ -969,9 +970,10 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
     setNukePreviewBusy(true);
     setNukeConfigStatus(null);
     try {
-      const preview = await nukeOpenworkAndOpencodeConfigPreview();
+      const preview = await nukeOpenworkAndOpencodeConfigPreview({ preserveBootstrap: true });
       setNukeManifestPreview(preview);
       setNukeConfirmationText("");
+      setNukePreserveBootstrap(true);
       setNukeDialogOpen(true);
     } catch (error) {
       setNukeConfigStatus(error instanceof Error ? error.message : safeStringify(error));
@@ -979,6 +981,22 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       setNukePreviewBusy(false);
     }
   }, []);
+
+  const onSetNukePreserveBootstrap = useCallback(async (preserveBootstrap: boolean) => {
+    if (nukeConfigBusy || nukePreviewBusy) return;
+    setNukePreserveBootstrap(preserveBootstrap);
+    setNukePreviewBusy(true);
+    setNukeConfigStatus(null);
+    try {
+      const preview = await nukeOpenworkAndOpencodeConfigPreview({ preserveBootstrap });
+      setNukeManifestPreview(preview);
+    } catch (error) {
+      setNukePreserveBootstrap(!preserveBootstrap);
+      setNukeConfigStatus(error instanceof Error ? error.message : safeStringify(error));
+    } finally {
+      setNukePreviewBusy(false);
+    }
+  }, [nukeConfigBusy, nukePreviewBusy]);
 
   const onCloseNukeDialog = useCallback(() => {
     if (nukeConfigBusy) return;
@@ -991,7 +1009,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
     setNukeConfigStatus(null);
     try {
       await revokeDenSessionBeforeNuke();
-      await nukeOpenworkAndOpencodeConfigAndExit();
+      await nukeOpenworkAndOpencodeConfigAndExit({ preserveBootstrap: nukePreserveBootstrap });
     } catch (error) {
       setNukeConfigStatus(error instanceof Error ? error.message : safeStringify(error));
       setNukeConfigBusy(false);
@@ -999,7 +1017,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
     } finally {
       setNukeDialogOpen(false);
     }
-  }, [nukeConfirmationText]);
+  }, [nukeConfirmationText, nukePreserveBootstrap]);
 
   const [workspaceDebugEventsStatus, setWorkspaceDebugEventsStatus] = useState<string | null>(null);
   const onClearWorkspaceDebugEvents = useCallback(async () => {
@@ -1103,10 +1121,12 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       nukePreviewBusy,
       nukeDialogOpen,
       nukeConfirmationText,
+      nukePreserveBootstrap,
       nukeManifestPreview,
       onOpenNukeDialog,
       onCloseNukeDialog,
       onSetNukeConfirmationText: setNukeConfirmationText,
+      onSetNukePreserveBootstrap,
       onConfirmNukeOpenworkAndOpencodeConfig,
     }),
     [
@@ -1132,11 +1152,13 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       nukeConfirmationText,
       nukeDialogOpen,
       nukeManifestPreview,
+      nukePreserveBootstrap,
       nukePreviewBusy,
       onClearDeveloperLog,
       onClearEngineCustomBinPath,
       onClearWorkspaceDebugEvents,
       onCloseNukeDialog,
+      onSetNukePreserveBootstrap,
       onCopyDeveloperLog,
       onCopyRuntimeDebugReport,
       onExportDeveloperLog,

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1720,6 +1720,7 @@ const desktopCommandHandlers = {
         env: process.env,
         homedir: os.homedir(),
         platform: process.platform,
+        preserveBootstrap: args[0]?.preserveBootstrap !== false,
         userDataPath: app.getPath("userData"),
       });
   },
@@ -1730,7 +1731,7 @@ const desktopCommandHandlers = {
         runtimeManager,
         uiControlServer,
         removeWindowsBrandShortcut,
-      });
+      }, { preserveBootstrap: args[0]?.preserveBootstrap !== false });
   },
   "orchestratorStartDetached": async (event, ...args) => {
       return runtimeManager.orchestratorStartDetached(args[0] ?? {});

--- a/apps/desktop/electron/nuke-worker.mjs
+++ b/apps/desktop/electron/nuke-worker.mjs
@@ -68,6 +68,7 @@ export function validateNukeWorkerPayload(value) {
       env: nukeInput.env && typeof nukeInput.env === "object" && !Array.isArray(nukeInput.env) ? nukeInput.env : {},
       homedir,
       platform,
+      preserveBootstrap: nukeInput.preserveBootstrap !== false,
       userDataPath,
     },
     appExecutablePath,

--- a/apps/desktop/electron/nuke.mjs
+++ b/apps/desktop/electron/nuke.mjs
@@ -239,7 +239,8 @@ function addOpenworkConfigFiles(deletePaths, roots, paths) {
 function resolveNukePlan(input) {
   const resolved = resolveNukeEnvironment(input);
   const { env, homedir, platform, paths, userDataPath } = resolved;
-  const preserveBootstrapPath = desktopBootstrapPath(env, homedir, platform, paths, userDataPath);
+  const bootstrapPath = desktopBootstrapPath(env, homedir, platform, paths, userDataPath);
+  const preserveBootstrapPath = input.preserveBootstrap === false ? null : bootstrapPath;
   const legacyBootstrapPath = legacyDesktopBootstrapPath(homedir, paths);
   const serverConfig = openworkServerConfigPath(env, homedir, platform, paths);
   const runtimeDb = runtimeDbPath(env, serverConfig, homedir, paths);
@@ -256,6 +257,7 @@ function resolveNukePlan(input) {
     runtimeConfig,
     tokens,
     envStore,
+    bootstrapPath,
     legacyBootstrapPath,
     ...dataDirs,
     ...opencodeDbOverridePaths(env, dataDirs, paths),
@@ -283,6 +285,7 @@ function resolveNukePlan(input) {
   );
   const manifest = {
     deletePaths: uniquePaths(filteredDeletePaths, paths, platform),
+    bootstrapPath,
     preserveBootstrapPath: preserveBootstrapPath || null,
     partitions: [...NUKE_PARTITIONS],
   };
@@ -292,7 +295,7 @@ function resolveNukePlan(input) {
     manifest,
     pendingPath,
     preservePaths: uniquePaths([preserveBootstrapPath, paths.join(homedir, ".opencode", "bin")], paths, platform),
-    legacyBootstrapPath: paths.resolve(legacyBootstrapPath) === paths.resolve(preserveBootstrapPath) ? null : legacyBootstrapPath,
+    legacyBootstrapPath: paths.resolve(legacyBootstrapPath) === paths.resolve(bootstrapPath) ? null : legacyBootstrapPath,
     platform,
   };
 }
@@ -311,6 +314,7 @@ export function buildNukeWorkerNukeInput(input) {
     env,
     homedir: String(input.homedir ?? ""),
     platform: normalizePlatform(input.platform),
+    preserveBootstrap: input.preserveBootstrap !== false,
     userDataPath: String(input.userDataPath ?? ""),
   };
 }
@@ -598,6 +602,9 @@ async function writePendingNukeFile(pendingPath, paths, pending = null, options 
   const attemptedAt = nukeNowIso(options);
   await writeJsonFile(pendingPath, {
     paths,
+    preserveBootstrap: typeof pending?.preserveBootstrap === "boolean"
+      ? pending.preserveBootstrap
+      : options.preserveBootstrap !== false,
     createdAt: pendingCreatedAt(pending, attemptedAt),
     attemptedAt,
   });
@@ -664,14 +671,15 @@ function preservePathsWithoutBootstrap(plan) {
 }
 
 export async function runPendingNukeCleanup(input, options = {}) {
-  const plan = resolveNukePlan(input);
-  const pendingFile = await readJsonIfPresent(plan.pendingPath);
+  const initialPlan = resolveNukePlan(input);
+  const pendingFile = await readJsonIfPresent(initialPlan.pendingPath);
   if (!pendingFile.exists) return pendingCleanupResult({ ran: false });
   if (!pendingFile.ok) {
-    await rm(plan.pendingPath, { force: true });
+    await rm(initialPlan.pendingPath, { force: true });
     return pendingCleanupResult({ ran: false, invalid: true });
   }
   const pending = pendingFile.ok ? pendingFile.value : null;
+  const plan = resolveNukePlan({ ...input, preserveBootstrap: pending?.preserveBootstrap !== false });
   const paths = Array.isArray(pending?.paths)
     ? pending.paths.filter((entry) => typeof entry === "string" && entry.trim()).map((entry) => entry.trim())
     : [];
@@ -694,11 +702,14 @@ export async function runPendingNukeCleanup(input, options = {}) {
 
 /** @returns {Promise<import("@openwork/types/desktop-ipc").NukeReceipt>} */
 export async function executeNukeFreshStart({ app, session, runtimeManager, uiControlServer, removeWindowsBrandShortcut }, options = {}) {
-  const input = options.input ?? {
-    env: process.env,
-    homedir: os.homedir(),
-    platform: process.platform,
-    userDataPath: app.getPath("userData"),
+  const input = {
+    ...(options.input ?? {
+      env: process.env,
+      homedir: os.homedir(),
+      platform: process.platform,
+      userDataPath: app.getPath("userData"),
+    }),
+    preserveBootstrap: options.preserveBootstrap ?? options.input?.preserveBootstrap ?? true,
   };
   const plan = resolveNukePlan(input);
   const phaseErrors = [];
@@ -715,7 +726,9 @@ export async function executeNukeFreshStart({ app, session, runtimeManager, uiCo
   const deletionErrors = await deleteManifestPaths(plan.manifest, plan.platform, preservePaths, options);
   const verified = await verifyManifestDeletion(plan.manifest, [...phaseErrors, ...deletionErrors], preservePaths);
   if (verified.pendingRetry.length > 0) {
-    await writePendingNukeFile(plan.pendingPath, verified.pendingRetry).catch((error) => {
+    await writePendingNukeFile(plan.pendingPath, verified.pendingRetry, null, {
+      preserveBootstrap: input.preserveBootstrap,
+    }).catch((error) => {
       verified.errors.push(receiptError(plan.pendingPath, error));
     });
   }

--- a/apps/desktop/electron/nuke.test.mjs
+++ b/apps/desktop/electron/nuke.test.mjs
@@ -109,6 +109,7 @@ test("buildNukeManifest includes default macOS state roots and preserves bootstr
   const userDataPath = "/Users/alice/Library/Application Support/com.differentai.openwork";
   const manifest = buildNukeManifest({ env: {}, homedir: home, platform: "darwin", userDataPath });
 
+  assert.equal(manifest.bootstrapPath, "/Users/alice/.config/openwork/desktop-bootstrap.json");
   assert.equal(manifest.preserveBootstrapPath, "/Users/alice/.config/openwork/desktop-bootstrap.json");
   assert.deepEqual(manifest.partitions, ["default", "persist:openwork-browser"]);
   assert.ok(manifest.deletePaths.includes(userDataPath));
@@ -126,6 +127,21 @@ test("buildNukeManifest includes default macOS state roots and preserves bootstr
   assert.ok(manifest.deletePaths.includes("/Users/alice/.openwork/openwork-orchestrator"));
   assert.ok(!manifest.deletePaths.includes("/Users/alice/.opencode/bin"));
   assert.ok(!manifest.deletePaths.includes("/Users/alice/project/.opencode"));
+});
+
+test("buildNukeManifest can include the bootstrap file in the wipe", () => {
+  const bootstrapPath = "/Users/alice/.config/openwork/desktop-bootstrap.json";
+  const manifest = buildNukeManifest({
+    env: {},
+    homedir: "/Users/alice",
+    platform: "darwin",
+    preserveBootstrap: false,
+    userDataPath: "/Users/alice/Library/Application Support/com.differentai.openwork",
+  });
+
+  assert.equal(manifest.bootstrapPath, bootstrapPath);
+  assert.equal(manifest.preserveBootstrapPath, null);
+  assert.ok(manifest.deletePaths.includes(bootstrapPath));
 });
 
 test("buildNukeManifest includes default Linux state roots", () => {
@@ -318,6 +334,24 @@ test("runPendingNukeCleanup removes the sentinel after all pending paths are gon
   });
 });
 
+test("runPendingNukeCleanup retains the choice to remove bootstrap state", async () => {
+  await withTempDir(async (root) => {
+    const input = pendingNukeInput(root);
+    const bootstrapPath = path.join(input.env.XDG_CONFIG_HOME, "openwork", "desktop-bootstrap.json");
+    await mkdir(path.dirname(bootstrapPath), { recursive: true });
+    await writeFile(bootstrapPath, JSON.stringify({ baseUrl: "https://den.example.com" }), "utf8");
+    await writePendingNuke(root, {
+      paths: [bootstrapPath],
+      preserveBootstrap: false,
+    });
+
+    const result = await runPendingNukeCleanup(input);
+
+    assert.equal(result.ran, true);
+    assert.equal(await exists(bootstrapPath), false);
+  });
+});
+
 test("runPendingNukeCleanup rewrites only failed paths and removes them on the next boot", async () => {
   await withTempDir(async (root) => {
     const okPath = path.join(root, "ok-runtime.sqlite");
@@ -394,6 +428,7 @@ test("nuke worker payload only serializes safe path inputs", () => {
     homedir: "/tmp/home",
     platform: "darwin",
     userDataPath: "/tmp/userData",
+    preserveBootstrap: false,
   });
   const payload = buildNukeWorkerPayload({
     parentPid: 123,
@@ -408,6 +443,7 @@ test("nuke worker payload only serializes safe path inputs", () => {
   assert.equal(payload.nukeInput.env.APPDATA, "C:\\Users\\Alice\\AppData\\Roaming");
   assert.equal(payload.nukeInput.env.XDG_CONFIG_HOME, "/tmp/config");
   assert.equal(payload.nukeInput.env.OPENWORK_TOKEN_STORE, "C:\\Users\\Alice\\AppData\\Roaming\\openwork\\tokens.json");
+  assert.equal(payload.nukeInput.preserveBootstrap, false);
   assert.deepEqual(payload.appArgv, []);
   assert.equal(serialized.includes("secret-api-key"), false);
   assert.equal(serialized.includes("secret-token"), false);
@@ -649,5 +685,28 @@ test("executeNukeFreshStart relaunches directly when no paths remain pending", a
     await tinyDelay();
     assert.equal(app.relaunchCount, 1);
     assert.equal(app.quitCount, 1);
+  });
+});
+
+test("executeNukeFreshStart removes the bootstrap when preservation is disabled", async () => {
+  await withTempDir(async (root) => {
+    const input = { ...pendingNukeInput(root), preserveBootstrap: false };
+    const bootstrapPath = path.join(input.env.XDG_CONFIG_HOME, "openwork", "desktop-bootstrap.json");
+    await mkdir(path.dirname(bootstrapPath), { recursive: true });
+    await writeFile(bootstrapPath, JSON.stringify({ baseUrl: "https://den.example.com" }), "utf8");
+    await mkdir(input.userDataPath, { recursive: true });
+    const app = fakeApp(input.userDataPath);
+
+    const receipt = await executeNukeFreshStart({
+      app,
+      session: fakeSession(),
+      runtimeManager: fakeRuntimeManager(),
+      uiControlServer: fakeUiControlServer(),
+      removeWindowsBrandShortcut: async () => {},
+    }, { input });
+
+    assert.equal(receipt.preservedBootstrap, false);
+    assert.equal(await exists(bootstrapPath), false);
+    await tinyDelay();
   });
 });

--- a/apps/desktop/electron/preload.mjs
+++ b/apps/desktop/electron/preload.mjs
@@ -93,11 +93,11 @@ contextBridge.exposeInMainWorld("__OPENWORK_ELECTRON__", {
     },
   },
   nuke: {
-    preview() {
-      return ipcRenderer.invoke("openwork:desktop", "nukeOpenworkAndOpencodeConfigPreview");
+    preview(options) {
+      return ipcRenderer.invoke("openwork:desktop", "nukeOpenworkAndOpencodeConfigPreview", options);
     },
-    execute() {
-      return ipcRenderer.invoke("openwork:desktop", "nukeOpenworkAndOpencodeConfigAndExit");
+    execute(options) {
+      return ipcRenderer.invoke("openwork:desktop", "nukeOpenworkAndOpencodeConfigAndExit", options);
     },
   },
   updater: {

--- a/evals/flows/debug-nuke-bootstrap-toggle.flow.mjs
+++ b/evals/flows/debug-nuke-bootstrap-toggle.flow.mjs
@@ -1,0 +1,148 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "debug-nuke-bootstrap-toggle";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+if (vo.length !== 2) {
+  throw new Error(`Expected 2 voiceover frames for ${FLOW_ID}, found ${vo.length}.`);
+}
+
+const SWITCH_SELECTOR = '[role="switch"][aria-label="Keep bootstrap / organization server"]';
+
+async function prepareDebugSettings(ctx) {
+  await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+    width: 1440,
+    height: 1000,
+    deviceScaleFactor: 1,
+    mobile: false,
+  });
+  await ctx.waitFor("document.body.innerText.trim().length > 40", {
+    timeoutMs: 60_000,
+    label: "rendered desktop app",
+  });
+  await ctx.eval(`(() => {
+    localStorage.setItem('openwork.developerMode', '1');
+    localStorage.setItem('openwork.preferences', JSON.stringify({ hasCompletedOnboarding: true }));
+    localStorage.setItem('openwork.react.settings.theme-mode', 'light');
+    return true;
+  })()`);
+  await ctx.navigateHash("/settings/debug");
+  await ctx.waitForText("Danger zone", { timeoutMs: 60_000 });
+}
+
+async function openNukeDialog(ctx) {
+  const alreadyOpen = await ctx.eval(`Boolean(document.querySelector(${JSON.stringify(SWITCH_SELECTOR)}))`);
+  if (!alreadyOpen) {
+    await ctx.clickText("Nuke & fresh start");
+  }
+  await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(SWITCH_SELECTOR)}))`, {
+    timeoutMs: 30_000,
+    label: "bootstrap preservation switch",
+  });
+}
+
+async function nukePreviewState(ctx) {
+  return ctx.eval(`(() => {
+    const switchEl = document.querySelector(${JSON.stringify(SWITCH_SELECTOR)});
+    const cardText = (heading) => {
+      const label = [...document.querySelectorAll('div')]
+        .find((element) => element.textContent.trim().toUpperCase() === heading);
+      return label?.parentElement?.innerText ?? '';
+    };
+    return {
+      checked: switchEl?.getAttribute('aria-checked'),
+      deleteText: cardText('WILL DELETE'),
+      surviveText: cardText('WILL SURVIVE'),
+    };
+  })()`);
+}
+
+function recordStateAssertions(ctx, state, preserveBootstrap) {
+  const suffix = "desktop-bootstrap.json";
+  ctx.assert(state.checked === String(preserveBootstrap), `Bootstrap switch state was ${state.checked}.`);
+  ctx.assert(
+    state.surviveText.includes(suffix) === preserveBootstrap,
+    `Will survive bootstrap visibility did not match preserve=${preserveBootstrap}.`,
+  );
+  ctx.assert(
+    state.deleteText.includes(suffix) === !preserveBootstrap,
+    `Will delete bootstrap visibility did not match preserve=${preserveBootstrap}.`,
+  );
+  ctx.recordEvidence({
+    type: "assertion",
+    status: "passed",
+    assertion: preserveBootstrap
+      ? "desktop-bootstrap.json is listed under Will survive and omitted from Will delete"
+      : "desktop-bootstrap.json is listed under Will delete and omitted from Will survive",
+    actual: state,
+  });
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Nuke dialog toggles bootstrap preservation",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "The safe default keeps organization bootstrap",
+      run: async (ctx) => {
+        await prepareDebugSettings(ctx);
+        await ctx.prove("The nuke dialog preserves desktop-bootstrap.json by default", {
+          voiceover: vo[0],
+          action: async () => {
+            await openNukeDialog(ctx);
+          },
+          assert: async () => {
+            recordStateAssertions(ctx, await nukePreviewState(ctx), true);
+            await ctx.expectText("Keep bootstrap / organization server");
+            await ctx.expectText("Type NUKE to confirm");
+          },
+          screenshot: {
+            name: "bootstrap-preserved-by-default",
+            requireText: [
+              "Nuke local state and start fresh?",
+              "WILL SURVIVE",
+              "Keep bootstrap / organization server",
+              "desktop-bootstrap.json",
+              "Type NUKE to confirm",
+            ],
+          },
+        });
+      },
+    },
+    {
+      name: "Turning the switch off moves bootstrap into the delete plan",
+      run: async (ctx) => {
+        await ctx.prove("The user can include desktop-bootstrap.json in the local-state wipe", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.eval(`(() => {
+              const switchEl = document.querySelector(${JSON.stringify(SWITCH_SELECTOR)});
+              if (!switchEl) throw new Error('bootstrap switch not found');
+              switchEl.click();
+              return true;
+            })()`);
+            await ctx.waitFor(
+              `document.querySelector(${JSON.stringify(SWITCH_SELECTOR)})?.getAttribute('aria-checked') === 'false'`,
+              { timeoutMs: 30_000, label: "bootstrap switch to turn off" },
+            );
+          },
+          assert: async () => {
+            recordStateAssertions(ctx, await nukePreviewState(ctx), false);
+            await ctx.expectText("Type NUKE to confirm");
+          },
+          screenshot: {
+            name: "bootstrap-included-in-delete-plan",
+            requireText: [
+              "WILL DELETE",
+              "WILL SURVIVE",
+              "Keep bootstrap / organization server",
+              "desktop-bootstrap.json",
+              "Type NUKE to confirm",
+            ],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/debug-nuke-fresh-start.flow.mjs
+++ b/evals/flows/debug-nuke-fresh-start.flow.mjs
@@ -1106,6 +1106,7 @@ export default {
             await ctx.expectText("This removes local OpenWork, OpenCode, browser, token, runtime, cache, and orchestrator state on this device.");
             await ctx.expectText("WILL DELETE");
             await ctx.expectText("WILL SURVIVE");
+            await ctx.expectText("Keep bootstrap / organization server");
             await ctx.expectText("Type NUKE to confirm");
             await ctx.expectText("Chromium storage cleared: default, persist:openwork-browser");
             await ctx.expectText("Nuke & relaunch");
@@ -1117,6 +1118,7 @@ export default {
               "This removes local OpenWork, OpenCode, browser, token, runtime, cache, and orchestrator state on this device.",
               "WILL DELETE",
               "WILL SURVIVE",
+              "Keep bootstrap / organization server",
               "Type NUKE to confirm",
               "Chromium storage cleared: default, persist:openwork-browser",
               "Nuke & relaunch",

--- a/evals/voiceovers/debug-nuke-bootstrap-toggle.md
+++ b/evals/voiceovers/debug-nuke-bootstrap-toggle.md
@@ -1,0 +1,5 @@
+# debug-nuke-bootstrap-toggle — Choose whether organization bootstrap survives
+
+1. The fresh-start dialog keeps the organization bootstrap by default. The exact desktop-bootstrap.json path appears under Will survive, so the safe existing behavior is explicit before anything destructive can run.
+
+2. One switch changes the plan to a complete local reset. The bootstrap path moves into Will delete and disappears from Will survive, while the typed NUKE confirmation remains required.

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -294,8 +294,13 @@ export type CacheResetResult = {
 
 export type NukeManifestPreview = {
   deletePaths: string[];
+  bootstrapPath: string;
   preserveBootstrapPath: string | null;
   partitions: string[];
+};
+
+export type NukeOptions = {
+  preserveBootstrap: boolean;
 };
 
 export type NukeReceiptError = {
@@ -478,8 +483,8 @@ export type DesktopCommandMap = {
     args: [rawUrl: string];
     result: { ok: true; config: DesktopBootstrapConfig } | ConnectLinkVerifyFailure;
   };
-  nukeOpenworkAndOpencodeConfigPreview: { args: []; result: NukeManifestPreview };
-  nukeOpenworkAndOpencodeConfigAndExit: { args: []; result: NukeReceipt };
+  nukeOpenworkAndOpencodeConfigPreview: { args: [options?: NukeOptions]; result: NukeManifestPreview };
+  nukeOpenworkAndOpencodeConfigAndExit: { args: [options?: NukeOptions]; result: NukeReceipt };
 
   // Sandbox
   sandboxDoctor: { args: []; result: SandboxDoctorResult };


### PR DESCRIPTION
## Summary

- add a default-on toggle to keep the desktop bootstrap / organization server during a local-state nuke
- pass the choice through the shared desktop IPC contract, Electron cleanup plan, worker payload, and pending retry marker
- show the bootstrap path in the preview and keep the dialog usable on shorter screens
- cover removal, worker serialization, deferred cleanup, and the visible toggle states

## Checks

- `pnpm --filter @openwork/desktop exec node --test electron/nuke.test.mjs` — passed (23/23)
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/desktop typecheck:electron` — passed
- `pnpm --filter @openwork/desktop check:electron` — passed (56 renderer methods covered)
- `node --check evals/flows/debug-nuke-fresh-start.flow.mjs` — passed
- `pnpm fraimz --flow debug-nuke-bootstrap-toggle --cdp-url http://127.0.0.1:30223` — passed (2 validated frames plus voice-over coverage)
- `git diff --check` — passed

## Fraimz evidence

- [Hosted frame-by-frame proof](https://openwork-bootstrap-nuke-toggle-evid.vercel.app/)
- Frame 1 proves desktop-bootstrap.json is under Will survive with the switch on by default.
- Frame 2 proves turning the switch off moves desktop-bootstrap.json into Will delete and removes it from Will survive.

## Manual verification

1. In a disposable desktop profile, enable Developer mode and open Settings > Debug > Danger zone > Nuke & fresh start.
2. Verify Keep bootstrap / organization server is on by default and the bootstrap path appears under Will survive.
3. Turn the toggle off and verify the bootstrap path is included in Will delete and no longer appears under Will survive.
4. Type NUKE and relaunch; verify the disposable profile starts fresh and desktop-bootstrap.json was removed.
5. Repeat with the toggle on and verify a valid sanitized desktop-bootstrap.json survives.

## Risks and gaps

- The non-destructive toggle journey is Fraimz-proven on the isolated macOS development app.
- The full destructive packaged-app journey was not rerun. The matching debug-nuke-fresh-start eval requires a remote Windows packaged sandbox and OPENWORK_EVAL_WIN_SANDBOX_ID, OPENWORK_EVAL_CDP_URL, and OPENWORK_EVAL_WIN_PROFILE, which were unavailable.
- Existing callers remain safe because omission defaults to preserving the bootstrap file.