### PR TITLE
docs: per-component trust architecture and enterprise onboarding runbook

### DIFF
--- a/packages/docs/docs.json
+++ b/packages/docs/docs.json
@@ -83,6 +83,7 @@
             "group": "Install and operate",
             "pages": [
               "start-here/installer-delivery",
+              "start-here/enterprise-onboarding-runbook",
               "start-here/on-prem-branding",
               "start-here/github-connector-helm"
             ]

--- a/packages/docs/start-here/certificate-trust-and-proxies.mdx
+++ b/packages/docs/start-here/certificate-trust-and-proxies.mdx
@@ -5,6 +5,29 @@ description: "Configure private CAs and outbound proxies for desktop, local runt
 
 OpenWork has several network trust surfaces. Installing a private root for one surface does not automatically configure all of the others.
 
+## Which network stack each component uses
+
+Desktop OpenWork runs the OpenWork server embedded in the Electron main process. That means desktop server egress can use Chromium networking, while the spawned OpenCode engine still has its own runtime TLS stack.
+
+| Component | Stack | Trust source | Repairs missing intermediates? |
+| --- | --- | --- | --- |
+| App UI (renderer) | Chromium renderer fetch | OS trust plus AIA fetching | Yes |
+| Desktop Den calls (`__fetch` via main) | Electron `net.fetch` | OS trust plus AIA fetching | Yes |
+| OpenWork server `externalFetch` in desktop | Electron `net.fetch` | OS trust plus AIA fetching | Yes |
+| OpenWork server standalone/hosted | Node `fetch` / undici | Node's bundled Mozilla roots plus `NODE_EXTRA_CA_CERTS` | No |
+| Diagnostics runtime probe | Deliberately raw runtime fetch: Node/undici in Electron or standalone Node, Bun fetch in Bun builds | Runtime bundled Mozilla roots plus `NODE_EXTRA_CA_CERTS` | No, by design, so it emulates engine-class clients |
+| OpenCode engine | Spawned OpenCode child running on Bun | Bun's bundled Mozilla roots plus `NODE_EXTRA_CA_CERTS` | No |
+
+## Incomplete certificate chains
+
+TLS servers must send the leaf certificate plus every intermediate certificate needed to reach a trusted root. Browsers and Chromium can often fetch a missing intermediate through the certificate's AIA URL, so a browser test can pass while strict runtimes fail.
+
+The strict-runtime symptom is usually `UNABLE_TO_VERIFY_LEAF_SIGNATURE` or `unable to verify the first certificate`. OpenWork's agent diagnostic includes `servedChainLength` for the configured Den origin so you can see whether the endpoint only served the leaf certificate.
+
+The durable fix is at the TLS terminator: serve the full chain, usually the `fullchain` file from your CA or ACME client. Restart or reload the terminator after replacing the served certificate bundle.
+
+As a temporary bridge only, append the exact issuing intermediate certificate to the PEM file referenced by `NODE_EXTRA_CA_CERTS`, then fully restart OpenWork. That file is additive for the embedded server and the OpenCode engine. Remove the bridge after the server sends the full chain; intermediates rotate, and stale client-side intermediates create another incident when the issuing CA changes.
+
 ## The four trust surfaces
 
 ### 1. Desktop app HTTPS
@@ -25,6 +48,20 @@ The desktop also starts the embedded OpenWork server plus local runtimes and sid
 - The Electron main process extends Node's default CA list with the same generated additions when the runtime supports it, so the embedded server's own outbound TLS diagnostics and probes use the same enterprise roots.
 - The generated bundle is for spawned Node-compatible runtimes. It does not configure Electron's Chromium trust store.
 - Do not assume every sidecar honors `HTTP_PROXY` or `HTTPS_PROXY` universally. Use proxy settings documented for the specific runtime or sidecar.
+
+#### `env.json` and launch environment
+
+The desktop reads the user environment store from these locations unless `OPENWORK_ENV_STORE` is set before launch:
+
+| OS | Default `env.json` path |
+| --- | --- |
+| Windows | `%APPDATA%\openwork\env.json`, falling back to `%USERPROFILE%\AppData\Roaming\openwork\env.json` |
+| macOS | `$XDG_CONFIG_HOME/openwork/env.json`, falling back to `~/.config/openwork/env.json` |
+| Linux | `$XDG_CONFIG_HOME/openwork/env.json`, falling back to `~/.config/openwork/env.json` |
+
+Keys beginning with `OPENWORK_` or `OPENCODE_` are stripped from this file before the desktop injects user variables into the embedded server and spawned children. For example, `OPENWORK_AGENT_DIAGNOSTICS_TRUSTED_ORIGINS` only works as a launch environment variable from your shell, MDM profile, service wrapper, or desktop launcher.
+
+`NODE_EXTRA_CA_CERTS` is allowed. If a user value is present in `env.json` or in the launch environment, it wins over OpenWork's generated `system-ca-bundle.pem`. The launch environment wins over `env.json`; the generated bundle is used only when no user value is already set.
 
 ### 3. Den containers and Helm
 

