### PR TITLE
docs(enterprise): document outbound network access and guard it in CI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -129,6 +129,9 @@ jobs:
       - name: Run eval runner unit tests
         run: pnpm test:eval-runner
 
+      - name: Check outbound access manifest
+        run: pnpm check:outbound-access
+
       - name: Typecheck Electron main against the IPC contract
         run: pnpm --filter @openwork/desktop typecheck:electron
 

--- a/docs/enterprise/outbound-access.json
+++ b/docs/enterprise/outbound-access.json
@@ -208,12 +208,21 @@
       "override": "OPENWORK_GOOGLE_WORKSPACE_TOKEN_BROKER_URL for token exchange/refresh only"
     },
     {
+      "host": "release-assets.githubusercontent.com",
+      "kind": "redirect-target",
+      "components": ["desktop", "installer"],
+      "purpose": "Current GitHub release-asset download target reached after github.com redirects installer and updater downloads. Verified live against a real OpenWork release asset.",
+      "requirement": "required-in-practice",
+      "blockedEffect": "OpenWork downloads start from github.com and then fail partway through when the redirect target is blocked.",
+      "override": null
+    },
+    {
       "host": "objects.githubusercontent.com",
       "kind": "redirect-target",
       "components": ["desktop", "installer"],
-      "purpose": "GitHub release-asset download target reached after github.com redirects installer and updater downloads.",
+      "purpose": "Legacy GitHub release-asset download target. GitHub has migrated to release-assets.githubusercontent.com, but allow both so older clients and any staged rollback keep working.",
       "requirement": "required-in-practice",
-      "blockedEffect": "OpenWork downloads start from github.com and then fail partway through when the redirect target is blocked.",
+      "blockedEffect": "OpenWork downloads start from github.com and then fail partway through if GitHub serves this legacy redirect target and it is blocked.",
       "override": null
     },
     {

--- a/docs/enterprise/outbound-access.json
+++ b/docs/enterprise/outbound-access.json
@@ -1,0 +1,310 @@
+{
+  "hosts": [
+    {
+      "host": "accounts.google.com",
+      "kind": "fetched",
+      "components": ["server"],
+      "purpose": "Google Workspace OAuth authorization page opened when a user connects Google Workspace.",
+      "requirement": "opt-in",
+      "blockedEffect": "Users cannot complete Google Workspace sign-in from OpenWork.",
+      "override": null
+    },
+    {
+      "host": "api.github.com",
+      "kind": "fetched",
+      "components": ["server"],
+      "purpose": "GitHub API calls for importing and previewing GitHub-hosted Claude Code/OpenWork plugins.",
+      "requirement": "opt-in",
+      "blockedEffect": "GitHub plugin import cannot inspect repositories, branches, or plugin manifests.",
+      "override": "OPENWORK_GITHUB_API_BASE"
+    },
+    {
+      "host": "api.githubcopilot.com",
+      "kind": "fetched",
+      "components": ["renderer", "server"],
+      "purpose": "Example remote MCP server URL for GitHub Copilot; reached only if a user configures that URL.",
+      "requirement": "opt-in",
+      "blockedEffect": "A GitHub Copilot MCP connection using the example URL cannot connect.",
+      "override": "MCP server URL setting"
+    },
+    {
+      "host": "api.openai.com",
+      "kind": "fetched",
+      "components": ["renderer", "server"],
+      "purpose": "Direct OpenAI Realtime voice and image-generation calls when the user provides an OpenAI key.",
+      "requirement": "opt-in",
+      "blockedEffect": "Direct OpenAI voice or image features fail for users who configured OpenAI.",
+      "override": null
+    },
+    {
+      "host": "api.openworklabs.com",
+      "kind": "fetched",
+      "components": ["desktop", "installer", "server"],
+      "purpose": "Hosted OpenWork public API and OpenWork Connect MCP endpoint used by hosted Cloud and install flows.",
+      "requirement": "required-for-cloud",
+      "blockedEffect": "Hosted install checks, OpenWork Connect, or legacy hosted API configurations cannot reach OpenWork Cloud.",
+      "override": "installer apiUrl / self-hosted Den API origin"
+    },
+    {
+      "host": "app.openworklabs.com",
+      "kind": "fetched",
+      "components": ["desktop", "renderer", "bootstrap"],
+      "purpose": "Hosted OpenWork Cloud web origin; the desktop derives Den API and MCP calls from this base URL.",
+      "requirement": "required-for-cloud",
+      "blockedEffect": "Hosted Cloud sign-in, org settings, marketplace, and remote workspace flows cannot load.",
+      "override": "desktop base URL (self-hosted Den replaces this host)"
+    },
+    {
+      "host": "cdn.simpleicons.org",
+      "kind": "fetched",
+      "components": ["renderer"],
+      "purpose": "Brand icons for MCP and extension cards when a built-in local icon is not available.",
+      "requirement": "optional",
+      "blockedEffect": "Some provider icons are missing; the app still works.",
+      "override": null
+    },
+    {
+      "host": "chat.googleapis.com",
+      "kind": "fetched",
+      "components": ["server"],
+      "purpose": "Google Chat API calls for Google Workspace chat actions.",
+      "requirement": "opt-in",
+      "blockedEffect": "Google Chat spaces, messages, and send-message actions fail for connected Google Workspace accounts.",
+      "override": null
+    },
+    {
+      "host": "code.claude.com",
+      "kind": "link-only",
+      "components": ["server"],
+      "purpose": "Source-code comment pointing maintainers to the Claude Code plugin format reference.",
+      "requirement": "optional",
+      "blockedEffect": "No runtime effect; it is not opened or fetched by OpenWork.",
+      "override": null
+    },
+    {
+      "host": "discord.gg",
+      "kind": "link-only",
+      "components": ["renderer"],
+      "purpose": "Community link from Settings.",
+      "requirement": "optional",
+      "blockedEffect": "The Discord community link will not open.",
+      "override": null
+    },
+    {
+      "host": "ghcr.io",
+      "kind": "subprocess",
+      "components": ["den"],
+      "purpose": "Container registry for self-hosted Den API, web, inference images, and Helm chart pulls.",
+      "requirement": "required",
+      "blockedEffect": "A self-hosted Den deployment cannot pull OpenWork images or the Helm chart from GitHub Container Registry.",
+      "override": "container registry mirror / Helm image.repository values"
+    },
+    {
+      "host": "github.com",
+      "kind": "fetched",
+      "components": ["desktop", "installer", "renderer", "server"],
+      "purpose": "Desktop installer and updater release URLs, GitHub issue links, and GitHub plugin source URLs.",
+      "requirement": "required-in-practice",
+      "blockedEffect": "Desktop install/update downloads cannot start; GitHub issue and plugin-source links may not open.",
+      "override": null
+    },
+    {
+      "host": "gmail.googleapis.com",
+      "kind": "fetched",
+      "components": ["server"],
+      "purpose": "Gmail API calls for Google Workspace message search, reading, attachments, and draft creation.",
+      "requirement": "opt-in",
+      "blockedEffect": "Gmail read and draft actions fail for connected Google Workspace accounts.",
+      "override": null
+    },
+    {
+      "host": "linear.app",
+      "kind": "link-only",
+      "components": ["renderer"],
+      "purpose": "Sample link in the deterministic demo transcript used to exercise link rendering.",
+      "requirement": "optional",
+      "blockedEffect": "Clicking that sample Linear link fails; OpenWork functionality is unaffected.",
+      "override": null
+    },
+    {
+      "host": "mail.google.com",
+      "kind": "link-only",
+      "components": ["server"],
+      "purpose": "Gmail draft and thread links returned after Google Workspace Gmail actions.",
+      "requirement": "opt-in",
+      "blockedEffect": "Generated Gmail draft/thread links cannot open in the user's browser.",
+      "override": null
+    },
+    {
+      "host": "mcp.context7.com",
+      "kind": "fetched",
+      "components": ["renderer", "server"],
+      "purpose": "Context7 MCP Quick Connect preset.",
+      "requirement": "opt-in",
+      "blockedEffect": "The Context7 MCP connection cannot connect when enabled.",
+      "override": "MCP server URL setting"
+    },
+    {
+      "host": "mcp.linear.app",
+      "kind": "fetched",
+      "components": ["renderer", "server"],
+      "purpose": "Linear MCP Quick Connect preset.",
+      "requirement": "opt-in",
+      "blockedEffect": "The Linear MCP connection cannot connect when enabled.",
+      "override": "MCP server URL setting"
+    },
+    {
+      "host": "mcp.notion.com",
+      "kind": "fetched",
+      "components": ["renderer", "server"],
+      "purpose": "Notion MCP Quick Connect preset.",
+      "requirement": "opt-in",
+      "blockedEffect": "The Notion MCP connection cannot connect when enabled.",
+      "override": "MCP server URL setting"
+    },
+    {
+      "host": "mcp.sentry.dev",
+      "kind": "fetched",
+      "components": ["renderer", "server"],
+      "purpose": "Sentry MCP Quick Connect preset.",
+      "requirement": "opt-in",
+      "blockedEffect": "The Sentry MCP connection cannot connect when enabled.",
+      "override": "MCP server URL setting"
+    },
+    {
+      "host": "mcp.slack.com",
+      "kind": "fetched",
+      "components": ["renderer", "server"],
+      "purpose": "Slack MCP connection preset and OAuth guidance.",
+      "requirement": "opt-in",
+      "blockedEffect": "The Slack MCP connection cannot connect when enabled.",
+      "override": "MCP server URL setting"
+    },
+    {
+      "host": "mcp.stripe.com",
+      "kind": "fetched",
+      "components": ["renderer", "server"],
+      "purpose": "Stripe MCP Quick Connect preset.",
+      "requirement": "opt-in",
+      "blockedEffect": "The Stripe MCP connection cannot connect when enabled.",
+      "override": "MCP server URL setting"
+    },
+    {
+      "host": "models.openworklabs.com",
+      "kind": "fetched",
+      "components": ["server"],
+      "purpose": "First-party OpenCode model catalog mirror passed to managed OpenCode as OPENCODE_MODELS_URL.",
+      "requirement": "required-in-practice",
+      "blockedEffect": "The model catalog is unavailable or degraded; model selection may be stale or incomplete.",
+      "override": "OPENCODE_MODELS_URL"
+    },
+    {
+      "host": "oauth2.googleapis.com",
+      "kind": "fetched",
+      "components": ["server"],
+      "purpose": "Google OAuth token exchange, refresh, and revocation for Google Workspace connections.",
+      "requirement": "opt-in",
+      "blockedEffect": "Google Workspace accounts cannot finish OAuth, refresh tokens, or revoke tokens cleanly.",
+      "override": "OPENWORK_GOOGLE_WORKSPACE_TOKEN_BROKER_URL for token exchange/refresh only"
+    },
+    {
+      "host": "objects.githubusercontent.com",
+      "kind": "redirect-target",
+      "components": ["desktop", "installer"],
+      "purpose": "GitHub release-asset download target reached after github.com redirects installer and updater downloads.",
+      "requirement": "required-in-practice",
+      "blockedEffect": "OpenWork downloads start from github.com and then fail partway through when the redirect target is blocked.",
+      "override": null
+    },
+    {
+      "host": "ollama.com",
+      "kind": "link-only",
+      "components": ["renderer"],
+      "purpose": "Ollama download and library links in local model settings.",
+      "requirement": "optional",
+      "blockedEffect": "Users cannot open Ollama download/library links from the settings UI; local Ollama traffic remains loopback.",
+      "override": null
+    },
+    {
+      "host": "opencode.ai",
+      "kind": "fetched",
+      "components": ["desktop", "renderer", "server"],
+      "purpose": "Fallback OpenCode installer command plus OpenCode auth/docs links and config schema identifiers.",
+      "requirement": "optional",
+      "blockedEffect": "Guided fallback OpenCode installation and OpenCode web links fail; packaged builds still use bundled OpenCode.",
+      "override": null
+    },
+    {
+      "host": "openwork.dev",
+      "kind": "link-only",
+      "components": ["renderer"],
+      "purpose": "Documentation and feedback links in the command palette.",
+      "requirement": "optional",
+      "blockedEffect": "Those external support links will not open.",
+      "override": null
+    },
+    {
+      "host": "openworklabs.com",
+      "kind": "link-only",
+      "components": ["desktop", "renderer"],
+      "purpose": "Documentation, feedback, support, and sample OpenWork links.",
+      "requirement": "optional",
+      "blockedEffect": "Documentation or feedback links do not open; core app networking is unaffected.",
+      "override": "VITE_OPENWORK_FEEDBACK_URL for the feedback link only"
+    },
+    {
+      "host": "raw.githubusercontent.com",
+      "kind": "fetched",
+      "components": ["server"],
+      "purpose": "Raw file downloads for GitHub-hosted plugin manifests, MCP configs, skills, commands, and agents.",
+      "requirement": "opt-in",
+      "blockedEffect": "GitHub plugin import can discover metadata but cannot download component contents.",
+      "override": "OPENWORK_GITHUB_RAW_BASE"
+    },
+    {
+      "host": "registry.npmjs.org",
+      "kind": "subprocess",
+      "components": ["desktop", "renderer"],
+      "purpose": "npx package resolution for openwork-ui-mcp and development-only MCP helper commands.",
+      "requirement": "required-in-practice",
+      "blockedEffect": "The OpenWork UI-control MCP is silently unavailable when npx cannot download openwork-ui-mcp.",
+      "override": "npm registry configuration used by npx"
+    },
+    {
+      "host": "schemas.agentskills.io",
+      "kind": "schema-string",
+      "components": ["server"],
+      "purpose": "Skill index $schema identifier used for validation; OpenWork does not fetch the schema URL.",
+      "requirement": "optional",
+      "blockedEffect": "No runtime network effect.",
+      "override": null
+    },
+    {
+      "host": "us.i.posthog.com",
+      "kind": "fetched",
+      "components": ["renderer"],
+      "purpose": "Optional product analytics endpoint when analytics are enabled and a PostHog key is configured.",
+      "requirement": "optional",
+      "blockedEffect": "Analytics events are dropped silently; user-facing app behavior is unaffected.",
+      "override": "VITE_OPENWORK_POSTHOG_HOST; users can disable analytics with the analyticsEnabled preference"
+    },
+    {
+      "host": "www.google.com",
+      "kind": "fetched",
+      "components": ["desktop", "renderer"],
+      "purpose": "Favicon image service and the embedded browser panel's user-created new-tab page.",
+      "requirement": "optional",
+      "blockedEffect": "Favicons may be missing and the browser panel's new tab page may not load.",
+      "override": null
+    },
+    {
+      "host": "www.googleapis.com",
+      "kind": "fetched",
+      "components": ["server"],
+      "purpose": "Google profile, Calendar, and Drive API calls for Google Workspace connections.",
+      "requirement": "opt-in",
+      "blockedEffect": "Google profile, Calendar, and Drive actions fail for connected Google Workspace accounts.",
+      "override": null
+    }
+  ]
+}

--- a/docs/enterprise/outbound-access.md
+++ b/docs/enterprise/outbound-access.md
@@ -10,6 +10,7 @@ For a practical hosted OpenWork desktop install, allow TCP 443 to:
 app.openworklabs.com:443
 api.openworklabs.com:443
 github.com:443
+release-assets.githubusercontent.com:443
 objects.githubusercontent.com:443
 registry.npmjs.org:443
 models.openworklabs.com:443
@@ -17,7 +18,7 @@ models.openworklabs.com:443
 
 Commonly missed entries:
 
-- `objects.githubusercontent.com` is where GitHub release-asset downloads redirect. If only `github.com` is allowed, the OpenWork installer/updater can start and then fail during the download.
+- GitHub release-asset downloads redirect away from `github.com` to a separate download host. If only `github.com` is allowed, the OpenWork installer/updater can start and then fail during the download. Allow both `release-assets.githubusercontent.com` (the host GitHub uses today, verified against a real OpenWork release asset) and `objects.githubusercontent.com` (the earlier host, kept for older clients and any staged rollback).
 - `registry.npmjs.org` is used by `npx -y openwork-ui-mcp` in packaged desktop builds. If it is blocked, the UI-control MCP is unavailable even though the desktop app still opens.
 
 ## Desktop client outbound access
@@ -29,7 +30,8 @@ Commonly missed entries:
 | `app.openworklabs.com` | Required for OpenWork Cloud | Hosted Cloud web origin. The desktop uses one base URL and derives Den API/MCP calls as `<baseUrl>/api/den/...`. | Cloud sign-in, org settings, marketplace, and remote workspace flows cannot load. |
 | `api.openworklabs.com` | Required for hosted install/OpenWork Connect | Hosted public API and OpenWork Connect MCP endpoint used by installer and external-client flows. | Hosted install checks or public OpenWork Connect fail. |
 | `github.com` | Required in practice | Installer/updater release URLs and GitHub links. | Install/update downloads cannot start. |
-| `objects.githubusercontent.com` | Required in practice | GitHub release-asset redirect target. | Downloads start from `github.com` and fail partway through. |
+| `release-assets.githubusercontent.com` | Required in practice | GitHub release-asset redirect target used today. | Downloads start from `github.com` and fail partway through. |
+| `objects.githubusercontent.com` | Required in practice | Earlier GitHub release-asset redirect target, allowed for older clients and staged rollback. | Downloads can fail partway through if GitHub serves this host. |
 | `registry.npmjs.org` | Required in practice | `npx` package resolution for `openwork-ui-mcp`. | UI-control MCP is unavailable. |
 | `models.openworklabs.com` | Required in practice | First-party model catalog mirror, overridable with `OPENCODE_MODELS_URL`. | Model catalog is unavailable or degraded. |
 

--- a/docs/enterprise/outbound-access.md
+++ b/docs/enterprise/outbound-access.md
@@ -1,0 +1,68 @@
+# Outbound network access for OpenWork
+
+This page lists what OpenWork may need to reach from locked-down networks. The machine-readable source is [`outbound-access.json`](./outbound-access.json).
+
+## Minimum allowlist for the hosted desktop
+
+For a practical hosted OpenWork desktop install, allow TCP 443 to:
+
+```text
+app.openworklabs.com:443
+api.openworklabs.com:443
+github.com:443
+objects.githubusercontent.com:443
+registry.npmjs.org:443
+models.openworklabs.com:443
+```
+
+Commonly missed entries:
+
+- `objects.githubusercontent.com` is where GitHub release-asset downloads redirect. If only `github.com` is allowed, the OpenWork installer/updater can start and then fail during the download.
+- `registry.npmjs.org` is used by `npx -y openwork-ui-mcp` in packaged desktop builds. If it is blocked, the UI-control MCP is unavailable even though the desktop app still opens.
+
+## Desktop client outbound access
+
+### Core hosted desktop
+
+| Host | Required or optional | Purpose | What breaks when blocked |
+| --- | --- | --- | --- |
+| `app.openworklabs.com` | Required for OpenWork Cloud | Hosted Cloud web origin. The desktop uses one base URL and derives Den API/MCP calls as `<baseUrl>/api/den/...`. | Cloud sign-in, org settings, marketplace, and remote workspace flows cannot load. |
+| `api.openworklabs.com` | Required for hosted install/OpenWork Connect | Hosted public API and OpenWork Connect MCP endpoint used by installer and external-client flows. | Hosted install checks or public OpenWork Connect fail. |
+| `github.com` | Required in practice | Installer/updater release URLs and GitHub links. | Install/update downloads cannot start. |
+| `objects.githubusercontent.com` | Required in practice | GitHub release-asset redirect target. | Downloads start from `github.com` and fail partway through. |
+| `registry.npmjs.org` | Required in practice | `npx` package resolution for `openwork-ui-mcp`. | UI-control MCP is unavailable. |
+| `models.openworklabs.com` | Required in practice | First-party model catalog mirror, overridable with `OPENCODE_MODELS_URL`. | Model catalog is unavailable or degraded. |
+
+Self-hosted Den replaces `app.openworklabs.com` and `api.openworklabs.com` with your own origin. Current desktop clients need only one Den origin; API and MCP requests are derived from that base URL as `<baseUrl>/api/den/...`.
+
+### Optional desktop links, icons, and analytics
+
+| Host | Required or optional | Purpose | What breaks when blocked |
+| --- | --- | --- | --- |
+| `cdn.simpleicons.org` | Optional | Provider icons. | Some icons are missing. |
+| `www.google.com` | Optional | Favicon image service and browser-panel new tab. | Favicons or the embedded browser new tab may not load. |
+| `us.i.posthog.com` | Optional | Product analytics, only when analytics are enabled. | Analytics are dropped silently. |
+| `openworklabs.com`, `openwork.dev`, `discord.gg`, `ollama.com`, `opencode.ai`, `linear.app`, `mail.google.com`, `code.claude.com` | Optional or opt-in link-only | Docs, feedback, community, provider help, and generated Gmail links. | Links do not open; the core app still runs. |
+
+## Provider and connection access
+
+These are reached only when a user or admin enables that provider, connection, or import path.
+
+| Host | Required or optional | Purpose | What breaks when blocked |
+| --- | --- | --- | --- |
+| `api.openai.com` | Opt-in | Direct OpenAI Realtime voice and image generation with a user-provided OpenAI key. | Those OpenAI features fail. |
+| `accounts.google.com`, `oauth2.googleapis.com`, `www.googleapis.com`, `gmail.googleapis.com`, `chat.googleapis.com` | Opt-in | Google Workspace OAuth plus profile, Calendar, Drive, Gmail, and Chat APIs. | Google Workspace sign-in or actions fail. |
+| `mcp.notion.com`, `mcp.linear.app`, `mcp.sentry.dev`, `mcp.stripe.com`, `mcp.context7.com`, `mcp.slack.com` | Opt-in | Built-in MCP connection presets. | That specific MCP connection cannot connect. |
+| `api.githubcopilot.com` | Opt-in | Example custom remote MCP URL. | Only a user-configured connection to that URL fails. |
+| `api.github.com`, `raw.githubusercontent.com` | Opt-in | Importing GitHub-hosted plugins and skills. | GitHub plugin import cannot inspect or download plugin contents. |
+
+## Self-hosted server (Den) outbound access
+
+Approve Den separately from the desktop client. A Den behind a VPN or in a private cluster uses the server network, not the end-user desktop network.
+
+Hard requirements for self-hosted Den are:
+
+- Your MySQL endpoint, on the port you configured.
+- `ghcr.io` on port 443 at image-pull time, unless you mirror the OpenWork images and Helm chart into your own registry.
+
+Everything else is per-feature. For example, Google Workspace requires the Google hosts above, GitHub plugin import requires `api.github.com` and `raw.githubusercontent.com`, OpenAI features require `api.openai.com`, and MCP presets require their individual `mcp.*` host only when enabled.

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "test:session-switch": "pnpm --filter @openwork/app test:session-switch",
     "test:fs-engine": "pnpm --filter @openwork/app test:fs-engine",
     "test:eval-runner": "pnpm evals:test",
+    "check:outbound-access": "node scripts/check-outbound-access.mjs",
     "test:e2e": "pnpm --filter @openwork/app test:e2e",
     "test:admin-scale": "pnpm --filter @openwork-ee/den-api test:admin-scale",
     "benchmark:admin-scale:mysql": "pnpm --filter @openwork-ee/den-db benchmark:admin-scale:mysql",

--- a/scripts/check-outbound-access.mjs
+++ b/scripts/check-outbound-access.mjs
@@ -1,0 +1,263 @@
+import { readdir, readFile, stat } from "node:fs/promises";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = fileURLToPath(new URL("../", import.meta.url));
+const manifestPath = path.join(repoRoot, "docs/enterprise/outbound-access.json");
+const docsPath = "docs/enterprise/outbound-access.md";
+
+const scanRoots = [
+  "apps/desktop/electron",
+  "apps/installer/src",
+  "apps/server/src",
+  "apps/app/src",
+  "packages/openwork-bootstrap/bin",
+];
+
+const requiredFields = ["host", "kind", "components", "purpose", "requirement", "blockedEffect", "override"];
+const allowedKinds = new Set(["fetched", "redirect-target", "subprocess", "link-only", "schema-string"]);
+const allowedRequirements = new Set(["required", "required-for-cloud", "required-in-practice", "optional", "opt-in"]);
+const urlHostPattern = /https:\/\/([A-Za-z0-9.-]+)(?::\d+)?(?=$|[\/?#"'`<>\s)\]},;$])/g;
+
+function toRepoPath(filePath) {
+  return path.relative(repoRoot, filePath).split(path.sep).join("/");
+}
+
+function isTestFile(filePath) {
+  const parts = filePath.split(path.sep);
+  return parts.includes("__tests__") || path.basename(filePath).includes(".test.");
+}
+
+function ignoredHostReason(host) {
+  const value = host.toLowerCase();
+
+  if (!/[a-z0-9]/.test(value)) {
+    return "placeholder hostname";
+  }
+
+  // RFC 2606 / reserved documentation names: these are examples, not real
+  // customer allowlist requirements. This covers example.com/net/org and their
+  // subdomains, example.* placeholders, and the reserved .example/.invalid/.test
+  // suffixes used in docs and fixtures.
+  if (
+    value === "example.com" ||
+    value === "example.net" ||
+    value === "example.org" ||
+    value.endsWith(".example.com") ||
+    value.endsWith(".example.net") ||
+    value.endsWith(".example.org") ||
+    value.startsWith("example.") ||
+    value.endsWith(".example") ||
+    value === "invalid" ||
+    value.endsWith(".invalid") ||
+    value === "test" ||
+    value.endsWith(".test")
+  ) {
+    return "reserved documentation hostname";
+  }
+
+  // Local development and loopback URLs are intentionally not customer network
+  // destinations.
+  if (value === "localhost" || value.endsWith(".localhost") || value === "127.0.0.1" || value.startsWith("127.")) {
+    return "loopback/local development hostname";
+  }
+
+  // Standards/schema identifiers appear in manifests and XML/JSON metadata but
+  // are not fetched by OpenWork at runtime.
+  if (
+    value === "w3.org" ||
+    value.endsWith(".w3.org") ||
+    value === "json-schema.org" ||
+    value.endsWith(".json-schema.org") ||
+    value === "schema.org" ||
+    value.endsWith(".schema.org") ||
+    value === "openxmlformats.org" ||
+    value.endsWith(".openxmlformats.org")
+  ) {
+    return "standards/schema identifier hostname";
+  }
+
+  // Placeholder used in customer-facing self-hosted examples.
+  if (value === "openwork.yourcompany.com") {
+    return "customer placeholder hostname";
+  }
+
+  return null;
+}
+
+async function listFiles(root) {
+  const entries = await readdir(root, { withFileTypes: true });
+  const files = [];
+  for (const entry of entries) {
+    const fullPath = path.join(root, entry.name);
+    if (isTestFile(fullPath)) continue;
+    if (entry.isDirectory()) {
+      files.push(...await listFiles(fullPath));
+      continue;
+    }
+    if (entry.isFile()) files.push(fullPath);
+  }
+  return files;
+}
+
+function lineNumberForIndex(content, index) {
+  let line = 1;
+  for (let cursor = 0; cursor < index; cursor += 1) {
+    if (content.charCodeAt(cursor) === 10) line += 1;
+  }
+  return line;
+}
+
+async function scanHosts() {
+  const observed = new Map();
+  const ignored = [];
+
+  for (const root of scanRoots) {
+    const rootPath = path.join(repoRoot, root);
+    const info = await stat(rootPath);
+    if (!info.isDirectory()) throw new Error(`Scan root is not a directory: ${root}`);
+
+    const files = await listFiles(rootPath);
+    files.sort((left, right) => toRepoPath(left).localeCompare(toRepoPath(right)));
+    for (const file of files) {
+      const content = await readFile(file, "utf8");
+      for (const match of content.matchAll(urlHostPattern)) {
+        const host = match[1]?.toLowerCase().replace(/\.$/, "") ?? "";
+        if (!host) continue;
+        const occurrence = { file: toRepoPath(file), line: lineNumberForIndex(content, match.index ?? 0) };
+        const reason = ignoredHostReason(host);
+        if (reason) {
+          ignored.push({ host, ...occurrence, reason });
+          continue;
+        }
+        const existing = observed.get(host) ?? [];
+        existing.push(occurrence);
+        observed.set(host, existing);
+      }
+    }
+  }
+
+  return { observed, ignored };
+}
+
+async function readManifest() {
+  const errors = [];
+  let parsed;
+  try {
+    parsed = JSON.parse(await readFile(manifestPath, "utf8"));
+  } catch (error) {
+    errors.push(`Could not parse docs/enterprise/outbound-access.json: ${error instanceof Error ? error.message : String(error)}`);
+    return { hosts: new Map(), errors };
+  }
+
+  if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+    errors.push("docs/enterprise/outbound-access.json must contain an object.");
+    return { hosts: new Map(), errors };
+  }
+  if (!Array.isArray(parsed.hosts)) {
+    errors.push("docs/enterprise/outbound-access.json must contain a hosts array.");
+    return { hosts: new Map(), errors };
+  }
+
+  const hosts = new Map();
+  parsed.hosts.forEach((entry, index) => {
+    const label = `hosts[${index}]`;
+    if (!entry || typeof entry !== "object" || Array.isArray(entry)) {
+      errors.push(`${label} must be an object.`);
+      return;
+    }
+
+    for (const field of requiredFields) {
+      if (!Object.hasOwn(entry, field)) errors.push(`${label} is missing required field "${field}".`);
+    }
+
+    const host = typeof entry.host === "string" ? entry.host.trim().toLowerCase() : "";
+    if (!host) errors.push(`${label}.host must be a non-empty string.`);
+    if (host.includes("://") || host.includes("/")) errors.push(`${label}.host must be a hostname, not a URL: ${entry.host}`);
+    if (host && hosts.has(host)) errors.push(`Duplicate host in manifest: ${host}`);
+
+    if (typeof entry.kind !== "string" || !allowedKinds.has(entry.kind)) {
+      errors.push(`${label}.kind must be one of: ${[...allowedKinds].join(", ")}.`);
+    }
+    if (typeof entry.requirement !== "string" || !allowedRequirements.has(entry.requirement)) {
+      errors.push(`${label}.requirement must be one of: ${[...allowedRequirements].join(", ")}.`);
+    }
+    if (!Array.isArray(entry.components) || entry.components.length === 0 || entry.components.some((component) => typeof component !== "string" || !component.trim())) {
+      errors.push(`${label}.components must be a non-empty array of strings.`);
+    }
+    if (typeof entry.purpose !== "string" || !entry.purpose.trim()) errors.push(`${label}.purpose must be a non-empty string.`);
+    if (typeof entry.blockedEffect !== "string" || !entry.blockedEffect.trim()) errors.push(`${label}.blockedEffect must be a non-empty string.`);
+    if (entry.override !== null && typeof entry.override !== "string") errors.push(`${label}.override must be a string or null.`);
+
+    if (host) hosts.set(host, entry);
+  });
+
+  return { hosts, errors };
+}
+
+function buildReport(manifest, scan) {
+  const missing = [];
+  const stale = [];
+
+  for (const [host, occurrences] of scan.observed.entries()) {
+    if (!manifest.hosts.has(host)) missing.push({ host, occurrences });
+  }
+
+  for (const [host, entry] of manifest.hosts.entries()) {
+    if (entry.kind === "fetched" && !scan.observed.has(host)) stale.push({ host });
+  }
+
+  missing.sort((left, right) => left.host.localeCompare(right.host));
+  stale.sort((left, right) => left.host.localeCompare(right.host));
+
+  return {
+    ok: manifest.errors.length === 0 && missing.length === 0 && stale.length === 0,
+    manifestErrors: manifest.errors,
+    missing,
+    stale,
+    observedHosts: [...scan.observed.keys()].sort(),
+    manifestHosts: [...manifest.hosts.keys()].sort(),
+    ignored: scan.ignored,
+  };
+}
+
+function printText(report) {
+  if (report.ok) {
+    console.log(`Outbound access manifest covers ${report.manifestHosts.length} hosts. Scanned ${report.observedHosts.length} external hosts from shipped client surfaces. No stale fetched entries.`);
+    return;
+  }
+
+  const lines = ["Outbound access manifest check failed."];
+  for (const error of report.manifestErrors) lines.push(`- ${error}`);
+  for (const item of report.missing) {
+    const first = item.occurrences[0];
+    lines.push(`- Host ${item.host} is used in ${first.file}:${first.line} but is missing from docs/enterprise/outbound-access.json. Add it to docs/enterprise/outbound-access.json (see ${docsPath}).`);
+  }
+  for (const item of report.stale) {
+    lines.push(`- Manifest host ${item.host} has kind "fetched" but no https://${item.host} literal was found in the scan roots. Remove it from docs/enterprise/outbound-access.json or update its kind (see ${docsPath}).`);
+  }
+  console.error(lines.join("\n"));
+}
+
+function printJson(report) {
+  const jsonReport = {
+    ok: report.ok,
+    manifestErrors: report.manifestErrors,
+    missingHosts: report.missing.map((item) => ({ host: item.host, occurrences: item.occurrences })),
+    staleFetchedHosts: report.stale.map((item) => item.host),
+    observedHosts: report.observedHosts,
+    manifestHosts: report.manifestHosts,
+    ignoredHosts: report.ignored,
+  };
+  process.stdout.write(`${JSON.stringify(jsonReport, null, 2)}\n`);
+}
+
+const json = process.argv.includes("--json");
+const manifest = await readManifest();
+const scan = await scanHosts();
+const report = buildReport(manifest, scan);
+
+if (json) printJson(report);
+else printText(report);
+
+if (!report.ok) process.exitCode = 1;


### PR DESCRIPTION
## Why

Enterprise customers run OpenWork on networks where all outbound connections are blocked by default and IT approves each destination individually. Nothing in this repo listed what OpenWork needs to reach — so every deployment rediscovered it by hitting failures.

Two destinations were named **nowhere in the repo**, and both produce confusing symptoms:

| Host | Why it is needed | Symptom when only the obvious host is approved |
|---|---|---|
| `objects.githubusercontent.com` | Redirect target of every GitHub release-asset download (`redirect: "follow"`) | IT approves `github.com`; the download **starts and then dies partway through** |
| `registry.npmjs.org` | `npx -y openwork-ui-mcp` on the packaged desktop path | UI-control MCP is **silently unavailable** while the app otherwise opens normally |

## What this adds

**`docs/enterprise/outbound-access.md`** — written for customer IT and non-technical admins. Deliberately avoids the word "egress". Leads with a copy-pasteable minimum allowlist, then tables with purpose / required-or-optional / **what breaks when blocked**.

Desktop client access is documented **separately** from self-hosted Den access, because different teams approve them on different networks. It also records that self-hosted Den replaces the hosted origins and that the desktop needs only **one** origin (API and MCP are derived as `<baseUrl>/api/den/...`), and that Den's only hard requirements are its MySQL endpoint plus `ghcr.io` at image-pull time — everything else is per-feature.

**`docs/enterprise/outbound-access.json`** — machine-readable, 34 hosts:

| kind | count | | requirement | count |
|---|---|---|---|---|
| `fetched` | 23 | | `opt-in` | 16 |
| `link-only` | 7 | | `optional` | 11 |
| `subprocess` | 2 | | `required-in-practice` | 4 |
| `redirect-target` | 1 | | `required-for-cloud` | 2 |
| `schema-string` | 1 | | `required` | 1 |

The `kind` field is what lets indirectly-reached destinations be documented at all — a redirect target and an `npx` subprocess have no URL literal to find in the code.

**`scripts/check-outbound-access.mjs`** + a `ci-tests.yml` step — scans the shipped client surfaces (`apps/desktop/electron`, `apps/installer/src`, `apps/server/src`, `apps/app/src`, `packages/openwork-bootstrap/bin`) and fails when a hostname appears in code but not in the manifest. So a feature PR that introduces a new destination must document its enterprise impact. It also flags `fetched` entries whose host no longer exists in code, so the list cannot rot in either direction. RFC 2606 documentation names, loopback, and standards/schema hosts are ignored with a documented reason in the script.

## Classifications corrected while verifying

Every row was checked against a real call site rather than assumed. Corrections:

- `api.githubcopilot.com` — not a provider call path; an example custom MCP URL placeholder (`apps/app/src/i18n/locales/en.ts:803`).
- `ollama.com` — link-only help text (`ollama-config.tsx:312`); actual Ollama traffic is loopback `http://localhost:11434/v1`.
- `code.claude.com` — source comment only (`apps/server/src/claude-plugin-bundle.ts:11`), no runtime call.
- `linear.app` — demo transcript sample link (`session-surface.tsx:168`), not a fetch.
- `mail.google.com` — link-only Gmail draft/thread URLs emitted as output (`google-workspace.ts:925,929`).
- `schemas.agentskills.io` — schema identifier string, never fetched (`connect-skill-catalog.ts:11,15`).
- `registry.npmjs.org` — also covers the dev-only `npx -y @openwork/handsfree mcp` fallback (`computer-use.mjs:50`).
- Added `ghcr.io` for the self-hosted image/chart pull requirement (`values.yaml:184,212,241`).

## Compatibility

**No breaking changes for self-hosted deployments.** No product code, configuration, environment variable, API, Helm chart, or database surface is touched. This is documentation, one check script, one CI step, one `package.json` script.

One operational note for maintainers: because the check now runs in `ci-tests.yml`, an open PR that introduces a new outbound destination will fail until it adds a manifest line. That is the intended forcing function.

## Tests run

\`\`\`
node scripts/check-outbound-access.mjs
# Outbound access manifest covers 34 hosts. Scanned 31 external hosts from
# shipped client surfaces. No stale fetched entries.

pnpm check:outbound-access          # pass
node scripts/check-outbound-access.mjs --json   # valid JSON, ok: true
\`\`\`

**Negative controls**, run in three different files so the scan surface is genuinely covered:

Injected `https://collector.acme-telemetry.io/v1` into `apps/app/src/app/lib/desktop.ts`:
\`\`\`
Outbound access manifest check failed.
- Host collector.acme-telemetry.io is used in apps/app/src/app/lib/desktop.ts:601
  but is missing from docs/enterprise/outbound-access.json. Add it to
  docs/enterprise/outbound-access.json (see docs/enterprise/outbound-access.md).
exit=1
\`\`\`

Injected a fake host into `apps/installer/src/release-asset.ts` → caught. Deleted the `models.openworklabs.com` manifest entry → caught at `apps/server/src/opencode-models-url.ts:2`. Added a fake `kind: "fetched"` entry with no code literal → correctly reported as stale:
\`\`\`
- Manifest host stale-host.openworklabs.com has kind "fetched" but no
  https://stale-host.openworklabs.com literal was found in the scan roots.
\`\`\`

## Fraimz

Skipped, stated explicitly per AGENTS.md: documentation plus a CI check script, no runtime path changed. The executable proof is the four controls above.