### PR TITLE
chore(release): v0.17.38

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/app",
   "private": true,
-  "version": "0.17.37",
+  "version": "0.17.38",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/desktop",
   "private": true,
-  "version": "0.17.37",
+  "version": "0.17.38",
   "description": "OpenWork desktop shell",
   "author": {
     "name": "OpenWork",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-orchestrator",
-  "version": "0.17.37",
+  "version": "0.17.38",
   "description": "OpenWork host orchestrator for opencode + OpenWork server",
   "private": true,
   "type": "module",
@@ -46,7 +46,7 @@
     "@opencode-ai/sdk": "^1.17.11",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "openwork-server": "0.17.37",
+    "openwork-server": "0.17.38",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.17.37",
+  "version": "0.17.38",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/ee/apps/den-api/src/generated/desktop-versions.ts
+++ b/ee/apps/den-api/src/generated/desktop-versions.ts
@@ -1,6 +1,7 @@
 export const MIN_SUPPORTED_DESKTOP_VERSION = "0.17.0" as const;
 
 export const PUBLISHED_DESKTOP_VERSIONS = [
+  "0.17.38",
   "0.17.37",
   "0.17.36",
   "0.17.35",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,7 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       openwork-server:
-        specifier: 0.17.37
+        specifier: 0.17.38
         version: link:../server
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
Version bump. Ships the revalidated Windows installer fix (#2996), the 0.0.0.0 handoff URL fix (#2995), and the mac installer UX train (#3000: Paste button + clipboard hotkeys, run-once 'Install OpenWork' DMG, self-cleanup). Bump-script output only.