--- a/packages/docs/start-here/enterprise-onboarding-runbook.mdx
+++ b/packages/docs/start-here/enterprise-onboarding-runbook.mdx
@@ -1,0 +1,58 @@
+---
+title: "Enterprise onboarding runbook"
+description: "Admin checklist for invite, SSO, install, activation, model access, and member-owned connections."
+---
+
+Use this runbook when onboarding a member to an enterprise or private-cloud OpenWork organization. Do the steps in order; most hard-to-debug failures come from completing a later step before the earlier identity or activation state exists.
+
+## 1. Invite the member
+
+In the organization dashboard, open **Members**, click **Add member**, enter the member's email address, choose their role, and send the invite.
+
+Invites are tied to the invited email address. If domain allowlists are enabled, the invited email must also match an allowed domain.
+
+## 2. Add the member to the SSO group before they open the invite
+
+If SSO is enforced or required for this rollout, assign the member to the identity-provider application or group before they click the invite link.
+
+If this is skipped, the member can reach the identity provider but cannot complete sign-in. In incident reports this often looked like an invite that was already used or a sign-in loop. Add the IdP assignment first, then resend the invite or issue a fresh install/connect link if the old one was consumed.
+
+## 3. Have the member install from the organization install page
+
+The member should open the organization install page, download the standard OpenWork installer, run it, then return to the page and click **Open OpenWork**.
+
+Make sure the member has local permission to install signed desktop software on that machine. If endpoint controls block user installs, use IT pre-approval or MDM deployment instead.
+
+## 4. Complete first-launch activation
+
+On first launch, enterprise builds show the organization activation gate. The member must return to the organization's download page and click **Activate OpenWork Enterprise** or **Open OpenWork** so the one-time link can complete.
+
+Successful activation writes an `enterpriseActivation` record with `activatedAt` and `denBaseUrl` into the desktop bootstrap file. Current diagnostics trust that activated Den origin for deep credentialed probes, so v0.18.7 and newer can inspect the org server without requiring a separate diagnostic-origin launch variable.
+
+Default bootstrap file paths are:
+
+| OS | Default `desktop-bootstrap.json` path |
+| --- | --- |
+| Windows | `%LOCALAPPDATA%\openwork\desktop-bootstrap.json`, or `%XDG_CONFIG_HOME%\openwork\desktop-bootstrap.json` when `XDG_CONFIG_HOME` is set |
+| macOS | `$XDG_CONFIG_HOME/openwork/desktop-bootstrap.json`, falling back to `~/.config/openwork/desktop-bootstrap.json` |
+| Linux | `$XDG_CONFIG_HOME/openwork/desktop-bootstrap.json`, falling back to `~/.config/openwork/desktop-bootstrap.json` |
+
+`OPENWORK_DESKTOP_BOOTSTRAP_PATH` can override the path when it is set before launch. Current builds also read the older `~/.config/openwork/desktop-bootstrap.json` location for compatibility and choose the newest valid file.
+
+## 5. Grant model access
+
+Create or update the organization's managed LLM provider, choose the models the org should expose, and grant the member or their team access.
+
+If this is skipped, the member may sign in successfully but see an empty model list or the message that the organization has not published any models for them yet.
+
+## 6. Confirm per-member connections
+
+For individual-account connections such as Salesforce, ServiceNow, Notion, Linear, or Slack, each member must open **Settings -> Connect** and connect their own provider account. Admin-created connection definitions do not sign in every member automatically.
+
+Organization policy still applies. Some connections are granted only to specific teams or people, and some provider-side app allowlists restrict who can authorize. A member who is not granted access can legitimately see the service as not connected for them or not available to connect.
+
+<Warning>
+Deleting `desktop-bootstrap.json`, or running a runtime reset that does not preserve the bootstrap file, removes the `enterpriseActivation` record. Deep diagnostics then become trust-gated and report `untrusted_endpoint` until the desktop is re-activated with a fresh install/connect link.
+
+After any network or certificate-trust fix, fully quit and restart OpenWork. The OpenCode engine does not retry a failed MCP connection by itself; restart or an explicit repair/reload is what re-drives the connection attempt.
+</Warning>


### PR DESCRIPTION
## Context
During the incident, "which component uses which network stack and trust store" had to be reverse-engineered from source. This documents it, plus the enterprise onboarding sequence whose failure modes were undocumented.

## Changes
- `certificate-trust-and-proxies.mdx`: per-component table (Chromium renderer / desktop `__fetch` via `electronNet.fetch` / server `externalFetch` in-desktop vs standalone / deliberately-raw diagnostics probe / Bun engine — with "repairs missing intermediates?" column); new incomplete-chain section (browsers mask, engines fail, `servedChainLength` evidence, fullchain fix, temporary `NODE_EXTRA_CA_CERTS` bridge with rot warning); `env.json` mechanics (reserved `OPENWORK_*` prefixes, `NODE_EXTRA_CA_CERTS` user value wins).
- New `start-here/enterprise-onboarding-runbook.mdx`: invite -> SSO before invite opened -> install -> activation gate (writes `enterpriseActivation`; also authorizes deep diagnostics) -> model access -> per-member connections; symptom table per skipped step; warnings (bootstrap deletion gates diagnostics; full restart after fixes).

## Verification
- All architectural claims verified against source: `den.ts:1897-1911`, `desktop.ts:316-347`, `main.mjs:2078-2102`, `runtime.mjs:1018-1074` (embedded server + env injection), `server-fetch.ts:17-80`, `no-bare-fetch.test.ts:41-55`, `enterprise-den-origin.ts:35-65`, `den-auth-provider.tsx:355-371`, `agent-context-transport-probe.ts:318-401`, engine retry `cloud-mcp-health.ts:2328-2332`.
- `python3 -c "import json;json.load(open('packages/docs/docs.json'))"` — OK

Docs-only change with no runtime path — fraimz skipped per AGENTS.md, stated explicitly.
