### PR TITLE
chore(installer): report the real release version instead of 1.0.0

### DIFF
--- a/.github/workflows/release-generic-installer.yml
+++ b/.github/workflows/release-generic-installer.yml
@@ -126,6 +126,16 @@ jobs:
         with:
           bun-version: 1.3.9
 
+      - name: Resolve installer version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(node apps/installer/scripts/installer-version.mjs --release-tag "$RELEASE_TAG")
+          windows_version=$(node apps/installer/scripts/installer-version.mjs --release-tag "$RELEASE_TAG" --windows)
+          echo "INSTALLER_VERSION=$version" >> "$GITHUB_ENV"
+          echo "INSTALLER_WINDOWS_VERSION=$windows_version" >> "$GITHUB_ENV"
+          echo "Stamping installer version $version (windows resource $windows_version)"
+
       - name: Verify build config is the generic placeholder
         shell: bash
         run: |
@@ -165,8 +175,17 @@ jobs:
         run: |
           cd apps/installer
           extra_args=()
-          if [ "${{ matrix.os_type }}" = "windows" ]; then extra_args+=(--windows-icon=assets/icon.ico); fi
+          if [ "${{ matrix.os_type }}" = "windows" ]; then
+            extra_args+=(--windows-icon=assets/icon.ico)
+            # Version resource on the .exe so Windows properties and support
+            # tickets show the real build.
+            if [ -n "$INSTALLER_WINDOWS_VERSION" ]; then extra_args+=("--windows-version=$INSTALLER_WINDOWS_VERSION"); fi
+            extra_args+=("--windows-title=OpenWork Installer")
+            extra_args+=("--windows-publisher=Different AI")
+            extra_args+=("--windows-description=Installs OpenWork on this computer")
+          fi
           bun build --compile --minify --target=${{ matrix.bun_target }} "${extra_args[@]}" \
+            --define "process.env.OPENWORK_INSTALLER_VERSION=\"$INSTALLER_VERSION\"" \
             src/index.ts src/server-worker.ts \
             --outfile "dist/openwork-installer"
 
@@ -179,6 +198,12 @@ jobs:
           cd apps/installer
           binary=dist/openwork-installer
           if [ "${{ matrix.os_type }}" = "windows" ]; then binary=dist/openwork-installer.exe; fi
+          reported=$("$binary" --version)
+          printf '%s\n' "$reported"
+          if [ "$reported" != "openwork-installer $INSTALLER_VERSION" ]; then
+            echo "Compiled installer reports '$reported', expected 'openwork-installer $INSTALLER_VERSION'" >&2
+            exit 1
+          fi
           set +e
           output=$("$binary" --headless --dry-run 2>&1)
           status=$?
@@ -205,7 +230,9 @@ jobs:
           mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
           cp dist/openwork-installer "$APP/Contents/MacOS/openwork-installer"
           cp assets/icon.icns "$APP/Contents/Resources/icon.icns"
-          cat > "$APP/Contents/Info.plist" <<'PLIST'
+          # Unquoted heredoc: $INSTALLER_VERSION is the only expansion here, and
+          # this plist must be written before signing so the version is signed in.
+          cat > "$APP/Contents/Info.plist" <<PLIST
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -216,13 +243,14 @@ jobs:
             <key>CFBundleExecutable</key><string>openwork-installer</string>
             <key>CFBundleIconFile</key><string>icon</string>
             <key>CFBundlePackageType</key><string>APPL</string>
-            <key>CFBundleShortVersionString</key><string>1.0.0</string>
-            <key>CFBundleVersion</key><string>1</string>
+            <key>CFBundleShortVersionString</key><string>$INSTALLER_VERSION</string>
+            <key>CFBundleVersion</key><string>$INSTALLER_VERSION</string>
             <key>LSMinimumSystemVersion</key><string>11.0</string>
             <key>NSHighResolutionCapable</key><true/>
           </dict>
           </plist>
           PLIST
+          plutil -p "$APP/Contents/Info.plist"
 
       - name: Sign, notarize, and package macOS DMG
         if: matrix.os_type == 'macos'
