### PR TITLE
fix(den-web): drop the member Available resources summary strip

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/member-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/member-dashboard-screen.tsx
@@ -4,12 +4,7 @@ import { useQuery } from "@tanstack/react-query";
 import {
   CheckCircle2,
   ChevronRight,
-  Cpu,
-  Puzzle,
-  Sparkles,
-  Store,
   Users,
-  type LucideIcon,
 } from "lucide-react";
 import { getErrorMessage, requestJson } from "../../_lib/den-flow";
 import { formatRoleLabel } from "../../_lib/den-org";
@@ -68,46 +63,6 @@ function getErrorText(error: unknown) {
   return error instanceof Error ? error.message : "Something went wrong.";
 }
 
-function SummaryCard({
-  icon: Icon,
-  title,
-  value,
-  detail,
-  tone,
-}: {
-  icon: LucideIcon;
-  title: string;
-  value: string;
-  detail: string;
-  tone: "blue" | "emerald" | "violet" | "amber";
-}) {
-  const toneClass = {
-    blue: "bg-blue-50 text-blue-700",
-    emerald: "bg-emerald-50 text-emerald-700",
-    violet: "bg-violet-50 text-violet-700",
-    amber: "bg-amber-50 text-amber-700",
-  }[tone];
-
-  return (
-    <section
-      className="rounded-2xl border border-gray-100 bg-white px-4 py-3.5"
-      data-resource={title}
-      data-testid="member-resource-card"
-    >
-      <div className="flex items-start gap-3">
-        <div className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-[10px] ${toneClass}`}>
-          <Icon className="h-5 w-5" aria-hidden="true" />
-        </div>
-        <div className="min-w-0">
-          <p className="text-[13px] font-medium text-gray-500">{title}</p>
-          <p className="mt-0.5 text-[20px] font-semibold tracking-[-0.03em] text-gray-950">{value}</p>
-          <p className="mt-0.5 text-[12px] leading-5 text-gray-500">{detail}</p>
-        </div>
-      </div>
-    </section>
-  );
-}
-
 function ErrorNotice({ children }: { children: React.ReactNode }) {
   return (
     <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-[13px] leading-5 text-amber-800">
@@ -136,11 +91,6 @@ export function MemberDashboardScreen() {
   });
 
   const customProviders = llmProviders.filter((provider) => provider.source !== "openwork");
-  const openWorkProviders = llmProviders.filter((provider) => provider.source === "openwork");
-  const visiblePluginParts = plugins.reduce(
-    (count, plugin) => count + plugin.skills.length + plugin.hooks.length + plugin.mcps.length + plugin.agents.length + plugin.commands.length,
-    0,
-  );
 
   const currentMember = orgContext?.currentMember;
   const teamNames = orgContext?.currentMemberTeams.map((team) => team.name).sort((a, b) => a.localeCompare(b)) ?? [];
@@ -182,43 +132,6 @@ export function MemberDashboardScreen() {
           <OrganizationDownloadCard organizationId={activeOrg.id} organizationName={activeOrg.name} />
         </div>
       ) : null}
-
-      <section className="mt-5" aria-labelledby="member-resources-heading" data-testid="member-resource-overview">
-        <div className="mb-3">
-          <h2 id="member-resources-heading" className="text-[16px] font-semibold tracking-[-0.02em] text-gray-950">Available resources</h2>
-          <p className="mt-0.5 text-[13px] text-gray-500">Assigned directly to you, your teams, or everyone in the workspace.</p>
-        </div>
-        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-          <SummaryCard
-            icon={Sparkles}
-            title="OpenWork Models"
-            value={inferenceLabel}
-            detail={inference?.enabled ? `${openWorkProviders.length} model key group${openWorkProviders.length === 1 ? "" : "s"} visible to you.` : "Ask an admin to enable org-provided models."}
-            tone={inference?.enabled ? "emerald" : "amber"}
-          />
-          <SummaryCard
-            icon={Cpu}
-            title="Custom LLM Providers"
-            value={providersBusy ? "Loading" : `${customProviders.length}`}
-            detail="Provider credentials and models your role or teams can use."
-            tone="blue"
-          />
-          <SummaryCard
-            icon={Store}
-            title="Marketplaces"
-            value={marketplacesLoading ? "Loading" : `${marketplaces.length}`}
-            detail="Plugin collections assigned to you or everyone in your org."
-            tone="amber"
-          />
-          <SummaryCard
-            icon={Puzzle}
-            title="Plugins"
-            value={pluginsLoading ? "Loading" : `${plugins.length}`}
-            detail={`${visiblePluginParts} skill, hook, MCP, agent, or command parts available.`}
-            tone="violet"
-          />
-        </div>
-      </section>
 
       <div className="mt-5 grid gap-5 lg:grid-cols-[1fr_1fr]">
         <section className="rounded-2xl border border-gray-100 bg-white p-5">

--- a/ee/apps/den-web/tests/dashboard-home-layout.test.ts
+++ b/ee/apps/den-web/tests/dashboard-home-layout.test.ts
@@ -27,16 +27,17 @@ describe("dashboard home layouts", () => {
 
     expect(overview).toContain("<OrganizationDownloadCard");
     expect(member).toContain("<OrganizationDownloadCard");
-    expect(downloadCard).toContain('data-testid="organization-download-card"');
-    expect(downloadCard).toContain('data-testid="organization-download-button"');
+    expect(downloadCard).toContain('data-testid="workspace-install-card"');
+    expect(downloadCard).toContain('data-testid="workspace-install-open"');
   });
 
-  test("uses a compact member resource overview backed by member-scoped data", () => {
+  test("member dashboard lists usable resources without a summary strip of empty counts", () => {
     const member = readDashboardComponent("member-dashboard-screen.tsx");
 
     expect(member).toContain('data-testid="member-dashboard"');
-    expect(member).toContain('data-testid="member-resource-overview"');
-    expect(member).toContain('data-testid="member-resource-card"');
+    expect(member).not.toContain('data-testid="member-resource-overview"');
+    expect(member).not.toContain('data-testid="member-resource-card"');
+    expect(member).not.toContain("Available resources");
     expect(member).toContain('useOrgLlmProviders(orgId, { scope: "usable" })');
     expect(member).toContain("useMarketplaces()");
     expect(member).toContain("usePlugins()");

--- a/evals/flows/den-ui-consistency.flow.mjs
+++ b/evals/flows/den-ui-consistency.flow.mjs
@@ -293,7 +293,7 @@ export default {
             await ensureSetup(ctx);
             await uiSignIn(ctx, ADMIN_EMAIL, ADMIN_PASSWORD);
             await navigateTo(ctx, "/dashboard");
-            await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"organization-download-card\"]'))", {
+            await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"workspace-install-card\"]'))", {
               timeoutMs: 30_000,
               label: "organization download card",
             });
@@ -301,7 +301,7 @@ export default {
           assert: async () => {
             await ctx.expectNoText("Download the app to unlock extensions");
             const actual = await ctx.eval(`(() => ({
-              downloadCard: Boolean(document.querySelector('[data-testid="organization-download-card"]')),
+              downloadCard: Boolean(document.querySelector('[data-testid="workspace-install-card"]')),
               downloadButton: Boolean(document.querySelector('[data-testid="organization-download-button"]')),
               promotion: document.body.innerText.includes('Download the app to unlock extensions'),
             }))()`);
@@ -381,16 +381,17 @@ export default {
               dashboard: Boolean(document.querySelector('[data-testid="member-dashboard"]')),
               overview: Boolean(document.querySelector('[data-testid="member-resource-overview"]')),
               cards: document.querySelectorAll('[data-testid="member-resource-card"]').length,
-              download: Boolean(document.querySelector('[data-testid="organization-download-card"]')),
+              availableResources: (document.body?.innerText ?? "").includes("Available resources"),
+              download: Boolean(document.querySelector('[data-testid="workspace-install-card"]')),
               adminCreatePlugin: [...document.querySelectorAll('button, a')].some((entry) => entry.textContent?.trim() === 'Create plugin'),
             }))()`);
-            witness(ctx, actual.dashboard && actual.overview && actual.cards >= 3, "Riley sees compact member-scoped resource cards", actual);
+            witness(ctx, actual.dashboard && !actual.overview && actual.cards === 0 && !actual.availableResources, "Riley's home lists providers and plugins without a summary strip of empty counts", actual);
             witness(ctx, actual.download && !actual.adminCreatePlugin, "The member retains the download action without admin creation controls", actual);
           },
           screenshot: {
             name: "compact-member-dashboard",
             requireText: ["Your workspace", "OpenWork Models", "Marketplaces", "Plugins"],
-            rejectText: ["Create plugin", "Something went wrong"],
+            rejectText: ["Available resources", "Create plugin", "Something went wrong"],
             hashIncludes: "/dashboard",
           },
         });

