### PR TITLE
test(den-web): assert install-link error intent instead of stale copy

### DIFF
--- a/ee/apps/den-web/tests/install-errors.test.ts
+++ b/ee/apps/den-web/tests/install-errors.test.ts
@@ -3,9 +3,13 @@ import { getInstallConfigErrorMessage } from "../app/(den)/_lib/install-errors";
 
 describe("getInstallConfigErrorMessage", () => {
   test("does not expose the API error code for expired or invalid links", () => {
-    expect(getInstallConfigErrorMessage({ error: "install_link_not_found" }, 404)).toBe(
-      "This install link is expired or no longer available. Ask your organization admin for a fresh link.",
-    );
+    const message = getInstallConfigErrorMessage({ error: "install_link_not_found" }, 404);
+
+    expect(message).not.toContain("install_link_not_found");
+    expect(message).not.toContain("_");
+    expect(message).toContain("install link");
+    expect(message).toMatch(/expired/i);
+    expect(message).toMatch(/admin/i);
   });
 
   test("keeps useful server messages for other failures", () => {


### PR DESCRIPTION
## Problem
`ee/apps/den-web/tests/install-errors.test.ts` **fails on a clean checkout of `dev`**. The assertion pinned copy that no longer ships:

- test expected: `This install link is expired or no longer available. Ask your organization admin for a fresh link.`
- code returns: `This install link has expired or was replaced. Ask your workspace admin for a fresh one from the Members page.`

The shipped copy is the better one (it names the Members page), so the test was stale, not the product.

## Fix
Assert the actual contract instead of a brittle literal: the message must not leak the raw API error code, and must name the link, the expiry, and who to ask. Wording can now improve without breaking the test.

## Verification
```
pnpm --filter @openwork-ee/den-web exec bun test tests/install-errors.test.ts
  2 pass, 0 fail
pnpm --filter @openwork-ee/den-web test
  73 pass, 0 fail
```
Found while auditing unrelated work — this one is a pure test fix and unblocks a red suite on `dev`.
