### PR TITLE
docs: clarify OpenWork installation and setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,16 @@ The desktop app is there when you want a dedicated workspace, but it is not requ
 
 <img width="1481" height="842" alt="OpenWork desktop app" src="https://github.com/user-attachments/assets/66a8dd9b-5260-488c-957d-e54331e78c1c" />
 
-## Install with your AI agent
+## Install and set up OpenWork
+
+The desktop app is the quickest way to get started:
+
+1. [Download OpenWork](https://openworklabs.com/download) for macOS, Windows, or Linux.
+2. Install and open the app.
+3. Create a workspace and connect an LLM provider when prompted.
+4. Start a task in your new workspace. Sign in only if you want to connect managed services or share with a team.
+
+### Install with your AI agent
 
 Already use an AI agent? Copy this prompt and paste it into Claude Code, Cursor, Codex, ChatGPT, or any agent that can run commands on your computer.
 
@@ -83,7 +92,26 @@ OpenWork Den is the control plane for managing OpenWork across a team or organiz
 
 ## Local development
 
-For one checkout, keep using `pnpm dev`; with no extra environment variables it reuses the existing shared dev profile.
+### Prerequisites
+
+- [Git](https://git-scm.com/)
+- [Node.js 24](https://nodejs.org/) (the version pinned in `.nvmrc`)
+- [pnpm 11.4.0](https://pnpm.io/installation) (the version pinned in `package.json`)
+
+### Run the desktop app from source
+
+```bash
+git clone https://github.com/different-ai/openwork.git
+cd openwork
+corepack enable
+corepack install
+pnpm install --frozen-lockfile
+pnpm dev
+```
+
+No environment variables are required for the default local setup. `pnpm dev` starts the Vite UI and Electron desktop app and reuses the shared development profile. Press `Ctrl+C` to stop both processes.
+
+### Run more than one checkout
 
 To run multiple git worktrees at once, use:
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Install OpenWork on my computer, set up my first workspace, and open it ready to
 2. Creates your workspace
 3. Opens it ready to run
 
+The agent-first path installs to a user-local location without administrator privileges and creates a provisional workspace without requiring an account first. Inspect downloaded scripts instead of piping remote code directly into a shell, and keep tokens and claim links private. Claim the workspace in the app when you are ready to attach your identity and invite teammates. If you already belong to an OpenWork organization, sign in and select it instead of creating another workspace.
+
 ## Use OpenWork from any agent
 
 The OpenWork MCP brings your assigned skills, plugins, MCP connections, Google Workspace, and Microsoft 365 capabilities into any compatible agent.


### PR DESCRIPTION
## What changed

- turns the README download link into a short end-user install and first-workspace flow;
- explains the AI-agent installer, provisional workspace lifecycle, existing-organization path, and safety boundaries;
- documents the pinned Node.js and pnpm prerequisites plus the locked source-development commands;
- keeps volatile release details in the authoritative download/start/docs pages.

## Why

The README described individual entry points but did not give a new user one clear path from download or agent-assisted installation to a usable workspace. Source contributors also had to infer the required toolchain and locked install sequence.

## Impact

New users can choose desktop, agent-first, or MCP-only setup and know what successful setup looks like. Contributors get commands that are checked against the repository's current `.nvmrc`, `packageManager`, and scripts.

## Verification

- README contract assertions against `README.md`, `.nvmrc`, `package.json`, `packages/openwork-bootstrap/start.md`, and `ee/apps/landing/app/start.md/route.ts`
- `git diff --check 1f41a52070cbc400b17b05136533e8d3737e25da`
- exact diff: one file, 32 insertions, 2 deletions

No Electron or browser verification was run because this is a documentation-only P1 change.

## Snacks lineage

OpenWork Snacks produced and retained the one-file candidate at `fbe4cf9e14449285b13776799b75b302a82c6516` with two focused checks recorded as passed. An operator follow-up commit adds the source-backed setup-safety paragraph identified during final review; the checks above were rerun against this PR head.


## Current CI context

The final repository-derived README contract and git diff --check pass. Both OpenWork test runners currently fail on the same unrelated server test already present on exact dev 1f41a520: the bundled Connect guide says Settings > OpenWork Connect while apps/server/src/opencode-plugins/openwork-capabilities-knowledge.test.ts still expects Settings > Connect. This PR changes only README.md. The landing preview succeeds; four other Vercel projects report Git authorization setup failures rather than application test failures. No Electron, browser, Den, release-artifact, or native Kitchen publication proof is claimed for this README-only change.