### PR TITLE
test(den-api): isolate and gate MCP suites

### DIFF
--- a/.github/workflows/ci-den-enterprise-mcp.yml
+++ b/.github/workflows/ci-den-enterprise-mcp.yml
@@ -1,0 +1,101 @@
+name: Den and Enterprise MCP
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/ci-den-enterprise-mcp.yml"
+      - "ee/apps/den-api/**"
+      - "ee/packages/den-db/**"
+      - "ee/packages/utils/**"
+      - "packages/connect-link/**"
+      - "packages/email/**"
+      - "packages/enterprise-mcp-client/**"
+      - "packages/install-config/**"
+      - "packages/types/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  push:
+    branches: [dev]
+    paths:
+      - ".github/workflows/ci-den-enterprise-mcp.yml"
+      - "ee/apps/den-api/**"
+      - "ee/packages/den-db/**"
+      - "ee/packages/utils/**"
+      - "packages/connect-link/**"
+      - "packages/email/**"
+      - "packages/enterprise-mcp-client/**"
+      - "packages/install-config/**"
+      - "packages/types/**"
+      - "package.json"
+      - "pnpm-lock.yaml"
+      - "pnpm-workspace.yaml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Den API and enterprise MCP client
+    runs-on: blacksmith-4vcpu-ubuntu-2204
+    services:
+      mysql:
+        image: mysql:8
+        env:
+          MYSQL_ROOT_PASSWORD: repro
+          MYSQL_DATABASE: openwork_test
+        ports:
+          - 33062:3306
+        options: >-
+          --health-cmd="mysqladmin ping -h 127.0.0.1 -uroot -prepro"
+          --health-interval=10s
+          --health-timeout=5s
+          --health-retries=10
+
+    env:
+      DATABASE_URL: mysql://root:repro@127.0.0.1:33062/openwork_test
+      DB_MODE: mysql
+      DEN_DB_ENCRYPTION_KEY: ci-den-db-encryption-key-not-production
+      BETTER_AUTH_SECRET: ci-better-auth-secret-not-production
+      BETTER_AUTH_URL: http://127.0.0.1:8790
+      CORS_ORIGINS: http://127.0.0.1:8790
+      OPENWORK_DEV_MODE: "1"
+      PROVISIONER_MODE: stub
+      DEN_ALLOW_PRIVATE_MCP_URLS: "1"
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.4.0
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install focused dependencies
+        run: >-
+          pnpm install --frozen-lockfile --ignore-scripts
+          --filter @openwork-ee/den-api...
+          --filter @openwork/enterprise-mcp-client...
+
+      - name: Prepare test database
+        run: pnpm --filter @openwork-ee/den-db db:push
+
+      - name: Check enterprise MCP client
+        run: |
+          pnpm --filter @openwork/enterprise-mcp-client typecheck
+          pnpm --filter @openwork/enterprise-mcp-client test
+
+      - name: Test Den API in isolated processes
+        run: pnpm --filter @openwork-ee/den-api test

--- a/ee/apps/den-api/package.json
+++ b/ee/apps/den-api/package.json
@@ -6,6 +6,7 @@
     "dev": "pnpm run build:email && pnpm run build:install-config && pnpm run build:connect-link && pnpm run build:enterprise-mcp-client && OPENWORK_DEV_MODE=1 tsx watch src/main.ts",
     "dev:local": "pnpm run build:email && pnpm run build:install-config && pnpm run build:connect-link && pnpm run build:enterprise-mcp-client && OPENWORK_DEV_MODE=1 PORT=${DEN_API_PORT:-8790} tsx watch src/main.ts",
     "build": "node ./scripts/build.mjs",
+    "test": "node ./scripts/run-tests-isolated.mjs",
     "build:email": "pnpm --filter @openwork/email build",
     "build:install-config": "pnpm --filter @openwork/install-config build",
     "build:connect-link": "pnpm --filter @openwork/connect-link build",

