### PR TITLE
fix(app): stabilize the gateway bootstrap snapshot so the app mounts behind den-gateway

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -312,6 +312,9 @@ let desktopBootstrapConfig: DenBootstrapConfig = {
   source: "default",
   requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
 };
+let gatewayBootstrapConfig: DenBootstrapConfig | null = null;
+let gatewayBootstrapConfigOrigin: string | null = null;
+let gatewayBootstrapConfigSource: DenBootstrapConfig | null = null;
 
 export type DenAppVersionMetadata = {
   minAppVersion: string;
@@ -680,10 +683,21 @@ function applyDesktopBootstrapConfig(config: DenBootstrapConfig) {
 export function readDenBootstrapConfig(): DenBootstrapConfig {
   const gatewayOrigin = getOpenworkGatewayOrigin();
   if (gatewayOrigin) {
-    return {
+    if (
+      gatewayBootstrapConfig &&
+      gatewayBootstrapConfigOrigin === gatewayOrigin &&
+      gatewayBootstrapConfigSource === desktopBootstrapConfig
+    ) {
+      return gatewayBootstrapConfig;
+    }
+
+    gatewayBootstrapConfig = {
       ...desktopBootstrapConfig,
       ...resolveDenBaseUrls({ baseUrl: gatewayOrigin }),
     };
+    gatewayBootstrapConfigOrigin = gatewayOrigin;
+    gatewayBootstrapConfigSource = desktopBootstrapConfig;
+    return gatewayBootstrapConfig;
   }
 
   return desktopBootstrapConfig;

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { readDenSettings, resolveDenBaseUrls } from "../src/app/lib/den";
+import { readDenBootstrapConfig, readDenSettings, resolveDenBaseUrls } from "../src/app/lib/den";
 import {
   hydrateOpenworkServerSettingsFromEnv,
   readOpenworkServerSettings,
@@ -119,6 +119,17 @@ describe("gateway runtime mode", () => {
     expect(readDenSettings().baseUrl).toBe("https://web.openworklabs.com");
     expect(readDenSettings().apiBaseUrl).toBe("https://web.openworklabs.com/api/den");
     expect(readDenSettings().authToken).toBe("den-session-token");
+  });
+
+  test("returns a stable gateway bootstrap snapshot for React external stores", () => {
+    installWindow({ origin: "https://web.openworklabs.com", gateway: true });
+
+    const first = readDenBootstrapConfig();
+    const second = readDenBootstrapConfig();
+
+    expect(second).toBe(first);
+    expect(first.baseUrl).toBe("https://web.openworklabs.com");
+    expect(first.apiBaseUrl).toBe("https://web.openworklabs.com/api/den");
   });
 
   test("does not hydrate an instance bootstrap token into server storage behind the gateway", () => {


### PR DESCRIPTION
Behind den-gateway the app crashed to a blank page before rendering anything.

## Cause

`readDenBootstrapConfig()` built a brand-new object on every call in gateway mode. Consumers read it through `useSyncExternalStore`, whose `getSnapshot` must return a cached value — a fresh object every read looks like a changed store, so React's `updateStoreInstance` effect kept calling `forceStoreRerender` until it hit max update depth and threw **React #185**.

Captured component stacks: `mountSyncExternalStore -> useEnterpriseActivationRequired -> EnterpriseAwareAppProviders`, and fatally `<DenSigninGate>`.

The fix caches the gateway snapshot and returns a stable identity until either the gateway origin or the underlying desktop bootstrap config changes. All three writers of `desktopBootstrapConfig` reassign it rather than mutate it, so identity comparison is a sound invalidation signal.

## Evidence

Before, on the deployed gateway: `#root` children `0`, uncaught React #185. Non-gateway control (`window.__OPENWORK_GATEWAY__` absent) on the same build rendered fine, which is what isolated this to gateway mode.

After, on the deployed gateway (`https://gateway-rlch.onrender.com/signin`), sampled 10 times over 12s:

```
{"h":"/signin","k":0} then {"h":"/signin","k":2} x9   <- mounts and settles, no oscillation
final: "Welcome to OpenWork ... Sign in to OpenWork ... Paste sign-in code"
gatewayMarker=true  tokenInHtml=false  react185=0  exceptions=[]
```

## Tests

| Command | Result |
| --- | --- |
| `cd apps/app && bun test --isolate tests/` | 468 pass / 0 fail |
| `pnpm --filter @openwork-ee/den-gateway run test` | 13 pass / 0 fail |
| `pnpm --filter @openwork/app exec tsc --noEmit` | 0 errors |

Includes a regression test asserting the gateway bootstrap snapshot keeps a stable identity across reads.

## Known remaining gap (not this PR)

Sign-in still cannot complete behind the gateway, for a separate reason: `resolveRequestBaseUrl` routes every `/api/*` path to `baseUrl`, which gateway mode sets to the gateway origin, but the gateway only proxies `/api/den/*`. So `GET /api/auth/get-session` returns SPA HTML instead of JSON, and `buildDenAuthUrl` sends the user to the gateway origin instead of den-web. That needs a deliberate decision about how Den auth traverses the gateway and is tracked separately.