### PR TITLE
fix(installer): apply the organization app icon after install

### DIFF
--- a/.github/workflows/build-client-installer.yml
+++ b/.github/workflows/build-client-installer.yml
@@ -34,6 +34,11 @@ on:
         required: false
         type: string
         default: ""
+      client_icon_url:
+        description: "Optional square client app icon URL (png) applied to the installed app's dock/taskbar icon"
+        required: false
+        type: string
+        default: ""
       require_signin:
         description: "Force cloud sign-in in the desktop app (requireSignin)"
         required: false
@@ -150,6 +155,7 @@ jobs:
           WEB_URL: ${{ github.event.inputs.web_url }}
           API_URL: ${{ github.event.inputs.api_url }}
           LOGO_URL: ${{ github.event.inputs.client_logo_url }}
+          ICON_URL: ${{ github.event.inputs.client_icon_url }}
           REQUIRE_SIGNIN: ${{ github.event.inputs.require_signin }}
         run: |
           bun -e '
@@ -160,6 +166,7 @@ jobs:
               `export const BUILD_WEB_URL = ${JSON.stringify(process.env.WEB_URL ?? "")}`,
               `export const BUILD_API_URL = ${JSON.stringify(process.env.API_URL ?? "")}`,
               `export const BUILD_LOGO_URL = ${JSON.stringify(process.env.LOGO_URL ?? "")}`,
+              `export const BUILD_ICON_URL = ${JSON.stringify(process.env.ICON_URL ?? "")}`,
               `export const BUILD_REQUIRE_SIGNIN = ${process.env.REQUIRE_SIGNIN === "true"}`,
               "",
             ].join("\n")

--- a/apps/installer/src/config-sources.ts
+++ b/apps/installer/src/config-sources.ts
@@ -1,5 +1,5 @@
 import { installConfigSchema, installConfigUrlFor, type InstallConfig } from "@openwork/install-config"
-import { BUILD_API_URL, BUILD_APP_NAME, BUILD_CLIENT_NAME, BUILD_LOGO_URL, BUILD_REQUIRE_SIGNIN, BUILD_WEB_URL } from "./generated/build-config"
+import { BUILD_API_URL, BUILD_APP_NAME, BUILD_CLIENT_NAME, BUILD_ICON_URL, BUILD_LOGO_URL, BUILD_REQUIRE_SIGNIN, BUILD_WEB_URL } from "./generated/build-config"
 import type { InstallerConfig } from "./config"
 import { fetchWithSystemCa } from "./system-ca"
 
@@ -36,6 +36,7 @@ export type BuildConstants = {
   webUrl: string
   apiUrl: string
   logoUrl: string
+  iconUrl: string
   requireSignin: boolean
 }
 
@@ -45,6 +46,7 @@ const DEFAULT_BUILD_CONSTANTS: BuildConstants = {
   webUrl: BUILD_WEB_URL,
   apiUrl: BUILD_API_URL,
   logoUrl: BUILD_LOGO_URL,
+  iconUrl: BUILD_ICON_URL,
   requireSignin: BUILD_REQUIRE_SIGNIN,
 }
 
@@ -77,6 +79,7 @@ function toInstallerConfig(config: InstallConfig): InstallerConfig {
     webUrl: normalizeUrl(config.webUrl, "web URL"),
     apiUrl: normalizeUrl(config.apiUrl, "API URL"),
     logoUrl: config.logoUrl ? normalizeUrl(config.logoUrl, "logo URL") : null,
+    iconUrl: config.iconUrl ? normalizeUrl(config.iconUrl, "icon URL") : null,
     requireSignin: config.requireSignin,
   }
 }
@@ -108,7 +111,8 @@ export function envOverrides(env: NodeJS.ProcessEnv = process.env): InstallerCon
   const webUrl = env.OPENWORK_INSTALLER_WEB_URL?.trim() ?? ""
   const apiUrl = env.OPENWORK_INSTALLER_API_URL?.trim() ?? ""
   const logoUrl = env.OPENWORK_INSTALLER_LOGO_URL?.trim() ?? ""
