### PR TITLE
fix(release): retry notarization stapling to survive transient Apple CloudKit failures

### DIFF
--- a/.github/workflows/build-client-installer.yml
+++ b/.github/workflows/build-client-installer.yml
@@ -288,7 +288,12 @@ jobs:
             --key-id "$APPLE_NOTARY_API_KEY_ID" \
             --issuer "$APPLE_NOTARY_API_ISSUER_ID" \
             --wait
-          xcrun stapler staple "$APP"
+          for attempt in 1 2 3 4 5; do
+            if xcrun stapler staple "$APP"; then break; fi
+            if [ "$attempt" -eq 5 ]; then echo "stapler staple failed after 5 attempts" >&2; exit 1; fi
+            echo "stapler staple failed (attempt $attempt/5); retrying in $((attempt * 30))s..."
+            sleep $((attempt * 30))
+          done
 
       - name: Package macOS artifact
         if: matrix.os_type == 'macos'

--- a/.github/workflows/release-generic-installer.yml
+++ b/.github/workflows/release-generic-installer.yml
@@ -231,6 +231,16 @@ jobs:
           APPLE_NOTARY_API_ISSUER_ID: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
         run: |
           set -euo pipefail
+          staple_with_retry() {
+            local target="$1"
+            for attempt in 1 2 3 4 5; do
+              if xcrun stapler staple "$target"; then break; fi
+              if [ "$attempt" -eq 5 ]; then echo "stapler staple failed after 5 attempts" >&2; exit 1; fi
+              echo "stapler staple failed (attempt $attempt/5); retrying in $((attempt * 30))s..."
+              sleep $((attempt * 30))
+            done
+          }
+
           missing=()
           for name in \
             APPLE_CODESIGN_CERT_P12_BASE64 \
@@ -293,7 +303,7 @@ jobs:
             --key-id "$APPLE_NOTARY_API_KEY_ID" \
             --issuer "$APPLE_NOTARY_API_ISSUER_ID" \
             --wait
-          xcrun stapler staple "$APP"
+          staple_with_retry "$APP"
 
           mkdir -p "$RUNNER_TEMP/out"
           DMG="$RUNNER_TEMP/out/${{ matrix.asset }}"
@@ -306,7 +316,7 @@ jobs:
             --key-id "$APPLE_NOTARY_API_KEY_ID" \
             --issuer "$APPLE_NOTARY_API_ISSUER_ID" \
             --wait
-          xcrun stapler staple "$DMG"
+          staple_with_retry "$DMG"
           xcrun stapler validate "$DMG"
 
       # --- Windows: optional SignPath signing --------------------------------

--- a/apps/desktop/scripts/electron-after-sign.cjs
+++ b/apps/desktop/scripts/electron-after-sign.cjs
@@ -12,6 +12,21 @@ function run(command, args) {
   }
 }
 
+async function runWithRetry(command, args, attempts, baseDelayMs = 30_000) {
+  for (let attempt = 1; ; attempt++) {
+    const result = spawnSync(command, args, { stdio: "inherit" });
+    if (result.status === 0) return;
+    if (attempt >= attempts) {
+      throw new Error(`${command} ${args.join(" ")} failed with status ${result.status} after ${attempts} attempts`);
+    }
+    const delayMs = baseDelayMs * attempt;
+    console.warn(
+      `[electron-after-sign] ${command} ${args.join(" ")} failed with status ${result.status}; retrying in ${delayMs / 1000}s (attempt ${attempt}/${attempts}).`,
+    );
+    await new Promise((resolve) => setTimeout(resolve, delayMs));
+  }
+}
+
 function requireEnv(name) {
   const value = process.env[name];
   if (!value) {
@@ -75,7 +90,8 @@ async function afterSign(context) {
       issuer,
       "--wait",
     ]);
-    run("xcrun", ["stapler", "staple", appPath]);
+    // Notarization tickets can take minutes to propagate to Apple's CDN after acceptance; stapler can transiently fail with status 65 ("CloudKit query failed").
+    await runWithRetry("xcrun", ["stapler", "staple", appPath], 5);
     run("xcrun", ["stapler", "validate", appPath]);
   } finally {
     rmSync(notaryTempDir, { recursive: true, force: true });
@@ -84,3 +100,4 @@ async function afterSign(context) {
 
 module.exports = afterSign;
 module.exports.default = afterSign;
+module.exports.runWithRetry = runWithRetry;


### PR DESCRIPTION
## What broke

[Alpha Channel (macOS arm64) run #1816](https://github.com/different-ai/openwork/actions/runs/29991986911) failed **after** notarization was `Accepted`:

```
Processing complete
  id: f78494f7-f49f-4c62-aba3-439e6b2c2f7e
  status: Accepted
...
CloudKit query for OpenWork.app (2/46fa0e6a...) failed due to "(null)".
Could not find base64 encoded ticket in response
The staple and validate action failed! Error 65.
```

This is the well-known transient Apple failure: the notarization ticket can take minutes to propagate to Apple's CDN after acceptance, and `xcrun stapler staple` fails with status 65 until it does. Our scripts stapled exactly once with no retry, so a single Apple hiccup killed the release (runs immediately before and after succeeded on the same code path).

## Fix

Retry stapling with linear backoff (5 attempts, 30/60/90/120s waits ≈ 5 min propagation window) everywhere we staple:

- `apps/desktop/scripts/electron-after-sign.cjs` — the shared electron-builder `afterSign` hook used by the **alpha and stable** desktop channels (the site that actually failed). New `runWithRetry` helper; `stapler validate` stays single-shot since it reads the locally stapled ticket.
- `.github/workflows/release-generic-installer.yml` — same latent flaw at 2 call sites (`$APP`, `$DMG`); added a `staple_with_retry` function in the same step.
- `.github/workflows/build-client-installer.yml` — same latent flaw at 1 call site.

`notarytool submit --wait` semantics are unchanged; only the staple step retries.

## Tests run

- `node --check apps/desktop/scripts/electron-after-sign.cjs` — passed.
- Harness against the real module (`runWithRetry` is exported for testability): module shape (`exports === exports.default`, callable), non-darwin early return, `MACOS_NOTARIZE` skip path, **retry-then-succeed** (command fails with status 65 once, succeeds on attempt 2 — invocation counter verified exactly 2 runs), **exhaustion** (`false` with 2 attempts rejects with `failed with status 1 after 2 attempts`). Output:
  ```
  [electron-after-sign] MACOS_NOTARIZE is not true; skipping notarization.
  [electron-after-sign] bash -c ... failed with status 65; retrying in 0.05s (attempt 1/5).
  [electron-after-sign] false  failed with status 1; retrying in 0.01s (attempt 1/2).
  staple retry harness passed
  ```
- `actionlint` on both workflows — no new findings (one pre-existing SC2016 info at `build-client-installer.yml:154`, untouched by this PR).
- YAML parse check on both workflows — OK.
- `bash -n` on the extracted edited step bodies — OK.

## End-to-end evidence / fraimz

This change is CI-release-infrastructure only (electron-builder afterSign hook + workflow bash); there is no app UI/runtime path to drive, so no fraimz/video — the real end-to-end validation is the next alpha publish on `dev` after merge, which exercises `electron-after-sign.cjs` on every push. Reviewer repro of the flake: Apple stapler error 65 / "CloudKit query failed" immediately after `Accepted` notarization is documented Apple-side transience; the retry schedule mirrors the standard remediation (wait a few minutes, staple again).

Channel status meanwhile: the failed run's rerun was superseded (workflow `cancel-in-progress`) by the next dev push, which republished alpha successfully.
