### PR TITLE
feat(mcp): cloud MCP doctor — direct probe trace, engine refresh, advanced diagnostics

### DIFF
--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -480,6 +480,44 @@ export type OpenworkCloudMcpDeliverySnapshot = {
   failure?: OpenworkCloudMcpFailure;
 };
 
+export type OpenworkCloudMcpProbeStep = {
+  step: "initialize" | "initialized_notice" | "tools_list" | string;
+  ok: boolean;
+  httpStatus?: number;
+  latencyMs: number;
+  error?: unknown;
+};
+
+export type OpenworkCloudMcpProbeTrace = {
+  endpoint: string | null;
+  startedAt: string;
+  latencyMs: number;
+  protocolVersion: string | null;
+  serverInfo: { name: string | null; version: string | null } | null;
+  steps: OpenworkCloudMcpProbeStep[];
+};
+
+export type OpenworkCloudMcpEngineRefreshStep = {
+  step: "engine_disconnect" | "reapply" | string;
+  ok: boolean;
+  latencyMs: number;
+  detail?: unknown;
+};
+
+export type OpenworkCloudMcpEngineRefresh = {
+  performed: boolean;
+  reason?: "desired_missing" | string;
+  trigger: string;
+  startedAt: string;
+  finishedAt: string;
+  steps: OpenworkCloudMcpEngineRefreshStep[];
+};
+
+export type OpenworkCloudMcpEngineRefreshResult = {
+  refresh: OpenworkCloudMcpEngineRefresh;
+  health: OpenworkCloudMcpHealth;
+};
+
 export type OpenworkCloudMcpHealth = {
   schemaVersion: 1;
   phase: OpenworkCloudMcpHealthPhase;
@@ -510,6 +548,13 @@ export type OpenworkCloudMcpHealth = {
     status: "not_checked" | "missing" | "connected" | "disabled" | "failed" | "needs_auth" | "needs_client_registration" | "unreachable" | "unknown" | string;
     error?: unknown;
   };
+  /** The engine's own view of every MCP server it tracks (older servers omit this). */
+  engineInspection?: {
+    checked: boolean;
+    cloudPresent?: boolean;
+    serverCount?: number;
+    servers?: Array<{ name: string; status: string; error?: string }>;
+  };
   tools: {
     expected: string[];
     present: string[];
@@ -520,7 +565,9 @@ export type OpenworkCloudMcpHealth = {
       expected: string[];
       present: string[];
       missing: string[];
+      trace?: OpenworkCloudMcpProbeTrace;
       error?: unknown;
+      failure?: OpenworkCloudMcpFailure;
     };
     providerProjection: {
       checked: boolean;
@@ -544,6 +591,7 @@ export type OpenworkCloudMcpHealth = {
   toolDenies: unknown[];
   firstFailure: OpenworkCloudMcpFailure | null;
   checkedAt: string;
+  durationMs?: number;
 };
 
 export type OpenworkCloudMcpReconcilePayload = {
@@ -1322,6 +1370,7 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
     diagnostics: AGENT_CONTEXT_DIAGNOSTICS_REQUEST_TIMEOUT_MS,
     config: 10_000,
     cloudMcpHealth: 12_000,
+    cloudMcpProbeHealth: 30_000,
     cloudMcpReconcile: 60_000,
     workspaceExport: 30_000,
     workspaceImport: 30_000,
@@ -1779,17 +1828,24 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
         `/workspace/${workspaceId}/mcp`,
         { token, hostToken },
       ),
-    getOpenworkCloudMcpHealth: (workspaceId: string, providerModel?: OpenworkCloudMcpProviderModelContext) => {
+    getOpenworkCloudMcpHealth: (
+      workspaceId: string,
+      providerModel?: OpenworkCloudMcpProviderModelContext,
+      options?: { probe?: boolean },
+    ) => {
       const query = new URLSearchParams();
       if (providerModel?.provider.trim() && providerModel.model.trim()) {
         query.set("provider", providerModel.provider.trim());
         query.set("model", providerModel.model.trim());
       }
+      // probe=1 verifies the Cloud endpoint directly from the OpenWork server
+      // (initialize + tools/list), independent of the engine's own connection.
+      if (options?.probe) query.set("probe", "1");
       const suffix = query.size ? `?${query.toString()}` : "";
       return requestJson<OpenworkCloudMcpHealth>(
         baseUrl,
         `/workspace/${encodeURIComponent(workspaceId)}/mcp/openwork-cloud/health${suffix}`,
-        { token, hostToken, timeoutMs: timeouts.cloudMcpHealth },
+        { token, hostToken, timeoutMs: options?.probe ? timeouts.cloudMcpProbeHealth : timeouts.cloudMcpHealth },
       );
     },
     reconcileOpenworkCloudMcp: (workspaceId: string, payload: OpenworkCloudMcpReconcilePayload) =>
@@ -1801,6 +1857,21 @@ export function createOpenworkServerClient(options: { baseUrl: string; token?: s
           hostToken,
           method: "POST",
           body: payload,
+          timeoutMs: timeouts.cloudMcpReconcile,
+        },
+      ),
+    refreshOpenworkCloudMcpEngine: (
+      workspaceId: string,
+      payload?: { provider?: string; model?: string; trigger?: string },
+    ) =>
+      requestJson<OpenworkCloudMcpEngineRefreshResult>(
+        baseUrl,
+        `/workspace/${encodeURIComponent(workspaceId)}/mcp/openwork-cloud/engine-refresh`,
+        {
+          token,
+          hostToken,
+          method: "POST",
+          body: payload ?? {},
           timeoutMs: timeouts.cloudMcpReconcile,
         },
       ),

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-diagnostics.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-diagnostics.ts
@@ -1,0 +1,244 @@
+import { sanitizeCloudMcpHealthDiagnostic } from "../../../app/lib/diagnostic-sanitizer";
+import type {
+  OpenworkCloudMcpEngineRefresh,
+  OpenworkCloudMcpHealth,
+  OpenworkCloudMcpProbeTrace,
+} from "../../../app/lib/openwork-server";
+
+export type CloudMcpAdvancedRow = {
+  label: string;
+  value: string;
+  tone?: "error" | "muted";
+};
+
+const MAX_INLINE_ERROR_LENGTH = 400;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function compactText(value: string): string {
+  const collapsed = value.replace(/\s+/g, " ").trim();
+  if (collapsed.length <= MAX_INLINE_ERROR_LENGTH) return collapsed;
+  return `${collapsed.slice(0, MAX_INLINE_ERROR_LENGTH)}…`;
+}
+
+/** Flatten an unknown error payload into one support-readable line. */
+export function describeCloudMcpErrorDetail(error: unknown): string | null {
+  if (error === undefined || error === null) return null;
+  if (typeof error === "string") return compactText(error) || null;
+  if (typeof error === "number" || typeof error === "boolean") return String(error);
+  try {
+    return compactText(JSON.stringify(error));
+  } catch {
+    return compactText(String(error));
+  }
+}
+
+/**
+ * The engine stores only `Error.message` for a failed MCP connection (a
+ * network/TLS failure surfaces as the bare "fetch failed"), so the raw string
+ * matters on a support call even when it looks unhelpfully short.
+ */
+export function cloudMcpEngineErrorText(health: OpenworkCloudMcpHealth | null): string | null {
+  return describeCloudMcpErrorDetail(health?.engine.error);
+}
+
+function transportCauseText(details: unknown): string | null {
+  if (!isRecord(details)) return null;
+  const transport = details.transport;
+  if (!isRecord(transport)) return null;
+  const parts: string[] = [];
+  if (typeof transport.message === "string") parts.push(transport.message);
+  if (typeof transport.code === "string") parts.push(`code ${transport.code}`);
+  const causes = Array.isArray(transport.causes) ? transport.causes : [];
+  for (const cause of causes) {
+    if (!isRecord(cause)) continue;
+    const causeParts = [
+      typeof cause.message === "string" ? cause.message : null,
+      typeof cause.code === "string" ? `code ${cause.code}` : null,
+      typeof cause.syscall === "string" ? `syscall ${cause.syscall}` : null,
+    ].filter((item): item is string => Boolean(item));
+    if (causeParts.length) parts.push(`caused by: ${causeParts.join(" · ")}`);
+  }
+  return parts.length ? compactText(parts.join(" — ")) : null;
+}
+
+function formatEpoch(value: number | null | undefined): string {
+  if (typeof value !== "number" || !Number.isFinite(value)) return "never";
+  try {
+    return new Date(value).toISOString();
+  } catch {
+    return "invalid time";
+  }
+}
+
+function shortRevision(revision: string | null | undefined): string {
+  const trimmed = revision?.trim() ?? "";
+  if (!trimmed) return "none";
+  return trimmed.length > 12 ? trimmed.slice(0, 12) : trimmed;
+}
+
+export function cloudMcpProbeTraceLines(trace: OpenworkCloudMcpProbeTrace | null | undefined): string[] {
+  if (!trace) return [];
+  return trace.steps.map((step) => {
+    const parts = [
+      step.step,
+      step.ok ? "ok" : "failed",
+      ...(step.httpStatus !== undefined ? [`HTTP ${step.httpStatus}`] : []),
+      `${Math.max(0, Math.round(step.latencyMs))} ms`,
+    ];
+    const errorText = describeCloudMcpErrorDetail(step.error);
+    return `${parts.join(" · ")}${errorText ? ` — ${errorText}` : ""}`;
+  });
+}
+
+export function cloudMcpEngineRefreshLines(refresh: OpenworkCloudMcpEngineRefresh | null | undefined): string[] {
+  if (!refresh) return [];
+  const lines = refresh.steps.map((step) => {
+    const label = step.step === "engine_disconnect" ? "engine disconnect" : step.step === "reapply" ? "re-register and verify" : step.step;
+    const detailText = describeCloudMcpErrorDetail(step.detail);
+    return `${label} · ${step.ok ? "ok" : "failed"} · ${Math.max(0, Math.round(step.latencyMs))} ms${detailText ? ` — ${detailText}` : ""}`;
+  });
+  if (!refresh.performed) {
+    lines.unshift(`not performed${refresh.reason ? ` (${refresh.reason})` : ""}`);
+  }
+  return lines;
+}
+
+/**
+ * Support-call rows for the card's Advanced section. Everything here is
+ * derived from the already-sanitized health payload; no secrets are present.
+ */
+export function cloudMcpAdvancedRows(health: OpenworkCloudMcpHealth | null): CloudMcpAdvancedRow[] {
+  if (!health) return [];
+  const rows: CloudMcpAdvancedRow[] = [];
+  const failure = health.firstFailure;
+  rows.push({ label: "Phase", value: String(health.phase) });
+  if (failure) {
+    rows.push({
+      label: "Failure",
+      value: `${failure.code} · stage ${failure.stage} · ${failure.retryable ? "retryable" : "not retryable"}`,
+      tone: "error",
+    });
+    rows.push({ label: "Failure message", value: compactText(failure.message), tone: "error" });
+    const failureDetail = describeCloudMcpErrorDetail(failure.details);
+    if (failureDetail) rows.push({ label: "Failure detail", value: failureDetail, tone: "muted" });
+    if (failure.requestId) rows.push({ label: "Request ID", value: failure.requestId });
+    if (failure.referenceId) rows.push({ label: "Reference ID", value: failure.referenceId });
+  }
+  const engineError = cloudMcpEngineErrorText(health);
+  rows.push({
+    label: "Engine MCP status",
+    value: engineError ? `${health.engine.status} — ${engineError}` : String(health.engine.status),
+    ...(health.engine.status === "connected" ? {} : { tone: "error" as const }),
+  });
+  const inspection = health.engineInspection;
+  if (inspection?.checked) {
+    if (inspection.cloudPresent === false) {
+      rows.push({
+        label: "Engine registration",
+        value: "openwork-cloud is not registered in the engine (the dynamic entry is lost after an engine restart) — use Refresh engine connection",
+        tone: "error",
+      });
+    }
+    const servers = inspection.servers ?? [];
+    const summary = servers
+      .map((server) => `${server.name} ${server.status}${server.error ? ` — ${compactText(server.error)}` : ""}`)
+      .join("; ");
+    rows.push({
+      label: "Engine MCP servers",
+      value: servers.length ? compactText(`${inspection.serverCount ?? servers.length} tracked: ${summary}`) : "none tracked",
+      ...(servers.some((server) => server.status !== "connected") ? {} : { tone: "muted" as const }),
+    });
+  }
+  rows.push({
+    label: "Delivery",
+    value: `${health.delivery.state} · desired ${shortRevision(health.delivery.desiredRevision)} · applied ${shortRevision(health.delivery.appliedRevision)} · last attempt ${formatEpoch(health.delivery.lastAttemptAt)}${health.delivery.trigger ? ` · trigger ${health.delivery.trigger}` : ""}`,
+  });
+  const direct = health.tools.direct;
+  if (direct.checked || direct.trace) {
+    const probeFailure = direct.failure ?? null;
+    const cause = transportCauseText(probeFailure?.details);
+    const summary = direct.checked
+      ? direct.missing.length === 0 && direct.present.length > 0
+        ? `ok · tools ${direct.present.join(", ")}`
+        : probeFailure
+          ? compactText(`${probeFailure.code} — ${probeFailure.message}`)
+          : `missing ${direct.missing.join(", ") || "none"}`
+      : probeFailure
+        ? compactText(`${probeFailure.code} — ${probeFailure.message}`)
+        : "not checked";
+    rows.push({
+      label: "Direct endpoint check",
+      value: summary,
+      ...(direct.checked && direct.missing.length === 0 && direct.present.length > 0 ? {} : { tone: "error" as const }),
+    });
+    if (cause) rows.push({ label: "Probe transport cause", value: cause, tone: "error" });
+    if (direct.trace?.endpoint) rows.push({ label: "Endpoint", value: direct.trace.endpoint, tone: "muted" });
+    if (direct.trace?.serverInfo?.name) {
+      rows.push({
+        label: "Endpoint server",
+        value: `${direct.trace.serverInfo.name}${direct.trace.serverInfo.version ? ` ${direct.trace.serverInfo.version}` : ""}${direct.trace.protocolVersion ? ` · protocol ${direct.trace.protocolVersion}` : ""}`,
+        tone: "muted",
+      });
+    }
+  } else {
+    rows.push({ label: "Direct endpoint check", value: "not run — use Test now to verify the endpoint outside the engine", tone: "muted" });
+  }
+  const token = health.desired.token;
+  const expiresAt = token.metadata.expiresAt;
+  rows.push({
+    label: "Cloud token",
+    value: token.present
+      ? `present${typeof expiresAt === "string" || typeof expiresAt === "number" ? ` · expires ${expiresAt}` : ""}`
+      : "missing",
+    ...(token.present ? {} : { tone: "error" as const }),
+  });
+  const org = health.desired.org;
+  if (org && (org.id || org.slug || org.name)) {
+    rows.push({ label: "Organization", value: [org.name, org.slug, org.id].filter(Boolean).join(" · "), tone: "muted" });
+  }
+  const compatibility = health.compatibility;
+  rows.push({
+    label: "Versions",
+    value: `app ${describeCloudMcpErrorDetail(compatibility.openwork.app?.version) ?? "unknown"} · server ${compatibility.openwork.serverVersion ?? "unknown"} · engine ${compatibility.opencode.actualVersion ?? "unknown"}${compatibility.opencode.expectedVersion ? ` (expected ${compatibility.opencode.expectedVersion})` : ""}`,
+    tone: "muted",
+  });
+  rows.push({
+    label: "Checked",
+    value: `${health.checkedAt}${typeof health.durationMs === "number" ? ` · took ${Math.max(0, Math.round(health.durationMs))} ms` : ""}`,
+    tone: "muted",
+  });
+  return rows;
+}
+
+/**
+ * One-click support bundle: the sanitized health plus the operation context a
+ * support engineer needs to line the report up with Den/server logs.
+ */
+export function buildCloudMcpSupportBundle(input: {
+  health: OpenworkCloudMcpHealth | null;
+  refresh?: OpenworkCloudMcpEngineRefresh | null;
+  context?: {
+    workspaceId?: string | null;
+    orgId?: string | null;
+    denBaseUrl?: string | null;
+    serverBaseUrl?: string | null;
+  };
+  capturedAt?: string;
+}): string {
+  const bundle = {
+    kind: "openwork-cloud-mcp-diagnostic",
+    capturedAt: input.capturedAt ?? new Date().toISOString(),
+    context: {
+      workspaceId: input.context?.workspaceId ?? null,
+      orgId: input.context?.orgId ?? null,
+      denBaseUrl: input.context?.denBaseUrl ?? null,
+      serverBaseUrl: input.context?.serverBaseUrl ?? null,
+    },
+    ...(input.refresh ? { engineRefresh: input.refresh } : {}),
+    health: input.health ? sanitizeCloudMcpHealthDiagnostic(input.health) : null,
+  };
+  return JSON.stringify(bundle, null, 2);
+}

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
@@ -4,6 +4,8 @@ import {
   resolveCloudMcpResourceUrl,
 } from "../../../app/lib/den";
 import type {
+  OpenworkCloudMcpEngineRefresh,
+  OpenworkCloudMcpEngineRefreshResult,
   OpenworkCloudMcpFailure,
   OpenworkCloudMcpHealth,
   OpenworkCloudMcpProviderModelContext,
@@ -34,11 +36,16 @@ export type CloudMcpClient = {
   getOpenworkCloudMcpHealth: (
     workspaceId: string,
     providerModel?: OpenworkCloudMcpProviderModelContext,
+    options?: { probe?: boolean },
   ) => Promise<OpenworkCloudMcpHealth>;
   reconcileOpenworkCloudMcp: (
     workspaceId: string,
     payload: OpenworkCloudMcpReconcilePayload,
   ) => Promise<OpenworkCloudMcpHealth>;
+  refreshOpenworkCloudMcpEngine?: (
+    workspaceId: string,
+    payload?: { provider?: string; model?: string; trigger?: string },
+  ) => Promise<OpenworkCloudMcpEngineRefreshResult>;
 };
 
 export type CloudMcpOperationContext = CloudMcpScope & {
@@ -83,6 +90,12 @@ type CloudMcpReconcilerInput = {
   refreshMarginMs: number;
   now?: number;
   configuredEnabled?: boolean | null;
+  /**
+   * Ask the OpenWork server to also verify the Cloud endpoint directly
+   * (initialize + tools/list outside the engine). Only meaningful for
+   * mode "health"; repair reconciles always probe on the server.
+   */
+  probe?: boolean;
 };
 
 type OpenCodeDisconnectClient = {
@@ -243,7 +256,11 @@ function writeUsableMarker(input: {
 }
 
 async function probeHealth(input: CloudMcpReconcilerInput, scope: CloudMcpScope, options?: { writeFreshnessMarker?: boolean }): Promise<CloudMcpOperationResult> {
-  const health = await input.client.getOpenworkCloudMcpHealth(scope.workspaceId, input.context.providerModel);
+  const health = await input.client.getOpenworkCloudMcpHealth(
+    scope.workspaceId,
+    input.context.providerModel,
+    input.probe ? { probe: true } : undefined,
+  );
   const marker = options?.writeFreshnessMarker ? readCloudMcpSyncMarker(scope) : null;
   const markerWritten = options?.writeFreshnessMarker === true
     ? writeUsableMarker({ health, scope, expiresAt: marker?.expiresAt ?? null })
@@ -331,6 +348,57 @@ export async function runOpenworkCloudMcpReconciler(input: CloudMcpReconcilerInp
     repairInFlight.delete(scopeKey);
   });
   repairInFlight.set(scopeKey, task);
+  return task;
+}
+
+export type CloudMcpEngineRefreshRunResult = {
+  status: "refreshed" | "failed" | "skipped";
+  skippedReason?: "missing_workspace" | "unsupported";
+  health: OpenworkCloudMcpHealth | null;
+  refresh: OpenworkCloudMcpEngineRefresh | null;
+};
+
+const engineRefreshInFlight = new Map<string, Promise<CloudMcpEngineRefreshRunResult>>();
+
+/**
+ * Force the engine to drop its openwork-cloud MCP client and reconnect.
+ * OpenCode keeps a failed MCP failed forever (no automatic retry), so this is
+ * the explicit "try again from scratch" lever: engine disconnect, then
+ * re-registration from the persisted desired config, then a direct probe.
+ */
+export async function runOpenworkCloudMcpEngineRefresh(input: {
+  client: CloudMcpClient;
+  context: CloudMcpOperationContext;
+}): Promise<CloudMcpEngineRefreshRunResult> {
+  const scope = normalizedContextScope(input.context);
+  if (!scope?.workspaceId) {
+    return { status: "skipped", skippedReason: "missing_workspace", health: null, refresh: null };
+  }
+  const refreshEngine = input.client.refreshOpenworkCloudMcpEngine;
+  if (!refreshEngine) {
+    return { status: "skipped", skippedReason: "unsupported", health: null, refresh: null };
+  }
+  const scopeKey = getCloudMcpScopeKey(scope);
+  if (!scopeKey) {
+    return { status: "skipped", skippedReason: "missing_workspace", health: null, refresh: null };
+  }
+  const existing = engineRefreshInFlight.get(scopeKey);
+  if (existing) return existing;
+  const task = (async (): Promise<CloudMcpEngineRefreshRunResult> => {
+    const providerModel = input.context.providerModel;
+    const result = await refreshEngine(scope.workspaceId, {
+      ...(providerModel ? { provider: providerModel.provider, model: providerModel.model } : {}),
+      trigger: input.context.trigger ?? "desktop-engine-refresh",
+    });
+    return {
+      status: result.health.usable ? "refreshed" : "failed",
+      health: result.health,
+      refresh: result.refresh,
+    };
+  })().finally(() => {
+    engineRefreshInFlight.delete(scopeKey);
+  });
+  engineRefreshInFlight.set(scopeKey, task);
   return task;
 }
 

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -422,9 +422,29 @@ export function AdvancedCloudMcpDiagnosticsSection(props: AdvancedCloudMcpDiagno
               <DiagnosticRow label="Applied revision" value={props.cloudMcpHealth.delivery.appliedRevision ?? "none"} />
               <DiagnosticRow label="Delivery" value={`${props.cloudMcpHealth.delivery.state}${props.cloudMcpHealth.delivery.trigger ? ` / ${props.cloudMcpHealth.delivery.trigger}` : ""}`} />
               <DiagnosticRow label="Engine status" value={props.cloudMcpHealth.engine.status} />
+              {props.cloudMcpHealth.engineInspection?.checked ? (
+                <DiagnosticRow
+                  label="Engine MCP servers"
+                  value={(props.cloudMcpHealth.engineInspection.servers ?? []).length
+                    ? (props.cloudMcpHealth.engineInspection.servers ?? []).map((server) => `${server.name} ${server.status}${server.error ? ` (${server.error})` : ""}`).join("; ")
+                    : "none tracked"}
+                />
+              ) : null}
               <DiagnosticRow label="Provider/model" value={projection?.checked ? `${projection.provider ?? "unknown"}/${projection.model ?? "unknown"}; source ${projection.source ?? "unknown"}; tool calling ${formatMaybe(projection.toolCalling)}; present ${joinList(projection.present)}; missing ${joinList(projection.missing)}${projection.limitation ? `; limitation: ${projection.limitation}` : ""}` : "not checked"} />
               <DiagnosticRow label="Cloud tools" value={`derived present ${joinList(props.cloudMcpHealth.tools.present)}; missing ${joinList(props.cloudMcpHealth.tools.missing)}`} />
-              <DiagnosticRow label="Direct tools/list" value={`present ${joinList(props.cloudMcpHealth.tools.direct.present)}; missing ${joinList(props.cloudMcpHealth.tools.direct.missing)}`} />
+              <DiagnosticRow label="Direct tools/list" value={`checked ${props.cloudMcpHealth.tools.direct.checked ? "yes" : "no"}; present ${joinList(props.cloudMcpHealth.tools.direct.present)}; missing ${joinList(props.cloudMcpHealth.tools.direct.missing)}`} />
+              {props.cloudMcpHealth.tools.direct.trace ? (
+                <DiagnosticRow
+                  label="Direct probe"
+                  value={`${props.cloudMcpHealth.tools.direct.trace.endpoint ?? "unknown endpoint"} · ${props.cloudMcpHealth.tools.direct.trace.latencyMs} ms · ${props.cloudMcpHealth.tools.direct.trace.steps.map((step) => `${step.step} ${step.ok ? "ok" : "failed"}${step.httpStatus !== undefined ? ` (HTTP ${step.httpStatus})` : ""} ${Math.max(0, Math.round(step.latencyMs))}ms`).join(" → ") || "no steps"}`}
+                />
+              ) : null}
+              {props.cloudMcpHealth.firstFailure ? (
+                <DiagnosticRow
+                  label="First failure"
+                  value={`${props.cloudMcpHealth.firstFailure.code} (stage ${props.cloudMcpHealth.firstFailure.stage}; ${props.cloudMcpHealth.firstFailure.retryable ? "retryable" : "not retryable"}): ${props.cloudMcpHealth.firstFailure.message}`}
+                />
+              ) : null}
               <DiagnosticRow label="Plugin canaries" value={`present ${joinList(props.cloudMcpHealth.pluginCanaries.present)}; missing ${joinList(props.cloudMcpHealth.pluginCanaries.missing)}`} />
               <DiagnosticRow label="Safe capabilities" value={`schema v${props.cloudMcpHealth.schemaVersion}; connect catalog ${props.cloudMcpHealth.connectCatalogEnabled ? "enabled" : "disabled"}`} />
               {compatibility ? (

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -1,11 +1,16 @@
 /** @jsxImportSource react */
 import { useEffect, useMemo, useState } from "react";
-import { ArrowUpRight } from "lucide-react";
+import { ArrowUpRight, ChevronDown, ChevronRight } from "lucide-react";
 
 import type { DenExternalMcpConnection, DenOrgPlugin } from "@/app/lib/den";
 import { mintCloudControlMcpToken, readDenSettings } from "@/app/lib/den";
 import { openDesktopUrl } from "@/app/lib/desktop";
-import type { OpenworkCloudMcpHealth, OpenworkCloudMcpProviderModelContext, OpenworkServerClient } from "@/app/lib/openwork-server";
+import type {
+  OpenworkCloudMcpEngineRefresh,
+  OpenworkCloudMcpHealth,
+  OpenworkCloudMcpProviderModelContext,
+  OpenworkServerClient,
+} from "@/app/lib/openwork-server";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
@@ -47,9 +52,16 @@ import {
   OPENWORK_CLOUD_EXPECTED_TOOLS,
   clearCloudMcpDisabledIntent,
   cloudMcpDisplaySummary,
+  runOpenworkCloudMcpEngineRefresh,
   runOpenworkCloudMcpReconciler,
   type CloudMcpOperationContext,
 } from "../../connections/cloud-mcp-reconciler";
+import {
+  buildCloudMcpSupportBundle,
+  cloudMcpAdvancedRows,
+  cloudMcpEngineRefreshLines,
+  cloudMcpProbeTraceLines,
+} from "../../connections/cloud-mcp-diagnostics";
 import { readCloudMcpUserState } from "../../connections/cloud-mcp-user-state";
 
 export type ConnectViewState = "loading" | "signin" | "active" | "pitch";
@@ -152,8 +164,11 @@ function AgentAccessCard(props: {
 }) {
   const cloudSession = useCloudSession();
   const [health, setHealth] = useState<OpenworkCloudMcpHealth | null>(null);
-  const [busy, setBusy] = useState<"test" | "repair" | null>(null);
+  const [busy, setBusy] = useState<"test" | "repair" | "refresh" | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const [advancedOpen, setAdvancedOpen] = useState(false);
+  const [copyStatus, setCopyStatus] = useState<string | null>(null);
+  const [lastEngineRefresh, setLastEngineRefresh] = useState<OpenworkCloudMcpEngineRefresh | null>(null);
   const context = buildCloudMcpContext(props);
   const userState = context ? readCloudMcpUserState(context) : null;
   const signedIn = cloudSession.isSignedIn && Boolean(cloudSession.authToken.trim());
@@ -176,18 +191,67 @@ function AgentAccessCard(props: {
     setBusy("test");
     setError(null);
     try {
+      // probe: verify the Cloud endpoint directly from the OpenWork server as
+      // well, so a failure can be attributed to the endpoint, the network
+      // path, or the engine — not just reported as the engine's cached state.
       const result = await runOpenworkCloudMcpReconciler({
         mode: "health",
         client: props.client,
         context: { ...context, trigger: "desktop-connect-test" },
         mintToken: mintCloudControlMcpToken,
         refreshMarginMs: CLOUD_MCP_REFRESH_MARGIN_MS,
+        probe: true,
       });
       updateHealth(result.health);
     } catch (nextError) {
       setError(nextError instanceof Error ? nextError.message : "Could not test agent access.");
     } finally {
       setBusy(null);
+    }
+  };
+
+  const refreshEngineConnection = async () => {
+    if (!props.client || !context) return;
+    setBusy("refresh");
+    setError(null);
+    try {
+      const result = await runOpenworkCloudMcpEngineRefresh({
+        client: props.client,
+        context: { ...context, trigger: "desktop-connect-engine-refresh" },
+      });
+      setLastEngineRefresh(result.refresh);
+      if (result.health) updateHealth(result.health);
+      if (result.status === "skipped") {
+        setError(
+          result.skippedReason === "unsupported"
+            ? "This OpenWork server does not support engine refresh yet. Update OpenWork, then retry."
+            : "Select a workspace before refreshing the engine connection.",
+        );
+      }
+    } catch (nextError) {
+      setError(nextError instanceof Error ? nextError.message : "Could not refresh the engine connection.");
+    } finally {
+      setBusy(null);
+    }
+  };
+
+  const copyDiagnostics = async () => {
+    try {
+      await navigator.clipboard.writeText(buildCloudMcpSupportBundle({
+        health,
+        refresh: lastEngineRefresh,
+        context: context
+          ? {
+              workspaceId: context.workspaceId,
+              orgId: context.orgId,
+              denBaseUrl: context.denBaseUrl,
+              serverBaseUrl: context.serverBaseUrl,
+            }
+          : undefined,
+      }));
+      setCopyStatus("Copied sanitized diagnostic to the clipboard.");
+    } catch {
+      setCopyStatus("Could not copy the diagnostic.");
     }
   };
 
@@ -358,7 +422,104 @@ function AgentAccessCard(props: {
           {busy === "repair" ? "Repairing…" : "Repair and test"}
         </Button>
       </div>
+
+      <AgentAccessAdvanced
+        health={health}
+        engineRefresh={lastEngineRefresh}
+        open={advancedOpen}
+        onToggle={() => setAdvancedOpen((current) => !current)}
+        busyLabel={busy}
+        canRun={canRun}
+        copyStatus={copyStatus}
+        onRefreshEngine={() => void refreshEngineConnection()}
+        onCopy={() => void copyDiagnostics()}
+      />
     </SettingsInset>
+  );
+}
+
+function AgentAccessAdvanced(props: {
+  health: OpenworkCloudMcpHealth | null;
+  engineRefresh: OpenworkCloudMcpEngineRefresh | null;
+  open: boolean;
+  onToggle: () => void;
+  busyLabel: "test" | "repair" | "refresh" | null;
+  canRun: boolean;
+  copyStatus: string | null;
+  onRefreshEngine: () => void;
+  onCopy: () => void;
+}) {
+  const rows = cloudMcpAdvancedRows(props.health);
+  const traceLines = cloudMcpProbeTraceLines(props.health?.tools.direct.trace);
+  const refreshLines = cloudMcpEngineRefreshLines(props.engineRefresh);
+  return (
+    <div className="border-t border-dls-border pt-3" data-testid="agent-access-advanced">
+      <button
+        type="button"
+        className="flex items-center gap-1 text-xs font-medium text-dls-secondary transition-colors hover:text-dls-text"
+        aria-expanded={props.open}
+        onClick={props.onToggle}
+      >
+        {props.open ? <ChevronDown size={13} /> : <ChevronRight size={13} />}
+        Advanced diagnostics
+      </button>
+      {props.open ? (
+        <div className="mt-3 space-y-3">
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={!props.canRun || props.busyLabel !== null}
+              onClick={props.onRefreshEngine}
+            >
+              {props.busyLabel === "refresh" ? "Refreshing engine…" : "Refresh engine connection"}
+            </Button>
+            <Button variant="outline" size="sm" disabled={!props.health} onClick={props.onCopy}>
+              Copy sanitized diagnostic
+            </Button>
+          </div>
+          <div className="text-xs text-dls-secondary">
+            Refresh makes the agent engine drop its Cloud connection and reconnect from scratch — the engine never
+            retries a failed connection on its own. Diagnostics are redacted before copy.
+          </div>
+          {props.copyStatus ? <div className="text-xs text-dls-secondary">{props.copyStatus}</div> : null}
+          {rows.length ? (
+            <div className="grid gap-1.5" data-testid="agent-access-advanced-rows">
+              {rows.map((row) => (
+                <div key={row.label} className="grid gap-0.5 sm:grid-cols-[11rem_1fr] sm:gap-2">
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-dls-secondary">{row.label}</div>
+                  <div
+                    className={`break-words font-mono text-xs ${
+                      row.tone === "error" ? "text-red-11" : row.tone === "muted" ? "text-dls-secondary" : "text-dls-text"
+                    }`}
+                  >
+                    {row.value}
+                  </div>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-xs text-dls-secondary">Run Test now to load diagnostics for this workspace.</div>
+          )}
+          {traceLines.length ? (
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-dls-secondary">Direct probe steps</div>
+              <div className="mt-1 space-y-0.5 font-mono text-xs text-dls-text">
+                {traceLines.map((line, index) => <div key={`${index}-${line}`}>{line}</div>)}
+              </div>
+            </div>
+          ) : null}
+          {refreshLines.length ? (
+            <div>
+              <div className="text-[11px] font-semibold uppercase tracking-wide text-dls-secondary">Last engine refresh</div>
+              <div className="mt-1 space-y-0.5 font-mono text-xs text-dls-text">
+                {refreshLines.map((line, index) => <div key={`${index}-${line}`}>{line}</div>)}
+              </div>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
   );
 }
 

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -892,7 +892,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       setCloudMcpHealth(null);
       return null;
     }
-    const health = await client.getOpenworkCloudMcpHealth(workspaceId, currentCloudMcpModel ?? undefined);
+    // probe: the Advanced page refresh should verify the Cloud endpoint
+    // directly (outside the engine), not just report the engine's cached state.
+    const health = await client.getOpenworkCloudMcpHealth(workspaceId, currentCloudMcpModel ?? undefined, { probe: true });
     setCloudMcpHealth(health);
     return health;
   }, [currentCloudMcpModel, openworkClient, runtimeWorkspaceId, selectedWorkspaceEndpoint]);

--- a/apps/app/tests/cloud-mcp-diagnostics.test.ts
+++ b/apps/app/tests/cloud-mcp-diagnostics.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, test } from "bun:test";
+
+import type { OpenworkCloudMcpHealth } from "../src/app/lib/openwork-server";
+import {
+  buildCloudMcpSupportBundle,
+  cloudMcpAdvancedRows,
+  cloudMcpEngineErrorText,
+  cloudMcpEngineRefreshLines,
+  cloudMcpProbeTraceLines,
+} from "../src/react-app/domains/connections/cloud-mcp-diagnostics";
+
+const CHECKED_AT = "2026-07-22T10:00:00.000Z";
+
+function baseHealth(overrides?: Partial<OpenworkCloudMcpHealth>): OpenworkCloudMcpHealth {
+  return {
+    schemaVersion: 1,
+    phase: "engine_failed",
+    usable: false,
+    usableByCurrentModel: null,
+    connectCatalogEnabled: true,
+    workspace: { id: "ws_1", type: "local", directory: "/workspace", path: "/workspace" },
+    desired: {
+      present: true,
+      name: "openwork-cloud",
+      revision: "rev_desired_1234567890",
+      config: null,
+      token: { present: true, metadata: { expiresAt: "2026-07-23T00:00:00.000Z" } },
+      org: { id: "org_1", slug: "acme", name: "Acme" },
+    },
+    delivery: {
+      state: "failed",
+      desiredRevision: "rev_desired_1234567890",
+      appliedRevision: null,
+      updatedAt: 1,
+      appliedAt: null,
+      lastAttemptAt: Date.parse(CHECKED_AT),
+      trigger: "desktop-repair",
+    },
+    engine: { status: "failed", error: "fetch failed" },
+    engineInspection: {
+      checked: true,
+      cloudPresent: true,
+      serverCount: 2,
+      servers: [
+        { name: "openwork-cloud", status: "failed", error: "fetch failed" },
+        { name: "sibling", status: "connected" },
+      ],
+    },
+    tools: {
+      expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+      present: [],
+      missing: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
+      direct: {
+        checked: false,
+        source: "mcp_tools_list",
+        expected: ["search_capabilities", "execute_capability"],
+        present: [],
+        missing: [],
+      },
+      providerProjection: { checked: false, present: [], missing: [] },
+    },
+    pluginCanaries: { expected: [], present: [], missing: [] },
+    compatibility: {
+      openwork: { serverVersion: "0.17.36", app: { version: "0.17.36" } },
+      opencode: { expectedVersion: "1.17.11", actualVersion: "1.17.11", probe: "ok" },
+      pluginFileHashes: [],
+      supportedFeatures: { dynamicMcp: true, directoryScoping: true, toolIds: true, providerToolProjection: false, pluginCanaries: false },
+      experimentalToolIds: { checked: false, expected: [], present: [], missing: [], includesMcpTools: null },
+      experimentalProviderTools: { checked: false, expected: [], present: [], missing: [], includesMcpTools: null },
+    },
+    toolDenies: [],
+    firstFailure: {
+      code: "opencode_mcp_sync_failed",
+      stage: "engine_delivery",
+      retryable: true,
+      recommendedAction: "Retry reconcile or reconnect OpenWork Cloud",
+      message: "openwork-cloud MCP connection failed.",
+      details: { error: "fetch failed" },
+    },
+    checkedAt: CHECKED_AT,
+    durationMs: 480,
+    ...overrides,
+  };
+}
+
+describe("cloud MCP advanced diagnostics", () => {
+  test("surfaces the raw engine error string that OpenCode collapses to", () => {
+    expect(cloudMcpEngineErrorText(baseHealth())).toBe("fetch failed");
+  });
+
+  test("advanced rows expose failure code, engine detail, sibling servers, token, and timings", () => {
+    const rows = cloudMcpAdvancedRows(baseHealth());
+    const byLabel = new Map(rows.map((row) => [row.label, row]));
+
+    expect(byLabel.get("Failure")?.value).toBe("opencode_mcp_sync_failed · stage engine_delivery · retryable");
+    expect(byLabel.get("Engine MCP status")?.value).toBe("failed — fetch failed");
+    expect(byLabel.get("Engine MCP status")?.tone).toBe("error");
+    expect(byLabel.get("Engine MCP servers")?.value).toContain("openwork-cloud failed — fetch failed");
+    expect(byLabel.get("Engine MCP servers")?.value).toContain("sibling connected");
+    expect(byLabel.get("Delivery")?.value).toBe("failed · desired rev_desired_ · applied none · last attempt 2026-07-22T10:00:00.000Z · trigger desktop-repair");
+    expect(byLabel.get("Cloud token")?.value).toBe("present · expires 2026-07-23T00:00:00.000Z");
+    expect(byLabel.get("Direct endpoint check")?.value).toContain("not run");
+    expect(byLabel.get("Checked")?.value).toBe(`${CHECKED_AT} · took 480 ms`);
+  });
+
+  test("flags a lost engine registration as the refresh-worthy issue", () => {
+    const rows = cloudMcpAdvancedRows(baseHealth({
+      engineInspection: { checked: true, cloudPresent: false, serverCount: 0, servers: [] },
+      engine: { status: "missing" },
+    }));
+    const registration = rows.find((row) => row.label === "Engine registration");
+    expect(registration?.tone).toBe("error");
+    expect(registration?.value).toContain("not registered in the engine");
+  });
+
+  test("shows the probe transport cause from the direct check", () => {
+    const rows = cloudMcpAdvancedRows(baseHealth({
+      tools: {
+        ...baseHealth().tools,
+        direct: {
+          checked: false,
+          source: "mcp_tools_list",
+          expected: ["search_capabilities", "execute_capability"],
+          present: [],
+          missing: [],
+          failure: {
+            code: "probe_unreachable",
+            stage: "tool_registration",
+            retryable: true,
+            recommendedAction: "Check the network path",
+            message: "The OpenWork server could not reach the Cloud MCP endpoint.",
+            details: {
+              transport: {
+                message: "fetch failed",
+                causes: [{ message: "self signed certificate in certificate chain", code: "SELF_SIGNED_CERT_IN_CHAIN" }],
+              },
+            },
+          },
+          trace: {
+            endpoint: "https://api.openwork.test/mcp/agent",
+            startedAt: CHECKED_AT,
+            latencyMs: 42,
+            protocolVersion: null,
+            serverInfo: null,
+            steps: [{ step: "initialize", ok: false, latencyMs: 42, error: { message: "fetch failed" } }],
+          },
+        },
+      },
+    }));
+    const cause = rows.find((row) => row.label === "Probe transport cause");
+    expect(cause?.value).toContain("SELF_SIGNED_CERT_IN_CHAIN");
+    expect(rows.find((row) => row.label === "Endpoint")?.value).toBe("https://api.openwork.test/mcp/agent");
+  });
+
+  test("formats probe trace and engine refresh step lines", () => {
+    expect(cloudMcpProbeTraceLines({
+      endpoint: "https://api.openwork.test/mcp/agent",
+      startedAt: CHECKED_AT,
+      latencyMs: 240,
+      protocolVersion: "2025-06-18",
+      serverInfo: { name: "openwork-cloud", version: "1.0.0" },
+      steps: [
+        { step: "initialize", ok: true, httpStatus: 200, latencyMs: 120 },
+        { step: "tools_list", ok: false, httpStatus: 502, latencyMs: 88, error: { message: "bad gateway" } },
+      ],
+    })).toEqual([
+      "initialize · ok · HTTP 200 · 120 ms",
+      'tools_list · failed · HTTP 502 · 88 ms — {"message":"bad gateway"}',
+    ]);
+
+    expect(cloudMcpEngineRefreshLines({
+      performed: false,
+      reason: "desired_missing",
+      trigger: "support-call",
+      startedAt: CHECKED_AT,
+      finishedAt: CHECKED_AT,
+      steps: [],
+    })).toEqual(["not performed (desired_missing)"]);
+
+    expect(cloudMcpEngineRefreshLines({
+      performed: true,
+      trigger: "support-call",
+      startedAt: CHECKED_AT,
+      finishedAt: CHECKED_AT,
+      steps: [
+        { step: "engine_disconnect", ok: true, latencyMs: 10 },
+        { step: "reapply", ok: false, latencyMs: 900, detail: { code: "opencode_mcp_sync_failed" } },
+      ],
+    })).toEqual([
+      "engine disconnect · ok · 10 ms",
+      're-register and verify · failed · 900 ms — {"code":"opencode_mcp_sync_failed"}',
+    ]);
+  });
+
+  test("support bundle is JSON, carries context, and redacts bearer material", () => {
+    const bundle = buildCloudMcpSupportBundle({
+      health: baseHealth({
+        firstFailure: {
+          code: "invalid_mcp_token",
+          stage: "transport_auth",
+          retryable: false,
+          recommendedAction: "Reconnect OpenWork Cloud",
+          message: "rejected",
+          details: { header: "Bearer owt_super_secret_token_value" },
+        },
+      }),
+      context: {
+        workspaceId: "ws_1",
+        orgId: "org_1",
+        denBaseUrl: "https://app.openwork.test",
+        serverBaseUrl: "https://worker.openwork.test",
+      },
+      capturedAt: CHECKED_AT,
+    });
+
+    const parsed = JSON.parse(bundle) as Record<string, unknown>;
+    expect(parsed.kind).toBe("openwork-cloud-mcp-diagnostic");
+    expect(parsed.capturedAt).toBe(CHECKED_AT);
+    expect((parsed.context as Record<string, unknown>).workspaceId).toBe("ws_1");
+    expect(bundle).not.toContain("owt_super_secret_token_value");
+  });
+});

--- a/apps/app/tests/cloud-mcp-health.test.ts
+++ b/apps/app/tests/cloud-mcp-health.test.ts
@@ -14,6 +14,7 @@ import {
   cloudMcpFailureStageLabel,
   isCloudMcpAuthTokenFailure,
   isCloudMcpAuthTokenFailureCode,
+  runOpenworkCloudMcpEngineRefresh,
   runOpenworkCloudMcpReconciler,
 } from "../src/react-app/domains/connections/cloud-mcp-reconciler";
 
@@ -190,8 +191,102 @@ describe("OpenWork Cloud MCP reconciler", () => {
     expect(getCount).toBe(1);
     expect(mintCount).toBe(0);
     expect(postCount).toBe(0);
-    expect(result.markerWritten).toBe(false);
     expect(writes).toBe(0);
+  });
+
+  test("Test now with probe asks the server for a direct endpoint verification", async () => {
+    const probeOptionsSeen: Array<{ probe?: boolean } | undefined> = [];
+    const client = {
+      baseUrl: scope.serverBaseUrl,
+      getOpenworkCloudMcpHealth: async (
+        _workspaceId: string,
+        _providerModel?: unknown,
+        options?: { probe?: boolean },
+      ) => {
+        probeOptionsSeen.push(options);
+        return health({ usable: true });
+      },
+      reconcileOpenworkCloudMcp: async () => health({ usable: true }),
+    };
+
+    await runOpenworkCloudMcpReconciler({
+      mode: "health",
+      client,
+      context,
+      mintToken: async () => token,
+      refreshMarginMs: 24 * 60 * 60 * 1000,
+      probe: true,
+    });
+    await runOpenworkCloudMcpReconciler({
+      mode: "health",
+      client,
+      context,
+      mintToken: async () => token,
+      refreshMarginMs: 24 * 60 * 60 * 1000,
+    });
+
+    expect(probeOptionsSeen).toEqual([{ probe: true }, undefined]);
+  });
+
+  test("engine refresh maps the endpoint result and skips unsupported servers", async () => {
+    const calls: Array<{ workspaceId: string; payload?: { provider?: string; model?: string; trigger?: string } }> = [];
+    const refreshedHealth = health({ usable: true });
+    const refresh = {
+      performed: true,
+      trigger: "desktop-engine-refresh",
+      startedAt: new Date(NOW).toISOString(),
+      finishedAt: new Date(NOW + 500).toISOString(),
+      steps: [
+        { step: "engine_disconnect", ok: true, latencyMs: 12 },
+        { step: "reapply", ok: true, latencyMs: 480 },
+      ],
+    };
+    const result = await runOpenworkCloudMcpEngineRefresh({
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => refreshedHealth,
+        reconcileOpenworkCloudMcp: async () => refreshedHealth,
+        refreshOpenworkCloudMcpEngine: async (workspaceId, payload) => {
+          calls.push({ workspaceId, payload });
+          return { refresh, health: refreshedHealth };
+        },
+      },
+      context,
+    });
+
+    expect(result.status).toBe("refreshed");
+    expect(result.refresh?.steps.map((step) => step.step)).toEqual(["engine_disconnect", "reapply"]);
+    expect(calls).toEqual([
+      {
+        workspaceId: scope.workspaceId,
+        payload: { provider: "openwork", model: "gpt-5", trigger: "desktop-engine-refresh" },
+      },
+    ]);
+
+    const failed = await runOpenworkCloudMcpEngineRefresh({
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => refreshedHealth,
+        reconcileOpenworkCloudMcp: async () => refreshedHealth,
+        refreshOpenworkCloudMcpEngine: async () => ({
+          refresh: { ...refresh, steps: [{ step: "engine_disconnect", ok: false, latencyMs: 3 }, { step: "reapply", ok: false, latencyMs: 9 }] },
+          health: health({ usable: false }),
+        }),
+      },
+      context,
+    });
+    expect(failed.status).toBe("failed");
+
+    const skipped = await runOpenworkCloudMcpEngineRefresh({
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => refreshedHealth,
+        reconcileOpenworkCloudMcp: async () => refreshedHealth,
+      },
+      context,
+    });
+    expect(skipped.status).toBe("skipped");
+    expect(skipped.skippedReason).toBe("unsupported");
   });
 
   test("writes marker only when returned health is usable", async () => {

--- a/apps/server/src/cloud-mcp-health.test.ts
+++ b/apps/server/src/cloud-mcp-health.test.ts
@@ -75,7 +75,12 @@ function startMockOpencode(mode: DirectProbeMode) {
     async fetch(request) {
       const url = new URL(request.url);
       if (url.pathname === "/global/health") return Response.json({ healthy: true, version: "1.17.11" });
-      if (url.pathname === "/mcp" && request.method === "GET") return Response.json({ "openwork-cloud": { status: "connected" } });
+      if (url.pathname === "/mcp" && request.method === "GET") {
+        return Response.json({
+          "openwork-cloud": { status: "connected" },
+          "sibling-remote": { status: "failed", error: "fetch failed" },
+        });
+      }
       if (url.pathname === "/experimental/tool/ids") return Response.json([...OPENWORK_CLOUD_EXPECTED_TOOLS, ...OPENWORK_CLOUD_PLUGIN_CANARIES]);
       if (url.pathname === "/cloud-mcp/mcp/agent" && request.method === "POST") {
         if (mode === "unauthorized") return Response.json({ error: "invalid token" }, { status: 401 });
@@ -362,5 +367,72 @@ describe("cloud MCP health foundation", () => {
     expect(health.firstFailure?.code).toBe("cloud_tools_missing");
     expect(health.tools.direct.checked).toBe(true);
     expect(health.tools.direct.missing).toEqual(["execute_capability"]);
+  });
+
+  test("reports the engine's full MCP server map with per-server errors", async () => {
+    const { health } = await readHealthForDirectProbe("ok");
+
+    expect(health.engineInspection.checked).toBe(true);
+    expect(health.engineInspection.cloudPresent).toBe(true);
+    expect(health.engineInspection.serverCount).toBe(2);
+    expect(health.engineInspection.servers).toEqual([
+      { name: "openwork-cloud", status: "connected" },
+      { name: "sibling-remote", status: "failed", error: "fetch failed" },
+    ]);
+  });
+
+  test("records a probe step trace with latencies and endpoint server info", async () => {
+    const { health, directUrl } = await readHealthForDirectProbe("ok", { probe: true });
+
+    const trace = health.tools.direct.trace;
+    expect(trace?.endpoint).toBe(directUrl);
+    expect(trace?.steps.map((step) => step.step)).toEqual(["initialize", "initialized_notice", "tools_list"]);
+    for (const step of trace?.steps ?? []) {
+      expect(step.ok).toBe(true);
+      expect(step.latencyMs).toBeGreaterThanOrEqual(0);
+    }
+    expect(trace?.steps[0]?.httpStatus).toBe(200);
+    expect(trace?.serverInfo).toEqual({ name: "openwork-cloud-test", version: "1.0.0" });
+    expect(trace?.protocolVersion).toBe("2025-06-18");
+    expect(health.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  test("captures the rejected initialize step in the probe trace on HTTP 401", async () => {
+    const { health } = await readHealthForDirectProbe("unauthorized", { probe: true });
+
+    const steps = health.tools.direct.trace?.steps ?? [];
+    expect(steps).toHaveLength(1);
+    expect(steps[0]).toMatchObject({ step: "initialize", ok: false, httpStatus: 401 });
+  });
+
+  test("preserves the transport error cause chain when the probe cannot connect", async () => {
+    const { health } = await readHealthForDirectProbe("ok", {
+      probe: true,
+      beforeRead: (directUrl) => {
+        const originalFetch = globalThis.fetch;
+        globalThis.fetch = Object.assign(
+          (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
+            const url = input instanceof Request ? input.url : String(input);
+            if (url === directUrl) {
+              const cause = Object.assign(new Error("self signed certificate in certificate chain"), {
+                code: "SELF_SIGNED_CERT_IN_CHAIN",
+              });
+              return Promise.reject(new Error("fetch failed", { cause }));
+            }
+            return originalFetch(input, init);
+          },
+          { preconnect: originalFetch.preconnect },
+        );
+      },
+    });
+
+    // The engine stays authoritative, but the probe failure must carry the
+    // cause that OpenCode itself collapses to a bare "fetch failed".
+    expect(health.tools.direct.failure?.code).toBe("probe_unreachable");
+    const details = JSON.stringify(health.tools.direct.failure?.details);
+    expect(details).toContain("SELF_SIGNED_CERT_IN_CHAIN");
+    expect(details).toContain("self signed certificate in certificate chain");
+    const initializeStep = health.tools.direct.trace?.steps.find((step) => step.step === "initialize");
+    expect(initializeStep?.ok).toBe(false);
   });
 });

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -227,6 +227,7 @@ export type CloudMcpHealth = {
     status: "not_checked" | "missing" | "connected" | "disabled" | "failed" | "needs_auth" | "needs_client_registration" | "unreachable" | "unknown";
     error?: unknown;
   };
+  engineInspection: CloudMcpEngineInspection;
   tools: {
     expected: string[];
     present: string[];
@@ -237,6 +238,7 @@ export type CloudMcpHealth = {
       expected: string[];
       present: string[];
       missing: string[];
+      trace?: CloudMcpProbeTrace;
       error?: unknown;
       failure?: CloudMcpFailure;
     };
@@ -262,6 +264,7 @@ export type CloudMcpHealth = {
   toolDenies: McpToolDeny[];
   firstFailure: CloudMcpFailure | null;
   checkedAt: string;
+  durationMs: number;
 };
 
 type RedactedCloudMcpConfig = {
@@ -342,12 +345,52 @@ type ToolSnapshot = {
   missing: string[];
 };
 
+export type CloudMcpEngineServerStatus = {
+  name: string;
+  status: string;
+  error?: string;
+};
+
+/**
+ * The engine's own view of every MCP server it tracks, read over the OpenCode
+ * SDK. Support triage needs the siblings: "everything failed" points at the
+ * engine host's network path, "only openwork-cloud failed" points at the Cloud
+ * endpoint or token, and an absent entry means the dynamic registration was
+ * lost (e.g. after an engine state rebuild) and must be re-applied.
+ */
+export type CloudMcpEngineInspection = {
+  checked: boolean;
+  cloudPresent?: boolean;
+  serverCount?: number;
+  servers?: CloudMcpEngineServerStatus[];
+};
+
+export type CloudMcpProbeStepName = "initialize" | "initialized_notice" | "tools_list";
+
+export type CloudMcpProbeStep = {
+  step: CloudMcpProbeStepName;
+  ok: boolean;
+  httpStatus?: number;
+  latencyMs: number;
+  error?: unknown;
+};
+
+export type CloudMcpProbeTrace = {
+  endpoint: string | null;
+  startedAt: string;
+  latencyMs: number;
+  protocolVersion: string | null;
+  serverInfo: { name: string | null; version: string | null } | null;
+  steps: CloudMcpProbeStep[];
+};
+
 type DirectCloudToolsSnapshot = {
   checked: boolean;
   source: "mcp_tools_list";
   expected: string[];
   present: string[];
   missing: string[];
+  trace?: CloudMcpProbeTrace;
   error?: unknown;
   failure?: CloudMcpFailure;
 };
@@ -368,6 +411,7 @@ type ProviderProjectionSnapshot = {
 
 type Inspection = {
   engine: CloudMcpHealth["engine"];
+  engineInspection: CloudMcpEngineInspection;
   tools: ToolSnapshot;
   directTools: DirectCloudToolsSnapshot;
   providerProjection: ProviderProjectionSnapshot;
@@ -1130,17 +1174,75 @@ function toolsFromEngineAttestation(): ToolSnapshot {
   return { expected, present: [...expected], missing: [] };
 }
 
+// OpenCode collapses a failed remote connect to `Error.message` (often the bare
+// "fetch failed"), so the probe preserves the cause chain (code/errno/syscall)
+// — it is the only place the network-level cause survives for support.
+function describeTransportError(error: unknown): Record<string, unknown> {
+  const chain: Array<Record<string, unknown>> = [];
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current !== undefined && current !== null; depth += 1) {
+    if (!(current instanceof Error)) {
+      chain.push({ message: sanitizeDiagnosticString(String(current)) });
+      break;
+    }
+    const entry: Record<string, unknown> = { message: sanitizeDiagnosticString(current.message) };
+    if (current.name && current.name !== "Error") entry.name = sanitizeDiagnosticString(current.name);
+    const withCode = current as Error & { code?: unknown; errno?: unknown; syscall?: unknown };
+    if (typeof withCode.code === "string") entry.code = sanitizeDiagnosticString(withCode.code);
+    if (typeof withCode.errno === "number") entry.errno = withCode.errno;
+    if (typeof withCode.syscall === "string") entry.syscall = sanitizeDiagnosticString(withCode.syscall);
+    chain.push(entry);
+    current = current.cause;
+  }
+  const first = chain[0] ?? { message: "unknown transport error" };
+  return { ...first, ...(chain.length > 1 ? { causes: chain.slice(1) } : {}) };
+}
+
 async function readDirectCloudTools(config: Record<string, unknown>): Promise<DirectCloudToolsSnapshot> {
   const url = readString(config.url);
   const authorization = authorizationHeader(config);
   const endpoint = url ? sanitizeDiagnosticString(url) : null;
+  const startedAtMs = Date.now();
+  const steps: CloudMcpProbeStep[] = [];
+  let protocolVersionSeen: string | null = null;
+  let serverInfo: CloudMcpProbeTrace["serverInfo"] = null;
+  const trace = (): CloudMcpProbeTrace => ({
+    endpoint,
+    startedAt: new Date(startedAtMs).toISOString(),
+    latencyMs: Date.now() - startedAtMs,
+    protocolVersion: protocolVersionSeen,
+    serverInfo,
+    steps,
+  });
+  const timed = async <T>(input: {
+    step: CloudMcpProbeStepName;
+    task: () => Promise<T>;
+    httpStatus?: (value: T) => number;
+    ok?: (value: T) => boolean;
+  }): Promise<T> => {
+    const stepStarted = Date.now();
+    try {
+      const value = await input.task();
+      const httpStatus = input.httpStatus?.(value);
+      steps.push({
+        step: input.step,
+        ok: input.ok ? input.ok(value) : true,
+        ...(httpStatus !== undefined ? { httpStatus } : {}),
+        latencyMs: Date.now() - stepStarted,
+      });
+      return value;
+    } catch (error) {
+      steps.push({ step: input.step, ok: false, latencyMs: Date.now() - stepStarted, error: describeTransportError(error) });
+      throw error;
+    }
+  };
   if (!url || !authorization) {
     const failureResult = directCloudToolsFailure({
       retryable: false,
       message: "The persisted OpenWork Cloud MCP config cannot be used for direct tools/list verification.",
       details: { endpoint, authorizationPresent: Boolean(authorization) },
     });
-    return { ...directToolsNotChecked(), checked: true, missing: expectedDirectToolNames(), error: failureResult.details, failure: failureResult };
+    return { ...directToolsNotChecked(), checked: true, missing: expectedDirectToolNames(), trace: trace(), error: failureResult.details, failure: failureResult };
   }
 
   const baseHeaders: Record<string, string> = {
@@ -1149,19 +1251,24 @@ async function readDirectCloudTools(config: Record<string, unknown>): Promise<Di
     "content-type": "application/json",
   };
   try {
-    const initialized = await mcpJsonRpcPost({
-      url,
-      headers: baseHeaders,
-      body: {
-        id: 1,
-        jsonrpc: "2.0",
-        method: "initialize",
-        params: {
-          capabilities: {},
-          clientInfo: { name: "openwork-server-cloud-mcp-health", version: "1.0.0" },
-          protocolVersion: "2025-06-18",
+    const initialized = await timed({
+      step: "initialize",
+      task: () => mcpJsonRpcPost({
+        url,
+        headers: baseHeaders,
+        body: {
+          id: 1,
+          jsonrpc: "2.0",
+          method: "initialize",
+          params: {
+            capabilities: {},
+            clientInfo: { name: "openwork-server-cloud-mcp-health", version: "1.0.0" },
+            protocolVersion: "2025-06-18",
+          },
         },
-      },
+      }),
+      httpStatus: (value) => value.response.status,
+      ok: (value) => value.response.ok,
     });
     if (!initialized.response.ok) {
       const authFailure = directCloudAuthFailure(initialized.response, initialized.payload, endpoint ?? "unknown");
@@ -1170,26 +1277,48 @@ async function readDirectCloudTools(config: Record<string, unknown>): Promise<Di
         message: "The OpenWork Cloud MCP endpoint initialize request failed during direct verification.",
         details: { endpoint, status: initialized.response.status, response: initialized.payload },
       });
-      return { ...directToolsNotChecked(), checked: true, missing: expectedDirectToolNames(), error: failureResult.details, failure: failureResult };
+      return { ...directToolsNotChecked(), checked: true, missing: expectedDirectToolNames(), trace: trace(), error: failureResult.details, failure: failureResult };
+    }
+
+    const initRecord = jsonRpcRecord(initialized.payload);
+    const initResult = initRecord && isRecord(initRecord.result) ? initRecord.result : null;
+    const serverInfoRecord = initResult && isRecord(initResult.serverInfo) ? initResult.serverInfo : null;
+    if (serverInfoRecord) {
+      serverInfo = {
+        name: typeof serverInfoRecord.name === "string" ? sanitizeDiagnosticString(serverInfoRecord.name) : null,
+        version: typeof serverInfoRecord.version === "string" ? sanitizeDiagnosticString(serverInfoRecord.version) : null,
+      };
     }
 
     const sessionId = initialized.response.headers.get("mcp-session-id");
     const protocolVersion = initialized.response.headers.get("mcp-protocol-version");
+    protocolVersionSeen = protocolVersion
+      ?? (initResult && typeof initResult.protocolVersion === "string" ? sanitizeDiagnosticString(initResult.protocolVersion) : null);
     const sessionHeaders: Record<string, string> = {
       ...baseHeaders,
       ...(sessionId ? { "mcp-session-id": sessionId } : {}),
       ...(protocolVersion ? { "mcp-protocol-version": protocolVersion } : {}),
     };
-    await withCloudEndpointProbeTimeout((signal) => externalFetch(url, {
-      method: "POST",
-      headers: sessionHeaders,
-      body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }),
-      signal,
-    }));
-    const listed = await mcpJsonRpcPost({
-      url,
-      headers: sessionHeaders,
-      body: { id: 2, jsonrpc: "2.0", method: "tools/list", params: {} },
+    await timed({
+      step: "initialized_notice",
+      task: () => withCloudEndpointProbeTimeout((signal) => externalFetch(url, {
+        method: "POST",
+        headers: sessionHeaders,
+        body: JSON.stringify({ jsonrpc: "2.0", method: "notifications/initialized", params: {} }),
+        signal,
+      })),
+      httpStatus: (value) => value.status,
+      ok: (value) => value.ok,
+    });
+    const listed = await timed({
+      step: "tools_list",
+      task: () => mcpJsonRpcPost({
+        url,
+        headers: sessionHeaders,
+        body: { id: 2, jsonrpc: "2.0", method: "tools/list", params: {} },
+      }),
+      httpStatus: (value) => value.response.status,
+      ok: (value) => value.response.ok,
     });
     if (!listed.response.ok) {
       const authFailure = directCloudAuthFailure(listed.response, listed.payload, endpoint ?? "unknown");
@@ -1198,7 +1327,7 @@ async function readDirectCloudTools(config: Record<string, unknown>): Promise<Di
         message: "The OpenWork Cloud MCP endpoint tools/list request failed during direct verification.",
         details: { endpoint, status: listed.response.status, response: listed.payload },
       });
-      return { ...directToolsNotChecked(), checked: true, missing: expectedDirectToolNames(), error: failureResult.details, failure: failureResult };
+      return { ...directToolsNotChecked(), checked: true, missing: expectedDirectToolNames(), trace: trace(), error: failureResult.details, failure: failureResult };
     }
     const toolNames = toolNamesFromMcpPayload(listed.payload);
     if (!toolNames.names) {
@@ -1207,9 +1336,9 @@ async function readDirectCloudTools(config: Record<string, unknown>): Promise<Di
         message: "The OpenWork Cloud MCP endpoint tools/list response could not be parsed.",
         details: { endpoint, error: toolNames.error },
       });
-      return { ...directToolsNotChecked(), checked: true, missing: expectedDirectToolNames(), error: failureResult.details, failure: failureResult };
+      return { ...directToolsNotChecked(), checked: true, missing: expectedDirectToolNames(), trace: trace(), error: failureResult.details, failure: failureResult };
     }
-    return directToolsFromNames(toolNames.names);
+    return { ...directToolsFromNames(toolNames.names), trace: trace() };
   } catch (error) {
     // Field incident (corporate Windows, TLS interception): a probe transport
     // failure must never be reported as missing tools — the engine's own MCP
@@ -1220,9 +1349,9 @@ async function readDirectCloudTools(config: Record<string, unknown>): Promise<Di
       retryable: true,
       recommendedAction: "Check this machine's network path (proxy/TLS trust) to the Cloud MCP endpoint. The engine's own MCP connection is authoritative.",
       message: "The OpenWork server could not reach the Cloud MCP endpoint for direct verification (transport error before any HTTP response). This does not indicate missing tools.",
-      details: { endpoint, error: error instanceof Error ? error.message : String(error) },
+      details: { endpoint, error: error instanceof Error ? error.message : String(error), transport: describeTransportError(error) },
     });
-    return { ...directToolsNotChecked(), checked: false, missing: [], error: failureResult.details, failure: failureResult };
+    return { ...directToolsNotChecked(), checked: false, missing: [], trace: trace(), error: failureResult.details, failure: failureResult };
   }
 }
 
@@ -1496,6 +1625,27 @@ function engineStatusFromMcpStatus(status: McpStatus | undefined): CloudMcpHealt
   return { status: status.status };
 }
 
+function engineInspectionNotChecked(): CloudMcpEngineInspection {
+  return { checked: false };
+}
+
+function engineInspectionFromStatuses(statuses: Record<string, McpStatus>): CloudMcpEngineInspection {
+  const servers = Object.entries(statuses)
+    .map(([name, status]) => ({
+      name: sanitizeDiagnosticString(name),
+      status: status.status,
+      ...(("error" in status) && typeof status.error === "string" ? { error: sanitizeDiagnosticString(status.error) } : {}),
+    }))
+    .sort((a, b) => a.name.localeCompare(b.name))
+    .slice(0, 50);
+  return {
+    checked: true,
+    cloudPresent: Boolean(statuses[OPENWORK_CLOUD_MCP_NAME]),
+    serverCount: Object.keys(statuses).length,
+    servers,
+  };
+}
+
 function readVersionFromHealthPayload(payload: unknown): string | null {
   if (!isRecord(payload)) return null;
   return typeof payload.version === "string" ? sanitizeDiagnosticString(payload.version) : null;
@@ -1545,6 +1695,7 @@ async function inspectOpenworkCloud(input: {
     failures.push(statusResult.failure);
     return {
       engine: { status: statusResult.failure.code === "opencode_engine_unreachable" ? "unreachable" : "unknown", error: statusResult.failure.details },
+      engineInspection: engineInspectionNotChecked(),
       tools: emptyTools,
       directTools: emptyDirectTools,
       providerProjection: providerProjectionNotChecked(input.providerModel),
@@ -1556,6 +1707,7 @@ async function inspectOpenworkCloud(input: {
     };
   }
 
+  const engineInspection = engineInspectionFromStatuses(statusResult.data ?? {});
   const cloudStatus = statusResult.data?.[OPENWORK_CLOUD_MCP_NAME];
   if (cloudStatus) {
     input.refreshRegistrationFromLiveStatus?.(
@@ -1571,6 +1723,7 @@ async function inspectOpenworkCloud(input: {
     failures.push(statusFailure(cloudStatus));
     return {
       engine,
+      engineInspection,
       tools: emptyTools,
       directTools: emptyDirectTools,
       providerProjection: providerProjectionNotChecked(input.providerModel),
@@ -1587,6 +1740,7 @@ async function inspectOpenworkCloud(input: {
     failures.push(idsResult.failure);
     return {
       engine,
+      engineInspection,
       tools: emptyTools,
       directTools: emptyDirectTools,
       providerProjection: providerProjectionNotChecked(input.providerModel),
@@ -1633,7 +1787,7 @@ async function inspectOpenworkCloud(input: {
     }));
   }
 
-  return { engine, tools, directTools, providerProjection, pluginCanaries, experimentalToolIds, experimentalProviderTools, opencodeVersion, failures };
+  return { engine, engineInspection, tools, directTools, providerProjection, pluginCanaries, experimentalToolIds, experimentalProviderTools, opencodeVersion, failures };
 }
 
 function providerProjectionNotChecked(providerModel?: CloudMcpProviderModelContext): ProviderProjectionSnapshot {
@@ -1818,6 +1972,7 @@ export async function readOpenworkCloudMcpHealth(input: {
   refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
 }): Promise<CloudMcpHealth> {
   const checkedAt = new Date().toISOString();
+  const startedAtMs = Date.now();
   const desired = await readDesiredState({ config: input.config, workspace: input.workspace, directory: input.directory });
   let delivery = cloudMcpDeliveryState.snapshot(input.workspace, input.directory, desired.revision);
   const toolDenies = desired.present
@@ -1861,6 +2016,7 @@ export async function readOpenworkCloudMcpHealth(input: {
 
   let inspection: Inspection = {
     engine: { status: "not_checked" },
+    engineInspection: engineInspectionNotChecked(),
     tools: splitPresentMissing([], expectedTools()),
     directTools: directToolsNotChecked(),
     providerProjection: providerProjectionNotChecked(input.providerModel),
@@ -1921,6 +2077,7 @@ export async function readOpenworkCloudMcpHealth(input: {
     },
     delivery,
     engine: inspection.engine,
+    engineInspection: inspection.engineInspection,
     tools: {
       expected: inspection.tools.expected,
       present: inspection.tools.present,
@@ -1931,6 +2088,7 @@ export async function readOpenworkCloudMcpHealth(input: {
         expected: inspection.directTools.expected,
         present: inspection.directTools.present,
         missing: inspection.directTools.missing,
+        ...(inspection.directTools.trace ? { trace: inspection.directTools.trace } : {}),
         ...(inspection.directTools.error ? { error: inspection.directTools.error } : {}),
         ...(inspection.directTools.failure ? { failure: inspection.directTools.failure } : {}),
       },
@@ -1952,6 +2110,7 @@ export async function readOpenworkCloudMcpHealth(input: {
     toolDenies,
     firstFailure,
     checkedAt,
+    durationMs: Date.now() - startedAtMs,
   };
 }
 
@@ -2121,6 +2280,7 @@ export async function reconcilePersistedOpenworkCloudMcp(input: {
   config: ServerConfig;
   workspace: WorkspaceInfo;
   directory: string | null;
+  providerModel?: CloudMcpProviderModelContext;
   serverMetadata?: CloudMcpServerMetadata;
   createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
   registerRuntimeMcp: CloudMcpRuntimeRegistrar;
@@ -2143,4 +2303,110 @@ export async function reconcilePersistedOpenworkCloudMcp(input: {
 
 export function markOpenworkCloudMcpStale(workspace: WorkspaceInfo, directory: string | null): void {
   cloudMcpDeliveryState.markWorkspaceStale(workspace, directory);
+}
+
+export type CloudMcpEngineRefreshStep = {
+  step: "engine_disconnect" | "reapply";
+  ok: boolean;
+  latencyMs: number;
+  detail?: unknown;
+};
+
+export type CloudMcpEngineRefresh = {
+  performed: boolean;
+  reason?: "desired_missing";
+  trigger: string;
+  startedAt: string;
+  finishedAt: string;
+  steps: CloudMcpEngineRefreshStep[];
+};
+
+export type CloudMcpEngineRefreshResult = {
+  refresh: CloudMcpEngineRefresh;
+  health: CloudMcpHealth;
+};
+
+// OpenCode never retries a failed MCP connection on its own: a remote connect
+// failure is stored as {status:"failed"} and the client is dropped until
+// something external re-drives it. This refresh closes any wedged client
+// first (disconnect), then re-runs the persisted reconcile, which re-POSTs
+// /mcp — an unconditional fresh connect attempt on the engine side.
+export async function refreshOpenworkCloudMcpEngine(input: {
+  config: ServerConfig;
+  workspace: WorkspaceInfo;
+  directory: string | null;
+  providerModel?: CloudMcpProviderModelContext;
+  serverMetadata?: CloudMcpServerMetadata;
+  createWorkspaceOpencodeClient: (config: ServerConfig, workspace: WorkspaceInfo) => WorkspaceOpencodeClient;
+  registerRuntimeMcp: CloudMcpRuntimeRegistrar;
+  refreshRegistrationFromLiveStatus?: CloudMcpLiveStatusObserver;
+  trigger?: string;
+}): Promise<CloudMcpEngineRefreshResult> {
+  const trigger = input.trigger?.trim() || "engine-refresh";
+  const startedAt = new Date().toISOString();
+  const steps: CloudMcpEngineRefreshStep[] = [];
+  const finish = (performed: boolean, health: CloudMcpHealth, reason?: "desired_missing"): CloudMcpEngineRefreshResult => ({
+    refresh: {
+      performed,
+      ...(reason ? { reason } : {}),
+      trigger,
+      startedAt,
+      finishedAt: new Date().toISOString(),
+      steps,
+    },
+    health,
+  });
+
+  const runtimeConfig = await readRuntimeOpencodeConfig(input.config, input.workspace.id);
+  const desiredConfig = runtimeMcpMap(runtimeConfig)[OPENWORK_CLOUD_MCP_NAME];
+  if (!desiredConfig) {
+    return finish(false, await readOpenworkCloudMcpHealth({ ...input, probe: true }), "desired_missing");
+  }
+
+  const disconnectStarted = Date.now();
+  try {
+    const opencode = input.createWorkspaceOpencodeClient(input.config, input.workspace);
+    const result = await withEngineProbeTimeout(() => opencode.mcp.disconnect({
+      name: OPENWORK_CLOUD_MCP_NAME,
+      ...locationParams(input.directory),
+    }));
+    steps.push({
+      step: "engine_disconnect",
+      ok: result.error === undefined,
+      latencyMs: Date.now() - disconnectStarted,
+      ...(result.error !== undefined
+        ? { detail: sanitizeDiagnosticValue({ status: result.response.status, error: result.error }) }
+        : {}),
+    });
+  } catch (error) {
+    // A dynamically-registered entry can be gone after an engine state
+    // rebuild, and the engine itself can be down; the reapply below is the
+    // authoritative step either way.
+    steps.push({
+      step: "engine_disconnect",
+      ok: false,
+      latencyMs: Date.now() - disconnectStarted,
+      detail: sanitizeDiagnosticValue(describeTransportError(error)),
+    });
+  }
+
+  const reapplyStarted = Date.now();
+  const health = await reconcilePersistedOpenworkCloudMcp({
+    config: input.config,
+    workspace: input.workspace,
+    directory: input.directory,
+    providerModel: input.providerModel,
+    serverMetadata: input.serverMetadata,
+    createWorkspaceOpencodeClient: input.createWorkspaceOpencodeClient,
+    registerRuntimeMcp: input.registerRuntimeMcp,
+    refreshRegistrationFromLiveStatus: input.refreshRegistrationFromLiveStatus,
+    trigger,
+  });
+  steps.push({
+    step: "reapply",
+    ok: health.firstFailure === null,
+    latencyMs: Date.now() - reapplyStarted,
+    ...(health.firstFailure ? { detail: { code: health.firstFailure.code, stage: health.firstFailure.stage } } : {}),
+  });
+  return finish(true, health);
 }

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -1582,13 +1582,26 @@ function statusFailure(status: McpStatus | undefined): CloudMcpFailure {
 
 function inferFailedStatus(error: string): CloudMcpFailure {
   const lower = error.toLowerCase();
-  if (lower.includes("expired")) {
+  // Engines that preserve transport cause chains produce strings like
+  // "fetch failed; caused by: certificate has expired (CERT_HAS_EXPIRED)".
+  // Certificate/TLS wording ("expired", "authority", "revoked") must never be
+  // classified as a token or session problem — reconnecting cannot repair a
+  // broken transport, and richer engine errors must not change the verdict
+  // for what is still a connection-level failure.
+  const certTransport =
+    lower.includes("certificat") ||
+    lower.includes("cert_") ||
+    lower.includes("tls") ||
+    lower.includes("ssl") ||
+    lower.includes("self signed") ||
+    lower.includes("self-signed");
+  if (!certTransport && lower.includes("expired")) {
     return failure({ code: "invalid_mcp_token", stage: "transport_auth", retryable: false, recommendedAction: "Reconnect OpenWork Cloud", message: "openwork-cloud token is expired.", aliases: ["openwork_cloud_token_expired"], details: { error } });
   }
-  if (lower.includes("invalid_token") || lower.includes("unauthorized") || lower.includes("401") || lower.includes("auth")) {
+  if (!certTransport && (lower.includes("invalid_token") || lower.includes("unauthorized") || lower.includes("401") || lower.includes("auth"))) {
     return failure({ code: "invalid_mcp_token", stage: "transport_auth", retryable: false, recommendedAction: "Reconnect OpenWork Cloud", message: "openwork-cloud authentication failed.", aliases: ["openwork_cloud_auth_invalid"], details: { error } });
   }
-  if (lower.includes("invalid_grant") || lower.includes("session") || lower.includes("revoked")) {
+  if (!certTransport && (lower.includes("invalid_grant") || lower.includes("session") || lower.includes("revoked"))) {
     return failure({ code: "mcp_session_revoked", stage: "transport_auth", retryable: false, recommendedAction: "Reconnect OpenWork Cloud", message: "openwork-cloud session was revoked.", details: { error } });
   }
   if (lower.includes("membership") || lower.includes("member")) {

--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -28,6 +28,7 @@ type MockOpencodeOptions = {
   hangHealth?: boolean;
   delayMcpStatusMs?: number;
   postFailure?: { status: number; body: unknown };
+  cloudFailedError?: string;
 };
 
 type CloudConfig = {
@@ -109,6 +110,9 @@ function startMockOpencode(options: MockOpencodeOptions = {}) {
       if (url.pathname === "/mcp" && request.method === "GET") {
         statusReads += 1;
         if (options.delayMcpStatusMs) await new Promise((resolve) => setTimeout(resolve, options.delayMcpStatusMs));
+        if (options.cloudFailedError) {
+          return Response.json({ "openwork-cloud": { status: "failed", error: options.cloudFailedError } });
+        }
         if (options.connectAfterStatusReads && statusReads < options.connectAfterStatusReads) {
           return Response.json({ "openwork-cloud": { status: "failed", error: "slow connect" } });
         }
@@ -667,6 +671,45 @@ describe("openwork-cloud MCP engine refresh", () => {
     expect(requireArray(refresh.steps, "refresh.steps")).toHaveLength(0);
     expect(requireRecord(body.health, "health").usable).toBe(false);
     expect(mock.requests.filter((request) => request.pathname === "/mcp/openwork-cloud/disconnect")).toHaveLength(0);
+  });
+
+  test("rejects malformed JSON on engine refresh instead of silently ignoring it", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ initialConnected: true });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
+
+    const response = await fetch(`${openwork.base}/workspace/ws_1/mcp/openwork-cloud/engine-refresh`, {
+      method: "POST",
+      headers: headers(),
+      body: "not-json",
+    });
+    expect(response.status).toBe(400);
+    expect((await responseRecord(response)).code).toBe("invalid_json");
+    expect(mock.requests.filter((request) => request.pathname === "/mcp/openwork-cloud/disconnect")).toHaveLength(0);
+  });
+
+  test("richer engine cert/TLS error strings stay classified as connection failures, not token problems", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({
+      cloudFailedError: "fetch failed; caused by: certificate has expired (CERT_HAS_EXPIRED)",
+    });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
+
+    const body = await responseRecord(await reconcile(openwork.base));
+    const failure = firstFailure(body);
+    // A transport/cert failure must never be classified as an expired token:
+    // "Reconnect OpenWork Cloud" cannot repair a broken TLS path.
+    expect(failure.code).toBe("opencode_mcp_sync_failed");
+    expect(failure.recommendedAction).toBe("Retry reconcile or reconnect OpenWork Cloud");
+  });
+
+  test("token-expired engine errors keep their token classification", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ cloudFailedError: "openwork-cloud bearer token expired" });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
+
+    const body = await responseRecord(await reconcile(openwork.base));
+    expect(firstFailure(body).code).toBe("invalid_mcp_token");
   });
 
   test("keeps step-level failure detail when the engine goes down between seed and refresh", async () => {

--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -100,6 +100,12 @@ function startMockOpencode(options: MockOpencodeOptions = {}) {
         registerCount += 1;
         return Response.json({});
       }
+      if (url.pathname === "/mcp/openwork-cloud/disconnect" && request.method === "POST") {
+        // OpenCode closes the client and keeps the config; status is no longer
+        // connected until a later POST /mcp re-registers it.
+        registerCount = 0;
+        return Response.json(true);
+      }
       if (url.pathname === "/mcp" && request.method === "GET") {
         statusReads += 1;
         if (options.delayMcpStatusMs) await new Promise((resolve) => setTimeout(resolve, options.delayMcpStatusMs));
@@ -601,5 +607,89 @@ describe("openwork-cloud MCP strict reconcile", () => {
     expect(generic.status).toBe(200);
     const genericBody = await responseRecord(generic);
     expect(requireArray(genericBody.items, "items").some((item) => isRecord(item) && item.name === "posthog")).toBe(true);
+  });
+});
+
+async function engineRefresh(base: string, workspaceId = "ws_1", body?: Record<string, unknown>): Promise<Response> {
+  return fetch(`${base}/workspace/${workspaceId}/mcp/openwork-cloud/engine-refresh`, {
+    method: "POST",
+    headers: headers(),
+    ...(body ? { body: JSON.stringify(body) } : {}),
+  });
+}
+
+describe("openwork-cloud MCP engine refresh", () => {
+  test("disconnects the engine client, re-registers, and returns ordered refresh steps with probed health", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ initialConnected: true });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
+
+    const seeded = await reconcile(openwork.base, "ws_1", { trigger: "seed" });
+    expect(seeded.status).toBe(200);
+    const registersBeforeRefresh = mock.requests.filter((request) => request.pathname === "/mcp" && request.method === "POST").length;
+
+    const response = await engineRefresh(openwork.base, "ws_1", { trigger: "support-call" });
+    expect(response.status).toBe(200);
+    const body = await responseRecord(response);
+
+    const refresh = requireRecord(body.refresh, "refresh");
+    expect(refresh.performed).toBe(true);
+    expect(refresh.trigger).toBe("support-call");
+    const steps = requireArray(refresh.steps, "refresh.steps").map((step) => requireRecord(step, "step"));
+    expect(steps.map((step) => step.step)).toEqual(["engine_disconnect", "reapply"]);
+    expect(steps.every((step) => step.ok === true)).toBe(true);
+    expect(steps.every((step) => typeof step.latencyMs === "number")).toBe(true);
+
+    const health = requireRecord(body.health, "health");
+    expect(health.phase).toBe("ready");
+    expect(health.usable).toBe(true);
+    expect(delivery(health).state).toBe("ready");
+
+    const disconnects = mock.requests.filter((request) => request.pathname === "/mcp/openwork-cloud/disconnect");
+    expect(disconnects).toHaveLength(1);
+    expectDirectoryQuery(disconnects[0]?.search, root);
+    const registersAfterRefresh = mock.requests.filter((request) => request.pathname === "/mcp" && request.method === "POST").length;
+    expect(registersAfterRefresh).toBeGreaterThan(registersBeforeRefresh);
+  });
+
+  test("reports desired_missing without touching the engine when no config is persisted", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode();
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
+
+    const response = await engineRefresh(openwork.base);
+    expect(response.status).toBe(200);
+    const body = await responseRecord(response);
+
+    const refresh = requireRecord(body.refresh, "refresh");
+    expect(refresh.performed).toBe(false);
+    expect(refresh.reason).toBe("desired_missing");
+    expect(requireArray(refresh.steps, "refresh.steps")).toHaveLength(0);
+    expect(requireRecord(body.health, "health").usable).toBe(false);
+    expect(mock.requests.filter((request) => request.pathname === "/mcp/openwork-cloud/disconnect")).toHaveLength(0);
+  });
+
+  test("keeps step-level failure detail when the engine goes down between seed and refresh", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({ initialConnected: true });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
+
+    const seeded = await reconcile(openwork.base, "ws_1", { trigger: "seed" });
+    expect(seeded.status).toBe(200);
+    mock.server.stop(true);
+
+    const response = await engineRefresh(openwork.base, "ws_1", { trigger: "engine-down" });
+    expect(response.status).toBe(200);
+    const body = await responseRecord(response);
+
+    const refresh = requireRecord(body.refresh, "refresh");
+    expect(refresh.performed).toBe(true);
+    const steps = requireArray(refresh.steps, "refresh.steps").map((step) => requireRecord(step, "step"));
+    expect(steps.map((step) => step.step)).toEqual(["engine_disconnect", "reapply"]);
+    expect(steps.every((step) => step.ok === false)).toBe(true);
+
+    const health = requireRecord(body.health, "health");
+    expect(health.usable).toBe(false);
+    expect(typeof firstFailure(health).code).toBe("string");
   });
 });

--- a/apps/server/src/routes/cloud-mcp.ts
+++ b/apps/server/src/routes/cloud-mcp.ts
@@ -3,6 +3,7 @@ import {
   OPENWORK_CLOUD_MCP_NAME,
   readOpenworkCloudMcpHealth,
   reconcileOpenworkCloudMcp,
+  refreshOpenworkCloudMcpEngine,
   type CloudMcpServerMetadata,
   type CloudMcpProviderModelContext,
   type CloudMcpRuntimeRegistrar,
@@ -106,6 +107,29 @@ export function registerCloudMcpRoutes(options: RegisterCloudMcpRoutesOptions): 
       refreshRegistrationFromLiveStatus,
     });
     return jsonResponse(health);
+  });
+
+  addRoute(routes, "POST", "/workspace/:id/mcp/openwork-cloud/engine-refresh", "client", async (ctx) => {
+    ensureWritable(config);
+    requireClientScope(ctx, "collaborator");
+    const workspace = await resolveWorkspace(config, ctx.params.id);
+    assertExactWorkspace(ctx.params.id, workspace);
+    // The refresh needs no payload; an optional body may scope provider/model
+    // and name the trigger for the delivery ledger.
+    const body = await readJsonBody(ctx.request).catch(() => ({} as Record<string, unknown>));
+    if (isRecord(body)) assertStrictBody(body, workspace);
+    const result = await refreshOpenworkCloudMcpEngine({
+      config,
+      workspace,
+      directory: resolveOpencodeDirectory(workspace),
+      providerModel: isRecord(body) ? providerModelFromBody(body) : undefined,
+      serverMetadata,
+      createWorkspaceOpencodeClient,
+      registerRuntimeMcp,
+      refreshRegistrationFromLiveStatus,
+      trigger: isRecord(body) && typeof body.trigger === "string" ? body.trigger : undefined,
+    });
+    return jsonResponse(result);
   });
 
   addRoute(routes, "POST", "/workspace/:id/mcp/openwork-cloud/reconcile", "client", async (ctx) => {

--- a/apps/server/src/routes/cloud-mcp.ts
+++ b/apps/server/src/routes/cloud-mcp.ts
@@ -115,19 +115,33 @@ export function registerCloudMcpRoutes(options: RegisterCloudMcpRoutesOptions): 
     const workspace = await resolveWorkspace(config, ctx.params.id);
     assertExactWorkspace(ctx.params.id, workspace);
     // The refresh needs no payload; an optional body may scope provider/model
-    // and name the trigger for the delivery ledger.
-    const body = await readJsonBody(ctx.request).catch(() => ({} as Record<string, unknown>));
-    if (isRecord(body)) assertStrictBody(body, workspace);
+    // and name the trigger for the delivery ledger. An absent/empty body is
+    // fine, but malformed JSON stays a hard 400 — never silently ignored.
+    const raw = (await ctx.request.text()).trim();
+    let body: Record<string, unknown> = {};
+    if (raw) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(raw);
+      } catch {
+        throw new ApiError(400, "invalid_json", "Invalid JSON body");
+      }
+      if (!isRecord(parsed)) {
+        throw new ApiError(400, "invalid_payload", "JSON object body is required");
+      }
+      body = parsed;
+    }
+    assertStrictBody(body, workspace);
     const result = await refreshOpenworkCloudMcpEngine({
       config,
       workspace,
       directory: resolveOpencodeDirectory(workspace),
-      providerModel: isRecord(body) ? providerModelFromBody(body) : undefined,
+      providerModel: providerModelFromBody(body),
       serverMetadata,
       createWorkspaceOpencodeClient,
       registerRuntimeMcp,
       refreshRegistrationFromLiveStatus,
-      trigger: isRecord(body) && typeof body.trigger === "string" ? body.trigger : undefined,
+      trigger: typeof body.trigger === "string" ? body.trigger : undefined,
     });
     return jsonResponse(result);
   });


### PR DESCRIPTION
## Why

Field reports showed the Agent access card stuck on **Degraded — "Couldn't apply Cloud access to this workspace"** with no way to see what actually broke. Three structural problems make this failure opaque:

1. **OpenCode never retries a failed MCP connection.** A failed remote connect is stored as `{status:"failed"}` and the client is dropped; there is no timer, no on-tool-call reconnect, no on-session reconnect. It stays failed until something external re-drives it. Dynamically-registered entries are also lost entirely on an engine state rebuild.
2. **OpenCode keeps only `Error.message`.** A TLS/proxy/network failure collapses to the literal string `fetch failed`; the cause chain (`code`, `errno`, `syscall`) is discarded and is not written to the engine log either.
3. **The desktop never exercises the one path that can recover the real cause.** The server can already probe the Cloud endpoint directly (`probe=1`), but "Test now" never requested it, and none of the rich health detail (failure code/stage, raw engine error, delivery revisions) was visible anywhere near the card.

## What

### Server (`apps/server`)
- **Probe step trace**: the direct endpoint probe records `initialize → initialized_notice → tools_list` with HTTP status, per-step latency, endpoint `serverInfo`/protocol, and — on transport failure — the full error cause chain that the engine discards (`tools.direct.trace`, `failure.details.transport`).
- **`POST /workspace/:id/mcp/openwork-cloud/engine-refresh`**: explicit engine-side retry. Disconnects the engine's `openwork-cloud` client (closing a wedged transport), re-registers from the persisted desired config (an unconditional fresh connect on the engine side), polls to connected, and returns ordered refresh steps plus fully probed health. Also recovers the "entry lost after engine restart" case.
- **`engineInspection`**: health now includes the engine's full MCP server map (per-server status + raw error), read over the OpenCode SDK. Support can now distinguish *everything failed* (engine host network path) from *only openwork-cloud failed* (endpoint/token) from *entry not registered* (lost dynamic registration).
- Health gains `durationMs`; `reconcilePersistedOpenworkCloudMcp` accepts `providerModel`.

### App (`apps/app`)
- **"Test now" now verifies the endpoint directly** (`probe=1`) from the OpenWork server, independent of the engine's cached state. The Advanced settings page refresh does the same.
- **Advanced diagnostics on the card** (collapsed by default — zero change to the default UI): failure code/stage/retryability + message + request/reference IDs, the raw engine error string, delivery state with desired/applied revisions and last attempt, the probe step trace with latencies, the engine MCP server map, token presence/expiry, org, and app/server/engine versions.
- **"Refresh engine connection"** button (in Advanced) driving the new endpoint, with per-step outcome display.
- **"Copy sanitized diagnostic"**: one-click redacted JSON support bundle (health + refresh trace + workspace/org context) for support tickets.
- New pure helper module `cloud-mcp-diagnostics.ts` (rows/trace/bundle formatting), fully unit-tested.

## Behavior impact: none outside diagnostics (audited, not just intended)

- **No agent-context or prompt bloat.** The new fields (`tools.direct.trace`, `engineInspection`, `durationMs`) live only in the health JSON consumed by the settings card, the Advanced settings page, and the clipboard bundle. Nothing reaches the model: no system-prompt, plugin, instruction, or tool-surface changes; `openwork-cloud` tool registration is untouched.
- **No new automatic actions.** The passive mount auto-check and the online-reconnect repair issue byte-identical requests to before. The direct probe runs only on two explicit user actions (card **Test now**, Advanced page **Refresh**); the engine refresh runs only from its button. No timers or background retries were added on the OpenWork side.
- **Existing endpoints unchanged.** `GET …/health` without `probe` and `POST …/reconcile` behave exactly as before; all new fields are additive/optional (older clients ignore them, older servers simply omit them). The engine-refresh endpoint is new and opt-in.
- **Errors are recorded, never swallowed.** The probe's step trace records and rethrows; engine-refresh records a failed disconnect step and continues (deliberate — re-registration is the authoritative step), preserving the failure in `refresh.steps` and the health verdict. On the new endpoint an empty body is allowed but malformed JSON is a hard 400.
- **Guarded against verdict drift from richer engine errors.** Current or future engines that stop collapsing `Error.cause` can emit cert/TLS strings containing "expired"/"auth"/"revoked"; `inferFailedStatus` now explicitly keeps those classified as connection failures instead of newly misclassifying them as token/session problems (regression-tested in both directions).
- **The chat submission gate is unaffected.** `firstFailure` feeds the chat send gate (`useCloudMcpSubmitReadiness` / `ensureCloudMcpSubmissionReadiness`) and background session maintenance; both consume only `usable`, `usableByCurrentModel`, and the *code-derived fixed sentences* (`failure.message`/`recommendedAction`) — never raw engine strings, which stay in `details` (Advanced/bundle only). Neither path requests the probe (their health calls are unchanged), and with the classification guard above, gate decisions, banner text, and token-remint triggers stay byte-identical for transport failures.
- **One deliberate diagnostic-verdict change, on explicit action only:** "Test now" now truly verifies the endpoint (initialize + tools/list) instead of echoing the engine's cached state, so it can surface a real endpoint failure attestation missed — that is the button's purpose. The passive health check keeps the old cheap semantics.

## Support-call flow this enables

Open the card → expand **Advanced diagnostics** → read three signals side by side:

| Signal | Meaning when failing |
| --- | --- |
| Direct endpoint check (server-side probe) | Den endpoint/token/network path from the OpenWork server |
| Engine MCP status + raw error | what OpenCode itself experienced (with the probe supplying the cause OpenCode drops) |
| Engine MCP servers map | scope: one MCP vs all MCPs vs entry missing entirely |

Then **Refresh engine connection** (engine drop + fresh connect) or **Repair and test** (token remint + re-apply), and **Copy sanitized diagnostic** into the ticket.

## Verification

- `apps/server`: `bun test src/cloud-mcp-health.test.ts src/cloud-mcp-reconcile.e2e.test.ts` — 38 pass (11 new: probe trace, 401 step capture, transport cause chain, engine inspection map, engine-refresh e2e happy path / desired-missing / engine-down / malformed-body 400, cert-error classification guard in both directions).
- `apps/server`: `bun test src/mcp.engine-sync.e2e.test.ts src/extensions-connect-gating.test.ts` — 25 pass.
- `apps/app`: `bun test tests/cloud-mcp-diagnostics.test.ts tests/cloud-mcp-health.test.ts tests/connect-view.test.ts` — 33 pass (new: advanced rows incl. lost-registration flag and transport cause, trace/refresh line formatting, bundle redaction, probe flag passthrough, engine-refresh runner mapping).
- `tsc --noEmit` clean in `apps/server` and `apps/app`; `git diff --check` clean.

## Deliberately out of scope: no engine modifications

Everything here lives in `apps/server` and `apps/app` — the OpenCode engine is intentionally untouched, and its known gaps are compensated from outside:

- *Engine collapses errors to `Error.message` ("fetch failed")* → the server-side direct probe recovers the transport cause chain independently, on our own network path.
- *Engine never retries a failed initial connect* → re-registration is an unconditional fresh connect on the engine side, and OpenWork already re-drives it in four places: the chat send gate's repair retries, background session maintenance, the online-reconnect listener, and now the explicit engine-refresh action.
- *Mid-session connection drops* → upstream OpenCode `dev` already contains `bd738a0a7` ("reconnect closed remote MCP clients"), which OpenWork inherits with a future engine version pin — no fork patch needed.
- No automatic background retry loop was added beyond the existing ones: this PR adds the *explicit* retry lever and the visibility to know when to pull it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
