### PR TITLE
feat(mcp): rank capability search lexically

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -14,7 +14,7 @@ import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
 import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
-import { compareCapabilityMatches, SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities, searchCapabilitySourceFilter, type CapabilityMatch } from "./search.js"
+import { SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities, searchCapabilitySourceFilter, type CapabilityMatch } from "./search.js"
 import { executeExternalCapability, externalMcpSearchCoverageHint, parseExternalCapabilityName, resolveMcpMemberIdentity, searchExternalCapabilities, type ExternalCapabilityExecuteResult } from "./external-capabilities.js"
 import { executeMarketplaceCapability, parseMarketplaceCapabilityName, searchMarketplaceCapabilities, type MarketplaceCapabilityObjectType } from "./marketplace-capabilities.js"
 import { executeSkillCapability, parseSkillCapabilityName, searchSkillCapabilities } from "./skill-capabilities.js"
@@ -22,6 +22,7 @@ import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { env } from "../env.js"
 import { isPlatformAdminUserId } from "../middleware/admin.js"
 import { executeAvailableAdminCapability, parseAdminCapabilityName, searchAvailableAdminCapabilities } from "./admin-capabilities.js"
+import { rerankCapabilityMatches } from "./ranking.js"
 
 export const EXECUTE_CAPABILITY_TOOL_NAME = "execute_capability"
 const searchCapabilityTypeSchema = z.enum(["all", "api", "admin", "mcp", "marketplace", "skills"])
@@ -343,11 +344,12 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
       },
       async ({ query, limit, type }) => {
         const boundedLimit = limit ?? 5
+        const sourceCandidateLimit = 20
         const sourceFilter = searchCapabilitySourceFilter(type)
         const marketplaceObjectTypes = type === "skills" ? skillMarketplaceObjectTypes : undefined
-        const restMatches = sourceFilter.api ? searchCapabilities(catalog, query, boundedLimit) : []
+        const restMatches = sourceFilter.api ? searchCapabilities(catalog, query, sourceCandidateLimit) : []
         const adminMatches = sourceFilter.admin
-          ? await searchAvailableAdminCapabilities(await resolvePlatformAdmin(), query, boundedLimit)
+          ? await searchAvailableAdminCapabilities(await resolvePlatformAdmin(), query, sourceCandidateLimit)
           : []
         // Merged in from each connected External MCP Connection's live
         // tools/list (capability-sources/external-mcp-client.ts) — a
@@ -360,7 +362,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
             member: memberIdentity,
             query,
             redirectUriBase: resolvePublicOrigin(c.req.raw, env.apiPublicUrl),
-            limit: boundedLimit,
+            limit: sourceCandidateLimit,
             reportCoverage: (coverage) => {
               externalCoverageHint = externalMcpSearchCoverageHint(coverage)
             },
@@ -372,7 +374,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
             member: memberIdentity,
             objectTypes: marketplaceObjectTypes,
             query,
-            limit: boundedLimit,
+            limit: sourceCandidateLimit,
             enabled: externalMcpConnectionsEnabled,
           })
           : []
@@ -381,12 +383,14 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
             organizationId: principal.organizationId,
             member: memberIdentity,
             query,
-            limit: boundedLimit,
+            limit: sourceCandidateLimit,
           })
           : []
-        const matches = [...restMatches, ...adminMatches, ...externalMatches, ...marketplaceMatches, ...skillMatches]
-          .sort(compareCapabilityMatches)
-          .slice(0, boundedLimit)
+        const matches = rerankCapabilityMatches(
+          query,
+          [...restMatches, ...adminMatches, ...externalMatches, ...marketplaceMatches, ...skillMatches],
+          { limit: boundedLimit },
+        )
         return capabilitySearchToolResult(matches, externalCoverageHint)
       },
     )

