### PR TITLE
fix(den-api): capability discovery dropped query params — Gmail search was invisible to agents

### DIFF
--- a/ee/apps/den-api/src/mcp/catalog.ts
+++ b/ee/apps/den-api/src/mcp/catalog.ts
@@ -65,6 +65,9 @@ export function shortenToolName(operationId: string, taken?: ReadonlySet<string>
 
 type OpenApiDocument = {
   paths?: Record<string, Record<string, OpenApiOperation>>
+  components?: {
+    parameters?: Record<string, unknown>
+  }
 }
 
 type OpenApiParameter = {
@@ -96,7 +99,43 @@ export type McpToolOperation = {
 }
 
 function isOpenApiParameter(value: unknown): value is OpenApiParameter {
-  return typeof value === "object" && value !== null
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function componentParameterName(value: unknown) {
+  if (!isOpenApiParameter(value) || !("$ref" in value)) {
+    return null
+  }
+
+  const ref = value.$ref
+  const prefix = "#/components/parameters/"
+  if (typeof ref !== "string" || !ref.startsWith(prefix)) {
+    return null
+  }
+
+  const name = ref.slice(prefix.length)
+  return name.length > 0 ? name : null
+}
+
+function resolveParameterReference(document: OpenApiDocument, parameter: unknown) {
+  const name = componentParameterName(parameter)
+  if (!name) {
+    return parameter
+  }
+
+  const resolved = document.components?.parameters?.[name]
+  return isOpenApiParameter(resolved) ? resolved : parameter
+}
+
+function resolveOperationParameterRefs(document: OpenApiDocument, operation: OpenApiOperation): OpenApiOperation {
+  if (!operation.parameters) {
+    return operation
+  }
+
+  return {
+    ...operation,
+    parameters: operation.parameters.map((parameter) => resolveParameterReference(document, parameter)),
+  }
 }
 
 export function getParameters(operation: OpenApiOperation, location: "path" | "query") {
@@ -263,11 +302,13 @@ export function buildMcpCatalog(document: OpenApiDocument): McpToolOperation[] {
         continue
       }
 
-      if (!isMcpOperationAllowed({ method, path, operation })) {
+      const resolvedOperation = resolveOperationParameterRefs(document, operation)
+
+      if (!isMcpOperationAllowed({ method, path, operation: resolvedOperation })) {
         continue
       }
 
-      const operationId = operation.operationId
+      const operationId = resolvedOperation.operationId
       if (!operationId) {
         continue
       }
@@ -294,8 +335,8 @@ export function buildMcpCatalog(document: OpenApiDocument): McpToolOperation[] {
         name,
         method: method.toUpperCase(),
         path,
-        operation,
-        inputSchema: buildInputSchema(path, operation),
+        operation: resolvedOperation,
+        inputSchema: buildInputSchema(path, resolvedOperation),
       })
     }
   }

--- a/ee/apps/den-api/src/routes/memory/shared.ts
+++ b/ee/apps/den-api/src/routes/memory/shared.ts
@@ -45,15 +45,13 @@ export const searchMemoryQuerySchema = z
     q: z.string().trim().min(1).max(MAX_QUERY_LENGTH),
     limit: z.coerce.number().int().min(1).max(MAX_SEARCH_LIMIT).default(DEFAULT_LIMIT),
   })
-  .meta({ ref: "MemorySearchQuery" })
 
 export const listMemoryQuerySchema = z
   .object({
     limit: z.coerce.number().int().min(1).max(MAX_LIST_LIMIT).default(DEFAULT_LIMIT),
   })
-  .meta({ ref: "MemoryListQuery" })
 
