### PR TITLE
feat(den-gateway): one origin, gateway sign-in returns, and a publishable image

### DIFF
--- a/.github/workflows/publish-ee-images.yml
+++ b/.github/workflows/publish-ee-images.yml
@@ -149,6 +149,15 @@ jobs:
               -e DB_MODE=mysql
               -e DATABASE_URL=mysql://smoke:smoke@127.0.0.1:3306/smoke
               -e DEN_DB_ENCRYPTION_KEY=ci-den-db-encryption-key-value-123456
+          # The gateway's own liveness lives at /__gw/health because /health is
+          # proxied through to the user's instance.
+          - image: openwork-den-gateway
+            dockerfile: packaging/docker/Dockerfile.den-gateway
+            port: 8788
+            health_path: /__gw/health
+            smoke_env: >-
+              -e DEN_API_BASE=http://127.0.0.1:9
+              -e DEN_GATEWAY_KEY=ci-den-gateway-key-value-123456
 
     steps:
       - name: Checkout

--- a/.github/workflows/publish-ee-images.yml
+++ b/.github/workflows/publish-ee-images.yml
@@ -226,7 +226,10 @@ jobs:
           echo "den_web_upload=$den_web_upload" >> "$GITHUB_OUTPUT"
 
       - name: Build and optionally push without Sentry source-map upload
-        if: ${{ matrix.image == 'openwork-inference' || (matrix.image == 'openwork-den-api' && steps.sentry_sourcemaps.outputs.den_api_upload != 'true') || (matrix.image == 'openwork-den-web' && steps.sentry_sourcemaps.outputs.den_web_upload != 'true') }}
+        # Build every image except the ones whose Sentry-enabled step below owns
+        # them. Stated as an exclusion so a newly added matrix entry builds by
+        # default instead of silently skipping and failing the smoke step.
+        if: ${{ !((matrix.image == 'openwork-den-api' && steps.sentry_sourcemaps.outputs.den_api_upload == 'true') || (matrix.image == 'openwork-den-web' && steps.sentry_sourcemaps.outputs.den_web_upload == 'true')) }}
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -22,6 +22,7 @@ import {
   setDesktopBootstrapConfig as setDesktopBootstrapConfigInShell,
   type DesktopBootstrapConfig as ShellDesktopBootstrapConfig,
 } from "./desktop";
