### PR TITLE
fix(den): inject assigned marketplace plugin skills

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -16,7 +16,7 @@ import { getCatalog, protectedResourceMetadata } from "./index.js"
 import { preflightMcpJsonRpcRequest } from "./json-rpc-preflight.js"
 import { compareCapabilityMatches, SEARCH_CAPABILITIES_TOOL_NAME, searchCapabilities, searchCapabilitySourceFilter, type CapabilityMatch } from "./search.js"
 import { executeExternalCapability, externalMcpSearchCoverageHint, parseExternalCapabilityName, resolveMcpMemberIdentity, searchExternalCapabilities, type ExternalCapabilityExecuteResult } from "./external-capabilities.js"
-import { executeMarketplaceCapability, parseMarketplaceCapabilityName, searchMarketplaceCapabilities, type MarketplaceCapabilityObjectType } from "./marketplace-capabilities.js"
+import { executeMarketplaceCapability, listAccessibleMarketplaceSkillDescriptors, parseMarketplaceCapabilityName, searchMarketplaceCapabilities, type MarketplaceCapabilityObjectType } from "./marketplace-capabilities.js"
 import { executeSkillCapability, listAccessibleSkillDescriptors, parseSkillCapabilityName, searchSkillCapabilities, type RemoteSkillDescriptor } from "./skill-capabilities.js"
 import { resolvePublicOrigin } from "../capability-sources/generic-oauth.js"
 import { env } from "../env.js"
