### PR TITLE
fix(server,app): await managed config write before engine reload; fix provider list cache key

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -152,6 +152,7 @@ type CreateProviderAuthStoreOptions = {
   checkDesktopAppRestriction: DesktopAppRestrictionChecker;
   selectedWorkspaceDisplay: () => WorkspaceDisplay;
   selectedWorkspaceRoot: () => string;
+  opencodeBaseUrl?: () => string;
   runtimeWorkspaceId: () => string | null;
   ensureRuntimeWorkspaceId?: () => Promise<string | null | undefined>;
   openworkServer: ProviderAuthOpenworkServer;
@@ -1221,6 +1222,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       const updated = filterProviderList(
         await ensureProviderListQuery(getReactQueryClient(), {
           client: activeClient,
+          baseUrl: options.opencodeBaseUrl?.(),
           directory: options.selectedWorkspaceRoot(),
           force: Boolean(optionsArg?.dispose),
         }),

--- a/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
@@ -99,6 +99,7 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
               } as WorkspaceDisplay)
             : emptyWorkspaceDisplay,
         selectedWorkspaceRoot: () => stateRef.current.selectedWorkspaceRoot,
+        opencodeBaseUrl: () => stateRef.current.selectedWorkspaceEndpoint?.opencodeBaseUrl,
         runtimeWorkspaceId: () => stateRef.current.selectedWorkspaceEndpoint?.workspaceId ?? null,
         openworkServer: {
           getSnapshot: () => ({

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -625,6 +625,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         checkDesktopAppRestriction: checkDesktopRestriction,
         selectedWorkspaceDisplay: () => routeStateRef.current.selectedWorkspaceDisplay,
         selectedWorkspaceRoot: () => routeStateRef.current.selectedWorkspaceRoot,
+        opencodeBaseUrl: () => opencodeBaseUrl,
         runtimeWorkspaceId: () => routeStateRef.current.runtimeWorkspaceId,
         ensureRuntimeWorkspaceId: async () =>
           routeStateRef.current.runtimeWorkspaceId?.trim() ||

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -179,8 +179,8 @@ export async function writeOpenworkRuntimeConfigFile(config: ServerConfig, works
  * Returns an unsubscribe function.
  */
 export function keepOpenworkRuntimeConfigFileFresh(config: ServerConfig, workspaceId: string): () => void {
-  return onRuntimeOpencodeConfigWrite((writeConfig, writtenWorkspaceId) => {
+  return onRuntimeOpencodeConfigWrite(async (writeConfig, writtenWorkspaceId) => {
     if (writtenWorkspaceId !== workspaceId) return;
-    void writeOpenworkRuntimeConfigFile(writeConfig, workspaceId).catch(() => undefined);
+    await writeOpenworkRuntimeConfigFile(writeConfig, workspaceId).catch(() => undefined);
   });
 }

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -74,7 +74,7 @@ export function runtimeStorageDir(config: ServerConfig): string {
   return dirname(runtimeDbPath(config));
 }
 
-export type RuntimeOpencodeConfigWriteListener = (config: ServerConfig, workspaceId: string) => void;
+export type RuntimeOpencodeConfigWriteListener = (config: ServerConfig, workspaceId: string) => void | Promise<void>;
 
 const writeListeners = new Set<RuntimeOpencodeConfigWriteListener>();
 
@@ -364,7 +364,7 @@ export async function writeRuntimeOpencodeConfig(
     return { config: next, changed: false };
   }
   db.upsert({ workspaceId, configJson, updatedAt: now });
-  for (const listener of writeListeners) listener(config, workspaceId);
+  await Promise.all([...writeListeners].map(l => l(config, workspaceId)));
   return { config: next, changed: true };
 }
 


### PR DESCRIPTION
## Problem

When cloud providers sync, models show as "synced" but never appear in the model picker. The engine was reloading before the managed `OPENCODE_CONFIG` file write completed, so it always read stale config — the new provider was invisible.

### Root causes

1. **Race condition** — `writeRuntimeOpencodeConfig` wrote to the SQLite DB then fired write listeners fire-and-forget (`void`). The PATCH handler returned HTTP 200 before the managed file write finished. The client then called `reloadEngine`, the engine rebuilt and re-read `OPENCODE_CONFIG` from disk — but the file was still being written.

2. **Cache key mismatch** — `refreshProviders` called `ensureProviderListQuery` without `baseUrl`, caching results under `["", "/root"]`. The model picker reads from `["http://127.0.0.1:PORT", "/root"]` — a different cache slot — so it got stale cached data for up to 5 minutes.

## Fixes

1. **`runtime-opencode-config-store.ts`** — Change `RuntimeOpencodeConfigWriteListener` type to accept `void | Promise<void>` and `await Promise.all(...)` all listeners after the DB write completes.

2. **`openwork-runtime-config.ts`** — Make the config-file listener `async` and `await` the file write so it completes before the function returns.

3. **`provider-auth store`** — Add optional `opencodeBaseUrl` getter to store options and pass it to `ensureProviderListQuery` so the cache key matches what the model picker and session route expect.