### PR TITLE
fix(release): stage server npm package

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -39,7 +39,7 @@ on:
         type: boolean
         default: true
       publish_npm:
-        description: "Publish openwork-orchestrator/openwork-server to npm if versions changed"
+        description: "Publish openwork-server to npm if its version changed"
         required: false
         type: boolean
         default: true
@@ -709,7 +709,7 @@ jobs:
           gh release upload "$tag" apps/orchestrator/dist/bin/* apps/orchestrator/dist/sidecars/* --repo "$GITHUB_REPOSITORY" --clobber
 
   publish-npm:
-    name: Publish npm packages
+    name: Publish openwork-server
     needs: [resolve-release, verify-release, release-orchestrator-sidecars]
     if: |
       always() &&
@@ -766,38 +766,26 @@ jobs:
         id: package-versions
         shell: bash
         run: |
-          node -e "const fs=require('fs'); const orchestrator=JSON.parse(fs.readFileSync('apps/orchestrator/package.json','utf8')); const server=JSON.parse(fs.readFileSync('apps/server/package.json','utf8')); console.log('orchestrator=' + orchestrator.version); console.log('server=' + server.version);" >> "$GITHUB_OUTPUT"
+          node -e "const fs=require('fs'); const server=JSON.parse(fs.readFileSync('apps/server/package.json','utf8')); console.log('server=' + server.version);" >> "$GITHUB_OUTPUT"
 
       - name: Check npm versions
         id: npm-versions
         shell: bash
         env:
-          ORCHESTRATOR_VERSION: ${{ steps.package-versions.outputs.orchestrator }}
           SERVER_VERSION: ${{ steps.package-versions.outputs.server }}
         run: |
           set -euo pipefail
           # npm view exits non-zero for packages that don't exist yet (404).
           # Treat missing packages as "not published" so release can publish them.
-          orchestrator_current="$(npm view openwork-orchestrator version 2>/dev/null || true)"
           server_current="$(npm view openwork-server version 2>/dev/null || true)"
-
-          if [ "$orchestrator_current" = "$ORCHESTRATOR_VERSION" ]; then
-            echo "publish_orchestrator=false" >> "$GITHUB_OUTPUT"
-          else
-            echo "publish_orchestrator=true" >> "$GITHUB_OUTPUT"
-          fi
 
           if [ "$server_current" = "$SERVER_VERSION" ]; then
             echo "publish_server=false" >> "$GITHUB_OUTPUT"
+            echo "publish_any=false" >> "$GITHUB_OUTPUT"
           else
             echo "publish_server=true" >> "$GITHUB_OUTPUT"
+            echo "publish_any=true" >> "$GITHUB_OUTPUT"
           fi
-
-          publish_any=false
-          if [ "$orchestrator_current" != "$ORCHESTRATOR_VERSION" ] || [ "$server_current" != "$SERVER_VERSION" ]; then
-            publish_any=true
-          fi
-          echo "publish_any=$publish_any" >> "$GITHUB_OUTPUT"
 
       - name: Ensure npm auth
         id: npm-auth
@@ -824,22 +812,7 @@ jobs:
 
       - name: Publish openwork-server
         if: steps.npm-auth.outputs.enabled == 'true' && steps.npm-versions.outputs.publish_server == 'true'
-        run: pnpm --filter openwork-server publish --access public --no-git-checks
-
-      - name: Publish openwork-orchestrator
-        if: steps.npm-auth.outputs.enabled == 'true' && steps.npm-versions.outputs.publish_orchestrator == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-          ORCHESTRATOR_VERSION: ${{ steps.package-versions.outputs.orchestrator }}
-        run: |
-          set -euo pipefail
-          tag="openwork-orchestrator-v${ORCHESTRATOR_VERSION}"
-          if ! gh release view "$tag" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
-            echo "openwork-orchestrator sidecar release $tag not found. Publish sidecars before openwork-orchestrator." >&2
-            exit 1
-          fi
-          pnpm --filter openwork-orchestrator build:bin:all
-          node apps/orchestrator/scripts/publish-npm.mjs
+        run: pnpm --filter openwork-server publish:npm --access public
 
   publish-daytona-snapshot:
     name: Build + Push Daytona Snapshot

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,6 +13,7 @@
     "build": "tsc -p tsconfig.json && bun build src/opencode-plugins/openwork-extensions-preview.ts src/opencode-plugins/openwork-capabilities-knowledge.ts src/opencode-plugins/openwork-office-attachments.ts src/opencode-plugins/openwork-anthropic-adaptive-thinking.ts src/opencode-plugins/openwork-anthropic-tool-schema.ts --outdir dist/opencode-plugins --target node --format esm",
     "build:bin": "bun build --compile src/cli.ts --outfile dist/bin/openwork-server",
     "build:bin:all": "bun ./script/build.ts --outdir dist/bin --target bun-darwin-arm64 --target bun-darwin-x64 --target bun-linux-x64 --target bun-linux-arm64 --target bun-windows-x64 --target bun-windows-arm64",
+    "publish:npm": "pnpm build:bin && node scripts/publish-npm.mjs",
     "start": "bun dist/cli.js",
     "typecheck": "tsc -p tsconfig.json --noEmit",
     "prepublishOnly": "pnpm build:bin"
@@ -46,7 +47,6 @@
     ".": "./src/index.ts"
   },
   "dependencies": {
-    "@openwork/paths": "workspace:*",
     "@opencode-ai/sdk": "^1.17.11",
     "better-sqlite3": "^11.10.0",
     "drizzle-orm": "^0.45.1",
@@ -56,6 +56,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@openwork/paths": "workspace:*",
     "@openwork/types": "workspace:*",
     "@types/better-sqlite3": "^7.6.13",
     "@types/minimatch": "^5.1.2",

--- a/apps/server/scripts/publish-npm.mjs
+++ b/apps/server/scripts/publish-npm.mjs
@@ -1,0 +1,59 @@
+import { spawnSync } from "node:child_process";
+import { cp, mkdir, readFile, rm, writeFile } from "node:fs/promises";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+async function main() {
+  const packageRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+  const outputRoot = resolve(packageRoot, "dist/npm");
+  const sourcePackage = JSON.parse(
+    await readFile(resolve(packageRoot, "package.json"), "utf8")
+  );
+
+  const publishedPackage = {
+    name: sourcePackage.name,
+    version: sourcePackage.version,
+    description: sourcePackage.description,
+    type: sourcePackage.type,
+    bin: sourcePackage.bin,
+    repository: sourcePackage.repository,
+    homepage: sourcePackage.homepage,
+    bugs: sourcePackage.bugs,
+    keywords: sourcePackage.keywords,
+    license: sourcePackage.license,
+    publishConfig: sourcePackage.publishConfig
+  };
+
+  await rm(outputRoot, { recursive: true, force: true });
+  await mkdir(resolve(outputRoot, "bin"), { recursive: true });
+  await mkdir(resolve(outputRoot, "dist/bin"), { recursive: true });
+  await cp(
+    resolve(packageRoot, "bin/openwork-server.mjs"),
+    resolve(outputRoot, "bin/openwork-server.mjs")
+  );
+  await cp(
+    resolve(packageRoot, "dist/bin/openwork-server"),
+    resolve(outputRoot, "dist/bin/openwork-server")
+  );
+  await cp(resolve(packageRoot, "README.md"), resolve(outputRoot, "README.md"));
+  await writeFile(
+    resolve(outputRoot, "package.json"),
+    `${JSON.stringify(publishedPackage, null, 2)}\n`
+  );
+
+  const pnpmCli = process.env.npm_execpath;
+  if (!pnpmCli) throw new Error("pnpm executable path is unavailable");
+
+  const result = spawnSync(
+    process.execPath,
+    [pnpmCli, "--config.git-checks=false", "publish", ...process.argv.slice(2)],
+    { cwd: outputRoot, stdio: "inherit" }
+  );
+  if (result.error) throw result.error;
+  process.exit(result.status ?? 1);
+}
+
+main().catch(error => {
+  console.error(error);
+  process.exit(1);
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -332,9 +332,6 @@ importers:
       '@opencode-ai/sdk':
         specifier: ^1.17.11
         version: 1.17.11
-      '@openwork/paths':
-        specifier: workspace:*
-        version: link:../../packages/paths
       better-sqlite3:
         specifier: ^11.10.0
         version: 11.10.0
@@ -354,6 +351,9 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@openwork/paths':
+        specifier: workspace:*
+        version: link:../../packages/paths
       '@openwork/types':
         specifier: workspace:*
         version: link:../../packages/types


### PR DESCRIPTION
## Summary
- stage the compiled openwork-server CLI with a publish-only manifest that excludes private workspace dependencies
- publish openwork-server through the staged npm package
- remove obsolete openwork-orchestrator npm version checks and publishing while preserving sidecar releases

## Validation
- `pnpm --filter openwork-server publish:npm --dry-run --access public` (passed)
- `node apps/server/dist/npm/bin/openwork-server.mjs --version` (passed: 0.18.2)
- `pnpm --filter openwork-server typecheck` (passed)
- `pnpm release:review` (passed with expected local sidecar warnings)
- workflow YAML parse (passed)
- `git diff --check` (passed)
- `pnpm --filter openwork-server test` (existing unrelated failures: stale `dist/*.test.js` files and unavailable `node:sqlite` under Bun; 1077 passed, 4 failed, 3 errors)