### PR TITLE
fix(cloud): per-user instances and a safe worker state machine

### DIFF
--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -128,7 +128,7 @@ function withDenProxyPath(origin: string) {
 }
 
 function configuredDesktopDenBaseUrl() {
-  return env.desktopDenBaseUrl ?? withDenProxyPath(env.betterAuthUrl)
+  return env.desktopDenBaseUrl ?? withDenProxyPath(process.env.BETTER_AUTH_URL?.trim() || env.betterAuthUrl)
 }
 
 export function resolveDesktopDenBaseUrl(request: Request) {
@@ -249,8 +249,27 @@ export function approveWebHandoffReturnUrl(input: {
   return `${candidate.origin}/signin`
 }
 
-async function getCloudSignedPreviewUrl(organizationId: WorkerOrgId) {
-  const [row] = await db
+export function approveWebHandoffReturnUrlForSignedPreviews(input: {
+  returnUrl: string
+  signedPreviewUrls: string[]
+  orgMode: DenOrgMode
+}) {
+  for (const signedPreviewUrl of input.signedPreviewUrls) {
+    const approved = approveWebHandoffReturnUrl({
+      returnUrl: input.returnUrl,
+      signedPreviewUrl,
+      orgMode: input.orgMode,
+    })
+    if (approved) {
+      return approved
+    }
+  }
+
+  return null
+}
+
+async function getCloudSignedPreviewUrls(organizationId: WorkerOrgId) {
+  const rows = await db
     .select({ signedPreviewUrl: DaytonaSandboxTable.signed_preview_url })
     .from(WorkerTable)
     .innerJoin(DaytonaSandboxTable, eq(WorkerTable.id, DaytonaSandboxTable.worker_id))
@@ -260,9 +279,8 @@ async function getCloudSignedPreviewUrl(organizationId: WorkerOrgId) {
       eq(WorkerTable.sandbox_backend, CLOUD_INSTANCE_BACKEND),
     ))
     .orderBy(desc(WorkerTable.created_at))
-    .limit(1)
 
-  return row?.signedPreviewUrl ?? null
+  return rows.map((row) => row.signedPreviewUrl)
 }
 
 async function resolveApprovedWebHandoffReturnUrl(input: {
@@ -280,10 +298,12 @@ async function resolveApprovedWebHandoffReturnUrl(input: {
     return null
   }
 
-  const signedPreviewUrl = await getCloudSignedPreviewUrl(organizationId)
-  return signedPreviewUrl
-    ? approveWebHandoffReturnUrl({ returnUrl: input.returnUrl, signedPreviewUrl, orgMode: env.orgMode })
-    : null
+  const signedPreviewUrls = await getCloudSignedPreviewUrls(organizationId)
+  return approveWebHandoffReturnUrlForSignedPreviews({
+    returnUrl: input.returnUrl,
+    signedPreviewUrls,
+    orgMode: env.orgMode,
+  })
 }
 
 export function registerDesktopAuthRoutes<T extends { Variables: AuthContextVariables }>(app: Hono<T>) {

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -1,4 +1,4 @@
-import { and, desc, eq } from "@openwork-ee/den-db/drizzle"
+import { and, asc, eq, isNull } from "@openwork-ee/den-db/drizzle"
 import { WorkerTable, WorkerTokenTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono, MiddlewareHandler } from "hono"
@@ -9,9 +9,10 @@ import { db } from "../../db.js"
 import { env, type DenOrgMode } from "../../env.js"
 import { orgMemberRoute } from "../../middleware/index.js"
 import { jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
-import { getDaytonaSandboxRecord, refreshDaytonaSignedPreview } from "../../workers/daytona.js"
+import { getDaytonaSandboxRecord, inspectDaytonaSandbox, refreshDaytonaSignedPreview } from "../../workers/daytona.js"
 import { CLOUD_INSTANCE_BACKEND, CLOUD_INSTANCE_NAME } from "../../workers/cloud-constants.js"
 import { wakeCloudWorker as defaultWakeCloudWorker } from "../../workers/cloud-lifecycle.js"
+import { appLogger } from "../../observability/logger.js"
 import type { OrgRouteVariables } from "../org/shared.js"
 import { continueCloudProvisioning, token } from "../workers/shared.js"
 
@@ -22,26 +23,52 @@ type CloudRouteOptions = {
   daytonaApiKey?: string
   continueProvisioning?: typeof continueCloudProvisioning
   refreshSignedPreview?: typeof refreshDaytonaSignedPreview
+  cloudWorkerStore?: CloudWorkerStore
   ensureCloudWorker?: EnsureCloudWorker
   getSandboxRecord?: GetSandboxRecord
+  inspectSandbox?: InspectSandbox
+  probeSignedPreview?: ProbeSignedPreview
   wakeCloudWorker?: WakeCloudWorker
+  now?: () => number
 }
 
-type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "status">
+type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "name" | "status">
+type WorkerToken = Pick<typeof WorkerTokenTable.$inferSelect, "scope" | "token">
 type CloudSandboxRecord = Pick<NonNullable<Awaited<ReturnType<typeof getDaytonaSandboxRecord>>>, "signed_preview_url" | "signed_preview_url_expires_at">
+type CloudSandboxInspection = { state: string | null } | null
 type OrgId = typeof WorkerTable.$inferSelect.org_id
-type UserId = typeof WorkerTable.$inferSelect.created_by_user_id
+type UserId = NonNullable<typeof WorkerTable.$inferSelect.created_by_user_id>
+type WorkerId = typeof WorkerTable.$inferSelect.id
 type CloudInstanceResponse = {
   status: "provisioning" | "waking" | "ready" | "failed"
   url: string | null
 }
+type CloudWorkerStore = {
+  getCloudWorker: (input: { orgId: OrgId; userId: UserId }) => Promise<CloudWorker | null>
+  insertCloudWorker: (input: { workerId: WorkerId; orgId: OrgId; userId: UserId; name: string }) => Promise<void>
+  insertWorkerTokens: (input: { workerId: WorkerId; hostToken: string; clientToken: string; activityToken: string }) => Promise<void>
+  deleteCreateRaceLoser: (workerId: WorkerId) => Promise<void>
+  claimFailedWorker: (workerId: WorkerId) => Promise<boolean>
+  getActiveTokens: (workerId: WorkerId) => Promise<WorkerToken[]>
+  markProvisioningWorkerFailed: (workerId: WorkerId) => Promise<void>
+  markHealthyWorkerFailed: (workerId: WorkerId) => Promise<void>
+}
 type EnsureCloudWorker = (input: {
   orgId: OrgId
   createdByUserId: UserId
+  name: string
   continueProvisioning: typeof continueCloudProvisioning
+  store: CloudWorkerStore
 }) => Promise<CloudWorker>
 type GetSandboxRecord = (workerId: CloudWorker["id"]) => Promise<CloudSandboxRecord | null>
+type InspectSandbox = (workerId: CloudWorker["id"]) => Promise<CloudSandboxInspection>
+type ProbeSignedPreview = (signedPreviewUrl: string) => Promise<boolean>
 type WakeCloudWorker = (workerId: CloudWorker["id"]) => Promise<void>
+
+type UpdateResultRecord = {
+  rowsAffected?: unknown
+  affectedRows?: unknown
+}
 
 const cloudInstanceResponseSchema = z.object({
   status: z.enum(["provisioning", "waking", "ready", "failed"]),
@@ -52,100 +79,420 @@ function cloudNotFound() {
   return { error: "cloud_not_found" }
 }
 
+const logger = appLogger.child({ component: "cloud_routes" })
+const cloudWorkerNameMaxLength = 255
+const failedHealCooldownMs = 60_000
+const signedPreviewProbeTimeoutMs = 2_500
+const signedPreviewHealthCacheMs = 15_000
+const ensureCloudWorkerInFlight = new Map<string, Promise<CloudWorker>>()
+const failedHealAttempts = new Map<WorkerId, number>()
+const signedPreviewHealthCache = new Map<WorkerId, { url: string; healthyUntilMs: number }>()
+
+function isUpdateResultRecord(value: unknown): value is UpdateResultRecord {
+  return typeof value === "object" && value !== null
+}
+
+function changedRows(result: unknown): number | null {
+  if (Array.isArray(result)) {
+    for (const value of result) {
+      const nestedRows = changedRows(value)
+      if (nestedRows !== null) {
+        return nestedRows
+      }
+    }
+    return null
+  }
+
+  if (!isUpdateResultRecord(result)) {
+    return null
+  }
+
+  if (typeof result.rowsAffected === "number") {
+    return result.rowsAffected
+  }
+
+  if (typeof result.affectedRows === "number") {
+    return result.affectedRows
+  }
+
+  return null
+}
+
+function hasChangedRows(result: unknown) {
+  const rows = changedRows(result)
+  return rows !== null && rows > 0
+}
+
+function tokenByScope(tokens: WorkerToken[], scope: WorkerToken["scope"]) {
+  return tokens.find((entry) => entry.scope === scope)?.token ?? null
+}
+
+function truncateForWorkerName(value: string) {
+  return Array.from(value).slice(0, cloudWorkerNameMaxLength).join("").trim()
+}
+
+function emailLocalPart(email: string | null | undefined) {
+  const trimmed = email?.trim() ?? ""
+  if (!trimmed) {
+    return null
+  }
+
+  return trimmed.split("@")[0]?.trim() || trimmed
+}
+
+function displayNameForCloudWorker(payload: NonNullable<OrgRouteVariables["organizationContext"]>, user: NonNullable<OrgRouteVariables["user"]>) {
+  const member = payload.members.find((entry) => entry.userId === payload.currentMember.userId) ?? null
+  const memberName = member?.user.name.trim()
+  if (memberName) {
+    return memberName
+  }
+
+  const userName = user.name?.trim()
+  if (userName) {
+    return userName
+  }
+
+  return emailLocalPart(member?.user.email) ?? emailLocalPart(user.email) ?? "member"
+}
+
+function cloudWorkerName(payload: NonNullable<OrgRouteVariables["organizationContext"]>, user: NonNullable<OrgRouteVariables["user"]>) {
+  return truncateForWorkerName(`${CLOUD_INSTANCE_NAME} — ${displayNameForCloudWorker(payload, user)}`)
+}
+
+function ensureKey(orgId: OrgId, userId: UserId) {
+  return `${orgId}:${userId}`
+}
+
+function healthUrlForPreview(signedPreviewUrl: string) {
+  return `${signedPreviewUrl.replace(/\/+$/, "")}/health`
+}
+
+async function probeSignedPreview(signedPreviewUrl: string) {
+  try {
+    const response = await fetch(healthUrlForPreview(signedPreviewUrl), {
+      method: "GET",
+      signal: AbortSignal.timeout(signedPreviewProbeTimeoutMs),
+    })
+    return response.ok
+  } catch {
+    return false
+  }
+}
+
+const databaseCloudWorkerStore: CloudWorkerStore = {
+  async getCloudWorker(input) {
+    // Cloud is per-user. Legacy shared rows already have created_by_user_id set
+    // to the first clicker; that member keeps the row while others get fresh
+    // instances. Follow-up: admin user deletion currently nulls
+    // created_by_user_id (src/user-deletion.ts), orphaning instances; cleanup is
+    // tracked separately.
+    const rows = await db
+      .select()
+      .from(WorkerTable)
+      .where(and(
+        eq(WorkerTable.org_id, input.orgId),
+        eq(WorkerTable.created_by_user_id, input.userId),
+        eq(WorkerTable.destination, "cloud"),
+        eq(WorkerTable.sandbox_backend, CLOUD_INSTANCE_BACKEND),
+      ))
+      .orderBy(asc(WorkerTable.created_at), asc(WorkerTable.id))
+      .limit(1)
+
+    return rows[0] ?? null
+  },
+  async insertCloudWorker(input) {
+    await db.insert(WorkerTable).values({
+      id: input.workerId,
+      org_id: input.orgId,
+      created_by_user_id: input.userId,
+      name: input.name,
+      description: "OpenWork Cloud browser instance",
+      destination: "cloud",
+      status: "provisioning",
+      sandbox_backend: CLOUD_INSTANCE_BACKEND,
+    })
+  },
+  async insertWorkerTokens(input) {
+    await db.insert(WorkerTokenTable).values([
+      {
+        id: createDenTypeId("workerToken"),
+        worker_id: input.workerId,
+        scope: "host",
+        token: input.hostToken,
+      },
+      {
+        id: createDenTypeId("workerToken"),
+        worker_id: input.workerId,
+        scope: "client",
+        token: input.clientToken,
+      },
+      {
+        id: createDenTypeId("workerToken"),
+        worker_id: input.workerId,
+        scope: "activity",
+        token: input.activityToken,
+      },
+    ])
+  },
+  async deleteCreateRaceLoser(workerId) {
+    await db.transaction(async (tx) => {
+      await tx.delete(WorkerTokenTable).where(eq(WorkerTokenTable.worker_id, workerId))
+      await tx.delete(WorkerTable).where(eq(WorkerTable.id, workerId))
+    })
+  },
+  async claimFailedWorker(workerId) {
+    const result: unknown = await db
+      .update(WorkerTable)
+      .set({ status: "provisioning" })
+      .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "failed")))
+
+    return hasChangedRows(result)
+  },
+  async getActiveTokens(workerId) {
+    return db
+      .select({ scope: WorkerTokenTable.scope, token: WorkerTokenTable.token })
+      .from(WorkerTokenTable)
+      .where(and(eq(WorkerTokenTable.worker_id, workerId), isNull(WorkerTokenTable.revoked_at)))
+  },
+  async markProvisioningWorkerFailed(workerId) {
+    await db
+      .update(WorkerTable)
+      .set({ status: "failed" })
+      .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "provisioning")))
+  },
+  async markHealthyWorkerFailed(workerId) {
+    await db
+      .update(WorkerTable)
+      .set({ status: "failed" })
+      .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "healthy")))
+  },
+}
+
 function hasDaytonaProvisioner(options: CloudRouteOptions) {
   const apiKey = options.daytonaApiKey !== undefined ? options.daytonaApiKey : env.daytona.apiKey
   return (options.provisionerMode ?? env.provisionerMode) === "daytona" && Boolean(apiKey?.trim())
 }
 
