### PR TITLE
fix(branding): stop cleared icons from returning after restart

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -747,6 +747,7 @@ export async function refreshDenBootstrapConfigFromShell(): Promise<DenBootstrap
 
 export async function setDenBootstrapConfig(
   next: ShellDesktopBootstrapConfig,
+  options?: { dispatchSettingsChanged?: boolean },
 ): Promise<DenBootstrapConfig> {
   const normalized = resolveDenBootstrapConfig(next);
 
@@ -766,9 +767,11 @@ export async function setDenBootstrapConfig(
     applyDesktopBootstrapConfig(normalized);
   }
 
-  dispatchDenSettingsChanged({
-    settings: readDenSettings(),
-  });
+  if (options?.dispatchSettingsChanged !== false) {
+    dispatchDenSettingsChanged({
+      settings: readDenSettings(),
+    });
+  }
 
   return readDenBootstrapConfig();
 }

--- a/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
+++ b/apps/app/src/react-app/domains/cloud/desktop-config-provider.tsx
@@ -21,7 +21,9 @@ import {
   DenApiError,
   ensureDenActiveOrganization,
   normalizeDenDesktopConfig,
+  readDenBootstrapConfig,
   readDenSettings,
+  setDenBootstrapConfig,
   type DenDesktopConfig,
 } from "../../../app/lib/den";
 import { applyBrandAppName, applyBrandIcon } from "../../../app/lib/desktop";
@@ -30,8 +32,13 @@ import {
   denSessionUpdatedEvent,
   denSettingsChangedEvent,
 } from "../../../app/lib/den-session-events";
+import { isDesktopRuntime } from "../../../app/lib/runtime-env";
 import { resolveOpenworkConnection } from "../../shell/openwork-connection";
 import { useDenAuth } from "./den-auth-provider";
+import {
+  bootstrapBrandingFromDesktopConfig,
+  bootstrapBrandingNeedsSync,
+} from "./workspace-branding-restart";
 
 export type DesktopConfigStore = {
   config: DenDesktopConfig;
@@ -71,6 +78,10 @@ type DesktopConfigAction = {
   nextValue: DenDesktopConfig[DesktopConfigItem];
   previousValue: DenDesktopConfig[DesktopConfigItem];
 };
+
+function isBootstrapBrandingActionItem(item: DesktopConfigItem): boolean {
+  return item === "brandAppName" || item === "brandLogoUrl" || item === "brandIconUrl";
+}
 
 function getDesktopConfigCacheKey(): string {
   const settings = readDenSettings();
@@ -195,6 +206,27 @@ export function DesktopConfigProvider({ children }: DesktopConfigProviderProps) 
       const appName = typeof brandAppNameAction.nextValue === "string" ? brandAppNameAction.nextValue : null;
       document.title = appName ?? "OpenWork";
       void applyBrandAppName(appName).catch(() => null);
+    }
+
+    // Keep desktop-bootstrap.json aligned so a cleared wordmark/icon cannot
+    // resurrect from the install/connect snapshot on the next relaunch.
+    const shouldSyncBootstrapBranding = actions.some((action) =>
+      isBootstrapBrandingActionItem(action.item),
+    );
+    if (shouldSyncBootstrapBranding && isDesktopRuntime()) {
+      const bootstrap = readDenBootstrapConfig();
+      if (bootstrapBrandingNeedsSync(bootstrap, normalizedConfig)) {
+        const branding = bootstrapBrandingFromDesktopConfig(normalizedConfig);
+        void setDenBootstrapConfig(
+          {
+            ...bootstrap,
+            brandAppName: branding.brandAppName,
+            brandLogoUrl: branding.brandLogoUrl,
+            brandIconUrl: branding.brandIconUrl,
+          },
+          { dispatchSettingsChanged: false },
+        ).catch(() => undefined);
+      }
     }
 
     currentDesktopConfigRef.current = normalizedConfig;

--- a/apps/app/src/react-app/domains/cloud/workspace-branding-restart.test.ts
+++ b/apps/app/src/react-app/domains/cloud/workspace-branding-restart.test.ts
@@ -2,10 +2,13 @@ declare const describe: (name: string, fn: () => void) => void;
 declare const test: (name: string, fn: () => void) => void;
 declare const expect: (value: unknown) => {
   toBe: (expected: unknown) => void;
+  toEqual: (expected: unknown) => void;
   not: { toBe: (expected: unknown) => void };
 };
 
 import {
+  bootstrapBrandingFromDesktopConfig,
+  bootstrapBrandingNeedsSync,
   hasWorkspaceBranding,
   workspaceBrandingFingerprint,
 } from "./workspace-branding-restart";
@@ -26,5 +29,37 @@ describe("workspace branding restart", () => {
 
     expect(first).toBe(repeated);
     expect(first).not.toBe(changed);
+  });
+
+  test("maps cleared desktop branding to null bootstrap fields", () => {
+    expect(bootstrapBrandingFromDesktopConfig({
+      brandAppName: "Acme",
+      brandLogoUrl: "https://example.com/logo.png",
+      brandIconUrl: "https://example.com/icon.png",
+    })).toEqual({
+      brandAppName: "Acme",
+      brandLogoUrl: "https://example.com/logo.png",
+      brandIconUrl: "https://example.com/icon.png",
+    });
+    expect(bootstrapBrandingFromDesktopConfig({})).toEqual({
+      brandAppName: null,
+      brandLogoUrl: null,
+      brandIconUrl: null,
+    });
+  });
+
+  test("detects when bootstrap still holds a cleared brand icon or wordmark", () => {
+    expect(bootstrapBrandingNeedsSync(
+      { brandIconUrl: "https://example.com/icon.png", brandLogoUrl: "https://example.com/logo.png" },
+      {},
+    )).toBe(true);
+    expect(bootstrapBrandingNeedsSync(
+      { brandIconUrl: "https://example.com/icon.png" },
+      { brandIconUrl: "https://example.com/icon.png" },
+    )).toBe(false);
+    expect(bootstrapBrandingNeedsSync(
+      {},
+      { brandLogoUrl: "https://example.com/logo.png" },
+    )).toBe(true);
   });
 });

