### PR TITLE
fix(cloud): clarify OpenWork Models entitlement and self-heal member access

### DIFF
--- a/apps/app/scripts/session-render-state.test.ts
+++ b/apps/app/scripts/session-render-state.test.ts
@@ -340,6 +340,13 @@ describe("describeOpencodeSessionError", () => {
       },
     })).toBe("Invalid JSON\nRetries: 3");
   });
+
+  it("maps OpenAI ChatGPT token refresh 401 to reconnect guidance", () => {
+    expect(describeOpencodeSessionError(new Error("Token refresh failed: 401"))).toBe(
+      "OpenAI couldn’t renew the ChatGPT sign-in for this worker. Retry once. If it happens again, reconnect OpenAI under Connect providers → OpenAI → ChatGPT Pro/Plus.",
+    );
+    expect(describeOpencodeSessionError("Token refresh failed: 403")).toBe("Token refresh failed: 403");
+  });
 });
 
 describe("applyRevertCursor", () => {

--- a/apps/app/src/app/cloud/desktop-app-restrictions.ts
+++ b/apps/app/src/app/cloud/desktop-app-restrictions.ts
@@ -55,15 +55,18 @@ type DesktopAppRestrictionSyncContext = {
 export async function runDesktopAppRestrictionSyncEffects(
   input: DesktopAppRestrictionSyncContext,
 ) {
+  // Only force-disable OpenCode Zen when org policy blocks it. When Zen is
+  // allowed, do not force-enable — that would undo a user Disconnect that
+  // wrote `opencode` into runtime disabled_providers.
   const shouldDisableOpencodeProvider = input.checkRestriction({ restriction: "allowZenModel" });
 
   input.reconcileRestrictedModels?.();
 
-  if (input.ensureProjectProviderDisabledState) {
+  if (shouldDisableOpencodeProvider && input.ensureProjectProviderDisabledState) {
     try {
       await input.ensureProjectProviderDisabledState(
         DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID,
-        shouldDisableOpencodeProvider,
+        true,
       );
     } catch (error) {
       input.onError?.(

--- a/apps/app/src/components/model-select.tsx
+++ b/apps/app/src/components/model-select.tsx
@@ -198,6 +198,8 @@ interface ModelSelectProps {
   onOpenChange: (open: boolean) => void;
   onChange: (model: ModelRef) => void;
   disabled?: boolean;
+  /** Den/import includes OpenWork Models — never show Subscribe while true. */
+  openWorkModelsEntitled?: boolean;
 }
 
 export function ModelSelect({
@@ -206,6 +208,7 @@ export function ModelSelect({
   onOpenChange,
   onChange,
   disabled = false,
+  openWorkModelsEntitled = false,
 }: ModelSelectProps) {
   const [search, setSearch] = React.useState("");
   const [promoHidden, setPromoHidden] = React.useState(isOpenWorkModelsPromoHidden);
@@ -250,9 +253,18 @@ export function ModelSelect({
     }),
   );
 
+  const openWorkModelsAvailable = React.useMemo(
+    () => hasOpenWorkModelsProvider(modelOptions.map((option) => option.providerID)),
+    [modelOptions],
+  );
+  const showOpenWorkModelsSyncing = openWorkModelsEntitled && !openWorkModelsAvailable;
   const showOpenWorkModelsPromo = React.useMemo(
-    () => openWorkModelsPromoEligible && !promoHidden && !hasOpenWorkModelsProvider(modelOptions.map((option) => option.providerID)),
-    [modelOptions, openWorkModelsPromoEligible, promoHidden],
+    () =>
+      openWorkModelsPromoEligible &&
+      !promoHidden &&
+      !openWorkModelsAvailable &&
+      !openWorkModelsEntitled,
+    [openWorkModelsAvailable, openWorkModelsEntitled, openWorkModelsPromoEligible, promoHidden],
   );
 
   const groups = React.useMemo(() => {
@@ -329,6 +341,24 @@ export function ModelSelect({
             />
           </CommandHeader>
           <CommandEmpty>No models found.</CommandEmpty>
+          {showOpenWorkModelsSyncing ? (
+            <div className="mx-1 mb-1 flex items-center gap-2 rounded-md border border-amber-6/60 bg-amber-2/40 px-2 py-1.5">
+              <ProviderIcon
+                providerId={OPENWORK_MODELS_PROVIDER_ID}
+                providerName={OPENWORK_MODELS_PROVIDER_NAME}
+                className="size-3.5 shrink-0 text-amber-11"
+                size={14}
+              />
+              <span className="min-w-0 flex-1">
+                <span className="block truncate text-xs font-medium text-foreground">
+                  {OPENWORK_MODELS_PROVIDER_NAME}
+                </span>
+                <span className="block truncate text-[11px] text-muted-foreground">
+                  Included — syncing into this workspace…
+                </span>
+              </span>
+            </div>
+          ) : null}
           <CommandList>
             {(group: ModelSelectGroup) => (
               <CommandGroup

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -520,6 +520,7 @@ export default {
   "den.cloud_section_title": "OpenWork Cloud",
   "den.cloud_sleep_hint": "Sign in to OpenWork Cloud to keep your tasks alive even when your computer sleeps.",
   "den.cloud_signed_in_desc": "You are signed in and ready to use OpenWork Cloud.",
+  "den.open_dashboard": "Open Den dashboard",
   "den.cloud_unavailable_body": "Local work remains available. Reconnecting automatically.",
   "den.cloud_unavailable_title": "OpenWork Cloud is temporarily unavailable.",
   "den.copy_signin_link": "Copy sign-in link",

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
@@ -7,6 +7,7 @@ declare const expect: (value: unknown) => {
 
 import { DEFAULT_DEN_BASE_URL, HOSTED_DEFAULT_DEN_BASE_URL, setDenBootstrapConfig } from "../../../app/lib/den";
 import {
+  hasOpenWorkModelsAvailable,
   isOpenWorkModelsPromoEligible,
   isOpenWorkModelsPromoEligibleForDenBaseUrl,
   shouldShowOpenWorkModelsPromo,
@@ -28,5 +29,22 @@ describe("OpenWork Models promo eligibility", () => {
     expect(isOpenWorkModelsPromoEligible()).toBe(false);
     expect(shouldShowOpenWorkModelsPromo()).toBe(false);
     expect(wasOpenWorkModelsStartupPromoShown()).toBe(true);
+  });
+});
+
+describe("hasOpenWorkModelsAvailable", () => {
+  test("requires a connected openwork provider with at least one model", () => {
+    expect(
+      hasOpenWorkModelsAvailable({
+        providerConnectedIds: ["openwork"],
+        providers: [{ id: "openwork", models: {} }],
+      }),
+    ).toBe(false);
+    expect(
+      hasOpenWorkModelsAvailable({
+        providerConnectedIds: ["openwork"],
+        providers: [{ id: "openwork", models: { "gpt-5": {} } }],
+      }),
+    ).toBe(true);
   });
 });

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.ts
@@ -71,6 +71,18 @@ export function hasOpenWorkModelsProvider(providerIds: readonly string[]) {
   return providerIds.some((id) => id.trim().toLowerCase() === OPENWORK_MODELS_PROVIDER_ID);
 }
 
+/** Local engine has OpenWork Models connected with at least one selectable model. */
+export function hasOpenWorkModelsAvailable(input: {
+  providerConnectedIds: readonly string[];
+  providers: ReadonlyArray<{ id: string; models?: Record<string, unknown> | null }>;
+}) {
+  if (!hasOpenWorkModelsProvider(input.providerConnectedIds)) return false;
+  const openwork = input.providers.find(
+    (provider) => provider.id.trim().toLowerCase() === OPENWORK_MODELS_PROVIDER_ID,
+  );
+  return Object.keys(openwork?.models ?? {}).length > 0;
+}
+
 export function getOpenWorkModelsActionUrl(
   isSignedIn: boolean,
   authMode: "sign-in" | "sign-up" = "sign-in",

--- a/apps/app/src/react-app/domains/cloud/use-openwork-models-startup-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/use-openwork-models-startup-promo.ts
@@ -24,10 +24,12 @@ export type UseOpenWorkModelsStartupPromoInput = {
   clientReady: boolean;
   workspaceId: string;
   providerConnectedIds: string[];
+  /** Org member already has OpenWork Models on Den — never upsell Subscribe. */
+  openWorkModelsEntitled?: boolean;
 };
 
 export function useOpenWorkModelsStartupPromo(input: UseOpenWorkModelsStartupPromoInput) {
-  const { clientReady, workspaceId, providerConnectedIds } = input;
+  const { clientReady, workspaceId, providerConnectedIds, openWorkModelsEntitled = false } = input;
   const navigate = useNavigate();
   const platform = usePlatform();
   const denAuth = useDenAuth();
@@ -54,7 +56,7 @@ export function useOpenWorkModelsStartupPromo(input: UseOpenWorkModelsStartupPro
       setOpen(false);
       return;
     }
-    if (!shellConfig.cloudSignin || promoHidden || hasOpenWorkModels) return;
+    if (!shellConfig.cloudSignin || promoHidden || hasOpenWorkModels || openWorkModelsEntitled) return;
     if (denAuth.status === "checking" || !clientReady || !workspaceId) return;
     if (wasOpenWorkModelsStartupPromoShown() || scheduledRef.current) return;
 
@@ -64,7 +66,7 @@ export function useOpenWorkModelsStartupPromo(input: UseOpenWorkModelsStartupPro
       setOpen(true);
     }, 900);
     return () => window.clearTimeout(timeout);
-  }, [clientReady, denAuth.status, hasOpenWorkModels, openWorkModelsPromoEligible, promoHidden, shellConfig.cloudSignin, workspaceId]);
+  }, [clientReady, denAuth.status, hasOpenWorkModels, openWorkModelsEntitled, openWorkModelsPromoEligible, promoHidden, shellConfig.cloudSignin, workspaceId]);
 
   const subscribe = useCallback(() => {
     setOpen(false);

--- a/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
@@ -118,6 +118,20 @@ function normalizeCode(code: string | null | undefined): string {
   return code?.trim().toLowerCase().replace(/[-.]/g, "_") ?? "";
 }
 
+function isProviderProjectionFailure(failure?: OpenworkCloudMcpFailure | null): boolean {
+  if (!failure) return false;
+  if (failure.stage === "provider_projection") return true;
+  const code = normalizeCode(failure.code);
+  if (
+    code === "provider_tool_projection_missing" ||
+    code === "provider_projection_missing" ||
+    code === "provider_projection_unavailable"
+  ) {
+    return true;
+  }
+  return code.includes("provider_projection") || code.includes("provider_tool_projection");
+}
+
 function normalizedContextScope(context: CloudMcpOperationContext): CloudMcpScope | null {
   return normalizeCloudMcpScope({
     denBaseUrl: context.denBaseUrl,
@@ -418,7 +432,7 @@ export function cloudMcpFailureStageLabel(input: {
   if (code.includes("auth") || code.includes("token") || code.includes("unauthorized")) return "Cloud authentication expired";
   if (code === "cloud_tools_missing") return "Cloud endpoint tools are missing";
   if (code === "cloud_status_missing" || code === "cloud_registration_failed") return "Cloud tools weren’t registered";
-  if (code.includes("provider_projection")) return "Current model can’t use Cloud tools";
+  if (isProviderProjectionFailure(input.health?.firstFailure)) return "Current model can’t use Cloud tools";
   if (code.includes("tool_ids") || code.includes("client_registration")) return "OpenWork components need updating";
   if (code === "extensions_plugin_missing") return "Agent instructions are out of date";
   if (code.includes("unreachable") || code.includes("connection") || code.includes("status_missing")) return "Cloud connection unavailable";
@@ -445,7 +459,7 @@ export function cloudMcpRecommendedAction(input: {
   if (code.includes("membership")) return "Ask an organization admin to grant access.";
   if (code.includes("scope")) return "Reconnect OpenWork Cloud with the required permissions.";
   if (code.includes("policy") || code.includes("forbidden") || code.includes("resource")) return "Check organization policy and resource access.";
-  if (code.includes("provider_projection")) return "Choose a model that can use OpenWork Cloud tools.";
+  if (isProviderProjectionFailure(input.health?.firstFailure)) return "Choose a model that can use OpenWork Cloud tools.";
   if (code.includes("tool_ids") || code.includes("client_registration")) return "Update OpenWork, then retry.";
   if (code === "extensions_plugin_missing") return "Reload the agent so OpenWork instructions are current.";
   if (code === "cloud_tools_missing") return "Reconnect OpenWork Cloud so the endpoint exposes search_capabilities and execute_capability.";

--- a/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.test.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.test.ts
@@ -7,7 +7,9 @@ import type {
   DenOrgLlmProviderModel,
 } from "../../../../app/lib/den";
 import type { CloudImportedProvider } from "../../../../app/cloud/import-state";
+import type { DenOrgLlmProviderConnection } from "../../../../app/lib/den";
 import {
+  buildCloudProviderConfig,
   getCloudManagedProviderId,
   getProviderModelIds,
   isCloudProviderOutOfSync,
@@ -79,5 +81,50 @@ describe("isCloudProviderOutOfSync", () => {
     );
 
     expect(isCloudProviderOutOfSync(liveProvider, importedFrom(baselineProvider))).toBe(true);
+  });
+});
+
+describe("buildCloudProviderConfig", () => {
+  test("omits empty models for openwork so catalog models can remain", () => {
+    const provider: DenOrgLlmProviderConnection = {
+      id: "lpr_openwork",
+      source: "openwork",
+      providerId: "openwork",
+      name: "OpenWork Models",
+      providerConfig: {
+        npm: "@openrouter/ai-sdk-provider",
+        api: "https://inference.openworklabs.com/api/v1",
+        env: ["OPENWORK_API_KEY"],
+      },
+      hasApiKey: true,
+      models: [],
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: UPDATED_AT,
+      apiKey: "ow_inf_test",
+      apiKeys: null,
+    };
+
+    const config = buildCloudProviderConfig(provider);
+    expect(config.models).toBe(undefined);
+    expect(config.name).toBe("OpenWork Models");
+  });
+
+  test("keeps an empty models map for non-openwork cloud providers", () => {
+    const provider: DenOrgLlmProviderConnection = {
+      id: "lpr_custom",
+      source: "custom",
+      providerId: "openrouter",
+      name: "OpenRouter",
+      providerConfig: { env: ["OPENROUTER_API_KEY"] },
+      hasApiKey: true,
+      models: [],
+      createdAt: "2024-01-01T00:00:00.000Z",
+      updatedAt: UPDATED_AT,
+      apiKey: "sk-test",
+      apiKeys: null,
+    };
+
+    const config = buildCloudProviderConfig(provider);
+    expect(config.models).toEqual({});
   });
 });

--- a/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.ts
@@ -146,8 +146,14 @@ export const buildCloudProviderConfig = (
     id: provider.providerId,
     name: provider.name,
     env: getCloudProviderEnv(provider.providerConfig),
-    models,
   };
+
+  // OpenWork Models are catalog-backed via OPENCODE_MODELS_URL. Den provisions
+  // the provider + key with zero model rows — writing `models: {}` can prevent
+  // the engine from keeping catalog models, so omit an empty map for openwork.
+  if (Object.keys(models).length > 0 || provider.source !== "openwork") {
+    next.models = models;
+  }
 
   if (
     typeof provider.providerConfig.npm === "string" &&

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -71,6 +71,7 @@ import {
 import { dispatchNewProviders } from "../../../../app/lib/provider-events";
 import { updateManagedDisabledProviders } from "../managed-engine-config";
 import {
+  DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID,
   isDesktopProviderBlocked,
   type DesktopAppRestrictionChecker,
 } from "../../../../app/cloud/desktop-app-restrictions";
@@ -635,6 +636,37 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       return false;
     }
 
+    // Prefer runtime OPENCODE_CONFIG injection (server SQLite) so OpenCode Zen
+    // and other built-in/env-backed providers can be disabled without editing
+    // the user's opencode.jsonc. Fall back to project config only when the
+    // managed runtime endpoint is unavailable.
+    const c = options.client();
+    const openworkSnapshot = options.openworkServer.getSnapshot();
+    const workspaceId = options.runtimeWorkspaceId();
+    const workspaceType = options.selectedWorkspaceDisplay().workspaceType;
+    const canUseManagedRuntime = Boolean(
+      openworkSnapshot.openworkServerClient && workspaceId?.trim() && workspaceType === "local",
+    );
+
+    if (canUseManagedRuntime || c) {
+      const result = await updateManagedDisabledProviders({
+        opencodeClient: c,
+        openworkClient: openworkSnapshot.openworkServerClient,
+        workspaceId,
+        workspaceType,
+        disabledProviders: nextDisabled,
+        removeFallbackKeyWhenEmpty: true,
+        markReloadRequired: () => options.markOpencodeConfigReloadRequired(),
+      });
+      options.setDisabledProviders(result.disabledProviders);
+      if (!result.managedRuntime) {
+        options.markOpencodeConfigReloadRequired();
+      }
+      refreshSnapshot();
+      emitChange();
+      return true;
+    }
+
     const updatedConfig = await updateProjectConfigFile(
       (raw) => formatConfigWithProviderDisabledState(raw, resolvedProviderId, disabled),
       (config) => {
@@ -649,7 +681,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     );
 
     if (!updatedConfig) {
-      throw new Error("Could not update opencode.jsonc for this workspace.");
+      throw new Error("Could not update disabled providers for this workspace.");
     }
 
     options.setDisabledProviders(nextDisabled);
@@ -1279,6 +1311,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     };
 
     try {
+      if (resolved.toLowerCase() === DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID) {
+        await ensureProjectProviderDisabledState(resolved, false);
+      }
       const trimmedCode = code?.trim();
       const result = await c.provider.oauth.callback({
         providerID: resolved,
@@ -1328,6 +1363,9 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     assertProviderAllowedByDesktopPolicy(providerId);
 
     try {
+      if (providerId.trim().toLowerCase() === DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID) {
+        await ensureProjectProviderDisabledState(providerId, false);
+      }
       await c.auth.set({ providerID: providerId, auth: { type: "api", key: trimmed } });
       await refreshProviders({ dispose: true });
       return `${t("status.connected")} ${providerId}`;
@@ -1682,6 +1720,20 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
 
     try {
+      // OpenCode Zen is built-in / env-backed. Credential removal alone leaves
+      // it connected — disable it via runtime OPENCODE_CONFIG injection.
+      if (resolved.toLowerCase() === DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID) {
+        try {
+          await removeProviderAuthCredentials(resolved);
+        } catch {
+          // Zen may have no stored credentials; disable still applies.
+        }
+        await ensureProjectProviderDisabledState(resolved, true);
+        await refreshProviders({ dispose: true });
+        removeProviderFromState(resolved);
+        return `${t("providers.disconnected_prefix")} ${resolved}`;
+      }
+
       await removeProviderAuthCredentials(resolved);
       const updated = await refreshProviders({ dispose: true });
       if (Array.isArray(updated?.connected) && updated.connected.includes(resolved)) {

--- a/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/use-session-provider-auth.ts
@@ -150,16 +150,15 @@ export function useSessionProviderAuth(input: UseSessionProviderAuthInput) {
 
   useEffect(() => {
     if (!opencodeClient || !selectedWorkspaceId) return;
+    // Org policy may force Zen off. Never force it back on — that races user Disconnect.
+    if (!checkDesktopRestriction({ restriction: "allowZenModel" })) return;
 
     void store
-      .ensureProjectProviderDisabledState(
-        "opencode",
-        checkDesktopRestriction({ restriction: "allowZenModel" }),
-      )
+      .ensureProjectProviderDisabledState("opencode", true)
       .catch((error) => {
         console.warn("[desktop-app-restrictions] failed to sync Zen restriction", error);
       });
-  }, [checkDesktopRestriction, disabledProviderIds, opencodeClient, selectedWorkspaceId, selectedWorkspaceRoot, store]);
+  }, [checkDesktopRestriction, opencodeClient, selectedWorkspaceId, selectedWorkspaceRoot, store]);
 
   useEffect(() => {
     store.syncFromOptions();

--- a/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
+++ b/apps/app/src/react-app/domains/session/modals/model-picker-modal.tsx
@@ -6,7 +6,7 @@ import {
   useRef,
   useState,
 } from "react";
-import { ArrowRight, Check, ChevronDown, ChevronRight, Search, Sparkles, Star, X } from "lucide-react";
+import { ArrowRight, Check, ChevronDown, ChevronRight, RefreshCw, Search, Sparkles, Star, X } from "lucide-react";
 import { useNavigate } from "react-router-dom";
 
 import {
@@ -57,6 +57,9 @@ export type ModelPickerModalProps = {
   onToggleProvider?: (providerId: string, enabled: boolean) => void;
   onOpenSettings: () => void;
   onClose: (options?: { restorePromptFocus?: boolean }) => void;
+  /** Den entitlement present; used to avoid a false Subscribe CTA while models sync. */
+  openWorkModelsEntitled?: boolean;
+  onRefreshOpenWorkModels?: () => void | Promise<void>;
 };
 
 type ProviderGroup = {
@@ -164,12 +167,26 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
     }
   }, [props.query, providerGroups]);
 
-  // Expand current provider on open
+  // Expand current + OpenWork groups once they appear (options often load async).
+  const autoExpandedRef = useRef<Set<string>>(new Set());
   useEffect(() => {
-    if (!props.open) return;
-    const current = providerGroups.find((g) => g.hasCurrent);
-    if (current) setExpandedProviders(new Set([current.id]));
-  }, [props.open]);
+    if (!props.open) {
+      autoExpandedRef.current = new Set();
+      return;
+    }
+    const toExpand: string[] = [];
+    const current = providerGroups.find((group) => group.hasCurrent);
+    if (current && !autoExpandedRef.current.has(current.id)) toExpand.push(current.id);
+    const openwork = providerGroups.find((group) => group.id === OPENWORK_MODELS_PROVIDER_ID);
+    if (openwork && !autoExpandedRef.current.has(openwork.id)) toExpand.push(openwork.id);
+    if (toExpand.length === 0) return;
+    for (const id of toExpand) autoExpandedRef.current.add(id);
+    setExpandedProviders((prev) => {
+      const next = new Set(prev);
+      for (const id of toExpand) next.add(id);
+      return next;
+    });
+  }, [props.open, providerGroups]);
 
   const toggleProvider = useCallback((id: string) => {
     setExpandedProviders((prev) => {
@@ -179,9 +196,18 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
     });
   }, []);
 
+  const openWorkModelsAvailable = useMemo(
+    () => hasOpenWorkModelsProvider(props.options.map((option) => option.providerID)),
+    [props.options],
+  );
+  const showOpenWorkModelsSyncing = Boolean(props.openWorkModelsEntitled) && !openWorkModelsAvailable;
   const showOpenWorkModelsPromo = useMemo(
-    () => openWorkModelsPromoEligible && !promoHidden && !hasOpenWorkModelsProvider(props.options.map((option) => option.providerID)),
-    [openWorkModelsPromoEligible, promoHidden, props.options],
+    () =>
+      openWorkModelsPromoEligible &&
+      !promoHidden &&
+      !openWorkModelsAvailable &&
+      !props.openWorkModelsEntitled,
+    [openWorkModelsPromoEligible, openWorkModelsAvailable, promoHidden, props.openWorkModelsEntitled],
   );
 
   const openOpenWorkModels = useCallback(() => {
@@ -242,6 +268,31 @@ export function ModelPickerModal(props: ModelPickerModalProps) {
               onChange={(e) => props.setQuery(e.target.value)}
             />
           </div>
+
+          {showOpenWorkModelsSyncing ? (
+            <div className="mb-3 flex shrink-0 items-center overflow-hidden rounded-2xl border border-amber-6/60 bg-amber-2/40">
+              <div className="flex min-w-0 flex-1 items-center gap-3 px-3 py-2.5">
+                <ProviderIcon providerId={OPENWORK_MODELS_PROVIDER_ID} providerName={OPENWORK_MODELS_PROVIDER_NAME} size={18} className="shrink-0 text-amber-11" />
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-1.5 text-[13px] font-medium text-dls-text">
+                    <span>{OPENWORK_MODELS_PROVIDER_NAME}</span>
+                  </div>
+                  <div className="truncate text-[11px] text-dls-secondary">
+                    Included on your plan — finish syncing to choose a model.
+                  </div>
+                </div>
+                <Button
+                  size="sm"
+                  variant="outline"
+                  className="shrink-0"
+                  onClick={() => void props.onRefreshOpenWorkModels?.()}
+                >
+                  <RefreshCw className="mr-1 size-3" />
+                  Refresh
+                </Button>
+              </div>
+            </div>
+          ) : null}
 
           {showOpenWorkModelsPromo ? (
             <div className="mb-3 flex shrink-0 items-center overflow-hidden rounded-2xl border border-blue-6/60 bg-blue-2/60 shadow-[0_12px_30px_-20px_rgba(var(--dls-accent-rgb),0.45)]">

--- a/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
+++ b/apps/app/src/react-app/domains/session/modals/use-model-picker.ts
@@ -126,7 +126,10 @@ export function useModelPicker(input: UseModelPickerInput) {
           isFree: false,
           isConnected: true,
           isRecommended: isNew,
-          source: /^lpr_/i.test(provider.id) ? "cloud" as const : undefined,
+          source:
+            /^lpr_/i.test(provider.id) || provider.id.trim().toLowerCase() === "openwork"
+              ? ("cloud" as const)
+              : undefined,
         });
       }
     }

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -69,6 +69,7 @@ type ComposerProps = {
   statusLabel: string;
   modelPickerOpen: boolean;
   selectedModel: ModelRef;
+  openWorkModelsEntitled?: boolean;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
   attachments: ComposerAttachment[];
@@ -1707,6 +1708,7 @@ export function ReactSessionComposer(props: ComposerProps) {
                     if (!props.steering) props.onModelChange(model);
                   }}
                   disabled={props.steering}
+                  openWorkModelsEntitled={props.openWorkModelsEntitled}
                 />
                 {props.modelUnavailable ? (
                   <span className="text-xs font-medium text-red-10">Model no longer available</span>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -162,6 +162,8 @@ export type SessionSurfaceProps = {
   modelPickerOpen: boolean;
   modelUnavailable?: boolean;
   selectedModel: ModelRef;
+  /** Den/import includes OpenWork Models for this org member (not just local sync). */
+  openWorkModelsEntitled?: boolean;
   onModelPickerOpenChange: (open: boolean) => void;
   onModelChange: (model: ModelRef) => void;
   onSendDraft: (draft: ComposerDraft, sessionId: string) => Promise<CloudMcpSubmissionResult>;
@@ -1810,6 +1812,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         statusLabel={statusLabel(snapshot ?? undefined, chatStreaming)}
         modelPickerOpen={props.modelPickerOpen}
         selectedModel={props.selectedModel}
+        openWorkModelsEntitled={props.openWorkModelsEntitled}
         onModelPickerOpenChange={props.onModelPickerOpenChange}
         onModelChange={props.onModelChange}
         attachments={attachments}

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -54,9 +54,22 @@ function withAttachmentRecoveryHint(text: string) {
   return `${text}\nAn attached file in this conversation uses a format the model can't read. Revert the conversation to before the attachment was sent, or start a new session.`;
 }
 
+/**
+ * OpenCode Codex/ChatGPT OAuth refresh failures surface as a raw engine string.
+ * Narrowly rewrite the 401 case so users reconnect OpenAI — not OpenWork Cloud.
+ */
+function withOpenAiTokenRefreshHint(text: string) {
+  if (!/Token refresh failed:\s*401/i.test(text)) return text;
+  return "OpenAI couldn’t renew the ChatGPT sign-in for this worker. Retry once. If it happens again, reconnect OpenAI under Connect providers → OpenAI → ChatGPT Pro/Plus.";
+}
+
+function withSessionErrorHints(text: string) {
+  return withOpenAiTokenRefreshHint(withAttachmentRecoveryHint(text));
+}
+
 export function describeOpencodeSessionError(error: unknown, fallback = "Session failed") {
-  if (error instanceof Error) return withAttachmentRecoveryHint(error.message || fallback);
-  if (typeof error === "string") return withAttachmentRecoveryHint(error.trim() || fallback);
+  if (error instanceof Error) return withSessionErrorHints(error.message || fallback);
+  if (typeof error === "string") return withSessionErrorHints(error.trim() || fallback);
   if (!error || typeof error !== "object") return fallback;
 
   const data = recordValue(error, "data");
@@ -77,7 +90,7 @@ export function describeOpencodeSessionError(error: unknown, fallback = "Session
   if (code) lines.push(`Code: ${code}`);
   if (retries !== null) lines.push(`Retries: ${retries}`);
   if (responseBody && responseBody !== message) lines.push(`Response: ${responseBody}`);
-  if (lines.some((line) => line !== fallback)) return withAttachmentRecoveryHint(lines.join("\n"));
+  if (lines.some((line) => line !== fallback)) return withSessionErrorHints(lines.join("\n"));
 
   const serialized = safeStringify(error);
   return serialized && serialized !== "{}" ? serialized : fallback;

--- a/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/cloud-account-section.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { Building2, Check, LogOut, Loader2 } from "lucide-react";
+import { ArrowUpRight, Building2, Check, LogOut, Loader2 } from "lucide-react";
 
 import type { DenOrgSummary } from "../../../../app/lib/den";
 import { Button } from "@/components/ui/button";
@@ -21,6 +21,7 @@ export interface CloudAccountSectionProps {
   orgsError: string | null;
   sessionBusy: boolean;
   onActiveOrgChange: (orgId: string) => void | Promise<void>;
+  onOpenDashboard: () => void;
   onRefreshOrgs: () => void | Promise<void>;
   onSignOut: () => void | Promise<void>;
 }
@@ -34,6 +35,7 @@ export function CloudAccountSection({
   orgsError,
   sessionBusy,
   onActiveOrgChange,
+  onOpenDashboard,
   onRefreshOrgs,
   onSignOut,
 }: CloudAccountSectionProps) {
@@ -44,7 +46,7 @@ export function CloudAccountSection({
   return (
     <section className="flex flex-col gap-y-6">
       {/* User identity */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-center justify-between gap-3">
         <div className="min-w-0 flex items-center gap-3">
           <div className="flex size-9 shrink-0 items-center justify-center rounded-full bg-dls-hover text-sm font-semibold text-dls-text">
             {(user?.name ?? user?.email ?? "?").charAt(0).toUpperCase()}
@@ -58,16 +60,26 @@ export function CloudAccountSection({
             ) : null}
           </div>
         </div>
-        <Button
-          variant="outline"
-          size="sm"
-          className="shrink-0"
-          onClick={() => void onSignOut()}
-          disabled={controlsDisabled}
-        >
-          <LogOut className="size-3.5" />
-          {authBusy ? t("den.signing_out") : t("den.sign_out")}
-        </Button>
+        <div className="flex shrink-0 flex-wrap items-center justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onOpenDashboard}
+            disabled={controlsDisabled}
+          >
+            {t("den.open_dashboard")}
+            <ArrowUpRight className="size-3.5" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => void onSignOut()}
+            disabled={controlsDisabled}
+          >
+            <LogOut className="size-3.5" />
+            {authBusy ? t("den.signing_out") : t("den.sign_out")}
+          </Button>
+        </div>
       </div>
 
       {/* Org picker (stepper-style) or connected org display */}

--- a/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/ai-view.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { Button } from "@/components/ui/button";
 import type { ReactNode } from "react";
-import { ArrowRight, CheckCircle2, KeyRound, X } from "lucide-react";
+import { ArrowRight, CheckCircle2, KeyRound, RefreshCw, X } from "lucide-react";
 
 import { t } from "@/i18n";
 import { ProviderIcon } from "../../../design-system/provider-icon";
@@ -38,13 +38,16 @@ export type AiSettingsViewProps = {
   providerDisconnectError: string | null;
   onOpenProviderAuth: () => void | Promise<void>;
   onDisconnectProvider: (providerId: string) => void | Promise<void>;
-  canDisconnectProvider: (source?: ConnectedProvider["source"]) => boolean;
+  canDisconnectProvider: (provider: ConnectedProvider) => boolean;
   /** Set of local provider IDs that were imported from cloud. */
   cloudProviderIds?: Set<string>;
   showOpenWorkModelsSubscribe?: boolean;
   /** Subtle fallback row when OpenWork Models is not connected and the banner was dismissed. */
   showOpenWorkModelsConnect?: boolean;
+  /** Den entitlement is present but local engine has no selectable openwork models yet. */
+  showOpenWorkModelsSyncing?: boolean;
   onSubscribeOpenWorkModels?: () => void | Promise<void>;
+  onRefreshOpenWorkModels?: () => void | Promise<void>;
   onDismissOpenWorkModels?: () => void | Promise<void>;
   cloudProvidersView?: ReactNode;
 };
@@ -174,12 +177,12 @@ export function AiSettingsView(props: AiSettingsViewProps) {
                       props.busy ||
                       props.providerAuthBusy ||
                       props.disconnectingProviderId !== null ||
-                      !props.canDisconnectProvider(provider.source)
+                      !props.canDisconnectProvider(provider)
                     }
                   >
                     {props.disconnectingProviderId === provider.id
                       ? t("settings.disconnecting")
-                      : props.canDisconnectProvider(provider.source)
+                      : props.canDisconnectProvider(provider)
                         ? t("settings.disconnect")
                         : t("settings.managed_by_env")}
                   </Button>
@@ -212,6 +215,33 @@ export function AiSettingsView(props: AiSettingsViewProps) {
             >
               Connect
               <ArrowRight className="ml-1.5 size-3.5" />
+            </Button>
+          </LayoutSectionItem>
+        ) : null}
+
+        {props.showOpenWorkModelsSyncing ? (
+          <LayoutSectionItem className="flex-row flex-wrap items-center justify-between gap-3 rounded-2xl border border-amber-6/50 bg-amber-2/20 px-4 py-3">
+            <div className="flex min-w-0 items-center gap-3">
+              <ProviderIcon providerId="openwork" size={20} className="text-amber-11" />
+              <div className="min-w-0">
+                <div className="flex items-center gap-2">
+                  <span className="truncate text-sm font-medium text-dls-text">OpenWork Models</span>
+                  <span className="shrink-0 rounded-full border border-amber-6 bg-amber-3 px-2 py-0.5 text-[10px] font-medium text-amber-11">
+                    Included — finish syncing
+                  </span>
+                </div>
+                <div className="truncate text-xs text-muted-foreground">
+                  Your plan includes OpenWork Models, but they are not ready in this workspace yet.
+                </div>
+              </div>
+            </div>
+            <Button
+              variant="outline"
+              onClick={() => void props.onRefreshOpenWorkModels?.()}
+              disabled={props.busy || props.providerAuthBusy}
+            >
+              <RefreshCw className="mr-1.5 size-3.5" />
+              Refresh models
             </Button>
           </LayoutSectionItem>
         ) : null}

--- a/apps/app/src/react-app/domains/settings/pages/cloud-account-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/cloud-account-view.tsx
@@ -235,6 +235,7 @@ export function CloudAccountView({ developerMode, session }: CloudAccountViewPro
             orgsError={session.orgsError}
             sessionBusy={session.sessionBusy}
             onActiveOrgChange={session.onActiveOrgChange}
+            onOpenDashboard={session.onOpenControlPlane}
             onRefreshOrgs={session.onRefreshOrgs}
             onSignOut={session.onSignOut}
           />

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -721,6 +721,30 @@ export function SessionRoute() {
   const handleModelPickerOpen = useCallback(() => {
     void sessionProviderAuthStore.runCloudProviderSync("model_picker_open");
   }, [sessionProviderAuthStore]);
+  const openWorkModelsEntitled = useMemo(() => {
+    if (!denAuth.isSignedIn) return false;
+    const fromOrg = sessionProviderAuthSnapshot.cloudOrgProviders.some(
+      (provider) =>
+        [provider.providerId, provider.source].some(
+          (value) => value?.trim().toLowerCase() === "openwork",
+        ),
+    );
+    const fromImport = Object.values(sessionProviderAuthSnapshot.importedCloudProviders ?? {}).some(
+      (provider) =>
+        [provider.providerId, provider.source, provider.sourceProviderId].some(
+          (value) => value?.trim().toLowerCase() === "openwork",
+        ),
+    );
+    return fromOrg || fromImport;
+  }, [
+    denAuth.isSignedIn,
+    sessionProviderAuthSnapshot.cloudOrgProviders,
+    sessionProviderAuthSnapshot.importedCloudProviders,
+  ]);
+  const refreshOpenWorkModels = useCallback(async () => {
+    await sessionProviderAuthStore.runCloudProviderSync("model_picker_open");
+    await sessionProviderAuthStore.refreshProviders();
+  }, [sessionProviderAuthStore]);
   const modelPicker = useModelPicker({
     client: opencodeClient,
     baseUrl: opencodeBaseUrl,
@@ -785,6 +809,7 @@ export function SessionRoute() {
     clientReady: Boolean(opencodeClient),
     workspaceId: selectedWorkspaceId,
     providerConnectedIds,
+    openWorkModelsEntitled,
   });
 
   const {
@@ -947,7 +972,13 @@ export function SessionRoute() {
       modelPickerOpen: modelPicker.compactOpen,
       modelUnavailable: selectedModelUnavailable,
       selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
-      onModelPickerOpenChange: modelPicker.setCompactOpen,
+      openWorkModelsEntitled,
+      onModelPickerOpenChange: (open: boolean) => {
+        modelPicker.setCompactOpen(open);
+        if (open) {
+          void sessionProviderAuthStore.runCloudProviderSync("model_picker_open");
+        }
+      },
       onModelChange: (model: ModelRef) => {
         local.setPrefs((previous) => ({
           ...previous,
@@ -1136,6 +1167,7 @@ export function SessionRoute() {
     modelVariantLabel,
     modelVariantValue,
     navigate,
+    openWorkModelsEntitled,
     opencodeBaseUrl,
     opencodeClient,
     providerConnectedIds,
@@ -1145,6 +1177,7 @@ export function SessionRoute() {
     selectedWorkspace,
     selectedWorkspaceId,
     selectedWorkspaceRoot,
+    sessionProviderAuthStore,
     sessionsByWorkspaceId,
     submitWithCloudMcpReadiness,
     token,
@@ -2409,6 +2442,8 @@ export function SessionRoute() {
         handleOpenSettings("/settings/general");
       }}
       onClose={() => { modelPicker.setOpen(false); modelPicker.setRecentProviderIds(new Set()); }}
+      openWorkModelsEntitled={openWorkModelsEntitled}
+      onRefreshOpenWorkModels={refreshOpenWorkModels}
     />
     </WorkspaceProvider>
   );

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -129,7 +129,7 @@ import { useCheckDesktopRestriction, useDesktopConfig } from "@/react-app/domain
 import { useRestrictionNotice } from "@/react-app/domains/cloud/restriction-notice-provider";
 import { useCloudProviderAutoSync } from "@/react-app/domains/cloud/use-cloud-provider-auto-sync";
 import {
-  hasOpenWorkModelsProvider,
+  hasOpenWorkModelsAvailable,
   hideOpenWorkModelsPromo,
   useOpenWorkModelsPromoEligibility,
   isOpenWorkModelsPromoHidden,
@@ -778,11 +778,24 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
   );
   const [openWorkModelsPromoHidden, setOpenWorkModelsPromoHidden] = useState(isOpenWorkModelsPromoHidden);
   const openWorkModelsPromoEligible = useOpenWorkModelsPromoEligibility();
-  const openWorkModelsConnected =
-    (cloudSession.isSignedIn && hasOpenWorkCloudProvider) ||
-    hasOpenWorkModelsProvider(providerConnectedIds);
-  const showOpenWorkModelsSubscribe = openWorkModelsPromoEligible && !openWorkModelsConnected && !openWorkModelsPromoHidden;
-  const showOpenWorkModelsConnect = openWorkModelsPromoEligible && !openWorkModelsConnected && openWorkModelsPromoHidden;
+  // Entitled = Den/import says OpenWork Models is included. Available = local
+  // engine actually exposes selectable openwork models.
+  const openWorkModelsEntitled = cloudSession.isSignedIn && hasOpenWorkCloudProvider;
+  const openWorkModelsAvailable = hasOpenWorkModelsAvailable({
+    providerConnectedIds,
+    providers,
+  });
+  const showOpenWorkModelsSyncing = openWorkModelsEntitled && !openWorkModelsAvailable;
+  const showOpenWorkModelsSubscribe =
+    openWorkModelsPromoEligible &&
+    !openWorkModelsEntitled &&
+    !openWorkModelsAvailable &&
+    !openWorkModelsPromoHidden;
+  const showOpenWorkModelsConnect =
+    openWorkModelsPromoEligible &&
+    !openWorkModelsEntitled &&
+    !openWorkModelsAvailable &&
+    openWorkModelsPromoHidden;
 
   useEffect(() => {
     const handlePromoChanged = () => setOpenWorkModelsPromoHidden(isOpenWorkModelsPromoHidden());
@@ -806,6 +819,11 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     }, 0);
   }, [cloudSession.baseUrl, navigate, platform, providerAuthStore, selectedWorkspaceId]);
 
+  const refreshOpenWorkModels = useCallback(async () => {
+    await providerAuthStore.runCloudProviderSync("settings_cloud_opened");
+    await providerAuthStore.refreshProviders();
+  }, [providerAuthStore]);
+
   const handleOpenProviderAuth = useCallback(() => {
     if (checkDesktopRestriction({ restriction: "allowCustomProviders" })) {
       restrictionNotice.show({
@@ -820,16 +838,15 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
 
   useEffect(() => {
     if (!activeClient || !selectedWorkspaceId) return;
+    // Org policy may force Zen off. Never force it back on — that races user Disconnect.
+    if (!checkDesktopRestriction({ restriction: "allowZenModel" })) return;
 
     void providerAuthStore
-      .ensureProjectProviderDisabledState(
-        "opencode",
-        checkDesktopRestriction({ restriction: "allowZenModel" }),
-      )
+      .ensureProjectProviderDisabledState("opencode", true)
       .catch((error) => {
         console.warn("[desktop-app-restrictions] failed to sync Zen restriction", error);
       });
-  }, [activeClient, checkDesktopRestriction, disabledProviders, providerAuthStore, selectedWorkspaceId, selectedWorkspaceRoot]);
+  }, [activeClient, checkDesktopRestriction, providerAuthStore, selectedWorkspaceId, selectedWorkspaceRoot]);
 
   const shareWorkspaceState = useShareWorkspaceState({
     workspaces,
@@ -1684,8 +1701,12 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     ? t("status.providers_connected", { count: providerConnectedIds.length })
     : t("settings.no_providers_connected");
   const providerConnectedIdSet = new Set(providerConnectedIds);
+  const disabledProviderIdSet = new Set(
+    disabledProviders.map((id) => id.trim().toLowerCase()).filter(Boolean),
+  );
   const connectedProviders = providers.flatMap((provider) =>
-    providerConnectedIdSet.has(provider.id)
+    providerConnectedIdSet.has(provider.id) &&
+    !disabledProviderIdSet.has(provider.id.trim().toLowerCase())
       ? [{
           id: provider.id,
           name: provider.name ?? provider.id,
@@ -2168,15 +2189,23 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
             providerDisconnectError={null}
             onOpenProviderAuth={handleOpenProviderAuth}
             onDisconnectProvider={async (providerId) => {
-              await providerAuthStore.disconnectProvider(providerId);
+              const message = await providerAuthStore.disconnectProvider(providerId);
+              if (typeof message === "string" && message.trim()) {
+                setConfigActionStatus(message);
+              }
             }}
-            canDisconnectProvider={(source) => source !== "env"}
-            cloudProviderIds={new Set(
-              Object.values(providerAuthSnapshot.importedCloudProviders ?? {}).map((p) => p.providerId)
-            )}
+            canDisconnectProvider={(provider) =>
+              provider.id.trim().toLowerCase() === "opencode" || provider.source !== "env"
+            }
+            cloudProviderIds={new Set([
+              ...Object.values(providerAuthSnapshot.importedCloudProviders ?? {}).map((p) => p.providerId),
+              ...(openWorkModelsEntitled || openWorkModelsAvailable ? ["openwork"] : []),
+            ])}
             showOpenWorkModelsSubscribe={showOpenWorkModelsSubscribe}
             showOpenWorkModelsConnect={showOpenWorkModelsConnect}
+            showOpenWorkModelsSyncing={showOpenWorkModelsSyncing}
             onSubscribeOpenWorkModels={subscribeToOpenWorkModels}
+            onRefreshOpenWorkModels={refreshOpenWorkModels}
             onDismissOpenWorkModels={dismissOpenWorkModelsPromo}
             cloudProvidersView={
               <CloudProvidersView

--- a/apps/app/tests/cloud-mcp-health.test.ts
+++ b/apps/app/tests/cloud-mcp-health.test.ts
@@ -432,6 +432,27 @@ describe("OpenWork Cloud MCP reconciler", () => {
       health: health({ usable: false, failure: failure("provider_projection_missing") }),
     })).toBe("Current model can’t use Cloud tools");
 
+    const canonicalProjectionFailure = {
+      ...failure("provider_tool_projection_missing"),
+      stage: "provider_projection" as const,
+      recommendedAction: "Choose a model that can use OpenWork Cloud tools",
+    };
+    expect(cloudMcpFailureStageLabel({
+      signedIn: true,
+      orgSelected: true,
+      health: health({ usable: false, failure: canonicalProjectionFailure }),
+    })).toBe("Current model can’t use Cloud tools");
+    expect(cloudMcpDisplaySummary({
+      signedIn: true,
+      orgSelected: true,
+      connecting: false,
+      health: health({ usable: false, failure: canonicalProjectionFailure }),
+    })).toMatchObject({
+      statusLabel: "Degraded",
+      stageLabel: "Current model can’t use Cloud tools",
+      recommendedAction: "Choose a model that can use OpenWork Cloud tools.",
+    });
+
     const summary = cloudMcpDisplaySummary({
       signedIn: true,
       orgSelected: true,

--- a/apps/app/tests/desktop-app-restrictions-sync.test.ts
+++ b/apps/app/tests/desktop-app-restrictions-sync.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from "bun:test";
+
+import { runDesktopAppRestrictionSyncEffects } from "../src/app/cloud/desktop-app-restrictions";
+
+describe("runDesktopAppRestrictionSyncEffects", () => {
+  test("force-disables OpenCode Zen only when org policy blocks it", async () => {
+    const calls: Array<{ providerId: string; disabled: boolean }> = [];
+
+    await runDesktopAppRestrictionSyncEffects({
+      checkRestriction: ({ restriction }) => restriction === "allowZenModel",
+      ensureProjectProviderDisabledState: async (providerId, disabled) => {
+        calls.push({ providerId, disabled });
+      },
+    });
+
+    expect(calls).toEqual([{ providerId: "opencode", disabled: true }]);
+  });
+
+  test("does not force-enable OpenCode Zen when org policy allows it", async () => {
+    const calls: Array<{ providerId: string; disabled: boolean }> = [];
+
+    await runDesktopAppRestrictionSyncEffects({
+      checkRestriction: () => false,
+      ensureProjectProviderDisabledState: async (providerId, disabled) => {
+        calls.push({ providerId, disabled });
+      },
+    });
+
+    expect(calls).toEqual([]);
+  });
+});

--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -1385,8 +1385,12 @@ async function readProviderProjection(input: {
   opencode: WorkspaceOpencodeClient;
   directory: string | null;
   providerModel: CloudMcpProviderModelContext;
+  /** Kept for call-site compatibility; experimental MCP omissions always fall back. */
   experimentalToolIdsIncludeMcpTools: boolean | null;
 }): Promise<ProviderProjectionSnapshot> {
+  // experimentalToolIdsIncludeMcpTools is intentionally unused: a global IDs hit
+  // must not hard-fail when the per-model experimental list omits MCP tools.
+  void input.experimentalToolIdsIncludeMcpTools;
   let experimentalSplit: ToolSnapshot | null = null;
   let experimentalError: unknown;
   try {
@@ -1414,29 +1418,10 @@ async function readProviderProjection(input: {
     experimentalError = thrownOpencodeFailure("provider_projection", "/experimental/tool", error).details;
   }
 
-  if (input.experimentalToolIdsIncludeMcpTools === true) {
-    const split = experimentalSplit ?? splitPresentMissing([], expectedTools());
-    const projectionFailure = failure({
-      code: "provider_tool_projection_missing",
-      stage: "provider_projection",
-      retryable: false,
-      recommendedAction: "Choose a model that can use OpenWork Cloud tools",
-      message: "The current provider/model projection is missing openwork-cloud tools.",
-      aliases: ["provider_projection_missing"],
-      details: { provider: input.providerModel.provider, model: input.providerModel.model, missing: split.missing, source: "experimental_tool" },
-    });
-    return {
-      checked: true,
-      provider: input.providerModel.provider,
-      model: input.providerModel.model,
-      source: "experimental_tool",
-      present: split.present,
-      missing: split.missing,
-      ...(experimentalError ? { error: experimentalError } : {}),
-      failure: projectionFailure,
-    };
-  }
-
+  // OpenCode's /experimental/tool enumerates ToolRegistry tools and often omits
+  // MCP tools that prompts still attach at runtime. Always fall back to
+  // /provider tool-call capability when the per-model experimental list is
+  // incomplete — even if global /experimental/tool/ids includes MCP tools.
   return readProviderCapability({
     opencode: input.opencode,
     directory: input.directory,

--- a/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
+++ b/apps/server/src/cloud-mcp-reconcile.e2e.test.ts
@@ -573,6 +573,32 @@ describe("openwork-cloud MCP strict reconcile", () => {
     });
   });
 
+  test("falls back to provider capability when global MCP tool IDs exist but per-model experimental projection omits them", async () => {
+    const root = await createRoot();
+    const mock = startMockOpencode({
+      // Global IDs include Cloud MCP tools…
+      toolIds: allReadyToolIds(),
+      // …but the per-model experimental list does not (OpenCode ToolRegistry quirk).
+      providerToolIds: [...OPENWORK_CLOUD_PLUGIN_CANARIES],
+      providerToolCalling: true,
+      cloudToolsAsSse: true,
+    });
+    const openwork = await startOpenwork([workspace("ws_1", root, `http://127.0.0.1:${mock.server.port}`)]);
+
+    const body = await responseRecord(await reconcile(openwork.base, "ws_1", { provider: "anthropic", model: "claude" }));
+    expect(body.phase).toBe("ready");
+    expect(body.usable).toBe(true);
+    expect(body.usableByCurrentModel).toBe(true);
+    expect(requireRecord(requireRecord(body.compatibility, "compatibility").experimentalToolIds, "experimentalToolIds")).toMatchObject({
+      includesMcpTools: true,
+    });
+    expect(requireRecord(requireRecord(body.tools, "tools").providerProjection, "projection")).toMatchObject({
+      source: "provider_capability",
+      modelExists: true,
+      toolCalling: true,
+    });
+  });
+
   test("reports extension canary missing when docs canary is present but extension canary is absent", async () => {
     const root = await createRoot();
     const mock = startMockOpencode({ toolIds: [...OPENWORK_CLOUD_EXPECTED_TOOLS, "openwork_docs_search"] });

--- a/ee/apps/den-api/src/inference.ts
+++ b/ee/apps/den-api/src/inference.ts
@@ -209,6 +209,59 @@ async function ensureMemberInferenceAccess(input: { organizationId: OrgId; membe
   await ensureOpenWorkLlmProviderForMember({ ...input, inferenceKey: key })
 }
 
+async function memberHasOpenWorkInferenceAccess(input: { organizationId: OrgId; memberId: MemberId }) {
+  const [provider] = await db
+    .select({ id: LlmProviderTable.id })
+    .from(LlmProviderTable)
+    .where(and(
+      eq(LlmProviderTable.organizationId, input.organizationId),
+      eq(LlmProviderTable.createdByOrgMembershipId, input.memberId),
+      eq(LlmProviderTable.source, "openwork"),
+      eq(LlmProviderTable.providerId, OPENWORK_PROVIDER_ID),
+    ))
+    .limit(1)
+  const [key] = await db
+    .select({ id: InferenceKeyTable.id })
+    .from(InferenceKeyTable)
+    .where(and(
+      eq(InferenceKeyTable.organization_id, input.organizationId),
+      eq(InferenceKeyTable.org_membership_id, input.memberId),
+      eq(InferenceKeyTable.status, "active"),
+    ))
+    .limit(1)
+
+  return Boolean(provider && key)
+}
+
+/**
+ * Re-provision this member's OpenWork Models key + LLM provider when the org
+ * has inference enabled but the member row was deleted or never created.
+ * Safe to call from member-facing list endpoints (self-heal).
+ */
+export async function repairMemberInferenceAccessIfNeeded(input: {
+  organizationId: OrgId
+  memberId: MemberId
+}): Promise<boolean> {
+  const [organization] = await db
+    .select({ metadata: OrganizationTable.metadata })
+    .from(OrganizationTable)
+    .where(eq(OrganizationTable.id, input.organizationId))
+    .limit(1)
+
+  const inference = readInferenceMetadata(organization?.metadata ?? null)
+  if (!inference) {
+    return false
+  }
+
+  if (await memberHasOpenWorkInferenceAccess(input)) {
+    return false
+  }
+
+  await revokeMemberInferenceKeys(input.memberId)
+  await ensureMemberInferenceAccess(input)
+  return true
+}
+
 export async function syncInferenceForOrganizationMembers(input: { organizationId: OrgId }) {
   const [organization] = await db
     .select({ metadata: OrganizationTable.metadata })
@@ -225,30 +278,10 @@ export async function syncInferenceForOrganizationMembers(input: { organizationI
   await syncInferenceLimitPolicies({ organizationId: input.organizationId, tier: inference.tier, memberCount: members.length })
 
   for (const member of members) {
-    const [provider] = await db
-      .select({ id: LlmProviderTable.id })
-      .from(LlmProviderTable)
-      .where(and(
-        eq(LlmProviderTable.organizationId, input.organizationId),
-        eq(LlmProviderTable.createdByOrgMembershipId, member.id),
-        eq(LlmProviderTable.source, "openwork"),
-        eq(LlmProviderTable.providerId, OPENWORK_PROVIDER_ID),
-      ))
-      .limit(1)
-    const [key] = await db
-      .select({ id: InferenceKeyTable.id })
-      .from(InferenceKeyTable)
-      .where(and(
-        eq(InferenceKeyTable.organization_id, input.organizationId),
-        eq(InferenceKeyTable.org_membership_id, member.id),
-        eq(InferenceKeyTable.status, "active"),
-      ))
-      .limit(1)
-
-    if (!provider || !key) {
-      await revokeMemberInferenceKeys(member.id)
-      await ensureMemberInferenceAccess({ organizationId: input.organizationId, memberId: member.id })
-    }
+    await repairMemberInferenceAccessIfNeeded({
+      organizationId: input.organizationId,
+      memberId: member.id,
+    })
   }
 }
 
@@ -530,6 +563,21 @@ export async function getInferenceStatus(organizationId: OrgId) {
     .limit(1)
   const memberCount = await activeMemberCount(organizationId)
   const inference = readInferenceMetadata(organization?.metadata ?? null)
+  // Admin status reads are a natural repair point: org can show ENABLED in Den
+  // while individual members are missing keys/providers after manual deletes.
+  if (inference?.enabled === true) {
+    try {
+      const members = await listOrgMembers(organizationId)
+      for (const member of members) {
+        await repairMemberInferenceAccessIfNeeded({
+          organizationId,
+          memberId: member.id,
+        })
+      }
+    } catch {
+      // Status should still return even if upstream key provisioning fails.
+    }
+  }
   const buckets = inference?.enabled === true ? await getActiveUsageBuckets(organizationId) : []
   return {
     enabled: inference?.enabled === true,

--- a/ee/apps/den-api/src/routes/org/llm-providers.ts
+++ b/ee/apps/den-api/src/routes/org/llm-providers.ts
@@ -32,6 +32,7 @@ import {
 import { getModelsDevProvider, listModelsDevProviders } from "../../llm/models-dev.js"
 import type { MemberTeamsContext } from "../../middleware/member-teams.js"
 import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
+import { repairMemberInferenceAccessIfNeeded } from "../../inference.js"
 import type { OrgRouteVariables } from "./shared.js"
 import { ensureOrganizationAdmin, idParamSchema, memberHasRole, orgAccessFailureStatus } from "./shared.js"
 
@@ -678,6 +679,21 @@ export function registerOrgLlmProviderRoutes<T extends { Variables: OrgRouteVari
       const query = c.req.valid("query")
       const payload = c.get("organizationContext")
       const memberTeams = c.get("memberTeams") ?? []
+
+      // Desktop entitlement is based on this list. If org inference is enabled
+      // but this member's OpenWork provider/key was deleted, re-provision before
+      // listing so Subscribe CTAs don't lie about an already-enabled org.
+      if (query.scope === "usable") {
+        try {
+          await repairMemberInferenceAccessIfNeeded({
+            organizationId: payload.organization.id,
+            memberId: payload.currentMember.id,
+          })
+        } catch {
+          // Keep listing other providers even if OpenWork re-provision fails.
+        }
+      }
+
       const providers = await loadLlmProviders({
         organizationId: payload.organization.id,
         currentMemberId: payload.currentMember.id,


### PR DESCRIPTION
## Summary
- Split OpenWork Models **entitled** (Den/import has `openwork`) vs **available** (local engine connected), so desktop no longer shows Subscribe when the org already has models enabled
- Den self-heals missing member inference keys/providers on usable LLM provider list and admin inference status reads (covers deleted member inference)
- Fix OpenCode Zen Disconnect racing with org policy sync that force-reenabled Zen; map OpenAI token-refresh 401 to reconnect guidance; soften Cloud MCP projection false “Degraded”

## Test plan
- [x] `bun test` targeted app suites: cloud-mcp-health, desktop-app-restrictions-sync, openwork-models-promo, cloud-provider-config (23 pass)
- [ ] Sign in to an org with OpenWork Models **ENABLED** in Den but no member `openwork` provider → open model picker / AI settings → should repair + sync (no Subscribe)
- [ ] Disconnect OpenCode Zen in AI settings → stays disconnected after refresh
- [ ] Account settings shows Open Den dashboard when signed in

## Evidence
### Build / tests
- App unit tests above: passed
- Den DB integration test for repair skipped locally (no MySQL on `127.0.0.1:3306`)

### UI verification
- Manual: Subscribe false-positive reproduced against Den ENABLED + missing member provider; compact picker now treats entitlement separately from local availability


Made with [Cursor](https://cursor.com)