@@ -311,7 +339,7 @@ jobs:
 
           mkdir -p "$RUNNER_TEMP/out"
           DMG="$RUNNER_TEMP/out/${{ matrix.asset }}"
-          node scripts/package-mac-dmg.mjs --input "$APP" --output "$DMG"
+          node scripts/package-mac-dmg.mjs --input "$APP" --output "$DMG" --version "$INSTALLER_VERSION"
           hdiutil verify "$DMG"
           codesign --force --timestamp --sign "$IDENTITY" "$DMG"
           codesign --verify --verbose "$DMG"

--- a/apps/app/scripts/bump-version.mjs
+++ b/apps/app/scripts/bump-version.mjs
@@ -67,13 +67,23 @@ const updatePackageJson = async (nextVersion) => {
     "package.json",
   );
   const serverPath = path.join(REPO_ROOT, "apps", "server", "package.json");
+  const installerPath = path.join(
+    REPO_ROOT,
+    "apps",
+    "installer",
+    "package.json",
+  );
   const uiData = await readJson(uiPath);
   const tauriData = await readJson(tauriPath);
   const orchestratorData = await readJson(orchestratorPath);
   const serverData = await readJson(serverPath);
+  const installerData = await readJson(installerPath);
   uiData.version = nextVersion;
   tauriData.version = nextVersion;
   orchestratorData.version = nextVersion;
+  // The installer stamps this version into its artifacts when a release build
+  // has no tag to resolve from.
+  installerData.version = nextVersion;
 
   // Ensure openwork-orchestrator uses the same openwork-server version.
   orchestratorData.dependencies = orchestratorData.dependencies ?? {};
@@ -88,6 +98,7 @@ const updatePackageJson = async (nextVersion) => {
       JSON.stringify(orchestratorData, null, 2) + "\n",
     );
     await writeFile(serverPath, JSON.stringify(serverData, null, 2) + "\n");
+    await writeFile(installerPath, JSON.stringify(installerData, null, 2) + "\n");
   }
 };
 
@@ -146,6 +157,7 @@ const main = async () => {
           "apps/desktop/package.json",
           "apps/orchestrator/package.json",
           "apps/server/package.json",
+          "apps/installer/package.json",
           "ee/apps/den-api/src/generated/desktop-versions.ts",
           "pnpm-lock.yaml",
         ],

--- a/apps/installer/package.json
+++ b/apps/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openwork/installer",
-  "version": "0.1.0",
+  "version": "0.18.1",
   "private": true,
   "type": "module",
   "description": "OpenWork desktop installer: resolves an install-link config, writes desktop bootstrap config, then downloads and installs the newest supported desktop app.",

--- a/apps/installer/scripts/dmg-layout.mjs
+++ b/apps/installer/scripts/dmg-layout.mjs
@@ -7,6 +7,12 @@ export const dmgLayout = {
   window: { left: 100, top: 100, width: 660, height: 400 },
 }
 
+// The mounted volume is where a user reads which build they are installing.
+export function dmgVolumeName(version) {
+  const trimmed = (version ?? "").trim()
+  return trimmed ? `${dmgLayout.volumeName} ${trimmed}` : dmgLayout.volumeName
+}
+
 export function dmgWindowBounds(window) {
   return [window.left, window.top, window.left + window.width, window.top + window.height]
 }
@@ -23,8 +29,8 @@ export function buildTiffutilArgs(assetDir, outputPath) {
   return ["-cathidpicheck", `${assetDir}/bg.png`, `${assetDir}/bg@2x.png`, "-out", outputPath]
 }
 
