### PR TITLE
chore(installer): stamp the real release version into installer artifacts

### DIFF
--- a/.github/workflows/release-generic-installer.yml
+++ b/.github/workflows/release-generic-installer.yml
@@ -126,6 +126,16 @@ jobs:
         with:
           bun-version: 1.3.9
 
+      - name: Resolve installer version
+        shell: bash
+        run: |
+          set -euo pipefail
+          version=$(node apps/installer/scripts/installer-version.mjs --release-tag "$RELEASE_TAG")
+          windows_version=$(node apps/installer/scripts/installer-version.mjs --release-tag "$RELEASE_TAG" --windows)
+          echo "INSTALLER_VERSION=$version" >> "$GITHUB_ENV"
+          echo "INSTALLER_WINDOWS_VERSION=$windows_version" >> "$GITHUB_ENV"
+          echo "Stamping installer version $version (windows resource $windows_version)"
+
       - name: Verify build config is the generic placeholder
         shell: bash
         run: |
@@ -165,8 +175,17 @@ jobs:
         run: |
           cd apps/installer
           extra_args=()
-          if [ "${{ matrix.os_type }}" = "windows" ]; then extra_args+=(--windows-icon=assets/icon.ico); fi
+          if [ "${{ matrix.os_type }}" = "windows" ]; then
+            extra_args+=(--windows-icon=assets/icon.ico)
+            # Version resource on the .exe so Windows properties and support
+            # tickets show the real build.
+            if [ -n "$INSTALLER_WINDOWS_VERSION" ]; then extra_args+=("--windows-version=$INSTALLER_WINDOWS_VERSION"); fi
+            extra_args+=("--windows-title=OpenWork Installer")
+            extra_args+=("--windows-publisher=Different AI")
+            extra_args+=("--windows-description=Installs OpenWork on this computer")
+          fi
           bun build --compile --minify --target=${{ matrix.bun_target }} "${extra_args[@]}" \
+            --define "process.env.OPENWORK_INSTALLER_VERSION=\"$INSTALLER_VERSION\"" \
             src/index.ts src/server-worker.ts \
             --outfile "dist/openwork-installer"
 
@@ -179,6 +198,12 @@ jobs:
           cd apps/installer
           binary=dist/openwork-installer
           if [ "${{ matrix.os_type }}" = "windows" ]; then binary=dist/openwork-installer.exe; fi
+          reported=$("$binary" --version)
+          printf '%s\n' "$reported"
+          if [ "$reported" != "openwork-installer $INSTALLER_VERSION" ]; then
+            echo "Compiled installer reports '$reported', expected 'openwork-installer $INSTALLER_VERSION'" >&2
+            exit 1
+          fi
           set +e
           output=$("$binary" --headless --dry-run 2>&1)
           status=$?
@@ -205,7 +230,9 @@ jobs:
           mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources"
           cp dist/openwork-installer "$APP/Contents/MacOS/openwork-installer"
           cp assets/icon.icns "$APP/Contents/Resources/icon.icns"
-          cat > "$APP/Contents/Info.plist" <<'PLIST'
+          # Unquoted heredoc: $INSTALLER_VERSION is the only expansion here, and
+          # this plist must be written before signing so the version is signed in.
+          cat > "$APP/Contents/Info.plist" <<PLIST
           <?xml version="1.0" encoding="UTF-8"?>
           <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
           <plist version="1.0">
@@ -216,13 +243,14 @@ jobs:
             <key>CFBundleExecutable</key><string>openwork-installer</string>
             <key>CFBundleIconFile</key><string>icon</string>
             <key>CFBundlePackageType</key><string>APPL</string>
-            <key>CFBundleShortVersionString</key><string>1.0.0</string>
-            <key>CFBundleVersion</key><string>1</string>
+            <key>CFBundleShortVersionString</key><string>$INSTALLER_VERSION</string>
+            <key>CFBundleVersion</key><string>$INSTALLER_VERSION</string>
             <key>LSMinimumSystemVersion</key><string>11.0</string>
             <key>NSHighResolutionCapable</key><true/>
           </dict>
           </plist>
           PLIST
+          plutil -p "$APP/Contents/Info.plist"
 
       - name: Sign, notarize, and package macOS DMG
         if: matrix.os_type == 'macos'
