### PR TITLE
fix(cloud): require org choice after handoff

### DIFF
--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.test.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.test.tsx
@@ -1,0 +1,112 @@
+/** @jsxImportSource react */
+declare const describe: (name: string, fn: () => void) => void;
+declare const test: (name: string, fn: () => void) => void;
+declare const expect: (value: unknown) => {
+  toBe: (expected: unknown) => void;
+  toContain: (expected: string) => void;
+  toEqual: (expected: unknown) => void;
+};
+
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { DenOrgSummary } from "../../../app/lib/den";
+import {
+  OrganizationList,
+  initialOrgOnboardingSelectionState,
+  resolveOrgOnboardingPostListStep,
+} from "./org-onboarding-page";
+
+function org(id: string, name: string): DenOrgSummary {
+  return {
+    id,
+    name,
+    slug: name.toLowerCase().replaceAll(" ", "-"),
+    role: "member",
+  };
+}
+
+describe("org onboarding organization choice", () => {
+  test("keeps a recent handoff unselected so two orgs render the chooser", () => {
+    const currentOrg = org("org-current", "Acme Robotics");
+    const otherOrg = org("org-other", "Beta Labs");
+    const initial = initialOrgOnboardingSelectionState();
+    const step = resolveOrgOnboardingPostListStep({
+      orgs: [currentOrg, otherOrg],
+      activeOrgId: currentOrg.id,
+      hasSelectedOrganization: initial.hasSelectedOrganization,
+      autoContinueResources: initial.autoContinueResources,
+      autoSelectFailedOrgId: null,
+    });
+
+    expect(step.kind).toBe("choose-org");
+    const markup = renderToStaticMarkup(
+      <OrganizationList
+        orgs={[currentOrg, otherOrg]}
+        value={currentOrg}
+        onValueChange={() => {}}
+      />,
+    );
+    expect(markup).toContain("Acme Robotics");
+    expect(markup).toContain("Beta Labs");
+  });
+
+  test("auto-selects and auto-continues resources for one org", () => {
+    const soloOrg = org("org-solo", "Solo Workspace");
+    const initial = initialOrgOnboardingSelectionState();
+    const autoSelectStep = resolveOrgOnboardingPostListStep({
+      orgs: [soloOrg],
+      activeOrgId: "",
+      hasSelectedOrganization: initial.hasSelectedOrganization,
+      autoContinueResources: initial.autoContinueResources,
+      autoSelectFailedOrgId: null,
+    });
+
+    expect(autoSelectStep).toEqual({
+      kind: "auto-select-single-org",
+      organization: soloOrg,
+    });
+
+    const resourceStep = resolveOrgOnboardingPostListStep({
+      orgs: [soloOrg],
+      activeOrgId: soloOrg.id,
+      hasSelectedOrganization: true,
+      autoContinueResources: true,
+      autoSelectFailedOrgId: null,
+    });
+
+    expect(resourceStep).toEqual({ kind: "resources", autoContinue: true });
+  });
+
+  test("shows the chooser for two orgs without a handoff", () => {
+    const firstOrg = org("org-first", "First Workspace");
+    const activeOrg = org("org-active", "Active Workspace");
+    const step = resolveOrgOnboardingPostListStep({
+      orgs: [firstOrg, activeOrg],
+      activeOrgId: activeOrg.id,
+      hasSelectedOrganization: false,
+      autoContinueResources: false,
+      autoSelectFailedOrgId: null,
+    });
+
+    expect(step).toEqual({
+      kind: "choose-org",
+      defaultOrganization: activeOrg,
+    });
+  });
+
+  test("falls back to the chooser when single-org auto-selection failed", () => {
+    const soloOrg = org("org-solo", "Solo Workspace");
+    const step = resolveOrgOnboardingPostListStep({
+      orgs: [soloOrg],
+      activeOrgId: soloOrg.id,
+      hasSelectedOrganization: false,
+      autoContinueResources: false,
+      autoSelectFailedOrgId: soloOrg.id,
+    });
+
+    expect(step).toEqual({
+      kind: "choose-org",
+      defaultOrganization: soloOrg,
+    });
+  });
+});

--- a/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/org-onboarding-page.tsx
@@ -331,11 +331,53 @@ function markProvidersSeen(providers: DenOrgLlmProvider[]) {
   } catch {}
 }
 
