### PR TITLE
docs(helm): expose the private-network MCP opt-out to operators

### DIFF
--- a/ee/apps/den-api/.env.example
+++ b/ee/apps/den-api/.env.example
@@ -28,6 +28,10 @@ DEN_MARKETING_URL=http://localhost:3005
 DEN_MCP_RESOURCE_URL=http://localhost:8790/mcp
 # Extra public MCP resource URLs beyond the DEN_API_PUBLIC_URL API origin and web-app defaults.
 DEN_MCP_ADDITIONAL_RESOURCES=
+# Leave unset on hosted/multi-tenant deployments. Set to 1 only when Den runs
+# inside a private network and your MCP servers are on private addresses.
+# OPENWORK_DEV_MODE=1 already exempts local dev.
+DEN_ALLOW_PRIVATE_MCP_URLS=
 # Optional operator-owned override for the Org settings egress diagnostic.
 # The browser can never change it; the default is https://diagnostic.openworklabs.com.
 DEN_DIAGNOSTICS_ORIGIN=https://diagnostic.openworklabs.com

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -648,6 +648,28 @@ config:
 
 Local sign-in lockout protections stay enabled either way.
 
+Den API also protects External MCP connection URLs with an SSRF guard. On a
+hosted multi-tenant deployment, someone who can add an MCP connection could
+otherwise make Den fetch localhost, private-network services, or cloud metadata
+addresses from Den's network position.
+
+If a legitimate internal MCP server is blocked in an isolated private-network
+deployment, the diagnostic code is `MCP_URL_BLOCKED` and the operator-facing
+message is: "Use a public HTTPS MCP URL or change the deployment's
+private-network policy through security review."
+
+To allow private-address MCP servers for Den API, enable:
+
+```yaml
+config:
+  public:
+    allowPrivateMcpUrls: "1"
+```
+
+This disables SSRF protection for external MCP connection URLs. Enable it only
+on a deployment where Den's network position and the set of people who can add
+MCP connections are both trusted.
+
 ## Migrations
 
 The migration Job runs as a Helm `pre-install,pre-upgrade` hook by default:

--- a/packaging/helm/openwork-ee/templates/_helpers.tpl
+++ b/packaging/helm/openwork-ee/templates/_helpers.tpl
@@ -45,6 +45,16 @@ app.kubernetes.io/component: {{ .component }}
 {{ include "openwork-ee.fullname" . }}-config
 {{- end -}}
 
+{{- define "openwork-ee.allowPrivateMcpUrls" -}}
+{{- $value := .Values.config.public.allowPrivateMcpUrls | default "" | toString | trim | lower -}}
+{{- if eq $value "1" -}}
+1
+{{- else if or (eq $value "") (eq $value "0") (eq $value "false") -}}
+{{- else -}}
+{{- fail "config.public.allowPrivateMcpUrls must be blank, 0, false, or \"1\"" -}}
+{{- end -}}
+{{- end -}}
+
 {{- define "openwork-ee.secretName" -}}
 {{- if .Values.secret.existingSecret -}}
 {{- .Values.secret.existingSecret -}}

--- a/packaging/helm/openwork-ee/templates/den-api.yaml
+++ b/packaging/helm/openwork-ee/templates/den-api.yaml
@@ -120,6 +120,10 @@ spec:
             {{- if .Values.customCa.enabled }}
             {{- include "openwork-ee.customCa.env" . | nindent 12 }}
             {{- end }}
+            {{- if eq (include "openwork-ee.allowPrivateMcpUrls" .) "1" }}
+            - name: DEN_ALLOW_PRIVATE_MCP_URLS
+              value: "1"
+            {{- end }}
             {{- include "openwork-ee.observabilityEnv" (dict "root" . "serviceName" .Values.observability.serviceNames.denApi) | nindent 12 }}
             {{- range $key, $value := .Values.denApi.env }}
             - name: {{ $key }}

