### PR TITLE
docs: document organization prompt cards, team scoping, and token usage

### DIFF
--- a/docs/desktop-app-policies.md
+++ b/docs/desktop-app-policies.md
@@ -14,6 +14,14 @@ Do not duplicate the list of policy IDs in app docs or feature code unless a fea
 
 For boolean policy keys, `false` means the feature is restricted or disabled. `true` or `undefined` means the app should not block the feature locally.
 
+## Organization Prompt Suggestions
+
+Desktop policy documents can also include `onboardingPrompts` and `onboardingPromptDescriptions`. The shared schema requires 2 or 3 prompts, caps each prompt at 500 characters, and caps each description at 120 characters.
+
+In the desktop app, `onboardingPromptDescriptions` become prompt-card titles. `onboardingPrompts` become the visible card descriptions and the text inserted into the composer when a user clicks a card; the click does not auto-send.
+
+Boolean policy keys are OR-unioned across matching policies by `calculateEffectiveDesktopPolicy()`. Prompt suggestions are different: `selectEffectiveOnboardingPromptConfig()` picks one matching prompt config by highest `priority`, then earliest `createdAt`, then policy `id`, falling back to the default policy only when no targeted prompt config applies.
+
 ## Preferred Check
 
 Use `useCheckDesktopRestriction()` when gating app behavior.

--- a/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
+++ b/packages/docs/cloud/share-with-your-team/desktop-policies.mdx
@@ -3,7 +3,7 @@ title: "Desktop policies"
 description: "Use OpenWork Cloud to control desktop app capabilities for members and teams."
 ---
 
-Desktop policies let organization owners and admins manage what the OpenWork desktop app allows after a member signs in to Cloud. Policies can apply to the whole organization through the default policy, or to specific members and teams through assigned policies. The desktop app caches the effective policy, applies it on reload, and refreshes it when the active Cloud organization changes or the Cloud account is refreshed.
+Desktop policies let organization owners and admins manage what the OpenWork desktop app allows after a member signs in to Cloud. Policies can apply to the whole organization through the default policy, or to specific members and teams through assigned policies. Policies can also provide [team prompt cards](/cloud/share-with-your-team/team-prompt-cards). The desktop app caches the effective policy, applies it on reload, and refreshes it when the active Cloud organization changes, the Cloud account changes, or the hourly desktop-config refresh runs.
 
 ## What policies control
 
@@ -24,6 +24,6 @@ Current desktop policy keys map to concrete product capabilities:
 3. Create a new policy or edit the default policy.
 4. Turn capabilities on or off.
 5. Assign the policy to members or teams when it should not apply to everyone.
-6. Save the policy, then have members refresh their Cloud account or switch the active organization in the desktop app.
+6. Save the policy, then have members reload, refresh their Cloud account, switch the active organization, or wait for the hourly desktop-config refresh.
 
 The desktop app explains blocked capabilities as organization-controlled. For example, a built-in extension disabled by policy is hidden from the normal catalog and can appear in hidden views with a `Disabled by organization` explanation.

--- a/packages/docs/cloud/share-with-your-team/team-prompt-cards.mdx
+++ b/packages/docs/cloud/share-with-your-team/team-prompt-cards.mdx
@@ -1,0 +1,23 @@
+---
+title: "Team prompt cards"
+description: "Use desktop policies to show different suggested prompts to teams and members."
+---
+
+Organization prompt cards are managed from OpenWork Cloud and appear in the desktop composer as task suggestions. Managing desktop policies requires an Enterprise plan; the API returns `402` when the org is not entitled.
+
+## Create team prompts
+
+1. Open the Cloud dashboard and go to `Settings > Desktop policies`.
+2. Create a non-default policy for the audience. The default policy is org-wide only and cannot be assigned to members or teams.
+3. Turn on `Organization prompt suggestions`.
+4. Add 2 required prompts, and optionally a third. Each `Prompt` is limited to 500 characters; each `Description` is limited to 120 characters.
+5. Assign the policy to `Members` or `Teams`, then save. The API stores those choices as `memberIds` and `teamIds`, so different departments can use separate non-default policies.
+
+## Know what members see
+
+1. The admin's `Description` becomes the card title in the desktop app.
+2. The admin's `Prompt` becomes the card body and the text inserted into the composer.
+3. Clicking a card fills the composer; it does not auto-send the task.
+4. Boolean policy toggles combine across every matching policy: any `true` wins.
+5. Prompt cards do not combine. The desktop uses one prompt set from the matching policy with the highest `Priority`; ties go to the earliest created policy, then the lowest policy id.
+6. Members receive changes from `GET /v1/me/desktop-config`. The desktop loads its cached config first, refreshes on Cloud session/settings changes, and polls every hour, so reload or switch the active Cloud organization if a change is not visible.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -38,6 +38,7 @@
             "pages": [
               "start-here/do-work-with-it/control-the-browser",
               "start-here/do-work-with-it/cross-chat-memory",
+              "start-here/do-work-with-it/what-uses-tokens",
               "start-here/do-work-with-it/workflows",
               "start-here/do-work-with-it/share-your-setup"
             ]
