### PR TITLE
fix(den): default managed downloads to enterprise

### DIFF
--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -17,7 +17,6 @@ import {
   mintDesktopConnectGrant,
   previewDesktopConnectGrant,
 } from "../../desktop-connect-grants.js"
-import { parseOrganizationPlan } from "../../entitlements.js"
 import { env } from "../../env.js"
 import { hashInstallLinkToken, mintOrganizationInstallLink } from "../../install-links.js"
 import { jsonValidator, orgRoleRoute, publicRoute, queryValidator } from "../../middleware/index.js"
@@ -95,10 +94,8 @@ const rateLimitedSchema = z.object({
 type InstallPlatform = z.infer<typeof installPlatformSchema>
 type ManagedDesktopDistribution = "cloud" | "enterprise"
 
-function managedDesktopDistribution(metadata: unknown): ManagedDesktopDistribution {
-  return env.orgMode === "multi_org" && parseOrganizationPlan(organizationMetadataInput(metadata)).tier !== "enterprise"
-    ? "cloud"
-    : "enterprise"
+function managedDesktopDistribution(): ManagedDesktopDistribution {
+  return "enterprise"
 }
 
 export type InstallExperienceDependencies = {
@@ -262,7 +259,6 @@ async function resolveInstallConfigForToken(token: string, request: Request) {
   return {
     config: buildInstallConfig({ organization: row.organization, request }),
     installLinkId: row.installLink.id,
-    organizationMetadata: row.organization.metadata,
     organizationSlug: row.organization.slug,
     installerReleaseTag: installerReleaseTagForMetadata(row.organization.metadata),
   }
@@ -391,7 +387,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         activationUrl: exchangeHandoff.activationUrl,
         activationExpiresAt: exchangeHandoff.connectExpiresAt,
         desktopVersion: resolved.installerReleaseTag.replace(/^v/i, ""),
-        distribution: managedDesktopDistribution(resolved.organizationMetadata),
+        distribution: managedDesktopDistribution(),
       })
     },
   )
@@ -514,7 +510,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
       }
 
       const platform = platformResult.data.platform
-      const distribution = managedDesktopDistribution(resolved.organizationMetadata)
+      const distribution = managedDesktopDistribution()
       const fileName = distribution === "cloud"
         ? cloudDesktopReleaseAssetName(platform, resolved.installerReleaseTag)
         : enterpriseDesktopReleaseAssetName(platform, resolved.installerReleaseTag)

--- a/ee/apps/den-api/src/routes/org/install-links.ts
+++ b/ee/apps/den-api/src/routes/org/install-links.ts
@@ -17,6 +17,7 @@ import {
   mintDesktopConnectGrant,
   previewDesktopConnectGrant,
 } from "../../desktop-connect-grants.js"
+import { parseOrganizationPlan } from "../../entitlements.js"
 import { env } from "../../env.js"
 import { hashInstallLinkToken, mintOrganizationInstallLink } from "../../install-links.js"
 import { jsonValidator, orgRoleRoute, publicRoute, queryValidator } from "../../middleware/index.js"
@@ -94,8 +95,10 @@ const rateLimitedSchema = z.object({
 type InstallPlatform = z.infer<typeof installPlatformSchema>
 type ManagedDesktopDistribution = "cloud" | "enterprise"
 
-function managedDesktopDistribution(): ManagedDesktopDistribution {
-  return env.orgMode === "multi_org" ? "cloud" : "enterprise"
+function managedDesktopDistribution(metadata: unknown): ManagedDesktopDistribution {
+  return env.orgMode === "multi_org" && parseOrganizationPlan(organizationMetadataInput(metadata)).tier !== "enterprise"
+    ? "cloud"
+    : "enterprise"
 }
 
 export type InstallExperienceDependencies = {
@@ -259,6 +262,7 @@ async function resolveInstallConfigForToken(token: string, request: Request) {
   return {
     config: buildInstallConfig({ organization: row.organization, request }),
     installLinkId: row.installLink.id,
+    organizationMetadata: row.organization.metadata,
     organizationSlug: row.organization.slug,
     installerReleaseTag: installerReleaseTagForMetadata(row.organization.metadata),
   }
@@ -387,7 +391,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
         activationUrl: exchangeHandoff.activationUrl,
         activationExpiresAt: exchangeHandoff.connectExpiresAt,
         desktopVersion: resolved.installerReleaseTag.replace(/^v/i, ""),
-        distribution: managedDesktopDistribution(),
+        distribution: managedDesktopDistribution(resolved.organizationMetadata),
       })
     },
   )
@@ -510,7 +514,7 @@ export function registerOrgInstallLinkRoutes<T extends { Variables: OrgRouteVari
       }
 
       const platform = platformResult.data.platform
-      const distribution = managedDesktopDistribution()
+      const distribution = managedDesktopDistribution(resolved.organizationMetadata)
       const fileName = distribution === "cloud"
         ? cloudDesktopReleaseAssetName(platform, resolved.installerReleaseTag)
         : enterpriseDesktopReleaseAssetName(platform, resolved.installerReleaseTag)


### PR DESCRIPTION
## Summary
- default every managed organization download to the Enterprise desktop distribution
- disable Cloud distribution selection for now
- keep the existing organization install and activation experience intact

## Checks
- Not run at the requester’s direction (level 0)
- Reviewed the focused diff and ran `git diff --check`

## Risk
- Hosted multi-org deployments will now serve the Enterprise desktop flavor to every organization until Cloud distribution selection is restored.