### PR TITLE
fix(den-api): adopt an existing Daytona sandbox instead of wedging the worker forever

### DIFF
--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -468,6 +468,7 @@ async function resolveFailedCloudInstance(input: {
   worker: CloudWorker
   continueProvisioning: typeof continueCloudProvisioning
   getSandboxRecord: GetSandboxRecord
+  startWake: (workerId: CloudWorker["id"]) => void
   store: CloudWorkerStore
   now: () => number
 }): Promise<CloudInstanceResponse> {
@@ -479,12 +480,22 @@ async function resolveFailedCloudInstance(input: {
 
   failedHealAttempts.set(input.worker.id, now)
   const sandbox = await input.getSandboxRecord(input.worker.id)
+  if (sandbox) {
+    const claimed = await input.store.claimFailedWorker(input.worker.id)
+    if (!claimed) {
+      return { status: "failed", url: null }
+    }
+
+    input.startWake(input.worker.id)
+    return { status: "waking", url: null }
+  }
+
   const started = await startFailedCloudHeal(input)
   if (!started) {
     return { status: "failed", url: null }
   }
 
-  return { status: sandbox ? "waking" : "provisioning", url: null }
+  return { status: "provisioning", url: null }
 }
 
 async function readyFromSignedPreview(input: {

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -1,4 +1,4 @@
-import { Daytona, type Sandbox } from "@daytonaio/sdk"
+import { Daytona, DaytonaConflictError, type CreateSandboxFromImageParams, type CreateSandboxFromSnapshotParams, type Sandbox } from "@daytonaio/sdk"
 import { eq } from "@openwork-ee/den-db/drizzle"
 import { DaytonaSandboxTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
@@ -34,9 +34,51 @@ export type StopWorkerOnDaytonaResult =
   | { status: "no_sandbox" }
   | { status: "stopped" }
 
-type DaytonaSandboxListPage = {
-  items: Array<{ id?: unknown }>
-  nextCursor?: string | null
+type DaytonaCreateParams = CreateSandboxFromImageParams | CreateSandboxFromSnapshotParams
+type DaytonaVolumeRuntime = {
+  id: string
+  state?: string | null
+}
+type DaytonaSessionCommand = {
+  exitCode?: number | null
+}
+type DaytonaSessionCommandLogs = {
+  stdout?: string | null
+  stderr?: string | null
+}
+type DaytonaSessionCommandResult = {
+  cmdId: string
+}
+export type DaytonaSandboxRuntime = {
+  id: string
+  state: string | null
+  target: string | null
+  refreshData: () => Promise<unknown>
+  start: (timeout?: number) => Promise<unknown>
+  delete: (timeout?: number) => Promise<unknown>
+  getSignedPreviewUrl: (port: number, expiresInSeconds?: number) => Promise<{ url: string }>
+  process: {
+    createSession: (sessionId: string) => Promise<unknown>
+    executeSessionCommand: (sessionId: string, request: { command: string; runAsync: boolean }, timeout?: number) => Promise<DaytonaSessionCommandResult>
+    getSessionCommand: (sessionId: string, commandId: string) => Promise<DaytonaSessionCommand>
+    getSessionCommandLogs: (sessionId: string, commandId: string) => Promise<DaytonaSessionCommandLogs>
+  }
+}
+type UpsertDaytonaSandboxInput = {
+  workerId: WorkerId
+  sandboxId: string
+  workspaceVolumeId: string
+  dataVolumeId: string
+  signedPreviewUrl: string
+  signedPreviewUrlExpiresAt: Date
+  region: string | null
+}
+export type DaytonaProvisioningRuntime = {
+  getVolume: (name: string, create?: boolean) => Promise<DaytonaVolumeRuntime>
+  getSandbox: (sandboxIdOrName: string) => Promise<DaytonaSandboxRuntime>
+  createSandbox: (params: DaytonaCreateParams) => Promise<DaytonaSandboxRuntime>
+  upsertSandbox: (input: UpsertDaytonaSandboxInput) => Promise<void>
+  waitForHealth: typeof waitForHealth
 }
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
@@ -63,68 +105,24 @@ function createDaytonaClient() {
   })
 }
 
-function daytonaApiUrl(path: string) {
-  return `${env.daytona.apiUrl.replace(/\/+$/, "")}${path}`
-}
-
-function readDaytonaSandboxListPage(value: unknown): DaytonaSandboxListPage {
-  if (Array.isArray(value)) {
-    return { items: value as Array<{ id?: unknown }> }
-  }
-
-  if (!value || typeof value !== "object") {
-    return { items: [] }
-  }
-
-  const page = value as Record<string, unknown>
-  const items = Array.isArray(page.items)
-    ? page.items
-    : Array.isArray(page.data)
-      ? page.data
-      : Array.isArray(page.sandboxes)
-        ? page.sandboxes
-        : []
-  const nextCursor = typeof page.nextCursor === "string"
-    ? page.nextCursor
-    : typeof page.next_cursor === "string"
-      ? page.next_cursor
-      : null
-
-  return { items: items as Array<{ id?: unknown }>, nextCursor }
-}
-
 async function listDaytonaSandboxIdsByLabels(labels: Record<string, string>) {
+  const daytona = createDaytonaClient()
   const ids: string[] = []
-  let cursor: string | undefined
+  let page = 1
+  const limit = 100
 
-  do {
-    const url = new URL(daytonaApiUrl("/sandbox"))
-    url.searchParams.set("limit", "100")
-    url.searchParams.set("labels", JSON.stringify(labels))
-    if (cursor) {
-      url.searchParams.set("cursor", cursor)
+  while (true) {
+    const sandboxes = await daytona.list(labels, page, limit)
+    for (const sandbox of sandboxes.items) {
+      ids.push(sandbox.id)
     }
 
-    const response = await fetch(url, {
-      headers: {
-        Authorization: `Bearer ${env.daytona.apiKey}`,
-        "X-Daytona-Source": "openwork-den-api",
-      },
-    })
-
-    if (!response.ok) {
-      throw new Error(`Daytona sandbox list failed with ${response.status}`)
+    if (sandboxes.items.length < limit) {
+      break
     }
 
-    const page = readDaytonaSandboxListPage(await response.json())
-    for (const sandbox of page.items) {
-      if (typeof sandbox.id === "string") {
-        ids.push(sandbox.id)
-      }
-    }
-
-    cursor = page.nextCursor ?? undefined
-  } while (cursor)
+    page += 1
+  }
 
   return ids
 }
@@ -171,6 +169,11 @@ export function isDaytonaSandboxMissingError(error: unknown) {
     || (error instanceof Error && error.name === "DaytonaSandboxMissingError")
 }
 
+export function isDaytonaConflictError(error: unknown) {
+  return error instanceof DaytonaConflictError
+    || (error instanceof Error && error.name === "DaytonaConflictError")
+}
+
 function workerHint(workerId: WorkerId) {
   return workerId.replace(/-/g, "").slice(0, 12)
 }
@@ -182,7 +185,7 @@ function sandboxLabels(workerId: WorkerId) {
   }
 }
 
-function sandboxName(input: ProvisionInput) {
+export function daytonaSandboxName(input: ProvisionInput) {
   return slug(
     `${env.daytona.sandboxNamePrefix}-${input.name}-${workerHint(input.workerId)}`,
   ).slice(0, 63)
@@ -287,11 +290,11 @@ exit 1
   return `sh -lc ${shellQuote(script)}`
 }
 
-async function waitForVolumeReady(daytona: Daytona, name: string, timeoutMs: number) {
+async function waitForVolumeReady(getVolume: DaytonaProvisioningRuntime["getVolume"], name: string, timeoutMs: number) {
   const startedAt = Date.now()
 
   while (Date.now() - startedAt < timeoutMs) {
-    const volume = await daytona.volume.get(name)
+    const volume = await getVolume(name)
     if (volume.state === "ready") {
       return volume
     }
@@ -326,7 +329,7 @@ async function cleanupWorkerDataOnDaytona(daytona: Daytona, workerId: WorkerId) 
 
   try {
     sharedVolume = await waitForVolumeReady(
-      daytona,
+      (name, create) => daytona.volume.get(name, create),
       sharedVolumeName(),
       env.daytona.createTimeoutSeconds * 1000,
     )
@@ -382,7 +385,7 @@ async function cleanupWorkerDataOnDaytona(daytona: Daytona, workerId: WorkerId) 
   }
 }
 
-async function waitForHealth(url: string, timeoutMs: number, sandbox: Sandbox, sessionId: string, commandId: string) {
+async function waitForHealth(url: string, timeoutMs: number, sandbox: DaytonaSandboxRuntime, sessionId: string, commandId: string) {
   const startedAt = Date.now()
 
   while (Date.now() - startedAt < timeoutMs) {
@@ -432,15 +435,7 @@ async function waitForHealth(url: string, timeoutMs: number, sandbox: Sandbox, s
   )
 }
 
-async function upsertDaytonaSandbox(input: {
-  workerId: WorkerId
-  sandboxId: string
-  workspaceVolumeId: string
-  dataVolumeId: string
-  signedPreviewUrl: string
-  signedPreviewUrlExpiresAt: Date
-  region: string | null
-}) {
+async function upsertDaytonaSandbox(input: UpsertDaytonaSandboxInput) {
   const existing = await db
     .select({ id: DaytonaSandboxTable.id })
     .from(DaytonaSandboxTable)
@@ -553,100 +548,208 @@ export async function getDaytonaSignedPreviewForProxy(workerId: WorkerId) {
   return refreshed?.signed_preview_url ?? null
 }
 
+function toDaytonaSandboxRuntime(sandbox: Sandbox): DaytonaSandboxRuntime {
+  return {
+    get id() {
+      return sandbox.id
+    },
+    get state() {
+      return sandbox.state ?? null
+    },
+    get target() {
+      return sandbox.target ?? null
+    },
+    refreshData: () => sandbox.refreshData(),
+    start: (timeout) => sandbox.start(timeout),
+    delete: (timeout) => sandbox.delete(timeout),
+    getSignedPreviewUrl: (port, expiresInSeconds) => sandbox.getSignedPreviewUrl(port, expiresInSeconds),
+    process: {
+      createSession: (sessionId) => sandbox.process.createSession(sessionId),
+      executeSessionCommand: (sessionId, request, timeout) => sandbox.process.executeSessionCommand(sessionId, request, timeout),
+      getSessionCommand: (sessionId, commandId) => sandbox.process.getSessionCommand(sessionId, commandId),
+      getSessionCommandLogs: (sessionId, commandId) => sandbox.process.getSessionCommandLogs(sessionId, commandId),
+    },
+  }
+}
+
+function createDaytonaProvisioningRuntime(daytona: Daytona): DaytonaProvisioningRuntime {
+  return {
+    getVolume: (name, create) => daytona.volume.get(name, create),
+    getSandbox: async (sandboxIdOrName) => toDaytonaSandboxRuntime(await daytona.get(sandboxIdOrName)),
+    createSandbox: async (params) => {
+      if ("image" in params) {
+        return toDaytonaSandboxRuntime(await daytona.create(params, { timeout: env.daytona.createTimeoutSeconds }))
+      }
+
+      return toDaytonaSandboxRuntime(await daytona.create(params, { timeout: env.daytona.createTimeoutSeconds }))
+    },
+    upsertSandbox: upsertDaytonaSandbox,
+    waitForHealth,
+  }
+}
+
+async function getSharedDaytonaVolume(runtime: DaytonaProvisioningRuntime) {
+  const sharedVolumeNameValue = sharedVolumeName()
+  await runtime.getVolume(sharedVolumeNameValue, true)
+  return waitForVolumeReady(
+    runtime.getVolume,
+    sharedVolumeNameValue,
+    env.daytona.createTimeoutSeconds * 1000,
+  )
+}
+
+function buildDaytonaCreateParams(input: ProvisionInput, name: string, sharedVolume: DaytonaVolumeRuntime): DaytonaCreateParams {
+  const labels = sandboxLabels(input.workerId)
+  const base = {
+    name,
+    autoStopInterval: env.daytona.autoStopInterval,
+    autoArchiveInterval: env.daytona.autoArchiveInterval,
+    autoDeleteInterval: env.daytona.autoDeleteInterval,
+    public: env.daytona.public,
+    labels,
+    envVars: {
+      DEN_WORKER_ID: input.workerId,
+      DEN_RUNTIME_PROVIDER: "daytona",
+    },
+    volumes: sharedVolumeMounts(input.workerId, sharedVolume.id),
+  }
+
+  if (env.daytona.snapshot) {
+    return {
+      ...base,
+      snapshot: env.daytona.snapshot,
+    }
+  }
+
+  return {
+    ...base,
+    image: env.daytona.image,
+    resources: {
+      cpu: env.daytona.resources.cpu,
+      memory: env.daytona.resources.memory,
+      disk: env.daytona.resources.disk,
+    },
+  }
+}
+
+async function getSandboxByName(runtime: DaytonaProvisioningRuntime, name: string) {
+  try {
+    const sandbox = await runtime.getSandbox(name)
+    await sandbox.refreshData()
+    return sandbox
+  } catch (error) {
+    if (isDaytonaNotFoundError(error)) {
+      return null
+    }
+
+    throw error
+  }
+}
+
+async function startOpenWorkOnDaytonaSandbox(input: {
+  provisionInput: ProvisionInput
+  runtime: DaytonaProvisioningRuntime
+  sandbox: DaytonaSandboxRuntime
+  sessionId: string
+  workspaceVolumeId: string
+  dataVolumeId: string
+}): Promise<ProvisionedInstance> {
+  await input.sandbox.process.createSession(input.sessionId)
+  const command = await input.sandbox.process.executeSessionCommand(
+    input.sessionId,
+    {
+      command: buildOpenWorkStartCommand(input.provisionInput),
+      runAsync: true,
+    },
+    0,
+  )
+
+  const expiresInSeconds = normalizedSignedPreviewExpirySeconds()
+  const preview = await input.sandbox.getSignedPreviewUrl(env.daytona.openworkPort, expiresInSeconds)
+  await input.runtime.waitForHealth(preview.url, env.daytona.healthcheckTimeoutMs, input.sandbox, input.sessionId, command.cmdId)
+  await input.runtime.upsertSandbox({
+    workerId: input.provisionInput.workerId,
+    sandboxId: input.sandbox.id,
+    workspaceVolumeId: input.workspaceVolumeId,
+    dataVolumeId: input.dataVolumeId,
+    signedPreviewUrl: preview.url,
+    signedPreviewUrlExpiresAt: signedPreviewRefreshAt(expiresInSeconds),
+    region: input.sandbox.target,
+  })
+
+  return {
+    provider: "daytona",
+    url: workerProxyUrl(input.provisionInput.workerId),
+    status: "healthy",
+    region: input.sandbox.target ?? undefined,
+  }
+}
+
+async function adoptDaytonaSandbox(input: {
+  provisionInput: ProvisionInput
+  runtime: DaytonaProvisioningRuntime
+  sandbox: DaytonaSandboxRuntime
+  sharedVolume: DaytonaVolumeRuntime
+}): Promise<ProvisionedInstance> {
+  if (input.sandbox.state === "stopped") {
+    await input.sandbox.start(env.daytona.createTimeoutSeconds)
+  }
+
+  return startOpenWorkOnDaytonaSandbox({
+    provisionInput: input.provisionInput,
+    runtime: input.runtime,
+    sandbox: input.sandbox,
+    sessionId: `openwork-wake-${workerHint(input.provisionInput.workerId)}-${Date.now()}`,
+    workspaceVolumeId: input.sharedVolume.id,
+    dataVolumeId: input.sharedVolume.id,
+  })
+}
+
+export async function provisionWorkerOnDaytonaWithRuntime(
+  input: ProvisionInput,
+  runtime: DaytonaProvisioningRuntime,
+): Promise<ProvisionedInstance> {
+  const name = daytonaSandboxName(input)
+  const sharedVolume = await getSharedDaytonaVolume(runtime)
+  const existingSandbox = await getSandboxByName(runtime, name)
+  if (existingSandbox) {
+    return adoptDaytonaSandbox({ provisionInput: input, runtime, sandbox: existingSandbox, sharedVolume })
+  }
+
+  let createdSandbox: DaytonaSandboxRuntime | null = null
+  try {
+    createdSandbox = await runtime.createSandbox(buildDaytonaCreateParams(input, name, sharedVolume))
+    return startOpenWorkOnDaytonaSandbox({
+      provisionInput: input,
+      runtime,
+      sandbox: createdSandbox,
+      sessionId: `openwork-${workerHint(input.workerId)}`,
+      workspaceVolumeId: sharedVolume.id,
+      dataVolumeId: sharedVolume.id,
+    })
+  } catch (error) {
+    if (createdSandbox) {
+      await createdSandbox.delete(env.daytona.deleteTimeoutSeconds).catch(() => undefined)
+    }
+
+    if (isDaytonaConflictError(error)) {
+      const conflictSandbox = await getSandboxByName(runtime, name)
+      if (conflictSandbox) {
+        return adoptDaytonaSandbox({ provisionInput: input, runtime, sandbox: conflictSandbox, sharedVolume })
+      }
+    }
+
+    throw error
+  }
+}
+
 export async function provisionWorkerOnDaytona(
   input: ProvisionInput,
 ): Promise<ProvisionedInstance> {
   assertDaytonaConfig()
 
   const daytona = createDaytonaClient()
-  const labels = sandboxLabels(input.workerId)
-  const sharedVolumeNameValue = sharedVolumeName()
-  await daytona.volume.get(sharedVolumeNameValue, true)
-  const sharedVolume = await waitForVolumeReady(
-    daytona,
-    sharedVolumeNameValue,
-    env.daytona.createTimeoutSeconds * 1000,
-  )
-  let sandbox: Awaited<ReturnType<typeof daytona.create>> | null = null
-
-  try {
-    sandbox = env.daytona.snapshot
-      ? await daytona.create(
-          {
-            name: sandboxName(input),
-            snapshot: env.daytona.snapshot,
-            autoStopInterval: env.daytona.autoStopInterval,
-            autoArchiveInterval: env.daytona.autoArchiveInterval,
-            autoDeleteInterval: env.daytona.autoDeleteInterval,
-            public: env.daytona.public,
-            labels,
-            envVars: {
-              DEN_WORKER_ID: input.workerId,
-              DEN_RUNTIME_PROVIDER: "daytona",
-            },
-            volumes: sharedVolumeMounts(input.workerId, sharedVolume.id),
-          },
-          { timeout: env.daytona.createTimeoutSeconds },
-        )
-      : await daytona.create(
-          {
-            name: sandboxName(input),
-            image: env.daytona.image,
-            autoStopInterval: env.daytona.autoStopInterval,
-            autoArchiveInterval: env.daytona.autoArchiveInterval,
-            autoDeleteInterval: env.daytona.autoDeleteInterval,
-            public: env.daytona.public,
-            labels,
-            envVars: {
-              DEN_WORKER_ID: input.workerId,
-              DEN_RUNTIME_PROVIDER: "daytona",
-            },
-            resources: {
-              cpu: env.daytona.resources.cpu,
-              memory: env.daytona.resources.memory,
-              disk: env.daytona.resources.disk,
-            },
-            volumes: sharedVolumeMounts(input.workerId, sharedVolume.id),
-          },
-          { timeout: env.daytona.createTimeoutSeconds },
-        )
-
-    const sessionId = `openwork-${workerHint(input.workerId)}`
-    await sandbox.process.createSession(sessionId)
-    const command = await sandbox.process.executeSessionCommand(
-      sessionId,
-      {
-        command: buildOpenWorkStartCommand(input),
-        runAsync: true,
-      },
-      0,
-    )
-
-    const expiresInSeconds = normalizedSignedPreviewExpirySeconds()
-    const preview = await sandbox.getSignedPreviewUrl(env.daytona.openworkPort, expiresInSeconds)
-    await waitForHealth(preview.url, env.daytona.healthcheckTimeoutMs, sandbox, sessionId, command.cmdId)
-    await upsertDaytonaSandbox({
-      workerId: input.workerId,
-      sandboxId: sandbox.id,
-      workspaceVolumeId: sharedVolume.id,
-      dataVolumeId: sharedVolume.id,
-      signedPreviewUrl: preview.url,
-      signedPreviewUrlExpiresAt: signedPreviewRefreshAt(expiresInSeconds),
-      region: sandbox.target ?? null,
-    })
-
-    return {
-      provider: "daytona",
-      url: workerProxyUrl(input.workerId),
-      status: "healthy",
-      region: sandbox.target,
-    }
-  } catch (error) {
-    if (sandbox) {
-      await sandbox.delete(env.daytona.deleteTimeoutSeconds).catch(() => {})
-    }
-    throw error
-  }
+  return provisionWorkerOnDaytonaWithRuntime(input, createDaytonaProvisioningRuntime(daytona))
 }
 
 // This preserves customer data: deprovisionWorkerOnDaytona erases workers/<id>/,
@@ -681,9 +784,10 @@ export async function wakeWorkerOnDaytona(
   }
 
   const daytona = createDaytonaClient()
-  let sandbox: Sandbox
+  const runtime = createDaytonaProvisioningRuntime(daytona)
+  let sandbox: DaytonaSandboxRuntime
   try {
-    sandbox = await daytona.get(record.sandbox_id)
+    sandbox = await runtime.getSandbox(record.sandbox_id)
   } catch (error) {
     if (isDaytonaNotFoundError(error)) {
       throw new DaytonaSandboxMissingError(`Daytona sandbox ${record.sandbox_id} missing for worker ${input.workerId}`)
@@ -701,36 +805,14 @@ export async function wakeWorkerOnDaytona(
     throw error
   }
 
-  const sessionId = `openwork-wake-${workerHint(input.workerId)}-${Date.now()}`
-  await sandbox.process.createSession(sessionId)
-  const command = await sandbox.process.executeSessionCommand(
-    sessionId,
-    {
-      command: buildOpenWorkStartCommand(input),
-      runAsync: true,
-    },
-    0,
-  )
-
-  const expiresInSeconds = normalizedSignedPreviewExpirySeconds()
-  const preview = await sandbox.getSignedPreviewUrl(env.daytona.openworkPort, expiresInSeconds)
-  await waitForHealth(preview.url, env.daytona.healthcheckTimeoutMs, sandbox, sessionId, command.cmdId)
-  await upsertDaytonaSandbox({
-    workerId: input.workerId,
-    sandboxId: sandbox.id,
+  return startOpenWorkOnDaytonaSandbox({
+    provisionInput: input,
+    runtime,
+    sandbox,
+    sessionId: `openwork-wake-${workerHint(input.workerId)}-${Date.now()}`,
     workspaceVolumeId: record.workspace_volume_id,
     dataVolumeId: record.data_volume_id,
-    signedPreviewUrl: preview.url,
-    signedPreviewUrlExpiresAt: signedPreviewRefreshAt(expiresInSeconds),
-    region: sandbox.target ?? null,
   })
-
-  return {
-    provider: "daytona",
-    url: workerProxyUrl(input.workerId),
-    status: "healthy",
-    region: sandbox.target,
-  }
 }
 
 export async function deprovisionWorkerOnDaytona(workerId: WorkerId) {

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -603,6 +603,49 @@ describe("Cloud instance per-user workers", () => {
 })
 
 describe("Cloud instance failed self-heal", () => {
+  test("adopts an existing stopped sandbox for a failed worker instead of provisioning a duplicate", async () => {
+    const worker = storedWorker({ status: "failed" })
+    const store = makeCloudWorkerStore({
+      initialWorkers: [worker],
+      tokens: [makeToken(worker.id, "host"), makeToken(worker.id, "client"), makeToken(worker.id, "activity")],
+    })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let provisionCalls = 0
+    let wakeCalls = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandbox(),
+      inspectSandbox: async () => ({ state: "stopped" }),
+      probeSignedPreview: async () => true,
+      continueProvisioning: async () => {
+        provisionCalls += 1
+      },
+      wakeCloudWorker: async () => {
+        wakeCalls += 1
+        worker.status = "healthy"
+      },
+    })
+
+    const first = await app.request("http://den.local/v1/cloud/instance")
+    expect(first.status).toBe(200)
+    await expect(first.json()).resolves.toEqual({ status: "waking", url: null })
+    await flushMicrotasks()
+
+    expect(store.claimAttempts).toBe(1)
+    expect(provisionCalls).toBe(0)
+    expect(wakeCalls).toBe(1)
+    expect(worker.status).not.toBe("failed")
+
+    await expect(app.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
+      .resolves.toEqual({ status: "ready", url: "https://preview.example.test" })
+  })
+
   test("claims a failed worker, kicks provisioning, then throttles another failed GET for 60 seconds", async () => {
     const worker = storedWorker({ status: "failed" })
     const store = makeCloudWorkerStore({

--- a/ee/apps/den-api/test/cloud-lifecycle.test.ts
+++ b/ee/apps/den-api/test/cloud-lifecycle.test.ts
@@ -240,6 +240,36 @@ describe("cloud lifecycle wake", () => {
     expect(worker.status).toBe("healthy")
   })
 
+  test("marks the worker failed when an existing sandbox cannot be started", async () => {
+    const worker = makeWorker({ status: "stopped" })
+    const { store } = makeStore({
+      workers: [worker],
+      tokens: [
+        makeToken(worker.id, "host"),
+        makeToken(worker.id, "client"),
+        makeToken(worker.id, "activity"),
+      ],
+    })
+    let wakeExecutions = 0
+    let provisionExecutions = 0
+
+    await lifecycle.wakeCloudWorker(worker.id, {
+      store,
+      wakeWorker: async () => {
+        wakeExecutions += 1
+        throw new Error("start failed")
+      },
+      provisionWorker: async () => {
+        provisionExecutions += 1
+        return { provider: "daytona", url: "https://cloud.example", status: "healthy" }
+      },
+    })
+
+    expect(wakeExecutions).toBe(1)
+    expect(provisionExecutions).toBe(0)
+    expect(worker.status).toBe("failed")
+  })
+
   test("falls back to full provisioning when the Daytona sandbox is missing during wake", async () => {
     const worker = makeWorker({ status: "stopped" })
     const { store } = makeStore({

--- a/ee/apps/den-api/test/daytona-provisioning.test.ts
+++ b/ee/apps/den-api/test/daytona-provisioning.test.ts
@@ -1,0 +1,208 @@
+import { DaytonaConflictError } from "@daytonaio/sdk"
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, describe, expect, test } from "bun:test"
+import type { DaytonaProvisioningRuntime, DaytonaSandboxRuntime } from "../src/workers/daytona.js"
+
+type DaytonaModule = typeof import("../src/workers/daytona.js")
+type ProvisionInput = Parameters<DaytonaModule["provisionWorkerOnDaytonaWithRuntime"]>[0]
+type UpsertInput = Parameters<DaytonaProvisioningRuntime["upsertSandbox"]>[0]
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.DAYTONA_API_KEY = "daytona-test-key"
+  process.env.DAYTONA_WORKER_PROXY_BASE_URL = "https://workers.example.test"
+}
+
+let daytona: DaytonaModule
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  daytona = await import("../src/workers/daytona.js")
+})
+
+function provisionInput(): ProvisionInput {
+  return {
+    workerId: createDenTypeId("worker"),
+    name: "Cloud",
+    hostToken: "host-token",
+    clientToken: "client-token",
+    activityToken: "activity-token",
+  }
+}
+
+function makeSandbox(input: {
+  id: string
+  state: string
+  startError?: Error
+}) {
+  let state = input.state
+  let startCalls = 0
+  let deleteCalls = 0
+  const sandbox = {
+    id: input.id,
+    get state() {
+      return state
+    },
+    get target() {
+      return "us-test"
+    },
+    async refreshData() {},
+    async start() {
+      startCalls += 1
+      if (input.startError) {
+        throw input.startError
+      }
+      state = "started"
+    },
+    async delete() {
+      deleteCalls += 1
+    },
+    async getSignedPreviewUrl() {
+      return { url: `https://${input.id}.preview.example.test` }
+    },
+    process: {
+      async createSession() {},
+      async executeSessionCommand() {
+        return { cmdId: "cmd_1" }
+      },
+      async getSessionCommand() {
+        return { exitCode: null }
+      },
+      async getSessionCommandLogs() {
+        return { stdout: "", stderr: "" }
+      },
+    },
+  } satisfies DaytonaSandboxRuntime
+
+  return {
+    sandbox,
+    get startCalls() {
+      return startCalls
+    },
+    get deleteCalls() {
+      return deleteCalls
+    },
+  }
+}
+
+function makeRuntime(input: {
+  sandboxName: string
+  nameResults: Array<DaytonaSandboxRuntime | null>
+  createdSandbox?: DaytonaSandboxRuntime
+  createError?: Error
+}) {
+  let createCalls = 0
+  let nameLookups = 0
+  let healthChecks = 0
+  const upserts: UpsertInput[] = []
+  const runtime = {
+    async getVolume() {
+      return { id: "vol_shared", state: "ready" }
+    },
+    async getSandbox(sandboxIdOrName: string) {
+      if (sandboxIdOrName === input.sandboxName) {
+        const result = nameLookups < input.nameResults.length
+          ? input.nameResults[nameLookups]
+          : input.nameResults[input.nameResults.length - 1]
+        nameLookups += 1
+        if (result) {
+          return result
+        }
+      }
+
+      throw new Error(`sandbox ${sandboxIdOrName} not found`)
+    },
+    async createSandbox() {
+      createCalls += 1
+      if (input.createError) {
+        throw input.createError
+      }
+      if (!input.createdSandbox) {
+        throw new Error("created sandbox missing")
+      }
+      return input.createdSandbox
+    },
+    async upsertSandbox(row: UpsertInput) {
+      upserts.push(row)
+    },
+    async waitForHealth() {
+      healthChecks += 1
+    },
+  } satisfies DaytonaProvisioningRuntime
+
+  return {
+    runtime,
+    upserts,
+    get createCalls() {
+      return createCalls
+    },
+    get healthChecks() {
+      return healthChecks
+    },
+  }
+}
+
+describe("Daytona Cloud provisioning adoption", () => {
+  test("adopts the existing sandbox when create races and Daytona returns a conflict", async () => {
+    const input = provisionInput()
+    const sandboxName = daytona.daytonaSandboxName(input)
+    const existing = makeSandbox({ id: "sbx_existing", state: "stopped" })
+    const runtime = makeRuntime({
+      sandboxName,
+      nameResults: [null, existing.sandbox],
+      createError: new DaytonaConflictError("Sandbox with name already exists"),
+    })
+
+    const result = await daytona.provisionWorkerOnDaytonaWithRuntime(input, runtime.runtime)
+
+    expect(result.status).toBe("healthy")
+    expect(result.url).toBe(`https://workers.example.test/${encodeURIComponent(input.workerId)}`)
+    expect(runtime.createCalls).toBe(1)
+    expect(existing.startCalls).toBe(1)
+    expect(existing.deleteCalls).toBe(0)
+    expect(runtime.healthChecks).toBe(1)
+    expect(runtime.upserts).toHaveLength(1)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_existing")
+  })
+
+  test("creates a new sandbox when the deterministic name is unused", async () => {
+    const input = provisionInput()
+    const sandboxName = daytona.daytonaSandboxName(input)
+    const created = makeSandbox({ id: "sbx_created", state: "started" })
+    const runtime = makeRuntime({
+      sandboxName,
+      nameResults: [null],
+      createdSandbox: created.sandbox,
+    })
+
+    const result = await daytona.provisionWorkerOnDaytonaWithRuntime(input, runtime.runtime)
+
+    expect(result.status).toBe("healthy")
+    expect(runtime.createCalls).toBe(1)
+    expect(created.startCalls).toBe(0)
+    expect(created.deleteCalls).toBe(0)
+    expect(runtime.upserts).toHaveLength(1)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_created")
+  })
+
+  test("does not delete an adopted sandbox when starting it fails", async () => {
+    const input = provisionInput()
+    const sandboxName = daytona.daytonaSandboxName(input)
+    const existing = makeSandbox({ id: "sbx_stopped", state: "stopped", startError: new Error("start failed") })
+    const runtime = makeRuntime({
+      sandboxName,
+      nameResults: [existing.sandbox],
+    })
+
+    await expect(daytona.provisionWorkerOnDaytonaWithRuntime(input, runtime.runtime)).rejects.toThrow("start failed")
+
+    expect(runtime.createCalls).toBe(0)
+    expect(existing.startCalls).toBe(1)
+    expect(existing.deleteCalls).toBe(0)
+    expect(runtime.upserts).toHaveLength(0)
+  })
+})


### PR DESCRIPTION
A real user's Cloud workspace was permanently unusable, and den-api was hammering Daytona roughly twice a minute for hours. Both come from the same bug.

## What was happening

Diagnosed live in production:

- Worker `wrk_01kyev52cmfvk9rqnhjsk3t5w3` sat at **status `failed`**, updating every ~30-60s.
- den-api logs, on repeat since 07:53:
  ```
  DaytonaConflictError: Sandbox with name den-daytona-worker-cloud-wrk-01kyev52 already exists
  ```
- Daytona confirmed the sandbox **exists and is `stopped`** (idle since 00:07).

The loop: Daytona stops an idle sandbox -> the worker is marked `failed` -> self-heal flips it to `provisioning` -> provisioning **creates** a sandbox using a deterministic name -> the existing one causes a conflict -> `failed` again -> 60s cooldown -> forever.

The sandbox was never broken. It was asleep, and nothing ever tried to wake it — the recovery path only knew how to create. **Any Cloud sandbox stopped for idleness wedges permanently this way**, so this is not user-specific; there are 63 sandboxes in the account.

## The fix

Provisioning now adopts an existing sandbox instead of blindly creating one:

- Look up the deterministic name first; if it exists, adopt it — starting it when `stopped` — and hand off to the existing OpenWork startup/health flow.
- `DaytonaConflictError` on create is treated as recoverable: re-look-up the name and adopt. Both the pre-check and the conflict handler are needed, because two concurrent resolves can race between check and create.
- Route level: a `failed` worker that already has a sandbox record now claims `failed -> provisioning`, calls `startWake`, and reports `waking` rather than re-provisioning.

### Data safety

Adopted sandboxes are **never** deleted — user workspace files live in them. The only `delete` is of a sandbox this call just created, when its startup fails. On a conflict that variable is null, so nothing is removed. A sandbox that exists but will not start reports `failed` rather than being replaced.

Existing status semantics and the race-safe writes (`WHERE status IN ('provisioning','failed')` on success, `WHERE status = 'provisioning'` on failure) are unchanged.

## Tests

The regression test fails against the old code and passes now:

```
Expected: 0
Received: 1
(fail) adopts an existing stopped sandbox for a failed worker instead of provisioning a duplicate
```

| Command | Result |
| --- | --- |
| `bun test test/cloud-instance-route.test.ts test/desktop-handoff-public-url.test.ts` | 36 pass / 0 fail |
| `bun test test/daytona-provisioning.test.ts test/cloud-lifecycle.test.ts` | 10 pass / 0 fail |
| `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` | 0 errors |
| `pnpm --filter @openwork-ee/den-api test:admin-scale` | 4 pass / 0 fail |

Coverage added for: adopting a stopped sandbox, adopting on create-conflict, still creating when nothing exists, and reporting `failed` without deleting when an existing sandbox cannot start.

The full aggregate den-api suite could not be run locally — the DB-backed tests need MySQL on 127.0.0.1:3306 and this machine's Docker daemon is broken, so those failures are environmental, not from this change. CI runs that suite with a database.

## Follow-ups this exposes

- Other wedged workers likely exist. Once this deploys they should self-heal on the next resolve, but that is worth confirming against the 63 sandboxes.
- The app never surfaces instance state. den-api already returns `provisioning | waking | ready | failed` and the gateway uses it to route, then discards it, so a user with a stopped sandbox just gets silently redirected into a dead workspace with no explanation. Tracked separately.