### PR TITLE
fix(app): stop leaking raw OS browser-open errors into the UI

### DIFF
--- a/apps/app/src/app/lib/desktop.ts
+++ b/apps/app/src/app/lib/desktop.ts
@@ -1,4 +1,5 @@
 import { nativeDeepLinkEvent } from "./deep-link-bridge";
+import { t } from "../../i18n";
 
 export type * from "./desktop-types";
 export type {
@@ -363,12 +364,32 @@ export async function desktopFetchAgentContextDiagnostics(
 // Convenience wrappers
 // ---------------------------------------------------------------------------
 
+const BROWSER_OPEN_NO_HANDLER_PATTERN = /\b0x800401f5\b/i;
+const BROWSER_OPEN_TIMEOUT_PATTERN = /\btimed out after \d+ms\b/i;
+
+function errorMessage(error: unknown): string {
+  if (error instanceof Error) return error.message;
+  if (typeof error === "string") return error;
+  return "";
+}
+
+export function normalizeBrowserOpenFailureMessage(error: unknown, forceBrowserOpenFailure = false): string {
+  const detail = errorMessage(error).trim();
+  const message = t("app.error_browser_open_failed_action");
+  if (detail.startsWith(message)) return detail;
+  if (forceBrowserOpenFailure || BROWSER_OPEN_NO_HANDLER_PATTERN.test(detail) || BROWSER_OPEN_TIMEOUT_PATTERN.test(detail)) {
+    if (!detail || detail === "Failed to open browser") return message;
+    return `${message} (${detail})`;
+  }
+  return detail || t("app.unknown_error");
+}
+
 export async function openDesktopUrl(url: string): Promise<void> {
   const openExternal = window.__OPENWORK_ELECTRON__?.shell?.openExternal;
   if (openExternal) {
     const result = await openExternal(url);
     if (result && result.ok === false) {
-      throw new Error(result.error ?? "Failed to open browser");
+      throw new Error(normalizeBrowserOpenFailureMessage(result.error, true));
     }
     return;
   }

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -7,6 +7,7 @@ export default {
   "app.compact_command_desc": "Summarize this session to reduce context size.",
   "app.error_audit_load": "Failed to load audit log.",
   "app.error_auth_failed": "Authentication failed",
+  "app.error_browser_open_failed_action": "Your operating system couldn't open a browser. Copy the link and open it in any browser instead.",
   "app.error_command_not_resolved": "Command was not resolved.",
   "app.error_compact_empty": "Nothing to compact yet.",
   "app.error_compact_no_session": "Select a session with messages before running /compact.",

--- a/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/mcp-auth-modal.tsx
@@ -12,7 +12,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import type { McpDirectoryInfo } from "@/app/constants";
-import { openDesktopUrl, opencodeMcpAuth } from "@/app/lib/desktop";
+import { normalizeBrowserOpenFailureMessage, openDesktopUrl, opencodeMcpAuth } from "@/app/lib/desktop";
 import { unwrap } from "@/app/lib/opencode";
 import { validateMcpServerName } from "@/app/mcp";
 import type { Client } from "@/app/types";
@@ -293,7 +293,7 @@ export function McpAuthModal(props: McpAuthModalProps) {
       await openAuthorizationUrl(auth.authorizationUrl);
       startStatusPolling(slug);
     } catch (err) {
-      const message = err instanceof Error ? err.message : t("mcp.auth.failed_to_start_oauth");
+      const message = err instanceof Error ? normalizeBrowserOpenFailureMessage(err) : t("mcp.auth.failed_to_start_oauth");
 
       if (isSlackMcpEntry(props.entry, slug) && isDynamicClientRegistrationError(message)) {
         setNeedsReload(false);

--- a/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
+++ b/apps/app/src/react-app/domains/connections/provider-auth/provider-auth-modal.tsx
@@ -23,7 +23,7 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import { toast } from "@/components/ui/sonner";
-import { openDesktopUrl } from "@/app/lib/desktop";
+import { normalizeBrowserOpenFailureMessage, openDesktopUrl } from "@/app/lib/desktop";
 import { isDesktopRuntime } from "@/app/utils";
 import { compareProviders } from "@/app/utils/providers";
 import { Button } from "@/components/ui/button";
@@ -500,7 +500,7 @@ export default function ProviderAuthModal(props: ProviderAuthModalProps) {
 
       setView("oauth-auto");
     } catch (error) {
-      const message = error instanceof Error ? error.message : "Failed to start OAuth";
+      const message = error instanceof Error ? normalizeBrowserOpenFailureMessage(error) : "Failed to start OAuth";
       setLocalError(message);
     }
   };

--- a/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
+++ b/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 
 import { createDenClient, readDenSettings, type DenExternalMcpConnection } from "@/app/lib/den";
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
-import { openDesktopUrl } from "@/app/lib/desktop";
+import { normalizeBrowserOpenFailureMessage, openDesktopUrl } from "@/app/lib/desktop";
 import { isDesktopRuntime } from "@/app/utils";
 import { connectionNeedsReconnect, isNativeProviderConnectionId } from "./native-provider-connections";
 
@@ -237,7 +237,7 @@ export function useOrgMcpConnections() {
       }, CONNECT_POLL_INTERVAL_MS);
     } catch (connectError) {
       if (!isActionScopeCurrent(pollScope)) return;
-      setError(connectError instanceof Error ? connectError.message : "Failed to start the connection.");
+      setError(connectError instanceof Error ? normalizeBrowserOpenFailureMessage(connectError) : "Failed to start the connection.");
       setConnectingId(null);
     }
   }, [isActionScopeCurrent, refresh, stopPolling]);

--- a/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/connect-view.tsx
@@ -4,7 +4,7 @@ import { ArrowUpRight, ChevronDown, ChevronRight } from "lucide-react";
 
 import type { DenExternalMcpConnection, DenOrgPlugin } from "@/app/lib/den";
 import { mintCloudControlMcpToken, readDenSettings } from "@/app/lib/den";
-import { openDesktopUrl } from "@/app/lib/desktop";
+import { normalizeBrowserOpenFailureMessage, openDesktopUrl } from "@/app/lib/desktop";
 import type {
   OpenworkCloudMcpEngineRefresh,
   OpenworkCloudMcpHealth,
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Separator } from "@/components/ui/separator";
 import { Skeleton } from "@/components/ui/skeleton";
+import { toast } from "@/components/ui/sonner";
 import { t } from "@/i18n";
 import { DenSignInSurface } from "@/react-app/domains/cloud/den-signin-surface";
 import { useDenAuth, type DenAuthStatus } from "@/react-app/domains/cloud/den-auth-provider";
@@ -115,13 +116,21 @@ function denManageConnectionsUrl() {
   return new URL("/dashboard/mcp-connections", readDenSettings().baseUrl).toString();
 }
 
+async function openDenManageConnections() {
+  try {
+    await openDesktopUrl(denManageConnectionsUrl());
+  } catch (error) {
+    toast.error(normalizeBrowserOpenFailureMessage(error));
+  }
+}
+
 function ManageInDenButton() {
   return (
     <Button
       variant="outline"
       size="sm"
       className="w-fit"
-      onClick={() => void openDesktopUrl(denManageConnectionsUrl())}
+      onClick={() => void openDenManageConnections()}
     >
       {t("connect.manage_in_den_web")}
       <ArrowUpRight size={13} />
@@ -761,7 +770,7 @@ function ConnectOrganizationRow(props: {
             {t("connect.group_needs_admin_setup")}
           </span>
         ) : (
-          <Button size="sm" variant="outline" onClick={() => void openDesktopUrl(denManageConnectionsUrl())} title={setupNames.join(t("connect.row_meta_list_separator"))}>
+          <Button size="sm" variant="outline" onClick={() => void openDenManageConnections()} title={setupNames.join(t("connect.row_meta_list_separator"))}>
             {t("connect.row_action_set_up_connection")}
           </Button>
         )

--- a/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
+++ b/apps/app/src/react-app/domains/settings/state/debug-view-model.ts
@@ -9,6 +9,7 @@ import {
   debugDesktopBootstrapConfig,
   nukeOpenworkAndOpencodeConfigPreview,
   nukeOpenworkAndOpencodeConfigAndExit,
+  normalizeBrowserOpenFailureMessage,
   openDesktopUrl,
   openworkServerInfo as openworkServerInfoCmd,
   openworkServerRestart as openworkServerRestartCmd,
@@ -539,7 +540,7 @@ export function useDebugViewModel(options: UseDebugViewModelOptions) {
       await openDesktopUrl(ELECTRON_ALPHA_RELEASE_PAGE_URL);
       setElectronMigrationStatus("Opened the rolling Electron alpha release. Download links live there after dev builds finish.");
     } catch (error) {
-      setElectronMigrationStatus(error instanceof Error ? error.message : safeStringify(error));
+      setElectronMigrationStatus(error instanceof Error ? normalizeBrowserOpenFailureMessage(error) : safeStringify(error));
     }
   }, []);
 

--- a/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
+++ b/apps/app/src/react-app/shell/architecture-mismatch-gate.tsx
@@ -1,7 +1,9 @@
 /** @jsxImportSource react */
 import { useCallback, useEffect, useReducer, type ReactNode } from "react";
 
+import { normalizeBrowserOpenFailureMessage, openDesktopUrl } from "../../app/lib/desktop";
 import { isDesktopRuntime } from "../../app/utils";
+import { toast } from "@/components/ui/sonner";
 import { useBootState } from "./boot-state";
 
 type ArchitectureInfo = {
@@ -83,16 +85,24 @@ export function ArchitectureMismatchGate({ children }: ArchitectureMismatchGateP
     if (info?.mismatch) markRouteReady();
   }, [info?.mismatch, markRouteReady]);
 
+  const openUrl = useCallback(async (url: string) => {
+    try {
+      await openDesktopUrl(url);
+    } catch (error) {
+      toast.error(normalizeBrowserOpenFailureMessage(error));
+    }
+  }, []);
+
   const openDownload = useCallback(() => {
     const url = info?.downloadUrl || info?.releaseUrl;
     if (!url) return;
-    void window.__OPENWORK_ELECTRON__?.shell?.openExternal?.(url);
-  }, [info?.downloadUrl, info?.releaseUrl]);
+    void openUrl(url);
+  }, [info?.downloadUrl, info?.releaseUrl, openUrl]);
 
   const openRelease = useCallback(() => {
     if (!info?.releaseUrl) return;
-    void window.__OPENWORK_ELECTRON__?.shell?.openExternal?.(info.releaseUrl);
-  }, [info?.releaseUrl]);
+    void openUrl(info.releaseUrl);
+  }, [info?.releaseUrl, openUrl]);
 
   if (!checked) return null;
   if (!info?.mismatch) return <>{children}</>;

