### PR TITLE
fix(skills): retire legacy OpenWork skills

### DIFF
--- a/apps/app/src/react-app/domains/settings/extension-items.ts
+++ b/apps/app/src/react-app/domains/settings/extension-items.ts
@@ -4,7 +4,7 @@ import type { PendingCloudPluginChange } from "../../../app/cloud/desktop-cloud-
 import { evaluateEnablement, type EnablementContext } from "../../../app/enablement";
 import type { EnablementResult } from "../../../app/extensions";
 import type { DenExternalMcpConnection, DenOrgMarketplaceResolved, DenOrgPlugin } from "../../../app/lib/den";
-import type { McpServerEntry } from "../../../app/types";
+import type { McpServerEntry, SkillCard } from "../../../app/types";
 import { connectionNeedsReconnect } from "../connections/native-provider-connections";
 
 export type ExtensionItemSource = "builtin" | "marketplace" | "org-connection" | "mcp-directory" | "skill";
@@ -53,6 +53,17 @@ export type ExtensionItemBuildInput = {
 };
 
 const MCP_IMPORT_PATH_PREFIX = "opencode.jsonc#mcp.";
+const OPENWORK_PROVIDED_SKILL_NAMES = new Set([
+  "workspace-guide",
+  "skill-creator",
+]);
+
+export function isOpenworkProvidedSkill(skill: Pick<SkillCard, "name" | "path">) {
+  const normalizedName = skill.name.trim().toLowerCase();
+  const normalizedPath = skill.path.replace(/\\/g, "/").toLowerCase();
+  return normalizedPath.includes("/.opencode/skills/") &&
+    OPENWORK_PROVIDED_SKILL_NAMES.has(normalizedName);
+}
 
 export function isToggleControlledExtension(entry: McpDirectoryInfo) {
   return entry.extensionManifest?.enablement?.some((condition) => condition.type === "toggle-enabled") === true;

--- a/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/skills-view.tsx
@@ -34,6 +34,7 @@ import {
 } from "@/react-app/domains/workspace/modal-styles";
 import { Button } from "@/components/ui/button";
 import { ConfirmModal } from "@/react-app/design-system/modals/confirm-modal";
+import { isOpenworkProvidedSkill } from "../extension-items";
 
 type InstallResult = { ok: boolean; message: string };
 type SkillsFilter = "all" | "installed";
@@ -42,15 +43,6 @@ const pageTitleClass = "text-[28px] font-semibold tracking-[-0.5px] text-dls-tex
 const sectionTitleClass = "text-[15px] font-medium tracking-[-0.2px] text-dls-text";
 const panelCardClass =
   "rounded-[20px] border border-dls-border bg-dls-surface p-5 transition-all hover:border-dls-border hover:shadow-[0_2px_12px_-4px_rgba(0,0,0,0.06)]";
-
-const OPENWORK_DEFAULT_SKILL_NAMES = new Set([
-  "workspace-guide",
-  "get-started",
-  "skill-creator",
-  "command-creator",
-  "agent-creator",
-  "plugin-creator",
-]);
 
 export type SkillsExtensionsStore = {
   skills: () => SkillCard[];
@@ -264,13 +256,6 @@ export function SkillsView(props: SkillsViewProps) {
     }
   }, [extensions, maskError, selectedContent, selectedDirty, selectedSkill]);
 
