### PR TITLE
fix(desktop): package app icons in ASAR to fix broken Windows icon

### DIFF
--- a/apps/desktop/electron-builder.yml
+++ b/apps/desktop/electron-builder.yml
@@ -16,6 +16,7 @@ files:
   - server/**/*
   - "!server/dist/opencode-plugins/**"
   - package.json
+  - resources/icons/**/*
 extraResources:
   - from: ../app/dist
     to: app-dist


### PR DESCRIPTION
## Summary
In production packaged builds on Windows, the app was displaying a broken/placeholder taskbar icon. 
- **Solution**: Added `resources/icons/**/*` to the packaged files in `electron-builder.yml`. This ensures that the stock icon is successfully resolved from the ASAR package instead of falling back to extracting the icon dynamically from the executable path (which is prone to path resolution issues on Windows).

---

## Why
- The default stock icon is resolved from paths inside the packaged ASAR file (via `resolveAppIconPath()` in `main.mjs`). However, `resources/icons` was omitted from the `files` array in `apps/desktop/electron-builder.yml`, meaning the icons were never packaged inside `app.asar`.

## Issue
- Closes #3070  

## Scope
-

## Out of scope
-

## Testing
### Ran
```bash
node --test apps/desktop/electron/brand-icon-windows.test.mjs


### Result
- pass/fail:
- if fail, exact files/errors:

## CI status
- pass:
- code-related failures:
- external/env/auth blockers:

## Manual verification
1.
2.
3.

## Evidence
- video/screenshot link, or `N/A (docs-only)`

## Risk
-

## Rollback
-
