### PR TITLE
docs(mcp): per-client OpenWork MCP setup pages + SEO hub

### DIFF
--- a/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx
@@ -1,11 +1,12 @@
 ---
-title: "OpenWork Connect MCP"
-description: "Use your OpenWork organization, skills, and connected tools from OpenCode, Codex, ChatGPT Desktop, Cursor Web/Agents, Claude Code, VS Code, or any MCP client"
+title: "Model Context Protocol (MCP)"
+sidebarTitle: "Overview"
+description: "The OpenWork MCP server is a hosted endpoint that lets your AI agent use OpenWork from Claude Code, Codex, Claude Desktop, Cursor, VS Code, or any MCP client."
 ---
 
 import { OpenWorkConnectInstaller } from "/snippets/openwork-connect-installer.jsx";
 
-OpenWork Connect lets an external MCP client use the OpenWork capabilities your organization has made available to you. The public hosted endpoint is:
+The OpenWork Connect MCP server lets your AI agent use the OpenWork capabilities your organization has made available to you. The public hosted endpoint is:
 
 ```text
 https://api.openworklabs.com/mcp/agent
@@ -22,6 +23,23 @@ Your client opens a browser, you sign in to OpenWork, choose the organization to
 
 <OpenWorkConnectInstaller />
 
+## Set up your client
+
+Step-by-step guides for every client:
+
+<CardGroup cols={3}>
+  <Card title="OpenCode" href="/model-context-protocol/opencode" />
+  <Card title="Claude Code" href="/model-context-protocol/claude-code" />
+  <Card title="Codex" href="/model-context-protocol/codex" />
+  <Card title="Claude Desktop" href="/model-context-protocol/claude-desktop" />
+  <Card title="ChatGPT" href="/model-context-protocol/chatgpt" />
+  <Card title="Cursor" href="/model-context-protocol/cursor" />
+  <Card title="VS Code" href="/model-context-protocol/vs-code" />
+  <Card title="Windsurf" href="/model-context-protocol/windsurf" />
+  <Card title="Zed" href="/model-context-protocol/zed" />
+  <Card title="Gemini CLI" href="/model-context-protocol/gemini-cli" />
+</CardGroup>
+
 ## In the OpenWork desktop app
 
 If you use the OpenWork desktop app, there is no MCP endpoint to configure.
@@ -31,15 +49,19 @@ active organization and refreshes that first-party access automatically. Use
 
 ## Client support status
 
-| Client | Status | Notes |
-| --- | --- | --- |
-| OpenCode | Verified | Native remote MCP OAuth passed end-to-end implementation testing. |
-| Codex | Setup only | Add/login/reconnect steps are below; native remote MCP OAuth must be rerun on this exact branch before Codex is marked verified. |
-| Cursor | Setup only | Cursor Web/Agents can use an HTTPS OAuth callback. Cursor Desktop OAuth requires `cursor://anysphere.cursor-mcp/oauth/callback`, which OpenWork's MCP profile intentionally rejects, so Cursor Desktop OAuth is not currently supported. |
-| ChatGPT Desktop | Setup only | Setup guide only; use ChatGPT `Settings > MCP servers`. Native proof is not complete. |
-| Claude Code | Setup only | Setup guide only; native proof is not complete. |
-| VS Code | Setup only | Setup guide only; native proof is not complete. |
-| Any client | Setup only | Use only with clients that support remote Streamable HTTP MCP servers and OAuth. |
+| Client | Status | Notes | Guide |
+| --- | --- | --- | --- |
+| OpenCode | Verified | Native remote MCP OAuth passed end-to-end implementation testing. | [OpenWork MCP for OpenCode](/model-context-protocol/opencode) |
+| Codex | Setup only | Add/login/reconnect steps are below; native remote MCP OAuth must be rerun on this exact branch before Codex is marked verified. | [OpenWork MCP for Codex](/model-context-protocol/codex) |
+| Cursor | Setup only | Cursor Web/Agents can use an HTTPS OAuth callback. Cursor Desktop OAuth requires `cursor://anysphere.cursor-mcp/oauth/callback`, which OpenWork's MCP profile intentionally rejects, so Cursor Desktop OAuth is not currently supported. | [OpenWork MCP for Cursor](/model-context-protocol/cursor) |
+| ChatGPT Desktop | Setup only | Setup guide only; use ChatGPT `Settings > MCP servers`. Native proof is not complete. | [OpenWork MCP for ChatGPT](/model-context-protocol/chatgpt) |
+| Claude Code | Setup only | Setup guide only; native proof is not complete. | [OpenWork MCP for Claude Code](/model-context-protocol/claude-code) |
+| Claude Desktop | Setup only | Setup guide only; native proof is not complete. | [OpenWork MCP for Claude Desktop](/model-context-protocol/claude-desktop) |
+| VS Code | Setup only | Setup guide only; native proof is not complete. | [OpenWork MCP for VS Code](/model-context-protocol/vs-code) |
+| Windsurf | Setup only | Setup guide only via mcp-remote; native proof is not complete. | [OpenWork MCP for Windsurf](/model-context-protocol/windsurf) |
+| Zed | Setup only | Setup guide only via mcp-remote; native proof is not complete. | [OpenWork MCP for Zed](/model-context-protocol/zed) |
+| Gemini CLI | Setup only | Setup guide only; native proof is not complete. | [OpenWork MCP for Gemini CLI](/model-context-protocol/gemini-cli) |
+| Any client | Setup only | Use only with clients that support remote Streamable HTTP MCP servers and OAuth. | — |
 
 ## OpenCode setup
 
