### PR TITLE
fix(den): preserve admin capability arguments

### DIFF
--- a/ee/apps/den-api/src/mcp/admin-capabilities.ts
+++ b/ee/apps/den-api/src/mcp/admin-capabilities.ts
@@ -4,8 +4,11 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
 import type { CapabilityMatch } from "./search.js"
 import { scoreText, tokenize } from "./search.js"
 import { DEN_ADMIN_MCP_VERSION, registerAdminMcpTools } from "./admin-tools.js"
+import { normalizeToolRecord } from "./invoke.js"
 
 export const ADMIN_CAPABILITY_PREFIX = "admin:"
+
+const ADMIN_ARGUMENT_INVOCATION: NonNullable<CapabilityMatch["invocation"]> = { argumentsField: "body" }
 
 type AdminToolResult = {
   isError?: boolean
@@ -40,21 +43,25 @@ export async function searchAdminCapabilities(query: string, limit = 5): Promise
   const { tools } = await withAdminClient((client) => client.listTools())
 
   return tools
-    .map((tool) => ({
-      name: `${ADMIN_CAPABILITY_PREFIX}${tool.name}`,
-      method: "MCP",
-      path: "/mcp/admin",
-      score: scoreText(
-        tokenize(tool.name),
-        tokenize(tool.description ?? ""),
-        queryTokens,
-        ["admin", "platform"],
-      ),
-      summary: `[OpenWork Admin] ${tool.description ?? tool.name}`,
-      pathParams: [],
-      queryParams: [],
-      hasBody: Object.keys(tool.inputSchema.properties ?? {}).length > 0,
-    }))
+    .map((tool) => {
+      const hasBody = Object.keys(tool.inputSchema.properties ?? {}).length > 0
+      return {
+        name: `${ADMIN_CAPABILITY_PREFIX}${tool.name}`,
+        method: "MCP",
+        path: "/mcp/admin",
+        score: scoreText(
+          tokenize(tool.name),
+          tokenize(tool.description ?? ""),
+          queryTokens,
+          ["admin", "platform"],
+        ),
+        summary: `[OpenWork Admin] ${tool.description ?? tool.name}`,
+        pathParams: [],
+        queryParams: [],
+        hasBody,
+        ...(hasBody ? { argumentsSchema: tool.inputSchema, invocation: ADMIN_ARGUMENT_INVOCATION } : {}),
+      }
+    })
     .filter((match) => match.score > 0)
     .sort((a, b) => (b.score - a.score) || a.name.localeCompare(b.name))
     .slice(0, boundedLimit)
@@ -66,11 +73,6 @@ export async function searchAvailableAdminCapabilities(
   limit = 5,
 ): Promise<CapabilityMatch[]> {
   return platformAdmin ? searchAdminCapabilities(query, limit) : []
-}
-
-function normalizeArguments(body: unknown): Record<string, unknown> {
-  if (typeof body !== "object" || body === null || Array.isArray(body)) return {}
-  return Object.fromEntries(Object.entries(body))
 }
 
 function isTextContent(value: unknown): value is { type: "text"; text: string } {
@@ -98,7 +100,7 @@ export async function executeAdminCapability(name: string, body: unknown): Promi
   if (!toolName) return null
 
   return withAdminClient(async (client) => {
-    const result = await client.callTool({ name: toolName, arguments: normalizeArguments(body) })
+    const result = await client.callTool({ name: toolName, arguments: normalizeToolRecord(body) ?? {} })
     const content = resultTextContent(result)
     return {
       ...(resultIsError(result) ? { isError: true } : {}),

--- a/ee/apps/den-api/src/mcp/search.ts
+++ b/ee/apps/den-api/src/mcp/search.ts
@@ -33,6 +33,10 @@ export type CapabilityMatch = {
   hasBody: boolean
   /** Exact OpenAPI JSON schema for `body`, present only for JSON mutations. */
   bodySchema?: unknown
+  /** Exact MCP arguments schema returned by a live MCP tool list. */
+  argumentsSchema?: unknown
+  /** Tells generic execute callers where MCP arguments must be supplied. */
+  invocation?: { argumentsField: "body" }
 }
 
 export function compareCapabilityMatches(a: CapabilityMatch, b: CapabilityMatch): number {

--- a/ee/apps/den-api/test/admin-capabilities.test.ts
+++ b/ee/apps/den-api/test/admin-capabilities.test.ts
@@ -1,0 +1,78 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+}
+
+type AdminToolResult = {
+  isError?: boolean
+  content: { type: "text"; text: string }[]
+}
+
+let adminCapabilities: typeof import("../src/mcp/admin-capabilities.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  adminCapabilities = await import("../src/mcp/admin-capabilities.js")
+})
+
+function contentText(result: AdminToolResult | null) {
+  if (result === null) {
+    throw new Error("Expected admin capability result")
+  }
+  return result.content.map((entry) => entry.text).join("\n")
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+describe("executeAdminCapability", () => {
+  test("forwards arguments when body is a plain object", async () => {
+    const result = await adminCapabilities.executeAdminCapability("admin:den_query", { sql: "DELETE FROM user" })
+
+    expect(result?.isError).toBe(true)
+    expect(contentText(result)).toContain("Only SELECT/WITH/SHOW/DESCRIBE/EXPLAIN statements are allowed")
+  })
+
+  test("forwards arguments when body is a JSON-encoded string", async () => {
+    const result = await adminCapabilities.executeAdminCapability("admin:den_query", JSON.stringify({ sql: "DELETE FROM user" }))
+
+    expect(result?.isError).toBe(true)
+    expect(contentText(result)).toContain("Only SELECT/WITH/SHOW/DESCRIBE/EXPLAIN statements are allowed")
+  })
+
+  test("treats non-object non-JSON bodies as empty arguments", async () => {
+    const result = await adminCapabilities.executeAdminCapability("admin:den_admin_version", "not json")
+
+    expect(result?.isError).toBeUndefined()
+    expect(contentText(result)).toContain('"name": "den-admin"')
+  })
+})
+
+describe("searchAdminCapabilities", () => {
+  test("exposes argumentsSchema for tools that take input", async () => {
+    const matches = await adminCapabilities.searchAdminCapabilities("den_query", 5)
+    const match = matches.find((candidate) => candidate.name === "admin:den_query")
+
+    expect(match).toBeDefined()
+    if (!match) {
+      throw new Error("Expected admin:den_query search match")
+    }
+
+    expect(match.hasBody).toBe(true)
+    if (!isRecord(match)) {
+      throw new Error("Expected admin:den_query match to be a record")
+    }
+
+    const argumentsSchema = match.argumentsSchema
+    if (!isRecord(argumentsSchema) || !isRecord(argumentsSchema.properties)) {
+      throw new Error("Expected admin:den_query to expose an object argumentsSchema")
+    }
+    expect(argumentsSchema.properties.sql).toMatchObject({ type: "string" })
+    expect(match.invocation).toEqual({ argumentsField: "body" })
+  })
+})


### PR DESCRIPTION
## Summary

Fixes admin MCP capability argument plumbing so `execute_capability` can call tools like `admin:den_query` with real input.

Reproduced error before the fix when executing `admin:den_query` with body `{"sql":"SELECT @@sql_mode"}` (and equivalently with the new regression's JSON-string body):

```text
MCP error -32602: Input validation error: Invalid arguments for tool den_query: [
  { "expected": "string", "code": "invalid_type", "path": ["sql"],
    "message": "Invalid input: expected string, received undefined" }
]
```

## Root cause / fix

- Defect A: `ee/apps/den-api/src/mcp/admin-capabilities.ts:98-104` now uses the existing `normalizeToolRecord(body) ?? {}` helper from `./invoke.js`; the removed local `normalizeArguments` helper previously returned `{}` for JSON-encoded string bodies, silently dropping every admin argument.
- Defect B: `ee/apps/den-api/src/mcp/admin-capabilities.ts:40-63` now emits `argumentsSchema: tool.inputSchema` and `invocation: { argumentsField: "body" }` for admin tools with input, matching the external-MCP convention. `ee/apps/den-api/src/mcp/search.ts:36-39` types those shared match fields.

No changes were made to `admin:den_query` behavior, SQL allowlisting, permission gating, or `admin-tools.ts`.

## Regression proof

Before fix (tests added, production code still unfixed):

```text
$ pnpm --filter @openwork-ee/den-api exec bun test test/admin-capabilities.test.ts
bun test v1.3.10 (30e609e0)

test/admin-capabilities.test.ts:
40 | 
41 |   test("forwards arguments when body is a JSON-encoded string", async () => {
42 |     const result = await adminCapabilities.executeAdminCapability("admin:den_query", JSON.stringify({ sql: "DELETE FROM user" }))
43 | 
44 |     expect(result?.isError).toBe(true)
45 |     expect(contentText(result)).toContain("Only SELECT/WITH/SHOW/DESCRIBE/EXPLAIN statements are allowed")
                                     ^
error: expect(received).toContain(expected)

Expected to contain: "Only SELECT/WITH/SHOW/DESCRIBE/EXPLAIN statements are allowed"
Received: "MCP error -32602: Input validation error: Invalid arguments for tool den_query: [\n  {\n    \"expected\": \"string\",\n    \"code\": \"invalid_type\",\n    \"path\": [\n      \"sql\"\n    ],\n    \"message\": \"Invalid input: expected string, received undefined\"\n  }\n]"

      at <anonymous> (/Users/benjaminshafii/openwork-enterprise/_repos/_worktrees/openwork-admin-capability-args/ee/apps/den-api/test/admin-capabilities.test.ts:45:33)
(fail) executeAdminCapability > forwards arguments when body is a JSON-encoded string [2.24ms]
68 |       throw new Error("Expected admin:den_query match to be a record")
69 |     }
70 | 
71 |     const argumentsSchema = match.argumentsSchema
72 |     if (!isRecord(argumentsSchema) || !isRecord(argumentsSchema.properties)) {
73 |       throw new Error("Expected admin:den_query to expose an object argumentsSchema")
                     ^
error: Expected admin:den_query to expose an object argumentsSchema
      at <anonymous> (/Users/benjaminshafii/openwork-enterprise/_repos/_worktrees/openwork-admin-capability-args/ee/apps/den-api/test/admin-capabilities.test.ts:73:17)
(fail) searchAdminCapabilities > exposes argumentsSchema for tools that take input [4.42ms]

 2 pass
 2 fail
 8 expect() calls
Ran 4 tests across 1 file. [147.00ms]
undefined
/Users/benjaminshafii/openwork-enterprise/_repos/_worktrees/openwork-admin-capability-args/ee/apps/den-api:
[ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL] Command failed with exit code 1: bun test test/admin-capabilities.test.ts
```

After fix:

```text
$ NO_COLOR=1 pnpm --filter @openwork-ee/den-api exec bun test test/admin-capabilities.test.ts
bun test v1.3.10 (30e609e0)

test/admin-capabilities.test.ts:
2026-07-25T11:44:43.546Z WARN [Better Auth]: Please ensure '/.well-known/oauth-authorization-server/api/auth' exists. Upon completion, clear with silenceWarnings.oauthAuthServerConfig.

 4 pass
 0 fail
 10 expect() calls
Ran 4 tests across 1 file. [457.00ms]
```

Affected tests:

```text
$ NO_COLOR=1 pnpm --filter @openwork-ee/den-api exec bun test test/admin-capabilities.test.ts test/admin-mcp.test.ts test/admin-mcp-routes.test.ts
bun test v1.3.10 (30e609e0)

test/admin-capabilities.test.ts:
2026-07-25T11:44:50.660Z WARN [Better Auth]: Please ensure '/.well-known/oauth-authorization-server/api/auth' exists. Upon completion, clear with silenceWarnings.oauthAuthServerConfig.

 19 pass
 0 fail
 49 expect() calls
Ran 19 tests across 3 files. [450.00ms]
```

Typecheck:

```text
$ pnpm --filter @openwork-ee/den-api exec tsc -p tsconfig.json --noEmit
# exited 0 with no output
```

Other commands run:

```text
$ pnpm --filter @openwork-ee/den-db build
# passed; needed because this fresh worktree had no den-db dist files for Bun's default workspace export resolution

$ pnpm --filter @openwork/email build
# passed; needed after importing invoke.ts because Bun resolves @openwork/email to dist in this local setup

$ git diff --check
# exited 0 with no output
```

No video/fraimz is included because this is an MCP argument-plumbing fix with no UI surface. The real end-to-end proof after deploy is `admin:den_query` accepting `{"sql": "..."}` through `execute_capability`.
