### PR TITLE
perf(mcp): cache external tool discovery for search

### DIFF
--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -36,6 +36,7 @@ import {
 } from "./external-mcp-tool-arguments.js"
 import { compareCapabilityMatches, tokenize } from "./search.js"
 import type { CapabilityMatch } from "./search.js"
+import { createExternalMcpSearchCache } from "./external-mcp-search-cache.js"
 
 /**
  * Merges org-level External MCP Connections (capability-sources/) into the
@@ -59,6 +60,18 @@ const EXTERNAL_CAPABILITY_PREFIX = "mcp:"
 export const EXTERNAL_MCP_SEARCH_CONNECTION_LIMIT = 16
 export const EXTERNAL_MCP_SEARCH_CONCURRENCY = 4
 export const EXTERNAL_MCP_SEARCH_MATCH_LIMIT = 20
+export const EXTERNAL_MCP_SEARCH_CACHE_TTL_MS = 60_000
+export const EXTERNAL_MCP_SEARCH_CACHE_MAX_ENTRIES = 256
+export const EXTERNAL_MCP_SEARCH_CACHE_MAX_BYTES = 16 * 1024 * 1024
+
+type ExternalMcpToolList = Awaited<ReturnType<typeof listExternalMcpTools>>
+
+const externalMcpSearchCache = createExternalMcpSearchCache<ExternalMcpToolList>({
+  maxEntries: EXTERNAL_MCP_SEARCH_CACHE_MAX_ENTRIES,
+  maxTotalSize: EXTERNAL_MCP_SEARCH_CACHE_MAX_BYTES,
+  sizeOf: (tools) => new TextEncoder().encode(JSON.stringify(tools)).byteLength,
+  ttlMs: EXTERNAL_MCP_SEARCH_CACHE_TTL_MS,
+})
 
 export function buildExternalCapabilityName(connectionId: string, toolName: string): string {
   return `${EXTERNAL_CAPABILITY_PREFIX}${connectionId}:${toolName}`
@@ -115,6 +128,23 @@ function hasSharedCredential(connection: ExternalMcpConnectionRow): boolean {
 
 function redirectUriFor(redirectUriBase: string, connectionId: string): string {
   return `${redirectUriBase}/v1/mcp-connections/${encodeURIComponent(connectionId)}/connect/callback`
+}
+
+function externalMcpSearchCacheKey(
+  connection: ExternalMcpConnectionRow,
+  member: { orgMembershipId: DenTypeId<"member"> } | undefined,
+  credentialUpdatedAt: Date,
+): string {
+  return [
+    connection.organizationId,
+    connection.id,
+    member?.orgMembershipId ?? "shared",
+    connection.url,
+    connection.authType,
+    connection.credentialMode,
+    connection.updatedAt.toISOString(),
+    credentialUpdatedAt.toISOString(),
+  ].join("\0")
 }
 
 function scoreText(nameTokens: string[], summaryTokens: string[], queryTokens: string[]): number {
@@ -645,6 +675,7 @@ async function probeExternalMcpConnection(input: {
     }
     return matches
   }
+  let credentialUpdatedAt = connection.updatedAt
   if (connection.credentialMode === "per_member") {
     const account = await getConnectedAccount({
       organizationId: connection.organizationId,
@@ -670,6 +701,7 @@ async function probeExternalMcpConnection(input: {
       }
       return matches
     }
+    credentialUpdatedAt = account.updatedAt
   } else if (!hasSharedCredential(connection)) {
     const nameTokens = tokenize(connection.name)
     const score = scoreText(nameTokens, nameTokens, input.queryTokens)
@@ -692,12 +724,15 @@ async function probeExternalMcpConnection(input: {
     : undefined
   let tools: Awaited<ReturnType<typeof listExternalMcpTools>>
   try {
-    tools = await listExternalMcpTools(
-      connection,
-      redirectUriFor(input.redirectUriBase, connection.id),
-      member,
-      undefined,
-      input.deadline,
+    tools = await externalMcpSearchCache.getOrLoad(
+      externalMcpSearchCacheKey(connection, member, credentialUpdatedAt),
+      () => listExternalMcpTools(
+        connection,
+        redirectUriFor(input.redirectUriBase, connection.id),
+        member,
+        undefined,
+        input.deadline,
+      ),
     )
   } catch (error) {
     const message = upstreamErrorMessage(error)

--- a/ee/apps/den-api/src/mcp/external-mcp-search-cache.ts
+++ b/ee/apps/den-api/src/mcp/external-mcp-search-cache.ts
@@ -1,0 +1,83 @@
+export type ExternalMcpSearchCacheOptions<T> = {
+  maxEntries: number
+  maxTotalSize?: number
+  sizeOf?: (value: T) => number
+  ttlMs: number
+  now?: () => number
+}
+
+type CacheEntry<T> = {
+  expiresAt: number
+  size: number
+  value: T
+}
+
+/**
+ * A small process-local cache for search-only MCP tool discovery. It stores
+ * the complete sanitized tool shape, coalesces concurrent misses, never
+ * caches failures, and bounds both lifetime and memory use.
+ */
+export function createExternalMcpSearchCache<T>(options: ExternalMcpSearchCacheOptions<T>) {
+  const maxEntries = Math.max(1, Math.floor(options.maxEntries))
+  const maxTotalSize = Math.max(1, Math.floor(options.maxTotalSize ?? maxEntries))
+  const ttlMs = Math.max(1, Math.floor(options.ttlMs))
+  const now = options.now ?? Date.now
+  const entries = new Map<string, CacheEntry<T>>()
+  const inFlight = new Map<string, Promise<T>>()
+  let totalSize = 0
+
+  function remove(key: string): void {
+    const entry = entries.get(key)
+    if (!entry) return
+    totalSize -= entry.size
+    entries.delete(key)
+  }
+
+  function remember(key: string, value: T): T {
+    let size = 1
+    try {
+      size = Math.max(1, Math.floor(options.sizeOf?.(value) ?? 1))
+    } catch {
+      return value
+    }
+    if (size > maxTotalSize) return value
+    remove(key)
+    entries.set(key, { value, size, expiresAt: now() + ttlMs })
+    totalSize += size
+    while (entries.size > maxEntries || totalSize > maxTotalSize) {
+      const oldestKey = entries.keys().next().value
+      if (oldestKey === undefined) break
+      remove(oldestKey)
+    }
+    return value
+  }
+
+  return {
+    async getOrLoad(key: string, load: () => Promise<T>): Promise<T> {
+      const cached = entries.get(key)
+      if (cached && cached.expiresAt > now()) {
+        entries.delete(key)
+        entries.set(key, cached)
+        return cached.value
+      }
+      remove(key)
+
+      const pending = inFlight.get(key)
+      if (pending) return pending
+
+      const task = load().then((value) => remember(key, value))
+      inFlight.set(key, task)
+      try {
+        return await task
+      } finally {
+        if (inFlight.get(key) === task) inFlight.delete(key)
+      }
+    },
+    size(): number {
+      return entries.size
+    },
+    totalSize(): number {
+      return totalSize
+    },
+  }
+}

