### PR TITLE
refactor(server): centralize cursor event buffers

### DIFF
--- a/apps/server/src/cursor-event-store.test.ts
+++ b/apps/server/src/cursor-event-store.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, test } from "bun:test";
+import { CursorEventStore, WorkspaceCursorEventStore, type WorkspaceCursorEvent } from "./cursor-event-store.js";
+
+type TestEvent = WorkspaceCursorEvent & {
+  label: string;
+};
+
+function event(workspaceId: string, label: string) {
+  return (seq: number): TestEvent => ({ seq, workspaceId, label });
+}
+
+describe("CursorEventStore", () => {
+  test("starts at cursor zero and appends monotonic sequence numbers", () => {
+    const store = new CursorEventStore<TestEvent>(10);
+
+    expect(store.cursor()).toBe(0);
+    expect(store.record(event("ws_1", "first")).seq).toBe(1);
+    expect(store.record(event("ws_1", "second")).seq).toBe(2);
+    expect(store.cursor()).toBe(2);
+  });
+
+  test("filters by workspace and lists events after the cursor exclusively", () => {
+    const store = new CursorEventStore<TestEvent>(10);
+    const first = store.record(event("ws_1", "first"));
+    store.record(event("ws_2", "other"));
+    store.record(event("ws_1", "second"));
+
+    expect(store.list("ws_1", first.seq).map((item) => item.label)).toEqual(["second"]);
+    expect(store.list("ws_2").map((item) => item.label)).toEqual(["other"]);
+  });
+
+  test("evicts old events without resetting the cursor", () => {
+    const store = new CursorEventStore<TestEvent>(2);
+    store.record(event("ws_1", "first"));
+    store.record(event("ws_1", "second"));
+    store.record(event("ws_1", "third"));
+
+    expect(store.cursor()).toBe(3);
+    expect(store.list("ws_1").map((item) => item.label)).toEqual(["second", "third"]);
+    expect(store.list("ws_1", 2).map((item) => item.label)).toEqual(["third"]);
+  });
+
+  test("keeps independent cursor sequences per instance", () => {
+    const first = new CursorEventStore<TestEvent>(10);
+    const second = new CursorEventStore<TestEvent>(10);
+
+    expect(first.record(event("ws_1", "first")).seq).toBe(1);
+    expect(second.record(event("ws_1", "first")).seq).toBe(1);
+    expect(first.cursor()).toBe(1);
+    expect(second.cursor()).toBe(1);
+  });
+});
+
+describe("WorkspaceCursorEventStore", () => {
+  test("keeps independent workspace cursors and buffers", () => {
+    const store = new WorkspaceCursorEventStore<TestEvent>(2);
+
+    store.record("quiet", event("quiet", "only"));
+    store.record("busy", event("busy", "first"));
+    store.record("busy", event("busy", "second"));
+    store.record("busy", event("busy", "third"));
+
+    expect(store.cursor("quiet")).toBe(1);
+    expect(store.cursor("busy")).toBe(3);
+    expect(store.list("quiet").map((item) => item.label)).toEqual(["only"]);
+    expect(store.list("busy").map((item) => item.label)).toEqual(["second", "third"]);
+  });
+});