--- a/apps/app/tests/desktop-url.test.ts
+++ b/apps/app/tests/desktop-url.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from "bun:test";
+
+import { normalizeBrowserOpenFailureMessage } from "../src/app/lib/desktop";
+import { t } from "../src/i18n";
+
+const friendly = t("app.error_browser_open_failed_action");
+
+describe("normalizeBrowserOpenFailureMessage", () => {
+  test("maps Windows no-handler HRESULT failures to browser copy fallback", () => {
+    const detail = "Failed to open: Aplicativo não encontrado (0x800401F5)";
+    const message = normalizeBrowserOpenFailureMessage(detail);
+
+    expect(message).toContain(friendly);
+    expect(message).toContain(detail);
+  });
+
+  test("maps localized no-handler failures by HRESULT without English text", () => {
+    const detail = "Aplicativo não encontrado (0x800401F5)";
+    const message = normalizeBrowserOpenFailureMessage(detail);
+
+    expect(message).toContain(friendly);
+    expect(message).toContain(detail);
+  });
+
+  test("maps openExternal timeouts and keeps diagnostics", () => {
+    const detail = "timed out after 4000ms";
+    const message = normalizeBrowserOpenFailureMessage(detail);
+
+    expect(message).toContain(friendly);
+    expect(message).toContain(detail);
+  });
+
+  test("maps forced openExternal failures and keeps diagnostics", () => {
+    const detail = "simulated failure";
+    const message = normalizeBrowserOpenFailureMessage(detail, true);
+
+    expect(message).toContain(friendly);
+    expect(message).toContain(detail);
+  });
+});


