### PR TITLE
chore(release): v0.18.1

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/app",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "type": "module",
   "scripts": {
     "test": "bun test --isolate tests/",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@openwork/desktop",
   "private": true,
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "OpenWork desktop shell",
   "author": {
     "name": "OpenWork",

--- a/apps/orchestrator/package.json
+++ b/apps/orchestrator/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-orchestrator",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "OpenWork host orchestrator for opencode + OpenWork server",
   "private": true,
   "type": "module",
@@ -46,7 +46,7 @@
     "@opencode-ai/sdk": "^1.17.11",
     "@opentui/core": "0.1.77",
     "@opentui/solid": "0.1.77",
-    "openwork-server": "0.18.0",
+    "openwork-server": "0.18.1",
     "solid-js": "1.9.9"
   },
   "devDependencies": {

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openwork-server",
-  "version": "0.18.0",
+  "version": "0.18.1",
   "description": "Filesystem-backed API for OpenWork remote clients",
   "type": "module",
   "bin": {

--- a/ee/apps/den-api/src/generated/desktop-versions.ts
+++ b/ee/apps/den-api/src/generated/desktop-versions.ts
@@ -1,6 +1,7 @@
 export const MIN_SUPPORTED_DESKTOP_VERSION = "0.17.0" as const;
 
 export const PUBLISHED_DESKTOP_VERSIONS = [
+  "0.18.1",
   "0.18.0",
   "0.17.41",
   "0.17.40",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -287,7 +287,7 @@ importers:
         specifier: 0.1.77
         version: 0.1.77(solid-js@1.9.9)(stage-js@1.0.0-alpha.17)(typescript@5.9.3)(web-tree-sitter@0.25.10)
       openwork-server:
-        specifier: 0.18.0
+        specifier: 0.18.1
         version: link:../server
       solid-js:
         specifier: 1.9.9


### PR DESCRIPTION
Cuts v0.18.1 so the organization installer assets are rebuilt from `dev`.

The published `v0.18.0` installer predates the guided activation work (#3084), so it has no `HAS_ACTIVATION` gate and shows `Launch` instead of `Open this in your browser`. The hosted Den API already returns `activationUrl` in `/v1/install-config`, so only the installer binary is stale; the `publish-installers` job on the release tag rebuilds it.

Version-pinned organizations still need their `allowedDesktopVersions` raised to 0.18.1; unrestricted organizations follow `releases/latest/download` automatically.

Standard bump only: app/desktop/orchestrator/server package versions, `PUBLISHED_DESKTOP_VERSIONS`, and the lockfile.

Made with [Cursor](https://cursor.com)