### PR TITLE
fix(den-web): clarify installer download feedback

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { requestJson } from "../_lib/den-flow";
 import { LAST_DESKTOP_HANDOFF_GRANT_STORAGE_KEY, readLastDesktopHandoffGrant } from "../_lib/desktop-handoff";
@@ -140,12 +140,9 @@ export function InstallScreen() {
   const [isMobile, setIsMobile] = useState<boolean | null>(null);
   const [platform, setPlatform] = useState<InstallPlatform>("mac-arm64");
   const [copied, setCopied] = useState(false);
-  const [downloadState, setDownloadState] = useState<"idle" | "preparing" | "started">("idle");
-  const [downloadLabel, setDownloadLabel] = useState("");
-  const [downloadHref, setDownloadHref] = useState("");
+  const [download, setDownload] = useState<{ label: string; href: string } | null>(null);
   const [currentLink, setCurrentLink] = useState("");
   const [handoffGrant, setHandoffGrant] = useState<string | null>(null);
-  const downloadStartedTimer = useRef<number | null>(null);
   const handoffStatus = useDesktopHandoffStatus(handoffGrant);
 
   useEffect(() => {
@@ -207,12 +204,6 @@ export function InstallScreen() {
     };
   }, [token]);
 
-  useEffect(() => () => {
-    if (downloadStartedTimer.current !== null) {
-      window.clearTimeout(downloadStartedTimer.current);
-    }
-  }, []);
-
   const secondaryPlatforms = useMemo(() => platformOptions.filter((option) => option.value !== platform), [platform]);
 
   async function copyCurrentLink() {
@@ -222,16 +213,7 @@ export function InstallScreen() {
   }
 
   function beginDownload(label: string, href: string) {
-    setDownloadLabel(label);
-    setDownloadHref(href);
-    setDownloadState("preparing");
-    if (downloadStartedTimer.current !== null) {
-      window.clearTimeout(downloadStartedTimer.current);
-    }
-    downloadStartedTimer.current = window.setTimeout(() => {
-      setDownloadState("started");
-      downloadStartedTimer.current = null;
-    }, 5000);
+    setDownload({ label, href });
   }
 
   if (busy) {
@@ -329,23 +311,13 @@ export function InstallScreen() {
                       );
                     })}
                   </div>
