### PR TITLE
fix(ci): survive transient pscale errors in den-db-migrate; recovery mode for skill data migration

### DIFF
--- a/.github/workflows/den-db-migrate.yml
+++ b/.github/workflows/den-db-migrate.yml
@@ -104,10 +104,48 @@ jobs:
       - name: Disable safe migrations (allow DDL for this run only)
         run: |
           set -euo pipefail
-          state="$(pscale branch show "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" --format json | jq -r '.safe_migrations')"
+          pscale_retry() {
+            local attempt err_file error_output output status
+            for attempt in $(seq 1 5); do
+              err_file="$(mktemp)"
+              if output="$("$@" 2>"$err_file")"; then
+                error_output="$(<"$err_file")"
+                rm -f "$err_file"
+                if [ -n "$error_output" ]; then
+                  printf '%s\n' "$error_output" >&2
+                fi
+                printf '%s\n' "$output"
+                return 0
+              else
+                status=$?
+                error_output="$(<"$err_file")"
+                rm -f "$err_file"
+                if [ -n "$output" ]; then
+                  printf '%s\n' "$output" >&2
+                fi
+                if [ -n "$error_output" ]; then
+                  printf '%s\n' "$error_output" >&2
+                fi
+                if [ "$attempt" -lt 5 ]; then
+                  echo "pscale command failed (attempt $attempt/5, exit $status); retrying in 10s..." >&2
+                  sleep 10
+                fi
+              fi
+            done
+            return 1
+          }
+          read_safe_migrations_state() {
+            pscale_retry bash -o pipefail -c 'pscale branch show "$1" "$2" --org "$3" --format json | jq -r ".safe_migrations"' _ "$DATABASE_NAME" "$PLANETSCALE_BRANCH" "$PLANETSCALE_ORG"
+          }
+          if ! state="$(read_safe_migrations_state)"; then
+            state=""
+          fi
           echo "safe_migrations before run: $state"
           if [ "$state" = "true" ]; then
-            pscale branch safe-migrations disable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG"
+            if ! pscale_retry pscale branch safe-migrations disable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG"; then
+              echo "::error::Could not disable safe migrations for $DATABASE_NAME/$PLANETSCALE_BRANCH."
+              exit 1
+            fi
             echo "Safe migrations disabled for the duration of this run."
           elif [ "$state" = "false" ]; then
             echo "Safe migrations already disabled; will re-enable at the end of this run."
@@ -201,10 +239,72 @@ jobs:
         if: always() && steps.setup-pscale.conclusion == 'success'
         run: |
           set -euo pipefail
-          pscale branch safe-migrations enable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG"
-          state="$(pscale branch show "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" --format json | jq -r '.safe_migrations')"
-          echo "safe_migrations after run: $state"
-          if [ "$state" != "true" ]; then
+          pscale_retry() {
+            local attempt err_file error_output output status
+            for attempt in $(seq 1 5); do
+              err_file="$(mktemp)"
+              if output="$("$@" 2>"$err_file")"; then
+                error_output="$(<"$err_file")"
+                rm -f "$err_file"
+                if [ -n "$error_output" ]; then
+                  printf '%s\n' "$error_output" >&2
+                fi
+                printf '%s\n' "$output"
+                return 0
+              else
+                status=$?
+                error_output="$(<"$err_file")"
+                rm -f "$err_file"
+                if [ -n "$output" ]; then
+                  printf '%s\n' "$output" >&2
+                fi
+                if [ -n "$error_output" ]; then
+                  printf '%s\n' "$error_output" >&2
+                fi
+                if [ "$attempt" -lt 5 ]; then
+                  echo "pscale command failed (attempt $attempt/5, exit $status); retrying in 10s..." >&2
+                  sleep 10
+                fi
+              fi
+            done
+            return 1
+          }
+          read_safe_migrations_state() {
+            pscale_retry bash -o pipefail -c 'pscale branch show "$1" "$2" --org "$3" --format json | jq -r ".safe_migrations"' _ "$DATABASE_NAME" "$PLANETSCALE_BRANCH" "$PLANETSCALE_ORG"
+          }
+
+          confirmed="false"
+          for attempt in $(seq 1 5); do
+            echo "Enabling safe migrations (attempt $attempt/5)."
+            if output="$(pscale branch safe-migrations enable "$DATABASE_NAME" "$PLANETSCALE_BRANCH" --org "$PLANETSCALE_ORG" 2>&1)"; then
+              if [ -n "$output" ]; then
+                printf '%s\n' "$output"
+              fi
+            else
+              status=$?
+              if [ -n "$output" ]; then
+                printf '%s\n' "$output" >&2
+              fi
+              echo "pscale enable failed (attempt $attempt/5, exit $status); checking branch state." >&2
+            fi
+
+            if state="$(read_safe_migrations_state)"; then
+              echo "safe_migrations after run: $state"
+              if [ "$state" = "true" ]; then
+                confirmed="true"
+                break
+              fi
+            else
+              echo "Could not verify safe_migrations state after enable attempt $attempt." >&2
+            fi
+
+            if [ "$attempt" -lt 5 ]; then
+              echo "Safe migrations not confirmed enabled yet; retrying in 10s..."
+              sleep 10
+            fi
+          done
+
+          if [ "$confirmed" != "true" ]; then
             echo "::error::Safe migrations is NOT re-enabled on $DATABASE_NAME/$PLANETSCALE_BRANCH. Re-enable it manually: pscale branch safe-migrations enable $DATABASE_NAME $PLANETSCALE_BRANCH --org $PLANETSCALE_ORG"
             exit 1
           fi

