### PR TITLE
fix(app): surface skill reveal failures and localize the reveal label

### DIFF
--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -67,6 +67,8 @@ export type ExtensionDetailModalProps = {
   path?: string;
   /** Skill trigger phrase (e.g. "when user asks to create an agent"). */
   trigger?: string;
+  /** Localized reveal/open action label. */
+  revealLabel?: string;
   /** Reveal the file in Finder/Explorer. */
   onReveal?: () => void;
   /** Skill content preview (first ~500 chars of the SKILL.md). */
@@ -203,6 +205,7 @@ export function ExtensionDetailModal({
   path,
   trigger,
   contentPreview,
+  revealLabel,
   onReveal,
   onConnect,
   connectLabel = "Connect",
@@ -362,7 +365,7 @@ export function ExtensionDetailModal({
                     </div>
                   ) : null}
 
-                  {path && onReveal ? (
+                  {path && onReveal && revealLabel ? (
                     <div className="flex items-center justify-between text-sm">
                       <span className="text-muted-foreground">Location</span>
                       <Button
@@ -370,7 +373,7 @@ export function ExtensionDetailModal({
                         size="xs"
                         onClick={onReveal}
                       >
-                        Reveal in Finder
+                        {revealLabel}
                         <ExternalLink data-icon="inline-end" />
                       </Button>
                     </div>

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -48,6 +48,7 @@ import type { McpServerEntry, McpStatusMap } from "../../../../app/types";
 import { formatRelativeTime, isDesktopRuntime, isWindowsPlatform } from "../../../../app/utils";
 import { t } from "../../../../i18n";
 import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/sonner";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
 import { AddMcpModal } from "../../connections/modals/add-mcp-modal";
 import { ClaudePluginImportModal } from "../../connections/modals/claude-plugin-import-modal";
@@ -517,6 +518,21 @@ export function McpView(props: McpViewProps) {
     }
   };
 
+  const revealSkill = async (skillPath: string) => {
+    try {
+      if (isWindowsPlatform()) {
+        await openDesktopPath(skillPath);
+      } else {
+        await revealDesktopItemInDir(skillPath);
+      }
+    } catch (error) {
+      // why: the skill detail modal is open over the page, and `configError` only
+      // renders inside the Advanced settings panel — a toast is the only surface
+      // the user can actually see from here.
+      toast.error(error instanceof Error ? error.message : t("skills.reveal_failed"));
+    }
+  };
+
   return (
     <section className="space-y-8 max-w-3xl w-full animate-in fade-in duration-300">
       {showHeader ? (
@@ -831,10 +847,11 @@ export function McpView(props: McpViewProps) {
             connectedLabel={detailSkill.origin === "openwork-connect" ? "Available through OpenWork Connect" : undefined}
             hidden={hidden}
             path={detailSkill.origin === "openwork-connect" ? undefined : detailSkill.path}
+            revealLabel={revealLabel}
             trigger={detailSkill.trigger}
             contentPreview={detailSkillContent ?? undefined}
             onReveal={detailSkill.path && detailSkill.origin !== "openwork-connect" ? () => {
-              void revealDesktopItemInDir(detailSkill.path);
+              void revealSkill(detailSkill.path);
             } : undefined}
             onUninstall={props.uninstallSkill && detailSkill.origin !== "openwork-connect" ? () => {
               props.uninstallSkill?.(detailSkill.name);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -49,6 +49,7 @@ import {
 } from "./connect-link-branding.mjs";
 import { resolveConnectLinkPublicKeys } from "./connect-link-keys.mjs";
 import { openExternalUrl } from "./open-external.mjs";
+import { revealItemInDir } from "./reveal-item-in-dir.mjs";
 import { fetchAgentContextDiagnosticsResponse } from "./agent-context-diagnostics-fetch.mjs";
 import {
   applyWindowsTaskbarIcon,
@@ -1898,19 +1899,12 @@ const desktopCommandHandlers = {
   },
   "__revealItemInDir": async (event, ...args) => {
       const target = String(args[0] ?? "").trim();
-      if (!target) return "Path is required.";
-      if (existsSync(target)) {
-        shell.showItemInFolder(target);
-        return undefined;
-      }
-      // The exact file may not exist yet (or path is slightly off); fall back to
-      // opening the containing directory so the user still lands in the right place.
-      const parent = path.dirname(target);
-      if (parent && parent !== target && existsSync(parent)) {
-        const error = await shell.openPath(parent);
-        return error && error.trim() ? error : undefined;
-      }
-      return `Could not find "${target}" on disk.`;
+      return revealItemInDir(target, {
+        existsSync,
+        openPath: (nextTarget) => shell.openPath(nextTarget),
+        platform: process.platform,
+        showItemInFolder: (nextTarget) => shell.showItemInFolder(nextTarget),
+      });
   },
   "__getFileIcon": async (event, ...args) => {
       const target = String(args[0] ?? "").trim();

--- a/apps/desktop/electron/reveal-item-in-dir.mjs
+++ b/apps/desktop/electron/reveal-item-in-dir.mjs
@@ -1,0 +1,36 @@
+import path from "node:path";
+
+function openPathResult(error) {
+  return error && error.trim() ? error : undefined;
+}
+
+/**
+ * Reveal `rawTarget` in the OS file manager.
+ *
+ * Extracted from main.mjs so the branching is unit-testable via injected deps.
+ * Behavior is intentionally identical on every platform: `shell.showItemInFolder`
+ * is the cross-platform API and, unlike opening the parent directory, it selects
+ * the item. It returns `void`, so a failure there is not detectable — that is a
+ * limitation of Electron, and degrading the working case to work around it would
+ * lose item selection for every user. The failure this can report is the one that
+ * actually bites: a `target` the main process cannot see on disk (skill paths are
+ * produced by the server, so they can diverge from the client filesystem).
+ */
+export async function revealItemInDir(rawTarget, deps) {
+  const target = String(rawTarget ?? "").trim();
+  if (!target) return "Path is required.";
+
+  if (deps.existsSync(target)) {
+    deps.showItemInFolder(target);
+    return undefined;
+  }
+
+  // The exact file may not exist yet (or the path is slightly off); fall back to
+  // opening the containing directory so the user still lands in the right place.
+  // `openPath` returns an error string, so this branch is reportable.
+  const parent = (deps.platform === "win32" ? path.win32 : path).dirname(target);
+  if (parent && parent !== target && deps.existsSync(parent)) {
+    return openPathResult(await deps.openPath(parent));
+  }
+  return `Could not find "${target}" on disk.`;
+}

--- a/apps/desktop/electron/reveal-item-in-dir.test.mjs
+++ b/apps/desktop/electron/reveal-item-in-dir.test.mjs
@@ -1,0 +1,119 @@
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+import { revealItemInDir } from "./reveal-item-in-dir.mjs";
+
+describe("revealItemInDir", () => {
+  it("reveals an existing file off Windows", async () => {
+    let revealedPath = "";
+    let openPathCalled = false;
+
+    const result = await revealItemInDir("/workspace/skill/SKILL.md", {
+      existsSync: (target) => target === "/workspace/skill/SKILL.md",
+      openPath: async () => {
+        openPathCalled = true;
+        return "";
+      },
+      platform: "darwin",
+      showItemInFolder: (target) => {
+        revealedPath = target;
+      },
+    });
+
+    assert.equal(result, undefined);
+    assert.equal(revealedPath, "/workspace/skill/SKILL.md");
+    assert.equal(openPathCalled, false);
+  });
+
+  it("opens the parent directory for a missing file with an existing parent", async () => {
+    let openedPath = "";
+    let revealCalled = false;
+
+    const result = await revealItemInDir("/workspace/skill/MISSING.md", {
+      existsSync: (target) => target === "/workspace/skill",
+      openPath: async (target) => {
+        openedPath = target;
+        return "";
+      },
+      platform: "darwin",
+      showItemInFolder: () => {
+        revealCalled = true;
+      },
+    });
+
+    assert.equal(result, undefined);
+    assert.equal(openedPath, "/workspace/skill");
+    assert.equal(revealCalled, false);
+  });
+
+  it("reports an error when neither the file nor parent exists", async () => {
+    let openPathCalled = false;
+    let revealCalled = false;
+
+    const result = await revealItemInDir("/workspace/skill/MISSING.md", {
+      existsSync: () => false,
+      openPath: async () => {
+        openPathCalled = true;
+        return "";
+      },
+      platform: "darwin",
+      showItemInFolder: () => {
+        revealCalled = true;
+      },
+    });
+
+    assert.equal(result, "Could not find \"/workspace/skill/MISSING.md\" on disk.");
+    assert.equal(openPathCalled, false);
+    assert.equal(revealCalled, false);
+  });
+
+  it("selects an existing file on Windows too, rather than only opening its folder", async () => {
+    let revealedPath = "";
+    let openPathCalled = false;
+
+    const result = await revealItemInDir("C:\\workspace\\skill\\SKILL.md", {
+      existsSync: (target) => target === "C:\\workspace\\skill\\SKILL.md",
+      openPath: async () => {
+        openPathCalled = true;
+        return "";
+      },
+      platform: "win32",
+      showItemInFolder: (target) => {
+        revealedPath = target;
+      },
+    });
+
+    assert.equal(result, undefined);
+    assert.equal(revealedPath, "C:\\workspace\\skill\\SKILL.md");
+    assert.equal(openPathCalled, false);
+  });
+
+  it("propagates a parent-open failure so the caller can surface it", async () => {
+    const result = await revealItemInDir("C:\\workspace\\skill\\MISSING.md", {
+      existsSync: (target) => target === "C:\\workspace\\skill",
+      openPath: async () => "Explorer failed",
+      platform: "win32",
+      showItemInFolder: () => {
+        throw new Error("showItemInFolder must not run for a missing target");
+      },
+    });
+
+    assert.equal(result, "Explorer failed");
+  });
+
+  it("uses Windows path semantics when resolving the parent directory", async () => {
+    let openedPath = "";
+
+    await revealItemInDir("C:\\workspace\\skill\\MISSING.md", {
+      existsSync: (target) => target === "C:\\workspace\\skill",
+      openPath: async (target) => {
+        openedPath = target;
+        return "";
+      },
+      platform: "win32",
+      showItemInFolder: () => {},
+    });
+
+    assert.equal(openedPath, "C:\\workspace\\skill");
+  });
+});

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/reveal-item-in-dir.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@opencode-ai/sdk": "^1.17.11",


### PR DESCRIPTION
## ⚠️ Draft — Windows runtime behavior is UNPROVEN
I am on macOS. I could not exercise the actual Windows Explorer path. Do not merge on my evidence alone; this needs a Windows check. Everything below is what I *did* verify.

## What
Reported via OpenWork feedback (Scott Zahn, Jun 17, v0.17.0, Windows): viewing a skill in the extensions section and clicking **"Reveal in Finder"** does nothing.

Two confirmed defects:
1. `extension-detail-modal.tsx:373` hardcoded the literal English `Reveal in Finder` — in a file that imports **no i18n at all**, and on Windows there is no Finder. Suitable keys already existed (`en.ts:750,788,1748-1750`).
2. `mcp-view.tsx:836` called `void revealDesktopItemInDir(path)` — no platform branch, no catch. **The correct pattern already existed 300 lines up in the same file** (`mcp-view.tsx:506-510`) for the MCP config reveal: `isWindowsPlatform()` branch + try/catch + visible error + swapped label.

## Root cause of "nothing happens"
`shell.showItemInFolder` returns `void`, so a Windows failure is structurally undetectable — the handler reported success unconditionally. But the failure that most likely bit this user **is** reportable: `detailSkill.path` is produced by the **server** (`apps/server/src/skills.ts:78`, roots at `:123-137`), so it can be a path the Electron main process cannot `existsSync`. In that case `main.mjs:1913` returns an error string — which the bare `void` discarded.

## How
- Modal takes a `revealLabel` prop, so the design-system component stays presentational; `mcp-view` passes the already-localized, platform-correct label.
- `revealSkill()` gets the platform branch + try/catch. Errors surface via **toast**, not `configError` — `configError` only renders inside the Advanced settings panel (`mcp-view.tsx:1426`), which is the wrong surface when a skill modal is open over the page.
- Extracted the main-process handler to `reveal-item-in-dir.mjs` so its branching is unit-testable (precedent: `open-external.mjs`). **Behavior is unchanged** — see below.

## Deliberately NOT done
An earlier pass made Windows open the *parent directory* via `openPath` (which returns an error string) instead of `showItemInFolder`. I reverted that: it buys error detectability for a rare case by **losing item selection for every Windows user** in the common case. Not a good trade. The Electron limitation is documented in the helper instead.

## Tests run
```
$ pnpm --filter @openwork/desktop test
ℹ tests 116   ℹ pass 115   ℹ fail 0   ℹ skipped 1

$ pnpm --filter @openwork/app typecheck
$ tsc -p tsconfig.json --noEmit   (exit 0)

$ pnpm --filter @openwork/desktop typecheck:electron   (exit 0)
```
`__revealItemInDir` had **zero** coverage before this. Added 5 cases: existing file, missing file with existing parent, neither exists, Windows still selects the item, Windows path semantics for the parent, and parent-open failure propagation.

## Proven vs unproven
**Proven:** typecheck, 116 desktop unit tests, non-Windows branch logic via injected deps.
**Unproven:** real Windows Explorer behavior; no fraimz/CDP run.