### PR DESCRIPTION
## What
A Windows user (Bruno, Jun 23 OpenWork feedback) reported this rendered verbatim in the UI:

`Error invoking remote method 'openwork:shell:openExternal': Error: Failed to open: Aplicativo não encontrado (0x800401F5)`

The main-process side was already fixed in adf54b57a (`open-external.mjs`, try/catch + timeout + `rundll32` fallback). Two problems remained on the renderer side:

1. `openDesktopUrl` (`desktop.ts:371`) rethrew `result.error` **verbatim**, and that raw OS string was rendered untranslated in 4 places: provider-auth modal, MCP-auth modal, org MCP connections, and the debug migration status.
2. Several call sites `void`ed the promise, so a failure produced an unhandled rejection and **zero** feedback — the button looked dead (`architecture-mismatch-gate.tsx:89,94` discarded the `{ok:false}` result entirely; `connect-view.tsx:124,764`).

## How
- `normalizeBrowserOpenFailureMessage()` in `desktop.ts` maps the failure to actionable copy. Matches on the **locale-independent HRESULT** `0x800401F5` (the reporter's message was Portuguese, so English text matching would not work) plus the `timed out after Nms` case `open-external.mjs` can emit.
- The original diagnostic is **preserved in parentheses** so support can still debug — it is not thrown away.
- Applied at the 4 render sites; the silent call sites now surface a toast.

## Tradeoff
`openDesktopUrl` passes `forceBrowserOpenFailure = true`, so any `openExternal` failure gets the friendly copy. That is intentional: at that call site the context is known to be browser-opening.

## Tests run
```
$ pnpm --filter @openwork/app exec bun test tests/desktop-url.test.ts
 4 pass  0 fail  8 expect() calls

$ node --test apps/desktop/electron/open-external.test.mjs
ℹ tests 5   ℹ pass 5   ℹ fail 0

$ pnpm --filter @openwork/app typecheck
$ tsc -p tsconfig.json --noEmit   (exit 0)
```
New unit coverage asserts the HRESULT case, a localized variant, the timeout case, and that the diagnostic is not swallowed.

## Not done
No fraimz/CDP run. The existing `evals/flows/signin-browser-open-fallback.flow.mjs` covers the **sign-in** copy-link path, which already had good handling via `open-browser-auth.ts` — it does not exercise the modal surfaces this PR changes. `OPENWORK_SIMULATE_OPEN_EXTERNAL_FAILURE=1` makes the change observable if a reviewer wants to drive it manually.