### PR TITLE
test(installer): prove OS trust-store pickup on real Windows

### DIFF
--- a/.github/workflows/ci-installer-windows-trust.yml
+++ b/.github/workflows/ci-installer-windows-trust.yml
@@ -1,0 +1,112 @@
+name: Installer Windows Trust Store
+
+# Proves the installer picks a corporate root up from the real Windows machine
+# trust store. This is the case that broke on an enterprise POC: Bun's fetch
+# trusts only its bundled roots, and the installer's OS-trust fallback used to
+# short-circuit on the runtime's partial list, so it never enumerated
+# LocalMachine\Root where the corporate CA actually lives.
+#
+# macOS cannot cover this: Bun reports 0 system certificates there, so the
+# short-circuit never triggers.
+
+on:
+  pull_request:
+    paths:
+      - "apps/installer/**"
+      - ".github/workflows/ci-installer-windows-trust.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: installer-windows-trust-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  windows-trust:
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.9
+
+      - name: Install dependencies
+        shell: bash
+        run: |
+          set -euo pipefail
+          # @openwork/install-config's "default" export points at dist/, which a
+          # fresh checkout lacks.
+          (cd packages/install-config && bun install && bun run build)
+          # bun 1.3.9 on Windows can fail to create the parent-relative workspace
+          # symlink (ENOENT); the copy fallback repairs exactly that case.
+          (cd apps/installer && bun install) || true
+          if [ ! -e "apps/installer/node_modules/@openwork/install-config/package.json" ]; then
+            rm -rf "apps/installer/node_modules/@openwork/install-config"
+            mkdir -p "apps/installer/node_modules/@openwork"
+            cp -R "packages/install-config" "apps/installer/node_modules/@openwork/install-config"
+          fi
+          test -e "apps/installer/node_modules/@openwork/install-config/package.json"
+
+      - name: Compile installer
+        shell: bash
+        run: |
+          cd apps/installer
+          bun build --compile --minify --target=bun-windows-x64 \
+            --windows-icon=assets/icon.ico \
+            src/index.ts src/server-worker.ts --outfile "dist/openwork-installer"
+
+      - name: Build the corporate CA chain
+        shell: bash
+        run: node apps/installer/scripts/make-corporate-ca.mjs --out "$RUNNER_TEMP/corporate-ca"
+
+      - name: Report what Bun sees before anything is trusted
+        shell: bash
+        run: |
+          cd apps/installer
+          bun -e '
+            const { loadSystemCaBundle, summarizeSystemCaSources } = await import("./src/system-ca.ts")
+            const bundle = await loadSystemCaBundle()
+            console.log(`sources: ${summarizeSystemCaSources(bundle.sources)}`)
+            console.log(`total unique roots: ${bundle.certificates.length}`)
+          '
+
+      # Baseline: the corporate root is in no trust store, so the installer must
+      # refuse the link. Guards against the fix blanket-trusting anything.
+      - name: Fail repro - corporate root untrusted
+        shell: bash
+        run: |
+          node apps/installer/scripts/trust-repro.mjs \
+            --installer "apps/installer/dist/openwork-installer.exe" \
+            --certs "$RUNNER_TEMP/corporate-ca" \
+            --expect tls-untrusted
+
+      - name: Trust the corporate root the way enterprise IT does
+        shell: pwsh
+        run: |
+          Import-Certificate -FilePath "$env:RUNNER_TEMP\corporate-ca\root.pem" `
+            -CertStoreLocation Cert:\LocalMachine\Root | Format-List Subject, Thumbprint
+
+      # The real assertion: nothing but the machine trust store changed, so the
+      # installer resolves the link only by enumerating LocalMachine\Root.
+      - name: Valid repro - corporate root in LocalMachine\Root
+        shell: bash
+        run: |
+          node apps/installer/scripts/trust-repro.mjs \
+            --installer "apps/installer/dist/openwork-installer.exe" \
+            --certs "$RUNNER_TEMP/corporate-ca" \
+            --expect resolved
+
+      - name: Public HTTPS still verifies with the corporate root loaded
+        shell: bash
+        run: |
+          cd apps/installer
+          bun -e '
+            const { fetchWithSystemCa } = await import("./src/system-ca.ts")
+            const response = await fetchWithSystemCa("https://api.github.com/zen")
+            if (!response.ok) { console.error(`github.com -> ${response.status}`); process.exit(1) }
+            console.log(`github.com -> ${response.status}`)
+          '

--- a/apps/installer/scripts/make-corporate-ca.mjs
+++ b/apps/installer/scripts/make-corporate-ca.mjs
@@ -1,0 +1,50 @@
+// Builds the certificate chain an inspected enterprise network presents:
+// a corporate root, an intermediate that re-signs traffic, and a leaf for the
+// workspace host. Cross-platform so the same repro runs on Windows CI.
+//
+//   node scripts/make-corporate-ca.mjs --out <dir> [--host <name>]
+import { execFileSync } from "node:child_process";
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import path from "node:path";
+
+function arg(name, fallback = null) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+const out = arg("out");
+const host = arg("host", "workspace.corporate.test");
+if (!out) {
+  console.error("usage: make-corporate-ca.mjs --out <dir> [--host <name>]");
+  process.exit(2);
+}
+mkdirSync(out, { recursive: true });
+
+const openssl = (args, input) => execFileSync("openssl", args, { input, stdio: ["pipe", "pipe", "pipe"] });
+const file = (name) => path.join(out, name);
+
+writeFileSync(file("intermediate.ext"), "basicConstraints=critical,CA:TRUE,pathlen:0\nkeyUsage=critical,digitalSignature,cRLSign,keyCertSign\n");
+writeFileSync(
+  file("leaf.ext"),
+  `subjectAltName=DNS:${host},DNS:localhost,IP:127.0.0.1\nbasicConstraints=CA:FALSE\nkeyUsage=critical,digitalSignature,keyEncipherment\nextendedKeyUsage=serverAuth\n`,
+);
+
+openssl(["req", "-x509", "-newkey", "rsa:2048", "-nodes", "-sha256", "-days", "2",
+  "-keyout", file("root.key"), "-out", file("root.pem"),
+  "-subj", "/CN=Corporate Inspection Root CA/O=Corporate IT"]);
+
+openssl(["req", "-newkey", "rsa:2048", "-nodes", "-sha256",
+  "-keyout", file("intermediate.key"), "-out", file("intermediate.csr"),
+  "-subj", "/CN=Corporate TLS Inspection CA/O=Corporate IT"]);
+openssl(["x509", "-req", "-in", file("intermediate.csr"), "-CA", file("root.pem"), "-CAkey", file("root.key"),
+  "-CAcreateserial", "-out", file("intermediate.pem"), "-days", "2", "-sha256", "-extfile", file("intermediate.ext")]);
+
+openssl(["req", "-newkey", "rsa:2048", "-nodes", "-sha256",
+  "-keyout", file("leaf.key"), "-out", file("leaf.csr"), "-subj", `/CN=${host}/O=Corporate IT`]);
+openssl(["x509", "-req", "-in", file("leaf.csr"), "-CA", file("intermediate.pem"), "-CAkey", file("intermediate.key"),
+  "-CAcreateserial", "-out", file("leaf.pem"), "-days", "2", "-sha256", "-extfile", file("leaf.ext")]);
+
+// The server presents leaf + intermediate; the root stays out of the chain, so
+// only a client that already trusts the root can verify it.
+writeFileSync(file("chain.pem"), `${readFileSync(file("leaf.pem"), "utf8")}${readFileSync(file("intermediate.pem"), "utf8")}`);
+console.log(out);

--- a/apps/installer/scripts/trust-repro.mjs
+++ b/apps/installer/scripts/trust-repro.mjs
@@ -1,0 +1,118 @@
+// Drives the compiled installer's real /api/resolve-link route against a host
+// served with a corporate CA chain, the way an inspected enterprise network
+// presents it. Prints the outcome so CI can assert on it.
+//
+//   node scripts/trust-repro.mjs --installer <path> --certs <dir> [--expect resolved|tls-untrusted]
+//
+// Nothing in the chain is in Bun's bundled roots, so the installer resolves the
+// link only when it picks the corporate root up from an OS trust source.
+import { spawn } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { createServer } from "node:https";
+
+function arg(name, fallback = null) {
+  const index = process.argv.indexOf(`--${name}`);
+  return index === -1 ? fallback : process.argv[index + 1];
+}
+
+const installerPath = arg("installer");
+const certsDir = arg("certs");
+const expected = arg("expect");
+if (!installerPath || !certsDir) {
+  console.error("usage: trust-repro.mjs --installer <path> --certs <dir> [--expect resolved|tls-untrusted]");
+  process.exit(2);
+}
+
+const den = createServer(
+  { cert: readFileSync(`${certsDir}/chain.pem`), key: readFileSync(`${certsDir}/leaf.key`) },
+  (req, res) => {
+    const url = new URL(req.url, "https://workspace.invalid");
+    res.setHeader("content-type", "application/json");
+    if (url.pathname === "/v1/install-config") {
+      res.end(JSON.stringify({
+        appName: "Corporate Work",
+        clientName: "Corporate",
+        webUrl: "https://workspace.example.com",
+        apiUrl: "https://api.workspace.example.com",
+        requireSignin: true,
+        logoUrl: null,
+      }));
+      return;
+    }
+    if (url.pathname === "/v1/app-version") {
+      res.end(JSON.stringify({ latestAppVersion: "0.18.0" }));
+      return;
+    }
+    res.statusCode = 404;
+    res.end("{}");
+  },
+);
+
+const denPort = await new Promise((resolve) => {
+  den.listen(0, "127.0.0.1", () => resolve(den.address().port));
+});
+
+const installer = spawn(installerPath, [], {
+  env: { ...process.env, OPENWORK_INSTALLER_UI: "manual" },
+  stdio: ["ignore", "pipe", "pipe"],
+});
+
+let installerOutput = "";
+installer.stdout.setEncoding("utf8");
+installer.stderr.setEncoding("utf8");
+installer.stdout.on("data", (chunk) => { installerOutput += chunk; });
+installer.stderr.on("data", (chunk) => { installerOutput += chunk; });
+
+function shutdown(code) {
+  installer.kill();
+  den.close();
+  process.exit(code);
+}
+
+const uiUrl = await new Promise((resolve) => {
+  const deadline = Date.now() + 60_000;
+  const poll = setInterval(() => {
+    const match = installerOutput.match(/UI ready at (\S+)/);
+    if (match) {
+      clearInterval(poll);
+      resolve(match[1]);
+    } else if (Date.now() > deadline || installer.exitCode !== null) {
+      clearInterval(poll);
+      resolve(null);
+    }
+  }, 250);
+});
+
+if (!uiUrl) {
+  console.error("installer UI never became ready:");
+  console.error(installerOutput);
+  shutdown(2);
+}
+
+// The served page carries the API token, same as the real UI.
+const token = (await (await fetch(uiUrl)).text()).match(/[0-9a-f]{32}/)?.[0];
+if (!token) {
+  console.error("could not read the installer API token from the served page");
+  shutdown(2);
+}
+
+const response = await fetch(`${uiUrl}api/resolve-link`, {
+  method: "POST",
+  headers: { "content-type": "application/json", "x-installer-token": token },
+  body: JSON.stringify({ installLink: `https://localhost:${denPort}/v1/install-config?token=abcDEF12` }),
+});
+const body = await response.json();
+
+const outcome = response.ok ? "resolved" : body.error === "install_link_tls_untrusted" ? "tls-untrusted" : `other:${body.error}`;
+console.log(`outcome: ${outcome}`);
+if (body.message) console.log(`message: ${body.message}`);
+if (body.trustSources) console.log(`trustSources: ${body.trustSources}`);
+const diagnostics = installerOutput.match(/OS trust store: .*/g);
+if (diagnostics) console.log(`diagnostics: ${diagnostics.at(-1)}`);
+
+if (expected && outcome !== expected) {
+  console.error(`FAILED: expected ${expected}, got ${outcome}`);
+  shutdown(1);
+}
+console.log(expected ? `OK: ${outcome} as expected` : "done");
+shutdown(0);


