### PR TITLE
Arc-style shell: floating panel cards, denser chrome, sidebar account chip

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -182,14 +182,10 @@ html {
 body {
   margin: 0;
   font-family:
-    "IBM Plex Sans",
-    Geist,
-    "Avenir Next",
-    Inter,
-    ui-sans-serif,
-    system-ui,
     -apple-system,
     BlinkMacSystemFont,
+    system-ui,
+    ui-sans-serif,
     "Segoe UI",
     Roboto,
     "Helvetica Neue",
@@ -197,7 +193,7 @@ body {
     "Noto Sans",
     "Apple Color Emoji",
     "Segoe UI Emoji";
-  font-size: 0.875rem;
+  font-size: 13px;
   line-height: 1.5;
   color: var(--dls-text-primary);
   -webkit-font-smoothing: antialiased;
@@ -502,8 +498,9 @@ select:disabled {
 }
 
 @theme inline {
-  --font-sans: 'Geist Variable', sans-serif;
-  --font-heading: 'IBM Plex Sans Variable', sans-serif;
+  --font-sans: -apple-system, BlinkMacSystemFont, system-ui, ui-sans-serif, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --font-heading: -apple-system, BlinkMacSystemFont, system-ui, ui-sans-serif, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  --text-sm: 0.8125rem;
   --color-sidebar-ring: var(--sidebar-ring);
   --color-sidebar-border: var(--sidebar-border);
   --color-sidebar-accent-foreground: var(--sidebar-accent-foreground);

--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -227,6 +227,14 @@ body {
   box-shadow: var(--dls-shell-shadow);
 }
 
+/* Arc-style overflow: long labels fade out instead of showing an ellipsis. */
+.ow-fade-truncate {
+  overflow: hidden;
+  white-space: nowrap;
+  text-overflow: clip;
+  mask-image: linear-gradient(to right, black calc(100% - 18px), transparent);
+}
+
 .ow-soft-card {
   border: 1px solid var(--dls-border);
   background: var(--dls-surface);

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -99,7 +99,7 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
           }}
           rows={2}
           placeholder="Ask anything, or describe a task..."
-          className="w-full resize-none bg-transparent text-[14px] leading-[21px] text-foreground outline-none placeholder:text-muted-foreground"
+          className="w-full resize-none bg-transparent text-[13px] leading-[20px] text-foreground outline-none placeholder:text-muted-foreground"
         />
         <div className="mt-2">
           <Button size="sm" onClick={submit} disabled={!trimmedPrompt || props.busy}>

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -2,7 +2,7 @@
 import type { CSSProperties } from "react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { usePanelRef } from "react-resizable-panels";
-import { Cloud, FileText, Globe, Mic2, Settings2, TextSearch, Zap } from "lucide-react";
+import { Cloud, FileText, Globe, Mic2, PanelRight, Settings2, TextSearch, Zap } from "lucide-react";
 
 import { resolveExtensionIconSrc } from "@/react-app/design-system/extension-icon-src";
 import { t } from "../../../../i18n";
@@ -1038,15 +1038,15 @@ export function SessionPage(props: SessionPageProps) {
           onReorderWorkspaces={props.sidebar.onReorderWorkspaces}
           onStartResize={startLeftSidebarResize}
         />
-        <SidebarInset className="min-h-0 overflow-hidden bg-background mac:bg-background/80 mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-28 mac:max-md:[&_header]:pl-28">
-          <div className="flex min-h-0 flex-1">
+        <SidebarInset className="min-h-0 overflow-hidden bg-sidebar mac:bg-transparent mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-28 mac:max-md:[&_header]:pl-28">
+          <div className="flex min-h-0 flex-1 py-2 pl-2">
           <ResizablePanelGroup
             orientation="horizontal"
             onLayoutChanged={sidePanelOpen ? commitBrowserPanelWidth : undefined}
             className="min-h-0 flex-1"
           >
             <ResizablePanel minSize="360px" className="min-w-0">
-              <main className="flex h-full min-w-0 flex-col overflow-hidden border-r border-border">
+              <main className="flex h-full min-w-0 flex-col overflow-hidden rounded-[14px] border border-border bg-dls-surface shadow-[0_8px_24px_rgba(15,23,42,0.06)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.45)] mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
           <header className="z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
             <div className="flex min-w-0 items-center gap-3">
               {shellConfig.sidebar ? <SidebarTrigger className="mac:hidden" /> : null}
@@ -1088,6 +1088,32 @@ export function SessionPage(props: SessionPageProps) {
                 </Tooltip>
               ) : null}
               <NotificationBell />
+              <Tooltip>
+                <TooltipTrigger
+                  render={
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      className={cn(
+                        "rounded-xl text-gray-10 transition-colors hover:bg-muted hover:text-foreground",
+                        sidePanelOpen && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
+                      )}
+                      aria-label={sidePanelOpen ? "Close side panel" : "Open side panel"}
+                      aria-pressed={sidePanelOpen}
+                      onClick={() => {
+                        if (sidePanelOpen) {
+                          closeRightPane();
+                        } else {
+                          openBrowserRailPane();
+                        }
+                      }}
+                    >
+                      <PanelRight size={17} />
+                    </Button>
+                  }
+                />
+                <TooltipContent>{sidePanelOpen ? "Close side panel" : "Open side panel"}</TooltipContent>
+              </Tooltip>
               {showCloudSignIn ? (
                 <Button
                   variant="secondary"
@@ -1349,14 +1375,15 @@ export function SessionPage(props: SessionPageProps) {
             </ResizablePanel>
               {sidePanelOpen ? (
               <>
-                <ResizableHandle withHandle className="hidden lg:flex" />
+                <ResizableHandle withHandle className="hidden bg-transparent lg:flex" />
                 <ResizablePanel
                   panelRef={browserPanelRef}
                   defaultSize={`${activeSidePanel === "extensions" ? Math.max(browserPanelDefaultWidth, 480) : browserPanelDefaultWidth}px`}
                   minSize={activeSidePanel === "extensions" ? "420px" : "320px"}
                   maxSize="70%"
-                  className="min-h-0 overflow-hidden lg:flex lg:flex-col"
+                  className="min-h-0 overflow-hidden pl-1 lg:flex lg:flex-col"
                 >
+                  <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[14px] border border-border bg-dls-surface shadow-[0_8px_24px_rgba(15,23,42,0.06)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.45)] mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
                   {activeSidePanel === "extensions" && props.settingsSlot ? (
                     <div className="flex h-full min-h-0 flex-col overflow-y-auto bg-background">
                       {props.settingsSlot}
@@ -1378,11 +1405,12 @@ export function SessionPage(props: SessionPageProps) {
                       onClose={closeRightPane}
                     />
                   ) : null}
+                  </div>
                 </ResizablePanel>
               </>
             ) : null}
           </ResizablePanelGroup>
-          <aside className="flex w-11 shrink-0 flex-col items-center gap-1 border-l border-border bg-background/95 px-1 py-2 text-muted-foreground mac:titlebar-no-drag">
+          <aside className="flex w-11 shrink-0 flex-col items-center gap-1.5 px-1 py-2 text-muted-foreground mac:titlebar-no-drag">
             {isElectronRuntime() ? (
               <Button
                 variant="ghost"

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1037,6 +1037,7 @@ export function SessionPage(props: SessionPageProps) {
           }}
           onReorderWorkspaces={props.sidebar.onReorderWorkspaces}
           onStartResize={startLeftSidebarResize}
+          onOpenAccountSettings={props.onOpenSettings}
         />
         <SidebarInset className="min-h-0 overflow-hidden bg-sidebar mac:bg-transparent mac:[&_header]:transition-[padding-left] mac:[&_header]:duration-200 mac:[&_header]:ease-linear mac:peer-data-[state=collapsed]:[&_header]:pl-28 mac:max-md:[&_header]:pl-28">
           <div className="flex min-h-0 flex-1 py-2 pl-2">
@@ -1047,10 +1048,10 @@ export function SessionPage(props: SessionPageProps) {
           >
             <ResizablePanel minSize="360px" className="min-w-0">
               <main className="flex h-full min-w-0 flex-col overflow-hidden rounded-[14px] border border-border bg-dls-surface shadow-[0_8px_24px_rgba(15,23,42,0.06)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.45)] mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
-          <header className="z-10 flex h-10 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
+          <header className="z-10 flex h-9 shrink-0 items-center justify-between border-b border-border px-4 md:px-6 mac:titlebar-drag  mac:backdrop-blur-2xl mac:backdrop-saturate-150 @container/titlebar">
             <div className="flex min-w-0 items-center gap-3">
               {shellConfig.sidebar ? <SidebarTrigger className="mac:hidden" /> : null}
-              <h1 className="truncate text-[15px] font-semibold text-dls-text">
+              <h1 className="truncate text-[13px] font-medium text-dls-text">
                 {showWorkspaceSetupEmptyState
                   ? t("session.create_or_connect_workspace")
                   : selectedSessionTitle || t("session.default_title")}
@@ -1080,7 +1081,7 @@ export function SessionPage(props: SessionPageProps) {
                         aria-label="Find in conversation"
                         onClick={() => useSessionFindStore.getState().openFind({ sessionId: findButtonSessionId })}
                       >
-                        <TextSearch size={17} />
+                        <TextSearch size={16} />
                       </Button>
                     }
                   />
@@ -1108,7 +1109,7 @@ export function SessionPage(props: SessionPageProps) {
                         }
                       }}
                     >
-                      <PanelRight size={17} />
+                      <PanelRight size={16} />
                     </Button>
                   }
                 />
@@ -1233,7 +1234,7 @@ export function SessionPage(props: SessionPageProps) {
                     </ResizablePanel>
                     {canRenderSplitSurface ? (
                       <>
-                        <ResizableHandle withHandle />
+                        <ResizableHandle />
                         <ResizablePanel
                           minSize="320px"
                           className="min-h-0 min-w-0"
@@ -1341,7 +1342,7 @@ export function SessionPage(props: SessionPageProps) {
             </ResizablePanel>
             {props.terminalOpen ? (
               <>
-                <ResizableHandle withHandle />
+                <ResizableHandle />
                 <ResizablePanel defaultSize="280px" minSize="160px" maxSize="55%" className="min-h-0">
                   <TerminalDock
                     workspaceRoot={props.selectedWorkspaceRoot}
@@ -1375,7 +1376,7 @@ export function SessionPage(props: SessionPageProps) {
             </ResizablePanel>
               {sidePanelOpen ? (
               <>
-                <ResizableHandle withHandle className="hidden bg-transparent lg:flex" />
+                <ResizableHandle className="hidden bg-transparent lg:flex" />
                 <ResizablePanel
                   panelRef={browserPanelRef}
                   defaultSize={`${activeSidePanel === "extensions" ? Math.max(browserPanelDefaultWidth, 480) : browserPanelDefaultWidth}px`}
@@ -1410,7 +1411,7 @@ export function SessionPage(props: SessionPageProps) {
               </>
             ) : null}
           </ResizablePanelGroup>
-          <aside className="flex w-11 shrink-0 flex-col items-center gap-1.5 px-1 py-2 text-muted-foreground mac:titlebar-no-drag">
+          <aside className="flex w-9 shrink-0 flex-col items-center gap-1 px-0.5 py-2 text-muted-foreground mac:titlebar-no-drag">
             {isElectronRuntime() ? (
               <Button
                 variant="ghost"
@@ -1424,7 +1425,7 @@ export function SessionPage(props: SessionPageProps) {
                 aria-label="Browser"
                 aria-pressed={panelRailActive}
               >
-                <Globe size={17} />
+                <Globe size={15} />
               </Button>
             ) : null}
             {voiceExtensionEnabled ? (
@@ -1440,7 +1441,7 @@ export function SessionPage(props: SessionPageProps) {
                 aria-label="Voice Mode"
                 aria-pressed={voiceRailActive}
               >
-                <Mic2 size={17} />
+                <Mic2 size={15} />
               </Button>
             ) : null}
             <Button
@@ -1456,7 +1457,7 @@ export function SessionPage(props: SessionPageProps) {
               aria-pressed={panelRailActive}
               disabled={!hasArtifactTargets}
             >
-              <FileText size={17} />
+              <FileText size={15} />
               {artifactTargetCount > 0 ? (
                 <span className="absolute right-0 top-0 flex min-w-3.5 translate-x-1 -translate-y-1 items-center justify-center rounded-full bg-primary px-1 text-[9px] font-semibold leading-3 text-primary-foreground">
                   {artifactTargetCount > 9 ? "9+" : artifactTargetCount}
@@ -1475,7 +1476,7 @@ export function SessionPage(props: SessionPageProps) {
               aria-label="Extensions"
               aria-pressed={extensionsRailActive}
             >
-              <Settings2 size={17} />
+              <Settings2 size={15} />
             </Button>
           </aside>
           </div>

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1382,7 +1382,7 @@ export function SessionPage(props: SessionPageProps) {
                   defaultSize={`${activeSidePanel === "extensions" ? Math.max(browserPanelDefaultWidth, 480) : browserPanelDefaultWidth}px`}
                   minSize={activeSidePanel === "extensions" ? "420px" : "320px"}
                   maxSize="70%"
-                  className="min-h-0 overflow-hidden pl-1 lg:flex lg:flex-col"
+                  className="min-h-0 overflow-hidden pl-2 lg:flex lg:flex-col"
                 >
                   <div className="flex h-full min-h-0 min-w-0 flex-1 flex-col overflow-hidden rounded-[14px] border border-border bg-dls-surface shadow-[0_8px_24px_rgba(15,23,42,0.06)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.45)] mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
                   {activeSidePanel === "extensions" && props.settingsSlot ? (

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -1044,7 +1044,7 @@ export function SessionPage(props: SessionPageProps) {
           <ResizablePanelGroup
             orientation="horizontal"
             onLayoutChanged={sidePanelOpen ? commitBrowserPanelWidth : undefined}
-            className="min-h-0 flex-1"
+            className="min-h-0 flex-1 rounded-[14px]"
           >
             <ResizablePanel minSize="360px" className="min-w-0">
               <main className="flex h-full min-w-0 flex-col overflow-hidden rounded-[14px] border border-border bg-dls-surface shadow-[0_8px_24px_rgba(15,23,42,0.06)] dark:shadow-[0_10px_30px_rgba(0,0,0,0.45)] mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1027,7 +1027,7 @@ export function AppSidebar(props: AppSidebarProps) {
     <SidebarContext.Provider value={contextValue}>
       <Sidebar
         collapsible="offcanvas"
-        className="mac:**:data-[sidebar=sidebar]:bg-transparent"
+        className="border-e-0 mac:**:data-[sidebar=sidebar]:bg-transparent"
       >
         <div className="hidden h-14 mac:block mac:titlebar-drag"/>
         {brandLogoUrl ? (

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -748,7 +748,7 @@ function SidebarSplitPill({ workspaceSessionGroups, selectedWorkspaceId, selecte
 
   return (
     <div className="px-2 pb-1">
-      <div className="mb-1 flex items-center gap-1 px-1 text-[10px] font-medium uppercase tracking-wide text-sidebar-foreground/50">
+      <div className="mb-1 flex items-center gap-1 px-1 text-[12px] font-medium uppercase tracking-wide text-sidebar-foreground/50">
         <Columns2 className="size-3" />
         {t("session_management.split_view")}
       </div>
@@ -1174,7 +1174,7 @@ export function AppSidebar(props: AppSidebarProps) {
             ) : null}
             {/* pl-4 (16px): aligns with workspace titles now that the color dot is gone. */}
             <div className="group/workspaces-header flex items-center pb-1 pl-4 pr-3 pt-2">
-              <span className="text-[11px] font-normal uppercase tracking-[0.04em] text-muted-foreground">
+              <span className="text-[12px] font-normal uppercase tracking-[0.04em] text-muted-foreground">
                 {t("workspace_list.title")}
               </span>
               <button
@@ -1239,7 +1239,7 @@ function GlobalPinnedSessions({ entries }: { entries: GlobalPinnedSessionEntry[]
     <SidebarGroup data-global-pinned-sessions className="pb-1 pt-2">
       <SidebarGroupContent>
         {/* pl-2 (8px) + group p-2 = 16px: aligns with the WORKSPACES header lane. */}
-        <div className="pb-1 pl-2 pr-3 text-[11px] font-normal uppercase tracking-[0.04em] text-muted-foreground">
+        <div className="pb-1 pl-2 pr-3 text-[12px] font-normal uppercase tracking-[0.04em] text-muted-foreground">
           {t("session_management.pinned")}
         </div>
         <SidebarMenu>
@@ -1279,7 +1279,7 @@ function GlobalArchivedSessions({ entries }: { entries: GlobalArchivedSessionEnt
                 className="group/separator flex w-full cursor-pointer items-center gap-3 px-3 pb-1 pt-2.5 rounded transition-colors hover:bg-sidebar-accent/50"
               >
                 <Archive className="size-3 shrink-0 text-muted-foreground" />
-                <span className="text-[11px] font-medium uppercase tracking-wide text-muted-foreground">
+                <span className="text-[12px] font-medium uppercase tracking-wide text-muted-foreground">
                   {t("session_management.archived_label")}
                 </span>
                 <span className="text-[10px] tabular-nums text-muted-foreground/70">{entries.length}</span>
@@ -1924,7 +1924,7 @@ function SessionGroupSeparator({ label, count, expanded, onToggle, group, groups
     >
       <ChevronRight className={cn("size-3.5 shrink-0 text-muted-foreground transition-transform duration-200", expanded && "rotate-90")} />
       <span
-        className="min-w-0 flex-1 cursor-grab touch-none truncate text-[11px] font-normal uppercase tracking-[0.04em] text-muted-foreground active:cursor-grabbing"
+        className="min-w-0 flex-1 cursor-grab touch-none truncate text-[12px] font-normal uppercase tracking-[0.04em] text-muted-foreground active:cursor-grabbing"
         onPointerDown={onTitlePointerDown}
       >
         {label}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -21,6 +21,7 @@ import {
   RotateCcw,
   Settings,
   FolderOpen,
+  LogOut,
   Tag,
   UserRound,
   X,
@@ -103,7 +104,7 @@ import {
 
 import { SidebarContext, useSidebarContext } from "./app-sidebar-provider";
 import { useDenAuth } from "../../cloud/den-auth-provider";
-import { buildDenAuthUrl, readDenBootstrapConfig } from "../../../../app/lib/den";
+import { buildDenAuthUrl, clearDenSession, createDenClient, readDenBootstrapConfig, readDenSettings } from "../../../../app/lib/den";
 import { usePlatform } from "../../../kernel/platform";
 import type { SidebarContextValue } from "./app-sidebar-provider";
 import {
@@ -872,45 +873,74 @@ function SidebarAccountChip(props: { onOpenAccountSettings?: () => void }) {
   if (denAuth.status === "checking") return null;
 
   const user = denAuth.user;
-  if (!denAuth.isSignedIn || !user) {
-    return (
-      <button
-        type="button"
-        className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent"
-        onClick={() => {
-          platform.openLink(buildDenAuthUrl(readDenBootstrapConfig().baseUrl, "sign-up"));
-        }}
-      >
-        <span className="flex size-6 shrink-0 items-center justify-center rounded-full border border-dashed border-border text-muted-foreground">
-          <UserRound size={13} />
-        </span>
-        <span className="min-w-0 flex-1">
-          <span className="block truncate text-[12px] font-medium text-sidebar-foreground">Sign in</span>
-          <span className="block truncate text-[10.5px] leading-tight text-muted-foreground">Sync with OpenWork Cloud</span>
-        </span>
-      </button>
-    );
-  }
+  const signedIn = denAuth.isSignedIn && user !== null;
 
-  const label = user.name?.trim() || user.email;
+  const openSignIn = () => {
+    platform.openLink(buildDenAuthUrl(readDenBootstrapConfig().baseUrl, "sign-up"));
+  };
+
+  const logOut = () => {
+    const settings = readDenSettings();
+    if (settings.authToken) {
+      void createDenClient({ baseUrl: settings.baseUrl, token: settings.authToken })
+        .signOut()
+        .catch(() => undefined);
+    }
+    clearDenSession();
+    void denAuth.refresh();
+  };
+
   return (
-    <button
-      type="button"
-      className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent"
-      onClick={props.onOpenAccountSettings}
-      title={user.email}
-    >
-      <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[10px] font-semibold text-primary">
-        {accountInitials(user.name, user.email)}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span className="block truncate text-[12px] font-medium text-sidebar-foreground">{label}</span>
-        {user.name ? (
-          <span className="block truncate text-[10.5px] leading-tight text-muted-foreground">{user.email}</span>
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button
+            type="button"
+            className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent"
+            title={signedIn ? user.email : undefined}
+          >
+            {signedIn ? (
+              <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[10px] font-semibold text-primary">
+                {accountInitials(user.name, user.email)}
+              </span>
+            ) : (
+              <span className="flex size-6 shrink-0 items-center justify-center rounded-full border border-dashed border-border text-muted-foreground">
+                <UserRound size={13} />
+              </span>
+            )}
+            <span className="min-w-0 flex-1">
+              <span className="block truncate text-[12px] font-medium text-sidebar-foreground">
+                {signedIn ? user.name?.trim() || user.email : "Sign in"}
+              </span>
+              <span className="block truncate text-[10.5px] leading-tight text-muted-foreground">
+                {signedIn ? (user.name ? user.email : "OpenWork Cloud") : "Sync with OpenWork Cloud"}
+              </span>
+            </span>
+            <MoreHorizontal size={14} className="shrink-0 text-muted-foreground" />
+          </button>
+        }
+      />
+      <DropdownMenuContent side="top" align="start" className="w-56">
+        {signedIn ? (
+          <div className="px-2 py-1.5 text-[11px] text-muted-foreground">{user.email}</div>
         ) : null}
-      </span>
-      <MoreHorizontal size={14} className="shrink-0 text-muted-foreground" />
-    </button>
+        <DropdownMenuItem onClick={props.onOpenAccountSettings}>
+          <Settings className="size-3.5" />
+          Settings
+        </DropdownMenuItem>
+        {signedIn ? (
+          <DropdownMenuItem onClick={logOut}>
+            <LogOut className="size-3.5" />
+            Log out
+          </DropdownMenuItem>
+        ) : (
+          <DropdownMenuItem onClick={openSignIn}>
+            <UserRound className="size-3.5" />
+            Sign in
+          </DropdownMenuItem>
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
   );
 }
 
@@ -1090,7 +1120,7 @@ export function AppSidebar(props: AppSidebarProps) {
     <SidebarContext.Provider value={contextValue}>
       <Sidebar
         collapsible="offcanvas"
-        className="border-e-0 mac:**:data-[sidebar=sidebar]:bg-transparent"
+        className="border-e-0 group-data-[side=left]:border-e-0 mac:**:data-[sidebar=sidebar]:bg-transparent"
       >
         <div className="hidden h-14 mac:block mac:titlebar-drag"/>
         {brandLogoUrl ? (

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1919,7 +1919,7 @@ function SessionGroupSeparator({ label, count, expanded, onToggle, group, groups
         event.preventDefault();
         onToggle();
       }}
-      className="group/separator flex w-full items-center gap-3.5 rounded px-2 pb-1 pt-2.5 text-left transition-colors first:pt-1 hover:bg-sidebar-accent/50"
+      className="group/separator flex w-full items-center gap-1.5 rounded px-2 pb-1 pt-2.5 text-left transition-colors first:pt-1 hover:bg-sidebar-accent/50"
       aria-expanded={expanded}
     >
       <ChevronRight className={cn("size-3.5 shrink-0 text-muted-foreground transition-transform duration-200", expanded && "rotate-90")} />
@@ -2292,8 +2292,8 @@ function SessionMenuItem({
     // (light: --ow-light-hover ≈ black/5, dark: #FFFFFF17 ≈ white/9).
     // The left activity slot is the indent — dot-matrix sits in the chevron
     // lane and the title starts in the group-label lane without shifting.
-    "relative rounded-[11px] transition-[padding,background-color] duration-75 ps-3 pe-7 group-hover/menu-sub-item:pe-20 group-has-data-popup-open/menu-sub-item:pe-20 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] text-sidebar-foreground/80 data-active:text-sidebar-foreground",
-    depth > 0 && "ps-7",
+    "relative rounded-[11px] transition-[padding,background-color] duration-75 ps-1 pe-7 group-hover/menu-sub-item:pe-20 group-has-data-popup-open/menu-sub-item:pe-20 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] text-sidebar-foreground/80 data-active:text-sidebar-foreground",
+    depth > 0 && "ps-5",
   );
 
   // Pinned/archived rows identify their workspace via the tooltip title

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1216,7 +1216,6 @@ export function AppSidebar(props: AppSidebarProps) {
         </SidebarFooter>
 
         <SidebarRail
-          className="before:pointer-events-none before:absolute before:inset-y-0 before:left-[calc(50%+1px)] before:right-0 before:content-[''] group-data-[state=expanded]:before:bg-sidebar"
           style={{ cursor: "col-resize" }}
           aria-label={props.onStartResize ? t("session.resize_workspace_column") : undefined}
           title={props.onStartResize ? t("session.resize_workspace_column") : undefined}

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -22,6 +22,7 @@ import {
   Settings,
   FolderOpen,
   Tag,
+  UserRound,
   X,
 } from "lucide-react";
 import { LazyMotion, Reorder, domMax, m, useDragControls } from "motion/react";
@@ -51,6 +52,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
+  SidebarFooter,
   SidebarMenuSub,
   SidebarMenuSubButton,
   SidebarMenuSubItem,
@@ -100,6 +102,9 @@ import {
 } from "@/components/ui/select";
 
 import { SidebarContext, useSidebarContext } from "./app-sidebar-provider";
+import { useDenAuth } from "../../cloud/den-auth-provider";
+import { buildDenAuthUrl, readDenBootstrapConfig } from "../../../../app/lib/den";
+import { usePlatform } from "../../../kernel/platform";
 import type { SidebarContextValue } from "./app-sidebar-provider";
 import {
   MAX_SESSIONS_PREVIEW,
@@ -835,6 +840,7 @@ export type AppSidebarProps = {
   };
   onReorderWorkspaces?: (workspaceIds: string[]) => void;
   onStartResize?: React.PointerEventHandler<HTMLButtonElement>;
+  onOpenAccountSettings?: () => void;
 };
 
 function useSessionTree(
@@ -849,6 +855,63 @@ function useSessionTree(
 
 function isSessionActivityStatus(status: string | undefined): status is SessionActivityStatus {
   return status === "idle" || status === "thinking" || status === "responding" || status === "error" || status === "compacting" || status === "waiting";
+}
+
+function accountInitials(name: string | null, email: string) {
+  const source = name?.trim() || email;
+  const parts = source.split(/[\s@._-]+/).filter(Boolean);
+  if (parts.length === 0) return "?";
+  if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+  return (parts[0][0] + parts[1][0]).toUpperCase();
+}
+
+function SidebarAccountChip(props: { onOpenAccountSettings?: () => void }) {
+  const denAuth = useDenAuth();
+  const platform = usePlatform();
+
+  if (denAuth.status === "checking") return null;
+
+  const user = denAuth.user;
+  if (!denAuth.isSignedIn || !user) {
+    return (
+      <button
+        type="button"
+        className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent"
+        onClick={() => {
+          platform.openLink(buildDenAuthUrl(readDenBootstrapConfig().baseUrl, "sign-up"));
+        }}
+      >
+        <span className="flex size-6 shrink-0 items-center justify-center rounded-full border border-dashed border-border text-muted-foreground">
+          <UserRound size={13} />
+        </span>
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-[12px] font-medium text-sidebar-foreground">Sign in</span>
+          <span className="block truncate text-[10.5px] leading-tight text-muted-foreground">Sync with OpenWork Cloud</span>
+        </span>
+      </button>
+    );
+  }
+
+  const label = user.name?.trim() || user.email;
+  return (
+    <button
+      type="button"
+      className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent"
+      onClick={props.onOpenAccountSettings}
+      title={user.email}
+    >
+      <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[10px] font-semibold text-primary">
+        {accountInitials(user.name, user.email)}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span className="block truncate text-[12px] font-medium text-sidebar-foreground">{label}</span>
+        {user.name ? (
+          <span className="block truncate text-[10.5px] leading-tight text-muted-foreground">{user.email}</span>
+        ) : null}
+      </span>
+      <MoreHorizontal size={14} className="shrink-0 text-muted-foreground" />
+    </button>
+  );
 }
 
 export function AppSidebar(props: AppSidebarProps) {
@@ -1147,6 +1210,10 @@ export function AppSidebar(props: AppSidebarProps) {
             ) : null}
           </m.div>
         </LazyMotion>
+
+        <SidebarFooter className="border-t border-sidebar-border/60 p-1.5">
+          <SidebarAccountChip onOpenAccountSettings={props.onOpenAccountSettings} />
+        </SidebarFooter>
 
         <SidebarRail
           className="before:pointer-events-none before:absolute before:inset-y-0 before:left-[calc(50%+1px)] before:right-0 before:content-[''] group-data-[state=expanded]:before:bg-sidebar"

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -280,7 +280,7 @@ function SessionMenuContent({ variant, sessionId, workspaceId, isPinned, isArchi
           <DropdownMenuSubContent className="w-52">
             {groups.length === 0 ? (
               <DropdownMenuItem onClick={() => ctx.onOpenCreateGroupModal?.(workspaceId)}>
-                <span className="min-w-0 flex-1 truncate text-muted-foreground">
+                <span className="min-w-0 flex-1 ow-fade-truncate text-muted-foreground">
                   {t("session_management.no_groups_yet")}
                 </span>
                 <span className="ml-auto flex size-5 shrink-0 items-center justify-center rounded-full bg-foreground/10 text-foreground">
@@ -365,7 +365,7 @@ function SessionMenuContent({ variant, sessionId, workspaceId, isPinned, isArchi
         <ContextMenuSubContent>
           {groups.length === 0 ? (
             <ContextMenuItem onClick={() => ctx.onOpenCreateGroupModal?.(workspaceId)}>
-              <span className="min-w-0 flex-1 truncate text-muted-foreground">
+              <span className="min-w-0 flex-1 ow-fade-truncate text-muted-foreground">
                 {t("session_management.no_groups_yet")}
               </span>
               <span className="ml-auto flex size-5 shrink-0 items-center justify-center rounded-full bg-foreground/10 text-foreground">
@@ -773,7 +773,7 @@ function SidebarSplitPill({ workspaceSessionGroups, selectedWorkspaceId, selecte
             >
               <button
                 type="button"
-                className="min-w-0 flex-1 truncate text-left"
+                className="min-w-0 flex-1 ow-fade-truncate text-left"
                 title={title}
                 onClick={() => useWorkbenchStore.getState().focusPane(pane)}
               >
@@ -1489,7 +1489,7 @@ function WorkspaceHeader({
         className="min-w-0 flex-1 cursor-grab touch-none transition-[padding] duration-75 active:cursor-grabbing group-hover/workspace-header:pr-16 group-has-[[data-workspace-actions]:focus-within]/workspace-header:pr-16 group-has-data-popup-open/workspace-header:pr-11 group-hover/workspace-header:group-has-data-popup-open/workspace-header:pr-16 pr-2"
         onPointerDown={onTitlePointerDown}
       >
-        <span className="block truncate">{workspaceLabel(workspace)}</span>
+        <span className="block ow-fade-truncate">{workspaceLabel(workspace)}</span>
         {statusLabel ? (
           <span className={cn("block text-xs", isError ? "text-destructive" : "text-muted-foreground")}>
             {statusLabel}
@@ -1954,7 +1954,7 @@ function SessionGroupSeparator({ label, count, expanded, onToggle, group, groups
     >
       <ChevronRight className={cn("size-3.5 shrink-0 text-muted-foreground transition-transform duration-200", expanded && "rotate-90")} />
       <span
-        className="min-w-0 flex-1 cursor-grab touch-none truncate text-[12px] font-normal uppercase tracking-[0.04em] text-muted-foreground active:cursor-grabbing"
+        className="min-w-0 flex-1 cursor-grab touch-none ow-fade-truncate text-[12px] font-normal uppercase tracking-[0.04em] text-muted-foreground active:cursor-grabbing"
         onPointerDown={onTitlePointerDown}
       >
         {label}
@@ -2370,7 +2370,7 @@ function SessionMenuItem({
                 aria-label={accessibleState}
               >
                 {leading}
-                <span className="min-w-0 flex-1 truncate" title={itemTitle}>
+                <span className="min-w-0 flex-1 ow-fade-truncate" title={itemTitle}>
                   {displayTitle}
                 </span>
                 <span className="flex size-6 shrink-0 items-center justify-center">
@@ -2397,7 +2397,7 @@ function SessionMenuItem({
           className={rowButtonClass}
         >
           {leading}
-          <span className="min-w-0 flex-1 truncate" title={itemTitle}>{displayTitle}</span>
+          <span className="min-w-0 flex-1 ow-fade-truncate" title={itemTitle}>{displayTitle}</span>
         </SidebarMenuSubButton>
       </SessionContextMenu>
       {trailing}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1221,7 +1221,7 @@ export function ReactSessionComposer(props: ComposerProps) {
       <div className="max-w-[800px] mx-auto">
         {/* Main composer panel */}
         <div
-          className={`relative overflow-visible rounded-[24px] border border-dls-border bg-dls-surface transition-all ${panelRoundedClass}`}
+          className={`relative overflow-visible rounded-[18px] border border-dls-border bg-dls-surface transition-all ${panelRoundedClass}`}
         >
           {props.topAccessory ? <div className="relative z-10">{props.topAccessory}</div> : null}
 

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -1181,7 +1181,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
         <PlainTextPlugin
           contentEditable={
             <ContentEditable
-              className="min-h-[60px] max-h-[280px] w-full resize-none overflow-y-auto bg-transparent text-[15px] leading-6 text-dls-text outline-none placeholder:text-dls-secondary [&_p]:min-h-[1.5rem] [&_p]:m-0"
+              className="min-h-[60px] max-h-[280px] w-full resize-none overflow-y-auto bg-transparent text-[13px] leading-[1.55] text-dls-text outline-none placeholder:text-dls-secondary [&_p]:min-h-[1.5rem] [&_p]:m-0"
               aria-placeholder={props.placeholder}
               placeholder={<span />}
               onPaste={props.onPaste}
@@ -1191,7 +1191,7 @@ export const LexicalPromptEditor = forwardRef<LexicalPromptEditorHandle, EditorP
             />
           }
           placeholder={
-            <div className="pointer-events-none absolute left-0 top-0 text-[15px] leading-6 text-dls-secondary/70">
+            <div className="pointer-events-none absolute left-0 top-0 text-[13px] leading-[1.55] text-dls-secondary/70">
               {props.placeholder}
             </div>
           }

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -480,6 +480,9 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
         partition: BROWSER_SESSION_PARTITION,
       },
     });
+    // Match the renderer's rounded panel card so the native view's square
+    // corners don't poke out past the card's border radius.
+    view.setBorderRadius?.(14);
     const tab = { tabId, view, favicon: null };
     browserTabs.set(tabId, tab);
     browserTabOrder.push(tabId);

--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -480,9 +480,6 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
         partition: BROWSER_SESSION_PARTITION,
       },
     });
-    // Match the renderer's rounded panel card so the native view's square
-    // corners don't poke out past the card's border radius.
-    view.setBorderRadius?.(14);
     const tab = { tabId, view, favicon: null };
     browserTabs.set(tabId, tab);
     browserTabOrder.push(tabId);


### PR DESCRIPTION
## Summary
Implements the Arc-style shell design from the Paper composites:

- Main content and side panel render as elevated rounded cards floating over the sidebar-colored background, with matching 8px gutters.
- Header: notification bell, side-panel toggle, denser 36px height; right icon rail for browser/artifacts.
- Denser chrome overall: 13px base font on a system-UI stack, 12px sidebar section labels, tighter composer radius, invisible resize handles.
- Sidebar: account/sign-in chip bottom-left (ChatGPT-style) with Settings and Log out/Sign in menu; Arc-style fade truncation for overflowing labels; tighter chevron gap.
- Fixed the thin border line between sidebar and main card, and corner clipping: react-resizable-panels forces overflow:hidden on the group, so the outer group now carries the same 14px radius as the cards.

## Testing
- `tsc --noEmit` passes in apps/app.
- Verified live in the dev Electron app via CDP (light/dark, split view, browser panel, account menu open/sign-in flow).

Made with [Cursor](https://cursor.com)