### PR TITLE
docs: explain connectors and the plugins that support them

### DIFF
--- a/packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
+++ b/packages/docs/start-here/connect-your-stack/add-an-mcp-server.mdx
@@ -8,18 +8,18 @@ Use this guide only when you need a custom or local MCP server that is not avail
 For Gmail, Google Calendar, Google Drive, Slack, Notion, Linear, and other
 managed services, follow [Connect your services](/start-here/connect-your-stack/connect-services).
 
-Connecting a custom MCP server with OpenWork takes four clicks.
+Connecting a custom app with OpenWork takes four clicks.
 
-- Inside your workspace, click in `Extensions` \> `Advanced Settings` \> `Add MCP server`
+- In the desktop app, open `Settings` \> `Extensions`, then click `Add Custom App`
 
 <Frame>
-  ![Extensions page with Advanced Settings link](/images/mcp-extensions-advanced-settings.png)
+  ![Extensions page listing available and connected apps](/images/mcp-extensions-advanced-settings.png)
 </Frame>
 
-You can add the MCP server to this workspace or to your global OpenCode configuration for all workspaces.
+You can add the app to this workspace or to your global configuration for all workspaces.
 
 <Frame>
-  ![Add MCP Server dialog with name, URL, and OAuth toggle](/images/mcp-add-server-dialog.png)
+  ![Add Custom App dialog with name, URL, and OAuth options](/images/mcp-add-server-dialog.png)
 
   Indicate whether the server requires OAuth.
 </Frame>

--- a/packages/docs/start-here/connect-your-stack/connect-services.mdx
+++ b/packages/docs/start-here/connect-your-stack/connect-services.mdx
@@ -3,7 +3,7 @@ title: "Connect your services"
 description: "Sign in to OpenWork and connect the accounts your agent can use"
 ---
 
-Use `Settings` > `Connect` for services your organization makes available,
+Use `Settings` > `OpenWork Connect` for services your organization makes available,
 including Gmail, Google Calendar, Google Drive, Slack, Notion, and Linear. This
 is the recommended setup for everyday integrations.
 
@@ -14,7 +14,7 @@ that has Connect enabled. This is separate from signing in to an LLM provider
 such as ChatGPT.
 
 1. Open the OpenWork desktop app.
-2. Click `Sign in`, or open `Settings` > `Connect` and choose `Sign in`.
+2. Click `Sign in`, or open `Settings` > `OpenWork Connect` and choose `Sign in`.
 3. Complete sign-in in your browser and return to OpenWork.
 4. Choose the OpenWork organization you want to use if prompted.
 
@@ -23,7 +23,7 @@ to enable it.
 
 ## Connect an account
 
-1. Open `Settings` > `Connect`.
+1. Open `Settings` > `OpenWork Connect`.
 2. Find the service under `Needs your sign-in`.
 3. Click `Connect` and approve access on the provider's sign-in page.
 4. Return to OpenWork. The service moves to `Ready to use` automatically.
@@ -43,7 +43,7 @@ you want, for example:
 
 The agent searches the live capabilities available to your signed-in account,
 then executes an exact match. If an account still needs attention, it should
-send you back to `Settings` > `Connect` with the action to take instead of
+send you back to `Settings` > `OpenWork Connect` with the action to take instead of
 telling you to add an MCP server.
 
 ## Connect, Connections, and MCP servers

--- a/packages/docs/start-here/do-work-with-it/skills-plugins-and-mcp.mdx
+++ b/packages/docs/start-here/do-work-with-it/skills-plugins-and-mcp.mdx
@@ -1,19 +1,44 @@
 ---
-title: "Skills, plugins, and MCP"
-description: "Choose the right OpenWork building block for a reusable setup"
+title: "Connectors, skills, and plugins"
+description: "Use connectors for systems and plugins for the skills that make a system usable"
 ---
 
-MCP, skills, and plugins solve different parts of the same setup.
+OpenWork gives agents three building blocks. The connector reaches the system; the skill is the playbook; the plugin is the bundle.
 
 ## Choose the right unit
 
 | Use | Means | Reach for it when |
 | --- | --- | --- |
-| MCP | The connector to a system like mail, ticketing, or CRM. | The agent needs to call that system. |
-| Skill | Written instructions the agent loads when a task matches. | One workflow should become repeatable. |
-| Plugin | The package a marketplace distributes. | Related skills should travel together. |
+| Connector | How OpenWork reaches mail, calendar, CRM, or your ticketing system. | The agent needs to act in that system after you connect it once. |
+| Skill | Written instructions the agent loads when a task matches. | One repeatable way of doing work needs a playbook. |
+| Plugin | A bundle OpenWork can install or distribute as one thing. | Several related skills should travel together. |
 