### PR DESCRIPTION
Follow-up to #3087, which merged before these commits synced to it. #3087 changed the
installer's certificate handling but every claim on it was validated on **macOS only** —
the one platform where the bug it fixes cannot occur.

Bun's `tls.getCACertificates("system")` returns **0** certificates on macOS, so the
short-circuit #3087 removed (`if (nodeCerts.length > 0) return nodeCerts`) never
executed there. The macOS runs proved the `NODE_EXTRA_CA_CERTS` path end to end and the
union logic in unit tests, but never the actual enterprise failure, which needs a runtime
reporting a *partial* root list while the corporate CA sits in `LocalMachine\Root`.

This PR covers that on real Windows.

## What it adds

- **`apps/installer/scripts/make-corporate-ca.mjs`** — builds the chain an inspected
  network presents: corporate root → re-signing intermediate → leaf. The server serves
  leaf + intermediate and keeps the root out of the chain, so only a client that already
  trusts the root can verify it. Nothing in it is in Bun's bundled roots.
- **`apps/installer/scripts/trust-repro.mjs`** — starts that HTTPS host, launches the
  compiled binary in headless `OPENWORK_INSTALLER_UI=manual` mode, and drives its real
  `/api/resolve-link` route. Self-asserts via `--expect resolved|tls-untrusted` and echoes
  the per-source CA diagnostics.
