### PR TITLE
refactor(server): centralize runtime database setup

### DIFF
--- a/apps/server/src/agent-context-diagnostics.test.ts
+++ b/apps/server/src/agent-context-diagnostics.test.ts
@@ -26,6 +26,7 @@ import {
 import type { InspectAgentDiagnosticsEngine } from "./agent-context-engine-inspection.js";
 import type { ConnectSnapshot } from "./connect-state.js";
 import { buildOpenworkRuntimeConfigObjectFromSnapshot } from "./openwork-runtime-config.js";
+import { runtimeDbPath } from "./runtime-db.js";
 import {
   inspectEngineMcpRegistration,
   registerTrustedOpencodeProcess,
@@ -33,7 +34,6 @@ import {
   syncAllWorkspacesRuntimeMcpToEngine,
 } from "./server.js";
 import {
-  runtimeDbPath,
   writeRuntimeOpencodeConfig,
   type RuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";

--- a/apps/server/src/cloud-plugins.ts
+++ b/apps/server/src/cloud-plugins.ts
@@ -1,5 +1,4 @@
 import { mkdir, rm, writeFile } from "node:fs/promises";
-import { homedir } from "node:os";
 import { dirname, resolve } from "node:path";
 import { eq } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
@@ -7,7 +6,7 @@ import type { ServerConfig } from "./types.js";
 import { ApiError } from "./errors.js";
 import { parseFrontmatter, buildFrontmatter } from "./frontmatter.js";
 import { addMcp, removeMcp } from "./mcp.js";
-import { ensureDir } from "./utils.js";
+import { openRuntimeSqliteDatabase, runtimeDbPath } from "./runtime-db.js";
 
 const OPENCODE_SKILL_NAME_RE = /^[a-z0-9]+(-[a-z0-9]+)*$/;
 const OPENCODE_MCP_NAME_RE = /^[A-Za-z0-9_][A-Za-z0-9_-]*$/;
@@ -486,22 +485,12 @@ function readCloudImports(config: Record<string, unknown>): WorkspaceCloudImport
   };
 }
 
-function runtimeDbPath(config: ServerConfig): string {
-  const override = process.env.OPENWORK_RUNTIME_DB?.trim();
-  if (override) return resolve(override);
-  const configPath = config.configPath?.trim();
-  const configDir = configPath ? dirname(configPath) : resolve(homedir(), ".config", "openwork");
-  return resolve(configDir, "runtime.sqlite");
-}
-
 async function openCloudPluginDb(path: string): Promise<CloudPluginDb> {
-  await ensureDir(dirname(path));
-  if (typeof process.versions.bun === "string") {
-    const { Database } = await import("bun:sqlite");
-    const { drizzle } = await import("drizzle-orm/bun-sqlite");
-    const sqlite = new Database(path, { create: true });
+  const runtimeDb = await openRuntimeSqliteDatabase(path);
+  if (runtimeDb.kind === "bun") {
+    const sqlite = runtimeDb.sqlite;
     sqlite.run("CREATE TABLE IF NOT EXISTS cloud_plugin_install_configs (workspace_id TEXT PRIMARY KEY NOT NULL, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
-    const db = drizzle(sqlite);
+    const db = runtimeDb.db;
     return {
       get: (workspaceId) => db
         .select()
@@ -520,8 +509,7 @@ async function openCloudPluginDb(path: string): Promise<CloudPluginDb> {
       },
     };
   }
-  const { DatabaseSync } = await import("node:sqlite");
-  const sqlite = new DatabaseSync(path);
+  const sqlite = runtimeDb.sqlite;
   sqlite.exec("CREATE TABLE IF NOT EXISTS cloud_plugin_install_configs (workspace_id TEXT PRIMARY KEY NOT NULL, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
   const get = sqlite.prepare("SELECT config_json AS configJson FROM cloud_plugin_install_configs WHERE workspace_id = ?");
   const upsert = sqlite.prepare("INSERT INTO cloud_plugin_install_configs (workspace_id, config_json, updated_at) VALUES (?, ?, ?) ON CONFLICT(workspace_id) DO UPDATE SET config_json = excluded.config_json, updated_at = excluded.updated_at");

--- a/apps/server/src/connect-state.ts
+++ b/apps/server/src/connect-state.ts
@@ -11,10 +11,10 @@ import {
 } from "./cloud-mcp-health.js";
 import { googleWorkspaceLegacyConfigured } from "./extensions/google-workspace.js";
 import { readBoundedRegularTextFile } from "./jsonc.js";
+import { runtimeStorageDir } from "./runtime-db.js";
 import {
   inspectRuntimeOpencodeConfigState,
   runtimeMcpMap,
-  runtimeStorageDir,
 } from "./runtime-opencode-config-store.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
 import { ensureDir } from "./utils.js";

--- a/apps/server/src/legacy-config-sweep.ts
+++ b/apps/server/src/legacy-config-sweep.ts
@@ -2,9 +2,9 @@ import { copyFile, readFile, writeFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { applyEdits, modify, parse, printParseErrorCode } from "jsonc-parser";
+import { runtimeStorageDir } from "./runtime-db.js";
 import type { ServerConfig } from "./types.js";
 import { ensureDir, exists } from "./utils.js";
-import { runtimeStorageDir } from "./runtime-opencode-config-store.js";
 
 export type LegacyConfigSweepFile = {
   path: string;

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -23,13 +23,13 @@ import {
   openworkOfficeAttachmentsPluginPath,
 } from "./openwork-extensions-plugin-path.js";
 import type { ServerConfig } from "./types.js";
+import { runtimeStorageDir } from "./runtime-db.js";
 import {
   onRuntimeOpencodeConfigWrite,
   readRuntimeOpencodeConfig,
   runtimeDisabledProviderList,
   runtimeMcpMap,
   runtimePluginList,
-  runtimeStorageDir,
   type RuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";
 

--- a/apps/server/src/openwork-workspace-config-store.ts
+++ b/apps/server/src/openwork-workspace-config-store.ts
@@ -1,9 +1,7 @@
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
 import { eq } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { openRuntimeSqliteDatabase, runtimeDbPath } from "./runtime-db.js";
 import type { ServerConfig } from "./types.js";
-import { ensureDir } from "./utils.js";
 
 const openworkWorkspaceConfigs = sqliteTable("openwork_workspace_configs", {
   workspaceId: text("workspace_id").primaryKey(),
@@ -24,22 +22,12 @@ function normalizeOpenworkWorkspaceConfig(value: unknown): Record<string, unknow
   return isRecord(value) ? value : {};
 }
 
-function runtimeDbPath(config: ServerConfig): string {
-  const override = process.env.OPENWORK_RUNTIME_DB?.trim();
-  if (override) return resolve(override);
-  const configPath = config.configPath?.trim();
-  const configDir = configPath ? dirname(configPath) : join(homedir(), ".config", "openwork");
-  return join(configDir, "runtime.sqlite");
-}
-
 async function openDb(path: string): Promise<OpenworkWorkspaceConfigDb> {
-  await ensureDir(dirname(path));
-  if (typeof process.versions.bun === "string") {
-    const { Database } = await import("bun:sqlite");
-    const { drizzle } = await import("drizzle-orm/bun-sqlite");
-    const sqlite = new Database(path, { create: true });
+  const runtimeDb = await openRuntimeSqliteDatabase(path);
+  if (runtimeDb.kind === "bun") {
+    const sqlite = runtimeDb.sqlite;
     sqlite.run("CREATE TABLE IF NOT EXISTS openwork_workspace_configs (workspace_id TEXT PRIMARY KEY NOT NULL, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
-    const db = drizzle(sqlite);
+    const db = runtimeDb.db;
     return {
       get: (workspaceId) => db
         .select()
@@ -58,8 +46,7 @@ async function openDb(path: string): Promise<OpenworkWorkspaceConfigDb> {
       },
     };
   }
-  const { DatabaseSync } = await import("node:sqlite");
-  const sqlite = new DatabaseSync(path);
+  const sqlite = runtimeDb.sqlite;
   sqlite.exec("CREATE TABLE IF NOT EXISTS openwork_workspace_configs (workspace_id TEXT PRIMARY KEY NOT NULL, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
   const get = sqlite.prepare("SELECT config_json AS configJson FROM openwork_workspace_configs WHERE workspace_id = ?");
   const upsert = sqlite.prepare("INSERT INTO openwork_workspace_configs (workspace_id, config_json, updated_at) VALUES (?, ?, ?) ON CONFLICT(workspace_id) DO UPDATE SET config_json = excluded.config_json, updated_at = excluded.updated_at");

--- a/apps/server/src/runtime-db.node.test.ts
+++ b/apps/server/src/runtime-db.node.test.ts
@@ -1,0 +1,33 @@
+import assert from "node:assert/strict";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { openRuntimeSqliteDatabase } from "./runtime-db.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+if (typeof process.versions.bun !== "string") {
+  test("opens and closes the runtime SQLite database with Node's driver", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openwork-runtime-db-node-"));
+    try {
+      const dbPath = join(root, "nested", "runtime.sqlite");
+      const runtimeDb = await openRuntimeSqliteDatabase(dbPath);
+      assert.equal(runtimeDb.kind, "node");
+      if (runtimeDb.kind !== "node") throw new Error("expected Node runtime DB driver");
+
+      runtimeDb.sqlite.exec("CREATE TABLE node_driver_check (id TEXT PRIMARY KEY NOT NULL)");
+      runtimeDb.sqlite.prepare("INSERT INTO node_driver_check (id) VALUES (?)").run("ok");
+      const row = runtimeDb.sqlite.prepare("SELECT id FROM node_driver_check").get();
+      assert.equal(isRecord(row) ? row.id : null, "ok");
+
+      runtimeDb.close();
+      assert.throws(() => runtimeDb.sqlite.exec("SELECT 1"));
+      assert.equal((await stat(dbPath)).isFile(), true);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+}

--- a/apps/server/src/runtime-db.test.ts
+++ b/apps/server/src/runtime-db.test.ts
@@ -1,0 +1,158 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtemp, rm, stat } from "node:fs/promises";
+import { homedir, tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { installCloudPlugin, readInstalledCloudPlugins } from "./cloud-plugins.js";
+import { readOpenworkWorkspaceConfig, writeOpenworkWorkspaceConfig } from "./openwork-workspace-config-store.js";
+import { openRuntimeSqliteDatabase, runtimeDbPath, runtimeStorageDir } from "./runtime-db.js";
+import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import { readSessionGroupState, writeSessionGroupState } from "./session-groups.js";
+import type { ServerConfig } from "./types.js";
+
+const WORKSPACE_ID = "ws_runtime_db_primitive";
+
+const roots: string[] = [];
+const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+
+afterEach(async () => {
+  while (roots.length) {
+    const root = roots.pop();
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+  if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+});
+
+function serverConfig(root: string, configPath: string | null = join(root, "server.json")): ServerConfig {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: WORKSPACE_ID, name: "Test", path: root, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  if (configPath) config.configPath = configPath;
+  return config;
+}
+
+async function tempRoot(): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-runtime-db-primitive-"));
+  roots.push(root);
+  return root;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function rowNames(rows: unknown[]): string[] {
+  return rows.flatMap((row) => (isRecord(row) && typeof row.name === "string" ? [row.name] : []));
+}
+
+function rowCount(db: Database, tableName: string): number {
+  const row = db.query(`SELECT COUNT(*) AS count FROM ${tableName}`).get();
+  return isRecord(row) && typeof row.count === "number" ? row.count : -1;
+}
+
+describe("runtime DB primitive", () => {
+  test("resolves default and env-overridden runtime database paths", async () => {
+    const root = await tempRoot();
+    delete process.env.OPENWORK_RUNTIME_DB;
+
+    const config = serverConfig(root);
+    expect(runtimeDbPath(config)).toBe(join(root, "runtime.sqlite"));
+    expect(runtimeStorageDir(config)).toBe(root);
+
+    const configWithoutPath = serverConfig(root, null);
+    expect(runtimeDbPath(configWithoutPath)).toBe(join(homedir(), ".config", "openwork", "runtime.sqlite"));
+
+    const overridePath = join(root, "state", "override.sqlite");
+    process.env.OPENWORK_RUNTIME_DB = ` ${overridePath} `;
+    expect(runtimeDbPath(configWithoutPath)).toBe(resolve(overridePath));
+    expect(runtimeStorageDir(configWithoutPath)).toBe(join(root, "state"));
+
+    process.env.OPENWORK_RUNTIME_DB = "   ";
+    expect(runtimeDbPath(config)).toBe(join(root, "runtime.sqlite"));
+  });
+
+  test("opens and closes the active runtime SQLite driver while creating the parent directory", async () => {
+    const root = await tempRoot();
+    const dbPath = join(root, "nested", "runtime.sqlite");
+    const runtimeDb = await openRuntimeSqliteDatabase(dbPath);
+    try {
+      expect(runtimeDb.kind).toBe("bun");
+      if (runtimeDb.kind !== "bun") throw new Error("expected Bun runtime DB driver");
+      runtimeDb.sqlite.run("CREATE TABLE active_driver_check (id TEXT PRIMARY KEY NOT NULL)");
+      runtimeDb.sqlite.query("INSERT INTO active_driver_check (id) VALUES (?)").run("ok");
+      const row = runtimeDb.sqlite.query("SELECT id FROM active_driver_check").get();
+      expect(isRecord(row) && row.id === "ok").toBe(true);
+    } finally {
+      runtimeDb.close();
+    }
+
+    expect((await stat(dbPath)).isFile()).toBe(true);
+  });
+
+  test("keeps each migrated store in its own runtime DB table", async () => {
+    const root = await tempRoot();
+    const dbPath = join(root, "runtime.sqlite");
+    process.env.OPENWORK_RUNTIME_DB = dbPath;
+    const config = serverConfig(root);
+
+    await writeSessionGroupState(config, WORKSPACE_ID, {
+      groups: [{ id: "grp_runtime", label: "Runtime" }],
+      assignments: { ses_runtime: "grp_runtime" },
+    });
+    await writeOpenworkWorkspaceConfig(config, WORKSPACE_ID, (current) => ({
+      ...current,
+      workspace: { label: "Workspace config" },
+    }));
+    await writeRuntimeOpencodeConfig(config, WORKSPACE_ID, (current) => ({
+      ...current,
+      plugin: ["runtime-plugin"],
+    }));
+    await installCloudPlugin({
+      serverConfig: config,
+      workspaceId: WORKSPACE_ID,
+      workspaceRoot: root,
+      marketplaceId: "marketplace_runtime",
+      marketplace: { id: "marketplace_runtime", name: "Runtime Marketplace", updatedAt: null },
+      resolved: {
+        plugin: { id: "plugin_runtime", name: "Runtime Primitive Plugin", description: null, updatedAt: null },
+        memberships: [],
+      },
+    });
+
+    expect((await readSessionGroupState(config, WORKSPACE_ID)).state).toEqual({
+      groups: [{ id: "grp_runtime", label: "Runtime" }],
+      assignments: { ses_runtime: "grp_runtime" },
+    });
+    expect((await readOpenworkWorkspaceConfig(config, WORKSPACE_ID)).workspace).toEqual({ label: "Workspace config" });
+    expect((await readRuntimeOpencodeConfig(config, WORKSPACE_ID)).plugin).toEqual(["runtime-plugin"]);
+    expect((await readInstalledCloudPlugins(config, WORKSPACE_ID)).plugins.plugin_runtime?.name).toBe("Runtime Primitive Plugin");
+
+    const sqlite = new Database(dbPath, { readonly: true, create: false });
+    try {
+      const tables = rowNames(sqlite.query("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").all());
+      expect(tables).toEqual([
+        "cloud_plugin_install_configs",
+        "openwork_workspace_configs",
+        "runtime_opencode_configs",
+        "session_group_states",
+      ]);
+      for (const table of tables) expect(rowCount(sqlite, table)).toBe(1);
+    } finally {
+      sqlite.close();
+    }
+  });
+});

--- a/apps/server/src/runtime-db.ts
+++ b/apps/server/src/runtime-db.ts
@@ -1,0 +1,58 @@
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import type { Database as BunDatabase } from "bun:sqlite";
+import type { BunSQLiteDatabase } from "drizzle-orm/bun-sqlite";
+import type { DatabaseSync } from "node:sqlite";
+import type { ServerConfig } from "./types.js";
+import { ensureDir } from "./utils.js";
+
+export type RuntimeBunSqliteDatabase = {
+  kind: "bun";
+  sqlite: BunDatabase;
+  db: BunSQLiteDatabase;
+  close: () => void;
+};
+
+export type RuntimeNodeSqliteDatabase = {
+  kind: "node";
+  sqlite: DatabaseSync;
+  close: () => void;
+};
+
+export type RuntimeSqliteDatabase = RuntimeBunSqliteDatabase | RuntimeNodeSqliteDatabase;
+
+export function runtimeDbPath(config: ServerConfig): string {
+  const override = process.env.OPENWORK_RUNTIME_DB?.trim();
+  if (override) return resolve(override);
+  const configPath = config.configPath?.trim();
+  const configDir = configPath ? dirname(configPath) : join(homedir(), ".config", "openwork");
+  return join(configDir, "runtime.sqlite");
+}
+
+/** Directory holding runtime state (the SQLite DB and derived files). */
+export function runtimeStorageDir(config: ServerConfig): string {
+  return dirname(runtimeDbPath(config));
+}
+
+export async function openRuntimeSqliteDatabase(path: string): Promise<RuntimeSqliteDatabase> {
+  await ensureDir(dirname(path));
+  if (typeof process.versions.bun === "string") {
+    const { Database } = await import("bun:sqlite");
+    const { drizzle } = await import("drizzle-orm/bun-sqlite");
+    const sqlite = new Database(path, { create: true });
+    return {
+      kind: "bun",
+      sqlite,
+      db: drizzle(sqlite),
+      close: () => sqlite.close(),
+    };
+  }
+
+  const { DatabaseSync } = await import("node:sqlite");
+  const sqlite = new DatabaseSync(path);
+  return {
+    kind: "node",
+    sqlite,
+    close: () => sqlite.close(),
+  };
+}

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -1,10 +1,10 @@
-import { homedir } from "node:os";
 import { existsSync } from "node:fs";
-import { dirname, join, resolve } from "node:path";
 import { eq } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { openRuntimeSqliteDatabase, runtimeDbPath } from "./runtime-db.js";
 import type { ServerConfig } from "./types.js";
-import { ensureDir } from "./utils.js";
+
+export { runtimeDbPath, runtimeStorageDir } from "./runtime-db.js";
 
 export type RuntimeOpencodeConfig = {
   default_agent?: string;
@@ -61,19 +61,6 @@ function parseRuntimeOpencodeConfig(configJson: string): RuntimeOpencodeConfig {
   }
 }
 
-export function runtimeDbPath(config: ServerConfig): string {
-  const override = process.env.OPENWORK_RUNTIME_DB?.trim();
-  if (override) return resolve(override);
-  const configPath = config.configPath?.trim();
-  const configDir = configPath ? dirname(configPath) : join(homedir(), ".config", "openwork");
-  return join(configDir, "runtime.sqlite");
-}
-
-/** Directory holding runtime state (the SQLite DB and derived files). */
-export function runtimeStorageDir(config: ServerConfig): string {
-  return dirname(runtimeDbPath(config));
-}
-
 export type RuntimeOpencodeConfigWriteListener = (config: ServerConfig, workspaceId: string) => void;
 
 const writeListeners = new Set<RuntimeOpencodeConfigWriteListener>();
@@ -89,13 +76,11 @@ export function onRuntimeOpencodeConfigWrite(listener: RuntimeOpencodeConfigWrit
 }
 
 async function openRuntimeDb(path: string): Promise<RuntimeOpencodeDb> {
-  await ensureDir(dirname(path));
-  if (typeof process.versions.bun === "string") {
-    const { Database } = await import("bun:sqlite");
-    const { drizzle } = await import("drizzle-orm/bun-sqlite");
-    const sqlite = new Database(path, { create: true });
+  const runtimeDb = await openRuntimeSqliteDatabase(path);
+  if (runtimeDb.kind === "bun") {
+    const sqlite = runtimeDb.sqlite;
     sqlite.run("CREATE TABLE IF NOT EXISTS runtime_opencode_configs (workspace_id TEXT PRIMARY KEY NOT NULL, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
-    const db = drizzle(sqlite);
+    const db = runtimeDb.db;
     return {
       get: (workspaceId) => db
         .select()
@@ -114,8 +99,7 @@ async function openRuntimeDb(path: string): Promise<RuntimeOpencodeDb> {
       },
     };
   }
-  const { DatabaseSync } = await import("node:sqlite");
-  const sqlite = new DatabaseSync(path);
+  const sqlite = runtimeDb.sqlite;
   sqlite.exec("CREATE TABLE IF NOT EXISTS runtime_opencode_configs (workspace_id TEXT PRIMARY KEY NOT NULL, config_json TEXT NOT NULL, updated_at INTEGER NOT NULL)");
   const get = sqlite.prepare("SELECT config_json AS configJson FROM runtime_opencode_configs WHERE workspace_id = ?");
   const upsert = sqlite.prepare("INSERT INTO runtime_opencode_configs (workspace_id, config_json, updated_at) VALUES (?, ?, ?) ON CONFLICT(workspace_id) DO UPDATE SET config_json = excluded.config_json, updated_at = excluded.updated_at");

--- a/apps/server/src/session-groups.ts
+++ b/apps/server/src/session-groups.ts
@@ -1,9 +1,8 @@
-import { homedir } from "node:os";
-import { dirname, join, resolve } from "node:path";
 import { eq } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { openRuntimeSqliteDatabase, runtimeDbPath } from "./runtime-db.js";
 import type { ServerConfig } from "./types.js";
-import { ensureDir, shortId } from "./utils.js";
+import { shortId } from "./utils.js";
 
 export type SessionGroupDefinition = {
   id: string;
@@ -96,22 +95,12 @@ export function normalizeSessionGroupState(value: unknown): SessionGroupState {
   return { groups, assignments };
 }
 
-function runtimeDbPath(config: ServerConfig): string {
-  const override = process.env.OPENWORK_RUNTIME_DB?.trim();
-  if (override) return resolve(override);
-  const configPath = config.configPath?.trim();
-  const configDir = configPath ? dirname(configPath) : join(homedir(), ".config", "openwork");
-  return join(configDir, "runtime.sqlite");
-}
-
 async function openSessionGroupDb(path: string): Promise<SessionGroupDb> {
-  await ensureDir(dirname(path));
-  if (typeof process.versions.bun === "string") {
-    const { Database } = await import("bun:sqlite");
-    const { drizzle } = await import("drizzle-orm/bun-sqlite");
-    const sqlite = new Database(path, { create: true });
+  const runtimeDb = await openRuntimeSqliteDatabase(path);
+  if (runtimeDb.kind === "bun") {
+    const sqlite = runtimeDb.sqlite;
     sqlite.run("CREATE TABLE IF NOT EXISTS session_group_states (workspace_id TEXT PRIMARY KEY NOT NULL, state_json TEXT NOT NULL, schema_version INTEGER NOT NULL DEFAULT 1, updated_at INTEGER NOT NULL)");
-    const db = drizzle(sqlite);
+    const db = runtimeDb.db;
     return {
       get: (workspaceId) => db
         .select()
@@ -131,8 +120,7 @@ async function openSessionGroupDb(path: string): Promise<SessionGroupDb> {
     };
   }
 
-  const { DatabaseSync } = await import("node:sqlite");
-  const sqlite = new DatabaseSync(path);
+  const sqlite = runtimeDb.sqlite;
   sqlite.exec("CREATE TABLE IF NOT EXISTS session_group_states (workspace_id TEXT PRIMARY KEY NOT NULL, state_json TEXT NOT NULL, schema_version INTEGER NOT NULL DEFAULT 1, updated_at INTEGER NOT NULL)");
   const get = sqlite.prepare("SELECT state_json AS stateJson, updated_at AS updatedAt FROM session_group_states WHERE workspace_id = ?");
   const upsert = sqlite.prepare("INSERT INTO session_group_states (workspace_id, state_json, schema_version, updated_at) VALUES (?, ?, 1, ?) ON CONFLICT(workspace_id) DO UPDATE SET state_json = excluded.state_json, schema_version = excluded.schema_version, updated_at = excluded.updated_at");

--- a/evals/flows/runtime-db-primitive.flow.ts
+++ b/evals/flows/runtime-db-primitive.flow.ts
@@ -1,0 +1,375 @@
+import { spawnSync, type SpawnSyncReturns } from "node:child_process";
+import { mkdtemp, rm, stat, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import { DatabaseSync } from "node:sqlite";
+import { fileURLToPath, pathToFileURL } from "node:url";
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+
+const FLOW_ID = "runtime-db-primitive";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SERVER_DIR = join(ROOT, "apps", "server");
+const SERVER_SRC = join(SERVER_DIR, "src");
+const RUN_TIMEOUT_MS = 120_000;
+const WORKSPACE_ID = "ws_runtime_db_primitive_flow";
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+type HarnessPaths = {
+  root: string;
+  dbPath: string;
+  harnessPath: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function witness(ctx: FlowContext, condition: unknown, assertion: string, actual?: string): void {
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual });
+    ctx.assert(false, assertion + (actual ? ` (actual: ${actual})` : ""));
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual });
+}
+
+function moduleUrl(name: string): string {
+  return pathToFileURL(join(SERVER_SRC, name)).href;
+}
+
+function harnessSource(): string {
+  return `import { join } from "node:path";
+import { installCloudPlugin, readInstalledCloudPlugins } from ${JSON.stringify(moduleUrl("cloud-plugins.ts"))};
+import { readOpenworkWorkspaceConfig, writeOpenworkWorkspaceConfig } from ${JSON.stringify(moduleUrl("openwork-workspace-config-store.ts"))};
+import { openRuntimeSqliteDatabase, runtimeDbPath, runtimeStorageDir } from ${JSON.stringify(moduleUrl("runtime-db.ts"))};
+import { readRuntimeOpencodeConfig, writeRuntimeOpencodeConfig } from ${JSON.stringify(moduleUrl("runtime-opencode-config-store.ts"))};
+import { readSessionGroupState, writeSessionGroupState } from ${JSON.stringify(moduleUrl("session-groups.ts"))};
+
+const mode = process.argv[2] ?? "";
+const root = process.env.RUNTIME_DB_PRIMITIVE_ROOT;
+const dbPath = process.env.OPENWORK_RUNTIME_DB;
+const workspaceId = ${JSON.stringify(WORKSPACE_ID)};
+
+if (!root || !dbPath) throw new Error("runtime DB primitive harness needs RUNTIME_DB_PRIMITIVE_ROOT and OPENWORK_RUNTIME_DB");
+
+function serverConfig(configPath = join(root, "server.json")) {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "token",
+    hostToken: "host-token",
+    configPath,
+    approval: { mode: "auto", timeoutMs: 0 },
+    corsOrigins: [],
+    workspaces: [{ id: workspaceId, name: "Runtime DB Primitive", path: root, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: 1,
+    tokenSource: "generated",
+    hostTokenSource: "generated",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+async function writeSessionAndWorkspace(config) {
+  await writeSessionGroupState(config, workspaceId, {
+    groups: [{ id: "grp_flow", label: "Flow group" }],
+    assignments: { ses_flow: "grp_flow" },
+  });
+  await writeOpenworkWorkspaceConfig(config, workspaceId, (current) => ({
+    ...current,
+    workspace: { label: "Flow workspace config" },
+  }));
+}
+
+async function writeRuntimeAndCloud(config) {
+  await writeRuntimeOpencodeConfig(config, workspaceId, (current) => ({
+    ...current,
+    plugin: ["flow-runtime-plugin"],
+    mcp: { flow: { type: "remote", url: "https://runtime-db-primitive.example/mcp" } },
+  }));
+  await installCloudPlugin({
+    serverConfig: config,
+    workspaceId,
+    workspaceRoot: root,
+    marketplaceId: "marketplace_flow",
+    marketplace: { id: "marketplace_flow", name: "Flow Marketplace", updatedAt: null },
+    resolved: {
+      plugin: { id: "plugin_flow", name: "Flow Runtime Plugin", description: null, updatedAt: null },
+      memberships: [],
+    },
+  });
+}
+
+async function readSessionAndWorkspace(config) {
+  const session = await readSessionGroupState(config, workspaceId);
+  const workspace = await readOpenworkWorkspaceConfig(config, workspaceId);
+  return {
+    groupLabel: session.state.groups[0]?.label ?? null,
+    assignment: session.state.assignments.ses_flow ?? null,
+    workspaceLabel: workspace.workspace?.label ?? null,
+  };
+}
+
+async function readRuntimeAndCloud(config) {
+  const runtime = await readRuntimeOpencodeConfig(config, workspaceId);
+  const cloud = await readInstalledCloudPlugins(config, workspaceId);
+  return {
+    runtimePlugin: runtime.plugin?.[0] ?? null,
+    runtimeMcpUrl: runtime.mcp?.flow?.url ?? null,
+    cloudPluginName: cloud.plugins.plugin_flow?.name ?? null,
+    marketplacePluginIds: cloud.marketplaces.marketplace_flow?.pluginIds ?? [],
+  };
+}
+
+function print(value) {
+  console.log(JSON.stringify(value));
+}
+
+const config = serverConfig();
+
+if (mode === "paths") {
+  delete process.env.OPENWORK_RUNTIME_DB;
+  const defaultPath = runtimeDbPath(config);
+  process.env.OPENWORK_RUNTIME_DB = ` + "` ${dbPath} `" + `;
+  const overridePath = runtimeDbPath(config);
+  const storageDir = runtimeStorageDir(config);
+  const connection = await openRuntimeSqliteDatabase(overridePath);
+  connection.sqlite.run("CREATE TABLE primitive_path_check (id TEXT PRIMARY KEY NOT NULL)");
+  connection.sqlite.query("INSERT INTO primitive_path_check (id) VALUES (?)").run("ok");
+  connection.close();
+  print({ mode, defaultPath, overridePath, storageDir, driver: connection.kind });
+} else if (mode === "write-session-workspace") {
+  await writeSessionAndWorkspace(config);
+  print({ mode, wrote: ["session_group_states", "openwork_workspace_configs"] });
+} else if (mode === "read-session-workspace") {
+  print({ mode, ...(await readSessionAndWorkspace(config)) });
+} else if (mode === "write-runtime-cloud") {
+  await writeRuntimeAndCloud(config);
+  print({ mode, wrote: ["runtime_opencode_configs", "cloud_plugin_install_configs"] });
+} else if (mode === "read-runtime-cloud") {
+  print({ mode, ...(await readRuntimeAndCloud(config)) });
+} else if (mode === "write-all") {
+  await writeSessionAndWorkspace(config);
+  await writeRuntimeAndCloud(config);
+  print({ mode, wrote: "all" });
+} else if (mode === "read-all") {
+  print({ mode, ...(await readSessionAndWorkspace(config)), ...(await readRuntimeAndCloud(config)) });
+} else {
+  throw new Error(` + "`Unknown runtime DB primitive harness mode: ${mode}`" + `);
+}
+`;
+}
+
+async function createHarness(): Promise<HarnessPaths> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-runtime-db-primitive-flow-"));
+  const harnessPath = join(root, "runtime-db-primitive-harness.mjs");
+  await writeFile(harnessPath, harnessSource(), "utf8");
+  return { root, dbPath: join(root, "runtime.sqlite"), harnessPath };
+}
+
+function runHarness(paths: HarnessPaths, mode: string): SpawnSyncReturns<string> {
+  return spawnSync("bun", [paths.harnessPath, mode], {
+    cwd: SERVER_DIR,
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      OPENWORK_RUNTIME_DB: paths.dbPath,
+      RUNTIME_DB_PRIMITIVE_ROOT: paths.root,
+    },
+    timeout: RUN_TIMEOUT_MS,
+  });
+}
+
+function commandOutput(run: SpawnSyncReturns<string>): string {
+  const parts: string[] = [];
+  if (run.stdout.trim()) parts.push(run.stdout.trim());
+  if (run.stderr.trim()) parts.push(run.stderr.trim());
+  if (run.error) parts.push(run.error.message);
+  return parts.join("\n");
+}
+
+function parseHarnessJson(run: SpawnSyncReturns<string>): Record<string, unknown> {
+  const line = run.stdout.trim().split("\n").filter(Boolean).at(-1);
+  if (!line) throw new Error("Harness did not print JSON");
+  const parsed: unknown = JSON.parse(line);
+  if (!isRecord(parsed)) throw new Error("Harness JSON was not an object");
+  return parsed;
+}
+
+function recordRow(row: unknown): Record<string, unknown> {
+  if (!isRecord(row)) throw new Error("Expected a SQLite row object");
+  return row;
+}
+
+function readTableNames(dbPath: string): string[] {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    return db.prepare("SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name").all()
+      .flatMap((row: unknown) => (isRecord(row) && typeof row.name === "string" ? [row.name] : []));
+  } finally {
+    db.close();
+  }
+}
+
+function readTextCell(dbPath: string, sql: string): string | null {
+  const db = new DatabaseSync(dbPath, { readOnly: true });
+  try {
+    const row = recordRow(db.prepare(sql).get());
+    return typeof row.value === "string" ? row.value : null;
+  } finally {
+    db.close();
+  }
+}
+
+function readJsonCell(dbPath: string, sql: string): Record<string, unknown> {
+  const text = readTextCell(dbPath, sql);
+  if (!text) return {};
+  const parsed: unknown = JSON.parse(text);
+  return isRecord(parsed) ? parsed : {};
+}
+
+export default defineFlow({
+  id: FLOW_ID,
+  title: "Runtime DB primitive keeps server stores durable and isolated",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Resolve one runtime DB path before opening",
+      run: async (ctx) => {
+        const paths = await createHarness();
+        try {
+          let run: SpawnSyncReturns<string> | null = null;
+          await ctx.prove("The server resolves the canonical runtime DB path and opens the chosen file", {
+            voiceover: vo[0],
+            action: async () => {
+              run = runHarness(paths, "paths");
+            },
+            assert: async () => {
+              if (!run) throw new Error("paths harness did not run");
+              witness(ctx, run.status === 0, "Path harness exits 0", commandOutput(run));
+              const output = parseHarnessJson(run);
+              witness(ctx, output.defaultPath === join(paths.root, "runtime.sqlite"), "Default path resolves next to server.json", String(output.defaultPath));
+              witness(ctx, output.overridePath === paths.dbPath, "OPENWORK_RUNTIME_DB override wins after trimming", String(output.overridePath));
+              witness(ctx, output.storageDir === paths.root, "runtimeStorageDir points at the runtime DB directory", String(output.storageDir));
+              witness(ctx, output.driver === "bun", "Harness opened the active Bun SQLite driver through the primitive", String(output.driver));
+              witness(ctx, (await stat(paths.dbPath)).isFile(), "Opening the primitive created the runtime.sqlite file", paths.dbPath);
+              ctx.output("harness path", paths.harnessPath);
+              ctx.output("$ bun runtime-db-primitive-harness.mjs paths", commandOutput(run));
+            },
+          });
+        } finally {
+          await rm(paths.root, { recursive: true, force: true });
+        }
+      },
+    },
+    {
+      name: "Session groups and workspace config stay isolated",
+      run: async (ctx) => {
+        const paths = await createHarness();
+        try {
+          let writeRun: SpawnSyncReturns<string> | null = null;
+          let readRun: SpawnSyncReturns<string> | null = null;
+          await ctx.prove("Session groups and workspace configuration persist in separate runtime DB tables", {
+            voiceover: vo[1],
+            action: async () => {
+              writeRun = runHarness(paths, "write-session-workspace");
+              readRun = runHarness(paths, "read-session-workspace");
+            },
+            assert: async () => {
+              if (!writeRun || !readRun) throw new Error("session/workspace harness did not run");
+              witness(ctx, writeRun.status === 0 && readRun.status === 0, "Session/workspace write and read harnesses exit 0", [commandOutput(writeRun), commandOutput(readRun)].join("\n"));
+              const output = parseHarnessJson(readRun);
+              const tables = readTableNames(paths.dbPath);
+              const sessionRow = readJsonCell(paths.dbPath, "SELECT state_json AS value FROM session_group_states WHERE workspace_id = 'ws_runtime_db_primitive_flow'");
+              const workspaceRow = readJsonCell(paths.dbPath, "SELECT config_json AS value FROM openwork_workspace_configs WHERE workspace_id = 'ws_runtime_db_primitive_flow'");
+              witness(ctx, tables.includes("session_group_states"), "session_group_states table exists", tables.join(", "));
+              witness(ctx, tables.includes("openwork_workspace_configs"), "openwork_workspace_configs table exists", tables.join(", "));
+              witness(ctx, output.groupLabel === "Flow group" && output.assignment === "grp_flow", "Session group state reads back through the store", JSON.stringify(output));
+              witness(ctx, output.workspaceLabel === "Flow workspace config", "Workspace config reads back through its store", JSON.stringify(output));
+              witness(ctx, Array.isArray(sessionRow.groups) && isRecord(workspaceRow.workspace), "Raw DB rows keep domain JSON in separate schemas", JSON.stringify({ sessionRow, workspaceRow }));
+              ctx.output("$ bun runtime-db-primitive-harness.mjs write-session-workspace", commandOutput(writeRun));
+              ctx.output("$ bun runtime-db-primitive-harness.mjs read-session-workspace", commandOutput(readRun));
+              ctx.output("SQLite tables", tables.join("\n"));
+            },
+          });
+        } finally {
+          await rm(paths.root, { recursive: true, force: true });
+        }
+      },
+    },
+    {
+      name: "Runtime config and cloud plugin state share the primitive only",
+      run: async (ctx) => {
+        const paths = await createHarness();
+        try {
+          let writeRun: SpawnSyncReturns<string> | null = null;
+          let readRun: SpawnSyncReturns<string> | null = null;
+          await ctx.prove("Runtime OpenCode configuration and cloud plugin installs use the primitive without sharing rows", {
+            voiceover: vo[2],
+            action: async () => {
+              writeRun = runHarness(paths, "write-runtime-cloud");
+              readRun = runHarness(paths, "read-runtime-cloud");
+            },
+            assert: async () => {
+              if (!writeRun || !readRun) throw new Error("runtime/cloud harness did not run");
+              witness(ctx, writeRun.status === 0 && readRun.status === 0, "Runtime/cloud write and read harnesses exit 0", [commandOutput(writeRun), commandOutput(readRun)].join("\n"));
+              const output = parseHarnessJson(readRun);
+              const tables = readTableNames(paths.dbPath);
+              const runtimeRow = readJsonCell(paths.dbPath, "SELECT config_json AS value FROM runtime_opencode_configs WHERE workspace_id = 'ws_runtime_db_primitive_flow'");
+              const cloudRow = readJsonCell(paths.dbPath, "SELECT config_json AS value FROM cloud_plugin_install_configs WHERE workspace_id = 'ws_runtime_db_primitive_flow'");
+              witness(ctx, tables.includes("runtime_opencode_configs"), "runtime_opencode_configs table exists", tables.join(", "));
+              witness(ctx, tables.includes("cloud_plugin_install_configs"), "cloud_plugin_install_configs table exists", tables.join(", "));
+              witness(ctx, output.runtimePlugin === "flow-runtime-plugin", "Runtime OpenCode plugin reads back through its store", JSON.stringify(output));
+              witness(ctx, output.runtimeMcpUrl === "https://runtime-db-primitive.example/mcp", "Runtime OpenCode MCP reads back through its store", JSON.stringify(output));
+              witness(ctx, output.cloudPluginName === "Flow Runtime Plugin", "Cloud plugin install state reads back through its store", JSON.stringify(output));
+              witness(ctx, Array.isArray(runtimeRow.plugin) && isRecord(cloudRow.plugins), "Raw DB rows keep runtime config and cloud imports in separate JSON documents", JSON.stringify({ runtimeRow, cloudRow }));
+              ctx.output("$ bun runtime-db-primitive-harness.mjs write-runtime-cloud", commandOutput(writeRun));
+              ctx.output("$ bun runtime-db-primitive-harness.mjs read-runtime-cloud", commandOutput(readRun));
+              ctx.output("SQLite tables", tables.join("\n"));
+            },
+          });
+        } finally {
+          await rm(paths.root, { recursive: true, force: true });
+        }
+      },
+    },
+    {
+      name: "A fresh process can read every domain back",
+      run: async (ctx) => {
+        const paths = await createHarness();
+        try {
+          let writeRun: SpawnSyncReturns<string> | null = null;
+          let readRun: SpawnSyncReturns<string> | null = null;
+          await ctx.prove("After the writer process exits, a new store process reads every domain back from the same DB", {
+            voiceover: vo[3],
+            action: async () => {
+              writeRun = runHarness(paths, "write-all");
+              readRun = runHarness(paths, "read-all");
+            },
+            assert: async () => {
+              if (!writeRun || !readRun) throw new Error("durability harness did not run");
+              witness(ctx, writeRun.status === 0 && readRun.status === 0, "Writer and fresh reader harnesses exit 0", [commandOutput(writeRun), commandOutput(readRun)].join("\n"));
+              const output = parseHarnessJson(readRun);
+              const tables = readTableNames(paths.dbPath);
+              witness(ctx, output.groupLabel === "Flow group", "Fresh process reads session groups", JSON.stringify(output));
+              witness(ctx, output.workspaceLabel === "Flow workspace config", "Fresh process reads workspace config", JSON.stringify(output));
+              witness(ctx, output.runtimePlugin === "flow-runtime-plugin", "Fresh process reads runtime OpenCode config", JSON.stringify(output));
+              witness(ctx, output.cloudPluginName === "Flow Runtime Plugin", "Fresh process reads cloud plugin install state", JSON.stringify(output));
+              witness(ctx, tables.length === 4, "The reopened DB contains exactly the four migrated domain tables", tables.join(", "));
+              ctx.output("$ bun runtime-db-primitive-harness.mjs write-all", commandOutput(writeRun));
+              ctx.output("$ bun runtime-db-primitive-harness.mjs read-all", commandOutput(readRun));
+              ctx.output("runtime.sqlite", paths.dbPath);
+            },
+          });
+        } finally {
+          await rm(paths.root, { recursive: true, force: true });
+        }
+      },
+    },
+  ],
+});

--- a/evals/voiceovers/runtime-db-primitive.md
+++ b/evals/voiceovers/runtime-db-primitive.md
@@ -1,0 +1,9 @@
+# runtime-db-primitive — One safe runtime database foundation for server state
+
+1. The server resolves one runtime database location, including an explicit override, before any domain store opens it.
+
+2. Session groups and workspace configuration persist through the shared database foundation while remaining isolated in their own tables.
+
+3. Runtime OpenCode configuration and cloud plugin installation state use the same connection primitive without sharing or corrupting domain data.
+
+4. After the stores close and reopen, each domain reads back the state it wrote, demonstrating that the refactor preserves durable behavior.


### PR DESCRIPTION
## Summary
- add one typed runtime SQLite path/connection primitive for Bun and Node
- migrate session groups, workspace config, runtime OpenCode config, and cloud plugin state
- keep each domain schema, table initialization, JSON parsing, and CRUD explicit
- preserve compatibility exports for existing runtime storage consumers
- add dual-driver, table-isolation, and fresh-process durability proof

## Validation
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm --filter openwork-server build` — passed
- focused four-store persistence suite — passed (30/30)
- Node SQLite driver test — passed (1/1)
- broader runtime/config persistence suite — passed (23/23)
- `pnpm evals:typecheck` — passed
- `pnpm test:eval-runner` — passed (4/4)
- `pnpm fraimz --flow runtime-db-primitive` — passed (4/4 internal frames plus voiceover coverage)

## Proof
Internal fraimz proof will be posted as a PR comment.