### PR TITLE
fix(install-config): export TS source directly — repairs dev desktop build after #2973

### DIFF
--- a/packages/install-config/package.json
+++ b/packages/install-config/package.json
@@ -6,7 +6,7 @@
     ".": {
       "types": "./src/index.ts",
       "development": "./src/index.ts",
-      "default": "./dist/index.js"
+      "default": "./src/index.ts"
     }
   },
   "files": [


### PR DESCRIPTION
## What

Fixes the dev desktop/alpha build broken by #2973 (`vite build` in `apps/app`: "Failed to resolve entry for package @openwork/install-config").

#2973 made `apps/app` import `@openwork/install-config`, whose `exports.default` pointed at `./dist/index.js` — but nothing in the electron/vite build pipeline builds that package first, so CI (and Vercel app builds) fail. This commit was on the feature branch but landed after the squash-merge.

## Fix

Point `exports` at the TS source (`./src/index.ts`), exactly like `@openwork/types` and the other renderer-consumed workspace packages. Consumers (vite, bun, tsx, den-api's bundler) all handle TS source; no prebuild ordering needed. den-api tests also no longer need the `--conditions development` workaround.

## Validation (fresh checkout off dev + this commit, `packages/install-config/dist` absent — CI-identical)

- `pnpm --dir apps/app build` (the exact failing step) — **passes** (`✓ built in 5.22s`)
- `pnpm --filter @openwork-ee/den-api build` — passes
- `pnpm --dir apps/installer test` — passes (29 tests)

No runtime behavior change (module-resolution config only), so no fraimz for this PR — the feature's frame-by-frame runtime proof is on #2973.
