### PR TITLE
fix(server): prevent startup crash when workspace drive is missing

### DIFF
--- a/apps/server/src/workspace-init.test.ts
+++ b/apps/server/src/workspace-init.test.ts
@@ -180,4 +180,11 @@ describe("ensureLocalWorkspaceFiles", () => {
       ensureLocalWorkspaceFiles([{ path: "", preset: "starter", workspaceType: "local" }]),
     ).resolves.toBeUndefined();
   });
+
+  test("does not throw when a local workspace path is invalid or on a missing drive", async () => {
+    // e.g. path on Windows like Z:\some\path where Z: drive does not exist, or invalid chars
+    await expect(
+      ensureLocalWorkspaceFiles([{ path: "Z:\\missing-drive-workspace-test", preset: "starter", workspaceType: "local" }]),
+    ).resolves.toBeUndefined();
+  });
 });

--- a/apps/server/src/workspace-init.ts
+++ b/apps/server/src/workspace-init.ts
@@ -92,7 +92,11 @@ export async function ensureLocalWorkspaceFiles(
 ): Promise<void> {
   for (const workspace of workspaces) {
     if (workspace.workspaceType === "remote" || !workspace.path.trim()) continue;
-    await ensureWorkspaceFiles(workspace.path, workspace.preset);
+    try {
+      await ensureWorkspaceFiles(workspace.path, workspace.preset);
+    } catch (err) {
+      console.warn(`Failed to ensure files for workspace at ${workspace.path}:`, err);
+    }
   }
 }
 


### PR DESCRIPTION
## Summary
Fixes an app startup crash on Windows when a previously registered workspace points to a drive that is no longer plugged in or doesn't exist. 
Instead of letting `fs.mkdir` fail and halt the server boot, the error is caught and logged as a warning so that OpenWork can boot normally.

## Why
During boot, OpenWork checks all registered local workspaces and runs `fs.mkdir(..., { recursive: true })` on their paths. If a workspace is on an unplugged or missing drive, Node/Bun throws that `ENOENT ... mkdir '\\?'` error, crashing the app startup. I've wrapped this workspace check in a try/catch block so the app logs a warning and proceeds to boot normally instead of crashing. 

## Issue
- Closes #3137 

## Scope
- apps/server/src/workspace-init.ts
- apps/server/src/workspace-init.test.ts

## Out of scope
- Handling individual workspace loading failures on the frontend (handled gracefully once the backend starts).

## Testing
### Ran
- `bun test src/workspace-init.test.ts` (inside `apps/server`)

### Result
- pass/fail: pass
- if fail, exact files/errors: N/A

## CI status
- pass: N/A (local environment tests passed)
- code-related failures: None
- external/env/auth blockers: None

## Manual verification
1. Run server with a registered workspace pointing to a non-existent drive letter (e.g. `Z:\missing-drive-workspace-test`).
2. Verify that the server logs a warning `Failed to ensure files for workspace...` and successfully completes startup.

## Evidence
- `N/A (covered by unit tests)`

## Risk
- Low. Only wraps a startup filesystem path check in a try/catch block.

## Rollback
- Revert the try/catch wrapper in `ensureLocalWorkspaceFiles` in `workspace-init.ts`.