@@ -311,7 +339,7 @@ jobs:
 
           mkdir -p "$RUNNER_TEMP/out"
           DMG="$RUNNER_TEMP/out/${{ matrix.asset }}"
-          node scripts/package-mac-dmg.mjs --input "$APP" --output "$DMG"
+          node scripts/package-mac-dmg.mjs --input "$APP" --output "$DMG" --version "$INSTALLER_VERSION"
           hdiutil verify "$DMG"
           codesign --force --timestamp --sign "$IDENTITY" "$DMG"
           codesign --verify --verbose "$DMG"

--- a/apps/app/scripts/bump-version.mjs
+++ b/apps/app/scripts/bump-version.mjs
@@ -67,13 +67,23 @@ const updatePackageJson = async (nextVersion) => {
     "package.json",
   );
   const serverPath = path.join(REPO_ROOT, "apps", "server", "package.json");
+  const installerPath = path.join(
+    REPO_ROOT,
+    "apps",
+    "installer",
+    "package.json",
+  );
   const uiData = await readJson(uiPath);
   const tauriData = await readJson(tauriPath);
   const orchestratorData = await readJson(orchestratorPath);
   const serverData = await readJson(serverPath);
+  const installerData = await readJson(installerPath);
   uiData.version = nextVersion;
   tauriData.version = nextVersion;
   orchestratorData.version = nextVersion;
+  // The installer stamps this version into its artifacts when a release build
+  // has no tag to resolve from.
+  installerData.version = nextVersion;
 
   // Ensure openwork-orchestrator uses the same openwork-server version.
   orchestratorData.dependencies = orchestratorData.dependencies ?? {};
@@ -88,6 +98,7 @@ const updatePackageJson = async (nextVersion) => {
       JSON.stringify(orchestratorData, null, 2) + "\n",
     );
     await writeFile(serverPath, JSON.stringify(serverData, null, 2) + "\n");
+    await writeFile(installerPath, JSON.stringify(installerData, null, 2) + "\n");
   }
 };
 
@@ -146,6 +157,7 @@ const main = async () => {
           "apps/desktop/package.json",
           "apps/orchestrator/package.json",
           "apps/server/package.json",
+          "apps/installer/package.json",
           "ee/apps/den-api/src/generated/desktop-versions.ts",
           "pnpm-lock.yaml",
         ],

--- a/apps/installer/package.json
+++ b/apps/installer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@openwork/installer",
-  "version": "0.1.0",
+  "version": "0.18.1",
   "private": true,
   "type": "module",
   "description": "OpenWork desktop installer: resolves an install-link config, writes desktop bootstrap config, then downloads and installs the newest supported desktop app.",

--- a/apps/installer/scripts/dmg-layout.mjs
+++ b/apps/installer/scripts/dmg-layout.mjs
@@ -7,6 +7,12 @@ export const dmgLayout = {
   window: { left: 100, top: 100, width: 660, height: 400 },
 }
 
+// The mounted volume is where a user reads which build they are installing.
+export function dmgVolumeName(version) {
+  const trimmed = (version ?? "").trim()
+  return trimmed ? `${dmgLayout.volumeName} ${trimmed}` : dmgLayout.volumeName
+}
+
 export function dmgWindowBounds(window) {
   return [window.left, window.top, window.left + window.width, window.top + window.height]
 }
@@ -23,8 +29,8 @@ export function buildTiffutilArgs(assetDir, outputPath) {
   return ["-cathidpicheck", `${assetDir}/bg.png`, `${assetDir}/bg@2x.png`, "-out", outputPath]
 }
 
