### PR TITLE
fix(shell): keep live status inside the account menu, not on the collapsed chip

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
@@ -147,25 +147,6 @@ function useOpenWorkModelsPromoVisible(hasOpenWorkModels: boolean) {
   return eligible && config.cloudSignin && !hasOpenWorkModels && !hidden;
 }
 
-/** Status row inside the trigger: one dot plus one truncating label. */
-function TriggerStatusRow(props: {
-  variant: StatusDotVariant;
-  label: string;
-  title: string;
-  testId?: string;
-}) {
-  return (
-    <span
-      data-testid={props.testId}
-      title={props.title}
-      className="flex min-w-0 items-center gap-1.5 text-[10.5px] leading-tight text-muted-foreground"
-    >
-      <StatusDot variant={props.variant} />
-      <span className="truncate">{props.label}</span>
-    </span>
-  );
-}
-
 export type AccountStatusMenuProps = {
   clientConnected: boolean;
   openworkServerStatus: OpenworkServerStatus;
@@ -297,10 +278,16 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
             ref={triggerRef}
             type="button"
             data-testid="account-status-menu"
-            className="flex w-full flex-col gap-1.5 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent"
+            data-runtime-state={runtimeStatus?.variant}
+            data-connect-state={connectStatus?.state}
+            className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent"
             aria-label={signedIn ? `${user.email} — account and status` : "Account and status"}
+            title={connectNeedsAttention
+              ? openWorkConnectAttentionTitle(connectStatus.description)
+              : connectStatus
+                ? `${runtimeStatus ? `${runtimeStatus.label} · ` : ""}OpenWork Connect: ${connectStatus.label}`
+                : runtimeStatus?.label}
           >
-            <span className="flex w-full items-center gap-2">
               {signedIn ? (
                 <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[10px] font-semibold text-primary">
                   {accountInitials(user.name, user.email)}
@@ -324,28 +311,6 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
                 </span>
               ) : null}
               <MoreHorizontal size={14} className="shrink-0 text-muted-foreground" />
-            </span>
-            {showStatus ? (
-              <span className="flex w-full flex-col gap-1 pl-0.5 group-data-[collapsible=icon]:hidden">
-                {runtimeStatus ? (
-                  <TriggerStatusRow
-                    variant={runtimeStatus.variant}
-                    label={runtimeStatus.label}
-                    title={runtimeStatus.detail ?? runtimeStatus.label}
-                  />
-                ) : null}
-                {connectStatus ? (
-                  <TriggerStatusRow
-                    testId="openwork-connect-status"
-                    variant={connectDotVariant(connectStatus)}
-                    label={`OpenWork Connect: ${connectStatus.label}`}
-                    title={connectNeedsAttention
-                      ? openWorkConnectAttentionTitle(connectStatus.description)
-                      : connectStatus.description}
-                  />
-                ) : null}
-              </span>
-            ) : null}
           </button>
         }
       />
