### PR TITLE
fix(evals): start native MariaDB in root runtimes

### DIFF
--- a/evals/runner/den-stack.test.ts
+++ b/evals/runner/den-stack.test.ts
@@ -1,0 +1,8 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { nativeMysqlServerArgs } from "./den-stack.ts";
+
+test("native MariaDB explicitly permits root-owned Daytona runtimes", () => {
+  assert(nativeMysqlServerArgs(true).includes("--user=root"));
+  assert(!nativeMysqlServerArgs(false).includes("--user=root"));
+});

--- a/evals/runner/den-stack.ts
+++ b/evals/runner/den-stack.ts
@@ -231,6 +231,22 @@ async function nativeMysqlHealthy(): Promise<boolean> {
   }
 }
 
+export function nativeMysqlServerArgs(
+  runAsRoot = process.getuid?.() === 0,
+): string[] {
+  const args = [
+    `--datadir=${MYSQL_STATE_DIR}`,
+    `--socket=${MYSQL_SOCKET}`,
+    "--port=3306",
+    "--bind-address=127.0.0.1",
+    "--skip-networking=0",
+    `--pid-file=${join(MYSQL_STATE_DIR, "mysql.pid")}`,
+    `--log-error=${join(MYSQL_STATE_DIR, "mysql.error.log")}`,
+  ];
+  if (runAsRoot) args.push("--user=root");
+  return args;
+}
+
 async function ensureNativeMysql(log: (message: string) => void): Promise<void> {
   if (await nativeMysqlHealthy()) {
     await writePidState("mysql.backend", "native");
@@ -262,15 +278,7 @@ async function ensureNativeMysql(log: (message: string) => void): Promise<void> 
   log("Starting native MariaDB...");
   const pid = spawnDetached(
     server,
-    [
-      `--datadir=${MYSQL_STATE_DIR}`,
-      `--socket=${MYSQL_SOCKET}`,
-      "--port=3306",
-      "--bind-address=127.0.0.1",
-      "--skip-networking=0",
-      `--pid-file=${join(MYSQL_STATE_DIR, "mysql.pid")}`,
-      `--log-error=${join(MYSQL_STATE_DIR, "mysql.error.log")}`,
-    ],
+    nativeMysqlServerArgs(),
     { logName: "mysql", env: {} },
   );
   await writePidState("mysql.pid", pid);

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "evals": "node evals/runner/run.mjs --mode automation",
     "fraimz": "node evals/runner/run.mjs --mode demo",
     "evals:typecheck": "tsc -p evals",
-    "evals:test": "node --test evals/runner/context.test.ts",
+    "evals:test": "node --test evals/runner/*.test.ts",
     "test:orchestrator": "pnpm --filter openwork-orchestrator test:router",
     "bump:patch": "pnpm --filter @openwork/app bump:patch",
     "bump:minor": "pnpm --filter @openwork/app bump:minor",


### PR DESCRIPTION
## Summary
- pass `--user=root` when the native Den evaluator runs under a root-owned Daytona runtime
- preserve existing non-root MariaDB startup behavior
- add a direct regression test and run all evaluator-runner tests

## Root cause
MariaDB aborts immediately when launched as UID 0 without an explicit user, so the Den Web proof timed out before the API or browser flow started.

## Verification
- `pnpm evals:typecheck`
- `pnpm evals:test` (5 passed)
- `git diff --check`