### PR TITLE
fix(desktop): keep external fetches on Chromium network stack

### DIFF
--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -125,15 +125,6 @@ const uiControlServer = createUiControlServer({
   getWindow: () => createMainWindow(),
 });
 
-async function fetchWithElectronNetFallback(input, init) {
-  try {
-    return await electronNet.fetch(input, init);
-  } catch (error) {
-    if (typeof fetch !== "function") throw error;
-    return fetch(input, init);
-  }
-}
-
 const terminalProcesses = new Map();
 let nextTerminalId = 1;
 
@@ -2071,14 +2062,14 @@ const desktopCommandHandlers = {
       };
       if (init.agentContextDiagnostics && typeof init.agentContextDiagnostics === "object") {
         return fetchAgentContextDiagnosticsResponse(
-          fetchWithElectronNetFallback,
+          electronNet.fetch,
           url,
           requestInit,
           init.agentContextDiagnostics.deadlineAtMs,
         );
       }
       const timeoutMs = Number(init.timeoutMs);
-      const response = await fetchWithElectronNetFallback(url, {
+      const response = await electronNet.fetch(url, {
         ...requestInit,
         signal: Number.isFinite(timeoutMs) && timeoutMs > 0 ? AbortSignal.timeout(timeoutMs) : undefined,
       });


### PR DESCRIPTION
## Summary
- remove the Node bare-fetch fallback added in #3140
- keep Electron main-process external requests on `electronNet.fetch`
- restore the certificate trust and system proxy invariant enforced by the desktop test suite

## Verification
- `pnpm --filter @openwork/desktop test` — passed (116 passed, 1 skipped)
- `pnpm --filter @openwork/desktop typecheck:electron` — passed
- `git diff --check` — passed

## Fraimz
Incomplete: `pnpm fraimz --flow desktop-fetch-os-trust --cdp-url http://127.0.0.1:9826` could not attach because the local Electron process exposed CDP without creating a page target; relaunch through macOS LaunchServices failed because this shell has no supported GUI launch domain.