### PR TITLE
fix(desktop): lock enterprise organization server

### DIFF
--- a/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
+++ b/apps/app/src/react-app/domains/cloud/forced-signin-page.tsx
@@ -273,6 +273,8 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
     };
   }, []);
 
+  // The forced sign-in gate is configured by the enterprise installer.
+  // Do not expose the organization server editor on this managed surface.
   return (
     <DenSignInSurface
       variant="fullscreen"
@@ -290,11 +292,7 @@ export function ForcedSigninPage({ developerMode }: ForcedSigninPageProps) {
       sessionBusy={denAuth.status === "checking"}
       manualAuthOpen={manualAuthOpen}
       manualAuthInput={manualAuthInput}
-      organizationServerBusy={baseUrlBusy}
-      organizationServerError={baseUrlError}
-      organizationServerUrl={baseUrl}
       onBaseUrlDraftInput={setBaseUrlDraft}
-      onOrganizationServerSave={applyBaseUrl}
       onResetBaseUrl={() => setBaseUrlDraft(baseUrl)}
       onApplyBaseUrl={() => {
         void applyBaseUrl();


### PR DESCRIPTION
> **Review readiness — 2026-09-04: Incomplete.** This PR is open for review. Required current-head journey evidence and upstream review have not yet been verified in this cleanup. Historical checks below retain their original scope and do not establish current merge readiness.

## Summary

- hide the organization server selector from the forced enterprise sign-in gate
- keep the installer/bootstrap-provided server as the sign-in target
- leave the standard welcome flow and its self-managed server selector unchanged

## Root cause

The enterprise forced-sign-in page passed the same server-edit callback used by configurable onboarding surfaces. That made the shared sign-in surface render a `Connected to … / Change` control even though the enterprise installer owns the endpoint.

## Impact

Users of enterprise-managed installs can sign in to the configured organization server without being offered a way to retarget the app from the forced sign-in screen.

## Checks

- `git diff --check`
- Hub worktree readiness check
- Product tests not run (level 0)
