### PR TITLE
fix(evals): trust Den proof loopback origins

### DIFF
--- a/evals/runner/den-stack.test.ts
+++ b/evals/runner/den-stack.test.ts
@@ -43,6 +43,14 @@ test("Den evaluator explicitly permits the isolated demo signup", () => {
   );
 });
 
+test("Den evaluator trusts both loopback spellings used by the proof browser", () => {
+  const trustedOrigins = denEvalEnvironment()
+    .DEN_BETTER_AUTH_TRUSTED_ORIGINS?.split(",");
+
+  assert(trustedOrigins?.includes("http://localhost:3005"));
+  assert(trustedOrigins?.includes("http://127.0.0.1:3005"));
+});
+
 test("Den Web startup discards generated output from a reusable image", async () => {
   const denWebRoot = await mkdtemp(join(tmpdir(), "openwork-den-web-"));
   const staleManifest = join(denWebRoot, ".next", "server", "app-paths-manifest.json");

--- a/evals/runner/den-stack.ts
+++ b/evals/runner/den-stack.ts
@@ -38,7 +38,15 @@ const MYSQL_STATE_DIR = join(STATE_DIR, "mysql");
 const MYSQL_SOCKET = join(MYSQL_STATE_DIR, "mysql.sock");
 const COMPOSE_ARGS = ["compose", "-p", "openwork-den-local", "-f", "packaging/docker/docker-compose.web-local.yml"];
 const DEN_WEB_ORIGIN = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "http://localhost:3005").replace(/\/+$/, "");
-const DEN_TRUSTED_ORIGINS = `${DEN_BASE_URL},${DEN_WEB_ORIGIN},http://localhost:5173,http://127.0.0.1:5173`;
+const DEN_WEB_PORT = new URL(DEN_WEB_ORIGIN).port || "3005";
+const DEN_TRUSTED_ORIGINS = [
+  DEN_BASE_URL,
+  DEN_WEB_ORIGIN,
+  `http://localhost:${DEN_WEB_PORT}`,
+  `http://127.0.0.1:${DEN_WEB_PORT}`,
+  "http://localhost:5173",
+  "http://127.0.0.1:5173",
+].filter((origin, index, origins) => origins.indexOf(origin) === index).join(",");
 
 // Override with OPENWORK_EVAL_DATABASE_URL to isolate a run from the shared
 // dev database (e.g. a dedicated schema on the same MySQL container).


### PR DESCRIPTION
## What changed
- trust both `localhost` and `127.0.0.1` for the configured Den Web proof port
- keep the trusted-origin list deduplicated
- cover the proof-browser loopback aliases with a focused evaluator test

## Why
The Daytona proof browser can expose the Den page as `127.0.0.1` even when the evaluator configured `localhost`. Better Auth then rejects the real browser sign-in as `Invalid origin`, blocking otherwise healthy Den Web proof.

## Verification
- `node --test evals/runner/den-stack.test.ts` — 6/6 passed
- `pnpm evals:typecheck` — passed
- `git diff --check` — passed

The retained Skill CRUD Kitchen proof will be resumed against this exact fix after merge to produce the real fraimz evidence.