### PR TITLE
feat(den-web): Bring your Own Keys page + shared den primitives

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/badge.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/badge.tsx
@@ -1,0 +1,28 @@
+import type { ElementType, ReactNode } from "react";
+
+export type DenBadgeTone = "neutral" | "info" | "success" | "warning";
+
+const toneClasses: Record<DenBadgeTone, string> = {
+  neutral: "bg-gray-100 text-gray-600",
+  info: "bg-blue-50 text-blue-700",
+  success: "bg-emerald-50 text-emerald-700",
+  warning: "bg-amber-50 text-amber-700",
+};
+
+export type DenBadgeProps = {
+  children: ReactNode;
+  tone?: DenBadgeTone;
+  icon?: ElementType;
+  className?: string;
+};
+
+export function DenBadge({ children, tone = "neutral", icon: Icon, className = "" }: DenBadgeProps) {
+  return (
+    <span
+      className={`inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-[12px] font-medium ${toneClasses[tone]} ${className}`}
+    >
+      {Icon ? <Icon className="h-3.5 w-3.5" aria-hidden /> : null}
+      {children}
+    </span>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/ui/brand-mark.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/brand-mark.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { brandIconCandidates } from "../../_lib/brand-icon";
+
+export type DenBrandMarkProps = {
+  name: string;
+  /** Simple Icons slug, when the brand is known by name rather than by URL. */
+  simpleIconSlug?: string;
+  /** Any URL owned by the brand (docs, console, API). Used for the favicon fallback. */
+  serviceUrl?: string | null;
+  iconUrl?: string;
+  className?: string;
+  imageClassName?: string;
+};
+
+/**
+ * Brand tile that walks the shared icon ladder and ends on a monogram, so a
+ * provider without a usable logo still reads as a deliberate mark.
+ */
+export function DenBrandMark({
+  name,
+  simpleIconSlug,
+  serviceUrl,
+  iconUrl,
+  className = "h-10 w-10 rounded-[12px]",
+  imageClassName = "h-5 w-5",
+}: DenBrandMarkProps) {
+  const candidates = useMemo(
+    () => brandIconCandidates({ iconUrl, simpleIconSlug, serviceUrl }),
+    [iconUrl, simpleIconSlug, serviceUrl],
+  );
+  const [failedCount, setFailedCount] = useState(0);
+  const src = candidates[failedCount];
+  const monogram = name.trim().charAt(0).toUpperCase();
+
+  return (
+    <span className={`flex shrink-0 items-center justify-center border border-gray-100 bg-white ${className}`}>
+      {src ? (
+        <img
+          key={src}
+          src={src}
+          alt=""
+          aria-hidden
+          loading="lazy"
+          onError={() => setFailedCount((count) => count + 1)}
+          className={`object-contain ${imageClassName}`}
+        />
+      ) : (
+        <span aria-hidden className="text-[13px] font-semibold text-gray-500">
+          {monogram}
+        </span>
+      )}
+    </span>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/ui/option-card.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/option-card.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from "react";
+
+export type DenOptionCardProps = {
+  type: "radio" | "checkbox";
+  /** Required for radios so the browser groups them. */
+  name?: string;
+  checked: boolean;
+  onChange: (checked: boolean) => void;
+  title: string;
+  description?: ReactNode;
+  disabled?: boolean;
+  testId?: string;
+};
+
+/**
+ * Selectable card wrapping a native input, so keyboard, screen readers and
+ * end-to-end flows keep working against a real radio or checkbox.
+ */
+export function DenOptionCard({
+  type,
+  name,
+  checked,
+  onChange,
+  title,
+  description,
+  disabled = false,
+  testId,
+}: DenOptionCardProps) {
+  return (
+    <label
+      className={`flex cursor-pointer items-start gap-3 rounded-[22px] border px-4 py-3 transition-colors ${
+        checked ? "border-gray-900 bg-white" : "border-gray-200 bg-gray-50 hover:border-gray-300"
+      } ${disabled ? "cursor-not-allowed opacity-60" : ""}`}
+    >
+      <input
+        type={type}
+        name={name}
+        data-testid={testId}
+        className="mt-1 h-4 w-4 accent-gray-900"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        disabled={disabled}
+      />
+      <span className="min-w-0">
+        <span className="block text-[14px] font-medium text-gray-950">{title}</span>
+        {description ? <span className="mt-1 block text-[13px] leading-6 text-gray-500">{description}</span> : null}
+      </span>
+    </label>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/ui/section-header.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/section-header.tsx
@@ -1,0 +1,21 @@
+import type { ReactNode } from "react";
+
+export type DenSectionHeaderProps = {
+  title: string;
+  description?: ReactNode;
+  /** Right-aligned slot for the section's primary action. */
+  action?: ReactNode;
+  className?: string;
+};
+
+export function DenSectionHeader({ title, description, action, className = "" }: DenSectionHeaderProps) {
+  return (
+    <div className={`flex flex-wrap items-start justify-between gap-4 ${className}`}>
+      <div className="min-w-0">
+        <h2 className="text-[16px] font-medium tracking-[-0.02em] text-gray-950">{title}</h2>
+        {description ? <p className="mt-1 text-[13px] leading-6 text-gray-500">{description}</p> : null}
+      </div>
+      {action}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/ui/table.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/table.tsx
@@ -1,0 +1,52 @@
+import type { ReactNode } from "react";
+
+export type DenTableColumn<T> = {
+  key: string;
+  header: string;
+  align?: "left" | "right";
+  render: (row: T) => ReactNode;
+};
+
+export type DenTableProps<T> = {
+  columns: readonly DenTableColumn<T>[];
+  rows: readonly T[];
+  getRowKey: (row: T) => string;
+  emptyLabel?: string;
+};
+
+export function DenTable<T>({ columns, rows, getRowKey, emptyLabel = "Nothing here yet." }: DenTableProps<T>) {
+  if (rows.length === 0) {
+    return <p className="px-6 py-5 text-[13px] text-gray-500">{emptyLabel}</p>;
+  }
+
+  return (
+    <div className="overflow-x-auto">
+      <table className="min-w-full text-left text-[14px]">
+        <thead className="bg-gray-50 text-[12px] uppercase tracking-[0.08em] text-gray-500">
+          <tr>
+            {columns.map((column) => (
+              <th
+                key={column.key}
+                scope="col"
+                className={`px-6 py-3 font-medium ${column.align === "right" ? "text-right" : ""}`}
+              >
+                {column.header}
+              </th>
+            ))}
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-gray-100">
+          {rows.map((row) => (
+            <tr key={getRowKey(row)}>
+              {columns.map((column) => (
+                <td key={column.key} className={`px-6 py-3 ${column.align === "right" ? "text-right" : ""}`}>
+                  {column.render(row)}
+                </td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_lib/brand-icon.ts
+++ b/ee/apps/den-web/app/(den)/_lib/brand-icon.ts
@@ -1,0 +1,58 @@
+/**
+ * Registrable (apex) domain for favicon lookups. Service URLs usually point at
+ * a subdomain or a docs path (mcp.notion.com, docs.anthropic.com) while the
+ * apex (notion.com, anthropic.com) serves the real brand icon.
+ */
+export function apexDomain(serviceUrl?: string | null): string | undefined {
+  const trimmed = serviceUrl?.trim();
+  if (!trimmed?.match(/^https?:\/\//i)) return undefined;
+  try {
+    const host = new URL(trimmed).hostname;
+    const labels = host.split(".").filter(Boolean);
+    if (labels.length < 2) return host;
+    return labels.slice(-2).join(".");
+  } catch {
+    return undefined;
+  }
+}
+
+/** Bundled brand icons keyed by apex domain — no network, no adblock, no flaky favicons. */
+const BUNDLED_ICONS_BY_APEX: Record<string, string> = {
+  "notion.com": "/integrations/notion.svg",
+  "linear.app": "/integrations/linear.svg",
+  "stripe.com": "/integrations/stripe.svg",
+  "sentry.dev": "/integrations/sentry.svg",
+  "sentry.io": "/integrations/sentry.svg",
+  "context7.com": "/integrations/context7.png",
+  "google.com": "/integrations/google.svg",
+};
+
+const SIMPLE_ICON_SLUG_BY_APEX: Record<string, string> = {
+  "slack.com": "slack",
+  "granola.ai": "granola",
+  "polar.sh": "polar",
+  "exa.ai": "exa",
+  "render.com": "render",
+};
+
+/**
+ * Ordered icon candidates: explicit URL first, then a bundled brand icon
+ * matched from the service URL (never flaky), then the Simple Icons CDN,
+ * then the apex-domain favicon. Consumers walk this list on image error so
+ * one blocked CDN or missing favicon never leaves a broken tile.
+ */
+export function brandIconCandidates(input: {
+  iconUrl?: string;
+  simpleIconSlug?: string;
+  serviceUrl?: string | null;
+}): string[] {
+  const candidates: string[] = [];
+  if (input.iconUrl) candidates.push(input.iconUrl);
+  const apex = apexDomain(input.serviceUrl);
+  const bundled = apex ? BUNDLED_ICONS_BY_APEX[apex] : undefined;
+  const simpleIconSlug = input.simpleIconSlug ?? (apex ? SIMPLE_ICON_SLUG_BY_APEX[apex] : undefined);
+  if (bundled) candidates.push(bundled);
+  if (simpleIconSlug) candidates.push(`https://cdn.simpleicons.org/${simpleIconSlug}`);
+  if (apex) candidates.push(`https://www.google.com/s2/favicons?sz=64&domain=${encodeURIComponent(apex)}`);
+  return candidates;
+}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/integration-icon.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/integration-icon.tsx
@@ -3,66 +3,7 @@
 import { useMemo, useState } from "react";
 import { Plug } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-
-/**
- * Registrable (apex) domain for favicon lookups. MCP servers usually live on
- * subdomains without favicons (mcp.notion.com), while the apex (notion.com)
- * serves the real brand icon.
- */
-function apexDomain(serviceUrl?: string): string | undefined {
-  const trimmed = serviceUrl?.trim();
-  if (!trimmed?.match(/^https?:\/\//i)) return undefined;
-  try {
-    const host = new URL(trimmed).hostname;
-    const labels = host.split(".").filter(Boolean);
-    if (labels.length < 2) return host;
-    return labels.slice(-2).join(".");
-  } catch {
-    return undefined;
-  }
-}
-
-/** Bundled brand icons keyed by apex domain — no network, no adblock, no flaky favicons. */
-const BUNDLED_ICONS_BY_APEX: Record<string, string> = {
-  "notion.com": "/integrations/notion.svg",
-  "linear.app": "/integrations/linear.svg",
-  "stripe.com": "/integrations/stripe.svg",
-  "sentry.dev": "/integrations/sentry.svg",
-  "sentry.io": "/integrations/sentry.svg",
-  "context7.com": "/integrations/context7.png",
-  "google.com": "/integrations/google.svg",
-};
-
-const SIMPLE_ICON_SLUG_BY_APEX: Record<string, string> = {
-  "slack.com": "slack",
-  "granola.ai": "granola",
-  "polar.sh": "polar",
-  "exa.ai": "exa",
-  "render.com": "render",
-};
-
-/**
- * Ordered icon candidates: explicit URL first, then a bundled brand icon
- * matched from the service URL (never flaky), then the Simple Icons CDN,
- * then the apex-domain favicon. The <img> onError handler walks this list so
- * one blocked CDN or missing favicon never leaves a broken tile — worst case
- * we land on the lucide fallback glyph.
- */
-function iconCandidates(input: {
-  iconUrl?: string;
-  simpleIconSlug?: string;
-  serviceUrl?: string;
-}): string[] {
-  const candidates: string[] = [];
-  if (input.iconUrl) candidates.push(input.iconUrl);
-  const apex = apexDomain(input.serviceUrl);
-  const bundled = apex ? BUNDLED_ICONS_BY_APEX[apex] : undefined;
-  const simpleIconSlug = input.simpleIconSlug ?? (apex ? SIMPLE_ICON_SLUG_BY_APEX[apex] : undefined);
-  if (bundled) candidates.push(bundled);
-  if (simpleIconSlug) candidates.push(`https://cdn.simpleicons.org/${simpleIconSlug}`);
-  if (apex) candidates.push(`https://www.google.com/s2/favicons?sz=64&domain=${encodeURIComponent(apex)}`);
-  return candidates;
-}
+import { brandIconCandidates } from "../../_lib/brand-icon";
 
 export function IntegrationIcon({
   name,
@@ -82,7 +23,7 @@ export function IntegrationIcon({
   imageClassName?: string;
 }) {
   const candidates = useMemo(
-    () => iconCandidates({ iconUrl, simpleIconSlug, serviceUrl }),
+    () => brandIconCandidates({ iconUrl, simpleIconSlug, serviceUrl }),
     [iconUrl, simpleIconSlug, serviceUrl],
   );
   const [failedCount, setFailedCount] = useState(0);

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-data.tsx
@@ -292,6 +292,24 @@ export function getProviderDocUrl(config: Record<string, unknown>): string | nul
   return asString(config.doc);
 }
 
+/**
+ * Simple Icons slugs for providers whose models.dev id does not match the CDN
+ * slug. Anything missing here falls back to the provider id, then to the
+ * favicon of the documentation domain, then to a monogram.
+ */
+const SIMPLE_ICON_SLUG_BY_PROVIDER_ID: Record<string, string> = {
+  google: "googlegemini",
+  "google-vertex": "googlegemini",
+  mistral: "mistralai",
+  xai: "x",
+  amazonbedrock: "amazonaws",
+  openrouter: "openrouter",
+};
+
+export function getProviderIconSlug(providerId: string): string {
+  return SIMPLE_ICON_SLUG_BY_PROVIDER_ID[providerId] ?? providerId;
+}
+
 export function getProviderNpmPackage(config: Record<string, unknown>): string | null {
   return asString(config.npm);
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-providers-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-providers-screen.tsx
@@ -2,18 +2,23 @@
 
 import Link from "next/link";
 import { useEffect, useMemo, useState } from "react";
-import { CodeXml, Cpu, KeyRound, Plus, Search } from "lucide-react";
+import { Cpu, KeyRound, Plus, Search } from "lucide-react";
 import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
+import { DenBadge } from "../../_components/ui/badge";
+import { DenBrandMark } from "../../_components/ui/brand-mark";
 import { DenButton, buttonVariants } from "../../_components/ui/button";
 import { DenCard } from "../../_components/ui/card";
 import { DenInput } from "../../_components/ui/input";
+import { DenNotice } from "../../_components/ui/notice";
+import { DenOptionCard } from "../../_components/ui/option-card";
+import { DenSectionHeader } from "../../_components/ui/section-header";
+import { DenTable, type DenTableColumn } from "../../_components/ui/table";
 import {
   getLlmProviderRoute,
   getNewLlmProviderRoute,
 } from "../../_lib/den-org";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
-  DESKTOP_POLICY_ENTERPRISE_PLAN_ERROR,
   createDesktopPolicy,
   updateDesktopPolicy,
   useOrgDesktopPolicies,
@@ -25,10 +30,18 @@ import {
   formatProviderTimestamp,
   getProviderDocUrl,
   getProviderEnvNames,
+  getProviderIconSlug,
   useOrgLlmProviders,
 } from "./llm-provider-data";
 
 type ModelAccessMode = "open" | "managed";
+
+type OpenWorkKeyRow = {
+  id: string;
+  name: string;
+  email: string;
+  createdAt: string | null;
+};
 
 const ADMIN_EXCEPTION_POLICY_NAME = "Admins may add providers";
 const ADMIN_EXCEPTION_ROLES: DenDesktopPolicyRole[] = ["owner", "admin"];
@@ -38,9 +51,23 @@ function getProviderSourceLabel(source: DenLlmProviderSource) {
   return source === "custom" ? "Custom" : "Catalog";
 }
 
-function getProviderSourceIcon(source: DenLlmProviderSource) {
-  return source === "custom" ? CodeXml : Cpu;
-}
+const openWorkKeyColumns: readonly DenTableColumn<OpenWorkKeyRow>[] = [
+  {
+    key: "member",
+    header: "Member",
+    render: (row) => (
+      <>
+        <p className="text-[14px] font-medium text-gray-950">{row.name}</p>
+        <p className="text-[12px] text-gray-500">{row.email}</p>
+      </>
+    ),
+  },
+  {
+    key: "created",
+    header: "Created",
+    render: (row) => <span className="text-[13px] text-gray-600">{formatProviderTimestamp(row.createdAt)}</span>,
+  },
+];
 
 function getPolicyMemberIds(policy: DenDesktopPolicy) {
   return policy.assignments.flatMap((assignment) => (assignment.orgMemberId ? [assignment.orgMemberId] : []));
@@ -257,126 +284,99 @@ export function LlmProvidersScreen() {
 
   return (
     <DashboardPageTemplate
-      icon={Cpu}
+      icon={KeyRound}
       badgeLabel="New"
-      title="LLM Providers"
-      description="Configure catalog-backed or custom providers, choose the exact models each one exposes, and grant access to the right people and teams."
+      title="Bring your Own Keys"
+      description="Connect Anthropic, OpenAI, Azure or any models.dev provider with your own credentials, choose the exact models each one exposes, and grant access to the right people and teams."
       colors={["#F3FFF9", "#0F766E", "#34D399", "#7DD3FC"]}
     >
       <DenCard data-testid="models-access-card" className="mb-8 grid gap-5">
-        <div className="flex flex-wrap items-start justify-between gap-4">
-          <div>
-            <h2 className="text-[16px] font-medium tracking-[-0.02em] text-gray-950">Who can use models</h2>
-            <p className="mt-1 text-[13px] leading-6 text-gray-500">
-              Choose whether members bring their own providers or use only the models managed here.
-            </p>
-          </div>
-          <DenButton
-            type="button"
-            data-testid="models-access-save"
-            onClick={() => void saveModelAccess()}
-            loading={accessSaving}
-            disabled={accessFormDisabled}
-          >
-            Save
-          </DenButton>
-        </div>
+        <DenSectionHeader
+          title="Who can use models"
+          description="Choose whether members bring their own providers or use only the models managed here."
+          action={
+            <DenButton
+              type="button"
+              data-testid="models-access-save"
+              onClick={() => void saveModelAccess()}
+              loading={accessSaving}
+              disabled={accessFormDisabled}
+            >
+              Save
+            </DenButton>
+          }
+        />
 
-        {policiesError ? (
-          <div className="rounded-[20px] border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700">
-            {policiesError}
-          </div>
-        ) : null}
-        {accessError ? (
-          <div className="rounded-[20px] border border-red-200 bg-red-50 px-4 py-3 text-[13px] text-red-700">
-            {accessError === DESKTOP_POLICY_ENTERPRISE_PLAN_ERROR ? DESKTOP_POLICY_ENTERPRISE_PLAN_ERROR : accessError}
-          </div>
-        ) : null}
+        {policiesError ? <DenNotice message={policiesError} tone="error" /> : null}
+        {accessError ? <DenNotice message={accessError} tone="error" /> : null}
         {accessSaved ? (
-          <div className="rounded-[20px] border border-emerald-200 bg-emerald-50 px-4 py-3 text-[13px] text-emerald-700">
+          <p className="rounded-[24px] border border-emerald-200 bg-emerald-50 px-5 py-4 text-[14px] text-emerald-700">
             {accessSaved}
-          </div>
+          </p>
         ) : null}
         {!policiesBusy && !defaultPolicy ? (
-          <div className="rounded-[20px] border border-amber-200 bg-amber-50 px-4 py-3 text-[13px] text-amber-800">
+          <p className="rounded-[24px] border border-amber-200 bg-amber-50 px-5 py-4 text-[14px] text-amber-800">
             Default desktop policy not found.
-          </div>
+          </p>
         ) : null}
 
         <div className="grid gap-3 lg:grid-cols-2">
-          <label className="flex cursor-pointer items-start gap-3 rounded-[22px] border border-gray-200 bg-gray-50 px-4 py-3">
-            <input
-              type="radio"
-              name="models-access-mode"
-              data-testid="models-access-open"
-              className="mt-1 h-4 w-4"
-              checked={accessMode === "open"}
-              onChange={() => {
-                setAccessMode("open");
-                setAccessSaved(null);
-                setAccessError(null);
-              }}
-              disabled={accessFormDisabled}
-            />
-            <span>
-              <span className="block text-[14px] font-medium text-gray-950">Open</span>
-              <span className="mt-1 block text-[13px] leading-6 text-gray-500">Members may add their own providers.</span>
-            </span>
-          </label>
-
-          <label className="flex cursor-pointer items-start gap-3 rounded-[22px] border border-gray-200 bg-gray-50 px-4 py-3">
-            <input
-              type="radio"
-              name="models-access-mode"
-              data-testid="models-access-managed"
-              className="mt-1 h-4 w-4"
-              checked={accessMode === "managed"}
-              onChange={() => {
-                setAccessMode("managed");
-                setAccessSaved(null);
-                setAccessError(null);
-              }}
-              disabled={accessFormDisabled}
-            />
-            <span>
-              <span className="block text-[14px] font-medium text-gray-950">Managed</span>
-              <span className="mt-1 block text-[13px] leading-6 text-gray-500">Members use exactly the models below.</span>
-            </span>
-          </label>
+          <DenOptionCard
+            type="radio"
+            name="models-access-mode"
+            testId="models-access-open"
+            title="Open"
+            description="Members may add their own providers."
+            checked={accessMode === "open"}
+            disabled={accessFormDisabled}
+            onChange={() => {
+              setAccessMode("open");
+              setAccessSaved(null);
+              setAccessError(null);
+            }}
+          />
+          <DenOptionCard
+            type="radio"
+            name="models-access-mode"
+            testId="models-access-managed"
+            title="Managed"
+            description="Members use exactly the models below."
+            checked={accessMode === "managed"}
+            disabled={accessFormDisabled}
+            onChange={() => {
+              setAccessMode("managed");
+              setAccessSaved(null);
+              setAccessError(null);
+            }}
+          />
         </div>
 
         {accessMode === "managed" ? (
           <div className="grid gap-3 sm:grid-cols-2">
-            <label className="flex items-start gap-3 rounded-[20px] border border-gray-200 px-4 py-3 text-[13px] text-gray-700">
-              <input
-                type="checkbox"
-                data-testid="models-access-admin-exception"
-                className="mt-1 h-4 w-4"
-                checked={adminExceptionChecked}
-                onChange={(event) => {
-                  setAdminExceptionChecked(event.target.checked);
-                  setAccessSaved(null);
-                  setAccessError(null);
-                }}
-                disabled={accessFormDisabled}
-              />
-              <span>Admins may add their own providers</span>
-            </label>
-            <label className="flex items-start gap-3 rounded-[20px] border border-gray-200 px-4 py-3 text-[13px] text-gray-700">
-              <input
-                type="checkbox"
-                data-testid="models-access-zen"
-                className="mt-1 h-4 w-4"
-                checked={zenAllowed}
-                onChange={(event) => {
-                  setZenAllowed(event.target.checked);
-                  setAccessSaved(null);
-                  setAccessError(null);
-                }}
-                disabled={accessFormDisabled}
-              />
-              <span>Allow OpenCode Zen models</span>
-            </label>
+            <DenOptionCard
+              type="checkbox"
+              testId="models-access-admin-exception"
+              title="Admins may add their own providers"
+              checked={adminExceptionChecked}
+              disabled={accessFormDisabled}
+              onChange={(checked) => {
+                setAdminExceptionChecked(checked);
+                setAccessSaved(null);
+                setAccessError(null);
+              }}
+            />
+            <DenOptionCard
+              type="checkbox"
+              testId="models-access-zen"
+              title="Allow OpenCode Zen models"
+              checked={zenAllowed}
+              disabled={accessFormDisabled}
+              onChange={(checked) => {
+                setZenAllowed(checked);
+                setAccessSaved(null);
+                setAccessError(null);
+              }}
+            />
           </div>
         ) : null}
 
@@ -400,11 +400,7 @@ export function LlmProvidersScreen() {
         </Link>
       </div>
 
-      {providersError ? (
-        <div className="mb-6 rounded-[24px] border border-red-200 bg-red-50 px-5 py-4 text-[14px] text-red-700">
-          {providersError}
-        </div>
-      ) : null}
+      {providersError ? <DenNotice message={providersError} tone="error" className="mb-6" /> : null}
 
       {providersBusy ? (
         <div className="rounded-[28px] border border-gray-200 bg-white px-6 py-10 text-[15px] text-gray-500">
@@ -414,36 +410,20 @@ export function LlmProvidersScreen() {
       <div className="grid gap-8">
         {openWorkKeyRows.length > 0 ? (
           <section className="overflow-hidden rounded-[28px] border border-gray-200 bg-white">
-            <div className="border-b border-gray-100 px-6 py-4">
-              <h2 className="text-[16px] font-medium tracking-[-0.02em] text-gray-950">OpenWork Model Keys</h2>
-              <p className="mt-1 text-[13px] text-gray-500">Members in this organization with an OpenWork Models key.</p>
-            </div>
-            <div className="overflow-x-auto">
-              <table className="min-w-full text-left text-[14px]">
-                <thead className="bg-gray-50 text-[12px] uppercase tracking-[0.08em] text-gray-500">
-                  <tr>
-                    <th className="px-6 py-3 font-medium">Member</th>
-                    <th className="px-6 py-3 font-medium">Created</th>
-                  </tr>
-                </thead>
-                <tbody className="divide-y divide-gray-100">
-                  {openWorkKeyRows.map((row) => (
-                    <tr key={row.id}>
-                      <td className="px-6 py-3">
-                        <p className="text-[14px] font-medium text-gray-950">{row.name}</p>
-                        <p className="text-[12px] text-gray-500">{row.email}</p>
-                      </td>
-                      <td className="px-6 py-3 text-[13px] text-gray-600">{formatProviderTimestamp(row.createdAt)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
+            <DenSectionHeader
+              className="border-b border-gray-100 px-6 py-4"
+              title="OpenWork Model Keys"
+              description="Members in this organization with an OpenWork Models key."
+            />
+            <DenTable columns={openWorkKeyColumns} rows={openWorkKeyRows} getRowKey={(row) => row.id} />
           </section>
         ) : null}
 
         <section className="grid gap-4">
-          <h2 className="text-[16px] font-medium tracking-[-0.02em] text-gray-950">Custom</h2>
+          <DenSectionHeader
+            title="Your providers"
+            description="Each card is one set of credentials and the models it exposes."
+          />
           {filteredProviders.length === 0 ? (
             <div className="rounded-[32px] border border-dashed border-gray-200 bg-white px-6 py-12 text-center">
               <p className="text-[16px] font-medium tracking-[-0.03em] text-gray-900">
@@ -458,7 +438,6 @@ export function LlmProvidersScreen() {
           ) : (
             <div className="grid gap-4 lg:grid-cols-2 2xl:grid-cols-3">
               {filteredProviders.map((provider) => {
-            const SourceIcon = getProviderSourceIcon(provider.source);
             const envNames = getProviderEnvNames(provider.providerConfig);
             const memberAccessCount = provider.access.members.length;
             const teamAccessCount = provider.access.teams.length;
@@ -466,49 +445,40 @@ export function LlmProvidersScreen() {
               <Link
                 key={provider.id}
                 href={getLlmProviderRoute(orgSlug, provider.id)}
-                className="block overflow-hidden rounded-[28px] border border-gray-200 bg-white p-6 transition hover:-translate-y-0.5 hover:border-gray-300 hover:shadow-[0_18px_40px_-24px_rgba(15,23,42,0.25)]"
+                data-testid="llm-provider-card"
+                className="block overflow-hidden rounded-[28px] border border-gray-200 bg-white p-6 transition-colors hover:border-gray-300"
               >
-                <div className="flex items-start justify-between gap-4">
-                  <div>
-                    <div className="inline-flex items-center gap-2 rounded-full border border-emerald-100 bg-emerald-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.14em] text-emerald-700">
-                      <SourceIcon className="h-3.5 w-3.5" />
-                      {getProviderSourceLabel(provider.source)}
-                    </div>
-                    <h2 className="mt-4 text-[22px] font-semibold tracking-[-0.05em] text-gray-950">{provider.name}</h2>
-                    <p className="mt-2 text-[14px] text-gray-500">{provider.providerId}</p>
+                <div className="flex items-start gap-3">
+                  <DenBrandMark
+                    name={provider.name}
+                    simpleIconSlug={getProviderIconSlug(provider.providerId)}
+                    serviceUrl={getProviderDocUrl(provider.providerConfig)}
+                  />
+                  <div className="min-w-0 flex-1">
+                    <h3 className="truncate text-[16px] font-medium tracking-[-0.02em] text-gray-950">{provider.name}</h3>
+                    <p className="mt-0.5 truncate text-[13px] text-gray-500">
+                      {provider.providerId} · {getProviderSourceLabel(provider.source)}
+                    </p>
                   </div>
-
-                  <div className="rounded-full border border-gray-200 bg-gray-50 px-3 py-1 text-[12px] font-medium text-gray-600">
+                  <DenBadge>
                     {provider.models.length} {provider.models.length === 1 ? "model" : "models"}
-                  </div>
+                  </DenBadge>
                 </div>
 
-                <div className="mt-5 flex flex-wrap gap-2">
-                  <span className={`inline-flex items-center gap-1 rounded-full px-3 py-1 text-[12px] font-medium ${provider.hasApiKey ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}>
-                    <KeyRound className="h-3.5 w-3.5" />
+                <div className="mt-4 flex flex-wrap gap-2">
+                  <DenBadge tone={provider.hasApiKey ? "success" : "warning"} icon={KeyRound}>
                     {provider.hasApiKey ? "Credential saved" : "Credential missing"}
-                  </span>
+                  </DenBadge>
                   {envNames.slice(0, 2).map((envName) => (
-                    <span key={envName} className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-                      {envName}
-                    </span>
+                    <DenBadge key={envName}>{envName}</DenBadge>
                   ))}
-                  {envNames.length > 2 ? (
-                    <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-                      +{envNames.length - 2} more keys
-                    </span>
-                  ) : null}
+                  {envNames.length > 2 ? <DenBadge>+{envNames.length - 2} more keys</DenBadge> : null}
                 </div>
 
-                <div className="mt-6 grid gap-3 rounded-[24px] bg-gray-50 p-4 text-[13px] text-gray-600 sm:grid-cols-2">
-                  <div>
-                    <p className="font-medium text-gray-900">Access</p>
-                    <p className="mt-1">{memberAccessCount} people · {teamAccessCount} teams</p>
-                  </div>
-                  <div>
-                    <p className="font-medium text-gray-900">Updated</p>
-                    <p className="mt-1">{formatProviderTimestamp(provider.updatedAt)}</p>
-                  </div>
+                <div className="mt-5 flex flex-wrap items-center gap-x-2 gap-y-1 border-t border-gray-100 pt-4 text-[13px] text-gray-500">
+                  <span>{memberAccessCount} people · {teamAccessCount} teams</span>
+                  <span aria-hidden>·</span>
+                  <span>{formatProviderTimestamp(provider.updatedAt)}</span>
                 </div>
               </Link>
             );

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -253,7 +253,7 @@ function getDashboardPageTitle(pathname: string, orgSlug: string | null) {
     return "Background Tasks";
   }
   if (pathname.startsWith(getCustomLlmProvidersRoute(orgSlug))) {
-    return "LLM Providers";
+    return "Bring your Own Keys";
   }
   if (pathname.startsWith(getDesktopPoliciesRoute(orgSlug))) {
     return "Desktop Policies";
@@ -390,7 +390,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
           ...(showOpenWorkModels
             ? [{ href: getInferenceRoute(activeOrg.slug), label: "OpenWork Models" }]
             : []),
-          { href: getCustomLlmProvidersRoute(activeOrg.slug), label: "LLM Providers" },
+          { href: getCustomLlmProvidersRoute(activeOrg.slug), label: "Bring your Own Keys" },
         ],
       }
     : null;

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/cloud-super-admins-role-hierarchy.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts tests/scim-sso-readiness.test.ts app/api/_lib/upstream-proxy.test.mjs",
+    "test": "bun test tests/byok-page-primitives.test.ts tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/cloud-super-admins-role-hierarchy.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts tests/scim-sso-readiness.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/byok-page-primitives.test.ts
+++ b/ee/apps/den-web/tests/byok-page-primitives.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const appRoot = join(import.meta.dir, "..", "app", "(den)");
+
+function readComponent(...segments: string[]) {
+  return readFileSync(join(appRoot, ...segments), "utf8");
+}
+
+const screen = readComponent("dashboard", "_components", "llm-providers-screen.tsx");
+const shell = readComponent("dashboard", "_components", "org-dashboard-shell.tsx");
+
+describe("Bring your Own Keys page", () => {
+  test("sidebar and page title use the product name", () => {
+    expect(shell).toContain('label: "Bring your Own Keys"');
+    expect(shell).toContain('return "Bring your Own Keys";');
+    expect(shell).not.toContain('"LLM Providers"');
+    expect(screen).toContain('title="Bring your Own Keys"');
+  });
+
+  test("access controls keep the ids the invitee flow drives", () => {
+    for (const testId of [
+      "models-access-card",
+      "models-access-open",
+      "models-access-managed",
+      "models-access-admin-exception",
+      "models-access-zen",
+      "models-access-save",
+      "models-access-outcome",
+    ]) {
+      expect(screen).toContain(testId);
+    }
+  });
+
+  test("screen is built from shared primitives instead of local markup", () => {
+    for (const primitive of ["DenOptionCard", "DenSectionHeader", "DenTable", "DenBrandMark", "DenBadge", "DenNotice"]) {
+      expect(screen).toContain(primitive);
+    }
+    expect(screen).not.toContain("<table");
+    expect(screen).not.toContain("<input");
+    expect(screen).not.toContain("hover:-translate-y-0.5");
+  });
+
+  test("option card renders a native input so keyboard and e2e flows keep working", () => {
+    const optionCard = readComponent("_components", "ui", "option-card.tsx");
+    expect(optionCard).toContain("<input");
+    expect(optionCard).toContain("data-testid={testId}");
+  });
+
+  test("brand mark reuses the shared icon ladder and ends on a monogram", () => {
+    const brandMark = readComponent("_components", "ui", "brand-mark.tsx");
+    const integrationIcon = readComponent("dashboard", "_components", "integration-icon.tsx");
+    expect(brandMark).toContain("brandIconCandidates");
+    expect(integrationIcon).toContain("brandIconCandidates");
+    expect(integrationIcon).not.toContain("cdn.simpleicons.org");
+    expect(brandMark).toContain("monogram");
+  });
+});

--- a/ee/apps/den-web/tests/cloud-super-admins-role-hierarchy.test.ts
+++ b/ee/apps/den-web/tests/cloud-super-admins-role-hierarchy.test.ts
@@ -83,7 +83,7 @@ describe("cloud super-admin role hierarchy", () => {
   test("exposes exact admin sidebar destinations for Extensions, Models, Members, Analytics, and Settings", () => {
     const shell = read("../app/(den)/dashboard/_components/org-dashboard-shell.tsx");
 
-    for (const label of ["Extensions", "Marketplace", "Sources", "Plugins", "Connectors", "Models", "OpenWork Models", "LLM Providers", "Members", "Analytics", "Settings"]) {
+    for (const label of ["Extensions", "Marketplace", "Sources", "Plugins", "Connectors", "Models", "OpenWork Models", "Bring your Own Keys", "Members", "Analytics", "Settings"]) {
       expect(shell).toContain(`label: "${label}"`);
     }
 


### PR DESCRIPTION
## Summary
- Renames **LLM Providers** → **Bring your Own Keys** in the sidebar, breadcrumb title, and page hero.
- Rebuilds the page on new shared primitives: `DenBadge`, `DenSectionHeader`, `DenTable`, `DenOptionCard`, `DenBrandMark`.
- Provider cards use real brand marks (Simple Icons → favicon → monogram) via a shared `brand-icon` ladder also used by `IntegrationIcon`.
- Preserves all `models-access-*` test ids so the invitee-first-boot eval keeps working.

## Test plan
- [x] `pnpm --filter @openwork-ee/den-web typecheck`
- [x] `pnpm --filter @openwork-ee/den-web test` (80 pass)
- [ ] Manual: open `/dashboard/custom-llm-providers`, confirm sidebar label, access card radios/checkboxes, provider logos, Add Provider
- Live stack validation skipped: Docker Desktop VM was read-only / MySQL unreachable in this environment


Made with [Cursor](https://cursor.com)