### PR TITLE
fix(evals): resolve source exports in Den seed

### DIFF
--- a/evals/runner/den-stack.test.ts
+++ b/evals/runner/den-stack.test.ts
@@ -1,6 +1,7 @@
 import assert from "node:assert/strict";
 import test from "node:test";
 import {
+  denSeedNodeArgs,
   nativeMysqlServerArgs,
   nativeMysqlSocketArgs,
 } from "./den-stack.ts";
@@ -13,4 +14,13 @@ test("native MariaDB explicitly permits root-owned Daytona runtimes", () => {
 test("native MariaDB supports fresh and resumed socket authentication", () => {
   assert(!nativeMysqlSocketArgs(false).some((arg) => arg.startsWith("-p")));
   assert(nativeMysqlSocketArgs(true).includes("-ppassword"));
+});
+
+test("demo-org seed resolves development exports without package builds", () => {
+  assert.deepEqual(denSeedNodeArgs(), [
+    "--conditions=development",
+    "--import",
+    "tsx",
+    "scripts/seed-demo-org.ts",
+  ]);
 });

--- a/evals/runner/den-stack.ts
+++ b/evals/runner/den-stack.ts
@@ -498,13 +498,22 @@ async function ensureDenWeb(log: (message: string) => void): Promise<void> {
   throw new Error(`den-web did not become healthy at ${DEN_WEB_ORIGIN} within 90s.`);
 }
 
+export function denSeedNodeArgs(): string[] {
+  return [
+    "--conditions=development",
+    "--import",
+    "tsx",
+    "scripts/seed-demo-org.ts",
+  ];
+}
+
 async function ensureSeed(log: (message: string) => void): Promise<void> {
   if (await signInDemoOwner()) {
     log(`Demo org present (${DEMO_EMAIL})`);
     return;
   }
   log("Seeding demo org (Acme Robotics)...");
-  await run("pnpm", ["exec", "tsx", "scripts/seed-demo-org.ts"], {
+  await run(process.execPath, denSeedNodeArgs(), {
     cwd: join(REPO_ROOT, "ee", "apps", "den-api"),
     env: { ...process.env, ...DEN_ENV },
   });


### PR DESCRIPTION
## Summary
- run the Den demo-org seed with Node's development export condition
- resolve workspace package source entries without rebuilding dependencies
- cover the seed invocation with a focused harness test

## Verification
- `pnpm --filter @openwork-ee/den-api exec tsx --test ../../../evals/runner/den-stack.test.ts` (3/3)
- `pnpm exec tsc -p evals/tsconfig.json --noEmit`
- direct development-export import smoke check
- `git diff --check`