### PR TITLE
fix(server): scope Connect skill catalog to the host, not a workspace

### DIFF
--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -2135,6 +2135,10 @@ async function persistDesiredConfig(config: ServerConfig, workspaceId: string, d
       [OPENWORK_CLOUD_MCP_NAME]: desiredConfig,
     },
   }));
+  // Connect is server/account-scoped: keep a host-level copy for catalog + skill injection.
+  // Dynamic import avoids a connect-state <-> cloud-mcp-health cycle.
+  const { writeConnectCloudMcp } = await import("./connect-state.js");
+  await writeConnectCloudMcp(config, desiredConfig);
 }
 
 function registrationFailure(failures: CloudMcpRuntimeRegistrationFailure[]): CloudMcpFailure {

--- a/apps/server/src/connect-skill-catalog.test.ts
+++ b/apps/server/src/connect-skill-catalog.test.ts
@@ -1,6 +1,87 @@
-import { describe, expect, test } from "bun:test";
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 
-import { readMcpSkillIndex, renderOpenWorkConnectSkillInstruction } from "./connect-skill-catalog.js";
+import {
+  readMcpSkillIndex,
+  readOpenWorkConnectSkillCatalog,
+  renderOpenWorkConnectSkillInstruction,
+  resetOpenWorkConnectSkillCatalogCacheForTests,
+} from "./connect-skill-catalog.js";
+import { writeConnectCloudMcp } from "./connect-state.js";
+import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
+import type { ServerConfig } from "./types.js";
+
+const roots: string[] = [];
+const previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+
+afterEach(async () => {
+  resetOpenWorkConnectSkillCatalogCacheForTests();
+  while (roots.length) await rm(roots.pop() ?? "", { recursive: true, force: true });
+  if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+});
+
+function skillIndexFetcher(capability = "skill:skill_customer_briefing"): (url: string, init?: RequestInit) => Promise<Response> {
+  return async (_url: string, init?: RequestInit) => {
+    const body = JSON.parse(String(init?.body)) as Record<string, unknown>;
+    if (body.method === "initialize") {
+      return Response.json({ jsonrpc: "2.0", id: 1, result: { protocolVersion: "2025-06-18", capabilities: {} } });
+    }
+    if (body.method === "notifications/initialized") return new Response(null, { status: 202 });
+    return Response.json({
+      jsonrpc: "2.0",
+      id: 2,
+      result: {
+        contents: [{
+          uri: "skill://index.json",
+          mimeType: "application/json",
+          text: JSON.stringify({
+            $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+            skills: [{
+              name: "customer-briefing",
+              type: "skill-md",
+              description: "Prepare customer briefings.",
+              url: "skill://customer-briefing/SKILL.md",
+              capability,
+            }],
+          }),
+        }],
+      },
+    });
+  };
+}
+
+async function serverConfig(): Promise<ServerConfig> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-connect-skills-"));
+  roots.push(root);
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  const workspace = {
+    id: "ws_legacy",
+    name: "Legacy",
+    path: root,
+    preset: "starter",
+    workspaceType: "local" as const,
+  };
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "test",
+    hostToken: "host",
+    configPath: join(root, "openwork.json"),
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [workspace],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
 
 describe("OpenWork Connect skill catalog", () => {
   test("renders bounded discovery metadata and capability retrieval guidance", () => {
@@ -116,5 +197,42 @@ describe("OpenWork Connect skill catalog", () => {
 
     expect(skills).toHaveLength(1);
     expect(skills[0]?.capability).toBe("plugin:plg_test:cfg_test");
+  });
+
+  test("reads the skill catalog from server-scoped Connect MCP config", async () => {
+    const config = await serverConfig();
+    await writeConnectCloudMcp(config, {
+      type: "remote",
+      url: "https://connect.example/mcp/agent",
+      enabled: true,
+      headers: { Authorization: "Bearer secret" },
+    });
+
+    const skills = await readOpenWorkConnectSkillCatalog(config, skillIndexFetcher());
+    expect(skills).toHaveLength(1);
+    expect(skills[0]?.name).toBe("customer-briefing");
+  });
+
+  test("promotes legacy workspace openwork-cloud config into server scope", async () => {
+    const config = await serverConfig();
+    await writeRuntimeOpencodeConfig(config, "ws_legacy", (current) => ({
+      ...current,
+      mcp: {
+        "openwork-cloud": {
+          type: "remote",
+          url: "https://connect.example/mcp/agent",
+          enabled: true,
+        },
+      },
+    }));
+
+    const skills = await readOpenWorkConnectSkillCatalog(config, skillIndexFetcher("skill:skill_promoted"));
+    expect(skills[0]?.capability).toBe("skill:skill_promoted");
+
+    // Second read should use the promoted host-level copy even if workspace config is cleared.
+    await writeRuntimeOpencodeConfig(config, "ws_legacy", () => ({ mcp: {} }));
+    resetOpenWorkConnectSkillCatalogCacheForTests();
+    const again = await readOpenWorkConnectSkillCatalog(config, skillIndexFetcher("skill:skill_promoted"));
+    expect(again[0]?.capability).toBe("skill:skill_promoted");
   });
 });

--- a/apps/server/src/connect-skill-catalog.ts
+++ b/apps/server/src/connect-skill-catalog.ts
@@ -1,6 +1,7 @@
 import { createHash } from "node:crypto";
 import { z } from "zod";
 
+import { readConnectCloudMcp, writeConnectCloudMcp } from "./connect-state.js";
 import { readRuntimeMcpConfig } from "./runtime-opencode-config-store.js";
 import { externalFetch } from "./server-fetch.js";
 import type { ServerConfig } from "./types.js";
@@ -103,15 +104,34 @@ export async function readMcpSkillIndex(config: Record<string, unknown>, fetcher
   return skillIndexSchema.parse(JSON.parse(text)).skills;
 }
 
+async function resolveServerConnectMcpConfig(config: ServerConfig): Promise<Record<string, unknown> | null> {
+  const fromState = await readConnectCloudMcp(config);
+  if (fromState) return fromState;
+
+  // Back-compat: older hosts only stored openwork-cloud per workspace. Promote the
+  // first found copy into server-scoped connect-state so skills no longer depend
+  // on workspace resolution.
+  for (const workspace of config.workspaces) {
+    const cloud = await readRuntimeMcpConfig(config, workspace.id, OPENWORK_CLOUD_MCP_NAME);
+    if (!cloud) continue;
+    try {
+      await writeConnectCloudMcp(config, cloud);
+    } catch {
+      // Catalog reads should still succeed even if promotion fails.
+    }
+    return cloud;
+  }
+  return null;
+}
+
 export async function readOpenWorkConnectSkillCatalog(
   config: ServerConfig,
-  workspaceId: string,
   fetcher: McpFetch = externalFetch,
 ): Promise<OpenWorkConnectSkill[]> {
   try {
-    const cloud = await readRuntimeMcpConfig(config, workspaceId, OPENWORK_CLOUD_MCP_NAME);
+    const cloud = await resolveServerConnectMcpConfig(config);
     if (!cloud) return [];
-    const cacheKey = `${workspaceId}:${createHash("sha256").update(JSON.stringify(cloud)).digest("hex")}`;
+    const cacheKey = createHash("sha256").update(JSON.stringify(cloud)).digest("hex");
     const cached = catalogCache.get(cacheKey);
     if (cached && cached.expiresAt > Date.now()) return await cached.value;
     const value = readMcpSkillIndex(cloud, fetcher);

--- a/apps/server/src/connect-state.inspect.test.ts
+++ b/apps/server/src/connect-state.inspect.test.ts
@@ -28,6 +28,36 @@ function serverConfig(root: string): ServerConfig {
 }
 
 describe("Connect state inspection", () => {
+  test("treats server-scoped cloudMcp as present without scanning workspaces", async () => {
+    const root = await mkdtemp(join(tmpdir(), "openwork-connect-state-server-mcp-"));
+    const previousDb = process.env.OPENWORK_RUNTIME_DB;
+    process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+    try {
+      const config = serverConfig(root);
+      await writeFile(join(root, "connect-state.json"), JSON.stringify({
+        connectEnabled: true,
+        updatedAt: 123,
+        cloudMcp: {
+          type: "remote",
+          url: "https://connect.example/mcp/agent",
+          enabled: true,
+        },
+      }), "utf8");
+
+      expect(await inspectConnectSnapshot(config)).toMatchObject({
+        status: "available",
+        snapshot: {
+          connectEnabled: true,
+          cloudMcpPresent: true,
+        },
+      });
+    } finally {
+      if (previousDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+      else process.env.OPENWORK_RUNTIME_DB = previousDb;
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   test("distinguishes a missing state file from bounded read failures", async () => {
     const root = await mkdtemp(join(tmpdir(), "openwork-connect-state-inspect-"));
     const config = serverConfig(root);
@@ -41,7 +71,7 @@ describe("Connect state inspection", () => {
       await writeFile(path, JSON.stringify({ connectEnabled: true, updatedAt: 123 }), "utf8");
       expect(await inspectConnectState(config)).toEqual({
         status: "available",
-        state: { connectEnabled: true, updatedAt: 123 },
+        state: { connectEnabled: true, updatedAt: 123, cloudMcp: null },
       });
 
       await writeFile(path, JSON.stringify({

--- a/apps/server/src/connect-state.ts
+++ b/apps/server/src/connect-state.ts
@@ -28,6 +28,13 @@ type WorkspaceOpencodeClient = ReturnType<typeof createOpencodeClient>;
 type PersistedConnectState = {
   connectEnabled: boolean;
   updatedAt: number;
+  /**
+   * Server-scoped OpenWork Connect (`openwork-cloud`) MCP desired config.
+   * Connect is identity/org scoped, not per-workspace — workspace runtime
+   * copies remain for engine registration, but catalog/skill injection reads
+   * this host-level entry.
+   */
+  cloudMcp: Record<string, unknown> | null;
 };
 
 export type ConnectStateInspectionStatus = "available" | "missing" | "invalid" | "unreadable";
@@ -83,7 +90,15 @@ function connectStatePath(config: ServerConfig): string {
   return join(runtimeStorageDir(config), CONNECT_STATE_FILE);
 }
 
-const DEFAULT_CONNECT_STATE: PersistedConnectState = { connectEnabled: false, updatedAt: 0 };
+const DEFAULT_CONNECT_STATE: PersistedConnectState = {
+  connectEnabled: false,
+  updatedAt: 0,
+  cloudMcp: null,
+};
+
+function normalizeConnectCloudMcp(value: unknown): Record<string, unknown> | null {
+  return isRecord(value) ? value : null;
+}
 
 function normalizeConnectState(value: Record<string, unknown>): PersistedConnectState {
   return {
@@ -91,6 +106,7 @@ function normalizeConnectState(value: Record<string, unknown>): PersistedConnect
     updatedAt: typeof value.updatedAt === "number" && Number.isFinite(value.updatedAt)
       ? value.updatedAt
       : 0,
+    cloudMcp: Object.hasOwn(value, "cloudMcp") ? normalizeConnectCloudMcp(value.cloudMcp) : null,
   };
 }
 
@@ -142,12 +158,41 @@ export async function inspectConnectState(
   }
 }
 
-export async function writeConnectState(config: ServerConfig, state: { connectEnabled: boolean }): Promise<PersistedConnectState> {
-  const next = { connectEnabled: state.connectEnabled, updatedAt: Date.now() };
+async function persistConnectState(
+  config: ServerConfig,
+  state: PersistedConnectState,
+): Promise<PersistedConnectState> {
   const target = connectStatePath(config);
   await ensureDir(runtimeStorageDir(config));
-  await writeFile(target, `${JSON.stringify(next, null, 2)}\n`, "utf8");
-  return next;
+  await writeFile(target, `${JSON.stringify(state, null, 2)}\n`, "utf8");
+  return state;
+}
+
+export async function writeConnectState(config: ServerConfig, state: { connectEnabled: boolean }): Promise<PersistedConnectState> {
+  const current = await readConnectState(config);
+  return persistConnectState(config, {
+    connectEnabled: state.connectEnabled,
+    updatedAt: Date.now(),
+    cloudMcp: current.cloudMcp,
+  });
+}
+
+/** Read the host-level openwork-cloud MCP config used for Connect catalog/skills. */
+export async function readConnectCloudMcp(config: ServerConfig): Promise<Record<string, unknown> | null> {
+  return (await readConnectState(config)).cloudMcp;
+}
+
+/** Persist the host-level openwork-cloud MCP config (server-scoped Connect). */
+export async function writeConnectCloudMcp(
+  config: ServerConfig,
+  cloudMcp: Record<string, unknown> | null,
+): Promise<PersistedConnectState> {
+  const current = await readConnectState(config);
+  return persistConnectState(config, {
+    connectEnabled: current.connectEnabled,
+    updatedAt: Date.now(),
+    cloudMcp: normalizeConnectCloudMcp(cloudMcp),
+  });
 }
 
 function normalizeDirectory(directory: string): string {
@@ -290,6 +335,9 @@ async function inspectConnectRuntime(
   config: ServerConfig,
   options?: ConnectStateInspectionOptions,
 ): Promise<{ cloudMcpPresent: boolean; complete: boolean }> {
+  const serverCloudMcp = await readConnectCloudMcp(config);
+  if (serverCloudMcp) return { cloudMcpPresent: true, complete: true };
+
   const configuredMaxRows = options?.maxRuntimeRows;
   const maxRuntimeRows = typeof configuredMaxRows === "number"
     && Number.isSafeInteger(configuredMaxRows)

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview-steering.ts
@@ -291,17 +291,11 @@ async function fetchOpenWorkConnectState(input: unknown, fetcher: OpenWorkFetch)
   };
 }
 
-export async function resolveOpenWorkConnectSkillInstruction(input?: unknown, fetcher: OpenWorkFetch = fetch): Promise<string> {
+export async function resolveOpenWorkConnectSkillInstruction(_input?: unknown, fetcher: OpenWorkFetch = fetch): Promise<string> {
   try {
     const { url, token } = requireOpenWorkServer();
-    const context = readContext(input);
-    const query = new URLSearchParams();
-    const workspaceId = context.workspaceId ?? context.workspaceID;
-    const directory = context.worktree ?? context.directory;
-    if (workspaceId) query.set("workspaceId", workspaceId);
-    if (directory) query.set("directory", directory);
-    const suffix = query.size ? `?${query.toString()}` : "";
-    const response = await fetcher(`${url}/experimental/connect/skills${suffix}`, {
+    // Connect skills are server-scoped; workspace/directory query params are unused.
+    const response = await fetcher(`${url}/experimental/connect/skills`, {
       headers: { Authorization: `Bearer ${token}` },
     });
     if (!response.ok) return "";

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -227,7 +227,7 @@ describe("OpenWorkExtensionsPreview session tools", () => {
     const connectStateRequest = fake.requests.find((request) => request.pathname === "/experimental/connect/state");
     const connectSkillsRequest = fake.requests.find((request) => request.pathname === "/experimental/connect/skills");
     expect(connectStateRequest?.search).toBe("?directory=%2Ftmp%2Farchive&provider=anthropic&model=claude-sonnet-4");
-    expect(connectSkillsRequest?.search).toBe("?directory=%2Ftmp%2Farchive");
+    expect(connectSkillsRequest?.search).toBe("");
     expect(output.system.join("\n")).toContain("verified ready for this exact workspace/model");
     expect(output.system.join("\n")).toContain("<name>customer-briefing</name>");
   });

--- a/apps/server/src/routes/core.ts
+++ b/apps/server/src/routes/core.ts
@@ -5,7 +5,6 @@ import {
   type ConnectSnapshotOptions,
   getConnectSnapshot,
   googleWorkspaceStatusConnectExtra,
-  resolveConnectWorkspace,
   writeConnectState,
 } from "../connect-state.js";
 import type { CloudMcpLiveStatusObserver } from "../cloud-mcp-health.js";
@@ -324,13 +323,9 @@ export function registerCoreRoutes(options: RegisterCoreRoutesOptions): void {
     });
   });
 
-  addRoute(routes, "GET", "/experimental/connect/skills", "client", async (ctx) => {
-    const resolved = resolveConnectWorkspace(config, {
-      ...connectSnapshotOptionsFromQuery(ctx.url),
-      resolveOpencodeDirectory,
-    });
-    const workspaceId = "workspace" in resolved ? resolved.workspace.id : null;
-    const skills = workspaceId ? await readOpenWorkConnectSkillCatalog(config, workspaceId) : [];
+  addRoute(routes, "GET", "/experimental/connect/skills", "client", async (_ctx) => {
+    // Connect skills are server/account-scoped (openwork-cloud on the host), not per-workspace.
+    const skills = await readOpenWorkConnectSkillCatalog(config);
     return jsonResponse({
       ok: true,
       schemaVersion: 1,


### PR DESCRIPTION
## Summary
- Persist `openwork-cloud` MCP config on host-level `connect-state.json` (dual-write on reconcile; promote legacy per-workspace copies on first catalog read).
- Make `GET /experimental/connect/skills` and the extensions-preview plugin read skills without `workspaceId`/`directory`, so `<available_skills>` injection no longer depends on workspace resolution.
- Fixes agents falling back to `openwork-cloud_search_capabilities` for skills that should already be injected.

## Test plan
- [x] `bun test` in `apps/server` for connect skill/state, cloud-mcp health, gating, and extensions-preview (60 pass / 0 fail)
- [x] Isolated OpenCode proto harness (`tmp/proto-skill-injection`): injected tomato skill → model called `openwork-cloud_execute_capability` with exact capability, no search
- [ ] After merge: restart desktop/OpenWork server so new build loads; confirm status bar reaches Ready and a tomato/skill prompt uses execute, not search


Made with [Cursor](https://cursor.com)