### PR TITLE
feat(cloud): OpenWork Cloud alpha — a full instance in the browser, no orchestrator

### DIFF
--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -8,7 +8,7 @@
     "dev": "OPENWORK_DEV_MODE=1 vite",
     "build": "vite build",
     "dev:web": "OPENWORK_DEV_MODE=1 vite",
-    "build:web": "VITE_OPENWORK_DEPLOYMENT=web vite build",
+    "build:web": "VITE_OPENWORK_DEPLOYMENT=web VITE_DEN_REQUIRE_SIGNIN=1 vite build",
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:health": "node scripts/health.mjs",

--- a/apps/app/package.json
+++ b/apps/app/package.json
@@ -8,7 +8,7 @@
     "dev": "OPENWORK_DEV_MODE=1 vite",
     "build": "vite build",
     "dev:web": "OPENWORK_DEV_MODE=1 vite",
-    "build:web": "vite build",
+    "build:web": "VITE_OPENWORK_DEPLOYMENT=web vite build",
     "preview": "vite preview",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "test:health": "node scripts/health.mjs",

--- a/apps/app/src/app/constants.test.ts
+++ b/apps/app/src/app/constants.test.ts
@@ -1,0 +1,34 @@
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toEqual: (expected: unknown) => void;
+};
+
+import {
+  OPENWORK_EXTENSION_CATALOG,
+  filterOpenWorkExtensionCatalogForPlatform,
+  resolveOpenWorkExtensionCatalogPlatform,
+} from "./constants";
+
+function filteredIds(platform: "darwin" | "linux" | "windows" | "web") {
+  return filterOpenWorkExtensionCatalogForPlatform(OPENWORK_EXTENSION_CATALOG, platform)
+    .flatMap((entry) => entry.id ? [entry.id] : []);
+}
+
+describe("OpenWork extension catalog platform filter", () => {
+  test("resolves browser runtime to web and desktop runtime to OS", () => {
+    expect(resolveOpenWorkExtensionCatalogPlatform("web", "macos")).toEqual("web");
+    expect(resolveOpenWorkExtensionCatalogPlatform("desktop", "macos")).toEqual("darwin");
+    expect(resolveOpenWorkExtensionCatalogPlatform("desktop", "windows")).toEqual("windows");
+    expect(resolveOpenWorkExtensionCatalogPlatform("desktop", "linux")).toEqual("linux");
+  });
+
+  test("hides desktop-only extensions in web", () => {
+    expect(filteredIds("web")).toEqual(["openwork-voice", "google-workspace", "ollama"]);
+  });
+
+  test("keeps OpenWork Browser desktop-only and Computer Use mac-only", () => {
+    expect(filteredIds("darwin")).toEqual(["openwork-browser", "computer-use", "openwork-voice", "google-workspace", "ollama"]);
+    expect(filteredIds("linux")).toEqual(["openwork-browser", "openwork-voice", "google-workspace", "ollama"]);
+  });
+});

--- a/apps/app/src/app/constants.ts
+++ b/apps/app/src/app/constants.ts
@@ -7,6 +7,7 @@ import {
   extensionResource,
   isTrustedBuiltInExtension,
   type OpenWorkExtensionManifest,
+  type OpenWorkExtensionPlatform,
 } from "./extensions";
 
 export const MODEL_PREF_KEY = "openwork.defaultModel";
@@ -193,3 +194,23 @@ export const MCP_QUICK_CONNECT: McpDirectoryInfo[] = [
 ];
 
 export const OPENWORK_EXTENSION_CATALOG = MCP_QUICK_CONNECT.filter((entry) => entry.kind === "extension");
+
+export function resolveOpenWorkExtensionCatalogPlatform(
+  platform: "web" | "desktop",
+  os?: "macos" | "windows" | "linux",
+): OpenWorkExtensionPlatform {
+  if (platform === "web") return "web";
+  if (os === "macos") return "darwin";
+  if (os === "windows") return "windows";
+  return "linux";
+}
+
+export function filterOpenWorkExtensionCatalogForPlatform<TEntry extends Pick<McpDirectoryInfo, "extensionManifest">>(
+  entries: TEntry[],
+  platform: OpenWorkExtensionPlatform,
+): TEntry[] {
+  return entries.filter((entry) => {
+    const platforms = entry.extensionManifest?.platform;
+    return !platforms || platforms.includes(platform);
+  });
+}

--- a/apps/app/src/app/extensions.ts
+++ b/apps/app/src/app/extensions.ts
@@ -131,6 +131,8 @@ export type OpenWorkExtensionManifest = {
   platform?: Array<"darwin" | "linux" | "windows" | "web">;
 };
 
+export type OpenWorkExtensionPlatform = NonNullable<OpenWorkExtensionManifest["platform"]>[number];
+
 export function extensionContribution(
   manifest: OpenWorkExtensionManifest | undefined,
   type: OpenWorkExtensionContributionType,
@@ -179,6 +181,7 @@ export const BUILT_IN_OPENWORK_EXTENSION_MANIFESTS: OpenWorkExtensionManifest[] 
     ],
     lifecycle: { reload: ["plugins", "agents"], detection: ["plugin:opencode-chrome-devtools"] },
     defaultEnabled: true,
