### PR TITLE
fix(app): reflect the Den session after a web handoff instead of showing sign-in again

### DIFF
--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -121,10 +121,9 @@ function DenSigninGate({ children }: DenSigninGateProps) {
     requireSignin,
   ]);
 
-  // After a fresh sign-in, navigate to the onboarding page so the
-  // user sees what their org provides.
-  // Poll for activeOrgId (set asynchronously by refreshOrgs) rather
-  // than using a fixed delay — handles both fast and slow org lookups.
+  // After a fresh sign-in, navigate to the onboarding page so the user sees
+  // their signed-in org state. Do not wait for an active org: first-run users
+  // may not belong to one yet, and must not remain on the signed-out welcome.
   useEffect(() => {
     const handler = (event: WindowEventMap[typeof denSessionUpdatedEvent]) => {
       if (event.detail?.status !== "success") return;
@@ -132,10 +131,11 @@ function DenSigninGate({ children }: DenSigninGateProps) {
       const check = () => {
         attempts++;
         const settings = readDenSettings();
-        if (settings.authToken?.trim() && settings.activeOrgId?.trim()) {
+        if (settings.authToken?.trim()) {
           navigate("/onboarding", { replace: true });
         } else if (attempts < 10) {
-          // Org not selected yet — retry (max ~5 seconds)
+          // Session persistence should already be done, but retry briefly in
+          // case another consumer is still applying the handoff result.
           setTimeout(check, 500);
         }
       };

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -764,9 +764,9 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
     if (loading) return;
     if (workspaces.length > 0) return;
     if (local.prefs.hasCompletedOnboarding) return;
+    if (denAuth.status === "checking") return;
+    if (denAuth.isSignedIn) return;
     if (isDesktopRuntime()) {
-      if (denAuth.status === "checking") return;
-      if (denAuth.isSignedIn) return;
       if (readDenBootstrapConfig().source !== "default") return;
     }
     navigate("/welcome", { replace: true });

--- a/apps/app/src/react-app/shell/welcome-den-session.ts
+++ b/apps/app/src/react-app/shell/welcome-den-session.ts
@@ -1,0 +1,17 @@
+export type WelcomeDenAuthStatus =
+  | "checking"
+  | "signed_in"
+  | "unavailable"
+  | "signed_out";
+
+export function shouldHoldWelcomeForDenSession({
+  authStatus,
+  hasStoredAuthToken,
+  isSignedIn,
+}: {
+  authStatus: WelcomeDenAuthStatus;
+  hasStoredAuthToken: boolean;
+  isSignedIn: boolean;
+}) {
+  return isSignedIn || (hasStoredAuthToken && authStatus !== "signed_out");
+}

--- a/apps/app/src/react-app/shell/welcome-den-session.ts
+++ b/apps/app/src/react-app/shell/welcome-den-session.ts
@@ -13,5 +13,5 @@ export function shouldHoldWelcomeForDenSession({
   hasStoredAuthToken: boolean;
   isSignedIn: boolean;
 }) {
-  return isSignedIn || (hasStoredAuthToken && authStatus !== "signed_out");
+  return isSignedIn || (hasStoredAuthToken && authStatus === "checking");
 }

--- a/apps/app/src/react-app/shell/welcome-route.tsx
+++ b/apps/app/src/react-app/shell/welcome-route.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useReducer, useState } from "react";
+import { useCallback, useEffect, useReducer, useState, useSyncExternalStore } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { t } from "../../i18n";
@@ -41,6 +41,17 @@ import { writeActiveWorkspaceId, writeLastSessionFor, writeWorkspaceProjectDimen
 import { workspaceSessionRoute } from "./workspace-routes";
 import { ensureDesktopLocalOpenworkConnection } from "./desktop-local-openwork";
 import { saveControlPlaneUrl } from "../domains/settings/cloud/control-plane-url";
+import { shouldHoldWelcomeForDenSession } from "./welcome-den-session";
+
+function subscribeToDenSettings(onStoreChange: () => void) {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(denSettingsChangedEvent, onStoreChange);
+  return () => window.removeEventListener(denSettingsChangedEvent, onStoreChange);
+}
+
+function readDenAuthTokenSnapshot() {
+  return readDenSettings().authToken?.trim() ?? "";
+}
 
 function folderNameFromPath(path: string) {
   const normalized = path.replace(/\\/g, "/").replace(/\/+$/, "");
@@ -137,6 +148,16 @@ export function WelcomeRoute() {
   const [organizationServerError, setOrganizationServerError] = useState<string | null>(null);
   const [joinOrganizationOpen, setJoinOrganizationOpen] = useState(false);
   const showOpenWorkModelsPromo = useOpenWorkModelsPromoEligibility();
+  const denAuthTokenSnapshot = useSyncExternalStore(
+    subscribeToDenSettings,
+    readDenAuthTokenSnapshot,
+    readDenAuthTokenSnapshot,
+  );
+  const holdSignedOutSurface = shouldHoldWelcomeForDenSession({
+    authStatus: denAuth.status,
+    hasStoredAuthToken: Boolean(denAuthTokenSnapshot),
+    isSignedIn: denAuth.isSignedIn,
+  });
 
   // If user already completed onboarding, redirect away immediately.
   useEffect(() => {
@@ -144,6 +165,12 @@ export function WelcomeRoute() {
       navigate("/session", { replace: true });
     }
   }, [local.prefs.hasCompletedOnboarding, navigate]);
+
+  useEffect(() => {
+    if (denAuth.isSignedIn) {
+      navigate("/onboarding", { replace: true });
+    }
+  }, [denAuth.isSignedIn, navigate]);
 
   const markOnboardingComplete = useCallback(() => {
     local.setPrefs((prev) => ({ ...prev, hasCompletedOnboarding: true }));
@@ -389,6 +416,10 @@ export function WelcomeRoute() {
     captureAnalyticsEvent("attribution_survey_skipped");
     finishOnboarding();
   }, [finishOnboarding]);
+
+  if (holdSignedOutSurface) {
+    return null;
+  }
 
   return (
     <>

--- a/apps/app/tests/gateway-session-reflect.test.ts
+++ b/apps/app/tests/gateway-session-reflect.test.ts
@@ -1,0 +1,117 @@
+import { afterEach, describe, expect, test } from "bun:test";
+
+import {
+  initializeDenBootstrapConfig,
+  readDenBootstrapConfig,
+  readDenSettings,
+  writeDenSettings,
+} from "../src/app/lib/den";
+import { shouldHoldWelcomeForDenSession } from "../src/react-app/shell/welcome-den-session";
+
+const originalWindow = globalThis.window;
+
+function memoryStorage(): Storage {
+  const map = new Map<string, string>();
+  return {
+    get length() {
+      return map.size;
+    },
+    clear() {
+      map.clear();
+    },
+    getItem(key: string) {
+      return map.get(key) ?? null;
+    },
+    key(index: number) {
+      return Array.from(map.keys())[index] ?? null;
+    },
+    removeItem(key: string) {
+      map.delete(key);
+    },
+    setItem(key: string, value: string) {
+      map.set(key, value);
+    },
+  };
+}
+
+function installGatewayWindow() {
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      __OPENWORK_GATEWAY__: { version: 1 },
+      addEventListener: () => undefined,
+      dispatchEvent: () => true,
+      localStorage: memoryStorage(),
+      location: { origin: "https://web.openworklabs.com" },
+      removeEventListener: () => undefined,
+    },
+  });
+}
+
+describe("gateway Den session reflection", () => {
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  test("a stored gateway token suppresses the signed-out welcome surface", async () => {
+    installGatewayWindow();
+    await initializeDenBootstrapConfig();
+
+    writeDenSettings({
+      baseUrl: "https://app.openworklabs.com",
+      authToken: "tok_gateway_session",
+      activeOrgId: null,
+      activeOrgSlug: null,
+      activeOrgName: null,
+    });
+
+    const hasStoredAuthToken = Boolean(readDenSettings().authToken?.trim());
+    expect(hasStoredAuthToken).toBe(true);
+    expect(
+      shouldHoldWelcomeForDenSession({
+        authStatus: "checking",
+        hasStoredAuthToken,
+        isSignedIn: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHoldWelcomeForDenSession({
+        authStatus: "signed_in",
+        hasStoredAuthToken: true,
+        isSignedIn: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHoldWelcomeForDenSession({
+        authStatus: "signed_out",
+        hasStoredAuthToken: false,
+        isSignedIn: false,
+      }),
+    ).toBe(false);
+  });
+
+  test("gateway bootstrap snapshot identity stays stable while settings reflect the token", async () => {
+    installGatewayWindow();
+    await initializeDenBootstrapConfig();
+
+    const first = readDenBootstrapConfig();
+    const second = readDenBootstrapConfig();
+    expect(second).toBe(first);
+
+    writeDenSettings({
+      baseUrl: "https://app.openworklabs.com",
+      authToken: "tok_gateway_session",
+      activeOrgId: null,
+      activeOrgSlug: null,
+      activeOrgName: null,
+    });
+
+    const afterToken = readDenBootstrapConfig();
+    expect(afterToken).toBe(first);
+    expect(readDenSettings().authToken).toBe("tok_gateway_session");
+    expect(readDenSettings().apiBaseUrl).toBe("https://web.openworklabs.com/api/den");
+  });
+});

--- a/apps/app/tests/gateway-session-reflect.test.ts
+++ b/apps/app/tests/gateway-session-reflect.test.ts
@@ -93,6 +93,37 @@ describe("gateway Den session reflection", () => {
     ).toBe(false);
   });
 
+  test("a stored token holds the welcome surface only for transient or signed-in auth", () => {
+    expect(
+      shouldHoldWelcomeForDenSession({
+        authStatus: "checking",
+        hasStoredAuthToken: true,
+        isSignedIn: false,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHoldWelcomeForDenSession({
+        authStatus: "signed_in",
+        hasStoredAuthToken: true,
+        isSignedIn: true,
+      }),
+    ).toBe(true);
+    expect(
+      shouldHoldWelcomeForDenSession({
+        authStatus: "unavailable",
+        hasStoredAuthToken: true,
+        isSignedIn: false,
+      }),
+    ).toBe(false);
+    expect(
+      shouldHoldWelcomeForDenSession({
+        authStatus: "signed_out",
+        hasStoredAuthToken: true,
+        isSignedIn: false,
+      }),
+    ).toBe(false);
+  });
+
   test("gateway bootstrap snapshot identity stays stable while settings reflect the token", async () => {
     installGatewayWindow();
     await initializeDenBootstrapConfig();


### PR DESCRIPTION
A user who had just signed in through the web handoff was still shown the signed-out screen, so they had to click "Sign in" a second time. Reported by a real user and reproduced twice against production.

## Evidence

On `https://web.openworklabs.com` (now served by den-gateway), after completing sign-in on den-web and returning:

```
url: https://web.openworklabs.com/welcome
body: "Welcome to OpenWork ... Sign in to OpenWork Cloud | Use Without Cloud | ..."
localStorage['openwork.den.authToken']: present (32 chars)
GET /api/den/v1/me with that bearer -> 200 {"user":{"email":"ben+cloudgw@openworklabs.com",...}}
```

So the grant exchange had already succeeded and the token was valid — the UI simply did not reflect it.

## Cause

The post-sign-in navigation waited for **both** an auth token and an `activeOrgId`. A first-run user does not belong to an organization yet, so `activeOrgId` never arrived and the gate never advanced. Two supporting paths made it worse: the web "no workspaces" redirect could send an already signed-in user to `/welcome`, and `/welcome` rendered its signed-out buttons even when a valid session was stored.

So this was keyed on *missing organization*, not on *missing token* — a signed-in user was being told to sign in.

## Changes

- `app-root.tsx` — advance on a valid auth token; do not require an active org.
- `use-workspace-route-state.ts` — the no-workspace redirect now respects Den auth on web too, so a signed-in user is never sent to `/welcome` (previously those two guards applied only to desktop).
- `welcome-route.tsx` + new `welcome-den-session.ts` — the welcome route subscribes to Den settings changes and routes a signed-in user onward.

The welcome subscription reads a **primitive string** snapshot through `useSyncExternalStore`. That is deliberate: returning a fresh object from `getSnapshot` is exactly what caused the React #185 infinite loop fixed in #3205, and the regression test here keeps bootstrap snapshot identity stable.

## Blank-page edge case caught in review

The first version held the welcome surface (rendering nothing) whenever a token existed and status was not `signed_out` — which includes `"unavailable"`. But `unavailable` means the Den control plane is *unreachable* (VPN blip, captive portal, offline); the codebase deliberately keeps the stored token in that case and shows a non-blocking amber banner. That would have given a first-run offline user a permanently blank page with no way forward — worse than the original bug.

Final condition holds only for genuinely transient or confirmed states:

```ts
return isSignedIn || (hasStoredAuthToken && authStatus === "checking");
```

`unavailable` and `signed_out` now render the normal welcome surface, so there is always a path forward. Covered by tests for all four statuses.

## Tests

| Command | Result |
| --- | --- |
| `cd apps/app && bun test --isolate tests/` | 475 pass / 0 fail |
| `pnpm --filter @openwork/app exec tsc --noEmit` | 0 errors |
| `pnpm --filter @openwork-ee/den-gateway run test` | 13 pass / 0 fail |

CDP check against a gateway build with a valid token seeded — the signed-in app renders and the signed-out surface is gone:

```json
{"gateway":true,"tokenLength":32,"meStatus":200,"hasWelcome":false,"hasSignInCloud":false,"hasReact185":false,
 "visibleTextStart":"Create or connect a workspace  What do you need done? ..."}
```

## Note

`cloudInstanceStatus` is still `404 organization_not_found` for that account, which is correct — it has no organization. The Cloud capability gate itself (org without `capabilities.cloud` refused, then provisioning once enabled) is still unproven and tracked separately.