### PR TITLE
fix(den): download desktop app directly

### DIFF
--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -98,6 +98,7 @@ type InstallPlatform = z.infer<typeof installPlatformSchema>
 
 export type InstallExperienceDependencies = {
   resolveConfiguredArtifact: typeof resolveConfiguredInstallerArtifact
+  resolveDirectUrl: (platform: InstallPlatform, releaseTag: string) => string
   mintConnectGrant: typeof mintDesktopConnectGrant
   previewConnectGrant: typeof previewDesktopConnectGrant
   inspectConnectGrant: typeof inspectDesktopConnectGrant
@@ -106,6 +107,10 @@ export type InstallExperienceDependencies = {
 
 const defaultInstallerDependencies: InstallExperienceDependencies = {
   resolveConfiguredArtifact: resolveConfiguredInstallerArtifact,
+  resolveDirectUrl: (platform, releaseTag) => {
+    const fileName = desktopReleaseAssetName(platform, releaseTag)
+    return fileName ? installerReleaseAssetUrl(fileName, { releaseTag }) : OPENWORK_DOWNLOAD_URL
+  },
   mintConnectGrant: mintDesktopConnectGrant,
   previewConnectGrant: previewDesktopConnectGrant,
   inspectConnectGrant: inspectDesktopConnectGrant,
@@ -215,7 +220,7 @@ function maxAllowedDesktopVersion(versions: string[]) {
   return maxVersion
 }
 
-function desktopReleaseTagForMetadata(metadataInput: unknown) {
+function installerReleaseTagForMetadata(metadataInput: unknown) {
   const metadata = normalizeOrganizationMetadata(organizationMetadataInput(metadataInput)).metadata
   const allowedVersions = metadata.allowedDesktopVersions
   if (!allowedVersions?.length) {
@@ -250,7 +255,7 @@ async function resolveInstallConfigForToken(token: string, request: Request) {
     config: buildInstallConfig({ organization: row.organization, request }),
     installLinkId: row.installLink.id,
     organizationSlug: row.organization.slug,
-    desktopReleaseTag: desktopReleaseTagForMetadata(row.organization.metadata),
+    installerReleaseTag: installerReleaseTagForMetadata(row.organization.metadata),
   }
 }
 
@@ -602,12 +607,12 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         }
       }
 
-      const fileName = desktopReleaseAssetName(platform, resolved.desktopReleaseTag)
+      const fileName = desktopReleaseAssetName(platform, resolved.installerReleaseTag)
       if (!fileName) {
         return c.json({ error: "invalid_request", details: [{ message: "Unsupported desktop platform." }] }, 400)
       }
 
-      return c.redirect(installerReleaseAssetUrl(fileName, { releaseTag: resolved.desktopReleaseTag }), 302)
+      return c.redirect(installer.resolveDirectUrl(platform, resolved.installerReleaseTag), 302)
     },
   )
 }

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -26,10 +26,8 @@ import { denTypeIdSchema, emptyResponse, forbiddenSchema, invalidRequestSchema, 
 import { organizationCapabilityKeySchema } from "../../organization-capabilities.js"
 import { normalizeOrganizationMetadata } from "../../organization-limits.js"
 import {
-  DEFAULT_INSTALLER_RELEASE_REPO,
-  FIRST_GENERIC_INSTALLER_RELEASE,
+  desktopReleaseAssetName,
   genericInstallerArtifactName,
-  installerLatestReleaseAssetUrl,
   installerReleaseAssetUrl,
   resolveConfiguredInstallerArtifact,
 } from "../../utils/installer-artifacts.js"
@@ -217,29 +215,15 @@ function maxAllowedDesktopVersion(versions: string[]) {
   return maxVersion
 }
 
-function clampInstallerReleaseTag(releaseTag: string) {
-  const comparison = compareVersions(releaseTag, FIRST_GENERIC_INSTALLER_RELEASE)
-  if (env.installerReleaseRepo === DEFAULT_INSTALLER_RELEASE_REPO && comparison !== null && comparison < 0) {
-    // The generic installer is version-agnostic: it installs /v1/app-version,
-    // so allowedDesktopVersions still governs app updates. This only selects
-    // an installer binary release that actually has OpenWork-Installer-* assets.
-    return `v${FIRST_GENERIC_INSTALLER_RELEASE}`
-  }
-  return releaseTag
-}
-
-function installerReleaseTagForMetadata(metadataInput: unknown) {
+function desktopReleaseTagForMetadata(metadataInput: unknown) {
   const metadata = normalizeOrganizationMetadata(organizationMetadataInput(metadataInput)).metadata
   const allowedVersions = metadata.allowedDesktopVersions
   if (!allowedVersions?.length) {
-    if (env.installerReleaseRepo === DEFAULT_INSTALLER_RELEASE_REPO && !env.installerReleaseTagExplicit) {
-      return null
-    }
-    return clampInstallerReleaseTag(env.installerReleaseTag)
+    return env.installerReleaseTag
   }
 
   const maxVersion = maxAllowedDesktopVersion(allowedVersions)
-  return clampInstallerReleaseTag(maxVersion ? `v${maxVersion}` : env.installerReleaseTag)
+  return maxVersion ? `v${maxVersion}` : env.installerReleaseTag
 }
 
 async function resolveInstallConfigForToken(token: string, request: Request) {
@@ -266,7 +250,7 @@ async function resolveInstallConfigForToken(token: string, request: Request) {
     config: buildInstallConfig({ organization: row.organization, request }),
     installLinkId: row.installLink.id,
     organizationSlug: row.organization.slug,
-    installerReleaseTag: installerReleaseTagForMetadata(row.organization.metadata),
+    desktopReleaseTag: desktopReleaseTagForMetadata(row.organization.metadata),
   }
 }
 
@@ -561,11 +545,11 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
     "/v1/install/:platform",
     describeRoute({
       tags: ["Organizations"],
-      summary: "Download OpenWork installer",
-      description: "Always serves the OpenWork installer for the requested platform. By default Den redirects to the public release asset; unrestricted official-repo organizations follow the latest published release. Operators can optionally mount installer artifacts for an air-gapped mirror.",
+      summary: "Download OpenWork desktop",
+      description: "Redirects cloud downloads to the standard OpenWork desktop app for the requested platform and organization-approved version. Operators can still mount installer artifacts for an air-gapped mirror.",
       responses: {
-        200: textResponse("Installer artifact returned successfully."),
-        302: emptyResponse("Den redirected the browser to the public OpenWork installer release asset."),
+        200: textResponse("Mounted installer artifact returned successfully."),
+        302: emptyResponse("Den redirected the browser to the standard OpenWork desktop release asset."),
         400: jsonResponse("The install-link token or platform was invalid.", invalidRequestSchema),
         404: jsonResponse("The install link was missing, expired, or revoked.", installLinkNotFoundSchema),
         429: jsonResponse("Too many installer download attempts.", rateLimitedSchema),
@@ -618,16 +602,12 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         }
       }
 
-      if (!genericFileName) {
-        return c.json({ error: "invalid_request", details: [{ message: "Unsupported installer platform." }] }, 400)
+      const fileName = desktopReleaseAssetName(platform, resolved.desktopReleaseTag)
+      if (!fileName) {
+        return c.json({ error: "invalid_request", details: [{ message: "Unsupported desktop platform." }] }, 400)
       }
 
-      if (resolved.installerReleaseTag === null) {
-        // Follow GitHub latest published release so draft-release windows cannot 404.
-        return c.redirect(installerLatestReleaseAssetUrl(genericFileName), 302)
-      }
-
-      return c.redirect(installerReleaseAssetUrl(genericFileName, { releaseTag: resolved.installerReleaseTag }), 302)
+      return c.redirect(installerReleaseAssetUrl(fileName, { releaseTag: resolved.desktopReleaseTag }), 302)
     },
   )
 }

--- a/ee/apps/den-api/test/install-link-access.test.ts
+++ b/ee/apps/den-api/test/install-link-access.test.ts
@@ -22,8 +22,7 @@ const organizationId = createDenTypeId("organization")
 const installLinkId = createDenTypeId("installLink")
 const insertedRows: unknown[] = []
 const revokedRows: unknown[] = []
-const officialWindowsInstallerUrl = "https://github.com/different-ai/openwork/releases/download/v9.9.9/OpenWork-Installer-win-x64.exe"
-const latestOfficialWindowsInstallerUrl = "https://github.com/different-ai/openwork/releases/latest/download/OpenWork-Installer-win-x64.exe"
+const officialWindowsDesktopUrl = "https://github.com/different-ai/openwork/releases/download/v9.9.9/openwork-win-x64-9.9.9.exe"
 const connectKeyPair = generateConnectLinkKeyPair()
 const connectKeyId = "owc-route-test"
 
@@ -392,13 +391,13 @@ test("members cannot mint an install link for another organization", async () =>
   expect(insertedInstallLinks()).toHaveLength(0)
 })
 