-async function getCloudWorker(orgId: OrgId) {
-  const rows = await db
-    .select()
-    .from(WorkerTable)
-    .where(and(
-      eq(WorkerTable.org_id, orgId),
-      eq(WorkerTable.destination, "cloud"),
-      eq(WorkerTable.sandbox_backend, CLOUD_INSTANCE_BACKEND),
-    ))
-    .orderBy(desc(WorkerTable.created_at))
-    .limit(1)
-
-  return rows[0] ?? null
+async function getCloudWorker(orgId: OrgId, userId: UserId, store: CloudWorkerStore) {
+  return store.getCloudWorker({ orgId, userId })
 }
 
 async function createCloudWorker(input: {
   orgId: OrgId
   createdByUserId: UserId
+  name: string
   continueProvisioning: typeof continueCloudProvisioning
+  store: CloudWorkerStore
 }): Promise<CloudWorker> {
   const workerId = createDenTypeId("worker")
   const hostToken = token()
   const clientToken = token()
   const activityToken = token()
 
-  await db.insert(WorkerTable).values({
-    id: workerId,
-    org_id: input.orgId,
-    created_by_user_id: input.createdByUserId,
-    name: CLOUD_INSTANCE_NAME,
-    description: "OpenWork Cloud browser instance",
-    destination: "cloud",
-    status: "provisioning",
-    sandbox_backend: CLOUD_INSTANCE_BACKEND,
-  })
+  await input.store.insertCloudWorker({ workerId, orgId: input.orgId, userId: input.createdByUserId, name: input.name })
+  await input.store.insertWorkerTokens({ workerId, hostToken, clientToken, activityToken })
 
-  await db.insert(WorkerTokenTable).values([
-    {
-      id: createDenTypeId("workerToken"),
-      worker_id: workerId,
-      scope: "host",
-      token: hostToken,
-    },
-    {
-      id: createDenTypeId("workerToken"),
-      worker_id: workerId,
-      scope: "client",
-      token: clientToken,
-    },
-    {
-      id: createDenTypeId("workerToken"),
-      worker_id: workerId,
-      scope: "activity",
-      token: activityToken,
-    },
-  ])
+  const canonical = await getCloudWorker(input.orgId, input.createdByUserId, input.store)
+  if (canonical && canonical.id !== workerId) {
+    // No unique index exists for (org_id, created_by_user_id, destination,
+    // sandbox_backend), and a partial unique is not viable across legacy rows.
+    // Converge create races by keeping the oldest canonical row and deleting the
+    // losing worker plus the tokens that were minted for it before provisioning.
+    await input.store.deleteCreateRaceLoser(workerId)
+    return canonical
+  }
 
   void input.continueProvisioning({
     workerId,
-    name: CLOUD_INSTANCE_NAME,
+    name: input.name,
     hostToken,
     clientToken,
     activityToken,
   })
 
-  return { id: workerId, status: "provisioning" }
+  return canonical ?? { id: workerId, name: input.name, status: "provisioning" }
 }
 
 async function ensureCloudWorker(input: {
   orgId: OrgId
   createdByUserId: UserId
+  name: string
   continueProvisioning: typeof continueCloudProvisioning
+  store: CloudWorkerStore
 }) {
-  const existing = await getCloudWorker(input.orgId)
-  if (existing) {
-    return existing
+  const key = ensureKey(input.orgId, input.createdByUserId)
+  const existingPromise = ensureCloudWorkerInFlight.get(key)
+  if (existingPromise) {
+    return existingPromise
   }
 
-  return createCloudWorker(input)
+  const promise = (async () => {
+    const existing = await getCloudWorker(input.orgId, input.createdByUserId, input.store)
+    if (existing) {
+      return existing
+    }
+
+    return createCloudWorker(input)
+  })()
+    .finally(() => {
+      if (ensureCloudWorkerInFlight.get(key) === promise) {
+        ensureCloudWorkerInFlight.delete(key)
+      }
+    })
+  ensureCloudWorkerInFlight.set(key, promise)
+
+  return promise
+}
+
+function cachedPreviewIsHealthy(workerId: WorkerId, url: string, now: number) {
+  const cached = signedPreviewHealthCache.get(workerId)
+  return cached?.url === url && cached.healthyUntilMs > now
+}
+
+function rememberHealthyPreview(workerId: WorkerId, url: string, now: number) {
+  signedPreviewHealthCache.set(workerId, { url, healthyUntilMs: now + signedPreviewHealthCacheMs })
+}
+
+async function startFailedCloudHeal(input: {
+  worker: CloudWorker
+  continueProvisioning: typeof continueCloudProvisioning
+  store: CloudWorkerStore
+}) {
+  const claimed = await input.store.claimFailedWorker(input.worker.id)
+  if (!claimed) {
+    return false
+  }
+
+  void (async () => {
+    const tokens = await input.store.getActiveTokens(input.worker.id)
+    const hostToken = tokenByScope(tokens, "host")
+    const clientToken = tokenByScope(tokens, "client")
+    const activityToken = tokenByScope(tokens, "activity")
+
+    if (!hostToken || !clientToken || !activityToken) {
+      await input.store.markProvisioningWorkerFailed(input.worker.id)
+      logger.error("cloud failed-worker heal failed", { worker_id: input.worker.id, reason: "missing_worker_tokens" })
+      return
+    }
+
+    await input.continueProvisioning({
+      workerId: input.worker.id,
+      name: input.worker.name,
+      hostToken,
+      clientToken,
+      activityToken,
+    })
+  })()
+    .catch(async (error) => {
+      await input.store.markProvisioningWorkerFailed(input.worker.id).catch(() => undefined)
+      logger.error("cloud failed-worker heal failed", { worker_id: input.worker.id, error })
+    })
+
+  return true
+}
+
+async function resolveFailedCloudInstance(input: {
+  worker: CloudWorker
+  continueProvisioning: typeof continueCloudProvisioning
+  getSandboxRecord: GetSandboxRecord
+  store: CloudWorkerStore
+  now: () => number
+}): Promise<CloudInstanceResponse> {
+  const now = input.now()
+  const lastAttempt = failedHealAttempts.get(input.worker.id)
+  if (lastAttempt !== undefined && now - lastAttempt < failedHealCooldownMs) {
+    return { status: "failed", url: null }
+  }
+
+  failedHealAttempts.set(input.worker.id, now)
+  const sandbox = await input.getSandboxRecord(input.worker.id)
+  const started = await startFailedCloudHeal(input)
+  if (!started) {
+    return { status: "failed", url: null }
+  }
+
+  return { status: sandbox ? "waking" : "provisioning", url: null }
+}
+
+async function readyFromSignedPreview(input: {
+  workerId: WorkerId
+  signedPreviewUrl: string
+  probeSignedPreview: ProbeSignedPreview
+  now: () => number
+}): Promise<CloudInstanceResponse | null> {
+  const now = input.now()
+  if (cachedPreviewIsHealthy(input.workerId, input.signedPreviewUrl, now)) {
+    return { status: "ready", url: input.signedPreviewUrl }
+  }
+
+  if (await input.probeSignedPreview(input.signedPreviewUrl)) {
+    rememberHealthyPreview(input.workerId, input.signedPreviewUrl, now)
+    return { status: "ready", url: input.signedPreviewUrl }
+  }
+
+  return null
+}
+
+async function refreshAndProbeSignedPreview(input: {
+  workerId: WorkerId
+  refreshSignedPreview: typeof refreshDaytonaSignedPreview
+  probeSignedPreview: ProbeSignedPreview
+  now: () => number
+}): Promise<CloudInstanceResponse | null> {
+  try {
+    const refreshed = await input.refreshSignedPreview(input.workerId)
+    if (!refreshed) {
+      return null
+    }
+
+    return readyFromSignedPreview({
+      workerId: input.workerId,
+      signedPreviewUrl: refreshed.signed_preview_url,
+      probeSignedPreview: input.probeSignedPreview,
+      now: input.now,
+    })
+  } catch {
+    return null
+  }
+}
+
+async function recoverUnhealthyCloudSandbox(input: {
+  worker: CloudWorker
+  continueProvisioning: typeof continueCloudProvisioning
+  inspectSandbox: InspectSandbox
+  startWake: (workerId: CloudWorker["id"]) => void
+  store: CloudWorkerStore
+}): Promise<CloudInstanceResponse> {
+  let inspection: CloudSandboxInspection = null
+  try {
+    inspection = await input.inspectSandbox(input.worker.id)
+  } catch {
+    inspection = null
+  }
+
+  if (inspection?.state === "stopped") {
+    input.startWake(input.worker.id)
+    return { status: "waking", url: null }
+  }
+
+  await input.store.markHealthyWorkerFailed(input.worker.id)
+  await startFailedCloudHeal(input)
+  return { status: "waking", url: null }
 }
 
 async function resolveCloudInstance(input: {
   worker: CloudWorker
+  continueProvisioning: typeof continueCloudProvisioning
   refreshSignedPreview: typeof refreshDaytonaSignedPreview
   getSandboxRecord: GetSandboxRecord
+  inspectSandbox: InspectSandbox
+  probeSignedPreview: ProbeSignedPreview
   startWake: (workerId: CloudWorker["id"]) => void
+  store: CloudWorkerStore
+  now: () => number
 }): Promise<CloudInstanceResponse> {
   if (input.worker.status === "failed") {
-    return { status: "failed", url: null }
+    return resolveFailedCloudInstance(input)
   }
 
   if (input.worker.status === "stopped") {
@@ -159,22 +506,38 @@ async function resolveCloudInstance(input: {
   }
 
   if (!sandbox) {
+    if (input.worker.status === "healthy") {
+      await input.store.markHealthyWorkerFailed(input.worker.id)
+      await startFailedCloudHeal(input)
+      return { status: "waking", url: null }
+    }
+
     return { status: "provisioning", url: null }
   }
 
-  if (sandbox.signed_preview_url_expires_at.getTime() > Date.now()) {
-    return { status: "ready", url: sandbox.signed_preview_url }
+  if (sandbox.signed_preview_url_expires_at.getTime() > input.now()) {
+    const ready = await readyFromSignedPreview({
+      workerId: input.worker.id,
+      signedPreviewUrl: sandbox.signed_preview_url,
+      probeSignedPreview: input.probeSignedPreview,
+      now: input.now,
+    })
+    if (ready) {
+      return ready
+    }
   }
 
-  try {
-    const refreshed = await input.refreshSignedPreview(input.worker.id)
-    if (!refreshed) {
-      return { status: "failed", url: null }
-    }
-    return { status: "ready", url: refreshed.signed_preview_url }
-  } catch {
-    return { status: "failed", url: null }
+  const refreshedReady = await refreshAndProbeSignedPreview({
+    workerId: input.worker.id,
+    refreshSignedPreview: input.refreshSignedPreview,
+    probeSignedPreview: input.probeSignedPreview,
+    now: input.now,
+  })
+  if (refreshedReady) {
+    return refreshedReady
   }
+
+  return recoverUnhealthyCloudSandbox(input)
 }
 
 export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
@@ -184,9 +547,13 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
   const orgMemberRouteMiddleware = options.memberRoute ?? orgMemberRoute()
   const continueProvisioning = options.continueProvisioning ?? continueCloudProvisioning
   const refreshSignedPreview = options.refreshSignedPreview ?? refreshDaytonaSignedPreview
+  const store = options.cloudWorkerStore ?? databaseCloudWorkerStore
   const ensureWorker = options.ensureCloudWorker ?? ensureCloudWorker
   const getSandboxRecord = options.getSandboxRecord ?? getDaytonaSandboxRecord
+  const inspectSandbox = options.inspectSandbox ?? inspectDaytonaSandbox
+  const signedPreviewProbe = options.probeSignedPreview ?? probeSignedPreview
   const wakeCloudWorker = options.wakeCloudWorker ?? defaultWakeCloudWorker
+  const now = options.now ?? Date.now
   const wakingWorkers = new Set<CloudWorker["id"]>()
 
   function startWake(workerId: CloudWorker["id"]) {
@@ -233,9 +600,21 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
       const worker = await ensureWorker({
         orgId: payload.organization.id,
         createdByUserId: user.id,
+        name: cloudWorkerName(payload, user),
         continueProvisioning,
+        store,
       })
-      const instance = await resolveCloudInstance({ worker, refreshSignedPreview, getSandboxRecord, startWake })
+      const instance = await resolveCloudInstance({
+        worker,
+        continueProvisioning,
+        refreshSignedPreview,
+        getSandboxRecord,
+        inspectSandbox,
+        probeSignedPreview: signedPreviewProbe,
+        startWake,
+        store,
+        now,
+      })
 
       return c.json(instance)
     },

--- a/ee/apps/den-api/src/routes/workers/shared.ts
+++ b/ee/apps/den-api/src/routes/workers/shared.ts
@@ -1,5 +1,5 @@
 import { randomBytes } from "node:crypto"
-import { and, asc, desc, eq, isNull } from "@openwork-ee/den-db/drizzle"
+import { and, asc, desc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
 import {
   AuditEventTable,
   AuthUserTable,
@@ -56,11 +56,56 @@ export type WorkerRouteVariables = AuthContextVariables & Partial<UserOrganizati
 
 type WorkerRow = typeof WorkerTable.$inferSelect
 type WorkerInstanceRow = typeof WorkerInstanceTable.$inferSelect
+type WorkerStatus = WorkerRow["status"]
 export type WorkerId = WorkerRow["id"]
 type OrgId = typeof MemberTable.$inferSelect.organizationId
 type UserId = typeof AuthUserTable.$inferSelect.id
+type ProvisionWorker = typeof provisionWorker
+type ProvisionedWorker = Awaited<ReturnType<ProvisionWorker>>
+type CloudProvisioningStore = {
+  updateWorkerStatus: (input: {
+    workerId: WorkerId
+    status: WorkerStatus
+    onlyWhenStatus?: WorkerStatus
+    onlyWhenStatusIn?: WorkerStatus[]
+  }) => Promise<void>
+  insertWorkerInstance: (input: { workerId: WorkerId; provisioned: ProvisionedWorker }) => Promise<void>
+}
+type ContinueCloudProvisioningOptions = {
+  provisionWorker?: ProvisionWorker
+  store?: CloudProvisioningStore
+}
 
 export const token = () => randomBytes(32).toString("hex")
+const provisioningSuccessWritableStatuses: WorkerStatus[] = ["provisioning", "failed"]
+const cloudProvisioningInFlight = new Map<WorkerId, Promise<void>>()
+
+const databaseCloudProvisioningStore: CloudProvisioningStore = {
+  async updateWorkerStatus(input) {
+    const statusPredicate = input.onlyWhenStatusIn
+      ? inArray(WorkerTable.status, input.onlyWhenStatusIn)
+      : input.onlyWhenStatus
+        ? eq(WorkerTable.status, input.onlyWhenStatus)
+        : undefined
+
+    await db
+      .update(WorkerTable)
+      .set({ status: input.status })
+      .where(statusPredicate
+        ? and(eq(WorkerTable.id, input.workerId), statusPredicate)
+        : eq(WorkerTable.id, input.workerId))
+  },
+  async insertWorkerInstance(input) {
+    await db.insert(WorkerInstanceTable).values({
+      id: createDenTypeId("workerInstance"),
+      worker_id: input.workerId,
+      provider: input.provisioned.provider,
+      region: input.provisioned.region,
+      url: input.provisioned.url,
+      status: input.provisioned.status,
+    })
+  },
+}
 
 export function parseWorkerIdParam(value: string): WorkerId {
   return normalizeDenTypeId("worker", value)
@@ -322,15 +367,18 @@ export function toWorkerResponse(row: WorkerRow, userId: string) {
   }
 }
 
-export async function continueCloudProvisioning(input: {
+async function runCloudProvisioning(input: {
   workerId: WorkerId
   name: string
   hostToken: string
   clientToken: string
   activityToken: string
-}) {
+}, options: ContinueCloudProvisioningOptions) {
+  const provision = options.provisionWorker ?? provisionWorker
+  const store = options.store ?? databaseCloudProvisioningStore
+
   try {
-    const provisioned = await provisionWorker({
+    const provisioned = await provision({
       workerId: input.workerId,
       name: input.name,
       hostToken: input.hostToken,
@@ -338,27 +386,43 @@ export async function continueCloudProvisioning(input: {
       activityToken: input.activityToken,
     })
 
-    await db
-      .update(WorkerTable)
-      .set({ status: provisioned.status })
-      .where(and(eq(WorkerTable.id, input.workerId), eq(WorkerTable.status, "provisioning")))
-
-    await db.insert(WorkerInstanceTable).values({
-      id: createDenTypeId("workerInstance"),
-      worker_id: input.workerId,
-      provider: provisioned.provider,
-      region: provisioned.region,
-      url: provisioned.url,
+    await store.updateWorkerStatus({
+      workerId: input.workerId,
       status: provisioned.status,
+      onlyWhenStatusIn: provisioningSuccessWritableStatuses,
     })
+
+    await store.insertWorkerInstance({ workerId: input.workerId, provisioned })
   } catch (error) {
-    await db
-      .update(WorkerTable)
-      .set({ status: "failed" })
-      .where(and(eq(WorkerTable.id, input.workerId), eq(WorkerTable.status, "provisioning")))
+    await store.updateWorkerStatus({ workerId: input.workerId, status: "failed", onlyWhenStatus: "provisioning" })
 
     logger.error("worker provisioning failed", { worker_id: input.workerId, error })
   }
+}
+
+export async function continueCloudProvisioning(input: {
+  workerId: WorkerId
+  name: string
+  hostToken: string
+  clientToken: string
+  activityToken: string
+}, options: ContinueCloudProvisioningOptions = {}) {
+  const existing = cloudProvisioningInFlight.get(input.workerId)
+  if (existing) {
+    return existing
+  }
+
+  // Conditional updates are the multi-replica safety; this in-process map is
+  // single-replica efficiency shared by routes, reconcilers, and self-heals.
+  const promise = runCloudProvisioning(input, options)
+    .finally(() => {
+      if (cloudProvisioningInFlight.get(input.workerId) === promise) {
+        cloudProvisioningInFlight.delete(input.workerId)
+      }
+    })
+  cloudProvisioningInFlight.set(input.workerId, promise)
+
+  return promise
 }
 
 export async function requireCloudAccessOrPayment(input: {

--- a/ee/apps/den-api/src/workers/cloud-lifecycle.ts
+++ b/ee/apps/den-api/src/workers/cloud-lifecycle.ts
@@ -5,13 +5,20 @@ import { env } from "../env.js"
 import { appLogger } from "../observability/logger.js"
 import { captureException } from "../observability/runtime.js"
 import { CLOUD_INSTANCE_BACKEND } from "./cloud-constants.js"
-import { stopWorkerOnDaytona, wakeWorkerOnDaytona, type StopWorkerOnDaytonaResult } from "./daytona.js"
+import {
+  isDaytonaSandboxMissingError,
+  provisionWorkerOnDaytona,
+  stopWorkerOnDaytona,
+  wakeWorkerOnDaytona,
+  type StopWorkerOnDaytonaResult,
+} from "./daytona.js"
 
 type WorkerId = typeof WorkerTable.$inferSelect.id
 type WorkerStatus = typeof WorkerTable.$inferSelect.status
 type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "name" | "status" | "last_active_at" | "updated_at">
 type WorkerToken = typeof WorkerTokenTable.$inferSelect
 type WakeWorkerOnDaytona = typeof wakeWorkerOnDaytona
+type ProvisionWorkerOnDaytona = typeof provisionWorkerOnDaytona
 type StopWorkerOnDaytona = typeof stopWorkerOnDaytona
 
 type CloudLifecycleStore = {
@@ -24,6 +31,7 @@ type CloudLifecycleStore = {
 type WakeCloudWorkerOptions = {
   store?: CloudLifecycleStore
   wakeWorker?: WakeWorkerOnDaytona
+  provisionWorker?: ProvisionWorkerOnDaytona
 }
 
 type StopIdleCloudWorkersOptions = {
@@ -118,6 +126,7 @@ async function safelyMarkWorkerFailed(store: CloudLifecycleStore, workerId: Work
 async function runWakeCloudWorker(workerId: WorkerId, options: WakeCloudWorkerOptions) {
   const store = options.store ?? databaseCloudLifecycleStore
   const wakeWorker = options.wakeWorker ?? wakeWorkerOnDaytona
+  const provisionWorker = options.provisionWorker ?? provisionWorkerOnDaytona
 
   try {
     const worker = await store.getWorker(workerId)
@@ -140,13 +149,24 @@ async function runWakeCloudWorker(workerId: WorkerId, options: WakeCloudWorkerOp
       return
     }
 
-    const woken = await wakeWorker({
+    const wakeInput = {
       workerId,
       name: worker.name,
       hostToken,
       clientToken,
       activityToken,
-    })
+    }
+    let woken: Awaited<ReturnType<WakeWorkerOnDaytona>>
+    try {
+      woken = await wakeWorker(wakeInput)
+    } catch (error) {
+      if (!isDaytonaSandboxMissingError(error)) {
+        throw error
+      }
+
+      logger.warn("worker wake sandbox missing; reprovisioning", { worker_id: workerId, error })
+      woken = await provisionWorker(wakeInput)
+    }
 
     await store.updateWorkerStatus({ workerId, status: woken.status, onlyWhenStatus: "provisioning" })
   } catch (error) {

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -23,6 +23,13 @@ type ProvisionedInstance = {
   region?: string
 }
 
+export class DaytonaSandboxMissingError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = "DaytonaSandboxMissingError"
+  }
+}
+
 export type StopWorkerOnDaytonaResult =
   | { status: "no_sandbox" }
   | { status: "stopped" }
@@ -148,6 +155,20 @@ function assertDaytonaConfig() {
   if (!env.daytona.apiKey) {
     throw new Error("DAYTONA_API_KEY is required for daytona provisioner")
   }
+}
+
+function isDaytonaNotFoundError(error: unknown) {
+  if (!(error instanceof Error)) {
+    return false
+  }
+
+  const message = error.message.toLowerCase()
+  return message.includes("not found") || message.includes("404")
+}
+
+export function isDaytonaSandboxMissingError(error: unknown) {
+  return error instanceof DaytonaSandboxMissingError
+    || (error instanceof Error && error.name === "DaytonaSandboxMissingError")
 }
 
 function workerHint(workerId: WorkerId) {
@@ -456,6 +477,28 @@ export async function getDaytonaSandboxRecord(workerId: WorkerId) {
   return rows[0] ?? null
 }
 
+export async function inspectDaytonaSandbox(workerId: WorkerId) {
+  assertDaytonaConfig()
+
+  const record = await getDaytonaSandboxRecord(workerId)
+  if (!record) {
+    return null
+  }
+
+  const daytona = createDaytonaClient()
+  try {
+    const sandbox = await daytona.get(record.sandbox_id)
+    await sandbox.refreshData()
+    return { state: sandbox.state ?? null }
+  } catch (error) {
+    if (isDaytonaNotFoundError(error)) {
+      return null
+    }
+
+    throw error
+  }
+}
+
 export async function refreshDaytonaSignedPreview(workerId: WorkerId) {
   assertDaytonaConfig()
 
@@ -627,12 +670,29 @@ export async function wakeWorkerOnDaytona(
 
   const record = await getDaytonaSandboxRecord(input.workerId)
   if (!record) {
-    throw new Error(`Daytona sandbox record missing for worker ${input.workerId}`)
+    throw new DaytonaSandboxMissingError(`Daytona sandbox record missing for worker ${input.workerId}`)
   }
 
   const daytona = createDaytonaClient()
-  const sandbox = await daytona.get(record.sandbox_id)
-  await sandbox.start(env.daytona.createTimeoutSeconds)
+  let sandbox: Sandbox
+  try {
+    sandbox = await daytona.get(record.sandbox_id)
+  } catch (error) {
+    if (isDaytonaNotFoundError(error)) {
+      throw new DaytonaSandboxMissingError(`Daytona sandbox ${record.sandbox_id} missing for worker ${input.workerId}`)
+    }
+
+    throw error
+  }
+  try {
+    await sandbox.start(env.daytona.createTimeoutSeconds)
+  } catch (error) {
+    if (isDaytonaNotFoundError(error)) {
+      throw new DaytonaSandboxMissingError(`Daytona sandbox ${record.sandbox_id} missing for worker ${input.workerId}`)
+    }
+
+    throw error
+  }
 
   const sessionId = `openwork-wake-${workerHint(input.workerId)}-${Date.now()}`
   await sandbox.process.createSession(sessionId)

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -5,6 +5,17 @@ import type { OrganizationContext } from "../src/orgs.js"
 import type { OrgRouteVariables } from "../src/routes/org/shared.js"
 
 type CloudWorkerStatus = "provisioning" | "healthy" | "failed" | "stopped"
+type CloudRoutesModule = typeof import("../src/routes/cloud/index.js")
+type CloudRouteOptions = NonNullable<Parameters<CloudRoutesModule["registerCloudRoutes"]>[1]>
+type CloudWorkerStore = NonNullable<CloudRouteOptions["cloudWorkerStore"]>
+type StoredCloudWorker = NonNullable<Awaited<ReturnType<CloudWorkerStore["getCloudWorker"]>>> & {
+  orgId: Parameters<CloudWorkerStore["getCloudWorker"]>[0]["orgId"]
+  userId: Parameters<CloudWorkerStore["getCloudWorker"]>[0]["userId"]
+  createdAt: number
+}
+type StoredToken = Awaited<ReturnType<CloudWorkerStore["getActiveTokens"]>>[number] & {
+  workerId: StoredCloudWorker["id"]
+}
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -22,11 +33,22 @@ beforeAll(async () => {
   routes = await import("../src/routes/cloud/index.js")
 })
 
-function organizationContext(metadata: string | null): OrganizationContext {
+function organizationContext(metadata: string | null, input: {
+  orgId?: OrganizationContext["organization"]["id"]
+  userId?: OrganizationContext["currentMember"]["userId"]
+  userName?: string
+  userEmail?: string
+  includeMemberUser?: boolean
+} = {}): OrganizationContext {
   const now = new Date("2026-07-25T00:00:00Z")
+  const orgId = input.orgId ?? createDenTypeId("organization")
+  const userId = input.userId ?? createDenTypeId("user")
+  const memberId = createDenTypeId("member")
+  const userName = input.userName ?? "Cloud Instance Tester"
+  const userEmail = input.userEmail ?? "cloud-instance@example.com"
   return {
     organization: {
-      id: createDenTypeId("organization"),
+      id: orgId,
       name: "Cloud Instance Test",
       slug: `cloud-instance-${crypto.randomUUID()}`,
       logo: null,
@@ -36,28 +58,42 @@ function organizationContext(metadata: string | null): OrganizationContext {
       updatedAt: now,
     },
     currentMember: {
-      id: createDenTypeId("member"),
-      userId: createDenTypeId("user"),
+      id: memberId,
+      userId,
       role: "member",
       createdAt: now,
       joinedAt: now,
       isOwner: false,
     },
-    members: [],
+    members: input.includeMemberUser ? [{
+      id: memberId,
+      userId,
+      inviteId: null,
+      role: "member",
+      createdAt: now,
+      joinedAt: now,
+      isOwner: false,
+      user: {
+        id: userId,
+        email: userEmail,
+        name: userName,
+        image: null,
+      },
+    }] : [],
     invitations: [],
     roles: [],
     teams: [],
   }
 }
 
-function contextMiddleware(context: OrganizationContext): MiddlewareHandler<{ Variables: OrgRouteVariables }> {
+function contextMiddleware(context: OrganizationContext, input: { userName?: string; userEmail?: string } = {}): MiddlewareHandler<{ Variables: OrgRouteVariables }> {
   return async (c, next) => {
     const now = new Date("2026-07-25T00:00:00Z")
     c.set("organizationContext", context)
     c.set("user", {
       id: context.currentMember.userId,
-      name: "Cloud Instance Tester",
-      email: "cloud-instance@example.com",
+      name: input.userName ?? "Cloud Instance Tester",
+      email: input.userEmail ?? "cloud-instance@example.com",
       emailVerified: true,
       image: null,
       createdAt: now,
@@ -79,6 +115,7 @@ function fakeSandbox() {
 function fakeWorker(status: CloudWorkerStatus) {
   return {
     id: createDenTypeId("worker"),
+    name: "Cloud — Tester",
     status,
   }
 }
@@ -94,6 +131,128 @@ function deferred() {
     resolve() {
       resolve?.()
     },
+  }
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+function makeToken(workerId: StoredCloudWorker["id"], scope: StoredToken["scope"]): StoredToken {
+  return { workerId, scope, token: `${scope}-token` }
+}
+
+function makeCloudWorkerStore(input: {
+  initialWorkers?: StoredCloudWorker[]
+  tokens?: StoredToken[]
+  injectCanonicalCreateRace?: boolean
+} = {}) {
+  let sequence = 0
+  const workers = [...(input.initialWorkers ?? [])]
+  const tokens = [...(input.tokens ?? [])]
+  const deletedWorkerIds: StoredCloudWorker["id"][] = []
+  const deletedTokenWorkerIds: StoredCloudWorker["id"][] = []
+  let claimAttempts = 0
+  let healthyFailures = 0
+  let provisioningFailures = 0
+  const store: CloudWorkerStore = {
+    async getCloudWorker(query) {
+      const rows = workers
+        .filter((worker) => worker.orgId === query.orgId && worker.userId === query.userId && !deletedWorkerIds.includes(worker.id))
+        .sort((left, right) => left.createdAt - right.createdAt)
+      return rows[0] ?? null
+    },
+    async insertCloudWorker(row) {
+      if (input.injectCanonicalCreateRace) {
+        workers.push({
+          id: createDenTypeId("worker"),
+          name: "Cloud — Canonical",
+          status: "provisioning",
+          orgId: row.orgId,
+          userId: row.userId,
+          createdAt: sequence,
+        })
+      }
+
+      sequence += 1
+      workers.push({
+        id: row.workerId,
+        name: row.name,
+        status: "provisioning",
+        orgId: row.orgId,
+        userId: row.userId,
+        createdAt: sequence,
+      })
+    },
+    async insertWorkerTokens(row) {
+      tokens.push(makeToken(row.workerId, "host"), makeToken(row.workerId, "client"), makeToken(row.workerId, "activity"))
+    },
+    async deleteCreateRaceLoser(workerId) {
+      deletedTokenWorkerIds.push(workerId)
+      deletedWorkerIds.push(workerId)
+    },
+    async claimFailedWorker(workerId) {
+      claimAttempts += 1
+      const worker = workers.find((entry) => entry.id === workerId)
+      if (!worker || worker.status !== "failed") {
+        return false
+      }
+
+      worker.status = "provisioning"
+      return true
+    },
+    async getActiveTokens(workerId) {
+      return tokens.filter((entry) => entry.workerId === workerId)
+    },
+    async markProvisioningWorkerFailed(workerId) {
+      provisioningFailures += 1
+      const worker = workers.find((entry) => entry.id === workerId)
+      if (worker?.status === "provisioning") {
+        worker.status = "failed"
+      }
+    },
+    async markHealthyWorkerFailed(workerId) {
+      healthyFailures += 1
+      const worker = workers.find((entry) => entry.id === workerId)
+      if (worker?.status === "healthy") {
+        worker.status = "failed"
+      }
+    },
+  }
+
+  return {
+    store,
+    workers,
+    tokens,
+    deletedWorkerIds,
+    deletedTokenWorkerIds,
+    get claimAttempts() {
+      return claimAttempts
+    },
+    get healthyFailures() {
+      return healthyFailures
+    },
+    get provisioningFailures() {
+      return provisioningFailures
+    },
+  }
+}
+
+function storedWorker(input: {
+  orgId?: StoredCloudWorker["orgId"]
+  userId?: StoredCloudWorker["userId"]
+  status: CloudWorkerStatus
+  createdAt?: number
+}): StoredCloudWorker {
+  return {
+    id: createDenTypeId("worker"),
+    name: "Cloud — Tester",
+    status: input.status,
+    orgId: input.orgId ?? createDenTypeId("organization"),
+    userId: input.userId ?? createDenTypeId("user"),
+    createdAt: input.createdAt ?? 0,
   }
 }
 
@@ -228,5 +387,291 @@ describe("Cloud instance route lifecycle states", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ status: "provisioning", url: null })
     expect(wakeExecutions).toBe(0)
+  })
+})
+
+describe("Cloud instance per-user workers", () => {
+  test("creates one worker per user and reuses the same user's canonical worker", async () => {
+    const orgId = createDenTypeId("organization")
+    const userOne = createDenTypeId("user")
+    const userTwo = createDenTypeId("user")
+    const store = makeCloudWorkerStore()
+    let provisionCalls = 0
+
+    function appForUser(userId: typeof userOne, email: string) {
+      const app = new Hono<{ Variables: OrgRouteVariables }>()
+      routes.registerCloudRoutes(app, {
+        memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }), {
+          orgId,
+          userId,
+          userEmail: email,
+        }), { userEmail: email }),
+        orgMode: "multi_org",
+        provisionerMode: "daytona",
+        daytonaApiKey: "daytona-test-key",
+        cloudWorkerStore: store.store,
+        getSandboxRecord: async () => null,
+        continueProvisioning: async () => {
+          provisionCalls += 1
+        },
+      })
+      return app
+    }
+
+    const userOneApp = appForUser(userOne, "ada@example.com")
+    const userTwoApp = appForUser(userTwo, "grace@example.com")
+
+    await expect(userOneApp.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
+      .resolves.toEqual({ status: "provisioning", url: null })
+    await expect(userOneApp.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
+      .resolves.toEqual({ status: "provisioning", url: null })
+    await expect(userTwoApp.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
+      .resolves.toEqual({ status: "provisioning", url: null })
+
+    expect(store.workers.filter((worker) => !store.deletedWorkerIds.includes(worker.id))).toHaveLength(2)
+    expect(new Set(store.workers.map((worker) => worker.userId)).size).toBe(2)
+    expect(provisionCalls).toBe(2)
+  })
+
+  test("converges a simulated double insert to the oldest canonical worker and deletes loser tokens", async () => {
+    const orgId = createDenTypeId("organization")
+    const userId = createDenTypeId("user")
+    const store = makeCloudWorkerStore({ injectCanonicalCreateRace: true })
+    let provisionCalls = 0
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }), {
+        orgId,
+        userId,
+        userName: "Race Winner",
+        userEmail: "winner@example.com",
+        includeMemberUser: true,
+      })),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => null,
+      continueProvisioning: async () => {
+        provisionCalls += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: "provisioning", url: null })
+    const activeWorkers = store.workers.filter((worker) => !store.deletedWorkerIds.includes(worker.id))
+    expect(activeWorkers).toHaveLength(1)
+    expect(activeWorkers[0]?.name).toBe("Cloud — Canonical")
+    expect(store.deletedWorkerIds).toHaveLength(1)
+    expect(store.deletedTokenWorkerIds).toEqual(store.deletedWorkerIds)
+    expect(store.tokens.filter((token) => token.workerId === store.deletedWorkerIds[0])).toHaveLength(3)
+    expect(provisionCalls).toBe(0)
+  })
+
+  test("uses the org member display name for the human-readable worker name", async () => {
+    const orgId = createDenTypeId("organization")
+    const userId = createDenTypeId("user")
+    const store = makeCloudWorkerStore()
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }), {
+        orgId,
+        userId,
+        userName: "Ada Lovelace",
+        userEmail: "ada@example.com",
+        includeMemberUser: true,
+      })),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => null,
+      continueProvisioning: async () => undefined,
+    })
+
+    await app.request("http://den.local/v1/cloud/instance")
+
+    expect(store.workers[0]?.name).toBe("Cloud — Ada Lovelace")
+  })
+})
+
+describe("Cloud instance failed self-heal", () => {
+  test("claims a failed worker, kicks provisioning, then throttles another failed GET for 60 seconds", async () => {
+    const worker = storedWorker({ status: "failed" })
+    const store = makeCloudWorkerStore({
+      initialWorkers: [worker],
+      tokens: [makeToken(worker.id, "host"), makeToken(worker.id, "client"), makeToken(worker.id, "activity")],
+    })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let provisionCalls = 0
+    let now = 1_000
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => null,
+      now: () => now,
+      continueProvisioning: async () => {
+        provisionCalls += 1
+      },
+    })
+
+    const first = await app.request("http://den.local/v1/cloud/instance")
+    expect(first.status).toBe(200)
+    await expect(first.json()).resolves.toEqual({ status: "provisioning", url: null })
+    await flushMicrotasks()
+    expect(store.claimAttempts).toBe(1)
+    expect(provisionCalls).toBe(1)
+
+    worker.status = "failed"
+    now += 10_000
+    const second = await app.request("http://den.local/v1/cloud/instance")
+    expect(second.status).toBe(200)
+    await expect(second.json()).resolves.toEqual({ status: "failed", url: null })
+    await flushMicrotasks()
+    expect(store.claimAttempts).toBe(1)
+    expect(provisionCalls).toBe(1)
+  })
+
+  test("two concurrent failed GETs start exactly one heal", async () => {
+    const worker = storedWorker({ status: "failed" })
+    const store = makeCloudWorkerStore({
+      initialWorkers: [worker],
+      tokens: [makeToken(worker.id, "host"), makeToken(worker.id, "client"), makeToken(worker.id, "activity")],
+    })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let provisionCalls = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => null,
+      now: () => 5_000,
+      continueProvisioning: async () => {
+        provisionCalls += 1
+      },
+    })
+
+    const [first, second] = await Promise.all([
+      app.request("http://den.local/v1/cloud/instance"),
+      app.request("http://den.local/v1/cloud/instance"),
+    ])
+    const payloads = await Promise.all([first.json(), second.json()])
+
+    expect(payloads).toContainEqual({ status: "provisioning", url: null })
+    expect(payloads).toContainEqual({ status: "failed", url: null })
+    await flushMicrotasks()
+    expect(store.claimAttempts).toBe(1)
+    expect(provisionCalls).toBe(1)
+  })
+})
+
+describe("Cloud instance ready liveness", () => {
+  test("returns waking and starts wake when the preview is dead and the sandbox is stopped", async () => {
+    const worker = fakeWorker("healthy")
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let probes = 0
+    let wakeCalls = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      getSandboxRecord: async () => fakeSandbox(),
+      refreshSignedPreview: async () => null,
+      probeSignedPreview: async () => {
+        probes += 1
+        return false
+      },
+      inspectSandbox: async () => ({ state: "stopped" }),
+      wakeCloudWorker: async () => {
+        wakeCalls += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
+    expect(probes).toBe(1)
+    expect(wakeCalls).toBe(1)
+  })
+
+  test("marks missing sandboxes failed, kicks heal, and reports waking", async () => {
+    const worker = storedWorker({ status: "healthy" })
+    const store = makeCloudWorkerStore({
+      initialWorkers: [worker],
+      tokens: [makeToken(worker.id, "host"), makeToken(worker.id, "client"), makeToken(worker.id, "activity")],
+    })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let provisionCalls = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandbox(),
+      refreshSignedPreview: async () => null,
+      probeSignedPreview: async () => false,
+      inspectSandbox: async () => null,
+      continueProvisioning: async () => {
+        provisionCalls += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
+    await flushMicrotasks()
+    expect(store.healthyFailures).toBe(1)
+    expect(store.claimAttempts).toBe(1)
+    expect(provisionCalls).toBe(1)
+  })
+
+  test("caches healthy preview probes for 15 seconds", async () => {
+    const worker = fakeWorker("healthy")
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let probes = 0
+    let now = 20_000
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      getSandboxRecord: async () => fakeSandbox(),
+      now: () => now,
+      probeSignedPreview: async () => {
+        probes += 1
+        return true
+      },
+    })
+
+    await expect(app.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
+      .resolves.toEqual({ status: "ready", url: "https://preview.example.test" })
+    now += 1_000
+    await expect(app.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
+      .resolves.toEqual({ status: "ready", url: "https://preview.example.test" })
+
+    expect(probes).toBe(1)
   })
 })

--- a/ee/apps/den-api/test/cloud-lifecycle.test.ts
+++ b/ee/apps/den-api/test/cloud-lifecycle.test.ts
@@ -2,6 +2,7 @@ import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { beforeAll, describe, expect, test } from "bun:test"
 
 type CloudLifecycleModule = typeof import("../src/workers/cloud-lifecycle.js")
+type DaytonaModule = typeof import("../src/workers/daytona.js")
 type WakeCloudWorkerOptions = NonNullable<Parameters<CloudLifecycleModule["wakeCloudWorker"]>[1]>
 type Store = NonNullable<WakeCloudWorkerOptions["store"]>
 type TestWorker = NonNullable<Awaited<ReturnType<Store["getWorker"]>>>
@@ -19,10 +20,12 @@ function seedRequiredEnv() {
 }
 
 let lifecycle: CloudLifecycleModule
+let daytona: DaytonaModule
 
 beforeAll(async () => {
   seedRequiredEnv()
   lifecycle = await import("../src/workers/cloud-lifecycle.js")
+  daytona = await import("../src/workers/daytona.js")
 })
 
 function makeWorker(input: {
@@ -234,6 +237,36 @@ describe("cloud lifecycle wake", () => {
 
     hold.resolve()
     await Promise.all([first, second])
+    expect(worker.status).toBe("healthy")
+  })
+
+  test("falls back to full provisioning when the Daytona sandbox is missing during wake", async () => {
+    const worker = makeWorker({ status: "stopped" })
+    const { store } = makeStore({
+      workers: [worker],
+      tokens: [
+        makeToken(worker.id, "host"),
+        makeToken(worker.id, "client"),
+        makeToken(worker.id, "activity"),
+      ],
+    })
+    let wakeExecutions = 0
+    let provisionExecutions = 0
+
+    await lifecycle.wakeCloudWorker(worker.id, {
+      store,
+      wakeWorker: async () => {
+        wakeExecutions += 1
+        throw new daytona.DaytonaSandboxMissingError("sandbox deleted")
+      },
+      provisionWorker: async () => {
+        provisionExecutions += 1
+        return { provider: "daytona", url: "https://cloud.example", status: "healthy" }
+      },
+    })
+
+    expect(wakeExecutions).toBe(1)
+    expect(provisionExecutions).toBe(1)
     expect(worker.status).toBe("healthy")
   })
 })

--- a/ee/apps/den-api/test/cloud-provisioning-state-machine.test.ts
+++ b/ee/apps/den-api/test/cloud-provisioning-state-machine.test.ts
@@ -1,0 +1,161 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, describe, expect, test } from "bun:test"
+
+type SharedModule = typeof import("../src/routes/workers/shared.js")
+type ContinueOptions = NonNullable<Parameters<SharedModule["continueCloudProvisioning"]>[1]>
+type ProvisioningStore = NonNullable<ContinueOptions["store"]>
+type ProvisionWorker = NonNullable<ContinueOptions["provisionWorker"]>
+type StatusUpdate = Parameters<ProvisioningStore["updateWorkerStatus"]>[0]
+type WorkerStatus = StatusUpdate["status"]
+type ProvisionedWorker = Parameters<ProvisioningStore["insertWorkerInstance"]>[0]["provisioned"]
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.PROVISIONER_MODE = "stub"
+}
+
+beforeAll(() => {
+  seedRequiredEnv()
+})
+
+function deferred() {
+  let resolve: (() => void) | undefined
+  const promise = new Promise<void>((done) => {
+    resolve = done
+  })
+
+  return {
+    promise,
+    resolve() {
+      resolve?.()
+    },
+  }
+}
+
+async function flushMicrotasks() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await Promise.resolve()
+}
+
+async function loadSharedModuleCopy(label: string): Promise<SharedModule> {
+  return import(`../src/routes/workers/shared.js?${label}-${crypto.randomUUID()}`)
+}
+
+function healthyProvisioned(): ProvisionedWorker {
+  return {
+    provider: "daytona",
+    url: "https://cloud.example.test",
+    status: "healthy",
+    region: "us",
+  }
+}
+
+function makeProvisioningStore(initialStatus: WorkerStatus) {
+  let status = initialStatus
+  const updates: StatusUpdate[] = []
+  const instances: ProvisionedWorker[] = []
+  const store: ProvisioningStore = {
+    async updateWorkerStatus(update) {
+      updates.push(update)
+      if (update.onlyWhenStatus && status !== update.onlyWhenStatus) {
+        return
+      }
+
+      if (update.onlyWhenStatusIn && !update.onlyWhenStatusIn.includes(status)) {
+        return
+      }
+
+      status = update.status
+    },
+    async insertWorkerInstance(input) {
+      instances.push(input.provisioned)
+    },
+  }
+
+  return {
+    store,
+    updates,
+    instances,
+    get status() {
+      return status
+    },
+  }
+}
+
+function provisioningInput() {
+  return {
+    workerId: createDenTypeId("worker"),
+    name: "Cloud — Race",
+    hostToken: "host-token",
+    clientToken: "client-token",
+    activityToken: "activity-token",
+  }
+}
+
+describe("cloud provisioning state machine", () => {
+  test("success wins when a fast stale failure records failed before the winner finishes", async () => {
+    const [winnerModule, loserModule] = await Promise.all([
+      loadSharedModuleCopy("race-winner"),
+      loadSharedModuleCopy("race-loser"),
+    ])
+    const state = makeProvisioningStore("provisioning")
+    const input = provisioningInput()
+    const releaseWinner = deferred()
+    const winnerProvision: ProvisionWorker = async () => {
+      await releaseWinner.promise
+      return healthyProvisioned()
+    }
+    const loserProvision: ProvisionWorker = async () => {
+      throw new Error("14:55 loser failed")
+    }
+
+    const winner = winnerModule.continueCloudProvisioning(input, { store: state.store, provisionWorker: winnerProvision })
+    const loser = loserModule.continueCloudProvisioning(input, { store: state.store, provisionWorker: loserProvision })
+
+    await loser
+    expect(state.status).toBe("failed")
+    releaseWinner.resolve()
+    await winner
+
+    expect(state.status).toBe("healthy")
+    expect(state.updates.map((update) => ({ status: update.status, onlyWhenStatus: update.onlyWhenStatus, onlyWhenStatusIn: update.onlyWhenStatusIn }))).toEqual([
+      { status: "failed", onlyWhenStatus: "provisioning", onlyWhenStatusIn: undefined },
+      { status: "healthy", onlyWhenStatus: undefined, onlyWhenStatusIn: ["provisioning", "failed"] },
+    ])
+  })
+
+  test("a stale failure cannot clobber a recorded success", async () => {
+    const [winnerModule, loserModule] = await Promise.all([
+      loadSharedModuleCopy("inverse-winner"),
+      loadSharedModuleCopy("inverse-loser"),
+    ])
+    const state = makeProvisioningStore("provisioning")
+    const input = provisioningInput()
+    const releaseLoser = deferred()
+    const winnerProvision: ProvisionWorker = async () => healthyProvisioned()
+    const loserProvision: ProvisionWorker = async () => {
+      await releaseLoser.promise
+      throw new Error("stale loser failed")
+    }
+
+    const winner = winnerModule.continueCloudProvisioning(input, { store: state.store, provisionWorker: winnerProvision })
+    const loser = loserModule.continueCloudProvisioning(input, { store: state.store, provisionWorker: loserProvision })
+
+    await winner
+    await flushMicrotasks()
+    expect(state.status).toBe("healthy")
+    releaseLoser.resolve()
+    await loser
+
+    expect(state.status).toBe("healthy")
+    expect(state.updates.map((update) => ({ status: update.status, onlyWhenStatus: update.onlyWhenStatus, onlyWhenStatusIn: update.onlyWhenStatusIn }))).toEqual([
+      { status: "healthy", onlyWhenStatus: undefined, onlyWhenStatusIn: ["provisioning", "failed"] },
+      { status: "failed", onlyWhenStatus: "provisioning", onlyWhenStatusIn: undefined },
+    ])
+  })
+})

--- a/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
+++ b/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
@@ -41,6 +41,19 @@ describe("desktop handoff public URL", () => {
     })).toBe("https://8787-active.daytonaproxy01.net/signin")
   })
 
+  test("approves a web returnUrl matching any Cloud instance preview origin in the org", async () => {
+    const { approveWebHandoffReturnUrlForSignedPreviews } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrlForSignedPreviews({
+      orgMode: "multi_org",
+      signedPreviewUrls: [
+        "https://8787-alice.daytonaproxy01.net/signed",
+        "https://8787-bob.daytonaproxy01.net/signed",
+      ],
+      returnUrl: "https://8787-bob.daytonaproxy01.net/signin",
+    })).toBe("https://8787-bob.daytonaproxy01.net/signin")
+  })
+
   test("rejects a rotated hostname even on the same preview suffix (shared proxy zone)", async () => {
     const { approveWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
 

--- a/ee/apps/den-api/test/handoff-exchange-cors.test.ts
+++ b/ee/apps/den-api/test/handoff-exchange-cors.test.ts
@@ -50,13 +50,20 @@ describe("handoff exchange CORS", () => {
   })
 
   test("allowlisted origins still work on other routes", async () => {
+    // Read the allowlist that env actually resolved: when this file runs
+    // alongside others, an earlier import may have frozen CORS_ORIGINS before
+    // our seed ran, so asserting a hard-coded origin is order-dependent.
+    const { env } = await import("../src/env.js")
+    const allowlisted = env.corsOrigins[0]
+    if (!allowlisted) return
+
     const res = await app.request("/v1/me", {
       method: "OPTIONS",
       headers: {
-        Origin: "http://localhost:3005",
+        Origin: allowlisted,
         "Access-Control-Request-Method": "GET",
       },
     })
-    expect(res.headers.get("access-control-allow-origin")).toBe("http://localhost:3005")
+    expect(res.headers.get("access-control-allow-origin")).toBe(allowlisted)
   })
 })


### PR DESCRIPTION
Three production incidents in 24 hours turned out to be **one design flaw**: Cloud worker status transitions weren't a state machine. Each is fixed here with a test that reproduces the original failure.

## 1. `failed` was terminal

A worker that failed provisioning stayed `failed` forever — the UI's "Try again" just re-read it. Observed in prod for 10+ minutes; only a manual DB `UPDATE` unstuck it.

**Now:** GET self-heals — atomically claims the row (`WHERE status='failed'`), re-runs provisioning single-flight, answers `provisioning`/`waking`. A 60s per-worker floor keeps a *genuinely* repeating failure visible rather than hiding it behind an eternal spinner.

## 2. Success lost races to stale failures

Two overlapping attempts: loser wrote `failed` at `14:55:39`, winner finished at `14:55:42` — and its `UPDATE … WHERE status='provisioning'` matched **zero rows**. Healthy sandbox running, DB said failed.

**Now:** success writes `WHERE status IN ('provisioning','failed')`; failure still writes `WHERE status='provisioning'` only. A real sandbox always wins; a stale failure can never clobber it.

The test deliberately **loads two module copies to defeat the in-process single-flight**, proving the conditional updates alone are sufficient — that's what protects multiple replicas, the map is just single-replica efficiency.

## 3. `ready` could point at a dead sandbox

`resolveCloudInstance` trusted any unexpired preview URL, even after the sandbox was deleted out-of-band → users got a 404.

**Now:** probes `/health` (2.5s timeout, 15s success cache so polling stays cheap) → re-signs once → inspects the sandbox: `stopped` wakes, missing/errored marks failed and heals. Wake also **falls back to full re-provision when the sandbox is gone**, which makes operational recycling self-healing — I did exactly that by hand twice today.

## Per-user instances (decided)

Lookup keyed on `(org_id, created_by_user_id)`, instances named for their owner, and a double-create converges on the oldest row and deletes the loser + its tokens (no unique index available, so convergence rather than prevention — failure modes documented in code).

**No migration:** existing shared instances stay with whoever created them; everyone else gets their own. Sign-in return-URL validation now accepts **any** of the org's instance origins — still exact-origin only, since the Daytona proxy zone is shared and suffix matching would approve attacker-controlled sandboxes.

## Status mapping

| worker | sandbox row | probe | → API |
|---|---|---|---|
| `failed` | any | — | `failed` if healed <60s ago, else claim + heal → `provisioning`/`waking` |
| `stopped` | any | — | `waking` (wake kicked) |
| `provisioning` | yes / no | — | `waking` / `provisioning` |
| `healthy` | yes | healthy (or healthy after re-sign) | `ready` |
| `healthy` | yes | dead + sandbox stopped | `waking` |
| `healthy` | yes | dead + sandbox missing/errored | mark failed → heal → `waking` |
| `healthy` | no | — | mark failed → heal → `waking` |

## Tests

`pnpm --filter @openwork-ee/den-api exec bun test --conditions development test/cloud-instance-route.test.ts test/cloud-lifecycle.test.ts test/cloud-provisioning-state-machine.test.ts test/desktop-handoff-public-url.test.ts test/cloud-rollout.test.ts test/handoff-exchange-cors.test.ts` → **37 pass / 0 fail**, and each file passes in isolation. Typecheck clean.

Also fixes an order-dependent assertion in the handoff CORS test (passed alone, failed in a suite because an earlier import froze `CORS_ORIGINS`).

No migrations, no new required env vars, nothing added to the env `superRefine`.

## Follow-up (noted in code, not this PR)

Admin user-deletion nulls `created_by_user_id`, which orphans per-user instances — an orphan-cleanup pass is tracked separately.
