### PR TITLE
fix(gateway): send sign-in to den-web and approve the gateway return URL without an org

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -556,24 +556,33 @@ function ensureDenApiBasePath(input: string | null | undefined): string | null {
 }
 
 export function resolveDenBaseUrls(input: { baseUrl?: string | null; apiBaseUrl?: string | null } | string | null | undefined): DenBaseUrls {
+  const rawBaseUrl = typeof input === "string" ? input : input?.baseUrl;
+  const normalizedBaseUrl = normalizeDenBaseUrl(rawBaseUrl);
+  const normalizedApiBaseUrl = typeof input === "string" ? null : normalizeDenBaseUrl(input?.apiBaseUrl);
   const gatewayOrigin = getOpenworkGatewayOrigin();
+
   if (gatewayOrigin) {
-    const baseUrl = normalizeDenBaseUrl(gatewayOrigin) ?? gatewayOrigin;
+    const normalizedGatewayOrigin = normalizeDenBaseUrl(gatewayOrigin) ?? gatewayOrigin;
+    const gatewayBaseUrl =
+      normalizedBaseUrl && denOriginComparisonKey(normalizedBaseUrl) !== denOriginComparisonKey(normalizedGatewayOrigin)
+        ? normalizedBaseUrl
+        : DEFAULT_DEN_BASE_URL;
+    const baseUrl = stripDenApiBasePath(gatewayBaseUrl) ?? DEFAULT_DEN_BASE_URL;
+
     return {
       baseUrl,
-      apiBaseUrl: ensureDenApiBasePath(baseUrl) ?? baseUrl,
+      apiBaseUrl: ensureDenApiBasePath(normalizedGatewayOrigin) ?? normalizedGatewayOrigin,
     };
   }
 
-  const rawBaseUrl = typeof input === "string" ? input : input?.baseUrl;
-  const normalizedBaseUrl = normalizeDenBaseUrl(rawBaseUrl);
-  const legacyApiBaseUrl = typeof input === "string" ? null : normalizeDenBaseUrl(input?.apiBaseUrl);
-  const seedUrl = stripDenApiBasePath(normalizedBaseUrl ?? legacyApiBaseUrl) ?? DEFAULT_DEN_BASE_URL;
+  const seedUrl = stripDenApiBasePath(normalizedBaseUrl ?? normalizedApiBaseUrl) ?? DEFAULT_DEN_BASE_URL;
   const baseUrl = stripDenApiBasePath(seedUrl) ?? DEFAULT_DEN_BASE_URL;
 
   return {
     baseUrl,
-    apiBaseUrl: ensureDenApiBasePath(baseUrl) ?? baseUrl,
+    apiBaseUrl: normalizedApiBaseUrl
+      ? ensureDenApiBasePath(normalizedApiBaseUrl) ?? normalizedApiBaseUrl
+      : ensureDenApiBasePath(baseUrl) ?? baseUrl,
   };
 }
 
