### PR TITLE
fix(den): attribute our own MCP lifecycle deadline to OpenWork

### DIFF
--- a/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
+++ b/ee/apps/den-api/src/capability-sources/external-mcp-diagnostics.ts
@@ -1,4 +1,5 @@
 import { createHash } from "node:crypto"
+import { isEnterpriseMcpLifecycleDeadline } from "@openwork/enterprise-mcp-client"
 import { PrivateUrlError } from "./url-guard.js"
 
 export const EXTERNAL_MCP_DIAGNOSTIC_PHASES = [
@@ -648,7 +649,9 @@ function safeBaseMessageFor(input: {
   providerErrorMessage?: string
 }): string {
   if (input.code === "MCP_LIFECYCLE_DEADLINE") {
-    return "The MCP lifecycle exceeded OpenWork's bounded diagnostic deadline."
+    return input.phase === "MCP_TOOL_EXECUTION"
+      ? "The capability did not finish within the time OpenWork allows a single tool call."
+      : "The MCP lifecycle exceeded OpenWork's bounded diagnostic deadline."
   }
   if (input.code === "MCP_REQUEST_TIMEOUT") {
     return "The MCP server did not answer the current protocol request within its bounded timeout."
@@ -1042,14 +1045,18 @@ function classifyByCode(code: string): Classification | null {
 }
 
 function classifyError(error: unknown, fallbackPhase: ExternalMcpDiagnosticPhase): Classification {
-  if (error instanceof ExternalMcpLifecycleDeadlineError) {
+  // The enterprise client aborts with a RequestTimeout MCP error of its own, so
+  // check for our marker before any JSON-RPC code is read as the provider's.
+  if (error instanceof ExternalMcpLifecycleDeadlineError || isEnterpriseMcpLifecycleDeadline(error)) {
     return {
       phase: fallbackPhase,
       category: "lifecycle_deadline",
       code: "MCP_LIFECYCLE_DEADLINE",
       retryable: true,
       actionOwner: "provider_admin",
-      operatorAction: "Reduce provider latency or catalog pagination so the complete MCP lifecycle finishes within the bounded deadline, then retry.",
+      operatorAction: fallbackPhase === "MCP_TOOL_EXECUTION"
+        ? "Retry the capability, and reduce provider latency for this tool if it keeps running past the bounded deadline."
+        : "Reduce provider latency or catalog pagination so the complete MCP lifecycle finishes within the bounded deadline, then retry.",
     }
   }
   if (error instanceof ExternalMcpResponseBodyLimitError) {

--- a/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
+++ b/ee/apps/den-api/test/external-mcp-diagnostics.test.ts
@@ -1,7 +1,11 @@
 import { describe, expect, test } from "bun:test"
 import type { OAuthClientProvider } from "@modelcontextprotocol/sdk/client/auth.js"
 import type { OAuthClientInformationMixed, OAuthTokens } from "@modelcontextprotocol/sdk/shared/auth.js"
-import { EnterpriseMcpOAuthContractError } from "@openwork/enterprise-mcp-client"
+import {
+  EnterpriseMcpClientError,
+  EnterpriseMcpLifecycleDeadlineError,
+  EnterpriseMcpOAuthContractError,
+} from "@openwork/enterprise-mcp-client"
 import {
   ExternalMcpDiagnosticTracker,
   catalogDiagnosticError,
@@ -645,6 +649,41 @@ describe("external MCP diagnostics", () => {
       jsonRpcCode: -32001,
       providerErrorMessage: "MCP error -32001: synthetic provider detail",
       providerErrorData: '{"provider_detail":"must-not-surface"}',
+    })
+  })
+
+  test("attributes our own lifecycle deadline to OpenWork rather than the provider", () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_own_deadline")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const error = tracker.error(new EnterpriseMcpLifecycleDeadlineError("tool-execution"))
+
+    expect(error.diagnostic).toMatchObject({
+      phase: "MCP_TOOL_EXECUTION",
+      category: "lifecycle_deadline",
+      code: "MCP_LIFECYCLE_DEADLINE",
+      retryable: true,
+    })
+    expect(error.diagnostic.message).toBe(
+      "The capability did not finish within the time OpenWork allows a single tool call.",
+    )
+    expect(error.diagnostic.operatorAction).not.toContain("JSON-RPC error code")
+  })
+
+  test("attributes a wrapped lifecycle deadline to OpenWork through its cause chain", () => {
+    const tracker = new ExternalMcpDiagnosticTracker("req_wrapped_deadline")
+    tracker.begin("MCP_TOOL_EXECUTION")
+    const error = tracker.error(
+      new EnterpriseMcpClientError({
+        operationPhase: "tool-execution",
+        requestPhase: "mcp-tool-execution",
+        cause: new EnterpriseMcpLifecycleDeadlineError("tool-execution"),
+      }),
+    )
+
+    expect(error.diagnostic).toMatchObject({
+      category: "lifecycle_deadline",
+      code: "MCP_LIFECYCLE_DEADLINE",
+      retryable: true,
     })
   })
 

--- a/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
+++ b/packages/enterprise-mcp-client/src/enterprise-mcp-client.ts
@@ -20,7 +20,7 @@ import type {
   EnterpriseMcpOperationPhase,
   EnterpriseMcpRequestPhase,
 } from "./contracts.js"
-import { EnterpriseMcpClientError, EnterpriseMcpToolResultError } from "./errors.js"
+import { EnterpriseMcpClientError, EnterpriseMcpLifecycleDeadlineError, EnterpriseMcpToolResultError } from "./errors.js"
 import { EnterpriseMcpOAuthProvider } from "./oauth-provider.js"
 import { createEnterpriseMcpRequestObserver, type EnterpriseMcpRequestObserver } from "./request-observer.js"
 import { collectEnterpriseMcpTools } from "./tool-catalog.js"
@@ -208,7 +208,7 @@ export function createEnterpriseMcpClient(options: EnterpriseMcpClientOptions): 
     const configuredExpiresAt = options.lifecycle?.expiresAt ?? (clock.now() + operationTimeoutMs)
     const remaining = Math.max(1, Math.min(operationTimeoutMs, configuredExpiresAt - clock.now()))
     const timeout = setTimeout(() => {
-      controller.abort(new Error(`Enterprise MCP ${input.operationPhase} exceeded its lifecycle deadline.`))
+      controller.abort(new EnterpriseMcpLifecycleDeadlineError(input.operationPhase))
     }, remaining)
     controller.signal.addEventListener("abort", () => clearTimeout(timeout), { once: true })
 

--- a/packages/enterprise-mcp-client/src/errors.ts
+++ b/packages/enterprise-mcp-client/src/errors.ts
@@ -1,3 +1,5 @@
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
+
 import type { EnterpriseMcpOperationPhase, EnterpriseMcpRequestPhase } from "./contracts.js"
 
 export type EnterpriseMcpErrorCode =
@@ -62,6 +64,47 @@ export class EnterpriseMcpClientError extends Error {
     this.operationPhase = input.operationPhase
     this.requestPhase = input.requestPhase
   }
+}
+
+/**
+ * Marks a lifecycle abort as ours on the `data` of an MCP error. The SDK
+ * rethrows an `McpError` untouched but collapses any other abort reason into
+ * `String(reason)` on a RequestTimeout, leaving downstream diagnostics unable
+ * to tell an OpenWork deadline apart from a provider-declared failure.
+ */
+export const ENTERPRISE_MCP_LIFECYCLE_DEADLINE_DATA_KEY = "enterpriseMcpLifecycleDeadline"
+
+export class EnterpriseMcpLifecycleDeadlineError extends McpError {
+  readonly operationPhase: EnterpriseMcpOperationPhase
+
+  constructor(operationPhase: EnterpriseMcpOperationPhase) {
+    super(ErrorCode.RequestTimeout, `Enterprise MCP ${operationPhase} exceeded its lifecycle deadline.`, {
+      [ENTERPRISE_MCP_LIFECYCLE_DEADLINE_DATA_KEY]: true,
+      operationPhase,
+    })
+    this.name = "EnterpriseMcpLifecycleDeadlineError"
+    this.operationPhase = operationPhase
+  }
+}
+
+/** Walks an error chain for the deadline marker set by this client. */
+export function isEnterpriseMcpLifecycleDeadline(value: unknown): boolean {
+  let current: unknown = value
+  for (let depth = 0; depth < 5 && current; depth += 1) {
+    if (current instanceof EnterpriseMcpLifecycleDeadlineError) return true
+    if (typeof current === "object" && current !== null && "data" in current) {
+      const data: unknown = current.data
+      if (
+        typeof data === "object" && data !== null
+        && ENTERPRISE_MCP_LIFECYCLE_DEADLINE_DATA_KEY in data
+        && data[ENTERPRISE_MCP_LIFECYCLE_DEADLINE_DATA_KEY] === true
+      ) {
+        return true
+      }
+    }
+    current = typeof current === "object" && current !== null && "cause" in current ? current.cause : undefined
+  }
+  return false
 }
 
 export type EnterpriseMcpOAuthContractErrorCode =

--- a/packages/enterprise-mcp-client/test/lifecycle-deadline-error.test.ts
+++ b/packages/enterprise-mcp-client/test/lifecycle-deadline-error.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict"
+import { describe, it } from "node:test"
+import { ErrorCode, McpError } from "@modelcontextprotocol/sdk/types.js"
+import {
+  EnterpriseMcpClientError,
+  EnterpriseMcpLifecycleDeadlineError,
+  isEnterpriseMcpLifecycleDeadline,
+} from "../src/index.js"
+
+describe("lifecycle deadline error", () => {
+  it("aborts with an McpError so the SDK rethrows it instead of stringifying the reason", () => {
+    const error = new EnterpriseMcpLifecycleDeadlineError("tool-execution")
+
+    // The SDK only passes an abort reason through untouched when it is already
+    // an McpError; anything else becomes String(reason) on a new RequestTimeout.
+    assert.ok(error instanceof McpError)
+    assert.equal(error.code, ErrorCode.RequestTimeout)
+    assert.equal(error.operationPhase, "tool-execution")
+    assert.match(error.message, /exceeded its lifecycle deadline/)
+  })
+
+  it("carries a marker that survives an SDK round trip", () => {
+    const reason = new EnterpriseMcpLifecycleDeadlineError("tool-execution")
+    const rethrown = reason instanceof McpError ? reason : new McpError(ErrorCode.RequestTimeout, String(reason))
+
+    assert.ok(isEnterpriseMcpLifecycleDeadline(rethrown))
+  })
+
+  it("detects the deadline through a wrapped cause chain", () => {
+    const wrapped = new EnterpriseMcpClientError({
+      operationPhase: "tool-execution",
+      requestPhase: "mcp-tool-execution",
+      cause: new EnterpriseMcpLifecycleDeadlineError("tool-execution"),
+    })
+
+    assert.ok(isEnterpriseMcpLifecycleDeadline(wrapped))
+  })
+
+  it("does not claim a provider's own RequestTimeout as ours", () => {
+    const providerError = new McpError(ErrorCode.RequestTimeout, "upstream is busy", { provider_detail: "busy" })
+
+    assert.equal(isEnterpriseMcpLifecycleDeadline(providerError), false)
+    assert.equal(isEnterpriseMcpLifecycleDeadline(new Error("unrelated")), false)
+    assert.equal(isEnterpriseMcpLifecycleDeadline(undefined), false)
+  })
+})


### PR DESCRIPTION
## What

A capability that outran OpenWork's bounded deadline was reported to the member as an unrecognized **provider** error, instructing them to "look up the provider-declared JSON-RPC error code with the provider" — for a timeout the provider never declared:

> The provider rejected the call: provider error — The provider answered with a JSON-RPC error OpenWork does not recognize (code -32001). Provider-declared message (untrusted): "MCP error -32001: Error: Enterprise MCP tool-execution exceeded its lifecycle deadline."

That quoted "provider" message is our own abort text from `packages/enterprise-mcp-client`.

## Why it happened

The lifecycle timer aborted with a plain `Error`. The MCP SDK rethrows an abort reason untouched **only** when it is already an `McpError`; anything else is collapsed into `String(reason)` on a fresh `RequestTimeout` (`shared/protocol.js`):

```js
const error = reason instanceof McpError ? reason : new McpError(ErrorCode.RequestTimeout, String(reason));
```

So all structure was lost. Den's classifier saw code `-32001` with no `data.timeout`, and its only remaining branch for that code was "provider-declared".

## Change

- Abort with an `EnterpriseMcpLifecycleDeadlineError` (an `McpError` subclass) carrying a marker on `data`, so the SDK passes it through intact.
- Check that marker in `classifyError` **before** any JSON-RPC code is read as the provider's, classifying it as the existing retryable `MCP_LIFECYCLE_DEADLINE`.
- Phase-aware wording: a tool call now reads "The capability did not finish within the time OpenWork allows a single tool call."

Detection is structural, not message-based — Den labels provider messages untrusted, so trust decisions must not depend on their text.

## Tests

`npx tsx --test test/*.test.ts` in `packages/enterprise-mcp-client` — **59 pass, 0 fail** (4 new: the abort is an `McpError`, the marker survives the SDK round trip, detection through a wrapped cause chain, and a provider's own `RequestTimeout` is *not* claimed as ours).

`bun test test/external-mcp-diagnostics.test.ts` in `ee/apps/den-api` — **61 pass, 19 fail**, versus **59 pass, 19 fail** on `origin/dev` at baseline (verified by stashing). The same 19 fail before and after; my 2 new tests pass. Typecheck clean for both touched packages.

No fraimz: this is hosted Den API classification with no desktop UI path of its own, and the 31s failure needs a provider that stalls past the deadline. The unit tests assert the exact member-visible message and that `operatorAction` no longer mentions a JSON-RPC code. Reviewer repro: the two new cases in `external-mcp-diagnostics.test.ts`.

Made with [Cursor](https://cursor.com)