### PR TITLE
fix(desktop): repair AppImage launcher silently after updates

### DIFF
--- a/apps/desktop/electron/linux-desktop-integration.mjs
+++ b/apps/desktop/electron/linux-desktop-integration.mjs
@@ -526,20 +526,30 @@ export function createLinuxDesktopIntegration({
       || status.state === "integrated"
       || status.state === "managed_externally"
       || status.ownership === "external"
-      || await shouldSkipPrompt()
     ) {
       return status;
     }
 
-    const repair = status.ownership === "openwork";
+    // The user already accepted this integration, so drift in the files OpenWork
+    // owns is maintenance rather than a new decision. A self-update lands under a
+    // new versioned filename and a moved AppImage changes its path; both stale the
+    // launcher. Repair silently instead of prompting after every release.
+    if (status.ownership === "openwork") {
+      const repaired = await install();
+      if (!repaired.ok) {
+        console.warn("[desktop-integration] silent repair failed", repaired.error);
+      }
+      return repaired.status;
+    }
+
+    if (await shouldSkipPrompt()) return status;
+
     const { response, checkboxChecked } = await dialog.showMessageBox(window, {
       type: "question",
-      title: repair ? "Repair OpenWork desktop integration?" : "Add OpenWork to your applications?",
-      message: repair
-        ? "OpenWork moved or its desktop integration is incomplete."
-        : "Add OpenWork to your application launcher and register browser sign-in callbacks?",
-      detail: `The launcher will use this AppImage in its current location:\n${appImagePath}\n\nIf you move it later, use Settings → Preferences → AppImage desktop integration to repair it.`,
-      buttons: ["Not now", repair ? "Repair" : "Integrate"],
+      title: "Add OpenWork to your applications?",
+      message: "Add OpenWork to your application launcher and register browser sign-in callbacks?",
+      detail: `The launcher will use this AppImage in its current location:\n${appImagePath}\n\nIf you move or update it later, OpenWork repairs the launcher automatically. You can change or remove this in Settings → Preferences → AppImage desktop integration.`,
+      buttons: ["Not now", "Integrate"],
       defaultId: 1,
       cancelId: 0,
       checkboxLabel: "Don’t ask again for this AppImage",

--- a/apps/desktop/electron/linux-desktop-integration.test.mjs
+++ b/apps/desktop/electron/linux-desktop-integration.test.mjs
@@ -80,6 +80,40 @@ async function createHarness(options = {}) {
   };
 }
 
+// Simulates the next launch of the same install: same XDG dirs and state, but a
+// possibly different AppImage path and app version.
+function relaunchAt(harness, appImagePath, options = {}) {
+  let defaultHandler = options.defaultHandler ?? OPENWORK_DESKTOP_ID;
+  const dialogs = [];
+  const integration = createLinuxDesktopIntegration({
+    app: { isPackaged: true, getVersion: () => options.version ?? "0.18.7" },
+    dialog: {
+      async showMessageBox(_window, dialogOptions) {
+        dialogs.push(dialogOptions);
+        return { response: 0, checkboxChecked: false };
+      },
+    },
+    appName: "OpenWork",
+    distribution: "public",
+    env: {
+      APPIMAGE: appImagePath,
+      XDG_DATA_HOME: harness.dataHome,
+      XDG_CONFIG_HOME: harness.configHome,
+      XDG_DATA_DIRS: path.join(harness.root, "system-data"),
+    },
+    platform: "linux",
+    resourcesPath: path.join(harness.root, "resources"),
+    runCommand: async (command, args) => {
+      if (command === "xdg-mime" && args[0] === "query") {
+        return { ok: true, stdout: defaultHandler ? `${defaultHandler}\n` : "", stderr: "" };
+      }
+      if (command === "xdg-mime" && args[0] === "default") defaultHandler = args[1];
+      return { ok: true, stdout: "", stderr: "" };
+    },
+  });
+  return { dialogs, getDefaultHandler: () => defaultHandler, integration };
+}
+
 afterEach(async () => {
   await Promise.all(temporaryRoots.splice(0).map((root) => rm(root, { recursive: true, force: true })));
 });
@@ -159,6 +193,51 @@ describe("Linux AppImage desktop integration", () => {
       await readFile(moved.paths.desktopEntryPath, "utf8"),
       new RegExp(`^TryExec=${movedPath}$`, "m"),
     );
+  });
+
+  it("silently repairs an owned launcher after a self-update lands a new filename", async () => {
+    const harness = await createHarness();
+    assert.equal((await harness.integration.install()).ok, true);
+
+    // Linux artifacts carry the version in their filename, so electron-updater
+    // installs each release at a new path and stales the launcher.
+    const updatedPath = path.join(harness.root, "openwork-linux-x86_64-0.18.8.AppImage");
+    await rename(harness.appImagePath, updatedPath);
+    const relaunched = relaunchAt(harness, updatedPath, { version: "0.18.8" });
+    assert.equal((await relaunched.integration.getStatus()).state, "needs_repair");
+
+    const status = await relaunched.integration.maybePrompt({});
+    assert.equal(status.state, "integrated");
+    assert.equal(relaunched.dialogs.length, 0);
+    const entry = await readFile(relaunched.integration.paths.desktopEntryPath, "utf8");
+    assert.match(entry, new RegExp(`^TryExec=${updatedPath}$`, "m"));
+    assert.match(entry, /^X-OpenWork-Version=0\.18\.8$/m);
+  });
+
+  it("silently refreshes an owned launcher when only the version changed", async () => {
+    const harness = await createHarness();
+    assert.equal((await harness.integration.install()).ok, true);
+
+    const relaunched = relaunchAt(harness, harness.appImagePath, { version: "0.18.8" });
+    assert.deepEqual((await relaunched.integration.getStatus()).issues, ["version"]);
+
+    const status = await relaunched.integration.maybePrompt({});
+    assert.equal(status.state, "integrated");
+    assert.equal(relaunched.dialogs.length, 0);
+  });
+
+  it("keeps a failed silent repair quiet and leaves it to Settings", async () => {
+    const harness = await createHarness();
+    assert.equal((await harness.integration.install()).ok, true);
+
+    const movedPath = path.join(harness.root, "openwork-linux-x86_64-0.18.8.AppImage");
+    await rename(harness.appImagePath, movedPath);
+    const relaunched = relaunchAt(harness, movedPath, { version: "0.18.8" });
+    await rm(path.join(harness.root, "resources"), { recursive: true, force: true });
+
+    const status = await relaunched.integration.maybePrompt({});
+    assert.equal(status.state, "needs_repair");
+    assert.equal(relaunched.dialogs.length, 0);
   });
 
   it("does not prompt after a remembered Not now response", async () => {

--- a/evals/flows/appimage-desktop-integration.flow.mjs
+++ b/evals/flows/appimage-desktop-integration.flow.mjs
@@ -53,6 +53,17 @@ async function desktopStatus(ctx) {
   );
 }
 
+async function waitForIntegrationState(ctx, expected, timeoutMs = 45_000) {
+  const deadline = Date.now() + timeoutMs;
+  let last = null;
+  while (Date.now() < deadline) {
+    last = await desktopStatus(ctx);
+    if (last?.state === expected) return last;
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(`Desktop integration stayed at "${last?.state}" instead of "${expected}".`);
+}
+
 async function scrollIntegrationIntoView(ctx) {
   await ctx.eval(`(() => {
     const heading = [...document.querySelectorAll("h3")]
@@ -180,9 +191,9 @@ export default {
       },
     },
     {
-      name: "A moved AppImage repairs and manager ownership stays singular",
+      name: "A moved AppImage self-heals and manager ownership stays singular",
       run: async (ctx) => {
-        await ctx.prove("A moved AppImage repairs its owned entry, then defers to a manager-owned launcher without duplication", {
+        await ctx.prove("A moved AppImage silently repairs its owned entry, then defers to a manager-owned launcher without duplication", {
           voiceover: vo[2],
           action: async () => {
             await closeApp(ctx);
@@ -192,9 +203,16 @@ export default {
             launchAppImage(MOVED_APPIMAGE);
             await ctx.reconnect({ timeoutMs: 90_000 });
             await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 45_000 });
+            // The launcher is stale after the move. OpenWork repairs the entry it
+            // already owns without asking again.
+            await waitForIntegrationState(ctx, "integrated");
+            const repaired = await readFile(path.join(DATA_HOME, "applications", DESKTOP_ID), "utf8");
+            record(
+              ctx,
+              repaired.includes(`Exec="${MOVED_APPIMAGE}" %U`),
+              "The moved AppImage is repaired without prompting again",
+            );
             await ctx.navigateHash("/settings/preferences");
-            await ctx.waitForText("Needs repair", { timeoutMs: 30_000 });
-            await ctx.clickText("Repair", { selector: "button" });
             await ctx.waitForText("Integrated", { timeoutMs: 30_000 });
 
             await ctx.clickText("Remove", { selector: "button" });

--- a/evals/voiceovers/appimage-desktop-integration.md
+++ b/evals/voiceovers/appimage-desktop-integration.md
@@ -4,4 +4,4 @@
 
 2. I choose Integrate, and OpenWork appears in GNOME with the correct icon. I sign in through Firefox, and the callback returns.
 
-3. After moving the AppImage, Settings reports that it needs repair; I click Repair. If a manager already manages the AppImage, OpenWork does not create a duplicate.
+3. After moving the AppImage, OpenWork repairs its own launcher on the next start without asking me again, so sign-in keeps working after every update. If a manager already manages the AppImage, OpenWork does not create a duplicate.


### PR DESCRIPTION
## Summary
- Repair an OpenWork-owned AppImage launcher silently on the next start instead of prompting.
- Keep the first-run opt-in prompt exactly as it was.
- Keep externally managed AppImages untouched.
- Log a failed silent repair instead of showing a dialog on every launch.

## Why
Follow-up to #3217 (merged as 9d6d0277f).

Linux artifacts are named `openwork-${os}-${arch}-${version}.AppImage` (`apps/desktop/electron-builder.yml`). `electron-updater`'s `AppImageUpdater` only reuses the existing filename when it has no version in it; otherwise it installs the release at a **new path** beside the old one. So after every self-update:

1. the installed desktop entry still points at the previous file,
2. `openwork://` sign-in callbacks break again — the exact failure #3216 reported,
3. the user gets a "Repair OpenWork desktop integration?" dialog on the next start.

The user already answered the only real question when they opted in. Keeping the entry OpenWork owns pointed at the running binary is maintenance, not a new decision.

## Scope
- `maybePrompt` only: `ownership === "openwork"` + `needs_repair` now calls `install()` silently.
- The repair dialog variant is removed, so the prompt is only ever the first-run opt-in.
- Prompt copy now states that moves and updates are repaired automatically.

## Out of scope
- Sign-in that does not depend on a protocol handler (nonce polling / loopback redirect). That is the higher-leverage fix for #3216 and is still worth doing separately.
- Moving the AppImage to a stable `~/Applications/OpenWork.AppImage` path on opt-in, which would remove the path drift at its root.

## Behavior
| Situation | Before | After |
| --- | --- | --- |
| First run, not integrated | Prompt | Prompt (unchanged) |
| Self-update to a new filename | "Repair?" dialog every release | Silently repaired |
| AppImage moved by the user | "Repair?" dialog | Silently repaired |
| Managed by AppImageLauncher / Gear Lever | Untouched | Untouched |
| Silent repair fails | n/a | Logged; Settings still shows "Needs repair" + Repair button |

## Testing
### Ran
- `pnpm --filter @openwork/desktop test`
- `pnpm --filter @openwork/desktop check:electron`
- `pnpm --filter @openwork/desktop typecheck:electron`
- `node --check evals/flows/appimage-desktop-integration.flow.mjs`

### Result
- pass: desktop suite, **174 tests, 173 passed, 1 platform-only skip, 0 failed**
- pass: Electron desktop bridge covers all 52 renderer methods
- pass: Electron TypeScript check
- pass: eval flow parses
- Non-vacuous check: reverting only `linux-desktop-integration.mjs` fails exactly the 3 new tests (11 pass / 3 fail), and they pass again with the change restored.

New unit tests:
1. silently repairs an owned launcher after a self-update lands a new filename (asserts new `TryExec`, `X-OpenWork-Version=0.18.8`, **zero dialogs**)
2. silently refreshes an owned launcher when only the version changed
3. keeps a failed silent repair quiet and leaves it to Settings

## Evidence scope — please read
**No fraimz run for this change.** `appimage-desktop-integration` needs a packaged Linux AppImage plus `desktop-file-validate` / `xdg-mime` / `gtk-launch`; this was developed on macOS, so it could not be executed honestly. Reporting this as **Incomplete**, not Passed.

The flow was updated to match the new behavior and still needs a Linux run:
- it previously waited for "Needs repair" and clicked **Repair**, which this change removes;
- it now polls `desktopIntegrationStatus` until `integrated` after the move, records that the moved AppImage was repaired without prompting, and then asserts the manager-owned end state as before.

Repro on a Linux host:
```
pnpm --dir apps/desktop exec electron-builder --config electron-builder.yml --linux AppImage
APPIMAGE_EXTRACT_AND_RUN=1 pnpm fraimz --flow appimage-desktop-integration
```

## Risk
Low and Linux-AppImage-specific. Strictly fewer dialogs and fewer broken states than today; no new files or locations are written beyond what #3217 already wrote. Worst case is an unwanted silent rewrite of an entry OpenWork already owns, which Settings can still remove.

## Rollback
Revert this commit. The opt-in prompt and Settings controls from #3217 keep working, including the manual Repair button.