--- a/ee/apps/den-api/scripts/migrate-skills-to-plugins.ts
+++ b/ee/apps/den-api/scripts/migrate-skills-to-plugins.ts
@@ -11,6 +11,16 @@
  * Usage:
  *   pnpm --filter @openwork-ee/den-api migrate:skills-to-plugins        # dry run
  *   pnpm --filter @openwork-ee/den-api migrate:skills-to-plugins -- --yes
+ *
+ * Incident recovery after the legacy tables have already been dropped:
+ *   1. Restore a PlanetScale backup to a branch.
+ *   2. Copy skill, skill_hub, skill_hub_skill, and skill_hub_member into main
+ *      under a prefix such as recovered_ (for example, recovered_skill).
+ *   3. Run against production using the PlanetScale serverless driver over HTTPS
+ *      (DATABASE_URL is NOT reachable externally):
+ *      DATABASE_HOST=... DATABASE_USERNAME=... DATABASE_PASSWORD=... DEN_DB_ENCRYPTION_KEY=... \
+ *        pnpm --filter @openwork-ee/den-api migrate:skills-to-plugins -- --table-prefix recovered_ --yes
+ *   4. Drop the recovered_* tables after verifying the migrated plugins.
  */
 import { createDenDb, type DenDbMode } from "@openwork-ee/den-db"
 import { and, asc, eq, isNull, sql } from "@openwork-ee/den-db/drizzle"
@@ -32,6 +42,7 @@ import {
   DEFAULT_OPENWORK_MARKETPLACE_NAME,
 } from "../src/routes/org/plugin-system/default-marketplaces.js"
 
+const tablePrefix = resolveTablePrefix()
 const { db } = createDenDb(resolveDbConfig())
 
 type DbTransaction = Parameters<Parameters<typeof db.transaction>[0]>[0]
@@ -70,9 +81,31 @@ type Summary = {
   skipped: number
 }
 
