### PR TITLE
fix(den-api): race-safe rate-limit upsert shared by handoff status + install links

### DIFF
--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -1,7 +1,7 @@
 import { randomBytes } from "node:crypto"
 import { and, eq, gt, isNull } from "@openwork-ee/den-db/drizzle"
-import { AuthSessionTable, AuthUserTable, DesktopHandoffGrantTable, RateLimitTable } from "@openwork-ee/den-db/schema"
-import { createDenTypeId, normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { AuthSessionTable, AuthUserTable, DesktopHandoffGrantTable } from "@openwork-ee/den-db/schema"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
@@ -10,6 +10,7 @@ import { db } from "../../db.js"
 import { env } from "../../env.js"
 import { denTypeIdSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
+import { enforceRateLimit } from "../../utils/rate-limit.js"
 
 const createGrantSchema = z.object({
   next: z.string().trim().max(128).optional(),
@@ -55,43 +56,6 @@ const rateLimitedSchema = z.object({
 
 const HANDOFF_STATUS_RATE_LIMIT_WINDOW_MS = 60 * 1000
 const HANDOFF_STATUS_RATE_LIMIT_MAX = 240
-
-function requestAddress(headers: Headers) {
-  const forwarded = headers.get("x-forwarded-for")?.split(",")[0]?.trim()
-  return forwarded || headers.get("x-real-ip")?.trim() || "unknown"
-}
-
-async function checkRateLimit(key: string, maxRequests: number, now: number) {
-  const [row] = await db
-    .select({ id: RateLimitTable.id, count: RateLimitTable.count, lastRequest: RateLimitTable.lastRequest })
-    .from(RateLimitTable)
-    .where(eq(RateLimitTable.key, key))
-    .limit(1)
-
-  if (row && now - row.lastRequest <= HANDOFF_STATUS_RATE_LIMIT_WINDOW_MS && row.count >= maxRequests) {
-    return Math.max(1, Math.ceil((HANDOFF_STATUS_RATE_LIMIT_WINDOW_MS - (now - row.lastRequest)) / 1000))
-  }
-
-  if (!row) {
-    await db.insert(RateLimitTable).values({
-      id: createDenTypeId("rateLimit"),
-      key,
-      count: 1,
-      lastRequest: now,
-    })
-    return null
-  }
-
-  await db
-    .update(RateLimitTable)
-    .set({ count: now - row.lastRequest > HANDOFF_STATUS_RATE_LIMIT_WINDOW_MS ? 1 : row.count + 1, lastRequest: now })
-    .where(eq(RateLimitTable.id, row.id))
-  return null
-}
-
-async function enforceRateLimit(headers: Headers, scope: string, maxRequests: number) {
-  return checkRateLimit(`handoff:${scope}:${requestAddress(headers)}`, maxRequests, Date.now())
-}
 
 function readSingleHeader(value: string | null) {
   const first = value?.split(",")[0]?.trim() ?? ""
@@ -267,7 +231,7 @@ export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVari
     publicRoute,
     jsonValidator(statusGrantSchema),
     async (c) => {
-      const retryAfter = await enforceRateLimit(c.req.raw.headers, "handoff-status", HANDOFF_STATUS_RATE_LIMIT_MAX)
+      const retryAfter = await enforceRateLimit(c.req.raw.headers, "handoff:handoff-status", HANDOFF_STATUS_RATE_LIMIT_MAX, HANDOFF_STATUS_RATE_LIMIT_WINDOW_MS)
       if (retryAfter !== null) {
         c.header("Retry-After", String(retryAfter))
         return c.json({ error: "rate_limited", message: "Too many handoff status checks. Try again later." }, 429)

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -1,8 +1,7 @@
 import { installConfigSchema } from "@openwork/install-config"
 import { connectLinkClaimsSchema } from "@openwork/connect-link"
 import { and, eq, gt, isNull, or } from "@openwork-ee/den-db/drizzle"
-import { InstallLinkTable, OrganizationTable, RateLimitTable } from "@openwork-ee/den-db/schema"
-import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { InstallLinkTable, OrganizationTable } from "@openwork-ee/den-db/schema"
 import { createReadStream } from "node:fs"
 import type { MiddlewareHandler } from "hono"
 import type { Hono } from "hono"
@@ -30,6 +29,7 @@ import {
   installerReleaseAssetUrl,
   resolveConfiguredInstallerArtifact,
 } from "../../utils/installer-artifacts.js"
+import { checkRateLimit, enforceRateLimit } from "../../utils/rate-limit.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureOrganizationAdmin, orgAccessFailureStatus } from "./shared.js"
 
@@ -104,43 +104,6 @@ const defaultInstallerDependencies: InstallExperienceDependencies = {
   mintConnectGrant: mintDesktopConnectGrant,
   previewConnectGrant: previewDesktopConnectGrant,
   consumeConnectGrant: consumeDesktopConnectGrant,
-}
-
-function requestAddress(headers: Headers) {
-  const forwarded = headers.get("x-forwarded-for")?.split(",")[0]?.trim()
-  return forwarded || headers.get("x-real-ip")?.trim() || "unknown"
-}
-
-async function checkRateLimit(key: string, maxRequests: number, now: number) {
-  const [row] = await db
-    .select({ id: RateLimitTable.id, count: RateLimitTable.count, lastRequest: RateLimitTable.lastRequest })
-    .from(RateLimitTable)
-    .where(eq(RateLimitTable.key, key))
-    .limit(1)
-
-  if (row && now - row.lastRequest <= INSTALL_LINK_RATE_LIMIT_WINDOW_MS && row.count >= maxRequests) {
-    return Math.max(1, Math.ceil((INSTALL_LINK_RATE_LIMIT_WINDOW_MS - (now - row.lastRequest)) / 1000))
-  }
-
-  if (!row) {
-    await db.insert(RateLimitTable).values({
-      id: createDenTypeId("rateLimit"),
-      key,
-      count: 1,
-      lastRequest: now,
-    })
-    return null
-  }
-
-  await db
-    .update(RateLimitTable)
-    .set({ count: now - row.lastRequest > INSTALL_LINK_RATE_LIMIT_WINDOW_MS ? 1 : row.count + 1, lastRequest: now })
-    .where(eq(RateLimitTable.id, row.id))
-  return null
-}
-
-async function enforceRateLimit(headers: Headers, scope: string, maxRequests: number) {
-  return checkRateLimit(`install:${scope}:${requestAddress(headers)}`, maxRequests, Date.now())
 }
 
 function organizationMetadataInput(value: unknown): Record<string, unknown> | string | null {
@@ -415,6 +378,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
       const retryAfter = await checkRateLimit(
         `install:mint:user:${payload.currentMember.userId}`,
         INSTALL_LINK_MINT_RATE_LIMIT_MAX,
+        INSTALL_LINK_RATE_LIMIT_WINDOW_MS,
         Date.now(),
       )
       if (retryAfter !== null) {
@@ -453,7 +417,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
     publicRoute,
     queryValidator(installLinkQuerySchema),
     async (c) => {
-      const retryAfter = await enforceRateLimit(c.req.raw.headers, "config", INSTALL_CONFIG_RATE_LIMIT_MAX)
+      const retryAfter = await enforceRateLimit(c.req.raw.headers, "install:config", INSTALL_CONFIG_RATE_LIMIT_MAX, INSTALL_LINK_RATE_LIMIT_WINDOW_MS)
       if (retryAfter !== null) {
         c.header("Retry-After", String(retryAfter))
         return c.json({ error: "rate_limited", message: "Too many install-link attempts. Try again later." }, 429)
@@ -513,7 +477,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
       publicRoute,
       jsonValidator(connectGrantBodySchema),
       async (c) => {
-        const retryAfter = await enforceRateLimit(c.req.raw.headers, `connect-${mode}`, INSTALL_CONFIG_RATE_LIMIT_MAX)
+        const retryAfter = await enforceRateLimit(c.req.raw.headers, `install:connect-${mode}`, INSTALL_CONFIG_RATE_LIMIT_MAX, INSTALL_LINK_RATE_LIMIT_WINDOW_MS)
         if (retryAfter !== null) {
           c.header("Retry-After", String(retryAfter))
           return c.json({ error: "rate_limited", message: "Too many connection attempts. Try again later." }, 429)
@@ -559,7 +523,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         return c.json({ error: "invalid_request", details: platformResult.error.issues }, 400)
       }
 
-      const retryAfter = await enforceRateLimit(c.req.raw.headers, "artifact", INSTALL_ARTIFACT_RATE_LIMIT_MAX)
+      const retryAfter = await enforceRateLimit(c.req.raw.headers, "install:artifact", INSTALL_ARTIFACT_RATE_LIMIT_MAX, INSTALL_LINK_RATE_LIMIT_WINDOW_MS)
       if (retryAfter !== null) {
         c.header("Retry-After", String(retryAfter))
         return c.json({ error: "rate_limited", message: "Too many installer download attempts. Try again later." }, 429)

--- a/ee/apps/den-api/src/utils/rate-limit.ts
+++ b/ee/apps/den-api/src/utils/rate-limit.ts
@@ -1,0 +1,153 @@
+import { and, eq, lt, or, sql } from "@openwork-ee/den-db/drizzle"
+import { RateLimitTable } from "@openwork-ee/den-db/schema"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { db } from "../db.js"
+
+type RateLimitRow = {
+  count: number
+  lastRequest: number
+}
+
+function requestAddress(headers: Headers) {
+  const forwarded = headers.get("x-forwarded-for")?.split(",")[0]?.trim()
+  return forwarded || headers.get("x-real-ip")?.trim() || "unknown"
+}
+
+function retryAfterSeconds(row: RateLimitRow, maxRequests: number, windowMs: number, now: number) {
+  const elapsed = now - row.lastRequest
+  if (elapsed <= windowMs && row.count >= maxRequests) {
+    return Math.max(1, Math.ceil((windowMs - elapsed) / 1000))
+  }
+  return null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function isDuplicateKeyError(error: unknown): boolean {
+  if (!isRecord(error)) {
+    return false
+  }
+
+  const code = error.code
+  if (code === "ER_DUP_ENTRY" || code === "ALREADY_EXISTS") {
+    return true
+  }
+
+  if (error.errno === 1062) {
+    return true
+  }
+
+  const message = error.message
+  if (typeof message === "string" && message.includes("Duplicate entry")) {
+    return true
+  }
+
+  return isDuplicateKeyError(error.cause) || isDuplicateKeyError(error.body)
+}
+
+function changedRows(result: unknown): number | null {
+  if (Array.isArray(result)) {
+    for (const value of result) {
+      const nestedRows = changedRows(value)
+      if (nestedRows !== null) {
+        return nestedRows
+      }
+    }
+    return null
+  }
+
+  if (!isRecord(result)) {
+    return null
+  }
+
+  if (typeof result.rowsAffected === "number") {
+    return result.rowsAffected
+  }
+
+  if (typeof result.affectedRows === "number") {
+    return result.affectedRows
+  }
+
+  return null
+}
+
+async function readRateLimit(key: string): Promise<RateLimitRow | null> {
+  const [row] = await db
+    .select({ count: RateLimitTable.count, lastRequest: RateLimitTable.lastRequest })
+    .from(RateLimitTable)
+    .where(eq(RateLimitTable.key, key))
+    .limit(1)
+  return row ?? null
+}
+
+async function insertRateLimit(key: string, now: number) {
+  await db.insert(RateLimitTable).values({
+    id: createDenTypeId("rateLimit"),
+    key,
+    count: 1,
+    lastRequest: now,
+  })
+}
+
+async function incrementExistingRateLimit(key: string, maxRequests: number, windowMs: number, now: number) {
+  const result: unknown = await db
+    .update(RateLimitTable)
+    .set({
+      count: sql<number>`IF(${now} - ${RateLimitTable.lastRequest} > ${windowMs}, 1, ${RateLimitTable.count} + 1)`,
+      lastRequest: now,
+    })
+    .where(and(
+      eq(RateLimitTable.key, key),
+      or(
+        sql`${now} - ${RateLimitTable.lastRequest} > ${windowMs}`,
+        lt(RateLimitTable.count, maxRequests),
+      ),
+    ))
+
+  const rows = changedRows(result)
+  return rows !== null && rows > 0
+}
+
+async function claimExistingRateLimit(key: string, maxRequests: number, windowMs: number, now: number, row: RateLimitRow) {
+  const retryAfter = retryAfterSeconds(row, maxRequests, windowMs, now)
+  if (retryAfter !== null) {
+    return retryAfter
+  }
+
+  if (await incrementExistingRateLimit(key, maxRequests, windowMs, now)) {
+    return null
+  }
+
+  const latestRow = await readRateLimit(key)
+  return latestRow ? retryAfterSeconds(latestRow, maxRequests, windowMs, now) : null
+}
+
+export async function checkRateLimit(key: string, maxRequests: number, windowMs: number, now: number) {
+  const row = await readRateLimit(key)
+  if (row) {
+    return claimExistingRateLimit(key, maxRequests, windowMs, now, row)
+  }
+
+  try {
+    await insertRateLimit(key, now)
+    return null
+  } catch (error) {
+    if (!isDuplicateKeyError(error)) {
+      throw error
+    }
+  }
+
+  const existingRow = await readRateLimit(key)
+  if (!existingRow) {
+    await insertRateLimit(key, now)
+    return null
+  }
+
+  return claimExistingRateLimit(key, maxRequests, windowMs, now, existingRow)
+}
+
+export function enforceRateLimit(headers: Headers, scope: string, maxRequests: number, windowMs: number, now = Date.now()) {
+  return checkRateLimit(`${scope}:${requestAddress(headers)}`, maxRequests, windowMs, now)
+}

--- a/ee/apps/den-api/test/rate-limit.test.ts
+++ b/ee/apps/den-api/test/rate-limit.test.ts
@@ -1,0 +1,146 @@
+import { afterAll, beforeAll, expect, mock, test } from "bun:test"
+import { randomUUID } from "node:crypto"
+
+type StoredRateLimit = {
+  count: number
+  lastRequest: number
+}
+
+class DuplicateEntryError extends Error {
+  code = "ER_DUP_ENTRY"
+  errno = 1062
+}
+
+const rows = new Map<string, StoredRateLimit>()
+let checkRateLimit: typeof import("../src/utils/rate-limit.js").checkRateLimit
+let initialMisses = 0
+let activeKey = ""
+let activeMaxRequests = 0
+let activeWindowMs = 0
+let activeNow = 0
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function stringField(value: Record<string, unknown>, key: string) {
+  const field = value[key]
+  return typeof field === "string" ? field : null
+}
+
+function numberField(value: Record<string, unknown>, key: string) {
+  const field = value[key]
+  return typeof field === "number" ? field : null
+}
+
+function freshKey() {
+  return `test:rate-limit:${randomUUID()}`
+}
+
+function rowForActiveKey() {
+  if (initialMisses > 0) {
+    initialMisses -= 1
+    return []
+  }
+
+  const row = rows.get(activeKey)
+  return row ? [{ ...row }] : []
+}
+
+function claimActiveKey() {
+  const row = rows.get(activeKey)
+  if (!row) {
+    return { affectedRows: 0 }
+  }
+
+  if (activeNow - row.lastRequest > activeWindowMs) {
+    row.count = 1
+    row.lastRequest = activeNow
+    return { affectedRows: 1 }
+  }
+
+  if (row.count >= activeMaxRequests) {
+    return { affectedRows: 0 }
+  }
+
+  row.count += 1
+  row.lastRequest = activeNow
+  return { affectedRows: 1 }
+}
+
+mock.module("../src/db.js", () => ({
+  db: {
+    select: (_selection: unknown) => ({
+      from: (_table: unknown) => ({
+        where: (_condition: unknown) => ({
+          limit: (_limit: number) => Promise.resolve(rowForActiveKey()),
+        }),
+      }),
+    }),
+    insert: (_table: unknown) => ({
+      values: (values: unknown) => {
+        if (!isRecord(values)) {
+          throw new Error("rate limit insert values must be an object")
+        }
+
+        const key = stringField(values, "key")
+        const count = numberField(values, "count")
+        const lastRequest = numberField(values, "lastRequest")
+        if (!key || count === null || lastRequest === null) {
+          throw new Error("rate limit insert values were incomplete")
+        }
+
+        if (rows.has(key)) {
+          throw new DuplicateEntryError("Duplicate entry for rate_limit_key")
+        }
+
+        rows.set(key, { count, lastRequest })
+        return Promise.resolve({ affectedRows: 1 })
+      },
+    }),
+    update: (_table: unknown) => ({
+      set: (_values: unknown) => ({
+        where: (_condition: unknown) => Promise.resolve(claimActiveKey()),
+      }),
+    }),
+  },
+}))
+
+function check(key: string, maxRequests: number, windowMs: number, now: number) {
+  activeKey = key
+  activeMaxRequests = maxRequests
+  activeWindowMs = windowMs
+  activeNow = now
+  return checkRateLimit(key, maxRequests, windowMs, now)
+}
+
+beforeAll(async () => {
+  checkRateLimit = (await import("../src/utils/rate-limit.js")).checkRateLimit
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+test("concurrent first checks share one rate-limit row", async () => {
+  const key = freshKey()
+  initialMisses = 10
+  const now = Date.now()
+
+  const results = await Promise.all(Array.from({ length: 10 }, () => check(key, 20, 60_000, now)))
+
+  expect(results).toEqual(Array.from({ length: 10 }, () => null))
+  expect(rows.get(key)?.count).toBe(10)
+})
+
+test("rate limit preserves retry-after semantics", async () => {
+  const key = freshKey()
+  const now = Date.now()
+
+  await expect(check(key, 2, 60_000, now)).resolves.toBeNull()
+  await expect(check(key, 2, 60_000, now + 1_000)).resolves.toBeNull()
+  await expect(check(key, 2, 60_000, now + 2_000)).resolves.toBe(59)
+  expect(rows.get(key)?.count).toBe(2)
+  await expect(check(key, 2, 60_000, now + 62_000)).resolves.toBeNull()
+  expect(rows.get(key)?.count).toBe(1)
+})


### PR DESCRIPTION
## Production error

`failed query: insert into rate_limit (id, key, count, last_request) values (?,?,?,?)` params `...,handoff:handoff-status:16.163.42.30,1,...`

## Root cause

`rate_limit` has `UNIQUE(key)`, while the desktop handoff status and install-link rate limiters both did SELECT-then-INSERT. Handoff status is polled every 2s by two pages/surfaces, so concurrent first requests can both see no row and race on the first insert.

## Fix

- Added one shared Den API rate-limit helper with the existing forwarded-for / real-IP request address logic.
- The helper preserves the current sliding-window behavior, uses an atomic conditional UPDATE for existing rows, and catches duplicate-key first-insert races before falling through to the same update path.
- Replaced the handoff status and install-link call sites while preserving existing scopes and limits (`handoff:handoff-status`, `install:config`, `install:artifact`, `install:connect-*`, and `install:mint:user:*`).

## Verification

- `pnpm install --prefer-offline` — passed.
- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit --pretty false` — passed.
- `pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/rate-limit.test.ts test/install-link-access.test.ts` — passed (27 pass, 0 fail). The new rate-limit test deterministically simulates the duplicate-key fallback because this harness has no local MySQL on `127.0.0.1:3306` for a DB-backed concurrent test.
- `pnpm --filter @openwork-ee/den-api build` — passed.