--- a/apps/server/src/cursor-event-store.ts
+++ b/apps/server/src/cursor-event-store.ts
@@ -1,0 +1,70 @@
+export type WorkspaceCursorEvent = {
+  seq: number;
+  workspaceId: string;
+};
+
+export type CursorEventBuilder<TEvent extends WorkspaceCursorEvent> = (seq: number) => TEvent;
+
+function sinceCursor(since?: number): number {
+  return typeof since === "number" && Number.isFinite(since) ? since : 0;
+}
+
+export class CursorEventStore<TEvent extends WorkspaceCursorEvent> {
+  private events: TEvent[] = [];
+  private seq = 0;
+  private maxSize: number;
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+  }
+
+  record(build: CursorEventBuilder<TEvent>): TEvent {
+    const nextSeq = this.seq + 1;
+    const event = build(nextSeq);
+    this.seq = nextSeq;
+    this.events.push(event);
+    if (this.events.length > this.maxSize) {
+      this.events.splice(0, this.events.length - this.maxSize);
+    }
+    return event;
+  }
+
+  list(workspaceId: string, since?: number): TEvent[] {
+    const cursor = sinceCursor(since);
+    return this.events.filter((event) => event.workspaceId === workspaceId && event.seq > cursor);
+  }
+
+  cursor(): number {
+    return this.seq;
+  }
+}
+
+export class WorkspaceCursorEventStore<TEvent extends WorkspaceCursorEvent> {
+  private stores = new Map<string, CursorEventStore<TEvent>>();
+  private maxSize: number;
+
+  constructor(maxSize: number) {
+    this.maxSize = maxSize;
+  }
+
+  record(workspaceId: string, build: CursorEventBuilder<TEvent>): TEvent {
+    const store = this.storeFor(workspaceId);
+    return store.record(build);
+  }
+
+  list(workspaceId: string, since?: number): TEvent[] {
+    return this.stores.get(workspaceId)?.list(workspaceId, since) ?? [];
+  }
+
+  cursor(workspaceId: string): number {
+    return this.stores.get(workspaceId)?.cursor() ?? 0;
+  }
+
+  private storeFor(workspaceId: string): CursorEventStore<TEvent> {
+    const existing = this.stores.get(workspaceId);
+    if (existing) return existing;
+    const store = new CursorEventStore<TEvent>(this.maxSize);
+    this.stores.set(workspaceId, store);
+    return store;
+  }
+}

--- a/apps/server/src/events.test.ts
+++ b/apps/server/src/events.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, test } from "bun:test";
+import { ReloadEventStore } from "./events.js";
+
+describe("ReloadEventStore", () => {
+  test("keeps a global cursor while filtering reads by workspace", () => {
+    const store = new ReloadEventStore(2);
+    const quiet = store.record("quiet", "config", { type: "config", name: "quiet.json" });
+    store.record("busy", "config", { type: "config", name: "first.json" });
+    store.record("busy", "skills", { type: "skill", name: "second.md" });
+
+    expect(quiet.seq).toBe(1);
+    expect(store.cursor()).toBe(3);
+    expect(store.list("quiet")).toEqual([]);
+    expect(store.list("busy", 1).map((event) => event.trigger?.name)).toEqual(["first.json", "second.md"]);
+  });
+
+  test("keeps reload payload shape and debounce semantics outside the cursor buffer", () => {
+    const store = new ReloadEventStore();
+    const first = store.recordDebounced("ws_1", "mcp", { type: "mcp", name: "server.json" }, 1_000);
+    const second = store.recordDebounced("ws_1", "mcp", { type: "mcp", name: "server.json" }, 1_000);
+
+    expect(second).toBeNull();
+    expect(first).toMatchObject({
+      seq: 1,
+      workspaceId: "ws_1",
+      reason: "mcp",
+      trigger: { type: "mcp", name: "server.json" },
+    });
+    expect(typeof first?.id).toBe("string");
+    expect(typeof first?.timestamp).toBe("number");
+  });
+});

--- a/apps/server/src/events.ts
+++ b/apps/server/src/events.ts
@@ -1,32 +1,24 @@
 import type { ReloadEvent, ReloadReason, ReloadTrigger } from "./types.js";
