### PR TITLE
perf(extensions): prefetch the organization inventory, add a list view

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -619,6 +619,8 @@ export default {
   "extensions.filter_plugins": "Plugins",
   "extensions.filter_skills": "Skills",
   "extensions.group_ready_to_set_up": "Ready to set up",
+  "extensions.layout_grid": "Card view",
+  "extensions.layout_list": "List view",
   "extensions.mcp_servers_section": "MCP servers configured here",
   "extensions.group_ready_to_set_up_hint": "Turn these on when you need them",
   "extensions.from_org": "from {org}",

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -612,6 +612,8 @@ export default {
   "extensions.badge_mcp": "MCP",
   "extensions.badge_plugin": "Plugin",
   "extensions.badge_skill": "Skill",
+  "extensions.empty_connections": "{org} has not shared any connections with you yet. An admin adds them in the OpenWork Cloud dashboard.",
+  "extensions.empty_connections_signed_out": "Connections are shared by your organization. Sign in to OpenWork Cloud from Account to see yours.",
   "extensions.filter_all": "All",
   "extensions.filter_apps": "Apps",
   "extensions.filter_connections": "Connections",

--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -9,6 +9,9 @@ import {
 import { resolveExtensionIconUrl } from "./extension-icon-src";
 import { ExtensionMeshAvatar } from "./extension-mesh-avatar";
 
+/** How the inventory is showing this extension: as a tile, or as a dense row. */
+export type ExtensionLayout = "grid" | "list";
+
 export type ExtensionCardProps = {
   name: string;
   description: string;
@@ -20,6 +23,8 @@ export type ExtensionCardProps = {
   url?: string;
   /** What this row is: a local app, an account connection, an MCP server, a skill, or a plugin. */
   taxonomy?: ExtensionTaxonomy;
+  /** Tile or dense row. Defaults to the tile. */
+  layout?: ExtensionLayout;
   /** Whether the extension is already installed/connected. */
   connected?: boolean;
   connectedLabel?: string;
@@ -57,6 +62,104 @@ const taxonomyStyle: Record<ExtensionTaxonomy, string> = {
   plugin: "bg-violet-3 text-violet-11",
 };
 
+type ReadinessState = "ready" | "partial" | "none";
+
+function readinessSurface(state: ReadinessState) {
+  if (state === "ready") return "border-green-6 bg-green-2";
+  if (state === "partial") return "border-amber-6 bg-amber-2";
+  return "border-dls-border bg-dls-hover";
+}
+
+function ExtensionIcon(props: {
+  name: string;
+  taxonomy: ExtensionTaxonomy;
+  iconSrc: string | null;
+  connecting: boolean;
+  readiness: ReadinessState;
+  compact: boolean;
+}) {
+  const boxSize = props.compact ? "size-8" : "size-10";
+  const avatarSize = props.compact ? "size-6" : "size-7";
+  return (
+    <div className="relative shrink-0">
+      <div
+        className={`flex ${boxSize} items-center justify-center rounded-lg border ${readinessSurface(props.readiness)}`}
+      >
+        {props.connecting ? (
+          <Loader2 size={props.compact ? 15 : 18} className="animate-spin text-dls-secondary" />
+        ) : props.iconSrc ? (
+          <div className={`flex ${props.compact ? "size-5" : "size-6"} items-center justify-center rounded-md bg-white`}>
+            <img src={props.iconSrc} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
+          </div>
+        ) : (
+          <ExtensionMeshAvatar
+            name={props.name}
+            category={props.taxonomy}
+            className={`${avatarSize} rounded-md shadow-inner`}
+          />
+        )}
+      </div>
+      {props.readiness === "ready" ? (
+        <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full border-2 border-dls-surface bg-green-9">
+          <CheckCircle2 size={9} className="text-white" strokeWidth={3} />
+        </div>
+      ) : props.readiness === "partial" ? (
+        <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full border-2 border-dls-surface bg-amber-9">
+          <AlertCircle size={9} className="text-white" strokeWidth={3} />
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function ExtensionBadges(props: {
+  readiness: ReadinessState;
+  taxonomy: ExtensionTaxonomy;
+  connectedLabel: string;
+  hidden: boolean;
+  preview: boolean;
+  beta: boolean;
+  disabledReason: string | null;
+}) {
+  return (
+    <>
+      {props.readiness === "ready" ? (
+        <span className="shrink-0 rounded-md bg-green-3 px-1.5 py-0.5 text-[10px] font-medium text-green-11">
+          {props.connectedLabel}
+        </span>
+      ) : props.readiness === "partial" ? (
+        <span className="shrink-0 rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+          Partially set up
+        </span>
+      ) : (
+        <span className={`shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium ${taxonomyStyle[props.taxonomy]}`}>
+          {extensionTaxonomyLabel(props.taxonomy)}
+        </span>
+      )}
+      {props.hidden ? (
+        <span className="shrink-0 rounded-md bg-gray-3 px-1.5 py-0.5 text-[10px] font-medium text-gray-11">
+          Hidden
+        </span>
+      ) : null}
+      {props.preview ? (
+        <span className="rounded-md bg-blue-3 px-1.5 py-0.5 text-[10px] font-medium text-blue-11">
+          Preview
+        </span>
+      ) : null}
+      {props.beta ? (
+        <span className="shrink-0 rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+          {t("common.beta")}
+        </span>
+      ) : null}
+      {props.disabledReason ? (
+        <span className="shrink-0 rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+          Disabled
+        </span>
+      ) : null}
+    </>
+  );
+}
+
 /**
  * A reusable card for displaying an extension (MCP server, plugin, or skill)
  * in the extensions directory. Supports brand icons from Simple Icons CDN,
@@ -70,6 +173,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
     iconSrc,
     url,
     taxonomy = "mcp",
+    layout = "grid",
     connected: connectedProp = false,
     connectedLabel = "Connected",
     enablement,
@@ -89,92 +193,91 @@ export function ExtensionCard(props: ExtensionCardProps) {
   // When enablement results are provided, derive connected + partial state from them.
   const allMet = enablement ? enablement.every((r) => r.met) : connectedProp;
   const someMet = enablement ? enablement.some((r) => r.met) && !allMet : false;
-  const connected = allMet;
-  const resolvedIconSrc = resolveExtensionIconUrl({ iconSrc, iconSlug, serviceUrl: url });
+  const readiness: ReadinessState = allMet ? "ready" : someMet ? "partial" : "none";
+  const resolvedIconSrc = resolveExtensionIconUrl({ iconSrc, iconSlug, serviceUrl: url }) ?? null;
+  const shellState = readiness === "ready"
+    ? "border-green-6 bg-green-2"
+    : readiness === "partial"
+      ? "border-amber-6 bg-amber-2"
+      : "border-dls-border bg-dls-surface hover:bg-dls-hover";
+  const shellClassName = `group w-full border text-left transition-all ${shellState} ${hidden ? "border-dashed opacity-70" : ""}`;
+  const badges = (
+    <ExtensionBadges
+      readiness={readiness}
+      taxonomy={taxonomy}
+      connectedLabel={connectedLabel}
+      hidden={hidden}
+      preview={preview}
+      beta={beta}
+      disabledReason={disabledReason}
+    />
+  );
+  const icon = (
+    <ExtensionIcon
+      name={name}
+      taxonomy={taxonomy}
+      iconSrc={resolvedIconSrc}
+      connecting={connecting}
+      readiness={readiness}
+      compact={layout === "list"}
+    />
+  );
+  const nextAction = !disabledReason && !connecting && nextActionLabel ? (
+    <div
+      className="text-[11px] font-medium text-dls-text transition-colors group-hover:opacity-80"
+      onClick={(event) => {
+        if (!onNextAction) return;
+        event.stopPropagation();
+        onNextAction();
+      }}
+    >
+      {nextActionLabel}
+    </div>
+  ) : !disabledReason && !connecting && actionLabel ? (
+    <div className="text-[11px] font-medium text-dls-text transition-colors group-hover:opacity-80">
+      {actionLabel}
+    </div>
+  ) : null;
+
+  if (layout === "list") {
+    return (
+      <button
+        type="button"
+        disabled={disabled || connecting}
+        onClick={onClick}
+        className={`${shellClassName} flex items-center gap-3 rounded-lg px-3 py-2`}
+      >
+        {icon}
+        <div className="min-w-0 flex-1">
+          <div className="flex flex-wrap items-center gap-1.5">
+            <h4 className="min-w-0 truncate text-sm font-semibold text-dls-text">{name}</h4>
+            {badges}
+          </div>
+          <p className="truncate text-xs text-dls-secondary">
+            {disabledReason ?? description}
+          </p>
+        </div>
+        {meta ? (
+          <div className="hidden shrink-0 text-[11px] text-dls-secondary sm:block">{meta}</div>
+        ) : null}
+        {nextAction ? <div className="shrink-0">{nextAction}</div> : null}
+      </button>
+    );
+  }
 
   return (
     <button
       type="button"
       disabled={disabled || connecting}
       onClick={onClick}
-      className={`group w-full rounded-xl border p-4 text-left transition-all ${
-        connected
-          ? "border-green-6 bg-green-2"
-          : someMet
-          ? "border-amber-6 bg-amber-2"
-          : "border-dls-border bg-dls-surface hover:bg-dls-hover"
-      } ${hidden ? "border-dashed opacity-70" : ""}`}
+      className={`${shellClassName} rounded-xl p-4`}
     >
       <div className="flex items-start gap-3">
-        {/* Icon */}
-        <div className="relative shrink-0">
-          <div
-            className={`flex size-10 items-center justify-center rounded-lg border ${
-              connected ? "border-green-6 bg-green-2" : someMet ? "border-amber-6 bg-amber-2" : "border-dls-border bg-dls-hover"
-            }`}
-          >
-            {connecting ? (
-              <Loader2 size={18} className="animate-spin text-dls-secondary" />
-            ) : resolvedIconSrc ? (
-              <div className="flex size-6 items-center justify-center rounded-md bg-white">
-                <img src={resolvedIconSrc} alt="" width={16} height={16} loading="lazy" style={{ display: "block" }} />
-              </div>
-            ) : (
-              <ExtensionMeshAvatar
-                name={name}
-                category={taxonomy}
-                className="size-7 rounded-md shadow-inner"
-              />
-            )}
-          </div>
-          {connected ? (
-            <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full border-2 border-dls-surface bg-green-9">
-              <CheckCircle2 size={9} className="text-white" strokeWidth={3} />
-            </div>
-          ) : someMet ? (
-            <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full border-2 border-dls-surface bg-amber-9">
-              <AlertCircle size={9} className="text-white" strokeWidth={3} />
-            </div>
-          ) : null}
-        </div>
-
-        {/* Content */}
+        {icon}
         <div className="min-w-0 flex-1">
           <div className="flex flex-wrap items-center gap-1.5">
             <h4 className="min-w-0 break-words text-sm font-semibold text-dls-text">{name}</h4>
-            {connected ? (
-              <span className="shrink-0 rounded-md bg-green-3 px-1.5 py-0.5 text-[10px] font-medium text-green-11">
-                {connectedLabel}
-              </span>
-            ) : someMet ? (
-              <span className="shrink-0 rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
-                Partially set up
-              </span>
-            ) : (
-              <span className={`shrink-0 rounded-md px-1.5 py-0.5 text-[10px] font-medium ${taxonomyStyle[taxonomy]}`}>
-                {extensionTaxonomyLabel(taxonomy)}
-              </span>
-            )}
-            {hidden ? (
-              <span className="shrink-0 rounded-md bg-gray-3 px-1.5 py-0.5 text-[10px] font-medium text-gray-11">
-                Hidden
-              </span>
-            ) : null}
-            {preview ? (
-              <span className="rounded-md bg-blue-3 px-1.5 py-0.5 text-[10px] font-medium text-blue-11">
-                Preview
-              </span>
-            ) : null}
-            {beta ? (
-              <span className="shrink-0 rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
-                {t("common.beta")}
-              </span>
-            ) : null}
-            {disabledReason ? (
-              <span className="shrink-0 rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
-                Disabled
-              </span>
-            ) : null}
+            {badges}
           </div>
           <p className="mt-0.5 line-clamp-2 text-xs text-dls-secondary">{description}</p>
           {meta ? (
@@ -185,22 +288,7 @@ export function ExtensionCard(props: ExtensionCardProps) {
               {disabledReason}
             </div>
           ) : null}
-          {!disabledReason && !connecting && nextActionLabel ? (
-            <div
-              className="mt-2 text-[11px] font-medium text-dls-text transition-colors group-hover:opacity-80"
-              onClick={(event) => {
-                if (!onNextAction) return;
-                event.stopPropagation();
-                onNextAction();
-              }}
-            >
-              {nextActionLabel}
-            </div>
-          ) : !disabledReason && !connecting && actionLabel ? (
-            <div className="mt-2 text-[11px] font-medium text-dls-text transition-colors group-hover:opacity-80">
-              {actionLabel}
-            </div>
-          ) : null}
+          {nextAction ? <div className="mt-2">{nextAction}</div> : null}
         </div>
       </div>
     </button>

--- a/apps/app/src/react-app/domains/connections/cloud-inventory-cache.ts
+++ b/apps/app/src/react-app/domains/connections/cloud-inventory-cache.ts
@@ -1,0 +1,173 @@
+import { createDenClient, readDenSettings, type DenExternalMcpConnection } from "@/app/lib/den";
+import {
+  EMPTY_CONNECT_CAPABILITY_INVENTORY,
+  listAssignedConnectCapabilities,
+  type ConnectCapabilityClient,
+  type ConnectCapabilityInventory,
+} from "@/react-app/domains/session/surface/connect-capability-inventory";
+
+export type OrgMcpConnectionClient = {
+  listMcpConnections: (
+    organizationId: string,
+    scope: "usable" | "manageable",
+  ) => Promise<DenExternalMcpConnection[]>;
+};
+
+/**
+ * What the organization gives this member — Connect capabilities and external
+ * MCP connections — is the slowest part of the Extensions inventory: each one
+ * is a Den round-trip (marketplaces, then every resolved marketplace, then
+ * every resolved plugin). The composer and Settings both need it, and Settings
+ * remounts every time the extensions side panel opens, so without a cache the
+ * "Ready to use" group waits on the same fan-out again and again.
+ *
+ * These caches are module-scoped on purpose: they outlive the components that
+ * read them, so a view can paint the last known inventory on its first frame
+ * and revalidate behind it.
+ */
+
+export type CloudInventoryScope = {
+  baseUrl: string;
+  organizationId: string;
+};
+
+/** How long a cached answer is served without going back to Den. */
+const DEFAULT_MAX_AGE_MS = 60_000;
+
+export function cloudInventoryScopeKey(scope: CloudInventoryScope) {
+  return `${scope.baseUrl}\n${scope.organizationId}`;
+}
+
+/** The scope of the signed-in member, or null when there is nothing to fetch. */
+export function readCloudInventoryScope(): CloudInventoryScope | null {
+  const settings = readDenSettings();
+  const token = settings.authToken?.trim() ?? "";
+  const organizationId = settings.activeOrgId?.trim() ?? "";
+  if (!token || !organizationId) return null;
+  return { baseUrl: settings.baseUrl, organizationId };
+}
+
+type CacheSlot<T> = {
+  key: string;
+  value: T | null;
+  fetchedAt: number;
+  inflight: Promise<T> | null;
+};
+
+type ScopedCache<T, C> = {
+  read: (scope: CloudInventoryScope) => T | null;
+  load: (input: { client: C; scope: CloudInventoryScope; maxAgeMs?: number }) => Promise<T>;
+  clear: () => void;
+};
+
+function createScopedCache<T, C>(
+  fetcher: (input: { client: C; scope: CloudInventoryScope }) => Promise<T>,
+): ScopedCache<T, C> {
+  let slot: CacheSlot<T> | null = null;
+
+  return {
+    read(scope) {
+      const key = cloudInventoryScopeKey(scope);
+      return slot && slot.key === key ? slot.value : null;
+    },
+    async load({ client, scope, maxAgeMs = DEFAULT_MAX_AGE_MS }) {
+      const key = cloudInventoryScopeKey(scope);
+      const current = slot && slot.key === key ? slot : null;
+      if (current?.value && Date.now() - current.fetchedAt < maxAgeMs) return current.value;
+      if (current?.inflight) return current.inflight;
+
+      const inflight = fetcher({ client, scope });
+      const pending: CacheSlot<T> = {
+        key,
+        value: current?.value ?? null,
+        fetchedAt: current?.fetchedAt ?? 0,
+        inflight,
+      };
+      slot = pending;
+      try {
+        const value = await inflight;
+        if (slot === pending) slot = { key, value, fetchedAt: Date.now(), inflight: null };
+        return value;
+      } catch (error) {
+        // Keep the last good answer so a flaky refresh does not blank the list.
+        if (slot === pending) slot = { ...pending, inflight: null };
+        throw error;
+      }
+    },
+    clear() {
+      slot = null;
+    },
+  };
+}
+
+const connectCapabilitiesCache = createScopedCache<ConnectCapabilityInventory, ConnectCapabilityClient>(
+  ({ client, scope }) => listAssignedConnectCapabilities({ client, organizationId: scope.organizationId }),
+);
+
+const orgMcpConnectionsCache = createScopedCache<DenExternalMcpConnection[], OrgMcpConnectionClient>(
+  ({ client, scope }) => client.listMcpConnections(scope.organizationId, "usable"),
+);
+
+/** Last known Connect inventory for this scope, without fetching. */
+export function readCachedConnectCapabilities(scope: CloudInventoryScope) {
+  return connectCapabilitiesCache.read(scope);
+}
+
+export function loadConnectCapabilities(input: {
+  client: ConnectCapabilityClient;
+  scope: CloudInventoryScope;
+  maxAgeMs?: number;
+}) {
+  return connectCapabilitiesCache.load(input);
+}
+
+/** Last known organization MCP connections for this scope, without fetching. */
+export function readCachedOrgMcpConnections(scope: CloudInventoryScope) {
+  return orgMcpConnectionsCache.read(scope);
+}
+
+export function loadOrgMcpConnections(input: {
+  client: OrgMcpConnectionClient;
+  scope: CloudInventoryScope;
+  maxAgeMs?: number;
+}) {
+  return orgMcpConnectionsCache.load(input);
+}
+
+export function clearCloudInventoryCache() {
+  connectCapabilitiesCache.clear();
+  orgMcpConnectionsCache.clear();
+}
+
+function denClientForCurrentSession() {
+  const settings = readDenSettings();
+  return createDenClient({ baseUrl: settings.baseUrl, token: settings.authToken?.trim() ?? "" });
+}
+
+/**
+ * Connect inventory for the signed-in member, empty when signed out. Callers
+ * that only need the capabilities (composer tool lists) use this instead of
+ * building a scope and client themselves.
+ */
+export async function loadSessionConnectCapabilities(): Promise<ConnectCapabilityInventory> {
+  const scope = readCloudInventoryScope();
+  if (!scope) return EMPTY_CONNECT_CAPABILITY_INVENTORY;
+  try {
+    return await loadConnectCapabilities({ client: denClientForCurrentSession(), scope });
+  } catch {
+    return EMPTY_CONNECT_CAPABILITY_INVENTORY;
+  }
+}
+
+/**
+ * Warm both caches for the signed-in member. Called at app start and whenever
+ * the Den session changes, so the Extensions inventory has its organization
+ * rows ready before the user ever opens Settings.
+ */
+export function prefetchCloudInventory() {
+  const scope = readCloudInventoryScope();
+  if (!scope) return;
+  const client = denClientForCurrentSession();
+  void loadConnectCapabilities({ client, scope }).catch(() => {});
+  void loadOrgMcpConnections({ client, scope }).catch(() => {});
+}

--- a/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
+++ b/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
@@ -4,6 +4,11 @@ import { createDenClient, readDenSettings, type DenExternalMcpConnection } from 
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
 import { openDesktopUrl } from "@/app/lib/desktop";
 import { isDesktopRuntime } from "@/app/utils";
+import {
+  loadOrgMcpConnections,
+  readCachedOrgMcpConnections,
+  readCloudInventoryScope,
+} from "./cloud-inventory-cache";
 import { connectionNeedsReconnect, isNativeProviderConnectionId } from "./native-provider-connections";
 
 // Mirrors the poll-until-connected pattern used for local MCP OAuth
@@ -99,9 +104,14 @@ export function resolveOrgMcpConnectionCardState(
  * `execute_capability` surface, not local per-workspace `mcpServers` entries.
  */
 export function useOrgMcpConnections() {
-  const [connections, setConnections] = useState<DenExternalMcpConnection[]>([]);
+  // Settings remounts every time the extensions panel opens, so start from
+  // whatever the app already fetched instead of an empty list.
+  const prefetched = readCloudInventoryScope();
+  const [connections, setConnections] = useState<DenExternalMcpConnection[]>(
+    () => (prefetched ? readCachedOrgMcpConnections(prefetched) ?? [] : []),
+  );
   const [loading, setLoading] = useState(false);
-  const [loaded, setLoaded] = useState(false);
+  const [loaded, setLoaded] = useState(connections.length > 0);
   const [error, setError] = useState<string | null>(null);
   const [connectingId, setConnectingId] = useState<string | null>(null);
   const [disconnectingId, setDisconnectingId] = useState<string | null>(null);
@@ -144,7 +154,11 @@ export function useOrgMcpConnections() {
     setError(null);
     try {
       const client = createDenClient({ baseUrl: settings.baseUrl, token });
-      const result = await client.listMcpConnections(orgId, "usable");
+      const result = await loadOrgMcpConnections({
+        client,
+        scope: { baseUrl: settings.baseUrl, organizationId: orgId },
+        maxAgeMs: 0,
+      });
       if (
         refreshRunRef.current !== run
         || (expectedScope && !isActionScopeCurrent(expectedScope))

--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -13,11 +13,7 @@ import {
   resolvePastedTextPlaceholders,
   type PastedTextChip,
 } from "@/react-app/domains/session/surface/composer/pasted-text";
-import {
-  EMPTY_CONNECT_CAPABILITY_INVENTORY,
-  listAssignedConnectCapabilities,
-  type ConnectCapabilityInventory,
-} from "@/react-app/domains/session/surface/connect-capability-inventory";
+import { loadSessionConnectCapabilities } from "@/react-app/domains/connections/cloud-inventory-cache";
 
 /**
  * Workspace-scoped wiring for the new-task composer. Everything here is
@@ -81,42 +77,12 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const [mcpStatuses, setMcpStatuses] = useState<McpStatusMap>({});
   const [mcpStatus, setMcpStatus] = useState<string | null>(null);
   const [pastedText, setPastedText] = useState<PastedTextChip[]>([]);
-  const connectInventoryCacheRef = useRef<{ scope: string; promise: Promise<ConnectCapabilityInventory> } | null>(null);
   const context = props.context;
   const workspaceId = context?.workspaceId ?? null;
 
-  const loadConnectCapabilityInventory = async (): Promise<ConnectCapabilityInventory> => {
-    const settings = readDenSettings();
-    const token = settings.authToken?.trim() ?? "";
-    const organizationId = settings.activeOrgId?.trim() ?? "";
-    if (!token || !organizationId) return EMPTY_CONNECT_CAPABILITY_INVENTORY;
-
-    const scope = `${settings.baseUrl}\n${organizationId}`;
-    if (connectInventoryCacheRef.current?.scope === scope) {
-      try {
-        return await connectInventoryCacheRef.current.promise;
-      } catch {
-        connectInventoryCacheRef.current = null;
-        return EMPTY_CONNECT_CAPABILITY_INVENTORY;
-      }
-    }
-
-    const client = createDenClient({ baseUrl: settings.baseUrl, token });
-    const promise = listAssignedConnectCapabilities({ client, organizationId });
-    connectInventoryCacheRef.current = { scope, promise };
-    try {
-      return await promise;
-    } catch {
-      if (connectInventoryCacheRef.current?.promise === promise) {
-        connectInventoryCacheRef.current = null;
-      }
-      return EMPTY_CONNECT_CAPABILITY_INVENTORY;
-    }
-  };
-
   const listSkills = context && workspaceId
     ? async (): Promise<SkillCard[]> => {
-        const connectPromise = loadConnectCapabilityInventory();
+        const connectPromise = loadSessionConnectCapabilities();
         const response = await context.client.listSkills(workspaceId, { includeGlobal: true });
         const localSkills = (response.items ?? []).map((skill) => ({
           name: skill.name,
@@ -135,7 +101,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
 
   const listMcp = context && workspaceId
     ? async (): Promise<{ servers: McpServerEntry[]; statuses: McpStatusMap; status: string | null }> => {
-        const connectPromise = loadConnectCapabilityInventory();
+        const connectPromise = loadSessionConnectCapabilities();
         const response = await context.client.listMcp(workspaceId);
         const localServers = (response.items ?? []).map((entry) => ({
           name: entry.name,

--- a/apps/app/src/react-app/domains/session/surface/connect-capability-inventory.ts
+++ b/apps/app/src/react-app/domains/session/surface/connect-capability-inventory.ts
@@ -8,7 +8,7 @@ import type {
 } from "@/app/lib/den";
 import type { McpServerEntry, McpStatus, McpStatusMap, SkillCard } from "@/app/types";
 
-type ConnectCapabilityClient = {
+export type ConnectCapabilityClient = {
   listOrgMarketplaces: (organizationId: string) => Promise<DenOrgMarketplace[]>;
   getOrgMarketplaceResolved: (
     organizationId: string,

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -102,10 +102,9 @@ import {
   type ApplyEnvironmentChangesResult,
 } from "@/react-app/domains/settings/pages/environment-variable-provider";
 import {
-  EMPTY_CONNECT_CAPABILITY_INVENTORY,
-  listAssignedConnectCapabilities,
-  type ConnectCapabilityInventory,
-} from "./connect-capability-inventory";
+  clearCloudInventoryCache,
+  loadSessionConnectCapabilities,
+} from "@/react-app/domains/connections/cloud-inventory-cache";
 import { consumeComposerAutoSend } from "./composer-auto-send";
 
 const EMPTY_TRANSCRIPT: UIMessage[] = [];
@@ -658,10 +657,6 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [toolMcpStatuses, setToolMcpStatuses] = useState<McpStatusMap>({});
   const [toolImportedPlugins, setToolImportedPlugins] = useState<CloudImportedPlugin[]>([]);
   const [steering, setSteering] = useState(false);
-  const connectInventoryCacheRef = useRef<{
-    scope: string;
-    promise: Promise<ConnectCapabilityInventory>;
-  } | null>(null);
   const [verifiedOpenTargets, setVerifiedOpenTargets] = useState<OpenTarget[]>([]);
   const [cloudQueueRetryVersion, setCloudQueueRetryVersion] = useState(0);
   const sending = props.cloudMcpSubmissionState.status === "sending";
@@ -1420,37 +1415,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   }), [chatStreaming, handleAbort]);
   useControlAction(props.isControlTarget ? composerStopControlAction : null);
 
-  const loadConnectCapabilityInventory = async (): Promise<ConnectCapabilityInventory> => {
-    const settings = readDenSettings();
-    const token = settings.authToken?.trim() ?? "";
-    const organizationId = settings.activeOrgId?.trim() ?? "";
-    if (!token || !organizationId) return EMPTY_CONNECT_CAPABILITY_INVENTORY;
-
-    const scope = `${settings.baseUrl}\n${organizationId}`;
-    if (connectInventoryCacheRef.current?.scope === scope) {
-      try {
-        return await connectInventoryCacheRef.current.promise;
-      } catch {
-        connectInventoryCacheRef.current = null;
-        return EMPTY_CONNECT_CAPABILITY_INVENTORY;
-      }
-    }
-
-    const client = createDenClient({ baseUrl: settings.baseUrl, token });
-    const promise = listAssignedConnectCapabilities({ client, organizationId });
-    connectInventoryCacheRef.current = { scope, promise };
-    try {
-      return await promise;
-    } catch {
-      if (connectInventoryCacheRef.current?.promise === promise) {
-        connectInventoryCacheRef.current = null;
-      }
-      return EMPTY_CONNECT_CAPABILITY_INVENTORY;
-    }
-  };
-
   const listSkills = async (): Promise<SkillCard[]> => {
-    const connectPromise = loadConnectCapabilityInventory();
+    const connectPromise = loadSessionConnectCapabilities();
     const response = await props.client.listSkills(props.workspaceId, { includeGlobal: true });
     const localSkills = (response.items ?? []).map((skill) => ({
       name: skill.name,
@@ -1467,7 +1433,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   };
 
   const listMcp = async (): Promise<{ servers: McpServerEntry[]; statuses: McpStatusMap; status: string | null }> => {
-    const connectPromise = loadConnectCapabilityInventory();
+    const connectPromise = loadSessionConnectCapabilities();
     const response = await props.client.listMcp(props.workspaceId);
     const localServers = (response.items ?? []).map((entry) => ({
       name: entry.name,
@@ -1603,7 +1569,7 @@ export function SessionSurface(props: SessionSurfaceProps) {
   useEffect(() => {
     const resetReconnectState = () => {
       useChatMcpReconnectStore.getState().reset();
-      connectInventoryCacheRef.current = null;
+      clearCloudInventoryCache();
       setToolSkills((current) => current.filter((skill) => skill.origin !== "openwork-connect"));
       setToolMcpServers((current) => current.filter((server) => server.origin !== "openwork-connect"));
       setToolMcpStatuses((current) => Object.fromEntries(

--- a/apps/app/src/react-app/domains/settings/extension-state.ts
+++ b/apps/app/src/react-app/domains/settings/extension-state.ts
@@ -1,9 +1,22 @@
 import { getMcpServerName, type McpDirectoryInfo } from "../../../app/constants";
+import type { ExtensionLayout } from "../../design-system/extension-card";
 
+const EXTENSION_LAYOUT_KEY = "openwork.extensions.layout";
 const EXTENSION_DISABLED_KEY_PREFIX = "openwork.extension.disabled.";
 const EXTENSION_ENABLED_KEY_PREFIX = "openwork.extension.enabled.";
 const EXTENSION_HIDDEN_KEY_PREFIX = "openwork.extension.hidden.";
 export const OPENWORK_EXTENSION_STATE_CHANGED = "openwork:extension-state-changed";
+
+/** Whether the inventory shows tiles or dense rows. Remembered across sessions. */
+export function readExtensionLayout(): ExtensionLayout {
+  if (typeof window === "undefined") return "grid";
+  return window.localStorage.getItem(EXTENSION_LAYOUT_KEY) === "list" ? "list" : "grid";
+}
+
+export function writeExtensionLayout(layout: ExtensionLayout) {
+  if (typeof window === "undefined") return;
+  window.localStorage.setItem(EXTENSION_LAYOUT_KEY, layout);
+}
 
 export function getExtensionId(entry: McpDirectoryInfo): string {
   return entry.id ?? entry.serverName ?? getMcpServerName(entry);

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -13,6 +13,8 @@ import {
   ExternalLink,
   FolderOpen,
   Globe,
+  LayoutGrid,
+  List,
   Loader2,
   MonitorSmartphone,
   Plug2,
@@ -27,7 +29,7 @@ import { isBuiltInOpenWorkExtension, getMcpServerName, type McpDirectoryInfo } f
 import { evaluateEnablement } from "../../../../app/enablement";
 import type { EnablementResult } from "../../../../app/extensions";
 import type { CloudImportedPlugin } from "../../../../app/cloud/import-state";
-import { ExtensionCard } from "../../../design-system/extension-card";
+import { ExtensionCard, type ExtensionLayout } from "../../../design-system/extension-card";
 import { ExtensionDetailModal } from "../../../design-system/extension-detail-modal";
 import {
   isOrgMcpConnectionItem,
@@ -69,8 +71,10 @@ import {
   isOpenWorkExtensionEnabled,
   isOpenWorkExtensionHidden,
   OPENWORK_EXTENSION_STATE_CHANGED,
+  readExtensionLayout,
   setOpenWorkExtensionEnabled,
   setOpenWorkExtensionHidden,
+  writeExtensionLayout,
 } from "../extension-state";
 import {
   initialMcpViewLocalState,
@@ -347,6 +351,7 @@ export function McpView(props: McpViewProps) {
   const [search, setSearch] = useState("");
   const [filter, setFilter] = useState<ExtensionInventoryFilter>(props.initialFilter ?? "all");
   const [showHidden, setShowHidden] = useState(false);
+  const [layout, setLayout] = useState<ExtensionLayout>(readExtensionLayout);
   const [claudeImportOpen, setClaudeImportOpen] = useState(false);
   const [, setExtensionStateVersion] = useState(0);
 
@@ -930,6 +935,13 @@ export function McpView(props: McpViewProps) {
           >
             {showHidden ? "Showing hidden" : hiddenOrPolicyCount > 0 ? `Show hidden (${hiddenOrPolicyCount})` : "Show hidden"}
           </Button>
+          <ExtensionLayoutToggle
+            layout={layout}
+            onChange={(next) => {
+              setLayout(next);
+              writeExtensionLayout(next);
+            }}
+          />
         </div>
       </div>
 
@@ -967,6 +979,7 @@ export function McpView(props: McpViewProps) {
         }
         availableConnectMcpStatuses={props.availableConnectMcpStatuses ?? {}}
         loading={props.inventoryLoading === true}
+        layout={layout}
         installedPlugins={
           installedPlugins.filter((plugin) => {
             if (!showHidden && isOpenWorkExtensionHidden(`plugin:${plugin.pluginId}`)) return false;
@@ -1158,6 +1171,33 @@ type InventoryCard = {
   node: ReactNode;
 };
 
+function ExtensionLayoutToggle(props: {
+  layout: ExtensionLayout;
+  onChange: (layout: ExtensionLayout) => void;
+}) {
+  const options: { layout: ExtensionLayout; label: string; icon: ReactNode }[] = [
+    { layout: "grid", label: t("extensions.layout_grid"), icon: <LayoutGrid size={13} /> },
+    { layout: "list", label: t("extensions.layout_list"), icon: <List size={13} /> },
+  ];
+  return (
+    <div className="flex items-center gap-1">
+      {options.map((option) => (
+        <Button
+          key={option.layout}
+          variant={props.layout === option.layout ? "secondary" : "outline"}
+          size="xs"
+          aria-pressed={props.layout === option.layout}
+          aria-label={option.label}
+          title={option.label}
+          onClick={() => props.onChange(option.layout)}
+        >
+          {option.icon}
+        </Button>
+      ))}
+    </div>
+  );
+}
+
 function McpQuickConnectSection(props: {
   skillCount: number;
   entries: McpDirectoryInfo[];
@@ -1165,6 +1205,7 @@ function McpQuickConnectSection(props: {
   availableConnectMcpServers?: McpServerEntry[];
   availableConnectMcpStatuses: McpStatusMap;
   loading: boolean;
+  layout: ExtensionLayout;
   installedPlugins?: CloudImportedPlugin[];
   installedOrgMcpItems?: ExtensionItem[];
   organizationName?: string | null;
@@ -1209,6 +1250,7 @@ function McpQuickConnectSection(props: {
       group,
       node: (
         <ExtensionCard
+          layout={props.layout}
           name={entry.name}
           description={entry.description}
           iconSlug={entry.iconSlug}
@@ -1239,6 +1281,7 @@ function McpQuickConnectSection(props: {
       group: "ready",
       node: (
         <ExtensionCard
+          layout={props.layout}
           name={skill.name}
           description={skill.description ?? "Installed skill"}
           taxonomy="skill"
@@ -1261,6 +1304,7 @@ function McpQuickConnectSection(props: {
       group: ready ? "ready" : "needs_signin",
       node: (
         <ExtensionCard
+          layout={props.layout}
           name={entry.name}
           description={
             entry.pluginName
@@ -1289,6 +1333,7 @@ function McpQuickConnectSection(props: {
       group: "ready",
       node: (
         <ExtensionCard
+          layout={props.layout}
           name={plugin.name}
           description={plugin.description ?? `Organization extension with ${fileCount} installed file${fileCount === 1 ? "" : "s"}.`}
           taxonomy="plugin"
@@ -1313,6 +1358,7 @@ function McpQuickConnectSection(props: {
       node: (
         <div className="space-y-2">
           <ExtensionCard
+            layout={props.layout}
             name={item.name}
             description={item.description ?? "Shared by your organization."}
             taxonomy="connection"
@@ -1348,9 +1394,12 @@ function McpQuickConnectSection(props: {
   return (
     <div className="space-y-6">
       {grouped.length === 0 && props.loading ? (
-        <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3">
+        <div className={props.layout === "list" ? "flex flex-col gap-2" : "grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3"}>
           {[0, 1, 2].map((index) => (
-            <Skeleton key={index} className="h-[104px] rounded-xl" />
+            <Skeleton
+              key={index}
+              className={props.layout === "list" ? "h-[52px] rounded-lg" : "h-[104px] rounded-xl"}
+            />
           ))}
         </div>
       ) : grouped.length === 0 ? (
@@ -1367,7 +1416,7 @@ function McpQuickConnectSection(props: {
               count={groupCards.length}
               hint={group === "available" ? t("extensions.group_ready_to_set_up_hint") : undefined}
             />
-            <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3">
+            <div className={props.layout === "list" ? "flex flex-col gap-2" : "grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3"}>
               {groupCards.map((card) => (
                 <div key={card.key}>{card.node}</div>
               ))}

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -151,7 +151,7 @@ export type McpViewProps = {
   /** Install a Claude Code plugin bundle from a GitHub URL. */
   installClaudePlugin?: (url: string) => Promise<{ ok: boolean; message: string }>;
   /** Connected org-level External MCP Connections rendered in My Extensions. */
-  installedOrgMcpItems?: ExtensionItem[];
+  orgMcpItems?: ExtensionItem[];
   orgMcpDisconnectingId?: string | null;
   disconnectOrgMcp?: (connectionId: string) => void;
   initialFilter?: ExtensionInventoryFilter;
@@ -395,7 +395,7 @@ export function McpView(props: McpViewProps) {
   const installedSkills = props.installedSkills ?? [];
   const availableConnectMcpServers = props.availableConnectMcpServers ?? [];
   const installedPlugins = props.installedPlugins ?? [];
-  const installedOrgMcpItems = props.installedOrgMcpItems ?? [];
+  const orgMcpItems = props.orgMcpItems ?? [];
   const detailPresentation = useRoutedDetail ? "page" : "dialog";
   const setInventoryFilter = (nextFilter: ExtensionInventoryFilter) => {
     setFilter(nextFilter);
@@ -442,7 +442,7 @@ export function McpView(props: McpViewProps) {
       skills: installedSkills,
       connectMcps: availableConnectMcpServers,
       plugins: installedPlugins,
-      orgMcpItems: installedOrgMcpItems,
+      orgMcpItems,
     });
     setDetailTarget(resolved);
     if (resolved?.kind === "skill") {
@@ -465,7 +465,7 @@ export function McpView(props: McpViewProps) {
     installedSkills,
     availableConnectMcpServers,
     installedPlugins,
-    installedOrgMcpItems,
+    orgMcpItems,
   ]);
 
   useEffect(() => {
@@ -980,6 +980,7 @@ export function McpView(props: McpViewProps) {
         availableConnectMcpStatuses={props.availableConnectMcpStatuses ?? {}}
         loading={props.inventoryLoading === true}
         layout={layout}
+        filter={filter}
         installedPlugins={
           installedPlugins.filter((plugin) => {
             if (!showHidden && isOpenWorkExtensionHidden(`plugin:${plugin.pluginId}`)) return false;
@@ -992,8 +993,8 @@ export function McpView(props: McpViewProps) {
               .includes(q);
           })
         }
-        installedOrgMcpItems={
-          installedOrgMcpItems.filter((item) => {
+        orgMcpItems={
+          orgMcpItems.filter((item) => {
             if (!isOrgMcpConnectionItem(item)) return false;
             if (!matchesExtensionFilter(filter, "connection")) return false;
             if (!search.trim()) return true;
@@ -1206,8 +1207,9 @@ function McpQuickConnectSection(props: {
   availableConnectMcpStatuses: McpStatusMap;
   loading: boolean;
   layout: ExtensionLayout;
+  filter: ExtensionInventoryFilter;
   installedPlugins?: CloudImportedPlugin[];
-  installedOrgMcpItems?: ExtensionItem[];
+  orgMcpItems?: ExtensionItem[];
   organizationName?: string | null;
   busy: boolean;
   connectingName: string | null;
@@ -1347,7 +1349,7 @@ function McpQuickConnectSection(props: {
     });
   }
 
-  for (const item of (props.installedOrgMcpItems ?? []).filter(isOrgMcpConnectionItem)) {
+  for (const item of (props.orgMcpItems ?? []).filter(isOrgMcpConnectionItem)) {
     const connection = item.orgMcpConnection;
     const canDisconnect = canDisconnectNativeProviderAccount(connection);
     const disconnecting = props.orgMcpDisconnectingId === connection.id;
@@ -1406,7 +1408,13 @@ function McpQuickConnectSection(props: {
         <div className="rounded-xl border border-dashed border-dls-border px-5 py-10 text-center">
           <Unplug size={24} className="mx-auto mb-3 text-dls-secondary/30" />
           <div className="text-sm font-medium text-dls-secondary">No extensions found</div>
-          <div className="mt-1 text-xs text-dls-secondary/60">Try a different search or filter, or add an MCP server.</div>
+          <div className="mt-1 text-xs text-dls-secondary/60">
+            {props.filter === "connection"
+              ? props.organizationName?.trim()
+                ? t("extensions.empty_connections", { org: props.organizationName.trim() })
+                : t("extensions.empty_connections_signed_out")
+              : "Try a different search or filter, or add an MCP server."}
+          </div>
         </div>
       ) : (
         grouped.map(({ group, cards: groupCards }) => (

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -59,6 +59,7 @@ import type { McpServerEntry, McpStatusMap } from "../../../../app/types";
 import { formatRelativeTime, isDesktopRuntime, isWindowsPlatform } from "../../../../app/utils";
 import { t } from "../../../../i18n";
 import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
 import { AddMcpModal } from "../../connections/modals/add-mcp-modal";
 import { ClaudePluginImportModal } from "../../connections/modals/claude-plugin-import-modal";
@@ -108,6 +109,8 @@ export type McpViewProps = {
   /** MCP capabilities assigned through OpenWork Connect. */
   availableConnectMcpServers?: McpServerEntry[];
   availableConnectMcpStatuses?: McpStatusMap;
+  /** Organization inventory is still being fetched and nothing is cached yet. */
+  inventoryLoading?: boolean;
   /** Installed organization extensions to render alongside runtime extensions. */
   installedPlugins?: CloudImportedPlugin[];
   /** Uninstall a skill by name. */
@@ -963,6 +966,7 @@ export function McpView(props: McpViewProps) {
           })
         }
         availableConnectMcpStatuses={props.availableConnectMcpStatuses ?? {}}
+        loading={props.inventoryLoading === true}
         installedPlugins={
           installedPlugins.filter((plugin) => {
             if (!showHidden && isOpenWorkExtensionHidden(`plugin:${plugin.pluginId}`)) return false;
@@ -1160,6 +1164,7 @@ function McpQuickConnectSection(props: {
   installedSkills?: SkillItem[];
   availableConnectMcpServers?: McpServerEntry[];
   availableConnectMcpStatuses: McpStatusMap;
+  loading: boolean;
   installedPlugins?: CloudImportedPlugin[];
   installedOrgMcpItems?: ExtensionItem[];
   organizationName?: string | null;
@@ -1342,7 +1347,13 @@ function McpQuickConnectSection(props: {
 
   return (
     <div className="space-y-6">
-      {grouped.length === 0 ? (
+      {grouped.length === 0 && props.loading ? (
+        <div className="grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3">
+          {[0, 1, 2].map((index) => (
+            <Skeleton key={index} className="h-[104px] rounded-xl" />
+          ))}
+        </div>
+      ) : grouped.length === 0 ? (
         <div className="rounded-xl border border-dashed border-dls-border px-5 py-10 text-center">
           <Unplug size={24} className="mx-auto mb-3 text-dls-secondary/30" />
           <div className="text-sm font-medium text-dls-secondary">No extensions found</div>

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -19,6 +19,10 @@ import { evalRelaunchDesktopApp } from "../../app/lib/desktop";
 import { Button } from "../../components/ui/button";
 import { t } from "../../i18n";
 import { useDenAuth } from "../domains/cloud/den-auth-provider";
+import {
+  clearCloudInventoryCache,
+  prefetchCloudInventory,
+} from "../domains/connections/cloud-inventory-cache";
 import { ForcedSigninPage } from "../domains/cloud/forced-signin-page";
 import { EnterpriseActivationGate } from "../domains/cloud/enterprise-activation-gate";
 import { OrgOnboardingPage } from "../domains/cloud/org-onboarding-page";
@@ -321,6 +325,19 @@ export function AppRoot() {
     appOpenedCaptured = true;
     initAnalytics();
     captureAnalyticsEvent("app_opened", {});
+  }, []);
+
+  // Fetch what the organization shares with this member up front. Settings
+  // mounts cold every time the extensions panel opens, so without this the
+  // readiness groups wait on a Den round-trip the app could have done already.
+  useEffect(() => {
+    prefetchCloudInventory();
+    const handleSessionChanged = () => {
+      clearCloudInventoryCache();
+      prefetchCloudInventory();
+    };
+    window.addEventListener(denSettingsChangedEvent, handleSessionChanged);
+    return () => window.removeEventListener(denSettingsChangedEvent, handleSessionChanged);
   }, []);
 
   return (

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -85,9 +85,12 @@ import { AppearanceView } from "@/react-app/domains/settings/pages/appearance-vi
 import { CloudAccountView } from "@/react-app/domains/settings/pages/cloud-account-view";
 import {
   EMPTY_CONNECT_CAPABILITY_INVENTORY,
-  listAssignedConnectCapabilities,
   type ConnectCapabilityInventory,
 } from "@/react-app/domains/session/surface/connect-capability-inventory";
+import {
+  loadConnectCapabilities,
+  readCachedConnectCapabilities,
+} from "@/react-app/domains/connections/cloud-inventory-cache";
 import { createOpaqueDiagnosticsScopeKey } from "@/react-app/domains/settings/pages/agent-context-diagnostics-section";
 import { CloudProvidersView } from "@/react-app/domains/settings/pages/cloud-providers-view";
 import { MemoryView } from "@/react-app/domains/settings/pages/memory-view";
@@ -766,37 +769,53 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     openLink: (url) => platform.openLink(url),
   });
   const cloudSession = useCloudSession();
-  const [connectCapabilities, setConnectCapabilities] = useState<ConnectCapabilityInventory>(
-    EMPTY_CONNECT_CAPABILITY_INVENTORY,
+  const connectScope = useMemo(
+    () => ({
+      baseUrl: cloudSession.baseUrl,
+      organizationId: cloudSession.activeOrganization?.id?.trim() ?? "",
+    }),
+    [cloudSession.activeOrganization?.id, cloudSession.baseUrl],
   );
+  const [connectCapabilities, setConnectCapabilities] = useState<ConnectCapabilityInventory>(
+    () => readCachedConnectCapabilities(connectScope) ?? EMPTY_CONNECT_CAPABILITY_INVENTORY,
+  );
+  const [connectCapabilitiesLoading, setConnectCapabilitiesLoading] = useState(false);
   const connectCapabilitiesRequestRef = useRef(0);
-  const refreshConnectCapabilities = useCallback(async () => {
+  const refreshConnectCapabilities = useCallback(async (options?: { force?: boolean }) => {
     const requestId = connectCapabilitiesRequestRef.current + 1;
     connectCapabilitiesRequestRef.current = requestId;
-    const organizationId = cloudSession.activeOrganization?.id?.trim() ?? "";
-    if (!cloudSession.isSignedIn || !organizationId) {
+    if (!cloudSession.isSignedIn || !connectScope.organizationId) {
       setConnectCapabilities(EMPTY_CONNECT_CAPABILITY_INVENTORY);
+      setConnectCapabilitiesLoading(false);
       return;
     }
+    // Paint what the app already fetched, then revalidate behind it.
+    const cached = readCachedConnectCapabilities(connectScope);
+    if (cached) setConnectCapabilities(cached);
+    setConnectCapabilitiesLoading(!cached);
     try {
-      const inventory = await listAssignedConnectCapabilities({
+      const inventory = await loadConnectCapabilities({
         client: cloudSession.client,
-        organizationId,
+        scope: connectScope,
+        maxAgeMs: options?.force ? 0 : undefined,
       });
       if (connectCapabilitiesRequestRef.current === requestId) {
         setConnectCapabilities(inventory);
       }
     } catch {
-      if (connectCapabilitiesRequestRef.current === requestId) {
+      if (connectCapabilitiesRequestRef.current === requestId && !cached) {
         setConnectCapabilities(EMPTY_CONNECT_CAPABILITY_INVENTORY);
       }
+    } finally {
+      if (connectCapabilitiesRequestRef.current === requestId) setConnectCapabilitiesLoading(false);
     }
-  }, [cloudSession.activeOrganization?.id, cloudSession.client, cloudSession.isSignedIn]);
+  }, [cloudSession.client, cloudSession.isSignedIn, connectScope]);
 
+  // Not gated on the Extensions tab: the inventory should be warm before the
+  // user gets there, and the fetch is deduped by the shared cloud cache.
   useEffect(() => {
-    if (route.tab !== "extensions") return;
     void refreshConnectCapabilities();
-  }, [refreshConnectCapabilities, route.tab]);
+  }, [refreshConnectCapabilities]);
 
   const hasOpenWorkCloudProvider = useMemo(
     () =>
@@ -2289,7 +2308,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
               void extensionsStore.refreshPlugins();
               void extensionsStore.refreshCloudOrgMarketplaces({ force: true });
               void orgMcpConnections.refresh();
-              void refreshConnectCapabilities();
+              void refreshConnectCapabilities({ force: true });
             }}
             mcpView={({ initialFilter, onFilterChange, detailId, onDetailIdChange }) => (
               <McpView
@@ -2338,6 +2357,7 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                   ),
                 )}
                 availableConnectMcpStatuses={connectCapabilities.mcpStatuses}
+                inventoryLoading={connectCapabilitiesLoading || (orgMcpConnections.loading && !orgMcpConnections.loaded)}
                 installedPlugins={extensionItems.installedCloudPlugins}
                 installedOrgMcpItems={installedOrgMcpConnectionItems}
                 uninstallSkill={(name) => { void extensionsStore.uninstallSkill(name); }}

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -1845,10 +1845,10 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
     }),
     [connectionsSnapshot.mcpServers, enablementContext, extensionController, extensionsSnapshot, extensionsStore, orgMcpConnections.connections, quickConnectCatalog],
   );
-  const installedOrgMcpConnectionItems = useMemo(
-    () => extensionItems.orgMcpConnectionItems.filter((item) => item.installState === "installed"),
-    [extensionItems.orgMcpConnectionItems],
-  );
+  // Every connection the organization provisioned for this member, connected
+  // or not: one that still needs the member's sign-in is the whole reason the
+  // "Needs your attention" group exists, so it must not be filtered out here.
+  const orgMcpConnectionItems = extensionItems.orgMcpConnectionItems;
   const organizationConnectionsProbe = resolveOrganizationConnectionsProbe({
     signedIn: cloudSession.isSignedIn,
     activeOrganizationId: cloudSession.activeOrganization?.id,
@@ -2352,14 +2352,14 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                   ),
                 ]}
                 availableConnectMcpServers={connectCapabilities.mcpServers.filter(
-                  (entry) => !installedOrgMcpConnectionItems.some((item) =>
+                  (entry) => !orgMcpConnectionItems.some((item) =>
                     item.name.localeCompare(entry.name, undefined, { sensitivity: "accent" }) === 0
                   ),
                 )}
                 availableConnectMcpStatuses={connectCapabilities.mcpStatuses}
                 inventoryLoading={connectCapabilitiesLoading || (orgMcpConnections.loading && !orgMcpConnections.loaded)}
                 installedPlugins={extensionItems.installedCloudPlugins}
-                installedOrgMcpItems={installedOrgMcpConnectionItems}
+                orgMcpItems={orgMcpConnectionItems}
                 uninstallSkill={(name) => { void extensionsStore.uninstallSkill(name); }}
                 removeCloudPlugin={(pluginId) => { void extensionsStore.removeCloudOrgPlugin(pluginId); }}
                 orgMcpDisconnectingId={orgMcpConnections.disconnectingId}

--- a/apps/app/tests/cloud-inventory-cache.test.ts
+++ b/apps/app/tests/cloud-inventory-cache.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, test } from "bun:test";
+
+import type { DenExternalMcpConnection } from "../src/app/lib/den";
+import {
+  clearCloudInventoryCache,
+  loadOrgMcpConnections,
+  readCachedOrgMcpConnections,
+  type OrgMcpConnectionClient,
+} from "../src/react-app/domains/connections/cloud-inventory-cache";
+
+const scope = { baseUrl: "https://den.example", organizationId: "org_1" };
+
+function connection(id: string): DenExternalMcpConnection {
+  return {
+    id,
+    organizationId: scope.organizationId,
+    name: id,
+    url: `https://${id}.example/mcp`,
+    credentialMode: "per_member",
+    connected: true,
+    connectedForMe: true,
+    status: "active",
+  };
+}
+
+function countingClient(result: DenExternalMcpConnection[]) {
+  let calls = 0;
+  const client: OrgMcpConnectionClient = {
+    listMcpConnections: async () => {
+      calls += 1;
+      return result;
+    },
+  };
+  return { client, calls: () => calls };
+}
+
+describe("cloud inventory cache", () => {
+  beforeEach(() => {
+    clearCloudInventoryCache();
+  });
+
+  test("serves a fresh answer without going back to Den", async () => {
+    const { client, calls } = countingClient([connection("notion")]);
+
+    await loadOrgMcpConnections({ client, scope });
+    await loadOrgMcpConnections({ client, scope });
+
+    expect(calls()).toBe(1);
+    expect(readCachedOrgMcpConnections(scope)?.map((entry) => entry.id)).toEqual(["notion"]);
+  });
+
+  test("shares one request between callers that ask at the same time", async () => {
+    const { client, calls } = countingClient([connection("linear")]);
+
+    await Promise.all([
+      loadOrgMcpConnections({ client, scope }),
+      loadOrgMcpConnections({ client, scope }),
+    ]);
+
+    expect(calls()).toBe(1);
+  });
+
+  test("refetches when the caller asks for a fresher answer", async () => {
+    const { client, calls } = countingClient([connection("notion")]);
+
+    await loadOrgMcpConnections({ client, scope });
+    await loadOrgMcpConnections({ client, scope, maxAgeMs: 0 });
+
+    expect(calls()).toBe(2);
+  });
+
+  test("keeps nothing for a different organization", async () => {
+    const { client } = countingClient([connection("notion")]);
+
+    await loadOrgMcpConnections({ client, scope });
+
+    expect(readCachedOrgMcpConnections({ ...scope, organizationId: "org_2" })).toBeNull();
+  });
+
+  test("keeps the last good answer when a refresh fails", async () => {
+    const { client } = countingClient([connection("notion")]);
+    await loadOrgMcpConnections({ client, scope });
+
+    const failing: OrgMcpConnectionClient = {
+      listMcpConnections: async () => {
+        throw new Error("den is down");
+      },
+    };
+    await expect(loadOrgMcpConnections({ client: failing, scope, maxAgeMs: 0 })).rejects.toThrow("den is down");
+
+    expect(readCachedOrgMcpConnections(scope)?.map((entry) => entry.id)).toEqual(["notion"]);
+  });
+});


### PR DESCRIPTION
## What changed

Two complaints about the Extensions inventory: "Ready to use" takes far too long to show connected things, and there is no way to see the list densely.

### 1. The organization inventory is prefetched and cached

The slow part was never rendering — it was two Den fan-outs that only started *after* Settings mounted:

- `listAssignedConnectCapabilities` (list marketplaces → resolve every marketplace → resolve every plugin) was gated on `route.tab === "extensions"` and kept in component state with no cache.
- `listMcpConnections` refetched from scratch on every `useOrgMcpConnections` mount.

Settings remounts every single time the extensions side panel opens, so both ran again on every visit, and the readiness groups stayed empty until they finished. The session composer and the new-task composer each carried their own copy of the same 25-line promise cache for the first one.

Now there is one module-scoped cache (`cloud-inventory-cache.ts`) that all four callers share:

- **Warm at app start.** `AppRoot` prefetches both as soon as the app opens and again whenever the Den session changes, so the fetch overlaps with everything else the app does at startup instead of with the user waiting on the Extensions screen.
- **Paint first, revalidate behind.** Settings seeds its state from the cached inventory, so the "Ready to use" group renders on the first frame; the refresh runs behind it. Same for the org MCP connection list.
- **One request per scope.** Concurrent callers share the in-flight promise, a fresh answer (under 60s) is served without a round-trip, and Refresh forces a real fetch.
- **A failed refresh keeps the last good answer** instead of blanking the list.
- The two duplicate composer caches are deleted in favor of `loadSessionConnectCapabilities()`.

Also fixed: while the first fetch is genuinely in flight, the inventory used to say **"No extensions found"**. It now shows skeletons.

### 2. List view

A card/list toggle sits next to the filters and the choice is remembered (`openwork.extensions.layout`). Rather than a second component, `ExtensionCard` grew a `layout` prop and was split into shared `ExtensionIcon` / `ExtensionBadges` / action pieces, so readiness, badges, and next actions can never drift between the two layouts.

## Tests

- `pnpm exec tsc --noEmit -p apps/app/tsconfig.json` → clean.
- `bun test` in `apps/app` → **612 pass, 7 fail**. The 7 (artifact spreadsheet, `platformCapabilities` in Electron, OpenWork Models promo) fail identically on `origin/dev`, so they are pre-existing.
- New `tests/cloud-inventory-cache.test.ts` covers the behavior the fix depends on: a fresh answer skips Den, concurrent callers share one request, `maxAgeMs: 0` forces a refetch, a different organization is not served stale data, and a failed refresh keeps the last good answer.

## Proof

Driven through the running app with Playwright (Settings → Extensions).

Card view, with the new toggle at the right of the filter row:

![Card view](https://litter.catbox.moe/052oml.png)

List view — same rows, dense, with the meta and next action pulled to the right:

![List view](https://litter.catbox.moe/3g54hd.png)

After a full page reload the preference holds: `aria-pressed` is on `List view` and `localStorage["openwork.extensions.layout"] === "list"`.

The prefetch itself is not visible in these shots because this Vite-only run is not signed in to a Den organization; its behavior is covered by the cache tests above. Console errors during the run were `ERR_CONNECTION_REFUSED` on `127.0.0.1:4096/global/health` (no local OpenWork server in this setup) and are unrelated.

No fraimz run: this is the desktop Settings surface, validated directly against the running app as shown.
