### PR TITLE
fix(den-api): use public URL for desktop handoff

### DIFF
--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -152,11 +152,18 @@ function withDenProxyPath(origin: string) {
   return url.toString().replace(/\/+$/, "")
 }
 
-function resolveDesktopDenBaseUrl(request: Request) {
+function configuredDesktopDenBaseUrl() {
+  return env.desktopDenBaseUrl ?? withDenProxyPath(env.betterAuthUrl)
+}
+
+export function resolveDesktopDenBaseUrl(request: Request) {
   const originHeader = readSingleHeader(request.headers.get("origin"))
   if (originHeader) {
     try {
       const originUrl = new URL(originHeader)
+      if (originUrl.hostname === "0.0.0.0") {
+        return configuredDesktopDenBaseUrl()
+      }
       if ((originUrl.protocol === "https:" || originUrl.protocol === "http:") && isWebAppHost(originUrl.hostname)) {
         return withDenProxyPath(originUrl.origin)
       }
@@ -171,7 +178,7 @@ function resolveDesktopDenBaseUrl(request: Request) {
   const protocol = forwardedProto ?? new URL(request.url).protocol.replace(/:$/, "")
   const targetHost = forwardedHost ?? host
   if (!targetHost) {
-    return env.desktopDenBaseUrl ?? `${env.betterAuthUrl}/api/den`
+    return configuredDesktopDenBaseUrl()
   }
 
   const origin = `${protocol}://${targetHost}`

--- a/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
+++ b/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, test } from "bun:test"
+
+describe("desktop handoff public URL", () => {
+  test("does not send 0.0.0.0 to desktop clients", async () => {
+    process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+    process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+    process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+    process.env.BETTER_AUTH_URL = "https://public.example.test"
+
+    const { resolveDesktopDenBaseUrl } = await import("../src/routes/auth/desktop-handoff.js")
+
+    expect(resolveDesktopDenBaseUrl(new Request("http://0.0.0.0:8788/v1/auth/desktop-handoff", {
+      headers: { origin: "http://0.0.0.0:3005" },
+    }))).toBe("https://public.example.test/api/den")
+  })
+})


### PR DESCRIPTION
## Summary\n- avoid generating desktop handoff links with a 0.0.0.0 Den URL when Den Web proxies the request internally\n- fall back to the configured public Den web URL plus /api/den for desktop clients\n\n## Validation\n- pnpm --filter @openwork-ee/den-db build\n- pnpm --filter @openwork-ee/den-api exec bun test test/desktop-handoff-public-url.test.ts\n\nFound during the two-door semi-airgapped PR #2992 validation: the Windows app rejected the pasted handoff with net::ERR_ADDRESS_INVALID until the denBaseUrl was corrected to the public Daytona URL.