### PR TITLE
feat(chat): capability calls render as sentences (Paper transcript rules, step 1)

### DIFF
--- a/apps/app/src/components/chat/artifact.tsx
+++ b/apps/app/src/components/chat/artifact.tsx
@@ -5,65 +5,55 @@ import { ArrowUpRightIcon } from "lucide-react";
 
 import { ArtifactIcon } from "@/components/chat/artifact-icon";
 import {
-  DescriptiveButton,
-  DescriptiveButtonContent,
-  DescriptiveButtonIcon,
-  DescriptiveButtonTitle,
-} from "@/components/descriptive-button";
-import {
   type ArtifactItem,
   canOpenArtifact,
   canPreviewArtifact,
   useArtifacts,
   usePreviewArtifact,
 } from "@/lib/artifacts";
+import { useOpenTargets } from "@/lib/target-provider";
 
-interface ArtifactButtonProps {
+interface ArtifactChipProps {
   artifact: ArtifactItem
 }
 
-const MAX_ARTIFACT_TITLE_LENGTH = 20;
-
-function compactArtifactTitle(name: string) {
-  return name.length > MAX_ARTIFACT_TITLE_LENGTH
-    ? `${name.slice(0, MAX_ARTIFACT_TITLE_LENGTH - 1)}…`
-    : name;
-}
-
-function ArtifactButton({ artifact }: ArtifactButtonProps) {
+/**
+ * Paper "File paths → chips · artifact strip": one chip per artifact —
+ * type icon + name, full path in the tooltip. Click opens the artifact
+ * preview; ↗ opens in the default app.
+ */
+function ArtifactChip({ artifact }: ArtifactChipProps) {
   const previewArtifact = usePreviewArtifact();
+  const { onOpenTarget } = useOpenTargets();
   const canOpen = canOpenArtifact(artifact);
   const canPreview = canPreviewArtifact(artifact);
-  const title = compactArtifactTitle(artifact.name);
-
-  const content = (
-    <>
-      <DescriptiveButtonIcon className="size-5">
-        <ArtifactIcon className="size-4 shrink-0" type={artifact.type} />
-      </DescriptiveButtonIcon>
-      <DescriptiveButtonContent className="min-w-0 flex-none">
-        <DescriptiveButtonTitle className="max-w-32 text-xs font-medium" title={artifact.name}>{title}</DescriptiveButtonTitle>
-      </DescriptiveButtonContent>
-      {canOpen ? <ArrowUpRightIcon className="size-3.5 shrink-0 text-muted-foreground" /> : null}
-    </>
-  );
-
-  if (!canOpen) {
-    return (
-      <div className="flex h-auto w-fit max-w-full flex-none shrink-0 items-center justify-start gap-1.5 rounded-xl border border-border px-2 py-1.5 text-left whitespace-nowrap">
-        {content}
-      </div>
-    );
-  }
 
   return (
-    <DescriptiveButton
-      className="w-fit max-w-full flex-none items-center gap-1.5 rounded-xl px-2 py-1.5 whitespace-nowrap"
-      onClick={() => previewArtifact(artifact)}
-      title={canPreview ? `Preview ${artifact.name}` : `Open ${artifact.name}`}
-    >
-      {content}
-    </DescriptiveButton>
+    <span className="inline-flex shrink-0 items-stretch overflow-hidden rounded-lg border border-border/70 bg-muted/40 align-middle">
+      <button
+        type="button"
+        disabled={!canOpen}
+        onClick={() => previewArtifact(artifact)}
+        title={canPreview ? `Preview ${artifact.path}` : `Open ${artifact.path}`}
+        className="flex min-w-0 cursor-pointer items-center gap-2 px-2.5 py-1.5 transition-colors hover:bg-muted disabled:cursor-default disabled:hover:bg-transparent"
+      >
+        <ArtifactIcon className="size-3.5 shrink-0 text-muted-foreground" type={artifact.type} />
+        <span className="max-w-40 truncate text-[13px] font-medium leading-4 text-foreground" title={artifact.name}>
+          {artifact.name}
+        </span>
+      </button>
+      {canOpen ? (
+        <button
+          type="button"
+          onClick={() => onOpenTarget?.(artifact.legacy_target, { external: true })}
+          title={`Open ${artifact.name} in default app`}
+          aria-label={`Open ${artifact.name} in default app`}
+          className="flex cursor-pointer items-center border-l border-border/60 px-1.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+        >
+          <ArrowUpRightIcon aria-hidden="true" className="size-3" />
+        </button>
+      ) : null}
+    </span>
   );
 }
 
@@ -72,6 +62,10 @@ interface ArtifactListProps {
   includeTargetFallbacks?: boolean
 }
 
+/**
+ * Paper artifact strip: a turn that touched files ends with a "FILES"
+ * row of deduped chips — one place to open everything it produced.
+ */
 export function ArtifactList({ messages, includeTargetFallbacks = false }: ArtifactListProps) {
   const artifacts = useArtifacts(messages, { includeTargetFallbacks });
 
@@ -80,10 +74,13 @@ export function ArtifactList({ messages, includeTargetFallbacks = false }: Artif
   }
 
   return (
-    <div className="mx-auto w-full max-w-3xl px-2 md:px-10">
-      <div className="no-scrollbar flex min-w-0 flex-nowrap gap-2 overflow-x-auto pb-1">
+    <div className="mx-auto w-full max-w-3xl px-2 md:px-10" data-files-strip>
+      <div className="no-scrollbar flex min-w-0 flex-nowrap items-center gap-2.5 overflow-x-auto pb-1">
+        <span className="shrink-0 text-[11px] font-medium uppercase tracking-[0.06em] text-muted-foreground/80">
+          Files
+        </span>
         {artifacts.map((artifact) => (
-          <ArtifactButton key={artifact.id} artifact={artifact} />
+          <ArtifactChip key={artifact.id} artifact={artifact} />
         ))}
       </div>
     </div>

--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -53,9 +53,9 @@ function failureInstruction(part: DynamicToolUIPart, reconnectName: string | nul
  * a plain muted text line — dot-matrix while running, small green dot
  * when done, past-tense verb with duration. IDs, schema digests, and
  * raw payloads live under a collapsed "Technical details" section.
- * Failures follow "Failures are instructions": red dot, one line saying
- * what to do next, and an inline Reconnect/Retry button when the error
- * maps to a known connection.
+ * Failures follow "Failures are instructions": same neutral dot, one
+ * line saying what to do next, and an inline Reconnect/Retry button
+ * when the error maps to a known connection. No traffic-light colors.
  */
 export function CapabilityCallLine({
   part,
@@ -89,14 +89,11 @@ export function CapabilityCallLine({
             {inFlight ? (
               <DotMatrixLoader label={line} className="text-muted-foreground" />
             ) : (
-              <span
-                aria-hidden="true"
-                className={cn("size-1.5 rounded-full", isFailed ? "bg-red-9" : "bg-green-9")}
-              />
+              <span aria-hidden="true" className="size-1.5 rounded-full bg-muted-foreground/60" />
             )}
           </span>
           <span className="min-w-0 truncate">{line}</span>
-          {isFailed ? <span className="shrink-0 text-xs text-red-11">failed</span> : null}
+          {isFailed ? <span className="shrink-0 text-xs text-muted-foreground">failed</span> : null}
           {duration ? (
             <span className="shrink-0 text-xs tabular-nums text-muted-foreground/70">{duration}</span>
           ) : null}
@@ -156,7 +153,7 @@ export function CapabilityCallLine({
             </pre>
           ) : null}
           {isFailed && part.errorText ? (
-            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word text-red-11">
+            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
               {part.errorText}
             </pre>
           ) : null}

--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -16,7 +16,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
 import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader"
-import { getCapabilityCallSentence } from "@/lib/capability-call"
+import { getCapabilityCallSentence, parseRecord } from "@/lib/capability-call"
 import { trackToolCallDuration } from "@/lib/tool-call-duration"
 import { isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
@@ -40,12 +40,28 @@ function failureInstruction(part: DynamicToolUIPart, reconnectName: string | nul
   if (reconnectName) {
     return `${reconnectName} needs a fresh sign-in — reconnect it, then retry.`
   }
-  const attribution = part.state === "output-error" && part.errorText
-    ? attributeChatToolError(part.errorText)
-    : null
+  const errorText = part.state === "output-error" ? part.errorText : null
+  const attribution = errorText ? attributeChatToolError(errorText) : null
   if (attribution) return attribution.description
-  const firstLine = part.state === "output-error" ? part.errorText?.split("\n")[0]?.trim() : null
-  return firstLine || "The call failed. Full error is under Technical details."
+
+  // Structured provider errors ({ error, details: [{ message }] }) should
+  // read as a sentence, never as raw JSON.
+  const record = errorText ? parseRecord(errorText) : null
+  if (record) {
+    const code = typeof record.error === "string" ? record.error : null
+    const detailMessage = Array.isArray(record.details)
+      ? record.details
+        .map((detail) => (typeof detail === "object" && detail !== null && "message" in detail && typeof detail.message === "string" ? detail.message : null))
+        .find((message) => message)
+      : null
+    const message = detailMessage ?? (typeof record.message === "string" ? record.message : null)
+    const summary = [code?.replace(/_/g, " "), message].filter(Boolean).join(" — ")
+    if (summary) return `The provider rejected the call: ${summary}.`
+  }
+
+  const firstLine = errorText?.split("\n")[0]?.trim()
+  if (firstLine && !firstLine.startsWith("{") && !firstLine.startsWith("[")) return firstLine
+  return "The call failed. Full error is under Technical details."
 }
 
 /**

--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react"
 import type { DynamicToolUIPart } from "ai"
-import { ExternalLink, LoaderCircle, RefreshCcw } from "lucide-react"
+import { ChevronRight, CircleAlert, ExternalLink, LoaderCircle, RefreshCcw } from "lucide-react"
 
 import { attributeChatToolError } from "@/components/tools/error-attribution"
 import {
@@ -16,7 +16,7 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
 import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader"
-import { getCapabilityCallSentence, parseRecord } from "@/lib/capability-call"
+import { getCapabilityCallQuote, getCapabilityCallSentence, parseRecord } from "@/lib/capability-call"
 import { trackToolCallDuration } from "@/lib/tool-call-duration"
 import { isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
@@ -64,14 +64,40 @@ function failureInstruction(part: DynamicToolUIPart, reconnectName: string | nul
   return "The call failed. Full error is under Technical details."
 }
 
+function TechnicalDetailsPanel({ part }: { part: DynamicToolUIPart }) {
+  return (
+    <div className="mt-2 flex flex-col gap-2 rounded-lg bg-muted p-2 text-xs">
+      <div className="font-mono text-[11px] text-muted-foreground">
+        {part.toolName} · {part.toolCallId}
+      </div>
+      {part.input !== undefined && part.input !== null ? (
+        <pre className="max-h-40 overflow-auto whitespace-pre-wrap wrap-break-word">
+          {formatTechnicalValue(part.input)}
+        </pre>
+      ) : null}
+      {"output" in part && part.output !== undefined ? (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
+          {formatTechnicalValue(part.output)}
+        </pre>
+      ) : null}
+      {part.state === "output-error" && part.errorText ? (
+        <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
+          {part.errorText}
+        </pre>
+      ) : null}
+    </div>
+  )
+}
+
 /**
  * Paper "Capability calls → sentences" + "No icon per tool call":
- * a plain muted text line — dot-matrix while running, small green dot
- * when done, past-tense verb with duration. IDs, schema digests, and
- * raw payloads live under a collapsed "Technical details" section.
- * Failures follow "Failures are instructions": same neutral dot, one
- * line saying what to do next, and an inline Reconnect/Retry button
- * when the error maps to a known connection. No traffic-light colors.
+ * a plain muted text line — dot-matrix while running, past-tense verb
+ * with duration when done. IDs, schema digests, and raw payloads live
+ * under a collapsed "Technical details" section.
+ * Failures render the Paper "Failed Call Card": service avatar +
+ * present-participle headline, the interpreted ask as a quote, one
+ * instruction line saying what to do next with an inline
+ * Reconnect/Retry action, and technical details collapsed below.
  */
 export function CapabilityCallLine({
   part,
@@ -81,11 +107,10 @@ export function CapabilityCallLine({
   onRetry,
 }: CapabilityCallLineProps) {
   const [open, setOpen] = useState(false)
+  const [detailsOpen, setDetailsOpen] = useState(false)
   const inFlight = isToolPartInFlight(part)
   const isFailed = part.state === "output-error"
-  const sentence = getCapabilityCallSentence(part)
   const duration = trackToolCallDuration(part)
-  const line = inFlight ? sentence.present : sentence.past
   const { reconnectAction, reconnectState, reconnectError, reconnectPresentation, handleReconnect } =
     useChatToolReconnect(part, { onReconnect, onReopenAuthorization, onRetry })
   const ReconnectIcon = reconnectState === "opening"
@@ -94,6 +119,110 @@ export function CapabilityCallLine({
       ? ExternalLink
       : RefreshCcw
 
+  // Failures stay minimal until the user asks for more: one collapsed
+  // line, expanding into the Paper "Failed Call Card" (quote, instruction
+  // + Reconnect/Retry, technical details).
+  if (isFailed) {
+    const sentence = getCapabilityCallSentence(part, { includeQuery: false })
+    const quote = getCapabilityCallQuote(part)
+    const initial = sentence.service?.charAt(0).toUpperCase() ?? null
+    return (
+      <Collapsible
+        data-capability-call={part.toolName}
+        open={open}
+        onOpenChange={setOpen}
+        className={className}
+      >
+        <CollapsibleTrigger
+          className="group flex min-w-0 max-w-full cursor-pointer items-center gap-2 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
+          aria-label={open ? `${sentence.past}. Hide failure details` : `${sentence.past} failed. Show what to do next`}
+        >
+          <ChevronRight
+            aria-hidden="true"
+            className={cn("size-3.5 shrink-0 text-muted-foreground/70 transition-transform duration-150", open && "rotate-90")}
+          />
+          <span className="min-w-0 truncate">{sentence.past}</span>
+          <span className="shrink-0 text-xs font-medium text-destructive">failed</span>
+          {duration ? (
+            <span className="shrink-0 text-xs tabular-nums text-muted-foreground/70">{duration}</span>
+          ) : null}
+        </CollapsibleTrigger>
+        <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
+          <div className="mt-2 flex flex-col gap-3 rounded-xl border border-border bg-muted/30 p-4">
+            <div className="flex min-w-0 items-center gap-2.5">
+              {initial ? (
+                <span
+                  aria-hidden="true"
+                  className="flex size-6 shrink-0 items-center justify-center rounded-md bg-muted text-xs font-semibold text-foreground"
+                >
+                  {initial}
+                </span>
+              ) : null}
+              <span className="min-w-0 truncate text-sm font-medium text-foreground">
+                {sentence.present}
+              </span>
+            </div>
+            {quote ? (
+              <div className="flex min-w-0 gap-2.5 ps-0.5">
+                <span aria-hidden="true" className="w-0.5 shrink-0 rounded-full bg-border" />
+                <p className="min-w-0 text-[13px] leading-5 text-muted-foreground">“{quote}”</p>
+              </div>
+            ) : null}
+            <div className="flex min-w-0 items-center gap-2">
+              <CircleAlert aria-hidden="true" className="size-3.5 shrink-0 text-destructive" />
+              <p className="min-w-0 text-[13px] leading-5 text-destructive/90">
+                {failureInstruction(part, reconnectAction?.connectionName ?? null)}
+              </p>
+              {reconnectAction && onReconnect ? (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="xs"
+                  className="ms-auto h-6 shrink-0 gap-1.5 rounded-md px-2 font-semibold text-blue-11 shadow-none before:shadow-none hover:bg-blue-3/60"
+                  data-testid="chat-mcp-reconnect-action"
+                  disabled={reconnectPresentation?.disabled}
+                  title={`${reconnectPresentation?.buttonLabel} ${reconnectAction.connectionName}`}
+                  aria-label={`${reconnectPresentation?.buttonLabel} ${reconnectAction.connectionName}`}
+                  onClick={() => void handleReconnect()}
+                >
+                  <ReconnectIcon
+                    data-icon="inline-start"
+                    className={cn("size-3.5", reconnectState === "opening" && "animate-spin")}
+                    aria-hidden="true"
+                  />
+                  {reconnectPresentation?.buttonLabel}
+                </Button>
+              ) : null}
+            </div>
+            {reconnectError ? (
+              <p className="text-xs text-destructive" role="alert">{reconnectError}</p>
+            ) : null}
+            <div className="border-t border-border/60 pt-2.5">
+              <button
+                type="button"
+                onClick={() => setDetailsOpen(!detailsOpen)}
+                aria-expanded={detailsOpen}
+                className="flex min-w-0 cursor-pointer items-center gap-1.5 text-xs text-muted-foreground transition-colors hover:text-foreground"
+              >
+                <ChevronRight
+                  aria-hidden="true"
+                  className={cn("size-3 shrink-0 transition-transform duration-150", detailsOpen && "rotate-90")}
+                />
+                <span className="shrink-0">Technical details</span>
+                <span className="min-w-0 truncate text-muted-foreground/60">
+                  capability name · arguments · schema digest
+                </span>
+              </button>
+              {detailsOpen ? <TechnicalDetailsPanel part={part} /> : null}
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    )
+  }
+
+  const sentence = getCapabilityCallSentence(part)
+  const line = inFlight ? sentence.present : sentence.past
   return (
     <Collapsible data-capability-call={part.toolName} open={open} onOpenChange={setOpen} className={className}>
       <div className="flex min-w-0 items-center gap-2">
@@ -107,71 +236,13 @@ export function CapabilityCallLine({
             </span>
           ) : null}
           <span className="min-w-0 truncate">{line}</span>
-          {isFailed ? <span className="shrink-0 text-xs text-muted-foreground">failed</span> : null}
           {duration ? (
             <span className="shrink-0 text-xs tabular-nums text-muted-foreground/70">{duration}</span>
           ) : null}
         </CollapsibleTrigger>
-        {isFailed && reconnectAction && onReconnect ? (
-          <Button
-            type="button"
-            variant="outline"
-            size="xs"
-            className={cn(
-              "h-7 shrink-0 gap-1.5 rounded-lg px-2.5 font-semibold shadow-none before:shadow-none",
-              reconnectState === "connected"
-                ? "border-green-7/40 bg-green-3/60 text-green-11 hover:border-green-7/60 hover:bg-green-4/70"
-                : reconnectState === "failed"
-                  ? "border-destructive/30 bg-destructive/5 text-destructive hover:border-destructive/50 hover:bg-destructive/10"
-                  : "border-amber-7/40 bg-amber-3/60 text-amber-11 hover:border-amber-7/60 hover:bg-amber-4/70",
-            )}
-            data-testid="chat-mcp-reconnect-action"
-            disabled={reconnectPresentation?.disabled}
-            title={`${reconnectPresentation?.buttonLabel} ${reconnectAction.connectionName}`}
-            aria-label={`${reconnectPresentation?.buttonLabel} ${reconnectAction.connectionName}`}
-            onClick={() => void handleReconnect()}
-          >
-            <ReconnectIcon
-              data-icon="inline-start"
-              className={cn("size-3.5", reconnectState === "opening" && "animate-spin")}
-              aria-hidden="true"
-            />
-            {reconnectPresentation?.buttonLabel}
-          </Button>
-        ) : null}
       </div>
-      {isFailed ? (
-        <p className="mt-1 ps-5.5 text-xs text-muted-foreground">
-          {failureInstruction(part, reconnectAction?.connectionName ?? null)}
-        </p>
-      ) : null}
-      {reconnectError ? (
-        <p className="mt-1 ps-5.5 text-xs text-destructive" role="alert">{reconnectError}</p>
-      ) : null}
       <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
-        <div className="mt-2 flex flex-col gap-2 rounded-lg bg-muted p-2 text-xs">
-          <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
-            Technical details
-          </div>
-          <div className={cn("text-muted-foreground", "font-mono text-[11px]")}>
-            {part.toolName} · {part.toolCallId}
-          </div>
-          {part.input !== undefined && part.input !== null ? (
-            <pre className="max-h-40 overflow-auto whitespace-pre-wrap wrap-break-word">
-              {formatTechnicalValue(part.input)}
-            </pre>
-          ) : null}
-          {"output" in part && part.output !== undefined ? (
-            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
-              {formatTechnicalValue(part.output)}
-            </pre>
-          ) : null}
-          {isFailed && part.errorText ? (
-            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
-              {part.errorText}
-            </pre>
-          ) : null}
-        </div>
+        <TechnicalDetailsPanel part={part} />
       </CollapsibleContent>
     </Collapsible>
   )

--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -1,0 +1,83 @@
+"use client"
+
+import { useState } from "react"
+import type { DynamicToolUIPart } from "ai"
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader"
+import { getCapabilityCallSentence, trackCapabilityCallDuration } from "@/lib/capability-call"
+import { isToolPartInFlight } from "@/lib/tool-activity"
+import { cn } from "@/lib/utils"
+
+type CapabilityCallLineProps = {
+  part: DynamicToolUIPart
+  className?: string
+}
+
+function formatTechnicalValue(value: unknown): string {
+  if (typeof value === "string") return value
+  try {
+    return JSON.stringify(value, null, 2)
+  } catch {
+    return String(value)
+  }
+}
+
+/**
+ * Paper "Capability calls → sentences" + "No icon per tool call":
+ * a plain muted text line — dot-matrix while running, small green dot
+ * when done, past-tense verb with duration. IDs, schema digests, and
+ * raw payloads live under a collapsed "Technical details" section.
+ */
+export function CapabilityCallLine({ part, className }: CapabilityCallLineProps) {
+  const [open, setOpen] = useState(false)
+  const inFlight = isToolPartInFlight(part)
+  const sentence = getCapabilityCallSentence(part)
+  const duration = trackCapabilityCallDuration(part)
+  const line = inFlight ? sentence.present : sentence.past
+
+  return (
+    <Collapsible data-capability-call={part.toolName} open={open} onOpenChange={setOpen} className={className}>
+      <CollapsibleTrigger
+        className="group flex min-w-0 max-w-full cursor-pointer items-center gap-2 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
+        aria-label={open ? `${line}. Hide technical details` : `${line}. Show technical details`}
+      >
+        <span className="flex size-3.5 shrink-0 items-center justify-center">
+          {inFlight ? (
+            <DotMatrixLoader label={line} className="text-muted-foreground" />
+          ) : (
+            <span aria-hidden="true" className="size-1.5 rounded-full bg-green-9" />
+          )}
+        </span>
+        <span className="min-w-0 truncate">{line}</span>
+        {duration ? (
+          <span className="shrink-0 text-xs tabular-nums text-muted-foreground/70">{duration}</span>
+        ) : null}
+      </CollapsibleTrigger>
+      <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
+        <div className="mt-2 flex flex-col gap-2 rounded-lg bg-muted p-2 text-xs">
+          <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
+            Technical details
+          </div>
+          <div className={cn("text-muted-foreground", "font-mono text-[11px]")}>
+            {part.toolName} · {part.toolCallId}
+          </div>
+          {part.input !== undefined && part.input !== null ? (
+            <pre className="max-h-40 overflow-auto whitespace-pre-wrap wrap-break-word">
+              {formatTechnicalValue(part.input)}
+            </pre>
+          ) : null}
+          {"output" in part && part.output !== undefined ? (
+            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
+              {formatTechnicalValue(part.output)}
+            </pre>
+          ) : null}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -9,7 +9,8 @@ import {
   CollapsibleTrigger,
 } from "@/components/ui/collapsible"
 import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader"
-import { getCapabilityCallSentence, trackCapabilityCallDuration } from "@/lib/capability-call"
+import { getCapabilityCallSentence } from "@/lib/capability-call"
+import { trackToolCallDuration } from "@/lib/tool-call-duration"
 import { isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
 
@@ -37,7 +38,7 @@ export function CapabilityCallLine({ part, className }: CapabilityCallLineProps)
   const [open, setOpen] = useState(false)
   const inFlight = isToolPartInFlight(part)
   const sentence = getCapabilityCallSentence(part)
-  const duration = trackCapabilityCallDuration(part)
+  const duration = trackToolCallDuration(part)
   const line = inFlight ? sentence.present : sentence.past
 
   return (

--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -101,13 +101,11 @@ export function CapabilityCallLine({
           className="group flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
           aria-label={open ? `${line}. Hide technical details` : `${line}. Show technical details`}
         >
-          <span className="flex size-3.5 shrink-0 items-center justify-center">
-            {inFlight ? (
+          {inFlight ? (
+            <span className="flex size-3.5 shrink-0 items-center justify-center">
               <DotMatrixLoader label={line} className="text-muted-foreground" />
-            ) : (
-              <span aria-hidden="true" className="size-1.5 rounded-full bg-muted-foreground/60" />
-            )}
-          </span>
+            </span>
+          ) : null}
           <span className="min-w-0 truncate">{line}</span>
           {isFailed ? <span className="shrink-0 text-xs text-muted-foreground">failed</span> : null}
           {duration ? (

--- a/apps/app/src/components/chat/capability-call-line.tsx
+++ b/apps/app/src/components/chat/capability-call-line.tsx
@@ -2,7 +2,14 @@
 
 import { useState } from "react"
 import type { DynamicToolUIPart } from "ai"
+import { ExternalLink, LoaderCircle, RefreshCcw } from "lucide-react"
 
+import { attributeChatToolError } from "@/components/tools/error-attribution"
+import {
+  useChatToolReconnect,
+  type ChatToolReconnectCallbacks,
+} from "@/components/tools/use-chat-tool-reconnect"
+import { Button } from "@/components/ui/button"
 import {
   Collapsible,
   CollapsibleContent,
@@ -14,7 +21,7 @@ import { trackToolCallDuration } from "@/lib/tool-call-duration"
 import { isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
 
-type CapabilityCallLineProps = {
+type CapabilityCallLineProps = ChatToolReconnectCallbacks & {
   part: DynamicToolUIPart
   className?: string
 }
@@ -28,37 +35,108 @@ function formatTechnicalValue(value: unknown): string {
   }
 }
 
+/** One human sentence explaining what to do about a failed call. */
+function failureInstruction(part: DynamicToolUIPart, reconnectName: string | null): string {
+  if (reconnectName) {
+    return `${reconnectName} needs a fresh sign-in — reconnect it, then retry.`
+  }
+  const attribution = part.state === "output-error" && part.errorText
+    ? attributeChatToolError(part.errorText)
+    : null
+  if (attribution) return attribution.description
+  const firstLine = part.state === "output-error" ? part.errorText?.split("\n")[0]?.trim() : null
+  return firstLine || "The call failed. Full error is under Technical details."
+}
+
 /**
  * Paper "Capability calls → sentences" + "No icon per tool call":
  * a plain muted text line — dot-matrix while running, small green dot
  * when done, past-tense verb with duration. IDs, schema digests, and
  * raw payloads live under a collapsed "Technical details" section.
+ * Failures follow "Failures are instructions": red dot, one line saying
+ * what to do next, and an inline Reconnect/Retry button when the error
+ * maps to a known connection.
  */
-export function CapabilityCallLine({ part, className }: CapabilityCallLineProps) {
+export function CapabilityCallLine({
+  part,
+  className,
+  onReconnect,
+  onReopenAuthorization,
+  onRetry,
+}: CapabilityCallLineProps) {
   const [open, setOpen] = useState(false)
   const inFlight = isToolPartInFlight(part)
+  const isFailed = part.state === "output-error"
   const sentence = getCapabilityCallSentence(part)
   const duration = trackToolCallDuration(part)
   const line = inFlight ? sentence.present : sentence.past
+  const { reconnectAction, reconnectState, reconnectError, reconnectPresentation, handleReconnect } =
+    useChatToolReconnect(part, { onReconnect, onReopenAuthorization, onRetry })
+  const ReconnectIcon = reconnectState === "opening"
+    ? LoaderCircle
+    : reconnectState === "authorization_opened"
+      ? ExternalLink
+      : RefreshCcw
 
   return (
     <Collapsible data-capability-call={part.toolName} open={open} onOpenChange={setOpen} className={className}>
-      <CollapsibleTrigger
-        className="group flex min-w-0 max-w-full cursor-pointer items-center gap-2 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
-        aria-label={open ? `${line}. Hide technical details` : `${line}. Show technical details`}
-      >
-        <span className="flex size-3.5 shrink-0 items-center justify-center">
-          {inFlight ? (
-            <DotMatrixLoader label={line} className="text-muted-foreground" />
-          ) : (
-            <span aria-hidden="true" className="size-1.5 rounded-full bg-green-9" />
-          )}
-        </span>
-        <span className="min-w-0 truncate">{line}</span>
-        {duration ? (
-          <span className="shrink-0 text-xs tabular-nums text-muted-foreground/70">{duration}</span>
+      <div className="flex min-w-0 items-center gap-2">
+        <CollapsibleTrigger
+          className="group flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
+          aria-label={open ? `${line}. Hide technical details` : `${line}. Show technical details`}
+        >
+          <span className="flex size-3.5 shrink-0 items-center justify-center">
+            {inFlight ? (
+              <DotMatrixLoader label={line} className="text-muted-foreground" />
+            ) : (
+              <span
+                aria-hidden="true"
+                className={cn("size-1.5 rounded-full", isFailed ? "bg-red-9" : "bg-green-9")}
+              />
+            )}
+          </span>
+          <span className="min-w-0 truncate">{line}</span>
+          {isFailed ? <span className="shrink-0 text-xs text-red-11">failed</span> : null}
+          {duration ? (
+            <span className="shrink-0 text-xs tabular-nums text-muted-foreground/70">{duration}</span>
+          ) : null}
+        </CollapsibleTrigger>
+        {isFailed && reconnectAction && onReconnect ? (
+          <Button
+            type="button"
+            variant="outline"
+            size="xs"
+            className={cn(
+              "h-7 shrink-0 gap-1.5 rounded-lg px-2.5 font-semibold shadow-none before:shadow-none",
+              reconnectState === "connected"
+                ? "border-green-7/40 bg-green-3/60 text-green-11 hover:border-green-7/60 hover:bg-green-4/70"
+                : reconnectState === "failed"
+                  ? "border-destructive/30 bg-destructive/5 text-destructive hover:border-destructive/50 hover:bg-destructive/10"
+                  : "border-amber-7/40 bg-amber-3/60 text-amber-11 hover:border-amber-7/60 hover:bg-amber-4/70",
+            )}
+            data-testid="chat-mcp-reconnect-action"
+            disabled={reconnectPresentation?.disabled}
+            title={`${reconnectPresentation?.buttonLabel} ${reconnectAction.connectionName}`}
+            aria-label={`${reconnectPresentation?.buttonLabel} ${reconnectAction.connectionName}`}
+            onClick={() => void handleReconnect()}
+          >
+            <ReconnectIcon
+              data-icon="inline-start"
+              className={cn("size-3.5", reconnectState === "opening" && "animate-spin")}
+              aria-hidden="true"
+            />
+            {reconnectPresentation?.buttonLabel}
+          </Button>
         ) : null}
-      </CollapsibleTrigger>
+      </div>
+      {isFailed ? (
+        <p className="mt-1 ps-5.5 text-xs text-muted-foreground">
+          {failureInstruction(part, reconnectAction?.connectionName ?? null)}
+        </p>
+      ) : null}
+      {reconnectError ? (
+        <p className="mt-1 ps-5.5 text-xs text-destructive" role="alert">{reconnectError}</p>
+      ) : null}
       <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
         <div className="mt-2 flex flex-col gap-2 rounded-lg bg-muted p-2 text-xs">
           <div className="text-[10px] font-medium uppercase tracking-wide text-muted-foreground">
@@ -75,6 +153,11 @@ export function CapabilityCallLine({ part, className }: CapabilityCallLineProps)
           {"output" in part && part.output !== undefined ? (
             <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
               {formatTechnicalValue(part.output)}
+            </pre>
+          ) : null}
+          {isFailed && part.errorText ? (
+            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word text-red-11">
+              {part.errorText}
             </pre>
           ) : null}
         </div>

--- a/apps/app/src/components/chat/file-chip.tsx
+++ b/apps/app/src/components/chat/file-chip.tsx
@@ -1,0 +1,58 @@
+"use client"
+
+import { ArrowUpRight, FileText } from "lucide-react"
+
+import { useOpenArtifactPath } from "@/lib/artifacts"
+import { cn } from "@/lib/utils"
+
+type FileChipProps = {
+  /** Full (possibly absolute) file path; only the basename is shown. */
+  path: string
+  className?: string
+}
+
+function baseName(path: string): string {
+  const segments = path.split(/[/\\]/)
+  return segments[segments.length - 1] || path
+}
+
+/**
+ * Paper "File paths → chips": never render raw absolute paths. A file
+ * reference is an inline chip — icon + basename in mono, full path in
+ * the tooltip. Click opens the artifact preview; ↗ opens the file in
+ * the default app. Used in aggregate rows, failure reasons, and prose.
+ */
+export function FileChip({ path, className }: FileChipProps) {
+  const openArtifactPath = useOpenArtifactPath()
+  const name = baseName(path)
+
+  return (
+    <span
+      className={cn(
+        "inline-flex items-stretch overflow-hidden rounded-md border border-border/70 bg-muted/50 align-middle",
+        className,
+      )}
+    >
+      <button
+        type="button"
+        onClick={() => openArtifactPath(path)}
+        title={path}
+        className="flex min-w-0 cursor-pointer items-center gap-1.5 px-1.5 py-0.5 transition-colors hover:bg-muted"
+      >
+        <FileText aria-hidden="true" className="size-3 shrink-0 text-muted-foreground" />
+        <span className="min-w-0 truncate font-mono text-[11px] leading-4 text-foreground">
+          {name}
+        </span>
+      </button>
+      <button
+        type="button"
+        onClick={() => openArtifactPath(path, { external: true })}
+        title={`Open ${name} in default app`}
+        aria-label={`Open ${name} in default app`}
+        className="flex cursor-pointer items-center border-l border-border/60 px-1 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+      >
+        <ArrowUpRight aria-hidden="true" className="size-2.5" />
+      </button>
+    </span>
+  )
+}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -62,6 +62,7 @@ import {
   MessageContent,
 } from "@/components/ui/message"
 import { Tool } from "@/components/ui/tool"
+import { CapabilityCallLine } from "@/components/chat/capability-call-line"
 import {
   isApplyPatchToolPart,
   isBashToolPart,
@@ -73,6 +74,7 @@ import {
   isQuestionToolPart,
   isReadToolPart,
   isSkillToolPart,
+  isTaskToolPart,
   isTodoWriteToolPart,
   isWebFetchToolPart,
   isWebSearchToolPart,
@@ -198,6 +200,13 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
 
   if (part.type === "dynamic-tool" && part.toolName === "openwork_session_create") {
     return <OpenWorkSessionCreateTool part={part} />
+  }
+
+  // Sub-agent runs keep the generic card until the dedicated two-line
+  // rendering lands; failed calls keep it for the reconnect/Retry flow.
+  const isFailed = part.state === "output-error"
+  if (part.type === "dynamic-tool" && !isTaskToolPart(part) && !isFailed) {
+    return <CapabilityCallLine part={part} />
   }
 
   return (

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -63,6 +63,7 @@ import {
 } from "@/components/ui/message"
 import { Tool } from "@/components/ui/tool"
 import { CapabilityCallLine } from "@/components/chat/capability-call-line"
+import { ToolAggregateGroup } from "@/components/chat/tool-aggregate-group"
 import {
   isApplyPatchToolPart,
   isBashToolPart,
@@ -86,7 +87,8 @@ import {
   getActiveToolLabel,
 } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
-import { groupMessages, isMessageGroup, getLastTextPart, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCreated, formatMessageTimestamp, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl } from "./utils"
+import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCreated, formatMessageTimestamp, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl } from "./utils"
+import type { AnyToolPart } from "@/lib/tool-aggregate"
 
 const SEARCH_HIGHLIGHT_MARK_CLASS = "rounded px-0.5 bg-amber-4/70 text-current"
 
@@ -394,6 +396,14 @@ const AssistantMessage = React.memo(
               return (
                 <div key={`file-${index}`} className="w-fit max-w-full">
                   <FileMessage part={group.part} tone="assistant" />
+                </div>
+              )
+            }
+
+            if (group.kind === "tool-aggregate") {
+              return (
+                <div key={`tool-aggregate-${index}`} className="w-full">
+                  <ToolAggregateGroup parts={group.parts} />
                 </div>
               )
             }
@@ -772,7 +782,7 @@ function MessageGroup({
   messages,
   isStreaming,
 }: AssistantMessageGroupProps) {
-  const { onRevertToUserMessage, onForkAtMessage } = useMessageList()
+  const { onRevertToUserMessage, onForkAtMessage, showThinking } = useMessageList()
   const lastItem = items[items.length - 1]
   // Branch/revert must target a real server-side message id. Synthetic
   // client-side messages (e.g. session errors) don't exist on the server and
@@ -822,14 +832,50 @@ function MessageGroup({
     )
   }
 
+  // Consecutive step messages that contain nothing but command/edit/read/
+  // search tool calls merge into one aggregate line (Paper "Recurring
+  // actions"); any prose, reasoning, or other tool breaks the run.
+  const renderItems = (slice: UIMessageWithIndex[], offset: number) => {
+    const nodes: React.ReactNode[] = []
+    let run: { parts: AnyToolPart[]; messages: UIMessage[]; key: string } | null = null
+    const flush = () => {
+      if (!run) return
+      nodes.push(
+        <div key={`aggregate-${run.key}`}>
+          <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
+            <ToolAggregateGroup parts={run.parts} className="w-full" />
+          </Message>
+          <ArtifactList messages={run.messages} includeTargetFallbacks={false} />
+        </div>
+      )
+      run = null
+    }
+    slice.forEach((item, sliceIndex) => {
+      const aggregateParts =
+        item.message.role === "assistant" && !isSessionErrorMessage(item.message)
+          ? getAggregateOnlyParts(item.message, showThinking)
+          : null
+      if (aggregateParts) {
+        if (!run) run = { parts: [], messages: [], key: item.message.id }
+        run.parts.push(...aggregateParts)
+        run.messages.push(item.message)
+        return
+      }
+      flush()
+      nodes.push(renderItem(item, offset + sliceIndex))
+    })
+    flush()
+    return nodes
+  }
+
   return (
       <div className="flex flex-col gap-2 group/message-group">
       {stepItems.length > 0 ? (
         <div ref={stepsRef} className="max-h-[520px] overflow-y-auto">
-          {stepItems.map((item, groupIndex) => renderItem(item, groupIndex))}
+          {renderItems(stepItems, 0)}
         </div>
       ) : null}
-      {proseItems.map((item, groupIndex) => renderItem(item, stepItems.length + groupIndex))}
+      {renderItems(proseItems, stepItems.length)}
       {lastTextMessage && !isStreaming && (
         <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center gap-2 px-2 opacity-0 transition-opacity duration-150 group-hover/message-group:opacity-100 md:px-8">
           <MessageActions className="flex gap-0">

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -88,6 +88,7 @@ import {
   collectToolParts,
   getActiveToolLabel,
 } from "@/lib/tool-activity"
+import { faviconUrlForHref } from "@/lib/favicon"
 import { cn } from "@/lib/utils"
 import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCreated, formatMessageTimestamp, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl } from "./utils"
 import type { AnyToolPart } from "@/lib/tool-aggregate"
@@ -499,6 +500,7 @@ function renderPlainTextWithLinks(text: string, highlightQuery: string | undefin
         </React.Fragment>
       )
     }
+    const favicon = faviconUrlForHref(url)
     nodes.push(
       <a
         key={`${keyPrefix}:url:${start}`}
@@ -507,6 +509,16 @@ function renderPlainTextWithLinks(text: string, highlightQuery: string | undefin
         rel="noreferrer noopener"
         className="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8 break-all"
       >
+        {favicon ? (
+          <img
+            src={favicon}
+            alt=""
+            aria-hidden="true"
+            loading="lazy"
+            decoding="async"
+            className="me-1 inline-block size-3.5 rounded-[3px] align-[-2px]"
+          />
+        ) : null}
         {url}
       </a>
     )

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -483,15 +483,56 @@ function renderPlainTextWithSearchHighlights(text: string, highlightQuery: strin
   return nodes
 }
 
+// Bare URL, excluding trailing punctuation that usually ends a sentence.
+const PLAIN_URL_RE = /https?:\/\/[^\s<>"')\]]+[^\s<>"')\].,;:!?]/g
+
+/** User bubbles are plain text, so bare https:// URLs need explicit anchors. */
+function renderPlainTextWithLinks(text: string, highlightQuery: string | undefined, keyPrefix: string) {
+  const nodes: React.ReactNode[] = []
+  let cursor = 0
+  for (const match of text.matchAll(PLAIN_URL_RE)) {
+    const start = match.index
+    const url = match[0]
+    if (start > cursor) {
+      nodes.push(
+        <React.Fragment key={`${keyPrefix}:pre:${cursor}`}>
+          {renderPlainTextWithSearchHighlights(text.slice(cursor, start), highlightQuery, `${keyPrefix}:pre:${cursor}`)}
+        </React.Fragment>
+      )
+    }
+    nodes.push(
+      <a
+        key={`${keyPrefix}:url:${start}`}
+        href={url}
+        target="_blank"
+        rel="noreferrer noopener"
+        className="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8 break-all"
+      >
+        {url}
+      </a>
+    )
+    cursor = start + url.length
+  }
+  if (nodes.length === 0) return renderPlainTextWithSearchHighlights(text, highlightQuery, keyPrefix)
+  if (cursor < text.length) {
+    nodes.push(
+      <React.Fragment key={`${keyPrefix}:post:${cursor}`}>
+        {renderPlainTextWithSearchHighlights(text.slice(cursor), highlightQuery, `${keyPrefix}:post:${cursor}`)}
+      </React.Fragment>
+    )
+  }
+  return nodes
+}
+
 function renderUserTextWithSkillChips(text: string, highlightQuery: string | undefined) {
-  if (!USER_SKILL_TOKEN_RE.test(text)) return renderPlainTextWithSearchHighlights(text, highlightQuery, "text")
+  if (!USER_SKILL_TOKEN_RE.test(text)) return renderPlainTextWithLinks(text, highlightQuery, "text")
   let offset = 0
   return text.split(USER_SKILL_TOKEN_RE).map((segment) => {
     const key = `${offset}:${segment}`
     offset += segment.length
     const skillMatch = segment.match(/^(?:Load )?\[skill ([^\]]+)\](?: and follow its instructions\.)?$/)
     if (skillMatch?.[1]) return <UserSkillChip key={key} name={skillMatch[1]} />
-    return <React.Fragment key={key}>{renderPlainTextWithSearchHighlights(segment, highlightQuery, key)}</React.Fragment>
+    return <React.Fragment key={key}>{renderPlainTextWithLinks(segment, highlightQuery, key)}</React.Fragment>
   })
 }
 

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -507,7 +507,7 @@ function renderPlainTextWithLinks(text: string, highlightQuery: string | undefin
         href={url}
         target="_blank"
         rel="noreferrer noopener"
-        className="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8 break-all"
+        className="text-indigo-10 transition-colors hover:text-indigo-8 break-all"
       >
         {favicon ? (
           <img

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -830,10 +830,6 @@ function getRenderableMessage(message: UIMessage) {
   return parts.length > 0 ? { ...message, parts } : null;
 }
 
-function MessageArtifacts(props: { message: UIMessage }) {
-  return <ArtifactList messages={[props.message]} includeTargetFallbacks={false} />;
-}
-
 interface AssistantMessageGroupProps {
   items: UIMessageWithIndex[]
   messages: UIMessage[]
@@ -890,7 +886,6 @@ function MessageGroup({
           isStreaming={isLastMessage && isStreaming}
           isLastStep={groupIndex === items.length - 1}
         />
-        <MessageArtifacts message={item.message} />
       </div>
     )
   }
@@ -900,7 +895,7 @@ function MessageGroup({
   // actions"); any prose, reasoning, or other tool breaks the run.
   const renderItems = (slice: UIMessageWithIndex[], offset: number) => {
     const nodes: React.ReactNode[] = []
-    let run: { parts: AnyToolPart[]; messages: UIMessage[]; key: string } | null = null
+    let run: { parts: AnyToolPart[]; key: string } | null = null
     const flush = () => {
       if (!run) return
       nodes.push(
@@ -908,7 +903,6 @@ function MessageGroup({
           <Message className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10">
             <ToolAggregateGroup parts={run.parts} className="w-full" />
           </Message>
-          <ArtifactList messages={run.messages} includeTargetFallbacks={false} />
         </div>
       )
       run = null
@@ -919,9 +913,8 @@ function MessageGroup({
           ? getAggregateOnlyParts(item.message, showThinking)
           : null
       if (aggregateParts) {
-        if (!run) run = { parts: [], messages: [], key: item.message.id }
+        if (!run) run = { parts: [], key: item.message.id }
         run.parts.push(...aggregateParts)
-        run.messages.push(item.message)
         return
       }
       flush()
@@ -939,6 +932,11 @@ function MessageGroup({
         </div>
       ) : null}
       {renderItems(proseItems, stepItems.length)}
+      {/* Paper artifact strip: one FILES row per turn, at the end. */}
+      <ArtifactList
+        messages={items.map((item) => item.message)}
+        includeTargetFallbacks={false}
+      />
       {lastTextMessage && !isStreaming && (
         <div className="mx-auto flex w-full max-w-3xl flex-wrap items-center gap-2 px-2 opacity-0 transition-opacity duration-150 group-hover/message-group:opacity-100 md:px-8">
           <MessageActions className="flex gap-0">
@@ -1019,7 +1017,7 @@ export function MessageList({ messages, status, retryStatus }: MessageListProps)
               isStreaming={isLastMessage && isStreaming}
               isLastStep={isLastStep}
             />
-            <MessageArtifacts message={item.message} />
+            <ArtifactList messages={[item.message]} includeTargetFallbacks={false} />
           </div>
         )
       })}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -63,6 +63,7 @@ import {
 } from "@/components/ui/message"
 import { Tool } from "@/components/ui/tool"
 import { CapabilityCallLine } from "@/components/chat/capability-call-line"
+import { ReasoningBlock } from "@/components/chat/reasoning-block"
 import { SubagentRunLine } from "@/components/chat/subagent-run-line"
 import { ToolAggregateGroup } from "@/components/chat/tool-aggregate-group"
 import {
@@ -393,13 +394,11 @@ const AssistantMessage = React.memo(
 
             if (group.kind === "reasoning") {
               return (
-                <MessageContent
+                <ReasoningBlock
                   key={`reasoning-${index}`}
-                  className="text-muted-foreground prose w-full min-w-0 flex-1 rounded-lg bg-transparent p-0"
-                  markdown
-                >
-                  {group.text}
-                </MessageContent>
+                  text={group.text}
+                  isStreaming={group.isStreaming}
+                />
               )
             }
 

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -63,6 +63,7 @@ import {
 } from "@/components/ui/message"
 import { Tool } from "@/components/ui/tool"
 import { CapabilityCallLine } from "@/components/chat/capability-call-line"
+import { SubagentRunLine } from "@/components/chat/subagent-run-line"
 import { ToolAggregateGroup } from "@/components/chat/tool-aggregate-group"
 import {
   isApplyPatchToolPart,
@@ -204,11 +205,21 @@ const ToolMessageInner = ({ part }: ToolMessageProps) => {
     return <OpenWorkSessionCreateTool part={part} />
   }
 
-  // Sub-agent runs keep the generic card until the dedicated two-line
-  // rendering lands; failed calls keep it for the reconnect/Retry flow.
-  const isFailed = part.state === "output-error"
-  if (part.type === "dynamic-tool" && !isTaskToolPart(part) && !isFailed) {
-    return <CapabilityCallLine part={part} />
+  if (isTaskToolPart(part)) {
+    return <SubagentRunLine part={part} />
+  }
+
+  // Failed calls use the same sentence line with the "failures are
+  // instructions" treatment (inline Reconnect/Retry).
+  if (part.type === "dynamic-tool") {
+    return (
+      <CapabilityCallLine
+        part={part}
+        onReconnect={onMcpReconnect}
+        onReopenAuthorization={onMcpReopenAuthorization}
+        onRetry={onMcpRetry}
+      />
+    )
   }
 
   return (

--- a/apps/app/src/components/chat/reasoning-block.tsx
+++ b/apps/app/src/components/chat/reasoning-block.tsx
@@ -1,0 +1,49 @@
+"use client"
+
+import { useState } from "react"
+import { ChevronDown } from "lucide-react"
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import { MessageContent } from "@/components/ui/message"
+import { cn } from "@/lib/utils"
+
+type ReasoningBlockProps = {
+  text: string
+  isStreaming: boolean
+  className?: string
+}
+
+/**
+ * Thinking is collapsed by default — a single "Thinking… / Thought"
+ * line with a chevron; the full reasoning renders as markdown only
+ * when the user opens it.
+ */
+export function ReasoningBlock({ text, isStreaming, className }: ReasoningBlockProps) {
+  const [open, setOpen] = useState(false)
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className={cn("w-full", className)} data-reasoning-block="">
+      <CollapsibleTrigger className="group flex cursor-pointer items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground">
+        <span className={cn(isStreaming && "animate-pulse")}>
+          {isStreaming ? "Thinking…" : "Thought"}
+        </span>
+        <ChevronDown
+          aria-hidden="true"
+          className="size-3.5 text-muted-foreground/70 transition-transform duration-150 group-data-panel-open:rotate-180"
+        />
+      </CollapsibleTrigger>
+      <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
+        <MessageContent
+          markdown
+          className="text-muted-foreground prose mt-1 w-full min-w-0 rounded-lg bg-transparent p-0 text-sm"
+        >
+          {text}
+        </MessageContent>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/apps/app/src/components/chat/subagent-run-line.tsx
+++ b/apps/app/src/components/chat/subagent-run-line.tsx
@@ -51,19 +51,17 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
         aria-label={open ? `${title}. Hide details` : `${title}. Show details`}
       >
         <span className="flex min-w-0 items-center gap-2">
-          <span className="flex size-3.5 shrink-0 items-center justify-center">
-            {inFlight ? (
+          {inFlight ? (
+            <span className="flex size-3.5 shrink-0 items-center justify-center">
               <DotMatrixLoader label={`${title} — ${agent}`} className="text-muted-foreground" />
-            ) : (
-              <span aria-hidden="true" className="size-1.5 rounded-full bg-muted-foreground/60" />
-            )}
-          </span>
+            </span>
+          ) : null}
           <span className="min-w-0 truncate">
             {title}
             <span className="text-muted-foreground/70"> · {agent} agent</span>
           </span>
         </span>
-        <span className="min-w-0 truncate ps-5.5 text-xs text-muted-foreground/70">
+        <span className={cn("min-w-0 truncate text-xs text-muted-foreground/70", inFlight && "ps-5.5")}>
           {isFailed ? `Failed — ${status}` : status}
           {!inFlight && !isFailed && duration ? ` · ${duration}` : ""}
         </span>

--- a/apps/app/src/components/chat/subagent-run-line.tsx
+++ b/apps/app/src/components/chat/subagent-run-line.tsx
@@ -1,0 +1,103 @@
+"use client"
+
+import { useState } from "react"
+
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
+import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader"
+import type { TaskToolPart } from "@/lib/build-in-tools"
+import { isToolPartInFlight } from "@/lib/tool-activity"
+import { trackToolCallDuration } from "@/lib/tool-call-duration"
+import { cn } from "@/lib/utils"
+
+type SubagentRunLineProps = {
+  part: TaskToolPart
+  className?: string
+}
+
+function agentName(slug: string): string {
+  const words = slug.split(/[-_.\s]+/).filter(Boolean)
+  if (words.length === 0) return "Agent"
+  return words
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
+}
+
+/**
+ * Paper "Sub-agents" rule: dot-matrix while running, gray dot when done.
+ * Line 1 = task title + agent name; line 2 = live status verb or
+ * "Completed". Prompt and result live under the collapsed panel.
+ */
+export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
+  const [open, setOpen] = useState(false)
+  const inFlight = isToolPartInFlight(part)
+  const isFailed = part.state === "output-error"
+  const duration = trackToolCallDuration(part)
+  const title = part.input?.description?.trim() || "Sub-agent task"
+  const agent = agentName(part.input?.subagent_type ?? "")
+  const status = inFlight
+    ? "Working…"
+    : isFailed
+      ? part.errorText?.split("\n")[0]?.trim() || "Failed"
+      : "Completed"
+
+  return (
+    <Collapsible data-subagent-run={part.toolCallId} open={open} onOpenChange={setOpen} className={className}>
+      <CollapsibleTrigger
+        className="group flex min-w-0 max-w-full cursor-pointer flex-col gap-0.5 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
+        aria-label={open ? `${title}. Hide details` : `${title}. Show details`}
+      >
+        <span className="flex min-w-0 items-center gap-2">
+          <span className="flex size-3.5 shrink-0 items-center justify-center">
+            {inFlight ? (
+              <DotMatrixLoader label={`${title} — ${agent}`} className="text-muted-foreground" />
+            ) : (
+              <span
+                aria-hidden="true"
+                className={cn(
+                  "size-1.5 rounded-full",
+                  isFailed ? "bg-red-9" : "bg-muted-foreground/60",
+                )}
+              />
+            )}
+          </span>
+          <span className="min-w-0 truncate">
+            {title}
+            <span className="text-muted-foreground/70"> · {agent} agent</span>
+          </span>
+        </span>
+        <span
+          className={cn(
+            "min-w-0 truncate ps-5.5 text-xs",
+            isFailed ? "text-red-11" : "text-muted-foreground/70",
+          )}
+        >
+          {status}
+          {!inFlight && !isFailed && duration ? ` · ${duration}` : ""}
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
+        <div className="mt-2 flex flex-col gap-2 rounded-lg bg-muted p-2 text-xs">
+          {part.input?.prompt ? (
+            <pre className="max-h-40 overflow-auto whitespace-pre-wrap wrap-break-word">
+              {part.input.prompt}
+            </pre>
+          ) : null}
+          {part.state === "output-available" ? (
+            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
+              {part.output}
+            </pre>
+          ) : null}
+          {isFailed && part.errorText ? (
+            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word text-red-11">
+              {part.errorText}
+            </pre>
+          ) : null}
+        </div>
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}

--- a/apps/app/src/components/chat/subagent-run-line.tsx
+++ b/apps/app/src/components/chat/subagent-run-line.tsx
@@ -55,13 +55,7 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
             {inFlight ? (
               <DotMatrixLoader label={`${title} — ${agent}`} className="text-muted-foreground" />
             ) : (
-              <span
-                aria-hidden="true"
-                className={cn(
-                  "size-1.5 rounded-full",
-                  isFailed ? "bg-red-9" : "bg-muted-foreground/60",
-                )}
-              />
+              <span aria-hidden="true" className="size-1.5 rounded-full bg-muted-foreground/60" />
             )}
           </span>
           <span className="min-w-0 truncate">
@@ -69,13 +63,8 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
             <span className="text-muted-foreground/70"> · {agent} agent</span>
           </span>
         </span>
-        <span
-          className={cn(
-            "min-w-0 truncate ps-5.5 text-xs",
-            isFailed ? "text-red-11" : "text-muted-foreground/70",
-          )}
-        >
-          {status}
+        <span className="min-w-0 truncate ps-5.5 text-xs text-muted-foreground/70">
+          {isFailed ? `Failed — ${status}` : status}
           {!inFlight && !isFailed && duration ? ` · ${duration}` : ""}
         </span>
       </CollapsibleTrigger>
@@ -92,7 +81,7 @@ export function SubagentRunLine({ part, className }: SubagentRunLineProps) {
             </pre>
           ) : null}
           {isFailed && part.errorText ? (
-            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word text-red-11">
+            <pre className="max-h-60 overflow-auto whitespace-pre-wrap wrap-break-word opacity-80">
               {part.errorText}
             </pre>
           ) : null}

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -1,0 +1,152 @@
+"use client"
+
+import { useState } from "react"
+import { ChevronRight } from "lucide-react"
+
+import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader"
+import {
+  getAggregateNowLabel,
+  getAggregateRowLabel,
+  getAggregateSummary,
+  type AnyToolPart,
+} from "@/lib/tool-aggregate"
+import { isToolPartInFlight } from "@/lib/tool-activity"
+import { trackToolCallDuration } from "@/lib/tool-call-duration"
+import { cn } from "@/lib/utils"
+
+const ROW_CAP = 8
+
+/** Expansion persists per group while the session stays mounted (Paper rule). */
+const expandedByGroupKey = new Map<string, boolean>()
+const showAllByGroupKey = new Map<string, boolean>()
+
+type ToolAggregateGroupProps = {
+  parts: AnyToolPart[]
+  className?: string
+}
+
+function rowStatus(part: AnyToolPart): "running" | "failed" | "done" {
+  if (isToolPartInFlight(part)) return "running"
+  if (part.state === "output-error") return "failed"
+  return "done"
+}
+
+function failureReason(part: AnyToolPart): string | null {
+  if (part.state !== "output-error" || !part.errorText) return null
+  const firstLine = part.errorText.split("\n")[0]?.trim()
+  return firstLine ? (firstLine.length > 120 ? `${firstLine.slice(0, 119)}…` : firstLine) : null
+}
+
+/**
+ * Paper "Recurring actions · aggregate + latest": one line with live
+ * totals while running plus a self-replacing "Now:" line; past-tense
+ * summary when done. Chevron expands the chronological list — status
+ * dot, monospace action, per-item duration — capped with "Show N more".
+ */
+export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps) {
+  const groupKey = parts[0]?.toolCallId ?? "aggregate"
+  const [expanded, setExpandedState] = useState(() => expandedByGroupKey.get(groupKey) ?? false)
+  const [showAll, setShowAllState] = useState(() => showAllByGroupKey.get(groupKey) ?? false)
+
+  const setExpanded = (value: boolean) => {
+    expandedByGroupKey.set(groupKey, value)
+    setExpandedState(value)
+  }
+  const setShowAll = (value: boolean) => {
+    showAllByGroupKey.set(groupKey, value)
+    setShowAllState(value)
+  }
+
+  const anyRunning = parts.some((part) => isToolPartInFlight(part))
+  const failedCount = parts.filter((part) => part.state === "output-error").length
+  const summary = getAggregateSummary(parts, anyRunning ? "present" : "past")
+  const nowLabel = anyRunning ? getAggregateNowLabel(parts) : null
+
+  // Track durations for every part so each is frozen the moment it completes.
+  const durations = parts.map((part) => trackToolCallDuration(part))
+  const visibleParts = showAll ? parts : parts.slice(0, ROW_CAP)
+  const hiddenCount = parts.length - visibleParts.length
+
+  return (
+    <div className={className} data-tool-aggregate={groupKey}>
+      <button
+        type="button"
+        onClick={() => setExpanded(!expanded)}
+        aria-expanded={expanded}
+        className="group flex min-w-0 max-w-full cursor-pointer items-center gap-1.5 text-start text-sm text-muted-foreground transition-colors hover:text-foreground"
+      >
+        <ChevronRight
+          aria-hidden="true"
+          className={cn(
+            "size-3.5 shrink-0 text-muted-foreground/70 transition-transform duration-150",
+            expanded && "rotate-90",
+          )}
+        />
+        <span className="min-w-0 truncate">{summary}</span>
+        {failedCount > 0 ? (
+          <span className="shrink-0 text-xs text-red-11">
+            {failedCount} failed
+          </span>
+        ) : null}
+      </button>
+
+      {nowLabel ? (
+        <div className="mt-1 flex min-w-0 items-center gap-2 ps-5 text-sm text-muted-foreground">
+          <DotMatrixLoader label={nowLabel} className="text-muted-foreground" />
+          <span className="min-w-0 truncate">
+            <span className="text-muted-foreground/70">Now: </span>
+            {nowLabel}
+          </span>
+        </div>
+      ) : null}
+
+      {expanded ? (
+        <div className="mt-1.5 flex flex-col gap-1 ps-5">
+          {visibleParts.map((part, index) => {
+            const status = rowStatus(part)
+            const reason = failureReason(part)
+            return (
+              <div key={part.toolCallId} className="flex min-w-0 flex-col gap-0.5">
+                <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
+                  <span className="flex size-3.5 shrink-0 items-center justify-center">
+                    {status === "running" ? (
+                      <DotMatrixLoader label="Running" className="size-3 text-muted-foreground" />
+                    ) : (
+                      <span
+                        aria-hidden="true"
+                        className={cn(
+                          "size-1.5 rounded-full",
+                          status === "failed" ? "bg-red-9" : "bg-green-9",
+                        )}
+                      />
+                    )}
+                  </span>
+                  <span className="min-w-0 truncate font-mono text-[11px]">
+                    {getAggregateRowLabel(part)}
+                  </span>
+                  {durations[index] ? (
+                    <span className="shrink-0 tabular-nums text-muted-foreground/70">
+                      {durations[index]}
+                    </span>
+                  ) : null}
+                </div>
+                {reason ? (
+                  <div className="ps-5.5 text-[11px] text-red-11">{reason}</div>
+                ) : null}
+              </div>
+            )
+          })}
+          {hiddenCount > 0 ? (
+            <button
+              type="button"
+              onClick={() => setShowAll(true)}
+              className="w-fit ps-5.5 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+            >
+              Show {hiddenCount} more
+            </button>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  )
+}

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -112,19 +112,11 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
             return (
               <div key={part.toolCallId} className="flex min-w-0 flex-col gap-0.5">
                 <div className="flex min-w-0 items-center gap-2 text-xs text-muted-foreground">
-                  <span className="flex size-3.5 shrink-0 items-center justify-center">
-                    {status === "running" ? (
+                  {status === "running" ? (
+                    <span className="flex size-3.5 shrink-0 items-center justify-center">
                       <DotMatrixLoader label="Running" className="size-3 text-muted-foreground" />
-                    ) : (
-                      <span
-                        aria-hidden="true"
-                        className={cn(
-                          "size-1.5 rounded-full bg-muted-foreground",
-                          status === "failed" ? "opacity-90" : "opacity-60",
-                        )}
-                      />
-                    )}
-                  </span>
+                    </span>
+                  ) : null}
                   {(() => {
                     const file = getAggregateRowFile(part)
                     if (!file) {
@@ -155,7 +147,7 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
                   ) : null}
                 </div>
                 {reason ? (
-                  <div className="ps-5.5 text-[11px] text-muted-foreground">failed — {reason}</div>
+                  <div className="text-[11px] text-muted-foreground">failed — {reason}</div>
                 ) : null}
               </div>
             )
@@ -164,7 +156,7 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
             <button
               type="button"
               onClick={() => setShowAll(true)}
-              className="w-fit ps-5.5 text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
+              className="w-fit text-xs text-muted-foreground underline-offset-2 hover:text-foreground hover:underline"
             >
               Show {hiddenCount} more
             </button>

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -84,7 +84,7 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
         />
         <span className="min-w-0 truncate">{summary}</span>
         {failedCount > 0 ? (
-          <span className="shrink-0 text-xs text-red-11">
+          <span className="shrink-0 text-xs text-muted-foreground">
             {failedCount} failed
           </span>
         ) : null}
@@ -115,8 +115,8 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
                       <span
                         aria-hidden="true"
                         className={cn(
-                          "size-1.5 rounded-full",
-                          status === "failed" ? "bg-red-9" : "bg-green-9",
+                          "size-1.5 rounded-full bg-muted-foreground",
+                          status === "failed" ? "opacity-90" : "opacity-60",
                         )}
                       />
                     )}
@@ -131,7 +131,7 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
                   ) : null}
                 </div>
                 {reason ? (
-                  <div className="ps-5.5 text-[11px] text-red-11">{reason}</div>
+                  <div className="ps-5.5 text-[11px] text-muted-foreground">failed — {reason}</div>
                 ) : null}
               </div>
             )

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -4,8 +4,11 @@ import { useState } from "react"
 import { ChevronRight } from "lucide-react"
 
 import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader"
+import { useOpenArtifactPath } from "@/lib/artifacts"
 import {
+  fileName,
   getAggregateNowLabel,
+  getAggregateRowFile,
   getAggregateRowLabel,
   getAggregateSummary,
   type AnyToolPart,
@@ -45,6 +48,7 @@ function failureReason(part: AnyToolPart): string | null {
  */
 export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps) {
   const groupKey = parts[0]?.toolCallId ?? "aggregate"
+  const openArtifactPath = useOpenArtifactPath()
   const [expanded, setExpandedState] = useState(() => expandedByGroupKey.get(groupKey) ?? false)
   const [showAll, setShowAllState] = useState(() => showAllByGroupKey.get(groupKey) ?? false)
 
@@ -121,9 +125,29 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
                       />
                     )}
                   </span>
-                  <span className="min-w-0 truncate font-mono text-[11px]">
-                    {getAggregateRowLabel(part)}
-                  </span>
+                  {(() => {
+                    const file = getAggregateRowFile(part)
+                    if (!file) {
+                      return (
+                        <span className="min-w-0 truncate font-mono text-[11px]">
+                          {getAggregateRowLabel(part)}
+                        </span>
+                      )
+                    }
+                    return (
+                      <button
+                        type="button"
+                        onClick={() => openArtifactPath(file.path)}
+                        title={file.path}
+                        className="flex min-w-0 cursor-pointer items-baseline gap-1.5 text-start transition-colors hover:text-foreground"
+                      >
+                        <span className="shrink-0">{file.verb}</span>
+                        <span className="min-w-0 truncate font-mono text-[11px] underline-offset-2 hover:underline">
+                          {fileName(file.path)}
+                        </span>
+                      </button>
+                    )
+                  })()}
                   {durations[index] ? (
                     <span className="shrink-0 tabular-nums text-muted-foreground/70">
                       {durations[index]}

--- a/apps/app/src/components/chat/tool-aggregate-group.tsx
+++ b/apps/app/src/components/chat/tool-aggregate-group.tsx
@@ -3,10 +3,9 @@
 import { useState } from "react"
 import { ChevronRight } from "lucide-react"
 
+import { FileChip } from "@/components/chat/file-chip"
 import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader"
-import { useOpenArtifactPath } from "@/lib/artifacts"
 import {
-  fileName,
   getAggregateNowLabel,
   getAggregateRowFile,
   getAggregateRowLabel,
@@ -48,7 +47,6 @@ function failureReason(part: AnyToolPart): string | null {
  */
 export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps) {
   const groupKey = parts[0]?.toolCallId ?? "aggregate"
-  const openArtifactPath = useOpenArtifactPath()
   const [expanded, setExpandedState] = useState(() => expandedByGroupKey.get(groupKey) ?? false)
   const [showAll, setShowAllState] = useState(() => showAllByGroupKey.get(groupKey) ?? false)
 
@@ -127,17 +125,10 @@ export function ToolAggregateGroup({ parts, className }: ToolAggregateGroupProps
                       )
                     }
                     return (
-                      <button
-                        type="button"
-                        onClick={() => openArtifactPath(file.path)}
-                        title={file.path}
-                        className="flex min-w-0 cursor-pointer items-baseline gap-1.5 text-start transition-colors hover:text-foreground"
-                      >
+                      <span className="flex min-w-0 items-center gap-1.5">
                         <span className="shrink-0">{file.verb}</span>
-                        <span className="min-w-0 truncate font-mono text-[11px] underline-offset-2 hover:underline">
-                          {fileName(file.path)}
-                        </span>
-                      </button>
+                        <FileChip path={file.path} className="min-w-0" />
+                      </span>
                     )
                   })()}
                   {durations[index] ? (

--- a/apps/app/src/components/chat/utils.ts
+++ b/apps/app/src/components/chat/utils.ts
@@ -203,7 +203,10 @@ export function getAssistantRenderGroups(
 
     const previous = groups.at(-1)
     if (previous?.kind === "reasoning") {
-      previous.text += part.text
+      // Each reasoning part is its own section (often opening with a bold
+      // "**Title**"); joining without a break glues that title onto the
+      // previous paragraph's last sentence.
+      previous.text += previous.text && part.text.trim() ? `\n\n${part.text}` : part.text
       previous.isStreaming = previous.isStreaming || part.state === "streaming"
       return
     }

--- a/apps/app/src/components/chat/utils.ts
+++ b/apps/app/src/components/chat/utils.ts
@@ -1,5 +1,6 @@
 import { isReasoningUIPart, isToolUIPart, type DynamicToolUIPart, type FileUIPart, type ToolUIPart, type UIMessage } from "ai"
 import type { ThreadStatus } from "@/lib/messages"
+import { isAggregatableToolPart } from "@/lib/tool-aggregate"
 
 const DOCX_MIME = "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
 const PPTX_MIME = "application/vnd.openxmlformats-officedocument.presentationml.presentation"
@@ -142,6 +143,37 @@ type AssistantRenderGroup =
   | { kind: "reasoning"; text: string; isStreaming: boolean }
   | { kind: "file"; part: FileUIPart }
   | { kind: "tool"; part: ToolUIPart | DynamicToolUIPart }
+  | { kind: "tool-aggregate"; parts: (ToolUIPart | DynamicToolUIPart)[] }
+
+/**
+ * Steps often arrive as one assistant message per tool call. When a
+ * message contains nothing but aggregatable tool parts (plus step
+ * markers / hidden reasoning), return those parts so consecutive
+ * messages can merge into one aggregate line. Prose breaks the run.
+ */
+export function getAggregateOnlyParts(
+  message: UIMessage,
+  showThinking: boolean
+): (ToolUIPart | DynamicToolUIPart)[] | null {
+  const tools: (ToolUIPart | DynamicToolUIPart)[] = []
+  for (const part of message.parts) {
+    if (part.type === "step-start") continue
+    if (isReasoningUIPart(part)) {
+      if (showThinking && part.text.trim()) return null
+      continue
+    }
+    if (part.type === "text") {
+      if (part.text.trim()) return null
+      continue
+    }
+    if (isToolUIPart(part) && isAggregatableToolPart(part)) {
+      tools.push(part)
+      continue
+    }
+    return null
+  }
+  return tools.length > 0 ? tools : null
+}
 
 export function getAssistantRenderGroups(
   parts: UIMessage["parts"],
@@ -202,6 +234,17 @@ export function getAssistantRenderGroups(
     }
 
     if (isToolUIPart(part)) {
+      // Paper aggregation rule: consecutive command/edit/read/search calls
+      // collapse into one aggregate group; any other part breaks the run.
+      if (isAggregatableToolPart(part)) {
+        const previous = groups.at(-1)
+        if (previous?.kind === "tool-aggregate") {
+          previous.parts.push(part)
+        } else {
+          groups.push({ kind: "tool-aggregate", parts: [part] })
+        }
+        continue
+      }
       groups.push({ kind: "tool", part })
     }
   }

--- a/apps/app/src/components/markdown/markdown-primitive.ts
+++ b/apps/app/src/components/markdown/markdown-primitive.ts
@@ -253,10 +253,10 @@ function renderLink(profile: MarkdownProfile, href: string, title: string | null
       ? `<img src="${escapeAttribute(favicon)}" alt="" aria-hidden="true" loading="lazy" decoding="async" class="me-1 inline-block size-3.5 rounded-[3px] align-[-2px]" />`
       : "";
 
-    return `<a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8">${faviconHtml}${text}</a>`;
+    return `<a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 no-underline transition-colors hover:text-indigo-8">${faviconHtml}${text}</a>`;
   }
 
-  return `<a href="${safe}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8">${text}</a>`;
+  return `<a href="${safe}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 no-underline transition-colors hover:text-indigo-8">${text}</a>`;
 }
 
 function renderImage(profile: MarkdownProfile, href: string, title: string | null | undefined, text: string) {

--- a/apps/app/src/components/markdown/markdown-primitive.ts
+++ b/apps/app/src/components/markdown/markdown-primitive.ts
@@ -14,6 +14,8 @@ import {
 } from "@shikijs/transformers";
 import { bundledLanguages, codeToHtml } from "shiki";
 
+import { faviconUrlForHref } from "@/lib/favicon";
+
 export type MarkdownPresentation = "chat" | "surface";
 type RawHtmlMode = "passthrough" | "shiki-only";
 type ShikiThemeConfig =
@@ -246,7 +248,12 @@ function renderLink(profile: MarkdownProfile, href: string, title: string | null
       return `<span class="inline-flex items-stretch overflow-hidden rounded-md border border-border/60 bg-muted/40 text-xs font-medium text-foreground align-middle"><a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="inline-flex items-center gap-1 px-1.5 py-0.5 no-underline transition-colors hover:bg-muted">${fileIcon}${text}</a><button type="button" data-openwork-link-chevron="${originalHref}" class="inline-flex items-center border-l border-border/60 px-1 transition-colors hover:bg-muted" aria-label="Open with">${chevron}</button></span>`;
     }
 
-    return `<a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8">${text}</a>`;
+    const favicon = faviconUrlForHref(href);
+    const faviconHtml = favicon
+      ? `<img src="${escapeAttribute(favicon)}" alt="" aria-hidden="true" loading="lazy" decoding="async" class="me-1 inline-block size-3.5 rounded-[3px] align-[-2px]" />`
+      : "";
+
+    return `<a href="${safe}" data-openwork-link-href="${originalHref}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8">${faviconHtml}${text}</a>`;
   }
 
   return `<a href="${safe}"${titleAttr} target="_blank" rel="noreferrer noopener" class="text-indigo-10 underline underline-offset-2 transition-colors hover:text-indigo-8">${text}</a>`;

--- a/apps/app/src/components/tools/use-chat-tool-reconnect.ts
+++ b/apps/app/src/components/tools/use-chat-tool-reconnect.ts
@@ -1,0 +1,114 @@
+"use client"
+
+import type { DynamicToolUIPart, ToolUIPart } from "ai"
+
+import {
+  reconnectActionFromChatToolResult,
+  type ChatToolReconnectAction,
+  type ChatToolReconnectProgress,
+  type ChatToolReconnectResult,
+} from "@/components/tools/error-attribution"
+import {
+  chatMcpReconnectKey,
+  chatMcpReconnectPresentation,
+  useChatMcpReconnectStore,
+} from "@/components/tools/mcp-reconnect-state"
+
+export type ChatToolReconnectCallbacks = {
+  onReconnect?: (
+    action: ChatToolReconnectAction,
+    onProgress: (progress: ChatToolReconnectProgress) => void,
+  ) => Promise<ChatToolReconnectResult>
+  onReopenAuthorization?: (action: ChatToolReconnectAction, authorizeUrl: string) => Promise<void>
+  onRetry?: (action: ChatToolReconnectAction) => void | Promise<void>
+}
+
+/**
+ * Reconnect/Retry state for a chat tool call, shared between the generic
+ * Tool card and the sentence-style failure line. Only OpenWork Cloud
+ * capability tools can produce a reconnect action (see error-attribution).
+ */
+export function useChatToolReconnect(
+  toolPart: ToolUIPart | DynamicToolUIPart,
+  { onReconnect, onReopenAuthorization, onRetry }: ChatToolReconnectCallbacks,
+) {
+  const isError = toolPart.state === "output-error"
+  const reconnectResult = isError && toolPart.errorText
+    ? toolPart.errorText
+    : toolPart.state === "output-available" && "output" in toolPart
+      ? toolPart.output
+      : undefined
+  const reconnectAction = toolPart.type === "dynamic-tool" && reconnectResult !== undefined
+    ? reconnectActionFromChatToolResult(toolPart.toolName, reconnectResult)
+    : null
+  const reconnectKey = reconnectAction
+    ? chatMcpReconnectKey(toolPart.toolCallId, reconnectAction.connectionId)
+    : null
+  const reconnectState = useChatMcpReconnectStore((store) => (
+    reconnectKey ? store.records[reconnectKey]?.phase ?? "ready" : "ready"
+  ))
+  const reconnectError = useChatMcpReconnectStore((store) => (
+    reconnectKey ? store.records[reconnectKey]?.error ?? null : null
+  ))
+  const reconnectAuthorizeUrl = useChatMcpReconnectStore((store) => (
+    reconnectKey ? store.records[reconnectKey]?.authorizeUrl ?? null : null
+  ))
+  const setReconnectRecord = useChatMcpReconnectStore((store) => store.setRecord)
+  const reconnectPresentation = reconnectAction
+    ? chatMcpReconnectPresentation(reconnectAction, reconnectState)
+    : null
+
+  const handleReconnect = async () => {
+    if (!reconnectAction || !reconnectKey || !onReconnect) return
+    if (reconnectState === "connected") {
+      await onRetry?.(reconnectAction)
+      return
+    }
+    if (reconnectState === "authorization_opened") {
+      if (!onReopenAuthorization) return
+      if (!reconnectAuthorizeUrl) {
+        setReconnectRecord(reconnectKey, {
+          phase: "failed",
+          error: `${reconnectAction.connectionName} sign-in is no longer pending. Try reconnecting again.`,
+          authorizeUrl: null,
+        })
+        return
+      }
+      try {
+        await onReopenAuthorization(reconnectAction, reconnectAuthorizeUrl)
+        setReconnectRecord(reconnectKey, {
+          phase: "authorization_opened",
+          error: null,
+          authorizeUrl: reconnectAuthorizeUrl,
+        })
+      } catch (error) {
+        setReconnectRecord(reconnectKey, {
+          phase: "failed",
+          error: error instanceof Error ? error.message : "Could not reopen sign-in.",
+          authorizeUrl: null,
+        })
+      }
+      return
+    }
+    if (reconnectState === "opening") return
+    setReconnectRecord(reconnectKey, { phase: "opening", error: null, authorizeUrl: null })
+    try {
+      const result = await onReconnect(reconnectAction, (progress) => {
+        setReconnectRecord(reconnectKey, {
+          phase: progress.phase,
+          error: null,
+          authorizeUrl: progress.phase === "authorization_opened" ? progress.authorizeUrl : null,
+        })
+      })
+      setReconnectRecord(reconnectKey, { phase: result, error: null, authorizeUrl: null })
+    } catch (error) {
+      setReconnectRecord(reconnectKey, {
+        phase: "failed",
+        error: error instanceof Error ? error.message : "Could not reconnect this account.",
+        authorizeUrl: null,
+      })
+    }
+  }
+
+  return { reconnectAction, reconnectState, reconnectError, reconnectPresentation, handleReconnect }
+}

--- a/apps/app/src/components/ui/dot-matrix-loader.tsx
+++ b/apps/app/src/components/ui/dot-matrix-loader.tsx
@@ -1,0 +1,65 @@
+"use client"
+
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+type DotMatrixLoaderProps = React.ComponentPropsWithoutRef<"span"> & {
+  className?: string
+  label: string
+}
+
+/**
+ * Paper rendering rules: 3×3 dot-matrix is the only "living mark" for
+ * running work (sidebar rows, transcript tool lines). Frames shuffle;
+ * under prefers-reduced-motion a single static frame is shown. Dots use
+ * currentColor at two opacities so the lit/dim contrast holds in both
+ * light and dark themes.
+ */
+const FRAMES: ReadonlyArray<ReadonlyArray<number>> = [
+  [1, 0, 0, 1, 1, 0, 1, 0, 1],
+  [0, 1, 0, 1, 0, 1, 0, 1, 1],
+  [0, 0, 1, 0, 1, 1, 1, 1, 0],
+  [1, 1, 0, 0, 1, 0, 1, 0, 1],
+]
+
+export function DotMatrixLoader({ className, label, ...rest }: DotMatrixLoaderProps) {
+  const [frame, setFrame] = React.useState(0)
+  const [reduceMotion, setReduceMotion] = React.useState(false)
+
+  React.useEffect(() => {
+    const media = window.matchMedia("(prefers-reduced-motion: reduce)")
+    const sync = () => setReduceMotion(media.matches)
+    sync()
+    media.addEventListener("change", sync)
+    return () => media.removeEventListener("change", sync)
+  }, [])
+
+  React.useEffect(() => {
+    if (reduceMotion) return
+    const id = window.setInterval(() => {
+      setFrame((current) => (current + 1) % FRAMES.length)
+    }, 180)
+    return () => window.clearInterval(id)
+  }, [reduceMotion])
+
+  const pattern = FRAMES[frame] ?? FRAMES[0]
+
+  return (
+    <span
+      {...rest}
+      role="status"
+      aria-label={label}
+      title={label}
+      className={cn("inline-grid size-3.5 shrink-0 grid-cols-3 grid-rows-3 gap-px", className)}
+    >
+      {pattern.map((lit, index) => (
+        <span
+          key={index}
+          aria-hidden="true"
+          className={cn("size-full rounded-full bg-current", lit ? "opacity-90" : "opacity-25")}
+        />
+      ))}
+    </span>
+  )
+}

--- a/apps/app/src/components/ui/tool.tsx
+++ b/apps/app/src/components/ui/tool.tsx
@@ -8,17 +8,12 @@ import {
 import { Button } from "@/components/ui/button"
 import {
   attributeChatToolError,
-  reconnectActionFromChatToolResult,
   type ChatToolReconnectAction,
   type ChatToolReconnectProgress,
   type ChatToolReconnectResult,
   type ToolErrorAttribution,
 } from "@/components/tools/error-attribution"
-import {
-  chatMcpReconnectKey,
-  chatMcpReconnectPresentation,
-  useChatMcpReconnectStore,
-} from "@/components/tools/mcp-reconnect-state"
+import { useChatToolReconnect } from "@/components/tools/use-chat-tool-reconnect"
 import { getToolActivityLabel, isToolPartInFlight } from "@/lib/tool-activity"
 import { cn } from "@/lib/utils"
 import {
@@ -163,30 +158,8 @@ const Tool = ({
   const { state, input } = toolPart
   const inFlight = isToolPartInFlight(toolPart)
   const isError = state === "output-error"
-  const reconnectResult = isError && toolPart.errorText
-    ? toolPart.errorText
-    : state === "output-available" && "output" in toolPart
-      ? toolPart.output
-      : undefined
-  const reconnectAction = toolPart.type === "dynamic-tool" && reconnectResult !== undefined
-    ? reconnectActionFromChatToolResult(toolPart.toolName, reconnectResult)
-    : null
-  const reconnectKey = reconnectAction
-    ? chatMcpReconnectKey(toolPart.toolCallId, reconnectAction.connectionId)
-    : null
-  const reconnectState = useChatMcpReconnectStore((store) => (
-    reconnectKey ? store.records[reconnectKey]?.phase ?? "ready" : "ready"
-  ))
-  const reconnectError = useChatMcpReconnectStore((store) => (
-    reconnectKey ? store.records[reconnectKey]?.error ?? null : null
-  ))
-  const reconnectAuthorizeUrl = useChatMcpReconnectStore((store) => (
-    reconnectKey ? store.records[reconnectKey]?.authorizeUrl ?? null : null
-  ))
-  const setReconnectRecord = useChatMcpReconnectStore((store) => store.setRecord)
-  const reconnectPresentation = reconnectAction
-    ? chatMcpReconnectPresentation(reconnectAction, reconnectState)
-    : null
+  const { reconnectAction, reconnectState, reconnectError, reconnectPresentation, handleReconnect } =
+    useChatToolReconnect(toolPart, { onReconnect, onReopenAuthorization, onRetry })
   const errorAttribution = reconnectAction
     ? reconnectAttribution(reconnectAction, reconnectPresentation?.badgeLabel ?? "Reconnect required")
     : isError && toolPart.errorText
@@ -208,58 +181,6 @@ const Tool = ({
     : reconnectState === "authorization_opened"
       ? ExternalLink
       : RefreshCcw
-
-  const handleReconnect = async () => {
-    if (!reconnectAction || !reconnectKey || !onReconnect) return
-    if (reconnectState === "connected") {
-      await onRetry?.(reconnectAction)
-      return
-    }
-    if (reconnectState === "authorization_opened") {
-      if (!onReopenAuthorization) return
-      if (!reconnectAuthorizeUrl) {
-        setReconnectRecord(reconnectKey, {
-          phase: "failed",
-          error: `${reconnectAction.connectionName} sign-in is no longer pending. Try reconnecting again.`,
-          authorizeUrl: null,
-        })
-        return
-      }
-      try {
-        await onReopenAuthorization(reconnectAction, reconnectAuthorizeUrl)
-        setReconnectRecord(reconnectKey, {
-          phase: "authorization_opened",
-          error: null,
-          authorizeUrl: reconnectAuthorizeUrl,
-        })
-      } catch (error) {
-        setReconnectRecord(reconnectKey, {
-          phase: "failed",
-          error: error instanceof Error ? error.message : "Could not reopen sign-in.",
-          authorizeUrl: null,
-        })
-      }
-      return
-    }
-    if (reconnectState === "opening") return
-    setReconnectRecord(reconnectKey, { phase: "opening", error: null, authorizeUrl: null })
-    try {
-      const result = await onReconnect(reconnectAction, (progress) => {
-        setReconnectRecord(reconnectKey, {
-          phase: progress.phase,
-          error: null,
-          authorizeUrl: progress.phase === "authorization_opened" ? progress.authorizeUrl : null,
-        })
-      })
-      setReconnectRecord(reconnectKey, { phase: result, error: null, authorizeUrl: null })
-    } catch (error) {
-      setReconnectRecord(reconnectKey, {
-        phase: "failed",
-        error: error instanceof Error ? error.message : "Could not reconnect this account.",
-        authorizeUrl: null,
-      })
-    }
-  }
 
   const handleCopyResult = useCallback(async () => {
     if (resultText === null) return

--- a/apps/app/src/lib/artifacts.ts
+++ b/apps/app/src/lib/artifacts.ts
@@ -4,6 +4,7 @@ import * as React from "react";
 import {
   isApplyPatchToolPart,
   isEditToolPart,
+  isReadToolPart,
   isWriteToolPart,
 } from "@/lib/build-in-tools";
 import { useOpenTargets } from "@/lib/target-provider";
@@ -269,6 +270,12 @@ function getArtifactPathsFromMessage(message: UIMessage) {
       paths.push(part.input.filePath);
       continue;
     }
+
+    // Paper artifact strip covers every file "read, edited, or created".
+    if (isReadToolPart(part)) {
+      paths.push(part.input.filePath);
+      continue;
+    }
     if (isApplyPatchToolPart(part)) {
       paths.push(...parseApplyPatchPaths(part.input.patchText));
     }
@@ -354,7 +361,7 @@ export function useArtifacts(messages: UIMessage[], options: GetArtifactsOptions
 export function useOpenArtifactPath() {
   const { openTargets, onOpenTarget } = useOpenTargets();
 
-  return React.useCallback((path: string) => {
+  return React.useCallback((path: string, options?: { external?: boolean }) => {
     const normalized = normalizeArtifactPath(path);
     const target = openTargetFromArtifactPath(
       normalized,
@@ -362,7 +369,7 @@ export function useOpenArtifactPath() {
       getArtifactType(normalized),
       openTargets,
     );
-    onOpenTarget?.(target);
+    onOpenTarget?.(target, options);
   }, [onOpenTarget, openTargets]);
 }
 

--- a/apps/app/src/lib/artifacts.ts
+++ b/apps/app/src/lib/artifacts.ts
@@ -350,6 +350,22 @@ export function useArtifacts(messages: UIMessage[], options: GetArtifactsOptions
   );
 }
 
+/** Open any file path in the artifact preview panel (markdown, code, images…). */
+export function useOpenArtifactPath() {
+  const { openTargets, onOpenTarget } = useOpenTargets();
+
+  return React.useCallback((path: string) => {
+    const normalized = normalizeArtifactPath(path);
+    const target = openTargetFromArtifactPath(
+      normalized,
+      getArtifactName(normalized),
+      getArtifactType(normalized),
+      openTargets,
+    );
+    onOpenTarget?.(target);
+  }, [onOpenTarget, openTargets]);
+}
+
 export function usePreviewArtifact() {
   const { onOpenTarget } = useOpenTargets();
 

--- a/apps/app/src/lib/capability-call.ts
+++ b/apps/app/src/lib/capability-call.ts
@@ -1,0 +1,207 @@
+import type { DynamicToolUIPart } from "ai"
+
+import { isToolPartInFlight } from "@/lib/tool-activity"
+
+/**
+ * Paper rendering rules — "Capability calls → sentences":
+ * never render raw JSON. Map connection name → service ("Granola"),
+ * tool name → verb ("Asking about…"), body.query → quoted plain text.
+ * IDs and schema digests live under "Technical details", collapsed.
+ */
+
+export type CapabilityCallSentence = {
+  /** Human service name, e.g. "Granola" or "OpenWork Cloud". */
+  service: string | null
+  /** Present-tense line while the call runs. */
+  present: string
+  /** Past-tense line once the call completed. */
+  past: string
+}
+
+const PAST_TENSE: Record<string, string> = {
+  ask: "Asked",
+  search: "Searched",
+  find: "Found",
+  get: "Fetched",
+  fetch: "Fetched",
+  list: "Listed",
+  read: "Read",
+  check: "Checked",
+  create: "Created",
+  add: "Added",
+  send: "Sent",
+  update: "Updated",
+  delete: "Deleted",
+  remove: "Removed",
+  execute: "Ran",
+  run: "Ran",
+  open: "Opened",
+}
+
+const PRESENT_TENSE: Record<string, string> = {
+  ask: "Asking",
+  search: "Searching",
+  find: "Finding",
+  get: "Fetching",
+  fetch: "Fetching",
+  list: "Listing",
+  read: "Reading",
+  check: "Checking",
+  create: "Creating",
+  add: "Adding",
+  send: "Sending",
+  update: "Updating",
+  delete: "Deleting",
+  remove: "Removing",
+  execute: "Running",
+  run: "Running",
+  open: "Opening",
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function titleCase(slug: string): string {
+  return slug
+    .split(/[-_.\s]+/)
+    .filter(Boolean)
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(" ")
+}
+
+function humanize(slug: string): string {
+  return slug.split(/[-_.\s]+/).filter(Boolean).join(" ")
+}
+
+function truncate(text: string, max: number): string {
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text
+}
+
+/** Pull a short human query out of a capability call input, if one exists. */
+function extractQuery(input: unknown): string | null {
+  if (!isRecord(input)) return null
+  const direct = input.query ?? input.q ?? input.search ?? input.prompt
+  if (typeof direct === "string" && direct.trim()) return truncate(direct.trim(), 80)
+  const body = input.body
+  if (isRecord(body)) {
+    const nested = body.query ?? body.q ?? body.search ?? body.prompt ?? body.question
+    if (typeof nested === "string" && nested.trim()) return truncate(nested.trim(), 80)
+  }
+  return null
+}
+
+/** "granola.ask-about-meetings" or "granola/ask_about_meetings" → parts. */
+function splitCapabilityName(name: string): { service: string; action: string } | null {
+  const separator = name.includes(".") ? "." : name.includes("/") ? "/" : null
+  if (!separator) return null
+  const index = name.indexOf(separator)
+  const service = name.slice(0, index)
+  const action = name.slice(index + 1)
+  if (!service || !action) return null
+  return { service: titleCase(service), action }
+}
+
+function verbPhrase(action: string, tense: "present" | "past"): string {
+  const words = action.split(/[-_.\s]+/).filter(Boolean)
+  const first = words[0]?.toLowerCase()
+  const mapped = first ? (tense === "past" ? PAST_TENSE[first] : PRESENT_TENSE[first]) : undefined
+  if (mapped) {
+    return [mapped, ...words.slice(1)].join(" ")
+  }
+  const prefix = tense === "past" ? "Used" : "Using"
+  return `${prefix} ${humanize(action)}`
+}
+
+/**
+ * Build the human sentence for a dynamic (MCP / capability) tool call.
+ * Tool names follow "{connection}_{tool}", e.g.
+ * "openwork-cloud_search_capabilities".
+ */
+export function getCapabilityCallSentence(part: DynamicToolUIPart): CapabilityCallSentence {
+  const toolName = part.toolName
+  const query = extractQuery(part.input)
+  const quoted = query ? ` “${query}”` : ""
+
+  if (toolName.endsWith("search_capabilities")) {
+    return {
+      service: null,
+      present: `Searching your connections for${quoted || " capabilities"}`,
+      past: `Searched your connections for${quoted || " capabilities"}`,
+    }
+  }
+
+  if (toolName.endsWith("execute_capability")) {
+    const name = isRecord(part.input) && typeof part.input.name === "string" ? part.input.name : null
+    const split = name ? splitCapabilityName(name) : null
+    if (split) {
+      const suffix = quoted ? ` —${quoted}` : ""
+      return {
+        service: split.service,
+        present: `${verbPhrase(split.action, "present")} · ${split.service}${suffix}`,
+        past: `${verbPhrase(split.action, "past")} · ${split.service}${suffix}`,
+      }
+    }
+    return {
+      service: null,
+      present: `Running a capability${quoted ? ` for${quoted}` : ""}`,
+      past: `Ran a capability${quoted ? ` for${quoted}` : ""}`,
+    }
+  }
+
+  // Generic "{connection}_{tool}" MCP tools.
+  const underscore = toolName.indexOf("_")
+  if (underscore > 0) {
+    const service = titleCase(toolName.slice(0, underscore))
+    const action = toolName.slice(underscore + 1)
+    const suffix = quoted ? ` —${quoted}` : ""
+    return {
+      service,
+      present: `${verbPhrase(action, "present")} · ${service}${suffix}`,
+      past: `${verbPhrase(action, "past")} · ${service}${suffix}`,
+    }
+  }
+
+  const suffix = quoted ? ` —${quoted}` : ""
+  return {
+    service: null,
+    present: `${verbPhrase(toolName, "present")}${suffix}`,
+    past: `${verbPhrase(toolName, "past")}${suffix}`,
+  }
+}
+
+/**
+ * Client-side duration tracking. Tool parts carry no timing metadata, so
+ * we record when a call is first seen in flight and freeze the elapsed
+ * time on completion. Restored history (never seen running) gets no
+ * duration rather than a fabricated one.
+ */
+const startedAtByCallId = new Map<string, number>()
+const durationByCallId = new Map<string, number>()
+
+export function trackCapabilityCallDuration(part: DynamicToolUIPart): string | null {
+  const callId = part.toolCallId
+  const frozen = durationByCallId.get(callId)
+  if (frozen !== undefined) return formatDuration(frozen)
+
+  if (isToolPartInFlight(part)) {
+    if (!startedAtByCallId.has(callId)) startedAtByCallId.set(callId, Date.now())
+    return null
+  }
+
+  const startedAt = startedAtByCallId.get(callId)
+  if (startedAt === undefined) return null
+  const elapsed = Date.now() - startedAt
+  durationByCallId.set(callId, elapsed)
+  startedAtByCallId.delete(callId)
+  return formatDuration(elapsed)
+}
+
+function formatDuration(ms: number): string {
+  const seconds = ms / 1000
+  if (seconds < 10) return `${Math.max(0.1, Number(seconds.toFixed(1)))}s`
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  const minutes = Math.floor(seconds / 60)
+  const rest = Math.round(seconds % 60)
+  return `${minutes}m ${rest}s`
+}

--- a/apps/app/src/lib/capability-call.ts
+++ b/apps/app/src/lib/capability-call.ts
@@ -89,16 +89,24 @@ function truncate(text: string, max: number): string {
 }
 
 /** Pull a short human query out of a capability call input, if one exists. */
-function extractQuery(input: unknown): string | null {
+function extractQuery(input: unknown, max = 80): string | null {
   if (!isRecord(input)) return null
   const direct = input.query ?? input.q ?? input.search ?? input.prompt
-  if (typeof direct === "string" && direct.trim()) return truncate(direct.trim(), 80)
+  if (typeof direct === "string" && direct.trim()) return truncate(direct.trim(), max)
   const body = input.body
   if (isRecord(body)) {
-    const nested = body.query ?? body.q ?? body.search ?? body.prompt ?? body.question
-    if (typeof nested === "string" && nested.trim()) return truncate(nested.trim(), 80)
+    const nested = body.query ?? body.q ?? body.search ?? body.prompt ?? body.question ?? body.message ?? body.text
+    if (typeof nested === "string" && nested.trim()) return truncate(nested.trim(), max)
   }
   return null
+}
+
+/**
+ * Full natural-language ask behind a capability call, for the failed-call
+ * card's quote block (Paper "Failed Call Card" · Query Quote).
+ */
+export function getCapabilityCallQuote(part: DynamicToolUIPart): string | null {
+  return extractQuery(part.input, 280)
 }
 
 /** "granola.ask-about-meetings" or "granola/ask_about_meetings" → parts. */
@@ -128,9 +136,12 @@ function verbPhrase(action: string, tense: "present" | "past"): string {
  * Tool names follow "{connection}_{tool}", e.g.
  * "openwork-cloud_search_capabilities".
  */
-export function getCapabilityCallSentence(part: DynamicToolUIPart): CapabilityCallSentence {
+export function getCapabilityCallSentence(
+  part: DynamicToolUIPart,
+  options?: { includeQuery?: boolean },
+): CapabilityCallSentence {
   const toolName = part.toolName
-  const query = extractQuery(part.input)
+  const query = options?.includeQuery === false ? null : extractQuery(part.input)
   const quoted = query ? ` “${query}”` : ""
 
   if (toolName.endsWith("search_capabilities")) {

--- a/apps/app/src/lib/capability-call.ts
+++ b/apps/app/src/lib/capability-call.ts
@@ -1,7 +1,5 @@
 import type { DynamicToolUIPart } from "ai"
 
-import { isToolPartInFlight } from "@/lib/tool-activity"
-
 /**
  * Paper rendering rules — "Capability calls → sentences":
  * never render raw JSON. Map connection name → service ("Granola"),
@@ -170,38 +168,3 @@ export function getCapabilityCallSentence(part: DynamicToolUIPart): CapabilityCa
   }
 }
 
-/**
- * Client-side duration tracking. Tool parts carry no timing metadata, so
- * we record when a call is first seen in flight and freeze the elapsed
- * time on completion. Restored history (never seen running) gets no
- * duration rather than a fabricated one.
- */
-const startedAtByCallId = new Map<string, number>()
-const durationByCallId = new Map<string, number>()
-
-export function trackCapabilityCallDuration(part: DynamicToolUIPart): string | null {
-  const callId = part.toolCallId
-  const frozen = durationByCallId.get(callId)
-  if (frozen !== undefined) return formatDuration(frozen)
-
-  if (isToolPartInFlight(part)) {
-    if (!startedAtByCallId.has(callId)) startedAtByCallId.set(callId, Date.now())
-    return null
-  }
-
-  const startedAt = startedAtByCallId.get(callId)
-  if (startedAt === undefined) return null
-  const elapsed = Date.now() - startedAt
-  durationByCallId.set(callId, elapsed)
-  startedAtByCallId.delete(callId)
-  return formatDuration(elapsed)
-}
-
-function formatDuration(ms: number): string {
-  const seconds = ms / 1000
-  if (seconds < 10) return `${Math.max(0.1, Number(seconds.toFixed(1)))}s`
-  if (seconds < 60) return `${Math.round(seconds)}s`
-  const minutes = Math.floor(seconds / 60)
-  const rest = Math.round(seconds % 60)
-  return `${minutes}m ${rest}s`
-}

--- a/apps/app/src/lib/capability-call.ts
+++ b/apps/app/src/lib/capability-call.ts
@@ -60,6 +60,18 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value)
 }
 
+/** Tool outputs arrive as objects or JSON strings depending on transport. */
+export function parseRecord(value: unknown): Record<string, unknown> | null {
+  if (isRecord(value)) return value
+  if (typeof value !== "string") return null
+  try {
+    const parsed: unknown = JSON.parse(value)
+    return isRecord(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
 function titleCase(slug: string): string {
   return slug
     .split(/[-_.\s]+/)
@@ -140,6 +152,44 @@ export function getCapabilityCallSentence(part: DynamicToolUIPart): CapabilityCa
         past: `${verbPhrase(split.action, "past")} · ${split.service}${suffix}`,
       }
     }
+
+    // "plugin:plg_…:cob_…" refs are opaque; the human name only exists in
+    // the output ({ kind: "skill", plugin: "Plan My Day", … }).
+    if (name?.startsWith("plugin:")) {
+      const output = parseRecord("output" in part ? part.output : undefined)
+      const kind = typeof output?.kind === "string" ? output.kind : "plugin"
+      const pluginName = typeof output?.plugin === "string"
+        ? output.plugin
+        : typeof output?.name === "string"
+          ? humanize(output.name)
+          : null
+      const label = pluginName ? `${kind} “${pluginName}”` : `a ${kind} capability`
+      return {
+        service: pluginName,
+        present: `Using ${label}`,
+        past: `Used ${label}`,
+      }
+    }
+
+    // Native camelCase capabilities, e.g.
+    // "getCapabilitiesGoogleWorkspaceCalendarEvents".
+    if (name) {
+      const words = name.split(/(?=[A-Z])|[-_.\s]+/).filter(Boolean)
+      const first = words[0]?.toLowerCase()
+      const verbPast = first ? PAST_TENSE[first] : undefined
+      const verbPresent = first ? PRESENT_TENSE[first] : undefined
+      let rest = words.slice(1)
+      if (/^capabilit(y|ies)$/i.test(rest[0] ?? "")) rest = rest.slice(1)
+      if (verbPast && verbPresent && rest.length > 0) {
+        const phrase = rest.join(" ")
+        return {
+          service: null,
+          present: `${verbPresent} ${phrase}`,
+          past: `${verbPast} ${phrase}`,
+        }
+      }
+    }
+
     return {
       service: null,
       present: `Running a capability${quoted ? ` for${quoted}` : ""}`,

--- a/apps/app/src/lib/favicon.ts
+++ b/apps/app/src/lib/favicon.ts
@@ -1,0 +1,14 @@
+/**
+ * Paper rule "Pasted links get favicons": any http(s) URL in user or
+ * assistant text renders with the site's favicon next to it.
+ */
+export function faviconUrlForHref(href: string): string | null {
+  try {
+    const url = new URL(href)
+    if (url.protocol !== "http:" && url.protocol !== "https:") return null
+    if (!url.hostname || url.hostname === "localhost") return null
+    return `https://www.google.com/s2/favicons?domain=${encodeURIComponent(url.hostname)}&sz=32`
+  } catch {
+    return null
+  }
+}

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -1,0 +1,112 @@
+import type { DynamicToolUIPart, ToolUIPart } from "ai"
+
+import {
+  isApplyPatchToolPart,
+  isBashToolPart,
+  isEditToolPart,
+  isGlobToolPart,
+  isGrepToolPart,
+  isReadToolPart,
+  isWriteToolPart,
+} from "@/lib/build-in-tools"
+import { getToolActivityLabel, isToolPartInFlight } from "@/lib/tool-activity"
+
+export type AnyToolPart = ToolUIPart | DynamicToolUIPart
+
+/**
+ * Paper "Recurring actions · aggregate + latest": consecutive tool calls
+ * of the same families (commands, file edits, reads, searches) collapse
+ * into one aggregate line. Prose from the model always breaks a group.
+ */
+export type ToolFamily = "command" | "edit" | "read" | "search"
+
+export function getToolFamily(part: AnyToolPart): ToolFamily | null {
+  if (isBashToolPart(part)) return "command"
+  if (isEditToolPart(part) || isWriteToolPart(part) || isApplyPatchToolPart(part)) return "edit"
+  if (isReadToolPart(part)) return "read"
+  if (isGrepToolPart(part) || isGlobToolPart(part)) return "search"
+  return null
+}
+
+export function isAggregatableToolPart(part: AnyToolPart): boolean {
+  return getToolFamily(part) !== null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function filePathOf(part: AnyToolPart): string | null {
+  if (!isRecord(part.input)) return null
+  const value = part.input.filePath
+  return typeof value === "string" && value ? value : null
+}
+
+function plural(count: number, singular: string, pluralForm = `${singular}s`): string {
+  return `${count} ${count === 1 ? singular : pluralForm}`
+}
+
+/**
+ * "Editing 3 files, running 8 commands" / "Edited 3 files, ran 8 commands".
+ * File counts are unique paths; searches and commands are call counts.
+ */
+export function getAggregateSummary(parts: AnyToolPart[], tense: "present" | "past"): string {
+  const commands = parts.filter((part) => getToolFamily(part) === "command").length
+  const editPaths = new Set<string>()
+  let editCalls = 0
+  const readPaths = new Set<string>()
+  let readCalls = 0
+  let searches = 0
+
+  for (const part of parts) {
+    const family = getToolFamily(part)
+    if (family === "edit") {
+      editCalls += 1
+      const path = filePathOf(part)
+      if (path) editPaths.add(path)
+    } else if (family === "read") {
+      readCalls += 1
+      const path = filePathOf(part)
+      if (path) readPaths.add(path)
+    } else if (family === "search") {
+      searches += 1
+    }
+  }
+
+  const pieces: string[] = []
+  if (editCalls > 0) {
+    const count = editPaths.size > 0 ? editPaths.size : editCalls
+    pieces.push(`${tense === "past" ? "edited" : "editing"} ${plural(count, "file")}`)
+  }
+  if (commands > 0) {
+    pieces.push(`${tense === "past" ? "ran" : "running"} ${plural(commands, "command")}`)
+  }
+  if (readCalls > 0) {
+    const count = readPaths.size > 0 ? readPaths.size : readCalls
+    pieces.push(`${tense === "past" ? "read" : "reading"} ${plural(count, "file")}`)
+  }
+  if (searches > 0) {
+    pieces.push(`${tense === "past" ? "ran" : "running"} ${plural(searches, "search", "searches")}`)
+  }
+
+  const joined = pieces.join(", ")
+  return joined.charAt(0).toUpperCase() + joined.slice(1)
+}
+
+/** Monospace action text for an expanded aggregate row. */
+export function getAggregateRowLabel(part: AnyToolPart): string {
+  if (isBashToolPart(part)) {
+    const command = part.input?.command?.trim()
+    if (command) return command.length > 96 ? `${command.slice(0, 95)}…` : command
+  }
+  return getToolActivityLabel(part)
+}
+
+/** Label for the single latest in-flight call — the self-replacing "Now:" line. */
+export function getAggregateNowLabel(parts: AnyToolPart[]): string | null {
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const part = parts[index]
+    if (part && isToolPartInFlight(part)) return getAggregateRowLabel(part)
+  }
+  return null
+}

--- a/apps/app/src/lib/tool-aggregate.ts
+++ b/apps/app/src/lib/tool-aggregate.ts
@@ -93,6 +93,25 @@ export function getAggregateSummary(parts: AnyToolPart[], tense: "present" | "pa
   return joined.charAt(0).toUpperCase() + joined.slice(1)
 }
 
+export function fileName(path: string): string {
+  const segments = path.split(/[/\\]/)
+  return segments[segments.length - 1] || path
+}
+
+/**
+ * File-family rows render as "Edited <name>" with the name clickable
+ * (absolute path stays in the tooltip, opens in the artifact view).
+ */
+export function getAggregateRowFile(part: AnyToolPart): { verb: string; path: string } | null {
+  const running = isToolPartInFlight(part)
+  const path = filePathOf(part)
+  if (!path) return null
+  if (isEditToolPart(part)) return { verb: running ? "Editing" : "Edited", path }
+  if (isWriteToolPart(part)) return { verb: running ? "Writing" : "Wrote", path }
+  if (isReadToolPart(part)) return { verb: running ? "Reading" : "Read", path }
+  return null
+}
+
 /** Monospace action text for an expanded aggregate row. */
 export function getAggregateRowLabel(part: AnyToolPart): string {
   if (isBashToolPart(part)) {

--- a/apps/app/src/lib/tool-call-duration.ts
+++ b/apps/app/src/lib/tool-call-duration.ts
@@ -1,0 +1,41 @@
+import type { DynamicToolUIPart, ToolUIPart } from "ai"
+
+import { isToolPartInFlight } from "@/lib/tool-activity"
+
+type AnyToolPart = ToolUIPart | DynamicToolUIPart
+
+/**
+ * Client-side duration tracking. Tool parts carry no timing metadata, so
+ * we record when a call is first seen in flight and freeze the elapsed
+ * time on completion. Restored history (never seen running) gets no
+ * duration rather than a fabricated one.
+ */
+const startedAtByCallId = new Map<string, number>()
+const durationByCallId = new Map<string, number>()
+
+export function trackToolCallDuration(part: AnyToolPart): string | null {
+  const callId = part.toolCallId
+  const frozen = durationByCallId.get(callId)
+  if (frozen !== undefined) return formatToolCallDuration(frozen)
+
+  if (isToolPartInFlight(part)) {
+    if (!startedAtByCallId.has(callId)) startedAtByCallId.set(callId, Date.now())
+    return null
+  }
+
+  const startedAt = startedAtByCallId.get(callId)
+  if (startedAt === undefined) return null
+  const elapsed = Date.now() - startedAt
+  durationByCallId.set(callId, elapsed)
+  startedAtByCallId.delete(callId)
+  return formatToolCallDuration(elapsed)
+}
+
+export function formatToolCallDuration(ms: number): string {
+  const seconds = ms / 1000
+  if (seconds < 10) return `${Math.max(0.1, Number(seconds.toFixed(1)))}s`
+  if (seconds < 60) return `${Math.round(seconds)}s`
+  const minutes = Math.floor(seconds / 60)
+  const rest = Math.round(seconds % 60)
+  return `${minutes}m ${rest}s`
+}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,7 +2,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { ArrowLeft, ArrowRight, Cloud, Columns2, FileText, Globe, Mic2, Settings2, TextSearch, X, Zap } from "lucide-react";
+import { Cloud, Columns2, FileText, Globe, Mic2, Settings2, TextSearch, X, Zap } from "lucide-react";
 
 import { resolveExtensionIconSrc } from "@/react-app/design-system/extension-icon-src";
 import { t } from "../../../../i18n";
@@ -1021,6 +1021,11 @@ export function SessionPage(props: SessionPageProps) {
           onForgetWorkspace={props.sidebar.onForgetWorkspace}
           onOpenCreateWorkspace={props.sidebar.onOpenCreateWorkspace}
           onOpenSessionSearch={props.sidebar.onOpenSessionSearch}
+          conversationHistory={{
+            canGoBack: canGoBackInConversationHistory,
+            canGoForward: canGoForwardInConversationHistory,
+            onNavigate: navigateConversationHistory,
+          }}
           onReorderWorkspaces={props.sidebar.onReorderWorkspaces}
           onStartResize={startLeftSidebarResize}
         />
@@ -1157,46 +1162,6 @@ export function SessionPage(props: SessionPageProps) {
                 <div className="flex h-full min-h-0 flex-col">
                   {sessionTabs.length > 0 ? (
                     <div className="flex h-10 shrink-0 items-center gap-1 border-b border-border bg-background/80 px-2 mac:backdrop-blur-xl">
-                      <div className="flex shrink-0 items-center gap-0.5 pr-1" role="group" aria-label="Conversation history controls">
-                        <Tooltip>
-                          <TooltipTrigger
-                            render={
-                              <Button
-                                variant="ghost"
-                                size="icon-xs"
-                                className="rounded-lg text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40"
-                                aria-label="Back in conversation history"
-                                title="Back in conversation history"
-                                data-conversation-history-control="back"
-                                disabled={!canGoBackInConversationHistory}
-                                onClick={() => navigateConversationHistory("back")}
-                              >
-                                <ArrowLeft size={14} />
-                              </Button>
-                            }
-                          />
-                          <TooltipContent>Back in conversation history</TooltipContent>
-                        </Tooltip>
-                        <Tooltip>
-                          <TooltipTrigger
-                            render={
-                              <Button
-                                variant="ghost"
-                                size="icon-xs"
-                                className="rounded-lg text-dls-secondary transition-colors hover:bg-dls-hover hover:text-dls-text disabled:opacity-40"
-                                aria-label="Forward in conversation history"
-                                title="Forward in conversation history"
-                                data-conversation-history-control="forward"
-                                disabled={!canGoForwardInConversationHistory}
-                                onClick={() => navigateConversationHistory("forward")}
-                              >
-                                <ArrowRight size={14} />
-                              </Button>
-                            }
-                          />
-                          <TooltipContent>Forward in conversation history</TooltipContent>
-                        </Tooltip>
-                      </div>
                       <div className="flex min-w-0 flex-1 items-center gap-1 overflow-x-auto">
                         {sessionTabs.map((tab) => {
                           const title = sessionTitleForId(props.sidebar.workspaceSessionGroups, tab.sessionId) || t("session.default_title");

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -4,6 +4,8 @@ import {
   AlertCircle,
   Archive,
   ArchiveRestore,
+  ArrowLeft,
+  ArrowRight,
   ChevronRight,
   FolderPlus,
   MoreHorizontal,
@@ -688,6 +690,12 @@ export type AppSidebarProps = {
   onOpenCreateWorkspace: () => void;
   /** Opens the cross-session message search dialog (Cmd/Ctrl+Shift+F). */
   onOpenSessionSearch?: () => void;
+  /** Back/forward across recently viewed conversations, rendered at the top of the sidebar. */
+  conversationHistory?: {
+    canGoBack: boolean;
+    canGoForward: boolean;
+    onNavigate: (direction: "back" | "forward") => void;
+  };
   onReorderWorkspaces?: (workspaceIds: string[]) => void;
   onStartResize?: React.PointerEventHandler<HTMLButtonElement>;
 };
@@ -895,6 +903,38 @@ export function AppSidebar(props: AppSidebarProps) {
               alt="Organization logo"
               className="max-h-9 w-auto max-w-[140px] object-contain object-left"
             />
+          </div>
+        ) : null}
+        {props.conversationHistory ? (
+          <div
+            className="flex shrink-0 items-center gap-0.5 px-3 pb-1"
+            role="group"
+            aria-label="Conversation history controls"
+          >
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="rounded-lg text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground disabled:opacity-40"
+              aria-label="Back in conversation history"
+              title="Back in conversation history"
+              data-conversation-history-control="back"
+              disabled={!props.conversationHistory.canGoBack}
+              onClick={() => props.conversationHistory?.onNavigate("back")}
+            >
+              <ArrowLeft size={14} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon-xs"
+              className="rounded-lg text-sidebar-foreground/60 transition-colors hover:text-sidebar-foreground disabled:opacity-40"
+              aria-label="Forward in conversation history"
+              title="Forward in conversation history"
+              data-conversation-history-control="forward"
+              disabled={!props.conversationHistory.canGoForward}
+              onClick={() => props.conversationHistory?.onNavigate("forward")}
+            >
+              <ArrowRight size={14} />
+            </Button>
           </div>
         ) : null}
         {props.onOpenSessionSearch ? (

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -907,7 +907,7 @@ export function AppSidebar(props: AppSidebarProps) {
         ) : null}
         {props.conversationHistory ? (
           <div
-            className="flex shrink-0 items-center gap-0.5 px-3 pb-1"
+            className="flex shrink-0 items-center justify-end gap-0.5 px-2 pb-1 mac:-mt-11 mac:pb-2"
             role="group"
             aria-label="Conversation history controls"
           >

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1454,7 +1454,7 @@ function WorkspaceSidebarGroup({
                           const full = [...ids, ...allRootIds.filter((id) => !visible.has(id))];
                           store.getState().reorderSessions(workspace.id, full);
                         }}
-                        className="flex flex-col"
+                        className="flex flex-col gap-1"
                       >
                         {sessionRows.map((row) => (
                           <SessionMenuItem
@@ -1919,7 +1919,7 @@ function GroupedSessionList({ sessionRows, groups, assignments, pinnedIds, tree,
                   const full = allRootIds.map((id) => ungroupedSet.has(id) ? fullUngrouped[ui++] : id);
                   store.getState().reorderSessions(workspaceId, full);
                 }}
-                className="flex flex-col"
+                className="flex flex-col gap-1"
               >
                 {visibleUngroupedRows.map((row) => (
                   <React.Fragment key={row.session.id}>
@@ -1997,7 +1997,7 @@ function SessionGroupSection({ group, rows, expanded, workspaceId, store, render
             workspaceId={workspaceId}
             onTitlePointerDown={(event) => dragControls.start(event)}
           />
-          <CollapsibleContent>
+          <CollapsibleContent className="flex flex-col gap-1">
             {visibleRows.length > 0
               ? (
                 <>

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -2098,7 +2098,7 @@ function SessionMenuItem({
     // (light: --ow-light-hover ≈ black/5, dark: #FFFFFF17 ≈ white/9).
     // The left activity slot is the indent — dot-matrix sits in the chevron
     // lane and the title starts in the group-label lane without shifting.
-    "relative rounded-[11px] transition-[padding,background-color] duration-75 ps-3 pe-7 group-hover/menu-sub-item:pe-20 group-has-data-popup-open/menu-sub-item:pe-20 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] data-active:font-medium",
+    "relative rounded-[11px] transition-[padding,background-color] duration-75 ps-3 pe-7 group-hover/menu-sub-item:pe-20 group-has-data-popup-open/menu-sub-item:pe-20 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] text-sidebar-foreground/80 data-active:text-sidebar-foreground",
     depth > 0 && "ps-7",
   );
 

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -907,7 +907,7 @@ export function AppSidebar(props: AppSidebarProps) {
         ) : null}
         {props.conversationHistory ? (
           <div
-            className="flex shrink-0 items-center justify-end gap-0.5 px-2 pb-1 mac:-mt-11 mac:pb-2"
+            className="flex shrink-0 items-center justify-end gap-0.5 px-2 pb-1 mac:absolute mac:right-1.5 mac:top-[7px] mac:z-50 mac:p-0 mac:titlebar-no-drag"
             role="group"
             aria-label="Conversation history controls"
           >

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1029,7 +1029,7 @@ function GlobalPinnedSessions({ entries }: { entries: GlobalPinnedSessionEntry[]
         </div>
         <SidebarMenu>
           <SidebarMenuItem>
-            <SidebarMenuSub>
+            <SidebarMenuSub className="gap-1">
               {entries.map((entry) => (
                 <GlobalPinnedSessionTree
                   key={`${entry.group.workspace.id}:${entry.sessionId}`}
@@ -1075,7 +1075,7 @@ function GlobalArchivedSessions({ entries }: { entries: GlobalArchivedSessionEnt
           <CollapsibleContent>
             <SidebarMenu>
               <SidebarMenuItem>
-                <SidebarMenuSub>
+                <SidebarMenuSub className="gap-1">
                   {entries.map((entry) => (
                     <GlobalArchivedSessionItem
                       key={`${entry.group.workspace.id}:${entry.session.id}`}
@@ -1406,7 +1406,7 @@ function WorkspaceSidebarGroup({
             </div>
 
             <CollapsibleContent className="pt-px">
-              <SidebarMenuSub>
+              <SidebarMenuSub className="gap-1">
                 {showRemoteConnectionIssue ? (
                   <RemoteConnectionIssueCard
                     message={connectionIssueMessage}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -2062,11 +2062,10 @@ function SessionMenuItem({
     depth > 0 && "ps-7",
   );
 
+  // Pinned/archived rows identify their workspace via the tooltip title
+  // only — no workspace color dot in these sections.
   const leading = (
-    <>
-      <SessionLoadingIndicator status={sessionActivityStatus} isActiveWork={resolvedActiveWork} />
-      {workspaceName ? <WorkspaceIcon workspaceId={workspaceId} sizeClass="size-3.5" /> : null}
-    </>
+    <SessionLoadingIndicator status={sessionActivityStatus} isActiveWork={resolvedActiveWork} />
   );
 
   const trailing = (

--- a/apps/app/src/react-app/domains/session/sidebar/session-dot-matrix-loader.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/session-dot-matrix-loader.tsx
@@ -1,6 +1,5 @@
 /** @jsxImportSource react */
-import * as React from "react";
-
+import { DotMatrixLoader } from "@/components/ui/dot-matrix-loader";
 import { cn } from "@/lib/utils";
 
 type SessionDotMatrixLoaderProps = {
@@ -8,59 +7,13 @@ type SessionDotMatrixLoaderProps = {
   label: string;
 };
 
-/**
- * Paper interaction notes: 3×3 frames shuffle in the fixed left activity
- * slot (~14–16px). Under prefers-reduced-motion, hold one static frame.
- * Dots use currentColor at two opacities so the lit/dim contrast from the
- * artboard (#ECECEE vs #5A5C61 on dark) holds in both themes.
- */
-const FRAMES: ReadonlyArray<ReadonlyArray<number>> = [
-  [1, 0, 0, 1, 1, 0, 1, 0, 1],
-  [0, 1, 0, 1, 0, 1, 0, 1, 1],
-  [0, 0, 1, 0, 1, 1, 1, 1, 0],
-  [1, 1, 0, 0, 1, 0, 1, 0, 1],
-];
-
+/** Sidebar left-lane activity indicator — shared dot-matrix in the fixed slot. */
 export function SessionDotMatrixLoader({ className, label }: SessionDotMatrixLoaderProps) {
-  const [frame, setFrame] = React.useState(0);
-  const [reduceMotion, setReduceMotion] = React.useState(false);
-
-  React.useEffect(() => {
-    const media = window.matchMedia("(prefers-reduced-motion: reduce)");
-    const sync = () => setReduceMotion(media.matches);
-    sync();
-    media.addEventListener("change", sync);
-    return () => media.removeEventListener("change", sync);
-  }, []);
-
-  React.useEffect(() => {
-    if (reduceMotion) return;
-    const id = window.setInterval(() => {
-      setFrame((current) => (current + 1) % FRAMES.length);
-    }, 180);
-    return () => window.clearInterval(id);
-  }, [reduceMotion]);
-
-  const pattern = FRAMES[frame] ?? FRAMES[0];
-
   return (
-    <span
+    <DotMatrixLoader
       data-session-loading-indicator
-      role="status"
-      aria-label={label}
-      title={label}
-      className={cn(
-        "inline-grid size-3.5 shrink-0 grid-cols-3 grid-rows-3 gap-px text-sidebar-foreground",
-        className,
-      )}
-    >
-      {pattern.map((lit, index) => (
-        <span
-          key={index}
-          aria-hidden="true"
-          className={cn("size-full rounded-full bg-current", lit ? "opacity-90" : "opacity-25")}
-        />
-      ))}
-    </span>
+      label={label}
+      className={cn("text-sidebar-foreground", className)}
+    />
   );
 }

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -148,6 +148,92 @@ function createMarkdownPrimitiveEvalMessages(sessionId: string) {
   return { messages, assistantMessageId };
 }
 
+/**
+ * Dev-only deterministic transcript exercising the Paper chat rules:
+ * sentence-style capability calls, aggregated tool runs, collapsed
+ * thinking, linkified bare URLs with favicons, and the FILES strip.
+ */
+function createChatTranscriptEvalMessages(sessionId: string) {
+  const now = Date.now();
+  const messages: UIMessage[] = [
+    {
+      id: `${sessionId}:eval-transcript-user`,
+      role: "user",
+      parts: [{
+        type: "text",
+        text: "Plan tomorrow around my calendar and check https://linear.app for open issues.",
+      }],
+      metadata: { opencode: { created: now } },
+    },
+    {
+      id: `${sessionId}:eval-transcript-assistant`,
+      role: "assistant",
+      parts: [
+        {
+          type: "reasoning",
+          text: "**Planning approach**\n\nCalendar first, then open issues, then draft the plan.",
+          state: "done",
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "openwork-cloud_execute_capability",
+          toolCallId: "eval-transcript-capability",
+          state: "output-available",
+          input: { name: "getCapabilitiesGoogleWorkspaceCalendarEvents", body: {} },
+          output: JSON.stringify({ events: 3 }),
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "bash",
+          toolCallId: "eval-transcript-bash-1",
+          state: "output-available",
+          input: { command: "git status --short", description: "Check repo state" },
+          output: "",
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "bash",
+          toolCallId: "eval-transcript-bash-2",
+          state: "output-available",
+          input: { command: "pnpm typecheck", description: "Typecheck the app" },
+          output: "",
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "edit",
+          toolCallId: "eval-transcript-edit-1",
+          state: "output-available",
+          input: { filePath: "/tmp/openwork-eval/plan-tomorrow.md", oldString: "", newString: "" },
+          output: "",
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "read",
+          toolCallId: "eval-transcript-read-1",
+          state: "output-available",
+          input: { filePath: "/tmp/openwork-eval/meeting-notes.md" },
+          output: "",
+        },
+        {
+          type: "dynamic-tool",
+          toolName: "granola_ask_about_meetings",
+          toolCallId: "eval-transcript-failed",
+          state: "output-error",
+          input: { body: { query: "What did we decide about pricing?" } },
+          errorText: "unauthorized",
+        },
+        {
+          type: "text",
+          text: "Your plan is drafted — details in [OpenWork](https://openworklabs.com). Search token: chat-transcript-proof.",
+        },
+      ],
+      metadata: { opencode: { created: now + 1 } },
+    },
+  ];
+
+  return { messages };
+}
+
 export type SessionSurfaceProps = {
   client: OpenworkServerClient;
   environmentClient?: OpenworkServerClient | null;
@@ -723,6 +809,23 @@ export function SessionSurface(props: SessionSurfaceProps) {
     };
   }, [props.sessionId]);
   useControlAction(props.isControlTarget ? seedMarkdownPrimitiveControlAction : null);
+  const seedChatTranscriptControlAction = useMemo<OpenworkControlAction | null>(() => {
+    if (!import.meta.env.DEV) return null;
+
+    return {
+      id: "eval.chat_transcript.seed",
+      label: "Seed chat transcript proof",
+      description: "Dev-only eval hook that renders a deterministic transcript with capability calls, aggregated tools, thinking, links, and file chips.",
+      sideEffect: "mutation",
+      disabled: !props.sessionId,
+      execute: () => {
+        const seeded = createChatTranscriptEvalMessages(props.sessionId);
+        setEvalMarkdownMessages(seeded.messages);
+        return { ok: true, messageCount: seeded.messages.length };
+      },
+    };
+  }, [props.sessionId]);
+  useControlAction(props.isControlTarget ? seedChatTranscriptControlAction : null);
   const openTargets = useMemo(() => deriveOpenTargets(renderedMessages), [renderedMessages]);
   const openTargetsFingerprint = useMemo(
     () => openTargets.map((target) => `${target.kind}:${target.value}:${target.confidence}`).join("|"),

--- a/evals/flows/chat-transcript-sentences.flow.mjs
+++ b/evals/flows/chat-transcript-sentences.flow.mjs
@@ -53,10 +53,15 @@ export default {
               const scope = anchor.closest("div");
               const favicon = anchor.querySelector("img[src*='favicons']")
                 || scope?.querySelector("img[src*='favicons']");
-              return { linkified: true, favicon: Boolean(favicon) };
+              return {
+                linkified: true,
+                favicon: Boolean(favicon),
+                decoration: getComputedStyle(anchor).textDecorationLine,
+              };
             })()`);
             ctx.assert(link?.linkified, "Bare https://linear.app in the user message is not a link.");
             ctx.assert(link?.favicon, "No favicon rendered next to the linear.app link.");
+            ctx.assert(link?.decoration === "none", `Chat links must not be underlined (got ${link?.decoration}).`);
             await ctx.expectText("Fetched Google Workspace Calendar Events");
             // Sentence line, not a JSON card: no raw braces in the visible line.
             const rawJson = await ctx.eval(`(() => {
@@ -88,6 +93,7 @@ export default {
               if (!group.textContent.includes("git status --short")) trigger.click();
               return group.textContent.includes("git status --short");
             })()`, { timeoutMs: 15_000, label: "expanded aggregate rows" });
+            await ctx.eval(`document.querySelector("[data-tool-aggregate]")?.scrollIntoView({ block: "center" })`);
           },
           assert: async () => {
             await ctx.expectText("Edited 1 file, ran 2 commands, read 1 file");
@@ -116,6 +122,9 @@ export default {
           },
           assert: async () => {
             await ctx.waitForText("Calendar first, then open issues", { timeoutMs: 10_000 });
+            await ctx.eval(`[...document.querySelectorAll("button")]
+              .find((b) => b.textContent.includes("Thought"))
+              ?.scrollIntoView({ block: "center" })`);
           },
           screenshot: {
             name: "thinking-expanded",
@@ -144,6 +153,7 @@ export default {
             await ctx.expectText("failed");
             await ctx.waitForText("What did we decide about pricing?", { timeoutMs: 10_000 });
             await ctx.expectText("Technical details");
+            await ctx.eval(`document.querySelector('[data-capability-call="granola_ask_about_meetings"]')?.scrollIntoView({ block: "center" })`);
           },
           screenshot: {
             name: "failed-call-card",
@@ -157,6 +167,19 @@ export default {
       run: async (ctx) => {
         await ctx.prove("A FILES strip lists every touched file as an openable chip", {
           voiceover: vo[4],
+          action: async () => {
+            // Collapse the failure card again so this frame is visually its own.
+            await ctx.eval(`(() => {
+              const line = document.querySelector('[data-capability-call="granola_ask_about_meetings"] button');
+              line?.click();
+              return true;
+            })()`);
+            await ctx.waitFor(
+              `!document.body.innerText.includes("What did we decide about pricing?")`,
+              { timeoutMs: 10_000, label: "failure card collapsed" },
+            );
+            await ctx.eval(`document.querySelector("[data-files-strip]")?.scrollIntoView({ block: "center" })`);
+          },
           assert: async () => {
             const strip = await ctx.eval(`(() => {
               const strip = document.querySelector("[data-files-strip]");

--- a/evals/flows/chat-transcript-sentences.flow.mjs
+++ b/evals/flows/chat-transcript-sentences.flow.mjs
@@ -1,0 +1,189 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("chat-transcript-sentences");
+
+/**
+ * Paper chat transcript rules, proven on a deterministic seeded turn
+ * (dev-only `eval.chat_transcript.seed` control action): capability calls
+ * as sentences, aggregated tool runs, collapsed thinking, linkified bare
+ * URLs with favicons, minimal failed calls, and the per-turn FILES strip.
+ */
+export default {
+  id: "chat-transcript-sentences",
+  title: "Chat transcript renders sentences, aggregates, chips — never raw JSON",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 60_000,
+      label: "control API",
+    });
+    const state = await ctx.waitFor(
+      `(() => {
+        const control = window.__openworkControl;
+        const route = control.snapshot().route;
+        if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+        const action = control.listActions().find((a) => a.id === "session.create_task");
+        if (action && !action.disabled) return "ready";
+        return null;
+      })()`,
+      { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+    );
+    return state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); this flow requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "Seeded turn renders capability sentences and linkified user URL",
+      run: async (ctx) => {
+        await ctx.control("session.create_task");
+        await ctx.waitFor(
+          `window.__openworkControl.listActions().some((a) => a.id === "eval.chat_transcript.seed" && !a.disabled)`,
+          { timeoutMs: 30_000, label: "chat transcript seed action" },
+        );
+        await ctx.control("eval.chat_transcript.seed");
+        await ctx.waitForText("Fetched Google Workspace Calendar Events", { timeoutMs: 30_000 });
+
+        await ctx.prove("Capability call reads as a sentence; the pasted link gets a favicon", {
+          voiceover: vo[0],
+          assert: async () => {
+            const link = await ctx.eval(`(() => {
+              const anchor = [...document.querySelectorAll('a[href="https://linear.app"]')][0];
+              if (!anchor) return null;
+              const scope = anchor.closest("div");
+              const favicon = anchor.querySelector("img[src*='favicons']")
+                || scope?.querySelector("img[src*='favicons']");
+              return { linkified: true, favicon: Boolean(favicon) };
+            })()`);
+            ctx.assert(link?.linkified, "Bare https://linear.app in the user message is not a link.");
+            ctx.assert(link?.favicon, "No favicon rendered next to the linear.app link.");
+            await ctx.expectText("Fetched Google Workspace Calendar Events");
+            // Sentence line, not a JSON card: no raw braces in the visible line.
+            const rawJson = await ctx.eval(`(() => {
+              const el = [...document.querySelectorAll('[data-capability-call="openwork-cloud_execute_capability"]')][0];
+              return el ? el.textContent.includes("{") : null;
+            })()`);
+            ctx.assert(rawJson === false, "Capability line leaks raw JSON while collapsed.");
+          },
+          screenshot: {
+            name: "capability-sentence-and-favicon-link",
+            requireText: ["Fetched Google Workspace Calendar Events"],
+          },
+        });
+      },
+    },
+    {
+      name: "Consecutive tool calls aggregate into one expandable line",
+      run: async (ctx) => {
+        await ctx.prove("Aggregate line summarizes the work and expands to rows with file chips", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.waitForText("Edited 1 file, ran 2 commands, read 1 file", { timeoutMs: 15_000 });
+            // Expand via the aggregate group's own trigger; clickText can hit
+            // a stale match while the transcript is still settling.
+            await ctx.waitFor(`(() => {
+              const group = document.querySelector("[data-tool-aggregate]");
+              const trigger = group?.querySelector("button");
+              if (!trigger) return false;
+              if (!group.textContent.includes("git status --short")) trigger.click();
+              return group.textContent.includes("git status --short");
+            })()`, { timeoutMs: 15_000, label: "expanded aggregate rows" });
+          },
+          assert: async () => {
+            await ctx.expectText("Edited 1 file, ran 2 commands, read 1 file");
+            await ctx.waitForText("git status --short", { timeoutMs: 10_000 });
+            await ctx.expectText("plan-tomorrow.md");
+            await ctx.expectText("meeting-notes.md");
+          },
+          screenshot: {
+            name: "aggregate-expanded-with-file-chips",
+            requireText: ["git status --short", "plan-tomorrow.md"],
+          },
+        });
+      },
+    },
+    {
+      name: "Thinking is collapsed by default and opens on demand",
+      run: async (ctx) => {
+        await ctx.prove("Reasoning hides behind a Thought toggle until clicked", {
+          voiceover: vo[2],
+          action: async () => {
+            const collapsed = await ctx.eval(
+              `!document.body.innerText.includes("Calendar first, then open issues")`,
+            );
+            ctx.assert(collapsed, "Reasoning content is visible before expanding.");
+            await ctx.clickText("Thought", { timeoutMs: 10_000 });
+          },
+          assert: async () => {
+            await ctx.waitForText("Calendar first, then open issues", { timeoutMs: 10_000 });
+          },
+          screenshot: {
+            name: "thinking-expanded",
+            requireText: ["Planning approach"],
+          },
+        });
+      },
+    },
+    {
+      name: "Failed call stays minimal and expands into the failure card",
+      run: async (ctx) => {
+        await ctx.prove("Failure is one muted line; expanding reveals quote and instruction", {
+          voiceover: vo[3],
+          action: async () => {
+            const collapsed = await ctx.eval(
+              `!document.body.innerText.includes("What did we decide about pricing?")`,
+            );
+            ctx.assert(collapsed, "Failure card content is visible before expanding.");
+            await ctx.eval(`(() => {
+              const line = document.querySelector('[data-capability-call="granola_ask_about_meetings"] button');
+              line?.click();
+              return Boolean(line);
+            })()`);
+          },
+          assert: async () => {
+            await ctx.expectText("failed");
+            await ctx.waitForText("What did we decide about pricing?", { timeoutMs: 10_000 });
+            await ctx.expectText("Technical details");
+          },
+          screenshot: {
+            name: "failed-call-card",
+            requireText: ["What did we decide about pricing?", "Technical details"],
+          },
+        });
+      },
+    },
+    {
+      name: "The turn ends with the FILES strip",
+      run: async (ctx) => {
+        await ctx.prove("A FILES strip lists every touched file as an openable chip", {
+          voiceover: vo[4],
+          assert: async () => {
+            const strip = await ctx.eval(`(() => {
+              const strip = document.querySelector("[data-files-strip]");
+              if (!strip) return null;
+              return {
+                label: strip.textContent.includes("Files"),
+                plan: strip.textContent.includes("plan-tomorrow.md"),
+                notes: strip.textContent.includes("meeting-notes.md"),
+              };
+            })()`);
+            ctx.assert(strip, "No FILES strip rendered for the seeded turn.");
+            ctx.assert(strip.label, "FILES strip is missing its label.");
+            ctx.assert(strip.plan && strip.notes, "FILES strip is missing touched file chips.");
+            // Assistant markdown link also carries a favicon.
+            const favicon = await ctx.eval(`(() => {
+              const anchor = [...document.querySelectorAll('a[href*="openworklabs.com"]')][0];
+              return Boolean(anchor && (anchor.querySelector("img[src*='favicons']")
+                || anchor.previousElementSibling?.matches?.("img[src*='favicons']")));
+            })()`);
+            ctx.assert(favicon, "Assistant markdown link has no favicon.");
+          },
+          screenshot: {
+            name: "files-strip",
+            requireText: ["FILES", "plan-tomorrow.md"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/chat-transcript-sentences.flow.mjs
+++ b/evals/flows/chat-transcript-sentences.flow.mjs
@@ -36,6 +36,14 @@ export default {
     {
       name: "Seeded turn renders capability sentences and linkified user URL",
       run: async (ctx) => {
+        // Idempotency: a previous run may have left panels expanded in this
+        // renderer; a reload resets all component state before we seed.
+        await ctx.eval("location.reload()");
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after reload" });
+        await ctx.waitFor(
+          `window.__openworkControl.listActions().some((a) => a.id === "session.create_task" && !a.disabled)`,
+          { timeoutMs: 30_000, label: "task creation ready" },
+        );
         await ctx.control("session.create_task");
         await ctx.waitFor(
           `window.__openworkControl.listActions().some((a) => a.id === "eval.chat_transcript.seed" && !a.disabled)`,
@@ -94,6 +102,13 @@ export default {
               return group.textContent.includes("git status --short");
             })()`, { timeoutMs: 15_000, label: "expanded aggregate rows" });
             await ctx.eval(`document.querySelector("[data-tool-aggregate]")?.scrollIntoView({ block: "center" })`);
+            // The rows reveal with a height transition; wait until the command
+            // row is actually laid out, or the frame can double the previous.
+            await ctx.waitFor(`(() => {
+              const leaf = [...document.querySelectorAll("[data-tool-aggregate] *")]
+                .find((node) => node.childElementCount === 0 && node.textContent.includes("git status --short"));
+              return Boolean(leaf && leaf.getClientRects().length > 0);
+            })()`, { timeoutMs: 10_000, label: "aggregate rows painted" });
           },
           assert: async () => {
             await ctx.expectText("Edited 1 file, ran 2 commands, read 1 file");

--- a/evals/voiceovers/chat-transcript-sentences.md
+++ b/evals/voiceovers/chat-transcript-sentences.md
@@ -1,0 +1,11 @@
+# chat-transcript-sentences — The transcript reads like sentences, not JSON
+
+1. I ask for a plan and drop a plain link in my message. The link comes back clickable with the site's favicon next to it, and the calendar lookup shows up as a plain sentence — "Fetched Google Workspace Calendar Events" — instead of a JSON card.
+
+2. The routine tool work collapses into a single line that says what happened — files edited, commands run, files read. When I expand it, I see each command in order and every touched file as a small chip I can click.
+
+3. The model's thinking stays out of my way: a collapsed "Thought" toggle by default. One click and the full reasoning opens right where it belongs.
+
+4. A failed call stays calm — one muted line with a small "failed" tag. Expanding it shows the failure card: what was being asked, in my words, and one clear instruction about what to do next, with the raw payload tucked under Technical details.
+
+5. The turn ends with a FILES strip — every file this turn touched, as chips with icons, so I can open any of them without scrolling back through the transcript.


### PR DESCRIPTION
## Summary

First chunk of the Paper "08 — Chat Transcript" rendering rules:

- **Capability calls → sentences**: MCP/dynamic tool calls now render as plain muted text lines instead of icon + collapsible JSON cards. `openwork-cloud_search_capabilities` → "Searched your connections for “gmail drafts list”"; `execute_capability` maps the capability name to a service + verb; generic `{connection}_{tool}` names get the same treatment with a small verb-tense dictionary.
- **No icon per tool call**: the only living mark is the shared 3×3 dot-matrix while a call runs; completed calls show a small green dot, past-tense verb, and duration.
- **Technical details, collapsed**: tool name, call id, and raw input/output payloads move under a collapsed panel — never inline.
- **Honest durations**: measured client-side while streaming; restored history shows no duration rather than a fabricated one.
- Failed calls and sub-agent (`task`) runs intentionally keep the existing card — the reconnect/Retry flow and the two-line sub-agent treatment are the next chunks.
- `DotMatrixLoader` promoted to `components/ui/` (currentColor + reduced-motion static frame); the sidebar loader re-exports it.

## Test plan

- `pnpm --filter @openwork/app typecheck` — passes
- Verified live in the Electron app via CDP on a real session with four `openwork-cloud_search_capabilities` calls:
  - all four render as past-tense sentences with green dots, zero legacy JSON cards
  - expanding a line shows Technical details (tool name · call id, input JSON, output)
  - verified in both light and dark mode (screenshots captured for both)

Made with [Cursor](https://cursor.com)