-  const isOpenworkInjectedSkill = (skill: SkillCard) => {
-    const normalizedName = skill.name.trim().toLowerCase();
-    const normalizedPath = skill.path.replace(/\\/g, "/").toLowerCase();
-    return normalizedPath.includes("/.opencode/skills/") &&
-      (OPENWORK_DEFAULT_SKILL_NAMES.has(normalizedName) || normalizedName.endsWith("-creator"));
-  };
-
   const handleSkillCardKeyDown = (
     event: ReactKeyboardEvent<HTMLDivElement>,
     skill: SkillCard,
@@ -400,7 +385,7 @@ export function SkillsView(props: SkillsViewProps) {
                       <div className="min-w-0 flex-1">
                         <div className="flex flex-wrap items-center gap-2">
                           <h4 className="truncate text-[14px] font-semibold text-dls-text">{skill.name}</h4>
-                          {isOpenworkInjectedSkill(skill) ? <span className={tagClass}>OpenWork</span> : null}
+                          {isOpenworkProvidedSkill(skill) ? <span className={tagClass}>OpenWork</span> : null}
                         </div>
                         <p className="mt-2 line-clamp-2 text-[13px] leading-relaxed text-dls-secondary">
                           {skill.description || t("skills.no_description")}

--- a/apps/app/tests/extension-items.test.ts
+++ b/apps/app/tests/extension-items.test.ts
@@ -3,7 +3,10 @@ import { describe, expect, test } from "bun:test";
 import type { McpDirectoryInfo } from "../src/app/constants";
 import type { DenExternalMcpConnection } from "../src/app/lib/den";
 import type { McpServerEntry } from "../src/app/types";
-import { buildExtensionItems } from "../src/react-app/domains/settings/extension-items";
+import {
+  buildExtensionItems,
+  isOpenworkProvidedSkill,
+} from "../src/react-app/domains/settings/extension-items";
 
 const connectedBuiltIn: McpDirectoryInfo = {
   id: "openwork-browser",
@@ -73,6 +76,30 @@ function orgMcpConnection(input: Partial<DenExternalMcpConnection> = {}): DenExt
 }
 
 describe("extension item projection", () => {
+  test("attributes only current OpenWork-provided local skills", () => {
+    expect(isOpenworkProvidedSkill({
+      name: "skill-creator",
+      path: "/workspace/.opencode/skills/skill-creator/SKILL.md",
+    })).toBe(true);
+    expect(isOpenworkProvidedSkill({
+      name: "workspace-guide",
+      path: String.raw`C:\workspace\.opencode\skills\workspace-guide\SKILL.md`,
+    })).toBe(true);
+
+    for (const name of [
+      "get-started",
+      "command-creator",
+      "agent-creator",
+      "plugin-creator",
+      "customer-creator",
+    ]) {
+      expect(isOpenworkProvidedSkill({
+        name,
+        path: `/workspace/.opencode/skills/${name}/SKILL.md`,
+      })).toBe(false);
+    }
+  });
+
   test("keeps unconnected built-ins out of My Extensions quick connect", () => {
     const result = buildExtensionItems({
       quickConnect: [connectedBuiltIn, availableBuiltIn],

--- a/apps/server/src/openwork-runtime-config.test.ts
+++ b/apps/server/src/openwork-runtime-config.test.ts
@@ -75,6 +75,10 @@ describe("openwork runtime config file", () => {
         permission: {
           skill: {
             "customize-opencode": "deny",
+            "get-started": "deny",
+            "command-creator": "deny",
+            "agent-creator": "deny",
+            "plugin-creator": "deny",
           },
         },
       },

--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -107,8 +107,13 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
         prompt: OPENWORK_AGENT_PROMPT,
         permission: {
           skill: {
-            // OpenWork supplies its own Cloud/local skill-creator routing.
+            // OpenWork supplies its own current skill routing and no longer
+            // supports these engine or legacy workspace skills.
             "customize-opencode": "deny",
+            "get-started": "deny",
+            "command-creator": "deny",
+            "agent-creator": "deny",
+            "plugin-creator": "deny",
           },
         },
       },


### PR DESCRIPTION
## Summary

- deny `get-started`, `command-creator`, `agent-creator`, and `plugin-creator` for the managed `openwork` agent
- keep legacy files intact and visible for users to inspect or remove, while preventing the OpenWork agent from loading them
- restrict the Settings `OpenWork` badge to the two current OpenWork-provided local skills: `skill-creator` and `workspace-guide`
- stop labeling every arbitrary `*-creator` skill as OpenWork-owned

## Root cause

These names came from historical OpenWork skill state, not OpenCode's native embedded registry. Their bodies were removed, but old workspace copies could still be discovered by OpenCode and the Settings UI continued to classify the four names—and every other `*-creator` name—as OpenWork-injected.

## Checks

- `./bin/openwork-hub run integrations remove-legacy-openwork-skills -- pnpm --filter openwork-server test -- src/openwork-runtime-config.test.ts` — 6 passed
- `./bin/openwork-hub run integrations remove-legacy-openwork-skills -- pnpm --filter @openwork/app exec bun test tests/extension-items.test.ts` — 7 passed
- `./bin/openwork-hub run integrations remove-legacy-openwork-skills -- pnpm --filter @openwork/app test -- extension-items.test.ts` — 396 passed across the app suite
- `./bin/openwork-hub run integrations remove-legacy-openwork-skills -- pnpm --filter openwork-server typecheck` — passed
- `git diff --check` — passed

`./bin/openwork-hub run integrations remove-legacy-openwork-skills -- pnpm --filter @openwork/app typecheck` remains blocked by the unchanged upstream `cloud-provider-config.test.ts:128` test shim (`TS2339: Property 'toEqual' does not exist`). The failing file has no branch diff.

## Manual verification

Not run — developer verification deferred. Reviewers can reload the OpenWork engine with a workspace containing one of the four legacy skills and confirm it is not advertised or loadable by the managed agent. In Settings → Skills, legacy and user-created `*-creator` skills should remain visible without an `OpenWork` badge, while `skill-creator` and `workspace-guide` retain the badge.

## Risk and scope

No skill files are deleted or rewritten. Standalone OpenCode and non-OpenWork agents are unchanged. The change affects only the managed OpenWork agent's skill permission policy and Settings provenance labeling; it does not touch OAuth, credentials, tenant state, or Cloud marketplace delivery.