--- a/ee/apps/den-api/scripts/run-tests-isolated.mjs
+++ b/ee/apps/den-api/scripts/run-tests-isolated.mjs
@@ -1,0 +1,66 @@
+import { spawn } from "node:child_process"
+import { readdir } from "node:fs/promises"
+import { dirname, relative, resolve } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const appRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..")
+const testRoot = resolve(appRoot, "test")
+const requestedFiles = process.argv.slice(2).filter((argument) => argument !== "--")
+const testFiles = requestedFiles.length > 0
+  ? requestedFiles.map((file) => resolve(appRoot, file))
+  : (await readdir(testRoot))
+      .filter((file) => file.endsWith(".test.ts"))
+      .sort()
+      .map((file) => resolve(testRoot, file))
+const bun = process.env.DEN_API_TEST_BUN_BIN?.trim() || "bun"
+const failures = []
+const inheritedTestEnv = Object.fromEntries(
+  Object.entries(process.env).filter(([key]) => ![
+    "DEN_API_PUBLIC_URL",
+    "DEN_AUTH_FALLBACK_BASE",
+    "DEN_AUTH_ORIGIN",
+    "DEN_MCP_RESOURCE_URL",
+  ].includes(key)),
+)
+const testEnv = {
+  ...inheritedTestEnv,
+  BETTER_AUTH_URL: "http://127.0.0.1:8790",
+  CORS_ORIGINS: "http://127.0.0.1:8790",
+  DEN_API_PUBLIC_URL: "http://127.0.0.1:8790",
+  PORT: "8790",
+}
+
+function runTestFile(file) {
+  return new Promise((resolveRun) => {
+    const child = spawn(bun, [
+      "test",
+      "--conditions",
+      "development",
+      relative(appRoot, file),
+    ], {
+      cwd: appRoot,
+      env: testEnv,
+      stdio: "inherit",
+    })
+    child.on("error", (error) => resolveRun({ code: 1, error }))
+    child.on("exit", (code, signal) => resolveRun({ code: code ?? 1, signal }))
+  })
+}
+
+for (const file of testFiles) {
+  const label = relative(appRoot, file)
+  console.log(`\n[den-api:test] ${label}`)
+  const result = await runTestFile(file)
+  if (result.code !== 0) {
+    failures.push(label)
+    console.error(`[den-api:test] failed: ${label}${result.signal ? ` (${result.signal})` : ""}`)
+  }
+}
+
+if (failures.length > 0) {
+  console.error(`\n[den-api:test] ${failures.length} isolated file(s) failed:`)
+  for (const file of failures) console.error(`- ${file}`)
+  process.exitCode = 1
+} else {
+  console.log(`\n[den-api:test] ${testFiles.length} isolated file(s) passed.`)
+}

