### PR TITLE
fix(sidebar): align every row on shared glyph and label lanes

### DIFF
--- a/apps/app/src/react-app/ARCHITECTURE.md
+++ b/apps/app/src/react-app/ARCHITECTURE.md
@@ -154,6 +154,29 @@ Do not register backend reads as pretend navigation actions. Add an explicit
 query, keep UI commands outcome-oriented, and scope session operations by ID so
 split-screen sessions cannot be confused.
 
+## Sidebar lanes
+
+The sidebar has two vertical rails, defined once in
+`domains/session/sidebar/sidebar-lanes.tsx`:
+
+- **glyph lane, 20px** — activity dot-matrix, chevrons, row icons, and the
+  top-level `WORKSPACES` label.
+- **label lane, 44px** — every row title: workspace names, session titles,
+  group labels (`TO DO`, `PINNED`, `ARCHIVED`), empty/loading placeholders, and
+  the account name in the footer.
+
+Rules when adding a sidebar row:
+
+1. Compose the row with `SIDEBAR_ROW_LANE` (or `SIDEBAR_ROW_LANE_NESTED`, one
+   12px step per depth level) instead of ad-hoc `ps-*`.
+2. Render `SidebarGlyphSlot` as the first child even when there is no glyph, so
+   the title never shifts when an indicator appears.
+3. Style section labels with `SIDEBAR_SECTION_LABEL`; put them on the glyph lane
+   only when they are top-level.
+
+`evals/flows/sidebar-lanes.flow.mjs` asserts every rendered row lands on one of
+the two rails, so a new row with its own padding fails the flow.
+
 ## Testing
 
 - Unit: `bun test tests/` (CI-gated). Pure logic and parsers belong here.

--- a/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
@@ -280,7 +280,8 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
             data-testid="account-status-menu"
             data-runtime-state={runtimeStatus?.variant}
             data-connect-state={connectStatus?.state}