--- a/apps/app/src/react-app/domains/cloud/workspace-branding-restart.ts
+++ b/apps/app/src/react-app/domains/cloud/workspace-branding-restart.ts
@@ -1,10 +1,16 @@
-import type { DenDesktopConfig } from "../../../app/lib/den";
+import type { DenBootstrapConfig, DenDesktopConfig } from "../../../app/lib/den";
 
 const BRANDING_KEYS = [
   "brandAppName",
   "brandLogoUrl",
   "brandIconUrl",
   "brandAccentColor",
+] as const satisfies readonly (keyof DenDesktopConfig)[];
+
+const BOOTSTRAP_BRANDING_KEYS = [
+  "brandAppName",
+  "brandLogoUrl",
+  "brandIconUrl",
 ] as const satisfies readonly (keyof DenDesktopConfig)[];
 
 export function hasWorkspaceBranding(config: DenDesktopConfig): boolean {
@@ -25,4 +31,28 @@ export function workspaceBrandingFingerprint(
     config.brandIconUrl ?? null,
     config.brandAccentColor ?? null,
   ]);
+}
+
+export type BootstrapBrandingFields = {
+  brandAppName: string | null;
+  brandLogoUrl: string | null;
+  brandIconUrl: string | null;
+};
+
+export function bootstrapBrandingFromDesktopConfig(
+  config: DenDesktopConfig,
+): BootstrapBrandingFields {
+  return {
+    brandAppName: typeof config.brandAppName === "string" ? config.brandAppName : null,
+    brandLogoUrl: typeof config.brandLogoUrl === "string" ? config.brandLogoUrl : null,
+    brandIconUrl: typeof config.brandIconUrl === "string" ? config.brandIconUrl : null,
+  };
+}
+
+export function bootstrapBrandingNeedsSync(
+  bootstrap: Pick<DenBootstrapConfig, "brandAppName" | "brandLogoUrl" | "brandIconUrl">,
+  config: DenDesktopConfig,
+): boolean {
+  const next = bootstrapBrandingFromDesktopConfig(config);
+  return BOOTSTRAP_BRANDING_KEYS.some((key) => (bootstrap[key] ?? null) !== next[key]);
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -168,6 +168,8 @@ export function SidebarBrandMark({
   );
 }
 
+const DEFAULT_WORKSPACE_FAVICON_HREF = "/openwork-mark.svg";
+
 export function WorkspaceFavicon({
   metadata,
 }: {
@@ -176,16 +178,17 @@ export function WorkspaceFavicon({
   const iconUrl = getManagedBrandIconUrl(metadata ?? null);
 
   useEffect(() => {
-    if (!iconUrl) {
-      return;
-    }
-
     let favicon = document.head.querySelector<HTMLLinkElement>('link[rel="icon"]');
-    const created = favicon === null;
     if (!favicon) {
       favicon = document.createElement("link");
       favicon.rel = "icon";
       document.head.appendChild(favicon);
+    }
+
+    if (!iconUrl) {
+      favicon.href = DEFAULT_WORKSPACE_FAVICON_HREF;
+      favicon.removeAttribute("type");
+      return;
     }
 
     const previousHref = favicon.getAttribute("href");
@@ -197,12 +200,8 @@ export function WorkspaceFavicon({
       : "image/png";
 
     return () => {
-      if (created) {
-        favicon.remove();
-        return;
-      }
       if (previousHref === null) {
-        favicon.removeAttribute("href");
+        favicon.setAttribute("href", DEFAULT_WORKSPACE_FAVICON_HREF);
       } else {
         favicon.setAttribute("href", previousHref);
       }

--- a/ee/apps/den-web/tests/workspace-branding-polish.test.ts
+++ b/ee/apps/den-web/tests/workspace-branding-polish.test.ts
@@ -16,6 +16,8 @@ describe("workspace branding polish", () => {
     expect(source).toContain("export function WorkspaceFavicon");
     expect(source).toContain("getManagedBrandIconUrl(metadata ?? null)");
     expect(source).toContain('<WorkspaceFavicon metadata={orgContext?.organization.metadata} />');
+    expect(source).toContain('DEFAULT_WORKSPACE_FAVICON_HREF = "/openwork-mark.svg"');
+    expect(source).toContain("favicon.href = DEFAULT_WORKSPACE_FAVICON_HREF");
   });
 
   test("does not show the artificial loading line in the desktop identity preview", () => {


### PR DESCRIPTION
## Summary
- When Den clears wordmark/app icon, sync that clear into `desktop-bootstrap.json` so relaunch no longer restores the old dock/sidebar branding from the install/connect snapshot.
- Restore the Den dashboard favicon to the default OpenWork mark after a managed icon is cleared.

## Test plan
- [x] `bun test apps/app/src/react-app/domains/cloud/workspace-branding-restart.test.ts ee/apps/den-web/tests/workspace-branding-polish.test.ts`
- [ ] In Den Brand appearance: set square app icon → Save → confirm dock updates
- [ ] Clear square app icon → Save → quit and relaunch desktop app → confirm stock OpenWork dock icon stays (does not resurrect)
- [ ] Clear wordmark → confirm Den favicon returns to `/openwork-mark.svg`


Made with [Cursor](https://cursor.com)