### PR TITLE
fix(app): show API key save feedback

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -22,6 +22,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
+import { toast } from "@/components/ui/sonner";
 import { openDesktopUrl } from "@/app/lib/desktop";
 import { isDesktopRuntime } from "@/app/utils";
 import { compareProviders } from "@/app/utils/providers";
@@ -558,6 +559,9 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
     setLocalError(null);
     try {
       await props.onSubmitApiKey(selectedEntry.id, trimmed);
+      toast.success(`${selectedEntry.name} connected`, {
+        description: "API key saved locally by OpenCode.",
+      });
       // Close the modal after a successful save
       props.onClose();
     } catch (error) {
@@ -901,7 +905,14 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
                       onClick={handleApiSubmit}
                       disabled={actionDisabled || !apiKeyInput.trim()}
                     >
-                      {props.submitting ? "Saving…" : "Save key"}
+                      {props.submitting ? (
+                        <>
+                          <Loader2 className="size-4 animate-spin" />
+                          Saving…
+                        </>
+                      ) : (
+                        "Save key"
+                      )}
                     </Button>
                   </div>
                 </div>

--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -1362,6 +1362,7 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
     }
     assertProviderAllowedByDesktopPolicy(providerId);
 
+    setStateField("providerAuthBusy", true);
     try {
       if (providerId.trim().toLowerCase() === DESKTOP_RESTRICTION_OPENCODE_PROVIDER_ID) {
         await ensureProjectProviderDisabledState(providerId, false);
@@ -1373,6 +1374,8 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
       const message = describeProviderError(error, t("providers.save_api_key_failed"));
       setStateField("providerAuthError", message);
       throw error instanceof Error ? error : new Error(message);
+    } finally {
+      setStateField("providerAuthBusy", false);
     }
   }
 


### PR DESCRIPTION
## Summary
- Set provider auth busy state while saving an API key so the save button and footer show progress.
- Add a spinner to the Save key button during submission.
- Show a success toast after the API key is saved before closing the provider auth modal.

## Verification
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app build (passes; existing Vite bundle-size/use memo warnings)

## Evidence
- No fraimz/video captured for this quick UI polish because the provider-auth API-key flow needs a live local app/provider setup and no approved voiceover was provided in this task.