### PR TITLE
fix(cloud): ship the OpenCode plugins in the Cloud snapshot

### DIFF
--- a/apps/server/src/cloud-mcp-health.ts
+++ b/apps/server/src/cloud-mcp-health.ts
@@ -1,10 +1,9 @@
 import { createHash } from "node:crypto";
 import { readFile } from "node:fs/promises";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
 import type { createOpencodeClient, McpStatus, ToolIds, ToolList } from "@opencode-ai/sdk/v2/client";
 import { ApiError } from "./errors.js";
 import { diagnoseMcpToolDenies, type McpToolDeny } from "./mcp.js";
+import { openworkPluginPath } from "./openwork-extensions-plugin-path.js";
 import { sanitizeDiagnosticString, sanitizeDiagnosticValue } from "./diagnostic-sanitizer.js";
 import { readRuntimeOpencodeConfig, runtimeMcpMap, writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import { externalFetch } from "./server-fetch.js";
@@ -1915,18 +1914,14 @@ function baseUrlConfigured(config: ServerConfig, workspace: WorkspaceInfo): bool
 }
 
 async function pluginFileHashes(): Promise<CloudMcpCompatibilitySnapshot["pluginFileHashes"]> {
-  const here = dirname(fileURLToPath(import.meta.url));
   const names = ["openwork-extensions-preview", "openwork-capabilities-knowledge"];
   return Promise.all(names.map(async (name) => {
-    let lastError = "not found";
-    for (const extension of ["ts", "js"]) {
-      try {
-        return { name, sha256: hashString(await readFile(join(here, "opencode-plugins", `${name}.${extension}`), "utf8")) };
-      } catch (error) {
-        lastError = error instanceof Error ? error.message : String(error);
-      }
+    try {
+      return { name, sha256: hashString(await readFile(openworkPluginPath(name), "utf8")) };
+    } catch (error) {
+      const lastError = error instanceof Error ? error.message : String(error);
+      return { name, sha256: null, error: sanitizeDiagnosticString(lastError) };
     }
-    return { name, sha256: null, error: sanitizeDiagnosticString(lastError) };
   }));
 }
 

--- a/apps/server/src/openwork-extensions-plugin-path.test.ts
+++ b/apps/server/src/openwork-extensions-plugin-path.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+import { openworkPluginPath } from "./openwork-extensions-plugin-path.js";
+
+function withPluginDir(value: string | undefined, fn: () => void) {
+  const previous = process.env.OPENWORK_EXTENSIONS_PLUGIN_DIR;
+  if (value === undefined) {
+    delete process.env.OPENWORK_EXTENSIONS_PLUGIN_DIR;
+  } else {
+    process.env.OPENWORK_EXTENSIONS_PLUGIN_DIR = value;
+  }
+
+  try {
+    fn();
+  } finally {
+    if (previous === undefined) {
+      delete process.env.OPENWORK_EXTENSIONS_PLUGIN_DIR;
+    } else {
+      process.env.OPENWORK_EXTENSIONS_PLUGIN_DIR = previous;
+    }
+  }
+}
+
+function restoreResourcesPath(previous: string | undefined) {
+  if (previous === undefined) {
+    delete process.resourcesPath;
+  } else {
+    process.resourcesPath = previous;
+  }
+}
+
+describe("openworkPluginPath", () => {
+  test("prefers OPENWORK_EXTENSIONS_PLUGIN_DIR", () => {
+    withPluginDir("/opt/openwork/opencode-plugins", () => {
+      const resourcesPath = join("/Applications", "OpenWork.app", "Contents", "Resources");
+      const previousResourcesPath = process.resourcesPath;
+      process.resourcesPath = resourcesPath;
+      try {
+        expect(openworkPluginPath("openwork-extensions-preview", join(resourcesPath, "app.asar", "server", "dist")))
+          .toBe(join("/opt/openwork/opencode-plugins", "openwork-extensions-preview.js"));
+      } finally {
+        restoreResourcesPath(previousResourcesPath);
+      }
+    });
+  });
+
+  test("uses external resources plugin path in packaged Electron when env is unset", () => {
+    withPluginDir(undefined, () => {
+      const previousResourcesPath = process.resourcesPath;
+      const resourcesPath = join("/Applications", "OpenWork.app", "Contents", "Resources");
+      process.resourcesPath = resourcesPath;
+      try {
+        const pluginPath = openworkPluginPath(
+          "openwork-extensions-preview",
+          join(resourcesPath, "app.asar", "server", "dist"),
+        );
+
+        expect(pluginPath).toBe(join(resourcesPath, "opencode-plugins", "openwork-extensions-preview.js"));
+        expect(pluginPath).not.toContain("app.asar");
+      } finally {
+        restoreResourcesPath(previousResourcesPath);
+      }
+    });
+  });
+
+  test("uses source plugin path in development when env is unset", () => {
+    withPluginDir(undefined, () => {
+      const here = join("/repo", "apps", "server", "src");
+      expect(openworkPluginPath("openwork-extensions-preview", here))
+        .toBe(join(here, "opencode-plugins", "openwork-extensions-preview.ts"));
+    });
+  });
+});

--- a/apps/server/src/openwork-extensions-plugin-path.ts
+++ b/apps/server/src/openwork-extensions-plugin-path.ts
@@ -14,7 +14,13 @@ function resourcesPathFromAppAsarPath(path: string): string | null {
   return match ? path.slice(0, match.index) : null;
 }
 
-export function openworkPluginPath(name: string, here = dirname(fileURLToPath(import.meta.url))): string {
+export function openworkPluginPath(name: string, here?: string): string {
+  const pluginDir = process.env.OPENWORK_EXTENSIONS_PLUGIN_DIR;
+  if (pluginDir) {
+    return join(pluginDir, `${name}.js`);
+  }
+
+  here = here ?? dirname(fileURLToPath(import.meta.url));
   const resourcesPath = resourcesPathFromAppAsarPath(here);
   if (resourcesPath) {
     const electronResourcesPath = process.resourcesPath?.includes("app.asar") ? resourcesPath : process.resourcesPath?.trim();

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -239,6 +239,8 @@ function buildOpenWorkStartCommand(input: ProvisionInput) {
     shellQuote("/usr/local/bin/opencode"),
     " OPENWORK_WEB_ROOT=",
     shellQuote("/opt/openwork/web"),
+    " OPENWORK_EXTENSIONS_PLUGIN_DIR=",
+    shellQuote("/opt/openwork/opencode-plugins"),
     " DEN_RUNTIME_PROVIDER=",
     shellQuote("daytona"),
     " DEN_WORKER_ID=",

--- a/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
+++ b/ee/apps/den-worker-runtime/Dockerfile.daytona-snapshot
@@ -25,6 +25,7 @@ RUN set -eux; \
     arm64) target="bun-linux-arm64" ;; \
     *) echo "unsupported architecture: $arch" >&2; exit 1 ;; \
   esac; \
+  pnpm --filter openwork-server build; \
   pnpm --filter openwork-server exec bun ./script/build.ts --outdir dist/bin --target "$target"; \
   install -m 0755 "apps/server/dist/bin/openwork-server-${target}" /tmp/openwork-server; \
   pnpm --filter @openwork/app build:web
@@ -41,6 +42,7 @@ RUN apt-get update \
 
 COPY --from=openwork-builder /tmp/openwork-server /usr/local/bin/openwork-server
 COPY --from=openwork-builder /src/apps/app/dist /opt/openwork/web
+COPY --from=openwork-builder /src/apps/server/dist/opencode-plugins /opt/openwork/opencode-plugins
 
 RUN set -eux; \
   test -n "$OPENCODE_VERSION"; \
@@ -68,7 +70,12 @@ RUN set -eux; \
 # real hardware.
 ARG RUNTIME_ASSERTS=1
 RUN if [ "$RUNTIME_ASSERTS" = "1" ]; then \
-    test "$(openwork-server --version)" = "$OPENWORK_SERVER_VERSION" \
+    test -f /opt/openwork/opencode-plugins/openwork-extensions-preview.js \
+    && test -f /opt/openwork/opencode-plugins/openwork-capabilities-knowledge.js \
+    && test -f /opt/openwork/opencode-plugins/openwork-office-attachments.js \
+    && test -f /opt/openwork/opencode-plugins/openwork-anthropic-adaptive-thinking.js \
+    && test -f /opt/openwork/opencode-plugins/openwork-anthropic-tool-schema.js \
+    && test "$(openwork-server --version)" = "$OPENWORK_SERVER_VERSION" \
     && opencode --version; \
   else \
     echo "RUNTIME_ASSERTS disabled (cross-build); binaries must be verified on target hardware"; \


### PR DESCRIPTION
**Prod blocker.** A Cloud instance sits forever on *"OpenWork Connect: Checking — Restoring connected service tools (1/3)"*, and *OpenWork Models — syncing into this workspace…* never completes.

The instance's own diagnostics named it precisely: `phase: extensions_plugin_missing`, `stage: plugin_load` — while the desired MCP config was **correct** (right URL, valid token, right org) and Den's `/mcp/agent` was answering **200/202**. So: not auth, not connectivity. Inside the sandbox, `find / -type d -name opencode-plugins` returned **nothing**.

## Two causes, both mine, both from the snapshot work

**1. The image never built them.** The Dockerfile compiles the server binary via `script/build.ts` and copies the web dist — but never runs openwork-server's package `build`, which is the step that emits `dist/opencode-plugins/*.js`. Now it does, copies them to `/opt/openwork/opencode-plugins`, and **asserts all five exist** so a missing plugin fails the image build instead of shipping silently.

**2. Path resolution can't work from a compiled binary.** `openworkPluginPath` resolved `join(here, "opencode-plugins", …)` from its own module directory — under `bun --compile` that's a virtual embedded path, and these paths are handed to **opencode, a separate process** that must read real files. An `OPENWORK_EXTENSIONS_PLUGIN_DIR` override now takes precedence, and the Daytona start command points at the shipped directory.

**Desktop is unaffected:** with the env unset, the packaged-Electron and dev branches behave exactly as before — asserted by tests.

Bonus: `cloud-mcp-health.ts` had a *second, independent* copy of the resolution logic for its hash evidence. It now uses the same helper, so health evidence and actual loading can't disagree — which is what made this bug harder to read than it needed to be.

## Tests

- 3 new plugin-path tests (env override · packaged Electron unset · dev unset) — pass
- 20 cloud route/lifecycle tests — pass
- server + den-api typechecks — clean
- plugin build emits all five bundles — verified by `ls`

**Pre-existing failures, not regressions:** the full server suite has 4 failures (reload watcher/event timing, plus one plugin test that fails only in suite order). I stashed this change and confirmed the **identical** failure set on clean `origin/dev` — with the change the suite gains +3 passes and no new failures.