### PR TITLE
feat: add guided organization install activation

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -2407,7 +2407,12 @@ if (!app.requestSingleInstanceLock()) {
 
   app.on("open-url", async (event, url) => {
     event.preventDefault();
-    await createMainWindow();
+    const win = await createMainWindow();
+    if (win.isMinimized()) {
+      win.restore();
+    }
+    win.show();
+    win.focus();
     queueDeepLinks([url]);
   });
 

--- a/apps/installer/src/config-sources.ts
+++ b/apps/installer/src/config-sources.ts
@@ -1,4 +1,9 @@
-import { installConfigSchema, installConfigUrlFor, type InstallConfig } from "@openwork/install-config"
+import {
+  installConfigSchema,
+  installConfigUrlFor,
+  installExperienceConfigSchema,
+  type InstallConfig,
+} from "@openwork/install-config"
 import { BUILD_API_URL, BUILD_APP_NAME, BUILD_CLIENT_NAME, BUILD_LOGO_URL, BUILD_REQUIRE_SIGNIN, BUILD_WEB_URL } from "./generated/build-config"
 import type { InstallerConfig } from "./config"
 import { fetchWithSystemCa } from "./system-ca"
@@ -8,10 +13,17 @@ export type InstallerConfigSource = "env" | "build" | "install-link"
 export type InstallerConfigResolution = {
   config: InstallerConfig
   source: InstallerConfigSource
+  activation: InstallerActivation | null
+  installLink: string | null
+}
+
+export type InstallerActivation = {
+  url: string
+  expiresAt: string
 }
 
 export type InstallLinkConfigResult =
-  | { status: "resolved"; config: InstallerConfig }
+  | { status: "resolved"; config: InstallerConfig; activation: InstallerActivation | null }
   | { status: "invalid-input" }
   | { status: "not-found" }
   | { status: "unreachable"; reason: "tls" | "network" }
@@ -81,14 +93,27 @@ function toInstallerConfig(config: InstallConfig): InstallerConfig {
   }
 }
 
