### PR TITLE
fix(den-web): describe the real macOS installer steps

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -61,18 +61,20 @@ function openGuidance(os: InstallerOs | null, appName: string, fileName: string 
 
   if (os === "macos") {
     return {
-      actions: [openFile, `Drag ${appName} into Applications, then open it.`],
+      // The disk image holds only "Install OpenWork" — there is no Applications
+      // shortcut to drag onto. That app is the installer, and it installs the app.
+      actions: [openFile, `In the window that opens, double-click Install OpenWork, then choose Install.`],
       trust: {
-        title: `macOS may ask before it opens ${appName}`,
+        title: "macOS may ask before it opens the installer",
         body: "If you see “unidentified developer”, choose Open. This is normal for a new app.",
       },
     };
   }
   if (os === "windows") {
     return {
-      actions: [openFile, `Follow the setup prompts, then open ${appName}.`],
+      actions: [openFile, `Choose Install in the installer window.`],
       trust: {
-        title: `Windows may warn before it opens ${appName}`,
+        title: "Windows may warn before it opens the installer",
         body: "If you see “Windows protected your PC”, choose More info, then Run anyway.",
       },
     };
@@ -87,9 +89,9 @@ function openGuidance(os: InstallerOs | null, appName: string, fileName: string 
     };
   }
   return {
-    actions: [openFile, `Follow the setup prompts, then open ${appName}.`],
+    actions: [openFile, `Choose Install in the installer window.`],
     trust: {
-      title: `Your computer may ask before it opens ${appName}`,
+      title: "Your computer may ask before it opens the installer",
       body: "If you see a warning about an app from the internet, choose to open it anyway. This is normal for a new app.",
     },
   };
@@ -652,7 +654,7 @@ export function InstallScreen() {
               title="Continue on your computer"
               description={guideStep < 2
                 ? `Only continue once ${config.appName} is installed and running on this computer.`
-                : `Your download is done. Open the file on this computer — ${config.appName} takes it from there.`}
+                : `Your download is done. Open the file on this computer — the installer takes it from there.`}
               expanded={expandedStep === 2 && guideStep >= 2}
               onExpand={() => setExpandedStep(2)}
               testId="install-guide-step-open"
@@ -700,8 +702,8 @@ export function InstallScreen() {
                           <span className="size-1.5 rounded-full bg-[#3e63dd]" />
                         </span>
                         <span className="grid gap-0.5">
-                          <span className="text-[13px] font-semibold leading-[17px] text-[#1f3d8f]">{config.appName} continues from here</span>
-                          <span className="text-[13px] leading-[17px] text-[#3a4e80]">The moment it opens, it brings up a sign-in page in your browser so you can approve this computer.</span>
+                          <span className="text-[13px] font-semibold leading-[17px] text-[#1f3d8f]">The installer continues from here</span>
+                          <span className="text-[13px] leading-[17px] text-[#3a4e80]">It installs {config.appName} and opens a sign-in page in your browser so you can approve this computer.</span>
                         </span>
                       </div>
 


### PR DESCRIPTION
Step 2 of the org install guide told macOS users to "Drag OpenWork into Applications, then open it". That is not what happens.

## Why it was wrong

The published disk image contains exactly one item — `Install OpenWork.app` — and no Applications symlink. `apps/installer/scripts/dmg-layout.mjs` positions that single icon, and mounting the real `v0.18.1` artifact confirms it: the volume root holds the installer app and nothing else. So there is nothing to drag anywhere. The user double-clicks the disk image, double-clicks `Install OpenWork`, and chooses Install in the window that appears (`apps/installer/src/ui-html.ts` renders that primary button). The installer then installs the app.

The same mix-up ran through the neighbouring copy, which credited the app with the installer's work: the OS warning is about opening *the installer*, and it is the installer that opens the browser to approve the computer.

## What changed

- **macOS action 2** is now "In the window that opens, double-click Install OpenWork, then choose Install." The name is hardcoded rather than interpolated from `appName` on purpose: the generic installer's bundle is always `Install OpenWork`, and organization branding only changes the installer's window title at runtime, so a white-labelled org would otherwise be told to look for an icon that does not exist.
- **Windows action 2** is now "Choose Install in the installer window" instead of "Follow the setup prompts, then open OpenWork" — the `.exe` is the installer and it has an Install button, not a prompt chain.
- **Trust notes** now say the OS may warn before opening *the installer*.
- **The blue handoff note** reads "The installer continues from here / It installs {appName} and opens a sign-in page in your browser so you can approve this computer."
- **Step 2's subtitle** now credits the installer rather than the app.

The `Open {appName}` button is untouched and still correct. It navigates to `openwork://connect?code=…`, a scheme owned solely by the desktop app (`app.setAsDefaultProtocolClient("openwork")` in `apps/desktop/electron/main.mjs`); the installer registers no scheme at all and can only open `http`/`https` outward. That deeplink therefore cannot and should not address the installer, which is exactly why the button sits behind "Already have {appName} on this computer?".

## Testing

- `pnpm typecheck` in `ee/apps/den-web` — passes
- Rendered both platforms against a mocked install-config and read the copy back out of the DOM, confirming the macOS branch shows the `.dmg` with the double-click-Install steps and the Windows branch shows the `.exe` with the SmartScreen note
- Checked the eval flows for assertions on the changed strings — none of the changed copy is asserted, so no eval updates were needed

Made with [Cursor](https://cursor.com)