+    platform: ["darwin", "linux", "windows"],
   },
   {
     schemaVersion: 1,

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -833,6 +833,16 @@ const STORAGE_TOKEN = "openwork.server.token";
 const STORAGE_HOST_AUTH_KEY = "openwork.server.hostToken";
 const STORAGE_REMOTE_ACCESS = "openwork.server.remoteAccessEnabled";
 
+type OpenworkBootstrap = {
+  token?: string;
+};
+
+declare global {
+  interface Window {
+    __OPENWORK_BOOTSTRAP__?: OpenworkBootstrap;
+  }
+}
+
 export function normalizeOpenworkServerUrl(input: string) {
   const trimmed = input.trim();
   if (!trimmed) return null;
@@ -1040,8 +1050,11 @@ export function hydrateOpenworkServerSettingsFromEnv() {
   const envHostToken = typeof import.meta.env?.VITE_OPENWORK_HOST_TOKEN === "string"
     ? import.meta.env.VITE_OPENWORK_HOST_TOKEN.trim()
     : "";
+  const bootstrapToken = typeof window.__OPENWORK_BOOTSTRAP__?.token === "string"
+    ? window.__OPENWORK_BOOTSTRAP__.token.trim()
+    : "";
 
-  if (!envUrl && !envPort && !envToken && !envHostToken) return;
+  if (!envUrl && !envPort && !envToken && !envHostToken && !bootstrapToken) return;
 
   try {
     const current = readOpenworkServerSettings();
@@ -1061,7 +1074,10 @@ export function hydrateOpenworkServerSettingsFromEnv() {
       }
     }
 
-    if (!current.token && envToken) {
+    if (bootstrapToken && current.token !== bootstrapToken) {
+      next.token = bootstrapToken;
+      changed = true;
+    } else if (!current.token && envToken) {
       next.token = envToken;
       changed = true;
     }

--- a/apps/app/src/app/lib/platform-capabilities.test.ts
+++ b/apps/app/src/app/lib/platform-capabilities.test.ts
@@ -1,0 +1,63 @@
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toEqual: (expected: unknown) => void;
+};
+
+import { platformCapabilities } from "./platform-capabilities";
+
+const originalWindow = Object.getOwnPropertyDescriptor(globalThis, "window");
+const originalElectron = Object.getOwnPropertyDescriptor(globalThis, "__OPENWORK_ELECTRON__");
+
+function setElectronRuntime(enabled: boolean) {
+  if (!originalWindow && typeof window === "undefined") {
+    Object.defineProperty(globalThis, "window", { value: globalThis, configurable: true });
+  }
+  Object.defineProperty(globalThis, "__OPENWORK_ELECTRON__", {
+    value: enabled ? {} : undefined,
+    configurable: true,
+  });
+}
+
+function restoreRuntime() {
+  if (originalElectron) {
+    Object.defineProperty(globalThis, "__OPENWORK_ELECTRON__", originalElectron);
+  } else {
+    Object.defineProperty(globalThis, "__OPENWORK_ELECTRON__", { value: undefined, configurable: true });
+  }
+  if (originalWindow) {
+    Object.defineProperty(globalThis, "window", originalWindow);
+  } else if (typeof window !== "undefined") {
+    Object.defineProperty(globalThis, "window", { value: undefined, configurable: true });
+  }
+}
+
+describe("platformCapabilities", () => {
+  test("returns false for every capability outside Electron", () => {
+    setElectronRuntime(false);
+    expect(platformCapabilities()).toEqual({
+      nativeFilePicker: false,
+      revealInFileManager: false,
+      terminal: false,
+      autoUpdate: false,
+      osNotifications: false,
+      localRuntimeControl: false,
+      desktopBootstrap: false,
+    });
+    restoreRuntime();
+  });
+
+  test("returns true for every capability in Electron", () => {
+    setElectronRuntime(true);
+    expect(platformCapabilities()).toEqual({
+      nativeFilePicker: true,
+      revealInFileManager: true,
+      terminal: true,
+      autoUpdate: true,
+      osNotifications: true,
+      localRuntimeControl: true,
+      desktopBootstrap: true,
+    });
+    restoreRuntime();
+  });
+});

--- a/apps/app/src/app/lib/platform-capabilities.ts
+++ b/apps/app/src/app/lib/platform-capabilities.ts
@@ -1,0 +1,24 @@
+import { isElectronRuntime } from "./runtime-env";
+
+export type PlatformCapabilities = {
+  nativeFilePicker: boolean;
+  revealInFileManager: boolean;
+  terminal: boolean;
+  autoUpdate: boolean;
+  osNotifications: boolean;
+  localRuntimeControl: boolean;
+  desktopBootstrap: boolean;
+};
+
+export function platformCapabilities(): PlatformCapabilities {
+  const desktop = isElectronRuntime();
+  return {
+    nativeFilePicker: desktop,
+    revealInFileManager: desktop,
+    terminal: desktop,
+    autoUpdate: desktop,
+    osNotifications: desktop,
+    localRuntimeControl: desktop,
+    desktopBootstrap: desktop,
+  };
+}

--- a/apps/app/src/components/markdown/link-action-menu.tsx
+++ b/apps/app/src/components/markdown/link-action-menu.tsx
@@ -4,8 +4,8 @@ import { ExternalLink, Eye, FolderOpen, Loader2 } from "lucide-react";
 
 import type { DesktopApplication } from "@/app/lib/desktop";
 import { getDesktopApplicationsForFile, openDesktopWithApp } from "@/app/lib/desktop";
-import { isElectronRuntime } from "@/app/utils";
 import type { OpenTarget } from "@/react-app/domains/session/artifacts/open-target";
+import { usePlatform } from "@/react-app/kernel/platform";
 import type { OpenTargetOptions } from "@/lib/target-provider";
 
 const SUPPORTED_PANEL_PREVIEWS = new Set(["markdown", "sheet", "slides", "image", "pdf", "html", "text"]);
@@ -18,11 +18,12 @@ type LinkActionMenuProps = {
 };
 
 export function LinkActionMenu({ target, anchorRect, onOpenTarget, onClose }: LinkActionMenuProps) {
+  const platform = usePlatform();
   const menuRef = useRef<HTMLDivElement>(null);
   const [apps, setApps] = useState<DesktopApplication[] | null>(null);
   const [appsLoading, setAppsLoading] = useState(false);
   const canOpenInPanel = target.kind === "file" && SUPPORTED_PANEL_PREVIEWS.has(target.preview);
-  const canOpenExternally = isElectronRuntime() && target.kind === "file";
+  const canOpenExternally = platform.capabilities.revealInFileManager && target.kind === "file";
 
   useEffect(() => {
     function handleOutside(event: MouseEvent) {
@@ -94,15 +95,16 @@ export function LinkActionMenu({ target, anchorRect, onOpenTarget, onClose }: Li
       className="fixed z-50 min-w-52 rounded-lg border border-border bg-popover/95 p-1 shadow-lg backdrop-blur-xl"
       style={{ top, left }}
     >
-      <button
-        type="button"
-        onClick={handleOpenDefault}
-        disabled={!canOpenExternally}
-        className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-foreground/10 disabled:opacity-50"
-      >
-        <ExternalLink className="size-4 shrink-0" />
-        Open with default app
-      </button>
+      {canOpenExternally ? (
+        <button
+          type="button"
+          onClick={handleOpenDefault}
+          className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-foreground/10"
+        >
+          <ExternalLink className="size-4 shrink-0" />
+          Open with default app
+        </button>
+      ) : null}
       {canOpenInPanel ? (
         <button
           type="button"
@@ -113,15 +115,16 @@ export function LinkActionMenu({ target, anchorRect, onOpenTarget, onClose }: Li
           Open in panel
         </button>
       ) : null}
-      <button
-        type="button"
-        onClick={handleReveal}
-        disabled={!canOpenExternally}
-        className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-foreground/10 disabled:opacity-50"
-      >
-        <FolderOpen className="size-4 shrink-0" />
-        Show in folder
-      </button>
+      {canOpenExternally ? (
+        <button
+          type="button"
+          onClick={handleReveal}
+          className="flex w-full items-center gap-2.5 rounded-md px-3 py-2 text-sm font-medium text-foreground transition-colors hover:bg-foreground/10"
+        >
+          <FolderOpen className="size-4 shrink-0" />
+          Show in folder
+        </button>
+      ) : null}
       {canOpenExternally && apps && apps.length > 0 ? (
         <>
           <div className="my-1 h-px bg-foreground/5" />

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -428,6 +428,7 @@ export default {
   "context_panel.folder_already_authorized": "Folder is already authorized.",
   "context_panel.folders_updated": "Authorized folders updated.",
   "context_panel.input_placeholder": "Type a folder path to authorize...",
+  "context_panel.manage_folders_from_workspace": "Folders are managed from the workspace. You can still review and remove folders here.",
   "context_panel.no_external_folders": "No external folders authorized",
   "context_panel.no_mcp": "No MCP servers loaded.",
   "context_panel.no_server_workspace": "No active server workspace is selected.",

--- a/apps/app/src/index.react.tsx
+++ b/apps/app/src/index.react.tsx
@@ -17,6 +17,7 @@ import {
 } from "./react-app/kernel/platform";
 import { AppProviders } from "./react-app/shell/providers";
 import { AppRoot } from "./react-app/shell/app-root";
+import { setWebNotificationHandler } from "./react-app/shell/desktop-notifications";
 import { startDeepLinkBridge } from "./react-app/shell/startup-deep-links";
 import "./app/index.css";
 
@@ -34,6 +35,7 @@ if (!root) {
 root.dataset.openworkDeployment = getOpenWorkDeployment();
 
 const platform = createDefaultPlatform();
+setWebNotificationHandler(platform.notify);
 const queryClient = getReactQueryClient();
 const Router = isDesktopRuntime() ? HashRouter : BrowserRouter;
 

--- a/apps/app/src/react-app/domains/cloud/join-organization-dialog.tsx
+++ b/apps/app/src/react-app/domains/cloud/join-organization-dialog.tsx
@@ -5,6 +5,7 @@ import { installConfigSchema, parseInstallLinkInput } from "@openwork/install-co
 import { createDenClient, readDenSettings, setDenBootstrapConfig } from "@/app/lib/den";
 import { exchangeHandoffAndSignIn } from "@/app/lib/den-handoff";
 import { desktopFetchViaMain } from "@/app/lib/desktop";
+import { isDesktopRuntime } from "@/app/utils";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -42,6 +43,13 @@ function hostFromUrl(value: string): string {
   } catch {
     return value.replace(/^https?:\/\//, "").replace(/\/+$/, "");
   }
+}
+
+function fetchInstallConfig(url: string) {
+  const init = { headers: { accept: "application/json" } };
+  return isDesktopRuntime()
+    ? desktopFetchViaMain(url, init, 10_000)
+    : globalThis.fetch(url, init);
 }
 
 export function JoinOrganizationDialog({
@@ -89,11 +97,7 @@ export function JoinOrganizationDialog({
 
     let response: Response;
     try {
-      response = await desktopFetchViaMain(
-        parsed.url,
-        { headers: { accept: "application/json" } },
-        10_000,
-      );
+      response = await fetchInstallConfig(parsed.url);
     } catch {
       setError(t("join_org.error_network"));
       return true;

--- a/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
+++ b/apps/app/src/react-app/domains/cloud/openwork-models-promo.test.ts
@@ -6,6 +6,7 @@ declare const expect: (value: unknown) => {
 };
 
 import { DEFAULT_DEN_BASE_URL, HOSTED_DEFAULT_DEN_BASE_URL, setDenBootstrapConfig } from "../../../app/lib/den";
+import { OPENWORK_DEPLOYMENT_ENV_VAR, isWebDeployment } from "../../../app/lib/openwork-deployment";
 import {
   hasOpenWorkModelsAvailable,
   isOpenWorkModelsPromoEligible,
@@ -13,10 +14,44 @@ import {
   shouldShowOpenWorkModelsPromo,
   wasOpenWorkModelsStartupPromoShown,
 } from "./openwork-models-promo";
+import {
+  type OpenWorkModelsStartupPromoScheduleInput,
+  shouldScheduleOpenWorkModelsStartupPromo,
+} from "./use-openwork-models-startup-promo";
 
 afterEach(async () => {
   await setDenBootstrapConfig({ baseUrl: DEFAULT_DEN_BASE_URL, requireSignin: false });
 });
+
+function withOpenWorkDeployment(value: string, run: () => void) {
+  const previous = process.env[OPENWORK_DEPLOYMENT_ENV_VAR];
+  process.env[OPENWORK_DEPLOYMENT_ENV_VAR] = value;
+  try {
+    run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[OPENWORK_DEPLOYMENT_ENV_VAR];
+    } else {
+      process.env[OPENWORK_DEPLOYMENT_ENV_VAR] = previous;
+    }
+  }
+}
+
+function startupPromoReadyInput(): OpenWorkModelsStartupPromoScheduleInput {
+  return {
+    openWorkModelsPromoEligible: true,
+    webDeployment: isWebDeployment(),
+    cloudSignin: true,
+    promoHidden: false,
+    hasOpenWorkModels: false,
+    openWorkModelsEntitled: false,
+    denAuthStatus: "signed_out",
+    clientReady: true,
+    workspaceId: "workspace-1",
+    startupPromoShown: () => false,
+    startupPromoScheduled: false,
+  };
+}
 
 describe("OpenWork Models promo eligibility", () => {
   test("allows promotions on the default Den URL after normalization", () => {
@@ -29,6 +64,18 @@ describe("OpenWork Models promo eligibility", () => {
     expect(isOpenWorkModelsPromoEligible()).toBe(false);
     expect(shouldShowOpenWorkModelsPromo()).toBe(false);
     expect(wasOpenWorkModelsStartupPromoShown()).toBe(true);
+  });
+});
+
+describe("OpenWork Models startup promo", () => {
+  test("stays closed in web deployment and opens on desktop under the same conditions", () => {
+    withOpenWorkDeployment("web", () => {
+      expect(shouldScheduleOpenWorkModelsStartupPromo(startupPromoReadyInput())).toBe(false);
+    });
+
+    withOpenWorkDeployment("desktop", () => {
+      expect(shouldScheduleOpenWorkModelsStartupPromo(startupPromoReadyInput())).toBe(true);
+    });
   });
 });
 

--- a/apps/app/src/react-app/domains/cloud/use-openwork-models-startup-promo.ts
+++ b/apps/app/src/react-app/domains/cloud/use-openwork-models-startup-promo.ts
@@ -4,7 +4,9 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 
+import { isWebDeployment } from "@/app/lib/openwork-deployment";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
+import type { DenAuthStatus } from "@/react-app/domains/cloud/den-auth-provider";
 import { usePlatform } from "@/react-app/kernel/platform";
 import { useShellConfig } from "@/react-app/shell/shell-config";
 import { workspaceSettingsRoute } from "@/react-app/shell/workspace-routes";
@@ -27,6 +29,27 @@ export type UseOpenWorkModelsStartupPromoInput = {
   /** Org member already has OpenWork Models on Den — never upsell Subscribe. */
   openWorkModelsEntitled?: boolean;
 };
+
+export type OpenWorkModelsStartupPromoScheduleInput = {
+  openWorkModelsPromoEligible: boolean;
+  webDeployment: boolean;
+  cloudSignin: boolean;
+  promoHidden: boolean;
+  hasOpenWorkModels: boolean;
+  openWorkModelsEntitled: boolean;
+  denAuthStatus: DenAuthStatus;
+  clientReady: boolean;
+  workspaceId: string;
+  startupPromoShown: () => boolean;
+  startupPromoScheduled: boolean;
+};
+
+export function shouldScheduleOpenWorkModelsStartupPromo(input: OpenWorkModelsStartupPromoScheduleInput) {
+  if (!input.openWorkModelsPromoEligible || input.webDeployment) return false;
+  if (!input.cloudSignin || input.promoHidden || input.hasOpenWorkModels || input.openWorkModelsEntitled) return false;
+  if (input.denAuthStatus === "checking" || !input.clientReady || !input.workspaceId) return false;
+  return !input.startupPromoShown() && !input.startupPromoScheduled;
+}
 
 export function useOpenWorkModelsStartupPromo(input: UseOpenWorkModelsStartupPromoInput) {
   const { clientReady, workspaceId, providerConnectedIds, openWorkModelsEntitled = false } = input;
@@ -52,13 +75,24 @@ export function useOpenWorkModelsStartupPromo(input: UseOpenWorkModelsStartupPro
   );
 
   useEffect(() => {
-    if (!openWorkModelsPromoEligible) {
+    const webDeployment = isWebDeployment();
+    if (!shouldScheduleOpenWorkModelsStartupPromo({
+      openWorkModelsPromoEligible,
+      webDeployment,
+      cloudSignin: shellConfig.cloudSignin,
+      promoHidden,
+      hasOpenWorkModels,
+      openWorkModelsEntitled,
+      denAuthStatus: denAuth.status,
+      clientReady,
+      workspaceId,
+      startupPromoShown: wasOpenWorkModelsStartupPromoShown,
+      startupPromoScheduled: scheduledRef.current,
+    })) {
+      if (openWorkModelsPromoEligible && !webDeployment) return;
       setOpen(false);
       return;
     }
-    if (!shellConfig.cloudSignin || promoHidden || hasOpenWorkModels || openWorkModelsEntitled) return;
-    if (denAuth.status === "checking" || !clientReady || !workspaceId) return;
-    if (wasOpenWorkModelsStartupPromoShown() || scheduledRef.current) return;
 
     scheduledRef.current = true;
     const timeout = window.setTimeout(() => {

--- a/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-panel.tsx
@@ -10,6 +10,7 @@ import { Button } from "@/components/ui/button";
 import { toast } from "@/components/ui/sonner";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { formatFileSize } from "@/lib/utils";
+import { usePlatform } from "@/react-app/kernel/platform";
 import { type ArtifactPanelTab, usePanelTabStore } from "../panel/panel-tab-store";
 import { isCollectibleArtifactTarget, type BinaryData, type Data, type OpenTarget, type TextData } from "./open-target";
 import { HTMLPreview, ImagePreview, MarkdownPreview, PdfPreview, PlainText, PreviewError, PreviewLoading, PreviewUnavailable } from "./preview";
@@ -91,16 +92,18 @@ export function ArtifactPanel({ sessionId, tab, client, workspaceId, workspaceRo
 }
 
 function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspace = false, target, onClose }: ArtifactPanelViewProps) {
+  const platform = usePlatform();
   const queryClient = useQueryClient();
   const [editing, setEditing] = useState(false);
   const [draft, setDraft] = useState("");
   const isDirectTextEdit = isTextContent(target) && target.preview === "markdown" && !isMarkdownPrimitiveEvalArtifact(target);
   const externalPath = useMemo(() => target.kind === "file" ? absoluteWorkspacePath(workspaceRoot, target.value) : target.value, [target.kind, target.value, workspaceRoot]);
+  const canUseDesktopFileActions = target.kind === "file" && !isRemoteWorkspace && platform.capabilities.revealInFileManager;
 
   const { data: fileIcon } = useQuery<string | null>({
     queryKey: ["desktop-file-icon", externalPath] as const,
     queryFn: async () => getDesktopFileIcon(externalPath, "small"),
-    enabled: target.kind === "file" && !isRemoteWorkspace && isElectronRuntime(),
+    enabled: canUseDesktopFileActions && isElectronRuntime(),
     staleTime: Infinity,
     gcTime: 5 * 60 * 1000,
   });
@@ -325,7 +328,7 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
               <TooltipContent>Download artifact</TooltipContent>
             </Tooltip>
           ) : null}
-          {target.kind === "file" && !isRemoteWorkspace ? (
+          {canUseDesktopFileActions ? (
             <Tooltip>
               <TooltipTrigger
                 render={(
@@ -337,16 +340,18 @@ function ArtifactPanelView({ client, workspaceId, workspaceRoot, isRemoteWorkspa
               <TooltipContent>Show in folder</TooltipContent>
             </Tooltip>
           ) : null}
-          <Tooltip>
-            <TooltipTrigger
-              render={(
-                <Button variant="ghost" size="icon-sm" onClick={() => void openExternal()} aria-label={isRemoteWorkspace ? "Download artifact" : "Open externally"}>
-                  <ExternalLink />
-                </Button>
-              )}
-            />
-            <TooltipContent>{isRemoteWorkspace ? "Download artifact" : "Open externally"}</TooltipContent>
-          </Tooltip>
+          {target.kind === "url" || isRemoteWorkspace || canUseDesktopFileActions ? (
+            <Tooltip>
+              <TooltipTrigger
+                render={(
+                  <Button variant="ghost" size="icon-sm" onClick={() => void openExternal()} aria-label={isRemoteWorkspace ? "Download artifact" : "Open externally"}>
+                    <ExternalLink />
+                  </Button>
+                )}
+              />
+              <TooltipContent>{isRemoteWorkspace ? "Download artifact" : "Open externally"}</TooltipContent>
+            </Tooltip>
+          ) : null}
           <Tooltip>
             <TooltipTrigger
               render={(

--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -102,6 +102,7 @@ import {
 
 import { SidebarContext, useSidebarContext } from "./app-sidebar-provider";
 import { AccountStatusMenu, type AccountStatusMenuProps } from "./account-status-menu";
+import { usePlatform } from "../../../kernel/platform";
 import type { SidebarContextValue } from "./app-sidebar-provider";
 import {
   MAX_SESSIONS_PREVIEW,
@@ -537,6 +538,7 @@ type WorkspaceActionsMenuProps = {
 
 function WorkspaceActionsMenu({ workspace, isConnectionActionBusy, canRecover, className }: WorkspaceActionsMenuProps) {
   const ctx = useSidebarContext();
+  const platform = usePlatform();
 
   return (
     <DropdownMenu>
@@ -564,7 +566,7 @@ function WorkspaceActionsMenu({ workspace, isConnectionActionBusy, canRecover, c
           <Share2 className="size-4" />
           {t("workspace_list.share")}
         </DropdownMenuItem>
-        {workspace.workspaceType === "local" ? (
+        {workspace.workspaceType === "local" && platform.capabilities.revealInFileManager ? (
           <DropdownMenuItem onClick={() => ctx.onRevealWorkspace(workspace.id)}>
             <FolderOpen className="size-4" />
             {isWindowsPlatform() ? t("workspace_list.reveal_explorer") : t("workspace_list.reveal_finder")}

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -5,13 +5,19 @@ import { AppWindowMac, ArrowUp, Check, ChevronDown, ChevronRight, FileText, List
 import fuzzysort from "fuzzysort";
 import { toast } from "@/components/ui/sonner";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuShortcut, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
-import { OPENWORK_EXTENSION_CATALOG, type McpDirectoryInfo } from "@/app/constants";
+import {
+  OPENWORK_EXTENSION_CATALOG,
+  filterOpenWorkExtensionCatalogForPlatform,
+  resolveOpenWorkExtensionCatalogPlatform,
+  type McpDirectoryInfo,
+} from "@/app/constants";
 import type { CloudImportedPlugin, CloudImportedPluginFile } from "@/app/cloud/import-state";
 import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
 import { isMacPlatform } from "@/app/utils";
 import { t } from "@/i18n";
 import { isOpenWorkExtensionEnabled, isOpenWorkExtensionHidden, OPENWORK_EXTENSION_STATE_CHANGED } from "@/react-app/domains/settings/extension-state";
 import { useDesktopRestriction } from "@/react-app/domains/cloud/desktop-config-provider";
+import { usePlatform } from "@/react-app/kernel/platform";
 import { resolveExtensionIconUrl } from "@/react-app/design-system/extension-icon-src";
 import { ModelBehaviorSelect } from "@/components/model-behavior-select";
 import { ModelSelect } from "@/components/model-select";
@@ -287,6 +293,7 @@ function pluginSlashCommandName(file: CloudImportedPluginFile) {
 }
 
 export function ReactSessionComposer(props: ComposerProps) {
+  const platform = usePlatform();
   const builtInExtensionsDisabled = useDesktopRestriction("allowBuiltInExtensions");
   let fileInput: HTMLInputElement | undefined;
   const [agents, setAgents] = useState<Agent[]>([]);
@@ -778,7 +785,8 @@ export function ReactSessionComposer(props: ComposerProps) {
   const activePlugin = toolMenuSection.startsWith("plugin:")
     ? pluginSections.find((entry) => entry.section === toolMenuSection)?.plugin ?? null
     : null;
-  const composerExtensions = OPENWORK_EXTENSION_CATALOG.filter((entry) =>
+  const extensionCatalogPlatform = resolveOpenWorkExtensionCatalogPlatform(platform.platform, platform.os);
+  const composerExtensions = filterOpenWorkExtensionCatalogForPlatform(OPENWORK_EXTENSION_CATALOG, extensionCatalogPlatform).filter((entry) =>
     !builtInExtensionsDisabled &&
     !isOpenWorkExtensionHidden(entry) && isComposerExtensionAvailable(entry)
   );

--- a/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/advanced-view-sections.tsx
@@ -24,6 +24,7 @@ import {
 import { isDesktopRuntime } from "@/app/utils";
 import { t } from "@/i18n";
 import { ControlPlaneUrlEditor } from "../cloud/control-plane-url-editor";
+import { usePlatform } from "../../../kernel/platform";
 import {
   displayCustomControlPlaneUrl,
   isValidControlPlaneUrl,
@@ -184,6 +185,7 @@ interface AdvancedOrganizationServerSectionProps {
 }
 
 export function AdvancedOrganizationServerSection(props: AdvancedOrganizationServerSectionProps) {
+  const platform = usePlatform();
   const [clearConfirming, setClearConfirming] = useState(false);
   const controlsDisabled = [props.authBusy, props.baseUrlBusy, props.sessionBusy].some(Boolean);
   const customUrl = displayCustomControlPlaneUrl(props.baseUrlDraft);
@@ -224,23 +226,25 @@ export function AdvancedOrganizationServerSection(props: AdvancedOrganizationSer
             : t("settings.organization_server_default")}
         </LayoutSectionItemFootnote>
         {isDesktopRuntime() ? <ServerEndpointsCard cloudMcpUrl={props.cloudMcpUrl} /> : null}
-        <div className="flex flex-wrap items-center gap-2 text-[11px] text-gray-9">
-          <Button
-            variant={clearConfirming ? "destructive" : "outline"}
-            size="sm"
-            onClick={clearServerConfiguration}
-            disabled={controlsDisabled}
-          >
-            {clearConfirming
-              ? t("den.cloud_control_plane_clear_confirm")
-              : t("den.cloud_control_plane_clear")}
-          </Button>
-          <span>
-            {clearConfirming
-              ? t("den.cloud_control_plane_clear_confirm_hint")
-              : t("den.cloud_control_plane_clear_hint")}
-          </span>
-        </div>
+        {platform.capabilities.desktopBootstrap ? (
+          <div className="flex flex-wrap items-center gap-2 text-[11px] text-gray-9">
+            <Button
+              variant={clearConfirming ? "destructive" : "outline"}
+              size="sm"
+              onClick={clearServerConfiguration}
+              disabled={controlsDisabled}
+            >
+              {clearConfirming
+                ? t("den.cloud_control_plane_clear_confirm")
+                : t("den.cloud_control_plane_clear")}
+            </Button>
+            <span>
+              {clearConfirming
+                ? t("den.cloud_control_plane_clear_confirm_hint")
+                : t("den.cloud_control_plane_clear_hint")}
+            </span>
+          </div>
+        ) : null}
         {props.baseUrlError ? <SettingsNotice tone="error">{props.baseUrlError}</SettingsNotice> : null}
       </LayoutSectionItem>
     </LayoutSection>

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -304,6 +304,12 @@ export function McpView(props: McpViewProps) {
   const quickConnectList = props.quickConnect;
 
   useEffect(() => {
+    if (detailEntry && !quickConnectList.includes(detailEntry)) {
+      setDetailEntry(null);
+    }
+  }, [detailEntry, quickConnectList]);
+
+  useEffect(() => {
     const refresh = () => setExtensionStateVersion((value) => value + 1);
     window.addEventListener(OPENWORK_EXTENSION_STATE_CHANGED, refresh);
     window.addEventListener("storage", refresh);

--- a/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
+++ b/apps/app/src/react-app/domains/settings/panels/authorized-folders-panel.tsx
@@ -20,9 +20,9 @@ import type {
 } from "../../../../app/lib/openwork-server";
 import { pickDirectory } from "../../../../app/lib/desktop";
 import {
-  isDesktopRuntime,
   safeStringify,
 } from "../../../../app/utils";
+import { usePlatform } from "../../../kernel/platform";
 import {
   authorizedFoldersReducer,
   buildAuthorizedFoldersStatus,
@@ -115,6 +115,7 @@ function AuthorizedFolderItem(props: AuthorizedFolderItemProps) {
 }
 
 export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
+  const platform = usePlatform();
   const [serverWorkspaceRoot, setServerWorkspaceRoot] = useState("");
   const [folderState, dispatchFolderState] = useReducer(
     authorizedFoldersReducer,
@@ -151,8 +152,9 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
     return null;
   }, [canReadConfig, canWriteConfig, openworkServerReady, openworkServerWorkspaceReady]);
 
+  const canUseNativeFilePicker = platform.capabilities.nativeFilePicker;
   const canPickAuthorizedFolder =
-    isDesktopRuntime() && canWriteConfig && props.activeWorkspaceType === "local";
+    canUseNativeFilePicker && canWriteConfig && props.activeWorkspaceType === "local";
   const workspaceRootFolder = serverWorkspaceRoot || props.selectedWorkspaceRoot.trim();
   const visibleAuthorizedFolders = useMemo(() => {
     const root = workspaceRootFolder;
@@ -235,7 +237,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
   }, [authorizedFolders, persistAuthorizedFolders]);
 
   const pickAuthorizedFolder = useCallback(async () => {
-    if (!isDesktopRuntime()) return;
+    if (!canUseNativeFilePicker) return;
     try {
       const selection = await pickDirectory({
         title: t("onboarding.authorize_folder"),
@@ -264,7 +266,7 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
       const message = error instanceof Error ? error.message : safeStringify(error);
       setAuthorizedFoldersError(message);
     }
-  }, [authorizedFolders, persistAuthorizedFolders, workspaceRootFolder]);
+  }, [authorizedFolders, canUseNativeFilePicker, persistAuthorizedFolders, workspaceRootFolder]);
 
   return (
     <LayoutSectionItem className="gap-6">
@@ -275,15 +277,17 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
         <LayoutSectionItemDescription>
           {t("context_panel.authorized_folders_desc")}
         </LayoutSectionItemDescription>
-        <LayoutSectionItemHeaderActions>
-          <Button
-            onClick={() => void pickAuthorizedFolder()}
-            disabled={authorizedFoldersLoading || authorizedFoldersSaving || !canPickAuthorizedFolder}
-          >
-            <Plus className="size-4" />
-            Add folder
-          </Button>
-        </LayoutSectionItemHeaderActions>
+        {canUseNativeFilePicker ? (
+          <LayoutSectionItemHeaderActions>
+            <Button
+              onClick={() => void pickAuthorizedFolder()}
+              disabled={authorizedFoldersLoading || authorizedFoldersSaving || !canPickAuthorizedFolder}
+            >
+              <Plus className="size-4" />
+              Add folder
+            </Button>
+          </LayoutSectionItemHeaderActions>
+        ) : null}
       </LayoutSectionItemHeader>
 
       {!canReadConfig ? (
@@ -317,18 +321,22 @@ export function AuthorizedFoldersPanel(props: AuthorizedFoldersPanelProps) {
                   {t("context_panel.no_external_folders")}
                 </EmptyTitle>
                 <EmptyDescription>
-                  {t("context_panel.add_folder_hint")}
+                  {canUseNativeFilePicker
+                    ? t("context_panel.add_folder_hint")
+                    : t("context_panel.manage_folders_from_workspace")}
                 </EmptyDescription>
               </EmptyHeader>
-            <EmptyContent>
-              <Button
-                onClick={() => void pickAuthorizedFolder()}
-                disabled={authorizedFoldersLoading || authorizedFoldersSaving || !canPickAuthorizedFolder}
-              >
-                <Plus className="size-4" />
-                Add folder
-              </Button>
-            </EmptyContent>
+            {canUseNativeFilePicker ? (
+              <EmptyContent>
+                <Button
+                  onClick={() => void pickAuthorizedFolder()}
+                  disabled={authorizedFoldersLoading || authorizedFoldersSaving || !canPickAuthorizedFolder}
+                >
+                  <Plus className="size-4" />
+                  Add folder
+                </Button>
+              </EmptyContent>
+            ) : null}
             </Empty>
           )}
 

--- a/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-page.tsx
@@ -42,8 +42,10 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { t } from "../../../../i18n";
+import type { PlatformCapabilities } from "../../../../app/lib/platform-capabilities";
 import type { SettingsTab } from "../../../../app/types";
 import { cn } from "@/lib/utils";
+import { usePlatform } from "../../../kernel/platform";
 import { useOrgRestrictions } from "../../cloud/desktop-config-provider";
 import {
   SettingsContent,
@@ -190,8 +192,13 @@ export function getWorkspaceSettingsTabs(): SettingsTab[] {
   return ["preferences", "permissions", "extensions", "advanced"];
 }
 
-export function getGlobalSettingsTabs(developerMode: boolean): SettingsTab[] {
-  const tabs: SettingsTab[] = ["ai", "shell", "appearance", "environment", "updates", "recovery"];
+export function getGlobalSettingsTabs(
+  developerMode: boolean,
+  capabilities: Pick<PlatformCapabilities, "autoUpdate" | "localRuntimeControl">,
+): SettingsTab[] {
+  const tabs: SettingsTab[] = ["ai", "shell", "appearance", "environment"];
+  if (capabilities.autoUpdate) tabs.push("updates");
+  if (capabilities.localRuntimeControl) tabs.push("recovery");
   if (developerMode) tabs.push("debug");
   return tabs;
 }
@@ -262,9 +269,10 @@ type SettingsSidebarProps = Pick<SettingsPageProps, "activeTab" | "onSelectTab" 
 };
 
 export function SettingsSidebar(props: SettingsSidebarProps) {
+  const platform = usePlatform();
   const { memoryEnabled } = useFeatureFlagsPreferences();
   const workspaceTabs = getWorkspaceSettingsTabs();
-  const globalTabs = getGlobalSettingsTabs(props.developerMode);
+  const globalTabs = getGlobalSettingsTabs(props.developerMode, platform.capabilities);
   const cloudTabs = getCloudSettingsTabs(memoryEnabled);
 
   return (

--- a/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
+++ b/apps/app/src/react-app/domains/settings/shell/settings-shell.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/sidebar";
 import { t } from "../../../../i18n";
 import { NotificationBell } from "../../../shell/notification-center";
+import { usePlatform } from "../../../kernel/platform";
 import type { SettingsTab } from "../../../../app/types";
 import {
   SettingsPage,
@@ -163,11 +164,12 @@ export function SettingsShell(props: SettingsShellProps) {
 }
 
 function SettingsSectionMenu(props: Pick<SettingsPageFrameProps, "activeTab" | "developerMode" | "onSelectTab">) {
+  const platform = usePlatform();
   const { memoryEnabled } = useFeatureFlagsPreferences();
   const sections: Array<{ label: string | null; tabs: SettingsTab[] }> = [
     { label: null, tabs: ["general"] },
     { label: t("settings.group_workspace"), tabs: getWorkspaceSettingsTabs() },
-    { label: t("settings.group_global"), tabs: getGlobalSettingsTabs(props.developerMode) },
+    { label: t("settings.group_global"), tabs: getGlobalSettingsTabs(props.developerMode, platform.capabilities) },
     { label: t("settings.group_cloud"), tabs: getCloudSettingsTabs(memoryEnabled) },
   ];
   const ActiveIcon = getSettingsTabIcon(props.activeTab);

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.test.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.test.ts
@@ -1,0 +1,33 @@
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toBe: (expected: unknown) => void;
+  toEqual: (expected: unknown) => void;
+};
+
+import {
+  ELECTRON_UPDATER_UNSUPPORTED_REASON,
+  shouldScheduleElectronUpdateAutoCheck,
+  unsupportedElectronUpdaterEnvState,
+} from "./electron-updater-state";
+
+describe("electron updater web unsupported state", () => {
+  test("marks the updater environment unsupported in web", () => {
+    expect(unsupportedElectronUpdaterEnvState()).toEqual({
+      appVersion: null,
+      updateEnv: {
+        supported: false,
+        reason: ELECTRON_UPDATER_UNSUPPORTED_REASON,
+      },
+    });
+  });
+
+  test("does not schedule automatic checks when unsupported", () => {
+    expect(shouldScheduleElectronUpdateAutoCheck({
+      updateAutoCheck: true,
+      updateEnv: unsupportedElectronUpdaterEnvState().updateEnv,
+      autoCheckKey: null,
+      nextAutoCheckKey: "stable:unknown",
+    })).toBe(false);
+  });
+});

--- a/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
+++ b/apps/app/src/react-app/domains/settings/state/electron-updater-state.ts
@@ -47,10 +47,30 @@ type UseElectronUpdaterStateOptions = {
   setError: (message: string | null) => void;
 };
 
-type ElectronUpdaterEnvState = {
+export type ElectronUpdaterEnvState = {
   appVersion: string | null;
   updateEnv: { supported?: boolean; reason?: string | null } | null;
 };
+
+export const ELECTRON_UPDATER_UNSUPPORTED_REASON = "Electron updater bridge is unavailable.";
+
+export function unsupportedElectronUpdaterEnvState(): ElectronUpdaterEnvState {
+  return {
+    appVersion: null,
+    updateEnv: { supported: false, reason: ELECTRON_UPDATER_UNSUPPORTED_REASON },
+  };
+}
+
+export function shouldScheduleElectronUpdateAutoCheck(input: {
+  updateAutoCheck: boolean;
+  updateEnv: ElectronUpdaterEnvState["updateEnv"];
+  autoCheckKey: string | null;
+  nextAutoCheckKey: string;
+}) {
+  return input.updateAutoCheck &&
+    input.updateEnv?.supported !== false &&
+    input.autoCheckKey !== input.nextAutoCheckKey;
+}
 
 type ElectronUpdaterEnvAction =
   | { type: "app-version"; appVersion: string | null }
@@ -126,7 +146,9 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
   const [updateStatus, setUpdateStatus] = useState<SettingsUpdateStatus>(null);
   const [envState, dispatchEnvState] = useReducer(electronUpdaterEnvReducer, {
     appVersion: null,
-    updateEnv: null,
+    updateEnv: isElectronRuntime()
+      ? null
+      : { supported: false, reason: ELECTRON_UPDATER_UNSUPPORTED_REASON },
   });
   const { appVersion, updateEnv } = envState;
   const autoCheckKeyRef = useRef<string | null>(null);
@@ -181,10 +203,13 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
   ]);
 
   useEffect(() => {
-    if (!isElectronRuntime()) return;
+    if (!isElectronRuntime()) {
+      dispatchEnvState({ type: "unsupported", reason: ELECTRON_UPDATER_UNSUPPORTED_REASON });
+      return;
+    }
     const bridge = electronUpdaterBridge();
     if (!bridge?.getChannel) {
-      dispatchEnvState({ type: "unsupported", reason: "Electron updater bridge is unavailable." });
+      dispatchEnvState({ type: "unsupported", reason: ELECTRON_UPDATER_UNSUPPORTED_REASON });
       return;
     }
     let cancelled = false;
@@ -204,7 +229,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
       })
       .catch(() => {
         if (!cancelled) {
-          dispatchEnvState({ type: "unsupported", reason: "Electron updater bridge is unavailable." });
+          dispatchEnvState({ type: "unsupported", reason: ELECTRON_UPDATER_UNSUPPORTED_REASON });
         }
       });
     return () => {
@@ -300,6 +325,7 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
     channelOverride?: ReleaseChannel,
     manual = false,
   ) => {
+    if (!isElectronRuntime()) return;
     const requestedReleaseChannel = channelOverride ?? releaseChannel;
     const bridge = electronUpdaterBridge();
     if (!bridge?.check) {
@@ -445,9 +471,13 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
   );
 
   useEffect(() => {
-    if (!updateAutoCheck || updateEnv?.supported === false) return;
     const key = `${policyReleaseChannel}:${appVersion ?? "unknown"}`;
-    if (autoCheckKeyRef.current === key) return;
+    if (!shouldScheduleElectronUpdateAutoCheck({
+      updateAutoCheck,
+      updateEnv,
+      autoCheckKey: autoCheckKeyRef.current,
+      nextAutoCheckKey: key,
+    })) return;
     autoCheckKeyRef.current = key;
     void runCheckForUpdates(undefined, false);
   }, [appVersion, policyReleaseChannel, runCheckForUpdates, updateAutoCheck, updateEnv?.supported]);
@@ -455,10 +485,10 @@ export function useElectronUpdaterState(options: UseElectronUpdaterStateOptions)
   // Run a check when the native "Check for Updates..." menu item was used.
   const updateCheckRequestedAt = useUpdateCheckRequestStore((state) => state.requestedAt);
   useEffect(() => {
-    if (updateCheckRequestedAt == null) return;
+    if (updateCheckRequestedAt == null || updateEnv?.supported === false) return;
     useUpdateCheckRequestStore.getState().clearUpdateCheckRequest();
     void checkForUpdates();
-  }, [checkForUpdates, updateCheckRequestedAt]);
+  }, [checkForUpdates, updateCheckRequestedAt, updateEnv?.supported]);
 
   const installUpdateAndRestart = useCallback(async () => {
     const bridge = electronUpdaterBridge();

--- a/apps/app/src/react-app/domains/workspace/create-workspace-modal.tsx
+++ b/apps/app/src/react-app/domains/workspace/create-workspace-modal.tsx
@@ -153,6 +153,9 @@ export function CreateWorkspaceModal(props: CreateWorkspaceModalProps) {
       );
       const next = await props.onPickFolder();
       if (next) setSelectedFolder(next);
+    } catch {
+      // Folder picker cancellation or bridge errors should never leave the
+      // modal in a busy state.
     } finally {
       setPickingFolder(false);
     }

--- a/apps/app/src/react-app/domains/workspace/use-remote-workspace-connection-editor.ts
+++ b/apps/app/src/react-app/domains/workspace/use-remote-workspace-connection-editor.ts
@@ -5,7 +5,8 @@ import {
   workspaceUpdateRemote,
   type WorkspaceInfo,
 } from "../../../app/lib/desktop";
-import { buildOpenworkWorkspaceBaseUrl } from "../../../app/lib/openwork-server";
+import { buildOpenworkWorkspaceBaseUrl, type OpenworkServerClient } from "../../../app/lib/openwork-server";
+import { isDesktopRuntime } from "../../../app/lib/runtime-env";
 import { t } from "../../../i18n";
 import type { RemoteWorkspaceInput } from "./types";
 
@@ -22,9 +23,10 @@ function describeEditorError(error: unknown) {
 
 export function useRemoteWorkspaceConnectionEditor<TWorkspace extends WorkspaceInfo>(input: {
   workspaces: TWorkspace[];
+  client: OpenworkServerClient | null;
   onSaved: (workspaceId: string) => void | Promise<void>;
 }) {
-  const { onSaved, workspaces } = input;
+  const { client, onSaved, workspaces } = input;
   const [workspaceId, setWorkspaceId] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -88,18 +90,42 @@ export function useRemoteWorkspaceConnectionEditor<TWorkspace extends WorkspaceI
       setBusy(true);
       setError(null);
       try {
-        await workspaceUpdateRemote({
-          workspaceId: id,
-          baseUrl,
-          openworkHostUrl: baseUrl,
-          openworkToken: fields.openworkToken?.trim() ?? "",
-          openworkClientToken: "",
-          openworkHostToken: "",
-          displayName: fields.displayName?.trim() || null,
-          directory: fields.directory?.trim() || null,
-          remoteType: "openwork",
-        });
-        await onSaved(id);
+        const displayName = fields.displayName?.trim() || null;
+        const directory = fields.directory?.trim() || null;
+        const openworkToken = fields.openworkToken?.trim() ?? "";
+        if (isDesktopRuntime()) {
+          await workspaceUpdateRemote({
+            workspaceId: id,
+            baseUrl,
+            openworkHostUrl: baseUrl,
+            openworkToken,
+            openworkClientToken: "",
+            openworkHostToken: "",
+            displayName,
+            directory,
+            remoteType: "openwork",
+          });
+          await onSaved(id);
+        } else {
+          if (!client) throw new Error(t("app.error_connect_first"));
+          const connectionChanged = baseUrl !== (initialValues.openworkHostUrl?.trim() ?? "") ||
+            openworkToken !== (initialValues.openworkToken?.trim() ?? "") ||
+            directory !== (initialValues.directory?.trim() || null);
+          if (connectionChanged) {
+            const result = await client.createRemoteWorkspace({
+              baseUrl,
+              openworkHostUrl: baseUrl,
+              openworkToken: openworkToken || null,
+              displayName,
+              directory,
+              remoteType: "openwork",
+            });
+            await onSaved(result.activeId ?? id);
+          } else {
+            await client.updateWorkspaceDisplayName(id, displayName);
+            await onSaved(id);
+          }
+        }
         setWorkspaceId(null);
       } catch (nextError) {
         setError(describeEditorError(nextError));
@@ -107,7 +133,7 @@ export function useRemoteWorkspaceConnectionEditor<TWorkspace extends WorkspaceI
         setBusy(false);
       }
     },
-    [onSaved, workspaceId],
+    [client, initialValues.directory, initialValues.openworkHostUrl, initialValues.openworkToken, onSaved, workspaceId],
   );
 
   return {

--- a/apps/app/src/react-app/kernel/platform.tsx
+++ b/apps/app/src/react-app/kernel/platform.tsx
@@ -2,7 +2,8 @@
 import { createContext, use, type ReactNode } from "react";
 
 import { desktopNotificationShow, openDesktopUrl, relaunchDesktopApp } from "../../app/lib/desktop";
-import { isDesktopRuntime } from "../../app/utils";
+import { platformCapabilities, type PlatformCapabilities } from "../../app/lib/platform-capabilities";
+import { isDesktopRuntime, isMacPlatform, isWindowsPlatform } from "../../app/utils";
 
 export type SyncStorage = {
   getItem(key: string): string | null;
@@ -20,6 +21,7 @@ export type Platform = {
   platform: "web" | "desktop";
   os?: "macos" | "windows" | "linux";
   version?: string;
+  capabilities: PlatformCapabilities;
   openLink(url: string): void;
   restart(): Promise<void>;
   notify(title: string, description?: string, href?: string): Promise<void>;
@@ -58,9 +60,18 @@ function shouldOpenInCurrentTab(url: string) {
   return /^(mailto|tel):/i.test(url.trim());
 }
 
+function currentDesktopOs(): Platform["os"] {
+  if (isMacPlatform()) return "macos";
+  if (isWindowsPlatform()) return "windows";
+  return "linux";
+}
+
 export function createDefaultPlatform(): Platform {
+  const desktop = isDesktopRuntime();
   return {
-    platform: isDesktopRuntime() ? "desktop" : "web",
+    platform: desktop ? "desktop" : "web",
+    os: desktop ? currentDesktopOs() : undefined,
+    capabilities: platformCapabilities(),
     openLink(url: string) {
       if (isDesktopRuntime()) {
         void openDesktopUrl(url).catch(() => {

--- a/apps/app/src/react-app/shell/desktop-notifications.ts
+++ b/apps/app/src/react-app/shell/desktop-notifications.ts
@@ -8,6 +8,7 @@ import {
 import { LOCAL_PREFERENCES_KEY } from "@/react-app/kernel/local-preferences-storage";
 
 type DesktopNotificationImportance = "important" | "routine";
+type WebNotificationHandler = (title: string, description?: string, href?: string) => Promise<void>;
 
 export type DesktopNotificationEvent =
   | { type: "task.completed"; sessionId: string }
@@ -20,6 +21,12 @@ type NotificationCopy = {
   body: string;
   importance: DesktopNotificationImportance;
 };
+
+let webNotificationHandler: WebNotificationHandler | null = null;
+
+export function setWebNotificationHandler(handler: WebNotificationHandler | null): void {
+  webNotificationHandler = handler;
+}
 
 function readDesktopNotificationPreference(): DesktopNotificationPreference {
   if (typeof window === "undefined") return DEFAULT_DESKTOP_NOTIFICATION_PREFERENCE;
@@ -82,10 +89,14 @@ function copyForEvent(event: DesktopNotificationEvent): NotificationCopy {
 }
 
 export function notifyDesktopEvent(event: DesktopNotificationEvent): void {
-  if (!isDesktopRuntime()) return;
   const copy = copyForEvent(event);
   if (!shouldNotify(readDesktopNotificationPreference(), copy.importance)) return;
   if (isAppInView()) return;
+
+  if (!isDesktopRuntime()) {
+    void webNotificationHandler?.(copy.title, copy.body).catch(() => undefined);
+    return;
+  }
 
   void desktopNotificationShow({
     title: copy.title,

--- a/apps/app/src/react-app/shell/openwork-connection.ts
+++ b/apps/app/src/react-app/shell/openwork-connection.ts
@@ -3,10 +3,11 @@ import {
   normalizeOpenworkServerUrl,
   readOpenworkServerSettings,
 } from "../../app/lib/openwork-server";
+import { isWebDeployment } from "../../app/lib/openwork-deployment";
 import { openworkServerInfo, type OpenworkServerInfo } from "../../app/lib/desktop";
 import { isDesktopRuntime } from "../../app/utils";
 
-export type OpenworkConnectionSource = "desktop-runtime" | "stored-settings" | "empty";
+export type OpenworkConnectionSource = "desktop-runtime" | "stored-settings" | "same-origin" | "empty";
 
 export type ResolvedOpenworkConnection = {
   normalizedBaseUrl: string;
@@ -55,6 +56,10 @@ export async function resolveOpenworkConnection(): Promise<ResolvedOpenworkConne
 
   const settings = readOpenworkServerSettings();
   const normalizedBaseUrl = normalizeOpenworkServerUrl(settings.urlOverride ?? "") ?? "";
+  const sameOriginBaseUrl =
+    !normalizedBaseUrl && !isDesktopRuntime() && isWebDeployment() && typeof window !== "undefined"
+      ? normalizeOpenworkServerUrl(window.location.origin) ?? ""
+      : "";
   const resolvedToken = settings.token?.trim() ?? "";
   const resolvedHostToken =
     normalizedBaseUrl && isLoopbackOpenworkServerUrl(normalizedBaseUrl)
@@ -68,10 +73,16 @@ export async function resolveOpenworkConnection(): Promise<ResolvedOpenworkConne
   const source =
     !storedConnectionIsStaleDesktopRuntime && hasUsableConnection(normalizedBaseUrl, resolvedToken)
       ? "stored-settings"
-      : "empty";
+      : hasUsableConnection(sameOriginBaseUrl, resolvedToken)
+        ? "same-origin"
+        : "empty";
 
   return {
-    normalizedBaseUrl: source === "empty" ? "" : normalizedBaseUrl,
+    normalizedBaseUrl: source === "same-origin"
+      ? sameOriginBaseUrl
+      : source === "empty"
+        ? ""
+        : normalizedBaseUrl,
     resolvedToken: source === "empty" ? "" : resolvedToken,
     resolvedHostToken: source === "empty" ? "" : resolvedHostToken,
     hostInfo: null,

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -407,6 +407,14 @@ async function draftToParts(
   return parts;
 }
 
+function singlePickedDirectory(selection: string | string[] | null) {
+  return typeof selection === "string"
+    ? selection
+    : Array.isArray(selection)
+      ? selection[0] ?? null
+      : null;
+}
+
 export function SessionRoute() {
   const navigate = useNavigate();
   const platform = usePlatform();
@@ -630,6 +638,7 @@ export function SessionRoute() {
 
   const remoteWorkspaceConnectionEditor = useRemoteWorkspaceConnectionEditor({
     workspaces,
+    client,
     onSaved: handleRemoteWorkspaceConnectionSaved,
   });
 
@@ -1766,7 +1775,7 @@ export function SessionRoute() {
     };
   }, [selectedSessionId]);
 
-  const terminalPaletteItems = useMemo<PaletteItem[]>(() => [
+  const terminalPaletteItems = useMemo<PaletteItem[]>(() => platform.capabilities.terminal ? [
     {
       id: "terminal.toggle",
       title: terminalOpen ? "Hide terminal" : "Show terminal",
@@ -1778,7 +1787,7 @@ export function SessionRoute() {
         setTerminalOpen((value) => !value);
       },
     },
-  ], [terminalOpen]);
+  ] : [], [platform.capabilities.terminal, terminalOpen]);
 
   const developerModePaletteItem = useMemo<PaletteItem>(() => ({
     id: "developer-mode.toggle",
@@ -2472,9 +2481,15 @@ export function SessionRoute() {
       }}
       onConfirm={handleCreateWorkspace}
       onConfirmRemote={handleCreateRemoteWorkspace}
-      onPickFolder={() => pickDirectory({ title: t("onboarding.authorize_folder") }) as Promise<string | null>}
+      onPickFolder={async () => singlePickedDirectory(await pickDirectory({ title: t("onboarding.authorize_folder") }))}
       submitting={createWorkspaceBusy}
       localError={createWorkspaceError}
+      localDisabled={!platform.capabilities.nativeFilePicker}
+      localDisabledReason={
+        platform.capabilities.nativeFilePicker
+          ? undefined
+          : t("app.local_disabled_reason")
+      }
       remoteSubmitting={createWorkspaceRemoteBusy}
       remoteError={createWorkspaceRemoteError}
     />

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -3,7 +3,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { Navigate, useLocation, useNavigate, useParams } from "react-router-dom";
 import { toast } from "@/components/ui/sonner";
 
-import { SUGGESTED_PLUGINS } from "@/app/constants";
+import {
+  SUGGESTED_PLUGINS,
+  filterOpenWorkExtensionCatalogForPlatform,
+  resolveOpenWorkExtensionCatalogPlatform,
+} from "@/app/constants";
 import type { EnablementContext } from "@/app/enablement";
 import { createClient, unwrap } from "@/app/lib/opencode";
 import {
@@ -328,6 +332,14 @@ function writeStoredBoolean(key: string, value: boolean) {
   } catch {
     // ignore persistence failures
   }
+}
+
+function singlePickedDirectory(selection: string | string[] | null) {
+  return typeof selection === "string"
+    ? selection
+    : Array.isArray(selection)
+      ? selection[0] ?? null
+      : null;
 }
 
 function readNavigationWorkspaceId(state: unknown): string | null {
@@ -1454,6 +1466,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
 
   const remoteWorkspaceConnectionEditor = useRemoteWorkspaceConnectionEditor({
     workspaces,
+    client: openworkClient,
     onSaved: handleRemoteWorkspaceConnectionSaved,
   });
 
@@ -1801,9 +1814,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       onInstall: installLocalProvider,
     },
   });
+  const extensionCatalogPlatform = resolveOpenWorkExtensionCatalogPlatform(platform.platform, platform.os);
+  const quickConnectCatalog = useMemo(
+    () => filterOpenWorkExtensionCatalogForPlatform(connectionsStore.quickConnect, extensionCatalogPlatform),
+    [connectionsStore.quickConnect, extensionCatalogPlatform],
+  );
   const extensionItems = useMemo(
     () => buildExtensionItems({
-      quickConnect: connectionsStore.quickConnect,
+      quickConnect: quickConnectCatalog,
       mcpServers: connectionsSnapshot.mcpServers,
       installedSkills: extensionsStore.skills(),
       importedCloudPlugins: extensionsSnapshot.importedCloudPlugins,
@@ -1813,7 +1831,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
       enablementContext,
       isBuiltInConnected: extensionController.isConnected,
     }),
-    [connectionsSnapshot.mcpServers, connectionsStore.quickConnect, enablementContext, extensionController, extensionsSnapshot, extensionsStore, orgMcpConnections.connections],
+    [connectionsSnapshot.mcpServers, enablementContext, extensionController, extensionsSnapshot, extensionsStore, orgMcpConnections.connections, quickConnectCatalog],
   );
   const installedOrgMcpConnectionItems = useMemo(
     () => extensionItems.orgMcpConnectionItems.filter((item) => item.installState === "installed"),
@@ -2581,9 +2599,15 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
         }}
         onConfirm={handleCreateWorkspace}
         onConfirmRemote={handleCreateRemoteWorkspace}
-        onPickFolder={() => pickDirectory({ title: t("onboarding.authorize_folder") }) as Promise<string | null>}
+        onPickFolder={async () => singlePickedDirectory(await pickDirectory({ title: t("onboarding.authorize_folder") }))}
         submitting={createWorkspaceBusy}
         localError={createWorkspaceError}
+        localDisabled={!platform.capabilities.nativeFilePicker}
+        localDisabledReason={
+          platform.capabilities.nativeFilePicker
+            ? undefined
+            : t("app.local_disabled_reason")
+        }
         showProjectLabel={false}
         remoteSubmitting={createWorkspaceRemoteBusy}
         remoteError={createWorkspaceRemoteError}

--- a/apps/app/src/react-app/shell/use-shell-shortcuts.ts
+++ b/apps/app/src/react-app/shell/use-shell-shortcuts.ts
@@ -2,6 +2,7 @@
 // global keyboard shortcuts that toggle them. Extracted verbatim from
 // session-route.tsx.
 import { useEffect, useEffectEvent, useState } from "react";
+import { usePlatform } from "../kernel/platform";
 
 export type UseShellShortcutsInput = {
   canCreateTask: boolean;
@@ -32,6 +33,7 @@ export function useCommandPaletteShortcut(enabled = true) {
 }
 
 export function useShellShortcuts(input: UseShellShortcutsInput) {
+  const platform = usePlatform();
   const { canCreateTask, workspaceId, onCreateTask, onNextSessionTab, onPrevSessionTab } = input;
   const { commandPaletteOpen, setCommandPaletteOpen } = useCommandPaletteShortcut();
   const [sessionSearchOpen, setSessionSearchOpen] = useState(false);
@@ -76,7 +78,7 @@ export function useShellShortcuts(input: UseShellShortcutsInput) {
       }
       return;
     }
-    if (key === "j") {
+    if (key === "j" && platform.capabilities.terminal) {
       event.preventDefault();
       setTerminalOpen((value) => !value);
       return;

--- a/apps/server/src/cli.ts
+++ b/apps/server/src/cli.ts
@@ -16,6 +16,7 @@ import { findManagedEngineWorkspace } from "./workspaces.js";
 import { keepOpenworkRuntimeConfigFileFresh, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { sweepLegacyOpenCodeConfig } from "./legacy-config-sweep.js";
 import { resolveOpencodeModelsUrl } from "./opencode-models-url.js";
+import { startWorkerActivityHeartbeat } from "./worker-activity-heartbeat.js";
 import pkg from "../package.json" with { type: "json" };
 
 const args = parseCliArgs(process.argv.slice(2));
@@ -89,6 +90,7 @@ if (!config.opencodeBaseUrl && process.env.OPENWORK_MANAGE_OPENCODE === "1") {
 }
 
 const server = await startServer(config);
+const workerActivityHeartbeat = startWorkerActivityHeartbeat(config, logger);
 
 // The runtime config file above only covers workspaces[0]. Push every
 // workspace's runtime-DB MCPs into the engine so they aren't invisible
@@ -125,6 +127,7 @@ if (args.verbose) {
 }
 
 const shutdown = () => {
+  workerActivityHeartbeat?.stop();
   if (managedOpencodeIdentity) {
     clearTrustedOpencodeProcess(config, managedOpencodeIdentity);
   }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -56,6 +56,7 @@ import {
   type WorkspaceExportSensitiveMode,
 } from "./workspace-export-safety.js";
 import { serve, type ServeResult } from "./serve-node.js";
+import { serveStaticUi } from "./static-ui.js";
 import { externalFetch, loopbackFetch } from "./server-fetch.js";
 import { registerCoreRoutes } from "./routes/core.js";
 import { registerFileRoutes } from "./routes/files.js";
@@ -921,6 +922,8 @@ export async function startServer(config: ServerConfig): Promise<ServeResult> {
 
       const route = matchRoute(routes, request.method, url.pathname);
       if (!route) {
+        const staticUiResponse = await serveStaticUi(request, config);
+        if (staticUiResponse) return finalize(staticUiResponse);
         errorMessage = "not_found";
         return finalize(jsonResponse({ code: "not_found", message: "Not found" }, 404));
       }
@@ -1025,7 +1028,7 @@ type OpencodeClientResult<T, E> =
   | { data: T | undefined; error: undefined; response: Response }
   | { data: undefined; error: E; response: Response };
 
-function createWorkspaceOpencodeClient(
+export function createWorkspaceOpencodeClient(
   config: ServerConfig,
   workspace: WorkspaceInfo,
   options?: { boundedDiagnosticsReads?: boolean },

--- a/apps/server/src/static-ui.test.ts
+++ b/apps/server/src/static-ui.test.ts
@@ -7,6 +7,7 @@ import { startServer } from "./server.js";
 import type { ServerConfig } from "./types.js";
 
 const IMMUTABLE_CACHE = "public, max-age=31536000, immutable";
+const WEB_BOOTSTRAP_TOKEN_ENV = "OPENWORK_WEB_BOOTSTRAP_TOKEN";
 
 async function createWebRoot() {
   const root = join(tmpdir(), `openwork-static-ui-${Date.now()}-${Math.random().toString(36).slice(2)}`);
@@ -35,6 +36,25 @@ async function withWebRoot(root: string | null, run: () => Promise<void>) {
       delete process.env.OPENWORK_WEB_ROOT;
     } else {
       process.env.OPENWORK_WEB_ROOT = previous;
+    }
+  }
+}
+
+async function withBootstrapTokenEnv(value: string | null, run: () => Promise<void>) {
+  const previous = process.env[WEB_BOOTSTRAP_TOKEN_ENV];
+  if (value === null) {
+    delete process.env[WEB_BOOTSTRAP_TOKEN_ENV];
+  } else {
+    process.env[WEB_BOOTSTRAP_TOKEN_ENV] = value;
+  }
+
+  try {
+    await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env[WEB_BOOTSTRAP_TOKEN_ENV];
+    } else {
+      process.env[WEB_BOOTSTRAP_TOKEN_ENV] = previous;
     }
   }
 }
@@ -159,13 +179,30 @@ describe("serveStaticUi", () => {
 
   test("injects escaped bootstrap JSON into index.html", async () => {
     const root = await createWebRoot();
-    await withWebRoot(root, async () => {
-      const response = await serveStaticUi(new Request("http://openwork.test/"), staticConfig("tok<\u2028>\u2029&"));
-      if (!response) throw new Error("expected index response");
-      const body = await response.text();
-      expect(body).toContain("<script>window.__OPENWORK_BOOTSTRAP__ = {\"token\":\"tok\\u003c\\u2028\\u003e\\u2029\\u0026\"}</script></head>");
-      expect(body).not.toContain("tok<");
+    await withBootstrapTokenEnv(null, async () => {
+      await withWebRoot(root, async () => {
+        const response = await serveStaticUi(new Request("http://openwork.test/"), staticConfig("tok<\u2028>\u2029&"));
+        if (!response) throw new Error("expected index response");
+        const body = await response.text();
+        expect(body).toContain("<script>window.__OPENWORK_BOOTSTRAP__ = {\"token\":\"tok\\u003c\\u2028\\u003e\\u2029\\u0026\"}</script></head>");
+        expect(body).not.toContain("tok<");
+      });
     });
+  });
+
+  test("can disable bootstrap token injection", async () => {
+    const root = await createWebRoot();
+    for (const value of ["0", "false"]) {
+      await withBootstrapTokenEnv(value, async () => {
+        await withWebRoot(root, async () => {
+          const response = await serveStaticUi(new Request("http://openwork.test/"), staticConfig("client-token"));
+          if (!response) throw new Error("expected index response");
+          const body = await response.text();
+          expect(body).toContain("App shell");
+          expect(body).not.toContain("__OPENWORK_BOOTSTRAP__");
+        });
+      });
+    }
   });
 
   test("leaves non-GET route misses on the existing JSON 404 path", async () => {

--- a/apps/server/src/static-ui.test.ts
+++ b/apps/server/src/static-ui.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { serveStaticUi } from "./static-ui.js";
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const IMMUTABLE_CACHE = "public, max-age=31536000, immutable";
+
+async function createWebRoot() {
+  const root = join(tmpdir(), `openwork-static-ui-${Date.now()}-${Math.random().toString(36).slice(2)}`);
+  await mkdir(join(root, "assets"), { recursive: true });
+  await writeFile(join(root, "index.html"), "<html><head><title>OpenWork</title></head><body>App shell</body></html>");
+  await writeFile(join(root, "overlay.html"), "<html><head></head><body>Overlay</body></html>");
+  await writeFile(join(root, "assets", "app.123.js"), "console.log('app');");
+  await writeFile(join(root, "assets", "style.123.css"), "body { color: black; }");
+  await writeFile(join(root, "data.json"), "{\"ok\":true}");
+  await writeFile(join(root, "icon.svg"), "<svg></svg>");
+  return root;
+}
+
+async function withWebRoot(root: string | null, run: () => Promise<void>) {
+  const previous = process.env.OPENWORK_WEB_ROOT;
+  if (root) {
+    process.env.OPENWORK_WEB_ROOT = root;
+  } else {
+    delete process.env.OPENWORK_WEB_ROOT;
+  }
+
+  try {
+    await run();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OPENWORK_WEB_ROOT;
+    } else {
+      process.env.OPENWORK_WEB_ROOT = previous;
+    }
+  }
+}
+
+function staticConfig(token = "client-token") {
+  return { token };
+}
+
+function serverConfig(root: string, port: number): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port,
+    token: "client-token",
+    hostToken: "host-token",
+    configPath: join(root, "server.json"),
+    approval: { mode: "auto", timeoutMs: 30000 },
+    corsOrigins: ["*"],
+    workspaces: [
+      {
+        id: "default",
+        name: "Default",
+        path: root,
+        preset: "default",
+        workspaceType: "local",
+      },
+    ],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+describe("serveStaticUi", () => {
+  test("is a no-op when OPENWORK_WEB_ROOT is unset", async () => {
+    await withWebRoot(null, async () => {
+      const response = await serveStaticUi(new Request("http://openwork.test/"), staticConfig());
+      expect(response).toBeNull();
+    });
+  });
+
+  test("rejects path traversal", async () => {
+    const root = await createWebRoot();
+    await withWebRoot(root, async () => {
+      const response = await serveStaticUi(new Request("http://openwork.test/safe%2F..%2F..%2Fsecret.txt"), staticConfig());
+      if (!response) throw new Error("expected traversal response");
+      expect(response.status).toBe(400);
+      expect(await response.json()).toEqual({ code: "path_escape", message: "Path escapes workspace root" });
+    });
+  });
+
+  test("serves configured MIME types", async () => {
+    const root = await createWebRoot();
+    await withWebRoot(root, async () => {
+      const js = await serveStaticUi(new Request("http://openwork.test/assets/app.123.js"), staticConfig());
+      const css = await serveStaticUi(new Request("http://openwork.test/assets/style.123.css"), staticConfig());
+      const json = await serveStaticUi(new Request("http://openwork.test/data.json"), staticConfig());
+      const svg = await serveStaticUi(new Request("http://openwork.test/icon.svg"), staticConfig());
+      if (!js || !css || !json || !svg) throw new Error("expected static responses");
+      expect(js.headers.get("Content-Type")).toBe("text/javascript; charset=utf-8");
+      expect(css.headers.get("Content-Type")).toBe("text/css; charset=utf-8");
+      expect(json.headers.get("Content-Type")).toBe("application/json; charset=utf-8");
+      expect(svg.headers.get("Content-Type")).toBe("image/svg+xml; charset=utf-8");
+    });
+  });
+
+  test("uses immutable cache headers for assets", async () => {
+    const root = await createWebRoot();
+    await withWebRoot(root, async () => {
+      const response = await serveStaticUi(new Request("http://openwork.test/assets/app.123.js"), staticConfig());
+      if (!response) throw new Error("expected asset response");
+      expect(response.headers.get("Cache-Control")).toBe(IMMUTABLE_CACHE);
+    });
+  });
+
+  test("falls back to index.html for SPA routes", async () => {
+    const root = await createWebRoot();
+    await withWebRoot(root, async () => {
+      const response = await serveStaticUi(new Request("http://openwork.test/settings/general"), staticConfig(""));
+      if (!response) throw new Error("expected SPA fallback response");
+      expect(response.status).toBe(200);
+      expect(response.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+      expect(response.headers.get("Cache-Control")).toBe("no-cache");
+      expect(await response.text()).toContain("App shell");
+    });
+  });
+
+  test("leaves missing assets on the existing JSON 404 path while SPA routes fallback", async () => {
+    const root = await createWebRoot();
+    await withWebRoot(root, async () => {
+      const server = await startServer(serverConfig(root, 0));
+      try {
+        const base = `http://127.0.0.1:${server.port}`;
+        const missingAsset = await fetch(`${base}/assets/app-DEADBEEF.js`);
+        expect(missingAsset.status).toBe(404);
+        expect(missingAsset.headers.get("Content-Type")).toBe("application/json");
+        expect(await missingAsset.json()).toEqual({ code: "not_found", message: "Not found" });
+
+        const route = await fetch(`${base}/settings/general`);
+        expect(route.status).toBe(200);
+        expect(route.headers.get("Content-Type")).toBe("text/html; charset=utf-8");
+        expect(await route.text()).toContain("App shell");
+      } finally {
+        await server.stop();
+      }
+    });
+  });
+
+  test("serves overlay.html directly without using it as the fallback", async () => {
+    const root = await createWebRoot();
+    await withWebRoot(root, async () => {
+      const overlay = await serveStaticUi(new Request("http://openwork.test/overlay.html"), staticConfig());
+      const fallback = await serveStaticUi(new Request("http://openwork.test/missing-route"), staticConfig(""));
+      if (!overlay || !fallback) throw new Error("expected overlay and fallback responses");
+      expect(await overlay.text()).toContain("Overlay");
+      expect(await fallback.text()).toContain("App shell");
+    });
+  });
+
+  test("injects escaped bootstrap JSON into index.html", async () => {
+    const root = await createWebRoot();
+    await withWebRoot(root, async () => {
+      const response = await serveStaticUi(new Request("http://openwork.test/"), staticConfig("tok<\u2028>\u2029&"));
+      if (!response) throw new Error("expected index response");
+      const body = await response.text();
+      expect(body).toContain("<script>window.__OPENWORK_BOOTSTRAP__ = {\"token\":\"tok\\u003c\\u2028\\u003e\\u2029\\u0026\"}</script></head>");
+      expect(body).not.toContain("tok<");
+    });
+  });
+
+  test("leaves non-GET route misses on the existing JSON 404 path", async () => {
+    const root = await createWebRoot();
+    await withWebRoot(root, async () => {
+      const server = await startServer(serverConfig(root, 0));
+      try {
+        const response = await fetch(`http://127.0.0.1:${server.port}/definitely-not-a-route`, { method: "POST" });
+        expect(response.status).toBe(404);
+        expect(response.headers.get("Content-Type")).toBe("application/json");
+        expect(await response.json()).toEqual({ code: "not_found", message: "Not found" });
+      } finally {
+        await server.stop();
+      }
+    });
+  });
+});

--- a/apps/server/src/static-ui.ts
+++ b/apps/server/src/static-ui.ts
@@ -6,6 +6,7 @@ import { cssResponse, htmlResponse, jsResponse, svgResponse } from "./toy-ui.js"
 import type { ServerConfig } from "./types.js";
 
 const WEB_ROOT_ENV = "OPENWORK_WEB_ROOT";
+const WEB_BOOTSTRAP_TOKEN_ENV = "OPENWORK_WEB_BOOTSTRAP_TOKEN";
 const ASSET_CACHE = "public, max-age=31536000, immutable";
 const INDEX_CACHE = "no-cache";
 
@@ -120,6 +121,8 @@ function contentType(extension: string): string {
 }
 
 function injectBootstrap(html: string, token: string): string {
+  if (!shouldInjectBootstrapToken()) return html;
+
   const clientToken = token.trim();
   if (!clientToken) return html;
 
@@ -128,6 +131,11 @@ function injectBootstrap(html: string, token: string): string {
   const headCloseIndex = html.toLowerCase().indexOf("</head>");
   if (headCloseIndex < 0) return `${script}${html}`;
   return `${html.slice(0, headCloseIndex)}${script}${html.slice(headCloseIndex)}`;
+}
+
+function shouldInjectBootstrapToken(): boolean {
+  const configured = process.env[WEB_BOOTSTRAP_TOKEN_ENV]?.trim().toLowerCase();
+  return configured !== "0" && configured !== "false";
 }
 
 function escapeScriptJson(json: string): string {

--- a/apps/server/src/static-ui.ts
+++ b/apps/server/src/static-ui.ts
@@ -1,0 +1,142 @@
+import { readFile, stat } from "node:fs/promises";
+import { extname } from "node:path";
+import { ApiError, formatError } from "./errors.js";
+import { resolveWithinRoot } from "./paths.js";
+import { cssResponse, htmlResponse, jsResponse, svgResponse } from "./toy-ui.js";
+import type { ServerConfig } from "./types.js";
+
+const WEB_ROOT_ENV = "OPENWORK_WEB_ROOT";
+const ASSET_CACHE = "public, max-age=31536000, immutable";
+const INDEX_CACHE = "no-cache";
+
+type StaticUiConfig = Pick<ServerConfig, "token">;
+
+export async function serveStaticUi(request: Request, config: StaticUiConfig): Promise<Response | null> {
+  const root = process.env[WEB_ROOT_ENV]?.trim();
+  if (!root) return null;
+
+  const method = request.method.toUpperCase();
+  if (method !== "GET" && method !== "HEAD") return null;
+
+  const url = new URL(request.url);
+  if (url.pathname.startsWith("/w/")) return null;
+
+  const relativePath = requestPathToRelativePath(url.pathname);
+  if (!relativePath) {
+    return jsonError(new ApiError(400, "invalid_path", "Invalid URL path"));
+  }
+
+  try {
+    const fileResponse = await serveFile(root, relativePath, url.pathname, method, config.token);
+    if (fileResponse) return fileResponse;
+    if (url.pathname.startsWith("/assets/")) return null;
+    return serveFile(root, "index.html", "/index.html", method, config.token);
+  } catch (error) {
+    if (error instanceof ApiError) return jsonError(error);
+    throw error;
+  }
+}
+
+function requestPathToRelativePath(pathname: string): string | null {
+  try {
+    const decoded = decodeURIComponent(pathname);
+    return decoded.replace(/^\/+/, "") || "index.html";
+  } catch {
+    return null;
+  }
+}
+
+async function serveFile(
+  root: string,
+  relativePath: string,
+  requestPathname: string,
+  method: string,
+  token: string,
+): Promise<Response | null> {
+  const filePath = await resolveWithinRoot(root, relativePath);
+  const fileStat = await stat(filePath).catch(() => null);
+  if (!fileStat?.isFile()) return null;
+
+  const extension = extname(relativePath).toLowerCase();
+  const cacheControl = requestPathname.startsWith("/assets/") ? ASSET_CACHE : INDEX_CACHE;
+  if (method === "HEAD") {
+    return new Response(null, {
+      status: 200,
+      headers: responseHeaders(extension, cacheControl),
+    });
+  }
+
+  if (isTextExtension(extension)) {
+    const body = await readFile(filePath, "utf8");
+    const text = relativePath === "index.html" ? injectBootstrap(body, token) : body;
+    return withCacheControl(textResponse(extension, text), cacheControl);
+  }
+
+  return new Response(await readFile(filePath), {
+    status: 200,
+    headers: responseHeaders(extension, cacheControl),
+  });
+}
+
+function isTextExtension(extension: string): boolean {
+  return extension === ".html" || extension === ".js" || extension === ".mjs" || extension === ".css" ||
+    extension === ".json" || extension === ".svg" || extension === ".map";
+}
+
+function textResponse(extension: string, body: string): Response {
+  if (extension === ".html") return htmlResponse(body);
+  if (extension === ".js" || extension === ".mjs") return jsResponse(body);
+  if (extension === ".css") return cssResponse(body);
+  if (extension === ".svg") return svgResponse(body);
+  return new Response(body, { status: 200, headers: { "Content-Type": contentType(extension) } });
+}
+
+function withCacheControl(response: Response, cacheControl: string): Response {
+  const headers = new Headers(response.headers);
+  headers.set("Cache-Control", cacheControl);
+  return new Response(response.body, { status: response.status, headers });
+}
+
+function responseHeaders(extension: string, cacheControl: string): Headers {
+  const headers = new Headers({ "Cache-Control": cacheControl });
+  headers.set("Content-Type", contentType(extension));
+  return headers;
+}
+
+function contentType(extension: string): string {
+  if (extension === ".html") return "text/html; charset=utf-8";
+  if (extension === ".js" || extension === ".mjs") return "text/javascript; charset=utf-8";
+  if (extension === ".css") return "text/css; charset=utf-8";
+  if (extension === ".json" || extension === ".map") return "application/json; charset=utf-8";
+  if (extension === ".svg") return "image/svg+xml; charset=utf-8";
+  if (extension === ".png") return "image/png";
+  if (extension === ".jpg" || extension === ".jpeg") return "image/jpeg";
+  if (extension === ".webp") return "image/webp";
+  if (extension === ".ico") return "image/x-icon";
+  if (extension === ".woff") return "font/woff";
+  if (extension === ".woff2") return "font/woff2";
+  if (extension === ".ttf") return "font/ttf";
+  return "application/octet-stream";
+}
+
+function injectBootstrap(html: string, token: string): string {
+  const clientToken = token.trim();
+  if (!clientToken) return html;
+
+  const bootstrap = escapeScriptJson(JSON.stringify({ token: clientToken }));
+  const script = `<script>window.__OPENWORK_BOOTSTRAP__ = ${bootstrap}</script>`;
+  const headCloseIndex = html.toLowerCase().indexOf("</head>");
+  if (headCloseIndex < 0) return `${script}${html}`;
+  return `${html.slice(0, headCloseIndex)}${script}${html.slice(headCloseIndex)}`;
+}
+
+function escapeScriptJson(json: string): string {
+  return json.replace(/[<>&\u2028\u2029]/g, (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`);
+}
+
+function jsonError(error: ApiError): Response {
+  return new Response(JSON.stringify(formatError(error)), {
+    status: error.status,
+    headers: { "Content-Type": "application/json" },
+  });
+}

--- a/apps/server/src/worker-activity-heartbeat.test.ts
+++ b/apps/server/src/worker-activity-heartbeat.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, test } from "bun:test";
+import {
+  buildWorkerActivityHeartbeatPayload,
+  parseSessionActivityAt,
+  postWorkerActivityHeartbeat,
+  resolveWorkerActivityHeartbeatConfig,
+  startWorkerActivityHeartbeat,
+  type WorkerActivityHeartbeatLogger,
+} from "./worker-activity-heartbeat.js";
+import type { ServerConfig } from "./types.js";
+
+const enabledEnv = {
+  DEN_ACTIVITY_HEARTBEAT_ENABLED: "true",
+  DEN_RUNTIME_PROVIDER: "daytona",
+  DEN_WORKER_ID: "worker-1",
+  DEN_ACTIVITY_HEARTBEAT_URL: "https://den.test/heartbeat",
+  DEN_ACTIVITY_HEARTBEAT_TOKEN: "secret-token",
+};
+
+function heartbeatConfig(overrides: Record<string, string | undefined> = {}) {
+  return resolveWorkerActivityHeartbeatConfig({ ...enabledEnv, ...overrides });
+}
+
+function serverConfig(): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    token: "client-token",
+    hostToken: "host-token",
+    approval: { mode: "auto", timeoutMs: 30000 },
+    corsOrigins: ["*"],
+    workspaces: [],
+    authorizedRoots: [],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  };
+}
+
+async function waitFor(promise: Promise<void>) {
+  let timeout: ReturnType<typeof setTimeout> | null = null;
+  try {
+    await Promise.race([
+      promise,
+      new Promise<void>((_, reject) => {
+        timeout = setTimeout(() => reject(new Error("timed out waiting for heartbeat warning")), 1000);
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+describe("worker activity heartbeat", () => {
+  const disabledCases: Array<{ name: string; override: Record<string, string | undefined> }> = [
+    { name: "enabled flag", override: { DEN_ACTIVITY_HEARTBEAT_ENABLED: "0" } },
+    { name: "runtime provider", override: { DEN_RUNTIME_PROVIDER: "docker" } },
+    { name: "worker id", override: { DEN_WORKER_ID: "" } },
+    { name: "heartbeat URL", override: { DEN_ACTIVITY_HEARTBEAT_URL: "" } },
+    { name: "heartbeat token", override: { DEN_ACTIVITY_HEARTBEAT_TOKEN: "" } },
+  ];
+
+  for (const item of disabledCases) {
+    test(`disables when ${item.name} gate fails`, () => {
+      expect(heartbeatConfig(item.override).enabled).toBe(false);
+    });
+  }
+
+  test("uses five-minute defaults when the gate passes", () => {
+    const config = heartbeatConfig();
+    expect(config.enabled).toBe(true);
+    expect(config.intervalMs).toBe(5 * 60_000);
+    expect(config.activeWindowMs).toBe(5 * 60_000);
+  });
+
+  test("prefers updated session activity and falls back to created", () => {
+    expect(parseSessionActivityAt({ time: { updated: 2000, created: 1000 } })).toBe(2000);
+    expect(parseSessionActivityAt({ time: { created: 1000 } })).toBe(1000);
+  });
+
+  test("sets isActiveRecently on both sides of the active window boundary", () => {
+    const now = 10_000;
+    const windowMs = 1000;
+    expect(buildWorkerActivityHeartbeatPayload([{ time: { updated: now - windowMs } }], now, windowMs).isActiveRecently).toBe(true);
+    expect(buildWorkerActivityHeartbeatPayload([{ time: { updated: now - windowMs - 1 } }], now, windowMs).isActiveRecently).toBe(false);
+  });
+
+  test("uses null lastActivityAt when there are no sessions", () => {
+    const now = Date.UTC(2026, 0, 1, 0, 0, 0);
+    expect(buildWorkerActivityHeartbeatPayload([], now, 1000)).toEqual({
+      sentAt: "2026-01-01T00:00:00.000Z",
+      isActiveRecently: false,
+      lastActivityAt: null,
+      openSessionCount: 0,
+    });
+  });
+
+  test("posts the expected payload and headers", async () => {
+    const now = Date.UTC(2026, 0, 1, 0, 0, 0);
+    const requests: Request[] = [];
+    const fetchImpl = async (input: string | URL | Request, init?: RequestInit): Promise<Response> => {
+      requests.push(new Request(input, init));
+      return new Response("ok");
+    };
+
+    await postWorkerActivityHeartbeat({
+      config: heartbeatConfig({ DEN_ACTIVITY_WINDOW_SECONDS: "60" }),
+      sessions: [{ time: { updated: now - 30_000 } }, { time: { created: now - 120_000 } }],
+      fetchImpl,
+      now: () => now,
+    });
+
+    const request = requests[0];
+    if (!request) throw new Error("expected heartbeat request");
+    expect(request.method).toBe("POST");
+    expect(request.headers.get("Content-Type")).toBe("application/json");
+    expect(request.headers.get("Authorization")).toBe("Bearer secret-token");
+    expect(await request.json()).toEqual({
+      sentAt: "2026-01-01T00:00:00.000Z",
+      isActiveRecently: true,
+      lastActivityAt: "2025-12-31T23:59:30.000Z",
+      openSessionCount: 2,
+    });
+  });
+
+  test("logs and swallows non-OK responses from the scheduler", async () => {
+    const warnings: Array<{ message: string; attributes?: Record<string, unknown> }> = [];
+    let resolveWarning: () => void = () => undefined;
+    const warned = new Promise<void>((resolve) => {
+      resolveWarning = resolve;
+    });
+    const logger: WorkerActivityHeartbeatLogger = {
+      log: (level, message, attributes) => {
+        if (level !== "warn") return;
+        warnings.push(attributes ? { message, attributes } : { message });
+        resolveWarning();
+      },
+    };
+
+    const handle = startWorkerActivityHeartbeat(serverConfig(), logger, {
+      env: { ...enabledEnv, DEN_ACTIVITY_HEARTBEAT_INTERVAL_SECONDS: "60" },
+      fetchImpl: async () => new Response("nope", { status: 503 }),
+      listSessions: async () => [],
+      now: () => Date.UTC(2026, 0, 1, 0, 0, 0),
+    });
+
+    try {
+      expect(handle).not.toBeNull();
+      await waitFor(warned);
+    } finally {
+      handle?.stop();
+    }
+
+    const warning = warnings[0];
+    if (!warning) throw new Error("expected warning log");
+    expect(warning.message).toBe("Worker activity heartbeat failed");
+    expect(warning.attributes?.error).toBe("heartbeat_failed:503");
+  });
+});

--- a/apps/server/src/worker-activity-heartbeat.ts
+++ b/apps/server/src/worker-activity-heartbeat.ts
@@ -1,0 +1,189 @@
+import { createWorkspaceOpencodeClient } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const DEFAULT_ACTIVITY_WINDOW_MS = 5 * 60_000;
+const DEFAULT_ACTIVITY_HEARTBEAT_INTERVAL_MS = 5 * 60_000;
+
+export type WorkerActivityHeartbeatConfig = {
+  enabled: boolean;
+  workerId: string;
+  url: string;
+  token: string;
+  intervalMs: number;
+  activeWindowMs: number;
+};
+
+export type WorkerActivityHeartbeatHandle = {
+  stop: () => void;
+};
+
+export type WorkerActivityHeartbeatLogger = {
+  log: (level: "info" | "warn" | "error", message: string, attributes?: Record<string, unknown>) => void;
+};
+
+export type WorkerActivityHeartbeatPayload = {
+  sentAt: string;
+  isActiveRecently: boolean;
+  lastActivityAt: string | null;
+  openSessionCount: number;
+};
+
+type HeartbeatEnv = Record<string, string | undefined>;
+type HeartbeatFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+function parsePositiveNumberEnv(value: string | undefined, fallback: number): number {
+  const raw = value?.trim();
+  if (!raw) return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object";
+}
+
+export function parseSessionActivityAt(session: unknown): number | null {
+  if (!isRecord(session) || !isRecord(session.time)) return null;
+  const updated = session.time.updated;
+  if (typeof updated === "number" && Number.isFinite(updated) && updated > 0) return updated;
+  const created = session.time.created;
+  if (typeof created === "number" && Number.isFinite(created) && created > 0) return created;
+  return null;
+}
+
+export function resolveWorkerActivityHeartbeatConfig(env: HeartbeatEnv = process.env): WorkerActivityHeartbeatConfig {
+  const enabled = (env.DEN_ACTIVITY_HEARTBEAT_ENABLED ?? "").trim().toLowerCase();
+  const provider = (env.DEN_RUNTIME_PROVIDER ?? "").trim().toLowerCase();
+  const workerId = (env.DEN_WORKER_ID ?? "").trim();
+  const url = (env.DEN_ACTIVITY_HEARTBEAT_URL ?? "").trim();
+  const token = (env.DEN_ACTIVITY_HEARTBEAT_TOKEN ?? "").trim();
+  const featureEnabled = enabled === "1" || enabled === "true" || enabled === "yes";
+
+  if (!featureEnabled || provider !== "daytona" || !workerId || !url || !token) {
+    return {
+      enabled: false,
+      workerId: "",
+      url: "",
+      token: "",
+      intervalMs: DEFAULT_ACTIVITY_HEARTBEAT_INTERVAL_MS,
+      activeWindowMs: DEFAULT_ACTIVITY_WINDOW_MS,
+    };
+  }
+
+  const intervalSeconds = parsePositiveNumberEnv(
+    env.DEN_ACTIVITY_HEARTBEAT_INTERVAL_SECONDS,
+    DEFAULT_ACTIVITY_HEARTBEAT_INTERVAL_MS / 1000,
+  );
+  const activeWindowSeconds = parsePositiveNumberEnv(
+    env.DEN_ACTIVITY_WINDOW_SECONDS,
+    DEFAULT_ACTIVITY_WINDOW_MS / 1000,
+  );
+
+  return {
+    enabled: true,
+    workerId,
+    url,
+    token,
+    intervalMs: Math.round(intervalSeconds * 1000),
+    activeWindowMs: Math.round(activeWindowSeconds * 1000),
+  };
+}
+
+export function buildWorkerActivityHeartbeatPayload(
+  sessions: readonly unknown[],
+  now: number,
+  activeWindowMs: number,
+): WorkerActivityHeartbeatPayload {
+  let latestActivityAt = 0;
+  for (const session of sessions) {
+    const activityAt = parseSessionActivityAt(session);
+    if (activityAt && activityAt > latestActivityAt) latestActivityAt = activityAt;
+  }
+
+  return {
+    sentAt: new Date(now).toISOString(),
+    isActiveRecently: latestActivityAt > 0 && now - latestActivityAt <= activeWindowMs,
+    lastActivityAt: latestActivityAt > 0 ? new Date(latestActivityAt).toISOString() : null,
+    openSessionCount: sessions.length,
+  };
+}
+
+export async function postWorkerActivityHeartbeat(input: {
+  config: WorkerActivityHeartbeatConfig;
+  sessions: readonly unknown[];
+  fetchImpl?: HeartbeatFetch;
+  now?: () => number;
+}): Promise<WorkerActivityHeartbeatPayload | null> {
+  if (!input.config.enabled) return null;
+
+  const payload = buildWorkerActivityHeartbeatPayload(
+    input.sessions,
+    input.now ? input.now() : Date.now(),
+    input.config.activeWindowMs,
+  );
+  const response = await (input.fetchImpl ?? fetch)(input.config.url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${input.config.token}`,
+    },
+    body: JSON.stringify(payload),
+    signal: AbortSignal.timeout(10_000),
+  });
+
+  if (!response.ok) throw new Error(`heartbeat_failed:${response.status}`);
+  return payload;
+}
+
+async function listOpenSessions(config: ServerConfig): Promise<readonly unknown[]> {
+  const workspace = config.workspaces[0];
+  if (!workspace) return [];
+  const opencode = createWorkspaceOpencodeClient(config, workspace);
+  const result = await opencode.session.list({ limit: 200 });
+  if (result.data != null) return result.data;
+  if (result.error === undefined) throw new Error("opencode_empty_response");
+  throw new Error(`opencode_request_failed:${result.response.status}`);
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function startWorkerActivityHeartbeat(
+  config: ServerConfig,
+  logger: WorkerActivityHeartbeatLogger,
+  options?: {
+    env?: HeartbeatEnv;
+    fetchImpl?: HeartbeatFetch;
+    listSessions?: () => Promise<readonly unknown[]>;
+    now?: () => number;
+  },
+): WorkerActivityHeartbeatHandle | null {
+  const heartbeatConfig = resolveWorkerActivityHeartbeatConfig(options?.env);
+  if (!heartbeatConfig.enabled) return null;
+
+  logger.log("info", "Worker activity heartbeat enabled", {
+    workerId: heartbeatConfig.workerId,
+    intervalMs: heartbeatConfig.intervalMs,
+    activeWindowMs: heartbeatConfig.activeWindowMs,
+  });
+
+  const listSessions = options?.listSessions ?? (() => listOpenSessions(config));
+  const runHeartbeat = () => {
+    void listSessions()
+      .then((sessions) => postWorkerActivityHeartbeat({
+        config: heartbeatConfig,
+        sessions,
+        fetchImpl: options?.fetchImpl,
+        now: options?.now,
+      }))
+      .catch((error) => {
+        logger.log("warn", "Worker activity heartbeat failed", { error: errorMessage(error) });
+      });
+  };
+
+  runHeartbeat();
+  const interval = setInterval(runHeartbeat, heartbeatConfig.intervalMs);
+  return { stop: () => clearInterval(interval) };
+}

--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -21,6 +21,7 @@ import { createRequestAccessLogMiddleware, createTelemetryErrorSanitizerMiddlewa
 import { registerAdminRoutes } from "./routes/admin/index.js"
 import { registerAuthRoutes } from "./routes/auth/index.js"
 import { registerBootstrapRoutes } from "./routes/bootstrap/index.js"
+import { registerCloudRoutes } from "./routes/cloud/index.js"
 import { registerDeprecatedSkillHubRoutes } from "./routes/deprecated-skill-hubs.js"
 import { registerDevRoutes } from "./routes/dev/index.js"
 import { registerMcpTokenRoutes } from "./routes/mcp/index.js"
@@ -171,6 +172,7 @@ app.get(
 registerAdminRoutes(app)
 registerAuthRoutes(app)
 registerBootstrapRoutes(app)
+registerCloudRoutes(app)
 registerDeprecatedSkillHubRoutes(app)
 registerDevRoutes(app)
 registerMeRoutes(app)

--- a/ee/apps/den-api/src/capability-sources/cloud-rollout.ts
+++ b/ee/apps/den-api/src/capability-sources/cloud-rollout.ts
@@ -1,0 +1,49 @@
+/**
+ * Alpha rollout gate for OpenWork Cloud.
+ *
+ * Cloud is default-off for every organization. Platform admins must explicitly
+ * enable the alpha with `metadata.capabilities.cloud: true`; absent and
+ * non-boolean values stay disabled.
+ *
+ * The alpha is hosted-only: even a literal org opt-in is ignored unless Den is
+ * running in multi-org mode. Keep this as the one place to relax the gate if
+ * Cloud is later offered to self-hosted deployments.
+ */
+
+import type { DenOrgMode } from "../env.js"
+
+type MetadataInput = Record<string, unknown> | string | null | undefined
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function parseMetadata(input: MetadataInput): Record<string, unknown> {
+  if (!input) {
+    return {}
+  }
+
+  if (typeof input === "string") {
+    try {
+      const parsed: unknown = JSON.parse(input)
+      return isRecord(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+
+  return isRecord(input) ? input : {}
+}
+
+export function organizationCloudEnabled(
+  metadata: MetadataInput,
+  options: { orgMode: DenOrgMode },
+): boolean {
+  if (options.orgMode !== "multi_org") {
+    return false
+  }
+
+  const parsed = parseMetadata(metadata)
+  const capabilities = isRecord(parsed.capabilities) ? parsed.capabilities : {}
+  return capabilities.cloud === true
+}

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -73,6 +73,9 @@ const EnvSchema = z.object({
   WORKER_PROVISIONING_RECONCILE_INTERVAL_MS: z.string().optional(),
   WORKER_PROVISIONING_RECONCILE_STALE_MS: z.string().optional(),
   WORKER_PROVISIONING_RECONCILE_BATCH_SIZE: z.string().optional(),
+  CLOUD_IDLE_STOP_MINUTES: z.string().optional(),
+  CLOUD_IDLE_LOOP_SECONDS: z.string().optional(),
+  CLOUD_IDLE_STOP_BATCH_SIZE: z.string().optional(),
   PROVISIONER_MODE: z.enum(["stub", "render", "daytona"]).optional(),
   WORKER_URL_TEMPLATE: z.string().optional(),
   WORKER_ACTIVITY_BASE_URL: z.string().optional(),
@@ -137,6 +140,7 @@ const EnvSchema = z.object({
   DAYTONA_OPENCODE_PORT: z.string().optional(),
   DAYTONA_CREATE_TIMEOUT_SECONDS: z.string().optional(),
   DAYTONA_DELETE_TIMEOUT_SECONDS: z.string().optional(),
+  DAYTONA_STOP_TIMEOUT_SECONDS: z.string().optional(),
   DAYTONA_HEALTHCHECK_TIMEOUT_MS: z.string().optional(),
   INFERENCE_PROXY_BASE_URL: z.string().optional(),
   OPENROUTER_MANAGEMENT_API_KEY: z.string().optional(),
@@ -480,6 +484,9 @@ export const env = {
   workerProvisioningReconcileIntervalMs: Number(parsed.WORKER_PROVISIONING_RECONCILE_INTERVAL_MS ?? "60000"),
   workerProvisioningReconcileStaleMs: Number(parsed.WORKER_PROVISIONING_RECONCILE_STALE_MS ?? "1200000"),
   workerProvisioningReconcileBatchSize: Number(parsed.WORKER_PROVISIONING_RECONCILE_BATCH_SIZE ?? "10"),
+  cloudIdleStopMs: Number(parsed.CLOUD_IDLE_STOP_MINUTES ?? "30") * 60_000,
+  cloudIdleLoopIntervalMs: Number(parsed.CLOUD_IDLE_LOOP_SECONDS ?? "60") * 1000,
+  cloudIdleStopBatchSize: Number(parsed.CLOUD_IDLE_STOP_BATCH_SIZE ?? "10"),
   workerUrlTemplate: parsed.WORKER_URL_TEMPLATE,
   workerActivityBaseUrl:
     optionalString(parsed.WORKER_ACTIVITY_BASE_URL) ??
@@ -581,6 +588,9 @@ export const env = {
     opencodePort: Number(parsed.DAYTONA_OPENCODE_PORT ?? "4096"),
     createTimeoutSeconds: Number(parsed.DAYTONA_CREATE_TIMEOUT_SECONDS ?? "300"),
     deleteTimeoutSeconds: Number(parsed.DAYTONA_DELETE_TIMEOUT_SECONDS ?? "120"),
+    stopTimeoutSeconds: parsed.DAYTONA_STOP_TIMEOUT_SECONDS === undefined
+      ? undefined
+      : Number(parsed.DAYTONA_STOP_TIMEOUT_SECONDS),
     healthcheckTimeoutMs: Number(
       parsed.DAYTONA_HEALTHCHECK_TIMEOUT_MS ?? "300000",
     ),

--- a/ee/apps/den-api/src/organization-capabilities.ts
+++ b/ee/apps/den-api/src/organization-capabilities.ts
@@ -11,7 +11,7 @@ import { z } from "zod"
  * Storage rides the existing organization metadata JSON column — the same
  * home as `limits`, `plan`, and `requireSso` — so no schema change is needed.
  */
-export const ORGANIZATION_CAPABILITY_KEYS = ["installLinks", "mcpConnections"] as const
+export const ORGANIZATION_CAPABILITY_KEYS = ["installLinks", "mcpConnections", "cloud"] as const
 
 export const organizationCapabilityKeySchema = z.enum(ORGANIZATION_CAPABILITY_KEYS)
 
@@ -50,6 +50,7 @@ export function normalizeOrganizationCapabilities(metadata: MetadataInput): Orga
   return {
     installLinks: raw.installLinks === true,
     mcpConnections: raw.mcpConnections === true,
+    cloud: raw.cloud === true,
   }
 }
 
@@ -64,6 +65,9 @@ export function readOrganizationCapabilityOverrides(metadata: MetadataInput): Pa
   }
   if (typeof raw.mcpConnections === "boolean") {
     capabilities.mcpConnections = raw.mcpConnections
+  }
+  if (typeof raw.cloud === "boolean") {
+    capabilities.cloud = raw.cloud
   }
 
   return capabilities

--- a/ee/apps/den-api/src/orgs.ts
+++ b/ee/apps/den-api/src/orgs.ts
@@ -49,6 +49,7 @@ type MemberRow = typeof MemberTable.$inferSelect
 type MemberId = MemberRow["id"]
 type InvitationRow = typeof InvitationTable.$inferSelect
 export type AllowedEmailDomains = string[] | null
+type OrganizationMetadataInput = Record<string, unknown> | string | null | undefined
 
 type MemberLifecycleValidationFailure = Extract<MemberLifecycleValidation, { ok: false }>
 
@@ -319,6 +320,50 @@ export function isEmailAllowedForOrganization(allowedEmailDomains: readonly stri
 function normalizeStoredAllowedEmailDomains(value: unknown): AllowedEmailDomains {
   const values = Array.isArray(value) ? value.filter((entry): entry is string => typeof entry === "string") : null
   return normalizeAllowedEmailDomains(values).domains
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null
+}
+
+function parseMetadataRecord(input: OrganizationMetadataInput): Record<string, unknown> {
+  if (!input) {
+    return {}
+  }
+
+  if (typeof input === "string") {
+    try {
+      const parsed: unknown = JSON.parse(input)
+      return isRecord(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+
+  return isRecord(input) ? input : {}
+}
+
+function serializeMetadataRecord(metadata: Record<string, unknown>) {
+  return Object.keys(metadata).length > 0 ? JSON.stringify(metadata) : null
+}
+
+export function serializeMemberFacingOrganizationMetadata(input: OrganizationMetadataInput) {
+  const metadata = parseMetadataRecord(input)
+  const capabilities = isRecord(metadata.capabilities) ? metadata.capabilities : null
+  if (!capabilities || !("cloud" in capabilities)) {
+    return serializeOrganizationMetadata(input)
+  }
+
+  const nextCapabilities = { ...capabilities }
+  delete nextCapabilities.cloud
+  const nextMetadata = { ...metadata }
+  if (Object.keys(nextCapabilities).length > 0) {
+    nextMetadata.capabilities = nextCapabilities
+  } else {
+    delete nextMetadata.capabilities
+  }
+
+  return serializeMetadataRecord(nextMetadata)
 }
 
 export function parsePermissionRecord(value: string | null) {
@@ -1191,7 +1236,7 @@ export async function listUserOrgs(userId: UserId) {
     slug: row.organization.slug,
     logo: row.organization.logo,
     allowedEmailDomains: normalizeStoredAllowedEmailDomains(row.organization.allowedEmailDomains),
-    metadata: serializeOrganizationMetadata(row.organization.metadata),
+    metadata: serializeMemberFacingOrganizationMetadata(row.organization.metadata),
     role: row.role,
     orgMemberId: row.membershipId,
     membershipId: row.membershipId,

--- a/ee/apps/den-api/src/routes/admin/index.ts
+++ b/ee/apps/den-api/src/routes/admin/index.ts
@@ -30,10 +30,12 @@ import { parseOrganizationPlan, type PlanTier } from "../../entitlements.js"
 import { adminRoute, queryValidator } from "../../middleware/index.js"
 import { denTypeIdSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, unauthorizedSchema } from "../../openapi.js"
 import { appLogger } from "../../observability/logger.js"
+import { organizationCloudEnabled } from "../../capability-sources/cloud-rollout.js"
 import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
 import { organizationInstallLinksEnabled } from "../../capability-sources/install-links-rollout.js"
 import { normalizeOrganizationCapabilities, readOrganizationCapabilityOverrides } from "../../organization-capabilities.js"
 import { DEFAULT_ORGANIZATION_LIMITS, normalizeOrganizationMetadata } from "../../organization-limits.js"
+import { env } from "../../env.js"
 import type { AuthContextVariables } from "../../session.js"
 import { calculateOrganizationSeatBillingCounts, getOrganizationSeatBillingCounts, refreshOrgSubscriptionFromStripe, syncSeatSubscriptionQuantityAfterMemberChange } from "../../stripe-billing.js"
 import { buildAdminPageInfo, normalizeAdminPageRequest, sanitizeAdminSearchForLike, type AdminPageRequest } from "./scale-performance.js"
@@ -81,6 +83,7 @@ const updateOrganizationCapabilitiesSchema = z.object({
   capabilities: z.object({
     installLinks: z.boolean().nullable().optional(),
     mcpConnections: z.boolean().nullable().optional(),
+    cloud: z.boolean().nullable().optional(),
   }),
 })
 
@@ -264,6 +267,7 @@ function readAdminVisibleOrganizationCapabilities(metadata: Record<string, unkno
   return {
     installLinks: organizationInstallLinksEnabled(metadata, { gatingEnabled: false }),
     mcpConnections: memberFacingMcpConnectionsEnabled(metadata, { gatingEnabled: false }),
+    cloud: organizationCloudEnabled(metadata, { orgMode: env.orgMode }),
   }
 }
 
@@ -272,7 +276,7 @@ function readUnmanagedCapabilityMetadata(metadata: Record<string, unknown>): Rec
   const capabilities: Record<string, unknown> = {}
 
   for (const [key, value] of Object.entries(raw)) {
-    if (key !== "installLinks" && key !== "mcpConnections") {
+    if (key !== "installLinks" && key !== "mcpConnections" && key !== "cloud") {
       capabilities[key] = value
     }
   }
@@ -1384,6 +1388,14 @@ export function registerAdminRoutes<T extends { Variables: AuthContextVariables 
           delete capabilities.mcpConnections
         } else {
           capabilities.mcpConnections = mcpConnections
+        }
+      }
+      const cloud = body.data.capabilities.cloud
+      if (cloud !== undefined) {
+        if (cloud === null) {
+          delete capabilities.cloud
+        } else {
+          capabilities.cloud = cloud
         }
       }
 

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -10,6 +10,8 @@ import { env, type DenOrgMode } from "../../env.js"
 import { orgMemberRoute } from "../../middleware/index.js"
 import { jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { getDaytonaSandboxRecord, refreshDaytonaSignedPreview } from "../../workers/daytona.js"
+import { CLOUD_INSTANCE_BACKEND, CLOUD_INSTANCE_NAME } from "../../workers/cloud-constants.js"
+import { wakeCloudWorker as defaultWakeCloudWorker } from "../../workers/cloud-lifecycle.js"
 import type { OrgRouteVariables } from "../org/shared.js"
 import { continueCloudProvisioning, token } from "../workers/shared.js"
 
@@ -20,21 +22,29 @@ type CloudRouteOptions = {
   daytonaApiKey?: string
   continueProvisioning?: typeof continueCloudProvisioning
   refreshSignedPreview?: typeof refreshDaytonaSignedPreview
+  ensureCloudWorker?: EnsureCloudWorker
+  getSandboxRecord?: GetSandboxRecord
+  wakeCloudWorker?: WakeCloudWorker
 }
 
 type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "status">
+type CloudSandboxRecord = Pick<NonNullable<Awaited<ReturnType<typeof getDaytonaSandboxRecord>>>, "signed_preview_url" | "signed_preview_url_expires_at">
 type OrgId = typeof WorkerTable.$inferSelect.org_id
 type UserId = typeof WorkerTable.$inferSelect.created_by_user_id
 type CloudInstanceResponse = {
-  status: "provisioning" | "ready" | "failed"
+  status: "provisioning" | "waking" | "ready" | "failed"
   url: string | null
 }
-
-const CLOUD_INSTANCE_NAME = "Cloud"
-const CLOUD_INSTANCE_BACKEND = "cloud-instance"
+type EnsureCloudWorker = (input: {
+  orgId: OrgId
+  createdByUserId: UserId
+  continueProvisioning: typeof continueCloudProvisioning
+}) => Promise<CloudWorker>
+type GetSandboxRecord = (workerId: CloudWorker["id"]) => Promise<CloudSandboxRecord | null>
+type WakeCloudWorker = (workerId: CloudWorker["id"]) => Promise<void>
 
 const cloudInstanceResponseSchema = z.object({
-  status: z.enum(["provisioning", "ready", "failed"]),
+  status: z.enum(["provisioning", "waking", "ready", "failed"]),
   url: z.string().url().nullable(),
 }).meta({ ref: "CloudInstanceResponse" })
 
@@ -131,12 +141,23 @@ async function ensureCloudWorker(input: {
 async function resolveCloudInstance(input: {
   worker: CloudWorker
   refreshSignedPreview: typeof refreshDaytonaSignedPreview
+  getSandboxRecord: GetSandboxRecord
+  startWake: (workerId: CloudWorker["id"]) => void
 }): Promise<CloudInstanceResponse> {
   if (input.worker.status === "failed") {
     return { status: "failed", url: null }
   }
 
-  const sandbox = await getDaytonaSandboxRecord(input.worker.id)
+  if (input.worker.status === "stopped") {
+    input.startWake(input.worker.id)
+    return { status: "waking", url: null }
+  }
+
+  const sandbox = await input.getSandboxRecord(input.worker.id)
+  if (input.worker.status === "provisioning" && sandbox) {
+    return { status: "waking", url: null }
+  }
+
   if (!sandbox) {
     return { status: "provisioning", url: null }
   }
@@ -163,6 +184,23 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
   const orgMemberRouteMiddleware = options.memberRoute ?? orgMemberRoute()
   const continueProvisioning = options.continueProvisioning ?? continueCloudProvisioning
   const refreshSignedPreview = options.refreshSignedPreview ?? refreshDaytonaSignedPreview
+  const ensureWorker = options.ensureCloudWorker ?? ensureCloudWorker
+  const getSandboxRecord = options.getSandboxRecord ?? getDaytonaSandboxRecord
+  const wakeCloudWorker = options.wakeCloudWorker ?? defaultWakeCloudWorker
+  const wakingWorkers = new Set<CloudWorker["id"]>()
+
+  function startWake(workerId: CloudWorker["id"]) {
+    if (wakingWorkers.has(workerId)) {
+      return
+    }
+
+    wakingWorkers.add(workerId)
+    void wakeCloudWorker(workerId)
+      .catch(() => undefined)
+      .finally(() => {
+        wakingWorkers.delete(workerId)
+      })
+  }
 
   app.get(
     "/v1/cloud/instance",
@@ -192,12 +230,12 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
         return c.json({ error: "unauthorized" }, 401)
       }
 
-      const worker = await ensureCloudWorker({
+      const worker = await ensureWorker({
         orgId: payload.organization.id,
         createdByUserId: user.id,
         continueProvisioning,
       })
-      const instance = await resolveCloudInstance({ worker, refreshSignedPreview })
+      const instance = await resolveCloudInstance({ worker, refreshSignedPreview, getSandboxRecord, startWake })
 
       return c.json(instance)
     },

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -1,0 +1,205 @@
+import { and, desc, eq } from "@openwork-ee/den-db/drizzle"
+import { WorkerTable, WorkerTokenTable } from "@openwork-ee/den-db/schema"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import type { Hono, MiddlewareHandler } from "hono"
+import { describeRoute } from "hono-openapi"
+import { z } from "zod"
+import { organizationCloudEnabled } from "../../capability-sources/cloud-rollout.js"
+import { db } from "../../db.js"
+import { env, type DenOrgMode } from "../../env.js"
+import { orgMemberRoute } from "../../middleware/index.js"
+import { jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
+import { getDaytonaSandboxRecord, refreshDaytonaSignedPreview } from "../../workers/daytona.js"
+import type { OrgRouteVariables } from "../org/shared.js"
+import { continueCloudProvisioning, token } from "../workers/shared.js"
+
+type CloudRouteOptions = {
+  memberRoute?: MiddlewareHandler<{ Variables: OrgRouteVariables }>
+  orgMode?: DenOrgMode
+  provisionerMode?: "stub" | "render" | "daytona"
+  daytonaApiKey?: string
+  continueProvisioning?: typeof continueCloudProvisioning
+  refreshSignedPreview?: typeof refreshDaytonaSignedPreview
+}
+
+type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "status">
+type OrgId = typeof WorkerTable.$inferSelect.org_id
+type UserId = typeof WorkerTable.$inferSelect.created_by_user_id
+type CloudInstanceResponse = {
+  status: "provisioning" | "ready" | "failed"
+  url: string | null
+}
+
+const CLOUD_INSTANCE_NAME = "Cloud"
+const CLOUD_INSTANCE_BACKEND = "cloud-instance"
+
+const cloudInstanceResponseSchema = z.object({
+  status: z.enum(["provisioning", "ready", "failed"]),
+  url: z.string().url().nullable(),
+}).meta({ ref: "CloudInstanceResponse" })
+
+function cloudNotFound() {
+  return { error: "cloud_not_found" }
+}
+
+function hasDaytonaProvisioner(options: CloudRouteOptions) {
+  const apiKey = options.daytonaApiKey !== undefined ? options.daytonaApiKey : env.daytona.apiKey
+  return (options.provisionerMode ?? env.provisionerMode) === "daytona" && Boolean(apiKey?.trim())
+}
+
+async function getCloudWorker(orgId: OrgId) {
+  const rows = await db
+    .select()
+    .from(WorkerTable)
+    .where(and(
+      eq(WorkerTable.org_id, orgId),
+      eq(WorkerTable.destination, "cloud"),
+      eq(WorkerTable.sandbox_backend, CLOUD_INSTANCE_BACKEND),
+    ))
+    .orderBy(desc(WorkerTable.created_at))
+    .limit(1)
+
+  return rows[0] ?? null
+}
+
+async function createCloudWorker(input: {
+  orgId: OrgId
+  createdByUserId: UserId
+  continueProvisioning: typeof continueCloudProvisioning
+}): Promise<CloudWorker> {
+  const workerId = createDenTypeId("worker")
+  const hostToken = token()
+  const clientToken = token()
+  const activityToken = token()
+
+  await db.insert(WorkerTable).values({
+    id: workerId,
+    org_id: input.orgId,
+    created_by_user_id: input.createdByUserId,
+    name: CLOUD_INSTANCE_NAME,
+    description: "OpenWork Cloud browser instance",
+    destination: "cloud",
+    status: "provisioning",
+    sandbox_backend: CLOUD_INSTANCE_BACKEND,
+  })
+
+  await db.insert(WorkerTokenTable).values([
+    {
+      id: createDenTypeId("workerToken"),
+      worker_id: workerId,
+      scope: "host",
+      token: hostToken,
+    },
+    {
+      id: createDenTypeId("workerToken"),
+      worker_id: workerId,
+      scope: "client",
+      token: clientToken,
+    },
+    {
+      id: createDenTypeId("workerToken"),
+      worker_id: workerId,
+      scope: "activity",
+      token: activityToken,
+    },
+  ])
+
+  void input.continueProvisioning({
+    workerId,
+    name: CLOUD_INSTANCE_NAME,
+    hostToken,
+    clientToken,
+    activityToken,
+  })
+
+  return { id: workerId, status: "provisioning" }
+}
+
+async function ensureCloudWorker(input: {
+  orgId: OrgId
+  createdByUserId: UserId
+  continueProvisioning: typeof continueCloudProvisioning
+}) {
+  const existing = await getCloudWorker(input.orgId)
+  if (existing) {
+    return existing
+  }
+
+  return createCloudWorker(input)
+}
+
+async function resolveCloudInstance(input: {
+  worker: CloudWorker
+  refreshSignedPreview: typeof refreshDaytonaSignedPreview
+}): Promise<CloudInstanceResponse> {
+  if (input.worker.status === "failed") {
+    return { status: "failed", url: null }
+  }
+
+  const sandbox = await getDaytonaSandboxRecord(input.worker.id)
+  if (!sandbox) {
+    return { status: "provisioning", url: null }
+  }
+
+  if (sandbox.signed_preview_url_expires_at.getTime() > Date.now()) {
+    return { status: "ready", url: sandbox.signed_preview_url }
+  }
+
+  try {
+    const refreshed = await input.refreshSignedPreview(input.worker.id)
+    if (!refreshed) {
+      return { status: "failed", url: null }
+    }
+    return { status: "ready", url: refreshed.signed_preview_url }
+  } catch {
+    return { status: "failed", url: null }
+  }
+}
+
+export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
+  app: Hono<T>,
+  options: CloudRouteOptions = {},
+) {
+  const orgMemberRouteMiddleware = options.memberRoute ?? orgMemberRoute()
+  const continueProvisioning = options.continueProvisioning ?? continueCloudProvisioning
+  const refreshSignedPreview = options.refreshSignedPreview ?? refreshDaytonaSignedPreview
+
+  app.get(
+    "/v1/cloud/instance",
+    describeRoute({
+      tags: ["Cloud"],
+      summary: "Get the active organization's Cloud instance",
+      description: "Starts the active organization's OpenWork Cloud browser instance when needed and returns its browser URL once ready.",
+      responses: {
+        200: jsonResponse("Cloud instance status returned successfully.", cloudInstanceResponseSchema),
+        401: jsonResponse("The caller must be signed in to open Cloud.", unauthorizedSchema),
+        404: jsonResponse("Cloud is not available for this organization.", notFoundSchema),
+      },
+    }),
+    orgMemberRouteMiddleware,
+    async (c) => {
+      const payload = c.get("organizationContext")
+      if (!organizationCloudEnabled(payload.organization.metadata, { orgMode: options.orgMode ?? env.orgMode })) {
+        return c.json(cloudNotFound(), 404)
+      }
+
+      if (!hasDaytonaProvisioner(options)) {
+        return c.json(cloudNotFound(), 404)
+      }
+
+      const user = c.get("user")
+      if (!user?.id) {
+        return c.json({ error: "unauthorized" }, 401)
+      }
+
+      const worker = await ensureCloudWorker({
+        orgId: payload.organization.id,
+        createdByUserId: user.id,
+        continueProvisioning,
+      })
+      const instance = await resolveCloudInstance({ worker, refreshSignedPreview })
+
+      return c.json(instance)
+    },
+  )
+}

--- a/ee/apps/den-api/src/routes/org/core.ts
+++ b/ee/apps/den-api/src/routes/org/core.ts
@@ -6,6 +6,7 @@ import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { auth } from "../../auth.js"
 import { validateBrandIconUrl } from "../../brand-icon-validation.js"
+import { organizationCloudEnabled } from "../../capability-sources/cloud-rollout.js"
 import { memberFacingMcpConnectionsEnabled } from "../../capability-sources/external-mcp-rollout.js"
 import { organizationInstallLinksEnabled } from "../../capability-sources/install-links-rollout.js"
 import { db } from "../../db.js"
@@ -14,7 +15,6 @@ import { env } from "../../env.js"
 import { findEnterpriseAuthRequirementForEmail } from "../../enterprise-auth-requirement.js"
 import { authenticatedRoute, jsonValidator, orgMemberRoute, orgRoleRoute, publicRoute, queryValidator, resolveMemberTeamsMiddleware } from "../../middleware/index.js"
 import { denTypeIdSchema, enterprisePlanRequiredSchema, forbiddenSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
-import { normalizeOrganizationCapabilities } from "../../organization-capabilities.js"
 import { validateInvitationAcceptVerification } from "../../organization-join-verification.js"
 import { normalizeOrganizationMetadata } from "../../organization-limits.js"
 import {
@@ -24,6 +24,7 @@ import {
   getSingletonSsoStatus,
   normalizeAllowedEmailDomains,
   OrganizationEmailDomainRestrictionError,
+  serializeMemberFacingOrganizationMetadata,
   setSessionActiveOrganization,
   updateOrganizationSettings,
 } from "../../orgs.js"
@@ -507,7 +508,7 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
     async (c) => {
       const payload = c.get("organizationContext")
       const owner = payload.members.find((member: typeof payload.members[number]) => member.isOwner) ?? null
-      const capabilities = normalizeOrganizationCapabilities(payload.organization.metadata)
+      const cloudEnabled = organizationCloudEnabled(payload.organization.metadata, { orgMode: env.orgMode })
       const [ssoRows, scimRows] = await Promise.all([
         db
           .select({ id: SsoConnectionTable.id })
@@ -525,6 +526,7 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         ...payload,
         organization: {
           ...payload.organization,
+          metadata: serializeMemberFacingOrganizationMetadata(payload.organization.metadata),
           owner: owner
             ? {
               memberId: owner.id,
@@ -539,7 +541,6 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
         plan: parseOrganizationPlan(payload.organization.metadata),
         entitlements: getOrganizationEntitlements(payload.organization.metadata),
         capabilities: {
-          ...capabilities,
           // Expose the effective value, not the raw stored flag: Connect is
           // member-facing default-on unless an explicit org kill switch says no.
           mcpConnections: memberFacingMcpConnectionsEnabled(payload.organization.metadata, {
@@ -548,6 +549,7 @@ export function registerOrgCoreRoutes<T extends { Variables: OrgRouteVariables }
           installLinks: organizationInstallLinksEnabled(payload.organization.metadata, {
             gatingEnabled: env.installLinksGatingEnabled,
           }),
+          ...(cloudEnabled ? { cloud: true } : {}),
         },
         authMethods: {
           sso: Boolean(ssoRows[0]),

--- a/ee/apps/den-api/src/server.ts
+++ b/ee/apps/den-api/src/server.ts
@@ -4,11 +4,13 @@ import { env } from "./env.js"
 import { appLogger } from "./observability/logger.js"
 import { shutdownObservability } from "./observability/runtime.js"
 import { startScimMaintenanceLoop } from "./scim-maintenance.js"
+import { startCloudIdleStopLoop } from "./workers/cloud-lifecycle.js"
 import { startWorkerProvisioningReconcileLoop } from "./workers/reconciler.js"
 import { startTelegramUpdateDispatcher } from "./capability-sources/telegram-dispatcher.js"
 import { externalMcpClientRuntimeName } from "./capability-sources/external-mcp-client-runtime.js"
 
 const stopScimMaintenanceLoop = startScimMaintenanceLoop()
+const stopCloudIdleStopLoop = startCloudIdleStopLoop()
 const stopWorkerProvisioningReconcileLoop = startWorkerProvisioningReconcileLoop()
 const stopTelegramUpdateDispatcher = startTelegramUpdateDispatcher()
 
@@ -66,6 +68,7 @@ async function closeServer() {
 async function stopBackgroundLoops() {
   const results = await Promise.allSettled([
     stopScimMaintenanceLoop(),
+    stopCloudIdleStopLoop(),
     stopWorkerProvisioningReconcileLoop(),
     stopTelegramUpdateDispatcher(),
   ])

--- a/ee/apps/den-api/src/workers/cloud-constants.ts
+++ b/ee/apps/den-api/src/workers/cloud-constants.ts
@@ -1,0 +1,2 @@
+export const CLOUD_INSTANCE_BACKEND = "cloud-instance"
+export const CLOUD_INSTANCE_NAME = "Cloud"

--- a/ee/apps/den-api/src/workers/cloud-lifecycle.ts
+++ b/ee/apps/den-api/src/workers/cloud-lifecycle.ts
@@ -1,0 +1,244 @@
+import { and, asc, eq, isNull, lt, or } from "@openwork-ee/den-db/drizzle"
+import { WorkerTable, WorkerTokenTable } from "@openwork-ee/den-db/schema"
+import { db } from "../db.js"
+import { env } from "../env.js"
+import { appLogger } from "../observability/logger.js"
+import { captureException } from "../observability/runtime.js"
+import { CLOUD_INSTANCE_BACKEND } from "./cloud-constants.js"
+import { stopWorkerOnDaytona, wakeWorkerOnDaytona, type StopWorkerOnDaytonaResult } from "./daytona.js"
+
+type WorkerId = typeof WorkerTable.$inferSelect.id
+type WorkerStatus = typeof WorkerTable.$inferSelect.status
+type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "name" | "status" | "last_active_at" | "updated_at">
+type WorkerToken = typeof WorkerTokenTable.$inferSelect
+type WakeWorkerOnDaytona = typeof wakeWorkerOnDaytona
+type StopWorkerOnDaytona = typeof stopWorkerOnDaytona
+
+type CloudLifecycleStore = {
+  getWorker: (workerId: WorkerId) => Promise<CloudWorker | null>
+  getActiveTokens: (workerId: WorkerId) => Promise<WorkerToken[]>
+  listIdleWorkers: (input: { idleBefore: Date; limit: number }) => Promise<CloudWorker[]>
+  updateWorkerStatus: (input: { workerId: WorkerId; status: WorkerStatus; onlyWhenStatus?: WorkerStatus }) => Promise<void>
+}
+
+type WakeCloudWorkerOptions = {
+  store?: CloudLifecycleStore
+  wakeWorker?: WakeWorkerOnDaytona
+}
+
+type StopIdleCloudWorkersOptions = {
+  store?: CloudLifecycleStore
+  stopWorker?: StopWorkerOnDaytona
+  provisionerMode?: typeof env.provisionerMode
+  idleMs?: number
+  idleBefore?: Date
+  batchSize?: number
+}
+
+type StartCloudIdleStopLoopOptions = {
+  stopIdleWorkers?: () => Promise<unknown>
+}
+
+const logger = appLogger.child({ component: "cloud_lifecycle" })
+const wakeInFlight = new Map<WorkerId, Promise<void>>()
+
+let cloudIdleStopRunning = false
+let cloudIdleStopPromise: Promise<void> | null = null
+
+function tokenByScope(tokens: WorkerToken[], scope: typeof WorkerTokenTable.$inferSelect.scope) {
+  return tokens.find((entry) => entry.scope === scope)?.token ?? null
+}
+
+const databaseCloudLifecycleStore: CloudLifecycleStore = {
+  async getWorker(workerId) {
+    const rows = await db
+      .select()
+      .from(WorkerTable)
+      .where(and(
+        eq(WorkerTable.id, workerId),
+        eq(WorkerTable.destination, "cloud"),
+        eq(WorkerTable.sandbox_backend, CLOUD_INSTANCE_BACKEND),
+      ))
+      .limit(1)
+
+    return rows[0] ?? null
+  },
+  async getActiveTokens(workerId) {
+    return db
+      .select()
+      .from(WorkerTokenTable)
+      .where(and(eq(WorkerTokenTable.worker_id, workerId), isNull(WorkerTokenTable.revoked_at)))
+  },
+  async listIdleWorkers(input) {
+    return db
+      .select()
+      .from(WorkerTable)
+      .where(and(
+        eq(WorkerTable.destination, "cloud"),
+        eq(WorkerTable.sandbox_backend, CLOUD_INSTANCE_BACKEND),
+        eq(WorkerTable.status, "healthy"),
+        or(
+          lt(WorkerTable.last_active_at, input.idleBefore),
+          and(isNull(WorkerTable.last_active_at), lt(WorkerTable.updated_at, input.idleBefore)),
+        ),
+      ))
+      .orderBy(asc(WorkerTable.updated_at))
+      .limit(input.limit)
+  },
+  async updateWorkerStatus(input) {
+    await db
+      .update(WorkerTable)
+      .set({ status: input.status })
+      .where(input.onlyWhenStatus
+        ? and(eq(WorkerTable.id, input.workerId), eq(WorkerTable.status, input.onlyWhenStatus))
+        : eq(WorkerTable.id, input.workerId))
+  },
+}
+
+export function cloudWorkerIdleReferenceTime(worker: Pick<CloudWorker, "last_active_at" | "updated_at">) {
+  return worker.last_active_at ?? worker.updated_at
+}
+
+export function isCloudWorkerIdleForStop(worker: Pick<CloudWorker, "last_active_at" | "updated_at">, idleBefore: Date) {
+  return cloudWorkerIdleReferenceTime(worker).getTime() < idleBefore.getTime()
+}
+
+async function markWorkerFailed(store: CloudLifecycleStore, workerId: WorkerId) {
+  await store.updateWorkerStatus({ workerId, status: "failed", onlyWhenStatus: "provisioning" })
+}
+
+async function safelyMarkWorkerFailed(store: CloudLifecycleStore, workerId: WorkerId) {
+  try {
+    await markWorkerFailed(store, workerId)
+  } catch (error) {
+    logger.error("worker wake status update failed", { worker_id: workerId, error })
+  }
+}
+
+async function runWakeCloudWorker(workerId: WorkerId, options: WakeCloudWorkerOptions) {
+  const store = options.store ?? databaseCloudLifecycleStore
+  const wakeWorker = options.wakeWorker ?? wakeWorkerOnDaytona
+
+  try {
+    const worker = await store.getWorker(workerId)
+
+    if (!worker) {
+      logger.error("worker wake failed", { worker_id: workerId, reason: "worker_not_found" })
+      return
+    }
+
+    await store.updateWorkerStatus({ workerId, status: "provisioning", onlyWhenStatus: "stopped" })
+
+    const tokens = await store.getActiveTokens(workerId)
+    const hostToken = tokenByScope(tokens, "host")
+    const clientToken = tokenByScope(tokens, "client")
+    const activityToken = tokenByScope(tokens, "activity")
+
+    if (!hostToken || !clientToken || !activityToken) {
+      await safelyMarkWorkerFailed(store, workerId)
+      logger.error("worker wake failed", { worker_id: workerId, reason: "missing_worker_tokens" })
+      return
+    }
+
+    const woken = await wakeWorker({
+      workerId,
+      name: worker.name,
+      hostToken,
+      clientToken,
+      activityToken,
+    })
+
+    await store.updateWorkerStatus({ workerId, status: woken.status, onlyWhenStatus: "provisioning" })
+  } catch (error) {
+    await safelyMarkWorkerFailed(store, workerId)
+    logger.error("worker wake failed", { worker_id: workerId, error })
+  }
+}
+
+export async function wakeCloudWorker(workerId: WorkerId, options: WakeCloudWorkerOptions = {}) {
+  const existing = wakeInFlight.get(workerId)
+  if (existing) {
+    return existing
+  }
+
+  const promise = runWakeCloudWorker(workerId, options)
+    .finally(() => {
+      if (wakeInFlight.get(workerId) === promise) {
+        wakeInFlight.delete(workerId)
+      }
+    })
+  wakeInFlight.set(workerId, promise)
+
+  return promise
+}
+
+function stopResultAllowsStoppedStatus(result: StopWorkerOnDaytonaResult) {
+  return result.status === "stopped" || result.status === "no_sandbox"
+}
+
+export async function stopIdleCloudWorkers(options: StopIdleCloudWorkersOptions = {}) {
+  if ((options.provisionerMode ?? env.provisionerMode) !== "daytona") {
+    return { checked: 0, stopped: 0 }
+  }
+
+  const store = options.store ?? databaseCloudLifecycleStore
+  const stopWorker = options.stopWorker ?? stopWorkerOnDaytona
+  const idleBefore = options.idleBefore ?? new Date(Date.now() - (options.idleMs ?? env.cloudIdleStopMs))
+  const workers = await store.listIdleWorkers({
+    idleBefore,
+    limit: options.batchSize ?? env.cloudIdleStopBatchSize,
+  })
+  let stopped = 0
+
+  for (const worker of workers) {
+    try {
+      const result = await stopWorker(worker.id)
+      if (stopResultAllowsStoppedStatus(result)) {
+        await store.updateWorkerStatus({ workerId: worker.id, status: "stopped", onlyWhenStatus: "healthy" })
+        stopped += 1
+      }
+    } catch (error) {
+      logger.error("cloud idle stop failed", { worker_id: worker.id, error })
+      captureException(error, { component: "cloud_lifecycle", worker_id: worker.id })
+    }
+  }
+
+  return { checked: workers.length, stopped }
+}
+
+export function startCloudIdleStopLoop(
+  intervalMs = env.cloudIdleLoopIntervalMs,
+  options: StartCloudIdleStopLoopOptions = {},
+) {
+  if (!Number.isFinite(intervalMs) || intervalMs <= 0) {
+    return () => undefined
+  }
+
+  const stopIdleWorkers = options.stopIdleWorkers ?? stopIdleCloudWorkers
+  const run = () => {
+    if (cloudIdleStopRunning) {
+      return
+    }
+
+    cloudIdleStopRunning = true
+    cloudIdleStopPromise = stopIdleWorkers()
+      .then(() => undefined)
+      .catch((error) => {
+        logger.error("cloud idle stop loop failed", { error })
+        captureException(error, { component: "cloud_lifecycle" })
+      })
+      .finally(() => {
+        cloudIdleStopRunning = false
+        cloudIdleStopPromise = null
+      })
+    void cloudIdleStopPromise
+  }
+
+  const timer = setInterval(run, intervalMs)
+  timer.unref()
+  run()
+  return async () => {
+    clearInterval(timer)
+    await cloudIdleStopPromise
+  }
+}

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -23,6 +23,10 @@ type ProvisionedInstance = {
   region?: string
 }
 
+export type StopWorkerOnDaytonaResult =
+  | { status: "no_sandbox" }
+  | { status: "stopped" }
+
 type DaytonaSandboxListPage = {
   items: Array<{ id?: unknown }>
   nextCursor?: string | null
@@ -592,6 +596,73 @@ export async function provisionWorkerOnDaytona(
       await sandbox.delete(env.daytona.deleteTimeoutSeconds).catch(() => {})
     }
     throw error
+  }
+}
+
+// This preserves customer data: deprovisionWorkerOnDaytona erases workers/<id>/,
+// while stopWorkerOnDaytona must not delete the sandbox, cleanup data, or touch volumes.
+export async function stopWorkerOnDaytona(workerId: WorkerId): Promise<StopWorkerOnDaytonaResult> {
+  assertDaytonaConfig()
+
+  const record = await getDaytonaSandboxRecord(workerId)
+  if (!record) {
+    return { status: "no_sandbox" }
+  }
+
+  const daytona = createDaytonaClient()
+  const sandbox = await daytona.get(record.sandbox_id)
+  if (sandbox.state === "stopped") {
+    return { status: "stopped" }
+  }
+
+  await sandbox.stop(env.daytona.stopTimeoutSeconds ?? env.daytona.deleteTimeoutSeconds)
+
+  return { status: "stopped" }
+}
+
+export async function wakeWorkerOnDaytona(
+  input: ProvisionInput,
+): Promise<ProvisionedInstance> {
+  assertDaytonaConfig()
+
+  const record = await getDaytonaSandboxRecord(input.workerId)
+  if (!record) {
+    throw new Error(`Daytona sandbox record missing for worker ${input.workerId}`)
+  }
+
+  const daytona = createDaytonaClient()
+  const sandbox = await daytona.get(record.sandbox_id)
+  await sandbox.start(env.daytona.createTimeoutSeconds)
+
+  const sessionId = `openwork-wake-${workerHint(input.workerId)}-${Date.now()}`
+  await sandbox.process.createSession(sessionId)
+  const command = await sandbox.process.executeSessionCommand(
+    sessionId,
+    {
+      command: buildOpenWorkStartCommand(input),
+      runAsync: true,
+    },
+    0,
+  )
+
+  const expiresInSeconds = normalizedSignedPreviewExpirySeconds()
+  const preview = await sandbox.getSignedPreviewUrl(env.daytona.openworkPort, expiresInSeconds)
+  await waitForHealth(preview.url, env.daytona.healthcheckTimeoutMs, sandbox, sessionId, command.cmdId)
+  await upsertDaytonaSandbox({
+    workerId: input.workerId,
+    sandboxId: sandbox.id,
+    workspaceVolumeId: record.workspace_volume_id,
+    dataVolumeId: record.data_volume_id,
+    signedPreviewUrl: preview.url,
+    signedPreviewUrlExpiresAt: signedPreviewRefreshAt(expiresInSeconds),
+    region: sandbox.target ?? null,
+  })
+
+  return {
+    provider: "daytona",
+    url: workerProxyUrl(input.workerId),
+    status: "healthy",
+    region: sandbox.target,
   }
 }
 

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -196,18 +196,24 @@ function sharedVolumeMounts(workerId: WorkerId, volumeId: string) {
 
 function buildOpenWorkStartCommand(input: ProvisionInput) {
   const verifyRuntimeStep = [
-    "if ! command -v openwork >/dev/null 2>&1; then echo 'openwork binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
+    "if ! command -v openwork-server >/dev/null 2>&1; then echo 'openwork-server binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
     "if ! command -v opencode >/dev/null 2>&1; then echo 'opencode binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
   ].join("; ")
   const openworkServe = [
     "OPENWORK_DATA_DIR=",
     shellQuote(env.daytona.runtimeDataPath),
-    " OPENWORK_SIDECAR_DIR=",
-    shellQuote(env.daytona.sidecarDir),
+    " OPENWORK_SERVER_CONFIG=",
+    shellQuote(`${env.daytona.runtimeDataPath}/server.json`),
     " OPENWORK_TOKEN=",
     shellQuote(input.clientToken),
     " OPENWORK_HOST_TOKEN=",
     shellQuote(input.hostToken),
+    " OPENWORK_MANAGE_OPENCODE=",
+    shellQuote("1"),
+    " OPENWORK_OPENCODE_BIN=",
+    shellQuote("/usr/local/bin/opencode"),
+    " OPENWORK_WEB_ROOT=",
+    shellQuote("/opt/openwork/web"),
     " DEN_RUNTIME_PROVIDER=",
     shellQuote("daytona"),
     " DEN_WORKER_ID=",
@@ -218,18 +224,12 @@ function buildOpenWorkStartCommand(input: ProvisionInput) {
     shellQuote(workerActivityHeartbeatUrl(input.workerId)),
     " DEN_ACTIVITY_HEARTBEAT_TOKEN=",
     shellQuote(input.activityToken),
-    " openwork serve",
+    " openwork-server",
     ` --workspace ${shellQuote(env.daytona.runtimeWorkspacePath)}`,
-    ` --remote-access`,
-    ` --openwork-port ${env.daytona.openworkPort}`,
-    ` --opencode-host 127.0.0.1`,
-    ` --opencode-port ${env.daytona.opencodePort}`,
-    ` --connect-host 127.0.0.1`,
+    ` --host 0.0.0.0`,
+    ` --port ${shellQuote(String(env.daytona.openworkPort))}`,
     ` --cors '*'`,
     ` --approval manual`,
-    ` --allow-external`,
-    ` --opencode-source external`,
-    ` --opencode-bin $(command -v opencode)`,
     ` --verbose`,
   ].join("")
 
@@ -246,7 +246,7 @@ while [ "$attempt" -lt 3 ]; do
     exit 0
   fi
   status=$?
-  echo "openwork serve failed (attempt $attempt, exit $status); retrying in 3s"
+  echo "openwork-server failed (attempt $attempt, exit $status); rebuild and republish the Daytona snapshot if this persists; retrying in 3s"
   sleep 3
 done
 exit 1

--- a/ee/apps/den-api/test/admin-organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/admin-organization-capabilities.test.ts
@@ -15,6 +15,7 @@ function seedRequiredEnv() {
   process.env.BETTER_AUTH_SECRET = "y".repeat(32)
   process.env.BETTER_AUTH_URL = "http://127.0.0.1:8790"
   process.env.CORS_ORIGINS = "http://127.0.0.1:8790"
+  process.env.DEN_ORG_MODE = "multi_org"
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -89,7 +90,7 @@ async function replaceOrganizationMetadata(metadata: Record<string, unknown>) {
     .where(drizzle.eq(schema.OrganizationTable.id, organizationId))
 }
 
-async function putCapabilities(capabilities: { installLinks?: boolean | null; mcpConnections?: boolean | null }) {
+async function putCapabilities(capabilities: { installLinks?: boolean | null; mcpConnections?: boolean | null; cloud?: boolean | null }) {
   return routeApp().request(`http://den.local/v1/admin/organizations/${organizationId}/capabilities`, {
     method: "PUT",
     headers: { "content-type": "application/json" },
@@ -186,12 +187,12 @@ test("admin capability routes show effective defaults while preserving raw overr
 
   const getAbsent = await routeApp().request(`http://den.local/v1/admin/organizations/${organizationId}/capabilities`)
   expect(getAbsent.status).toBe(200)
-  await expect(getAbsent.json()).resolves.toMatchObject({ capabilities: { installLinks: true, mcpConnections: true } })
+  await expect(getAbsent.json()).resolves.toMatchObject({ capabilities: { installLinks: true, mcpConnections: true, cloud: false } })
 
   const listAbsent = await routeApp().request(`http://den.local/v1/admin/organizations?search=${organizationId}`)
   expect(listAbsent.status).toBe(200)
   await expect(listAbsent.json()).resolves.toMatchObject({
-    organizations: [{ id: organizationId, capabilities: { installLinks: true, mcpConnections: true } }],
+    organizations: [{ id: organizationId, capabilities: { installLinks: true, mcpConnections: true, cloud: false } }],
   })
 
   const enableInstallLinks = await putCapabilities({ installLinks: true })
@@ -209,6 +210,16 @@ test("admin capability routes show effective defaults while preserving raw overr
   expect(clearConnect.status).toBe(200)
   await expect(clearConnect.json()).resolves.toMatchObject({ capabilities: { installLinks: true, mcpConnections: true } })
   expect("mcpConnections" in readCapabilityMetadata(await readOrganizationMetadata())).toBe(false)
+
+  const enableCloud = await putCapabilities({ cloud: true })
+  expect(enableCloud.status).toBe(200)
+  await expect(enableCloud.json()).resolves.toMatchObject({ capabilities: { cloud: true } })
+  expect(readCapabilityMetadata(await readOrganizationMetadata())).toMatchObject({ installLinks: true, cloud: true })
+
+  const disableCloud = await putCapabilities({ cloud: false })
+  expect(disableCloud.status).toBe(200)
+  await expect(disableCloud.json()).resolves.toMatchObject({ capabilities: { cloud: false } })
+  expect(readCapabilityMetadata(await readOrganizationMetadata())).toMatchObject({ installLinks: true, cloud: false })
 
   await replaceOrganizationMetadata({ connectEnabled: true, capabilities: { installLinks: true } })
   const disableFlatEnabledConnect = await putCapabilities({ mcpConnections: false })

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -4,6 +4,8 @@ import { Hono, type MiddlewareHandler } from "hono"
 import type { OrganizationContext } from "../src/orgs.js"
 import type { OrgRouteVariables } from "../src/routes/org/shared.js"
 
+type CloudWorkerStatus = "provisioning" | "healthy" | "failed" | "stopped"
+
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
   process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
@@ -50,8 +52,48 @@ function organizationContext(metadata: string | null): OrganizationContext {
 
 function contextMiddleware(context: OrganizationContext): MiddlewareHandler<{ Variables: OrgRouteVariables }> {
   return async (c, next) => {
+    const now = new Date("2026-07-25T00:00:00Z")
     c.set("organizationContext", context)
+    c.set("user", {
+      id: context.currentMember.userId,
+      name: "Cloud Instance Tester",
+      email: "cloud-instance@example.com",
+      emailVerified: true,
+      image: null,
+      createdAt: now,
+      updatedAt: now,
+    })
+    c.set("session", null)
+    c.set("apiKey", null)
     await next()
+  }
+}
+
+function fakeSandbox() {
+  return {
+    signed_preview_url: "https://preview.example.test",
+    signed_preview_url_expires_at: new Date(Date.now() + 60_000),
+  }
+}
+
+function fakeWorker(status: CloudWorkerStatus) {
+  return {
+    id: createDenTypeId("worker"),
+    status,
+  }
+}
+
+function deferred() {
+  let resolve: (() => void) | undefined
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+
+  return {
+    promise,
+    resolve() {
+      resolve?.()
+    },
   }
 }
 
@@ -98,5 +140,93 @@ describe("Cloud instance route gate", () => {
 
     expect(response.status).toBe(404)
     await expect(response.json()).resolves.toEqual({ error: "cloud_not_found" })
+  })
+})
+
+describe("Cloud instance route lifecycle states", () => {
+  test("returns waking and starts one wake for concurrent stopped-worker requests", async () => {
+    const worker = fakeWorker("stopped")
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    const wakeHold = deferred()
+    let wakeExecutions = 0
+    let wakePromise: Promise<void> | null = null
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      getSandboxRecord: async () => fakeSandbox(),
+      wakeCloudWorker: async () => {
+        if (!wakePromise) {
+          wakeExecutions += 1
+          wakePromise = wakeHold.promise
+        }
+        return wakePromise
+      },
+    })
+
+    const [first, second] = await Promise.all([
+      app.request("http://den.local/v1/cloud/instance"),
+      app.request("http://den.local/v1/cloud/instance"),
+    ])
+
+    expect(first.status).toBe(200)
+    expect(second.status).toBe(200)
+    await expect(first.json()).resolves.toEqual({ status: "waking", url: null })
+    await expect(second.json()).resolves.toEqual({ status: "waking", url: null })
+    expect(wakeExecutions).toBe(1)
+
+    wakeHold.resolve()
+    await wakePromise
+  })
+
+  test("maps provisioning with a sandbox row to waking", async () => {
+    const worker = fakeWorker("provisioning")
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let wakeExecutions = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      getSandboxRecord: async () => fakeSandbox(),
+      wakeCloudWorker: async () => {
+        wakeExecutions += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
+    expect(wakeExecutions).toBe(0)
+  })
+
+  test("keeps first provisioning without a sandbox row as provisioning", async () => {
+    const worker = fakeWorker("provisioning")
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let wakeExecutions = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      getSandboxRecord: async () => null,
+      wakeCloudWorker: async () => {
+        wakeExecutions += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: "provisioning", url: null })
+    expect(wakeExecutions).toBe(0)
   })
 })

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -1,0 +1,102 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, describe, expect, test } from "bun:test"
+import { Hono, type MiddlewareHandler } from "hono"
+import type { OrganizationContext } from "../src/orgs.js"
+import type { OrgRouteVariables } from "../src/routes/org/shared.js"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.PROVISIONER_MODE = "stub"
+}
+
+let routes: typeof import("../src/routes/cloud/index.js")
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  routes = await import("../src/routes/cloud/index.js")
+})
+
+function organizationContext(metadata: string | null): OrganizationContext {
+  const now = new Date("2026-07-25T00:00:00Z")
+  return {
+    organization: {
+      id: createDenTypeId("organization"),
+      name: "Cloud Instance Test",
+      slug: `cloud-instance-${crypto.randomUUID()}`,
+      logo: null,
+      allowedEmailDomains: null,
+      metadata,
+      createdAt: now,
+      updatedAt: now,
+    },
+    currentMember: {
+      id: createDenTypeId("member"),
+      userId: createDenTypeId("user"),
+      role: "member",
+      createdAt: now,
+      joinedAt: now,
+      isOwner: false,
+    },
+    members: [],
+    invitations: [],
+    roles: [],
+    teams: [],
+  }
+}
+
+function contextMiddleware(context: OrganizationContext): MiddlewareHandler<{ Variables: OrgRouteVariables }> {
+  return async (c, next) => {
+    c.set("organizationContext", context)
+    await next()
+  }
+}
+
+describe("Cloud instance route gate", () => {
+  test("returns 404 when the Cloud capability is off", async () => {
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(null)),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: "cloud_not_found" })
+  })
+
+  test("returns 404 in single-org mode even with a literal Cloud opt-in", async () => {
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "single_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: "cloud_not_found" })
+  })
+
+  test("returns 404 when Daytona provisioning is not configured", async () => {
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "stub",
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: "cloud_not_found" })
+  })
+})

--- a/ee/apps/den-api/test/cloud-lifecycle.test.ts
+++ b/ee/apps/den-api/test/cloud-lifecycle.test.ts
@@ -1,0 +1,239 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, describe, expect, test } from "bun:test"
+
+type CloudLifecycleModule = typeof import("../src/workers/cloud-lifecycle.js")
+type WakeCloudWorkerOptions = NonNullable<Parameters<CloudLifecycleModule["wakeCloudWorker"]>[1]>
+type Store = NonNullable<WakeCloudWorkerOptions["store"]>
+type TestWorker = NonNullable<Awaited<ReturnType<Store["getWorker"]>>>
+type TestWorkerToken = Awaited<ReturnType<Store["getActiveTokens"]>>[number]
+type StatusUpdate = Parameters<Store["updateWorkerStatus"]>[0]
+type ListIdleInput = Parameters<Store["listIdleWorkers"]>[0]
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.PROVISIONER_MODE = "stub"
+}
+
+let lifecycle: CloudLifecycleModule
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  lifecycle = await import("../src/workers/cloud-lifecycle.js")
+})
+
+function makeWorker(input: {
+  status: TestWorker["status"]
+  lastActiveAt?: Date | null
+  updatedAt?: Date
+}): TestWorker {
+  const now = new Date("2026-07-25T12:00:00.000Z")
+  return {
+    id: createDenTypeId("worker"),
+    name: "Cloud",
+    status: input.status,
+    last_active_at: input.lastActiveAt ?? null,
+    updated_at: input.updatedAt ?? now,
+  }
+}
+
+function makeToken(workerId: TestWorker["id"], scope: TestWorkerToken["scope"]): TestWorkerToken {
+  return {
+    id: createDenTypeId("workerToken"),
+    worker_id: workerId,
+    scope,
+    token: `${scope}-token`,
+    created_at: new Date("2026-07-25T12:00:00.000Z"),
+    revoked_at: null,
+  }
+}
+
+function makeStore(input: { workers: TestWorker[]; tokens?: TestWorkerToken[] }) {
+  const updates: StatusUpdate[] = []
+  const tokens = input.tokens ?? []
+  const store: Store = {
+    async getWorker(workerId) {
+      return input.workers.find((worker) => worker.id === workerId) ?? null
+    },
+    async getActiveTokens(workerId) {
+      return tokens.filter((token) => token.worker_id === workerId && !token.revoked_at)
+    },
+    async listIdleWorkers(listInput: ListIdleInput) {
+      return input.workers
+        .filter((worker) => worker.status === "healthy" && lifecycle.isCloudWorkerIdleForStop(worker, listInput.idleBefore))
+        .slice(0, listInput.limit)
+    },
+    async updateWorkerStatus(update) {
+      const worker = input.workers.find((entry) => entry.id === update.workerId)
+      if (!worker) {
+        return
+      }
+      if (update.onlyWhenStatus && worker.status !== update.onlyWhenStatus) {
+        return
+      }
+
+      worker.status = update.status
+      updates.push(update)
+    },
+  }
+
+  return { store, updates }
+}
+
+function deferred() {
+  let resolve: (() => void) | undefined
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+
+  return {
+    promise,
+    resolve() {
+      resolve?.()
+    },
+  }
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+describe("cloud lifecycle idle stop", () => {
+  test("uses last_active_at when present and falls back to updated_at when last_active_at is null", () => {
+    const idleBefore = new Date("2026-07-25T12:00:00.000Z")
+    const idleActivity = makeWorker({
+      status: "healthy",
+      lastActiveAt: new Date("2026-07-25T11:00:00.000Z"),
+      updatedAt: new Date("2026-07-25T11:55:00.000Z"),
+    })
+    const activeActivity = makeWorker({
+      status: "healthy",
+      lastActiveAt: new Date("2026-07-25T12:05:00.000Z"),
+      updatedAt: new Date("2026-07-25T11:00:00.000Z"),
+    })
+    const idleByUpdatedAt = makeWorker({
+      status: "healthy",
+      lastActiveAt: null,
+      updatedAt: new Date("2026-07-25T11:00:00.000Z"),
+    })
+    const activeByUpdatedAt = makeWorker({
+      status: "healthy",
+      lastActiveAt: null,
+      updatedAt: new Date("2026-07-25T12:05:00.000Z"),
+    })
+
+    expect(lifecycle.isCloudWorkerIdleForStop(idleActivity, idleBefore)).toBe(true)
+    expect(lifecycle.isCloudWorkerIdleForStop(activeActivity, idleBefore)).toBe(false)
+    expect(lifecycle.isCloudWorkerIdleForStop(idleByUpdatedAt, idleBefore)).toBe(true)
+    expect(lifecycle.isCloudWorkerIdleForStop(activeByUpdatedAt, idleBefore)).toBe(false)
+  })
+
+  test("does not start the loop when the interval is disabled", () => {
+    let runs = 0
+    const stop = lifecycle.startCloudIdleStopLoop(0, {
+      stopIdleWorkers: async () => {
+        runs += 1
+      },
+    })
+
+    expect(stop()).toBeUndefined()
+    expect(runs).toBe(0)
+  })
+
+  test("marks stopped only when the Daytona stop succeeds", async () => {
+    const idleBefore = new Date("2026-07-25T12:00:00.000Z")
+    const stoppedWorker = makeWorker({
+      status: "healthy",
+      lastActiveAt: new Date("2026-07-25T11:00:00.000Z"),
+    })
+    const retryWorker = makeWorker({
+      status: "healthy",
+      lastActiveAt: new Date("2026-07-25T11:10:00.000Z"),
+    })
+    const { store } = makeStore({ workers: [stoppedWorker, retryWorker] })
+    const result = await lifecycle.stopIdleCloudWorkers({
+      store,
+      provisionerMode: "daytona",
+      idleBefore,
+      batchSize: 10,
+      stopWorker: async (workerId) => {
+        if (workerId === retryWorker.id) {
+          throw new Error("stop failed")
+        }
+        return { status: "stopped" }
+      },
+    })
+
+    expect(result).toEqual({ checked: 2, stopped: 1 })
+    expect(stoppedWorker.status).toBe("stopped")
+    expect(retryWorker.status).toBe("healthy")
+  })
+})
+
+describe("cloud lifecycle wake", () => {
+  test("marks the worker failed when a wake token is missing", async () => {
+    const worker = makeWorker({ status: "stopped" })
+    const { store, updates } = makeStore({
+      workers: [worker],
+      tokens: [
+        makeToken(worker.id, "host"),
+        makeToken(worker.id, "client"),
+      ],
+    })
+    let wakeExecutions = 0
+
+    await lifecycle.wakeCloudWorker(worker.id, {
+      store,
+      wakeWorker: async () => {
+        wakeExecutions += 1
+        return { provider: "daytona", url: "https://cloud.example", status: "healthy" }
+      },
+    })
+
+    expect(wakeExecutions).toBe(0)
+    expect(worker.status).toBe("failed")
+    expect(updates.map((update) => update.status)).toEqual(["provisioning", "failed"])
+  })
+
+  test("runs one Daytona wake for concurrent calls to the same worker", async () => {
+    const worker = makeWorker({ status: "stopped" })
+    const { store } = makeStore({
+      workers: [worker],
+      tokens: [
+        makeToken(worker.id, "host"),
+        makeToken(worker.id, "client"),
+        makeToken(worker.id, "activity"),
+      ],
+    })
+    const hold = deferred()
+    let wakeExecutions = 0
+
+    const first = lifecycle.wakeCloudWorker(worker.id, {
+      store,
+      wakeWorker: async () => {
+        wakeExecutions += 1
+        await hold.promise
+        return { provider: "daytona", url: "https://cloud.example", status: "healthy" }
+      },
+    })
+    const second = lifecycle.wakeCloudWorker(worker.id, {
+      store,
+      wakeWorker: async () => {
+        wakeExecutions += 1
+        return { provider: "daytona", url: "https://cloud.example", status: "healthy" }
+      },
+    })
+
+    await flushMicrotasks()
+    expect(wakeExecutions).toBe(1)
+
+    hold.resolve()
+    await Promise.all([first, second])
+    expect(worker.status).toBe("healthy")
+  })
+})

--- a/ee/apps/den-api/test/cloud-rollout.test.ts
+++ b/ee/apps/den-api/test/cloud-rollout.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from "bun:test"
+import { organizationCloudEnabled } from "../src/capability-sources/cloud-rollout.js"
+
+describe("organizationCloudEnabled", () => {
+  test("is off when metadata is absent, empty, or unparseable", () => {
+    for (const metadata of [null, undefined, "", "{}", "not json", "[]", {}, JSON.stringify({ limits: { members: 5 } })]) {
+      expect(organizationCloudEnabled(metadata, { orgMode: "multi_org" })).toBe(false)
+    }
+  })
+
+  test("stays off for single-org deployments even with a literal opt-in", () => {
+    for (const metadata of [
+      { capabilities: { cloud: true } },
+      JSON.stringify({ capabilities: { cloud: true } }),
+    ]) {
+      expect(organizationCloudEnabled(metadata, { orgMode: "single_org" })).toBe(false)
+    }
+  })
+
+  test("is on only for multi-org deployments with a literal opt-in", () => {
+    expect(organizationCloudEnabled({ capabilities: { cloud: true } }, { orgMode: "multi_org" })).toBe(true)
+    expect(organizationCloudEnabled(JSON.stringify({ capabilities: { cloud: true } }), { orgMode: "multi_org" })).toBe(true)
+    expect(organizationCloudEnabled({ capabilities: { cloud: false } }, { orgMode: "multi_org" })).toBe(false)
+    expect(organizationCloudEnabled({ capabilities: { cloud: "true" } }, { orgMode: "multi_org" })).toBe(false)
+  })
+})

--- a/ee/apps/den-api/test/organization-capabilities.test.ts
+++ b/ee/apps/den-api/test/organization-capabilities.test.ts
@@ -5,7 +5,7 @@ import {
   readOrganizationCapabilityOverrides,
 } from "../src/organization-capabilities.js"
 
-const defaultCapabilities = { installLinks: false, mcpConnections: false }
+const defaultCapabilities = { installLinks: false, mcpConnections: false, cloud: false }
 
 describe("normalizeOrganizationCapabilities", () => {
   test("defaults every capability to false when metadata is empty", () => {
@@ -16,18 +16,19 @@ describe("normalizeOrganizationCapabilities", () => {
   })
 
   test("reads an explicit opt-in from record metadata", () => {
-    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: true } })).toEqual({ installLinks: true, mcpConnections: false })
-    expect(normalizeOrganizationCapabilities({ capabilities: { mcpConnections: true } })).toEqual({ installLinks: false, mcpConnections: true })
+    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: true } })).toEqual({ installLinks: true, mcpConnections: false, cloud: false })
+    expect(normalizeOrganizationCapabilities({ capabilities: { mcpConnections: true } })).toEqual({ installLinks: false, mcpConnections: true, cloud: false })
+    expect(normalizeOrganizationCapabilities({ capabilities: { cloud: true } })).toEqual({ installLinks: false, mcpConnections: false, cloud: true })
     expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: false, mcpConnections: false } })).toEqual(defaultCapabilities)
   })
 
   test("reads an explicit opt-in from JSON string metadata", () => {
-    expect(normalizeOrganizationCapabilities(JSON.stringify({ capabilities: { installLinks: true, mcpConnections: true } }))).toEqual({ installLinks: true, mcpConnections: true })
+    expect(normalizeOrganizationCapabilities(JSON.stringify({ capabilities: { installLinks: true, mcpConnections: true, cloud: true } }))).toEqual({ installLinks: true, mcpConnections: true, cloud: true })
   })
 
   test("treats anything but literal true as off", () => {
-    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: "true", mcpConnections: "true" } })).toEqual(defaultCapabilities)
-    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: 1, mcpConnections: 1 } })).toEqual(defaultCapabilities)
+    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: "true", mcpConnections: "true", cloud: "true" } })).toEqual(defaultCapabilities)
+    expect(normalizeOrganizationCapabilities({ capabilities: { installLinks: 1, mcpConnections: 1, cloud: 1 } })).toEqual(defaultCapabilities)
     expect(normalizeOrganizationCapabilities({ capabilities: null })).toEqual(defaultCapabilities)
     expect(normalizeOrganizationCapabilities({ capabilities: [] })).toEqual(defaultCapabilities)
     expect(normalizeOrganizationCapabilities("not json")).toEqual(defaultCapabilities)
@@ -37,9 +38,9 @@ describe("normalizeOrganizationCapabilities", () => {
     const metadata = {
       limits: { members: 5, workers: 1 },
       plan: { tier: "enterprise", source: "manual" },
-      capabilities: { installLinks: true, mcpConnections: true },
+      capabilities: { installLinks: true, mcpConnections: true, cloud: true },
     }
-    expect(normalizeOrganizationCapabilities(metadata)).toEqual({ installLinks: true, mcpConnections: true })
+    expect(normalizeOrganizationCapabilities(metadata)).toEqual({ installLinks: true, mcpConnections: true, cloud: true })
   })
 })
 
@@ -51,19 +52,19 @@ describe("readOrganizationCapabilityOverrides", () => {
   })
 
   test("preserves explicit boolean false overrides", () => {
-    expect(readOrganizationCapabilityOverrides({ capabilities: { installLinks: false, mcpConnections: false } })).toEqual({ installLinks: false, mcpConnections: false })
+    expect(readOrganizationCapabilityOverrides({ capabilities: { installLinks: false, mcpConnections: false, cloud: false } })).toEqual({ installLinks: false, mcpConnections: false, cloud: false })
   })
 
   test("ignores unrelated and non-boolean metadata", () => {
     expect(readOrganizationCapabilityOverrides({
       limits: { members: 10 },
       plan: { tier: "enterprise" },
-      capabilities: { installLinks: "true", mcpConnections: 1, otherCapability: true },
+      capabilities: { installLinks: "true", mcpConnections: 1, cloud: "true", otherCapability: true },
     })).toEqual({})
   })
 
   test("reads explicit overrides from JSON metadata", () => {
-    expect(readOrganizationCapabilityOverrides(JSON.stringify({ capabilities: { installLinks: true, mcpConnections: false } }))).toEqual({ installLinks: true, mcpConnections: false })
+    expect(readOrganizationCapabilityOverrides(JSON.stringify({ capabilities: { installLinks: true, mcpConnections: false, cloud: true } }))).toEqual({ installLinks: true, mcpConnections: false, cloud: true })
   })
 })
 
@@ -71,11 +72,15 @@ describe("organizationHasCapability", () => {
   test("is false by default and true only with an explicit opt-in", () => {
     expect(organizationHasCapability(null, "installLinks")).toBe(false)
     expect(organizationHasCapability(null, "mcpConnections")).toBe(false)
+    expect(organizationHasCapability(null, "cloud")).toBe(false)
     expect(organizationHasCapability({ capabilities: {} }, "installLinks")).toBe(false)
     expect(organizationHasCapability({ capabilities: {} }, "mcpConnections")).toBe(false)
+    expect(organizationHasCapability({ capabilities: {} }, "cloud")).toBe(false)
     expect(organizationHasCapability({ capabilities: { installLinks: true } }, "installLinks")).toBe(true)
     expect(organizationHasCapability({ capabilities: { mcpConnections: true } }, "mcpConnections")).toBe(true)
+    expect(organizationHasCapability({ capabilities: { cloud: true } }, "cloud")).toBe(true)
     expect(organizationHasCapability(JSON.stringify({ capabilities: { installLinks: true } }), "installLinks")).toBe(true)
     expect(organizationHasCapability(JSON.stringify({ capabilities: { mcpConnections: true } }), "mcpConnections")).toBe(true)
+    expect(organizationHasCapability(JSON.stringify({ capabilities: { cloud: true } }), "cloud")).toBe(true)
   })
 })

--- a/ee/apps/den-web/app/(den)/_lib/den-org.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-org.ts
@@ -240,6 +240,7 @@ export type DenOrgEntitlements = {
 export type DenOrgCapabilities = {
   installLinks: boolean;
   mcpConnections: boolean;
+  cloud: boolean;
 };
 
 export type DenOrganizationMetadata = {
@@ -528,6 +529,10 @@ export function getCustomLlmProvidersRoute(orgSlug?: string | null): string {
 
 export function getInferenceRoute(orgSlug?: string | null): string {
   return `${getOrgDashboardRoute(orgSlug)}/inference`;
+}
+
+export function getCloudRoute(orgSlug?: string | null): string {
+  return `${getOrgDashboardRoute(orgSlug)}/cloud`;
 }
 
 export function getLlmProvidersRoute(orgSlug?: string | null): string {
@@ -894,12 +899,13 @@ function parseOrgAuthMethods(value: unknown): DenOrgAuthMethods {
 
 function parseOrgCapabilities(value: unknown): DenOrgCapabilities {
   if (!isRecord(value)) {
-    return { installLinks: false, mcpConnections: false };
+    return { installLinks: false, mcpConnections: false, cloud: false };
   }
 
   return {
     installLinks: value.installLinks === true,
     mcpConnections: value.mcpConnections === true,
+    cloud: value.cloud === true,
   };
 }
 

--- a/ee/apps/den-web/app/(den)/dashboard/_components/cloud-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/cloud-screen.tsx
@@ -7,7 +7,7 @@ import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-templ
 import { getErrorMessage, requestJson } from "../../_lib/den-flow";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 
-type CloudInstanceStatus = "provisioning" | "ready" | "failed";
+type CloudInstanceStatus = "provisioning" | "waking" | "ready" | "failed";
 
 type CloudInstance = {
   status: CloudInstanceStatus;
@@ -26,7 +26,7 @@ function parseCloudInstance(payload: unknown): CloudInstance | null {
   }
 
   const status = payload.status;
-  if (status !== "provisioning" && status !== "ready" && status !== "failed") {
+  if (status !== "provisioning" && status !== "waking" && status !== "ready" && status !== "failed") {
     return null;
   }
 
@@ -92,7 +92,7 @@ export function CloudScreen() {
         }
 
         setInstance(parsed);
-        if (parsed.status === "provisioning") {
+        if (parsed.status === "provisioning" || parsed.status === "waking") {
           pollTimer = setTimeout(() => void loadInstance(), CLOUD_POLL_MS);
         }
       } catch (loadError) {
@@ -143,7 +143,8 @@ export function CloudScreen() {
 
   const readyUrl = instance?.status === "ready" ? instance.url : null;
   const failed = instance?.status === "failed";
-  const starting = !readyUrl && !failed && !error && !unavailable && (loading || instance?.status === "provisioning");
+  const waking = instance?.status === "waking";
+  const starting = !readyUrl && !failed && !error && !unavailable && (loading || instance?.status === "provisioning" || waking);
 
   return (
     <DashboardPageTemplate
@@ -165,9 +166,11 @@ export function CloudScreen() {
 
             {starting ? (
               <>
-                <p className="mt-2 text-[15px] font-medium text-gray-950">Starting Cloud</p>
+                <p className="mt-2 text-[15px] font-medium text-gray-950">{waking ? "Waking your workspace…" : "Starting Cloud"}</p>
                 <p className="mt-2 text-[13px] leading-6 text-gray-500">
-                  We’re bringing up a full OpenWork instance for this organization. This usually takes a few seconds.
+                  {waking
+                    ? "We’re turning your existing Cloud workspace back on. This usually takes a few seconds."
+                    : "We’re bringing up a full OpenWork instance for this organization. This usually takes a few seconds."}
                 </p>
                 <p className="mt-2 text-[13px] leading-6 text-gray-500">
                   Keep this page open. Cloud opens in a new tab as soon as it is ready.

--- a/ee/apps/den-web/app/(den)/dashboard/_components/cloud-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/cloud-screen.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Cloud } from "lucide-react";
+import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+
+export function CloudScreen() {
+  return (
+    <DashboardPageTemplate
+      icon={Cloud}
+      badgeLabel="Alpha"
+      title="Cloud"
+      description="OpenWork Cloud is enabled for this workspace. The full browser instance experience lands next."
+      colors={["#EFF6FF", "#0F172A", "#2563EB", "#BAE6FD"]}
+    >
+      <section className="rounded-3xl border border-gray-100 bg-white p-6 shadow-[0_18px_45px_-35px_rgba(15,23,42,0.35)]">
+        <p className="text-[15px] font-medium text-gray-950">Cloud is ready for this organization.</p>
+        <p className="mt-2 text-[13px] leading-6 text-gray-500">
+          The launch flow for a full OpenWork instance will appear here in the next alpha milestone.
+        </p>
+      </section>
+    </DashboardPageTemplate>
+  );
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/cloud-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/cloud-screen.tsx
@@ -1,22 +1,233 @@
 "use client";
 
-import { Cloud } from "lucide-react";
+import { useEffect, useState } from "react";
+import { AlertTriangle, Cloud, ExternalLink, Loader2, RefreshCw } from "lucide-react";
+import { DenButton } from "../../_components/ui/button";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { getErrorMessage, requestJson } from "../../_lib/den-flow";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+
+type CloudInstanceStatus = "provisioning" | "ready" | "failed";
+
+type CloudInstance = {
+  status: CloudInstanceStatus;
+  url: string | null;
+};
+
+const CLOUD_POLL_MS = 5000;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parseCloudInstance(payload: unknown): CloudInstance | null {
+  if (!isRecord(payload)) {
+    return null;
+  }
+
+  const status = payload.status;
+  if (status !== "provisioning" && status !== "ready" && status !== "failed") {
+    return null;
+  }
+
+  const url = typeof payload.url === "string" ? payload.url : null;
+  if (status === "ready" && !url) {
+    return null;
+  }
+
+  return { status, url };
+}
+
+function openCloudTab(url: string) {
+  const opened = window.open(url, "_blank");
+  if (opened) {
+    opened.opener = null;
+  }
+  return Boolean(opened);
+}
 
 export function CloudScreen() {
+  const { orgContext } = useOrgDashboard();
+  const organizationId = orgContext?.organization.id ?? null;
+  const [instance, setInstance] = useState<CloudInstance | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [unavailable, setUnavailable] = useState(false);
+  const [openedUrl, setOpenedUrl] = useState<string | null>(null);
+  const [autoOpenBlocked, setAutoOpenBlocked] = useState(false);
+  const [refreshKey, setRefreshKey] = useState(0);
+
+  useEffect(() => {
+    if (!organizationId) {
+      return;
+    }
+
+    let cancelled = false;
+    let pollTimer: ReturnType<typeof setTimeout> | null = null;
+
+    async function loadInstance() {
+      setLoading(true);
+      setError(null);
+      setUnavailable(false);
+
+      try {
+        const { response, payload } = await requestJson("/v1/cloud/instance", { method: "GET" }, 20000);
+        if (cancelled) {
+          return;
+        }
+
+        if (response.status === 404) {
+          setInstance(null);
+          setUnavailable(true);
+          return;
+        }
+
+        if (!response.ok) {
+          throw new Error(getErrorMessage(payload, `Cloud could not start (${response.status}).`));
+        }
+
+        const parsed = parseCloudInstance(payload);
+        if (!parsed) {
+          throw new Error("Cloud response was incomplete.");
+        }
+
+        setInstance(parsed);
+        if (parsed.status === "provisioning") {
+          pollTimer = setTimeout(() => void loadInstance(), CLOUD_POLL_MS);
+        }
+      } catch (loadError) {
+        if (!cancelled) {
+          setInstance(null);
+          setError(loadError instanceof Error ? loadError.message : "Cloud could not start.");
+        }
+      } finally {
+        if (!cancelled) {
+          setLoading(false);
+        }
+      }
+    }
+
+    void loadInstance();
+
+    return () => {
+      cancelled = true;
+      if (pollTimer) {
+        clearTimeout(pollTimer);
+      }
+    };
+  }, [organizationId, refreshKey]);
+
+  useEffect(() => {
+    if (instance?.status !== "ready" || !instance.url || openedUrl === instance.url) {
+      return;
+    }
+
+    setOpenedUrl(instance.url);
+    setAutoOpenBlocked(!openCloudTab(instance.url));
+  }, [instance, openedUrl]);
+
+  function retry() {
+    setOpenedUrl(null);
+    setAutoOpenBlocked(false);
+    setRefreshKey((value) => value + 1);
+  }
+
+  function openReadyCloud() {
+    if (instance?.status !== "ready" || !instance.url) {
+      return;
+    }
+
+    setOpenedUrl(instance.url);
+    setAutoOpenBlocked(!openCloudTab(instance.url));
+  }
+
+  const readyUrl = instance?.status === "ready" ? instance.url : null;
+  const failed = instance?.status === "failed";
+  const starting = !readyUrl && !failed && !error && !unavailable && (loading || instance?.status === "provisioning");
+
   return (
     <DashboardPageTemplate
       icon={Cloud}
       badgeLabel="Alpha"
       title="Cloud"
-      description="OpenWork Cloud is enabled for this workspace. The full browser instance experience lands next."
+      description="Open a full OpenWork instance in your browser. Nothing to install."
       colors={["#EFF6FF", "#0F172A", "#2563EB", "#BAE6FD"]}
     >
       <section className="rounded-3xl border border-gray-100 bg-white p-6 shadow-[0_18px_45px_-35px_rgba(15,23,42,0.35)]">
-        <p className="text-[15px] font-medium text-gray-950">Cloud is ready for this organization.</p>
-        <p className="mt-2 text-[13px] leading-6 text-gray-500">
-          The launch flow for a full OpenWork instance will appear here in the next alpha milestone.
-        </p>
+        <div className="flex items-start gap-4">
+          <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-blue-50 text-blue-700">
+            {starting ? <Loader2 className="size-4 animate-spin" aria-hidden="true" /> : null}
+            {readyUrl ? <ExternalLink className="size-5" aria-hidden="true" /> : null}
+            {failed || error || unavailable ? <AlertTriangle className="size-5" aria-hidden="true" /> : null}
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-blue-700">Cloud Alpha</p>
+
+            {starting ? (
+              <>
+                <p className="mt-2 text-[15px] font-medium text-gray-950">Starting Cloud</p>
+                <p className="mt-2 text-[13px] leading-6 text-gray-500">
+                  We’re bringing up a full OpenWork instance for this organization. This usually takes a few seconds.
+                </p>
+                <p className="mt-2 text-[13px] leading-6 text-gray-500">
+                  Keep this page open. Cloud opens in a new tab as soon as it is ready.
+                </p>
+              </>
+            ) : null}
+
+            {readyUrl ? (
+              <>
+                <p className="mt-2 text-[15px] font-medium text-gray-950">Cloud is ready</p>
+                <p className="mt-2 text-[13px] leading-6 text-gray-500">
+                  {autoOpenBlocked
+                    ? "Your browser blocked the new tab. Click Open Cloud to continue."
+                    : "Cloud opened in a new tab. If you do not see it, open it again here."}
+                </p>
+                <p className="mt-2 text-[13px] leading-6 text-gray-500">
+                  Alpha note: the Cloud URL is itself the credential. Do not share it or paste it anywhere public.
+                </p>
+                <div className="mt-5 flex flex-wrap gap-3">
+                  <DenButton icon={ExternalLink} onClick={openReadyCloud}>Open Cloud</DenButton>
+                  <DenButton variant="secondary" icon={RefreshCw} onClick={retry}>Refresh status</DenButton>
+                </div>
+              </>
+            ) : null}
+
+            {failed ? (
+              <>
+                <p className="mt-2 text-[15px] font-medium text-gray-950">Cloud could not start</p>
+                <p className="mt-2 text-[13px] leading-6 text-gray-500">
+                  Ask an OpenWork admin to check the Cloud alpha configuration, then try again.
+                </p>
+                <div className="mt-5">
+                  <DenButton variant="secondary" icon={RefreshCw} onClick={retry}>Try again</DenButton>
+                </div>
+              </>
+            ) : null}
+
+            {unavailable ? (
+              <>
+                <p className="mt-2 text-[15px] font-medium text-gray-950">Cloud is not available</p>
+                <p className="mt-2 text-[13px] leading-6 text-gray-500">
+                  Ask an OpenWork admin to enable Cloud for this organization and confirm hosted Cloud is configured.
+                </p>
+                <div className="mt-5">
+                  <DenButton variant="secondary" icon={RefreshCw} onClick={retry}>Check again</DenButton>
+                </div>
+              </>
+            ) : null}
+
+            {error ? (
+              <>
+                <p className="mt-2 text-[15px] font-medium text-gray-950">Cloud needs attention</p>
+                <p className="mt-2 text-[13px] leading-6 text-gray-500">{error}</p>
+                <div className="mt-5">
+                  <DenButton variant="secondary" icon={RefreshCw} onClick={retry}>Try again</DenButton>
+                </div>
+              </>
+            ) : null}
+          </div>
+        </div>
       </section>
     </DashboardPageTemplate>
   );

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -7,6 +7,7 @@ import {
   BarChart3,
   ChevronDown,
   ChevronRight,
+  Cloud,
   FileText,
   Home,
   LogOut,
@@ -29,6 +30,7 @@ import {
   getApiKeysRoute,
   getBrandAppearanceRoute,
   getBillingRoute,
+  getCloudRoute,
   getCustomLlmProvidersRoute,
   getDiagnosticsRoute,
   getDesktopPoliciesRoute,
@@ -262,6 +264,9 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
   if (pathname.startsWith(getInferenceRoute(orgSlug))) {
     return "OpenWork Models";
   }
+  if (pathname.startsWith(getCloudRoute(orgSlug))) {
+    return "Cloud";
+  }
   if (pathname.startsWith(getPluginsRoute(orgSlug))) {
     return "Plugins";
   }
@@ -347,6 +352,10 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
     orgSlug: activeOrg?.slug,
   });
   const mcpConnectionsEnabled = orgContext?.capabilities.mcpConnections === true;
+  // Cloud is a hosted alpha. The org payload only reports `cloud` after the
+  // server rollout helper has verified the multi-org deployment gate, so the
+  // sidebar stays hidden by default until both config and org context load.
+  const showCloud = runtimeConfigLoaded && orgContext?.capabilities.cloud === true;
 
   // Top-level rows: Dashboard, optional Your Connections, Extensions, Models,
   // Members, Analytics, Settings. Everything tool-shaped groups under
@@ -424,6 +433,14 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
           label: "Your Connections",
           icon: Plug,
           badge: "Beta",
+        }]
+      : []),
+    ...(showCloud
+      ? [{
+          href: activeOrg ? getCloudRoute(activeOrg.slug) : "#",
+          label: "Cloud",
+          icon: Cloud,
+          badge: "Alpha",
         }]
       : []),
     ...(extensionsGroup ? [extensionsGroup] : []),

--- a/ee/apps/den-web/app/(den)/dashboard/cloud/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/cloud/page.tsx
@@ -1,0 +1,36 @@
+"use client";
+
+import { notFound } from "next/navigation";
+import { Loader2 } from "lucide-react";
+
+import { CloudScreen } from "../_components/cloud-screen";
+import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+
+export default function CloudPage() {
+  const { orgContext, orgBusy } = useOrgDashboard();
+  const enabled = orgContext?.capabilities.cloud === true;
+
+  if (orgBusy || !orgContext) {
+    return (
+      <div className="flex min-h-[420px] items-center justify-center px-6" data-testid="cloud-access-state" data-access-state="checking">
+        <div className="w-full max-w-sm rounded-2xl border border-gray-200 bg-white p-6 shadow-[0_12px_40px_-28px_rgba(15,23,42,0.35)]">
+          <div className="flex items-start gap-4">
+            <div className="flex size-10 shrink-0 items-center justify-center rounded-xl bg-gray-100 text-gray-600">
+              <Loader2 className="size-4 animate-spin" aria-hidden="true" />
+            </div>
+            <div>
+              <p className="text-[15px] font-medium text-gray-950">Checking workspace access</p>
+              <p className="mt-1 text-[13px] leading-5 text-gray-500">We’re confirming which settings are available to your account.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  if (!enabled) {
+    notFound();
+  }
+
+  return <CloudScreen />;
+}

--- a/ee/apps/den-web/components/den-admin-panel.tsx
+++ b/ee/apps/den-web/components/den-admin-panel.tsx
@@ -101,6 +101,7 @@ type AdminUser = {
 type AdminOrganizationCapabilities = {
   installLinks: boolean;
   mcpConnections: boolean;
+  cloud: boolean;
 };
 
 type AdminOrganization = {
@@ -384,7 +385,8 @@ function parseAdminPayload(payload: unknown): AdminPayload | null {
           billableSeatCount: toNumberValue(value.billableSeatCount),
           capabilities: {
             installLinks: capabilities.installLinks === true,
-            mcpConnections: capabilities.mcpConnections === true
+            mcpConnections: capabilities.mcpConnections === true,
+            cloud: capabilities.cloud === true
           }
         };
       })
@@ -722,7 +724,7 @@ function buildFixtureOrganization(index: number): AdminOrganization {
     freeSeatCount: target ? 25 : DEFAULT_FREE_SEAT_COUNT,
     seatsFreeAdditional: target ? 20 : 0,
     billableSeatCount: target ? 103 : 0,
-    capabilities: { installLinks: target, mcpConnections: target }
+    capabilities: { installLinks: target, mcpConnections: target, cloud: false }
   };
 }
 
@@ -2328,6 +2330,19 @@ export function DenAdminPanel() {
                         />
                         OpenWork Connect (alpha)
                       </label>
+                      <label className="inline-flex items-center gap-2 text-sm text-slate-700">
+                        <input
+                          type="checkbox"
+                          data-testid="admin-capability-cloud"
+                          checked={org.capabilities.cloud}
+                          disabled={savingCapabilityOrgId === org.id}
+                          onChange={(event) => {
+                            void saveOrganizationCapability(org, "cloud", event.target.checked);
+                          }}
+                          className="h-4 w-4 rounded border-slate-300"
+                        />
+                        Cloud (alpha)
+                      </label>
                     </div>
                     {capabilityError?.orgId === org.id ? (
                       <p data-testid="admin-capability-error" className="mt-2 rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-xs leading-5 text-red-700">
@@ -2336,6 +2351,7 @@ export function DenAdminPanel() {
                     ) : null}
                     <p className="mt-1 text-xs text-slate-400">On by default. Turn off to stop workspace admins from minting desktop install links for this organization.</p>
                     <p className="mt-1 text-xs text-slate-400">On by default. Turn off to hide member-facing org connections, marketplace capabilities on the agent rail, and the desktop Connect tab.</p>
+                    <p className="mt-1 text-xs text-slate-400">Off by default. Turn on to show Cloud alpha access in this organization.</p>
                   </div>
 
                   <div className="mt-4 grid gap-3 border-t border-slate-200 pt-4 lg:grid-cols-[12rem_10rem_auto] lg:items-end">

--- a/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
+++ b/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
@@ -1,4 +1,8 @@
-FROM node:22-bookworm-slim AS openwork-builder
+# The builder runs on the BUILD host's native platform and cross-compiles for
+# the target: bun compiles openwork-server via --target and the web build is
+# arch-independent. This avoids emulating the whole toolchain under QEMU
+# (node's libuv crashes under qemu-x86_64: uv__io_poll EEXIST assert).
+FROM --platform=$BUILDPLATFORM node:22-bookworm-slim AS openwork-builder
 
 WORKDIR /src
 
@@ -58,7 +62,16 @@ RUN set -eux; \
   install -m 0755 "$binary" /usr/local/bin/opencode; \
   rm -rf "$tmpdir"
 
-RUN test "$(openwork-server --version)" = "$OPENWORK_SERVER_VERSION" \
-  && opencode --version
+# Runtime asserts run the target-arch binaries. Keep them on in CI (native
+# amd64 runners); disable only for local cross-builds, where bun binaries die
+# with "Illegal instruction" under qemu-x86_64 even though they run fine on
+# real hardware.
+ARG RUNTIME_ASSERTS=1
+RUN if [ "$RUNTIME_ASSERTS" = "1" ]; then \
+    test "$(openwork-server --version)" = "$OPENWORK_SERVER_VERSION" \
+    && opencode --version; \
+  else \
+    echo "RUNTIME_ASSERTS disabled (cross-build); binaries must be verified on target hardware"; \
+  fi
 
 CMD ["sleep", "infinity"]

--- a/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
+++ b/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
@@ -10,12 +10,24 @@ RUN apt-get update \
 
 COPY . .
 
-RUN pnpm install --frozen-lockfile --filter openwork-orchestrator... \
-  && pnpm --filter openwork-orchestrator build:bin
+RUN pnpm install --frozen-lockfile --filter openwork-server... --filter @openwork/app...
+
+ARG TARGETARCH
+
+RUN set -eux; \
+  arch="${TARGETARCH:-$(dpkg --print-architecture)}"; \
+  case "$arch" in \
+    amd64) target="bun-linux-x64" ;; \
+    arm64) target="bun-linux-arm64" ;; \
+    *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
+  esac; \
+  pnpm --filter openwork-server exec bun ./script/build.ts --outdir dist/bin --target "$target"; \
+  install -m 0755 "apps/server/dist/bin/openwork-server-${target}" /tmp/openwork-server; \
+  pnpm --filter @openwork/app build:web
 
 FROM node:22-bookworm-slim
 
-ARG OPENWORK_ORCHESTRATOR_VERSION=0.11.151
+ARG OPENWORK_SERVER_VERSION=0.18.1
 ARG OPENCODE_VERSION
 ARG OPENCODE_DOWNLOAD_URL=
 
@@ -23,8 +35,8 @@ RUN apt-get update \
   && apt-get install -y --no-install-recommends ca-certificates curl tar unzip \
   && rm -rf /var/lib/apt/lists/*
 
-COPY --from=openwork-builder /src/apps/orchestrator/dist/bin/openwork /usr/local/bin/openwork
-COPY --from=openwork-builder /src/constants.json /usr/local/constants.json
+COPY --from=openwork-builder /tmp/openwork-server /usr/local/bin/openwork-server
+COPY --from=openwork-builder /src/apps/app/dist /opt/openwork/web
 
 RUN set -eux; \
   test -n "$OPENCODE_VERSION"; \
@@ -46,7 +58,7 @@ RUN set -eux; \
   install -m 0755 "$binary" /usr/local/bin/opencode; \
   rm -rf "$tmpdir"
 
-RUN test "$(openwork --version)" = "$OPENWORK_ORCHESTRATOR_VERSION" \
+RUN test "$(openwork-server --version)" = "$OPENWORK_SERVER_VERSION" \
   && opencode --version
 
 CMD ["sleep", "infinity"]

--- a/evals/flows/cloud-instance.flow.ts
+++ b/evals/flows/cloud-instance.flow.ts
@@ -1,0 +1,151 @@
+import { defineFlow } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+
+// Narration is loaded from the approved script (evals/voiceovers/cloud-instance.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("cloud-instance");
+if (!vo) throw new Error("Missing approved voice-over script for cloud-instance.");
+
+export default defineFlow({
+  id: "cloud-instance",
+  title: "TODO: one-line claim — user can do X and sees Y",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 1", {
+          voiceover: vo[0],
+          // "I'm signed in to OpenWork on the web. There's no Cloud anywhere — not in the"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 1 not implemented yet");
+          },
+          screenshot: { name: "frame-1", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 2", {
+          voiceover: vo[1],
+          // "A platform admin turns Cloud on for my organization alone. It stays off for "
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 2 not implemented yet");
+          },
+          screenshot: { name: "frame-2", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 3", {
+          voiceover: vo[2],
+          // "I reload, and Cloud is in my sidebar, marked Alpha. Nothing to install, noth"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 3 not implemented yet");
+          },
+          screenshot: { name: "frame-3", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 4", {
+          voiceover: vo[3],
+          // "I open Cloud. It brings an instance up for me on the spot, and in a few seco"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 4 not implemented yet");
+          },
+          screenshot: { name: "frame-4", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 5", {
+          voiceover: vo[4],
+          // "My organization's connections are already there. I ask what's on my calendar"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 5 not implemented yet");
+          },
+          screenshot: { name: "frame-5", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 6", {
+          voiceover: vo[5],
+          // "I ask it to save a summary to a file in my workspace, and the file appears."
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 6 not implemented yet");
+          },
+          screenshot: { name: "frame-6", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 7",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 7", {
+          voiceover: vo[6],
+          // "I close the tab and go do something else. The instance puts itself to sleep,"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 7 not implemented yet");
+          },
+          screenshot: { name: "frame-7", requireText: [] },
+        });
+      },
+    },
+    {
+      name: "Frame 8",
+      run: async (ctx) => {
+        await ctx.prove("TODO: claim for frame 8", {
+          voiceover: vo[7],
+          // "Later I open Cloud again. It wakes up, my summary file is still sitting in t"
+          action: async () => {
+            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+          },
+          assert: async () => {
+            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
+            ctx.assert(false, "frame 8 not implemented yet");
+          },
+          screenshot: { name: "frame-8", requireText: [] },
+        });
+      },
+    },
+  ],
+});

--- a/evals/flows/cloud-web-connect-e2e.flow.mjs
+++ b/evals/flows/cloud-web-connect-e2e.flow.mjs
@@ -1,0 +1,734 @@
+import { defineFlow } from "../runner/flow.ts";
+
+const FLOW_ID = "cloud-web-connect-e2e";
+const SIGN_IN_ORIGIN = "http://localhost:3005";
+const CONNECTION_NAME = "Acme Mock Tools";
+const ACTION_FILE = "eval-action.md";
+const ACTION_CONTENT = "cloud-web-connect-e2e proof";
+const LOOKUP_RECORD = "record-7";
+const LOOKUP_OK_TEXT = `acme lookup ok: ${LOOKUP_RECORD}`;
+
+const state = {
+  denToken: "",
+  org: null,
+  cloudInstance: null,
+  unauthenticatedCloudStatus: 0,
+  clientToken: "",
+  workspaceId: "",
+  approvalId: "",
+  connectionId: "",
+  executedToolName: "",
+  executeResultText: "",
+  mockWitnessEntries: [],
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function trimBase(value) {
+  return String(value ?? "").trim().replace(/\/+$/, "");
+}
+
+function required(ctx, name) {
+  return ctx.env[name].trim();
+}
+
+function denBase(ctx) {
+  return trimBase(required(ctx, "OPENWORK_EVAL_DEN_API_URL"));
+}
+
+function spaBase(ctx) {
+  return trimBase(required(ctx, "OPENWORK_EVAL_SPA_URL"));
+}
+
+function mockBase(ctx) {
+  return trimBase(required(ctx, "OPENWORK_EVAL_MOCK_URL"));
+}
+
+function instanceBase() {
+  return trimBase(state.cloudInstance?.url);
+}
+
+function instanceUrl(path) {
+  return `${instanceBase()}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function bearer(token) {
+  return { authorization: `Bearer ${token}` };
+}
+
+function hostHeaders(ctx) {
+  return {
+    "content-type": "application/json",
+    "x-openwork-host-token": required(ctx, "OPENWORK_EVAL_INSTANCE_HOST_TOKEN"),
+  };
+}
+
+function clientHeaders() {
+  return {
+    "content-type": "application/json",
+    authorization: `Bearer ${state.clientToken}`,
+  };
+}
+
+function safeJson(value) {
+  try {
+    return JSON.stringify(value).slice(0, 1_200);
+  } catch {
+    return String(value).slice(0, 1_200);
+  }
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : `. Actual: ${safeJson(actual)}`}`);
+}
+
+function recordOutput(ctx, name, value) {
+  ctx.output(name, typeof value === "string" ? value : JSON.stringify(value, null, 2));
+}
+
+async function fetchText(url, options = {}) {
+  const response = await fetch(url, options);
+  const text = await response.text();
+  return { response, text };
+}
+
+async function fetchJson(url, options = {}) {
+  const { response, text } = await fetchText(url, options);
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+async function denFetch(ctx, path, options = {}) {
+  return fetchJson(`${denBase(ctx)}${path}`, {
+    ...options,
+    headers: {
+      "content-type": "application/json",
+      origin: SIGN_IN_ORIGIN,
+      ...(options.headers ?? {}),
+    },
+  });
+}
+
+async function instanceFetchJson(path, options = {}) {
+  return fetchJson(instanceUrl(path), options);
+}
+
+async function navigateAbsolute(ctx, url, timeoutMs = 90_000) {
+  await ctx.eval(`location.href = ${JSON.stringify(url)}`);
+  await ctx.waitFor("document.readyState === 'complete' || document.body.innerText.length > 0", {
+    timeoutMs,
+    label: `loaded ${url}`,
+  });
+}
+
+async function clearDenBrowserSession(ctx) {
+  await ctx.eval(`(() => {
+    for (const key of Object.keys(localStorage)) {
+      if (key.startsWith("openwork.den.")) localStorage.removeItem(key);
+    }
+    localStorage.removeItem("openwork:web:auth-token");
+    return true;
+  })()`);
+}
+
+function denBrowserBase(ctx) {
+  const override = process.env.OPENWORK_EVAL_DEN_BROWSER_URL?.trim();
+  return override || denBase(ctx);
+}
+
+async function seedDenSession(ctx) {
+  const org = state.org;
+  witness(ctx, Boolean(state.denToken), "The Den session token is available before browser seeding");
+  witness(ctx, Boolean(org?.id), "The active organization is available before browser seeding", org);
+  await ctx.eval(`(() => {
+    localStorage.setItem("openwork.den.baseUrl", ${JSON.stringify(denBrowserBase(ctx))});
+    localStorage.setItem("openwork.den.authToken", ${JSON.stringify(state.denToken)});
+    localStorage.setItem("openwork.den.activeOrgId", ${JSON.stringify(org.id)});
+    localStorage.setItem("openwork.den.activeOrgSlug", ${JSON.stringify(org.slug ?? "")});
+    localStorage.setItem("openwork.den.activeOrgName", ${JSON.stringify(org.name ?? "")});
+    return true;
+  })()`);
+}
+
+async function signIn(ctx) {
+  const signInResult = await denFetch(ctx, "/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({
+      email: required(ctx, "OPENWORK_EVAL_DEN_EMAIL"),
+      password: required(ctx, "OPENWORK_EVAL_DEN_PASSWORD"),
+    }),
+  });
+  witness(ctx, signInResult.response.ok, "Admin email/password sign-in returns HTTP 200", {
+    status: signInResult.response.status,
+    body: signInResult.body,
+  });
+  const token = typeof signInResult.body?.token === "string" ? signInResult.body.token.trim() : "";
+  witness(ctx, token.length > 0, "Admin sign-in response includes a bearer token");
+  state.denToken = token;
+}
+
+async function resolveSignedInOrg(ctx) {
+  const orgsResult = await denFetch(ctx, "/v1/me/orgs", {
+    headers: bearer(state.denToken),
+  });
+  witness(ctx, orgsResult.response.ok, "Signed-in admin can read /v1/me/orgs", {
+    status: orgsResult.response.status,
+    body: orgsResult.body,
+  });
+  const orgs = Array.isArray(orgsResult.body?.orgs) ? orgsResult.body.orgs : [];
+  const org = orgs[0] ?? null;
+  witness(ctx, Boolean(org?.id), "The signed-in admin belongs to an organization", orgsResult.body);
+  witness(ctx, org.name === required(ctx, "OPENWORK_EVAL_ORG_NAME"), "The active organization display name matches the eval org", {
+    expected: required(ctx, "OPENWORK_EVAL_ORG_NAME"),
+    actual: org.name,
+  });
+  state.org = org;
+}
+
+async function waitForOnboarding(ctx) {
+  try {
+    await ctx.waitForRoute("/onboarding", { timeoutMs: 60_000 });
+  } catch {
+    await ctx.waitFor("location.pathname === '/onboarding' || location.hash.replace(/^#/, '').startsWith('/onboarding')", {
+      timeoutMs: 60_000,
+      label: "onboarding route",
+    });
+  }
+}
+
+async function pollCloudInstance(ctx) {
+  const deadline = Date.now() + 180_000;
+  let last = null;
+  while (Date.now() < deadline) {
+    const result = await denFetch(ctx, "/v1/cloud/instance", {
+      headers: bearer(state.denToken),
+    });
+    last = { status: result.response.status, body: result.body };
+    if (result.response.ok && result.body?.status === "ready" && typeof result.body.url === "string" && result.body.url.trim()) {
+      state.cloudInstance = { ...result.body, url: trimBase(result.body.url) };
+      return;
+    }
+    if ([401, 403, 404].includes(result.response.status)) {
+      witness(ctx, false, "Authenticated cloud instance lookup is allowed and available", last);
+    }
+    await sleep(5_000);
+  }
+  witness(ctx, false, "Cloud instance became ready within 3 minutes", last);
+}
+
+async function extractClientToken(ctx) {
+  const root = await fetchText(instanceUrl("/"));
+  witness(ctx, root.response.ok, "The Cloud instance root HTML is fetchable", { status: root.response.status });
+  const match = root.text.match(/window\.__OPENWORK_BOOTSTRAP__\s*=\s*(\{[^<]+?\})\s*<\/script>/);
+  witness(ctx, Boolean(match), "The instance HTML includes __OPENWORK_BOOTSTRAP__", root.text.slice(0, 500));
+  const bootstrap = JSON.parse(match[1]);
+  const token = typeof bootstrap?.token === "string" ? bootstrap.token.trim() : "";
+  witness(ctx, token.length > 0, "The bootstrap JSON includes a client token");
+  state.clientToken = token;
+}
+
+function pickWorkspace(payload) {
+  const items = Array.isArray(payload?.items)
+    ? payload.items
+    : Array.isArray(payload?.workspaces)
+      ? payload.workspaces
+      : Array.isArray(payload)
+        ? payload
+        : [];
+  return items.find((workspace) => workspace.id === payload?.activeId) ?? items[0] ?? null;
+}
+
+async function resolveWorkspace(ctx) {
+  const workspaces = await instanceFetchJson("/workspaces", { headers: clientHeaders() });
+  witness(ctx, workspaces.response.ok, "The instance client token can list workspaces", {
+    status: workspaces.response.status,
+    body: workspaces.body,
+  });
+  const workspace = pickWorkspace(workspaces.body);
+  witness(ctx, Boolean(workspace?.id), "The Cloud instance exposes a workspace id", workspaces.body);
+  state.workspaceId = workspace.id;
+}
+
+async function waitForFileWriteApproval(ctx) {
+  const deadline = Date.now() + 30_000;
+  let last = null;
+  while (Date.now() < deadline) {
+    const approvals = await instanceFetchJson("/approvals", { headers: hostHeaders(ctx) });
+    last = { status: approvals.response.status, body: approvals.body };
+    witness(ctx, approvals.response.ok, "The host token can list pending approvals", last);
+    const items = Array.isArray(approvals.body?.items) ? approvals.body.items : [];
+    const approval = items.find((item) =>
+      item.workspaceId === state.workspaceId
+      && item.action === "workspace.file.write"
+      && typeof item.summary === "string"
+      && item.summary.includes(ACTION_FILE)
+    ) ?? items.find((item) => typeof item.summary === "string" && item.summary.includes(ACTION_FILE));
+    if (approval?.id) return approval;
+    await sleep(500);
+  }
+  witness(ctx, false, "A pending approval appears for the eval file write", last);
+}
+
+async function approveFileWrite(ctx, approval) {
+  const approved = await instanceFetchJson(`/approvals/${encodeURIComponent(approval.id)}`, {
+    method: "POST",
+    headers: hostHeaders(ctx),
+    body: JSON.stringify({ reply: "allow" }),
+  });
+  witness(ctx, approved.response.ok && approved.body?.ok === true && approved.body?.allowed === true, "The host token approves the pending file write", {
+    status: approved.response.status,
+    body: approved.body,
+  });
+  state.approvalId = approval.id;
+}
+
+async function performApprovedFileWrite(ctx) {
+  await extractClientToken(ctx);
+  await resolveWorkspace(ctx);
+
+  const controller = new AbortController();
+  const writePromise = instanceFetchJson(`/workspace/${encodeURIComponent(state.workspaceId)}/files/content`, {
+    method: "POST",
+    headers: clientHeaders(),
+    signal: controller.signal,
+    body: JSON.stringify({
+      path: ACTION_FILE,
+      content: ACTION_CONTENT,
+      force: true,
+    }),
+  }).catch((error) => ({ error }));
+
+  await sleep(2_000);
+  const approval = await waitForFileWriteApproval(ctx).catch((error) => {
+    controller.abort();
+    throw error;
+  });
+  await approveFileWrite(ctx, approval);
+
+  const write = await writePromise;
+  witness(ctx, !write.error, "The file write request completes after approval", write.error?.message);
+  witness(ctx, write.response.ok && write.body?.ok === true, "The approved file write returns ok:true", {
+    status: write.response.status,
+    body: write.body,
+  });
+
+  const read = await instanceFetchJson(`/workspace/${encodeURIComponent(state.workspaceId)}/files/content?path=${encodeURIComponent(ACTION_FILE)}`, {
+    headers: clientHeaders(),
+  });
+  witness(ctx, read.response.ok && read.body?.content === ACTION_CONTENT, "The written file can be read back from the Cloud instance", {
+    status: read.response.status,
+    body: read.body,
+  });
+  recordOutput(ctx, "approved-file-write.json", {
+    workspaceId: state.workspaceId,
+    approvalId: state.approvalId,
+    path: ACTION_FILE,
+    content: read.body?.content,
+  });
+}
+
+async function listManageableConnections(ctx) {
+  const list = await denFetch(ctx, "/v1/mcp-connections?scope=manageable", {
+    headers: bearer(state.denToken),
+  });
+  witness(ctx, list.response.ok, "Admin can list manageable MCP connections", {
+    status: list.response.status,
+    body: list.body,
+  });
+  return Array.isArray(list.body?.connections) ? list.body.connections : [];
+}
+
+function matchingMockConnection(connection, mockUrl) {
+  return connection?.name === CONNECTION_NAME
+    && connection?.url === `${mockUrl}/mcp`
+    && connection?.authType === "none";
+}
+
+async function ensureMockMcpConnection(ctx) {
+  const mockUrl = mockBase(ctx);
+  const existing = (await listManageableConnections(ctx)).find((connection) => matchingMockConnection(connection, mockUrl));
+  if (existing?.id) {
+    state.connectionId = existing.id;
+    recordOutput(ctx, "mock-mcp-connection.json", existing);
+    return;
+  }
+
+  const created = await denFetch(ctx, "/v1/mcp-connections", {
+    method: "POST",
+    headers: bearer(state.denToken),
+    body: JSON.stringify({
+      name: CONNECTION_NAME,
+      url: `${mockUrl}/mcp`,
+      authType: "none",
+      access: { orgWide: true },
+    }),
+  });
+  if (created.response.ok && created.body?.id) {
+    state.connectionId = created.body.id;
+    recordOutput(ctx, "mock-mcp-connection.json", created.body);
+    return;
+  }
+
+  const reusable = (await listManageableConnections(ctx)).find((connection) => matchingMockConnection(connection, mockUrl));
+  witness(ctx, Boolean(reusable?.id), "A prior Acme Mock Tools connection can be reused after create conflict/validation", {
+    createStatus: created.response.status,
+    createBody: created.body,
+    reusable,
+  });
+  state.connectionId = reusable.id;
+  recordOutput(ctx, "mock-mcp-connection.json", reusable);
+}
+
+async function mockRequests(ctx) {
+  const result = await fetchJson(`${mockBase(ctx)}/requests`);
+  witness(ctx, result.response.ok, "The mock MCP witness log is readable", {
+    status: result.response.status,
+    body: result.body,
+  });
+  if (Array.isArray(result.body)) return result.body;
+  if (Array.isArray(result.body?.requests)) return result.body.requests;
+  if (Array.isArray(result.body?.entries)) return result.body.entries;
+  return [];
+}
+
+async function mintMcpToken(ctx) {
+  const result = await denFetch(ctx, "/v1/mcp/token", {
+    method: "POST",
+    headers: bearer(state.denToken),
+    body: JSON.stringify({ scopes: ["mcp:read", "mcp:write"] }),
+  });
+  witness(ctx, result.response.ok, "Admin can mint an agent MCP token", {
+    status: result.response.status,
+    body: result.body,
+  });
+  const token = typeof result.body?.token === "string" ? result.body.token.trim() : "";
+  witness(ctx, token.length > 0, "The minted MCP token is present");
+  return token;
+}
+
+async function mcpAgentCall(ctx, mcpToken, method, params = {}) {
+  const response = await fetch(`${denBase(ctx)}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${mcpToken}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
+  });
+  const raw = await response.text();
+  witness(ctx, response.ok, `MCP ${method} returned HTTP 200`, raw.slice(0, 500));
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  witness(ctx, Boolean(dataLine), `MCP ${method} returned a data frame`, raw.slice(0, 500));
+  const payload = JSON.parse(dataLine.slice(5));
+  witness(ctx, !payload.error, `MCP ${method} returned no JSON-RPC error`, payload.error ?? null);
+  return payload.result;
+}
+
+function toolResultText(result) {
+  const content = Array.isArray(result?.content) ? result.content : [];
+  return content.map((entry) => typeof entry?.text === "string" ? entry.text : "").join("\n");
+}
+
+function parseToolJson(result) {
+  const text = toolResultText(result).trim();
+  try {
+    return JSON.parse(text);
+  } catch {
+    return { raw: text };
+  }
+}
+
+function schemaProperties(schema) {
+  const properties = schema && typeof schema === "object" && !Array.isArray(schema) ? schema.properties : null;
+  return properties && typeof properties === "object" && !Array.isArray(properties) ? Object.keys(properties) : [];
+}
+
+function schemaRequired(schema) {
+  return schema && typeof schema === "object" && Array.isArray(schema.required)
+    ? schema.required.filter((entry) => typeof entry === "string")
+    : [];
+}
+
+function toolNameFromCapability(name) {
+  const parts = String(name ?? "").split(":");
+  return parts[parts.length - 1] ?? "";
+}
+
+function lookupBodyForMatch(match, toolName) {
+  const properties = schemaProperties(match?.argumentsSchema);
+  const requiredFields = schemaRequired(match?.argumentsSchema);
+  const preferredLookupKeys = ["recordId", "record_id", "id", "record", "query"];
+  const preferredEchoKeys = ["text", "message", "input"];
+  if (toolName === "mock_echo") {
+    const echoKey = preferredEchoKeys.find((key) => properties.includes(key)) ?? requiredFields[0] ?? properties[0] ?? "text";
+    return { [echoKey]: LOOKUP_OK_TEXT };
+  }
+  const lookupKey = preferredLookupKeys.find((key) => properties.includes(key)) ?? requiredFields[0] ?? properties[0] ?? "recordId";
+  return { [lookupKey]: LOOKUP_RECORD };
+}
+
+function selectMockCapability(matches) {
+  const exactAcme = matches.find((match) => match?.name === `mcp:${state.connectionId}:acme_lookup`);
+  const acme = exactAcme ?? matches.find((match) => toolNameFromCapability(match?.name) === "acme_lookup");
+  if (acme) return acme;
+  const exactEcho = matches.find((match) => match?.name === `mcp:${state.connectionId}:mock_echo`);
+  return exactEcho ?? matches.find((match) => toolNameFromCapability(match?.name) === "mock_echo") ?? null;
+}
+
+function entryToolNames(entry) {
+  return Array.isArray(entry?.toolNames) ? entry.toolNames.filter((name) => typeof name === "string") : [];
+}
+
+async function executeMockMcpThroughAgent(ctx) {
+  const before = await mockRequests(ctx);
+  const mcpToken = await mintMcpToken(ctx);
+  const search = await mcpAgentCall(ctx, mcpToken, "tools/call", {
+    name: "search_capabilities",
+    arguments: { query: "acme lookup records", limit: 10, type: "mcp" },
+  });
+  const parsedSearch = parseToolJson(search);
+  const matches = Array.isArray(parsedSearch.matches) ? parsedSearch.matches : [];
+  const match = selectMockCapability(matches);
+  witness(ctx, Boolean(match?.name), "search_capabilities finds the mock MCP acme_lookup capability (or mock_echo fallback)", {
+    connectionId: state.connectionId,
+    matches: matches.map((entry) => ({ name: entry.name, summary: entry.summary, schemaDigest: entry.schemaDigest })),
+  });
+
+  const toolName = toolNameFromCapability(match.name);
+  const executeArguments = {
+    name: match.name,
+    body: lookupBodyForMatch(match, toolName),
+  };
+  if (typeof match.schemaDigest === "string" && match.schemaDigest.trim()) {
+    executeArguments.schemaDigest = match.schemaDigest;
+  }
+
+  const execute = await mcpAgentCall(ctx, mcpToken, "tools/call", {
+    name: "execute_capability",
+    arguments: executeArguments,
+  });
+  state.executedToolName = toolName;
+  state.executeResultText = toolResultText(execute);
+
+  const after = await mockRequests(ctx);
+  const newEntries = after.slice(before.length);
+  state.mockWitnessEntries = newEntries.filter((entry) => entryToolNames(entry).includes(toolName));
+
+  witness(ctx, after.length > before.length, "The mock MCP witness log grew after execute_capability", {
+    before: before.length,
+    after: after.length,
+  });
+  witness(ctx, state.mockWitnessEntries.length > 0, `A new mock MCP request names ${toolName}`, newEntries);
+  witness(ctx, state.executeResultText.includes(LOOKUP_OK_TEXT), "The execute_capability result contains the Acme lookup proof text", state.executeResultText);
+  recordOutput(ctx, "mock-mcp-witness.json", {
+    toolName,
+    executeResultText: state.executeResultText,
+    entries: state.mockWitnessEntries,
+  });
+}
+
+export default defineFlow({
+  id: FLOW_ID,
+  title: "Cloud web sign-in opens a real instance, completes an approved action, and executes a mock MCP through OpenWork Connect",
+  kind: "user-facing",
+  preserveTheme: true,
+  requiresApp: true,
+  requiredEnv: [
+    "OPENWORK_EVAL_DEN_API_URL",
+    "OPENWORK_EVAL_SPA_URL",
+    "OPENWORK_EVAL_MOCK_URL",
+    "OPENWORK_EVAL_DEN_EMAIL",
+    "OPENWORK_EVAL_DEN_PASSWORD",
+    "OPENWORK_EVAL_ORG_NAME",
+    "OPENWORK_EVAL_INSTANCE_HOST_TOKEN",
+  ],
+  steps: [
+    {
+      name: "Frame 1 — No app without sign-in",
+      run: async (ctx) => {
+        await ctx.prove("No app without sign-in.", {
+          action: async () => {
+            await navigateAbsolute(ctx, `${spaBase(ctx)}/`);
+            await clearDenBrowserSession(ctx);
+            await ctx.eval("location.reload()");
+            await ctx.waitForText("Welcome to", { timeoutMs: 60_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Welcome to", { timeoutMs: 60_000 });
+            await ctx.expectNoText("New session");
+          },
+          screenshot: {
+            name: "frame-1-signin-gate",
+            claim: "The web SPA shows the forced sign-in gate and the app shell is absent before authentication.",
+            requireText: ["Welcome to"],
+            rejectText: ["New session"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2 — Admin signs in",
+      run: async (ctx) => {
+        await ctx.prove("Admin signs in.", {
+          action: async () => {
+            await signIn(ctx);
+            await resolveSignedInOrg(ctx);
+            await seedDenSession(ctx);
+            await ctx.eval("location.reload()");
+          },
+          assert: async () => {
+            await waitForOnboarding(ctx);
+            await ctx.waitForText("Choose your organization", { timeoutMs: 60_000 });
+            await ctx.waitForText(required(ctx, "OPENWORK_EVAL_ORG_NAME"), { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "frame-2-signed-in",
+            claim: "The admin's Den session is seeded into the browser and the app reaches the organization onboarding screen.",
+            requireText: ["Choose your organization"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — Machine assigned after sign-in",
+      run: async (ctx) => {
+        await ctx.prove("A machine is assigned only after sign-in.", {
+          action: async () => {
+            const unauthenticated = await denFetch(ctx, "/v1/cloud/instance");
+            state.unauthenticatedCloudStatus = unauthenticated.response.status;
+            await pollCloudInstance(ctx);
+            recordOutput(ctx, "cloud-instance.json", state.cloudInstance);
+          },
+          assert: async () => {
+            witness(ctx, state.unauthenticatedCloudStatus === 401, "Unauthenticated cloud instance lookup returns 401", state.unauthenticatedCloudStatus);
+            witness(ctx, state.cloudInstance?.status === "ready", "The authenticated cloud instance is ready", state.cloudInstance);
+            witness(ctx, instanceBase().startsWith("https://") && instanceBase().includes("daytonaproxy"), "The Cloud instance URL is a Daytona HTTPS proxy URL", instanceBase());
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4 — Instance is full app",
+      run: async (ctx) => {
+        await ctx.prove("The instance is the full OpenWork app.", {
+          action: async () => {
+            await navigateAbsolute(ctx, instanceBase());
+            await seedDenSession(ctx);
+            // The instance build also forces sign-in; after seeding, land on the
+            // session surface directly instead of whatever route the gate picks.
+            await navigateAbsolute(ctx, `${instanceBase()}/session`);
+            await ctx.waitFor("document.body.innerText.includes('What do you need done?') || document.body.innerText.includes('New session')", {
+              timeoutMs: 90_000,
+              label: "OpenWork app shell in Cloud instance",
+            });
+          },
+          assert: async () => {
+            const marker = await ctx.eval(`(() => {
+              const text = document.body.innerText;
+              if (text.includes("What do you need done?")) return "What do you need done?";
+              if (text.includes("New session")) return "New session";
+              return "";
+            })()`);
+            witness(ctx, marker === "What do you need done?" || marker === "New session", "The Cloud instance renders the OpenWork app shell", marker);
+          },
+          screenshot: {
+            name: "frame-4-instance-app",
+            claim: "The Cloud instance loads the full OpenWork app shell after the same signed-in organization session is restored.",
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5 — Approved file write action",
+      run: async (ctx) => {
+        await ctx.prove("Admin completes an action (approved file write).", {
+          action: async () => {
+            await performApprovedFileWrite(ctx);
+          },
+          assert: async () => {
+            witness(ctx, Boolean(state.workspaceId), "The action ran against a Cloud workspace", state.workspaceId);
+            witness(ctx, Boolean(state.approvalId), "The file write exercised the approvals system before completing", state.approvalId);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 6 — Mock MCP appears in Connect",
+      run: async (ctx) => {
+        await ctx.prove("The org's mock MCP appears in Connect, in the instance.", {
+          action: async () => {
+            await ensureMockMcpConnection(ctx);
+            await navigateAbsolute(ctx, instanceUrl("/settings/connect"));
+            // The Den availability probe can latch "unavailable" if its first
+            // request raced the cold tunnel; the banner's Refresh retries it.
+            // The org-connections hook fetches once on mount and renders a
+            // stale "Failed to fetch" without retrying, and the availability
+            // probe can latch "unavailable" when its first request races a
+            // cold connection. Reload until a mount succeeds end to end.
+            for (let round = 0; round < 8; round += 1) {
+              await new Promise((resolve) => setTimeout(resolve, 8000));
+              let pageState = "";
+              try {
+                pageState = String(await ctx.eval(`(() => {
+                  const text = document.body.innerText || "";
+                  if (text.includes(${JSON.stringify(CONNECTION_NAME)})) return "ready";
+                  if (text.includes("Failed to fetch") || text.includes("temporarily unavailable")) return "stale";
+                  return "pending";
+                })()`));
+              } catch {
+                continue;
+              }
+              if (pageState === "ready") break;
+              if (pageState === "stale") {
+                try { await ctx.eval("location.reload()"); } catch {}
+              }
+            }
+          },
+          assert: async () => {
+            await ctx.waitForText(CONNECTION_NAME, { timeoutMs: 60_000 });
+            await ctx.waitForText("Connected to", { timeoutMs: 60_000 });
+          },
+          screenshot: {
+            name: "frame-6-connect",
+            claim: "Settings > Connect in the Cloud instance shows the org-wide Acme Mock Tools MCP connection.",
+            requireText: [CONNECTION_NAME],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 7 — Mock MCP executes through Connect",
+      run: async (ctx) => {
+        await ctx.prove("The mock MCP provably executes through OpenWork Connect.", {
+          action: async () => {
+            await executeMockMcpThroughAgent(ctx);
+          },
+          assert: async () => {
+            witness(ctx, state.mockWitnessEntries.length > 0, "The mock MCP witness log captured the executed tool", state.mockWitnessEntries);
+            witness(ctx, state.executeResultText.includes(LOOKUP_OK_TEXT), "The OpenWork Connect execution returned the Acme lookup proof", state.executeResultText);
+          },
+          // No screenshot: the execution is node-side and the Connect view is
+          // visually identical to frame 6 (the runner rejects duplicate
+          // frames). The witness is the recorded mock request log + result.
+        });
+      },
+    },
+  ],
+});

--- a/evals/voiceovers/cloud-instance.md
+++ b/evals/voiceovers/cloud-instance.md
@@ -1,0 +1,30 @@
+# cloud-instance — OpenWork Cloud opens a full instance in the browser, booted just in time
+
+Cloud is an alpha, per-organization capability: off by default, hosted (multi-org)
+deployments only, so it is absent on self-hosted installs and nothing about it is
+required for them to run. An enabled org's members get a full OpenWork instance in
+the browser — a Daytona sandbox running openwork-server plus the web UI from our
+own snapshot. No orchestrator, no download.
+
+1. I'm signed in to OpenWork on the web. There's no Cloud anywhere — not in the
+   sidebar, not in settings, nothing that hints it exists.
+
+2. A platform admin turns Cloud on for my organization alone. It stays off for
+   everyone else, and it isn't offered at all on self-hosted installs.
+
+3. I reload, and Cloud is in my sidebar, marked Alpha. Nothing to install,
+   nothing to set up.
+
+4. I open Cloud. It brings an instance up for me on the spot, and in a few
+   seconds I'm looking at the full OpenWork interface in my browser.
+
+5. My organization's connections are already there. I ask what's on my calendar
+   and it answers immediately — I never pasted a credential.
+
+6. I ask it to save a summary to a file in my workspace, and the file appears.
+
+7. I close the tab and go do something else. The instance puts itself to sleep,
+   so nothing runs while I'm away.
+
+8. Later I open Cloud again. It wakes up, my summary file is still sitting in
+   the workspace, and I carry on exactly where I stopped.

--- a/packages/docs/cloud/run-in-the-cloud/open-cloud-in-browser.mdx
+++ b/packages/docs/cloud/run-in-the-cloud/open-cloud-in-browser.mdx
@@ -1,0 +1,32 @@
+---
+title: "Open Cloud in your browser"
+description: "Open a full OpenWork instance in your browser with nothing to install"
+---
+
+OpenWork Cloud is currently marked `Alpha` in the dashboard. When your organization has Cloud enabled, you can open a full OpenWork instance in your browser. There is nothing to install and nothing to set up on your computer.
+
+## Who can use it
+
+Cloud is enabled per organization by an OpenWork admin. If you do not see `Cloud` in the sidebar, your organization does not have the alpha enabled yet.
+
+Cloud is only available on hosted OpenWork Cloud organizations. It is not available on self-hosted deployments.
+
+## Open Cloud
+
+1. Sign in to OpenWork Cloud.
+2. Open your organization dashboard.
+3. Click `Cloud` in the sidebar.
+4. Wait a few seconds while Cloud starts.
+5. Open the new browser tab when it is ready.
+
+You are now looking at the full OpenWork interface in your browser.
+
+## Sleep and persistence
+
+The Cloud instance sleeps when it is idle and wakes when you open Cloud again. Files in the workspace persist across sleep, so you can close the tab and come back later without losing your work.
+
+## Alpha limitation
+
+During the alpha, the Cloud instance URL is itself the credential. Do not share it, paste it into public chats, or publish it anywhere public.
+
+If you accidentally share the URL, ask an OpenWork admin for help.

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -83,7 +83,8 @@
           {
             "group": "Run in the cloud",
             "pages": [
-              "cloud/run-in-the-cloud/shared-workspace"
+              "cloud/run-in-the-cloud/shared-workspace",
+              "cloud/run-in-the-cloud/open-cloud-in-browser"
             ]
           },
           {

--- a/scripts/create-daytona-openwork-snapshot.sh
+++ b/scripts/create-daytona-openwork-snapshot.sh
@@ -34,18 +34,18 @@ SNAPSHOT_MEMORY="${DAYTONA_SNAPSHOT_MEMORY:-2}"
 SNAPSHOT_DISK="${DAYTONA_SNAPSHOT_DISK:-8}"
 LOCAL_IMAGE_TAG="${DAYTONA_LOCAL_IMAGE_TAG:-openwork-daytona-snapshot:${SNAPSHOT_NAME//[^a-zA-Z0-9_.-]/-}}"
 
-OPENWORK_ORCHESTRATOR_VERSION="${OPENWORK_ORCHESTRATOR_VERSION:-$(node -e 'const fs=require("fs"); const pkg=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(pkg.version));' "$ROOT_DIR/apps/orchestrator/package.json")}"
+OPENWORK_SERVER_VERSION="${OPENWORK_SERVER_VERSION:-$(node -e 'const fs=require("fs"); const pkg=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(pkg.version));' "$ROOT_DIR/apps/server/package.json")}"
 OPENCODE_VERSION="$(node -e 'const fs=require("fs"); const parsed=JSON.parse(fs.readFileSync(process.argv[1], "utf8")); process.stdout.write(String(parsed.opencodeVersion || "").trim().replace(/^v/, ""));' "$ROOT_DIR/constants.json")"
 
 echo "Building local image $LOCAL_IMAGE_TAG" >&2
-echo "- openwork-orchestrator@$OPENWORK_ORCHESTRATOR_VERSION" >&2
+echo "- openwork-server@$OPENWORK_SERVER_VERSION" >&2
 echo "- opencode@$OPENCODE_VERSION" >&2
 
 docker buildx build \
   --platform linux/amd64 \
   -t "$LOCAL_IMAGE_TAG" \
   -f "$DOCKERFILE" \
-  --build-arg "OPENWORK_ORCHESTRATOR_VERSION=$OPENWORK_ORCHESTRATOR_VERSION" \
+  --build-arg "OPENWORK_SERVER_VERSION=$OPENWORK_SERVER_VERSION" \
   --build-arg "OPENCODE_VERSION=$OPENCODE_VERSION" \
   --load \
   "$ROOT_DIR"


### PR DESCRIPTION
## What this is

**OpenWork Cloud** — an alpha, per-organization capability. When an OpenWork admin enables it for an org, members get a **Cloud** entry in the dashboard that opens a full OpenWork instance in the browser: a Daytona sandbox running `openwork-server` plus the web UI, from our own snapshot. Nothing to install.

It also removes `openwork-orchestrator` from that path entirely.

Spec is the approved voice-over at `evals/voiceovers/cloud-instance.md` (8 frames). This PR implements frames 1-6.

## Two decisions worth reviewing

**1. No credential injection.** The sandbox never receives org credentials. `openwork-server` already has cloud-MCP machinery (`routes/cloud-mcp.ts`, `cloud-mcp-health.ts`), so org connections are brokered server-side by Den and the instance needs only a scoped token. The browser receives **no token at all** — the instance injects its own collaborator-scoped token into the `index.html` it serves. The host token is never injected.

**2. The browser gets the Daytona signed preview URL, not `workerProxyUrl()`.** I verified this empirically against a real sandbox (`public = false`):

| Request | Result |
|---|---|
| `/` top-level nav | 200 `text/html` |
| `/assets/app.js` sub-resource | 200 `text/javascript` |
| `/api/data.json` XHR | 200 `application/json` |
| wrong sandbox id | **401** |
| wrong port | **401** |

So sub-resources work with no cookie/header/shim, and the URL itself is the credential. `den-worker-proxy` cannot serve a browser app — it 401s any request without a token (a `<script src>` has none) and its `/{workerId}` prefix breaks the SPA's `base: "/"`. `provisionWorkerOnDaytona`'s return value is unchanged because `worker_instance.url` is consumed by the Telegram path.

## Self-hosted is untouched

This was a hard requirement and it is enforced structurally:

- **No new required env var**, and **nothing added** to the `superRefine` in `ee/apps/den-api/src/env.ts:173-183`.
- **No DB migration** — the capability rides the existing `organization.metadata` JSON.
- The `multi_org` gate lives in **exactly one helper**, `organizationCloudEnabled()` in `ee/apps/den-api/src/capability-sources/cloud-rollout.ts` — so offering Cloud to other deployments later is a one-line change.
- `startEmbeddedServer` is **untouched**, so the desktop cannot regress. The heartbeat is started only from `apps/server/src/cli.ts`.
- Static UI serving is a **complete no-op** when `OPENWORK_WEB_ROOT` is unset, and the heartbeat stays disabled unless all five `DEN_*` conditions hold.
- When Cloud is off it returns **404, not 403**, so the feature never advertises itself.

## Tests run

| Command | Result |
|---|---|
| `pnpm --filter openwork-server exec bun test` | **540 pass / 0 fail** (550 across 77 files) |
| `pnpm --filter @openwork-ee/den-api exec bun test test/cloud-instance-route.test.ts test/cloud-rollout.test.ts test/organization-capabilities.test.ts test/admin-organization-capabilities.test.ts test/route-access-policy.test.ts` | **18 pass / 0 fail** |
| `pnpm --filter openwork-server exec tsc --noEmit` | PASS |
| `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` | PASS |
| `pnpm --filter @openwork-ee/den-web exec tsc --noEmit` | PASS |
| `pnpm --filter @openwork/app exec tsc --noEmit` | PASS |

New coverage includes the gate returning 404 when the capability is off **and** in `single_org` even with a literal `cloud: true`, plus static-UI traversal rejection, MIME/cache headers, SPA fallback, bootstrap escaping, and the heartbeat config gate.

Live `curl` proof of the server serving the SPA (captured locally):

```
GET /                        -> 200 text/html   (body contains __OPENWORK_BOOTSTRAP__ + token)
GET /assets/<hashed>.js      -> 200 + Cache-Control: public, max-age=31536000, immutable
GET /settings/general        -> 200 text/html   (SPA history fallback)
GET /assets/app-DEADBEEF.js  -> 404 JSON        (missing hashed asset is a hard 404, not HTML)
GET /health                  -> 200 JSON        (API unaffected)
POST /not-a-route            -> 404 JSON
GET / without OPENWORK_WEB_ROOT -> 404 JSON     (proves the no-op)
encoded ../ traversal        -> 400 path_escape (no leak)
```

## NOT verified — please read

Per the repo's validation standard I am **not** claiming this passes.

1. **No fraimz.** `evals/flows/cloud-instance.flow.ts` is scaffolded but its frames are still `ctx.assert(false, ...)` stubs. No `fraimz.html` exists, so nothing here is backed by frame-by-frame proof yet. Frames 1-3 are provable today; frames 4-6 need the two items below.
2. **The snapshot image was never built.** `docker build` was aborted locally (the machine hit 100% disk). So `Dockerfile.daytona-snapshot` is **unproven end to end** — in particular whether `better-sqlite3` (imported by `apps/server/src/opencode-db.ts`) loads inside the `bun --compile` binary. The image asserts `openwork-server --version && opencode --version`, which is where that would surface.
3. **Frames 7-8 (sleep/wake) are not implemented.** `deprovisionWorkerOnDaytona` deletes the sandbox *and* erases `workers/<id>/`; there is still no stop-without-cleanup or wake path. Tracked as follow-up.

## Follow-ups

- **JIT lifecycle**: stop-without-cleanup, wake, and signed-preview-URL re-resolution (frames 7-8).
- **Delete Render worker provisioning.** `ee/apps/den-api/src/workers/provisioner.ts` still runs `npm install -g openwork-orchestrator` at an **unpinned** version (prod `RENDER_WORKER_OPENWORK_VERSION` is unset, so worker builds float to npm `latest`) off branch `dev`. Once Cloud replaces it, that path and the orchestrator sidecar can go, and the npm package can be deprecated.
- Before Cloud leaves alpha, replace the inline bootstrap token with a Den-authenticated one-time-code handoff so the token never sits in static HTML.
