### PR TITLE
docs(self-host): document the private-network (semi air-gapped) deployment

### DIFF
--- a/docs/org-install-links.md
+++ b/docs/org-install-links.md
@@ -57,7 +57,10 @@ flag.
 
 Set `BETTER_AUTH_URL` to the externally reachable Den web origin, for example
 `https://openwork.example.com`. Set `DEN_API_PUBLIC_URL` to the externally
-reachable Den API origin. The desktop must be able to reach both origins.
+reachable Den API base; in a single-origin setup, use the Den web proxy path,
+such as `https://openwork.example.com/api/den`, so desktops reach only the Den
+web origin. If you publish a separate Den API origin, the install-link exchange
+and external MCP clients must be able to reach it.
 
 Invitation acceptance links use the first non-wildcard entry of
 `DEN_BETTER_AUTH_TRUSTED_ORIGINS`, falling back to `BETTER_AUTH_URL`. In a

--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -50,6 +50,7 @@
             "group": "Self-host",
             "pages": [
               "start-here/self-host",
+              "start-here/private-network-deployment",
               "start-here/on-prem-branding",
               "start-here/github-connector-helm"
             ]

--- a/packages/docs/start-here/private-network-deployment.mdx
+++ b/packages/docs/start-here/private-network-deployment.mdx
@@ -1,0 +1,103 @@
+---
+title: "Private network deployment"
+description: "Run OpenWork when laptops have internet and VPN access while Den stays inside a private network."
+---
+
+Most enterprise OpenWork installs are not fully air-gapped. The common shape is:
+
+- Employee laptops have normal internet access and VPN access.
+- Den web and Den API run inside the customer's private network.
+- The desktop is configured with one customer Den URL over the VPN.
+
+This page is for IT and platform teams approving those two network paths.
+
+## What the desktop must reach
+
+Use one desktop-facing Den origin when you can: the Den web origin, with its `/api/den` route proxying to Den API inside your deployment. The signed-in desktop runtime is pointed at that Den web URL and derives API and MCP traffic from it:
+
+- API: `<den-web-origin>/api/den/v1/...`
+- MCP: `<den-web-origin>/api/den/mcp/...`
+
+`DEN_API_PUBLIC_URL` still must be configured correctly, but it does not need to be a second desktop-facing origin. In the single-origin shape, set it to the proxied API base, for example `https://openwork.example.internal/api/den`. Den uses that value for install-link claims, OAuth callbacks, webhooks, MCP resource/audience values, and links. If you instead publish a separate Den API origin, the one-time install-link exchange and external MCP clients must be able to reach that origin too.
+
+External MCP clients such as Cursor, Claude Code, VS Code, ChatGPT, and OpenCode are separate from the desktop. They must reach the MCP endpoint you configure for them, usually `<DEN_API_PUBLIC_URL>/mcp/agent`; with the single-origin proxy example above, that is `https://openwork.example.internal/api/den/mcp/agent`. See [OpenWork Connect MCP](/cloud/run-in-the-cloud/cloud-mcp) for the external-client flow.
+
+Unless you mirror or replace them internally, laptops also need outbound network access to:
+
+| Destination | Why the laptop reaches it |
+| --- | --- |
+| `github.com` | Standard desktop installer downloads redirect to GitHub release assets. |
+| `objects.githubusercontent.com` and `release-assets.githubusercontent.com` | GitHub release/download asset hosts; allowlisting only `github.com` often makes a download start and then fail. |
+| `registry.npmjs.org` | The packaged UI-control MCP path starts `npx -y openwork-ui-mcp`. |
+| `models.openworklabs.com` | The local OpenWork server passes the OpenCode model catalog URL unless you override it with `OPENCODE_MODELS_URL`. |
+
+For a fully internal download path, mount the standard installer artifacts into Den instead. `OPENWORK_INSTALLER_ARTIFACTS_DIR` points at the mounted files, `OPENWORK_INSTALLER_RELEASE_TAG` controls the expected filenames, and `OPENWORK_INSTALLER_RELEASE_REPO` controls the GitHub redirect path when you use the internet path. When the matching file is mounted, Den streams it instead of redirecting the browser to GitHub. The full installer-delivery matrix lives in the repository's [Organization Install Links guide](https://github.com/different-ai/openwork/blob/dev/docs/org-install-links.md#installer-delivery).
+
+## What Den must reach
+
+The hard requirements are small:
+
+- The MySQL-compatible database endpoint configured for Den.
+- `ghcr.io` at chart and image-pull time, unless you mirror the Helm chart and the `openwork-den-api`, `openwork-den-web`, and optional `openwork-inference` images into an internal registry.
+
+Everything else is feature-specific and can be blocked until that feature is approved:
+
+| Feature | What Den needs to reach |
+| --- | --- |
+| Google Workspace | Google OAuth plus Gmail, Calendar, Drive, and related Google APIs, unless you use the Den Google endpoint overrides for testing. |
+| Microsoft 365 | Microsoft Entra OAuth and Microsoft Graph, unless you use the Den Microsoft endpoint overrides for testing. |
+| GitHub plugin import | GitHub API endpoints, plus inbound GitHub webhooks if you enable connector sync. See [GitHub connector for Helm](/start-here/github-connector-helm). |
+| Email | Resend when `RESEND_API_KEY` is set, otherwise the configured `SMTP_HOST`. |
+| Model providers | The provider catalog and the provider API you enable, such as OpenRouter for managed OpenWork Models. |
+| MCP presets and custom MCP connections | The configured MCP server URL and any OAuth/token endpoints it advertises. Internal MCP URLs need the private-network policy switch below. |
+
+For isolated Helm installs, the chart already disables the external breached-password lookup by default:
+
+```yaml
+config:
+  auth:
+    passwordBreachScreeningEnabled: "false"
+```
+
+On corporate networks that require an outbound proxy or private-CA TLS inspection, set process-level Node.js options on the Den container before it starts:
+
+- `NODE_USE_ENV_PROXY=1` with the appropriate `HTTPS_PROXY` and `NO_PROXY` values.
+- `NODE_EXTRA_CA_CERTS` when TLS inspection uses a private trust root.
+
+These settings belong on the Den process/container, not in the browser or the in-app environment editor.
+
+## Three surprises for operators
+
+### Internal MCP servers are refused
+
+**Symptom:** adding or testing an MCP server on a private address fails with `MCP_URL_BLOCKED` and the operator action says: "Use a public HTTPS MCP URL or change the deployment's private-network policy through security review."
+
+**Why:** Den fetches MCP URLs server-side. By default, it blocks private and reserved addresses as SSRF protection for multi-tenant deployments.
+
+**Fix:** set `DEN_ALLOW_PRIVATE_MCP_URLS=1` on Den. This disables that SSRF protection, so use it only when Den's network position is trusted and the people allowed to add MCP connections are trusted.
+
+### The Cloud MCP diagnostic is skipped
+
+**Symptom:** `Settings → Debug` reports that the live cloud catalog was not observed, and the detail says the endpoint is outside the diagnostics trust policy.
+
+**Why:** the diagnostic only sends a credentialed probe to trusted origins. By default, it trusts the hosted OpenWork origins, not your self-hosted Den origin.
+
+**Fix:** set `OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS` in the OpenWork process environment before OpenWork launches, for example `https://openwork.example.internal`. The in-app environment store strips `OPENWORK_*` and `OPENCODE_*` keys, so set this through your launcher, MDM, service wrapper, or shell environment.
+
+This affects the diagnostic only. Cloud MCP itself can still work in real chats without this variable, so do not treat a skipped probe as proof that the deployment is broken.
+
+### Den's outbound self-check points at a public host
+
+**Symptom:** an admin-triggered Den outbound diagnostic cannot reach `https://diagnostic.openworklabs.com` from a VPN-isolated Den deployment.
+
+**Why:** `DEN_DIAGNOSTICS_ORIGIN` defaults to that public diagnostic service.
+
+**Fix:** self-host `ee/apps/diagnostics` inside the private network, then point Den at it with `DEN_DIAGNOSTICS_ORIGIN` and `DEN_DIAGNOSTICS_BEARER_TOKEN`. The token must be at least 24 characters. Configuring and running the check is gated to workspace owners and super-admins, and the check is optional and admin-triggered; it is not a background dependency for Den.
+
+## Verification checklist
+
+| Chain | Success looks like | First place to look if it fails |
+| --- | --- | --- |
+| Installer activates against internal Den | The Den install page opens over VPN, the installer download completes, and **Open OpenWork** shows the expected organization and server before changing local configuration. | If the app opens, use `Settings → Debug` to confirm the Den web and API endpoints. If it never opens, return to the Den install page and check the download or handoff step. |
+| Desktop signs in and reaches a ready workspace | The user signs in through the internal Den URL, sees the correct organization, and can open a ready workspace or start a chat. | `Settings → Debug` for server endpoints, sign-in state, proxy, and TLS/certificate clues. |
+| Cloud MCP works in a real chat | In a chat, the agent can search available OpenWork capabilities and execute one that the user is allowed to run. | `Settings → Connect` for provider sign-in or admin setup. Use `Settings → Debug` to interpret diagnostics, especially a skipped catalog probe. |

