### PR TITLE
fix(diagnostics): probe activated on-prem Den origins and correct engine-evidence staleness

### DIFF
--- a/apps/server/src/agent-context-cloud-probe.test.ts
+++ b/apps/server/src/agent-context-cloud-probe.test.ts
@@ -186,6 +186,8 @@ describe("OpenWork Cloud catalog probe", () => {
       status: "observed",
       stage: "complete",
       code: "catalog_observed",
+      trustSource: "builtin-cloud",
+      enterpriseActivationPresent: false,
       networkCode: null,
       retryable: false,
       runtimeFamily: "bun",
@@ -968,6 +970,8 @@ describe("OpenWork Cloud catalog probe", () => {
       retryable: false,
       runtimeFamily: "bun",
       transport: "test-seam",
+      trustSource: "builtin-cloud",
+      enterpriseActivationPresent: false,
       httpStatus: 200,
       durationMs: 1,
       toolsListPerformed: true,
@@ -986,18 +990,91 @@ describe("OpenWork Cloud catalog probe", () => {
       engineEvidenceAgeMs: 1_000,
       ...overrides,
     });
-    expect(differentialCloudVerdict(base({}))).toBe("runtime_and_engine_connected");
-    expect(differentialCloudVerdict(base({ engineRegistrationStatus: "failed" })))
+    expect(differentialCloudVerdict(base({}), true)).toBe("runtime_and_engine_connected");
+    expect(differentialCloudVerdict(base({ engineRegistrationStatus: "failed" }), true))
       .toBe("runtime_connected_engine_failed");
-    expect(differentialCloudVerdict(base({ status: "failed", code: "tls_error" })))
+    expect(differentialCloudVerdict(base({ status: "failed", code: "tls_error" }), true))
       .toBe("runtime_failed_engine_connected");
-    expect(differentialCloudVerdict(base({ status: "failed", code: "tls_error", engineRegistrationStatus: "failed" })))
+    expect(differentialCloudVerdict(base({ status: "failed", code: "tls_error", engineRegistrationStatus: "failed" }), true))
       .toBe("runtime_and_engine_failed");
-    expect(differentialCloudVerdict(base({ performed: false, status: "not-performed", code: "untrusted_endpoint" })))
+    expect(differentialCloudVerdict(base({ performed: false, status: "not-performed", code: "untrusted_endpoint" }), true))
       .toBe("runtime_probe_not_performed");
-    expect(differentialCloudVerdict(base({ engineRegistrationStatus: "not-recorded" })))
+    expect(differentialCloudVerdict(base({ engineRegistrationStatus: "not-recorded" }), true))
       .toBe("engine_evidence_stale_or_unavailable");
-    expect(differentialCloudVerdict(base({ engineEvidenceAgeMs: 120_000 })))
+    // Aged connected evidence is the engine's standing state and stays
+    // trusted; only an aged failure a reachable engine could have refreshed
+    // is downgraded to stale.
+    expect(differentialCloudVerdict(base({ engineEvidenceAgeMs: 120_000 }), true))
+      .toBe("runtime_and_engine_connected");
+    expect(differentialCloudVerdict(base({ engineRegistrationStatus: "failed", engineEvidenceAgeMs: 120_000 }), true))
       .toBe("engine_evidence_stale_or_unavailable");
+    expect(differentialCloudVerdict(base({ engineRegistrationStatus: "failed", engineEvidenceAgeMs: 120_000 }), false))
+      .toBe("runtime_connected_engine_failed");
+  });
+
+  test("trusts the activated enterprise origin and reports the trust source", async () => {
+    const enterpriseEndpoint = "https://den.customer.example/custom/mcp/agent";
+    const enterpriseConfig = {
+      type: "remote",
+      enabled: true,
+      url: enterpriseEndpoint,
+      headers: { Authorization: TOKEN },
+    };
+
+    let calls = 0;
+    const activated = await probeOpenworkCloudCatalog(input({
+      requestId: "enterprise-activated",
+      config: enterpriseConfig,
+      activatedEnterpriseOrigin: "https://den.customer.example",
+      fetchImpl: async () => {
+        calls += 1;
+        return jsonResponse("enterprise-activated");
+      },
+    }));
+    expect(calls).toBe(1);
+    expect(activated).toMatchObject({
+      performed: true,
+      status: "observed",
+      trustSource: "enterprise-activation",
+      enterpriseActivationPresent: true,
+    });
+    expect(JSON.stringify(activated)).not.toContain("den.customer.example");
+
+    // Activated against a different control plane than the configured MCP:
+    // the mismatch must stay fail-closed but remain distinguishable.
+    let mismatchCalls = 0;
+    const mismatch = await probeOpenworkCloudCatalog(input({
+      requestId: "enterprise-mismatch",
+      config: enterpriseConfig,
+      activatedEnterpriseOrigin: "https://den.other.example",
+      fetchImpl: async () => {
+        mismatchCalls += 1;
+        return jsonResponse("enterprise-mismatch");
+      },
+    }));
+    expect(mismatchCalls).toBe(0);
+    expect(mismatch).toMatchObject({
+      performed: false,
+      code: "untrusted_endpoint",
+      trustSource: "untrusted",
+      enterpriseActivationPresent: true,
+    });
+
+    let unactivatedCalls = 0;
+    const unactivated = await probeOpenworkCloudCatalog(input({
+      requestId: "enterprise-absent",
+      config: enterpriseConfig,
+      fetchImpl: async () => {
+        unactivatedCalls += 1;
+        return jsonResponse("enterprise-absent");
+      },
+    }));
+    expect(unactivatedCalls).toBe(0);
+    expect(unactivated).toMatchObject({
+      performed: false,
+      code: "untrusted_endpoint",
+      trustSource: "untrusted",
+      enterpriseActivationPresent: false,
+    });
   });
 });