+import { CursorEventStore } from "./cursor-event-store.js";
 import { shortId } from "./utils.js";
 
 export class ReloadEventStore {
-  private events: ReloadEvent[] = [];
-  private seq = 0;
-  private maxSize: number;
+  private events: CursorEventStore<ReloadEvent>;
   private lastRecorded: Map<string, number> = new Map();
 
   constructor(maxSize = 200) {
-    this.maxSize = maxSize;
+    this.events = new CursorEventStore(maxSize);
   }
 
   record(workspaceId: string, reason: ReloadReason, trigger?: ReloadTrigger): ReloadEvent {
-    const event: ReloadEvent = {
+    return this.events.record((seq) => ({
       id: shortId(),
-      seq: ++this.seq,
+      seq,
       workspaceId,
       reason,
       trigger,
       timestamp: Date.now(),
-    };
-
-    this.events.push(event);
-    if (this.events.length > this.maxSize) {
-      this.events.splice(0, this.events.length - this.maxSize);
-    }
-
-    return event;
+    }));
   }
 
   recordDebounced(
@@ -44,11 +36,10 @@ export class ReloadEventStore {
   }
 
   list(workspaceId: string, since?: number): ReloadEvent[] {
-    const cursor = Number.isFinite(since) ? (since as number) : 0;
-    return this.events.filter((event) => event.workspaceId === workspaceId && event.seq > cursor);
+    return this.events.list(workspaceId, since);
   }
 
   cursor(): number {
-    return this.seq;
+    return this.events.cursor();
   }
 }

--- a/apps/server/src/file-sessions.e2e.test.ts
+++ b/apps/server/src/file-sessions.e2e.test.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const stops: Array<() => void | Promise<void>> = [];
+const roots: string[] = [];
+
+afterEach(async () => {
+  while (stops.length) {
+    const stop = stops.pop();
+    if (stop) await stop();
+  }
+  while (roots.length) {
+    const root = roots.pop();
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+});
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function auth(token: string) {
+  return { Authorization: `Bearer ${token}`, "Content-Type": "application/json" };
+}
+
+async function createWorkspaceRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-file-sessions-"));
+  roots.push(root);
+  return root;
+}
+
+async function startOpenworkServer(workspaceRoot: string) {
+  const config: ServerConfig = {
+    host: "127.0.0.1",
+    port: 0,
+    token: "owt_test_token",
+    hostToken: "owt_host_token",
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: workspaceRoot, preset: "starter", workspaceType: "local" }],
+    authorizedRoots: [workspaceRoot],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+  const server = await startServer(config);
+  stops.push(() => server.stop());
+  return { base: `http://127.0.0.1:${server.port}`, token: config.token };
+}
+
+async function json(response: Response): Promise<unknown> {
+  expect(response.status).toBe(200);
+  return response.json();
+}
+
+function nestedString(value: unknown, first: string, second: string): string {
+  if (!isRecord(value) || !isRecord(value[first]) || typeof value[first][second] !== "string") {
+    throw new Error(`Expected ${first}.${second}`);
+  }
+  return value[first][second];
+}
+
+function numberField(value: unknown, field: string): number {
+  if (!isRecord(value) || typeof value[field] !== "number") {
+    throw new Error(`Expected numeric ${field}`);
+  }
+  return value[field];
+}
+
+function itemRecords(value: unknown): Record<string, unknown>[] {
+  if (!isRecord(value) || !Array.isArray(value.items)) {
+    throw new Error("Expected items array");
+  }
+  const items: Record<string, unknown>[] = [];
+  for (const item of value.items) {
+    if (!isRecord(item)) throw new Error("Expected item record");
+    items.push(item);
+  }
+  return items;
+}
+
+describe("file session catalog event API", () => {
+  test("serves catalog events with preserved cursor order and payload shape", async () => {
+    const root = await createWorkspaceRoot();
+    const { base, token } = await startOpenworkServer(root);
+
+    const created = await json(await fetch(`${base}/workspace/ws_1/files/sessions`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({}),
+    }));
+    const sessionId = nestedString(created, "session", "id");
+
+    const written = await json(await fetch(`${base}/files/sessions/${sessionId}/write-batch`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({
+        writes: [{ path: "notes/a.md", contentBase64: Buffer.from("hello").toString("base64") }],
+      }),
+    }));
+    expect(numberField(written, "cursor")).toBe(1);
+
+    const operated = await json(await fetch(`${base}/files/sessions/${sessionId}/ops`, {
+      method: "POST",
+      headers: auth(token),
+      body: JSON.stringify({
+        operations: [
+          { type: "mkdir", path: "notes/sub" },
+          { type: "rename", from: "notes/a.md", to: "notes/b.md" },
+        ],
+      }),
+    }));
+    expect(numberField(operated, "cursor")).toBe(3);
+
+    const events = await json(await fetch(`${base}/files/sessions/${sessionId}/catalog/events?since=1`, {
+      headers: auth(token),
+    }));
+    expect(numberField(events, "cursor")).toBe(3);
+    const items = itemRecords(events);
+    expect(items.map((item) => item.type)).toEqual(["mkdir", "rename"]);
+    expect(items.map((item) => item.path)).toEqual(["notes/sub", "notes/a.md"]);
+    expect(items[1]?.toPath).toBe("notes/b.md");
+    expect(items.every((item) => item.workspaceId === "ws_1" && typeof item.timestamp === "number")).toBe(true);
+  });
+});

