### PR TITLE
feat(desktop): isolate dev profiles per worktree so several can run at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,21 @@ OpenWork Den is the control plane for managing OpenWork across a team or organiz
 ## Documentation
 
 [Read the OpenWork docs.](https://openworklabs.com/docs)
+
+## Local development
+
+For one checkout, keep using `pnpm dev`; with no extra environment variables it reuses the existing shared dev profile.
+
+To run multiple git worktrees at once, use:
+
+```bash
+pnpm dev:worktree
+```
+
+That sets `OPENWORK_DEV_PROFILE=auto`, derives a stable profile name from the worktree path, lets Electron choose a free CDP port, and asks Vite for a free dev-server port. You can also choose a named profile, for example `OPENWORK_DEV_PROFILE=my-feature OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=0 PORT=0 pnpm dev`.
+
+`dev:worktree` also defaults `OPENWORK_ELECTRON_USE_MOCK_KEYCHAIN=1`. A brand-new profile has no stored credentials, so on macOS the real keychain prompts as soon as Chromium persists an authenticated cookie, and that modal blocks Electron's main loop until it is dismissed. Set `OPENWORK_ELECTRON_USE_MOCK_KEYCHAIN=0` if you specifically want the system keychain in an isolated profile.
+
+Dev startup prints a banner like `[openwork] dev profile=... cdp=http://127.0.0.1:9223`; use it to find the profile directory and pass the CDP URL to local tooling.
+
+If a second instance cannot get the profile lock it now says so and exits, instead of lingering with an open CDP port and no window.

--- a/apps/desktop/electron/dev-profile.mjs
+++ b/apps/desktop/electron/dev-profile.mjs
@@ -1,0 +1,74 @@
+import { createHash } from "node:crypto";
+import path from "node:path";
+
+const WINDOWS_RESERVED_NAMES = new Set([
+  "aux",
+  "com1",
+  "com2",
+  "com3",
+  "com4",
+  "com5",
+  "com6",
+  "com7",
+  "com8",
+  "com9",
+  "con",
+  "lpt1",
+  "lpt2",
+  "lpt3",
+  "lpt4",
+  "lpt5",
+  "lpt6",
+  "lpt7",
+  "lpt8",
+  "lpt9",
+  "nul",
+  "prn",
+]);
+
+export function sanitizeDevProfileName(value) {
+  const sanitized = String(value ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, "-")
+    .replace(/^[._-]+|[._-]+$/g, "")
+    .replace(/[._-]{2,}/g, "-");
+  if (!sanitized) return "profile";
+  if (WINDOWS_RESERVED_NAMES.has(sanitized)) return `${sanitized}-profile`;
+  return sanitized;
+}
+
+export function deriveAutoDevProfileName(appRootPath) {
+  const resolvedRoot = path.resolve(appRootPath);
+  const hint = sanitizeDevProfileName(path.basename(resolvedRoot));
+  const hash = createHash("sha256").update(resolvedRoot).digest("hex").slice(0, 10);
+  return `${hint}-${hash}`;
+}
+
+export function resolveAppIdentifier({
+  appIdentifierOverride,
+  appRootPath,
+  baseAppIdentifier,
+  devAppIdentifier,
+  devProfile,
+  isDevMode,
+  isPackaged,
+}) {
+  const explicitIdentifier = appIdentifierOverride?.trim();
+  if (explicitIdentifier) return explicitIdentifier;
+  if (!isDevMode || isPackaged) return baseAppIdentifier;
+
+  const profile = devProfile?.trim();
+  if (!profile) return baseAppIdentifier;
+
+  const profileName = profile.toLowerCase() === "auto"
+    ? deriveAutoDevProfileName(appRootPath)
+    : sanitizeDevProfileName(profile);
+  return `${devAppIdentifier}.${profileName}`;
+}
+
+export function resolveUserDataPath({ appDataPath, appIdentifier, userDataOverride }) {
+  const explicitUserData = userDataOverride?.trim();
+  if (explicitUserData) return explicitUserData;
+  return path.join(appDataPath, appIdentifier);
+}

--- a/apps/desktop/electron/dev-profile.test.mjs
+++ b/apps/desktop/electron/dev-profile.test.mjs
@@ -1,0 +1,79 @@
+import assert from "node:assert/strict";
+import path from "node:path";
+import test from "node:test";
+
+import {
+  deriveAutoDevProfileName,
+  resolveAppIdentifier,
+  resolveUserDataPath,
+} from "./dev-profile.mjs";
+
+const PROD_APP_IDENTIFIER = "com.differentai.openwork";
+const DEV_APP_IDENTIFIER = "com.differentai.openwork.dev";
+const APP_DATA_PATH = path.join("tmp", "appData");
+
+function resolveProfile({
+  appIdentifierOverride = "",
+  appRootPath = path.join("tmp", "openwork"),
+  devProfile = "",
+  isDevMode = true,
+  isPackaged = false,
+  userDataOverride = "",
+} = {}) {
+  const baseAppIdentifier = isDevMode ? DEV_APP_IDENTIFIER : PROD_APP_IDENTIFIER;
+  const appIdentifier = resolveAppIdentifier({
+    appIdentifierOverride,
+    appRootPath,
+    baseAppIdentifier,
+    devAppIdentifier: DEV_APP_IDENTIFIER,
+    devProfile,
+    isDevMode,
+    isPackaged,
+  });
+  return {
+    appIdentifier,
+    userDataPath: resolveUserDataPath({
+      appDataPath: APP_DATA_PATH,
+      appIdentifier,
+      userDataOverride,
+    }),
+  };
+}
+
+test("unset OPENWORK_DEV_PROFILE keeps the legacy dev identifier", () => {
+  const profile = resolveProfile();
+
+  assert.equal(profile.appIdentifier, DEV_APP_IDENTIFIER);
+  assert.equal(profile.userDataPath, path.join(APP_DATA_PATH, DEV_APP_IDENTIFIER));
+});
+
+test("auto dev profile is stable for one worktree and different for another", () => {
+  const firstPath = path.join("tmp", "worktrees", "openwork");
+  const secondPath = path.join("tmp", "other", "openwork");
+  const firstProfile = deriveAutoDevProfileName(firstPath);
+
+  assert.equal(deriveAutoDevProfileName(firstPath), firstProfile);
+  assert.notEqual(deriveAutoDevProfileName(secondPath), firstProfile);
+  assert.match(firstProfile, /^openwork-[a-f0-9]{10}$/);
+});
+
+test("named dev profile is sanitized into the dev app identifier", () => {
+  const profile = resolveProfile({ devProfile: "  Feature/Profile: 01  " });
+
+  assert.equal(profile.appIdentifier, `${DEV_APP_IDENTIFIER}.feature-profile-01`);
+  assert.equal(profile.userDataPath, path.join(APP_DATA_PATH, `${DEV_APP_IDENTIFIER}.feature-profile-01`));
+});
+
+test("OPENWORK_ELECTRON_USERDATA beats OPENWORK_DEV_PROFILE for the profile directory", () => {
+  const explicitUserData = path.join("tmp", "explicit-user-data");
+  const profile = resolveProfile({ devProfile: "auto", userDataOverride: explicitUserData });
+
+  assert.equal(profile.userDataPath, explicitUserData);
+});
+
+test("packaged mode ignores OPENWORK_DEV_PROFILE", () => {
+  const profile = resolveProfile({ devProfile: "auto", isPackaged: true });
+
+  assert.equal(profile.appIdentifier, DEV_APP_IDENTIFIER);
+  assert.equal(profile.userDataPath, path.join(APP_DATA_PATH, DEV_APP_IDENTIFIER));
+});

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -50,6 +50,7 @@ import {
 } from "./connect-link-branding.mjs";
 import { resolveConnectLinkPublicKeys } from "./connect-link-keys.mjs";
 import { openExternalUrl } from "./open-external.mjs";
+import { resolveAppIdentifier, resolveUserDataPath } from "./dev-profile.mjs";
 import { fetchAgentContextDiagnosticsResponse } from "./agent-context-diagnostics-fetch.mjs";
 import {
   applyWindowsTaskbarIcon,
@@ -63,6 +64,7 @@ import {
 } from "./brand-icon-windows.mjs";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const APP_ROOT = path.resolve(__dirname, "../../..");
 const require = createRequire(import.meta.url);
 // Electron 35 eagerly resolves every export in a named ESM import, including
 // safeStorage. Loading through CommonJS keeps safeStorage lazy so isolated demo
@@ -90,9 +92,16 @@ const APP_NAME =
   process.env.OPENWORK_ELECTRON_APP_NAME?.trim() ||
   (isDevMode ? "OpenWork - Dev" : "OpenWork");
 let currentDisplayAppName = APP_NAME;
-const APP_IDENTIFIER =
-  process.env.OPENWORK_ELECTRON_APP_IDENTIFIER?.trim() ||
-  (isDevMode ? DEV_APP_IDENTIFIER : TAURI_APP_IDENTIFIER);
+const BASE_APP_IDENTIFIER = isDevMode ? DEV_APP_IDENTIFIER : TAURI_APP_IDENTIFIER;
+const APP_IDENTIFIER = resolveAppIdentifier({
+  appIdentifierOverride: process.env.OPENWORK_ELECTRON_APP_IDENTIFIER,
+  appRootPath: APP_ROOT,
+  baseAppIdentifier: BASE_APP_IDENTIFIER,
+  devAppIdentifier: DEV_APP_IDENTIFIER,
+  devProfile: process.env.OPENWORK_DEV_PROFILE,
+  isDevMode,
+  isPackaged: app.isPackaged,
+});
 if (process.env.OPENWORK_ELECTRON_USE_MOCK_KEYCHAIN === "1") {
   // Fresh, isolated development profiles otherwise trigger macOS's native
   // "Login" keychain prompt as soon as Chromium persists an authenticated
@@ -155,22 +164,20 @@ function killTerminalsForWebContents(webContentsId) {
 // so in-place migration is a no-op for almost every file. Dev mode uses the
 // separate dev identifier so it can run beside the production app.
 //
-// Override via OPENWORK_ELECTRON_USERDATA so dogfooders can isolate their
-// Electron install from the real Tauri app.
+// Dev profile precedence: OPENWORK_ELECTRON_USERDATA (explicit profile path)
+// wins over everything; then OPENWORK_ELECTRON_APP_IDENTIFIER; then
+// OPENWORK_DEV_PROFILE in unpackaged dev; then the legacy identifier default.
 app.setName(APP_NAME);
 app.setAppUserModelId(APP_IDENTIFIER);
 if (app.isPackaged && process.env.OPENWORK_ELECTRON_DISABLE_PROTOCOL_REGISTRATION !== "1") {
   app.setAsDefaultProtocolClient(DESKTOP_PROTOCOL_SCHEME);
 }
-const userDataOverride = process.env.OPENWORK_ELECTRON_USERDATA?.trim();
-if (userDataOverride) {
-  app.setPath("userData", userDataOverride);
-} else {
-  app.setPath(
-    "userData",
-    path.join(app.getPath("appData"), APP_IDENTIFIER),
-  );
-}
+const userDataPath = resolveUserDataPath({
+  appDataPath: app.getPath("appData"),
+  appIdentifier: APP_IDENTIFIER,
+  userDataOverride: process.env.OPENWORK_ELECTRON_USERDATA,
+});
+app.setPath("userData", userDataPath);
 
 // Resolve and cache the app icon (reused for BrowserWindow + mac dock).
 // Packaged builds ship icons via electron-builder config, but for `dev:electron`
@@ -848,6 +855,10 @@ if (remoteDebugPort > 0) {
 // Make the resolved port available to the embedded server so it flows into
 // agent instructions via ensureOpenworkAgent → resolveAgentTemplate.
 process.env.OPENWORK_ELECTRON_REMOTE_DEBUG_PORT = String(remoteDebugPort);
+if (isDevMode && !app.isPackaged) {
+  const cdpAddress = remoteDebugPort > 0 ? `http://127.0.0.1:${remoteDebugPort}` : "disabled";
+  console.log(`[openwork] dev profile=${app.getPath("userData")} cdp=${cdpAddress}`);
+}
 
 // Apply extra Chromium flags from ELECTRON_EXTRA_LAUNCH_ARGS.
 // Used in headless/Daytona environments to pass e.g. --disable-gpu.
@@ -2387,7 +2398,17 @@ registerMigrationIpc({ app, ipcMain });
 const { ensureAutoUpdater } = registerUpdaterIpc({ app, ipcMain, getMainWindow: () => mainWindow });
 
 if (!app.requestSingleInstanceLock()) {
-  app.quit();
+  if (isDevMode && !app.isPackaged) {
+    console.error(`[openwork] Another OpenWork dev instance already holds this profile directory:
+  ${app.getPath("userData")}
+The second process is exiting so its CDP port is released.
+Run this worktree with an isolated profile: OPENWORK_DEV_PROFILE=auto pnpm dev
+or use: pnpm dev:worktree`);
+    app.exit(1);
+    setImmediate(() => process.exit(1));
+  } else {
+    app.quit();
+  }
 } else {
   app.on("before-quit", (event) => {
     if (runtimeDisposedForQuit) return;

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/dev-profile.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@openwork/paths": "workspace:*",

--- a/apps/desktop/scripts/electron-dev.mjs
+++ b/apps/desktop/scripts/electron-dev.mjs
@@ -16,8 +16,32 @@ const defaultDevDataDir = resolve(
 
 const pnpmCmd = process.platform === "win32" ? "pnpm.cmd" : "pnpm";
 const nodeCmd = process.execPath;
-const portValue = Number.parseInt(process.env.PORT ?? "", 10);
-const devPort = Number.isFinite(portValue) && portValue > 0 ? portValue : 5173;
+
+async function findFreeTcpPort() {
+  return new Promise((resolvePort, rejectPort) => {
+    const server = net.createServer();
+    server.once("error", rejectPort);
+    server.listen({ port: 0, host: "127.0.0.1" }, () => {
+      const address = server.address();
+      server.close(() => {
+        if (address && typeof address === "object") {
+          resolvePort(address.port);
+          return;
+        }
+        rejectPort(new Error("Unable to resolve a free Vite dev port"));
+      });
+    });
+  });
+}
+
+const rawPort = process.env.PORT?.trim() ?? "";
+const portValue = Number.parseInt(rawPort, 10);
+const devPort = rawPort === "0"
+  ? await findFreeTcpPort()
+  : Number.isFinite(portValue) && portValue > 0 ? portValue : 5173;
+if (rawPort === "0") {
+  console.log(`[electron-dev] Vite dev server will use free port ${devPort}`);
+}
 const explicitStartUrl = process.env.OPENWORK_ELECTRON_START_URL?.trim() || "";
 const startUrl = explicitStartUrl || `http://localhost:${devPort}`;
 const viteProbeUrls = explicitStartUrl

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "0.0.0",
   "scripts": {
     "dev": "OPENWORK_DEV_MODE=1 OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=${OPENWORK_ELECTRON_REMOTE_DEBUG_PORT:-9823} pnpm --filter @openwork/desktop dev",
+    "dev:worktree": "OPENWORK_DEV_MODE=1 OPENWORK_DEV_PROFILE=auto OPENWORK_ELECTRON_USE_MOCK_KEYCHAIN=${OPENWORK_ELECTRON_USE_MOCK_KEYCHAIN:-1} OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=0 PORT=0 pnpm --filter @openwork/desktop dev",
     "dev:electron": "OPENWORK_DEV_MODE=1 pnpm --filter @openwork/desktop dev:electron",
     "dev:electron:two": "OPENWORK_DEV_MODE=1 node scripts/dev-two-electron-demo.mjs",
     "demo:den": "DEN_ORG_MODE=multi_org OPENWORK_EXTRA_APP_PORTS=5273,5274 pnpm dev:den",


### PR DESCRIPTION
## Problem
Contributors keep many git worktrees of this repo. Every dev Electron instance shares **one** profile directory (`com.differentai.openwork.dev`), so `app.requestSingleInstanceLock()` fails for the second worktree. The failure mode is the bad part: Chromium has already opened the CDP port by then, so the process **lingers answering `/json/version` while never creating a window and never logging anything**. It looks exactly like a hang, with no hint and no easy way to run two worktrees side by side.

## The primitive
**`OPENWORK_DEV_PROFILE`** — dev-only, completely inert when packaged:

| value | behavior |
|---|---|
| unset | **exactly today's behavior** — keeps the shared profile |
| `auto` | stable per-worktree profile derived from the app root path |
| any name | explicitly named profile, sanitized |

Precedence (documented in the code): `OPENWORK_ELECTRON_USERDATA` → `OPENWORK_ELECTRON_APP_IDENTIFIER` → `OPENWORK_DEV_PROFILE` → today's default.

**Unset is unchanged on purpose.** Nobody's existing dev profile (sessions, auth, providers) moves or disappears. There is no migration.

**Fail loud instead of hanging.** On lock contention a dev instance now names the locked profile directory, says another instance holds it, gives the exact remedy, and **exits for real** (`app.exit` + `process.exit`) so the CDP port is released and no zombie remains. `second-instance` focus behavior is untouched, and production still uses plain `app.quit()`.

**Dev boot banner** so you can tell instances apart:
```
[openwork] dev profile=…/com.differentai.openwork.dev.cap-dev-profile-wt2-156b2b1bc8 cdp=http://127.0.0.1:9853
```

**`pnpm dev:worktree`** — `OPENWORK_DEV_PROFILE=auto` plus free CDP and Vite ports. `pnpm dev` keeps its pinned `9823` **unchanged**, because `evals/runner` default-probes `9825` then `9823` and moving it would break eval discovery.

It also defaults `OPENWORK_ELECTRON_USE_MOCK_KEYCHAIN=1`, which I only found by testing: a brand-new profile has no stored credentials, so on macOS the real keychain prompts as soon as Chromium persists an authenticated cookie — and `main.mjs` already documents that this modal *"blocks the entire Electron main loop"*. Without this default, the new script would reproduce the very hang it exists to remove. Override with `=0`.

## Verification
```
pnpm typecheck                        clean
pnpm --filter @openwork/desktop test  116 tests, 115 pass, 0 fail, 1 skipped
```
New `apps/desktop/electron/dev-profile.test.mjs` covers: unset → legacy identifier unchanged; `auto` stable for the same path and different for another; named value sanitized; `OPENWORK_ELECTRON_USERDATA` beating `OPENWORK_DEV_PROFILE`; packaged mode ignoring the var.

Observed live from a second worktree:
- isolated profile actually produced — `…/com.differentai.openwork.dev.cap-dev-profile-wt2-156b2b1bc8`
- free Vite port actually selected and bound — `[electron-dev] Vite dev server will use free port 59148`
- free CDP port selected, banner correct
- `pnpm dev` script verified byte-identical to before

## What I could NOT verify, honestly
I could not observe **two dev windows side by side on this machine**, because dev Electron currently opens **no window on this macOS host at all** — I reproduced 0 CDP page targets from the unmodified main checkout with an isolated profile and a mock keychain, so it is pre-existing and unrelated to this change. The same commit **does** open a window in a clean Linux sandbox.

I also want to correct something I claimed earlier on a related PR: I attributed that local no-window hang to the single-instance lock. That was **wrong** — this testing disproved it. The lock collision is real and worth fixing (this PR), but it is not the cause of the local no-window symptom, which remains an open macOS-host issue I have not root-caused.

So: the profile/port collision and the silent-hang-on-lock-contention are fixed and unit-tested; the "two windows at once" end state is verified only in the sense that both instances get distinct profiles and ports.