+import { getOpenworkGatewayOrigin } from "./gateway-runtime";
 import { isDesktopRuntime } from "./runtime-env";
 import type { ReloadReason } from "../types";
 import type {
@@ -552,6 +553,15 @@ function ensureDenApiBasePath(input: string | null | undefined): string | null {
 }
 
 export function resolveDenBaseUrls(input: { baseUrl?: string | null; apiBaseUrl?: string | null } | string | null | undefined): DenBaseUrls {
+  const gatewayOrigin = getOpenworkGatewayOrigin();
+  if (gatewayOrigin) {
+    const baseUrl = normalizeDenBaseUrl(gatewayOrigin) ?? gatewayOrigin;
+    return {
+      baseUrl,
+      apiBaseUrl: ensureDenApiBasePath(baseUrl) ?? baseUrl,
+    };
+  }
+
   const rawBaseUrl = typeof input === "string" ? input : input?.baseUrl;
   const normalizedBaseUrl = normalizeDenBaseUrl(rawBaseUrl);
   const legacyApiBaseUrl = typeof input === "string" ? null : normalizeDenBaseUrl(input?.apiBaseUrl);
@@ -668,13 +678,21 @@ function applyDesktopBootstrapConfig(config: DenBootstrapConfig) {
 }
 
 export function readDenBootstrapConfig(): DenBootstrapConfig {
+  const gatewayOrigin = getOpenworkGatewayOrigin();
+  if (gatewayOrigin) {
+    return {
+      ...desktopBootstrapConfig,
+      ...resolveDenBaseUrls({ baseUrl: gatewayOrigin }),
+    };
+  }
+
   return desktopBootstrapConfig;
 }
 
 export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig> {
   if (!isDesktopRuntime()) {
     desktopBootstrapConfig = resolveDenBootstrapConfig({
-      baseUrl: BUILD_DEN_BASE_URL,
+      baseUrl: getOpenworkGatewayOrigin() ?? BUILD_DEN_BASE_URL,
       requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
     });
     return desktopBootstrapConfig;
@@ -822,7 +840,7 @@ export function readDenSettings(): DenSettings {
   const baseUrls = resolveDenBaseUrls({
     baseUrl: isDesktopRuntime()
       ? readDenBootstrapConfig().baseUrl
-      : window.localStorage.getItem(STORAGE_BASE_URL) ?? readDenBootstrapConfig().baseUrl,
+      : getOpenworkGatewayOrigin() ?? window.localStorage.getItem(STORAGE_BASE_URL) ?? readDenBootstrapConfig().baseUrl,
   });
 
   return {

--- a/apps/app/src/app/lib/gateway-runtime.ts
+++ b/apps/app/src/app/lib/gateway-runtime.ts
@@ -1,0 +1,32 @@
+// Gateway runtime detection primitives. Leaf module by design: keep it import-free
+// so low-level clients can choose same-origin gateway behavior without cycles.
+export type OpenworkGatewayMarker = {
+  version?: number;
+};
+
+declare global {
+  interface Window {
+    __OPENWORK_GATEWAY__?: OpenworkGatewayMarker;
+  }
+}
+
+const DEN_AUTH_TOKEN_STORAGE_KEY = "openwork.den.authToken";
+
+export function isOpenworkGatewayRuntime() {
+  return typeof window !== "undefined" && window.__OPENWORK_GATEWAY__?.version === 1;
+}
+
+export function getOpenworkGatewayOrigin() {
+  if (!isOpenworkGatewayRuntime()) return null;
+  const origin = window.location.origin.trim();
+  return origin || null;
+}
+
+export function readOpenworkGatewayDenToken() {
+  if (!isOpenworkGatewayRuntime()) return "";
+  try {
+    return window.localStorage.getItem(DEN_AUTH_TOKEN_STORAGE_KEY)?.trim() ?? "";
+  } catch {
+    return "";
+  }
+}

--- a/apps/app/src/app/lib/openwork-server.ts
+++ b/apps/app/src/app/lib/openwork-server.ts
@@ -11,6 +11,7 @@ import {
   requestAgentContextDiagnosticsPayload,
 } from "./agent-context-diagnostics-transport";
 import { desktopFetch, desktopFetchAgentContextDiagnostics } from "./desktop";
+import { isOpenworkGatewayRuntime } from "./gateway-runtime";
 import { isDesktopRuntime } from "./runtime-env";
 import type { ExecResult, OpencodeConfigFile, WorkspaceInfo, WorkspaceList } from "./desktop";
 import type { DenOrgMarketplace, DenOrgPluginResolved, DenResourceSnapshot } from "./den-types";
@@ -984,6 +985,7 @@ export function writeOpenworkServerSettings(next: OpenworkServerSettings): Openw
 
 export function hydrateOpenworkServerSettingsFromEnv() {
   if (typeof window === "undefined") return;
+  if (isOpenworkGatewayRuntime()) return;
 
   const envUrl = typeof import.meta.env?.VITE_OPENWORK_URL === "string"
     ? import.meta.env.VITE_OPENWORK_URL.trim()

--- a/apps/app/src/react-app/shell/openwork-connection.ts
+++ b/apps/app/src/react-app/shell/openwork-connection.ts
@@ -1,4 +1,8 @@
 import {
+  getOpenworkGatewayOrigin,
+  readOpenworkGatewayDenToken,
+} from "../../app/lib/gateway-runtime";
+import {
   isLoopbackOpenworkServerUrl,
   normalizeOpenworkServerUrl,
   readOpenworkServerSettings,
@@ -7,7 +11,7 @@ import { isWebDeployment } from "../../app/lib/openwork-deployment";
 import { openworkServerInfo, type OpenworkServerInfo } from "../../app/lib/desktop";
 import { isDesktopRuntime } from "../../app/utils";
 
-export type OpenworkConnectionSource = "desktop-runtime" | "stored-settings" | "same-origin" | "empty";
+export type OpenworkConnectionSource = "desktop-runtime" | "stored-settings" | "same-origin" | "gateway" | "empty";
 
 export type ResolvedOpenworkConnection = {
   normalizedBaseUrl: string;
@@ -30,6 +34,17 @@ function hasUsableConnection(url: string, token: string) {
  * connections and for desktop cases where the runtime bridge is unavailable.
  */
 export async function resolveOpenworkConnection(): Promise<ResolvedOpenworkConnection> {
+  const gatewayOrigin = getOpenworkGatewayOrigin();
+  if (gatewayOrigin) {
+    return {
+      normalizedBaseUrl: normalizeOpenworkServerUrl(gatewayOrigin) ?? "",
+      resolvedToken: readOpenworkGatewayDenToken(),
+      resolvedHostToken: "",
+      hostInfo: null,
+      source: "gateway",
+    };
+  }
+
   let staleDesktopRuntimeBaseUrl = "";
 
   if (isDesktopRuntime()) {

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -1,0 +1,198 @@
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+
+import { readDenSettings, resolveDenBaseUrls } from "../src/app/lib/den";
+import {
+  hydrateOpenworkServerSettingsFromEnv,
+  readOpenworkServerSettings,
+} from "../src/app/lib/openwork-server";
+import { resolveOpenworkConnection } from "../src/react-app/shell/openwork-connection";
+
+const originalWindow = globalThis.window;
+const originalDeployment = process.env.VITE_OPENWORK_DEPLOYMENT;
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+function installWindow(options: {
+  origin: string;
+  gateway?: boolean;
+  bootstrapToken?: string;
+  electronInfo?: {
+    baseUrl: string;
+    ownerToken: string;
+    hostToken?: string;
+  };
+}) {
+  const localStorage = memoryStorage();
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      localStorage,
+      dispatchEvent: () => true,
+      location: { origin: options.origin },
+      __OPENWORK_GATEWAY__: options.gateway ? { version: 1 } : undefined,
+      __OPENWORK_BOOTSTRAP__: options.bootstrapToken ? { token: options.bootstrapToken } : undefined,
+      __OPENWORK_ELECTRON__: options.electronInfo
+        ? {
+            invokeDesktop: async (command: string) => {
+              if (command !== "openworkServerInfo") {
+                throw new Error(`Unexpected desktop command: ${command}`);
+              }
+              return {
+                running: true,
+                baseUrl: options.electronInfo?.baseUrl,
+                ownerToken: options.electronInfo?.ownerToken,
+                hostToken: options.electronInfo?.hostToken,
+              };
+            },
+          }
+        : undefined,
+    },
+  });
+  return localStorage;
+}
+
+describe("gateway runtime mode", () => {
+  beforeEach(() => {
+    process.env.VITE_OPENWORK_DEPLOYMENT = "web";
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+    if (originalDeployment === undefined) {
+      delete process.env.VITE_OPENWORK_DEPLOYMENT;
+    } else {
+      process.env.VITE_OPENWORK_DEPLOYMENT = originalDeployment;
+    }
+  });
+
+  test("resolves OpenWork server traffic through the gateway origin with the Den session token", async () => {
+    const storage = installWindow({ origin: "https://web.openworklabs.com", gateway: true });
+    storage.setItem("openwork.den.authToken", "den-session-token");
+    storage.setItem("openwork.server.urlOverride", "https://direct-instance.example.com");
+    storage.setItem("openwork.server.token", "stale-instance-token");
+
+    const connection = await resolveOpenworkConnection();
+
+    expect(connection).toEqual({
+      normalizedBaseUrl: "https://web.openworklabs.com",
+      resolvedToken: "den-session-token",
+      resolvedHostToken: "",
+      hostInfo: null,
+      source: "gateway",
+    });
+  });
+
+  test("keeps Den API calls on the gateway origin and ignores stale Den storage", () => {
+    const storage = installWindow({ origin: "https://web.openworklabs.com", gateway: true });
+    storage.setItem("openwork.den.baseUrl", "https://app.openworklabs.com");
+    storage.setItem("openwork.den.authToken", "den-session-token");
+
+    expect(resolveDenBaseUrls("https://app.openworklabs.com")).toEqual({
+      baseUrl: "https://web.openworklabs.com",
+      apiBaseUrl: "https://web.openworklabs.com/api/den",
+    });
+    expect(readDenSettings().baseUrl).toBe("https://web.openworklabs.com");
+    expect(readDenSettings().apiBaseUrl).toBe("https://web.openworklabs.com/api/den");
+    expect(readDenSettings().authToken).toBe("den-session-token");
+  });
+
+  test("does not hydrate an instance bootstrap token into server storage behind the gateway", () => {
+    const storage = installWindow({
+      origin: "https://web.openworklabs.com",
+      gateway: true,
+      bootstrapToken: "instance-token-must-not-store",
+    });
+
+    hydrateOpenworkServerSettingsFromEnv();
+
+    expect(storage.getItem("openwork.server.token")).toBeNull();
+    expect(readOpenworkServerSettings().token).toBeUndefined();
+  });
+});
+
+describe("non-gateway connection modes", () => {
+  beforeEach(() => {
+    process.env.VITE_OPENWORK_DEPLOYMENT = "web";
+  });
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+    if (originalDeployment === undefined) {
+      delete process.env.VITE_OPENWORK_DEPLOYMENT;
+    } else {
+      process.env.VITE_OPENWORK_DEPLOYMENT = originalDeployment;
+    }
+  });
+
+  test("direct instance bootstrap hydration and same-origin resolution are unchanged without the marker", async () => {
+    installWindow({ origin: "https://instance.example.com", bootstrapToken: "instance-token" });
+
+    hydrateOpenworkServerSettingsFromEnv();
+    const connection = await resolveOpenworkConnection();
+
+    expect(readOpenworkServerSettings().token).toBe("instance-token");
+    expect(connection.normalizedBaseUrl).toBe("https://instance.example.com");
+    expect(connection.resolvedToken).toBe("instance-token");
+    expect(connection.source).toBe("same-origin");
+  });
+
+  test("stored server settings still win without the marker", async () => {
+    const storage = installWindow({ origin: "https://instance.example.com" });
+    storage.setItem("openwork.server.urlOverride", "https://manual.example.com");
+    storage.setItem("openwork.server.token", "manual-token");
+    storage.setItem("openwork.server.hostToken", "host-token");
+
+    const connection = await resolveOpenworkConnection();
+
+    expect(connection.normalizedBaseUrl).toBe("https://manual.example.com");
+    expect(connection.resolvedToken).toBe("manual-token");
+    expect(connection.resolvedHostToken).toBe("");
+    expect(connection.source).toBe("stored-settings");
+  });
+
+  test("desktop runtime still uses live desktop server info without the marker", async () => {
+    installWindow({
+      origin: "https://instance.example.com",
+      electronInfo: {
+        baseUrl: "http://127.0.0.1:8787",
+        ownerToken: "owner-token",
+        hostToken: "host-token",
+      },
+    });
+
+    const connection = await resolveOpenworkConnection();
+
+    expect(connection.normalizedBaseUrl).toBe("http://127.0.0.1:8787");
+    expect(connection.resolvedToken).toBe("owner-token");
+    expect(connection.resolvedHostToken).toBe("host-token");
+    expect(connection.source).toBe("desktop-runtime");
+  });
+});

--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -51,6 +51,7 @@ const EnvSchema = z.object({
   DEN_DIAGNOSTICS_ORIGIN: z.string().optional(),
   DEN_DIAGNOSTICS_BEARER_TOKEN: z.string().optional(),
   DEN_GATEWAY_KEY: z.string().optional(),
+  DEN_GATEWAY_ORIGIN: z.string().optional(),
   DEN_GOOGLE_OAUTH_AUTHORIZE_URL: z.string().optional(),
   DEN_GOOGLE_OAUTH_TOKEN_URL: z.string().optional(),
   DEN_GOOGLE_API_BASE_URL: z.string().optional(),
@@ -278,6 +279,29 @@ function normalizeDiagnosticsOrigin(value: string | undefined, allowInsecureHttp
   return url.origin
 }
 
+function normalizeOptionalHttpsOrigin(envName: string, value: string | undefined) {
+  const configured = optionalString(value)
+  if (!configured) {
+    return undefined
+  }
+
+  let url: URL
+  try {
+    url = new URL(configured)
+  } catch {
+    throw new Error(`${envName} must be an absolute https origin.`)
+  }
+
+  if (url.protocol !== "https:") {
+    throw new Error(`${envName} must be an absolute https origin.`)
+  }
+  if (url.username || url.password || url.search || url.hash || (url.pathname !== "/" && url.pathname !== "")) {
+    throw new Error(`${envName} cannot contain credentials, a path, a query string, or a fragment.`)
+  }
+
+  return url.origin
+}
+
 function normalizeAbsoluteUrlCsv(envName: string, value: string | undefined) {
   const entries = splitCsv(value)
   const invalidEntries: string[] = []
@@ -407,6 +431,7 @@ export const env = {
     bearerToken: diagnosticsBearerToken,
   },
   gatewayKey: optionalString(parsed.DEN_GATEWAY_KEY),
+  gatewayOrigin: normalizeOptionalHttpsOrigin("DEN_GATEWAY_ORIGIN", parsed.DEN_GATEWAY_ORIGIN),
   planGatingEnabled,
   installLinksGatingEnabled,
   connectLink,

--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -68,6 +68,11 @@ const HANDOFF_STATUS_RATE_LIMIT_WINDOW_MS = 60 * 1000
 const HANDOFF_STATUS_RATE_LIMIT_MAX = 240
 type WorkerOrgId = typeof WorkerTable.$inferSelect.org_id
 
+type ApprovedWebHandoffReturnUrlCandidate = {
+  origin: string
+  returnUrl: string
+}
+
 function readSingleHeader(value: string | null) {
   const first = value?.split(",")[0]?.trim() ?? ""
   return first || null
@@ -203,27 +208,23 @@ function hasPathTraversal(pathname: string) {
   return candidates.some((candidate) => candidate.split("/").some((segment) => segment === "." || segment === ".."))
 }
 
-export function approveWebHandoffReturnUrl(input: {
+function resolveWebHandoffReturnUrlCandidate(input: {
   returnUrl: string
-  signedPreviewUrl: string
   orgMode: DenOrgMode
-}) {
+}): ApprovedWebHandoffReturnUrlCandidate | null {
   if (input.orgMode !== "multi_org") {
     return null
   }
 
   let candidate: URL
-  let signedPreview: URL
   try {
     candidate = new URL(input.returnUrl)
-    signedPreview = new URL(input.signedPreviewUrl)
   } catch {
     return null
   }
 
   if (
     candidate.protocol !== "https:"
-    || signedPreview.protocol !== "https:"
     || candidate.username
     || candidate.password
     || candidate.hash
@@ -236,32 +237,101 @@ export function approveWebHandoffReturnUrl(input: {
     return null
   }
 
+  return {
+    origin: candidate.origin,
+    returnUrl: `${candidate.origin}/signin`,
+  }
+}
+
+function isConfiguredGatewayOrigin(candidateOrigin: string, gatewayOrigin: string | null | undefined) {
+  if (!gatewayOrigin) {
+    return false
+  }
+
+  let gateway: URL
+  try {
+    gateway = new URL(gatewayOrigin)
+  } catch {
+    return false
+  }
+
+  if (
+    gateway.protocol !== "https:"
+    || gateway.username
+    || gateway.password
+    || gateway.search
+    || gateway.hash
+    || (gateway.pathname !== "/" && gateway.pathname !== "")
+  ) {
+    return false
+  }
+
+  // Exact-origin only. As with Daytona preview origins, suffix-based gateway
+  // matches would approve an attacker-controlled origin.
+  return candidateOrigin === gateway.origin
+}
+
+function isSignedPreviewOrigin(candidateOrigin: string, signedPreviewUrl: string) {
+  let signedPreview: URL
+  try {
+    signedPreview = new URL(signedPreviewUrl)
+  } catch {
+    return false
+  }
+
+  if (signedPreview.protocol !== "https:") {
+    return false
+  }
+
   // Exact-origin only. The Daytona preview proxy zone is shared by every
   // Daytona customer, so any suffix-based match would approve an
   // attacker-controlled sandbox origin and leak one-time session grants.
   // If the preview URL was re-signed between opening the instance and
   // signing in, this fails closed and the user reopens Cloud for a fresh
   // URL.
-  if (candidate.origin !== signedPreview.origin) {
+  return candidateOrigin === signedPreview.origin
+}
+
+export function approveWebHandoffReturnUrl(input: {
+  returnUrl: string
+  signedPreviewUrl: string
+  orgMode: DenOrgMode
+  gatewayOrigin?: string | null
+}) {
+  const candidate = resolveWebHandoffReturnUrlCandidate(input)
+  if (!candidate) {
     return null
   }
 
-  return `${candidate.origin}/signin`
+  if (isConfiguredGatewayOrigin(candidate.origin, input.gatewayOrigin)) {
+    return candidate.returnUrl
+  }
+
+  if (isSignedPreviewOrigin(candidate.origin, input.signedPreviewUrl)) {
+    return candidate.returnUrl
+  }
+
+  return null
 }
 
 export function approveWebHandoffReturnUrlForSignedPreviews(input: {
   returnUrl: string
   signedPreviewUrls: string[]
   orgMode: DenOrgMode
+  gatewayOrigin?: string | null
 }) {
+  const candidate = resolveWebHandoffReturnUrlCandidate(input)
+  if (!candidate) {
+    return null
+  }
+
+  if (isConfiguredGatewayOrigin(candidate.origin, input.gatewayOrigin)) {
+    return candidate.returnUrl
+  }
+
   for (const signedPreviewUrl of input.signedPreviewUrls) {
-    const approved = approveWebHandoffReturnUrl({
-      returnUrl: input.returnUrl,
-      signedPreviewUrl,
-      orgMode: input.orgMode,
-    })
-    if (approved) {
-      return approved
+    if (isSignedPreviewOrigin(candidate.origin, signedPreviewUrl)) {
+      return candidate.returnUrl
     }
   }
 
@@ -303,6 +373,7 @@ async function resolveApprovedWebHandoffReturnUrl(input: {
     returnUrl: input.returnUrl,
     signedPreviewUrls,
     orgMode: env.orgMode,
+    gatewayOrigin: env.gatewayOrigin,
   })
 }
 

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -239,6 +239,11 @@ function buildOpenWorkStartCommand(input: ProvisionInput) {
     shellQuote("/usr/local/bin/opencode"),
     " OPENWORK_WEB_ROOT=",
     shellQuote("/opt/openwork/web"),
+    // The instance still serves its own SPA copy for direct/debug access, but
+    // without a bootstrap token that path is intentionally inert; the gateway
+    // is the supported entry.
+    " OPENWORK_WEB_BOOTSTRAP_TOKEN=",
+    shellQuote("0"),
     " OPENWORK_EXTENSIONS_PLUGIN_DIR=",
     shellQuote("/opt/openwork/opencode-plugins"),
     " DEN_RUNTIME_PROVIDER=",

--- a/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
+++ b/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
@@ -54,6 +54,49 @@ describe("desktop handoff public URL", () => {
     })).toBe("https://8787-bob.daytonaproxy01.net/signin")
   })
 
+  test("approves a web returnUrl on the exact configured gateway origin", async () => {
+    const { approveWebHandoffReturnUrlForSignedPreviews } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrlForSignedPreviews({
+      orgMode: "multi_org",
+      gatewayOrigin: "https://web.openworklabs.com",
+      signedPreviewUrls: [],
+      returnUrl: "https://web.openworklabs.com/",
+    })).toBe("https://web.openworklabs.com/signin")
+  })
+
+  test("rejects a gateway web returnUrl when the gateway origin is unset", async () => {
+    const { approveWebHandoffReturnUrlForSignedPreviews } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrlForSignedPreviews({
+      orgMode: "multi_org",
+      signedPreviewUrls: ["https://8787-active.daytonaproxy01.net/signed"],
+      returnUrl: "https://web.openworklabs.com/signin",
+    })).toBeNull()
+  })
+
+  test("rejects a gateway web returnUrl on a different origin", async () => {
+    const { approveWebHandoffReturnUrlForSignedPreviews } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrlForSignedPreviews({
+      orgMode: "multi_org",
+      gatewayOrigin: "https://web.openworklabs.com",
+      signedPreviewUrls: [],
+      returnUrl: "https://app.openworklabs.com/signin",
+    })).toBeNull()
+  })
+
+  test("rejects an http gateway web returnUrl", async () => {
+    const { approveWebHandoffReturnUrlForSignedPreviews } = await loadDesktopHandoffRoutes()
+
+    expect(approveWebHandoffReturnUrlForSignedPreviews({
+      orgMode: "multi_org",
+      gatewayOrigin: "https://web.openworklabs.com",
+      signedPreviewUrls: [],
+      returnUrl: "http://web.openworklabs.com/signin",
+    })).toBeNull()
+  })
+
   test("rejects a rotated hostname even on the same preview suffix (shared proxy zone)", async () => {
     const { approveWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
 

--- a/ee/apps/den-gateway/src/app.ts
+++ b/ee/apps/den-gateway/src/app.ts
@@ -51,6 +51,19 @@ const ASSET_CACHE = "public, max-age=31536000, immutable"
 const INDEX_CACHE = "no-cache"
 const gatewayKeyHeader = "X-OpenWork-Gateway-Key"
 const resolvePath = "/v1/cloud/gateway/resolve"
+const denApiRoutePrefix = "/api/den"
+const gatewayMarker = { version: 1 }
+const hopByHopHeaders = new Set([
+  "connection",
+  "keep-alive",
+  "proxy-authenticate",
+  "proxy-authorization",
+  "te",
+  "trailer",
+  "transfer-encoding",
+  "upgrade",
+])
+const spoofableForwardingHeaders = new Set(["forwarded", "x-forwarded-host", "x-forwarded-prefix", "x-forwarded-proto"])
 const proxyPathNamespaces = [
   "/health",
   "/status",
@@ -293,6 +306,20 @@ function responseHeaders(extension: string, cacheControl: string) {
   })
 }
 
+function escapeScriptJson(json: string) {
+  return json.replace(/[<>&\u2028\u2029]/g, (char) => `\\u${char.charCodeAt(0).toString(16).padStart(4, "0")}`)
+}
+
+function injectGatewayMarker(html: string) {
+  const marker = escapeScriptJson(JSON.stringify(gatewayMarker))
+  const script = `<script>window.__OPENWORK_GATEWAY__ = ${marker}</script>`
+  const headCloseIndex = html.toLowerCase().indexOf("</head>")
+  if (headCloseIndex < 0) {
+    return `${script}${html}`
+  }
+  return `${html.slice(0, headCloseIndex)}${script}${html.slice(headCloseIndex)}`
+}
+
 async function serveFile(root: string, relativePath: string, requestPathname: string, method: string) {
   const filePath = await resolveWithinRoot(root, relativePath)
   const fileStat = await stat(filePath).catch(() => null)
@@ -308,7 +335,9 @@ async function serveFile(root: string, relativePath: string, requestPathname: st
   }
 
   if (isTextExtension(extension)) {
-    return new Response(await readFile(filePath, "utf8"), { status: 200, headers })
+    const body = await readFile(filePath, "utf8")
+    const text = relativePath === "index.html" ? injectGatewayMarker(body) : body
+    return new Response(text, { status: 200, headers })
   }
 
   const bytes = await readFile(filePath)
@@ -429,6 +458,26 @@ function buildProxyUrl(baseUrl: string, requestUrl: string) {
   return target.toString()
 }
 
+function denApiProxyPath(pathname: string) {
+  if (pathname === denApiRoutePrefix) {
+    return ""
+  }
+  if (pathname.startsWith(`${denApiRoutePrefix}/`)) {
+    return pathname.slice(denApiRoutePrefix.length)
+  }
+  return pathname
+}
+
+function buildDenApiProxyUrl(denApiBase: string, requestUrl: string) {
+  const current = new URL(requestUrl)
+  const target = new URL(denApiBase)
+  const basePath = target.pathname.replace(/\/+$/, "")
+  const proxyPath = denApiProxyPath(current.pathname)
+  target.pathname = `${basePath}${proxyPath}` || "/"
+  target.search = current.search
+  return target.toString()
+}
+
 async function requestBody(request: Request) {
   const method = request.method.toUpperCase()
   if (method === "GET" || method === "HEAD") {
@@ -452,6 +501,24 @@ function upstreamRequestHeaders(headers: Headers, clientToken: string) {
   return upstream
 }
 
+function denApiRequestHeaders(request: Request) {
+  const upstream = new Headers()
+  request.headers.forEach((value, name) => {
+    const normalized = name.toLowerCase()
+    if (hopByHopHeaders.has(normalized)) return
+    if (normalized === "host" || normalized === "content-length" || normalized === "cookie") return
+    if (spoofableForwardingHeaders.has(normalized)) return
+    if (normalized === gatewayKeyHeader.toLowerCase()) return
+    upstream.append(name, value)
+  })
+
+  const url = new URL(request.url)
+  upstream.set("x-forwarded-host", url.host)
+  upstream.set("x-forwarded-proto", url.protocol.replace(/:$/, ""))
+  upstream.set("x-forwarded-prefix", denApiRoutePrefix)
+  return upstream
+}
+
 function sanitizeProxyResponse(response: Response) {
   const headers = new Headers(response.headers)
   headers.delete("content-encoding")
@@ -463,6 +530,37 @@ function sanitizeProxyResponse(response: Response) {
     statusText: response.statusText,
     headers,
   })
+}
+
+function sanitizeDenApiResponse(response: Response) {
+  const headers = new Headers(response.headers)
+  headers.delete("content-encoding")
+  headers.delete("transfer-encoding")
+  headers.delete("content-length")
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  })
+}
+
+async function proxyToDenApi(input: {
+  config: GatewayConfig
+  request: Request
+}) {
+  let response: Response
+  try {
+    response = await input.config.fetchImpl(buildDenApiProxyUrl(input.config.denApiBase, input.request.url), {
+      method: input.request.method,
+      headers: denApiRequestHeaders(input.request),
+      body: await requestBody(input.request),
+      redirect: "manual",
+    })
+  } catch {
+    return jsonResponse({ error: "gateway_den_api_failed" }, 502)
+  }
+
+  return sanitizeDenApiResponse(response)
 }
 
 async function proxyToInstance(input: {
@@ -550,6 +648,9 @@ export function createGatewayApp(options: GatewayAppOptions = {}) {
 
   app.get("/__gw/health", (c) => c.json({ ok: true, service: "den-gateway" }))
   app.get("/__gw/ready", (c) => c.json({ ok: true, service: "den-gateway" }))
+
+  app.all(denApiRoutePrefix, (c) => proxyToDenApi({ config, request: c.req.raw }))
+  app.all(`${denApiRoutePrefix}/*`, (c) => proxyToDenApi({ config, request: c.req.raw }))
 
   app.all("*", async (c) => {
     if (shouldProxyToInstance(c.req.raw)) {

--- a/ee/apps/den-gateway/test/gateway.test.mjs
+++ b/ee/apps/den-gateway/test/gateway.test.mjs
@@ -68,6 +68,51 @@ function startDenApi(resolvePayload) {
   return { server, observed }
 }
 
+function startPassthroughDenApi() {
+  const observed = { requests: [] }
+  const encoder = new TextEncoder()
+  const server = startServer(async (request) => {
+    const url = new URL(request.url)
+    observed.requests.push({
+      method: request.method,
+      path: `${url.pathname}${url.search}`,
+      authorization: request.headers.get("authorization"),
+      cookie: request.headers.get("cookie"),
+      gatewayKey: request.headers.get("x-openwork-gateway-key"),
+      forwardedPrefix: request.headers.get("x-forwarded-prefix"),
+      body: await request.text(),
+    })
+
+    if (url.pathname === "/v1/events") {
+      const stream = new ReadableStream({
+        start(controller) {
+          controller.enqueue(encoder.encode("data: den-first\n\n"))
+          setTimeout(() => {
+            controller.enqueue(encoder.encode("data: den-second\n\n"))
+            controller.close()
+          }, 500)
+        },
+      })
+      return new Response(stream, { headers: { "Content-Type": "text/event-stream" } })
+    }
+
+    if (url.pathname === "/v1/compressed") {
+      return new Response(Bun.gzipSync("compressed den upstream"), {
+        headers: {
+          "Content-Type": "text/plain; charset=utf-8",
+          "Content-Encoding": "gzip",
+          "Transfer-Encoding": "chunked",
+        },
+      })
+    }
+
+    return Response.json({ ok: true, path: url.pathname }, {
+      headers: { "Cache-Control": "private, max-age=10" },
+    })
+  })
+  return { server, observed }
+}
+
 function startUpstream() {
   const observed = { requests: [] }
   const encoder = new TextEncoder()
@@ -137,9 +182,76 @@ describe("den-gateway static UI", () => {
     const traversal = await fetch(`${base}/%2e%2e%2fsecret.txt`)
     expect(traversal.status).toBe(400)
   })
+
+  test("injects the gateway runtime marker into index.html without a bootstrap token", async () => {
+    const root = await makeWebRoot()
+    const gateway = startGateway({ webRoot: root })
+
+    const response = await fetch(`${serverBase(gateway)}/`)
+    const html = await response.text()
+
+    expect(html).toContain("window.__OPENWORK_GATEWAY__ = {\"version\":1}")
+    expect(html).not.toContain("__OPENWORK_BOOTSTRAP__")
+    expect(html).not.toContain("client-token")
+  })
 })
 
 describe("den-gateway proxy", () => {
+  test("passes /api/den through to den-api with the caller bearer, no cookies, and the prefix stripped", async () => {
+    const denApi = startPassthroughDenApi()
+    const upstream = startUpstream()
+    const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
+
+    const response = await fetch(`${serverBase(gateway)}/api/den/v1/me?expand=org`, {
+      method: "POST",
+      headers: {
+        Authorization: "Bearer den-session",
+        Cookie: "ow_session=must_not_leak",
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({ hello: "world" }),
+    })
+
+    expect(response.status).toBe(200)
+    expect(response.headers.get("cache-control")).toBe("private, max-age=10")
+    expect(denApi.observed.requests).toHaveLength(1)
+    expect(denApi.observed.requests[0]).toEqual({
+      method: "POST",
+      path: "/v1/me?expand=org",
+      authorization: "Bearer den-session",
+      cookie: null,
+      gatewayKey: null,
+      forwardedPrefix: "/api/den",
+      body: '{"hello":"world"}',
+    })
+    expect(upstream.observed.requests).toHaveLength(0)
+  })
+
+  test("streams /api/den responses without buffering and strips stale compression headers", async () => {
+    const denApi = startPassthroughDenApi()
+    const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
+    const base = serverBase(gateway)
+
+    const startedAt = Date.now()
+    const streamResponse = await fetch(`${base}/api/den/v1/events`, {
+      headers: { Authorization: "Bearer den-stream", Accept: "text/event-stream" },
+    })
+    expect(streamResponse.headers.get("content-type")).toContain("text/event-stream")
+    const reader = streamResponse.body.getReader()
+    const first = await reader.read()
+    const elapsed = Date.now() - startedAt
+    expect(new TextDecoder().decode(first.value)).toBe("data: den-first\n\n")
+    expect(elapsed).toBeLessThan(300)
+    await reader.read()
+
+    const compressed = await fetch(`${base}/api/den/v1/compressed`, {
+      headers: { Authorization: "Bearer den-stream" },
+    })
+    expect(compressed.headers.get("content-encoding")).toBeNull()
+    expect(compressed.headers.get("transfer-encoding")).toBeNull()
+    expect(await compressed.text()).toBe("compressed den upstream")
+  })
+
   test("answers gateway health while /health proxies to the instance", async () => {
     const upstream = startUpstream()
     const denApi = startDenApi(() => ({ status: "ready", url: serverBase(upstream.server), clientToken: "client-token" }))

--- a/evals/voiceovers/den-gateway.md
+++ b/evals/voiceovers/den-gateway.md
@@ -1,12 +1,12 @@
 # den-gateway — OpenWork in the browser at one address, with the machine invisible
 
-ui.openworklabs.com is served by den-gateway: it signs the user in, routes them
+web.openworklabs.com is served by den-gateway: it signs the user in, routes them
 to their own instance, and injects that instance's credentials server-side. The
 browser never holds an instance token, never sees a machine name, and never
 learns which compute vendor is behind it. den-api remains the only thing that
 talks to Daytona.
 
-1. I go to ui.openworklabs.com and get a sign-in page. Nothing is running for me
+1. I go to web.openworklabs.com and get a sign-in page. Nothing is running for me
    yet, and there is nothing to install.
 
 2. I sign in with my work account and land in OpenWork with the cursor already
@@ -20,7 +20,7 @@ talks to Daytona.
 
 5. I ask it to save a summary to a file, and the file appears in my workspace.
 
-6. The address bar says ui.openworklabs.com and nothing else — no tokens, no
+6. The address bar says web.openworklabs.com and nothing else — no tokens, no
    machine names, nothing I'd think twice about screen-sharing.
 
 7. I close the tab and come back the next morning from a different laptop. The

--- a/packaging/docker/Dockerfile.den-gateway
+++ b/packaging/docker/Dockerfile.den-gateway
@@ -1,0 +1,57 @@
+# syntax=docker/dockerfile:1.7
+FROM node:22-bookworm-slim
+
+RUN corepack enable
+
+WORKDIR /app
+
+ARG DEN_GATEWAY_VERSION=dev
+ENV DEN_GATEWAY_VERSION=${DEN_GATEWAY_VERSION}
+ENV PORT=8788
+
+# The gateway serves the OpenWork web build itself, so the app and Den end up on
+# one origin. That is what removes the need for cross-origin patches, and it is
+# why the SPA is baked in here rather than served from a separate CDN origin.
+ENV DEN_GATEWAY_WEB_ROOT=/opt/openwork/web
+
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /app/
+COPY patches /app/patches
+COPY packages/types/package.json /app/packages/types/package.json
+COPY packages/ui/package.json /app/packages/ui/package.json
+COPY packages/install-config/package.json /app/packages/install-config/package.json
+COPY ee/packages/utils/package.json /app/ee/packages/utils/package.json
+COPY ee/apps/den-gateway/package.json /app/ee/apps/den-gateway/package.json
+COPY apps/app/package.json /app/apps/app/package.json
+
+RUN pnpm install --frozen-lockfile --trust-lockfile
+
+COPY packages/types /app/packages/types
+COPY packages/ui /app/packages/ui
+COPY packages/install-config /app/packages/install-config
+COPY ee/packages/utils /app/ee/packages/utils
+COPY ee/apps/den-gateway /app/ee/apps/den-gateway
+COPY apps/app /app/apps/app
+
+RUN pnpm --dir /app/packages/types run build
+RUN pnpm --dir /app/packages/ui run build
+RUN pnpm --dir /app/packages/install-config run build
+RUN pnpm --dir /app/ee/packages/utils run build
+
+# build:web already sets VITE_OPENWORK_DEPLOYMENT=web and
+# VITE_DEN_REQUIRE_SIGNIN=1. VITE_DEN_BASE_URL is deliberately NOT baked: in
+# gateway mode the app resolves Den from window.location.origin at runtime via
+# the gateway marker, and a baked base URL would silently defeat that.
+RUN pnpm --dir /app/apps/app run build:web
+
+RUN pnpm --dir /app/ee/apps/den-gateway run build
+
+RUN mkdir -p /opt/openwork \
+  && cp -R /app/apps/app/dist /opt/openwork/web \
+  && test -f /opt/openwork/web/index.html \
+  && test -d /opt/openwork/web/assets
+
+EXPOSE 8788
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=20s --retries=3 CMD node -e "fetch('http://127.0.0.1:' + (process.env.PORT || '8788') + '/__gw/health').then((res) => process.exit(res.ok ? 0 : 1)).catch(() => process.exit(1))"
+
+CMD ["node", "/app/ee/apps/den-gateway/dist/server.js"]


### PR DESCRIPTION
Follow-up to #3191 (which landed the gateway app + resolve endpoint). This makes the gateway actually reachable end-to-end and shippable.

## What this adds

**One origin for app + Den.** `/api/den/*` passes through to Den with the bearer forwarded unchanged and cookies stripped. The app learns it is behind a gateway from a token-free `window.__OPENWORK_GATEWAY__` marker and switches to a same-origin base with the Den session token, ignoring `__OPENWORK_BOOTSTRAP__`.

**Gateway sign-in no longer dead-ends.** `approveWebHandoffReturnUrl` previously accepted only Daytona preview origins, so a sign-in that started on the gateway had nowhere valid to return to. It now also accepts a configured `DEN_GATEWAY_ORIGIN` — exact origin match only, no wildcards, unset means nothing new is accepted.

**No web token on provisioned instances.** `buildOpenWorkStartCommand` sets `OPENWORK_WEB_BOOTSTRAP_TOKEN=0`; the gateway is the only thing that holds credentials.

**A publishable image.** `packaging/docker/Dockerfile.den-gateway` bakes the web build into `/opt/openwork/web` so the SPA and Den share an origin, and the image is registered in the EE publish matrix. Its liveness path is `/__gw/health` because `/health` proxies through to the user's instance.

**A CI footgun fixed.** The image build step's condition was an allowlist of image names, so adding a matrix entry silently skipped the build and then failed the smoke step with a confusing registry `denied` error — that is exactly what happened on this PR's first run. It is now stated as an exclusion, so a new image builds by default. The two build conditions are exact complements, and behavior for den-api / den-web / inference is unchanged.

## Tests run

| Command | Result |
| --- | --- |
| `pnpm --filter @openwork-ee/den-gateway run test` | 13 pass / 0 fail |
| `bun test --isolate tests/gateway-runtime.test.ts` (apps/app) | 6 pass / 0 fail |
| `bun test test/desktop-handoff-public-url.test.ts test/cloud-instance-route.test.ts` (den-api) | 31 pass / 0 fail |
| `tsc --noEmit` — den-gateway / den-api / apps/app | 0 errors each |

Re-ran all of the above after rebasing onto current `dev`. All 16 PR checks are green.

## Image proof (CI)

`Build openwork-den-gateway` builds the image and then runs it and polls its health endpoint. Both steps pass:

- `Build and optionally push without Sentry source-map upload` -> success
- `Smoke health endpoint` -> success (container runs, `/__gw/health` responds ok)

## Runtime proof (local)

Booted the built gateway (`dist/server.js`) against the real `build:web` output — the same entrypoint and web root the image uses:

- `GET /__gw/health` -> `200 {"ok":true,"service":"den-gateway"}`
- `GET /` -> `200 text/html`, contains `__OPENWORK_GATEWAY__`, and contains **no** token, key, or `__OPENWORK_BOOTSTRAP__`
- `GET /settings/extensions` -> `200` (deep link falls back to the SPA)
- `GET /assets/app-*.js` -> `200 text/javascript`
- Both Dockerfile assertions verified against a real build: `dist/index.html` and `dist/assets` exist

## Not verified here

No fraimz in this PR: the gateway sign-in return needs the deployed origin (`DEN_GATEWAY_ORIGIN` + DNS) to exercise, and `evals/flows/den-gateway.flow.ts` frames are still stubs. That proof comes with the deploy, before any DNS cutover of `web.openworklabs.com`.