### PR TITLE
fix(den): CORS for handoff exchange from rotating Cloud instance origins

### DIFF
--- a/ee/apps/den-api/src/app.ts
+++ b/ee/apps/den-api/src/app.ts
@@ -86,6 +86,25 @@ registerAppErrorHandler(app, (error, c, requestId) => {
   return operationalErrorResponse(error, c, requestId)
 })
 
+// The handoff exchange is called from Cloud instance pages, whose Daytona
+// preview origins rotate on every re-sign and can never be statically
+// allowlisted. Reflecting the origin here is safe because this route is
+// authenticated solely by the one-time, 5-minute grant in the request body
+// and never consults cookies or sessions - a hostile page gains nothing
+// without a valid grant. Registered before the global CORS middleware so it
+// answers the preflight for exactly this path; every other route keeps the
+// strict allowlist below.
+app.use(
+  "/v1/auth/desktop-handoff/exchange",
+  cors({
+    origin: (origin) => origin,
+    credentials: true,
+    allowHeaders: ["Content-Type", "Authorization", "X-Request-Id"],
+    allowMethods: ["POST", "OPTIONS"],
+    maxAge: 600,
+  }),
+)
+
 if (env.corsOrigins.length > 0) {
   app.use(
     "*",

--- a/ee/apps/den-api/test/handoff-exchange-cors.test.ts
+++ b/ee/apps/den-api/test/handoff-exchange-cors.test.ts
@@ -1,0 +1,62 @@
+import { beforeAll, describe, expect, test } from "bun:test"
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.DEN_API_PUBLIC_URL = process.env.DEN_API_PUBLIC_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://localhost:3005"
+}
+
+let app: typeof import("../src/app.js")["default"]
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  app = (await import("../src/app.js")).default
+})
+
+// Cloud instance pages live on rotating Daytona preview origins that can
+// never be statically allowlisted. The handoff exchange is grant-in-body
+// authenticated and ignores cookies, so it reflects any origin; every other
+// route must keep the strict allowlist.
+const INSTANCE_ORIGIN = "https://8787-rotating.daytonaproxy01.net"
+
+describe("handoff exchange CORS", () => {
+  test("preflight on the exchange route reflects a rotating instance origin", async () => {
+    const res = await app.request("/v1/auth/desktop-handoff/exchange", {
+      method: "OPTIONS",
+      headers: {
+        Origin: INSTANCE_ORIGIN,
+        "Access-Control-Request-Method": "POST",
+        "Access-Control-Request-Headers": "content-type,authorization",
+      },
+    })
+    expect(res.status).toBe(204)
+    expect(res.headers.get("access-control-allow-origin")).toBe(INSTANCE_ORIGIN)
+    expect(res.headers.get("access-control-allow-credentials")).toBe("true")
+    expect(res.headers.get("access-control-allow-methods") ?? "").toContain("POST")
+  })
+
+  test("other routes do NOT reflect unknown origins", async () => {
+    const res = await app.request("/v1/me", {
+      method: "OPTIONS",
+      headers: {
+        Origin: INSTANCE_ORIGIN,
+        "Access-Control-Request-Method": "GET",
+      },
+    })
+    expect(res.headers.get("access-control-allow-origin")).toBeNull()
+  })
+
+  test("allowlisted origins still work on other routes", async () => {
+    const res = await app.request("/v1/me", {
+      method: "OPTIONS",
+      headers: {
+        Origin: "http://localhost:3005",
+        "Access-Control-Request-Method": "GET",
+      },
+    })
+    expect(res.headers.get("access-control-allow-origin")).toBe("http://localhost:3005")
+  })
+})


### PR DESCRIPTION
Prod sign-in blocker: the grant-exchange preflight from a Cloud instance origin (`https://8787-<id>.daytonaproxy01.net`) gets no `Access-Control-Allow-Origin` — instance origins rotate per re-sign and cannot be statically allowlisted.

Fix: reflect the origin **only** on `POST /v1/auth/desktop-handoff/exchange` (registered before the global allowlist CORS). Safe on this route alone: it authenticates solely via the one-time 5-minute grant in the body and ignores cookies/sessions entirely.

Tests (against the real `app.ts`): rotating origin reflected on the exchange route · same origin NOT reflected on `/v1/me` · allowlisted origins unaffected. `pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/handoff-exchange-cors.test.ts` → 3 pass. Typecheck clean.

Follow-up (tracked): the broader instance→Den surface (Connect UI in the instance) still needs dynamic-origin CORS or the Phase-2 gateway; this PR unblocks sign-in only.