### PR TITLE
feat(den-web): rebuild OpenWork Models page on the Paper redesign

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/page-header.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/page-header.tsx
@@ -1,0 +1,35 @@
+import type { ReactNode } from "react";
+
+/**
+ * DenPageHeader
+ *
+ * Flat page header for dashboard pages that lead with content instead of the
+ * gradient hero (`DashboardPageTemplate`): title and description on the left,
+ * the page's primary action plus an optional caption on the right.
+ */
+export type DenPageHeaderProps = {
+  title: string;
+  description?: ReactNode;
+  /** Right-aligned slot for the page's primary action. */
+  action?: ReactNode;
+  /** Muted line under the action — pricing, counts, sync timestamps. */
+  caption?: ReactNode;
+  className?: string;
+};
+
+export function DenPageHeader({ title, description, action, caption, className = "" }: DenPageHeaderProps) {
+  return (
+    <div className={`flex flex-wrap items-start justify-between gap-8 ${className}`}>
+      <div className="min-w-0">
+        <h1 className="text-[28px] font-medium leading-[34px] tracking-[-0.5px] text-gray-950">{title}</h1>
+        {description ? <p className="mt-2 text-[14px] leading-[20px] text-gray-500">{description}</p> : null}
+      </div>
+      {action || caption ? (
+        <div className="flex shrink-0 flex-col items-end gap-2">
+          {action}
+          {caption ? <p className="text-[12px] leading-4 text-gray-400">{caption}</p> : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/ee/apps/den-web/app/(den)/_components/ui/table.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/table.tsx
@@ -4,6 +4,8 @@ export type DenTableColumn<T> = {
   key: string;
   header: string;
   align?: "left" | "right";
+  /** Fixed lane width (e.g. "190px") so cells stay aligned across rows. */
+  width?: string;
   render: (row: T) => ReactNode;
 };
 
@@ -12,9 +14,17 @@ export type DenTableProps<T> = {
   rows: readonly T[];
   getRowKey: (row: T) => string;
   emptyLabel?: string;
+  /** `plain` drops the filled header row for tables that sit on a white surface. */
+  headerTone?: "muted" | "plain";
 };
 
-export function DenTable<T>({ columns, rows, getRowKey, emptyLabel = "Nothing here yet." }: DenTableProps<T>) {
+export function DenTable<T>({
+  columns,
+  rows,
+  getRowKey,
+  emptyLabel = "Nothing here yet.",
+  headerTone = "muted",
+}: DenTableProps<T>) {
   if (rows.length === 0) {
     return <p className="px-6 py-5 text-[13px] text-gray-500">{emptyLabel}</p>;
   }
@@ -22,12 +32,19 @@ export function DenTable<T>({ columns, rows, getRowKey, emptyLabel = "Nothing he
   return (
     <div className="overflow-x-auto">
       <table className="min-w-full text-left text-[14px]">
-        <thead className="bg-gray-50 text-[12px] uppercase tracking-[0.08em] text-gray-500">
+        <thead
+          className={
+            headerTone === "plain"
+              ? "border-b border-gray-100 text-[12px] uppercase tracking-[0.05em] text-gray-400"
+              : "bg-gray-50 text-[12px] uppercase tracking-[0.08em] text-gray-500"
+          }
+        >
           <tr>
             {columns.map((column) => (
               <th
                 key={column.key}
                 scope="col"
+                style={column.width ? { width: column.width } : undefined}
                 className={`px-6 py-3 font-medium ${column.align === "right" ? "text-right" : ""}`}
               >
                 {column.header}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/inference-screen.tsx
@@ -1,15 +1,15 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, type ReactNode } from "react";
+import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { Check, Sparkles } from "lucide-react";
 import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
-import { DashboardPageTemplate } from "../../_components/ui/dashboard-page-template";
-import { DenBadge } from "../../_components/ui/badge";
 import { DenButton } from "../../_components/ui/button";
 import { DenCard } from "../../_components/ui/card";
 import { DenNotice } from "../../_components/ui/notice";
+import { DenPageHeader } from "../../_components/ui/page-header";
 import { DenSectionHeader } from "../../_components/ui/section-header";
+import { DenTable, type DenTableColumn } from "../../_components/ui/table";
 import { getErrorMessage, getRequestError, requestJson } from "../../_lib/den-flow";
 import { getBillingRoute, getCustomLlmProvidersRoute, getOrgAccessFlags } from "../../_lib/den-org";
 import { useDenFlow } from "../../_providers/den-flow-provider";
@@ -155,73 +155,135 @@ function UsageLimitsCard({ buckets }: { buckets: InferenceUsageBucket[] }) {
   );
 }
 
-const MODEL_LINEUP = Object.entries(INFERENCE_MODEL_ALIASES)
-  .filter(([, model]) => model.enabled)
-  .map(([id, model]) => ({
-    id,
-    name: model.displayName.replace(/^OpenWork:\s*/, ""),
-  }));
+/**
+ * Editorial detail per model: what a knowledge worker should reach for it for,
+ * and the vendor monogram shown in the lineup table. Keyed by model alias so
+ * unmapped models still render with sane defaults.
+ */
+const MODEL_DETAILS: Record<string, { bestFor: string; monogram: string } | undefined> = {
+  "moonshotai/kimi-k3": { bestFor: "Research & synthesis", monogram: "MS" },
+  "z-ai/glm-5.2": { bestFor: "Multi-step tasks", monogram: "ZA" },
+  "moonshotai/kimi-k2.7-code": { bestFor: "Spreadsheets & scripts", monogram: "MS" },
+  "tencent/hy3-preview": { bestFor: "Long documents", monogram: "TC" },
+  "moonshotai/kimi-k2.6": { bestFor: "Everyday drafting", monogram: "MS" },
+  "deepseek/deepseek-v4-flash": { bestFor: "Quick summaries", monogram: "DS" },
+  "minimax/minimax-m2.7": { bestFor: "Tools & integrations", monogram: "MM" },
+  "minimax/minimax-m3": { bestFor: "Images & screenshots", monogram: "MM" },
+  "z-ai/glm-5.1": { bestFor: "Balanced default", monogram: "ZA" },
+};
 
-const VALUE_POINTS = [
-  "Open-source frontier models, hosted and kept up to date by OpenWork",
-  "No API keys to manage — every member is provisioned automatically",
-  "One subscription covers your whole workspace, with usage limits that scale with your team",
+type LineupModel = {
+  id: string;
+  name: string;
+  bestFor: string;
+  monogram: string;
+};
+
+const MODEL_LINEUP: LineupModel[] = Object.entries(INFERENCE_MODEL_ALIASES)
+  .filter(([, model]) => model.enabled)
+  .map(([id, model]) => {
+    const detail = MODEL_DETAILS[id];
+    return {
+      id,
+      name: model.displayName.replace(/^OpenWork:\s*/, ""),
+      bestFor: detail?.bestFor ?? "General knowledge work",
+      monogram: detail?.monogram ?? id.split("/")[0].slice(0, 2).toUpperCase(),
+    };
+  });
+
+const MODEL_COLUMNS: readonly DenTableColumn<LineupModel>[] = [
+  {
+    key: "model",
+    header: "Model",
+    render: (model) => (
+      <div className="flex items-center gap-3">
+        <span
+          aria-hidden="true"
+          className="flex h-[22px] w-[22px] shrink-0 items-center justify-center rounded-[7px] bg-gray-100 text-[9px] font-semibold tracking-[0.02em] text-gray-500"
+        >
+          {model.monogram}
+        </span>
+        <span className="text-[13px] font-medium text-gray-900">{model.name}</span>
+      </div>
+    ),
+  },
+  {
+    key: "bestFor",
+    header: "Best for",
+    width: "190px",
+    render: (model) => <span className="text-[13px] text-gray-500">{model.bestFor}</span>,
+  },
+  {
+    key: "id",
+    header: "Model ID",
+    width: "230px",
+    render: (model) => <span className="whitespace-nowrap font-mono text-[12px] text-gray-500">{model.id}</span>,
+  },
 ];
 
-function ModelsValueProp(props: {
-  canManage: boolean;
-  memberCount: number;
-  subscribeBusy: boolean;
-  onSubscribe: () => void;
-}) {
+const PILLARS = [
+  {
+    label: "You or your whole team",
+    body: "One subscription activates OpenWork Models across your organization and lets everyone use battle-tested LLMs without setting anything up.",
+  },
+  {
+    label: "Nothing to set up",
+    body: "Every member is provisioned automatically. No provider accounts, no API keys.",
+  },
+  {
+    label: "No lock-in",
+    body: "Keep your own provider keys alongside these models and switch whenever you want.",
+  },
+];
+
+const STEPS: ReactNode[] = [
+  "Subscribe — one plan covers the whole workspace",
+  "Every member is provisioned automatically — nothing to send",
+  <>
+    Open OpenWork and pick any model from the{" "}
+    <code className="rounded-md bg-gray-100 px-2 py-1 font-mono text-[12px] text-gray-700">OpenWork</code> group
+  </>,
+  "Start working — usage limits are shared and scale with active members",
+];
+
+function GettingStartedCard() {
   return (
-    <DenCard className="grid gap-8 p-8 lg:grid-cols-[minmax(0,1fr)_280px]">
-      <div>
-        <DenSectionHeader
-          title="The best open-source models, ready for your whole team."
-          description="Every member gets instant access to a hand-picked lineup of OSS frontier models — no provider accounts, no key juggling."
-        />
-        <ul className="mt-6 grid gap-3">
-          {VALUE_POINTS.map((point) => (
-            <li key={point} className="flex items-start gap-3 text-[14px] leading-6 text-gray-700">
-              <Check className="mt-1 h-4 w-4 shrink-0 text-emerald-600" aria-hidden="true" />
-              <span>{point}</span>
-            </li>
-          ))}
-        </ul>
-        <div className="mt-8 flex flex-col gap-3 sm:flex-row sm:items-center">
-          <DenButton
-            type="button"
-            disabled={!props.canManage}
-            loading={props.subscribeBusy}
-            onClick={props.onSubscribe}
-          >
-            Subscribe with Stripe
-          </DenButton>
-          <p className="text-[13px] leading-5 text-gray-500">
-            $10/user/month · {props.memberCount > 0 ? `${props.memberCount} active member${props.memberCount === 1 ? "" : "s"}` : "billed per active member"} · cancel anytime
-          </p>
-        </div>
-        {props.canManage ? null : (
-          <p className="mt-3 text-[13px] leading-5 text-amber-700">
-            Only workspace admins can subscribe. Ask an owner, super-admin, or admin to enable OpenWork Models for your team.
-          </p>
-        )}
+    <DenCard className="grid gap-6">
+      <div className="grid gap-4 sm:grid-cols-3">
+        {PILLARS.map((pillar) => (
+          <div key={pillar.label} className="grid gap-2 rounded-[16px] border border-gray-100 p-5">
+            <p className="text-[11px] font-semibold uppercase tracking-[0.06em] text-gray-400">{pillar.label}</p>
+            <p className="text-[13px] leading-5 text-gray-500">{pillar.body}</p>
+          </div>
+        ))}
       </div>
-      <div className="rounded-[22px] border border-gray-100 bg-gray-50 p-5">
-        <p className="text-[12px] font-medium uppercase tracking-[0.08em] text-gray-500">
-          Included models
-        </p>
-        <ul className="mt-3 divide-y divide-gray-100">
-          {MODEL_LINEUP.map((model) => (
-            <li key={model.id} className="py-2.5">
-              <p className="text-[14px] font-medium text-gray-900">{model.name}</p>
-              <p className="text-[12px] text-gray-500">{model.id}</p>
-            </li>
-          ))}
-        </ul>
-      </div>
+      <ol className="grid gap-3 border-t border-gray-100 px-1 pt-6">
+        {STEPS.map((step, index) => (
+          <li key={index} className="flex items-baseline gap-3">
+            <span className="shrink-0 font-mono text-[12px] text-gray-400">{index + 1}.</span>
+            <span className="text-[13.5px] leading-6 text-gray-700">{step}</span>
+          </li>
+        ))}
+      </ol>
     </DenCard>
+  );
+}
+
+function ModelsLineup({ subscribed }: { subscribed: boolean }) {
+  return (
+    <section className="grid gap-3.5">
+      <DenSectionHeader
+        title="Models"
+        description={
+          subscribed
+            ? `Every member of your workspace can use all ${MODEL_LINEUP.length} models.`
+            : `Every member of your workspace can use all ${MODEL_LINEUP.length} models, the moment you subscribe.`
+        }
+      />
+      <div className="overflow-hidden rounded-[16px] border border-gray-100 bg-white">
+        <DenTable headerTone="plain" columns={MODEL_COLUMNS} rows={MODEL_LINEUP} getRowKey={(model) => model.id} />
+      </div>
+    </section>
   );
 }
 
@@ -355,55 +417,53 @@ export function InferenceScreen() {
 
   const enabled = status?.enabled === true;
   const subscribed = status?.subscribed === true;
-  const showValueProp = !loading && status !== null && !subscribed;
-  const cardTitle = enabled ? "OpenWork Models enabled" : "Enable OpenWork Models";
-  const actionLabel = enabled ? "Manage subscription" : "Enable";
-  const statusTone = loading ? "info" : enabled ? "success" : "neutral";
-  const statusLabel = loading ? "Checking" : enabled ? "Enabled" : "Disabled";
+  const showGettingStarted = !loading && status !== null && !subscribed;
+  const memberCount = status?.memberCount ?? 0;
+  const actionLabel = subscribed ? (enabled ? "Manage subscription" : "Enable") : "Subscribe with Stripe";
+  const memberCaption = memberCount > 0
+    ? `${memberCount} active member${memberCount === 1 ? "" : "s"}`
+    : "billed per active member";
 
   return (
-    <DashboardPageTemplate
-      icon={Sparkles}
-      badgeLabel="Beta"
-      title="OpenWork Models"
-      description="Frontier intelligence, hand picked for knowledge work. No API keys to manage."
-      colors={["#EEF2FF", "#1E3A8A", "#3B82F6", "#93C5FD"]}
-    >
-      <div className="grid gap-4">
-        {error ? <DenNotice message={error} tone="error" /> : null}
+    <div className="mx-auto grid max-w-[860px] gap-6 px-8 pb-16 pt-8">
+      <DenPageHeader
+        title="OpenWork Models"
+        description="Reliable, hand-picked models for knowledge work. No API keys to manage."
+        action={
+          <DenButton
+            type="button"
+            onClick={subscribed ? toggleEnabled : () => void startSubscribeCheckout()}
+            loading={loading || saving || subscribeBusy}
+            disabled={!canManageModels}
+            variant={enabled ? "secondary" : "primary"}
+          >
+            {actionLabel}
+          </DenButton>
+        }
+        caption={`$10 / user / month · ${memberCaption}`}
+      />
 
-        {showValueProp ? (
-          <ModelsValueProp
-            canManage={canManageModels}
-            memberCount={status?.memberCount ?? 0}
-            subscribeBusy={subscribeBusy}
-            onSubscribe={() => void startSubscribeCheckout()}
-          />
-        ) : (
-          <DenCard>
-            <DenSectionHeader
-              title={cardTitle}
-              description="Turn models on for every member, or manage the Stripe subscription for this workspace."
-              action={
-                <div className="flex flex-wrap items-center gap-3">
-                  <DenBadge tone={statusTone}>{statusLabel}</DenBadge>
-                  <DenButton
-                    type="button"
-                    onClick={toggleEnabled}
-                    loading={saving || loading}
-                    disabled={!canManageModels}
-                    variant={enabled ? "secondary" : "primary"}
-                  >
-                    {actionLabel}
-                  </DenButton>
-                </div>
-              }
-            />
-          </DenCard>
-        )}
+      {error ? <DenNotice message={error} tone="error" /> : null}
 
-        {enabled && status ? <UsageLimitsCard buckets={status.buckets} /> : null}
-      </div>
-    </DashboardPageTemplate>
+      {canManageModels ? null : (
+        <DenNotice
+          tone="info"
+          message="Only workspace admins can subscribe or enable OpenWork Models. Ask an owner, super-admin, or admin for this workspace."
+        />
+      )}
+
+      {showGettingStarted ? <GettingStartedCard /> : null}
+
+      <ModelsLineup subscribed={subscribed} />
+
+      {enabled && status ? <UsageLimitsCard buckets={status.buckets} /> : null}
+
+      <p className="text-[13px] text-gray-400">
+        Prefer your own provider accounts?{" "}
+        <Link href={getCustomLlmProvidersRoute(activeOrgSlug)} className="text-gray-900 underline">
+          Set up Bring your Own Keys.
+        </Link>
+      </p>
+    </div>
   );
 }

--- a/ee/apps/den-web/tests/openwork-models-page.test.ts
+++ b/ee/apps/den-web/tests/openwork-models-page.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
+import { INFERENCE_MODEL_ALIASES } from "@openwork/types/den/inference";
 
 const screen = readFileSync(
   join(import.meta.dir, "..", "app", "(den)", "dashboard", "_components", "inference-screen.tsx"),
@@ -8,17 +9,37 @@ const screen = readFileSync(
 );
 
 describe("OpenWork Models page", () => {
-  test("rebuilds the screen on shared den primitives", () => {
-    for (const primitive of ["DenCard", "DenBadge", "DenSectionHeader", "DenNotice", "DenButton"]) {
+  test("leads with the flat page header instead of the gradient hero", () => {
+    expect(screen).toContain("DenPageHeader");
+    expect(screen).toContain("Reliable, hand-picked models for knowledge work.");
+    expect(screen).not.toContain("DashboardPageTemplate");
+  });
+
+  test("renders the lineup through the shared table primitive", () => {
+    for (const primitive of ["DenTable", "DenCard", "DenSectionHeader", "DenNotice", "DenButton"]) {
       expect(screen).toContain(primitive);
     }
-    expect(screen).not.toContain("shadow-[0_18px_45px");
+    expect(screen).toContain('headerTone="plain"');
+    expect(screen).toContain("Best for");
+    expect(screen).toContain("Model ID");
+  });
+
+  test("describes every shipped model", () => {
+    for (const [id, model] of Object.entries(INFERENCE_MODEL_ALIASES)) {
+      if (!model.enabled) continue;
+      expect(screen).toContain(`"${id}": { bestFor:`);
+    }
   });
 
   test("keeps the Stripe subscribe and enable flows", () => {
     expect(screen).toContain("Subscribe with Stripe");
+    expect(screen).toContain("Manage subscription");
     expect(screen).toContain("/v1/billing/stripe/checkout");
     expect(screen).toContain('method: "PATCH"');
-    expect(screen).toContain("OpenWork Models");
+  });
+
+  test("cross-links to bring your own keys", () => {
+    expect(screen).toContain("getCustomLlmProvidersRoute");
+    expect(screen).toContain("Set up Bring your Own Keys.");
   });
 });


### PR DESCRIPTION
## Summary

The earlier Models PR (#3164) only swapped in shared primitives, so the page still looked like the old one. This is the actual Paper redesign:

- **Flat page header** replaces the gradient hero: title, one-line description, subscribe/manage action, and the `$10 / user / month · N active members` line underneath.
- **Value card** with three pillars (you or your whole team / nothing to set up / no lock-in) and the four numbered getting-started steps, shown only while the workspace is unsubscribed.
- **Model lineup as a table**: vendor monogram + model name, a "best for" column so people can pick without guessing, and the model ID in mono. Copy is data-driven off `INFERENCE_MODEL_ALIASES`, so the count and rows follow the shipped lineup.
- Footer cross-link to **Bring your Own Keys** for teams that prefer their own provider accounts.
- The enabled/disabled badge is gone (as requested when the design was reviewed) — state now reads from the action label: `Subscribe with Stripe` → `Enable` → `Manage subscription`.

New/extended primitives:

- `DenPageHeader` (new) — title + description + action + caption, for pages that lead with content instead of `DashboardPageTemplate`'s hero.
- `DenTable` — added `headerTone="plain"` (no filled header row for tables on white surfaces) and per-column `width` so lanes stay aligned. Existing BYOK usage is unchanged.

## Evidence

### Screenshots

![OpenWork Models page rebuilt on the Paper design](https://litter.catbox.moe/ep5m4o.png)

Captured from a real Next.js render of the shipped components (temporary preview route driven with Playwright, removed before commit — the DB-backed dashboard stack is unavailable locally right now, so state-dependent blocks were rendered in their unsubscribed state).

### Build verification

- `pnpm --filter @openwork-ee/den-web build` — passed
- `pnpm --filter @openwork-ee/den-web typecheck` — passed
- `pnpm --filter @openwork-ee/den-web test` — passed (91 tests, 0 fail), including an updated `tests/openwork-models-page.test.ts` that asserts the flat header, the table primitive, the Stripe/enable flows, the BYOK cross-link, and that **every enabled model alias has "best for" copy** (so adding a model to `INFERENCE_MODEL_ALIASES` fails loudly instead of shipping a blank cell).

### API verification

No API changes — the screen still uses `GET /v1/inference`, `PATCH /v1/inference`, and `POST /v1/billing/stripe/checkout` exactly as before.

### UI verification

- Console errors: none
- Failed network requests: none

## Test instructions

1. `pnpm dev:den` and `pnpm dev:den:seed-demo`
2. Sign in as an org admin, go to **Models → OpenWork Models**
3. Unsubscribed org: header shows `Subscribe with Stripe` + price line, value card and numbered steps are visible, table lists all 9 models
4. Subscribed org: value card collapses, action becomes `Enable` / `Manage subscription`, usage limits card appears under the table
5. Non-admin member: action is disabled and an info notice explains that admins manage this

Made with [Cursor](https://cursor.com)