--- a/apps/server/src/agent-context-cloud-probe.test.ts
+++ b/apps/server/src/agent-context-cloud-probe.test.ts
@@ -1021,17 +1021,31 @@ describe("OpenWork Cloud catalog probe", () => {
       headers: { Authorization: TOKEN },
     };
 
-    let calls = 0;
-    const activated = await probeOpenworkCloudCatalog(input({
+    // Every request must go to the operator's own configured Den endpoint.
+    // The built-in origins are a membership allowlist, never a destination,
+    // so an on-prem probe must never contact OpenWork-hosted Cloud.
+    const requestedUrls: string[] = [];
+    const activatedInput = input({
       requestId: "enterprise-activated",
       config: enterpriseConfig,
       activatedEnterpriseOrigin: "https://den.customer.example",
-      fetchImpl: async () => {
-        calls += 1;
-        return jsonResponse("enterprise-activated");
-      },
-    }));
-    expect(calls).toBe(1);
+    });
+    activatedInput.fetchImpl = async (url, init) => {
+      requestedUrls.push(String(url));
+      if (init?.method === "DELETE") return new Response(null, { status: 204 });
+      const body = requestPayload(init);
+      if (body.method === "initialize") return initializeResponse();
+      if (body.method === "notifications/initialized") return new Response(null, { status: 202 });
+      return jsonResponse("enterprise-activated");
+    };
+    const activated = await probeOpenworkCloudCatalog(activatedInput);
+    expect(requestedUrls).toEqual([
+      enterpriseEndpoint,
+      enterpriseEndpoint,
+      enterpriseEndpoint,
+      enterpriseEndpoint,
+    ]);
+    expect(requestedUrls.some((url) => url.includes("openworklabs.com"))).toBe(false);
     expect(activated).toMatchObject({
       performed: true,
       status: "observed",

--- a/apps/server/src/agent-context-cloud-probe.ts
+++ b/apps/server/src/agent-context-cloud-probe.ts
@@ -131,8 +131,26 @@ export type CloudRuntimeEngineDifferential =
   | "runtime_probe_not_performed"
   | "engine_evidence_stale_or_unavailable";
 
+/**
+ * Which allowlist entry authorized the credentialed request, or why none did.
+ * Reported instead of the origin itself so an administrator can distinguish
+ * "this install is not enterprise activated" from "it is activated, but
+ * against a different origin than the configured Cloud MCP" — a real
+ * misconfiguration — without the report ever carrying a hostname.
+ */
+export type CloudEndpointTrustSource =
+  | "builtin-cloud"
+  | "loopback"
+  | "administrator-env"
+  | "enterprise-activation"
+  | "untrusted"
+  /** The endpoint was absent or structurally invalid, so trust never applied. */
+  | "not-evaluated";
+
 export type CloudCatalogProbe = {
   performed: boolean;
+  trustSource: CloudEndpointTrustSource;
+  enterpriseActivationPresent: boolean;
   status: CloudCatalogProbeStatus;
   stage: CloudCatalogProbeStage;
   code: CloudCatalogProbeCode;
@@ -180,6 +198,13 @@ export type ProbeOpenworkCloudCatalogInput = {
   signal?: AbortSignal;
   /** Test seam for proxy and extra-CA presence detection. */
   env?: Record<string, string | undefined>;
+  /**
+   * Exact origin of the enterprise/on-prem Den control plane this install is
+   * activated against, resolved by the caller from administrator-provisioned
+   * desktop activation state. Null when the install is not enterprise
+   * activated; never a renderer- or request-supplied value.
+   */
+  activatedEnterpriseOrigin?: string | null;
 };
 
 type PreparedProbe = {
@@ -223,10 +248,28 @@ type ProbeBaseFacts = {
   transport: RuntimeDiagnosticTransport;
   proxyConfigured: boolean;
   extraCaConfigured: boolean;
+  trustSource: CloudEndpointTrustSource;
+  enterpriseActivationPresent: boolean;
   engineRegistrationStatus: CloudEngineRegistrationStatus;
   engineEvidenceSource: "transport_failure" | "engine_status" | null;
   engineEvidenceAgeMs: number | null;
 };
+
+/** Classifies which allowlist entry authorized this exact endpoint origin. */
+function resolveTrustSource(
+  endpoint: URL,
+  activatedEnterpriseOrigin?: string | null,
+): CloudEndpointTrustSource {
+  if (isLoopbackHostname(endpoint.hostname)) return "loopback";
+  if (DEFAULT_TRUSTED_ORIGINS.has(endpoint.origin)) return "builtin-cloud";
+  if (activatedEnterpriseOrigin && endpoint.origin === activatedEnterpriseOrigin) {
+    return "enterprise-activation";
+  }
+  if (configuredTrustedOrigins(activatedEnterpriseOrigin).has(endpoint.origin)) {
+    return "administrator-env";
+  }
+  return "untrusted";
+}
 
 const activeProbes = new Set<Promise<CloudCatalogProbe>>();
 
@@ -258,8 +301,12 @@ function isLoopbackHostname(hostname: string): boolean {
  * administrator setting; the desktop bootstrap's Den activation state is not
  * visible to this server process, so it can never widen this list implicitly.
  */
-function configuredTrustedOrigins(): Set<string> {
+function configuredTrustedOrigins(activatedEnterpriseOrigin?: string | null): Set<string> {
   const origins = new Set(DEFAULT_TRUSTED_ORIGINS);
+  // The activated enterprise/on-prem control-plane origin is administrator
+  // provisioned (written only after a signed activation claim verifies), so
+  // it joins the allowlist as an exact origin without an explicit override.
+  if (activatedEnterpriseOrigin) origins.add(activatedEnterpriseOrigin);
   const configured = process.env.OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS ?? "";
   for (const entry of configured.split(",")) {
     const raw = entry.trim().replace(/\/+$/u, "");
@@ -324,7 +371,10 @@ function prepare(input: ProbeOpenworkCloudCatalogInput): PreparedProbe | CloudCa
   if (input.config.enabled !== true) return "cloud_mcp_disabled";
   const endpoint = safeCatalogEndpoint(input.config.url);
   if (!endpoint) return "invalid_endpoint";
-  if (!isLoopbackHostname(endpoint.hostname) && !configuredTrustedOrigins().has(endpoint.origin)) {
+  if (
+    !isLoopbackHostname(endpoint.hostname)
+    && !configuredTrustedOrigins(input.activatedEnterpriseOrigin).has(endpoint.origin)
+  ) {
     return "untrusted_endpoint";
   }
   const authorization = authorizationHeader(input.config);
@@ -906,14 +956,26 @@ async function performProbe(
  * registration evidence for the same managed entry, so a report can implicate
  * the correct runtime boundary instead of collapsing both into one failure.
  */
-export function differentialCloudVerdict(probe: CloudCatalogProbe): CloudRuntimeEngineDifferential {
+export function differentialCloudVerdict(
+  probe: CloudCatalogProbe,
+  engineReachableNow: boolean,
+): CloudRuntimeEngineDifferential {
   if (!probe.performed) return "runtime_probe_not_performed";
   if (probe.engineRegistrationStatus === "not-recorded") return "engine_evidence_stale_or_unavailable";
-  if (probe.engineEvidenceAgeMs !== null && probe.engineEvidenceAgeMs > STALE_ENGINE_EVIDENCE_MS) {
+  const engineConnected = probe.engineRegistrationStatus === "connected";
+  // A connected record is the engine's standing state and ages naturally
+  // between syncs, so it stays trustworthy. Only a failure record the
+  // reachable engine could already have refreshed is downgraded, mirroring
+  // the mcp_registration_stale_failure rule on the sync check.
+  if (
+    !engineConnected
+    && engineReachableNow
+    && probe.engineEvidenceAgeMs !== null
+    && probe.engineEvidenceAgeMs > STALE_ENGINE_EVIDENCE_MS
+  ) {
     return "engine_evidence_stale_or_unavailable";
   }
   const runtimeConnected = probe.status === "observed";
-  const engineConnected = probe.engineRegistrationStatus === "connected";
   if (runtimeConnected && engineConnected) return "runtime_and_engine_connected";
   if (runtimeConnected) return "runtime_connected_engine_failed";
   if (engineConnected) return "runtime_failed_engine_connected";
@@ -938,11 +1000,16 @@ export async function probeOpenworkCloudCatalog(
   const transportInfo = input.fetchImpl
     ? { runtimeFamily: runtimeDiagnosticTransportInfo().runtimeFamily, transport: "test-seam" as const }
     : runtimeDiagnosticTransportInfo();
+  const endpointForTrust = isRecord(input.config) ? safeCatalogEndpoint(input.config.url) : null;
   const base: ProbeBaseFacts = {
     runtimeFamily: transportInfo.runtimeFamily,
     transport: transportInfo.transport,
     proxyConfigured: proxyEnvConfigured(env),
     extraCaConfigured: extraCaEnvConfigured(env),
+    trustSource: endpointForTrust
+      ? resolveTrustSource(endpointForTrust, input.activatedEnterpriseOrigin)
+      : "not-evaluated",
+    enterpriseActivationPresent: Boolean(input.activatedEnterpriseOrigin),
     engineRegistrationStatus: input.engineRegistration.status,
     engineEvidenceSource: input.engineRegistration.source,
     engineEvidenceAgeMs: input.engineRegistration.recordAgeMs,

--- a/apps/server/src/agent-context-diagnostics.test.ts
+++ b/apps/server/src/agent-context-diagnostics.test.ts
@@ -883,7 +883,84 @@ describe("agent context diagnostics analyzer", () => {
       status: "skipped",
       code: "runtime_probe_not_performed",
     });
+    expect(check.details.trustSource).toBe("untrusted");
+    expect(check.details.enterpriseActivationPresent).toBe(false);
     expect(fetchCalls).toEqual([]);
+  });
+
+  test("probes an on-prem endpoint this installation is activated against", async () => {
+    const runtime = diagnosticRuntimeConfig();
+    if (!runtime.mcp) throw new Error("Expected the diagnostics MCP fixture.");
+    runtime.mcp["openwork-cloud"] = {
+      ...cloudConfig(),
+      url: "https://den.customer.example/custom/mcp/agent",
+    };
+    const fixture = await createFixture({ runtime });
+    const fetchCalls: CatalogFetchCall[] = [];
+
+    const report = agentContextDiagnosticsReportSchema.parse(await runAgentContextDiagnostics({
+      config: fixture.config,
+      workspace: fixture.workspace,
+      request: emptyObservedRequest,
+      // The engine reports this managed entry as failed; the independent
+      // probe must still run and separate endpoint from engine.
+      inspectRegistration: () => ({ status: "failed", source: "engine_status", recordAgeMs: 16_000 }),
+      dependencies: {
+        fetchImpl: catalogFetch(["search_capabilities", "execute_capability"], fetchCalls),
+        inspectEffectiveEngine: effectiveEngineInspection(runtime),
+        readActivatedEnterpriseOrigin: async () => "https://den.customer.example",
+      },
+    }));
+
+    expect(checkById(report, "cloud-tool-catalog")).toMatchObject({
+      status: "passed",
+      code: "cloud_catalog_exact_match",
+      details: {
+        requestPerformed: true,
+        trustSource: "enterprise-activation",
+        enterpriseActivationPresent: true,
+      },
+    });
+    expect(checkById(report, "cloud-endpoint-differential")).toMatchObject({
+      status: "failed",
+      code: "runtime_connected_engine_failed",
+      owner: "opencode-engine",
+    });
+    expect(fetchCalls).toHaveLength(4);
+    expect(JSON.stringify(report)).not.toContain("den.customer.example");
+  });
+
+  test("distinguishes an activation origin that does not match the configured cloud MCP", async () => {
+    const runtime = diagnosticRuntimeConfig();
+    if (!runtime.mcp) throw new Error("Expected the diagnostics MCP fixture.");
+    runtime.mcp["openwork-cloud"] = {
+      ...cloudConfig(),
+      url: "https://den.customer.example/custom/mcp/agent",
+    };
+    const fixture = await createFixture({ runtime });
+    const fetchCalls: CatalogFetchCall[] = [];
+
+    const report = agentContextDiagnosticsReportSchema.parse(await runAgentContextDiagnostics({
+      config: fixture.config,
+      workspace: fixture.workspace,
+      request: emptyObservedRequest,
+      inspectRegistration: () => "connected",
+      dependencies: {
+        fetchImpl: catalogFetch(["search_capabilities", "execute_capability"], fetchCalls),
+        inspectEffectiveEngine: effectiveEngineInspection(runtime),
+        readActivatedEnterpriseOrigin: async () => "https://den.other.example",
+      },
+    }));
+
+    const check = checkById(report, "cloud-tool-catalog");
+    expect(check).toMatchObject({
+      status: "warning",
+      code: "untrusted_endpoint",
+      details: { requestPerformed: false, trustSource: "untrusted", enterpriseActivationPresent: true },
+    });
+    expect(check.message).toContain("mismatch");
+    expect(fetchCalls).toEqual([]);
+    expect(JSON.stringify(report)).not.toContain("den.other.example");
   });
 
   test("fails closed when the effective engine response is invalid or unavailable", async () => {

--- a/apps/server/src/agent-context-diagnostics.test.ts
+++ b/apps/server/src/agent-context-diagnostics.test.ts
@@ -927,6 +927,15 @@ describe("agent context diagnostics analyzer", () => {
       owner: "opencode-engine",
     });
     expect(fetchCalls).toHaveLength(4);
+    // The handshake must reach the operator's own Den deployment. Trusting an
+    // origin never redirects the probe to OpenWork-hosted Cloud.
+    expect(fetchCalls.map((call) => call.url)).toEqual([
+      "https://den.customer.example/custom/mcp/agent",
+      "https://den.customer.example/custom/mcp/agent",
+      "https://den.customer.example/custom/mcp/agent",
+      "https://den.customer.example/custom/mcp/agent",
+    ]);
+    expect(fetchCalls.some((call) => call.url.includes("openworklabs.com"))).toBe(false);
     expect(JSON.stringify(report)).not.toContain("den.customer.example");
   });
 

--- a/apps/server/src/agent-context-diagnostics.ts
+++ b/apps/server/src/agent-context-diagnostics.ts
@@ -27,6 +27,7 @@ import {
   probeOpenworkCloudCatalog,
   type CloudCatalogProbe,
 } from "./agent-context-cloud-probe.js";
+import { readActivatedEnterpriseDenOrigin } from "./enterprise-den-origin.js";
 import {
   inspectConnectSnapshot,
   type ConnectSnapshot,
@@ -102,6 +103,8 @@ type DiagnosticDependencies = {
   uuid?: () => string;
   inspectEffectiveEngine?: InspectAgentDiagnosticsEngine;
   signal?: AbortSignal;
+  /** Test seam for the administrator-provisioned enterprise activation read. */
+  readActivatedEnterpriseOrigin?: (signal?: AbortSignal) => Promise<string | null>;
 };
 
 type EffectiveToolPolicyAssessment = {
@@ -458,6 +461,8 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
       referenceId: probe.referenceId,
       proxyConfigured: probe.proxyConfigured,
       extraCaConfigured: probe.extraCaConfigured,
+      trustSource: probe.trustSource,
+      enterpriseActivationPresent: probe.enterpriseActivationPresent,
       probeSteps: probe.steps,
     },
   };
@@ -518,8 +523,12 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
     case "untrusted_endpoint":
       status = "warning";
       evidenceKind = "unavailable";
-      message = "The runtime endpoint probe was not performed because the configured origin is not in the diagnostics trust list; no request was sent, so this is a trust-configuration state, not a network, TLS, or MCP failure.";
-      action = "Have an administrator set OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS on the OpenWork desktop/server process to the exact Cloud or on-prem Den endpoint origin, then rerun diagnostics.";
+      message = probe.enterpriseActivationPresent
+        ? "The runtime endpoint probe was not performed: this installation is enterprise activated, but against a different control-plane origin than the configured OpenWork Cloud MCP. No request was sent, so this is a configuration mismatch, not a network, TLS, or MCP failure."
+        : "The runtime endpoint probe was not performed because the configured origin is not in the diagnostics trust list; no request was sent, so this is a trust-configuration state, not a network, TLS, or MCP failure.";
+      action = probe.enterpriseActivationPresent
+        ? "Reconcile the enterprise activation origin with the configured OpenWork Cloud MCP origin, or have an administrator add the exact endpoint origin to OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS, then rerun diagnostics."
+        : "Activate this installation against your on-prem Den, or have an administrator set OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS on the OpenWork desktop/server process to the exact endpoint origin, then rerun diagnostics.";
       break;
     case "credential_missing":
     case "duplicate_authorization":
@@ -626,7 +635,7 @@ function cloudCatalogCheck(probe: CloudCatalogProbe): AgentContextDiagnosticChec
 }
 
 function cloudDifferentialCheck(probe: CloudCatalogProbe, engineReachableNow: boolean): AgentContextDiagnosticCheck {
-  const verdict = differentialCloudVerdict(probe);
+  const verdict = differentialCloudVerdict(probe, engineReachableNow);
   const common = {
     id: "cloud-endpoint-differential" as const,
     code: verdict,
@@ -1162,6 +1171,15 @@ export async function runAgentContextDiagnostics(input: {
     return "unspecified";
   };
   const engineReachableNow = engineInspectionStatus === "observed" || engineInspectionStatus === "invalid";
+  // Local workspaces only: the activation record describes this installation,
+  // so it must never authorize egress on behalf of a remote workspace shell.
+  const activatedEnterpriseOrigin = input.workspace.workspaceType === "local"
+    ? await (input.dependencies?.readActivatedEnterpriseOrigin
+      ?? ((signal?: AbortSignal) => readActivatedEnterpriseDenOrigin({ signal })))(
+        input.dependencies?.signal,
+      ).catch(() => null)
+    : null;
+  input.dependencies?.signal?.throwIfAborted();
   const cloudRegistration = runtimeCloudItem && runtimeCloudConfig
     ? registrationForItem(runtimeCloudItem)
     : null;
@@ -1182,6 +1200,7 @@ export async function runAgentContextDiagnostics(input: {
       source: cloudRegistration?.source ?? null,
       recordAgeMs: cloudRegistration?.recordAgeMs ?? null,
     },
+    activatedEnterpriseOrigin,
     requestId: runId,
     fetchImpl,
     now,

--- a/apps/server/src/enterprise-den-origin.test.ts
+++ b/apps/server/src/enterprise-den-origin.test.ts
@@ -1,0 +1,79 @@
+import { afterEach, expect, test } from "bun:test";
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import {
+  exactEnterpriseOrigin,
+  readActivatedEnterpriseDenOrigin,
+} from "./enterprise-den-origin.js";
+
+const roots: string[] = [];
+
+async function bootstrapFile(contents: unknown): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), "openwork-enterprise-origin-"));
+  roots.push(root);
+  const path = join(root, "desktop-bootstrap.json");
+  await writeFile(path, typeof contents === "string" ? contents : JSON.stringify(contents), "utf8");
+  return path;
+}
+
+afterEach(async () => {
+  while (roots.length) await rm(roots.pop()!, { recursive: true, force: true });
+});
+
+test("reduces an activation URL to its exact https origin", () => {
+  expect(exactEnterpriseOrigin("https://den.customer.example")).toBe("https://den.customer.example");
+  expect(exactEnterpriseOrigin("https://den.customer.example/api/den/")).toBe("https://den.customer.example");
+  expect(exactEnterpriseOrigin("https://den.customer.example:8443/x")).toBe("https://den.customer.example:8443");
+});
+
+test("rejects non-https, credential-bearing, and malformed activation URLs", () => {
+  for (const value of [
+    "http://den.customer.example",
+    "https://user:pass@den.customer.example",
+    "https://den.customer.example/?token=secret",
+    "https://den.customer.example/#fragment",
+    "not-a-url",
+    "",
+    null,
+    42,
+  ]) {
+    expect(exactEnterpriseOrigin(value)).toBeNull();
+  }
+});
+
+test("reads the activated enterprise origin from desktop bootstrap state", async () => {
+  const path = await bootstrapFile({
+    baseUrl: "https://den.customer.example",
+    enterpriseActivation: {
+      activatedAt: "2026-07-20T10:00:00.000Z",
+      denBaseUrl: "https://den.customer.example/api/den",
+    },
+  });
+  expect(await readActivatedEnterpriseDenOrigin({ path })).toBe("https://den.customer.example");
+});
+
+test("returns null without a completed activation record", async () => {
+  const missing = await bootstrapFile({ baseUrl: "https://den.customer.example" });
+  expect(await readActivatedEnterpriseDenOrigin({ path: missing })).toBeNull();
+
+  // A base URL alone is not proof of a provisioned tenant, and neither is an
+  // activation entry whose completion timestamp is absent.
+  const incomplete = await bootstrapFile({
+    enterpriseActivation: { activatedAt: "", denBaseUrl: "https://den.customer.example" },
+  });
+  expect(await readActivatedEnterpriseDenOrigin({ path: incomplete })).toBeNull();
+
+  const insecure = await bootstrapFile({
+    enterpriseActivation: { activatedAt: "2026-07-20T10:00:00.000Z", denBaseUrl: "http://den.customer.example" },
+  });
+  expect(await readActivatedEnterpriseDenOrigin({ path: insecure })).toBeNull();
+});
+
+test("fails closed on unreadable or malformed bootstrap state", async () => {
+  expect(await readActivatedEnterpriseDenOrigin({ path: join(tmpdir(), "definitely-absent-bootstrap.json") }))
+    .toBeNull();
+  const malformed = await bootstrapFile("{ not json");
+  expect(await readActivatedEnterpriseDenOrigin({ path: malformed })).toBeNull();
+});

--- a/apps/server/src/enterprise-den-origin.ts
+++ b/apps/server/src/enterprise-den-origin.ts
@@ -1,0 +1,70 @@
+import { desktopBootstrapPath } from "@openwork/paths";
+
+import { readJsoncFile } from "./jsonc.js";
+
+const MAX_BOOTSTRAP_BYTES = 256 * 1024;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+/**
+ * Reduces an administrator-provisioned Den control-plane URL to its exact
+ * origin. Anything carrying credentials, a query, or a fragment is rejected
+ * rather than trimmed, so a malformed activation record can never widen the
+ * diagnostics trust list.
+ */
+export function exactEnterpriseOrigin(rawValue: unknown): string | null {
+  if (typeof rawValue !== "string") return null;
+  const raw = rawValue.trim();
+  if (!raw || raw.length > 2 * 1024) return null;
+  try {
+    const url = new URL(raw);
+    if (url.protocol !== "https:") return null;
+    if (url.username || url.password || url.search || url.hash) return null;
+    return url.origin;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolves the origin of the enterprise/on-prem Den control plane this
+ * installation is already activated against.
+ *
+ * The desktop writes `enterpriseActivation` only after a signed connect-link
+ * activation claim verifies, so it is administrator-provisioned configuration
+ * rather than a renderer- or request-supplied URL — the one non-built-in
+ * source the credentialed diagnostics probe may trust without an explicit
+ * environment override. A missing, unreadable, or malformed record yields
+ * null and the probe stays fail-closed.
+ */
+export async function readActivatedEnterpriseDenOrigin(options?: {
+  signal?: AbortSignal;
+  path?: string;
+}): Promise<string | null> {
+  const path = options?.path ?? desktopBootstrapPath({ env: process.env });
+  if (typeof path !== "string" || !path.trim()) return null;
+  try {
+    const { data, invalid } = await readJsoncFile<Record<string, unknown>>(
+      path,
+      {},
+      {
+        allowInvalid: true,
+        maxBytes: MAX_BOOTSTRAP_BYTES,
+        regularFileOnly: true,
+        signal: options?.signal,
+      },
+    );
+    if (invalid) return null;
+    const activation = isRecord(data.enterpriseActivation) ? data.enterpriseActivation : null;
+    if (!activation) return null;
+    // Both fields are required by the desktop writer; an entry without a
+    // completed activation timestamp is not proof of a provisioned tenant.
+    if (typeof activation.activatedAt !== "string" || !activation.activatedAt.trim()) return null;
+    return exactEnterpriseOrigin(activation.denBaseUrl);
+  } catch {
+    options?.signal?.throwIfAborted();
+    return null;
+  }
+}


### PR DESCRIPTION
Follow-up to #3199. Driven by a real enterprise diagnostics report in which the new runtime probe **could not run at all**, so the report still could not say why the MCP failed.

## The report that motivated this

```
engine-mcp-sync      failed   openwork-cloud status=failed source=engine_status
                              recordAgeMs=15982 engineReachableNow=true
cloud-tool-catalog   failed   untrusted_endpoint
                              handshakePerformed=false  requestPerformed=false
```

The engine says `failed` and nothing else — OpenCode collapses transport failures into an opaque status and never retries a failed MCP — and the independent probe never sent a request. The deployment's managed `openwork-cloud` entry points at the customer's **own on-prem Den origin**, which is not a built-in Cloud origin, so `untrusted_endpoint` fired at the eligibility stage. Net evidence available to support: zero.

So the deployments that most need differential diagnosis were exactly the ones the probe refused to run for. This PR fixes that, plus a staleness bug found while validating against the same report.

## 1. Trust the activated enterprise control plane

`enterpriseActivation` is written by the desktop **only after a signed connect-link activation claim verifies** (`main.mjs` → `workspace-store.mjs`), which makes it administrator-provisioned configuration rather than a renderer- or request-supplied URL. That is precisely the "exact origin derived from the already trusted enterprise/on-prem Den control-plane configuration" case the original design allowed but could not reach, because #3199's audit found the origin was not available server-side.

It is available as a **file**: `desktopBootstrapPath()` already lives in the shared `@openwork/paths` package. New `apps/server/src/enterprise-den-origin.ts` reads it bounded and read-only (256 KiB cap, regular-file only, abort-aware) and returns the exact origin.

Constraints kept:

- **https only**; credential-, query-, or fragment-bearing URLs rejected outright rather than trimmed.
- Reduced to an **exact origin** — a path prefix can never widen the allowlist.
- Requires a non-empty `activatedAt`; a `denBaseUrl` without a completed activation is not proof of a provisioned tenant.
- **Local workspaces only** — the activation record describes this installation and must never authorize egress for a remote workspace shell.
- Missing, unreadable, or malformed state → `null` → probe stays fail-closed.
- No desktop changes, no new IPC, no runtime env plumbing — so this still does not touch #3118's area.

### The probe reaches the operator's own deployment, not OpenWork Cloud

Worth stating explicitly for on-prem review: trusting an origin never changes where the request goes. The endpoint is derived once from the operator's configured `openwork-cloud` entry (`safeCatalogEndpoint(config.url)`), and both fetch call sites — the handshake and the session cleanup — use only that value. The built-in Cloud origins are consulted solely through `.has()` as a membership allowlist; they are never a destination, a fallback, or a substitution, and there is no code path that rewrites the endpoint.

That invariant was previously enforced only by inspection. It is now pinned by tests at both the probe and analyzer levels: every request URL of the four-step handshake must equal the exact configured on-prem endpoint, and no OpenWork-hosted origin may be contacted.

## 2. Report trust provenance, never the origin

New exported `trustSource` (`builtin-cloud` | `loopback` | `administrator-env` | `enterprise-activation` | `untrusted` | `not-evaluated`) and `enterpriseActivationPresent`.

This closes a genuine diagnostic blind spot. Previously these two situations produced an identical report:

| Situation | Now |
|---|---|
| Install is not enterprise activated | `enterpriseActivationPresent: false` → activate, or set the env override |
| Activated, but against a **different** origin than the configured Cloud MCP | `enterpriseActivationPresent: true`, `trustSource: untrusted` → real misconfiguration, message says "mismatch" |

The `untrusted_endpoint` message and action now branch on that distinction. No hostname, origin, or URL is ever added to the report — tests assert the origins never appear in the serialized output.

## 3. Correct the engine-evidence staleness rule (bug from #3199)

#3199 downgraded **any** engine record older than 60s to `engine_evidence_stale_or_unavailable`. A `connected` registration is the engine's standing state and ages naturally between syncs, so every healthy steady-state diagnostics run would have reported a spurious staleness warning.

Now only a **failure** record that a **reachable** engine could already have refreshed is downgraded — mirroring the existing `mcp_registration_stale_failure` semantics on the sync check. An aged failure on an unreachable engine keeps implicating the engine, and aged connected evidence stays trusted.

`differentialCloudVerdict` takes `engineReachableNow` for this; it was previously computed in the analyzer and not passed through.

## What the motivating report will now show

With the installation activated against its own Den, the probe runs despite the engine's `failed` registration and reports the stage and cause: TLS validation (`SELF_SIGNED_CERT_IN_CHAIN`, `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, …), DNS, connect, proxy, or an HTTP class (401 credential vs 403 membership/scope vs 404 route/version vs 502-504 gateway), alongside boolean `proxyConfigured` / `extraCaConfigured` posture. The differential then separates the two hypotheses: if the runtime probe succeeds while the engine says failed → `runtime_connected_engine_failed`, i.e. the endpoint is fine and the engine's connection path is implicated; if both fail with a TLS cause → corporate TLS interception on the shared path.

## Tests

From `apps/server` (Bun 1.3.9, `BUN_RUNTIME_TRANSPILER_CACHE_PATH=0`):

- `bun test` (full package): **563 pass, 10 skip, 1 fail** — the one failure is `workspace-kv-store.node.test.ts` failing to resolve `node:sqlite` under Bun, pre-existing on `dev` and unrelated (verified against the base commit in #3199).
- `bun test src/enterprise-den-origin.test.ts src/agent-context-cloud-probe.test.ts src/no-bare-fetch.test.ts` — 35 pass.
- `bun test src/agent-context-diagnostics.test.ts` — 46 pass, including two new end-to-end cases: an activated on-prem origin probing successfully while the engine reports `failed`, and an activation/MCP origin mismatch staying fail-closed but distinguishable. Both pin the request URLs to the operator's own endpoint.
- `npx tsc --noEmit` (`apps/server`) — clean.
- `apps/app`: `bun test tests/agent-context-diagnostics-report.test.tsx` — 13 pass.

New coverage in `enterprise-den-origin.test.ts`: exact-origin reduction, rejection of non-https/credentialed/query/fragment/malformed values, activation-record completeness, and fail-closed behavior on absent or malformed bootstrap state.

## Validation limitations

No video/fraimz run: this is server-side diagnostic-evidence work with no new UI surface (the two new fields render through the existing generic check-details renderer). To reproduce: on an enterprise-activated install whose Cloud MCP points at the on-prem Den, run Settings → Debug → Agent context diagnostics → **Run agent diagnostics**, and confirm `cloud-tool-catalog` now shows `trustSource: "enterprise-activation"` with a real `stage`/`networkCode` instead of `untrusted_endpoint`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