-  const hasEnvOverride = Boolean(clientName || webUrl || apiUrl || logoUrl || env.OPENWORK_INSTALLER_REQUIRE_SIGNIN !== undefined)
+  const iconUrl = env.OPENWORK_INSTALLER_ICON_URL?.trim() ?? ""
+  const hasEnvOverride = Boolean(clientName || webUrl || apiUrl || logoUrl || iconUrl || env.OPENWORK_INSTALLER_REQUIRE_SIGNIN !== undefined)
 
   if (!hasEnvOverride) {
     return null
@@ -123,6 +127,7 @@ export function envOverrides(env: NodeJS.ProcessEnv = process.env): InstallerCon
     webUrl: normalizeUrl(webUrl, "web URL"),
     apiUrl: normalizeUrl(apiUrl, "API URL"),
     logoUrl: logoUrl ? normalizeUrl(logoUrl, "logo URL") : null,
+    iconUrl: iconUrl ? normalizeUrl(iconUrl, "icon URL") : null,
     requireSignin: parseRequireSignin(env.OPENWORK_INSTALLER_REQUIRE_SIGNIN, BUILD_REQUIRE_SIGNIN),
   }
 }
@@ -241,6 +246,7 @@ export function buildConstantsConfig(constants: BuildConstants = DEFAULT_BUILD_C
   const webUrl = constants.webUrl.trim()
   const apiUrl = constants.apiUrl.trim()
   const logoUrl = constants.logoUrl.trim()
+  const iconUrl = constants.iconUrl.trim()
   if (!clientName || !webUrl || !apiUrl) {
     return null
   }
@@ -251,6 +257,7 @@ export function buildConstantsConfig(constants: BuildConstants = DEFAULT_BUILD_C
     webUrl: normalizeUrl(webUrl, "web URL"),
     apiUrl: normalizeUrl(apiUrl, "API URL"),
     logoUrl: logoUrl ? normalizeUrl(logoUrl, "logo URL") : null,
+    iconUrl: iconUrl ? normalizeUrl(iconUrl, "icon URL") : null,
     requireSignin: constants.requireSignin,
   }
 }

--- a/apps/installer/src/config.ts
+++ b/apps/installer/src/config.ts
@@ -8,6 +8,8 @@ export type InstallerConfig = {
   apiUrl: string
   /** Optional client logo (png/svg URL) shown in the installer UI. */
   logoUrl: string | null
+  /** Optional square app icon (png URL) the desktop shell applies to the dock/taskbar. */
+  iconUrl: string | null
   requireSignin: boolean
 }
 

--- a/apps/installer/src/generated/build-config.ts
+++ b/apps/installer/src/generated/build-config.ts
@@ -8,4 +8,5 @@ export const BUILD_CLIENT_NAME = ""
 export const BUILD_WEB_URL = ""
 export const BUILD_API_URL = ""
 export const BUILD_LOGO_URL = ""
+export const BUILD_ICON_URL = ""
 export const BUILD_REQUIRE_SIGNIN = false

--- a/apps/installer/src/install.ts
+++ b/apps/installer/src/install.ts
@@ -128,6 +128,7 @@ export function writeBootstrapConfig(
           requireSignin: config.requireSignin,
           brandAppName: config.appName,
           ...(config.logoUrl ? { brandLogoUrl: config.logoUrl } : {}),
+          ...(config.iconUrl ? { brandIconUrl: config.iconUrl } : {}),
         }
       : {}),
     ...(prepared !== undefined ? { prepared } : {}),

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -219,6 +219,7 @@ describe("resolveInstallerConfig", () => {
       webUrl: "https://openwork.acme.com",
       apiUrl: "https://openwork-api.acme.com",
       logoUrl: null,
+      iconUrl: null,
       requireSignin: true,
     })
   })
@@ -270,6 +271,7 @@ describe("resolveInstallerConfig", () => {
         webUrl: "https://build.example.com/",
         apiUrl: "https://build-api.example.com/",
         logoUrl: "https://build.example.com/logo.svg",
+        iconUrl: "https://build.example.com/icon.png",
         requireSignin: true,
       },
       installLink: "https://app.example.com/install?token=abcDEF12",
@@ -285,6 +287,7 @@ describe("resolveInstallerConfig", () => {
       webUrl: "https://build.example.com",
       apiUrl: "https://build-api.example.com",
       logoUrl: "https://build.example.com/logo.svg",
+      iconUrl: "https://build.example.com/icon.png",
       requireSignin: true,
     })
   })
