### PR TITLE
feat(diagnostics): add independent runtime MCP verification with detailed failure attribution

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -139,6 +139,7 @@ export default {
   "connect.diagnostics_check_agent_prompt_markers_effective": "Effective agent context markers",
   "connect.diagnostics_check_agent_resolution": "OpenWork agent configuration intent",
   "connect.diagnostics_check_agent_resolution_effective": "Effective OpenWork agent resolution",
+  "connect.diagnostics_check_cloud_endpoint_differential": "Runtime probe vs engine verdict",
   "connect.diagnostics_check_cloud_tool_catalog": "OpenWork Cloud tool catalog",
   "connect.diagnostics_check_connect_steering_scope": "Connect steering scope",
   "connect.diagnostics_check_engine_agent": "Effective engine agent (not queried)",

--- a/apps/app/src/react-app/domains/settings/pages/agent-context-diagnostics-report.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/agent-context-diagnostics-report.tsx
@@ -102,6 +102,7 @@ const CHECK_LABEL_KEYS: Record<AgentContextDiagnosticCheckId, string> = {
   "engine-mcp-sync": "connect.diagnostics_check_engine_mcp_sync",
   "engine-mcp-status": "connect.diagnostics_check_engine_mcp_status",
   "cloud-tool-catalog": "connect.diagnostics_check_cloud_tool_catalog",
+  "cloud-endpoint-differential": "connect.diagnostics_check_cloud_endpoint_differential",
   "organization-connections": "connect.diagnostics_check_organization_connections",
   "report-safety": "connect.diagnostics_check_report_safety",
 };

--- a/apps/app/tests/agent-context-diagnostics-report.test.tsx
+++ b/apps/app/tests/agent-context-diagnostics-report.test.tsx
@@ -138,6 +138,7 @@ function healthyReport(): AgentContextDiagnosticsReport {
     safety: {
       diagnosticsWorkspaceRuntimeConfigurationReadOnly: true,
       cloudCatalogToolsListPerformed: false,
+      cloudSessionCleanupRequested: false,
       directNonCloudMcpFetchPerformed: false,
       directMcpToolCallPerformed: false,
       directProviderOperationPerformed: false,
@@ -362,11 +363,14 @@ describe("AgentContextDiagnosticsReportView", () => {
     };
     expect(agentContextDiagnosticsReportSchema.safeParse(toolsWithoutProbe).success).toBe(false);
 
-    const cloudProbeWithoutEffectivePolicy = {
+    // Engine registration state and tool policy no longer gate the probe;
+    // handshake evidence only requires the retained runtime cloud entry.
+    const cloudProbeWithoutRetainedEntry = {
       ...healthyReport(),
       safety: { ...healthyReport().safety, cloudCatalogToolsListPerformed: true },
+      mcps: healthyReport().mcps.filter((mcp) => mcp.name !== "openwork-cloud"),
     };
-    expect(agentContextDiagnosticsReportSchema.safeParse(cloudProbeWithoutEffectivePolicy).success).toBe(false);
+    expect(agentContextDiagnosticsReportSchema.safeParse(cloudProbeWithoutRetainedEntry).success).toBe(false);
 
     const effectiveEvidenceWithoutEngineRead = {
       ...healthyReport(),

--- a/apps/server/src/agent-context-cloud-probe.test.ts
+++ b/apps/server/src/agent-context-cloud-probe.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, describe, expect, test } from "bun:test";
 
 import {
+  differentialCloudVerdict,
   probeOpenworkCloudCatalog,
+  type CloudCatalogProbe,
   type CloudCatalogProbeCode,
   type CloudCatalogProbeFetch,
   type ProbeOpenworkCloudCatalogInput,
@@ -26,10 +28,9 @@ function input(overrides: Partial<ProbeOpenworkCloudCatalogInput> = {}): ProbeOp
         "x-must-not-forward": "private-value",
       },
     },
-    toolPolicyStatus: "available",
-    toolPolicyProvenance: "authoritative-effective-engine",
-    registrationStatus: "connected",
+    engineRegistration: { status: "connected", source: "engine_status", recordAgeMs: 1_000 },
     requestId: "11111111-1111-4111-8111-111111111111",
+    env: {},
     ...values,
     ...(fetchImpl ? { fetchImpl: withCompletedHandshake(fetchImpl) } : {}),
   };
@@ -93,6 +94,7 @@ function initializeResponse(extraHeaders: Record<string, string> = {}): Response
 
 function withCompletedHandshake(toolsListFetch: CloudCatalogProbeFetch): CloudCatalogProbeFetch {
   return async (url, init) => {
+    if (init?.method === "DELETE") return new Response(null, { status: 204 });
     const body = requestPayload(init);
     if (body.method === "initialize") return initializeResponse();
     if (body.method === "notifications/initialized") return new Response(null, { status: 202 });
@@ -114,28 +116,37 @@ afterEach(() => {
 });
 
 describe("OpenWork Cloud catalog probe", () => {
-  test("performs initialize, initialized notification, and bounded tools/list with allowlisted headers", async () => {
+  test("performs initialize, initialized notification, bounded tools/list, and session cleanup with allowlisted headers", async () => {
     let calls = 0;
+    let deleteCalls = 0;
     let sharedSignal: AbortSignal | null = null;
     const fetchImpl: CloudCatalogProbeFetch = async (url, init) => {
       calls += 1;
       expect(url).toBe(ENDPOINT);
-      expect(init?.method).toBe("POST");
       expect(init?.redirect).toBe("manual");
       expect(init?.signal).toBeInstanceOf(AbortSignal);
       if (sharedSignal === null) sharedSignal = init?.signal ?? null;
       expect(init?.signal).toBe(sharedSignal);
       const headers = new Headers(init?.headers);
+      expect(headers.get("accept")).toBe("application/json, text/event-stream");
+      expect(headers.get("authorization")).toBe(TOKEN);
+      expect(headers.has("x-must-not-forward")).toBe(false);
+      expect(headers.has("x-initialize-secret")).toBe(false);
+      if (init?.method === "DELETE") {
+        deleteCalls += 1;
+        expect(init.body).toBeUndefined();
+        expect([...headers.keys()].sort()).toEqual(["accept", "authorization", "mcp-protocol-version", "mcp-session-id"]);
+        expect(headers.get("mcp-session-id")).toBe(SESSION_ID);
+        expect(headers.get("mcp-protocol-version")).toBe(PROTOCOL_VERSION);
+        return new Response(null, { status: 204 });
+      }
+      expect(init?.method).toBe("POST");
       const body = requestPayload(init);
       const isInitialize = body.method === "initialize";
       expect([...headers.keys()].sort()).toEqual(isInitialize
         ? ["accept", "authorization", "content-type"]
         : ["accept", "authorization", "content-type", "mcp-protocol-version", "mcp-session-id"]);
-      expect(headers.get("accept")).toBe("application/json, text/event-stream");
-      expect(headers.get("authorization")).toBe(TOKEN);
       expect(headers.get("content-type")).toBe("application/json");
-      expect(headers.has("x-must-not-forward")).toBe(false);
-      expect(headers.has("x-initialize-secret")).toBe(false);
       if (isInitialize) {
         expect(body).toEqual({
           jsonrpc: "2.0",
@@ -167,13 +178,36 @@ describe("OpenWork Cloud catalog probe", () => {
     const probeInput = input();
     probeInput.fetchImpl = fetchImpl;
     const observed = await probeOpenworkCloudCatalog(probeInput);
-    expect(calls).toBe(3);
+    expect(calls).toBe(4);
+    expect(deleteCalls).toBe(1);
     expect(observed).toEqual({
       performed: true,
       toolsListPerformed: true,
       status: "observed",
+      stage: "complete",
       code: "catalog_observed",
+      networkCode: null,
+      retryable: false,
+      runtimeFamily: "bun",
+      transport: "test-seam",
       toolIds: ["search_capabilities", "execute_capability"],
+      totalToolCount: 2,
+      requiredToolsPresent: true,
+      sessionEstablished: true,
+      cleanupAttempted: true,
+      cleanupSucceeded: true,
+      referenceId: null,
+      proxyConfigured: false,
+      extraCaConfigured: false,
+      steps: [
+        expect.stringContaining("initialize ok 200"),
+        expect.stringContaining("initialized_notification ok 202"),
+        expect.stringContaining("tools_list ok 200"),
+        expect.stringContaining("session_cleanup ok"),
+      ],
+      engineRegistrationStatus: "connected",
+      engineEvidenceSource: "engine_status",
+      engineEvidenceAgeMs: 1_000,
       durationMs: expect.any(Number),
       httpStatus: 200,
     });
@@ -193,24 +227,42 @@ describe("OpenWork Cloud catalog probe", () => {
     expect(observed.toolIds).toEqual(["search_capabilities", "execute_capability"]);
   });
 
-  test("requires the exact catalog and never reflects an unexpected tool ID", async () => {
+  test("requires both expected tools and never reflects a provider-controlled tool ID", async () => {
     const reflectedCredential = "ow_mcp_at_dGhpcy1jYW5hcnktbXVzdC1uZXZlci1iZS1yZXR1cm5lZA";
-    const cases = [
-      ["missing-tool", ["search_capabilities"]],
+    const missing = await probeOpenworkCloudCatalog(input({
+      requestId: "missing-tool",
+      fetchImpl: async () => jsonResponse("missing-tool", ["search_capabilities"]),
+    }));
+    expect(missing).toMatchObject({
+      performed: true,
+      status: "failed",
+      stage: "catalog_validation",
+      code: "required_tools_missing",
+      retryable: false,
+      toolIds: [],
+      totalToolCount: 1,
+      requiredToolsPresent: false,
+      httpStatus: 200,
+    });
+
+    // Additional provider tools are forward-compatible; only the expected
+    // allowlisted IDs and the aggregate count may be exported.
+    const futureCases = [
       ["unexpected-tool", ["search_capabilities", "execute_capability", "provider_extra"]],
       ["reflected-tool", ["search_capabilities", "execute_capability", reflectedCredential]],
     ] as const;
-    for (const [requestId, toolIds] of cases) {
+    for (const [requestId, toolIds] of futureCases) {
       const observed = await probeOpenworkCloudCatalog(input({
         requestId,
         fetchImpl: async () => jsonResponse(requestId, [...toolIds]),
       }));
       expect(observed).toMatchObject({
         performed: true,
-        status: "failed",
-        code: "invalid_catalog",
-        toolIds: [],
-        httpStatus: 200,
+        status: "observed",
+        code: "catalog_observed",
+        toolIds: ["search_capabilities", "execute_capability"],
+        totalToolCount: 3,
+        requiredToolsPresent: true,
       });
       expect(JSON.stringify(observed)).not.toContain(reflectedCredential);
       expect(JSON.stringify(observed)).not.toContain("provider_extra");
@@ -227,7 +279,7 @@ describe("OpenWork Cloud catalog probe", () => {
     });
   });
 
-  test("blocks remote workspaces, unavailable state, stale registration, and unsafe endpoints before fetch", async () => {
+  test("blocks remote workspaces, unavailable state, and unsafe endpoints before fetch", async () => {
     let calls = 0;
     const fetchImpl: CloudCatalogProbeFetch = async () => {
       calls += 1;
@@ -236,18 +288,9 @@ describe("OpenWork Cloud catalog probe", () => {
     const cases: Array<[Partial<ProbeOpenworkCloudCatalogInput>, CloudCatalogProbeCode]> = [
       [{ workspaceType: "remote" }, "remote_workspace_unavailable"],
       [{ runtimeConfigAvailable: false }, "runtime_config_unavailable"],
-      [{ registrationStatus: "failed" }, "registration_failed"],
-      [{ registrationStatus: "disabled" }, "registration_disabled"],
-      [{ registrationStatus: "needs-auth" }, "registration_needs_auth"],
-      [{ registrationStatus: "needs-client-registration" }, "registration_needs_client_registration"],
-      [{ registrationStatus: "not-recorded" }, "registration_not_recorded"],
       [{ config: null }, "cloud_mcp_missing"],
       [{ config: { type: "local", enabled: true } }, "cloud_mcp_not_remote"],
       [{ config: { type: "remote", enabled: false, url: ENDPOINT } }, "cloud_mcp_disabled"],
-      [{ toolPolicyStatus: "unavailable" }, "cloud_tool_policy_unavailable"],
-      [{ toolPolicyStatus: "denied" }, "cloud_tool_policy_denied"],
-      [{ toolPolicyProvenance: "passive-static-subset" }, "cloud_tool_policy_unavailable"],
-      [{ toolPolicyProvenance: "unavailable" }, "cloud_tool_policy_unavailable"],
       [{ config: { type: "remote", enabled: true, url: "https://app.openworklabs.com/api/den/mcp/agent?token=secret", headers: { Authorization: TOKEN } } }, "invalid_endpoint"],
       [{ config: { type: "remote", enabled: true, url: "https://app.openworklabs.com/api/den/mcp/agent/", headers: { Authorization: TOKEN } } }, "invalid_endpoint"],
       [{ config: { type: "remote", enabled: true, url: "https://app.openworklabs.com/api/den/mcp/agent/status", headers: { Authorization: TOKEN } } }, "invalid_endpoint"],
@@ -258,9 +301,36 @@ describe("OpenWork Cloud catalog probe", () => {
     for (const [overrides, code] of cases) {
       const blocked = await probeOpenworkCloudCatalog(input({ ...overrides, fetchImpl }));
       expect(blocked.performed).toBe(false);
+      expect(blocked.status).toBe("not-performed");
+      expect(blocked.stage).toBe("eligibility");
       expect(blocked.code).toBe(code);
+      expect(blocked.steps).toEqual([`eligibility ${code}`]);
     }
     expect(calls).toBe(0);
+  });
+
+  test("runs the probe despite failed, stale, or missing engine registration evidence", async () => {
+    const statuses = ["failed", "disabled", "needs-auth", "needs-client-registration", "not-recorded"] as const;
+    for (const status of statuses) {
+      let calls = 0;
+      const observed = await probeOpenworkCloudCatalog(input({
+        requestId: `despite-${status}`,
+        engineRegistration: { status, source: "engine_status", recordAgeMs: 2_000 },
+        fetchImpl: async () => {
+          calls += 1;
+          return jsonResponse(`despite-${status}`);
+        },
+      }));
+      expect(calls).toBe(1);
+      expect(observed).toMatchObject({
+        performed: true,
+        status: "observed",
+        code: "catalog_observed",
+        engineRegistrationStatus: status,
+        engineEvidenceSource: "engine_status",
+        engineEvidenceAgeMs: 2_000,
+      });
+    }
   });
 
   test("allows exact loopback and explicitly configured HTTPS origins only", async () => {
@@ -574,20 +644,22 @@ describe("OpenWork Cloud catalog probe", () => {
   });
 
   test("rejects JSON-RPC errors, wrong IDs, pagination, duplicate tools, and unsafe names", async () => {
-    const cases: Array<[string, unknown, CloudCatalogProbeCode]> = [
-      ["wrong-id", payload("different-id"), "invalid_response"],
-      ["rpc-error", { jsonrpc: "2.0", id: "rpc-error", error: { code: -1, message: "Bearer private" } }, "jsonrpc_error"],
-      ["pagination", { ...payload("pagination"), result: { tools: [], nextCursor: "secret-cursor" } }, "pagination_unsupported"],
-      ["duplicate", payload("duplicate", ["search_capabilities", "search_capabilities"]), "invalid_catalog"],
-      ["unsafe", payload("unsafe", ["search_capabilities\r\nspoof"]), "invalid_catalog"],
+    const cases: Array<[string, unknown, CloudCatalogProbeCode, CloudCatalogProbe["stage"]]> = [
+      ["wrong-id", payload("different-id"), "request_id_mismatch", "tools_list_protocol"],
+      ["rpc-error", { jsonrpc: "2.0", id: "rpc-error", error: { code: -1, message: "Bearer private" } }, "jsonrpc_error", "tools_list_protocol"],
+      ["pagination", { ...payload("pagination"), result: { tools: [], nextCursor: "secret-cursor" } }, "pagination_unsupported", "catalog_validation"],
+      ["duplicate", payload("duplicate", ["search_capabilities", "search_capabilities"]), "invalid_catalog", "catalog_validation"],
+      ["unsafe", payload("unsafe", ["search_capabilities\r\nspoof"]), "invalid_catalog", "catalog_validation"],
     ];
-    for (const [requestId, body, code] of cases) {
+    for (const [requestId, body, code, stage] of cases) {
       const observed = await probeOpenworkCloudCatalog(input({
         workspaceId: `ws_${requestId}`,
         requestId,
         fetchImpl: async () => new Response(JSON.stringify(body), { headers: { "content-type": "application/json" } }),
       }));
       expect(observed.code).toBe(code);
+      expect(observed.stage).toBe(stage);
+      expect(observed.retryable).toBe(false);
       expect(JSON.stringify(observed)).not.toContain("private");
       expect(JSON.stringify(observed)).not.toContain("secret-cursor");
     }
@@ -661,24 +733,271 @@ describe("OpenWork Cloud catalog probe", () => {
     expect(serialized).not.toContain("/Users/private");
   });
 
-  test("classifies allowlisted network causes without exposing raw errors", async () => {
-    const cases = [
-      ["ENOTFOUND", "dns_error"],
-      ["ECONNREFUSED", "connection_refused"],
-      ["ECONNRESET", "connection_reset"],
-      ["ERR_TLS_CERT_ALTNAME_INVALID", "tls_error"],
-      ["ERR_PROXY_AUTH_FAILED", "proxy_error"],
-    ] as const;
-    for (const [causeCode, expectedCode] of cases) {
+  test("classifies allowlisted network causes with stage and retryability, never raw errors", async () => {
+    const cases: Array<[string, CloudCatalogProbeCode, CloudCatalogProbe["networkCode"], CloudCatalogProbe["stage"], boolean]> = [
+      ["ENOTFOUND", "dns_error", "ENOTFOUND", "dns", false],
+      ["EAI_AGAIN", "dns_error", "EAI_AGAIN", "dns", true],
+      ["ECONNREFUSED", "connection_refused", "ECONNREFUSED", "connect", false],
+      ["ECONNRESET", "connection_reset", "ECONNRESET", "connect", true],
+      ["ETIMEDOUT", "timeout", "ETIMEDOUT", "connect", true],
+      ["UND_ERR_CONNECT_TIMEOUT", "timeout", "UND_ERR_CONNECT_TIMEOUT", "connect", true],
+      ["CERT_HAS_EXPIRED", "tls_error", "CERT_HAS_EXPIRED", "tls", false],
+      ["SELF_SIGNED_CERT_IN_CHAIN", "tls_error", "SELF_SIGNED_CERT_IN_CHAIN", "tls", false],
+      ["DEPTH_ZERO_SELF_SIGNED_CERT", "tls_error", "DEPTH_ZERO_SELF_SIGNED_CERT", "tls", false],
+      ["UNABLE_TO_VERIFY_LEAF_SIGNATURE", "tls_error", "UNABLE_TO_VERIFY_LEAF_SIGNATURE", "tls", false],
+      ["ERR_TLS_CERT_ALTNAME_INVALID", "tls_error", "ERR_TLS_CERT_ALTNAME_INVALID", "tls", false],
+      ["ERR_PROXY_AUTH_FAILED", "proxy_error", "PROXY_ERROR", "proxy", false],
+      ["EUNKNOWNISH", "network_error", "UNKNOWN_NETWORK_ERROR", "tools_list_request", false],
+    ];
+    for (const [causeCode, expectedCode, expectedNetworkCode, expectedStage, expectedRetryable] of cases) {
       const failed = await probeOpenworkCloudCatalog(input({
-        requestId: `network-${expectedCode}`,
+        requestId: `network-${causeCode}`,
         fetchImpl: async () => {
           throw new Error("RAW_NETWORK_SECRET", { cause: { code: causeCode } });
         },
       }));
-      expect(failed).toMatchObject({ performed: true, status: "failed", code: expectedCode });
+      expect(failed).toMatchObject({
+        performed: true,
+        status: "failed",
+        code: expectedCode,
+        networkCode: expectedNetworkCode,
+        stage: expectedStage,
+        retryable: expectedRetryable,
+      });
       expect(JSON.stringify(failed)).not.toContain("RAW_NETWORK_SECRET");
-      expect(JSON.stringify(failed)).not.toContain(causeCode);
     }
+  });
+
+  test("classifies HTTP statuses with deterministic retryability", async () => {
+    const cases: Array<[number, CloudCatalogProbeCode, boolean]> = [
+      [401, "unauthorized", false],
+      [403, "forbidden", false],
+      [404, "mcp_route_not_found", false],
+      [429, "rate_limited", true],
+      [502, "gateway_unavailable", true],
+      [503, "gateway_unavailable", true],
+      [504, "gateway_unavailable", true],
+      [500, "http_error", false],
+    ];
+    for (const [status, expectedCode, expectedRetryable] of cases) {
+      const failed = await probeOpenworkCloudCatalog(input({
+        requestId: `http-${status}`,
+        fetchImpl: async () => new Response(null, { status }),
+      }));
+      expect(failed).toMatchObject({
+        performed: true,
+        status: "failed",
+        stage: "tools_list_http",
+        code: expectedCode,
+        httpStatus: status,
+        retryable: expectedRetryable,
+        networkCode: null,
+      });
+    }
+  });
+
+  test("attributes initialize-phase failures to initialize stages", async () => {
+    const initFails: CloudCatalogProbeFetch = async () => new Response(null, { status: 401 });
+    const probeInput = input();
+    probeInput.fetchImpl = initFails;
+    const failed = await probeOpenworkCloudCatalog(probeInput);
+    expect(failed).toMatchObject({
+      performed: true,
+      status: "failed",
+      stage: "initialize_http",
+      code: "unauthorized",
+      httpStatus: 401,
+      toolsListPerformed: false,
+      sessionEstablished: false,
+      cleanupAttempted: false,
+      cleanupSucceeded: null,
+    });
+    expect(failed.steps).toEqual([expect.stringContaining("initialize failed unauthorized")]);
+  });
+
+  test("rejects an unsupported negotiated protocol version", async () => {
+    const fetchImpl: CloudCatalogProbeFetch = async (_url, init) => {
+      const body = requestPayload(init);
+      if (body.method !== "initialize") throw new Error("Unexpected JSON-RPC method");
+      return new Response(JSON.stringify({
+        jsonrpc: "2.0",
+        id: "openwork-agent-diagnostics-initialize",
+        result: { capabilities: {}, protocolVersion: "2024-11-05", serverInfo: { name: "old", version: "0.1.0" } },
+      }), { status: 200, headers: { "content-type": "application/json" } });
+    };
+    const probeInput = input();
+    probeInput.fetchImpl = fetchImpl;
+    const failed = await probeOpenworkCloudCatalog(probeInput);
+    expect(failed).toMatchObject({
+      performed: true,
+      status: "failed",
+      stage: "initialize_protocol",
+      code: "unsupported_protocol_version",
+      retryable: false,
+      toolsListPerformed: false,
+    });
+  });
+
+  test("splits invalid UTF-8, invalid JSON, and malformed envelopes into distinct codes", async () => {
+    const utf8 = await probeOpenworkCloudCatalog(input({
+      requestId: "bad-utf8",
+      fetchImpl: async () => new Response(new Uint8Array([0xff, 0xfe, 0xfd]), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    }));
+    expect(utf8).toMatchObject({ code: "invalid_utf8", stage: "tools_list_protocol" });
+
+    const json = await probeOpenworkCloudCatalog(input({
+      requestId: "bad-json",
+      fetchImpl: async () => new Response("{not json", { status: 200, headers: { "content-type": "application/json" } }),
+    }));
+    expect(json).toMatchObject({ code: "invalid_json", stage: "tools_list_protocol" });
+
+    const envelope = await probeOpenworkCloudCatalog(input({
+      requestId: "bad-envelope",
+      fetchImpl: async () => new Response(JSON.stringify({ jsonrpc: "1.0", id: "bad-envelope", result: {} }), {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    }));
+    expect(envelope).toMatchObject({ code: "invalid_jsonrpc_envelope", stage: "tools_list_protocol" });
+  });
+
+  test("keeps availability observed when only session cleanup fails and reports it", async () => {
+    let deleteCalls = 0;
+    const fetchImpl: CloudCatalogProbeFetch = async (url, init) => {
+      if (init?.method === "DELETE") {
+        deleteCalls += 1;
+        return new Response(null, { status: 500 });
+      }
+      const body = requestPayload(init);
+      if (body.method === "initialize") return initializeResponse();
+      if (body.method === "notifications/initialized") return new Response(null, { status: 202 });
+      return jsonResponse("cleanup-fails");
+    };
+    const probeInput = input({ requestId: "cleanup-fails" });
+    probeInput.fetchImpl = fetchImpl;
+    const observed = await probeOpenworkCloudCatalog(probeInput);
+    expect(deleteCalls).toBe(1);
+    expect(observed).toMatchObject({
+      status: "observed",
+      code: "catalog_observed",
+      sessionEstablished: true,
+      cleanupAttempted: true,
+      cleanupSucceeded: false,
+    });
+  });
+
+  test("skips cleanup when the server never returned a session ID", async () => {
+    let deleteCalls = 0;
+    const fetchImpl: CloudCatalogProbeFetch = async (_url, init) => {
+      if (init?.method === "DELETE") {
+        deleteCalls += 1;
+        return new Response(null, { status: 204 });
+      }
+      const body = requestPayload(init);
+      if (body.method === "initialize") {
+        return new Response(JSON.stringify({
+          jsonrpc: "2.0",
+          id: "openwork-agent-diagnostics-initialize",
+          result: { capabilities: {}, protocolVersion: PROTOCOL_VERSION, serverInfo: { name: "t", version: "1" } },
+        }), { status: 200, headers: { "content-type": "application/json" } });
+      }
+      if (body.method === "notifications/initialized") return new Response(null, { status: 202 });
+      return jsonResponse("no-session");
+    };
+    const probeInput = input({ requestId: "no-session" });
+    probeInput.fetchImpl = fetchImpl;
+    const observed = await probeOpenworkCloudCatalog(probeInput);
+    expect(deleteCalls).toBe(0);
+    expect(observed).toMatchObject({
+      status: "observed",
+      sessionEstablished: false,
+      cleanupAttempted: false,
+      cleanupSucceeded: null,
+    });
+  });
+
+  test("exports a reference ID only from a strictly validated safe header", async () => {
+    const safe = await probeOpenworkCloudCatalog(input({
+      requestId: "with-reference",
+      fetchImpl: async () => {
+        const response = jsonResponse("with-reference");
+        response.headers.set("x-request-id", "req-1234.abc:z");
+        return response;
+      },
+    }));
+    expect(safe.referenceId).toBe("req-1234.abc:z");
+
+    const unsafe = await probeOpenworkCloudCatalog(input({
+      requestId: "with-unsafe-reference",
+      fetchImpl: async () => {
+        const response = jsonResponse("with-unsafe-reference");
+        response.headers.set("x-request-id", "spaced value with secrets");
+        return response;
+      },
+    }));
+    expect(unsafe.referenceId).toBeNull();
+    expect(JSON.stringify(unsafe)).not.toContain("spaced value");
+  });
+
+  test("reports boolean-only proxy and extra-CA posture from the environment seam", async () => {
+    const configured = await probeOpenworkCloudCatalog(input({
+      requestId: "env-posture",
+      env: {
+        HTTPS_PROXY: "http://proxy.corp.example:8080",
+        NODE_EXTRA_CA_CERTS: "/etc/ssl/corp-root.pem",
+      },
+      fetchImpl: async () => jsonResponse("env-posture"),
+    }));
+    expect(configured.proxyConfigured).toBe(true);
+    expect(configured.extraCaConfigured).toBe(true);
+    const serialized = JSON.stringify(configured);
+    expect(serialized).not.toContain("proxy.corp.example");
+    expect(serialized).not.toContain("corp-root");
+  });
+
+  test("derives the differential verdict from probe and engine evidence", () => {
+    const base = (overrides: Partial<CloudCatalogProbe>): CloudCatalogProbe => ({
+      performed: true,
+      status: "observed",
+      stage: "complete",
+      code: "catalog_observed",
+      networkCode: null,
+      retryable: false,
+      runtimeFamily: "bun",
+      transport: "test-seam",
+      httpStatus: 200,
+      durationMs: 1,
+      toolsListPerformed: true,
+      sessionEstablished: true,
+      cleanupAttempted: true,
+      cleanupSucceeded: true,
+      toolIds: ["search_capabilities", "execute_capability"],
+      totalToolCount: 2,
+      requiredToolsPresent: true,
+      referenceId: null,
+      proxyConfigured: false,
+      extraCaConfigured: false,
+      steps: [],
+      engineRegistrationStatus: "connected",
+      engineEvidenceSource: "engine_status",
+      engineEvidenceAgeMs: 1_000,
+      ...overrides,
+    });
+    expect(differentialCloudVerdict(base({}))).toBe("runtime_and_engine_connected");
+    expect(differentialCloudVerdict(base({ engineRegistrationStatus: "failed" })))
+      .toBe("runtime_connected_engine_failed");
+    expect(differentialCloudVerdict(base({ status: "failed", code: "tls_error" })))
+      .toBe("runtime_failed_engine_connected");
+    expect(differentialCloudVerdict(base({ status: "failed", code: "tls_error", engineRegistrationStatus: "failed" })))
+      .toBe("runtime_and_engine_failed");
+    expect(differentialCloudVerdict(base({ performed: false, status: "not-performed", code: "untrusted_endpoint" })))
+      .toBe("runtime_probe_not_performed");
+    expect(differentialCloudVerdict(base({ engineRegistrationStatus: "not-recorded" })))
+      .toBe("engine_evidence_stale_or_unavailable");
+    expect(differentialCloudVerdict(base({ engineEvidenceAgeMs: 120_000 })))
+      .toBe("engine_evidence_stale_or_unavailable");
   });
 });

--- a/apps/server/src/agent-context-cloud-probe.ts
+++ b/apps/server/src/agent-context-cloud-probe.ts
@@ -1,3 +1,10 @@
+import {
+  runtimeDiagnosticFetch,
+  runtimeDiagnosticTransportInfo,
+  type RuntimeDiagnosticRuntimeFamily,
+  type RuntimeDiagnosticTransport,
+} from "./server-fetch.js";
+
 const REQUEST_TIMEOUT_MS = 12_000;
 const MAX_RESPONSE_BYTES = 64 * 1024;
 const MAX_TOOL_COUNT = 100;
@@ -6,14 +13,16 @@ const MAX_AUTHORIZATION_LENGTH = 8 * 1024;
 const MAX_ENDPOINT_LENGTH = 2 * 1024;
 const MAX_SESSION_HEADER_LENGTH = 1024;
 const MAX_PROTOCOL_HEADER_LENGTH = 128;
+const MAX_STEP_SUMMARIES = 12;
 const MAX_ACTIVE_PROBES = 16;
+const STALE_ENGINE_EVIDENCE_MS = 60_000;
 const MCP_ACCEPT = "application/json, text/event-stream";
 const MCP_PROTOCOL_VERSION = "2025-06-18";
 const INITIALIZE_REQUEST_ID = "openwork-agent-diagnostics-initialize";
 const TOOL_ID = /^[A-Za-z][A-Za-z0-9_.:-]*$/;
 const SAFE_RESPONSE_HEADER = /^[!-~]+$/;
+const SAFE_REFERENCE_ID = /^[A-Za-z0-9._:-]{1,64}$/;
 const REQUIRED_TOOL_IDS = ["search_capabilities", "execute_capability"] as const;
-const REQUIRED_TOOL_ID_SET = new Set<string>(REQUIRED_TOOL_IDS);
 const BEARER = /^Bearer [A-Za-z0-9\-._~+/]+=*$/;
 const REQUEST_ID = /^[A-Za-z0-9_.:-]{1,128}$/;
 const REQUIRED_TERMINAL_PATH = "/mcp/agent";
@@ -24,6 +33,38 @@ const DEFAULT_TRUSTED_ORIGINS = new Set([
 
 export type CloudCatalogProbeStatus = "observed" | "not-performed" | "failed";
 
+export type CloudCatalogProbeStage =
+  | "eligibility"
+  | "dns"
+  | "connect"
+  | "tls"
+  | "proxy"
+  | "initialize_request"
+  | "initialize_http"
+  | "initialize_protocol"
+  | "initialized_notification"
+  | "tools_list_request"
+  | "tools_list_http"
+  | "tools_list_protocol"
+  | "catalog_validation"
+  | "session_cleanup"
+  | "complete";
+
+export type CloudCatalogProbeNetworkCode =
+  | "ENOTFOUND"
+  | "EAI_AGAIN"
+  | "ECONNREFUSED"
+  | "ECONNRESET"
+  | "ETIMEDOUT"
+  | "UND_ERR_CONNECT_TIMEOUT"
+  | "CERT_HAS_EXPIRED"
+  | "SELF_SIGNED_CERT_IN_CHAIN"
+  | "DEPTH_ZERO_SELF_SIGNED_CERT"
+  | "UNABLE_TO_VERIFY_LEAF_SIGNATURE"
+  | "ERR_TLS_CERT_ALTNAME_INVALID"
+  | "PROXY_ERROR"
+  | "UNKNOWN_NETWORK_ERROR";
+
 export type CloudCatalogProbeCode =
   | "catalog_observed"
   | "runtime_config_unavailable"
@@ -31,17 +72,11 @@ export type CloudCatalogProbeCode =
   | "cloud_mcp_missing"
   | "cloud_mcp_not_remote"
   | "cloud_mcp_disabled"
-  | "cloud_tool_policy_unavailable"
-  | "cloud_tool_policy_denied"
   | "invalid_endpoint"
   | "untrusted_endpoint"
   | "credential_missing"
   | "duplicate_authorization"
-  | "registration_failed"
-  | "registration_disabled"
-  | "registration_needs_auth"
-  | "registration_needs_client_registration"
-  | "registration_not_recorded"
+  | "probe_busy"
   | "timeout"
   | "network_error"
   | "dns_error"
@@ -52,24 +87,75 @@ export type CloudCatalogProbeCode =
   | "redirect_rejected"
   | "unauthorized"
   | "forbidden"
+  | "mcp_route_not_found"
   | "rate_limited"
-  | "probe_busy"
+  | "gateway_unavailable"
   | "http_error"
   | "response_too_large"
   | "invalid_content_type"
-  | "invalid_response"
+  | "invalid_utf8"
+  | "invalid_json"
+  | "invalid_jsonrpc_envelope"
+  | "request_id_mismatch"
   | "jsonrpc_error"
+  | "unsupported_protocol_version"
+  | "invalid_session_header"
   | "pagination_unsupported"
-  | "invalid_catalog";
+  | "invalid_catalog"
+  | "required_tools_missing";
+
+export type CloudEngineRegistrationStatus =
+  | "connected"
+  | "disabled"
+  | "failed"
+  | "needs-auth"
+  | "needs-client-registration"
+  | "not-recorded";
+
+/**
+ * Cached engine-side evidence for the exact managed OpenWork Cloud entry.
+ * This is a comparison input for the differential verdict; it never gates
+ * whether the independent runtime probe is allowed to run.
+ */
+export type CloudEngineRegistrationEvidence = {
+  status: CloudEngineRegistrationStatus;
+  source: "transport_failure" | "engine_status" | null;
+  recordAgeMs: number | null;
+};
+
+export type CloudRuntimeEngineDifferential =
+  | "runtime_and_engine_connected"
+  | "runtime_connected_engine_failed"
+  | "runtime_failed_engine_connected"
+  | "runtime_and_engine_failed"
+  | "runtime_probe_not_performed"
+  | "engine_evidence_stale_or_unavailable";
 
 export type CloudCatalogProbe = {
   performed: boolean;
-  toolsListPerformed: boolean;
   status: CloudCatalogProbeStatus;
+  stage: CloudCatalogProbeStage;
   code: CloudCatalogProbeCode;
-  toolIds: string[];
-  durationMs: number;
+  networkCode: CloudCatalogProbeNetworkCode | null;
+  retryable: boolean;
+  runtimeFamily: RuntimeDiagnosticRuntimeFamily;
+  transport: RuntimeDiagnosticTransport;
   httpStatus: number | null;
+  durationMs: number;
+  toolsListPerformed: boolean;
+  sessionEstablished: boolean;
+  cleanupAttempted: boolean;
+  cleanupSucceeded: boolean | null;
+  toolIds: string[];
+  totalToolCount: number | null;
+  requiredToolsPresent: boolean | null;
+  referenceId: string | null;
+  proxyConfigured: boolean;
+  extraCaConfigured: boolean;
+  steps: string[];
+  engineRegistrationStatus: CloudEngineRegistrationStatus;
+  engineEvidenceSource: "transport_failure" | "engine_status" | null;
+  engineEvidenceAgeMs: number | null;
 };
 
 export type CloudCatalogProbeFetch = (
@@ -82,15 +168,7 @@ export type ProbeOpenworkCloudCatalogInput = {
   workspaceType: "local" | "remote";
   runtimeConfigAvailable?: boolean;
   config: Record<string, unknown> | null | undefined;
-  toolPolicyStatus: "available" | "denied" | "unavailable";
-  toolPolicyProvenance: "authoritative-effective-engine" | "passive-static-subset" | "unavailable";
-  registrationStatus:
-    | "connected"
-    | "disabled"
-    | "failed"
-    | "needs-auth"
-    | "needs-client-registration"
-    | "not-recorded";
+  engineRegistration: CloudEngineRegistrationEvidence;
   requestId: string;
   fetchImpl?: CloudCatalogProbeFetch;
   clock?: () => number;
@@ -100,6 +178,8 @@ export type ProbeOpenworkCloudCatalogInput = {
   timeoutMs?: number;
   /** Overall diagnostics deadline; aborting it prevents or cancels egress. */
   signal?: AbortSignal;
+  /** Test seam for proxy and extra-CA presence detection. */
+  env?: Record<string, string | undefined>;
 };
 
 type PreparedProbe = {
@@ -119,6 +199,12 @@ class ProbeHttpFailure extends SafeProbeFailure {
   }
 }
 
+class CatalogRequiredToolsFailure extends SafeProbeFailure {
+  constructor(readonly totalToolCount: number) {
+    super("required_tools_missing");
+  }
+}
+
 class ProbeTimeout extends Error {}
 
 type ProbeDeadline = {
@@ -132,6 +218,16 @@ type ProbeResponseBudget = {
   remaining: number;
 };
 
+type ProbeBaseFacts = {
+  runtimeFamily: RuntimeDiagnosticRuntimeFamily;
+  transport: RuntimeDiagnosticTransport;
+  proxyConfigured: boolean;
+  extraCaConfigured: boolean;
+  engineRegistrationStatus: CloudEngineRegistrationStatus;
+  engineEvidenceSource: "transport_failure" | "engine_status" | null;
+  engineEvidenceAgeMs: number | null;
+};
+
 const activeProbes = new Set<Promise<CloudCatalogProbe>>();
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -143,24 +239,8 @@ function elapsed(startedAt: number, clock: () => number): number {
   return Number.isFinite(value) ? Math.max(0, Math.round(value)) : 0;
 }
 
-function result(
-  startedAt: number,
-  clock: () => number,
-  input: Omit<CloudCatalogProbe, "durationMs" | "toolIds" | "toolsListPerformed"> & {
-    toolIds?: string[];
-    toolsListPerformed?: boolean;
-  },
-): CloudCatalogProbe {
-  return {
-    ...input,
-    toolsListPerformed: input.toolsListPerformed ?? false,
-    toolIds: input.toolIds ? [...input.toolIds] : [],
-    durationMs: elapsed(startedAt, clock),
-  };
-}
-
 function cloneResult(value: CloudCatalogProbe): CloudCatalogProbe {
-  return { ...value, toolIds: [...value.toolIds] };
+  return { ...value, toolIds: [...value.toolIds], steps: [...value.steps] };
 }
 
 function isLoopbackHostname(hostname: string): boolean {
@@ -171,6 +251,13 @@ function isLoopbackHostname(hostname: string): boolean {
   return Number(match[1]) === 127 && match.slice(1).every((part) => Number(part) <= 255);
 }
 
+/**
+ * Origins the credentialed diagnostic request may reach: built-in OpenWork
+ * Cloud origins plus exact administrator-configured diagnostic origins. An
+ * enterprise/on-prem Den origin must be provisioned through the same explicit
+ * administrator setting; the desktop bootstrap's Den activation state is not
+ * visible to this server process, so it can never widen this list implicitly.
+ */
 function configuredTrustedOrigins(): Set<string> {
   const origins = new Set(DEFAULT_TRUSTED_ORIGINS);
   const configured = process.env.OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS ?? "";
@@ -222,20 +309,19 @@ function authorizationHeader(config: Record<string, unknown>): { value: string |
   return { value, duplicate: false };
 }
 
+/**
+ * Eligibility is deliberately independent of cached OpenCode registration
+ * state and of agent tool policy: the probe exists to diagnose engine-side
+ * failures, and tool visibility is a separate diagnostic dimension reported
+ * by its own check. Only structural, trust, credential, and privacy
+ * boundaries can skip the probe.
+ */
 function prepare(input: ProbeOpenworkCloudCatalogInput): PreparedProbe | CloudCatalogProbeCode {
   if (input.workspaceType !== "local") return "remote_workspace_unavailable";
   if (input.runtimeConfigAvailable === false) return "runtime_config_unavailable";
   if (!isRecord(input.config)) return "cloud_mcp_missing";
   if (input.config.type !== "remote") return "cloud_mcp_not_remote";
   if (input.config.enabled !== true) return "cloud_mcp_disabled";
-  if (input.toolPolicyStatus === "unavailable") return "cloud_tool_policy_unavailable";
-  if (input.toolPolicyStatus === "denied") return "cloud_tool_policy_denied";
-  // Absence of a deny in passively inspected config is never authority to
-  // send a credentialed request. Only a complete effective-engine snapshot
-  // may authorize the catalog probe's available path.
-  if (input.toolPolicyProvenance !== "authoritative-effective-engine") {
-    return "cloud_tool_policy_unavailable";
-  }
   const endpoint = safeCatalogEndpoint(input.config.url);
   if (!endpoint) return "invalid_endpoint";
   if (!isLoopbackHostname(endpoint.hostname) && !configuredTrustedOrigins().has(endpoint.origin)) {
@@ -244,13 +330,6 @@ function prepare(input: ProbeOpenworkCloudCatalogInput): PreparedProbe | CloudCa
   const authorization = authorizationHeader(input.config);
   if (authorization.duplicate) return "duplicate_authorization";
   if (!authorization.value) return "credential_missing";
-  if (input.registrationStatus === "failed") return "registration_failed";
-  if (input.registrationStatus === "disabled") return "registration_disabled";
-  if (input.registrationStatus === "needs-auth") return "registration_needs_auth";
-  if (input.registrationStatus === "needs-client-registration") {
-    return "registration_needs_client_registration";
-  }
-  if (input.registrationStatus !== "connected") return "registration_not_recorded";
   if (!REQUEST_ID.test(input.requestId)) return "invalid_endpoint";
   return {
     endpoint: endpoint.toString(),
@@ -338,7 +417,9 @@ async function readBoundedBody(
     // a hostile stream can ignore both AbortSignal and cancellation.
     void reader.cancel().catch(() => undefined);
     if (error instanceof ProbeTimeout || deadline.timedOut()) throw new ProbeTimeout();
-    throw new SafeProbeFailure("invalid_response");
+    // Mid-body transport failures keep their original cause so the outer
+    // classifier can attribute them to the network layer, not the protocol.
+    throw error;
   }
   const bytes = new Uint8Array(size);
   let offset = 0;
@@ -349,7 +430,7 @@ async function readBoundedBody(
   try {
     return new TextDecoder("utf-8", { fatal: true }).decode(bytes);
   } catch {
-    throw new SafeProbeFailure("invalid_response");
+    throw new SafeProbeFailure("invalid_utf8");
   }
 }
 
@@ -357,7 +438,7 @@ function parseJson(text: string): unknown {
   try {
     return JSON.parse(text);
   } catch {
-    throw new SafeProbeFailure("invalid_response");
+    throw new SafeProbeFailure("invalid_json");
   }
 }
 
@@ -370,7 +451,7 @@ function parseSse(text: string): unknown {
       event = "";
       return;
     }
-    if (event && event !== "message") throw new SafeProbeFailure("invalid_response");
+    if (event && event !== "message") throw new SafeProbeFailure("invalid_json");
     messages.push(parseJson(data.join("\n")));
     event = "";
     data = [];
@@ -389,21 +470,29 @@ function parseSse(text: string): unknown {
     if (field === "data") data.push(value);
   }
   dispatch();
-  if (messages.length !== 1) throw new SafeProbeFailure("invalid_response");
+  if (messages.length !== 1) throw new SafeProbeFailure("invalid_json");
   return messages[0];
 }
 
 function parseJsonRpcResult(payload: unknown, requestId: string): Record<string, unknown> {
-  if (!isRecord(payload) || payload.jsonrpc !== "2.0" || payload.id !== requestId) {
-    throw new SafeProbeFailure("invalid_response");
+  if (!isRecord(payload) || payload.jsonrpc !== "2.0") {
+    throw new SafeProbeFailure("invalid_jsonrpc_envelope");
   }
   if (Object.hasOwn(payload, "error")) throw new SafeProbeFailure("jsonrpc_error");
-  if (!isRecord(payload.result)) throw new SafeProbeFailure("invalid_response");
+  if (payload.id !== requestId) throw new SafeProbeFailure("request_id_mismatch");
+  if (!isRecord(payload.result)) throw new SafeProbeFailure("invalid_jsonrpc_envelope");
   return payload.result;
 }
 
-function parseToolIds(payload: unknown, requestId: string): string[] {
-  const rpcResult = parseJsonRpcResult(payload, requestId);
+function requireSupportedProtocolVersion(initializeResult: Record<string, unknown>): void {
+  const version = initializeResult.protocolVersion;
+  if (typeof version !== "string" || version.length === 0 || version.length > MAX_PROTOCOL_HEADER_LENGTH) {
+    throw new SafeProbeFailure("invalid_jsonrpc_envelope");
+  }
+  if (version !== MCP_PROTOCOL_VERSION) throw new SafeProbeFailure("unsupported_protocol_version");
+}
+
+function validateCatalog(rpcResult: Record<string, unknown>): { toolIds: string[]; totalToolCount: number } {
   if (rpcResult.nextCursor !== undefined && rpcResult.nextCursor !== null) {
     throw new SafeProbeFailure("pagination_unsupported");
   }
@@ -415,42 +504,104 @@ function parseToolIds(payload: unknown, requestId: string): string[] {
     if (!isRecord(tool) || typeof tool.name !== "string" || tool.name.length > MAX_TOOL_ID_LENGTH || !TOOL_ID.test(tool.name)) {
       throw new SafeProbeFailure("invalid_catalog");
     }
-    // Never reflect provider-controlled catalog names into the diagnostic
-    // report. In particular, a compromised trusted endpoint must not be able
-    // to echo the bearer token back as a syntactically valid tool identifier.
-    if (!REQUIRED_TOOL_ID_SET.has(tool.name)) throw new SafeProbeFailure("invalid_catalog");
     if (seen.has(tool.name)) throw new SafeProbeFailure("invalid_catalog");
     seen.add(tool.name);
   }
-  if (seen.size !== REQUIRED_TOOL_IDS.length) throw new SafeProbeFailure("invalid_catalog");
-  return [...REQUIRED_TOOL_IDS];
+  // Additional provider tools are forward-compatible and allowed, but never
+  // reflect provider-controlled catalog names into the diagnostic report. In
+  // particular, a compromised trusted endpoint must not be able to echo the
+  // bearer token back as a syntactically valid tool identifier. Only the
+  // expected allowlisted IDs and the aggregate count are exported.
+  const missing = REQUIRED_TOOL_IDS.filter((toolId) => !seen.has(toolId));
+  if (missing.length > 0) throw new CatalogRequiredToolsFailure(rpcResult.tools.length);
+  return { toolIds: [...REQUIRED_TOOL_IDS], totalToolCount: rpcResult.tools.length };
 }
 
 function httpFailureCode(status: number): CloudCatalogProbeCode {
   if (status === 401) return "unauthorized";
   if (status === 403) return "forbidden";
+  if (status === 404) return "mcp_route_not_found";
   if (status === 429) return "rate_limited";
+  if (status === 502 || status === 503 || status === 504) return "gateway_unavailable";
   if (status >= 300 && status < 400) return "redirect_rejected";
   return "http_error";
 }
 
-function networkFailureCode(error: unknown): CloudCatalogProbeCode {
+function classifyNetworkError(error: unknown): { code: CloudCatalogProbeCode; networkCode: CloudCatalogProbeNetworkCode } {
   const cause = isRecord(error) && isRecord(error.cause) ? error.cause : null;
   const code = cause && typeof cause.code === "string" ? cause.code.toUpperCase() : "";
-  if (code === "ENOTFOUND" || code === "EAI_AGAIN") return "dns_error";
-  if (code === "ECONNREFUSED") return "connection_refused";
-  if (code === "ECONNRESET" || code === "EPIPE") return "connection_reset";
-  if (code === "ETIMEDOUT" || code === "UND_ERR_CONNECT_TIMEOUT") return "timeout";
-  if (code.includes("PROXY")) return "proxy_error";
+  if (code === "ENOTFOUND") return { code: "dns_error", networkCode: "ENOTFOUND" };
+  if (code === "EAI_AGAIN") return { code: "dns_error", networkCode: "EAI_AGAIN" };
+  if (code === "ECONNREFUSED") return { code: "connection_refused", networkCode: "ECONNREFUSED" };
+  if (code === "ECONNRESET" || code === "EPIPE") return { code: "connection_reset", networkCode: "ECONNRESET" };
+  if (code === "ETIMEDOUT") return { code: "timeout", networkCode: "ETIMEDOUT" };
+  if (code === "UND_ERR_CONNECT_TIMEOUT") return { code: "timeout", networkCode: "UND_ERR_CONNECT_TIMEOUT" };
+  if (code.includes("PROXY")) return { code: "proxy_error", networkCode: "PROXY_ERROR" };
+  if (code === "CERT_HAS_EXPIRED") return { code: "tls_error", networkCode: "CERT_HAS_EXPIRED" };
+  if (code === "SELF_SIGNED_CERT_IN_CHAIN") return { code: "tls_error", networkCode: "SELF_SIGNED_CERT_IN_CHAIN" };
+  if (code === "DEPTH_ZERO_SELF_SIGNED_CERT") return { code: "tls_error", networkCode: "DEPTH_ZERO_SELF_SIGNED_CERT" };
+  if (code === "UNABLE_TO_VERIFY_LEAF_SIGNATURE") return { code: "tls_error", networkCode: "UNABLE_TO_VERIFY_LEAF_SIGNATURE" };
+  if (code === "ERR_TLS_CERT_ALTNAME_INVALID") return { code: "tls_error", networkCode: "ERR_TLS_CERT_ALTNAME_INVALID" };
+  if (code.startsWith("ERR_TLS_") || code.startsWith("CERT_") || code.includes("CERTIFICATE")) {
+    return { code: "tls_error", networkCode: "UNKNOWN_NETWORK_ERROR" };
+  }
+  return { code: "network_error", networkCode: "UNKNOWN_NETWORK_ERROR" };
+}
+
+function networkStageFor(networkCode: CloudCatalogProbeNetworkCode): CloudCatalogProbeStage | null {
+  if (networkCode === "ENOTFOUND" || networkCode === "EAI_AGAIN") return "dns";
   if (
-    code.startsWith("ERR_TLS_")
-    || code.startsWith("CERT_")
-    || code.includes("CERTIFICATE")
-    || code === "DEPTH_ZERO_SELF_SIGNED_CERT"
-    || code === "SELF_SIGNED_CERT_IN_CHAIN"
-    || code === "UNABLE_TO_VERIFY_LEAF_SIGNATURE"
-  ) return "tls_error";
-  return "network_error";
+    networkCode === "ECONNREFUSED"
+    || networkCode === "ECONNRESET"
+    || networkCode === "ETIMEDOUT"
+    || networkCode === "UND_ERR_CONNECT_TIMEOUT"
+  ) return "connect";
+  if (networkCode === "PROXY_ERROR") return "proxy";
+  if (networkCode === "UNKNOWN_NETWORK_ERROR") return null;
+  return "tls";
+}
+
+/**
+ * Retryability is derived only from the closed code sets, never from raw
+ * error message text: transient DNS, timeouts, resets, rate limits, gateway
+ * availability, and local probe-capacity exhaustion are retryable; TLS
+ * validation, credential, route, protocol, and catalog failures are not.
+ */
+function retryableFor(code: CloudCatalogProbeCode, networkCode: CloudCatalogProbeNetworkCode | null): boolean {
+  if (networkCode === "EAI_AGAIN" || networkCode === "ETIMEDOUT" || networkCode === "UND_ERR_CONNECT_TIMEOUT" || networkCode === "ECONNRESET") {
+    return true;
+  }
+  switch (code) {
+    case "timeout":
+    case "connection_reset":
+    case "rate_limited":
+    case "gateway_unavailable":
+    case "probe_busy":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function stepPhaseFor(stage: CloudCatalogProbeStage): string {
+  if (stage === "initialize_request" || stage === "initialize_http" || stage === "initialize_protocol") return "initialize";
+  if (stage === "tools_list_request" || stage === "tools_list_http" || stage === "tools_list_protocol") return "tools_list";
+  return stage;
+}
+
+function proxyEnvConfigured(env: Record<string, string | undefined>): boolean {
+  return Boolean(
+    env.HTTPS_PROXY?.trim()
+    || env.https_proxy?.trim()
+    || env.HTTP_PROXY?.trim()
+    || env.http_proxy?.trim()
+    || env.ALL_PROXY?.trim()
+    || env.all_proxy?.trim(),
+  );
+}
+
+function extraCaEnvConfigured(env: Record<string, string | undefined>): boolean {
+  return Boolean(env.NODE_EXTRA_CA_CERTS?.trim());
 }
 
 function baseProbeHeaders(authorization: string): Record<string, string> {
@@ -465,18 +616,34 @@ function returnedSessionHeader(response: Response, name: string, maxLength: numb
   const value = response.headers.get(name);
   if (value === null) return undefined;
   if (value.length === 0 || value.length > maxLength || !SAFE_RESPONSE_HEADER.test(value)) {
-    throw new SafeProbeFailure("invalid_response");
+    throw new SafeProbeFailure("invalid_session_header");
   }
   return value;
 }
 
-function sessionProbeHeaders(response: Response, authorization: string): Record<string, string> {
+function captureReferenceId(response: Response, current: string | null): string | null {
+  const value = response.headers.get("x-request-id");
+  if (value !== null && SAFE_REFERENCE_ID.test(value)) return value;
+  return current;
+}
+
+type ProbeSession = {
+  headers: Record<string, string>;
+  sessionId: string | undefined;
+  protocolVersion: string | undefined;
+};
+
+function sessionProbe(response: Response, authorization: string): ProbeSession {
   const sessionId = returnedSessionHeader(response, "mcp-session-id", MAX_SESSION_HEADER_LENGTH);
   const protocolVersion = returnedSessionHeader(response, "mcp-protocol-version", MAX_PROTOCOL_HEADER_LENGTH);
   return {
-    ...baseProbeHeaders(authorization),
-    ...(sessionId ? { "mcp-session-id": sessionId } : {}),
-    ...(protocolVersion ? { "mcp-protocol-version": protocolVersion } : {}),
+    headers: {
+      ...baseProbeHeaders(authorization),
+      ...(sessionId ? { "mcp-session-id": sessionId } : {}),
+      ...(protocolVersion ? { "mcp-protocol-version": protocolVersion } : {}),
+    },
+    sessionId,
+    protocolVersion,
   };
 }
 
@@ -523,10 +690,41 @@ async function readJsonRpcPayload(
   return mediaType === "text/event-stream" ? parseSse(body) : parseJson(body);
 }
 
+/**
+ * Bounded best-effort termination of the diagnostic MCP session. Failure here
+ * is reported but never converts a successful availability observation into
+ * a failed one.
+ */
+async function terminateSession(
+  prepared: PreparedProbe,
+  session: ProbeSession,
+  fetchImpl: CloudCatalogProbeFetch,
+  deadline: ProbeDeadline,
+): Promise<boolean> {
+  try {
+    const response = await deadline.race(fetchImpl(prepared.endpoint, {
+      method: "DELETE",
+      redirect: "manual",
+      headers: {
+        Accept: MCP_ACCEPT,
+        Authorization: prepared.authorization,
+        ...(session.sessionId ? { "mcp-session-id": session.sessionId } : {}),
+        ...(session.protocolVersion ? { "mcp-protocol-version": session.protocolVersion } : {}),
+      },
+      signal: deadline.signal,
+    }));
+    await cancelBody(response, deadline);
+    return response.status >= 200 && response.status < 300;
+  } catch {
+    return false;
+  }
+}
+
 async function performProbe(
   prepared: PreparedProbe,
   requestId: string,
   fetchImpl: CloudCatalogProbeFetch,
+  base: ProbeBaseFacts,
   startedAt: number,
   clock: () => number,
   timeoutMs: number,
@@ -534,13 +732,30 @@ async function performProbe(
 ): Promise<CloudCatalogProbe> {
   const deadline = createDeadline(timeoutMs, parentSignal);
   const budget: ProbeResponseBudget = { remaining: MAX_RESPONSE_BYTES };
+  const steps: string[] = [];
+  const record = (label: string) => {
+    if (steps.length < MAX_STEP_SUMMARIES) steps.push(label);
+  };
+  let stage: CloudCatalogProbeStage = "initialize_request";
   let currentHttpStatus: number | null = null;
   let toolsListPerformed = false;
+  let session: ProbeSession | null = null;
+  let referenceId: string | null = null;
+  let totalToolCount: number | null = null;
+  let requiredToolsPresent: boolean | null = null;
+  let toolIds: string[] = [];
+  let failure: {
+    stage: CloudCatalogProbeStage;
+    code: CloudCatalogProbeCode;
+    networkCode: CloudCatalogProbeNetworkCode | null;
+    httpStatus: number | null;
+  } | null = null;
+  let phaseStart = clock();
+  const phaseMs = () => `${elapsed(phaseStart, clock)}ms`;
   try {
-    const baseHeaders = baseProbeHeaders(prepared.authorization);
     const initialized = await postJsonRpc(
       prepared,
-      baseHeaders,
+      baseProbeHeaders(prepared.authorization),
       {
         jsonrpc: "2.0",
         id: INITIALIZE_REQUEST_ID,
@@ -555,106 +770,213 @@ async function performProbe(
       deadline,
     );
     currentHttpStatus = initialized.status;
+    referenceId = captureReferenceId(initialized, referenceId);
+    stage = "initialize_http";
     await requireHttpStatus(initialized, deadline, (status) => status === 200);
-    parseJsonRpcResult(await readJsonRpcPayload(initialized, deadline, budget), INITIALIZE_REQUEST_ID);
-    const sessionHeaders = sessionProbeHeaders(initialized, prepared.authorization);
+    stage = "initialize_protocol";
+    const initializeResult = parseJsonRpcResult(
+      await readJsonRpcPayload(initialized, deadline, budget),
+      INITIALIZE_REQUEST_ID,
+    );
+    requireSupportedProtocolVersion(initializeResult);
+    session = sessionProbe(initialized, prepared.authorization);
+    record(`initialize ok ${initialized.status} ${phaseMs()}`);
 
+    phaseStart = clock();
+    stage = "initialized_notification";
     currentHttpStatus = null;
     const acknowledged = await postJsonRpc(
       prepared,
-      sessionHeaders,
+      session.headers,
       { jsonrpc: "2.0", method: "notifications/initialized", params: {} },
       fetchImpl,
       deadline,
     );
     currentHttpStatus = acknowledged.status;
+    referenceId = captureReferenceId(acknowledged, referenceId);
     await requireHttpStatus(acknowledged, deadline, (status) => status >= 200 && status < 300);
     await readBoundedBody(acknowledged, deadline, budget);
+    record(`initialized_notification ok ${acknowledged.status} ${phaseMs()}`);
 
+    phaseStart = clock();
+    stage = "tools_list_request";
     currentHttpStatus = null;
     toolsListPerformed = true;
     const listed = await postJsonRpc(
       prepared,
-      sessionHeaders,
+      session.headers,
       { jsonrpc: "2.0", id: requestId, method: "tools/list", params: {} },
       fetchImpl,
       deadline,
     );
     currentHttpStatus = listed.status;
+    referenceId = captureReferenceId(listed, referenceId);
+    stage = "tools_list_http";
     await requireHttpStatus(listed, deadline, (status) => status === 200);
-    const toolIds = parseToolIds(await readJsonRpcPayload(listed, deadline, budget), requestId);
-    return result(startedAt, clock, {
-      performed: true,
-      status: "observed",
-      code: "catalog_observed",
-      toolsListPerformed,
-      toolIds,
-      httpStatus: listed.status,
-    });
+    stage = "tools_list_protocol";
+    const listResult = parseJsonRpcResult(await readJsonRpcPayload(listed, deadline, budget), requestId);
+    stage = "catalog_validation";
+    const catalog = validateCatalog(listResult);
+    toolIds = catalog.toolIds;
+    totalToolCount = catalog.totalToolCount;
+    requiredToolsPresent = true;
+    record(`tools_list ok ${listed.status} ${phaseMs()}`);
+    stage = "complete";
   } catch (error) {
     const timedOut = error instanceof ProbeTimeout || deadline.timedOut();
-    return result(startedAt, clock, {
-      performed: true,
-      status: "failed",
-      code: timedOut
-        ? "timeout"
-        : error instanceof SafeProbeFailure
-          ? error.code
-          : networkFailureCode(error),
-      toolsListPerformed,
+    if (error instanceof CatalogRequiredToolsFailure) {
+      totalToolCount = error.totalToolCount;
+      requiredToolsPresent = false;
+    }
+    let code: CloudCatalogProbeCode;
+    let networkCode: CloudCatalogProbeNetworkCode | null = null;
+    let failureStage: CloudCatalogProbeStage = stage;
+    if (timedOut) {
+      code = "timeout";
+    } else if (error instanceof SafeProbeFailure) {
+      code = error.code;
+    } else {
+      const classified = classifyNetworkError(error);
+      code = classified.code;
+      networkCode = classified.networkCode;
+      failureStage = networkStageFor(classified.networkCode) ?? stage;
+    }
+    failure = {
+      stage: failureStage,
+      code,
+      networkCode,
       httpStatus: error instanceof ProbeHttpFailure
         ? error.httpStatus
         : timedOut || error instanceof SafeProbeFailure
           ? currentHttpStatus
           : null,
-    });
-  } finally {
-    deadline.dispose();
+    };
+    record(`${stepPhaseFor(stage)} failed ${code} ${phaseMs()}`);
   }
+
+  let cleanupAttempted = false;
+  let cleanupSucceeded: boolean | null = null;
+  if (session?.sessionId !== undefined && !deadline.timedOut()) {
+    phaseStart = clock();
+    cleanupAttempted = true;
+    cleanupSucceeded = await terminateSession(prepared, session, fetchImpl, deadline);
+    record(`session_cleanup ${cleanupSucceeded ? "ok" : "failed"} ${phaseMs()}`);
+  }
+  deadline.dispose();
+
+  const common = {
+    performed: true,
+    toolsListPerformed,
+    sessionEstablished: session?.sessionId !== undefined,
+    cleanupAttempted,
+    cleanupSucceeded,
+    totalToolCount,
+    requiredToolsPresent,
+    referenceId,
+    steps,
+    durationMs: elapsed(startedAt, clock),
+    ...base,
+  };
+  if (failure) {
+    return {
+      ...common,
+      status: "failed",
+      stage: failure.stage,
+      code: failure.code,
+      networkCode: failure.networkCode,
+      retryable: retryableFor(failure.code, failure.networkCode),
+      httpStatus: failure.httpStatus,
+      toolIds: [],
+    };
+  }
+  return {
+    ...common,
+    status: "observed",
+    stage: "complete",
+    code: "catalog_observed",
+    networkCode: null,
+    retryable: false,
+    httpStatus: currentHttpStatus,
+    toolIds,
+  };
 }
 
 /**
- * Performs one credential-safe direct catalog observation for the exact
- * runtime-managed OpenWork Cloud entry supplied by the caller. This function
- * never discovers another MCP, follows redirects, calls a tool, or returns
- * endpoint, credential, header, response-body, or caught-error values.
+ * Compares the independent runtime observation with the engine's cached
+ * registration evidence for the same managed entry, so a report can implicate
+ * the correct runtime boundary instead of collapsing both into one failure.
+ */
+export function differentialCloudVerdict(probe: CloudCatalogProbe): CloudRuntimeEngineDifferential {
+  if (!probe.performed) return "runtime_probe_not_performed";
+  if (probe.engineRegistrationStatus === "not-recorded") return "engine_evidence_stale_or_unavailable";
+  if (probe.engineEvidenceAgeMs !== null && probe.engineEvidenceAgeMs > STALE_ENGINE_EVIDENCE_MS) {
+    return "engine_evidence_stale_or_unavailable";
+  }
+  const runtimeConnected = probe.status === "observed";
+  const engineConnected = probe.engineRegistrationStatus === "connected";
+  if (runtimeConnected && engineConnected) return "runtime_and_engine_connected";
+  if (runtimeConnected) return "runtime_connected_engine_failed";
+  if (engineConnected) return "runtime_failed_engine_connected";
+  return "runtime_and_engine_failed";
+}
+
+/**
+ * Performs one credential-safe direct verification of the exact
+ * runtime-managed OpenWork Cloud entry supplied by the caller, running the
+ * complete bounded MCP handshake (initialize, initialized notification,
+ * tools/list, best-effort session termination) on the OpenWork runtime's own
+ * fetch stack. This function never discovers another MCP, follows redirects,
+ * calls a tool, mutates configuration, or returns endpoint, credential,
+ * header, response-body, or caught-error values.
  */
 export async function probeOpenworkCloudCatalog(
   input: ProbeOpenworkCloudCatalogInput,
 ): Promise<CloudCatalogProbe> {
   const clock = input.clock ?? input.now ?? Date.now;
   const startedAt = clock();
-  if (input.signal?.aborted) {
-    return result(startedAt, clock, {
-      performed: false,
-      status: "not-performed",
-      code: "timeout",
-      httpStatus: null,
-    });
-  }
+  const env = input.env ?? process.env;
+  const transportInfo = input.fetchImpl
+    ? { runtimeFamily: runtimeDiagnosticTransportInfo().runtimeFamily, transport: "test-seam" as const }
+    : runtimeDiagnosticTransportInfo();
+  const base: ProbeBaseFacts = {
+    runtimeFamily: transportInfo.runtimeFamily,
+    transport: transportInfo.transport,
+    proxyConfigured: proxyEnvConfigured(env),
+    extraCaConfigured: extraCaEnvConfigured(env),
+    engineRegistrationStatus: input.engineRegistration.status,
+    engineEvidenceSource: input.engineRegistration.source,
+    engineEvidenceAgeMs: input.engineRegistration.recordAgeMs,
+  };
+  const notPerformed = (code: CloudCatalogProbeCode): CloudCatalogProbe => ({
+    performed: false,
+    status: "not-performed",
+    stage: "eligibility",
+    code,
+    networkCode: null,
+    retryable: retryableFor(code, null),
+    httpStatus: null,
+    durationMs: elapsed(startedAt, clock),
+    toolsListPerformed: false,
+    sessionEstablished: false,
+    cleanupAttempted: false,
+    cleanupSucceeded: null,
+    toolIds: [],
+    totalToolCount: null,
+    requiredToolsPresent: null,
+    referenceId: null,
+    steps: [`eligibility ${code}`],
+    ...base,
+  });
+  if (input.signal?.aborted) return notPerformed("timeout");
   const prepared = prepare(input);
-  if (typeof prepared === "string") {
-    return result(startedAt, clock, {
-      performed: false,
-      status: "not-performed",
-      code: prepared,
-      httpStatus: null,
-    });
-  }
-
-  if (activeProbes.size >= MAX_ACTIVE_PROBES) {
-    return result(startedAt, clock, {
-      performed: false,
-      status: "not-performed",
-      code: "probe_busy",
-      httpStatus: null,
-    });
-  }
+  if (typeof prepared === "string") return notPerformed(prepared);
+  if (activeProbes.size >= MAX_ACTIVE_PROBES) return notPerformed("probe_busy");
 
   const task = performProbe(
     prepared,
     input.requestId,
-    input.fetchImpl ?? fetch,
+    input.fetchImpl ?? runtimeDiagnosticFetch,
+    base,
     startedAt,
     clock,
     Math.min(REQUEST_TIMEOUT_MS, Math.max(1, Math.round(input.timeoutMs ?? REQUEST_TIMEOUT_MS))),

--- a/apps/server/src/agent-context-diagnostics-schema.ts
+++ b/apps/server/src/agent-context-diagnostics-schema.ts
@@ -25,6 +25,7 @@ export const AGENT_CONTEXT_DIAGNOSTIC_CHECK_IDS = [
   "engine-mcp-sync",
   "engine-mcp-status",
   "cloud-tool-catalog",
+  "cloud-endpoint-differential",
   "organization-connections",
   "report-safety",
 ] as const;
@@ -390,6 +391,7 @@ export const agentContextDiagnosticsReportSchema = z.object({
   safety: z.object({
     diagnosticsWorkspaceRuntimeConfigurationReadOnly: z.literal(true),
     cloudCatalogToolsListPerformed: z.boolean(),
+    cloudSessionCleanupRequested: z.boolean(),
     directNonCloudMcpFetchPerformed: z.literal(false),
     directMcpToolCallPerformed: z.literal(false),
     directProviderOperationPerformed: z.literal(false),
@@ -500,7 +502,6 @@ export const agentContextDiagnosticsReportSchema = z.object({
 
   const engineConfigCheck = value.checks.find((check) => check.id === "engine-config");
   const engineAgentCheck = value.checks.find((check) => check.id === "engine-agent");
-  const toolPolicyCheck = value.checks.find((check) => check.id === "agent-connect-tool-permissions");
   if (value.agent.evidenceSource === "effective-engine") {
     if (!value.safety.engineApiReadPerformed) {
       context.addIssue({
@@ -539,25 +540,21 @@ export const agentContextDiagnosticsReportSchema = z.object({
     });
   }
 
-  if (value.safety.cloudCatalogToolsListPerformed) {
+  // Engine registration state and agent tool policy are deliberately not
+  // preconditions here: the independent runtime probe exists to diagnose
+  // engine-side failures, and it never calls a tool. Retained runtime
+  // evidence must still prove which managed entry was probed.
+  if (value.safety.cloudCatalogToolsListPerformed || value.safety.cloudSessionCleanupRequested) {
     const runtimeCloudMcp = value.mcps.find((mcp) =>
       mcp.source === "config.remote"
       && mcp.name === "openwork-cloud"
-      && mcp.path === "/mcp/agent"
-      && mcp.syncStatus === "connected",
+      && mcp.path === "/mcp/agent",
     );
     if (!runtimeCloudMcp) {
       context.addIssue({
         code: "custom",
-        message: "cloud tools/list requires retained connected runtime OpenWork Cloud evidence",
+        message: "cloud handshake evidence requires the retained runtime OpenWork Cloud entry",
         path: ["mcps"],
-      });
-    }
-    if (value.agent.evidenceSource !== "effective-engine" || toolPolicyCheck?.status !== "passed") {
-      context.addIssue({
-        code: "custom",
-        message: "cloud tools/list requires observed effective agent policy that does not deny the candidate tool IDs",
-        path: ["safety", "cloudCatalogToolsListPerformed"],
       });
     }
   }

--- a/apps/server/src/agent-context-diagnostics.test.ts
+++ b/apps/server/src/agent-context-diagnostics.test.ts
@@ -561,9 +561,15 @@ describe("agent context diagnostics analyzer", () => {
       status: "warning",
       code: "per_request_connect_context_not_observed",
     });
+    expect(checkById(report, "cloud-endpoint-differential")).toMatchObject({
+      status: "passed",
+      evidenceKind: "derived",
+      code: "runtime_and_engine_connected",
+    });
     expect(report.safety).toMatchObject({
       diagnosticsWorkspaceRuntimeConfigurationReadOnly: true,
       cloudCatalogToolsListPerformed: true,
+      cloudSessionCleanupRequested: true,
       directNonCloudMcpFetchPerformed: false,
       directMcpToolCallPerformed: false,
       directProviderOperationPerformed: false,
@@ -579,10 +585,10 @@ describe("agent context diagnostics analyzer", () => {
         !(mcp.source === "config.remote" && mcp.name === "openwork-cloud"),
       ),
     }).success).toBe(false);
-    expect(fetchCalls).toHaveLength(3);
-    expect(fetchCalls.map((call) => call.url)).toEqual([CLOUD_ENDPOINT, CLOUD_ENDPOINT, CLOUD_ENDPOINT]);
-    expect(fetchCalls.map((call) => call.method)).toEqual(["POST", "POST", "POST"]);
-    expect(fetchCalls.map((call) => call.body.method)).toEqual([
+    expect(fetchCalls).toHaveLength(4);
+    expect(fetchCalls.map((call) => call.url)).toEqual([CLOUD_ENDPOINT, CLOUD_ENDPOINT, CLOUD_ENDPOINT, CLOUD_ENDPOINT]);
+    expect(fetchCalls.map((call) => call.method)).toEqual(["POST", "POST", "POST", "DELETE"]);
+    expect(fetchCalls.slice(0, 3).map((call) => call.body.method)).toEqual([
       "initialize",
       "notifications/initialized",
       "tools/list",
@@ -591,6 +597,7 @@ describe("agent context diagnostics analyzer", () => {
     expect(fetchCalls[0]?.headers.get("accept")).toBe("application/json, text/event-stream");
     expect(fetchCalls[0]?.headers.has("mcp-session-id")).toBe(false);
     expect(fetchCalls[2]?.headers.get("mcp-session-id")).toBe("diagnostics-test-session");
+    expect(fetchCalls[3]?.headers.get("mcp-session-id")).toBe("diagnostics-test-session");
     expect(engine.requests).toEqual([]);
 
     const serialized = JSON.stringify(report);
@@ -614,7 +621,7 @@ describe("agent context diagnostics analyzer", () => {
     expect(serialized).not.toMatch(/[\u0000-\u001f\u007f-\u009f\u061c\u200e\u200f\u202a-\u202e\u2066-\u2069]/u);
   });
 
-  test("does not egress or label tools allowed without an effective engine inspection", async () => {
+  test("probes the endpoint without an effective engine inspection while tool policy stays its own dimension", async () => {
     const fixture = await createFixture();
     const fetchCalls: CatalogFetchCall[] = [];
 
@@ -643,14 +650,16 @@ describe("agent context diagnostics analyzer", () => {
         ]),
       },
     });
+    // An unavailable tool policy is a separate diagnostic dimension; it must
+    // never be reported as endpoint unavailability.
     expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
-      status: "warning",
-      evidenceKind: "unavailable",
-      code: "cloud_tool_policy_unavailable",
-      details: { requestPerformed: false },
+      status: "passed",
+      evidenceKind: "observed",
+      code: "cloud_catalog_exact_match",
+      details: { requestPerformed: true },
     });
-    expect(report.safety.cloudCatalogToolsListPerformed).toBe(false);
-    expect(fetchCalls).toEqual([]);
+    expect(report.safety.cloudCatalogToolsListPerformed).toBe(true);
+    expect(fetchCalls).toHaveLength(4);
   });
 
   test("retains the probed runtime cloud MCP when the combined inventory is truncated", async () => {
@@ -694,10 +703,10 @@ describe("agent context diagnostics analyzer", () => {
       status: "passed",
       code: "cloud_catalog_exact_match",
     });
-    expect(fetchCalls).toHaveLength(3);
+    expect(fetchCalls).toHaveLength(4);
   });
 
-  test("honors a whole-resource deny from the effective engine agent before cloud egress", async () => {
+  test("keeps a whole-resource deny in the policy dimension while the endpoint probe still runs", async () => {
     const fixture = await createFixture();
     const fetchCalls: CatalogFetchCall[] = [];
 
@@ -725,9 +734,12 @@ describe("agent context diagnostics analyzer", () => {
       evidenceKind: "observed",
       code: "required_connect_tools_denied_by_effective_policy",
     });
+    // The policy deny stays a policy failure; the endpoint itself is probed
+    // and reported on its own dimension.
     expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
-      code: "cloud_tool_policy_denied",
-      details: { requestPerformed: false },
+      status: "passed",
+      code: "cloud_catalog_exact_match",
+      details: { requestPerformed: true },
     });
     expect(report.mcps.find(
       (mcp) => mcp.name === "openwork-cloud" && mcp.source === "engine.config",
@@ -735,7 +747,7 @@ describe("agent context diagnostics analyzer", () => {
       source: "engine.config",
       disabledByTools: true,
     });
-    expect(fetchCalls).toEqual([]);
+    expect(fetchCalls).toHaveLength(4);
   });
 
   test("reports an effective ask rule as approval required while keeping the visible tool probe eligible", async () => {
@@ -774,7 +786,7 @@ describe("agent context diagnostics analyzer", () => {
       code: "cloud_catalog_exact_match",
       details: { requestPerformed: true },
     });
-    expect(fetchCalls).toHaveLength(3);
+    expect(fetchCalls).toHaveLength(4);
   });
 
   test("distinguishes a missing Connect state default from a corrupt state file", async () => {
@@ -856,15 +868,21 @@ describe("agent context diagnostics analyzer", () => {
 
     const check = checkById(report, "cloud-tool-catalog");
     expect(check).toMatchObject({
-      status: "failed",
-      evidenceKind: "derived",
+      status: "warning",
+      evidenceKind: "unavailable",
       code: "untrusted_endpoint",
       owner: "openwork-server",
-      message: "The server did not send the credentialed cloud catalog request because the Cloud endpoint origin is not in the diagnostics trust list.",
-      details: { requestPerformed: false },
+      details: { requestPerformed: false, handshakePerformed: false, stage: "eligibility" },
     });
-    expect(check.action).toBe("Set OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS on the OpenWork desktop/server process to include the Cloud endpoint origin, then rerun diagnostics.");
+    // An untrusted origin means no request occurred; the report must describe
+    // a trust-configuration state, never a network, TLS, or MCP failure.
+    expect(check.message).toContain("not performed");
+    expect(check.message).toContain("trust");
     expect(check.action).toContain("OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS");
+    expect(checkById(report, "cloud-endpoint-differential")).toMatchObject({
+      status: "skipped",
+      code: "runtime_probe_not_performed",
+    });
     expect(fetchCalls).toEqual([]);
   });
 
@@ -900,14 +918,15 @@ describe("agent context diagnostics analyzer", () => {
         evidenceKind: "unavailable",
       });
       expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
-        code: "cloud_tool_policy_unavailable",
-        details: { requestPerformed: false },
+        status: "passed",
+        code: "cloud_catalog_exact_match",
+        details: { requestPerformed: true },
       });
       expect(report.safety.engineApiReadPerformed).toBe(true);
       expect(JSON.stringify(report)).not.toContain("RAW_ENGINE_ERROR_CANARY");
     }
 
-    expect(fetchCalls).toEqual([]);
+    expect(fetchCalls).toHaveLength(8);
   });
 
   test("fails closed when the effective engine does not resolve the OpenWork agent", async () => {
@@ -931,10 +950,11 @@ describe("agent context diagnostics analyzer", () => {
       details: { policyUnavailableReasons: ["effective_openwork_agent_missing"] },
     });
     expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
-      code: "cloud_tool_policy_unavailable",
-      details: { requestPerformed: false },
+      status: "passed",
+      code: "cloud_catalog_exact_match",
+      details: { requestPerformed: true },
     });
-    expect(fetchCalls).toEqual([]);
+    expect(fetchCalls).toHaveLength(4);
   });
 
   test("rejects hidden and subagent-only OpenWork defaults before cloud egress", async () => {
@@ -969,10 +989,11 @@ describe("agent context diagnostics analyzer", () => {
         code: "effective_connect_tool_policy_unavailable",
       });
       expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
-        code: "cloud_tool_policy_unavailable",
-        details: { requestPerformed: false },
+        status: "passed",
+        code: "cloud_catalog_exact_match",
+        details: { requestPerformed: true },
       });
-      expect(fetchCalls).toEqual([]);
+      expect(fetchCalls).toHaveLength(4);
     }
   });
 
@@ -1101,14 +1122,22 @@ describe("agent context diagnostics analyzer", () => {
     expect(report.firstFailedCheck).toBe("cloud-tool-catalog");
     expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
       status: "failed",
-      code: "invalid_catalog",
+      code: "required_tools_missing",
       details: {
         expectedToolIds: ["search_capabilities", "execute_capability"],
         observedToolIds: [],
         requestPerformed: true,
+        stage: "catalog_validation",
+        totalToolCount: 1,
+        requiredToolsPresent: false,
+        retryable: false,
       },
     });
-    expect(fetchCalls).toHaveLength(3);
+    expect(checkById(report, "cloud-endpoint-differential")).toMatchObject({
+      status: "warning",
+      code: "runtime_failed_engine_connected",
+    });
+    expect(fetchCalls).toHaveLength(4);
   });
 
   test("reports a corrupt runtime database as failed and unavailable without egress", async () => {
@@ -1145,7 +1174,7 @@ describe("agent context diagnostics analyzer", () => {
     expect(JSON.stringify(report)).not.toContain("CANARY_DB_SECRET");
   });
 
-  test("does not probe when the current cloud registration fingerprint is not recorded", async () => {
+  test("probes despite an unrecorded registration and reports stale-or-missing engine evidence", async () => {
     const fixture = await createFixture();
     const fetchCalls: CatalogFetchCall[] = [];
 
@@ -1164,15 +1193,20 @@ describe("agent context diagnostics analyzer", () => {
     expect(report.firstFailedCheck).toBeNull();
     expect(checkById(report, "engine-mcp-sync")).toMatchObject({ status: "warning", code: "mcp_registration_not_recorded" });
     expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
-      status: "warning",
-      code: "registration_not_recorded",
-      details: { requestPerformed: false },
+      status: "passed",
+      code: "cloud_catalog_exact_match",
+      details: { requestPerformed: true },
     });
-    expect(report.safety.cloudCatalogToolsListPerformed).toBe(false);
-    expect(fetchCalls).toEqual([]);
+    expect(checkById(report, "cloud-endpoint-differential")).toMatchObject({
+      status: "warning",
+      code: "engine_evidence_stale_or_unavailable",
+      details: { engineRegistrationStatus: "not-recorded" },
+    });
+    expect(report.safety.cloudCatalogToolsListPerformed).toBe(true);
+    expect(fetchCalls).toHaveLength(4);
   });
 
-  test("reports an engine needs-auth registration as failed injection evidence without egress", async () => {
+  test("separates a reachable endpoint from an engine needs-auth registration", async () => {
     const fixture = await createFixture();
     const fetchCalls: CatalogFetchCall[] = [];
     const report = await runAgentContextDiagnostics({
@@ -1192,11 +1226,17 @@ describe("agent context diagnostics analyzer", () => {
       details: { needsAuthCount: 3, connectedCount: 0 },
     });
     expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
-      status: "failed",
-      code: "registration_needs_auth",
-      details: { requestPerformed: false },
+      status: "passed",
+      code: "cloud_catalog_exact_match",
+      details: { requestPerformed: true },
     });
-    expect(fetchCalls).toEqual([]);
+    expect(checkById(report, "cloud-endpoint-differential")).toMatchObject({
+      status: "failed",
+      code: "runtime_connected_engine_failed",
+      owner: "opencode-engine",
+      details: { engineRegistrationStatus: "needs-auth" },
+    });
+    expect(fetchCalls).toHaveLength(4);
   });
 
   test("downgrades stale failed registration evidence when the engine is reachable", async () => {
@@ -1228,7 +1268,12 @@ describe("agent context diagnostics analyzer", () => {
       { name: "non-cloud-canary", status: "failed", source: "transport_failure", recordAgeMs: 61_000, engineReachableNow: true },
       { name: "[redacted-sensitive-label]", status: "failed", source: "transport_failure", recordAgeMs: 61_000, engineReachableNow: true },
     ]);
-    expect(fetchCalls).toEqual([]);
+    expect(checkById(report, "cloud-endpoint-differential")).toMatchObject({
+      status: "warning",
+      code: "engine_evidence_stale_or_unavailable",
+      details: { engineEvidenceAgeMs: 61_000 },
+    });
+    expect(fetchCalls).toHaveLength(4);
   });
 
   test("keeps fresh failed registration evidence as a failed check", async () => {
@@ -1254,7 +1299,12 @@ describe("agent context diagnostics analyzer", () => {
       code: "mcp_registration_not_connected",
       details: { engineReachableNow: true, failedCount: 3 },
     });
-    expect(fetchCalls).toEqual([]);
+    expect(checkById(report, "cloud-endpoint-differential")).toMatchObject({
+      status: "failed",
+      code: "runtime_connected_engine_failed",
+      details: { engineRegistrationStatus: "failed", engineEvidenceSource: "engine_status", engineEvidenceAgeMs: 1_000 },
+    });
+    expect(fetchCalls).toHaveLength(4);
   });
 
   test("reports a missing credential without putting authorization-shaped text in the report", async () => {
@@ -1326,15 +1376,15 @@ describe("agent context diagnostics analyzer", () => {
       },
     });
     expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
-      status: "failed",
-      code: "cloud_tool_policy_denied",
-      details: { requestPerformed: false },
+      status: "passed",
+      code: "cloud_catalog_exact_match",
+      details: { requestPerformed: true },
     });
     expect(report.mcps.find((mcp) => (
       mcp.name === "openwork-cloud" && mcp.source === "config.remote"
     ))?.disabledByTools).toBe(true);
-    expect(report.safety.cloudCatalogToolsListPerformed).toBe(false);
-    expect(fetchCalls).toEqual([]);
+    expect(report.safety.cloudCatalogToolsListPerformed).toBe(true);
+    expect(fetchCalls).toHaveLength(4);
   });
 
   test("fails closed when a static OpenCode tool policy layer is invalid", async () => {
@@ -1372,13 +1422,12 @@ describe("agent context diagnostics analyzer", () => {
       details: { projectLayerStatus: "invalid" },
     });
     expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
-      status: "warning",
-      evidenceKind: "unavailable",
-      code: "cloud_tool_policy_unavailable",
-      details: { requestPerformed: false },
+      status: "passed",
+      code: "cloud_catalog_exact_match",
+      details: { requestPerformed: true },
     });
-    expect(report.safety.cloudCatalogToolsListPerformed).toBe(false);
-    expect(fetchCalls).toEqual([]);
+    expect(report.safety.cloudCatalogToolsListPerformed).toBe(true);
+    expect(fetchCalls).toHaveLength(4);
   });
 
   test("never reads a same-id local runtime row or performs egress for a remote workspace shell", async () => {
@@ -1462,7 +1511,7 @@ describe("agent context diagnostics analyzer", () => {
     releaseProbe();
     const [firstReport, secondReport] = await Promise.all([first, second]);
 
-    expect(fetchCalls).toHaveLength(6);
+    expect(fetchCalls).toHaveLength(8);
     expect(firstReport.organizationConnections.map((connection) => connection.id)).toEqual(["org.first"]);
     expect(secondReport.organizationConnections.map((connection) => connection.id)).toEqual(["org.second"]);
     expect(firstReport.organizationConnections[0]?.name).toBe("First organization");
@@ -1609,13 +1658,14 @@ describe("agent context diagnostics route", () => {
     });
     expect(report.safety.engineApiReadPerformed).toBe(true);
     expect(report.safety.cloudCatalogToolsListPerformed).toBe(true);
-    expect(catalogCalls).toHaveLength(3);
-    expect(catalogCalls.map((call) => call.body.method)).toEqual([
+    expect(catalogCalls).toHaveLength(4);
+    expect(catalogCalls.slice(0, 3).map((call) => call.body.method)).toEqual([
       "initialize",
       "notifications/initialized",
       "tools/list",
     ]);
-    expect(downstreamFetches.filter((url) => url === CLOUD_ENDPOINT)).toHaveLength(3);
+    expect(catalogCalls[3]?.method).toBe("DELETE");
+    expect(downstreamFetches.filter((url) => url === CLOUD_ENDPOINT)).toHaveLength(4);
     expect(engine.requests
       .slice(engineRequestCountBeforeDiagnostics)
       .filter((request) => request.method === "GET")

--- a/apps/server/src/agent-context-diagnostics.ts
+++ b/apps/server/src/agent-context-diagnostics.ts
@@ -23,6 +23,7 @@ import {
   type InspectAgentDiagnosticsEngine,
 } from "./agent-context-engine-inspection.js";
 import {
+  differentialCloudVerdict,
   probeOpenworkCloudCatalog,
   type CloudCatalogProbe,
 } from "./agent-context-cloud-probe.js";
@@ -444,6 +445,20 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
       handshakePerformed: probe.performed,
       requestPerformed: probe.toolsListPerformed,
       httpStatus: probe.httpStatus,
+      stage: probe.stage,
+      networkCode: probe.networkCode,
+      retryable: probe.retryable,
+      runtimeFamily: probe.runtimeFamily,
+      transport: probe.transport,
+      sessionEstablished: probe.sessionEstablished,
+      sessionCleanupAttempted: probe.cleanupAttempted,
+      sessionCleanupSucceeded: probe.cleanupSucceeded,
+      totalToolCount: probe.totalToolCount,
+      requiredToolsPresent: probe.requiredToolsPresent,
+      referenceId: probe.referenceId,
+      proxyConfigured: probe.proxyConfigured,
+      extraCaConfigured: probe.extraCaConfigured,
+      probeSteps: probe.steps,
     },
   };
   if (probe.status === "observed") {
@@ -474,7 +489,7 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
     case "runtime_config_unavailable":
       status = "warning";
       evidenceKind = "unavailable";
-      message = "The passive runtime configuration snapshot is unavailable, so the cloud catalog request was not started.";
+      message = "The passive runtime configuration snapshot is unavailable, so the runtime endpoint probe was not started.";
       action = "Start or repair the selected workspace runtime, then rerun diagnostics.";
       break;
     case "remote_workspace_unavailable":
@@ -492,18 +507,6 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
       message = "The selected workspace OpenWork Cloud MCP entry is disabled.";
       action = "Enable or reconnect OpenWork Cloud from Settings > Connect, then rerun diagnostics.";
       break;
-    case "cloud_tool_policy_unavailable":
-      status = "warning";
-      evidenceKind = "unavailable";
-      owner = "opencode-engine";
-      message = "Required tool visibility could not be observed from the selected engine's effective OpenWork agent, so the cloud catalog request was not started.";
-      action = "Check the selected workspace engine health and rerun diagnostics.";
-      break;
-    case "cloud_tool_policy_denied":
-      owner = "member";
-      message = "Policy evidence denies at least one required OpenWork Cloud tool, so the cloud catalog request was not started.";
-      action = "Allow the required openwork-cloud capability tool IDs in the workspace or OpenWork agent policy, then rerun diagnostics.";
-      break;
     case "cloud_mcp_not_remote":
       message = "The managed OpenWork Cloud entry is not configured as a remote MCP.";
       action = "Reconnect OpenWork Cloud to restore its managed remote configuration.";
@@ -513,8 +516,10 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
       action = "Reconnect OpenWork Cloud to restore its managed endpoint, then rerun diagnostics.";
       break;
     case "untrusted_endpoint":
-      message = "The server did not send the credentialed cloud catalog request because the Cloud endpoint origin is not in the diagnostics trust list.";
-      action = "Set OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS on the OpenWork desktop/server process to include the Cloud endpoint origin, then rerun diagnostics.";
+      status = "warning";
+      evidenceKind = "unavailable";
+      message = "The runtime endpoint probe was not performed because the configured origin is not in the diagnostics trust list; no request was sent, so this is a trust-configuration state, not a network, TLS, or MCP failure.";
+      action = "Have an administrator set OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS on the OpenWork desktop/server process to the exact Cloud or on-prem Den endpoint origin, then rerun diagnostics.";
       break;
     case "credential_missing":
     case "duplicate_authorization":
@@ -522,76 +527,64 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
       message = "The managed OpenWork Cloud entry does not contain one unambiguous authentication value.";
       action = "Reconnect OpenWork Cloud so the client can replace the managed credential, then rerun diagnostics.";
       break;
-    case "registration_failed":
-      owner = "opencode-engine";
-      message = "The selected engine reported that this exact OpenWork Cloud registration failed, so no new egress was started.";
-      action = "Repair the selected workspace runtime registration, then rerun diagnostics.";
-      break;
-    case "registration_disabled":
-      owner = "opencode-engine";
-      message = "The selected engine reported this enabled OpenWork Cloud registration as disabled, so no new egress was started.";
-      action = "Enable the managed OpenWork Cloud MCP in the selected engine, then rerun diagnostics.";
-      break;
-    case "registration_needs_auth":
-      owner = "member";
-      message = "The selected engine reported that OpenWork Cloud needs authentication, so no new egress was started.";
-      action = "Reconnect OpenWork Cloud from Settings > Connect, then rerun diagnostics.";
-      break;
-    case "registration_needs_client_registration":
-      owner = "openwork-server";
-      message = "The selected engine reported that OpenWork Cloud needs MCP client registration, so no new egress was started.";
-      action = "Repair the selected engine MCP client-registration flow, then rerun diagnostics.";
-      break;
-    case "registration_not_recorded":
-      status = "warning";
-      owner = "opencode-engine";
-      message = "This exact runtime-managed OpenWork Cloud configuration has no current engine registration record, so no new egress was started.";
-      action = "Start the selected workspace runtime so its managed MCP registration connects, then rerun diagnostics.";
-      break;
     case "timeout":
     case "network_error":
     case "redirect_rejected":
     case "http_error":
       owner = "network-admin";
-      message = "The one-shot OpenWork Cloud catalog request could not be completed through the configured network path.";
+      message = "The independent runtime endpoint probe could not be completed through the configured network path.";
       action = "Verify server egress, DNS, TLS, proxy policy, and the configured OpenWork Cloud service, then rerun diagnostics.";
       break;
     case "dns_error":
       owner = "network-admin";
-      message = "The one-shot OpenWork Cloud catalog request could not resolve the configured service hostname.";
+      message = "The independent runtime endpoint probe could not resolve the configured service hostname.";
       action = "Verify DNS resolution from the OpenWork server, then rerun diagnostics.";
       break;
     case "connection_refused":
       owner = "network-admin";
-      message = "The configured OpenWork Cloud service refused the one-shot catalog connection.";
+      message = "The configured OpenWork Cloud service refused the independent runtime probe connection.";
       action = "Verify the service listener, firewall, and egress route, then rerun diagnostics.";
       break;
     case "connection_reset":
       owner = "network-admin";
-      message = "The one-shot OpenWork Cloud catalog connection was reset before a response completed.";
+      message = "The independent runtime probe connection was reset before a response completed.";
       action = "Verify the service, proxy, and network path, then rerun diagnostics.";
       break;
     case "tls_error":
       owner = "network-admin";
-      message = "The one-shot OpenWork Cloud catalog request failed TLS certificate validation or negotiation.";
+      message = "The independent runtime endpoint probe failed TLS certificate validation or negotiation on the OpenWork runtime trust store.";
       action = "Verify the server trust store, enterprise certificates, TLS inspection, and service certificate, then rerun diagnostics.";
       break;
     case "proxy_error":
       owner = "network-admin";
-      message = "The configured proxy could not complete the one-shot OpenWork Cloud catalog request.";
+      message = "The configured proxy could not complete the independent runtime endpoint probe.";
       action = "Verify proxy reachability, authentication, and bypass policy, then rerun diagnostics.";
       break;
     case "unauthorized":
-    case "forbidden":
       owner = "openwork-client";
-      message = "OpenWork Cloud rejected the configured credential during the one-shot catalog request.";
+      message = "OpenWork Cloud rejected the configured credential during the independent runtime probe.";
       action = "Reconnect OpenWork Cloud so the client can replace the managed credential, then rerun diagnostics.";
+      break;
+    case "forbidden":
+      owner = "organization-admin";
+      message = "OpenWork Cloud rejected the probe for membership, scope, or policy reasons rather than credential validity.";
+      action = "Verify organization membership, workspace scope, and Cloud policy for this credential, then rerun diagnostics.";
+      break;
+    case "mcp_route_not_found":
+      owner = "openwork-support";
+      message = "The configured service answered, but the MCP agent route was not found; the deployment version or route configuration is implicated.";
+      action = "Verify the OpenWork Cloud or on-prem Den deployment version exposes the /mcp/agent route, then rerun diagnostics.";
       break;
     case "rate_limited":
       status = "warning";
       owner = "openwork-support";
-      message = "OpenWork Cloud rate-limited the one-shot catalog request.";
+      message = "OpenWork Cloud rate-limited the independent runtime probe.";
       action = "Wait before rerunning diagnostics; contact OpenWork support if rate limiting persists.";
+      break;
+    case "gateway_unavailable":
+      owner = "network-admin";
+      message = "A gateway or upstream in front of the OpenWork Cloud service reported it unavailable during the independent runtime probe.";
+      action = "Check service status and gateway health, wait briefly, then rerun diagnostics.";
       break;
     case "probe_busy":
       status = "warning";
@@ -602,13 +595,23 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
       break;
     case "response_too_large":
     case "invalid_content_type":
-    case "invalid_response":
+    case "invalid_utf8":
+    case "invalid_json":
+    case "invalid_jsonrpc_envelope":
+    case "request_id_mismatch":
     case "jsonrpc_error":
+    case "unsupported_protocol_version":
+    case "invalid_session_header":
     case "pagination_unsupported":
     case "invalid_catalog":
       owner = "openwork-support";
-      message = "OpenWork Cloud returned a response that does not satisfy the bounded tools/list protocol contract.";
-      action = "Review the OpenWork Cloud deployment and restore the canonical two-tool catalog response.";
+      message = "OpenWork Cloud returned a response that does not satisfy the bounded MCP handshake protocol contract.";
+      action = "Review the OpenWork Cloud deployment and restore a conformant MCP handshake response.";
+      break;
+    case "required_tools_missing":
+      owner = "openwork-support";
+      message = "The OpenWork Cloud catalog handshake succeeded, but the catalog does not contain both required capability tools.";
+      action = "Review the OpenWork Cloud deployment and restore the canonical capability catalog.";
       break;
   }
   return diagnosticCheck({
@@ -619,6 +622,84 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
     message,
     owner,
     action,
+  });
+}
+
+function cloudDifferentialCheck(probe: CloudCatalogProbe, engineReachableNow: boolean): AgentContextDiagnosticCheck {
+  const verdict = differentialCloudVerdict(probe);
+  const common = {
+    id: "cloud-endpoint-differential" as const,
+    code: verdict,
+    details: {
+      runtimeProbeStatus: probe.status,
+      runtimeProbeStage: probe.stage,
+      runtimeProbeCode: probe.code,
+      runtimeProbeRetryable: probe.retryable,
+      runtimeFamily: probe.runtimeFamily,
+      transport: probe.transport,
+      engineRegistrationStatus: probe.engineRegistrationStatus,
+      engineEvidenceSource: probe.engineEvidenceSource,
+      engineEvidenceAgeMs: probe.engineEvidenceAgeMs,
+      engineReachableNow,
+    },
+  };
+  if (verdict === "runtime_and_engine_connected") {
+    return diagnosticCheck({
+      ...common,
+      status: "passed",
+      evidenceKind: "derived",
+      message: "The independent OpenWork runtime probe and the engine registration evidence both report the OpenWork Cloud endpoint as reachable.",
+      owner: "openwork-server",
+      action: "No action is required.",
+    });
+  }
+  if (verdict === "runtime_connected_engine_failed") {
+    return diagnosticCheck({
+      ...common,
+      status: "failed",
+      evidenceKind: "derived",
+      message: "The OpenWork runtime reached the Cloud endpoint directly, but the engine registration evidence reports a failure; the engine-side connection path or registration lifecycle is implicated, not the endpoint.",
+      owner: "opencode-engine",
+      action: "Reconnect OpenWork Cloud or restart the selected workspace engine, then rerun diagnostics; the endpoint itself is reachable from this machine.",
+    });
+  }
+  if (verdict === "runtime_failed_engine_connected") {
+    return diagnosticCheck({
+      ...common,
+      status: "warning",
+      evidenceKind: "derived",
+      message: "The engine registration evidence reports a live connection, but the independent runtime probe failed; the OpenWork runtime network path is implicated rather than the endpoint or the engine.",
+      owner: "network-admin",
+      action: "Compare proxy, DNS, and trust-store configuration between the OpenWork runtime and the engine process, then rerun diagnostics.",
+    });
+  }
+  if (verdict === "runtime_and_engine_failed") {
+    return diagnosticCheck({
+      ...common,
+      status: "failed",
+      evidenceKind: "derived",
+      message: "Both the independent runtime probe and the engine registration evidence report failures; the endpoint or the shared network path is implicated.",
+      owner: "network-admin",
+      action: "Verify endpoint availability, network egress, and credentials, then rerun diagnostics.",
+    });
+  }
+  if (verdict === "engine_evidence_stale_or_unavailable") {
+    return diagnosticCheck({
+      ...common,
+      status: "warning",
+      evidenceKind: "derived",
+      message: "The engine registration evidence for OpenWork Cloud is stale or was never recorded, so only the independent runtime observation is current.",
+      owner: "opencode-engine",
+      action: "Start or reconnect the selected workspace engine to refresh its registration evidence, then rerun diagnostics.",
+    });
+  }
+  return diagnosticCheck({
+    ...common,
+    status: "skipped",
+    evidenceKind: "unavailable",
+    message: "The independent runtime probe was not performed, so endpoint availability cannot be compared with the engine registration evidence.",
+    owner: "openwork-server",
+    action: "Address the probe eligibility code reported by the cloud catalog check, then rerun diagnostics.",
   });
 }
 
@@ -883,7 +964,9 @@ export async function runAgentContextDiagnostics(input: {
   input.dependencies?.signal?.throwIfAborted();
   const now = input.dependencies?.now ?? Date.now;
   const uuid = input.dependencies?.uuid ?? randomUUID;
-  const fetchImpl = input.dependencies?.fetchImpl ?? fetch;
+  // No global-fetch fallback here: the probe resolves its transport through
+  // the named runtimeDiagnosticFetch wrapper unless a test seam is injected.
+  const fetchImpl = input.dependencies?.fetchImpl;
   const startedMs = now();
   const startedAt = new Date(startedMs).toISOString();
   const runId = uuid();
@@ -1078,6 +1161,13 @@ export async function runAgentContextDiagnostics(input: {
     if (decision === "ask") return "approval-required";
     return "unspecified";
   };
+  const engineReachableNow = engineInspectionStatus === "observed" || engineInspectionStatus === "invalid";
+  const cloudRegistration = runtimeCloudItem && runtimeCloudConfig
+    ? registrationForItem(runtimeCloudItem)
+    : null;
+  // Cached engine registration and agent tool policy are comparison inputs
+  // for the differential verdict, never eligibility gates: the independent
+  // runtime probe exists precisely to diagnose engine-side failures.
   const cloudProbe = await probeOpenworkCloudCatalog({
     workspaceId: input.workspace.id,
     workspaceType: input.workspace.workspaceType,
@@ -1087,15 +1177,11 @@ export async function runAgentContextDiagnostics(input: {
       || runtimeInspection.status === "table-missing"
       ? null
       : runtimeCloudConfig,
-    toolPolicyStatus: cloudToolPolicyStatus,
-    toolPolicyProvenance: effectiveEngine && effectiveToolPolicy.status !== "unavailable"
-      ? "authoritative-effective-engine"
-      : staticallyDeniedCloudAgentToolIds.size > 0
-        ? "passive-static-subset"
-        : "unavailable",
-    registrationStatus: runtimeCloudItem && runtimeCloudConfig
-      ? registrationForItem(runtimeCloudItem).status
-      : "not-recorded",
+    engineRegistration: {
+      status: cloudRegistration?.status ?? "not-recorded",
+      source: cloudRegistration?.source ?? null,
+      recordAgeMs: cloudRegistration?.recordAgeMs ?? null,
+    },
     requestId: runId,
     fetchImpl,
     now,
@@ -1104,7 +1190,6 @@ export async function runAgentContextDiagnostics(input: {
   input.dependencies?.signal?.throwIfAborted();
 
   const remoteMcps = inventory.items.filter((item) => item.source === "config.remote");
-  const engineReachableNow = engineInspectionStatus === "observed" || engineInspectionStatus === "invalid";
   const registrationInspections = remoteMcps.map((item) => registrationForItem(item));
   const enabledRemoteMcps = remoteMcps.filter((item) => item.config.enabled !== false);
   const disabledRemoteMcps = remoteMcps.filter((item) => item.config.enabled === false);
@@ -1500,6 +1585,7 @@ export async function runAgentContextDiagnostics(input: {
       },
     }),
     cloudCatalogCheck(cloudProbe),
+    cloudDifferentialCheck(cloudProbe, engineReachableNow),
     organizationCheck(request),
     diagnosticCheck({
       id: "report-safety",
@@ -1592,6 +1678,7 @@ export async function runAgentContextDiagnostics(input: {
     safety: {
       diagnosticsWorkspaceRuntimeConfigurationReadOnly: true,
       cloudCatalogToolsListPerformed: cloudProbe.toolsListPerformed,
+      cloudSessionCleanupRequested: cloudProbe.cleanupAttempted,
       directNonCloudMcpFetchPerformed: false,
       directMcpToolCallPerformed: false,
       directProviderOperationPerformed: false,

--- a/apps/server/src/no-bare-fetch.test.ts
+++ b/apps/server/src/no-bare-fetch.test.ts
@@ -4,7 +4,12 @@ import { dirname, join, relative, sep } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const srcDir = dirname(fileURLToPath(import.meta.url));
-const bareFetchPattern = /(?<![.\w])fetch\s*\(/;
+// Flags every bare `fetch` reference, not only call sites, so fallback
+// expressions such as `input.fetchImpl ?? fetch` or `= fetch` cannot bypass
+// the ban. Allowed contexts: member access (`globalThis.fetch`), the
+// type-only `typeof fetch`, `fetch:` object/type keys, and prose where the
+// word `fetch` is followed by another word.
+const bareFetchPattern = /(?<![-.\w$])(?<!typeof )fetch\b(?!\s*:)(?!\s+[A-Za-z_$])/;
 
 async function collectTypescriptFiles(dir: string): Promise<string[]> {
   const entries = await readdir(dir, { withFileTypes: true });
@@ -41,11 +46,12 @@ test("server source does not use bare fetch", async () => {
     const lines = (await readFile(file, "utf8")).split(/\r?\n/);
     lines.forEach((line, index) => {
       const code = line.replace(/\/\/.*$/, "");
+      if (/^\s*[*/]/.test(code)) return;
       if (bareFetchPattern.test(code)) offenders.push(`${path}:${index + 1}`);
     });
   }
 
   if (offenders.length > 0) {
-    throw new Error(`Bare fetch is banned in apps/server/src. Use externalFetch for external egress or loopbackFetch for loopback/engine traffic. Offenders:\n${offenders.join("\n")}`);
+    throw new Error(`Bare fetch is banned in apps/server/src. Use externalFetch for external egress, loopbackFetch for loopback/engine traffic, or runtimeDiagnosticFetch for the independent runtime diagnostic probe. Offenders:\n${offenders.join("\n")}`);
   }
 });

--- a/apps/server/src/opencode-models-url.ts
+++ b/apps/server/src/opencode-models-url.ts
@@ -1,3 +1,5 @@
+import { loopbackFetch } from "./server-fetch.js";
+
 const LOCAL_MODELS_URL = "http://localhost:8791/models";
 const PRODUCTION_MODELS_URL = "https://models.openworklabs.com/";
 
@@ -15,7 +17,7 @@ export async function resolveOpencodeModelsUrl(
   if (env.OPENWORK_DEV_MODE !== "1") return PRODUCTION_MODELS_URL;
 
   try {
-    const response = await (options.fetchModels ?? fetch)(`${LOCAL_MODELS_URL}/api.json`, {
+    const response = await (options.fetchModels ?? loopbackFetch)(`${LOCAL_MODELS_URL}/api.json`, {
       signal: AbortSignal.timeout(1_000),
     });
     if (response.ok) return LOCAL_MODELS_URL;

--- a/apps/server/src/server-fetch.ts
+++ b/apps/server/src/server-fetch.ts
@@ -44,3 +44,37 @@ export function loopbackFetch(
 ): ReturnType<typeof globalThis.fetch> {
   return globalThis.fetch(input, init);
 }
+
+export type RuntimeDiagnosticRuntimeFamily = "electron-node" | "node" | "bun" | "unknown";
+export type RuntimeDiagnosticTransport = "node-undici" | "bun-fetch" | "test-seam" | "unknown";
+
+export type RuntimeDiagnosticTransportInfo = {
+  runtimeFamily: RuntimeDiagnosticRuntimeFamily;
+  transport: RuntimeDiagnosticTransport;
+};
+
+/**
+ * Identifies the JavaScript runtime and fetch transport behind
+ * runtimeDiagnosticFetch, so a diagnostic can attribute its own egress path
+ * instead of implying it exercised Chromium networking or the OpenCode engine.
+ */
+export function runtimeDiagnosticTransportInfo(): RuntimeDiagnosticTransportInfo {
+  const versions: Record<string, string | undefined> = process.versions;
+  if (versions.bun) return { runtimeFamily: "bun", transport: "bun-fetch" };
+  if (versions.electron && versions.node) return { runtimeFamily: "electron-node", transport: "node-undici" };
+  if (versions.node) return { runtimeFamily: "node", transport: "node-undici" };
+  return { runtimeFamily: "unknown", transport: "unknown" };
+}
+
+/**
+ * Deliberate runtime-diagnostic egress. Unlike externalFetch, this must stay
+ * on the embedding JavaScript runtime's own fetch stack (Node/undici inside
+ * Electron main and standalone Node, Bun's fetch in the compiled binary) and
+ * must never route through Chromium's electronNet or the OpenCode engine —
+ * that independence is what lets diagnostics compare the OpenWork runtime's
+ * network path against the engine's report. Pair every use with
+ * runtimeDiagnosticTransportInfo so reports state which stack actually ran.
+ */
+export function runtimeDiagnosticFetch(input: string | URL | Request, init?: RequestInit): Promise<Response> {
+  return globalThis.fetch(input, init);
+}

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -1012,7 +1012,7 @@ function buildOpencodeDirectoryHeader(directory: string) {
   return /[^\x00-\x7F]/.test(directory) ? encodeURIComponent(directory) : directory;
 }
 
-function createOpencodeDirectoryFetch(directory: string, fetchImpl: typeof fetch = fetch): typeof fetch {
+function createOpencodeDirectoryFetch(directory: string, fetchImpl: typeof fetch = globalThis.fetch): typeof fetch {
   return Object.assign(
     (input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) => {
       const request = input instanceof Request ? input : new Request(input, init);
@@ -1035,7 +1035,7 @@ export function createWorkspaceOpencodeClient(
 ) {
   const connection = resolveWorkspaceOpencodeConnection(config, workspace);
   const directory = resolveOpencodeDirectory(workspace);
-  const baseFetch = directory ? createOpencodeDirectoryFetch(directory) : fetch;
+  const baseFetch = directory ? createOpencodeDirectoryFetch(directory) : globalThis.fetch;
   const clientFetch = options?.boundedDiagnosticsReads
     ? createAgentDiagnosticsEngineFetch(baseFetch)
     : directory ? baseFetch : undefined;

--- a/apps/server/src/worker-activity-heartbeat.ts
+++ b/apps/server/src/worker-activity-heartbeat.ts
@@ -1,3 +1,4 @@
+import { externalFetch } from "./server-fetch.js";
 import { createWorkspaceOpencodeClient } from "./server.js";
 import type { ServerConfig } from "./types.js";
 
@@ -122,7 +123,7 @@ export async function postWorkerActivityHeartbeat(input: {
     input.now ? input.now() : Date.now(),
     input.config.activeWindowMs,
   );
-  const response = await (input.fetchImpl ?? fetch)(input.config.url, {
+  const response = await (input.fetchImpl ?? externalFetch)(input.config.url, {
     method: "POST",
     headers: {
       "Content-Type": "application/json",

--- a/packages/types/src/agent-context-diagnostics.ts
+++ b/packages/types/src/agent-context-diagnostics.ts
@@ -17,6 +17,7 @@ export const AGENT_CONTEXT_DIAGNOSTIC_CHECK_IDS = [
   "engine-mcp-sync",
   "engine-mcp-status",
   "cloud-tool-catalog",
+  "cloud-endpoint-differential",
   "organization-connections",
   "report-safety",
 ] as const
@@ -412,6 +413,7 @@ export const agentContextDiagnosticsReportSchema = z.object({
   safety: z.object({
     diagnosticsWorkspaceRuntimeConfigurationReadOnly: z.literal(true),
     cloudCatalogToolsListPerformed: z.boolean(),
+    cloudSessionCleanupRequested: z.boolean(),
     directNonCloudMcpFetchPerformed: z.literal(false),
     directMcpToolCallPerformed: z.literal(false),
     directProviderOperationPerformed: z.literal(false),
@@ -518,7 +520,6 @@ export const agentContextDiagnosticsReportSchema = z.object({
 
   const engineConfigCheck = value.checks.find((check) => check.id === "engine-config")
   const engineAgentCheck = value.checks.find((check) => check.id === "engine-agent")
-  const toolPolicyCheck = value.checks.find((check) => check.id === "agent-connect-tool-permissions")
   if (value.agent.evidenceSource === "effective-engine") {
     if (!value.safety.engineApiReadPerformed) {
       context.addIssue({
@@ -557,25 +558,21 @@ export const agentContextDiagnosticsReportSchema = z.object({
     })
   }
 
-  if (value.safety.cloudCatalogToolsListPerformed) {
+  // Engine registration state and agent tool policy are deliberately not
+  // preconditions here: the independent runtime probe exists to diagnose
+  // engine-side failures, and it never calls a tool. Retained runtime
+  // evidence must still prove which managed entry was probed.
+  if (value.safety.cloudCatalogToolsListPerformed || value.safety.cloudSessionCleanupRequested) {
     const runtimeCloudMcp = value.mcps.find((mcp) =>
       mcp.source === "config.remote"
       && mcp.name === "openwork-cloud"
-      && mcp.path === "/mcp/agent"
-      && mcp.syncStatus === "connected",
+      && mcp.path === "/mcp/agent",
     )
     if (!runtimeCloudMcp) {
       context.addIssue({
         code: "custom",
-        message: "cloud tools/list requires retained connected runtime OpenWork Cloud evidence",
+        message: "cloud handshake evidence requires the retained runtime OpenWork Cloud entry",
         path: ["mcps"],
-      })
-    }
-    if (value.agent.evidenceSource !== "effective-engine" || toolPolicyCheck?.status !== "passed") {
-      context.addIssue({
-        code: "custom",
-        message: "cloud tools/list requires observed effective agent policy that does not deny the candidate tool IDs",
-        path: ["safety", "cloudCatalogToolsListPerformed"],
       })
     }
   }


### PR DESCRIPTION
## What this does

Extends the Agent Context diagnostic so it can verify the configured `openwork-cloud` MCP endpoint **independently of OpenCode**, from the OpenWork runtime's own network stack, and then answer the differential question support actually needs:

- Did the independent Node/Bun runtime path reach the endpoint?
- What did OpenCode report for the same managed entry?
- If they disagree, which runtime boundary is implicated?
- At exactly which network or protocol stage did the independent probe fail?

The probe runs the complete bounded MCP handshake — `initialize` (with protocol-version validation), `notifications/initialized`, `tools/list`, and a bounded best-effort `DELETE` session cleanup. It never calls an MCP tool, never mutates configuration, never reconnects OpenCode, and never remints credentials.

## Runtime transport is now explicit

`apps/server/src/server-fetch.ts` gains `runtimeDiagnosticFetch` and `runtimeDiagnosticTransportInfo()`. The probe reports `runtimeFamily` (`electron-node` | `node` | `bun` | `unknown`) and `transport` (`node-undici` | `bun-fetch` | `test-seam` | `unknown`), so a Bun standalone result is never claimed to have come from Node, and the deliberate Node/undici path inside Electron main is a named seam instead of an accidental `?? fetch` fallback.

The bare-fetch guard test now flags bare `fetch` **references**, not just call sites, so `input.fetchImpl ?? fetch` can no longer bypass it. The sweep surfaced and fixed three more accidental fallbacks: `opencode-models-url.ts` (→ `loopbackFetch`), `worker-activity-heartbeat.ts` (→ `externalFetch`), and the engine-client default in `server.ts` (→ explicit `globalThis.fetch`).

## Eligibility is decoupled from OpenCode state

Cached registration states (`failed`, `needs-auth`, `needs-client-registration`, `not-recorded`) and agent tool policy no longer gate the probe — the probe exists precisely to diagnose those situations. They are now comparison inputs and separate reported dimensions. A denied or unavailable tool policy is never reported as endpoint unavailability.

The probe still skips (as `not-performed`, stage `eligibility`) for: remote-workspace privacy, disabled MCP config, missing/malformed/duplicate credentials, invalid endpoints, untrusted origins, expired overall deadline, and probe-concurrency exhaustion.

> **Reviewer note (deliberate behavior change):** the credentialed probe now runs in states where it previously did not (engine-failed registration, denied/unavailable tool policy). It remains bounded to explicit user-initiated diagnostics runs, local workspaces, the exact managed entry, and explicitly trusted origins only.

## Trust boundary preserved; on-prem audit result

Only built-in OpenWork Cloud origins, exact administrator-configured origins (`OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS`), and loopback may receive the credentialed request. Renderer/user-supplied URLs cannot widen this.

**Audit:** the enterprise/on-prem Den base origin (`denBaseUrl`) is provisioned desktop-side (desktop bootstrap / enterprise activation / connect-link claims in `apps/desktop/electron/workspace-store.mjs`) and is not visible to the server process, so the diagnostic cannot derive a trusted origin from it today. Per that result, `untrusted_endpoint` is reported as **probe not performed** (warning, stage `eligibility`) with an actionable admin-configuration explanation — explicitly *not* as a network/TLS/MCP failure. Plumbing the activation `denBaseUrl` into the server's trust list is left as a follow-up because the desktop runtime env wiring is owned by #3118's area (see overlap below).

## Detailed failure attribution

Failures no longer collapse into `network_error`/`invalid_response`. The typed result includes `performed`, `stage`, `code`, `networkCode`, `retryable`, `runtimeFamily`, `transport`, `httpStatus`, `durationMs`, `toolsListPerformed`, `sessionEstablished`, `cleanupAttempted`, `cleanupSucceeded`, `engineRegistrationStatus`, `engineEvidenceSource`, `engineEvidenceAgeMs`, `proxyConfigured`/`extraCaConfigured` (booleans only), a strictly validated `referenceId` (`x-request-id`), aggregate catalog counts, and a bounded list of sanitized step summaries.

- Closed stage enum: `eligibility`, `dns`, `connect`, `tls`, `proxy`, `initialize_request|_http|_protocol`, `initialized_notification`, `tools_list_request|_http|_protocol`, `catalog_validation`, `session_cleanup`, `complete`.
- Closed network codes: `ENOTFOUND`, `EAI_AGAIN`, `ECONNREFUSED`, `ECONNRESET`, `ETIMEDOUT`, `UND_ERR_CONNECT_TIMEOUT`, four TLS-validation codes + `ERR_TLS_CERT_ALTNAME_INVALID`, `PROXY_ERROR`, `UNKNOWN_NETWORK_ERROR`.
- HTTP classes: 401 credential, 403 membership/scope/policy, 404 MCP route/deployment mismatch, 429 rate limit, 502/503/504 gateway, redirects rejected, bounded generic otherwise.
- Protocol classes: content-type, oversize, invalid UTF-8, invalid JSON, malformed JSON-RPC envelope, request-ID mismatch, JSON-RPC error, unsupported protocol version, invalid session header, invalid catalog, required tools missing, pagination unsupported.
- Retryability is derived deterministically from the closed sets (transient DNS, timeouts, resets, 429, 502-504, probe-busy → retryable; TLS validation, 401/403/404, protocol/catalog defects → not), never from raw message text.

Raw exception messages, cause objects, errno numbers, certificate subjects, paths, proxy values, response bodies, headers, and stack traces are never exported. Catalog validation is forward-compatible: extra provider tools no longer fail the check, but only the allowlisted expected IDs and aggregate counts are exported — provider-controlled names are never reflected.

## Differential verdict

A new `cloud-endpoint-differential` check compares the runtime observation with the engine's cached registration evidence for the same entry: `runtime_and_engine_connected`, `runtime_connected_engine_failed` (implicates the engine-side path/lifecycle — endpoint is reachable), `runtime_failed_engine_connected` (implicates the OpenWork runtime network path — proxy/trust-store/DNS as seen by Node or Bun), `runtime_and_engine_failed` (shared outage), `runtime_probe_not_performed`, and `engine_evidence_stale_or_unavailable` (record missing, or a failure record older than 60s while the engine is reachable and could have refreshed it — mirroring the existing `mcp_registration_stale_failure` semantics; aged *connected* records are the engine's standing state and stay trusted so healthy steady-state runs do not warn).

## Schema changes (server + shared types kept in exact sync)

- New check ID `cloud-endpoint-differential` (canonical position after `cloud-tool-catalog`); one new label key in the report page + `en.ts`.
- New safety field `cloudSessionCleanupRequested` disclosing the DELETE.
- The `cloudCatalogToolsListPerformed` cross-invariant no longer requires `syncStatus === "connected"` or a passed tool-policy check (those were the schema-level encoding of the removed gates); it still requires the retained runtime `openwork-cloud` entry with the `/mcp/agent` terminal path, proving which managed entry was probed.

The fail-closed redaction principles from #2997 are preserved: all new detail values pass the existing safe-text schema (no URLs, paths, or credential-shaped text), and eligibility/trust failures stay "no request occurred" states.

## Overlap with open PRs (checked 2026-07-27)

- **#3118** (perf/startup, open): identified as material overlap in planning. Its diff was inspected hunk-by-hunk: `cloud-mcp-health.ts` (pollConnected tracing), `server.ts` (reload-event stores + dispose avoidance), `runtime.mjs`/`main.mjs` (startup tracing + updater-manifest `electronNet.fetch`). This PR does **not** touch any of those regions — `cloud-mcp-health.ts` and all Electron files are untouched here, and the two-line `server.ts` change (engine-client fetch default) is far from its hunks. Based directly on `dev`; no stacking needed; none of its lifecycle/networking work is rewritten or absorbed. The on-prem trust plumbing follow-up should coordinate with its owner since it owns the runtime env wiring area.
- **#3029** (draft prompt observability): touches the same diagnostics modules broadly; this PR keeps its own changes additive and schema-mirrored so rebasing either direction stays mechanical.
- **#3074** (Connect incidents): adds a header passthrough inside `readDirectCloudTools` in `cloud-mcp-health.ts` — untouched here, no conflict.
- **#2997** (Den diagnostic redaction): no file overlap; its fail-closed principles are preserved as described above.

## Tests run

From `apps/server` (Bun 1.3.9; `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0` to avoid a pre-existing flaky `node:sqlite` transpiler-cache resolution on this machine):

- `bun test` (full package): **555 pass, 10 skip, 1 fail** — the single failure is `workspace-kv-store.node.test.ts` failing to resolve `node:sqlite` under Bun; verified identical on the pristine base commit (`git stash` → same failure), unrelated to this change.
- `bun test src/agent-context-cloud-probe.test.ts src/no-bare-fetch.test.ts` — 29 pass.
- `bun test src/agent-context-diagnostics.test.ts` — 44 pass.
- `bun test src/agent-context-diagnostics.schema.test.ts src/agent-context-diagnostics-local-schema.test.ts src/agent-context-diagnostics.plugin-label.test.ts src/agent-context-engine-inspection.test.ts src/opencode-models-url.test.ts` — pass.
- `bun test src/worker-activity-heartbeat.test.ts src/cloud-mcp-health.test.ts` — 26 pass.
- `npx tsc --noEmit` in `apps/server`, `packages/types`, and `apps/app` — clean.

From `apps/app`: `bun test tests/agent-context-diagnostics-report.test.tsx` — 13 pass.

## Validation limitations

No video/fraimz run is attached: this is a server-side diagnostic-evidence change whose only UI delta is one additional check row rendered by the existing generic check renderer (label added to `en.ts`). To reproduce end-to-end: run the desktop app with a connected OpenWork Cloud workspace, open Settings → Connect → Agent Context diagnostics, run diagnostics, and inspect the `cloud-tool-catalog` details (stage/networkCode/transport/steps) and the new `Runtime probe vs engine verdict` check; to see the differential in action, stop or break the engine registration (e.g. revoke Cloud auth) and rerun — the catalog check now still probes and the differential reports `runtime_connected_engine_failed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
