### PR TITLE
feat(den): author organization prompts from chat

### DIFF
--- a/ee/apps/den-api/src/mcp/agent.ts
+++ b/ee/apps/den-api/src/mcp/agent.ts
@@ -8,7 +8,9 @@ import { openworkCloudMcpConnectionActionSchema } from "@openwork/types/den/mcp-
 import type { Hono } from "hono"
 import { z } from "zod"
 import { memberFacingMcpConnectionsEnabled } from "../capability-sources/external-mcp-rollout.js"
+import { checkEntitlement } from "../entitlements.js"
 import { publicRoute, tokenRoute } from "../middleware/index.js"
+import { ORGANIZATION_SUPER_ADMIN_ROLE, organizationRoleValueSatisfies } from "../organization-role-hierarchy.js"
 import { db } from "../db.js"
 import { getMcpResourceContext, verifyMcpRequest } from "./auth.js"
 import { invokeMcpOperation, normalizeToolBody, normalizeToolRecord } from "./invoke.js"
@@ -120,6 +122,43 @@ export const AGENT_MCP_INSTRUCTIONS = [
   "When a match has kind connection_status, name connectionStatus.connectionName and relay connectionStatus.action exactly. Distinguish the member's Your Connections page, the organization Connections dashboard, and the provider's own admin console.",
   "Connection probes are live. After the requested human fixes that connector, search again in the same task; otherwise do not retry unchanged or improvise workarounds through other tools.",
 ].join("\n")
+
+export const ORGANIZATION_PROMPT_SUGGESTIONS_AUTHORING_INSTRUCTION = [
+  "Organization prompt suggestions: Cloud. The signed-in member can manage them.",
+  "When asked, search for the desktop-policy list and organization prompt-suggestion update capabilities.",
+  "List policies first, confirm the target policy and its audience, then replace or clear only its two or three prompt cards.",
+  "Each card has a prompt of at most 500 characters and an optional description of at most 120 characters.",
+  "Execute only the exact capability returned by search, then verify the returned policy before reporting success.",
+].join(" ")
+
+export function canManageOrganizationPromptSuggestions(input: {
+  role?: string
+  organizationMetadata: Record<string, unknown> | null
+  planGatingEnabled?: boolean
+}) {
+  if (
+    !input.role
+    || !organizationRoleValueSatisfies({
+      roleValue: input.role,
+      requiredRole: ORGANIZATION_SUPER_ADMIN_ROLE,
+    })
+  ) {
+    return false
+  }
+  return checkEntitlement(
+    input.organizationMetadata,
+    "desktopPolicies",
+    input.planGatingEnabled === undefined ? {} : { gatingEnabled: input.planGatingEnabled },
+  ).ok
+}
+
+export function filterAgentApiCatalogForMember<T extends { path: string }>(
+  catalog: T[],
+  canManagePromptSuggestions: boolean,
+): T[] {
+  if (canManagePromptSuggestions) return catalog
+  return catalog.filter((operation) => !operation.path.startsWith("/v1/desktop-policies"))
+}
 
 async function mcpRequestMethod(request: Request): Promise<string | null> {
   if (request.method.toUpperCase() !== "POST") return null
@@ -282,12 +321,14 @@ export async function executeCapabilityWithBudget<T extends ExecuteCapabilityToo
   }
 }
 
