### PR TITLE
fix(landing): never serve paste-gated OpenWork-Installer assets from public /download

### DIFF
--- a/ee/apps/landing/lib/github.ts
+++ b/ee/apps/landing/lib/github.ts
@@ -129,9 +129,19 @@ export const getGithubData = async () => {
     (latestRelease && hasWindowsDesktopAsset(latestRelease) ? latestRelease : null) ||
     releaseList.find((release) => isStableDesktopRelease(release) && hasWindowsDesktopAsset(release));
 
-  const assets = Array.isArray(pick?.assets) ? pick.assets : [];
+  // Since v0.17.38 releases also ship the paste-gated organization installers
+  // ("OpenWork-Installer-*", the two-door model's door 2). They match the
+  // loose per-arch keywords below ("mac-arm64", "win-x64", ...) and sort
+  // first, so they must be excluded here: the public landing only ever serves
+  // the plain desktop app artifacts.
+  const isGatedInstallerAsset = (asset: ReleaseAsset) =>
+    String(asset?.name || "").toLowerCase().startsWith("openwork-installer-");
+  const publicAssets = (list: ReleaseAsset[] | undefined) =>
+    (Array.isArray(list) ? list : []).filter((asset) => !isGatedInstallerAsset(asset));
+
+  const assets = publicAssets(pick?.assets);
   const releaseUrl = pick?.html_url || FALLBACK_RELEASE;
-  const windowsAssets = Array.isArray(windowsPick?.assets) ? windowsPick.assets : assets;
+  const windowsAssets = windowsPick ? publicAssets(windowsPick.assets) : assets;
   const windowsReleaseUrl = windowsPick?.html_url || releaseUrl;
   const dmg = selectAsset(assets, [".dmg"], ["openwork-mac-"]);
   const exe = selectAsset(windowsAssets, [".exe"], ["openwork-win-"]);


### PR DESCRIPTION
## What broke

Since **v0.17.38** (#3001), stable releases ship the two-door org installers (#2990) — `OpenWork-Installer-mac-arm64.dmg`, `-mac-x64.dmg`, `-win-x64.exe` — **next to** the plain desktop artifacts.

The landing's per-arch asset matchers in `ee/apps/landing/lib/github.ts` select by loose substring (`"mac-arm64"`, `"mac-x64"`, `"win-x64"`). The installer assets match those keywords too and sort first in the release asset list, so **https://openworklabs.com/download handed no-org visitors the paste-gated org installer** they cannot use.

## Fix

Filter `openwork-installer-*` assets out of the public landing selection (12 lines, one file). Organizations still get door 2 via their install links (den-api path, untouched).

## Validation (executed the real module against the live GitHub API, tag v0.17.38)

Before (origin/dev):
```
FAIL card mac appleSilicon: .../v0.17.38/OpenWork-Installer-mac-arm64.dmg
FAIL card mac intel:        .../v0.17.38/OpenWork-Installer-mac-x64.dmg
FAIL card win x64:          .../v0.17.38/OpenWork-Installer-win-x64.exe
 ok  card win arm64:        .../v0.17.38/openwork-win-arm64-0.17.38.exe
 ok  nav downloads.macos:   .../v0.17.38/openwork-mac-arm64-0.17.38.dmg
```

After (this branch):
```
 ok  card mac appleSilicon: .../v0.17.38/openwork-mac-arm64-0.17.38.dmg
 ok  card mac intel:        .../v0.17.38/openwork-mac-x64-0.17.38.dmg
 ok  card win x64:          .../v0.17.38/openwork-win-x64-0.17.38.exe
 ok  card win arm64:        .../v0.17.38/openwork-win-arm64-0.17.38.exe
 ok  nav downloads.macos:   .../v0.17.38/openwork-mac-arm64-0.17.38.dmg
 ok  nav downloads.windows: .../v0.17.38/openwork-win-arm64-0.17.38.exe
```

Commands run: `npx tsc -p ee/apps/landing/tsconfig.json --noEmit` (pass) + the validation script above replaying `getGithubData()` from both origin/dev and this branch against the live release payload.

Repro for reviewer: `node --experimental-strip-types <script importing getGithubData>` and check `installers.macos.appleSilicon` contains `openwork-mac-arm64`, not `OpenWork-Installer`.

Note: no fraimz for this one — it's a server-rendered marketing page whose regression and fix are both fully captured by the URL-resolution evidence above; happy to add a landing eval flow as a follow-up if wanted.