### PR TITLE
fix(app): reveal the full skill description on hover

### DIFF
--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
 import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import type { ExtensionKind } from "../../app/constants";
 import type { EnablementResult } from "../../app/extensions";
 import { t } from "../../i18n";
@@ -172,7 +173,10 @@ export function ExtensionCard(props: ExtensionCardProps) {
               </span>
             ) : null}
           </div>
-          <p className="mt-0.5 line-clamp-2 text-xs text-dls-secondary">{description}</p>
+          <Tooltip>
+            <TooltipTrigger render={<p className="mt-0.5 line-clamp-2 text-xs text-dls-secondary">{description}</p>} />
+            <TooltipContent>{description}</TooltipContent>
+          </Tooltip>
           {disabledReason ? (
             <div className="mt-2 text-[11px] font-medium text-amber-11">
               {disabledReason}


### PR DESCRIPTION
## What
Reported via OpenWork feedback (fangrenzsf-creator, Jun 14, v0.16.2, Windows), in Chinese: Skills list descriptions are unreadable when long.

## Investigation — the reported symptom was NOT reproducible
The user said the text *does not wrap* and forces a *horizontal scrollbar*. That is **not** what the code does:
- `extension-card.tsx:175` uses `line-clamp-2` — the text **wraps**, then clips at 2 lines. No `whitespace-nowrap`, no `truncate`, no `overflow-x` scroller, and the grid tracks are `minmax(0,1fr)` so content cannot widen a track.
- The page the user actually saw at v0.16.2 (`settings/pages/skills-view.tsx`) is **dead code** on `dev` — unreferenced since 820d00ad3. Its skill *name* had `truncate` without `min-w-0`, which is the real source of their horizontal scrollbar, but that file no longer ships. The live card already has `min-w-0 break-words`.

## The genuine remaining gap
Clipped text had **no `title` and no tooltip**, so the full description was unreachable from the list — it existed only in the detail modal. That matches the user's own suggestion #3.

## How
Wrap the clipped `<p>` in the existing `Tooltip` primitive (`components/ui/tooltip.tsx`, Base UI). `TooltipProvider` is already mounted app-wide at `index.react.tsx:43`. `TooltipContent` already has `max-w-xs`. 5 insertions, 1 deletion.

## Tradeoff (please weigh in)
The tooltip is **unconditional** — it shows even when the description is short enough not to clip, duplicating visible text. Detecting actual clipping needs DOM measurement, which is disproportionate here. Skill descriptions are characteristically long (they are LLM-facing trigger text, which is why this was reported at all), so in practice it nearly always adds information. Happy to gate it on a measured overflow check if you'd rather.

## Tests run
```
$ pnpm --filter @openwork/app typecheck
$ tsc -p tsconfig.json --noEmit   (exit 0)

$ pnpm --filter @openwork/app exec bun test tests/openwork-connect-beta-badge.test.tsx
 1 pass  0 fail   (only existing test touching extension-card)

$ git diff --stat
 1 file changed, 5 insertions(+), 1 deletion(-)
```

## Not done
No fraimz/CDP run.