### PR TITLE
fix(evals): clear stale Den Web build cache

### DIFF
--- a/evals/runner/den-stack.test.ts
+++ b/evals/runner/den-stack.test.ts
@@ -1,6 +1,16 @@
 import assert from "node:assert/strict";
+import {
+  access,
+  mkdir,
+  mkdtemp,
+  rm,
+  writeFile,
+} from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 import {
+  clearDenWebBuildCache,
   denEvalEnvironment,
   denSeedNodeArgs,
   nativeMysqlServerArgs,
@@ -31,4 +41,20 @@ test("Den evaluator explicitly permits the isolated demo signup", () => {
     denEvalEnvironment().DEN_SINGLE_ORG_ALLOW_PUBLIC_SIGNUP,
     "true",
   );
+});
+
+test("Den Web startup discards generated output from a reusable image", async () => {
+  const denWebRoot = await mkdtemp(join(tmpdir(), "openwork-den-web-"));
+  const staleManifest = join(denWebRoot, ".next", "server", "app-paths-manifest.json");
+
+  try {
+    await mkdir(join(denWebRoot, ".next", "server"), { recursive: true });
+    await writeFile(staleManifest, "{}");
+
+    await clearDenWebBuildCache(denWebRoot);
+
+    await assert.rejects(access(staleManifest));
+  } finally {
+    await rm(denWebRoot, { recursive: true, force: true });
+  }
 });

--- a/evals/runner/den-stack.ts
+++ b/evals/runner/den-stack.ts
@@ -474,6 +474,12 @@ async function ensureDenApi(log: (message: string) => void): Promise<void> {
   throw new Error("den proxy did not expose /api/den/health within 30s.");
 }
 
+export async function clearDenWebBuildCache(
+  denWebRoot = join(REPO_ROOT, "ee", "apps", "den-web"),
+): Promise<void> {
+  await rm(join(denWebRoot, ".next"), { recursive: true, force: true });
+}
+
 async function ensureDenWeb(log: (message: string) => void): Promise<void> {
   if (await httpOk(`${DEN_WEB_ORIGIN}/api/den/health`)) {
     log(`den-web already healthy at ${DEN_WEB_ORIGIN}`);
@@ -482,6 +488,10 @@ async function ensureDenWeb(log: (message: string) => void): Promise<void> {
 
   const webUrl = new URL(DEN_WEB_ORIGIN);
   const denWebPort = webUrl.port || "3005";
+  // Reusable Daytona images may retain a generated Next.js route manifest
+  // from an older checkout. Dependencies remain cached, but generated app
+  // output must match the exact candidate being proved.
+  await clearDenWebBuildCache();
   log(`Starting den-web on :${denWebPort}...`);
   const pid = spawnDetached("pnpm", ["dev:den:web"], {
     logName: "den-web",


### PR DESCRIPTION
## Summary
- remove generated Den Web `.next` output before evaluator startup
- preserve dependency caching while preventing route manifests from an older reusable image checkout
- cover stale generated-output cleanup with a focused filesystem test

## Diagnosis
The retained Daytona runtime showed Next.js ready while `/api/den/health` returned 404 for the full timeout. Restarting the exact same checkout after the generated cache refreshed returned 200 immediately.

## Verification
- focused Den harness tests (5/5)
- evaluator TypeScript check
- `git diff --check`