### PR TITLE
fix(cloud): web sign-in handoff back into the Cloud instance

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -10,7 +10,7 @@ import {
 export type { SharedDesktopConfig };
 export { normalizeDesktopConfig };
 
-import { isDesktopDeployment } from "./openwork-deployment";
+import { isDesktopDeployment, isWebDeployment } from "./openwork-deployment";
 import {
   dispatchDenSettingsChanged,
 } from "./den-session-events";
@@ -774,6 +774,9 @@ export function buildDenAuthUrl(baseUrl: string, mode: "sign-in" | "sign-up"): s
   if (isDesktopDeployment()) {
     target.searchParams.set("desktopAuth", "1");
     target.searchParams.set("desktopScheme", "openwork");
+  } else if (isWebDeployment() && typeof window !== "undefined") {
+    target.searchParams.set("webAuth", "1");
+    target.searchParams.set("webAuthReturn", window.location.origin);
   }
   return target.toString();
 }

--- a/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
@@ -124,17 +124,7 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
     [baseUrl],
   );
 
-  const submitManualAuth = useCallback(async () => {
-    const parsed = parseManualAuthInput(manualAuthInput);
-    if (!parsed || authBusy) {
-      if (!parsed) {
-        setAuthError(t("den.error_paste_valid_code"));
-      }
-      return;
-    }
-
-    const nextBaseUrl = parsed.baseUrl ?? baseUrl;
-
+  const exchangeGrant = useCallback(async (grant: string, nextBaseUrl: string) => {
     setAuthBusy(true);
     setAuthError(null);
     setStatusMessage(t("den.signing_in"));
@@ -144,7 +134,7 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
         baseUrl: nextBaseUrl,
       });
       // The helper exchanges, persists, and dispatches the success/error session events.
-      const result = await exchangeHandoffAndSignIn(parsed.grant, {
+      const result = await exchangeHandoffAndSignIn(grant, {
         baseUrl: nextBaseUrl,
         client,
         fallbackErrorMessage: t("den.error_no_token"),
@@ -165,7 +155,37 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
     } finally {
       setAuthBusy(false);
     }
-  }, [authBusy, baseUrl, developerMode, manualAuthInput]);
+  }, [developerMode]);
+
+  const submitManualAuth = useCallback(async () => {
+    const parsed = parseManualAuthInput(manualAuthInput);
+    if (!parsed || authBusy) {
+      if (!parsed) {
+        setAuthError(t("den.error_paste_valid_code"));
+      }
+      return;
+    }
+
+    const nextBaseUrl = parsed.baseUrl ?? baseUrl;
+    return exchangeGrant(parsed.grant, nextBaseUrl);
+  }, [authBusy, baseUrl, exchangeGrant, manualAuthInput]);
+
+  useEffect(() => {
+    if (typeof window === "undefined" || authBusy) return;
+
+    const url = new URL(window.location.href);
+    const grant = url.searchParams.get("grant")?.trim() ?? "";
+    if (!grant) return;
+
+    url.searchParams.delete("grant");
+    window.history.replaceState(
+      window.history.state,
+      document.title,
+      `${url.pathname}${url.search}${url.hash}`,
+    );
+
+    void exchangeGrant(grant, baseUrl);
+  }, [authBusy, baseUrl, exchangeGrant]);
 
   const applyBaseUrl = useCallback(async (value?: string) => {
     const normalized = normalizeDenBaseUrl(value ?? baseUrlDraft);

--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -1,21 +1,23 @@
 import { randomBytes } from "node:crypto"
-import { and, eq, gt, isNull } from "@openwork-ee/den-db/drizzle"
-import { AuthSessionTable, AuthUserTable, DesktopHandoffGrantTable } from "@openwork-ee/den-db/schema"
+import { and, desc, eq, gt, isNull } from "@openwork-ee/den-db/drizzle"
+import { AuthSessionTable, AuthUserTable, DaytonaSandboxTable, DesktopHandoffGrantTable, WorkerTable } from "@openwork-ee/den-db/schema"
 import { normalizeDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono } from "hono"
 import { describeRoute } from "hono-openapi"
 import { z } from "zod"
 import { authenticatedRoute, jsonValidator, publicRoute } from "../../middleware/index.js"
 import { db } from "../../db.js"
-import { env } from "../../env.js"
+import { env, type DenOrgMode } from "../../env.js"
 import { denTypeIdSchema, invalidRequestSchema, jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import type { AuthContextVariables } from "../../session.js"
 import { enforceRateLimit } from "../../utils/rate-limit.js"
+import { CLOUD_INSTANCE_BACKEND } from "../../workers/cloud-constants.js"
 
 const createGrantSchema = z.object({
-  next: z.string().trim().max(128).optional(),
-  desktopScheme: z.string().trim().max(32).optional(),
-})
+  next: z.string().trim().max(128).optional().describe("Optional continuation hint for handoff clients."),
+  desktopScheme: z.string().trim().max(32).optional().describe("Optional desktop URL scheme to use when building the OpenWork deep link."),
+  returnUrl: z.string().trim().max(2048).optional().describe("Optional HTTPS OpenWork Cloud web return URL. Accepted only for multi-organization Cloud instances after server-side origin validation."),
+}).meta({ ref: "DesktopHandoffGrantCreateBody" })
 
 const exchangeGrantSchema = z.object({
   grant: z.string().trim().min(12).max(128),
@@ -29,6 +31,7 @@ const desktopHandoffGrantResponseSchema = z.object({
   grant: z.string(),
   expiresAt: z.string().datetime(),
   openworkUrl: z.string().url(),
+  returnUrl: z.string().url().optional(),
 }).meta({ ref: "DesktopHandoffGrantResponse" })
 
 const desktopHandoffExchangeResponseSchema = z.object({
@@ -54,8 +57,16 @@ const rateLimitedSchema = z.object({
   message: z.string(),
 }).meta({ ref: "DesktopHandoffRateLimitedError" })
 
+const invalidReturnUrlSchema = z.object({
+  error: z.literal("invalid_return_url"),
+  message: z.string(),
+}).meta({ ref: "DesktopHandoffInvalidReturnUrlError" })
+
+const createGrantBadRequestSchema = z.union([invalidRequestSchema, invalidReturnUrlSchema]).meta({ ref: "DesktopHandoffCreateBadRequest" })
+
 const HANDOFF_STATUS_RATE_LIMIT_WINDOW_MS = 60 * 1000
 const HANDOFF_STATUS_RATE_LIMIT_MAX = 240
+type WorkerOrgId = typeof WorkerTable.$inferSelect.org_id
 
 function readSingleHeader(value: string | null) {
   const first = value?.split(",")[0]?.trim() ?? ""
@@ -176,6 +187,105 @@ function buildOpenworkDeepLink(input: {
   return url.toString()
 }
 
+function rawPathnameForUrl(value: string) {
+  const match = value.match(/^[a-z][a-z0-9+.-]*:\/\/[^/?#]*(\/[^?#]*)?/i)
+  return match?.[1] ?? "/"
+}
+
+function hasPathTraversal(pathname: string) {
+  const candidates = [pathname.toLowerCase()]
+  try {
+    candidates.push(decodeURIComponent(pathname).toLowerCase())
+  } catch {
+    // Keep the original escaped path candidate.
+  }
+
+  return candidates.some((candidate) => candidate.split("/").some((segment) => segment === "." || segment === ".."))
+}
+
+export function approveWebHandoffReturnUrl(input: {
+  returnUrl: string
+  signedPreviewUrl: string
+  orgMode: DenOrgMode
+}) {
+  if (input.orgMode !== "multi_org") {
+    return null
+  }
+
+  let candidate: URL
+  let signedPreview: URL
+  try {
+    candidate = new URL(input.returnUrl)
+    signedPreview = new URL(input.signedPreviewUrl)
+  } catch {
+    return null
+  }
+
+  if (
+    candidate.protocol !== "https:"
+    || signedPreview.protocol !== "https:"
+    || candidate.username
+    || candidate.password
+    || candidate.hash
+    || hasPathTraversal(rawPathnameForUrl(input.returnUrl))
+  ) {
+    return null
+  }
+
+  if (candidate.pathname !== "/" && candidate.pathname !== "/signin") {
+    return null
+  }
+
+  // Exact-origin only. The Daytona preview proxy zone is shared by every
+  // Daytona customer, so any suffix-based match would approve an
+  // attacker-controlled sandbox origin and leak one-time session grants.
+  // If the preview URL was re-signed between opening the instance and
+  // signing in, this fails closed and the user reopens Cloud for a fresh
+  // URL.
+  if (candidate.origin !== signedPreview.origin) {
+    return null
+  }
+
+  return `${candidate.origin}/signin`
+}
+
+async function getCloudSignedPreviewUrl(organizationId: WorkerOrgId) {
+  const [row] = await db
+    .select({ signedPreviewUrl: DaytonaSandboxTable.signed_preview_url })
+    .from(WorkerTable)
+    .innerJoin(DaytonaSandboxTable, eq(WorkerTable.id, DaytonaSandboxTable.worker_id))
+    .where(and(
+      eq(WorkerTable.org_id, organizationId),
+      eq(WorkerTable.destination, "cloud"),
+      eq(WorkerTable.sandbox_backend, CLOUD_INSTANCE_BACKEND),
+    ))
+    .orderBy(desc(WorkerTable.created_at))
+    .limit(1)
+
+  return row?.signedPreviewUrl ?? null
+}
+
+async function resolveApprovedWebHandoffReturnUrl(input: {
+  returnUrl: string
+  activeOrganizationId?: string | null
+}) {
+  if (env.orgMode !== "multi_org" || !input.activeOrganizationId) {
+    return null
+  }
+
+  let organizationId: WorkerOrgId
+  try {
+    organizationId = normalizeDenTypeId("organization", input.activeOrganizationId)
+  } catch {
+    return null
+  }
+
+  const signedPreviewUrl = await getCloudSignedPreviewUrl(organizationId)
+  return signedPreviewUrl
+    ? approveWebHandoffReturnUrl({ returnUrl: input.returnUrl, signedPreviewUrl, orgMode: env.orgMode })
+    : null
+}
+
 export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {
   app.post(
     "/v1/auth/desktop-handoff",
@@ -183,10 +293,10 @@ export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVari
       hide: true,
       tags: ["Authentication"],
       summary: "Create desktop handoff grant",
-      description: "Creates a short-lived desktop handoff grant and deep link so a signed-in web user can continue the same account in the OpenWork desktop app.",
+      description: "Creates a short-lived handoff grant for a signed-in web user. Desktop clients receive an OpenWork deep link; approved Cloud web clients also receive a validated return URL.",
       responses: {
         200: jsonResponse("Desktop handoff grant created successfully.", desktopHandoffGrantResponseSchema),
-        400: jsonResponse("The handoff request body was invalid.", invalidRequestSchema),
+        400: jsonResponse("The handoff request body or Cloud web return URL was invalid.", createGrantBadRequestSchema),
         401: jsonResponse("The caller must be signed in to create a desktop handoff grant.", unauthorizedSchema),
       },
     }),
@@ -200,6 +310,19 @@ export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVari
     }
 
     const input = c.req.valid("json")
+    let approvedReturnUrl: string | null = null
+    if (input.returnUrl !== undefined) {
+      approvedReturnUrl = await resolveApprovedWebHandoffReturnUrl({
+        returnUrl: input.returnUrl,
+        activeOrganizationId: session.activeOrganizationId,
+      })
+      if (!approvedReturnUrl) {
+        return c.json({
+          error: "invalid_return_url",
+          message: "The Cloud web handoff return URL is not approved for this organization.",
+        }, 400)
+      }
+    }
 
     const grant = randomBytes(24).toString("base64url")
     const expiresAt = new Date(Date.now() + 5 * 60 * 1000)
@@ -221,6 +344,7 @@ export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVari
         grant,
         denBaseUrl,
       }),
+      ...(approvedReturnUrl ? { returnUrl: approvedReturnUrl } : {}),
     })
     },
   )

--- a/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
+++ b/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
@@ -1,13 +1,23 @@
 import { describe, expect, test } from "bun:test"
 
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = "https://public.example.test"
+}
+
+async function loadDesktopHandoffRoutes() {
+  seedRequiredEnv()
+  return import("../src/routes/auth/desktop-handoff.js")
+}
+
 describe("desktop handoff public URL", () => {
   test("does not send 0.0.0.0 to desktop clients", async () => {
-    process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
-    process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
-    process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+    seedRequiredEnv()
     process.env.BETTER_AUTH_URL = "https://public.example.test"
 
-    const { resolveDesktopDenBaseUrl } = await import("../src/routes/auth/desktop-handoff.js")
+    const { resolveDesktopDenBaseUrl } = await loadDesktopHandoffRoutes()
 
     expect(resolveDesktopDenBaseUrl(new Request("http://0.0.0.0:8788/v1/auth/desktop-handoff", {
       headers: { origin: "http://0.0.0.0:3005" },
@@ -19,5 +29,77 @@ describe("desktop handoff public URL", () => {
         "x-forwarded-proto": "https",
       },
     }))).toBe("https://public.example.test/api/den")
+  })
+
+  test("approves a web returnUrl on the exact active Cloud instance origin", async () => {
+    const { approveWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrl({
+      orgMode: "multi_org",
+      signedPreviewUrl: "https://8787-active.daytonaproxy01.net/signed",
+      returnUrl: "https://8787-active.daytonaproxy01.net/",
+    })).toBe("https://8787-active.daytonaproxy01.net/signin")
+  })
+
+  test("rejects a rotated hostname even on the same preview suffix (shared proxy zone)", async () => {
+    const { approveWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+
+    // Every Daytona customer gets origins under the same proxy zone, so a
+    // suffix match would approve an attacker-controlled sandbox.
+    expect(approveWebHandoffReturnUrl({
+      orgMode: "multi_org",
+      signedPreviewUrl: "https://8787-old.daytonaproxy01.net/signed",
+      returnUrl: "https://8787-new.daytonaproxy01.net/signin",
+    })).toBe(null)
+  })
+
+  test("rejects an http web returnUrl", async () => {
+    const { approveWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrl({
+      orgMode: "multi_org",
+      signedPreviewUrl: "https://8787-active.daytonaproxy01.net/signed",
+      returnUrl: "http://8787-active.daytonaproxy01.net/signin",
+    })).toBeNull()
+  })
+
+  test("rejects a web returnUrl with the wrong preview suffix", async () => {
+    const { approveWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrl({
+      orgMode: "multi_org",
+      signedPreviewUrl: "https://8787-active.daytonaproxy01.net/signed",
+      returnUrl: "https://8787-active.evil.example/signin",
+    })).toBeNull()
+  })
+
+  test("rejects a web returnUrl in single_org mode", async () => {
+    const { approveWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrl({
+      orgMode: "single_org",
+      signedPreviewUrl: "https://8787-active.daytonaproxy01.net/signed",
+      returnUrl: "https://8787-active.daytonaproxy01.net/signin",
+    })).toBeNull()
+  })
+
+  test("rejects a web returnUrl with path traversal", async () => {
+    const { approveWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrl({
+      orgMode: "multi_org",
+      signedPreviewUrl: "https://8787-active.daytonaproxy01.net/signed",
+      returnUrl: "https://8787-active.daytonaproxy01.net/dashboard/../signin",
+    })).toBeNull()
+  })
+
+  test("rejects a web returnUrl with userinfo", async () => {
+    const { approveWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrl({
+      orgMode: "multi_org",
+      signedPreviewUrl: "https://8787-active.daytonaproxy01.net/signed",
+      returnUrl: "https://user@8787-active.daytonaproxy01.net/signin",
+    })).toBeNull()
   })
 })

--- a/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/auth-screen.tsx
@@ -47,8 +47,8 @@ export function AuthScreen() {
   const router = useRouter();
   const pathname = usePathname();
   const routingRef = useRef(false);
-  const { user, sessionHydrated, desktopAuthRequested, resolveUserLandingRoute } = useDenFlow();
-  const hasResolvedSession = sessionHydrated && Boolean(user) && !desktopAuthRequested;
+  const { user, sessionHydrated, desktopAuthRequested, webAuthRequested, resolveUserLandingRoute } = useDenFlow();
+  const hasResolvedSession = sessionHydrated && Boolean(user) && !desktopAuthRequested && !webAuthRequested;
 
   useEffect(() => {
     if (!hasResolvedSession || routingRef.current) {

--- a/ee/apps/den-web/app/(den)/_lib/den-flow.ts
+++ b/ee/apps/den-web/app/(den)/_lib/den-flow.ts
@@ -313,7 +313,7 @@ export function getSocialCallbackUrl(authCallbackBaseUrl = ""): string {
     const callbackUrl = new URL("/", origin);
     if (typeof window !== "undefined") {
       const params = new URLSearchParams(window.location.search);
-      for (const key of ["mode", "desktopAuth", "desktopScheme", "invite", "intent"]) {
+      for (const key of ["mode", "desktopAuth", "desktopScheme", "webAuth", "webAuthReturn", "invite", "intent"]) {
         const value = params.get(key)?.trim() ?? "";
         if (value) {
           callbackUrl.searchParams.set(key, value);

--- a/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
+++ b/ee/apps/den-web/app/(den)/_providers/den-flow-provider.tsx
@@ -95,6 +95,7 @@ type DenFlowContextValue = {
   sessionHydrated: boolean;
   desktopAuthRequested: boolean;
   desktopAuthScheme: string;
+  webAuthRequested: boolean;
   desktopRedirectUrl: string | null;
   desktopRedirectBusy: boolean;
   showAuthFeedback: boolean;
@@ -222,9 +223,13 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   const [sessionHydrated, setSessionHydrated] = useState(false);
   const [desktopAuthRequested, setDesktopAuthRequested] = useState(false);
   const [desktopAuthScheme, setDesktopAuthScheme] = useState("openwork");
+  const [webAuthRequested, setWebAuthRequested] = useState(false);
+  const [webAuthReturnUrl, setWebAuthReturnUrl] = useState<string | null>(null);
   const [desktopRedirectBusy, setDesktopRedirectBusy] = useState(false);
   const [desktopRedirectUrl, setDesktopRedirectUrl] = useState<string | null>(null);
   const [desktopRedirectAttempted, setDesktopRedirectAttempted] = useState(false);
+  const [webRedirectBusy, setWebRedirectBusy] = useState(false);
+  const [webRedirectAttempted, setWebRedirectAttempted] = useState(false);
   const [billingSummary, setBillingSummary] = useState<BillingSummary | null>(null);
   const [billingBusy, setBillingBusy] = useState(false);
   const [billingError, setBillingError] = useState<string | null>(null);
@@ -479,6 +484,11 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     }
 
     if (desktopAuthRequested) {
+      setAuthInfo("Signed in. Returning to OpenWork...");
+      return null;
+    }
+
+    if (webAuthRequested) {
       setAuthInfo("Signed in. Returning to OpenWork...");
       return null;
     }
@@ -1019,6 +1029,63 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
       setAuthError(error instanceof Error ? error.message : "Failed to open OpenWork.");
     } finally {
       setDesktopRedirectBusy(false);
+    }
+  }
+
+  function getWebHandoffReturnUrl(payload: unknown) {
+    if (typeof payload !== "object" || payload === null || !("returnUrl" in payload)) {
+      return null;
+    }
+
+    const returnUrl = payload.returnUrl;
+    return typeof returnUrl === "string" && returnUrl.trim() ? returnUrl.trim() : null;
+  }
+
+  async function completeWebAuthHandoff() {
+    if (!webAuthRequested || webRedirectBusy) {
+      return;
+    }
+
+    setWebRedirectBusy(true);
+    setWebRedirectAttempted(true);
+    setAuthError(null);
+
+    try {
+      if (!webAuthReturnUrl) {
+        setAuthError("Web handoff failed because no return URL was provided.");
+        return;
+      }
+
+      const headers = new Headers();
+      if (authToken) {
+        headers.set("Authorization", `Bearer ${authToken}`);
+      }
+
+      const { response, payload } = await requestJson("/v1/auth/desktop-handoff", {
+        method: "POST",
+        headers,
+        body: JSON.stringify({ returnUrl: webAuthReturnUrl })
+      });
+
+      if (!response.ok) {
+        setAuthError(getErrorMessage(payload, `Web handoff failed with ${response.status}.`));
+        return;
+      }
+
+      const grant = getDesktopHandoffGrant(payload, null) ?? "";
+      const approvedReturnUrl = getWebHandoffReturnUrl(payload) ?? "";
+      if (!grant || !approvedReturnUrl) {
+        setAuthError("Web handoff succeeded, but no Cloud return URL was returned.");
+        return;
+      }
+
+      const redirectUrl = new URL(approvedReturnUrl);
+      redirectUrl.searchParams.set("grant", grant);
+      window.location.replace(redirectUrl.toString());
+    } catch (error) {
+      setAuthError(error instanceof Error ? error.message : "Failed to return to OpenWork Cloud.");
+    } finally {
+      setWebRedirectBusy(false);
     }
   }
 
@@ -1781,6 +1848,9 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     if (/^[a-z][a-z0-9+.-]*$/i.test(requestedScheme)) {
       setDesktopAuthScheme(requestedScheme);
     }
+    setWebAuthRequested(params.get("webAuth") === "1");
+    const requestedWebReturnUrl = params.get("webAuthReturn")?.trim() ?? "";
+    setWebAuthReturnUrl(requestedWebReturnUrl || null);
 
     const invitationId = params.get("invite")?.trim() ?? "";
     if (invitationId) {
@@ -2016,6 +2086,14 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
   }, [desktopAuthRequested, user?.id, authToken, desktopRedirectUrl, desktopRedirectBusy, desktopRedirectAttempted, desktopAuthScheme]);
 
   useEffect(() => {
+    if (!webAuthRequested || !user || webRedirectBusy || webRedirectAttempted) {
+      return;
+    }
+
+    void completeWebAuthHandoff();
+  }, [webAuthRequested, webAuthReturnUrl, user?.id, authToken, webRedirectBusy, webRedirectAttempted]);
+
+  useEffect(() => {
     if (!user || !onboardingPending) {
       onboardingAutoLaunchKeyRef.current = null;
       return;
@@ -2084,6 +2162,7 @@ export function DenFlowProvider({ children }: { children: ReactNode }) {
     sessionHydrated,
     desktopAuthRequested,
     desktopAuthScheme,
+    webAuthRequested,
     desktopRedirectUrl,
     desktopRedirectBusy,
     showAuthFeedback,


### PR DESCRIPTION
## What broke

Signing in from inside a Cloud instance dead-ended on the den-web dashboard. Three verified gaps:

1. `buildDenAuthUrl` (`apps/app/src/app/lib/den.ts:774`) only sent handoff params for **desktop** deployments — web got a bare `?mode=sign-in`.
2. den-web's grant machinery only delivered grants via the `openwork://` deep link.
3. The web sign-in page never consumed a `?grant=` query param.

So den-web signed you in to the dashboard, and the instance tab never heard about it. (Prod incident: reported by an admin on the live Cloud alpha.)

## The loop this adds

instance → den-web `?webAuth=1&webAuthReturn=<instance origin>` → den-web signs the user in → mints the **existing** one-time, 5-min handoff grant with `returnUrl` → redirects to the **server-approved** URL with `?grant=` → `ForcedSigninPage` exchanges it via the existing paste-code path and strips it from the URL.

No new auth primitives: same grant, same exchange endpoint, same TTL/one-time semantics.

## Security model (the important part)

`returnUrl` is validated **fail-closed in den-api** — den-web never trusts the query param:

- multi-org deployments only (self-hosted rejects).
- `https:` only; no userinfo, no fragment, no path traversal; path must be `/` or `/signin`, normalized to `/signin`.
- **Origin must exactly equal the caller org's live Cloud instance preview URL.** Suffix matching was implemented and then deliberately removed: the Daytona preview proxy zone (`*.daytonaproxy01.net`) is shared by every Daytona customer, so any suffix rule would approve an attacker-controlled sandbox origin and hand it a session grant. There's a regression test asserting the rotated-same-suffix case is **rejected**.
- Known trade-off: if the preview URL re-signs between opening the instance and signing in, validation fails closed and the user reopens Cloud for a fresh URL. Rare, honest, and disappears entirely with the gateway (stable origin).

## Tests run

| Command | Result |
|---|---|
| `pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/desktop-handoff-public-url.test.ts` | **8 pass / 0 fail** (exact-origin approved; rotated-suffix, http, userinfo, traversal, single-org all rejected) |
| den-api / den-web / app typechecks | all PASS |
| `pnpm --filter @openwork/app build:web` | PASS; `webAuthReturn` confirmed in the built bundle |

## Not verified end-to-end yet

The full browser loop needs the deploy chain: den-api + den-web deploys **plus a new snapshot publish** (the instance serves the SPA from the baked image, which must carry the `?grant=` consumer) and a `DAYTONA_SNAPSHOT` repoint. Until the snapshot ships, prod instances keep the old sign-in button behavior. Happy to run the deploy chain + a live verification pass on merge.