-                  {downloadState !== "idle" ? (
+                  {download ? (
                     <div className="den-frame-inset grid gap-2 rounded-[1.25rem] p-4" aria-live="polite" data-testid="install-download-status">
-                      {downloadState === "preparing" ? (
-                        <>
-                          <span className="size-5 animate-spin rounded-full border-2 border-[var(--dls-border-strong)] border-t-[var(--dls-accent)]" aria-hidden="true" />
-                          <p className="m-0 font-medium text-[var(--dls-text-primary)]">Preparing your {downloadLabel} download...</p>
-                          <p className="den-copy">The first download may take up to a minute. Your browser will begin downloading when it is ready.</p>
-                        </>
-                      ) : (
-                        <>
-                          <p className="m-0 font-medium text-[var(--dls-text-primary)]">Download started</p>
-                          <p className="den-copy">Your browser is preparing the file. If it does not appear, try the download again.</p>
-                          <a className="den-button-secondary w-fit" href={downloadHref} onClick={() => beginDownload(downloadLabel, downloadHref)}>
-                            Try again
-                          </a>
-                        </>
-                      )}
+                      <p className="m-0 font-medium text-[var(--dls-text-primary)]">Download requested</p>
+                      <p className="den-copy">Check your browser&apos;s Downloads menu for the {download.label} installer and its progress.</p>
+                      <a className="den-button-secondary w-fit" href={download.href} onClick={() => beginDownload(download.label, download.href)}>
+                        Try again
+                      </a>
                     </div>
                   ) : null}
                 </div>

--- a/evals/flows/install-download-feedback.flow.mjs
+++ b/evals/flows/install-download-feedback.flow.mjs
@@ -28,7 +28,7 @@ async function openInstallPage(ctx) {
 
 export default {
   id: "install-download-feedback",
-  title: "Installer downloads stay clear while the bundle is prepared",
+  title: "Installer downloads hand progress off to the browser clearly",
   kind: "user-facing",
   requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_TOKEN", "OPENWORK_EVAL_DEN_WEB_URL"],
   steps: [
@@ -39,75 +39,28 @@ export default {
       },
     },
     {
-      name: "Centered install card",
+      name: "Browser download feedback",
       run: async (ctx) => {
-        await ctx.prove("The organization install page presents a centered, focused download card", {
+        await ctx.prove("Choosing a platform immediately confirms the request and points to browser progress", {
           voiceover: vo[0],
-          action: async () => {},
-          assert: async () => {
-            const geometry = await ctx.eval(`(() => {
-              const card = document.querySelector('[data-testid="install-card"]')?.getBoundingClientRect();
-              if (!card) return null;
-              return { cardCenter: card.left + card.width / 2, viewportCenter: innerWidth / 2 };
-            })()`);
-            ctx.assert(geometry && Math.abs(geometry.cardCenter - geometry.viewportCenter) < 4, `Install card was not centered: ${JSON.stringify(geometry)}`);
-          },
-          screenshot: { name: "frame-1-centered-install-card", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: [`Download OpenWork for ${ORG_NAME}`] },
-        });
-      },
-    },
-    {
-      name: "Focused installer choices",
-      run: async (ctx) => {
-        await ctx.prove("Redundant team and server metadata are absent from the install page", {
-          voiceover: vo[1],
-          action: async () => {
-            await ctx.eval(`Array.from(document.querySelectorAll('a')).find((link) => link.textContent?.trim() === 'Windows')?.focus()`);
-          },
-          assert: async () => {
-            const text = await ctx.eval("document.body.innerText");
-            ctx.assert(!text.includes(`Team · ${ORG_NAME}`), "The redundant team footer is still visible.");
-            const metaRows = await ctx.eval("document.querySelectorAll('.den-meta-row').length");
-            ctx.assert(metaRows === 0, `Found ${metaRows} metadata rows.`);
-          },
-          screenshot: { name: "frame-2-focused-installer-choices", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: ["Mac (Apple silicon)", "Windows"], rejectText: [`Team · ${ORG_NAME}`] },
-        });
-      },
-    },
-    {
-      name: "Preparing feedback",
-      run: async (ctx) => {
-        await ctx.prove("Choosing a platform immediately explains that the download is being prepared", {
-          voiceover: vo[2],
           action: async () => {
             await ctx.eval(`(() => {
               const cancelDownload = (event) => event.preventDefault();
               document.addEventListener('click', cancelDownload, { capture: true, once: true });
               document.querySelector('[data-testid="install-download-primary"]')?.click();
             })()`);
-            await ctx.waitFor("document.body.innerText.includes('Preparing your')", { timeoutMs: 1_000, label: "preparing download feedback" });
+            await ctx.waitFor("document.body.innerText.includes('Download requested')", { timeoutMs: 1_000, label: "browser download feedback" });
           },
           assert: async () => {
             const text = await ctx.eval("document.querySelector('[data-testid=install-download-status]')?.textContent ?? ''");
-            ctx.assert(text.includes("The first download may take up to a minute"), `Preparation guidance was missing: ${text}`);
-          },
-          screenshot: { name: "frame-3-preparing-download", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: ["Preparing your", "The first download may take up to a minute"] },
-        });
-      },
-    },
-    {
-      name: "Download started feedback",
-      run: async (ctx) => {
-        await ctx.prove("The page confirms the browser download request and offers a retry", {
-          voiceover: vo[3],
-          action: async () => {
-            await ctx.waitFor("document.body.innerText.includes('Download started')", { timeoutMs: 5_000, label: "download started feedback" });
-          },
-          assert: async () => {
-            const text = await ctx.eval("document.querySelector('[data-testid=install-download-status]')?.textContent ?? ''");
+            ctx.assert(text.includes("browser's Downloads menu"), `Browser download guidance was missing: ${text}`);
+            ctx.assert(!text.includes("Preparing your"), `Synthetic preparation feedback is still visible: ${text}`);
             ctx.assert(text.includes("Try again"), `Retry action was missing: ${text}`);
+            ctx.assert(!text.includes("Download started"), `The page still claims the browser download completed: ${text}`);
+            const spinners = await ctx.eval("document.querySelectorAll('[data-testid=install-download-status] .animate-spin').length");
+            ctx.assert(spinners === 0, `Found ${spinners} synthetic download spinners.`);
           },
-          screenshot: { name: "frame-4-download-started", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: ["Download started", "Try again"] },
+          screenshot: { name: "browser-download-feedback", sandboxCapture: true, textTargetUrlIncludes: "/install?token=", requireText: ["Download requested", "Check your browser's Downloads menu", "Try again"], rejectText: ["Download started", "Preparing your"] },
         });
       },
     },

--- a/evals/voiceovers/install-download-feedback.md
+++ b/evals/voiceovers/install-download-feedback.md
@@ -1,9 +1,3 @@
-# install-download-feedback — Installer downloads stay clear while the bundle is prepared
+# install-download-feedback — Installer downloads hand progress off to the browser clearly
 
-1.  The organization install link opens as a centered, focused card with the organization branding and “Download OpenWork for Different AI.”
-
-2.  The redundant team and server details are gone, so the page stays focused on choosing the right installer.
-
-3.  When I choose my platform, the page immediately says it is preparing that download and explains that the first download can take up to a minute.
-
-4.  When the bundle is ready, the browser download starts and the page confirms it, with a clear way to retry if the download does not appear.
+1.  When I choose my platform, the page immediately confirms the request, points me to my browser's Downloads menu for real progress, and keeps a retry available without a fake spinner or success countdown.


### PR DESCRIPTION
## Summary

- remove the synthetic five-second installer download spinner and timer
- show immediate, honest “Download requested” feedback
- direct users to the browser Downloads menu for real progress while retaining a retry action
- narrow the matching coded eval to prevent the fake loading/completion states from returning

## Root cause

The install page still modeled the older server-side installer preparation flow. The current flow redirects directly to a normal release asset, but the UI continued to display a fixed five-second “Preparing” state and then claimed “Download started” without observing the browser. That made a healthy browser-managed download look stalled or broken.

## User impact

Selecting any installer platform now produces immediate guidance that matches what the app can actually know. Download progress remains owned by the browser instead of being represented by a fake app-level spinner.

## Verification

- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm evals:typecheck` — passed
- `pnpm evals --flow install-download-feedback --cdp-url http://127.0.0.1:45603` against the isolated local Den stack — passed on `a055183cb` (1 passed, 0 failed, 0 skipped)
- confirmed the current macOS ARM64 and Windows x64 generic installer release assets resolve successfully

The reporter supplied a screen recording reproducing the misleading spinner behavior. The corrected behavior has not yet been manually confirmed by the reporter.

## Risks and remaining gaps

- No download URL, server route, token handling, or installer artifact behavior changed.
- The coded UI flow intentionally prevents navigation so it can assert the status panel; it does not download the installer artifact through the browser.
- Cross-browser placement and wording of native Downloads menus may vary, but the page no longer claims to know native download completion.