@@ -372,15 +337,13 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
               </div>
             ) : null}
             {connectStatus ? (
-              <div className="flex items-start gap-2">
+              <div data-testid="openwork-connect-status" className="flex items-start gap-2">
                 <span className="mt-1">
                   <StatusDot variant={connectDotVariant(connectStatus)} />
                 </span>
                 <div className="min-w-0">
                   <div className="text-[11.5px] font-medium text-foreground">
-                    {connectNeedsAttention
-                      ? "OpenWork Connect needs attention"
-                      : `OpenWork Connect: ${connectStatus.label}`}
+                    {`OpenWork Connect: ${connectStatus.label}`}
                   </div>
                   <div className="text-[10.5px] leading-tight text-muted-foreground">
                     {connectStatus.description}

--- a/evals/flows/openwork-connect-status.flow.mjs
+++ b/evals/flows/openwork-connect-status.flow.mjs
@@ -109,14 +109,51 @@ async function waitForTranscriptIncrease(ctx, before) {
   throw new Error(`Transcript did not grow beyond ${before}.`);
 }
 
-async function waitForConnectReady(ctx) {
-  const deadline = Date.now() + 90_000;
+const ACCOUNT_MENU = '[data-testid="account-status-menu"]';
+const CONNECT_ROW = '[data-testid="openwork-connect-status"]';
+
+/** Live status lives inside the sidebar account menu, so frames open it first. */
+async function openAccountMenu(ctx) {
+  await ctx.eval(`(() => {
+    const trigger = document.querySelector('${ACCOUNT_MENU}');
+    if (trigger && trigger.getAttribute("aria-expanded") !== "true") trigger.click();
+    return true;
+  })()`);
+  await ctx.waitFor(`Boolean(document.querySelector('${CONNECT_ROW}') || document.body.innerText.includes("Ready for new tasks"))`, {
+    timeoutMs: 10_000,
+    label: "account status menu open",
+  });
+}
+
+async function closeAccountMenu(ctx) {
+  await ctx.eval(`(() => {
+    const trigger = document.querySelector('${ACCOUNT_MENU}');
+    if (trigger && trigger.getAttribute("aria-expanded") === "true") trigger.click();
+    return true;
+  })()`);
+  await ctx.waitFor(`!document.querySelector('${CONNECT_ROW}')`, {
+    timeoutMs: 10_000,
+    label: "account status menu closed",
+  });
+}
+
+/** The trigger mirrors the lifecycle state so polling never needs the menu open. */
+async function connectState(ctx) {
+  return ctx.eval(`document.querySelector('${ACCOUNT_MENU}')?.dataset.connectState ?? ""`);
+}
+
+async function waitForConnectState(ctx, expected, timeoutMs = 90_000) {
+  const deadline = Date.now() + timeoutMs;
   while (Date.now() < deadline) {
-    if (await ctx.hasText("OpenWork Connect: Ready")) return;
+    if (await connectState(ctx) === expected) return;
     await ctx.eval("window.dispatchEvent(new Event('focus'))");
-    await new Promise((resolve) => setTimeout(resolve, 3_000));
+    await new Promise((resolve) => setTimeout(resolve, 2_000));
   }
-  throw new Error("OpenWork Connect did not become ready after background retries.");
+  throw new Error(`OpenWork Connect did not reach "${expected}" after background retries.`);
+}
+
+async function waitForConnectReady(ctx) {
+  await waitForConnectState(ctx, "ready");
 }
 
 async function beginSavedSessionRestore(ctx) {
@@ -236,6 +273,7 @@ export default {
           voiceover: vo[0],
           action: async () => {
             await beginSavedSessionRestore(ctx);
+            await openAccountMenu(ctx);
             await ctx.waitForText("OpenWork Connect: Checking", { timeoutMs: 10_000 });
           },
           assert: async () => {
@@ -257,6 +295,7 @@ export default {
         await ctx.prove("The shared background lifecycle leaves normal message submission unblocked", {
           voiceover: vo[1],
           action: async () => {
+            await closeAccountMenu(ctx);
             await ctx.control("composer.set_text", { text: PROMPT });
             const clicked = await ctx.eval(`(() => {
               const button = [...document.querySelectorAll("button")].find((entry) => entry.title === "Run task");
@@ -277,6 +316,7 @@ export default {
               ctx.assert(retried, "Could not resubmit after the first-task model choice.");
             }
             state.transcriptCount = await waitForTranscriptIncrease(ctx, state.transcriptCount);
+            await openAccountMenu(ctx);
           },
           assert: async () => {
             witness(ctx, state.transcriptCount > 0, "The message entered the transcript while Connect restoration remained pending.", { transcriptCount: state.transcriptCount });
@@ -298,8 +338,10 @@ export default {
         await ctx.prove("Successful reconciliation changes OpenWork Connect to Ready", {
           voiceover: vo[2],
           action: async () => {
+            await closeAccountMenu(ctx);
             await authDelay(ctx, "release");
             await waitForConnectReady(ctx);
+            await openAccountMenu(ctx);
           },
           assert: async () => {
             ctx.expectNoText("OpenWork Connect: Needs attention");
@@ -319,24 +361,20 @@ export default {
         await ctx.prove("A persistent lifecycle failure turns the status red and offers diagnostics", {
           voiceover: vo[3],
           action: async () => {
+            await closeAccountMenu(ctx);
             await installHealthFailureProbe(ctx);
-            const deadline = Date.now() + 45_000;
-            while (Date.now() < deadline && !(await ctx.hasText("OpenWork Connect: Needs attention"))) {
-              await ctx.eval("window.dispatchEvent(new Event('focus'))");
-              await new Promise((resolve) => setTimeout(resolve, 1_000));
-            }
-            ctx.assert(await ctx.hasText("OpenWork Connect: Needs attention"), "OpenWork Connect did not reach Needs attention after bounded retries.");
-            await ctx.clickText("OpenWork Connect: Needs attention", { selector: "button", timeoutMs: 5_000 });
+            await waitForConnectState(ctx, "needs_attention", 45_000);
+            await openAccountMenu(ctx);
             await ctx.waitForText("Run diagnostics", { timeoutMs: 5_000 });
           },
           assert: async () => {
-            const red = await ctx.eval(`Boolean(document.querySelector('[data-testid="openwork-connect-status"] .bg-red-9'))`);
+            const red = await ctx.eval(`Boolean(document.querySelector('${CONNECT_ROW} .bg-red-9'))`);
             witness(ctx, red, "The failed OpenWork Connect status uses the red error indicator.", { red });
           },
           screenshot: {
             name: "openwork-connect-needs-attention",
             claim: "The failed status is red and explains how to run diagnostics.",
-            requireText: ["OpenWork Connect: Needs attention", "OpenWork Connect needs attention", "Run diagnostics"],
+            requireText: ["OpenWork Connect: Needs attention", "Run diagnostics"],
             hashIncludes: `/workspace/${state.workspaceId}/session/`,
           },
         });
@@ -348,6 +386,7 @@ export default {
         await ctx.prove("The OpenWork Connect status is absent when the user is signed out", {
           voiceover: vo[4],
           action: async () => {
+            await closeAccountMenu(ctx);
             await restoreHealthProbe(ctx);
             await ctx.eval(`(() => {
               const token = localStorage.getItem("openwork.den.authToken") || "";
@@ -358,6 +397,7 @@ export default {
             })()`);
             await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after sign-out" });
             await ctx.waitFor("!document.body.innerText.includes('OpenWork Connect:')", { timeoutMs: 15_000, label: "Connect status hidden" });
+            await openAccountMenu(ctx);
           },
           assert: async () => {
             ctx.expectNoText("OpenWork Connect:");


### PR DESCRIPTION
## Summary

Follow-up to #3096. The status lines were rendering on the sidebar footer chip itself; they should only appear once the account menu is expanded.

- The collapsed chip is now a single row: avatar, name, email, `…`. Footer height drops from 83px to 55px.
- `Ready for new tasks` and `OpenWork Connect: <state>` live only inside the menu.
- Two things stay on the collapsed chip so an unexpanded sidebar can still surface a problem: a small red dot when Connect needs attention, and a `title` tooltip carrying the runtime and Connect summary (the attention description when unhealthy).
- The trigger now exposes `data-runtime-state` and `data-connect-state` so automation can poll the lifecycle without opening the menu.

## Evidence

### Screenshots

Collapsed — no status text:

![Collapsed account chip](https://litter.catbox.moe/j280va.png)

Expanded, signed in with Connect failing — status block, `Run diagnostics`, and the red dot on the chip behind it:

![Expanded account menu](https://litter.catbox.moe/hnirxc.png)

### Build verification

- `pnpm typecheck` — passed
- `pnpm --filter @openwork/app build` — passed
- `bun test --isolate tests/` (apps/app) — 423 pass, 0 fail
- `node --check evals/flows/openwork-connect-status.flow.mjs` — passed

### UI verification

Driven over CDP against an isolated Electron dev instance built from this branch.

- Collapsed footer text is exactly `Sign in / Sync with OpenWork Cloud`; `data-runtime-state="connected"`.
- With a signed-in failing state stubbed in (reverted before committing): `data-connect-state="needs_attention"`, the chip `title` reads `One possible issue: OpenWork Connect could not verify connected service tools…`, the menu row reads `OpenWork Connect: Needs attention` plus its description, `[data-testid="openwork-connect-status"] .bg-red-9` resolves, and `Run diagnostics` is present.
- Console errors: none observed.

## Eval flow update

`evals/flows/openwork-connect-status.flow.mjs` asserted on status text that was previously always on screen, so it needed real changes rather than a rename:

- Added `openAccountMenu` / `closeAccountMenu` helpers; each frame opens the menu before asserting and closes it before interacting with the composer.
- `waitForConnectReady` now polls `data-connect-state` on the trigger instead of scraping page text, so waiting never depends on the menu being open.
- Frame 4 opens the menu instead of clicking the status text, and its `requireText` drops `OpenWork Connect needs attention` — the menu now shows the single, non-redundant `OpenWork Connect: Needs attention` line plus the description.
- `[data-testid="openwork-connect-status"]` moved onto the menu's Connect row, so the `.bg-red-9` assertion still resolves.

I have not executed this flow — it needs the local Den eval stack (`OPENWORK_EVAL_DEN_API_URL`). The edits are consistent with the DOM I verified by hand over CDP, but they are unproven end-to-end.

## Test instructions

1. `pnpm dev` in `_repos/openwork`
2. Bottom-left sidebar: the account row shows only your name and email; hover it for the status summary.
3. Click it — the menu shows `Ready for new tasks`, `OpenWork Connect: <state>` with its description, the provider/MCP counts, then Settings / Docs / Feedback / Log out.

Made with [Cursor](https://cursor.com)