### PR TITLE
fix(mcp): gate cloud sync marker on live status

### DIFF
--- a/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-mcp-reconciler.ts
@@ -14,6 +14,7 @@ import type {
 import {
   CLOUD_MCP_SERVER_NAME,
   clearCloudMcpScopedMetadata,
+  clearCloudMcpSyncMarker,
   clearCloudMcpUserState,
   getCloudMcpScopeKey,
   isCloudMcpSyncMarkerFresh,
@@ -259,31 +260,41 @@ function shouldSkipForPrerequisite(input: CloudMcpReconcilerInput, scope: CloudM
   return null;
 }
 
-function writeUsableMarker(input: {
+function isLiveCloudMcpRegistrationCurrent(health: OpenworkCloudMcpHealth | null): boolean {
+  if (health?.engine.status !== "connected" || health.delivery.state !== "ready") return false;
+  return health.delivery.desiredRevision !== null &&
+    health.delivery.appliedRevision === health.delivery.desiredRevision;
+}
+
+function healthTokenExpiresAt(health: OpenworkCloudMcpHealth | null): string | null {
+  const expiresAt = health?.desired.token.metadata.expiresAt;
+  return typeof expiresAt === "string" && expiresAt.trim() ? expiresAt : null;
+}
+
+function writeConnectedMarker(input: {
   health: OpenworkCloudMcpHealth | null;
   scope: CloudMcpScope;
   expiresAt: string | null;
 }): boolean {
-  if (!input.health?.usable || !input.expiresAt) return false;
+  if (!isLiveCloudMcpRegistrationCurrent(input.health) || !input.expiresAt) {
+    clearCloudMcpSyncMarker(input.scope);
+    return false;
+  }
   writeCloudMcpSyncMarker({ ...input.scope, expiresAt: input.expiresAt });
   return true;
 }
 
-async function probeHealth(input: CloudMcpReconcilerInput, scope: CloudMcpScope, options?: { writeFreshnessMarker?: boolean }): Promise<CloudMcpOperationResult> {
+async function probeHealth(input: CloudMcpReconcilerInput, scope: CloudMcpScope): Promise<CloudMcpOperationResult> {
   const health = await input.client.getOpenworkCloudMcpHealth(
     scope.workspaceId,
     input.context.providerModel,
     input.probe ? { probe: true } : undefined,
   );
-  const marker = options?.writeFreshnessMarker ? readCloudMcpSyncMarker(scope) : null;
-  const markerWritten = options?.writeFreshnessMarker === true
-    ? writeUsableMarker({ health, scope, expiresAt: marker?.expiresAt ?? null })
-    : false;
   return {
     status: health.usable ? "ready" : "checked",
     health,
     attempts: 0,
-    markerWritten,
+    markerWritten: false,
     reminted: false,
   };
 }
@@ -305,18 +316,21 @@ async function mintAndPost(input: CloudMcpReconcilerInput, scope: CloudMcpScope)
 
 async function repairCloudMcp(input: CloudMcpReconcilerInput, scope: CloudMcpScope): Promise<CloudMcpOperationResult> {
   if (!input.force) {
-    const healthResult = await probeHealth(input, scope, { writeFreshnessMarker: true });
-    if (healthResult.health?.usable) return { ...healthResult, status: "unchanged" };
-  }
-
-  const marker = readCloudMcpSyncMarker(scope);
-  if (!input.force && marker && isCloudMcpSyncMarkerFresh({
-    expiresAt: marker.expiresAt,
-    now: input.now ?? Date.now(),
-    refreshMarginMs: input.refreshMarginMs,
-  })) {
-    const health = await input.client.getOpenworkCloudMcpHealth(scope.workspaceId, input.context.providerModel);
-    if (health.usable) return { status: "unchanged", health, attempts: 0, markerWritten: false, reminted: false };
+    const healthResult = await probeHealth(input, scope);
+    const marker = readCloudMcpSyncMarker(scope);
+    const registrationCurrent = isLiveCloudMcpRegistrationCurrent(healthResult.health);
+    if (!registrationCurrent) clearCloudMcpSyncMarker(scope);
+    const expiresAt = marker?.expiresAt ?? healthTokenExpiresAt(healthResult.health);
+    if (registrationCurrent && expiresAt && isCloudMcpSyncMarkerFresh({
+      expiresAt,
+      now: input.now ?? Date.now(),
+      refreshMarginMs: input.refreshMarginMs,
+    })) {
+      const markerWritten = marker
+        ? false
+        : writeConnectedMarker({ health: healthResult.health, scope, expiresAt });
+      return { ...healthResult, status: "unchanged", markerWritten };
+    }
   }
 
   const first = await mintAndPost(input, scope);
@@ -336,7 +350,7 @@ async function repairCloudMcp(input: CloudMcpReconcilerInput, scope: CloudMcpSco
     if (second.health) health = second.health;
   }
 
-  const markerWritten = writeUsableMarker({ health, scope, expiresAt: token.expiresAt });
+  const markerWritten = writeConnectedMarker({ health, scope, expiresAt: token.expiresAt });
   return {
     status: health?.usable ? "repaired" : "failed",
     health,

--- a/apps/app/tests/cloud-mcp-health.test.ts
+++ b/apps/app/tests/cloud-mcp-health.test.ts
@@ -57,9 +57,21 @@ function failure(code: string): OpenworkCloudMcpFailure {
   };
 }
 
-function health(input: { usable: boolean; failure?: OpenworkCloudMcpFailure | null; projectionChecked?: boolean }): OpenworkCloudMcpHealth {
+function health(input: {
+  usable: boolean;
+  failure?: OpenworkCloudMcpFailure | null;
+  projectionChecked?: boolean;
+  engineStatus?: OpenworkCloudMcpHealth["engine"]["status"];
+  deliveryState?: OpenworkCloudMcpHealth["delivery"]["state"];
+  appliedRevision?: string | null;
+}): OpenworkCloudMcpHealth {
   const usable = input.usable;
   const projectionChecked = input.projectionChecked ?? usable;
+  const engineStatus = input.engineStatus ?? (usable ? "connected" : "failed");
+  const deliveryState = input.deliveryState ?? (usable ? "ready" : "pending");
+  const appliedRevision = input.appliedRevision === undefined
+    ? deliveryState === "ready" ? "rev_desired" : null
+    : input.appliedRevision;
   return {
     schemaVersion: 1,
     phase: usable ? "ready" : "engine_failed",
@@ -75,14 +87,14 @@ function health(input: { usable: boolean; failure?: OpenworkCloudMcpFailure | nu
       token: { present: true, metadata: { expiresAt: token.expiresAt, scopes: "mcp:read mcp:write" } },
     },
     delivery: {
-      state: usable ? "ready" : "pending",
+      state: deliveryState,
       desiredRevision: "rev_desired",
-      appliedRevision: usable ? "rev_desired" : null,
+      appliedRevision,
       updatedAt: NOW,
-      appliedAt: usable ? NOW : null,
+      appliedAt: deliveryState === "ready" ? NOW : null,
       lastAttemptAt: NOW,
     },
-    engine: { status: usable ? "connected" : "failed" },
+    engine: { status: engineStatus },
     tools: {
       expected: ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"],
       present: usable ? ["openwork-cloud_search_capabilities", "openwork-cloud_execute_capability"] : [],
@@ -289,7 +301,50 @@ describe("OpenWork Cloud MCP reconciler", () => {
     expect(skipped.skippedReason).toBe("unsupported");
   });
 
-  test("writes marker only when returned health is usable", async () => {
+  test("a fresh marker short-circuits only when the live registration is connected", async () => {
+    for (const engineStatus of ["connected", "failed", "needs_auth", "needs_client_registration", "missing"] as const) {
+      installStorageStub();
+      writeCloudMcpSyncMarker({ ...scope, expiresAt: token.expiresAt });
+      let mintCount = 0;
+      let postCount = 0;
+      const liveHealth = health({
+        usable: engineStatus === "connected",
+        engineStatus,
+        deliveryState: engineStatus === "connected" ? "ready" : "failed",
+        appliedRevision: engineStatus === "connected" ? "rev_desired" : null,
+      });
+      const result = await runOpenworkCloudMcpReconciler({
+        mode: "repair",
+        client: {
+          baseUrl: scope.serverBaseUrl,
+          getOpenworkCloudMcpHealth: async () => liveHealth,
+          reconcileOpenworkCloudMcp: async () => {
+            postCount += 1;
+            return health({ usable: true });
+          },
+        },
+        context,
+        mintToken: async () => {
+          mintCount += 1;
+          return token;
+        },
+        now: NOW,
+        refreshMarginMs: 24 * 60 * 60 * 1000,
+      });
+
+      if (engineStatus === "connected") {
+        expect(result.status).toBe("unchanged");
+        expect(mintCount).toBe(0);
+        expect(postCount).toBe(0);
+      } else {
+        expect(result.status).toBe("repaired");
+        expect(mintCount).toBe(1);
+        expect(postCount).toBe(1);
+      }
+    }
+  });
+
+  test("writes the marker only after the desired config is live and connected", async () => {
     const client = {
       baseUrl: scope.serverBaseUrl,
       getOpenworkCloudMcpHealth: async () => health({ usable: false, failure: failure("cloud_status_missing") }),
@@ -308,6 +363,98 @@ describe("OpenWork Cloud MCP reconciler", () => {
       refreshMarginMs: 1,
     });
     expect(readCloudMcpSyncMarker(scope)?.expiresAt).toBe(token.expiresAt);
+  });
+
+  test("defers the marker across reload-required delivery until post-reload status is connected", async () => {
+    let liveHealth = health({
+      usable: false,
+      engineStatus: "connected",
+      deliveryState: "pending",
+      appliedRevision: "rev_previous",
+      failure: failure("cloud_registration_pending"),
+    });
+    let mintCount = 0;
+    let postCount = 0;
+    const client = {
+      baseUrl: scope.serverBaseUrl,
+      getOpenworkCloudMcpHealth: async () => liveHealth,
+      reconcileOpenworkCloudMcp: async () => {
+        postCount += 1;
+        return liveHealth;
+      },
+    };
+
+    const configured = await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client,
+      context,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+      force: true,
+      now: NOW,
+      refreshMarginMs: 24 * 60 * 60 * 1000,
+    });
+    expect(configured.markerWritten).toBe(false);
+    expect(readCloudMcpSyncMarker(scope)).toBeNull();
+
+    liveHealth = health({ usable: true });
+    const afterReload = await runOpenworkCloudMcpReconciler({
+      mode: "repair",
+      client,
+      context,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+      now: NOW,
+      refreshMarginMs: 24 * 60 * 60 * 1000,
+    });
+    expect(afterReload.status).toBe("unchanged");
+    expect(afterReload.markerWritten).toBe(true);
+    expect(readCloudMcpSyncMarker(scope)?.expiresAt).toBe(token.expiresAt);
+    expect(mintCount).toBe(1);
+    expect(postCount).toBe(1);
+  });
+
+  test("coalesces concurrent reconciliation attempts for repeated mounts", async () => {
+    let releasePost: (() => void) | null = null;
+    const postBlocked = new Promise<void>((resolve) => {
+      releasePost = resolve;
+    });
+    let mintCount = 0;
+    let postCount = 0;
+    const input = {
+      mode: "repair" as const,
+      client: {
+        baseUrl: scope.serverBaseUrl,
+        getOpenworkCloudMcpHealth: async () => health({ usable: false }),
+        reconcileOpenworkCloudMcp: async () => {
+          postCount += 1;
+          await postBlocked;
+          return health({ usable: true });
+        },
+      },
+      context,
+      mintToken: async () => {
+        mintCount += 1;
+        return token;
+      },
+      force: true,
+      refreshMarginMs: 1,
+    };
+
+    const first = runOpenworkCloudMcpReconciler(input);
+    const second = runOpenworkCloudMcpReconciler(input);
+    await Promise.resolve();
+    expect(mintCount).toBe(1);
+    releasePost?.();
+    const [firstResult, secondResult] = await Promise.all([first, second]);
+
+    expect(firstResult).toEqual(secondResult);
+    expect(postCount).toBe(1);
+    expect(mintCount).toBe(1);
   });
 
   test("auth failures remint exactly once", async () => {


### PR DESCRIPTION
> **Review readiness — 2026-09-04: Incomplete.** This PR is open for review. Required current-head journey evidence and upstream review have not yet been verified in this cleanup. Historical checks below retain their original scope and do not establish current merge readiness.

## Summary

- treat `openwork.den.mcp.sync` only as token/config freshness metadata
- require live `openwork-cloud` engine status `connected` with the desired revision applied before writing or retaining the marker
- reconcile fresh markers when live status is failed, needs auth/client registration, or missing
- defer marker creation across reload-required delivery and preserve in-flight reconciliation coalescing

## Root cause

Cloud MCP reconciliation could retain or write a fresh sync marker from configuration/token state even when OpenCode had not successfully registered `openwork-cloud`. Later mounts could interpret that marker as a successful sync and skip repair while the live MCP was failed or absent.

## Checks

- `bun test --isolate tests/cloud-mcp-health.test.ts` — 15 passed
- `bun test --isolate tests/cloud-mcp-maintenance-gate.test.ts` — 4 passed

## Scope and risk

The change is limited to Cloud MCP reconciliation and its focused tests. It does not change Den APIs, protocol routes, TLS, token formats, general MCP behavior, or endpoint fallback behavior. No end-to-end app run or manual UI verification was performed.