--- a/evals/flows/member-dashboard-no-resource-overview.flow.mjs
+++ b/evals/flows/member-dashboard-no-resource-overview.flow.mjs
@@ -1,0 +1,265 @@
+import { execFileSync } from "node:child_process";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "member-dashboard-no-resource-overview";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? "").trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MEMBER_EMAIL = "riley.no-resource-overview@acme.test";
+const MEMBER_PASSWORD = "OpenWorkDemo123!";
+
+const state = {
+  adminToken: "",
+  memberToken: "",
+  organizationId: "",
+};
+
+function sleep(ms) {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual: actual === undefined ? undefined : JSON.stringify(actual).slice(0, 1_200),
+  });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : `. Actual: ${JSON.stringify(actual).slice(0, 600)}`}`);
+}
+
+async function denFetch(path, options = {}) {
+  const authPath = path.startsWith("/api/auth/");
+  const response = await fetch(`${authPath ? DEN_WEB_URL : DEN_API_URL}${path}`, {
+    ...options,
+    headers: {
+      accept: "application/json",
+      origin: DEN_WEB_URL,
+      ...(options.body ? { "content-type": "application/json" } : {}),
+      ...(options.headers ?? {}),
+    },
+  });
+  const text = await response.text();
+  let body = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body };
+}
+
+function authHeaders(token) {
+  return { authorization: `Bearer ${token}` };
+}
+
+async function signInApi(email, password) {
+  const result = await denFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  return result.response.ok && typeof result.body?.token === "string" ? result.body.token : "";
+}
+
+function runMysql(sql) {
+  const container = process.env.OPENWORK_EVAL_DEN_MYSQL_CONTAINER?.trim() || "openwork-web-local-mysql";
+  execFileSync("docker", ["exec", container, "mysql", "-uroot", "-ppassword", "openwork_den", "-e", sql], { stdio: "ignore" });
+}
+
+async function ensureAccount(ctx, { email, name, password }) {
+  let token = await signInApi(email, password);
+  if (!token) {
+    const signUp = await denFetch("/api/auth/sign-up/email", {
+      method: "POST",
+      body: JSON.stringify({ email, name, password }),
+    });
+    witness(ctx, signUp.response.ok || [400, 409, 422].includes(signUp.response.status), `${name}'s account exists or was created`, {
+      status: signUp.response.status,
+      body: signUp.body,
+    });
+    runMysql(`UPDATE user SET email_verified = 1 WHERE email = '${email.replaceAll("'", "''")}';`);
+    token = await signInApi(email, password);
+  }
+  witness(ctx, token.length > 0, `${name} can sign in through Den`, { email });
+  return token;
+}
+
+async function ensureMember(ctx) {
+  if (state.adminToken && state.memberToken && state.organizationId) return;
+
+  state.adminToken = await ensureAccount(ctx, { email: ADMIN_EMAIL, name: "Alex Chen", password: ADMIN_PASSWORD });
+  const org = await denFetch("/v1/org", { headers: authHeaders(state.adminToken) });
+  witness(ctx, org.response.ok && typeof org.body?.organization?.id === "string", "Alex can load the active workspace", {
+    status: org.response.status,
+    organization: org.body?.organization,
+  });
+  state.organizationId = org.body.organization.id;
+
+  state.memberToken = await ensureAccount(ctx, { email: MEMBER_EMAIL, name: "Riley Member", password: MEMBER_PASSWORD });
+  let memberOrgs = await denFetch("/v1/me/orgs", { headers: authHeaders(state.memberToken) });
+  const alreadyMember = () => Array.isArray(memberOrgs.body?.orgs)
+    && memberOrgs.body.orgs.some((entry) => entry?.id === state.organizationId);
+  if (!alreadyMember()) {
+    const invite = await denFetch("/v1/invitations", {
+      method: "POST",
+      headers: authHeaders(state.adminToken),
+      body: JSON.stringify({ email: MEMBER_EMAIL, role: "member" }),
+    });
+    witness(ctx, invite.response.ok, "Alex can invite Riley to the active workspace", {
+      status: invite.response.status,
+      body: invite.body,
+    });
+    const accept = await denFetch("/v1/orgs/invitations/accept", {
+      method: "POST",
+      headers: authHeaders(state.memberToken),
+      body: JSON.stringify({ id: invite.body.inviteToken }),
+    });
+    witness(ctx, accept.response.ok && accept.body?.accepted === true, "Riley can accept the workspace invitation", {
+      status: accept.response.status,
+      body: accept.body,
+    });
+    memberOrgs = await denFetch("/v1/me/orgs", { headers: authHeaders(state.memberToken) });
+  }
+  witness(ctx, alreadyMember(), "Riley is an ordinary member of Alex's workspace", memberOrgs.body?.orgs);
+}
+
+async function navigateTo(ctx, path) {
+  const url = new URL(path, DEN_WEB_URL).toString();
+  await ctx.eval(`(() => { location.assign(${JSON.stringify(url)}); return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete'", { timeoutMs: 30_000, label: `load ${path}` });
+}
+
+async function clearSession(ctx) {
+  await navigateTo(ctx, "/");
+  await ctx.eval(`fetch('/api/auth/sign-out', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: '{}'
+  }).catch(() => null).then(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    return true;
+  })`, { awaitPromise: true });
+  if (ctx.client?.send) await ctx.client.send("Network.clearBrowserCookies", {});
+}
+
+async function clickExact(ctx, text, selector = "button, a") {
+  await ctx.waitFor(`(() => {
+    const element = [...document.querySelectorAll(${JSON.stringify(selector)})]
+      .find((entry) => (entry.textContent ?? '').replace(/\\s+/g, ' ').trim() === ${JSON.stringify(text)} && !entry.disabled);
+    element?.scrollIntoView({ block: 'center' });
+    element?.click();
+    return Boolean(element);
+  })()`, { timeoutMs: 20_000, label: `click ${text}` });
+}
+
+async function uiSignIn(ctx, email, password) {
+  await clearSession(ctx);
+  await navigateTo(ctx, "/");
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"email\"]'))", { timeoutMs: 30_000, label: "email-first sign in" });
+  await ctx.fill('input[type="email"]', email);
+  await clickExact(ctx, "Next", "button");
+  await ctx.waitFor("Boolean(document.querySelector('input[type=\"password\"]'))", { timeoutMs: 30_000, label: "password sign in step" });
+  await ctx.fill('input[type="password"]', password);
+  await clickExact(ctx, "Sign in", "button");
+  await ctx.waitFor("location.pathname.startsWith('/dashboard')", { timeoutMs: 45_000, label: "dashboard after sign in" });
+  await ctx.waitFor("Boolean(document.querySelector('nav'))", { timeoutMs: 30_000, label: "Den dashboard navigation" });
+  await sleep(700);
+}
+
+async function readMemberHome(ctx) {
+  return ctx.eval(`(() => {
+    const text = document.body?.innerText ?? "";
+    return {
+      dashboard: Boolean(document.querySelector('[data-testid="member-dashboard"]')),
+      overview: Boolean(document.querySelector('[data-testid="member-resource-overview"]')),
+      cards: document.querySelectorAll('[data-testid="member-resource-card"]').length,
+      availableResources: text.includes("Available resources"),
+      assignedDirectly: text.includes("Assigned directly to you"),
+      yourWorkspace: text.includes("Your workspace"),
+      llmProviders: text.includes("LLM providers"),
+      openWorkModels: text.includes("OpenWork Models"),
+      marketplaces: text.includes("Marketplaces"),
+      plugins: text.includes("Plugins"),
+    };
+  })()`);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "Member dashboard drops the empty Available resources summary strip",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"],
+  steps: [
+    {
+      name: "Member home has no Available resources strip",
+      run: async (ctx) => {
+        await ctx.prove("Riley's member home opens on the real sections with no Available resources strip", {
+          voiceover: vo[0],
+          action: async () => {
+            await ensureMember(ctx);
+            await uiSignIn(ctx, MEMBER_EMAIL, MEMBER_PASSWORD);
+            await navigateTo(ctx, "/dashboard");
+            await ctx.waitFor("Boolean(document.querySelector('[data-testid=\"member-dashboard\"]'))", {
+              timeoutMs: 30_000,
+              label: "member dashboard",
+            });
+          },
+          assert: async () => {
+            const actual = await readMemberHome(ctx);
+            witness(ctx, actual.dashboard === true, "Riley lands on the member dashboard", actual);
+            witness(ctx, actual.overview === false && actual.cards === 0 && actual.availableResources === false && actual.assignedDirectly === false, "The Available resources summary strip is gone", actual);
+            witness(ctx, actual.yourWorkspace === true && actual.llmProviders === true && actual.openWorkModels === true && actual.marketplaces === true && actual.plugins === true, "The real sections are still on the page", actual);
+          },
+          screenshot: {
+            name: "member-home-no-overview",
+            requireText: ["Your workspace", "LLM providers", "OpenWork Models", "Marketplaces", "Plugins"],
+            rejectText: ["Available resources", "Assigned directly to you", "Something went wrong"],
+            hashIncludes: "/dashboard",
+          },
+        });
+      },
+    },
+    {
+      name: "Empty states live in the real sections",
+      run: async (ctx) => {
+        await ctx.prove("Empty states stay inside LLM providers and the other real sections", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.eval(`(() => {
+              const heading = [...document.querySelectorAll('h2')].find((entry) => entry.textContent?.trim() === 'LLM providers');
+              heading?.scrollIntoView({ block: 'center' });
+              return Boolean(heading);
+            })()`);
+            await sleep(400);
+          },
+          assert: async () => {
+            const actual = await ctx.eval(`(() => {
+              const text = document.body?.innerText ?? "";
+              return {
+                overview: Boolean(document.querySelector('[data-testid="member-resource-overview"]')),
+                availableResources: text.includes("Available resources"),
+                disabledCard: [...document.querySelectorAll('[data-testid="member-resource-card"]')].some((card) => (card.textContent ?? "").includes("Disabled")),
+                llmEmpty: text.includes("No custom providers are available to you yet.") || text.includes("available"),
+                openWorkModels: text.includes("OpenWork Models"),
+                marketplaces: text.includes("Marketplaces"),
+                plugins: text.includes("Plugins"),
+              };
+            })()`);
+            witness(ctx, actual.overview === false && actual.availableResources === false && actual.disabledCard === false, "No Disabled / 0 summary cards remain on the page", actual);
+            witness(ctx, actual.openWorkModels === true && actual.marketplaces === true && actual.plugins === true, "The real sections still describe what Riley can use", actual);
+          },
+          screenshot: {
+            name: "member-sections-without-summary",
+            requireText: ["LLM providers", "OpenWork Models"],
+            rejectText: ["Available resources", "Assigned directly to you", "Something went wrong"],
+            hashIncludes: "/dashboard",
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/member-dashboard-no-resource-overview.md
+++ b/evals/voiceovers/member-dashboard-no-resource-overview.md
@@ -1,0 +1,7 @@
+# member-dashboard-no-resource-overview — Member dashboard drops the empty summary strip
+
+A non-admin member opens their workspace dashboard. The old “Available resources” cards led with Disabled / 0 and duplicated the sections below, so for a new member the first thing they saw was a wall of emptiness.
+
+1. Riley signs in as a member and lands on Your workspace. The page goes straight into the real sections — LLM providers, OpenWork Models, Marketplaces, Plugins — with no Available resources summary strip above them.
+
+2. Those sections still show what she can use (including empty states when nothing is assigned yet). The page no longer opens with a row of Disabled / 0 cards that say the same thing twice.


### PR DESCRIPTION
## Summary
- New members opening **Your workspace** saw an “Available resources” strip of four cards leading with Disabled / 0, which only repeated the real sections below.
- Remove that overview so the page goes straight into LLM providers, OpenWork Models, Marketplaces, and Plugins.
- Update the layout contract test and the `den-ui-consistency` member-home frame to assert the strip is gone.

## Test plan
- [x] `bun test tests/dashboard-home-layout.test.ts` (3 pass)
- [ ] `pnpm fraimz --flow member-dashboard-no-resource-overview` (blocked locally: Docker/OrbStack down, Den auth returns 500 without MySQL)
- [ ] Sign in as a non-admin member and confirm the dashboard no longer shows “Available resources”

## Notes
Fraimz voiceover + flow are in the PR (`evals/voiceovers/member-dashboard-no-resource-overview.md`). Re-run once Den MySQL is up:

```bash
pnpm fraimz --stack den --flow member-dashboard-no-resource-overview --pr
```

Made with [Cursor](https://cursor.com)