### PR TITLE
feat(app): show chat attachments as expandable inline badges

### DIFF
--- a/apps/app/src/components/chat/image-attachment-badge.tsx
+++ b/apps/app/src/components/chat/image-attachment-badge.tsx
@@ -1,0 +1,69 @@
+import * as React from "react"
+import { X } from "lucide-react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { cn } from "@/lib/utils"
+
+type ImageAttachmentBadgeProps = {
+  src: string
+  alt: string
+  onRemove?: () => void
+  className?: string
+}
+
+export function ImageAttachmentBadge({
+  src,
+  alt,
+  onRemove,
+  className,
+}: ImageAttachmentBadgeProps) {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <div className={cn("relative inline-flex shrink-0", className)}>
+      <button
+        type="button"
+        className="h-10 w-10 overflow-hidden rounded-xl border border-border/70 bg-background/50 transition-opacity hover:opacity-90"
+        onClick={() => setOpen(true)}
+        aria-label={`Expand ${alt}`}
+        title={alt}
+      >
+        <img
+          src={src}
+          alt={alt}
+          loading="lazy"
+          decoding="async"
+          className="h-full w-full object-cover"
+        />
+      </button>
+      {onRemove ? (
+        <button
+          type="button"
+          className="absolute -right-1.5 -top-1.5 inline-flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground"
+          onClick={(event) => {
+            event.stopPropagation()
+            onRemove()
+          }}
+          aria-label={`Remove ${alt}`}
+          title="Remove"
+        >
+          <X className="size-3" />
+        </button>
+      ) : null}
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[90vh] w-auto max-w-[min(90vw,56rem)] overflow-hidden border-none bg-transparent p-0 shadow-none sm:max-w-[min(90vw,56rem)]">
+          <DialogTitle className="sr-only">{alt}</DialogTitle>
+          <img
+            src={src}
+            alt={alt}
+            className="max-h-[85vh] w-auto max-w-full rounded-xl object-contain"
+          />
+        </DialogContent>
+      </Dialog>
+    </div>
+  )
+}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -53,6 +53,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
+import { ImageAttachmentBadge } from "@/components/chat/image-attachment-badge"
 import { Image } from "@/components/ui/image"
 import {
   Message,
@@ -226,11 +227,10 @@ interface FileMessageProps {
   tone: "user" | "assistant"
 }
 
-// TODO: Add tone to the file message
-function FileMessage({ part }: FileMessageProps) {
+function FileMessage({ part, tone }: FileMessageProps) {
   const title = getFileTitle(part)
   const badge = getMediaBadge(part)
-  const isImage = part.mediaType.startsWith("image/") && part.url
+  const isImage = part.mediaType.startsWith("image/") && Boolean(part.url)
   const downloadUrl = getSafeFileDownloadUrl(part)
 
   const handleDownload = React.useCallback(() => {
@@ -244,6 +244,10 @@ function FileMessage({ part }: FileMessageProps) {
     anchor.remove()
   }, [downloadUrl, title])
 
+  if (isImage && tone === "user") {
+    return <ImageAttachmentBadge src={part.url} alt={title} />
+  }
+
   if (isImage) {
     return (
       <Image
@@ -251,20 +255,23 @@ function FileMessage({ part }: FileMessageProps) {
         alt={title}
         loading="lazy"
         decoding="async"
+        previewMaxWidth={280}
+        previewMaxHeight={160}
+        className="rounded-xl border border-border/70"
       />
     )
   }
 
   return (
-    <div className="flex h-auto w-fit min-w-0 max-w-full shrink items-center justify-start gap-2 rounded-xl border border-border ps-2 pe-2 py-1 text-left text-sm font-medium whitespace-normal">
+    <div className="flex h-auto w-fit min-w-0 max-w-full shrink items-center justify-start gap-2 rounded-xl border border-border/70 bg-background/40 ps-2 pe-2 py-1 text-left text-sm font-medium whitespace-normal">
       <div className="flex min-w-0 items-center gap-2 pe-2">
         <DescriptiveButtonIcon>
-          <FileIcon className="size-6 shrink-0" />
+          <FileIcon className="size-5 shrink-0" />
         </DescriptiveButtonIcon>
         <DescriptiveButtonContent className="gap-0">
-          <DescriptiveButtonTitle>{title}</DescriptiveButtonTitle>
+          <DescriptiveButtonTitle className="truncate text-xs">{title}</DescriptiveButtonTitle>
           {badge ? (
-            <DescriptiveButtonDescription className="text-xs">
+            <DescriptiveButtonDescription className="text-[10px]">
               {badge}
             </DescriptiveButtonDescription>
           ) : null}
@@ -376,7 +383,7 @@ const AssistantMessage = React.memo(
 
             if (group.kind === "file") {
               return (
-                <div key={`file-${index}`} className="w-full">
+                <div key={`file-${index}`} className="w-fit max-w-full">
                   <FileMessage part={group.part} tone="assistant" />
                 </div>
               )
@@ -462,6 +469,11 @@ const UserMessage = React.memo(
   ({ message, isStreaming }: UserMessageProps) => {
     const { onRevertToUserMessage, onForkAtMessage, onEditUserMessage, highlightQuery } = useMessageList()
     const messageText = React.useMemo(() => getMessagesText([message]), [message])
+    const inlineParts = React.useMemo(
+      () => message.parts.filter((part) => (part.type === "text" && Boolean(part.text)) || isFileUIPart(part)),
+      [message.parts],
+    )
+    const hasContent = inlineParts.length > 0
 
     return (
       <Message
@@ -471,17 +483,38 @@ const UserMessage = React.memo(
       >
         <ContextMenu>
           <ContextMenuTrigger
+            // Override Trigger's select-none so user bubbles stay copyable.
+            className="!select-text"
             render={
-              <div className="group flex w-full flex-col items-end gap-1">
-                {message.parts.filter(isFileUIPart).map((part, index) => (
-                  <FileMessage key={`${part.url}-${index}`} part={part} tone="user" />
-                ))}
-                {message.parts.some((part) => part.type === "text" && part.text) ? (
+              <div
+                className="group flex w-full flex-col items-end gap-1 !select-text"
+                style={{ userSelect: "text" }}
+              >
+                {hasContent ? (
                   <MessageContent
-                    layoutId={message.id}
-                    className="bg-muted text-foreground max-w-[85%] rounded-3xl px-5 py-2.5 whitespace-pre-wrap sm:max-w-[75%]"
+                    className="bg-muted text-foreground max-w-[85%] rounded-3xl px-4 py-2.5 leading-6 sm:max-w-[75%] !select-text not-prose"
+                    style={{ userSelect: "text" }}
                   >
-                    {renderUserTextWithSkillChips(message.parts.map((part) => (part.type === "text" ? part.text : "")).join(""), highlightQuery)}
+                    {inlineParts.map((part, index) => {
+                      if (part.type === "text") {
+                        return (
+                          <span key={`text-${index}`} className="whitespace-pre-wrap">
+                            {renderUserTextWithSkillChips(part.text, highlightQuery)}
+                          </span>
+                        )
+                      }
+                      if (isFileUIPart(part)) {
+                        return (
+                          <span
+                            key={`file-${part.url}-${index}`}
+                            className="mx-1 inline-flex align-middle not-prose"
+                          >
+                            <FileMessage part={part} tone="user" />
+                          </span>
+                        )
+                      }
+                      return null
+                    })}
                   </MessageContent>
                 ) : null}
                 {!isStreaming && (

--- a/apps/app/src/components/markdown/markdown-primitive.ts
+++ b/apps/app/src/components/markdown/markdown-primitive.ts
@@ -35,7 +35,8 @@ type MarkdownProfile = {
   shikiTheme: ShikiThemeConfig;
 };
 
-const MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT = 100;
+const MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT = 160;
+const MARKDOWN_IMAGE_PREVIEW_MAX_WIDTH = 280;
 const CODE_COPY_ICON = `<svg data-openwork-code-copy-icon="" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-3.5 w-3.5" aria-hidden="true"><rect width="14" height="14" x="8" y="8" rx="2" ry="2"/><path d="M4 16c-1.1 0-2-.9-2-2V4c0-1.1.9-2 2-2h10c1.1 0 2 .9 2 2"/></svg>`;
 const CODE_COPIED_ICON = `<svg data-openwork-code-copy-check-icon="" xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" class="h-3.5 w-3.5" aria-hidden="true" hidden><path d="M20 6 9 17l-5-5"/></svg>`;
 
@@ -132,13 +133,10 @@ export function hasFencedCodeBlock(text: string) {
   return /(^|\n)```/.test(text);
 }
 
-function estimatedRenderedImageHeight(image: HTMLImageElement) {
-  if (!image.naturalWidth || !image.naturalHeight) return 0;
-
-  const renderedWidth = image.clientWidth || image.getBoundingClientRect().width;
-  return renderedWidth > 0
-    ? (image.naturalHeight / image.naturalWidth) * renderedWidth
-    : image.naturalHeight;
+function imageExceedsMarkdownPreview(image: HTMLImageElement) {
+  if (!image.naturalWidth || !image.naturalHeight) return false;
+  return image.naturalWidth > MARKDOWN_IMAGE_PREVIEW_MAX_WIDTH
+    || image.naturalHeight > MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT;
 }
 
 export function syncMarkdownImagePreviews(root: HTMLElement) {
@@ -151,16 +149,17 @@ export function syncMarkdownImagePreviews(root: HTMLElement) {
     const button = preview.querySelector("[data-openwork-image-toggle]");
     if (!(image instanceof HTMLImageElement) || !(button instanceof HTMLButtonElement)) continue;
 
-    const previewable = estimatedRenderedImageHeight(image) > MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT;
+    const previewable = imageExceedsMarkdownPreview(image);
     button.hidden = !previewable;
 
-    if (!previewable) {
-      preview.style.maxHeight = "";
-      continue;
-    }
-
     const expanded = preview.dataset.openworkImagePreview === "expanded";
-    preview.style.maxHeight = expanded ? "" : `${MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT}px`;
+    if (!previewable || expanded) {
+      image.style.maxHeight = "";
+      image.style.maxWidth = "";
+    } else {
+      image.style.maxHeight = `${MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT}px`;
+      image.style.maxWidth = `${MARKDOWN_IMAGE_PREVIEW_MAX_WIDTH}px`;
+    }
 
     const label = button.querySelector("[data-openwork-image-toggle-label]");
     if (label) label.textContent = expanded ? "Show less" : "Show full image";
@@ -278,7 +277,7 @@ function renderImage(profile: MarkdownProfile, href: string, title: string | nul
   const titleAttr = title ? ` title="${escapeAttribute(title)}"` : "";
 
   if (profile.imagePresentation === "chat") {
-    return `<span data-openwork-image-preview="collapsed" class="relative my-4 inline-block max-w-full overflow-hidden rounded-lg border border-border/70 align-top" style="max-height: ${MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT}px"><img src="${safe}" alt="${escapeAttribute(text)}"${titleAttr} loading="lazy" decoding="async" class="block h-auto max-w-full"><button type="button" data-openwork-image-toggle="" hidden class="absolute inset-x-0 bottom-0 flex justify-center bg-gradient-to-t from-background via-background/90 to-transparent pb-2 pt-8"><span data-openwork-image-toggle-label="" class="rounded-full border border-border bg-background/95 px-3 py-1 text-xs font-medium text-foreground shadow-sm">Show full image</span></button></span>`;
+    return `<span data-openwork-image-preview="collapsed" class="relative my-4 inline-block max-w-full align-top"><img src="${safe}" alt="${escapeAttribute(text)}"${titleAttr} loading="lazy" decoding="async" class="block h-auto w-auto rounded-lg border border-border/70 object-contain" style="max-height: ${MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT}px; max-width: ${MARKDOWN_IMAGE_PREVIEW_MAX_WIDTH}px"><button type="button" data-openwork-image-toggle="" hidden class="absolute inset-x-0 bottom-0 flex justify-center bg-gradient-to-t from-background via-background/90 to-transparent pb-2 pt-8"><span data-openwork-image-toggle-label="" class="rounded-full border border-border bg-background/95 px-3 py-1 text-xs font-medium text-foreground shadow-sm">Show full image</span></button></span>`;
   }
 
   return `<img src="${safe}" alt="${escapeAttribute(text)}"${titleAttr} loading="lazy" decoding="async" class="my-4 max-w-full rounded-[18px] border border-dls-border/70">`;

--- a/apps/app/src/components/ui/image.tsx
+++ b/apps/app/src/components/ui/image.tsx
@@ -12,9 +12,11 @@ export type ImageProps = GeneratedImageLike &
   Omit<React.ComponentProps<"img">, "src"> & {
     alt: string
     previewMaxHeight?: number
+    previewMaxWidth?: number
   }
 
-const DEFAULT_PREVIEW_MAX_HEIGHT = 100
+const DEFAULT_PREVIEW_MAX_HEIGHT = 160
+const DEFAULT_PREVIEW_MAX_WIDTH = 280
 
 function getImageSrc({
   base64,
@@ -34,7 +36,9 @@ export const Image = ({
   className,
   alt,
   previewMaxHeight = DEFAULT_PREVIEW_MAX_HEIGHT,
+  previewMaxWidth = DEFAULT_PREVIEW_MAX_WIDTH,
   onLoad,
+  style,
   ...props
 }: ImageProps) => {
   const [objectUrl, setObjectUrl] = React.useState<string | undefined>(undefined)
@@ -59,7 +63,7 @@ export const Image = ({
   const imageSrc = src ?? base64Src ?? objectUrl
 
   const updateCanExpand = React.useCallback((image: HTMLImageElement) => {
-    if (previewMaxHeight <= 0) {
+    if (previewMaxHeight <= 0 && previewMaxWidth <= 0) {
       setCanExpand(false)
       return
     }
@@ -69,13 +73,10 @@ export const Image = ({
       return
     }
 
-    const renderedWidth = image.clientWidth || image.getBoundingClientRect().width
-    const renderedHeight = renderedWidth > 0
-      ? (image.naturalHeight / image.naturalWidth) * renderedWidth
-      : image.naturalHeight
-
-    setCanExpand(renderedHeight > previewMaxHeight)
-  }, [previewMaxHeight])
+    const widerThanPreview = previewMaxWidth > 0 && image.naturalWidth > previewMaxWidth
+    const tallerThanPreview = previewMaxHeight > 0 && image.naturalHeight > previewMaxHeight
+    setCanExpand(widerThanPreview || tallerThanPreview)
+  }, [previewMaxHeight, previewMaxWidth])
 
   React.useEffect(() => {
     setExpanded(false)
@@ -100,7 +101,7 @@ export const Image = ({
         aria-label={alt}
         role="img"
         className={cn(
-          "h-auto max-w-full animate-pulse overflow-hidden rounded-md bg-gray-100 dark:bg-neutral-800",
+          "h-24 w-40 animate-pulse overflow-hidden rounded-md bg-gray-100 dark:bg-neutral-800",
           className
         )}
         {...props}
@@ -108,13 +109,27 @@ export const Image = ({
     )
   }
 
+  const constrained = previewMaxHeight > 0 || previewMaxWidth > 0
+  const previewStyle = !expanded && constrained
+    ? {
+        ...style,
+        ...(previewMaxHeight > 0 ? { maxHeight: previewMaxHeight } : {}),
+        ...(previewMaxWidth > 0 ? { maxWidth: previewMaxWidth } : {}),
+      }
+    : style
+
   const image = (
     <img
       ref={imageRef}
       src={imageSrc}
       alt={alt}
-      className={cn("h-auto max-w-full overflow-hidden rounded-md", className)}
+      className={cn(
+        "h-auto w-auto overflow-hidden rounded-md object-contain",
+        expanded || !constrained ? "max-w-full" : null,
+        className
+      )}
       role="img"
+      style={previewStyle}
       onLoad={(event) => {
         updateCanExpand(event.currentTarget)
         onLoad?.(event)
@@ -123,16 +138,13 @@ export const Image = ({
     />
   )
 
-  if (previewMaxHeight <= 0) {
+  if (!constrained) {
     return image
   }
 
   return (
     <div className="inline-flex max-w-full flex-col items-start gap-1">
-      <div
-        className="relative max-w-full overflow-hidden rounded-md"
-        style={expanded ? undefined : { maxHeight: previewMaxHeight }}
-      >
+      <div className="relative inline-block max-w-full overflow-hidden rounded-md">
         {image}
         {!expanded && canExpand ? (
           <div className="absolute inset-x-0 bottom-0 flex justify-center bg-gradient-to-t from-background via-background/90 to-transparent pb-2 pt-8">

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -8,7 +8,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuShortc
 import { OPENWORK_EXTENSION_CATALOG, type McpDirectoryInfo } from "@/app/constants";
 import type { CloudImportedPlugin, CloudImportedPluginFile } from "@/app/cloud/import-state";
 import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
-import { formatBytes, isMacPlatform } from "@/app/utils";
+import { isMacPlatform } from "@/app/utils";
 import { t } from "@/i18n";
 import { isOpenWorkExtensionEnabled, isOpenWorkExtensionHidden, OPENWORK_EXTENSION_STATE_CHANGED } from "@/react-app/domains/settings/extension-state";
 import { useDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
@@ -1225,38 +1225,6 @@ export function ReactSessionComposer(props: ComposerProps) {
           {renderMentionMenu()}
           {renderSlashMenu()}
 
-          {props.attachments.length > 0 ? (
-            <div className="mx-5 mt-5 flex flex-wrap gap-2 md:mx-6">
-              {props.attachments.map((attachment) => (
-                <div key={attachment.id} className="flex items-center gap-2 rounded-2xl border border-gray-6 bg-gray-2 px-3 py-2 text-xs text-gray-10">
-                  {isImageAttachment(attachment) && attachment.previewUrl ? (
-                    <div className="h-10 w-10 overflow-hidden rounded-xl border border-gray-6 bg-gray-1">
-                      <img src={attachment.previewUrl} alt={attachment.name} decoding="async" className="h-full w-full object-cover" />
-                    </div>
-                  ) : (
-                    <FileText size={14} className="text-gray-9" />
-                  )}
-                  <div className="max-w-[160px] min-w-0">
-                    <div className="truncate text-[12px] font-medium text-gray-11">{attachment.name}</div>
-                    <div className="flex items-center gap-1.5 text-[11px] text-gray-10">
-                      <span>{isImageAttachment(attachment) ? t("composer.image_kind") : t("composer.file_kind")}</span>
-                      <span>·</span>
-                      <span>{formatBytes(attachment.size)}</span>
-                    </div>
-                  </div>
-                  <button
-                    type="button"
-                    className="ml-1 inline-flex h-5 w-5 items-center justify-center rounded-full text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
-                    onClick={() => props.onRemoveAttachment(attachment.id)}
-                    title={t("action.remove")}
-                  >
-                    <X size={12} />
-                  </button>
-                </div>
-              ))}
-            </div>
-          ) : null}
-
           {/*
             The pasted-text chip used to render twice — once inline inside
             the Lexical editor (via ComposerPastedTextNode) and again as a
@@ -1281,11 +1249,18 @@ export function ReactSessionComposer(props: ComposerProps) {
               value={props.draft}
               mentions={props.mentions}
               pastedText={pastedTextTokens}
+              attachments={props.attachments.map((attachment) => ({
+                id: attachment.id,
+                name: attachment.name,
+                kind: isImageAttachment(attachment) ? "image" : "file",
+                previewUrl: attachment.previewUrl,
+              }))}
               disabled={props.disabled}
               placeholder={t("composer.placeholder")}
               onChange={props.onDraftChange}
               onSubmit={handleEditorSubmit}
               onExpandPastedText={handleExpandPastedText}
+              onRemoveAttachment={props.onRemoveAttachment}
               onPasteText={props.onPasteText}
               onPaste={(event) => {
                 // Paste policy:

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -40,15 +40,24 @@ import { insertStyledPastedText } from "./pasted-text-insertion";
 
 type PastedTextToken = { label: string; lines: number; text: string };
 
+export type ComposerAttachmentToken = {
+  id: string;
+  name: string;
+  kind: "image" | "file";
+  previewUrl?: string;
+};
+
 type EditorProps = {
   value: string;
   mentions: Record<string, ComposerMentionKind>;
   pastedText?: PastedTextToken[];
+  attachments?: ComposerAttachmentToken[];
   disabled: boolean;
   placeholder: string;
   onChange: (value: string) => void;
   onSubmit: (options: { queue: boolean }) => void | Promise<void>;
   onExpandPastedText?: (label: string) => void;
+  onRemoveAttachment?: (id: string) => void;
   onPaste?: React.ClipboardEventHandler<HTMLDivElement>;
   onPasteText?: (text: string) => void;
   onDrop?: React.DragEventHandler<HTMLDivElement>;
@@ -437,7 +446,185 @@ function $createComposerPastedTextNode(label: string, lines: number) {
   return $applyNodeReplacement(new ComposerPastedTextNode(label, lines));
 }
 
-type ComposerInlineTokenNode = ComposerMentionNode | ComposerSlashCommandNode | ComposerSkillNode | ComposerPastedTextNode;
+function createAttachmentChipDom(attachment: ComposerAttachmentToken) {
+  const dom = document.createElement("span");
+  dom.className = "relative mx-0.5 inline-flex h-10 max-w-[140px] shrink-0 items-center align-middle";
+  dom.contentEditable = "false";
+  dom.setAttribute("spellcheck", "false");
+  dom.title = attachment.name;
+
+  if (attachment.kind === "image" && attachment.previewUrl) {
+    const img = document.createElement("img");
+    img.src = attachment.previewUrl;
+    img.alt = attachment.name;
+    img.decoding = "async";
+    img.className = "h-10 w-10 rounded-xl border border-border/70 object-cover";
+    dom.append(img);
+  } else {
+    const chip = document.createElement("span");
+    chip.className = "inline-flex h-10 max-w-[140px] items-center gap-1.5 rounded-xl border border-border/70 bg-muted/40 px-2";
+    const label = document.createElement("span");
+    label.className = "truncate text-[11px] font-medium text-foreground";
+    label.textContent = attachment.name;
+    chip.append(label);
+    dom.append(chip);
+  }
+
+  const remove = document.createElement("button");
+  remove.type = "button";
+  remove.className = "absolute -right-1.5 -top-1.5 inline-flex h-5 w-5 items-center justify-center rounded-full border border-border bg-background text-xs leading-none text-muted-foreground shadow-sm transition-colors hover:bg-muted hover:text-foreground";
+  remove.title = "Remove";
+  remove.setAttribute("aria-label", `Remove ${attachment.name}`);
+  remove.dataset.attachmentRemoveId = attachment.id;
+  remove.textContent = "×";
+  dom.append(remove);
+  return dom;
+}
+
+function updateAttachmentChipDom(dom: HTMLElement, attachment: ComposerAttachmentToken) {
+  dom.title = attachment.name;
+  const remove = dom.querySelector("button[data-attachment-remove-id]");
+  if (remove instanceof HTMLButtonElement) {
+    remove.dataset.attachmentRemoveId = attachment.id;
+    remove.setAttribute("aria-label", `Remove ${attachment.name}`);
+  }
+  const img = dom.querySelector("img");
+  if (img instanceof HTMLImageElement && attachment.previewUrl) {
+    img.src = attachment.previewUrl;
+    img.alt = attachment.name;
+  }
+  const label = dom.querySelector("span.truncate");
+  if (label) label.textContent = attachment.name;
+}
+
+type SerializedComposerAttachmentNode = Spread<
+  {
+    attachmentId: string;
+    attachmentName: string;
+    attachmentKind: "image" | "file";
+    attachmentPreviewUrl?: string;
+    type: "composer-attachment";
+    version: 1;
+  },
+  SerializedTextNode
+>;
+
+class ComposerAttachmentNode extends TextNode {
+  __attachmentId: string;
+  __attachmentName: string;
+  __attachmentKind: "image" | "file";
+  __attachmentPreviewUrl?: string;
+
+  static override getType() {
+    return "composer-attachment";
+  }
+
+  static override clone(node: ComposerAttachmentNode) {
+    return new ComposerAttachmentNode(
+      {
+        id: node.__attachmentId,
+        name: node.__attachmentName,
+        kind: node.__attachmentKind,
+        previewUrl: node.__attachmentPreviewUrl,
+      },
+      node.__key,
+    );
+  }
+
+  static override importJSON(serializedNode: SerializedComposerAttachmentNode) {
+    return $createComposerAttachmentNode({
+      id: serializedNode.attachmentId,
+      name: serializedNode.attachmentName,
+      kind: serializedNode.attachmentKind,
+      previewUrl: serializedNode.attachmentPreviewUrl,
+    });
+  }
+
+  constructor(attachment: ComposerAttachmentToken, key?: NodeKey) {
+    super(`[attachment ${attachment.id}]`, key);
+    this.__attachmentId = attachment.id;
+    this.__attachmentName = attachment.name;
+    this.__attachmentKind = attachment.kind;
+    this.__attachmentPreviewUrl = attachment.previewUrl;
+  }
+
+  getAttachmentId() {
+    return this.__attachmentId;
+  }
+
+  override exportJSON(): SerializedComposerAttachmentNode {
+    return {
+      ...super.exportJSON(),
+      attachmentId: this.__attachmentId,
+      attachmentName: this.__attachmentName,
+      attachmentKind: this.__attachmentKind,
+      attachmentPreviewUrl: this.__attachmentPreviewUrl,
+      type: "composer-attachment",
+      version: 1,
+    };
+  }
+
+  override createDOM(_config: EditorConfig) {
+    return createAttachmentChipDom({
+      id: this.__attachmentId,
+      name: this.__attachmentName,
+      kind: this.__attachmentKind,
+      previewUrl: this.__attachmentPreviewUrl,
+    });
+  }
+
+  override updateDOM(prevNode: ComposerAttachmentNode, dom: HTMLElement) {
+    if (
+      prevNode.__attachmentId !== this.__attachmentId
+      || prevNode.__attachmentName !== this.__attachmentName
+      || prevNode.__attachmentKind !== this.__attachmentKind
+      || prevNode.__attachmentPreviewUrl !== this.__attachmentPreviewUrl
+    ) {
+      updateAttachmentChipDom(dom, {
+        id: this.__attachmentId,
+        name: this.__attachmentName,
+        kind: this.__attachmentKind,
+        previewUrl: this.__attachmentPreviewUrl,
+      });
+    }
+    return false;
+  }
+
+  override canInsertTextBefore(): false {
+    return false;
+  }
+
+  override canInsertTextAfter(): false {
+    return false;
+  }
+
+  override isTextEntity(): true {
+    return true;
+  }
+
+  override isToken(): true {
+    return true;
+  }
+}
+
+function $createComposerAttachmentNode(attachment: ComposerAttachmentToken) {
+  return $applyNodeReplacement(new ComposerAttachmentNode(attachment));
+}
+
+type ComposerInlineTokenNode =
+  | ComposerMentionNode
+  | ComposerSlashCommandNode
+  | ComposerSkillNode
+  | ComposerPastedTextNode
+  | ComposerAttachmentNode;
+
+function isComposerInlineTokenNode(node: unknown): node is ComposerInlineTokenNode {
+  return node instanceof ComposerMentionNode
+    || node instanceof ComposerSlashCommandNode
+    || node instanceof ComposerSkillNode
+    || node instanceof ComposerPastedTextNode
+    || node instanceof ComposerAttachmentNode;
+}
 
 function setSelectionAfterNode(node: TextNode) {
   const parent = node.getParent();
@@ -486,7 +673,12 @@ function appendSegmentWithNewlines(
   return current;
 }
 
-function setPrompt(value: string, mentions: Record<string, ComposerMentionKind>, pastedText?: PastedTextToken[]) {
+function setPrompt(
+  value: string,
+  mentions: Record<string, ComposerMentionKind>,
+  pastedText?: PastedTextToken[],
+  attachments?: ComposerAttachmentToken[],
+) {
   const root = $getRoot();
   root.clear();
   let paragraph = $createParagraphNode();
@@ -499,10 +691,19 @@ function setPrompt(value: string, mentions: Record<string, ComposerMentionKind>,
     value = slashMatch[2] ?? "";
   }
 
-  const segments = value.split(/(\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
+  const segments = value.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
   const pastedTextByLabel = new Map((pastedText ?? []).map((item) => [item.label, item]));
+  const attachmentsById = new Map((attachments ?? []).map((item) => [item.id, item]));
   for (const segment of segments) {
     if (!segment) continue;
+    const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
+    if (attachmentMatch?.[1]) {
+      const target = attachmentsById.get(attachmentMatch[1]);
+      if (target) {
+        paragraph.append($createComposerAttachmentNode(target));
+        continue;
+      }
+    }
     const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
     if (pasteMatch?.[1]) {
       const target = pastedTextByLabel.get(pasteMatch[1]);
@@ -565,7 +766,13 @@ function serializePromptFromRoot(): string {
     .join("\n");
 }
 
-function SyncPlugin(props: { value: string; mentions: Record<string, ComposerMentionKind>; pastedText?: PastedTextToken[]; disabled: boolean }) {
+function SyncPlugin(props: {
+  value: string;
+  mentions: Record<string, ComposerMentionKind>;
+  pastedText?: PastedTextToken[];
+  attachments?: ComposerAttachmentToken[];
+  disabled: boolean;
+}) {
   const [editor] = useLexicalComposerContext();
   const valueRef = useRef(props.value);
 
@@ -597,7 +804,7 @@ function SyncPlugin(props: { value: string; mentions: Record<string, ComposerMen
       // Double-check inside the update in case another queued update
       // changed the state between the read above and this callback.
       if (!forceRebuild && serializePromptFromRoot() === props.value) return;
-      setPrompt(props.value, props.mentions, props.pastedText);
+      setPrompt(props.value, props.mentions, props.pastedText, props.attachments);
       // $getRoot().selectEnd() doesn't work when the last node is a
       // token (chip) — Lexical can't position a cursor inside a token,
       // so the selection collapses to position 0. Use element-level
@@ -611,7 +818,7 @@ function SyncPlugin(props: { value: string; mentions: Record<string, ComposerMen
         $getRoot().selectEnd();
       }
     });
-  }, [editor, props.mentions, props.pastedText, props.value]);
+  }, [editor, props.attachments, props.mentions, props.pastedText, props.value]);
 
   return null;
 }
@@ -791,10 +998,10 @@ function MentionChipNavigationPlugin() {
           }
         }
 
-        // --- Mention / pasted-text chips: atomic delete (same as before) ---
+        // --- Mention / pasted-text / attachment chips: atomic delete ---
         if ($isTextNode(anchorNode) && selection.anchor.offset === 0) {
           const previous = anchorNode.getPreviousSibling();
-          if (previous instanceof ComposerMentionNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode) {
+          if (isComposerInlineTokenNode(previous) && !(previous instanceof ComposerSlashCommandNode)) {
             previous.remove();
             return true;
           }
@@ -802,7 +1009,7 @@ function MentionChipNavigationPlugin() {
 
         if ($isElementNode(anchorNode)) {
           const previous = anchorNode.getChildAtIndex(selection.anchor.offset - 1);
-          if (previous instanceof ComposerSlashCommandNode || previous instanceof ComposerMentionNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode) {
+          if (isComposerInlineTokenNode(previous)) {
             previous.remove();
             return true;
           }
@@ -822,7 +1029,7 @@ function MentionChipNavigationPlugin() {
 
         if ($isTextNode(anchorNode) && selection.anchor.offset === 0) {
           const previous = anchorNode.getPreviousSibling();
-          if (previous instanceof ComposerMentionNode || previous instanceof ComposerSlashCommandNode || previous instanceof ComposerSkillNode || previous instanceof ComposerPastedTextNode) {
+          if (isComposerInlineTokenNode(previous)) {
             setSelectionBeforeNode(previous);
             return true;
           }
@@ -840,14 +1047,14 @@ function MentionChipNavigationPlugin() {
         if (!$isRangeSelection(selection) || !selection.isCollapsed()) return false;
         const anchorNode = selection.anchor.getNode();
 
-        if (anchorNode instanceof ComposerMentionNode || anchorNode instanceof ComposerSlashCommandNode || anchorNode instanceof ComposerSkillNode || anchorNode instanceof ComposerPastedTextNode) {
+        if (isComposerInlineTokenNode(anchorNode)) {
           setSelectionAfterNode(anchorNode);
           return true;
         }
 
         if ($isElementNode(anchorNode)) {
           const current = anchorNode.getChildAtIndex(selection.anchor.offset);
-          if (current instanceof ComposerMentionNode || current instanceof ComposerSlashCommandNode || current instanceof ComposerSkillNode || current instanceof ComposerPastedTextNode) {
+          if (isComposerInlineTokenNode(current)) {
             setSelectionAfterNode(current);
             return true;
           }
@@ -881,6 +1088,48 @@ function ImperativeHandlePlugin(props: { editorRef: ForwardedRef<LexicalPromptEd
   return null;
 }
 
+function attachmentRemoveButton(target: EventTarget | null) {
+  if (!(target instanceof Element)) return null;
+  const button = target.closest("button[data-attachment-remove-id]");
+  return button instanceof HTMLButtonElement ? button : null;
+}
+
+function AttachmentRemovePlugin(props: { onRemoveAttachment?: (id: string) => void }) {
+  const [editor] = useLexicalComposerContext();
+  const onRemoveAttachmentRef = useRef(props.onRemoveAttachment);
+
+  useEffect(() => {
+    onRemoveAttachmentRef.current = props.onRemoveAttachment;
+  }, [props.onRemoveAttachment]);
+
+  useEffect(() => {
+    const handleMouseDown = (event: MouseEvent) => {
+      if (!attachmentRemoveButton(event.target)) return;
+      event.preventDefault();
+      event.stopPropagation();
+    };
+
+    const handleClick = (event: MouseEvent) => {
+      const button = attachmentRemoveButton(event.target);
+      if (!button) return;
+      const id = button.dataset.attachmentRemoveId;
+      if (!id) return;
+      event.preventDefault();
+      event.stopPropagation();
+      onRemoveAttachmentRef.current?.(id);
+    };
+
+    return editor.registerRootListener((rootElement, previousRootElement) => {
+      previousRootElement?.removeEventListener("mousedown", handleMouseDown, true);
+      previousRootElement?.removeEventListener("click", handleClick, true);
+      rootElement?.addEventListener("mousedown", handleMouseDown, true);
+      rootElement?.addEventListener("click", handleClick, true);
+    });
+  }, [editor]);
+
+  return null;
+}
+
 export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorProps>(function LexicalPromptEditor(props, ref) {
   const valueRef = useRef(props.value);
   const onChangeRef = useRef(props.onChange);
@@ -900,9 +1149,9 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         throw error;
       },
         editable: !props.disabled,
-        nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerPastedTextNode],
+        nodes: [ComposerMentionNode, ComposerSlashCommandNode, ComposerSkillNode, ComposerPastedTextNode, ComposerAttachmentNode],
         editorState: () => {
-          setPrompt(props.value, props.mentions, props.pastedText);
+          setPrompt(props.value, props.mentions, props.pastedText, props.attachments);
         },
       }),
     [],
@@ -950,10 +1199,17 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         />
         <OnChangePlugin onChange={syncPromptFromEditorState} />
         <HistoryPlugin />
-        <SyncPlugin value={props.value} mentions={props.mentions} pastedText={props.pastedText} disabled={props.disabled} />
+        <SyncPlugin
+          value={props.value}
+          mentions={props.mentions}
+          pastedText={props.pastedText}
+          attachments={props.attachments}
+          disabled={props.disabled}
+        />
         <SubmitPlugin onSubmit={props.onSubmit} disabled={props.disabled} />
         <PasteChipPlugin onPasteText={props.onPasteText} />
         <PastedTextExpandPlugin pastedText={props.pastedText} onExpandPastedText={props.onExpandPastedText} />
+        <AttachmentRemovePlugin onRemoveAttachment={props.onRemoveAttachment} />
         <MentionChipNavigationPlugin />
         <ImperativeHandlePlugin editorRef={ref} />
       </div>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -208,6 +208,13 @@ function messageToReadableText(message: UIMessage) {
     .flatMap((part) => {
       if (part.type === "text") return [part.text];
       if (part.type === "reasoning") return [part.text];
+      if (part.type === "file") {
+        const name = part.filename?.trim() || "file";
+        const url = part.url.startsWith("data:")
+          ? `data:${part.mediaType || "application/octet-stream"};base64,…`
+          : part.url;
+        return [`[file:${name}] ${url}`];
+      }
       if (part.type === "dynamic-tool") {
         if (part.state === "output-error") return [`[tool:${part.toolName}] ${part.errorText}`];
         if (part.state === "output-available") return [`[tool:${part.toolName}] ${JSON.stringify(part.output)}`];
@@ -819,8 +826,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
   });
 
   const buildDraft = useCallback((text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
-    const parts: ComposerPart[] = text.split(/(\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
+    const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
       if (!segment) return [] as ComposerDraft["parts"];
+      const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
+      if (attachmentMatch) {
+        // Attachment chips are visual tokens only; bytes travel via draft.attachments.
+        return [] as ComposerDraft["parts"];
+      }
       const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
       if (pasteMatch) {
         const target = pasteParts.find((item) => item.label === pasteMatch[1]);
@@ -847,6 +859,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     for (const part of pasteParts) {
       resolved = resolved.replace(`[pasted text ${part.label}]`, part.text);
     }
+    resolved = resolved.replace(/\[attachment [^\]]+\]/g, "");
     resolved = resolved.replace(/\[skill ([^\]]+)\]/g, (_match, name: string) => `the \"${name}\" skill`);
     for (const value of Object.keys(mentions)) {
       resolved = resolved.replaceAll(`@${encodeComposerMentionValue(value)}`, `@${value}`);
@@ -864,7 +877,16 @@ export function SessionSurface(props: SessionSurfaceProps) {
 
   const handleComposerDraftChange = useCallback((value: string) => {
     setComposerDraft(props.sessionId, value);
-  }, [props.sessionId, setComposerDraft]);
+    const idsInDraft = new Set(
+      [...value.matchAll(/\[attachment ([^\]]+)\]/g)].map((match) => match[1]).filter((id): id is string => Boolean(id)),
+    );
+    const retained = attachments.filter((attachment) => idsInDraft.has(attachment.id));
+    if (retained.length === attachments.length) return;
+    for (const attachment of attachments) {
+      if (!idsInDraft.has(attachment.id)) revokeAttachmentPreview(attachment);
+    }
+    setComposerAttachments(props.sessionId, retained);
+  }, [attachments, props.sessionId, setComposerAttachments, setComposerDraft]);
 
   const handleCopyTranscript = async () => {
     try {
@@ -1068,7 +1090,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     const next = accepted.map((file) => {
       const metadata = resolveAttachmentFileMetadata(file);
       return {
-        id: `${file.name}-${file.lastModified}-${Math.random().toString(36).slice(2)}`,
+        id: `att-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
         name: file.name,
         mimeType: metadata.mime,
         size: file.size,
@@ -1078,6 +1100,12 @@ export function SessionSurface(props: SessionSurfaceProps) {
       };
     });
     setComposerAttachments(props.sessionId, [...attachments, ...next]);
+    // Inline attachment chips live in the draft as Lexical tokens (same
+    // pattern as pasted-text chips), so they sit in the text flow.
+    setComposerDraft(
+      props.sessionId,
+      `${draft}${next.map((attachment) => `[attachment ${attachment.id}]`).join("")}`,
+    );
   };
 
   const handleRemoveAttachment = (id: string) => {
@@ -1086,6 +1114,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       URL.revokeObjectURL(target.previewUrl);
     }
     setComposerAttachments(props.sessionId, attachments.filter((item) => item.id !== id));
+    setComposerDraft(props.sessionId, draft.replaceAll(`[attachment ${id}]`, ""));
   };
 
   const handleInsertMention = (kind: ComposerMentionKind, value: string) => {

--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -40,6 +40,7 @@ type UploadedChatAttachment = {
   bytes: number;
   workspacePath: string;
   url: string;
+  file: AttachmentFile;
 };
 
 const WORKSPACE_INBOX_ROOT = ".opencode/openwork/inbox";
@@ -223,15 +224,33 @@ function uploadErrorMessage(filename: string, error: unknown) {
   return `Failed to copy attachment "${filename}" into this worker workspace: ${detail}`;
 }
 
-function attachmentPathNote(uploaded: UploadedChatAttachment[]) {
-  return `\n\n${[
-    "Attached files were copied into this worker workspace for tool access:",
-    ...uploaded.map((item) => `- ${item.filename}: ${item.workspacePath} (${item.url})`),
-    "Use these paths with Read/Bash/MCP/Docling when a tool needs the file bytes.",
-  ].join("\n")}`;
+function attachmentPathNotePart(uploaded: UploadedChatAttachment[]): TextPartInput {
+  // Synthetic: model/tools still see workspace paths, but the chat UI renders
+  // file parts as compact badges instead of this wall of path text.
+  return {
+    type: "text",
+    synthetic: true,
+    text: [
+      "Attached files were copied into this worker workspace for tool access:",
+      ...uploaded.map((item) => `- ${item.filename}: ${item.workspacePath} (${item.url})`),
+      "Use these paths with Read/Bash/MCP/Docling when a tool needs the file bytes.",
+    ].join("\n"),
+  };
 }
 
-function uploadedAttachmentFilePart(item: UploadedChatAttachment): FilePartInput {
+async function uploadedAttachmentFilePart(item: UploadedChatAttachment): Promise<FilePartInput> {
+  // Images need a browser-displayable URL so the transcript can show the same
+  // expandable miniature preview as paste/composer attachments. Workspace
+  // `file://` paths stay in the synthetic note for tool access.
+  if (item.mime.startsWith("image/")) {
+    return {
+      type: "file",
+      url: await fileToDataUrl(item.file, item.mime),
+      filename: item.filename,
+      mime: item.mime,
+    };
+  }
+
   return {
     type: "file",
     url: item.url,
@@ -294,12 +313,13 @@ export async function composerAttachmentsToWorkspaceFileParts(input: {
       bytes: result.bytes,
       workspacePath,
       url: toFileUrl(absolutePath),
+      file: attachment.file,
     });
   }
 
   return [
-    { type: "text", text: attachmentPathNote(uploaded) },
-    ...uploaded.map(uploadedAttachmentFilePart),
+    attachmentPathNotePart(uploaded),
+    ...(await Promise.all(uploaded.map(uploadedAttachmentFilePart))),
   ];
 }
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -104,6 +104,7 @@ import { useModelBehavior } from "@/react-app/domains/session/surface/use-model-
 import { useSessionFindStore } from "@/react-app/domains/session/surface/find-store";
 import { useModelPicker } from "@/react-app/domains/session/modals/use-model-picker";
 import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
+import { decodeComposerMentionValue } from "@/react-app/domains/session/surface/composer/mention-encoding";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
 import type { CreateWorkspaceOptions } from "@/react-app/domains/workspace/types";
@@ -266,52 +267,129 @@ async function draftToParts(
     return segments[segments.length - 1] ?? "file";
   };
 
-  for (const part of draft.parts) {
-    if (part.type === "text") {
-      parts.push({ type: "text", text: part.text });
-      continue;
-    }
-    if (part.type === "paste") {
-      parts.push({ type: "text", text: part.text });
-      continue;
-    }
-    if (part.type === "agent") {
-      parts.push({ type: "agent", name: part.name });
-      continue;
-    }
-    if (part.type === "skill") {
-      parts.push({ type: "text", text: `Load [skill ${part.name}] and follow its instructions.` });
-      continue;
-    }
-    if (part.type === "app") {
-      parts.push({ type: "text", text: appMentionInstruction(part.name) });
-      continue;
-    }
-    if (part.type === "file") {
-      const absolute = toAbsolutePath(part.path);
-      if (!absolute) continue;
-      parts.push({
-        type: "file",
-        mime: "text/plain",
-        url: toFileUrl(absolute),
-        filename: filenameFromPath(part.path),
-      });
-    }
-  }
-
-  parts.push(...firstLineLocalFileParts(draft.resolvedText ?? draft.text, root));
-
+  const attachmentFileById = new Map<string, FilePartInput>();
   if (draft.attachments.length > 0) {
     if (!endpoint) {
       throw new Error("Workspace endpoint is unavailable; attachments could not be copied for tool access.");
     }
-    parts.push(...(await composerAttachmentsToWorkspaceFileParts({
+    const uploaded = await composerAttachmentsToWorkspaceFileParts({
       attachments: draft.attachments,
       endpoint,
       sessionId,
       workspaceRoot: root,
-    })));
+    });
+    for (const part of uploaded) {
+      if (part.type === "text") {
+        parts.push(part);
+        continue;
+      }
+    }
+    const fileParts = uploaded.filter((part): part is FilePartInput => part.type === "file");
+    for (const [index, attachment] of draft.attachments.entries()) {
+      const filePart = fileParts[index];
+      if (filePart) attachmentFileById.set(attachment.id, filePart);
+    }
   }
+
+  // Prefer draft.text token order so attachment chips stay inline with surrounding text
+  // (same positions as the composer), instead of dumping every file part at the end.
+  const hasAttachmentTokens = /\[attachment [^\]]+\]/.test(draft.text);
+  if (hasAttachmentTokens || attachmentFileById.size > 0) {
+    const pasteByLabel = new Map(
+      draft.parts
+        .filter((part): part is Extract<ComposerPart, { type: "paste" }> => part.type === "paste")
+        .map((part) => [part.label, part.text] as const),
+    );
+    for (const segment of draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/)) {
+      if (!segment) continue;
+      const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
+      if (attachmentMatch?.[1]) {
+        const filePart = attachmentFileById.get(attachmentMatch[1]);
+        if (filePart) {
+          parts.push(filePart);
+          attachmentFileById.delete(attachmentMatch[1]);
+        }
+        continue;
+      }
+      const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
+      if (pasteMatch?.[1]) {
+        const pasted = pasteByLabel.get(pasteMatch[1]);
+        if (pasted) parts.push({ type: "text", text: pasted });
+        continue;
+      }
+      const skillMatch = segment.match(/^\[skill (.+)\]$/);
+      if (skillMatch?.[1]) {
+        parts.push({ type: "text", text: `Load [skill ${skillMatch[1]}] and follow its instructions.` });
+        continue;
+      }
+      if (segment.startsWith("@")) {
+        const value = decodeComposerMentionValue(segment.slice(1));
+        const mentionPart = draft.parts.find((part) =>
+          (part.type === "agent" && part.name === value)
+          || (part.type === "app" && part.name === value)
+          || (part.type === "file" && part.path === value),
+        );
+        if (mentionPart?.type === "agent") {
+          parts.push({ type: "agent", name: mentionPart.name });
+          continue;
+        }
+        if (mentionPart?.type === "app") {
+          parts.push({ type: "text", text: appMentionInstruction(mentionPart.name) });
+          continue;
+        }
+        if (mentionPart?.type === "file") {
+          const absolute = toAbsolutePath(mentionPart.path);
+          if (!absolute) continue;
+          parts.push({
+            type: "file",
+            mime: "text/plain",
+            url: toFileUrl(absolute),
+            filename: filenameFromPath(mentionPart.path),
+          });
+          continue;
+        }
+      }
+      parts.push({ type: "text", text: segment });
+    }
+    for (const filePart of attachmentFileById.values()) {
+      parts.push(filePart);
+    }
+  } else {
+    for (const part of draft.parts) {
+      if (part.type === "text") {
+        parts.push({ type: "text", text: part.text });
+        continue;
+      }
+      if (part.type === "paste") {
+        parts.push({ type: "text", text: part.text });
+        continue;
+      }
+      if (part.type === "agent") {
+        parts.push({ type: "agent", name: part.name });
+        continue;
+      }
+      if (part.type === "skill") {
+        parts.push({ type: "text", text: `Load [skill ${part.name}] and follow its instructions.` });
+        continue;
+      }
+      if (part.type === "app") {
+        parts.push({ type: "text", text: appMentionInstruction(part.name) });
+        continue;
+      }
+      if (part.type === "file") {
+        const absolute = toAbsolutePath(part.path);
+        if (!absolute) continue;
+        parts.push({
+          type: "file",
+          mime: "text/plain",
+          url: toFileUrl(absolute),
+          filename: filenameFromPath(part.path),
+        });
+      }
+    }
+  }
+
+  parts.push(...firstLineLocalFileParts(draft.resolvedText ?? draft.text, root));
 
   return parts;
 }

--- a/apps/app/tests/attachment-file-part.test.ts
+++ b/apps/app/tests/attachment-file-part.test.ts
@@ -67,10 +67,14 @@ function uploadRecorder(workspaceId: string) {
   return { endpoint, calls };
 }
 
-function textPartText(parts: Awaited<ReturnType<typeof composerAttachmentsToWorkspaceFileParts>>) {
+function textPart(parts: Awaited<ReturnType<typeof composerAttachmentsToWorkspaceFileParts>>) {
   const part = parts[0];
   if (!part || part.type !== "text") throw new Error("Expected first attachment part to be a text note");
-  return part.text;
+  return part;
+}
+
+function textPartText(parts: Awaited<ReturnType<typeof composerAttachmentsToWorkspaceFileParts>>) {
+  return textPart(parts).text;
 }
 
 function filePartUrl(parts: Awaited<ReturnType<typeof composerAttachmentsToWorkspaceFileParts>>, index: number) {
@@ -288,7 +292,11 @@ describe("composer attachment file parts", () => {
       filename: "image-only scan.pdf",
       bytes: Array.from(PDF_BYTES),
     }]);
-    expect(textPartText(parts).startsWith("\n\nAttached files were copied")).toBe(true);
+    expect(textPart(parts)).toMatchObject({
+      type: "text",
+      synthetic: true,
+    });
+    expect(textPartText(parts).startsWith("Attached files were copied")).toBe(true);
     expect(textPartText(parts)).toContain(".opencode/openwork/inbox/chat-attachments/ses_abc/nonce-a-image-only scan.pdf");
     expect(textPartText(parts)).toContain("Read/Bash/MCP/Docling");
     expect(filePartUrl(parts, 1)).toBe("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_abc/nonce-a-image-only%20scan.pdf");
@@ -296,6 +304,36 @@ describe("composer attachment file parts", () => {
       type: "file",
       filename: "image-only scan.pdf",
       mime: "application/pdf",
+    });
+  });
+
+  test("workspace image attachments use displayable data URLs while keeping a synthetic path note for tools", async () => {
+    const { endpoint, calls } = uploadRecorder("server-workspace-42");
+    const file = new File([JPEG_BYTES], "shot.png", { type: "image/png" });
+
+    const parts = await composerAttachmentsToWorkspaceFileParts({
+      attachments: [attachmentFor(file)],
+      endpoint,
+      sessionId: "ses_img",
+      workspaceRoot: "/workspaces/Worker Root",
+      createId: () => "nonce-img",
+    });
+
+    expect(calls).toEqual([{
+      workspaceId: "server-workspace-42",
+      path: "chat-attachments/ses_img/nonce-img-shot.png",
+      filename: "shot.png",
+      bytes: Array.from(JPEG_BYTES),
+    }]);
+    expect(textPart(parts)).toMatchObject({ type: "text", synthetic: true });
+    expect(textPartText(parts)).toContain(".opencode/openwork/inbox/chat-attachments/ses_img/nonce-img-shot.png");
+    expect(textPartText(parts)).toContain("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_img/nonce-img-shot.png");
+    expect(filePartUrl(parts, 1).startsWith("data:image/png;base64,")).toBe(true);
+    expect(Array.from(decodedDataUrlBytes(filePartUrl(parts, 1)))).toEqual(Array.from(JPEG_BYTES));
+    expect(parts[1]).toMatchObject({
+      type: "file",
+      filename: "shot.png",
+      mime: "image/png",
     });
   });
 

--- a/evals/flows/chat-attachment-workspace-path.flow.mjs
+++ b/evals/flows/chat-attachment-workspace-path.flow.mjs
@@ -178,14 +178,16 @@ export default {
             await ctx.control("composer.send");
           },
           assert: async () => {
-            await ctx.waitForText(".opencode/openwork/inbox/chat-attachments/", { timeoutMs: 30_000 });
+            // Path note is synthetic (hidden from chat UI); the file badge stays visible
+            // and the transcript still exposes the worker file:// inbox URL for tools.
+            await ctx.waitForText(FILENAME, { timeoutMs: 30_000 });
             const transcript = await ctx.control("session.read_transcript", { count: 5 });
             const text = transcriptText(transcript);
             assertEvidence(ctx, text.includes(".opencode/openwork/inbox/chat-attachments/"), "Transcript contains the workspace inbox path", text);
             assertEvidence(ctx, !text.includes("data:application/pdf"), "Transcript does not expose the PDF as a data URL fallback", text);
             ctx.output("submitted user turn", text);
           },
-          screenshot: { name: "worker-path-in-turn", requireText: [".opencode/openwork/inbox/chat-attachments/", FILENAME] },
+          screenshot: { name: "worker-path-in-turn", requireText: [FILENAME] },
         });
       },
     },
@@ -207,7 +209,7 @@ export default {
             assertEvidence(ctx, !text.toLowerCase().includes("ocr complete"), "The prompt does not claim OpenWork performed native OCR", text);
             ctx.output("Docling-ready path", filePath);
           },
-          screenshot: { name: "docling-ready-path", requireText: [FILENAME, "chat-attachments"] },
+          screenshot: { name: "docling-ready-path", requireText: [FILENAME] },
         });
       },
     },


### PR DESCRIPTION
## Summary
- Replace the verbose “Attached files were copied…” path dump with compact expandable image badges in composer and sent user messages
- Keep workspace paths available to the model via a synthetic text part (hidden in the UI)
- Render attachments inline with surrounding text (Lexical chips in composer; interleaved parts in sent messages) and keep user message text selectable
- Constrain assistant/markdown image previews so they scale without cropping or stretching full width

## Test plan
- [x] `cd apps/app && bun test tests/attachment-file-part.test.ts` (15 pass)
- [ ] Attach an image in composer → thumbnail sits inline in the text flow; click expands; ×/backspace removes
- [ ] Send message with image + text → bubble shows inline badge (not path wall); text is selectable
- [ ] Confirm tools still receive workspace inbox paths (synthetic note / transcript)
- [ ] Optional: `pnpm fraimz --flow chat-attachment-workspace-path`


Made with [Cursor](https://cursor.com)