-1. Keep using connectors for MCPs. An MCP is the system connection, not the playbook.
-2. Create a skill when one set of instructions is enough. Creating a skill already creates a single-skill plugin for you.
-3. Use a multi-skill plugin when several skills make one system usable, such as ticketing skills that fill gaps around a thin MCP.
-4. Keep those system skills together because they depend on the system's capabilities, not one person's workflow.
+MCP is the open standard underneath many connectors, but day to day you can think in terms of apps, connectors, skills, and plugins.
+
+## Connect the system first
+
+Use connectors for the apps themselves. In the desktop app, start in `Settings` > `OpenWork Connect`; for the click-by-click flow, see [Connect your services](/start-here/connect-your-stack/connect-services).
+
+Everything your agent can use is listed in `Settings` > `Extensions`, under `Available apps` and `Your apps`. Use `Add Custom App` to connect something we do not list yet.
+
+## Add skills when the connector is thin
+
+A connector may reach your ticketing system but still be awkward: an incident may need exact fields, a priority change may need a safe sequence, or one ticket action may behave badly.
+
+Write skills for those system rules:
+
+- how to file an incident with the right fields;
+- how to update a customer note without losing context;
+- how to work around an unreliable ticket action.
+
+These skills describe the system, not one person's style, so everyone who uses that system needs them.
+
+## Bundle system skills into a plugin
+
+Everything is a plugin under the hood. When you ask OpenWork to create a skill, OpenWork creates a small plugin containing that one skill, so “skill or plugin?” is not a decision most people need to make.
+
+The useful plugin case is a thin connector with several system skills. If half a dozen ticketing skills make one system usable, bundle them into one plugin — the ticketing unit — and share that single thing. For distribution options, see [Publish and copy a skill](/start-here/do-work-with-it/publish-and-copy-a-skill).
+
+## Keep personal skills separate
+
+Use connectors for systems. Use plugins to bundle the skills that make a system usable. Personal or workflow-specific skills can stay individual unless a team should receive them together.


### PR DESCRIPTION
## Why
The ask was to explain **how connectors work and which plugins pair well with them**, in the framing used on a customer call — and to be less technical, using OpenWork's own vocabulary instead of protocol jargon.

## What
Deepens the existing concepts page rather than adding a new one (we're pruning docs in #3125, so no nav sprawl — `docs.json` is untouched). It now tells the story in order:

1. **A connector reaches the system.** Mail, calendar, CRM, your ticketing system. Connect once, then the agent can act there.
2. **A skill is the playbook**, not the connection.
3. **Everything is a plugin underneath** — asking for a skill creates a plugin containing that one skill, so "skill or plugin?" isn't a decision most people have to make.
4. **The case that actually matters: a thin connector.** Some connectors reach a system but are awkward — an incident needs exact fields, a priority change needs a safe sequence, one action misbehaves. So you write skills to compensate, and you can end up with half a dozen.
5. **Those skills describe the system, not the person** — everyone using that system needs them. *That* is when you bundle them into one plugin, "the ticketing unit", and hand out a single thing.
6. **The rule:** connectors for the systems, plugins for the skills that make a system usable. Personal workflow skills can stay individual.

Tone: written for a non-technical reader, with exactly one plain-language mention that MCP is the open standard underneath, then "connector"/"app" throughout. Uses a generic ticketing example rather than naming a vendor.

## Stale click-paths fixed while verifying
Checking every path against `en.ts` turned up real inaccuracies:

- The settings tab is labelled **`OpenWork Connect`**, not `Connect`. Fixed in the new content **and** in `connect-services.mdx`, which had it wrong in 4 places.
- **`Add MCP server` no longer exists** (0 occurrences in `en.ts`). `add-an-mcp-server.mdx` still instructed `Extensions > Advanced Settings > Add MCP server`; the real entry point is `Settings > Extensions` → **`Add Custom App`**. Fixed, and the dialog alt-text no longer asserts a title the UI dropped. Note the same page already said `Add Custom App` further down, so it was self-contradictory.

I checked two labels I'd assumed were also stale and they are **not**: `Advanced settings` and `Advanced OAuth` both still exist, so I left them alone.

## Verification
```
docs.json                unchanged (no nav entry needed)
internal links           all resolve
image references         none added; all existing images still present
line count               44
git diff -- apps/ ee/ packages/types   (empty — docs only)
```

## Known caveat
The page's URL slug is still `/skills-plugins-and-mcp` while the title is now "Connectors, skills, and plugins". I deliberately did **not** rename the file: that URL is already live and was handed over as a shareable link. Say the word and I'll rename it with a redirect.

Docs-only, no runtime path — no fraimz.