-function readHandoffAutoContinueFlag() {
-  if (typeof window === "undefined") return false;
-  const raw = window.sessionStorage.getItem(DEN_HANDOFF_AUTO_CONTINUE_KEY);
-  const timestamp = Number(raw);
-  return Number.isFinite(timestamp) && Date.now() - timestamp < 5 * 60_000;
+type OrgOnboardingInitialSelectionState = {
+  hasSelectedOrganization: boolean;
+  autoContinueResources: boolean;
+};
+
+export function initialOrgOnboardingSelectionState(): OrgOnboardingInitialSelectionState {
+  return {
+    hasSelectedOrganization: false,
+    autoContinueResources: false,
+  };
+}
+
+type OrgOnboardingPostListStep =
+  | { kind: "auto-select-single-org"; organization: DenOrgSummary }
+  | { kind: "choose-org"; defaultOrganization: DenOrgSummary }
+  | { kind: "resources"; autoContinue: boolean };
+
+export function resolveOrgOnboardingPostListStep({
+  orgs,
+  activeOrgId,
+  hasSelectedOrganization,
+  autoContinueResources,
+  autoSelectFailedOrgId,
+}: {
+  orgs: DenOrgSummary[];
+  activeOrgId: string;
+  hasSelectedOrganization: boolean;
+  autoContinueResources: boolean;
+  autoSelectFailedOrgId: string | null;
+}): OrgOnboardingPostListStep {
+  const singleOrg = orgs.length === 1 ? orgs[0] : null;
+
+  if (orgs.length > 0 && !hasSelectedOrganization) {
+    if (singleOrg && autoSelectFailedOrgId !== singleOrg.id) {
+      return { kind: "auto-select-single-org", organization: singleOrg };
+    }
+
+    return {
+      kind: "choose-org",
+      defaultOrganization: orgs.find((org) => org.id === activeOrgId) ?? orgs[0],
+    };
+  }
+
+  return {
+    kind: "resources",
+    autoContinue: autoContinueResources || orgs.length <= 1,
+  };
 }
 
 /**
@@ -350,16 +392,16 @@ export function OrgOnboardingPage() {
   const { authToken, denClient, orgId, settings } = useDenClient();
   const { markRouteReady } = useBootState();
   const prepared = usePreparedBootstrap();
-  const handoffAutoContinueRef = useRef<boolean | null>(null);
-  if (handoffAutoContinueRef.current === null) {
-    handoffAutoContinueRef.current = readHandoffAutoContinueFlag();
-  }
-  const handoffAutoContinue = handoffAutoContinueRef.current === true;
-  const [hasSelectedOrganization, setHasSelectedOrganization] = useState(handoffAutoContinue);
-  const [autoContinueResources, setAutoContinueResources] = useState(handoffAutoContinue);
+  const initialSelectionState = initialOrgOnboardingSelectionState();
+  const [hasSelectedOrganization, setHasSelectedOrganization] = useState(
+    initialSelectionState.hasSelectedOrganization,
+  );
+  const [autoContinueResources, setAutoContinueResources] = useState(
+    initialSelectionState.autoContinueResources,
+  );
   const [autoSelectFailedOrgId, setAutoSelectFailedOrgId] = useState<string | null>(null);
   const autoSelectingOrgIdRef = useRef<string | null>(null);
-  
+
   useEffect(() => {
     window.dispatchEvent(new CustomEvent(orgOnboardingVisibilityEvent, { detail: { visible: true } }));
     return () => {
@@ -396,34 +438,42 @@ export function OrgOnboardingPage() {
     queryFn: () => denClient.listOrgs(),
   });
   const orgs = data?.orgs ?? [];
-  const singleOrg = orgs.length === 1 ? orgs[0] : null;
+  const postListStep = resolveOrgOnboardingPostListStep({
+    orgs,
+    activeOrgId: orgId,
+    hasSelectedOrganization,
+    autoContinueResources,
+    autoSelectFailedOrgId,
+  });
+  const autoSelectOrg = postListStep.kind === "auto-select-single-org"
+    ? postListStep.organization
+    : null;
 
   useEffect(() => {
-    if (!authToken || hasSelectedOrganization || !singleOrg) return;
-    if (autoSelectFailedOrgId === singleOrg.id) return;
-    if (autoSelectingOrgIdRef.current === singleOrg.id) return;
+    if (!authToken || !autoSelectOrg) return;
+    if (autoSelectingOrgIdRef.current === autoSelectOrg.id) return;
 
     let cancelled = false;
-    autoSelectingOrgIdRef.current = singleOrg.id;
+    autoSelectingOrgIdRef.current = autoSelectOrg.id;
     void denClient
-      .setActiveOrganization({ organizationId: singleOrg.id })
+      .setActiveOrganization({ organizationId: autoSelectOrg.id })
       .then(() => {
         if (cancelled) return;
         writeDenSettings({
           ...settings,
           authToken: authToken || null,
-          activeOrgId: singleOrg.id,
-          activeOrgSlug: singleOrg.slug,
-          activeOrgName: singleOrg.name,
+          activeOrgId: autoSelectOrg.id,
+          activeOrgSlug: autoSelectOrg.slug,
+          activeOrgName: autoSelectOrg.name,
         });
         setAutoContinueResources(true);
         setHasSelectedOrganization(true);
       })
       .catch(() => {
-        if (!cancelled) setAutoSelectFailedOrgId(singleOrg.id);
+        if (!cancelled) setAutoSelectFailedOrgId(autoSelectOrg.id);
       })
       .finally(() => {
-        if (autoSelectingOrgIdRef.current === singleOrg.id) {
+        if (autoSelectingOrgIdRef.current === autoSelectOrg.id) {
           autoSelectingOrgIdRef.current = null;
         }
       });
@@ -431,7 +481,7 @@ export function OrgOnboardingPage() {
     return () => {
       cancelled = true;
     };
-  }, [authToken, autoSelectFailedOrgId, denClient, hasSelectedOrganization, settings, singleOrg]);
+  }, [authToken, autoSelectOrg, denClient, settings]);
 
   if (!authToken) {
     return prepared ? <PreparedWorkspacePage prepared={prepared} /> : null;
@@ -477,34 +527,31 @@ export function OrgOnboardingPage() {
     );
   }
 
-  if (orgs.length > 0 && !hasSelectedOrganization) {
-    if (singleOrg && autoSelectFailedOrgId !== singleOrg.id) {
-      return (
-        <Page>
-          <PageBackground />
-          <PageTitlebarRegion />
-          <PageContainer>
-            <PageHeader>
-              <PageTitle>Your organization</PageTitle>
-            </PageHeader>
-            <PageContent>
-              <PageLoading>
-                <PageLoadingSpinner />
-                <PageLoadingDescription>Loading organizations...</PageLoadingDescription>
-              </PageLoading>
-            </PageContent>
-          </PageContainer>
-        </Page>
-      );
-    }
+  if (postListStep.kind === "auto-select-single-org") {
+    return (
+      <Page>
+        <PageBackground />
+        <PageTitlebarRegion />
+        <PageContainer>
+          <PageHeader>
+            <PageTitle>Your organization</PageTitle>
+          </PageHeader>
+          <PageContent>
+            <PageLoading>
+              <PageLoadingSpinner />
+              <PageLoadingDescription>Loading organizations...</PageLoadingDescription>
+            </PageLoading>
+          </PageContent>
+        </PageContainer>
+      </Page>
+    );
+  }
 
+  if (postListStep.kind === "choose-org") {
     return (
       <OrganizationSelectionPage
         orgs={orgs}
-        defaultOrganization={
-          orgs.find((org) => org.id === orgId) ??
-          orgs[0]
-        }
+        defaultOrganization={postListStep.defaultOrganization}
         onContinue={() => {
           setAutoContinueResources(false);
           setHasSelectedOrganization(true);
@@ -515,7 +562,7 @@ export function OrgOnboardingPage() {
 
   return (
     <ResourceSelectionPage
-      autoContinue={autoContinueResources || orgs.length <= 1}
+      autoContinue={postListStep.autoContinue}
     />
   );
 }

--- a/evals/flows/org-chooser-handoff-regression.flow.mjs
+++ b/evals/flows/org-chooser-handoff-regression.flow.mjs
@@ -1,0 +1,275 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("org-chooser-handoff-regression");
+
+const DEFAULT_ORG = {
+  id: "org-acme-fixture",
+  name: "Acme Robotics",
+  slug: "acme-robotics",
+  role: "admin",
+};
+const TARGET_ORG = {
+  id: "org-beta-fixture",
+  name: "Beta Labs",
+  slug: "beta-labs",
+  role: "member",
+};
+const ORGS = [DEFAULT_ORG, TARGET_ORG];
+
+function installFixtureExpression() {
+  return `(() => {
+    const orgs = ${JSON.stringify(ORGS)};
+    const defaultOrg = orgs[0];
+    const targetOrg = orgs[1];
+    const originalFetch = window.__openworkOrgChooserOriginalFetch ?? window.fetch.bind(window);
+    window.__openworkOrgChooserOriginalFetch = originalFetch;
+    window.__openworkOrgChooserFixture = {
+      calls: [],
+      requests: [],
+      selectedOrgId: defaultOrg.id,
+    };
+    const fixture = window.__openworkOrgChooserFixture;
+    const json = (payload, status = 200) => new Response(JSON.stringify(payload), {
+      status,
+      headers: { "content-type": "application/json" },
+    });
+    window.fetch = async (input, init = {}) => {
+      const rawUrl = typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.toString()
+          : input.url;
+      const url = new URL(rawUrl, window.location.origin);
+      if (!url.pathname.startsWith("/api/den/")) {
+        return originalFetch(input, init);
+      }
+
+      const method = String(init.method ?? "GET").toUpperCase();
+      const path = url.pathname.replace("/api/den", "");
+      const headers = new Headers(init.headers ?? {});
+      fixture.requests.push({
+        method,
+        path,
+        organizationId: headers.get("x-openwork-organization-id") ?? null,
+      });
+
+      if (method === "GET" && path === "/v1/me") {
+        return json({ user: { id: "user-fixture", email: "alex@example.test", name: "Alex" } });
+      }
+
+      if (method === "GET" && path === "/v1/me/orgs") {
+        return json({
+          orgs,
+          activeOrgId: defaultOrg.id,
+          activeOrgSlug: defaultOrg.slug,
+          defaultOrgId: defaultOrg.id,
+        });
+      }
+
+      if (method === "POST" && path === "/v1/me/active-organization") {
+        let organizationId = null;
+        try {
+          const body = JSON.parse(String(init.body ?? "{}"));
+          organizationId = typeof body.organizationId === "string" ? body.organizationId : null;
+        } catch {}
+        fixture.calls.push({ organizationId });
+        if (organizationId === targetOrg.id) fixture.selectedOrgId = targetOrg.id;
+        if (organizationId === defaultOrg.id) fixture.selectedOrgId = defaultOrg.id;
+        return new Response(null, { status: 204 });
+      }
+
+      if (method === "GET" && path === "/v1/me/desktop-config") {
+        return json({});
+      }
+
+      if (method === "GET" && path === "/v1/llm-providers") {
+        const selected = orgs.find((org) => org.id === fixture.selectedOrgId) ?? defaultOrg;
+        return json({
+          llmProviders: [
+            {
+              id: targetOrg.id + "-openai",
+              source: "custom",
+              providerId: "openai",
+              name: selected.name + " OpenAI",
+              providerConfig: {},
+              hasApiKey: true,
+              models: [{ id: "gpt-4.1-mini", name: "GPT-4.1 mini", config: {} }],
+              createdAt: null,
+              updatedAt: null,
+            },
+          ],
+        });
+      }
+
+      if (method === "GET" && path === "/v1/marketplaces") {
+        return json({
+          items: [
+            {
+              id: "marketplace-fixture",
+              name: "Team Plugins",
+              description: "Shared extensions for the selected workspace",
+              status: "active",
+              pluginCount: 2,
+              updatedAt: null,
+            },
+          ],
+        });
+      }
+
+      return json({ error: "unhandled_fixture_route", method, path }, 404);
+    };
+
+    localStorage.setItem("openwork.den.baseUrl", window.location.origin);
+    localStorage.setItem("openwork.den.authToken", "fixture-token");
+    localStorage.setItem("openwork.den.activeOrgId", defaultOrg.id);
+    localStorage.setItem("openwork.den.activeOrgSlug", defaultOrg.slug);
+    localStorage.setItem("openwork.den.activeOrgName", defaultOrg.name);
+    sessionStorage.setItem("openwork.den.handoffAutoContinueAt", String(Date.now()));
+    return true;
+  })()`;
+}
+
+async function prepareHandoffFixture(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", {
+    timeoutMs: 60_000,
+    label: "OpenWork control API",
+  });
+  await ctx.eval(installFixtureExpression(), { awaitPromise: true });
+  const baseUrl = await ctx.eval("window.location.origin");
+  await ctx.control("eval.auth.set-base-url", { baseUrl });
+  await navigateAppRoute(ctx, "/welcome?orgChooserReset=" + Date.now());
+  await ctx.waitFor(routeExpression("/welcome"), {
+    timeoutMs: 10_000,
+    label: "welcome route before onboarding fixture",
+  });
+  await ctx.eval(`(() => {
+    localStorage.setItem("openwork.den.baseUrl", window.location.origin);
+    localStorage.setItem("openwork.den.authToken", "fixture-token");
+    localStorage.setItem("openwork.den.activeOrgId", ${JSON.stringify(DEFAULT_ORG.id)});
+    localStorage.setItem("openwork.den.activeOrgSlug", ${JSON.stringify(DEFAULT_ORG.slug)});
+    localStorage.setItem("openwork.den.activeOrgName", ${JSON.stringify(DEFAULT_ORG.name)});
+    sessionStorage.setItem("openwork.den.handoffAutoContinueAt", String(Date.now()));
+    return true;
+  })()`);
+  await navigateAppRoute(ctx, "/onboarding?orgChooserHandoffRegression=" + Date.now());
+}
+
+function routeExpression(path) {
+  return `(() => window.__OPENWORK_ELECTRON__
+    ? location.hash.includes(${JSON.stringify(path)})
+    : location.pathname === ${JSON.stringify(path)})()`;
+}
+
+async function navigateAppRoute(ctx, route) {
+  await ctx.eval(`(() => {
+    const route = ${JSON.stringify(route)};
+    if (window.__OPENWORK_ELECTRON__) {
+      window.location.hash = route;
+    } else {
+      window.history.pushState(null, "", route);
+      window.dispatchEvent(new PopStateEvent("popstate"));
+    }
+    return true;
+  })()`);
+}
+
+function fixtureSnapshotExpression() {
+  return `(() => ({
+    calls: window.__openworkOrgChooserFixture?.calls ?? [],
+    requests: window.__openworkOrgChooserFixture?.requests ?? [],
+    selectedOrgId: window.__openworkOrgChooserFixture?.selectedOrgId ?? null,
+    activeOrgId: localStorage.getItem("openwork.den.activeOrgId"),
+    activeOrgName: localStorage.getItem("openwork.den.activeOrgName"),
+    handoffAutoContinueAt: sessionStorage.getItem("openwork.den.handoffAutoContinueAt"),
+    text: document.body.innerText,
+  }))()`;
+}
+
+async function waitForChooser(ctx) {
+  await ctx.waitFor(`(() => {
+    const text = document.body.innerText;
+    const onOnboarding = window.__OPENWORK_ELECTRON__
+      ? location.hash.includes("/onboarding")
+      : location.pathname === "/onboarding";
+    return onOnboarding
+      && text.includes("Choose your organization")
+      && text.includes(${JSON.stringify(DEFAULT_ORG.name)})
+      && text.includes(${JSON.stringify(TARGET_ORG.name)});
+  })()`, { timeoutMs: 45_000, label: "multi-org chooser after handoff" });
+}
+
+async function chooseTargetOrg(ctx) {
+  const clicked = await ctx.eval(`(() => {
+    const label = [...document.querySelectorAll("label")]
+      .find((entry) => (entry.textContent ?? "").includes(${JSON.stringify(TARGET_ORG.name)}));
+    label?.scrollIntoView({ block: "center" });
+    label?.click();
+    return Boolean(label);
+  })()`);
+  ctx.assert(clicked, `Could not click ${TARGET_ORG.name}.`);
+  await ctx.clickText("Continue with organization", { selector: "button", timeoutMs: 10_000 });
+}
+
+export default {
+  id: "org-chooser-handoff-regression",
+  title: "Desktop handoff keeps multi-organization choice explicit",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("A desktop handoff with two organizations still shows the chooser", {
+          voiceover: vo[0],
+          action: async () => {
+            await prepareHandoffFixture(ctx);
+            await waitForChooser(ctx);
+          },
+          assert: async () => {
+            const snapshot = await ctx.eval(fixtureSnapshotExpression());
+            ctx.assert(snapshot.handoffAutoContinueAt, "The handoff auto-continue flag was not present.");
+            ctx.assert(snapshot.calls.length === 0, `Expected no automatic active-org POST before user choice: ${JSON.stringify(snapshot.calls)}`);
+            ctx.assert(snapshot.activeOrgId === DEFAULT_ORG.id, `Default org should remain active before choice: ${JSON.stringify(snapshot)}`);
+            ctx.assert(snapshot.text.includes(DEFAULT_ORG.name) && snapshot.text.includes(TARGET_ORG.name), `Chooser did not show both orgs: ${snapshot.text}`);
+          },
+          screenshot: {
+            name: "handoff-multi-org-chooser",
+            claim: "After a recent handoff, accounts with two organizations still see both organization choices.",
+            requireText: ["Choose your organization", DEFAULT_ORG.name, TARGET_ORG.name, "Continue with organization"],
+            rejectText: ["Loading organizations", "Loading available resources", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("Choosing the non-default organization activates it before resources load", {
+          voiceover: vo[1],
+          action: async () => {
+            await waitForChooser(ctx);
+            await chooseTargetOrg(ctx);
+          },
+          assert: async () => {
+            await ctx.waitFor(`(() => {
+              const text = document.body.innerText;
+              return text.includes(${JSON.stringify(TARGET_ORG.name)})
+                && text.includes("You have access to the following resources.")
+                && text.includes("AI Providers");
+            })()`, { timeoutMs: 45_000, label: "target org resources" });
+            const snapshot = await ctx.eval(fixtureSnapshotExpression());
+            ctx.assert(snapshot.activeOrgId === TARGET_ORG.id, `Active org id did not update: ${JSON.stringify(snapshot)}`);
+            ctx.assert(snapshot.activeOrgName === TARGET_ORG.name, `Active org name did not update: ${JSON.stringify(snapshot)}`);
+            ctx.assert(snapshot.calls.length === 1, `Expected exactly one active-org POST after clicking Continue: ${JSON.stringify(snapshot.calls)}`);
+            ctx.assert(snapshot.calls[0]?.organizationId === TARGET_ORG.id, `The POST selected the wrong organization: ${JSON.stringify(snapshot.calls)}`);
+          },
+          screenshot: {
+            name: "handoff-selected-org-resources",
+            claim: "After selecting Beta Labs, the resources screen is scoped to Beta Labs.",
+            requireText: [TARGET_ORG.name, "You have access to the following resources.", "AI Providers", "Marketplaces"],
+            rejectText: ["Choose your organization", "Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/org-chooser-handoff-regression.md
+++ b/evals/voiceovers/org-chooser-handoff-regression.md
@@ -1,0 +1,5 @@
+# org-chooser-handoff-regression — Desktop handoff keeps multi-org choice explicit
+
+1. “After a desktop handoff, OpenWork still stops on Choose your organization when the account belongs to more than one workspace. Both Acme Robotics and Beta Labs are visible, with Acme only preselected as a default.”
+
+2. “The user deliberately switches to Beta Labs and continues. OpenWork applies that explicit choice before showing the workspace resources.”


### PR DESCRIPTION
## Root cause
PR #3140 initialized org onboarding as already selected when a recent handoff flag existed. With 2+ orgs, that skipped the organization chooser before listOrgs resolved.

## Fix
- Handoff no longer initializes org selection or resource auto-continue.
- The post-list decision now only auto-selects exactly one org.
- 2+ orgs always render the chooser with the current active org as the default selection.
- Single-org auto-select failure still falls back to the chooser.

## Tests
- pnpm --filter @openwork/app typecheck
- pnpm --filter @openwork/app exec bun test src/react-app/domains/cloud/org-onboarding-page.test.tsx src/react-app/domains/cloud/openwork-models-promo.test.ts src/react-app/domains/cloud/workspace-branding-restart.test.ts
- pnpm evals:typecheck
- git diff --check
- pnpm fraimz --flow org-chooser-handoff-regression --cdp-url http://127.0.0.1:9445

## Proof
Fraimz passed locally: evals/results/2026-07-26T09-24-02-834Z/fraimz.html

Screenshots uploaded:
- https://b8tgacyg507ru26g.public.blob.vercel-storage.com/pr/org-chooser-handoff-regression/org-chooser-handoff-regression-01-handoff-multi-org-chooser-4Rt91LJYJZTp3TRBg03a2QzkluihHa.png
- https://b8tgacyg507ru26g.public.blob.vercel-storage.com/pr/org-chooser-handoff-regression/org-chooser-handoff-regression-02-handoff-selected-org-resources-xjojlJKSLN5SF5ssCC52o1ckvUL3hy.png

Note: proof used the local browser/CDP fixture flow against the real React app/Vite dev server to isolate the handoff + multi-org regression without a full Daytona Den stack.