### PR TITLE
fix(app): align code blocks with chat theme

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -204,6 +204,26 @@ body {
   -moz-osx-font-smoothing: grayscale;
 }
 
+.markdown-content [data-openwork-code-block] pre {
+  margin: 0;
+  background: transparent !important;
+}
+
+.markdown-content [data-openwork-code-block] .shiki {
+  background: transparent !important;
+}
+
+:is(.dark, [data-theme="dark"]) .markdown-content [data-openwork-code-block] .shiki,
+:is(.dark, [data-theme="dark"]) .markdown-content [data-openwork-code-block] .shiki span {
+  color: var(--shiki-dark) !important;
+}
+
+:is(.dark, [data-theme="dark"]) .markdown-content [data-openwork-code-block] .shiki span {
+  font-style: var(--shiki-dark-font-style) !important;
+  font-weight: var(--shiki-dark-font-weight) !important;
+  text-decoration: var(--shiki-dark-text-decoration) !important;
+}
+
 .ow-soft-shell {
   border: 1px solid var(--dls-border);
   background: var(--dls-surface);

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { memo, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { motion } from "motion/react";
 import DOMPurify from "dompurify";
 import { Marked, type Tokens } from "marked";
@@ -145,6 +145,37 @@ function createEmojiAliases() {
 
 const emojiAliases = createEmojiAliases();
 const MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT = 100;
+const CODE_COPY_RESET_DELAY_MS = 2000;
+const CODE_COPY_ICON = `<svg data-openwork-code-copy-icon="" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-3.5 w-3.5" aria-hidden="true"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
+const CODE_COPIED_ICON = `<svg data-openwork-code-copy-check-icon="" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-3.5 w-3.5" aria-hidden="true" hidden><path d="M20 6 9 17l-5-5"/></svg>`;
+
+function codeCopyButton() {
+  return `<button type="button" data-openwork-code-copy="" class="absolute right-2 top-2 z-10 inline-flex h-7 w-7 items-center justify-center rounded-md border border-border/70 bg-background/95 text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring" aria-label="Copy code block" title="Copy code block">${CODE_COPY_ICON}${CODE_COPIED_ICON}<span data-openwork-code-copy-label="" class="sr-only" aria-live="polite">Copy code block</span></button>`;
+}
+
+function codeBlockContainer(html: string, shiki: boolean) {
+  const shikiAttribute = shiki ? ` data-openwork-shiki="true"` : "";
+
+  return `<div data-openwork-code-block=""${shikiAttribute} class="relative my-4 overflow-hidden rounded-[18px] border border-border/70 bg-gray-2/60 font-mono text-xs leading-6 text-foreground">${codeCopyButton()}${html}</div>`;
+}
+
+function codeBlockHtml(text: string, lang: string | undefined) {
+  return codeBlockContainer(
+    `<pre class="overflow-x-auto px-4 pb-3 pt-11"><code${codeLanguageClass(lang)}>${escapeHtml(text)}</code></pre>`,
+    false,
+  );
+}
+
+function setCodeCopyButtonState(button: HTMLButtonElement, copied: boolean) {
+  const label = button.querySelector("[data-openwork-code-copy-label]");
+  if (label) label.textContent = copied ? "Code block copied" : "Copy code block";
+
+  button.querySelector("[data-openwork-code-copy-icon]")?.toggleAttribute("hidden", copied);
+  button.querySelector("[data-openwork-code-copy-check-icon]")?.toggleAttribute("hidden", !copied);
+
+  button.title = copied ? "Copied" : "Copy code block";
+  button.setAttribute("aria-label", copied ? "Code block copied" : "Copy code block");
+}
 
 function parseShikiLanguage(lang: string) {
   const normalized = lang.trim().split(/\s+/)[0]?.toLowerCase() ?? "";
@@ -191,10 +222,19 @@ function syncMarkdownImagePreviews(root: HTMLElement) {
 }
 
 function sanitizeMarkdownHtml(value: string) {
+  if (typeof DOMPurify.sanitize !== "function") {
+    return value;
+  }
+
   return DOMPurify.sanitize(value, {
     ADD_ATTR: [
       "checked",
       "class",
+      "data-openwork-code-block",
+      "data-openwork-code-copy",
+      "data-openwork-code-copy-check-icon",
+      "data-openwork-code-copy-icon",
+      "data-openwork-code-copy-label",
       "data-openwork-image-preview",
       "data-openwork-image-toggle",
       "data-openwork-image-toggle-label",
@@ -258,7 +298,7 @@ const baseMarkedOptions = {
       return `<blockquote class="my-4 rounded-r-lg border-l border-border bg-muted/40 pl-4 italic text-muted-foreground">${this.parser.parse(tokens)}</blockquote>`;
     },
     code({ text, lang }) {
-      return `<pre class="my-4 overflow-x-auto rounded-[18px] border border-border/70 bg-gray-1/80 px-4 py-3 text-xs leading-6 text-muted-foreground"><code${codeLanguageClass(lang)}>${escapeHtml(text)}</code></pre>`;
+      return codeBlockHtml(text, lang);
     },
     codespan({ text }) {
       return `<code class="rounded-md bg-gray-2/70 px-1.5 py-0.5 font-mono text-sm text-foreground">${escapeHtml(text)}</code>`;
@@ -340,7 +380,10 @@ const highlightedMarkdownParser = new Marked({
       return codeToHtml(code, {
         lang: language,
         meta: { __raw: props.join(" ") },
-        theme: "github-light",
+        themes: {
+          light: "github-light",
+          dark: "github-dark",
+        },
         transformers: [
           transformerNotationDiff({ matchAlgorithm: "v3" }),
           transformerNotationHighlight({ matchAlgorithm: "v3" }),
@@ -352,9 +395,22 @@ const highlightedMarkdownParser = new Marked({
         ],
       });
     },
-    container: `<div data-openwork-shiki="true" class="my-4 overflow-x-auto rounded-lg border border-border/70 bg-gray-1/80 p-4 text-xs leading-6">%s</div>`,
+    container: codeBlockContainer(`<div class="overflow-x-auto px-4 pb-3 pt-11">%s</div>`, true),
   }),
 );
+
+export function renderMarkdownHtml(text: string) {
+  if (!text.trim()) {
+    return "";
+  }
+
+  return sanitizeMarkdownHtml(markdownParser.parse(text, { async: false }));
+}
+
+export async function renderHighlightedMarkdownHtml(text: string) {
+  const html = await highlightedMarkdownParser.parse(text, { async: true });
+  return sanitizeMarkdownHtml(html);
+}
 
 type MarkdownBlockInnerProps = {
   className?: string;
@@ -374,15 +430,45 @@ function MarkdownBlockInner({
   ...props
 }: MarkdownBlockInnerProps) {
   const rootRef = useRef<HTMLDivElement>(null);
+  const codeCopyResetTimers = useRef(new Map<HTMLButtonElement, number>());
   const { openTargets, onOpenTarget } = useOpenTargets();
   const [linkMenu, setLinkMenu] = useState<{ target: OpenTarget; rect: DOMRect } | null>(null);
   const syncHtml = useMemo(() => {
-    if (!text.trim()) {
-      return "";
-    }
-    return sanitizeMarkdownHtml(markdownParser.parse(text, { async: false }));
+    return renderMarkdownHtml(text);
   }, [text]);
   const [highlightedHtml, setHighlightedHtml] = useState<{ text: string; html: string } | null>(null);
+
+  const handleCodeBlockCopy = useCallback(async (button: HTMLButtonElement, code: string) => {
+    try {
+      await navigator.clipboard.writeText(code);
+    } catch {
+      return;
+    }
+
+    const previousTimer = codeCopyResetTimers.current.get(button);
+    if (previousTimer !== undefined) {
+      window.clearTimeout(previousTimer);
+    }
+
+    setCodeCopyButtonState(button, true);
+
+    const resetTimer = window.setTimeout(() => {
+      setCodeCopyButtonState(button, false);
+      codeCopyResetTimers.current.delete(button);
+    }, CODE_COPY_RESET_DELAY_MS);
+    codeCopyResetTimers.current.set(button, resetTimer);
+  }, []);
+
+  useEffect(() => {
+    const timers = codeCopyResetTimers.current;
+
+    return () => {
+      for (const timer of timers.values()) {
+        window.clearTimeout(timer);
+      }
+      timers.clear();
+    };
+  }, []);
 
   useEffect(() => {
     if (streaming || !hasFencedCodeBlock(text)) {
@@ -391,11 +477,9 @@ function MarkdownBlockInner({
     }
 
     let cancelled = false;
-    void highlightedMarkdownParser.parse(text, { async: true }).then((html) => {
-      const sanitizedHtml = sanitizeMarkdownHtml(html);
-
-      if (!cancelled && sanitizedHtml.trim()) {
-        setHighlightedHtml({ text, html: sanitizedHtml });
+    void renderHighlightedMarkdownHtml(text).then((html) => {
+      if (!cancelled && html.trim()) {
+        setHighlightedHtml({ text, html });
       }
     }).catch(() => {
       if (!cancelled) {
@@ -444,6 +528,17 @@ function MarkdownBlockInner({
 
     const handleClick = (event: MouseEvent) => {
       if (!(event.target instanceof Element)) return;
+
+      const copyButton = event.target.closest("[data-openwork-code-copy]");
+      if (copyButton instanceof HTMLButtonElement) {
+        event.preventDefault();
+        event.stopPropagation();
+
+        const codeBlock = copyButton.closest("[data-openwork-code-block]");
+        const code = codeBlock?.querySelector("code");
+        void handleCodeBlockCopy(copyButton, code?.textContent ?? "");
+        return;
+      }
 
       const chevron = event.target.closest("[data-openwork-link-chevron]");
       if (chevron instanceof HTMLElement) {
@@ -499,7 +594,7 @@ function MarkdownBlockInner({
       root.removeEventListener("load", handleLoad, true);
       root.removeEventListener("click", handleClick);
     };
-  }, [html, onOpenTarget, openTargets]);
+  }, [handleCodeBlockCopy, html, onOpenTarget, openTargets]);
 
   if (!html) {
     return null;

--- a/apps/app/tests/markdown-code-block.test.ts
+++ b/apps/app/tests/markdown-code-block.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { renderHighlightedMarkdownHtml, renderMarkdownHtml } from "../src/components/markdown/markdown";
+
+const CODE = "const value = 1;\nconsole.log(value);";
+const MARKDOWN = `\`\`\`ts\n${CODE}\n\`\`\``;
+
+describe("markdown code blocks", () => {
+  test("renders fallback code blocks with subtle theme-aware styling and copy affordance", () => {
+    const html = renderMarkdownHtml(MARKDOWN);
+
+    expect(html).toContain("data-openwork-code-block");
+    expect(html).toContain("bg-gray-2/60");
+    expect(html).toContain("data-openwork-code-copy");
+    expect(html).toContain("data-openwork-code-copy-icon");
+    expect(html).toContain("data-openwork-code-copy-check-icon");
+    expect(html).toContain("h-7 w-7");
+    expect(html).toContain('aria-label="Copy code block"');
+    expect(html).toContain('aria-live="polite"');
+    expect(html).toContain('class="sr-only"');
+    expect(html).toContain('title="Copy code block"');
+    expect(html).not.toContain(">Copy</span>");
+    expect(html).toContain("pt-11");
+    expect(html).toContain(CODE.split("\n")[0]);
+    expect(html).toContain(CODE.split("\n")[1]);
+  });
+
+  test("renders highlighted code blocks with the same copy affordance and dual Shiki themes", async () => {
+    const html = await renderHighlightedMarkdownHtml(MARKDOWN);
+
+    expect(html).toContain("data-openwork-code-block");
+    expect(html).toContain("data-openwork-shiki");
+    expect(html).toContain("data-openwork-code-copy");
+    expect(html).toContain("data-openwork-code-copy-icon");
+    expect(html).toContain("data-openwork-code-copy-check-icon");
+    expect(html).toContain("--shiki-dark");
+    expect(html).toContain("github-light");
+    expect(html).toContain("github-dark");
+  });
+});

--- a/evals/flows/fix-codeblock-styling.flow.mjs
+++ b/evals/flows/fix-codeblock-styling.flow.mjs
@@ -1,0 +1,327 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/fix-codeblock-styling.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("fix-codeblock-styling");
+
+const EDITOR_SELECTOR = '[contenteditable="true"][data-lexical-editor="true"], [contenteditable="true"]';
+const CODE_BLOCK_SELECTOR = '[data-message-role="assistant"] [data-openwork-code-block]';
+const COPY_BUTTON_SELECTOR = `${CODE_BLOCK_SELECTOR} [data-openwork-code-copy]`;
+const SAMPLE_CODE = [
+  "function greet(name) {",
+  "  return `Hello, ${name}!`;",
+  "}",
+  "",
+  'console.log(greet("OpenWork"));',
+].join("\n");
+const PROMPT = `Reply with only this fenced JavaScript code block and preserve every space and newline:\n\n\`\`\`js\n${SAMPLE_CODE}\n\`\`\``;
+
+async function waitForReadySession(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API",
+  });
+  return ctx.waitFor(
+    `(() => {
+      const control = window.__openworkControl;
+      const route = control.snapshot().route;
+      if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+      const action = control.listActions().find((item) => item.id === "session.create_task");
+      if (action && !action.disabled) return "ready";
+      return null;
+    })()`,
+    { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+  );
+}
+
+async function setTheme(ctx, theme) {
+  await ctx.eval(
+    `(() => {
+      const theme = ${JSON.stringify(theme)};
+      localStorage.setItem("openwork.react.settings.theme-mode", theme);
+      document.documentElement.dataset.theme = theme;
+      document.documentElement.classList.toggle("dark", theme === "dark");
+      return document.documentElement.dataset.theme;
+    })()`,
+  );
+  await ctx.waitFor(`document.documentElement.dataset.theme === ${JSON.stringify(theme)}`, {
+    timeoutMs: 5_000,
+    label: `${theme} mode`,
+  });
+}
+
+async function waitForComposer(ctx) {
+  await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(EDITOR_SELECTOR)}))`, {
+    timeoutMs: 30_000,
+    label: "composer editor",
+  });
+}
+
+async function createFreshTask(ctx) {
+  await ctx.control("session.create_task");
+  await waitForComposer(ctx);
+}
+
+async function pasteComposer(ctx, text) {
+  const result = await ctx.eval(
+    `(() => {
+      const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+      if (!editor) return { ok: false, reason: "composer not found" };
+      editor.focus();
+      const data = new DataTransfer();
+      data.setData("text/plain", ${JSON.stringify(text)});
+      editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+      return { ok: true, text: editor.innerText };
+    })()`,
+  );
+  ctx.assert(result?.ok === true, `Could not paste into composer: ${result?.reason ?? "unknown"}`);
+}
+
+async function submitComposer(ctx) {
+  const ran = await ctx.eval(`(() => {
+    const byLabel = Array.from(document.querySelectorAll("button"))
+      .find((button) => /run task|send|run/i.test((button.textContent || "").trim()) && !button.disabled);
+    if (byLabel) { byLabel.click(); return "clicked"; }
+    const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+    if (editor) {
+      editor.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+      return "enter";
+    }
+    return "none";
+  })()`);
+  ctx.assert(ran !== "none", "Could not submit the composer message.");
+}
+
+async function waitForHighlightedCodeBlock(ctx) {
+  await ctx.waitFor(
+    `(() => Array.from(document.querySelectorAll(${JSON.stringify(CODE_BLOCK_SELECTOR)}))
+      .some((block) => block.matches("[data-openwork-shiki]")
+        && block.textContent.includes("function greet")
+        && block.textContent.includes("OpenWork")
+        && block.querySelector('[data-openwork-code-copy][aria-label="Copy code block"] [data-openwork-code-copy-icon]:not([hidden])')
+        && block.querySelector("[data-openwork-code-copy] [data-openwork-code-copy-check-icon][hidden]")))()`,
+    { timeoutMs: 120_000, label: "highlighted assistant code block with copy button" },
+  );
+}
+
+function codeBlockInfoExpression() {
+  return `(() => {
+    const block = Array.from(document.querySelectorAll(${JSON.stringify(CODE_BLOCK_SELECTOR)}))
+      .find((candidate) => candidate.textContent.includes("function greet") && candidate.textContent.includes("OpenWork"));
+    if (!block) return { ok: false, reason: "code block not found" };
+    const button = block.querySelector("[data-openwork-code-copy]");
+    const copyIcon = button?.querySelector("[data-openwork-code-copy-icon]");
+    const checkIcon = button?.querySelector("[data-openwork-code-copy-check-icon]");
+    const copyLabel = button?.querySelector("[data-openwork-code-copy-label]");
+    const code = block.querySelector("code");
+    const token = block.querySelector(".shiki span");
+    const paddedElement = code
+      ? Array.from(block.querySelectorAll("div, pre"))
+        .find((element) => element.contains(code) && Number.parseFloat(getComputedStyle(element).paddingTop) > 0)
+      : null;
+
+    const resolveColor = (cssValue) => {
+      const probe = document.createElement("div");
+      probe.style.position = "absolute";
+      probe.style.pointerEvents = "none";
+      probe.style.background = cssValue;
+      document.body.appendChild(probe);
+      const value = getComputedStyle(probe).backgroundColor;
+      probe.remove();
+      return value;
+    };
+    const canvas = document.createElement("canvas");
+    canvas.width = 1;
+    canvas.height = 1;
+    const context = canvas.getContext("2d", { willReadFrequently: true });
+    const paintColor = (cssValue, backdrop) => {
+      if (!context || !cssValue) return null;
+      context.clearRect(0, 0, 1, 1);
+      context.globalAlpha = 1;
+      context.globalCompositeOperation = "source-over";
+      context.fillStyle = "rgba(1, 2, 3, 0.4)";
+      const sentinel = context.fillStyle;
+      try {
+        context.fillStyle = cssValue;
+      } catch {
+        return null;
+      }
+      if (context.fillStyle === sentinel) return null;
+      context.fillRect(0, 0, 1, 1);
+      const pixel = context.getImageData(0, 0, 1, 1).data;
+      const alpha = pixel[3] / 255;
+      return [
+        pixel[0] * alpha + backdrop[0] * (1 - alpha),
+        pixel[1] * alpha + backdrop[1] * (1 - alpha),
+        pixel[2] * alpha + backdrop[2] * (1 - alpha),
+      ];
+    };
+    const luminance = (channels) => {
+      if (!channels) return null;
+      const [red, green, blue] = channels;
+      return (0.2126 * red + 0.7152 * green + 0.0722 * blue) / 255;
+    };
+
+    const blockRect = block.getBoundingClientRect();
+    const buttonRect = button?.getBoundingClientRect();
+    const blockBackground = getComputedStyle(block).backgroundColor;
+    const pageBackground = resolveColor("var(--background)");
+    const tokenColor = token ? getComputedStyle(token).color : "";
+    const pageChannels = paintColor(pageBackground, [255, 255, 255]);
+    const blockChannels = pageChannels ? paintColor(blockBackground, pageChannels) : null;
+    const tokenChannels = tokenColor && blockChannels ? paintColor(tokenColor, blockChannels) : null;
+    const blockLuminance = luminance(blockChannels);
+    const pageLuminance = luminance(pageChannels);
+    const tokenLuminance = luminance(tokenChannels);
+
+    return {
+      ok: true,
+      theme: document.documentElement.dataset.theme || "",
+      text: code?.textContent || "",
+      blockBackground,
+      pageBackground,
+      tokenColor,
+      colorMeasurementsOk: Boolean(blockChannels && pageChannels && (!tokenColor || tokenChannels)),
+      blockLuminance,
+      pageLuminance,
+      backgroundDelta: blockLuminance === null || pageLuminance === null ? null : Math.abs(blockLuminance - pageLuminance),
+      tokenContrastDelta: tokenLuminance === null || blockLuminance === null ? null : Math.abs(tokenLuminance - blockLuminance),
+      buttonAria: button?.getAttribute("aria-label") || "",
+      buttonTitle: button?.getAttribute("title") || "",
+      hasCopyIcon: Boolean(copyIcon),
+      hasCheckIcon: Boolean(checkIcon),
+      copyIconAriaHidden: copyIcon?.getAttribute("aria-hidden") || "",
+      checkIconAriaHidden: checkIcon?.getAttribute("aria-hidden") || "",
+      copyIconHidden: copyIcon ? copyIcon.hasAttribute("hidden") : null,
+      checkIconHidden: checkIcon ? checkIcon.hasAttribute("hidden") : null,
+      copyLabel: copyLabel?.textContent?.trim() || "",
+      copyLabelHidden: copyLabel?.classList.contains("sr-only") || false,
+      copyLabelLive: copyLabel?.getAttribute("aria-live") || "",
+      buttonTop: buttonRect ? buttonRect.top - blockRect.top : null,
+      buttonRight: buttonRect ? blockRect.right - buttonRect.right : null,
+      codePaddingTop: paddedElement ? Number.parseFloat(getComputedStyle(paddedElement).paddingTop) : 0,
+    };
+  })()`;
+}
+
+export default {
+  id: "fix-codeblock-styling",
+  title: "Code blocks stay theme-subtle and copy exact text",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    const state = await waitForReadySession(ctx);
+    return state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); code-block styling flow requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "Light mode code block is subtle",
+      run: async (ctx) => {
+        await ctx.prove("Light mode renders the assistant code block on a near-background surface", {
+          voiceover: vo[0],
+          action: async () => {
+            await setTheme(ctx, "light");
+            await createFreshTask(ctx);
+            await pasteComposer(ctx, PROMPT);
+            await submitComposer(ctx);
+            await waitForHighlightedCodeBlock(ctx);
+          },
+          assert: async () => {
+            const info = await ctx.eval(codeBlockInfoExpression());
+            ctx.assert(info.ok === true, info.reason ?? "No code block info returned.");
+            ctx.assert(info.theme === "light", `Expected light theme, got ${info.theme}.`);
+            ctx.assert(info.colorMeasurementsOk === true, `Could not measure light code block colors: ${JSON.stringify(info)}`);
+            ctx.assert(info.blockLuminance > 0.75, `Light code block is too dark: ${JSON.stringify(info)}`);
+            ctx.assert(info.backgroundDelta > 0.002 && info.backgroundDelta < 0.12, `Light code block is not one subtle shade from the page: ${JSON.stringify(info)}`);
+            ctx.assert(info.tokenContrastDelta > 0.25, `Light syntax colors do not contrast enough: ${JSON.stringify(info)}`);
+          },
+          screenshot: { name: "light-subtle-code-block", requireText: ["function greet"] },
+        });
+      },
+    },
+    {
+      name: "Dark mode code block stays dark",
+      run: async (ctx) => {
+        await ctx.prove("Dark mode keeps the same code block dark and subtly distinct", {
+          voiceover: vo[1],
+          action: async () => {
+            await setTheme(ctx, "dark");
+            await waitForHighlightedCodeBlock(ctx);
+          },
+          assert: async () => {
+            const info = await ctx.eval(codeBlockInfoExpression());
+            ctx.assert(info.ok === true, info.reason ?? "No code block info returned.");
+            ctx.assert(info.theme === "dark", `Expected dark theme, got ${info.theme}.`);
+            ctx.assert(info.colorMeasurementsOk === true, `Could not measure dark code block colors: ${JSON.stringify(info)}`);
+            ctx.assert(info.blockLuminance < 0.35, `Dark code block turned light: ${JSON.stringify(info)}`);
+            ctx.assert(info.backgroundDelta > 0.002 && info.backgroundDelta < 0.15, `Dark code block is not subtly distinct: ${JSON.stringify(info)}`);
+            ctx.assert(info.tokenContrastDelta > 0.25, `Dark syntax colors do not contrast enough: ${JSON.stringify(info)}`);
+          },
+          screenshot: { name: "dark-subtle-code-block", requireText: ["function greet"] },
+        });
+      },
+    },
+    {
+      name: "Copy button is in the top right",
+      run: async (ctx) => {
+        await ctx.prove("The code block exposes an accessible Copy button in the top-right corner", {
+          voiceover: vo[2],
+          action: async () => {
+            await waitForHighlightedCodeBlock(ctx);
+          },
+          assert: async () => {
+            const info = await ctx.eval(codeBlockInfoExpression());
+            ctx.assert(info.ok === true, info.reason ?? "No code block info returned.");
+            ctx.assert(info.buttonAria === "Copy code block", `Unexpected copy aria label: ${info.buttonAria}.`);
+            ctx.assert(info.buttonTitle === "Copy code block", `Unexpected copy title: ${info.buttonTitle}.`);
+            ctx.assert(info.hasCopyIcon === true, `Copy icon is missing: ${JSON.stringify(info)}`);
+            ctx.assert(info.hasCheckIcon === true, `Copied check icon is missing: ${JSON.stringify(info)}`);
+            ctx.assert(info.copyIconAriaHidden === "true", `Copy icon should be aria-hidden: ${JSON.stringify(info)}`);
+            ctx.assert(info.checkIconAriaHidden === "true", `Copied check icon should be aria-hidden: ${JSON.stringify(info)}`);
+            ctx.assert(info.copyIconHidden === false, `Copy icon should be visible before copy: ${JSON.stringify(info)}`);
+            ctx.assert(info.checkIconHidden === true, `Check icon should be hidden before copy: ${JSON.stringify(info)}`);
+            ctx.assert(info.copyLabel === "Copy code block", `Unexpected copy assistive label: ${info.copyLabel}.`);
+            ctx.assert(info.copyLabelHidden === true, `Copy assistive label is not screen-reader-only: ${JSON.stringify(info)}`);
+            ctx.assert(info.copyLabelLive === "polite", `Copy assistive feedback should be polite: ${JSON.stringify(info)}`);
+            ctx.assert(info.buttonTop >= 0 && info.buttonTop <= 16, `Copy button is not near the top: ${JSON.stringify(info)}`);
+            ctx.assert(info.buttonRight >= 0 && info.buttonRight <= 16, `Copy button is not near the right edge: ${JSON.stringify(info)}`);
+            ctx.assert(info.codePaddingTop >= 36, `Code is not padded below the button: ${JSON.stringify(info)}`);
+          },
+          screenshot: { name: "copy-button-top-right", requireText: ["function greet"] },
+        });
+      },
+    },
+    {
+      name: "Copy preserves formatting",
+      run: async (ctx) => {
+        await ctx.prove("Selecting Copy writes the exact code block text to the clipboard", {
+          voiceover: vo[3],
+          action: async () => {
+            await ctx.trustedClick(COPY_BUTTON_SELECTOR);
+            await ctx.waitFor(
+              `(() => {
+                const button = document.querySelector(${JSON.stringify(COPY_BUTTON_SELECTOR)});
+                return Boolean(button
+                  && button.getAttribute("aria-label") === "Code block copied"
+                  && button.querySelector("[data-openwork-code-copy-icon][hidden]")
+                  && button.querySelector("[data-openwork-code-copy-check-icon]:not([hidden])"));
+              })()`,
+              { timeoutMs: 5_000, label: "copied feedback" },
+            );
+          },
+          assert: async () => {
+            const info = await ctx.eval(codeBlockInfoExpression());
+            ctx.assert(info.buttonAria === "Code block copied", `Copied aria feedback did not occur: ${JSON.stringify(info)}`);
+            ctx.assert(info.copyIconHidden === true, `Copy icon was not hidden after copy: ${JSON.stringify(info)}`);
+            ctx.assert(info.checkIconHidden === false, `Check icon was not shown after copy: ${JSON.stringify(info)}`);
+            ctx.assert(info.copyLabel === "Code block copied", `Copied assistive feedback did not occur: ${JSON.stringify(info)}`);
+            const copied = await ctx.eval("navigator.clipboard.readText()", { awaitPromise: true });
+            ctx.assert(copied === SAMPLE_CODE, `Clipboard text changed formatting: ${JSON.stringify(copied)}`);
+          },
+          screenshot: { name: "copy-feedback", requireText: ["function greet"] },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/fix-codeblock-styling.md
+++ b/evals/voiceovers/fix-codeblock-styling.md
@@ -1,0 +1,9 @@
+# Fix code block styling
+
+1. “In light mode, code blocks now sit just one shade apart from the chat background instead of appearing dark and inverted.”
+
+2. “In dark mode, the same treatment keeps code blocks subtly distinct without turning them light.”
+
+3. “Every code block includes a simple Copy button in its top-right corner.”
+
+4. “I select Copy, and the complete code is placed on the clipboard without changing its formatting.”


### PR DESCRIPTION
## Summary
- keep fenced code blocks subtly offset from the chat background in light and dark themes
- add an accessible copy icon with copied-state feedback to every rendered code block
- add focused renderer coverage and a frame-by-frame desktop proof

## Testing
- `pnpm --filter @openwork/app exec bun test --isolate tests/markdown-code-block.test.ts` — passed (2 tests)
- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm fraimz --flow fix-codeblock-styling --cdp-url http://127.0.0.1:9826` — passed (4 frames + voice-over coverage)

## Proof
- `evals/results/2026-07-21T17-14-41-099Z/fraimz.html`