### PR TITLE
fix(installer): retry busy Windows app launch

### DIFF
--- a/apps/installer/src/install.ts
+++ b/apps/installer/src/install.ts
@@ -179,7 +179,13 @@ async function downloadAsset(asset: ReleaseAsset, targetPath: string, opts: Inst
   await writer.end()
 }
 
-function run(command: string, args: string[]): Promise<void> {
+const WINDOWS_SPAWN_BUSY_RETRIES = 5
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function spawnOnce(command: string, args: string[]): Promise<void> {
   return new Promise((resolve, reject) => {
     const child = spawn(command, args, { stdio: "ignore" })
     child.on("error", reject)
@@ -188,6 +194,28 @@ function run(command: string, args: string[]): Promise<void> {
       else reject(new Error(`${command} ${args.join(" ")} exited with ${code}`))
     })
   })
+}
+
+async function run(command: string, args: string[]): Promise<void> {
+  for (let attempt = 0; attempt <= WINDOWS_SPAWN_BUSY_RETRIES; attempt += 1) {
+    try {
+      await spawnOnce(command, args)
+      return
+    } catch (error) {
+      const canRetry = process.platform === "win32" && error instanceof Error && error.message.includes("EBUSY")
+      if (!canRetry || attempt === WINDOWS_SPAWN_BUSY_RETRIES) throw error
+      await wait(300 * (attempt + 1))
+    }
+  }
+  throw new Error(`${command} ${args.join(" ")} did not start`)
+}
+
+export function windowsInstalledExePath(localAppData: string): string {
+  const candidates = [
+    path.join(localAppData, "Programs", "OpenWork", "OpenWork.exe"),
+    path.join(localAppData, "Programs", "@openworkdesktop", "OpenWork.exe"),
+  ]
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]
 }
 
 function installDmg(dmgPath: string, workDir: string): string {
@@ -219,7 +247,7 @@ async function installExe(exePath: string): Promise<string> {
   // silent install (shortcuts, uninstaller, updater layout all included).
   await run(exePath, ["/S"])
   const localAppData = process.env.LOCALAPPDATA || path.join(os.homedir(), "AppData", "Local")
-  return path.join(localAppData, "Programs", "OpenWork", "OpenWork.exe")
+  return windowsInstalledExePath(localAppData)
 }
 
 function installAppImage(appImagePath: string): string {

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -6,7 +6,7 @@ import { installConfigUrlFor } from "@openwork/install-config"
 
 import { desktopBootstrapPath, legacyDesktopBootstrapPath } from "../src/bootstrap-path"
 import { buildConstantsConfig, parseInstallLinkInput, resolveInstallerConfig } from "../src/config"
-import { writeBootstrapConfig } from "../src/install"
+import { windowsInstalledExePath, writeBootstrapConfig } from "../src/install"
 import { releaseAssetFor } from "../src/release-asset"
 import { startInstallerServer } from "../src/server"
 
@@ -55,6 +55,20 @@ describe("releaseAssetFor", () => {
   test("rejects unsupported targets", () => {
     expect(() => releaseAssetFor("0.17.7", "win32", "arm64")).toThrow()
     expect(() => releaseAssetFor("", "darwin", "arm64")).toThrow()
+  })
+})
+
+describe("windowsInstalledExePath", () => {
+  test("reports the installed electron-builder package directory", () => {
+    const temp = mkdtempSync(path.join(os.tmpdir(), "openwork-installed-path-"))
+    const installed = path.join(temp, "Programs", "@openworkdesktop", "OpenWork.exe")
+    mkdirSync(path.dirname(installed), { recursive: true })
+    writeFileSync(installed, "")
+    try {
+      expect(windowsInstalledExePath(temp)).toBe(installed)
+    } finally {
+      rmSync(temp, { recursive: true, force: true })
+    }
   })
 })
 


### PR DESCRIPTION
## Summary\n- retry launching the freshly downloaded Windows app installer when Windows reports EBUSY\n- report the actual electron-builder install directory when it installs under @openworkdesktop\n\n## Validation\n- pnpm --filter @openwork/installer test\n\nFound during the two-door semi-airgapped PR #2992 validation. The generic installer downloaded openwork-win-x64-0.17.37.exe from GitHub, then failed at install with EBUSY: resource busy or locked, uv_spawn. A manually downloaded app installer ran successfully and installed under Programs/@openworkdesktop.