### PR TITLE
feat(release): add staged desktop builds

### DIFF
--- a/.github/workflows/release-macos-aarch64.yml
+++ b/.github/workflows/release-macos-aarch64.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+      - "!v*-staging.*"
   workflow_dispatch:
     inputs:
       tag:

--- a/.github/workflows/staging-desktop.yml
+++ b/.github/workflows/staging-desktop.yml
@@ -1,0 +1,416 @@
+name: Stage Desktop App
+
+on:
+  push:
+    tags:
+      - "v*-staging.*"
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Existing staging tag to build (vX.Y.Z-staging.N)"
+        required: true
+        type: string
+
+permissions:
+  actions: read
+  contents: write
+
+concurrency:
+  group: staging-desktop-${{ github.event.inputs.tag || github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  prepare-staging:
+    name: Prepare Staging Release
+    runs-on: ubuntu-latest
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      version: ${{ steps.version.outputs.version }}
+      base_version: ${{ steps.version.outputs.base_version }}
+      source_version: ${{ steps.version.outputs.source_version }}
+    steps:
+      - name: Checkout staging tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.inputs.tag || github.ref_name }}
+          fetch-depth: 0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Resolve staging version
+        id: version
+        env:
+          STAGING_TAG: ${{ github.event.inputs.tag || github.ref_name }}
+        run: node scripts/release/staging-version.mjs --tag "$STAGING_TAG" --github-output "$GITHUB_OUTPUT"
+
+      - name: Verify tag belongs to dev
+        env:
+          STAGING_TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch origin dev --no-tags
+          tag_commit="$(git rev-list -n 1 "$STAGING_TAG")"
+          if [ -z "$tag_commit" ] || ! git merge-base --is-ancestor "$tag_commit" origin/dev; then
+            echo "Staging tag $STAGING_TAG must point to a commit reachable from dev." >&2
+            exit 1
+          fi
+
+      - name: Create draft staging prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STAGING_TAG: ${{ steps.version.outputs.tag }}
+          STAGING_VERSION: ${{ steps.version.outputs.version }}
+          SOURCE_VERSION: ${{ steps.version.outputs.source_version }}
+        run: |
+          set -euo pipefail
+          if gh release view "$STAGING_TAG" --repo "$GITHUB_REPOSITORY" >/dev/null 2>&1; then
+            echo "Release $STAGING_TAG already exists; reusing it."
+            exit 0
+          fi
+
+          body_file="$RUNNER_TEMP/staging-release.md"
+          {
+            echo "## OpenWork staging build"
+            echo
+            echo "Candidate version: \`$STAGING_VERSION\`"
+            echo "Source package version: \`$SOURCE_VERSION\`"
+            echo "Source commit: \`$GITHUB_SHA\`"
+            echo
+            echo "This prerelease contains public desktop artifacts for validation before a stable release."
+            echo "It does not publish npm packages, sidecar releases, Daytona snapshots, AUR updates, or stable updater metadata."
+          } > "$body_file"
+
+          gh release create "$STAGING_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --title "OpenWork $STAGING_VERSION (staging)" \
+            --notes-file "$body_file" \
+            --verify-tag \
+            --draft \
+            --prerelease
+
+  build-staging:
+    name: Build Staging (${{ matrix.artifact }})
+    needs: prepare-staging
+    runs-on: ${{ matrix.platform }}
+    timeout-minutes: 120
+    env:
+      STAGING_TAG: ${{ needs.prepare-staging.outputs.tag }}
+      STAGING_BUILD_VERSION: ${{ needs.prepare-staging.outputs.base_version }}
+      MACOS_NOTARIZE: ${{ vars.STAGING_MACOS_NOTARIZE || vars.MACOS_NOTARIZE || 'true' }}
+      SIGN_WINDOWS: ${{ vars.STAGING_SIGN_WINDOWS || 'false' }}
+      SIGNPATH_ORGANIZATION_ID: ${{ secrets.SIGNPATH_ORGANIZATION_ID || vars.SIGNPATH_ORGANIZATION_ID }}
+      SIGNPATH_PROJECT_SLUG: ${{ secrets.SIGNPATH_PROJECT_SLUG || vars.SIGNPATH_PROJECT_SLUG }}
+      SIGNPATH_SIGNING_POLICY_SLUG: ${{ secrets.SIGNPATH_SIGNING_POLICY_SLUG || vars.SIGNPATH_SIGNING_POLICY_SLUG }}
+      SIGNPATH_ARTIFACT_CONFIGURATION_SLUG: ${{ secrets.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG || vars.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: macos-14
+            os_type: macos
+            artifact: staging-macos-arm64
+            electron_args: "--mac --arm64"
+            target_triple: aarch64-apple-darwin
+          - platform: macos-14
+            os_type: macos
+            artifact: staging-macos-x64
+            electron_args: "--mac --x64"
+            target_triple: x86_64-apple-darwin
+          - platform: ubuntu-22.04
+            os_type: linux
+            artifact: staging-linux-x64
+            electron_args: "--linux --x64"
+            target_triple: x86_64-unknown-linux-gnu
+          - platform: ubuntu-22.04-arm
+            os_type: linux
+            artifact: staging-linux-arm64
+            electron_args: "--linux --arm64"
+            target_triple: aarch64-unknown-linux-gnu
+          - platform: windows-2022
+            os_type: windows
+            artifact: staging-windows-x64
+            electron_args: "--win --x64"
+            target_triple: x86_64-pc-windows-msvc
+          - platform: windows-11-arm
+            os_type: windows
+            artifact: staging-windows-arm64
+            electron_args: "--win --arm64"
+            target_triple: aarch64-pc-windows-msvc
+
+    steps:
+      - name: Checkout staging tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ env.STAGING_TAG }}
+          fetch-depth: 0
+
+      - name: Enable git long paths (Windows)
+        if: matrix.os_type == 'windows'
+        shell: pwsh
+        run: git config --global core.longpaths true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Setup Bun
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.10
+
+      - name: Get pnpm store path
+        id: pnpm-store
+        shell: bash
+        run: echo "path=$(pnpm store path --silent)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache pnpm store
+        uses: actions/cache@v5
+        continue-on-error: true
+        with:
+          path: ${{ steps.pnpm-store.outputs.path }}
+          key: ${{ runner.os }}-staging-electron-pnpm-${{ hashFiles('pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-staging-electron-pnpm-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --prefer-offline
+
+      - name: Stamp staging version
+        run: node scripts/release/staging-version.mjs --tag "$STAGING_TAG" --write
+
+      - name: Write Electron notary API key (macOS)
+        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
+        env:
+          APPLE_NOTARY_API_KEY_P8_BASE64: ${{ secrets.APPLE_NOTARY_API_KEY_P8_BASE64 }}
+          APPLE_NOTARY_API_KEY_ID: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_NOTARY_API_ISSUER_ID: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
+          APPLE_CODESIGN_CERT_P12_BASE64: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
+          APPLE_CODESIGN_CERT_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            APPLE_NOTARY_API_KEY_P8_BASE64 \
+            APPLE_NOTARY_API_KEY_ID \
+            APPLE_NOTARY_API_ISSUER_ID \
+            APPLE_CODESIGN_CERT_P12_BASE64 \
+            APPLE_CODESIGN_CERT_PASSWORD; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing staging macOS signing secrets: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+          notary_key_path="$RUNNER_TEMP/AuthKey.p8"
+          printf '%s' "$APPLE_NOTARY_API_KEY_P8_BASE64" | base64 --decode > "$notary_key_path"
+          chmod 600 "$notary_key_path"
+          echo "NOTARY_KEY_PATH=$notary_key_path" >> "$GITHUB_ENV"
+
+      - name: Reject unnotarized macOS staging build
+        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE != 'true'
+        shell: bash
+        run: |
+          echo "macOS staging artifacts must be signed and notarized." >&2
+          exit 1
+
+      - name: Build Electron app
+        shell: bash
+        env:
+          TARGET: ${{ matrix.target_triple }}
+        run: pnpm --filter @openwork/desktop build:electron
+
+      - name: Package Electron (macOS, signed + notarized)
+        if: matrix.os_type == 'macos' && env.MACOS_NOTARIZE == 'true'
+        env:
+          CSC_LINK: ${{ secrets.APPLE_CODESIGN_CERT_P12_BASE64 }}
+          CSC_KEY_PASSWORD: ${{ secrets.APPLE_CODESIGN_CERT_PASSWORD }}
+          APPLE_API_KEY: ${{ secrets.APPLE_NOTARY_API_KEY_ID }}
+          APPLE_API_ISSUER: ${{ secrets.APPLE_NOTARY_API_ISSUER_ID }}
+          APPLE_API_KEY_PATH: ${{ env.NOTARY_KEY_PATH }}
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/desktop exec electron-builder \
+            --config electron-builder.yml \
+            --config.buildVersion "$STAGING_BUILD_VERSION" \
+            ${{ matrix.electron_args }} \
+            --publish never
+
+      - name: Package Electron (Linux)
+        if: matrix.os_type == 'linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/desktop exec electron-builder \
+            --config electron-builder.yml \
+            --config.buildVersion "$STAGING_BUILD_VERSION" \
+            ${{ matrix.electron_args }} \
+            --publish never
+
+      - name: Package Electron (Windows)
+        if: matrix.os_type == 'windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          pnpm --dir apps/desktop exec electron-builder \
+            --config electron-builder.yml \
+            --config.buildVersion "$STAGING_BUILD_VERSION" \
+            ${{ matrix.electron_args }} \
+            --publish never
+
+      - name: Validate SignPath configuration (Windows)
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
+        shell: bash
+        env:
+          SIGNPATH_API_TOKEN: ${{ secrets.SIGNPATH_API_TOKEN }}
+        run: |
+          set -euo pipefail
+          missing=()
+          for name in \
+            SIGNPATH_API_TOKEN \
+            SIGNPATH_ORGANIZATION_ID \
+            SIGNPATH_PROJECT_SLUG \
+            SIGNPATH_SIGNING_POLICY_SLUG; do
+            if [ -z "${!name:-}" ]; then
+              missing+=("$name")
+            fi
+          done
+          if [ "${#missing[@]}" -gt 0 ]; then
+            printf 'Missing staging Windows SignPath configuration: %s\n' "${missing[*]}" >&2
+            exit 1
+          fi
+
+      - name: Stage unsigned Windows installer for SignPath
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
+        shell: bash
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/signpath-unsigned"
+          shopt -s nullglob
+          installers=(apps/desktop/dist-electron/openwork-win-*.exe)
+          if [ "${#installers[@]}" -ne 1 ]; then
+            printf 'Expected exactly one unsigned Windows installer, found %s.\n' "${#installers[@]}" >&2
+            exit 1
+          fi
+          cp "${installers[0]}" "$RUNNER_TEMP/signpath-unsigned/"
+
+      - name: Upload unsigned Windows installer for SignPath
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
+        id: upload-unsigned-windows-installer
+        uses: actions/upload-artifact@v4
+        with:
+          name: unsigned-${{ matrix.artifact }}-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ runner.temp }}/signpath-unsigned/*.exe
+          if-no-files-found: error
+          retention-days: 1
+
+      - name: Submit Windows signing request to SignPath
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true' && env.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG == ''
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ env.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ env.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-windows-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: ${{ runner.temp }}/signpath-signed
+
+      - name: Submit Windows signing request (artifact configuration)
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true' && env.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG != ''
+        uses: signpath/github-action-submit-signing-request@v2
+        with:
+          api-token: ${{ secrets.SIGNPATH_API_TOKEN }}
+          organization-id: ${{ env.SIGNPATH_ORGANIZATION_ID }}
+          project-slug: ${{ env.SIGNPATH_PROJECT_SLUG }}
+          signing-policy-slug: ${{ env.SIGNPATH_SIGNING_POLICY_SLUG }}
+          artifact-configuration-slug: ${{ env.SIGNPATH_ARTIFACT_CONFIGURATION_SLUG }}
+          github-artifact-id: ${{ steps.upload-unsigned-windows-installer.outputs.artifact-id }}
+          wait-for-completion: true
+          output-artifact-directory: ${{ runner.temp }}/signpath-signed
+
+      - name: Apply signed Windows installer
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS == 'true'
+        shell: bash
+        run: node scripts/release/apply-signpath-windows-artifact.mjs "$RUNNER_TEMP/signpath-signed" apps/desktop/dist-electron
+
+      - name: Warn about unsigned Windows staging build
+        if: matrix.os_type == 'windows' && env.SIGN_WINDOWS != 'true'
+        shell: bash
+        run: echo "::warning::Publishing an unsigned Windows staging installer because STAGING_SIGN_WINDOWS is not enabled."
+
+      - name: Upload staging release assets
+        env:
+          GH_TOKEN: ${{ github.token }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          shopt -s nullglob
+          assets=(apps/desktop/dist-electron/openwork-*)
+          if [ "${#assets[@]}" -eq 0 ]; then
+            echo "No Electron staging assets found." >&2
+            exit 1
+          fi
+          gh release upload "$STAGING_TAG" "${assets[@]}" \
+            --repo "$GITHUB_REPOSITORY" \
+            --clobber
+
+      - name: Upload updater manifest artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact }}
+          path: apps/desktop/dist-electron/latest*.yml
+          if-no-files-found: error
+          retention-days: 7
+
+  publish-staging:
+    name: Publish Staging Prerelease
+    needs: [prepare-staging, build-staging]
+    runs-on: ubuntu-latest
+    environment:
+      name: staging
+      url: https://github.com/${{ github.repository }}/releases/tag/${{ needs.prepare-staging.outputs.tag }}
+    steps:
+      - name: Checkout staging tag
+        uses: actions/checkout@v6
+        with:
+          ref: ${{ needs.prepare-staging.outputs.tag }}
+
+      - name: Setup Node
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Download updater manifests
+        uses: actions/download-artifact@v4
+        with:
+          pattern: staging-*
+          path: ${{ runner.temp }}/staging-electron-manifests
+
+      - name: Upload merged updater manifests
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STAGING_TAG: ${{ needs.prepare-staging.outputs.tag }}
+        run: node scripts/release/publish-electron-assets.mjs --manifests-only "$RUNNER_TEMP/staging-electron-manifests" "$STAGING_TAG"
+
+      - name: Publish GitHub prerelease
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STAGING_TAG: ${{ needs.prepare-staging.outputs.tag }}
+        run: |
+          set -euo pipefail
+          gh release edit "$STAGING_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --draft=false \
+            --prerelease

--- a/docs/staging-desktop-releases.md
+++ b/docs/staging-desktop-releases.md
@@ -1,0 +1,106 @@
+# Staging desktop releases
+
+## Proposal
+
+OpenWork desktop staging builds use an isolated GitHub prerelease lane before
+a stable release. A staging tag stamps the public Electron app with a SemVer
+prerelease version and produces the same six public desktop targets as the
+stable pipeline:
+
+| Platform | Architectures |
+| --- | --- |
+| macOS | arm64, x64 |
+| Linux | arm64, x64 |
+| Windows | arm64, x64 |
+
+The lane intentionally does not publish Cloud or enterprise distributions,
+npm packages, OpenWork sidecar releases, Daytona snapshots, AUR changes, or a
+stable updater pointer. Stable releases remain owned by the `Release App`
+workflow.
+
+## Version and tag contract
+
+Use immutable annotated tags in this exact format:
+
+```text
+vMAJOR.MINOR.PATCH-staging.SEQUENCE
+```
+
+For example, candidates before `v0.18.6` are:
+
+```text
+v0.18.6-staging.1
+v0.18.6-staging.2
+```
+
+`SEQUENCE` is a non-negative integer without leading zeroes. A staging tag must
+point to a commit reachable from `dev`, and its base version must be newer than
+the app version in that commit.
+
+The workflow writes `0.18.6-staging.1` into `apps/app/package.json` and
+`apps/desktop/package.json` only inside the build runner. The repository stays
+on its stable source version, and the staged app reports the staging version in
+its package metadata and UI. When `v0.18.6` is later released, SemVer ranks that
+stable version above its prereleases.
+
+Electron's machine build version is set separately to the numeric base version
+(`0.18.6` in this example). This keeps macOS `CFBundleVersion` and Windows file
+metadata numeric while preserving the full staging version as the user-facing
+application version.
+
+The production release workflow explicitly excludes `v*-staging.*`, preventing
+a staging tag from publishing stable release side effects.
+
+## GitHub environment
+
+Create a GitHub Actions environment named `staging` before the first staged
+release. Recommended settings:
+
+1. Allow only tags matching `v*-staging.*`.
+2. Require one release reviewer and prevent self-review when the repository
+   plan supports those controls.
+3. Keep signing credentials in the same repository secret boundary used by the
+   stable release until environment-scoped secret migration is planned.
+4. Set `STAGING_MACOS_NOTARIZE=true` (the workflow also defaults to the stable
+   `MACOS_NOTARIZE` setting).
+5. Set `STAGING_SIGN_WINDOWS=true` only after the SignPath staging path is
+   confirmed. Windows staging installers are clearly marked unsigned otherwise.
+
+The build creates a draft prerelease first. All platform artifacts and merged
+updater manifests must succeed before the final job requests the `staging`
+environment and publishes the prerelease.
+
+GitHub documents environment approvals, tag restrictions, and secret access in
+[Deployments and environments](https://docs.github.com/en/actions/reference/workflows-and-actions/deployments-and-environments).
+
+## Cut a staging build
+
+Start from an up-to-date `dev` commit:
+
+```bash
+git switch dev
+git pull --ff-only
+git tag -a v0.18.6-staging.1 -m "OpenWork 0.18.6 staging 1"
+git push origin v0.18.6-staging.1
+```
+
+The tag push starts `Stage Desktop App`. A maintainer can also rerun a failed
+candidate with the workflow's manual `tag` input. Do not move or reuse a
+published tag; increment the staging sequence.
+
+## Promotion and rollback
+
+Promotion is a new stable tag through the existing release process:
+
+```text
+v0.18.6-staging.1 -> v0.18.6-staging.2 -> v0.18.6
+```
+
+There is no automatic promotion and no staging-to-stable artifact copy. Stable
+artifacts are rebuilt from the stable tag with the production checks and
+publication steps.
+
+If a staging candidate is bad, leave its immutable tag as an audit record,
+withdraw the prerelease if necessary, fix `dev`, and create the next staging
+sequence. If any matrix build fails, the release stays in draft form and can be
+recovered by manually rerunning the workflow for the same tag.

--- a/scripts/release/staging-version.mjs
+++ b/scripts/release/staging-version.mjs
@@ -1,0 +1,132 @@
+#!/usr/bin/env node
+import { appendFileSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = resolve(fileURLToPath(new URL("../..", import.meta.url)));
+const stableVersionPattern = /^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)$/;
+const stagingTagPattern =
+  /^v((0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*))-staging\.(0|[1-9]\d*)$/;
+const desktopPackagePaths = [
+  "apps/app/package.json",
+  "apps/desktop/package.json",
+];
+
+function compareStableVersions(left, right) {
+  const leftParts = left.split(".").map(Number);
+  const rightParts = right.split(".").map(Number);
+  for (let index = 0; index < 3; index += 1) {
+    const difference = leftParts[index] - rightParts[index];
+    if (difference !== 0) return difference;
+  }
+  return 0;
+}
+
+function readDesktopPackages(root) {
+  return desktopPackagePaths.map((relativePath) => {
+    const path = resolve(root, relativePath);
+    return {
+      path,
+      relativePath,
+      value: JSON.parse(readFileSync(path, "utf8")),
+    };
+  });
+}
+
+export function parseStagingTag(value) {
+  const tag = String(value ?? "").trim();
+  const match = tag.match(stagingTagPattern);
+  if (!match) {
+    throw new Error(
+      `Invalid staging tag: ${tag || "(empty)"} (expected vX.Y.Z-staging.N)`,
+    );
+  }
+
+  return {
+    tag,
+    version: `${match[1]}-staging.${match[5]}`,
+    baseVersion: match[1],
+    sequence: match[5],
+  };
+}
+
+export function resolveStagingVersion({ root = repoRoot, tag }) {
+  const resolved = parseStagingTag(tag);
+  const packages = readDesktopPackages(root);
+  const sourceVersions = [...new Set(packages.map((entry) => entry.value.version))];
+
+  if (
+    sourceVersions.length !== 1 ||
+    !stableVersionPattern.test(sourceVersions[0] ?? "")
+  ) {
+    const details = packages
+      .map((entry) => `${entry.relativePath}=${entry.value.version ?? "(missing)"}`)
+      .join(", ");
+    throw new Error(`Desktop source versions must match and be stable: ${details}`);
+  }
+
+  const sourceVersion = sourceVersions[0];
+  if (compareStableVersions(resolved.baseVersion, sourceVersion) <= 0) {
+    throw new Error(
+      `Staging base version ${resolved.baseVersion} must be newer than source version ${sourceVersion}`,
+    );
+  }
+
+  return { ...resolved, sourceVersion };
+}
+
+export function applyStagingVersion({ root = repoRoot, tag }) {
+  const resolved = resolveStagingVersion({ root, tag });
+  const packages = readDesktopPackages(root);
+
+  for (const entry of packages) {
+    entry.value.version = resolved.version;
+    writeFileSync(entry.path, `${JSON.stringify(entry.value, null, 2)}\n`, "utf8");
+  }
+
+  return {
+    ...resolved,
+    files: packages.map((entry) => entry.relativePath),
+  };
+}
+
+function optionValue(args, option) {
+  const index = args.indexOf(option);
+  return index >= 0 ? args[index + 1] : null;
+}
+
+function writeGitHubOutput(path, result) {
+  appendFileSync(
+    path,
+    [
+      `tag=${result.tag}`,
+      `version=${result.version}`,
+      `base_version=${result.baseVersion}`,
+      `sequence=${result.sequence}`,
+      `source_version=${result.sourceVersion}`,
+      "",
+    ].join("\n"),
+    "utf8",
+  );
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const tag = optionValue(args, "--tag") ?? process.env.STAGING_TAG;
+  const outputPath = optionValue(args, "--github-output");
+  const result = args.includes("--write")
+    ? applyStagingVersion({ tag })
+    : resolveStagingVersion({ tag });
+
+  if (outputPath) writeGitHubOutput(outputPath, result);
+  console.log(JSON.stringify({ ok: true, ...result }, null, 2));
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+  }
+}

--- a/scripts/release/staging-version.test.mjs
+++ b/scripts/release/staging-version.test.mjs
@@ -1,0 +1,99 @@
+import assert from "node:assert/strict";
+import { mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { afterEach, describe, it } from "node:test";
+
+import {
+  applyStagingVersion,
+  parseStagingTag,
+  resolveStagingVersion,
+} from "./staging-version.mjs";
+
+const temporaryRoots = [];
+
+function createFixture(appVersion = "0.18.5", desktopVersion = appVersion) {
+  const root = mkdtempSync(resolve(tmpdir(), "openwork-staging-version-"));
+  temporaryRoots.push(root);
+  for (const [relativePath, version] of [
+    ["apps/app/package.json", appVersion],
+    ["apps/desktop/package.json", desktopVersion],
+  ]) {
+    const path = resolve(root, relativePath);
+    mkdirSync(resolve(path, ".."), { recursive: true });
+    writeFileSync(path, `${JSON.stringify({ name: relativePath, version }, null, 2)}\n`);
+  }
+  return root;
+}
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })),
+  );
+});
+
+describe("parseStagingTag", () => {
+  it("resolves a strict staging tag into the Electron version", () => {
+    assert.deepEqual(parseStagingTag("v0.18.6-staging.12"), {
+      tag: "v0.18.6-staging.12",
+      version: "0.18.6-staging.12",
+      baseVersion: "0.18.6",
+      sequence: "12",
+    });
+  });
+
+  it("rejects stable, loosely named, and zero-padded tags", () => {
+    for (const tag of [
+      "v0.18.6",
+      "0.18.6-staging.1",
+      "v0.18.6-rc.1",
+      "v0.18.6-staging.01",
+      "v0.18-staging.1",
+    ]) {
+      assert.throws(() => parseStagingTag(tag), /expected vX\.Y\.Z-staging\.N/);
+    }
+  });
+});
+
+describe("resolveStagingVersion", () => {
+  it("accepts a future stable base version", () => {
+    const root = createFixture();
+    const result = resolveStagingVersion({
+      root,
+      tag: "v0.19.0-staging.1",
+    });
+    assert.equal(result.baseVersion, "0.19.0");
+    assert.equal(result.sourceVersion, "0.18.5");
+  });
+
+  it("rejects current or older staging bases and mismatched source versions", () => {
+    const root = createFixture();
+    for (const tag of ["v0.18.5-staging.1", "v0.18.4-staging.1"]) {
+      assert.throws(
+        () => resolveStagingVersion({ root, tag }),
+        /must be newer than source version/,
+      );
+    }
+
+    const mismatchedRoot = createFixture("0.18.5", "0.18.6");
+    assert.throws(
+      () => resolveStagingVersion({ root: mismatchedRoot, tag: "v0.18.7-staging.1" }),
+      /must match and be stable/,
+    );
+  });
+});
+
+describe("applyStagingVersion", () => {
+  it("stamps both desktop package versions without touching other metadata", () => {
+    const root = createFixture();
+    const result = applyStagingVersion({ root, tag: "v0.18.6-staging.3" });
+
+    assert.equal(result.version, "0.18.6-staging.3");
+    for (const relativePath of result.files) {
+      const value = JSON.parse(readFileSync(resolve(root, relativePath), "utf8"));
+      assert.equal(value.version, "0.18.6-staging.3");
+      assert.equal(value.name, relativePath);
+    }
+  });
+});


### PR DESCRIPTION
> **Review readiness — 2026-09-04: Incomplete.** This PR is open for review. Required current-head journey evidence and upstream review have not yet been verified in this cleanup. Historical checks below retain their original scope and do not establish current merge readiness.

## Summary
- add an isolated Stage Desktop App workflow for immutable vX.Y.Z-staging.N tags
- build public Electron artifacts for macOS, Linux, and Windows on arm64 and x64
- stamp the user-facing prerelease version while keeping macOS and Windows machine versions numeric
- publish only a GitHub prerelease behind the staging environment
- prevent staging tags from triggering the stable Release App workflow
- document environment setup, tag creation, promotion, recovery, and rollback

## Why
OpenWork needs installable release candidates that exercise the desktop packaging boundary without publishing npm packages, sidecar releases, Daytona snapshots, AUR updates, stable updater pointers, or production latest metadata.

## Scope
- public desktop distribution
- staging version resolver and tests
- GitHub Actions tag routing and prerelease publication
- operator documentation

## Out of scope
- Cloud and enterprise desktop distributions
- npm, sidecar, Daytona, AUR, or Den deployment
- automatic staging-to-stable promotion
- creation of the upstream GitHub staging environment and its reviewer policy

## Testing
### Ran
- node --test scripts/release/staging-version.test.mjs
- actionlint 1.7.12 on .github/workflows/staging-desktop.yml
- YAML parse of staging-desktop.yml and release-macos-aarch64.yml
- TARGET=aarch64-apple-darwin pnpm --filter @openwork/desktop build:electron through the isolated Hub wrapper
- electron-builder macOS arm64 directory packaging with buildVersion 0.18.6

### Result
- pass: 5 of 5 staging version tests
- pass: workflow syntax and expression lint
- pass: Electron renderer, server, sidecar, and bridge build
- pass: packaged arm64 Mach-O application
- pass: CFBundleShortVersionString=0.18.6-staging.1
- pass: CFBundleVersion=0.18.6

## CI status
- pass: i18n-audit
- pass: openwork-tests on Linux
- pass: openwork-tests on macOS
- pass: Vercel openwork-landing and preview comments
- external authorization blocker: Vercel previews for openwork-app, openwork-den, openwork-den-worker-proxy, and openwork-diagnostics report Authorization required to deploy from the fork
- deferred until the first post-merge staging tag: signed and notarized staging matrix, release asset upload, updater manifest merge, and environment-gated prerelease publication

## Manual verification
1. Agent inspected the locally packaged macOS arm64 bundle at revision b999ec53c4a90dc69baf653ac264989974c39b4c.
2. User confirmation is not yet recorded.
3. Before the first staging tag, create the staging environment and restrict it to v*-staging.* tags as documented.

## Evidence
N/A: build and release automation change; no user-interface flow or video was requested.

## Risk
- The full GitHub-hosted staging matrix and signing paths remain unproven until the first post-merge staging tag.
- Windows artifacts remain unsigned unless STAGING_SIGN_WINDOWS is enabled with valid SignPath configuration.
- A failed matrix leaves the GitHub release in draft for safe recovery.

## Rollback
Revert this PR to remove the staging lane. If a candidate has already been cut, withdraw its prerelease while retaining the immutable tag as an audit record.