### PR TITLE
feat(den-web): guide invited members on their first dashboard load

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/member-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/member-dashboard-screen.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
 import {
   CheckCircle2,
   ChevronRight,
@@ -11,58 +10,16 @@ import {
   Users,
   type LucideIcon,
 } from "lucide-react";
-import { getErrorMessage, requestJson } from "../../_lib/den-flow";
 import { formatRoleLabel } from "../../_lib/den-org";
+import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
   formatProviderTimestamp,
-  getProviderEnvNames,
   useOrgLlmProviders,
 } from "./llm-provider-data";
 import { useMarketplaces } from "./marketplace-data";
-import { OrganizationDownloadCard } from "./organization-download-card";
+import { MemberOnboardingCard, useMemberOnboarding } from "./member-onboarding-card";
 import { getPluginPartsSummary, usePlugins } from "./plugin-data";
-
-type MemberInferenceStatus = {
-  enabled: boolean;
-  subscribed: boolean | null;
-  memberCount: number;
-};
-
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function parseInferenceStatus(payload: unknown): MemberInferenceStatus | null {
-  if (!isRecord(payload) || !isRecord(payload.inference)) {
-    return null;
-  }
-
-  const inference = payload.inference;
-  if (typeof inference.enabled !== "boolean") {
-    return null;
-  }
-
-  return {
-    enabled: inference.enabled,
-    subscribed: typeof inference.subscribed === "boolean" ? inference.subscribed : null,
-    memberCount: typeof inference.memberCount === "number" ? inference.memberCount : 0,
-  };
-}
-
-async function fetchInferenceStatus() {
-  const { response, payload } = await requestJson("/v1/inference", { method: "GET" }, 12000);
-  if (!response.ok) {
-    throw new Error(getErrorMessage(payload, `Failed to load OpenWork Models status (${response.status}).`));
-  }
-
-  const parsed = parseInferenceStatus(payload);
-  if (!parsed) {
-    throw new Error("OpenWork Models status response was incomplete.");
-  }
-
-  return parsed;
-}
 
 function getErrorText(error: unknown) {
   return error instanceof Error ? error.message : "Something went wrong.";
@@ -116,24 +73,15 @@ function ErrorNotice({ children }: { children: React.ReactNode }) {
   );
 }
 