--- a/packaging/helm/openwork-ee/tests/private-mcp-urls.sh
+++ b/packaging/helm/openwork-ee/tests/private-mcp-urls.sh
@@ -1,0 +1,173 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assert_count() {
+  local file="$1"
+  local needle="$2"
+  local expected="$3"
+  local count
+  count="$(grep -F -c -- "$needle" "$file" || true)"
+  if [[ "$count" != "$expected" ]]; then
+    printf 'Expected %s occurrences of %s, found %s\n' "$expected" "$needle" "$count" >&2
+    return 1
+  fi
+}
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart not to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+assert_failure() {
+  local values_file="$1"
+  local expected="$2"
+  local output_file="$tmp_dir/failure-output.yaml"
+  local error_file="$tmp_dir/failure-error.txt"
+
+  if helm template openwork-ee "$chart_dir" -f "$values_file" > "$output_file" 2> "$error_file"; then
+    printf 'Expected helm template to fail for %s\n' "$values_file" >&2
+    return 1
+  fi
+  assert_contains "$error_file" "$expected"
+}
+
+assert_source_contains() {
+  local file="$1"
+  local source="$2"
+  local needle="$3"
+  local in_source=0
+  local found=0
+  local line
+
+  while IFS= read -r line; do
+    if [[ "$line" == '# Source: openwork-ee/templates/'* ]]; then
+      if [[ "$line" == "# Source: openwork-ee/templates/$source" ]]; then
+        in_source=1
+      else
+        in_source=0
+      fi
+    fi
+    if [[ "$in_source" == 1 && "$line" == *"$needle"* ]]; then
+      found=1
+      break
+    fi
+  done < "$file"
+
+  if [[ "$found" != 1 ]]; then
+    printf 'Expected %s to contain %s\n' "$source" "$needle" >&2
+    return 1
+  fi
+}
+
+assert_source_not_contains() {
+  local file="$1"
+  local source="$2"
+  local needle="$3"
+  local in_source=0
+  local line
+
+  while IFS= read -r line; do
+    if [[ "$line" == '# Source: openwork-ee/templates/'* ]]; then
+      if [[ "$line" == "# Source: openwork-ee/templates/$source" ]]; then
+        in_source=1
+      else
+        in_source=0
+      fi
+    fi
+    if [[ "$in_source" == 1 && "$line" == *"$needle"* ]]; then
+      printf 'Expected %s not to contain %s\n' "$source" "$needle" >&2
+      return 1
+    fi
+  done < "$file"
+}
+
+default_rendered="$tmp_dir/default.yaml"
+helm template openwork-ee "$chart_dir" > "$default_rendered"
+assert_count "$default_rendered" 'DEN_ALLOW_PRIVATE_MCP_URLS' 0
+assert_not_contains "$default_rendered" 'openwork-ee-den-api-private-mcp-urls'
+
+enabled_values="$tmp_dir/enabled-values.yaml"
+enabled_rendered="$tmp_dir/enabled.yaml"
+cat > "$enabled_values" <<'YAML'
+inference:
+  enabled: true
+config:
+  public:
+    allowPrivateMcpUrls: "1"
+YAML
+helm template openwork-ee "$chart_dir" -f "$enabled_values" > "$enabled_rendered"
+assert_count "$enabled_rendered" 'DEN_ALLOW_PRIVATE_MCP_URLS' 1
+assert_count "$enabled_rendered" 'name: DEN_ALLOW_PRIVATE_MCP_URLS' 1
+assert_count "$enabled_rendered" 'value: "1"' 1
+assert_not_contains "$enabled_rendered" 'key: DEN_ALLOW_PRIVATE_MCP_URLS'
+assert_not_contains "$enabled_rendered" 'configMapKeyRef:'
+assert_not_contains "$enabled_rendered" 'openwork-ee-den-api-private-mcp-urls'
+assert_source_contains "$enabled_rendered" 'den-api.yaml' 'name: DEN_ALLOW_PRIVATE_MCP_URLS'
+assert_source_contains "$enabled_rendered" 'den-api.yaml' 'value: "1"'
+assert_source_not_contains "$enabled_rendered" 'den-web.yaml' 'DEN_ALLOW_PRIVATE_MCP_URLS'
+assert_source_not_contains "$enabled_rendered" 'inference.yaml' 'DEN_ALLOW_PRIVATE_MCP_URLS'
+
+disabled_values="$tmp_dir/disabled-values.yaml"
+disabled_rendered="$tmp_dir/disabled.yaml"
+cat > "$disabled_values" <<'YAML'
+config:
+  public:
+    allowPrivateMcpUrls: "0"
+YAML
+helm template openwork-ee "$chart_dir" -f "$disabled_values" > "$disabled_rendered"
+assert_count "$disabled_rendered" 'DEN_ALLOW_PRIVATE_MCP_URLS' 0
+
+false_values="$tmp_dir/false-values.yaml"
+false_rendered="$tmp_dir/false.yaml"
+cat > "$false_values" <<'YAML'
+config:
+  public:
+    allowPrivateMcpUrls: "false"
+YAML
+helm template openwork-ee "$chart_dir" -f "$false_values" > "$false_rendered"
+assert_count "$false_rendered" 'DEN_ALLOW_PRIVATE_MCP_URLS' 0
+
+blank_values="$tmp_dir/blank-values.yaml"
+blank_rendered="$tmp_dir/blank.yaml"
+cat > "$blank_values" <<'YAML'
+config:
+  public:
+    allowPrivateMcpUrls: ""
+YAML
+helm template openwork-ee "$chart_dir" -f "$blank_values" > "$blank_rendered"
+assert_count "$blank_rendered" 'DEN_ALLOW_PRIVATE_MCP_URLS' 0
+
+invalid_true_values="$tmp_dir/invalid-true-values.yaml"
+cat > "$invalid_true_values" <<'YAML'
+config:
+  public:
+    allowPrivateMcpUrls: "true"
+YAML
+assert_failure "$invalid_true_values" 'config.public.allowPrivateMcpUrls must be blank, 0, false, or "1"'
+
+invalid_yes_values="$tmp_dir/invalid-yes-values.yaml"
+cat > "$invalid_yes_values" <<'YAML'
+config:
+  public:
+    allowPrivateMcpUrls: "yes"
+YAML
+assert_failure "$invalid_yes_values" 'config.public.allowPrivateMcpUrls must be blank, 0, false, or "1"'
+
+printf 'private-mcp-urls chart checks passed\n'

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -29,6 +29,9 @@ config:
     apiOrigin: https://api.openwork.example.com
     mcpResourceUrl: https://api.openwork.example.com/mcp
     mcpAdditionalResources: ""
