### PR TITLE
feat(app): make session pinning global

### DIFF
--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -231,7 +231,7 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
   const pinControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.pin",
     label: "Pin or unpin a session",
-    description: "Toggle pin on a session. Pinned sessions float to the top of the sidebar.",
+    description: "Toggle pin on a session. Pinned sessions appear in a global section at the top of the sidebar.",
     sideEffect: "mutation",
     requiresArgs: true,
     args: [{ name: "sessionId", type: "string", required: true, description: "Session ID to pin/unpin." }],

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -746,6 +746,20 @@ export function AppSidebar(props: AppSidebarProps) {
   };
 
   const brandLogoUrl = useBrandLogoUrl();
+  const pinnedIds = useSessionManagementStore((state) => state.pinnedIds);
+  const pinnedSessions = React.useMemo(() => {
+    const sessionsById = new Map<string, GlobalPinnedSessionEntry>();
+    for (const group of props.workspaceSessionGroups) {
+      const roots = getRootSessions(partitionArchivedSessions(group.sessions).active);
+      for (const session of roots) {
+        sessionsById.set(session.id, { group, sessionId: session.id });
+      }
+    }
+    return pinnedIds.flatMap((sessionId) => {
+      const entry = sessionsById.get(sessionId);
+      return entry ? [entry] : [];
+    });
+  }, [pinnedIds, props.workspaceSessionGroups]);
 
   return (
     <SidebarContext.Provider value={contextValue}>
@@ -792,6 +806,9 @@ export function AppSidebar(props: AppSidebarProps) {
             data-sidebar="content"
             className="no-scrollbar flex min-h-0 flex-1 flex-col gap-px overflow-auto [--radius:var(--radius-xl)] group-data-[collapsible=icon]:overflow-hidden"
           >
+            {pinnedSessions.length > 0 ? (
+              <GlobalPinnedSessions entries={pinnedSessions} />
+            ) : null}
             <Reorder.Group
               as="div"
               axis="y"
@@ -836,6 +853,75 @@ export function AppSidebar(props: AppSidebarProps) {
       </Sidebar>
     </SidebarContext.Provider>
   );
+}
+
+type GlobalPinnedSessionEntry = {
+  group: WorkspaceSessionGroup;
+  sessionId: string;
+};
+
+function GlobalPinnedSessions({ entries }: { entries: GlobalPinnedSessionEntry[] }) {
+  return (
+    <SidebarGroup data-global-pinned-sessions className="pb-1 pt-2">
+      <SidebarGroupContent>
+        <div className="flex items-center gap-1.5 px-3 pb-1 text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+          <Pin className="size-3" />
+          {t("session_management.pinned")}
+        </div>
+        <SidebarMenu>
+          <SidebarMenuItem>
+            <SidebarMenuSub>
+              {entries.map((entry) => (
+                <GlobalPinnedSessionTree
+                  key={`${entry.group.workspace.id}:${entry.sessionId}`}
+                  group={entry.group}
+                  sessionId={entry.sessionId}
+                />
+              ))}
+            </SidebarMenuSub>
+          </SidebarMenuItem>
+        </SidebarMenu>
+      </SidebarGroupContent>
+    </SidebarGroup>
+  );
+}
+
+function GlobalPinnedSessionTree({ group, sessionId }: GlobalPinnedSessionEntry) {
+  const ctx = useSidebarContext();
+  const pinnedIds = usePinnedSessionIds();
+  const tree = useSessionTree(group.sessions, ctx.sessionStatusById);
+  const forcedExpandedSessionIds = React.useMemo(
+    () => new Set(
+      ctx.selectedSessionId
+        ? tree.ancestorIdsBySessionId.get(ctx.selectedSessionId) ?? []
+        : [],
+    ),
+    [ctx.selectedSessionId, tree.ancestorIdsBySessionId],
+  );
+  const rootIds = React.useMemo(() => new Set([sessionId]), [sessionId]);
+  const rows = flattenSessionRows(
+    group.sessions,
+    1,
+    tree,
+    ctx.expandedSessionIds,
+    forcedExpandedSessionIds,
+    pinnedIds,
+    [],
+    { include: rootIds },
+  );
+
+  return rows.map((row) => (
+    <SessionMenuItem
+      key={row.session.id}
+      session={row.session}
+      depth={row.depth}
+      tree={tree}
+      workspaceId={group.workspace.id}
+      forcedExpandedSessionIds={forcedExpandedSessionIds}
+      isPinned={pinnedIds.has(row.session.id)}
+      workspaceName={row.depth === 0 ? workspaceLabel(group.workspace) : undefined}
+    />
+  ));
 }
 
 type WorkspaceReorderItemProps = {
@@ -1017,16 +1103,17 @@ function WorkspaceSidebarGroup({
     tree,
     ctx.expandedSessionIds,
     forcedExpandedSessionIds,
-    pinnedIds,
+    EMPTY_PINNED_IDS,
     orderIds,
+    { exclude: pinnedIds },
   );
   const visibleRootIds = React.useMemo(
     () => sessionRows.flatMap((row) => (row.depth === 0 ? [row.session.id] : [])),
     [sessionRows],
   );
   const activeRootCount = React.useMemo(
-    () => getRootSessions(activeSessions).length,
-    [activeSessions],
+    () => getRootSessions(activeSessions).filter((session) => !pinnedIds.has(session.id)).length,
+    [activeSessions, pinnedIds],
   );
   const [archivedExpanded, setArchivedExpanded] = React.useState(false);
   const remainingRootSessions = Math.max(0, activeRootCount - previewCount);
@@ -1229,6 +1316,7 @@ function WorkspaceSidebarGroup({
 }
 
 const SESSION_DRAG_TYPE = "application/x-openwork-session-id";
+const EMPTY_PINNED_IDS = new Set<string>();
 const UNGROUPED_GROUP_ID = "__openwork_ungrouped";
 
 function SessionGroupActions({ group, groups, workspaceId, count }: {
@@ -1741,6 +1829,7 @@ type SessionMenuItemProps = {
   forcedExpandedSessionIds: Set<string>;
   isPinned?: boolean;
   draggable?: boolean;
+  workspaceName?: string;
 };
 
 function SessionMenuItem({
@@ -1751,10 +1840,12 @@ function SessionMenuItem({
   depth,
   isPinned = false,
   draggable = false,
+  workspaceName,
 }: SessionMenuItemProps) {
   const ctx = useSidebarContext();
   const isSelected = ctx.selectedSessionId === session.id;
   const displayTitle = getDisplaySessionTitle(session.title);
+  const itemTitle = workspaceName ? `${displayTitle} — ${workspaceName}` : displayTitle;
   const hasChildren = (tree.descendantCountBySessionId.get(session.id) ?? 0) > 0;
   const isExpanded = ctx.expandedSessionIds.has(session.id) || forcedExpandedSessionIds.has(session.id);
   const sessionActivityStatus = ctx.sessionStatusById?.[session.id];
@@ -1798,11 +1889,13 @@ function SessionMenuItem({
                 onClick={openSession}
                 onPointerEnter={prefetchSession}
                 onFocus={prefetchSession}
+                aria-label={itemTitle}
               >
                 <PinnedIndicator isPinned={isPinned} />
+                {workspaceName ? <WorkspaceIcon workspaceId={workspaceId} sizeClass="size-3.5" /> : null}
                 <span
                   className={cn("min-w-0 flex-1 truncate transition-[padding] duration-75 group-hover/menu-sub-item:pe-12 group-has-data-popup-open/menu-sub-item:pe-12 pe-4", (isSessionStreaming || isSessionActive) && "pe-12")}
-                  title={displayTitle}
+                  title={itemTitle}
                 >
                   {displayTitle}
                 </span>
@@ -1831,10 +1924,12 @@ function SessionMenuItem({
           onClick={openSession}
           onPointerEnter={prefetchSession}
           onFocus={prefetchSession}
+          aria-label={itemTitle}
           className={cn("transition-[padding] duration-75 group-hover/menu-sub-item:pe-8 group-has-data-popup-open/menu-sub-item:pe-8", depth > 0 && "ps-13", (isSessionStreaming || isSessionActive) && "pe-12")}
         >
           <PinnedIndicator isPinned={isPinned} />
-          <span className="min-w-0 flex-1 truncate" title={displayTitle}>{displayTitle}</span>
+          {workspaceName ? <WorkspaceIcon workspaceId={workspaceId} sizeClass="size-3.5" /> : null}
+          <span className="min-w-0 flex-1 truncate" title={itemTitle}>{displayTitle}</span>
         </SidebarMenuSubButton>
       </SessionContextMenu>
       <SessionActions

--- a/apps/app/src/react-app/domains/session/sidebar/utils.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/utils.ts
@@ -144,9 +144,15 @@ export const flattenSessionRows = (
   forcedExpandedSessionIds: Set<string>,
   pinnedIds: Set<string> = EMPTY_SET,
   orderIds: string[] = EMPTY_ARRAY,
+  rootFilter?: { include?: Set<string>; exclude?: Set<string> },
 ) => {
   const { active } = partitionArchivedSessions(sessions);
-  const orderedRoots = orderRootSessions(getRootSessions(active), pinnedIds, orderIds).slice(0, rootLimit);
+  const orderedRoots = orderRootSessions(getRootSessions(active), pinnedIds, orderIds)
+    .filter((root) => (
+      (!rootFilter?.include || rootFilter.include.has(root.id)) &&
+      !rootFilter?.exclude?.has(root.id)
+    ))
+    .slice(0, rootLimit);
   const rows: FlattenedSessionRow[] = [];
   const visited = new Set<string>();
 

--- a/apps/app/tests/session-sidebar-utils.test.ts
+++ b/apps/app/tests/session-sidebar-utils.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, test } from "bun:test";
+
+import type { SidebarSessionItem } from "../src/app/types";
+import {
+  buildSessionTreeState,
+  flattenSessionRows,
+} from "../src/react-app/domains/session/sidebar/utils";
+
+const sessions: SidebarSessionItem[] = [
+  { id: "session-a", title: "Pinned root" },
+  { id: "session-a-child", title: "Pinned child", parentID: "session-a" },
+  { id: "session-b", title: "Regular root" },
+];
+
+describe("global session pinning", () => {
+  test("selects a pinned root and its expanded descendants", () => {
+    const tree = buildSessionTreeState(sessions, undefined);
+    const rows = flattenSessionRows(
+      sessions,
+      1,
+      tree,
+      new Set(["session-a"]),
+      new Set(),
+      new Set(["session-a"]),
+      [],
+      { include: new Set(["session-a"]) },
+    );
+
+    expect(rows.map((row) => row.session.id)).toEqual(["session-a", "session-a-child"]);
+  });
+
+  test("removes pinned roots before applying the workspace preview limit", () => {
+    const tree = buildSessionTreeState(sessions, undefined);
+    const rows = flattenSessionRows(
+      sessions,
+      1,
+      tree,
+      new Set(),
+      new Set(),
+      new Set(),
+      [],
+      { exclude: new Set(["session-a"]) },
+    );
+
+    expect(rows.map((row) => row.session.id)).toEqual(["session-b"]);
+  });
+});

--- a/evals/flows/global-session-pinning.flow.mjs
+++ b/evals/flows/global-session-pinning.flow.mjs
@@ -1,0 +1,105 @@
+import { mkdir } from "node:fs/promises";
+import { resolve } from "node:path";
+
+const RUN_SUFFIX = Date.now().toString().slice(-5);
+const FIRST_TITLE = `Pinned alpha ${RUN_SUFFIX}`;
+const SECOND_TITLE = `Pinned beta ${RUN_SUFFIX}`;
+const FIRST_WORKSPACE = resolve(
+  process.env.OPENWORK_EVAL_ARTIFACTS_DIR ?? "evals/results",
+  "..",
+  `global-pinning-alpha-${RUN_SUFFIX}`,
+);
+const SECOND_WORKSPACE = resolve(
+  process.env.OPENWORK_EVAL_ARTIFACTS_DIR ?? "evals/results",
+  "..",
+  `global-pinning-beta-${RUN_SUFFIX}`,
+);
+
+async function currentSessionId(ctx) {
+  return ctx.waitFor(`(() => {
+    const match = /session\\/([^/?#]+)/.exec(window.__openworkControl.snapshot().route);
+    return match ? decodeURIComponent(match[1]) : null;
+  })()`, { timeoutMs: 30_000, label: "current session" });
+}
+
+async function finishOnboarding(ctx) {
+  await ctx.eval("location.reload()");
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+  await mkdir(FIRST_WORKSPACE, { recursive: true });
+
+  const welcomeInput = 'input[placeholder="/workspace/my-project"]';
+  const onWelcome = await ctx.eval(`Boolean(document.querySelector(${JSON.stringify(welcomeInput)}))`);
+  if (onWelcome) {
+    await ctx.fill(welcomeInput, FIRST_WORKSPACE);
+    await ctx.clickText("Use this folder", { selector: "button", timeoutMs: 10_000 });
+    await ctx.clickText("Skip and use the free model", { selector: "button", timeoutMs: 30_000 }).catch(() => {});
+    await ctx.clickText("Skip", { selector: "button", timeoutMs: 10_000 }).catch(() => {});
+  }
+
+  await ctx.waitFor(
+    "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+    { timeoutMs: 60_000, label: "enabled task creation" },
+  );
+}
+
+async function createNamedSession(ctx, title) {
+  await ctx.control("session.create_task");
+  const sessionId = await currentSessionId(ctx);
+  await ctx.waitFor(
+    "window.__openworkControl.listActions().some((action) => action.id === 'session.rename' && !action.disabled)",
+    { timeoutMs: 30_000, label: "enabled session rename" },
+  );
+  await ctx.control("session.rename", { sessionId, title });
+  await ctx.waitFor(
+    `document.body.textContent.includes(${JSON.stringify(title)})`,
+    { timeoutMs: 30_000, label: `visible session ${title}` },
+  );
+  return sessionId;
+}
+
+export default {
+  id: "global-session-pinning",
+  title: "Pinned sessions stay globally accessible across workspaces",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Pin sessions from two workspaces globally",
+      run: async (ctx) => {
+        await finishOnboarding(ctx);
+        const firstSessionId = await createNamedSession(ctx, FIRST_TITLE);
+        await ctx.control("session.pin", { sessionId: firstSessionId });
+
+        await mkdir(SECOND_WORKSPACE, { recursive: true });
+        await ctx.control("workspace.create", { path: SECOND_WORKSPACE, projectLabel: `Beta ${RUN_SUFFIX}` });
+        await ctx.waitFor(
+          "window.__openworkControl.listActions().some((action) => action.id === 'session.create_task' && !action.disabled)",
+          { timeoutMs: 60_000, label: "second workspace task creation" },
+        );
+        const secondSessionId = await createNamedSession(ctx, SECOND_TITLE);
+        await ctx.control("session.pin", { sessionId: secondSessionId });
+
+        await ctx.waitFor(`(() => {
+          const pinned = document.querySelector('[data-global-pinned-sessions]');
+          return pinned?.textContent?.includes(${JSON.stringify(FIRST_TITLE)}) &&
+            pinned.textContent.includes(${JSON.stringify(SECOND_TITLE)});
+        })()`, { timeoutMs: 30_000, label: "both globally pinned sessions" });
+
+        const counts = await ctx.eval(`({
+          first: document.querySelectorAll(${JSON.stringify(`span[title^="${FIRST_TITLE}"]`)}).length,
+          second: document.querySelectorAll(${JSON.stringify(`span[title^="${SECOND_TITLE}"]`)}).length,
+          globalSections: document.querySelectorAll('[data-global-pinned-sessions]').length,
+        })`);
+        ctx.assert(counts.globalSections === 1, `Expected one global pinned section, got ${counts.globalSections}`);
+        ctx.assert(counts.first === 1, `Expected ${FIRST_TITLE} once, got ${counts.first}`);
+        ctx.assert(counts.second === 1, `Expected ${SECOND_TITLE} once, got ${counts.second}`);
+
+        await ctx.control("session.pin", { sessionId: firstSessionId });
+        await ctx.waitFor(`(() => {
+          const pinned = document.querySelector('[data-global-pinned-sessions]');
+          return !pinned?.textContent?.includes(${JSON.stringify(FIRST_TITLE)}) &&
+            document.body.textContent.includes(${JSON.stringify(FIRST_TITLE)});
+        })()`, { timeoutMs: 30_000, label: "unpinned session returned to its workspace" });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary

- surface pinned sessions from every workspace in one global **Pinned** section at the top of the sidebar
- remove pinned roots from their workspace lists so each pinned session appears once without consuming workspace preview slots
- preserve pin order, expanded descendants, workspace identity, and accessible labels
- add focused root-filter tests and a coded two-workspace pin/unpin eval

## Why

Pin persistence was already global, but the sidebar only promoted a pinned session inside its workspace. A collapsed workspace could therefore hide a supposedly pinned session. This change makes the presentation match the global persistence model.

## Checks

- `pnpm --filter @openwork/app typecheck` — passed after rebasing onto current `upstream/dev`
- `pnpm --filter @openwork/app exec bun test --isolate tests/session-sidebar-utils.test.ts` — passed, 2 tests
- `global-session-pinning` coded Electron eval — passed once against the feature commit: two sessions in separate workspaces appeared exactly once in the global section, then unpinning returned one to its workspace

## Verification gap

Two post-rebase eval reruns did not complete in the isolated development runtime: one Electron/Vite process exited with `SIGINT` and produced a CDP timeout; a final retry timed out waiting for a newly created session. The two rebased upstream commits only affect markdown styling and MCP diagnostics, and the post-rebase typecheck and focused tests pass, but the final live rerun remains unconfirmed.

## User confirmation

Not yet manually confirmed by the requester.

## Risk / remaining behavior

- Pin state remains local client state in the existing persisted store.
- The global section promotes active root sessions, matching the existing root-pinning semantics; archived sessions stay in their workspace archive section.
- No video or screenshot evidence was requested.
