### PR TITLE
feat(helm): tls-chain-check test hook that fails on incomplete certificate chains

### DIFF
--- a/packaging/helm/openwork-ee/README.md
+++ b/packaging/helm/openwork-ee/README.md
@@ -129,6 +129,26 @@ Provider-specific starter guides:
 install an ingress controller. Use it only when the cluster already has a
 compatible provider ingress controller.
 
+### Verify TLS serving
+
+After the release is deployed and ingress DNS resolves, run:
+
+```bash
+helm test <release>
+```
+
+The `tls-chain-check` test pod connects to each configured web/API ingress host
+with SNI and fails if the endpoint serves fewer than two certificates. Manually,
+the equivalent check is:
+
+```bash
+echo | openssl s_client -connect HOST:443 -servername HOST -showcerts 2>/dev/null | grep -c "BEGIN CERT"
+```
+
+The count must be at least `2`. Create the Kubernetes TLS Secret from
+`fullchain.pem` (leaf + intermediate), not `cert.pem`, so engine clients do not
+fail with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`.
+
 Published self-host planning pages:
 
 - [Private network deployment](../../../packages/docs/start-here/private-network-deployment.mdx)

--- a/packaging/helm/openwork-ee/templates/tests/tls-chain-check.yaml
+++ b/packaging/helm/openwork-ee/templates/tests/tls-chain-check.yaml
@@ -1,0 +1,51 @@
+{{- if and .Values.ingress.enabled .Values.ingress.tls .Values.tests.tlsChainCheck.enabled }}
+{{- $hosts := list .Values.ingress.web.host -}}
+{{- if .Values.ingress.api.enabled -}}
+{{- $hosts = append $hosts .Values.ingress.api.host -}}
+{{- end -}}
+apiVersion: v1
+kind: Pod
+metadata:
+  name: {{ include "openwork-ee.fullname" . }}-tls-chain-check
+  labels:
+    {{- include "openwork-ee.componentLabels" (dict "root" . "component" "tls-chain-check") | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test
+spec:
+  restartPolicy: Never
+  activeDeadlineSeconds: 120
+  {{- with .Values.imagePullSecrets }}
+  imagePullSecrets:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  containers:
+    - name: tls-chain-check
+      image: {{ .Values.tests.tlsChainCheck.image | quote }}
+      imagePullPolicy: IfNotPresent
+      command:
+        - /bin/sh
+        - -ec
+      args:
+        - |-
+          failed=0
+
+          for host in $TLS_CHAIN_CHECK_HOSTS; do
+            cert_count="$(echo | openssl s_client -connect "${host}:443" -servername "$host" -showcerts 2>/dev/null | grep -c "BEGIN CERT" || true)"
+
+            if [ "$cert_count" -lt 2 ]; then
+              printf 'TLS chain incomplete: %s served %s certificate(s); serve the full chain (leaf + intermediate, fullchain.pem) or engine clients will fail with UNABLE_TO_VERIFY_LEAF_SIGNATURE\n' "$host" "$cert_count" >&2
+              failed=1
+            else
+              printf 'TLS chain OK: %s served %s certificate(s)\n' "$host" "$cert_count"
+            fi
+          done
+
+          exit "$failed"
+      env:
+        - name: TLS_CHAIN_CHECK_HOSTS
+          value: {{ join " " $hosts | quote }}
+      resources:
+        requests:
+          cpu: 10m
+          memory: 16Mi
+{{- end }}

--- a/packaging/helm/openwork-ee/tests/tls-chain-check.sh
+++ b/packaging/helm/openwork-ee/tests/tls-chain-check.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+chart_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+assert_contains() {
+  local file="$1"
+  local needle="$2"
+  if ! grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+assert_not_contains() {
+  local file="$1"
+  local needle="$2"
+  if grep -F -q -- "$needle" "$file"; then
+    printf 'Expected rendered chart not to contain %s\n' "$needle" >&2
+    return 1
+  fi
+}
+
+enabled_values="$tmp_dir/enabled-values.yaml"
+enabled_rendered="$tmp_dir/enabled.yaml"
+cat > "$enabled_values" <<'YAML'
+ingress:
+  enabled: true
+  web:
+    host: openwork.example.com
+  api:
+    enabled: true
+    host: api.openwork.example.com
+  tls:
+    - secretName: openwork-tls
+      hosts:
+        - openwork.example.com
+        - api.openwork.example.com
+YAML
+helm template openwork-ee "$chart_dir" -f "$enabled_values" > "$enabled_rendered"
+assert_contains "$enabled_rendered" 'name: openwork-ee-tls-chain-check'
+assert_contains "$enabled_rendered" '"helm.sh/hook": test'
+assert_contains "$enabled_rendered" 'image: "alpine/openssl:latest"'
+assert_contains "$enabled_rendered" 'value: "openwork.example.com api.openwork.example.com"'
+assert_contains "$enabled_rendered" 'TLS chain incomplete:'
+assert_contains "$enabled_rendered" 'serve the full chain (leaf + intermediate, fullchain.pem)'
+assert_contains "$enabled_rendered" 'UNABLE_TO_VERIFY_LEAF_SIGNATURE'
+
+disabled_values="$tmp_dir/disabled-values.yaml"
+disabled_rendered="$tmp_dir/disabled.yaml"
+cat > "$disabled_values" <<'YAML'
+tests:
+  tlsChainCheck:
+    enabled: false
+ingress:
+  enabled: true
+  tls:
+    - secretName: openwork-tls
+      hosts:
+        - openwork.example.com
+YAML
+helm template openwork-ee "$chart_dir" -f "$disabled_values" > "$disabled_rendered"
+assert_not_contains "$disabled_rendered" 'openwork-ee-tls-chain-check'
+assert_not_contains "$disabled_rendered" 'TLS chain incomplete:'
+
+ingress_disabled_values="$tmp_dir/ingress-disabled-values.yaml"
+ingress_disabled_rendered="$tmp_dir/ingress-disabled.yaml"
+cat > "$ingress_disabled_values" <<'YAML'
+ingress:
+  enabled: false
+  tls:
+    - secretName: openwork-tls
+      hosts:
+        - openwork.example.com
+YAML
+helm template openwork-ee "$chart_dir" -f "$ingress_disabled_values" > "$ingress_disabled_rendered"
+assert_not_contains "$ingress_disabled_rendered" 'openwork-ee-tls-chain-check'
+assert_not_contains "$ingress_disabled_rendered" 'TLS chain incomplete:'
+
+printf 'tls-chain-check chart checks passed\n'

--- a/packaging/helm/openwork-ee/values.yaml
+++ b/packaging/helm/openwork-ee/values.yaml
@@ -133,6 +133,14 @@ customCa:
   existingConfigMap: ""
   key: ca.crt
 
+tests:
+  tlsChainCheck:
+    # Helm test pod that checks each configured ingress host serves a full TLS
+    # certificate chain. Create ingress TLS Secrets from fullchain.pem
+    # (leaf + intermediate), not cert.pem, so engine clients can verify TLS.
+    enabled: true
+    image: alpine/openssl:latest
+
 secret:
   create: true
   existingSecret: ""


### PR DESCRIPTION
## Context
A customer ingress served a leaf-only TLS chain; browsers masked it, the engine failed with `UNABLE_TO_VERIFY_LEAF_SIGNATURE`, and it cost the POC three weeks. `helm test` now catches it at deploy time.

## Changes
- `templates/tests/tls-chain-check.yaml`: `helm.sh/hook: test` Pod, emitted only when `ingress.enabled` + `ingress.tls` + `tests.tlsChainCheck.enabled`; counts certificates served per ingress host via `openssl s_client -servername`; fails with an actionable message naming the fullchain fix and the engine failure mode.
- `values.yaml`: documented `tests.tlsChainCheck` block (enabled, overridable image for air-gapped clusters).
- `tests/tls-chain-check.sh`: render harness asserting inclusion/exclusion and the failure-message string, following the existing tests/*.sh pattern.
- README: "Verify TLS serving" (helm test usage + manual one-liner + fullchain.pem-not-cert.pem note).

## Tests run
- `packaging/helm/openwork-ee/tests/tls-chain-check.sh` — passed
- `packaging/helm/openwork-ee/tests/custom-ca.sh` — passed (shared helpers unaffected)
- `helm lint packaging/helm/openwork-ee` — 1 chart linted, 0 failed (helm v4.2.2)

No app UI surface — evidence is the harness/lint output above; fraimz not applicable.
