### PR TITLE
fix(installer): posix path semantics for mac self-cleanup guard (unblocks Windows CI + release)

### DIFF
--- a/apps/installer/src/install.ts
+++ b/apps/installer/src/install.ts
@@ -206,18 +206,23 @@ export function removableInstallerBundlePath(
   const trimmedSelfPath = selfPath.trim()
   const trimmedHomeDir = homeDir.trim()
   if (!trimmedSelfPath || !trimmedHomeDir) return null
+  // macOS paths are POSIX; use posix path semantics explicitly so the logic
+  // (and its tests) behave identically on any host platform.
+  if (!trimmedSelfPath.startsWith("/") || !trimmedHomeDir.startsWith("/")) return null
 
-  let current = path.resolve(trimmedSelfPath)
+  let current = path.posix.normalize(trimmedSelfPath)
   while (true) {
-    if (path.basename(current) === INSTALLER_APP_BUNDLE_NAME) {
-      const parent = path.dirname(current)
-      const allowedParents = ["/Applications", path.join(trimmedHomeDir, "Applications"), path.join(trimmedHomeDir, "Downloads")].map((entry) =>
-        path.resolve(entry),
-      )
+    if (path.posix.basename(current) === INSTALLER_APP_BUNDLE_NAME) {
+      const parent = path.posix.dirname(current)
+      const allowedParents = [
+        "/Applications",
+        path.posix.join(trimmedHomeDir, "Applications"),
+        path.posix.join(trimmedHomeDir, "Downloads"),
+      ].map((entry) => path.posix.normalize(entry))
       return allowedParents.includes(parent) ? current : null
     }
 
-    const parent = path.dirname(current)
+    const parent = path.posix.dirname(current)
     if (parent === current) return null
     current = parent
   }


### PR DESCRIPTION
Release App v0.17.38 failed on its Windows test job: removableInstallerBundlePath simulated darwin paths with host path semantics. The function is darwin-only, so it now uses path.posix explicitly (+ absolute-path guard) — deterministic on any host. Ran: pnpm --dir apps/installer test (24/24 on macOS; the failing case is host-independent now).