### PR TITLE
test(den): make Skill CRUD proof Daytona-ready

### DIFF
--- a/evals/flows/den-skill-crud-complete-body.flow.mjs
+++ b/evals/flows/den-skill-crud-complete-body.flow.mjs
@@ -1,0 +1,364 @@
+import {
+  denWebUrl,
+  signInViaBrowser,
+} from "./lib/den-web.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "den-skill-crud-complete-body";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const ADMIN_EMAIL =
+  process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD =
+  process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+
+const unique = Date.now().toString(36);
+const state = {
+  skillId: "",
+  originalName: `skill-proof-${unique}`,
+  editedName: `skill-proof-${unique}-edited`,
+  originalDescription: "Use this skill to prepare a careful incident handoff.",
+  editedDescription:
+    "Use this updated skill to prepare and verify an incident handoff.",
+  originalBody: [
+    "# Incident handoff",
+    "",
+    "Keep the complete context visible:",
+    "",
+    "- Summarize impact",
+    "- List owners and next steps",
+    "",
+    "```sh",
+    "openwork verify-handoff",
+    "```",
+  ].join("\n"),
+  editedBody: [
+    "# Verified incident handoff",
+    "",
+    "Preserve the complete updated context:",
+    "",
+    "1. Confirm current impact",
+    "2. Record owners and next steps",
+    "3. Link the verification receipt",
+    "",
+    "```sh",
+    "openwork verify-handoff --strict",
+    "```",
+  ].join("\n"),
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual:
+      actual === undefined
+        ? undefined
+        : JSON.stringify(actual).slice(0, 1_200),
+  });
+  ctx.assert(
+    condition,
+    `${assertion}${
+      actual === undefined
+        ? ""
+        : `. Actual: ${JSON.stringify(actual).slice(0, 600)}`
+    }`,
+  );
+}
+
+async function navigateTo(ctx, path) {
+  const url = new URL(path, denWebUrl()).toString();
+  await ctx.eval(
+    `(() => { location.assign(${JSON.stringify(url)}); return true; })()`,
+  );
+  await ctx.waitFor("document.readyState === 'complete'", {
+    timeoutMs: 30_000,
+    label: `load ${path}`,
+  });
+}
+
+async function setEditorValues(ctx, { name, description, body }) {
+  const filled = await ctx.eval(`(() => {
+    const setNative = (element, value) => {
+      const prototype = Object.getPrototypeOf(element);
+      const descriptor = Object.getOwnPropertyDescriptor(prototype, "value");
+      descriptor.set.call(element, value);
+      element.dispatchEvent(new Event("input", { bubbles: true }));
+      element.dispatchEvent(new Event("change", { bubbles: true }));
+    };
+    const name = document.querySelector('input[placeholder="e.g. customer-research"]');
+    const description = document.querySelector('input[placeholder="When should an agent use this skill?"]');
+    const body = document.querySelector('textarea[placeholder^="# Instructions"]');
+    if (!name || !description || !body) return false;
+    setNative(name, ${JSON.stringify(name)});
+    setNative(description, ${JSON.stringify(description)});
+    setNative(body, ${JSON.stringify(body)});
+    return true;
+  })()`);
+  witness(ctx, filled, "The complete skill editor can be filled");
+}
+
+async function clickButton(ctx, label) {
+  const clicked = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll("button")]
+      .find((entry) =>
+        (entry.textContent ?? "").replace(/\\s+/g, " ").trim() ===
+          ${JSON.stringify(label)} && !entry.disabled
+      );
+    button?.click();
+    return Boolean(button);
+  })()`);
+  witness(ctx, clicked, `The ${label} button is available`);
+}
+
+function screenshot(name, claim, requireText, rejectText = []) {
+  return {
+    name,
+    claim,
+    requireText,
+    rejectText: [
+      "Failed to load",
+      "Failed to save",
+      "Something went wrong",
+      ...rejectText,
+    ],
+  };
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Den creates, shows, edits, reloads, and deletes a complete skill",
+  kind: "user-facing",
+  preserveTheme: true,
+  spec: `evals/voiceovers/${FLOW_ID}.md`,
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Create a complete skill",
+      run: async (ctx) => {
+        await ctx.prove(
+          "An administrator can fill a new skill with complete Markdown instructions",
+          {
+            voiceover: vo[0],
+            action: async () => {
+              if (ctx.client?.send) {
+                await ctx.client.send("Emulation.setDeviceMetricsOverride", {
+                  width: 1440,
+                  height: 1000,
+                  deviceScaleFactor: 1,
+                  mobile: false,
+                });
+              }
+              await signInViaBrowser(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
+              await navigateTo(ctx, "/dashboard/skills/new");
+              await ctx.waitForText("Create a skill", { timeoutMs: 30_000 });
+              await setEditorValues(ctx, {
+                name: state.originalName,
+                description: state.originalDescription,
+                body: state.originalBody,
+              });
+            },
+            assert: async () => {
+              const values = await ctx.eval(`(() => ({
+                name: document.querySelector('input[placeholder="e.g. customer-research"]')?.value ?? "",
+                description: document.querySelector('input[placeholder="When should an agent use this skill?"]')?.value ?? "",
+                body: document.querySelector('textarea[placeholder^="# Instructions"]')?.value ?? "",
+              }))()`);
+              witness(
+                ctx,
+                values.name === state.originalName &&
+                  values.description === state.originalDescription &&
+                  values.body === state.originalBody,
+                "The editor retains the complete name, description, and body",
+                values,
+              );
+            },
+            screenshot: screenshot(
+              "skill-create-complete-body",
+              "The Den skill editor contains complete multi-line Markdown instructions.",
+              ["Create a skill", "Name", "Description", "Skill body"],
+            ),
+          },
+        );
+      },
+    },
+    {
+      name: "Read the complete body",
+      run: async (ctx) => {
+        await ctx.prove(
+          "Saving opens a detail page that displays the complete skill body",
+          {
+            voiceover: vo[1],
+            action: async () => {
+              await clickButton(ctx, "Create skill");
+              await ctx.waitFor(
+                "location.pathname.startsWith('/dashboard/skills/') && !location.pathname.endsWith('/new')",
+                {
+                  timeoutMs: 45_000,
+                  label: "created skill detail route",
+                },
+              );
+              state.skillId = await ctx.eval(
+                "location.pathname.split('/').filter(Boolean).at(-1)",
+              );
+              witness(
+                ctx,
+                typeof state.skillId === "string" && state.skillId.length > 0,
+                "The saved skill has a stable detail route",
+                { skillId: state.skillId },
+              );
+              await ctx.waitForText("Complete skill body", {
+                timeoutMs: 30_000,
+              });
+            },
+            assert: async () => {
+              const detail = await ctx.eval(`(() => ({
+                title: document.querySelector("h1")?.textContent?.trim() ?? "",
+                description: document.querySelector("header p")?.textContent?.trim() ?? "",
+                body: document.querySelector("article pre")?.textContent ?? "",
+              }))()`);
+              witness(
+                ctx,
+                detail.title === state.originalName &&
+                  detail.description === state.originalDescription &&
+                  detail.body === state.originalBody,
+                "The detail page shows the exact complete stored skill",
+                detail,
+              );
+            },
+            screenshot: screenshot(
+              "skill-detail-complete-body",
+              "The detail page visibly shows the entire skill body without truncation.",
+              [
+                state.originalName,
+                "Complete skill body",
+                "Incident handoff",
+                "openwork verify-handoff",
+              ],
+            ),
+          },
+        );
+      },
+    },
+    {
+      name: "Edit and reload",
+      run: async (ctx) => {
+        await ctx.prove(
+          "Skill edits persist exactly after a full page reload",
+          {
+            voiceover: vo[2],
+            action: async () => {
+              await navigateTo(
+                ctx,
+                `/dashboard/skills/${encodeURIComponent(state.skillId)}/edit`,
+              );
+              await ctx.waitForText(`Edit ${state.originalName}`, {
+                timeoutMs: 30_000,
+              });
+              await setEditorValues(ctx, {
+                name: state.editedName,
+                description: state.editedDescription,
+                body: state.editedBody,
+              });
+              await clickButton(ctx, "Save changes");
+              await ctx.waitFor(
+                `location.pathname === ${JSON.stringify(
+                  `/dashboard/skills/${state.skillId}`,
+                )}`,
+                { timeoutMs: 45_000, label: "updated skill detail route" },
+              );
+              await ctx.eval("location.reload(); true");
+              await ctx.waitFor("document.readyState === 'complete'", {
+                timeoutMs: 30_000,
+                label: "reloaded updated skill",
+              });
+              await ctx.waitForText(state.editedName, { timeoutMs: 30_000 });
+            },
+            assert: async () => {
+              const detail = await ctx.eval(`(() => ({
+                title: document.querySelector("h1")?.textContent?.trim() ?? "",
+                description: document.querySelector("header p")?.textContent?.trim() ?? "",
+                body: document.querySelector("article pre")?.textContent ?? "",
+              }))()`);
+              witness(
+                ctx,
+                detail.title === state.editedName &&
+                  detail.description === state.editedDescription &&
+                  detail.body === state.editedBody,
+                "The reloaded detail page shows every saved edit exactly",
+                detail,
+              );
+            },
+            screenshot: screenshot(
+              "skill-edits-persist-after-reload",
+              "The reloaded detail page visibly retains the edited complete body.",
+              [
+                state.editedName,
+                state.editedDescription,
+                "Verified incident handoff",
+                "openwork verify-handoff --strict",
+              ],
+            ),
+          },
+        );
+      },
+    },
+    {
+      name: "Delete the exact skill",
+      run: async (ctx) => {
+        await ctx.prove(
+          "The named confirmation deletes only the selected skill",
+          {
+            voiceover: vo[3],
+            action: async () => {
+              await clickButton(ctx, "Delete");
+              await ctx.waitForText(`Delete “${state.editedName}”?`, {
+                timeoutMs: 15_000,
+              });
+              await clickButton(ctx, `Delete “${state.editedName}”`);
+              await ctx.waitFor("location.pathname === '/dashboard/skills'", {
+                timeoutMs: 45_000,
+                label: "skills catalog after deletion",
+              });
+              await sleep(1_000);
+            },
+            assert: async () => {
+              const catalog = await ctx.eval(`(() => ({
+                text: document.body.innerText,
+                hrefs: [...document.querySelectorAll('a')].map((entry) => entry.getAttribute('href')),
+              }))()`);
+              witness(
+                ctx,
+                !catalog.text.includes(state.editedName) &&
+                  !catalog.hrefs.some(
+                    (href) =>
+                      typeof href === "string" &&
+                      href.includes(encodeURIComponent(state.skillId)),
+                  ),
+                "The deleted skill is absent from the catalog",
+                {
+                  nameVisible: catalog.text.includes(state.editedName),
+                  detailLinkVisible: catalog.hrefs.some(
+                    (href) =>
+                      typeof href === "string" &&
+                      href.includes(encodeURIComponent(state.skillId)),
+                  ),
+                },
+              );
+            },
+            screenshot: screenshot(
+              "skill-deleted-from-catalog",
+              "The Skills catalog no longer contains the deleted skill.",
+              ["Skills", "Create skill"],
+              [state.editedName],
+            ),
+          },
+        );
+      },
+    },
+  ],
+};

--- a/evals/runner/den-stack.ts
+++ b/evals/runner/den-stack.ts
@@ -16,7 +16,7 @@
  */
 import { execFile, spawn } from "node:child_process";
 import { openSync } from "node:fs";
-import { mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { access, mkdir, readFile, rm, writeFile } from "node:fs/promises";
 import { dirname, join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -34,6 +34,8 @@ const DEN_BASE_URL = `http://localhost:${DEN_API_PORT}`;
 const DEMO_EMAIL = process.env.DEN_DEMO_OWNER_EMAIL ?? "alex@acme.test";
 const DEMO_PASSWORD = process.env.DEN_DEMO_OWNER_PASSWORD ?? "OpenWorkDemo123!";
 const MYSQL_CONTAINER = "openwork-web-local-mysql";
