### PR TITLE
fix(desktop): widen chain-repair budgets for slow networks

### DIFF
--- a/apps/desktop/electron/runtime-chain-repair.test.mjs
+++ b/apps/desktop/electron/runtime-chain-repair.test.mjs
@@ -95,6 +95,22 @@ function authorizedSocket() {
   return socket;
 }
 
+function hangingSocket() {
+  const socket = {
+    destroy() {},
+    setTimeout() {
+      return socket;
+    },
+    once() {
+      return socket;
+    },
+    off() {
+      return socket;
+    },
+  };
+  return socket;
+}
+
 test("repairs a leaf-only TLS chain from an AIA intermediate", async () => {
   await withTlsServer({ cert: leafPem, key: leafKey }, async (port) => {
     const userDataDir = await mkdtemp(path.join(tmpdir(), "openwork-chain-repair-"));
@@ -244,6 +260,34 @@ test("user NODE_EXTRA_CA_CERTS disables repair", async () => {
   assert.equal(fetchCalled, false);
   assert.equal(probeCalled, false);
   assert.equal(logged, true);
+});
+
+test("chain repair total timeout can be shortened by env", async () => {
+  const userDataDir = await mkdtemp(path.join(tmpdir(), "openwork-chain-repair-"));
+  const logs = [];
+  const startTime = Date.now();
+
+  const env = await resolveSystemCaEnv({
+    tlsModule: { getCACertificates: () => [] },
+    userDataDir,
+    parentEnv: { OPENWORK_CHAIN_REPAIR_TIMEOUT_MS: "1500" },
+    logInfo(message) {
+      logs.push(String(message));
+    },
+    loadPlatformCertificates: async () => [],
+    chainRepair: {
+      origins: ["https://localhost:443"],
+      fetchImpl: async () => {
+        throw new Error("timed-out chain repair should not fetch");
+      },
+      tlsConnectImpl: hangingSocket,
+      rootsProvider: () => [rootPem],
+    },
+  });
+
+  assert.deepEqual(env, {});
+  assert.ok(Date.now() - startTime < 5000);
+  assert.ok(logs.some((line) => line.includes("chain repair skipped: timed out")));
 });
 
 test("activation bootstrap origin parsing is strict", async () => {

--- a/apps/desktop/electron/runtime.mjs
+++ b/apps/desktop/electron/runtime.mjs
@@ -24,9 +24,9 @@ const OPENWORK_SERVER_PORT_RANGE_END = 51_000;
 const MAX_BOOTSTRAP_BYTES = 256 * 1024;
 const MAX_CHAIN_REPAIR_BODY_BYTES = 64 * 1024;
 const MAX_CHAIN_REPAIR_ORIGINS = 3;
-const CHAIN_REPAIR_TOTAL_TIMEOUT_MS = 6000;
-const CHAIN_REPAIR_SOCKET_TIMEOUT_MS = 4000;
-const CHAIN_REPAIR_FETCH_TIMEOUT_MS = 4000;
+const CHAIN_REPAIR_TOTAL_TIMEOUT_MS = 20000;
+const CHAIN_REPAIR_SOCKET_TIMEOUT_MS = 8000;
+const CHAIN_REPAIR_FETCH_TIMEOUT_MS = 8000;
 /** @type {Map<string, X509Certificate | null>} */
 const chainRepairRootCache = new Map();
 
@@ -883,6 +883,11 @@ async function repairIncompleteChains(options) {
   const fetchImpl = chainRepair.fetchImpl ?? globalThis.fetch;
   const tlsModule = options.tlsModule ?? tls;
   const tlsConnectImpl = chainRepair.tlsConnectImpl ?? tls.connect;
+  const totalTimeoutValue = Number(env.OPENWORK_CHAIN_REPAIR_TIMEOUT_MS);
+  const totalTimeoutMs =
+    Number.isFinite(totalTimeoutValue) && totalTimeoutValue >= 1000 && totalTimeoutValue <= 120000
+      ? totalTimeoutValue
+      : CHAIN_REPAIR_TOTAL_TIMEOUT_MS;
   const rootsProvider = chainRepair.rootsProvider ?? (() => {
     if (typeof tlsModule?.getCACertificates !== "function") return [];
     const roots = tlsModule.getCACertificates("default");
@@ -955,7 +960,7 @@ async function repairIncompleteChains(options) {
 
   let timeoutId;
   const timeout = new Promise((resolve) => {
-    timeoutId = setTimeout(() => resolve({ pems: [], timedOut: true }), CHAIN_REPAIR_TOTAL_TIMEOUT_MS);
+    timeoutId = setTimeout(() => resolve({ pems: [], timedOut: true }), totalTimeoutMs);
     timeoutId.unref?.();
   });
   try {

--- a/packages/docs/start-here/certificate-trust-and-proxies.mdx
+++ b/packages/docs/start-here/certificate-trust-and-proxies.mdx
@@ -28,7 +28,7 @@ The desktop also starts the embedded OpenWork server plus local runtimes and sid
 
 #### Automatic chain repair for the activated organization server
 
-At startup, the desktop checks the activated organization server for a leaf-only TLS chain. If the leaf certificate points to a missing intermediate through AIA, OpenWork fetches that intermediate, verifies the leaf signature, and confirms the intermediate chains to bundled public roots before adding it to the generated `system-ca-bundle.pem`. It refuses private or corporate roots and any non-leaf-only TLS failure. Set `OPENWORK_DISABLE_CHAIN_REPAIR=1` to turn this resilience behavior off. The server should still be fixed to serve its full chain; diagnostics continue to report what the server actually sends.
+At startup, the desktop checks the activated organization server for a leaf-only TLS chain. If the leaf certificate points to a missing intermediate through AIA, OpenWork fetches that intermediate, verifies the leaf signature, and confirms the intermediate chains to bundled public roots before adding it to the generated `system-ca-bundle.pem`. It refuses private or corporate roots and any non-leaf-only TLS failure. The repair phase is bounded at 20 seconds by default and can be tuned with `OPENWORK_CHAIN_REPAIR_TIMEOUT_MS`. Set `OPENWORK_DISABLE_CHAIN_REPAIR=1` to turn this resilience behavior off. The server should still be fixed to serve its full chain; diagnostics continue to report what the server actually sends.
 
 ### 3. Den containers and Helm
 


### PR DESCRIPTION
Prod validation of #3218 on a slow Windows VM (Daytona sandbox) measured a single TLS handshake at ~3.1s — the 4s socket / 6s total budgets caused the repair to fail-open with ETIMEDOUT on exactly the slow enterprise networks the feature targets.

- Budgets: socket 4s→8s, fetch 4s→8s, total 6s→20s
- New `OPENWORK_CHAIN_REPAIR_TIMEOUT_MS` env override for the total budget (clamped 1s–120s)
- New deterministic test: hanging-socket stub + 1.5s override → fail-open under 5s with the timed-out log

Tests: `pnpm --dir apps/desktop test` → 175 tests, 174 pass, 1 pre-existing skip, 0 fail (re-verified by orchestrator). Typecheck clean.