-export function buildReadWriteDmgArgs({ sourceFolder, outputPath }) {
-  return ["create", "-format", "UDRW", "-volname", dmgLayout.volumeName, "-srcfolder", sourceFolder, "-ov", outputPath]
+export function buildReadWriteDmgArgs({ sourceFolder, outputPath, volumeName = dmgLayout.volumeName }) {
+  return ["create", "-format", "UDRW", "-volname", volumeName, "-srcfolder", sourceFolder, "-ov", outputPath]
 }
 
 export function buildCompressedDmgArgs({ inputPath, outputPath }) {

--- a/apps/installer/scripts/installer-version.mjs
+++ b/apps/installer/scripts/installer-version.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+// Single source of truth for the version stamped into the installer artifacts.
+// CI resolves it from the release tag; local builds fall back to package.json so
+// a developer build never claims to be a release.
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..")
+
+const versionPattern = /^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$/
+
+export function versionFromReleaseTag(releaseTag) {
+  const candidate = (releaseTag ?? "").trim().replace(/^v/, "")
+  return versionPattern.test(candidate) ? candidate : ""
+}
+
+export function readPackageVersion() {
+  return JSON.parse(readFileSync(path.join(packageRoot, "package.json"), "utf8")).version
+}
+
+// Precedence: an explicit --version/env value, then the release tag, then the
+// committed package.json version.
+export function resolveInstallerVersion({ explicit, releaseTag, packageVersion } = {}) {
+  const explicitVersion = (explicit ?? "").trim()
+  if (explicitVersion) return explicitVersion
+  const tagVersion = versionFromReleaseTag(releaseTag)
+  if (tagVersion) return tagVersion
+  return (packageVersion ?? "").trim()
+}
+
+// Windows version resources are four numeric fields, so a semver prerelease
+// suffix has no representation there and only the numeric core is used.
+export function windowsFileVersion(version) {
+  const core = (version ?? "").trim().split(/[-+]/)[0]
+  return /^\d+\.\d+\.\d+$/.test(core) ? `${core}.0` : ""
+}
+
+function argValue(name) {
+  const inline = process.argv.find((entry) => entry.startsWith(`${name}=`))
+  if (inline) return inline.slice(name.length + 1).trim()
+  const index = process.argv.indexOf(name)
+  return index >= 0 ? process.argv[index + 1]?.trim() ?? "" : ""
+}
+
+export function installerVersionFromEnvironment() {
+  return resolveInstallerVersion({
+    explicit: argValue("--version") || process.env.OPENWORK_INSTALLER_VERSION,
+    releaseTag: argValue("--release-tag") || process.env.OPENWORK_INSTALLER_RELEASE_TAG,
+    packageVersion: readPackageVersion(),
+  })
+}
+
+// `node scripts/installer-version.mjs --release-tag v0.18.1` prints the version
+// the release workflow stamps into every installer artifact.
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const version = installerVersionFromEnvironment()
+  if (!version) {
+    console.error("[installer-version] Could not resolve an installer version.")
+    process.exit(1)
+  }
+  console.log(process.argv.includes("--windows") ? windowsFileVersion(version) : version)
+}

--- a/apps/installer/scripts/package-mac-dmg.mjs
+++ b/apps/installer/scripts/package-mac-dmg.mjs
@@ -12,7 +12,9 @@ import {
   buildTiffutilArgs,
   dmgBackgroundPaths,
   dmgLayout,
+  dmgVolumeName,
 } from "./dmg-layout.mjs"
+import { installerVersionFromEnvironment } from "./installer-version.mjs"
 
 const appName = "Install OpenWork.app"
 const executableName = "openwork-installer"
@@ -46,7 +48,7 @@ function defaultInputPath() {
   return path.resolve("dist", executableName)
 }
 
-function writeInfoPlist(appPath) {
+function writeInfoPlist(appPath, version) {
   writeFileSync(path.join(appPath, "Contents", "Info.plist"), `<?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -57,8 +59,8 @@ function writeInfoPlist(appPath) {
   <key>CFBundleExecutable</key><string>${executableName}</string>
   <key>CFBundleIconFile</key><string>icon</string>
   <key>CFBundlePackageType</key><string>APPL</string>
-  <key>CFBundleShortVersionString</key><string>1.0.0</string>
-  <key>CFBundleVersion</key><string>1</string>
+  <key>CFBundleShortVersionString</key><string>${version}</string>
+  <key>CFBundleVersion</key><string>${version}</string>
   <key>LSMinimumSystemVersion</key><string>11.0</string>
   <key>NSHighResolutionCapable</key><true/>
 </dict>
@@ -75,7 +77,7 @@ function copyAppIcon(appPath) {
   cpSync(iconAssetPath, iconPath)
 }
 
-function stageInput(inputPath, stagedAppPath) {
+function stageInput(inputPath, stagedAppPath, version) {
   if (!existsSync(inputPath)) fail(`Input not found: ${inputPath}`)
   const inputStat = statSync(inputPath)
   if (inputStat.isDirectory()) {
@@ -83,7 +85,9 @@ function stageInput(inputPath, stagedAppPath) {
     execFileSync("ditto", [inputPath, stagedAppPath], { stdio: "inherit" })
     const stagedBinary = path.join(stagedAppPath, "Contents", "MacOS", executableName)
     if (!existsSync(stagedBinary)) fail(`App bundle is missing Contents/MacOS/${executableName}`)
-    if (!existsSync(path.join(stagedAppPath, "Contents", "Info.plist"))) writeInfoPlist(stagedAppPath)
+    // A staged .app arrives from CI already signed; rewriting its Info.plist
+    // would invalidate that signature, so only fill in a missing one.
+    if (!existsSync(path.join(stagedAppPath, "Contents", "Info.plist"))) writeInfoPlist(stagedAppPath, version)
     copyAppIcon(stagedAppPath)
     return
   }
@@ -93,7 +97,7 @@ function stageInput(inputPath, stagedAppPath) {
   mkdirSync(macOsDir, { recursive: true })
   cpSync(inputPath, path.join(macOsDir, executableName))
   chmodSync(path.join(macOsDir, executableName), 0o755)
-  writeInfoPlist(stagedAppPath)
+  writeInfoPlist(stagedAppPath, version)
   copyAppIcon(stagedAppPath)
 }
 
@@ -158,17 +162,20 @@ async function main() {
   const inputPath = path.resolve(argValue("--input") || defaultInputPath())
   const outDir = path.resolve(argValue("--out-dir") || "dist")
   const outputPath = path.resolve(argValue("--output") || path.join(outDir, `OpenWork-Installer-${arch}.dmg`))
+  const version = installerVersionFromEnvironment()
+  if (!version) fail("Could not resolve an installer version. Pass --version 0.18.1.")
+  const volumeName = dmgVolumeName(version)
   const stagingRoot = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-dmg-root-"))
   const imageRoot = mkdtempSync(path.join(os.tmpdir(), "openwork-installer-dmg-image-"))
   const rwImagePath = path.join(imageRoot, "OpenWork-Installer.readwrite.dmg")
-  const mountPoint = path.join(imageRoot, dmgLayout.volumeName)
+  const mountPoint = path.join(imageRoot, volumeName)
   let attached = false
 
   try {
     mkdirSync(path.dirname(outputPath), { recursive: true })
-    stageInput(inputPath, path.join(stagingRoot, appName))
+    stageInput(inputPath, path.join(stagingRoot, appName), version)
     stageDmgBackground(stagingRoot)
-    execFileSync("hdiutil", buildReadWriteDmgArgs({ sourceFolder: stagingRoot, outputPath: rwImagePath }), { stdio: "inherit" })
+    execFileSync("hdiutil", buildReadWriteDmgArgs({ sourceFolder: stagingRoot, outputPath: rwImagePath, volumeName }), { stdio: "inherit" })
     attachReadWriteDmg(rwImagePath, mountPoint)
     attached = true
     applyFinderLayout(mountPoint)
@@ -176,7 +183,7 @@ async function main() {
     detachDmg(mountPoint)
     attached = false
     execFileSync("hdiutil", buildCompressedDmgArgs({ inputPath: rwImagePath, outputPath }), { stdio: "inherit" })
-    console.log(`[package-mac-dmg] Wrote ${outputPath}`)
+    console.log(`[package-mac-dmg] Wrote ${outputPath} (version ${version})`)
   } finally {
     if (attached) detachDmg(mountPoint)
     rmSync(stagingRoot, { recursive: true, force: true })

--- a/apps/installer/src/index.ts
+++ b/apps/installer/src/index.ts
@@ -5,9 +5,15 @@ import { runInstall, scheduleInstallerSelfCleanup } from "./install"
 import { openExternalUrl } from "./open-external-url"
 import { startInstallerServer } from "./server"
 import { loadSystemCaCertificates } from "./system-ca"
+import { INSTALLER_VERSION } from "./version"
 
 const rawArgs = Bun.argv.slice(2)
 const args = new Set(rawArgs)
+
+if (args.has("--version")) {
+  console.log(`openwork-installer ${INSTALLER_VERSION}`)
+  process.exit(0)
+}
 const headless = args.has("--headless") || process.env.OPENWORK_INSTALLER_HEADLESS === "1"
 const dryRun = args.has("--dry-run") || process.env.OPENWORK_INSTALLER_DRY_RUN === "1"
 const smokeExitMs = Number.parseInt(process.env.OPENWORK_INSTALLER_SMOKE_EXIT_MS ?? "", 10)

--- a/apps/installer/src/ui-html.ts
+++ b/apps/installer/src/ui-html.ts
@@ -1,5 +1,6 @@
 import { installerConfigSourceLabel, type InstallerConfigResolution } from "./config"
 import { OPENWORK_LOGO_SVG } from "./openwork-logo"
+import { INSTALLER_VERSION } from "./version"
 
 function escapeHtml(value: string): string {
   return value.replace(/[&<>"']/g, (char) => {
@@ -109,12 +110,15 @@ export function renderInstallerHtml(resolution: InstallerConfigResolution | null
   .activation-copy, .activation-expiry { color: #71717a; font-size: 11px; line-height: 1.4; }
   #activation-link { background: #ffffff; color: #52525b; font-size: 10px; }
   #copy-activation, #retry-activation { padding-left: 12px; padding-right: 12px; }
+  /* Pinned to the window edge so identifying the build never shifts the primary action. */
+  .version { position: fixed; bottom: 6px; left: 0; right: 0; text-align: center; font-size: 10px; color: #c8c8cc; }
 </style>
 </head>
 <body>
 <main>
 ${configuredContent}
 </main>
+<div class="version">Installer ${escapeHtml(INSTALLER_VERSION)}</div>
 <script>
   const TOKEN = ${JSON.stringify(token)};
   const CONFIGURED = ${config ? "true" : "false"};

--- a/apps/installer/src/version.ts
+++ b/apps/installer/src/version.ts
@@ -1,0 +1,5 @@
+// Release builds are stamped by the release workflow (--define); running from
+// source or compiling locally falls back to the committed package version.
+import packageJson from "../package.json"
+
+export const INSTALLER_VERSION = process.env.OPENWORK_INSTALLER_VERSION?.trim() || packageJson.version

--- a/apps/installer/test/installer.test.ts
+++ b/apps/installer/test/installer.test.ts
@@ -14,8 +14,10 @@ import {
   buildTiffutilArgs,
   dmgBackgroundPaths,
   dmgLayout,
+  dmgVolumeName,
   dmgWindowBounds,
 } from "../scripts/dmg-layout.mjs"
+import { resolveInstallerVersion, versionFromReleaseTag, windowsFileVersion } from "../scripts/installer-version.mjs"
 import { desktopBootstrapPath, legacyDesktopBootstrapPath } from "../src/bootstrap-path"
 import { buildConstantsConfig, parseInstallLinkInput, resolveInstallLinkConfig, resolveInstallerConfig } from "../src/config"
 import { removableInstallerBundlePath, windowsInstalledExePath, writeBootstrapConfig } from "../src/install"
@@ -32,6 +34,8 @@ import {
   summarizeSystemCaSources,
   type SystemCaLoaders,
 } from "../src/system-ca"
+import { renderInstallerHtml } from "../src/ui-html"
+import { INSTALLER_VERSION } from "../src/version"
 
 type SelfSignedCertificate = {
   cert: string
@@ -148,6 +152,49 @@ describe("mac DMG layout helpers", () => {
 
   test("escapes AppleScript strings", () => {
     expect(appleScriptString('/tmp/Install "OpenWork"/back\\ground.tiff')).toBe('/tmp/Install \\"OpenWork\\"/back\\\\ground.tiff')
+  })
+
+  test("names the mounted volume after the build being installed", () => {
+    expect(dmgVolumeName("0.18.1")).toBe("Install OpenWork 0.18.1")
+    expect(dmgVolumeName("")).toBe("Install OpenWork")
+    expect(buildReadWriteDmgArgs({ sourceFolder: "/tmp/root", outputPath: "/tmp/openwork.rw.dmg", volumeName: "Install OpenWork 0.18.1" })).toContain(
+      "Install OpenWork 0.18.1",
+    )
+  })
+})
+
+describe("installer version resolution", () => {
+  test("reads the version out of a release tag", () => {
+    expect(versionFromReleaseTag("v0.18.1")).toBe("0.18.1")
+    expect(versionFromReleaseTag("0.18.1")).toBe("0.18.1")
+    expect(versionFromReleaseTag(" v1.2.3-rc.1 ")).toBe("1.2.3-rc.1")
+  })
+
+  test("ignores tags that are not releases", () => {
+    expect(versionFromReleaseTag("installer-release-e2e-abc123")).toBe("")
+    expect(versionFromReleaseTag("v0.18")).toBe("")
+    expect(versionFromReleaseTag("")).toBe("")
+    expect(versionFromReleaseTag(undefined)).toBe("")
+  })
+
+  test("prefers an explicit version, then the release tag, then package.json", () => {
+    expect(resolveInstallerVersion({ explicit: "9.9.9", releaseTag: "v0.18.1", packageVersion: "0.1.0" })).toBe("9.9.9")
+    expect(resolveInstallerVersion({ releaseTag: "v0.18.1", packageVersion: "0.1.0" })).toBe("0.18.1")
+    expect(resolveInstallerVersion({ releaseTag: "not-a-release", packageVersion: "0.1.0" })).toBe("0.1.0")
+    expect(resolveInstallerVersion({})).toBe("")
+  })
+
+  test("reduces a version to a four-field Windows resource", () => {
+    expect(windowsFileVersion("0.18.1")).toBe("0.18.1.0")
+    expect(windowsFileVersion("1.2.3-rc.1")).toBe("1.2.3.0")
+    expect(windowsFileVersion("nightly")).toBe("")
+  })
+
+  test("shows the build in the installer window without competing with the primary action", () => {
+    const html = renderInstallerHtml(null, "token")
+    expect(html).toContain(`<div class="version">Installer ${INSTALLER_VERSION}</div>`)
+    expect(html).toContain(".version { position: fixed;")
+    expect(INSTALLER_VERSION).toMatch(/^\d+\.\d+\.\d+/)
   })
 })
 


### PR DESCRIPTION
The installer shipped as an unversioned artifact: `apps/installer/package.json` was pinned at `0.1.0`, the macOS bundle hardcoded `CFBundleShortVersionString` `1.0.0`, the Windows `.exe` carried no version resource, and nothing in the UI or on the binary told you which build you had. That makes support ("which installer are you running?") guesswork.

## What changed

- **One source of truth** for the stamped version: `apps/installer/scripts/installer-version.mjs`. Precedence is explicit flag/env, then the release tag, then the committed `package.json` — so a developer build never claims to be a release.
- **The release workflow resolves it from the tag** and stamps it everywhere: `bun build --define` for the runtime constant, the signed macOS `Info.plist` (both `CFBundleShortVersionString` and `CFBundleVersion`), a Windows version resource plus title/publisher/description on the `.exe`, and the DMG volume name.
- **CI asserts the stamp took.** The compiled binary is run with `--version` and the build fails if it does not report `openwork-installer <version>`, so a silently unstamped artifact cannot ship.
- **The installer UI shows the build** in a fixed footer line, positioned so it never shifts the primary action.
- **`bump-version.mjs` now bumps `apps/installer/package.json`** alongside the other packages and includes it in the release commit, so the fallback stays truthful.

## Asset filenames are deliberately unchanged

The published names stay `OpenWork-Installer-mac-arm64.dmg` / `-mac-x64.dmg` / `-win-x64.exe`. den-api's `genericInstallerArtifactName()` resolves download links by those stable names, and the org install guide in den-web now shows the exact filename to the user, so putting a version in the filename would break both. The version lives inside the artifact instead, where it is signed and inspectable.

## Testing

- `bun test` in `apps/installer` — 52 pass, 0 fail
- Resolver sanity-checked directly: `--release-tag v0.19.0` → `0.19.0`, with `--windows` → `0.19.0.0`, and no tag → `0.18.1` from `package.json`

**Not verified locally:** the macOS signing/notarization and Windows resource-stamping paths only run in CI with release credentials, so the end-to-end stamp needs a release build to confirm. The `--version` assertion in the workflow is what guards it.

Made with [Cursor](https://cursor.com)