### PR TITLE
fix(den-api): report newest desktop version

### DIFF
--- a/ee/apps/den-api/src/generated/app-version.ts
+++ b/ee/apps/den-api/src/generated/app-version.ts
@@ -1,1 +1,1 @@
-export const BUILD_LATEST_APP_VERSION = "0.17.30" as const
+export const BUILD_LATEST_APP_VERSION = "0.17.37" as const

--- a/ee/apps/den-api/src/version.ts
+++ b/ee/apps/den-api/src/version.ts
@@ -1,12 +1,15 @@
 import { BUILD_LATEST_APP_VERSION } from "./generated/app-version.js";
-import { MIN_SUPPORTED_DESKTOP_VERSION } from "./generated/desktop-versions.js";
+import { MIN_SUPPORTED_DESKTOP_VERSION, PUBLISHED_DESKTOP_VERSIONS } from "./generated/desktop-versions.js";
 
 function normalizeVersion(value: string | undefined | null) {
   const trimmed = value?.trim() ?? "";
   return trimmed || null;
 }
 
+const latestPublishedDesktopVersion = normalizeVersion(PUBLISHED_DESKTOP_VERSIONS[0]);
+const buildLatestAppVersion = normalizeVersion(BUILD_LATEST_APP_VERSION);
+
 export const denApiAppVersion = {
   minAppVersion: MIN_SUPPORTED_DESKTOP_VERSION,
-  latestAppVersion: normalizeVersion(BUILD_LATEST_APP_VERSION) ?? "0.0.0",
+  latestAppVersion: latestPublishedDesktopVersion ?? buildLatestAppVersion ?? "0.0.0",
 } as const;

--- a/ee/apps/den-api/test/version.test.ts
+++ b/ee/apps/den-api/test/version.test.ts
@@ -1,0 +1,7 @@
+import { expect, test } from "bun:test"
+import { PUBLISHED_DESKTOP_VERSIONS } from "../src/generated/desktop-versions.js"
+import { denApiAppVersion } from "../src/version.js"
+
+test("latest app version matches the newest published desktop version", () => {
+  expect(denApiAppVersion.latestAppVersion).toBe(PUBLISHED_DESKTOP_VERSIONS[0])
+})


### PR DESCRIPTION
## Summary
- Use the generated published desktop version inventory as the Den API latest version source.
- Refresh the generated app-version file for v0.17.37.
- Add a regression test that `latestAppVersion` matches the newest published desktop version.

## Repro
On the v0.17.37 Daytona Den server, `GET /v1/app-version` returned `latestAppVersion: 0.17.30` while `publishedDesktopVersions[0]` was `0.17.37`; consequently `/v1/install/win-x64?token=...` redirected to `https://github.com/different-ai/openwork/releases/download/v0.17.30/OpenWork-Installer-win-x64.exe`.

## Verification
- `pnpm --filter @openwork-ee/den-api exec bun test test/version.test.ts test/install-link-access.test.ts` — 26 pass, 0 fail.
- `pnpm --filter @openwork-ee/den-api build` — passed.
- `pnpm --filter @openwork-ee/den-api exec node -e "import('./dist/version.js').then((m) => console.log(JSON.stringify(m.denApiAppVersion)))"` — `latestAppVersion` is `0.17.37`.