@@ -74,6 +96,8 @@ opencode mcp logout openwork
 opencode mcp auth openwork
 ```
 
+Full guide: [OpenWork MCP for OpenCode](/model-context-protocol/opencode).
+
 ## Codex setup
 
 Codex is setup-only for this PR until its native OAuth flow is rerun on this exact branch.
@@ -92,6 +116,8 @@ codex mcp logout openwork
 codex mcp login openwork
 ```
 
+Full guide: [OpenWork MCP for Codex](/model-context-protocol/codex).
+
 ## Cursor Web/Agents setup-only guide
 
 Use this guide only for Cursor Web/Agents flows that provide an HTTPS OAuth callback. Paste the OpenWork Connect endpoint where Cursor Web/Agents asks for the remote MCP server URL:
@@ -102,6 +128,8 @@ https://api.openworklabs.com/mcp/agent
 
 Cursor Desktop OAuth is not currently supported. The official desktop OAuth callback is `cursor://anysphere.cursor-mcp/oauth/callback`, and OpenWork's MCP profile intentionally rejects private-use callback schemes for public OAuth clients.
 
+Full guide: [OpenWork MCP for Cursor](/model-context-protocol/cursor).
+
 ## ChatGPT setup-only guide
 
 Open ChatGPT `Settings > MCP servers` ([open settings](https://chatgpt.com/#settings/Connectors)), paste the OpenWork Connect endpoint, and start OAuth from ChatGPT's connection prompt:
@@ -109,6 +137,8 @@ Open ChatGPT `Settings > MCP servers` ([open settings](https://chatgpt.com/#sett
 ```text
 https://api.openworklabs.com/mcp/agent
 ```
+
+Full guide: [OpenWork MCP for ChatGPT](/model-context-protocol/chatgpt).
 
 ## Organization selection
 

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -84,8 +84,23 @@
           {
             "group": "Run in the cloud",
             "pages": [
-              "cloud/run-in-the-cloud/shared-workspace",
+              "cloud/run-in-the-cloud/shared-workspace"
+            ]
+          },
+          {
+            "group": "Model Context Protocol (MCP)",
+            "pages": [
               "cloud/run-in-the-cloud/cloud-mcp",
+              "model-context-protocol/opencode",
+              "model-context-protocol/claude-code",
+              "model-context-protocol/codex",
+              "model-context-protocol/claude-desktop",
+              "model-context-protocol/chatgpt",
+              "model-context-protocol/cursor",
+              "model-context-protocol/vs-code",
+              "model-context-protocol/windsurf",
+              "model-context-protocol/zed",
+              "model-context-protocol/gemini-cli",
               "cloud/run-in-the-cloud/connect-openwork-mcp-remote-machine"
             ]
           },
@@ -118,6 +133,10 @@
     {
       "source": "/",
       "destination": "/start-here/get-started"
+    },
+    {
+      "source": "/model-context-protocol",
+      "destination": "/cloud/run-in-the-cloud/cloud-mcp"
     },
     {
       "source": "/quickstart",

--- a/packages/docs/model-context-protocol/chatgpt.mdx
+++ b/packages/docs/model-context-protocol/chatgpt.mdx
@@ -1,0 +1,67 @@
+---
+title: "OpenWork MCP for ChatGPT"
+sidebarTitle: "ChatGPT"
+description: "ChatGPT MCP setup for OpenWork Connect, so ChatGPT Desktop can use your org's shared OpenWork capabilities through OAuth."
+---
+
+The OpenWork MCP server ([OpenWork Connect](/cloud/run-in-the-cloud/cloud-mcp))
+enables ChatGPT Desktop to use the OpenWork capabilities your organization has
+made available to you: Gmail read/search, Calendar list/create, Drive
+search/read, Gmail draft creation, shared MCP connections such as Notion,
+Linear, Slack, Stripe, Exa, and Context7, shared skills, and OpenWork Cloud
+resources like skills, plugins, marketplaces, workers, members, roles, teams,
+and LLM providers. The server exposes only `search_capabilities` and
+`execute_capability`, so ChatGPT searches what you can access and runs exact
+capability names instead of loading hundreds of tool definitions into context.
+
+## Server URL
+
+```text
+https://api.openworklabs.com/mcp/agent
+```
+
+OAuth sign-in uses your OpenWork account, and the organization you pick is
+pinned into the token. If you do not have an account, create a
+[free OpenWork account](https://app.openworklabs.com?mode=sign-up).
+
+## Setup
+
+1. Open ChatGPT `Settings > MCP servers`
+   ([open settings](https://chatgpt.com/#settings/Connectors)).
+
+2. Paste the server URL:
+
+   ```text
+   https://api.openworklabs.com/mcp/agent
+   ```
+
+3. Start OAuth from ChatGPT's connection prompt, sign in to OpenWork, and pick
+   the organization ChatGPT should use.
+
+## Switch organizations
+
+Open ChatGPT `Settings > MCP servers`, disconnect or clear the `OpenWork`
+server's stored auth, then connect again and choose the organization you want.
+
+<Note>
+This is a setup guide. These steps match OpenWork Connect's OAuth profile:
+HTTPS or HTTP loopback callbacks, PKCE S256, and dynamic client registration
+fallback. ChatGPT Desktop is listed as setup only because native proof is not
+complete. See the
+[client support status](/cloud/run-in-the-cloud/cloud-mcp#client-support-status)
+table.
+</Note>
+
+## What you can ask
+
+- "Which OpenWork organization am I connected to?"
+- "Search my org's capabilities for calendar tools, then list tomorrow's events."
+- "Create a skill that writes weekly status reports and share it with my whole organization."
+- "Find the Q3 launch page in Notion and summarize it."
+
+## What's next
+
+- Read the [hub overview](/cloud/run-in-the-cloud/cloud-mcp) for OAuth, token,
+  server exposure, and troubleshooting details.
+- Publish Notion, Linear, Slack, and other shared tools with
+  [shared MCP connections](/cloud/share-with-your-team/shared-mcp-connections).

--- a/packages/docs/model-context-protocol/claude-code.mdx
+++ b/packages/docs/model-context-protocol/claude-code.mdx
@@ -1,0 +1,69 @@
+---
+title: "OpenWork MCP for Claude Code"
+sidebarTitle: "Claude Code"
+description: "Claude Code MCP setup for OpenWork Connect, with OAuth access to your org's Gmail, Calendar, Drive, shared MCP connections, skills, and Cloud resources."
+---
+
+The OpenWork MCP server ([OpenWork Connect](/cloud/run-in-the-cloud/cloud-mcp))
+enables Claude Code to use the OpenWork capabilities your organization has made
+available to you: Gmail read/search, Calendar list/create, Drive search/read,
+Gmail draft creation, shared MCP connections such as Notion, Linear, Slack,
+Stripe, Exa, and Context7, shared skills, and OpenWork Cloud resources like
+skills, plugins, marketplaces, workers, members, roles, teams, and LLM
+providers. The server exposes only `search_capabilities` and
+`execute_capability`, so Claude Code searches what you can access and runs exact
+capability names instead of loading hundreds of tool definitions into context.
+
+## Server URL
+
+```text
+https://api.openworklabs.com/mcp/agent
+```
+
+OAuth sign-in uses your OpenWork account, and the organization you pick is
+pinned into the token. If you do not have an account, create a
+[free OpenWork account](https://app.openworklabs.com?mode=sign-up).
+
+## Setup
+
+1. Add OpenWork Connect as a remote HTTP MCP server:
+
+   ```sh
+   claude mcp add --transport http openwork https://api.openworklabs.com/mcp/agent
+   ```
+
+   Add `-s user` to make it available in every project.
+
+2. Open Claude Code and run `/mcp`.
+
+3. Select `openwork`, then follow the browser sign-in and choose your
+   organization.
+
+## Switch organizations
+
+Run `/mcp` inside Claude Code, select `openwork`, then clear or
+re-authenticate the connection. The next browser sign-in lets you pick a new
+organization.
+
+<Note>
+This is a setup guide. These steps match OpenWork Connect's OAuth profile:
+HTTPS or HTTP loopback callbacks, PKCE S256, and dynamic client registration
+fallback. Claude Code is listed as setup only because native proof is not
+complete. See the
+[client support status](/cloud/run-in-the-cloud/cloud-mcp#client-support-status)
+table.
+</Note>
+
+## What you can ask
+
+- "Which OpenWork organization am I connected to?"
+- "Search my org's capabilities for calendar tools, then list tomorrow's events."
+- "Assign Priya to the Sales team."
+- "Find the Q3 launch page in Notion and summarize it."
+
+## What's next
+
+- Read the [hub overview](/cloud/run-in-the-cloud/cloud-mcp) for OAuth, token,
+  server exposure, and troubleshooting details.
+- Publish Notion, Linear, Slack, and other shared tools with
+  [shared MCP connections](/cloud/share-with-your-team/shared-mcp-connections).

--- a/packages/docs/model-context-protocol/claude-desktop.mdx
+++ b/packages/docs/model-context-protocol/claude-desktop.mdx
@@ -1,0 +1,89 @@
+---
+title: "OpenWork MCP for Claude Desktop"
+sidebarTitle: "Claude Desktop"
+description: "Claude Desktop MCP setup for OpenWork Connect, using custom connectors or mcp-remote to reach your org's shared capabilities."
+---
+
+The OpenWork MCP server ([OpenWork Connect](/cloud/run-in-the-cloud/cloud-mcp))
+enables Claude Desktop to use the OpenWork capabilities your organization has
+made available to you: Gmail read/search, Calendar list/create, Drive
+search/read, Gmail draft creation, shared MCP connections such as Notion,
+Linear, Slack, Stripe, Exa, and Context7, shared skills, and OpenWork Cloud
+resources like skills, plugins, marketplaces, workers, members, roles, teams,
+and LLM providers. The server exposes only `search_capabilities` and
+`execute_capability`, so Claude Desktop searches what you can access and runs
+exact capability names instead of loading hundreds of tool definitions into
+context.
+
+## Server URL
+
+```text
+https://api.openworklabs.com/mcp/agent
+```
+
+OAuth sign-in uses your OpenWork account, and the organization you pick is
+pinned into the token. If you do not have an account, create a
+[free OpenWork account](https://app.openworklabs.com?mode=sign-up).
+
+## Connect
+
+1. Open Claude Desktop `Settings` > `Connectors`.
+
+2. Click `Add custom connector`.
+
+3. Name it `OpenWork` and set the URL to:
+
+   ```text
+   https://api.openworklabs.com/mcp/agent
+   ```
+
+4. Click `Connect`, then finish the browser sign-in and choose your
+   organization. Claude's connector OAuth uses an HTTPS callback, which
+   OpenWork accepts.
+
+## Fallback config
+
+For Claude Desktop builds without custom connectors, open `Settings` >
+`Developer` > `Edit Config` and add this to `claude_desktop_config.json`:
+
+```json
+{
+  "mcpServers": {
+    "openwork": {
+      "command": "npx",
+      "args": ["-y", "mcp-remote@latest", "https://api.openworklabs.com/mcp/agent"]
+    }
+  }
+}
+```
+
+`mcp-remote` runs the OAuth locally on an HTTP loopback callback, which
+OpenWork accepts. Restart Claude Desktop after editing the config.
+
+## Switch organizations
+
+Remove the stored MCP auth token for `openwork`, then connect again and choose
+the organization you want during browser sign-in.
+
+<Note>
+This is a setup guide. These steps match OpenWork Connect's OAuth profile:
+HTTPS or HTTP loopback callbacks, PKCE S256, and dynamic client registration
+fallback. Claude Desktop is listed as setup only because native proof is not
+complete. See the
+[client support status](/cloud/run-in-the-cloud/cloud-mcp#client-support-status)
+table.
+</Note>
+
+## What you can ask
+
+- "Which OpenWork organization am I connected to?"
+- "Add omar@example.com to my organization."
+- "Assign Priya to the Sales team."
+- "Find the Q3 launch page in Notion and summarize it."
+
+## What's next
+
+- Read the [hub overview](/cloud/run-in-the-cloud/cloud-mcp) for OAuth, token,
+  server exposure, and troubleshooting details.
+- Publish Notion, Linear, Slack, and other shared tools with
+  [shared MCP connections](/cloud/share-with-your-team/shared-mcp-connections).

--- a/packages/docs/model-context-protocol/codex.mdx
+++ b/packages/docs/model-context-protocol/codex.mdx
@@ -1,0 +1,76 @@
+---
+title: "OpenWork MCP for Codex"
+sidebarTitle: "Codex"
+description: "Codex MCP setup for OpenWork Connect, with OAuth access to your org's Gmail, Calendar, Drive, shared connections, skills, and Cloud resources."
+---
+
+The OpenWork MCP server ([OpenWork Connect](/cloud/run-in-the-cloud/cloud-mcp))
+enables Codex to use the OpenWork capabilities your organization has made
+available to you: Gmail read/search, Calendar list/create, Drive search/read,
+Gmail draft creation, shared MCP connections such as Notion, Linear, Slack,
+Stripe, Exa, and Context7, shared skills, and OpenWork Cloud resources like
+skills, plugins, marketplaces, workers, members, roles, teams, and LLM
+providers. The server exposes only `search_capabilities` and
+`execute_capability`, so Codex searches what you can access and runs exact
+capability names instead of loading hundreds of tool definitions into context.
+
+## Server URL
+
+```text
+https://api.openworklabs.com/mcp/agent
+```
+
+OAuth sign-in uses your OpenWork account, and the organization you pick is
+pinned into the token. If you do not have an account, create a
+[free OpenWork account](https://app.openworklabs.com?mode=sign-up).
+
+## Setup
+
+1. Add OpenWork Connect:
+
+   ```sh
+   codex mcp add openwork --url https://api.openworklabs.com/mcp/agent
+   ```
+
+2. Log in and finish the browser sign-in:
+
+   ```sh
+   codex mcp login openwork
+   ```
+
+In the Codex desktop app, open `codex://settings/connections` and paste the
+server URL there instead.
+
+## Switch organizations
+
+Log out, then log in again and choose the organization you want:
+
+```sh
+codex mcp logout openwork
+codex mcp login openwork
+```
+
+<Note>
+This is a setup guide. These steps match OpenWork Connect's OAuth profile:
+HTTPS or HTTP loopback callbacks, PKCE S256, and dynamic client registration
+fallback. Codex is listed as setup only because native proof is not complete.
+See the
+[client support status](/cloud/run-in-the-cloud/cloud-mcp#client-support-status)
+table.
+</Note>
+
+## What you can ask
+
+- "Which OpenWork organization am I connected to?"
+- "Add omar@example.com to my organization."
+- "Search my org's capabilities for calendar tools, then list tomorrow's events."
+- "Create a skill that writes weekly status reports and share it with my whole organization."
+
+## What's next
+
+- Read the [hub overview](/cloud/run-in-the-cloud/cloud-mcp) for OAuth, token,
+  server exposure, and troubleshooting details.
+- Publish Notion, Linear, Slack, and other shared tools with
+  [shared MCP connections](/cloud/share-with-your-team/shared-mcp-connections).
+- Connect from a remote environment with
+  [OpenWork MCP on a remote machine](/cloud/run-in-the-cloud/connect-openwork-mcp-remote-machine).

--- a/packages/docs/model-context-protocol/cursor.mdx
+++ b/packages/docs/model-context-protocol/cursor.mdx
@@ -1,0 +1,72 @@
+---
+title: "OpenWork MCP for Cursor"
+sidebarTitle: "Cursor"
+description: "Cursor MCP setup for OpenWork Connect on Cursor Web and Agents, plus why Cursor Desktop OAuth is not currently supported."
+---
+
+The OpenWork MCP server ([OpenWork Connect](/cloud/run-in-the-cloud/cloud-mcp))
+enables Cursor Web and Cursor Agents to use the OpenWork capabilities your
+organization has made available to you: Gmail read/search, Calendar list/create,
+Drive search/read, Gmail draft creation, shared MCP connections such as Notion,
+Linear, Slack, Stripe, Exa, and Context7, shared skills, and OpenWork Cloud
+resources like skills, plugins, marketplaces, workers, members, roles, teams,
+and LLM providers. The server exposes only `search_capabilities` and
+`execute_capability`, so Cursor searches what you can access and runs exact
+capability names instead of loading hundreds of tool definitions into context.
+
+## Server URL
+
+```text
+https://api.openworklabs.com/mcp/agent
+```
+
+OAuth sign-in uses your OpenWork account, and the organization you pick is
+pinned into the token. If you do not have an account, create a
+[free OpenWork account](https://app.openworklabs.com?mode=sign-up).
+
+## Cursor Web and Cursor Agents
+
+Use Cursor Web or Cursor Agents where they ask for a remote MCP server URL.
+Paste the server URL, start OAuth from Cursor's connection prompt, sign in to
+OpenWork, and pick the organization Cursor should use.
+
+Cursor Web and Cursor Agents can use HTTPS OAuth callbacks, which OpenWork
+accepts.
+
+## Cursor Desktop is not currently supported
+
+Cursor Desktop OAuth requires `cursor://anysphere.cursor-mcp/oauth/callback`, a
+private-use scheme that OpenWork's MCP profile intentionally rejects. OpenWork
+accepts HTTPS callbacks or HTTP loopback callbacks only.
+
+Use Cursor Web/Agents, or use a verified client like
+[OpenCode](/model-context-protocol/opencode), until Cursor Desktop can use an
+accepted callback type.
+
+## Switch organizations
+
+Remove the stored MCP auth token for `openwork`, then connect again and choose
+the organization you want during browser sign-in.
+
+<Note>
+This is a setup guide for Cursor Web and Cursor Agents. These steps match
+OpenWork Connect's OAuth profile: HTTPS or HTTP loopback callbacks, PKCE S256,
+and dynamic client registration fallback. Cursor is listed as setup only because
+native proof is not complete. See the
+[client support status](/cloud/run-in-the-cloud/cloud-mcp#client-support-status)
+table.
+</Note>
+
+## What you can ask
+
+- "Which OpenWork organization am I connected to?"
+- "Add omar@example.com to my organization."
+- "Search my org's capabilities for calendar tools, then list tomorrow's events."
+- "Find the Q3 launch page in Notion and summarize it."
+
+## What's next
+
+- Read the [hub overview](/cloud/run-in-the-cloud/cloud-mcp) for OAuth, token,
+  server exposure, and troubleshooting details.
+- Publish Notion, Linear, Slack, and other shared tools with
+  [shared MCP connections](/cloud/share-with-your-team/shared-mcp-connections).

--- a/packages/docs/model-context-protocol/gemini-cli.mdx
+++ b/packages/docs/model-context-protocol/gemini-cli.mdx
@@ -1,0 +1,75 @@
+---
+title: "OpenWork MCP for Gemini CLI"
+sidebarTitle: "Gemini CLI"
+description: "Gemini CLI MCP setup for OpenWork Connect, with OAuth access to your org's Gmail, Calendar, Drive, shared connections, skills, and Cloud resources."
+---
+
+The OpenWork MCP server ([OpenWork Connect](/cloud/run-in-the-cloud/cloud-mcp))
+enables Gemini CLI to use the OpenWork capabilities your organization has made
+available to you: Gmail read/search, Calendar list/create, Drive search/read,
+Gmail draft creation, shared MCP connections such as Notion, Linear, Slack,
+Stripe, Exa, and Context7, shared skills, and OpenWork Cloud resources like
+skills, plugins, marketplaces, workers, members, roles, teams, and LLM
+providers. The server exposes only `search_capabilities` and
+`execute_capability`, so Gemini CLI searches what you can access and runs exact
+capability names instead of loading hundreds of tool definitions into context.
+
+## Server URL
+
+```text
+https://api.openworklabs.com/mcp/agent
+```
+
+OAuth sign-in uses your OpenWork account, and the organization you pick is
+pinned into the token. If you do not have an account, create a
+[free OpenWork account](https://app.openworklabs.com?mode=sign-up).
+
+## Setup
+
+1. Add OpenWork Connect as a remote HTTP MCP server:
+
+   ```sh
+   gemini mcp add --transport http openwork https://api.openworklabs.com/mcp/agent
+   ```
+
+2. Start Gemini CLI:
+
+   ```sh
+   gemini
+   ```
+
+3. Authenticate OpenWork inside Gemini:
+
+   ```text
+   /mcp auth openwork
+   ```
+
+4. Finish the browser sign-in and choose your organization.
+
+## Switch organizations
+
+Remove the stored MCP auth token for `openwork`, then run `/mcp auth openwork`
+again and choose the organization you want during browser sign-in.
+
+<Note>
+This is a setup guide. These steps match OpenWork Connect's OAuth profile:
+HTTPS or HTTP loopback callbacks, PKCE S256, and dynamic client registration
+fallback. Gemini CLI is listed as setup only because native proof is not
+complete. See the
+[client support status](/cloud/run-in-the-cloud/cloud-mcp#client-support-status)
+table.
+</Note>
+
+## What you can ask
+
+- "Which OpenWork organization am I connected to?"
+- "Add omar@example.com to my organization."
+- "Search my org's capabilities for calendar tools, then list tomorrow's events."
+- "Create a skill that writes weekly status reports and share it with my whole organization."
+
+## What's next
+
+- Read the [hub overview](/cloud/run-in-the-cloud/cloud-mcp) for OAuth, token,
+  server exposure, and troubleshooting details.
+- Publish Notion, Linear, Slack, and other shared tools with
+  [shared MCP connections](/cloud/share-with-your-team/shared-mcp-connections).

--- a/packages/docs/model-context-protocol/opencode.mdx
+++ b/packages/docs/model-context-protocol/opencode.mdx
@@ -1,0 +1,84 @@
+---
+title: "OpenWork MCP for OpenCode"
+sidebarTitle: "OpenCode"
+description: "OpenCode MCP setup for OpenWork Connect, OpenWork's hosted MCP server for Gmail, Calendar, Drive, shared connections, skills, and Cloud resources."
+---
+
+The OpenWork MCP server ([OpenWork Connect](/cloud/run-in-the-cloud/cloud-mcp))
+enables OpenCode to use the OpenWork capabilities your organization has made
+available to you: Gmail read/search, Calendar list/create, Drive search/read,
+Gmail draft creation, shared MCP connections such as Notion, Linear, Slack,
+Stripe, Exa, and Context7, shared skills, and OpenWork Cloud resources like
+skills, plugins, marketplaces, workers, members, roles, teams, and LLM
+providers. The server exposes only `search_capabilities` and
+`execute_capability`, so OpenCode searches what you can access and runs exact
+capability names instead of loading hundreds of tool definitions into context.
+
+## Server URL
+
+```text
+https://api.openworklabs.com/mcp/agent
+```
+
+OAuth sign-in uses your OpenWork account, and the organization you pick is
+pinned into the token. If you do not have an account, create a
+[free OpenWork account](https://app.openworklabs.com?mode=sign-up).
+
+## Setup
+
+1. Add this MCP entry to your `opencode.json` file:
+
+   ```json
+   {
+     "mcp": {
+       "openwork": {
+         "type": "remote",
+         "enabled": true,
+         "url": "https://api.openworklabs.com/mcp/agent",
+         "oauth": {}
+       }
+     }
+   }
+   ```
+
+2. Authenticate the server:
+
+   ```sh
+   opencode mcp auth openwork
+   ```
+
+3. Finish the browser sign-in, then choose the organization OpenCode should use.
+
+If OpenCode runs on a remote machine or SSH host, follow
+[Connect OpenWork MCP from a remote machine](/cloud/run-in-the-cloud/connect-openwork-mcp-remote-machine).
+
+## Switch organizations
+
+Log out, then authenticate again and pick the organization you want in the
+browser:
+
+```sh
+opencode mcp logout openwork
+opencode mcp auth openwork
+```
+
+<Note>
+OpenCode is the verified OpenWork Connect client. Native remote MCP OAuth passed
+end-to-end implementation testing.
+</Note>
+
+## What you can ask
+
+- "Which OpenWork organization am I connected to?"
+- "Add omar@example.com to my organization."
+- "Create a skill that writes weekly status reports and share it with my whole organization."
+- "Find the Q3 launch page in Notion and summarize it."
+
+## What's next
+
+- Read the [hub overview](/cloud/run-in-the-cloud/cloud-mcp) for OAuth, token,
+  server exposure, and troubleshooting details.
+- Publish Notion, Linear, Slack, and other shared tools with
+  [shared MCP connections](/cloud/share-with-your-team/shared-mcp-connections).
+- Connect from an SSH host with
+  [OpenWork MCP on a remote machine](/cloud/run-in-the-cloud/connect-openwork-mcp-remote-machine).

--- a/packages/docs/model-context-protocol/vs-code.mdx
+++ b/packages/docs/model-context-protocol/vs-code.mdx
@@ -1,0 +1,83 @@
+---
+title: "OpenWork MCP for VS Code"
+sidebarTitle: "VS Code"
+description: "VS Code MCP setup for OpenWork Connect, with OAuth access to your org's Gmail, Calendar, Drive, shared connections, skills, and Cloud resources."
+---
+
+The OpenWork MCP server ([OpenWork Connect](/cloud/run-in-the-cloud/cloud-mcp))
+enables VS Code to use the OpenWork capabilities your organization has made
+available to you: Gmail read/search, Calendar list/create, Drive search/read,
+Gmail draft creation, shared MCP connections such as Notion, Linear, Slack,
+Stripe, Exa, and Context7, shared skills, and OpenWork Cloud resources like
+skills, plugins, marketplaces, workers, members, roles, teams, and LLM
+providers. The server exposes only `search_capabilities` and
+`execute_capability`, so VS Code searches what you can access and runs exact
+capability names instead of loading hundreds of tool definitions into context.
+
+## Server URL
+
+```text
+https://api.openworklabs.com/mcp/agent
+```
+
+OAuth sign-in uses your OpenWork account, and the organization you pick is
+pinned into the token. If you do not have an account, create a
+[free OpenWork account](https://app.openworklabs.com?mode=sign-up).
+
+## Setup
+
+Run this command:
+
+```sh
+code --add-mcp '{"name":"openwork","type":"http","url":"https://api.openworklabs.com/mcp/agent"}'
+```
+
+Then open the Command Palette and run `MCP: List Servers` > `openwork` >
+`Start Server`. Follow the sign-in prompt and choose your organization.
+
+## Manual setup
+
+Open the Command Palette and run `MCP: Open User Configuration`, or edit
+`.vscode/mcp.json` for one workspace:
+
+```json
+{
+  "servers": {
+    "openwork": {
+      "type": "http",
+      "url": "https://api.openworklabs.com/mcp/agent"
+    }
+  }
+}
+```
+
+Then run `MCP: List Servers` > `openwork` > `Start Server`, and follow the
+sign-in prompt.
+
+## Switch organizations
+
+Remove the stored MCP auth token for `openwork`, then start the server again
+and choose the organization you want during browser sign-in.
+
+<Note>
+This is a setup guide. These steps match OpenWork Connect's OAuth profile:
+HTTPS or HTTP loopback callbacks, PKCE S256, and dynamic client registration
+fallback. VS Code is listed as setup only because native proof is not complete.
+See the
+[client support status](/cloud/run-in-the-cloud/cloud-mcp#client-support-status)
+table.
+</Note>
+
+## What you can ask
+
+- "Which OpenWork organization am I connected to?"
+- "Assign Priya to the Sales team."
+- "Search my org's capabilities for calendar tools, then list tomorrow's events."
+- "Find the Q3 launch page in Notion and summarize it."
+
+## What's next
+
+- Read the [hub overview](/cloud/run-in-the-cloud/cloud-mcp) for OAuth, token,
+  server exposure, and troubleshooting details.
+- Publish Notion, Linear, Slack, and other shared tools with
+  [shared MCP connections](/cloud/share-with-your-team/shared-mcp-connections).

--- a/packages/docs/model-context-protocol/windsurf.mdx
+++ b/packages/docs/model-context-protocol/windsurf.mdx
@@ -1,0 +1,75 @@
+---
+title: "OpenWork MCP for Windsurf"
+sidebarTitle: "Windsurf"
+description: "Windsurf MCP setup for OpenWork Connect through mcp-remote and OAuth access to your org's shared capabilities."
+---
+
+The OpenWork MCP server ([OpenWork Connect](/cloud/run-in-the-cloud/cloud-mcp))
+enables Windsurf to use the OpenWork capabilities your organization has made
+available to you: Gmail read/search, Calendar list/create, Drive search/read,
+Gmail draft creation, shared MCP connections such as Notion, Linear, Slack,
+Stripe, Exa, and Context7, shared skills, and OpenWork Cloud resources like
+skills, plugins, marketplaces, workers, members, roles, teams, and LLM
+providers. The server exposes only `search_capabilities` and
+`execute_capability`, so Windsurf searches what you can access and runs exact
+capability names instead of loading hundreds of tool definitions into context.
+
+## Server URL
+
+```text
+https://api.openworklabs.com/mcp/agent
+```
+
+OAuth sign-in uses your OpenWork account, and the organization you pick is
+pinned into the token. If you do not have an account, create a
+[free OpenWork account](https://app.openworklabs.com?mode=sign-up).
+
+## Setup
+
+1. Open Windsurf `Settings` > `Cascade` > `MCP Servers`.
+
+2. Click `Manage MCP Servers`, then `View raw config`.
+
+3. Add this to `~/.codeium/windsurf/mcp_config.json`:
+
+   ```json
+   {
+     "mcpServers": {
+       "openwork": {
+         "command": "npx",
+         "args": ["-y", "mcp-remote@latest", "https://api.openworklabs.com/mcp/agent"]
+       }
+     }
+   }
+   ```
+
+`mcp-remote` handles the browser OAuth on an HTTP loopback callback, which
+OpenWork accepts.
+
+## Switch organizations
+
+Remove the stored MCP auth token for `openwork`, then restart the server and
+choose the organization you want during browser sign-in.
+
+<Note>
+This is a setup guide. These steps match OpenWork Connect's OAuth profile:
+HTTPS or HTTP loopback callbacks, PKCE S256, and dynamic client registration
+fallback. Windsurf is listed as setup only because native proof is not complete.
+See the
+[client support status](/cloud/run-in-the-cloud/cloud-mcp#client-support-status)
+table.
+</Note>
+
+## What you can ask
+
+- "Which OpenWork organization am I connected to?"
+- "Add omar@example.com to my organization."
+- "Create a skill that writes weekly status reports and share it with my whole organization."
+- "Find the Q3 launch page in Notion and summarize it."
+
+## What's next
+
+- Read the [hub overview](/cloud/run-in-the-cloud/cloud-mcp) for OAuth, token,
+  server exposure, and troubleshooting details.
+- Publish Notion, Linear, Slack, and other shared tools with
+  [shared MCP connections](/cloud/share-with-your-team/shared-mcp-connections).

--- a/packages/docs/model-context-protocol/zed.mdx
+++ b/packages/docs/model-context-protocol/zed.mdx
@@ -1,0 +1,72 @@
+---
+title: "OpenWork MCP for Zed"
+sidebarTitle: "Zed"
+description: "Zed MCP setup for OpenWork Connect through mcp-remote and OAuth access to your org's shared capabilities."
+---
+
+The OpenWork MCP server ([OpenWork Connect](/cloud/run-in-the-cloud/cloud-mcp))
+enables Zed to use the OpenWork capabilities your organization has made
+available to you: Gmail read/search, Calendar list/create, Drive search/read,
+Gmail draft creation, shared MCP connections such as Notion, Linear, Slack,
+Stripe, Exa, and Context7, shared skills, and OpenWork Cloud resources like
+skills, plugins, marketplaces, workers, members, roles, teams, and LLM
+providers. The server exposes only `search_capabilities` and
+`execute_capability`, so Zed searches what you can access and runs exact
+capability names instead of loading hundreds of tool definitions into context.
+
+## Server URL
+
+```text
+https://api.openworklabs.com/mcp/agent
+```
+
+OAuth sign-in uses your OpenWork account, and the organization you pick is
+pinned into the token. If you do not have an account, create a
+[free OpenWork account](https://app.openworklabs.com?mode=sign-up).
+
+## Setup
+
+Add this to Zed `settings.json`:
+
+```json
+{
+  "context_servers": {
+    "openwork": {
+      "source": "custom",
+      "command": "npx",
+      "args": ["-y", "mcp-remote@latest", "https://api.openworklabs.com/mcp/agent"],
+      "env": {}
+    }
+  }
+}
+```
+
+`mcp-remote` handles the browser OAuth on an HTTP loopback callback, which
+OpenWork accepts.
+
+## Switch organizations
+
+Remove the stored MCP auth token for `openwork`, then restart the server and
+choose the organization you want during browser sign-in.
+
+<Note>
+This is a setup guide. These steps match OpenWork Connect's OAuth profile:
+HTTPS or HTTP loopback callbacks, PKCE S256, and dynamic client registration
+fallback. Zed is listed as setup only because native proof is not complete. See
+the [client support status](/cloud/run-in-the-cloud/cloud-mcp#client-support-status)
+table.
+</Note>
+
+## What you can ask
+
+- "Which OpenWork organization am I connected to?"
+- "Assign Priya to the Sales team."
+- "Search my org's capabilities for calendar tools, then list tomorrow's events."
+- "Find the Q3 launch page in Notion and summarize it."
+
+## What's next
+
+- Read the [hub overview](/cloud/run-in-the-cloud/cloud-mcp) for OAuth, token,
+  server exposure, and troubleshooting details.
+- Publish Notion, Linear, Slack, and other shared tools with
+  [shared MCP connections](/cloud/share-with-your-team/shared-mcp-connections).


### PR DESCRIPTION
## What

PostHog-style SEO cluster for the OpenWork MCP server in the Mintlify docs (see how [PostHog's MCP docs](https://posthog.com/docs/model-context-protocol) appear in Google with per-client sitelinks: "PostHog MCP for Claude Code / Codex / Claude Desktop / Cursor / VS Code").

- **Hub** (existing page, existing URL kept): `cloud/run-in-the-cloud/cloud-mcp` retitled **"Model Context Protocol (MCP)"** (sidebar: "Overview"), with a "Set up your client" card grid, a `Guide` column on the client support table, and per-section "Full guide" links.
- **10 new per-client pages** under `/model-context-protocol/` with search-matching titles ("OpenWork MCP for Claude Code", "… for Codex", "… for Claude Desktop", "… for ChatGPT", "… for Cursor", "… for VS Code", "… for Windsurf", "… for Zed", "… for Gemini CLI", "… for OpenCode"), each with server URL, exact setup steps, switch-org steps, honest support-status note, example prompts, and next links.
- **Nav**: new "Model Context Protocol (MCP)" group in the Cloud tab (hub + 10 clients + remote-machine guide). **Redirect** added: `/model-context-protocol` → `/cloud/run-in-the-cloud/cloud-mcp`.

## Deliberate constraints respected

- Hub URL unchanged — `scripts/check-connect-installer-parity.mjs`, `evals/flows/docs-openwork-connect.flow.mjs`, `evals/flows/reliable-openwork-connect.flow.mjs`, landing `DOCS_URL`, den-web onboarding, and bootstrap `start.md` all pin it. Zero code changes needed.
- The exact phrase `OpenWork Connect MCP` stays in the page body (asserted by `reliable-openwork-connect`).
- Support table keeps the exact `| Client | Status |` cell text for all pre-existing rows (parity script asserts substrings); only a trailing `Guide` column and 4 new rows (Claude Desktop, Windsurf, Zed, Gemini CLI — all "Setup only") were added.
- Only OpenCode is presented as **Verified**; every other client page carries a "this is a setup guide, native proof is not complete" note, matching the team's support-status convention.
- Cursor Desktop remains documented as **not supported** (private-use `cursor://` callback rejected); no `~/.cursor/mcp.json`, no install deeplinks (parity script bans them). The new Cursor page covers Cursor Web/Agents and explains the desktop limitation.
- No banned strings introduced (`JWKS`, `CIMD`, `opaque bearer tokens`, `openwork-ui-mcp`, …).

## Tests / verification (commands + results)

- `node scripts/check-connect-installer-parity.mjs` → `OpenWork Connect landing and docs installers are in parity.` ✅
- `python3 -c "import json; json.load(open('packages/docs/docs.json'))"` → ok ✅
- `npx mint@latest broken-links` (Node 22) → `success no broken links found` ✅
- Nav↔file audit: every docs.json entry has an `.mdx`, no orphan pages ✅
- Banned-string grep across hub + new pages → no matches ✅
- Rendered check via `mint dev` + headless Chrome CDP: hub 200 with `<title>Model Context Protocol (MCP) - OpenWork Docs</title>`; client pages 200 with `OpenWork MCP for <Client>` titles; `/model-context-protocol` redirect follows to the hub (200); hub card grid renders 10 client links; Guide column renders ✅

**fraimz:** skipped — docs-only change (mdx + docs.json), no runtime code path. Rendered experience validated manually as above instead.

## Screenshots (local `mint dev` render)

**Hub — Model Context Protocol (MCP)**
<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/docs-mcp-seo/docs-mcp-hub-OTSpLp2yp9YQdoqRneSd3eqLr5T2S0.png" width="700">

**OpenWork MCP for Claude Code**
<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/docs-mcp-seo/docs-mcp-claude-code-1lHyfHrFWg4x9yp5BrhJ8nFIOoXVRW.png" width="700">

**OpenWork MCP for Cursor (honest desktop-unsupported section)**
<img src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/docs-mcp-seo/docs-mcp-cursor-l8SC4YezP2EDQPn3cytraQZyfm7NG9.png" width="700">
