### PR TITLE
fix(den): never point install links at releases without installer assets; actionable installer paste errors

### DIFF
--- a/apps/installer/src/config-sources.ts
+++ b/apps/installer/src/config-sources.ts
@@ -11,7 +11,9 @@ export type InstallerConfigResolution = {
 
 export type InstallLinkConfigResult =
   | { status: "resolved"; config: InstallerConfig }
+  | { status: "invalid-input" }
   | { status: "not-found" }
+  | { status: "unreachable" }
   | { status: "unresolved" }
 
 type ConfigSourceOptions = {
@@ -84,7 +86,12 @@ function parseConfigPayload(payload: unknown, label: string, options?: ConfigSou
     warn(options, `${label} did not contain a valid OpenWork install config.`)
     return null
   }
-  return toInstallerConfig(parsed.data)
+  try {
+    return toInstallerConfig(parsed.data)
+  } catch {
+    warn(options, `${label} did not contain a valid OpenWork install config.`)
+    return null
+  }
 }
 
 function parseRequireSignin(value: string | undefined, fallback: boolean) {
@@ -189,7 +196,13 @@ async function fetchInstallConfig(configUrl: string, options?: ConfigSourceOptio
     warn(options, `Install config request failed (${response.status} ${response.statusText}).`)
     return { status: response.status === 404 ? "not-found" : "unresolved" }
   }
-  const payload: unknown = await response.json()
+  let payload: unknown
+  try {
+    payload = await response.json()
+  } catch {
+    warn(options, `${configUrl} did not contain a valid OpenWork install config.`)
+    return { status: "unresolved" }
+  }
   const config = parseConfigPayload(payload, configUrl, options)
   return config ? { status: "resolved", config } : { status: "unresolved" }
 }
@@ -201,9 +214,13 @@ export async function installLinkConfig(input: string, options: ConfigSourceOpti
 export async function resolveInstallLinkConfig(input: string, options: ConfigSourceOptions = {}): Promise<InstallLinkConfigResult> {
   const parsed = parseInstallLinkInput(input)
   if (!parsed) {
-    return { status: "unresolved" }
+    return { status: "invalid-input" }
   }
-  return fetchInstallConfig(parsed.url, options)
+  try {
+    return await fetchInstallConfig(parsed.url, options)
+  } catch {
+    return { status: "unreachable" }
+  }
 }
 
 export function buildConstantsConfig(constants: BuildConstants = DEFAULT_BUILD_CONSTANTS): InstallerConfig | null {

--- a/apps/installer/src/server.ts
+++ b/apps/installer/src/server.ts
@@ -56,11 +56,16 @@ export function startInstallerServer(initialResolution: InstallerConfigResolutio
           }
           const result = await resolveInstallLinkConfig(installLink)
           if (result.status !== "resolved") {
-            const expired = result.status === "not-found"
-            const message = expired
-              ? "This install link has expired or was replaced. Ask your workspace admin for a fresh one from the Members page."
-              : "Install link could not be resolved."
-            return Response.json({ error: expired ? "install_link_expired" : "install_link_invalid", message }, { status: 400 })
+            if (result.status === "not-found") {
+              return Response.json({ error: "install_link_expired", message: "This install link has expired or was replaced. Ask your workspace admin for a fresh one from the Members page." }, { status: 400 })
+            }
+            if (result.status === "invalid-input") {
+              return Response.json({ error: "install_link_invalid", message: "That doesn't look like an install link. On your team's install page, copy the link shown in step 2 — it ends with ?token=..." }, { status: 400 })
+            }
+            if (result.status === "unreachable") {
+              return Response.json({ error: "install_link_unreachable", message: "Could not reach your workspace. Check your internet or VPN connection and try again." }, { status: 400 })
+            }
+            return Response.json({ error: "install_link_invalid", message: "Install link could not be resolved." }, { status: 400 })
           }
           resolution = { config: result.config, source: "install-link" }
           return Response.json({ ok: true, source: installerConfigSourceLabel(resolution.source) })

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -289,6 +289,51 @@ describe("install link helpers", () => {
 })
 
 describe("resolve-link API", () => {
+  test("explains pasted GitHub artifact URLs are not install links", async () => {
+    const installerServer = startInstallerServer(null, () => undefined)
+    try {
+      const response = await fetch(`${installerServer.url}api/resolve-link`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-installer-token": installerServer.token },
+        body: JSON.stringify({ installLink: "https://github.com/different-ai/openwork/releases/download/v0.17.39/OpenWork-Installer-win-x64.exe" }),
+      })
+
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual({
+        error: "install_link_invalid",
+        message: "That doesn't look like an install link. On your team's install page, copy the link shown in step 2 — it ends with ?token=...",
+      })
+    } finally {
+      installerServer.stop()
+    }
+  })
+
+  test("explains unreachable workspaces as connection or VPN problems", async () => {
+    const configServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => Response.json({ ok: true }),
+    })
+    const port = configServer.port
+    const installerServer = startInstallerServer(null, () => undefined)
+    configServer.stop(true)
+    try {
+      const response = await fetch(`${installerServer.url}api/resolve-link`, {
+        method: "POST",
+        headers: { "content-type": "application/json", "x-installer-token": installerServer.token },
+        body: JSON.stringify({ installLink: `http://127.0.0.1:${port}/install?token=abcDEF12` }),
+      })
+
+      expect(response.status).toBe(400)
+      expect(await response.json()).toEqual({
+        error: "install_link_unreachable",
+        message: "Could not reach your workspace. Check your internet or VPN connection and try again.",
+      })
+    } finally {
+      installerServer.stop()
+    }
+  })
+
   test("maps missing install configs to the expired-link message", async () => {
     const configServer = Bun.serve({
       hostname: "127.0.0.1",

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -25,6 +25,8 @@ import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, 
 import { organizationCapabilityKeySchema } from "../../organization-capabilities.js"
 import { normalizeOrganizationMetadata } from "../../organization-limits.js"
 import {
+  DEFAULT_INSTALLER_RELEASE_REPO,
+  FIRST_GENERIC_INSTALLER_RELEASE,
   genericInstallerArtifactName,
   installerReleaseAssetUrl,
   resolveConfiguredInstallerArtifact,
@@ -209,15 +211,26 @@ function maxAllowedDesktopVersion(versions: string[]) {
   return maxVersion
 }
 
+function clampInstallerReleaseTag(releaseTag: string) {
+  const comparison = compareVersions(releaseTag, FIRST_GENERIC_INSTALLER_RELEASE)
+  if (env.installerReleaseRepo === DEFAULT_INSTALLER_RELEASE_REPO && comparison !== null && comparison < 0) {
+    // The generic installer is version-agnostic: it installs /v1/app-version,
+    // so allowedDesktopVersions still governs app updates. This only selects
+    // an installer binary release that actually has OpenWork-Installer-* assets.
+    return `v${FIRST_GENERIC_INSTALLER_RELEASE}`
+  }
+  return releaseTag
+}
+
 function installerReleaseTagForMetadata(metadataInput: unknown) {
   const metadata = normalizeOrganizationMetadata(organizationMetadataInput(metadataInput)).metadata
   const allowedVersions = metadata.allowedDesktopVersions
   if (!allowedVersions?.length) {
-    return env.installerReleaseTag
+    return clampInstallerReleaseTag(env.installerReleaseTag)
   }
 
   const maxVersion = maxAllowedDesktopVersion(allowedVersions)
-  return maxVersion ? `v${maxVersion}` : env.installerReleaseTag
+  return clampInstallerReleaseTag(maxVersion ? `v${maxVersion}` : env.installerReleaseTag)
 }
 
 async function resolveInstallConfigForToken(token: string, request: Request) {

--- a/ee/apps/den-api/src/utils/installer-artifacts.ts
+++ b/ee/apps/den-api/src/utils/installer-artifacts.ts
@@ -8,6 +8,11 @@ export type ConfiguredInstallerArtifact = {
   size: number
 }
 
+export const DEFAULT_INSTALLER_RELEASE_REPO = "different-ai/openwork"
+// First GitHub release tag on different-ai/openwork that carries the OpenWork-Installer-* assets;
+// earlier tags have no installer assets so redirects to them 404.
+export const FIRST_GENERIC_INSTALLER_RELEASE = "0.17.37"
+
 export function installerReleaseAssetUrl(
   fileName: string,
   options: { releaseRepo?: string; releaseTag?: string } = {},

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -403,6 +403,22 @@ test("zero-config downloads redirect the browser to the official release", async
 test("unordered organization allowed desktop versions select the maximum direct release URL", async () => {
   organizationMetadata = {
     ...defaultOrganizationMetadata(),
+    allowedDesktopVersions: ["0.17.38", "0.17.37", "0.17.39"],
+  }
+
+  const response = await createApp().request("http://den.local/v1/install/win-x64?token=opaque-token", {
+    redirect: "manual",
+  })
+
+  expect(response.status).toBe(302)
+  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.39/OpenWork-Installer-win-x64.exe")
+  expect(response.headers.get("location")).not.toContain("v9.9.9")
+  expect(response.headers.get("location")).not.toContain("opaque-token")
+})
+
+test("below-floor allowed desktop versions serve the first installer release that has assets", async () => {
+  organizationMetadata = {
+    ...defaultOrganizationMetadata(),
     allowedDesktopVersions: ["0.17.26", "0.17.25", "0.17.27"],
   }
 
@@ -411,8 +427,8 @@ test("unordered organization allowed desktop versions select the maximum direct 
   })
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.27/OpenWork-Installer-win-x64.exe")
-  expect(response.headers.get("location")).not.toContain("v9.9.9")
+  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.37/OpenWork-Installer-win-x64.exe")
+  expect(response.headers.get("location")).not.toContain("v0.17.27")
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
@@ -457,9 +473,9 @@ test("unrestricted organizations use Den's configured installer release tag", as
 test("install token organization policy applies to member and admin downloads", async () => {
   organizationMetadata = {
     ...defaultOrganizationMetadata(),
-    allowedDesktopVersions: ["0.17.26", "0.17.27"],
+    allowedDesktopVersions: ["0.17.37", "0.17.39"],
   }
-  const expectedUrl = "https://github.com/different-ai/openwork/releases/download/v0.17.27/OpenWork-Installer-win-x64.exe"
+  const expectedUrl = "https://github.com/different-ai/openwork/releases/download/v0.17.39/OpenWork-Installer-win-x64.exe"
 
   for (const nextRole of ["member", "admin"]) {
     role = nextRole
@@ -470,6 +486,39 @@ test("install token organization policy applies to member and admin downloads", 
     expect(response.status).toBe(302)
     expect(response.headers.get("location")).toBe(expectedUrl)
   }
+})
+
+test("below-floor configured installer release tags are clamped for unrestricted official downloads", async () => {
+  envModule.env.installerReleaseTag = "v0.17.27"
+  organizationMetadata = {
+    ...defaultOrganizationMetadata(),
+    allowedDesktopVersions: [],
+  }
+
+  const response = await createApp().request("http://den.local/v1/install/win-x64?token=opaque-token", {
+    redirect: "manual",
+  })
+
+  expect(response.status).toBe(302)
+  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.37/OpenWork-Installer-win-x64.exe")
+  expect(response.headers.get("location")).not.toContain("v0.17.27")
+  expect(response.headers.get("location")).not.toContain("opaque-token")
+})
+
+test("custom installer release repos are not clamped", async () => {
+  envModule.env.installerReleaseRepo = "acme/openwork"
+  organizationMetadata = {
+    ...defaultOrganizationMetadata(),
+    allowedDesktopVersions: ["0.17.26", "0.17.27"],
+  }
+
+  const response = await createApp().request("http://den.local/v1/install/win-x64?token=opaque-token", {
+    redirect: "manual",
+  })
+
+  expect(response.status).toBe(302)
+  expect(response.headers.get("location")).toBe("https://github.com/acme/openwork/releases/download/v0.17.27/OpenWork-Installer-win-x64.exe")
+  expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
 test.each([

--- a/evals/flows/den-download-link-match-allowed-versions.flow.mjs
+++ b/evals/flows/den-download-link-match-allowed-versions.flow.mjs
@@ -4,11 +4,13 @@ const FLOW_ID = "den-download-link-match-allowed-versions";
 const DEN_API_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_API_URL);
 const DEN_TOKEN = process.env.OPENWORK_EVAL_DEN_TOKEN?.trim() || "";
 const MEMBER_TOKEN = process.env.OPENWORK_EVAL_MEMBER_DEN_TOKEN?.trim() || DEN_TOKEN;
-const DEFAULT_RELEASE_TAG = process.env.OPENWORK_EVAL_DEFAULT_INSTALLER_RELEASE_TAG?.trim() || "v0.17.28";
+const DEFAULT_RELEASE_TAG = process.env.OPENWORK_EVAL_DEFAULT_INSTALLER_RELEASE_TAG?.trim() || "v0.17.39";
 const DEFAULT_RELEASE_VERSION = DEFAULT_RELEASE_TAG.replace(/^v/i, "");
-const ALLOWED_VERSIONS = ["0.17.26", "0.17.27"];
-const SELECTED_VERSION = "0.17.27";
-const DISALLOWED_VERSION = "0.17.28";
+const ALLOWED_VERSIONS = ["0.17.37", "0.17.38"];
+const SELECTED_VERSION = "0.17.38";
+const DISALLOWED_VERSION = "0.17.39";
+const LEGACY_ALLOWED_VERSIONS = ["0.17.26", "0.17.27"];
+const FIRST_GENERIC_INSTALLER_VERSION = "0.17.37";
 
 // Narration is loaded from the approved script (evals/voiceovers/den-download-link-match-allowed-versions.md).
 // The runner fails this flow if the narration drifts from that script.
@@ -19,6 +21,8 @@ const state = {
   organizationName: null,
   memberInstallToken: null,
   restrictedDownload: null,
+  legacyInstallToken: null,
+  legacyDownload: null,
   unrestrictedInstallToken: null,
   unrestrictedDownload: null,
 };
@@ -146,7 +150,7 @@ export default {
     {
       name: "Frame 1 — Admin restricts desktop versions",
       run: async (ctx) => {
-        await ctx.prove("An admin saves a policy allowing 0.17.26 and 0.17.27 while 0.17.28 remains disallowed", {
+        await ctx.prove("An admin saves a policy allowing 0.17.37 and 0.17.38 while 0.17.39 remains disallowed", {
           voiceover: vo[0],
           action: async () => {
             const organization = await setAllowedDesktopVersions(ctx, ALLOWED_VERSIONS);
@@ -156,7 +160,7 @@ export default {
             const current = await denApiFetch("/v1/org");
             const versions = readOrganizationMetadata(current.body?.organization).allowedDesktopVersions;
             witness(ctx, Array.isArray(versions), "The saved organization metadata exposes allowedDesktopVersions", current.body);
-            witness(ctx, versions.includes("0.17.26") && versions.includes(SELECTED_VERSION), "The saved policy includes the two allowed versions", versions);
+            witness(ctx, versions.includes("0.17.37") && versions.includes(SELECTED_VERSION), "The saved policy includes the two allowed versions", versions);
             witness(ctx, !versions.includes(DISALLOWED_VERSION), "The saved policy excludes the disallowed latest version", versions);
           },
         });
@@ -182,24 +186,42 @@ export default {
     {
       name: "Frame 3 — Download selects the highest allowed version",
       run: async (ctx) => {
-        await ctx.prove("Clicking download returns OpenWork 0.17.27 instead of the disallowed 0.17.28 release", {
+        await ctx.prove("Clicking download returns OpenWork 0.17.38 instead of the disallowed 0.17.39 release", {
           voiceover: vo[2],
           action: async () => {
             state.restrictedDownload = await fetchInstallerDownload(state.memberInstallToken);
           },
           assert: async () => {
             witness(ctx, [200, 302].includes(state.restrictedDownload.status), "The installer endpoint returns a download or redirect", state.restrictedDownload);
-            witness(ctx, downloadMentionsVersion(state.restrictedDownload, SELECTED_VERSION), "The selected direct URL or artifact filename contains 0.17.27", state.restrictedDownload);
-            witness(ctx, !downloadMentionsVersion(state.restrictedDownload, DISALLOWED_VERSION), "The selected download does not contain disallowed 0.17.28", state.restrictedDownload);
+            witness(ctx, downloadMentionsVersion(state.restrictedDownload, SELECTED_VERSION), "The selected direct URL or artifact filename contains 0.17.38", state.restrictedDownload);
+            witness(ctx, !downloadMentionsVersion(state.restrictedDownload, DISALLOWED_VERSION), "The selected download does not contain disallowed 0.17.39", state.restrictedDownload);
           },
         });
       },
     },
     {
-      name: "Frame 4 — Unrestricted org keeps Den default",
+      name: "Frame 4 — Legacy pins still get an installer binary that exists",
+      run: async (ctx) => {
+        await ctx.prove("Legacy desktop-version pins download the first generic installer release instead of a missing legacy asset", {
+          voiceover: vo[3],
+          action: async () => {
+            await setAllowedDesktopVersions(ctx, LEGACY_ALLOWED_VERSIONS);
+            state.legacyInstallToken = await mintInstallToken(ctx, DEN_TOKEN);
+            state.legacyDownload = await fetchInstallerDownload(state.legacyInstallToken);
+          },
+          assert: async () => {
+            witness(ctx, [200, 302].includes(state.legacyDownload.status), "The legacy-pinned installer endpoint returns a download or redirect", state.legacyDownload);
+            witness(ctx, downloadMentionsVersion(state.legacyDownload, FIRST_GENERIC_INSTALLER_VERSION), "The legacy-pinned download uses the first release with installer assets", state.legacyDownload);
+            witness(ctx, !downloadMentionsVersion(state.legacyDownload, "0.17.27"), "The legacy-pinned download does not point at the missing v0.17.27 installer asset", state.legacyDownload);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5 — Unrestricted org keeps Den default",
       run: async (ctx) => {
         await ctx.prove("Removing the allowed-version restriction restores Den's configured installer release", {
-          voiceover: vo[3],
+          voiceover: vo[4],
           action: async () => {
             await setAllowedDesktopVersions(ctx, null);
             state.unrestrictedInstallToken = await mintInstallToken(ctx, DEN_TOKEN);

--- a/evals/voiceovers/den-download-link-match-allowed-versions.md
+++ b/evals/voiceovers/den-download-link-match-allowed-versions.md
@@ -2,10 +2,12 @@
 
 The organization-wide desktop version policy applies to every member who uses the guided installer flow.
 
-1. An admin allows desktop versions 0.17.26 and 0.17.27, while 0.17.28 remains disallowed.
+1. An admin allows desktop versions 0.17.37 and 0.17.38, while 0.17.39 remains disallowed.
 
 2. A non-admin signs in to the single-organization dashboard and opens the three-step installer flow.
 
-3. Clicking “Download and install” downloads OpenWork 0.17.27—the highest version permitted by the organization.
+3. Clicking “Download and install” downloads OpenWork 0.17.38—the highest version permitted by the organization.
 
-4. Organizations without version restrictions continue downloading Den’s configured latest release.
+4. If an admin pins legacy versions 0.17.26 and 0.17.27, the guided installer still downloads v0.17.37—the first release that has installer assets—instead of pointing at the missing v0.17.27 asset.
+
+5. Organizations without version restrictions continue downloading Den’s configured latest release.


### PR DESCRIPTION
## What broke (live, on the Blue Yonder call)

An org member clicked **dashboard → Open install page → Download for Windows** and got a dead link, then pasted a link into the installer and hit a dead-end *"Install link could not be resolved."* The workaround required the org owner to approve a newer app version — she was in another meeting.

### Root cause 1 — dead installer download
`installerReleaseTagForMetadata()` resolves the installer artifact tag from the org's **max `allowedDesktopVersions`**. Generic installer assets (`OpenWork-Installer-*.{dmg,exe}`) only exist on releases **≥ v0.17.37**; orgs pinned below that got a 302 to a GitHub 404:

- pre-fix target `…/v0.17.27/OpenWork-Installer-win-x64.exe` → **HTTP 404** (verified)
- post-fix target `…/v0.17.37/OpenWork-Installer-win-x64.exe` → **HTTP 200** (verified)

**Fix:** clamp the resolved tag to `FIRST_GENERIC_INSTALLER_RELEASE = 0.17.37`. This is safe because the generic installer is **version-agnostic**: it installs whatever app version `GET /v1/app-version` pins, so `allowedDesktopVersions` still fully governs the app version — the clamp only picks an installer *binary* that exists. Custom `OPENWORK_INSTALLER_RELEASE_REPO` values and unparseable tags pass through unchanged.

### Root cause 2 — dead-end paste error
The installer collapsed unparseable input (on the call: a GitHub artifact URL from chat), unreachable hosts (VPN), bad payloads, and expired links into one message. Now each failure tells the user what to do:

| status | message |
|---|---|
| unparseable input | "That doesn't look like an install link. On your team's install page, copy the link shown in step 2 — it ends with ?token=..." |
| unreachable host | "Could not reach your workspace. Check your internet or VPN connection and try again." |
| expired/replaced (404) | unchanged |
| other | unchanged generic |

## Proof (fraimz)

`pnpm fraimz --flow den-download-link-match-allowed-versions --stack den` — **PASSED, 5/5 frames** against a real den stack running this branch, including the new incident-regression frame: *legacy pins (0.17.26/0.17.27) → download redirects to v0.17.37, the first release with installer assets*. Proof comment posted below via `--pr`.

## Tests run

- `cd ee/apps/den-api && bun test test/install-link-access.test.ts test/installer-artifacts.test.ts` → **41 pass / 0 fail** (was 38; +3 new: below-floor clamp, env-fallback clamp, custom-repo passthrough)
- `cd apps/installer && bun test` → **29 pass / 0 fail** (was 27; +2 new: GitHub-artifact-URL paste, unreachable host)
- `pnpm exec tsc --noEmit -p ee/apps/den-api` → clean
- `node --check evals/flows/den-download-link-match-allowed-versions.flow.mjs` → clean
- Honest note: the *full* `bun test` den-api suite fails 86 tests at baseline (origin/dev, pre-change) from cross-file env/mock interference when all files run in one process; with this change it fails 89 — the +3 are exactly the new tests in `install-link-access.test.ts`, whose file already fails wholesale in full-suite mode at baseline (its pre-existing tests fail there too). In isolation the file is 41/41 green. CI does not run the den-api suite as one process.

## Not in scope
- The installer already accepts the install-page URL as the happy paste path (`/install?token=…`) — unchanged.
- Fresh installs follow the Den `/v1/app-version` pin rather than the org allowlist max (pre-existing behavior, separate discussion).