--- a/ee/apps/den-api/src/mcp/ranking.ts
+++ b/ee/apps/den-api/src/mcp/ranking.ts
@@ -1,0 +1,321 @@
+import type { CapabilityMatch } from "./search.js"
+
+export type CapabilitySearchText = {
+  name: string
+  summary: string
+  path?: string
+  keywords?: string[]
+}
+
+export type CapabilityCandidate<TMatch extends CapabilityMatch = CapabilityMatch> = {
+  match: TMatch
+  searchText: CapabilitySearchText
+  priority?: boolean
+}
+
+export type QueryConcept = {
+  original: string
+  terms: { factor: number; token: string }[]
+}
+
+const FIELD_WEIGHTS = {
+  nameExact: 5,
+  namePrefix: 3,
+  summaryExact: 2,
+  keywordExact: 2,
+  pathExact: 1,
+}
+
+const MAX_SCORE_PER_CONCEPT = FIELD_WEIGHTS.nameExact
+  + FIELD_WEIGHTS.summaryExact
+  + FIELD_WEIGHTS.keywordExact
+  + FIELD_WEIGHTS.pathExact
+
+const STOPWORD_SOURCE = [
+  "a", "an", "the", "to", "for", "of", "in", "on", "at", "by", "with", "and", "or",
+  "my", "your", "our", "their", "its", "this", "that", "these", "those", "i", "me", "we",
+  "you", "they", "it", "is", "are", "be", "been", "was", "do", "does", "did", "done",
+  "how", "what", "which", "who", "when", "where", "can", "could", "should", "would", "will",
+  "shall", "may", "might", "must", "please", "want", "wants", "need", "needs", "about", "into", "from",
+]
+
+const SYNONYM_GROUP_SOURCE = [
+  ["create", "add", "new", "make", "register", "post"],
+  ["save", "store", "persist", "record", "write", "remember", "post"],
+  ["get", "fetch", "read", "show", "view", "retrieve"],
+  ["list", "enumerate", "browse"],
+  ["update", "edit", "modify", "change", "rename", "set", "patch", "put"],
+  ["delete", "remove", "destroy", "erase", "forget"],
+  ["search", "find", "query", "lookup", "discover"],
+  ["grant", "allow", "authorize", "share", "assign"],
+  ["revoke", "deny", "unshare"],
+  ["connect", "link", "attach", "login", "authenticate"],
+  ["disconnect", "unlink", "detach", "logout"],
+  ["cancel", "abort", "stop"],
+  ["organization", "org", "company", "tenant"],
+  ["member", "user", "person", "people", "teammate"],
+  ["team", "group"],
+  ["role", "permission"],
+  ["invitation", "invite"],
+  ["memory", "note", "fact"],
+  ["skill", "playbook", "guide"],
+  ["worker", "agent", "bot", "machine"],
+  ["credential", "secret", "token", "key"],
+  ["connection", "connector", "integration"],
+  ["config", "configuration", "setting", "preference"],
+  ["plugin", "extension", "addon"],
+  ["llm", "model", "ai"],
+  ["billing", "payment", "subscription", "invoice"],
+  ["repo", "repository", "github"],
+  ["auth", "oauth", "sso"],
+  ["email", "mail", "gmail"],
+  ["heartbeat", "activity", "health"],
+]
+
+const STOPWORDS = new Set(STOPWORD_SOURCE.map((word) => normalizeToken(word)))
+const SYNONYMS = buildSynonyms()
+
+export function tokenizeText(value: string): string[] {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((token) => token.length > 0)
+}
+
+export function normalizeToken(token: string): string {
+  if (token.length < 4 || /\d/.test(token)) return token
+  let normalized = token
+  if (normalized.length >= 5 && normalized.endsWith("ies")) {
+    normalized = applyIfUseful(normalized, `${normalized.slice(0, -3)}y`)
+  }
+  if (normalized.length >= 5 && shouldDropEs(normalized)) {
+    normalized = applyIfUseful(normalized, normalized.slice(0, -2))
+  } else if (
+    normalized.length >= 4
+    && normalized.endsWith("s")
+    && !normalized.endsWith("ss")
+    && !normalized.endsWith("us")
+    && !normalized.endsWith("is")
+  ) {
+    normalized = applyIfUseful(normalized, normalized.slice(0, -1))
+  }
+  if (normalized.length >= 6 && normalized.endsWith("ing")) {
+    normalized = applyIfUseful(normalized, undoubleTrailingConsonant(normalized.slice(0, -3)))
+  } else if (normalized.length >= 5 && normalized.endsWith("ed")) {
+    normalized = applyIfUseful(normalized, undoubleTrailingConsonant(normalized.slice(0, -2)))
+  }
+  if (normalized.endsWith("e")) normalized = applyIfUseful(normalized, normalized.slice(0, -1))
+  return normalized
+}
+
+export function parseQuery(query: string): QueryConcept[] {
+  const concepts: QueryConcept[] = []
+  const seen = new Set<string>()
+  for (const token of tokenizeText(query).map((entry) => normalizeToken(entry))) {
+    if (STOPWORDS.has(token) || seen.has(token)) continue
+    seen.add(token)
+    concepts.push({ original: token, terms: expandTerms(token) })
+    if (concepts.length >= 12) break
+  }
+  return concepts
+}
+
+export function rankCapabilities<TMatch extends CapabilityMatch>(
+  query: string,
+  candidates: CapabilityCandidate<TMatch>[],
+  opts: { limit?: number } = {},
+): TMatch[] {
+  const concepts = parseQuery(query)
+  if (concepts.length === 0 || candidates.length === 0) return []
+
+  const docs = candidates.map((candidate) => ({ candidate, tokens: tokenizeCandidate(candidate.searchText) }))
+  const documentFrequency = buildDocumentFrequency(concepts, docs)
+  const rarityDenominator = concepts.reduce(
+    (total, concept) => total + rarity(concept, documentFrequency, docs.length),
+    0,
+  )
+  if (rarityDenominator === 0) return []
+
+  const ranked = docs
+    .map((doc) => {
+      const score = scoreCandidate(doc.tokens, concepts, documentFrequency, docs.length, rarityDenominator)
+      if (score <= 0) return null
+      return {
+        candidate: doc.candidate,
+        score,
+      }
+    })
+    .filter((entry) => entry !== null)
+    .sort((left, right) => (
+      Number(right.candidate.priority) - Number(left.candidate.priority)
+      || right.score - left.score
+      || right.candidate.match.score - left.candidate.match.score
+      || left.candidate.match.name.localeCompare(right.candidate.match.name)
+    ))
+
+  const aboveFloor = ranked.filter((entry) => entry.score >= 8 || entry.candidate.priority)
+  const visible = aboveFloor.length > 0 ? aboveFloor : ranked.slice(0, 3)
+  return visible.slice(0, boundLimit(opts.limit)).map((entry) => ({
+    ...entry.candidate.match,
+    score: entry.score,
+  }))
+}
+
+export function rerankCapabilityMatches<TMatch extends CapabilityMatch>(
+  query: string,
+  matches: TMatch[],
+  opts: { limit?: number } = {},
+): TMatch[] {
+  return rankCapabilities(query, matches.map((match) => ({
+    match,
+    priority: "kind" in match && match.kind === "connection_status",
+    searchText: {
+      name: match.name,
+      summary: match.summary,
+      path: match.path,
+      keywords: [match.method],
+    },
+  })), opts)
+}
+
+function boundLimit(limit: number | undefined): number {
+  return Math.max(1, Math.min(20, Math.trunc(limit ?? 5) || 5))
+}
+
+function applyIfUseful(original: string, next: string): string {
+  return next.length >= 3 ? next : original
+}
+
+function shouldDropEs(token: string): boolean {
+  return token.endsWith("ses")
+    || token.endsWith("xes")
+    || token.endsWith("zes")
+    || token.endsWith("ches")
+    || token.endsWith("shes")
+    || token.endsWith("oes")
+}
+
+function undoubleTrailingConsonant(token: string): string {
+  if (token.length < 2) return token
+  const last = token.at(-1)
+  if (!last || last !== token.at(-2) || "aeiou".includes(last)) return token
+  return token.slice(0, -1)
+}
+
+function buildSynonyms(): Map<string, string[]> {
+  const synonyms = new Map<string, string[]>()
+  for (const group of SYNONYM_GROUP_SOURCE) {
+    const normalized = [...new Set(group.map((entry) => normalizeToken(entry)))]
+    for (const token of normalized) synonyms.set(token, normalized.filter((entry) => entry !== token))
+  }
+  return synonyms
+}
+
+function expandTerms(token: string): { factor: number; token: string }[] {
+  return [
+    { factor: 1, token },
+    ...(SYNONYMS.get(token) ?? []).map((synonym) => ({ factor: 0.7, token: synonym })),
+  ]
+}
+
+function tokenizeCandidate(searchText: CapabilitySearchText) {
+  const normalize = (value: string) => tokenizeText(value).map((token) => normalizeToken(token))
+  return {
+    name: normalize(searchText.name),
+    summary: normalize(searchText.summary),
+    path: normalize(searchText.path ?? ""),
+    keywords: (searchText.keywords ?? []).flatMap(normalize),
+  }
+}
+
+function buildDocumentFrequency(
+  concepts: QueryConcept[],
+  docs: { tokens: ReturnType<typeof tokenizeCandidate> }[],
+): Map<string, number> {
+  const frequency = new Map<string, number>()
+  for (const concept of concepts) {
+    let count = 0
+    for (const doc of docs) {
+      const tokens = new Set([...doc.tokens.name, ...doc.tokens.summary, ...doc.tokens.path, ...doc.tokens.keywords])
+      if (tokens.has(concept.original)) count += 1
+    }
+    frequency.set(concept.original, count)
+  }
+  return frequency
+}
+
+function rarity(concept: QueryConcept, frequency: Map<string, number>, documentCount: number): number {
+  return Math.max(0.25, 1 - ((frequency.get(concept.original) ?? 0) / documentCount))
+}
+
+function scoreCandidate(
+  tokens: ReturnType<typeof tokenizeCandidate>,
+  concepts: QueryConcept[],
+  frequency: Map<string, number>,
+  documentCount: number,
+  rarityDenominator: number,
+): number {
+  let raw = 0
+  let matched = 0
+  for (const concept of concepts) {
+    const conceptScore = scoreConcept(tokens, concept)
+    if (conceptScore > 0) matched += 1
+    raw += conceptScore * rarity(concept, frequency, documentCount)
+  }
+  if (matched === 0) return 0
+  const coverageFactor = 0.3 + (0.7 * (matched / concepts.length))
+  const bonus = adjacencyBonus(tokens, concepts) * exactNameBonus(tokens.name, concepts)
+  return Math.min(100, Math.round(
+    (100 * raw * coverageFactor * bonus) / (rarityDenominator * MAX_SCORE_PER_CONCEPT),
+  ))
+}
+
+function scoreConcept(tokens: ReturnType<typeof tokenizeCandidate>, concept: QueryConcept): number {
+  let best = 0
+  for (const term of concept.terms) {
+    const directScore = scoreName(tokens.name, term.token)
+      + (tokens.summary.includes(term.token) ? FIELD_WEIGHTS.summaryExact : 0)
+      + (tokens.keywords.includes(term.token) ? FIELD_WEIGHTS.keywordExact : 0)
+      + (tokens.path.includes(term.token) ? FIELD_WEIGHTS.pathExact : 0)
+    best = Math.max(best, directScore * term.factor)
+  }
+  return best
+}
+
+function scoreName(tokens: string[], token: string): number {
+  if (tokens.includes(token)) return FIELD_WEIGHTS.nameExact
+  return tokens.some((entry) => isBidirectionalPrefix(entry, token)) ? FIELD_WEIGHTS.namePrefix : 0
+}
+
+function isBidirectionalPrefix(left: string, right: string): boolean {
+  return left.length >= 3 && right.length >= 3 && (left.startsWith(right) || right.startsWith(left))
+}
+
+function adjacencyBonus(tokens: ReturnType<typeof tokenizeCandidate>, concepts: QueryConcept[]): number {
+  const queryTokens = concepts.map((concept) => concept.original)
+  if (queryTokens.length < 2) return 1
+  if (hasOrderedSubsequence(tokens.name, queryTokens) || hasOrderedSubsequence(tokens.summary, queryTokens)) return 1.25
+  return hasAdjacentPair(tokens.name, queryTokens) || hasAdjacentPair(tokens.summary, queryTokens) ? 1.1 : 1
+}
+
+function exactNameBonus(nameTokens: string[], concepts: QueryConcept[]): number {
+  const queryName = concepts.map((concept) => concept.original).join(" ")
+  return queryName.length > 0 && queryName === nameTokens.join(" ") ? 1.5 : 1
+}
+
+function hasOrderedSubsequence(tokens: string[], queryTokens: string[]): boolean {
+  const docTokens = tokens.filter((token) => !STOPWORDS.has(token))
+  if (queryTokens.length === 0 || queryTokens.length > docTokens.length) return false
+  for (let index = 0; index <= docTokens.length - queryTokens.length; index += 1) {
+    if (queryTokens.every((token, offset) => docTokens[index + offset] === token)) return true
+  }
+  return false
+}
+
+function hasAdjacentPair(tokens: string[], queryTokens: string[]): boolean {
+  for (let index = 0; index < queryTokens.length - 1; index += 1) {
+    if (hasOrderedSubsequence(tokens, [queryTokens[index]!, queryTokens[index + 1]!])) return true
+  }
+  return false
+}

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -1,4 +1,5 @@
 import { getJsonRequestBodySchema, getParameters, hasJsonRequestBody, pathParameterNamesFromTemplate, type McpToolOperation } from "./catalog.js"