@@ -75,6 +76,7 @@
             "pages": [
               "cloud/share-with-your-team/team-templates",
               "cloud/share-with-your-team/desktop-policies",
+              "cloud/share-with-your-team/team-prompt-cards",
               "cloud/share-with-your-team/managed-llm-provider",
               "cloud/share-with-your-team/custom-llm-provider",
               "cloud/share-with-your-team/shared-mcp-connections"

--- a/packages/docs/start-here/do-work-with-it/what-uses-tokens.mdx
+++ b/packages/docs/start-here/do-work-with-it/what-uses-tokens.mdx
@@ -1,0 +1,23 @@
+---
+title: "What uses tokens"
+description: "Understand when OpenWork model usage starts and how to control it."
+---
+
+OpenWork uses model tokens when a member actually runs work. Setup actions do not consume tokens by themselves.
+
+## Know when usage starts
+
+1. Sending a prompt runs the selected model and consumes tokens. Running a skill does the same because the skill is loaded into the task and the model follows its instructions.
+2. There is no result cache today: rerunning the same task sends a new model request.
+3. Usage scales with the context the agent has to read, including long transcripts, pasted text, file attachments, and tool results.
+4. Tasks that make more tool calls usually cost more because the agent reads results and decides the next step.
+5. Prompt cards do not cost anything while they sit in a policy, no matter how many an admin configures. Installing skills or publishing marketplace plugins also costs nothing until a member runs a task that uses them.
+6. A good skill can reduce cost by making repeat work shorter and more deterministic, with fewer exploratory tool calls.
+
+## Control spend today
+
+1. Keep prompt cards short and specific.
+2. Prefer focused skills for repeat workflows.
+3. Attach only the files and transcript context the task needs.
+4. Ask for narrow outputs before broad analysis.
+5. Watch for tasks that loop through many tools, then turn the successful path into a skill.


### PR DESCRIPTION
## Why
Two documentation gaps from enterprise rollout questions, both cases where the product ships a behavior the docs never mention.

## 1. Organization prompt cards + per-team scoping
`cloud/share-with-your-team/desktop-policies.mdx` documented only the boolean toggles and **never mentioned the custom prompt feature at all**, though it has shipped. New `cloud/share-with-your-team/team-prompt-cards.mdx` (23 lines) documents, all verified against code:

- Limits: **2 or 3** prompts, prompt max **500** chars, description max **120** chars.
- The counter-intuitive mapping: the admin's **Description** becomes the **card title**; the **Prompt** text becomes the card body and the composer text. Clicking **fills the composer, it does not auto-send**.
- **Per-team / per-person scoping** via `memberIds`/`teamIds` — the concrete answer to "different prompts for different departments".
- The footgun: boolean policies are **OR-unioned**, but prompts are **winner-takes-all by `priority`**, then `createdAt`, then `id`.
- The **default policy cannot be assigned**, so a department-specific set needs a non-default policy.
- Requires Enterprise (`desktopPolicies` entitlement, HTTP 402), and changes arrive via `GET /v1/me/desktop-config` so a member may need to reload.

## 2. What actually uses tokens
No page anywhere in `packages/docs` covered cost, tokens, or usage — and enterprise buyers sizing thousands of seats ask this first. New `start-here/do-work-with-it/what-uses-tokens.mdx` (23 lines) states only what is true today: every run costs, there is **no result cache**; cost scales with context read and tool calls, not with how many prompt cards an admin configures; configuring/installing/publishing costs nothing until someone runs something; a skill can *reduce* cost by making a task deterministic.

**Deliberately omitted** because they do not exist in this repo: compiled widgets that execute without the model, result caching, free dashboard refresh, and scheduled runs. Documenting any of those would be a promise we cannot honor.

## Verification
`docs.json` parses, both pages registered and resolve on disk, all internal links resolve, no image paths invented. Code citations for every numeric claim are in the commit discussion.

Docs-only, no runtime path — no fraimz.
