### PR TITLE
fix(den): unrestricted installer downloads follow the latest published release — no 404s during release windows

### DIFF
--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -461,6 +461,7 @@ export const env = {
   // Standard desktop release assets: the release tag to download from,
   // defaulting to the pinned app release this den-api build shipped with.
   installerReleaseTag: optionalString(parsed.OPENWORK_INSTALLER_RELEASE_TAG) ?? `v${denApiAppVersion.latestAppVersion}`,
+  installerReleaseTagExplicit: optionalString(parsed.OPENWORK_INSTALLER_RELEASE_TAG) !== undefined,
   installerReleaseRepo: optionalString(parsed.OPENWORK_INSTALLER_RELEASE_REPO) ?? "different-ai/openwork",
   installerCacheDir: optionalString(parsed.OPENWORK_INSTALLER_CACHE_DIR) ?? path.join(os.tmpdir(), "openwork-desktop-artifacts"),
   // Native-provider endpoint overrides for evals/self-host testing. Unset in

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -28,6 +28,7 @@ import {
   DEFAULT_INSTALLER_RELEASE_REPO,
   FIRST_GENERIC_INSTALLER_RELEASE,
   genericInstallerArtifactName,
+  installerLatestReleaseAssetUrl,
   installerReleaseAssetUrl,
   resolveConfiguredInstallerArtifact,
 } from "../../utils/installer-artifacts.js"
@@ -226,6 +227,9 @@ function installerReleaseTagForMetadata(metadataInput: unknown) {
   const metadata = normalizeOrganizationMetadata(organizationMetadataInput(metadataInput)).metadata
   const allowedVersions = metadata.allowedDesktopVersions
   if (!allowedVersions?.length) {
+    if (env.installerReleaseRepo === DEFAULT_INSTALLER_RELEASE_REPO && !env.installerReleaseTagExplicit) {
+      return null
+    }
     return clampInstallerReleaseTag(env.installerReleaseTag)
   }
 
@@ -519,7 +523,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
     describeRoute({
       tags: ["Organizations"],
       summary: "Download OpenWork installer",
-      description: "Always serves the OpenWork installer for the requested platform. By default Den redirects to the public release asset; operators can optionally mount installer artifacts for an air-gapped mirror.",
+      description: "Always serves the OpenWork installer for the requested platform. By default Den redirects to the public release asset; unrestricted official-repo organizations follow the latest published release. Operators can optionally mount installer artifacts for an air-gapped mirror.",
       responses: {
         200: textResponse("Installer artifact returned successfully."),
         302: emptyResponse("Den redirected the browser to the public OpenWork installer release asset."),
@@ -577,6 +581,11 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
 
       if (!genericFileName) {
         return c.json({ error: "invalid_request", details: [{ message: "Unsupported installer platform." }] }, 400)
+      }
+
+      if (resolved.installerReleaseTag === null) {
+        // Follow GitHub's latest published release so draft-release windows cannot 404.
+        return c.redirect(installerLatestReleaseAssetUrl(genericFileName), 302)
       }
 
       return c.redirect(installerReleaseAssetUrl(genericFileName, { releaseTag: resolved.installerReleaseTag }), 302)

--- a/ee/apps/den-api/src/utils/installer-artifacts.ts
+++ b/ee/apps/den-api/src/utils/installer-artifacts.ts
@@ -22,6 +22,16 @@ export function installerReleaseAssetUrl(
   return `https://github.com/${releaseRepo}/releases/download/${encodeURIComponent(releaseTag)}/${encodeURIComponent(fileName)}`
 }
 
+export function installerLatestReleaseAssetUrl(
+  fileName: string,
+  options: { releaseRepo?: string } = {},
+) {
+  const releaseRepo = options.releaseRepo ?? env.installerReleaseRepo
+  // GitHub latest only flips when publish-release un-drafts, which is gated on installer assets,
+  // so this URL cannot 404 during a release window.
+  return `https://github.com/${releaseRepo}/releases/latest/download/${encodeURIComponent(fileName)}`
+}
+
 export function desktopReleaseAssetName(platform: string, releaseTag: string) {
   const version = releaseTag.startsWith("v") ? releaseTag.slice(1) : releaseTag
   if (platform === "mac-arm64" || platform === "mac-x64") {

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -23,6 +23,7 @@ const installLinkId = createDenTypeId("installLink")
 const insertedRows: unknown[] = []
 const revokedRows: unknown[] = []
 const officialWindowsInstallerUrl = "https://github.com/different-ai/openwork/releases/download/v9.9.9/OpenWork-Installer-win-x64.exe"
+const latestOfficialWindowsInstallerUrl = "https://github.com/different-ai/openwork/releases/latest/download/OpenWork-Installer-win-x64.exe"
 const connectKeyPair = generateConnectLinkKeyPair()
 const connectKeyId = "owc-route-test"
 
@@ -159,6 +160,7 @@ beforeEach(() => {
   envModule.env.installerArtifactsDir = undefined
   envModule.env.installerReleaseRepo = "different-ai/openwork"
   envModule.env.installerReleaseTag = "v9.9.9"
+  envModule.env.installerReleaseTagExplicit = true
   insertedRows.length = 0
   revokedRows.length = 0
   role = "member"
@@ -470,6 +472,58 @@ test("unrestricted organizations use Den's configured installer release tag", as
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
+test("unrestricted organizations on the official repo follow the latest published release", async () => {
+  envModule.env.installerReleaseTagExplicit = false
+  organizationMetadata = {
+    ...defaultOrganizationMetadata(),
+    allowedDesktopVersions: [],
+  }
+
+  const response = await createApp().request("http://den.local/v1/install/win-x64?token=opaque-token", {
+    redirect: "manual",
+  })
+
+  expect(response.status).toBe(302)
+  expect(response.headers.get("location")).toBe(latestOfficialWindowsInstallerUrl)
+  expect(response.headers.get("location")).not.toContain("v9.9.9")
+  expect(response.headers.get("location")).not.toContain("opaque-token")
+})
+
+test("organization version pins stay tag-pinned even without an explicit installer tag", async () => {
+  envModule.env.installerReleaseTagExplicit = false
+  organizationMetadata = {
+    ...defaultOrganizationMetadata(),
+    allowedDesktopVersions: ["0.17.37", "0.17.39"],
+  }
+
+  const response = await createApp().request("http://den.local/v1/install/win-x64?token=opaque-token", {
+    redirect: "manual",
+  })
+
+  expect(response.status).toBe(302)
+  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.39/OpenWork-Installer-win-x64.exe")
+  expect(response.headers.get("location")).not.toContain("/releases/latest/")
+  expect(response.headers.get("location")).not.toContain("opaque-token")
+})
+
+test("custom release repos never use the latest-release URL", async () => {
+  envModule.env.installerReleaseTagExplicit = false
+  envModule.env.installerReleaseRepo = "acme/openwork"
+  organizationMetadata = {
+    ...defaultOrganizationMetadata(),
+    allowedDesktopVersions: [],
+  }
+
+  const response = await createApp().request("http://den.local/v1/install/win-x64?token=opaque-token", {
+    redirect: "manual",
+  })
+
+  expect(response.status).toBe(302)
+  expect(response.headers.get("location")).toBe("https://github.com/acme/openwork/releases/download/v9.9.9/OpenWork-Installer-win-x64.exe")
+  expect(response.headers.get("location")).not.toContain("/releases/latest/")
+  expect(response.headers.get("location")).not.toContain("opaque-token")
+})
+
 test("install token organization policy applies to member and admin downloads", async () => {
   organizationMetadata = {
     ...defaultOrganizationMetadata(),
@@ -489,6 +543,7 @@ test("install token organization policy applies to member and admin downloads", 
 })
 
 test("below-floor configured installer release tags are clamped for unrestricted official downloads", async () => {
+  envModule.env.installerReleaseTagExplicit = true
   envModule.env.installerReleaseTag = "v0.17.27"
   organizationMetadata = {
     ...defaultOrganizationMetadata(),

--- a/evals/flows/den-download-link-match-allowed-versions.flow.mjs
+++ b/evals/flows/den-download-link-match-allowed-versions.flow.mjs
@@ -4,8 +4,7 @@ const FLOW_ID = "den-download-link-match-allowed-versions";
 const DEN_API_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_API_URL);
 const DEN_TOKEN = process.env.OPENWORK_EVAL_DEN_TOKEN?.trim() || "";
 const MEMBER_TOKEN = process.env.OPENWORK_EVAL_MEMBER_DEN_TOKEN?.trim() || DEN_TOKEN;
-const DEFAULT_RELEASE_TAG = process.env.OPENWORK_EVAL_DEFAULT_INSTALLER_RELEASE_TAG?.trim() || "v0.17.39";
-const DEFAULT_RELEASE_VERSION = DEFAULT_RELEASE_TAG.replace(/^v/i, "");
+const LATEST_WINDOWS_INSTALLER_URL = "https://github.com/different-ai/openwork/releases/latest/download/OpenWork-Installer-win-x64.exe";
 const ALLOWED_VERSIONS = ["0.17.37", "0.17.38"];
 const SELECTED_VERSION = "0.17.38";
 const DISALLOWED_VERSION = "0.17.39";
@@ -218,9 +217,9 @@ export default {
       },
     },
     {
-      name: "Frame 5 — Unrestricted org keeps Den default",
+      name: "Frame 5 — Unrestricted orgs follow the latest published release",
       run: async (ctx) => {
-        await ctx.prove("Removing the allowed-version restriction restores Den's configured installer release", {
+        await ctx.prove("Removing the allowed-version restriction redirects to GitHub's latest published installer", {
           voiceover: vo[4],
           action: async () => {
             await setAllowedDesktopVersions(ctx, null);
@@ -228,8 +227,8 @@ export default {
             state.unrestrictedDownload = await fetchInstallerDownload(state.unrestrictedInstallToken);
           },
           assert: async () => {
-            witness(ctx, [200, 302].includes(state.unrestrictedDownload.status), "The unrestricted installer endpoint returns a download or redirect", state.unrestrictedDownload);
-            witness(ctx, downloadMentionsVersion(state.unrestrictedDownload, DEFAULT_RELEASE_VERSION), `The unrestricted download uses Den's configured ${DEFAULT_RELEASE_TAG} release`, state.unrestrictedDownload);
+            witness(ctx, state.unrestrictedDownload.status === 302, "The unrestricted installer endpoint redirects to GitHub", state.unrestrictedDownload);
+            witness(ctx, state.unrestrictedDownload.location === LATEST_WINDOWS_INSTALLER_URL, "The unrestricted download follows the latest published installer release", state.unrestrictedDownload);
           },
         });
       },

--- a/evals/voiceovers/den-download-link-match-allowed-versions.md
+++ b/evals/voiceovers/den-download-link-match-allowed-versions.md
@@ -10,4 +10,4 @@ The organization-wide desktop version policy applies to every member who uses th
 
 4. If an admin pins legacy versions 0.17.26 and 0.17.27, the guided installer still downloads v0.17.37—the first release that has installer assets—instead of pointing at the missing v0.17.27 asset.
 
-5. Organizations without version restrictions continue downloading Den’s configured latest release.
+5. Organizations without version restrictions follow GitHub’s latest published installer release, avoiding draft-release download windows.


### PR DESCRIPTION
## Follow-up to #3020 — the release-window 404

#3020 fixed the *permanent* 404 (org pinned below v0.17.37, a tag with no installer assets). This PR fixes the *release-window* 404: **"when a new version is being released and we click Download for [platform], we see a 404 on GitHub."**

### Why it happens
- Tag-triggered releases are created as **drafts** and only published after `publish-release` verifies assets (incl. `publish-installers` — a hard `needs`). Draft-release assets are not publicly downloadable, so `releases/download/v0.17.40/...` 404s until publish.
- But dens get pinned to the new version **before** publish: the version-bump commit lands on dev first, hosted den deploys race the release (self-hosted deploy buttons too). During that window `GET /v1/install/:platform` 302'd into the draft → GitHub 404.

### The fix
`https://github.com/different-ai/openwork/releases/latest/download/OpenWork-Installer-<platform>.<ext>` only flips when publish-release un-drafts — which is gated on installer assets — so it **cannot 404 mid-release**. Mid-window users get the previous published installer, which is correct: the installer binary is version-agnostic (it installs whatever app version the den's `/v1/app-version` pins).

Redirect decision matrix (`/v1/install/:platform`):

| repo | org allowlist | `OPENWORK_INSTALLER_RELEASE_TAG` | redirect |
|---|---|---|---|
| official | — (empty) | unset (derived default) | **`releases/latest/download/...`** (new) |
| official | non-empty | any | `v<max allowed>` clamped to v0.17.37 floor (#3020, unchanged) |
| official | — (empty) | explicitly set | that tag, clamped (unchanged — operator pinning honored) |
| custom | any | any | tag-pinned, unclamped (unchanged) |

## Proof

- fraimz `den-download-link-match-allowed-versions` — **PASSED 5/5** against a real den stack running this branch; Frame 5 asserts the 302 location **exactly equals** the latest-URL (self-authenticating: pre-change code emits tag URLs, so a stale server cannot fake this frame). Proof comment posted below via `--pr`.
- Live check: `curl -IL .../releases/latest/download/OpenWork-Installer-win-x64.exe` → **HTTP 200** (resolves to the signed v0.17.39 asset today).

## Tests run

- `cd ee/apps/den-api && bun test test/install-link-access.test.ts test/installer-artifacts.test.ts` → **44 pass / 0 fail** (+3: latest-URL for unrestricted, tag-pinned survives without explicit tag when allowlisted, custom repos never use latest)
- `pnpm exec tsc --noEmit -p ee/apps/den-api` → clean
- `node --check evals/flows/den-download-link-match-allowed-versions.flow.mjs` → clean

## Residual (accepted)
- Version-pinned orgs that approve a brand-new version *minutes before* its release publishes still hit a short tag-pinned window; narrow, self-inflicted, self-healing.
- Fresh dispatch-created releases with `draft=false` publish before assets attach; operator-recovery edge, unchanged by this PR.
