### PR TITLE
fix(app): open chat images in a modal instead of expand overlay

### DIFF
--- a/apps/app/src/components/markdown/markdown-primitive.ts
+++ b/apps/app/src/components/markdown/markdown-primitive.ts
@@ -133,12 +133,6 @@ export function hasFencedCodeBlock(text: string) {
   return /(^|\n)```/.test(text);
 }
 
-function imageExceedsMarkdownPreview(image: HTMLImageElement) {
-  if (!image.naturalWidth || !image.naturalHeight) return false;
-  return image.naturalWidth > MARKDOWN_IMAGE_PREVIEW_MAX_WIDTH
-    || image.naturalHeight > MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT;
-}
-
 export function syncMarkdownImagePreviews(root: HTMLElement) {
   const previews = root.querySelectorAll("[data-openwork-image-preview]");
 
@@ -146,23 +140,10 @@ export function syncMarkdownImagePreviews(root: HTMLElement) {
     if (!(preview instanceof HTMLElement)) continue;
 
     const image = preview.querySelector("img");
-    const button = preview.querySelector("[data-openwork-image-toggle]");
-    if (!(image instanceof HTMLImageElement) || !(button instanceof HTMLButtonElement)) continue;
+    if (!(image instanceof HTMLImageElement)) continue;
 
-    const previewable = imageExceedsMarkdownPreview(image);
-    button.hidden = !previewable;
-
-    const expanded = preview.dataset.openworkImagePreview === "expanded";
-    if (!previewable || expanded) {
-      image.style.maxHeight = "";
-      image.style.maxWidth = "";
-    } else {
-      image.style.maxHeight = `${MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT}px`;
-      image.style.maxWidth = `${MARKDOWN_IMAGE_PREVIEW_MAX_WIDTH}px`;
-    }
-
-    const label = button.querySelector("[data-openwork-image-toggle-label]");
-    if (label) label.textContent = expanded ? "Show less" : "Show full image";
+    image.style.maxHeight = `${MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT}px`;
+    image.style.maxWidth = `${MARKDOWN_IMAGE_PREVIEW_MAX_WIDTH}px`;
   }
 }
 
@@ -191,9 +172,8 @@ function sanitizeMarkdownHtml(value: string) {
       "data-openwork-code-copy-check-icon",
       "data-openwork-code-copy-icon",
       "data-openwork-code-copy-label",
+      "aria-label",
       "data-openwork-image-preview",
-      "data-openwork-image-toggle",
-      "data-openwork-image-toggle-label",
       "data-openwork-link-href",
       "data-openwork-link-chevron",
       "data-openwork-shiki",
@@ -277,7 +257,7 @@ function renderImage(profile: MarkdownProfile, href: string, title: string | nul
   const titleAttr = title ? ` title="${escapeAttribute(title)}"` : "";
 
   if (profile.imagePresentation === "chat") {
-    return `<span data-openwork-image-preview="collapsed" class="relative my-4 inline-block max-w-full align-top"><img src="${safe}" alt="${escapeAttribute(text)}"${titleAttr} loading="lazy" decoding="async" class="block h-auto w-auto rounded-lg border border-border/70 object-contain" style="max-height: ${MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT}px; max-width: ${MARKDOWN_IMAGE_PREVIEW_MAX_WIDTH}px"><button type="button" data-openwork-image-toggle="" hidden class="absolute inset-x-0 bottom-0 flex justify-center bg-gradient-to-t from-background via-background/90 to-transparent pb-2 pt-8"><span data-openwork-image-toggle-label="" class="rounded-full border border-border bg-background/95 px-3 py-1 text-xs font-medium text-foreground shadow-sm">Show full image</span></button></span>`;
+    return `<button type="button" data-openwork-image-preview="" class="my-4 inline-block max-w-full cursor-zoom-in align-top text-left transition-opacity hover:opacity-90" aria-label="Expand ${escapeAttribute(text)}"><img src="${safe}" alt="${escapeAttribute(text)}"${titleAttr} loading="lazy" decoding="async" class="block h-auto w-auto rounded-lg border border-border/70 object-contain" style="max-height: ${MARKDOWN_IMAGE_PREVIEW_MAX_HEIGHT}px; max-width: ${MARKDOWN_IMAGE_PREVIEW_MAX_WIDTH}px"></button>`;
   }
 
   return `<img src="${safe}" alt="${escapeAttribute(text)}"${titleAttr} loading="lazy" decoding="async" class="my-4 max-w-full rounded-[18px] border border-dls-border/70">`;

--- a/apps/app/src/components/markdown/markdown.tsx
+++ b/apps/app/src/components/markdown/markdown.tsx
@@ -2,6 +2,11 @@
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { motion } from "motion/react";
 
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog";
 import { cn } from "@/lib/utils";
 import { useOpenTargets } from "@/lib/target-provider";
 import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
@@ -98,6 +103,7 @@ function MarkdownBlockInner({
   const codeCopyResetTimers = useRef(new Map<HTMLButtonElement, number>());
   const { openTargets, onOpenTarget } = useOpenTargets();
   const [linkMenu, setLinkMenu] = useState<{ target: OpenTarget; rect: DOMRect } | null>(null);
+  const [imagePreview, setImagePreview] = useState<{ src: string; alt: string } | null>(null);
   const syncHtml = useMemo(() => {
     return renderMarkdownHtml(text);
   }, [text]);
@@ -229,16 +235,14 @@ function MarkdownBlockInner({
         }
       }
 
-      const button = event.target.closest("[data-openwork-image-toggle]");
-      if (!(button instanceof HTMLButtonElement)) return;
-
-      const preview = button.closest("[data-openwork-image-preview]");
+      const preview = event.target.closest("[data-openwork-image-preview]");
       if (!(preview instanceof HTMLElement)) return;
 
-      preview.dataset.openworkImagePreview = preview.dataset.openworkImagePreview === "expanded"
-        ? "collapsed"
-        : "expanded";
-      sync();
+      event.preventDefault();
+      event.stopPropagation();
+      const image = preview.querySelector("img");
+      if (!(image instanceof HTMLImageElement) || !image.src) return;
+      setImagePreview({ src: image.src, alt: image.alt || "Image" });
     };
 
     root.addEventListener("load", handleLoad, true);
@@ -281,6 +285,23 @@ function MarkdownBlockInner({
           onClose={() => setLinkMenu(null)}
         />
       ) : null}
+      <Dialog
+        open={imagePreview !== null}
+        onOpenChange={(open) => {
+          if (!open) setImagePreview(null);
+        }}
+      >
+        <DialogContent className="max-h-[90vh] w-auto max-w-[min(90vw,56rem)] overflow-hidden border-none bg-transparent p-0 shadow-none sm:max-w-[min(90vw,56rem)]">
+          <DialogTitle className="sr-only">{imagePreview?.alt ?? "Image"}</DialogTitle>
+          {imagePreview ? (
+            <img
+              src={imagePreview.src}
+              alt={imagePreview.alt}
+              className="max-h-[85vh] w-auto max-w-full rounded-xl object-contain"
+            />
+          ) : null}
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/apps/app/src/components/ui/image.tsx
+++ b/apps/app/src/components/ui/image.tsx
@@ -1,5 +1,11 @@
-import { cn } from "@/lib/utils"
 import * as React from "react"
+
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+} from "@/components/ui/dialog"
+import { cn } from "@/lib/utils"
 
 export type GeneratedImageLike = {
   src?: string
@@ -42,9 +48,7 @@ export const Image = ({
   ...props
 }: ImageProps) => {
   const [objectUrl, setObjectUrl] = React.useState<string | undefined>(undefined)
-  const [expanded, setExpanded] = React.useState(false)
-  const [canExpand, setCanExpand] = React.useState(false)
-  const imageRef = React.useRef<HTMLImageElement | null>(null)
+  const [open, setOpen] = React.useState(false)
 
   React.useEffect(() => {
     if (uint8Array && mediaType) {
@@ -62,39 +66,6 @@ export const Image = ({
   const base64Src = getImageSrc({ base64, mediaType })
   const imageSrc = src ?? base64Src ?? objectUrl
 
-  const updateCanExpand = React.useCallback((image: HTMLImageElement) => {
-    if (previewMaxHeight <= 0 && previewMaxWidth <= 0) {
-      setCanExpand(false)
-      return
-    }
-
-    if (!image.naturalWidth || !image.naturalHeight) {
-      setCanExpand(false)
-      return
-    }
-
-    const widerThanPreview = previewMaxWidth > 0 && image.naturalWidth > previewMaxWidth
-    const tallerThanPreview = previewMaxHeight > 0 && image.naturalHeight > previewMaxHeight
-    setCanExpand(widerThanPreview || tallerThanPreview)
-  }, [previewMaxHeight, previewMaxWidth])
-
-  React.useEffect(() => {
-    setExpanded(false)
-  }, [imageSrc])
-
-  React.useEffect(() => {
-    const image = imageRef.current
-    if (!image) return
-
-    updateCanExpand(image)
-
-    if (globalThis.ResizeObserver === undefined) return
-
-    const observer = new ResizeObserver(() => updateCanExpand(image))
-    observer.observe(image)
-    return () => observer.disconnect()
-  }, [imageSrc, updateCanExpand])
-
   if (!imageSrc) {
     return (
       <div
@@ -110,7 +81,7 @@ export const Image = ({
   }
 
   const constrained = previewMaxHeight > 0 || previewMaxWidth > 0
-  const previewStyle = !expanded && constrained
+  const previewStyle = constrained
     ? {
         ...style,
         ...(previewMaxHeight > 0 ? { maxHeight: previewMaxHeight } : {}),
@@ -120,20 +91,16 @@ export const Image = ({
 
   const image = (
     <img
-      ref={imageRef}
       src={imageSrc}
       alt={alt}
       className={cn(
         "h-auto w-auto overflow-hidden rounded-md object-contain",
-        expanded || !constrained ? "max-w-full" : null,
+        constrained ? null : "max-w-full",
         className
       )}
       role="img"
       style={previewStyle}
-      onLoad={(event) => {
-        updateCanExpand(event.currentTarget)
-        onLoad?.(event)
-      }}
+      onLoad={onLoad}
       {...props}
     />
   )
@@ -143,30 +110,26 @@ export const Image = ({
   }
 
   return (
-    <div className="inline-flex max-w-full flex-col items-start gap-1">
-      <div className="relative inline-block max-w-full overflow-hidden rounded-md">
+    <>
+      <button
+        type="button"
+        className="inline-block max-w-full cursor-zoom-in rounded-md text-left transition-opacity hover:opacity-90"
+        onClick={() => setOpen(true)}
+        aria-label={`Expand ${alt}`}
+        title={alt}
+      >
         {image}
-        {!expanded && canExpand ? (
-          <div className="absolute inset-x-0 bottom-0 flex justify-center bg-gradient-to-t from-background via-background/90 to-transparent pb-2 pt-8">
-            <button
-              type="button"
-              className="rounded-full border border-border bg-background/95 px-3 py-1 text-xs font-medium text-foreground shadow-sm transition-colors hover:bg-muted"
-              onClick={() => setExpanded(true)}
-            >
-              Show full image
-            </button>
-          </div>
-        ) : null}
-      </div>
-      {expanded && canExpand ? (
-        <button
-          type="button"
-          className="rounded-full border border-border px-3 py-1 text-xs font-medium text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
-          onClick={() => setExpanded(false)}
-        >
-          Show less
-        </button>
-      ) : null}
-    </div>
+      </button>
+      <Dialog open={open} onOpenChange={setOpen}>
+        <DialogContent className="max-h-[90vh] w-auto max-w-[min(90vw,56rem)] overflow-hidden border-none bg-transparent p-0 shadow-none sm:max-w-[min(90vw,56rem)]">
+          <DialogTitle className="sr-only">{alt}</DialogTitle>
+          <img
+            src={imageSrc}
+            alt={alt}
+            className="max-h-[85vh] w-auto max-w-full rounded-xl object-contain"
+          />
+        </DialogContent>
+      </Dialog>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- Remove the ugly “Show full image” overlay button from chat/assistant image previews
- Clicking a constrained preview opens the same full-size modal used by attachment badges
- Applies to both the shared `Image` component and markdown-rendered chat images

## Test plan
- [ ] Click an assistant/tool image preview → modal opens with full image; no overlay button
- [ ] Click a markdown image in chat → same modal behavior
- [ ] Esc / backdrop closes the modal


Made with [Cursor](https://cursor.com)