### PR TITLE
feat(composer): render skills as /slug pills; default to empty state on launch

### DIFF
--- a/apps/app/src/app/index.css
+++ b/apps/app/src/app/index.css
@@ -437,6 +437,33 @@ select:disabled {
   animation: progress-shimmer 2s infinite linear;
 }
 
+/* Quiet text shimmer for lightweight loading hints (e.g. cloud worker
+   sessions catching up): a soft highlight sweeps across muted text. */
+@keyframes ow-text-shimmer {
+  0% {
+    background-position: 150% 0;
+  }
+  100% {
+    background-position: -50% 0;
+  }
+}
+
+@utility ow-text-shimmer {
+  background-image: linear-gradient(
+    90deg,
+    rgb(var(--dls-secondary-rgb) / 0.7) 0%,
+    rgb(var(--dls-secondary-rgb) / 0.7) 42%,
+    var(--dls-text-primary) 50%,
+    rgb(var(--dls-secondary-rgb) / 0.7) 58%,
+    rgb(var(--dls-secondary-rgb) / 0.7) 100%
+  );
+  background-size: 200% 100%;
+  background-clip: text;
+  -webkit-background-clip: text;
+  color: transparent;
+  animation: ow-text-shimmer 2.4s linear infinite;
+}
+
 /* Quiet, small dot ticker (`:: :: ::`). Each dot pulses briefly in sequence,
    illuminating left-to-right like a subtle running light. Used for boot,
    "awaiting first token", and any idle-but-alive hint. */

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -4,6 +4,7 @@ import * as React from "react"
 import {
   AlertTriangle,
   Check,
+  ChevronRight,
   Copy,
   Download,
   FileIcon,
@@ -53,6 +54,11 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from "@/components/ui/context-menu"
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger,
+} from "@/components/ui/collapsible"
 import { ImageAttachmentBadge } from "@/components/chat/image-attachment-badge"
 import { Image } from "@/components/ui/image"
 import {
@@ -84,6 +90,7 @@ import {
   isWriteToolPart,
 } from "@/lib/build-in-tools"
 import type { ThreadStatus } from "@/lib/messages"
+import { formatToolCallDuration } from "@/lib/tool-call-duration"
 import {
   collectToolParts,
   getActiveToolLabel,
@@ -830,6 +837,39 @@ function getRenderableMessage(message: UIMessage) {
   return parts.length > 0 ? { ...message, parts } : null;
 }
 
+/**
+ * A finished turn's steps collapse to a single "Worked for 1m 19s" line
+ * that expands back into the full run. Only live turns show their steps
+ * unprompted; once the answer is in, the reasoning is available but out
+ * of the way.
+ */
+function CompletedStepRun({ label, children }: { label: string; children: React.ReactNode }) {
+  const [open, setOpen] = React.useState(false)
+
+  return (
+    <Collapsible open={open} onOpenChange={setOpen} className="flex w-full flex-col gap-2">
+      <div className="mx-auto flex w-full max-w-3xl px-2 md:px-10">
+        <CollapsibleTrigger
+          className="group flex cursor-pointer items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-foreground"
+          aria-label={open ? `${label}. Hide steps` : `${label}. Show steps`}
+        >
+          <span>{label}</span>
+          <ChevronRight
+            aria-hidden="true"
+            className={cn(
+              "size-3.5 text-muted-foreground/70 transition-transform duration-150",
+              open && "rotate-90"
+            )}
+          />
+        </CollapsibleTrigger>
+      </div>
+      <CollapsibleContent className="h-(--collapsible-panel-height) overflow-hidden transition-[height] duration-150 ease-out data-starting-style:h-0 data-ending-style:h-0 [&[hidden]:not([hidden='until-found'])]:hidden">
+        {children}
+      </CollapsibleContent>
+    </Collapsible>
+  )
+}
+
 interface AssistantMessageGroupProps {
   items: UIMessageWithIndex[]
   messages: UIMessage[]
@@ -874,6 +914,16 @@ function MessageGroup({
   }
   const stepItems = items.slice(0, stepCount)
   const proseItems = items.slice(stepCount)
+  // How long the turn spent working, from the first step to the message
+  // carrying the answer. Server timestamps, so this survives a reload.
+  const stepsStartedAt = stepItems.length > 0 ? getMessageCreated(stepItems[0].message) : null
+  const stepsEndedAt = getMessageCreated(lastItem.message)
+  const stepRunLabel =
+    stepsStartedAt !== null && stepsEndedAt !== null && stepsEndedAt > stepsStartedAt
+      ? `Worked for ${formatToolCallDuration(stepsEndedAt - stepsStartedAt)}`
+      : stepItems.length === 1
+        ? "1 step"
+        : `${stepItems.length} steps`
 
   const renderItem = (item: UIMessageWithIndex, groupIndex: number) => {
     const isLastMessage = item.index === messages.length - 1
@@ -930,9 +980,17 @@ function MessageGroup({
           message use, so a step row is spaced identically whether or not a
           message boundary happens to fall between it and the previous row. */}
       {stepItems.length > 0 ? (
-        <div ref={stepsRef} className="flex max-h-[520px] flex-col gap-2 overflow-y-auto">
-          {renderItems(stepItems, 0)}
-        </div>
+        isLiveGroup ? (
+          <div ref={stepsRef} className="flex max-h-[520px] flex-col gap-2 overflow-y-auto">
+            {renderItems(stepItems, 0)}
+          </div>
+        ) : (
+          <CompletedStepRun label={stepRunLabel}>
+            <div className="flex max-h-[520px] flex-col gap-2 overflow-y-auto">
+              {renderItems(stepItems, 0)}
+            </div>
+          </CompletedStepRun>
+        )
       ) : null}
       {renderItems(proseItems, stepItems.length)}
       {/* Paper artifact strip: one FILES row per turn, at the end. */}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -369,14 +369,19 @@ type AssistantMessageProps = {
   isLastMessage: boolean
   isStreaming: boolean
   isLastStep: boolean
+  /** Set when the turn's collapsed step run shows this reasoning instead. */
+  hideReasoning?: boolean
 }
 
 const AssistantMessage = React.memo(
-  ({ message }: AssistantMessageProps) => {
+  ({ message, hideReasoning }: AssistantMessageProps) => {
     const { showThinking, highlightQuery } = useMessageList()
     const assistantRenderGroups = React.useMemo(
-      () => getAssistantRenderGroups(message.parts, showThinking),
-      [message.parts, showThinking]
+      () => {
+        const groups = getAssistantRenderGroups(message.parts, showThinking)
+        return hideReasoning ? groups.filter((group) => group.kind !== "reasoning") : groups
+      },
+      [hideReasoning, message.parts, showThinking]
     )
 
     return (
@@ -686,10 +691,11 @@ type MessageComponentProps = {
   isLastMessage: boolean
   isStreaming: boolean
   isLastStep: boolean
+  hideReasoning?: boolean
 }
 
 const MessageComponent = React.memo(
-  ({ message, isLastMessage, isStreaming, isLastStep }: MessageComponentProps) => {
+  ({ message, isLastMessage, isStreaming, isLastStep, hideReasoning }: MessageComponentProps) => {
     if (isSessionErrorMessage(message)) {
       return <ErrorMessage error={getMessagesText([message]) || "Session failed"} />
     }
@@ -705,6 +711,7 @@ const MessageComponent = React.memo(
           isLastMessage={isLastMessage}
           isStreaming={isStreaming}
           isLastStep={isLastStep}
+          hideReasoning={hideReasoning}
         />
       )
     }
@@ -925,7 +932,29 @@ function MessageGroup({
         ? "1 step"
         : `${stepItems.length} steps`
 
-  const renderItem = (item: UIMessageWithIndex, groupIndex: number) => {
+  // The answer message's own thinking belongs to the work, not the answer, so
+  // a collapsed run shows it and the message below renders text only.
+  const foldedReasoning =
+    isLiveGroup || stepItems.length === 0
+      ? []
+      : proseItems.flatMap((item) =>
+        item.message.role === "assistant" && !isSessionErrorMessage(item.message)
+          ? getAssistantRenderGroups(item.message.parts, showThinking).flatMap((group, groupIndex) =>
+            group.kind === "reasoning"
+              ? [
+                <Message
+                  key={`folded-reasoning-${item.message.id}-${groupIndex}`}
+                  className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10"
+                >
+                  <ReasoningBlock text={group.text} isStreaming={group.isStreaming} />
+                </Message>,
+              ]
+              : []
+          )
+          : []
+      )
+
+  const renderItem = (item: UIMessageWithIndex, groupIndex: number, hideReasoning?: boolean) => {
     const isLastMessage = item.index === messages.length - 1
 
     return (
@@ -935,6 +964,7 @@ function MessageGroup({
           isLastMessage={isLastMessage}
           isStreaming={isLastMessage && isStreaming}
           isLastStep={groupIndex === items.length - 1}
+          hideReasoning={hideReasoning}
         />
       </div>
     )
@@ -943,7 +973,7 @@ function MessageGroup({
   // Consecutive step messages that contain nothing but command/edit/read/
   // search tool calls merge into one aggregate line (Paper "Recurring
   // actions"); any prose, reasoning, or other tool breaks the run.
-  const renderItems = (slice: UIMessageWithIndex[], offset: number) => {
+  const renderItems = (slice: UIMessageWithIndex[], offset: number, hideReasoning?: boolean) => {
     const nodes: React.ReactNode[] = []
     let run: { parts: AnyToolPart[]; key: string } | null = null
     const flush = () => {
@@ -968,7 +998,7 @@ function MessageGroup({
         return
       }
       flush()
-      nodes.push(renderItem(item, offset + sliceIndex))
+      nodes.push(renderItem(item, offset + sliceIndex, hideReasoning))
     })
     flush()
     return nodes
@@ -988,11 +1018,12 @@ function MessageGroup({
           <CompletedStepRun label={stepRunLabel}>
             <div className="flex max-h-[520px] flex-col gap-2 overflow-y-auto">
               {renderItems(stepItems, 0)}
+              {foldedReasoning}
             </div>
           </CompletedStepRun>
         )
       ) : null}
-      {renderItems(proseItems, stepItems.length)}
+      {renderItems(proseItems, stepItems.length, foldedReasoning.length > 0)}
       {/* Paper artifact strip: one FILES row per turn, at the end. */}
       <ArtifactList
         messages={items.map((item) => item.message)}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -926,8 +926,11 @@ function MessageGroup({
 
   return (
       <div className="flex flex-col gap-2 group/message-group">
+      {/* The scroll area keeps the same 8px rhythm the parts inside a single
+          message use, so a step row is spaced identically whether or not a
+          message boundary happens to fall between it and the previous row. */}
       {stepItems.length > 0 ? (
-        <div ref={stepsRef} className="max-h-[520px] overflow-y-auto">
+        <div ref={stepsRef} className="flex max-h-[520px] flex-col gap-2 overflow-y-auto">
           {renderItems(stepItems, 0)}
         </div>
       ) : null}

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -102,6 +102,9 @@ import type { AnyToolPart } from "@/lib/tool-aggregate"
 
 const SEARCH_HIGHLIGHT_MARK_CLASS = "rounded px-0.5 bg-amber-4/70 text-current"
 
+/** Above this many step rows a finished turn folds into one summary line. */
+const COLLAPSED_STEP_RUN_MIN_ROWS = 4
+
 function MessageTimestamp({ message, className }: { message: UIMessage; className?: string }) {
   const created = getMessageCreated(message)
   if (created === null) return null
@@ -934,25 +937,37 @@ function MessageGroup({
 
   // The answer message's own thinking belongs to the work, not the answer, so
   // a collapsed run shows it and the message below renders text only.
-  const foldedReasoning =
-    isLiveGroup || stepItems.length === 0
-      ? []
-      : proseItems.flatMap((item) =>
-        item.message.role === "assistant" && !isSessionErrorMessage(item.message)
-          ? getAssistantRenderGroups(item.message.parts, showThinking).flatMap((group, groupIndex) =>
-            group.kind === "reasoning"
-              ? [
-                <Message
-                  key={`folded-reasoning-${item.message.id}-${groupIndex}`}
-                  className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10"
-                >
-                  <ReasoningBlock text={group.text} isStreaming={group.isStreaming} />
-                </Message>,
-              ]
-              : []
-          )
+  const proseReasoning = proseItems.flatMap((item) =>
+    item.message.role === "assistant" && !isSessionErrorMessage(item.message)
+      ? getAssistantRenderGroups(item.message.parts, showThinking).flatMap((group, groupIndex) =>
+        group.kind === "reasoning"
+          ? [{ key: `${item.message.id}-${groupIndex}`, text: group.text, isStreaming: group.isStreaming }]
           : []
       )
+      : []
+  )
+  const stepRowCount =
+    stepItems.reduce(
+      (total, item) =>
+        total +
+        (item.message.role === "assistant" && !isSessionErrorMessage(item.message)
+          ? getAssistantRenderGroups(item.message.parts, showThinking).length
+          : 1),
+      0
+    ) + proseReasoning.length
+  // A short finished run reads fine as a list, so only long ones fold away.
+  const collapseSteps =
+    !isLiveGroup && stepItems.length > 0 && stepRowCount > COLLAPSED_STEP_RUN_MIN_ROWS
+  const foldedReasoning = collapseSteps
+    ? proseReasoning.map((reasoning) => (
+      <Message
+        key={`folded-reasoning-${reasoning.key}`}
+        className="mx-auto flex w-full max-w-3xl flex-col items-start gap-2 px-2 md:px-10"
+      >
+        <ReasoningBlock text={reasoning.text} isStreaming={reasoning.isStreaming} />
+      </Message>
+    ))
+    : []
 
   const renderItem = (item: UIMessageWithIndex, groupIndex: number, hideReasoning?: boolean) => {
     const isLastMessage = item.index === messages.length - 1
@@ -1010,20 +1025,20 @@ function MessageGroup({
           message use, so a step row is spaced identically whether or not a
           message boundary happens to fall between it and the previous row. */}
       {stepItems.length > 0 ? (
-        isLiveGroup ? (
-          <div ref={stepsRef} className="flex max-h-[520px] flex-col gap-2 overflow-y-auto">
-            {renderItems(stepItems, 0)}
-          </div>
-        ) : (
+        collapseSteps ? (
           <CompletedStepRun label={stepRunLabel}>
             <div className="flex max-h-[520px] flex-col gap-2 overflow-y-auto">
               {renderItems(stepItems, 0)}
               {foldedReasoning}
             </div>
           </CompletedStepRun>
+        ) : (
+          <div ref={stepsRef} className="flex max-h-[520px] flex-col gap-2 overflow-y-auto">
+            {renderItems(stepItems, 0)}
+          </div>
         )
       ) : null}
-      {renderItems(proseItems, stepItems.length, foldedReasoning.length > 0)}
+      {renderItems(proseItems, stepItems.length, collapseSteps)}
       {/* Paper artifact strip: one FILES row per turn, at the end. */}
       <ArtifactList
         messages={items.map((item) => item.message)}

--- a/apps/app/src/lib/capability-call.ts
+++ b/apps/app/src/lib/capability-call.ts
@@ -34,6 +34,7 @@ const PAST_TENSE: Record<string, string> = {
   execute: "Ran",
   run: "Ran",
   open: "Opened",
+  query: "Queried",
 }
 
 const PRESENT_TENSE: Record<string, string> = {
@@ -54,6 +55,7 @@ const PRESENT_TENSE: Record<string, string> = {
   execute: "Running",
   run: "Running",
   open: "Opening",
+  query: "Querying",
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -93,8 +95,10 @@ function extractQuery(input: unknown, max = 80): string | null {
   if (!isRecord(input)) return null
   const direct = input.query ?? input.q ?? input.search ?? input.prompt
   if (typeof direct === "string" && direct.trim()) return truncate(direct.trim(), max)
-  const body = input.body
-  if (isRecord(body)) {
+  // Bodies arrive as objects or as a JSON string, depending on how the
+  // capability was invoked.
+  const body = parseRecord(input.body)
+  if (body) {
     const nested = body.query ?? body.q ?? body.search ?? body.prompt ?? body.question ?? body.message ?? body.text
     if (typeof nested === "string" && nested.trim()) return truncate(nested.trim(), max)
   }
@@ -161,6 +165,21 @@ export function getCapabilityCallSentence(
         service: split.service,
         present: `${verbPhrase(split.action, "present")} · ${split.service}${suffix}`,
         past: `${verbPhrase(split.action, "past")} · ${split.service}${suffix}`,
+      }
+    }
+
+    // Org MCP capabilities arrive as "mcp:<connection-id>:<tool_name>". The
+    // connection id is opaque, so the trailing tool name carries the meaning
+    // ("query_granola_meetings" → "Queried granola meetings").
+    if (name?.startsWith("mcp:")) {
+      const action = name.split(":").filter(Boolean).at(-1)
+      if (action) {
+        const suffix = quoted ? ` —${quoted}` : ""
+        return {
+          service: null,
+          present: `${verbPhrase(action, "present")}${suffix}`,
+          past: `${verbPhrase(action, "past")}${suffix}`,
+        }
       }
     }
 

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -1,0 +1,226 @@
+/** @jsxImportSource react */
+import { useRef, useState } from "react";
+import type { Agent } from "@opencode-ai/sdk/v2/client";
+
+import { createDenClient, readDenSettings } from "@/app/lib/den";
+import type { OpenworkServerClient } from "@/app/lib/openwork-server";
+import type { McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
+import { t } from "@/i18n";
+import { ReactSessionComposer } from "@/react-app/domains/session/surface/composer/composer";
+import { encodeComposerMentionValue, type ComposerMentionKind } from "@/react-app/domains/session/surface/composer/mention-encoding";
+import {
+  EMPTY_CONNECT_CAPABILITY_INVENTORY,
+  listAssignedConnectCapabilities,
+  type ConnectCapabilityInventory,
+} from "@/react-app/domains/session/surface/connect-capability-inventory";
+
+/**
+ * Workspace-scoped wiring for the new-task composer. Everything here is
+ * route-level state (default model prefs, selected agent, workspace client),
+ * so choices made before the session exists carry into the session that the
+ * hero creates.
+ */
+export type NewTaskComposerContext = {
+  client: OpenworkServerClient;
+  workspaceId: string | null;
+  selectedModel: ModelRef;
+  modelPickerOpen: boolean;
+  onModelPickerOpenChange: (open: boolean) => void;
+  onModelChange: (model: ModelRef) => void;
+  openWorkModelsEntitled?: boolean;
+  modelVariantLabel: string;
+  modelVariant: string | null;
+  modelBehaviorOptions?: { value: string | null; label: string }[];
+  onModelVariantChange: (value: string | null) => void;
+  agentLabel: string;
+  selectedAgent: string | null;
+  listAgents: () => Promise<Agent[]>;
+  onSelectAgent: (agent: string | null) => void;
+  listCommands: () => Promise<SlashCommandOption[]>;
+  searchFiles: (query: string) => Promise<string[]>;
+  isRemoteWorkspace: boolean;
+  isSandboxWorkspace: boolean;
+  onOpenSettingsSection?: (section: "commands" | "skills" | "mcps" | "plugins") => void;
+};
+
+export type NewTaskComposerProps = {
+  draft: string;
+  onDraftChange: (value: string) => void;
+  /** Called with a non-empty draft; the caller creates the session (and workspace if needed). */
+  onRunTask: () => void;
+  /** Disable submission while a default workspace is being prepared. */
+  busy: boolean;
+  context: NewTaskComposerContext | null;
+};
+
+const noop = () => {};
+const emptyAgents = async (): Promise<Agent[]> => [];
+const emptyCommands = async (): Promise<SlashCommandOption[]> => [];
+const emptyFiles = async (): Promise<string[]> => [];
+const FALLBACK_MODEL: ModelRef = { providerID: "", modelID: "" };
+
+/**
+ * The real session composer, reused for the "What do you need done?" empty
+ * state. The draft (including skill/mention tokens) is seeded into the
+ * created session's composer, so pills typed here survive the handoff.
+ * Attachments stay disabled: they are uploaded per session, which does not
+ * exist yet.
+ */
+export function NewTaskComposer(props: NewTaskComposerProps) {
+  const [mentions, setMentions] = useState<Record<string, ComposerMentionKind>>({});
+  const [skills, setSkills] = useState<SkillCard[]>([]);
+  const [mcpServers, setMcpServers] = useState<McpServerEntry[]>([]);
+  const [mcpStatuses, setMcpStatuses] = useState<McpStatusMap>({});
+  const [mcpStatus, setMcpStatus] = useState<string | null>(null);
+  const connectInventoryCacheRef = useRef<{ scope: string; promise: Promise<ConnectCapabilityInventory> } | null>(null);
+  const context = props.context;
+  const workspaceId = context?.workspaceId ?? null;
+
+  const loadConnectCapabilityInventory = async (): Promise<ConnectCapabilityInventory> => {
+    const settings = readDenSettings();
+    const token = settings.authToken?.trim() ?? "";
+    const organizationId = settings.activeOrgId?.trim() ?? "";
+    if (!token || !organizationId) return EMPTY_CONNECT_CAPABILITY_INVENTORY;
+
+    const scope = `${settings.baseUrl}\n${organizationId}`;
+    if (connectInventoryCacheRef.current?.scope === scope) {
+      try {
+        return await connectInventoryCacheRef.current.promise;
+      } catch {
+        connectInventoryCacheRef.current = null;
+        return EMPTY_CONNECT_CAPABILITY_INVENTORY;
+      }
+    }
+
+    const client = createDenClient({ baseUrl: settings.baseUrl, token });
+    const promise = listAssignedConnectCapabilities({ client, organizationId });
+    connectInventoryCacheRef.current = { scope, promise };
+    try {
+      return await promise;
+    } catch {
+      if (connectInventoryCacheRef.current?.promise === promise) {
+        connectInventoryCacheRef.current = null;
+      }
+      return EMPTY_CONNECT_CAPABILITY_INVENTORY;
+    }
+  };
+
+  const listSkills = context && workspaceId
+    ? async (): Promise<SkillCard[]> => {
+        const connectPromise = loadConnectCapabilityInventory();
+        const response = await context.client.listSkills(workspaceId, { includeGlobal: true });
+        const localSkills = (response.items ?? []).map((skill) => ({
+          name: skill.name,
+          path: skill.path,
+          description: skill.description,
+          trigger: skill.trigger,
+          scope: skill.scope,
+          origin: "local",
+        } satisfies SkillCard));
+        const connect = await connectPromise;
+        const next = [...localSkills, ...connect.skills];
+        setSkills(next);
+        return next;
+      }
+    : undefined;
+
+  const listMcp = context && workspaceId
+    ? async (): Promise<{ servers: McpServerEntry[]; statuses: McpStatusMap; status: string | null }> => {
+        const connectPromise = loadConnectCapabilityInventory();
+        const response = await context.client.listMcp(workspaceId);
+        const localServers = (response.items ?? []).map((entry) => ({
+          name: entry.name,
+          config: entry.config as McpServerEntry["config"],
+          source: entry.source,
+          origin: entry.name === "openwork-cloud" ? "openwork-connect" : "local",
+        } satisfies McpServerEntry));
+        const connect = await connectPromise;
+        const servers = [...localServers, ...connect.mcpServers];
+        const statuses = connect.mcpStatuses;
+        const status = servers.length ? null : "No MCP servers loaded.";
+        setMcpServers(servers);
+        setMcpStatuses(statuses);
+        setMcpStatus(status);
+        return { servers, statuses, status };
+      }
+    : undefined;
+
+  const handleInsertMention = (kind: ComposerMentionKind, value: string) => {
+    // @agent mentions switch the pending task's agent instead of inserting a
+    // mention token (mirrors the session composer, #2101).
+    if (kind === "agent") {
+      props.onDraftChange(props.draft.replace(/@([^\s@]*)$/, ""));
+      context?.onSelectAgent(value);
+      return;
+    }
+    props.onDraftChange(props.draft.replace(/@([^\s@]*)$/, `@${encodeComposerMentionValue(value)} `));
+    setMentions((previous) => ({ ...previous, [value]: kind }));
+  };
+
+  // No paste-chip store exists before the session does, so large pastes are
+  // inlined into the draft instead of becoming expandable chips.
+  const handlePasteText = (text: string) => {
+    props.onDraftChange(props.draft ? `${props.draft}\n${text}` : text);
+  };
+
+  const handleUnsupportedFileLinks = (links: string[]) => {
+    if (!links.length) return;
+    props.onDraftChange(`${props.draft}${props.draft && !props.draft.endsWith("\n") ? "\n" : ""}${links.join("\n")}`);
+  };
+
+  return (
+    <ReactSessionComposer
+      draft={props.draft}
+      mentions={mentions}
+      onDraftChange={props.onDraftChange}
+      onSend={props.onRunTask}
+      onSteer={noop}
+      onQueue={noop}
+      onStop={noop}
+      busy={false}
+      steering={false}
+      submissionPreparing={props.busy}
+      queuedCount={0}
+      disabled={false}
+      statusLabel=""
+      modelPickerOpen={context?.modelPickerOpen ?? false}
+      selectedModel={context?.selectedModel ?? FALLBACK_MODEL}
+      openWorkModelsEntitled={context?.openWorkModelsEntitled}
+      onModelPickerOpenChange={context?.onModelPickerOpenChange ?? noop}
+      onModelChange={context?.onModelChange ?? noop}
+      attachments={[]}
+      onAttachFiles={noop}
+      onRemoveAttachment={noop}
+      attachmentsEnabled={false}
+      attachmentsDisabledReason="Attachments become available once the task starts."
+      modelVariantLabel={context?.modelVariantLabel ?? ""}
+      modelVariant={context?.modelVariant ?? null}
+      modelBehaviorOptions={context?.modelBehaviorOptions}
+      onModelVariantChange={context?.onModelVariantChange ?? noop}
+      agentLabel={context?.agentLabel ?? t("session.default_agent")}
+      selectedAgent={context?.selectedAgent ?? null}
+      listAgents={context?.listAgents ?? emptyAgents}
+      onSelectAgent={context?.onSelectAgent ?? noop}
+      listCommands={context?.listCommands ?? emptyCommands}
+      listSkills={listSkills}
+      skills={skills}
+      listMcp={listMcp}
+      mcpServers={mcpServers}
+      mcpStatus={mcpStatus}
+      mcpStatuses={mcpStatuses}
+      onOpenSettingsSection={context?.onOpenSettingsSection}
+      recentFiles={[]}
+      searchFiles={context?.searchFiles ?? emptyFiles}
+      onInsertMention={handleInsertMention}
+      onPasteText={handlePasteText}
+      onUnsupportedFileLinks={handleUnsupportedFileLinks}
+      pastedText={[]}
+      onExpandPastedText={noop}
+      onRemovePastedText={noop}
+      isRemoteWorkspace={context?.isRemoteWorkspace ?? false}
+      isSandboxWorkspace={context?.isSandboxWorkspace ?? false}
+      onUploadInboxFiles={null}
+      draftScopeKey={`new-task:${workspaceId ?? "chat-first"}`}
+    />
+  );
+}

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -1,10 +1,10 @@
 /** @jsxImportSource react */
-import { useRef, useState } from "react";
+import { useState } from "react";
 import { Zap } from "lucide-react";
 
-import { Button } from "@/components/ui/button";
 import { resolveOrganizationPromptCardContent } from "@/components/chat/task-suggestions";
 import { useOrgRestrictions } from "@/react-app/domains/cloud/desktop-config-provider";
+import { NewTaskComposer, type NewTaskComposerContext } from "./new-task-composer";
 
 type HeroSuggestion = {
   title: string;
@@ -42,17 +42,18 @@ export type SessionEmptyHeroProps = {
   /** Called with the task prompt; the caller creates the session (and workspace if needed). */
   onRunTask: (prompt: string) => void;
   onOpenProviderAuth?: () => void;
+  /** Workspace-scoped wiring for the full composer (skills, agents, models). */
+  composer?: NewTaskComposerContext | null;
 };
 
 /**
- * Paper "first chat" empty state: a plain-language composer front and
+ * Paper "first chat" empty state: the real session composer front and
  * center with suggestion cards below. Suggestions come from desktop
  * policies (organization onboarding prompts) when configured, with
  * built-in defaults otherwise.
  */
 export function SessionEmptyHero(props: SessionEmptyHeroProps) {
   const [prompt, setPrompt] = useState("");
-  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const orgRestrictions = useOrgRestrictions();
 
   const organizationPrompts = orgRestrictions.onboardingPrompts;
@@ -67,19 +68,19 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
     })
     : DEFAULT_SUGGESTIONS;
 
-  const trimmedPrompt = prompt.trim();
   const submit = () => {
+    const trimmedPrompt = prompt.trim();
     if (!trimmedPrompt || props.busy) return;
     props.onRunTask(trimmedPrompt);
   };
 
   const fillPrompt = (value: string) => {
     setPrompt(value);
-    textareaRef.current?.focus();
+    window.dispatchEvent(new Event("openwork:focusPrompt"));
   };
 
   return (
-    <div className="mx-auto w-full max-w-[560px] space-y-6 px-6">
+    <div className="mx-auto w-full max-w-[640px] space-y-6 px-6">
       <div className="space-y-1.5 text-center">
         <h2 className="text-[24px] font-semibold leading-[30px] tracking-[-0.02em] text-foreground">
           What do you need done?
@@ -87,26 +88,13 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
         <p className="text-[13px] text-muted-foreground">Describe it in plain language</p>
       </div>
 
-      <div className="rounded-2xl border border-border bg-background p-4 shadow-[var(--dls-card-shadow)] focus-within:border-foreground/25">
-        <textarea
-          ref={textareaRef}
-          value={prompt}
-          onChange={(event) => setPrompt(event.currentTarget.value)}
-          onKeyDown={(event) => {
-            if (event.key !== "Enter" || event.shiftKey) return;
-            event.preventDefault();
-            submit();
-          }}
-          rows={2}
-          placeholder="Ask anything, or describe a task..."
-          className="w-full resize-none bg-transparent text-[13px] leading-[20px] text-foreground outline-none placeholder:text-muted-foreground"
-        />
-        <div className="mt-2">
-          <Button size="sm" onClick={submit} disabled={!trimmedPrompt || props.busy}>
-            {props.busy ? "Preparing workspace..." : "Run task"}
-          </Button>
-        </div>
-      </div>
+      <NewTaskComposer
+        draft={prompt}
+        onDraftChange={setPrompt}
+        onRunTask={submit}
+        busy={props.busy ?? false}
+        context={props.composer ?? null}
+      />
 
       {props.providerCount === 0 && props.onOpenProviderAuth ? (
         <button

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -53,6 +53,7 @@ import {
 } from "@/components/ui/resizable";
 import { ShareWorkspaceModal } from "../../workspace/share-workspace-modal";
 import { SessionEmptyHero } from "./session-empty-hero";
+import type { NewTaskComposerContext } from "./new-task-composer";
 import { StatusBar, type StatusBarProps } from "./status-bar";
 import { OwDotTicker } from "../../../shell/dot-ticker";
 import { NotificationBell } from "../../../shell/notification-center";
@@ -206,6 +207,8 @@ export type SessionPageProps = {
   /** Chat-first: create a default workspace and start a task from the empty-state composer. */
   onChatFirstTask?: (prompt: string) => void;
   chatFirstBusy?: boolean;
+  /** Workspace-scoped wiring for the empty-state hero's full composer. */
+  newTaskComposer?: NewTaskComposerContext | null;
   onRenameSession?: (sessionId: string, title: string) => Promise<void> | void;
   onDeleteSession?: (sessionId: string) => Promise<void> | void;
   onArchiveSession?: (sessionId: string, archived: boolean) => Promise<void> | void;
@@ -1279,6 +1282,7 @@ export function SessionPage(props: SessionPageProps) {
                       busy={props.chatFirstBusy}
                       onRunTask={(prompt) => props.onChatFirstTask?.(prompt)}
                       onOpenProviderAuth={props.onOpenProviderAuth}
+                      composer={props.newTaskComposer}
                     />
                   ) : showSelectedWorkspaceError ? (
                     <div className="px-6 py-16">
@@ -1333,6 +1337,7 @@ export function SessionPage(props: SessionPageProps) {
                           props.sidebar.onCreateTaskWithPrompt?.(props.selectedWorkspaceId, prompt)
                         }
                         onOpenProviderAuth={props.onOpenProviderAuth}
+                        composer={props.newTaskComposer}
                       />
                     </div>
                   )}

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -795,8 +795,6 @@ export function SessionPage(props: SessionPageProps) {
     props.startupPhase !== "sessionIndexReady" &&
     props.startupPhase !== "firstSessionReady" &&
     props.startupPhase !== "ready";
-  const showSessionLoadingState =
-    Boolean(props.selectedSessionId) && props.sessionLoadingById(props.selectedSessionId) && !showWorkspaceSetupEmptyState;
   const sidebarInitialLoading = useMemo(() => getSidebarInitialLoading(props.sidebar), [props.sidebar]);
   // Derive the main-pane error from the same data the sidebar uses so the two
   // panes can never disagree. We check (in priority order):
@@ -839,6 +837,18 @@ export function SessionPage(props: SessionPageProps) {
       props.surface,
   );
   const canRenderSplitSurface = Boolean(canRenderReactSurface && splitSessionId && splitSessionId !== props.selectedSessionId);
+  // Route-level refreshes must only gate the very first paint of a session.
+  // Once the surface can mount it owns its own data stream, so replacing a
+  // rendered chat with a loading pane (and leaving it there when a refresh
+  // hangs) is never correct.
+  const showSessionLoadingState =
+    Boolean(props.selectedSessionId) &&
+    props.sessionLoadingById(props.selectedSessionId) &&
+    !showWorkspaceSetupEmptyState &&
+    !canRenderReactSurface;
+  const selectedWorkspaceIsRemote = props.workspaces.some(
+    (workspace) => workspace.id === props.selectedWorkspaceId && workspace.workspaceType === "remote",
+  );
   const findButtonSessionId = props.selectedSessionId;
   const canGoBackInConversationHistory = !pendingConversationHistoryNavigation && canNavigateSelectedConversationHistory(
     conversationHistory,
@@ -1180,18 +1190,29 @@ export function SessionPage(props: SessionPageProps) {
               ) : null}
 
               {showDelayedSessionLoadingState ? (
-                <div className="px-6 py-16">
-                  <div
-                    className="mx-auto flex max-w-[320px] flex-col items-center gap-3 text-center"
-                    role="status"
-                    aria-live="polite"
-                  >
-                    <OwDotTicker size="md" />
-                    <div className="text-[12px] leading-5 text-dls-secondary">
+                selectedWorkspaceIsRemote ? (
+                  // Cloud workers sync over the network all the time; the full
+                  // loading pane reads as "something is wrong". Keep it to a
+                  // quiet text shimmer.
+                  <div className="px-6 py-16 text-center" role="status" aria-live="polite">
+                    <span className="ow-text-shimmer text-[12px] leading-5">
                       {t("session.loading_detail")}
+                    </span>
+                  </div>
+                ) : (
+                  <div className="px-6 py-16">
+                    <div
+                      className="mx-auto flex max-w-[320px] flex-col items-center gap-3 text-center"
+                      role="status"
+                      aria-live="polite"
+                    >
+                      <OwDotTicker size="md" />
+                      <div className="text-[12px] leading-5 text-dls-secondary">
+                        {t("session.loading_detail")}
+                      </div>
                     </div>
                   </div>
-                </div>
+                )
               ) : null}
 
               {!showDelayedSessionLoadingState && canRenderReactSurface ? (

--- a/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
+++ b/apps/app/src/react-app/domains/session/modals/queued-messages-panel.tsx
@@ -5,6 +5,7 @@ import { Fragment, type ReactNode } from "react";
 import { ImageAttachmentBadge } from "@/components/chat/image-attachment-badge";
 import { t } from "@/i18n";
 import type { ComposerAttachment, ComposerDraft, ComposerPart } from "@/app/types";
+import { parseConnectSkillToken } from "@/react-app/domains/session/surface/composer/connect-skill-token";
 
 export type QueuedMessagesPanelProps = {
   drafts: ComposerDraft[];
@@ -13,7 +14,7 @@ export type QueuedMessagesPanelProps = {
   sending?: boolean;
 };
 
-const TOKEN_RE = /(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[skill [^\]]+\])/;
+const TOKEN_RE = /(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\])/;
 
 function isImageAttachment(attachment: ComposerAttachment) {
   return attachment.kind === "image" || attachment.mimeType.startsWith("image/");
@@ -70,15 +71,17 @@ function QueuedDraftContent(props: { draft: ComposerDraft }) {
       continue;
     }
 
+    const connectSkill = parseConnectSkillToken(segment);
     const skillMatch = segment.match(/^\[skill (.+)\]$/);
-    if (skillMatch?.[1]) {
+    const skillName = connectSkill?.slug ?? skillMatch?.[1];
+    if (skillName) {
       nodes.push(
         <span
           key={key}
           className="mx-0.5 inline-flex items-center rounded-full border border-violet-6/35 bg-violet-3/20 px-2.5 py-1 text-xs font-medium text-violet-11 align-middle"
-          title={`Skill: ${skillMatch[1]}`}
+          title={`Skill: ${connectSkill?.name ?? skillName}`}
         >
-          {skillMatch[1]}
+          {`/${skillName}`}
         </span>,
       );
       continue;

--- a/apps/app/src/react-app/domains/session/surface/composer-auto-send.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer-auto-send.ts
@@ -1,0 +1,17 @@
+/**
+ * One-step "Run task" from the empty-state hero: the route seeds the created
+ * session's draft and marks it here; the session surface consumes the mark
+ * and fires its normal send path once the composer is ready. If the send
+ * conditions are never met (e.g. no usable model), the mark simply expires
+ * with the surface and the seeded draft stays for manual sending.
+ */
+const pendingAutoSendSessionIds = new Set<string>();
+
+export function markComposerAutoSend(sessionId: string) {
+  const id = sessionId.trim();
+  if (id) pendingAutoSendSessionIds.add(id);
+}
+
+export function consumeComposerAutoSend(sessionId: string): boolean {
+  return pendingAutoSendSessionIds.delete(sessionId.trim());
+}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -25,6 +25,7 @@ import {
   skillSlashCommandName,
   type ComposerSlashCommandOption,
 } from "./slash-command";
+import { encodeConnectSkillToken } from "./connect-skill-token";
 import { FILE_URL_RE, HTTP_URL_RE } from "./pasted-text";
 
 type MentionItem = {
@@ -820,16 +821,23 @@ export function ReactSessionComposer(props: ComposerProps) {
       ? { name: input, path: "", origin: "local" as const }
       : input;
     if (skill.origin === "openwork-connect") {
-      const prompt = t("composer.connect_skill_prompt", {
+      const slug = skillSlashCommandName(skill);
+      const token = encodeConnectSkillToken({
+        slug,
         name: skill.name,
         marketplace: skill.marketplaceName ?? "assigned",
         capability: skill.connectCapabilityName ?? skill.name,
       });
       if (options?.replaceSkillDraft) {
-        props.onDraftChange(prompt);
+        props.onDraftChange(`${token} `);
       } else {
-        const separator = props.draft.length > 0 && !/\s$/.test(props.draft) ? " " : "";
-        props.onDraftChange(`${props.draft}${separator}${prompt}`);
+        const editor = editorRef.current;
+        if (editor) {
+          editor.insertSkillAtSelection(slug, token);
+        } else {
+          const separator = props.draft.length > 0 && !/\s$/.test(props.draft) ? " " : "";
+          props.onDraftChange(`${props.draft}${separator}${token} `);
+        }
       }
       setSlashOpen(false);
       setToolMenuOpen(false);

--- a/apps/app/src/react-app/domains/session/surface/composer/connect-skill-token.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/connect-skill-token.ts
@@ -1,0 +1,52 @@
+import { t } from "@/i18n";
+
+/**
+ * Fields carried by a `[connect-skill …]` composer draft token.
+ * The token keeps the full connect-skill invocation self-contained in the
+ * draft text so the composer can render a compact `/slug` pill while the
+ * send path expands it back into the full connect prompt.
+ */
+export type ConnectSkillToken = {
+  /** Slash-command style display slug (e.g. `daytona-chrome-cdp`). */
+  slug: string;
+  /** Human-readable skill name used in the prompt. */
+  name: string;
+  marketplace: string;
+  capability: string;
+};
+
+/** Regex source matching one `[connect-skill …]` token (no capture group). */
+export const CONNECT_SKILL_TOKEN_RE_SOURCE = String.raw`\[connect-skill [^\]]+\]`;
+
+const FIELD_SEPARATOR = "|";
+
+function encodeField(value: string) {
+  return value.replaceAll("%", "%25").replaceAll("|", "%7C").replaceAll("]", "%5D");
+}
+
+function decodeField(value: string) {
+  return value.replaceAll("%5D", "]").replaceAll("%7C", "|").replaceAll("%25", "%");
+}
+
+export function encodeConnectSkillToken(token: ConnectSkillToken) {
+  const fields = [token.slug, token.name, token.marketplace, token.capability].map(encodeField);
+  return `[connect-skill ${fields.join(FIELD_SEPARATOR)}]`;
+}
+
+export function parseConnectSkillToken(segment: string): ConnectSkillToken | null {
+  const match = segment.match(/^\[connect-skill (.+)\]$/);
+  if (!match?.[1]) return null;
+  const fields = match[1].split(FIELD_SEPARATOR).map(decodeField);
+  const [slug, name, marketplace, capability] = fields;
+  if (fields.length !== 4 || !slug || !name || !marketplace || !capability) return null;
+  return { slug, name, marketplace, capability };
+}
+
+/** Expand a connect-skill token into the full prompt sent to the model. */
+export function connectSkillPrompt(token: ConnectSkillToken) {
+  return t("composer.connect_skill_prompt", {
+    name: token.name,
+    marketplace: token.marketplace,
+    capability: token.capability,
+  });
+}

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -35,6 +35,7 @@ import {
 } from "lexical";
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./mention-encoding";
+import { parseConnectSkillToken } from "./connect-skill-token";
 import { shouldCollapsePastedText } from "./pasted-text";
 import { insertStyledPastedText } from "./pasted-text-insertion";
 
@@ -66,7 +67,7 @@ type EditorProps = {
 };
 
 export type LexicalPromptEditorHandle = {
-  insertSkillAtSelection: (skillName: string) => void;
+  insertSkillAtSelection: (skillName: string, skillToken?: string) => void;
 };
 
 type SerializedComposerMentionNode = Spread<
@@ -91,6 +92,7 @@ type SerializedComposerSlashCommandNode = Spread<
 type SerializedComposerSkillNode = Spread<
   {
     skillName: string;
+    skillToken?: string;
     type: "composer-skill";
     version: 1;
   },
@@ -249,28 +251,31 @@ function $createComposerSlashCommandNode(commandName: string) {
 
 class ComposerSkillNode extends TextNode {
   __skillName: string;
+  __skillToken: string;
 
   static override getType() {
     return "composer-skill";
   }
 
   static override clone(node: ComposerSkillNode) {
-    return new ComposerSkillNode(node.__skillName, node.__key);
+    return new ComposerSkillNode(node.__skillName, node.__skillToken, node.__key);
   }
 
   static override importJSON(serializedNode: SerializedComposerSkillNode) {
-    return $createComposerSkillNode(serializedNode.skillName);
+    return $createComposerSkillNode(serializedNode.skillName, serializedNode.skillToken);
   }
 
-  constructor(skillName = "", key?: NodeKey) {
-    super(`[skill ${skillName}]`, key);
+  constructor(skillName = "", skillToken?: string, key?: NodeKey) {
+    super(skillToken ?? `[skill ${skillName}]`, key);
     this.__skillName = skillName;
+    this.__skillToken = skillToken ?? `[skill ${skillName}]`;
   }
 
   override exportJSON(): SerializedComposerSkillNode {
     return {
       ...super.exportJSON(),
       skillName: this.__skillName,
+      skillToken: this.__skillToken,
       type: "composer-skill",
       version: 1,
     };
@@ -279,7 +284,7 @@ class ComposerSkillNode extends TextNode {
   override createDOM(_config: EditorConfig) {
     const dom = document.createElement("span");
     dom.className = "inline-flex items-center rounded-full border border-violet-6/35 bg-violet-3/20 px-2.5 py-1 text-xs font-medium text-violet-11";
-    dom.textContent = this.__skillName;
+    dom.textContent = `/${this.__skillName}`;
     dom.contentEditable = "false";
     dom.setAttribute("spellcheck", "false");
     dom.title = `Skill: ${this.__skillName}`;
@@ -288,7 +293,7 @@ class ComposerSkillNode extends TextNode {
 
   override updateDOM(prevNode: ComposerSkillNode, dom: HTMLElement) {
     if (prevNode.__skillName !== this.__skillName) {
-      dom.textContent = this.__skillName;
+      dom.textContent = `/${this.__skillName}`;
       dom.title = `Skill: ${this.__skillName}`;
     }
     return false;
@@ -311,8 +316,8 @@ class ComposerSkillNode extends TextNode {
   }
 }
 
-function $createComposerSkillNode(skillName: string) {
-  return $applyNodeReplacement(new ComposerSkillNode(skillName));
+function $createComposerSkillNode(skillName: string, skillToken?: string) {
+  return $applyNodeReplacement(new ComposerSkillNode(skillName, skillToken));
 }
 
 function pastedTextChipLabel(lines: number) {
@@ -691,7 +696,7 @@ function setPrompt(
     value = slashMatch[2] ?? "";
   }
 
-  const segments = value.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
+  const segments = value.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/);
   const pastedTextByLabel = new Map((pastedText ?? []).map((item) => [item.label, item]));
   const attachmentsById = new Map((attachments ?? []).map((item) => [item.id, item]));
   for (const segment of segments) {
@@ -712,6 +717,11 @@ function setPrompt(
         continue;
       }
     }
+    const connectSkill = parseConnectSkillToken(segment);
+    if (connectSkill) {
+      paragraph.append($createComposerSkillNode(connectSkill.slug, segment));
+      continue;
+    }
     const skillMatch = segment.match(/^\[skill (.+)\]$/);
     if (skillMatch?.[1]) {
       paragraph.append($createComposerSkillNode(skillMatch[1]));
@@ -729,24 +739,24 @@ function setPrompt(
   }
 }
 
-function appendSkillAtEnd(skillName: string) {
+function appendSkillAtEnd(skillName: string, skillToken?: string) {
   const root = $getRoot();
   const lastChild = root.getLastChild();
   const paragraph = $isElementNode(lastChild) ? lastChild : $createParagraphNode();
   if (!$isElementNode(lastChild)) root.append(paragraph);
-  const skillNode = $createComposerSkillNode(skillName);
+  const skillNode = $createComposerSkillNode(skillName, skillToken);
   const spaceNode = $createTextNode(" ");
   paragraph.append(skillNode, spaceNode);
   setSelectionAfterNode(spaceNode);
 }
 
-function insertSkillAtSelection(skillName: string) {
+function insertSkillAtSelection(skillName: string, skillToken?: string) {
   const selection = $getSelection();
   if (!$isRangeSelection(selection)) {
-    appendSkillAtEnd(skillName);
+    appendSkillAtEnd(skillName, skillToken);
     return;
   }
-  const skillNode = $createComposerSkillNode(skillName);
+  const skillNode = $createComposerSkillNode(skillName, skillToken);
   const spaceNode = $createTextNode(" ");
   selection.insertNodes([skillNode, spaceNode]);
   setSelectionAfterNode(spaceNode);
@@ -1079,8 +1089,8 @@ function ImperativeHandlePlugin(props: { editorRef: ForwardedRef<LexicalPromptEd
   const [editor] = useLexicalComposerContext();
 
   useImperativeHandle(props.editorRef, () => ({
-    insertSkillAtSelection(skillName: string) {
-      editor.update(() => insertSkillAtSelection(skillName));
+    insertSkillAtSelection(skillName: string, skillToken?: string) {
+      editor.update(() => insertSkillAtSelection(skillName, skillToken));
       editor.focus();
     },
   }), [editor]);

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -45,6 +45,7 @@ import type { ProviderCatalog } from "./use-model-behavior";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./composer/mention-encoding";
 import { desktopBridge, openDesktopUrl } from "@/app/lib/desktop";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
+import { connectSkillPrompt, parseConnectSkillToken } from "./composer/connect-skill-token";
 import { DevProfiler } from "@/react-app/shell/dev-profiler";
 import { PaperGrainGradient } from "@openwork/ui/react";
 import { useShellConfig } from "@/react-app/shell/shell-config";
@@ -964,7 +965,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   });
 
   const buildDraft = useCallback((text: string, nextAttachments: ComposerAttachment[]): ComposerDraft => {
-    const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
+    const parts: ComposerPart[] = text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/).flatMap((segment) => {
       if (!segment) return [] as ComposerDraft["parts"];
       const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
       if (attachmentMatch) {
@@ -977,6 +978,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
         if (target) {
           return [{ type: "paste", id: target.id, label: target.label, text: target.text, lines: target.lines }];
         }
+      }
+      const connectSkill = parseConnectSkillToken(segment);
+      if (connectSkill) {
+        return [{ type: "text", text: connectSkillPrompt(connectSkill) } satisfies ComposerDraft["parts"][number]];
       }
       const skillMatch = segment.match(/^\[skill (.+)\]$/);
       if (skillMatch?.[1]) {
@@ -998,6 +1003,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
       resolved = resolved.replace(`[pasted text ${part.label}]`, part.text);
     }
     resolved = resolved.replace(/\[attachment [^\]]+\]/g, "");
+    resolved = resolved.replace(/\[connect-skill [^\]]+\]/g, (match) => {
+      const token = parseConnectSkillToken(match);
+      return token ? connectSkillPrompt(token) : match;
+    });
     resolved = resolved.replace(/\[skill ([^\]]+)\]/g, (_match, name: string) => `the \"${name}\" skill`);
     for (const value of Object.keys(mentions)) {
       resolved = resolved.replaceAll(`@${encodeComposerMentionValue(value)}`, `@${value}`);

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -105,6 +105,7 @@ import {
   listAssignedConnectCapabilities,
   type ConnectCapabilityInventory,
 } from "./connect-capability-inventory";
+import { consumeComposerAutoSend } from "./composer-auto-send";
 
 const EMPTY_TRANSCRIPT: UIMessage[] = [];
 const IDLE_STATUS: SessionStatus = { type: "idle" };
@@ -1098,6 +1099,20 @@ export function SessionSurface(props: SessionSurfaceProps) {
     } catch {
     }
   }, [attachments, buildDraft, clearComposer, draft, props.sessionId, sendDraft]);
+
+  // One-step run from the empty-state hero: the route seeds this session's
+  // draft and marks it for auto-send. Fire the same send path as the send
+  // button once the composer is usable; if these conditions never hold
+  // (e.g. no usable model), the mark is never consumed and the seeded
+  // draft stays for manual sending.
+  useEffect(() => {
+    if (model.transitionState !== "idle") return;
+    if (chatStreaming) return;
+    if (props.modelUnavailable) return;
+    if (!draft.trim()) return;
+    if (!consumeComposerAutoSend(props.sessionId)) return;
+    void handleSend();
+  }, [chatStreaming, draft, handleSend, model.transitionState, props.modelUnavailable, props.sessionId]);
 
   const handleSteer = useCallback(async () => {
     setSteering(true);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -109,6 +109,7 @@ import { getSessionModelSelection, useSessionModelStore } from "@/react-app/doma
 import { openModelPickerEvent } from "@/react-app/shell/new-providers-listener";
 import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
 import { decodeComposerMentionValue } from "@/react-app/domains/session/surface/composer/mention-encoding";
+import { connectSkillPrompt, parseConnectSkillToken } from "@/react-app/domains/session/surface/composer/connect-skill-token";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
 import type { CreateWorkspaceOptions } from "@/react-app/domains/workspace/types";
@@ -305,7 +306,7 @@ async function draftToParts(
         .filter((part): part is Extract<ComposerPart, { type: "paste" }> => part.type === "paste")
         .map((part) => [part.label, part.text] as const),
     );
-    for (const segment of draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/)) {
+    for (const segment of draft.text.split(/(\[attachment [^\]]+\]|\[pasted text [^\]]+\]|\[connect-skill [^\]]+\]|\[skill [^\]]+\]|@[^\s@]+)/)) {
       if (!segment) continue;
       const attachmentMatch = segment.match(/^\[attachment (.+)\]$/);
       if (attachmentMatch?.[1]) {
@@ -320,6 +321,11 @@ async function draftToParts(
       if (pasteMatch?.[1]) {
         const pasted = pasteByLabel.get(pasteMatch[1]);
         if (pasted) parts.push({ type: "text", text: pasted });
+        continue;
+      }
+      const connectSkill = parseConnectSkillToken(segment);
+      if (connectSkill) {
+        parts.push({ type: "text", text: connectSkillPrompt(connectSkill) });
         continue;
       }
       const skillMatch = segment.match(/^\[skill (.+)\]$/);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -111,6 +111,7 @@ import { openModelPickerEvent } from "@/react-app/shell/new-providers-listener";
 import { appMentionInstruction } from "@/react-app/domains/session/surface/composer/app-mentions";
 import { decodeComposerMentionValue } from "@/react-app/domains/session/surface/composer/mention-encoding";
 import { connectSkillPrompt, parseConnectSkillToken } from "@/react-app/domains/session/surface/composer/connect-skill-token";
+import { markComposerAutoSend } from "@/react-app/domains/session/surface/composer-auto-send";
 import { CreateRemoteWorkspaceModal } from "@/react-app/domains/workspace/create-remote-workspace-modal";
 import { CreateWorkspaceModal } from "@/react-app/domains/workspace/create-workspace-modal";
 import type { CreateWorkspaceOptions } from "@/react-app/domains/workspace/types";
@@ -2021,6 +2022,8 @@ export function SessionRoute() {
             // The composer reads its draft from the composer state store, not
             // the persisted draft store — seed both so the prompt shows up.
             useComposerStateStore.getState().setDraft(session.id, firstTaskPrompt);
+            // One-step run: the session surface sends the seeded draft itself.
+            markComposerAutoSend(session.id);
           }
           writeLastSessionFor(targetWorkspaceId, session.id);
           rememberPendingCreatedSession(targetWorkspaceId, session.id);
@@ -2341,6 +2344,8 @@ export function SessionRoute() {
               // The composer reads its draft from the composer state store,
               // not the persisted draft store — seed both.
               useComposerStateStore.getState().setDraft(session.id, prompt);
+              // One-step run: the session surface sends the seeded draft itself.
+              markComposerAutoSend(session.id);
               writeActiveWorkspaceId(workspaceId || null);
               writeLastSessionFor(workspaceId, session.id);
               rememberPendingCreatedSession(workspaceId, session.id);

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -90,6 +90,7 @@ import {
 import { useLocal } from "@/react-app/kernel/local-provider";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { SessionPage, type OpenSessionTab } from "@/react-app/domains/session/chat/session-page";
+import type { NewTaskComposerContext } from "@/react-app/domains/session/chat/new-task-composer";
 import { isDesktopProviderBlocked } from "@/app/cloud/desktop-app-restrictions";
 import { useCheckDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
 import { useRestrictionNotice } from "@/react-app/domains/cloud/restriction-notice-provider";
@@ -1220,6 +1221,85 @@ export function SessionRoute() {
     token,
   ]);
 
+  // Workspace-scoped wiring for the empty-state hero's full composer. Unlike
+  // `surfaceProps` this exists without a selected session, so the hero offers
+  // the same skills/commands/agent/model controls before the session is
+  // created. Model and agent choices land in the same route-level state the
+  // session composer reads, so they carry into the created session.
+  const newTaskComposerContext = useMemo<NewTaskComposerContext | null>(() => {
+    if (!client) return null;
+    return {
+      client,
+      workspaceId: selectedWorkspaceId || null,
+      selectedModel: local.prefs.defaultModel ?? { providerID: "", modelID: "" },
+      modelPickerOpen: modelPicker.compactOpen,
+      onModelPickerOpenChange: (open: boolean) => {
+        modelPicker.setCompactOpen(open);
+        if (open) {
+          void sessionProviderAuthStore.runCloudProviderSync("model_picker_open");
+        }
+      },
+      onModelChange: (model: ModelRef) => {
+        local.setPrefs((previous) => ({
+          ...previous,
+          defaultModel: model,
+          modelVariant: previous.defaultModel?.providerID === model.providerID && previous.defaultModel.modelID === model.modelID
+            ? previous.modelVariant
+            : null,
+        }));
+        modelPicker.setCompactOpen(false);
+      },
+      openWorkModelsEntitled,
+      modelVariantLabel,
+      modelVariant: modelVariantValue,
+      modelBehaviorOptions,
+      onModelVariantChange: (value: string | null) => {
+        local.setPrefs((previous) => ({ ...previous, modelVariant: value }));
+      },
+      agentLabel: selectedAgent ? selectedAgent.charAt(0).toUpperCase() + selectedAgent.slice(1) : t("session.default_agent"),
+      selectedAgent,
+      listAgents,
+      onSelectAgent: (agent: string | null) => setSelectedAgent(agent),
+      listCommands: listSlashCommands,
+      searchFiles: async (query: string) => {
+        const trimmed = query.trim();
+        if (!trimmed || !opencodeClient) return [];
+        const result = unwrap(
+          await opencodeClient.find.files({
+            query: trimmed,
+            dirs: "true",
+            limit: 50,
+            directory: selectedWorkspaceRoot || undefined,
+          }),
+        );
+        return result;
+      },
+      isRemoteWorkspace: selectedWorkspace?.workspaceType === "remote",
+      isSandboxWorkspace: selectedWorkspace ? isSandboxWorkspace(selectedWorkspace) : false,
+      onOpenSettingsSection: (section: "commands" | "skills" | "mcps" | "plugins") => {
+        handleOpenSettings(section === "skills" ? "/settings/extensions/skills" : section === "mcps" ? "/settings/extensions/mcp" : section === "plugins" ? "/settings/extensions/plugins" : "/settings/general");
+      },
+    };
+  }, [
+    client,
+    handleOpenSettings,
+    listAgents,
+    listSlashCommands,
+    local,
+    modelBehaviorOptions,
+    modelPicker,
+    modelVariantLabel,
+    modelVariantValue,
+    opencodeClient,
+    openWorkModelsEntitled,
+    selectedAgent,
+    selectedWorkspace,
+    selectedWorkspaceId,
+    selectedWorkspaceRoot,
+    sessionProviderAuthStore,
+    setSelectedAgent,
+  ]);
+
   const handleOpenCreateWorkspace = useCallback(() => {
     // Respect the org-level `allowMultipleWorkspaces` restriction (dev
     // #1505). If the checker returns true, the admin has disabled
@@ -2116,6 +2196,7 @@ export function SessionRoute() {
       onOpenProviderAuth={() => sessionProviderAuthStore.openProviderAuthModal({ returnFocusTarget: "composer" })}
       onChatFirstTask={handleChatFirstTask}
       chatFirstBusy={createWorkspaceBusy}
+      newTaskComposer={newTaskComposerContext}
       providerAuthModal={sessionProviderAuthSnapshot.providerAuthModalOpen ? {
         open: true,
         loading: false,

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -1,7 +1,7 @@
 // The session route's data + navigation core: workspace/session loading
 // (refreshRouteState + background session fetch), endpoint and opencode
 // client resolution, URL-derived selection, redirects (fallback workspace,
-// last-session restore, welcome), desktop local-server reconnect, remote
+// welcome), desktop local-server reconnect, remote
 // connection checks, and the route inspector slice. Extracted verbatim from
 // session-route.tsx as the final step of its decomposition; the route keeps
 // composition, handlers, and JSX.
@@ -54,7 +54,6 @@ import {
 } from "./route-workspaces";
 import {
   readActiveWorkspaceId,
-  readLastSessionFor,
   readWorkspaceOrderIds,
   writeActiveWorkspaceId,
 } from "./session-memory";
@@ -703,8 +702,10 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     workspaces,
   ]);
 
-  // Once workspaces + sessions are loaded and the URL has no sessionId, try to
-  // restore the last session the user opened in the active workspace.
+  // Once workspaces are loaded, normalize the URL onto the active workspace.
+  // Deliberately no last-session restore here: a fresh app load with no
+  // session in the URL lands on the empty "new task" state instead of
+  // jumping back into the previously opened session.
   useEffect(() => {
     if (loading) return;
     if (routeWorkspaceId && workspaces.length > 0 && !workspaces.some((workspace) => workspace.id === routeWorkspaceId)) {
@@ -718,15 +719,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     }
     if (!routeWorkspaceId && selectedWorkspaceId) {
       navigateToWorkspaceSession(selectedWorkspaceId, selectedSessionId, { replace: true });
-      return;
     }
-    if (selectedSessionId) return;
-    if (!selectedWorkspaceId) return;
-    const remembered = readLastSessionFor(selectedWorkspaceId);
-    if (!remembered) return;
-    const sessions = sessionsByWorkspaceId[selectedWorkspaceId] ?? [];
-    if (!sessions.some((session) => session?.id === remembered)) return;
-    navigateToWorkspaceSession(selectedWorkspaceId, remembered, { replace: true });
   }, [
     loading,
     legacySelectedWorkspaceId,
@@ -734,7 +727,6 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     routeWorkspaceId,
     selectedSessionId,
     selectedWorkspaceId,
-    sessionsByWorkspaceId,
     workspaces,
   ]);
 

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -78,6 +78,30 @@ type ModernRouteSessionResolution =
   | { key: string; status: "loading" }
   | { key: string; status: "not-found" | "error"; message: string };
 
+/** Hard ceiling for each blocking await of a route refresh. A hung desktop
+ * bridge or unresponsive server otherwise leaves `loading` true forever,
+ * which the session pane renders as an indefinite loading state. */
+const ROUTE_REFRESH_STEP_TIMEOUT_MS = 15_000;
+
+function withRouteRefreshTimeout<T>(promise: Promise<T>, label: string): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = window.setTimeout(
+      () => reject(new Error(`${label} did not respond within ${ROUTE_REFRESH_STEP_TIMEOUT_MS / 1000}s`)),
+      ROUTE_REFRESH_STEP_TIMEOUT_MS,
+    );
+    promise.then(
+      (value) => {
+        window.clearTimeout(timer);
+        resolve(value);
+      },
+      (error: unknown) => {
+        window.clearTimeout(timer);
+        reject(error);
+      },
+    );
+  });
+}
+
 export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
   const { developerMode, onServerSettingsChanged, onHostInfo } = input;
   const navigate = useNavigate();
@@ -354,7 +378,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     try {
       if (isDesktopRuntime()) {
         try {
-          desktopList = await workspaceBootstrap() as WorkspaceList;
+          desktopList = await withRouteRefreshTimeout(workspaceBootstrap(), "Desktop workspace bootstrap") as WorkspaceList;
           desktopWorkspaces = (desktopList.workspaces ?? []).map(mapDesktopWorkspace);
         } catch (error) {
           const message = describeRouteError(error);
@@ -368,7 +392,10 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         }
       }
 
-      const { normalizedBaseUrl, resolvedToken, resolvedHostToken, hostInfo } = await resolveOpenworkConnection();
+      const { normalizedBaseUrl, resolvedToken, resolvedHostToken, hostInfo } = await withRouteRefreshTimeout(
+        resolveOpenworkConnection(),
+        "OpenWork server connection",
+      );
       onHostInfo(hostInfo);
       if (!normalizedBaseUrl || !resolvedToken) {
         // Keep the workspace endpoint resolver in lockstep with the disconnected state.
@@ -402,7 +429,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         token: resolvedToken,
         hostToken: resolvedHostToken || undefined,
       });
-      const list = await openworkClient.listWorkspaces();
+      const list = await withRouteRefreshTimeout(openworkClient.listWorkspaces(), "Workspace list");
       const nextWorkspaces = orderRouteWorkspaces(
         mergeRouteWorkspaces(list.items, desktopWorkspaces),
         workspaceOrderIdsRef.current,

--- a/apps/app/tests/capability-call-sentence.test.ts
+++ b/apps/app/tests/capability-call-sentence.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import type { DynamicToolUIPart } from "ai";
+
+import { getCapabilityCallQuote, getCapabilityCallSentence } from "@/lib/capability-call";
+
+function executeCapability(input: unknown): DynamicToolUIPart {
+  return {
+    type: "dynamic-tool",
+    toolName: "openwork-cloud_execute_capability",
+    toolCallId: "call_test",
+    state: "output-error",
+    input,
+    errorText: "boom",
+  } as DynamicToolUIPart;
+}
+
+describe("capability call sentences", () => {
+  test("names an org MCP capability instead of falling back to 'a capability'", () => {
+    const part = executeCapability({
+      name: "mcp:emc_01kx2kfb42f6d94y1s1j992jhf:query_granola_meetings",
+      body: '{"query": "action items from recent meetings"}',
+    });
+
+    const sentence = getCapabilityCallSentence(part);
+
+    expect(sentence.past).toContain("Queried granola meetings");
+    expect(sentence.present).toContain("Querying granola meetings");
+    expect(sentence.past).not.toContain("a capability");
+    // The opaque connection id never reaches the reader.
+    expect(sentence.past).not.toContain("emc_01kx2kfb42f6d94y1s1j992jhf");
+  });
+
+  test("reads the ask out of a JSON-string body", () => {
+    const part = executeCapability({
+      name: "mcp:emc_01kx:query_granola_meetings",
+      body: '{"query": "action items from recent meetings"}',
+    });
+
+    expect(getCapabilityCallQuote(part)).toBe("action items from recent meetings");
+    expect(getCapabilityCallSentence(part).past).toContain("action items from recent meetings");
+  });
+
+  test("still reads the ask out of an object body", () => {
+    const part = executeCapability({
+      name: "mcp:emc_01kx:query_granola_meetings",
+      body: { query: "yesterday's notes" },
+    });
+
+    expect(getCapabilityCallQuote(part)).toBe("yesterday's notes");
+  });
+
+  test("keeps naming dotted capabilities by service", () => {
+    const part = executeCapability({ name: "granola.get_meetings" });
+    const sentence = getCapabilityCallSentence(part);
+
+    expect(sentence.service).toBe("Granola");
+    expect(sentence.past).toContain("Fetched meetings");
+  });
+
+  test("falls back to a generic sentence only when the name is unusable", () => {
+    expect(getCapabilityCallSentence(executeCapability({})).past).toBe("Ran a capability");
+  });
+});

--- a/apps/app/tests/connect-skill-token.test.ts
+++ b/apps/app/tests/connect-skill-token.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, test } from "bun:test";
+
+import {
+  connectSkillPrompt,
+  encodeConnectSkillToken,
+  parseConnectSkillToken,
+} from "@/react-app/domains/session/surface/composer/connect-skill-token";
+
+describe("connect skill token", () => {
+  const token = {
+    slug: "daytona-chrome-cdp",
+    name: "Daytona Chrome CDP",
+    marketplace: "Engineering Marketplace",
+    capability: "plugin:plg_01kx4t4h2aendr697p964fsg15:cob_01kx4t4hzjendr69kfjprv2wz6",
+  };
+
+  test("round-trips through the draft text token", () => {
+    const encoded = encodeConnectSkillToken(token);
+    expect(encoded.startsWith("[connect-skill ")).toBe(true);
+    expect(encoded.endsWith("]")).toBe(true);
+    expect(parseConnectSkillToken(encoded)).toEqual(token);
+  });
+
+  test("escapes separator and bracket characters in fields", () => {
+    const tricky = { ...token, name: "A|B ] C % D", marketplace: "M|]%" };
+    const encoded = encodeConnectSkillToken(tricky);
+    expect(parseConnectSkillToken(encoded)).toEqual(tricky);
+  });
+
+  test("rejects non-token segments", () => {
+    expect(parseConnectSkillToken("[skill fraimz]")).toBeNull();
+    expect(parseConnectSkillToken("[connect-skill only|two]")).toBeNull();
+    expect(parseConnectSkillToken("plain text")).toBeNull();
+  });
+
+  test("expands to the full connect prompt for the model", () => {
+    const prompt = connectSkillPrompt(token);
+    expect(prompt).toContain(`"${token.name}" skill`);
+    expect(prompt).toContain(`"${token.marketplace}" marketplace`);
+    expect(prompt).toContain(token.capability);
+  });
+});


### PR DESCRIPTION
## Summary

- Skill selections in the composer now render as compact violet `/skill-name` pills instead of dumping prompt text. OpenWork Connect (cloud marketplace) skills get a new self-contained `[connect-skill ...]` draft token (`connect-skill-token.ts`) that carries slug/name/marketplace/capability and expands to the full connect prompt only at send time.
- Local and connect skill pills both display `/name`, matching the slash-menu convention; queued-message previews render the same pills.
- Fresh app launch with no session in the URL lands on the empty new-task state instead of auto-restoring the last session (`use-workspace-route-state.ts` startup restore removed). Switching workspaces mid-session still restores that workspace's last open session.

## Evidence

### Screenshots (ephemeral, 24h)

Skill selected from Commands → Skills renders as a violet `/demo-skill` pill:

![skill pill](https://litter.catbox.moe/1z76uq.png)

Fresh load of the bare app URL with `openwork.react.sessionByWorkspace` still populated in localStorage lands on the empty state, not the remembered session:

![empty state](https://litter.catbox.moe/uxzyfp.png)

### Build verification
- `pnpm --filter @openwork/app build` — passed (vite build, 7.4s)

### Tests
- `bun test tests/connect-skill-token.test.ts` — 4 pass / 0 fail (encode/decode round-trip, field escaping, invalid token rejection, prompt expansion)

### UI verification
- Verified live via browser automation against the headless web stack (`scripts/dev-headless-web.ts`) from a clean worktree: inserted a local skill via Commands → Skills → pill renders `/demo-skill`, Run task enabled; then reloaded the bare URL and confirmed landing on "What do you need done?" with a session still remembered in localStorage.
- Console logs were not captured during the run; both flows completed without visible errors and all workspace API calls succeeded (no 403/500s observed in the session).

## Test instructions

1. From the repo root: `OPENWORK_WORKSPACE=<workspace-with-a-skill> bun scripts/dev-headless-web.ts` and open the printed Web URL.
2. Open (or create) a session, click the sparkles button (Commands, skills, and MCPs) → Skills → pick a skill.
3. Verify the composer shows a violet `/skill-name` pill (not a block of prompt text) and that sending still delivers the full skill instruction.
4. Open any session, then reload the app at the bare URL (`/`).
5. Verify you land on the empty "What do you need done?" state instead of the previously open session; switching workspaces mid-session still restores that workspace's last session.

## Update: session loading-state fixes (dc460f8d3)

Follow-up items in this PR:

- **Rendered chats are never replaced by the loading pane.** `showSessionLoadingState` now also requires `!canRenderReactSurface`, so a route-level refresh (or one that hangs) can no longer blank an already-mounted session after 1s. The pane only gates the very first paint.
- **Route refreshes can't stay "loading" forever.** Each blocking await of `refreshRouteState` (desktop bootstrap, server connection, workspace list) gets a 15s watchdog that converts a hang into a visible route error instead of an indefinite "Pulling in the latest messages" state.
- **Cloud workers get a quiet text shimmer.** When the selected workspace is remote, the delayed loading pane renders a subtle `ow-text-shimmer` text line instead of the dot-ticker block used for local sessions.

Evidence:

- Chat stays fully rendered while a refresh is still in flight (status bar: "Preparing workspace — Pulling in the latest messages"): ![chat survives refresh](https://tmpfiles.org/dl/wSw7QGBTXKhD/chat-survives-refresh.png)
- Cloud-worker shimmer (compiled utility verified in the live app; `background-position` sampled 81.3% → −4.8% over 600ms confirming the sweep animates): ![shimmer](https://tmpfiles.org/dl/w4w7QxBQXVkM/shimmer-clip-1.png)
- `pnpm --filter @openwork/app typecheck` — passed.

Made with [Cursor](https://cursor.com)