### PR TITLE
fix(den): serialize default marketplace seeding

### DIFF
--- a/ee/apps/den-api/src/observability/safe-fields.ts
+++ b/ee/apps/den-api/src/observability/safe-fields.ts
@@ -5,6 +5,15 @@ const MAX_STRING_LENGTH = 2_000
 const MAX_DEPTH = 4
 const SENSITIVE_KEY_PATTERN = /(?:authorization|cookie|set-cookie|password|secret|token|api[-_]?key|client[-_]?secret|credential|dsn|email|header|body|query)/iu
 const URL_PATTERN = /https?:\/\/[^\s)"'<>\]}]+/giu
+const QUERY_PARAMS_PATTERN = /(\bparams:\s*)[^\r\n]*/giu
+
+class SanitizedTelemetryError extends Error {
+  code?: string
+  errno?: number
+  sqlState?: string
+}
+
+type SanitizedErrorMetadata = Pick<SanitizedTelemetryError, "code" | "errno" | "sqlState">
 
 function truncate(value: string) {
   return value.length > MAX_STRING_LENGTH
@@ -30,11 +39,16 @@ export function stripUrlQuery(value: string) {
 export function sanitizeText(value: string) {
   return truncate(value.replace(URL_PATTERN, (match) => stripUrlQuery(match))
     .replace(/\b(Bearer|Basic)\s+[^\s,;]+/giu, "$1 [redacted]")
-    .replace(/\b([^\s=]*(?:token|secret|password|api[-_]?key|client[-_]?secret)[^\s=]*=)[^\s&]+/giu, "$1[redacted]"))
+    .replace(/\b([^\s=]*(?:token|secret|password|api[-_]?key|client[-_]?secret)[^\s=]*=)[^\s&]+/giu, "$1[redacted]")
+    .replace(QUERY_PARAMS_PATTERN, "$1[redacted]"))
 }
 
 function isJsonValue(value: JsonValue | undefined): value is JsonValue {
   return value !== undefined
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
 }
 
 export function serializeError(error: unknown): JsonObject {
@@ -50,14 +64,44 @@ export function serializeError(error: unknown): JsonObject {
   return { message: sanitizeText(String(error)) }
 }
 
-export function sanitizeExceptionForTelemetry(error: unknown) {
+function sanitizedErrorMetadata(error: unknown): SanitizedErrorMetadata {
+  if (!isRecord(error)) return {}
+  return {
+    code: typeof error.code === "string" ? sanitizeText(error.code) : undefined,
+    errno: typeof error.errno === "number" && Number.isFinite(error.errno) ? error.errno : undefined,
+    sqlState: typeof error.sqlState === "string" ? sanitizeText(error.sqlState) : undefined,
+  }
+}
+
+function sanitizedTelemetryError(error: unknown, depth: number): Error {
   const serialized = serializeError(error)
-  const sanitized = new Error(typeof serialized.message === "string" ? serialized.message : "unknown error")
+  const metadata = sanitizedErrorMetadata(error)
+  const diagnostic = [
+    metadata.code,
+    metadata.errno === undefined ? undefined : `errno ${metadata.errno}`,
+    metadata.sqlState ? `SQLSTATE ${metadata.sqlState}` : undefined,
+  ].filter((value) => value !== undefined).join(", ")
+  const message = diagnostic
+    ? `Underlying error (${diagnostic})`
+    : typeof serialized.message === "string" ? serialized.message : "unknown error"
+  const sanitized = new SanitizedTelemetryError(message)
   sanitized.name = typeof serialized.name === "string" ? serialized.name : "Error"
-  if (typeof serialized.stack === "string") {
+  sanitized.code = metadata.code
+  sanitized.errno = metadata.errno
+  sanitized.sqlState = metadata.sqlState
+  if (diagnostic) {
+    sanitized.stack = undefined
+  } else if (typeof serialized.stack === "string") {
     sanitized.stack = serialized.stack
   }
+  if (error instanceof Error && error.cause !== undefined && depth < MAX_DEPTH) {
+    sanitized.cause = sanitizedTelemetryError(error.cause, depth + 1)
+  }
   return sanitized
+}
+
+export function sanitizeExceptionForTelemetry(error: unknown) {
+  return sanitizedTelemetryError(error, 0)
 }
 
 function sanitizeValue(key: string, value: unknown, depth: number): JsonValue | undefined {

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -2072,39 +2072,55 @@ export async function listMarketplaces(input: { context: PluginArchActorContext;
 }
 
 async function ensureDefaultOpenWorkMarketplace(context: PluginArchActorContext) {
-  const now = new Date()
-  const anthropicMarketplace = await ensureDefaultMarketplace({
-    context,
-    createdAt: now,
-    description: DEFAULT_ANTHROPIC_MARKETPLACE_DESCRIPTION,
-    logoUrl: DEFAULT_ANTHROPIC_MARKETPLACE_LOGO_URL,
-    name: DEFAULT_ANTHROPIC_MARKETPLACE_NAME,
-  })
-  await ensureDefaultMarketplacePlugins({
-    context,
-    createdAt: now,
-    entries: DEFAULT_ANTHROPIC_STARTER_PLUGINS,
-    marketplaceId: anthropicMarketplace.id,
-  })
+  const organizationId = context.organizationContext.organization.id
+  await db.transaction(async (tx) => {
+    const organization = (await tx
+      .select({ id: OrganizationTable.id })
+      .from(OrganizationTable)
+      .where(eq(OrganizationTable.id, organizationId))
+      .limit(1)
+      .for("update"))[0]
+    if (!organization) throw new Error("Organization not found while provisioning default marketplaces.")
 
-  const marketplace = await ensureDefaultMarketplace({
-    context,
-    createdAt: now,
-    description: DEFAULT_OPENWORK_MARKETPLACE_DESCRIPTION,
-    logoUrl: DEFAULT_OPENWORK_MARKETPLACE_LOGO_URL,
-    name: DEFAULT_OPENWORK_MARKETPLACE_NAME,
-  })
-  await ensureDefaultMarketplacePlugins({
-    context,
-    createdAt: now,
-    entries: DEFAULT_OPENWORK_EXTENSION_MANIFESTS.map((manifest) => ({ description: manifest.description, name: manifest.name })),
-    marketplaceId: marketplace.id,
+    const now = new Date()
+    const anthropicMarketplace = await ensureDefaultMarketplace({
+      context,
+      createdAt: now,
+      database: tx,
+      description: DEFAULT_ANTHROPIC_MARKETPLACE_DESCRIPTION,
+      logoUrl: DEFAULT_ANTHROPIC_MARKETPLACE_LOGO_URL,
+      name: DEFAULT_ANTHROPIC_MARKETPLACE_NAME,
+    })
+    await ensureDefaultMarketplacePlugins({
+      context,
+      createdAt: now,
+      database: tx,
+      entries: DEFAULT_ANTHROPIC_STARTER_PLUGINS,
+      marketplaceId: anthropicMarketplace.id,
+    })
+
+    const marketplace = await ensureDefaultMarketplace({
+      context,
+      createdAt: now,
+      database: tx,
+      description: DEFAULT_OPENWORK_MARKETPLACE_DESCRIPTION,
+      logoUrl: DEFAULT_OPENWORK_MARKETPLACE_LOGO_URL,
+      name: DEFAULT_OPENWORK_MARKETPLACE_NAME,
+    })
+    await ensureDefaultMarketplacePlugins({
+      context,
+      createdAt: now,
+      database: tx,
+      entries: DEFAULT_OPENWORK_EXTENSION_MANIFESTS.map((manifest) => ({ description: manifest.description, name: manifest.name })),
+      marketplaceId: marketplace.id,
+    })
   })
 }
 
 async function ensureDefaultMarketplacePlugins(input: {
   context: PluginArchActorContext
   createdAt: Date
+  database: DbTransaction
   entries: DefaultMarketplacePluginEntry[]
   marketplaceId: MarketplaceId
 }) {
@@ -2112,7 +2128,7 @@ async function ensureDefaultMarketplacePlugins(input: {
   const createdByOrgMembershipId = input.context.organizationContext.currentMember.id
 
   for (const entry of input.entries) {
-    let plugin = (await db
+    let plugin = (await input.database
       .select()
       .from(PluginTable)
       .where(and(
@@ -2135,13 +2151,13 @@ async function ensureDefaultMarketplacePlugins(input: {
         status: "active" as const,
         updatedAt: input.createdAt,
       }
-      await db.insert(PluginTable).values(pluginRow)
+      await input.database.insert(PluginTable).values(pluginRow)
       plugin = pluginRow
     }
 
-    await ensureOrgWidePluginAccess({ context: input.context, pluginId: plugin.id, role: "viewer" })
+    await ensureOrgWidePluginAccess({ context: input.context, database: input.database, pluginId: plugin.id, role: "viewer" })
 
-    const existingMembership = (await db
+    const existingMembership = (await input.database
       .select()
       .from(MarketplacePluginTable)
       .where(and(
@@ -2152,12 +2168,12 @@ async function ensureDefaultMarketplacePlugins(input: {
 
     if (existingMembership) {
       if (existingMembership.removedAt) {
-        await db.update(MarketplacePluginTable).set({ membershipSource: "system", removedAt: null }).where(eq(MarketplacePluginTable.id, existingMembership.id))
+        await input.database.update(MarketplacePluginTable).set({ membershipSource: "system", removedAt: null }).where(eq(MarketplacePluginTable.id, existingMembership.id))
       }
       continue
     }
 
-    await db.insert(MarketplacePluginTable).values({
+    await input.database.insert(MarketplacePluginTable).values({
       createdAt: input.createdAt,
       createdByOrgMembershipId,
       id: createDenTypeId("marketplacePlugin"),
@@ -2173,6 +2189,7 @@ async function ensureDefaultMarketplacePlugins(input: {
 async function ensureDefaultMarketplace(input: {
   context: PluginArchActorContext
   createdAt: Date
+  database: DbTransaction
   description: string
   logoUrl: string
   name: string
@@ -2180,7 +2197,7 @@ async function ensureDefaultMarketplace(input: {
   const organizationId = input.context.organizationContext.organization.id
   const createdByOrgMembershipId = input.context.organizationContext.currentMember.id
 
-  let marketplace = (await db
+  let marketplace = (await input.database
     .select()
     .from(MarketplaceTable)
     .where(and(
@@ -2203,19 +2220,20 @@ async function ensureDefaultMarketplace(input: {
       status: "active" as const,
       updatedAt: input.createdAt,
     }
-    await db.insert(MarketplaceTable).values(marketplaceRow)
+    await input.database.insert(MarketplaceTable).values(marketplaceRow)
     marketplace = marketplaceRow
   } else if (!marketplace.logoUrl) {
-    await db.update(MarketplaceTable).set({ logoUrl: input.logoUrl }).where(eq(MarketplaceTable.id, marketplace.id))
+    await input.database.update(MarketplaceTable).set({ logoUrl: input.logoUrl }).where(eq(MarketplaceTable.id, marketplace.id))
     marketplace = { ...marketplace, logoUrl: input.logoUrl }
   }
 
-  await ensureOrgWideMarketplaceAccess({ context: input.context, marketplaceId: marketplace.id, role: "viewer" })
+  await ensureOrgWideMarketplaceAccess({ context: input.context, database: input.database, marketplaceId: marketplace.id, role: "viewer" })
   return marketplace
 }
 
 async function ensureOrgWideMarketplaceAccess(input: {
   context: PluginArchActorContext
+  database: DbTransaction
   marketplaceId: MarketplaceId
   role: PluginArchRole
 }) {
@@ -2223,18 +2241,18 @@ async function ensureOrgWideMarketplaceAccess(input: {
   const createdByOrgMembershipId = input.context.organizationContext.currentMember.id
   const organizationId = input.context.organizationContext.organization.id
 
-  const existing = (await db
+  const existing = (await input.database
     .select()
     .from(MarketplaceAccessGrantTable)
     .where(and(eq(MarketplaceAccessGrantTable.marketplaceId, input.marketplaceId), eq(MarketplaceAccessGrantTable.orgWide, true)))
     .limit(1))[0]
   if (existing) {
     if (existing.removedAt || existing.role !== input.role) {
-      await db.update(MarketplaceAccessGrantTable).set({ createdByOrgMembershipId, removedAt: null, role: input.role }).where(eq(MarketplaceAccessGrantTable.id, existing.id))
+      await input.database.update(MarketplaceAccessGrantTable).set({ createdByOrgMembershipId, removedAt: null, role: input.role }).where(eq(MarketplaceAccessGrantTable.id, existing.id))
     }
     return
   }
-  await db.insert(MarketplaceAccessGrantTable).values({
+  await input.database.insert(MarketplaceAccessGrantTable).values({
     createdAt,
     createdByOrgMembershipId,
     id: createDenTypeId("marketplaceAccessGrant"),
@@ -2249,6 +2267,7 @@ async function ensureOrgWideMarketplaceAccess(input: {
 
 async function ensureOrgWidePluginAccess(input: {
   context: PluginArchActorContext
+  database: DbTransaction
   pluginId: PluginId
   role: PluginArchRole
 }) {
@@ -2256,18 +2275,18 @@ async function ensureOrgWidePluginAccess(input: {
   const createdByOrgMembershipId = input.context.organizationContext.currentMember.id
   const organizationId = input.context.organizationContext.organization.id
 
-  const existing = (await db
+  const existing = (await input.database
     .select()
     .from(PluginAccessGrantTable)
     .where(and(eq(PluginAccessGrantTable.pluginId, input.pluginId), eq(PluginAccessGrantTable.orgWide, true)))
     .limit(1))[0]
   if (existing) {
     if (existing.removedAt || existing.role !== input.role) {
-      await db.update(PluginAccessGrantTable).set({ createdByOrgMembershipId, removedAt: null, role: input.role }).where(eq(PluginAccessGrantTable.id, existing.id))
+      await input.database.update(PluginAccessGrantTable).set({ createdByOrgMembershipId, removedAt: null, role: input.role }).where(eq(PluginAccessGrantTable.id, existing.id))
     }
     return
   }
-  await db.insert(PluginAccessGrantTable).values({
+  await input.database.insert(PluginAccessGrantTable).values({
     createdAt,
     createdByOrgMembershipId,
     id: createDenTypeId("pluginAccessGrant"),

--- a/ee/apps/den-api/test/observability.test.ts
+++ b/ee/apps/den-api/test/observability.test.ts
@@ -259,6 +259,32 @@ describe("den-api telemetry sanitization", () => {
     expect(sanitized.stack).not.toContain("user:pass")
   })
 
+  test("preserves safe database diagnostics without exposing query parameters", () => {
+    const cause = Object.assign(
+      new Error("Duplicate entry 'oauth-secret-value' for key 'marketplace_plugin_marketplace_plugin'"),
+      { code: "ER_DUP_ENTRY", errno: 1062, sqlState: "23000" },
+    )
+    const error = new Error(
+      "Failed query: insert into `marketplace_plugin` values (?, ?)\nparams: oauth-secret-value,plugin-secret",
+      { cause },
+    )
+    error.stack = `${error.message}\n    at store.ts:1:1`
+
+    const sanitized = sanitizeExceptionForTelemetry(error)
+
+    expect(sanitized.message).toContain("params: [redacted]")
+    expect(sanitized.message).not.toContain("oauth-secret-value")
+    expect(sanitized.stack).not.toContain("oauth-secret-value")
+    expect(sanitized.cause).toBeInstanceOf(Error)
+    expect(sanitized.cause).toMatchObject({
+      message: "Underlying error (ER_DUP_ENTRY, errno 1062, SQLSTATE 23000)",
+      code: "ER_DUP_ENTRY",
+      errno: 1062,
+      sqlState: "23000",
+    })
+    expect((sanitized.cause as Error).stack).toBeUndefined()
+  })
+
   test("rethrows sanitized request errors before provider middleware observes them", async () => {
     const observedErrors: unknown[] = []
     const app = new Hono()

--- a/ee/apps/den-api/test/plugin-system-marketplace-seeding-db.test.ts
+++ b/ee/apps/den-api/test/plugin-system-marketplace-seeding-db.test.ts
@@ -1,0 +1,135 @@
+import { afterAll, beforeAll, expect, test } from "bun:test"
+import {
+  MarketplaceAccessGrantTable,
+  MarketplacePluginTable,
+  MarketplaceTable,
+  MemberTable,
+  OrganizationTable,
+  PluginAccessGrantTable,
+  PluginTable,
+} from "@openwork-ee/den-db/schema"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import type { PluginArchActorContext } from "../src/routes/org/plugin-system/access.js"
+
+const databaseUrl = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_marketplace_seeding"
+if (!new URL(databaseUrl).pathname.includes("marketplace_seed")) {
+  throw new Error("Marketplace seeding test requires a dedicated database whose name contains marketplace_seed.")
+}
+process.env.DATABASE_URL = databaseUrl
+process.env.DB_MODE ??= "mysql"
+process.env.DEN_DB_ENCRYPTION_KEY ??= "marketplace-seeding-test-key-1234567890"
+process.env.BETTER_AUTH_SECRET ??= "marketplace-seeding-test-secret-123456"
+process.env.BETTER_AUTH_URL ??= "http://127.0.0.1:8790"
+
+let db: typeof import("../src/db.js").db
+let eq: typeof import("@openwork-ee/den-db/drizzle").eq
+let store: typeof import("../src/routes/org/plugin-system/store.js")
+
+const organizationId = createDenTypeId("organization")
+const memberId = createDenTypeId("member")
+const userId = createDenTypeId("user")
+
+async function clearSeededRows() {
+  await db.delete(MarketplacePluginTable)
+  await db.delete(MarketplaceAccessGrantTable)
+  await db.delete(PluginAccessGrantTable)
+  await db.delete(MarketplaceTable)
+  await db.delete(PluginTable)
+  await db.delete(MemberTable)
+  await db.delete(OrganizationTable)
+}
+
+beforeAll(async () => {
+  const [dbModule, drizzleModule, storeModule] = await Promise.all([
+    import("../src/db.js"),
+    import("@openwork-ee/den-db/drizzle"),
+    import("../src/routes/org/plugin-system/store.js"),
+  ])
+  db = dbModule.db
+  eq = drizzleModule.eq
+  store = storeModule
+  await clearSeededRows()
+})
+
+afterAll(async () => {
+  if (db) await clearSeededRows()
+})
+
+function ownerContext(): PluginArchActorContext {
+  const now = new Date("2026-07-22T00:00:00.000Z")
+  return {
+    memberTeams: [],
+    organizationContext: {
+      organization: {
+        id: organizationId,
+        name: "Marketplace Seeding Test",
+        slug: "marketplace-seeding-test",
+        logo: null,
+        allowedEmailDomains: null,
+        metadata: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      currentMember: {
+        id: memberId,
+        userId,
+        role: "owner",
+        createdAt: now,
+        joinedAt: now,
+        isOwner: true,
+      },
+      invitations: [],
+      members: [],
+      roles: [],
+      teams: [],
+    },
+    session: { createdAt: now },
+  }
+}
+
+test("concurrent marketplace lists seed one complete set of defaults", async () => {
+  await db.insert(OrganizationTable).values({
+    id: organizationId,
+    name: "Marketplace Seeding Test",
+    slug: "marketplace-seeding-test",
+  })
+  await db.insert(MemberTable).values({
+    id: memberId,
+    organizationId,
+    role: "owner",
+    userId,
+  })
+
+  const context = ownerContext()
+  const results = await Promise.all(
+    Array.from({ length: 8 }, () => store.listMarketplaces({ context })),
+  )
+
+  for (const result of results) {
+    expect(result.items.map((item) => item.name).sort()).toEqual([
+      "Anthropic-Compatible Plugins",
+      "OpenWork Marketplace",
+    ])
+  }
+
+  const [marketplaces, plugins, memberships, marketplaceGrants, pluginGrants] = await Promise.all([
+    db.select().from(MarketplaceTable).where(eq(MarketplaceTable.organizationId, organizationId)),
+    db.select().from(PluginTable).where(eq(PluginTable.organizationId, organizationId)),
+    db.select().from(MarketplacePluginTable).where(eq(MarketplacePluginTable.organizationId, organizationId)),
+    db.select().from(MarketplaceAccessGrantTable).where(eq(MarketplaceAccessGrantTable.organizationId, organizationId)),
+    db.select().from(PluginAccessGrantTable).where(eq(PluginAccessGrantTable.organizationId, organizationId)),
+  ])
+
+  expect(marketplaces).toHaveLength(2)
+  expect(new Set(marketplaces.map((marketplace) => marketplace.name)).size).toBe(marketplaces.length)
+  expect(new Set(plugins.map((plugin) => `${plugin.name}\n${plugin.description ?? ""}`)).size).toBe(plugins.length)
+  expect(new Set(memberships.map((membership) => `${membership.marketplaceId}:${membership.pluginId}`)).size).toBe(memberships.length)
+  expect(memberships).toHaveLength(plugins.length)
+  expect(marketplaceGrants).toHaveLength(marketplaces.length)
+  expect(pluginGrants).toHaveLength(plugins.length)
+
+  await store.listMarketplaces({ context })
+  const repeatedMemberships = await db.select().from(MarketplacePluginTable)
+    .where(eq(MarketplacePluginTable.organizationId, organizationId))
+  expect(repeatedMemberships).toHaveLength(memberships.length)
+})

--- a/ee/apps/den-api/test/plugin-system-marketplace-seeding-db.test.ts
+++ b/ee/apps/den-api/test/plugin-system-marketplace-seeding-db.test.ts
@@ -11,11 +11,7 @@ import {
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import type { PluginArchActorContext } from "../src/routes/org/plugin-system/access.js"
 
-const databaseUrl = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test_marketplace_seeding"
-if (!new URL(databaseUrl).pathname.includes("marketplace_seed")) {
-  throw new Error("Marketplace seeding test requires a dedicated database whose name contains marketplace_seed.")
-}
-process.env.DATABASE_URL = databaseUrl
+process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
 process.env.DB_MODE ??= "mysql"
 process.env.DEN_DB_ENCRYPTION_KEY ??= "marketplace-seeding-test-key-1234567890"
 process.env.BETTER_AUTH_SECRET ??= "marketplace-seeding-test-secret-123456"
@@ -30,13 +26,13 @@ const memberId = createDenTypeId("member")
 const userId = createDenTypeId("user")
 
 async function clearSeededRows() {
-  await db.delete(MarketplacePluginTable)
-  await db.delete(MarketplaceAccessGrantTable)
-  await db.delete(PluginAccessGrantTable)
-  await db.delete(MarketplaceTable)
-  await db.delete(PluginTable)
-  await db.delete(MemberTable)
-  await db.delete(OrganizationTable)
+  await db.delete(MarketplacePluginTable).where(eq(MarketplacePluginTable.organizationId, organizationId))
+  await db.delete(MarketplaceAccessGrantTable).where(eq(MarketplaceAccessGrantTable.organizationId, organizationId))
+  await db.delete(PluginAccessGrantTable).where(eq(PluginAccessGrantTable.organizationId, organizationId))
+  await db.delete(MarketplaceTable).where(eq(MarketplaceTable.organizationId, organizationId))
+  await db.delete(PluginTable).where(eq(PluginTable.organizationId, organizationId))
+  await db.delete(MemberTable).where(eq(MemberTable.organizationId, organizationId))
+  await db.delete(OrganizationTable).where(eq(OrganizationTable.id, organizationId))
 }
 
 beforeAll(async () => {


### PR DESCRIPTION
## Summary

- serialize default marketplace provisioning per organization with a database transaction and organization-row lock
- run marketplace, plugin, access-grant, and membership reconciliation through the same transaction
- add a MySQL regression test covering eight concurrent marketplace-list requests and a repeated idempotency check
- preserve sanitized database error causes for Sentry, including error code, errno, and SQLSTATE, while redacting query parameters

## Root cause

`GET /v1/marketplaces` lazily provisions the default marketplaces. The provisioner used independent select-then-insert operations without a transaction or concurrency guard, so concurrent requests or pods could observe the same missing records and race on `marketplace_plugin`'s unique key. Parent marketplace, plugin, and org-wide grant rows could also be duplicated because their lookup fields are not uniquely constrained.

## Impact

Concurrent first-time marketplace reads now serialize per organization. The winner provisions one complete default set, later requests reuse it, and a failure rolls the whole provisioning attempt back instead of leaving partial state.

If provisioning still fails, the existing Sentry request capture now includes the sanitized underlying database cause instead of only Drizzle's outer `Failed query` wrapper. Parameter values remain redacted.

## Validation

- `pnpm --filter @openwork-ee/den-api exec tsc --noEmit -p tsconfig.json` — passed
- `bun test ee/apps/den-api/test/observability.test.ts` — passed (17 tests, 57 assertions)
- `./bin/openwork-hub run enterprise marketplace-seed-race -- bun test ee/apps/den-api/test/plugin-system-marketplace-seeding-db.test.ts` — passed (1 test, 16 assertions)
- isolated Den schema was applied to `openwork_den_enterprise_marketplace_seed_race` before the MySQL test

The regression test verifies exactly two default marketplaces, unique plugins and memberships, one org-wide grant per resource, and no additional memberships on a subsequent call.
Its setup and cleanup are scoped to a generated organization ID; it does not truncate or clear shared tables.

## Risks and gaps

- `GET /v1/marketplaces` still performs lazy provisioning; this PR makes that existing behavior transactionally safe rather than moving provisioning to organization creation.
- Existing duplicate rows from races that happened before deployment are not removed; this prevents new races without introducing a data migration.
- Error-cause stacks that contain database diagnostic metadata are intentionally omitted; Sentry retains the safe code, errno, and SQLSTATE without risking values embedded in driver messages.
- No production database or customer data was accessed.
- No UI journey or fraimz was run because the API contract and rendered behavior are unchanged.
