### PR TITLE
fix(desktop): resolve getComputerUseMcpCommand crash on Windows settings page

### DIFF
--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1728,9 +1728,17 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     // Browser plugin detection: check if any configured plugin matches the chrome-devtools name.
     // For now, treat it as loaded if the plugin is in the MCP/plugin list — this will
     // be refined when we add a real plugin-loaded signal from the engine.
-    const browserPluginConfigured = connectionsSnapshot.mcpServers.some(
-      (s) => s.name === "opencode-chrome-devtools" || s.config.command?.some((c: string) => c.includes("chrome-devtools")),
-    );
+    const browserPluginConfigured = connectionsSnapshot.mcpServers.some((s) => {
+      if (s.name === "opencode-chrome-devtools") return true;
+      const cmd = s.config.command;
+      if (Array.isArray(cmd)) {
+        return cmd.some((c: string) => c.includes("chrome-devtools"));
+      }
+      if (typeof cmd === "string") {
+        return (cmd as string).includes("chrome-devtools");
+      }
+      return false;
+    });
     if (browserPluginConfigured) loadedPlugins.add("opencode-chrome-devtools");
 
     return {

--- a/apps/desktop/electron/computer-use.mjs
+++ b/apps/desktop/electron/computer-use.mjs
@@ -37,6 +37,9 @@ function computerUseHelperAppPath() {
 }
 
 function getComputerUseMcpCommand() {
+  if (process.platform !== "darwin") {
+    return null;
+  }
   const helperExecutable = computerUseHelperExecutablePath();
   if (helperExecutable) return [helperExecutable, "mcp"];
 

--- a/packages/types/src/desktop-ipc.ts
+++ b/packages/types/src/desktop-ipc.ts
@@ -457,7 +457,7 @@ export type DesktopCommandMap = {
   };
   getUiControlBridgeInfo: { args: []; result: UiControlBridgeInfo | null };
   getOpenworkUiMcpCommand: { args: []; result: string[] };
-  getComputerUseMcpCommand: { args: []; result: string[] };
+  getComputerUseMcpCommand: { args: []; result: string[] | null };
   getOpenworkUiMcpEnvironment: { args: []; result: Record<string, string> };
 
   // Computer use


### PR DESCRIPTION

## Summary

Resolves the White Screen of Death (WSOD) crash on Windows when booting or opening settings.
1. **Backend**: Prevented `getComputerUseMcpCommand()` from throwing a hard exception on non-macOS platforms. It now returns `null` so the caller falls back to the default command gracefully.
2. **Types**: Updated `getComputerUseMcpCommand` in `desktop-ipc.ts` to allow `string[] | null`.
3. **Frontend**: Fixed a `TypeError` in the browser plugin check in `settings-route.tsx` where `.some()` was called on `config.command` when it was parsed as a string at runtime instead of an array.


## Why
-

## Issue
- Closes #2908 

## Scope
-

## Out of scope
-

## Testing
### Ran
```bash
pnpm typecheck

### Result
- pass/fail:
- if fail, exact files/errors:

## CI status
- pass:
- code-related failures:
- external/env/auth blockers:

## Manual verification
1.
2.
3.

## Evidence
- video/screenshot link, or `N/A (docs-only)`

## Risk
-

## Rollback
-
