### PR TITLE
fix(installer): mac clipboard + paste button, run-once DMG naming, self-cleanup

### DIFF
--- a/apps/installer/scripts/package-mac-dmg.mjs
+++ b/apps/installer/scripts/package-mac-dmg.mjs
@@ -4,7 +4,7 @@ import { chmodSync, cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, statSync
 import os from "node:os"
 import path from "node:path"
 
-const appName = "OpenWork Installer.app"
+const appName = "Install OpenWork.app"
 const executableName = "openwork-installer"
 
 function fail(message) {
@@ -38,8 +38,8 @@ function writeInfoPlist(appPath) {
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-  <key>CFBundleName</key><string>OpenWork Installer</string>
-  <key>CFBundleDisplayName</key><string>OpenWork Installer</string>
+  <key>CFBundleName</key><string>Install OpenWork</string>
+  <key>CFBundleDisplayName</key><string>Install OpenWork</string>
   <key>CFBundleIdentifier</key><string>com.differentai.openwork.installer</string>
   <key>CFBundleExecutable</key><string>${executableName}</string>
   <key>CFBundlePackageType</key><string>APPL</string>
@@ -60,6 +60,7 @@ function stageInput(inputPath, stagedAppPath) {
     execFileSync("ditto", [inputPath, stagedAppPath], { stdio: "inherit" })
     const stagedBinary = path.join(stagedAppPath, "Contents", "MacOS", executableName)
     if (!existsSync(stagedBinary)) fail(`App bundle is missing Contents/MacOS/${executableName}`)
+    writeInfoPlist(stagedAppPath)
     return
   }
 
@@ -82,7 +83,7 @@ const stagingRoot = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-dmg-"
 try {
   mkdirSync(path.dirname(outputPath), { recursive: true })
   stageInput(inputPath, path.join(stagingRoot, appName))
-  execFileSync("hdiutil", ["create", "-volname", "OpenWork Installer", "-srcfolder", stagingRoot, "-ov", "-format", "UDZO", outputPath], { stdio: "inherit" })
+  execFileSync("hdiutil", ["create", "-volname", "Install OpenWork", "-srcfolder", stagingRoot, "-ov", "-format", "UDZO", outputPath], { stdio: "inherit" })
   console.log(`[package-mac-dmg] Wrote ${outputPath}`)
 } finally {
   rmSync(stagingRoot, { recursive: true, force: true })

--- a/apps/installer/src/index.ts
+++ b/apps/installer/src/index.ts
@@ -1,7 +1,7 @@
 import { spawn } from "node:child_process"
 
 import { installerConfigSourceLabel, resolveInstallerConfig, resolveOptionalInstallerConfig } from "./config"
-import { runInstall } from "./install"
+import { runInstall, scheduleInstallerSelfCleanup } from "./install"
 import { startInstallerServer } from "./server"
 
 const rawArgs = Bun.argv.slice(2)
@@ -200,21 +200,24 @@ process.on("exit", () => uiServer.stop())
 const uiResolution = await resolveOptionalInstallerConfig()
 const installerWindowTitle = `${uiResolution?.config.appName ?? "OpenWork"} Installer`
 
-async function installIsRunning(): Promise<boolean> {
+async function currentInstallState(): Promise<string> {
   try {
     const response = await fetch(`${ready.url}api/status`, { headers: { "x-installer-token": ready.token } })
     const status: unknown = await response.json()
-    return typeof status === "object" && status !== null && "state" in status && status.state === "running"
+    return typeof status === "object" && status !== null && "state" in status && typeof status.state === "string" ? status.state : ""
   } catch {
-    return false
+    return ""
   }
 }
 
 async function exitWhenInstallSettles(): Promise<never> {
   // Window closed mid-install: let a running install finish before exiting.
-  while (await installIsRunning()) {
+  let state = await currentInstallState()
+  while (state === "running") {
     await new Promise((resolve) => setTimeout(resolve, 500))
+    state = await currentInstallState()
   }
+  if (state === "done") scheduleInstallerSelfCleanup()
   uiServer.stop()
   process.exit(0)
 }

--- a/apps/installer/src/install.ts
+++ b/apps/installer/src/install.ts
@@ -39,6 +39,7 @@ const status: InstallStatus = {
 
 const HOSTED_DESKTOP_WEB_URL = "https://app.openworklabs.com"
 const HOSTED_DESKTOP_API_URL = "https://api.openworklabs.com"
+const INSTALLER_APP_BUNDLE_NAME = "Install OpenWork.app"
 
 type BootstrapCandidate = {
   config: Record<string, unknown>
@@ -188,6 +189,46 @@ function run(command: string, args: string[]): Promise<void> {
       else reject(new Error(`${command} ${args.join(" ")} exited with ${code}`))
     })
   })
+}
+
+export function removableInstallerBundlePath(
+  selfPath: string,
+  homeDir: string = os.homedir(),
+  platform: NodeJS.Platform = process.platform,
+): string | null {
+  if (platform !== "darwin") return null
+  const trimmedSelfPath = selfPath.trim()
+  const trimmedHomeDir = homeDir.trim()
+  if (!trimmedSelfPath || !trimmedHomeDir) return null
+
+  let current = path.resolve(trimmedSelfPath)
+  while (true) {
+    if (path.basename(current) === INSTALLER_APP_BUNDLE_NAME) {
+      const parent = path.dirname(current)
+      const allowedParents = ["/Applications", path.join(trimmedHomeDir, "Applications"), path.join(trimmedHomeDir, "Downloads")].map((entry) =>
+        path.resolve(entry),
+      )
+      return allowedParents.includes(parent) ? current : null
+    }
+
+    const parent = path.dirname(current)
+    if (parent === current) return null
+    current = parent
+  }
+}
+
+export function scheduleInstallerSelfCleanup(selfPath: string = process.execPath): void {
+  const bundlePath = removableInstallerBundlePath(selfPath)
+  if (!bundlePath || !existsSync(bundlePath)) return
+  try {
+    const child = spawn("/bin/sh", ["-c", "sleep 1; /bin/rm -rf \"$1\"", "openwork-installer-cleanup", bundlePath], {
+      detached: true,
+      stdio: "ignore",
+    })
+    child.unref()
+  } catch {
+    // Best-effort cleanup only; the installed app was already launched or installed.
+  }
 }
 
 function installDmg(dmgPath: string, workDir: string): string {

--- a/apps/installer/src/ui-html.ts
+++ b/apps/installer/src/ui-html.ts
@@ -44,7 +44,10 @@ export function renderInstallerHtml(resolution: InstallerConfigResolution | null
   <div class="title">Paste your install link</div>
   <div class="client">It's in the copy box on your team's install page — the tab you downloaded this from. Your organization admin can also copy it from the Members page.</div>
   <form class="paste" id="paste-form">
-    <input id="install-link" type="url" placeholder="https://.../install?token=..." autocomplete="off" required />
+    <div class="link-row">
+      <input id="install-link" type="url" placeholder="https://.../install?token=..." autocomplete="off" required />
+      <button class="primary paste-button" id="paste-button" type="button">Paste</button>
+    </div>
     <button class="primary" id="continue" type="submit">Continue</button>
   </form>
   <div class="buttons single">
@@ -86,6 +89,9 @@ export function renderInstallerHtml(resolution: InstallerConfigResolution | null
   button:disabled { opacity: .4; cursor: default; }
   .single { margin-top: 2px; }
   .paste { display: grid; gap: 10px; width: 100%; margin-top: 10px; }
+  .link-row { display: flex; gap: 8px; width: 100%; }
+  .link-row input { flex: 1; min-width: 0; }
+  .paste-button { padding-left: 16px; padding-right: 16px; }
   input { box-sizing: border-box; width: 100%; border: 1px solid rgba(24,24,27,.16); border-radius: 8px; padding: 9px 10px; font: inherit; font-size: 13px; }
 </style>
 </head>
@@ -103,6 +109,7 @@ ${configuredContent}
   const exitBtn = document.getElementById("exit");
   const pasteForm = document.getElementById("paste-form");
   const installLinkInput = document.getElementById("install-link");
+  const pasteBtn = document.getElementById("paste-button");
   const continueBtn = document.getElementById("continue");
   let polling = null;
   let installed = false;
@@ -111,6 +118,116 @@ ${configuredContent}
     const response = await fetch(path, { method: "POST", headers: { "x-installer-token": TOKEN } });
     if (!response.ok) throw new Error("request failed: " + response.status);
     return response.json();
+  }
+
+  function editableInput() {
+    const element = document.activeElement;
+    if (!element || element.tagName !== "INPUT") return null;
+    if (element.disabled || element.readOnly) return null;
+    return element;
+  }
+
+  function inputRange(input) {
+    const length = input.value.length;
+    const start = typeof input.selectionStart === "number" ? input.selectionStart : length;
+    const end = typeof input.selectionEnd === "number" ? input.selectionEnd : start;
+    return { start, end };
+  }
+
+  function dispatchInput(input) {
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  function showClipboardError() {
+    statusEl.textContent = "Could not read the clipboard. Copy your install link, then click Paste again or type it here.";
+    statusEl.classList.add("error");
+  }
+
+  function clearClipboardError() {
+    if (CONFIGURED) return;
+    statusEl.textContent = "";
+    statusEl.classList.remove("error");
+  }
+
+  function setInputValue(input, text) {
+    input.value = text;
+    input.focus();
+    input.setSelectionRange(input.value.length, input.value.length);
+    dispatchInput(input);
+  }
+
+  function insertInputValue(input, text) {
+    const range = inputRange(input);
+    input.setRangeText(text, range.start, range.end, "end");
+    input.focus();
+    dispatchInput(input);
+  }
+
+  function deleteInputSelection(input) {
+    const range = inputRange(input);
+    if (range.start === range.end) return;
+    input.setRangeText("", range.start, range.end, "start");
+    input.focus();
+    dispatchInput(input);
+  }
+
+  async function readClipboardText() {
+    if (navigator.clipboard && navigator.clipboard.readText) {
+      return await navigator.clipboard.readText();
+    }
+    return null;
+  }
+
+  async function writeClipboardText(text) {
+    if (!navigator.clipboard || !navigator.clipboard.writeText) return false;
+    await navigator.clipboard.writeText(text);
+    return true;
+  }
+
+  function tryExecCommand(command) {
+    try {
+      return document.execCommand(command);
+    } catch {
+      return false;
+    }
+  }
+
+  async function pasteClipboardText(input, replace) {
+    input.focus();
+    const text = await readClipboardText().catch(() => null);
+    if (text !== null) {
+      if (replace) setInputValue(input, text);
+      else insertInputValue(input, text);
+      clearClipboardError();
+      return;
+    }
+    if (replace) input.select();
+    if (tryExecCommand("paste")) {
+      clearClipboardError();
+      return;
+    }
+    showClipboardError();
+  }
+
+  function selectedInputText(input) {
+    const range = inputRange(input);
+    return range.start === range.end ? "" : input.value.slice(range.start, range.end);
+  }
+
+  async function copyInputSelection(input, cut) {
+    const selectedText = selectedInputText(input);
+    if (!selectedText) return;
+    const wrote = await writeClipboardText(selectedText).catch(() => false);
+    if (wrote) {
+      if (cut) deleteInputSelection(input);
+      clearClipboardError();
+      return;
+    }
+    if (tryExecCommand(cut ? "cut" : "copy")) {
+      clearClipboardError();
+      return;
+    }
+    showClipboardError();
   }
 
   function closeWindow() {
@@ -152,6 +269,15 @@ ${configuredContent}
   }
 
   if (pasteForm) {
+    if (pasteBtn) pasteBtn.addEventListener("click", async () => {
+      pasteBtn.disabled = true;
+      try {
+        await pasteClipboardText(installLinkInput, true);
+      } finally {
+        pasteBtn.disabled = false;
+      }
+    });
+
     pasteForm.addEventListener("submit", async (event) => {
       event.preventDefault();
       continueBtn.disabled = true;
@@ -173,6 +299,33 @@ ${configuredContent}
       }
     });
   }
+
+  document.addEventListener("keydown", (event) => {
+    if (!(event.metaKey || event.ctrlKey) || event.altKey) return;
+    const input = editableInput();
+    if (!input) return;
+    const key = event.key.toLowerCase();
+    if (key === "v") {
+      event.preventDefault();
+      void pasteClipboardText(input, false);
+      return;
+    }
+    if (key === "c") {
+      event.preventDefault();
+      void copyInputSelection(input, false);
+      return;
+    }
+    if (key === "x") {
+      event.preventDefault();
+      void copyInputSelection(input, true);
+      return;
+    }
+    if (key === "a") {
+      event.preventDefault();
+      input.focus();
+      input.select();
+    }
+  });
 
   if (actionBtn) actionBtn.addEventListener("click", async () => {
     if (installed) {

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -6,7 +6,7 @@ import { installConfigUrlFor } from "@openwork/install-config"
 
 import { desktopBootstrapPath, legacyDesktopBootstrapPath } from "../src/bootstrap-path"
 import { buildConstantsConfig, parseInstallLinkInput, resolveInstallerConfig } from "../src/config"
-import { writeBootstrapConfig } from "../src/install"
+import { removableInstallerBundlePath, writeBootstrapConfig } from "../src/install"
 import { releaseAssetFor } from "../src/release-asset"
 import { startInstallerServer } from "../src/server"
 
@@ -382,5 +382,29 @@ describe("writeBootstrapConfig", () => {
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
+  })
+})
+
+describe("removableInstallerBundlePath", () => {
+  const homeDir = "/Users/example"
+  const executablePath = "Contents/MacOS/openwork-installer"
+
+  test("allows only the installer app bundle in common writable locations", () => {
+    expect(removableInstallerBundlePath(`/Applications/Install OpenWork.app/${executablePath}`, homeDir, "darwin")).toBe(
+      "/Applications/Install OpenWork.app",
+    )
+    expect(removableInstallerBundlePath(`${homeDir}/Applications/Install OpenWork.app/${executablePath}`, homeDir, "darwin")).toBe(
+      `${homeDir}/Applications/Install OpenWork.app`,
+    )
+    expect(removableInstallerBundlePath(`${homeDir}/Downloads/Install OpenWork.app/${executablePath}`, homeDir, "darwin")).toBe(
+      `${homeDir}/Downloads/Install OpenWork.app`,
+    )
+  })
+
+  test("rejects DMG mounts, wrong app names, nested copies, and other platforms", () => {
+    expect(removableInstallerBundlePath(`/Volumes/Install OpenWork/Install OpenWork.app/${executablePath}`, homeDir, "darwin")).toBeNull()
+    expect(removableInstallerBundlePath(`/Applications/OpenWork.app/${executablePath}`, homeDir, "darwin")).toBeNull()
+    expect(removableInstallerBundlePath(`${homeDir}/Downloads/OpenWork/Install OpenWork.app/${executablePath}`, homeDir, "darwin")).toBeNull()
+    expect(removableInstallerBundlePath(`/Applications/Install OpenWork.app/${executablePath}`, homeDir, "linux")).toBeNull()
   })
 })


### PR DESCRIPTION
## Summary
- Add a visible Paste button next to the install-link input and implement input-scoped Cmd/Ctrl+V/C/X/A handling in the installer page.
- Rename the macOS installer bundle/display name and DMG volume to `Install OpenWork` while keeping the binary name `openwork-installer`.
- Add guarded best-effort self-cleanup for `Install OpenWork.app` when a completed installer exits from `/Applications`, `~/Applications`, or `~/Downloads`.

## Verification
- `pnpm install` — passed.
- `pnpm --dir apps/installer test` — passed (23 tests).
- `pnpm --filter @openwork/install-config build && pnpm --dir apps/installer test && pnpm --dir apps/installer compile` — passed.
- `pnpm --dir apps/installer package:mac-dmg` — passed.
- Mounted the DMG and verified `diskutil info` reports `Volume Name: Install OpenWork`; the mounted root contains only `Install OpenWork.app`; Info.plist has `CFBundleName`/`CFBundleDisplayName` = `Install OpenWork`; no Applications symlink was present.
- Electron desktop read-only check: `apps/desktop/electron/app-menu.mjs` already includes an Edit menu with standard cut/copy/paste/select-all roles; no desktop files changed.
- Paste screen screenshot (headless Chrome fallback because native capture was unavailable in this execution context):

  ![Install OpenWork paste screen](https://b8tgacyg507ru26g.public.blob.vercel-storage.com/uploads/2026-07-22/installer-mac-ux/browser-screenshot-1784719900462-JKiPuF9S4dxjRSoE29BWWhyjiHV9cg.png)

- CDP/headless verification against the compiled installer server: Cmd+V inserted `https://app.example.com/install?token=cmdPaste456`; Cmd+C copied `bcd`; Cmd+X cut `cde` and left `abf`; Cmd+A selected the full field. The Paste button is visible; CDP mouse click reached it, but headless Chrome denied clipboard read and the graceful error message appeared instead of setting the field.

## Honesty / limitations
- I attempted the requested native `osascript`/`screencapture` path, but this Mac session would not expose a usable GUI automation target: `open` returned `RBSRequestErrorDomain Code=5` / `OSLaunchdErrorDomain Code=125`, System Events process queries returned `-10810`, `screencapture` returned `could not create image from display`, and `pbcopy`/`pbpaste` produced an empty pasteboard. I did not claim native osascript keystroke verification.
- No DMG background art was added; that remains explicitly deferred.