### PR TITLE
fix(den-web): remove redundant cloud download action

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/install-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/install-screen.tsx
@@ -547,8 +547,6 @@ export function InstallScreen() {
   }
 
   if (config.distribution === "cloud") {
-    const cloudPlatform = detectedInstallPlatform(detected);
-
     return (
       <OnboardingShell state="install" width="full">
         <section data-testid="install-page">
@@ -570,21 +568,7 @@ export function InstallScreen() {
               </div>
             ) : (
               <div className="grid gap-5 text-left">
-                {cloudPlatform ? (
-                  <a
-                    className="den-button-primary w-full sm:w-fit"
-                    data-testid="install-cloud-download-primary"
-                    href={installHref(config, cloudPlatform, token)}
-                  >
-                    Download OpenWork
-                  </a>
-                ) : null}
-                <details className="grid gap-3">
-                  <summary className="w-fit cursor-pointer text-sm font-medium text-slate-600 hover:text-slate-950">
-                    Other platforms
-                  </summary>
-                  <DownloadPlatformGrid groups={downloadGroups} />
-                </details>
+                <DownloadPlatformGrid groups={downloadGroups} />
                 <a className="den-button-secondary w-fit" href={RETURN_TO_OPENWORK_URL}>
                   I already installed OpenWork
                 </a>

--- a/ee/apps/den-web/tests/join-org-invite-clean.test.ts
+++ b/ee/apps/den-web/tests/join-org-invite-clean.test.ts
@@ -182,8 +182,8 @@ describe("join organization invite clean layout contract", () => {
     expect(installSource).toContain("DownloadPlatformGrid");
     expect(installSource).toContain("<span>Download OpenWork Enterprise</span>");
     expect(installSource).toContain("Download OpenWork");
-    expect(installSource).toContain('data-testid="install-cloud-download-primary"');
-    expect(installSource).toContain("Other platforms");
+    expect(installSource).not.toContain('data-testid="install-cloud-download-primary"');
+    expect(installSource).not.toContain("Other platforms");
     expect(installSource).toContain('config.distribution === "cloud"');
     expect(installSource).not.toContain("never asks for an enterprise activation code");
     expect(installSource).toContain("<span>for</span>");


### PR DESCRIPTION
## Summary

- remove the redundant generic **Download OpenWork** action from the cloud install page
- show the existing macOS, Windows, and Linux download choices directly
- leave the enterprise installer flow and download URL/version resolution unchanged

## Checks

Not run (level 0).

## Manual verification

1. Open a Den cloud install link on desktop.
2. Confirm the OS-specific download grid is visible without expanding another section.
3. Confirm the generic download button and **Other platforms** disclosure are absent.
4. Select an OS-specific download and confirm the download begins.
