### PR TITLE
docs: self-hosted go-live checklist and enterprise network requirements

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -74,9 +74,11 @@
             "group": "Plan your network",
             "pages": [
               "start-here/private-network-deployment",
+              "start-here/enterprise-network-requirements",
               "start-here/air-gapped-deployment",
               "start-here/outbound-network-access",
-              "start-here/certificate-trust-and-proxies"
+              "start-here/certificate-trust-and-proxies",
+              "start-here/self-hosted-go-live-checklist"
             ]
           },
           {

--- a/packages/docs/start-here/enterprise-network-requirements.mdx
+++ b/packages/docs/start-here/enterprise-network-requirements.mdx
@@ -1,0 +1,34 @@
+---
+title: "Enterprise network requirements"
+description: "Network, TLS, proxy, DNS, and streaming requirements for enterprise desktop onboarding."
+---
+
+Share this page with customer IT before onboarding OpenWork Desktop to a self-hosted Den. The desktop includes browser-like surfaces and engine-class processes; both need the right network path.
+
+## Desktop destinations
+
+| Destination | Used for | Requirement |
+| --- | --- | --- |
+| Organization Den origin (`https://HOST`, TCP 443) | Sign-in, organization policy, install handoff, and agent MCP sync at `/api/den/mcp/agent`. | Allow HTTPS from desktop machines and serve a complete certificate chain. |
+| Configured model provider endpoints | Chat and agent model calls to the provider your organization configures. | Allow HTTPS to every provider origin you enable, or to your approved internal model gateway. |
+| Installer download origin | Initial app download and updates, or your self-hosted installer artifact host. | Allow HTTPS from onboarding machines, or publish installers from an approved internal origin. |
+
+## Requirements
+
+1. Serve the complete certificate chain on the Den origin. Replace `HOST` with your Den hostname:
+
+   ```bash
+   echo | openssl s_client -connect HOST:443 -servername HOST -showcerts 2>/dev/null | grep -c "BEGIN CERT"
+   ```
+
+   The result must be `2` or higher: at least the leaf certificate plus its intermediate.
+
+2. If TLS inspection re-signs traffic, provide the corporate CA to OpenWork through `NODE_EXTRA_CA_CERTS`. See [Certificate trust and proxies](/start-here/certificate-trust-and-proxies).
+
+3. The MCP route (`/api/den/mcp/agent`) uses streaming with server-sent events (SSE). Proxies must not buffer, transform, or terminate long-lived streamed responses.
+
+4. Do not require per-user client certificates (mTLS) on the Den origin. Browser clients can present them, but the engine cannot.
+
+5. The hostname must resolve through standard system resolvers for non-browser processes. For split-horizon VPN DNS, verify that terminal commands resolve the same host that the browser opens.
+
+6. `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables are honored by engine-class processes. PAC files, WinHTTP proxy settings, and browser proxy settings are not. If a proxy is mandatory, document both the environment variable configuration and the browser or system proxy policy.

--- a/packages/docs/start-here/self-hosted-go-live-checklist.mdx
+++ b/packages/docs/start-here/self-hosted-go-live-checklist.mdx
@@ -1,0 +1,55 @@
+---
+title: "Self-hosted go-live checklist"
+description: "Acceptance checks for TLS, DNS, health, MCP transport, and real desktop machines before a self-hosted Den goes live."
+---
+
+Browsers can mask TLS misconfigurations by fetching missing intermediates or using cached state. The OpenWork agent engine validates TLS strictly, like any backend runtime, so these checks catch the non-browser failures that browser sign-in and model tests cannot.
+
+## Check 1 — TLS chain completeness
+
+Replace `HOST` with your Den hostname:
+
+```bash
+echo | openssl s_client -connect HOST:443 -servername HOST -showcerts 2>/dev/null | grep -c "BEGIN CERT"
+```
+
+The result must be `2` or higher: at least the leaf certificate plus its intermediate.
+
+If the result is `1`, non-browser clients fail with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` even while browsers work. Fix the TLS terminator so it serves the full chain:
+
+- nginx: set `ssl_certificate fullchain.pem`.
+- Kubernetes TLS Secret: use `kubectl create secret tls <name> --cert=fullchain.pem --key=privkey.pem`; never use `cert.pem`.
+- F5 or NetScaler: attach the chain in the SSL profile.
+
+## Check 2 — Health endpoint
+
+```bash
+curl -sSi https://HOST/api/den/health
+```
+
+Expect HTTP `200`.
+
+## Check 3 — MCP endpoint from a non-browser client
+
+```bash
+curl -sSi -X POST https://HOST/api/den/mcp/agent \
+  -H 'content-type: application/json' \
+  -H 'accept: application/json, text/event-stream' \
+  -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"golive-check","version":"1.0.0"}}}'
+```
+
+Expect an HTTP response (`200` or `401` are both acceptable for this transport check), never a TLS error.
+
+## Check 4 — Acceptance on real machines
+
+Before go-live, install OpenWork on one macOS machine and one Windows machine from the customer-managed network. Sign in to the self-hosted deployment, enable developer mode, and run the agent diagnostic. Require both `engine-mcp-sync` and `cloud-tool-catalog` to pass.
+
+macOS is the strict canary because Macs never cache intermediates. Windows can mask a broken chain if the intermediate was cached in the OS store.
+
+## Check 5 — DNS
+
+The hostname must resolve through standard system resolvers on the VPN, not only inside browsers. Validate DNS from the same machine and account that will run OpenWork.
+
+## After fixing anything
+
+After fixing any item above, fully restart the desktop app. The engine re-attempts a failed MCP connection only on restart or repair.

--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -129,6 +129,32 @@ Provider-specific starter guides:
 install an ingress controller. Use it only when the cluster already has a
 compatible provider ingress controller.
 
+## Go-live verification
+
+The TLS Secret used by your ingress or load balancer must contain the complete
+server chain. Use `fullchain.pem`, not `cert.pem`, when creating TLS material:
+
+```bash
+kubectl create secret tls openwork-tls \
+  --cert=fullchain.pem \
+  --key=privkey.pem \
+  --namespace openwork
+```
+
+Then verify from a non-browser machine:
+
+```bash
+echo | openssl s_client -connect HOST:443 -servername HOST -showcerts 2>/dev/null | grep -c "BEGIN CERT"
+```
+
+The count must be at least `2` (leaf plus intermediate). Browsers may not reveal
+a missing intermediate because they can repair or cache chains, but the OpenWork
+engine will fail strict TLS with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`.
+
+Run the published
+[self-hosted go-live checklist](../../../packages/docs/start-here/self-hosted-go-live-checklist.mdx)
+before handoff.
+
 Published self-host planning pages:
 
 - [Private network deployment](../../../packages/docs/start-here/private-network-deployment.mdx)


### PR DESCRIPTION
## Context
A self-hosted enterprise POC served an incomplete TLS chain (leaf only, missing intermediate). Browsers masked it via AIA fetching, so all browser-path features worked while the engine failed with `UNABLE_TO_VERIFY_LEAF_SIGNATURE` — diagnosis took three weeks. These docs make chain completeness and non-browser acceptance testing a precondition of go-live.

## Changes
- New `start-here/self-hosted-go-live-checklist.mdx`: TLS chain count check (>= 2), health, MCP initialize via curl, acceptance on one macOS + one Windows machine (Mac is the strict canary), DNS, restart note.
- New `start-here/enterprise-network-requirements.mdx`: one-pager for customer IT (endpoints, full chain, SSE through proxies, no mTLS on the MCP path, split-DNS, proxy env vars).
- Registered both in `docs.json` (Self-host -> Plan your network).
- Helm README: "Go-live verification" section (fullchain.pem, not cert.pem).

## Verification
- `python3 -c "import json;json.load(open('packages/docs/docs.json'))"` — OK
- `git diff --check` — clean

Docs-only change with no runtime path — fraimz skipped per AGENTS.md, stated explicitly.