-function EmptyList({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center text-[13px] text-gray-500">
-      {children}
-    </div>
-  );
-}
-
 export function MemberDashboardScreen() {
+  const { user } = useDenFlow();
   const { activeOrg, orgContext, orgId } = useOrgDashboard();
   const { llmProviders, busy: providersBusy, error: providersError } = useOrgLlmProviders(orgId, { scope: "usable" });
   const { data: marketplaces = [], isLoading: marketplacesLoading, error: marketplacesError } = useMarketplaces();
   const { data: plugins = [], isLoading: pluginsLoading, error: pluginsError } = usePlugins();
-  const { data: inference, isLoading: inferenceLoading, error: inferenceError } = useQuery({
-    enabled: Boolean(orgId),
-    queryKey: ["member-dashboard", "inference", orgId],
-    queryFn: fetchInferenceStatus,
-  });
+  const { ready, installed, dismissed, markInstalled, reopen, dismiss } = useMemberOnboarding(orgId);
+  const showOnboarding = ready && !dismissed;
+  const memberEmail = user?.email ?? "";
 
   const customProviders = llmProviders.filter((provider) => provider.source !== "openwork");
   const openWorkProviders = llmProviders.filter((provider) => provider.source === "openwork");
@@ -145,7 +93,15 @@ export function MemberDashboardScreen() {
   const currentMember = orgContext?.currentMember;
   const teamNames = orgContext?.currentMemberTeams.map((team) => team.name).sort((a, b) => a.localeCompare(b)) ?? [];
   const roleLabel = currentMember ? formatRoleLabel(currentMember.role) : "Member";
-  const inferenceLabel = inferenceLoading ? "Checking" : inference?.enabled ? "Enabled" : "Disabled";
+  const organizationName = activeOrg?.name ?? orgContext?.organization.name ?? "your workspace";
+  const installLinksEnabled = orgContext?.capabilities.installLinks === true;
+  const hasOpenWorkModels = openWorkProviders.length > 0;
+  const hasCustomProviders = customProviders.length > 0;
+  const hasMarketplaces = marketplaces.length > 0;
+  const hasPlugins = plugins.length > 0;
+  const hasResources = hasOpenWorkModels || hasCustomProviders || hasMarketplaces || hasPlugins;
+  const hasAnyResourceLoading = providersBusy || marketplacesLoading || pluginsLoading;
+  const hasResourceErrors = Boolean(providersError || marketplacesError || pluginsError);
 
   return (
     <div className="mx-auto max-w-[1100px] px-4 pb-10 pt-4 sm:px-6 md:px-8" data-testid="member-dashboard">
@@ -157,206 +113,240 @@ export function MemberDashboardScreen() {
         <span className="text-[14px] font-medium tracking-[-0.01em] text-[#5A6886]">Dashboard</span>
       </div>
 
-      <div className="mt-4 grid gap-3 md:grid-cols-[1fr_auto] md:items-end">
-        <div>
-          <h1 className="text-[22px] font-semibold tracking-[-0.03em] text-[#07192C]">Your workspace</h1>
-          <p className="mt-1 max-w-[680px] text-[14px] leading-6 text-[#5A6886]">
-            The models, marketplaces, and plugins available to you in OpenWork.
-          </p>
-        </div>
-        <div className="flex items-center gap-3 rounded-2xl border border-gray-100 bg-white px-4 py-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-gray-50 text-gray-500">
-            <Users className="h-4 w-4" aria-hidden="true" />
-          </div>
-          <div className="min-w-0">
-            <p className="text-[12px] text-gray-500">Signed in as {roleLabel}</p>
-            <p className="max-w-[320px] truncate text-[13px] font-medium text-gray-900">
-              {teamNames.length > 0 ? teamNames.join(", ") : "No team assignment"}
-            </p>
-          </div>
-        </div>
-      </div>
-
-      {activeOrg && orgContext?.capabilities.installLinks ? (
+      {showOnboarding && orgId ? (
         <div className="mt-5">
-          <OrganizationDownloadCard organizationId={activeOrg.id} organizationName={activeOrg.name} />
-        </div>
-      ) : null}
-
-      <section className="mt-5" aria-labelledby="member-resources-heading" data-testid="member-resource-overview">
-        <div className="mb-3">
-          <h2 id="member-resources-heading" className="text-[16px] font-semibold tracking-[-0.02em] text-gray-950">Available resources</h2>
-          <p className="mt-0.5 text-[13px] text-gray-500">Assigned directly to you, your teams, or everyone in the workspace.</p>
-        </div>
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-          <SummaryCard
-            icon={Sparkles}
-            title="OpenWork Models"
-            value={inferenceLabel}
-            detail={inference?.enabled ? `${openWorkProviders.length} model key group${openWorkProviders.length === 1 ? "" : "s"} visible to you.` : "Ask an admin to enable org-provided models."}
-            tone={inference?.enabled ? "emerald" : "amber"}
-          />
-          <SummaryCard
-            icon={Cpu}
-            title="Custom LLM Providers"
-            value={providersBusy ? "Loading" : `${customProviders.length}`}
-            detail="Provider credentials and models your role or teams can use."
-            tone="blue"
-          />
-          <SummaryCard
-            icon={Store}
-            title="Marketplaces"
-            value={marketplacesLoading ? "Loading" : `${marketplaces.length}`}
-            detail="Plugin collections assigned to you or everyone in your org."
-            tone="amber"
-          />
-          <SummaryCard
-            icon={Puzzle}
-            title="Plugins"
-            value={pluginsLoading ? "Loading" : `${plugins.length}`}
-            detail={`${visiblePluginParts} skill, hook, MCP, agent, or command parts available.`}
-            tone="violet"
+          <MemberOnboardingCard
+            organizationId={orgId}
+            organizationName={organizationName}
+            memberEmail={memberEmail}
+            installLinksEnabled={installLinksEnabled}
+            collapsed={false}
+            installed={installed}
+            onMarkInstalled={markInstalled}
+            onDismiss={dismiss}
+            onReopen={reopen}
           />
         </div>
-      </section>
-
-      <div className="mt-5 grid gap-5 lg:grid-cols-[1fr_1fr]">
-        <section className="rounded-2xl border border-gray-100 bg-white p-5">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">LLM providers</h2>
-              <p className="mt-1 text-[13px] text-gray-500">Custom providers you can use from OpenWork.</p>
+      ) : (
+        <>
+          {ready && orgId ? (
+            <div className="mt-5">
+              <MemberOnboardingCard
+                organizationId={orgId}
+                organizationName={organizationName}
+                memberEmail={memberEmail}
+                installLinksEnabled={installLinksEnabled}
+                collapsed
+                installed={installed}
+                onMarkInstalled={markInstalled}
+                onDismiss={dismiss}
+                onReopen={reopen}
+              />
             </div>
-            <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-              {customProviders.length} available
-            </span>
-          </div>
+          ) : null}
 
-          <div className="mt-5 grid gap-3">
-            {providersError ? <ErrorNotice>{providersError}</ErrorNotice> : null}
-            {providersBusy ? (
-              <EmptyList>Loading providers...</EmptyList>
-            ) : customProviders.length === 0 ? (
-              <EmptyList>No custom providers are available to you yet.</EmptyList>
-            ) : (
-              customProviders.slice(0, 5).map((provider) => {
-                const envNames = getProviderEnvNames(provider.providerConfig);
-                return (
-                  <div key={provider.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate text-[14px] font-semibold text-gray-950">{provider.name}</p>
-                        <p className="mt-1 text-[12px] text-gray-500">{provider.models.length} model{provider.models.length === 1 ? "" : "s"}</p>
-                      </div>
-                      <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] text-gray-500">
-                        {provider.source === "custom" ? "Custom" : "Catalog"}
-                      </span>
-                    </div>
-                    <p className="mt-3 text-[12px] text-gray-500">
-                      {envNames.length > 0 ? envNames.slice(0, 3).join(", ") : "No environment keys listed"} - Updated {formatProviderTimestamp(provider.updatedAt)}
-                    </p>
-                  </div>
-                );
-              })
-            )}
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-gray-100 bg-white p-5">
-          <div className="flex items-center justify-between gap-4">
+          <div className="mt-4 grid gap-3 md:grid-cols-[1fr_auto] md:items-end">
             <div>
-              <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">OpenWork Models</h2>
-              <p className="mt-1 text-[13px] text-gray-500">Org-provided inference status.</p>
+              <h1 className="text-[22px] font-semibold tracking-[-0.03em] text-[#07192C]">Your workspace</h1>
+              <p className="mt-1 max-w-[680px] text-[14px] leading-6 text-[#5A6886]">
+                The models, marketplaces, and plugins available to you in OpenWork.
+              </p>
             </div>
-            <span className={`rounded-full px-3 py-1 text-[12px] font-medium ${inference?.enabled ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}>
-              {inferenceLabel}
-            </span>
-          </div>
-
-          <div className="mt-5 grid gap-3">
-            {inferenceError ? <ErrorNotice>{getErrorText(inferenceError)}</ErrorNotice> : null}
-            <div className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-4">
-              <div className="flex items-center gap-3">
-                <CheckCircle2 className={`h-5 w-5 ${inference?.enabled ? "text-emerald-600" : "text-gray-400"}`} aria-hidden="true" />
-                <div>
-                  <p className="text-[14px] font-semibold text-gray-950">
-                    {inference?.enabled ? "Enabled for this workspace" : "Not enabled for this workspace"}
-                  </p>
-                  <p className="mt-1 text-[12px] text-gray-500">
-                    {inference?.subscribed === false ? "The workspace needs an active subscription before members can use OpenWork Models." : `${inference?.memberCount ?? 0} member${inference?.memberCount === 1 ? "" : "s"} included in usage limits.`}
-                  </p>
-                </div>
+            <div className="flex items-center gap-3 rounded-2xl border border-gray-100 bg-white px-4 py-3">
+              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-gray-50 text-gray-500">
+                <Users className="h-4 w-4" aria-hidden="true" />
+              </div>
+              <div className="min-w-0">
+                <p className="text-[12px] text-gray-500">Signed in as {roleLabel}</p>
+                <p className="max-w-[320px] truncate text-[13px] font-medium text-gray-900">
+                  {teamNames.length > 0 ? teamNames.join(", ") : "No team assignment"}
+                </p>
               </div>
             </div>
           </div>
-        </section>
-      </div>
 
-      <div className="mt-5 grid gap-5 lg:grid-cols-[1fr_1fr]">
-        <section className="rounded-2xl border border-gray-100 bg-white p-5">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">Marketplaces</h2>
-              <p className="mt-1 text-[13px] text-gray-500">Marketplaces contain plugins and sync into the app after sign-in.</p>
+          {hasResourceErrors ? (
+            <div className="mt-5 grid gap-3">
+              {providersError ? <ErrorNotice>{providersError}</ErrorNotice> : null}
+              {marketplacesError ? <ErrorNotice>{getErrorText(marketplacesError)}</ErrorNotice> : null}
+              {pluginsError ? <ErrorNotice>{getErrorText(pluginsError)}</ErrorNotice> : null}
             </div>
-            <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-              {marketplaces.length} visible
-            </span>
-          </div>
+          ) : null}
 
-          <div className="mt-5 grid gap-3">
-            {marketplacesError ? <ErrorNotice>{getErrorText(marketplacesError)}</ErrorNotice> : null}
-            {marketplacesLoading ? (
-              <EmptyList>Loading marketplaces...</EmptyList>
-            ) : marketplaces.length === 0 ? (
-              <EmptyList>No marketplaces are available to you yet.</EmptyList>
-            ) : (
-              marketplaces.slice(0, 5).map((marketplace) => (
-                <div key={marketplace.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <p className="truncate text-[14px] font-semibold text-gray-950">{marketplace.name}</p>
-                      {marketplace.description ? <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-gray-500">{marketplace.description}</p> : null}
+          {hasResources ? (
+            <section className="mt-5" aria-labelledby="member-resources-heading" data-testid="member-resource-overview">
+              <div className="mb-3">
+                <h2 id="member-resources-heading" className="text-[16px] font-semibold tracking-[-0.02em] text-gray-950">Available resources</h2>
+                <p className="mt-0.5 text-[13px] text-gray-500">Assigned directly to you, your teams, or everyone in the workspace.</p>
+              </div>
+              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+                {hasOpenWorkModels ? (
+                  <SummaryCard
+                    icon={Sparkles}
+                    title="OpenWork Models"
+                    value={`${openWorkProviders.length}`}
+                    detail="Model key groups your workspace provides."
+                    tone="emerald"
+                  />
+                ) : null}
+                {hasCustomProviders ? (
+                  <SummaryCard
+                    icon={Cpu}
+                    title="Custom LLM Providers"
+                    value={`${customProviders.length}`}
+                    detail="Provider credentials and models your role or teams can use."
+                    tone="blue"
+                  />
+                ) : null}
+                {hasMarketplaces ? (
+                  <SummaryCard
+                    icon={Store}
+                    title="Marketplaces"
+                    value={`${marketplaces.length}`}
+                    detail="Plugin collections assigned to you or everyone in your org."
+                    tone="amber"
+                  />
+                ) : null}
+                {hasPlugins ? (
+                  <SummaryCard
+                    icon={Puzzle}
+                    title="Plugins"
+                    value={`${plugins.length}`}
+                    detail={`${visiblePluginParts} skill, hook, MCP, agent, or command parts available.`}
+                    tone="violet"
+                  />
+                ) : null}
+              </div>
+            </section>
+          ) : null}
+
+          {hasAnyResourceLoading && !hasResources ? (
+            <p className="mt-5 text-[13px] leading-5 text-gray-500">Loading your resources...</p>
+          ) : null}
+          {!hasAnyResourceLoading && !hasResources ? (
+            <p className="mt-5 text-[13px] leading-5 text-gray-500" data-testid="member-resources-empty">
+              Your team hasn&apos;t shared models, plugins, or marketplaces yet. You can still use OpenWork with your own setup.
+            </p>
+          ) : null}
+
+          {hasResources ? (
+            <div className="mt-5 grid gap-5 lg:grid-cols-2">
+              {hasCustomProviders ? (
+                <section className="rounded-2xl border border-gray-100 bg-white p-5">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">LLM providers</h2>
+                      <p className="mt-1 text-[13px] text-gray-500">Custom providers you can use from OpenWork.</p>
                     </div>
-                    <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] text-gray-500">
-                      {marketplace.pluginCount} plugin{marketplace.pluginCount === 1 ? "" : "s"}
+                    <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
+                      {customProviders.length} available
                     </span>
                   </div>
-                </div>
-              ))
-            )}
-          </div>
-        </section>
 
-        <section className="rounded-2xl border border-gray-100 bg-white p-5">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">Plugins</h2>
-              <p className="mt-1 text-[13px] text-gray-500">Skills, hooks, MCPs, agents, and commands you can use.</p>
+                  <div className="mt-5 grid gap-3">
+                    {customProviders.slice(0, 5).map((provider) => (
+                      <div key={provider.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="truncate text-[14px] font-semibold text-gray-950">{provider.name}</p>
+                            <p className="mt-1 text-[12px] text-gray-500">{provider.models.length} model{provider.models.length === 1 ? "" : "s"}</p>
+                          </div>
+                          <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] text-gray-500">
+                            {provider.source === "custom" ? "Custom" : "Catalog"}
+                          </span>
+                        </div>
+                        <p className="mt-3 text-[12px] text-gray-500">Updated {formatProviderTimestamp(provider.updatedAt)}</p>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
+              {hasOpenWorkModels ? (
+                <section className="rounded-2xl border border-gray-100 bg-white p-5">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">OpenWork Models</h2>
+                      <p className="mt-1 text-[13px] text-gray-500">Org-provided models you can use from OpenWork.</p>
+                    </div>
+                    <span className="rounded-full bg-emerald-50 px-3 py-1 text-[12px] font-medium text-emerald-700">
+                      Available
+                    </span>
+                  </div>
+
+                  <div className="mt-5 grid gap-3">
+                    <div className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-4">
+                      <div className="flex items-center gap-3">
+                        <CheckCircle2 className="h-5 w-5 text-emerald-600" aria-hidden="true" />
+                        <div>
+                          <p className="text-[14px] font-semibold text-gray-950">Available in this workspace</p>
+                          <p className="mt-1 text-[12px] text-gray-500">
+                            {openWorkProviders.length} model key group{openWorkProviders.length === 1 ? "" : "s"} you can use.
+                          </p>
+                        </div>
+                      </div>
+                    </div>
+                  </div>
+                </section>
+              ) : null}
+
+              {hasMarketplaces ? (
+                <section className="rounded-2xl border border-gray-100 bg-white p-5">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">Marketplaces</h2>
+                      <p className="mt-1 text-[13px] text-gray-500">Marketplaces contain plugins and sync into the app after sign-in.</p>
+                    </div>
+                    <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
+                      {marketplaces.length} visible
+                    </span>
+                  </div>
+
+                  <div className="mt-5 grid gap-3">
+                    {marketplaces.slice(0, 5).map((marketplace) => (
+                      <div key={marketplace.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
+                        <div className="flex items-start justify-between gap-3">
+                          <div className="min-w-0">
+                            <p className="truncate text-[14px] font-semibold text-gray-950">{marketplace.name}</p>
+                            {marketplace.description ? <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-gray-500">{marketplace.description}</p> : null}
+                          </div>
+                          <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] text-gray-500">
+                            {marketplace.pluginCount} plugin{marketplace.pluginCount === 1 ? "" : "s"}
+                          </span>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
+
+              {hasPlugins ? (
+                <section className="rounded-2xl border border-gray-100 bg-white p-5">
+                  <div className="flex items-center justify-between gap-4">
+                    <div>
+                      <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">Plugins</h2>
+                      <p className="mt-1 text-[13px] text-gray-500">Skills, hooks, MCPs, agents, and commands you can use.</p>
+                    </div>
+                    <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
+                      {plugins.length} visible
+                    </span>
+                  </div>
+
+                  <div className="mt-5 grid gap-3">
+                    {plugins.slice(0, 5).map((plugin) => (
+                      <div key={plugin.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
+                        <p className="truncate text-[14px] font-semibold text-gray-950">{plugin.name}</p>
+                        <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-gray-500">{plugin.description}</p>
+                        <p className="mt-3 text-[12px] text-gray-500">{getPluginPartsSummary(plugin)}</p>
+                      </div>
+                    ))}
+                  </div>
+                </section>
+              ) : null}
             </div>
-            <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-              {plugins.length} visible
-            </span>
-          </div>
-
-          <div className="mt-5 grid gap-3">
-            {pluginsError ? <ErrorNotice>{getErrorText(pluginsError)}</ErrorNotice> : null}
-            {pluginsLoading ? (
-              <EmptyList>Loading plugins...</EmptyList>
-            ) : plugins.length === 0 ? (
-              <EmptyList>No plugins are available to you yet.</EmptyList>
-            ) : (
-              plugins.slice(0, 5).map((plugin) => (
-                <div key={plugin.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
-                  <p className="truncate text-[14px] font-semibold text-gray-950">{plugin.name}</p>
-                  <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-gray-500">{plugin.description}</p>
-                  <p className="mt-3 text-[12px] text-gray-500">{getPluginPartsSummary(plugin)}</p>
-                </div>
-              ))
-            )}
-          </div>
-        </section>
-      </div>
+          ) : null}
+        </>
+      )}
     </div>
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/member-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/member-dashboard-screen.tsx
@@ -1,22 +1,10 @@
 "use client";
 
-import {
-  CheckCircle2,
-  ChevronRight,
-  Cpu,
-  Puzzle,
-  Sparkles,
-  Store,
-  Users,
-  type LucideIcon,
-} from "lucide-react";
+import { ChevronRight, Sparkles } from "lucide-react";
 import { formatRoleLabel } from "../../_lib/den-org";
 import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
-import {
-  formatProviderTimestamp,
-  useOrgLlmProviders,
-} from "./llm-provider-data";
+import { useOrgLlmProviders } from "./llm-provider-data";
 import { useMarketplaces } from "./marketplace-data";
 import { MemberOnboardingCard, useMemberOnboarding } from "./member-onboarding-card";
 import { getPluginPartsSummary, usePlugins } from "./plugin-data";
@@ -25,44 +13,13 @@ function getErrorText(error: unknown) {
   return error instanceof Error ? error.message : "Something went wrong.";
 }
 
-function SummaryCard({
-  icon: Icon,
-  title,
-  value,
-  detail,
-  tone,
-}: {
-  icon: LucideIcon;
-  title: string;
-  value: string;
-  detail: string;
-  tone: "blue" | "emerald" | "violet" | "amber";
-}) {
-  const toneClass = {
-    blue: "bg-blue-50 text-blue-700",
-    emerald: "bg-emerald-50 text-emerald-700",
-    violet: "bg-violet-50 text-violet-700",
-    amber: "bg-amber-50 text-amber-700",
-  }[tone];
+function cleanDescription(description: string): string {
+  const firstParagraph = description.split(/\n\s*\n/)[0].trim();
+  return firstParagraph.length > 0 ? firstParagraph : description.trim();
+}
 
-  return (
-    <section
-      className="rounded-2xl border border-gray-100 bg-white px-4 py-3.5"
-      data-resource={title}
-      data-testid="member-resource-card"
-    >
-      <div className="flex items-start gap-3">
-        <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] ${toneClass}`}>
-          <Icon className="h-5 w-5" aria-hidden="true" />
-        </div>
-        <div className="min-w-0">
-          <p className="text-[13px] font-medium text-gray-500">{title}</p>
-          <p className="mt-0.5 text-[20px] font-semibold tracking-[-0.03em] text-gray-950">{value}</p>
-          <p className="mt-0.5 text-[12px] leading-5 text-gray-500">{detail}</p>
-        </div>
-      </div>
-    </section>
-  );
+function getRoleArticle(roleLabel: string): "a" | "an" {
+  return /^[aeiou]/i.test(roleLabel) ? "an" : "a";
 }
 
 function ErrorNotice({ children }: { children: React.ReactNode }) {
@@ -85,23 +42,25 @@ export function MemberDashboardScreen() {
 
   const customProviders = llmProviders.filter((provider) => provider.source !== "openwork");
   const openWorkProviders = llmProviders.filter((provider) => provider.source === "openwork");
-  const visiblePluginParts = plugins.reduce(
-    (count, plugin) => count + plugin.skills.length + plugin.hooks.length + plugin.mcps.length + plugin.agents.length + plugin.commands.length,
-    0,
-  );
 
   const currentMember = orgContext?.currentMember;
   const teamNames = orgContext?.currentMemberTeams.map((team) => team.name).sort((a, b) => a.localeCompare(b)) ?? [];
   const roleLabel = currentMember ? formatRoleLabel(currentMember.role) : "Member";
+  const roleWord = roleLabel.toLowerCase();
   const organizationName = activeOrg?.name ?? orgContext?.organization.name ?? "your workspace";
   const installLinksEnabled = orgContext?.capabilities.installLinks === true;
   const hasOpenWorkModels = openWorkProviders.length > 0;
   const hasCustomProviders = customProviders.length > 0;
+  const hasModelResources = hasOpenWorkModels || hasCustomProviders;
   const hasMarketplaces = marketplaces.length > 0;
   const hasPlugins = plugins.length > 0;
-  const hasResources = hasOpenWorkModels || hasCustomProviders || hasMarketplaces || hasPlugins;
+  const hasResources = hasModelResources || hasMarketplaces || hasPlugins;
   const hasAnyResourceLoading = providersBusy || marketplacesLoading || pluginsLoading;
   const hasResourceErrors = Boolean(providersError || marketplacesError || pluginsError);
+  const modelSummaryParts = [
+    hasOpenWorkModels ? "OpenWork Models" : null,
+    hasCustomProviders ? `${customProviders.length} custom provider${customProviders.length === 1 ? "" : "s"}` : null,
+  ].filter((part): part is string => part !== null);
 
   return (
     <div className="mx-auto max-w-[1100px] px-4 pb-10 pt-4 sm:px-6 md:px-8" data-testid="member-dashboard">
@@ -145,24 +104,15 @@ export function MemberDashboardScreen() {
             </div>
           ) : null}
 
-          <div className="mt-4 grid gap-3 md:grid-cols-[1fr_auto] md:items-end">
-            <div>
-              <h1 className="text-[22px] font-semibold tracking-[-0.03em] text-[#07192C]">Your workspace</h1>
-              <p className="mt-1 max-w-[680px] text-[14px] leading-6 text-[#5A6886]">
-                The models, marketplaces, and plugins available to you in OpenWork.
-              </p>
-            </div>
-            <div className="flex items-center gap-3 rounded-2xl border border-gray-100 bg-white px-4 py-3">
-              <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-gray-50 text-gray-500">
-                <Users className="h-4 w-4" aria-hidden="true" />
-              </div>
-              <div className="min-w-0">
-                <p className="text-[12px] text-gray-500">Signed in as {roleLabel}</p>
-                <p className="max-w-[320px] truncate text-[13px] font-medium text-gray-900">
-                  {teamNames.length > 0 ? teamNames.join(", ") : "No team assignment"}
-                </p>
-              </div>
-            </div>
+          <div className="mt-4">
+            <h1 className="text-[22px] font-semibold tracking-[-0.03em] text-[#07192C]">Your workspace</h1>
+            <p className="mt-1 max-w-[680px] text-[14px] leading-6 text-[#5A6886]">
+              Everything your team set up for you — ready when you open the OpenWork desktop app.
+            </p>
+            <p className="mt-1 text-[13px] leading-5 text-[#5A6886]">
+              You&apos;re {getRoleArticle(roleWord)} {roleWord} of {organizationName}
+              {teamNames.length > 0 ? ` · ${teamNames.join(", ")}` : ""}
+            </p>
           </div>
 
           {hasResourceErrors ? (
@@ -171,53 +121,6 @@ export function MemberDashboardScreen() {
               {marketplacesError ? <ErrorNotice>{getErrorText(marketplacesError)}</ErrorNotice> : null}
               {pluginsError ? <ErrorNotice>{getErrorText(pluginsError)}</ErrorNotice> : null}
             </div>
-          ) : null}
-
-          {hasResources ? (
-            <section className="mt-5" aria-labelledby="member-resources-heading" data-testid="member-resource-overview">
-              <div className="mb-3">
-                <h2 id="member-resources-heading" className="text-[16px] font-semibold tracking-[-0.02em] text-gray-950">Available resources</h2>
-                <p className="mt-0.5 text-[13px] text-gray-500">Assigned directly to you, your teams, or everyone in the workspace.</p>
-              </div>
-              <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-                {hasOpenWorkModels ? (
-                  <SummaryCard
-                    icon={Sparkles}
-                    title="OpenWork Models"
-                    value={`${openWorkProviders.length}`}
-                    detail="Model key groups your workspace provides."
-                    tone="emerald"
-                  />
-                ) : null}
-                {hasCustomProviders ? (
-                  <SummaryCard
-                    icon={Cpu}
-                    title="Custom LLM Providers"
-                    value={`${customProviders.length}`}
-                    detail="Provider credentials and models your role or teams can use."
-                    tone="blue"
-                  />
-                ) : null}
-                {hasMarketplaces ? (
-                  <SummaryCard
-                    icon={Store}
-                    title="Marketplaces"
-                    value={`${marketplaces.length}`}
-                    detail="Plugin collections assigned to you or everyone in your org."
-                    tone="amber"
-                  />
-                ) : null}
-                {hasPlugins ? (
-                  <SummaryCard
-                    icon={Puzzle}
-                    title="Plugins"
-                    value={`${plugins.length}`}
-                    detail={`${visiblePluginParts} skill, hook, MCP, agent, or command parts available.`}
-                    tone="violet"
-                  />
-                ) : null}
-              </div>
-            </section>
           ) : null}
 
           {hasAnyResourceLoading && !hasResources ? (
@@ -230,118 +133,49 @@ export function MemberDashboardScreen() {
           ) : null}
 
           {hasResources ? (
-            <div className="mt-5 grid gap-5 lg:grid-cols-2">
-              {hasCustomProviders ? (
-                <section className="rounded-2xl border border-gray-100 bg-white p-5">
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">LLM providers</h2>
-                      <p className="mt-1 text-[13px] text-gray-500">Custom providers you can use from OpenWork.</p>
+            <div className="mt-5 space-y-5" data-testid="member-resource-overview">
+              {hasModelResources ? (
+                <section
+                  className="flex items-center justify-between gap-4 rounded-2xl border border-gray-100 bg-white px-4 py-3"
+                  data-testid="member-models-summary"
+                >
+                  <div className="flex min-w-0 items-center gap-3">
+                    <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-[#f4f7fb] text-[#07192C]">
+                      <Sparkles className="h-4 w-4" aria-hidden="true" />
                     </div>
-                    <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-                      {customProviders.length} available
-                    </span>
+                    <p className="text-[14px] font-semibold text-[#07192C]">AI models</p>
                   </div>
-
-                  <div className="mt-5 grid gap-3">
-                    {customProviders.slice(0, 5).map((provider) => (
-                      <div key={provider.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <p className="truncate text-[14px] font-semibold text-gray-950">{provider.name}</p>
-                            <p className="mt-1 text-[12px] text-gray-500">{provider.models.length} model{provider.models.length === 1 ? "" : "s"}</p>
-                          </div>
-                          <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] text-gray-500">
-                            {provider.source === "custom" ? "Custom" : "Catalog"}
-                          </span>
-                        </div>
-                        <p className="mt-3 text-[12px] text-gray-500">Updated {formatProviderTimestamp(provider.updatedAt)}</p>
-                      </div>
-                    ))}
-                  </div>
+                  <p className="shrink-0 text-right text-[12px] leading-5 text-[#5A6886]">{modelSummaryParts.join(" · ")}</p>
                 </section>
               ) : null}
 
-              {hasOpenWorkModels ? (
-                <section className="rounded-2xl border border-gray-100 bg-white p-5">
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">OpenWork Models</h2>
-                      <p className="mt-1 text-[13px] text-gray-500">Org-provided models you can use from OpenWork.</p>
-                    </div>
-                    <span className="rounded-full bg-emerald-50 px-3 py-1 text-[12px] font-medium text-emerald-700">
-                      Available
-                    </span>
+              {hasPlugins ? (
+                <section>
+                  <div className="mb-3 flex items-center justify-between gap-4">
+                    <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-[#07192C]">Skills and tools</h2>
+                    <p className="text-[12px] text-[#5A6886]">{plugins.length} available</p>
                   </div>
-
-                  <div className="mt-5 grid gap-3">
-                    <div className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-4">
-                      <div className="flex items-center gap-3">
-                        <CheckCircle2 className="h-5 w-5 text-emerald-600" aria-hidden="true" />
-                        <div>
-                          <p className="text-[14px] font-semibold text-gray-950">Available in this workspace</p>
-                          <p className="mt-1 text-[12px] text-gray-500">
-                            {openWorkProviders.length} model key group{openWorkProviders.length === 1 ? "" : "s"} you can use.
-                          </p>
-                        </div>
+                  <div className="overflow-hidden rounded-2xl border border-gray-100 bg-white divide-y divide-gray-100" data-testid="member-plugin-list">
+                    {plugins.slice(0, 8).map((plugin) => (
+                      <div key={plugin.id} className="px-4 py-3.5">
+                        <p className="truncate text-[14px] font-semibold text-gray-950">{plugin.name}</p>
+                        <p className="mt-1 line-clamp-2 text-[13px] leading-5 text-gray-500">{cleanDescription(plugin.description)}</p>
+                        <p className="mt-2 text-[12px] text-gray-400">{getPluginPartsSummary(plugin)}</p>
                       </div>
-                    </div>
+                    ))}
+                    {plugins.length > 8 ? (
+                      <p className="px-4 py-3 text-[12px] leading-5 text-gray-400">
+                        Showing 8 of {plugins.length} — all of them sync into the desktop app.
+                      </p>
+                    ) : null}
                   </div>
                 </section>
               ) : null}
 
               {hasMarketplaces ? (
-                <section className="rounded-2xl border border-gray-100 bg-white p-5">
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">Marketplaces</h2>
-                      <p className="mt-1 text-[13px] text-gray-500">Marketplaces contain plugins and sync into the app after sign-in.</p>
-                    </div>
-                    <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-                      {marketplaces.length} visible
-                    </span>
-                  </div>
-
-                  <div className="mt-5 grid gap-3">
-                    {marketplaces.slice(0, 5).map((marketplace) => (
-                      <div key={marketplace.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
-                        <div className="flex items-start justify-between gap-3">
-                          <div className="min-w-0">
-                            <p className="truncate text-[14px] font-semibold text-gray-950">{marketplace.name}</p>
-                            {marketplace.description ? <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-gray-500">{marketplace.description}</p> : null}
-                          </div>
-                          <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] text-gray-500">
-                            {marketplace.pluginCount} plugin{marketplace.pluginCount === 1 ? "" : "s"}
-                          </span>
-                        </div>
-                      </div>
-                    ))}
-                  </div>
-                </section>
-              ) : null}
-
-              {hasPlugins ? (
-                <section className="rounded-2xl border border-gray-100 bg-white p-5">
-                  <div className="flex items-center justify-between gap-4">
-                    <div>
-                      <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">Plugins</h2>
-                      <p className="mt-1 text-[13px] text-gray-500">Skills, hooks, MCPs, agents, and commands you can use.</p>
-                    </div>
-                    <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-                      {plugins.length} visible
-                    </span>
-                  </div>
-
-                  <div className="mt-5 grid gap-3">
-                    {plugins.slice(0, 5).map((plugin) => (
-                      <div key={plugin.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
-                        <p className="truncate text-[14px] font-semibold text-gray-950">{plugin.name}</p>
-                        <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-gray-500">{plugin.description}</p>
-                        <p className="mt-3 text-[12px] text-gray-500">{getPluginPartsSummary(plugin)}</p>
-                      </div>
-                    ))}
-                  </div>
-                </section>
+                <p className="text-[12px] leading-5 text-gray-400" data-testid="member-marketplace-note">
+                  Delivered from {marketplaces.length} marketplace{marketplaces.length === 1 ? "" : "s"}: {marketplaces.map((marketplace) => marketplace.name).join(", ")}
+                </p>
               ) : null}
             </div>
           ) : null}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/member-onboarding-card.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/member-onboarding-card.tsx
@@ -1,0 +1,296 @@
+"use client";
+
+import { useEffect, useState, type ReactNode } from "react";
+import { Check, Copy, Download } from "lucide-react";
+import { DenButton } from "../../_components/ui/button";
+import { createOrganizationInstallLink } from "../../_lib/install-link-data";
+
+type StepState = "complete" | "active" | "pending";
+
+const STEP_SHELL: Record<StepState, string> = {
+  complete: "border-[#e7eaef] bg-[#fafbfc]",
+  active: "border-[#c8d6f5] bg-[#f8faff]",
+  pending: "border-[#e1e4e8] bg-[#f7f8fa]",
+};
+
+const STEP_BADGE: Record<StepState, string> = {
+  complete: "border-[1.5px] border-[#c9cfd7] bg-white text-[#7a828e]",
+  active: "bg-[#101828] text-white",
+  pending: "border-[1.5px] border-[#101828] text-[#101828]",
+};
+
+const GENERIC_DOWNLOAD_URL = "https://openworklabs.com/download";
+const TEXT_BUTTON_CLASS = "text-[13px] font-medium text-[#5A6886] underline-offset-4 hover:text-[#07192C] hover:underline";
+
+type MemberOnboardingState = {
+  orgId: string | null;
+  ready: boolean;
+  installed: boolean;
+  dismissed: boolean;
+};
+
+type MemberOnboardingCardProps = {
+  organizationId: string;
+  organizationName: string;
+  memberEmail: string;
+  installLinksEnabled: boolean;
+  collapsed: boolean;
+  installed: boolean;
+  onMarkInstalled: () => void;
+  onDismiss: () => void;
+  onReopen: () => void;
+};
+
+function installedKey(orgId: string) {
+  return `openwork:member-onboarding:installed:${orgId}`;
+}
+
+function dismissedKey(orgId: string) {
+  return `openwork:member-onboarding:dismissed:${orgId}`;
+}
+
+function getErrorText(error: unknown) {
+  return error instanceof Error ? error.message : "Could not create the install link.";
+}
+
+export function useMemberOnboarding(orgId: string | null) {
+  const [state, setState] = useState<MemberOnboardingState>({
+    orgId: null,
+    ready: false,
+    installed: false,
+    dismissed: false,
+  });
+
+  useEffect(() => {
+    if (!orgId) {
+      setState({ orgId: null, ready: false, installed: false, dismissed: false });
+      return;
+    }
+
+    let installed = false;
+    let dismissed = false;
+    try {
+      installed = localStorage.getItem(installedKey(orgId)) === "1";
+      dismissed = localStorage.getItem(dismissedKey(orgId)) === "1";
+    } catch {
+      // localStorage unavailable
+    }
+    setState({ orgId, ready: true, installed, dismissed });
+  }, [orgId]);
+
+  function markInstalled() {
+    if (!orgId) return;
+    setState((current) => current.orgId === orgId ? { ...current, installed: true } : current);
+    try {
+      localStorage.setItem(installedKey(orgId), "1");
+    } catch {
+      // localStorage unavailable
+    }
+  }
+
+  function reopen() {
+    if (!orgId) return;
+    setState((current) => current.orgId === orgId ? { ...current, dismissed: false } : current);
+    try {
+      localStorage.removeItem(dismissedKey(orgId));
+    } catch {
+      // localStorage unavailable
+    }
+  }
+
+  function dismiss() {
+    if (!orgId) return;
+    setState((current) => current.orgId === orgId ? { ...current, dismissed: true } : current);
+    try {
+      localStorage.setItem(dismissedKey(orgId), "1");
+    } catch {
+      // localStorage unavailable
+    }
+  }
+
+  const ready = state.ready && state.orgId === orgId && orgId !== null;
+
+  return {
+    ready,
+    installed: ready && state.installed,
+    dismissed: ready && state.dismissed,
+    markInstalled,
+    reopen,
+    dismiss,
+  };
+}
+
+function OnboardingStep({
+  index,
+  state,
+  title,
+  helper,
+  children,
+}: {
+  index: number;
+  state: StepState;
+  title: string;
+  helper: string;
+  children?: ReactNode;
+}) {
+  return (
+    <li className={`rounded-[18px] border ${STEP_SHELL[state]}`} data-state={state}>
+      <div className="flex items-start gap-4 p-5 sm:px-7 sm:py-6">
+        <span className={`grid size-8 shrink-0 place-items-center rounded-full text-[13px] font-semibold ${STEP_BADGE[state]}`} aria-hidden="true">
+          {state === "complete" ? "✓" : index}
+        </span>
+        <div className="min-w-0 grow">
+          <p className={`text-base font-semibold ${state === "complete" ? "text-[#667085]" : "text-[#101828]"}`}>{title}</p>
+          {state !== "complete" ? <p className="mt-1 text-[13px] leading-5 text-[#60646c]">{helper}</p> : null}
+          {state !== "complete" && children ? <div className="mt-4 grid gap-3">{children}</div> : null}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export function MemberOnboardingCard({
+  organizationId,
+  organizationName,
+  memberEmail,
+  installLinksEnabled,
+  collapsed,
+  installed,
+  onMarkInstalled,
+  onDismiss,
+  onReopen,
+}: MemberOnboardingCardProps) {
+  const [minting, setMinting] = useState<"download" | "copy" | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function mintInstallLink(action: "download" | "copy") {
+    setError(null);
+    setMinting(action);
+    try {
+      return await createOrganizationInstallLink(organizationId, false);
+    } catch (linkError) {
+      setError(getErrorText(linkError));
+      return null;
+    } finally {
+      setMinting(null);
+    }
+  }
+
+  async function downloadInstallLink() {
+    const url = await mintInstallLink("download");
+    if (url) {
+      window.location.assign(url);
+    }
+  }
+
+  async function copyInstallLink() {
+    const url = await mintInstallLink("copy");
+    if (!url) return;
+
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1800);
+    } catch (copyError) {
+      setError(getErrorText(copyError));
+    }
+  }
+
+  function openGenericDownload() {
+    window.location.assign(GENERIC_DOWNLOAD_URL);
+  }
+
+  return (
+    <section className="max-w-[720px]" data-testid="member-onboarding">
+      {collapsed ? (
+        <div className={`flex flex-wrap items-center justify-between gap-3 rounded-2xl border px-4 py-3 ${installed ? "border-emerald-100 bg-emerald-50" : "border-gray-100 bg-white"}`} data-testid="member-onboarding-complete">
+          <div className={`flex items-center gap-2.5 text-[14px] font-medium ${installed ? "text-emerald-800" : "text-[#344054]"}`}>
+            {installed ? <Check className="h-4 w-4 text-emerald-600" aria-hidden="true" /> : null}
+            <span>{installed ? `You're set up for ${organizationName}` : `Finish setting up OpenWork for ${organizationName}`}</span>
+          </div>
+          <button type="button" className={TEXT_BUTTON_CLASS} data-testid="member-onboarding-reopen" onClick={onReopen}>
+            Show setup steps
+          </button>
+        </div>
+      ) : (
+        <div className="rounded-[24px] border border-gray-100 bg-white p-5 shadow-sm sm:p-6">
+          <h1 className="text-[22px] font-semibold tracking-[-0.03em] text-[#07192C]">Welcome to {organizationName}</h1>
+          <p className="mt-2 text-[14px] leading-6 text-[#5A6886]">
+            OpenWork runs on your computer. Install it once — the models, plugins, and marketplaces your team set up come with it.
+          </p>
+
+          <p className="mt-4 text-[13px] font-medium text-[#5A6886]" data-testid="member-onboarding-progress">Step {installed ? 2 : 1} of 2</p>
+
+          <ol className="mt-3 grid gap-3" data-testid="member-onboarding-steps">
+            <OnboardingStep
+              index={1}
+              state={installed ? "complete" : "active"}
+              title={`Install OpenWork for ${organizationName}`}
+              helper="Your download is already configured for this workspace."
+            >
+              {!installed ? (
+                <>
+                  <div className="flex flex-wrap gap-2.5">
+                    {installLinksEnabled ? (
+                      <>
+                        <DenButton
+                          icon={Download}
+                          loading={minting === "download"}
+                          disabled={minting !== null}
+                          data-testid="member-onboarding-download"
+                          onClick={() => void downloadInstallLink()}
+                        >
+                          Download OpenWork
+                        </DenButton>
+                        <DenButton
+                          variant="secondary"
+                          icon={Copy}
+                          loading={minting === "copy"}
+                          disabled={minting !== null}
+                          data-testid="member-onboarding-copy"
+                          onClick={() => void copyInstallLink()}
+                        >
+                          {copied ? "Copied" : "Copy install link"}
+                        </DenButton>
+                      </>
+                    ) : (
+                      <DenButton icon={Download} data-testid="member-onboarding-download" onClick={openGenericDownload}>
+                        Download OpenWork
+                      </DenButton>
+                    )}
+                  </div>
+                  <button type="button" className={`${TEXT_BUTTON_CLASS} justify-self-start`} data-testid="member-onboarding-installed" onClick={onMarkInstalled}>
+                    I already installed it
+                  </button>
+                  {error ? <p role="alert" className="text-[13px] leading-5 text-red-600">{error}</p> : null}
+                </>
+              ) : null}
+            </OnboardingStep>
+
+            <OnboardingStep
+              index={2}
+              state={installed ? "active" : "pending"}
+              title={memberEmail ? `Sign in with ${memberEmail}` : "Sign in with your work email"}
+              helper="Everything your admins set up appears automatically — no extra configuration."
+            >
+              {installed ? (
+                <DenButton className="justify-self-start" data-testid="member-onboarding-finish" onClick={onDismiss}>
+                  Show my workspace
+                </DenButton>
+              ) : null}
+            </OnboardingStep>
+          </ol>
+
+          {!installed ? (
+            <div className="mt-5 border-t border-gray-100 pt-4">
+              <button type="button" className={TEXT_BUTTON_CLASS} data-testid="member-onboarding-skip" onClick={onDismiss}>
+                Skip for now — show workspace details
+              </button>
+            </div>
+          ) : null}
+        </div>
+      )}
+    </section>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -49,6 +49,7 @@ import {
 import { useOrgListWindow } from "../../_lib/use-org-list-window";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import { buildDenFeedbackUrl } from "../../_lib/feedback";
+import { useMemberOnboarding } from "./member-onboarding-card";
 import { OrgSelectionScreen } from "./org-selection-screen";
 import { UserProfileDialog } from "./user-profile-dialog";
 
@@ -295,6 +296,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
   const { user, signOut, updateUserProfile, runtimeConfig, runtimeConfigLoaded } = useDenFlow();
   const {
     activeOrg,
+    orgId,
     orgDirectory,
     orgContext,
     orgSelectionRequired,
@@ -317,6 +319,10 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     showMore: showMoreOrgDirectory,
     showSearch: showSwitcherSearch,
   } = useOrgListWindow(orgDirectory, 20);
+  const {
+    ready: memberOnboardingReady,
+    dismissed: memberOnboardingDismissed,
+  } = useMemberOnboarding(orgId);
 
   if (orgSelectionRequired) {
     return (
@@ -335,11 +341,13 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     orgContext?.currentMember.isOwner ?? false,
     orgContext?.roles,
   );
+  const memberOnboardingActive = !access.isAdmin && memberOnboardingReady && !memberOnboardingDismissed;
 
   const pageTitle = getDashboardPageTitle(pathname, activeOrg?.slug ?? null);
   const shouldShowProfilePrompt = Boolean(
     user &&
       !profilePromptDismissed &&
+      !memberOnboardingActive &&
       user.name?.trim() === DEFAULT_AUTH_NAME,
   );
   const feedbackHref = buildDenFeedbackUrl({

--- a/evals/flows/member-first-load-onboarding.flow.mjs
+++ b/evals/flows/member-first-load-onboarding.flow.mjs
@@ -1,0 +1,1113 @@
+/**
+ * User-facing proof: an invited teammate's first dashboard load starts with a
+ * guided member setup card, then reveals only the resources the workspace made
+ * available to that member.
+ *
+ * Local runbook:
+ *   1. pnpm evals --stack-down
+ *   2. OPENWORK_EVAL_DEN_WEB_URL=http://127.0.0.1:3005 OPENWORK_EVAL_WEB_CDP_ADMIN=http://127.0.0.1:9855 OPENWORK_EVAL_WEB_CDP_INVITEE=http://127.0.0.1:9856 pnpm fraimz --flow member-first-load-onboarding --stack den
+ *      (the stack exports OPENWORK_EVAL_DEN_API_URL and OPENWORK_EVAL_DEN_TOKEN)
+ *   3. In another shell, run den-web against the stack API:
+ *      DEN_WEB_PORT=3005 DEN_API_BASE=http://127.0.0.1:8790 DEN_AUTH_ORIGIN=http://127.0.0.1:3005 DEN_AUTH_FALLBACK_BASE=http://127.0.0.1:8790 pnpm --filter @openwork-ee/den-web dev:local
+ *   4. In another shell, run Chrome for the admin browser:
+ *      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless=new --remote-debugging-port=9855 --user-data-dir="$(mktemp -d)" --window-size=1440,1100 about:blank
+ *   5. In another shell, run Chrome for the invitee browser:
+ *      "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome" --headless=new --remote-debugging-port=9856 --user-data-dir="$(mktemp -d)" --window-size=1440,1100 about:blank
+ */
+import { execSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import { connect, debuggerUrlFor, listTargets } from "../runner/cdp.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "member-first-load-onboarding";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const DEN_API_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_API_URL);
+const DEN_WEB_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_DEN_WEB_URL);
+const ADMIN_CDP_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_WEB_CDP_ADMIN);
+const INVITEE_CDP_URL = cleanBaseUrl(process.env.OPENWORK_EVAL_WEB_CDP_INVITEE);
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const TARGET_ORG_SLUG = process.env.OPENWORK_EVAL_DEN_ORG_SLUG?.trim() || "acme-robotics-demo";
+const INVITEE_PASSWORD = "OpenWorkDemo123!";
+const RUN_TAG = `${Date.now().toString(36)}-${randomBytes(2).toString("hex")}`;
+const INVITEE_EMAIL = `newmember+${RUN_TAG}@acme.test`;
+const AUTH_TOKEN_STORAGE_KEY = "openwork:web:auth-token";
+const ORG_SCOPE_HEADER = "x-openwork-org-id";
+
+const EMPTY_PANEL_REJECT_TEXT = [
+  "are available to you yet",
+  "Ask an admin to enable org-provided models",
+  "Give teammates a preconfigured OpenWork",
+  "needs an active subscription",
+];
+
+const state = {
+  adminBrowserSignedIn: false,
+  adminToken: null,
+  inviteToken: null,
+  inviteeToken: null,
+  orgId: null,
+  orgName: null,
+  orgSlug: null,
+  orgCapabilities: null,
+  installLinkUrl: null,
+  resourceSummary: null,
+};
+
+export default {
+  id: "member-first-load-onboarding",
+  title: "An invited teammate's first load is a guided start, not a wall of empty panels",
+  kind: "user-facing",
+  requiresApp: false,
+  spec: "evals/cloud-org-membership-flows.md",
+  requiredEnv: [
+    "OPENWORK_EVAL_DEN_API_URL",
+    "OPENWORK_EVAL_DEN_TOKEN",
+    "OPENWORK_EVAL_DEN_WEB_URL",
+    "OPENWORK_EVAL_WEB_CDP_ADMIN",
+    "OPENWORK_EVAL_WEB_CDP_INVITEE",
+    "OPENWORK_EVAL_MARK_VERIFIED_CMD",
+  ],
+  steps: [
+    {
+      name: "Frame 1 — Admin invites a teammate",
+      run: async (ctx) => {
+        await withClient(ctx, ADMIN_CDP_URL, async () => {
+          await ctx.prove("An admin invite creates a pending member-list row for the new teammate", {
+            voiceover: vo[0],
+            action: async () => {
+              await signInAdminBrowser(ctx);
+              await openMembersPage(ctx);
+              await clickExactText(ctx, "Add member", "button");
+              await ctx.fill('input[placeholder="teammate@example.com"]', INVITEE_EMAIL);
+              await clickExactText(ctx, "Send invite", "button");
+              await ctx.waitForText(INVITEE_EMAIL, { timeoutMs: 30_000 });
+              await ctx.waitForText("Pending", { timeoutMs: 30_000 });
+            },
+            assert: async () => {
+              await ctx.expectText(INVITEE_EMAIL);
+              await ctx.expectText("Pending");
+
+              const org = await loadAdminOrg(ctx);
+              witness(ctx, typeof state.orgId === "string" && state.orgId.length > 0, "Admin organization id is available for the invited workspace", compactStateOrg());
+
+              const invitation = await assertPendingInvitation(ctx, org, INVITEE_EMAIL);
+              state.inviteToken = invitation.inviteToken;
+              const inviteTokenLength = typeof state.inviteToken === "string" ? state.inviteToken.length : 0;
+              witness(ctx, typeof state.inviteToken === "string" && state.inviteToken.trim().length > 0, "Pending invitation includes a non-empty invite token", {
+                inviteToken: { present: inviteTokenLength > 0, length: inviteTokenLength },
+              });
+              await assertPendingInviteUi(ctx, INVITEE_EMAIL);
+            },
+            screenshot: {
+              name: "admin-invites-teammate",
+              requireText: [INVITEE_EMAIL, "Pending"],
+              rejectText: ["Something went wrong"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 2 — Teammate joins in one click",
+      run: async (ctx) => {
+        await withClient(ctx, INVITEE_CDP_URL, async () => {
+          await ctx.prove("The invited teammate opens the invite link and reaches the joined success screen", {
+            voiceover: vo[1],
+            action: async () => {
+              await clearDenWebSession(ctx);
+              const inviteToken = requireStateString(state.inviteToken, "invite token");
+              await goToDenWeb(ctx, `/join-org?invite=${encodeURIComponent(inviteToken)}`);
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-root\"][data-state=\"signed-out\"]'))", { timeoutMs: 45_000, label: "signed-out join-org invite screen" });
+              await completeInviteSignup(ctx, INVITEE_EMAIL, INVITEE_PASSWORD);
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))", { timeoutMs: 45_000, label: "join-org success" });
+            },
+            assert: async () => {
+              const successVisible = await ctx.eval("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))");
+              witness(ctx, successVisible === true, "Join organization success screen is present", { successVisible });
+
+              const token = await ensureInviteeToken(ctx);
+              witness(ctx, typeof token === "string" && token.length > 0, "Invitee browser has an active session token", { token: token ? "<present>" : null });
+
+              const orgContext = await loadInviteeOrg(ctx);
+              state.orgCapabilities = orgContext?.capabilities ?? null;
+              witness(ctx, orgContext?.currentMember?.role === "member", "Invitee /v1/org payload reports the member role", {
+                currentMember: orgContext?.currentMember ?? null,
+                organization: compactOrg(orgContext),
+              });
+
+              await redactInviteCredential(ctx, state.inviteToken);
+            },
+            screenshot: {
+              name: "teammate-joined",
+              requireText: ["You're in, welcome to"],
+              rejectText: ["Something went wrong"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 3 — Guided dashboard first load",
+      run: async (ctx) => {
+        await withClient(ctx, INVITEE_CDP_URL, async () => {
+          await ctx.prove("The teammate's first dashboard load shows the focused member onboarding card", {
+            voiceover: vo[2],
+            action: async () => {
+              await clickTestId(ctx, "join-org-continue-browser");
+              await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 45_000, label: "dashboard route after invite success" });
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"member-onboarding\"]'))", { timeoutMs: 45_000, label: "member onboarding card" });
+            },
+            assert: async () => {
+              const observed = await onboardingState(ctx);
+              witness(ctx, observed.onboardingExists === true, "Member onboarding card exists on first dashboard load", observed);
+              witness(ctx, observed.progress === "Step 1 of 2", "Member onboarding progress starts at Step 1 of 2", observed);
+              witness(ctx, observed.stepOneState === "active", "First onboarding step is active", observed);
+              witness(ctx, observed.stepTwoState === "pending", "Second onboarding step is pending", observed);
+              witness(ctx, observed.resourceOverviewPresent === false, "Member resource overview is hidden during the first guided load", observed);
+              const profilePrompt = await ctx.eval(`({
+                dialogPresent: Boolean(document.querySelector('[role="dialog"]')),
+                bodyIncludesUserProfile: document.body.innerText.includes('User Profile'),
+              })`);
+              witness(ctx, profilePrompt.dialogPresent === false, "Profile dialog is absent during the guided first load", profilePrompt);
+              witness(ctx, profilePrompt.bodyIncludesUserProfile === false, "Guided first load does not include the User Profile prompt", profilePrompt);
+              for (const rejectedText of EMPTY_PANEL_REJECT_TEXT) {
+                witness(ctx, observed.bodyText.includes(rejectedText) === false, `Guided first load does not include '${rejectedText}'`, { rejectedText });
+              }
+            },
+            screenshot: {
+              name: "guided-first-load",
+              requireText: ["Welcome to", "Install OpenWork for", "Step 1 of 2", "Sign in with"],
+              rejectText: [...EMPTY_PANEL_REJECT_TEXT, "User Profile"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 4 — Workspace-configured installer",
+      run: async (ctx) => {
+        await withClient(ctx, INVITEE_CDP_URL, async () => {
+          const orgName = requireStateString(state.orgName, "organization name");
+          await ctx.prove("The first onboarding step opens a workspace-scoped installer page", {
+            voiceover: vo[3],
+            action: async () => {
+              await clickTestId(ctx, "member-onboarding-download");
+            },
+            assert: async () => {
+              await ctx.waitFor("location.pathname === '/install'", { timeoutMs: 45_000, label: "member landed on workspace install page" });
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"install-page\"]'))", { timeoutMs: 30_000, label: "workspace install page" });
+              // install-page also renders while the install config is still loading, so wait for
+              // the guide itself — the concrete artifact these assertions are about.
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"install-guide\"]'))", { timeoutMs: 30_000, label: "workspace install guide" });
+              await ctx.waitFor(
+                `[...document.querySelectorAll('h1')].some((heading) => (heading.textContent ?? '').includes(${JSON.stringify(orgName)}))`,
+                { timeoutMs: 30_000, label: "install page heading branded to the organization" },
+              );
+
+              const guideExists = await ctx.eval("Boolean(document.querySelector('[data-testid=\"install-guide\"]'))");
+              witness(ctx, guideExists === true, "Workspace install page includes the guided installer", { guideExists });
+
+              const headingText = await ctx.eval("[...document.querySelectorAll('h1')].map((heading) => (heading.textContent ?? '').trim()).find((text) => text.includes('Download OpenWork')) ?? ''");
+              witness(ctx, typeof headingText === "string" && headingText.includes("Download OpenWork") && headingText.includes(orgName), "Workspace install page heading is branded to this organization", {
+                headingText,
+                orgName,
+              });
+
+              const installRoute = await ctx.eval(`(() => {
+                const url = new URL(location.href);
+                const token = url.searchParams.get('token') ?? '';
+                return {
+                  pathname: location.pathname,
+                  token: { present: token.length > 0, length: token.length },
+                  searchKeys: [...url.searchParams.keys()],
+                };
+              })()`);
+              witness(ctx, installRoute?.pathname === "/install" && installRoute?.token?.present === true && installRoute.token.length > 0, "Workspace install page route carries a non-empty scoped token", installRoute);
+
+              const capabilities = state.orgCapabilities;
+              ctx.output("invitee-org-capabilities", JSON.stringify(capabilities, null, 2));
+              witness(ctx, capabilities?.installLinks === true, "Invitee /v1/org capabilities enable install links for member onboarding", { capabilities });
+
+              const orgId = requireStateString(state.orgId, "organization id");
+              const result = await inviteeAuthedFetch(`/v1/orgs/${encodeURIComponent(orgId)}/install-links`, {
+                method: "POST",
+                body: JSON.stringify({ rotate: false }),
+              });
+              const installPageUrl = typeof result.body?.installPageUrl === "string" ? result.body.installPageUrl : "";
+              const installPath = installPageUrl ? new URL(installPageUrl).pathname : "";
+              state.installLinkUrl = installPageUrl ? redactInstallLink(installPageUrl) : null;
+              witness(ctx, result.response.ok === true && installPath === "/install", "A plain member can mint a workspace-scoped install page URL", {
+                status: result.response.status,
+                ok: result.response.ok,
+                installPageUrl: state.installLinkUrl,
+                pathname: installPath,
+              });
+
+              const alertText = await ctx.eval("document.querySelector('[role=\"alert\"]')?.textContent?.trim() ?? ''");
+              witness(ctx, alertText === "", "Download action did not surface an alert error", { alertText });
+
+              await redactInstallCredential(ctx);
+            },
+            screenshot: {
+              name: "workspace-configured-installer",
+              requireText: ["Download OpenWork", orgName, "Complete one step at a time"],
+              rejectText: ["Something went wrong", "expired", "Could not create"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 5 — Install checked off",
+      run: async (ctx) => {
+        await withClient(ctx, INVITEE_CDP_URL, async () => {
+          let beforeInstallCheck = null;
+          await ctx.prove("Confirming the desktop app is installed moves the teammate to the sign-in step", {
+            voiceover: vo[4],
+            action: async () => {
+              await goToDenWeb(ctx, "/dashboard");
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"member-onboarding\"]'))", { timeoutMs: 30_000, label: "member onboarding after returning from installer" });
+              beforeInstallCheck = await onboardingState(ctx);
+              await clickExactText(ctx, "I already installed it", "button");
+              await ctx.waitFor("(document.querySelector('[data-testid=\"member-onboarding-progress\"]')?.textContent ?? '').trim() === 'Step 2 of 2'", { timeoutMs: 30_000, label: "member onboarding step two" });
+            },
+            assert: async () => {
+              witness(ctx, beforeInstallCheck?.stepOneState === "active", "First onboarding step is still active after returning from the install page", beforeInstallCheck);
+              const observed = await onboardingState(ctx);
+              witness(ctx, observed.progress === "Step 2 of 2", "Member onboarding progress advances to Step 2 of 2", observed);
+              witness(ctx, observed.stepOneState === "complete", "First onboarding step is complete", observed);
+              witness(ctx, observed.stepTwoState === "active", "Second onboarding step is active", observed);
+              witness(ctx, observed.finishPresent === true, "Show my workspace finish action is present", observed);
+              witness(ctx, observed.skipPresent === false, "Skip setup action is removed once install is confirmed", observed);
+
+              const storage = await memberOnboardingInstalledStorage(ctx);
+              witness(ctx, storage.value === "1", `Local storage marks the installer step complete at ${storage.key}`, storage);
+            },
+            screenshot: {
+              name: "install-checked-off",
+              requireText: ["Step 2 of 2", "Show my workspace"],
+              rejectText: ["I already installed it", "Step 1 of 2", "User Profile"],
+            },
+          });
+        });
+      },
+    },
+    {
+      name: "Frame 6 — Details match shared resources",
+      run: async (ctx) => {
+        await withClient(ctx, INVITEE_CDP_URL, async () => {
+          await ctx.prove("Finishing setup collapses onboarding and renders only member-visible resource panels", {
+            voiceover: vo[5],
+            action: async () => {
+              await clickTestId(ctx, "member-onboarding-finish");
+              await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"member-onboarding-complete\"]'))", { timeoutMs: 30_000, label: "collapsed member onboarding row" });
+            },
+            assert: async () => {
+              const summary = await fetchMemberVisibleResourceSummary(ctx);
+              state.resourceSummary = summary;
+              ctx.output("member-resource-ground-truth", JSON.stringify(summary, null, 2));
+
+              await waitForResourceDomToMatch(ctx, summary.expectations);
+              const observed = await resourceDomState(ctx);
+              witness(ctx, observed.completePresent === true && observed.completeText.includes("You're set up for"), "Collapsed member onboarding row confirms setup is complete", observed);
+              witness(ctx, observed.stepsPresent === false, "Detailed onboarding steps are hidden after finishing setup", observed);
+              witness(ctx, observed.workspaceHeadingPresent === true, "Your workspace heading is present", observed);
+              witness(ctx, observed.bodyText.includes("are available to you yet") === false, "No old empty-resource placeholder copy is rendered", observed);
+
+              witness(ctx, observed.headings["LLM providers"] === summary.expectations.expectCustomProviders, "LLM providers heading visibility matches usable custom providers", {
+                expected: summary.expectations.expectCustomProviders,
+                observed: observed.headings["LLM providers"],
+                providerSources: summary.providerSources,
+              });
+              witness(ctx, observed.headings["OpenWork Models"] === summary.expectations.expectOpenWorkModels, "OpenWork Models heading visibility matches usable OpenWork providers", {
+                expected: summary.expectations.expectOpenWorkModels,
+                observed: observed.headings["OpenWork Models"],
+                openWorkProviderCount: summary.counts.openWorkProviders,
+                providerSources: summary.providerSources,
+              });
+              witness(ctx, observed.headings.Marketplaces === summary.expectations.expectMarketplaces, "Marketplaces heading visibility matches assigned marketplaces", {
+                expected: summary.expectations.expectMarketplaces,
+                observed: observed.headings.Marketplaces,
+                marketplaceCount: summary.counts.marketplaces,
+              });
+              witness(ctx, observed.headings.Plugins === summary.expectations.expectPlugins, "Plugins heading visibility matches assigned plugins", {
+                expected: summary.expectations.expectPlugins,
+                observed: observed.headings.Plugins,
+                pluginCount: summary.counts.plugins,
+              });
+              witness(ctx, observed.resourceOverviewPresent === summary.expectations.hasAnyResources, "Resource overview presence matches whether any resource is shared", {
+                expected: summary.expectations.hasAnyResources,
+                observed: observed.resourceOverviewPresent,
+              });
+              witness(ctx, observed.resourcesEmptyPresent === !summary.expectations.hasAnyResources, "Empty resource note appears only when nothing is shared", {
+                expected: !summary.expectations.hasAnyResources,
+                observed: observed.resourcesEmptyPresent,
+              });
+              const profileDialogPresent = await ctx.eval("Boolean(document.querySelector('[role=\"dialog\"]'))");
+              witness(ctx, profileDialogPresent === false, "Profile dialog is absent from the finished member details view", { profileDialogPresent });
+            },
+            screenshot: {
+              name: "details-only-what-was-shared",
+              requireText: ["You're set up for", "Your workspace"],
+              rejectText: ["are available to you yet", "Step 1 of 2", "Ask an admin to enable org-provided models", "User Profile"],
+            },
+          });
+        });
+      },
+    },
+  ],
+};
+
+function cleanBaseUrl(value) {
+  return (value ?? "").trim().replace(/\/+$/, "");
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : typeof actual === "string" ? actual : JSON.stringify(actual).slice(0, 900),
+  });
+  ctx.assert(condition, assertion + (actual === undefined ? "" : ` (actual: ${JSON.stringify(actual).slice(0, 500)})`));
+}
+
+function requireStateString(value, label) {
+  if (typeof value === "string" && value.trim()) {
+    return value;
+  }
+  throw new Error(`${label} was not prepared by an earlier frame.`);
+}
+
+async function withClient(ctx, cdpBaseUrl, fn) {
+  const previous = ctx.client;
+  const target = await firstPageTarget(cdpBaseUrl);
+  const client = await connect(debuggerUrlFor(cdpBaseUrl, target));
+  ctx.client = client;
+  try {
+    return await fn();
+  } finally {
+    ctx.client = previous;
+    try {
+      client.close();
+    } catch {}
+  }
+}
+
+async function firstPageTarget(cdpBaseUrl) {
+  const existing = await listTargets(cdpBaseUrl);
+  const page = existing.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (page) {
+    return page;
+  }
+
+  const base = cdpBaseUrl.replace(/\/+$/, "");
+  let response = await fetch(`${base}/json/new?about:blank`, { method: "PUT" });
+  if (!response.ok) {
+    response = await fetch(`${base}/json/new?about:blank`);
+  }
+  if (!response.ok) {
+    throw new Error(`Could not create a page target at ${cdpBaseUrl}: ${response.status}`);
+  }
+
+  const created = await response.json();
+  if (created?.type === "page" && created.webSocketDebuggerUrl) {
+    return created;
+  }
+  const targets = await listTargets(cdpBaseUrl);
+  const nextPage = targets.find((target) => target.type === "page" && target.webSocketDebuggerUrl);
+  if (!nextPage) {
+    throw new Error(`No page target available at ${cdpBaseUrl}.`);
+  }
+  return nextPage;
+}
+
+function adminAuthOrigins() {
+  const origins = [];
+  if (DEN_WEB_URL) {
+    origins.push(new URL(DEN_WEB_URL).origin);
+  }
+  if (DEN_API_URL) {
+    const apiUrl = new URL(DEN_API_URL);
+    if (apiUrl.hostname === "127.0.0.1") {
+      const localhostUrl = new URL(apiUrl.toString());
+      localhostUrl.hostname = "localhost";
+      origins.push(localhostUrl.origin);
+    }
+    origins.push(apiUrl.origin);
+  }
+  return [...new Set(origins)];
+}
+
+function sessionCookiePair(setCookie) {
+  const match = String(setCookie ?? "").match(/better-auth\.session_token=([^;,\s]+)/);
+  return match ? `better-auth.session_token=${match[1]}` : "";
+}
+
+async function createAdminBrowserSession(ctx) {
+  const session = await createBrowserSession(ctx, ADMIN_EMAIL, ADMIN_PASSWORD, "Admin");
+  if (session) {
+    state.adminToken = session.token;
+  }
+  return session;
+}
+
+async function createBrowserSession(ctx, email, password, label) {
+  let last = null;
+  for (const origin of adminAuthOrigins()) {
+    const response = await fetch(`${DEN_API_URL}/api/auth/sign-in/email`, {
+      method: "POST",
+      headers: { "content-type": "application/json", origin },
+      body: JSON.stringify({ email, password }),
+    });
+    const text = await response.text();
+    const body = parseResponseBody(text);
+    const cookie = sessionCookiePair(response.headers.get("set-cookie"));
+    last = { origin, status: response.status, body: redactAuthBody(body), cookie: cookie ? "<present>" : null };
+    if (response.ok && typeof body?.token === "string" && cookie) {
+      witness(ctx, true, `${label} API sign-in minted a den-web browser session`, { origin, status: response.status, token: "<present>", cookie: "<present>" });
+      return { token: body.token, cookie };
+    }
+  }
+  witness(ctx, false, `${label} API sign-in minted a den-web browser session`, last);
+  return null;
+}
+
+async function signInAdminBrowser(ctx) {
+  if (state.adminBrowserSignedIn) {
+    return;
+  }
+
+  const session = await createAdminBrowserSession(ctx);
+  if (!session) {
+    throw new Error("Admin browser session could not be created.");
+  }
+  await pinAdminActiveOrganization(ctx, session.token);
+  await applyBrowserSession(ctx, session);
+  state.adminBrowserSignedIn = true;
+}
+
+async function pinAdminActiveOrganization(ctx, token) {
+  const listed = await denFetch("/v1/me/orgs", {
+    method: "GET",
+    headers: { authorization: `Bearer ${token}` },
+  });
+  const orgs = Array.isArray(listed.body?.orgs) ? listed.body.orgs : [];
+  witness(ctx, listed.response.ok && Array.isArray(listed.body?.orgs), "Admin session can list organizations before opening Members", {
+    status: listed.response.status,
+    count: orgs.length,
+  });
+
+  const target = orgs.find((org) => org?.slug === TARGET_ORG_SLUG) ?? null;
+  witness(ctx, Boolean(target), `Admin belongs to the target organization ${TARGET_ORG_SLUG}`, {
+    targetSlug: TARGET_ORG_SLUG,
+    available: orgs.map(compactOrgPair),
+  });
+
+  const active = await denFetch("/v1/me/active-organization", {
+    method: "POST",
+    headers: { authorization: `Bearer ${token}` },
+    body: JSON.stringify({ organizationSlug: TARGET_ORG_SLUG }),
+  });
+  witness(ctx, active.response.ok && active.body?.activeOrgSlug === TARGET_ORG_SLUG, "Admin session pins the target organization before opening Members", {
+    status: active.response.status,
+    ok: active.response.ok,
+    activeOrgId: active.body?.activeOrgId ?? null,
+    activeOrgSlug: active.body?.activeOrgSlug ?? null,
+  });
+
+  state.orgId = typeof target?.id === "string" ? target.id : null;
+  state.orgName = typeof target?.name === "string" ? target.name : null;
+  state.orgSlug = typeof target?.slug === "string" ? target.slug : null;
+  witness(ctx, typeof state.orgId === "string" && typeof state.orgName === "string", "Target organization identity was resolved from /v1/me/orgs", compactStateOrg());
+}
+
+async function applyBrowserSession(ctx, session) {
+  await goToDenWeb(ctx, "/");
+  await ctx.eval(`(() => {
+    document.cookie = 'better-auth.session_token=; Max-Age=0; Path=/';
+    document.cookie = ${JSON.stringify(`${session.cookie}; Path=/; SameSite=Lax`)};
+    localStorage.setItem(${JSON.stringify(AUTH_TOKEN_STORAGE_KEY)}, ${JSON.stringify(session.token)});
+    sessionStorage.clear();
+    return true;
+  })()`);
+}
+
+async function openMembersPage(ctx) {
+  await goToDenWeb(ctx, "/dashboard/members");
+  await ctx.waitFor("location.pathname.includes('/dashboard/members') || (document.body?.innerText ?? '').includes('Choose an organization')", { timeoutMs: 30_000, label: "members route or organization chooser" });
+  await chooseActiveOrganizationFromChooser(ctx);
+  const onMembersRoute = await ctx.eval("location.pathname.includes('/dashboard/members')");
+  if (!onMembersRoute) {
+    await goToDenWeb(ctx, "/dashboard/members");
+  }
+  await ctx.waitFor("location.pathname.includes('/dashboard/members')", { timeoutMs: 30_000, label: "members route" });
+  await waitForMembersPageReady(ctx);
+}
+
+async function chooseActiveOrganizationFromChooser(ctx) {
+  const chooserVisible = await ctx.eval("(document.body?.innerText ?? '').includes('Choose an organization')");
+  if (!chooserVisible) {
+    return;
+  }
+
+  const orgName = requireStateString(state.orgName, "organization name");
+  const clicked = await clickExactText(ctx, orgName, "button, a, [role=\"button\"]");
+  witness(ctx, clicked === true, "Organization chooser fallback selected the resolved organization", { orgName });
+  await ctx.waitFor("!(document.body?.innerText ?? '').includes('Choose an organization')", { timeoutMs: 30_000, label: "organization chooser dismissed" });
+}
+
+async function waitForMembersPageReady(ctx) {
+  await ctx.waitFor(`(() => {
+    const text = document.body?.innerText ?? '';
+    if (text.includes('Invite teammates, adjust roles, and keep access clean.')) return true;
+    return [...document.querySelectorAll('button')].some((button) => (button.textContent ?? '').trim() === 'Add member' && !button.disabled);
+  })()`, { timeoutMs: 45_000, label: "members page Add member button" });
+}
+
+async function goToDenWeb(ctx, path) {
+  const url = path.startsWith("http") ? path : `${DEN_WEB_URL}${path}`;
+  await ctx.eval(`location.assign(${JSON.stringify(url)})`);
+  const labelPath = path.includes("invite=") ? redactInviteLink(path) : path;
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `den-web loaded ${labelPath}` });
+}
+
+async function clearDenWebSession(ctx) {
+  await goToDenWeb(ctx, "/");
+  await ctx.eval(
+    `fetch('/api/auth/sign-out', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' }).catch(() => null).then(() => {
+      localStorage.clear();
+      sessionStorage.clear();
+      for (const cookie of document.cookie.split(';')) {
+        const name = cookie.split('=')[0]?.trim();
+        if (name) document.cookie = name + '=; Max-Age=0; Path=/';
+      }
+      return true;
+    })`,
+    { awaitPromise: true },
+  );
+}
+
+async function clickExactText(ctx, text, selector) {
+  const clicked = await ctx.waitFor(`(() => {
+    const candidates = [...document.querySelectorAll(${JSON.stringify(selector)})];
+    const text = ${JSON.stringify(text)};
+    const element = candidates.find((candidate) => {
+      if (candidate.disabled) return false;
+      const exactText = (candidate.textContent ?? '').trim();
+      const innerText = (candidate.innerText ?? candidate.textContent ?? '').trim();
+      return exactText === text || innerText === text;
+    });
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 20_000, label: `click exact text ${text}` });
+  return clicked;
+}
+
+async function clickTestId(ctx, testId, { timeoutMs = 20_000 } = {}) {
+  return ctx.waitFor(`(() => {
+    const el = document.querySelector('[data-testid=${JSON.stringify(testId)}]');
+    if (!el) return false;
+    if (el instanceof HTMLButtonElement && el.disabled) return false;
+    el.scrollIntoView({ block: "center" });
+    el.click();
+    return true;
+  })()`, { timeoutMs, label: `click [data-testid="${testId}"]` });
+}
+
+function memberRowsExpression(email) {
+  return `(() => {
+    const email = ${JSON.stringify(email)};
+    return [...document.querySelectorAll('div')]
+      .filter((el) => {
+        const style = getComputedStyle(el);
+        return style.display === 'grid' && style.gridTemplateColumns.includes('180px') && (el.innerText ?? '').includes(email);
+      })
+      .map((el) => {
+        const cells = [...el.children].map((child) => child.innerText.trim());
+        return {
+          text: el.innerText.trim(),
+          role: cells[1] ?? '',
+          joined: cells[2] ?? '',
+        };
+      });
+  })()`;
+}
+
+async function memberRows(ctx, email) {
+  return ctx.eval(memberRowsExpression(email));
+}
+
+async function waitForUiRows(ctx, email, predicateSource, label) {
+  await ctx.waitFor(`(() => {
+    const rows = ${memberRowsExpression(email)};
+    const predicate = ${predicateSource};
+    return predicate(rows);
+  })()`, { timeoutMs: 30_000, label });
+  return memberRows(ctx, email);
+}
+
+async function scrollMemberRowsIntoView(ctx, email) {
+  await ctx.eval(`(() => {
+    const rows = [...document.querySelectorAll('div')]
+      .filter((el) => {
+        const style = getComputedStyle(el);
+        return style.display === 'grid' && style.gridTemplateColumns.includes('180px') && (el.innerText ?? '').includes(${JSON.stringify(email)});
+      });
+    rows[0]?.scrollIntoView({ block: 'center' });
+    return rows.length;
+  })()`);
+  await ctx.eval("new Promise((resolve) => setTimeout(resolve, 250))", { awaitPromise: true });
+}
+
+async function assertPendingInviteUi(ctx, email) {
+  const rows = await waitForUiRows(
+    ctx,
+    email,
+    "(rows) => rows.length >= 1 && rows.some((row) => row.joined.includes('Pending'))",
+    `pending invited member row for ${email}`,
+  );
+  witness(ctx, rows.length >= 1, `${email} is visible in the members list`, rows);
+  witness(ctx, rows.some((row) => row.joined.includes("Pending")), `${email} den-web row shows Pending`, rows);
+  await scrollMemberRowsIntoView(ctx, email);
+}
+
+async function denFetch(path, options = {}) {
+  const response = await fetch(`${DEN_API_URL}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      origin: DEN_WEB_URL || DEN_API_URL,
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  return { response, body: parseResponseBody(text), text };
+}
+
+async function adminAuthedFetch(path, options = {}) {
+  const token = state.adminToken || process.env.OPENWORK_EVAL_DEN_TOKEN?.trim() || "";
+  return denFetch(path, {
+    ...options,
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(state.orgId ? { [ORG_SCOPE_HEADER]: state.orgId } : {}),
+      ...(options.headers ?? {}),
+    },
+  });
+}
+
+async function inviteeAuthedFetch(path, options = {}) {
+  const token = requireStateString(state.inviteeToken, "invitee token");
+  return denFetch(path, {
+    ...options,
+    headers: {
+      authorization: `Bearer ${token}`,
+      ...(state.orgId ? { [ORG_SCOPE_HEADER]: state.orgId } : {}),
+      ...(options.headers ?? {}),
+    },
+  });
+}
+
+async function loadAdminOrg(ctx) {
+  const result = await adminAuthedFetch("/v1/org");
+  witness(ctx, result.response.ok, "Admin token can load the active organization", { status: result.response.status, body: compactOrgResponse(result.body) });
+  return result.body;
+}
+
+async function assertPendingInvitation(ctx, orgPayload, email) {
+  const invitations = invitationsFromPayload(orgPayload);
+  const pending = invitations.find((invitation) => normalizeEmail(invitation?.email) === normalizeEmail(email) && String(invitation?.status ?? "").trim().toLowerCase() === "pending") ?? null;
+  witness(ctx, Boolean(pending), `Admin /v1/org payload contains a pending invitation for ${email}`, {
+    invitations: invitations.map(compactInvitation),
+  });
+  return pending ?? {};
+}
+
+async function loadInviteeOrg(ctx) {
+  const result = await inviteeAuthedFetch("/v1/org");
+  witness(ctx, result.response.ok, "Invitee token can load /v1/org", { status: result.response.status, body: compactOrgResponse(result.body) });
+  return result.body;
+}
+
+async function completeInviteSignup(ctx, email, password) {
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 30_000, label: "invite password field" });
+  await ctx.fill('input[type="password"]', password);
+  await clickExactText(ctx, joinButtonLabel(), "button");
+  await ctx.waitFor(
+    `document.body.innerText.includes("You're one click away from the team workspace.") || document.body.innerText.includes("Check your inbox.") || Boolean(document.querySelector('[data-testid="join-org-success"]'))`,
+    { timeoutMs: 45_000, label: "signed in invite accept step" },
+  );
+
+  const alreadySuccess = await ctx.eval("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))");
+  if (alreadySuccess) {
+    return;
+  }
+
+  markEmailVerified(ctx, email);
+  const needsSigninRefresh = await ctx.eval("document.body.innerText.includes('Check your inbox.') || Boolean(document.querySelector('input[inputmode=\"numeric\"]'))");
+  if (needsSigninRefresh) {
+    const session = await createBrowserSession(ctx, email, password, "Invitee");
+    if (!session) {
+      throw new Error(`Could not create invitee browser session for ${email}.`);
+    }
+    state.inviteeToken = session.token;
+    await applyBrowserSession(ctx, session);
+    const inviteToken = requireStateString(state.inviteToken, "invite token");
+    await goToDenWeb(ctx, `/join-org?invite=${encodeURIComponent(inviteToken)}`);
+    await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-root\"][data-state=\"signed-in\"]'))", { timeoutMs: 45_000, label: "signed-in join-org invite screen" });
+  }
+
+  await ctx.expectText(email, { timeoutMs: 20_000 });
+  await clickExactText(ctx, joinButtonLabel(), "button");
+  await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"join-org-success\"]'))", { timeoutMs: 45_000, label: "join org success" });
+}
+
+function joinButtonLabel() {
+  return `Join ${requireStateString(state.orgName, "organization name")}`;
+}
+
+function markEmailVerified(ctx, email) {
+  ctx.assert(
+    MARK_VERIFIED_CMD.length > 0,
+    "Invitation acceptance requires a verified email; set OPENWORK_EVAL_MARK_VERIFIED_CMD (shell template with {email}).",
+  );
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", email), { stdio: "ignore" });
+}
+
+async function ensureInviteeToken(ctx) {
+  if (state.inviteeToken) {
+    return state.inviteeToken;
+  }
+  const browserToken = await ctx.eval(`localStorage.getItem(${JSON.stringify(AUTH_TOKEN_STORAGE_KEY)}) ?? ''`);
+  if (typeof browserToken === "string" && browserToken.trim()) {
+    state.inviteeToken = browserToken.trim();
+    return state.inviteeToken;
+  }
+  const session = await createBrowserSession(ctx, INVITEE_EMAIL, INVITEE_PASSWORD, "Invitee");
+  if (!session) {
+    throw new Error("Invitee session token was not available after joining.");
+  }
+  state.inviteeToken = session.token;
+  return state.inviteeToken;
+}
+
+function redactInviteLink(inviteLink) {
+  try {
+    const parsed = new URL(inviteLink, DEN_WEB_URL);
+    if (parsed.searchParams.has("invite")) parsed.searchParams.set("invite", "[redacted]");
+    return parsed.toString();
+  } catch {
+    return "invalid invite URL";
+  }
+}
+
+async function redactInviteCredential(ctx, inviteToken) {
+  const result = await ctx.eval(`(() => {
+    const token = ${JSON.stringify(inviteToken ?? "")};
+    const redactedInvite = ${JSON.stringify(`${DEN_WEB_URL}/join-org?invite=%5Bredacted%5D`)};
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let redactedTextNodes = 0;
+    let node = walker.nextNode();
+    while (node) {
+      const before = node.nodeValue ?? '';
+      let after = before;
+      if (token) after = after.split(token).join('[redacted]');
+      after = after.replace(/([?&]invite=)[^&\\s<>"')]+/g, '$1[redacted]');
+      if (after !== before) {
+        node.nodeValue = after;
+        redactedTextNodes += 1;
+      }
+      node = walker.nextNode();
+    }
+    let redactedLinks = 0;
+    for (const link of document.querySelectorAll('a[href*="/join-org?invite="]')) {
+      link.href = redactedInvite;
+      link.setAttribute('href', redactedInvite);
+      redactedLinks += 1;
+    }
+    if (location.href.includes('/join-org') && (location.search.includes('invite=') || (token && location.href.includes(token)))) {
+      history.replaceState(history.state, document.title, '/join-org?invite=%5Bredacted%5D');
+    }
+    const bodyContainsToken = token ? document.body.innerText.includes(token) : false;
+    const hrefContainsToken = token ? [...document.querySelectorAll('a')].some((link) => link.href.includes(token) || (link.getAttribute('href') ?? '').includes(token)) : false;
+    const urlContainsToken = token ? location.href.includes(token) : false;
+    const urlHasInviteCredential = /[?&]invite=(?!%5Bredacted%5D|\\[redacted\\])/.test(location.href);
+    const safeHref = (token ? location.href.split(token).join('[redacted]') : location.href).replace(/([?&]invite=)[^&\\s<>"')]+/g, '$1[redacted]');
+    return { redactedTextNodes, redactedLinks, bodyContainsToken, hrefContainsToken, urlContainsToken, urlHasInviteCredential, href: safeHref };
+  })()`);
+  witness(ctx, !result.bodyContainsToken && !result.hrefContainsToken && !result.urlContainsToken && !result.urlHasInviteCredential, "Invite token is redacted from the page and recorded URL before capture", result);
+}
+
+async function redactInstallCredential(ctx) {
+  const result = await ctx.eval(`(() => {
+    const url = new URL(location.href);
+    const token = url.searchParams.get('token') ?? '';
+    const walker = document.createTreeWalker(document.body, NodeFilter.SHOW_TEXT);
+    let redactedTextNodes = 0;
+    let node = walker.nextNode();
+    while (node) {
+      const before = node.nodeValue ?? '';
+      let after = before;
+      if (token) after = after.split(token).join('[redacted]');
+      after = after.replace(/([?&]token=)[^&\\s<>"')]+/g, '$1[redacted]');
+      if (after !== before) {
+        node.nodeValue = after;
+        redactedTextNodes += 1;
+      }
+      node = walker.nextNode();
+    }
+    let redactedLinks = 0;
+    for (const link of document.querySelectorAll('a[href*="token="]')) {
+      const href = link.href;
+      try {
+        const parsed = new URL(href);
+        if (parsed.searchParams.has('token')) {
+          parsed.searchParams.set('token', '[redacted]');
+          link.href = parsed.toString();
+          link.setAttribute('href', parsed.toString());
+          redactedLinks += 1;
+        }
+      } catch {}
+    }
+    if (url.searchParams.has('token')) {
+      url.searchParams.set('token', '[redacted]');
+      history.replaceState(history.state, document.title, url.pathname + url.search + url.hash);
+    }
+    const bodyContainsToken = token ? document.body.innerText.includes(token) : false;
+    const hrefContainsToken = token ? [...document.querySelectorAll('a')].some((link) => link.href.includes(token) || (link.getAttribute('href') ?? '').includes(token)) : false;
+    const urlContainsToken = token ? location.href.includes(token) : false;
+    const urlHasTokenCredential = /[?&]token=(?!%5Bredacted%5D|\\[redacted\\])/.test(location.href);
+    return {
+      redactedTextNodes,
+      redactedLinks,
+      bodyContainsToken,
+      hrefContainsToken,
+      urlContainsToken,
+      urlHasTokenCredential,
+      href: location.origin + location.pathname + location.search.replace(/([?&]token=)[^&\\s<>"')]+/g, '$1[redacted]'),
+    };
+  })()`);
+  witness(ctx, !result.bodyContainsToken && !result.hrefContainsToken && !result.urlContainsToken && !result.urlHasTokenCredential, "Install token is redacted from the page and recorded URL before capture", result);
+}
+
+function redactInstallLink(installLink) {
+  return redactSensitiveUrlQuery(installLink);
+}
+
+function redactSensitiveUrlQuery(url) {
+  try {
+    const parsed = new URL(url);
+    for (const key of [...parsed.searchParams.keys()]) {
+      if (sensitiveQueryKey(key)) {
+        parsed.searchParams.set(key, "[redacted]");
+      }
+    }
+    return parsed.toString();
+  } catch {
+    return "invalid URL";
+  }
+}
+
+function sensitiveQueryKey(key) {
+  const normalized = key.toLowerCase();
+  return normalized === "invite" || normalized.includes("token") || normalized.includes("secret");
+}
+
+async function onboardingState(ctx) {
+  return ctx.eval(`(() => {
+    const bodyText = document.body.innerText;
+    const steps = document.querySelector('[data-testid="member-onboarding-steps"]');
+    return {
+      onboardingExists: Boolean(document.querySelector('[data-testid="member-onboarding"]')),
+      progress: (document.querySelector('[data-testid="member-onboarding-progress"]')?.textContent ?? '').trim(),
+      stepOneState: steps?.querySelector('li:nth-child(1)')?.getAttribute('data-state') ?? null,
+      stepTwoState: steps?.querySelector('li:nth-child(2)')?.getAttribute('data-state') ?? null,
+      resourceOverviewPresent: Boolean(document.querySelector('[data-testid="member-resource-overview"]')),
+      finishPresent: Boolean(document.querySelector('[data-testid="member-onboarding-finish"]')),
+      skipPresent: Boolean(document.querySelector('[data-testid="member-onboarding-skip"]')),
+      bodyText,
+    };
+  })()`);
+}
+
+async function memberOnboardingInstalledStorage(ctx) {
+  const orgId = requireStateString(state.orgId, "organization id");
+  return ctx.eval(`(() => {
+    const orgId = ${JSON.stringify(orgId)};
+    const key = 'openwork:member-onboarding:installed:' + orgId;
+    return {
+      orgId,
+      key,
+      value: localStorage.getItem(key),
+      memberOnboardingKeys: Object.keys(localStorage).filter((candidate) => candidate.includes('openwork:member-onboarding')).sort(),
+    };
+  })()`);
+}
+
+async function fetchMemberVisibleResourceSummary(ctx) {
+  const [marketplaces, plugins, providers] = await Promise.all([
+    inviteeAuthedFetch("/v1/marketplaces?status=active&limit=100"),
+    inviteeAuthedFetch("/v1/plugins?status=active&limit=100"),
+    inviteeAuthedFetch("/v1/llm-providers?scope=usable"),
+  ]);
+
+  witness(ctx, marketplaces.response.ok, "Invitee can load member-visible marketplaces", { status: marketplaces.response.status });
+  witness(ctx, plugins.response.ok, "Invitee can load member-visible plugins", { status: plugins.response.status });
+  witness(ctx, providers.response.ok, "Invitee can load usable LLM providers", { status: providers.response.status });
+
+  const marketplaceItems = Array.isArray(marketplaces.body?.items) ? marketplaces.body.items : [];
+  const pluginItems = Array.isArray(plugins.body?.items) ? plugins.body.items : [];
+  const llmProviders = Array.isArray(providers.body?.llmProviders) ? providers.body.llmProviders : [];
+  const customProviders = llmProviders.filter((provider) => provider?.source !== "openwork");
+  const openWorkProviders = llmProviders.filter((provider) => provider?.source === "openwork");
+  const providerSources = llmProviders.map((provider) => String(provider?.source ?? "unknown")).sort();
+  const expectations = {
+    expectMarketplaces: marketplaceItems.length > 0,
+    expectPlugins: pluginItems.length > 0,
+    expectCustomProviders: customProviders.length > 0,
+    expectOpenWorkModels: openWorkProviders.length > 0,
+  };
+  expectations.hasAnyResources = expectations.expectMarketplaces || expectations.expectPlugins || expectations.expectCustomProviders || expectations.expectOpenWorkModels;
+
+  return {
+    runTag: RUN_TAG,
+    inviteeEmail: INVITEE_EMAIL,
+    organizationId: state.orgId,
+    expectations,
+    counts: {
+      marketplaces: marketplaceItems.length,
+      plugins: pluginItems.length,
+      llmProviders: llmProviders.length,
+      customProviders: customProviders.length,
+      openWorkProviders: openWorkProviders.length,
+    },
+    providerSources,
+  };
+}
+
+async function waitForResourceDomToMatch(ctx, expectations) {
+  await ctx.waitFor(`(() => {
+    const expected = ${JSON.stringify(expectations)};
+    const bodyText = document.body.innerText;
+    const headings = [...document.querySelectorAll('h1,h2,h3,[role="heading"]')].map((heading) => (heading.textContent ?? '').trim());
+    const hasHeading = (label) => headings.includes(label);
+    const overviewPresent = Boolean(document.querySelector('[data-testid="member-resource-overview"]'));
+    const emptyPresent = Boolean(document.querySelector('[data-testid="member-resources-empty"]'));
+    const loading = bodyText.includes('Loading your resources...');
+    return !loading
+      && Boolean(document.querySelector('[data-testid="member-onboarding-complete"]'))
+      && headings.includes('Your workspace')
+      && overviewPresent === expected.hasAnyResources
+      && emptyPresent === !expected.hasAnyResources
+      && hasHeading('LLM providers') === expected.expectCustomProviders
+      && hasHeading('OpenWork Models') === expected.expectOpenWorkModels
+      && hasHeading('Marketplaces') === expected.expectMarketplaces
+      && hasHeading('Plugins') === expected.expectPlugins;
+  })()`, { timeoutMs: 45_000, label: "member resource panels match API truth" });
+}
+
+async function resourceDomState(ctx) {
+  return ctx.eval(`(() => {
+    const headingTexts = [...document.querySelectorAll('h1,h2,h3,[role="heading"]')].map((heading) => (heading.textContent ?? '').trim());
+    const hasHeading = (label) => headingTexts.includes(label);
+    const complete = document.querySelector('[data-testid="member-onboarding-complete"]');
+    return {
+      bodyText: document.body.innerText,
+      completePresent: Boolean(complete),
+      completeText: (complete?.textContent ?? '').trim(),
+      stepsPresent: Boolean(document.querySelector('[data-testid="member-onboarding-steps"]')),
+      workspaceHeadingPresent: hasHeading('Your workspace'),
+      resourceOverviewPresent: Boolean(document.querySelector('[data-testid="member-resource-overview"]')),
+      resourcesEmptyPresent: Boolean(document.querySelector('[data-testid="member-resources-empty"]')),
+      headings: {
+        'LLM providers': hasHeading('LLM providers'),
+        'OpenWork Models': hasHeading('OpenWork Models'),
+        Marketplaces: hasHeading('Marketplaces'),
+        Plugins: hasHeading('Plugins'),
+      },
+      headingTexts,
+    };
+  })()`);
+}
+
+function normalizeEmail(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function parseResponseBody(text) {
+  try {
+    return text ? JSON.parse(text) : null;
+  } catch {
+    return text;
+  }
+}
+
+function invitationsFromPayload(payload) {
+  if (Array.isArray(payload)) {
+    return payload;
+  }
+  if (Array.isArray(payload?.invitations)) {
+    return payload.invitations;
+  }
+  if (Array.isArray(payload?.items)) {
+    return payload.items;
+  }
+  return [];
+}
+
+function compactInvitation(invitation) {
+  return {
+    email: invitation?.email,
+    role: invitation?.role,
+    status: invitation?.status,
+  };
+}
+
+function compactOrg(payload) {
+  return {
+    id: payload?.organization?.id,
+    name: payload?.organization?.name,
+    slug: payload?.organization?.slug,
+  };
+}
+
+function compactOrgPair(org) {
+  return {
+    name: org?.name,
+    slug: org?.slug,
+  };
+}
+
+function compactStateOrg() {
+  return {
+    id: state.orgId,
+    name: state.orgName,
+    slug: state.orgSlug,
+  };
+}
+
+function compactOrgResponse(payload) {
+  return {
+    organization: compactOrg(payload),
+    currentMember: payload?.currentMember,
+    members: Array.isArray(payload?.members) ? payload.members.length : null,
+    invitations: Array.isArray(payload?.invitations) ? payload.invitations.map(compactInvitation) : null,
+  };
+}
+
+function redactAuthBody(body) {
+  if (!body || typeof body !== "object") {
+    return body;
+  }
+  return {
+    token: typeof body.token === "string" ? "<present>" : undefined,
+    user: body.user ? { id: body.user.id, email: body.user.email, emailVerified: body.user.emailVerified } : undefined,
+    session: body.session ? { id: body.session.id, activeOrganizationId: body.session.activeOrganizationId } : undefined,
+    body: body.token ? undefined : body,
+  };
+}

--- a/evals/flows/member-first-load-onboarding.flow.mjs
+++ b/evals/flows/member-first-load-onboarding.flow.mjs
@@ -299,7 +299,7 @@ export default {
       name: "Frame 6 — Details match shared resources",
       run: async (ctx) => {
         await withClient(ctx, INVITEE_CDP_URL, async () => {
-          await ctx.prove("Finishing setup collapses onboarding and renders only member-visible resource panels", {
+          await ctx.prove("Finishing setup collapses onboarding and renders only member-visible resource details", {
             voiceover: vo[5],
             action: async () => {
               await clickTestId(ctx, "member-onboarding-finish");
@@ -316,27 +316,26 @@ export default {
               witness(ctx, observed.stepsPresent === false, "Detailed onboarding steps are hidden after finishing setup", observed);
               witness(ctx, observed.workspaceHeadingPresent === true, "Your workspace heading is present", observed);
               witness(ctx, observed.bodyText.includes("are available to you yet") === false, "No old empty-resource placeholder copy is rendered", observed);
+              witness(ctx, observed.bodyText.includes("Source: https://") === false, "Plugin descriptions do not leak source URLs", observed);
+              witness(ctx, observed.bodyText.includes("No team assignment") === false, "Finished details view does not render the old missing-team chip copy", observed);
 
-              witness(ctx, observed.headings["LLM providers"] === summary.expectations.expectCustomProviders, "LLM providers heading visibility matches usable custom providers", {
-                expected: summary.expectations.expectCustomProviders,
-                observed: observed.headings["LLM providers"],
-                providerSources: summary.providerSources,
-              });
-              witness(ctx, observed.headings["OpenWork Models"] === summary.expectations.expectOpenWorkModels, "OpenWork Models heading visibility matches usable OpenWork providers", {
-                expected: summary.expectations.expectOpenWorkModels,
-                observed: observed.headings["OpenWork Models"],
+              const expectModelsSummary = summary.expectations.expectOpenWorkModels || summary.expectations.expectCustomProviders;
+              witness(ctx, observed.modelsSummaryPresent === expectModelsSummary, "AI models summary visibility matches usable model providers", {
+                expected: expectModelsSummary,
+                observed: observed.modelsSummaryPresent,
                 openWorkProviderCount: summary.counts.openWorkProviders,
+                customProviderCount: summary.counts.customProviders,
                 providerSources: summary.providerSources,
               });
-              witness(ctx, observed.headings.Marketplaces === summary.expectations.expectMarketplaces, "Marketplaces heading visibility matches assigned marketplaces", {
-                expected: summary.expectations.expectMarketplaces,
-                observed: observed.headings.Marketplaces,
-                marketplaceCount: summary.counts.marketplaces,
-              });
-              witness(ctx, observed.headings.Plugins === summary.expectations.expectPlugins, "Plugins heading visibility matches assigned plugins", {
+              witness(ctx, observed.pluginListPresent === summary.expectations.expectPlugins, "Skills and tools list visibility matches assigned plugins", {
                 expected: summary.expectations.expectPlugins,
-                observed: observed.headings.Plugins,
+                observed: observed.pluginListPresent,
                 pluginCount: summary.counts.plugins,
+              });
+              witness(ctx, observed.marketplaceNotePresent === summary.expectations.expectMarketplaces, "Marketplace delivery note visibility matches assigned marketplaces", {
+                expected: summary.expectations.expectMarketplaces,
+                observed: observed.marketplaceNotePresent,
+                marketplaceCount: summary.counts.marketplaces,
               });
               witness(ctx, observed.resourceOverviewPresent === summary.expectations.hasAnyResources, "Resource overview presence matches whether any resource is shared", {
                 expected: summary.expectations.hasAnyResources,
@@ -352,7 +351,7 @@ export default {
             screenshot: {
               name: "details-only-what-was-shared",
               requireText: ["You're set up for", "Your workspace"],
-              rejectText: ["are available to you yet", "Step 1 of 2", "Ask an admin to enable org-provided models", "User Profile"],
+              rejectText: ["are available to you yet", "Step 1 of 2", "Ask an admin to enable org-provided models", "User Profile", "Source: https://", "No team assignment", "Available resources"],
             },
           });
         });
@@ -995,20 +994,22 @@ async function waitForResourceDomToMatch(ctx, expectations) {
     const expected = ${JSON.stringify(expectations)};
     const bodyText = document.body.innerText;
     const headings = [...document.querySelectorAll('h1,h2,h3,[role="heading"]')].map((heading) => (heading.textContent ?? '').trim());
-    const hasHeading = (label) => headings.includes(label);
+    const expectModelsSummary = expected.expectOpenWorkModels || expected.expectCustomProviders;
     const overviewPresent = Boolean(document.querySelector('[data-testid="member-resource-overview"]'));
     const emptyPresent = Boolean(document.querySelector('[data-testid="member-resources-empty"]'));
+    const modelsSummaryPresent = Boolean(document.querySelector('[data-testid="member-models-summary"]'));
+    const pluginListPresent = Boolean(document.querySelector('[data-testid="member-plugin-list"]'));
+    const marketplaceNotePresent = Boolean(document.querySelector('[data-testid="member-marketplace-note"]'));
     const loading = bodyText.includes('Loading your resources...');
     return !loading
       && Boolean(document.querySelector('[data-testid="member-onboarding-complete"]'))
       && headings.includes('Your workspace')
       && overviewPresent === expected.hasAnyResources
       && emptyPresent === !expected.hasAnyResources
-      && hasHeading('LLM providers') === expected.expectCustomProviders
-      && hasHeading('OpenWork Models') === expected.expectOpenWorkModels
-      && hasHeading('Marketplaces') === expected.expectMarketplaces
-      && hasHeading('Plugins') === expected.expectPlugins;
-  })()`, { timeoutMs: 45_000, label: "member resource panels match API truth" });
+      && modelsSummaryPresent === expectModelsSummary
+      && pluginListPresent === expected.expectPlugins
+      && marketplaceNotePresent === expected.expectMarketplaces;
+  })()`, { timeoutMs: 45_000, label: "member resource details match API truth" });
 }
 
 async function resourceDomState(ctx) {
@@ -1024,12 +1025,9 @@ async function resourceDomState(ctx) {
       workspaceHeadingPresent: hasHeading('Your workspace'),
       resourceOverviewPresent: Boolean(document.querySelector('[data-testid="member-resource-overview"]')),
       resourcesEmptyPresent: Boolean(document.querySelector('[data-testid="member-resources-empty"]')),
-      headings: {
-        'LLM providers': hasHeading('LLM providers'),
-        'OpenWork Models': hasHeading('OpenWork Models'),
-        Marketplaces: hasHeading('Marketplaces'),
-        Plugins: hasHeading('Plugins'),
-      },
+      modelsSummaryPresent: Boolean(document.querySelector('[data-testid="member-models-summary"]')),
+      pluginListPresent: Boolean(document.querySelector('[data-testid="member-plugin-list"]')),
+      marketplaceNotePresent: Boolean(document.querySelector('[data-testid="member-marketplace-note"]')),
       headingTexts,
     };
   })()`);

--- a/evals/voiceovers/member-first-load-onboarding.md
+++ b/evals/voiceovers/member-first-load-onboarding.md
@@ -1,0 +1,13 @@
+# member-first-load-onboarding — An invited teammate's first load is a guided start, not a wall of empty panels
+
+1. “An admin invites a new teammate, and the invitation shows up as pending in the workspace members list.”
+
+2. “The teammate opens their invitation link and joins the workspace in one click.”
+
+3. “Their very first dashboard load is a focused welcome with one obvious next step — install OpenWork for this workspace. The old wall of zeroed-out stat cards and 'nothing is available to you yet' panels is gone.”
+
+4. “Step one hands them their own workspace-configured installer, so the download they get is already wired to their organization.”
+
+5. “Confirming the app is installed checks off step one and makes signing in with their work email the active step, so there is always exactly one thing to do next.”
+
+6. “Finishing setup collapses the welcome into a single done row and reveals the workspace details — and those details only show what the team actually shared, with no empty placeholder boxes.”


### PR DESCRIPTION
## The problem

An invited teammate accepts an invitation, clicks *Continue in the browser*, and lands on `/dashboard`. On day one that screen was **nine boxes of noise**:

- 4 stat cards reading `Disabled / 0 / 0 / 0`, one of them saying *"Ask an admin to enable org-provided models."*
- 4 large panels, each a dashed *"No X are available to you yet."* empty box
- an **admin-voiced** share card: *"Give teammates a preconfigured OpenWork…"*
- org **billing** copy leaking to a member: *"The workspace needs an active subscription…"*
- provider **env var names**, which a member cannot act on
- **zero** next action

## What this changes

The member dashboard now leads with a focused two-step guided start and only reveals workspace details once setup is finished or skipped.

1. **Install OpenWork for {Workspace}** — the download is already scoped to their org
2. **Sign in with {their email}** — everything their admins set up appears automatically

Details then render **only the resources the team actually shared**. Empty placeholder boxes are gone: a panel that has nothing simply does not render, and if nothing at all is shared it collapses to one quiet line.

## Real bugs found and fixed while proving this out

| Bug | Fix |
|---|---|
| The download button called `window.open` **after an `await`**, so transient user activation had expired and Chrome silently blocked the popup — a dead end on the member's single most important action. | Use `window.location.assign`, matching `join-org-success.tsx:108` which performs the identical action. |
| The member dashboard called `GET /v1/inference`, which is `orgRoleRoute(["admin"])` and **403s for every member**. That silently produced a misleading `Disabled` card plus an error notice. | Derive OpenWork Models availability from the member-readable usable LLM providers. Also removes one request from first load. |
| The **User Profile** modal auto-opened on top of the welcome card (an invited member never sets a name, so `user.name` is always the default), stacking two first-run experiences. | Defer the profile prompt until onboarding is finished or skipped. Admin behaviour unchanged. |

Also removed member-facing copy that was never theirs to act on: the admin-voiced install-share card, *"Ask an admin to enable org-provided models"*, the subscription/billing line, and provider env var names.

## Proof

`pnpm fraimz --flow member-first-load-onboarding --stack den` — **6 narrated frames, all passing**, driving a real multi-org Den stack through two separate Chrome profiles (admin + invitee).

Frame 6 is adaptive: it reads the four member-visible sources over the API, derives which panels *should* exist, and asserts the DOM matches **exactly** — each heading present **iff** its resource is actually shared. With the seeded org that means Marketplaces + Plugins render while OpenWork Models + Custom LLM Providers are correctly absent, with no empty placeholders.

Frames 3/5/6 also `rejectText: ["User Profile"]` so the modal regression cannot come back silently.

## Tests run

| Command | Result |
|---|---|
| `pnpm --filter @openwork-ee/den-web typecheck` | clean |
| `pnpm evals:typecheck` | clean |
| `pnpm --filter @openwork-ee/den-web test` | 69 pass / 1 fail |
| `pnpm fraimz --flow member-first-load-onboarding --stack den` | **PASSED** — 6/6 frames + voice-over coverage |

The single test failure is **pre-existing on `dev`**: `tests/install-errors.test.ts` asserts install-link copy that commit #3084 already changed. Verified by stashing this branch's changes and re-running on a clean tree — identical failure. Untouched here.

## Notes for the reviewer

- The guided start also appears once for **existing** members (localStorage has no flag yet). That is deliberate — it is dismissible, and it nudges the many members who never installed the desktop app. Say the word and I will scope it to recently-joined members via `currentMember.createdAt`.
- Onboarding state is per-browser `localStorage`, following the existing `marketplace-onboarding-screen.tsx` precedent. There is no server-side per-member "has onboarded" column today.
- Running the flow locally requires the stack in **multi-org** mode (`DEN_ORG_MODE=multi_org`); in `single_org` mode den-web force-flips the invite auth panel from sign-up to sign-in, so a brand-new invitee can never accept an invitation. The runbook at the top of the flow file documents the exact commands.


---

## Follow-up: the details view was still ugly

First pass only removed the *empty* boxes; the populated state was still cluttered. Second commit fixes that:

- **Every fact was stated twice** — a stat card reading "Marketplaces 3" sat above a panel reading "Marketplaces · 3 visible". Dropped the stat row and all four panels.
- **Ragged grid** — the stat row was `xl:grid-cols-4` but usually rendered two cards plus a dead void.
- **Boxes inside boxes** — each item was a bordered card inside a bordered panel, so nothing had hierarchy. Now one bordered list with dividers.
- **Raw URLs leaked** — descriptions are `"<sentence>\n\nSource: https://…"` rendered `line-clamp-2`, so members saw `Source: https://github.com/anthropics/knowledge-…` mid-URL. Now trimmed at the blank line.
- **"No team assignment"** was bold in a floating chip and read like an error about the user. Replaced with a quiet `You're a member of {org}`, mentioning teams only when there are teams.
- **Marketplaces took half the screen** although a member cannot act on one. Demoted to a muted footnote.
- **Admin vocabulary** ("Available resources", "190 skill, hook, MCP, agent, or command parts", "3 visible") replaced with "Skills and tools" / "33 available".

Net **176 fewer lines** in the screen. Frame 6 now asserts the new structure and adds regression witnesses for the source-URL leak and the missing-team chip.
