### PR TITLE
fix(skills): hide legacy OpenCode customization skill

### DIFF
--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -70,6 +70,15 @@ describe("openwork runtime config file", () => {
     expect(mcp.posthog?.enabled).toBe(true);
     expect(parsed.default_agent).toBe("openwork");
     expect(Array.isArray(parsed.plugin)).toBe(true);
+    expect(parsed.agent).toMatchObject({
+      openwork: {
+        permission: {
+          skill: {
+            "customize-opencode": "deny",
+          },
+        },
+      },
+    });
   });
 
   test("openwork prompt has a static search-first Memory Bank section, distinct from ## Memory", async () => {

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -105,6 +105,12 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
         mode: "primary",
         temperature: 0.2,
         prompt: OPENWORK_AGENT_PROMPT,
+        permission: {
+          skill: {
+            // OpenWork supplies its own Cloud/local skill-creator routing.
+            "customize-opencode": "deny",
+          },
+        },
       },
     },
     plugin: [


### PR DESCRIPTION
## Summary

- deny OpenCode's embedded `customize-opencode` skill for the managed `openwork` agent
- keep the embedded skill available to standalone OpenCode and other agents
- let the Cloud/local `skill-creator` routing from #3039 remain the authoritative OpenWork skill-authoring path

## Root cause

OpenCode embeds `customize-opencode` in its native skill registry and advertises every permitted skill in the agent system prompt. OpenWork supplied newer `skill-creator` routing but did not deny the older engine-owned skill, so models could still select and load it.

## Checks

- `./bin/openwork-hub run mcp disable-customize-opencode-skill -- pnpm --filter openwork-server test -- src/openwork-runtime-config.test.ts src/opencode-plugins/openwork-extensions-preview-connect-steering.test.ts src/opencode-plugins/openwork-extensions-preview.test.ts` — 35 passed
- `./bin/openwork-hub run mcp disable-customize-opencode-skill -- pnpm --filter openwork-server typecheck` — passed
- `git diff --check` — passed

## Manual verification

Not run — developer verification deferred. Reviewers can start OpenWork, ask it to create a skill, and confirm the managed `openwork` agent no longer advertises or loads `customize-opencode` while the selected Cloud/local `skill-creator` guidance is still present.

## Risk and scope

The change is limited to the server-managed `openwork` agent permission policy. It does not remove the built-in from OpenCode, alter user-installed skills, or change other agents. No UI, OAuth, credential, tenant, or persistence boundaries changed.
