### PR TITLE
fix(enterprise-mcp): require invalid_token proof before destroying credentials

### DIFF
--- a/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
+++ b/ee/apps/den-api/src/capability-sources/enterprise-mcp-client-adapter.ts
@@ -98,6 +98,17 @@ function diagnosticSink(tracker: ExternalMcpDiagnosticTracker) {
     // still available to package consumers, but must not overwrite that richer
     // Den evidence after a response settles.
     if (event.kind === "request") return
+    if (event.kind === "credential-invalidation") {
+      console.error("external_mcp_credential_invalidated", {
+        referenceId: tracker.referenceId,
+        connectionId: event.connectionId,
+        operationPhase: event.operationPhase,
+        requestPhase: event.requestPhase,
+        httpStatus: event.httpStatus,
+        invalidToken: event.invalidToken,
+      })
+      return
+    }
     const phase = diagnosticPhase(event)
     if (event.outcome === "started") {
       tracker.begin(phase)

--- a/evals/flows/enterprise-mcp-terminal-401-guard.flow.mjs
+++ b/evals/flows/enterprise-mcp-terminal-401-guard.flow.mjs
@@ -1,0 +1,151 @@
+/**
+ * Internal demo: the terminal-401 credential guard.
+ *
+ * Production forensics showed the enterprise MCP client destroyed stored
+ * connection credentials on any unresolved 401 — including transient provider
+ * blips and background search probes — forcing users to reconnect (Notion,
+ * Stripe, Salesforce, Granola cases confirmed in the Den DB). This flow proves
+ * the new policy on the real client (requiresApp: false): evidence is claims +
+ * assertions + real command output from driving createEnterpriseMcpClient
+ * through scripted provider scenarios.
+ */
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "enterprise-mcp-terminal-401-guard";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CLIENT_SOURCE = join(ROOT, "packages", "enterprise-mcp-client", "src", "enterprise-mcp-client.ts");
+const ADAPTER_SOURCE = join(ROOT, "ee", "apps", "den-api", "src", "capability-sources", "enterprise-mcp-client-adapter.ts");
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+/** Assert + record, so every check shows up as evidence in the frame. */
+function witness(ctx, condition, assertion, actual) {
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual });
+    ctx.assert(false, assertion + (actual ? ` (actual: ${actual})` : ""));
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual });
+}
+
+let acts = null;
+
+function act(ctx, name) {
+  witness(ctx, Array.isArray(acts), "The demo run produced parseable act results");
+  const found = acts.find((entry) => entry.act === name);
+  witness(ctx, Boolean(found), `The demo run includes act "${name}"`);
+  return found;
+}
+
+export default {
+  id: FLOW_ID,
+  title: "A transient 401 no longer destroys stored connection credentials",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "The policy: invalidation requires user intent and provider proof",
+      run: async (ctx) => {
+        await ctx.prove("Credential invalidation is gated to tool execution with an invalid_token challenge", {
+          voiceover: vo[0],
+          assert: async () => {
+            const source = await readFile(CLIENT_SOURCE, "utf8");
+            witness(
+              ctx,
+              source.includes('input.operationPhase !== "tool-execution"'),
+              "Only user-initiated tool execution may invalidate (background probes are excluded)",
+            );
+            witness(
+              ctx,
+              source.includes("failure.httpStatus === 401 && failure.invalidToken"),
+              "A 401 is terminal only with an explicit invalid_token bearer challenge",
+            );
+            witness(
+              ctx,
+              source.includes('kind: "credential-invalidation"'),
+              "Every invalidation emits a credential-invalidation diagnostic",
+            );
+            const start = source.indexOf("async function invalidateTerminallyRejectedCredential");
+            const end = source.indexOf("function createSession", start);
+            witness(ctx, start >= 0 && end > start, "The guard function is present in the client source");
+            ctx.output("invalidateTerminallyRejectedCredential", source.slice(start, end).trimEnd());
+          },
+        });
+      },
+    },
+    {
+      name: "A transient 401 during tool execution leaves the credential intact",
+      run: async (ctx) => {
+        await ctx.prove("The stored credential survives a bare 401 on a user-initiated tool call", {
+          voiceover: vo[1],
+          assert: async () => {
+            const demo = spawnSync(
+              "pnpm",
+              ["--filter", "@openwork/enterprise-mcp-client", "exec", "tsx", "test/terminal-401-guard.demo.ts"],
+              { cwd: ROOT, encoding: "utf8" },
+            );
+            witness(ctx, demo.status === 0, "The demo drive of the real client exits cleanly", demo.status === 0 ? undefined : `${demo.stdout}\n${demo.stderr}`);
+            const line = demo.stdout.split("\n").find((entry) => entry.startsWith("DEMO_RESULT_JSON="));
+            witness(ctx, Boolean(line), "The demo prints machine-readable act evidence");
+            acts = JSON.parse(line.slice("DEMO_RESULT_JSON=".length));
+            const result = act(ctx, "transient-401-on-execute");
+            witness(ctx, result.operation === "tools/call", "The act is a user-initiated tool call");
+            witness(ctx, result.credentialIntact === true, "The stored credential survived the bare 401");
+            witness(ctx, result.invalidationCount === 0, "No invalidation was written to persistence");
+            ctx.output("act: transient-401-on-execute", demo.stdout.split("\n").filter((entry) => entry.startsWith("act=")).join("\n"));
+          },
+        });
+      },
+    },
+    {
+      name: "Background discovery probes never destroy credentials",
+      run: async (ctx) => {
+        await ctx.prove("A tool-discovery probe cannot invalidate, even on an invalid_token challenge", {
+          voiceover: vo[2],
+          assert: async () => {
+            const result = act(ctx, "invalid-token-on-discovery-probe");
+            witness(ctx, result.operation === "tools/list", "The act is a background discovery probe");
+            witness(ctx, result.providerResponse.includes("invalid_token"), "The provider claimed invalid_token");
+            witness(ctx, result.credentialIntact === true, "The stored credential survived the probe");
+            witness(ctx, result.invalidationCount === 0, "No invalidation was written to persistence");
+          },
+        });
+      },
+    },
+    {
+      name: "A genuine invalid_token rejection invalidates once, with a diagnostic trail",
+      run: async (ctx) => {
+        await ctx.prove("Provider-proven token rejection still invalidates and is now observable", {
+          voiceover: vo[3],
+          assert: async () => {
+            const result = act(ctx, "invalid-token-on-execute");
+            witness(ctx, result.credentialIntact === false, "The credential was invalidated");
+            witness(ctx, result.invalidationCount === 1, "Exactly one invalidation was written");
+            witness(ctx, result.invalidationDiagnostics.length === 1, "Exactly one credential-invalidation diagnostic was emitted");
+            const diagnostic = result.invalidationDiagnostics[0];
+            witness(ctx, diagnostic.operationPhase === "tool-execution", "The diagnostic records the user-initiated phase");
+            witness(ctx, diagnostic.httpStatus === 401 && diagnostic.invalidToken === true, "The diagnostic records the provider's proof");
+            const adapter = await readFile(ADAPTER_SOURCE, "utf8");
+            witness(
+              ctx,
+              adapter.includes('console.error("external_mcp_credential_invalidated"'),
+              "Den logs external_mcp_credential_invalidated unconditionally (no more silent kills)",
+            );
+            ctx.output("credential-invalidation diagnostic", JSON.stringify(diagnostic, null, 2));
+            const tests = spawnSync(
+              "pnpm",
+              ["--filter", "@openwork/enterprise-mcp-client", "test"],
+              { cwd: ROOT, encoding: "utf8" },
+            );
+            witness(ctx, tests.status === 0, "The full enterprise MCP client test suite passes", tests.status === 0 ? undefined : `${tests.stdout}\n${tests.stderr}`);
+            const tail = `${tests.stdout}\n${tests.stderr}`.split("\n").filter((entry) => entry.includes("pass") || entry.includes("fail")).slice(-6).join("\n");
+            ctx.output("test suite", tail);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/enterprise-mcp-terminal-401-guard.md
+++ b/evals/voiceovers/enterprise-mcp-terminal-401-guard.md
@@ -1,0 +1,11 @@
+# enterprise-mcp-terminal-401-guard — A transient 401 no longer signs you out of your connections
+
+This is an internal proof: the protagonist is the stored connection credential inside OpenWork Cloud's MCP client, driven through real provider scenarios at the terminal.
+
+1. Here is the new rule in the client itself: a connection credential may only be destroyed during a real tool call the user asked for, and only when the provider proves the token itself is bad with an explicit invalid_token challenge. A plain 401 blip is no longer a death sentence.
+
+2. First scenario: the user runs a tool and the provider hiccups with a bare 401, the kind a gateway redeploy or a VPN change produces. The call fails, but the stored credential survives untouched — no reconnect prompt will greet the user afterwards.
+
+3. Second scenario: a background capability search probes the same connection and the provider even claims invalid_token. Background probes are never allowed to destroy credentials, so the stored tokens survive this too.
+
+4. Third scenario: the user runs a tool and the provider genuinely rejects the token with an invalid_token challenge. Now the client does invalidate the credential, exactly once, and for the first time it emits a diagnostic that operators can see in the logs — and the full test suite confirms nothing else regressed.

--- a/packages/enterprise-mcp-client/src/contracts.ts
+++ b/packages/enterprise-mcp-client/src/contracts.ts
@@ -168,15 +168,24 @@ export type EnterpriseMcpOperationPhase =
   | "tool-execution"
   | "shutdown"
 
-export type EnterpriseMcpDiagnosticEvent = {
-  kind: "request" | "operation"
-  connectionId: string
-  operationPhase: EnterpriseMcpOperationPhase
-  requestPhase: EnterpriseMcpRequestPhase | null
-  outcome: "started" | "succeeded" | "failed"
-  durationMs?: number
-  httpStatus?: number
-}
+export type EnterpriseMcpDiagnosticEvent =
+  | {
+    kind: "request" | "operation"
+    connectionId: string
+    operationPhase: EnterpriseMcpOperationPhase
+    requestPhase: EnterpriseMcpRequestPhase | null
+    outcome: "started" | "succeeded" | "failed"
+    durationMs?: number
+    httpStatus?: number
+  }
+  | {
+    kind: "credential-invalidation"
+    connectionId: string
+    operationPhase: EnterpriseMcpOperationPhase
+    requestPhase: EnterpriseMcpRequestPhase
+    httpStatus?: number
+    invalidToken: boolean
+  }
 
 export type EnterpriseMcpDiagnosticSink = (event: EnterpriseMcpDiagnosticEvent) => void
 

--- a/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
+++ b/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
@@ -168,14 +168,25 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
       || phase === "endpoint-request"
   }
 
-  async function invalidateTerminallyRejectedCredential(session: Session): Promise<void> {
-    if (!session.oauthProvider) return
+  async function invalidateTerminallyRejectedCredential(
+    session: Session,
+    input: { connectionId: string; operationPhase: EnterpriseMcpOperationPhase },
+  ): Promise<void> {
+    if (!session.oauthProvider || input.operationPhase !== "tool-execution") return
     const failure = session.observer.lastRequestFailure()
     if (!failure || !isMcpResourceRequest(failure.requestPhase)) return
-    const rejected = failure.httpStatus === 401
+    const rejected = (failure.httpStatus === 401 && failure.invalidToken)
       || (failure.httpStatus === 403 && (failure.bearerChallenge || failure.insufficientScope))
     if (!rejected) return
     await session.oauthProvider.invalidateCredentials("tokens")
+    emitDiagnostic({
+      kind: "credential-invalidation",
+      connectionId: input.connectionId,
+      operationPhase: input.operationPhase,
+      requestPhase: failure.requestPhase,
+      httpStatus: failure.httpStatus,
+      invalidToken: failure.invalidToken,
+    })
   }
 
   function createSession(input: {
@@ -352,7 +363,10 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
             }
           }
         } catch (error) {
-          await invalidateTerminallyRejectedCredential(session)
+          await invalidateTerminallyRejectedCredential(session, {
+            connectionId: input.connection.id,
+            operationPhase: input.operationPhase,
+          })
           throw error
         }
       },

--- a/packages/enterprise-mcp-client/src/request-observer.ts
+++ b/packages/enterprise-mcp-client/src/request-observer.ts
@@ -77,6 +77,7 @@ export type EnterpriseMcpRequestObserver = {
     httpStatus?: number
     bearerChallenge: boolean
     insufficientScope: boolean
+    invalidToken: boolean
   } | null
 }
 
@@ -122,6 +123,7 @@ export function createEnterpriseMcpRequestObserver(input: {
             httpStatus: response.status,
             bearerChallenge: challenge.includes("bearer"),
             insufficientScope: challenge.includes("insufficient_scope"),
+            invalidToken: challenge.includes("invalid_token"),
           }
         } else if (isMcpRequestPhase(requestPhase)) {
           // A successful retry proves that a preceding challenge was
@@ -145,6 +147,7 @@ export function createEnterpriseMcpRequestObserver(input: {
           requestPhase,
           bearerChallenge: false,
           insufficientScope: false,
+          invalidToken: false,
         }
         input.diagnosticSink?.({
           kind: "request",

--- a/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
+++ b/packages/enterprise-mcp-client/test/enterprise-mcp-client.test.ts
@@ -306,9 +306,9 @@ describe("enterprise MCP client", () => {
       arguments: { table: "incident" },
     })
     assert.equal("isError" in result ? result.isError : undefined, false)
-    assert.ok(events.some((event) => event.requestPhase === "mcp-initialize" && event.outcome === "succeeded"))
-    assert.ok(events.some((event) => event.requestPhase === "mcp-tool-discovery" && event.outcome === "succeeded"))
-    assert.ok(events.some((event) => event.requestPhase === "mcp-tool-execution" && event.outcome === "succeeded"))
+    assert.ok(events.some((event) => event.kind !== "credential-invalidation" && event.requestPhase === "mcp-initialize" && event.outcome === "succeeded"))
+    assert.ok(events.some((event) => event.kind !== "credential-invalidation" && event.requestPhase === "mcp-tool-discovery" && event.outcome === "succeeded"))
+    assert.ok(events.some((event) => event.kind !== "credential-invalidation" && event.requestPhase === "mcp-tool-execution" && event.outcome === "succeeded"))
   })
 
   it("connects to a spec-legal MCP server that does not advertise tools", async () => {
@@ -643,6 +643,58 @@ function oauthProvider(input: {
     authorizationTransactionTtlMs: input.authorizationTransactionTtlMs ?? 600_000,
     expirationSkewMs: input.expirationSkewMs ?? 0,
   })
+}
+
+function runtimeRejectingMcpFetch(input: {
+  rejectMethod: "tools/call" | "tools/list"
+  status: number
+  wwwAuthenticate?: string
+}): EnterpriseMcpFetch {
+  return async (_url, init) => {
+    const body = requestText(init?.body)
+    if (!body) return new Response(null, { status: 202 })
+    const request = rpcRequestSchema.parse(JSON.parse(body))
+    if (request.method === "notifications/initialized") return new Response(null, { status: 202 })
+    if (request.method === "initialize") {
+      return Response.json({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name: "runtime-rejection-test", version: "1.0.0" },
+        },
+      })
+    }
+    if (request.method === input.rejectMethod) {
+      const headers = new Headers()
+      if (input.wwwAuthenticate) headers.set("www-authenticate", input.wwwAuthenticate)
+      return new Response(null, { status: input.status, headers })
+    }
+    if (request.method === "tools/list") {
+      return Response.json({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: { tools: [{ name: "oauth-tool", inputSchema: { type: "object", properties: {} } }] },
+      })
+    }
+    if (request.method === "tools/call") {
+      return Response.json({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: { content: [{ type: "text", text: "ok" }], isError: false },
+      })
+    }
+    return new Response(null, { status: 404 })
+  }
+}
+
+function oauthRuntimeConnection(id: string, persistence: EnterpriseMcpOAuthPersistence): EnterpriseMcpConnection {
+  return {
+    id,
+    serverUrl: "https://mcp.example.test/mcp",
+    authorization: { type: "oauth", persistence },
+  }
 }
 
 describe("enterprise MCP OAuth persistence contract", () => {
@@ -1296,51 +1348,78 @@ describe("enterprise MCP OAuth persistence contract", () => {
     }
   })
 
-  it("invalidates a credential when the MCP resource terminally rejects it", async () => {
-    const origin = "https://mcp.example.test"
+  it("preserves a credential when tool execution gets a 401 without invalid_token", async () => {
     const persistence = new MemoryOAuthPersistence()
     persistence.seedRegistration({ client_id: "registered-client" })
     persistence.seedCredential({ access_token: "rejected-access-token", token_type: "Bearer" })
     const client = createEnterpriseMcpClient({
-      fetch: async (url) => {
-        const target = new URL(url)
-        if (target.pathname === "/mcp") {
-          return new Response(null, {
-            status: 401,
-            headers: {
-              "www-authenticate": `Bearer resource_metadata="${origin}/.well-known/oauth-protected-resource/mcp"`,
-            },
-          })
-        }
-        if (target.pathname === "/.well-known/oauth-protected-resource/mcp") {
-          return Response.json({ resource: `${origin}/mcp`, authorization_servers: [origin] })
-        }
-        if (target.pathname === "/.well-known/oauth-authorization-server") {
-          return Response.json({
-            issuer: origin,
-            authorization_endpoint: `${origin}/authorize`,
-            token_endpoint: `${origin}/token`,
-            response_types_supported: ["code"],
-            grant_types_supported: ["authorization_code"],
-            token_endpoint_auth_methods_supported: ["none"],
-            code_challenge_methods_supported: ["S256"],
-          })
-        }
-        return new Response(null, { status: 404 })
-      },
+      fetch: runtimeRejectingMcpFetch({ rejectMethod: "tools/call", status: 401 }),
     })
-    const connection: EnterpriseMcpConnection = {
-      id: "runtime-rejected-token",
-      serverUrl: `${origin}/mcp`,
-      authorization: { type: "oauth", persistence },
-    }
 
-    await assert.rejects(client.listTools({
-      connection,
+    await assert.rejects(client.callTool({
+      connection: oauthRuntimeConnection("runtime-plain-401", persistence),
       redirectUri: "https://den.example.test/oauth/callback",
+      toolName: "oauth-tool",
+      arguments: {},
+    }))
+    assert.equal(persistence.credential?.tokens.access_token, "rejected-access-token")
+    assert.equal(persistence.invalidationCount, 0)
+  })
+
+  it("invalidates a credential and emits diagnostics when tool execution gets invalid_token", async () => {
+    const persistence = new MemoryOAuthPersistence()
+    persistence.seedRegistration({ client_id: "registered-client" })
+    persistence.seedCredential({ access_token: "rejected-access-token", token_type: "Bearer" })
+    const events: EnterpriseMcpDiagnosticEvent[] = []
+    const client = createEnterpriseMcpClient({
+      fetch: runtimeRejectingMcpFetch({
+        rejectMethod: "tools/call",
+        status: 401,
+        wwwAuthenticate: 'Bearer error="invalid_token"',
+      }),
+      diagnosticSink: (event) => events.push(event),
+    })
+
+    await assert.rejects(client.callTool({
+      connection: oauthRuntimeConnection("runtime-invalid-token", persistence),
+      redirectUri: "https://den.example.test/oauth/callback",
+      toolName: "oauth-tool",
+      arguments: {},
     }))
     assert.equal(persistence.credential, undefined)
     assert.equal(persistence.invalidationCount, 1)
+    const invalidationEvents = events.filter((event) => event.kind === "credential-invalidation")
+    assert.equal(invalidationEvents.length, 1)
+    const [event] = invalidationEvents
+    if (!event || event.kind !== "credential-invalidation") throw new Error("Expected a credential invalidation event.")
+    assert.deepEqual(event, {
+      kind: "credential-invalidation",
+      connectionId: "runtime-invalid-token",
+      operationPhase: "tool-execution",
+      requestPhase: "mcp-tool-execution",
+      httpStatus: 401,
+      invalidToken: true,
+    })
+  })
+
+  it("preserves a credential when tool discovery gets invalid_token", async () => {
+    const persistence = new MemoryOAuthPersistence()
+    persistence.seedRegistration({ client_id: "registered-client" })
+    persistence.seedCredential({ access_token: "rejected-access-token", token_type: "Bearer" })
+    const client = createEnterpriseMcpClient({
+      fetch: runtimeRejectingMcpFetch({
+        rejectMethod: "tools/list",
+        status: 401,
+        wwwAuthenticate: 'Bearer error="invalid_token"',
+      }),
+    })
+
+    await assert.rejects(client.listTools({
+      connection: oauthRuntimeConnection("discovery-invalid-token", persistence),
+      redirectUri: "https://den.example.test/oauth/callback",
+    }))
+    assert.equal(persistence.credential?.tokens.access_token, "rejected-access-token")
+    assert.equal(persistence.invalidationCount, 0)
   })
 
   it("preserves a credential when a provider returns a plain tool-policy 403", async () => {
@@ -1369,6 +1448,28 @@ describe("enterprise MCP OAuth persistence contract", () => {
     } finally {
       await server.close()
     }
+  })
+
+  it("still invalidates a credential when tool execution gets a 403 bearer challenge", async () => {
+    const persistence = new MemoryOAuthPersistence()
+    persistence.seedRegistration({ client_id: "registered-client" })
+    persistence.seedCredential({ access_token: "rejected-access-token", token_type: "Bearer" })
+    const client = createEnterpriseMcpClient({
+      fetch: runtimeRejectingMcpFetch({
+        rejectMethod: "tools/call",
+        status: 403,
+        wwwAuthenticate: "Bearer realm=\"provider\"",
+      }),
+    })
+
+    await assert.rejects(client.callTool({
+      connection: oauthRuntimeConnection("runtime-bearer-403", persistence),
+      redirectUri: "https://den.example.test/oauth/callback",
+      toolName: "oauth-tool",
+      arguments: {},
+    }))
+    assert.equal(persistence.credential, undefined)
+    assert.equal(persistence.invalidationCount, 1)
   })
 
   it("rejects a stale concurrent refresh response instead of overwriting newer credentials", async () => {

--- a/packages/enterprise-mcp-client/test/terminal-401-guard.demo.ts
+++ b/packages/enterprise-mcp-client/test/terminal-401-guard.demo.ts
@@ -1,0 +1,240 @@
+/**
+ * Runnable demo for the terminal-401 credential guard (fraimz flow
+ * enterprise-mcp-terminal-401-guard). Drives the real createEnterpriseMcpClient
+ * through three provider scenarios and prints machine-readable evidence:
+ *
+ *   act 1  tool execution gets a transient 401 (no WWW-Authenticate proof)
+ *          -> the stored credential must survive
+ *   act 2  a background tool-discovery probe gets 401 + invalid_token
+ *          -> the stored credential must survive (probes never invalidate)
+ *   act 3  tool execution gets 401 + invalid_token proof
+ *          -> the credential is invalidated once and a credential-invalidation
+ *             diagnostic is emitted
+ *
+ * Output: human-readable act lines plus a final DEMO_RESULT_JSON=<json> line.
+ */
+import { z } from "zod"
+import {
+  createEnterpriseMcpClient,
+  type EnterpriseMcpConnection,
+  type EnterpriseMcpDiagnosticEvent,
+  type EnterpriseMcpFetch,
+  type EnterpriseMcpOAuthAuthorizationHandle,
+  type EnterpriseMcpOAuthClientRegistration,
+  type EnterpriseMcpOAuthCredential,
+  type EnterpriseMcpOAuthPersistence,
+} from "../src/index.js"
+import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
+import type { OAuthDiscoveryState } from "@modelcontextprotocol/sdk/client/auth.js"
+
+const rpcRequestSchema = z.object({
+  id: z.union([z.string(), z.number()]).nullish(),
+  method: z.string(),
+})
+
+class DemoOAuthPersistence implements EnterpriseMcpOAuthPersistence {
+  registration: EnterpriseMcpOAuthClientRegistration | undefined
+  credential: EnterpriseMcpOAuthCredential | undefined
+  invalidationCount = 0
+  private revision = 0
+  private discoveryState: OAuthDiscoveryState | undefined
+  private readonly authorizationRecords = new Map<
+    string,
+    { handle: EnterpriseMcpOAuthAuthorizationHandle; codeVerifier: string }
+  >()
+
+  private nextRevision(): string {
+    this.revision += 1
+    return `revision-${this.revision}`
+  }
+
+  readonly clientRegistrations = {
+    load: async () => this.registration,
+    save: async (input: {
+      clientInformation: OAuthClientInformationMixed
+      expiresAt?: number
+      source: "client-metadata" | "dynamic"
+    }) => {
+      if (!this.registration) {
+        this.registration = {
+          clientInformation: input.clientInformation,
+          revision: this.nextRevision(),
+          expiresAt: input.expiresAt,
+          source: input.source,
+        }
+      }
+      return this.registration
+    },
+    invalidate: async () => {
+      this.registration = undefined
+    },
+  }
+
+  readonly authorizations = {
+    begin: async (input: {
+      id: string
+      codeVerifier: string
+      expiresAt: number
+      clientRegistrationRevision?: string
+    }) => {
+      this.authorizationRecords.set(input.id, {
+        handle: {
+          id: input.id,
+          revision: this.nextRevision(),
+          expiresAt: input.expiresAt,
+          clientRegistrationRevision: input.clientRegistrationRevision,
+        },
+        codeVerifier: input.codeVerifier,
+      })
+    },
+    load: async (input: { id: string }) => this.authorizationRecords.get(input.id),
+    invalidate: async (input: { id: string }) => {
+      this.authorizationRecords.delete(input.id)
+    },
+  }
+
+  readonly discovery = {
+    load: async () => this.discoveryState,
+    save: async (input: { state: OAuthDiscoveryState }) => {
+      this.discoveryState = input.state
+    },
+    invalidate: async () => {
+      this.discoveryState = undefined
+    },
+  }
+
+  readonly credentials = {
+    load: async () => this.credential,
+    save: async (input: { tokens: OAuthTokens; expiresAt?: number }) => {
+      this.credential = {
+        tokens: input.tokens,
+        expiresAt: input.expiresAt,
+        revision: this.nextRevision(),
+      }
+    },
+    invalidate: async () => {
+      this.credential = undefined
+      this.invalidationCount += 1
+    },
+  }
+
+  seed(): void {
+    this.registration = {
+      clientInformation: { client_id: "demo-client" },
+      revision: this.nextRevision(),
+      source: "pre-registered",
+    }
+    this.credential = {
+      tokens: { access_token: "demo-access-token", token_type: "Bearer" },
+      revision: this.nextRevision(),
+    }
+  }
+}
+
+function scriptedProviderFetch(input: {
+  rejectMethod: "tools/call" | "tools/list"
+  status: number
+  wwwAuthenticate?: string
+}): EnterpriseMcpFetch {
+  return async (_url, init) => {
+    const body = typeof init?.body === "string" ? init.body : undefined
+    if (!body) return new Response(null, { status: 202 })
+    const request = rpcRequestSchema.parse(JSON.parse(body))
+    if (request.method === "notifications/initialized") return new Response(null, { status: 202 })
+    if (request.method === "initialize") {
+      return Response.json({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: {
+          protocolVersion: "2025-06-18",
+          capabilities: { tools: {} },
+          serverInfo: { name: "terminal-401-guard-demo", version: "1.0.0" },
+        },
+      })
+    }
+    if (request.method === input.rejectMethod) {
+      const headers = new Headers()
+      if (input.wwwAuthenticate) headers.set("www-authenticate", input.wwwAuthenticate)
+      return new Response(null, { status: input.status, headers })
+    }
+    if (request.method === "tools/list") {
+      return Response.json({
+        jsonrpc: "2.0",
+        id: request.id,
+        result: { tools: [{ name: "demo-tool", inputSchema: { type: "object", properties: {} } }] },
+      })
+    }
+    return new Response(null, { status: 404 })
+  }
+}
+
+type ActResult = {
+  act: string
+  operation: "tools/call" | "tools/list"
+  providerResponse: string
+  credentialIntact: boolean
+  invalidationCount: number
+  invalidationDiagnostics: EnterpriseMcpDiagnosticEvent[]
+}
+
+async function runAct(input: {
+  act: string
+  operation: "tools/call" | "tools/list"
+  status: number
+  wwwAuthenticate?: string
+}): Promise<ActResult> {
+  const persistence = new DemoOAuthPersistence()
+  persistence.seed()
+  const events: EnterpriseMcpDiagnosticEvent[] = []
+  const client = createEnterpriseMcpClient({
+    fetch: scriptedProviderFetch({
+      rejectMethod: input.operation,
+      status: input.status,
+      wwwAuthenticate: input.wwwAuthenticate,
+    }),
+    diagnosticSink: (event) => events.push(event),
+  })
+  const connection: EnterpriseMcpConnection = {
+    id: `demo-${input.act}`,
+    serverUrl: "https://mcp.example.test/mcp",
+    authorization: { type: "oauth", persistence },
+  }
+  const operation = input.operation === "tools/call"
+    ? client.callTool({ connection, redirectUri: "https://den.example.test/oauth/callback", toolName: "demo-tool", arguments: {} })
+    : client.listTools({ connection, redirectUri: "https://den.example.test/oauth/callback" })
+  const rejected = await operation.then(() => false, () => true)
+  if (!rejected) throw new Error(`act "${input.act}" expected the provider rejection to surface`)
+  return {
+    act: input.act,
+    operation: input.operation,
+    providerResponse: `${input.status}${input.wwwAuthenticate ? ` with WWW-Authenticate: ${input.wwwAuthenticate}` : " without a WWW-Authenticate challenge"}`,
+    credentialIntact: persistence.credential?.tokens.access_token === "demo-access-token",
+    invalidationCount: persistence.invalidationCount,
+    invalidationDiagnostics: events.filter((event) => event.kind === "credential-invalidation"),
+  }
+}
+
+const acts: ActResult[] = [
+  await runAct({ act: "transient-401-on-execute", operation: "tools/call", status: 401 }),
+  await runAct({
+    act: "invalid-token-on-discovery-probe",
+    operation: "tools/list",
+    status: 401,
+    wwwAuthenticate: 'Bearer error="invalid_token"',
+  }),
+  await runAct({
+    act: "invalid-token-on-execute",
+    operation: "tools/call",
+    status: 401,
+    wwwAuthenticate: 'Bearer error="invalid_token"',
+  }),
+]
+
+for (const act of acts) {
+  console.log(
+    `act=${act.act} operation=${act.operation} provider=${act.providerResponse} `
+    + `credentialIntact=${act.credentialIntact} invalidations=${act.invalidationCount} `
+    + `invalidationDiagnostics=${act.invalidationDiagnostics.length}`,
+  )
+}
+console.log(`DEMO_RESULT_JSON=${JSON.stringify(acts)}`)


### PR DESCRIPTION
## Problem

Prod DB forensics (Den, PlanetScale) showed **every runtime credential invalidation** was written by `invalidateTerminallyRejectedCredential`: any unresolved HTTP 401 on an MCP resource request wiped the member's stored access+refresh tokens and forced a reconnect. Confirmed victims: Notion (ben, 2 days after connect), Stripe (ben, 62 min after connect — token-TTL boundary), Salesforce (jalil, ~2h40m after connect), Granola (jalil). Background `search_capabilities` probes could trigger it on connections the user never touched, and invalidations were completely silent (the probe-failure log is gated behind query-match score).

This is the root of the 'users get prompted to reconnect way too often' issue reported by Blue Yonder (Rashmi) and reproduced on our own first-party connectors.

## Fix

- Credential invalidation only during **user-initiated tool execution** — never during tool-discovery probes
- 401 is terminal **only with an explicit `WWW-Authenticate: Bearer error="invalid_token"` challenge** (mirrors the existing 403 bearer/scope gate); a bare 401 (gateway redeploy, VPN flap, session flush) no longer kills the credential
- 403 policy unchanged
- Every invalidation now emits a `credential-invalidation` diagnostic; Den logs `external_mcp_credential_invalidated` (referenceId, connectionId, phases, httpStatus, invalidToken) unconditionally

## Tests run

- `pnpm --filter @openwork/enterprise-mcp-client typecheck` — pass
- `pnpm --filter @openwork/enterprise-mcp-client test` — **55 pass / 0 fail** (4 new policy tests: bare-401 preserved, invalid_token invalidates + diagnostic, probe safety, 403 regression guard)
- `pnpm exec tsc --noEmit -p ee/apps/den-api/tsconfig.json` — pass
- `pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/external-mcp-diagnostics.test.ts test/mcp-oauth-refresh-lifecycle.test.ts` — **79 pass / 4 skip / 0 fail**
- `pnpm fraimz --flow enterprise-mcp-terminal-401-guard` — **PASSED** (internal demo driving the real client through all three scenarios; proof comment below)

Note: this package has no runtime path into the local Electron app (consumed by den-api cloud), hence the internal-kind fraimz.

Follow-ups tracked separately: per-identity refresh single-flight (M3 race), Slack/github providers issuing no refresh token (M4).