### PR TITLE
fix(app): let the browser rail button open a browser on first click

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -521,11 +521,15 @@ export function SessionPage(props: SessionPageProps) {
     setCurrentSidePanel(null);
   }, [setCurrentSidePanel]);
   const openBrowserRailPane = useCallback(() => {
-    if (!hasBrowserTabs) return;
     // Opening the browser pane should land on a usable page, not an empty
-    // panel that forces the user to click "+".
+    // panel that forces the user to click "+", so the first click opens a tab.
+    if (!hasBrowserTabs) {
+      setCurrentSidePanel("panel");
+      void window.__OPENWORK_ELECTRON__?.browser?.createTab?.();
+      return;
+    }
     toggleCurrentSidePanel("panel");
-  }, [hasBrowserTabs, toggleCurrentSidePanel]);
+  }, [hasBrowserTabs, setCurrentSidePanel, toggleCurrentSidePanel]);
   const openBrowserUrlControlAction = useMemo<OpenworkControlAction>(() => ({
     id: "browser.open_url",
     label: "Open URL in built-in browser",
@@ -1432,10 +1436,10 @@ export function SessionPage(props: SessionPageProps) {
                   panelRailActive && hasBrowserTabs && "bg-primary/10 text-primary hover:bg-primary/15 hover:text-primary",
                 )}
                 onClick={openBrowserRailPane}
-                title={hasBrowserTabs ? "Browser" : "Browser opens when a page is available"}
-                aria-label={hasBrowserTabs ? "Browser" : "Browser opens when a page is available"}
+                title={props.selectedSessionId ? "Browser" : "Browser opens once you start a task"}
+                aria-label={props.selectedSessionId ? "Browser" : "Browser opens once you start a task"}
                 aria-pressed={panelRailActive && hasBrowserTabs}
-                disabled={!hasBrowserTabs}
+                disabled={!props.selectedSessionId}
               >
                 <Globe size={15} />
               </Button>

--- a/evals/flows/artifact-tab-overflow.flow.mjs
+++ b/evals/flows/artifact-tab-overflow.flow.mjs
@@ -30,11 +30,16 @@ export default {
           );
         }
 
+        // The browser rail button toggles the side panel, so only click it when
+        // the panel (and with it the seed action) is not already mounted.
         await ctx.eval(`(() => {
+          const seedReady = window.__openworkControl.listActions()
+            .some((item) => item.id === "eval.artifact_tabs.seed_overflow" && !item.disabled);
+          if (seedReady) return "already-open";
           const button = Array.from(document.querySelectorAll("button"))
-            .find((item) => item.getAttribute("aria-label") === "Browser" && !item.disabled);
+            .find((item) => (item.getAttribute("aria-label") || "").startsWith("Browser") && !item.disabled);
           button?.click();
-          return Boolean(button);
+          return button ? "clicked" : "no-button";
         })()`);
         await ctx.waitFor(
           `window.__openworkControl.listActions().some((a) => a.id === "eval.artifact_tabs.seed_overflow" && !a.disabled)`,

--- a/evals/flows/browser-rail-first-click.flow.mjs
+++ b/evals/flows/browser-rail-first-click.flow.mjs
@@ -1,0 +1,235 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/browser-rail-first-click.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("browser-rail-first-click");
+
+const HERO_HEADING = "What do you need done?";
+
+async function closeStaleDialogs(ctx) {
+  await ctx.eval(`(() => {
+    for (let index = 0; index < 3; index += 1) {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    }
+    const active = document.activeElement;
+    if (active && typeof active.blur === "function") active.blur();
+    return true;
+  })()`);
+}
+
+async function bootPrecondition(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+  await closeStaleDialogs(ctx);
+  const state = await ctx.waitFor(
+    `(() => {
+      const route = String(window.__openworkControl.snapshot().route || "");
+      if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+      if (!window.__OPENWORK_ELECTRON__?.browser?.createTab) return "no-browser";
+      const action = window.__openworkControl.listActions().find((item) => item.id === "session.create_task");
+      return action && !action.disabled ? "ready" : null;
+    })()`,
+    { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+  );
+  if (state === "blocked") return "Profile is not onboarded (welcome/signin); the browser rail needs a workspace.";
+  if (state === "no-browser") return "The built-in browser bridge is unavailable; this flow needs the Electron shell.";
+  return null;
+}
+
+/** State of the globe button in the right-hand rail. */
+const READ_GLOBE = `(() => {
+  const globe = Array.from(document.querySelectorAll("button"))
+    .find((button) => (button.getAttribute("aria-label") || "").startsWith("Browser"));
+  if (!globe) return { ok: false, reason: "browser rail button not found" };
+  return {
+    ok: true,
+    label: globe.getAttribute("aria-label"),
+    title: globe.getAttribute("title"),
+    disabled: globe.disabled,
+    pointerEvents: getComputedStyle(globe).pointerEvents,
+    opacity: Number(getComputedStyle(globe).opacity),
+  };
+})()`;
+
+/** Browser tab strip rendered by the side panel, plus the panel's own chrome. */
+const READ_PANEL = `(() => {
+  const labels = Array.from(document.querySelectorAll("button"))
+    .map((button) => button.getAttribute("aria-label"))
+    .filter(Boolean);
+  return {
+    hasNewTabButton: labels.includes("New tab"),
+    selectTabLabels: labels.filter((label) => label.startsWith("Select tab:")),
+  };
+})()`;
+
+/** The Electron browser bridge is promise-based, so these reads await it. */
+function readBrowserTabs(ctx) {
+  return ctx.eval(
+    `(async () => ((await window.__OPENWORK_ELECTRON__.browser.getState())?.tabs || []).map((tab) => ({ id: tab.id, url: tab.url })))()`,
+    { awaitPromise: true },
+  );
+}
+
+async function waitForBrowserTabs(ctx, predicate, label, timeoutMs = 30_000) {
+  const deadline = Date.now() + timeoutMs;
+  let tabs = await readBrowserTabs(ctx);
+  while (!predicate(tabs)) {
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for ${label}; the browser reported ${JSON.stringify(tabs)}.`);
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+    tabs = await readBrowserTabs(ctx);
+  }
+  return tabs;
+}
+
+async function readGlobe(ctx) {
+  return ctx.waitFor(
+    `(() => { const result = ${READ_GLOBE}; return result.ok ? result : null; })()`,
+    { timeoutMs: 30_000, label: "browser rail button" },
+  );
+}
+
+async function clickGlobe(ctx) {
+  const clicked = await ctx.eval(`(() => {
+    const globe = Array.from(document.querySelectorAll("button"))
+      .find((button) => (button.getAttribute("aria-label") || "").startsWith("Browser"));
+    if (!globe || globe.disabled) return false;
+    globe.click();
+    return true;
+  })()`);
+  ctx.assert(clicked, "The browser rail button was missing or disabled, so it could not be clicked.");
+}
+
+export default {
+  id: "browser-rail-first-click",
+  title: "The browser rail button opens the built-in browser on the first click",
+  kind: "user-facing",
+  precondition: bootPrecondition,
+  steps: [
+    {
+      name: "Without a task the browser button explains itself",
+      run: async (ctx) => {
+        await ctx.prove("With no task open the globe is disabled and says why", {
+          voiceover: vo[0],
+          action: async () => {
+            await closeStaleDialogs(ctx);
+            await ctx.control("route.session");
+            await ctx.waitForText(HERO_HEADING, { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            const globe = await readGlobe(ctx);
+            ctx.assert(globe.disabled, `Expected the globe to be disabled with no task open, got label "${globe.label}".`);
+            ctx.assert(
+              globe.label === "Browser opens once you start a task",
+              `Expected the globe to explain itself, got "${globe.label}".`,
+            );
+            ctx.assert(globe.title === globe.label, "The globe tooltip should match its accessible name.");
+            ctx.log(`no-task globe: ${JSON.stringify(globe)}`);
+          },
+          screenshot: {
+            name: "no-task-browser-disabled",
+            requireText: [HERO_HEADING],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Opening a task makes the browser button clickable with zero tabs",
+      run: async (ctx) => {
+        await ctx.prove("A task with no browser tabs still offers an enabled browser button", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.control("session.create_task");
+            await ctx.waitFor(
+              `String(window.__openworkControl.snapshot().route || "").includes("/session/ses_")`,
+              { timeoutMs: 60_000, label: "session route after task creation" },
+            );
+            // Reach the state the bug was about: a task open and nothing browsed yet.
+            await ctx.eval("window.__OPENWORK_ELECTRON__.browser.closeAllTabs()", { awaitPromise: true });
+            await waitForBrowserTabs(ctx, (tabs) => tabs.length === 0, "the browser to have no tabs");
+          },
+          assert: async () => {
+            const tabs = await readBrowserTabs(ctx);
+            ctx.assert(tabs.length === 0, `Expected no browser tabs before the first click, got ${tabs.length}.`);
+            const globe = await readGlobe(ctx);
+            ctx.assert(!globe.disabled, "The globe is still disabled while a task is open with no browser tabs.");
+            ctx.assert(globe.label === "Browser", `Expected the globe to read "Browser", got "${globe.label}".`);
+            ctx.assert(globe.pointerEvents !== "none", "The globe still ignores pointer events.");
+            ctx.assert(globe.opacity > 0.9, `The globe still renders dimmed at opacity ${globe.opacity}.`);
+            ctx.log(`task globe with zero tabs: ${JSON.stringify(globe)}`);
+          },
+          screenshot: {
+            name: "task-open-browser-enabled",
+            hashIncludes: "/session/ses_",
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "The first click opens the browser on a real page",
+      run: async (ctx) => {
+        await ctx.prove("Clicking the globe creates a browser tab and shows the panel", {
+          voiceover: vo[2],
+          action: async () => {
+            await clickGlobe(ctx);
+            // A new tab starts on about:blank and then navigates, so wait for the
+            // real page rather than for the tab to merely exist.
+            await waitForBrowserTabs(
+              ctx,
+              (tabs) => tabs.some((tab) => tab.url && tab.url !== "about:blank"),
+              "the rail click to open a browser tab on a real page",
+            );
+          },
+          assert: async () => {
+            const tabs = await readBrowserTabs(ctx);
+            ctx.assert(tabs.length === 1, `Expected exactly one browser tab after the first click, got ${tabs.length}.`);
+            ctx.assert(
+              Boolean(tabs[0].url) && tabs[0].url !== "about:blank",
+              `The rail click opened an empty tab (${tabs[0].url}) instead of a usable page.`,
+            );
+            const panel = await ctx.waitFor(
+              `(() => { const result = ${READ_PANEL}; return result.hasNewTabButton && result.selectTabLabels.length > 0 ? result : null; })()`,
+              { timeoutMs: 30_000, label: "browser panel chrome" },
+            );
+            ctx.log(`opened ${tabs[0].url} with tabs ${JSON.stringify(panel.selectTabLabels)}`);
+            ctx.output("browser-tabs-after-first-click", JSON.stringify({ tabs, panel }, null, 2));
+          },
+          screenshot: {
+            name: "first-click-opens-browser",
+            hashIncludes: "/session/ses_",
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Clicking again closes the browser and keeps the tab",
+      run: async (ctx) => {
+        await ctx.prove("The globe still toggles the panel closed without discarding the tab", {
+          voiceover: vo[3],
+          action: async () => {
+            await clickGlobe(ctx);
+            await ctx.waitFor(
+              `(() => { const result = ${READ_PANEL}; return result.hasNewTabButton ? null : true; })()`,
+              { timeoutMs: 30_000, label: "browser panel closed" },
+            );
+          },
+          assert: async () => {
+            const tabs = await readBrowserTabs(ctx);
+            ctx.assert(tabs.length === 1, `Closing the panel should keep the opened tab, but the browser has ${tabs.length}.`);
+            const globe = await readGlobe(ctx);
+            ctx.assert(!globe.disabled, "The globe became unclickable after closing the panel.");
+            ctx.log(`after toggle close: tabs=${tabs.length} globe=${JSON.stringify(globe)}`);
+          },
+          screenshot: {
+            name: "second-click-closes-browser",
+            hashIncludes: "/session/ses_",
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/browser-rail-first-click.md
+++ b/evals/voiceovers/browser-rail-first-click.md
@@ -1,0 +1,11 @@
+# browser-rail-first-click — The browser button opens a browser on the first click
+
+This user-facing proof drives the OpenWork desktop app over CDP and shows that the globe button in the right-hand rail is clickable as soon as a task is open, that the first click opens the built-in browser on a real page instead of doing nothing, and that clicking it again still closes the panel.
+
+1. Before any task is open there is nothing for a browser to sit next to, so the globe in the right-hand rail is dimmed and its tooltip explains that the browser opens once you start a task.
+
+2. Opening a task lights the globe up. Nothing has been browsed yet in this task, so there is not a single browser tab behind it, and this is exactly the moment where the button used to be dead and there was no way to reach the browser by hand.
+
+3. One click on the globe opens the browser beside the conversation, already loaded on a real page with an address bar, back and forward arrows, and a plus button for more tabs. Nobody had to ask an agent to browse something first.
+
+4. Clicking the globe a second time tucks the browser away again, and the tab that was opened is still there waiting, so the button reads as a toggle rather than a one-way door.


### PR DESCRIPTION
## Summary
- The globe button in the session rail is now clickable as soon as a task is open, and the first click opens the built-in browser on a real page.

## Why
Reported: *"I can't click on the OpenWork browser icon anymore — this should be clickable when a session is loaded up."*

The rail button was `disabled={!hasBrowserTabs}`, so it only became clickable **after** a browser tab already existed. With a task open and nothing browsed yet, it was dead — there was no way to reach the built-in browser by hand. In practice only an agent calling a browser tool could surface the panel, and then the button worked.

Measured on `dev`, with a task open and zero browser tabs:

```
route:  #/workspace/ws_.../session/ses_05c4c4afaffelbK2zHkq4hhIuN
tabs:   0
globe:  { label: "Browser opens when a page is available", disabled: true, opacity: "0.35" }
click → tabs: 0     (nothing happens)
```

## Issue
- Closes #

## Scope
- `session-page.tsx`: the globe is gated on a task being open (`props.selectedSessionId`) instead of on a browser tab already existing, and the first click creates a tab.
- New fraimz flow + approved voice-over covering the disabled state, the enabled-with-zero-tabs state, the first click, and the toggle-closed behaviour.

## Out of scope
- The artifacts rail button keeps its existing `hasArtifactTargets` gate — there is nothing meaningful to open when a task has produced no files.
- The panel's own chrome, tab strip, and `+` button are untouched.

## Notes on the approach
The original code carried this comment, which I kept honouring:

> Opening the browser pane should land on a usable page, not an empty panel that forces the user to click "+".

That intent is preserved: the main process already loads `BROWSER_NEW_TAB_URL` for a tab created with no URL (`browser-panel.mjs`), so the first click lands on a real page with an address bar, back/forward, and `+` — not an empty panel. The `createTab` call mirrors the existing pattern a few lines above in the same file (`openTarget`, line ~472).

## Testing
### Ran
- `pnpm fraimz --flow browser-rail-first-click --cdp-url http://127.0.0.1:9826`
- `pnpm typecheck`
- `pnpm --filter @openwork/app test`
- `pnpm test:eval-runner`
- `node scripts/i18n-audit.mjs --ci`

### Result
- pass/fail: **all pass**
  - fraimz: `PASSED — 1 passed, 0 failed, 0 skipped` (4 frames + voice-over coverage)
  - typecheck: clean
  - app unit tests: `445 pass, 0 fail` (86 files)
  - eval runner tests: `10 pass, 0 fail`
  - i18n audit: clean

**The flow is a real regression test.** With the fix stashed it fails immediately:

```
✗ Without a task the browser button explains itself — Expected the globe to explain itself,
  got "Browser opens when a page is available".
```

and the core symptom reproduces exactly as quoted under **Why** above (globe disabled with a task open, click creates no tab). Restoring the fix returns the flow to `PASSED`.

## CI status
- pass: to be confirmed by CI on this PR
- code-related failures: none known
- external/env/auth blockers: none

## Manual verification
1. `pnpm dev`, open or create a task, and don't browse anything.
2. The globe in the right-hand rail is solid rather than dimmed, tooltip "Browser".
3. Click it once — the browser opens beside the conversation, already on a page, with an address bar and a `+` for more tabs.
4. Click it again — the panel closes and the tab is still there when you reopen it.
5. Go back to the new-task screen with no task selected: the globe is dimmed and reads "Browser opens once you start a task".

## Evidence
fraimz proof posted as a PR comment (4 validated frames). Note that the browser page content itself is an Electron `WebContentsView`, which renderer-level CDP screenshots do not capture — so the frames assert the browser state over the IPC bridge (tab count and resolved URL) alongside the panel chrome in the DOM, rather than relying on page pixels.

## Risk
Low, and scoped to the rail button. The behaviour when tabs already exist is unchanged (still a toggle). The one new behaviour is "first click creates a tab", which reuses the same main-process path the agent-driven browser already uses.

## Rollback
Revert this commit; the globe returns to being disabled until a browser tab exists.