+const MYSQL_STATE_DIR = join(STATE_DIR, "mysql");
+const MYSQL_SOCKET = join(MYSQL_STATE_DIR, "mysql.sock");
 const COMPOSE_ARGS = ["compose", "-p", "openwork-den-local", "-f", "packaging/docker/docker-compose.web-local.yml"];
 const DEN_WEB_ORIGIN = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "http://localhost:3005").replace(/\/+$/, "");
 const DEN_TRUSTED_ORIGINS = `${DEN_BASE_URL},${DEN_WEB_ORIGIN},http://localhost:5173,http://127.0.0.1:5173`;
@@ -42,6 +44,9 @@ const DEN_TRUSTED_ORIGINS = `${DEN_BASE_URL},${DEN_WEB_ORIGIN},http://localhost:
 // dev database (e.g. a dedicated schema on the same MySQL container).
 const DEN_DATABASE_URL = process.env.OPENWORK_EVAL_DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_den";
 const DEN_DATABASE_NAME = new URL(DEN_DATABASE_URL).pathname.replace(/^\//, "") || "openwork_den";
+if (!/^[A-Za-z0-9_]+$/.test(DEN_DATABASE_NAME)) {
+  throw new Error(`Unsupported Den database name: ${DEN_DATABASE_NAME}`);
+}
 
 const DEN_ENV = {
   OPENWORK_DEV_MODE: "1",
@@ -176,10 +181,166 @@ async function readPidState(name: string): Promise<string | null> {
   }
 }
 
-async function ensureMysql(log: (message: string) => void): Promise<void> {
+async function resolveExecutable(names: string[]): Promise<string | null> {
+  for (const name of names) {
+    try {
+      const { stdout } = await run("which", [name]);
+      const executable = stdout.trim();
+      if (executable) return executable;
+    } catch {
+      // Try the next compatible binary name.
+    }
+  }
+  return null;
+}
+
+function mysqlConnectionArgs(includeDatabase = true): string[] {
+  const url = new URL(DEN_DATABASE_URL);
+  const args = [
+    "--protocol=tcp",
+    "-h",
+    url.hostname,
+    "-P",
+    url.port || "3306",
+    `-u${decodeURIComponent(url.username || "root")}`,
+  ];
+  const password = decodeURIComponent(url.password);
+  if (password) args.push(`-p${password}`);
+  if (includeDatabase) args.push(DEN_DATABASE_NAME);
+  return args;
+}
+
+async function nativeMysqlQuery(sql: string, includeDatabase = true): Promise<string> {
+  const client = await resolveExecutable(["mariadb", "mysql"]);
+  if (!client) throw new Error("Neither mariadb nor mysql client is available.");
+  const { stdout } = await run(client, [
+    ...mysqlConnectionArgs(includeDatabase),
+    "-N",
+    "-e",
+    sql,
+  ]);
+  return stdout.trim();
+}
+
+async function nativeMysqlHealthy(): Promise<boolean> {
   try {
-    const { stdout } = await run("docker", ["inspect", "-f", "{{.State.Health.Status}}", MYSQL_CONTAINER]);
+    await nativeMysqlQuery("SELECT 1");
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+async function ensureNativeMysql(log: (message: string) => void): Promise<void> {
+  if (await nativeMysqlHealthy()) {
+    await writePidState("mysql.backend", "native");
+    log("Native MySQL already healthy");
+    return;
+  }
+
+  const server = await resolveExecutable(["mariadbd", "mysqld"]);
+  const installer = await resolveExecutable(["mariadb-install-db", "mysql_install_db"]);
+  const socketClient = await resolveExecutable(["mariadb", "mysql"]);
+  if (!server || !installer || !socketClient) {
+    throw new Error(
+      "Docker is unavailable and the native MySQL server/client toolchain is incomplete.",
+    );
+  }
+
+  await mkdir(MYSQL_STATE_DIR, { recursive: true });
+  try {
+    await access(join(MYSQL_STATE_DIR, "mysql"));
+  } catch {
+    log("Initializing native MariaDB data directory...");
+    await run(installer, [
+      `--datadir=${MYSQL_STATE_DIR}`,
+      "--auth-root-authentication-method=normal",
+      "--skip-test-db",
+    ]);
+  }
+
+  log("Starting native MariaDB...");
+  const pid = spawnDetached(
+    server,
+    [
+      `--datadir=${MYSQL_STATE_DIR}`,
+      `--socket=${MYSQL_SOCKET}`,
+      "--port=3306",
+      "--bind-address=127.0.0.1",
+      "--skip-networking=0",
+      `--pid-file=${join(MYSQL_STATE_DIR, "mysql.pid")}`,
+      `--log-error=${join(MYSQL_STATE_DIR, "mysql.error.log")}`,
+    ],
+    { logName: "mysql", env: {} },
+  );
+  await writePidState("mysql.pid", pid);
+  await writePidState("mysql.backend", "native");
+
+  let socketReady = false;
+  for (let attempt = 0; attempt < 60; attempt += 1) {
+    try {
+      await run(socketClient, [
+        "--protocol=socket",
+        `--socket=${MYSQL_SOCKET}`,
+        "-uroot",
+        "-N",
+        "-e",
+        "SELECT 1",
+      ]);
+      socketReady = true;
+      break;
+    } catch {
+      await sleep(500);
+    }
+  }
+  if (!socketReady) {
+    throw new Error("Native MariaDB did not become ready within 30s.");
+  }
+
+  await run(socketClient, [
+    "--protocol=socket",
+    `--socket=${MYSQL_SOCKET}`,
+    "-uroot",
+    "-e",
+    [
+      "ALTER USER 'root'@'localhost' IDENTIFIED BY 'password'",
+      "CREATE USER IF NOT EXISTS 'root'@'127.0.0.1' IDENTIFIED BY 'password'",
+      "GRANT ALL PRIVILEGES ON *.* TO 'root'@'127.0.0.1' WITH GRANT OPTION",
+      `CREATE DATABASE IF NOT EXISTS \`${DEN_DATABASE_NAME}\``,
+      "FLUSH PRIVILEGES",
+    ].join("; "),
+  ]);
+
+  for (let attempt = 0; attempt < 30; attempt += 1) {
+    if (await nativeMysqlHealthy()) {
+      log("Native MariaDB healthy");
+      return;
+    }
+    await sleep(500);
+  }
+  throw new Error("Native MariaDB did not accept Den database connections within 15s.");
+}
+
+async function ensureMysql(log: (message: string) => void): Promise<void> {
+  if (process.env.OPENWORK_EVAL_DATABASE_URL) {
+    if (!(await nativeMysqlHealthy())) {
+      throw new Error("OPENWORK_EVAL_DATABASE_URL is configured but not reachable.");
+    }
+    await writePidState("mysql.backend", "external");
+    log("External MySQL already healthy");
+    return;
+  }
+
+  const docker = await resolveExecutable(["docker"]);
+  if (!docker) {
+    await ensureNativeMysql(log);
+    return;
+  }
+
+  try {
+    const { stdout } = await run(docker, ["inspect", "-f", "{{.State.Health.Status}}", MYSQL_CONTAINER]);
     if (stdout.trim() === "healthy") {
+      await writePidState("mysql.backend", "docker");
       log("MySQL already healthy");
       return;
     }
@@ -187,13 +348,20 @@ async function ensureMysql(log: (message: string) => void): Promise<void> {
     // Not running — start it below.
   }
   log("Starting MySQL (docker compose)...");
-  await run("docker", [...COMPOSE_ARGS, "up", "-d", "--wait", "mysql"]);
+  await run(docker, [...COMPOSE_ARGS, "up", "-d", "--wait", "mysql"]);
+  await writePidState("mysql.backend", "docker");
   await writePidState("mysql.started", "1");
   log("MySQL healthy");
 }
 
 async function mysqlQuery(sql: string): Promise<string> {
-  const { stdout } = await run("docker", [
+  const backend = await readPidState("mysql.backend");
+  if (backend === "native" || backend === "external") {
+    return nativeMysqlQuery(sql);
+  }
+  const docker = await resolveExecutable(["docker"]);
+  if (!docker) throw new Error("The selected Docker MySQL backend is unavailable.");
+  const { stdout } = await run(docker, [
     "exec", MYSQL_CONTAINER,
     "mysql", "-uroot", "-ppassword", DEN_DATABASE_NAME, "-N", "-e", sql,
   ]);
@@ -440,11 +608,25 @@ export async function denStackDown({ log }: DenStackDownOptions): Promise<void> 
     await rm(bootstrapPath, { force: true });
     log("Removed dev desktop bootstrap override");
   }
-  try {
-    await run("docker", [...COMPOSE_ARGS, "down"]);
-    log("MySQL compose project stopped (volume kept)");
-  } catch {
-    log("Docker compose down skipped (docker unavailable?)");
+  const mysqlBackend = await readPidState("mysql.backend");
+  const mysqlPid = await readPidState("mysql.pid");
+  if (mysqlBackend === "native" && mysqlPid) {
+    try {
+      process.kill(Number(mysqlPid));
+      log(`Stopped native MariaDB (pid ${mysqlPid})`);
+    } catch {
+      // Already gone.
+    }
+  } else if (mysqlBackend === "docker") {
+    const docker = await resolveExecutable(["docker"]);
+    if (docker) {
+      try {
+        await run(docker, [...COMPOSE_ARGS, "down"]);
+        log("MySQL compose project stopped (volume kept)");
+      } catch {
+        log("Docker compose down skipped (docker unavailable?)");
+      }
+    }
   }
   await rm(STATE_DIR, { recursive: true, force: true });
 }

--- a/evals/voiceovers/den-skill-crud-complete-body.md
+++ b/evals/voiceovers/den-skill-crud-complete-body.md
@@ -1,0 +1,9 @@
+# den-skill-crud-complete-body — Complete Den skill lifecycle
+
+1. I open Den Skills and create a reusable organization skill with a clear description and a complete multi-line Markdown body.
+
+2. After saving, Den opens the skill detail page and shows the entire body—including its heading, list, and fenced command—without reducing it to a summary.
+
+3. I edit the skill's name, description, and instructions, then reload the page. Every change remains exactly as I saved it.
+
+4. I delete the exact skill from its named confirmation dialog. Den returns to the Skills catalog, where the deleted skill is no longer present.


### PR DESCRIPTION
## Summary

- add an immutable Den Web acceptance flow for complete Skill CRUD
- preserve Docker Compose for local proof runs
- fall back to a native MariaDB server when Docker is unavailable, as in Daytona container sandboxes
- accept an explicitly supplied external MySQL URL without provisioning a local database

## Verification

- `pnpm evals:typecheck`
- `pnpm evals:test` (4 passed)
- `git diff --check`

This is proof infrastructure only; it does not include the Skill CRUD product implementation.