--- a/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
+++ b/ee/apps/den-api/test/external-capabilities-search-divergence.test.ts
@@ -32,6 +32,7 @@ type FakeTool = {
 type FakeMcpServer = {
   url: string
   stop: () => void
+  requestCount?: () => number
 }
 
 type MutableSchemaMcpServer = FakeMcpServer & {
@@ -99,6 +100,7 @@ function requestIdFromPayload(payload: unknown): string | number | null {
 
 function startFakeMcpServer(name: string, tools: FakeTool[], requiredBearer?: string): FakeMcpServer {
   const app = new Hono()
+  let requestCount = 0
   app.get("/.well-known/oauth-protected-resource/mcp", (c) => {
     const origin = new URL(c.req.url).origin
     return c.json({
@@ -118,6 +120,7 @@ function startFakeMcpServer(name: string, tools: FakeTool[], requiredBearer?: st
     })
   })
   app.all("/mcp", async (c) => {
+    requestCount += 1
     if (requiredBearer && c.req.header("authorization") !== `Bearer ${requiredBearer}`) {
       const origin = new URL(c.req.url).origin
       return c.json(
@@ -146,6 +149,7 @@ function startFakeMcpServer(name: string, tools: FakeTool[], requiredBearer?: st
   return {
     url: `http://127.0.0.1:${server.port}/mcp`,
     stop: () => server.stop(true),
+    requestCount: () => requestCount,
   }
 }
 
@@ -542,6 +546,49 @@ test("control-healthy: Connections list and search_capabilities both see Slack t
   }
   if (process.env.OPENWORK_EVAL_VERBOSE === "1") {
     console.log("E2E_HEALTHY_DISCOVERY", JSON.stringify({ connectionName: "Slack", toolCount: matches.length, status: "available" }))
+  }
+})
+
+test("repeated search variants reuse the full current external tool catalog", async () => {
+  const server = startFakeMcpServer("search-cache", slackTools)
+  try {
+    if (!server.requestCount) throw new Error("Counting MCP server did not expose requestCount")
+    const seed = await seedOrganization("search-cache")
+    const connection = await createGrantedConnection(seed, {
+      name: "Slack Search Cache",
+      authType: "none",
+      credentialMode: "shared",
+      url: server.url,
+    })
+
+    const coldStartedAt = performance.now()
+    const coldMatches = await search(seed, "slack")
+    const coldMs = performance.now() - coldStartedAt
+    const requestsAfterCold = server.requestCount()
+
+    const warmStartedAt = performance.now()
+    const warmMatches = await search(seed, "slack channel message")
+    const warmMs = performance.now() - warmStartedAt
+    const requestsAfterWarm = server.requestCount()
+
+    expect(requestsAfterCold).toBeGreaterThan(0)
+    expect(requestsAfterWarm).toBe(requestsAfterCold)
+    expect(coldMatches.length).toBeGreaterThan(0)
+    expect(warmMatches.length).toBeGreaterThan(0)
+    expect(warmMatches[0]).toEqual(expect.objectContaining({
+      name: expect.stringContaining(`mcp:${connection.id}:`),
+      argumentsSchema: expect.objectContaining({ type: "object" }),
+      schemaDigest: expect.stringMatching(/^sha256:[a-f0-9]{64}$/),
+      invocation: { argumentsField: "body" },
+    }))
+    console.log("MCP_SEARCH_CACHE_BENCHMARK", JSON.stringify({
+      coldMs: Number(coldMs.toFixed(2)),
+      coldRemoteRequests: requestsAfterCold,
+      warmMs: Number(warmMs.toFixed(2)),
+      warmRemoteRequests: requestsAfterWarm - requestsAfterCold,
+    }))
+  } finally {
+    server.stop()
   }
 })
 

--- a/ee/apps/den-api/test/external-mcp-search-cache.test.ts
+++ b/ee/apps/den-api/test/external-mcp-search-cache.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, test } from "bun:test"
+import { createExternalMcpSearchCache } from "../src/mcp/external-mcp-search-cache.js"
+
+describe("external MCP search cache", () => {
+  test("serves repeated searches without another load", async () => {
+    const cache = createExternalMcpSearchCache<string[]>({ maxEntries: 4, ttlMs: 1_000 })
+    let loads = 0
+    const load = async () => {
+      loads += 1
+      return ["send-message"]
+    }
+
+    expect(await cache.getOrLoad("shared:slack", load)).toEqual(["send-message"])
+    expect(await cache.getOrLoad("shared:slack", load)).toEqual(["send-message"])
+    expect(loads).toBe(1)
+  })
+
+  test("coalesces concurrent misses", async () => {
+    const cache = createExternalMcpSearchCache<string[]>({ maxEntries: 4, ttlMs: 1_000 })
+    let loads = 0
+    let release = () => undefined
+    const blocker = new Promise<void>((resolve) => {
+      release = resolve
+    })
+    const load = async () => {
+      loads += 1
+      await blocker
+      return ["search"]
+    }
+
+    const first = cache.getOrLoad("member:linear", load)
+    const second = cache.getOrLoad("member:linear", load)
+    release()
+    expect(await Promise.all([first, second])).toEqual([["search"], ["search"]])
+    expect(loads).toBe(1)
+  })
+
+  test("expires entries and does not cache failures", async () => {
+    let clock = 0
+    const cache = createExternalMcpSearchCache<number>({ maxEntries: 4, ttlMs: 10, now: () => clock })
+    let loads = 0
+    const load = async () => {
+      loads += 1
+      return loads
+    }
+
+    expect(await cache.getOrLoad("key", load)).toBe(1)
+    clock = 9
+    expect(await cache.getOrLoad("key", load)).toBe(1)
+    clock = 10
+    expect(await cache.getOrLoad("key", load)).toBe(2)
+
+    await expect(cache.getOrLoad("failure", async () => {
+      throw new Error("provider unavailable")
+    })).rejects.toThrow("provider unavailable")
+    expect(await cache.getOrLoad("failure", load)).toBe(3)
+  })
+
+  test("evicts least-recently-used entries at the memory bound", async () => {
+    const cache = createExternalMcpSearchCache<string>({ maxEntries: 2, ttlMs: 1_000 })
+    let loads = 0
+    const load = async (value: string) => {
+      loads += 1
+      return value
+    }
+
+    await cache.getOrLoad("a", () => load("a"))
+    await cache.getOrLoad("b", () => load("b"))
+    await cache.getOrLoad("a", () => load("unused"))
+    await cache.getOrLoad("c", () => load("c"))
+    expect(cache.size()).toBe(2)
+    expect(await cache.getOrLoad("b", () => load("b-reloaded"))).toBe("b-reloaded")
+    expect(loads).toBe(4)
+  })
+
+  test("bounds total retained catalog size and skips oversized values", async () => {
+    const cache = createExternalMcpSearchCache<string>({
+      maxEntries: 10,
+      maxTotalSize: 5,
+      sizeOf: (value) => value.length,
+      ttlMs: 1_000,
+    })
+
+    await cache.getOrLoad("a", async () => "aaa")
+    await cache.getOrLoad("b", async () => "bb")
+    await cache.getOrLoad("c", async () => "cccc")
+    expect(cache.size()).toBe(1)
+    expect(cache.totalSize()).toBe(4)
+
+    await cache.getOrLoad("oversized", async () => "123456")
+    expect(cache.size()).toBe(1)
+    expect(cache.totalSize()).toBe(4)
+  })
+})


### PR DESCRIPTION
## Summary

- add a 60-second process-local cache for external MCP tool discovery used by search
- coalesce concurrent misses and avoid caching failures
- retain complete sanitized tool schemas so argumentsSchema, schemaDigest, and invocation metadata stay current
- key entries by organization, connection, principal, endpoint, auth and credential mode, connection version, and connected-account version
- bound retention to 256 entries and 16 MiB with LRU eviction; oversized catalogs are not retained

## Why this version

The useful latency goal from #2570 is preserved without reviving its large persisted-manifest migration. Authorization and credential checks remain live, execution still performs live schema discovery, and only search discovery is cached.

## Checks

- `bun test test/external-mcp-search-cache.test.ts` — 5 passed
- focused integration: repeated search variants reuse the full current external tool catalog — 1 passed
- benchmark fixture: cold 20.38 ms / 4 remote requests; warm 2.79 ms / 0 remote requests
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit -p tsconfig.json`
- `git diff --check`

## Risk and gaps

- cache lifetime is process-local, so cold starts still discover tools remotely
- the benchmark is a deterministic local fixture, not a production latency claim
- backend-only change; no UI manual journey applies
- full Den API suite was not run in this branch

Supersedes #2570.