### PR TITLE
fix: improve markdown table rendering in sidebar preview

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -209,6 +209,29 @@ body {
   background: transparent !important;
 }
 
+/* Table rendering improvements for sidebar and narrow containers */
+.markdown-content table {
+  table-layout: auto;
+  min-width: 100%;
+}
+
+.markdown-content table th,
+.markdown-content table td {
+  word-wrap: break-word;
+  overflow-wrap: break-word;
+  max-width: 300px;
+  min-width: min-content;
+}
+
+.markdown-content table thead tr:first-child th {
+  border-top-width: 1px;
+}
+
+/* Ensure table wrapper scrolls horizontally when needed */
+.markdown-content div:has(> table) {
+  max-width: 100%;
+}
+
 .markdown-content [data-openwork-code-block] .shiki {
   background: transparent !important;
 }

--- a/apps/app/src/components/markdown/markdown-primitive.ts
+++ b/apps/app/src/components/markdown/markdown-primitive.ts
@@ -327,7 +327,7 @@ function createMarkedOptions(profile: MarkdownProfile, isAsync: boolean) {
         const header = token.header.map((cell) => this.tablecell({ ...cell, header: true })).join("");
         const body = token.rows.map((row) => this.tablerow({ text: row.map((cell) => this.tablecell(cell)).join("") })).join("");
 
-        return `<table class="my-4 w-full border-collapse"><thead>${this.tablerow({ text: header })}</thead><tbody>${body}</tbody></table>`;
+        return `<div class="my-4 overflow-x-auto"><table class="w-full border-collapse text-sm">${this.tablerow({ text: header })}${body}</table></div>`;
       },
       tablerow({ text }) {
         return `<tr>${text}</tr>`;

--- a/apps/app/tests/markdown-code-block.test.ts
+++ b/apps/app/tests/markdown-code-block.test.ts
@@ -81,6 +81,32 @@ describe("markdown safety and links", () => {
   });
 });
 
+describe("markdown tables", () => {
+  test("renders tables inside scrollable wrapper for sidebar compatibility", () => {
+    const markdown = `| Name | Value |\n|------|-------|\n| Foo  | Bar   |`;
+    const html = renderMarkdownHtml(markdown);
+
+    // Table should be wrapped in a scrollable container
+    expect(html).toContain('class="my-4 overflow-x-auto"');
+    // Table should have text-sm for better readability in narrow containers
+    expect(html).toContain('class="w-full border-collapse text-sm"');
+    // Table structure should be intact
+    expect(html).toContain("<table");
+    expect(html).toContain("<tr>");
+    expect(html).toContain("<th");
+    expect(html).toContain("<td");
+  });
+
+  test("renders surface markdown tables with scrollable wrapper", () => {
+    const markdown = `| Header 1 | Header 2 |\n|----------|----------|\n| Cell 1   | Cell 2   |`;
+    const html = renderPrimitiveMarkdownHtml(markdown, "surface");
+
+    expect(html).toContain('class="my-4 overflow-x-auto"');
+    expect(html).toContain('class="w-full border-collapse text-sm"');
+    expect(html).toContain("<table");
+  });
+});
+
 describe("markdown text highlighting", () => {
   test("splits matching text without changing the original casing", () => {
     expect(textHighlightParts("Markdown makes marks in markdown.", "MARK")).toEqual([


### PR DESCRIPTION
## Problem

Markdown tables in the right sidebar (artifact preview / side panel) were not rendering correctly. Wide tables would overflow their container, making content unreadable.

## Root Cause

The table renderer in `markdown-primitive.ts` generated tables with `w-full` but without a scrollable wrapper. In the narrow sidebar, tables with many columns or wide content would break the layout.

## Changes

### markdown-primitive.ts
- Wrap tables in `<div class="my-4 overflow-x-auto">` for horizontal scrolling in narrow containers
- Add `text-sm` to tables for better readability in sidebar
- Keep `w-full border-collapse` on the table itself

### index.css  
- Add `table-layout: auto` for flexible column widths
- Add `word-wrap: break-word` and `overflow-wrap: break-word` to table cells
- Set `max-width: 300px` on cells to prevent extreme stretching
- Add `max-width: 100%` to table wrapper divs

### Tests
- Add test coverage for table rendering in both `chat` and `surface` presentation modes
- Verify scrollable wrapper and proper CSS classes are present

## Verification

Test markdown that benefits from this fix:
```markdown
| Header 1 | Header 2 | Header 3 | Header 4 |
|----------|----------|----------|----------|
| Value 1  | Value 2  | Value 3  | Value 4  |
| A        | B        | C        | D        |
```

This table will now scroll horizontally in the sidebar instead of breaking the layout.

Fixes rendering issues when opening markdown files with tables in the artifact preview panel (right sidebar).