### PR TITLE
feat(app): keep queued drafts rich and allow send-now

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -111,6 +111,8 @@ export default {
   "composer.send_options": "More send options",
   "composer.queued_attachments_only": "{count} attachment(s)",
   "composer.queued_count": "{count} queued",
+  "composer.queued_send_now": "Send now",
+  "composer.queued_send_now_hint": "Send this message now instead of waiting for the agent to finish",
   "composer.escape_to_stop": "Hit Escape again to stop the agent",
   "composer.skill_source": "Skill",
   "composer.stop": "Stop",

--- a/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
+++ b/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
@@ -1,22 +1,134 @@
 /** @jsxImportSource react */
-import { ListPlus, X } from "lucide-react";
+import { ArrowUp, FileText, ListPlus, X } from "lucide-react";
+import { Fragment, type ReactNode } from "react";
 
+import { ImageAttachmentBadge } from "@/components/chat/image-attachment-badge";
 import { t } from "@/i18n";
+import type { ComposerAttachment, ComposerDraft, ComposerPart } from "@/app/types";
 
 export type QueuedMessagesPanelProps = {
-  messages: string[];
+  drafts: ComposerDraft[];
   onRemove: (index: number) => void;
+  onSendNow: (index: number) => void;
+  sending?: boolean;
 };
+
+const TOKEN_RE = /(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[skill [^\]]+\])/;
+
+function isImageAttachment(attachment: ComposerAttachment) {
+  return attachment.kind === "image" || attachment.mimeType.startsWith("image/");
+}
+
+function pastedLines(parts: ComposerPart[], label: string) {
+  for (const part of parts) {
+    if (part.type === "paste" && part.label === label) return part.lines;
+  }
+  return 1;
+}
+
+function QueuedDraftContent(props: { draft: ComposerDraft }) {
+  const attachmentsById = new Map(props.draft.attachments.map((attachment) => [attachment.id, attachment]));
+  const text = props.draft.text;
+  if (!text.trim() && props.draft.attachments.length > 0) {
+    return (
+      <span className="inline-flex flex-wrap items-center gap-1.5">
+        {props.draft.attachments.map((attachment) => (
+          <QueuedAttachmentChip key={attachment.id} attachment={attachment} />
+        ))}
+      </span>
+    );
+  }
+
+  const nodes: ReactNode[] = [];
+  let offset = 0;
+  for (const segment of text.split(TOKEN_RE)) {
+    if (!segment) continue;
+    const key = `${offset}:${segment}`;
+    offset += segment.length;
+
+    const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
+    if (attachmentMatch?.[1]) {
+      const attachment = attachmentsById.get(attachmentMatch[1]);
+      if (attachment) {
+        nodes.push(<QueuedAttachmentChip key={key} attachment={attachment} />);
+        continue;
+      }
+    }
+
+    const pasteMatch = segment.match(/^\[pasted text (.+)\]$/);
+    if (pasteMatch?.[1]) {
+      const lines = pastedLines(props.draft.parts, pasteMatch[1]);
+      nodes.push(
+        <span
+          key={key}
+          className="mx-0.5 inline-flex items-center rounded-full border border-amber-6/35 bg-amber-3/15 px-2.5 py-1 text-xs font-medium text-amber-11 align-middle"
+          title={`Pasted text · ${pasteMatch[1]}`}
+        >
+          {`Pasted · ${lines} line${lines === 1 ? "" : "s"}`}
+        </span>,
+      );
+      continue;
+    }
+
+    const skillMatch = segment.match(/^\[skill (.+)\]$/);
+    if (skillMatch?.[1]) {
+      nodes.push(
+        <span
+          key={key}
+          className="mx-0.5 inline-flex items-center rounded-full border border-violet-6/35 bg-violet-3/20 px-2.5 py-1 text-xs font-medium text-violet-11 align-middle"
+          title={`Skill: ${skillMatch[1]}`}
+        >
+          {skillMatch[1]}
+        </span>,
+      );
+      continue;
+    }
+
+    nodes.push(
+      <Fragment key={key}>{segment}</Fragment>,
+    );
+  }
+
+  if (nodes.length === 0) {
+    return (
+      <span className="text-gray-10">
+        {t("composer.queued_attachments_only", { count: props.draft.attachments.length })}
+      </span>
+    );
+  }
+
+  return <span className="inline">{nodes}</span>;
+}
+
+function QueuedAttachmentChip(props: { attachment: ComposerAttachment }) {
+  if (isImageAttachment(props.attachment) && props.attachment.previewUrl) {
+    return (
+      <ImageAttachmentBadge
+        src={props.attachment.previewUrl}
+        alt={props.attachment.name}
+        className="mx-0.5 align-middle"
+      />
+    );
+  }
+
+  return (
+    <span
+      className="mx-0.5 inline-flex h-10 max-w-[140px] items-center gap-1.5 rounded-xl border border-border/70 bg-muted/40 px-2 align-middle"
+      title={props.attachment.name}
+    >
+      <FileText className="size-3.5 shrink-0 text-muted-foreground" />
+      <span className="truncate text-[11px] font-medium text-foreground">{props.attachment.name}</span>
+    </span>
+  );
+}
 
 /**
  * Shows the follow-up messages the user has queued while the agent is busy.
  * Rendered above the composer (mirrors the QuestionPanel header style). Each
- * entry can be removed with an X. The whole panel hides when the queue is
- * empty — callers should simply not render it in that case, but we also guard
- * here for safety.
+ * entry can be sent immediately (arrow up) or removed (X).
  */
 export function QueuedMessagesPanel(props: QueuedMessagesPanelProps) {
-  if (props.messages.length === 0) return null;
+  if (props.drafts.length === 0) return null;
 
   return (
     <div className="overflow-hidden border-b border-dls-border bg-transparent">
@@ -26,29 +138,43 @@ export function QueuedMessagesPanel(props: QueuedMessagesPanelProps) {
             <ListPlus size={12} />
           </div>
           <div className="text-sm font-medium leading-5 text-gray-12">
-            {t("composer.queued_count", { count: props.messages.length })}
+            {t("composer.queued_count", { count: props.drafts.length })}
           </div>
         </div>
       </div>
 
       <div className="max-h-48 space-y-2 overflow-auto px-4 py-3">
-        {props.messages.map((message, index) => (
-          <div
-            key={index}
-            className="flex items-start justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 px-3 py-2.5"
-          >
-            <div className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm leading-5 text-gray-11">
-              {message}
-            </div>
-            <button
-              type="button"
-              onClick={() => props.onRemove(index)}
-              className="mt-0.5 flex size-5 shrink-0 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12"
-              title={t("common.remove")}
+        {props.drafts.map((draft, index) => (
+            <div
+              key={index}
+              className="flex items-start justify-between gap-3 rounded-xl border border-gray-6 bg-gray-1 px-3 py-2.5"
             >
-              <X size={13} />
-            </button>
-          </div>
+              <div className="min-w-0 flex-1 whitespace-pre-wrap break-words text-sm leading-5 text-gray-11">
+                <QueuedDraftContent draft={draft} />
+              </div>
+              <div className="mt-0.5 flex shrink-0 items-center gap-0.5">
+                <button
+                  type="button"
+                  onClick={() => props.onSendNow(index)}
+                  disabled={props.sending}
+                  className="flex size-5 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12 disabled:pointer-events-none disabled:opacity-40"
+                  title={t("composer.queued_send_now")}
+                  aria-label={t("composer.queued_send_now")}
+                >
+                  <ArrowUp size={13} />
+                </button>
+                <button
+                  type="button"
+                  onClick={() => props.onRemove(index)}
+                  disabled={props.sending}
+                  className="flex size-5 items-center justify-center rounded-md text-gray-10 transition-colors hover:bg-gray-3 hover:text-gray-12 disabled:pointer-events-none disabled:opacity-40"
+                  title={t("common.remove")}
+                  aria-label={t("common.remove")}
+                >
+                  <X size={13} />
+                </button>
+              </div>
+            </div>
         ))}
       </div>
     </div>

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -544,6 +544,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [cloudQueueRetryVersion, setCloudQueueRetryVersion] = useState(0);
   const sending = props.cloudMcpSubmissionState.status === "sending";
   const cloudQueueBlockedRef = useRef(false);
+  // Shared with promote-to-send so a manual send-now cannot race the idle drain.
+  const drainingQueueRef = useRef(false);
   const composerShellRef = useRef<HTMLDivElement>(null);
   const hydratedKeyRef = useRef<string | null>(null);
   const autoOpenedTargetRef = useRef<string | null>(null);
@@ -978,21 +980,41 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }, [appendQueuedDraft, attachments, buildDraft, clearComposer, draft, props.sessionId]);
 
   const removeQueuedDraft = useCallback((index: number) => {
+    const target = queuedDrafts[index];
     removeQueuedDraftFromStore(props.sessionId, index);
-  }, [props.sessionId, removeQueuedDraftFromStore]);
+    target?.attachments.forEach(revokeAttachmentPreview);
+  }, [props.sessionId, queuedDrafts, removeQueuedDraftFromStore]);
 
-  // One label per queued draft, kept index-aligned with `queuedDrafts` so the
-  // panel's remove action targets the correct entry. Attachment-only drafts
-  // (no text) fall back to a count label instead of being dropped.
-  const queuedMessages = useMemo(
-    () =>
-      queuedDrafts.map((draftItem) => {
-        const text = draftItem.text.trim();
-        if (text) return text;
-        return t("composer.queued_attachments_only", { count: draftItem.attachments.length });
-      }),
-    [queuedDrafts],
-  );
+  // Promote a queued follow-up to an immediate send (steer-style), instead of
+  // waiting for the idle drain. Guarded against the drain effect so the same
+  // draft cannot be delivered twice.
+  const [sendingQueued, setSendingQueued] = useState(false);
+  const sendQueuedDraftNow = useCallback(async (index: number) => {
+    if (drainingQueueRef.current || sendingQueued) return;
+    const target = queuedDrafts[index];
+    if (!target) return;
+    setSendingQueued(true);
+    removeQueuedDraftFromStore(props.sessionId, index);
+    try {
+      const result = await sendDraft(target);
+      if (result.outcome === "blocked" || result.outcome === "cancelled") {
+        prependQueuedDrafts(props.sessionId, [target]);
+        return;
+      }
+      target.attachments.forEach(revokeAttachmentPreview);
+    } catch {
+      prependQueuedDrafts(props.sessionId, [target]);
+    } finally {
+      setSendingQueued(false);
+    }
+  }, [
+    prependQueuedDrafts,
+    props.sessionId,
+    queuedDrafts,
+    removeQueuedDraftFromStore,
+    sendDraft,
+    sendingQueued,
+  ]);
 
   const handleAbort = useCallback(async () => {
     if (!chatStreaming) return;
@@ -1000,6 +1022,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     // Stop means stop: drop queued follow-ups before aborting, otherwise the
     // queue-drain effect below re-prompts the agent the moment the abort
     // lands and the session reports idle (#2014).
+    queuedDrafts.forEach((draftItem) => draftItem.attachments.forEach(revokeAttachmentPreview));
     clearQueuedDrafts(props.sessionId);
     // The prompt was sent through a directory-scoped client (session-route
     // passes the workspace root), so the abort must target the same scope —
@@ -1016,7 +1039,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     }
     captureAnalyticsEvent("task_run_stopped", {});
     await snapshotQuery.refetch();
-  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.sessionId, props.workspaceRoot, snapshotQuery.refetch]);
+  }, [chatStreaming, clearQueuedDrafts, opencodeClient, props.sessionId, props.workspaceRoot, queuedDrafts, snapshotQuery.refetch]);
 
   const handleDismissError = useCallback(() => {
     setError(null);
@@ -1026,9 +1049,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   // Drain the queued follow-ups once the session goes idle. OpenCode has no
   // server-side queue, so we send everything that's queued as a single merged
   // message. The ref guards against re-entrancy while the send is in flight.
-  const drainingQueueRef = useRef(false);
   useEffect(() => {
-    if (drainingQueueRef.current) return;
+    if (drainingQueueRef.current || sendingQueued) return;
     if (cloudQueueBlockedRef.current) return;
     if (queuedDrafts.length === 0) return;
     if (chatStreaming || liveStatus.type !== "idle") return;
@@ -1045,6 +1067,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
           prependQueuedDrafts(props.sessionId, drained);
         } else if (result.outcome === "cancelled") {
           prependQueuedDrafts(props.sessionId, drained);
+        } else {
+          drained.forEach((draftItem) => draftItem.attachments.forEach(revokeAttachmentPreview));
         }
       } catch {
         // Restore the queue so the user can retry / edit on failure.
@@ -1053,7 +1077,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         drainingQueueRef.current = false;
       }
     })();
