### PR TITLE
fix(desktop): route updater manifest through OS trust and guard bare fetch

### DIFF
--- a/apps/desktop/electron/browser-panel.mjs
+++ b/apps/desktop/electron/browser-panel.mjs
@@ -122,6 +122,7 @@ export function createBrowserPanel({ getWindow, remoteDebugPort, onDeepLink }) {
 
   async function listCdpTargets() {
     if (!remoteDebugPort || remoteDebugPort <= 0) return [];
+    // loopback-fetch: CDP discovery targets Electron's local remote debugging port on 127.0.0.1.
     const response = await fetch(`${cdpBrowserUrl()}/json/list`, { signal: AbortSignal.timeout(1000) });
     if (!response.ok) throw new Error(`CDP target list failed: HTTP ${response.status}`);
     const targets = await response.json();

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -296,8 +296,11 @@ function selectDownloadFile(files, arch) {
 
 async function resolveCorrectArchitectureDownloadUrl(arch) {
   const manifestUrl = `${RELEASE_DOWNLOAD_BASE_URL}/${updaterManifestName(arch)}`;
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10_000);
   try {
-    const response = await fetch(manifestUrl, {
+    const response = await electronNet.fetch(manifestUrl, {
+      signal: controller.signal,
       headers: { Accept: "text/yaml, text/plain, */*" },
     });
     if (!response.ok) throw new Error(`HTTP ${response.status}`);
@@ -309,6 +312,8 @@ async function resolveCorrectArchitectureDownloadUrl(arch) {
   } catch (error) {
     console.warn("[architecture] failed to resolve latest download URL", error);
     return null;
+  } finally {
+    clearTimeout(timeout);
   }
 }
 

--- a/apps/desktop/electron/no-bare-external-fetch.test.mjs
+++ b/apps/desktop/electron/no-bare-external-fetch.test.mjs
@@ -51,6 +51,6 @@ test("desktop electron source does not use unmarked bare fetch", async () => {
   }
 
   if (offenders.length > 0) {
-    throw new Error(`Unmarked bare fetch is banned in apps/desktop/electron because bare fetch bypasses the OS certificate trust store and system proxy; use electronNet.fetch for external requests, or add // loopback-fetch: <reason> if the target is provably 127.0.0.1/localhost. Offenders:\n${offenders.join("\n")}`);
+    throw new Error(`Unmarked bare fetch is banned in apps/desktop/electron because bare fetch bypasses Chromium's certificate trust path and system proxy; use electronNet.fetch for external requests, or add // loopback-fetch: <reason> if the target is provably 127.0.0.1/localhost. Offenders:\n${offenders.join("\n")}`);
   }
 });

--- a/apps/desktop/electron/no-bare-external-fetch.test.mjs
+++ b/apps/desktop/electron/no-bare-external-fetch.test.mjs
@@ -1,0 +1,56 @@
+import { readdir, readFile } from "node:fs/promises";
+import { dirname, join, relative, sep } from "node:path";
+import { test } from "node:test";
+import { fileURLToPath } from "node:url";
+
+const srcDir = dirname(fileURLToPath(import.meta.url));
+const bareFetchPattern = /(?<![.\w])fetch\s*\(/;
+const loopbackMarkerPattern = /\/\/\s*loopback-fetch:\s*\S/;
+
+async function collectModuleFiles(dir) {
+  const entries = await readdir(dir, { withFileTypes: true });
+  const sortedEntries = entries.sort((left, right) => left.name.localeCompare(right.name));
+  const files = [];
+  for (const entry of sortedEntries) {
+    const file = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      files.push(...await collectModuleFiles(file));
+    } else if (entry.isFile() && entry.name.endsWith(".mjs")) {
+      files.push(file);
+    }
+  }
+  return files;
+}
+
+function relativeSrcPath(file) {
+  return relative(srcDir, file).split(sep).join("/");
+}
+
+function shouldCheck(file) {
+  return !relativeSrcPath(file).endsWith(".test.mjs");
+}
+
+function hasLoopbackMarker(lines, index) {
+  return loopbackMarkerPattern.test(lines[index] ?? "") || (
+    index > 0 && loopbackMarkerPattern.test(lines[index - 1] ?? "")
+  );
+}
+
+test("desktop electron source does not use unmarked bare fetch", async () => {
+  const offenders = [];
+  const files = (await collectModuleFiles(srcDir)).filter(shouldCheck);
+  for (const file of files) {
+    const path = relativeSrcPath(file);
+    const lines = (await readFile(file, "utf8")).split(/\r?\n/);
+    lines.forEach((line, index) => {
+      const code = line.replace(/\/\/.*$/, "");
+      if (bareFetchPattern.test(code) && !hasLoopbackMarker(lines, index)) {
+        offenders.push(`${path}:${index + 1}`);
+      }
+    });
+  }
+
+  if (offenders.length > 0) {
+    throw new Error(`Unmarked bare fetch is banned in apps/desktop/electron because bare fetch bypasses the OS certificate trust store and system proxy; use electronNet.fetch for external requests, or add // loopback-fetch: <reason> if the target is provably 127.0.0.1/localhost. Offenders:\n${offenders.join("\n")}`);
+  }
+});

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -427,6 +427,7 @@ async function waitForHttpOk(url, timeoutMs) {
 
   while (Date.now() < deadline) {
     try {
+      // loopback-fetch: waitForHttpOk is only called with health URLs for 127.0.0.1-bound sidecars.
       const response = await fetch(url);
       if (response.ok) {
         return response;
@@ -445,6 +446,7 @@ async function fetchJson(url, options = {}, timeoutMs = 3000) {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
+    // loopback-fetch: fetchJson callers pass runtime-managed 127.0.0.1 server URLs.
     const response = await fetch(url, {
       ...options,
       signal: controller.signal,
@@ -639,6 +641,7 @@ export function createRuntimeManager({ app, desktopRoot, listLocalWorkspacePaths
     const baseUrl = state?.daemon?.baseUrl?.trim();
     if (!baseUrl) return false;
     try {
+      // loopback-fetch: orchestrator daemon state is written by the 127.0.0.1-bound sidecar launched below.
       await fetch(`${baseUrl.replace(/\/+$/, "")}/shutdown`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "check:electron": "node ./scripts/check-electron-bridge.mjs",
     "typecheck:electron": "pnpm --dir ../server exec tsc -p ../desktop/tsconfig.electron.json --noEmit",
     "prepare:sidecar": "node ./scripts/prepare-sidecar.mjs",
-    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/dev-profile.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
+    "test": "node --test electron/agent-context-diagnostics-fetch.test.mjs electron/brand-app-name.test.mjs electron/brand-icon-windows.test.mjs electron/connect-link.test.mjs electron/dev-profile.test.mjs electron/no-bare-external-fetch.test.mjs electron/nuke.test.mjs electron/open-external.test.mjs electron/runtime.test.mjs electron/runtime-ca.test.mjs electron/ui-control-server.test.mjs electron/updater.test.mjs electron/remote-workspace.test.mjs electron/workspace-store.test.mjs"
   },
   "dependencies": {
     "@openwork/paths": "workspace:*",

--- a/apps/installer/src/index.ts
+++ b/apps/installer/src/index.ts
@@ -212,6 +212,7 @@ const installerWindowTitle = `${uiResolution?.config.appName ?? "OpenWork"} Inst
 
 async function currentInstallState(): Promise<string> {
   try {
+    // loopback-fetch: ready.url comes from startInstallerServer, which binds 127.0.0.1 and returns http://127.0.0.1:<port>/.
     const response = await fetch(`${ready.url}api/status`, { headers: { "x-installer-token": ready.token } })
     const status: unknown = await response.json()
     return typeof status === "object" && status !== null && "state" in status && typeof status.state === "string" ? status.state : ""

--- a/apps/installer/test/no-bare-fetch.test.ts
+++ b/apps/installer/test/no-bare-fetch.test.ts
@@ -1,0 +1,79 @@
+import { test } from "bun:test"
+import { readdir, readFile } from "node:fs/promises"
+import { dirname, join, relative, sep } from "node:path"
+import { fileURLToPath } from "node:url"
+
+const testDir = dirname(fileURLToPath(import.meta.url))
+const srcDir = join(testDir, "..", "src")
+const bareFetchPattern = /(?<![.\w])fetch\s*\(/g
+const loopbackMarkerPattern = /\/\/\s*loopback-fetch:\s*\S/
+
+async function collectTypescriptFiles(dir: string): Promise<string[]> {
+  const entries = await readdir(dir, { withFileTypes: true })
+  const sortedEntries = entries.sort((left, right) => left.name.localeCompare(right.name))
+  const files: string[] = []
+  for (const entry of sortedEntries) {
+    const path = join(dir, entry.name)
+    if (entry.isDirectory()) {
+      files.push(...await collectTypescriptFiles(path))
+    } else if (entry.isFile() && entry.name.endsWith(".ts")) {
+      files.push(path)
+    }
+  }
+  return files
+}
+
+function relativeSrcPath(file: string): string {
+  return relative(srcDir, file).split(sep).join("/")
+}
+
+function shouldCheck(file: string): boolean {
+  const path = relativeSrcPath(file)
+  return !path.endsWith(".test.ts")
+    // Test files use bare fetch only against local HTTP fixtures and never ship in installer runtime code.
+    // system-ca.ts defines createSystemCaFetch/fetchWithSystemCa; its bare fetch calls are the wrapped implementation.
+    && path !== "system-ca.ts"
+    // ui-html.ts is a browser-side HTML/JS template served by the 127.0.0.1 installer UI; its fetch calls use relative /api paths.
+    && path !== "ui-html.ts"
+}
+
+function hasLoopbackMarker(lines: string[], index: number): boolean {
+  return loopbackMarkerPattern.test(lines[index] ?? "") || (
+    index > 0 && loopbackMarkerPattern.test(lines[index - 1] ?? "")
+  )
+}
+
+function isFetchDefinition(code: string, index: number): boolean {
+  // Bun.serve accepts an object method named fetch(request) { ... }; that is not a network call.
+  const before = code.slice(0, index)
+  const after = code.slice(index)
+  if (/\bfunction\s+$/.test(before)) return true
+  if (!/^fetch\s*\([^)]*\)\s*\{/.test(after)) return false
+  return /^\s*(?:async\s+)?$/.test(before) || /[{,]\s*(?:async\s+)?$/.test(before)
+}
+
+function hasUnmarkedBareFetchCall(line: string, lines: string[], index: number): boolean {
+  const code = line.replace(/\/\/.*$/, "")
+  bareFetchPattern.lastIndex = 0
+  for (const match of code.matchAll(bareFetchPattern)) {
+    if (match.index === undefined) continue
+    if (!isFetchDefinition(code, match.index) && !hasLoopbackMarker(lines, index)) return true
+  }
+  return false
+}
+
+test("installer source does not use bare fetch", async () => {
+  const offenders: string[] = []
+  const files = (await collectTypescriptFiles(srcDir)).filter(shouldCheck)
+  for (const file of files) {
+    const path = relativeSrcPath(file)
+    const lines = (await readFile(file, "utf8")).split(/\r?\n/)
+    lines.forEach((line, index) => {
+      if (hasUnmarkedBareFetchCall(line, lines, index)) offenders.push(`${path}:${index + 1}`)
+    })
+  }
+
+  if (offenders.length > 0) {
+    throw new Error(`Bare fetch is banned in apps/installer/src because bare fetch bypasses the OS certificate trust store and system proxy; use fetchWithSystemCa for external requests, or add // loopback-fetch: <reason> if the target is provably 127.0.0.1/localhost. Offenders:\n${offenders.join("\n")}`)
+  }
+})


### PR DESCRIPTION
## What broke

`resolveCorrectArchitectureDownloadUrl` in `apps/desktop/electron/main.mjs` fetched the electron-updater manifest from `github.com` with **bare Node `fetch`**, twenty lines away from six correct `electronNet.fetch` calls in the same file.

Bare `fetch` only trusts bundled Mozilla roots and ignores system proxy configuration. On a corporate network that inspects TLS, that one call fails while the whole rest of the app works — the hardest class of bug to diagnose. It also had no timeout.

## What this does

1. **Fixes the leak.** Routes it through `electronNet.fetch` (Chromium stack: OS trust store + system proxy) with a 10s abort. Failure behavior is unchanged — still warns and returns `null`, so the banner can never block startup.

2. **Stops the next one.** `apps/server/src` already bans bare `fetch` via `no-bare-fetch.test.ts`. This extends the same enforcement to the two remaining surfaces that talk to the network:

| Surface | Sanctioned call | Guard |
|---|---|---|
| `apps/server/src` | `externalFetch` / `loopbackFetch` | already enforced |
| `apps/desktop/electron` | `electronNet.fetch` | **new** |
| `apps/installer/src` | `fetchWithSystemCa` | **new** |

Genuine loopback call sites carry an explicit `// loopback-fetch: <reason>` marker naming why 127.0.0.1 is provable, so the exemption is reviewable rather than invisible. Four in electron (sidecar health, runtime JSON, daemon shutdown, CDP discovery), one in the installer (its own local server).

## Compatibility

**No breaking changes for self-hosted deployments.** No configuration, environment variable, API, Helm chart, or database surface is touched. The only behavior change is that one manifest request now honors OS trust and system proxy — strictly more permissive than before, so networks that worked continue to work and inspected networks start working.

## Tests run

\`\`\`
pnpm --filter @openwork/desktop test        # 117 tests, 116 pass, 0 fail, 1 skipped
cd apps/installer && bun test               # 53 pass, 0 fail, 132 expect() calls
pnpm --filter @openwork/desktop typecheck:electron   # pass
pnpm typecheck                              # pass
\`\`\`

**Negative controls** — each guard was proven to actually catch the bug, in files this PR does not otherwise modify:

Reverting the fix in \`main.mjs\`:
\`\`\`
Error: Unmarked bare fetch is banned in apps/desktop/electron because bare fetch
bypasses the OS certificate trust store and system proxy; use electronNet.fetch
for external requests, or add // loopback-fetch: <reason> if the target is
provably 127.0.0.1/localhost. Offenders:
main.mjs:300
\`\`\`

Injecting \`fetch("https://github.com/x")\` into \`electron/updater.mjs\` → caught at \`updater.mjs:434\`.
Injecting the same into \`installer/src/config-sources.ts\` → caught at \`config-sources.ts:331\`.
Adding a *marked* loopback fetch to the same file → passes, confirming the marker path works.
Bun.serve's \`async fetch(request)\` handler in \`installer/src/server.ts\` is correctly recognized as a definition, not a call.

## Fraimz

Skipped, stated explicitly per AGENTS.md. This change has no user-visible surface: it is two CI guards plus one internal request that swaps its network stack. The observable effect only appears on a TLS-inspecting network, which is already covered end-to-end by the existing \`installer-tls-trust\` and \`desktop-fetch-os-trust\` flows. The executable proof for this PR is the negative controls above — each guard demonstrably fails on the exact bug it exists to prevent.