@@ -295,6 +295,7 @@ export function registerAgentSkillResources(input: {
   skills: RemoteSkillDescriptor[]
   organizationId: string
   member: Awaited<ReturnType<typeof resolveMcpMemberIdentity>>
+  marketplaceEnabled?: boolean
 }) {
   input.server.registerResource("agent-skills-index", AGENT_SKILL_INDEX_URI, {
     title: "Available Agent Skills",
@@ -314,17 +315,30 @@ export function registerAgentSkillResources(input: {
       mimeType: "text/markdown",
     }, async () => {
       const skillId = parseSkillCapabilityName(skill.capability)
-      const result = skillId ? await executeSkillCapability({
+      const nativeResult = skillId ? await executeSkillCapability({
         organizationId: input.organizationId,
         member: input.member,
         skillId,
       }) : null
-      if (!result?.ok) throw new McpError(ErrorCode.InvalidRequest, "Skill is no longer available")
+      const marketplace = parseMarketplaceCapabilityName(skill.capability)
+      const marketplaceResult = marketplace ? await executeMarketplaceCapability({
+        organizationId: input.organizationId,
+        member: input.member,
+        pluginId: marketplace.pluginId,
+        configObjectId: marketplace.configObjectId,
+        enabled: input.marketplaceEnabled,
+      }) : null
+      const source = nativeResult?.ok
+        ? nativeResult.skill.skillText
+        : marketplaceResult?.ok && marketplaceResult.result.kind === "skill"
+          ? marketplaceResult.result.content
+          : null
+      if (typeof source !== "string") throw new McpError(ErrorCode.InvalidRequest, "Skill is no longer available")
       return {
         contents: [{
           uri: skill.location,
           mimeType: "text/markdown",
-          text: standardSkillMarkdown(skill, result.skill.skillText),
+          text: standardSkillMarkdown(skill, source),
         }],
       }
     })
@@ -396,10 +410,19 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
     let remoteSkills: RemoteSkillDescriptor[] = []
     const method = await mcpRequestMethod(c.req.raw)
     if (method === "initialize" || method === "resources/list" || method === "resources/read") {
-      remoteSkills = await listAccessibleSkillDescriptors({
-        organizationId: principal.organizationId,
-        member: memberIdentity,
-      })
+      const [nativeSkills, marketplaceSkills] = await Promise.all([
+        listAccessibleSkillDescriptors({
+          organizationId: principal.organizationId,
+          member: memberIdentity,
+        }),
+        listAccessibleMarketplaceSkillDescriptors({
+          organizationId: principal.organizationId,
+          member: memberIdentity,
+          enabled: externalMcpConnectionsEnabled,
+        }),
+      ])
+      remoteSkills = [...nativeSkills, ...marketplaceSkills]
+        .sort((a, b) => a.name.localeCompare(b.name) || a.capability.localeCompare(b.capability))
     }
     const server = createAgentMcpServer()
     if (method === "initialize" || method === "resources/list" || method === "resources/read") {
@@ -408,6 +431,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         skills: remoteSkills,
         organizationId: principal.organizationId,
         member: memberIdentity,
+        marketplaceEnabled: externalMcpConnectionsEnabled,
       })
     }
 

--- a/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/marketplace-capabilities.ts
@@ -31,6 +31,7 @@ import { listPluginMcpRequirementBindings, type PluginMcpRequirementBindingRow }
 import { scoreText, tokenize } from "./search.js"
 import type { McpMemberIdentity } from "./external-capabilities.js"
 import type { CapabilityMatch } from "./search.js"
+import { standardSkillName, type RemoteSkillDescriptor } from "./skill-capabilities.js"
 
 const MARKETPLACE_CAPABILITY_PREFIX = "plugin:"
 const PROVENANCE_SUFFIX = "in your organization's library."
@@ -476,6 +477,42 @@ async function filterVisibleRows(input: {
     if (grantRole(input.member, pluginGrants.get(row.plugin.id) ?? [])) return true
     return Boolean(grantRole(input.member, marketplaceGrants.get(row.marketplace.id) ?? []))
   })
+}
+
+export async function listAccessibleMarketplaceSkillDescriptors(input: {
+  enabled?: boolean
+  member: McpMemberIdentity | null
+  organizationId: string
+}): Promise<RemoteSkillDescriptor[]> {
+  if (input.enabled === false || !input.member) return []
+
+  const organizationId = normalizeDenTypeId("organization", input.organizationId)
+  const memberRow = await getActiveMember(organizationId, input.member)
+  if (!memberRow) return []
+
+  const rows = await filterVisibleRows({
+    organizationId,
+    member: input.member,
+    memberRow,
+    rows: (await listActiveMarketplaceRows(organizationId))
+      .filter((row) => row.configObject.objectType === "skill"),
+  })
+  const descriptors = new Map<string, RemoteSkillDescriptor>()
+  for (const row of rows) {
+    const capability = buildMarketplaceCapabilityName(row.plugin.id, row.configObject.id)
+    if (descriptors.has(capability)) continue
+    const uniqueSuffix = `${row.plugin.id.slice(-4)}${row.configObject.id.slice(-4)}`
+    const name = standardSkillName(row.configObject.title, uniqueSuffix)
+    descriptors.set(capability, {
+      name,
+      description: row.configObject.description,
+      capability,
+      location: `skill://${name}/SKILL.md`,
+    })
+  }
+
+  return [...descriptors.values()]
+    .sort((a, b) => a.name.localeCompare(b.name) || a.capability.localeCompare(b.capability))
 }
 
 async function latestVersion(configObjectId: ConfigObjectId, organizationId: OrganizationId) {

--- a/ee/apps/den-api/src/mcp/skill-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/skill-capabilities.ts
@@ -33,8 +33,8 @@ export type RemoteSkillDescriptor = {
 
 const AGENT_SKILL_NAME_PATTERN = /^[a-z0-9]+(?:-[a-z0-9]+)*$/
 
-function standardSkillName(title: string, skillId: string): string {
-  const suffix = skillId.replace(/^skill_/, "").slice(-8).toLowerCase()
+export function standardSkillName(title: string, stableId: string): string {
+  const suffix = stableId.replace(/^skill_/, "").slice(-8).toLowerCase()
   const base = title
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")

--- a/ee/apps/den-api/test/marketplace-capabilities.test.ts
+++ b/ee/apps/den-api/test/marketplace-capabilities.test.ts
@@ -471,6 +471,45 @@ function expectOrganizationConnectionsUrl(value: string | undefined) {
 }
 
 describe("marketplace capabilities source", () => {
+  test("lists only marketplace plugin skills assigned to the member for prompt discovery", async () => {
+    const owner = await seedMember()
+    const assigned = await seedCapability({
+      owner,
+      objectType: "skill",
+      title: "Renewal Playbook",
+      description: "Use for enterprise renewal strategy",
+      rawSourceText: "# Renewal Playbook\n\nAlways mention expansion risk.",
+    })
+    const unassigned = await seedCapability({
+      owner,
+      objectType: "skill",
+      title: "Private Acquisition Playbook",
+      grant: "none",
+      rawSourceText: "# Private Acquisition Playbook",
+    })
+    await seedCapability({
+      owner,
+      objectType: "command",
+      title: "Assigned Command",
+      rawSourceText: "Draft a follow-up.",
+    })
+
+    const descriptors = await marketplaceCapabilities.listAccessibleMarketplaceSkillDescriptors({
+      organizationId: owner.organizationId,
+      member: owner.member,
+      enabled: true,
+    })
+
+    expect(descriptors).toHaveLength(1)
+    expect(descriptors[0]).toMatchObject({
+      description: "Use for enterprise renewal strategy",
+      capability: assigned.name,
+    })
+    expect(descriptors[0]?.name).toStartWith("renewal-playbook-")
+    expect(descriptors[0]?.location).toBe(`skill://${descriptors[0]?.name}/SKILL.md`)
+    expect(descriptors.some((descriptor) => descriptor.capability === unassigned.name)).toBe(false)
+  })
+
   test("search finds a published plugin skill and execute returns provenance-framed raw content", async () => {
     const owner = await seedMember()
     const seeded = await seedCapability({


### PR DESCRIPTION
## Summary

- include marketplace plugin skills in the authenticated `skill://index.json` catalog consumed by OpenWork Server prompt injection
- reuse the existing marketplace member/team/org grant resolver so agents see only skills they can access
- keep full skill bodies on demand through the existing exact `plugin:<plugin-id>:<config-object-id>` capability and per-skill MCP resource
- generate collision-resistant skill resource names when one cloud object is published through multiple plugins

Follow-up to #2965.

## Validation

- `pnpm --dir ee/apps/den-api exec tsc -p tsconfig.json --noEmit`
- `bun test test/marketplace-capabilities.test.ts` — 18 passed
- `bun test test/mcp-agent-timeouts.test.ts` — 13 passed

The new test proves assigned marketplace skills enter prompt discovery while unassigned skills and non-skill plugin objects remain absent.