### PR TITLE
feat(den-web): rebuild onboarding around app download + model choice

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/choice-card.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/choice-card.tsx
@@ -1,0 +1,45 @@
+import Link from "next/link";
+import type { ReactNode } from "react";
+import { buttonVariants } from "./button";
+
+export type DenChoiceCardProps = {
+  icon: ReactNode;
+  title: string;
+  description: string;
+  href: string;
+  ctaLabel: string;
+  ctaVariant?: "primary" | "secondary";
+  testId?: string;
+};
+
+/**
+ * Large navigation card used on onboarding to present a single path forward
+ * (e.g. OpenWork Models vs Bring your Own Keys).
+ */
+export function DenChoiceCard({
+  icon,
+  title,
+  description,
+  href,
+  ctaLabel,
+  ctaVariant = "primary",
+  testId,
+}: DenChoiceCardProps) {
+  return (
+    <div
+      data-testid={testId}
+      className="flex h-full flex-col gap-5 rounded-[28px] border border-gray-200 bg-white p-6"
+    >
+      <div className="flex h-10 w-10 items-center justify-center rounded-[12px] border border-gray-100 bg-gray-50">
+        {icon}
+      </div>
+      <div className="min-w-0 flex-1">
+        <h3 className="text-[16px] font-medium tracking-[-0.02em] text-gray-950">{title}</h3>
+        <p className="mt-2 text-[13px] leading-6 text-gray-500">{description}</p>
+      </div>
+      <Link href={href} className={buttonVariants({ variant: ctaVariant })}>
+        {ctaLabel}
+      </Link>
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_lib/public-installers.ts
+++ b/ee/apps/den-web/app/(den)/_lib/public-installers.ts
@@ -1,0 +1,91 @@
+import type { DownloadCardInstallers } from "@openwork/ui/react";
+
+const FALLBACK_RELEASE = "https://github.com/different-ai/openwork/releases";
+
+type ReleaseAsset = {
+  name?: string;
+  browser_download_url?: string;
+};
+
+type Release = {
+  tag_name?: string;
+  html_url?: string;
+  draft?: boolean;
+  prerelease?: boolean;
+  assets?: ReleaseAsset[];
+};
+
+function selectAsset(assets: ReleaseAsset[], extensions: string[], keywords: string[]) {
+  const loweredExtensions = extensions.map((value) => value.toLowerCase());
+  const loweredKeywords = keywords.map((value) => value.toLowerCase());
+  return (
+    assets.find((asset) => {
+      const name = String(asset.name || "").toLowerCase();
+      return (
+        loweredExtensions.some((extension) => name.endsWith(extension)) &&
+        loweredKeywords.every((keyword) => name.includes(keyword)) &&
+        !name.startsWith("openwork-installer-")
+      );
+    }) ?? null
+  );
+}
+
+/**
+ * Public desktop installers for the onboarding download card. Same asset rules
+ * as the landing page: never return gated org installers.
+ */
+export async function getPublicInstallers(): Promise<{
+  installers: DownloadCardInstallers;
+  releaseTag: string;
+}> {
+  try {
+    const response = await fetch("https://api.github.com/repos/different-ai/openwork/releases/latest", {
+      next: { revalidate: 3600 },
+      headers: { Accept: "application/vnd.github+json" },
+    });
+    if (!response.ok) {
+      return { installers: fallbackInstallers(), releaseTag: "" };
+    }
+    const release = (await response.json()) as Release;
+    const assets = Array.isArray(release.assets) ? release.assets : [];
+    const releaseUrl = release.html_url || FALLBACK_RELEASE;
+    const dmg = selectAsset(assets, [".dmg"], ["openwork-mac-"]);
+    return {
+      releaseTag: typeof release.tag_name === "string" ? release.tag_name : "",
+      installers: {
+        macos: {
+          appleSilicon: selectAsset(assets, [".dmg"], ["mac-arm64"])?.browser_download_url || dmg?.browser_download_url || releaseUrl,
+          intel: selectAsset(assets, [".dmg"], ["mac-x64"])?.browser_download_url || dmg?.browser_download_url || releaseUrl,
+        },
+        windows: {
+          x64: selectAsset(assets, [".exe"], ["win-x64"])?.browser_download_url || releaseUrl,
+          arm64: selectAsset(assets, [".exe"], ["win-arm64"])?.browser_download_url || releaseUrl,
+        },
+        linux: {
+          appImageX64:
+            selectAsset(assets, [".appimage"], ["linux-x86_64"])?.browser_download_url ||
+            selectAsset(assets, [".appimage"], ["linux-x64"])?.browser_download_url ||
+            releaseUrl,
+          appImageArm64: selectAsset(assets, [".appimage"], ["linux-arm64"])?.browser_download_url || releaseUrl,
+          tarX64: selectAsset(assets, [".tar.gz"], ["linux-x64"])?.browser_download_url || releaseUrl,
+          tarArm64: selectAsset(assets, [".tar.gz"], ["linux-arm64"])?.browser_download_url || releaseUrl,
+        },
+      },
+    };
+  } catch {
+    return { installers: fallbackInstallers(), releaseTag: "" };
+  }
+}
+
+function fallbackInstallers(): DownloadCardInstallers {
+  return {
+    macos: { appleSilicon: FALLBACK_RELEASE, intel: FALLBACK_RELEASE },
+    windows: { x64: FALLBACK_RELEASE, arm64: FALLBACK_RELEASE },
+    linux: {
+      appImageX64: FALLBACK_RELEASE,
+      appImageArm64: FALLBACK_RELEASE,
+      tarX64: FALLBACK_RELEASE,
+      tarArm64: FALLBACK_RELEASE,
+    },
+  };
+}

--- a/ee/apps/den-web/app/(den)/dashboard/(admin)/onboarding/page.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/(admin)/onboarding/page.tsx
@@ -1,5 +1,7 @@
 import { MarketplaceOnboardingScreen } from "../../_components/marketplace-onboarding-screen";
+import { getPublicInstallers } from "../../../_lib/public-installers";
 
-export default function MarketplaceOnboardingPage() {
-  return <MarketplaceOnboardingScreen />;
+export default async function MarketplaceOnboardingPage() {
+  const { installers, releaseTag } = await getPublicInstallers();
+  return <MarketplaceOnboardingScreen installers={installers} releaseTag={releaseTag} />;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -3,23 +3,18 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Check, Copy, KeyRound, Zap } from "lucide-react";
+import { Check, KeyRound } from "lucide-react";
+import { DownloadOpenWorkCard, type DownloadCardInstallers } from "@openwork/ui/react";
+import { DenBadge } from "../../_components/ui/badge";
+import { DenChoiceCard } from "../../_components/ui/choice-card";
+import { DenSectionHeader } from "../../_components/ui/section-header";
 import {
   getCustomLlmProvidersRoute,
   getInferenceRoute,
-  getMarketplacesRoute,
   getOrgDashboardRoute,
 } from "../../_lib/den-org";
 import { requestJson } from "../../_lib/den-flow";
-import { buttonVariants, DenButton } from "../../_components/ui/button";
-import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
-import { useDenFlow } from "../../_providers/den-flow-provider";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
-import { LlmProviderLogos } from "./llm-provider-logos";
-import { OrganizationDownloadCard } from "./organization-download-card";
-
-const OPENWORK_MCP_DOCS = "https://openworklabs.com/docs/cloud/run-in-the-cloud/cloud-mcp";
-const OPENWORK_MCP_ENDPOINT = "https://api.openworklabs.com/mcp/agent";
 
 const APP_INSTALLED_KEY = "openwork:onboarding:app-installed";
 
@@ -64,191 +59,114 @@ function useInferenceEnabled() {
   });
 }
 
-function StepHeading({ step, title, done }: { step: number; title: string; done: boolean }) {
+function OpenWorkMark({ className = "h-5 w-5" }: { className?: string }) {
   return (
-    <div className="mb-3 flex flex-wrap items-center gap-x-3 gap-y-1">
-      <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-gray-400">Step {step} of 2</p>
-      <p className="text-[15px] font-medium tracking-[-0.02em] text-gray-950">{title}</p>
-      {done ? (
-        <span className="inline-flex items-center gap-1 rounded-full border border-emerald-100 bg-emerald-50 px-2 py-0.5 text-[11px] font-medium text-emerald-700">
-          <Check className="h-3 w-3" aria-hidden="true" /> Done
-        </span>
-      ) : null}
-    </div>
+    // eslint-disable-next-line @next/next/no-img-element
+    <img src="/openwork-mark.svg" alt="" aria-hidden className={className} />
   );
 }
 
-/** One of the two ways to get a model running. Same shell, different emphasis. */
-function ModelOption({
-  recommended,
-  icon,
-  title,
-  body,
-  children,
+export function MarketplaceOnboardingScreen({
+  installers,
+  releaseTag,
 }: {
-  recommended?: boolean;
-  icon: React.ReactNode;
-  title: string;
-  body: string;
-  children: React.ReactNode;
+  installers?: DownloadCardInstallers | null;
+  releaseTag?: string;
 }) {
-  return (
-    <div
-      className={`flex flex-1 flex-col gap-3 rounded-2xl border p-5 ${
-        recommended ? "border-blue-200 bg-blue-50/60" : "border-gray-100 bg-gray-50"
-      }`}
-    >
-      <div className="flex items-center justify-between gap-2">
-        <div className="flex items-center gap-2">
-          {icon}
-          <p className="text-[15px] font-medium tracking-[-0.02em] text-gray-950">{title}</p>
-        </div>
-        {recommended ? (
-          <span className="shrink-0 rounded-full bg-blue-600 px-2 py-0.5 text-[10px] font-semibold uppercase tracking-[0.1em] text-white">
-            Recommended
-          </span>
-        ) : null}
-      </div>
-      <p className="flex-1 text-[13px] leading-5 text-gray-500">{body}</p>
-      {children}
-    </div>
-  );
-}
-
-export function MarketplaceOnboardingScreen() {
   const { activeOrg, orgSlug } = useOrgDashboard();
-  const { runtimeConfig, runtimeConfigLoaded } = useDenFlow();
-  const { data: modelsEnabled = false } = useInferenceEnabled();
+  const { data: modelsEnabled = false, isLoading: modelsLoading } = useInferenceEnabled();
   const [appInstalled, setAppInstalled] = useLocalStorageFlag(APP_INSTALLED_KEY);
-  const [copied, setCopied] = useState(false);
 
   const orgName = activeOrg?.name ?? "your team";
-  const allDone = appInstalled && modelsEnabled;
-  // OpenWork Models are a hosted OpenWork Cloud offering; self-hosted
-  // (single-org) deployments bring their own provider key instead.
-  const showOpenWorkModels = runtimeConfigLoaded && runtimeConfig.orgMode === "multi_org";
-
-  async function copyMcpEndpoint() {
-    try {
-      await navigator.clipboard.writeText(OPENWORK_MCP_ENDPOINT);
-      setCopied(true);
-      setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // clipboard unavailable
-    }
-  }
+  const requiredDone = appInstalled && modelsEnabled;
 
   return (
-    <DashboardPageTemplate
-      size="compact"
-      title={allDone ? `${orgName} is ready.` : `Set up ${orgName}`}
-      description={
-        allDone
-          ? "The app is installed and models are on. Everything below stays here if you need it again."
-          : "OpenWork runs on the desktop app. Install it, turn on a model, and you're working."
-      }
-      colors={["#0f172a", "#047857", "#6ee7b7", "#f8fafc"]}
-    >
-      <div className="grid gap-8">
-        <section data-testid="onboarding-step-download">
-          <StepHeading step={1} title="Install the desktop app" done={appInstalled} />
-          {activeOrg ? (
-            <OrganizationDownloadCard organizationId={activeOrg.id} organizationName={activeOrg.name} />
-          ) : null}
-          <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2">
-            <p className="text-[13px] leading-5 text-gray-500">
-              Computer Use, Browser, Image Gen, and Google Workspace only run in the app.
-            </p>
-            {appInstalled ? null : (
-              <DenButton variant="secondary" size="sm" onClick={() => setAppInstalled(true)}>
-                I&apos;ve already installed it
-              </DenButton>
-            )}
-          </div>
-        </section>
+    <div className="mx-auto max-w-3xl px-4 pb-12 pt-8 sm:px-6" data-testid="marketplace-onboarding">
+      <header className="max-w-xl">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-500">Get started</p>
+        <h1 className="mt-3 text-[28px] font-semibold leading-[1.1] tracking-[-0.04em] text-gray-950 sm:text-[32px]">
+          {requiredDone ? `${orgName} is ready.` : `Get the OpenWork app`}
+        </h1>
+        <p className="mt-3 text-[14px] leading-6 text-gray-500">
+          {requiredDone
+            ? "The desktop app is installed and models are available. Jump into your dashboard whenever you're ready."
+            : "OpenWork runs on the desktop. Install the app, then choose OpenWork Models or bring your own keys."}
+        </p>
+      </header>
 
-        <section data-testid="onboarding-step-models">
-          <StepHeading step={2} title="Turn on a model" done={modelsEnabled} />
-          {modelsEnabled ? null : (
-            <div className="flex flex-col gap-4 md:flex-row">
-              {showOpenWorkModels ? (
-                <ModelOption
-                  recommended
-                  icon={<Zap className="h-4 w-4 text-blue-600" aria-hidden="true" />}
-                  title="OpenWork Models"
-                  body="Frontier and open models, already wired up. No API keys, no billing to configure."
-                >
-                  <Link href={getInferenceRoute(orgSlug)} className={buttonVariants({ className: "w-full" })}>
-                    Use OpenWork Models
-                  </Link>
-                </ModelOption>
-              ) : null}
+      <section className="mt-8 grid gap-3">
+        <DenSectionHeader
+          title="1. Install the desktop app"
+          description="Computer Use, Browser, Image Gen, and Google Workspace only run in the app."
+          action={
+            appInstalled ? (
+              <DenBadge tone="success" icon={Check}>
+                Installed
+              </DenBadge>
+            ) : null
+          }
+        />
+        <DownloadOpenWorkCard installers={installers} releaseTag={releaseTag} />
+        {!appInstalled ? (
+          <button
+            type="button"
+            data-testid="onboarding-app-installed"
+            onClick={() => setAppInstalled(true)}
+            className="w-fit text-[13px] font-medium text-gray-500 transition hover:text-gray-950"
+          >
+            I&apos;ve already installed it →
+          </button>
+        ) : null}
+      </section>
 
-              <ModelOption
-                icon={<KeyRound className="h-4 w-4 text-gray-500" aria-hidden="true" />}
-                title="Bring your own key"
-                body="Already paying for OpenAI, OpenRouter, or Anthropic? Paste your key and keep your own billing."
-              >
-                <LlmProviderLogos />
-                <Link
-                  href={getCustomLlmProvidersRoute(orgSlug)}
-                  className={buttonVariants({
-                    variant: showOpenWorkModels ? "secondary" : "primary",
-                    className: "w-full",
-                  })}
-                >
-                  Add your own key
-                </Link>
-              </ModelOption>
-            </div>
-          )}
-        </section>
+      <section className="mt-10 grid gap-4">
+        <DenSectionHeader
+          title="2. Choose how your team uses models"
+          description={
+            modelsLoading
+              ? "Checking whether OpenWork Models are already on…"
+              : modelsEnabled
+                ? "OpenWork Models are on for this workspace."
+                : "Pick one path. You can change this later under Models."
+          }
+          action={
+            modelsEnabled ? (
+              <DenBadge tone="success" icon={Check}>
+                Models on
+              </DenBadge>
+            ) : null
+          }
+        />
+        <div className="grid gap-4 lg:grid-cols-2">
+          <DenChoiceCard
+            testId="onboarding-choice-openwork-models"
+            icon={<OpenWorkMark />}
+            title="OpenWork Models"
+            description="Hosted frontier models for knowledge work. No API keys to manage — every member is provisioned automatically."
+            href={getInferenceRoute(orgSlug)}
+            ctaLabel={modelsEnabled ? "Manage models" : "Turn on models"}
+            ctaVariant="primary"
+          />
+          <DenChoiceCard
+            testId="onboarding-choice-byok"
+            icon={<KeyRound className="h-5 w-5 text-gray-700" aria-hidden />}
+            title="Bring your Own Keys"
+            description="Connect Anthropic, OpenAI, Azure, or any models.dev provider with credentials your org already has."
+            href={getCustomLlmProvidersRoute(orgSlug)}
+            ctaLabel="Add providers"
+            ctaVariant="secondary"
+          />
+        </div>
+      </section>
 
-        <section className="border-t border-gray-100 pt-6">
-          <p className="text-[12px] font-semibold uppercase tracking-[0.12em] text-gray-400">Other clients</p>
-          <p className="mt-2 max-w-[620px] text-[13px] leading-5 text-gray-500">
-            Prefer OpenCode, Codex, or another MCP app? Point it at the OpenWork Connect endpoint. OpenCode is verified;
-            Codex, Cursor Web/Agents, ChatGPT Desktop, Claude Code, and VS Code have setup guides.
-          </p>
-          <div className="mt-3 flex flex-wrap items-center gap-x-4 gap-y-2">
-            <button
-              type="button"
-              aria-label={`Copy OpenWork MCP endpoint ${OPENWORK_MCP_ENDPOINT}`}
-              onClick={copyMcpEndpoint}
-              className="inline-flex max-w-full items-center gap-2 whitespace-normal rounded-lg border border-gray-200 bg-gray-50 px-3 py-2 text-left font-mono text-[12px] text-gray-700 transition-colors hover:bg-gray-100"
-            >
-              <span className="min-w-0 break-all">{OPENWORK_MCP_ENDPOINT}</span>
-              {copied ? (
-                <Check className="h-3.5 w-3.5 shrink-0 text-emerald-600" aria-hidden="true" />
-              ) : (
-                <Copy className="h-3.5 w-3.5 shrink-0 text-gray-400" aria-hidden="true" />
-              )}
-            </button>
-            <a
-              href={OPENWORK_MCP_DOCS}
-              target="_blank"
-              rel="noreferrer"
-              className="inline-flex items-center gap-1.5 text-[13px] font-medium text-gray-700 hover:text-gray-950"
-            >
-              Read docs <ArrowRight className="h-3.5 w-3.5" aria-hidden="true" />
-            </a>
-          </div>
-          <p aria-live="polite" className="mt-2 min-h-5 text-[12px] font-medium text-emerald-600">
-            {copied ? "OpenWork MCP endpoint copied." : ""}
-          </p>
-        </section>
-
+      <footer className="mt-10 border-t border-gray-100 pt-5">
         <p className="text-[13px] text-gray-500">
           Already set up?{" "}
-          <Link href={getMarketplacesRoute(orgSlug)} className="font-medium text-gray-700 hover:text-gray-950">
-            View marketplaces
-          </Link>{" "}
-          ·{" "}
-          <Link href={getOrgDashboardRoute(orgSlug)} className="font-medium text-gray-700 hover:text-gray-950">
+          <Link href={getOrgDashboardRoute(orgSlug)} className="font-medium text-gray-900 underline-offset-2 hover:underline">
             Go to dashboard
           </Link>
         </p>
-      </div>
-    </DashboardPageTemplate>
+      </footer>
+    </div>
   );
 }

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/openwork-models-page.test.ts tests/byok-page-primitives.test.ts tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/cloud-super-admins-role-hierarchy.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts tests/scim-sso-readiness.test.ts app/api/_lib/upstream-proxy.test.mjs",
+"test": "bun test tests/onboarding-page.test.ts tests/openwork-models-page.test.ts tests/byok-page-primitives.test.ts tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/cloud-super-admins-role-hierarchy.test.ts tests/install-errors.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts tests/scim-sso-readiness.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/onboarding-page.test.ts
+++ b/ee/apps/den-web/tests/onboarding-page.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const appRoot = join(import.meta.dir, "..", "app", "(den)");
+
+function read(...segments: string[]) {
+  return readFileSync(join(appRoot, ...segments), "utf8");
+}
+
+const screen = read("dashboard", "_components", "marketplace-onboarding-screen.tsx");
+const page = read("dashboard", "(admin)", "onboarding", "page.tsx");
+
+describe("Marketplace onboarding page", () => {
+  test("reuses the landing download card and den choice cards", () => {
+    expect(screen).toContain("DownloadOpenWorkCard");
+    expect(screen).toContain("DenChoiceCard");
+    expect(screen).toContain("DenSectionHeader");
+    expect(screen).toContain("DenBadge");
+    expect(page).toContain("getPublicInstallers");
+  });
+
+  test("offers OpenWork Models and Bring your Own Keys as the model path", () => {
+    expect(screen).toContain("onboarding-choice-openwork-models");
+    expect(screen).toContain("onboarding-choice-byok");
+    expect(screen).toContain("Turn on models");
+    expect(screen).toContain("Bring your Own Keys");
+    expect(screen).toContain("/openwork-mark.svg");
+  });
+
+  test("keeps the installed flag and inference check", () => {
+    expect(screen).toContain("openwork:onboarding:app-installed");
+    expect(screen).toContain("/v1/inference");
+    expect(screen).toContain("onboarding-app-installed");
+  });
+});


### PR DESCRIPTION
## Summary
- Rebuilds `/dashboard/onboarding` to lead with **Get the OpenWork app**, reusing `DownloadOpenWorkCard` from `@openwork/ui/react` (same card as the landing `/download` page).
- Adds `DenChoiceCard` and presents **OpenWork Models** vs **Bring your Own Keys** as the model path (OpenWork mark on the models card, no lightning CTA icon).
- Fetches public release installers via `getPublicInstallers()` so links point at real assets when GitHub is reachable.
- Drops the old multi-step MCP/marketplace checklist in favor of this focused setup flow.

## Stack
Depends on #3163 (base: `feat/byok-page`) for `DenBadge` / `DenSectionHeader`.

## Test plan
- [x] `pnpm --filter @openwork-ee/den-web typecheck`
- [x] `bun test tests/onboarding-page.test.ts`
- [ ] Manual: open `/dashboard/onboarding` — download card renders, installed flag toggles, both choice cards navigate correctly
- Live stack validation skipped (Docker/MySQL unavailable in this environment)


Made with [Cursor](https://cursor.com)