-test("zero-config downloads redirect the browser to the official release", async () => {
+test("zero-config downloads redirect the browser to the standard desktop release", async () => {
   const response = await createApp().request("http://den.local/v1/install/win-x64?token=opaque-token", {
     redirect: "manual",
   })
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe(officialWindowsInstallerUrl)
+  expect(response.headers.get("location")).toBe(officialWindowsDesktopUrl)
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
@@ -413,12 +412,12 @@ test("unordered organization allowed desktop versions select the maximum direct 
   })
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.39/OpenWork-Installer-win-x64.exe")
+  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.39/openwork-win-x64-0.17.39.exe")
   expect(response.headers.get("location")).not.toContain("v9.9.9")
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
-test("below-floor allowed desktop versions serve the first installer release that has assets", async () => {
+test("older allowed desktop versions keep their matching direct desktop release", async () => {
   organizationMetadata = {
     ...defaultOrganizationMetadata(),
     allowedDesktopVersions: ["0.17.26", "0.17.25", "0.17.27"],
@@ -429,12 +428,11 @@ test("below-floor allowed desktop versions serve the first installer release tha
   })
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.37/OpenWork-Installer-win-x64.exe")
-  expect(response.headers.get("location")).not.toContain("v0.17.27")
+  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.27/openwork-win-x64-0.17.27.exe")
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
-test("mounted artifact lookup uses the exact Windows installer filename", async () => {
+test("mounted artifact lookup keeps serving the exact Windows installer filename", async () => {
   organizationMetadata = {
     ...defaultOrganizationMetadata(),
     allowedDesktopVersions: ["0.17.26", "0.17.27"],
@@ -457,7 +455,7 @@ test("mounted artifact lookup uses the exact Windows installer filename", async 
   expect(Buffer.from(await response.arrayBuffer())).toEqual(installer)
 })
 
-test("unrestricted organizations use Den's configured installer release tag", async () => {
+test("unrestricted organizations use Den's configured desktop release tag", async () => {
   organizationMetadata = {
     ...defaultOrganizationMetadata(),
     allowedDesktopVersions: [],
@@ -468,11 +466,11 @@ test("unrestricted organizations use Den's configured installer release tag", as
   })
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe(officialWindowsInstallerUrl)
+  expect(response.headers.get("location")).toBe(officialWindowsDesktopUrl)
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
-test("unrestricted organizations on the official repo follow the latest published release", async () => {
+test("unrestricted organizations use Den's release version when the tag was not set explicitly", async () => {
   envModule.env.installerReleaseTagExplicit = false
   organizationMetadata = {
     ...defaultOrganizationMetadata(),
@@ -484,8 +482,7 @@ test("unrestricted organizations on the official repo follow the latest publishe
   })
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe(latestOfficialWindowsInstallerUrl)
-  expect(response.headers.get("location")).not.toContain("v9.9.9")
+  expect(response.headers.get("location")).toBe(officialWindowsDesktopUrl)
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
@@ -501,7 +498,7 @@ test("organization version pins stay tag-pinned even without an explicit install
   })
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.39/OpenWork-Installer-win-x64.exe")
+  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.39/openwork-win-x64-0.17.39.exe")
   expect(response.headers.get("location")).not.toContain("/releases/latest/")
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
@@ -519,7 +516,7 @@ test("custom release repos never use the latest-release URL", async () => {
   })
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe("https://github.com/acme/openwork/releases/download/v9.9.9/OpenWork-Installer-win-x64.exe")
+  expect(response.headers.get("location")).toBe("https://github.com/acme/openwork/releases/download/v9.9.9/openwork-win-x64-9.9.9.exe")
   expect(response.headers.get("location")).not.toContain("/releases/latest/")
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
@@ -529,7 +526,7 @@ test("install token organization policy applies to member and admin downloads", 
     ...defaultOrganizationMetadata(),
     allowedDesktopVersions: ["0.17.37", "0.17.39"],
   }
-  const expectedUrl = "https://github.com/different-ai/openwork/releases/download/v0.17.39/OpenWork-Installer-win-x64.exe"
+  const expectedUrl = "https://github.com/different-ai/openwork/releases/download/v0.17.39/openwork-win-x64-0.17.39.exe"
 
   for (const nextRole of ["member", "admin"]) {
     role = nextRole
@@ -542,7 +539,7 @@ test("install token organization policy applies to member and admin downloads", 
   }
 })
 
-test("below-floor configured installer release tags are clamped for unrestricted official downloads", async () => {
+test("configured desktop release tags are not clamped to the generic-installer floor", async () => {
   envModule.env.installerReleaseTagExplicit = true
   envModule.env.installerReleaseTag = "v0.17.27"
   organizationMetadata = {
@@ -555,12 +552,11 @@ test("below-floor configured installer release tags are clamped for unrestricted
   })
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.37/OpenWork-Installer-win-x64.exe")
-  expect(response.headers.get("location")).not.toContain("v0.17.27")
+  expect(response.headers.get("location")).toBe("https://github.com/different-ai/openwork/releases/download/v0.17.27/openwork-win-x64-0.17.27.exe")
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
-test("custom installer release repos are not clamped", async () => {
+test("custom desktop release repos use the organization-approved version", async () => {
   envModule.env.installerReleaseRepo = "acme/openwork"
   organizationMetadata = {
     ...defaultOrganizationMetadata(),
@@ -572,16 +568,16 @@ test("custom installer release repos are not clamped", async () => {
   })
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe("https://github.com/acme/openwork/releases/download/v0.17.27/OpenWork-Installer-win-x64.exe")
+  expect(response.headers.get("location")).toBe("https://github.com/acme/openwork/releases/download/v0.17.27/openwork-win-x64-0.17.27.exe")
   expect(response.headers.get("location")).not.toContain("opaque-token")
 })
 
 test.each([
-  { platform: "mac-arm64", assetName: "OpenWork-Installer-mac-arm64.dmg" },
-  { platform: "mac-x64", assetName: "OpenWork-Installer-mac-x64.dmg" },
-  { platform: "win-x64", assetName: "OpenWork-Installer-win-x64.exe" },
+  { platform: "mac-arm64", assetName: "openwork-mac-arm64-9.9.9.dmg" },
+  { platform: "mac-x64", assetName: "openwork-mac-x64-9.9.9.dmg" },
+  { platform: "win-x64", assetName: "openwork-win-x64-9.9.9.exe" },
 ])(
-  "zero-config $platform downloads redirect immediately to the installer release asset without forwarding the token",
+  "zero-config $platform downloads redirect to the standard desktop asset without forwarding the token",
   async ({ platform, assetName }) => {
     const directUrl = `https://github.com/different-ai/openwork/releases/download/v9.9.9/${assetName}`
     const response = await createApp().request(
@@ -607,7 +603,7 @@ test.each(["linux-x64", "linux-arm64"])(
   },
 )
 
-test("guided semi-air-gapped mac downloads return a provisioned DMG without ZIP wrapping", async () => {
+test("guided semi-air-gapped mac downloads keep returning a provisioned installer DMG", async () => {
   const installer = Buffer.from("signed-standard-mac-installer", "utf8")
   const artifactPath = path.join(mkdtempSync(path.join(os.tmpdir(), "openwork-installer-route-")), "installer.dmg")
   writeFileSync(artifactPath, installer)
@@ -724,7 +720,7 @@ test("keyless preview is read-only and exchange consumes the grant once", async 
   await expect(replay.json()).resolves.toEqual({ error: "connect_grant_replayed" })
 })
 
-test("signed handoffs use the same direct standard-installer route", async () => {
+test("signed handoffs use the same direct standard desktop route", async () => {
   envModule.env.connectLink = { privateKeyPem: "unused by download route", kid: "test" }
   const response = await createApp().request(
     "http://den.local/v1/install/win-x64?token=opaque-token",
@@ -732,7 +728,7 @@ test("signed handoffs use the same direct standard-installer route", async () =>
   )
 
   expect(response.status).toBe(302)
-  expect(response.headers.get("location")).toBe(officialWindowsInstallerUrl)
+  expect(response.headers.get("location")).toBe(officialWindowsDesktopUrl)
 })
 
 test("install config includes a fresh signed organization handoff while preserving normal sign-in", async () => {


### PR DESCRIPTION
## Summary

- redirect Den cloud downloads for macOS and Windows to the standard versioned OpenWork desktop artifacts
- preserve the existing guided Den install and activation experience
- preserve Linux setup scripts and mounted installer artifacts for air-gapped deployments

## Why

Den's default cloud path currently downloads the separate `OpenWork-Installer-*` launcher. The download page should deliver the standard desktop app directly while leaving organization connection and activation in the existing Den flow.

## Checks

- `bun test ee/apps/den-api/test/install-link-access.test.ts` — 31 passed
- `pnpm --filter @openwork-ee/den-api build` — passed

## Manual verification

Not run — developer verification deferred. Reviewers can open an organization install page, select macOS or Windows, and confirm the download resolves to an `openwork-mac-*` or `openwork-win-*` release artifact before completing the unchanged activation flow.

## Risk and compatibility

- organization desktop-version allowlists still select the highest allowed release
- mounted installer artifacts still take precedence for managed and air-gapped deployments
- Linux behavior is unchanged
- install-link tokens are not forwarded to GitHub