--- a/packages/docs/start-here/self-host.mdx
+++ b/packages/docs/start-here/self-host.mdx
@@ -117,7 +117,8 @@ MCP traffic through the Den web proxy:
 
 For self-hosted deployments, configure `baseUrl` to the public Den web origin
 and make sure that web app's `/api/den` route can reach your Den API backend.
-The desktop app no longer needs, reads, or writes a separate API URL.
+After sign-in, normal desktop API and MCP traffic does not use a separate API
+origin.
 
 These three alone cover most feature but do not include:
 


### PR DESCRIPTION
## Why

Full air-gap is rare. **The common enterprise shape is a split:** employee laptops have normal internet *and* VPN access, while Den web and Den API run inside the customer's private network.

That shape was undocumented, so every customer rediscovered its gotchas by hitting failures.

Adds `packages/docs/start-here/private-network-deployment.mdx`, registered in the existing **Self-host** docs group.

## Structure

The two network paths are documented **separately**, because different teams approve them.

**What the desktop must reach** — one Den origin over the VPN, plus the internet destinations that need mirroring otherwise (`github.com` and both release-asset hosts, `registry.npmjs.org`, `models.openworklabs.com`), with the fully-internal alternative of mounting installer artifacts so the browser only ever talks to Den.

**What Den must reach** — only two hard requirements: its MySQL endpoint, and `ghcr.io` at chart/image-pull time unless mirrored. Everything else is a per-feature table that can stay blocked until that feature is approved. Includes the process-level `NODE_USE_ENV_PROXY` / `HTTPS_PROXY` / `NO_PROXY` / `NODE_EXTRA_CA_CERTS` settings a Den container needs behind a corporate proxy or TLS inspection.

