### PR TITLE
fix(app): restore the Extensions typecheck

### DIFF
--- a/apps/app/src/react-app/domains/settings/cloud/agent-access-card.tsx
+++ b/apps/app/src/react-app/domains/settings/cloud/agent-access-card.tsx
@@ -1,8 +1,9 @@
 /** @jsxImportSource react */
 import { useEffect, useState } from "react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ArrowUpRight, ChevronDown, ChevronRight } from "lucide-react";
 
 import { mintCloudControlMcpToken, readDenSettings } from "@/app/lib/den";
+import { openDesktopUrl } from "@/app/lib/desktop";
 import type {
   OpenworkCloudMcpEngineRefresh,
   OpenworkCloudMcpHealth,
@@ -31,6 +32,7 @@ import {
   cloudMcpProbeTraceLines,
 } from "@/react-app/domains/connections/cloud-mcp-diagnostics";
 import { readCloudMcpUserState } from "@/react-app/domains/connections/cloud-mcp-user-state";
+import { t } from "@/i18n";
 
 const CLOUD_MCP_REFRESH_MARGIN_MS = 24 * 60 * 60 * 1000;
 

--- a/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/extensions-view.tsx
@@ -57,7 +57,7 @@ export function ExtensionsView(props: ExtensionsViewProps) {
     () => props.extensions.pluginList().length,
     [props.extensions],
   );
-  const initialFilter = props.initialSection === "mcp"
+  const initialFilter: ExtensionsInventoryFilter = props.initialSection === "mcp"
     ? "mcp"
     : props.initialSection === "skills"
       ? "skill"


### PR DESCRIPTION
## Summary
- Restores `@openwork/app` typecheck after #3184 by importing the missing `openDesktopUrl`, `t`, and `ArrowUpRight` symbols used by `ManageInDenButton`.
- Keeps `ManageInDenButton` and `denManageConnectionsUrl` intact because the button is currently unrendered, but its `connect.manage_in_den_web` i18n key exists.
- Types `initialFilter` as `ExtensionsInventoryFilter` instead of allowing it to infer as a bare `string`.

## Exact errors fixed
1. `apps/app/src/react-app/domains/settings/cloud/agent-access-card.tsx`: `Cannot find name openDesktopUrl`.
2. `apps/app/src/react-app/domains/settings/cloud/agent-access-card.tsx`: `Cannot find name t`.
3. `apps/app/src/react-app/domains/settings/cloud/agent-access-card.tsx`: `Cannot find name ArrowUpRight`.
4. `apps/app/src/react-app/domains/settings/pages/extensions-view.tsx` line ~77: `TS2345` because `initialFilter: string` was not assignable to `ExtensionsInventoryFilter`.
5. `apps/app/src/react-app/domains/settings/pages/extensions-view.tsx` line ~102: same `TS2345` for the second `mcpView(mcpRouting)` call.

## Verification
- `pnpm --filter @openwork/app typecheck` — passed with 0 TypeScript errors.
- `pnpm --filter @openwork/app test` — 456 pass, 0 fail, 1269 expect() calls across 86 files.

## Runtime proof
This is a compile-fix with no runtime path change: `ManageInDenButton` is currently not rendered anywhere, so there is no user-visible behavior change. No end-to-end frame proof accompanies this PR for that reason.