### PR TITLE
docs(self-host): make the cloud catalog diagnostic actionable on-prem

### DIFF
--- a/apps/server/src/agent-context-cloud-probe.test.ts
+++ b/apps/server/src/agent-context-cloud-probe.test.ts
@@ -264,6 +264,26 @@ describe("OpenWork Cloud catalog probe", () => {
   });
 
   test("allows exact loopback and explicitly configured HTTPS origins only", async () => {
+    let blockedCalls = 0;
+    const blocked = await probeOpenworkCloudCatalog(input({
+      config: {
+        type: "remote",
+        enabled: true,
+        url: "https://den.customer.example/custom/mcp/agent",
+        headers: { Authorization: TOKEN },
+      },
+      requestId: "untrusted-self-hosted-request",
+      fetchImpl: async () => {
+        blockedCalls += 1;
+        return jsonResponse("untrusted-self-hosted-request");
+      },
+    }));
+    expect(blocked).toMatchObject({
+      performed: false,
+      code: "untrusted_endpoint",
+    });
+    expect(blockedCalls).toBe(0);
+
     const loopback = await probeOpenworkCloudCatalog(input({
       config: {
         type: "remote",

--- a/apps/server/src/agent-context-diagnostics.test.ts
+++ b/apps/server/src/agent-context-diagnostics.test.ts
@@ -833,6 +833,41 @@ describe("agent context diagnostics analyzer", () => {
     });
   });
 
+  test("names the trusted-origins environment variable for untrusted cloud endpoints", async () => {
+    const runtime = diagnosticRuntimeConfig();
+    if (!runtime.mcp) throw new Error("Expected the diagnostics MCP fixture.");
+    runtime.mcp["openwork-cloud"] = {
+      ...cloudConfig(),
+      url: "https://den.customer.example/custom/mcp/agent",
+    };
+    const fixture = await createFixture({ runtime });
+    const fetchCalls: CatalogFetchCall[] = [];
+
+    const report = agentContextDiagnosticsReportSchema.parse(await runAgentContextDiagnostics({
+      config: fixture.config,
+      workspace: fixture.workspace,
+      request: emptyObservedRequest,
+      inspectRegistration: () => "connected",
+      dependencies: {
+        fetchImpl: catalogFetch(["search_capabilities", "execute_capability"], fetchCalls),
+        inspectEffectiveEngine: effectiveEngineInspection(runtime),
+      },
+    }));
+
+    const check = checkById(report, "cloud-tool-catalog");
+    expect(check).toMatchObject({
+      status: "failed",
+      evidenceKind: "derived",
+      code: "untrusted_endpoint",
+      owner: "openwork-server",
+      message: "The server did not send the credentialed cloud catalog request because the Cloud endpoint origin is not in the diagnostics trust list.",
+      details: { requestPerformed: false },
+    });
+    expect(check.action).toBe("Set OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS on the OpenWork desktop/server process to include the Cloud endpoint origin, then rerun diagnostics.");
+    expect(check.action).toContain("OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS");
+    expect(fetchCalls).toEqual([]);
+  });
+
   test("fails closed when the effective engine response is invalid or unavailable", async () => {
     const fixture = await createFixture();
     const fetchCalls: CatalogFetchCall[] = [];

--- a/apps/server/src/agent-context-diagnostics.ts
+++ b/apps/server/src/agent-context-diagnostics.ts
@@ -513,8 +513,8 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
       action = "Reconnect OpenWork Cloud to restore its managed endpoint, then rerun diagnostics.";
       break;
     case "untrusted_endpoint":
-      message = "The managed OpenWork Cloud endpoint is outside the server's diagnostics trust policy.";
-      action = "Use the hosted OpenWork Cloud endpoint or have the server administrator explicitly trust the development origin.";
+      message = "The server did not send the credentialed cloud catalog request because the Cloud endpoint origin is not in the diagnostics trust list.";
+      action = "Set OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS on the OpenWork desktop/server process to include the Cloud endpoint origin, then rerun diagnostics.";
       break;
     case "credential_missing":
     case "duplicate_authorization":

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -45,6 +45,33 @@ service. Leaving the value empty preserves the default Node.js behavior.
 Existing deployments using `denApi.env.NODE_OPTIONS` can keep that setting when
 upgrading; it takes precedence over `config.denApiNodeOptions`.
 
+### Trust self-hosted Cloud catalog diagnostics
+
+Settings > Debug includes a cloud catalog diagnostic that runs a bounded
+`initialize` → `tools/list` check against the managed `openwork-cloud` MCP entry
+and verifies that Cloud exposes exactly `search_capabilities` and
+`execute_capability`. The request carries an organization MCP bearer token, so
+self-hosted Den origins are skipped unless the OpenWork desktop/server process
+explicitly trusts that origin for diagnostics.
+
+Set `OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS` on the OpenWork desktop/server
+process to add your Den origin to the hosted defaults:
+
+```bash
+OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS=https://openwork.example.com
+```
+
+The value is a comma-separated list of bare origins. Each entry must be only the
+scheme, host, and optional port: no path, query, fragment, username, or
+password. Entries must use `https:`; loopback origins may use `http:`. Invalid
+entries are ignored instead of failing open, and valid entries are added to the
+hosted defaults rather than replacing them.
+
+If you do not set this, the cloud catalog check reports that the endpoint is
+outside the diagnostics trust list and no credentialed request is made. The
+diagnostic probe is skipped rather than attempted and failed, and Cloud MCP
+itself is unaffected; this variable only enables the diagnostic probe.
+
 If you want self-hosted repository imports and sync from GitHub, configure the [GitHub connector for Helm](/start-here/github-connector-helm) after the core Den web and Den controller hosts are reachable.
 
 To keep organization names, wordmarks, and desktop icons entirely inside your deployment, follow [Brand an on-prem deployment](/start-here/on-prem-branding).


### PR DESCRIPTION
## The problem

Settings → Debug runs a **cloud catalog** check: a bounded `initialize` → `tools/list` against the managed `openwork-cloud` MCP entry, asserting Cloud exposes exactly `search_capabilities` + `execute_capability`. It is the single most useful "is Cloud MCP actually working" signal we have.

It carries an organization MCP bearer token, so `agent-context-cloud-probe.ts` refuses to send that credential to an origin outside a trust list. `DEFAULT_TRUSTED_ORIGINS` contains only:

```
https://app.openworklabs.com
https://api.openworklabs.com
```

**So on every self-hosted deployment the endpoint origin is the customer's own Den, `prepare()` returns `untrusted_endpoint`, and the probe never runs.** The diagnostic is dead for on-prem.

There is an escape hatch — `OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS` — which appeared in **exactly two places in the entire repo**: its own source file and its own test. No documentation anywhere. And the guidance the operator actually saw was:

> Use the hosted OpenWork Cloud endpoint or have the server administrator explicitly trust the development origin.

That calls a production on-prem Den a *development origin* and never names the variable. An operator cannot act on it.

## What this changes

**Two string literals and a docs section. That is the entire code diff.**

| | Before | After |
|---|---|---|
| message | The managed OpenWork Cloud endpoint is outside the server's diagnostics trust policy. | The server did not send the credentialed cloud catalog request because the Cloud endpoint origin is not in the diagnostics trust list. |
| action | Use the hosted OpenWork Cloud endpoint or have the server administrator explicitly trust the development origin. | Set `OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS` on the OpenWork desktop/server process to include the Cloud endpoint origin, then rerun diagnostics. |

Plus a `### Trust self-hosted Cloud catalog diagnostics` section in `packages/docs/start-here/self-host.mdx` documenting the real format rules enforced by `configuredTrustedOrigins()`: comma-separated bare origins; scheme + host + optional port only, no path/query/fragment/credentials; `https:` required except loopback; **invalid entries are ignored rather than failing open**; entries are **added to** the hosted defaults, not replacing them.

The docs state explicitly that this variable enables **the diagnostic only** and that **Cloud MCP itself works without it** — so operators do not read a skipped probe as a broken deployment.

## Compatibility

**Cannot break an existing self-hosted deployment.** `apps/server/src/agent-context-cloud-probe.ts` is **untouched** — verified with `git diff --stat`, empty. Which origins are trusted is therefore provably identical before and after. `DEFAULT_TRUSTED_ORIGINS`, `safeCatalogEndpoint`, the loopback rule, and `configuredTrustedOrigins()` parsing are all unchanged. Nothing was added to `PERSISTABLE_INTERNAL_KEYS`.

### Why I did not "fix" the trust model

The obvious-looking fix — trust the configured Den origin — is **circular and unsafe**. The probe exists to validate the runtime MCP config; deriving trust from that same config would let a tampered config exfiltrate the org MCP bearer token to an attacker origin. The file makes this philosophy explicit elsewhere: *"Absence of a deny in passively inspected config is never authority to send a credentialed request."*

Doing it properly needs an **independent** source of truth for the operator-provisioned Den origin. `apps/server` has none today — the only candidate is the desktop bootstrap config, which lives in the renderer and would require a diagnostics request-schema change across client and server. That is a security-model decision for a maintainer, not something to slip into a backward-compatibility-sensitive PR. Flagged as a follow-up below.

## Tests

\`\`\`
pnpm --filter openwork-server test    # 521 pass, 10 skip, 0 fail, 2827 expect() calls, 531 tests / 75 files
pnpm typecheck                        # pass
\`\`\`

Coverage added — note both tests pin the **no-credentialed-request** property, not just the string:

- `agent-context-cloud-probe.test.ts`: an unlisted self-hosted origin returns `untrusted_endpoint` **and** `blockedCalls === 0`, proving no request leaves the process. (Acceptance when the variable *is* set was already covered; I extended that test rather than duplicating it.)
- `agent-context-diagnostics.test.ts`: the report's `action` must keep naming `OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS`, **and** `fetchCalls` is empty. This stops the guidance regressing to something unactionable.

Report-safety respected: both strings are static, well under the bounded-text limit, and interpolate no endpoint, credential, org id, or host.

## Follow-ups (reported, deliberately not fixed)

1. **The variable cannot be set from inside the app.** `apps/desktop/electron/runtime.mjs:470-485` strips all `OPENWORK_*` keys from the Settings → Environment store when building the sidecar child env, and `apps/server/src/env-file.ts:22-28,205-206` rejects non-persistable `OPENWORK_*` keys. It must be set in the process environment *before* OpenWork launches (`runtime.mjs:764-772` overlays real `process.env`, so pre-set values survive). Fixing this means touching a reserved-key policy that is mirrored across three files under a documented "must agree byte-for-byte" contract — out of scope here.

2. **Should a provisioned Den origin be trusted automatically?** Needs a maintainer decision on the threat model plus a diagnostics request-schema change. Worth doing; not safe to decide unilaterally.

## Fraimz

Skipped, stated explicitly per AGENTS.md. No runtime path changes — the observable surface is two operator-facing strings in a diagnostics report, which are asserted directly by the new unit test above.