### PR TITLE
fix(den): gate OAuth refresh on session liveness; report infra failures as 503, not revocation

### DIFF
--- a/ee/apps/den-api/src/auth.ts
+++ b/ee/apps/den-api/src/auth.ts
@@ -1,7 +1,12 @@
+import * as crypto from "node:crypto";
 import { getInitialActiveOrganizationIdForUser } from "./active-organization.js";
 import { db } from "./db.js";
 import { env } from "./env.js";
 import { appLogger } from "./observability/logger.js";
+import {
+  deleteMcpOAuthGrantFamilyForSession,
+  getMcpSessionLiveness,
+} from "./mcp/session-liveness.js";
 import { deriveDenMcpAgentResource, deriveDenMcpResource, mcpEndpointResource } from "./mcp/resource.js";
 import { getDenAuthIssuer, getDenJwtOptions } from "./mcp/jwt-policy.js";
 import {
@@ -155,6 +160,8 @@ export const DEN_MCP_TOKEN_USE_CLAIM = `${env.mcpClaimNamespace}/token_use`;
 export const DEN_MCP_ORG_ID_CLAIM = `${env.mcpClaimNamespace}/org_id`;
 export const DEN_MCP_RESOURCE_CLAIM = `${env.mcpClaimNamespace}/resource`;
 export const DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX = "ow_mcp_at_";
+const DEN_MCP_REFRESH_TOKEN_PREFIX = "ow_mcp_rt_";
+const INVALID_MCP_SESSION_GRANT_DESCRIPTION = "The session backing this grant has been signed out or expired. Re-authorize the connection.";
 export { DEN_MCP_SCOPES } from "./mcp/scopes.js";
 
 export function normalizeMcpOAuthResource(resource: string): string | null {
@@ -364,6 +371,54 @@ function readBooleanProperty(value: unknown, propertyName: string) {
   return Object.getOwnPropertyDescriptor(value, propertyName)?.value === true;
 }
 
+function hashOAuthProviderToken(token: string) {
+  return crypto.createHash("sha256").update(token).digest("base64url");
+}
+
+function stripMcpRefreshTokenPrefix(refreshToken: string) {
+  return refreshToken.startsWith(DEN_MCP_REFRESH_TOKEN_PREFIX)
+    ? refreshToken.slice(DEN_MCP_REFRESH_TOKEN_PREFIX.length)
+    : null;
+}
+
+async function assertLiveMcpSessionForRefreshGrant(ctx: Parameters<Parameters<typeof createAuthMiddleware>[0]>[0]) {
+  if (ctx.path !== "/oauth2/token" || readStringProperty(ctx.body, "grant_type") !== "refresh_token") {
+    return;
+  }
+
+  const refreshToken = readStringProperty(ctx.body, "refresh_token");
+  if (!refreshToken) {
+    return;
+  }
+
+  const tokenSecret = stripMcpRefreshTokenPrefix(refreshToken);
+  if (!tokenSecret) {
+    return;
+  }
+
+  const grant = await ctx.context.adapter.findOne<{ sessionId?: string | null }>({
+    model: "oauthRefreshToken",
+    where: [{ field: "token", value: hashOAuthProviderToken(tokenSecret) }],
+  });
+  const sessionId = typeof grant?.sessionId === "string" && grant.sessionId.trim()
+    ? grant.sessionId.trim()
+    : null;
+  if (!sessionId) {
+    return;
+  }
+
+  const sessionLiveness = await getMcpSessionLiveness(sessionId);
+  if (sessionLiveness === "alive" || sessionLiveness === "check_failed") {
+    return;
+  }
+
+  await deleteMcpOAuthGrantFamilyForSession(sessionId);
+  throw new APIError("BAD_REQUEST", {
+    error: "invalid_grant",
+    error_description: INVALID_MCP_SESSION_GRANT_DESCRIPTION,
+  });
+}
+
 async function assertBetterAuthInvitationRoleAssignment(input: {
   organizationId: string;
   userId: string;
@@ -541,6 +596,8 @@ export const auth = betterAuth({
   },
   hooks: {
     before: createAuthMiddleware(async (ctx) => {
+      await assertLiveMcpSessionForRefreshGrant(ctx);
+
       if (ctx.path === "/oauth2/authorize") {
         const clientId = maybeString(ctx.query?.client_id);
         const requestedScopes = maybeString(ctx.query?.scope)?.split(/\s+/).filter(Boolean) ?? [];
@@ -943,6 +1000,7 @@ export const auth = betterAuth({
       accessTokenExpiresIn: DEN_MCP_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
       m2mAccessTokenExpiresIn: DEN_MCP_ACCESS_TOKEN_EXPIRES_IN_SECONDS,
       refreshTokenExpiresIn: DEN_MCP_REFRESH_TOKEN_EXPIRES_IN_SECONDS,
+      storeTokens: { hash: hashOAuthProviderToken },
       clientRegistrationDefaultScopes: [...DEN_MCP_DEFAULT_CLIENT_SCOPES],
       clientRegistrationAllowedScopes: [...DEN_MCP_SCOPES],
       advertisedMetadata: {
@@ -993,7 +1051,7 @@ export const auth = betterAuth({
       },
       prefix: {
         opaqueAccessToken: DEN_MCP_OPAQUE_ACCESS_TOKEN_PREFIX,
-        refreshToken: "ow_mcp_rt_",
+        refreshToken: DEN_MCP_REFRESH_TOKEN_PREFIX,
         clientSecret: "ow_mcp_cs_",
       },
     }),

--- a/ee/apps/den-api/src/mcp/auth.ts
+++ b/ee/apps/den-api/src/mcp/auth.ts
@@ -1,6 +1,6 @@
 import * as crypto from "node:crypto"
-import { and, eq, gt, isNull, lt, lte } from "@openwork-ee/den-db/drizzle"
-import { AuthSessionTable, MemberTable, OAuthAccessTokenTable } from "@openwork-ee/den-db/schema"
+import { and, eq, isNull } from "@openwork-ee/den-db/drizzle"
+import { MemberTable, OAuthAccessTokenTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import { verifyJwsAccessToken } from "better-auth/oauth2"
 import {
@@ -17,10 +17,11 @@ import {
 import { db } from "../db.js"
 import { env } from "../env.js"
 import { publicRequestUrl } from "../request-url.js"
-import { getDenSessionExpiresAt, getDenSessionRefreshCutoff } from "../session-lifetime.js"
 import { DEN_JWT_SIGNING_ALGORITHM, getDenAuthIssuer } from "./jwt-policy.js"
 import { mcpProtectedResourceMetadataUrl, mcpRouteResource, resolveMcpResourceFromRequest, type McpResourceRoute } from "./resource.js"
 import { DEN_MCP_REQUESTED_SCOPE } from "./scopes.js"
+import { getMcpSessionLiveness } from "./session-liveness.js"
+export { hasActiveMcpSession } from "./session-liveness.js"
 
 export type McpPrincipal = {
   userId: string
@@ -195,8 +196,10 @@ function mcpJsonResponse(
   status: number,
   body: { error: string; message: string; referenceId: string; oauthError?: "invalid_token" | "insufficient_scope"; scope?: string },
   challenge?: string,
+  extraHeaders?: HeadersInit,
 ) {
-  const headers = new Headers({ "content-type": "application/json" })
+  const headers = new Headers(extraHeaders)
+  headers.set("content-type", "application/json")
   if (challenge) headers.set("www-authenticate", challenge)
   return new Response(JSON.stringify(body), { status, headers })
 }
@@ -270,46 +273,6 @@ export async function hasActiveMcpMembership(input: { userId: string; organizati
     .limit(1)
 
   return rows.length > 0
-}
-
-export async function hasActiveMcpSession(sessionId: string, now = new Date()) {
-  try {
-    const normalizedSessionId = normalizeDenTypeId("session", sessionId)
-    const nextExpiresAt = getDenSessionExpiresAt(now)
-
-    // MCP clients can be the only active surface for days at a time. Apply
-    // the same rolling-session policy used by desktop bearer requests so a
-    // regularly used, rotating OAuth grant does not die at the original
-    // seven-day browser-session boundary. The active-session predicate keeps
-    // this update from ever resurrecting an expired or explicitly deleted
-    // session, and the expiry guard prevents concurrent touches from
-    // shortening a session another request already renewed.
-    await db
-      .update(AuthSessionTable)
-      .set({
-        expiresAt: nextExpiresAt,
-        updatedAt: now,
-      })
-      .where(and(
-        eq(AuthSessionTable.id, normalizedSessionId),
-        gt(AuthSessionTable.expiresAt, now),
-        lte(AuthSessionTable.expiresAt, getDenSessionRefreshCutoff(now)),
-        lt(AuthSessionTable.expiresAt, nextExpiresAt),
-      ))
-
-    const rows = await db
-      .select({ id: AuthSessionTable.id })
-      .from(AuthSessionTable)
-      .where(and(
-        eq(AuthSessionTable.id, normalizedSessionId),
-        gt(AuthSessionTable.expiresAt, now),
-      ))
-      .limit(1)
-
-    return rows.length > 0
-  } catch {
-    return false
-  }
 }
 
 async function getJwks() {
@@ -445,7 +408,16 @@ export async function verifyMcpRequest(headers: Headers, optionsInput?: string |
     }, bearerChallenge({ metadataUrl: options.metadataUrl, error: "invalid_token", message }))
   }
 
-  if (!(await hasActiveMcpSession(sessionId))) {
+  const sessionLiveness = await getMcpSessionLiveness(sessionId)
+  if (sessionLiveness === "check_failed") {
+    return mcpJsonResponse(503, {
+      error: "mcp_session_check_unavailable",
+      message: "OpenWork could not verify the token session. Retry shortly.",
+      referenceId,
+    }, undefined, { "retry-after": "10" })
+  }
+
+  if (sessionLiveness === "missing") {
     const message = "The MCP bearer token session is missing, expired, or revoked."
     return mcpJsonResponse(401, {
       error: "mcp_session_revoked",

--- a/ee/apps/den-api/src/mcp/session-liveness.ts
+++ b/ee/apps/den-api/src/mcp/session-liveness.ts
@@ -1,0 +1,111 @@
+import { and, eq, gt, lt, lte } from "@openwork-ee/den-db/drizzle"
+import { AuthSessionTable, OAuthAccessTokenTable, OAuthRefreshTokenTable } from "@openwork-ee/den-db/schema"
+import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
+import { db } from "../db.js"
+import { getDenSessionExpiresAt, getDenSessionRefreshCutoff } from "../session-lifetime.js"
+
+export type McpSessionLiveness = "alive" | "missing" | "check_failed"
+
+function normalizeMcpSessionId(sessionId: string) {
+  return normalizeDenTypeId("session", sessionId)
+}
+
+type NormalizedMcpSessionId = ReturnType<typeof normalizeMcpSessionId>
+type McpSessionTouch = (input: { normalizedSessionId: NormalizedMcpSessionId; now: Date; nextExpiresAt: Date }) => Promise<void>
+type McpSessionSelect = (input: { normalizedSessionId: NormalizedMcpSessionId; now: Date }) => Promise<readonly { id: NormalizedMcpSessionId }[]>
+
+function livenessLogDetails(sessionId: NormalizedMcpSessionId, error: unknown) {
+  return {
+    sessionId: sessionId.slice(0, 12),
+    error: String(error).slice(0, 200),
+  }
+}
+
+const touchMcpSession: McpSessionTouch = async ({ normalizedSessionId, now, nextExpiresAt }) => {
+  // MCP clients can be the only active surface for days at a time. Apply
+  // the same rolling-session policy used by desktop bearer requests so a
+  // regularly used, rotating OAuth grant does not die at the original
+  // seven-day browser-session boundary. The active-session predicate keeps
+  // this update from ever resurrecting an expired or explicitly deleted
+  // session, and the expiry guard prevents concurrent touches from
+  // shortening a session another request already renewed.
+  await db
+    .update(AuthSessionTable)
+    .set({
+      expiresAt: nextExpiresAt,
+      updatedAt: now,
+    })
+    .where(and(
+      eq(AuthSessionTable.id, normalizedSessionId),
+      gt(AuthSessionTable.expiresAt, now),
+      lte(AuthSessionTable.expiresAt, getDenSessionRefreshCutoff(now)),
+      lt(AuthSessionTable.expiresAt, nextExpiresAt),
+    ))
+}
+
+const selectActiveMcpSession: McpSessionSelect = ({ normalizedSessionId, now }) => db
+  .select({ id: AuthSessionTable.id })
+  .from(AuthSessionTable)
+  .where(and(
+    eq(AuthSessionTable.id, normalizedSessionId),
+    gt(AuthSessionTable.expiresAt, now),
+  ))
+  .limit(1)
+
+let activeMcpSessionTouch = touchMcpSession
+let activeMcpSessionSelect = selectActiveMcpSession
+
+export function setMcpSessionLivenessDependenciesForTest(input: {
+  touch?: McpSessionTouch
+  select?: McpSessionSelect
+}) {
+  const previousTouch = activeMcpSessionTouch
+  const previousSelect = activeMcpSessionSelect
+  if (input.touch) activeMcpSessionTouch = input.touch
+  if (input.select) activeMcpSessionSelect = input.select
+  return () => {
+    activeMcpSessionTouch = previousTouch
+    activeMcpSessionSelect = previousSelect
+  }
+}
+
+export async function getMcpSessionLiveness(sessionId: string, now = new Date()): Promise<McpSessionLiveness> {
+  let normalizedSessionId: NormalizedMcpSessionId
+  try {
+    normalizedSessionId = normalizeMcpSessionId(sessionId)
+  } catch {
+    return "missing"
+  }
+
+  const nextExpiresAt = getDenSessionExpiresAt(now)
+
+  try {
+    await activeMcpSessionTouch({ normalizedSessionId, now, nextExpiresAt })
+  } catch (error) {
+    console.error("mcp_session_liveness_touch_failed", livenessLogDetails(normalizedSessionId, error))
+  }
+
+  try {
+    const rows = await activeMcpSessionSelect({ normalizedSessionId, now })
+    return rows.length > 0 ? "alive" : "missing"
+  } catch (error) {
+    console.error("mcp_session_liveness_check_failed", livenessLogDetails(normalizedSessionId, error))
+    return "check_failed"
+  }
+}
+
+export async function hasActiveMcpSession(sessionId: string, now = new Date()) {
+  return (await getMcpSessionLiveness(sessionId, now)) === "alive"
+}
+
+export async function deleteMcpOAuthGrantFamilyForSession(sessionId: string) {
+  const normalizedSessionId = normalizeDenTypeId("session", sessionId)
+
+  await db
+    .delete(OAuthAccessTokenTable)
+    .where(eq(OAuthAccessTokenTable.sessionId, normalizedSessionId))
+
+  await db
+    .delete(OAuthRefreshTokenTable)
+    .where(eq(OAuthRefreshTokenTable.sessionId, normalizedSessionId))
+}

--- a/ee/apps/den-api/test/mcp-oauth-refresh-lifecycle.test.ts
+++ b/ee/apps/den-api/test/mcp-oauth-refresh-lifecycle.test.ts
@@ -68,6 +68,16 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null
 }
 
+function serializedConsoleErrors(errors: unknown[][]) {
+  return errors
+    .flat()
+    .map((entry) => {
+      const serialized = typeof entry === "string" ? entry : JSON.stringify(entry)
+      return serialized ?? ""
+    })
+    .join(" ")
+}
+
 function requiredString(value: unknown, key: string) {
   if (!isRecord(value) || typeof value[key] !== "string") {
     throw new Error(`OAuth response did not include ${key}`)
@@ -77,6 +87,10 @@ function requiredString(value: unknown, key: string) {
 
 function codeChallenge(verifier: string) {
   return createHash("sha256").update(verifier).digest("base64url")
+}
+
+function hashStoredOAuthToken(token: string) {
+  return createHash("sha256").update(token).digest("base64url")
 }
 
 async function sleep(ms: number) {
@@ -155,6 +169,7 @@ let app: typeof import("../src/app.js").default
 let db: typeof import("../src/db.js").db
 let schema: typeof import("@openwork-ee/den-db/schema")
 let drizzle: typeof import("@openwork-ee/den-db/drizzle")
+let setMcpSessionLivenessDependenciesForTest: typeof import("../src/mcp/session-liveness.js").setMcpSessionLivenessDependenciesForTest
 
 const userId = createDenTypeId("user")
 const organizationId = createDenTypeId("organization")
@@ -177,11 +192,13 @@ beforeAll(async () => {
     import("../src/db.js"),
     import("@openwork-ee/den-db/schema"),
     import("@openwork-ee/den-db/drizzle"),
+    import("../src/mcp/session-liveness.js"),
   ])
   app = modules[0].default
   db = modules[1].db
   schema = modules[2]
   drizzle = modules[3]
+  setMcpSessionLivenessDependenciesForTest = modules[4].setMcpSessionLivenessDependenciesForTest
 
   await db.insert(schema.AuthUserTable).values({
     id: userId,
@@ -329,6 +346,24 @@ async function issueOAuthGrant() {
   }
 }
 
+async function issueRefreshGrantWithoutSession() {
+  const clientId = await registerOAuthClient()
+  const refreshTokenSecret = `mcp-null-session-refresh-${createDenTypeId("verification")}`
+  await db.insert(schema.OAuthRefreshTokenTable).values({
+    id: createDenTypeId("oauthRefreshToken"),
+    token: hashStoredOAuthToken(refreshTokenSecret),
+    clientId,
+    userId,
+    referenceId: organizationId,
+    expiresAt: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000),
+    scopes: JSON.stringify(MCP_SCOPE.split(" ")),
+  })
+  return {
+    clientId,
+    refreshToken: `ow_mcp_rt_${refreshTokenSecret}`,
+  }
+}
+
 async function refreshOAuthToken(input: { clientId: string; refreshToken: string }) {
   const response = await app.fetch(new Request(`${API_ORIGIN}/api/auth/oauth2/token`, {
     method: "POST",
@@ -344,6 +379,17 @@ async function refreshOAuthToken(input: { clientId: string; refreshToken: string
     }),
   }))
   return { status: response.status, body: await response.json() }
+}
+
+async function fetchAgentToolsWithAccessToken(accessToken: string, id: string) {
+  return app.fetch(new Request(AGENT_RESOURCE, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${accessToken}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id, method: "tools/list", params: {} }),
+  }))
 }
 
 function requireRefreshToken(tokens: OAuthTokens) {
@@ -390,6 +436,186 @@ childTest("SDK MCP client survives multiple serial access-token refresh and repl
     await session.client.close()
   }
 }, 12_000)
+
+childTest("refresh_token grant with a live backing session still rotates", async () => {
+  const grant = await issueOAuthGrant()
+  const refresh = await refreshOAuthToken({
+    clientId: grant.clientInformation.client_id,
+    refreshToken: requireRefreshToken(grant.tokens),
+  })
+
+  expect(refresh.status).toBe(200)
+  const tokens = OAuthTokensSchema.parse(refresh.body)
+  expect(tokens.access_token).toBeTruthy()
+  expect(requireRefreshToken(tokens)).toStartWith("ow_mcp_rt_")
+}, 8_000)
+
+childTest("refresh_token grant with a deleted backing session returns invalid_grant and clears the grant family", async () => {
+  const grant = await issueOAuthGrant()
+  const clientId = grant.clientInformation.client_id
+  await db.insert(schema.OAuthAccessTokenTable).values({
+    id: createDenTypeId("oauthAccessToken"),
+    token: hashStoredOAuthToken(`dead-session-access-${grant.sessionId}`),
+    clientId,
+    sessionId: grant.sessionId,
+    userId,
+    referenceId: organizationId,
+    expiresAt: new Date(Date.now() + 60_000),
+    scopes: JSON.stringify(MCP_SCOPE.split(" ")),
+  })
+  await db.delete(schema.AuthSessionTable).where(drizzle.eq(schema.AuthSessionTable.id, grant.sessionId))
+
+  const refresh = await refreshOAuthToken({
+    clientId,
+    refreshToken: requireRefreshToken(grant.tokens),
+  })
+
+  expect(refresh.status).toBe(400)
+  if (!isRecord(refresh.body)) throw new Error("Expected OAuth error response body")
+  expect(refresh.body.error).toBe("invalid_grant")
+  expect(refresh.body.access_token).toBeUndefined()
+  expect(refresh.body.refresh_token).toBeUndefined()
+
+  const refreshGrants = await db
+    .select({ id: schema.OAuthRefreshTokenTable.id })
+    .from(schema.OAuthRefreshTokenTable)
+    .where(drizzle.eq(schema.OAuthRefreshTokenTable.sessionId, grant.sessionId))
+  const accessGrants = await db
+    .select({ id: schema.OAuthAccessTokenTable.id })
+    .from(schema.OAuthAccessTokenTable)
+    .where(drizzle.eq(schema.OAuthAccessTokenTable.sessionId, grant.sessionId))
+  expect(refreshGrants).toHaveLength(0)
+  expect(accessGrants).toHaveLength(0)
+}, 8_000)
+
+childTest("refresh_token grant with an expired backing session returns invalid_grant", async () => {
+  const grant = await issueOAuthGrant()
+  await db.update(schema.AuthSessionTable)
+    .set({ expiresAt: new Date(Date.now() - 1_000), updatedAt: new Date() })
+    .where(drizzle.eq(schema.AuthSessionTable.id, grant.sessionId))
+
+  const refresh = await refreshOAuthToken({
+    clientId: grant.clientInformation.client_id,
+    refreshToken: requireRefreshToken(grant.tokens),
+  })
+
+  expect(refresh.status).toBe(400)
+  if (!isRecord(refresh.body)) throw new Error("Expected OAuth error response body")
+  expect(refresh.body.error).toBe("invalid_grant")
+  expect(refresh.body.error_description).toBe("The session backing this grant has been signed out or expired. Re-authorize the connection.")
+}, 8_000)
+
+childTest("refresh_token grant with no session_id remains valid", async () => {
+  const grant = await issueRefreshGrantWithoutSession()
+  const refresh = await refreshOAuthToken({
+    clientId: grant.clientId,
+    refreshToken: grant.refreshToken,
+  })
+
+  expect(refresh.status).toBe(200)
+  const tokens = OAuthTokensSchema.parse(refresh.body)
+  expect(tokens.access_token).toBeTruthy()
+  expect(requireRefreshToken(tokens)).toStartWith("ow_mcp_rt_")
+}, 8_000)
+
+childTest("authorization_code grant path still issues session-bound refresh tokens", async () => {
+  const grant = await issueOAuthGrant()
+  const clientId = grant.clientInformation.client_id
+  expect(grant.tokens.access_token).toBeTruthy()
+  expect(requireRefreshToken(grant.tokens)).toStartWith("ow_mcp_rt_")
+
+  const [refreshGrant] = await db
+    .select({ sessionId: schema.OAuthRefreshTokenTable.sessionId })
+    .from(schema.OAuthRefreshTokenTable)
+    .where(drizzle.eq(schema.OAuthRefreshTokenTable.clientId, clientId))
+    .limit(1)
+  expect(refreshGrant?.sessionId).toBe(grant.sessionId)
+}, 8_000)
+
+childTest("session liveness check failures 503 resource requests but fail open refresh grants", async () => {
+  const grant = await issueOAuthGrant()
+  const clientId = grant.clientInformation.client_id
+  await db.insert(schema.OAuthAccessTokenTable).values({
+    id: createDenTypeId("oauthAccessToken"),
+    token: hashStoredOAuthToken(`fail-open-access-${grant.sessionId}`),
+    clientId,
+    sessionId: grant.sessionId,
+    userId,
+    referenceId: organizationId,
+    expiresAt: new Date(Date.now() + 60_000),
+    scopes: JSON.stringify(MCP_SCOPE.split(" ")),
+  })
+  const errors: unknown[][] = []
+  const originalError = console.error
+  console.error = (...args: unknown[]) => {
+    errors.push(args)
+  }
+  const restoreLiveness = setMcpSessionLivenessDependenciesForTest({
+    select: async () => {
+      throw new Error("simulated liveness select outage")
+    },
+  })
+
+  try {
+    const response = await fetchAgentToolsWithAccessToken(grant.tokens.access_token, "liveness-check-failed")
+    expect(response.status).toBe(503)
+    expect(response.headers.get("www-authenticate")).toBeNull()
+    expect(response.headers.get("retry-after")).toBe("10")
+    const body: unknown = await response.json()
+    expect(isRecord(body) && body.error).toBe("mcp_session_check_unavailable")
+
+    const refresh = await refreshOAuthToken({
+      clientId,
+      refreshToken: requireRefreshToken(grant.tokens),
+    })
+    expect(refresh.status).toBe(200)
+    expect(OAuthTokensSchema.parse(refresh.body).access_token).toBeTruthy()
+  } finally {
+    restoreLiveness()
+    console.error = originalError
+  }
+
+  expect(serializedConsoleErrors(errors)).toContain("mcp_session_liveness_check_failed")
+  const refreshGrants = await db
+    .select({ id: schema.OAuthRefreshTokenTable.id })
+    .from(schema.OAuthRefreshTokenTable)
+    .where(drizzle.eq(schema.OAuthRefreshTokenTable.sessionId, grant.sessionId))
+  const accessGrants = await db
+    .select({ id: schema.OAuthAccessTokenTable.id })
+    .from(schema.OAuthAccessTokenTable)
+    .where(drizzle.eq(schema.OAuthAccessTokenTable.sessionId, grant.sessionId))
+  expect(refreshGrants.length).toBeGreaterThan(0)
+  expect(accessGrants.length).toBeGreaterThan(0)
+}, 8_000)
+
+childTest("session touch failures do not block healthy liveness checks", async () => {
+  const grant = await issueOAuthGrant()
+  const provider = new HarnessOAuthProvider(grant)
+  const errors: unknown[][] = []
+  const originalError = console.error
+  console.error = (...args: unknown[]) => {
+    errors.push(args)
+  }
+  const restoreLiveness = setMcpSessionLivenessDependenciesForTest({
+    touch: async () => {
+      throw new Error("simulated liveness touch outage")
+    },
+  })
+
+  let session: Awaited<ReturnType<typeof connectMcpClient>> | null = null
+  try {
+    session = await connectMcpClient(provider)
+    await expectAgentTools(session.client)
+  } finally {
+    await session?.client.close()
+    restoreLiveness()
+    console.error = originalError
+  }
+
+  const logs = serializedConsoleErrors(errors)
+  expect(logs).toContain("mcp_session_liveness_touch_failed")
+  expect(logs).not.toContain("mcp_session_liveness_check_failed")
+}, 8_000)
 
 type RefreshRecord = {
   refreshToken: string | null

--- a/evals/flows/oauth-refresh-session-liveness.flow.mjs
+++ b/evals/flows/oauth-refresh-session-liveness.flow.mjs
@@ -1,0 +1,114 @@
+/**
+ * Internal demo: OAuth refresh grants vs session liveness.
+ *
+ * Proven prod incident, two failure classes:
+ * (1) refresh grants outlive the session that authorized them — the token
+ *     endpoint kept minting tokens for signed-out sessions, which the resource
+ *     then rejected forever ("Server returned 401 after successful
+ *     authentication"); 24 such zombie grants existed in prod at fix time.
+ * (2) the resource's session check reported infrastructure failures as
+ *     "session revoked" (catch -> false), turning DB blips into mass
+ *     credential death and pointless grant rotation.
+ *
+ * This flow proves the fix on the real den-api wire harness
+ * (requiresApp: false): claims + assertions + real bun test output.
+ */
+import { spawnSync } from "node:child_process";
+import { readFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "oauth-refresh-session-liveness";
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const AUTH_SOURCE = join(ROOT, "ee", "apps", "den-api", "src", "auth.ts");
+const RESOURCE_SOURCE = join(ROOT, "ee", "apps", "den-api", "src", "mcp", "auth.ts");
+const LIVENESS_SOURCE = join(ROOT, "ee", "apps", "den-api", "src", "mcp", "session-liveness.ts");
+const LIFECYCLE_TEST = join(ROOT, "ee", "apps", "den-api", "test", "mcp-oauth-refresh-lifecycle.test.ts");
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+function witness(ctx, condition, assertion, actual) {
+  if (!condition) {
+    ctx.recordEvidence({ type: "assertion", status: "failed", assertion, actual });
+    ctx.assert(false, assertion + (actual ? ` (actual: ${actual})` : ""));
+  }
+  ctx.recordEvidence({ type: "assertion", status: "passed", assertion, actual });
+}
+
+function denApiTest(files, env = {}) {
+  return spawnSync(
+    "pnpm",
+    ["--filter", "@openwork-ee/den-api", "exec", "bun", "test", "--conditions", "development", ...files],
+    { cwd: ROOT, encoding: "utf8", env: { ...process.env, ...env } },
+  );
+}
+
+function tallyLine(output) {
+  return output.split("\n").filter((line) => /\d+ (pass|fail)/.test(line)).join(" | ");
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Refresh grants die with their session; infra blips stop impersonating sign-outs",
+  kind: "internal",
+  requiresApp: false,
+  steps: [
+    {
+      name: "The contract: liveness-gated refresh, truthful resource errors",
+      run: async (ctx) => {
+        await ctx.prove("Refresh is gated on session liveness and the resource distinguishes revoked from unverifiable", {
+          voiceover: vo[0],
+          assert: async () => {
+            const liveness = await readFile(LIVENESS_SOURCE, "utf8");
+            witness(ctx, liveness.includes('"alive" | "missing" | "check_failed"'), "Session liveness is three-state (alive / missing / check_failed)");
+            witness(ctx, liveness.includes("mcp_session_liveness_check_failed"), "Failed liveness checks log a stable marker (no more silent misclassification)");
+            const auth = await readFile(AUTH_SOURCE, "utf8");
+            witness(ctx, auth.includes('"invalid_grant"'), "The token endpoint refuses dead-session refresh grants with invalid_grant");
+            witness(ctx, auth.includes('sessionLiveness === "alive" || sessionLiveness === "check_failed"'), "The refresh gate fails open on check_failed (infra blips never destroy grants)");
+            const resource = await readFile(RESOURCE_SOURCE, "utf8");
+            witness(ctx, resource.includes("mcp_session_check_unavailable"), "The resource returns a distinct 503 when the session check itself fails");
+            witness(ctx, resource.includes('"retry-after"'), "The 503 carries Retry-After so clients back off instead of re-authing");
+            const gateStart = auth.indexOf("assertLiveMcpSessionForRefreshGrant");
+            witness(ctx, gateStart >= 0, "The refresh gate function is present");
+            ctx.output("refresh gate (auth.ts)", auth.slice(gateStart, auth.indexOf("}", auth.indexOf("throw new APIError", gateStart)) + 1).slice(0, 1600));
+          },
+        });
+      },
+    },
+    {
+      name: "Wire proof: the full lifecycle against the real token endpoint and resource",
+      run: async (ctx) => {
+        await ctx.prove("Dead sessions get invalid_grant + cleanup; live and m2m grants keep working; check failures 503 and fail open", {
+          voiceover: vo[1],
+          assert: async () => {
+            const testSource = await readFile(LIFECYCLE_TEST, "utf8");
+            for (const marker of ["invalid_grant", "mcp_session_check_unavailable", "mcp_session_liveness_check_failed", "retry-after"]) {
+              witness(ctx, testSource.includes(marker), `The wire suite asserts on "${marker}"`);
+            }
+            const run = denApiTest(["test/mcp-oauth-refresh-lifecycle.test.ts"], { DEN_MCP_REFRESH_LIFECYCLE_CHILD: "1" });
+            witness(ctx, run.status === 0, "The lifecycle wire suite exits cleanly", run.status === 0 ? undefined : `${run.stdout}\n${run.stderr}`.slice(-1200));
+            const combined = `${run.stdout}\n${run.stderr}`;
+            witness(ctx, /11 pass/.test(combined) && /\b0 fail/.test(combined), "All 11 lifecycle scenarios pass (live/deleted/expired/m2m/auth-code/check-failed/touch-failed)", tallyLine(combined));
+            ctx.output("lifecycle suite", tallyLine(combined));
+          },
+        });
+      },
+    },
+    {
+      name: "Nothing around it moved",
+      run: async (ctx) => {
+        await ctx.prove("Connector diagnostics and provider refresh flows are untouched", {
+          voiceover: vo[2],
+          assert: async () => {
+            const run = denApiTest(["test/external-mcp-diagnostics.test.ts", "test/mcp-oauth-refresh-flow.test.ts"]);
+            witness(ctx, run.status === 0, "Regression suites exit cleanly", run.status === 0 ? undefined : `${run.stdout}\n${run.stderr}`.slice(-1200));
+            const combined = `${run.stdout}\n${run.stderr}`;
+            witness(ctx, /79 pass/.test(combined) && /\b0 fail/.test(combined), "79 regression tests pass with 0 failures", tallyLine(combined));
+            ctx.output("regression suites", tallyLine(combined));
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/oauth-refresh-session-liveness.md
+++ b/evals/voiceovers/oauth-refresh-session-liveness.md
@@ -1,0 +1,9 @@
+# oauth-refresh-session-liveness — Signed-out sessions stop pretending to refresh, and infra blips stop pretending to be sign-outs
+
+This is an internal proof: the protagonist is the OAuth grant behind an MCP connection, driven through OpenWork's real token endpoint and resource handler at the wire level.
+
+1. Here is the new contract in the code itself: the token endpoint now checks that the session behind a refresh grant is still alive before minting tokens, and the resource endpoint now tells the truth when it merely could not check — a missing session means invalid grant, a failed check means try again shortly, and only a real rejection carries an authentication challenge.
+
+2. Now the whole contract runs against the real server: a signed-out session's refresh is refused with invalid grant and its leftover tokens are swept away, a live session keeps refreshing exactly as before, machine-to-machine grants without sessions are untouched, and when the database check itself fails the refresh proceeds, the resource answers with a retryable 503 instead of revoking anything, and a loud marker lands in the logs.
+
+3. And nothing around it moved: the external connector diagnostics and the provider refresh flow still pass every test they passed before this change.


### PR DESCRIPTION
## The two bugs (both verified against prod)

**1. Refresh grants outlive the session that authorized them.** Every MCP access token carries the authorizing session's `sid`, and `/mcp/agent` enforces session liveness per request — but `/oauth2/token` did NOT check it for `refresh_token` grants. Live probe: with a dead backing session, refresh returned **200 + fresh token**, resource returned **401 `mcp_session_revoked`** — forever. SDK clients surface this as `Server returned 401 after successful authentication` and loop unrecoverably; desktop shows unfixable Degraded. Prod census at fix time: **24 live zombie grants / 16 users** (10 deleted sessions, 14 expired) vs 54 healthy grants.

**2. Infra failures reported as revocation.** `hasActiveMcpSession` ended in `catch { return false }` — any DB error became `mcp_session_revoked`. Observed in prod (Jul 24, ~13:45–15:42Z): a provably-alive session rejected for ~2h, then self-healed; every client retry pointlessly rotated refresh grants the whole time.

## The fix

- `session-liveness.ts` (new shared helper): three-state `alive | missing | check_failed`; rolling-touch failures are logged, never verdict-affecting; `check_failed` logs a stable `mcp_session_liveness_check_failed` marker.
- Token endpoint (`hooks.before` on `/oauth2/token`): refresh grant + `missing` session → **400 `invalid_grant`** + grant-family cleanup (clients re-authorize cleanly). `check_failed` → fail-open (never destroy grants on infra blips). m2m grants (no session) unaffected.
- Resource (`verifyMcpRequest`): `missing` → 401 `mcp_session_revoked` (unchanged); `check_failed` → **503 `mcp_session_check_unavailable`** with `Retry-After: 10` and **no WWW-Authenticate challenge**, so clients back off instead of re-authing/rotating.

## Tests run

- `pnpm exec tsc --noEmit -p ee/apps/den-api/tsconfig.json` — pass
- `DEN_MCP_REFRESH_LIFECYCLE_CHILD=1 bun test test/mcp-oauth-refresh-lifecycle.test.ts` — **11 pass / 0 fail** (live 200 · deleted → invalid_grant+cleanup · expired → invalid_grant · NULL session_id unaffected · auth-code untouched · SELECT-failure → resource 503 + refresh fail-open + marker logged · touch-failure alone → still alive)
- `bun test test/external-mcp-diagnostics.test.ts test/mcp-oauth-refresh-flow.test.ts` — **79 pass / 0 fail**
- `test/mcp-membership-revocation.test.ts` fails identically on clean `dev` (pre-existing harness mock issue, unrelated)
- `pnpm fraimz --flow oauth-refresh-session-liveness` — **PASSED** (internal demo, wire-level; proof comment below)

Ops note: a daily zombie-grant census job now tracks the affected-grant count; expect the 24 zombies to convert to clean `invalid_grant` re-auth prompts once deployed.