### PR TITLE
feat(den-web): server-render the workspace favicon from the org square icon

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -175,9 +175,15 @@ export function WorkspaceFavicon({
 }: {
   metadata: string | null | undefined;
 }) {
+  const orgContextLoading = metadata === undefined;
   const iconUrl = getManagedBrandIconUrl(metadata ?? null);
 
   useEffect(() => {
+    if (orgContextLoading) {
+      // Keep the server-rendered favicon until the org context is known.
+      return;
+    }
+
     let favicon = document.head.querySelector<HTMLLinkElement>('link[rel="icon"]');
     if (!favicon) {
       favicon = document.createElement("link");
@@ -211,7 +217,7 @@ export function WorkspaceFavicon({
         favicon.setAttribute("type", previousType);
       }
     };
-  }, [iconUrl]);
+  }, [orgContextLoading, iconUrl]);
 
   return null;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/layout.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/layout.tsx
@@ -1,6 +1,48 @@
+import type { Metadata } from "next";
+import { headers } from "next/headers";
+
+import { getManagedBrandIconUrl, parseOrgListPayload } from "../_lib/den-org";
 import { OrgDashboardShell } from "./_components/org-dashboard-shell";
 import { OrgDashboardProvider } from "./_providers/org-dashboard-provider";
 import { DashboardQueryClientProvider } from "./_providers/query-client-provider";
+
+async function getWorkspaceFaviconUrl(): Promise<string | null> {
+  const apiBase = process.env.DEN_API_BASE?.trim().replace(/\/+$/, "");
+  if (!apiBase) {
+    return null;
+  }
+
+  const cookie = (await headers()).get("cookie");
+  if (!cookie) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(`${apiBase}/v1/me/orgs`, {
+      headers: { cookie },
+      cache: "no-store",
+      signal: AbortSignal.timeout(3000),
+    });
+    if (!response.ok) {
+      return null;
+    }
+
+    const { orgs, activeOrgId } = parseOrgListPayload(await response.json());
+    const activeOrg =
+      (activeOrgId ? orgs.find((org) => org.id === activeOrgId) : null) ??
+      orgs.find((org) => org.isActive) ??
+      orgs[0] ??
+      null;
+    return activeOrg ? getManagedBrandIconUrl(activeOrg.metadata) : null;
+  } catch {
+    return null;
+  }
+}
+
+export async function generateMetadata(): Promise<Metadata> {
+  const iconUrl = await getWorkspaceFaviconUrl();
+  return iconUrl ? { icons: { icon: iconUrl } } : {};
+}
 
 export default function DashboardLayout({
   children,

--- a/ee/apps/den-web/tests/workspace-branding-polish.test.ts
+++ b/ee/apps/den-web/tests/workspace-branding-polish.test.ts
@@ -8,6 +8,9 @@ const shellPath = fileURLToPath(
 const appearancePath = fileURLToPath(
   new URL("../app/(den)/dashboard/_components/brand-appearance-screen.tsx", import.meta.url),
 );
+const dashboardLayoutPath = fileURLToPath(
+  new URL("../app/(den)/dashboard/layout.tsx", import.meta.url),
+);
 
 describe("workspace branding polish", () => {
   test("uses the canonical managed square icon for the workspace favicon", () => {
@@ -18,6 +21,23 @@ describe("workspace branding polish", () => {
     expect(source).toContain('<WorkspaceFavicon metadata={orgContext?.organization.metadata} />');
     expect(source).toContain('DEFAULT_WORKSPACE_FAVICON_HREF = "/openwork-mark.svg"');
     expect(source).toContain("favicon.href = DEFAULT_WORKSPACE_FAVICON_HREF");
+  });
+
+  test("keeps the server-rendered favicon while the org context is loading", () => {
+    const source = readFileSync(shellPath, "utf8");
+
+    expect(source).toContain("const orgContextLoading = metadata === undefined;");
+    expect(source).toContain("if (orgContextLoading) {");
+    expect(source).toContain("[orgContextLoading, iconUrl]");
+  });
+
+  test("server-renders the workspace favicon from the managed square icon", () => {
+    const source = readFileSync(dashboardLayoutPath, "utf8");
+
+    expect(source).toContain("export async function generateMetadata");
+    expect(source).toContain("/v1/me/orgs");
+    expect(source).toContain("getManagedBrandIconUrl(activeOrg.metadata)");
+    expect(source).toContain("icons: { icon: iconUrl }");
   });
 
   test("does not show the artificial loading line in the desktop identity preview", () => {


### PR DESCRIPTION
## What

When an organization sets a **square app icon** (Brand appearance), the dashboard favicon already followed it — but only client-side, so the tab flashed the default OpenWork mark until the org context finished loading.

This PR makes the favicon server-rendered:

- `app/(den)/dashboard/layout.tsx`: new `generateMetadata()` forwards the request cookies to den-api `GET /v1/me/orgs` (3s timeout, fail-safe to default), picks the active org, and resolves the icon with the same `getManagedBrandIconUrl` helper the client uses. The initial HTML now ships `<link rel="icon">` pointing at the signed square-icon asset.
- `org-dashboard-shell.tsx`: `WorkspaceFavicon` no-ops while org context is still loading (`metadata === undefined`) so hydration doesn't reset the SSR favicon back to the default — which would have reintroduced the flash.
- `tests/workspace-branding-polish.test.ts`: two new tests covering the SSR favicon and the loading guard.

## Tests run

- `bun test tests/workspace-branding-polish.test.ts` — 4 pass, 0 fail (on top of latest `origin/dev`)
- `pnpm typecheck` (den-web) — clean
- `pnpm test` (den-web) — 69 pass; 1 pre-existing failure in `install-errors.test.ts` (copy drift, fails on `dev` HEAD with this change stashed; unrelated)

## Validation caveat

No fraimz / live e2e proof: I did not have a running Den stack in this environment. Manual repro for a reviewer: set a square app icon in Brand appearance, hard-reload the dashboard, view-source — `<link rel="icon">` should already point at `/v1/brand-assets/<orgId>/icon/<version>.png?signature=...` before any JS runs. Clearing the icon falls back to `/openwork-mark.svg`.