### PR TITLE
Cover unread session markers

### DIFF
--- a/apps/app/tests/session-management-store.test.ts
+++ b/apps/app/tests/session-management-store.test.ts
@@ -7,6 +7,7 @@ const workspaceId = "workspace-1";
 function resetStore() {
   useSessionManagementStore.setState({
     pinnedIds: [],
+    unreadIds: [],
     orderByWorkspace: {},
     groupsByWorkspace: {
       [workspaceId]: {
@@ -54,5 +55,38 @@ describe("session group management", () => {
     expect(useSessionManagementStore.getState().groupsByWorkspace[workspaceId]?.assignments).toEqual({
       "session-3": "group-b",
     });
+  });
+});
+
+describe("unread session markers", () => {
+  beforeEach(resetStore);
+
+  test("starts with no unread sessions after reset", () => {
+    expect(useSessionManagementStore.getState().unreadIds).toEqual([]);
+  });
+
+  test("markUnread is idempotent", () => {
+    const { markUnread } = useSessionManagementStore.getState();
+    markUnread("session-1");
+    markUnread("session-1");
+
+    expect(useSessionManagementStore.getState().unreadIds).toEqual(["session-1"]);
+  });
+
+  test("clearUnread removes only the requested session", () => {
+    const { markUnread, clearUnread } = useSessionManagementStore.getState();
+    markUnread("session-1");
+    markUnread("session-2");
+    clearUnread("session-1");
+
+    expect(useSessionManagementStore.getState().unreadIds).toEqual(["session-2"]);
+  });
+
+  test("clearUnread is a no-op for sessions that are not unread", () => {
+    const { markUnread, clearUnread } = useSessionManagementStore.getState();
+    markUnread("session-1");
+    clearUnread("session-2");
+
+    expect(useSessionManagementStore.getState().unreadIds).toEqual(["session-1"]);
   });
 });


### PR DESCRIPTION
<!-- open-work-snacks-run:fbbe7fc2-f6fe-4ab9-899f-44a4ad881adc -->
## Automated snack receipt

The private implementation prompt remains in the authenticated controller receipt and is intentionally omitted from this public PR.

### Exact candidate

- Base: `37e1d9bab9122f10217ee86d216aaefb0ca9c6d0`
- Head: `7775c84f4e7fdcf929f21c6067241af36ad990c5`
- Run: `fbbe7fc2-f6fe-4ab9-899f-44a4ad881adc`
- Proven surfaces: web, Electron

### Assertions

- electron: `app-smoke` — passed

### Checks

- [x] `pnpm evals --flow app-smoke --surface electron` — passed

### Provenance

Created by open-work-snacks. This is a draft PR; ready-for-review, review requests, merge, release, and production actions remain manual.