### PR TITLE
fix(diagnostics): omit SNI servername for IP-literal cloud endpoints

### DIFF
--- a/apps/desktop/electron/updater.mjs
+++ b/apps/desktop/electron/updater.mjs
@@ -262,7 +262,7 @@ export function registerUpdaterIpc({
   app,
   ipcMain,
   getMainWindow,
-  loadAutoUpdater,
+  loadAutoUpdater = () => import("electron-updater"),
   manifestChannel = "latest",
   shipItDefaultsDomain = SHIP_IT_DEFAULTS_DOMAIN,
 }) {
@@ -288,9 +288,7 @@ export function registerUpdaterIpc({
     if (autoUpdaterLoaded) return autoUpdaterInstance;
     autoUpdaterLoaded = true;
     try {
-      const mod = await (loadAutoUpdater
-        ? loadAutoUpdater()
-        : import("electron-updater"));
+      const mod = await loadAutoUpdater();
       autoUpdaterInstance = mod.autoUpdater ?? mod.default?.autoUpdater ?? null;
       if (autoUpdaterInstance) {
         autoUpdaterInstance.autoDownload = false;

--- a/apps/server/src/agent-context-transport-probe.test.ts
+++ b/apps/server/src/agent-context-transport-probe.test.ts
@@ -4,10 +4,10 @@ import { mkdtemp, readFile, rm } from "node:fs/promises";
 import { createServer as createNetServer } from "node:net";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import tls from "node:tls";
+import tls, { type ConnectionOptions } from "node:tls";
 import { promisify } from "node:util";
 
-import { probeCloudEndpointTransport } from "./agent-context-transport-probe.js";
+import { probeCloudEndpointTransport, type TransportProbeConnector } from "./agent-context-transport-probe.js";
 
 const execFileAsync = promisify(execFile);
 const roots: string[] = [];
@@ -91,7 +91,74 @@ async function startSelfSignedTlsServer(): Promise<number> {
   return port;
 }
 
+function captureConnectorOptions(): { connector: TransportProbeConnector; options: ConnectionOptions[] } {
+  const options: ConnectionOptions[] = [];
+  return {
+    connector: (connectionOptions) => {
+      options.push(connectionOptions);
+      throw new Error("captured options");
+    },
+    options,
+  };
+}
+
+function onlyCapturedOption(options: ConnectionOptions[]): ConnectionOptions {
+  const option = options[0];
+  if (!option || options.length !== 1) throw new Error(`Expected one connector call, got ${options.length}`);
+  return option;
+}
+
 describe("probeCloudEndpointTransport", () => {
+  test("passes SNI servername for DNS endpoints", async () => {
+    const capture = captureConnectorOptions();
+
+    await probeCloudEndpointTransport({
+      endpointUrl: "https://example.com/mcp/agent",
+      performProbe: true,
+      timeoutMs: 1_000,
+      connector: capture.connector,
+      env: {},
+    });
+
+    const options = onlyCapturedOption(capture.options);
+    expect(options.host).toBe("example.com");
+    expect(options.servername).toBe("example.com");
+  });
+
+  test("omits SNI servername for IPv4 endpoints", async () => {
+    const capture = captureConnectorOptions();
+
+    await probeCloudEndpointTransport({
+      endpointUrl: "https://127.0.0.1:444/mcp/agent",
+      performProbe: true,
+      timeoutMs: 1_000,
+      connector: capture.connector,
+      env: {},
+    });
+
+    const options = onlyCapturedOption(capture.options);
+    expect(options.host).toBe("127.0.0.1");
+    expect(options.port).toBe(444);
+    expect("servername" in options).toBe(false);
+  });
+
+  test("omits SNI servername and strips brackets for IPv6 endpoints", async () => {
+    const capture = captureConnectorOptions();
+
+    await probeCloudEndpointTransport({
+      endpointUrl: "https://[::1]/mcp/agent",
+      performProbe: true,
+      timeoutMs: 1_000,
+      connector: capture.connector,
+      env: {},
+    });
+
+    const options = onlyCapturedOption(capture.options);
+    expect(options.host).toBe("::1");
+    expect(options.port).toBe(443);
+    expect("servername" in options).toBe(false);
+  });
+
   test("captures certificate-chain evidence for a self-signed endpoint without credentials", async () => {
     const port = await startSelfSignedTlsServer();
     const result = await probeCloudEndpointTransport({
@@ -129,6 +196,7 @@ describe("probeCloudEndpointTransport", () => {
     });
 
     expect(result.verifiedHandshake).toBe("failed");
+    expect(result.verifyErrorCode).not.toBe("ERR_INVALID_ARG_VALUE");
     expect(result.verifyErrorCode).toBe("ECONNREFUSED");
     expect(result.dnsResolved).toBe(true);
     expect(result.tcpConnected).toBe(false);

--- a/apps/server/src/agent-context-transport-probe.ts
+++ b/apps/server/src/agent-context-transport-probe.ts
@@ -1,4 +1,5 @@
 import { readFile } from "node:fs/promises";
+import { isIP } from "node:net";
 import tls from "node:tls";
 import type { ConnectionOptions, DetailedPeerCertificate, TLSSocket } from "node:tls";
 
@@ -181,14 +182,21 @@ function endpointPort(url: URL): number {
   return Number.isInteger(port) && port > 0 && port <= 65_535 ? port : 443;
 }
 
+function stripIpv6HostnameBrackets(hostname: string): string {
+  return hostname.startsWith("[") && hostname.endsWith("]") ? hostname.slice(1, -1) : hostname;
+}
+
 function tlsOptions(url: URL, rejectUnauthorized: boolean): ConnectionOptions {
-  return {
-    host: url.hostname,
+  const host = stripIpv6HostnameBrackets(url.hostname);
+  const options: ConnectionOptions = {
+    host,
     port: endpointPort(url),
-    servername: url.hostname,
     rejectUnauthorized,
     ALPNProtocols: ["http/1.1"],
   };
+  // SNI forbids IP literals; Node throws ERR_INVALID_ARG_VALUE if servername is an IP address.
+  if (isIP(host) === 0) options.servername = host;
+  return options;
 }
 
 function connectTls(input: {


### PR DESCRIPTION
## Problem
dev CI went red on d1c395bde (#3201): 3 transport-probe tests fail on the CI runtime with `verifyErrorCode: ERR_INVALID_ARG_VALUE` — only for `127.0.0.1` endpoints (the DNS-hostname test passed).

Root cause: `tlsOptions()` set `servername: url.hostname` unconditionally. SNI forbids IP literals — **Node throws `ERR_INVALID_ARG_VALUE` synchronously** ("Setting the TLS ServerName to an IP address is not permitted"). Local Bun 1.3.10 tolerates it, which is why the PR's local runs were green; CI (and the production embedded-server runtime, Node) enforce it. Reproduced with a 5-line script under `node`.

## Fix
Set `servername` only when the host is not an IP literal (`net.isIP`), stripping IPv6 brackets from URL hostnames for the raw `host` option. One function, plus regression tests: connector-captured options for DNS/IPv4/IPv6 endpoints, and an explicit not-`ERR_INVALID_ARG_VALUE` assertion on the refused-connection path.

## Tests
- `bun test` (apps/server, full suite CI runs): **589 pass / 0 fail** (599 tests, 80 files) — includes the 3 previously CI-failing tests
- Node-runtime proof (production runtime): raw `tls.connect` with the fixed option shape → `ECONNREFUSED` on closed port, `DEPTH_ZERO_SELF_SIGNED_CERT` on a self-signed server, no servername in options
- `pnpm --filter openwork-server typecheck` ✅