### PR TITLE
fix(den-web): align org chooser with desktop sign-in card

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/dashboard-page-template.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/dashboard-page-template.tsx
@@ -19,8 +19,8 @@ import { Dithering } from "@paper-design/shaders-react";
  */
 
 export type DashboardPageTemplateProps = {
-  /** Lucide (or any) icon component rendered inside the frosted glass icon box */
-  icon: ElementType<{
+  /** Lucide (or any) icon component rendered inside the frosted glass icon box. Omit to hide. */
+  icon?: ElementType<{
     size?: number;
     className?: string;
     strokeWidth?: number;
@@ -36,6 +36,8 @@ export type DashboardPageTemplateProps = {
    * Tip: vary hue across pages so each section feels distinct at a glance.
    */
   colors: [string, string, string, string];
+  /** `compact` shrinks the hero for setup/onboarding pages. */
+  size?: "default" | "compact";
   children?: React.ReactNode;
 };
 
@@ -45,12 +47,21 @@ export function DashboardPageTemplate({
   title,
   description,
   colors,
+  size = "default",
   children,
 }: DashboardPageTemplateProps) {
+  const compact = size === "compact";
+
   return (
-    <div className="mx-auto max-w-[860px] p-8">
+    <div className={`mx-auto max-w-[860px] ${compact ? "p-6 md:p-8" : "p-8"}`}>
       {/* ── Gradient hero card ── */}
-      <div className="relative mb-8 flex h-[200px] items-center overflow-hidden rounded-3xl border border-gray-100 px-10">
+      <div
+        className={`relative flex items-center overflow-hidden border border-gray-100 ${
+          compact
+            ? "mb-5 h-[88px] rounded-2xl px-6 sm:h-[96px] sm:px-8"
+            : "mb-8 h-[200px] rounded-3xl px-10"
+        }`}
+      >
         {/* Background layers: mesh gradient wrapped in a dithering texture */}
         <div className="absolute inset-0 z-0">
           <Dithering
@@ -82,25 +93,43 @@ export function DashboardPageTemplate({
         </div>
 
         {/* Icon — top right */}
-        <div className="absolute right-8 top-8 z-10 flex h-12 w-12 items-center justify-center rounded-xl border border-white/30 bg-white/20 backdrop-blur-md">
-          <Icon size={24} className="text-white" strokeWidth={1.5} />
-        </div>
+        {Icon ? (
+          <div
+            className={`absolute z-10 flex items-center justify-center rounded-xl border border-white/30 bg-white/20 backdrop-blur-md ${
+              compact
+                ? "right-5 top-1/2 h-9 w-9 -translate-y-1/2"
+                : "right-8 top-8 h-12 w-12"
+            }`}
+          >
+            <Icon size={compact ? 18 : 24} className="text-white" strokeWidth={1.5} />
+          </div>
+        ) : null}
 
-        {/* Badge (optional) + Title — bottom left */}
-        <div className="absolute bottom-8 left-10 z-10 flex flex-col items-start gap-2">
+        {/* Badge (optional) + Title */}
+        <div
+          className={`absolute z-10 flex flex-col items-start gap-2 ${
+            compact ? "left-6 top-1/2 -translate-y-1/2 sm:left-8" : "bottom-8 left-10"
+          }`}
+        >
           {badgeLabel ? (
             <span className="rounded-full border border-white/20 bg-white/20 px-2.5 py-1 text-[10px] uppercase tracking-[1px] text-white backdrop-blur-md">
               {badgeLabel}
             </span>
           ) : null}
-          <h1 className="text-[28px] font-medium tracking-[-0.5px] text-white">
+          <h1
+            className={`font-medium text-white ${
+              compact
+                ? "text-[20px] tracking-[-0.03em] sm:text-[22px]"
+                : "text-[28px] tracking-[-0.5px]"
+            }`}
+          >
             {title}
           </h1>
         </div>
       </div>
 
       {/* ── Description ── */}
-      <p className="mb-6 text-[14px] text-gray-500">{description}</p>
+      <p className={`text-[14px] text-gray-500 ${compact ? "mb-5" : "mb-6"}`}>{description}</p>
 
       {/* ── Page content ── */}
       {children}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
-import { ArrowRight, Check, Copy, KeyRound, Rocket, Zap } from "lucide-react";
+import { ArrowRight, Check, Copy, KeyRound, Zap } from "lucide-react";
 import {
   getCustomLlmProvidersRoute,
   getInferenceRoute,
@@ -140,7 +140,7 @@ export function MarketplaceOnboardingScreen() {
 
   return (
     <DashboardPageTemplate
-      icon={Rocket}
+      size="compact"
       title={allDone ? `${orgName} is ready.` : `Set up ${orgName}`}
       description={
         allDone

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-selection-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-selection-screen.tsx
@@ -38,6 +38,11 @@ function useReducedMotion() {
   );
 }
 
+/**
+ * Organization picker after Den sign-in.
+ * Layout mirrors the desktop OpenWork forced sign-in / welcome card:
+ * dither field + centered branded card + left-aligned headline + full-width actions.
+ */
 export function OrgSelectionScreen({
   orgs,
   onSelect,
@@ -61,16 +66,16 @@ export function OrgSelectionScreen({
     showSearch,
   } = useOrgListWindow(orgs);
   const reducedMotion = useReducedMotion();
-  const shaderSpeed = reducedMotion ? 0 : 0.012;
+  const shaderSpeed = reducedMotion ? 0 : 0.01;
 
   return (
     <section
-      className="relative isolate min-h-dvh overflow-y-auto bg-[#f8fbff] px-4 py-8 text-slate-950 sm:py-12"
+      className="relative isolate min-h-dvh overflow-y-auto bg-[var(--dls-surface)] text-[var(--dls-text-primary)]"
       data-testid="org-chooser-root"
     >
       <div
         aria-hidden="true"
-        className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#f8fbff] opacity-[0.09]"
+        className="pointer-events-none absolute inset-0 z-0 overflow-hidden opacity-[0.1]"
         data-motion={shaderSpeed === 0 ? "reduced" : "ambient"}
         data-shader-speed={shaderSpeed}
         data-testid="org-chooser-background"
@@ -78,116 +83,134 @@ export function OrgSelectionScreen({
         <Dithering
           speed={shaderSpeed}
           shape="warp"
-          type="4x4"
-          size={2.4}
-          scale={0.9}
-          frame={24017.6}
-          colorBack="#F8FBFF"
-          colorFront="#8FB7E8"
-          style={{ backgroundColor: "#F8FBFF", width: "100%", height: "100%" }}
+          type="2x2"
+          size={20.3}
+          scale={1.19}
+          frame={264559.21}
+          colorBack="#00000000"
+          colorFront="#000000"
+          style={{ width: "100%", height: "100%" }}
         />
       </div>
 
       <div
-        className="relative z-10 mx-auto flex min-h-[calc(100dvh-4rem)] w-full max-w-md flex-col justify-center sm:min-h-[calc(100dvh-6rem)]"
+        className="relative z-10 flex min-h-dvh items-center justify-center px-6 py-16"
         data-testid="org-chooser-foreground"
       >
-        <div className="den-frame w-full p-6 md:p-8">
-          <div className="mb-6 text-center">
-            <h1 className="den-title-lg">Choose an organization</h1>
-            <p className="mt-2 text-[13px] text-[var(--dls-text-secondary)]">
-              You belong to {orgs.length} organizations. Select one to continue.
+        <div className="w-full max-w-[720px] rounded-3xl border border-[var(--dls-border)] bg-[var(--dls-surface)] px-8 pb-12 pt-10 sm:px-16 sm:pb-16 sm:pt-14">
+          <div className="flex items-center gap-2.5">
+            <img
+              src="/openwork-mark.svg"
+              alt=""
+              width={26}
+              height={26}
+              className="max-h-[26px] shrink-0 object-contain object-left"
+              aria-hidden="true"
+            />
+            <span className="text-[15px] font-semibold tracking-tight text-[var(--dls-text-primary)]">
+              OpenWork
+            </span>
+          </div>
+
+          <div className="mt-10 flex flex-col gap-2.5 sm:mt-14">
+            <h1 className="text-[30px] font-semibold leading-[38px] tracking-[-0.03em] text-[var(--dls-text-primary)] sm:text-[38px] sm:leading-[46px]">
+              Choose an organization
+            </h1>
+            <p className="text-[15px] leading-[23px] text-[var(--dls-text-secondary)]">
+              You belong to {orgs.length}{" "}
+              {orgs.length === 1 ? "organization" : "organizations"}. Select one
+              to continue.
             </p>
           </div>
 
-          {showSearch ? (
-            <input
-              type="search"
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search organizations"
-              className="den-input mb-3 px-3 py-2.5 text-[13px]"
-            />
-          ) : null}
+          <div className="mt-11 flex flex-col gap-3">
+            {showSearch ? (
+              <input
+                type="search"
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder="Search organizations"
+                className="h-12 w-full rounded-xl border border-[var(--dls-border)] bg-[var(--dls-surface)] px-4 text-[15px] text-[var(--dls-text-primary)] placeholder:text-[var(--dls-text-secondary)] focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.2)]"
+              />
+            ) : null}
 
-          <div
-            className="den-frame-inset grid gap-2 rounded-[1.5rem] p-2"
-            data-testid="org-chooser-list"
-          >
-            {visible.map((org) => (
-              <button
-                key={org.id}
-                type="button"
-                disabled={busy}
-                onClick={() => onSelect(org.slug)}
-                className="flex items-center justify-between gap-3 rounded-[1rem] px-3 py-2.5 text-left transition-colors hover:bg-white focus:outline-none focus:ring-4 focus:ring-slate-950/5 disabled:cursor-not-allowed disabled:bg-white"
-              >
-                <span className="flex min-w-0 items-center gap-3">
-                  <span className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-white text-[var(--dls-text-secondary)] shadow-sm">
+            <div
+              className="flex flex-col gap-2"
+              data-testid="org-chooser-list"
+            >
+              {visible.map((org) => (
+                <button
+                  key={org.id}
+                  type="button"
+                  disabled={busy}
+                  onClick={() => onSelect(org.slug)}
+                  className="flex items-center gap-3 rounded-xl border border-[var(--dls-border)] bg-[var(--dls-surface)] px-4 py-3.5 text-left transition-colors hover:border-[var(--dls-text-primary)]/20 hover:bg-[var(--dls-hover)] focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.2)] disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-[var(--dls-hover)] text-[var(--dls-text-secondary)]">
                     <Building2 className="h-4 w-4" strokeWidth={1.8} />
                   </span>
-                  <span className="min-w-0">
-                    <span className="block truncate text-[14px] font-medium text-gray-900">
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-[15px] font-medium text-[var(--dls-text-primary)]">
                       {org.name}
                     </span>
-                    <span className="block truncate text-[12px] text-gray-500">
-                      {formatRoleLabel(org.role)} • {org.memberCount}{" "}
+                    <span className="block truncate text-[13px] text-[var(--dls-text-secondary)]">
+                      {formatRoleLabel(org.role)} · {org.memberCount}{" "}
                       {org.memberCount === 1 ? "member" : "members"}
                     </span>
                   </span>
-                </span>
-                <ChevronRight
-                  className="h-4 w-4 shrink-0 text-gray-300"
-                  strokeWidth={2}
-                />
-              </button>
-            ))}
-          </div>
+                  <ChevronRight
+                    className="h-4 w-4 shrink-0 text-[var(--dls-text-secondary)]"
+                    strokeWidth={2}
+                  />
+                </button>
+              ))}
+            </div>
 
-          {filteredCount === 0 && query ? (
-            <p className="mt-3 px-1 text-[13px] text-[var(--dls-text-secondary)]">
-              No organizations match your search.
-            </p>
-          ) : null}
-
-          {hasMore ? (
-            <div className="mt-3 flex items-center justify-between gap-3 px-1">
-              <p className="text-[12px] text-[var(--dls-text-secondary)]">
-                Showing {visible.length} of {filteredCount} organizations
+            {filteredCount === 0 && query ? (
+              <p className="text-[14px] text-[var(--dls-text-secondary)]">
+                No organizations match your search.
               </p>
+            ) : null}
+
+            {hasMore ? (
+              <div className="flex flex-col items-start gap-2">
+                <button
+                  type="button"
+                  onClick={showMore}
+                  className="inline-flex h-9 items-center justify-center rounded-full border border-[var(--dls-border)] bg-[var(--dls-surface)] px-4 text-[13px] font-medium text-[var(--dls-text-primary)] transition-colors hover:bg-[var(--dls-hover)]"
+                >
+                  Show more
+                </button>
+                <p className="text-[12px] text-[var(--dls-text-secondary)]">
+                  Showing {visible.length} of {filteredCount} organizations
+                </p>
+              </div>
+            ) : null}
+
+            {error ? (
+              <div className="rounded-xl border border-red-200 bg-red-50 px-3 py-2 text-[13px] text-red-700">
+                {error}
+              </div>
+            ) : null}
+
+            <div
+              className="mt-2 flex flex-wrap items-center gap-2"
+              data-testid="org-chooser-actions"
+            >
+              <Link
+                href="/organization"
+                className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full border border-[var(--dls-border)] bg-[var(--dls-surface)] px-4 text-[13px] font-medium text-[var(--dls-text-primary)] transition-colors hover:bg-[var(--dls-hover)] focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.2)]"
+              >
+                <Plus className="h-4 w-4" /> Create or join
+              </Link>
               <button
                 type="button"
-                onClick={showMore}
-                className="shrink-0 rounded-full border border-[var(--dls-border)] bg-white px-3 py-1.5 text-[12px] font-medium text-gray-700 transition-colors hover:bg-slate-50"
+                onClick={onSignOut}
+                className="inline-flex h-10 items-center justify-center gap-1.5 rounded-full border border-[var(--dls-border)] bg-[var(--dls-surface)] px-4 text-[13px] font-medium text-[var(--dls-text-secondary)] transition-colors hover:bg-[var(--dls-hover)] hover:text-[var(--dls-text-primary)] focus:outline-none focus:ring-2 focus:ring-[rgba(var(--dls-accent-rgb),0.2)]"
               >
-                Show more
+                <LogOut className="h-4 w-4" /> Sign out
               </button>
             </div>
-          ) : null}
-
-          {error ? (
-            <p className="mt-3 px-1 text-[12px] font-medium text-rose-600">
-              {error}
-            </p>
-          ) : null}
-
-          <div
-            className="mt-4 flex items-center justify-between gap-3 px-1"
-            data-testid="org-chooser-actions"
-          >
-            <Link
-              href="/organization"
-              className="flex items-center gap-1.5 text-[13px] font-medium text-[var(--dls-text-secondary)] transition-colors hover:text-[var(--dls-text-primary)] focus:outline-none focus:ring-4 focus:ring-slate-950/5"
-            >
-              <Plus className="h-4 w-4" /> Create or join
-            </Link>
-            <button
-              type="button"
-              onClick={onSignOut}
-              className="flex items-center gap-1.5 text-[13px] font-medium text-[var(--dls-text-secondary)] transition-colors hover:text-[var(--dls-text-primary)] focus:outline-none focus:ring-4 focus:ring-slate-950/5"
-            >
-              <LogOut className="h-4 w-4" /> Sign out
-            </button>
           </div>
         </div>
       </div>

--- a/ee/apps/den-web/tests/org-selection-background.test.ts
+++ b/ee/apps/den-web/tests/org-selection-background.test.ts
@@ -10,18 +10,23 @@ function readOrgSelectionSource() {
   return readFileSync(orgSelectionPath, "utf8");
 }
 
-describe("org selection paper contract", () => {
-  test("uses the same light Dithering layer as the join flow", () => {
+describe("org selection desktop sign-in pattern", () => {
+  test("uses the same dither + centered card shell as desktop forced sign-in", () => {
     const source = readOrgSelectionSource();
 
-    expect(source).toContain('className="relative isolate min-h-dvh overflow-y-auto bg-[#f8fbff] px-4 py-8 text-slate-950 sm:py-12"');
-    expect(source).toContain('className="pointer-events-none fixed inset-0 z-0 overflow-hidden bg-[#f8fbff] opacity-[0.09]"');
-    expect(source).toContain('colorBack="#F8FBFF"');
-    expect(source).toContain('colorFront="#8FB7E8"');
-    expect(source).toContain("const shaderSpeed = reducedMotion ? 0 : 0.012;");
-    expect(source).toContain('data-shader-speed={shaderSpeed}');
-    expect(source).toContain('className="den-frame-inset grid gap-2 rounded-[1.5rem] p-2"');
-    expect(source).not.toContain("bg-[#0f1d31]");
+    expect(source).toContain('data-testid="org-chooser-root"');
+    expect(source).toContain('data-testid="org-chooser-background"');
+    expect(source).toContain('opacity-[0.1]');
+    expect(source).toContain('type="2x2"');
+    expect(source).toContain("size={20.3}");
+    expect(source).toContain('colorBack="#00000000"');
+    expect(source).toContain('colorFront="#000000"');
+    expect(source).toContain("const shaderSpeed = reducedMotion ? 0 : 0.01;");
+    expect(source).toContain("max-w-[720px]");
+    expect(source).toContain("rounded-3xl");
+    expect(source).toContain("/openwork-mark.svg");
+    expect(source).not.toContain("bg-[#f8fbff]");
+    expect(source).not.toContain('colorFront="#8FB7E8"');
     expect(source).not.toContain("PaperMeshGradient");
   });
 
@@ -30,16 +35,16 @@ describe("org selection paper contract", () => {
 
     expect(source).toContain('data-testid="org-chooser-foreground"');
     expect(source).toContain('data-testid="org-chooser-list"');
-    expect(source).toContain("hover:bg-white");
-    expect(source).not.toContain("disabled:opacity");
+    expect(source).toContain("Choose an organization");
+    expect(source).toContain("hover:bg-[var(--dls-hover)]");
   });
 
   test("keeps the shell and actions stable on small screens", () => {
     const source = readOrgSelectionSource();
 
-    expect(source).toContain('data-testid="org-chooser-root"');
     expect(source).toContain('data-testid="org-chooser-actions"');
     expect(source).toContain("Create or join");
     expect(source).toContain("Sign out");
+    expect(source).toContain("sm:px-16");
   });
 });


### PR DESCRIPTION
## Summary
- Restyle Den’s post-auth **Choose an organization** screen to match the desktop OpenWork forced sign-in / welcome card
- Same brand mark + large left-aligned headline, centered `720px` bordered card, black dither field, and bordered org rows instead of the old inset list
- Update the org-selection paper/contract tests to lock the desktop-aligned shell

## Evidence

### Screenshots
![Org chooser aligned to desktop sign-in](https://litter.catbox.moe/m8z71u.png)

### Build verification
- `bun test ee/apps/den-web/tests/org-selection-background.test.ts` — passed (3)

### UI verification
- Verified via local `den-web` preview at `/dev/org-chooser` with the real `OrgSelectionScreen` component
- Console: Next.js proxy warnings for missing local Den API (expected without full stack); no UI regressions on the chooser itself

## Test plan
- [ ] Sign in to Den with a multi-org account and confirm the chooser matches the desktop welcome/sign-in card
- [ ] Select an org, Create or join, and Sign out still work
- [ ] Narrow viewport: card padding remains usable


Made with [Cursor](https://cursor.com)