### PR TITLE
Cover unread session markers

### DIFF
--- a/apps/app/tests/session-management-store.test.ts
+++ b/apps/app/tests/session-management-store.test.ts
@@ -7,6 +7,7 @@ const workspaceId = "workspace-1";
 function resetStore() {
   useSessionManagementStore.setState({
     pinnedIds: [],
+    unreadIds: [],
     orderByWorkspace: {},
     groupsByWorkspace: {
       [workspaceId]: {
@@ -54,5 +55,31 @@ describe("session group management", () => {
     expect(useSessionManagementStore.getState().groupsByWorkspace[workspaceId]?.assignments).toEqual({
       "session-3": "group-b",
     });
+  });
+});
+
+describe("unread session markers", () => {
+  beforeEach(resetStore);
+
+  test("markUnread is idempotent", () => {
+    useSessionManagementStore.getState().markUnread("session-1");
+    useSessionManagementStore.getState().markUnread("session-1");
+
+    expect(useSessionManagementStore.getState().unreadIds).toEqual(["session-1"]);
+  });
+
+  test("clearUnread removes only the requested session", () => {
+    useSessionManagementStore.getState().markUnread("session-1");
+    useSessionManagementStore.getState().markUnread("session-2");
+    useSessionManagementStore.getState().clearUnread("session-1");
+
+    expect(useSessionManagementStore.getState().unreadIds).toEqual(["session-2"]);
+  });
+
+  test("clearUnread on an unmarked session leaves state unchanged", () => {
+    useSessionManagementStore.getState().markUnread("session-1");
+    useSessionManagementStore.getState().clearUnread("session-2");
+
+    expect(useSessionManagementStore.getState().unreadIds).toEqual(["session-1"]);
   });
 });


### PR DESCRIPTION
<!-- open-work-snacks-run:fbbe7fc2-f6fe-4ab9-899f-44a4ad881adc -->
## Automated snack receipt

The private implementation prompt remains in the authenticated controller receipt and is intentionally omitted from this public PR.

### Exact candidate

- Base: `37e1d9bab9122f10217ee86d216aaefb0ca9c6d0`
- Head: `17550e69e236238550fa0c66bbdfa53156be2b16`
- Run: `fbbe7fc2-f6fe-4ab9-899f-44a4ad881adc`
- Proven surfaces: web, Electron

### Assertions

- electron: `app-smoke` — passed

### Checks

- [x] `pnpm evals --flow app-smoke --surface electron` — passed

### Provenance

Created by open-work-snacks. This is a draft PR; ready-for-review, review requests, merge, release, and production actions remain manual.