### PR TITLE
docs: explain skills vs plugins vs MCP, and how to create/publish a skill

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -39,6 +39,9 @@
               "start-here/do-work-with-it/control-the-browser",
               "start-here/do-work-with-it/cross-chat-memory",
               "start-here/do-work-with-it/workflows",
+              "start-here/do-work-with-it/skills-plugins-and-mcp",
+              "start-here/do-work-with-it/create-a-skill-from-chat",
+              "start-here/do-work-with-it/publish-and-copy-a-skill",
               "start-here/do-work-with-it/share-your-setup"
             ]
           },

--- a/packages/docs/start-here/do-work-with-it/create-a-skill-from-chat.mdx
+++ b/packages/docs/start-here/do-work-with-it/create-a-skill-from-chat.mdx
@@ -1,0 +1,29 @@
+---
+title: "Create a skill from chat"
+description: "Turn a useful OpenWork chat into a reusable skill"
+---
+
+Do the work once in chat before you turn it into instructions.
+
+## Turn a good chat into a skill
+
+1. Finish the task in chat and keep the thread open.
+2. Ask: `Turn what we just did into a reusable skill`. OpenWork uses the Cloud skill flow when it is available, or a local skill only when you ask for one.
+3. If the helper is available, start from `/skill-creator` in the composer.
+
+<Frame>
+  ![Composer showing the skill-creator command entered](/images/skill-import-skill-creator-command.png)
+</Frame>
+
+4. The agent writes a complete `SKILL.md`, then reads back or verifies the skill before saying it is ready.
+5. Use the new `/skill-name` from the composer, or describe a matching task and let the agent load it.
+
+<Frame>
+  ![Composer skill menu highlighting a workspace guide skill](/images/skill-import-use-in-chat.png)
+</Frame>
+
+6. If OpenWork says reload is required, click `Reload now`, then refine the skill by asking for changes in chat.
+
+<Frame>
+  ![Reload required banner with Reload now and Later buttons](/images/skill-import-reload-required.png)
+</Frame>

--- a/packages/docs/start-here/do-work-with-it/publish-and-copy-a-skill.mdx
+++ b/packages/docs/start-here/do-work-with-it/publish-and-copy-a-skill.mdx
@@ -1,0 +1,15 @@
+---
+title: "Publish and copy a skill"
+description: "Where shared skills show up and how to customize them safely"
+---
+
+Publishing is an admin action in OpenWork Cloud, not a desktop marketplace editor.
+
+## Publish without surprising the team
+
+1. In the Cloud dashboard, an admin creates an organization marketplace with `New marketplace` and `Create marketplace`.
+2. When a plugin is published to that marketplace, its skills show up for teammates who have access.
+3. Marketplace access can be everyone in the organization, specific teams, or individual members. Follow the full admin path in [Team quickstart](/cloud/team-quickstart).
+4. The desktop app shows assigned marketplace content in `Settings > Extensions`; it does not create or fork marketplaces.
+5. To change a shared skill without affecting others, make your own copy in a marketplace you control and edit that copy.
+6. For lighter changes, write a new skill that tells the agent to use the standard skill first, then add your extra instructions.

--- a/packages/docs/start-here/do-work-with-it/share-your-setup.mdx
+++ b/packages/docs/start-here/do-work-with-it/share-your-setup.mdx
@@ -1,25 +1,14 @@
 ---
 title: "Share skills with your team"
-description: "Learn how to save skills to OpenWork Cloud for your teammates"
+description: "Find team skills in the desktop app and publish them through Cloud marketplaces"
 ---
 
-OpenWork sharing focuses on saving skills to your OpenWork Cloud organization so teammates can install them from the Cloud tab.
+OpenWork no longer shares skills from a `Workspace > Skills` screen. The desktop app shows what is already available to your agent.
 
-## How to save a skill to your OpenWork Cloud organization
+## Find shared skills
 