--- a/apps/server/src/file-sessions.test.ts
+++ b/apps/server/src/file-sessions.test.ts
@@ -30,9 +30,19 @@ describe("FileSessionStore", () => {
   test("records and paginates workspace events", () => {
     const store = new FileSessionStore({ maxEventsPerWorkspace: 5 });
 
-    store.recordWorkspaceEvent({ workspaceId: "ws_1", type: "write", path: "notes/a.md", revision: "1" });
+    const written = store.recordWorkspaceEvent({ workspaceId: "ws_1", type: "write", path: "notes/a.md", revision: "1" });
     store.recordWorkspaceEvent({ workspaceId: "ws_1", type: "mkdir", path: "notes" });
     store.recordWorkspaceEvent({ workspaceId: "ws_1", type: "rename", path: "notes/a.md", toPath: "notes/b.md" });
+
+    expect(written).toMatchObject({
+      seq: 1,
+      workspaceId: "ws_1",
+      type: "write",
+      path: "notes/a.md",
+      revision: "1",
+    });
+    expect(typeof written.id).toBe("string");
+    expect(typeof written.timestamp).toBe("number");
 
     const fromStart = store.listWorkspaceEvents("ws_1", 0);
     expect(fromStart.items.length).toBe(3);
@@ -41,5 +51,19 @@ describe("FileSessionStore", () => {
     const fromSecond = store.listWorkspaceEvents("ws_1", 2);
     expect(fromSecond.items.length).toBe(1);
     expect(fromSecond.items[0]?.type).toBe("rename");
+  });
+
+  test("keeps file session event buffers scoped per workspace", () => {
+    const store = new FileSessionStore({ maxEventsPerWorkspace: 2 });
+
+    store.recordWorkspaceEvent({ workspaceId: "quiet", type: "write", path: "quiet.md" });
+    store.recordWorkspaceEvent({ workspaceId: "busy", type: "write", path: "first.md" });
+    store.recordWorkspaceEvent({ workspaceId: "busy", type: "write", path: "second.md" });
+    store.recordWorkspaceEvent({ workspaceId: "busy", type: "delete", path: "third.md" });
+
+    expect(store.listWorkspaceEvents("quiet").cursor).toBe(1);
+    expect(store.listWorkspaceEvents("quiet").items.map((event) => event.path)).toEqual(["quiet.md"]);
+    expect(store.listWorkspaceEvents("busy").cursor).toBe(3);
+    expect(store.listWorkspaceEvents("busy").items.map((event) => event.path)).toEqual(["second.md", "third.md"]);
   });
 });

--- a/apps/server/src/file-sessions.ts
+++ b/apps/server/src/file-sessions.ts
@@ -1,3 +1,4 @@
+import { WorkspaceCursorEventStore } from "./cursor-event-store.js";
 import type { TokenScope } from "./types.js";
 import { shortId } from "./utils.js";
 
@@ -25,23 +26,16 @@ export type FileSessionRecord = {
   expiresAt: number;
 };
 
-type WorkspaceEventState = {
-  seq: number;
-  events: FileSessionEvent[];
-};
-
 export class FileSessionStore {
   private sessions = new Map<string, FileSessionRecord>();
 
-  private workspaceEvents = new Map<string, WorkspaceEventState>();
+  private workspaceEvents: WorkspaceCursorEventStore<FileSessionEvent>;
 
   private maxSessions: number;
 
-  private maxEventsPerWorkspace: number;
-
   constructor(options?: { maxSessions?: number; maxEventsPerWorkspace?: number }) {
     this.maxSessions = options?.maxSessions ?? 256;
-    this.maxEventsPerWorkspace = options?.maxEventsPerWorkspace ?? 500;
+    this.workspaceEvents = new WorkspaceCursorEventStore(options?.maxEventsPerWorkspace ?? 500);
   }
 
   create(input: {
@@ -96,34 +90,20 @@ export class FileSessionStore {
     toPath?: string;
     revision?: string;
   }): FileSessionEvent {
-    const state = this.workspaceEvents.get(input.workspaceId) ?? { seq: 0, events: [] };
-    const event: FileSessionEvent = {
+    return this.workspaceEvents.record(input.workspaceId, (seq) => ({
       id: shortId(),
-      seq: state.seq + 1,
+      seq,
       workspaceId: input.workspaceId,
       type: input.type,
       path: input.path,
       toPath: input.toPath,
       revision: input.revision,
       timestamp: Date.now(),
-    };
-    state.seq = event.seq;
-    state.events.push(event);
-    if (state.events.length > this.maxEventsPerWorkspace) {
-      state.events.splice(0, state.events.length - this.maxEventsPerWorkspace);
-    }
-    this.workspaceEvents.set(input.workspaceId, state);
-    return event;
+    }));
   }
 
   listWorkspaceEvents(workspaceId: string, since = 0): { items: FileSessionEvent[]; cursor: number } {
-    const state = this.workspaceEvents.get(workspaceId);
-    if (!state) {
-      return { items: [], cursor: 0 };
-    }
-    const cursor = Number.isFinite(since) && since > 0 ? since : 0;
-    const items = state.events.filter((item) => item.seq > cursor);
-    return { items, cursor: state.seq };
+    return { items: this.workspaceEvents.list(workspaceId, since), cursor: this.workspaceEvents.cursor(workspaceId) };
   }
 
   private pruneExpired(): void {

--- a/apps/server/src/session-groups.e2e.test.ts
+++ b/apps/server/src/session-groups.e2e.test.ts
@@ -222,4 +222,20 @@ describe("session group API", () => {
     expect(store.cursor("quiet")).toBe(1);
     expect(store.cursor("busy")).toBe(3);
   });
+
+  test("preserves session group event payload shape", () => {
+    const store = new SessionGroupEventStore();
+    const event = store.record("ws_1", "assigned", { groupId: "grp_1", sessionId: "ses_1" });
+
+    expect(event).toMatchObject({
+      seq: 1,
+      workspaceId: "ws_1",
+      type: "session_groups.updated",
+      action: "assigned",
+      groupId: "grp_1",
+      sessionId: "ses_1",
+    });
+    expect(typeof event.id).toBe("string");
+    expect(typeof event.timestamp).toBe("number");
+  });
 });

--- a/apps/server/src/session-groups.ts
+++ b/apps/server/src/session-groups.ts
@@ -2,6 +2,7 @@ import { homedir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { eq } from "drizzle-orm";
 import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+import { WorkspaceCursorEventStore } from "./cursor-event-store.js";
 import type { ServerConfig } from "./types.js";
 import { ensureDir, shortId } from "./utils.js";
 
@@ -40,11 +41,6 @@ const sessionGroupStates = sqliteTable("session_group_states", {
 type SessionGroupDb = {
   get: (workspaceId: string) => { stateJson: string; updatedAt: number } | undefined;
   upsert: (value: { workspaceId: string; stateJson: string; updatedAt: number }) => void;
-};
-
-type SessionGroupEventState = {
-  seq: number;
-  events: SessionGroupEvent[];
 };
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -213,11 +209,10 @@ export async function updateSessionGroupState(
 }
 
 export class SessionGroupEventStore {
-  private eventsByWorkspace = new Map<string, SessionGroupEventState>();
-  private maxSize: number;
+  private events: WorkspaceCursorEventStore<SessionGroupEvent>;
 
   constructor(maxSize = 500) {
-    this.maxSize = maxSize;
+    this.events = new WorkspaceCursorEventStore(maxSize);
   }
 
   record(
@@ -225,33 +220,23 @@ export class SessionGroupEventStore {
     action: SessionGroupEventAction,
     details?: { groupId?: string; sessionId?: string },
   ): SessionGroupEvent {
-    const state = this.eventsByWorkspace.get(workspaceId) ?? { seq: 0, events: [] };
-    const event: SessionGroupEvent = {
+    return this.events.record(workspaceId, (seq) => ({
       id: shortId(),
-      seq: ++state.seq,
+      seq,
       workspaceId,
       type: "session_groups.updated",
       action,
       ...(details?.groupId ? { groupId: details.groupId } : {}),
       ...(details?.sessionId ? { sessionId: details.sessionId } : {}),
       timestamp: Date.now(),
-    };
-
-    state.events.push(event);
-    if (state.events.length > this.maxSize) {
-      state.events.splice(0, state.events.length - this.maxSize);
-    }
-    this.eventsByWorkspace.set(workspaceId, state);
-    return event;
+    }));
   }
 
   list(workspaceId: string, since?: number): SessionGroupEvent[] {
-    const cursor = typeof since === "number" && Number.isFinite(since) ? since : 0;
-    const state = this.eventsByWorkspace.get(workspaceId);
-    return state ? state.events.filter((event) => event.seq > cursor) : [];
+    return this.events.list(workspaceId, since);
   }
 
   cursor(workspaceId: string): number {
-    return this.eventsByWorkspace.get(workspaceId)?.seq ?? 0;
+    return this.events.cursor(workspaceId);
   }
 }

--- a/evals/flows/cursor-event-store.flow.ts
+++ b/evals/flows/cursor-event-store.flow.ts
@@ -1,0 +1,166 @@
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineFlow } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+
+const FLOW_ID = "cursor-event-store";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error("Missing approved voice-over script for cursor-event-store.");
+
+type CommandResult = {
+  status: number;
+  output: string;
+};
+
+function witness(ctx: { recordEvidence: (entry: { type: "assertion"; status: "passed" | "failed"; assertion: string; actual?: string }) => unknown; assert: (condition: unknown, message: string) => void }, condition: boolean, assertion: string, actual?: string): void {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    ...(actual ? { actual } : {}),
+  });
+  ctx.assert(condition, assertion + (actual ? ` (actual: ${actual})` : ""));
+}
+
+function run(ctx: { output: (name: string, text: unknown) => unknown }, label: string, args: string[]): CommandResult {
+  const result = spawnSync("pnpm", args, {
+    cwd: ROOT,
+    encoding: "utf8",
+    timeout: 120_000,
+  });
+  const stdout = typeof result.stdout === "string" ? result.stdout : "";
+  const stderr = typeof result.stderr === "string" ? result.stderr : "";
+  const output = [stdout, stderr].filter(Boolean).join("\n").trim();
+  const status = typeof result.status === "number" ? result.status : -1;
+  ctx.output(label, output);
+  return { status, output };
+}
+
+function requireResult(result: CommandResult | null): CommandResult {
+  if (!result) throw new Error("Expected command result");
+  return result;
+}
+
+async function sourceSnippet(path: string, includes: string[]): Promise<string> {
+  const source = await readFile(join(ROOT, path), "utf8");
+  return source.split("\n").filter((line) => includes.some((item) => line.includes(item))).join("\n");
+}
+
+export default defineFlow({
+  id: FLOW_ID,
+  title: "One cursor primitive preserves local server event semantics",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "Fresh stores start at a known cursor",
+      run: async (ctx) => {
+        let result: CommandResult | null = null;
+        await ctx.prove("The generic event store starts at cursor 0 and assigns seq 1, then seq 2", {
+          voiceover: vo[0],
+          action: () => {
+            result = run(ctx, "$ cursor primitive initial cursor test", [
+              "--filter", "openwork-server", "exec", "bun", "test",
+              "src/cursor-event-store.test.ts",
+              "--test-name-pattern", "starts at cursor zero",
+            ]);
+          },
+          assert: async () => {
+            const command = requireResult(result);
+            witness(ctx, command.status === 0, "The primitive initial-cursor test exits successfully", command.output.split("\n").at(-1));
+            const snippet = await sourceSnippet("apps/server/src/cursor-event-store.test.ts", [
+              "expect(store.cursor()).toBe(0)",
+              "first\")).seq).toBe(1)",
+              "second\")).seq).toBe(2)",
+            ]);
+            ctx.output("Initial cursor assertions", snippet);
+            witness(ctx, snippet.includes("toBe(0)") && snippet.includes("toBe(1)") && snippet.includes("toBe(2)"), "The checked harness asserts cursor 0 and monotonic seq 1/2");
+          },
+        });
+      },
+    },
+    {
+      name: "Workspace readers get newer events in order",
+      run: async (ctx) => {
+        let result: CommandResult | null = null;
+        await ctx.prove("The cursor list operation is workspace-scoped and treats since as exclusive", {
+          voiceover: vo[1],
+          action: () => {
+            result = run(ctx, "$ cursor primitive workspace filter test", [
+              "--filter", "openwork-server", "exec", "bun", "test",
+              "src/cursor-event-store.test.ts",
+              "--test-name-pattern", "filters by workspace",
+            ]);
+          },
+          assert: async () => {
+            const command = requireResult(result);
+            witness(ctx, command.status === 0, "The workspace filter/since test exits successfully", command.output.split("\n").at(-1));
+            const snippet = await sourceSnippet("apps/server/src/cursor-event-store.test.ts", [
+              "store.list(\"ws_1\", first.seq)",
+              "store.list(\"ws_2\")",
+            ]);
+            ctx.output("Workspace filter assertions", snippet);
+            witness(ctx, snippet.includes("[\"second\"]") && snippet.includes("[\"other\"]"), "The checked harness asserts only newer same-workspace events are returned in order");
+          },
+        });
+      },
+    },
+    {
+      name: "Domain wrappers and routes keep their payloads",
+      run: async (ctx) => {
+        let result: CommandResult | null = null;
+        await ctx.prove("Reload, session-group, and file-session wrappers keep their event payload contracts", {
+          voiceover: vo[2],
+          action: () => {
+            result = run(ctx, "$ wrapper and route payload tests", [
+              "--filter", "openwork-server", "exec", "bun", "test",
+              "src/events.test.ts",
+              "src/session-groups.e2e.test.ts",
+              "src/file-sessions.test.ts",
+              "src/file-sessions.e2e.test.ts",
+            ]);
+          },
+          assert: async () => {
+            const command = requireResult(result);
+            witness(ctx, command.status === 0, "The wrapper and route payload tests exit successfully", command.output.split("\n").at(-1));
+            const reloadSnippet = await sourceSnippet("apps/server/src/events.test.ts", ["reason: \"mcp\"", "trigger: { type: \"mcp\", name: \"server.json\" }"]);
+            const groupSnippet = await sourceSnippet("apps/server/src/session-groups.e2e.test.ts", ["type: \"session_groups.updated\"", "action: \"assigned\""]);
+            const fileSnippet = await sourceSnippet("apps/server/src/file-sessions.e2e.test.ts", ["toPath).toBe(\"notes/b.md\")", "workspaceId === \"ws_1\""]);
+            ctx.output("Preserved domain payload assertions", [reloadSnippet, groupSnippet, fileSnippet].filter(Boolean).join("\n"));
+            witness(ctx, reloadSnippet.includes("reason: \"mcp\"") && groupSnippet.includes("session_groups.updated") && fileSnippet.includes("notes/b.md"), "The checked harness asserts reload reason/trigger, session-group type/action, and file toPath/workspace payloads");
+          },
+        });
+      },
+    },
+    {
+      name: "Bounded buffers evict without leaking workspaces",
+      run: async (ctx) => {
+        let result: CommandResult | null = null;
+        await ctx.prove("Bounded buffers evict old events while cursors continue and workspace scopes stay isolated", {
+          voiceover: vo[3],
+          action: () => {
+            result = run(ctx, "$ cursor eviction and wrapper scoping tests", [
+              "--filter", "openwork-server", "exec", "bun", "test",
+              "src/cursor-event-store.test.ts",
+              "src/events.test.ts",
+              "src/session-groups.e2e.test.ts",
+              "src/file-sessions.test.ts",
+              "--test-name-pattern", "evicts|independent workspace|global cursor|buffered per workspace|buffers scoped",
+            ]);
+          },
+          assert: async () => {
+            const command = requireResult(result);
+            witness(ctx, command.status === 0, "The eviction and scoping tests exit successfully", command.output.split("\n").at(-1));
+            const primitiveSnippet = await sourceSnippet("apps/server/src/cursor-event-store.test.ts", ["toEqual([\"second\", \"third\"])", "store.cursor()).toBe(3)", "cursor(\"quiet\")"]);
+            const wrapperSnippet = await sourceSnippet("apps/server/src/file-sessions.test.ts", ["maxEventsPerWorkspace: 2", "[\"second.md\", \"third.md\"]", "[\"quiet.md\"]"]);
+            ctx.output("Eviction and no-leak assertions", [primitiveSnippet, wrapperSnippet].filter(Boolean).join("\n"));
+            witness(ctx, primitiveSnippet.includes("second") && primitiveSnippet.includes("third") && wrapperSnippet.includes("quiet.md"), "The checked harness asserts bounded eviction, cursor continuity, and no cross-workspace leakage");
+          },
+        });
+      },
+    },
+  ],
+});

--- a/evals/voiceovers/cursor-event-store.md
+++ b/evals/voiceovers/cursor-event-store.md
@@ -1,0 +1,9 @@
+# cursor-event-store — One reliable cursor primitive for workspace events
+
+1. A fresh event store starts at a known cursor and assigns strictly increasing sequence numbers as workspace events arrive.
+
+2. Consumers can read one workspace after a cursor and receive only newer events in their original order.
+
+3. Reload, session-group, and file-session events keep their domain-specific payloads while sharing the same bounded cursor behavior.
+
+4. When the buffer reaches its limit, old events are evicted without resetting the cursor or leaking events across workspaces.


### PR DESCRIPTION
## Summary
- add a typed bounded cursor-event primitive with global and per-workspace variants
- preserve reload events global cursor and debounce behavior
- preserve independent session-group and file-session workspace cursors
- keep domain IDs, timestamps, payloads, routes, and lifecycle rules in their wrappers
- add unit, wrapper, and route coverage for ordering, filtering, payloads, and eviction

## Validation
- `pnpm --filter openwork-server typecheck` — passed
- `pnpm --filter openwork-server build` — passed
- focused event/wrapper/e2e suite — passed (26/26)
- `pnpm evals:typecheck` — passed
- `pnpm test:eval-runner` — passed (4/4)
- `pnpm fraimz --flow cursor-event-store` — passed (4/4 internal frames plus voiceover coverage)

## Proof
Internal fraimz proof will be posted as a PR comment.