+import { rankCapabilities, tokenizeText, type CapabilityCandidate } from "./ranking.js"
 
 /**
  * `search_capabilities` is the "search" half of a search+execute facade laid
@@ -53,10 +54,7 @@ export function searchCapabilitySourceFilter(type?: SearchCapabilityType) {
 }
 
 export function tokenize(value: string): string[] {
-  return value
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter((token) => token.length > 0)
+  return tokenizeText(value)
 }
 
 export function scoreText(
@@ -95,15 +93,36 @@ function summaryFor(operation: McpToolOperation): string {
   return operation.operation.summary ?? operation.operation.description ?? `${operation.method} ${operation.path}`
 }
 
-function scoreOperation(operation: McpToolOperation, queryTokens: string[]): number {
-  if (queryTokens.length === 0) {
-    return 0
-  }
+function legacyOperationScore(operation: McpToolOperation, queryTokens: string[]): number {
+  return scoreText(
+    tokenizeToolName(operation.name),
+    tokenize(summaryFor(operation)),
+    queryTokens,
+    tokenize(operation.path),
+  )
+}
 
-  const nameTokens = tokenizeToolName(operation.name)
-  const summaryTokens = tokenize(summaryFor(operation))
-  const pathTokens = tokenize(operation.path)
-  return scoreText(nameTokens, summaryTokens, queryTokens, pathTokens)
+function capabilityCandidate(operation: McpToolOperation, queryTokens: string[]): CapabilityCandidate {
+  const bodySchema = getJsonRequestBodySchema(operation.operation)
+  return {
+    match: {
+      name: operation.name,
+      method: operation.method,
+      path: operation.path,
+      score: legacyOperationScore(operation, queryTokens),
+      summary: summaryFor(operation),
+      pathParams: pathParameterNamesFromTemplate(operation.path),
+      queryParams: getParameters(operation.operation, "query").map((parameter) => parameter.name as string),
+      hasBody: hasJsonRequestBody(operation.operation),
+      ...(bodySchema === undefined ? {} : { bodySchema }),
+    },
+    searchText: {
+      name: tokenizeToolName(operation.name).join(" "),
+      summary: summaryFor(operation),
+      path: operation.path,
+      keywords: operation.operation.tags ?? [],
+    },
+  }
 }
 
 export function searchCapabilities(
@@ -112,23 +131,5 @@ export function searchCapabilities(
   limit = 5,
 ): CapabilityMatch[] {
   const queryTokens = tokenize(query)
-  const boundedLimit = Math.max(1, Math.min(20, Math.trunc(limit) || 5))
-
-  return catalog
-    .map((operation) => ({
-      name: operation.name,
-      method: operation.method,
-      path: operation.path,
-      score: scoreOperation(operation, queryTokens),
-      summary: summaryFor(operation),
-      pathParams: pathParameterNamesFromTemplate(operation.path),
-      queryParams: getParameters(operation.operation, "query").map((parameter) => parameter.name as string),
-      hasBody: hasJsonRequestBody(operation.operation),
-      ...(getJsonRequestBodySchema(operation.operation) === undefined
-        ? {}
-        : { bodySchema: getJsonRequestBodySchema(operation.operation) }),
-    }))
-    .filter((match) => match.score > 0)
-    .sort(compareCapabilityMatches)
-    .slice(0, boundedLimit)
+  return rankCapabilities(query, catalog.map((operation) => capabilityCandidate(operation, queryTokens)), { limit })
 }

--- a/ee/apps/den-api/test/mcp-capability-ranking.test.ts
+++ b/ee/apps/den-api/test/mcp-capability-ranking.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, test } from "bun:test"
+import {
+  normalizeToken,
+  parseQuery,
+  rankCapabilities,
+  rerankCapabilityMatches,
+  tokenizeText,
+  type CapabilityCandidate,
+} from "../src/mcp/ranking.js"
+import type { CapabilityMatch } from "../src/mcp/search.js"
+
+type CurrentCapabilityMatch = CapabilityMatch & {
+  argumentsSchema?: unknown
+  schemaDigest?: string
+  invocation?: { argumentsField: "body" }
+  kind?: string
+  status?: string
+  connectionStatus?: { action: { label: string } }
+  mcpRequirements?: { serverName: string; state: string }[]
+}
+
+function candidate(input: {
+  name: string
+  searchName?: string
+  summary: string
+  keywords?: string[]
+  method?: string
+}): CapabilityCandidate {
+  return {
+    match: {
+      name: input.name,
+      method: input.method ?? "GET",
+      path: "/v1/example",
+      score: 0,
+      summary: input.summary,
+      pathParams: [],
+      queryParams: [],
+      hasBody: input.name.startsWith("post"),
+    },
+    searchText: {
+      name: input.searchName ?? input.name,
+      summary: input.summary,
+      keywords: input.keywords,
+    },
+  }
+}
+
+const corpus: CapabilityCandidate[] = [
+  candidate({ name: "postMemory", summary: "Save a memory for the current user.", keywords: ["Memory"] }),
+  candidate({ name: "getMemorySearch", summary: "Search memories by semantic text.", keywords: ["Memory"] }),
+  candidate({ name: "getWorkers", summary: "List hosted workers.", keywords: ["Workers"] }),
+  candidate({ name: "postWorkers", summary: "Create a hosted worker.", keywords: ["Workers"] }),
+  candidate({
+    name: "marketplace:memory-keeper",
+    searchName: "Memory keeper",
+    summary: "A skill for remembering customer facts.",
+    keywords: ["skill"],
+  }),
+  candidate({
+    name: "mcp:notion:createPage",
+    searchName: "Notion createPage",
+    summary: "Create a page in Notion.",
+    keywords: ["Notion"],
+    method: "MCP",
+  }),
+  candidate({
+    name: "skill:incident-response",
+    searchName: "Incident response playbook",
+    summary: "Guide responders through a production outage.",
+    keywords: ["skill", "playbook"],
+    method: "SKILL",
+  }),
+  candidate({
+    name: "admin:listOrganizations",
+    searchName: "list organizations",
+    summary: "List organizations for platform support.",
+    keywords: ["admin", "platform"],
+    method: "MCP",
+  }),
+]
+
+describe("capability lexical ranking", () => {
+  test("tokenizes camelCase and normalizes conservative stems", () => {
+    expect(tokenizeText("postMemory")).toEqual(["post", "memory"])
+    expect(tokenizeText("mcp:conn:notion-search")).toEqual(["mcp", "conn", "notion", "search"])
+    expect(normalizeToken("workers")).toBe("worker")
+    expect(normalizeToken("memories")).toBe("memory")
+    expect(normalizeToken("created")).toBe("creat")
+    expect(normalizeToken("setting")).toBe("set")
+    expect(normalizeToken("analysis")).toBe("analysis")
+  })
+
+  test("removes stopwords, deduplicates concepts, and expands synonyms", () => {
+    expect(parseQuery("to the a")).toEqual([])
+    const concepts = parseQuery("please save save a memory")
+    expect(concepts.map((concept) => concept.original)).toEqual(["sav", "memory"])
+    expect(concepts[0]?.terms).toContainEqual({ token: "post", factor: 0.7 })
+  })
+
+  test("closes common capability vocabulary gaps", () => {
+    expect(rankCapabilities("save a memory", corpus)[0]?.name).toBe("postMemory")
+    expect(rankCapabilities("search my memories", corpus)[0]?.name).toBe("getMemorySearch")
+    expect(rankCapabilities("store a note", corpus)[0]?.name).toBe("postMemory")
+    expect(rankCapabilities("production outage playbook", corpus)[0]?.name).toBe("skill:incident-response")
+    expect(rankCapabilities("platform organizations", corpus)[0]?.name).toBe("admin:listOrganizations")
+  })
+
+  test("uses coverage and adjacency to separate list from create", () => {
+    const matches = rankCapabilities("list workers", corpus)
+    expect(matches[0]?.name).toBe("getWorkers")
+    expect(matches.findIndex((match) => match.name === "getWorkers")).toBeLessThan(
+      matches.findIndex((match) => match.name === "postWorkers"),
+    )
+  })
+
+  test("preserves current contracts while globally reranking sources", () => {
+    const bodySchema = { type: "object", required: ["email"] }
+    const argumentsSchema = { type: "object", properties: { channel: { type: "string" } } }
+    const matches: CurrentCapabilityMatch[] = [
+      {
+        name: "postInvitations",
+        method: "POST",
+        path: "/v1/invitations",
+        score: 2,
+        summary: "Invite a member to the organization.",
+        pathParams: [],
+        queryParams: [],
+        hasBody: true,
+        bodySchema,
+      },
+      {
+        name: "mcp:slack:sendMessage",
+        method: "MCP",
+        path: "https://slack.example/mcp",
+        score: 7,
+        summary: "Send a Slack channel message.",
+        pathParams: [],
+        queryParams: [],
+        hasBody: true,
+        argumentsSchema,
+        schemaDigest: `sha256:${"a".repeat(64)}`,
+        invocation: { argumentsField: "body" },
+      },
+      {
+        name: "marketplace:incident-response",
+        method: "PLUGIN",
+        path: "PLUGIN.md",
+        score: 5,
+        summary: "Install the incident response playbook.",
+        pathParams: [],
+        queryParams: [],
+        hasBody: false,
+        mcpRequirements: [{ serverName: "Slack", state: "needs_signin" }],
+      },
+    ]
+
+    expect(rerankCapabilityMatches("invite a teammate", matches)[0]).toEqual(expect.objectContaining({
+      name: "postInvitations",
+      bodySchema,
+    }))
+    expect(rerankCapabilityMatches("send slack message", matches)[0]).toEqual(expect.objectContaining({
+      name: "mcp:slack:sendMessage",
+      argumentsSchema,
+      invocation: { argumentsField: "body" },
+    }))
+    expect(rerankCapabilityMatches("incident playbook", matches)[0]).toEqual(expect.objectContaining({
+      name: "marketplace:incident-response",
+      mcpRequirements: [{ serverName: "Slack", state: "needs_signin" }],
+    }))
+  })
+
+  test("keeps actionable connection status ahead of ordinary matches", () => {
+    const status: CurrentCapabilityMatch = {
+      name: "mcp:linear:*",
+      method: "MCP",
+      path: "https://linear.example/mcp",
+      score: 1,
+      summary: "Linear needs to be connected.",
+      pathParams: [],
+      queryParams: [],
+      hasBody: false,
+      kind: "connection_status",
+      status: "needs_connection",
+      connectionStatus: { action: { label: "Connect Linear" } },
+    }
+    const ordinary: CurrentCapabilityMatch = {
+      name: "mcp:notion:search",
+      method: "MCP",
+      path: "https://notion.example/mcp",
+      score: 20,
+      summary: "Search Notion for Linear project notes.",
+      pathParams: [],
+      queryParams: [],
+      hasBody: true,
+    }
+    expect(rerankCapabilityMatches("linear", [ordinary, status])[0]).toEqual(expect.objectContaining({
+      name: "mcp:linear:*",
+      connectionStatus: { action: { label: "Connect Linear" } },
+    }))
+  })
+
+  test("returns bounded sorted integer scores", () => {
+    const matches = rankCapabilities("memory", corpus, { limit: 100 })
+    expect(matches.length).toBeLessThanOrEqual(20)
+    for (let index = 0; index < matches.length; index += 1) {
+      const score = matches[index]?.score ?? 0
+      expect(Number.isInteger(score)).toBe(true)
+      expect(score).toBeGreaterThan(0)
+      expect(score).toBeLessThanOrEqual(100)
+      if (index > 0) expect(score).toBeLessThanOrEqual(matches[index - 1]?.score ?? 100)
+    }
+  })
+})

--- a/ee/apps/den-api/test/mcp-capability-search.test.ts
+++ b/ee/apps/den-api/test/mcp-capability-search.test.ts
@@ -1,0 +1,34 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+import { readFileSync } from "node:fs"
+
+let buildMcpCatalog: typeof import("../src/mcp/catalog.js")["buildMcpCatalog"]
+let searchCapabilities: typeof import("../src/mcp/search.js")["searchCapabilities"]
+let catalog: ReturnType<typeof buildMcpCatalog>
+
+beforeAll(async () => {
+  buildMcpCatalog = (await import("../src/mcp/catalog.js")).buildMcpCatalog
+  searchCapabilities = (await import("../src/mcp/search.js")).searchCapabilities
+  catalog = buildMcpCatalog(JSON.parse(readFileSync("../../../packages/docs/openapi.json", "utf8")))
+})
+
+function names(query: string, limit = 10): string[] {
+  return searchCapabilities(catalog, query, limit).map((match) => match.name)
+}
+
+describe("MCP capability catalog search", () => {
+  test("pins high-value catalog relevance", () => {
+    expect(names("list workers", 5)[0]).toBe("getWorkers")
+    expect(names("list organization", 5)[0]).toBe("getMeOrgs")
+    expect(names("invite a teammate", 5)).toContain("postInvitations")
+    expect(names("store a note", 5)).toContain("postMemory")
+  })
+
+  test("preserves native request body schemas", () => {
+    const match = searchCapabilities(catalog, "invite a teammate", 5)
+      .find((candidate) => candidate.name === "postInvitations")
+    expect(match).toEqual(expect.objectContaining({
+      hasBody: true,
+      bodySchema: expect.objectContaining({ type: "object" }),
+    }))
+  })
+})


### PR DESCRIPTION
## Summary

- rank capability search results with a dependency-free lexical scorer over the full native catalog
- normalize camelCase, conservative stems, stopwords, synonyms, rarity, coverage, and adjacency
- rerank current REST, admin, external MCP, marketplace, and skill matches without changing their public result contracts
- preserve request and argument schemas, invocation metadata, connection actions, and marketplace requirements

## Why this version

The useful idea from #2573 is preserved, but the implementation is rebuilt on the current capability-search pipeline instead of reviving stale snapshots. Legacy source scores are only a deterministic tie-breaker, and actionable connection status remains ahead of ordinary matches.

## Checks

- `bun test test/google-workspace-capabilities.test.ts test/mcp-capability-ranking.test.ts test/mcp-capability-search.test.ts test/mcp-agent-timeouts.test.ts` — 49 passed
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit -p tsconfig.json`
- `git diff --check`

## Risk and gaps

- lexical relevance is intentionally heuristic and covered by pinned fixtures for high-value queries
- backend-only change; no UI manual journey applies
- full Den API suite was not run in this branch

Supersedes #2573.