-Open `Workspace -> Skills` in the desktop app.
-
-<Frame>
-  ![Skills management page showing installed skills](/images/sharing-skills-list.png)
-</Frame>
-
-1. Pick the installed skill you want to share.
-2. Click `Share with team`.
-3. Sign in to OpenWork Cloud if needed.
-4. Pick the sharing permission:
-    - `Organization Only - Not in hub` keeps the skill available to the active org without adding it to a hub.
-    - `Private for me only` uploads it to the org but keeps it limited to your account.
-    - If a hub is available, you can also attach the skill to that hub during the same flow.
-5. Click `Upload and save`.
-
-After that, teammates can install the skill from `Skills -> Cloud`. If the skill was attached to a hub, it also appears in `Settings -> Cloud -> Skills` with the hub label so people can sync or remove it later.
+1. Open `Settings > Extensions` in the desktop app.
+2. Use the `Skills` filter or search to find skills from your workspace and organization.
+3. Click a skill and choose `View details` to read its description; local skills can be revealed or removed, while OpenWork Connect skills are read-only.
+4. Click `Refresh` if an admin just published a marketplace or changed your access.
+5. To publish or customize a skill for teammates, use an organization marketplace in OpenWork Cloud instead: [Publish and copy a skill](/start-here/do-work-with-it/publish-and-copy-a-skill).

--- a/packages/docs/start-here/do-work-with-it/skills-plugins-and-mcp.mdx
+++ b/packages/docs/start-here/do-work-with-it/skills-plugins-and-mcp.mdx
@@ -1,0 +1,19 @@
+---
+title: "Skills, plugins, and MCP"
+description: "Choose the right OpenWork building block for a reusable setup"
+---
+
+MCP, skills, and plugins solve different parts of the same setup.
+
+## Choose the right unit
+
+| Use | Means | Reach for it when |
+| --- | --- | --- |
+| MCP | The connector to a system like mail, ticketing, or CRM. | The agent needs to call that system. |
+| Skill | Written instructions the agent loads when a task matches. | One workflow should become repeatable. |
+| Plugin | The package a marketplace distributes. | Related skills should travel together. |
+
+1. Keep using connectors for MCPs. An MCP is the system connection, not the playbook.
+2. Create a skill when one set of instructions is enough. Creating a skill already creates a single-skill plugin for you.
+3. Use a multi-skill plugin when several skills make one system usable, such as ticketing skills that fill gaps around a thin MCP.
+4. Keep those system skills together because they depend on the system's capabilities, not one person's workflow.


### PR DESCRIPTION
## Why
Enterprise rollout feedback kept returning to the same three questions, and we had **no documentation for any of them**:

1. "We know how to make a skill — when do we make a *plugin* instead?"
2. "How do I turn what I just did into a reusable skill?"
3. "Where does a published skill show up, and can I change a shared one without affecting everyone?"

## What
Three short pages in the existing house style (`title`/`description` frontmatter, 10–30 lines, numbered steps, backticked UI paths), registered in `docs.json`:

| Page | Lines | Answers |
|---|---|---|
| `start-here/do-work-with-it/skills-plugins-and-mcp.mdx` | 19 | MCP = the connector, skill = the instructions, plugin = the package. Includes the decision rule: creating a skill already makes a single-skill plugin; reach for a multi-skill plugin when several skills exist to make **one system** usable. |
| `start-here/do-work-with-it/create-a-skill-from-chat.mdx` | 29 | The real conversational flow — do the task, then ask for a skill. |
| `start-here/do-work-with-it/publish-and-copy-a-skill.mdx` | 15 | Org marketplaces, access scoping, and taking your own copy to customize safely. |

**Free win:** the create-a-skill page uses screenshots that were already committed at `packages/docs/images/skill-import-*.png` and referenced by no page.

## Also fixed
`share-your-setup.mdx` told readers to open `Workspace -> Skills`, **a surface that no longer exists**. Corrected to the live inventory (`Settings > Extensions`) and cross-linked to the new publish page.

## Verification
- `docs.json` parses; all five new/changed page paths resolve to real files on disk.
- Every referenced image verified present with `ls`.
- Every internal link target verified to exist.
- Deliberately **not** documented: scheduled workflows/automations (removed in `53e0e1d11`), and desktop marketplace creation/forking (the desktop app is read-only for marketplaces).

Docs-only, no runtime path — no fraimz.
