### PR TITLE
fix(release): unblock Daytona and AUR publishing

### DIFF
--- a/.github/workflows/release-daytona-snapshot.yml
+++ b/.github/workflows/release-daytona-snapshot.yml
@@ -93,6 +93,8 @@ jobs:
 
       - name: Install Daytona CLI
         shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
 
@@ -118,7 +120,7 @@ jobs:
           install_dir="$HOME/.local/bin"
           mkdir -p "$install_dir"
 
-          release_json="$(curl -fsSL https://api.github.com/repos/daytonaio/daytona/releases/latest)"
+          release_json="$(gh api repos/daytonaio/daytona/releases/latest)"
           asset_url="$(python3 -c 'import json, sys; data = json.load(sys.stdin); name = sys.argv[1]; print(next(asset["browser_download_url"] for asset in data["assets"] if asset["name"] == name))' "$asset_name" <<<"$release_json")"
 
           curl -fL "$asset_url" -o "$install_dir/daytona"

--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -918,7 +918,7 @@ jobs:
       always() &&
       needs.resolve-release.result == 'success' &&
       needs.publish-electron.result == 'success' &&
-      (needs.publish-release.result == 'success' || needs.publish-release.result == 'skipped')
+      needs.publish-release.result == 'success'
     runs-on: blacksmith-4vcpu-ubuntu-2404
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- authenticate the Daytona latest-release API lookup to avoid runner rate-limit failures
- only run AUR publishing after the GitHub release is successfully public

## Verification
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path) }' .github/workflows/release-daytona-snapshot.yml .github/workflows/release-macos-aarch64.yml`\n- `pnpm dlx prettier@3.6.2 --check .github/workflows/release-daytona-snapshot.yml .github/workflows/release-macos-aarch64.yml`\n- authenticated `gh api repos/daytonaio/daytona/releases/latest` returned the expected platform assets\n- `git diff --check`