+    # Leave blank to keep External MCP URL SSRF protection enabled.
+    # Set "1" only for trusted private-network MCP servers.
+    allowPrivateMcpUrls: ""
     mcpClaimNamespace: ""
     desktopDenBaseUrl: https://openwork.example.com
     corsOrigins: https://openwork.example.com,https://api.openwork.example.com


### PR DESCRIPTION
## The problem

Den's SSRF guard (`ee/apps/den-api/src/capability-sources/url-guard.ts`) refuses to fetch private/reserved addresses on behalf of users. On hosted multi-tenant Den that is correct and must stay.

But a very common enterprise topology is: **Den runs inside the customer's private network, and their MCP servers live on private IPs.** There the guard blocks every internal MCP server by default. The operator sees `MCP_URL_BLOCKED` and:

> Use a public HTTPS MCP URL or change the deployment's private-network policy through security review.

`ee/apps/den-api/src/env.ts:352-359` has provided the opt-out all along:

```ts
const allowPrivateMcpUrls = devMode || (parsed.DEN_ALLOW_PRIVATE_MCP_URLS ?? "0").trim() === "1"
```

**But `DEN_ALLOW_PRIVATE_MCP_URLS` appeared only in source, unit tests, and one eval flow.** Not in `.env.example`. Not in the chart. Not in any doc. An operator hitting `MCP_URL_BLOCKED` had no supported way to discover the fix.