-export function buildReadWriteDmgArgs({ sourceFolder, outputPath }) {
-  return ["create", "-format", "UDRW", "-volname", dmgLayout.volumeName, "-srcfolder", sourceFolder, "-ov", outputPath]
+export function buildReadWriteDmgArgs({ sourceFolder, outputPath, volumeName = dmgLayout.volumeName }) {
+  return ["create", "-format", "UDRW", "-volname", volumeName, "-srcfolder", sourceFolder, "-ov", outputPath]
 }
 
 export function buildCompressedDmgArgs({ inputPath, outputPath }) {

--- a/apps/installer/scripts/installer-version.mjs
+++ b/apps/installer/scripts/installer-version.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Single source of truth for the version stamped into the installer artifacts.
+// CI resolves it from the release tag; local builds fall back to package.json so
+// a developer build never claims to be a release.
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+const versionPattern = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/
+
+export function versionFromReleaseTag(releaseTag) {
+  const candidate = (releaseTag ?? "").trim().replace(/^v/, "")
+  return versionPattern.test(candidate) ? candidate : ""
+}
+
+export function readPackageVersion() {
+  return JSON.parse(readFileSync(path.join(packageRoot, "package.json"), "utf8")).version
+}
+
+// Precedence: an explicit --version/env value, then the release tag, then the
+// committed package.json version.
+export function resolveInstallerVersion({ explicit, releaseTag, packageVersion } = {}) {
+  const explicitVersion = (explicit ?? "").trim()
+  if (explicitVersion) return explicitVersion
+  const tagVersion = versionFromReleaseTag(releaseTag)
+  if (tagVersion) return tagVersion
+  return (packageVersion ?? "").trim()
+}
+
+// Windows version resources are four numeric fields, so a semver prerelease
+// suffix has no representation there and only the numeric core is used.
+export function windowsFileVersion(version) {
+  const core = (version ?? "").trim().split(/[-+]/)[0]
+  return /^\d+\.\d+\.\d+$/.test(core) ? `${core}.0` : ""
+}
+
+function argValue(name) {
+  const inline = process.argv.find((entry) => entry.startsWith(`${name}=`))
+  if (inline) return inline.slice(name.length + 1).trim()
+  const index = process.argv.indexOf(name)
+  return index >= 0 ? process.argv[index + 1]?.trim() ?? "" : ""
+}
+
+export function installerVersionFromEnvironment() {
+  return resolveInstallerVersion({
+    explicit: argValue("--version") || process.env.OPENWORK_INSTALLER_VERSION,
+    releaseTag: argValue("--release-tag") || process.env.OPENWORK_INSTALLER_RELEASE_TAG,
+    packageVersion: readPackageVersion(),
+  })
+}
+
+// `node scripts/installer-version.mjs --release-tag v0.18.1` prints the version
+// the release workflow stamps into every installer artifact.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const version = installerVersionFromEnvironment()
+  if (!version) {
+    console.error("[installer-version] Could not resolve an installer version.")
+    process.exit(1)
+  }
+  console.log(process.argv.includes("--windows") ? windowsFileVersion(version) : version)
+}

--- a/apps/installer/scripts/package-mac-dmg.mjs
+++ b/apps/installer/scripts/package-mac-dmg.mjs
@@ -12,7 +12,9 @@ import {
   buildTiffutilArgs,
   dmgBackgroundPaths,
   dmgLayout,
+  dmgVolumeName,
 } from "./dmg-layout.mjs"
+import { installerVersionFromEnvironment } from "./installer-version.mjs"
 
 const appName = "Install OpenWork.app"
 const executableName = "openwork-installer"
@@ -46,7 +48,7 @@ function defaultInputPath() {
   return path.resolve("dist", executableName)
 }
 
-function writeInfoPlist(appPath) {
+function writeInfoPlist(appPath, version) {
   writeFileSync(path.join(appPath, "Contents", "Info.plist"), `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -57,8 +59,8 @@ function writeInfoPlist(appPath) {
   <key>CFBundleExecutable</key><string>${executableName}</string>
   <key>CFBundleIconFile</key><string>icon</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>1.0.0</string>
-  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleShortVersionString</key><string>${version}</string>
+  <key>CFBundleVersion</key><string>${version}</string>
   <key>LSMinimumSystemVersion</key><string>11.0</string>
   <key>NSHighResolutionCapable</key><true/>
 </dict>
@@ -75,7 +77,7 @@ function copyAppIcon(appPath) {
   cpSync(iconAssetPath, iconPath)
 }
 
-function stageInput(inputPath, stagedAppPath) {
+function stageInput(inputPath, stagedAppPath, version) {
   if (!existsSync(inputPath)) fail(`Input not found: ${inputPath}`)
   const inputStat = statSync(inputPath)
   if (inputStat.isDirectory()) {
@@ -83,7 +85,9 @@ function stageInput(inputPath, stagedAppPath) {
     execFileSync("ditto", [inputPath, stagedAppPath], { stdio: "inherit" })
     const stagedBinary = path.join(stagedAppPath, "Contents", "MacOS", executableName)
     if (!existsSync(stagedBinary)) fail(`App bundle is missing Contents/MacOS/${executableName}`)
-    if (!existsSync(path.join(stagedAppPath, "Contents", "Info.plist"))) writeInfoPlist(stagedAppPath)
+    // A staged .app arrives from CI already signed; rewriting its Info.plist
+    // would invalidate that signature, so only fill in a missing one.
+    if (!existsSync(path.join(stagedAppPath, "Contents", "Info.plist"))) writeInfoPlist(stagedAppPath, version)
     copyAppIcon(stagedAppPath)
     return
   }
@@ -93,7 +97,7 @@ function stageInput(inputPath, stagedAppPath) {
   mkdirSync(macOsDir, { recursive: true })
   cpSync(inputPath, path.join(macOsDir, executableName))
   chmodSync(path.join(macOsDir, executableName), 0o755)
-  writeInfoPlist(stagedAppPath)
+  writeInfoPlist(stagedAppPath, version)
   copyAppIcon(stagedAppPath)
 }
 
@@ -158,17 +162,20 @@ async function main() {
   const inputPath = path.resolve(argValue("--input") || defaultInputPath())
   const outDir = path.resolve(argValue("--out-dir") || "dist")
   const outputPath = path.resolve(argValue("--output") || path.join(outDir, `OpenWork-Installer-${arch}.dmg`))
+  const version = installerVersionFromEnvironment()
+  if (!version) fail("Could not resolve an installer version. Pass --version 0.18.1.")
+  const volumeName = dmgVolumeName(version)
   const stagingRoot = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-dmg-root-"))
   const imageRoot = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-dmg-image-"))
   const rwImagePath = path.join(imageRoot, "OpenWork-Installer.readwrite.dmg")
-  const mountPoint = path.join(imageRoot, dmgLayout.volumeName)
+  const mountPoint = path.join(imageRoot, volumeName)
   let attached = false
 
   try {
     mkdirSync(path.dirname(outputPath), { recursive: true })
-    stageInput(inputPath, path.join(stagingRoot, appName))
+    stageInput(inputPath, path.join(stagingRoot, appName), version)
     stageDmgBackground(stagingRoot)
-    execFileSync("hdiutil", buildReadWriteDmgArgs({ sourceFolder: stagingRoot, outputPath: rwImagePath }), { stdio: "inherit" })
+    execFileSync("hdiutil", buildReadWriteDmgArgs({ sourceFolder: stagingRoot, outputPath: rwImagePath, volumeName }), { stdio: "inherit" })
     attachReadWriteDmg(rwImagePath, mountPoint)
     attached = true
     applyFinderLayout(mountPoint)
@@ -176,7 +183,7 @@ async function main() {
     detachDmg(mountPoint)
     attached = false
     execFileSync("hdiutil", buildCompressedDmgArgs({ inputPath: rwImagePath, outputPath }), { stdio: "inherit" })
-    console.log(`[package-mac-dmg] Wrote ${outputPath}`)
+    console.log(`[package-mac-dmg] Wrote ${outputPath} (version ${version})`)
   } finally {
     if (attached) detachDmg(mountPoint)
     rmSync(stagingRoot, { recursive: true, force: true })

--- a/apps/installer/src/index.ts
+++ b/apps/installer/src/index.ts
@@ -5,9 +5,15 @@ import { runInstall, scheduleInstallerSelfCleanup } from "./install"
 import { openExternalUrl } from "./open-external-url"
 import { startInstallerServer } from "./server"
 import { loadSystemCaCertificates } from "./system-ca"
+import { INSTALLER_VERSION } from "./version"
 
 const rawArgs = Bun.argv.slice(2)
 const args = new Set(rawArgs)
+
+if (args.has("--version")) {
+  console.log(`openwork-installer ${INSTALLER_VERSION}`)
+  process.exit(0)
+}
 const headless = args.has("--headless") || process.env.OPENWORK_INSTALLER_HEADLESS === "1"
 const dryRun = args.has("--dry-run") || process.env.OPENWORK_INSTALLER_DRY_RUN === "1"
 const smokeExitMs = Number.parseInt(process.env.OPENWORK_INSTALLER_SMOKE_EXIT_MS ?? "", 10)

--- a/apps/installer/src/ui-html.ts
+++ b/apps/installer/src/ui-html.ts
@@ -1,5 +1,6 @@
 import { installerConfigSourceLabel, type InstallerConfigResolution } from "./config"
 import { OPENWORK_LOGO_SVG } from "./openwork-logo"
+import { INSTALLER_VERSION } from "./version"
 
 function escapeHtml(value: string): string {
   return value.replace(/[&<>"']/g, (char) => {
@@ -109,12 +110,15 @@ export function renderInstallerHtml(resolution: InstallerConfigResolution | null
   .activation-copy, .activation-expiry { color: #71717a; font-size: 11px; line-height: 1.4; }
   #activation-link { background: #ffffff; color: #52525b; font-size: 10px; }
   #copy-activation, #retry-activation { padding-left: 12px; padding-right: 12px; }
+  /* Pinned to the window edge so identifying the build never shifts the primary action. */
+  .version { position: fixed; bottom: 6px; left: 0; right: 0; text-align: center; font-size: 10px; color: #c8c8cc; }
 </style>
 </head>
 <body>
 <main>
 ${configuredContent}
 </main>
+<div class="version">Installer ${escapeHtml(INSTALLER_VERSION)}</div>
 <script>
   const TOKEN = ${JSON.stringify(token)};
   const CONFIGURED = ${config ? "true" : "false"};

--- a/apps/installer/src/version.ts
+++ b/apps/installer/src/version.ts
@@ -1,0 +1,5 @@
+// Release builds are stamped by the release workflow (--define); running from
+// source or compiling locally falls back to the committed package version.
+import packageJson from "../package.json"
+
+export const INSTALLER_VERSION = process.env.OPENWORK_INSTALLER_VERSION?.trim() || packageJson.version

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -14,8 +14,10 @@ import {
   buildTiffutilArgs,
   dmgBackgroundPaths,
   dmgLayout,
+  dmgVolumeName,
   dmgWindowBounds,
 } from "../scripts/dmg-layout.mjs"
+import { resolveInstallerVersion, versionFromReleaseTag, windowsFileVersion } from "../scripts/installer-version.mjs"
 import { desktopBootstrapPath, legacyDesktopBootstrapPath } from "../src/bootstrap-path"
 import { buildConstantsConfig, parseInstallLinkInput, resolveInstallLinkConfig, resolveInstallerConfig } from "../src/config"
 import { removableInstallerBundlePath, windowsInstalledExePath, writeBootstrapConfig } from "../src/install"
@@ -32,6 +34,8 @@ import {
   summarizeSystemCaSources,
   type SystemCaLoaders,
 } from "../src/system-ca"
+import { renderInstallerHtml } from "../src/ui-html"
+import { INSTALLER_VERSION } from "../src/version"
 
 type SelfSignedCertificate = {
   cert: string
@@ -148,6 +152,49 @@ describe("mac DMG layout helpers", () => {
 
   test("escapes AppleScript strings", () => {
     expect(appleScriptString('/tmp/Install "OpenWork"/back\\ground.tiff')).toBe('/tmp/Install \\"OpenWork\\"/back\\\\ground.tiff')
+  })
+
+  test("names the mounted volume after the build being installed", () => {
+    expect(dmgVolumeName("0.18.1")).toBe("Install OpenWork 0.18.1")
+    expect(dmgVolumeName("")).toBe("Install OpenWork")
+    expect(buildReadWriteDmgArgs({ sourceFolder: "/tmp/root", outputPath: "/tmp/openwork.rw.dmg", volumeName: "Install OpenWork 0.18.1" })).toContain(
+      "Install OpenWork 0.18.1",
+    )
+  })
+})
+
+describe("installer version resolution", () => {
+  test("reads the version out of a release tag", () => {
+    expect(versionFromReleaseTag("v0.18.1")).toBe("0.18.1")
+    expect(versionFromReleaseTag("0.18.1")).toBe("0.18.1")
+    expect(versionFromReleaseTag(" v1.2.3-rc.1 ")).toBe("1.2.3-rc.1")
+  })
+
+  test("ignores tags that are not releases", () => {
+    expect(versionFromReleaseTag("installer-release-e2e-abc123")).toBe("")
+    expect(versionFromReleaseTag("v0.18")).toBe("")
+    expect(versionFromReleaseTag("")).toBe("")
+    expect(versionFromReleaseTag(undefined)).toBe("")
+  })
+
+  test("prefers an explicit version, then the release tag, then package.json", () => {
+    expect(resolveInstallerVersion({ explicit: "9.9.9", releaseTag: "v0.18.1", packageVersion: "0.1.0" })).toBe("9.9.9")
+    expect(resolveInstallerVersion({ releaseTag: "v0.18.1", packageVersion: "0.1.0" })).toBe("0.18.1")
+    expect(resolveInstallerVersion({ releaseTag: "not-a-release", packageVersion: "0.1.0" })).toBe("0.1.0")
+    expect(resolveInstallerVersion({})).toBe("")
+  })
+
+  test("reduces a version to a four-field Windows resource", () => {
+    expect(windowsFileVersion("0.18.1")).toBe("0.18.1.0")
+    expect(windowsFileVersion("1.2.3-rc.1")).toBe("1.2.3.0")
+    expect(windowsFileVersion("nightly")).toBe("")
+  })
+
+  test("shows the build in the installer window without competing with the primary action", () => {
+    const html = renderInstallerHtml(null, "token")
+    expect(html).toContain(`<div class="version">Installer ${INSTALLER_VERSION}</div>`)
+    expect(html).toContain(".version { position: fixed;")
+    expect(INSTALLER_VERSION).toMatch(/^\d+\.\d+\.\d+/)
   })
 })
 


### PR DESCRIPTION
## Problem

The installer asset shipped in `v0.18.1` reports `1.0.0`, so nobody can tell which build a user has. Read from the release DMG a user already had mounted:

```
$ defaults read "/Volumes/Install OpenWork/Install OpenWork.app/Contents/Info.plist" CFBundleShortVersionString
1.0.0
$ defaults read "/Volumes/Install OpenWork/Install OpenWork.app/Contents/Info.plist" CFBundleVersion
1
```

Three separate causes: the mac `Info.plist` hardcoded `1.0.0`/`1` (in both `package-mac-dmg.mjs` and the copy inlined in the release workflow), the `.exe` carried no version resource, and `apps/installer/package.json` was stuck at `0.1.0` because the release bump script never touched it.

## What changed

- **`apps/installer/scripts/installer-version.mjs`** (new) — one place that resolves the version: explicit `--version`/`OPENWORK_INSTALLER_VERSION`, then the release tag (`v0.18.1` → `0.18.1`), then `apps/installer/package.json`. Also derives the four-field Windows resource version (`0.18.1` → `0.18.1.0`).
- **`apps/installer/src/version.ts`** (new) — runtime constant, stamped by the release build via `--define` and falling back to the committed package version.
- **`apps/installer/src/index.ts`** — `--version` prints `openwork-installer <version>` and exits.
- **`apps/installer/src/ui-html.ts`** — quiet footer pinned to the window bottom edge (`Installer 0.18.1`, 10px grey), so it never shifts or competes with the Install button.
- **`apps/installer/scripts/package-mac-dmg.mjs`** — real `CFBundleShortVersionString`/`CFBundleVersion`, and the mounted DMG volume is now `Install OpenWork 0.18.1`. A staged `.app` that already has an `Info.plist` (the CI path, already signed) is still left untouched.
- **`apps/installer/scripts/dmg-layout.mjs`** — `dmgVolumeName(version)`; `buildReadWriteDmgArgs` takes an optional `volumeName`.
- **`.github/workflows/release-generic-installer.yml`** — resolves `INSTALLER_VERSION` from `RELEASE_TAG`, stamps it into the compiled binary, the signed `Info.plist`, the DMG, and the Windows version resource, and fails the build if `--version` disagrees.
- **`apps/app/scripts/bump-version.mjs`** — bumps `apps/installer/package.json` with the rest of the release.

Asset filenames are untouched (`OpenWork-Installer-mac-arm64.dmg`, `-mac-x64.dmg`, `-win-x64.exe`), so den-api's `releases/latest/download/...` redirect keeps working. The `build-config.ts` generic-placeholder guard is untouched.

## Proof

```
$ cd apps/installer && bun test
 52 pass
 0 fail
 132 expect() calls

$ bun run compile && ./dist/openwork-installer --version
openwork-installer 0.18.1

$ node scripts/package-mac-dmg.mjs --arch arm64 --version 0.18.1
[package-mac-dmg] Wrote .../dist/OpenWork-Installer-arm64.dmg (version 0.18.1)

$ hdiutil attach dist/OpenWork-Installer-arm64.dmg -nobrowse -readonly
/dev/disk15s1  41504653-0000-11AA-AA11-0030654  /Volumes/Install OpenWork 0.18.1

$ plutil -p "/Volumes/Install OpenWork 0.18.1/Install OpenWork.app/Contents/Info.plist"
  "CFBundleShortVersionString" => "0.18.1"
  "CFBundleVersion" => "0.18.1"

$ "/Volumes/Install OpenWork 0.18.1/Install OpenWork.app/Contents/MacOS/openwork-installer" --version
openwork-installer 0.18.1
```

The CI stamping path, verified locally with the same command shape:

```
$ bun build --compile --minify --define 'process.env.OPENWORK_INSTALLER_VERSION="9.9.9-tagproof"' ... && ./dist/openwork-installer-tagproof --version
openwork-installer 9.9.9-tagproof
```

And the bump script really tracks the installer now:

```
$ node scripts/bump-version.mjs --set 0.18.99   # then reverted
 apps/installer/package.json | 2 +-
$ node -p "require('./apps/installer/package.json').version"
0.18.99
```

## Windows

Done with Bun's existing flags, no new tooling: `--windows-version`, `--windows-title`, `--windows-publisher`, `--windows-description` alongside the `--windows-icon` already in use. Those flags only work when compiling **on** Windows (bun errors out cross-compiling from macOS, exactly as it already does for `--windows-icon`), so the `windows-2022` job is the only place this can be observed. SignPath signing runs after compile and preserves the resource. A reviewer can confirm on the release run via the .exe's Properties → Details, or `(Get-Item OpenWork-Installer-win-x64.exe).VersionInfo`.

## Notes for the reviewer

- `pnpm lint` is broken repo-wide in den-web (`next lint` removed in Next 16) and was not run. `apps/installer` has no tsconfig/typecheck script; `bun test` and `bun build` exercise the touched TypeScript.
- Versioned filenames were deliberately not added. If we want them, the safe shape is dual assets: keep the stable name for the `latest/download` redirect and additionally upload `OpenWork-Installer-mac-arm64-0.18.1.dmg`, rather than renaming.
- `evals/flows/generic-installer-release-contract.flow.mjs` is already out of date with this workflow (it asserts `.zip` assets and a `publish-generic-installer` job name); pre-existing, untouched here.
