### PR TITLE
test(landing): lock public /download asset selection against gated installer artifacts

### DIFF
--- a/ee/apps/landing/package.json
+++ b/ee/apps/landing/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "OPENWORK_DEV_MODE=1 next dev --hostname 0.0.0.0",
+    "test": "bun test --isolate test/",
     "prebuild": "pnpm --dir ../../../packages/email build && pnpm --dir ../../../packages/ui build && node ../../../scripts/check-connect-installer-parity.mjs && node scripts/copy-bootstrap-cli.mjs",
     "build": "next build",
     "start": "next start --hostname 0.0.0.0",
@@ -20,6 +21,7 @@
     "react-dom": "catalog:react18"
   },
   "devDependencies": {
+    "@types/bun": "^1.3.6",
     "@types/node": "20.12.12",
     "@types/react": "18.2.79",
     "@types/react-dom": "18.2.25",

--- a/ee/apps/landing/test/github.test.ts
+++ b/ee/apps/landing/test/github.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { getGithubData } from "../lib/github";
+
+type GithubFixtureAsset = {
+  name: string;
+  browser_download_url: string;
+};
+
+type GithubFixtureRelease = {
+  draft: boolean;
+  prerelease: boolean;
+  html_url: string;
+  tag_name: string;
+  assets: GithubFixtureAsset[];
+};
+
+type GithubFetchFixtures = {
+  latestRelease: GithubFixtureRelease;
+  releases: GithubFixtureRelease[];
+};
+
+const repoUrl = "https://api.github.com/repos/different-ai/openwork";
+const latestReleaseUrl = "https://api.github.com/repos/different-ai/openwork/releases/latest";
+const releasesUrl = "https://api.github.com/repos/different-ai/openwork/releases?per_page=50";
+const fallbackReleaseUrl = "https://github.com/different-ai/openwork/releases";
+const releaseTag = "v0.17.38";
+const releasePageUrl = `${fallbackReleaseUrl}/tag/${releaseTag}`;
+const downloadBaseUrl = `${fallbackReleaseUrl}/download/${releaseTag}`;
+const originalFetch = globalThis.fetch;
+
+const asset = (name: string): GithubFixtureAsset => ({
+  name,
+  browser_download_url: `${downloadBaseUrl}/${name}`
+});
+
+const installGithubFetch = ({ latestRelease, releases }: GithubFetchFixtures) => {
+  const fixtures: Record<string, unknown> = {
+    [repoUrl]: { stargazers_count: 12345 },
+    [latestReleaseUrl]: latestRelease,
+    [releasesUrl]: releases
+  };
+
+  const fetchStub = Object.assign(
+    async (input: Parameters<typeof fetch>[0]) => {
+      const url =
+        typeof input === "string" ? input : input instanceof URL ? input.href : input.url;
+      const fixture = fixtures[url];
+
+      if (fixture === undefined) {
+        return new Response("Not found", { status: 404 });
+      }
+
+      return new Response(JSON.stringify(fixture), {
+        status: 200,
+        headers: { "content-type": "application/json" }
+      });
+    },
+    { preconnect: originalFetch.preconnect }
+  ) satisfies typeof fetch;
+
+  globalThis.fetch = fetchStub;
+};
+
+const releaseWithAssets = (assets: GithubFixtureAsset[]): GithubFixtureRelease => ({
+  draft: false,
+  prerelease: false,
+  html_url: releasePageUrl,
+  tag_name: releaseTag,
+  assets
+});
+
+const expectNoInstallerUrl = (url: string) => {
+  expect(url.length).toBeGreaterThan(0);
+  expect(url.toLowerCase()).not.toContain("installer");
+};
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe("getGithubData", () => {
+  test("selects only public desktop assets when installer assets are listed first", async () => {
+    const macArm64 = asset("openwork-mac-arm64-0.17.38.dmg");
+    const macX64 = asset("openwork-mac-x64-0.17.38.dmg");
+    const winArm64 = asset("openwork-win-arm64-0.17.38.exe");
+    const winX64 = asset("openwork-win-x64-0.17.38.exe");
+    const linuxX64 = asset("openwork-linux-x86_64-0.17.38.AppImage");
+    const release = releaseWithAssets([
+      asset("OpenWork-Installer-mac-arm64.dmg"),
+      asset("OpenWork-Installer-mac-x64.dmg"),
+      asset("OpenWork-Installer-win-x64.exe"),
+      macArm64,
+      macX64,
+      winArm64,
+      winX64,
+      linuxX64
+    ]);
+
+    installGithubFetch({ latestRelease: release, releases: [release] });
+
+    const data = await getGithubData();
+
+    expectNoInstallerUrl(data.downloads.macos);
+    expectNoInstallerUrl(data.downloads.windows);
+    expectNoInstallerUrl(data.downloads.linux);
+    expect(data.installers.macos.appleSilicon).toBe(macArm64.browser_download_url);
+    expect(data.installers.macos.intel).toBe(macX64.browser_download_url);
+    expect(data.installers.windows.x64).toBe(winX64.browser_download_url);
+    expect(data.installers.windows.arm64).toBe(winArm64.browser_download_url);
+    expect(data.releaseTag).toBe(releaseTag);
+  });
+
+  test("falls back to release pages when a release contains only installer assets", async () => {
+    const release = releaseWithAssets([
+      asset("OpenWork-Installer-mac-arm64.dmg"),
+      asset("OpenWork-Installer-mac-x64.dmg"),
+      asset("OpenWork-Installer-win-x64.exe")
+    ]);
+
+    installGithubFetch({ latestRelease: release, releases: [release] });
+
+    const data = await getGithubData();
+    const returnedUrls = [
+      data.downloads.macos,
+      data.downloads.windows,
+      data.downloads.linux,
+      data.installers.macos.appleSilicon,
+      data.installers.macos.intel,
+      data.installers.windows.x64,
+      data.installers.windows.arm64,
+      data.installers.linux.appImageX64,
+      data.installers.linux.appImageArm64,
+      data.installers.linux.tarX64,
+      data.installers.linux.tarArm64
+    ];
+
+    for (const url of returnedUrls) {
+      expectNoInstallerUrl(url);
+    }
+
+    expect(data.downloads).toEqual({
+      macos: fallbackReleaseUrl,
+      windows: fallbackReleaseUrl,
+      linux: fallbackReleaseUrl
+    });
+    expect(data.installers.macos.appleSilicon).toBe(releasePageUrl);
+    expect(data.installers.macos.intel).toBe(releasePageUrl);
+    expect(data.installers.windows.x64).toBe(releasePageUrl);
+    expect(data.installers.windows.arm64).toBe(releasePageUrl);
+    expect(data.installers.linux.appImageX64).toBe(releasePageUrl);
+    expect(data.installers.linux.appImageArm64).toBe(releasePageUrl);
+    expect(data.installers.linux.tarX64).toBe(releasePageUrl);
+    expect(data.installers.linux.tarArm64).toBe(releasePageUrl);
+    expect(data.releaseUrl).toBe(releasePageUrl);
+    expect(data.releaseTag).toBe(releaseTag);
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -233,7 +233,7 @@ importers:
         version: 11.10.0
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.17)(mysql2@3.17.4)
+        version: 0.45.1(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)(kysely@0.28.17)(mysql2@3.17.4)
       electron-updater:
         specifier: ^6.3.9
         version: 6.8.3
@@ -598,7 +598,7 @@ importers:
         version: 0.0.72(@types/react@19.2.14)(react@19.2.4)
       '@sentry/nextjs':
         specifier: 10.64.0
-        version: 10.64.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.108.4(postcss@8.4.38))
+        version: 10.64.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.1(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.108.4(postcss@8.4.38))
       '@tanstack/react-query':
         specifier: ^5.96.2
         version: 5.96.2(react@19.2.4)
@@ -607,7 +607,7 @@ importers:
         version: 0.577.0(react@19.2.4)
       next:
         specifier: 16.2.1
-        version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.1(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 'catalog:'
         version: 19.2.4
@@ -678,7 +678,7 @@ importers:
         version: link:../../../packages/types
       next:
         specifier: 16.2.1
-        version: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        version: 16.2.1(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react:
         specifier: 'catalog:'
         version: 19.2.4
@@ -749,7 +749,7 @@ importers:
         version: 16.6.1
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.17)(mysql2@3.17.4)
+        version: 0.45.1(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)(kysely@0.28.17)(mysql2@3.17.4)
       hono:
         specifier: ^4.7.2
         version: 4.12.12
@@ -794,6 +794,9 @@ importers:
         specifier: catalog:react18
         version: 18.2.0(react@18.2.0)
     devDependencies:
+      '@types/bun':
+        specifier: ^1.3.6
+        version: 1.3.14
       '@types/node':
         specifier: 20.12.12
         version: 20.12.12
@@ -841,7 +844,7 @@ importers:
         version: 1.19.0
       drizzle-orm:
         specifier: ^0.45.1
-        version: 0.45.1(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.17)(mysql2@3.17.4)
+        version: 0.45.1(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)(kysely@0.28.17)(mysql2@3.17.4)
       mysql2:
         specifier: ^3.11.3
         version: 3.17.4
@@ -5036,6 +5039,9 @@ packages:
   '@types/better-sqlite3@7.6.13':
     resolution: {integrity: sha512-NMv9ASNARoKksWtsq/SHakpYAYnhBrQgGD8zkLYk/jaK8jUGn08CfEdTRgYhMypUQAfzSP8W6gNLe0q19/t4VA==}
 
+  '@types/bun@1.3.14':
+    resolution: {integrity: sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw==}
+
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
@@ -5590,6 +5596,9 @@ packages:
     resolution: {integrity: sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w==}
     peerDependencies:
       typescript: ^5
+
+  bun-types@1.3.14:
+    resolution: {integrity: sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ==}
 
   bun-types@1.3.6:
     resolution: {integrity: sha512-OlFwHcnNV99r//9v5IIOgQ9Uk37gZqrNMCcqEaExdkVq3Avwqok1bJFmvGMCkCE0FqzdY8VMOZpfpR3lwI+CsQ==}
@@ -13098,7 +13107,7 @@ snapshots:
       '@hono/node-server': 1.19.11(hono@4.12.12)
       '@sentry/node': 10.65.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.220.0(@opentelemetry/api@1.9.1))
 
-  '@sentry/nextjs@10.64.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.108.4(postcss@8.4.38))':
+  '@sentry/nextjs@10.64.0(@opentelemetry/core@2.9.0(@opentelemetry/api@1.9.1))(@opentelemetry/sdk-trace-base@2.9.0(@opentelemetry/api@1.9.1))(next@16.2.1(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react@19.2.4)(webpack@5.108.4(postcss@8.4.38))':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@rollup/plugin-commonjs': 28.0.1(rollup@4.62.2)
@@ -13111,7 +13120,7 @@ snapshots:
       '@sentry/react': 10.64.0(react@19.2.4)
       '@sentry/vercel-edge': 10.64.0
       '@sentry/webpack-plugin': 5.4.0(rollup@4.62.2)(webpack@5.108.4(postcss@8.4.38))
-      next: 16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.1(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       rollup: 4.62.2
       stacktrace-parser: 0.1.11
     transitivePeerDependencies:
@@ -13809,6 +13818,10 @@ snapshots:
     dependencies:
       '@types/node': 20.12.12
 
+  '@types/bun@1.3.14':
+    dependencies:
+      bun-types: 1.3.14
+
   '@types/cacheable-request@6.0.3':
     dependencies:
       '@types/http-cache-semantics': 4.2.0
@@ -14435,6 +14448,10 @@ snapshots:
     dependencies:
       typescript: 5.9.3
 
+  bun-types@1.3.14:
+    dependencies:
+      '@types/node': 20.12.12
+
   bun-types@1.3.6:
     dependencies:
       '@types/node': 20.12.12
@@ -14840,6 +14857,16 @@ snapshots:
       esbuild-register: 3.6.0(esbuild@0.25.12)
     transitivePeerDependencies:
       - supports-color
+
+  drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.14)(kysely@0.28.17)(mysql2@3.17.4):
+    optionalDependencies:
+      '@opentelemetry/api': 1.9.1
+      '@planetscale/database': 1.19.0
+      '@types/better-sqlite3': 7.6.13
+      better-sqlite3: 11.10.0
+      bun-types: 1.3.14
+      kysely: 0.28.17
+      mysql2: 3.17.4
 
   drizzle-orm@0.45.1(@opentelemetry/api@1.9.1)(@planetscale/database@1.19.0)(@types/better-sqlite3@7.6.13)(better-sqlite3@11.10.0)(bun-types@1.3.6)(kysely@0.28.17)(mysql2@3.17.4):
     optionalDependencies:
@@ -16642,7 +16669,7 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@16.2.1(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.1(@opentelemetry/api@1.9.1)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       '@next/env': 16.2.1
       '@swc/helpers': 0.5.15
@@ -16651,7 +16678,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.1
       '@next/swc-darwin-x64': 16.2.1
@@ -16677,7 +16704,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
+      styled-jsx: 5.1.6(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.3
       '@next/swc-darwin-x64': 16.2.3
@@ -17907,12 +17934,10 @@ snapshots:
       client-only: 0.0.1
       react: 18.2.0
 
-  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
+  styled-jsx@5.1.6(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
-    optionalDependencies:
-      '@babel/core': 7.29.0
 
   sucrase@3.35.1:
     dependencies:


### PR DESCRIPTION
Follow-up regression guard for #3011 (the /download page serving the paste-gated `OpenWork-Installer-*` DMG to no-org visitors).

## What it locks

`ee/apps/landing/test/github.test.ts` stubs the three GitHub API calls `getGithubData()` makes and asserts, with a realistic v0.17.38-style release listing the installer assets FIRST (real GitHub ordering):

1. **Mixed release** (installers + plain apps): every public link — nav `downloads.*` and per-arch `installers.*` — resolves to the plain desktop artifacts, never an installer URL, and `releaseTag` is preserved.
2. **Installer-only release** (no plain desktop assets): nothing leaks — `downloads.*` fall back to the releases index and `installers.*` to the release page, because `hasElectronDesktopAsset` refuses to pick such a release as a desktop release.

## Test run

```
$ pnpm --dir ee/apps/landing test
bun test v1.3.10
 2 pass
 0 fail
 44 expect() calls
```

Also ran `pnpm exec tsc -p ee/apps/landing/tsconfig.json --noEmit` (clean). Adds a `test` script + `@types/bun` devDependency to the landing app (first tests for this package), matching the repo's bun-test convention.

No runtime code changes, so no fraimz — the guarded behavior itself was validated end-to-end on #3011 (live production check: zero installer refs on openworklabs.com/download).