### PR TITLE
fix(den-web): bearer-only CORS for Cloud instance origins

### DIFF
--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.test.mjs
@@ -82,6 +82,89 @@ describe("Den upstream proxy", () => {
     }
   });
 
+  const INSTANCE_ORIGIN = "https://8787-2bnptanfwxs5j8vu.daytonaproxy01.net";
+
+  test("answers the preflight for a rotating Cloud instance origin", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const request = new NextRequest("https://app.example.com/api/den/v1/me", {
+      method: "OPTIONS",
+      headers: {
+        origin: INSTANCE_ORIGIN,
+        "access-control-request-method": "GET",
+        "access-control-request-headers": "authorization,content-type",
+      },
+    });
+
+    const response = await proxyUpstream(request, [], { routePrefix: "/api/den" });
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get("access-control-allow-origin")).toBe(INSTANCE_ORIGIN);
+    expect(response.headers.get("access-control-allow-credentials")).toBe("true");
+    expect(response.headers.get("access-control-allow-headers")).toBe("authorization,content-type");
+    expect(response.headers.get("vary")).toContain("Origin");
+  });
+
+  test("reflects the instance origin on the real response and strips cookies upstream", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const request = new NextRequest("https://app.example.com/api/den/v1/me", {
+      method: "GET",
+      headers: {
+        origin: INSTANCE_ORIGIN,
+        authorization: "Bearer tok_instance",
+        cookie: "ow_session=must_not_leak",
+      },
+    });
+
+    const response = await proxyUpstream(request, [], { routePrefix: "/api/den" });
+
+    expect(response.headers.get("access-control-allow-origin")).toBe(INSTANCE_ORIGIN);
+    // The whole safety argument: an instance-origin call is bearer-only and can
+    // never ride the viewer's dashboard session.
+    expect(observed.cookie).toBeNull();
+    expect(observed.authorization).toBe("Bearer tok_instance");
+  });
+
+  test("does not reflect a non-instance origin and keeps its cookies", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const request = new NextRequest("https://app.example.com/api/den/v1/me", {
+      method: "GET",
+      headers: {
+        origin: "https://evil.example.com",
+        cookie: "ow_session=sess_test",
+      },
+    });
+
+    const response = await proxyUpstream(request, [], { routePrefix: "/api/den" });
+
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(observed.cookie).toBe("ow_session=sess_test");
+  });
+
+  test("does not reflect instance origins on the auth proxy", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    const request = new NextRequest("https://app.example.com/api/auth/session", {
+      method: "GET",
+      headers: { origin: INSTANCE_ORIGIN, cookie: "ow_session=sess_test" },
+    });
+
+    const response = await proxyUpstream(request, [], { routePrefix: "/api/auth", upstreamPathPrefix: "api/auth" });
+
+    expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    expect(observed.cookie).toBe("ow_session=sess_test");
+  });
+
+  test("rejects http and lookalike hostnames", async () => {
+    const { proxyUpstream } = await import("./upstream-proxy.ts");
+    for (const origin of ["http://8787-x.daytonaproxy01.net", "https://daytonaproxy01.net.evil.com"]) {
+      const request = new NextRequest("https://app.example.com/api/den/v1/me", {
+        method: "GET",
+        headers: { origin },
+      });
+      const response = await proxyUpstream(request, [], { routePrefix: "/api/den" });
+      expect(response.headers.get("access-control-allow-origin")).toBeNull();
+    }
+  });
+
   test("passes method, path, query, body, cookies, auth, status, and headers through", async () => {
     const { proxyUpstream } = await import("./upstream-proxy.ts");
     const request = new NextRequest("https://app.example.com/api/den/v1/me?include=org", {

--- a/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
+++ b/ee/apps/den-web/app/api/_lib/upstream-proxy.ts
@@ -18,6 +18,63 @@ const REQUEST_ONLY_HEADERS = new Set(["host", "content-length"]);
 const RESPONSE_ONLY_HEADERS = new Set(["content-length", "content-encoding"]);
 const SPOOFABLE_FORWARDING_HEADERS = new Set(["forwarded", "x-forwarded-host", "x-forwarded-prefix", "x-forwarded-proto"]);
 
+/**
+ * OpenWork Cloud instances are served from Daytona preview origins that are
+ * re-signed (and therefore renamed) on every wake, so they can never appear in
+ * a static CORS allowlist. The signed-in SPA running there has to reach Den for
+ * /v1/me, /v1/me/orgs, MCP tokens and org connections.
+ *
+ * We reflect those origins, and make that safe by stripping the cookie header
+ * from the forwarded request: an instance-origin call is authenticated by its
+ * bearer token alone and can never ride the viewer's app.openworklabs.com
+ * session. A hostile page on some other origin therefore gains nothing from the
+ * reflection - it has no bearer token and its cookies are discarded.
+ *
+ * Only the Den API proxy opts in; /api/auth keeps cookies and the strict
+ * allowlist, because that is where sessions are actually established.
+ */
+const DEN_API_ROUTE_PREFIX = "/api/den";
+const DEFAULT_CLOUD_INSTANCE_ORIGIN_SUFFIXES = [".daytonaproxy01.net"];
+const CORS_ALLOW_HEADERS = "authorization,content-type,x-openwork-org-id,x-request-id,accept";
+const CORS_ALLOW_METHODS = "GET,HEAD,POST,PUT,PATCH,DELETE,OPTIONS";
+
+function cloudInstanceOriginSuffixes(): string[] {
+  const configured = process.env.DEN_CLOUD_INSTANCE_ORIGIN_SUFFIXES?.trim();
+  if (!configured) return DEFAULT_CLOUD_INSTANCE_ORIGIN_SUFFIXES;
+  const parsed = configured
+    .split(",")
+    .map((entry) => entry.trim().toLowerCase())
+    .filter((entry) => entry.startsWith("."));
+  return parsed.length > 0 ? parsed : DEFAULT_CLOUD_INSTANCE_ORIGIN_SUFFIXES;
+}
+
+function isCloudInstanceOrigin(origin: string | null): boolean {
+  if (!origin) return false;
+  let parsed: URL;
+  try {
+    parsed = new URL(origin);
+  } catch {
+    return false;
+  }
+  if (parsed.protocol !== "https:") return false;
+  const hostname = parsed.hostname.toLowerCase();
+  return cloudInstanceOriginSuffixes().some((suffix) => hostname.endsWith(suffix));
+}
+
+function reflectsCloudInstanceOrigin(request: NextRequest, options: ProxyOptions): boolean {
+  return options.routePrefix === DEN_API_ROUTE_PREFIX && isCloudInstanceOrigin(request.headers.get("origin"));
+}
+
+function applyCloudInstanceCorsHeaders(headers: Headers, origin: string): void {
+  // Never emit a second allow-origin: browsers reject duplicates, and den-api
+  // already reflects on the grant-exchange route.
+  if (!headers.has("access-control-allow-origin")) {
+    headers.set("access-control-allow-origin", origin);
+    headers.set("access-control-allow-credentials", "true");
+  }
+  headers.append("vary", "Origin");
+}
+
 type ProxyOptions = {
   routePrefix: string;
   upstreamPathPrefix?: string;
@@ -96,12 +153,18 @@ async function injectActiveTraceContext(headers: Headers): Promise<void> {
   }
 }
 
-async function cloneRequestHeaders(request: NextRequest, routePrefix: string): Promise<Headers> {
+async function cloneRequestHeaders(
+  request: NextRequest,
+  routePrefix: string,
+  stripCookies = false,
+): Promise<Headers> {
   const headers = new Headers();
   request.headers.forEach((value, name) => {
-    if (!shouldSkipRequestHeader(name)) {
-      headers.append(name, value);
-    }
+    if (shouldSkipRequestHeader(name)) return;
+    // Bearer-only for reflected instance origins - see the note above
+    // isCloudInstanceOrigin. This is what makes reflection safe.
+    if (stripCookies && name.toLowerCase() === "cookie") return;
+    headers.append(name, value);
   });
   const publicOrigin = requestPublicOrigin(request);
   headers.set("x-forwarded-host", publicOrigin.host);
@@ -201,13 +264,32 @@ export async function proxyUpstream(
     return buildUpstreamErrorResponse(503, "DEN_API_BASE must be configured.");
   }
 
+  const instanceOrigin = reflectsCloudInstanceOrigin(request, options)
+    ? request.headers.get("origin")
+    : null;
+
+  // Answer the preflight here: den-api's allowlist cannot know this origin, and
+  // the browser will not send the real request without it.
+  if (instanceOrigin && request.method === "OPTIONS") {
+    const preflight = new Headers({
+      "access-control-allow-origin": instanceOrigin,
+      "access-control-allow-credentials": "true",
+      "access-control-allow-headers":
+        request.headers.get("access-control-request-headers") ?? CORS_ALLOW_HEADERS,
+      "access-control-allow-methods": CORS_ALLOW_METHODS,
+      "access-control-max-age": "600",
+    });
+    preflight.append("vary", "Origin");
+    return new Response(null, { status: 204, headers: preflight });
+  }
+
   const targetPath = getTargetPath(request, segments, options.routePrefix);
   const targetUrl = buildTargetUrl(apiBase, request, targetPath, options.upstreamPathPrefix);
   let upstream: Response;
   try {
     upstream = await fetch(targetUrl, {
       method: request.method,
-      headers: await cloneRequestHeaders(request, options.routePrefix),
+      headers: await cloneRequestHeaders(request, options.routePrefix, instanceOrigin !== null),
       body: await readRequestBody(request),
       redirect: "manual",
     });
@@ -233,9 +315,13 @@ export async function proxyUpstream(
   });
 
   const shouldDropBody = request.method === "HEAD" || NO_BODY_STATUS.has(upstream.status);
+  const responseHeaders = cloneResponseHeaders(request, upstream, options, apiBase);
+  if (instanceOrigin) {
+    applyCloudInstanceCorsHeaders(responseHeaders, instanceOrigin);
+  }
 
   return new Response(shouldDropBody ? null : upstream.body, {
     status: upstream.status,
-    headers: cloneResponseHeaders(request, upstream, options, apiBase),
+    headers: responseHeaders,
   });
 }


### PR DESCRIPTION
**Prod blocker.** After sign-in, the SPA inside a Cloud instance can't load: `/v1/me` and `/v1/me/orgs` preflights from `https://8787-<id>.daytonaproxy01.net` get no `Access-Control-Allow-Origin`, so the app shows *"OpenWork Cloud is temporarily unavailable"* and retries forever. Instance origins are re-signed (renamed) on every wake — a static allowlist can never cover them.

## Fix

The `/api/den` proxy reflects Cloud instance origins **and strips the cookie header** from the forwarded request.

That strip is the whole security argument: an instance-origin call is authenticated by its **bearer token alone** and can never ride the viewer's `app.openworklabs.com` session. A hostile page gains nothing from the reflection — it has no bearer token, and its cookies are discarded before the request reaches Den. Preflights are answered at the proxy because den-api's allowlist cannot know the origin.

Deliberately narrow: only `/api/den` opts in. **`/api/auth` keeps cookies and the strict allowlist**, since that's where sessions are established. Suffixes default to `.daytonaproxy01.net`, overridable via `DEN_CLOUD_INSTANCE_ORIGIN_SUFFIXES`; https + suffix only, so `daytonaproxy01.net.evil.com` does not match.

## Tests — 11 pass

New coverage: preflight reflected for an instance origin · cookie stripped upstream while the bearer survives · non-instance origin neither reflected nor stripped · `/api/auth` unaffected · `http://` and lookalike hostnames rejected. `pnpm --filter @openwork-ee/den-web exec bun test --conditions development app/api/_lib/upstream-proxy.test.mjs` → 11 pass / 0 fail. Typecheck clean.

Supersedes the need for per-route CORS patches; the Phase-2 gateway will subsume this boundary entirely.