### PR TITLE
fix(app): render markdown tables in the artifact editor

### DIFF
--- a/apps/app/src/react-app/domains/session/artifacts/artifact-text-editor.tsx
+++ b/apps/app/src/react-app/domains/session/artifacts/artifact-text-editor.tsx
@@ -1,7 +1,7 @@
 /** @jsxImportSource react */
 import { useEffect, useRef } from "react";
 import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
-import { markdown } from "@codemirror/lang-markdown";
+import { markdown, markdownLanguage } from "@codemirror/lang-markdown";
 import { EditorState } from "@codemirror/state";
 import { EditorView, keymap, lineNumbers } from "@codemirror/view";
 import { cn } from "@/lib/utils";
@@ -38,7 +38,9 @@ export function ArtifactTextEditor(props: ArtifactTextEditorProps) {
           props.language === "markdown" ? [] : lineNumbers(),
           history(),
           keymap.of([...defaultKeymap, ...historyKeymap]),
-          props.language === "markdown" ? [markdown(), markdownLivePreview()] : [],
+          // GFM base so tables, strikethrough and task lists parse; the
+          // CommonMark default never produces Table nodes to render.
+          props.language === "markdown" ? [markdown({ base: markdownLanguage }), markdownLivePreview()] : [],
           EditorView.lineWrapping,
           EditorView.updateListener.of((update) => {
             if (update.docChanged) {

--- a/apps/app/src/react-app/domains/session/artifacts/markdown-live-preview.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/markdown-live-preview.ts
@@ -1,9 +1,10 @@
 import { ensureSyntaxTree, syntaxTree } from "@codemirror/language";
-import { type EditorState, type Extension, type Range, RangeSetBuilder, StateField } from "@codemirror/state";
+import { type EditorState, type Extension, Prec, type Range, RangeSetBuilder, StateField } from "@codemirror/state";
 import {
   Decoration,
   type DecorationSet,
   EditorView,
+  keymap,
   ViewPlugin,
   type ViewUpdate,
   WidgetType,
@@ -229,6 +230,18 @@ const livePreviewPlugin = ViewPlugin.fromClass(
 );
 
 /**
+ * Source lines of a pipe table map to rendered rows: header, delimiter, then one
+ * line per body row. Returns how far the clicked row sits from the table start so
+ * a click lands the cursor on the row the user aimed at.
+ */
+function clickedRowOffset(target: EventTarget | null): number {
+  const row = target instanceof Element ? target.closest("tr") : null;
+  const body = row?.parentElement;
+  if (!row || !(body instanceof HTMLTableSectionElement) || body.tagName !== "TBODY") return 0;
+  return Array.from(body.rows).indexOf(row) + 2;
+}
+
+/**
  * A GFM table rendered as one block. Pipe tables are unreadable as source once
  * they have more than a couple of columns, so the whole table is replaced by the
  * same HTML the rest of the app uses for markdown, and clicking it hands the
@@ -250,7 +263,9 @@ class TableWidget extends WidgetType {
     wrapper.innerHTML = renderMarkdownHtml(this.source, "surface");
     wrapper.addEventListener("mousedown", (event) => {
       event.preventDefault();
-      view.dispatch({ selection: { anchor: this.from } });
+      const doc = view.state.doc;
+      const lineNumber = doc.lineAt(this.from).number + clickedRowOffset(event.target);
+      view.dispatch({ selection: { anchor: doc.line(Math.min(lineNumber, doc.lines)).from } });
       view.focus();
     });
     return wrapper;
@@ -303,6 +318,35 @@ const tableField = StateField.define<DecorationSet>({
   provide: (field) => EditorView.decorations.from(field),
 });
 
+/**
+ * A rendered table has no text positions inside it, so vertical cursor motion
+ * steps straight over it. Arrowing into one puts the cursor on the nearest source
+ * line instead, which returns the table to editable markdown.
+ */
+function enterTable(view: EditorView, direction: 1 | -1): boolean {
+  const { state } = view;
+  const cursorLine = state.doc.lineAt(state.selection.main.head);
+  const probe = direction === 1 ? cursorLine.to + 1 : cursorLine.from - 1;
+  if (probe < 0 || probe > state.doc.length) return false;
+
+  let target: number | null = null;
+  state.field(tableField).between(probe, probe, (from, to) => {
+    target = direction === 1 ? from : state.doc.lineAt(to).from;
+    return false;
+  });
+  if (target === null) return false;
+
+  view.dispatch({ selection: { anchor: target }, scrollIntoView: true });
+  return true;
+}
+
+const tableKeymap = Prec.high(
+  keymap.of([
+    { key: "ArrowDown", run: (view) => enterTable(view, 1) },
+    { key: "ArrowUp", run: (view) => enterTable(view, -1) },
+  ]),
+);
+
 const livePreviewTheme = EditorView.baseTheme({
   ".cm-md-h1": { fontSize: "1.6em", fontWeight: "700", lineHeight: "1.3" },
   ".cm-md-h2": { fontSize: "1.4em", fontWeight: "700", lineHeight: "1.3" },
@@ -339,5 +383,5 @@ const livePreviewTheme = EditorView.baseTheme({
 });
 
 export function markdownLivePreview(): Extension {
-  return [tableField, livePreviewPlugin, livePreviewTheme];
+  return [tableField, tableKeymap, livePreviewPlugin, livePreviewTheme];
 }

--- a/apps/app/src/react-app/domains/session/artifacts/markdown-live-preview.ts
+++ b/apps/app/src/react-app/domains/session/artifacts/markdown-live-preview.ts
@@ -1,5 +1,5 @@
 import { ensureSyntaxTree, syntaxTree } from "@codemirror/language";
-import { type Extension, type Range, RangeSetBuilder } from "@codemirror/state";
+import { type EditorState, type Extension, type Range, RangeSetBuilder, StateField } from "@codemirror/state";
 import {
   Decoration,
   type DecorationSet,
@@ -8,6 +8,8 @@ import {
   type ViewUpdate,
   WidgetType,
 } from "@codemirror/view";
+
+import { renderMarkdownHtml } from "@/components/markdown/markdown-primitive";
 
 /**
  * Obsidian-style "merged" markdown view for CodeMirror 6: the document stays
@@ -53,8 +55,8 @@ class BulletWidget extends WidgetType {
 
 const BULLET = Decoration.replace({ widget: new BulletWidget() });
 
-function selectionTouchesRange(view: EditorView, from: number, to: number) {
-  for (const range of view.state.selection.ranges) {
+function selectionTouches(state: EditorState, from: number, to: number) {
+  for (const range of state.selection.ranges) {
     if (range.from <= to && range.to >= from) {
       return true;
     }
@@ -64,7 +66,7 @@ function selectionTouchesRange(view: EditorView, from: number, to: number) {
 
 function lineHasSelection(view: EditorView, pos: number) {
   const line = view.state.doc.lineAt(pos);
-  return selectionTouchesRange(view, line.from, line.to);
+  return selectionTouches(view.state, line.from, line.to);
 }
 
 function buildDecorations(view: EditorView): DecorationSet {
@@ -81,6 +83,12 @@ function buildDecorations(view: EditorView): DecorationSet {
       to,
       enter: (node) => {
         const name = node.name;
+
+        if (name === "Table") {
+          // Tables are handled as one block by `tableField`, so their pipes and
+          // cell markup are never half-rendered alongside it.
+          return false;
+        }
 
         if (/^ATXHeading[1-6]$/.test(name)) {
           const level = Number(name.slice(-1)) - 1;
@@ -220,6 +228,81 @@ const livePreviewPlugin = ViewPlugin.fromClass(
   },
 );
 
+/**
+ * A GFM table rendered as one block. Pipe tables are unreadable as source once
+ * they have more than a couple of columns, so the whole table is replaced by the
+ * same HTML the rest of the app uses for markdown, and clicking it hands the
+ * source back for editing.
+ */
+class TableWidget extends WidgetType {
+  constructor(readonly source: string, readonly from: number) {
+    super();
+  }
+
+  eq(other: TableWidget) {
+    return other.source === this.source && other.from === this.from;
+  }
+
+  toDOM(view: EditorView) {
+    const wrapper = document.createElement("div");
+    wrapper.className = "cm-md-table";
+    // renderMarkdownHtml sanitizes its output.
+    wrapper.innerHTML = renderMarkdownHtml(this.source, "surface");
+    wrapper.addEventListener("mousedown", (event) => {
+      event.preventDefault();
+      view.dispatch({ selection: { anchor: this.from } });
+      view.focus();
+    });
+    return wrapper;
+  }
+
+  ignoreEvent() {
+    return true;
+  }
+}
+
+/**
+ * Block decorations may not come from a view plugin, so table replacement lives
+ * in its own state field.
+ */
+function buildTableDecorations(state: EditorState): DecorationSet {
+  const builder = new RangeSetBuilder<Decoration>();
+  const tree = ensureSyntaxTree(state, state.doc.length, 200) ?? syntaxTree(state);
+
+  tree.iterate({
+    enter: (node) => {
+      if (node.name !== "Table") return;
+      // Selecting into a table returns it to editable markdown.
+      if (selectionTouches(state, node.from, node.to)) return false;
+
+      const source = state.doc.sliceString(node.from, node.to);
+      builder.add(
+        node.from,
+        node.to,
+        Decoration.replace({ widget: new TableWidget(source, node.from), block: true }),
+      );
+      return false;
+    },
+  });
+
+  return builder.finish();
+}
+
+const tableField = StateField.define<DecorationSet>({
+  create: (state) => buildTableDecorations(state),
+  update(value, transaction) {
+    if (
+      transaction.docChanged ||
+      transaction.selection ||
+      syntaxTree(transaction.startState) !== syntaxTree(transaction.state)
+    ) {
+      return buildTableDecorations(transaction.state);
+    }
+    return value;
+  },
+  provide: (field) => EditorView.decorations.from(field),
+});
+
 const livePreviewTheme = EditorView.baseTheme({
   ".cm-md-h1": { fontSize: "1.6em", fontWeight: "700", lineHeight: "1.3" },
   ".cm-md-h2": { fontSize: "1.4em", fontWeight: "700", lineHeight: "1.3" },
@@ -248,8 +331,13 @@ const livePreviewTheme = EditorView.baseTheme({
     fontFamily: "ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace",
   },
   ".cm-md-bullet": { paddingRight: "0.4em", color: "hsl(var(--muted-foreground))" },
+  // `contain: inline-size` keeps a wide table from stretching the editor (which
+  // would stop every other paragraph from wrapping); the table scrolls in place.
+  ".cm-md-table": { cursor: "text", overflowX: "auto", contain: "inline-size" },
+  // Size columns to their content rather than squeezing words apart in a narrow panel.
+  ".cm-md-table table": { fontSize: "0.95em", width: "max-content", minWidth: "100%" },
 });
 
 export function markdownLivePreview(): Extension {
-  return [livePreviewPlugin, livePreviewTheme];
+  return [tableField, livePreviewPlugin, livePreviewTheme];
 }

--- a/evals/flows/markdown-table-live-preview.flow.mjs
+++ b/evals/flows/markdown-table-live-preview.flow.mjs
@@ -1,0 +1,322 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+// Narration is loaded from the approved script (evals/voiceovers/markdown-table-live-preview.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("markdown-table-live-preview");
+
+const DOC = `# Recovery objectives
+
+| Service or obligation | Proposed RTO | Proposed RPO | Approval |
+|---|---:|---:|---|
+| Critical support intake | 4 hours | Not applicable | Joint |
+| OpenWork server | 8 hours | 24 hours | Genpact |
+
+Some prose between the two tables that should still wrap to the width of the panel.
+
+| Role | Name |
+|---|---|
+| Plan owner | Benjamin Shafii |
+`;
+
+const NEW_ROW = "\\n| Security owner | [CONFIRM] |";
+
+async function closeStaleDialogs(ctx) {
+  await ctx.eval(`(() => {
+    for (let index = 0; index < 3; index += 1) {
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
+    }
+    const active = document.activeElement;
+    if (active && typeof active.blur === "function") active.blur();
+    return true;
+  })()`);
+}
+
+async function bootPrecondition(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+  await closeStaleDialogs(ctx);
+  const state = await ctx.waitFor(
+    `(() => {
+      const route = String(window.__openworkControl.snapshot().route || "");
+      if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+      const action = window.__openworkControl.listActions().find((item) => item.id === "session.create_task");
+      return action && !action.disabled ? "ready" : null;
+    })()`,
+    { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+  );
+  if (state === "blocked") return "Profile is not onboarded (welcome/signin); this flow needs a workspace.";
+  return null;
+}
+
+/** Rendered tables plus any markdown source still visible as text. */
+const READ_EDITOR = `(() => {
+  const content = document.querySelector(".cm-editor .cm-content");
+  if (!content) return { ok: false, reason: "markdown editor is not mounted" };
+  const tables = Array.from(content.querySelectorAll("table"));
+  const lines = Array.from(content.querySelectorAll(".cm-line")).map((line) => (line.textContent || "").trim());
+  return {
+    ok: true,
+    tableCount: tables.length,
+    pipeLines: lines.filter((text) => text.startsWith("|")).length,
+    dividerLines: lines.filter((text) => /^\\|[\\s\\-:|]+\\|$/.test(text)).length,
+    rightAlignedCells: content.querySelectorAll('[style*="text-align: right"]').length,
+    headers: tables[0] ? Array.from(tables[0].querySelectorAll("th")).map((cell) => cell.textContent) : [],
+    lastTableRows: tables.length
+      ? Array.from(tables[tables.length - 1].querySelectorAll("tbody tr")).map((row) =>
+          Array.from(row.querySelectorAll("td")).map((cell) => cell.textContent))
+      : [],
+  };
+})()`;
+
+async function readEditor(ctx) {
+  return ctx.waitFor(
+    `(() => { const result = ${READ_EDITOR}; return result.ok ? result : null; })()`,
+    { timeoutMs: 30_000, label: "markdown artifact editor" },
+  );
+}
+
+async function openMarkdownArtifact(ctx) {
+  const hasSession = await ctx.eval(`String(window.__openworkControl.snapshot().route || "").includes("/session/ses_")`);
+  if (!hasSession) {
+    await ctx.control("session.create_task");
+    await ctx.waitFor(
+      `String(window.__openworkControl.snapshot().route || "").includes("/session/ses_")`,
+      { timeoutMs: 60_000, label: "session route after task creation" },
+    );
+  }
+
+  // The artifact seed action is registered by the side panel, so the panel has
+  // to be mounted before it can be called.
+  const seedReady = `window.__openworkControl.listActions().some((item) => item.id === "eval.artifact_tabs.seed_overflow" && !item.disabled)`;
+  if (!(await ctx.eval(seedReady))) {
+    await ctx.eval(`(() => {
+      const globe = Array.from(document.querySelectorAll("button"))
+        .find((button) => (button.getAttribute("aria-label") || "").startsWith("Browser"));
+      globe?.click();
+      return Boolean(globe);
+    })()`);
+    await ctx.waitFor(seedReady, { timeoutMs: 30_000, label: "artifact seed action enabled" });
+  }
+
+  await ctx.control("eval.artifact_tabs.seed_overflow", { count: 12 });
+  await ctx.waitFor(
+    `document.querySelectorAll('button[aria-label^="Select tab: overflow-tab"]').length >= 12`,
+    { timeoutMs: 30_000, label: "seeded artifact tabs" },
+  );
+  await ctx.eval(`(() => {
+    const tabs = Array.from(document.querySelectorAll('button[aria-label^="Select tab: overflow-tab"]'));
+    tabs[tabs.length - 1]?.click();
+    return tabs.length;
+  })()`);
+  await ctx.waitFor(
+    `Boolean(document.querySelector(".cm-editor .cm-content")) && Boolean(window.__artifactEditorView)`,
+    { timeoutMs: 30_000, label: "markdown editor mounted" },
+  );
+
+  // Load the document and park the cursor outside every table.
+  await ctx.eval(`(() => {
+    const view = window.__artifactEditorView;
+    view.dispatch({ changes: { from: 0, to: view.state.doc.length, insert: ${JSON.stringify(DOC)} } });
+    view.dispatch({ selection: { anchor: 0 } });
+    return true;
+  })()`);
+}
+
+export default {
+  id: "markdown-table-live-preview",
+  title: "Markdown tables render in the artifact editor while staying editable",
+  kind: "user-facing",
+  precondition: bootPrecondition,
+  steps: [
+    {
+      name: "Tables render instead of showing pipes",
+      run: async (ctx) => {
+        await ctx.prove("Both markdown tables draw as real tables with their column alignment", {
+          voiceover: vo[0],
+          action: async () => {
+            await closeStaleDialogs(ctx);
+            await openMarkdownArtifact(ctx);
+            await ctx.waitFor(
+              `document.querySelectorAll(".cm-editor .cm-content table").length === 2`,
+              { timeoutMs: 30_000, label: "both tables rendered" },
+            );
+          },
+          assert: async () => {
+            const editor = await readEditor(ctx);
+            ctx.assert(editor.tableCount === 2, `Expected 2 rendered tables, got ${editor.tableCount}.`);
+            ctx.assert(editor.pipeLines === 0, `Expected no raw pipe rows on screen, got ${editor.pipeLines}.`);
+            ctx.assert(editor.dividerLines === 0, `The dashed divider row is still visible as text (${editor.dividerLines} line(s)).`);
+            ctx.assert(
+              editor.rightAlignedCells >= 6,
+              `Expected the two right-aligned columns to keep their alignment, got ${editor.rightAlignedCells} right-aligned cells.`,
+            );
+            ctx.assert(
+              editor.headers.join("|") === "Service or obligation|Proposed RTO|Proposed RPO|Approval",
+              `Unexpected header cells: ${JSON.stringify(editor.headers)}.`,
+            );
+            ctx.log(`rendered ${editor.tableCount} tables, ${editor.rightAlignedCells} right-aligned cells`);
+          },
+          screenshot: {
+            name: "tables-rendered",
+            requireText: ["Recovery objectives", "Proposed RTO"],
+            rejectText: ["|---|", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Clicking a table hands back its markdown",
+      run: async (ctx) => {
+        await ctx.prove("Clicking a table returns its source with the cursor on the clicked row", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.eval(`(() => {
+              const wrapper = document.querySelectorAll(".cm-md-table")[1];
+              const rect = wrapper.getBoundingClientRect();
+              wrapper.dispatchEvent(new MouseEvent("mousedown", {
+                bubbles: true,
+                clientX: rect.x + 20,
+                clientY: rect.y + 20,
+              }));
+              return true;
+            })()`);
+            await ctx.waitFor(
+              `document.querySelectorAll(".cm-editor .cm-content table").length === 1`,
+              { timeoutMs: 30_000, label: "clicked table back to source" },
+            );
+          },
+          assert: async () => {
+            const editor = await readEditor(ctx);
+            ctx.assert(editor.tableCount === 1, `The untouched table should stay rendered; found ${editor.tableCount} tables.`);
+            ctx.assert(editor.pipeLines >= 3, `Expected the clicked table's markdown source, got ${editor.pipeLines} pipe rows.`);
+            const cursorLine = await ctx.eval(`(() => {
+              const view = window.__artifactEditorView;
+              return view.state.doc.lineAt(view.state.selection.main.head).text;
+            })()`);
+            ctx.assert(
+              cursorLine.startsWith("|"),
+              `Expected the cursor to land inside the table markdown, but it is on: "${cursorLine}".`,
+            );
+            ctx.log(`cursor landed on: ${cursorLine}`);
+          },
+          screenshot: {
+            name: "clicked-table-shows-source",
+            requireText: ["| Role | Name |"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "A typed row shows up in the rendered table",
+      run: async (ctx) => {
+        await ctx.prove("Adding a row in markdown and clicking away re-renders the table with it", {
+          voiceover: vo[2],
+          action: async () => {
+            await ctx.eval(`(() => {
+              const view = window.__artifactEditorView;
+              const doc = view.state.doc;
+              let insertAt = -1;
+              for (let number = 1; number <= doc.lines; number += 1) {
+                if (doc.line(number).text.startsWith("| Plan owner")) insertAt = doc.line(number).to;
+              }
+              if (insertAt < 0) return "row not found";
+              view.dispatch({ changes: { from: insertAt, insert: "${NEW_ROW}" } });
+              view.dispatch({ selection: { anchor: 0 } });
+              return "typed";
+            })()`);
+            await ctx.waitFor(
+              `document.querySelectorAll(".cm-editor .cm-content table").length === 2`,
+              { timeoutMs: 30_000, label: "edited table rendered again" },
+            );
+          },
+          assert: async () => {
+            const editor = await readEditor(ctx);
+            ctx.assert(editor.tableCount === 2, `Expected both tables rendered again, got ${editor.tableCount}.`);
+            ctx.assert(editor.pipeLines === 0, `Expected no raw pipe rows after clicking away, got ${editor.pipeLines}.`);
+            const rows = editor.lastTableRows.map((row) => row.join(" / "));
+            ctx.assert(
+              rows.some((row) => row.includes("Security owner") && row.includes("[CONFIRM]")),
+              `The typed row is missing from the rendered table: ${JSON.stringify(rows)}.`,
+            );
+            ctx.log(`rendered rows: ${JSON.stringify(rows)}`);
+            ctx.output("rendered-table-rows", JSON.stringify(editor.lastTableRows, null, 2));
+          },
+          screenshot: {
+            name: "typed-row-rendered",
+            requireText: ["Security owner"],
+            rejectText: ["| Security owner |", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "A wide table does not stop the prose wrapping",
+      run: async (ctx) => {
+        await ctx.prove("The table scrolls in its own box instead of stretching the document", {
+          voiceover: vo[3],
+          action: async () => {
+            await ctx.waitFor(
+              `Boolean(document.querySelector(".cm-editor .cm-scroller")) && document.querySelectorAll(".cm-md-table").length === 2`,
+              { timeoutMs: 30_000, label: "both rendered tables present" },
+            );
+            // Scroll the wide table sideways to reveal its last column. If the
+            // table were stretching the document this would scroll the whole
+            // editor instead.
+            await ctx.eval(`(() => {
+              const wrapper = document.querySelectorAll(".cm-md-table")[0];
+              wrapper.scrollLeft = wrapper.scrollWidth;
+              return wrapper.scrollLeft;
+            })()`);
+            await ctx.waitFor(
+              `document.querySelectorAll(".cm-md-table")[0].scrollLeft > 0`,
+              { timeoutMs: 10_000, label: "table scrolled in place" },
+            );
+          },
+          assert: async () => {
+            const layout = await ctx.eval(`(() => {
+              const scroller = document.querySelector(".cm-editor .cm-scroller");
+              const content = document.querySelector(".cm-editor .cm-content");
+              const wrapper = document.querySelectorAll(".cm-md-table")[0];
+              const table = wrapper.querySelector("table");
+              return {
+                scrollerClient: scroller.clientWidth,
+                scrollerScrollLeft: scroller.scrollLeft,
+                contentWidth: content.offsetWidth,
+                wrapperClient: wrapper.clientWidth,
+                wrapperScroll: wrapper.scrollWidth,
+                wrapperScrollLeft: wrapper.scrollLeft,
+                tableWidth: table.offsetWidth,
+              };
+            })()`);
+            ctx.assert(
+              layout.contentWidth <= layout.scrollerClient + 1,
+              `The table stretched the document: content is ${layout.contentWidth}px inside a ${layout.scrollerClient}px editor, so other paragraphs stop wrapping.`,
+            );
+            ctx.assert(
+              layout.tableWidth > layout.wrapperClient,
+              `This frame cannot witness the containment: the table (${layout.tableWidth}px) already fits its box (${layout.wrapperClient}px).`,
+            );
+            ctx.assert(
+              layout.wrapperScroll > layout.wrapperClient,
+              `The wide table is not scrollable in place (scrollWidth ${layout.wrapperScroll}px vs client ${layout.wrapperClient}px).`,
+            );
+            ctx.assert(
+              layout.wrapperScrollLeft > 0,
+              "Scrolling the table sideways had no effect, so its extra columns are unreachable.",
+            );
+            ctx.assert(
+              layout.scrollerScrollLeft === 0,
+              `Scrolling the table dragged the whole document sideways (editor scrollLeft ${layout.scrollerScrollLeft}px).`,
+            );
+            ctx.log(`editor ${layout.scrollerClient}px, content ${layout.contentWidth}px, table ${layout.tableWidth}px scrolled to ${layout.wrapperScrollLeft}px inside ${layout.wrapperClient}px`);
+          },
+          screenshot: {
+            name: "wide-table-contained",
+            requireText: ["wrap to the width of the panel"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/markdown-table-live-preview.flow.mjs
+++ b/evals/flows/markdown-table-live-preview.flow.mjs
@@ -169,16 +169,20 @@ export default {
         await ctx.prove("Clicking a table returns its source with the cursor on the clicked row", {
           voiceover: vo[1],
           action: async () => {
-            await ctx.eval(`(() => {
+            // Click a body row, not the header, so the cursor position proves the
+            // click landed on the row the user aimed at.
+            const clicked = await ctx.eval(`(() => {
               const wrapper = document.querySelectorAll(".cm-md-table")[1];
-              const rect = wrapper.getBoundingClientRect();
-              wrapper.dispatchEvent(new MouseEvent("mousedown", {
+              const row = wrapper.querySelectorAll("tbody tr")[0];
+              const rect = row.getBoundingClientRect();
+              row.querySelector("td").dispatchEvent(new MouseEvent("mousedown", {
                 bubbles: true,
                 clientX: rect.x + 20,
-                clientY: rect.y + 20,
+                clientY: rect.y + rect.height / 2,
               }));
-              return true;
+              return Array.from(row.querySelectorAll("td")).map((cell) => cell.textContent).join(" / ");
             })()`);
+            ctx.log(`clicked row: ${clicked}`);
             await ctx.waitFor(
               `document.querySelectorAll(".cm-editor .cm-content table").length === 1`,
               { timeoutMs: 30_000, label: "clicked table back to source" },
@@ -193,8 +197,8 @@ export default {
               return view.state.doc.lineAt(view.state.selection.main.head).text;
             })()`);
             ctx.assert(
-              cursorLine.startsWith("|"),
-              `Expected the cursor to land inside the table markdown, but it is on: "${cursorLine}".`,
+              cursorLine.startsWith("| Plan owner"),
+              `Expected the cursor on the clicked row's markdown, but it is on: "${cursorLine}".`,
             );
             ctx.log(`cursor landed on: ${cursorLine}`);
           },
@@ -250,11 +254,76 @@ export default {
       },
     },
     {
+      name: "Arrow keys step into a table instead of over it",
+      run: async (ctx) => {
+        await ctx.prove("Arrowing down into a table, and up into its last row, opens its markdown", {
+          voiceover: vo[3],
+          action: async () => {
+            // Both keyboard journeys run here because the assertion below has to
+            // stay read-only (the frame screenshot is taken after it).
+            const walk = await ctx.eval(`(async () => {
+              const view = window.__artifactEditorView;
+              const press = async (key) => {
+                view.contentDOM.dispatchEvent(new KeyboardEvent("keydown", { key, code: key, bubbles: true, cancelable: true }));
+                await new Promise((resolve) => setTimeout(resolve, 150));
+                return view.state.doc.lineAt(view.state.selection.main.head).text;
+              };
+
+              view.dispatch({ selection: { anchor: 0 } });
+              view.focus();
+              await new Promise((resolve) => setTimeout(resolve, 150));
+              const down = [];
+              for (let step = 0; step < 3; step += 1) down.push(await press("ArrowDown"));
+
+              view.dispatch({ selection: { anchor: view.state.doc.length } });
+              await new Promise((resolve) => setTimeout(resolve, 150));
+              const up = await press("ArrowUp");
+              return { down, up };
+            })()`, { awaitPromise: true });
+            ctx.log(`arrow down walk: ${JSON.stringify(walk.down)}`);
+            ctx.log(`arrow up landed on: ${walk.up}`);
+            ctx.assert(
+              walk.down.some((line) => line.startsWith("| Service or obligation")),
+              `Arrow down skipped the table instead of entering it: ${JSON.stringify(walk.down)}.`,
+            );
+            ctx.assert(
+              walk.up.startsWith("| Security owner"),
+              `Arrow up should land on the table's last row, but landed on: "${walk.up}".`,
+            );
+          },
+          assert: async () => {
+            const editor = await readEditor(ctx);
+            ctx.assert(
+              editor.tableCount === 1,
+              `Only the table holding the cursor should be source; found ${editor.tableCount} rendered tables.`,
+            );
+            ctx.assert(
+              editor.pipeLines >= 4,
+              `Expected the entered table's markdown on screen, got ${editor.pipeLines} pipe rows.`,
+            );
+            ctx.log(`${editor.tableCount} table still rendered, ${editor.pipeLines} pipe rows shown as source`);
+          },
+          screenshot: {
+            name: "arrow-keys-enter-table",
+            requireText: ["| Security owner |"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
       name: "A wide table does not stop the prose wrapping",
       run: async (ctx) => {
         await ctx.prove("The table scrolls in its own box instead of stretching the document", {
-          voiceover: vo[3],
+          voiceover: vo[4],
           action: async () => {
+            // The previous frame left the cursor inside a table; move it out so
+            // both tables are rendered again.
+            await ctx.eval(`(() => {
+              const view = window.__artifactEditorView;
+              view.dispatch({ selection: { anchor: 0 } });
+              return true;
+            })()`);
             await ctx.waitFor(
               `Boolean(document.querySelector(".cm-editor .cm-scroller")) && document.querySelectorAll(".cm-md-table").length === 2`,
               { timeoutMs: 30_000, label: "both rendered tables present" },

--- a/evals/voiceovers/markdown-table-live-preview.md
+++ b/evals/voiceovers/markdown-table-live-preview.md
@@ -1,6 +1,6 @@
 # markdown-table-live-preview — Markdown tables render in the artifact editor
 
-This user-facing proof drives the OpenWork desktop app over CDP, loads a document with markdown tables into a markdown artifact, and shows that the tables render as real tables while the document stays editable, that clicking one hands its markdown source back, and that a wide table no longer stops the surrounding prose from wrapping.
+This user-facing proof drives the OpenWork desktop app over CDP, loads a document with markdown tables into a markdown artifact, and shows that the tables render as real tables while the document stays editable, that clicking or arrowing into one hands its markdown source back, and that a wide table no longer stops the surrounding prose from wrapping.
 
 1. A markdown document with two tables opens in an artifact, and both tables are drawn as real tables with header rows, ruled cells, and the right-hand columns aligned to the right the way the markdown asked for. None of the pipe characters or the dashed divider row are left on screen as text.
 
@@ -8,4 +8,6 @@ This user-facing proof drives the OpenWork desktop app over CDP, loads a documen
 
 3. Typing another row into that markdown and then clicking away renders the table again with the new row in place, which is the loop someone actually uses to fill in a table by hand.
 
-4. The wide table keeps its own column widths and scrolls inside its own box instead of stretching the document, so the paragraph next to it still wraps to the width of the panel.
+4. Arrow keys reach a table as well: pressing down from the lines above steps into the table's markdown instead of skipping over the whole block, and pressing up from the line below lands on its last row, so anyone editing with the keyboard can still get into a rendered table.
+
+5. The wide table keeps its own column widths and scrolls inside its own box instead of stretching the document, so the paragraph next to it still wraps to the width of the panel.

--- a/evals/voiceovers/markdown-table-live-preview.md
+++ b/evals/voiceovers/markdown-table-live-preview.md
@@ -1,0 +1,11 @@
+# markdown-table-live-preview — Markdown tables render in the artifact editor
+
+This user-facing proof drives the OpenWork desktop app over CDP, loads a document with markdown tables into a markdown artifact, and shows that the tables render as real tables while the document stays editable, that clicking one hands its markdown source back, and that a wide table no longer stops the surrounding prose from wrapping.
+
+1. A markdown document with two tables opens in an artifact, and both tables are drawn as real tables with header rows, ruled cells, and the right-hand columns aligned to the right the way the markdown asked for. None of the pipe characters or the dashed divider row are left on screen as text.
+
+2. Clicking a table hands its markdown straight back, pipes and all, with the cursor waiting on the row that was clicked. The other table on the page stays rendered, so editing one table does not turn the whole document back into source.
+
+3. Typing another row into that markdown and then clicking away renders the table again with the new row in place, which is the loop someone actually uses to fill in a table by hand.
+
+4. The wide table keeps its own column widths and scrolls inside its own box instead of stretching the document, so the paragraph next to it still wraps to the width of the panel.


### PR DESCRIPTION
## Summary
- Markdown artifacts open in the CodeMirror "merged view" editor (`isDirectTextEdit` in `artifact-panel.tsx`), not in the `marked`-based renderer that chat and the surface use. That editor had two gaps:
  1. It was configured with `markdown()`, whose default base is **CommonMark**, so GFM tables were never even parsed — the syntax tree contained no `Table` nodes to render.
  2. The live-preview plugin decorates headings, emphasis, code, quotes, lists and links, but had no table case.
- Selecting into a table hands the markdown source back so the document stays editable: clicking a row lands the cursor on that row's source line, and arrow keys enter the table instead of skipping the whole block.
- Wide tables scroll inside their own box (`contain: inline-size`) so surrounding prose still wraps.

Measured in the running app before this change, with a two-table document loaded into a markdown artifact:

```
renderedTableElements: 0
pipeLines:             5     (including the raw |---|---|---|---| divider)
```

## Scope
- `artifact-text-editor.tsx`: use the GFM base grammar so `Table` nodes exist.
- `markdown-live-preview.ts`: replace each table with rendered HTML via a state field, map clicks to the aimed-at row, let ArrowUp/ArrowDown enter a replaced table, and keep a wide table from stretching the editor.
- New fraimz flow + approved voice-over (5 frames).

## Out of scope
- **Mermaid diagrams**, which were requested alongside this. They need a new (fairly heavy) dependency and are deliberately deferred to a follow-up PR; today a ` ```mermaid ` fence still renders as a code block.
- Chat and surface markdown, which already rendered tables correctly and are untouched.

## Notes on the approach
- **Why a state field rather than the existing view plugin:** CodeMirror refuses block-level decorations from a plugin (`"Block decorations may not be specified via plugins"`), and replacing a multi-line table requires exactly that. So table replacement lives in its own `StateField` and the view plugin skips `Table` subtrees.
- **Why reuse `renderMarkdownHtml`:** the widget renders the table with the same (DOMPurify-sanitized) renderer the rest of the app uses, so alignment, inline bold/links and theming match chat and the surface.
- **Why `contain: inline-size`:** a `max-content` table stretched `.cm-content` and silently stopped every other paragraph from wrapping. Containment keeps the table's width out of the editor's intrinsic size so the table scrolls in place and the prose keeps wrapping.
- **Why a high-precedence keymap:** a replaced table has no text positions inside it, so default vertical motion steps over the whole block. `ArrowDown`/`ArrowUp` handlers put the cursor on the nearest source line instead, which returns the table to editable markdown.

## Testing
### Ran
- `pnpm fraimz --flow markdown-table-live-preview --cdp-url http://127.0.0.1:9826`
- `pnpm fraimz --flow artifact-markdown-render` (regression over the same editor)
- `pnpm --filter @openwork/app test` / CI `openwork-tests` + `i18n-audit`

### Result
- **fraimz:** `PASSED` — 5 frames + voice-over coverage (render, click-to-row, type-and-re-render, arrow-keys enter, wide-table containment)
- **artifact-markdown-render:** PASSED
- **CI:** green (`openwork-tests` linux + macos, `i18n-audit`)

**The flow is a real regression test.** Stashing the click/arrow fix and reloading the renderer fails frame 2 with the cursor on the header row instead of the clicked body row, and arrowing down reports `["", "", "Some prose between the two tables…"]` — never entering the table. Restoring the change returns it to `PASSED`. (Vite HMR does not rebuild an already-mounted CodeMirror instance, so the renderer has to be reloaded for a revert to take effect.)

## Manual verification
1. `pnpm dev`, open a task, and open any `.md` artifact.
2. Paste a document containing a GFM table — it renders with a header row, ruled cells and right-aligned columns where the markdown asks for them.
3. Click a body row — the pipes come back with the cursor on that row, and the *other* tables on the page stay rendered.
4. From the line above a rendered table, press ArrowDown — the cursor enters the table's markdown. From the line below, ArrowUp lands on its last row.
5. Add a row, then click away — the table re-renders with the new row.
6. Make the panel narrow: the table keeps its column widths and scrolls sideways on its own, while the paragraphs beside it still wrap.

## Evidence
fraimz proof posted as a PR comment (5 validated frames).

## Risk
Low and contained to the markdown artifact editor. The grammar change also enables GFM strikethrough and task-list parsing, which the live preview already had a `Strikethrough` case for (previously dead code under CommonMark). The existing `artifact-markdown-render` flow covers the heading behaviour and still passes.

## Rollback
Revert these commits; markdown artifacts return to showing table markdown as raw pipes.