### PR TITLE
fix(installer): trust every OS certificate source on inspected networks

### DIFF
--- a/apps/installer/README.md
+++ b/apps/installer/README.md
@@ -27,6 +27,26 @@ a DMG containing the generic `OpenWork Installer.app`; Windows ships as the bare
 generic `OpenWork-Installer-win-x64.exe`. A generic UI build gates on the paste
 screen until the user provides their OpenWork install link.
 
+## Networks that inspect TLS
+
+Bun's `fetch` trusts only its bundled roots, so on a network that re-signs HTTPS the
+installer additionally trusts the OS stores (Windows `Root`/`CA` for both machine and
+user, macOS `System.keychain` and `SystemRootCertificates.keychain`) plus whatever the
+runtime reports. The user-writable macOS login keychain is deliberately excluded, since
+`security find-certificate` ignores trust settings.
+
+When a corporate root lives somewhere the installer cannot enumerate, IT can point it at
+a PEM bundle — the same variable the desktop shell honors:
+
+```bash
+NODE_EXTRA_CA_CERTS=/path/to/corporate-root.pem
+```
+
+On startup the installer logs what each source contributed
+(`OS trust store: runtime=0 windows-cert-stores=214 NODE_EXTRA_CA_CERTS=1`), and a TLS
+rejection repeats that summary in `trustSources` so support can tell an untrusted
+certificate apart from a trust store that could not be read.
+
 ## Local development
 
 ```bash

--- a/apps/installer/src/server.ts
+++ b/apps/installer/src/server.ts
@@ -2,7 +2,7 @@ import { randomBytes } from "node:crypto"
 
 import { installerConfigSourceLabel, parseInstallLinkInput, resolveInstallLinkConfig, type InstallerConfigResolution } from "./config"
 import { installStatus, launchInstalledApp, runInstall } from "./install"
-import { loadSystemCaCertificates } from "./system-ca"
+import { loadSystemCaBundle, summarizeSystemCaSources } from "./system-ca"
 import { renderInstallerHtml } from "./ui-html"
 
 export type InstallerServer = {
@@ -39,7 +39,11 @@ export function startInstallerServer(initialResolution: InstallerConfigResolutio
   let resolution = initialResolution
   // Warm the OS trust-store CA cache now so the first resolve-link fetch does
   // not spend its 10s abort budget waiting on PowerShell/security exports.
-  void loadSystemCaCertificates()
+  // Record what each source produced: a TLS failure is otherwise indistinguishable
+  // from silent enumeration failure when supporting a locked-down fleet.
+  void loadSystemCaBundle().then((bundle) => {
+    console.log(`[openwork-installer] OS trust store: ${summarizeSystemCaSources(bundle.sources)}`)
+  })
 
   const server = Bun.serve({
     hostname: "127.0.0.1",
@@ -74,7 +78,12 @@ export function startInstallerServer(initialResolution: InstallerConfigResolutio
             }
             if (result.status === "unreachable") {
               if (result.reason === "tls") {
-                return Response.json({ error: "install_link_tls_untrusted", message: tlsUntrustedMessage(installLink) }, { status: 400 })
+                const bundle = await loadSystemCaBundle()
+                return Response.json({
+                  error: "install_link_tls_untrusted",
+                  message: tlsUntrustedMessage(installLink),
+                  trustSources: summarizeSystemCaSources(bundle.sources),
+                }, { status: 400 })
               }
               return Response.json({ error: "install_link_unreachable", message: "Could not reach your workspace. Check your internet or VPN connection and try again." }, { status: 400 })
             }

--- a/apps/installer/src/system-ca.ts
+++ b/apps/installer/src/system-ca.ts
@@ -1,4 +1,5 @@
 import { spawn } from "node:child_process"
+import { readFileSync } from "node:fs"
 import tls from "node:tls"
 
 // Enterprise TLS interception can be trusted by the browser/OS while Bun fetch
@@ -18,7 +19,7 @@ const WINDOWS_CERT_END = "-----END-OPENWORK-CERTIFICATE-----"
 const PEM_CERT_PATTERN = /-----BEGIN CERTIFICATE-----[\s\S]+?-----END CERTIFICATE-----/g
 const TLS_SYSTEM_MODULE: SystemCaTlsModule = tls
 
-let systemCaCertificatesPromise: Promise<string[]> | null = null
+let systemCaCertificatesPromise: Promise<SystemCaBundle> | null = null
 
 function dedupeCertificates(certs: Iterable<string>): string[] {
   const seen = new Set<string>()
@@ -127,27 +128,92 @@ foreach ($store in $stores) {
   return output ? parseWindowsPowerShellCertificates(output) : []
 }
 
+// Admin-controlled keychains only. `find-certificate` ignores trust settings, so
+// including the user-writable login keychain would let any local process widen
+// what the installer trusts; user-domain roots go through NODE_EXTRA_CA_CERTS.
+export const DARWIN_KEYCHAINS = [
+  "/Library/Keychains/System.keychain",
+  "/System/Library/Keychains/SystemRootCertificates.keychain",
+]
+
 async function loadDarwinSystemCertificates(): Promise<string[]> {
-  const output = await runCommand("security", ["find-certificate", "-a", "-p", "/Library/Keychains/System.keychain"], false)
+  const output = await runCommand("security", ["find-certificate", "-a", "-p", ...DARWIN_KEYCHAINS], false)
   return output ? parseDarwinSecurityCertificates(output) : []
 }
 
-async function resolveSystemCaCertificates(): Promise<string[]> {
-  const nodeCerts = loadNodeSystemCertificates()
-  if (nodeCerts.length > 0) return nodeCerts
-
+/**
+ * The documented escape hatch. IT can always point the installer at a PEM
+ * bundle, matching what the desktop shell already honors and giving locked-down
+ * fleets a deterministic override when store enumeration comes up short.
+ */
+export function loadExtraCaCertificates(
+  filePath: string | undefined = process.env.NODE_EXTRA_CA_CERTS,
+): string[] {
+  const trimmed = filePath?.trim()
+  if (!trimmed) return []
   try {
-    if (process.platform === "win32") return await loadWindowsSystemCertificates()
-    if (process.platform === "darwin") return await loadDarwinSystemCertificates()
-    return []
+    return dedupeCertificates(readFileSync(trimmed, "utf8").match(PEM_CERT_PATTERN) ?? [])
   } catch {
     return []
   }
 }
 
-export async function loadSystemCaCertificates(): Promise<string[]> {
-  systemCaCertificatesPromise ??= resolveSystemCaCertificates()
+export type SystemCaSource = { name: string; count: number }
+
+export type SystemCaBundle = {
+  certificates: string[]
+  sources: SystemCaSource[]
+}
+
+export function summarizeSystemCaSources(sources: SystemCaSource[]): string {
+  if (sources.length === 0) return "no OS trust sources returned certificates"
+  return sources.map((source) => `${source.name}=${source.count}`).join(" ")
+}
+
+function platformCertificateLoader(): { name: string; load: () => Promise<string[]> } {
+  if (process.platform === "win32") return { name: "windows-cert-stores", load: loadWindowsSystemCertificates }
+  if (process.platform === "darwin") return { name: "macos-keychains", load: loadDarwinSystemCertificates }
+  return { name: "platform-stores", load: async () => [] }
+}
+
+export type SystemCaLoaders = {
+  runtime: () => string[]
+  platform: { name: string; load: () => Promise<string[]> }
+  extra: () => string[]
+}
+
+/**
+ * Every source is additive. Returning the runtime list as soon as it was
+ * non-empty skipped the thorough platform enumeration, so a runtime that
+ * reports a partial set of roots — the case on an inspected network — never
+ * got the corporate CA it was missing.
+ */
+export async function resolveSystemCaBundle(loaders: SystemCaLoaders): Promise<SystemCaBundle> {
+  const runtimeCerts = loaders.runtime()
+  const platformCerts = await loaders.platform.load().catch(() => [])
+  const extraCerts = loaders.extra()
+
+  return {
+    certificates: dedupeCertificates([...runtimeCerts, ...platformCerts, ...extraCerts]),
+    sources: [
+      { name: "runtime", count: runtimeCerts.length },
+      { name: loaders.platform.name, count: platformCerts.length },
+      { name: "NODE_EXTRA_CA_CERTS", count: extraCerts.length },
+    ],
+  }
+}
+
+export async function loadSystemCaBundle(): Promise<SystemCaBundle> {
+  systemCaCertificatesPromise ??= resolveSystemCaBundle({
+    runtime: loadNodeSystemCertificates,
+    platform: platformCertificateLoader(),
+    extra: loadExtraCaCertificates,
+  })
   return await systemCaCertificatesPromise
+}
+
+export async function loadSystemCaCertificates(): Promise<string[]> {
+  return (await loadSystemCaBundle()).certificates
 }
 
 function mergeFetchInitWithCa(init: TlsFetchInit | undefined, ca: string[]): TlsFetchInit {

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -21,7 +21,16 @@ import { buildConstantsConfig, parseInstallLinkInput, resolveInstallLinkConfig, 
 import { removableInstallerBundlePath, windowsInstalledExePath, writeBootstrapConfig } from "../src/install"
 import { releaseAssetFor } from "../src/release-asset"
 import { startInstallerServer } from "../src/server"
-import { createSystemCaFetch, parseDarwinSecurityCertificates, parseWindowsPowerShellCertificates } from "../src/system-ca"
+import {
+  DARWIN_KEYCHAINS,
+  createSystemCaFetch,
+  loadExtraCaCertificates,
+  parseDarwinSecurityCertificates,
+  parseWindowsPowerShellCertificates,
+  resolveSystemCaBundle,
+  summarizeSystemCaSources,
+  type SystemCaLoaders,
+} from "../src/system-ca"
 
 type SelfSignedCertificate = {
   cert: string
@@ -435,6 +444,114 @@ describe("system CA fetch", () => {
   })
 })
 
+describe("OS trust store sources", () => {
+  const CORPORATE_ROOT = "-----BEGIN CERTIFICATE-----\ncorporate-root\n-----END CERTIFICATE-----"
+  const PUBLIC_ROOT = "-----BEGIN CERTIFICATE-----\npublic-root\n-----END CERTIFICATE-----"
+
+  function loaders(overrides: Partial<SystemCaLoaders> = {}): SystemCaLoaders {
+    return {
+      runtime: () => [],
+      platform: { name: "windows-cert-stores", load: async () => [] },
+      extra: () => [],
+      ...overrides,
+    }
+  }
+
+  test("keeps enumerating the platform stores when the runtime already returned roots", async () => {
+    // The shape of the failure on an inspected network: the runtime knows the
+    // public roots, and only the platform store holds the corporate one.
+    const bundle = await resolveSystemCaBundle(
+      loaders({
+        runtime: () => [PUBLIC_ROOT],
+        platform: { name: "windows-cert-stores", load: async () => [CORPORATE_ROOT] },
+      }),
+    )
+
+    expect(bundle.certificates).toEqual([PUBLIC_ROOT, CORPORATE_ROOT])
+  })
+
+  test("dedupes roots reported by more than one source", async () => {
+    const bundle = await resolveSystemCaBundle(
+      loaders({
+        runtime: () => [PUBLIC_ROOT],
+        platform: { name: "macos-keychains", load: async () => [PUBLIC_ROOT, CORPORATE_ROOT] },
+        extra: () => [CORPORATE_ROOT],
+      }),
+    )
+
+    expect(bundle.certificates).toEqual([PUBLIC_ROOT, CORPORATE_ROOT])
+  })
+
+  test("still contributes the other sources when platform enumeration fails", async () => {
+    const bundle = await resolveSystemCaBundle(
+      loaders({
+        runtime: () => [PUBLIC_ROOT],
+        platform: {
+          name: "windows-cert-stores",
+          load: async () => {
+            throw new Error("powershell blocked by policy")
+          },
+        },
+        extra: () => [CORPORATE_ROOT],
+      }),
+    )
+
+    expect(bundle.certificates).toEqual([PUBLIC_ROOT, CORPORATE_ROOT])
+  })
+
+  test("reports what every source contributed so an empty bundle is explainable", async () => {
+    const bundle = await resolveSystemCaBundle(
+      loaders({ platform: { name: "windows-cert-stores", load: async () => [PUBLIC_ROOT] } }),
+    )
+
+    expect(summarizeSystemCaSources(bundle.sources)).toBe("runtime=0 windows-cert-stores=1 NODE_EXTRA_CA_CERTS=0")
+  })
+
+  test("reads every certificate out of a NODE_EXTRA_CA_CERTS bundle", () => {
+    const bundlePath = path.join(mkdtempSync(path.join(os.tmpdir(), "ow-ca-")), "corporate.pem")
+    writeFileSync(bundlePath, `# corporate bundle\n${CORPORATE_ROOT}\n${PUBLIC_ROOT}\n`)
+
+    expect(loadExtraCaCertificates(bundlePath)).toEqual([CORPORATE_ROOT, PUBLIC_ROOT])
+  })
+
+  test("ignores an unset or unreadable NODE_EXTRA_CA_CERTS instead of failing the install", () => {
+    const previous = process.env.NODE_EXTRA_CA_CERTS
+    delete process.env.NODE_EXTRA_CA_CERTS
+    try {
+      expect(loadExtraCaCertificates()).toEqual([])
+      expect(loadExtraCaCertificates("   ")).toEqual([])
+      expect(loadExtraCaCertificates(path.join(os.tmpdir(), "ow-ca-does-not-exist.pem"))).toEqual([])
+    } finally {
+      if (previous !== undefined) process.env.NODE_EXTRA_CA_CERTS = previous
+    }
+  })
+
+  test("leaves the user-writable login keychain out of the trusted set", () => {
+    // `security find-certificate` ignores trust settings, so enumerating a
+    // keychain any local process can write to would widen what we trust.
+    expect(DARWIN_KEYCHAINS.some((keychain) => keychain.includes("login.keychain"))).toBe(false)
+    expect(DARWIN_KEYCHAINS).toContain("/Library/Keychains/System.keychain")
+  })
+
+  test("a corporate root supplied only through NODE_EXTRA_CA_CERTS resolves a real TLS install link", async () => {
+    const certificate = createSelfSignedCertificate()
+    const configServer = startTlsInstallConfigServer(certificate)
+    const bundlePath = path.join(mkdtempSync(path.join(os.tmpdir(), "ow-ca-")), "corporate.pem")
+    writeFileSync(bundlePath, certificate.cert)
+    try {
+      const bundle = await resolveSystemCaBundle(loaders({ extra: () => loadExtraCaCertificates(bundlePath) }))
+      const result = await resolveInstallLinkConfig(`https://127.0.0.1:${configServer.port}/install?token=abcDEF12`, {
+        fetcher: createSystemCaFetch(async () => bundle.certificates),
+      })
+
+      expect(result.status).toBe("resolved")
+    } finally {
+      configServer.stop(true)
+      certificate.cleanup()
+    }
+  })
+})
+
 describe("resolve-link API", () => {
   test("explains pasted GitHub artifact URLs are not install links", async () => {
     const installerServer = startInstallerServer(null, () => undefined)
@@ -493,8 +610,11 @@ describe("resolve-link API", () => {
       })
 
       expect(response.status).toBe(400)
-      expect(await response.json()).toEqual({
+      expect(await response.json()).toMatchObject({
         error: "install_link_tls_untrusted",
+        // Carried alongside the user-facing copy so a support screenshot shows
+        // whether the trust stores were even readable.
+        trustSources: expect.stringContaining("runtime="),
         message: `Reached your workspace, but the secure connection isn't trusted on this computer yet. This usually means your company inspects secure traffic. Try again — if it keeps failing, ask IT to check the certificate for 127.0.0.1:${configServer.port}.`,
       })
     } finally {


### PR DESCRIPTION
## The bug

On the Blue Yonder POC the installer could not resolve the install link:

> Reached your workspace, but the secure connection isn't trusted on this computer yet.

Their network re-signs HTTPS, so `openwork-poc.blueyonder.com` presents a corporate-CA
chain. The installer already tries to work around Bun's bundled-roots-only `fetch` by
loading OS certificates — but it preferred one source over another:

```ts
const nodeCerts = loadNodeSystemCertificates()
if (nodeCerts.length > 0) return nodeCerts   // never enumerates the platform stores
```

Any non-empty runtime list short-circuits the thorough platform enumeration. A runtime
that reports *some* roots (the public ones) but not the corporate one therefore wins,
and the corporate CA is never loaded. macOS additionally read only `System.keychain`.

## The fix

- **Union all sources** — runtime + platform stores + `NODE_EXTRA_CA_CERTS`, deduped. A
  partial source can no longer mask a complete one.
- **`NODE_EXTRA_CA_CERTS`** — the deterministic override for locked-down fleets, matching
  the variable the desktop shell already honors.
- **macOS also reads `SystemRootCertificates.keychain`.** The user-writable login keychain
  is deliberately *excluded*: `security find-certificate` ignores trust settings, so
  enumerating it would let any local process widen what the installer trusts. User-domain
  corporate roots go through `NODE_EXTRA_CA_CERTS`.
- **Per-source diagnostics** at startup and in the TLS rejection body, so next time an
  untrusted certificate is distinguishable from a trust store that could not be read.

## Fail repro → valid repro

Built a Blue-Yonder-shaped chain (root → intermediate → leaf), none of it in Bun's
bundled roots, serving the Den `install-config` endpoint. Drove the real compiled binary
through its actual `/api/resolve-link` route.

**Fail repro** — corporate root not available to the installer:

```
REJECTED [install_link_tls_untrusted]
message: Reached your workspace, but the secure connection isn't trusted on this
         computer yet. This usually means your company inspects secure traffic...
diagnostics: OS trust store: runtime=0 macos-keychains=165 NODE_EXTRA_CA_CERTS=0
```

This reproduces the reported message byte-for-byte, and it still fails after the fix —
the change does not blanket-trust anything.

**Valid repro** — same binary, same host, root provided the way IT would:

```
NODE_EXTRA_CA_CERTS=/…/corporate-root.pem
RESOLVED ok=True source='install link'
diagnostics: OS trust store: runtime=0 macos-keychains=165 NODE_EXTRA_CA_CERTS=1
```

Public HTTPS is unaffected with the corporate root loaded (`api.github.com -> 200`);
Bun's `tls.ca` augments the default roots rather than replacing them.

## Tests

`pnpm --dir apps/installer test` → **44 pass, 0 fail** (8 new).

Each fix was reverted in isolation to prove its test is load-bearing:

| Reverted | Result |
| --- | --- |
| Restore the short-circuit | union test fails (3 fail) |
| Drop `NODE_EXTRA_CA_CERTS` | both escape-hatch tests fail |
| Re-add the login keychain | security guard fails |

## Not covered

The short-circuit only bites where the runtime returns a partial non-empty list, which is
the **Windows** case — Bun returns 0 on macOS, so the union's effect is not observable
end-to-end on this machine and is covered by unit tests instead. Windows Daytona
validation is blocked (org credits depleted). Worth a run on a real Windows box with the
corporate root in `LocalMachine\Root` before relying on it at Blue Yonder.

Made with [Cursor](https://cursor.com)