### PR TITLE
fix(composer): collapse pasted text only when it would scroll

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -9,6 +9,11 @@ import { t } from "@/i18n";
 import { ReactSessionComposer } from "@/react-app/domains/session/surface/composer/composer";
 import { encodeComposerMentionValue, type ComposerMentionKind } from "@/react-app/domains/session/surface/composer/mention-encoding";
 import {
+  createPastedTextChip,
+  resolvePastedTextPlaceholders,
+  type PastedTextChip,
+} from "@/react-app/domains/session/surface/composer/pasted-text";
+import {
   EMPTY_CONNECT_CAPABILITY_INVENTORY,
   listAssignedConnectCapabilities,
   type ConnectCapabilityInventory,
@@ -50,7 +55,7 @@ export type NewTaskComposerProps = {
   draft: string;
   onDraftChange: (value: string) => void;
   /** Called with a non-empty draft; the caller creates the session (and workspace if needed). */
-  onRunTask: () => void;
+  onRunTask: (resolvedDraft: string) => void;
   /** Disable submission while a default workspace is being prepared. */
   busy: boolean;
   context: NewTaskComposerContext | null;
@@ -75,6 +80,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const [mcpServers, setMcpServers] = useState<McpServerEntry[]>([]);
   const [mcpStatuses, setMcpStatuses] = useState<McpStatusMap>({});
   const [mcpStatus, setMcpStatus] = useState<string | null>(null);
+  const [pastedText, setPastedText] = useState<PastedTextChip[]>([]);
   const connectInventoryCacheRef = useRef<{ scope: string; promise: Promise<ConnectCapabilityInventory> } | null>(null);
   const context = props.context;
   const workspaceId = context?.workspaceId ?? null;
@@ -160,10 +166,28 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     setMentions((previous) => ({ ...previous, [value]: kind }));
   };
 
-  // No paste-chip store exists before the session does, so large pastes are
-  // inlined into the draft instead of becoming expandable chips.
   const handlePasteText = (text: string) => {
-    props.onDraftChange(props.draft ? `${props.draft}\n${text}` : text);
+    const pasted = createPastedTextChip(text);
+    setPastedText((current) => [...current, pasted]);
+    props.onDraftChange(`${props.draft}[pasted text ${pasted.label}]`);
+  };
+
+  const handleExpandPastedText = (id: string) => {
+    const pasted = pastedText.find((item) => item.id === id);
+    if (!pasted) return;
+    props.onDraftChange(props.draft.replace(`[pasted text ${pasted.label}]`, pasted.text));
+    setPastedText((current) => current.filter((item) => item.id !== id));
+  };
+
+  const handleRemovePastedText = (id: string) => {
+    const pasted = pastedText.find((item) => item.id === id);
+    if (!pasted) return;
+    props.onDraftChange(props.draft.replace(`[pasted text ${pasted.label}]`, ""));
+    setPastedText((current) => current.filter((item) => item.id !== id));
+  };
+
+  const handleRunTask = () => {
+    props.onRunTask(resolvePastedTextPlaceholders(props.draft, pastedText));
   };
 
   const handleUnsupportedFileLinks = (links: string[]) => {
@@ -176,7 +200,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       draft={props.draft}
       mentions={mentions}
       onDraftChange={props.onDraftChange}
-      onSend={props.onRunTask}
+      onSend={handleRunTask}
       onSteer={noop}
       onQueue={noop}
       onStop={noop}
@@ -220,9 +244,9 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       onInsertMention={handleInsertMention}
       onPasteText={handlePasteText}
       onUnsupportedFileLinks={handleUnsupportedFileLinks}
-      pastedText={[]}
-      onExpandPastedText={noop}
-      onRemovePastedText={noop}
+      pastedText={pastedText}
+      onExpandPastedText={handleExpandPastedText}
+      onRemovePastedText={handleRemovePastedText}
       isRemoteWorkspace={context?.isRemoteWorkspace ?? false}
       isSandboxWorkspace={context?.isSandboxWorkspace ?? false}
       onUploadInboxFiles={null}

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -70,8 +70,8 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
     })
     : DEFAULT_SUGGESTIONS;
 
