### PR TITLE
fix(agent): publish semantic UI MCP cleanly

### DIFF
--- a/apps/server/src/extensions-export.test.ts
+++ b/apps/server/src/extensions-export.test.ts
@@ -207,48 +207,11 @@ describe("POST /workspace/:id/extensions/export", () => {
   });
 });
 
-describe("openwork_extensions_export plugin tool", () => {
-  test("exports end to end through the bundled plugin tool", async () => {
-    await withWorkspace(async ({ root, config }) => {
-      await writeSkill(root);
-      await addMcp(config, WORKSPACE_ID, "linear", {
-        type: "remote",
-        url: "https://mcp.linear.app/sse",
-        headers: { Authorization: "Bearer secret" },
-        enabled: true,
-      });
+describe("bundled agent tool surface", () => {
+  test("keeps portable export out of every chat", async () => {
+    const { OpenWorkExtensionsPreview } = await import("./opencode-plugins/openwork-extensions-preview.js");
+    const plugin = await OpenWorkExtensionsPreview();
 
-      const server = await startServer(config) as Served;
-      const previousUrl = process.env.OPENWORK_SERVER_URL;
-      const previousToken = process.env.OPENWORK_SERVER_TOKEN;
-      process.env.OPENWORK_SERVER_URL = `http://127.0.0.1:${server.port}`;
-      process.env.OPENWORK_SERVER_TOKEN = config.token;
-      try {
-        const { OpenWorkExtensionsPreview } = await import("./opencode-plugins/openwork-extensions-preview.js");
-        const plugin = await OpenWorkExtensionsPreview();
-        const output = await plugin.tool.openwork_extensions_export.execute(
-          { skills: ["release-notes"], mcps: ["linear", "not-installed"] },
-          { directory: root },
-        );
-        expect(output).not.toContain("Bearer secret");
-        const parsed = JSON.parse(output) as {
-          ok: boolean;
-          workspaceId: string;
-          components: Array<ExportedSkill | ExportedMcp>;
-          missing: { skills: string[]; mcps: string[] };
-        };
-        expect(parsed.ok).toBe(true);
-        expect(parsed.workspaceId).toBe(WORKSPACE_ID);
-        expect(findSkill(parsed.components, "release-notes")?.content).toBe(SKILL_CONTENT);
-        expect(findMcp(parsed.components, "linear")?.config.headers).toEqual({ Authorization: "<redacted>" });
-        expect(parsed.missing).toEqual({ skills: [], mcps: ["not-installed"] });
-      } finally {
-        if (previousUrl === undefined) delete process.env.OPENWORK_SERVER_URL;
-        else process.env.OPENWORK_SERVER_URL = previousUrl;
-        if (previousToken === undefined) delete process.env.OPENWORK_SERVER_TOKEN;
-        else process.env.OPENWORK_SERVER_TOKEN = previousToken;
-        await server.stop(true);
-      }
-    });
+    expect(Object.keys(plugin.tool)).not.toContain("openwork_extensions_export");
   });
 });

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts
@@ -40,6 +40,7 @@ describe("OpenWork capabilities knowledge plugin", () => {
     expect(knowledge).not.toContain("Access tokens are opaque");
     expect(knowledge).not.toContain("https://api.openworklabs.com/mcp`");
     expect(knowledge).not.toContain("openwork-ui-mcp");
+    expect(knowledge).not.toContain("openwork_extensions_export");
   });
 
   test("retrieves Slack connection guidance from bundled docs", async () => {

--- a/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
+++ b/apps/server/src/opencode-plugins/openwork-capabilities-knowledge.ts
@@ -94,12 +94,6 @@ Here is what you can help users with:
 - Manageable via Settings > Skills.
 - When a user asks to create or update a skill, use the built-in \`skill-creator\` skill. Follow the separate runtime \`Skill creation:\` instruction to choose its Remote Cloud or local flow; do not default to creating a workspace file.
 
-## Packaging & Publishing Skills and MCPs
-- Some skills and MCP servers are managed by OpenWork at runtime (stored server-side and injected into the engine config), so they are not visible as plain workspace files. Do not try to read the OPENCODE_CONFIG file or runtime database directly.
-- To get portable definitions of installed skills and MCP servers — including runtime-managed ones — use the openwork_extensions_export tool. It returns full SKILL.md content and MCP configs with secret header/environment values redacted (listed in redactedKeys).
-- When packaging exported components into a plugin or publishing to a marketplace, never inline secret values; declare the redacted keys as required inputs the installer must provide.
-- To publish to an OpenWork Cloud marketplace, follow the marketplace docs and only use Cloud execution tools when runtime steering verifies they are ready for this workspace/model.
-
 ## Creating Plugins
 - Plugins extend OpenWork/OpenCode with custom tools.
 - Create a file in \`.opencode/plugins/my-plugin.ts\` and add it to the \`plugin\` array in \`opencode.json\`.

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.test.ts
@@ -464,6 +464,7 @@ describe("OpenWorkExtensionsPreview UI control tools", () => {
     expect(tools).toContain("openwork_session_create");
     expect(tools).toContain("openwork_session_search");
     expect(tools).toContain("openwork_extension_list_actions");
+    expect(tools).not.toContain("openwork_extensions_export");
 
     const system = await transformedSystem(plugin);
     expect(system).not.toContain("openwork_ui_");

--- a/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
+++ b/apps/server/src/opencode-plugins/openwork-extensions-preview.ts
@@ -93,12 +93,6 @@ const sessionCreateArgsSchema = z.object({
   workspaceId: z.string().trim().optional().describe("Optional OpenWork workspace id/name. Defaults to the workspace containing the current session."),
 });
 
-const extensionsExportArgsSchema = z.object({
-  skills: z.array(z.string().trim().min(1)).optional().describe("Names of installed skills to export, as shown in Settings > Skills or .opencode/skills/**."),
-  mcps: z.array(z.string().trim().min(1)).optional().describe("Names of installed MCP servers to export, including OpenWork-managed runtime MCPs."),
-  workspaceId: z.string().trim().optional().describe("Optional OpenWork workspace id/name. Defaults to the workspace containing the current directory."),
-});
-
 const workspaceSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
@@ -843,22 +837,6 @@ async function resolveContextWorkspace(workspaceId: string | undefined, context:
   throw new Error(`Multiple OpenWork workspaces match; pass workspaceId. Available: ${workspaces.map((workspace) => workspaceLabel(workspace)).join(", ")}`);
 }
 
-async function exportOpenWorkExtensions(rawArgs: unknown, context: OpenCodeContext): Promise<object> {
-  const args = extensionsExportArgsSchema.parse(rawArgs);
-  const skills = args.skills ?? [];
-  const mcps = args.mcps ?? [];
-  if (skills.length === 0 && mcps.length === 0) {
-    return { ok: false, error: "Provide at least one skill or mcp name to export." };
-  }
-  const workspace = await resolveContextWorkspace(args.workspaceId, context);
-  const payload = await postJson(`/workspace/${encodeURIComponent(workspace.id)}/extensions/export`, { skills, mcps });
-  const base = { ok: true, workspaceId: workspace.id, workspace: workspaceLabel(workspace) };
-  if (typeof payload === "object" && payload !== null && !Array.isArray(payload)) {
-    return Object.assign(base, payload);
-  }
-  return Object.assign(base, { result: payload });
-}
-
 async function createOpenWorkSessions(rawArgs: unknown, context: OpenCodeContext): Promise<object> {
   const args = sessionCreateArgsSchema.parse(rawArgs);
   const workspace = await resolveContextWorkspace(args.workspaceId, context);
@@ -1066,18 +1044,6 @@ export const OpenWorkExtensionsPreview = async (factoryInput?: unknown) => {
       async execute(rawArgs: unknown) {
         const result = await readOpenWorkSession(rawArgs);
         return JSON.stringify(result, null, 2);
-      },
-    },
-    openwork_extensions_export: {
-      description: "Export portable definitions of installed skills and MCP servers from OpenWork, including OpenWork-managed runtime MCPs that are not visible as workspace files. Returns full SKILL.md content and MCP configs with secret header/environment values redacted (listed in redactedKeys). Use this when packaging skills/MCPs into a plugin or publishing them to a marketplace; declare redacted keys as required inputs instead of inlining values.",
-      args: extensionsExportArgsSchema.shape,
-      async execute(rawArgs: unknown, context: OpenCodeContext) {
-        try {
-          const result = await exportOpenWorkExtensions(rawArgs, context);
-          return JSON.stringify(result, null, 2);
-        } catch (error) {
-          return JSON.stringify({ ok: false, error: unknownErrorMessage(error) }, null, 2);
-        }
       },
     },
     openwork_browser_open_url: {

--- a/evals/flows/extensions-export-portable.flow.mjs
+++ b/evals/flows/extensions-export-portable.flow.mjs
@@ -1,27 +1,20 @@
 /**
- * Portable extensions export: a user's installed skill and an
- * OpenWork-managed runtime MCP (which lives in the runtime DB, not in
- * workspace files) can be exported as one portable bundle — with secret
- * header values redacted — so the agent can package them into a
- * marketplace plugin.
+ * Portable extensions export: an installed skill and an OpenWork-managed
+ * runtime MCP can be exported through the authenticated server API as one
+ * portable bundle with secret header values redacted.
  *
  * The end user is the protagonist:
  *   1. User installs a skill; it is visible in Settings > Skills.
  *   2. User connects an MCP server that carries a secret Authorization
  *      header (the same programmatic path the app's connect flows use);
  *      it is visible in Settings > Extensions as a runtime-managed entry.
- *   3. The new export surface (POST /workspace/:id/extensions/export —
- *      exactly what the bundled openwork_extensions_export agent tool
- *      calls) returns both components; the SKILL.md content round-trips,
- *      the secret never appears, and headers.Authorization is <redacted>.
- *   4. (Agent frame, requires a usable model) The user asks the agent to
- *      export both by name with the openwork_extensions_export tool; the
- *      agent replies with the redacted header value in the transcript.
+ *   3. POST /workspace/:id/extensions/export returns both components; the
+ *      SKILL.md content round-trips, the secret never appears, and
+ *      headers.Authorization is <redacted>.
  *
  * REST calls use the app's own port/token from localStorage (pattern from
  * cloud-config-sync-latency.flow.mjs) and are only how we witness side
- * effects; the export endpoint itself is the experience under test since
- * it is the agent-facing surface.
+ * effects; the export endpoint itself is the experience under test.
  */
 
 const SKILL_NAME = "release-notes-eval";
@@ -31,17 +24,6 @@ const SKILL_CONTENT = `---\nname: ${SKILL_NAME}\ndescription: ${SKILL_DESCRIPTIO
 const MCP_NAME = "eval-export-mcp";
 const MCP_URL = "https://mcp.example.com/eval-export";
 const SECRET = "Bearer eval-export-secret-12345";
-
-// The reply must contain values the model can only learn from the tool
-// result (the exported MCP url and the redactedKeys entries) — neither is
-// present in this prompt, so a match proves the tool actually ran.
-const AGENT_MESSAGE = [
-  `Call the openwork_extensions_export tool with skills ["${SKILL_NAME}"] and mcps ["${MCP_NAME}"].`,
-  'From the tool result, take the exported MCP config "url" and the "redactedKeys" list.',
-  "Reply with exactly one line: EXPORT-RESULT <url> <redactedKeys entries joined with commas>.",
-  "Write the values verbatim without quotes or angle brackets. Do not run any other tools.",
-].join(" ");
-const AGENT_REPLY_RE = "EXPORT-RESULT\\s+https:\\/\\/mcp\\.example\\.com\\/eval-export\\s+headers\\.Authorization";
 
 // In-page OpenWork server access using the app's own connection details.
 const serverCallExpr = (pathTemplate, init) => `(async () => {
@@ -74,21 +56,6 @@ async function serverCall(ctx, pathTemplate, init, { tolerate = false } = {}) {
     ctx.assert(result?.ok, `Server call ${pathTemplate} failed: ${result?.status ?? "?"} ${JSON.stringify(result?.payload ?? {}).slice(0, 300)}`);
   }
   return result;
-}
-
-async function pasteComposer(ctx, text) {
-  return ctx.eval(
-    `(() => {
-      const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]')
-        || document.querySelector('[contenteditable="true"]');
-      if (!editor) return { ok: false, reason: 'composer not found' };
-      editor.focus();
-      const data = new DataTransfer();
-      data.setData('text/plain', ${JSON.stringify(text)});
-      editor.dispatchEvent(new ClipboardEvent('paste', { bubbles: true, cancelable: true, clipboardData: data }));
-      return { ok: true };
-    })()`,
-  );
 }
 
 export default {
@@ -223,59 +190,6 @@ export default {
               "Export reported missing components.",
             );
             ctx.log(`export ok: ${payload.components.length} components, redactedKeys=${JSON.stringify(mcp.redactedKeys)}`);
-          },
-        });
-      },
-    },
-    {
-      name: "Agent exports both via the openwork_extensions_export tool",
-      run: async (ctx) => {
-        await ctx.prove("Agent calls openwork_extensions_export and reports the redacted header", {
-          action: async () => {
-            // Leave settings; session actions register on the session surface.
-            await ctx.navigateHash("/");
-            await ctx.waitFor(
-              "window.__openworkControl.listActions().some((a) => a.id === 'session.create_task' && !a.disabled)",
-              { timeoutMs: 45_000, label: "session.create_task available" },
-            );
-            await ctx.control("session.create_task");
-            await ctx.waitFor(
-              `(() => {
-                const route = window.__openworkControl.snapshot().route || "";
-                return /ses_[A-Za-z0-9]+/.test(route);
-              })()`,
-              { timeoutMs: 30_000, label: "active session id in route" },
-            );
-            const pasted = await pasteComposer(ctx, AGENT_MESSAGE);
-            ctx.assert(pasted?.ok, `Composer not ready: ${pasted?.reason ?? "unknown"}`);
-            const ran = await ctx.eval(`(() => {
-              const byLabel = Array.from(document.querySelectorAll('button'))
-                .find((b) => /run task|send|run/i.test((b.textContent || "").trim()) && !b.disabled);
-              if (byLabel) { byLabel.click(); return "clicked"; }
-              const editor = document.querySelector('[contenteditable="true"]');
-              if (editor) {
-                editor.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }));
-                return "enter";
-              }
-              return "none";
-            })()`);
-            ctx.assert(ran !== "none", "Could not submit the composer message.");
-          },
-          assert: async () => {
-            // The url + redacted key are only in the tool result, not the
-            // prompt — the model cannot produce this line without actually
-            // calling openwork_extensions_export.
-            await ctx.waitFor(
-              `Boolean(document.body.innerText.match(new RegExp(${JSON.stringify(AGENT_REPLY_RE)})))`,
-              { timeoutMs: 180_000, label: "agent EXPORT-RESULT reply" },
-            );
-            await ctx.expectNoText(SECRET);
-            await ctx.expectNoText("Something went wrong");
-          },
-          screenshot: {
-            name: "agent-export-proof",
-            requireText: ["EXPORT-RESULT", MCP_URL],
-            rejectText: [SECRET],
           },
         });
       },

--- a/packages/openwork-ui-mcp/package.json
+++ b/packages/openwork-ui-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-ui-mcp",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP server for OpenWork app context and semantic UI control",
   "author": "OpenWork <support@openworklabs.com>",
   "license": "MIT",


### PR DESCRIPTION
## Summary
- bump `openwork-ui-mcp` to `0.2.0`, matching the semantic MCP server version and allowing the npm dry-run publish check to validate an unpublished version
- remove the niche `openwork_extensions_export` tool and its static prompt steering from every agent chat
- retain portable extension export behind the authenticated server API

## Test plan
- [x] `node --check packages/openwork-ui-mcp/index.mjs`
- [x] `npm publish --dry-run --access public` from `packages/openwork-ui-mcp` (`openwork-ui-mcp@0.2.0`)
- [x] `pnpm --filter openwork-server typecheck`
- [x] `pnpm --filter openwork-server exec bun test src/opencode-plugins/openwork-capabilities-knowledge.test.ts src/opencode-plugins/openwork-extensions-preview.test.ts` (17 passed)
- [x] `node --check evals/flows/extensions-export-portable.flow.mjs`

Fraimz was not run because this follow-up changes package metadata and a hidden agent tool/prompt surface, not rendered UI behavior.

Made with [Cursor](https://cursor.com)