### PR TITLE
feat(attachments): transcript badges for every attachment, clickable Files entries, no client size caps

### DIFF
--- a/apps/app/src/components/chat/utils.ts
+++ b/apps/app/src/components/chat/utils.ts
@@ -59,14 +59,17 @@ export function getMediaBadge(part: Pick<FileUIPart, "filename" | "mediaType">) 
   if (mime === PPTX_MIME) return "PPTX"
   if (mime === XLSX_MIME) return "XLSX"
 
+  // Prefer the filename extension: attachment mimes are transport details
+  // (e.g. everything text-like or binary travels as text/plain so providers
+  // accept it), while the extension reflects what the user actually attached.
   const fromExtension = extensionBadge(part.filename)
-  if (fromExtension === "DOCX" || fromExtension === "PPTX" || fromExtension === "XLSX") return fromExtension
+  if (fromExtension) return fromExtension
 
   if (mime && mime !== "application/octet-stream") {
     return mime.replace(/^application\//, "").replace(/^text\//, "").toUpperCase()
   }
 
-  return fromExtension
+  return null
 }
 
 export function getSafeFileDownloadUrl(part: Pick<FileUIPart, "url">) {

--- a/apps/app/src/i18n/locales/ca.ts
+++ b/apps/app/src/i18n/locales/ca.ts
@@ -82,7 +82,6 @@ export default {
   "composer.behavior_label": "Comportament",
   "composer.configure": "Configura",
   "composer.default_agent": "Agent per defecte",
-  "composer.file_exceeds_limit": "{name} supera el límit de 8 MB.",
   "composer.file_kind": "Fitxer",
   "composer.image_kind": "Imatge",
   "composer.inserted_links_unsupported": "S'han inserit enllaços per a fitxers no compatibles.",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -93,7 +93,6 @@ export default {
   "composer.configure": "Configure",
   "composer.connect_skill_prompt": "Use the \"{name}\" skill from the \"{marketplace}\" marketplace. Find it with openwork-cloud_search_capabilities, then call openwork-cloud_execute_capability with the exact capability name \"{capability}\", follow the returned skill content, and use it to ",
   "composer.default_agent": "Default agent",
-  "composer.file_exceeds_limit": "{name} exceeds the 8MB limit.",
   "composer.file_kind": "File",
   "composer.image_kind": "Image",
   "composer.inserted_links_unsupported": "Inserted links for unsupported files.",

--- a/apps/app/src/i18n/locales/es.ts
+++ b/apps/app/src/i18n/locales/es.ts
@@ -82,7 +82,6 @@ export default {
   "composer.behavior_label": "Comportamiento",
   "composer.configure": "Configurar",
   "composer.default_agent": "Agente predeterminado",
-  "composer.file_exceeds_limit": "{name} supera el límite de 8 MB.",
   "composer.file_kind": "Archivo",
   "composer.image_kind": "Imagen",
   "composer.inserted_links_unsupported": "Enlaces insertados para archivos no compatibles.",

--- a/apps/app/src/i18n/locales/fr.ts
+++ b/apps/app/src/i18n/locales/fr.ts
@@ -82,7 +82,6 @@ export default {
   "composer.behavior_label": "Comportement",
   "composer.configure": "Configurer",
   "composer.default_agent": "Agent par défaut",
-  "composer.file_exceeds_limit": "{name} dépasse la limite de 8 Mo.",
   "composer.file_kind": "Fichier",
   "composer.image_kind": "Image",
   "composer.inserted_links_unsupported": "Liens insérés pour des fichiers non pris en charge.",

--- a/apps/app/src/i18n/locales/ja.ts
+++ b/apps/app/src/i18n/locales/ja.ts
@@ -81,7 +81,6 @@ export default {
   "composer.behavior_label": "動作",
   "composer.configure": "設定",
   "composer.default_agent": "デフォルトエージェント",
-  "composer.file_exceeds_limit": "{name}は8MBの制限を超えています。",
   "composer.file_kind": "ファイル",
   "composer.image_kind": "画像",
   "composer.inserted_links_unsupported": "未対応ファイルのリンクを挿入しました。",

--- a/apps/app/src/i18n/locales/pt-BR.ts
+++ b/apps/app/src/i18n/locales/pt-BR.ts
@@ -82,7 +82,6 @@ export default {
   "composer.behavior_label": "Comportamento",
   "composer.configure": "Configurar",
   "composer.default_agent": "Agente padrão",
-  "composer.file_exceeds_limit": "{name} excede o limite de 8MB.",
   "composer.file_kind": "Arquivo",
   "composer.image_kind": "Imagem",
   "composer.inserted_links_unsupported": "Links inseridos para arquivos não suportados.",

--- a/apps/app/src/i18n/locales/ru.ts
+++ b/apps/app/src/i18n/locales/ru.ts
@@ -83,7 +83,6 @@ export default {
   "composer.behavior_label": "Поведение",
   "composer.configure": "Настроить",
   "composer.default_agent": "Агент по умолчанию",
-  "composer.file_exceeds_limit": "{name} превышает лимит 8 МБ.",
   "composer.file_kind": "Файл",
   "composer.image_kind": "Изображение",
   "composer.inserted_links_unsupported": "Вставлены ссылки для неподдерживаемых файлов.",

--- a/apps/app/src/i18n/locales/th.ts
+++ b/apps/app/src/i18n/locales/th.ts
@@ -82,7 +82,6 @@ export default {
   "composer.behavior_label": "พฤติกรรม",
   "composer.configure": "ตั้งค่า",
   "composer.default_agent": "Agent เริ่มต้น",
-  "composer.file_exceeds_limit": "{name} เกินขีดจำกัด 8MB",
   "composer.file_kind": "ไฟล์",
   "composer.image_kind": "รูปภาพ",
   "composer.inserted_links_unsupported": "แทรกลิงก์สำหรับไฟล์ที่ไม่รองรับ",

--- a/apps/app/src/i18n/locales/vi.ts
+++ b/apps/app/src/i18n/locales/vi.ts
@@ -82,7 +82,6 @@ export default {
   "composer.behavior_label": "Hành vi",
   "composer.configure": "Cấu hình",
   "composer.default_agent": "Agent mặc định",
-  "composer.file_exceeds_limit": "{name} vượt quá giới hạn 8MB.",
   "composer.file_kind": "Tệp",
   "composer.image_kind": "Hình ảnh",
   "composer.inserted_links_unsupported": "Đã chèn liên kết cho các tệp không được hỗ trợ.",

--- a/apps/app/src/i18n/locales/zh.ts
+++ b/apps/app/src/i18n/locales/zh.ts
@@ -85,7 +85,6 @@ export default {
   "composer.behavior_label": "行为",
   "composer.configure": "配置",
   "composer.default_agent": "默认智能体",
-  "composer.file_exceeds_limit": "{name}超过8MB限制。",
   "composer.file_kind": "文件",
   "composer.image_kind": "图片",
   "composer.inserted_links_unsupported": "已为不支持的文件插入链接。",

--- a/apps/app/src/lib/artifacts.ts
+++ b/apps/app/src/lib/artifacts.ts
@@ -8,7 +8,7 @@ import {
   isWriteToolPart,
 } from "@/lib/build-in-tools";
 import { useOpenTargets } from "@/lib/target-provider";
-import { isCollectibleArtifactTarget, isOpenableFileTarget, type OpenTarget, type OpenTargetPreview } from "@/react-app/domains/session/artifacts/open-target";
+import { filePathFromFileUrl, isCollectibleArtifactTarget, isOpenableFileTarget, type OpenTarget, type OpenTargetPreview } from "@/react-app/domains/session/artifacts/open-target";
 
 export type ArtifactType = "website" | "markdown" | "sheet" | "slides" | "document" | "image" | "video" | "audio" | "pdf" | "html" | "text" | "unknown";
 
@@ -245,6 +245,14 @@ function getArtifactPathsFromMessage(message: UIMessage) {
   for (const part of message.parts) {
     if (part.type === "text" && message.role === "assistant") {
       paths.push(...getArtifactPathsFromText(part.text));
+      continue;
+    }
+
+    if (part.type === "file") {
+      // Chat attachments carry workspace `file://` URLs; surface them as
+      // artifacts so users can click/preview what they attached.
+      const path = filePathFromFileUrl(part.url);
+      if (path) paths.push(path);
       continue;
     }
 

--- a/apps/app/src/react-app/domains/session/artifacts/open-target.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/open-target.ts
@@ -105,6 +105,23 @@ function textWithoutRedundantMarkdownLinkLabels(text: string) {
   });
 }
 
+/**
+ * Chat attachments are uploaded into the workspace inbox and referenced by
+ * `file://` URLs on message file parts. Decoding the URL here lets those
+ * attachments resolve as openable artifacts (regex path scanning cannot,
+ * because attachment filenames often contain spaces).
+ */
+export function filePathFromFileUrl(url: string): string | null {
+  if (!url.startsWith("file://")) return null;
+  try {
+    const pathname = decodeURIComponent(new URL(url).pathname);
+    if (!pathname) return null;
+    return /^\/[A-Za-z]:\//.test(pathname) ? pathname.slice(1) : pathname;
+  } catch {
+    return null;
+  }
+}
+
 function targetFromFile(path: string, confidence: number, reason: string): OpenTarget | null {
   const normalized = normalizePath(path).replace(/[.,;:]+$/, "");
   if (!normalized || normalized.length > 500 || !normalized.includes(".")) return null;
@@ -288,6 +305,15 @@ export function deriveOpenTargets(messages: UIMessage[], options: DeriveOpenTarg
         scanText(targets, part.text, message.role === "assistant" ? 65 : 40, "message", {
           includeFiles: options.includeFileMentions === true || (message.role === "assistant" && shouldScanAssistantFileMentions(part.text)),
         });
+        continue;
+      }
+
+      if (part.type === "file") {
+        const path = filePathFromFileUrl(part.url);
+        if (path) {
+          const target = targetFromFile(path, 95, "chat attachment");
+          addTarget(targets, target && part.filename ? { ...target, name: part.filename } : target);
+        }
         continue;
       }
 

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -117,7 +117,6 @@ type ComposerProps = {
 
 const FLUSH_PROMPT_EVENT = "openwork:flushPromptDraft";
 const FOCUS_PROMPT_EVENT = "openwork:focusPrompt";
-const MAX_ATTACHMENT_BYTES = 8 * 1024 * 1024;
 const IMAGE_COMPRESS_MAX_PX = 2048;
 const IMAGE_COMPRESS_QUALITY = 0.82;
 const IMAGE_COMPRESS_TARGET_BYTES = 1_500_000;
@@ -1062,30 +1061,16 @@ export function ReactSessionComposer(props: ComposerProps) {
       return;
     }
 
+    // No client-side size cap: oversized files are rejected upstream (upload
+    // endpoint or provider) with their own errors instead of a composer rule.
     const accepted: File[] = [];
-    const oversize: string[] = [];
-
     for (const original of inputFiles) {
-      const processed = original.type.startsWith("image/") ? await compressImageFile(original) : original;
-      if (processed.size > MAX_ATTACHMENT_BYTES) {
-        oversize.push(processed.name || original.name);
-        continue;
-      }
-      accepted.push(processed);
+      accepted.push(original.type.startsWith("image/") ? await compressImageFile(original) : original);
     }
 
     if (accepted.length) {
       props.onAttachFiles(accepted);
     }
-
-    if (oversize.length) {
-      toast.warning(
-        oversize.length === 1
-          ? t("composer.file_exceeds_limit", { name: oversize[0] })
-          : `${oversize.length} files exceed the 8MB limit.`,
-      );
-    }
-
   };
 
   const activeMcpItems = mcpServers.map((entry) => ({

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -1228,19 +1228,13 @@ export function SessionSurface(props: SessionSurfaceProps) {
       toast.warning(props.attachmentsDisabledReason ?? "Attachments are unavailable.");
       return;
     }
-    const oversized = files.filter((file) => file.size > 25 * 1024 * 1024);
-    const sized = files.filter((file) => file.size <= 25 * 1024 * 1024);
-    if (oversized.length) {
-      toast.warning(
-        oversized.length === 1 ? `${oversized[0]?.name ?? "File"} is too large` : `${oversized.length} files are too large`,
-        { description: "Files over 25 MB were skipped." },
-      );
-    }
-    // Any file type is accepted: model-readable formats become file parts,
-    // everything else is copied into the workspace so the model reads it
-    // with tools (see modelFacingAttachmentMime in attachment-file-part.ts).
-    if (!sized.length) return;
-    const next = sized.map((file) => {
+    // Any file type and size is accepted: model-readable formats become file
+    // parts, everything else is copied into the workspace so the model reads
+    // it with tools (see modelFacingAttachmentMime in attachment-file-part.ts).
+    // Oversized files are rejected by the upload endpoint or provider with
+    // their own errors instead of an opinionated composer cap.
+    if (!files.length) return;
+    const next = files.map((file) => {
       const metadata = resolveAttachmentFileMetadata(file);
       return {
         id: `att-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,

--- a/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
+++ b/apps/app/src/react-app/domains/session/sync/attachment-file-part.ts
@@ -160,8 +160,10 @@ function isTextLikeAttachmentMime(mime: string) {
  *   content via the Read tool (the proven `@file` mention mechanism);
  * - images, PDFs, and Office mimes pass through (Office parts are rewritten
  *   to text by the OpenWorkOfficeAttachments plugin before the provider);
- * - everything else gets no model-facing file part (`null`): the synthetic
- *   workspace-path note gives the model tool access to the bytes instead.
+ * - everything else returns `null`: workspace (`file://`) attachments fall
+ *   back to a `text/plain` part that opencode mediates through the Read tool,
+ *   while data-URL attachments are dropped (inlining binary bytes as text is
+ *   garbage); the synthetic workspace-path note gives tools the bytes.
  */
 export function modelFacingAttachmentMime(mimeType: string): string | null {
   const mime = normalizedMime(mimeType);
@@ -264,9 +266,12 @@ function attachmentPathNotePart(uploaded: UploadedChatAttachment[]): TextPartInp
   };
 }
 
-async function uploadedAttachmentFilePart(item: UploadedChatAttachment): Promise<FilePartInput | null> {
-  const modelMime = modelFacingAttachmentMime(item.mime);
-  if (!modelMime) return null;
+async function uploadedAttachmentFilePart(item: UploadedChatAttachment): Promise<FilePartInput> {
+  // Binary/unknown mimes also get a `text/plain` file part: opencode expands
+  // text/plain `file://` parts through the Read tool (which fails gracefully
+  // with "Cannot read binary file") and never forwards them to the provider,
+  // so the transcript keeps an attachment badge without any provider risk.
+  const modelMime = modelFacingAttachmentMime(item.mime) ?? "text/plain";
 
   // Images need a browser-displayable URL so the transcript can show the same
   // expandable miniature preview as paste/composer attachments. Workspace
@@ -346,11 +351,10 @@ export async function composerAttachmentsToWorkspaceFileParts(input: {
     });
   }
 
-  const parts: Array<TextPartInput | FilePartInput> = [attachmentPathNotePart(uploaded)];
-  for (const filePart of await Promise.all(uploaded.map(uploadedAttachmentFilePart))) {
-    if (filePart) parts.push(filePart);
-  }
-  return parts;
+  return [
+    attachmentPathNotePart(uploaded),
+    ...(await Promise.all(uploaded.map(uploadedAttachmentFilePart))),
+  ];
 }
 
 export async function composerAttachmentToFilePart(attachment: ComposerAttachment): Promise<FilePartInput | null> {

--- a/apps/app/tests/attachment-artifacts.test.ts
+++ b/apps/app/tests/attachment-artifacts.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, test } from "bun:test";
+import type { UIMessage } from "ai";
+
+import { canOpenArtifact, getArtifactsFromMessages } from "../src/lib/artifacts";
+import { deriveOpenTargets, filePathFromFileUrl, type OpenTarget } from "../src/react-app/domains/session/artifacts/open-target";
+
+const ATTACHMENT_URL = "file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_1/nonce-pge_natural_gas_billing_billing_data_service%202_2_2025-02-20_to_2025-12-05.csv";
+const ATTACHMENT_PATH = "/workspaces/Worker Root/.opencode/openwork/inbox/chat-attachments/ses_1/nonce-pge_natural_gas_billing_billing_data_service 2_2_2025-02-20_to_2025-12-05.csv";
+
+function userMessageWithAttachment(): UIMessage {
+  return {
+    id: "msg_1",
+    role: "user",
+    parts: [
+      { type: "text", text: "what do you make of these bills?" },
+      {
+        type: "file",
+        mediaType: "text/plain",
+        filename: "pge_natural_gas_billing_billing_data_service 2_2_2025-02-20_to_2025-12-05.csv",
+        url: ATTACHMENT_URL,
+      },
+    ],
+  };
+}
+
+describe("attachment artifacts", () => {
+  test("filePathFromFileUrl decodes workspace file URLs and rejects other schemes", () => {
+    expect(filePathFromFileUrl(ATTACHMENT_URL)).toBe(ATTACHMENT_PATH);
+    expect(filePathFromFileUrl("file:///C:/Users/Ada/%E5%B7%A5%E4%BD%9C/scan.pdf")).toBe("C:/Users/Ada/工作/scan.pdf");
+    expect(filePathFromFileUrl("data:text/plain;base64,aGk=")).toBeNull();
+    expect(filePathFromFileUrl("https://example.com/file.csv")).toBeNull();
+  });
+
+  test("deriveOpenTargets surfaces user attachment file parts, spaces included", () => {
+    const targets = deriveOpenTargets([userMessageWithAttachment()]);
+    const attachment = targets.find((target) => target.reason === "chat attachment");
+
+    expect(attachment).toMatchObject({
+      kind: "file",
+      value: ATTACHMENT_PATH,
+      name: "pge_natural_gas_billing_billing_data_service 2_2_2025-02-20_to_2025-12-05.csv",
+      preview: "sheet",
+      confidence: 95,
+    });
+  });
+
+  test("attachment artifacts become clickable once the server verifies they exist", () => {
+    const message = userMessageWithAttachment();
+    const derived = deriveOpenTargets([message]);
+    const verified: OpenTarget[] = derived.map((target) => ({ ...target, exists: true }));
+
+    const artifacts = getArtifactsFromMessages([message], verified);
+    const attachment = artifacts.find((artifact) => artifact.legacy_target.reason === "chat attachment");
+
+    expect(attachment).toBeDefined();
+    expect(attachment && canOpenArtifact(attachment)).toBe(true);
+  });
+});

--- a/apps/app/tests/attachment-file-part.test.ts
+++ b/apps/app/tests/attachment-file-part.test.ts
@@ -375,7 +375,7 @@ describe("composer attachment file parts", () => {
     });
   });
 
-  test("workspace binary attachments upload for tool access but emit no model-facing file part", async () => {
+  test("workspace binary attachments upload for tool access and emit a Read-mediated text/plain file part", async () => {
     const { endpoint, calls } = uploadRecorder("server-workspace-42");
     const file = new File([PPTX_BYTES], "recording.zip", { type: "application/zip" });
 
@@ -393,10 +393,17 @@ describe("composer attachment file parts", () => {
       filename: "recording.zip",
       bytes: Array.from(PPTX_BYTES),
     }]);
-    expect(parts).toHaveLength(1);
     expect(textPart(parts)).toMatchObject({ type: "text", synthetic: true });
     expect(textPartText(parts)).toContain(".opencode/openwork/inbox/chat-attachments/ses_bin/nonce-bin-recording.zip");
     expect(textPartText(parts)).toContain("Read/Bash/MCP/Docling");
+    // text/plain file parts never reach the provider (opencode expands them
+    // through the Read tool), so binaries keep a transcript badge safely.
+    expect(filePartUrl(parts, 1)).toBe("file:///workspaces/Worker%20Root/.opencode/openwork/inbox/chat-attachments/ses_bin/nonce-bin-recording.zip");
+    expect(parts[1]).toMatchObject({
+      type: "file",
+      filename: "recording.zip",
+      mime: "text/plain",
+    });
   });
 
   test("uploads duplicate filenames to distinct non-overwriting paths", async () => {

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1280,9 +1280,12 @@ function resolveInboxMaxBytes(): number {
   const raw = (process.env.OPENWORK_INBOX_MAX_BYTES ?? "").trim();
   const parsed = raw ? Number(raw) : NaN;
   if (Number.isFinite(parsed) && parsed > 0) {
-    return Math.min(Math.trunc(parsed), 250_000_000);
+    return Math.trunc(parsed);
   }
-  return 50_000_000;
+  // Generous default: the composer no longer caps attachment sizes, so large
+  // uploads should be bounded here (memory: formData buffers the body) and by
+  // downstream provider/tool limits rather than an arbitrary small cap.
+  return 250_000_000;
 }
 
 function resolveToyUiEnabled(): boolean {


### PR DESCRIPTION
Follow-up to #3079, addressing three reports:

## 1. Zip (binary) attachments were invisible in the chat

#3079 emitted no file part for binaries, so nothing rendered in the transcript. Now every workspace attachment emits a file part; binaries get `mime: "text/plain"` pointing at the workspace `file://` copy. This is provider-safe by construction: opencode expands `text/plain` file parts through the Read tool (which fails gracefully with `Cannot read binary file: ...`) and **never forwards them to the provider** — verified in the engine binary. The model still gets the workspace path note for tool access, and the user keeps an attachment badge.

Badges also now prefer the filename extension over the transport mime, so a zip shows **ZIP** instead of **PLAIN**.

## 2. Files/Artifacts entries for attachments weren't clickable

e.g. `pge_natural_gas_billing_billing_data_service 2_2_2025-02-20_to_2025-12-05.csv`. Two compounding causes:
- artifact derivation only scanned assistant text (regex) and write/edit tools — **never user attachment file parts**;
- the path regex can't match filenames with spaces, so it produced truncated paths that failed server resolution → `exists` never true → rendered as a dead `div`.

Fix: `deriveOpenTargets` and `getArtifactPathsFromMessage` now read `file://` URLs straight off message file parts (new `filePathFromFileUrl`, exact path, spaces intact, display name from `part.filename`). These resolve server-side (inbox lives inside the workspace root) → `exists: true` → clickable + previewable (`.csv` → sheet preview).

## 3. Size caps removed (be unopinionated)

- composer 8 MB cap: **removed** (image compression retained)
- session-surface 25 MB cap: **removed**
- server inbox upload: default raised 50 MB → **250 MB**, and `OPENWORK_INBOX_MAX_BYTES` is now respected as-is (previously clamped to 250 MB)

A 150 MB file now attaches; if something can't handle it, the block comes from the actual boundary (upload endpoint 413, provider error, or Read-tool truncation) instead of an arbitrary composer rule.

## Tests

- `pnpm --filter @openwork/app test` → **414 pass / 0 fail** (81 files), including new `tests/attachment-artifacts.test.ts` (file-URL decoding incl. spaces + Windows drives, attachment → open target derivation, clickability after server verification) and the updated binary-attachment routing test
- `pnpm --filter @openwork/app typecheck` → clean
- `node scripts/i18n-audit.mjs --ci` → clean (removed key verified)
- `apps/server` office-attachments plugin tests → 18 pass. Full `openwork-server` suite has one pre-existing env-dependent failure (`runtime-opencode-config-store.test.ts`) that fails identically on clean `dev` locally and passes in CI.

No fraimz/e2e recording was captured for this change — stated explicitly. Reviewer repro:
1. Attach a `.zip` → badge shows in the sent message (ZIP), model reads it via workspace path
2. Attach a `.csv` with spaces in the name → after the reply, the file chip under messages / Artifacts panel is clickable and opens the sheet preview
3. Attach a 150 MB file → uploads (or fails with a clear 413 if `OPENWORK_INBOX_MAX_BYTES` is set lower), no composer block