-  const submit = () => {
-    const trimmedPrompt = prompt.trim();
+  const submit = (resolvedPrompt: string) => {
+    const trimmedPrompt = resolvedPrompt.trim();
     if (!trimmedPrompt || props.busy) return;
     props.onRunTask(trimmedPrompt);
   };

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -32,20 +32,13 @@ import {
   type ComposerSlashCommandOption,
 } from "./slash-command";
 import { encodeConnectSkillToken } from "./connect-skill-token";
-import { FILE_URL_RE, HTTP_URL_RE } from "./pasted-text";
+import { FILE_URL_RE, HTTP_URL_RE, type PastedTextChip } from "./pasted-text";
 
 type MentionItem = {
   id: string;
   kind: ComposerMentionKind;
   value: string;
   label: string;
-};
-
-type PastedTextChip = {
-  id: string;
-  label: string;
-  text: string;
-  lines: number;
 };
 
 type ToolMenuSettingsSection = "commands" | "skills" | "mcps" | "plugins";

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1301,8 +1301,9 @@ export function ReactSessionComposer(props: ComposerProps) {
                 // Plain text paste display is owned by PasteChipPlugin inside
                 // the Lexical editor: text collapses when it would exceed the
                 // editor's current width and maximum height, unless the whole
-                // string is a standalone HTTP(S) URL. Expanded pasted text gets
-                // the gray pasted-content styling. Do NOT duplicate that here.
+                // string is a standalone HTTP(S) URL. Text that fits, or is
+                // expanded from a chip, renders like normal text. Do NOT
+                // duplicate that here.
 
                 if (
                   text.trim() &&

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -1299,8 +1299,9 @@ export function ReactSessionComposer(props: ComposerProps) {
                 const text = event.clipboardData?.getData("text/plain") ?? "";
 
                 // Plain text paste display is owned by PasteChipPlugin inside
-                // the Lexical editor: >50 chars collapse unless the whole
-                // string is a standalone HTTP(S) URL; expanded pasted text gets
+                // the Lexical editor: text collapses when it would exceed the
+                // editor's current width and maximum height, unless the whole
+                // string is a standalone HTTP(S) URL. Expanded pasted text gets
                 // the gray pasted-content styling. Do NOT duplicate that here.
 
                 if (

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -36,7 +36,7 @@ import {
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./mention-encoding";
 import { parseConnectSkillToken } from "./connect-skill-token";
-import { shouldCollapsePastedText } from "./pasted-text";
+import { PASTED_TEXT_INLINE_STYLE, shouldCollapsePastedText, splitPastedText } from "./pasted-text";
 import { insertStyledPastedText } from "./pasted-text-insertion";
 
 type PastedTextToken = { label: string; lines: number; text: string };
@@ -869,6 +869,49 @@ function SubmitPlugin(props: { onSubmit: (options: { queue: boolean }) => void |
   return null;
 }
 
+function appendPastedTextMeasurement(element: HTMLElement, text: string) {
+  const paragraph = document.createElement("p");
+  for (const segment of splitPastedText(text)) {
+    if (segment.kind === "line-break") {
+      paragraph.append(document.createElement("br"));
+    } else if (segment.kind === "tab") {
+      paragraph.append(document.createTextNode("\t"));
+    } else {
+      const span = document.createElement("span");
+      span.style.cssText = PASTED_TEXT_INLINE_STYLE;
+      span.textContent = segment.text;
+      paragraph.append(span);
+    }
+  }
+  element.append(paragraph);
+}
+
+function pastedTextWouldOverflowEditor(text: string, editorElement: HTMLElement | null) {
+  if (!editorElement) return false;
+  const bounds = editorElement.getBoundingClientRect();
+  if (bounds.width <= 0) return false;
+
+  const measurement = editorElement.cloneNode(false);
+  if (!(measurement instanceof HTMLElement)) return false;
+  measurement.setAttribute("aria-hidden", "true");
+  measurement.style.position = "fixed";
+  measurement.style.left = "-10000px";
+  measurement.style.top = "0";
+  measurement.style.width = `${bounds.width}px`;
+  measurement.style.height = "auto";
+  measurement.style.minHeight = "0";
+  measurement.style.visibility = "hidden";
+  measurement.style.pointerEvents = "none";
+  appendPastedTextMeasurement(measurement, text);
+  document.body.append(measurement);
+
+  try {
+    return measurement.scrollHeight > measurement.clientHeight;
+  } finally {
+    measurement.remove();
+  }
+}
+
 function PasteChipPlugin(props: { onPasteText?: (text: string) => void }) {
   const [editor] = useLexicalComposerContext();
   const onPasteTextRef = useRef(props.onPasteText);
@@ -888,7 +931,8 @@ function PasteChipPlugin(props: { onPasteText?: (text: string) => void }) {
         if (event.clipboardData?.getData("text/uri-list").trim()) return false;
         const text = event.clipboardData?.getData("text/plain") ?? "";
         if (!text.trim()) return false;
-        if (shouldCollapsePastedText(text)) {
+        const wouldOverflowComposer = pastedTextWouldOverflowEditor(text, editor.getRootElement());
+        if (shouldCollapsePastedText(text, wouldOverflowComposer)) {
           if (!onPasteTextRef.current) return false;
           event.preventDefault();
           onPasteTextRef.current(text);

--- a/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/editor.tsx
@@ -36,8 +36,8 @@ import {
 import type { InitialConfigType } from "@lexical/react/LexicalComposer.js";
 import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMentionKind } from "./mention-encoding";
 import { parseConnectSkillToken } from "./connect-skill-token";
-import { PASTED_TEXT_INLINE_STYLE, shouldCollapsePastedText, splitPastedText } from "./pasted-text";
-import { insertStyledPastedText } from "./pasted-text-insertion";
+import { shouldCollapsePastedText, splitPastedText } from "./pasted-text";
+import { insertPastedText } from "./pasted-text-insertion";
 
 type PastedTextToken = { label: string; lines: number; text: string };
 
@@ -877,10 +877,7 @@ function appendPastedTextMeasurement(element: HTMLElement, text: string) {
     } else if (segment.kind === "tab") {
       paragraph.append(document.createTextNode("\t"));
     } else {
-      const span = document.createElement("span");
-      span.style.cssText = PASTED_TEXT_INLINE_STYLE;
-      span.textContent = segment.text;
-      paragraph.append(span);
+      paragraph.append(document.createTextNode(segment.text));
     }
   }
   element.append(paragraph);
@@ -939,7 +936,7 @@ function PasteChipPlugin(props: { onPasteText?: (text: string) => void }) {
           return true;
         }
         event.preventDefault();
-        return insertStyledPastedText(text);
+        return insertPastedText(text);
       },
       COMMAND_PRIORITY_CRITICAL,
     );
@@ -958,12 +955,12 @@ function replacePastedTextChip(label: string, text: string, button: HTMLButtonEl
   const nearest = $getNearestNodeFromDOMNode(button);
   if (nearest instanceof ComposerPastedTextNode && nearest.getPastedLabel() === label) {
     nearest.select(0, nearest.getTextContentSize());
-    return insertStyledPastedText(text);
+    return insertPastedText(text);
   }
   for (const node of $nodesOfType(ComposerPastedTextNode)) {
     if (node.getPastedLabel() !== label) continue;
     node.select(0, node.getTextContentSize());
-    return insertStyledPastedText(text);
+    return insertPastedText(text);
   }
   return false;
 }

--- a/apps/app/src/react-app/domains/session/surface/composer/pasted-text-insertion.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/pasted-text-insertion.ts
@@ -6,9 +6,9 @@ import {
   $isRangeSelection,
   type LexicalNode,
 } from "lexical";
-import { PASTED_TEXT_INLINE_STYLE, splitPastedText } from "./pasted-text";
+import { splitPastedText } from "./pasted-text";
 
-function createStyledPastedTextNodes(text: string) {
+function createPastedTextNodes(text: string) {
   const nodes: LexicalNode[] = [];
   for (const segment of splitPastedText(text)) {
     if (segment.kind === "line-break") {
@@ -16,19 +16,17 @@ function createStyledPastedTextNodes(text: string) {
     } else if (segment.kind === "tab") {
       nodes.push($createTabNode());
     } else {
-      const textNode = $createTextNode(segment.text);
-      textNode.setStyle(PASTED_TEXT_INLINE_STYLE);
-      nodes.push(textNode);
+      nodes.push($createTextNode(segment.text));
     }
   }
 
   return nodes;
 }
 
-export function insertStyledPastedText(text: string) {
+export function insertPastedText(text: string) {
   const selection = $getSelection();
   if (!$isRangeSelection(selection)) return false;
-  selection.insertNodes(createStyledPastedTextNodes(text));
+  selection.insertNodes(createPastedTextNodes(text));
   const nextSelection = $getSelection();
   if ($isRangeSelection(nextSelection)) nextSelection.setStyle("");
   return true;

--- a/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
@@ -1,4 +1,3 @@
-export const PASTE_CHIP_CHAR_THRESHOLD = 50;
 export const FILE_URL_RE = /^file:\/\//i;
 export const HTTP_URL_RE = /^https?:\/\//i;
 export const PASTED_TEXT_INLINE_STYLE = "background-color: rgba(229, 231, 235, 0.6); border-radius: 4px; box-decoration-break: clone; -webkit-box-decoration-break: clone; padding: 1px 2px;";
@@ -14,8 +13,8 @@ export function isStandaloneHttpUrl(text: string) {
   return HTTP_URL_RE.test(text) && !WHITESPACE_RE.test(text);
 }
 
-export function shouldCollapsePastedText(text: string) {
-  return text.length > PASTE_CHIP_CHAR_THRESHOLD && !isStandaloneHttpUrl(text);
+export function shouldCollapsePastedText(text: string, wouldOverflowComposer: boolean) {
+  return wouldOverflowComposer && !isStandaloneHttpUrl(text);
 }
 
 export function splitPastedText(text: string) {

--- a/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
@@ -1,6 +1,5 @@
 export const FILE_URL_RE = /^file:\/\//i;
 export const HTTP_URL_RE = /^https?:\/\//i;
-export const PASTED_TEXT_INLINE_STYLE = "background-color: rgba(229, 231, 235, 0.6); border-radius: 4px; box-decoration-break: clone; -webkit-box-decoration-break: clone; padding: 1px 2px;";
 
 export type PastedTextSegment =
   | { kind: "text"; text: string }

--- a/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
+++ b/apps/app/src/react-app/domains/session/surface/composer/pasted-text.ts
@@ -6,6 +6,13 @@ export type PastedTextSegment =
   | { kind: "line-break" }
   | { kind: "tab" };
 
+export type PastedTextChip = {
+  id: string;
+  label: string;
+  text: string;
+  lines: number;
+};
+
 const WHITESPACE_RE = /\s/;
 
 export function isStandaloneHttpUrl(text: string) {
@@ -14,6 +21,25 @@ export function isStandaloneHttpUrl(text: string) {
 
 export function shouldCollapsePastedText(text: string, wouldOverflowComposer: boolean) {
   return wouldOverflowComposer && !isStandaloneHttpUrl(text);
+}
+
+export function createPastedTextChip(text: string): PastedTextChip {
+  const id = `paste-${Math.random().toString(36).slice(2)}`;
+  const lines = text.split(/\r?\n/).length;
+  return {
+    id,
+    label: `${id.slice(-4)} · ${lines} lines`,
+    text,
+    lines,
+  };
+}
+
+export function resolvePastedTextPlaceholders(text: string, pastedText: readonly Pick<PastedTextChip, "label" | "text">[]) {
+  let resolved = text;
+  for (const part of pastedText) {
+    resolved = resolved.replace(`[pasted text ${part.label}]`, part.text);
+  }
+  return resolved;
 }
 
 export function splitPastedText(text: string) {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -46,6 +46,7 @@ import { decodeComposerMentionValue, encodeComposerMentionValue, type ComposerMe
 import { desktopBridge, openDesktopUrl } from "@/app/lib/desktop";
 import { parseSlashCommandInvocation } from "./composer/slash-command";
 import { connectSkillPrompt, parseConnectSkillToken } from "./composer/connect-skill-token";
+import { createPastedTextChip, resolvePastedTextPlaceholders } from "./composer/pasted-text";
 import { DevProfiler } from "@/react-app/shell/dev-profiler";
 import { PaperGrainGradient } from "@openwork/ui/react";
 import { useShellConfig } from "@/react-app/shell/shell-config";
@@ -1001,10 +1002,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
     });
     // Expand paste placeholders in resolvedText so the model receives
     // the actual pasted content instead of "[pasted text <label>]".
-    let resolved = text;
-    for (const part of pasteParts) {
-      resolved = resolved.replace(`[pasted text ${part.label}]`, part.text);
-    }
+    let resolved = resolvePastedTextPlaceholders(text, pasteParts);
     resolved = resolved.replace(/\[attachment [^\]]+\]/g, "");
     resolved = resolved.replace(/\[connect-skill [^\]]+\]/g, (match) => {
       const token = parseConnectSkillToken(match);
@@ -1326,10 +1324,9 @@ export function SessionSurface(props: SessionSurfaceProps) {
   };
 
   const handlePasteText = (text: string) => {
-    const id = `paste-${Math.random().toString(36).slice(2)}`;
-    const label = `${id.slice(-4)} · ${text.split(/\r?\n/).length} lines`;
-    setComposerPasteParts(props.sessionId, [...pasteParts, { id, label, text, lines: text.split(/\r?\n/).length }]);
-    setComposerDraft(props.sessionId, `${draft}[pasted text ${label}]`);
+    const pasted = createPastedTextChip(text);
+    setComposerPasteParts(props.sessionId, [...pasteParts, pasted]);
+    setComposerDraft(props.sessionId, `${draft}[pasted text ${pasted.label}]`);
   };
 
   const handleExpandPastedText = (id: string) => {

--- a/apps/app/tests/pasted-text-insertion.test.ts
+++ b/apps/app/tests/pasted-text-insertion.test.ts
@@ -1,12 +1,10 @@
 import { describe, expect, test } from "bun:test";
 import {
-  PASTED_TEXT_INLINE_STYLE,
   splitPastedText,
 } from "../src/react-app/domains/session/surface/composer/pasted-text";
 
-describe("styled pasted-text insertion", () => {
-  test("plans styled text nodes while preserving newlines and tabs", () => {
-    expect(PASTED_TEXT_INLINE_STYLE).toContain("background-color");
+describe("plain pasted-text insertion", () => {
+  test("plans normal text nodes while preserving newlines and tabs", () => {
     expect(splitPastedText("first\nsecond\tthird")).toEqual([
       { kind: "text", text: "first" },
       { kind: "line-break" },

--- a/apps/app/tests/pasted-text.test.ts
+++ b/apps/app/tests/pasted-text.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, test } from "bun:test";
 import {
+  createPastedTextChip,
+  resolvePastedTextPlaceholders,
   shouldCollapsePastedText,
 } from "../src/react-app/domains/session/surface/composer/pasted-text";
 
@@ -21,5 +23,15 @@ describe("pasted text collapse policy", () => {
     const longUrl = "https://example.com/long-url";
     expect(shouldCollapsePastedText(`${longUrl} `, true)).toBeTrue();
     expect(shouldCollapsePastedText(`Read ${longUrl}`, true)).toBeTrue();
+  });
+
+  test("creates a reusable chip and resolves it before submission", () => {
+    const pasted = createPastedTextChip("first\nsecond");
+    expect(pasted.id).toStartWith("paste-");
+    expect(pasted.label).toEndWith("· 2 lines");
+    expect(pasted.lines).toBe(2);
+    expect(
+      resolvePastedTextPlaceholders(`Before [pasted text ${pasted.label}] after`, [pasted]),
+    ).toBe("Before first\nsecond after");
   });
 });

--- a/apps/app/tests/pasted-text.test.ts
+++ b/apps/app/tests/pasted-text.test.ts
@@ -1,32 +1,25 @@
 import { describe, expect, test } from "bun:test";
 import {
-  PASTE_CHIP_CHAR_THRESHOLD,
   shouldCollapsePastedText,
 } from "../src/react-app/domains/session/surface/composer/pasted-text";
 
 describe("pasted text collapse policy", () => {
-  test("keeps text at or below the threshold directly in the text field", () => {
-    expect(PASTE_CHIP_CHAR_THRESHOLD).toBe(50);
-    expect(shouldCollapsePastedText("a".repeat(PASTE_CHIP_CHAR_THRESHOLD - 1))).toBeFalse();
-    expect(shouldCollapsePastedText("a".repeat(PASTE_CHIP_CHAR_THRESHOLD))).toBeFalse();
+  test("keeps text that fits without scrolling directly in the text field", () => {
+    expect(shouldCollapsePastedText("Short paste", false)).toBeFalse();
   });
 
-  test("collapses text above the threshold into an expandable chip", () => {
-    expect(shouldCollapsePastedText("a".repeat(PASTE_CHIP_CHAR_THRESHOLD + 1))).toBeTrue();
+  test("collapses text that would make the composer scroll", () => {
+    expect(shouldCollapsePastedText("Long paste", true)).toBeTrue();
   });
 
   test("does not collapse standalone HTTP or HTTPS URLs", () => {
-    expect(shouldCollapsePastedText(`https://example.com/${"a".repeat(PASTE_CHIP_CHAR_THRESHOLD)}`)).toBeFalse();
-    expect(shouldCollapsePastedText(`http://example.com/${"b".repeat(PASTE_CHIP_CHAR_THRESHOLD)}`)).toBeFalse();
+    expect(shouldCollapsePastedText("https://example.com/long-url", true)).toBeFalse();
+    expect(shouldCollapsePastedText("http://example.com/long-url", true)).toBeFalse();
   });
 
   test("only exempts URLs that are the whole paste with no whitespace", () => {
-    const longUrl = `https://example.com/${"c".repeat(PASTE_CHIP_CHAR_THRESHOLD)}`;
-    expect(shouldCollapsePastedText(`${longUrl} `)).toBeTrue();
-    expect(shouldCollapsePastedText(`Read ${longUrl}`)).toBeTrue();
-  });
-
-  test("does not collapse short multiline text", () => {
-    expect(shouldCollapsePastedText("first\nsecond\nthird")).toBeFalse();
+    const longUrl = "https://example.com/long-url";
+    expect(shouldCollapsePastedText(`${longUrl} `, true)).toBeTrue();
+    expect(shouldCollapsePastedText(`Read ${longUrl}`, true)).toBeTrue();
   });
 });

--- a/evals/flows/pasted-text-threshold.flow.mjs
+++ b/evals/flows/pasted-text-threshold.flow.mjs
@@ -6,8 +6,8 @@ const vo = await loadVoiceoverParagraphs("pasted-text-threshold");
 
 const EDITOR_SELECTOR = '[contenteditable="true"][data-lexical-editor="true"], [contenteditable="true"]';
 const EXPAND_BUTTON_SELECTOR = 'button[data-pasted-expand-label]';
-const LONG_PASTE = "This pasted message is longer than fifty characters and should collapse into a chip.";
-const SHORT_PASTE = "1234567890".repeat(5);
+const LONG_PASTE = "This pasted message should fill the composer without being shown in full. ".repeat(100);
+const FITTING_PASTE = "This pasted message fits in the composer.";
 const URL_PASTE = "https://example.com/pasted-text-threshold/abcdefghijklmnopqrstuvwxyz";
 
 async function waitForReadySession(ctx) {
@@ -107,7 +107,7 @@ async function composerInfo(ctx, text = "") {
 
 export default {
   id: "pasted-text-threshold",
-  title: "Pasted text collapses only above 50 characters and expanded pastes stay visibly distinct",
+  title: "Pasted text collapses only when it would make the composer scroll",
   kind: "user-facing",
   precondition: async (ctx) => {
     const state = await waitForReadySession(ctx);
@@ -119,7 +119,7 @@ export default {
     {
       name: "Long paste collapses into a chip",
       run: async (ctx) => {
-        await ctx.prove("Text longer than 50 characters is collapsed into one inline pasted-text chip", {
+        await ctx.prove("Text that exceeds the composer's visible capacity is collapsed into one inline pasted-text chip", {
           voiceover: vo[0],
           action: async () => {
             await createFreshTask(ctx);
@@ -193,29 +193,29 @@ export default {
       },
     },
     {
-      name: "Fifty characters stays expanded and gray",
+      name: "Fitting paste stays expanded and gray",
       run: async (ctx) => {
-        await ctx.prove("Text of exactly 50 characters stays expanded while showing pasted-content styling", {
+        await ctx.prove("Text that fits without scrolling stays expanded while showing pasted-content styling", {
           voiceover: vo[3],
           action: async () => {
             await createFreshTask(ctx);
-            await pasteComposer(ctx, SHORT_PASTE);
+            await pasteComposer(ctx, FITTING_PASTE);
             await ctx.waitFor(
               `(() => {
                 const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
-                return Boolean(editor && editor.innerText.includes(${JSON.stringify(SHORT_PASTE)}) && !editor.querySelector("button[data-pasted-expand-label]"));
+                return Boolean(editor && editor.innerText.includes(${JSON.stringify(FITTING_PASTE)}) && !editor.querySelector("button[data-pasted-expand-label]"));
               })()`,
-              { label: "50-character paste expanded" },
+              { label: "fitting paste expanded" },
             );
-            await ctx.waitFor(styledTextExpression(SHORT_PASTE), { label: "gray styling on 50-character paste" });
+            await ctx.waitFor(styledTextExpression(FITTING_PASTE), { label: "gray styling on fitting paste" });
           },
           assert: async () => {
-            const info = await composerInfo(ctx, SHORT_PASTE);
-            ctx.assert(info.chipCount === 0, `50-character paste incorrectly created ${info.chipCount} chip(s).`);
-            ctx.assert(info.text.includes(SHORT_PASTE), "50-character pasted text was not visible.");
-            ctx.assert(info.hasStyledTarget === true, `50-character paste did not have gray styling: ${JSON.stringify(info.styledMatches)}.`);
+            const info = await composerInfo(ctx, FITTING_PASTE);
+            ctx.assert(info.chipCount === 0, `Fitting paste incorrectly created ${info.chipCount} chip(s).`);
+            ctx.assert(info.text.includes(FITTING_PASTE), "Fitting pasted text was not visible.");
+            ctx.assert(info.hasStyledTarget === true, `Fitting paste did not have gray styling: ${JSON.stringify(info.styledMatches)}.`);
           },
-          screenshot: { name: "short-paste-gray", requireText: [SHORT_PASTE] },
+          screenshot: { name: "fitting-paste-gray", requireText: [FITTING_PASTE] },
         });
       },
     },

--- a/evals/flows/pasted-text-threshold.flow.mjs
+++ b/evals/flows/pasted-text-threshold.flow.mjs
@@ -66,15 +66,16 @@ async function pasteComposer(ctx, text) {
   return result;
 }
 
-function styledTextExpression(text) {
+function plainTextExpression(text) {
   return `(() => {
     const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
     if (!editor) return false;
-    return Array.from(editor.querySelectorAll("span")).some((element) => {
+    const hasHighlight = Array.from(editor.querySelectorAll("span")).some((element) => {
       if (!(element.textContent || "").includes(${JSON.stringify(text)})) return false;
       const background = getComputedStyle(element).backgroundColor;
       return Boolean(background && background !== "transparent" && background !== "rgba(0, 0, 0, 0)");
     });
+    return editor.innerText.includes(${JSON.stringify(text)}) && !hasHighlight;
   })()`;
 }
 
@@ -84,7 +85,7 @@ async function composerInfo(ctx, text = "") {
       const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
       if (!editor) return { ok: false, reason: "composer not found" };
       const button = editor.querySelector("button[data-pasted-expand-label]");
-      const styledMatches = Array.from(editor.querySelectorAll("span")).filter((element) => {
+      const highlightedMatches = Array.from(editor.querySelectorAll("span")).filter((element) => {
         if (${JSON.stringify(text)} && !(element.textContent || "").includes(${JSON.stringify(text)})) return false;
         const background = getComputedStyle(element).backgroundColor;
         return Boolean(background && background !== "transparent" && background !== "rgba(0, 0, 0, 0)");
@@ -98,8 +99,8 @@ async function composerInfo(ctx, text = "") {
         chipCount: editor.querySelectorAll("button[data-pasted-expand-label]").length,
         expandTitle: button ? button.title : "",
         expandAriaLabel: button ? button.getAttribute("aria-label") || "" : "",
-        hasStyledTarget: styledMatches.length > 0,
-        styledMatches,
+        hasHighlightedTarget: highlightedMatches.length > 0,
+        highlightedMatches,
       };
     })()`,
   );
@@ -167,9 +168,9 @@ export default {
       },
     },
     {
-      name: "Expanded chip text is gray and editable",
+      name: "Expanded chip text is plain and editable",
       run: async (ctx) => {
-        await ctx.prove("Expanding the chip restores the pasted text inline with gray pasted-content styling", {
+        await ctx.prove("Expanding the chip restores the pasted text as normal editable text without highlighting", {
           voiceover: vo[2],
           action: async () => {
             await ctx.trustedClick(EXPAND_BUTTON_SELECTOR);
@@ -180,22 +181,22 @@ export default {
               })()`,
               { label: "expanded pasted text without chip" },
             );
-            await ctx.waitFor(styledTextExpression(LONG_PASTE), { label: "gray styling on expanded paste" });
+            await ctx.waitFor(plainTextExpression(LONG_PASTE), { label: "normal styling on expanded paste" });
           },
           assert: async () => {
             const info = await composerInfo(ctx, LONG_PASTE);
             ctx.assert(info.chipCount === 0, `Expanded paste still had ${info.chipCount} chip(s).`);
             ctx.assert(info.text.includes(LONG_PASTE), "Expanded pasted text was not visible in the composer.");
-            ctx.assert(info.hasStyledTarget === true, `Expanded paste did not have gray styling: ${JSON.stringify(info.styledMatches)}.`);
+            ctx.assert(info.hasHighlightedTarget === false, `Expanded paste was still highlighted: ${JSON.stringify(info.highlightedMatches)}.`);
           },
-          screenshot: { name: "expanded-chip-gray", requireText: [LONG_PASTE] },
+          screenshot: { name: "expanded-chip-plain", requireText: [LONG_PASTE] },
         });
       },
     },
     {
-      name: "Fitting paste stays expanded and gray",
+      name: "Fitting paste stays expanded and plain",
       run: async (ctx) => {
-        await ctx.prove("Text that fits without scrolling stays expanded while showing pasted-content styling", {
+        await ctx.prove("Text that fits without scrolling stays expanded and looks like normal typed text", {
           voiceover: vo[3],
           action: async () => {
             await createFreshTask(ctx);
@@ -207,15 +208,15 @@ export default {
               })()`,
               { label: "fitting paste expanded" },
             );
-            await ctx.waitFor(styledTextExpression(FITTING_PASTE), { label: "gray styling on fitting paste" });
+            await ctx.waitFor(plainTextExpression(FITTING_PASTE), { label: "normal styling on fitting paste" });
           },
           assert: async () => {
             const info = await composerInfo(ctx, FITTING_PASTE);
             ctx.assert(info.chipCount === 0, `Fitting paste incorrectly created ${info.chipCount} chip(s).`);
             ctx.assert(info.text.includes(FITTING_PASTE), "Fitting pasted text was not visible.");
-            ctx.assert(info.hasStyledTarget === true, `Fitting paste did not have gray styling: ${JSON.stringify(info.styledMatches)}.`);
+            ctx.assert(info.hasHighlightedTarget === false, `Fitting paste was highlighted: ${JSON.stringify(info.highlightedMatches)}.`);
           },
-          screenshot: { name: "fitting-paste-gray", requireText: [FITTING_PASTE] },
+          screenshot: { name: "fitting-paste-plain", requireText: [FITTING_PASTE] },
         });
       },
     },

--- a/evals/flows/pasted-text-threshold.flow.mjs
+++ b/evals/flows/pasted-text-threshold.flow.mjs
@@ -35,6 +35,29 @@ async function waitForComposer(ctx) {
   });
 }
 
+async function openEmptyComposer(ctx) {
+  const target = await ctx.eval(
+    `(() => {
+      const route = window.__openworkControl.snapshot().route || "";
+      const match = route.match(/^\\/workspace\\/([^/]+)/);
+      if (!match) return { ok: false, reason: "workspace route not found", route };
+      const targetRoute = "/workspace/" + match[1] + "/session";
+      if (route !== targetRoute) window.location.hash = "#" + targetRoute;
+      return { ok: true, targetRoute };
+    })()`,
+  );
+  ctx.assert(target?.ok === true, `Could not open the empty-state composer: ${target?.reason ?? "unknown"}`);
+  await ctx.waitFor(
+    `window.__openworkControl.snapshot().route === ${JSON.stringify(target.targetRoute)}`,
+    { label: "empty workspace session route" },
+  );
+  await waitForComposer(ctx);
+  await ctx.waitFor(
+    `document.body.innerText.includes("What do you need done?")`,
+    { label: "empty-state composer heading" },
+  );
+}
+
 async function createFreshTask(ctx) {
   const previousRoute = await ctx.eval("window.__openworkControl.snapshot().route || ''");
   await ctx.control("session.create_task");
@@ -118,10 +141,59 @@ export default {
   },
   steps: [
     {
+      name: "Empty-state composer collapses long paste",
+      run: async (ctx) => {
+        await ctx.prove("The centered new-task composer collapses text that exceeds its visible capacity", {
+          voiceover: vo[0],
+          action: async () => {
+            await openEmptyComposer(ctx);
+            await pasteComposer(ctx, LONG_PASTE);
+            await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(EXPAND_BUTTON_SELECTOR)}))`, {
+              label: "empty-state pasted-text chip",
+            });
+          },
+          assert: async () => {
+            const info = await composerInfo(ctx);
+            ctx.assert(info.ok === true, info.reason ?? "Composer was not found.");
+            ctx.assert(info.chipCount === 1, `Expected one empty-state pasted-text chip, got ${info.chipCount}.`);
+            ctx.assert(info.text.includes("Pasted · 1 line"), `Chip label was not visible: ${JSON.stringify(info.text)}`);
+            ctx.assert(!info.text.includes(LONG_PASTE), "Empty-state pasted text was expanded instead of collapsed.");
+          },
+          screenshot: { name: "empty-state-long-paste-chip", requireText: ["What do you need done?", "Pasted · 1 line", "Expand"] },
+        });
+      },
+    },
+    {
+      name: "Empty-state chip expands to plain text",
+      run: async (ctx) => {
+        await ctx.prove("Expanding an empty-state paste chip restores normal editable text without highlighting", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.trustedClick(EXPAND_BUTTON_SELECTOR);
+            await ctx.waitFor(
+              `(() => {
+                const editor = document.querySelector(${JSON.stringify(EDITOR_SELECTOR)});
+                return Boolean(editor && editor.innerText.includes(${JSON.stringify(LONG_PASTE)}) && !editor.querySelector("button[data-pasted-expand-label]"));
+              })()`,
+              { label: "expanded empty-state pasted text" },
+            );
+            await ctx.waitFor(plainTextExpression(LONG_PASTE), { label: "normal styling on expanded empty-state paste" });
+          },
+          assert: async () => {
+            const info = await composerInfo(ctx, LONG_PASTE);
+            ctx.assert(info.chipCount === 0, `Expanded empty-state paste still had ${info.chipCount} chip(s).`);
+            ctx.assert(info.text.includes(LONG_PASTE), "Expanded empty-state pasted text was not visible.");
+            ctx.assert(info.hasHighlightedTarget === false, `Expanded empty-state paste was highlighted: ${JSON.stringify(info.highlightedMatches)}.`);
+          },
+          screenshot: { name: "empty-state-expanded-paste-plain", requireText: ["What do you need done?", LONG_PASTE] },
+        });
+      },
+    },
+    {
       name: "Long paste collapses into a chip",
       run: async (ctx) => {
         await ctx.prove("Text that exceeds the composer's visible capacity is collapsed into one inline pasted-text chip", {
-          voiceover: vo[0],
+          voiceover: vo[2],
           action: async () => {
             await createFreshTask(ctx);
             await pasteComposer(ctx, LONG_PASTE);
@@ -144,7 +216,7 @@ export default {
       name: "Chip hover says Expand",
       run: async (ctx) => {
         await ctx.prove("Hovering the pasted-text chip expansion control exposes the exact title Expand", {
-          voiceover: vo[1],
+          voiceover: vo[3],
           action: async () => {
             const point = await ctx.waitFor(
               `(() => {
@@ -171,7 +243,7 @@ export default {
       name: "Expanded chip text is plain and editable",
       run: async (ctx) => {
         await ctx.prove("Expanding the chip restores the pasted text as normal editable text without highlighting", {
-          voiceover: vo[2],
+          voiceover: vo[4],
           action: async () => {
             await ctx.trustedClick(EXPAND_BUTTON_SELECTOR);
             await ctx.waitFor(
@@ -197,7 +269,7 @@ export default {
       name: "Fitting paste stays expanded and plain",
       run: async (ctx) => {
         await ctx.prove("Text that fits without scrolling stays expanded and looks like normal typed text", {
-          voiceover: vo[3],
+          voiceover: vo[5],
           action: async () => {
             await createFreshTask(ctx);
             await pasteComposer(ctx, FITTING_PASTE);
@@ -224,7 +296,7 @@ export default {
       name: "Standalone URL never chips",
       run: async (ctx) => {
         await ctx.prove("A standalone HTTP URL with no whitespace remains an expanded link-like paste instead of a chip", {
-          voiceover: vo[4],
+          voiceover: vo[6],
           action: async () => {
             await createFreshTask(ctx);
             await pasteComposer(ctx, URL_PASTE);

--- a/evals/voiceovers/pasted-text-threshold.md
+++ b/evals/voiceovers/pasted-text-threshold.md
@@ -1,11 +1,15 @@
 # pasted-text-threshold — Pasted text stays tidy and recognizable
 
-1. I paste text that would make the composer scroll, and OpenWork keeps the composer tidy by showing it as a compact chip.
+1. Before selecting a task, I paste text that would make the centered composer scroll, and OpenWork shows it as a compact chip.
 
-2. I hover over the chip and see the label “Expand,” making its action clear.
+2. I expand that chip, and the full paste returns as normal editable text without a special highlight.
 
-3. I expand it, and the pasted text appears inline as normal editable text without a special highlight.
+3. Inside a task, I paste text that would make the composer scroll, and OpenWork keeps the composer tidy with the same compact chip.
 
-4. I paste text that fits within the composer, and it stays expanded with the same styling as text I type normally.
+4. I hover over the chip and see the label “Expand,” making its action clear.
 
-5. I paste a standalone URL with no spaces, and OpenWork recognizes it as a link rather than collapsing it into a chip.
+5. I expand it, and the pasted text appears inline as normal editable text without a special highlight.
+
+6. I paste text that fits within the composer, and it stays expanded with the same styling as text I type normally.
+
+7. I paste a standalone URL with no spaces, and OpenWork recognizes it as a link rather than collapsing it into a chip.

--- a/evals/voiceovers/pasted-text-threshold.md
+++ b/evals/voiceovers/pasted-text-threshold.md
@@ -4,8 +4,8 @@
 
 2. I hover over the chip and see the label “Expand,” making its action clear.
 
-3. I expand it, and the pasted text appears inline with a light gray background so it remains distinct from text I type normally.
+3. I expand it, and the pasted text appears inline as normal editable text without a special highlight.
 
-4. I paste text that fits within the composer, and it stays expanded while retaining the subtle gray pasted-text styling.
+4. I paste text that fits within the composer, and it stays expanded with the same styling as text I type normally.
 
 5. I paste a standalone URL with no spaces, and OpenWork recognizes it as a link rather than collapsing it into a chip.

--- a/evals/voiceovers/pasted-text-threshold.md
+++ b/evals/voiceovers/pasted-text-threshold.md
@@ -1,11 +1,11 @@
 # pasted-text-threshold — Pasted text stays tidy and recognizable
 
-1. I paste text longer than 50 characters, and OpenWork keeps the composer tidy by showing it as a compact chip.
+1. I paste text that would make the composer scroll, and OpenWork keeps the composer tidy by showing it as a compact chip.
 
 2. I hover over the chip and see the label “Expand,” making its action clear.
 
 3. I expand it, and the pasted text appears inline with a light gray background so it remains distinct from text I type normally.
 
-4. I paste text of 50 characters or fewer, and it stays expanded while retaining the subtle gray pasted-text styling.
+4. I paste text that fits within the composer, and it stays expanded while retaining the subtle gray pasted-text styling.
 
 5. I paste a standalone URL with no spaces, and OpenWork recognizes it as a link rather than collapsing it into a chip.


### PR DESCRIPTION
## Summary

- measure pasted text at the live composer width and maximum height
- collapse it into the existing pasted-text chip only when the rendered content would scroll
- keep standalone HTTP(S) URLs inline
- render fitting or expanded pasted content as normal editable text without a highlight
- support the same paste-chip flow in the welcome/chat-first and centered no-session composers
- resolve pre-session paste chips back to their full text before creating or sending the task
- update the existing unit and user-flow definitions for the new behavior

## Why

The previous fixed 50-character cutoff ignored the composer width and available vertical space, so relatively short pastes could become attachment-like chips even when they fit. Inline pasted text also received a gray background that made it look different from typed text.

## Checks

- Not run on the latest commit; the branch was pushed immediately at the author's request

## Manual verification

Not performed on the latest commit.

1. Paste content that fits below the composer maximum height and confirm it stays inline without highlighting.
2. Resize the composer and paste content that would exceed its maximum height; confirm one pasted-text chip appears.
3. Expand the chip and confirm the full content is editable and styled like normal typed text.
4. Paste a standalone long HTTP(S) URL and confirm it remains inline.
5. Repeat the long-paste flow in the welcome/chat-first composer and in the centered composer shown with no selected session.
6. Start a task from a collapsed pre-session paste and confirm the full pasted text reaches the created task.

## Risk and gaps

- Overflow is measured at paste time using the current composer width and CSS height cap.
- Focused tests, app typecheck, and the updated coded Electron journey were not run on the latest commit.
