### PR TITLE
fix(mcp): redact provider payloads at diagnostic boundaries

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
@@ -1857,8 +1857,10 @@ export function createExternalMcpDiagnosticFetch(input: {
 }
 
 export function externalMcpDiagnosticForResponse(error: unknown, referenceId: string, fallbackPhase: ExternalMcpDiagnosticPhase): ExternalMcpDiagnostic {
-  if (error instanceof ExternalMcpDiagnosticError) return error.diagnostic
-  return new ExternalMcpDiagnosticTracker(referenceId).error(error, fallbackPhase).diagnostic
+  const diagnostic = error instanceof ExternalMcpDiagnosticError
+    ? error.diagnostic
+    : new ExternalMcpDiagnosticTracker(referenceId).error(error, fallbackPhase).diagnostic
+  return externalMcpDiagnosticForUntrustedBoundary(diagnostic)
 }
 
 const OAUTH_CALLBACK_ERROR_NAMES: Record<string, string> = {
@@ -1891,8 +1893,21 @@ export function externalMcpDiagnosticForLog(error: unknown, referenceId: string,
     ? error
     : new ExternalMcpDiagnosticTracker(referenceId).error(error, fallbackPhase)
   return {
-    diagnostic: diagnosticError.diagnostic,
+    diagnostic: externalMcpDiagnosticForUntrustedBoundary(diagnosticError.diagnostic),
     causeChain: diagnosticError.safeCauseChain,
+  }
+}
+
+function externalMcpDiagnosticForUntrustedBoundary(diagnostic: ExternalMcpDiagnostic): ExternalMcpDiagnostic {
+  const {
+    providerErrorMessage: _providerErrorMessage,
+    providerErrorData: _providerErrorData,
+    message: _message,
+    ...safeDiagnostic
+  } = diagnostic
+  return {
+    ...safeDiagnostic,
+    message: safeMessageFor(safeDiagnostic),
   }
 }
 

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -7,6 +7,7 @@ import {
   catalogDiagnosticError,
   createExternalMcpDiagnosticFetch,
   externalMcpDiagnosticForLog,
+  externalMcpDiagnosticForResponse,
   safeExternalMcpEndpointForLog,
   safeExternalMcpCauseChain,
 } from "../src/capability-sources/external-mcp-diagnostics.js"
@@ -852,6 +853,38 @@ describe("external MCP diagnostics", () => {
       providerErrorData: '{"provider_detail":"must-not-surface"}',
     })
     expect(error.diagnostic.message).toContain("code -32050")
+  })
+
+  test("removes provider-declared payloads from response and log diagnostics", () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_untrusted_boundary")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const diagnosticError = tracker.error(jsonRpcError(-32050, {
+      provider_detail: "provider-data-secret",
+    }))
+
+    const responseDiagnostic = externalMcpDiagnosticForResponse(
+      diagnosticError,
+      "ignored",
+      "MCP_TOOL_EXECUTION",
+    )
+    const logDiagnostic = externalMcpDiagnosticForLog(
+      diagnosticError,
+      "ignored",
+      "MCP_TOOL_EXECUTION",
+    ).diagnostic
+
+    for (const diagnostic of [responseDiagnostic, logDiagnostic]) {
+      expect(diagnostic).toMatchObject({
+        referenceId: "req_untrusted_boundary",
+        code: "MCP_PROVIDER_DECLARED_ERROR",
+        jsonRpcCode: -32050,
+      })
+      expect(diagnostic.providerErrorMessage).toBeUndefined()
+      expect(diagnostic.providerErrorData).toBeUndefined()
+      expect(diagnostic.message).toContain("code -32050")
+      expect(JSON.stringify(diagnostic)).not.toContain("provider-data-secret")
+      expect(JSON.stringify(diagnostic)).not.toContain("synthetic provider detail")
+    }
   })
 
   test("classifies structured provider validation errors as correctable tool input", () => {


### PR DESCRIPTION
## Summary
- strip provider-declared message and data fields before diagnostics cross HTTP response or structured-log boundaries
- rebuild the public message from trusted diagnostic fields
- preserve internal provider evidence for agent-facing recovery while preventing provider-controlled secrets from reaching clients or logs

## Verification
- `bun test --conditions development test/external-mcp-diagnostics.test.ts` — 79 passed, 0 failed
- `bun test --conditions development test/mcp-connections-tools.test.ts` — 16 passed, 0 failed
- `pnpm --filter @openwork-ee/den-api build` — passed

## Regression proof
Before this fix, the tools-route suite failed 2 tests and emitted `provider-catalog-secret` in both the response diagnostic and structured error log. The new boundary test also fails on the base revision.

## Risk
Low and fail-closed. Internal diagnostics retain bounded provider evidence; only untrusted response/log projections remove provider payloads. No authentication, protocol, size, or routing policy is relaxed.