@@ -296,6 +299,7 @@ describe("resolveInstallerConfig", () => {
       webUrl: "",
       apiUrl: "",
       logoUrl: "",
+      iconUrl: "",
       requireSignin: false,
     })).toBeNull()
   })
@@ -326,7 +330,33 @@ describe("resolveInstallerConfig", () => {
         apiUrl: "https://linked-api.example.com",
         requireSignin: true,
         logoUrl: null,
+        iconUrl: null,
       })
+    } finally {
+      configServer.stop(true)
+    }
+  })
+
+  test("carries the deployment app icon from the install link", async () => {
+    const configServer = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      fetch: () => Response.json({
+        clientName: "Linked Corp",
+        webUrl: "https://linked.example.com/",
+        apiUrl: "https://linked-api.example.com/",
+        requireSignin: true,
+        logoUrl: null,
+        iconUrl: "https://linked.example.com/icon.png",
+      }),
+    })
+    try {
+      const resolution = await resolveInstallerConfig({
+        env: {},
+        installLink: `http://127.0.0.1:${configServer.port}/install?token=abcDEF12`,
+      })
+
+      expect(resolution.config.iconUrl).toBe("https://linked.example.com/icon.png")
     } finally {
       configServer.stop(true)
     }
@@ -384,6 +414,7 @@ describe("system CA fetch", () => {
           apiUrl: "https://tls-api.example.com",
           requireSignin: true,
           logoUrl: null,
+          iconUrl: null,
         },
       })
     } finally {
@@ -621,6 +652,7 @@ describe("writeBootstrapConfig", () => {
         apiUrl: "https://api.openworklabs.com/",
         requireSignin: false,
         logoUrl: null,
+        iconUrl: null,
       }
 
       writeBootstrapConfig(hostedConfig, env, "win32")
@@ -661,6 +693,7 @@ describe("writeBootstrapConfig", () => {
           apiUrl: "https://api.custom.internal.example",
           requireSignin: true,
           logoUrl: "https://openwork.custom.internal.example/assets/wordmark.svg",
+          iconUrl: "https://openwork.custom.internal.example/assets/icon.png",
         },
         env,
         "win32",
@@ -674,6 +707,63 @@ describe("writeBootstrapConfig", () => {
       expect(parsed.brandLogoUrl).toBe("https://openwork.custom.internal.example/assets/wordmark.svg")
       expect(parsed.prepared).toEqual({ orgId: "org_example" })
       expect(parsed.claimLinks).toEqual([{ id: "claim_example" }])
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("hands the organization app icon to the desktop shell as brandIconUrl", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-test-"))
+    const env = {
+      LOCALAPPDATA: path.join(dir, "LocalAppData"),
+      USERPROFILE: path.join(dir, "profile"),
+    }
+    const target = desktopBootstrapPath(env, "win32")
+    try {
+      writeBootstrapConfig(
+        {
+          appName: "Example Org Work",
+          clientName: "Example Org",
+          webUrl: "https://openwork.custom.internal.example",
+          apiUrl: "https://api.custom.internal.example",
+          requireSignin: true,
+          logoUrl: "https://openwork.custom.internal.example/assets/wordmark.svg",
+          iconUrl: "https://openwork.custom.internal.example/assets/icon.png",
+        },
+        env,
+        "win32",
+      )
+
+      const parsed = JSON.parse(readFileSync(target, "utf8"))
+      expect(parsed.brandIconUrl).toBe("https://openwork.custom.internal.example/assets/icon.png")
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  test("omits brandIconUrl when the deployment has no app icon", () => {
+    const dir = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-test-"))
+    const env = {
+      LOCALAPPDATA: path.join(dir, "LocalAppData"),
+      USERPROFILE: path.join(dir, "profile"),
+    }
+    const target = desktopBootstrapPath(env, "win32")
+    try {
+      writeBootstrapConfig(
+        {
+          appName: "Example Org Work",
+          clientName: "Example Org",
+          webUrl: "https://openwork.custom.internal.example",
+          apiUrl: "https://api.custom.internal.example",
+          requireSignin: true,
+          logoUrl: null,
+          iconUrl: null,
+        },
+        env,
+        "win32",
+      )
+
+      expect(JSON.parse(readFileSync(target, "utf8")).brandIconUrl).toBeUndefined()
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }


### PR DESCRIPTION
## Problem

From the Jul 22 "Problems in installer - onboarding" session: after installing through an organization installer, the app keeps the stock OpenWork dock/taskbar icon instead of the organization's uploaded icon. The note recorded it as *"No logic coded to swap the icon resource at install time."*

The logic mostly exists already — the installer was the broken link in the middle:

- The Den API `/v1/install-config` **already returns** the organization's square app icon as `iconUrl` (`ee/apps/den-api/src/routes/org/install-links.ts`).
- The Electron shell **already applies** `brandIconUrl` from `desktop-bootstrap.json` on every launch (`applyDesktopBootstrapBrandIcon` in `main.mjs`), and `workspace-store.mjs` already normalizes the field.
- But `InstallerConfig` had no `iconUrl` at all, so `writeBootstrapConfig` only ever wrote `brandLogoUrl`. The icon was parsed off the wire and silently dropped.

`brandLogoUrl` is the in-app wordmark; `brandIconUrl` is the OS-level app icon. Only the wordmark was surviving installation.

## Fix

Carry `iconUrl` from the install-config through to `brandIconUrl` in `desktop-bootstrap.json`, across all three config sources (install link, env overrides, build constants), plus the `client_icon_url` input in the per-client installer workflow.

## Testing

**`cd apps/installer && bun test` — 39 pass, 0 fail** (4 new tests covering the icon handoff and the no-icon case)

**`cd apps/desktop && node --test electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/workspace-store.test.mjs` — 43 pass, 0 fail**

### End-to-end with the real compiled installer

Compiled both the `origin/dev` installer and this branch's installer, ran each headless against the same stub Den endpoint returning `iconUrl`, and diffed the `desktop-bootstrap.json` each one wrote:

**Before (`origin/dev`)** — icon dropped:
```json
{
  "baseUrl": "http://127.0.0.1:51284",
  "apiBaseUrl": "http://127.0.0.1:51284",
  "requireSignin": true,
  "brandAppName": "Acme Work",
  "brandLogoUrl": "https://cdn.example.com/acme/wordmark.svg",
  "writtenAt": "2026-07-24T21:08:40.141Z"
}
```

**After (this branch)**:
```json
{
  "baseUrl": "http://127.0.0.1:51284",
  "apiBaseUrl": "http://127.0.0.1:51284",
  "requireSignin": true,
  "brandAppName": "Acme Work",
  "brandLogoUrl": "https://cdn.example.com/acme/wordmark.svg",
  "brandIconUrl": "https://cdn.example.com/acme/app-icon.png",
  "writtenAt": "2026-07-24T21:08:40.480Z"
}
```

### Windows code path

Ran `writeBootstrapConfig(..., "win32")` with a Windows env, confirming the file lands at the real Windows location with the icon:

```
Windows bootstrap path: C:\AppData\Local\openwork\desktop-bootstrap.json
{
  "brandAppName": "Acme Work",
  "brandLogoUrl": "https://cdn.example.com/acme/wordmark.svg",
  "brandIconUrl": "https://cdn.example.com/acme/app-icon.png"
}
```

### Shell consumption

Fed that exact file to the real `applyDesktopBootstrapBrandIcon` from the Electron shell:

```
shell requested brand icon download for: [ 'https://cdn.example.com/acme/app-icon.png' ]
apply result: { ok: true }
```

## Not done — please read

**I could not run the Windows Daytona validation.** `daytona create --snapshot windows-medium` fails with `Forbidden: Organization is suspended: Depleted credits`, so no Windows VM could be created and the `daytona-windows-cert` / `windows-brand-icon-real-taskbar` flows could not run. No fraimz run either, for the same reason — the flow needs the sandbox.

So there is **no screenshot of a real branded Windows taskbar icon** in this PR. The evidence above proves the installer now hands the icon to the shell and that the shell requests it; it does not prove the final pixel on a real Windows desktop. That last hop is already covered by the existing `windows-brand-icon-real-taskbar` flow and is unchanged by this PR (no desktop code was touched), but a reviewer with Daytona credits should confirm.

To reproduce the Windows check once credits are restored:

```bash
daytona create --snapshot windows-medium
pnpm fraimz --flow windows-brand-icon-real-taskbar
```
