### PR TITLE
feat(app): add semantic agent surface

### DIFF
--- a/apps/app/src/react-app/ARCHITECTURE.md
+++ b/apps/app/src/react-app/ARCHITECTURE.md
@@ -126,6 +126,34 @@ Practical examples:
 - Creating a new task in a workspace navigates to
   `/workspace/<workspace-id>/session/<new-session-id>`.
 
+## Agent-readable workbench state
+
+The URL remains authoritative for the active workspace and primary session.
+`domains/session/chat/workbench-store.ts` owns the additional workbench state
+that a URL cannot represent: retained conversation tabs, the secondary split
+session, and which pane is focused. It is process memory so this state survives
+temporary navigation to Settings, but it does not replace route identity.
+
+`shell/openwork-context-projector.ts` combines route state, the workbench store,
+UI chrome state, and panel-tab state into the shared
+`OpenworkContextSnapshot` contract. `OpenworkContextPublisher` publishes that
+snapshot through `window.__openworkControl`; the desktop loopback bridge and
+`openwork-ui-mcp` expose the same contract without requiring every element to
+be mounted or visible.
+
+Control registrations have semantic metadata:
+
+- `kind: "query"` is a concurrent, side-effect-free read and must not focus the
+  desktop window.
+- `kind: "command"` can change UI, durable data, or an external system.
+  Commands are serialized and may use `expectedRevision` to reject stale work.
+- `effects`, `confirmation`, `availability`, and `executor` let agents choose
+  behavior from data instead of relying on a large steering prompt.
+
+Do not register backend reads as pretend navigation actions. Add an explicit
+query, keep UI commands outcome-oriented, and scope session operations by ID so
+split-screen sessions cannot be confused.
+
 ## Testing
 
 - Unit: `bun test tests/` (CI-gated). Pure logic and parsers belong here.

--- a/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.test.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/cloud-provider-config.test.ts
@@ -1,6 +1,9 @@
 declare const describe: (name: string, fn: () => void) => void;
 declare const test: (name: string, fn: () => void) => void;