-export function createAgentMcpServer(): McpServer {
+export function createAgentMcpServer(options: { canManagePromptSuggestions?: boolean } = {}): McpServer {
   return new McpServer({
     name: "openwork-den-api-agent",
     version: "1.0.0",
   }, {
-    instructions: AGENT_MCP_INSTRUCTIONS,
+    instructions: options.canManagePromptSuggestions
+      ? `${AGENT_MCP_INSTRUCTIONS}\n${ORGANIZATION_PROMPT_SUGGESTIONS_AUTHORING_INSTRUCTION}`
+      : AGENT_MCP_INSTRUCTIONS,
   })
 }
 
@@ -400,6 +441,11 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
     const externalMcpConnectionsEnabled = memberFacingMcpConnectionsEnabled(organizationRows[0]?.metadata, {
       gatingEnabled: env.mcpConnectionsGatingEnabled,
     })
+    const canManagePromptSuggestions = canManageOrganizationPromptSuggestions({
+      role: memberIdentity?.role,
+      organizationMetadata: organizationRows[0]?.metadata ?? null,
+    })
+    const agentApiCatalog = filterAgentApiCatalogForMember(catalog, canManagePromptSuggestions)
     let remoteSkills: RemoteSkillDescriptor[] = []
     const method = await mcpRequestMethod(c.req.raw)
     if (method === "initialize" || method === "resources/list" || method === "resources/read") {
@@ -410,7 +456,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
       }))
         .sort((a, b) => a.name.localeCompare(b.name) || a.capability.localeCompare(b.capability))
     }
