### PR TITLE
fix(desktop): stop pinning the updater test to a released version

### DIFF
--- a/apps/desktop/electron/updater.test.mjs
+++ b/apps/desktop/electron/updater.test.mjs
@@ -1,5 +1,6 @@
 import { describe, it } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
 import { mkdtemp, rm } from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
@@ -12,6 +13,12 @@ import {
 } from "./updater.mjs";
 
 const fakeApp = { getPath: (key) => (key === "home" ? "/Users/test" : `/Users/test/${key}`) };
+
+// Unpackaged builds resolve their version from package.json, so release bumps
+// must not require touching this test.
+const desktopVersion = JSON.parse(
+  readFileSync(new URL("../package.json", import.meta.url), "utf8"),
+).version;
 
 describe("staleUpdaterStatePaths", () => {
   it("targets the ShipIt cache on macOS", { skip: process.platform !== "darwin" }, () => {
@@ -96,7 +103,7 @@ describe("release channel changes", () => {
       registerUpdaterIpc({
         app: {
           isPackaged: false,
-          getVersion: () => "0.18.3",
+          getVersion: () => desktopVersion,
           getPath: () => userData,
         },
         ipcMain: { handle: (name, handler) => handlers.set(name, handler) },
@@ -109,7 +116,7 @@ describe("release channel changes", () => {
       assert.deepEqual(await setChannel(null, "alpha"), {
         channel: "stable",
         feedUrl: "https://github.com/different-ai/openwork/releases/latest/download",
-        currentVersion: "0.18.3",
+        currentVersion: desktopVersion,
       });
     } finally {
       await rm(userData, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

`dev` has been red since `chore(release): v0.18.4` (76565e94). `electron/updater.test.mjs` stubbed `app.getVersion()` as `0.18.3`, but unpackaged builds resolve their version from `apps/desktop/package.json` (see `resolveAppVersion`), so the assertion broke the moment the release bump landed — and it will break on every future bump.

The test now reads the version the same way the updater does, so it keeps asserting what it cares about (enterprise builds pinned to the stable manifest channel and feed URL) without tracking release numbers.

## Evidence

```
$ cd apps/desktop && node --test electron/updater.test.mjs
✔ pins enterprise builds to their parallel stable manifest channel (21.014916ms)
ℹ tests 9
ℹ pass 8
ℹ fail 0
ℹ skipped 1
```

Before the change, the same command failed with `currentVersion: '0.18.4'` (actual) vs `'0.18.3'` (expected).

No product code changed — test-only.

## Test instructions

1. `cd apps/desktop && node --test electron/updater.test.mjs` — passes
2. Bump `apps/desktop/package.json` version locally and re-run — still passes

Made with [Cursor](https://cursor.com)