## What this adds

Discoverability only — the mechanism already existed.

- `ee/apps/den-api/.env.example` — documented alongside the other `DEN_*` MCP/network settings.
- `packaging/helm/openwork-ee/values.yaml` — `config.public.allowPrivateMcpUrls`, defaulted blank, grouped with the other MCP URL settings (`mcpResourceUrl`, `mcpAdditionalResources`, `mcpClaimNamespace`).
- `packaging/helm/openwork-ee/README.md` — extends the existing `## Isolated Networks` section with what the guard does, the exact symptom, the YAML, and an explicit security warning that enabling it disables SSRF protection for external MCP connection URLs and is only appropriate where Den's network position **and** the set of people who can add MCP connections are both trusted.
- `packaging/helm/openwork-ee/tests/private-mcp-urls.sh` — new chart test, auto-discovered by `publish-ee-images.yml:96-100`.

`url-guard.ts` and `env.ts` are **untouched**.

## Compatibility — this is the important part

**`helm template` with default values is byte-identical to the current chart.** Nothing renders unless an operator opts in, so there is no ConfigMap checksum change and therefore **no pod restart on upgrade** for existing self-hosted deployments.

Verified by rendering `origin/dev` and this branch from separate worktrees and diffing:

\`\`\`
=== default render diff ===
IDENTICAL
=== CI-style render diff (--set ingress.enabled=true --set inference.enabled=true) ===
IDENTICAL
\`\`\`

I deliberately did **not** follow the `DEN_PASSWORD_BREACH_SCREENING_ENABLED` pattern (`configmap.yaml:19`), which renders unconditionally — that would add a key to every existing deployment's ConfigMap.

Value handling is fail-safe and matches the code exactly (`env.ts:359` compares `.trim() === "1"`):

| Value | Result |
|---|---|
| unset / blank / `0` / `false` | renders nothing — guard stays on |
| `1` | enables |
| anything else (`true`, `yes`, …) | **fails the render** rather than guessing |

## Scoped to den-api only

`den-api.yaml:100-102`, `den-web.yaml:72-74`, and `inference.yaml:73-75` all `envFrom` the **same** main ConfigMap. Putting the key there would inject an SSRF-bypass flag into two workloads that never read it, so the value is emitted directly on the den-api container instead.

Only den-api consumes `allowPrivateMcpUrls` — `mcp-connections.ts:110,1814`, `plugin-system/store.ts:3969`, `enterprise-mcp-client-adapter.ts:79`, `external-mcp-client.ts:460`.

Proven in the render with `--set inference.enabled=true` so the assertion is not vacuous:

\`\`\`
den-api.yaml DEN_ALLOW_PRIVATE_MCP_URLS occurrences: 1
den-web.yaml DEN_ALLOW_PRIVATE_MCP_URLS occurrences: 0
inference.yaml DEN_ALLOW_PRIVATE_MCP_URLS occurrences: 0
full render configMapKeyRef occurrences: 0
\`\`\`

## Tests run

\`\`\`
helm lint packaging/helm/openwork-ee
# 1 chart(s) linted, 0 chart(s) failed

for t in packaging/helm/openwork-ee/tests/*.sh; do bash "$t"; done
# PASS custom-ca.sh
# PASS observability-env.sh
# PASS private-mcp-urls.sh

helm template ... --set config.public.allowPrivateMcpUrls=true
# correctly rejected 'true'
\`\`\`

The new chart test asserts: default render has zero occurrences (the compatibility guarantee); enabled render has exactly one, as a direct `value: "1"` with no `configMapKeyRef`; the flag lands on den-api and **not** on den-web or inference; `0`/`false`/blank render nothing; an unexpected value fails the render. It also asserts the removed intermediate ConfigMap name never reappears.

## Fraimz

Skipped, stated explicitly per AGENTS.md: chart, `.env.example`, and docs only, with no runtime code path changed. The executable proof is the byte-identical render diff plus the chart test, both above.