-    const server = createAgentMcpServer()
+    const server = createAgentMcpServer({ canManagePromptSuggestions })
     if (method === "initialize" || method === "resources/list" || method === "resources/read") {
       registerAgentSkillResources({
         server,
@@ -429,6 +475,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
           "Search for a capability by keyword. This connection only exposes this tool and execute_capability —",
           "there is no list of individually-named tools to browse. Always search first.",
           "Search covers native Google Workspace capabilities (Gmail, Calendar, Drive, Gmail drafts), org-connected external MCPs, and namespaced OpenWork Admin tools for allowlisted platform admins.",
+          ...(canManagePromptSuggestions ? [ORGANIZATION_PROMPT_SUGGESTIONS_AUTHORING_INSTRUCTION] : []),
           "Try 2-4 keyword variants before deciding a capability is unavailable.",
           "Native API matches include pathParams, queryParams, hasBody, and bodySchema. External MCP matches include argumentsSchema, schemaDigest, and invocation.argumentsField.",
           "Marketplace skill matches return stored SKILL.md content when executed.",
@@ -445,7 +492,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
         const boundedLimit = limit ?? 5
         const sourceFilter = searchCapabilitySourceFilter(type)
         const marketplaceObjectTypes = type === "skills" ? skillMarketplaceObjectTypes : undefined
-        const restMatches = sourceFilter.api ? searchCapabilities(catalog, query, boundedLimit) : []
+        const restMatches = sourceFilter.api ? searchCapabilities(agentApiCatalog, query, boundedLimit) : []
         const adminMatches = sourceFilter.admin
           ? await searchAvailableAdminCapabilities(await resolvePlatformAdmin(), query, boundedLimit)
           : []
@@ -562,7 +609,7 @@ export function registerAgentMcpRoutes<T extends { Variables: Record<string, unk
               return { content: textContent(JSON.stringify(result.result, null, 2)) }
             }
 
-            const operation = catalog.find((candidate) => candidate.name === name)
+            const operation = agentApiCatalog.find((candidate) => candidate.name === name)
             if (!operation) {
               return {
                 isError: true,

--- a/ee/apps/den-api/src/mcp/external-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/external-capabilities.ts
@@ -78,6 +78,7 @@ export function parseExternalCapabilityName(name: string): { connectionId: strin
 export type McpMemberIdentity = {
   orgMembershipId: DenTypeId<"member">
   teamIds: DenTypeId<"team">[]
+  role?: string
 }
 
 /**
@@ -92,7 +93,7 @@ export async function resolveMcpMemberIdentity(input: {
 }): Promise<McpMemberIdentity | null> {
   const organizationId = normalizeDenTypeId("organization", input.organizationId)
   const rows = await db
-    .select({ id: MemberTable.id })
+    .select({ id: MemberTable.id, role: MemberTable.role })
     .from(MemberTable)
     .where(and(
       eq(MemberTable.userId, normalizeDenTypeId("user", input.userId)),
@@ -103,7 +104,7 @@ export async function resolveMcpMemberIdentity(input: {
   const member = rows[0]
   if (!member) return null
   const teams = await listTeamsForMember({ organizationId, memberId: member.id })
-  return { orgMembershipId: member.id, teamIds: teams.map((team) => team.id) }
+  return { orgMembershipId: member.id, teamIds: teams.map((team) => team.id), role: member.role }
 }
 
 function hasSharedCredential(connection: ExternalMcpConnectionRow): boolean {

--- a/ee/apps/den-api/src/mcp/policy.ts
+++ b/ee/apps/den-api/src/mcp/policy.ts
@@ -19,6 +19,7 @@ const SAFE_INCLUDED_TAGS = new Set([
   "Connectors",
   "GitHub",
   "Capability Sources",
+  "Organization Prompt Suggestions",
 ])
 
 const BLOCKED_OPERATION_IDS = new Set([

--- a/ee/apps/den-api/src/routes/org/desktop-policies.ts
+++ b/ee/apps/den-api/src/routes/org/desktop-policies.ts
@@ -11,6 +11,8 @@ import {
   desktopPolicyDocumentWriteSchema,
   normalizeDefaultDesktopPolicyDocument,
   normalizeDesktopPolicyDocument,
+  onboardingPromptDescriptionsSchema,
+  onboardingPromptsSchema,
   resolveDesktopPolicyDocumentWrite,
 } from "@openwork/types/den/desktop-policies"
 import type { Hono } from "hono"
@@ -36,6 +38,32 @@ const desktopPolicyWriteSchema = z.object({
   isEnabled: z.boolean().optional(),
   memberIds: z.array(denTypeIdSchema("member")).max(500).optional().default([]),
   teamIds: z.array(denTypeIdSchema("team")).max(500).optional().default([]),
+})
+
+const organizationPromptSuggestionsWriteSchema = z.object({
+  onboardingPrompts: onboardingPromptsSchema.nullable(),
+  onboardingPromptDescriptions: onboardingPromptDescriptionsSchema.nullable().optional(),
+}).superRefine((value, ctx) => {
+  if (value.onboardingPrompts === null) {
+    if (Array.isArray(value.onboardingPromptDescriptions)) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: "Descriptions cannot be provided when prompt suggestions are cleared.",
+        path: ["onboardingPromptDescriptions"],
+      })
+    }
+    return
+  }
+  if (
+    Array.isArray(value.onboardingPromptDescriptions)
+    && value.onboardingPromptDescriptions.length !== value.onboardingPrompts.length
+  ) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Provide one description for each prompt suggestion.",
+      path: ["onboardingPromptDescriptions"],
+    })
+  }
 })
 
 const desktopPolicyListResponseSchema = z.object({
@@ -147,7 +175,7 @@ export function registerOrgDesktopPolicyRoutes<T extends { Variables: OrgRouteVa
   app.get(
     "/v1/desktop-policies",
     describeRoute({
-      tags: ["Desktop Policies"],
+      tags: ["Desktop Policies", "Organization Prompt Suggestions"],
       summary: "List desktop policies",
       responses: {
         200: jsonResponse("Desktop policies returned successfully.", desktopPolicyListResponseSchema),
@@ -160,6 +188,81 @@ export function registerOrgDesktopPolicyRoutes<T extends { Variables: OrgRouteVa
       const payload = c.get("organizationContext")
       const desktopPolicies = await loadDesktopPolicies(payload.organization.id)
       return c.json({ definitions: desktopPolicyDefinitions, desktopPolicies })
+    },
+  )
+
+  app.put(
+    "/v1/desktop-policies/:desktopPolicyId/prompt-suggestions",
+    describeRoute({
+      tags: ["Desktop Policies", "Organization Prompt Suggestions"],
+      summary: "Update organization prompt suggestions for a desktop policy",
+      description: "Replaces or clears the new-session prompt suggestion cards without changing any other desktop policy settings or assignments.",
+      responses: {
+        200: jsonResponse("Organization prompt suggestions updated successfully.", desktopPolicyResponseSchema),
+        400: jsonResponse("The organization prompt suggestions were invalid.", invalidRequestSchema),
+        401: jsonResponse("The caller must be signed in to update organization prompt suggestions.", unauthorizedSchema),
+        402: jsonResponse("Organization prompt suggestions require an Enterprise plan.", enterprisePlanRequiredSchema),
+        403: jsonResponse("Only workspace owners and super-admins can update organization prompt suggestions.", forbiddenSchema),
+        404: jsonResponse("The desktop policy was not found.", notFoundSchema),
+      },
+    }),
+    orgRoleRoute(["super-admin"]),
+    paramValidator(desktopPolicyParamsSchema),
+    jsonValidator(organizationPromptSuggestionsWriteSchema),
+    async (c) => {
+      const payload = c.get("organizationContext")
+      const permission = ensureOrganizationSuperAdmin(c, "Only workspace owners and super-admins can manage organization prompt suggestions.")
+      if (!permission.ok) {
+        return c.json(permission.response, orgAccessFailureStatus(permission.response))
+      }
+
+      const entitlement = checkEntitlement(payload.organization.metadata, "desktopPolicies")
+      if (!entitlement.ok) {
+        return c.json(entitlement.response, entitlement.status)
+      }
+
+      let desktopPolicyId: DesktopPolicyId
+      try {
+        desktopPolicyId = parseDesktopPolicyId(c.req.valid("param").desktopPolicyId)
+      } catch {
+        return c.json({ error: "desktop_policy_not_found" }, 404)
+      }
+
+      const rows = await db
+        .select()
+        .from(DesktopPolicyTable)
+        .where(and(
+          eq(DesktopPolicyTable.id, desktopPolicyId),
+          eq(DesktopPolicyTable.organizationId, payload.organization.id),
+          isNull(DesktopPolicyTable.deletedAt),
+        ))
+        .limit(1)
+      const existing = rows[0]
+      if (!existing) return c.json({ error: "desktop_policy_not_found" }, 404)
+
+      const input = c.req.valid("json")
+      const currentPolicy = existing.isDefault === true
+        ? normalizeDefaultDesktopPolicyDocument(existing.policy)
+        : normalizeDesktopPolicyDocument(existing.policy)
+      const policy = resolveDesktopPolicyDocumentWrite({
+        value: {
+          ...currentPolicy,
+          onboardingPrompts: input.onboardingPrompts,
+          onboardingPromptDescriptions: input.onboardingPrompts === null
+            ? null
+            : input.onboardingPromptDescriptions ?? null,
+        },
+        isDefault: existing.isDefault === true,
+      })
+
+      await db
+        .update(DesktopPolicyTable)
+        .set({ policy, updatedAt: new Date() })
+        .where(eq(DesktopPolicyTable.id, existing.id))
+
+      const [desktopPolicy] = await loadDesktopPolicies(payload.organization.id)
+        .then((policies) => policies.filter((candidate) => candidate.id === existing.id))
+      return c.json({ desktopPolicy })
     },
   )
 

--- a/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-config-policy.test.ts
@@ -159,6 +159,35 @@ describe("agent-configurable org connections policy", () => {
     }))
   })
 
+  test("chat exposes only the narrow desktop-policy surfaces needed for organization prompt suggestions", () => {
+    expect(allowed("getV1DesktopPolicies")).toBe(true)
+    expect(allowed("putV1DesktopPoliciesByDesktopPolicyIdPromptSuggestions")).toBe(true)
+    expect(allowed("postV1DesktopPolicies")).toBe(false)
+    expect(allowed("patchV1DesktopPoliciesByDesktopPolicyId")).toBe(false)
+    expect(allowed("deleteV1DesktopPoliciesByDesktopPolicyId")).toBe(false)
+
+    const catalog = buildMcpCatalog(document)
+    const listMatches = searchCapabilities(catalog, "list desktop policies", 10)
+    const updateMatches = searchCapabilities(catalog, "update organization prompt suggestions", 10)
+    expect(listMatches).toContainEqual(expect.objectContaining({
+      method: "GET",
+      path: "/v1/desktop-policies",
+    }))
+    expect(updateMatches).toContainEqual(expect.objectContaining({
+      method: "PUT",
+      path: "/v1/desktop-policies/{desktopPolicyId}/prompt-suggestions",
+      hasBody: true,
+      bodySchema: expect.objectContaining({
+        type: "object",
+        properties: expect.objectContaining({
+          onboardingPrompts: expect.objectContaining({}),
+          onboardingPromptDescriptions: expect.objectContaining({}),
+        }),
+        required: expect.arrayContaining(["onboardingPrompts"]),
+      }),
+    }))
+  })
+
   test("agent capability search source filter can restrict searches to skills", () => {
     expect(searchCapabilitySourceFilter()).toEqual({
       api: true,

--- a/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
+++ b/ee/apps/den-api/test/mcp-agent-timeouts.test.ts
@@ -125,6 +125,74 @@ test("agent MCP server exposes steering instructions during initialize", async (
   await server.close()
 })
 
+test("organization prompt authoring instructions are conditional on verified management access", async () => {
+  const unavailableServer = agentModule.createAgentMcpServer()
+  const availableServer = agentModule.createAgentMcpServer({ canManagePromptSuggestions: true })
+  const unavailableClient = new Client({ name: "test-client", version: "1.0.0" })
+  const availableClient = new Client({ name: "test-client", version: "1.0.0" })
+  const unavailableTransports = createMemoryTransportPair()
+  const availableTransports = createMemoryTransportPair()
+
+  await unavailableServer.connect(unavailableTransports.server)
+  await unavailableClient.connect(unavailableTransports.client)
+  await availableServer.connect(availableTransports.server)
+  await availableClient.connect(availableTransports.client)
+
+  expect(unavailableClient.getInstructions()).not.toContain("Organization prompt suggestions: Cloud")
+  expect(availableClient.getInstructions()).toContain(agentModule.ORGANIZATION_PROMPT_SUGGESTIONS_AUTHORING_INSTRUCTION)
+  expect(availableClient.getInstructions()).toContain("confirm the target policy and its audience")
+  expect(availableClient.getInstructions()).toContain("verify the returned policy")
+
+  await unavailableClient.close()
+  await unavailableServer.close()
+  await availableClient.close()
+  await availableServer.close()
+})
+
+test("organization prompt authoring access requires both role and Enterprise entitlement", () => {
+  const enterprise = { plan: { tier: "enterprise", source: "manual" } }
+  const free = { plan: { tier: "free", source: "default" } }
+
+  expect(agentModule.canManageOrganizationPromptSuggestions({
+    role: "owner",
+    organizationMetadata: enterprise,
+    planGatingEnabled: true,
+  })).toBe(true)
+  expect(agentModule.canManageOrganizationPromptSuggestions({
+    role: "super-admin",
+    organizationMetadata: enterprise,
+    planGatingEnabled: true,
+  })).toBe(true)
+  expect(agentModule.canManageOrganizationPromptSuggestions({
+    role: "admin",
+    organizationMetadata: enterprise,
+    planGatingEnabled: true,
+  })).toBe(false)
+  expect(agentModule.canManageOrganizationPromptSuggestions({
+    role: "member",
+    organizationMetadata: enterprise,
+    planGatingEnabled: true,
+  })).toBe(false)
+  expect(agentModule.canManageOrganizationPromptSuggestions({
+    role: "owner",
+    organizationMetadata: free,
+    planGatingEnabled: true,
+  })).toBe(false)
+})
+
+test("desktop-policy capabilities are absent from a member catalog without prompt management access", () => {
+  const catalog = [
+    { name: "list-prompts", path: "/v1/desktop-policies" },
+    { name: "update-prompts", path: "/v1/desktop-policies/{desktopPolicyId}/prompt-suggestions" },
+    { name: "list-plugins", path: "/v1/plugins" },
+  ]
+
+  expect(agentModule.filterAgentApiCatalogForMember(catalog, false)).toEqual([
+    { name: "list-plugins", path: "/v1/plugins" },
+  ])
+  expect(agentModule.filterAgentApiCatalogForMember(catalog, true)).toEqual(catalog)
+})
+
 test("agent MCP server exposes a standards-shaped remote skill index", () => {
   const index = agentModule.buildAgentSkillIndex([{
     name: "customer-briefing",

--- a/ee/apps/den-api/test/me-desktop-config.test.ts
+++ b/ee/apps/den-api/test/me-desktop-config.test.ts
@@ -327,6 +327,38 @@ test("GET /v1/me/desktop-config returns the effective onboarding prompts", async
   expect(body.onboardingPromptDescriptions).toEqual(highPriorityOnboardingPromptDescriptions)
 })
 
+test("prompt-suggestion update replaces only the selected policy cards", async () => {
+  const invalid = await requestDesktopPolicyAdmin({
+    method: "PUT",
+    path: `/v1/desktop-policies/${encodeURIComponent(defaultPolicyId)}/prompt-suggestions`,
+    expectedStatus: 400,
+    body: {
+      onboardingPrompts: ["First invalid prompt", "Second invalid prompt"],
+      onboardingPromptDescriptions: ["Only one description"],
+    },
+  })
+  expect(invalid?.error).toBe("invalid_request")
+
+  const payload = await requestDesktopPolicyAdmin({
+    method: "PUT",
+    path: `/v1/desktop-policies/${encodeURIComponent(defaultPolicyId)}/prompt-suggestions`,
+    expectedStatus: 200,
+    body: {
+      onboardingPrompts: ["Chat-authored task", "Chat-authored follow-up"],
+      onboardingPromptDescriptions: ["Chat task", "Chat follow-up"],
+    },
+  })
+  if (!payload) throw new Error("Prompt suggestion update response was empty")
+  const updated = expectDesktopPolicy(payload)
+  expect(updated.id).toBe(defaultPolicyId)
+  expect(updated.isDefault).toBe(true)
+  expect(updated.policyName).toBe("Default desktop policy")
+  const policy = expectRecord(updated.policy, "Updated desktop policy was missing policy")
+  expect(policy.allowAlphaUpdates).toBe(false)
+  expect(policy.onboardingPrompts).toEqual(["Chat-authored task", "Chat-authored follow-up"])
+  expect(policy.onboardingPromptDescriptions).toEqual(["Chat task", "Chat follow-up"])
+})
+
 test("desktop policy CRUD preserves, replaces, and clears onboarding prompts and descriptions", async () => {
   const createPayload = await requestDesktopPolicyAdmin({
     method: "POST",


### PR DESCRIPTION
## Summary

- expose organization prompt-suggestion authoring to chat only for Enterprise owners and super-admins
- conditionally add short MCP guidance and remove the related capabilities from both discovery and execution for ineligible members
- add a purpose-built prompt-suggestion update route that preserves every other desktop-policy setting and assignment
- keep general desktop-policy creation, editing, and deletion unavailable to chat

## Why

Organization prompt suggestions already appear as new-session cards, but eligible administrators cannot manage them through chat. The agent should see this workflow only when the signed-in member can actually use it, following the same capability-search pattern used for cloud skill creation without adding a long universal prompt.

## Validation

- `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-agent-timeouts.test.ts` — 16 passed
- `pnpm --filter @openwork-ee/den-api exec bun test test/mcp-agent-config-policy.test.ts --test-name-pattern 'organization prompt suggestions'` — 1 passed
- `pnpm --filter @openwork-ee/den-api exec bun test test/me-desktop-config.test.ts --test-name-pattern 'prompt-suggestion update'` — 1 passed
- `pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit`
- `pnpm --filter @openwork-ee/den-api build`

## Manual verification

Not run yet.

1. Connect an Enterprise organization as an owner or super-admin and ask chat to update the organization prompt suggestions.
2. Confirm the agent lists policies first, confirms the intended policy/audience, and changes only the prompt cards.
3. Repeat as an admin/member or without the Enterprise entitlement and confirm the authoring instruction and capabilities are unavailable.

## Risk and scope

- no database migration
- existing tenant, role, entitlement, and privileged-session checks remain enforced by the route
- the new endpoint replaces or clears only prompt suggestions; it does not expose general desktop-policy mutation
