### PR TITLE
fix(composer): expand pasted text as plain text

### DIFF
--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -36,7 +36,7 @@ import {
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./mention-encoding";
 import { shouldCollapsePastedText } from "./pasted-text";
-import { insertStyledPastedText } from "./pasted-text-insertion";
+import { insertPastedText } from "./pasted-text-insertion";
 
 type PastedTextToken = { label: string; lines: number; text: string };
 
@@ -678,7 +678,7 @@ function PasteChipPlugin(props: { onPasteText?: (text: string) => void }) {
           return true;
         }
         event.preventDefault();
-        return insertStyledPastedText(text);
+        return insertPastedText(text);
       },
       COMMAND_PRIORITY_CRITICAL,
     );
@@ -697,12 +697,12 @@ function replacePastedTextChip(label: string, text: string, button: HTMLButtonEl
   const nearest = $getNearestNodeFromDOMNode(button);
   if (nearest instanceof ComposerPastedTextNode && nearest.getPastedLabel() === label) {
     nearest.select(0, nearest.getTextContentSize());
-    return insertStyledPastedText(text);
+    return insertPastedText(text);
   }
   for (const node of $nodesOfType(ComposerPastedTextNode)) {
     if (node.getPastedLabel() !== label) continue;
     node.select(0, node.getTextContentSize());
-    return insertStyledPastedText(text);
+    return insertPastedText(text);
   }
   return false;
 }

--- a/apps/app/src/react-app/domains/session/surface/composer/pasted-text-insertion.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/pasted-text-insertion.ts
@@ -6,9 +6,9 @@ import {
   $isRangeSelection,
   type LexicalNode,
 } from "lexical";
-import { PASTED_TEXT_INLINE_STYLE, splitPastedText } from "./pasted-text";
+import { splitPastedText } from "./pasted-text";
 
-function createStyledPastedTextNodes(text: string) {
+function createPastedTextNodes(text: string) {
   const nodes: LexicalNode[] = [];
   for (const segment of splitPastedText(text)) {
     if (segment.kind === "line-break") {
@@ -17,7 +17,6 @@ function createStyledPastedTextNodes(text: string) {
       nodes.push($createTabNode());
     } else {
       const textNode = $createTextNode(segment.text);
-      textNode.setStyle(PASTED_TEXT_INLINE_STYLE);
       nodes.push(textNode);
     }
   }
@@ -25,10 +24,10 @@ function createStyledPastedTextNodes(text: string) {
   return nodes;
 }
 
-export function insertStyledPastedText(text: string) {
+export function insertPastedText(text: string) {
   const selection = $getSelection();
   if (!$isRangeSelection(selection)) return false;
-  selection.insertNodes(createStyledPastedTextNodes(text));
+  selection.insertNodes(createPastedTextNodes(text));
   const nextSelection = $getSelection();
   if ($isRangeSelection(nextSelection)) nextSelection.setStyle("");
   return true;

--- a/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
@@ -1,7 +1,6 @@
 export const PASTE_CHIP_CHAR_THRESHOLD = 50;
 export const FILE_URL_RE = /^file:\/\//i;
 export const HTTP_URL_RE = /^https?:\/\//i;
-export const PASTED_TEXT_INLINE_STYLE = "background-color: rgba(229, 231, 235, 0.6); border-radius: 4px; box-decoration-break: clone; -webkit-box-decoration-break: clone; padding: 1px 2px;";
 
 export type PastedTextSegment =
   | { kind: "text"; text: string }

--- a/apps/app/tests/pasted-text-insertion.test.ts
+++ b/apps/app/tests/pasted-text-insertion.test.ts
@@ -1,12 +1,24 @@
-import { describe, expect, test } from "bun:test";
-import {
-  PASTED_TEXT_INLINE_STYLE,
-  splitPastedText,
-} from "../src/react-app/domains/session/surface/composer/pasted-text";
+import { describe, expect, mock, test } from "bun:test";
+import { splitPastedText } from "../src/react-app/domains/session/surface/composer/pasted-text";
 
-describe("styled pasted-text insertion", () => {
-  test("plans styled text nodes while preserving newlines and tabs", () => {
-    expect(PASTED_TEXT_INLINE_STYLE).toContain("background-color");
+type FakeNodeKind = "line-break" | "tab" | "text";
+
+type FakeNode = {
+  kind: FakeNodeKind;
+  setStyle: (style: string) => void;
+  style: string;
+  text: string;
+};
+
+type FakeSelection = {
+  insertNodes: (nodes: FakeNode[]) => void;
+  kind: "range";
+  setStyle: (style: string) => void;
+  style: string;
+};
+
+describe("pasted-text insertion", () => {
+  test("plans pasted text nodes while preserving newlines and tabs", () => {
     expect(splitPastedText("first\nsecond\tthird")).toEqual([
       { kind: "text", text: "first" },
       { kind: "line-break" },
@@ -14,5 +26,48 @@ describe("styled pasted-text insertion", () => {
       { kind: "tab" },
       { kind: "text", text: "third" },
     ]);
+  });
+
+  test("expands pasted text as plain text and clears selection style", async () => {
+    const insertedNodes: FakeNode[] = [];
+    const selection: FakeSelection = {
+      insertNodes(nodes) {
+        insertedNodes.push(...nodes);
+      },
+      kind: "range",
+      setStyle(style) {
+        this.style = style;
+      },
+      style: "stale-style",
+    };
+
+    function createNode(kind: FakeNodeKind, text = ""): FakeNode {
+      return {
+        kind,
+        setStyle(style) {
+          this.style = style;
+        },
+        style: "",
+        text,
+      };
+    }
+
+    mock.module("lexical", () => ({
+      $createLineBreakNode: () => createNode("line-break"),
+      $createTabNode: () => createNode("tab"),
+      $createTextNode: (text: string) => createNode("text", text),
+      $getSelection: () => selection,
+      $isRangeSelection: (value: unknown) => value === selection,
+    }));
+
+    const { insertPastedText } = await import("../src/react-app/domains/session/surface/composer/pasted-text-insertion");
+
+    expect(insertPastedText("first\nsecond")).toBe(true);
+    expect(insertedNodes.map((node) => ({ kind: node.kind, style: node.style, text: node.text }))).toEqual([
+      { kind: "text", style: "", text: "first" },
+      { kind: "line-break", style: "", text: "" },
+      { kind: "text", style: "", text: "second" },
+    ]);
+    expect(selection.style).toBe("");
   });
 });


### PR DESCRIPTION
## Summary

Fixes inconsistent behavior when expanding pasted-text chips in the composer.

Expanded pasted text was inserted with temporary grey inline styling. That styling was not durable: it disappeared after later composer rebuilds, and text typed immediately after an expanded paste could inherit the grey style.

This change expands pasted text as plain text while preserving newlines/tabs and clearing stale selection style, so expanded paste content and following typed text behave consistently.

## Testing

- pnpm --filter @openwork/app exec bun test tests/pasted-text-insertion.test.ts — passed
- pnpm --filter @openwork/app typecheck — passed
- pnpm --filter @openwork/app test — passed, 381 tests
- git diff --check — passed

## Manual verification

Verified locally by pasting long text, expanding the pasted-text chip, typing after it, then repeating with another paste. Expanded text stays plain and newly typed text no longer inherits grey styling.