-declare const expect: (value: unknown) => { toBe: (expected: unknown) => void };
+declare const expect: (value: unknown) => {
+  toBe: (expected: unknown) => void;
+  toEqual: (expected: unknown) => void;
+};
 
 import type {
   DenOrgLlmProvider,

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -79,6 +79,7 @@ import {
   type ConversationTabHistory,
   type ConversationHistoryDirection,
 } from "./conversation-tab-history";
+import { useWorkbenchStore, type WorkbenchSessionTab } from "./workbench-store";
 
 const STARTUP_SKELETON_ROWS = [
   { id: "intro", titleWidth: "42%", bodyWidth: "88%" },
@@ -87,11 +88,9 @@ const STARTUP_SKELETON_ROWS = [
 ];
 const GLOBAL_VOICE_SIDE_PANEL_KEY = "__openwork_voice__";
 const EMPTY_TRANSCRIPT_TARGETS: OpenTarget[] = [];
+const EMPTY_SESSION_TABS: WorkbenchSessionTab[] = [];
 
-export type OpenSessionTab = {
-  workspaceId: string;
-  sessionId: string;
-};
+export type OpenSessionTab = WorkbenchSessionTab;
 
 type PendingConversationHistoryNavigation = {
   history: ConversationTabHistory;
@@ -238,13 +237,6 @@ function sessionTitleForId(groups: WorkspaceSessionGroup[], id: string | null | 
   return match ? getDisplaySessionTitle(match.title) : "";
 }
 
-function sessionExistsInWorkspace(groups: WorkspaceSessionGroup[], workspaceId: string, sessionId: string | null | undefined) {
-  if (!sessionId) return false;
-  return groups.some((group) => (
-    group.workspace.id === workspaceId && group.sessions.some((session) => session.id === sessionId)
-  ));
-}
-
 function isTrackableAccessibleTarget(target: OpenTarget) {
   return isOpenableFileTarget(target) || isLocalhostBrowserTarget(target);
 }
@@ -370,12 +362,21 @@ export function SessionPage(props: SessionPageProps) {
   const [deleteOpen, setDeleteOpen] = useState(false);
   const [deleteBusy, setDeleteBusy] = useState(false);
   const [sessionActionId, setSessionActionId] = useState<string | null>(null);
-  const [sessionTabs, setSessionTabs] = useState<OpenSessionTab[]>([]);
+  const workbenchWorkspaceId = useWorkbenchStore((state) => state.workspaceId);
+  const workbenchTabs = useWorkbenchStore((state) => state.tabs);
+  const workbenchSplitSessionId = useWorkbenchStore((state) => state.splitSessionId);
+  const focusedWorkbenchPane = useWorkbenchStore((state) => state.focusedPane);
+  const syncWorkbench = useWorkbenchStore((state) => state.sync);
+  const openWorkbenchTab = useWorkbenchStore((state) => state.openTab);
+  const closeWorkbenchTab = useWorkbenchStore((state) => state.closeTab);
+  const setWorkbenchSplit = useWorkbenchStore((state) => state.setSplit);
+  const focusWorkbenchPane = useWorkbenchStore((state) => state.focusPane);
+  const sessionTabs = workbenchWorkspaceId === props.selectedWorkspaceId ? workbenchTabs : EMPTY_SESSION_TABS;
+  const splitSessionId = workbenchWorkspaceId === props.selectedWorkspaceId ? workbenchSplitSessionId : null;
   const [conversationHistory, setConversationHistory] = useState(() => (
     createConversationTabHistory(props.selectedWorkspaceId, props.selectedSessionId)
   ));
   const [pendingConversationHistoryNavigation, setPendingConversationHistoryNavigation] = useState<PendingConversationHistoryNavigation | null>(null);
-  const [splitSessionId, setSplitSessionId] = useState<string | null>(null);
   const [createGroupOpen, setCreateGroupOpen] = useState(false);
   const [createGroupLabel, setCreateGroupLabel] = useState("");
   const [createGroupWorkspaceId, setCreateGroupWorkspaceId] = useState<string | null>(null);
@@ -665,6 +666,7 @@ export function SessionPage(props: SessionPageProps) {
       id: "voice.panel.open",
       label: "Open Voice Mode",
       description: "Open the sticky Voice Mode right-side panel.",
+      effects: { data: "none", ui: "layout", external: false },
       sideEffect: "none",
       execute: () => {
         setCurrentSidePanel("voice");
@@ -679,6 +681,7 @@ export function SessionPage(props: SessionPageProps) {
       id: "voice.panel.close",
       label: "Close Voice Mode",
       description: "Close the Voice Mode right-side panel.",
+      effects: { data: "none", ui: "layout", external: false },
       sideEffect: "none",
       execute: () => {
         setCurrentSidePanel(null);
@@ -726,30 +729,28 @@ export function SessionPage(props: SessionPageProps) {
     return () => window.clearTimeout(id);
   }, [pendingConversationHistoryNavigation]);
   useEffect(() => {
-    setSessionTabs((current) => {
-      const currentWorkspaceTabs = current.filter((tab) => tab.workspaceId === props.selectedWorkspaceId);
-      const next = props.selectedSessionId && !currentWorkspaceTabs.some((tab) => tab.sessionId === props.selectedSessionId)
-        ? [...currentWorkspaceTabs, { workspaceId: props.selectedWorkspaceId, sessionId: props.selectedSessionId }]
-        : currentWorkspaceTabs;
-      return next.filter((tab) => (
-        tab.sessionId === props.selectedSessionId ||
-        sessionExistsInWorkspace(props.sidebar.workspaceSessionGroups, tab.workspaceId, tab.sessionId)
-      ));
+    const workspaceGroup = props.sidebar.workspaceSessionGroups.find(
+      (group) => group.workspace.id === props.selectedWorkspaceId,
+    );
+    syncWorkbench({
+      workspaceId: props.selectedWorkspaceId,
+      primarySessionId: props.selectedSessionId,
+      sessionsKnown: workspaceGroup?.status === "ready",
+      sessions: (workspaceGroup?.sessions ?? []).map((session) => ({
+        workspaceId: props.selectedWorkspaceId,
+        sessionId: session.id,
+        title: getDisplaySessionTitle(session.title),
+      })),
     });
-  }, [props.selectedSessionId, props.selectedWorkspaceId, props.sidebar.workspaceSessionGroups]);
+  }, [
+    props.selectedSessionId,
+    props.selectedWorkspaceId,
+    props.sidebar.workspaceSessionGroups,
+    syncWorkbench,
+  ]);
   useEffect(() => {
     props.onSessionTabsChange?.(sessionTabs);
   }, [sessionTabs, props.onSessionTabsChange]);
-  useEffect(() => {
-    if (!splitSessionId) return;
-    if (splitSessionId === props.selectedSessionId) {
-      setSplitSessionId(null);
-      return;
-    }
-    if (!sessionExistsInWorkspace(props.sidebar.workspaceSessionGroups, props.selectedWorkspaceId, splitSessionId)) {
-      setSplitSessionId(null);
-    }
-  }, [props.selectedSessionId, props.selectedWorkspaceId, props.sidebar.workspaceSessionGroups, splitSessionId]);
   const sessionActionTitle = useMemo(
     () => sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionActionId),
     [props.sidebar.workspaceSessionGroups, sessionActionId],
@@ -826,18 +827,66 @@ export function SessionPage(props: SessionPageProps) {
   );
 
   const openSessionTab = useCallback((workspaceId: string, sessionId: string) => {
-    setSessionTabs((current) => {
-      const next = current.filter((tab) => tab.workspaceId === workspaceId);
-      if (next.some((tab) => tab.sessionId === sessionId)) return next;
-      return [...next, { workspaceId, sessionId }];
+    openWorkbenchTab({
+      workspaceId,
+      sessionId,
+      title: sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionId),
     });
     props.sidebar.onOpenSession(workspaceId, sessionId);
-  }, [props.sidebar]);
+  }, [openWorkbenchTab, props.sidebar]);
+
+  const focusWorkbenchSessionControlAction = useMemo<OpenworkControlAction>(() => ({
+    id: "workbench.session.focus",
+    label: "Focus an open session",
+    description: "Focus a session already visible in either split-screen pane, or reuse its existing tab without opening a duplicate.",
+    effects: { data: "none", ui: "navigate", external: false },
+    sideEffect: "navigation",
+    requiresArgs: true,
+    args: [{
+      name: "sessionId",
+      type: "string",
+      required: true,
+      description: "Session id from the OpenWork context resources or conversation tabs.",
+    }],
+    execute: (args) => {
+      if (!args || typeof args !== "object" || !("sessionId" in args) || typeof args.sessionId !== "string") {
+        return { ok: false, error: "sessionId is required" };
+      }
+      const sessionId = args.sessionId.trim();
+      if (!sessionId) return { ok: false, error: "sessionId is required" };
+      if (sessionId === props.selectedSessionId) {
+        focusWorkbenchPane("primary");
+        return { ok: true, sessionId, reused: "primary-pane" };
+      }
+      if (sessionId === splitSessionId) {
+        focusWorkbenchPane("secondary");
+        return { ok: true, sessionId, reused: "secondary-pane" };
+      }
+      const tab = sessionTabs.find((entry) => entry.sessionId === sessionId);
+      if (tab) {
+        props.sidebar.onOpenSession(tab.workspaceId, tab.sessionId);
+        return { ok: true, sessionId, reused: "tab" };
+      }
+      const workspace = props.sidebar.workspaceSessionGroups.find((group) => (
+        group.sessions.some((session) => session.id === sessionId)
+      ));
+      if (!workspace) return { ok: false, error: `Session is unavailable: ${sessionId}` };
+      openSessionTab(workspace.workspace.id, sessionId);
+      return { ok: true, sessionId, reused: "new-tab" };
+    },
+  }), [
+    focusWorkbenchPane,
+    openSessionTab,
+    props.selectedSessionId,
+    props.sidebar,
+    sessionTabs,
+    splitSessionId,
+  ]);
+  useControlAction(focusWorkbenchSessionControlAction);
 
   const closeSessionTab = useCallback((sessionId: string) => {
     const nextTab = sessionTabs.find((tab) => tab.sessionId !== sessionId && tab.workspaceId === props.selectedWorkspaceId);
-    setSessionTabs((current) => current.filter((tab) => tab.sessionId !== sessionId));
-    setSplitSessionId((current) => current === sessionId ? null : current);
+    closeWorkbenchTab(sessionId);
     setPendingConversationHistoryNavigation(null);
     setConversationHistory((current) => removeConversationHistoryEntry(current, props.selectedWorkspaceId, sessionId));
     if (sessionId !== props.selectedSessionId) return;
@@ -847,7 +896,7 @@ export function SessionPage(props: SessionPageProps) {
       return;
     }
     props.sidebar.onSelectWorkspace(props.selectedWorkspaceId);
-  }, [props.selectedSessionId, props.selectedWorkspaceId, props.sidebar, sessionTabs]);
+  }, [closeWorkbenchTab, props.selectedSessionId, props.selectedWorkspaceId, props.sidebar, sessionTabs]);
 
   const navigateConversationHistory = useCallback((direction: ConversationHistoryDirection) => {
     if (!canNavigateSelectedConversationHistory(
@@ -1173,7 +1222,7 @@ export function SessionPage(props: SessionPageProps) {
                               <button
                                 type="button"
                                 className="rounded p-0.5 text-dls-secondary hover:bg-dls-hover hover:text-dls-text disabled:pointer-events-none disabled:opacity-40"
-                                onClick={() => setSplitSessionId(split ? null : tab.sessionId)}
+                                onClick={() => setWorkbenchSplit(split ? null : tab.sessionId)}
                                 disabled={active}
                                 title={split ? "Close split" : "Open in split view"}
                                 aria-label={split ? "Close split" : "Open in split view"}
@@ -1196,7 +1245,12 @@ export function SessionPage(props: SessionPageProps) {
                     </div>
                   ) : null}
                   <div className="flex min-h-0 flex-1 flex-col lg:flex-row">
-                    <div className={cn("min-h-0 min-w-0 flex-1", canRenderSplitSurface && "lg:border-r lg:border-border")}>
+                    <div
+                      className={cn("min-h-0 min-w-0 flex-1", canRenderSplitSurface && "lg:border-r lg:border-border")}
+                      data-workbench-pane="primary"
+                      data-workbench-pane-focused={focusedWorkbenchPane === "primary" ? "true" : undefined}
+                      onPointerDown={() => focusWorkbenchPane("primary")}
+                    >
                       <SessionSurface
                         // Spread `surface` first so the explicit per-workspace
                         // routing props below CAN'T be silently overridden by
@@ -1223,7 +1277,12 @@ export function SessionPage(props: SessionPageProps) {
                       />
                     </div>
                     {canRenderSplitSurface ? (
-                      <div className="min-h-0 min-w-0 flex-1 border-t border-border lg:border-t-0">
+                      <div
+                        className="min-h-0 min-w-0 flex-1 border-t border-border lg:border-t-0"
+                        data-workbench-pane="secondary"
+                        data-workbench-pane-focused={focusedWorkbenchPane === "secondary" ? "true" : undefined}
+                        onPointerDown={() => focusWorkbenchPane("secondary")}
+                      >
                         <SessionSurface
                           {...props.surface!}
                           client={props.openworkServerClient!}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -148,7 +148,7 @@ export type SessionPageSidebarProps = {
 
 export type SessionPageSurfaceProps = Omit<
   SessionSurfaceProps,
-  "client" | "workspaceId" | "sessionId" | "opencodeBaseUrl" | "openworkToken"
+  "client" | "workspaceId" | "sessionId" | "opencodeBaseUrl" | "openworkToken" | "isControlTarget"
 >;
 
 export type SessionPageProps = {
@@ -696,6 +696,10 @@ export function SessionPage(props: SessionPageProps) {
     () => sessionTitleForId(props.sidebar.workspaceSessionGroups, props.selectedSessionId),
     [props.selectedSessionId, props.sidebar.workspaceSessionGroups],
   );
+  const workspaceName =
+    props.selectedWorkspaceDisplay.displayName?.trim() ||
+    props.selectedWorkspaceDisplay.name?.trim() ||
+    t("session.workspace_fallback");
   useEffect(() => {
     if (pendingConversationHistoryNavigation) {
       if (
@@ -734,6 +738,7 @@ export function SessionPage(props: SessionPageProps) {
     );
     syncWorkbench({
       workspaceId: props.selectedWorkspaceId,
+      workspaceTitle: workspaceName,
       primarySessionId: props.selectedSessionId,
       sessionsKnown: workspaceGroup?.status === "ready",
       sessions: (workspaceGroup?.sessions ?? []).map((session) => ({
@@ -747,6 +752,7 @@ export function SessionPage(props: SessionPageProps) {
     props.selectedWorkspaceId,
     props.sidebar.workspaceSessionGroups,
     syncWorkbench,
+    workspaceName,
   ]);
   useEffect(() => {
     props.onSessionTabsChange?.(sessionTabs);
@@ -755,10 +761,6 @@ export function SessionPage(props: SessionPageProps) {
     () => sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionActionId),
     [props.sidebar.workspaceSessionGroups, sessionActionId],
   );
-  const workspaceName =
-    props.selectedWorkspaceDisplay.displayName?.trim() ||
-    props.selectedWorkspaceDisplay.name?.trim() ||
-    t("session.workspace_fallback");
   const providerCount = props.hasUsableModel ? 1 : props.providerConnectedIds.length;
   const messageCountVisible = props.selectedSessionId ? 1 : 0;
   const showWorkspaceSetupEmptyState = props.workspaces.length === 0 && !props.selectedSessionId;
@@ -832,8 +834,9 @@ export function SessionPage(props: SessionPageProps) {
       sessionId,
       title: sessionTitleForId(props.sidebar.workspaceSessionGroups, sessionId),
     });
+    focusWorkbenchPane("primary");
     props.sidebar.onOpenSession(workspaceId, sessionId);
-  }, [openWorkbenchTab, props.sidebar]);
+  }, [focusWorkbenchPane, openWorkbenchTab, props.sidebar]);
 
   const focusWorkbenchSessionControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "workbench.session.focus",
@@ -864,6 +867,7 @@ export function SessionPage(props: SessionPageProps) {
       }
       const tab = sessionTabs.find((entry) => entry.sessionId === sessionId);
       if (tab) {
+        focusWorkbenchPane("primary");
         props.sidebar.onOpenSession(tab.workspaceId, tab.sessionId);
         return { ok: true, sessionId, reused: "tab" };
       }
@@ -1214,7 +1218,7 @@ export function SessionPage(props: SessionPageProps) {
                               <button
                                 type="button"
                                 className="min-w-0 flex-1 truncate text-left"
-                                onClick={() => props.sidebar.onOpenSession(tab.workspaceId, tab.sessionId)}
+                                onClick={() => openSessionTab(tab.workspaceId, tab.sessionId)}
                                 title={title}
                               >
                                 {title}
@@ -1250,6 +1254,7 @@ export function SessionPage(props: SessionPageProps) {
                       data-workbench-pane="primary"
                       data-workbench-pane-focused={focusedWorkbenchPane === "primary" ? "true" : undefined}
                       onPointerDown={() => focusWorkbenchPane("primary")}
+                      onFocusCapture={() => focusWorkbenchPane("primary")}
                     >
                       <SessionSurface
                         // Spread `surface` first so the explicit per-workspace
@@ -1263,6 +1268,7 @@ export function SessionPage(props: SessionPageProps) {
                         environmentClient={props.environmentClient}
                         workspaceId={props.runtimeWorkspaceId!}
                         sessionId={props.selectedSessionId!}
+                        isControlTarget={focusedWorkbenchPane === "primary"}
                         opencodeBaseUrl={reactSessionBaseUrl}
                         openworkToken={reactSessionToken}
                         todos={props.todos}
@@ -1282,6 +1288,7 @@ export function SessionPage(props: SessionPageProps) {
                         data-workbench-pane="secondary"
                         data-workbench-pane-focused={focusedWorkbenchPane === "secondary" ? "true" : undefined}
                         onPointerDown={() => focusWorkbenchPane("secondary")}
+                        onFocusCapture={() => focusWorkbenchPane("secondary")}
                       >
                         <SessionSurface
                           {...props.surface!}
@@ -1289,6 +1296,7 @@ export function SessionPage(props: SessionPageProps) {
                           environmentClient={props.environmentClient}
                           workspaceId={props.runtimeWorkspaceId!}
                           sessionId={splitSessionId!}
+                          isControlTarget={focusedWorkbenchPane === "secondary"}
                           opencodeBaseUrl={reactSessionBaseUrl}
                           openworkToken={reactSessionToken}
                           todos={[]}

--- a/apps/app/src/react-app/domains/session/chat/workbench-store.ts
+++ b/apps/app/src/react-app/domains/session/chat/workbench-store.ts
@@ -7,6 +7,7 @@ export type WorkbenchSessionTab = OpenworkSessionRef;
 export type WorkbenchSnapshot = {
   revision: number;
   workspaceId: string | null;
+  workspaceTitle: string | null;
   primarySessionId: string | null;
   tabs: OpenworkSessionRef[];
   splitSessionId: string | null;
@@ -15,6 +16,7 @@ export type WorkbenchSnapshot = {
 
 export type SyncWorkbenchInput = {
   workspaceId: string;
+  workspaceTitle?: string;
   primarySessionId: string | null;
   sessions: OpenworkSessionRef[];
   sessionsKnown: boolean;
@@ -23,6 +25,7 @@ export type SyncWorkbenchInput = {
 const initialWorkbenchSnapshot: WorkbenchSnapshot = {
   revision: 0,
   workspaceId: null,
+  workspaceTitle: null,
   primarySessionId: null,
   tabs: [],
   splitSessionId: null,
@@ -41,6 +44,7 @@ function sameTabs(left: OpenworkSessionRef[], right: OpenworkSessionRef[]) {
 function withRevision(current: WorkbenchSnapshot, next: Omit<WorkbenchSnapshot, "revision">): WorkbenchSnapshot {
   if (
     current.workspaceId === next.workspaceId
+    && current.workspaceTitle === next.workspaceTitle
     && current.primarySessionId === next.primarySessionId
     && current.splitSessionId === next.splitSessionId
     && current.focusedPane === next.focusedPane
@@ -69,7 +73,8 @@ export function syncWorkbenchSnapshot(
     tabs.push(primary);
   }
 
-  const splitSessionId = current.workspaceId === input.workspaceId
+  const splitSessionId = input.primarySessionId
+    && current.workspaceId === input.workspaceId
     && current.splitSessionId !== input.primarySessionId
     && current.splitSessionId
     && tabs.some((tab) => tab.sessionId === current.splitSessionId)
@@ -78,6 +83,7 @@ export function syncWorkbenchSnapshot(
 
   return withRevision(current, {
     workspaceId: input.workspaceId,
+    workspaceTitle: input.workspaceTitle?.trim() || input.workspaceId,
     primarySessionId: input.primarySessionId,
     tabs,
     splitSessionId,
@@ -95,6 +101,7 @@ export function openWorkbenchTab(
   }
   return withRevision(current, {
     workspaceId: tab.workspaceId,
+    workspaceTitle: current.workspaceId === tab.workspaceId ? current.workspaceTitle : tab.workspaceId,
     primarySessionId: current.workspaceId === tab.workspaceId ? current.primarySessionId : null,
     tabs,
     splitSessionId: current.workspaceId === tab.workspaceId ? current.splitSessionId : null,
@@ -110,6 +117,7 @@ export function closeWorkbenchTab(
   const splitSessionId = current.splitSessionId === sessionId ? null : current.splitSessionId;
   return withRevision(current, {
     workspaceId: current.workspaceId,
+    workspaceTitle: current.workspaceTitle,
     primarySessionId: current.primarySessionId === sessionId ? null : current.primarySessionId,
     tabs,
     splitSessionId,
@@ -128,6 +136,7 @@ export function setWorkbenchSplit(
       : null;
   return withRevision(current, {
     workspaceId: current.workspaceId,
+    workspaceTitle: current.workspaceTitle,
     primarySessionId: current.primarySessionId,
     tabs: current.tabs,
     splitSessionId,
@@ -142,6 +151,7 @@ export function focusWorkbenchPane(
   const focusedPane = pane === "secondary" && !current.splitSessionId ? "primary" : pane;
   return withRevision(current, {
     workspaceId: current.workspaceId,
+    workspaceTitle: current.workspaceTitle,
     primarySessionId: current.primarySessionId,
     tabs: current.tabs,
     splitSessionId: current.splitSessionId,

--- a/apps/app/src/react-app/domains/session/chat/workbench-store.ts
+++ b/apps/app/src/react-app/domains/session/chat/workbench-store.ts
@@ -1,0 +1,167 @@
+import type { OpenworkSessionRef } from "@openwork/types/openwork-context";
+import { create } from "zustand";
+
+export type WorkbenchPane = "primary" | "secondary";
+export type WorkbenchSessionTab = OpenworkSessionRef;
+
+export type WorkbenchSnapshot = {
+  revision: number;
+  workspaceId: string | null;
+  primarySessionId: string | null;
+  tabs: OpenworkSessionRef[];
+  splitSessionId: string | null;
+  focusedPane: WorkbenchPane;
+};
+
+export type SyncWorkbenchInput = {
+  workspaceId: string;
+  primarySessionId: string | null;
+  sessions: OpenworkSessionRef[];
+  sessionsKnown: boolean;
+};
+
+const initialWorkbenchSnapshot: WorkbenchSnapshot = {
+  revision: 0,
+  workspaceId: null,
+  primarySessionId: null,
+  tabs: [],
+  splitSessionId: null,
+  focusedPane: "primary",
+};
+
+function sameTabs(left: OpenworkSessionRef[], right: OpenworkSessionRef[]) {
+  return left.length === right.length && left.every((tab, index) => {
+    const other = right[index];
+    return other?.workspaceId === tab.workspaceId
+      && other.sessionId === tab.sessionId
+      && other.title === tab.title;
+  });
+}
+
+function withRevision(current: WorkbenchSnapshot, next: Omit<WorkbenchSnapshot, "revision">): WorkbenchSnapshot {
+  if (
+    current.workspaceId === next.workspaceId
+    && current.primarySessionId === next.primarySessionId
+    && current.splitSessionId === next.splitSessionId
+    && current.focusedPane === next.focusedPane
+    && sameTabs(current.tabs, next.tabs)
+  ) {
+    return current;
+  }
+  return { ...next, revision: current.revision + 1 };
+}
+
+export function syncWorkbenchSnapshot(
+  current: WorkbenchSnapshot,
+  input: SyncWorkbenchInput,
+): WorkbenchSnapshot {
+  const availableById = new Map(input.sessions.map((session) => [session.sessionId, session]));
+  const currentTabs = current.workspaceId === input.workspaceId ? current.tabs : [];
+  const tabs = currentTabs
+    .filter((tab) => !input.sessionsKnown || availableById.has(tab.sessionId) || tab.sessionId === input.primarySessionId)
+    .map((tab) => availableById.get(tab.sessionId) ?? tab);
+
+  if (input.primarySessionId && !tabs.some((tab) => tab.sessionId === input.primarySessionId)) {
+    const primary = availableById.get(input.primarySessionId) ?? {
+      workspaceId: input.workspaceId,
+      sessionId: input.primarySessionId,
+    };
+    tabs.push(primary);
+  }
+
+  const splitSessionId = current.workspaceId === input.workspaceId
+    && current.splitSessionId !== input.primarySessionId
+    && current.splitSessionId
+    && tabs.some((tab) => tab.sessionId === current.splitSessionId)
+      ? current.splitSessionId
+      : null;
+
+  return withRevision(current, {
+    workspaceId: input.workspaceId,
+    primarySessionId: input.primarySessionId,
+    tabs,
+    splitSessionId,
+    focusedPane: splitSessionId ? current.focusedPane : "primary",
+  });
+}
+
+export function openWorkbenchTab(
+  current: WorkbenchSnapshot,
+  tab: OpenworkSessionRef,
+): WorkbenchSnapshot {
+  const tabs = current.workspaceId === tab.workspaceId ? [...current.tabs] : [];
+  if (!tabs.some((entry) => entry.sessionId === tab.sessionId)) {
+    tabs.push(tab);
+  }
+  return withRevision(current, {
+    workspaceId: tab.workspaceId,
+    primarySessionId: current.workspaceId === tab.workspaceId ? current.primarySessionId : null,
+    tabs,
+    splitSessionId: current.workspaceId === tab.workspaceId ? current.splitSessionId : null,
+    focusedPane: current.workspaceId === tab.workspaceId ? current.focusedPane : "primary",
+  });
+}
+
+export function closeWorkbenchTab(
+  current: WorkbenchSnapshot,
+  sessionId: string,
+): WorkbenchSnapshot {
+  const tabs = current.tabs.filter((tab) => tab.sessionId !== sessionId);
+  const splitSessionId = current.splitSessionId === sessionId ? null : current.splitSessionId;
+  return withRevision(current, {
+    workspaceId: current.workspaceId,
+    primarySessionId: current.primarySessionId === sessionId ? null : current.primarySessionId,
+    tabs,
+    splitSessionId,
+    focusedPane: splitSessionId ? current.focusedPane : "primary",
+  });
+}
+
+export function setWorkbenchSplit(
+  current: WorkbenchSnapshot,
+  sessionId: string | null,
+): WorkbenchSnapshot {
+  const splitSessionId = sessionId
+    && sessionId !== current.primarySessionId
+    && current.tabs.some((tab) => tab.sessionId === sessionId)
+      ? sessionId
+      : null;
+  return withRevision(current, {
+    workspaceId: current.workspaceId,
+    primarySessionId: current.primarySessionId,
+    tabs: current.tabs,
+    splitSessionId,
+    focusedPane: splitSessionId ? "secondary" : "primary",
+  });
+}
+
+export function focusWorkbenchPane(
+  current: WorkbenchSnapshot,
+  pane: WorkbenchPane,
+): WorkbenchSnapshot {
+  const focusedPane = pane === "secondary" && !current.splitSessionId ? "primary" : pane;
+  return withRevision(current, {
+    workspaceId: current.workspaceId,
+    primarySessionId: current.primarySessionId,
+    tabs: current.tabs,
+    splitSessionId: current.splitSessionId,
+    focusedPane,
+  });
+}
+
+type WorkbenchStore = WorkbenchSnapshot & {
+  sync: (input: SyncWorkbenchInput) => void;
+  openTab: (tab: OpenworkSessionRef) => void;
+  closeTab: (sessionId: string) => void;
+  setSplit: (sessionId: string | null) => void;
+  focusPane: (pane: WorkbenchPane) => void;
+};
+
+export const useWorkbenchStore = create<WorkbenchStore>((set) => ({
+  ...initialWorkbenchSnapshot,
+  sync: (input) => set((state) => syncWorkbenchSnapshot(state, input)),
+  openTab: (tab) => set((state) => openWorkbenchTab(state, tab)),
+  closeTab: (sessionId) => set((state) => closeWorkbenchTab(state, sessionId)),
+  setSplit: (sessionId) => set((state) => setWorkbenchSplit(state, sessionId)),
+  focusPane: (pane) => set((state) => focusWorkbenchPane(state, pane)),
+}));

--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -7,6 +7,7 @@ import { setSessionArchived } from "../../../../app/lib/opencode-session";
 import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import { useControlAction, type OpenworkControlAction } from "../../../shell/control/control-provider";
 import { useSessionManagementStore } from "../sidebar/session-management-store";
+import { useWorkbenchStore } from "../chat/workbench-store";
 
 type SessionLike = {
   id?: string;
@@ -123,17 +124,34 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
   const openSessionControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.open",
     label: "Open a session by ID",
-    description: "Navigate to a specific session. Use list_sessions first to get the session ID.",
+    description: "Focus a visible session or reuse its existing tab. Use list_sessions first to get the session ID.",
+    effects: { data: "none", ui: "navigate", external: false },
     sideEffect: "navigation",
     requiresArgs: true,
     args: [{ name: "sessionId", type: "string", required: true, description: "Session ID from session.list_sessions." }],
     execute: (args) => {
       const sessionId = stringArg(args, "sessionId");
       if (!sessionId) return { ok: false, error: "sessionId is required" };
+      const targetWorkspace = findSessionWorkspace(workspaces, sessionsByWorkspaceId, sessionId);
+      const workbench = useWorkbenchStore.getState();
+      if (targetWorkspace?.id === workbench.workspaceId) {
+        if (sessionId === workbench.primarySessionId) {
+          workbench.focusPane("primary");
+          return { ok: true, sessionId, reused: "primary-pane" };
+        }
+        if (sessionId === workbench.splitSessionId) {
+          workbench.focusPane("secondary");
+          return { ok: true, sessionId, reused: "secondary-pane" };
+        }
+      }
       navigateToSession(sessionId);
-      return { ok: true, navigatedTo: sessionId };
+      return {
+        ok: true,
+        sessionId,
+        reused: workbench.tabs.some((tab) => tab.sessionId === sessionId) ? "tab" : "new-tab",
+      };
     },
-  }), [navigateToSession]);
+  }), [navigateToSession, sessionsByWorkspaceId, workspaces]);
   useControlAction(openSessionControlAction);
 
   const renameSessionControlAction = useMemo<OpenworkControlAction>(() => ({

--- a/apps/app/src/react-app/domains/session/control/session-control-actions.ts
+++ b/apps/app/src/react-app/domains/session/control/session-control-actions.ts
@@ -99,6 +99,8 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
     id: "session.list_sessions",
     label: "List available sessions",
     description: "Return the list of sessions across workspaces so the user can ask to open one by name.",
+    kind: "query",
+    effects: { data: "read", ui: "none", external: false },
     sideEffect: "none",
     execute: () => {
       const out: { sessionId: string; title: string; workspace: string; updatedAt: number }[] = [];
@@ -199,6 +201,7 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
     id: "session.model_picker.open",
     label: "Open the model picker",
     description: "Open the current session model picker.",
+    effects: { data: "none", ui: "dialog", external: false },
     sideEffect: "none",
     disabled: !selectedWorkspaceId,
     execute: openModelPicker,
@@ -347,6 +350,8 @@ export function useSessionControlActions(input: UseSessionControlActionsInput) {
     id: "session.group.list",
     label: "List session groups",
     description: "List all groups in a workspace with their IDs and labels.",
+    kind: "query",
+    effects: { data: "read", ui: "none", external: false },
     sideEffect: "none",
     args: [{ name: "workspaceId", type: "string", required: false, description: "Workspace ID. Defaults to selected." }],
     execute: (args) => {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -154,6 +154,7 @@ export type SessionSurfaceProps = {
   workspaceId: string;
   workspaceRoot: string;
   sessionId: string;
+  isControlTarget: boolean;
   opencodeBaseUrl: string;
   openworkToken: string;
   developerMode: boolean;
@@ -721,7 +722,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       },
     };
   }, [props.sessionId]);
-  useControlAction(seedMarkdownPrimitiveControlAction);
+  useControlAction(props.isControlTarget ? seedMarkdownPrimitiveControlAction : null);
   const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
   const openTargetsFingerprint = useMemo(
     () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),
@@ -1246,7 +1247,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return { draftLength: text.length };
     },
   }), [attachments, buildDraft, props.onDraftChange, typeComposerText]);
-  useControlAction(composerSetTextControlAction);
+  useControlAction(props.isControlTarget ? composerSetTextControlAction : null);
 
   const composerSendControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "composer.send",
@@ -1260,7 +1261,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return true;
     },
   }), [attachments.length, draft, handleSend, model.transitionState, props.modelUnavailable]);
-  useControlAction(composerSendControlAction);
+  useControlAction(props.isControlTarget ? composerSendControlAction : null);
 
   const composerStopControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "composer.stop",
@@ -1274,7 +1275,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return true;
     },
   }), [chatStreaming, handleAbort]);
-  useControlAction(composerStopControlAction);
+  useControlAction(props.isControlTarget ? composerStopControlAction : null);
 
   const loadConnectCapabilityInventory = async (): Promise<ConnectCapabilityInventory> => {
     const settings = readDenSettings();
@@ -1604,7 +1605,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return { ok: true, position: "top" };
     },
   }), []);
-  useControlAction(sessionScrollTopControlAction);
+  useControlAction(props.isControlTarget ? sessionScrollTopControlAction : null);
 
   const sessionScrollBottomControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.scroll_bottom",
@@ -1617,7 +1618,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       return { ok: true, position: "bottom" };
     },
   }), [sessionScroll.jumpToLatest]);
-  useControlAction(sessionScrollBottomControlAction);
+  useControlAction(props.isControlTarget ? sessionScrollBottomControlAction : null);
 
   const sessionLatestMessageControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.latest_message",
@@ -1638,7 +1639,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       };
     },
   }), [props.sessionId, renderedMessages]);
-  useControlAction(sessionLatestMessageControlAction);
+  useControlAction(props.isControlTarget ? sessionLatestMessageControlAction : null);
 
   const sessionReadTranscriptControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "session.read_transcript",
@@ -1668,7 +1669,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
       };
     },
   }), [props.sessionId, renderedMessages]);
-  useControlAction(sessionReadTranscriptControlAction);
+  useControlAction(props.isControlTarget ? sessionReadTranscriptControlAction : null);
 
   return (
     <DevProfiler id="SessionSurface">

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1232,6 +1232,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     id: "composer.set_text",
     label: "Type into the composer",
     description: "Replace the current session draft and type the supplied text visibly.",
+    effects: { data: "none", ui: "focus", external: false },
     sideEffect: "none",
     requiresArgs: true,
     args: [{ name: "text", type: "string", required: true, description: "Prompt text to place in the composer." }],
@@ -1594,6 +1595,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     id: "session.scroll_top",
     label: "Go to the top of the session",
     description: "Scroll the visible session transcript to the first messages.",
+    effects: { data: "none", ui: "focus", external: false },
     sideEffect: "none",
     execute: () => {
       const container = scrollRef.current;
@@ -1608,6 +1610,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     id: "session.scroll_bottom",
     label: "Go to the bottom of the session",
     description: "Scroll the visible session transcript to the newest messages and composer area.",
+    effects: { data: "none", ui: "focus", external: false },
     sideEffect: "none",
     execute: () => {
       sessionScroll.jumpToLatest("smooth");
@@ -1620,6 +1623,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     id: "session.latest_message",
     label: "Read the latest session message",
     description: "Return the latest visible message in the current session transcript.",
+    kind: "query",
+    effects: { data: "read", ui: "none", external: false },
     sideEffect: "none",
     execute: () => {
       const message = renderedMessages[renderedMessages.length - 1];
@@ -1639,6 +1644,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
     id: "session.read_transcript",
     label: "Read the current session transcript",
     description: "Return the last messages from the current session transcript as readable text, including the session ID, title, and message count.",
+    kind: "query",
+    effects: { data: "read", ui: "none", external: false },
     sideEffect: "none",
     args: [{ name: "count", type: "number", required: false, description: "Number of recent messages to return, from 1 to 30. Defaults to 10." }],
     execute: (args) => {

--- a/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
+++ b/apps/app/src/react-app/domains/session/voice/voice-panel.tsx
@@ -722,6 +722,7 @@ export function VoicePanel(props: VoicePanelProps) {
     id: "voice.toggle_mute",
     label: micMuted ? "Unmute Voice Mode" : "Mute Voice Mode",
     description: "Toggle the microphone track without closing the Realtime session.",
+    effects: { data: "none", ui: "none", external: true },
     sideEffect: "none",
     disabled: !connected,
     targetRef: panelRef,
@@ -771,6 +772,8 @@ export function VoicePanel(props: VoicePanelProps) {
     id: "voice.status",
     label: "Read Voice Mode status",
     description: "Return the Voice Mode runtime state for tests and agents.",
+    kind: "query",
+    effects: { data: "read", ui: "none", external: false },
     sideEffect: "none",
     execute: () => ({ status, statusText, connected, micMuted, micDiagnostics, realtimeDiagnostics, latestUserTranscript, assistantPreview }),
   }), [assistantPreview, connected, latestUserTranscript, micDiagnostics, micMuted, realtimeDiagnostics, status, statusText]);

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -33,6 +33,7 @@ import {
   useControlAction,
   type OpenworkControlAction,
 } from "./control/control-provider";
+import { OpenworkContextPublisher } from "./openwork-context-publisher";
 import { SessionRoute } from "./session-route";
 import { SettingsRoute } from "./settings-route";
 import { ShellConfigProvider } from "./shell-config";
@@ -217,6 +218,8 @@ function DenAuthControlActions() {
     id: "auth.status",
     label: "Get auth status",
     description: "Return the current cloud sign-in status and user.",
+    kind: "query",
+    effects: { data: "read", ui: "none", external: false },
     sideEffect: "none",
     execute: () => ({
       status: denAuth.status,
@@ -325,6 +328,7 @@ export function AppRoot() {
         <AppMenuProvider>
         <OpenworkControlProvider>
           <OpenworkRouteControlActions />
+          <OpenworkContextPublisher />
           <DenAuthControlActions />
           <BrandThemeControlActions />
           <DenSigninGate>

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -10,6 +10,13 @@ import {
   type ReactNode,
 } from "react";
 import { useLocation, useNavigate } from "react-router-dom";
+import type {
+  OpenworkAffordanceDescriptor,
+  OpenworkAffordanceEffects,
+  OpenworkAffordanceRequest,
+  OpenworkAffordanceResult,
+} from "@openwork/types/openwork-affordance";
+import type { OpenworkContextSnapshot } from "@openwork/types/openwork-context";
 
 export type OpenworkControlSideEffect = "none" | "navigation" | "mutation" | "external";
 
@@ -24,6 +31,8 @@ export type OpenworkControlActionMetadata = {
   id: string;
   label: string;
   description?: string;
+  kind: "query" | "command";
+  effects: OpenworkAffordanceEffects;
   sideEffect: OpenworkControlSideEffect;
   requiresConfirmation: boolean;
   requiresArgs: boolean;
@@ -60,6 +69,8 @@ export type OpenworkControlAction = {
   id: string;
   label: string;
   description?: string;
+  kind?: "query" | "command";
+  effects?: OpenworkAffordanceEffects;
   sideEffect?: OpenworkControlSideEffect;
   requiresConfirmation?: boolean;
   requiresArgs?: boolean;
@@ -96,6 +107,7 @@ type OpenworkControlContextValue = {
   actions: OpenworkControlActionMetadata[];
   registerAction: (actionId: string, actionRef: ControlActionRef) => () => void;
   executeAction: (actionId: string, args?: unknown) => Promise<OpenworkControlResult>;
+  publishContext: (context: OpenworkContextSnapshot) => void;
   snapshot: () => OpenworkControlSnapshot;
 };
 
@@ -104,6 +116,9 @@ type OpenworkControlAPI = {
   snapshot: () => OpenworkControlSnapshot;
   listActions: () => OpenworkControlActionMetadata[];
   execute: (actionId: string, args?: unknown) => Promise<OpenworkControlResult>;
+  context: () => OpenworkContextSnapshot;
+  query: (request: OpenworkAffordanceRequest) => Promise<OpenworkAffordanceResult>;
+  command: (request: OpenworkAffordanceRequest) => Promise<OpenworkAffordanceResult>;
   setEnabled: (enabled: boolean) => void;
   subscribe: (listener: (snapshot: OpenworkControlSnapshot) => void) => () => void;
 };
@@ -144,13 +159,29 @@ function isBrowser() {
   return typeof window !== "undefined" && typeof document !== "undefined";
 }
 
+function effectsForSideEffect(sideEffect: OpenworkControlSideEffect): OpenworkAffordanceEffects {
+  if (sideEffect === "navigation") {
+    return { data: "none", ui: "navigate", external: false };
+  }
+  if (sideEffect === "mutation") {
+    return { data: "write", ui: "none", external: false };
+  }
+  if (sideEffect === "external") {
+    return { data: "none", ui: "none", external: true };
+  }
+  return { data: "none", ui: "none", external: false };
+}
+
 function metadataForAction(registered: RegisteredAction, busyActionId: string | null): OpenworkControlActionMetadata {
   const action = registered.ref.current;
+  const sideEffect = action?.sideEffect ?? "none";
   return {
     id: registered.id,
     label: action?.label ?? registered.id,
     description: action?.description,
-    sideEffect: action?.sideEffect ?? "none",
+    kind: action?.kind ?? "command",
+    effects: action?.effects ?? effectsForSideEffect(sideEffect),
+    sideEffect,
     requiresConfirmation: action?.requiresConfirmation === true,
     requiresArgs: action?.requiresArgs === true,
     hasPreviewArgs: action?.previewArgs !== undefined,
@@ -158,6 +189,29 @@ function metadataForAction(registered: RegisteredAction, busyActionId: string | 
     args: action?.args,
     disabled: action?.disabled === true,
     busy: busyActionId === registered.id,
+  };
+}
+
+function affordanceForAction(action: OpenworkControlActionMetadata): OpenworkAffordanceDescriptor {
+  return {
+    id: action.id,
+    kind: action.kind,
+    title: action.label,
+    description: action.description ?? action.label,
+    provider: { id: "openwork-ui", kind: "builtin" },
+    arguments: (action.args ?? []).map((argument) => ({
+      name: argument.name,
+      type: argument.type ?? "unknown",
+      required: argument.required === true,
+      ...(argument.description ? { description: argument.description } : {}),
+    })),
+    effects: action.effects,
+    confirmation: action.requiresConfirmation ? "destructive" : "never",
+    availability: {
+      enabled: !action.disabled && !action.busy,
+      ...(action.disabled ? { reason: "This action is not available in the current app state." } : {}),
+    },
+    executor: { kind: "openwork" },
   };
 }
 
@@ -184,6 +238,8 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
   const location = useLocation();
   const actionsRef = useRef(new Map<string, RegisteredAction>());
   const listenersRef = useRef(new Set<(snapshot: OpenworkControlSnapshot) => void>());
+  const contextRef = useRef<OpenworkContextSnapshot | null>(null);
+  const contextRevisionRef = useRef(0);
   const nextOrderRef = useRef(1);
   const [version, setVersion] = useState(0);
   const [enabledState, setEnabledState] = useState(false);
@@ -191,6 +247,7 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
   const [narration, setNarration] = useState("Control mode is off.");
   const [spotlight, setSpotlight] = useState<SpotlightState>({ visible: false, phase: "target", rect: null });
   const busyActionIdRef = useRef<string | null>(null);
+  const busyActorRef = useRef<string | null>(null);
   const spotlightRunRef = useRef(0);
 
   const route = `${location.pathname}${location.search}${location.hash}`;
@@ -221,6 +278,65 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
     actions: listActionMetadata(),
   }), [busyActionId, enabled, listActionMetadata, narration, route, status]);
 
+  const publishContext = useCallback((context: OpenworkContextSnapshot) => {
+    if (contextRef.current === context) return;
+    contextRef.current = context;
+    contextRevisionRef.current += 1;
+  }, []);
+
+  const contextSnapshot = useCallback((): OpenworkContextSnapshot => {
+    const availableAffordances = listActionMetadata().map(affordanceForAction);
+    const published = contextRef.current;
+    const revision = contextRevisionRef.current;
+    if (published) {
+      return {
+        ...published,
+        revision,
+        capturedAt: new Date().toISOString(),
+        availableAffordances,
+        execution: {
+          ...published.execution,
+          busyCommandId: busyActionId,
+          busyActor: busyActorRef.current,
+        },
+      };
+    }
+    return {
+      schemaVersion: 1,
+      revision,
+      capturedAt: new Date().toISOString(),
+      screen: { kind: "other", route },
+      conversations: { tabs: [], layout: { kind: "empty" } },
+      chrome: {
+        sidebarOpen: true,
+        applicationMenuVisible: false,
+        rightSidebarExpanded: false,
+      },
+      execution: {
+        queries: "parallel",
+        commands: "serialized",
+        busyCommandId: busyActionId,
+        busyActor: busyActorRef.current,
+      },
+      sidePanel: {
+        open: false,
+        ownerSessionId: null,
+        kind: null,
+        tabs: [],
+        activeTabId: null,
+      },
+      resources: [{
+        ref: `screen:${route}`,
+        kind: "screen",
+        title: "OpenWork",
+        provider: { id: "openwork-ui", kind: "builtin" },
+        state: { kind: "other", route },
+      }],
+      availableAffordances,
+      contributions: [],
+    };
+  }, [busyActionId, listActionMetadata, route]);
+
   const registerAction = useCallback((actionId: string, actionRef: ControlActionRef) => {
     const token = Symbol(actionId);
     const previous = actionsRef.current.get(actionId);
@@ -230,12 +346,14 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
       token,
       ref: actionRef,
     });
+    contextRevisionRef.current += 1;
     setVersion((current) => current + 1);
 
     return () => {
       const current = actionsRef.current.get(actionId);
       if (current?.token === token) {
         actionsRef.current.delete(actionId);
+        contextRevisionRef.current += 1;
         setVersion((value) => value + 1);
       }
     };
@@ -278,7 +396,10 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
     const action = registered?.ref.current;
     if (!registered || !action) return { ok: false, actionId, error: `Unknown action: ${actionId}` };
     if (action.disabled) return { ok: false, actionId, error: `Action is disabled: ${action.label}` };
-    if (busyActionIdRef.current) return { ok: false, actionId, error: `Already acting: ${busyActionIdRef.current}` };
+    if (busyActionIdRef.current) {
+      const actor = busyActorRef.current ? ` for ${busyActorRef.current}` : "";
+      return { ok: false, actionId, error: `Already acting: ${busyActionIdRef.current}${actor}` };
+    }
 
     if (action.requiresConfirmation && isBrowser()) {
       const confirmed = window.confirm(`Allow Control Mode to ${action.label}?`);
@@ -288,6 +409,7 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
     const runId = spotlightRunRef.current + 1;
     spotlightRunRef.current = runId;
     busyActionIdRef.current = action.id;
+    contextRevisionRef.current += 1;
     setEnabled(true);
     setBusyActionId(action.id);
     setNarration(`Moving to ${action.label}…`);
@@ -320,9 +442,119 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
       return { ok: false, actionId, error: message };
     } finally {
       if (busyActionIdRef.current === action.id) busyActionIdRef.current = null;
+      contextRevisionRef.current += 1;
       setBusyActionId(null);
     }
   }, [playTargetChoreography, setEnabled]);
+
+  const queryAffordance = useCallback(async (
+    request: OpenworkAffordanceRequest,
+  ): Promise<OpenworkAffordanceResult> => {
+    const action = actionsRef.current.get(request.id)?.ref.current;
+    const revision = contextRevisionRef.current;
+    if (!action || action.kind !== "query") {
+      return {
+        ok: false,
+        id: request.id,
+        error: `Unknown query: ${request.id}`,
+        code: "unavailable",
+        revision,
+      };
+    }
+    if (action.disabled) {
+      return {
+        ok: false,
+        id: request.id,
+        error: `Query is disabled: ${action.label}`,
+        code: "unavailable",
+        revision,
+      };
+    }
+    try {
+      const effectiveArgs = request.args === undefined ? action.previewArgs : request.args;
+      const result = await action.execute(effectiveArgs, { setNarration: () => undefined });
+      const resultError = returnedActionError(result);
+      if (resultError) {
+        return {
+          ok: false,
+          id: request.id,
+          error: resultError,
+          code: "failed",
+          revision,
+        };
+      }
+      return {
+        ok: true,
+        id: request.id,
+        result,
+        revision,
+        effects: action.effects ?? { data: "read", ui: "none", external: false },
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        id: request.id,
+        error: describeError(error),
+        code: "failed",
+        revision,
+      };
+    }
+  }, []);
+
+  const executeCommand = useCallback(async (
+    request: OpenworkAffordanceRequest,
+  ): Promise<OpenworkAffordanceResult> => {
+    const action = actionsRef.current.get(request.id)?.ref.current;
+    const revision = contextRevisionRef.current;
+    if (!action || action.kind === "query") {
+      return {
+        ok: false,
+        id: request.id,
+        error: `Unknown command: ${request.id}`,
+        code: "unavailable",
+        revision,
+      };
+    }
+    if (busyActionIdRef.current) {
+      const actor = busyActorRef.current ? ` for ${busyActorRef.current}` : "";
+      return {
+        ok: false,
+        id: request.id,
+        error: `Already acting: ${busyActionIdRef.current}${actor}`,
+        code: "conflict",
+        revision,
+      };
+    }
+    if (request.expectedRevision !== undefined && request.expectedRevision !== revision) {
+      return {
+        ok: false,
+        id: request.id,
+        error: `OpenWork context changed from revision ${request.expectedRevision} to ${revision}.`,
+        code: "conflict",
+        revision,
+      };
+    }
+    busyActorRef.current = request.actor ?? null;
+    const result = await executeAction(request.id, request.args);
+    if (!busyActionIdRef.current) busyActorRef.current = null;
+    if (!result.ok) {
+      return {
+        ok: false,
+        id: request.id,
+        error: result.error,
+        code: result.error.startsWith("Already acting:") ? "conflict" : "failed",
+        revision: contextRevisionRef.current,
+      };
+    }
+    const sideEffect = action.sideEffect ?? "none";
+    return {
+      ok: true,
+      id: request.id,
+      result: result.result,
+      revision: contextRevisionRef.current,
+      effects: action.effects ?? effectsForSideEffect(sideEffect),
+    };
+  }, [executeAction]);
 
   const value = useMemo<OpenworkControlContextValue>(() => ({
     enabled,
@@ -333,8 +565,20 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
     actions,
     registerAction,
     executeAction,
+    publishContext,
     snapshot,
-  }), [actions, busyActionId, enabled, executeAction, narration, registerAction, route, setEnabled, snapshot]);
+  }), [
+    actions,
+    busyActionId,
+    enabled,
+    executeAction,
+    narration,
+    publishContext,
+    registerAction,
+    route,
+    setEnabled,
+    snapshot,
+  ]);
 
   useEffect(() => {
     if (!enabled) {
@@ -352,6 +596,9 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
       snapshot,
       listActions: () => snapshot().actions,
       execute: executeAction,
+      context: contextSnapshot,
+      query: queryAffordance,
+      command: executeCommand,
       setEnabled,
       subscribe(listener) {
         listenersRef.current.add(listener);
@@ -368,7 +615,7 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
         delete window.__openworkControl;
       }
     };
-  }, [executeAction, setEnabled, snapshot]);
+  }, [contextSnapshot, executeAction, executeCommand, queryAffordance, setEnabled, snapshot]);
 
   useEffect(() => {
     busyActionIdRef.current = busyActionId;
@@ -389,6 +636,15 @@ export function OpenworkControlProvider({ children }: { children: ReactNode }) {
 
 export function useOpenworkControl() {
   return use(OpenworkControlContext);
+}
+
+export function usePublishOpenworkContext(context: OpenworkContextSnapshot) {
+  const control = useOpenworkControl();
+  const publishContext = control?.publishContext;
+
+  useEffect(() => {
+    publishContext?.(context);
+  }, [context, publishContext]);
 }
 
 export function useControlAction(action: OpenworkControlAction | null | false | undefined) {
@@ -542,6 +798,8 @@ export function OpenworkRouteControlActions() {
       id: "help.capabilities",
       label: "What can OpenWork do?",
       description: "List the main capabilities of OpenWork.",
+      kind: "query",
+      effects: { data: "read", ui: "none", external: false },
       sideEffect: "none",
       execute: () => ({
         capabilities: [

--- a/apps/app/src/react-app/shell/control/control-provider.tsx
+++ b/apps/app/src/react-app/shell/control/control-provider.tsx
@@ -129,7 +129,7 @@ declare global {
   }
 }
 
-const CONTROL_API_VERSION = 1;
+const CONTROL_API_VERSION = 2;
 const OpenworkControlContext = createContext<OpenworkControlContextValue | null>(null);
 const SPOTLIGHT_TIMING_MS = Object.freeze({
   missingTarget: 80,

--- a/apps/app/src/react-app/shell/notification-center.tsx
+++ b/apps/app/src/react-app/shell/notification-center.tsx
@@ -69,6 +69,8 @@ export function NotificationBell() {
     id: "notifications.list",
     label: "List notifications",
     description: "Return the current notification center entries.",
+    kind: "query",
+    effects: { data: "read", ui: "none", external: false },
     sideEffect: "none",
     execute: () => notifications.map((n) => ({
       id: n.id,

--- a/apps/app/src/react-app/shell/openwork-context-projector.ts
+++ b/apps/app/src/react-app/shell/openwork-context-projector.ts
@@ -111,10 +111,19 @@ export function buildOpenworkContext(
       ? { kind: "single", sessionId: primarySessionId }
       : { kind: "empty" };
 
-  const sessionPanelKind = primarySessionId ? input.ui.sidePanelState[primarySessionId] ?? null : null;
+  const focusedSessionId = input.workbench.focusedPane === "secondary" && splitSessionId
+    ? splitSessionId
+    : primarySessionId;
+  const panelOwnerSessionId = focusedSessionId && input.ui.sidePanelState[focusedSessionId]
+    ? focusedSessionId
+    : primarySessionId;
+  const sessionPanelKind = panelOwnerSessionId
+    ? input.ui.sidePanelState[panelOwnerSessionId] ?? null
+    : null;
   const voiceOpen = Object.values(input.ui.sidePanelState).includes("voice");
   const sidePanelKind = voiceOpen ? "voice" : sessionPanelKind;
-  const sessionPanel = primarySessionId ? input.panelSessions[primarySessionId] : undefined;
+  const ownerSessionId = sidePanelKind === "voice" ? null : panelOwnerSessionId;
+  const sessionPanel = ownerSessionId ? input.panelSessions[ownerSessionId] : undefined;
   const screen = screenFromRoute(input.route);
   const provider: OpenworkProviderRef = { id: "openwork-ui", kind: "builtin" };
   const resources: OpenworkResourceDescriptor[] = [{
@@ -128,7 +137,7 @@ export function buildOpenworkContext(
     resources.push({
       ref: `workspace:${input.workbench.workspaceId}`,
       kind: "workspace",
-      title: input.workbench.workspaceId,
+      title: input.workbench.workspaceTitle ?? input.workbench.workspaceId,
       provider,
       state: { active: true },
     });
@@ -163,14 +172,14 @@ export function buildOpenworkContext(
   }
   if (sidePanelKind) {
     resources.push({
-      ref: `side-panel:${primarySessionId ?? "global"}`,
+      ref: `side-panel:${ownerSessionId ?? "global"}`,
       kind: "side-panel",
       title: sidePanelKind,
       provider,
       state: {
         open: true,
         kind: sidePanelKind,
-        ownerSessionId: primarySessionId,
+        ownerSessionId,
       },
     });
   }
@@ -197,10 +206,10 @@ export function buildOpenworkContext(
     },
     sidePanel: {
       open: sidePanelKind !== null,
-      ownerSessionId: primarySessionId,
+      ownerSessionId,
       kind: sidePanelKind,
-      tabs: (sessionPanel?.tabs ?? []).map(panelTab),
-      activeTabId: sessionPanel?.activeTabId ?? null,
+      tabs: sidePanelKind === "panel" ? (sessionPanel?.tabs ?? []).map(panelTab) : [],
+      activeTabId: sidePanelKind === "panel" ? sessionPanel?.activeTabId ?? null : null,
     },
     resources,
     availableAffordances: input.availableAffordances,

--- a/apps/app/src/react-app/shell/openwork-context-projector.ts
+++ b/apps/app/src/react-app/shell/openwork-context-projector.ts
@@ -1,0 +1,209 @@
+import type {
+  OpenworkAffordanceDescriptor,
+  OpenworkProviderRef,
+} from "@openwork/types/openwork-affordance";
+import type {
+  OpenworkConversationLayout,
+  OpenworkContextSnapshot,
+  OpenworkPanelTab,
+  OpenworkResourceDescriptor,
+  OpenworkScreen,
+} from "@openwork/types/openwork-context";
+
+import type { PanelTabStore } from "../domains/session/panel/panel-tab-store";
+import type { WorkbenchSnapshot } from "../domains/session/chat/workbench-store";
+import type { UiState } from "./ui-state-store";
+
+type OpenworkContextProjectorInput = {
+  route: string;
+  revision: number;
+  capturedAt: string;
+  workbench: WorkbenchSnapshot;
+  ui: Pick<
+    UiState,
+    "sidebarOpen" | "sidePanelState" | "applicationMenuVisible" | "workspaceRightSidebarExpanded"
+  >;
+  panelSessions: PanelTabStore["sessions"];
+  availableAffordances: OpenworkAffordanceDescriptor[];
+};
+
+function decoded(value: string | undefined) {
+  if (!value) return undefined;
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function screenFromRoute(route: string): OpenworkScreen {
+  const workspaceSettings = route.match(/^\/workspace\/([^/]+)\/settings(?:\/([^/?#]+))?/);
+  if (workspaceSettings) {
+    return {
+      kind: "settings",
+      route,
+      workspaceId: decoded(workspaceSettings[1]),
+      panel: decoded(workspaceSettings[2]) ?? "general",
+    };
+  }
+
+  const settings = route.match(/^\/settings(?:\/([^/?#]+))?/);
+  if (settings) {
+    return {
+      kind: "settings",
+      route,
+      panel: decoded(settings[1]) ?? "general",
+    };
+  }
+
+  const workspaceSession = route.match(/^\/workspace\/([^/]+)\/session(?:\/([^/?#]+))?/);
+  if (workspaceSession) {
+    return {
+      kind: "conversation",
+      route,
+      workspaceId: decoded(workspaceSession[1]),
+      sessionId: decoded(workspaceSession[2]),
+    };
+  }
+
+  const session = route.match(/^\/session(?:\/([^/?#]+))?/);
+  if (session) {
+    return {
+      kind: "conversation",
+      route,
+      sessionId: decoded(session[1]),
+    };
+  }
+
+  return { kind: "other", route };
+}
+
+function panelTab(tab: PanelTabStore["sessions"][string]["tabs"][number]): OpenworkPanelTab {
+  if (tab.type === "browser") {
+    return {
+      id: tab.id,
+      kind: "browser",
+      label: tab.label,
+      url: tab.url,
+      status: tab.status,
+    };
+  }
+  return {
+    id: tab.id,
+    kind: "artifact",
+    label: tab.label,
+  };
+}
+
+export function buildOpenworkContext(
+  input: OpenworkContextProjectorInput,
+): OpenworkContextSnapshot {
+  const primarySessionId = input.workbench.primarySessionId;
+  const splitSessionId = input.workbench.splitSessionId;
+  const layout: OpenworkConversationLayout = primarySessionId && splitSessionId
+    ? {
+        kind: "split",
+        primarySessionId,
+        secondarySessionId: splitSessionId,
+        focused: input.workbench.focusedPane,
+      }
+    : primarySessionId
+      ? { kind: "single", sessionId: primarySessionId }
+      : { kind: "empty" };
+
+  const sessionPanelKind = primarySessionId ? input.ui.sidePanelState[primarySessionId] ?? null : null;
+  const voiceOpen = Object.values(input.ui.sidePanelState).includes("voice");
+  const sidePanelKind = voiceOpen ? "voice" : sessionPanelKind;
+  const sessionPanel = primarySessionId ? input.panelSessions[primarySessionId] : undefined;
+  const screen = screenFromRoute(input.route);
+  const provider: OpenworkProviderRef = { id: "openwork-ui", kind: "builtin" };
+  const resources: OpenworkResourceDescriptor[] = [{
+    ref: `screen:${input.route}`,
+    kind: "screen",
+    title: screen.kind === "settings" ? `${screen.panel} settings` : "OpenWork",
+    provider,
+    state: { kind: screen.kind, route: input.route },
+  }];
+  if (input.workbench.workspaceId) {
+    resources.push({
+      ref: `workspace:${input.workbench.workspaceId}`,
+      kind: "workspace",
+      title: input.workbench.workspaceId,
+      provider,
+      state: { active: true },
+    });
+  }
+  for (const tab of input.workbench.tabs) {
+    const primary = tab.sessionId === primarySessionId;
+    const secondary = tab.sessionId === splitSessionId;
+    resources.push({
+      ref: `session:${tab.sessionId}`,
+      kind: "session",
+      title: tab.title ?? tab.sessionId,
+      provider,
+      state: {
+        workspaceId: tab.workspaceId,
+        open: true,
+        visible: primary || secondary,
+        pane: primary ? "primary" : secondary ? "secondary" : null,
+        focused: primary
+          ? input.workbench.focusedPane === "primary"
+          : secondary && input.workbench.focusedPane === "secondary",
+      },
+    });
+  }
+  if (screen.kind === "settings") {
+    resources.push({
+      ref: `settings:${screen.panel}`,
+      kind: "settings",
+      title: `${screen.panel} settings`,
+      provider,
+      state: { active: true, workspaceId: screen.workspaceId ?? null },
+    });
+  }
+  if (sidePanelKind) {
+    resources.push({
+      ref: `side-panel:${primarySessionId ?? "global"}`,
+      kind: "side-panel",
+      title: sidePanelKind,
+      provider,
+      state: {
+        open: true,
+        kind: sidePanelKind,
+        ownerSessionId: primarySessionId,
+      },
+    });
+  }
+
+  return {
+    schemaVersion: 1,
+    revision: input.revision,
+    capturedAt: input.capturedAt,
+    screen,
+    conversations: {
+      tabs: input.workbench.tabs,
+      layout,
+    },
+    chrome: {
+      sidebarOpen: input.ui.sidebarOpen,
+      applicationMenuVisible: input.ui.applicationMenuVisible,
+      rightSidebarExpanded: input.ui.workspaceRightSidebarExpanded,
+    },
+    execution: {
+      queries: "parallel",
+      commands: "serialized",
+      busyCommandId: null,
+      busyActor: null,
+    },
+    sidePanel: {
+      open: sidePanelKind !== null,
+      ownerSessionId: primarySessionId,
+      kind: sidePanelKind,
+      tabs: (sessionPanel?.tabs ?? []).map(panelTab),
+      activeTabId: sessionPanel?.activeTabId ?? null,
+    },
+    resources,
+    availableAffordances: input.availableAffordances,
+    contributions: [],
+  };
+}

--- a/apps/app/src/react-app/shell/openwork-context-publisher.tsx
+++ b/apps/app/src/react-app/shell/openwork-context-publisher.tsx
@@ -1,0 +1,63 @@
+/** @jsxImportSource react */
+import { useMemo } from "react";
+import { useLocation } from "react-router-dom";
+
+import { usePanelTabStore } from "../domains/session/panel/panel-tab-store";
+import { useWorkbenchStore } from "../domains/session/chat/workbench-store";
+import { usePublishOpenworkContext } from "./control/control-provider";
+import { buildOpenworkContext } from "./openwork-context-projector";
+import { useUiStateStore } from "./ui-state-store";
+
+export function OpenworkContextPublisher() {
+  const location = useLocation();
+  const revision = useWorkbenchStore((state) => state.revision);
+  const workspaceId = useWorkbenchStore((state) => state.workspaceId);
+  const primarySessionId = useWorkbenchStore((state) => state.primarySessionId);
+  const tabs = useWorkbenchStore((state) => state.tabs);
+  const splitSessionId = useWorkbenchStore((state) => state.splitSessionId);
+  const focusedPane = useWorkbenchStore((state) => state.focusedPane);
+  const sidebarOpen = useUiStateStore((state) => state.sidebarOpen);
+  const sidePanelState = useUiStateStore((state) => state.sidePanelState);
+  const applicationMenuVisible = useUiStateStore((state) => state.applicationMenuVisible);
+  const workspaceRightSidebarExpanded = useUiStateStore((state) => state.workspaceRightSidebarExpanded);
+  const panelSessions = usePanelTabStore((state) => state.sessions);
+  const route = `${location.pathname}${location.search}${location.hash}`;
+
+  const context = useMemo(() => buildOpenworkContext({
+    route,
+    revision,
+    capturedAt: new Date().toISOString(),
+    workbench: {
+      revision,
+      workspaceId,
+      primarySessionId,
+      tabs,
+      splitSessionId,
+      focusedPane,
+    },
+    ui: {
+      sidebarOpen,
+      sidePanelState,
+      applicationMenuVisible,
+      workspaceRightSidebarExpanded,
+    },
+    panelSessions,
+    availableAffordances: [],
+  }), [
+    applicationMenuVisible,
+    focusedPane,
+    panelSessions,
+    primarySessionId,
+    revision,
+    route,
+    sidebarOpen,
+    sidePanelState,
+    splitSessionId,
+    tabs,
+    workspaceId,
+    workspaceRightSidebarExpanded,
+  ]);
+
+  usePublishOpenworkContext(context);
+  return null;
+}

--- a/apps/app/src/react-app/shell/openwork-context-publisher.tsx
+++ b/apps/app/src/react-app/shell/openwork-context-publisher.tsx
@@ -12,6 +12,7 @@ export function OpenworkContextPublisher() {
   const location = useLocation();
   const revision = useWorkbenchStore((state) => state.revision);
   const workspaceId = useWorkbenchStore((state) => state.workspaceId);
+  const workspaceTitle = useWorkbenchStore((state) => state.workspaceTitle);
   const primarySessionId = useWorkbenchStore((state) => state.primarySessionId);
   const tabs = useWorkbenchStore((state) => state.tabs);
   const splitSessionId = useWorkbenchStore((state) => state.splitSessionId);
@@ -30,6 +31,7 @@ export function OpenworkContextPublisher() {
     workbench: {
       revision,
       workspaceId,
+      workspaceTitle,
       primarySessionId,
       tabs,
       splitSessionId,
@@ -55,6 +57,7 @@ export function OpenworkContextPublisher() {
     splitSessionId,
     tabs,
     workspaceId,
+    workspaceTitle,
     workspaceRightSidebarExpanded,
   ]);
 

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -1546,6 +1546,7 @@ export function SessionRoute() {
     id: "command_palette.open",
     label: "Open the command palette",
     description: "Open the in-app command palette so the next choice is visible.",
+    effects: { data: "none", ui: "dialog", external: false },
     sideEffect: "none",
     execute: () => setCommandPaletteOpen(true),
   }), []);

--- a/apps/app/tests/openwork-context-projector.test.ts
+++ b/apps/app/tests/openwork-context-projector.test.ts
@@ -6,9 +6,79 @@ import {
 } from "../src/react-app/shell/openwork-context-projector";
 import type { WorkbenchSnapshot } from "../src/react-app/domains/session/chat/workbench-store";
 
+type ContextProjectorInput = Parameters<typeof buildOpenworkContext>[0];
+
+const baseInput: ContextProjectorInput = {
+  route: "/workspace/workspace-a/session/session-a",
+  revision: 4,
+  capturedAt: "2026-07-23T12:00:00.000Z",
+  workbench: {
+    revision: 4,
+    workspaceId: "workspace-a",
+    workspaceTitle: "Customer workspace",
+    primarySessionId: "session-a",
+    tabs: [
+      { workspaceId: "workspace-a", sessionId: "session-a", title: "Primary" },
+      { workspaceId: "workspace-a", sessionId: "session-b", title: "Secondary" },
+    ],
+    splitSessionId: "session-b",
+    focusedPane: "secondary",
+  },
+  ui: {
+    sidebarOpen: true,
+    sidePanelState: { "session-b": "panel" },
+    applicationMenuVisible: false,
+    workspaceRightSidebarExpanded: true,
+  },
+  panelSessions: {
+    "session-b": {
+      tabs: [{ id: "artifact-a", type: "artifact", label: "Report", preview: "markdown" }],
+      activeTabId: "artifact-a",
+    },
+  },
+  availableAffordances: [],
+};
+
+describe("OpenWork context projector", () => {
+  test("projects the focused split session and its panel state", () => {
+    const context = buildOpenworkContext(baseInput);
+
+    expect(context.conversations.layout).toEqual({
+      kind: "split",
+      primarySessionId: "session-a",
+      secondarySessionId: "session-b",
+      focused: "secondary",
+    });
+    expect(context.resources.find((resource) => resource.kind === "workspace")?.title)
+      .toBe("Customer workspace");
+    expect(context.sidePanel).toEqual({
+      open: true,
+      ownerSessionId: "session-b",
+      kind: "panel",
+      tabs: [{ id: "artifact-a", kind: "artifact", label: "Report" }],
+      activeTabId: "artifact-a",
+    });
+  });
+
+  test("does not leak artifact tabs into a non-panel surface", () => {
+    const context = buildOpenworkContext({
+      ...baseInput,
+      ui: {
+        ...baseInput.ui,
+        sidePanelState: { "session-b": "extensions" },
+      },
+    });
+
+    expect(context.sidePanel.kind).toBe("extensions");
+    expect(context.sidePanel.tabs).toEqual([]);
+    expect(context.sidePanel.activeTabId).toBeNull();
+  });
+});
+
 const splitWorkbench: WorkbenchSnapshot = {
   revision: 5,
   workspaceId: "workspace-a",
+  workspaceTitle: "Workspace A",
   primarySessionId: "session-a",
   tabs: [
     { workspaceId: "workspace-a", sessionId: "session-a", title: "Current plan" },

--- a/apps/app/tests/openwork-context-projector.test.ts
+++ b/apps/app/tests/openwork-context-projector.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  buildOpenworkContext,
+  screenFromRoute,
+} from "../src/react-app/shell/openwork-context-projector";
+import type { WorkbenchSnapshot } from "../src/react-app/domains/session/chat/workbench-store";
+
+const splitWorkbench: WorkbenchSnapshot = {
+  revision: 5,
+  workspaceId: "workspace-a",
+  primarySessionId: "session-a",
+  tabs: [
+    { workspaceId: "workspace-a", sessionId: "session-a", title: "Current plan" },
+    { workspaceId: "workspace-a", sessionId: "session-b", title: "Previous research" },
+    { workspaceId: "workspace-a", sessionId: "session-c", title: "Draft" },
+  ],
+  splitSessionId: "session-b",
+  focusedPane: "secondary",
+};
+
+function contextForRoute(route: string) {
+  return buildOpenworkContext({
+    route,
+    revision: 7,
+    capturedAt: "2026-07-23T10:59:00.000Z",
+    workbench: splitWorkbench,
+    ui: {
+      sidebarOpen: false,
+      sidePanelState: { "session-a": "panel" },
+      applicationMenuVisible: false,
+      workspaceRightSidebarExpanded: true,
+    },
+    panelSessions: {
+      "session-a": {
+        tabs: [{
+          id: "browser-one",
+          type: "browser",
+          label: "OpenWork docs",
+          url: "https://docs.openwork.so",
+          favicon: null,
+          status: "ready",
+          canGoBack: false,
+          canGoForward: false,
+        }],
+        activeTabId: "browser-one",
+      },
+    },
+    availableAffordances: [],
+  });
+}
+
+describe("OpenWork context projector", () => {
+  test("represents all open tabs and both visible split sessions", () => {
+    const context = contextForRoute("/workspace/workspace-a/session/session-a");
+
+    expect(context.conversations.tabs.map((tab) => tab.sessionId)).toEqual([
+      "session-a",
+      "session-b",
+      "session-c",
+    ]);
+    expect(context.conversations.layout).toEqual({
+      kind: "split",
+      primarySessionId: "session-a",
+      secondarySessionId: "session-b",
+      focused: "secondary",
+    });
+    expect(context.resources.find((resource) => resource.ref === "session:session-b")).toMatchObject({
+      kind: "session",
+      title: "Previous research",
+      state: {
+        open: true,
+        visible: true,
+        pane: "secondary",
+        focused: true,
+      },
+    });
+    expect(context.chrome.sidebarOpen).toBe(false);
+    expect(context.execution).toEqual({
+      queries: "parallel",
+      commands: "serialized",
+      busyCommandId: null,
+      busyActor: null,
+    });
+    expect(context.sidePanel).toMatchObject({
+      open: true,
+      ownerSessionId: "session-a",
+      kind: "panel",
+      activeTabId: "browser-one",
+    });
+  });
+
+  test("retains workbench context while settings is the active screen", () => {
+    const context = contextForRoute("/workspace/workspace-a/settings/ai");
+
+    expect(context.screen).toEqual({
+      kind: "settings",
+      route: "/workspace/workspace-a/settings/ai",
+      workspaceId: "workspace-a",
+      panel: "ai",
+    });
+    expect(context.conversations.layout.kind).toBe("split");
+    expect(context.conversations.tabs).toHaveLength(3);
+  });
+
+  test("parses legacy and workspace-scoped routes without reading the DOM", () => {
+    expect(screenFromRoute("/session/session-a")).toMatchObject({
+      kind: "conversation",
+      sessionId: "session-a",
+    });
+    expect(screenFromRoute("/settings/extensions")).toMatchObject({
+      kind: "settings",
+      panel: "extensions",
+    });
+  });
+});

--- a/apps/app/tests/workbench-store.test.ts
+++ b/apps/app/tests/workbench-store.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  closeWorkbenchTab,
+  focusWorkbenchPane,
+  openWorkbenchTab,
+  setWorkbenchSplit,
+  syncWorkbenchSnapshot,
+  type WorkbenchSnapshot,
+} from "../src/react-app/domains/session/chat/workbench-store";
+
+const emptyWorkbench: WorkbenchSnapshot = {
+  revision: 0,
+  workspaceId: null,
+  primarySessionId: null,
+  tabs: [],
+  splitSessionId: null,
+  focusedPane: "primary",
+};
+
+describe("workbench store", () => {
+  test("retains open tabs and represents two visible sessions", () => {
+    let state = syncWorkbenchSnapshot(emptyWorkbench, {
+      workspaceId: "workspace-a",
+      primarySessionId: "session-a",
+      sessionsKnown: true,
+      sessions: [
+        { workspaceId: "workspace-a", sessionId: "session-a", title: "Primary" },
+        { workspaceId: "workspace-a", sessionId: "session-b", title: "Secondary" },
+      ],
+    });
+    state = openWorkbenchTab(state, {
+      workspaceId: "workspace-a",
+      sessionId: "session-b",
+      title: "Secondary",
+    });
+    state = setWorkbenchSplit(state, "session-b");
+
+    expect(state.tabs.map((tab) => tab.sessionId)).toEqual(["session-a", "session-b"]);
+    expect(state.primarySessionId).toBe("session-a");
+    expect(state.splitSessionId).toBe("session-b");
+    expect(state.focusedPane).toBe("secondary");
+  });
+
+  test("focuses an existing split pane without duplicating its tab", () => {
+    let state = syncWorkbenchSnapshot(emptyWorkbench, {
+      workspaceId: "workspace-a",
+      primarySessionId: "session-a",
+      sessionsKnown: true,
+      sessions: [
+        { workspaceId: "workspace-a", sessionId: "session-a" },
+        { workspaceId: "workspace-a", sessionId: "session-b" },
+      ],
+    });
+    state = openWorkbenchTab(state, { workspaceId: "workspace-a", sessionId: "session-b" });
+    state = setWorkbenchSplit(state, "session-b");
+    state = focusWorkbenchPane(state, "primary");
+    state = focusWorkbenchPane(state, "secondary");
+
+    expect(state.tabs).toHaveLength(2);
+    expect(state.focusedPane).toBe("secondary");
+  });
+
+  test("removes a closed split session and returns focus to primary", () => {
+    let state = syncWorkbenchSnapshot(emptyWorkbench, {
+      workspaceId: "workspace-a",
+      primarySessionId: "session-a",
+      sessionsKnown: true,
+      sessions: [
+        { workspaceId: "workspace-a", sessionId: "session-a" },
+        { workspaceId: "workspace-a", sessionId: "session-b" },
+      ],
+    });
+    state = openWorkbenchTab(state, { workspaceId: "workspace-a", sessionId: "session-b" });
+    state = setWorkbenchSplit(state, "session-b");
+    state = closeWorkbenchTab(state, "session-b");
+
+    expect(state.splitSessionId).toBeNull();
+    expect(state.focusedPane).toBe("primary");
+  });
+
+  test("keeps the same revision when synchronization changes nothing", () => {
+    const state = syncWorkbenchSnapshot(emptyWorkbench, {
+      workspaceId: "workspace-a",
+      primarySessionId: "session-a",
+      sessionsKnown: true,
+      sessions: [{ workspaceId: "workspace-a", sessionId: "session-a", title: "Session" }],
+    });
+    const unchanged = syncWorkbenchSnapshot(state, {
+      workspaceId: "workspace-a",
+      primarySessionId: "session-a",
+      sessionsKnown: true,
+      sessions: [{ workspaceId: "workspace-a", sessionId: "session-a", title: "Session" }],
+    });
+
+    expect(unchanged).toBe(state);
+    expect(unchanged.revision).toBe(state.revision);
+  });
+
+  test("does not prune retained tabs while the session index reloads", () => {
+    let state = syncWorkbenchSnapshot(emptyWorkbench, {
+      workspaceId: "workspace-a",
+      primarySessionId: "session-a",
+      sessionsKnown: true,
+      sessions: [
+        { workspaceId: "workspace-a", sessionId: "session-a" },
+        { workspaceId: "workspace-a", sessionId: "session-b" },
+      ],
+    });
+    state = openWorkbenchTab(state, { workspaceId: "workspace-a", sessionId: "session-b" });
+    state = setWorkbenchSplit(state, "session-b");
+
+    const loading = syncWorkbenchSnapshot(state, {
+      workspaceId: "workspace-a",
+      primarySessionId: "session-a",
+      sessionsKnown: false,
+      sessions: [],
+    });
+
+    expect(loading.tabs.map((tab) => tab.sessionId)).toEqual(["session-a", "session-b"]);
+    expect(loading.splitSessionId).toBe("session-b");
+  });
+});

--- a/apps/app/tests/workbench-store.test.ts
+++ b/apps/app/tests/workbench-store.test.ts
@@ -12,6 +12,7 @@ import {
 const emptyWorkbench: WorkbenchSnapshot = {
   revision: 0,
   workspaceId: null,
+  workspaceTitle: null,
   primarySessionId: null,
   tabs: [],
   splitSessionId: null,
@@ -22,6 +23,7 @@ describe("workbench store", () => {
   test("retains open tabs and represents two visible sessions", () => {
     let state = syncWorkbenchSnapshot(emptyWorkbench, {
       workspaceId: "workspace-a",
+      workspaceTitle: "Customer workspace",
       primarySessionId: "session-a",
       sessionsKnown: true,
       sessions: [
@@ -37,6 +39,7 @@ describe("workbench store", () => {
     state = setWorkbenchSplit(state, "session-b");
 
     expect(state.tabs.map((tab) => tab.sessionId)).toEqual(["session-a", "session-b"]);
+    expect(state.workspaceTitle).toBe("Customer workspace");
     expect(state.primarySessionId).toBe("session-a");
     expect(state.splitSessionId).toBe("session-b");
     expect(state.focusedPane).toBe("secondary");

--- a/apps/desktop/electron/ui-control-server.mjs
+++ b/apps/desktop/electron/ui-control-server.mjs
@@ -58,13 +58,11 @@ export function createUiControlServer({ appName, appIdentifier, getWindow }) {
     return JSON.stringify(JSON.stringify(value ?? {}));
   }
 
-  async function evaluateOpenworkControl(expression, options = {}) {
+  async function evaluateOpenworkControl(expression) {
     const win = await getWindow();
-    if (options.focus === true) {
-      win.show();
-      if (win.isMinimized()) win.restore();
-      win.focus();
-    }
+    // Commands mutate renderer state directly and do not require the desktop
+    // window to become active. Foreground activation must be an explicit
+    // affordance, never an implicit side effect of remote control.
     return win.webContents.executeJavaScript(expression, true);
   }
 
@@ -102,7 +100,7 @@ export function createUiControlServer({ appName, appIdentifier, getWindow }) {
           return { ok: false, error: "Missing OpenWork affordance id." };
         }
         return control[${JSON.stringify(command)}](input);
-      })()`, { focus: command === "command" });
+      })()`);
     }
     if (command === "execute") {
       return evaluateOpenworkControl(`(async () => {
@@ -114,7 +112,7 @@ export function createUiControlServer({ appName, appIdentifier, getWindow }) {
         }
         control.setEnabled?.(true);
         return control.execute(input.actionId, input.args ?? {});
-      })()`, { focus: true });
+      })()`);
     }
     return { ok: false, error: `Unknown OpenWork control command: ${command}` };
   }

--- a/apps/desktop/electron/ui-control-server.mjs
+++ b/apps/desktop/electron/ui-control-server.mjs
@@ -1,6 +1,6 @@
-// Local UI-control HTTP bridge: a loopback server exposing /snapshot,
-// /actions, /execute, dispatched to the renderer's window.__openworkControl
-// surface via executeJavaScript. Consumed over HTTP by openwork-ui-mcp.
+// Local UI-control HTTP bridge: a loopback server exposing the legacy
+// /snapshot, /actions and /execute routes plus the semantic /context, /query
+// and /command surface. Dispatched to the renderer's window.__openworkControl.
 // Extracted from main.mjs; state and lifecycle live in this factory
 // (createRuntimeManager pattern).
 import { randomBytes } from "node:crypto";
@@ -86,6 +86,24 @@ export function createUiControlServer({ appName, appIdentifier, getWindow }) {
         return { ok: true, actions: control.listActions() };
       })()`);
     }
+    if (command === "context") {
+      return evaluateOpenworkControl(`(async () => {
+        const control = window.__openworkControl;
+        if (!control) return { ok: false, error: "OpenWork control surface is not available yet." };
+        return { ok: true, context: control.context() };
+      })()`);
+    }
+    if (command === "query" || command === "command") {
+      return evaluateOpenworkControl(`(async () => {
+        const control = window.__openworkControl;
+        const input = JSON.parse(${argsJsonLiteral});
+        if (!control) return { ok: false, error: "OpenWork control surface is not available yet." };
+        if (!input || typeof input.id !== "string" || !input.id.trim()) {
+          return { ok: false, error: "Missing OpenWork affordance id." };
+        }
+        return control[${JSON.stringify(command)}](input);
+      })()`, { focus: command === "command" });
+    }
     if (command === "execute") {
       return evaluateOpenworkControl(`(async () => {
         const control = window.__openworkControl;
@@ -107,7 +125,7 @@ export function createUiControlServer({ appName, appIdentifier, getWindow }) {
       try {
         const url = new URL(request.url ?? "/", "http://127.0.0.1");
         if (request.method === "GET" && url.pathname === "/health") {
-          sendJsonResponse(response, 200, { ok: true, app: appName, version: 1 });
+          sendJsonResponse(response, 200, { ok: true, app: appName, version: 2 });
           return;
         }
         if (!authorizedUiControlRequest(request)) {
@@ -120,6 +138,18 @@ export function createUiControlServer({ appName, appIdentifier, getWindow }) {
         }
         if (request.method === "GET" && url.pathname === "/actions") {
           sendJsonResponse(response, 200, await runOpenworkControlCommand("actions"));
+          return;
+        }
+        if (request.method === "GET" && url.pathname === "/context") {
+          sendJsonResponse(response, 200, await runOpenworkControlCommand("context"));
+          return;
+        }
+        if (request.method === "POST" && url.pathname === "/query") {
+          sendJsonResponse(response, 200, await runOpenworkControlCommand("query", await readJsonRequestBody(request)));
+          return;
+        }
+        if (request.method === "POST" && url.pathname === "/command") {
+          sendJsonResponse(response, 200, await runOpenworkControlCommand("command", await readJsonRequestBody(request)));
           return;
         }
         if (request.method === "POST" && url.pathname === "/execute") {
@@ -141,7 +171,7 @@ export function createUiControlServer({ appName, appIdentifier, getWindow }) {
     uiControlDiscoveryPath = path.join(app.getPath("userData"), "openwork-ui-control.json");
     await writeFile(
       uiControlDiscoveryPath,
-      `${JSON.stringify({ version: 1, app: appName, identifier: appIdentifier, platform: process.platform, baseUrl: `http://127.0.0.1:${port}`, token: uiControlToken }, null, 2)}\n`,
+      `${JSON.stringify({ version: 2, app: appName, identifier: appIdentifier, platform: process.platform, baseUrl: `http://127.0.0.1:${port}`, token: uiControlToken }, null, 2)}\n`,
       "utf8",
     );
     // Make the discovery path available to child processes (server → managed OpenCode → plugin).

--- a/apps/desktop/electron/ui-control-server.test.mjs
+++ b/apps/desktop/electron/ui-control-server.test.mjs
@@ -1,0 +1,10 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+test("UI control commands never activate the desktop window implicitly", async () => {
+  const source = await readFile(new URL("./ui-control-server.mjs", import.meta.url), "utf8");
+
+  assert.match(source, /webContents\.executeJavaScript/);
+  assert.doesNotMatch(source, /\bwin\.(?:show|restore|focus)\(/);
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.11",

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -268,10 +268,19 @@ describe("OpenWorkExtensionsPreview session tools", () => {
       id: "session.read",
       args: { sessionId: "ses_archive", count: 2 },
     });
-    const parsed = readResultSchema.parse(JSON.parse(output));
+    const parsed = z.object({
+      ok: z.literal(true),
+      id: z.literal("session.read"),
+      result: readResultSchema,
+      effects: z.object({
+        data: z.literal("read"),
+        ui: z.literal("none"),
+        external: z.literal(false),
+      }),
+    }).parse(JSON.parse(output));
 
-    expect(parsed.sessionId).toBe("ses_archive");
-    expect(parsed.messages.at(-1)?.text).toContain("archive importer");
+    expect(parsed.result.sessionId).toBe("ses_archive");
+    expect(parsed.result.messages.at(-1)?.text).toContain("archive importer");
   });
 
   test("searches past chat transcript text and prefers the user's matching message", async () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -119,7 +119,12 @@ function startFakeOpenWorkServer() {
         return Response.json({
           ok: true,
           schemaVersion: 1,
-          skills: [],
+          skills: [{
+            name: "customer-briefing",
+            title: "Customer briefing",
+            description: "Prepare a connected customer briefing.",
+            capability: "skill:skl_customer_briefing",
+          }],
           instruction: "<available_skills><skill><name>customer-briefing</name></skill></available_skills>",
         });
       }
@@ -194,6 +199,79 @@ function startFakeOpenWorkServer() {
 describe("OpenWorkExtensionsPreview session tools", () => {
   test("plugin entry exposes only the factory export for the OpenCode loader", () => {
     expect(Object.keys(OpenWorkExtensionsPreviewEntry)).toEqual(["OpenWorkExtensionsPreview"]);
+  });
+
+  test("projects built-in, extension, and Connect providers into one agent context", async () => {
+    startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview({
+      client: {
+        mcp: {
+          status: async () => ({
+            data: {
+              notion: { status: "connected" },
+              "openwork-cloud": { status: "connected" },
+            },
+          }),
+        },
+      },
+    });
+
+    const output = await plugin.tool.openwork_context.execute();
+    const parsed = z.object({
+      context: z.object({
+        contributions: z.array(z.object({
+          featureId: z.string(),
+          affordances: z.array(z.object({
+            id: z.string(),
+            executor: z.object({ kind: z.string(), tool: z.string().optional() }),
+          }).passthrough()),
+          guidance: z.array(z.object({
+            ref: z.string(),
+          }).passthrough()),
+        }).passthrough()),
+      }).passthrough().nullable().optional(),
+      contributions: z.array(z.object({
+        featureId: z.string(),
+        affordances: z.array(z.object({
+          id: z.string(),
+          executor: z.object({ kind: z.string(), tool: z.string().optional() }),
+        }).passthrough()),
+        guidance: z.array(z.object({
+          ref: z.string(),
+        }).passthrough()),
+      }).passthrough()).optional(),
+    }).passthrough().parse(JSON.parse(output));
+    const contributions = parsed.context?.contributions ?? parsed.contributions ?? [];
+
+    expect(contributions.map((contribution) => contribution.featureId)).toEqual([
+      "sessions",
+      "extensions",
+      "mcp:notion",
+      "connect",
+    ]);
+    expect(contributions.find((contribution) => contribution.featureId === "connect")?.guidance)
+      .toContainEqual(expect.objectContaining({ ref: "skill:skl_customer_briefing" }));
+    expect(
+      contributions.flatMap((contribution) => contribution.affordances)
+        .find((affordance) => affordance.id === "connect.capability.execute")?.executor,
+    ).toEqual({
+      kind: "tool",
+      tool: "openwork-cloud_execute_capability",
+    });
+  });
+
+  test("routes semantic session queries without navigating the UI", async () => {
+    startFakeOpenWorkServer();
+    const plugin = await OpenWorkExtensionsPreview();
+
+    const output = await plugin.tool.openwork_query.execute({
+      id: "session.read",
+      args: { sessionId: "ses_archive", count: 2 },
+    });
+    const parsed = readResultSchema.parse(JSON.parse(output));
+
+    expect(parsed.sessionId).toBe("ses_archive");
+    expect(parsed.messages.at(-1)?.text).toContain("archive importer");
   });
 
   test("searches past chat transcript text and prefers the user's matching message", async () => {
@@ -371,14 +449,18 @@ describe("OpenWorkExtensionsPreview UI control tools", () => {
     expect(tools).not.toContain("openwork_ui_snapshot");
     expect(tools).not.toContain("openwork_ui_list_actions");
     expect(tools).not.toContain("openwork_ui_execute_action");
+    expect(tools).toContain("openwork_context");
+    expect(tools).toContain("openwork_query");
+    expect(tools).toContain("openwork_execute");
     expect(tools).toContain("openwork_session_create");
     expect(tools).toContain("openwork_session_search");
     expect(tools).toContain("openwork_extension_list_actions");
 
     const system = await transformedSystem(plugin);
     expect(system).not.toContain("openwork_ui_");
-    expect(system).toContain("ALWAYS use openwork_session_create");
-    expect(system).toContain("openwork_session_search");
+    expect(system).toContain("Use openwork_context");
+    expect(system).toContain("session.search");
+    expect(system).not.toContain("ALWAYS use openwork_session_create");
   });
 
   test("registers UI-control tools and steering when opted in", async () => {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -15,6 +15,11 @@ import {
   type OpenCodeContext,
   type OpenWorkEngineMcpStatusClient,
 } from "./openwork-extensions-preview-steering.js";
+import {
+  buildOpenworkProviderContributions,
+  type ConnectSkillDescriptor,
+  type EngineMcpDescriptor,
+} from "./openwork-provider-adapters.js";
 
 type ExtensionActionPayload = {
   extensionId: string;
@@ -37,6 +42,24 @@ const uiExecuteArgsSchema = z.object({
   actionId: z.string().describe("The action id from openwork_ui_list_actions, e.g. 'settings.panel.open' or 'composer.set_text'."),
   args: z.record(z.string(), z.unknown()).optional().describe("JSON arguments for the action, if required."),
 });
+
+const openworkAffordanceRequestSchema = z.object({
+  id: z.string().trim().min(1).describe("Semantic affordance id from openwork_context."),
+  args: z.record(z.string(), z.unknown()).optional().describe("JSON arguments for the affordance."),
+  expectedRevision: z.number().int().nonnegative().optional().describe("Context revision from openwork_context. Use for commands to prevent stale writes."),
+  actor: z.string().trim().min(1).optional().describe("Optional agent or client id used to attribute serialized commands."),
+});
+
+const connectSkillDescriptorSchema = z.object({
+  name: z.string(),
+  title: z.string().optional(),
+  description: z.string(),
+  capability: z.string(),
+}).passthrough();
+
+const connectSkillsEnvelopeSchema = z.object({
+  skills: z.array(connectSkillDescriptorSchema),
+}).passthrough();
 
 const browserOpenUrlArgsSchema = z.object({
   url: z.string().describe("The website URL to open in the OpenWork built-in browser."),
@@ -130,6 +153,12 @@ const sessionMessagesEnvelopeSchema = z.object({
   items: z.array(sessionMessageSchema),
 }).passthrough();
 
+const OPENWORK_AGENT_SURFACE_INSTRUCTION =
+  `## OpenWork app context
+Use openwork_context when the request depends on the current OpenWork screen, open tabs, split view, focused pane, sidebar, side panel, settings panel, or available app actions.
+Each affordance declares its effects and executor. Use openwork_query only for side-effect-free affordances whose executor is OpenWork. Use openwork_execute for OpenWork commands. If executor names another tool, call that exact tool instead.
+Reading another session does not require opening it. Prefer the session.search then session.read affordances for transcript questions; use session.create for new chats and a UI command only when the user asks to navigate.`;
+
 const OPENWORK_UI_CONTROL_INSTRUCTION =
   `IMPORTANT: You are running inside the OpenWork desktop app. When the user asks you to open settings, navigate the app, add providers, or control the OpenWork UI in any way, ALWAYS use the openwork_ui_* tools — NOT the browser_* tools. The browser tools are for external websites only. The openwork_ui_* tools control the app directly and are instant (one tool call).
 
@@ -138,17 +167,6 @@ To add a provider: openwork_ui_execute_action with actionId "settings.provider.a
 To see what the user sees: openwork_ui_snapshot
 To list all available actions: openwork_ui_list_actions
 To ask what OpenWork can do: openwork_ui_execute_action with actionId "help.capabilities"`;
-
-const OPENWORK_SESSION_MEMORY_INSTRUCTION =
-  `## Cross-session memory
-When the user asks what they said, what happened, or what was decided in another OpenWork chat/session, treat it as a session-history lookup, not hidden model memory.
-Use openwork_session_search first to search session titles and message transcripts across workspaces. If there is one clear match, use openwork_session_read with the returned sessionId/workspaceId to retrieve transcript context without navigating the UI.
-Answer only from the returned search/read results. If multiple sessions match, ask a short clarifying question. If the returned transcript is limited or missing the older context needed, say so instead of guessing.`;
-
-const OPENWORK_SESSION_CREATION_INSTRUCTION =
-  `## Creating sessions
-When the user asks to create one or more new OpenWork sessions or chats, ALWAYS use openwork_session_create. Do not use UI-control tools or browser automation to create sessions.
-Pass one entry per requested session, with a short title and a self-contained prompt describing the work for that session. The tool creates and starts every session in the background without navigating away from the current chat. After the call, report only the sessions in created and clearly report any failures.`;
 
 const OPENWORK_BROWSER_INSTRUCTION =
   `Do NOT use browser_navigate, browser_click, or browser_snapshot to interact with the OpenWork app itself. Those are for browsing external websites.
@@ -330,6 +348,127 @@ async function serverGet(path: string): Promise<unknown> {
   const payload = await parseResponse(response);
   if (!response.ok) throw new Error(errorMessage(payload, "OpenWork server request failed"));
   return payload;
+}
+
+async function readConnectSkillDescriptors(): Promise<ConnectSkillDescriptor[]> {
+  try {
+    const parsed = connectSkillsEnvelopeSchema.safeParse(
+      await serverGet("/experimental/connect/skills"),
+    );
+    return parsed.success ? parsed.data.skills : [];
+  } catch {
+    return [];
+  }
+}
+
+async function readEngineMcpDescriptors(
+  client: OpenWorkEngineMcpStatusClient | undefined,
+  directory: string | undefined,
+): Promise<EngineMcpDescriptor[]> {
+  if (!client) return [];
+  try {
+    const result = await client.mcp.status(directory ? { query: { directory } } : undefined);
+    const payload = isRecord(result) && result.data !== undefined ? result.data : result;
+    if (!isRecord(payload)) return [];
+    return Object.entries(payload).map(([name, entry]) => {
+      const status = typeof entry === "string"
+        ? entry
+        : optionalStringProperty(entry, "status");
+      return status ? { name, status } : { name };
+    });
+  } catch {
+    return [];
+  }
+}
+
+async function readOpenworkAgentContext(
+  engineMcpStatusClient: OpenWorkEngineMcpStatusClient | undefined,
+  engineMcpStatusDirectory: string | undefined,
+): Promise<Record<string, unknown>> {
+  const [uiResult, skills, mcps] = await Promise.all([
+    uiBridgeRequest("/context"),
+    readConnectSkillDescriptors(),
+    readEngineMcpDescriptors(engineMcpStatusClient, engineMcpStatusDirectory),
+  ]);
+  const contributions = buildOpenworkProviderContributions(skills, mcps);
+  const providerAffordances = contributions.flatMap((contribution) => contribution.affordances);
+  const uiContext = isRecord(uiResult) && isRecord(uiResult.context) ? uiResult.context : null;
+  if (!uiContext) {
+    return {
+      ok: true,
+      context: null,
+      ui: uiResult,
+      availableAffordances: providerAffordances,
+      contributions,
+    };
+  }
+  const uiAffordances = Array.isArray(uiContext.availableAffordances)
+    ? uiContext.availableAffordances
+    : [];
+  return {
+    ok: true,
+    context: {
+      ...uiContext,
+      availableAffordances: [...uiAffordances, ...providerAffordances],
+      contributions,
+    },
+  };
+}
+
+async function queryOpenworkAffordance(rawArgs: unknown): Promise<unknown> {
+  const request = openworkAffordanceRequestSchema.parse(rawArgs);
+  if (request.id === "session.search") {
+    return searchOpenWorkSessions(request.args ?? {});
+  }
+  if (request.id === "session.read") {
+    return readOpenWorkSession(request.args ?? {});
+  }
+  if (request.id === "extension.actions") {
+    const args = listActionsArgsSchema.parse(request.args ?? {});
+    const query = args.extensionId ? `?extensionId=${encodeURIComponent(args.extensionId)}` : "";
+    return serverGet(`/experimental/extensions/actions${query}`);
+  }
+  if (request.id.startsWith("connect.")) {
+    return {
+      ok: false,
+      error: "This affordance declares a dedicated Connect executor. Call the tool named in openwork_context.",
+      code: "executor-required",
+    };
+  }
+  return uiBridgeRequest("/query", {
+    method: "POST",
+    body: request,
+  });
+}
+
+async function executeOpenworkAffordance(
+  rawArgs: unknown,
+  context: OpenCodeContext,
+): Promise<unknown> {
+  const request = openworkAffordanceRequestSchema.parse(rawArgs);
+  if (request.id === "session.create") {
+    return createOpenWorkSessions(request.args ?? {}, context);
+  }
+  if (request.id === "extension.call") {
+    const args = callArgsSchema.parse(request.args ?? {});
+    return postJson("/experimental/extensions/call", {
+      extensionId: args.extensionId,
+      action: args.action,
+      args: args.args ?? {},
+      context: contextPayload(context),
+    });
+  }
+  if (request.id.startsWith("connect.")) {
+    return {
+      ok: false,
+      error: "This affordance declares a dedicated Connect executor. Call the tool named in openwork_context.",
+      code: "executor-required",
+    };
+  }
+  return uiBridgeRequest("/command", {
+    method: "POST",
+    body: request,
+  });
 }
 
 function collapseWhitespace(value: string): string {
@@ -761,16 +900,41 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
     // remote skills, session, browser, and UI tools never overlap by accident.
     const sections = combineInstructionSections(
       createInstructionSection("routing", extensionInstruction),
+      createInstructionSection("agent-surface", OPENWORK_AGENT_SURFACE_INSTRUCTION),
       createInstructionSection("skill-authoring", skillAuthoring.prompt),
       createInstructionSection("connect-skills", skillInstruction),
-      createInstructionSection("session-create", OPENWORK_SESSION_CREATION_INSTRUCTION),
-      createInstructionSection("session-memory", OPENWORK_SESSION_MEMORY_INSTRUCTION),
       createInstructionSection("browser", OPENWORK_BROWSER_INSTRUCTION),
       uiControlEnabled ? createInstructionSection("ui-control", OPENWORK_UI_CONTROL_INSTRUCTION) : null,
     );
     output.system.push(...composeAgentInstructions(sections));
   },
   tool: {
+    openwork_context: {
+      description: "Read one semantic snapshot of OpenWork: current screen, retained conversation tabs, split view and focused pane, sidebar and side panel state, settings panel, provider contributions, remote skill guidance, and available affordances with explicit effects and executors.",
+      args: {},
+      async execute() {
+        return JSON.stringify(
+          await readOpenworkAgentContext(engineMcpStatusClient, engineMcpStatusDirectory),
+          null,
+          2,
+        );
+      },
+    },
+    openwork_query: {
+      description: "Run a side-effect-free OpenWork affordance whose executor is OpenWork. Use the exact id and arguments from openwork_context. This reads backend or app state without navigation or window focus.",
+      args: openworkAffordanceRequestSchema.shape,
+      async execute(rawArgs: unknown) {
+        return JSON.stringify(await queryOpenworkAffordance(rawArgs), null, 2);
+      },
+    },
+    openwork_execute: {
+      description: "Execute an OpenWork command whose executor is OpenWork. Use the exact id and arguments from openwork_context, and pass expectedRevision for UI commands to prevent stale writes. If the descriptor names another executor tool, call that tool instead.",
+      args: openworkAffordanceRequestSchema.shape,
+      async execute(rawArgs: unknown, context: OpenCodeContext) {
+        const mergedContext = { ...factoryContext, ...normalizeOpenCodeContext(context) };
+        return JSON.stringify(await executeOpenworkAffordance(rawArgs, mergedContext), null, 2);
+      },
+    },
     openwork_extension_list_actions: {
       description: `List extension actions currently exposed by OpenWork. ${OPENWORK_EXTENSION_DISCOVERY_INSTRUCTION}`,
       args: listActionsArgsSchema.shape,

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -2,6 +2,7 @@ import { readFile } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir, platform } from "node:os";
 import { z } from "zod";
+import type { OpenworkAffordanceEffects } from "@openwork/types/openwork-affordance";
 import {
   combineInstructionSections,
   composeAgentInstructions,
@@ -216,6 +217,30 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+const affordanceReadEffects: OpenworkAffordanceEffects = { data: "read", ui: "none", external: false };
+const affordanceWriteEffects: OpenworkAffordanceEffects = { data: "write", ui: "none", external: false };
+const affordanceExternalWriteEffects: OpenworkAffordanceEffects = { data: "write", ui: "none", external: true };
+
+function affordanceResult(
+  id: string,
+  result: unknown,
+  effects: OpenworkAffordanceEffects,
+) {
+  if (isRecord(result) && result.ok === false) {
+    return {
+      ok: false,
+      id,
+      error: typeof result.error === "string" ? result.error : `${id} failed`,
+      code: "failed",
+    };
+  }
+  return { ok: true, id, result, effects };
+}
+
+function unavailableAffordance(id: string, error: string) {
+  return { ok: false, id, error, code: "unavailable" };
+}
+
 function optionalStringProperty(value: unknown, key: string): string | undefined {
   if (!isRecord(value)) return undefined;
   const property = value[key];
@@ -418,27 +443,41 @@ async function readOpenworkAgentContext(
 async function queryOpenworkAffordance(rawArgs: unknown): Promise<unknown> {
   const request = openworkAffordanceRequestSchema.parse(rawArgs);
   if (request.id === "session.search") {
-    return searchOpenWorkSessions(request.args ?? {});
+    return affordanceResult(
+      request.id,
+      await searchOpenWorkSessions(request.args ?? {}),
+      affordanceReadEffects,
+    );
   }
   if (request.id === "session.read") {
-    return readOpenWorkSession(request.args ?? {});
+    return affordanceResult(
+      request.id,
+      await readOpenWorkSession(request.args ?? {}),
+      affordanceReadEffects,
+    );
   }
   if (request.id === "extension.actions") {
     const args = listActionsArgsSchema.parse(request.args ?? {});
     const query = args.extensionId ? `?extensionId=${encodeURIComponent(args.extensionId)}` : "";
-    return serverGet(`/experimental/extensions/actions${query}`);
+    return affordanceResult(
+      request.id,
+      await serverGet(`/experimental/extensions/actions${query}`),
+      affordanceReadEffects,
+    );
   }
   if (request.id.startsWith("connect.")) {
-    return {
-      ok: false,
-      error: "This affordance declares a dedicated Connect executor. Call the tool named in openwork_context.",
-      code: "executor-required",
-    };
+    return unavailableAffordance(
+      request.id,
+      "This affordance declares a dedicated Connect executor. Call the tool named in openwork_context.",
+    );
   }
-  return uiBridgeRequest("/query", {
+  const result = await uiBridgeRequest("/query", {
     method: "POST",
     body: request,
   });
+  return isRecord(result) && typeof result.ok === "boolean"
+    ? result
+    : unavailableAffordance(request.id, "OpenWork UI query returned an invalid response.");
 }
 
 async function executeOpenworkAffordance(
@@ -447,28 +486,38 @@ async function executeOpenworkAffordance(
 ): Promise<unknown> {
   const request = openworkAffordanceRequestSchema.parse(rawArgs);
   if (request.id === "session.create") {
-    return createOpenWorkSessions(request.args ?? {}, context);
+    return affordanceResult(
+      request.id,
+      await createOpenWorkSessions(request.args ?? {}, context),
+      affordanceWriteEffects,
+    );
   }
   if (request.id === "extension.call") {
     const args = callArgsSchema.parse(request.args ?? {});
-    return postJson("/experimental/extensions/call", {
-      extensionId: args.extensionId,
-      action: args.action,
-      args: args.args ?? {},
-      context: contextPayload(context),
-    });
+    return affordanceResult(
+      request.id,
+      await postJson("/experimental/extensions/call", {
+        extensionId: args.extensionId,
+        action: args.action,
+        args: args.args ?? {},
+        context: contextPayload(context),
+      }),
+      affordanceExternalWriteEffects,
+    );
   }
   if (request.id.startsWith("connect.")) {
-    return {
-      ok: false,
-      error: "This affordance declares a dedicated Connect executor. Call the tool named in openwork_context.",
-      code: "executor-required",
-    };
+    return unavailableAffordance(
+      request.id,
+      "This affordance declares a dedicated Connect executor. Call the tool named in openwork_context.",
+    );
   }
-  return uiBridgeRequest("/command", {
+  const result = await uiBridgeRequest("/command", {
     method: "POST",
     body: request,
   });
+  return isRecord(result) && typeof result.ok === "boolean"
+    ? result
+    : unavailableAffordance(request.id, "OpenWork UI command returned an invalid response.");
 }
 
 function collapseWhitespace(value: string): string {

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -977,7 +977,7 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
       },
     },
     openwork_execute: {
-      description: "Execute an OpenWork command whose executor is OpenWork. Use the exact id and arguments from openwork_context, and pass expectedRevision for UI commands to prevent stale writes. If the descriptor names another executor tool, call that tool instead.",
+      description: "Execute an OpenWork command whose executor is OpenWork without activating the desktop window. Use the exact id and arguments from openwork_context, and pass expectedRevision for UI commands to prevent stale writes. If the descriptor names another executor tool, call that tool instead.",
       args: openworkAffordanceRequestSchema.shape,
       async execute(rawArgs: unknown, context: OpenCodeContext) {
         const mergedContext = { ...factoryContext, ...normalizeOpenCodeContext(context) };
@@ -1031,7 +1031,7 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
       },
     },
     openwork_ui_execute_action: {
-      description: `Execute an OpenWork UI action by its id. Use openwork_ui_list_actions first to see available actions. ${OPENWORK_UI_CONTROL_INSTRUCTION}`,
+      description: `Execute an OpenWork UI action by its id without activating the desktop window. Use openwork_ui_list_actions first to see available actions. ${OPENWORK_UI_CONTROL_INSTRUCTION}`,
       args: uiExecuteArgsSchema.shape,
       async execute(rawArgs: unknown) {
         const { actionId, args } = uiExecuteArgsSchema.parse(rawArgs);

--- a/apps/server/src/opencode-plugins/openwork-provider-adapters.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-provider-adapters.test.ts
@@ -53,6 +53,10 @@ describe("OpenWork provider adapters", () => {
         executor: { kind: "tool", tool: "openwork-cloud_execute_capability" },
       },
     ]);
+    expect(
+      connect?.affordances.find((affordance) => affordance.id === "connect.capability.execute")
+        ?.arguments.map((argument) => argument.name),
+    ).toEqual(["name", "schemaDigest", "path", "query", "body"]);
   });
 
   test("includes only MCP providers observed from the engine", () => {
@@ -65,10 +69,15 @@ describe("OpenWork provider adapters", () => {
       "sessions",
       "extensions",
       "mcp:notion",
+      "connect",
     ]);
     expect(contributions[2]).toMatchObject({
       provider: { id: "notion", kind: "mcp" },
       affordances: [],
     });
+    expect(contributions[3]?.affordances.map((affordance) => affordance.id)).toEqual([
+      "connect.capabilities.search",
+      "connect.capability.execute",
+    ]);
   });
 });

--- a/apps/server/src/opencode-plugins/openwork-provider-adapters.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-provider-adapters.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from "bun:test";
+import { openworkFeatureContributionSchema } from "@openwork/types/openwork-provider";
+
+import { buildOpenworkProviderContributions } from "./openwork-provider-adapters.js";
+
+describe("OpenWork provider adapters", () => {
+  test("normalizes sessions and extensions into semantic contributions", () => {
+    const contributions = buildOpenworkProviderContributions([]);
+
+    expect(contributions.map((contribution) => contribution.featureId)).toEqual([
+      "sessions",
+      "extensions",
+    ]);
+    expect(
+      contributions.flatMap((contribution) => contribution.affordances)
+        .find((affordance) => affordance.id === "session.read"),
+    ).toMatchObject({
+      kind: "query",
+      effects: { data: "read", ui: "none", external: false },
+      executor: { kind: "openwork" },
+    });
+    for (const contribution of contributions) {
+      expect(openworkFeatureContributionSchema.safeParse(contribution).success).toBe(true);
+    }
+  });
+
+  test("keeps known Connect skills direct and search available for unknown capabilities", () => {
+    const contributions = buildOpenworkProviderContributions([{
+      name: "customer-briefing",
+      title: "Customer briefing",
+      description: "Prepare a customer briefing from connected sources.",
+      capability: "skill:skl_customer_briefing",
+    }]);
+    const connect = contributions.find((contribution) => contribution.featureId === "connect");
+
+    expect(connect?.guidance).toEqual([{
+      ref: "skill:skl_customer_briefing",
+      title: "Customer briefing",
+      description: "Prepare a customer briefing from connected sources.",
+      provider: { id: "openwork-cloud", kind: "connect" },
+      loading: "catalog",
+    }]);
+    expect(connect?.affordances.map((affordance) => ({
+      id: affordance.id,
+      executor: affordance.executor,
+    }))).toEqual([
+      {
+        id: "connect.capabilities.search",
+        executor: { kind: "tool", tool: "openwork-cloud_search_capabilities" },
+      },
+      {
+        id: "connect.capability.execute",
+        executor: { kind: "tool", tool: "openwork-cloud_execute_capability" },
+      },
+    ]);
+  });
+
+  test("includes only MCP providers observed from the engine", () => {
+    const contributions = buildOpenworkProviderContributions([], [
+      { name: "notion", status: "connected" },
+      { name: "openwork-cloud", status: "connected" },
+    ]);
+
+    expect(contributions.map((contribution) => contribution.featureId)).toEqual([
+      "sessions",
+      "extensions",
+      "mcp:notion",
+    ]);
+    expect(contributions[2]).toMatchObject({
+      provider: { id: "notion", kind: "mcp" },
+      affordances: [],
+    });
+  });
+});

--- a/apps/server/src/opencode-plugins/openwork-provider-adapters.ts
+++ b/apps/server/src/opencode-plugins/openwork-provider-adapters.ts
@@ -1,0 +1,217 @@
+import type {
+  OpenworkAffordanceArgument,
+  OpenworkAffordanceDescriptor,
+  OpenworkAffordanceEffects,
+  OpenworkProviderRef,
+} from "@openwork/types/openwork-affordance";
+import type {
+  OpenworkFeatureContribution,
+  OpenworkGuidanceDescriptor,
+} from "@openwork/types/openwork-provider";
+
+export type ConnectSkillDescriptor = {
+  name: string;
+  title?: string;
+  description: string;
+  capability: string;
+};
+
+export type EngineMcpDescriptor = {
+  name: string;
+  status?: string;
+};
+
+const noEffects: OpenworkAffordanceEffects = {
+  data: "none",
+  ui: "none",
+  external: false,
+};
+const readEffects: OpenworkAffordanceEffects = {
+  data: "read",
+  ui: "none",
+  external: false,
+};
+const writeEffects: OpenworkAffordanceEffects = {
+  data: "write",
+  ui: "none",
+  external: false,
+};
+
+function argument(
+  name: string,
+  type: OpenworkAffordanceArgument["type"],
+  required: boolean,
+  description: string,
+): OpenworkAffordanceArgument {
+  return { name, type, required, description };
+}
+
+function affordance(input: {
+  id: string;
+  kind: "query" | "command";
+  title: string;
+  description: string;
+  provider: OpenworkProviderRef;
+  arguments?: OpenworkAffordanceArgument[];
+  effects?: OpenworkAffordanceEffects;
+  tool?: string;
+}): OpenworkAffordanceDescriptor {
+  return {
+    id: input.id,
+    kind: input.kind,
+    title: input.title,
+    description: input.description,
+    provider: input.provider,
+    arguments: input.arguments ?? [],
+    effects: input.effects ?? noEffects,
+    confirmation: "never",
+    availability: { enabled: true },
+    executor: input.tool
+      ? { kind: "tool", tool: input.tool }
+      : { kind: "openwork" },
+  };
+}
+
+function sessionContribution(): OpenworkFeatureContribution {
+  const provider: OpenworkProviderRef = { id: "openwork-server", kind: "builtin" };
+  return {
+    featureId: "sessions",
+    provider,
+    affordances: [
+      affordance({
+        id: "session.search",
+        kind: "query",
+        title: "Find sessions",
+        description: "Search session titles and transcripts without changing the visible workbench.",
+        provider,
+        arguments: [
+          argument("query", "string", true, "Text to find in session titles or messages."),
+          argument("workspaceId", "string", false, "Optional workspace id or name."),
+        ],
+        effects: readEffects,
+      }),
+      affordance({
+        id: "session.read",
+        kind: "query",
+        title: "Read a session transcript",
+        description: "Read recent messages from a session without opening it.",
+        provider,
+        arguments: [
+          argument("sessionId", "string", true, "Session id returned by session.search."),
+          argument("workspaceId", "string", false, "Optional workspace id or name."),
+          argument("count", "number", false, "Number of recent messages to return."),
+        ],
+        effects: readEffects,
+      }),
+      affordance({
+        id: "session.create",
+        kind: "command",
+        title: "Create sessions",
+        description: "Create and start one or more sessions without navigating away.",
+        provider,
+        arguments: [argument("sessions", "array", true, "Session titles and self-contained prompts.")],
+        effects: writeEffects,
+      }),
+    ],
+    guidance: [],
+  };
+}
+
+function extensionContribution(): OpenworkFeatureContribution {
+  const provider: OpenworkProviderRef = { id: "openwork-extensions", kind: "extension" };
+  return {
+    featureId: "extensions",
+    provider,
+    affordances: [
+      affordance({
+        id: "extension.actions",
+        kind: "query",
+        title: "List extension actions",
+        description: "List actions exposed by enabled local OpenWork extensions.",
+        provider,
+        arguments: [argument("extensionId", "string", false, "Optional extension id.")],
+        effects: readEffects,
+      }),
+      affordance({
+        id: "extension.call",
+        kind: "command",
+        title: "Call an extension action",
+        description: "Execute one action exposed by a local OpenWork extension.",
+        provider,
+        arguments: [
+          argument("extensionId", "string", true, "Extension id."),
+          argument("action", "string", true, "Action id returned by extension.actions."),
+          argument("args", "object", false, "Extension action arguments."),
+        ],
+        effects: { data: "write", ui: "none", external: true },
+      }),
+    ],
+    guidance: [],
+  };
+}
+
+function connectContribution(skills: ConnectSkillDescriptor[]): OpenworkFeatureContribution | null {
+  if (skills.length === 0) return null;
+  const provider: OpenworkProviderRef = { id: "openwork-cloud", kind: "connect" };
+  const guidance: OpenworkGuidanceDescriptor[] = skills.map((skill) => ({
+    ref: skill.capability,
+    title: skill.title?.trim() || skill.name,
+    description: skill.description,
+    provider,
+    loading: "catalog",
+  }));
+  return {
+    featureId: "connect",
+    provider,
+    affordances: [
+      affordance({
+        id: "connect.capabilities.search",
+        kind: "query",
+        title: "Search Connect capabilities",
+        description: "Discover a remote capability when no exact capability ref is already known.",
+        provider,
+        arguments: [argument("query", "string", true, "Capability keywords.")],
+        effects: { data: "read", ui: "none", external: true },
+        tool: "openwork-cloud_search_capabilities",
+      }),
+      affordance({
+        id: "connect.capability.execute",
+        kind: "command",
+        title: "Execute a Connect capability",
+        description: "Execute an exact remote capability ref or load a known remote skill.",
+        provider,
+        arguments: [
+          argument("name", "string", true, "Exact capability ref."),
+          argument("arguments", "object", false, "Capability arguments."),
+        ],
+        effects: { data: "write", ui: "none", external: true },
+        tool: "openwork-cloud_execute_capability",
+      }),
+    ],
+    guidance,
+  };
+}
+
+function mcpContribution(mcp: EngineMcpDescriptor): OpenworkFeatureContribution {
+  return {
+    featureId: `mcp:${mcp.name}`,
+    provider: { id: mcp.name, kind: "mcp" },
+    affordances: [],
+    guidance: [],
+  };
+}
+
+export function buildOpenworkProviderContributions(
+  skills: ConnectSkillDescriptor[],
+  mcps: EngineMcpDescriptor[] = [],
+): OpenworkFeatureContribution[] {
+  const connect = connectContribution(skills);
+  return [
+    sessionContribution(),
+    extensionContribution(),
+    ...mcps
+      .filter((mcp) => mcp.name !== "openwork-cloud")
+      .map(mcpContribution),
+    ...(connect ? [connect] : []),
+  ];
+}

--- a/apps/server/src/opencode-plugins/openwork-provider-adapters.ts
+++ b/apps/server/src/opencode-plugins/openwork-provider-adapters.ts
@@ -150,8 +150,11 @@ function extensionContribution(): OpenworkFeatureContribution {
   };
 }
 
-function connectContribution(skills: ConnectSkillDescriptor[]): OpenworkFeatureContribution | null {
-  if (skills.length === 0) return null;
+function connectContribution(
+  skills: ConnectSkillDescriptor[],
+  cloudMcp: EngineMcpDescriptor | undefined,
+): OpenworkFeatureContribution | null {
+  if (skills.length === 0 && !cloudMcp) return null;
   const provider: OpenworkProviderRef = { id: "openwork-cloud", kind: "connect" };
   const guidance: OpenworkGuidanceDescriptor[] = skills.map((skill) => ({
     ref: skill.capability,
@@ -170,7 +173,11 @@ function connectContribution(skills: ConnectSkillDescriptor[]): OpenworkFeatureC
         title: "Search Connect capabilities",
         description: "Discover a remote capability when no exact capability ref is already known.",
         provider,
-        arguments: [argument("query", "string", true, "Capability keywords.")],
+        arguments: [
+          argument("query", "string", true, "Capability keywords."),
+          argument("limit", "number", false, "Maximum capabilities to return."),
+          argument("type", "string", false, "Optional capability type filter."),
+        ],
         effects: { data: "read", ui: "none", external: true },
         tool: "openwork-cloud_search_capabilities",
       }),
@@ -181,8 +188,11 @@ function connectContribution(skills: ConnectSkillDescriptor[]): OpenworkFeatureC
         description: "Execute an exact remote capability ref or load a known remote skill.",
         provider,
         arguments: [
-          argument("name", "string", true, "Exact capability ref."),
-          argument("arguments", "object", false, "Capability arguments."),
+          argument("name", "string", false, "Exact capability ref returned by Connect search or remote skill guidance."),
+          argument("schemaDigest", "string", false, "Schema digest returned by Connect search when required."),
+          argument("path", "object", false, "Path parameters for the capability."),
+          argument("query", "object", false, "Query parameters for the capability."),
+          argument("body", "object", false, "Request body for the capability."),
         ],
         effects: { data: "write", ui: "none", external: true },
         tool: "openwork-cloud_execute_capability",
@@ -205,7 +215,8 @@ export function buildOpenworkProviderContributions(
   skills: ConnectSkillDescriptor[],
   mcps: EngineMcpDescriptor[] = [],
 ): OpenworkFeatureContribution[] {
-  const connect = connectContribution(skills);
+  const cloudMcp = mcps.find((mcp) => mcp.name === "openwork-cloud");
+  const connect = connectContribution(skills, cloudMcp);
   return [
     sessionContribution(),
     extensionContribution(),

--- a/evals/flows/semantic-agent-surface.flow.ts
+++ b/evals/flows/semantic-agent-surface.flow.ts
@@ -1,0 +1,461 @@
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+
+const vo = await loadVoiceoverParagraphs("semantic-agent-surface");
+if (!vo) throw new Error("Missing approved voice-over script for semantic-agent-surface.");
+
+const PREVIOUS_MARKER = "violet-otter-742";
+const SURFACE_SELECTOR = "[data-session-surface-id]";
+
+let previousSessionId: string | null = null;
+let draftSessionId: string | null = null;
+let primarySessionId: string | null = null;
+let primaryRoute: string | null = null;
+
+function required(value: string | null, label: string): string {
+  if (!value) throw new Error(`${label} is missing.`);
+  return value;
+}
+
+function sessionSurfaceExpression(sessionId: string, body: string) {
+  return `(() => {
+    const root = Array.from(document.querySelectorAll(${JSON.stringify(SURFACE_SELECTOR)}))
+      .find((candidate) => candidate.getAttribute("data-session-surface-id") === ${JSON.stringify(sessionId)});
+    if (!root) return null;
+    return (() => { ${body} })();
+  })()`;
+}
+
+async function currentRouteSessionId(ctx: FlowContext): Promise<string | null> {
+  const sessionId = await ctx.eval(`(() => {
+    const route = window.__openworkControl?.snapshot?.().route || "";
+    const match = route.match(/ses_[A-Za-z0-9_-]+/);
+    return match ? match[0] : null;
+  })()`);
+  return typeof sessionId === "string" ? sessionId : null;
+}
+
+async function waitForNewSession(
+  ctx: FlowContext,
+  previousId: string | null,
+  label: string,
+): Promise<string> {
+  const sessionId = await ctx.waitFor(`(() => {
+    const route = window.__openworkControl?.snapshot?.().route || "";
+    const match = route.match(/ses_[A-Za-z0-9_-]+/);
+    if (!match || match[0] === ${JSON.stringify(previousId)}) return null;
+    return match[0];
+  })()`, { timeoutMs: 30_000, label });
+  ctx.assert(typeof sessionId === "string", `${label} did not return a session id.`);
+  return String(sessionId);
+}
+
+async function createNamedSession(ctx: FlowContext, title: string): Promise<string> {
+  const previousId = await currentRouteSessionId(ctx);
+  await ctx.control("session.create_task");
+  const sessionId = await waitForNewSession(ctx, previousId, `${title} route`);
+  await ctx.control("session.rename", { sessionId, title });
+  await ctx.waitFor(
+    `Boolean(document.querySelector('[data-session-tab-id="${sessionId}"]'))`,
+    { timeoutMs: 15_000, label: `${title} tab` },
+  );
+  return sessionId;
+}
+
+async function closeStaleTabs(ctx: FlowContext) {
+  await ctx.eval(`(() => {
+    document.querySelector('button[aria-label="Close split"]')?.click();
+    return true;
+  })()`);
+  for (let attempt = 0; attempt < 12; attempt += 1) {
+    const before = await ctx.eval('document.querySelectorAll("[data-session-tab-id]").length');
+    if (typeof before !== "number" || before <= 1) break;
+    const closed = await ctx.eval(`(() => {
+      const tabs = Array.from(document.querySelectorAll("[data-session-tab-id]"));
+      const inactive = tabs.find((tab) => tab.getAttribute("data-session-tab-active") !== "true");
+      const close = inactive?.querySelector('button[aria-label="Close tab"]');
+      if (!close) return false;
+      close.click();
+      return true;
+    })()`);
+    if (closed !== true) break;
+    await ctx.waitFor(
+      `document.querySelectorAll("[data-session-tab-id]").length < ${before}`,
+      { timeoutMs: 5_000, label: "stale tab to close" },
+    );
+  }
+}
+
+async function setSidebarOpen(ctx: FlowContext, open: boolean) {
+  const already = await ctx.eval(
+    `window.__openworkControl?.context?.().chrome.sidebarOpen === ${JSON.stringify(open)}`,
+  );
+  if (already === true) return;
+  const clicked = await ctx.eval(`(() => {
+    const trigger = document.querySelector('[data-sidebar="trigger"]');
+    if (!trigger) return false;
+    trigger.click();
+    return true;
+  })()`);
+  ctx.assert(clicked === true, "Sidebar trigger was unavailable.");
+  await ctx.waitFor(
+    `window.__openworkControl?.context?.().chrome.sidebarOpen === ${JSON.stringify(open)}`,
+    { timeoutMs: 10_000, label: `sidebar ${open ? "open" : "closed"}` },
+  );
+}
+
+async function sendPrompt(
+  ctx: FlowContext,
+  sessionId: string,
+  prompt: string,
+  expectedAssistantText: string,
+) {
+  await ctx.waitFor(sessionSurfaceExpression(
+    sessionId,
+    `return Boolean(root.querySelector('[contenteditable="true"]'));`,
+  ), { timeoutMs: 30_000, label: `composer for ${sessionId}` });
+
+  const pasted = await ctx.eval(sessionSurfaceExpression(sessionId, `
+    const editor = root.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
+      || root.querySelector('[contenteditable="true"]');
+    if (!editor) return false;
+    editor.focus();
+    const selection = window.getSelection();
+    const range = document.createRange();
+    range.selectNodeContents(editor);
+    selection?.removeAllRanges();
+    selection?.addRange(range);
+    const data = new DataTransfer();
+    data.setData("text/plain", ${JSON.stringify(prompt)});
+    editor.dispatchEvent(new ClipboardEvent("paste", {
+      bubbles: true,
+      cancelable: true,
+      clipboardData: data,
+    }));
+    return true;
+  `));
+  ctx.assert(pasted === true, `Could not type into ${sessionId}.`);
+
+  await ctx.waitFor(sessionSurfaceExpression(sessionId, `
+    const button = Array.from(root.querySelectorAll("button"))
+      .find((candidate) => /^(run task|send|run)$/i.test((candidate.textContent || "").trim()) && !candidate.disabled);
+    return Boolean(button);
+  `), { timeoutMs: 15_000, label: `send button for ${sessionId}` });
+
+  const sent = await ctx.eval(sessionSurfaceExpression(sessionId, `
+    const button = Array.from(root.querySelectorAll("button"))
+      .find((candidate) => /^(run task|send|run)$/i.test((candidate.textContent || "").trim()) && !candidate.disabled);
+    if (!button) return false;
+    button.click();
+    return true;
+  `));
+  ctx.assert(sent === true, `Could not send from ${sessionId}.`);
+
+  await ctx.waitFor(sessionSurfaceExpression(sessionId, `
+    const assistants = Array.from(root.querySelectorAll('[data-message-role="assistant"]'));
+    return assistants.some((message) => message.innerText.includes(${JSON.stringify(expectedAssistantText)}));
+  `), { timeoutMs: 180_000, label: `assistant response containing ${expectedAssistantText}` });
+}
+
+async function semanticContext(ctx: FlowContext) {
+  return ctx.eval("window.__openworkControl?.context?.()");
+}
+
+export default defineFlow({
+  id: "semantic-agent-surface",
+  title: "People and agents share one semantic OpenWork context",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 60_000,
+      label: "OpenWork control API",
+    });
+    const state = await ctx.waitFor(`(() => {
+      const control = window.__openworkControl;
+      const route = control.snapshot().route;
+      if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+      const create = control.listActions().find((action) => action.id === "session.create_task");
+      const rename = control.listActions().find((action) => action.id === "session.rename");
+      return create && rename && !create.disabled && !rename.disabled ? "ready" : null;
+    })()`, { timeoutMs: 30_000, label: "session controls ready" });
+    return state === "blocked"
+      ? "Profile is not onboarded; semantic context proof requires a workspace and model."
+      : null;
+  },
+  steps: [
+    {
+      name: "Three tabs and split view become agent-readable context",
+      run: async (ctx) => {
+        await ctx.prove("Agent context names the complete visible and retained workbench", {
+          voiceover: vo[0],
+          action: async () => {
+            await closeStaleTabs(ctx);
+            const current = await currentRouteSessionId(ctx);
+            previousSessionId = current ?? await createNamedSession(ctx, "Context Previous");
+            await ctx.control("session.rename", {
+              sessionId: previousSessionId,
+              title: "Context Previous",
+            });
+            await sendPrompt(
+              ctx,
+              previousSessionId,
+              `Remember this exact previous-session marker: ${PREVIOUS_MARKER}. Reply with exactly PREVIOUS-SEEDED.`,
+              "PREVIOUS-SEEDED",
+            );
+
+            draftSessionId = await createNamedSession(ctx, "Context Draft");
+            primarySessionId = await createNamedSession(ctx, "Context Primary");
+            primaryRoute = String(await ctx.eval("window.__openworkControl.snapshot().route"));
+            await setSidebarOpen(ctx, true);
+
+            const splitClicked = await ctx.eval(`(() => {
+              const tab = document.querySelector('[data-session-tab-id="${previousSessionId}"]');
+              const button = tab?.querySelector('button[aria-label="Open in split view"]');
+              if (!button) return false;
+              button.click();
+              return true;
+            })()`);
+            ctx.assert(splitClicked === true, "Could not open Context Previous in split view.");
+            await ctx.waitFor(
+              `document.querySelectorAll(${JSON.stringify(SURFACE_SELECTOR)}).length === 2`,
+              { timeoutMs: 30_000, label: "two visible session panes" },
+            );
+
+            await sendPrompt(
+              ctx,
+              primarySessionId,
+              "Call openwork_context. Reply with exactly: CONTEXT-SUMMARY TABS=3 SPLIT=yes FOCUSED=secondary SIDEBAR=open SETTINGS=none",
+              "CONTEXT-SUMMARY",
+            );
+          },
+          assert: async () => {
+            const context = await semanticContext(ctx);
+            ctx.output("frame-1-context", context);
+            const state = await ctx.eval(`(() => {
+              const context = window.__openworkControl.context();
+              return {
+                tabs: context.conversations.tabs.length,
+                layout: context.conversations.layout,
+                sidebarOpen: context.chrome.sidebarOpen,
+                sessionResources: context.resources.filter((resource) => resource.kind === "session").length,
+              };
+            })()`);
+            ctx.assert(
+              JSON.stringify(state).includes('"tabs":3'),
+              `Expected three tabs, received ${JSON.stringify(state)}.`,
+            );
+            ctx.assert(
+              JSON.stringify(state).includes('"kind":"split"'),
+              `Expected split layout, received ${JSON.stringify(state)}.`,
+            );
+            await ctx.expectText("CONTEXT-SUMMARY");
+          },
+          screenshot: {
+            name: "frame-1-complete-workbench-context",
+            requireText: ["Context Previous", "Context Primary", "CONTEXT-SUMMARY"],
+          },
+        });
+      },
+    },
+    {
+      name: "Focusing an existing session reuses its split pane",
+      run: async (ctx) => {
+        ctx.assert(Boolean(primarySessionId && previousSessionId), "Frame 1 session setup is missing.");
+        await ctx.prove("Agent navigation reuses the existing split session", {
+          voiceover: vo[1],
+          action: async () => {
+            const primary = required(primarySessionId, "Primary session");
+            await sendPrompt(
+              ctx,
+              primary,
+              "Call openwork_context, find the session resource titled Context Previous, then call openwork_execute with id workbench.session.focus, that sessionId, expectedRevision, and actor fraimz. Reply with exactly FOCUS-RESULT=secondary-reused.",
+              "FOCUS-RESULT=secondary-reused",
+            );
+          },
+          assert: async () => {
+            await ctx.waitFor(
+              `document.querySelector('[data-workbench-pane="secondary"][data-workbench-pane-focused="true"]') !== null`,
+              { timeoutMs: 30_000, label: "secondary pane focused" },
+            );
+            const state = await ctx.eval(`(() => ({
+              tabs: window.__openworkControl.context().conversations.tabs.length,
+              surfaces: document.querySelectorAll(${JSON.stringify(SURFACE_SELECTOR)}).length,
+              route: window.__openworkControl.snapshot().route,
+            }))()`);
+            ctx.assert(
+              JSON.stringify(state).includes('"tabs":3') && JSON.stringify(state).includes('"surfaces":2'),
+              `Expected reused split without duplicates, received ${JSON.stringify(state)}.`,
+            );
+            await ctx.expectText("FOCUS-RESULT=secondary-reused");
+          },
+          screenshot: {
+            name: "frame-2-reused-split-session",
+            requireText: ["Context Previous", "FOCUS-RESULT=secondary-reused"],
+          },
+        });
+      },
+    },
+    {
+      name: "Reading another transcript does not navigate",
+      run: async (ctx) => {
+        ctx.assert(Boolean(primarySessionId && primaryRoute), "Primary session setup is missing.");
+        await ctx.prove("Agent reads another session without changing the workbench", {
+          voiceover: vo[2],
+          action: async () => {
+            const primary = required(primarySessionId, "Primary session");
+            await sendPrompt(
+              ctx,
+              primary,
+              `Call openwork_context, find Context Previous, then call openwork_query with id session.read for that sessionId. Do not call a UI command. Reply with exactly PREVIOUS-SAID=${PREVIOUS_MARKER}.`,
+              `PREVIOUS-SAID=${PREVIOUS_MARKER}`,
+            );
+          },
+          assert: async () => {
+            const state = await ctx.eval(`(() => ({
+              route: window.__openworkControl.snapshot().route,
+              layout: window.__openworkControl.context().conversations.layout.kind,
+              tabs: window.__openworkControl.context().conversations.tabs.length,
+              surfaces: document.querySelectorAll(${JSON.stringify(SURFACE_SELECTOR)}).length,
+            }))()`);
+            ctx.assert(
+              JSON.stringify(state).includes(JSON.stringify(primaryRoute)),
+              `Transcript query navigated away: ${JSON.stringify(state)}.`,
+            );
+            ctx.assert(
+              JSON.stringify(state).includes('"layout":"split"') && JSON.stringify(state).includes('"tabs":3'),
+              `Transcript query changed the workbench: ${JSON.stringify(state)}.`,
+            );
+            await ctx.expectText(`PREVIOUS-SAID=${PREVIOUS_MARKER}`);
+          },
+          screenshot: {
+            name: "frame-3-read-without-navigation",
+            requireText: [`PREVIOUS-SAID=${PREVIOUS_MARKER}`, "Context Previous"],
+          },
+        });
+      },
+    },
+    {
+      name: "Settings retain off-screen workbench context",
+      run: async (ctx) => {
+        await ctx.prove("Settings context retains tabs and split layout after chat unmounts", {
+          voiceover: vo[3],
+          action: async () => {
+            await setSidebarOpen(ctx, false);
+            const result = await ctx.eval(`(async () => {
+              const control = window.__openworkControl;
+              const context = control.context();
+              return control.command({
+                id: "settings.panel.open",
+                args: { panel: "ai" },
+                expectedRevision: context.revision,
+                actor: "fraimz",
+              });
+            })()`, { awaitPromise: true });
+            ctx.assert(JSON.stringify(result).includes('"ok":true'), `Could not open AI settings: ${JSON.stringify(result)}.`);
+            await ctx.waitFor(
+              `window.__openworkControl.context().screen.kind === "settings"
+                && window.__openworkControl.context().screen.panel === "ai"`,
+              { timeoutMs: 30_000, label: "AI settings semantic screen" },
+            );
+          },
+          assert: async () => {
+            const context = await semanticContext(ctx);
+            ctx.output("frame-4-settings-context", context);
+            const state = await ctx.eval(`(() => {
+              const context = window.__openworkControl.context();
+              return {
+                screen: context.screen,
+                sidebarOpen: context.chrome.sidebarOpen,
+                tabs: context.conversations.tabs.length,
+                layout: context.conversations.layout.kind,
+              };
+            })()`);
+            const serialized = JSON.stringify(state);
+            ctx.assert(serialized.includes('"panel":"ai"'), `Expected AI settings, received ${serialized}.`);
+            ctx.assert(serialized.includes('"sidebarOpen":false'), `Expected collapsed sidebar, received ${serialized}.`);
+            ctx.assert(
+              serialized.includes('"tabs":3') && serialized.includes('"layout":"split"'),
+              `Settings lost retained workbench context: ${serialized}.`,
+            );
+          },
+          screenshot: {
+            name: "frame-4-settings-retain-workbench",
+            requireText: ["AI"],
+          },
+        });
+      },
+    },
+    {
+      name: "Extensions, MCP, Connect, and skills share descriptors",
+      run: async (ctx) => {
+        ctx.assert(Boolean(primaryRoute && primarySessionId), "Primary route is missing.");
+        await ctx.prove("Known skills stay direct while unknown capabilities stay discoverable", {
+          voiceover: vo[4],
+          action: async () => {
+            const route = required(primaryRoute, "Primary route");
+            const primary = required(primarySessionId, "Primary session");
+            await ctx.navigateHash(route);
+            await ctx.waitFor(
+              `Boolean(document.querySelector('[data-session-surface-id="${primary}"]'))`,
+              { timeoutMs: 30_000, label: "primary session after settings" },
+            );
+            await sendPrompt(
+              ctx,
+              primary,
+              "Choose one remote skill already listed in available_skills. Load it directly with its exact capability using openwork-cloud_execute_capability; do not search first and do not perform the skill workflow. Then call openwork_context. Reply with exactly these three lines: DIRECT_SKILL_TOOL=openwork-cloud_execute_capability; UNKNOWN_CAPABILITY_TOOL=openwork-cloud_search_capabilities; LOCAL_EXTENSION_COMMAND=extension.call",
+              "DIRECT_SKILL_TOOL=openwork-cloud_execute_capability",
+            );
+          },
+          assert: async () => {
+            await ctx.expectText("DIRECT_SKILL_TOOL=openwork-cloud_execute_capability");
+            await ctx.expectText("UNKNOWN_CAPABILITY_TOOL=openwork-cloud_search_capabilities");
+            await ctx.expectText("LOCAL_EXTENSION_COMMAND=extension.call");
+          },
+          screenshot: {
+            name: "frame-5-provider-and-skill-routing",
+            requireText: [
+              "DIRECT_SKILL_TOOL=openwork-cloud_execute_capability",
+              "UNKNOWN_CAPABILITY_TOOL=openwork-cloud_search_capabilities",
+              "LOCAL_EXTENSION_COMMAND=extension.call",
+            ],
+          },
+        });
+      },
+    },
+    {
+      name: "Available actions explain effects and concurrency",
+      run: async (ctx) => {
+        ctx.assert(Boolean(primarySessionId), "Primary session is missing.");
+        await ctx.prove("Agent reports actions by effect instead of a flat tool list", {
+          voiceover: vo[5],
+          action: async () => {
+            const primary = required(primarySessionId, "Primary session");
+            await sendPrompt(
+              ctx,
+              primary,
+              "Call openwork_context and inspect availableAffordances plus execution. Reply with exactly five lines using real ids: READ=<id> data=read; UI=<id> ui=<effect>; DURABLE=<id> data=write; CONFIRMATION=<id> confirmation=destructive; CONCURRENCY=queries:parallel commands:serialized",
+              "CONCURRENCY=queries:parallel commands:serialized",
+            );
+          },
+          assert: async () => {
+            await ctx.expectText("data=read");
+            await ctx.expectText("data=write");
+            await ctx.expectText("confirmation=destructive");
+            await ctx.expectText("CONCURRENCY=queries:parallel commands:serialized");
+            const context = await semanticContext(ctx);
+            ctx.output("frame-6-affordances", context);
+          },
+          screenshot: {
+            name: "frame-6-understandable-effects",
+            requireText: [
+              "data=read",
+              "data=write",
+              "confirmation=destructive",
+              "CONCURRENCY=queries:parallel commands:serialized",
+            ],
+          },
+        });
+      },
+    },
+  ],
+});

--- a/evals/voiceovers/semantic-agent-surface.md
+++ b/evals/voiceovers/semantic-agent-surface.md
@@ -1,0 +1,13 @@
+# semantic-agent-surface — OpenWork exposes one understandable surface to people and agents
+
+1. OpenWork shows three conversation tabs with two sessions in split view. I ask, “What am I looking at?” and chat identifies the workspace, open tabs, both visible sessions, focused pane, sidebar, side panel, and settings state.
+
+2. I ask, “Take me to the previous session.” OpenWork resolves the session from backend data and reuses its existing tab or split pane instead of opening a duplicate.
+
+3. I ask, “What did I say in the previous session?” OpenWork reads the transcript without changing the visible session or stealing focus.
+
+4. I open AI settings and collapse the sidebar. Chat still understands the retained workbench and current settings panel, despite those elements not all being visible simultaneously.
+
+5. A known remote skill remains available directly from injected skill guidance, while an unknown remote capability follows search then exact execution. Local extensions follow the same descriptor pattern.
+
+6. I ask what actions are currently available. OpenWork returns understandable actions with their effects—read data, change UI, change durable state, or require user interaction.

--- a/packages/openwork-ui-mcp/index.mjs
+++ b/packages/openwork-ui-mcp/index.mjs
@@ -3,7 +3,8 @@
 /**
  * openwork-ui-mcp
  *
- * MCP server that exposes OpenWork's UI control surface as MCP tools.
+ * MCP server that exposes OpenWork's semantic app context and UI control
+ * surface as an MCP resource and tools.
  * Speaks MCP stdio and proxies to the OpenWork desktop bridge HTTP API.
  *
  * Requires OpenWork desktop running with the local UI control bridge active.
@@ -156,8 +157,39 @@ function formatExecutionResult(actionId, result) {
 
 const server = new McpServer({
   name: "openwork-ui",
-  version: "0.1.0",
+  version: "0.2.0",
 });
+
+// ── openwork://context/current ──
+server.resource(
+  "current_openwork_context",
+  "openwork://context/current",
+  async (uri) => {
+    const result = await bridgeRequest("/context");
+    const context = result.context ?? result;
+    return {
+      contents: [{
+        uri: uri.href,
+        mimeType: "application/json",
+        text: JSON.stringify(context, null, 2),
+      }],
+    };
+  },
+);
+
+// ── ui.context ──
+server.tool(
+  "ui_context",
+  "Read OpenWork's semantic app context: current screen, all open conversation tabs, split-screen layout, focused pane, sidebar, side panel, settings, and currently available queries and commands. Reads app state without focusing the window.",
+  {},
+  async () => {
+    const result = await bridgeRequest("/context");
+    if (!result.ok && result.error) {
+      return { content: [{ type: "text", text: `Error: ${result.error}` }], isError: true };
+    }
+    return { content: [{ type: "text", text: JSON.stringify(result.context ?? result, null, 2) }] };
+  },
+);
 
 // ── ui.snapshot ──
 server.tool(
@@ -222,6 +254,48 @@ server.tool(
     }
     return { content: [{ type: "text", text: formatExecutionResult(actionId, result) }] };
   }
+);
+
+// ── ui.query ──
+server.tool(
+  "ui_query",
+  "Run a side-effect-free OpenWork query by id. Use ui_context to inspect currently available queries. Queries never focus or navigate the app.",
+  {
+    id: z.string().describe("Query id from ui_context, such as 'session.list_sessions' or 'notifications.list'"),
+    args: z.record(z.unknown()).optional().describe("JSON arguments for the query, if required"),
+  },
+  async ({ id, args }) => {
+    const result = await bridgeRequest("/query", {
+      method: "POST",
+      body: { id, args: args ?? {} },
+    });
+    if (!result.ok && result.error) {
+      return { content: [{ type: "text", text: `Error querying ${id}: ${result.error}` }], isError: true };
+    }
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  },
+);
+
+// ── ui.command ──
+server.tool(
+  "ui_command",
+  "Execute a semantic OpenWork command by id. Use ui_context first and pass its revision to prevent acting on stale UI state.",
+  {
+    id: z.string().describe("Command id from ui_context"),
+    args: z.record(z.unknown()).optional().describe("JSON arguments for the command, if required"),
+    expectedRevision: z.number().int().nonnegative().optional().describe("Revision returned by ui_context"),
+    actor: z.string().optional().describe("Optional agent or client id for serialized-command attribution"),
+  },
+  async ({ id, args, expectedRevision, actor }) => {
+    const result = await bridgeRequest("/command", {
+      method: "POST",
+      body: { id, args: args ?? {}, expectedRevision, actor },
+    });
+    if (!result.ok && result.error) {
+      return { content: [{ type: "text", text: `Error executing ${id}: ${result.error}` }], isError: true };
+    }
+    return { content: [{ type: "text", text: JSON.stringify(result, null, 2) }] };
+  },
 );
 
 // ── ui.status ──

--- a/packages/openwork-ui-mcp/index.mjs
+++ b/packages/openwork-ui-mcp/index.mjs
@@ -239,7 +239,7 @@ server.tool(
 // ── ui.execute_action ──
 server.tool(
   "ui_execute_action",
-  "Execute an OpenWork UI action by its id. Use ui_list_actions first to see available actions and their required arguments.",
+  "Execute an OpenWork UI action by its id without activating the desktop window. Use ui_list_actions first to see available actions and their required arguments.",
   {
     actionId: z.string().describe("The action id from ui_list_actions, e.g. 'session.create_task' or 'composer.set_text'"),
     args: z.record(z.unknown()).optional().describe("JSON arguments for the action, if required"),
@@ -279,7 +279,7 @@ server.tool(
 // ── ui.command ──
 server.tool(
   "ui_command",
-  "Execute a semantic OpenWork command by id. Use ui_context first and pass its revision to prevent acting on stale UI state.",
+  "Execute a semantic OpenWork command by id while OpenWork remains in the background. Use ui_context first and pass its revision to prevent acting on stale UI state.",
   {
     id: z.string().describe("Command id from ui_context"),
     args: z.record(z.unknown()).optional().describe("JSON arguments for the command, if required"),

--- a/packages/openwork-ui-mcp/package.json
+++ b/packages/openwork-ui-mcp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openwork-ui-mcp",
   "version": "0.1.0",
-  "description": "MCP server for OpenWork UI control — exposes snapshot, actions, and execute as MCP tools",
+  "description": "MCP server for OpenWork app context and semantic UI control",
   "author": "OpenWork <support@openworklabs.com>",
   "license": "MIT",
   "type": "module",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -14,6 +14,21 @@
       "development": "./src/agent-context-diagnostics.ts",
       "default": "./src/agent-context-diagnostics.ts"
     },
+    "./openwork-affordance": {
+      "types": "./src/openwork-affordance.ts",
+      "development": "./src/openwork-affordance.ts",
+      "default": "./src/openwork-affordance.ts"
+    },
+    "./openwork-context": {
+      "types": "./src/openwork-context.ts",
+      "development": "./src/openwork-context.ts",
+      "default": "./src/openwork-context.ts"
+    },
+    "./openwork-provider": {
+      "types": "./src/openwork-provider.ts",
+      "development": "./src/openwork-provider.ts",
+      "default": "./src/openwork-provider.ts"
+    },
     "./den/desktop-app-restrictions": {
       "types": "./src/den/desktop-app-restrictions.ts",
       "development": "./src/den/desktop-app-restrictions.ts",

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,4 +1,7 @@
 export * from "./agent-context-diagnostics"
+export * from "./openwork-affordance"
+export * from "./openwork-context"
+export * from "./openwork-provider"
 export * from "./den/desktop-policies"
 export * from "./den/egress-diagnostics"
 export * from "./den/inference"

--- a/packages/types/src/openwork-affordance.ts
+++ b/packages/types/src/openwork-affordance.ts
@@ -1,0 +1,89 @@
+import { z } from "zod"
+
+export const OPENWORK_AFFORDANCE_SCHEMA_VERSION = 1
+
+export const openworkAffordanceKindSchema = z.enum(["query", "command", "guidance"])
+export type OpenworkAffordanceKind = z.infer<typeof openworkAffordanceKindSchema>
+
+export const openworkProviderKindSchema = z.enum(["builtin", "extension", "mcp", "connect"])
+export type OpenworkProviderKind = z.infer<typeof openworkProviderKindSchema>
+
+export const openworkProviderRefSchema = z.object({
+  id: z.string().trim().min(1),
+  kind: openworkProviderKindSchema,
+})
+export type OpenworkProviderRef = z.infer<typeof openworkProviderRefSchema>
+
+export const openworkAffordanceArgumentSchema = z.object({
+  name: z.string().trim().min(1),
+  type: z.enum(["string", "number", "boolean", "object", "array", "unknown"]),
+  required: z.boolean(),
+  description: z.string().trim().min(1).optional(),
+})
+export type OpenworkAffordanceArgument = z.infer<typeof openworkAffordanceArgumentSchema>
+
+export const openworkAffordanceEffectsSchema = z.object({
+  data: z.enum(["none", "read", "write"]),
+  ui: z.enum(["none", "focus", "navigate", "layout", "dialog"]),
+  external: z.boolean(),
+})
+export type OpenworkAffordanceEffects = z.infer<typeof openworkAffordanceEffectsSchema>
+
+export const openworkAffordanceAvailabilitySchema = z.object({
+  enabled: z.boolean(),
+  reason: z.string().trim().min(1).optional(),
+})
+export type OpenworkAffordanceAvailability = z.infer<typeof openworkAffordanceAvailabilitySchema>
+
+export const openworkAffordanceExecutorSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("openwork") }),
+  z.object({
+    kind: z.literal("tool"),
+    tool: z.string().trim().min(1),
+  }),
+])
+export type OpenworkAffordanceExecutor = z.infer<typeof openworkAffordanceExecutorSchema>
+
+export const openworkAffordanceDescriptorSchema = z.object({
+  id: z.string().trim().min(1),
+  kind: openworkAffordanceKindSchema,
+  title: z.string().trim().min(1),
+  description: z.string().trim().min(1),
+  provider: openworkProviderRefSchema,
+  arguments: z.array(openworkAffordanceArgumentSchema),
+  effects: openworkAffordanceEffectsSchema,
+  confirmation: z.enum(["never", "destructive", "always"]),
+  availability: openworkAffordanceAvailabilitySchema,
+  executor: openworkAffordanceExecutorSchema,
+})
+export type OpenworkAffordanceDescriptor = z.infer<typeof openworkAffordanceDescriptorSchema>
+
+export const openworkAffordanceRequestSchema = z.object({
+  id: z.string().trim().min(1),
+  args: z.record(z.string(), z.unknown()).optional(),
+  expectedRevision: z.number().int().nonnegative().optional(),
+  actor: z.string().trim().min(1).optional(),
+})
+export type OpenworkAffordanceRequest = z.infer<typeof openworkAffordanceRequestSchema>
+
+const openworkAffordanceSuccessSchema = z.object({
+  ok: z.literal(true),
+  id: z.string(),
+  result: z.unknown().optional(),
+  revision: z.number().int().nonnegative().optional(),
+  effects: openworkAffordanceEffectsSchema,
+})
+
+const openworkAffordanceFailureSchema = z.object({
+  ok: z.literal(false),
+  id: z.string(),
+  error: z.string(),
+  code: z.enum(["unavailable", "invalid-args", "conflict", "failed"]),
+  revision: z.number().int().nonnegative().optional(),
+})
+
+export const openworkAffordanceResultSchema = z.discriminatedUnion("ok", [
+  openworkAffordanceSuccessSchema,
+  openworkAffordanceFailureSchema,
+])
+export type OpenworkAffordanceResult = z.infer<typeof openworkAffordanceResultSchema>

--- a/packages/types/src/openwork-context.ts
+++ b/packages/types/src/openwork-context.ts
@@ -1,0 +1,102 @@
+import { z } from "zod"
+
+import {
+  openworkAffordanceDescriptorSchema,
+  openworkProviderRefSchema,
+} from "./openwork-affordance.js"
+import { openworkFeatureContributionSchema } from "./openwork-provider.js"
+
+export const OPENWORK_CONTEXT_SCHEMA_VERSION = 1
+
+export const openworkSessionRefSchema = z.object({
+  workspaceId: z.string().trim().min(1),
+  sessionId: z.string().trim().min(1),
+  title: z.string().optional(),
+})
+export type OpenworkSessionRef = z.infer<typeof openworkSessionRefSchema>
+
+export const openworkScreenSchema = z.discriminatedUnion("kind", [
+  z.object({
+    kind: z.literal("conversation"),
+    route: z.string(),
+    workspaceId: z.string().optional(),
+    sessionId: z.string().optional(),
+  }),
+  z.object({
+    kind: z.literal("settings"),
+    route: z.string(),
+    workspaceId: z.string().optional(),
+    panel: z.string(),
+  }),
+  z.object({
+    kind: z.literal("other"),
+    route: z.string(),
+  }),
+])
+export type OpenworkScreen = z.infer<typeof openworkScreenSchema>
+
+export const openworkConversationLayoutSchema = z.discriminatedUnion("kind", [
+  z.object({ kind: z.literal("empty") }),
+  z.object({
+    kind: z.literal("single"),
+    sessionId: z.string(),
+  }),
+  z.object({
+    kind: z.literal("split"),
+    primarySessionId: z.string(),
+    secondarySessionId: z.string(),
+    focused: z.enum(["primary", "secondary"]),
+  }),
+])
+export type OpenworkConversationLayout = z.infer<typeof openworkConversationLayoutSchema>
+
+export const openworkPanelTabSchema = z.object({
+  id: z.string(),
+  kind: z.enum(["browser", "artifact"]),
+  label: z.string(),
+  url: z.string().optional(),
+  status: z.enum(["loading", "ready"]).optional(),
+})
+export type OpenworkPanelTab = z.infer<typeof openworkPanelTabSchema>
+
+export const openworkResourceDescriptorSchema = z.object({
+  ref: z.string().trim().min(1),
+  kind: z.enum(["workspace", "session", "screen", "side-panel", "settings"]),
+  title: z.string(),
+  provider: openworkProviderRefSchema,
+  state: z.record(z.string(), z.unknown()),
+})
+export type OpenworkResourceDescriptor = z.infer<typeof openworkResourceDescriptorSchema>
+
+export const openworkContextSnapshotSchema = z.object({
+  schemaVersion: z.literal(OPENWORK_CONTEXT_SCHEMA_VERSION),
+  revision: z.number().int().nonnegative(),
+  capturedAt: z.string(),
+  screen: openworkScreenSchema,
+  conversations: z.object({
+    tabs: z.array(openworkSessionRefSchema),
+    layout: openworkConversationLayoutSchema,
+  }),
+  chrome: z.object({
+    sidebarOpen: z.boolean(),
+    applicationMenuVisible: z.boolean(),
+    rightSidebarExpanded: z.boolean(),
+  }),
+  execution: z.object({
+    queries: z.literal("parallel"),
+    commands: z.literal("serialized"),
+    busyCommandId: z.string().nullable(),
+    busyActor: z.string().nullable(),
+  }),
+  sidePanel: z.object({
+    open: z.boolean(),
+    ownerSessionId: z.string().nullable(),
+    kind: z.enum(["panel", "extensions", "voice"]).nullable(),
+    tabs: z.array(openworkPanelTabSchema),
+    activeTabId: z.string().nullable(),
+  }),
+  resources: z.array(openworkResourceDescriptorSchema),
+  availableAffordances: z.array(openworkAffordanceDescriptorSchema),
+  contributions: z.array(openworkFeatureContributionSchema),
+})
+export type OpenworkContextSnapshot = z.infer<typeof openworkContextSnapshotSchema>

--- a/packages/types/src/openwork-provider.ts
+++ b/packages/types/src/openwork-provider.ts
@@ -1,0 +1,52 @@
+import { z } from "zod"
+
+import {
+  openworkAffordanceDescriptorSchema,
+  openworkProviderRefSchema,
+} from "./openwork-affordance.js"
+
+export const openworkGuidanceDescriptorSchema = z.object({
+  ref: z.string().trim().min(1),
+  title: z.string().trim().min(1),
+  description: z.string().trim().min(1),
+  provider: openworkProviderRefSchema,
+  loading: z.enum(["eager", "catalog", "on-demand"]),
+})
+export type OpenworkGuidanceDescriptor = z.infer<typeof openworkGuidanceDescriptorSchema>
+
+export const openworkFeatureContributionSchema = z.object({
+  featureId: z.string().trim().min(1),
+  provider: openworkProviderRefSchema,
+  affordances: z.array(openworkAffordanceDescriptorSchema),
+  guidance: z.array(openworkGuidanceDescriptorSchema),
+})
+export type OpenworkFeatureContribution = z.infer<typeof openworkFeatureContributionSchema>
+
+export const openworkProviderCatalogSchema = z.object({
+  schemaVersion: z.literal(1),
+  contributions: z.array(openworkFeatureContributionSchema),
+})
+export type OpenworkProviderCatalog = z.infer<typeof openworkProviderCatalogSchema>
+
+export const openworkCapabilityResultSchema = z.discriminatedUnion("status", [
+  z.object({
+    status: z.literal("completed"),
+    data: z.unknown(),
+    additionalContext: z.array(z.string()).optional(),
+  }),
+  z.object({
+    status: z.literal("guidance"),
+    instructions: z.array(z.string()),
+  }),
+  z.object({
+    status: z.literal("requires-user-action"),
+    message: z.string(),
+    action: z.string().optional(),
+  }),
+  z.object({
+    status: z.literal("failed"),
+    error: z.string(),
+    retryable: z.boolean(),
+  }),
+])
+export type OpenworkCapabilityResult = z.infer<typeof openworkCapabilityResultSchema>

--- a/packages/types/tsup.config.ts
+++ b/packages/types/tsup.config.ts
@@ -4,6 +4,9 @@ export default defineConfig({
   entry: {
     index: "src/index.ts",
     "agent-context-diagnostics": "src/agent-context-diagnostics.ts",
+    "openwork-affordance": "src/openwork-affordance.ts",
+    "openwork-context": "src/openwork-context.ts",
+    "openwork-provider": "src/openwork-provider.ts",
     "den/desktop-app-restrictions": "src/den/desktop-app-restrictions.ts",
     "den/desktop-policies": "src/den/desktop-policies.ts",
     "den/egress-diagnostics": "src/den/egress-diagnostics.ts",


### PR DESCRIPTION
## Summary
- introduce shared affordance, provider, and context contracts with canonical workbench state for tabs, split panes, settings, side panels, resources, effects, and revision-safe commands
- expose the same semantic resource/query/command model through the renderer control API, Electron bridge, OpenWork UI MCP, and OpenCode tools
- normalize local extensions, engine MCPs, Connect capabilities, and injected remote skills into provider contributions while preserving direct known-skill execution

## Test plan
- [x] `pnpm --filter @openwork/app typecheck`
- [x] `pnpm --filter @openwork/app test` — 402 passed
- [x] `pnpm --filter @openwork/app build`
- [x] `pnpm --filter openwork-server build`
- [x] focused OpenCode semantic/plugin suite — 22 passed
- [x] `pnpm --filter @openwork/desktop typecheck:electron`
- [x] `pnpm evals:typecheck`
- [x] `pnpm fraimz --flow semantic-agent-surface --cdp-url http://127.0.0.1:9825` — 6/6 narrated frames passed; screenshot proof follows in a PR comment


Made with [Cursor](https://cursor.com)