### PR TITLE
fix(server): skip dead openwork-cloud configs when resolving Connect skills

### DIFF
--- a/apps/server/src/connect-skill-catalog.test.ts
+++ b/apps/server/src/connect-skill-catalog.test.ts
@@ -9,7 +9,7 @@ import {
   renderOpenWorkConnectSkillInstruction,
   resetOpenWorkConnectSkillCatalogCacheForTests,
 } from "./connect-skill-catalog.js";
-import { writeConnectCloudMcp } from "./connect-state.js";
+import { readConnectCloudMcp, writeConnectCloudMcp } from "./connect-state.js";
 import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import type { ServerConfig } from "./types.js";
 
@@ -150,7 +150,7 @@ describe("OpenWork Connect skill catalog", () => {
     }, fetcher);
 
     expect(skills).toHaveLength(1);
-    expect(skills[0]?.capability).toBe("skill:skill_customer_briefing");
+    expect(skills?.[0]?.capability).toBe("skill:skill_customer_briefing");
     expect(requests.map((request) => request.body.method)).toEqual([
       "initialize",
       "notifications/initialized",
@@ -196,7 +196,7 @@ describe("OpenWork Connect skill catalog", () => {
     }, fetcher);
 
     expect(skills).toHaveLength(1);
-    expect(skills[0]?.capability).toBe("plugin:plg_test:cfg_test");
+    expect(skills?.[0]?.capability).toBe("plugin:plg_test:cfg_test");
   });
 
   test("reads the skill catalog from server-scoped Connect MCP config", async () => {
@@ -234,5 +234,57 @@ describe("OpenWork Connect skill catalog", () => {
     resetOpenWorkConnectSkillCatalogCacheForTests();
     const again = await readOpenWorkConnectSkillCatalog(config, skillIndexFetcher("skill:skill_promoted"));
     expect(again[0]?.capability).toBe("skill:skill_promoted");
+  });
+
+  test("skips revoked or dead configs and promotes the first working candidate", async () => {
+    const config = await serverConfig();
+    // Poisoned server-scoped copy: stale local Den URL with a revoked token.
+    await writeConnectCloudMcp(config, {
+      type: "remote",
+      url: "https://stale.local.test/mcp/agent",
+      enabled: true,
+      headers: { Authorization: "Bearer revoked" },
+    });
+    await writeRuntimeOpencodeConfig(config, "ws_legacy", (current) => ({
+      ...current,
+      mcp: {
+        "openwork-cloud": {
+          type: "remote",
+          url: "https://connect.example/mcp/agent",
+          enabled: true,
+          headers: { Authorization: "Bearer live" },
+        },
+      },
+    }));
+
+    const working = skillIndexFetcher("skill:skill_live");
+    const fetcher = async (url: string, init?: RequestInit) => {
+      if (url.startsWith("https://stale.local.test")) {
+        return Response.json({ error: "mcp_session_revoked" }, { status: 401 });
+      }
+      return working(url, init);
+    };
+
+    const skills = await readOpenWorkConnectSkillCatalog(config, fetcher);
+    expect(skills[0]?.capability).toBe("skill:skill_live");
+
+    // The working workspace config must replace the poisoned server-scoped copy.
+    const promoted = await readConnectCloudMcp(config);
+    expect(promoted?.url).toBe("https://connect.example/mcp/agent");
+  });
+
+  test("returns empty when every candidate config is unusable", async () => {
+    const config = await serverConfig();
+    await writeConnectCloudMcp(config, {
+      type: "remote",
+      url: "https://stale.local.test/mcp/agent",
+      enabled: true,
+    });
+    const fetcher = async () => Response.json({ error: "invalid_token" }, { status: 401 });
+
+    expect(await readOpenWorkConnectSkillCatalog(config, fetcher)).toEqual([]);
+    // The dead config must not be re-promoted or kept as a false positive.
+    const kept = await readConnectCloudMcp(config);
+    expect(kept?.url).toBe("https://stale.local.test/mcp/agent");
   });
 });

