### PR TITLE
chore(release): v0.17.37

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/app",
   "private": true,
-  "version": "0.17.36",
+  "version": "0.17.37",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/desktop",
   "private": true,
-  "version": "0.17.36",
+  "version": "0.17.37",
   "description": "OpenWork desktop shell",
   "author": {
     "name": "OpenWork",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-orchestrator",
-  "version": "0.17.36",
+  "version": "0.17.37",
   "description": "OpenWork host orchestrator for opencode + OpenWork server",
   "private": true,
   "type": "module",
@@ -46,7 +46,7 @@
     "@opencode-ai/sdk": "^1.17.11",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "openwork-server": "0.17.36",
+    "openwork-server": "0.17.37",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.17.36",
+  "version": "0.17.37",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/ee/apps/den-api/src/generated/desktop-versions.ts
+++ b/ee/apps/den-api/src/generated/desktop-versions.ts
@@ -1,6 +1,7 @@
 export const MIN_SUPPORTED_DESKTOP_VERSION = "0.17.0" as const;
 
 export const PUBLISHED_DESKTOP_VERSIONS = [
+  "0.17.37",
   "0.17.36",
   "0.17.35",
   "0.17.34",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,7 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       openwork-server:
-        specifier: 0.17.36
+        specifier: 0.17.37
         version: link:../server
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
Version bump for the v0.17.37 release — first release publishing the paste-gated installer assets (OpenWork-Installer-mac-arm64.dmg, mac-x64.dmg, win-x64.exe) alongside the app (#2990). Verified: bump script output only; no code changes.