-function parseConfigPayload(payload: unknown, label: string, options?: ConfigSourceOptions): InstallerConfig | null {
+function parseConfigPayload(
+  payload: unknown,
+  label: string,
+  options?: ConfigSourceOptions,
+): { config: InstallerConfig; activation: InstallerActivation | null } | null {
   const parsed = installConfigSchema.safeParse(payload)
   if (!parsed.success) {
     warn(options, `${label} did not contain a valid OpenWork install config.`)
     return null
   }
   try {
-    return toInstallerConfig(parsed.data)
+    const experience = installExperienceConfigSchema.safeParse(payload)
+    return {
+      config: toInstallerConfig(parsed.data),
+      activation: experience.success
+        ? {
+            url: experience.data.activationUrl,
+            expiresAt: experience.data.activationExpiresAt,
+          }
+        : null,
+    }
   } catch {
     warn(options, `${label} did not contain a valid OpenWork install config.`)
     return null
@@ -204,8 +229,8 @@ async function fetchInstallConfig(configUrl: string, options?: ConfigSourceOptio
     warn(options, `${configUrl} did not contain a valid OpenWork install config.`)
     return { status: "unresolved" }
   }
-  const config = parseConfigPayload(payload, configUrl, options)
-  return config ? { status: "resolved", config } : { status: "unresolved" }
+  const resolved = parseConfigPayload(payload, configUrl, options)
+  return resolved ? { status: "resolved", ...resolved } : { status: "unresolved" }
 }
 
 function isTlsError(error: unknown): boolean {
@@ -269,18 +294,23 @@ export function installerConfigSourceLabel(source: InstallerConfigSource) {
 export async function resolveInstallerConfig(options: ResolveOptions = {}): Promise<InstallerConfigResolution> {
   const envConfig = envOverrides(options.env ?? process.env)
   if (envConfig) {
-    return { config: envConfig, source: "env" }
+    return { config: envConfig, source: "env", activation: null, installLink: null }
   }
 
   const buildConfig = buildConstantsConfig(options.buildConstants)
   if (buildConfig) {
-    return { config: buildConfig, source: "build" }
+    return { config: buildConfig, source: "build", activation: null, installLink: null }
   }
 
   if (options.installLink) {
-    const linkConfig = await installLinkConfig(options.installLink, options)
-    if (linkConfig) {
-      return { config: linkConfig, source: "install-link" }
+    const result = await resolveInstallLinkConfig(options.installLink, options)
+    if (result.status === "resolved") {
+      return {
+        config: result.config,
+        source: "install-link",
+        activation: result.activation,
+        installLink: options.installLink,
+      }
     }
   }
 

--- a/apps/installer/src/config.ts
+++ b/apps/installer/src/config.ts
@@ -23,6 +23,7 @@ export {
   resolveOptionalInstallerConfig,
   type BuildConstants,
   type InstallLinkConfigResult,
+  type InstallerActivation,
   type InstallerConfigResolution,
   type InstallerConfigSource,
 } from "./config-sources"

--- a/apps/installer/src/index.ts
+++ b/apps/installer/src/index.ts
@@ -2,6 +2,7 @@ import { spawn } from "node:child_process"
 
 import { installerConfigSourceLabel, resolveInstallerConfig, resolveOptionalInstallerConfig } from "./config"
 import { runInstall, scheduleInstallerSelfCleanup } from "./install"
+import { openExternalUrl } from "./open-external-url"
 import { startInstallerServer } from "./server"
 import { loadSystemCaCertificates } from "./system-ca"
 
@@ -225,11 +226,6 @@ async function exitWhenInstallSettles(): Promise<never> {
   process.exit(0)
 }
 
-function openInBrowser(url: string) {
-  const command = process.platform === "darwin" ? ["open", url] : process.platform === "win32" ? ["cmd", "/c", "start", "", url] : ["xdg-open", url]
-  Bun.spawn(command, { stdio: ["ignore", "ignore", "ignore"] })
-}
-
 if (process.env.OPENWORK_INSTALLER_UI === "manual") {
   // Manual UI mode: serve the installer UI without opening any window or
   // browser (headless CI, remote debugging, UI evals). The URL is printed so
@@ -271,7 +267,7 @@ try {
     process.exit(3)
   }
   console.warn(`[openwork-installer] native window unavailable (${error instanceof Error ? error.message : String(error)}); opening browser UI`)
-  openInBrowser(ready.url)
+  void openExternalUrl(ready.url)
   uiServer.onExit(() => void exitWhenInstallSettles())
 }
 }

--- a/apps/installer/src/open-external-url.ts
+++ b/apps/installer/src/open-external-url.ts
@@ -1,0 +1,22 @@
+export function externalUrlCommand(url: string, platform: NodeJS.Platform = process.platform): string[] {
+  const parsed = new URL(url)
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error("Only browser URLs can be opened.")
+  }
+  if (platform === "darwin") return ["open", parsed.toString()]
+  if (platform === "win32") return ["cmd", "/c", "start", "", parsed.toString()]
+  return ["xdg-open", parsed.toString()]
+}
+
+export async function openExternalUrl(url: string): Promise<boolean> {
+  try {
+    const child = Bun.spawn(externalUrlCommand(url), {
+      stdin: "ignore",
+      stdout: "ignore",
+      stderr: "ignore",
+    })
+    return await child.exited === 0
+  } catch {
+    return false
+  }
+}

--- a/apps/installer/src/open-external-url.ts
+++ b/apps/installer/src/open-external-url.ts
@@ -9,6 +9,9 @@ export function externalUrlCommand(url: string, platform: NodeJS.Platform = proc
 }
 
 export async function openExternalUrl(url: string): Promise<boolean> {
+  if (process.env.OPENWORK_INSTALLER_DISABLE_BROWSER_OPEN === "1") {
+    return false
+  }
   try {
     const child = Bun.spawn(externalUrlCommand(url), {
       stdin: "ignore",

--- a/apps/installer/src/server.ts
+++ b/apps/installer/src/server.ts
@@ -41,6 +41,7 @@ export function startInstallerServer(
   openBrowser: (url: string) => Promise<boolean> = openExternalUrl,
 ): InstallerServer {
   const token = randomBytes(16).toString("hex")
+  const dryRun = process.env.OPENWORK_INSTALLER_DRY_RUN === "1"
   let resolution = initialResolution
   // Warm the OS trust-store CA cache now so the first resolve-link fetch does
   // not spend its 10s abort budget waiting on PowerShell/security exports.
@@ -112,7 +113,7 @@ export function startInstallerServer(
           if (!resolution) {
             return Response.json({ error: "missing_config" }, { status: 409 })
           }
-          void runInstall(resolution.config)
+          void runInstall(resolution.config, { dryRun })
           return Response.json({ ok: true })
         }
         if (request.method === "POST" && url.pathname === "/api/launch") {

--- a/apps/installer/src/server.ts
+++ b/apps/installer/src/server.ts
@@ -2,6 +2,7 @@ import { randomBytes } from "node:crypto"
 
 import { installerConfigSourceLabel, parseInstallLinkInput, resolveInstallLinkConfig, type InstallerConfigResolution } from "./config"
 import { installStatus, launchInstalledApp, runInstall } from "./install"
+import { openExternalUrl } from "./open-external-url"
 import { loadSystemCaCertificates } from "./system-ca"
 import { renderInstallerHtml } from "./ui-html"
 
@@ -34,12 +35,31 @@ function tlsUntrustedMessage(installLink: string): string {
   return `Reached your workspace, but the secure connection isn't trusted on this computer yet. This usually means your company inspects secure traffic. Try again — if it keeps failing, ask IT to check ${certificateTarget}.`
 }
 
-export function startInstallerServer(initialResolution: InstallerConfigResolution | null, onExit: () => void): InstallerServer {
+export function startInstallerServer(
+  initialResolution: InstallerConfigResolution | null,
+  onExit: () => void,
+  openBrowser: (url: string) => Promise<boolean> = openExternalUrl,
+): InstallerServer {
   const token = randomBytes(16).toString("hex")
   let resolution = initialResolution
   // Warm the OS trust-store CA cache now so the first resolve-link fetch does
   // not spend its 10s abort budget waiting on PowerShell/security exports.
   void loadSystemCaCertificates()
+
+  async function refreshActivation() {
+    if (!resolution) return null
+    if (!resolution.installLink) return resolution.activation
+
+    const result = await resolveInstallLinkConfig(resolution.installLink)
+    if (result.status !== "resolved") return null
+    resolution = {
+      config: result.config,
+      source: "install-link",
+      activation: result.activation,
+      installLink: resolution.installLink,
+    }
+    return resolution.activation
+  }
 
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -80,7 +100,12 @@ export function startInstallerServer(initialResolution: InstallerConfigResolutio
             }
             return Response.json({ error: "install_link_invalid", message: "Install link could not be resolved." }, { status: 400 })
           }
-          resolution = { config: result.config, source: "install-link" }
+          resolution = {
+            config: result.config,
+            source: "install-link",
+            activation: result.activation,
+            installLink,
+          }
           return Response.json({ ok: true, source: installerConfigSourceLabel(resolution.source) })
         }
         if (request.method === "POST" && url.pathname === "/api/install") {
@@ -95,6 +120,33 @@ export function startInstallerServer(initialResolution: InstallerConfigResolutio
           if (!installedPath) return Response.json({ error: "not_installed" }, { status: 409 })
           launchInstalledApp(installedPath)
           return Response.json({ ok: true })
+        }
+        if (request.method === "POST" && url.pathname === "/api/activation") {
+          const activation = await refreshActivation()
+          if (!activation) {
+            return Response.json({
+              error: "activation_unavailable",
+              message: "Could not create a browser activation link. Paste the organization install link again.",
+            }, { status: 409 })
+          }
+          return Response.json({
+            activationUrl: activation.url,
+            expiresAt: activation.expiresAt,
+          })
+        }
+        if (request.method === "POST" && url.pathname === "/api/open-activation") {
+          const activation = await refreshActivation()
+          if (!activation) {
+            return Response.json({
+              error: "activation_unavailable",
+              message: "Could not create a browser activation link. Paste the organization install link again.",
+            }, { status: 409 })
+          }
+          return Response.json({
+            opened: await openBrowser(activation.url),
+            activationUrl: activation.url,
+            expiresAt: activation.expiresAt,
+          })
         }
         if (request.method === "POST" && url.pathname === "/api/exit") {
           setTimeout(onExit, 50)

--- a/apps/installer/src/ui-html.ts
+++ b/apps/installer/src/ui-html.ts
@@ -38,6 +38,16 @@ export function renderInstallerHtml(resolution: InstallerConfigResolution | null
     <button class="primary" id="action">Install</button>
     <button id="exit">Exit</button>
   </div>
+  <div class="activation" id="activation" hidden>
+    <div class="activation-title">Browser didn&apos;t open?</div>
+    <div class="activation-copy">Try again, or copy this one-time activation link into a browser on this computer.</div>
+    <div class="link-row">
+      <input id="activation-link" type="url" readonly aria-label="Activation link" />
+      <button id="copy-activation" type="button">Copy link</button>
+    </div>
+    <button id="retry-activation" type="button">Try opening browser again</button>
+    <div class="activation-expiry" id="activation-expiry"></div>
+  </div>
   <div class="status" id="status"></div>`
     : `
   <div class="logo">${OPENWORK_LOGO_SVG}</div>
@@ -93,6 +103,12 @@ export function renderInstallerHtml(resolution: InstallerConfigResolution | null
   .link-row input { flex: 1; min-width: 0; }
   .paste-button { padding-left: 16px; padding-right: 16px; }
   input { box-sizing: border-box; width: 100%; border: 1px solid rgba(24,24,27,.16); border-radius: 8px; padding: 9px 10px; font: inherit; font-size: 13px; }
+  .activation { display: grid; gap: 8px; width: 100%; margin-top: 10px; padding: 12px; box-sizing: border-box; border: 1px solid rgba(24,24,27,.12); border-radius: 10px; background: #f7f7f8; text-align: left; }
+  .activation[hidden] { display: none; }
+  .activation-title { font-size: 13px; font-weight: 600; }
+  .activation-copy, .activation-expiry { color: #71717a; font-size: 11px; line-height: 1.4; }
+  #activation-link { background: #ffffff; color: #52525b; font-size: 10px; }
+  #copy-activation, #retry-activation { padding-left: 12px; padding-right: 12px; }
 </style>
 </head>
 <body>
@@ -102,6 +118,7 @@ ${configuredContent}
 <script>
   const TOKEN = ${JSON.stringify(token)};
   const CONFIGURED = ${config ? "true" : "false"};
+  const HAS_ACTIVATION = ${resolution?.activation ? "true" : "false"};
   const statusEl = document.getElementById("status");
   const barEl = document.getElementById("bar");
   const barFillEl = document.getElementById("bar-fill");
@@ -111,6 +128,11 @@ ${configuredContent}
   const installLinkInput = document.getElementById("install-link");
   const pasteBtn = document.getElementById("paste-button");
   const continueBtn = document.getElementById("continue");
+  const activationEl = document.getElementById("activation");
+  const activationLinkInput = document.getElementById("activation-link");
+  const activationExpiryEl = document.getElementById("activation-expiry");
+  const copyActivationBtn = document.getElementById("copy-activation");
+  const retryActivationBtn = document.getElementById("retry-activation");
   let polling = null;
   let installed = false;
 
@@ -118,6 +140,13 @@ ${configuredContent}
     const response = await fetch(path, { method: "POST", headers: { "x-installer-token": TOKEN } });
     if (!response.ok) throw new Error("request failed: " + response.status);
     return response.json();
+  }
+
+  async function postJson(path) {
+    const response = await fetch(path, { method: "POST", headers: { "x-installer-token": TOKEN } });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) throw new Error(payload.message || "request failed: " + response.status);
+    return payload;
   }
 
   function editableInput() {
@@ -230,6 +259,50 @@ ${configuredContent}
     showClipboardError();
   }
 
+  function showActivation(payload) {
+    activationLinkInput.value = payload.activationUrl;
+    activationEl.hidden = false;
+    const expiry = new Date(payload.expiresAt);
+    activationExpiryEl.textContent = Number.isNaN(expiry.getTime())
+      ? "This link is one-time and short-lived."
+      : "One-time link · expires " + expiry.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+  }
+
+  async function copyFreshActivation() {
+    const payload = await postJson("/api/activation");
+    showActivation(payload);
+    activationLinkInput.focus();
+    activationLinkInput.select();
+    const wrote = await writeClipboardText(payload.activationUrl).catch(() => false);
+    if (!wrote && !tryExecCommand("copy")) {
+      throw new Error("Could not copy automatically. Select the link and copy it manually.");
+    }
+    copyActivationBtn.textContent = "Copied";
+    setTimeout(() => { copyActivationBtn.textContent = "Copy link"; }, 1800);
+  }
+
+  async function openActivation() {
+    actionBtn.disabled = true;
+    retryActivationBtn.disabled = true;
+    statusEl.classList.remove("error");
+    statusEl.textContent = "Opening the secure approval step in your browser...";
+    try {
+      const payload = await postJson("/api/open-activation");
+      showActivation(payload);
+      statusEl.textContent = payload.opened
+        ? "Browser requested. Keep this installer open until OpenWork is connected."
+        : "The browser did not open. Try again or copy the activation link below.";
+      statusEl.classList.toggle("error", !payload.opened);
+      actionBtn.textContent = "Try opening browser again";
+    } catch (error) {
+      statusEl.textContent = error.message || "Could not open the browser.";
+      statusEl.classList.add("error");
+    } finally {
+      actionBtn.disabled = false;
+      retryActivationBtn.disabled = false;
+    }
+  }
+
   function closeWindow() {
     if (window.openworkInstallerExit) {
       // Native webview: the bound function terminates the window run loop.
@@ -257,7 +330,7 @@ ${configuredContent}
     if (status.state === "done") {
       installed = true;
       statusEl.textContent = "Successfully Installed";
-      actionBtn.textContent = "Launch";
+      actionBtn.textContent = HAS_ACTIVATION ? "Open this in your browser" : "Launch";
       actionBtn.disabled = false;
       return;
     }
@@ -329,6 +402,10 @@ ${configuredContent}
 
   if (actionBtn) actionBtn.addEventListener("click", async () => {
     if (installed) {
+      if (HAS_ACTIVATION) {
+        await openActivation();
+        return;
+      }
       try { await api("/api/launch"); } catch {}
       closeWindow();
       return;
@@ -348,6 +425,20 @@ ${configuredContent}
       actionBtn.disabled = false;
     }
   });
+
+  if (copyActivationBtn) copyActivationBtn.addEventListener("click", async () => {
+    copyActivationBtn.disabled = true;
+    try {
+      await copyFreshActivation();
+    } catch (error) {
+      statusEl.textContent = error.message || "Could not copy the activation link.";
+      statusEl.classList.add("error");
+    } finally {
+      copyActivationBtn.disabled = false;
+    }
+  });
+
+  if (retryActivationBtn) retryActivationBtn.addEventListener("click", openActivation);
 
   exitBtn.addEventListener("click", closeWindow);
 </script>

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -19,6 +19,7 @@ import {
 import { desktopBootstrapPath, legacyDesktopBootstrapPath } from "../src/bootstrap-path"
 import { buildConstantsConfig, parseInstallLinkInput, resolveInstallLinkConfig, resolveInstallerConfig } from "../src/config"
 import { removableInstallerBundlePath, windowsInstalledExePath, writeBootstrapConfig } from "../src/install"
+import { externalUrlCommand } from "../src/open-external-url"
 import { releaseAssetFor } from "../src/release-asset"
 import { startInstallerServer } from "../src/server"
 import { createSystemCaFetch, parseDarwinSecurityCertificates, parseWindowsPowerShellCertificates } from "../src/system-ca"
@@ -189,6 +190,14 @@ describe("releaseAssetFor", () => {
   })
 })
 
+test("browser activation uses each platform's standard URL opener", () => {
+  const url = "https://den.example.test/activate?code=one-time-code"
+  expect(externalUrlCommand(url, "darwin")).toEqual(["open", url])
+  expect(externalUrlCommand(url, "win32")).toEqual(["cmd", "/c", "start", "", url])
+  expect(externalUrlCommand(url, "linux")).toEqual(["xdg-open", url])
+  expect(() => externalUrlCommand("openwork://connect", "darwin")).toThrow()
+})
+
 describe("windowsInstalledExePath", () => {
   test("reports the installed electron-builder package directory", () => {
     const temp = mkdtempSync(path.join(os.tmpdir(), "openwork-installed-path-"))
@@ -310,6 +319,11 @@ describe("resolveInstallerConfig", () => {
         apiUrl: "https://linked-api.example.com/",
         requireSignin: true,
         logoUrl: null,
+        iconUrl: null,
+        connectUrl: "openwork://connect?code=abcdefghijklmnopqrstuvwxyz123456&apiBaseUrl=https%3A%2F%2Flinked-api.example.com",
+        connectExpiresAt: "2030-01-01T00:00:00.000Z",
+        activationUrl: "https://linked.example.com/activate?code=abcdefghijklmnopqrstuvwxyz123456",
+        activationExpiresAt: "2030-01-01T00:00:00.000Z",
       }),
     })
     try {
@@ -319,6 +333,11 @@ describe("resolveInstallerConfig", () => {
       })
 
       expect(resolution.source).toBe("install-link")
+      expect(resolution.activation).toEqual({
+        url: "https://linked.example.com/activate?code=abcdefghijklmnopqrstuvwxyz123456",
+        expiresAt: "2030-01-01T00:00:00.000Z",
+      })
+      expect(resolution.installLink).toBe(`http://127.0.0.1:${configServer.port}/install?token=abcDEF12`)
       expect(resolution.config).toEqual({
         appName: "OpenWork",
         clientName: "Linked Corp",
@@ -377,6 +396,7 @@ describe("system CA fetch", () => {
 
       expect(result).toEqual({
         status: "resolved",
+        activation: null,
         config: {
           appName: "OpenWork",
           clientName: "TLS Corp",
@@ -551,6 +571,58 @@ describe("resolve-link API", () => {
     } finally {
       installerServer.stop()
       configServer.stop(true)
+    }
+  })
+})
+
+describe("browser activation API", () => {
+  test("keeps a copyable link when the operating system cannot open the browser", async () => {
+    const openedUrls: string[] = []
+    const activationUrl = "https://den.example.test/activate?code=abcdefghijklmnopqrstuvwxyz123456"
+    const installerServer = startInstallerServer({
+      config: {
+        appName: "OpenWork",
+        clientName: "Acme Robotics",
+        webUrl: "https://den.example.test",
+        apiUrl: "https://api.den.example.test",
+        logoUrl: null,
+        requireSignin: true,
+      },
+      source: "install-link",
+      activation: {
+        url: activationUrl,
+        expiresAt: "2030-01-01T00:00:00.000Z",
+      },
+      installLink: null,
+    }, () => undefined, (url) => {
+      openedUrls.push(url)
+      return Promise.resolve(false)
+    })
+
+    try {
+      const response = await fetch(`${installerServer.url}api/open-activation`, {
+        method: "POST",
+        headers: { "x-installer-token": installerServer.token },
+      })
+      expect(response.status).toBe(200)
+      await expect(response.json()).resolves.toEqual({
+        opened: false,
+        activationUrl,
+        expiresAt: "2030-01-01T00:00:00.000Z",
+      })
+      expect(openedUrls).toEqual([activationUrl])
+
+      const fallback = await fetch(`${installerServer.url}api/activation`, {
+        method: "POST",
+        headers: { "x-installer-token": installerServer.token },
+      })
+      expect(fallback.status).toBe(200)
+      await expect(fallback.json()).resolves.toEqual({
+        activationUrl,
+        expiresAt: "2030-01-01T00:00:00.000Z",
+      })
+    } finally {
+      installerServer.stop()
     }
   })
 })

--- a/ee/apps/den-api/src/desktop-connect-grants.ts
+++ b/ee/apps/den-api/src/desktop-connect-grants.ts
@@ -18,6 +18,15 @@ export type DesktopConnectGrantResult =
   | { ok: true; claims: ConnectLinkClaims }
   | { ok: false; code: DesktopConnectGrantFailureCode }
 
+export type DesktopConnectGrantStatusResult =
+  | {
+      ok: true
+      status: "pending" | "connected"
+      claims: ConnectLinkClaims
+      expiresAt: Date
+    }
+  | { ok: false; code: Exclude<DesktopConnectGrantFailureCode, "replayed"> }
+
 type DesktopConnectGrantRow = {
   grant: typeof DesktopConnectGrantTable.$inferSelect
   installLink: typeof InstallLinkTable.$inferSelect
@@ -54,6 +63,25 @@ function validateGrantRow(row: DesktopConnectGrantRow | undefined, now: Date): D
   return claims.success
     ? { ok: true, claims: claims.data }
     : { ok: false, code: "invalid_token" }
+}
+
+function inspectGrantRow(row: DesktopConnectGrantRow | undefined, now: Date): DesktopConnectGrantStatusResult {
+  if (!row || row.installLink.revokedAt || (row.installLink.expiresAt && row.installLink.expiresAt <= now)) {
+    return { ok: false, code: "invalid_token" }
+  }
+  if (row.grant.expiresAt <= now) {
+    return { ok: false, code: "expired" }
+  }
+  const claims = connectLinkClaimsSchema.safeParse(grantClaimsInput(row.grant.claims))
+  if (!claims.success) {
+    return { ok: false, code: "invalid_token" }
+  }
+  return {
+    ok: true,
+    status: row.grant.consumedAt ? "connected" : "pending",
+    claims: claims.data,
+    expiresAt: row.grant.expiresAt,
+  }
 }
 
 export async function mintDesktopConnectGrant(
@@ -97,9 +125,13 @@ export async function mintDesktopConnectGrant(
     consumedNonce: null,
   })
 
+  const activationUrl = new URL("/activate", input.webUrl)
+  activationUrl.searchParams.set("code", code)
+
   return {
     connectUrl: buildConnectExchangeDeepLink(code, input.apiUrl),
     connectExpiresAt: expiresAt.toISOString(),
+    activationUrl: activationUrl.toString(),
   }
 }
 
@@ -112,6 +144,17 @@ export async function previewDesktopConnectGrant(code: string): Promise<DesktopC
     .where(eq(DesktopConnectGrantTable.codeHash, hashConnectGrantCode(code)))
     .limit(1)
   return validateGrantRow(row, now)
+}
+
+export async function inspectDesktopConnectGrant(code: string): Promise<DesktopConnectGrantStatusResult> {
+  const now = new Date()
+  const [row] = await db
+    .select({ grant: DesktopConnectGrantTable, installLink: InstallLinkTable })
+    .from(DesktopConnectGrantTable)
+    .innerJoin(InstallLinkTable, eq(DesktopConnectGrantTable.installLinkId, InstallLinkTable.id))
+    .where(eq(DesktopConnectGrantTable.codeHash, hashConnectGrantCode(code)))
+    .limit(1)
+  return inspectGrantRow(row, now)
 }
 
 export async function consumeDesktopConnectGrant(code: string): Promise<DesktopConnectGrantResult> {

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -1,4 +1,4 @@
-import { installConfigSchema } from "@openwork/install-config"
+import { installConfigSchema, installExperienceConfigSchema } from "@openwork/install-config"
 import { connectLinkClaimsSchema } from "@openwork/connect-link"
 import { and, eq, gt, isNull, or } from "@openwork-ee/den-db/drizzle"
 import { InstallLinkTable, OrganizationTable } from "@openwork-ee/den-db/schema"
@@ -15,6 +15,7 @@ import { db } from "../../db.js"
 import { mintDesktopConnectLink } from "../../desktop-connect-link.js"
 import {
   consumeDesktopConnectGrant,
+  inspectDesktopConnectGrant,
   mintDesktopConnectGrant,
   previewDesktopConnectGrant,
 } from "../../desktop-connect-grants.js"
@@ -40,6 +41,7 @@ const INSTALL_LINK_RATE_LIMIT_WINDOW_MS = 1000 * 60 * 60
 const INSTALL_LINK_MINT_RATE_LIMIT_MAX = 30
 const INSTALL_CONFIG_RATE_LIMIT_MAX = 60
 const INSTALL_ARTIFACT_RATE_LIMIT_MAX = 20
+const INSTALL_CONNECT_STATUS_RATE_LIMIT_MAX = 300
 const INSTALL_LINK_TOKEN_PATTERN = /^[A-Za-z0-9_-]{8,}$/
 const CONNECT_GRANT_CODE_PATTERN = /^[A-Za-z0-9_-]{24,128}$/
 
@@ -64,6 +66,12 @@ const connectGrantResponseSchema = z.object({
   claims: connectLinkClaimsSchema,
 }).meta({ ref: "DesktopConnectGrantResponse" })
 
+const connectGrantStatusResponseSchema = z.object({
+  status: z.enum(["pending", "connected"]),
+  claims: connectLinkClaimsSchema,
+  expiresAt: z.string().datetime(),
+}).meta({ ref: "DesktopConnectGrantStatusResponse" })
+
 const connectGrantFailureSchema = z.object({
   error: z.enum(["connect_grant_invalid", "connect_grant_expired", "connect_grant_replayed"]),
 }).meta({ ref: "DesktopConnectGrantFailure" })
@@ -77,11 +85,6 @@ const installPlatformParamSchema = z.object({
 const installLinkNotFoundSchema = z.object({
   error: z.literal("install_link_not_found"),
 }).meta({ ref: "InstallLinkNotFoundError" })
-
-const installExperienceConfigSchema = installConfigSchema.extend({
-  connectUrl: z.string(),
-  connectExpiresAt: z.string().datetime(),
-}).meta({ ref: "InstallExperienceConfig" })
 
 const capabilityDisabledSchema = z.object({
   error: z.literal("capability_disabled"),
@@ -99,6 +102,7 @@ export type InstallExperienceDependencies = {
   resolveConfiguredArtifact: typeof resolveConfiguredInstallerArtifact
   mintConnectGrant: typeof mintDesktopConnectGrant
   previewConnectGrant: typeof previewDesktopConnectGrant
+  inspectConnectGrant: typeof inspectDesktopConnectGrant
   consumeConnectGrant: typeof consumeDesktopConnectGrant
 }
 
@@ -106,6 +110,7 @@ const defaultInstallerDependencies: InstallExperienceDependencies = {
   resolveConfiguredArtifact: resolveConfiguredInstallerArtifact,
   mintConnectGrant: mintDesktopConnectGrant,
   previewConnectGrant: previewDesktopConnectGrant,
+  inspectConnectGrant: inspectDesktopConnectGrant,
   consumeConnectGrant: consumeDesktopConnectGrant,
 }
 
@@ -446,15 +451,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         return c.json({ error: "install_link_not_found" }, 404)
       }
 
-      const connectLink = mintDesktopConnectLink({
-        organizationName: resolved.config.clientName,
-        appName: resolved.config.appName,
-        logoUrl: resolved.config.logoUrl,
-        iconUrl: resolved.config.iconUrl,
-        webUrl: resolved.config.webUrl,
-        apiUrl: resolved.config.apiUrl,
-      })
-      const handoff = connectLink ?? await installer.mintConnectGrant({
+      const connectInput = {
         installLinkId: resolved.installLinkId,
         organizationName: resolved.config.clientName,
         appName: resolved.config.appName,
@@ -462,13 +459,55 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         iconUrl: resolved.config.iconUrl,
         webUrl: resolved.config.webUrl,
         apiUrl: resolved.config.apiUrl,
-      })
+      }
+      const exchangeHandoff = await installer.mintConnectGrant(connectInput)
+      const handoff = mintDesktopConnectLink(connectInput) ?? exchangeHandoff
 
       return c.json({
         ...resolved.config,
         connectUrl: handoff.connectUrl,
         connectExpiresAt: handoff.connectExpiresAt,
+        activationUrl: exchangeHandoff.activationUrl,
+        activationExpiresAt: exchangeHandoff.connectExpiresAt,
       })
+    },
+  )
+
+  app.post(
+    "/v1/install-connect/status",
+    describeRoute({
+      tags: ["Organizations"],
+      summary: "Inspect desktop connection status",
+      description: "Reports whether a short-lived organization connection code is still pending or has been accepted by a desktop.",
+      responses: {
+        200: jsonResponse("Desktop connection status resolved successfully.", connectGrantStatusResponseSchema),
+        400: jsonResponse("The connection code body was invalid.", invalidRequestSchema),
+        404: jsonResponse("The connection code was not found.", connectGrantFailureSchema),
+        410: jsonResponse("The connection code expired.", connectGrantFailureSchema),
+        429: jsonResponse("Too many connection attempts.", rateLimitedSchema),
+      },
+    }),
+    publicRoute,
+    jsonValidator(connectGrantBodySchema),
+    async (c) => {
+      const retryAfter = await enforceRateLimit(c.req.raw.headers, "install:connect-status", INSTALL_CONNECT_STATUS_RATE_LIMIT_MAX, INSTALL_LINK_RATE_LIMIT_WINDOW_MS)
+      if (retryAfter !== null) {
+        c.header("Retry-After", String(retryAfter))
+        return c.json({ error: "rate_limited", message: "Too many connection attempts. Try again later." }, 429)
+      }
+
+      const result = await installer.inspectConnectGrant(c.req.valid("json").code)
+      if (result.ok) {
+        return c.json({
+          status: result.status,
+          claims: result.claims,
+          expiresAt: result.expiresAt.toISOString(),
+        })
+      }
+      if (result.code === "expired") {
+        return c.json({ error: "connect_grant_expired" }, 410)
+      }
+      return c.json({ error: "connect_grant_invalid" }, 404)
     },
   )
 

--- a/ee/apps/den-api/test/desktop-connect-grants-db.test.ts
+++ b/ee/apps/den-api/test/desktop-connect-grants-db.test.ts
@@ -86,6 +86,10 @@ test("MySQL grants preview across pods and allow exactly one concurrent consumer
 
   expect(firstPreview.ok).toBe(true)
   expect(secondPreview.ok).toBe(true)
+  await expect(grants.inspectDesktopConnectGrant(code)).resolves.toMatchObject({
+    ok: true,
+    status: "pending",
+  })
 
   const attempts = await Promise.all([
     grants.consumeDesktopConnectGrant(code),
@@ -95,6 +99,10 @@ test("MySQL grants preview across pods and allow exactly one concurrent consumer
   expect(attempts.filter((result) => result.ok)).toHaveLength(1)
   expect(attempts.filter((result) => !result.ok && result.code === "replayed")).toHaveLength(2)
   await expect(grants.previewDesktopConnectGrant(code)).resolves.toEqual({ ok: false, code: "replayed" })
+  await expect(grants.inspectDesktopConnectGrant(code)).resolves.toMatchObject({
+    ok: true,
+    status: "connected",
+  })
 
   const [stored] = await db.select({
     claims: schema.DesktopConnectGrantTable.claims,

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -178,7 +178,7 @@ afterAll(() => {
 function createApp(options: {
   configuredArtifact?: { filePath: string; size: number }
   artifactFileNames?: string[]
-  grantOverrides?: Partial<Pick<InstallExperienceDependencies, "mintConnectGrant" | "previewConnectGrant" | "consumeConnectGrant">>
+  grantOverrides?: Partial<Pick<InstallExperienceDependencies, "mintConnectGrant" | "previewConnectGrant" | "inspectConnectGrant" | "consumeConnectGrant">>
 } = {}) {
   const app = new Hono()
   app.use("*", async (c, next) => {
@@ -630,11 +630,14 @@ test("zero-config install config mints a short-lived exchange without storing th
   expect(response.status).toBe(200)
   const body = await response.json()
   expect(body.connectUrl).toStartWith("openwork://connect?code=")
+  expect(body.activationUrl).toStartWith("http://127.0.0.1:8790/activate?code=")
   expect(body.requireSignin).toBe(true)
   expect(Date.parse(body.connectExpiresAt)).toBeGreaterThan(Date.now())
+  expect(body.activationExpiresAt).toBe(body.connectExpiresAt)
 
   const url = new URL(body.connectUrl)
   const code = url.searchParams.get("code") ?? ""
+  expect(new URL(body.activationUrl).searchParams.get("code")).toBe(code)
   expect(code.length).toBeGreaterThanOrEqual(24)
   expect(url.searchParams.get("apiBaseUrl")).toBe("http://127.0.0.1:8790")
 
@@ -682,6 +685,12 @@ test("keyless preview is read-only and exchange consumes the grant once", async 
         consumed = true
         return Promise.resolve({ ok: true, claims })
       },
+      inspectConnectGrant: () => Promise.resolve({
+        ok: true,
+        status: consumed ? "connected" : "pending",
+        claims,
+        expiresAt: new Date((claims.exp + 1) * 1000),
+      }),
     },
   })
   const request = (mode: "preview" | "exchange") => app.request(`http://den.local/v1/install-connect/${mode}`, {
@@ -693,9 +702,23 @@ test("keyless preview is read-only and exchange consumes the grant once", async 
   const firstPreview = await request("preview")
   expect(firstPreview.status).toBe(200)
   expect(consumed).toBe(false)
+  const pending = await app.request("http://den.local/v1/install-connect/status", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ code }),
+  })
+  expect(pending.status).toBe(200)
+  await expect(pending.json()).resolves.toMatchObject({ status: "pending", claims })
   const exchange = await request("exchange")
   expect(exchange.status).toBe(200)
   expect(consumed).toBe(true)
+  const connected = await app.request("http://den.local/v1/install-connect/status", {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify({ code }),
+  })
+  expect(connected.status).toBe(200)
+  await expect(connected.json()).resolves.toMatchObject({ status: "connected", claims })
   const replay = await request("exchange")
   expect(replay.status).toBe(409)
   await expect(replay.json()).resolves.toEqual({ error: "connect_grant_replayed" })
@@ -719,6 +742,7 @@ test("install config includes a fresh signed organization handoff while preservi
   expect(response.status).toBe(200)
   const body = await response.json()
   expect(body.connectUrl).toStartWith("openwork://connect?token=")
+  expect(body.activationUrl).toStartWith("http://127.0.0.1:8790/activate?code=")
   expect(body.requireSignin).toBe(true)
 
   const token = new URL(body.connectUrl).searchParams.get("token") ?? ""

--- a/ee/apps/den-api/test/route-guard-policy.test.ts
+++ b/ee/apps/den-api/test/route-guard-policy.test.ts
@@ -63,6 +63,7 @@ const routeGuardExceptions = new Map<string, string>([
   ["DELETE /api/auth/scim/v2/Users/:userId", "SCIM bearer token is validated before forwarding"],
   ["GET /v1/install-config", "public install-link config; the install-link token is validated in-handler and rate-limited"],
   ["GET /v1/install/:platform", "public installer download; the install-link token is validated in-handler and rate-limited"],
+  ["POST /v1/install-connect/status", "short-lived install connection status is validated and rate-limited in-handler"],
   ["POST /v1/install-connect/preview", "short-lived install connection code preview is validated and rate-limited in-handler"],
   ["POST /v1/install-connect/exchange", "short-lived install connection code exchange is one-time and rate-limited in-handler"],
   ["GET /v1/orgs/invitations/preview", "public invitation preview by invitation id"],

--- a/ee/apps/den-web/app/(den)/_components/activation-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/activation-screen.tsx
@@ -1,0 +1,253 @@
+"use client";
+
+import { CheckCircle2, Copy, ExternalLink, LoaderCircle } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useSearchParams } from "next/navigation";
+import { getErrorMessage, requestJson } from "../_lib/den-flow";
+import { OnboardingShell } from "./onboarding-shell";
+import { OrganizationBrandIdentity, type OrganizationBrand } from "./organization-brand-identity";
+
+const CONNECT_CODE_PATTERN = /^[A-Za-z0-9_-]{24,128}$/;
+const RETURN_TO_OPENWORK_URL = "openwork://open";
+
+type ActivationDetails = {
+  status: "pending" | "connected";
+  organizationName: string;
+  brand: OrganizationBrand;
+  apiBaseUrl: string;
+  expiresAt: string;
+};
+
+type ActivationState =
+  | { kind: "loading" }
+  | { kind: "ready"; details: ActivationDetails }
+  | { kind: "expired" }
+  | { kind: "error"; message: string };
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseActivationDetails(value: unknown): ActivationDetails | null {
+  if (!isRecord(value) || (value.status !== "pending" && value.status !== "connected")) return null;
+  if (!isRecord(value.claims) || !isRecord(value.claims.org) || !isRecord(value.claims.brand) || !isRecord(value.claims.den)) {
+    return null;
+  }
+
+  const organizationName = value.claims.org.name;
+  const appName = value.claims.brand.appName;
+  const logoUrl = value.claims.brand.logoUrl;
+  const iconUrl = value.claims.brand.iconUrl;
+  const apiBaseUrl = value.claims.den.apiBaseUrl;
+  const expiresAt = value.expiresAt;
+  if (
+    typeof organizationName !== "string"
+    || typeof appName !== "string"
+    || (logoUrl !== null && typeof logoUrl !== "string")
+    || (iconUrl !== null && typeof iconUrl !== "string")
+    || typeof apiBaseUrl !== "string"
+    || typeof expiresAt !== "string"
+  ) {
+    return null;
+  }
+
+  try {
+    new URL(apiBaseUrl);
+    if (logoUrl) new URL(logoUrl);
+    if (iconUrl) new URL(iconUrl);
+    if (Number.isNaN(Date.parse(expiresAt))) return null;
+  } catch {
+    return null;
+  }
+
+  return {
+    status: value.status,
+    organizationName,
+    brand: { appName, logoUrl, iconUrl },
+    apiBaseUrl,
+    expiresAt,
+  };
+}
+
+function connectUrlFor(code: string, apiBaseUrl: string) {
+  const url = new URL("openwork://connect");
+  url.searchParams.set("code", code);
+  url.searchParams.set("apiBaseUrl", apiBaseUrl);
+  return url.toString();
+}
+
+export function ActivationScreen() {
+  const searchParams = useSearchParams();
+  const code = searchParams.get("code")?.trim() ?? "";
+  const [state, setState] = useState<ActivationState>({ kind: "loading" });
+  const [openAttempted, setOpenAttempted] = useState(false);
+  const [copied, setCopied] = useState<"connect" | "return" | null>(null);
+
+  useEffect(() => {
+    if (!CONNECT_CODE_PATTERN.test(code)) {
+      setState({ kind: "error", message: "This activation link is incomplete. Return to the installer and try again." });
+      return;
+    }
+
+    let cancelled = false;
+    let timer: number | null = null;
+
+    async function poll() {
+      try {
+        const { response, payload } = await requestJson(
+          "/v1/install-connect/status",
+          { method: "POST", body: JSON.stringify({ code }) },
+          12000,
+        );
+        if (cancelled) return;
+        if (response.status === 410) {
+          setState({ kind: "expired" });
+          return;
+        }
+        if (!response.ok) {
+          setState({
+            kind: "error",
+            message: getErrorMessage(payload, "This activation link could not be opened."),
+          });
+          return;
+        }
+
+        const details = parseActivationDetails(payload);
+        if (!details) {
+          setState({ kind: "error", message: "This activation link returned incomplete setup details." });
+          return;
+        }
+        setState({ kind: "ready", details });
+        if (details.status === "pending") {
+          timer = window.setTimeout(() => void poll(), 2000);
+        }
+      } catch {
+        if (!cancelled) {
+          timer = window.setTimeout(() => void poll(), 4000);
+        }
+      }
+    }
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [code]);
+
+  async function copyLink(kind: "connect" | "return", value: string) {
+    await navigator.clipboard.writeText(value);
+    setCopied(kind);
+    window.setTimeout(() => setCopied(null), 1800);
+  }
+
+  if (state.kind === "loading") {
+    return (
+      <OnboardingShell state="activation-loading" width="wide">
+        <section className="grid justify-items-center gap-4 rounded-[1.75rem] border border-slate-200/80 bg-white p-8 text-center" data-testid="activation-page">
+          <LoaderCircle className="size-6 animate-spin text-slate-500" aria-hidden="true" />
+          <h1 className="den-title-lg">Preparing this computer.</h1>
+          <p className="den-copy">Checking the secure activation link…</p>
+        </section>
+      </OnboardingShell>
+    );
+  }
+
+  if (state.kind === "expired" || state.kind === "error") {
+    const message = state.kind === "expired"
+      ? "This one-time activation link has expired. Return to the installer and choose Try opening browser again."
+      : state.message;
+    return (
+      <OnboardingShell state="activation-error" width="wide">
+        <section className="grid gap-5 rounded-[1.75rem] border border-slate-200/80 bg-white p-6 sm:p-8" data-testid="activation-page">
+          <p className="den-eyebrow">OpenWork Desktop</p>
+          <h1 className="den-title-lg">This computer still needs approval.</h1>
+          <p className="den-copy" role="alert">{message}</p>
+          <button type="button" className="den-button-secondary w-fit" onClick={() => window.history.back()}>
+            Return to the installer
+          </button>
+        </section>
+      </OnboardingShell>
+    );
+  }
+
+  const { details } = state;
+  const connectUrl = connectUrlFor(code, details.apiBaseUrl);
+  const connected = details.status === "connected";
+
+  return (
+    <OnboardingShell state={connected ? "activation-connected" : "activation-pending"} width="wide">
+      <section
+        className="grid gap-6 rounded-[1.75rem] border border-slate-200/80 bg-white p-6 sm:p-8 md:p-10"
+        data-testid="activation-page"
+      >
+        <div className="grid justify-items-start gap-3">
+          <p className="den-eyebrow">{details.brand.appName} Desktop</p>
+          <h1 className="m-0 text-[2rem] font-semibold leading-[1.04] tracking-[-0.05em] text-slate-950 sm:text-[2.5rem]">
+            {connected ? "Connected to " : "Connect this computer to "}
+            <OrganizationBrandIdentity organizationName={details.organizationName} brand={details.brand} />
+          </h1>
+          <p className="den-copy">
+            {connected
+              ? `${details.organizationName}'s setup and branding are ready in ${details.brand.appName}.`
+              : `OpenWork will show ${details.organizationName} and its server before anything changes.`}
+          </p>
+        </div>
+
+        {connected ? (
+          <div className="grid gap-4" aria-live="polite">
+            <div className="flex items-center gap-3 rounded-2xl bg-emerald-50 px-4 py-3 text-sm font-medium text-emerald-800" data-testid="activation-connected">
+              <CheckCircle2 className="size-5 shrink-0" aria-hidden="true" />
+              Connected to {details.organizationName}
+            </div>
+            <a className="den-button-primary w-full justify-center sm:w-fit" href={RETURN_TO_OPENWORK_URL} data-testid="activation-return-openwork">
+              Return to OpenWork
+              <ExternalLink className="size-4" aria-hidden="true" />
+            </a>
+            <div className="grid gap-2 rounded-2xl bg-slate-50 p-4">
+              <p className="m-0 text-sm text-slate-600">Nothing opened? Copy this OpenWork link and open it from your browser.</p>
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <input className="den-input min-w-0 flex-1 text-xs" value={RETURN_TO_OPENWORK_URL} readOnly onFocus={(event) => event.currentTarget.select()} />
+                <button type="button" className="den-button-secondary sm:w-auto" onClick={() => void copyLink("return", RETURN_TO_OPENWORK_URL)}>
+                  <Copy className="size-4" aria-hidden="true" />
+                  {copied === "return" ? "Copied" : "Copy link"}
+                </button>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="grid gap-4" aria-live="polite">
+            <button
+              type="button"
+              className="den-button-primary w-full justify-center sm:w-fit"
+              data-testid="activation-open-openwork"
+              onClick={() => {
+                setOpenAttempted(true);
+                window.location.assign(connectUrl);
+              }}
+            >
+              Open OpenWork
+              <ExternalLink className="size-4" aria-hidden="true" />
+            </button>
+            <div className="flex items-center gap-2 text-sm text-slate-500">
+              <LoaderCircle className="size-4 animate-spin" aria-hidden="true" />
+              {openAttempted ? "Waiting for OpenWork to accept this setup…" : "Waiting for your approval…"}
+            </div>
+            {openAttempted ? (
+              <div className="grid gap-2 rounded-2xl bg-slate-50 p-4" data-testid="activation-open-fallback">
+                <p className="m-0 text-sm text-slate-600">OpenWork did not appear? Copy this one-time link and open it anywhere that handles OpenWork links.</p>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <input className="den-input min-w-0 flex-1 text-xs" value={connectUrl} readOnly onFocus={(event) => event.currentTarget.select()} />
+                  <button type="button" className="den-button-secondary sm:w-auto" onClick={() => void copyLink("connect", connectUrl)}>
+                    <Copy className="size-4" aria-hidden="true" />
+                    {copied === "connect" ? "Copied" : "Copy OpenWork link"}
+                  </button>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        )}
+      </section>
+    </OnboardingShell>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -1,12 +1,14 @@
 "use client";
 
 import { DownloadPlatformGrid, type DownloadPlatformGroup, type DownloadPlatformOption } from "@openwork/ui/react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { ChevronDown } from "lucide-react";
+import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
 import { useSearchParams } from "next/navigation";
 import { requestJson } from "../_lib/den-flow";
 import { getInstallConfigErrorMessage } from "../_lib/install-errors";
 import { buildInstallDownloadHref, type InstallPlatform } from "../_lib/install-download";
 import { isMobileUserAgent } from "../_lib/platform";
+import { InstallerPreview } from "./installer-preview";
 import { OnboardingShell } from "./onboarding-shell";
 import { OrganizationBrandIdentity } from "./organization-brand-identity";
 
@@ -143,6 +145,88 @@ function installHref(config: InstallConfig, platform: InstallPlatform, token: st
   return buildInstallDownloadHref(config.apiUrl, platform, token);
 }
 
+type StepState = "complete" | "active" | "pending";
+
+const STEP_SHELL: Record<StepState, string> = {
+  complete: "border-[#e7eaef] bg-[#fafbfc]",
+  active: "border-[#c8d6f5] bg-[#f8faff]",
+  pending: "border-[#e1e4e8] bg-[#f7f8fa]",
+};
+
+const STEP_BADGE: Record<StepState, string> = {
+  complete: "border-[1.5px] border-[#c9cfd7] bg-white text-[#7a828e]",
+  active: "bg-[#101828] text-white",
+  pending: "border-[1.5px] border-[#101828] text-[#101828]",
+};
+
+function InstallStep({
+  index,
+  state,
+  title,
+  description,
+  expanded,
+  onExpand,
+  testId,
+  children,
+}: {
+  index: number;
+  state: StepState;
+  title: string;
+  description: string;
+  expanded: boolean;
+  onExpand: () => void;
+  testId: string;
+  children: ReactNode;
+}) {
+  return (
+    <li className={`rounded-[18px] border ${STEP_SHELL[state]}`} data-state={state} data-testid={testId}>
+      <button
+        type="button"
+        className="flex w-full items-start gap-4 p-5 text-left disabled:cursor-default sm:px-7 sm:py-6"
+        aria-expanded={expanded}
+        disabled={state === "pending"}
+        onClick={onExpand}
+      >
+        <span className={`grid size-8 shrink-0 place-items-center rounded-full text-[13px] font-semibold ${STEP_BADGE[state]}`} aria-hidden="true">
+          {state === "complete" ? "✓" : index}
+        </span>
+        <span className="grid grow gap-1">
+          <span className={`text-base font-semibold ${state === "complete" ? "text-[#667085]" : "text-[#101828]"}`}>{title}</span>
+          {expanded ? <span className="text-[13px] leading-5 text-[#60646c]">{description}</span> : null}
+        </span>
+        <ChevronDown className={`mt-0.5 size-5 shrink-0 text-[#667085] ${expanded ? "rotate-180" : ""}`} aria-hidden="true" />
+      </button>
+      {expanded ? <div className="grid gap-4 px-5 pb-5 sm:pb-6 sm:pl-[4.25rem] sm:pr-7">{children}</div> : null}
+    </li>
+  );
+}
+
+function CopyLinkRow({
+  value,
+  copied,
+  onCopy,
+  testId,
+}: {
+  value: string;
+  copied: boolean;
+  onCopy: () => void;
+  testId?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-[10px] border border-[#e1e4e8] bg-[#fafbfc] px-3 py-2.5" data-testid={testId}>
+      <input
+        className="min-w-0 grow bg-transparent text-[11px] text-[#344054] outline-none"
+        value={value}
+        readOnly
+        onFocus={(event) => event.currentTarget.select()}
+      />
+      <button type="button" className="shrink-0 text-[11px] font-semibold text-[#101828] hover:underline" onClick={onCopy}>
+        {copied ? "Copied" : "Copy"}
+      </button>
+    </div>
+  );
+}
+
 export function InstallScreen() {
   const searchParams = useSearchParams();
   const token = searchParams.get("token")?.trim() ?? "";
@@ -161,7 +245,6 @@ export function InstallScreen() {
   const [expandedStep, setExpandedStep] = useState<1 | 2 | 3>(initialStep);
   const [connecting, setConnecting] = useState(false);
   const [connectError, setConnectError] = useState<string | null>(null);
-  const [connectRecoveryVisible, setConnectRecoveryVisible] = useState(false);
   const [activationCode, setActivationCode] = useState<string | null>(null);
   const [activationStatus, setActivationStatus] = useState<"idle" | "pending" | "connected" | "expired">("idle");
   const [connectLink, setConnectLink] = useState("");
@@ -409,7 +492,7 @@ export function InstallScreen() {
   return (
     <OnboardingShell state="install" width="full">
       <section data-testid="install-page">
-        <div className="grid gap-6 rounded-[1.75rem] border border-slate-200/80 bg-white p-5 text-center sm:p-6 md:p-8" data-testid="install-card">
+        <div className="grid gap-6 rounded-[1.75rem] border border-[#e7eaef] bg-[#fcfcfd] p-5 text-center sm:p-6 md:p-8" data-testid="install-card">
           <div className="grid justify-items-center gap-3">
             <h1 className="m-0 grid max-w-[22ch] gap-1 text-[2rem] font-semibold leading-[1.04] tracking-[-0.05em] text-slate-950 sm:text-[2.4rem]">
               <span>Download OpenWork</span>
@@ -421,9 +504,7 @@ export function InstallScreen() {
                 />
               </span>
             </h1>
-            <p className="den-copy">
-              This page walks you through connecting this computer to {config.clientName}.
-            </p>
+            <p className="den-copy">Complete one step at a time. Select any step to expand or review.</p>
           </div>
 
         {isMobile ? (
@@ -436,27 +517,15 @@ export function InstallScreen() {
           </div>
         ) : (
           <ol className="grid gap-3 text-left" data-testid="install-guide">
-            <li
-              className="overflow-hidden rounded-[1.25rem] border border-slate-200 bg-slate-50"
-              data-state={guideStep > 1 ? "complete" : "active"}
-              data-testid="install-guide-step-download"
+            <InstallStep
+              index={1}
+              state={guideStep > 1 ? "complete" : "active"}
+              title="Download the OpenWork installer"
+              description="It's a small setup app. When the download finishes, open it and keep this page open."
+              expanded={expandedStep === 1}
+              onExpand={() => setExpandedStep(1)}
+              testId="install-guide-step-download"
             >
-              <button
-                type="button"
-                className="grid w-full grid-cols-[2rem_minmax(0,1fr)] items-center gap-3 p-4 text-left sm:p-5"
-                aria-expanded={expandedStep === 1}
-                onClick={() => setExpandedStep(1)}
-              >
-                <span className="grid size-8 place-items-center rounded-full bg-[var(--dls-accent)] font-semibold text-white" aria-hidden="true">
-                  {guideStep > 1 ? "✓" : "1"}
-                </span>
-                <span>
-                  <span className="block font-semibold text-[var(--dls-text-primary)]">Download and install OpenWork</span>
-                  <span className="den-copy block">The recommended installer is highlighted for this computer.</span>
-                </span>
-              </button>
-              {expandedStep === 1 ? (
-                <div className="grid gap-3 border-t border-slate-200 bg-white p-4 sm:p-5">
                   <DownloadPlatformGrid
                     groups={downloadGroups}
                     recommendedTestId="install-download-primary"
@@ -489,144 +558,112 @@ export function InstallScreen() {
                       )}
                     </div>
                   ) : null}
-                </div>
-              ) : null}
-            </li>
+            </InstallStep>
 
-            <li
-              className="overflow-hidden rounded-[1.25rem] border border-slate-200 bg-slate-50"
-              data-state={guideStep === 2 ? "active" : guideStep > 2 ? "complete" : "pending"}
-              data-testid="install-guide-step-open"
+            <InstallStep
+              index={2}
+              state={guideStep === 2 ? "active" : guideStep > 2 ? "complete" : "pending"}
+              title="Continue on your computer"
+              description={guideStep < 2
+                ? `Only continue once ${config.appName} is installed and running on this computer.`
+                : `Already installed? Open ${config.appName} directly. First install? Verify the link, then finish activation in your browser.`}
+              expanded={expandedStep === 2 && guideStep >= 2}
+              onExpand={() => setExpandedStep(2)}
+              testId="install-guide-step-open"
             >
-              <button
-                type="button"
-                className="grid w-full grid-cols-[2rem_minmax(0,1fr)] items-center gap-3 p-4 text-left disabled:cursor-default sm:p-5"
-                aria-expanded={expandedStep === 2}
-                disabled={guideStep < 2}
-                onClick={() => setExpandedStep(2)}
-              >
-                <span className={`grid size-8 place-items-center rounded-full font-semibold ${guideStep >= 2 ? "bg-[var(--dls-accent)] text-white" : "border border-[var(--dls-border-strong)] text-slate-500"}`} aria-hidden="true">
-                  {guideStep > 2 ? "✓" : "2"}
-                </span>
-                <span>
-                  <span className="block font-semibold text-[var(--dls-text-primary)]">Continue on your computer</span>
-                  <span className="den-copy block">
-                    {guideStep < 2 ? `Only continue once ${config.appName} is installed and running on this computer.` : `Open ${config.appName} or run the installer to connect this computer to ${config.clientName}.`}
-                  </span>
-                </span>
-              </button>
-              {expandedStep === 2 && guideStep >= 2 ? (
-                <div className="grid gap-4 border-t border-slate-200 bg-white p-4 sm:p-5">
-                  <div className="grid gap-3 rounded-2xl bg-slate-50 p-4">
-                    <div>
-                      <p className="m-0 font-medium text-slate-950">Already installed?</p>
-                      <p className="den-copy">Open the app and confirm that you want to connect it to {config.clientName}.</p>
+                  <div className="grid gap-5 lg:grid-cols-2">
+                    <div className="grid content-start gap-3 rounded-[14px] border border-[#e1e4e8] bg-white p-4">
+                      <p className="m-0 text-xs font-semibold uppercase tracking-[0.04em] text-[#667085]">{config.appName} already installed</p>
+                      <p className="m-0 text-sm font-semibold text-[#101828]">Connect this computer to {config.clientName}</p>
+                      <p className="m-0 text-xs leading-[1.5] text-[#60646c]">Your browser may ask permission to open {config.appName}.</p>
+                      <button
+                        type="button"
+                        className="grid h-11 w-full place-items-center rounded-[11px] bg-[#101828] text-[13px] font-semibold text-white transition-colors hover:bg-black disabled:opacity-60"
+                        data-testid="install-connect-open"
+                        disabled={connecting}
+                        onClick={() => void beginConnect()}
+                      >
+                        {connecting ? "Preparing connection…" : `Open ${config.appName}`}
+                      </button>
+                      <div className="flex items-center gap-2.5">
+                        <span className="h-px grow bg-[#e1e4e8]" />
+                        <span className="text-[11px] text-[#7a808a]">Didn&apos;t open?</span>
+                        <span className="h-px grow bg-[#e1e4e8]" />
+                      </div>
+                      <CopyLinkRow
+                        value={currentLink}
+                        copied={copied}
+                        onCopy={() => void copyCurrentLink()}
+                        testId="install-copy-link"
+                      />
+                      <p className="m-0 text-[11px] text-[#7a808a]">Paste this same link in {config.appName} or the installer.</p>
+                      <button
+                        type="button"
+                        className="w-fit text-[11px] font-medium text-[#667085] underline-offset-4 hover:text-[#101828] hover:underline"
+                        data-testid="install-connect-copy"
+                        disabled={connecting}
+                        onClick={() => void prepareAndCopyConnectionLink()}
+                      >
+                        {connectCopied ? "Copied a fresh connection link" : "Or copy a fresh connection link"}
+                      </button>
                     </div>
-                    <button
-                      type="button"
-                      className="den-button-primary w-full justify-center sm:w-fit"
-                      data-testid="install-connect-open"
-                      disabled={connecting}
-                      onClick={() => void beginConnect()}
-                    >
-                      {connecting ? "Preparing connection…" : `Open ${config.appName}`}
-                    </button>
-                    <button
-                      type="button"
-                      className="w-fit text-sm text-slate-500 underline-offset-4 hover:text-slate-950 hover:underline"
-                      data-testid="install-connect-recovery"
-                      onClick={() => setConnectRecoveryVisible(true)}
-                    >
-                      Didn&apos;t open?
-                    </button>
-                    {connectRecoveryVisible ? (
-                      <div className="grid gap-3 rounded-xl border border-slate-200 bg-white p-3">
-                        <p className="den-copy text-sm">Copy a fresh connection link and open it anywhere links work. The same confirmation will appear.</p>
-                        <button
-                          type="button"
-                          className="den-button-secondary w-fit"
-                          data-testid="install-connect-copy"
-                          disabled={connecting}
-                          onClick={() => void prepareAndCopyConnectionLink()}
-                        >
-                          {connectCopied ? "Copied" : "Copy connection link"}
-                        </button>
+                    <InstallerPreview
+                      appName={config.appName}
+                      iconUrl={config.iconUrl}
+                      activationLinkHint={`${config.webUrl.replace(/\/+$/, "")}/activate?token=…`}
+                    />
+                  </div>
+
+                  {connectError ? <p className="m-0 text-sm text-red-600" role="alert">{connectError}</p> : null}
+            </InstallStep>
+
+            <InstallStep
+              index={3}
+              state={guideStep === 3 ? "active" : "pending"}
+              title="Finish in your browser, then return to OpenWork"
+              description="Sign in and approve this computer. The browser will give you a button back to the desktop app."
+              expanded={expandedStep === 3 && guideStep === 3}
+              onExpand={() => setExpandedStep(3)}
+              testId="install-guide-step-signin"
+            >
+                  <div className="grid gap-3" aria-live="polite">
+                    <div className="flex flex-col gap-3 sm:flex-row">
+                      <a
+                        className="grid h-11 shrink-0 place-items-center rounded-[11px] bg-[#101828] px-6 text-[13px] font-semibold text-white transition-colors hover:bg-black sm:w-[18rem]"
+                        href={RETURN_TO_OPENWORK_URL}
+                      >
+                        Return to OpenWork
+                      </a>
+                      {activationStatus === "connected" ? null : (
+                        <p className="m-0 flex grow items-center gap-3 rounded-[11px] border border-[#e1e4e8] bg-white px-4 text-[13px] text-[#60646c]">
+                          <span className="size-4 animate-spin rounded-full border-2 border-[#b0b7c3] border-t-[#101828]" aria-hidden="true" />
+                          Waiting for browser confirmation…
+                        </p>
+                      )}
+                    </div>
+
+                    {activationStatus === "connected" ? (
+                      <div className="flex items-start gap-3 rounded-[11px] border border-[#e7eaef] bg-[#fafbfc] px-3.5 py-3" data-testid="install-connected">
+                        <span className="grid size-5 shrink-0 place-items-center rounded-full border-[1.5px] border-[#c9cfd7] bg-white text-[11px] font-bold text-[#30a46c]" aria-hidden="true">✓</span>
+                        <span className="grid gap-0.5">
+                          <span className="text-[13px] font-semibold text-[#1c2024]">Connected to {config.clientName}</span>
+                          <span className="text-[11px] text-[#60646c]">Your organization setup and branding are ready in {config.appName}.</span>
+                        </span>
+                      </div>
+                    ) : activationStatus === "expired" ? (
+                      <p className="m-0 text-sm text-amber-700">This one-time link expired. Return to step 2 and open {config.appName} again.</p>
+                    ) : null}
+
+                    {activationStatus === "connected" ? (
+                      <CopyLinkRow value={RETURN_TO_OPENWORK_URL} copied={returnCopied} onCopy={() => void copyReturnLink()} />
+                    ) : connectLink ? (
+                      <div className="grid gap-2">
+                        <p className="m-0 text-[11px] text-[#7a808a]">Nothing opened? Copy this {config.appName} link and open it anywhere links work.</p>
+                        <CopyLinkRow value={connectLink} copied={connectCopied} onCopy={() => void copyConnectionLink()} />
                       </div>
                     ) : null}
                   </div>
-
-                  <div className="grid gap-3">
-                    <div>
-                      <p className="m-0 font-medium text-slate-950">Using the installer?</p>
-                      <p className="den-copy">Paste this organization link when asked. After installing, it opens a secure approval page in your browser.</p>
-                    </div>
-                    <div className="grid gap-2" data-testid="install-copy-link">
-                      <div className="flex flex-col gap-2 sm:flex-row">
-                        <input className="den-input min-w-0 flex-1 text-xs" value={currentLink} readOnly onFocus={(event) => event.currentTarget.select()} />
-                        <button type="button" className="den-button-secondary sm:w-auto" onClick={() => void copyCurrentLink()}>
-                          {copied ? "Copied" : "Copy install link"}
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                  {connectError ? <p className="m-0 text-sm text-red-600" role="alert">{connectError}</p> : null}
-                </div>
-              ) : null}
-            </li>
-
-            <li
-              className="overflow-hidden rounded-[1.25rem] border border-slate-200 bg-slate-50"
-              data-state={guideStep === 3 ? "active" : "pending"}
-              data-testid="install-guide-step-signin"
-            >
-              <button
-                type="button"
-                className="grid w-full grid-cols-[2rem_minmax(0,1fr)] items-center gap-3 p-4 text-left disabled:cursor-default sm:p-5"
-                aria-expanded={expandedStep === 3}
-                disabled={guideStep < 3}
-                onClick={() => setExpandedStep(3)}
-              >
-                <span className={`grid size-8 place-items-center rounded-full font-semibold ${guideStep === 3 ? "bg-[var(--dls-accent)] text-white" : "border border-[var(--dls-border-strong)] text-slate-500"}`} aria-hidden="true">3</span>
-                <span>
-                  <span className="block font-semibold text-[var(--dls-text-primary)]">Finish in your browser</span>
-                  <span className="den-copy block">Confirm the connection, then Sign in. This page reports when OpenWork accepts the organization setup.</span>
-                </span>
-              </button>
-              {expandedStep === 3 && guideStep === 3 ? (
-                <div className="grid gap-3 border-t border-slate-200 bg-white p-4 sm:p-5" aria-live="polite">
-                  {activationStatus === "connected" ? (
-                    <>
-                      <p className="m-0 text-sm font-medium text-emerald-700" data-testid="install-connected">✓ Connected to {config.clientName}</p>
-                      <p className="den-copy">{config.clientName}&apos;s setup and branding are ready in {config.appName}.</p>
-                      <a className="den-button-primary w-fit" href={RETURN_TO_OPENWORK_URL}>Return to OpenWork</a>
-                      <div className="flex flex-col gap-2 sm:flex-row">
-                        <input className="den-input min-w-0 flex-1 text-xs" value={RETURN_TO_OPENWORK_URL} readOnly onFocus={(event) => event.currentTarget.select()} />
-                        <button type="button" className="den-button-secondary sm:w-auto" onClick={() => void copyReturnLink()}>
-                          {returnCopied ? "Copied" : "Copy OpenWork link"}
-                        </button>
-                      </div>
-                    </>
-                  ) : activationStatus === "expired" ? (
-                    <p className="m-0 text-sm text-amber-700">This one-time link expired. Return to step 2 and open OpenWork again.</p>
-                  ) : (
-                    <>
-                      <p className="m-0 text-sm text-[var(--dls-text-secondary)]">Waiting for OpenWork to accept this setup…</p>
-                      {connectLink ? (
-                        <div className="grid gap-2 rounded-xl bg-slate-50 p-3">
-                          <p className="den-copy text-sm">Nothing opened? Copy this OpenWork link and open it anywhere links work.</p>
-                          <div className="flex flex-col gap-2 sm:flex-row">
-                            <input className="den-input min-w-0 flex-1 text-xs" value={connectLink} readOnly onFocus={(event) => event.currentTarget.select()} />
-                            <button type="button" className="den-button-secondary sm:w-auto" onClick={() => void copyConnectionLink()}>
-                              {connectCopied ? "Copied" : "Copy link"}
-                            </button>
-                          </div>
-                        </div>
-                      ) : null}
-                    </>
-                  )}
-                </div>
-              ) : null}
-            </li>
+            </InstallStep>
           </ol>
         )}
         </div>

--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -4,11 +4,9 @@ import { DownloadPlatformGrid, type DownloadPlatformGroup, type DownloadPlatform
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useSearchParams } from "next/navigation";
 import { requestJson } from "../_lib/den-flow";
-import { LAST_DESKTOP_HANDOFF_GRANT_STORAGE_KEY, readLastDesktopHandoffGrant } from "../_lib/desktop-handoff";
 import { getInstallConfigErrorMessage } from "../_lib/install-errors";
 import { buildInstallDownloadHref, type InstallPlatform } from "../_lib/install-download";
 import { isMobileUserAgent } from "../_lib/platform";
-import { useDesktopHandoffStatus } from "../_lib/use-desktop-handoff-status";
 import { OnboardingShell } from "./onboarding-shell";
 import { OrganizationBrandIdentity } from "./organization-brand-identity";
 
@@ -22,7 +20,12 @@ type InstallConfig = {
   iconUrl: string | null;
   connectUrl: string | null;
   connectExpiresAt: string | null;
+  activationUrl: string;
+  activationExpiresAt: string;
 };
+
+const CONNECT_CODE_PATTERN = /^[A-Za-z0-9_-]{24,128}$/;
+const RETURN_TO_OPENWORK_URL = "openwork://open";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -52,6 +55,23 @@ function isConnectUrl(value: string) {
   }
 }
 
+function activationCodeFromUrl(value: string) {
+  try {
+    const url = new URL(value);
+    const code = url.searchParams.get("code")?.trim() ?? "";
+    return CONNECT_CODE_PATTERN.test(code) ? code : null;
+  } catch {
+    return null;
+  }
+}
+
+function exchangeConnectUrl(code: string, apiBaseUrl: string) {
+  const url = new URL("openwork://connect");
+  url.searchParams.set("code", code);
+  url.searchParams.set("apiBaseUrl", apiBaseUrl);
+  return url.toString();
+}
+
 function parseInstallConfig(value: unknown): InstallConfig | null {
   if (!isRecord(value)) {
     return null;
@@ -66,6 +86,8 @@ function parseInstallConfig(value: unknown): InstallConfig | null {
   const iconUrl = value.iconUrl ?? null;
   const connectUrl = value.connectUrl ?? null;
   const connectExpiresAt = value.connectExpiresAt ?? null;
+  const activationUrl = typeof value.activationUrl === "string" ? value.activationUrl.trim() : "";
+  const activationExpiresAt = typeof value.activationExpiresAt === "string" ? value.activationExpiresAt : "";
 
   if (!clientName || !isUrl(webUrl) || !isUrl(apiUrl) || typeof requireSignin !== "boolean") {
     return null;
@@ -82,6 +104,9 @@ function parseInstallConfig(value: unknown): InstallConfig | null {
   if (connectExpiresAt !== null && (typeof connectExpiresAt !== "string" || Number.isNaN(Date.parse(connectExpiresAt)))) {
     return null;
   }
+  if (!isUrl(activationUrl) || Number.isNaN(Date.parse(activationExpiresAt))) {
+    return null;
+  }
 
   return {
     appName,
@@ -93,6 +118,8 @@ function parseInstallConfig(value: unknown): InstallConfig | null {
     iconUrl,
     connectUrl,
     connectExpiresAt,
+    activationUrl,
+    activationExpiresAt,
   };
 }
 
@@ -128,30 +155,23 @@ export function InstallScreen() {
   const [downloadLabel, setDownloadLabel] = useState("");
   const [downloadHref, setDownloadHref] = useState("");
   const [currentLink, setCurrentLink] = useState("");
-  const [handoffGrant, setHandoffGrant] = useState<string | null>(null);
+  const requestedStep = searchParams.get("step");
+  const initialStep = requestedStep === "3" ? 3 : requestedStep === "2" ? 2 : 1;
+  const [guideStep, setGuideStep] = useState<1 | 2 | 3>(initialStep);
+  const [expandedStep, setExpandedStep] = useState<1 | 2 | 3>(initialStep);
+  const [connecting, setConnecting] = useState(false);
+  const [connectError, setConnectError] = useState<string | null>(null);
+  const [connectRecoveryVisible, setConnectRecoveryVisible] = useState(false);
+  const [activationCode, setActivationCode] = useState<string | null>(null);
+  const [activationStatus, setActivationStatus] = useState<"idle" | "pending" | "connected" | "expired">("idle");
+  const [connectLink, setConnectLink] = useState("");
+  const [connectCopied, setConnectCopied] = useState(false);
+  const [returnCopied, setReturnCopied] = useState(false);
   const downloadStartedTimer = useRef<number | null>(null);
-  const handoffStatus = useDesktopHandoffStatus(handoffGrant);
 
   useEffect(() => {
     setIsMobile(isMobileUserAgent());
     setCurrentLink(window.location.href);
-  }, []);
-
-  useEffect(() => {
-    function refreshLastHandoffGrant() {
-      setHandoffGrant(readLastDesktopHandoffGrant());
-    }
-
-    refreshLastHandoffGrant();
-
-    function handleStorage(event: StorageEvent) {
-      if (event.key === LAST_DESKTOP_HANDOFF_GRANT_STORAGE_KEY) {
-        refreshLastHandoffGrant();
-      }
-    }
-
-    window.addEventListener("storage", handleStorage);
-    return () => window.removeEventListener("storage", handleStorage);
   }, []);
 
   useEffect(() => {
@@ -189,6 +209,45 @@ export function InstallScreen() {
       cancelled = true;
     };
   }, [token]);
+
+  useEffect(() => {
+    if (!activationCode) {
+      setActivationStatus("idle");
+      return;
+    }
+
+    let cancelled = false;
+    let timer: number | null = null;
+    setActivationStatus("pending");
+
+    async function poll() {
+      try {
+        const { response, payload } = await requestJson(
+          "/v1/install-connect/status",
+          { method: "POST", body: JSON.stringify({ code: activationCode }) },
+          12000,
+        );
+        if (cancelled) return;
+        if (response.status === 410) {
+          setActivationStatus("expired");
+          return;
+        }
+        if (response.ok && isRecord(payload) && payload.status === "connected") {
+          setActivationStatus("connected");
+          return;
+        }
+      } catch {
+        // Keep waiting through temporary network failures.
+      }
+      if (!cancelled) timer = window.setTimeout(() => void poll(), 2500);
+    }
+
+    void poll();
+    return () => {
+      cancelled = true;
+      if (timer !== null) window.clearTimeout(timer);
+    };
+  }, [activationCode]);
 
   useEffect(() => () => {
     if (downloadStartedTimer.current !== null) {
@@ -229,15 +288,28 @@ export function InstallScreen() {
   }, [config, token]);
 
   async function copyCurrentLink() {
-    await navigator.clipboard.writeText(currentLink || window.location.href);
-    setCopied(true);
-    window.setTimeout(() => setCopied(false), 1800);
+    try {
+      await navigator.clipboard.writeText(currentLink || window.location.href);
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch {
+      setConnectError("Could not copy automatically. Select the install link and copy it manually.");
+    }
+  }
+
+  function advanceGuide(nextStep: 2 | 3) {
+    setGuideStep(nextStep);
+    setExpandedStep(nextStep);
+    const url = new URL(window.location.href);
+    url.searchParams.set("step", String(nextStep));
+    window.history.replaceState(null, "", url);
   }
 
   function beginDownload(label: string, href: string) {
     setDownloadLabel(label);
     setDownloadHref(href);
     setDownloadState("preparing");
+    advanceGuide(2);
     if (downloadStartedTimer.current !== null) {
       window.clearTimeout(downloadStartedTimer.current);
     }
@@ -245,6 +317,67 @@ export function InstallScreen() {
       setDownloadState("started");
       downloadStartedTimer.current = null;
     }, 5000);
+  }
+
+  async function beginConnect() {
+    setConnecting(true);
+    setConnectError(null);
+    try {
+      const freshConfig = await fetchInstallConfig(token);
+      const code = activationCodeFromUrl(freshConfig.activationUrl);
+      if (!code) throw new Error("This setup could not create a one-time activation link.");
+      const nextConnectLink = exchangeConnectUrl(code, freshConfig.apiUrl);
+      setConfig(freshConfig);
+      setActivationCode(code);
+      setConnectLink(nextConnectLink);
+      advanceGuide(3);
+      window.location.assign(nextConnectLink);
+    } catch (connectFailure) {
+      setConnectError(connectFailure instanceof Error ? connectFailure.message : "Could not open OpenWork. Try again.");
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  async function copyConnectionLink() {
+    try {
+      await navigator.clipboard.writeText(connectLink);
+      setConnectCopied(true);
+      window.setTimeout(() => setConnectCopied(false), 1800);
+    } catch {
+      setConnectError("Could not copy automatically. Select the OpenWork link and copy it manually.");
+    }
+  }
+
+  async function prepareAndCopyConnectionLink() {
+    setConnecting(true);
+    setConnectError(null);
+    try {
+      const freshConfig = await fetchInstallConfig(token);
+      const code = activationCodeFromUrl(freshConfig.activationUrl);
+      if (!code) throw new Error("This setup could not create a one-time activation link.");
+      const nextConnectLink = exchangeConnectUrl(code, freshConfig.apiUrl);
+      setConfig(freshConfig);
+      setActivationCode(code);
+      setConnectLink(nextConnectLink);
+      await navigator.clipboard.writeText(nextConnectLink);
+      setConnectCopied(true);
+      window.setTimeout(() => setConnectCopied(false), 1800);
+    } catch (copyFailure) {
+      setConnectError(copyFailure instanceof Error ? copyFailure.message : "Could not copy a fresh OpenWork link.");
+    } finally {
+      setConnecting(false);
+    }
+  }
+
+  async function copyReturnLink() {
+    try {
+      await navigator.clipboard.writeText(RETURN_TO_OPENWORK_URL);
+      setReturnCopied(true);
+      window.setTimeout(() => setReturnCopied(false), 1800);
+    } catch {
+      setConnectError("Could not copy automatically. Select the OpenWork link and copy it manually.");
+    }
   }
 
   if (busy) {
@@ -272,10 +405,6 @@ export function InstallScreen() {
       </OnboardingShell>
     );
   }
-
-  const showInstallTroubleshoot = handoffGrant !== null
-    && handoffStatus.status !== "consumed"
-    && (handoffStatus.timedOut || handoffStatus.status === "unknown");
 
   return (
     <OnboardingShell state="install" width="full">
@@ -308,23 +437,39 @@ export function InstallScreen() {
         ) : (
           <ol className="grid gap-3 text-left" data-testid="install-guide">
             <li
-              className="grid grid-cols-[2rem_minmax(0,1fr)] gap-3 rounded-[1.25rem] bg-slate-50 p-4 sm:p-5"
+              className="overflow-hidden rounded-[1.25rem] border border-slate-200 bg-slate-50"
+              data-state={guideStep > 1 ? "complete" : "active"}
               data-testid="install-guide-step-download"
             >
-              <span className="grid size-8 place-items-center rounded-full bg-[var(--dls-accent)] font-semibold text-white" aria-hidden="true">
-                1
-              </span>
-              <div className="grid gap-3">
-                <div>
-                  <p className="m-0 font-semibold text-[var(--dls-text-primary)]">Download the OpenWork installer</p>
-                  <p className="den-copy">It&apos;s a small setup app. When the download finishes, open it and keep this page open.</p>
-                </div>
-                <div className="grid gap-3">
+              <button
+                type="button"
+                className="grid w-full grid-cols-[2rem_minmax(0,1fr)] items-center gap-3 p-4 text-left sm:p-5"
+                aria-expanded={expandedStep === 1}
+                onClick={() => setExpandedStep(1)}
+              >
+                <span className="grid size-8 place-items-center rounded-full bg-[var(--dls-accent)] font-semibold text-white" aria-hidden="true">
+                  {guideStep > 1 ? "✓" : "1"}
+                </span>
+                <span>
+                  <span className="block font-semibold text-[var(--dls-text-primary)]">Download and install OpenWork</span>
+                  <span className="den-copy block">The recommended installer is highlighted for this computer.</span>
+                </span>
+              </button>
+              {expandedStep === 1 ? (
+                <div className="grid gap-3 border-t border-slate-200 bg-white p-4 sm:p-5">
                   <DownloadPlatformGrid
                     groups={downloadGroups}
                     recommendedTestId="install-download-primary"
                     onDownload={(option: DownloadPlatformOption) => beginDownload(option.label, option.href)}
                   />
+                  <button
+                    type="button"
+                    className="w-fit text-sm font-medium text-slate-600 underline-offset-4 hover:text-slate-950 hover:underline"
+                    onClick={() => advanceGuide(2)}
+                    data-testid="install-skip-download"
+                  >
+                    I already have {config.appName}
+                  </button>
                   {downloadState !== "idle" ? (
                     <div className="den-frame-inset grid gap-2 rounded-[1.25rem] p-4" aria-live="polite" data-testid="install-download-status">
                       {downloadState === "preparing" ? (
@@ -345,50 +490,142 @@ export function InstallScreen() {
                     </div>
                   ) : null}
                 </div>
-              </div>
+              ) : null}
             </li>
 
             <li
-              className="grid grid-cols-[2rem_minmax(0,1fr)] gap-3 rounded-[1.25rem] bg-slate-50 p-4 sm:p-5"
+              className="overflow-hidden rounded-[1.25rem] border border-slate-200 bg-slate-50"
+              data-state={guideStep === 2 ? "active" : guideStep > 2 ? "complete" : "pending"}
               data-testid="install-guide-step-open"
             >
-              <span className="grid size-8 place-items-center rounded-full border border-[var(--dls-border-strong)] font-semibold text-[var(--dls-text-primary)]" aria-hidden="true">
-                2
-              </span>
-              <div className="grid gap-3">
-                <p className="m-0 font-semibold text-[var(--dls-text-primary)]">Open the installer and paste this link:</p>
-                <div className="grid gap-2" data-testid="install-copy-link">
-                  <div className="flex flex-col gap-2 sm:flex-row">
-                    <input className="den-input min-w-0 flex-1 text-xs" value={currentLink} readOnly onFocus={(event) => event.currentTarget.select()} />
-                    <button type="button" className="den-button-secondary sm:w-auto" onClick={() => void copyCurrentLink()}>
-                      {copied ? "Copied" : "Copy link"}
+              <button
+                type="button"
+                className="grid w-full grid-cols-[2rem_minmax(0,1fr)] items-center gap-3 p-4 text-left disabled:cursor-default sm:p-5"
+                aria-expanded={expandedStep === 2}
+                disabled={guideStep < 2}
+                onClick={() => setExpandedStep(2)}
+              >
+                <span className={`grid size-8 place-items-center rounded-full font-semibold ${guideStep >= 2 ? "bg-[var(--dls-accent)] text-white" : "border border-[var(--dls-border-strong)] text-slate-500"}`} aria-hidden="true">
+                  {guideStep > 2 ? "✓" : "2"}
+                </span>
+                <span>
+                  <span className="block font-semibold text-[var(--dls-text-primary)]">Continue on your computer</span>
+                  <span className="den-copy block">
+                    {guideStep < 2 ? `Only continue once ${config.appName} is installed and running on this computer.` : `Open ${config.appName} or run the installer to connect this computer to ${config.clientName}.`}
+                  </span>
+                </span>
+              </button>
+              {expandedStep === 2 && guideStep >= 2 ? (
+                <div className="grid gap-4 border-t border-slate-200 bg-white p-4 sm:p-5">
+                  <div className="grid gap-3 rounded-2xl bg-slate-50 p-4">
+                    <div>
+                      <p className="m-0 font-medium text-slate-950">Already installed?</p>
+                      <p className="den-copy">Open the app and confirm that you want to connect it to {config.clientName}.</p>
+                    </div>
+                    <button
+                      type="button"
+                      className="den-button-primary w-full justify-center sm:w-fit"
+                      data-testid="install-connect-open"
+                      disabled={connecting}
+                      onClick={() => void beginConnect()}
+                    >
+                      {connecting ? "Preparing connection…" : `Open ${config.appName}`}
                     </button>
+                    <button
+                      type="button"
+                      className="w-fit text-sm text-slate-500 underline-offset-4 hover:text-slate-950 hover:underline"
+                      data-testid="install-connect-recovery"
+                      onClick={() => setConnectRecoveryVisible(true)}
+                    >
+                      Didn&apos;t open?
+                    </button>
+                    {connectRecoveryVisible ? (
+                      <div className="grid gap-3 rounded-xl border border-slate-200 bg-white p-3">
+                        <p className="den-copy text-sm">Copy a fresh connection link and open it anywhere links work. The same confirmation will appear.</p>
+                        <button
+                          type="button"
+                          className="den-button-secondary w-fit"
+                          data-testid="install-connect-copy"
+                          disabled={connecting}
+                          onClick={() => void prepareAndCopyConnectionLink()}
+                        >
+                          {connectCopied ? "Copied" : "Copy connection link"}
+                        </button>
+                      </div>
+                    ) : null}
                   </div>
+
+                  <div className="grid gap-3">
+                    <div>
+                      <p className="m-0 font-medium text-slate-950">Using the installer?</p>
+                      <p className="den-copy">Paste this organization link when asked. After installing, it opens a secure approval page in your browser.</p>
+                    </div>
+                    <div className="grid gap-2" data-testid="install-copy-link">
+                      <div className="flex flex-col gap-2 sm:flex-row">
+                        <input className="den-input min-w-0 flex-1 text-xs" value={currentLink} readOnly onFocus={(event) => event.currentTarget.select()} />
+                        <button type="button" className="den-button-secondary sm:w-auto" onClick={() => void copyCurrentLink()}>
+                          {copied ? "Copied" : "Copy install link"}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                  {connectError ? <p className="m-0 text-sm text-red-600" role="alert">{connectError}</p> : null}
                 </div>
-                <p className="den-copy">The installer only continues with a valid link — that&apos;s what connects this computer to {config.clientName}.</p>
-              </div>
+              ) : null}
             </li>
 
             <li
-              className="grid grid-cols-[2rem_minmax(0,1fr)] gap-3 rounded-[1.25rem] bg-slate-50 p-4 sm:p-5"
+              className="overflow-hidden rounded-[1.25rem] border border-slate-200 bg-slate-50"
+              data-state={guideStep === 3 ? "active" : "pending"}
               data-testid="install-guide-step-signin"
             >
-              <span className="grid size-8 place-items-center rounded-full border border-[var(--dls-border-strong)] font-semibold text-[var(--dls-text-primary)]" aria-hidden="true">3</span>
-              <div className="grid gap-3">
-                <p className="m-0 font-semibold text-[var(--dls-text-primary)]">Sign in — this page will confirm when you&apos;re connected.</p>
-                <div className="den-frame-inset grid gap-2 rounded-[1rem] p-3" aria-live="polite">
-                  {handoffStatus.status === "consumed" ? (
-                    <p className="m-0 text-sm font-medium text-emerald-700" data-testid="install-connected">✓ Connected — OpenWork is set up for {config.clientName}</p>
+              <button
+                type="button"
+                className="grid w-full grid-cols-[2rem_minmax(0,1fr)] items-center gap-3 p-4 text-left disabled:cursor-default sm:p-5"
+                aria-expanded={expandedStep === 3}
+                disabled={guideStep < 3}
+                onClick={() => setExpandedStep(3)}
+              >
+                <span className={`grid size-8 place-items-center rounded-full font-semibold ${guideStep === 3 ? "bg-[var(--dls-accent)] text-white" : "border border-[var(--dls-border-strong)] text-slate-500"}`} aria-hidden="true">3</span>
+                <span>
+                  <span className="block font-semibold text-[var(--dls-text-primary)]">Finish in your browser</span>
+                  <span className="den-copy block">Confirm the connection, then Sign in. This page reports when OpenWork accepts the organization setup.</span>
+                </span>
+              </button>
+              {expandedStep === 3 && guideStep === 3 ? (
+                <div className="grid gap-3 border-t border-slate-200 bg-white p-4 sm:p-5" aria-live="polite">
+                  {activationStatus === "connected" ? (
+                    <>
+                      <p className="m-0 text-sm font-medium text-emerald-700" data-testid="install-connected">✓ Connected to {config.clientName}</p>
+                      <p className="den-copy">{config.clientName}&apos;s setup and branding are ready in {config.appName}.</p>
+                      <a className="den-button-primary w-fit" href={RETURN_TO_OPENWORK_URL}>Return to OpenWork</a>
+                      <div className="flex flex-col gap-2 sm:flex-row">
+                        <input className="den-input min-w-0 flex-1 text-xs" value={RETURN_TO_OPENWORK_URL} readOnly onFocus={(event) => event.currentTarget.select()} />
+                        <button type="button" className="den-button-secondary sm:w-auto" onClick={() => void copyReturnLink()}>
+                          {returnCopied ? "Copied" : "Copy OpenWork link"}
+                        </button>
+                      </div>
+                    </>
+                  ) : activationStatus === "expired" ? (
+                    <p className="m-0 text-sm text-amber-700">This one-time link expired. Return to step 2 and open OpenWork again.</p>
                   ) : (
-                    <p className="m-0 text-sm text-[var(--dls-text-secondary)]">Waiting for sign-in…</p>
+                    <>
+                      <p className="m-0 text-sm text-[var(--dls-text-secondary)]">Waiting for OpenWork to accept this setup…</p>
+                      {connectLink ? (
+                        <div className="grid gap-2 rounded-xl bg-slate-50 p-3">
+                          <p className="den-copy text-sm">Nothing opened? Copy this OpenWork link and open it anywhere links work.</p>
+                          <div className="flex flex-col gap-2 sm:flex-row">
+                            <input className="den-input min-w-0 flex-1 text-xs" value={connectLink} readOnly onFocus={(event) => event.currentTarget.select()} />
+                            <button type="button" className="den-button-secondary sm:w-auto" onClick={() => void copyConnectionLink()}>
+                              {connectCopied ? "Copied" : "Copy link"}
+                            </button>
+                          </div>
+                        </div>
+                      ) : null}
+                    </>
                   )}
-                  {showInstallTroubleshoot ? (
-                    <p className="m-0 text-sm text-[var(--dls-text-secondary)]">
-                      Still not connected? If the app is not installed, start with step 1. If nothing opened, try the sign-in tab again.
-                    </p>
-                  ) : null}
                 </div>
-              </div>
+              ) : null}
             </li>
           </ol>
         )}

--- a/ee/apps/den-web/app/(den)/_components/installer-preview.tsx
+++ b/ee/apps/den-web/app/(den)/_components/installer-preview.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { detectPlatform } from "@openwork/ui/react";
+import { useEffect, useState } from "react";
+
+const BACKDROP: Record<"macos" | "windows", string> = {
+  macos: "linear-gradient(160deg, #23306f 0%, #46318f 28%, #7d3a9c 55%, #c2508b 78%, #dd8f66 100%)",
+  windows: "linear-gradient(160deg, #073a8f 0%, #0f5bc4 55%, #1c74e0 100%)",
+};
+
+function AppleIcon() {
+  return (
+    <svg viewBox="0 0 24 28" className="size-3 shrink-0 fill-[#1d1d1f]" aria-hidden="true">
+      <path d="M12.2 6.9c-.9 0-2.4-1.1-4-1-2 .1-3.9 1.2-4.9 3-2.1 3.7-.5 9.1 1.5 12.1 1 1.5 2.2 3.1 3.8 3 1.5-.1 2.1-1 3.9-1 1.8 0 2.4 1 4 .9 1.6 0 2.7-1.5 3.7-2.9 1.2-1.7 1.6-3.3 1.7-3.4 0 0-3.2-1.2-3.2-4.9 0-3 2.5-4.5 2.6-4.6-1.4-2.1-3.6-2.3-4.4-2.4-2-.1-3.7 1.1-4.7 1.2zM15.5 3.8c.8-1 1.4-2.4 1.2-3.8-1.2.1-2.6.8-3.5 1.8-.8.9-1.5 2.3-1.3 3.7 1.4.1 2.8-.7 3.6-1.7z" />
+    </svg>
+  );
+}
+
+function MacMenuBar({ appName }: { appName: string }) {
+  return (
+    <div className="absolute inset-x-0 top-0 flex h-[26px] items-center gap-3.5 border-b border-black/[0.06] bg-[#fafafc]/70 px-3 text-[10px] text-[#1d1d1f]">
+      <AppleIcon />
+      <span className="font-bold">{appName} Installer</span>
+      <span>File</span>
+      <span>Edit</span>
+      <span>Help</span>
+      <span className="grow" />
+      <span>9:41 AM</span>
+    </div>
+  );
+}
+
+function MacDock() {
+  return (
+    <div className="absolute bottom-2.5 left-1/2 flex h-[3.25rem] -translate-x-1/2 items-center gap-2 rounded-2xl border border-white/40 bg-white/30 px-2.5 shadow-[0_8px_22px_rgba(0,0,0,0.22)]">
+      <span className="size-9 rounded-[9px] bg-gradient-to-b from-[#4aa8f0] to-[#2f6fdd]" />
+      <span className="size-9 rounded-[9px] bg-gradient-to-b from-white to-[#dfe3ea]" />
+      <span className="size-9 rounded-[9px] bg-gradient-to-b from-[#5fd08a] to-[#28a35f]" />
+      <span className="size-9 rounded-[9px] bg-gradient-to-b from-[#9aa1ab] to-[#6b727c]" />
+      <span className="h-9 w-px bg-white/50" />
+      <span className="grid size-9 place-items-center rounded-[9px] bg-white shadow-[inset_0_0_0_1px_rgba(0,0,0,0.08)]">
+        <span className="size-4 rounded-[5px] bg-[#101828]" />
+      </span>
+    </div>
+  );
+}
+
+function WindowsTaskBar() {
+  return (
+    <div className="absolute inset-x-0 bottom-0 flex h-[26px] items-center gap-3 bg-[#eef2f8]/90 px-3 text-[9px] text-[#1c2b44]">
+      <span className="size-3 rounded-[2px] bg-[#1c74e0]" />
+      <span className="size-3 rounded-full border border-[#1c2b44]/40" />
+      <span className="size-3 rounded-[2px] bg-[#f2b23c]" />
+      <span className="size-3 rounded-full bg-[#1c74e0]" />
+      <span className="grow" />
+      <span>9:41 AM</span>
+    </div>
+  );
+}
+
+/** Decorative preview of the installer window as it appears on this computer. */
+export function InstallerPreview({
+  appName,
+  iconUrl,
+  activationLinkHint,
+}: {
+  appName: string;
+  iconUrl: string | null;
+  activationLinkHint: string;
+}) {
+  const [os, setOs] = useState<"macos" | "windows">("macos");
+
+  useEffect(() => {
+    let cancelled = false;
+    void detectPlatform().then((platform) => {
+      if (!cancelled && platform?.os === "windows") setOs("windows");
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <div
+      aria-hidden="true"
+      data-testid="installer-preview"
+      data-preview-os={os}
+      className="relative grid min-h-[27rem] place-items-center overflow-hidden rounded-[14px] border border-[#8a93a6] px-3.5 pb-20 pt-14"
+      style={{ backgroundImage: BACKDROP[os] }}
+    >
+      {os === "macos" ? <MacMenuBar appName={appName} /> : null}
+
+      <span className="absolute left-3 top-9 flex items-center gap-1.5 rounded-full border border-slate-500/25 bg-white/90 px-2 py-0.5 text-[9px] font-bold tracking-[0.08em] text-[#344054] shadow-[0_2px_8px_rgba(16,24,40,0.16)]">
+        <span className="size-1.5 rounded-full bg-[#3e63dd]" />
+        ON YOUR COMPUTER
+      </span>
+
+      <div className="w-[21rem] max-w-full overflow-hidden rounded-xl border border-[#c7ced8] bg-white shadow-[0_11px_26px_rgba(16,24,40,0.2)]">
+        {os === "macos" ? (
+          <div className="relative flex h-7 items-center justify-center border-b border-[#e4e8ee] bg-[#f7f9fc]">
+            <span className="absolute left-2.5 flex items-center gap-1.5">
+              <span className="size-2.5 rounded-full bg-[#ff5f57]" />
+              <span className="size-2.5 rounded-full bg-[#febc2e]" />
+              <span className="size-2.5 rounded-full bg-[#28c840]" />
+            </span>
+            <span className="text-[11px] font-semibold text-[#3a3a3c]">{appName} Installer</span>
+          </div>
+        ) : (
+          <div className="flex h-7 items-center justify-between border-b border-[#e4e8ee] bg-[#f7f9fc] px-3">
+            <span className="text-[11px] font-semibold text-[#3a3a3c]">{appName} Installer</span>
+            <span className="flex items-center gap-2 text-[10px] text-[#6b7280]">
+              <span>—</span>
+              <span>▢</span>
+              <span>✕</span>
+            </span>
+          </div>
+        )}
+
+        <div className="grid gap-2 p-3.5">
+          <div className="flex items-center gap-1.5">
+            {iconUrl ? (
+              // Organization icons may be served by private on-prem hosts that Next/Image cannot proxy.
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={iconUrl} alt="" className="size-5 rounded-[6px] object-contain" />
+            ) : (
+              <span className="size-5 rounded-[6px] bg-[#101828]" />
+            )}
+            <span className="text-xs font-semibold text-[#101828]">{appName}</span>
+          </div>
+          <p className="m-0 text-[17px] font-semibold tracking-[-0.02em] text-[#101828]">Welcome to {appName}</p>
+          <p className="m-0 text-[9px] leading-[1.5] text-[#59616e]">
+            Let&apos;s connect this computer to your organization. We&apos;ll open a secure browser window so you can
+            sign in and approve access.
+          </p>
+          <span className="grid h-9 place-items-center rounded-[9px] bg-[#101828] text-[11px] font-semibold text-white shadow-[0_5px_11px_rgba(16,24,40,0.16)]">
+            Open this in your browser
+          </span>
+          <div className="grid gap-1.5 rounded-lg border border-[#dce1e8] bg-[#f5f7fa] px-2 py-1.5">
+            <span className="text-[8px] font-semibold text-[#60646c]">Browser didn&apos;t open? Copy this activation link:</span>
+            <span className="flex items-center gap-2 rounded-md border border-[#d8dce3] bg-white px-1.5 py-1">
+              <span className="grow truncate text-[7px] text-[#475467]">{activationLinkHint}</span>
+              <span className="text-[8px] font-semibold text-[#101828]">Copy link</span>
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {os === "macos" ? <MacDock /> : <WindowsTaskBar />}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/activate/page.tsx
+++ b/ee/apps/den-web/app/(den)/activate/page.tsx
@@ -1,0 +1,10 @@
+import { Suspense } from "react";
+import { ActivationScreen } from "../_components/activation-screen";
+
+export default function ActivatePage() {
+  return (
+    <Suspense fallback={null}>
+      <ActivationScreen />
+    </Suspense>
+  );
+}

--- a/evals/flows/lib/den-web.d.mts
+++ b/evals/flows/lib/den-web.d.mts
@@ -1,0 +1,8 @@
+export interface DenApiResult {
+  response: Response;
+  body: unknown;
+}
+
+export function denWebUrl(): string;
+export function denApiUrl(): string;
+export function denApiFetch(path: string, options?: RequestInit): Promise<DenApiResult>;

--- a/evals/flows/org-download-handoff.flow.mjs
+++ b/evals/flows/org-download-handoff.flow.mjs
@@ -272,9 +272,8 @@ export default {
             action: async () => {
               await withWeb(ctx, async () => {
                 await navigateToAbsolute(ctx, `${requireStateValue(state.installPageUrl, "install page URL")}&step=2`);
-                await ctx.waitFor("Boolean(document.querySelector('[data-testid=install-connect-recovery]'))", { timeoutMs: 30_000, label: "connection recovery button" });
-                await clickSelector(ctx, "[data-testid=install-connect-recovery]", "connection recovery button");
-                await ctx.waitForText("Copy a fresh connection link and open it anywhere links work", { timeoutMs: 20_000 });
+                await ctx.waitFor("Boolean(document.querySelector('[data-testid=install-connect-copy]'))", { timeoutMs: 30_000, label: "connection recovery button" });
+                await ctx.waitForText("Or copy a fresh connection link", { timeoutMs: 20_000 });
                 await stubConnectionClipboardCapture(ctx);
                 await clickSelector(ctx, "[data-testid=install-connect-copy]", "copy connection link button");
                 state.recoveryConnectUrl = await ctx.waitFor(`(() => {

--- a/evals/flows/org-install-activation.flow.ts
+++ b/evals/flows/org-install-activation.flow.ts
@@ -1,0 +1,787 @@
+import { execSync, spawn, type ChildProcess } from "node:child_process";
+import { rmSync } from "node:fs";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, listTargets, type CdpTarget } from "../runner/cdp.ts";
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+import { denApiFetch, denApiUrl, denWebUrl } from "./lib/den-web.mjs";
+
+const FLOW_ID = "org-install-activation";
+const INVITE_PASSWORD = "OpenWorkDemo!123";
+const BROWSER_TIMEOUT_MS = 20_000;
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+interface ActivationFlowState {
+  desktopClient: FlowContext["client"];
+  originalDesktopBootstrapConfig: unknown;
+  desktopConfigured: boolean;
+  inviteeEmail: string;
+  invitationId: string;
+  invitationToken: string;
+  memberBearer: string;
+  installLink: string;
+  activationUrl: string;
+  connectUrl: string;
+  installer: ChildProcess | null;
+  installerUrl: string;
+  installerConfigDir: string;
+  webTargetId: string;
+}
+
+const state: ActivationFlowState = {
+  desktopClient: null,
+  originalDesktopBootstrapConfig: null,
+  desktopConfigured: false,
+  inviteeEmail: "",
+  invitationId: "",
+  invitationToken: "",
+  memberBearer: "",
+  installLink: "",
+  activationUrl: "",
+  connectUrl: "",
+  installer: null,
+  installerUrl: "",
+  installerConfigDir: "",
+  webTargetId: "",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function wait(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function getDenStackUrls(): { apiBaseUrl: string; webBaseUrl: string } {
+  return {
+    apiBaseUrl: requiredString(denApiUrl(), "OPENWORK_EVAL_DEN_API_URL"),
+    webBaseUrl: requiredString(denWebUrl(), "OPENWORK_EVAL_DEN_WEB_URL"),
+  };
+}
+
+function evalToken(ctx: FlowContext): string {
+  return requiredString(ctx.env.OPENWORK_EVAL_DEN_TOKEN, "OPENWORK_EVAL_DEN_TOKEN");
+}
+
+function randomInviteeEmail(ctx: FlowContext): string {
+  const domain = requiredString(ctx.env.OPENWORK_EVAL_ORG_DOMAIN, "OPENWORK_EVAL_ORG_DOMAIN");
+  return `maya-activation-${Date.now().toString(36)}@${domain}`;
+}
+
+function requiredString(value: unknown, label: string): string {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    throw new Error(`${label} must be a non-empty string.`);
+  }
+  return value.trim();
+}
+
+function exactTextClickExpression(label: string): string {
+  return `(() => {
+    const expected = ${JSON.stringify(label)};
+    const normalize = (value) => String(value || "").replace(/\\s+/g, " ").trim();
+    const element = [...document.querySelectorAll("button, a")]
+      .find((candidate) => normalize(candidate.textContent) === expected);
+    if (!(element instanceof HTMLElement)) {
+      throw new Error("Missing exact control: " + expected);
+    }
+    element.click();
+    return true;
+  })()`;
+}
+
+async function clickExactText(ctx: FlowContext, label: string): Promise<void> {
+  await ctx.eval(exactTextClickExpression(label));
+}
+
+async function firstPageTarget(cdpBaseUrl: string): Promise<CdpTarget> {
+  const existing = await listTargets(cdpBaseUrl);
+  const remembered = existing.find(
+    (target) => target.id === state.webTargetId && target.type === "page" && target.webSocketDebuggerUrl,
+  );
+  if (remembered) return remembered;
+  const available = existing.find(
+    (target) => target.type === "page" && target.webSocketDebuggerUrl && target.url !== "about:blank",
+  ) ?? existing.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (available) {
+    state.webTargetId = available.id;
+    return available;
+  }
+
+  try {
+    const response = await fetch(`${cdpBaseUrl}/json/new?about:blank`, { method: "PUT" });
+    if (response.ok) {
+      const created: unknown = await response.json();
+      if (
+        isRecord(created)
+        && created.type === "page"
+        && typeof created.id === "string"
+        && typeof created.webSocketDebuggerUrl === "string"
+      ) {
+        const target = {
+          id: created.id,
+          type: "page",
+          title: typeof created.title === "string" ? created.title : "",
+          url: typeof created.url === "string" ? created.url : "about:blank",
+          webSocketDebuggerUrl: created.webSocketDebuggerUrl,
+        };
+        state.webTargetId = target.id;
+        return target;
+      }
+    }
+  } catch {
+    // Fall back to a page that is already available.
+  }
+
+  for (let attempt = 0; attempt < 20; attempt += 1) {
+    const targets = await listTargets(cdpBaseUrl);
+    const page = targets.find((target) => target.type === "page");
+    if (page) {
+      state.webTargetId = page.id;
+      return page;
+    }
+    await wait(250);
+  }
+  throw new Error(`No browser page target found at ${cdpBaseUrl}.`);
+}
+
+async function withWeb(ctx: FlowContext, run: () => Promise<void>): Promise<void> {
+  const webCdpBaseUrl = requiredString(ctx.env.OPENWORK_EVAL_WEB_CDP_INVITEE, "OPENWORK_EVAL_WEB_CDP_INVITEE");
+  const previousClient = ctx.client;
+  const target = await firstPageTarget(webCdpBaseUrl);
+  const webClient = await connect(requiredString(target.webSocketDebuggerUrl, "web CDP debugger URL"));
+  ctx.client = webClient;
+  try {
+    await run();
+  } finally {
+    ctx.client = previousClient;
+    webClient.close();
+  }
+}
+
+async function navigate(ctx: FlowContext, url: string): Promise<void> {
+  if (!ctx.client) throw new Error("A CDP client is required.");
+  await ctx.client.send("Page.navigate", { url });
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${url}` });
+}
+
+async function invokeDesktop(ctx: FlowContext, command: string, input?: unknown): Promise<unknown> {
+  await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", {
+    timeoutMs: 60_000,
+    label: "desktop bridge",
+  });
+  return ctx.eval(
+    `window.__OPENWORK_ELECTRON__.invokeDesktop(${JSON.stringify(command)}, ${JSON.stringify(input)})`,
+    { awaitPromise: true },
+  );
+}
+
+async function captureOriginalDesktopBootstrap(ctx: FlowContext): Promise<void> {
+  if (state.desktopConfigured) return;
+  state.originalDesktopBootstrapConfig = await invokeDesktop(ctx, "getDesktopBootstrapConfig");
+  state.desktopConfigured = true;
+}
+
+async function restoreDesktopBootstrap(ctx: FlowContext): Promise<void> {
+  if (!state.desktopConfigured) return;
+  try {
+    await invokeDesktop(ctx, "setDesktopBootstrapConfig", state.originalDesktopBootstrapConfig);
+  } finally {
+    state.desktopConfigured = false;
+    state.originalDesktopBootstrapConfig = null;
+  }
+}
+
+function markInviteeVerified(ctx: FlowContext, email: string): void {
+  const commandTemplate = requiredString(
+    ctx.env.OPENWORK_EVAL_MARK_VERIFIED_CMD,
+    "OPENWORK_EVAL_MARK_VERIFIED_CMD",
+  );
+  execSync(commandTemplate.replaceAll("{email}", email), {
+    cwd: new URL("../../", import.meta.url),
+    env: ctx.env,
+    stdio: "ignore",
+  });
+}
+
+async function createInvitation(ctx: FlowContext): Promise<void> {
+  state.inviteeEmail = randomInviteeEmail(ctx);
+  const created = await denApiFetch("/v1/invitations", {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${evalToken(ctx)}`,
+    },
+    body: JSON.stringify({ email: state.inviteeEmail, role: "member" }),
+  });
+  ctx.output("create-invitation", JSON.stringify({
+    status: created.response.status,
+    email: state.inviteeEmail,
+  }, null, 2));
+  ctx.assert(created.response.ok, `invitation creation failed (${created.response.status})`);
+  ctx.assert(isRecord(created.body), "invitation response must be an object");
+  if (!isRecord(created.body)) return;
+  state.invitationId = requiredString(created.body.invitationId, "invitation id");
+  state.invitationToken = requiredString(created.body.inviteToken, "invitation token");
+}
+
+async function clearDenWebSession(ctx: FlowContext): Promise<void> {
+  const { webBaseUrl } = getDenStackUrls();
+  await navigate(ctx, webBaseUrl);
+  await ctx.eval(
+    `Promise.allSettled([
+      fetch('/api/den/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }),
+      fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }),
+    ]).then(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+      return true;
+    })`,
+    { awaitPromise: true },
+  );
+  if (!ctx.client) throw new Error("A CDP client is required.");
+  await ctx.client.send("Network.clearBrowserCookies", {});
+}
+
+async function acceptInvitationAndOpenWelcome(ctx: FlowContext): Promise<void> {
+  const { webBaseUrl } = getDenStackUrls();
+  await clearDenWebSession(ctx);
+  const invitationUrl = new URL(
+    `/join-org?invite=${encodeURIComponent(state.invitationToken)}`,
+    webBaseUrl,
+  ).toString();
+  await navigate(ctx, invitationUrl);
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", {
+    timeoutMs: 30_000,
+    label: "invite password field",
+  });
+  await ctx.fill('input[type="password"]', INVITE_PASSWORD);
+  const joinLabel = `Join ${requiredString(ctx.env.OPENWORK_EVAL_ORG_NAME, "OPENWORK_EVAL_ORG_NAME")}`;
+  await clickExactText(ctx, joinLabel);
+  await ctx.waitFor(
+    `document.body.innerText.includes("You're one click away from the team workspace.")
+      || Boolean(document.querySelector('[data-testid="join-org-success"]'))`,
+    { timeoutMs: 45_000, label: "signed-in invite accept step" },
+  );
+  const alreadySuccess = await ctx.eval("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))");
+  if (!alreadySuccess) {
+    markInviteeVerified(ctx, state.inviteeEmail);
+    await clickExactText(ctx, joinLabel);
+  }
+  await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))", {
+    timeoutMs: 45_000,
+    label: "join-org success",
+  });
+}
+
+async function openInstallGuide(ctx: FlowContext): Promise<void> {
+  await ctx.trustedClick("[data-testid=join-org-get-app]");
+  await ctx.waitForText("Download and install OpenWork", { timeoutMs: BROWSER_TIMEOUT_MS });
+  const href = await ctx.eval(`window.location.href`);
+  state.installLink = requiredString(href, "install link");
+}
+
+async function startDownloadWithoutFetchingAsset(ctx: FlowContext): Promise<void> {
+  const recommendation = await ctx.eval(`(() => {
+    const grid = document.querySelector('[data-testid="download-platform-grid"]');
+    const primary = document.querySelector('[data-testid="install-download-primary"]');
+    return {
+      detectedOs: grid?.getAttribute("data-detected-os") ?? "",
+      detectedArch: grid?.getAttribute("data-detected-arch") ?? "",
+      recommended: primary?.getAttribute("data-recommended") === "true",
+    };
+  })()`);
+  ctx.assert(
+    isRecord(recommendation)
+      && typeof recommendation.detectedOs === "string"
+      && recommendation.detectedOs.length > 0
+      && recommendation.recommended === true,
+    "the guide must detect this computer and mark one installer as recommended",
+  );
+  await ctx.eval(`(() => {
+    document.addEventListener("click", (event) => {
+      const target = event.target instanceof Element ? event.target.closest("a") : null;
+      if (target?.matches('[data-testid="install-download-primary"]')) event.preventDefault();
+    }, { capture: true, once: true });
+  })()`);
+  await ctx.trustedClick('[data-testid="install-download-primary"]');
+  await ctx.waitForText("Continue on your computer", { timeoutMs: BROWSER_TIMEOUT_MS });
+  await ctx.waitFor("document.querySelector('[data-testid=install-guide-step-download]')?.dataset.state === 'complete'", {
+    timeoutMs: BROWSER_TIMEOUT_MS,
+    label: "download step complete",
+  });
+}
+
+async function showInstallerRecoveryLink(ctx: FlowContext): Promise<void> {
+  await ctx.trustedClick('[data-testid="install-connect-recovery"]');
+  await ctx.waitForText("Copy a fresh connection link", { timeoutMs: BROWSER_TIMEOUT_MS });
+}
+
+function waitForInstallerUrl(child: ChildProcess, timeoutMs = 20_000): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    let output = "";
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      reject(new Error(`Timed out waiting for installer URL. Output:\n${output}`));
+    }, timeoutMs);
+
+    const inspect = (chunk: Buffer | string) => {
+      output += chunk.toString();
+      const match = output.match(/(?:Installer UI:|UI ready at)\s+(http:\/\/[^\s]+)/);
+      if (!match || settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve(match[1]);
+    };
+    child.stdout?.on("data", inspect);
+    child.stderr?.on("data", inspect);
+    child.once("exit", (code) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      reject(new Error(`Installer exited before printing its URL (code ${String(code)}).\n${output}`));
+    });
+  });
+}
+
+async function startInstaller(ctx: FlowContext): Promise<void> {
+  if (state.installer && state.installer.exitCode === null) return;
+  state.installerConfigDir = await mkdtemp(join(tmpdir(), "openwork-installer-eval-"));
+  const child = spawn("bun", ["run", "src/index.ts"], {
+    cwd: new URL("../../apps/installer", import.meta.url),
+    env: {
+      ...ctx.env,
+      OPENWORK_INSTALLER_UI: "manual",
+      OPENWORK_INSTALLER_DRY_RUN: "1",
+      OPENWORK_INSTALLER_DISABLE_BROWSER_OPEN: "1",
+      XDG_CONFIG_HOME: state.installerConfigDir,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  state.installer = child;
+  state.installerUrl = await waitForInstallerUrl(child);
+}
+
+async function stopInstaller(): Promise<void> {
+  if (state.installer && state.installer.exitCode === null) {
+    state.installer.kill("SIGTERM");
+    await Promise.race([
+      new Promise<void>((resolve) => state.installer?.once("exit", () => resolve())),
+      wait(2_000),
+    ]);
+    if (state.installer.exitCode === null) state.installer.kill("SIGKILL");
+  }
+  state.installer = null;
+  if (state.installerConfigDir) {
+    await rm(state.installerConfigDir, { recursive: true, force: true });
+    state.installerConfigDir = "";
+  }
+}
+
+async function configureAndRunInstaller(ctx: FlowContext): Promise<void> {
+  await startInstaller(ctx);
+  await navigate(ctx, state.installerUrl);
+  await ctx.waitForText("Paste your install link", { timeoutMs: BROWSER_TIMEOUT_MS });
+  await ctx.fill("#install-link", state.installLink);
+  await ctx.trustedClick("#continue");
+  await ctx.waitForText(requiredString(ctx.env.OPENWORK_EVAL_ORG_NAME, "OPENWORK_EVAL_ORG_NAME"), {
+    timeoutMs: BROWSER_TIMEOUT_MS,
+  });
+  await ctx.trustedClick("#action");
+  await ctx.waitForText("Successfully Installed", { timeoutMs: 120_000 });
+}
+
+async function openInstallerActivationFallback(ctx: FlowContext): Promise<void> {
+  await ctx.trustedClick("#action");
+  await ctx.waitForText("Browser didn't open?", { timeoutMs: BROWSER_TIMEOUT_MS });
+  const activationUrl = await ctx.eval(`document.querySelector("#activation-link")?.value || ""`);
+  state.activationUrl = requiredString(activationUrl, "activation URL");
+}
+
+function connectUrlFromActivation(): string {
+  const { apiBaseUrl } = getDenStackUrls();
+  const code = new URL(state.activationUrl).searchParams.get("code");
+  const connectUrl = new URL("openwork://connect");
+  connectUrl.searchParams.set("code", requiredString(code, "activation code"));
+  connectUrl.searchParams.set("apiBaseUrl", apiBaseUrl);
+  return connectUrl.toString();
+}
+
+async function useDesktop(ctx: FlowContext): Promise<void> {
+  if (!state.desktopClient) throw new Error("Desktop CDP client was not captured.");
+  ctx.client = state.desktopClient;
+}
+
+async function resetDesktopSession(ctx: FlowContext): Promise<void> {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "desktop ready" });
+  await captureOriginalDesktopBootstrap(ctx);
+  await ctx.eval(`(() => {
+    document.querySelector('[data-testid=connect-confirm-cancel]')?.click();
+    document.querySelector('[data-testid=connect-error-dismiss]')?.click();
+    for (const key of [
+      "openwork.den.authToken",
+      "openwork.den.activeOrgId",
+      "openwork.den.activeOrgSlug",
+      "openwork.den.activeOrgName",
+    ]) localStorage.removeItem(key);
+    window.dispatchEvent(new CustomEvent("openwork-den-session-updated", { detail: { status: "signed_out" } }));
+    return true;
+  })()`);
+}
+
+async function deliverConnectLinkToDesktop(ctx: FlowContext): Promise<void> {
+  state.connectUrl = connectUrlFromActivation();
+  await deliverDeepLinkToDesktop(ctx, state.connectUrl);
+  await ctx.waitFor("Boolean(document.querySelector('[data-testid=connect-confirm-dialog]'))", {
+    timeoutMs: 30_000,
+    label: "connection confirmation",
+  });
+}
+
+async function acceptDesktopConnection(ctx: FlowContext): Promise<void> {
+  await ctx.trustedClick("[data-testid=connect-confirm-accept]");
+  await ctx.waitForText("Welcome to OpenWork", { timeoutMs: 45_000 });
+}
+
+async function signInInvitee(ctx: FlowContext): Promise<void> {
+  const signIn = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email: state.inviteeEmail, password: INVITE_PASSWORD }),
+  });
+  ctx.assert(signIn.response.ok && isRecord(signIn.body), `invitee sign in failed (${signIn.response.status})`);
+  if (!isRecord(signIn.body)) return;
+  state.memberBearer = requiredString(signIn.body.token, "member bearer");
+  const handoff = await denApiFetch("/v1/auth/desktop-handoff", {
+    method: "POST",
+    headers: { Authorization: `Bearer ${state.memberBearer}` },
+    body: JSON.stringify({ desktopScheme: "openwork" }),
+  });
+  ctx.assert(handoff.response.ok && isRecord(handoff.body), `desktop handoff failed (${handoff.response.status})`);
+  if (!isRecord(handoff.body)) return;
+  const openworkUrl = requiredString(handoff.body.openworkUrl, "desktop handoff URL");
+  await deliverDeepLinkToDesktop(ctx, openworkUrl);
+  await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", {
+    timeoutMs: 60_000,
+    label: "persisted Den auth token",
+  });
+  await completeDesktopSignedInJourney(ctx);
+}
+
+async function deliverDeepLinkToDesktop(ctx: FlowContext, openworkUrl: string): Promise<void> {
+  await ctx.eval(`(() => {
+    const url = ${JSON.stringify(openworkUrl)};
+    window.__OPENWORK__ = window.__OPENWORK__ || {};
+    const pending = window.__OPENWORK__.deepLinks || [];
+    window.__OPENWORK__.deepLinks = [...pending, url];
+    window.dispatchEvent(new CustomEvent("openwork:deep-link", { detail: { urls: [url] } }));
+    return true;
+  })()`);
+}
+
+async function completeDesktopSignedInJourney(ctx: FlowContext): Promise<void> {
+  await ctx.waitFor(
+    `document.body.innerText.includes("Choose your organization")
+      || document.body.innerText.includes("You have access to the following resources.")
+      || document.body.innerText.includes("No resources have been configured for this organization yet.")
+      || location.hash.includes("/session")
+      || location.hash.includes("/workspace/")
+      || document.body.innerText.includes("OpenWork Cloud")`,
+    { timeoutMs: 60_000, label: "post-sign-in desktop surface" },
+  );
+
+  if (await ctx.hasText("Choose your organization")) {
+    await clickExactText(ctx, "Continue with organization");
+    await ctx.waitFor(
+      `document.body.innerText.includes("You have access to the following resources.")
+        || document.body.innerText.includes("No resources have been configured for this organization yet.")`,
+      { timeoutMs: 45_000, label: "organization resources step" },
+    );
+  }
+  if (await ctx.hasText("You have access to the following resources.")) {
+    await clickExactText(ctx, "Continue to workspace");
+  } else if (await ctx.hasText("No resources have been configured for this organization yet.")) {
+    await clickExactText(ctx, "Continue");
+  }
+  await ctx.waitFor("location.hash.includes('/session') || location.hash.includes('/workspace/')", {
+    timeoutMs: 45_000,
+    label: "workspace route",
+  });
+  await ctx.navigateHash("/settings/cloud-account");
+  await ctx.waitForText("OpenWork Cloud", { timeoutMs: 45_000 });
+  await ctx.waitForText("Sign out", { timeoutMs: 45_000 });
+}
+
+async function cleanupDesktopSession(ctx: FlowContext): Promise<void> {
+  try {
+    await ctx.eval(`(() => {
+      document.querySelector('[data-testid=connect-confirm-cancel]')?.click();
+      document.querySelector('[data-testid=connect-error-dismiss]')?.click();
+      for (const key of [
+        "openwork.den.authToken",
+        "openwork.den.activeOrgId",
+        "openwork.den.activeOrgSlug",
+        "openwork.den.activeOrgName",
+      ]) localStorage.removeItem(key);
+      window.dispatchEvent(new CustomEvent("openwork-den-session-updated", { detail: { status: "signed_out" } }));
+      return true;
+    })()`);
+  } catch {
+    // Continue restoring the original bootstrap.
+  }
+  await restoreDesktopBootstrap(ctx);
+}
+
+async function prepareFlow(ctx: FlowContext): Promise<void> {
+  state.desktopClient = ctx.client;
+  await createInvitation(ctx);
+}
+
+async function assertBrandedWelcome(ctx: FlowContext): Promise<void> {
+  await ctx.expectText("You're in, welcome to");
+  await ctx.expectText(requiredString(ctx.env.OPENWORK_EVAL_ORG_NAME, "OPENWORK_EVAL_ORG_NAME"));
+  await ctx.expectText("Get the desktop app");
+  await ctx.expectText("Continue in the browser");
+}
+
+async function assertInstallRecommendation(ctx: FlowContext): Promise<void> {
+  await ctx.expectText("Download and install OpenWork");
+  await ctx.expectText("recommended installer");
+  await ctx.expectText("Continue on your computer");
+}
+
+async function assertInstallerContinuation(ctx: FlowContext): Promise<void> {
+  await ctx.expectText("Continue on your computer");
+  await ctx.expectText("Using the installer?");
+  await ctx.expectText("Paste this organization link");
+  await ctx.expectText("Copy a fresh connection link");
+}
+
+async function assertInstallerApproval(ctx: FlowContext): Promise<void> {
+  await ctx.expectText(requiredString(ctx.env.OPENWORK_EVAL_ORG_NAME, "OPENWORK_EVAL_ORG_NAME"));
+  await ctx.expectText("Successfully Installed");
+  await ctx.expectText("Open this in your browser");
+}
+
+async function assertInstallerFallback(ctx: FlowContext): Promise<void> {
+  await ctx.expectText("Browser didn't open?");
+  await ctx.expectText("copy this one-time activation link");
+  await ctx.expectText("Try opening browser again");
+  ctx.assert(state.activationUrl.startsWith("http"), "installer must expose a browser activation URL");
+  await ctx.eval(`(() => {
+    const input = document.querySelector("#activation-link");
+    if (input instanceof HTMLInputElement) {
+      input.value = input.value.replace(/([?&]code=)[^&]+/, "$1[one-time-code]");
+    }
+    return true;
+  })()`);
+}
+
+async function assertDesktopConfirmation(ctx: FlowContext): Promise<void> {
+  await ctx.expectText("Nothing has been changed yet.");
+  await ctx.expectText(requiredString(ctx.env.OPENWORK_EVAL_ORG_NAME, "OPENWORK_EVAL_ORG_NAME"));
+  await ctx.expectText(new URL(getDenStackUrls().webBaseUrl).host);
+  await ctx.expectText("Connect");
+}
+
+async function assertBrowserConnected(ctx: FlowContext): Promise<void> {
+  const orgName = requiredString(ctx.env.OPENWORK_EVAL_ORG_NAME, "OPENWORK_EVAL_ORG_NAME");
+  await ctx.expectText(`Connected to ${orgName}`);
+  await ctx.expectText(`${orgName}'s setup and branding are ready`);
+  await ctx.expectText("Return to OpenWork");
+  await ctx.expectText("Copy this OpenWork link");
+}
+
+async function assertSignedInDesktop(ctx: FlowContext): Promise<void> {
+  await ctx.expectText(state.inviteeEmail);
+  const orgName = requiredString(ctx.env.OPENWORK_EVAL_ORG_NAME, "OPENWORK_EVAL_ORG_NAME");
+  await ctx.expectText(orgName);
+  const activeOrgName = await ctx.eval("localStorage.getItem('openwork.den.activeOrgName') ?? ''");
+  ctx.assert(activeOrgName === orgName, "desktop must retain the active organization name");
+  const bootstrap = await invokeDesktop(ctx, "getDesktopBootstrapConfig");
+  ctx.assert(
+    isRecord(bootstrap) && bootstrap.requireSignin === true,
+    "desktop bootstrap must retain the organization's required sign-in policy",
+  );
+}
+
+const flow = defineFlow({
+  id: FLOW_ID,
+  title: "Join an organization and reach a confirmed, branded desktop",
+  kind: "user-facing",
+  spec: "evals/voiceovers/org-install-activation.md",
+  requiredEnv: [
+    "OPENWORK_EVAL_DEN_API_URL",
+    "OPENWORK_EVAL_DEN_WEB_URL",
+    "OPENWORK_EVAL_DEN_TOKEN",
+    "OPENWORK_EVAL_MARK_VERIFIED_CMD",
+    "OPENWORK_EVAL_WEB_CDP_INVITEE",
+    "OPENWORK_EVAL_ORG_NAME",
+    "OPENWORK_EVAL_ORG_DOMAIN",
+  ],
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await prepareFlow(ctx);
+        await withWeb(ctx, async () => {
+          await ctx.prove("Branded organization welcome", {
+            voiceover: vo[0],
+            action: async () => acceptInvitationAndOpenWelcome(ctx),
+            assert: async () => assertBrandedWelcome(ctx),
+            screenshot: {
+              name: "branded-organization-welcome",
+              requireText: ["You're in, welcome to", "Get the desktop app", "Continue in the browser"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await withWeb(ctx, async () => {
+          await ctx.prove("Platform-aware install recommendation", {
+            voiceover: vo[1],
+            action: async () => {
+              await openInstallGuide(ctx);
+              await startDownloadWithoutFetchingAsset(ctx);
+            },
+            assert: async () => assertInstallRecommendation(ctx),
+            screenshot: {
+              name: "platform-aware-install-recommendation",
+              requireText: ["Download and install OpenWork", "recommended installer", "Continue on your computer"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await withWeb(ctx, async () => {
+          await ctx.prove("Installer and already-installed paths", {
+            voiceover: vo[2],
+            action: async () => showInstallerRecoveryLink(ctx),
+            assert: async () => assertInstallerContinuation(ctx),
+            screenshot: {
+              name: "installer-and-already-installed-paths",
+              requireText: ["Continue on your computer", "Using the installer?", "Copy a fresh connection link"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await withWeb(ctx, async () => {
+          await ctx.prove("Organization-aware installer", {
+            voiceover: vo[3],
+            action: async () => configureAndRunInstaller(ctx),
+            assert: async () => assertInstallerApproval(ctx),
+            screenshot: {
+              name: "organization-aware-installer",
+              requireText: ["Successfully Installed", "Open this in your browser"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await withWeb(ctx, async () => {
+          await ctx.prove("Installer-to-browser recovery", {
+            voiceover: vo[4],
+            action: async () => openInstallerActivationFallback(ctx),
+            assert: async () => assertInstallerFallback(ctx),
+            screenshot: {
+              name: "installer-to-browser-recovery",
+              requireText: ["Browser didn't open?", "Try opening browser again", "Copy link"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("Desktop connection confirmation", {
+          voiceover: vo[5],
+          action: async () => {
+            await withWeb(ctx, async () => {
+              await navigate(ctx, state.activationUrl);
+              await ctx.waitForText("Open OpenWork", { timeoutMs: BROWSER_TIMEOUT_MS });
+              await ctx.expectText(requiredString(ctx.env.OPENWORK_EVAL_ORG_NAME, "OPENWORK_EVAL_ORG_NAME"));
+            });
+            await useDesktop(ctx);
+            await resetDesktopSession(ctx);
+            await deliverConnectLinkToDesktop(ctx);
+          },
+          assert: async () => assertDesktopConfirmation(ctx),
+          screenshot: {
+            name: "desktop-connection-confirmation",
+            requireText: ["Nothing has been changed yet", "Connect"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 7",
+      run: async (ctx) => {
+        await withWeb(ctx, async () => {
+          const webClient = ctx.client;
+          await ctx.prove("Connected browser status", {
+            voiceover: vo[6],
+            action: async () => {
+              await useDesktop(ctx);
+              await acceptDesktopConnection(ctx);
+              ctx.client = webClient;
+              await ctx.waitForText(
+                `Connected to ${requiredString(ctx.env.OPENWORK_EVAL_ORG_NAME, "OPENWORK_EVAL_ORG_NAME")}`,
+                { timeoutMs: BROWSER_TIMEOUT_MS },
+              );
+            },
+            assert: async () => assertBrowserConnected(ctx),
+            screenshot: {
+              name: "connected-browser-status",
+              requireText: ["Connected to", "Return to OpenWork", "Copy this OpenWork link"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 8",
+      run: async (ctx) => {
+        try {
+          await useDesktop(ctx);
+          await ctx.prove("Signed-in branded desktop", {
+            voiceover: vo[7],
+            action: async () => signInInvitee(ctx),
+            assert: async () => assertSignedInDesktop(ctx),
+            screenshot: {
+              name: "signed-in-branded-desktop",
+              requireText: ["OpenWork Cloud", state.inviteeEmail, "Sign out"],
+            },
+          });
+        } finally {
+          await stopInstaller();
+          await cleanupDesktopSession(ctx);
+        }
+      },
+    },
+  ],
+});
+
+process.once("exit", () => {
+  if (state.installer && state.installer.exitCode === null) state.installer.kill("SIGKILL");
+  if (state.installerConfigDir) rmSync(state.installerConfigDir, { recursive: true, force: true });
+});
+
+export default flow;

--- a/evals/flows/org-install-activation.flow.ts
+++ b/evals/flows/org-install-activation.flow.ts
@@ -279,7 +279,7 @@ async function acceptInvitationAndOpenWelcome(ctx: FlowContext): Promise<void> {
 
 async function openInstallGuide(ctx: FlowContext): Promise<void> {
   await ctx.trustedClick("[data-testid=join-org-get-app]");
-  await ctx.waitForText("Download and install OpenWork", { timeoutMs: BROWSER_TIMEOUT_MS });
+  await ctx.waitForText("Download the OpenWork installer", { timeoutMs: BROWSER_TIMEOUT_MS });
   const href = await ctx.eval(`window.location.href`);
   state.installLink = requiredString(href, "install link");
 }
@@ -316,8 +316,11 @@ async function startDownloadWithoutFetchingAsset(ctx: FlowContext): Promise<void
 }
 
 async function showInstallerRecoveryLink(ctx: FlowContext): Promise<void> {
-  await ctx.trustedClick('[data-testid="install-connect-recovery"]');
-  await ctx.waitForText("Copy a fresh connection link", { timeoutMs: BROWSER_TIMEOUT_MS });
+  await ctx.waitFor("Boolean(document.querySelector('[data-testid=install-copy-link] input'))", {
+    timeoutMs: BROWSER_TIMEOUT_MS,
+    label: "organization install link",
+  });
+  await ctx.waitForText("Paste this same link in", { timeoutMs: BROWSER_TIMEOUT_MS });
 }
 
 function waitForInstallerUrl(child: ChildProcess, timeoutMs = 20_000): Promise<string> {
@@ -549,16 +552,16 @@ async function assertBrandedWelcome(ctx: FlowContext): Promise<void> {
 }
 
 async function assertInstallRecommendation(ctx: FlowContext): Promise<void> {
-  await ctx.expectText("Download and install OpenWork");
-  await ctx.expectText("recommended installer");
+  await ctx.expectText("Download the OpenWork installer");
+  await ctx.expectText("For your device");
   await ctx.expectText("Continue on your computer");
 }
 
 async function assertInstallerContinuation(ctx: FlowContext): Promise<void> {
   await ctx.expectText("Continue on your computer");
-  await ctx.expectText("Using the installer?");
-  await ctx.expectText("Paste this organization link");
-  await ctx.expectText("Copy a fresh connection link");
+  await ctx.expectText("already installed");
+  await ctx.expectText("Paste this same link in");
+  await ctx.expectText("Didn't open?");
 }
 
 async function assertInstallerApproval(ctx: FlowContext): Promise<void> {
@@ -654,7 +657,7 @@ const flow = defineFlow({
             assert: async () => assertInstallRecommendation(ctx),
             screenshot: {
               name: "platform-aware-install-recommendation",
-              requireText: ["Download and install OpenWork", "recommended installer", "Continue on your computer"],
+              requireText: ["Download the OpenWork installer", "For your device", "Continue on your computer"],
             },
           });
         });
@@ -670,7 +673,7 @@ const flow = defineFlow({
             assert: async () => assertInstallerContinuation(ctx),
             screenshot: {
               name: "installer-and-already-installed-paths",
-              requireText: ["Continue on your computer", "Using the installer?", "Copy a fresh connection link"],
+              requireText: ["Continue on your computer", "already installed", "Paste this same link in"],
             },
           });
         });

--- a/evals/voiceovers/org-install-activation.md
+++ b/evals/voiceovers/org-install-activation.md
@@ -1,0 +1,17 @@
+# org-install-activation — Join an organization and reach a confirmed, branded desktop
+
+1. Maya accepts her invitation to Blue Yonder and lands on a welcome screen branded for her organization. There is one clear next step—get the desktop app—with a quieter option to continue in the browser.
+
+2. The setup guide recognizes Maya’s computer and recommends the correct installer while keeping the other supported platforms available. She starts the download without losing the Blue Yonder context.
+
+3. Once downloaded, the guide marks that step complete and opens “Continue on your computer.” If OpenWork is already installed she can open it directly; otherwise she runs the installer, with the organization link available as a reliable fallback.
+
+4. The installer identifies Blue Yonder before changing anything and offers one clear action: open the secure approval step in her browser. The installer stays open while the browser handoff is in progress.
+
+5. If the browser does not open, nothing is lost: Maya can try again or copy the one-time activation link and paste it into a browser on this computer. The installer keeps showing the same organization and waiting state until she continues or the link expires.
+
+6. In the browser, Maya approves this computer; OpenWork comes forward and asks her to confirm the connection and sign in. She never has to type a server URL or reconstruct which organization invited her.
+
+7. As soon as OpenWork accepts the setup, the browser changes from waiting to “Connected to Blue Yonder,” confirms that the organization’s setup and branding are ready, and offers one clear button back to OpenWork.
+
+8. Maya returns to OpenWork already inside Blue Yonder’s workspace. If that final browser → app handoff is blocked, the page keeps a copyable OpenWork link available so the flow never ends in a dead end.

--- a/packages/install-config/src/index.ts
+++ b/packages/install-config/src/index.ts
@@ -15,6 +15,15 @@ export const installConfigSchema = z.object({
 
 export type InstallConfig = z.infer<typeof installConfigSchema>
 
+export const installExperienceConfigSchema = installConfigSchema.extend({
+  connectUrl: z.string().trim().min(1),
+  connectExpiresAt: z.string().datetime(),
+  activationUrl: z.string().trim().url(),
+  activationExpiresAt: z.string().datetime(),
+}).meta({ ref: "InstallExperienceConfig" })
+
+export type InstallExperienceConfig = z.infer<typeof installExperienceConfigSchema>
+
 export const desktopBootstrapConfigSchema = z.object({
   baseUrl: z.string().trim().url(),
   apiBaseUrl: z.string().trim().url().optional(),


### PR DESCRIPTION
## Summary
- add a branded, progressive Den install guide and browser activation status page
- carry a one-time organization connection grant through the installer with retry and copy-link recovery when the browser does not open
- confirm the organization in the desktop, focus it on deep link, and report connection completion back to the browser
- add an eight-frame fraimz journey covering invitation through signed-in Blue Yonder desktop

## Validation
- `pnpm --filter @openwork-ee/den-api build`
- `BETTER_AUTH_URL=http://127.0.0.1:8790 pnpm --dir ee/apps/den-api exec bun test test/install-link-access.test.ts test/route-guard-policy.test.ts` — 33 passed
- `pnpm --dir ee/apps/den-api exec bun test test/desktop-connect-grants-db.test.ts` — 1 passed against MySQL
- `pnpm --filter @openwork-ee/den-web typecheck`
- `pnpm --dir ee/apps/den-web exec bun test tests/join-org-invite-clean.test.ts tests/desktop-handoff.test.ts` — 9 passed
- `pnpm --filter @openwork/installer test` — 38 passed
- `pnpm --filter @openwork/install-config typecheck`
- `pnpm --filter @openwork/desktop test` — 109 passed, 1 skipped
- `pnpm exec tsc -p evals/tsconfig.json`
- `pnpm fraimz --flow org-install-activation --stack den --cdp-url http://127.0.0.1:9824` — passed all 8 frames plus voice-over coverage

The full den-web test command also has one pre-existing copy assertion mismatch in `tests/install-errors.test.ts`; the affected source and test are unchanged by this PR. Fraimz screenshots will be posted in a follow-up PR comment.

Made with [Cursor](https://cursor.com)