-export const memoryIdParamSchema = z.object({ id: z.string() }).meta({ ref: "MemoryIdParam" })
+export const memoryIdParamSchema = z.object({ id: z.string() })
 
 const memoryContextResponseSchema = z
   .object({

--- a/ee/apps/den-api/src/routes/org/google-workspace.ts
+++ b/ee/apps/den-api/src/routes/org/google-workspace.ts
@@ -110,11 +110,11 @@ function gmailThreadUrl(threadId: string | undefined): string | null {
 const gmailMessagesQuerySchema = z.object({
   q: z.string().trim().min(1).max(1_000).optional().describe("Optional Gmail search query, using Gmail's search syntax."),
   maxResults: z.coerce.number().int().min(1).max(25).default(10).describe("Maximum messages to return, capped at 25."),
-}).meta({ ref: "GoogleWorkspaceGmailMessagesQuery" })
+})
 
 const gmailMessageParamSchema = z.object({
   messageId: z.string().trim().min(1).max(512).describe("Gmail message id."),
-}).meta({ ref: "GoogleWorkspaceGmailMessageParams" })
+})
 
 const gmailAttachmentSchema = z.object({
   attachmentId: z.string(),
@@ -151,7 +151,7 @@ const gmailMessageResponseSchema = z.object({
 const gmailAttachmentParamSchema = z.object({
   messageId: z.string().trim().min(1).max(512).describe("Gmail message id that contains the attachment."),
   attachmentId: z.string().trim().min(1).max(2_048).describe("Attachment id from the gmail-message capability's attachments metadata."),
-}).meta({ ref: "GoogleWorkspaceGmailAttachmentParams" })
+})
 
 const gmailAttachmentResponseSchema = z.object({
   ok: z.literal(true),
@@ -165,11 +165,11 @@ const calendarEventsQuerySchema = z.object({
   timeMin: z.string().datetime().describe("Inclusive lower bound for event start time."),
   timeMax: z.string().datetime().describe("Exclusive upper bound for event start time."),
   maxResults: z.coerce.number().int().min(1).max(100).default(25).describe("Maximum events to return, capped at 100."),
-}).meta({ ref: "GoogleWorkspaceCalendarEventsQuery" })
+})
 
 const calendarEventParamSchema = z.object({
   eventId: z.string().trim().min(1).max(512).describe("Google Calendar event id."),
-}).meta({ ref: "GoogleWorkspaceCalendarEventParams" })
+})
 
 const calendarEventSchema = z.object({
   id: z.string(),
@@ -227,7 +227,7 @@ const updateCalendarEventResponseSchema = z.object({
 const driveFilesQuerySchema = z.object({
   query: z.string().trim().min(1).max(500).describe("Text to search in Drive file names and full text."),
   maxResults: z.coerce.number().int().min(1).max(25).default(10).describe("Maximum files to return, capped at 25."),
-}).meta({ ref: "GoogleWorkspaceDriveFilesQuery" })
+})
 
 const uploadDriveFileBodySchema = z.object({
   filename: z.string().trim().min(1).max(255).refine((value) => !/[\r\n]/.test(value), "Filename must not contain line breaks.").describe("Filename to create in Google Drive."),
@@ -246,7 +246,7 @@ const uploadDriveFileBodySchema = z.object({
 
 const driveFileParamSchema = z.object({
   fileId: z.string().trim().min(1).max(512).describe("Google Drive file id."),
-}).meta({ ref: "GoogleWorkspaceDriveFileParams" })
+})
 
 const shareDriveFileBodySchema = z.object({
   type: z.enum(["user", "domain"]).describe("Use type=user to share with one person, or type=domain to share with the entire organization."),

--- a/ee/apps/den-api/src/routes/org/microsoft-365.ts
+++ b/ee/apps/den-api/src/routes/org/microsoft-365.ts
@@ -41,11 +41,11 @@ const mailMessageSchema = mailMessageSummarySchema.extend({
 const mailMessagesQuerySchema = z.object({
   search: z.string().trim().min(1).max(1_000).optional().describe("Optional Outlook message search text."),
   maxResults: z.coerce.number().int().min(1).max(25).default(10).describe("Maximum messages to return, capped at 25."),
-}).meta({ ref: "Microsoft365MailMessagesQuery" })
+})
 
 const mailMessageParamSchema = z.object({
   messageId: z.string().trim().min(1).max(512).describe("Microsoft Graph message id."),
-}).meta({ ref: "Microsoft365MailMessageParams" })
+})
 
 const mailMessagesResponseSchema = z.object({
   ok: z.literal(true),
@@ -74,7 +74,7 @@ const calendarEventsQuerySchema = z.object({
   timeMin: z.string().datetime().describe("Inclusive lower bound for event start time."),
   timeMax: z.string().datetime().describe("Exclusive upper bound for event start time."),
   maxResults: z.coerce.number().int().min(1).max(100).default(25).describe("Maximum events to return, capped at 100."),
-}).meta({ ref: "Microsoft365CalendarEventsQuery" })
+})
 
 const calendarEventSchema = z.object({
   id: z.string(),
@@ -118,11 +118,11 @@ const calendarEventResponseSchema = z.object({
 const driveFilesQuerySchema = z.object({
   query: z.string().trim().min(1).max(500).describe("Text to search in OneDrive file names and content."),
   maxResults: z.coerce.number().int().min(1).max(25).default(10).describe("Maximum files to return, capped at 25."),
-}).meta({ ref: "Microsoft365DriveFilesQuery" })
+})
 
 const driveFileParamSchema = z.object({
   itemId: z.string().trim().min(1).max(512).describe("Microsoft Graph drive item id."),
-}).meta({ ref: "Microsoft365DriveFileParams" })
+})
 
 const driveItemSchema = z.object({
   id: z.string(),
@@ -162,15 +162,15 @@ const driveFileWriteResponseSchema = z.object({
 
 const teamsChatsQuerySchema = z.object({
   maxResults: z.coerce.number().int().min(1).max(50).default(20),
-}).meta({ ref: "Microsoft365TeamsChatsQuery" })
+})
 
 const teamsChatParamSchema = z.object({
   chatId: z.string().trim().min(1).max(1_024),
-}).meta({ ref: "Microsoft365TeamsChatParams" })
+})
 
 const teamsMessagesQuerySchema = z.object({
   maxResults: z.coerce.number().int().min(1).max(50).default(20),
-}).meta({ ref: "Microsoft365TeamsMessagesQuery" })
+})
 
 const teamsMessageBodySchema = z.object({
   content: z.string().trim().min(1).max(20_000),

--- a/ee/apps/den-api/src/routes/org/sso.ts
+++ b/ee/apps/den-api/src/routes/org/sso.ts
@@ -110,7 +110,7 @@ const ssoConnectionResponseSchema = z.object({
 
 const metadataQuerySchema = z.object({
   format: z.enum(["xml", "json"]).default("xml"),
-}).meta({ ref: "OrganizationSsoMetadataQuery" })
+})
 
 const domainVerificationResponseSchema = z.object({
   domainVerificationToken: z.string().min(1),

--- a/ee/apps/den-api/test/google-workspace-capabilities.test.ts
+++ b/ee/apps/den-api/test/google-workspace-capabilities.test.ts
@@ -1055,12 +1055,19 @@ test("Google Workspace capability tools are discoverable and keep readable names
   }
 
   const catalog = buildMcpCatalog(document)
-  expect(searchCapabilities(catalog, "calendar events list", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceCalendarEvents")
+  const calendarMatch = searchCapabilities(catalog, "calendar events list", 10)[0]
+  expect(calendarMatch?.name).toBe("getCapabilitiesGoogleWorkspaceCalendarEvents")
+  expect(calendarMatch?.queryParams).toEqual(["timeMin", "timeMax", "maxResults"])
   expect(searchCapabilities(catalog, "add meet link existing event", 10)[0]?.name).toBe("patchCapabilitiesGoogleWorkspaceCalendarEvent")
-  expect(searchCapabilities(catalog, "drive files", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceDriveFiles")
+  const driveMatch = searchCapabilities(catalog, "drive files", 10)[0]
+  expect(driveMatch?.name).toBe("getCapabilitiesGoogleWorkspaceDriveFiles")
+  expect(driveMatch?.queryParams).toEqual(["query", "maxResults"])
   expect(searchCapabilities(catalog, "drive upload", 10)[0]?.name).toBe("postCapabilitiesGoogleWorkspaceDriveFiles")
   expect(searchCapabilities(catalog, "share drive file", 10)[0]?.name).toBe("postCapabilitiesGoogleWorkspaceDriveFileShare")
-  expect(searchCapabilities(catalog, "gmail search read messages", 10)[0]?.name).toBe("getCapabilitiesGoogleWorkspaceGmailMessages")
+  const gmailMatch = searchCapabilities(catalog, "gmail search read messages", 10)[0]
+  expect(gmailMatch?.name).toBe("getCapabilitiesGoogleWorkspaceGmailMessages")
+  expect(gmailMatch?.queryParams).toEqual(["q", "maxResults"])
+  expect(searchCapabilities(catalog, "outlook mail messages", 20).find((match) => match.name === "getCapabilitiesMicrosoft365MailMessages")?.queryParams).toEqual(["search", "maxResults"])
   const draftMatch = searchCapabilities(catalog, "gmail draft workspace attachment", 10)[0]
   expect(draftMatch?.name).toBe("postCapabilitiesGoogleWorkspaceGmailDrafts")
   expect(draftMatch?.summary).toContain("attachments: [{ filename, mimeType, dataBase64 }]")

--- a/ee/apps/den-api/test/mcp-catalog-parameter-refs.test.ts
+++ b/ee/apps/den-api/test/mcp-catalog-parameter-refs.test.ts
@@ -1,0 +1,55 @@
+import { expect, test } from "bun:test"
+import { buildMcpCatalog } from "../src/mcp/catalog.js"
+import { searchCapabilities } from "../src/mcp/search.js"
+
+test("MCP catalog resolves OpenAPI parameter refs for discovery", () => {
+  const document = {
+    paths: {
+      "/v1/synthetic/{itemId}": {
+        get: {
+          operationId: "getV1SyntheticItemsByItemId",
+          tags: ["Capability Sources"],
+          summary: "Synthetic parameter refs",
+          parameters: [
+            { $ref: "#/components/parameters/ComponentQuery" },
+            { name: "inlineQuery", in: "query", description: "Inline query", schema: { type: "string" } },
+            { $ref: "#/components/parameters/MissingQuery" },
+            { $ref: "#/components/parameters/ItemId" },
+          ],
+        },
+      },
+    },
+    components: {
+      parameters: {
+        ComponentQuery: {
+          name: "componentQuery",
+          in: "query",
+          required: true,
+          description: "Resolved query parameter",
+          schema: { type: "string" },
+        },
+        ItemId: {
+          name: "itemId",
+          in: "path",
+          required: true,
+          description: "Resolved path parameter",
+          schema: { type: "integer" },
+        },
+      },
+    },
+  }
+
+  const catalog = buildMcpCatalog(document)
+  const match = searchCapabilities(catalog, "synthetic parameter refs", 10).find((result) => result.name === "getSyntheticItems")
+  if (!match) {
+    throw new Error("Expected synthetic capability match")
+  }
+  expect(match.queryParams).toEqual(["componentQuery", "inlineQuery"])
+  expect(match.pathParams).toEqual(["itemId"])
+
+  const tool = catalog.find((operation) => operation.name === "getSyntheticItems")
+  if (!tool) {
+    throw new Error("Expected synthetic catalog operation")
+  }
+  expect(tool.inputSchema.safeParse({ path: { itemId: 42 }, query: { componentQuery: "ref", inlineQuery: "inline" } }).success).toBe(true)
+})


### PR DESCRIPTION
## What

An agent using the OpenWork Cloud connection reported: *"the discovered `gmail-messages` capability exposed **no search/query parameters**, so it could only list the latest inbox messages, not filter by 'Gaurav'"* — and fell back to searching Gmail in the browser by hand. The route has supported `q` (Gmail search syntax) since #2571; **discovery** was silently erasing it.

## Root cause (two compounding bugs, verified against production)

1. **Lossy spec generation** — `.meta({ ref })` on Zod schemas passed to `queryValidator`/`paramValidator` makes hono-openapi hoist the whole multi-field object into `components.parameters` as a **single `$ref` parameter, keeping only the first field**. In the production `openapi.json` today, `GoogleWorkspaceGmailMessagesQuery` contains only `q` (`maxResults` gone), `GoogleWorkspaceCalendarEventsQuery` only `timeMin` (`timeMax`/`maxResults` gone), etc.
2. **Catalog drops `$ref`s** — `buildMcpCatalog`/`getParameters` only read inline `{ in, name }` parameters, so the surviving `$ref` was dropped too → `search_capabilities` matches advertised `queryParams: []` for **20 operations** (Gmail, Calendar, Drive, Memory Bank, all Microsoft 365).

Evidence chain (gmail-messages `queryParams` as an agent sees them):

| Configuration | `queryParams` |
|---|---|
| production doc + production catalog (user's experience) | `[]` |
| production doc + new catalog (`$ref` resolution alone) | `["q"]` |
| **this PR** (fixed doc + resolving catalog) | `["q", "maxResults"]` |

## How

- Remove `.meta({ ref })` from every query/path-param validator schema (`google-workspace.ts`, `microsoft-365.ts`, `memory/shared.ts`, `sso.ts`) so params are emitted inline and complete, with their descriptions ("Optional Gmail search query, using Gmail's search syntax."). Response/body schema metas untouched.
- Defensively resolve `#/components/parameters/*` `$refs` in `buildMcpCatalog` so this failure class degrades gracefully instead of silently hiding parameters (no mutation, no casts).
- Regression tests: discoverability test now locks `queryParams` for gmail `["q","maxResults"]`, calendar `["timeMin","timeMax","maxResults"]`, drive `["query","maxResults"]`, m365 mail `["search","maxResults"]`; new pure-unit test covers resolvable/unresolvable/inline/path `$ref`s.

## Tests run (all from `ee/apps/den-api`, dockerized MySQL via `pnpm dev:den:mysql`)

- `bun test test/mcp-catalog-parameter-refs.test.ts test/google-workspace-capabilities.test.ts test/microsoft-365-routes.test.ts` → **33 pass, 0 fail**
- `bun test` on adjacent suites (memory ×2, agent-mcp-routes, mcp-agent-timeouts, mcp-agent-config-policy, sso ×6) → **50 pass, 2 fail** — both failures reproduce identically with this change stashed (pre-existing on `origin/dev`): `mcp-agent-config-policy.test.ts` (marketplaceId in bodySchema.required) and `memory-ownership.test.ts` (404 vs 201 org gate)
- `pnpm exec tsc --noEmit -p tsconfig.json` → clean

## Validation note (why no fraimz/video)

This is a den-api (cloud server) schema/discovery fix with no desktop UI path. The end-user surface is the `search_capabilities` MCP response, and the proof drives exactly that code path against reality: the discoverability test builds the catalog from the real app's `openapi.json` and asserts through `searchCapabilities()` (the same function the `/mcp/agent` tool handler calls), plus the production-spec probes in the table above. Reproduce the "before" yourself: `curl -s https://app.openworklabs.com/api/den/openapi.json | jq '.paths."/v1/capabilities/google-workspace/gmail-messages".get.parameters'` → a lone `$ref`.

After deploy, an agent asked to "find emails from Gaurav" will discover `queryParams: ["q", "maxResults"]` and call `execute_capability` with `query: { q: "from:gaurav" }` instead of paging the whole inbox.