@@ -693,7 +702,10 @@ export function readDenBootstrapConfig(): DenBootstrapConfig {
 
     gatewayBootstrapConfig = {
       ...desktopBootstrapConfig,
-      ...resolveDenBaseUrls({ baseUrl: gatewayOrigin }),
+      ...resolveDenBaseUrls({
+        baseUrl: desktopBootstrapConfig.baseUrl,
+        apiBaseUrl: gatewayOrigin,
+      }),
     };
     gatewayBootstrapConfigOrigin = gatewayOrigin;
     gatewayBootstrapConfigSource = desktopBootstrapConfig;
@@ -705,8 +717,10 @@ export function readDenBootstrapConfig(): DenBootstrapConfig {
 
 export async function initializeDenBootstrapConfig(): Promise<DenBootstrapConfig> {
   if (!isDesktopRuntime()) {
+    const gatewayOrigin = getOpenworkGatewayOrigin();
     desktopBootstrapConfig = resolveDenBootstrapConfig({
-      baseUrl: getOpenworkGatewayOrigin() ?? BUILD_DEN_BASE_URL,
+      baseUrl: BUILD_DEN_BASE_URL,
+      ...(gatewayOrigin ? { apiBaseUrl: gatewayOrigin } : {}),
       requireSignin: BUILD_DEN_REQUIRE_SIGNIN,
     });
     return desktopBootstrapConfig;
@@ -851,11 +865,12 @@ export function readDenSettings(): DenSettings {
     };
   }
 
-  const baseUrls = resolveDenBaseUrls({
-    baseUrl: isDesktopRuntime()
-      ? readDenBootstrapConfig().baseUrl
-      : getOpenworkGatewayOrigin() ?? window.localStorage.getItem(STORAGE_BASE_URL) ?? readDenBootstrapConfig().baseUrl,
-  });
+  const bootstrapConfig = readDenBootstrapConfig();
+  const baseUrls = resolveDenBaseUrls(
+    isDesktopRuntime() || getOpenworkGatewayOrigin()
+      ? bootstrapConfig
+      : { baseUrl: window.localStorage.getItem(STORAGE_BASE_URL) ?? bootstrapConfig.baseUrl },
+  );
 
   return {
     ...baseUrls,

--- a/apps/app/tests/den-mcp-url.test.ts
+++ b/apps/app/tests/den-mcp-url.test.ts
@@ -8,7 +8,7 @@ import {
 } from "../src/app/lib/den";
 
 describe("resolveDenBaseUrls", () => {
-  test("always derives the API proxy from the base URL", () => {
+  test("adds the API proxy path to an explicit API base URL", () => {
     const resolved = resolveDenBaseUrls({
       baseUrl: "https://app.openworklabs.com",
       apiBaseUrl: "https://app.openworklabs.com",
@@ -16,25 +16,28 @@ describe("resolveDenBaseUrls", () => {
     expect(resolved.apiBaseUrl).toBe("https://app.openworklabs.com/api/den");
   });
 
-  test("ignores an explicit API origin when a base URL is present", () => {
+  test("keeps an explicit API origin independent from the web base URL", () => {
     const resolved = resolveDenBaseUrls({
       baseUrl: "https://app.openworklabs.com",
       apiBaseUrl: "https://api.example.com",
     });
-    expect(resolved.apiBaseUrl).toBe("https://app.openworklabs.com/api/den");
+    expect(resolved.baseUrl).toBe("https://app.openworklabs.com");
+    expect(resolved.apiBaseUrl).toBe("https://api.example.com/api/den");
   });
 
-  test("ignores an explicit loopback API URL when a base URL is present", () => {
+  test("keeps an explicit loopback API URL when a base URL is present", () => {
     const resolved = resolveDenBaseUrls({
       baseUrl: "http://localhost:3000",
       apiBaseUrl: "http://127.0.0.1:8787",
     });
-    expect(resolved.apiBaseUrl).toBe("http://localhost:3000/api/den");
+    expect(resolved.baseUrl).toBe("http://localhost:3000");
+    expect(resolved.apiBaseUrl).toBe("http://127.0.0.1:8787/api/den");
   });
 
   test("derives the /api/den proxy from a web-app baseUrl when no apiBaseUrl is set", () => {
-    const resolved = resolveDenBaseUrls({ baseUrl: "https://app.openworklabs.com" });
-    expect(resolved.apiBaseUrl).toBe("https://app.openworklabs.com/api/den");
+    const resolved = resolveDenBaseUrls({ baseUrl: "https://den.self-hosted.example.com" });
+    expect(resolved.baseUrl).toBe("https://den.self-hosted.example.com");
+    expect(resolved.apiBaseUrl).toBe("https://den.self-hosted.example.com/api/den");
   });
 });
 

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -1,6 +1,13 @@
 import { afterEach, beforeEach, describe, expect, test } from "bun:test";
 
-import { readDenBootstrapConfig, readDenSettings, resolveDenBaseUrls } from "../src/app/lib/den";
+import {
+  buildDenAuthUrl,
+  createDenClient,
+  getDenMcpUrl,
+  readDenBootstrapConfig,
+  readDenSettings,
+  resolveDenBaseUrls,
+} from "../src/app/lib/den";
 import {
   hydrateOpenworkServerSettingsFromEnv,
   readOpenworkServerSettings,
@@ -8,6 +15,7 @@ import {
 import { resolveOpenworkConnection } from "../src/react-app/shell/openwork-connection";
 
 const originalWindow = globalThis.window;
+const originalFetch = globalThis.fetch;
 const originalDeployment = process.env.VITE_OPENWORK_DEPLOYMENT;
 
 function memoryStorage(): Storage {
@@ -32,6 +40,12 @@ function memoryStorage(): Storage {
       map.set(key, value);
     },
   };
+}
+
+function getRequestUrl(input: RequestInfo | URL): string {
+  if (input instanceof URL) return input.toString();
+  if (typeof input === "string") return input;
+  return input.url;
 }
 
 function installWindow(options: {
@@ -83,6 +97,10 @@ describe("gateway runtime mode", () => {
       configurable: true,
       value: originalWindow,
     });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: originalFetch,
+    });
     if (originalDeployment === undefined) {
       delete process.env.VITE_OPENWORK_DEPLOYMENT;
     } else {
@@ -107,18 +125,62 @@ describe("gateway runtime mode", () => {
     });
   });
 
-  test("keeps Den API calls on the gateway origin and ignores stale Den storage", () => {
-    const storage = installWindow({ origin: "https://web.openworklabs.com", gateway: true });
+  test("keeps Den web on the configured origin and Den API calls on the gateway origin", () => {
+    const storage = installWindow({ origin: "https://gw.example", gateway: true });
     storage.setItem("openwork.den.baseUrl", "https://app.openworklabs.com");
     storage.setItem("openwork.den.authToken", "den-session-token");
 
-    expect(resolveDenBaseUrls("https://app.openworklabs.com")).toEqual({
-      baseUrl: "https://web.openworklabs.com",
-      apiBaseUrl: "https://web.openworklabs.com/api/den",
+    expect(resolveDenBaseUrls("https://gw.example")).toEqual({
+      baseUrl: "https://app.openworklabs.com",
+      apiBaseUrl: "https://gw.example/api/den",
     });
-    expect(readDenSettings().baseUrl).toBe("https://web.openworklabs.com");
-    expect(readDenSettings().apiBaseUrl).toBe("https://web.openworklabs.com/api/den");
+    expect(readDenSettings().baseUrl).toBe("https://app.openworklabs.com");
+    expect(readDenSettings().apiBaseUrl).toBe("https://gw.example/api/den");
     expect(readDenSettings().authToken).toBe("den-session-token");
+  });
+
+  test("builds web auth URLs on the Den web origin with the gateway return origin", () => {
+    installWindow({ origin: "https://gw.example", gateway: true });
+
+    const authUrl = new URL(buildDenAuthUrl(readDenSettings().baseUrl, "sign-up"));
+
+    expect(authUrl.origin).toBe("https://app.openworklabs.com");
+    expect(authUrl.searchParams.get("mode")).toBe("sign-up");
+    expect(authUrl.searchParams.get("webAuth")).toBe("1");
+    expect(authUrl.searchParams.get("webAuthReturn")).toBe("https://gw.example");
+  });
+
+  test("routes Den auth API paths to Den web and v1 paths through the gateway API", async () => {
+    installWindow({ origin: "https://gw.example", gateway: true });
+    const requestedUrls: string[] = [];
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: RequestInfo | URL) => {
+        requestedUrls.push(getRequestUrl(input));
+        return new Response(JSON.stringify({
+          user: { id: "user_test", email: "user@example.com" },
+          token: "tok_test",
+        }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    const client = createDenClient({ baseUrl: readDenSettings().baseUrl, token: "tok_test" });
+    await client.signInEmail("user@example.com", "password");
+    await client.getSession();
+
+    expect(requestedUrls).toEqual([
+      "https://app.openworklabs.com/api/auth/sign-in/email",
+      "https://gw.example/api/den/v1/me",
+    ]);
+  });
+
+  test("uses the gateway Den API proxy for MCP", () => {
+    installWindow({ origin: "https://gw.example", gateway: true });
+
+    expect(getDenMcpUrl()).toBe("https://gw.example/api/den/mcp");
   });
 
   test("returns a stable gateway bootstrap snapshot for React external stores", () => {
@@ -128,7 +190,7 @@ describe("gateway runtime mode", () => {
     const second = readDenBootstrapConfig();
 
     expect(second).toBe(first);
-    expect(first.baseUrl).toBe("https://web.openworklabs.com");
+    expect(first.baseUrl).toBe("https://app.openworklabs.com");
     expect(first.apiBaseUrl).toBe("https://web.openworklabs.com/api/den");
   });
 
@@ -155,6 +217,10 @@ describe("non-gateway connection modes", () => {
     Object.defineProperty(globalThis, "window", {
       configurable: true,
       value: originalWindow,
+    });
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: originalFetch,
     });
     if (originalDeployment === undefined) {
       delete process.env.VITE_OPENWORK_DEPLOYMENT;
@@ -187,6 +253,14 @@ describe("non-gateway connection modes", () => {
     expect(connection.resolvedToken).toBe("manual-token");
     expect(connection.resolvedHostToken).toBe("");
     expect(connection.source).toBe("stored-settings");
+  });
+
+  test("plain web Den settings still use a stored custom base URL without the marker", () => {
+    const storage = installWindow({ origin: "https://instance.example.com" });
+    storage.setItem("openwork.den.baseUrl", "https://den.self-hosted.example.com");
+
+    expect(readDenSettings().baseUrl).toBe("https://den.self-hosted.example.com");
+    expect(readDenSettings().apiBaseUrl).toBe("https://den.self-hosted.example.com/api/den");
   });
 
   test("desktop runtime still uses live desktop server info without the marker", async () => {

--- a/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
+++ b/ee/apps/den-api/src/routes/auth/desktop-handoff.ts
@@ -353,10 +353,20 @@ async function getCloudSignedPreviewUrls(organizationId: WorkerOrgId) {
   return rows.map((row) => row.signedPreviewUrl)
 }
 
-async function resolveApprovedWebHandoffReturnUrl(input: {
+export async function resolveApprovedWebHandoffReturnUrl(input: {
   returnUrl: string
   activeOrganizationId?: string | null
 }) {
+  const gatewayReturnUrl = approveWebHandoffReturnUrlForSignedPreviews({
+    returnUrl: input.returnUrl,
+    signedPreviewUrls: [],
+    orgMode: env.orgMode,
+    gatewayOrigin: env.gatewayOrigin,
+  })
+  if (gatewayReturnUrl) {
+    return gatewayReturnUrl
+  }
+
   if (env.orgMode !== "multi_org" || !input.activeOrganizationId) {
     return null
   }

--- a/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
+++ b/ee/apps/den-api/test/desktop-handoff-public-url.test.ts
@@ -12,6 +12,14 @@ async function loadDesktopHandoffRoutes() {
   return import("../src/routes/auth/desktop-handoff.js")
 }
 
+async function configureDesktopHandoffEnv(input: {
+  gatewayOrigin?: string
+}) {
+  const { env } = await import("../src/env.js")
+  env.orgMode = "multi_org"
+  env.gatewayOrigin = input.gatewayOrigin
+}
+
 describe("desktop handoff public URL", () => {
   test("does not send 0.0.0.0 to desktop clients", async () => {
     seedRequiredEnv()
@@ -83,6 +91,46 @@ describe("desktop handoff public URL", () => {
       gatewayOrigin: "https://web.openworklabs.com",
       signedPreviewUrls: [],
       returnUrl: "https://app.openworklabs.com/signin",
+    })).toBeNull()
+  })
+
+  test("approves the configured gateway web returnUrl without an active organization", async () => {
+    const { resolveApprovedWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+    await configureDesktopHandoffEnv({ gatewayOrigin: "https://web.openworklabs.com" })
+
+    expect(await resolveApprovedWebHandoffReturnUrl({
+      activeOrganizationId: null,
+      returnUrl: "https://web.openworklabs.com/",
+    })).toBe("https://web.openworklabs.com/signin")
+  })
+
+  test("rejects a different web returnUrl origin without an active organization", async () => {
+    const { resolveApprovedWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+    await configureDesktopHandoffEnv({ gatewayOrigin: "https://web.openworklabs.com" })
+
+    expect(await resolveApprovedWebHandoffReturnUrl({
+      activeOrganizationId: null,
+      returnUrl: "https://app.openworklabs.com/signin",
+    })).toBeNull()
+  })
+
+  test("rejects a gateway web returnUrl without a configured gateway origin or active organization", async () => {
+    const { resolveApprovedWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+    await configureDesktopHandoffEnv({})
+
+    expect(await resolveApprovedWebHandoffReturnUrl({
+      activeOrganizationId: null,
+      returnUrl: "https://web.openworklabs.com/signin",
+    })).toBeNull()
+  })
+
+  test("rejects signed-preview web returnUrls without an active organization", async () => {
+    const { resolveApprovedWebHandoffReturnUrl } = await loadDesktopHandoffRoutes()
+    await configureDesktopHandoffEnv({})
+
+    expect(await resolveApprovedWebHandoffReturnUrl({
+      activeOrganizationId: null,
+      returnUrl: "https://8787-active.daytonaproxy01.net/signin",
     })).toBeNull()
   })
 


### PR DESCRIPTION
Two defects found by driving the real sign-in flow against the deployed gateway. Both block sign-in entirely; neither was caught by unit tests.

## 1. Sign-in pointed at the gateway instead of den-web

`resolveRequestBaseUrl` routes every `/api/*` path to `baseUrl`, and gateway mode set `baseUrl` to the gateway origin — but the gateway only proxies `/api/den/*`. Measured on the live gateway:

| Request | Gateway | den-web |
| --- | --- | --- |
| `/api/auth/get-session` | `200 <!doctype html>` | `200 null` |

So better-auth calls received SPA HTML, and the sign-in button navigated to the gateway origin instead of the Den sign-in UI.

Now the gateway's same-origin override is scoped to the Den **API** only: `apiBaseUrl` = `<gatewayOrigin>/api/den`, while `baseUrl` stays the configured Den web origin (already defaults to `https://app.openworklabs.com`). This required `resolveDenBaseUrls` to stop forcing `apiBaseUrl` to be derived from `baseUrl`; non-gateway callers that pass no `apiBaseUrl` still derive it exactly as before. Note this is a deliberate contract change: an explicitly passed `apiBaseUrl` is now honored rather than ignored.

Verified on the deployed gateway — the button now opens:
```
https://app.openworklabs.com/?mode=sign-up&webAuth=1&webAuthReturn=https%3A%2F%2Fgateway-rlch.onrender.com
```

## 2. The gateway return URL could never be approved for a new user

`resolveApprovedWebHandoffReturnUrl` returned early when the session had no `activeOrganizationId`, before ever consulting `DEN_GATEWAY_ORIGIN`. That guard is right for **signed preview** origins, which are per-organization, but `DEN_GATEWAY_ORIGIN` is a single operator-configured deployment constant. A freshly signed-up user has no active org yet, so sign-in through the gateway always failed with "The Cloud web handoff return URL is not approved for this organization."

Reproduced end to end in production: signed up `ben+cloudgw@openworklabs.com` on den-web, entered the emailed code, reached "Signed in as ..." and then hit exactly that error.

The configured gateway origin is now matched independently of the org. The signed-preview path is unchanged and still requires `multi_org`, an active organization, and per-org signed preview URLs. Still exact-origin only, no wildcards; unset `DEN_GATEWAY_ORIGIN` approves nothing. This is safe because the origin is operator-configured rather than user input, and approving a redirect target grants nothing by itself — the Cloud gate still independently requires `capabilities.cloud === true`.

## Why unit tests missed both

The slice-3 tests called `approveWebHandoffReturnUrl` with `gatewayOrigin` passed in directly, so they never exercised the wrapper that computes it. The new test asserts the wrapper approves the gateway origin with `activeOrganizationId: null`, and it fails on the pre-fix code:

```
(fail) approves the configured gateway web returnUrl without an active organization
Expected: "https://web.openworklabs.com/signin"
Received: null
```

## Tests

| Command | Result |
| --- | --- |
| `cd apps/app && bun test --isolate tests/` | 472 pass / 0 fail |
| den-api `desktop-handoff-public-url` + `cloud-instance-route` | 35 pass / 0 fail |
| `pnpm --filter @openwork-ee/den-gateway run test` | 13 pass / 0 fail |
| `tsc --noEmit` (app, den-api) | 0 errors |

Added coverage: gateway `baseUrl`/`apiBaseUrl` split, auth URL origin + `webAuthReturn`, `/api/auth` vs `/v1` request routing, gateway MCP URL, and the handoff approvals above.

## Not verified yet

The full signed-in journey (instance provisioning, the Cloud capability gate in the UI) is still unproven — it was blocked behind these two bugs. I am continuing that against the deployed gateway now and will post the frames.