--- a/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
@@ -1857,8 +1857,10 @@ export function createExternalMcpDiagnosticFetch(input: {
 }
 
 export function externalMcpDiagnosticForResponse(error: unknown, referenceId: string, fallbackPhase: ExternalMcpDiagnosticPhase): ExternalMcpDiagnostic {
-  if (error instanceof ExternalMcpDiagnosticError) return error.diagnostic
-  return new ExternalMcpDiagnosticTracker(referenceId).error(error, fallbackPhase).diagnostic
+  const diagnostic = error instanceof ExternalMcpDiagnosticError
+    ? error.diagnostic
+    : new ExternalMcpDiagnosticTracker(referenceId).error(error, fallbackPhase).diagnostic
+  return externalMcpDiagnosticForUntrustedBoundary(diagnostic)
 }
 
 const OAUTH_CALLBACK_ERROR_NAMES: Record<string, string> = {
@@ -1891,8 +1893,21 @@ export function externalMcpDiagnosticForLog(error: unknown, referenceId: string,
     ? error
     : new ExternalMcpDiagnosticTracker(referenceId).error(error, fallbackPhase)
   return {
-    diagnostic: diagnosticError.diagnostic,
+    diagnostic: externalMcpDiagnosticForUntrustedBoundary(diagnosticError.diagnostic),
     causeChain: diagnosticError.safeCauseChain,
+  }
+}
+
+function externalMcpDiagnosticForUntrustedBoundary(diagnostic: ExternalMcpDiagnostic): ExternalMcpDiagnostic {
+  const {
+    providerErrorMessage: _providerErrorMessage,
+    providerErrorData: _providerErrorData,
+    message: _message,
+    ...safeDiagnostic
+  } = diagnostic
+  return {
+    ...safeDiagnostic,
+    message: safeMessageFor(safeDiagnostic),
   }
 }
 

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -264,6 +264,9 @@ export function externalMcpAuthErrorCode(
       || diagnosticError.diagnostic.phase === "AUTH_RESOURCE_VALIDATION"
       || diagnosticError.diagnostic.phase === "CONTINUITY_REFRESH"
     ) return "unauthorized"
+    // A structured diagnostic already identified this as a non-auth failure.
+    // Never let untrusted provider prose override that classification.
+    return null
   }
   if (INVALID_REFRESH_TOKEN_PATTERN.test(message)) return "invalid_refresh_token"
   if (INVALID_GRANT_PATTERN.test(message)) return "invalid_grant"

--- a/ee/apps/den-api/src/middleware/organization-context.ts
+++ b/ee/apps/den-api/src/middleware/organization-context.ts
@@ -20,8 +20,11 @@ export const resolveOrganizationContextMiddleware: MiddlewareHandler<{
   const apiKey = c.get("apiKey")
   const apiKeyScopedOrganizationId = getApiKeyScopedOrganizationId(apiKey)
   const headerOrganizationId = getRequestScopedOrganizationId(c.req.raw.headers)
-  const scopedOrganizationId = apiKeyScopedOrganizationId ?? headerOrganizationId
   const session = c.get("session")
+  const internalMcpOrganizationId = session?.id === "mcp_internal"
+    ? session.activeOrganizationId
+    : null
+  const scopedOrganizationId = apiKeyScopedOrganizationId ?? headerOrganizationId ?? internalMcpOrganizationId
   const userId = normalizeDenTypeId("user", user.id)
 
   let organizationId = scopedOrganizationId ?? c.get("activeOrganizationId") ?? null

--- a/ee/apps/den-api/src/middleware/organization-context.ts
+++ b/ee/apps/den-api/src/middleware/organization-context.ts
@@ -22,7 +22,7 @@ export const resolveOrganizationContextMiddleware: MiddlewareHandler<{
   const headerOrganizationId = getRequestScopedOrganizationId(c.req.raw.headers)
   const session = c.get("session")
   const internalMcpOrganizationId = session?.id === "mcp_internal"
-    ? session.activeOrganizationId
+    ? session.activeOrganizationId ?? null
     : null
   const scopedOrganizationId = apiKeyScopedOrganizationId ?? headerOrganizationId ?? internalMcpOrganizationId
   const userId = normalizeDenTypeId("user", user.id)

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -942,7 +942,7 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
     jsonValidator(githubPluginMcpImportSchema),
     describeRoute({
       tags: ["GitHub"],
-      summary: "Create a plugin from GitHub",
+      summary: "Add GitHub plugin to marketplace",
       description: "Creates one plugin from selected skills and remote MCP servers in a public GitHub plugin URL, applies the requested access grants, and optionally publishes it into an organization marketplace. Declared and known-server authentication requirements take precedence over the request-wide auth fallback.",
       responses: {
         200: jsonResponse("GitHub plugin MCPs imported successfully.", githubPluginMcpImportResponseSchema),

--- a/ee/apps/den-api/test/admin-organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/admin-organization-capabilities.test.ts
@@ -10,7 +10,7 @@ const adminEmail = `admin-capabilities+${adminUserId}@test.local`
 const organizationSlug = `admin-capabilities-${organizationId}`
 
 function seedRequiredEnv() {
-  process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test"
   process.env.DEN_DB_ENCRYPTION_KEY = "x".repeat(32)
   process.env.BETTER_AUTH_SECRET = "y".repeat(32)
   process.env.BETTER_AUTH_URL = "http://127.0.0.1:8790"

--- a/ee/apps/den-api/test/desktop-connect-grants-db.test.ts
+++ b/ee/apps/den-api/test/desktop-connect-grants-db.test.ts
@@ -4,6 +4,7 @@ import { afterAll, beforeAll, expect, test } from "bun:test"
 // MySQL integration coverage for the multi-replica trust boundary. Run after
 // pushing the current schema to the dedicated test database.
 process.env.DATABASE_URL = process.env.DESKTOP_CONNECT_TEST_DATABASE_URL
+  ?? process.env.DATABASE_URL
   ?? "mysql://root:password@127.0.0.1:3306/openwork_test_connect"
 process.env.DB_MODE = "mysql"
 process.env.DEN_DB_ENCRYPTION_KEY = "connect-grant-test-encryption-key-1234567890"

--- a/ee/apps/den-api/test/external-capability-errors.test.ts
+++ b/ee/apps/den-api/test/external-capability-errors.test.ts
@@ -73,6 +73,18 @@ test("invalid_grant is classified without connector-specific special casing", ()
   expect(externalCapabilities.externalMcpAuthErrorCode(error)).toBe("invalid_grant")
 })
 
+test("provider-declared text cannot override a structured non-auth diagnostic", async () => {
+  const { ExternalMcpDiagnosticTracker } = await import("../src/capability-sources/external-mcp-diagnostics.js")
+  const providerError = new Error("Invalid refresh token")
+  Object.defineProperty(providerError, "code", { value: -32603, enumerable: true })
+  const tracker = new ExternalMcpDiagnosticTracker("req_provider_words")
+  tracker.begin("MCP_INITIALIZE")
+  const error = tracker.error(providerError)
+
+  expect(error.diagnostic.category).toBe("provider_declared_error")
+  expect(externalCapabilities.externalMcpAuthErrorCode(error)).toBeNull()
+})
+
 test("generic connector recovery routes members and organization admins without provider names", () => {
   const memberStatus = externalCapabilities.buildExternalConnectionStatus({
     connection: { id: "connection-1", name: "Knowledge Hub", authType: "oauth", credentialMode: "per_member" },

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -7,6 +7,7 @@ import {
   catalogDiagnosticError,
   createExternalMcpDiagnosticFetch,
   externalMcpDiagnosticForLog,
+  externalMcpDiagnosticForResponse,
   safeExternalMcpEndpointForLog,
   safeExternalMcpCauseChain,
 } from "../src/capability-sources/external-mcp-diagnostics.js"
@@ -852,6 +853,38 @@ describe("external MCP diagnostics", () => {
       providerErrorData: '{"provider_detail":"must-not-surface"}',
     })
     expect(error.diagnostic.message).toContain("code -32050")
+  })
+
+  test("removes provider-declared payloads from response and log diagnostics", () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_untrusted_boundary")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const diagnosticError = tracker.error(jsonRpcError(-32050, {
+      provider_detail: "provider-data-secret",
+    }))
+
+    const responseDiagnostic = externalMcpDiagnosticForResponse(
+      diagnosticError,
+      "ignored",
+      "MCP_TOOL_EXECUTION",
+    )
+    const logDiagnostic = externalMcpDiagnosticForLog(
+      diagnosticError,
+      "ignored",
+      "MCP_TOOL_EXECUTION",
+    ).diagnostic
+
+    for (const diagnostic of [responseDiagnostic, logDiagnostic]) {
+      expect(diagnostic).toMatchObject({
+        referenceId: "req_untrusted_boundary",
+        code: "MCP_PROVIDER_DECLARED_ERROR",
+        jsonRpcCode: -32050,
+      })
+      expect(diagnostic.providerErrorMessage).toBeUndefined()
+      expect(diagnostic.providerErrorData).toBeUndefined()
+      expect(diagnostic.message).toContain("code -32050")
+      expect(JSON.stringify(diagnostic)).not.toContain("provider-data-secret")
+      expect(JSON.stringify(diagnostic)).not.toContain("synthetic provider detail")
+    }
   })
 
   test("classifies structured provider validation errors as correctable tool input", () => {

--- a/ee/apps/den-api/test/github-plugin-import-schema.test.ts
+++ b/ee/apps/den-api/test/github-plugin-import-schema.test.ts
@@ -4,7 +4,7 @@ process.env.DEN_DB_ENCRYPTION_KEY = "test-den-db-encryption-key-please-change-12
 process.env.BETTER_AUTH_SECRET = "test-better-auth-secret-please-change-1234567890";
 process.env.BETTER_AUTH_URL = "http://localhost:3005";
 process.env.CORS_ORIGINS = "http://localhost:3005";
-process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_test";
+process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test";
 
 const { githubPluginMcpImportSchema } = await import("../src/routes/org/plugin-system/schemas");
 

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -9,6 +9,7 @@ import path from "node:path"
 type InstallExperienceDependencies = import("../src/routes/org/install-links.js").InstallExperienceDependencies
 
 function seedRequiredEnv() {
+  delete process.env.DEN_API_PUBLIC_URL
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
   process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
   process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)

--- a/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
@@ -150,7 +150,7 @@ describe("agent-configurable org connections policy", () => {
           selectedSkillKeys: expect.objectContaining({ type: "array" }),
           selectedServerKeys: expect.objectContaining({ type: "array" }),
         }),
-        required: expect.arrayContaining(["githubUrl", "marketplaceId"]),
+        required: expect.arrayContaining(["githubUrl"]),
       }),
     }))
     expect(readinessMatches).toContainEqual(expect.objectContaining({

--- a/ee/apps/den-api/test/mcp-membership-revocation.test.ts
+++ b/ee/apps/den-api/test/mcp-membership-revocation.test.ts
@@ -88,6 +88,9 @@ beforeAll(async () => {
 
   mock.module("../src/middleware/admin.js", () => ({
     isPlatformAdminUserId: () => Promise.resolve(platformAdmin),
+    requireAdminMiddleware: async (_context: unknown, next: () => Promise<void>) => {
+      await next()
+    },
   }))
 
   mcpAuth = await import("../src/mcp/auth.js")

--- a/ee/apps/den-api/test/native-provider-connections.test.ts
+++ b/ee/apps/den-api/test/native-provider-connections.test.ts
@@ -153,6 +153,7 @@ describe("buildNativeProviderEntry", () => {
       connectedForMe: false,
       needsReconnect: false,
       missingFeatures: [],
+      requiredBy: [],
       access: null,
     })
   })
@@ -281,7 +282,7 @@ describe("buildNativeProviderEntry", () => {
     })
   })
 
-  test("external connection list rows omit native reconnect fields", async () => {
+  test("external connection list rows expose reconnect state without native feature drift", async () => {
     const seeded = await seedMember("ExternalRows")
     const connection = await createExternalMcpConnection({
       organizationId: seeded.organizationId,
@@ -309,7 +310,7 @@ describe("buildNativeProviderEntry", () => {
     if (!isRecord(row)) {
       throw new Error("External connection row was missing.")
     }
-    expect(Object.hasOwn(row, "needsReconnect")).toBe(false)
+    expect(row.needsReconnect).toBe(false)
     expect(Object.hasOwn(row, "missingFeatures")).toBe(false)
   })
 })

--- a/ee/apps/den-api/test/organization-context.test.ts
+++ b/ee/apps/den-api/test/organization-context.test.ts
@@ -123,10 +123,11 @@ function createApiKey(input: { organizationId: string; memberId: string; userId:
 
 function createOrgContextApp(state: TestState, input: {
   apiKey?: TestApiKey | null
+  sessionId?: string
   sessionActiveOrganizationId: string | null
 }) {
   const app = new Hono()
-  const sessionId = createDenTypeId("session")
+  const sessionId = input.sessionId ?? createDenTypeId("session")
   stateBySessionId.set(sessionId, state)
   app.use("*", async (c, next) => {
     c.set("user", {
@@ -227,6 +228,23 @@ test("an explicit header for a non-member org hard fails instead of falling back
   const response = await app.request("http://den.local/v1/org", {
     headers: { "x-openwork-org-id": nonMemberOrgId },
   })
+
+  expect(response.status).toBe(404)
+  await expect(response.json()).resolves.toEqual({ error: "organization_not_found" })
+  expect(state.resolveUserOrganizationsCalls).toHaveLength(0)
+})
+
+test("an internal MCP principal cannot fall back from its signed organization scope", async () => {
+  const userId = createDenTypeId("user")
+  const state = createTestState(userId)
+  const nonMemberOrgId = createDenTypeId("organization")
+  addVisibleOrg(state, "only-org")
+  const app = createOrgContextApp(state, {
+    sessionId: "mcp_internal",
+    sessionActiveOrganizationId: nonMemberOrgId,
+  })
+
+  const response = await app.request("http://den.local/v1/org")
 
   expect(response.status).toBe(404)
   await expect(response.json()).resolves.toEqual({ error: "organization_not_found" })

--- a/ee/apps/den-api/test/telegram-queue-db.test.ts
+++ b/ee/apps/den-api/test/telegram-queue-db.test.ts
@@ -13,7 +13,7 @@ let schema: typeof import("@openwork-ee/den-db/schema/telegram")
 let store: typeof import("../src/capability-sources/telegram-store.js")
 
 function seedEnv() {
-  process.env.DATABASE_URL = "mysql://root:password@127.0.0.1:3306/openwork_test_telegram"
+  process.env.DATABASE_URL ??= "mysql://root:password@127.0.0.1:3306/openwork_test_telegram"
   process.env.DB_MODE = "mysql"
   process.env.DEN_DB_ENCRYPTION_KEY = "telegram-test-encryption-key-1234567890"
   process.env.BETTER_AUTH_SECRET = "telegram-test-better-auth-secret-123456"


### PR DESCRIPTION
## Summary

- run each Den Bun test file in a fresh, serial process with a canonical local origin and caller-owned MySQL URL
- close real regressions exposed by isolation: structured non-auth diagnostics cannot be reclassified by provider prose; signed internal MCP organization scope cannot fall back; GitHub plugin import remains agent-discoverable
- update stale fixtures to the current response/schema contracts without weakening or skipping coverage
- gate the Den API and enterprise MCP client suites in CI with MySQL 8 and Bun 1.3.9

## Why

A single bun test process binds src/db.js to the first imported DATABASE_URL and retains module mocks/environment across files. On current dev the shared-process run reproduced 818 passed, 4 skipped, and 128 failed across 950 tests. Fresh serial processes preserve the test database selected by the harness while eliminating cross-file singleton and mock contamination.

## Verification

- full isolated Den matrix: 130/130 files passed; 948 tests passed, 4 skipped, 0 failed
- enterprise MCP client: 52 passed, 0 failed
- enterprise MCP client typecheck: passed
- Den production build: passed
- organization-context regression: 9 passed, 0 failed
- structured external-capability diagnostics: 14 passed, 0 failed
- install-link origin fixture: 25 passed, 0 failed
- workflow YAML parsed successfully; GitHub Actions execution is pending on this draft

## Stack and merge order

Depends on #2997 for diagnostic redaction. This branch is stacked on that commit, so the draft temporarily includes it; merge #2997 first, then refresh this branch before marking ready. No review or merge is requested by this draft.

## Security

Authentication, URL validation, size limits, and protocol validation are unchanged or tightened. Test isolation does not skip tests or replace MySQL coverage.