### PR TITLE
fix(desktop): keep Enterprise activation isolated

### DIFF
--- a/apps/app/src/app/lib/enterprise-activation.ts
+++ b/apps/app/src/app/lib/enterprise-activation.ts
@@ -5,9 +5,11 @@ export function enterpriseActivationRequired(
   distribution: DesktopDistributionInfo,
   bootstrap: Pick<DenBootstrapConfig, "requireActivation" | "enterpriseActivation">,
 ) {
-  const requireActivation = typeof bootstrap.requireActivation === "boolean"
-    ? bootstrap.requireActivation
-    : distribution.requireActivation;
+  const requireActivation = distribution.flavor === "enterprise"
+    ? distribution.requireActivation
+    : (typeof bootstrap.requireActivation === "boolean"
+        ? bootstrap.requireActivation
+        : distribution.requireActivation);
   return requireActivation
     && !(
       bootstrap.enterpriseActivation?.activatedAt

--- a/apps/app/src/react-app/domains/cloud/connect-confirm-dialog.tsx
+++ b/apps/app/src/react-app/domains/cloud/connect-confirm-dialog.tsx
@@ -75,7 +75,7 @@ export function ConnectConfirmDialog({
 }: ConnectConfirmDialogProps) {
   const targetHost = claims ? formatControlPlaneHost(claims.den.baseUrl) : null;
   const switching = Boolean(currentHost && targetHost && currentHost !== targetHost);
-  const trustedBrandUrl = transport === "signed" ? claims?.brand.iconUrl ?? claims?.brand.logoUrl : null;
+  const trustedBrandUrl = transport ? claims?.brand.iconUrl ?? claims?.brand.logoUrl : null;
   const logoUrl = trustedBrandUrl && isHttpsUrl(trustedBrandUrl) ? trustedBrandUrl : null;
 
   return (

--- a/apps/app/src/react-app/shell/providers.tsx
+++ b/apps/app/src/react-app/shell/providers.tsx
@@ -50,7 +50,7 @@ type AppProvidersProps = {
 function EnterpriseAwareAppProviders({ children }: AppProvidersProps) {
   const activationRequired = useEnterpriseActivationRequired();
   if (activationRequired) {
-    return children;
+    return <ConnectLinkProvider>{children}</ConnectLinkProvider>;
   }
   return (
     <>

--- a/apps/app/tests/enterprise-activation.test.ts
+++ b/apps/app/tests/enterprise-activation.test.ts
@@ -54,10 +54,13 @@ describe("enterprise desktop activation", () => {
     })).toBe(false);
   });
 
-  test("lets desktop-bootstrap.json override either artifact default", () => {
+  test("keeps the Enterprise artifact authoritative over bootstrap opt-out", () => {
     expect(enterpriseActivationRequired(enterpriseDistribution, {
       requireActivation: false,
-    })).toBe(false);
+    })).toBe(true);
+  });
+
+  test("lets desktop-bootstrap.json enable activation for other artifacts", () => {
     expect(enterpriseActivationRequired(publicDistribution, {
       requireActivation: true,
     })).toBe(true);
@@ -81,6 +84,18 @@ describe("enterprise desktop activation", () => {
     expect(gateEnd).toBeGreaterThan(gateStart);
     expect(overlay).toBeGreaterThan(gateStart);
     expect(overlay).toBeLessThan(gateEnd);
+  });
+
+  test("evaluates activation before rendering the sign-in gate", () => {
+    const activationStart = appRootSource.indexOf("<EnterpriseActivationGate>");
+    const activationEnd = appRootSource.indexOf("</EnterpriseActivationGate>");
+    const signInStart = appRootSource.indexOf("<DenSigninGate>");
+    const signInEnd = appRootSource.indexOf("</DenSigninGate>");
+
+    expect(activationStart).toBeGreaterThan(-1);
+    expect(signInStart).toBeGreaterThan(activationStart);
+    expect(signInEnd).toBeGreaterThan(signInStart);
+    expect(activationEnd).toBeGreaterThan(signInEnd);
   });
 
   test("matches the desktop login gate without guessing a Den portal URL", () => {

--- a/apps/app/tests/enterprise-activation.test.ts
+++ b/apps/app/tests/enterprise-activation.test.ts
@@ -20,6 +20,14 @@ const forcedSignInPageSource = readFileSync(
   new URL("../src/react-app/domains/cloud/forced-signin-page.tsx", import.meta.url),
   "utf8",
 );
+const providersSource = readFileSync(
+  new URL("../src/react-app/shell/providers.tsx", import.meta.url),
+  "utf8",
+);
+const connectConfirmDialogSource = readFileSync(
+  new URL("../src/react-app/domains/cloud/connect-confirm-dialog.tsx", import.meta.url),
+  "utf8",
+);
 
 const publicDistribution = {
   flavor: "public" as const,
@@ -96,6 +104,15 @@ describe("enterprise desktop activation", () => {
     expect(signInStart).toBeGreaterThan(activationStart);
     expect(signInEnd).toBeGreaterThan(signInStart);
     expect(activationEnd).toBeGreaterThan(signInEnd);
+  });
+
+  test("keeps the branded connect-link activation consumer mounted before activation", () => {
+    expect(providersSource).toContain(
+      "return <ConnectLinkProvider>{children}</ConnectLinkProvider>;",
+    );
+    expect(connectConfirmDialogSource).toContain(
+      "const trustedBrandUrl = transport ? claims?.brand.iconUrl ?? claims?.brand.logoUrl : null;",
+    );
   });
 
   test("matches the desktop login gate without guessing a Den portal URL", () => {

--- a/apps/desktop/electron/connect-link-branding.mjs
+++ b/apps/desktop/electron/connect-link-branding.mjs
@@ -17,10 +17,16 @@ export async function applyDesktopBootstrapBrandIcon(config, applyBrandIconUrl) 
  *     config: Partial<import("@openwork/types/desktop-ipc").DesktopBootstrapConfig>
  *   ) => Promise<import("@openwork/types/desktop-ipc").DesktopBootstrapConfig>,
  *   applyBrandIconUrl: (iconUrl: string) => Promise<unknown>,
+ *   enterpriseActivation?: { activatedAt: string, denBaseUrl: string } | null,
  * }} dependencies
  */
 export async function persistConnectLinkBranding(claims, dependencies) {
-  const config = await dependencies.persistBootstrap(desktopBootstrapFromConnectClaims(claims));
+  const config = await dependencies.persistBootstrap({
+    ...desktopBootstrapFromConnectClaims(claims),
+    ...(dependencies.enterpriseActivation
+      ? { enterpriseActivation: dependencies.enterpriseActivation }
+      : {}),
+  });
   await applyDesktopBootstrapBrandIcon(config, dependencies.applyBrandIconUrl);
   return config;
 }

--- a/apps/desktop/electron/connect-link.test.mjs
+++ b/apps/desktop/electron/connect-link.test.mjs
@@ -139,7 +139,7 @@ test("resolves a keyless exchange through the exact HTTPS Den endpoint", async (
   });
 });
 
-test("persists accepted connect branding before applying its icon", async () => {
+test("persists accepted Enterprise activation and branding before applying its icon", async () => {
   const expectedClaims = claims({
     brand: {
       appName: "Acme Work",
@@ -147,6 +147,10 @@ test("persists accepted connect branding before applying its icon", async () => 
       iconUrl: "https://assets.acme.example.com/icon.png",
     },
   });
+  const enterpriseActivation = {
+    activatedAt: "2026-07-27T14:00:00.000Z",
+    denBaseUrl: expectedClaims.den.baseUrl,
+  };
   const calls = [];
   const config = await persistConnectLinkBranding(expectedClaims, {
     persistBootstrap: async (nextConfig) => {
@@ -162,9 +166,13 @@ test("persists accepted connect branding before applying its icon", async () => 
       calls.push({ type: "apply", iconUrl });
       return { ok: true };
     },
+    enterpriseActivation,
   });
 
   assert.deepEqual(calls.map((call) => call.type), ["persist", "apply"]);
+  assert.deepEqual(calls[0].config.enterpriseActivation, enterpriseActivation);
+  assert.equal(calls[0].config.brandAppName, "Acme Work");
+  assert.equal(calls[0].config.brandIconUrl, "https://assets.acme.example.com/icon.png");
   assert.equal(calls[1].iconUrl, expectedClaims.brand.iconUrl);
   assert.equal(config.writtenAt, "2026-07-15T12:00:00.000Z");
 });

--- a/apps/desktop/electron/desktop-distribution.mjs
+++ b/apps/desktop/electron/desktop-distribution.mjs
@@ -73,6 +73,8 @@ export function desktopActivationRequired(distribution, config) {
 const ENTERPRISE_PREACTIVATION_COMMANDS = new Set([
   "__fetch",
   "appBuildInfo",
+  "connectLinkAccept",
+  "connectLinkVerify",
   "getDesktopBootstrapConfig",
   "setDesktopBootstrapConfig",
 ]);

--- a/apps/desktop/electron/desktop-distribution.mjs
+++ b/apps/desktop/electron/desktop-distribution.mjs
@@ -62,9 +62,11 @@ export function enterpriseActivationComplete(config) {
 }
 
 export function desktopActivationRequired(distribution, config) {
-  const requireActivation = typeof config?.requireActivation === "boolean"
-    ? config.requireActivation
-    : distribution.requireActivation;
+  const requireActivation = distribution.flavor === "enterprise"
+    ? distribution.requireActivation
+    : (typeof config?.requireActivation === "boolean"
+        ? config.requireActivation
+        : distribution.requireActivation);
   return requireActivation && !enterpriseActivationComplete(config);
 }
 

--- a/apps/desktop/electron/desktop-distribution.test.mjs
+++ b/apps/desktop/electron/desktop-distribution.test.mjs
@@ -77,11 +77,27 @@ describe("desktopActivationRequired", () => {
     assert.equal(desktopActivationRequired(PUBLIC_DESKTOP_DISTRIBUTION, {}), false);
   });
 
-  it("allows desktop-bootstrap.json to override either distribution default", () => {
+  it("keeps the Enterprise artifact authoritative over bootstrap opt-out", () => {
     assert.equal(desktopActivationRequired(
       ENTERPRISE_DESKTOP_DISTRIBUTION,
       { requireActivation: false },
+    ), true);
+  });
+
+  it("accepts completed activation from the Enterprise bootstrap file", () => {
+    assert.equal(desktopActivationRequired(
+      ENTERPRISE_DESKTOP_DISTRIBUTION,
+      {
+        requireActivation: false,
+        enterpriseActivation: {
+          activatedAt: "2026-07-27T10:00:00.000Z",
+          denBaseUrl: "https://enterprise.example.com",
+        },
+      },
     ), false);
+  });
+
+  it("allows desktop-bootstrap.json to enable activation for other distributions", () => {
     assert.equal(desktopActivationRequired(
       PUBLIC_DESKTOP_DISTRIBUTION,
       { requireActivation: true },

--- a/apps/desktop/electron/desktop-distribution.test.mjs
+++ b/apps/desktop/electron/desktop-distribution.test.mjs
@@ -119,8 +119,10 @@ describe("enterpriseActivationComplete", () => {
 });
 
 describe("enterprisePreactivationCommandAllowed", () => {
-  it("allows only bootstrap, build metadata, and the Den exchange fetch bridge", () => {
+  it("allows only activation, bootstrap, build metadata, and the Den exchange fetch bridge", () => {
     assert.equal(enterprisePreactivationCommandAllowed("__fetch"), true);
+    assert.equal(enterprisePreactivationCommandAllowed("connectLinkAccept"), true);
+    assert.equal(enterprisePreactivationCommandAllowed("connectLinkVerify"), true);
     assert.equal(enterprisePreactivationCommandAllowed("getDesktopBootstrapConfig"), true);
     assert.equal(enterprisePreactivationCommandAllowed("setDesktopBootstrapConfig"), true);
     assert.equal(enterprisePreactivationCommandAllowed("appBuildInfo"), true);

--- a/apps/desktop/electron/main.mjs
+++ b/apps/desktop/electron/main.mjs
@@ -1005,11 +1005,28 @@ async function acceptConnectLink(rawUrl) {
 }
 
 async function persistConnectLinkClaims(claims) {
-  return persistConnectLinkBranding(claims, {
+  const previous = workspaceStore.readDesktopBootstrapConfigSync();
+  const config = await persistConnectLinkBranding(claims, {
     persistBootstrap: (config) => workspaceStore.setDesktopBootstrapConfig(config),
     applyBrandIconUrl: (iconUrl) => applyBrandIconUrl(iconUrl).catch((error) =>
       brandIconFailure("connect-apply-failed", error)),
+    enterpriseActivation: DESKTOP_DISTRIBUTION.flavor === "enterprise"
+      ? {
+          activatedAt: new Date().toISOString(),
+          denBaseUrl: claims.den.baseUrl,
+        }
+      : null,
   });
+  if (
+    desktopActivationRequired(DESKTOP_DISTRIBUTION, previous)
+    && !desktopActivationRequired(DESKTOP_DISTRIBUTION, config)
+  ) {
+    await uiControlServer.start().catch((error) => {
+      console.warn("[ui-control] failed to start", error);
+    });
+    await runtimeManager.prepareFreshRuntime();
+  }
+  return config;
 }
 
 function normalizePlatform(value) {

--- a/apps/desktop/electron/workspace-store.mjs
+++ b/apps/desktop/electron/workspace-store.mjs
@@ -155,6 +155,10 @@ export function createWorkspaceStore({
   }
 
   function legacyDesktopBootstrapPath() {
+    // An explicit bootstrap path defines an isolated installation boundary.
+    // Never let a legacy global config cross that boundary: it may contain a
+    // completed activation from another distribution or deployment.
+    if (process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH?.trim()) return null;
     const primary = desktopBootstrapPath();
     if (primary === DEFAULT_DESKTOP_BOOTSTRAP_PATH && LEGACY_DESKTOP_BOOTSTRAP_PATH !== primary) {
       return LEGACY_DESKTOP_BOOTSTRAP_PATH;

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -373,6 +373,22 @@ test("explicit desktop bootstrap path never inherits legacy activation state", a
   });
 });
 
+test("explicit desktop bootstrap path still reads its configured bootstrap", async () => {
+  await withIsolatedBootstrapStore(async ({ store, root }) => {
+    const explicitPath = path.join(root, "isolated", "desktop-bootstrap.json");
+    process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH = explicitPath;
+    await writeBootstrapConfig(explicitPath, {
+      baseUrl: "https://enterprise.example.com",
+      requireSignin: true,
+    });
+
+    const config = await store.getDesktopBootstrapConfig();
+    assert.equal(config.fromFile, true);
+    assert.equal(config.baseUrl, "https://enterprise.example.com");
+    assert.equal("requireActivation" in config, false);
+  });
+});
+
 test("desktop bootstrap prefers an older legacy organization config over a newer canonical hosted default", async () => {
   await withIsolatedBootstrapStore(async ({ store, canonicalPath, legacyPath }) => {
     await writeBootstrapConfig(canonicalPath, {

--- a/apps/desktop/electron/workspace-store.test.mjs
+++ b/apps/desktop/electron/workspace-store.test.mjs
@@ -353,6 +353,26 @@ test("desktop bootstrap migrates a newer legacy writtenAt to canonical", async (
   });
 });
 
+test("explicit desktop bootstrap path never inherits legacy activation state", async () => {
+  await withIsolatedBootstrapStore(async ({ store, legacyPath, root }) => {
+    const explicitPath = path.join(root, "isolated", "desktop-bootstrap.json");
+    process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH = explicitPath;
+    await writeBootstrapConfig(legacyPath, {
+      baseUrl: "https://app.openworklabs.com",
+      requireSignin: true,
+      enterpriseActivation: {
+        activatedAt: "2026-07-27T13:30:23.342Z",
+        denBaseUrl: "https://app.openworklabs.com/api/den",
+      },
+    });
+
+    const config = await store.getDesktopBootstrapConfig();
+    assert.equal(config.fromFile, false);
+    assert.equal(config.enterpriseActivation, undefined);
+    await assert.rejects(readFile(explicitPath, "utf8"));
+  });
+});
+
 test("desktop bootstrap prefers an older legacy organization config over a newer canonical hosted default", async () => {
   await withIsolatedBootstrapStore(async ({ store, canonicalPath, legacyPath }) => {
     await writeBootstrapConfig(canonicalPath, {


### PR DESCRIPTION
## Summary
- keep explicit bootstrap files supported while isolating them from unrelated legacy activation state
- make the immutable Enterprise artifact authoritative over bootstrap activation opt-outs in Electron and the renderer
- render Enterprise activation before sign-in and keep runtime/session commands blocked until activation completes
- keep the verified `openwork://connect` activation consumer available while locked
- preserve organization app name, logo, and icon from signed or HTTPS exchange activation claims
- persist branding and completed Enterprise activation atomically, apply the desktop icon, then start the runtime
- preserve Public and Cloud bootstrap behavior

## Verification
- `node --test apps/desktop/electron/desktop-distribution.test.mjs apps/desktop/electron/workspace-store.test.mjs` (35/35 passed)
- `bun test apps/app/tests/enterprise-activation.test.ts` (10/10 passed)
- `node --test apps/desktop/electron/connect-link.test.mjs apps/desktop/electron/desktop-distribution.test.mjs` (19/19 passed)
- `git diff --check`

## Order of operation
1. Read the configured bootstrap file and immutable packaged distribution.
2. Enterprise shows activation before sign-in.
3. The Den activation page opens a one-time `openwork://connect` exchange link.
4. Electron verifies the exact HTTPS Den claims while other desktop commands stay blocked.
5. The confirmation dialog shows the organization and its HTTPS logo/icon.
6. On approval, Electron persists server plus branding plus completed activation, applies the desktop icon, and starts the runtime.
7. The activation gate clears; only then can the sign-in gate render.

## Risk
Scoped to desktop activation precedence and the existing verified connect-link handoff. Default migration remains unchanged; explicitly configured bootstrap files remain readable; Public and Cloud defaults remain unchanged.