### PR TITLE
fix(release): disable Daytona snapshot by default

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -47,7 +47,7 @@ on:
         description: "Build + push Daytona worker snapshot"
         required: false
         type: boolean
-        default: true
+        default: false
       build_electron:
         description: "Build + publish Electron desktop artifacts (macOS/Linux/Windows)"
         required: false
@@ -104,7 +104,7 @@ jobs:
           INPUT_PUBLISH_DAYTONA_SNAPSHOT: ${{ github.event.inputs.publish_daytona_snapshot }}
           DEFAULT_PUBLISH_SIDECARS: ${{ vars.RELEASE_PUBLISH_SIDECARS }}
           DEFAULT_PUBLISH_NPM: ${{ vars.RELEASE_PUBLISH_NPM }}
-          DEFAULT_PUBLISH_DAYTONA_SNAPSHOT: ${{ vars.RELEASE_PUBLISH_DAYTONA_SNAPSHOT }}
+          DEFAULT_PUBLISH_DAYTONA_SNAPSHOT: "false"
           DEFAULT_NOTARIZE: ${{ vars.MACOS_NOTARIZE }}
           DEFAULT_BUILD_ELECTRON: ${{ vars.RELEASE_PUBLISH_ELECTRON }}
           DEFAULT_SIGN_WINDOWS: ${{ vars.RELEASE_SIGN_WINDOWS }}


### PR DESCRIPTION
## Summary
- Make Release App Daytona snapshot publishing opt-in instead of default-on.
- Ignore the RELEASE_PUBLISH_DAYTONA_SNAPSHOT repo variable for default release behavior so tag releases do not block on Daytona snapshot creation.

## Context
- v0.17.40 release recovery succeeded by dispatching Release App with publish_daytona_snapshot=false.
- The failed Daytona snapshot job should not block urgent app releases.

## Validation
- pnpm release:review

## Runtime proof
- Not run: workflow-only release configuration change; no app runtime path changed.