-            className="flex w-full items-center gap-2 rounded-lg px-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent"
+            /* ps-1.5 puts the 24px avatar 12px from the edge, so the name lands on the sidebar label lane. */
+            className="flex w-full items-center gap-2 rounded-lg ps-1.5 pe-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent"
             aria-label={signedIn ? `${user.email} — account and status` : "Account and status"}
             title={connectNeedsAttention
               ? openWorkConnectAttentionTitle(connectStatus.description)

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -128,10 +128,14 @@ import {
 import { cn } from "@/lib/utils";
 import { getSessionActivityStatusLabel, type SessionActivityStatus } from "../status/session-activity-store";
 import { SessionDotMatrixLoader } from "./session-dot-matrix-loader";
+import {
+  SIDEBAR_ROW_LANE,
+  SIDEBAR_ROW_LANE_NESTED,
+  SIDEBAR_SECTION_LABEL,
+  SIDEBAR_SECTION_LANE,
+  SidebarGlyphSlot,
+} from "./sidebar-lanes";
 import { useWorkbenchStore } from "../chat/workbench-store";
-
-/** Fixed left lane from Paper — activity/chevron slot; never shifts the title. */
-const LEFT_ACTIVITY_SLOT = "flex size-4 shrink-0 items-center justify-center";
 
 /** Paper Desktop: unread #2FBE54, needs-action #E8933A (14px artboard → ~8px app). */
 const OUTCOME_DOT_UNREAD = "#2FBE54";
@@ -142,20 +146,18 @@ interface SessionLoadingIndicatorProps {
   isActiveWork: boolean;
 }
 
-/** Left-lane activity only — never used for unread / completion. */
+/** Glyph-lane activity only — never used for unread / completion. */
 function SessionLoadingIndicator({ status, isActiveWork }: SessionLoadingIndicatorProps) {
-  if (!isActiveWork) {
-    return <span aria-hidden="true" className={LEFT_ACTIVITY_SLOT} />;
-  }
+  if (!isActiveWork) return <SidebarGlyphSlot />;
 
   const title = isSessionActivityStatus(status) && status !== "idle"
     ? getSessionActivityStatusLabel(status)
     : t("workspace_list.session_streaming");
 
   return (
-    <span className={LEFT_ACTIVITY_SLOT}>
+    <SidebarGlyphSlot>
       <SessionDotMatrixLoader label={title} />
-    </span>
+    </SidebarGlyphSlot>
   );
 }
 
@@ -1114,9 +1116,8 @@ export function AppSidebar(props: AppSidebarProps) {
             {pinnedSessions.length > 0 ? (
               <GlobalPinnedSessions entries={pinnedSessions} />
             ) : null}
-            {/* pl-4 (16px): aligns with workspace titles now that the color dot is gone. */}
-            <div className="group/workspaces-header flex items-center pb-1 pl-4 pr-3 pt-2">
-              <span className="text-[12px] font-normal uppercase tracking-[0.04em] text-muted-foreground">
+            <div className={cn("group/workspaces-header flex items-center pb-1 pr-3 pt-2", SIDEBAR_SECTION_LANE)}>
+              <span className={SIDEBAR_SECTION_LABEL}>
                 {t("workspace_list.title")}
               </span>
               <button
@@ -1180,9 +1181,11 @@ function GlobalPinnedSessions({ entries }: { entries: GlobalPinnedSessionEntry[]
   return (
     <SidebarGroup data-global-pinned-sessions className="pb-1 pt-2">
       <SidebarGroupContent>
-        {/* pl-2 (8px) + group p-2 = 16px: aligns with the WORKSPACES header lane. */}
-        <div className="pb-1 pl-2 pr-3 text-[12px] font-normal uppercase tracking-[0.04em] text-muted-foreground">
-          {t("session_management.pinned")}
+        <div className={cn("flex items-center gap-2 pb-1 pr-3", SIDEBAR_ROW_LANE)}>
+          <SidebarGlyphSlot>
+            <Pin className="size-3 text-muted-foreground" />
+          </SidebarGlyphSlot>
+          <span className={SIDEBAR_SECTION_LABEL}>{t("session_management.pinned")}</span>
         </div>
         <SidebarMenu>
           <SidebarMenuItem>
@@ -1218,10 +1221,12 @@ function GlobalArchivedSessions({ entries }: { entries: GlobalArchivedSessionEnt
             render={
               <button
                 type="button"
-                className="group/separator flex w-full cursor-pointer items-center gap-3 px-3 pb-1 pt-2.5 rounded transition-colors hover:bg-sidebar-accent/50"
+                className={cn("group/separator flex w-full cursor-pointer items-center gap-2 pe-3 pb-1 pt-2.5 rounded transition-colors hover:bg-sidebar-accent/50", SIDEBAR_ROW_LANE)}
               >
-                <Archive className="size-3 shrink-0 text-muted-foreground" />
-                <span className="text-[12px] font-medium uppercase tracking-wide text-muted-foreground">
+                <SidebarGlyphSlot>
+                  <Archive className="size-3 text-muted-foreground" />
+                </SidebarGlyphSlot>
+                <span className={SIDEBAR_SECTION_LABEL}>
                   {t("session_management.archived_label")}
                 </span>
                 <span className="text-[10px] tabular-nums text-muted-foreground/70">{entries.length}</span>
@@ -1394,9 +1399,9 @@ function WorkspaceHeader({
         handleSelectWorkspace();
       }}
     >
-      {isLoading ? (
-        <SessionDotMatrixLoader label={t("workspace.loading_tasks")} />
-      ) : null}
+      <SidebarGlyphSlot>
+        {isLoading ? <SessionDotMatrixLoader label={t("workspace.loading_tasks")} /> : null}
+      </SidebarGlyphSlot>
       <div
         className="min-w-0 flex-1 cursor-grab touch-none transition-[padding] duration-75 active:cursor-grabbing group-hover/workspace-header:pr-16 group-has-[[data-workspace-actions]:focus-within]/workspace-header:pr-16 group-has-data-popup-open/workspace-header:pr-11 group-hover/workspace-header:group-has-data-popup-open/workspace-header:pr-16 pr-2"
         onPointerDown={onTitlePointerDown}
@@ -1581,8 +1586,10 @@ function WorkspaceSidebarGroup({
                   />
                 ) : showInitialLoading || (group.status === "loading" && group.sessions.length === 0) ? (
                   <SidebarMenuSubItem>
-                    <SidebarMenuSubButton aria-disabled className="text-muted-foreground text-xs truncate">
-                      <SessionDotMatrixLoader label={t("workspace.loading_tasks")} />
+                    <SidebarMenuSubButton aria-disabled className={cn("text-muted-foreground text-xs truncate", SIDEBAR_ROW_LANE)}>
+                      <SidebarGlyphSlot>
+                        <SessionDotMatrixLoader label={t("workspace.loading_tasks")} />
+                      </SidebarGlyphSlot>
                       <span className="truncate">{t("workspace.loading_tasks")}</span>
                     </SidebarMenuSubButton>
                   </SidebarMenuSubItem>
@@ -1861,12 +1868,14 @@ function SessionGroupSeparator({ label, count, expanded, onToggle, group, groups
         event.preventDefault();
         onToggle();
       }}
-      className="group/separator flex w-full items-center gap-1.5 rounded px-2 pb-1 pt-2.5 text-left transition-colors first:pt-1 hover:bg-sidebar-accent/50"
+      className={cn("group/separator flex w-full items-center gap-2 rounded pe-2 pb-1 pt-2.5 text-left transition-colors first:pt-1 hover:bg-sidebar-accent/50", SIDEBAR_ROW_LANE)}
       aria-expanded={expanded}
     >
-      <ChevronRight className={cn("size-3.5 shrink-0 text-muted-foreground transition-transform duration-200", expanded && "rotate-90")} />
+      <SidebarGlyphSlot>
+        <ChevronRight className={cn("size-3.5 text-muted-foreground transition-transform duration-200", expanded && "rotate-90")} />
+      </SidebarGlyphSlot>
       <span
-        className="min-w-0 flex-1 cursor-grab touch-none ow-fade-truncate text-[12px] font-normal uppercase tracking-[0.04em] text-muted-foreground active:cursor-grabbing"
+        className={cn("min-w-0 flex-1 cursor-grab touch-none ow-fade-truncate active:cursor-grabbing", SIDEBAR_SECTION_LABEL)}
         onPointerDown={onTitlePointerDown}
       >
         {label}
@@ -2232,10 +2241,8 @@ function SessionMenuItem({
   const rowButtonClass = cn(
     // Soft pill @ 11px radius from Paper; overlay tint adapts to theme
     // (light: --ow-light-hover ≈ black/5, dark: #FFFFFF17 ≈ white/9).
-    // The left activity slot is the indent — dot-matrix sits in the chevron
-    // lane and the title starts in the group-label lane without shifting.
-    "relative rounded-[11px] transition-[padding,background-color] duration-75 ps-1 pe-7 group-hover/menu-sub-item:pe-20 group-has-data-popup-open/menu-sub-item:pe-20 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] text-sidebar-foreground/80 data-active:text-sidebar-foreground",
-    depth > 0 && "ps-5",
+    "relative rounded-[11px] transition-[padding,background-color] duration-75 pe-7 group-hover/menu-sub-item:pe-20 group-has-data-popup-open/menu-sub-item:pe-20 group-hover/menu-sub-item:bg-black/[0.05] dark:group-hover/menu-sub-item:bg-white/[0.09] data-active:bg-black/[0.07] dark:data-active:bg-white/[0.12] text-sidebar-foreground/80 data-active:text-sidebar-foreground",
+    depth > 0 ? SIDEBAR_ROW_LANE_NESTED : SIDEBAR_ROW_LANE,
   );
 
   // Pinned/archived rows identify their workspace via the tooltip title

--- a/apps/app/src/react-app/domains/session/sidebar/sidebar-lanes.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/sidebar-lanes.tsx
@@ -1,0 +1,43 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+/**
+ * Sidebar lane system — two vertical rails shared by every row in the sidebar.
+ *
+ *   8px   row pill edge (SidebarGroup `p-2`)
+ *   20px  glyph lane  — activity dot-matrix, chevrons, row icons, section labels
+ *   44px  label lane  — every row title (glyph lane + 16px glyph + 8px `gap-2`)
+ *
+ * Rules:
+ * 1. A row's first child is a `SidebarGlyphSlot`, rendered even when it has no
+ *    glyph, so the title never shifts when an indicator appears.
+ * 2. Section labels sit on the glyph lane, one step left of the titles below.
+ * 3. Nesting steps right by 12px per depth level.
+ */
+
+/** Row padding that puts the glyph slot on the glyph lane. */
+export const SIDEBAR_ROW_LANE = "ps-3";
+
+/** One 12px nesting step right of `SIDEBAR_ROW_LANE`. */
+export const SIDEBAR_ROW_LANE_NESTED = "ps-6";
+
+/** Glyph lane for direct children of the sidebar content, which have no row edge. */
+export const SIDEBAR_SECTION_LANE = "pl-5";
+
+export const SIDEBAR_SECTION_LABEL =
+  "text-[12px] font-normal uppercase tracking-[0.04em] text-muted-foreground";
+
+const GLYPH_SLOT = "flex size-4 shrink-0 items-center justify-center";
+
+/** The 16px glyph lane of a sidebar row. Always render it, empty or not. */
+export function SidebarGlyphSlot({ children, className }: {
+  children?: React.ReactNode;
+  className?: string;
+}) {
+  return (
+    <span aria-hidden={children ? undefined : "true"} className={cn(GLYPH_SLOT, className)}>
+      {children}
+    </span>
+  );
+}

--- a/evals/flows/sidebar-lanes.flow.mjs
+++ b/evals/flows/sidebar-lanes.flow.mjs
@@ -1,0 +1,142 @@
+/**
+ * Sidebar lane system: every sidebar row lands on one of two vertical rails —
+ * the 20px glyph lane (activity dot-matrix, chevrons, top-level section label)
+ * and the 44px label lane (workspace names, session titles, group labels,
+ * placeholders, account name). Regression for the ragged sidebar where the
+ * section label, workspace titles and session titles each had their own left
+ * edge. Lanes are defined in
+ * `apps/app/src/react-app/domains/session/sidebar/sidebar-lanes.tsx`.
+ */
+const GLYPH_LANE = 20;
+const LABEL_LANE = 44;
+const NEST_STEP = 12;
+
+const MEASURE_LANES = `(() => {
+  const sidebar = document.querySelector('[data-slot="sidebar"]');
+  if (!sidebar) return null;
+  const round = (value) => Math.round(value * 10) / 10;
+  const firstTextX = (el) => {
+    const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+    while (walker.nextNode()) {
+      const node = walker.currentNode;
+      if (!node.nodeValue || !node.nodeValue.trim()) continue;
+      const range = document.createRange();
+      range.selectNodeContents(node);
+      const rect = range.getBoundingClientRect();
+      if (rect.width > 0) return round(rect.x);
+    }
+    return null;
+  };
+  // Leading glyph only: trailing affordances (add, count, chevron) are not
+  // lane-governed, so anything right of the label is ignored.
+  const glyphX = (el, labelX) => {
+    for (const child of el.querySelectorAll("span, svg")) {
+      const rect = child.getBoundingClientRect();
+      if (rect.width <= 0 || rect.width > 20 || rect.height <= 0) continue;
+      if (labelX !== null && rect.x >= labelX) continue;
+      return round(rect.x);
+    }
+    return null;
+  };
+  const rows = [];
+  const add = (kind, el) => {
+    const text = (el.innerText || "").split("\\n")[0].trim().slice(0, 24);
+    if (!text) return;
+    const label = firstTextX(el);
+    rows.push({ kind, glyph: glyphX(el, label), label, text });
+  };
+  for (const el of sidebar.querySelectorAll(".group\\\\/workspaces-header")) add("section", el);
+  for (const el of sidebar.querySelectorAll('.group\\\\/workspace-header [data-sidebar="menu-button"]')) add("workspace", el);
+  for (const el of sidebar.querySelectorAll("[data-session-group]")) add("group-label", el);
+  for (const el of sidebar.querySelectorAll('[data-sidebar-session-id] [data-sidebar="menu-sub-button"]')) add("session", el);
+  for (const el of sidebar.querySelectorAll('[data-sidebar="menu-sub-button"]')) {
+    if (el.closest("[data-sidebar-session-id]")) continue;
+    add("placeholder", el);
+  }
+  const account = sidebar.querySelector('[data-testid="account-status-menu"]');
+  if (account) rows.push({ kind: "account", glyph: null, label: firstTextX(account), text: "account" });
+  return rows;
+})()`;
+
+const EXPAND_ALL_WORKSPACES = `(() => {
+  let clicked = 0;
+  for (const header of document.querySelectorAll(".group\\\\/workspace-header")) {
+    const toggle = Array.from(header.querySelectorAll("button")).find(
+      (button) => button.getAttribute("aria-expanded") === "false",
+    );
+    if (toggle) {
+      toggle.click();
+      clicked += 1;
+    }
+  }
+  return clicked;
+})()`;
+
+export default {
+  id: "sidebar-lanes",
+  title: "Every sidebar row aligns on the shared glyph (20px) and label (44px) lanes",
+  spec: "apps/app/src/react-app/ARCHITECTURE.md",
+  steps: [
+    {
+      name: "App is ready and Electron-backed",
+      run: async (ctx) => {
+        const userAgent = await ctx.eval("navigator.userAgent");
+        ctx.assert(userAgent.includes("Electron/"), `Expected Electron userAgent, got ${userAgent}`);
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+      },
+    },
+    {
+      name: "A workspace with at least one session is visible in the sidebar",
+      run: async (ctx) => {
+        const hasSession = await ctx.eval(`document.querySelectorAll("[data-sidebar-session-id]").length > 0`);
+        if (!hasSession) {
+          await ctx.control("session.create_task");
+        }
+        await ctx.eval(EXPAND_ALL_WORKSPACES);
+        await ctx.waitFor(`document.querySelectorAll("[data-sidebar-session-id]").length > 0`, {
+          timeoutMs: 60_000,
+          label: "session rows in the sidebar",
+        });
+      },
+    },
+    {
+      name: "Rows share the glyph and label lanes",
+      run: async (ctx) => {
+        const rows = await ctx.eval(MEASURE_LANES);
+        ctx.assert(Array.isArray(rows) && rows.length > 0, "Could not measure any sidebar rows.");
+        ctx.log(`Measured rows: ${JSON.stringify(rows)}`);
+
+        const kinds = new Set(rows.map((row) => row.kind));
+        ctx.assert(kinds.has("workspace"), "No workspace header row was measured.");
+        ctx.assert(kinds.has("session"), "No session row was measured.");
+
+        const allowedGlyph = [GLYPH_LANE, GLYPH_LANE + NEST_STEP];
+        const allowedLabel = [GLYPH_LANE, LABEL_LANE, LABEL_LANE + NEST_STEP];
+        const offLane = rows.filter((row) => {
+          const glyphOff = row.glyph !== null && !allowedGlyph.some((lane) => Math.abs(row.glyph - lane) <= 1);
+          const labelOff = row.label !== null && !allowedLabel.some((lane) => Math.abs(row.label - lane) <= 1);
+          return glyphOff || labelOff;
+        });
+
+        await ctx.prove("Sidebar rows land on the two shared lanes", {
+          claim:
+            "Section label, workspace titles, group labels, session titles, placeholders and the account name all sit on the 20px glyph lane or the 44px label lane (+12px per nesting step).",
+          assert: () => {
+            ctx.assert(
+              offLane.length === 0,
+              `Rows off the shared lanes: ${JSON.stringify(offLane)}`,
+            );
+            const titles = rows.filter((row) => row.kind === "workspace" || row.kind === "session");
+            for (const row of titles) {
+              ctx.assert(
+                Math.abs(row.label - LABEL_LANE) <= 1 || Math.abs(row.label - (LABEL_LANE + NEST_STEP)) <= 1,
+                `Title "${row.text}" starts at ${row.label}px instead of the ${LABEL_LANE}px label lane.`,
+              );
+            }
+          },
+          screenshot: { name: "sidebar-lanes-aligned" },
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Problem

The sidebar had five different left edges, which is the misalignment reported:

| row | label started at |
| --- | --- |
| `WORKSPACES` section label | 16px |
| workspace titles | 20px |
| session titles | 36px (glyph poking out at 12px, left of the parent title) |
| group labels (`TO DO`, `UNGROUPED`) | 37px |
| placeholders (`No tasks yet.`) | 44px |

A workspace title also jumped 24px to the right whenever its loading
dot-matrix appeared, because the glyph was only rendered while loading.

## Fix

`apps/app/src/react-app/domains/session/sidebar/sidebar-lanes.tsx` is the new
single source for the sidebar's two rails:

- **glyph lane, 20px** — activity dot-matrix, chevrons, row icons, and the
  top-level `WORKSPACES` label.
- **label lane, 44px** — every title: workspace names, session titles, group
  labels, pinned/archived headers, placeholders, and the account name.
- nesting steps right by 12px per depth level.

Workspace headers, group separators, session rows, the pinned and archived
sections, the loading placeholder and the footer account chip now compose from
`SIDEBAR_ROW_LANE` / `SidebarGlyphSlot` instead of ad-hoc `ps-*` values, and the
glyph slot is always rendered so titles never shift when an indicator appears.

## Guideline + guardrail

- `apps/app/src/react-app/ARCHITECTURE.md` documents the rails and the three
  rules for adding a sidebar row.
- `evals/flows/sidebar-lanes.flow.mjs` measures every rendered row in the real
  app and fails if one lands off the rails, so a new row with its own padding
  cannot regress this silently.

## Before / after

| before | after |
| --- | --- |
| ![before](https://litter.catbox.moe/y5y3vl.png) | ![after](https://litter.catbox.moe/w95hk4.png) |

## Tests

- `pnpm fraimz --flow sidebar-lanes --cdp-url http://127.0.0.1:9834` — **PASSED**
  (1 passed, 0 failed) against a real Electron app; measured rows report label
  lanes `20, 44` only.
- Same flow against the pre-fix `app-sidebar.tsx` — **FAILED** as intended,
  listing the off-lane rows (`WORKSPACES` 16, `TO DO` 37, sessions 36), which
  proves the guardrail catches the regression.
- `npx tsc --noEmit -p apps/app/tsconfig.json` — clean.
- `bun test tests/managed-brand-header.test.ts` — 1 pass (only unit test that
  renders the sidebar).

Made with [Cursor](https://cursor.com)