-  }, [chatStreaming, clearQueuedDrafts, cloudQueueRetryVersion, liveStatus.type, prependQueuedDrafts, props.sessionId, queuedDrafts, sendDraft]);
+  }, [chatStreaming, clearQueuedDrafts, cloudQueueRetryVersion, liveStatus.type, prependQueuedDrafts, props.sessionId, queuedDrafts, sendDraft, sendingQueued]);
 
   useEffect(() => {
     if (props.cloudMcpSubmissionState.status !== "failed") {
@@ -1806,7 +1830,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
         busy={chatStreaming}
         steering={steering}
         submissionPreparing={preparingCloudTools}
-        queuedCount={queuedMessages.length}
+        queuedCount={queuedDrafts.length}
         disabled={model.transitionState !== "idle" || Boolean(props.modelUnavailable)}
         modelUnavailable={Boolean(props.modelUnavailable)}
         statusLabel={statusLabel(snapshot ?? undefined, chatStreaming)}
@@ -1850,12 +1874,17 @@ export function SessionSurface(props: SessionSurfaceProps) {
         isRemoteWorkspace={props.isRemoteWorkspace}
           isSandboxWorkspace={props.isSandboxWorkspace}
           onUploadInboxFiles={props.onUploadInboxFiles ?? handleUploadInboxFiles}
-          compactTopSpacing={Boolean(props.activeQuestion || (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission || queuedMessages.length > 0)}
+          compactTopSpacing={Boolean(props.activeQuestion || (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission || queuedDrafts.length > 0)}
           topAccessory={
-            props.activeQuestion || (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission || queuedMessages.length > 0 ? (
+            props.activeQuestion || (props.todos ?? []).some((todo) => todo.content.trim()) || props.activePermission || queuedDrafts.length > 0 ? (
               <div>
-                {queuedMessages.length > 0 ? (
-                  <QueuedMessagesPanel messages={queuedMessages} onRemove={removeQueuedDraft} />
+                {queuedDrafts.length > 0 ? (
+                  <QueuedMessagesPanel
+                    drafts={queuedDrafts}
+                    onRemove={removeQueuedDraft}
+                    onSendNow={(index) => void sendQueuedDraftNow(index)}
+                    sending={sendingQueued}
+                  />
                 ) : null}
                 {props.activeQuestion ? (
                   <QuestionPanel


### PR DESCRIPTION
## Summary
- Queued composer follow-ups keep inline image badges / paste / skill chips instead of raw `[attachment …]` tokens
- Add an arrow-up control on each queued item to send it immediately (promote from schedule → send)
- Guard promote vs idle queue-drain so the same draft can’t double-send

## Test plan
- [ ] While agent is busy, queue a message with inline images → queue panel shows thumbnails, not token text
- [ ] Click image badge in queue → full-size modal opens
- [ ] Click arrow up on a queued item → it sends now and leaves the queue
- [ ] Click X → removes queued item without sending
- [ ] Remaining queued items still drain when the agent goes idle


Made with [Cursor](https://cursor.com)