+type LegacyTableName = "skill" | "skill_hub" | "skill_hub_skill" | "skill_hub_member"
+
 function parseDbMode(value: string | undefined): DenDbMode | undefined {
   if (value === "mysql" || value === "planetscale") return value
   return undefined
+}
+
+function cliValue(flag: string) {
+  const index = process.argv.indexOf(flag)
+  if (index === -1) return null
+  const value = process.argv[index + 1]
+  if (value === undefined || value.startsWith("--")) throw new Error(`${flag} requires a value.`)
+  return value
+}
+
+function resolveTablePrefix() {
+  const prefix = cliValue("--table-prefix") ?? process.env.SKILL_MIGRATION_TABLE_PREFIX ?? ""
+  if (!/^[a-z0-9_]*$/.test(prefix)) {
+    throw new Error("--table-prefix/SKILL_MIGRATION_TABLE_PREFIX may only contain lowercase letters, digits, and underscores.")
+  }
+  return prefix
+}
+
+function legacyTable(name: LegacyTableName) {
+  return sql.raw(`${tablePrefix}${name}`)
 }
 
 function resolveDbConfig() {
@@ -146,7 +179,7 @@ async function legacyRows(query: ReturnType<typeof sql>) {
 async function legacySkills(): Promise<LegacySkillRow[]> {
   const rows = await legacyRows(sql`
     select id, organization_id, created_by_org_membership_id, title, description, skill_text, shared, created_at, updated_at
-    from skill
+    from ${legacyTable("skill")}
     order by created_at asc, id asc
   `)
   return rows.map((row) => ({
@@ -163,12 +196,12 @@ async function legacySkills(): Promise<LegacySkillRow[]> {
 }
 
 async function legacyHubs(): Promise<LegacyHubRow[]> {
-  const rows = await legacyRows(sql`select id from skill_hub`)
+  const rows = await legacyRows(sql`select id from ${legacyTable("skill_hub")}`)
   return rows.map((row) => ({ id: requiredString(row, "id") }))
 }
 
 async function legacyHubSkills(): Promise<LegacyHubSkillRow[]> {
-  const rows = await legacyRows(sql`select id, skill_hub_id, skill_id from skill_hub_skill`)
+  const rows = await legacyRows(sql`select id, skill_hub_id, skill_id from ${legacyTable("skill_hub_skill")}`)
   return rows.map((row) => ({
     id: requiredString(row, "id"),
     skillHubId: requiredString(row, "skill_hub_id"),
@@ -177,7 +210,7 @@ async function legacyHubSkills(): Promise<LegacyHubSkillRow[]> {
 }
 
 async function legacyHubMembers(): Promise<LegacyHubMemberRow[]> {
-  const rows = await legacyRows(sql`select id, skill_hub_id, org_membership_id, team_id from skill_hub_member`)
+  const rows = await legacyRows(sql`select id, skill_hub_id, org_membership_id, team_id from ${legacyTable("skill_hub_member")}`)
   return rows.map((row) => ({
     id: requiredString(row, "id"),
     orgMembershipId: optionalStringField(row, "org_membership_id"),


### PR DESCRIPTION
## Incident (today, 06:26Z)

Merging #3025 auto-ran `den-db-migrate` (run 29985067260):

1. Safe migrations disabled → DDL probes OK → `0045_drop_skill_hub.sql` **applied successfully** (legacy `skill*` tables dropped in prod).
2. The final **Re-enable safe migrations** step died instantly: `pscale branch safe-migrations enable` → `Error: An unexpected error occurred. Please try again or contact support.` (transient PlanetScale API flake, single-shot under `set -euo pipefail`).
3. Result: red run + **prod `main` left with safe migrations disabled** until I re-ran the failed job (`gh run rerun 29985067260 --failed`) — rerun is green and logged `safe_migrations after run: true`. Verified prod den-api serves the new spec (207 paths, 0 skill routes).

Separately, the manual data migration from #3025 was **not run before the merge**, so legacy skill rows were dropped un-migrated. Verified via prod DB (Infisical creds, read-only): `skill*` tables gone, `0045` recorded, **163 orphaned `openwork.den_skill.v1` pointer versions** (GitHub-imported skill content lived only in the dropped `skill.skill_text`), 1600 connector + 219 cloud skill config objects unaffected (content in `raw_source_text`), 285 bootstrap starter skills dropped (deterministic, regenerable).

## Fixes

- **`den-db-migrate.yml`**: retry wrapper (5 attempts / 10s backoff) around the pscale state reads and the safe-migrations disable/enable; the re-enable step now treats **branch state as the source of truth** — it verifies `safe_migrations` after every attempt (the API call can error after taking effect) and only fails with the manual-command error after the full budget. DDL probe loop untouched.
- **`migrate-skills-to-plugins.ts`**: `--table-prefix` / `SKILL_MIGRATION_TABLE_PREFIX` (validated `[a-z0-9_]*`, applied to the four legacy table reads only) so the migration can consume **backup-restored copies** (`recovered_skill`, …) now that canonical tables are gone; header documents the recovery runbook.

## Recovery runbook (operator action still needed)

1. PlanetScale dashboard → `openword-den`/`main` backups → restore the last backup **before 2026-07-23 06:28 UTC** to a new branch.
2. Copy `skill`, `skill_hub`, `skill_hub_skill`, `skill_hub_member` into `main` as `recovered_*`.
3. `DATABASE_HOST/USERNAME/PASSWORD` (PlanetScale HTTPS driver; internal `DATABASE_URL` is not reachable externally) + `DEN_DB_ENCRYPTION_KEY` (lives in the den-api runtime env, not Infisical):
   `pnpm --filter @openwork-ee/den-api migrate:skills-to-plugins -- --table-prefix recovered_` (dry run) then `-- --table-prefix recovered_ --yes`
4. Drop the `recovered_*` tables.

## Tests run

- PyYAML parse of the workflow (valid).
- `tsc --noEmit` on the migration script (pass), `pnpm --filter @openwork-ee/den-api build` (pass).
- No runtime app surface changes (CI workflow + ops script only), so no fraimz; the canonical core flow was proven green on #3025 yesterday and this PR does not touch the app.