- **`.github/workflows/ci-installer-windows-trust.yml`** — `windows-2022` job that runs the
  repro twice.

## The assertion that matters

1. **Fail repro** — corporate root in no trust store, expects `tls-untrusted`. Guards
   against the fix blanket-trusting anything.
2. `Import-Certificate -FilePath root.pem -CertStoreLocation Cert:\LocalMachine\Root`
3. **Valid repro** — expects `resolved`.

Between 1 and 3 the **only** variable is the Windows machine trust store: same binary,
same host, no environment variables. It can only pass if the installer actually
enumerates `LocalMachine\Root`, which is exactly what the short-circuit prevented.

The job also prints what each CA source contributed and re-checks public HTTPS, so a
regression that widens or narrows trust shows up as a diff in those counts.

## Verified locally

Against merged `dev`, on macOS (where this reduces to the env-var path):

```
fail repro:  outcome: tls-untrusted   OK: tls-untrusted as expected
             diagnostics: OS trust store: runtime=0 macos-keychains=165 NODE_EXTRA_CA_CERTS=0
valid repro: outcome: resolved        OK: resolved as expected
             diagnostics: OS trust store: runtime=0 macos-keychains=165 NODE_EXTRA_CA_CERTS=1
```

`pnpm --dir apps/installer test` → 44 pass, 0 fail.

## Still unproven until CI runs

I could not get the Windows job to execute — GitHub stopped syncing pushes to #3087 while
I was working (branch head advanced on the remote, PR head stayed put, no checks queued,
GitHub Status all-operational), which is also why #3087 merged without these commits.

**Do not treat the Windows path as validated until this job goes green.** If it fails, the
finding is real and belongs to #3087, not to this PR.

Made with [Cursor](https://cursor.com)