### PR TITLE
fix(composer): align the new-task composer with the cards below it

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -220,6 +220,8 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       isRemoteWorkspace={context?.isRemoteWorkspace ?? false}
       isSandboxWorkspace={context?.isSandboxWorkspace ?? false}
       onUploadInboxFiles={null}
+      // The hero owns its own page padding, so the composer must fill the hero column and line up with the suggestion cards.
+      flush
       draftScopeKey={`new-task:${workspaceId ?? "chat-first"}`}
     />
   );

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -113,6 +113,8 @@ type ComposerProps = {
   onUploadInboxFiles?: ((files: File[]) => void | Promise<unknown>) | null;
   draftScopeKey?: string;
   compactTopSpacing?: boolean;
+  /** Render inline in a page (new-task hero): no sticky dock chrome or inner max-width, aligning with sibling content. */
+  flush?: boolean;
   topAccessory?: ReactNode;
 };
 
@@ -1201,7 +1203,7 @@ export function ReactSessionComposer(props: ComposerProps) {
   return (
     <div
       ref={rootRef}
-      className={`sticky bottom-0 ${toolMenuOpen ? "z-50" : "z-20"} bg-gradient-to-t from-dls-surface via-dls-surface/95 to-transparent px-4 pb-2 md:px-8 ${props.compactTopSpacing ? "pt-0" : "pt-1"}`}
+      className={props.flush ? `relative ${toolMenuOpen ? "z-50" : "z-20"}` : `sticky bottom-0 ${toolMenuOpen ? "z-50" : "z-20"} bg-gradient-to-t from-dls-surface via-dls-surface/95 to-transparent px-4 pb-2 md:px-8 ${props.compactTopSpacing ? "pt-0" : "pt-1"}`}
       style={{ contain: "layout style" }}
       onKeyDownCapture={handleKeyDownCapture}
       onCompositionStart={() => {
@@ -1211,7 +1213,7 @@ export function ReactSessionComposer(props: ComposerProps) {
         imeComposingRef.current = false;
       }}
     >
-      <div className="max-w-[800px] mx-auto">
+      <div className={props.flush ? "" : "max-w-[800px] mx-auto"}>
         {/* Main composer panel */}
         <div
           className={`relative overflow-visible rounded-[18px] border border-dls-border bg-dls-surface transition-all ${panelRoundedClass}`}

--- a/evals/flows/hero-composer-alignment.flow.ts
+++ b/evals/flows/hero-composer-alignment.flow.ts
@@ -5,282 +5,69 @@ const FLOW_ID = "hero-composer-alignment";
 const vo = await loadVoiceoverParagraphs(FLOW_ID);
 if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
 
-type HeroAlignmentMetrics = {
-  panelLeft: number;
-  panelRight: number;
-  panelWidth: number;
-  gridLeft: number;
-  gridRight: number;
-  gridWidth: number;
-  firstCardLeft: number;
-  widestCardRight: number;
-  cardsLength: number;
-  rootPosition: string;
-};
-
-type DockedComposerMetrics = {
-  rootLeft: number;
-  rootRight: number;
-  rootWidth: number;
-  innerLeft: number;
-  innerRight: number;
-  innerWidth: number;
-  panelLeft: number;
-  panelRight: number;
-  panelWidth: number;
-  leftInset: number;
-  rightInset: number;
-  centerDelta: number;
-  rootPosition: string;
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
+async function num(ctx: FlowContext, expr: string): Promise<number> {
+  const value = await ctx.eval(expr);
+  ctx.assert(typeof value === "number" && Number.isFinite(value), `Expected a number from ${expr}, got ${JSON.stringify(value)}`);
+  return typeof value === "number" ? value : Number.NaN;
 }
 
-function numberProperty(record: Record<string, unknown>, key: string): number | null {
-  const value = Reflect.get(record, key);
-  return typeof value === "number" && Number.isFinite(value) ? value : null;
+async function text(ctx: FlowContext, expr: string): Promise<string> {
+  const value = await ctx.eval(expr);
+  ctx.assert(typeof value === "string", `Expected a string from ${expr}, got ${JSON.stringify(value)}`);
+  return typeof value === "string" ? value : "";
 }
 
-function stringProperty(record: Record<string, unknown>, key: string): string | null {
-  const value = Reflect.get(record, key);
-  return typeof value === "string" ? value : null;
+async function measure(ctx: FlowContext, expr: string, label: string): Promise<void> {
+  const value = await ctx.eval(expr);
+  ctx.assert(value === true, `${label}: ${JSON.stringify(value)}.`);
 }
-
-function heroAlignmentMetrics(value: unknown): HeroAlignmentMetrics | null {
-  if (!isRecord(value)) return null;
-  const panelLeft = numberProperty(value, "panelLeft");
-  const panelRight = numberProperty(value, "panelRight");
-  const panelWidth = numberProperty(value, "panelWidth");
-  const gridLeft = numberProperty(value, "gridLeft");
-  const gridRight = numberProperty(value, "gridRight");
-  const gridWidth = numberProperty(value, "gridWidth");
-  const firstCardLeft = numberProperty(value, "firstCardLeft");
-  const widestCardRight = numberProperty(value, "widestCardRight");
-  const cardsLength = numberProperty(value, "cardsLength");
-  const rootPosition = stringProperty(value, "rootPosition");
-  if (
-    panelLeft === null ||
-    panelRight === null ||
-    panelWidth === null ||
-    gridLeft === null ||
-    gridRight === null ||
-    gridWidth === null ||
-    firstCardLeft === null ||
-    widestCardRight === null ||
-    cardsLength === null ||
-    rootPosition === null
-  ) {
-    return null;
-  }
-  return {
-    panelLeft,
-    panelRight,
-    panelWidth,
-    gridLeft,
-    gridRight,
-    gridWidth,
-    firstCardLeft,
-    widestCardRight,
-    cardsLength,
-    rootPosition,
-  };
-}
-
-function dockedComposerMetrics(value: unknown): DockedComposerMetrics | null {
-  if (!isRecord(value)) return null;
-  const rootLeft = numberProperty(value, "rootLeft");
-  const rootRight = numberProperty(value, "rootRight");
-  const rootWidth = numberProperty(value, "rootWidth");
-  const innerLeft = numberProperty(value, "innerLeft");
-  const innerRight = numberProperty(value, "innerRight");
-  const innerWidth = numberProperty(value, "innerWidth");
-  const panelLeft = numberProperty(value, "panelLeft");
-  const panelRight = numberProperty(value, "panelRight");
-  const panelWidth = numberProperty(value, "panelWidth");
-  const leftInset = numberProperty(value, "leftInset");
-  const rightInset = numberProperty(value, "rightInset");
-  const centerDelta = numberProperty(value, "centerDelta");
-  const rootPosition = stringProperty(value, "rootPosition");
-  if (
-    rootLeft === null ||
-    rootRight === null ||
-    rootWidth === null ||
-    innerLeft === null ||
-    innerRight === null ||
-    innerWidth === null ||
-    panelLeft === null ||
-    panelRight === null ||
-    panelWidth === null ||
-    leftInset === null ||
-    rightInset === null ||
-    centerDelta === null ||
-    rootPosition === null
-  ) {
-    return null;
-  }
-  return {
-    rootLeft,
-    rootRight,
-    rootWidth,
-    innerLeft,
-    innerRight,
-    innerWidth,
-    panelLeft,
-    panelRight,
-    panelWidth,
-    leftInset,
-    rightInset,
-    centerDelta,
-    rootPosition,
-  };
-}
-
-function formatHeroMetrics(metrics: HeroAlignmentMetrics): string {
-  return JSON.stringify(metrics);
-}
-
-function formatDockedMetrics(metrics: DockedComposerMetrics): string {
-  return JSON.stringify(metrics);
-}
-
-const WAIT_FOR_CREATE_TASK_READY = `(() => {
-  const control = window.__openworkControl;
-  if (!control) return null;
-  const route = String(control.snapshot().route || "");
-  if (route.startsWith("/welcome") || route.startsWith("/signin")) {
-    return "Profile is on welcome/sign-in; hero composer alignment requires an onboarded workspace.";
-  }
-  const action = control.listActions().find((candidate) => candidate.id === "session.create_task");
-  if (action && !action.disabled) {
-    delete window.__heroComposerCreateTaskUnavailableSince;
-    return "ready";
-  }
-  const text = document.body.innerText || "";
-  let reason = "";
-  if (!action && text.trim().length > 40) {
-    reason = "session.create_task control action is not registered; cannot prove the docked composer handoff.";
-  } else if (action && action.disabled && (
-    text.includes("What do you need done?") ||
-    text.includes("Connect a model provider") ||
-    text.includes("OpenCode unavailable") ||
-    text.includes("Remote workspace unavailable")
-  )) {
-    reason = "session.create_task control action is disabled; cannot create a session for the docked composer check.";
-  }
-  if (!reason) return null;
-  const key = "__heroComposerCreateTaskUnavailableSince";
-  if (!window[key]) window[key] = Date.now();
-  return Date.now() - window[key] > 2000 ? reason : null;
-})()`;
-
-const INSPECT_CREATE_TASK_READY = `(() => {
-  const control = window.__openworkControl;
-  if (!control) return "OpenWork control API is unavailable.";
-  const route = String(control.snapshot().route || "");
-  if (route.startsWith("/welcome") || route.startsWith("/signin")) {
-    return "Profile is on welcome/sign-in; hero composer alignment requires an onboarded workspace.";
-  }
-  const action = control.listActions().find((candidate) => candidate.id === "session.create_task");
-  if (action && !action.disabled) return "ready";
-  if (!action) return "session.create_task control action is not registered; cannot prove the docked composer handoff.";
-  return "session.create_task control action is disabled; cannot create a session for the docked composer check.";
-})()`;
 
 async function createTaskPrecondition(ctx: FlowContext): Promise<string | null> {
-  await ctx.waitFor("Boolean(window.__openworkControl)", {
-    timeoutMs: 60_000,
-    label: "control API",
-  });
-  try {
-    const state = await ctx.waitFor(WAIT_FOR_CREATE_TASK_READY, {
-      timeoutMs: 30_000,
-      label: "session.create_task ready or unavailable",
-    });
-    return state === "ready"
-      ? null
-      : typeof state === "string"
-        ? state
-        : "session.create_task is unavailable; cannot prove the docked composer handoff.";
-  } catch {
-    const state = await ctx.eval(INSPECT_CREATE_TASK_READY);
-    return state === "ready"
-      ? null
-      : typeof state === "string"
-        ? state
-        : "session.create_task is unavailable; cannot prove the docked composer handoff.";
-  }
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+  const state = await ctx.waitFor(`(() => {
+    const control = window.__openworkControl;
+    const route = String(control.snapshot().route || "");
+    if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+    const action = control.listActions().find((candidate) => candidate.id === "session.create_task");
+    return action && !action.disabled ? "ready" : null;
+  })()`, { timeoutMs: 30_000, label: "session.create_task enabled or welcome/signin" });
+  return state === "blocked"
+    ? "Profile is on welcome/sign-in; hero composer alignment requires an onboarded workspace."
+    : null;
 }
 
 const EMPTY_TASK_ROUTE_FROM_SESSION = `(() => {
   const route = String(window.__openworkControl.snapshot().route || "");
-  if (!route.includes("/session/")) return "";
-  const workspaceMatch = route.match(/^\/workspace\/([^/]+)\/session\/[^/]+/);
-  if (workspaceMatch) return "/workspace/" + workspaceMatch[1] + "/session";
-  if (route.match(/^\/session\/[^/]+/)) return "/session";
-  return route.replace(/\/session\/.*$/, "/session");
+  const at = route.indexOf("/session/");
+  return at === -1 ? "" : route.slice(0, at) + "/session";
 })()`;
 
-const HERO_LAYOUT_READY = `(() => {
-  const heading = [...document.querySelectorAll("h2")].find((h) => h.textContent.trim() === "What do you need done?");
+const MEASURE_HERO = `(() => {
+  const heading = Array.from(document.querySelectorAll("h2")).find((h) => (h.textContent || "").trim() === "What do you need done?");
   const hero = heading && heading.parentElement ? heading.parentElement.parentElement : null;
   const editor = hero ? hero.querySelector('[contenteditable="true"]') : null;
   let panel = editor;
   while (panel && String(panel.className || "").indexOf("rounded-[18px]") === -1) panel = panel.parentElement;
-  const grid = hero ? [...hero.children].find((el) => el.classList.contains("grid")) : null;
-  const cards = grid ? [...grid.children] : [];
+  const grid = hero ? Array.from(hero.children).find((el) => el.classList.contains("grid")) : null;
+  const cards = grid ? Array.from(grid.children) : [];
   if (!heading || !hero || !editor || !panel || !grid || cards.length < 1) return false;
   const panelRect = panel.getBoundingClientRect();
   const gridRect = grid.getBoundingClientRect();
   const firstCardRect = cards[0].getBoundingClientRect();
-  return panelRect.width > 0 && gridRect.width > 0 && firstCardRect.width > 0;
-})()`;
-
-const MEASURE_HERO_ALIGNMENT = `(() => {
-  const heading = [...document.querySelectorAll("h2")].find((h) => h.textContent.trim() === "What do you need done?");
-  const hero = heading && heading.parentElement ? heading.parentElement.parentElement : null;
-  const editor = hero ? hero.querySelector('[contenteditable="true"]') : null;
-  let panel = editor;
-  while (panel && String(panel.className || "").indexOf("rounded-[18px]") === -1) panel = panel.parentElement;
-  const grid = hero ? [...hero.children].find((el) => el.classList.contains("grid")) : null;
-  const cards = grid ? [...grid.children] : [];
-  if (!panel || !grid || cards.length < 1) return null;
-  const panelRect = panel.getBoundingClientRect();
-  const gridRect = grid.getBoundingClientRect();
-  const firstCardRect = cards[0].getBoundingClientRect();
+  if (panelRect.width <= 0 || gridRect.width <= 0 || firstCardRect.width <= 0) return false;
   const widestCardRight = cards.reduce((right, card) => Math.max(right, card.getBoundingClientRect().right), firstCardRect.right);
   const composerRoot = panel.parentElement && panel.parentElement.parentElement ? panel.parentElement.parentElement : null;
-  return {
-    panelLeft: Math.round(panelRect.left),
-    panelRight: Math.round(panelRect.right),
-    panelWidth: Math.round(panelRect.width),
-    gridLeft: Math.round(gridRect.left),
-    gridRight: Math.round(gridRect.right),
-    gridWidth: Math.round(gridRect.width),
-    firstCardLeft: Math.round(firstCardRect.left),
-    widestCardRight: Math.round(widestCardRight),
-    cardsLength: cards.length,
+  window.__heroAlign = {
+    panelLeft: Math.round(panelRect.left), panelRight: Math.round(panelRect.right), panelWidth: Math.round(panelRect.width),
+    gridLeft: Math.round(gridRect.left), gridRight: Math.round(gridRect.right), gridWidth: Math.round(gridRect.width),
+    firstCardLeft: Math.round(firstCardRect.left), widestCardRight: Math.round(widestCardRight), cardsLength: cards.length,
     rootPosition: composerRoot ? getComputedStyle(composerRoot).position : "missing",
   };
-})()`;
-
-const DOCKED_COMPOSER_READY = `(() => {
-  const editors = [...document.querySelectorAll('[contenteditable="true"]')];
-  for (const editor of editors) {
-    let panel = editor;
-    while (panel && String(panel.className || "").indexOf("rounded-[18px]") === -1) panel = panel.parentElement;
-    if (!panel || !panel.parentElement || !panel.parentElement.parentElement) continue;
-    const root = panel.parentElement.parentElement;
-    const rootRect = root.getBoundingClientRect();
-    const panelRect = panel.getBoundingClientRect();
-    if (getComputedStyle(root).position === "sticky" && rootRect.width > 0 && panelRect.width > 0) return true;
-  }
-  return false;
+  return true;
 })()`;
 
 const MEASURE_DOCKED_COMPOSER = `(() => {
-  const editors = [...document.querySelectorAll('[contenteditable="true"]')];
+  const editors = Array.from(document.querySelectorAll('[contenteditable="true"]'));
   for (const editor of editors) {
     let panel = editor;
     while (panel && String(panel.className || "").indexOf("rounded-[18px]") === -1) panel = panel.parentElement;
@@ -291,23 +78,18 @@ const MEASURE_DOCKED_COMPOSER = `(() => {
     const rootRect = root.getBoundingClientRect();
     const innerRect = inner.getBoundingClientRect();
     const panelRect = panel.getBoundingClientRect();
-    return {
-      rootLeft: Math.round(rootRect.left),
-      rootRight: Math.round(rootRect.right),
-      rootWidth: Math.round(rootRect.width),
-      innerLeft: Math.round(innerRect.left),
-      innerRight: Math.round(innerRect.right),
-      innerWidth: Math.round(innerRect.width),
-      panelLeft: Math.round(panelRect.left),
-      panelRight: Math.round(panelRect.right),
-      panelWidth: Math.round(panelRect.width),
-      leftInset: Math.round(panelRect.left - rootRect.left),
-      rightInset: Math.round(rootRect.right - panelRect.right),
+    if (rootRect.width <= 0 || panelRect.width <= 0) continue;
+    window.__dockedComposer = {
+      rootLeft: Math.round(rootRect.left), rootRight: Math.round(rootRect.right), rootWidth: Math.round(rootRect.width),
+      innerLeft: Math.round(innerRect.left), innerRight: Math.round(innerRect.right), innerWidth: Math.round(innerRect.width),
+      panelLeft: Math.round(panelRect.left), panelRight: Math.round(panelRect.right), panelWidth: Math.round(panelRect.width),
+      leftInset: Math.round(panelRect.left - rootRect.left), rightInset: Math.round(rootRect.right - panelRect.right),
       centerDelta: Math.round(Math.abs((panelRect.left + panelRect.right) / 2 - (rootRect.left + rootRect.right) / 2)),
       rootPosition: getComputedStyle(root).position,
     };
+    return true;
   }
-  return null;
+  return false;
 })()`;
 
 export default defineFlow({
@@ -323,24 +105,16 @@ export default defineFlow({
         await ctx.prove("OpenWork lands on the empty new-task composer screen", {
           voiceover: vo[0],
           action: async () => {
-            await ctx.waitFor("Boolean(window.__openworkControl)", {
-              timeoutMs: 60_000,
-              label: "control API",
-            });
+            await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
             const emptyRoute = await ctx.eval(EMPTY_TASK_ROUTE_FROM_SESSION);
-            if (typeof emptyRoute === "string" && emptyRoute.length > 0) {
-              await ctx.navigateHash(emptyRoute);
-            }
+            if (typeof emptyRoute === "string" && emptyRoute.length > 0) await ctx.navigateHash(emptyRoute);
           },
           assert: async () => {
             await ctx.expectText("What do you need done?");
             await ctx.expectText("Describe your task");
             await ctx.expectText("Run task");
           },
-          screenshot: {
-            name: "new-task-screen",
-            requireText: ["What do you need done?", "Run task"],
-          },
+          screenshot: { name: "new-task-screen", requireText: ["What do you need done?", "Run task"] },
         });
       },
     },
@@ -350,48 +124,42 @@ export default defineFlow({
         await ctx.prove("The hero composer card and starter-card grid share the same edges", {
           voiceover: vo[1],
           action: async () => {
-            await ctx.waitFor(HERO_LAYOUT_READY, {
-              timeoutMs: 30_000,
-              label: "hero composer and starter cards laid out",
-            });
+            const starterCardClicked = await ctx.eval(`(() => {
+              const heading = Array.from(document.querySelectorAll("h2")).find((h) => (h.textContent || "").trim() === "What do you need done?");
+              const hero = heading && heading.parentElement ? heading.parentElement.parentElement : null;
+              const grid = hero ? Array.from(hero.children).find((el) => el.classList.contains("grid")) : null;
+              const firstCard = grid ? grid.children[0] : null;
+              if (!(firstCard instanceof HTMLButtonElement)) return false;
+              firstCard.click();
+              return true;
+            })()`);
+            ctx.assert(starterCardClicked === true, `Expected first starter card click to land, got ${JSON.stringify(starterCardClicked)}.`);
+            await ctx.waitFor(`(() => {
+              const heading = Array.from(document.querySelectorAll("h2")).find((h) => (h.textContent || "").trim() === "What do you need done?");
+              const hero = heading && heading.parentElement ? heading.parentElement.parentElement : null;
+              const editor = hero ? hero.querySelector('[contenteditable="true"]') : null;
+              return Boolean(editor && String(editor.innerText || "").trim().length > 0);
+            })()`, { timeoutMs: 30_000, label: "starter card prompt fills composer" });
+            await ctx.waitFor(MEASURE_HERO, { timeoutMs: 30_000, label: "hero composer and starter cards laid out" });
           },
           assert: async () => {
-            const measured = await ctx.eval(MEASURE_HERO_ALIGNMENT);
-            const metrics = heroAlignmentMetrics(measured);
-            if (!metrics) {
-              ctx.assert(false, `Could not measure hero alignment metrics: ${JSON.stringify(measured)}.`);
-              return;
-            }
-            ctx.log(`Hero alignment metrics: ${formatHeroMetrics(metrics)}`);
-            ctx.assert(
-              metrics.cardsLength >= 1,
-              `Expected cards.length >= 1, got ${metrics.cardsLength}; measured ${formatHeroMetrics(metrics)}.`,
-            );
-            ctx.assert(
-              Math.abs(metrics.panelLeft - metrics.gridLeft) <= 1,
-              `Composer left ${metrics.panelLeft}px must match grid left ${metrics.gridLeft}px within 1px; measured ${formatHeroMetrics(metrics)}.`,
-            );
-            ctx.assert(
-              Math.abs(metrics.panelRight - metrics.gridRight) <= 1,
-              `Composer right ${metrics.panelRight}px must match grid right ${metrics.gridRight}px within 1px; measured ${formatHeroMetrics(metrics)}.`,
-            );
-            ctx.assert(
-              Math.abs(metrics.panelWidth - metrics.gridWidth) <= 1,
-              `Composer width ${metrics.panelWidth}px must match grid width ${metrics.gridWidth}px within 1px; measured ${formatHeroMetrics(metrics)}.`,
-            );
-            ctx.assert(
-              metrics.panelWidth > 0,
-              `Composer panel width must be positive, got ${metrics.panelWidth}px; measured ${formatHeroMetrics(metrics)}.`,
-            );
-            ctx.assert(
-              metrics.rootPosition !== "sticky",
-              `New-task composer root must not be sticky, got position ${metrics.rootPosition}; measured ${formatHeroMetrics(metrics)}.`,
-            );
+            await measure(ctx, MEASURE_HERO, "Could not measure hero alignment metrics");
+            const measured = await text(ctx, "JSON.stringify(window.__heroAlign)");
+            ctx.output("hero-alignment-metrics", measured);
+            const [panelLeft, panelRight, panelWidth, gridLeft, gridRight, gridWidth, cardsLength] = await Promise.all([
+              num(ctx, "window.__heroAlign.panelLeft"), num(ctx, "window.__heroAlign.panelRight"), num(ctx, "window.__heroAlign.panelWidth"),
+              num(ctx, "window.__heroAlign.gridLeft"), num(ctx, "window.__heroAlign.gridRight"), num(ctx, "window.__heroAlign.gridWidth"),
+              num(ctx, "window.__heroAlign.cardsLength"),
+            ]);
+            const rootPosition = await text(ctx, "window.__heroAlign.rootPosition");
+            ctx.assert(cardsLength >= 1, `Expected cards.length >= 1, got ${cardsLength}; measured ${measured}.`);
+            ctx.assert(Math.abs(panelLeft - gridLeft) <= 1, `Composer left ${panelLeft}px must match grid left ${gridLeft}px within 1px; measured ${measured}.`);
+            ctx.assert(Math.abs(panelRight - gridRight) <= 1, `Composer right ${panelRight}px must match grid right ${gridRight}px within 1px; measured ${measured}.`);
+            ctx.assert(Math.abs(panelWidth - gridWidth) <= 1, `Composer width ${panelWidth}px must match grid width ${gridWidth}px within 1px; measured ${measured}.`);
+            ctx.assert(panelWidth > 0, `Composer panel width must be positive, got ${panelWidth}px; measured ${measured}.`);
+            ctx.assert(rootPosition !== "sticky", `New-task composer root must not be sticky, got position ${rootPosition}; measured ${measured}.`);
           },
-          screenshot: {
-            name: "composer-aligned-with-cards",
-            requireText: ["What do you need done?"],
-          },
+          screenshot: { name: "composer-aligned-with-cards", requireText: ["What do you need done?"] },
         });
       },
     },
@@ -402,41 +170,25 @@ export default defineFlow({
           voiceover: vo[2],
           action: async () => {
             await ctx.control("session.create_task");
-            await ctx.waitFor(`window.__openworkControl.snapshot().route.includes("/session/")`, {
-              timeoutMs: 60_000,
-              label: "session route after task creation",
-            });
-            await ctx.waitFor(DOCKED_COMPOSER_READY, {
-              timeoutMs: 30_000,
-              label: "sticky session composer laid out",
-            });
+            await ctx.waitFor(`window.__openworkControl.snapshot().route.includes("/session/")`, { timeoutMs: 60_000, label: "session route after task creation" });
+            await ctx.waitFor(MEASURE_DOCKED_COMPOSER, { timeoutMs: 30_000, label: "sticky session composer laid out" });
           },
           assert: async () => {
-            const measured = await ctx.eval(MEASURE_DOCKED_COMPOSER);
-            const metrics = dockedComposerMetrics(measured);
-            if (!metrics) {
-              ctx.assert(false, `Could not measure docked composer metrics: ${JSON.stringify(measured)}.`);
-              return;
-            }
-            ctx.log(`Docked composer metrics: ${formatDockedMetrics(metrics)}`);
-            ctx.assert(
-              metrics.rootPosition === "sticky",
-              `Session composer root must be sticky, got position ${metrics.rootPosition}; measured ${formatDockedMetrics(metrics)}.`,
-            );
-            ctx.assert(
-              metrics.panelWidth <= 800,
-              `Session composer panel must stay at most 800px wide, got ${metrics.panelWidth}px; measured ${formatDockedMetrics(metrics)}.`,
-            );
-            if (metrics.rootWidth > 800) {
-              ctx.assert(
-                metrics.centerDelta <= 2,
-                `Session composer panel must be centered in its ${metrics.rootWidth}px column within 2px, got center delta ${metrics.centerDelta}px; measured ${formatDockedMetrics(metrics)}.`,
-              );
+            await measure(ctx, MEASURE_DOCKED_COMPOSER, "Could not measure docked composer metrics");
+            const measured = await text(ctx, "JSON.stringify(window.__dockedComposer)");
+            ctx.output("docked-composer-metrics", measured);
+            const [rootWidth, panelWidth, leftInset, rightInset, centerDelta] = await Promise.all([
+              num(ctx, "window.__dockedComposer.rootWidth"), num(ctx, "window.__dockedComposer.panelWidth"),
+              num(ctx, "window.__dockedComposer.leftInset"), num(ctx, "window.__dockedComposer.rightInset"),
+              num(ctx, "window.__dockedComposer.centerDelta"),
+            ]);
+            const rootPosition = await text(ctx, "window.__dockedComposer.rootPosition");
+            ctx.assert(rootPosition === "sticky", `Session composer root must be sticky, got position ${rootPosition}; measured ${measured}.`);
+            ctx.assert(panelWidth <= 800, `Session composer panel must stay at most 800px wide, got ${panelWidth}px; measured ${measured}.`);
+            if (rootWidth > 800) {
+              ctx.assert(centerDelta <= 2, `Session composer panel must be centered in its ${rootWidth}px column within 2px, got center delta ${centerDelta}px; measured ${measured}.`);
             } else {
-              ctx.assert(
-                metrics.leftInset > 0 && metrics.rightInset > 0,
-                `Narrow session composer must keep dock padding, got left inset ${metrics.leftInset}px and right inset ${metrics.rightInset}px; measured ${formatDockedMetrics(metrics)}.`,
-              );
+              ctx.assert(leftInset > 0 && rightInset > 0, `Narrow session composer must keep dock padding, got left inset ${leftInset}px and right inset ${rightInset}px; measured ${measured}.`);
             }
           },
           screenshot: { name: "session-composer-still-docked" },

--- a/evals/flows/hero-composer-alignment.flow.ts
+++ b/evals/flows/hero-composer-alignment.flow.ts
@@ -1,0 +1,447 @@
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+
+const FLOW_ID = "hero-composer-alignment";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+type HeroAlignmentMetrics = {
+  panelLeft: number;
+  panelRight: number;
+  panelWidth: number;
+  gridLeft: number;
+  gridRight: number;
+  gridWidth: number;
+  firstCardLeft: number;
+  widestCardRight: number;
+  cardsLength: number;
+  rootPosition: string;
+};
+
+type DockedComposerMetrics = {
+  rootLeft: number;
+  rootRight: number;
+  rootWidth: number;
+  innerLeft: number;
+  innerRight: number;
+  innerWidth: number;
+  panelLeft: number;
+  panelRight: number;
+  panelWidth: number;
+  leftInset: number;
+  rightInset: number;
+  centerDelta: number;
+  rootPosition: string;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function numberProperty(record: Record<string, unknown>, key: string): number | null {
+  const value = Reflect.get(record, key);
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function stringProperty(record: Record<string, unknown>, key: string): string | null {
+  const value = Reflect.get(record, key);
+  return typeof value === "string" ? value : null;
+}
+
+function heroAlignmentMetrics(value: unknown): HeroAlignmentMetrics | null {
+  if (!isRecord(value)) return null;
+  const panelLeft = numberProperty(value, "panelLeft");
+  const panelRight = numberProperty(value, "panelRight");
+  const panelWidth = numberProperty(value, "panelWidth");
+  const gridLeft = numberProperty(value, "gridLeft");
+  const gridRight = numberProperty(value, "gridRight");
+  const gridWidth = numberProperty(value, "gridWidth");
+  const firstCardLeft = numberProperty(value, "firstCardLeft");
+  const widestCardRight = numberProperty(value, "widestCardRight");
+  const cardsLength = numberProperty(value, "cardsLength");
+  const rootPosition = stringProperty(value, "rootPosition");
+  if (
+    panelLeft === null ||
+    panelRight === null ||
+    panelWidth === null ||
+    gridLeft === null ||
+    gridRight === null ||
+    gridWidth === null ||
+    firstCardLeft === null ||
+    widestCardRight === null ||
+    cardsLength === null ||
+    rootPosition === null
+  ) {
+    return null;
+  }
+  return {
+    panelLeft,
+    panelRight,
+    panelWidth,
+    gridLeft,
+    gridRight,
+    gridWidth,
+    firstCardLeft,
+    widestCardRight,
+    cardsLength,
+    rootPosition,
+  };
+}
+
+function dockedComposerMetrics(value: unknown): DockedComposerMetrics | null {
+  if (!isRecord(value)) return null;
+  const rootLeft = numberProperty(value, "rootLeft");
+  const rootRight = numberProperty(value, "rootRight");
+  const rootWidth = numberProperty(value, "rootWidth");
+  const innerLeft = numberProperty(value, "innerLeft");
+  const innerRight = numberProperty(value, "innerRight");
+  const innerWidth = numberProperty(value, "innerWidth");
+  const panelLeft = numberProperty(value, "panelLeft");
+  const panelRight = numberProperty(value, "panelRight");
+  const panelWidth = numberProperty(value, "panelWidth");
+  const leftInset = numberProperty(value, "leftInset");
+  const rightInset = numberProperty(value, "rightInset");
+  const centerDelta = numberProperty(value, "centerDelta");
+  const rootPosition = stringProperty(value, "rootPosition");
+  if (
+    rootLeft === null ||
+    rootRight === null ||
+    rootWidth === null ||
+    innerLeft === null ||
+    innerRight === null ||
+    innerWidth === null ||
+    panelLeft === null ||
+    panelRight === null ||
+    panelWidth === null ||
+    leftInset === null ||
+    rightInset === null ||
+    centerDelta === null ||
+    rootPosition === null
+  ) {
+    return null;
+  }
+  return {
+    rootLeft,
+    rootRight,
+    rootWidth,
+    innerLeft,
+    innerRight,
+    innerWidth,
+    panelLeft,
+    panelRight,
+    panelWidth,
+    leftInset,
+    rightInset,
+    centerDelta,
+    rootPosition,
+  };
+}
+
+function formatHeroMetrics(metrics: HeroAlignmentMetrics): string {
+  return JSON.stringify(metrics);
+}
+
+function formatDockedMetrics(metrics: DockedComposerMetrics): string {
+  return JSON.stringify(metrics);
+}
+
+const WAIT_FOR_CREATE_TASK_READY = `(() => {
+  const control = window.__openworkControl;
+  if (!control) return null;
+  const route = String(control.snapshot().route || "");
+  if (route.startsWith("/welcome") || route.startsWith("/signin")) {
+    return "Profile is on welcome/sign-in; hero composer alignment requires an onboarded workspace.";
+  }
+  const action = control.listActions().find((candidate) => candidate.id === "session.create_task");
+  if (action && !action.disabled) {
+    delete window.__heroComposerCreateTaskUnavailableSince;
+    return "ready";
+  }
+  const text = document.body.innerText || "";
+  let reason = "";
+  if (!action && text.trim().length > 40) {
+    reason = "session.create_task control action is not registered; cannot prove the docked composer handoff.";
+  } else if (action && action.disabled && (
+    text.includes("What do you need done?") ||
+    text.includes("Connect a model provider") ||
+    text.includes("OpenCode unavailable") ||
+    text.includes("Remote workspace unavailable")
+  )) {
+    reason = "session.create_task control action is disabled; cannot create a session for the docked composer check.";
+  }
+  if (!reason) return null;
+  const key = "__heroComposerCreateTaskUnavailableSince";
+  if (!window[key]) window[key] = Date.now();
+  return Date.now() - window[key] > 2000 ? reason : null;
+})()`;
+
+const INSPECT_CREATE_TASK_READY = `(() => {
+  const control = window.__openworkControl;
+  if (!control) return "OpenWork control API is unavailable.";
+  const route = String(control.snapshot().route || "");
+  if (route.startsWith("/welcome") || route.startsWith("/signin")) {
+    return "Profile is on welcome/sign-in; hero composer alignment requires an onboarded workspace.";
+  }
+  const action = control.listActions().find((candidate) => candidate.id === "session.create_task");
+  if (action && !action.disabled) return "ready";
+  if (!action) return "session.create_task control action is not registered; cannot prove the docked composer handoff.";
+  return "session.create_task control action is disabled; cannot create a session for the docked composer check.";
+})()`;
+
+async function createTaskPrecondition(ctx: FlowContext): Promise<string | null> {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "control API",
+  });
+  try {
+    const state = await ctx.waitFor(WAIT_FOR_CREATE_TASK_READY, {
+      timeoutMs: 30_000,
+      label: "session.create_task ready or unavailable",
+    });
+    return state === "ready"
+      ? null
+      : typeof state === "string"
+        ? state
+        : "session.create_task is unavailable; cannot prove the docked composer handoff.";
+  } catch {
+    const state = await ctx.eval(INSPECT_CREATE_TASK_READY);
+    return state === "ready"
+      ? null
+      : typeof state === "string"
+        ? state
+        : "session.create_task is unavailable; cannot prove the docked composer handoff.";
+  }
+}
+
+const EMPTY_TASK_ROUTE_FROM_SESSION = `(() => {
+  const route = String(window.__openworkControl.snapshot().route || "");
+  if (!route.includes("/session/")) return "";
+  const workspaceMatch = route.match(/^\/workspace\/([^/]+)\/session\/[^/]+/);
+  if (workspaceMatch) return "/workspace/" + workspaceMatch[1] + "/session";
+  if (route.match(/^\/session\/[^/]+/)) return "/session";
+  return route.replace(/\/session\/.*$/, "/session");
+})()`;
+
+const HERO_LAYOUT_READY = `(() => {
+  const heading = [...document.querySelectorAll("h2")].find((h) => h.textContent.trim() === "What do you need done?");
+  const hero = heading && heading.parentElement ? heading.parentElement.parentElement : null;
+  const editor = hero ? hero.querySelector('[contenteditable="true"]') : null;
+  let panel = editor;
+  while (panel && String(panel.className || "").indexOf("rounded-[18px]") === -1) panel = panel.parentElement;
+  const grid = hero ? [...hero.children].find((el) => el.classList.contains("grid")) : null;
+  const cards = grid ? [...grid.children] : [];
+  if (!heading || !hero || !editor || !panel || !grid || cards.length < 1) return false;
+  const panelRect = panel.getBoundingClientRect();
+  const gridRect = grid.getBoundingClientRect();
+  const firstCardRect = cards[0].getBoundingClientRect();
+  return panelRect.width > 0 && gridRect.width > 0 && firstCardRect.width > 0;
+})()`;
+
+const MEASURE_HERO_ALIGNMENT = `(() => {
+  const heading = [...document.querySelectorAll("h2")].find((h) => h.textContent.trim() === "What do you need done?");
+  const hero = heading && heading.parentElement ? heading.parentElement.parentElement : null;
+  const editor = hero ? hero.querySelector('[contenteditable="true"]') : null;
+  let panel = editor;
+  while (panel && String(panel.className || "").indexOf("rounded-[18px]") === -1) panel = panel.parentElement;
+  const grid = hero ? [...hero.children].find((el) => el.classList.contains("grid")) : null;
+  const cards = grid ? [...grid.children] : [];
+  if (!panel || !grid || cards.length < 1) return null;
+  const panelRect = panel.getBoundingClientRect();
+  const gridRect = grid.getBoundingClientRect();
+  const firstCardRect = cards[0].getBoundingClientRect();
+  const widestCardRight = cards.reduce((right, card) => Math.max(right, card.getBoundingClientRect().right), firstCardRect.right);
+  const composerRoot = panel.parentElement && panel.parentElement.parentElement ? panel.parentElement.parentElement : null;
+  return {
+    panelLeft: Math.round(panelRect.left),
+    panelRight: Math.round(panelRect.right),
+    panelWidth: Math.round(panelRect.width),
+    gridLeft: Math.round(gridRect.left),
+    gridRight: Math.round(gridRect.right),
+    gridWidth: Math.round(gridRect.width),
+    firstCardLeft: Math.round(firstCardRect.left),
+    widestCardRight: Math.round(widestCardRight),
+    cardsLength: cards.length,
+    rootPosition: composerRoot ? getComputedStyle(composerRoot).position : "missing",
+  };
+})()`;
+
+const DOCKED_COMPOSER_READY = `(() => {
+  const editors = [...document.querySelectorAll('[contenteditable="true"]')];
+  for (const editor of editors) {
+    let panel = editor;
+    while (panel && String(panel.className || "").indexOf("rounded-[18px]") === -1) panel = panel.parentElement;
+    if (!panel || !panel.parentElement || !panel.parentElement.parentElement) continue;
+    const root = panel.parentElement.parentElement;
+    const rootRect = root.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    if (getComputedStyle(root).position === "sticky" && rootRect.width > 0 && panelRect.width > 0) return true;
+  }
+  return false;
+})()`;
+
+const MEASURE_DOCKED_COMPOSER = `(() => {
+  const editors = [...document.querySelectorAll('[contenteditable="true"]')];
+  for (const editor of editors) {
+    let panel = editor;
+    while (panel && String(panel.className || "").indexOf("rounded-[18px]") === -1) panel = panel.parentElement;
+    if (!panel || !panel.parentElement || !panel.parentElement.parentElement) continue;
+    const inner = panel.parentElement;
+    const root = inner.parentElement;
+    if (getComputedStyle(root).position !== "sticky") continue;
+    const rootRect = root.getBoundingClientRect();
+    const innerRect = inner.getBoundingClientRect();
+    const panelRect = panel.getBoundingClientRect();
+    return {
+      rootLeft: Math.round(rootRect.left),
+      rootRight: Math.round(rootRect.right),
+      rootWidth: Math.round(rootRect.width),
+      innerLeft: Math.round(innerRect.left),
+      innerRight: Math.round(innerRect.right),
+      innerWidth: Math.round(innerRect.width),
+      panelLeft: Math.round(panelRect.left),
+      panelRight: Math.round(panelRect.right),
+      panelWidth: Math.round(panelRect.width),
+      leftInset: Math.round(panelRect.left - rootRect.left),
+      rightInset: Math.round(rootRect.right - panelRect.right),
+      centerDelta: Math.round(Math.abs((panelRect.left + panelRect.right) / 2 - (rootRect.left + rootRect.right) / 2)),
+      rootPosition: getComputedStyle(root).position,
+    };
+  }
+  return null;
+})()`;
+
+export default defineFlow({
+  id: FLOW_ID,
+  title: "New-task composer spans the same width as the starter cards below it",
+  kind: "user-facing",
+  spec: "evals/react-session-flows.md",
+  precondition: createTaskPrecondition,
+  steps: [
+    {
+      name: "New-task screen is visible on launch",
+      run: async (ctx) => {
+        await ctx.prove("OpenWork lands on the empty new-task composer screen", {
+          voiceover: vo[0],
+          action: async () => {
+            await ctx.waitFor("Boolean(window.__openworkControl)", {
+              timeoutMs: 60_000,
+              label: "control API",
+            });
+            const emptyRoute = await ctx.eval(EMPTY_TASK_ROUTE_FROM_SESSION);
+            if (typeof emptyRoute === "string" && emptyRoute.length > 0) {
+              await ctx.navigateHash(emptyRoute);
+            }
+          },
+          assert: async () => {
+            await ctx.expectText("What do you need done?");
+            await ctx.expectText("Describe your task");
+            await ctx.expectText("Run task");
+          },
+          screenshot: {
+            name: "new-task-screen",
+            requireText: ["What do you need done?", "Run task"],
+          },
+        });
+      },
+    },
+    {
+      name: "New-task composer aligns to the starter-card column",
+      run: async (ctx) => {
+        await ctx.prove("The hero composer card and starter-card grid share the same edges", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.waitFor(HERO_LAYOUT_READY, {
+              timeoutMs: 30_000,
+              label: "hero composer and starter cards laid out",
+            });
+          },
+          assert: async () => {
+            const measured = await ctx.eval(MEASURE_HERO_ALIGNMENT);
+            const metrics = heroAlignmentMetrics(measured);
+            if (!metrics) {
+              ctx.assert(false, `Could not measure hero alignment metrics: ${JSON.stringify(measured)}.`);
+              return;
+            }
+            ctx.log(`Hero alignment metrics: ${formatHeroMetrics(metrics)}`);
+            ctx.assert(
+              metrics.cardsLength >= 1,
+              `Expected cards.length >= 1, got ${metrics.cardsLength}; measured ${formatHeroMetrics(metrics)}.`,
+            );
+            ctx.assert(
+              Math.abs(metrics.panelLeft - metrics.gridLeft) <= 1,
+              `Composer left ${metrics.panelLeft}px must match grid left ${metrics.gridLeft}px within 1px; measured ${formatHeroMetrics(metrics)}.`,
+            );
+            ctx.assert(
+              Math.abs(metrics.panelRight - metrics.gridRight) <= 1,
+              `Composer right ${metrics.panelRight}px must match grid right ${metrics.gridRight}px within 1px; measured ${formatHeroMetrics(metrics)}.`,
+            );
+            ctx.assert(
+              Math.abs(metrics.panelWidth - metrics.gridWidth) <= 1,
+              `Composer width ${metrics.panelWidth}px must match grid width ${metrics.gridWidth}px within 1px; measured ${formatHeroMetrics(metrics)}.`,
+            );
+            ctx.assert(
+              metrics.panelWidth > 0,
+              `Composer panel width must be positive, got ${metrics.panelWidth}px; measured ${formatHeroMetrics(metrics)}.`,
+            );
+            ctx.assert(
+              metrics.rootPosition !== "sticky",
+              `New-task composer root must not be sticky, got position ${metrics.rootPosition}; measured ${formatHeroMetrics(metrics)}.`,
+            );
+          },
+          screenshot: {
+            name: "composer-aligned-with-cards",
+            requireText: ["What do you need done?"],
+          },
+        });
+      },
+    },
+    {
+      name: "Session composer keeps the docked chat chrome",
+      run: async (ctx) => {
+        await ctx.prove("Starting a task keeps the session composer docked and width-capped", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.control("session.create_task");
+            await ctx.waitFor(`window.__openworkControl.snapshot().route.includes("/session/")`, {
+              timeoutMs: 60_000,
+              label: "session route after task creation",
+            });
+            await ctx.waitFor(DOCKED_COMPOSER_READY, {
+              timeoutMs: 30_000,
+              label: "sticky session composer laid out",
+            });
+          },
+          assert: async () => {
+            const measured = await ctx.eval(MEASURE_DOCKED_COMPOSER);
+            const metrics = dockedComposerMetrics(measured);
+            if (!metrics) {
+              ctx.assert(false, `Could not measure docked composer metrics: ${JSON.stringify(measured)}.`);
+              return;
+            }
+            ctx.log(`Docked composer metrics: ${formatDockedMetrics(metrics)}`);
+            ctx.assert(
+              metrics.rootPosition === "sticky",
+              `Session composer root must be sticky, got position ${metrics.rootPosition}; measured ${formatDockedMetrics(metrics)}.`,
+            );
+            ctx.assert(
+              metrics.panelWidth <= 800,
+              `Session composer panel must stay at most 800px wide, got ${metrics.panelWidth}px; measured ${formatDockedMetrics(metrics)}.`,
+            );
+            if (metrics.rootWidth > 800) {
+              ctx.assert(
+                metrics.centerDelta <= 2,
+                `Session composer panel must be centered in its ${metrics.rootWidth}px column within 2px, got center delta ${metrics.centerDelta}px; measured ${formatDockedMetrics(metrics)}.`,
+              );
+            } else {
+              ctx.assert(
+                metrics.leftInset > 0 && metrics.rightInset > 0,
+                `Narrow session composer must keep dock padding, got left inset ${metrics.leftInset}px and right inset ${metrics.rightInset}px; measured ${formatDockedMetrics(metrics)}.`,
+              );
+            }
+          },
+          screenshot: { name: "session-composer-still-docked" },
+        });
+      },
+    },
+  ],
+});

--- a/evals/voiceovers/hero-composer-alignment.md
+++ b/evals/voiceovers/hero-composer-alignment.md
@@ -8,6 +8,6 @@ user actually sees and measures the edges.
 
 1. OpenWork opens on the new-task screen: "What do you need done?", the real composer with its agent, model and effort controls, and the starter cards sitting underneath it.
 
-2. Now look down the column. The composer card begins and ends on exactly the same lines as the cards below it, so the whole screen reads as one aligned column instead of a narrow box floating above wider cards.
+2. Picking a starter card drops its prompt straight into the composer, and the column holds true: the composer card begins and ends on exactly the same lines as the cards below it, instead of sitting as a narrow box above wider cards.
 
 3. Starting a task hands the same composer to the chat, where it still docks to the bottom with its centred, cushioned chat look. Only the new-task screen changed.

--- a/evals/voiceovers/hero-composer-alignment.md
+++ b/evals/voiceovers/hero-composer-alignment.md
@@ -1,0 +1,13 @@
+# hero-composer-alignment — The new-task composer lines up with everything under it
+
+OpenWork now opens on the new-task screen, and that screen reuses the real chat
+composer. The composer used to be inset by the padding it needs when it is
+docked at the bottom of a chat, so it rendered visibly narrower than the starter
+cards underneath it and the column looked crooked. This demo walks the screen a
+user actually sees and measures the edges.
+
+1. OpenWork opens on the new-task screen: "What do you need done?", the real composer with its agent, model and effort controls, and the starter cards sitting underneath it.
+
+2. Now look down the column. The composer card begins and ends on exactly the same lines as the cards below it, so the whole screen reads as one aligned column instead of a narrow box floating above wider cards.
+
+3. Starting a task hands the same composer to the chat, where it still docks to the bottom with its centred, cushioned chat look. Only the new-task screen changed.


### PR DESCRIPTION
## What

On the "What do you need done?" new-task screen, the composer rendered **64px narrower** than the starter cards underneath it, so the column looked crooked.

That screen now reuses the real session composer (#3085), and `ReactSessionComposer` carries the chrome it needs when it is **docked** at the bottom of a chat: `sticky bottom-0`, a fade gradient, `px-4 md:px-8`, and an inner `max-w-[800px] mx-auto`. Inside the hero (which owns its own page padding) that inset shrank the composer card by 32px on each side.

This adds a `flush` mode to `ReactSessionComposer` that drops the dock chrome, and the new-task hero uses it. **The docked session composer's class string is byte-identical to before.**

```diff
-      className={`sticky bottom-0 ${...} px-4 pb-2 md:px-8 ...`}
+      className={props.flush ? `relative ${...}` : `sticky bottom-0 ${...} px-4 pb-2 md:px-8 ...`}
-      <div className="max-w-[800px] mx-auto">
+      <div className={props.flush ? "" : "max-w-[800px] mx-auto"}>
```

6 changed lines across 2 files.

## Before / after

Measured live in the running app (same window, same session, HMR toggle of the one `flush` prop):

| | composer card | starter-card grid | delta |
|---|---|---|---|
| **before** | `422 → 950` (**528px**) | `390 → 982` (592px) | **64px narrower** |
| **after** | `390 → 982` (**592px**) | `390 → 982` (592px) | **0px** |

<table>
<tr><th>Before — composer inset from the cards</th><th>After — edges line up</th></tr>
<tr>
<td><img width="480" src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/fraimz/hero-composer-alignment/before-misaligned-p8BsU6P7WUWauNhfFmSL1BVdmVKekT.png" /></td>
<td><img width="480" src="https://b8tgacyg507ru26g.public.blob.vercel-storage.com/fraimz/hero-composer-alignment/hero-composer-alignment-02-composer-aligned-with-cards-c4SizifyU6rXVipsKKp6Y0O9QtAec1.png" /></td>
</tr>
</table>

## Proof

New fraimz flow `evals/flows/hero-composer-alignment.flow.ts` (+ approved voice-over), driven as the end user against a real Electron build on a Daytona sandbox:

1. OpenWork lands on the new-task screen (asserts "What do you need done?", "Describe your task", "Run task").
2. Clicking a starter card fills the composer, then the composer card and the starter-card grid are measured — identical left, right and width (±1px), and the composer root is **not** sticky on this screen.
3. Starting a task hands the same composer to the chat, where it is still `position: sticky`, capped at 800px and centred (`centerDelta: 0`) — the dock is untouched.

Measured evidence recorded in the artifact:

```json
hero:   {"panelLeft":390,"panelRight":982,"panelWidth":592,"gridLeft":390,"gridRight":982,"gridWidth":592,"cardsLength":4,"rootPosition":"relative"}
docked: {"rootWidth":914,"panelLeft":286,"panelRight":1086,"panelWidth":800,"centerDelta":0,"rootPosition":"sticky"}
```

## Tests run

| command | result |
|---|---|
| `pnpm typecheck` | pass |
| `pnpm build:ui` | pass (`✓ built in 5.16s`) |
| `pnpm evals:typecheck` | pass |
| `pnpm fraimz --flow hero-composer-alignment --cdp-url <daytona>` | **PASSED — 1 passed, 0 failed, 0 skipped** (3/3 frames, voice-over coverage ✓) |

Frame-by-frame proof is posted as a comment below.

_Note: local Electron could not be launched on this machine (`app.whenReady()` never fires in this shell's GUI session), so the flow was run against a Daytona sandbox built from this branch — the documented preferred path._