**Three surprises for operators** — each with symptom → cause → fix:

| Surprise | Symptom | Fix |
|---|---|---|
| Internal MCP servers refused | `MCP_URL_BLOCKED` | `DEN_ALLOW_PRIVATE_MCP_URLS=1`, with the SSRF tradeoff stated plainly |
| Cloud MCP diagnostic skipped | Settings → Debug says the endpoint is outside the diagnostics trust policy | `OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS`, set **before launch** |
| Den's outbound self-check unreachable | Cannot reach `diagnostic.openworklabs.com` | Self-host `ee/apps/diagnostics`, point `DEN_DIAGNOSTICS_ORIGIN` at it |

The second one carries the most important framing in the page: **it affects the diagnostic only — Cloud MCP itself works without the variable.** Operators must not read a skipped probe as a broken deployment. It also records that the variable cannot be set from the in-app environment editor, because that store strips `OPENWORK_*` keys.

**Verification checklist** — the three chains to confirm after deploying (installer activates, desktop signs in, Cloud MCP works in a real chat), each with what success looks like and where to look first when it fails.

## A contradiction resolved — this decided whether IT opens one hostname or two

Two existing docs disagreed:

- `packages/docs/start-here/self-host.mdx:117-119` — *"The desktop app no longer needs, reads, or writes a separate API URL."*
- `docs/org-install-links.md:58-60` — *"The desktop must be able to reach both origins."*

Resolved **from the code**, not the prose:

- `apps/app/src/app/lib/den.ts:547-557` — `resolveDenBaseUrls` **ignores** an explicit `apiBaseUrl` when a `baseUrl` is present and derives `<baseUrl>/api/den`. `den.ts:560-563` builds MCP from that derived value.
- `apps/app/tests/den-mcp-url.test.ts:19-24` — existing test *"ignores an explicit API origin when a base URL is present"* pins it.
- `DEN_API_PUBLIC_URL` is still consumed, but for **claims and identifiers**, not desktop reachability: `auth.ts:127-140`, `mcp/resource.ts:53-55`, `routes/org/install-links.ts:124-130`, `desktop-connect-grants.ts:99-115`.
- The exception: `apps/desktop/electron/connect-link.mjs:332-344` builds the install-link exchange endpoint from the `apiBaseUrl` **carried in the link**, so a separate API origin must be reachable for that one-time exchange. External MCP clients also reach their configured origin directly and do not inherit the desktop's single-origin behavior.

So: **steady-state desktop traffic needs one origin.** `docs/org-install-links.md` was overbroad and is corrected; the `self-host.mdx` sentence is narrowed to say it applies to normal signed-in traffic. Both now state their context instead of disagreeing.

This matters concretely — it is the difference between a firewall request for one hostname and one for two.

## Compatibility

**No breaking changes.** Docs only. The sole non-docs edits are the two corrected sentences above. No product code, chart, `.env.example`, or test is touched.

## Verification

\`\`\`
node -e "JSON.parse(require('fs').readFileSync('packages/docs/docs.json','utf8'))"
# docs.json parses OK
\`\`\`

Internal links resolved against real files:

| Link | Target | |
|---|---|---|
| `/cloud/run-in-the-cloud/cloud-mcp` | `packages/docs/cloud/run-in-the-cloud/cloud-mcp.mdx` | OK |
| `/start-here/github-connector-helm` | `packages/docs/start-here/github-connector-helm.mdx` | OK |

Both code claims underpinning the contradiction fix were re-verified independently by reading `connect-link.mjs:332-344` and `den-mcp-url.test.ts:19-24` directly.

## Related

- #3131 documents the outbound destination list this page references (and now names `release-assets.githubusercontent.com`, the host GitHub actually serves today — verified live).
- #3132 makes the skipped cloud catalog probe's operator guidance name `OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS`.
- #3133 exposes `DEN_ALLOW_PRIVATE_MCP_URLS` in `.env.example` and the Helm chart.

These are independent and can merge in any order; this page stands alone.

## Fraimz

Skipped, stated explicitly per AGENTS.md: documentation only, no runtime path changed.