--- a/apps/server/src/connect-skill-catalog.ts
+++ b/apps/server/src/connect-skill-catalog.ts
@@ -26,7 +26,7 @@ const skillIndexSchema = z.object({
 
 export type OpenWorkConnectSkill = z.infer<typeof skillIndexSchema>["skills"][number];
 type McpFetch = (input: string, init?: RequestInit) => Promise<Response>;
-const catalogCache = new Map<string, { expiresAt: number; value: Promise<OpenWorkConnectSkill[]> }>();
+const catalogCache = new Map<string, { expiresAt: number; value: Promise<OpenWorkConnectSkill[] | null> }>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
@@ -68,9 +68,15 @@ async function mcpPost(fetcher: McpFetch, url: string, headers: Record<string, s
   return { response, payload: await readMcpPayload(response) };
 }
 
-export async function readMcpSkillIndex(config: Record<string, unknown>, fetcher: McpFetch): Promise<OpenWorkConnectSkill[]> {
+/**
+ * Read the standards-shaped skill index through one openwork-cloud config.
+ * Returns the skill list on success (possibly empty), or null when the config
+ * is unusable (invalid URL, disabled, auth rejected, transport/protocol error)
+ * so callers can fall back to another candidate config.
+ */
+export async function readMcpSkillIndex(config: Record<string, unknown>, fetcher: McpFetch): Promise<OpenWorkConnectSkill[] | null> {
   const url = typeof config.url === "string" ? config.url : "";
-  if (!/^https?:\/\//.test(url) || config.enabled === false) return [];
+  if (!/^https?:\/\//.test(url) || config.enabled === false) return null;
   const baseHeaders = stringHeaders(config.headers);
   const initialized = await mcpPost(fetcher, url, baseHeaders, {
     id: 1,
@@ -82,7 +88,7 @@ export async function readMcpSkillIndex(config: Record<string, unknown>, fetcher
       protocolVersion: "2025-06-18",
     },
   });
-  if (!initialized.response.ok || !jsonRpcResult(initialized.payload)) return [];
+  if (!initialized.response.ok || !jsonRpcResult(initialized.payload)) return null;
   const sessionHeaders = {
     ...baseHeaders,
     ...(initialized.response.headers.get("mcp-session-id") ? { "mcp-session-id": initialized.response.headers.get("mcp-session-id")! } : {}),
@@ -95,53 +101,60 @@ export async function readMcpSkillIndex(config: Record<string, unknown>, fetcher
     method: "resources/read",
     params: { uri: SKILL_INDEX_URI },
   });
-  if (!resource.response.ok) return [];
+  if (!resource.response.ok) return null;
   const result = jsonRpcResult(resource.payload);
   const contents = result?.contents;
-  if (!Array.isArray(contents)) return [];
+  if (!Array.isArray(contents)) return null;
   const text = contents.find((item) => isRecord(item) && item.uri === SKILL_INDEX_URI && typeof item.text === "string")?.text;
-  if (typeof text !== "string") return [];
+  if (typeof text !== "string") return null;
   return skillIndexSchema.parse(JSON.parse(text)).skills;
 }
 
-async function resolveServerConnectMcpConfig(config: ServerConfig): Promise<Record<string, unknown> | null> {
-  const fromState = await readConnectCloudMcp(config);
-  if (fromState) return fromState;
-
-  // Back-compat: older hosts only stored openwork-cloud per workspace. Promote the
-  // first found copy into server-scoped connect-state so skills no longer depend
-  // on workspace resolution.
-  for (const workspace of config.workspaces) {
-    const cloud = await readRuntimeMcpConfig(config, workspace.id, OPENWORK_CLOUD_MCP_NAME);
-    if (!cloud) continue;
-    try {
-      await writeConnectCloudMcp(config, cloud);
-    } catch {
-      // Catalog reads should still succeed even if promotion fails.
-    }
-    return cloud;
-  }
-  return null;
+async function readIndexCached(cloud: Record<string, unknown>, fetcher: McpFetch): Promise<OpenWorkConnectSkill[] | null> {
+  const cacheKey = createHash("sha256").update(JSON.stringify(cloud)).digest("hex");
+  const cached = catalogCache.get(cacheKey);
+  if (cached && cached.expiresAt > Date.now()) return await cached.value;
+  const value = readMcpSkillIndex(cloud, fetcher).catch(() => null);
+  catalogCache.set(cacheKey, { expiresAt: Date.now() + CATALOG_CACHE_TTL_MS, value });
+  return await value;
 }
 
+/**
+ * Resolve the skill catalog from the first *working* openwork-cloud config.
+ * Candidates are tried in order: the server-scoped connect-state copy, then
+ * each workspace runtime row (legacy scope). Stale rows — e.g. a revoked token
+ * or a dead local Den URL left behind by an old session — are skipped instead
+ * of shadowing a valid config, and the winning workspace copy is promoted to
+ * server scope so Connect stays account-level.
+ */
 export async function readOpenWorkConnectSkillCatalog(
   config: ServerConfig,
   fetcher: McpFetch = externalFetch,
 ): Promise<OpenWorkConnectSkill[]> {
   try {
-    const cloud = await resolveServerConnectMcpConfig(config);
-    if (!cloud) return [];
-    const cacheKey = createHash("sha256").update(JSON.stringify(cloud)).digest("hex");
-    const cached = catalogCache.get(cacheKey);
-    if (cached && cached.expiresAt > Date.now()) return await cached.value;
-    const value = readMcpSkillIndex(cloud, fetcher);
-    catalogCache.set(cacheKey, { expiresAt: Date.now() + CATALOG_CACHE_TTL_MS, value });
-    try {
-      return await value;
-    } catch (error) {
-      catalogCache.delete(cacheKey);
-      throw error;
+    const serverCloud = await readConnectCloudMcp(config);
+    const candidates: Array<{ cloud: Record<string, unknown>; source: "server" | "workspace" }> = [];
+    if (serverCloud) candidates.push({ cloud: serverCloud, source: "server" });
+    for (const workspace of config.workspaces) {
+      const cloud = await readRuntimeMcpConfig(config, workspace.id, OPENWORK_CLOUD_MCP_NAME);
+      if (cloud) candidates.push({ cloud, source: "workspace" });
     }
+
+    const seen = new Set<string>();
+    for (const candidate of candidates) {
+      const key = JSON.stringify(candidate.cloud);
+      if (seen.has(key)) continue;
+      seen.add(key);
+      const skills = await readIndexCached(candidate.cloud, fetcher);
+      if (skills === null) continue;
+      if (candidate.source === "workspace") {
+        await writeConnectCloudMcp(config, candidate.cloud).catch(() => {
+          // Catalog reads should still succeed even if promotion fails.
+        });
+      }
+      return skills;
+    }
+    return [];
   } catch {
     return [];
   }


### PR DESCRIPTION
## Summary
- Follow-up to #3021: `readMcpSkillIndex` now returns `null` for unusable configs (invalid URL, disabled, 401, protocol errors) instead of an empty catalog, so failure is distinguishable from "no skills".
- `readOpenWorkConnectSkillCatalog` tries candidates in order (server-scoped copy, then workspace rows), skips dead ones, and promotes the first **working** config to server scope — healing a poisoned `connect-state.json` instead of pinning it.
- Root cause found on a real install: a stale workspace row pointing at a dead local Den URL with a revoked token shadowed a valid prod config, so `<available_skills>` injection stayed empty while engine tools still worked.

## Test plan
- [x] `bun test` in `apps/server`: connect-skill-catalog (incl. new revoked-candidate + all-dead cases), connect-state, cloud-mcp-health, gating, extensions-preview — all pass
- [x] `tsc --noEmit` clean
- [x] Live run against the affected machine's real `~/.config/openwork` state: resolves 32 skills from prod Den, skipping two revoked rows


Made with [Cursor](https://cursor.com)