### PR TITLE
fix(den-api): use public handoff URL for forwarded zero host

### DIFF
--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -148,6 +148,9 @@ export function resolveDesktopDenBaseUrl(request: Request) {
   const origin = `${protocol}://${targetHost}`
   try {
     const url = new URL(origin)
+    if (url.hostname === "0.0.0.0") {
+      return configuredDesktopDenBaseUrl()
+    }
     if (isWebAppHost(url.hostname)) {
       return withDenProxyPath(url.origin)
     }

--- a/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
+++ b/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
@@ -12,5 +12,12 @@ describe("desktop handoff public URL", () => {
     expect(resolveDesktopDenBaseUrl(new Request("http://0.0.0.0:8788/v1/auth/desktop-handoff", {
       headers: { origin: "http://0.0.0.0:3005" },
     }))).toBe("https://public.example.test/api/den")
+
+    expect(resolveDesktopDenBaseUrl(new Request("http://127.0.0.1:8788/v1/auth/desktop-handoff", {
+      headers: {
+        "x-forwarded-host": "0.0.0.0:3005",
+        "x-forwarded-proto": "https",
+      },
+    }))).toBe("https://public.example.test/api/den")
   })
 })


### PR DESCRIPTION
## Summary
- Treat forwarded host `0.0.0.0:3005` as a local Den Web host and fall back to the configured public desktop Den URL.
- Extend the desktop handoff public URL regression test to cover the Den Web proxy forwarded-host path observed during the v0.17.38 victory-lap validation.

## Repro
During the v0.17.38 two-door validation against Daytona Den Web, after signing in at `https://3005-0obq6xy5mmmznswx.daytonaproxy01.net/?mode=sign-in&desktopAuth=1&desktopScheme=openwork`, the web proxy POST to `/api/den/v1/auth/desktop-handoff` returned:

```json
{"openworkUrl":"openwork://den-auth?grant=...&denBaseUrl=https%3A%2F%2F0.0.0.0%3A3005%2Fapi%2Fden"}
```

That leaves the installed desktop app unable to complete the browser handoff without a workaround.

## Validation
- `pnpm --filter @openwork-ee/den-db build && pnpm --filter @openwork-ee/den-api exec bun test test/desktop-handoff-public-url.test.ts` — 1 pass.
- `pnpm --filter @openwork-ee/den-api build` — passed.
