### PR TITLE
fix(app): collapse account status into a single Ready line

### DIFF
--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -1740,6 +1740,7 @@ export default {
   "status.openwork_ready": "OpenWork Ready",
   "status.providers_connected_one": "{count} provider connected",
   "status.providers_connected_other": "{count} providers connected",
+  "status.ready": "Ready",
   "status.ready_for_tasks": "Ready for new tasks",
   "status.reloading_config": "Reloading OpenCode config",
   "status.running": "Running",

--- a/apps/app/src/react-app/domains/session/sidebar/account-status-lines.ts
+++ b/apps/app/src/react-app/domains/session/sidebar/account-status-lines.ts
@@ -1,0 +1,97 @@
+import { t } from "@/i18n";
+import type { OpenWorkConnectStatus } from "../../connections/openwork-connect-status";
+
+export type StatusDotVariant = "connected" | "loading" | "partial" | "disconnected";
+
+export type RuntimeStatus = {
+  variant: StatusDotVariant;
+  label: string;
+  detail: string | null;
+};
+
+export type AccountStatusLine = {
+  testId?: string;
+  variant: StatusDotVariant;
+  label: string;
+  detail: string | null;
+};
+
+export function connectDotVariant(status: OpenWorkConnectStatus): StatusDotVariant {
+  if (status.state === "ready") return "connected";
+  if (status.state === "checking") return "loading";
+  return "disconnected";
+}
+
+/**
+ * What the account menu shows for live status.
+ *
+ * Everyone gets one summary line ("Ready", or the one problem that matters).
+ * Developer mode keeps the old granular breakdown so Connect and the workspace
+ * can be inspected separately.
+ */
+export function resolveAccountStatusLines(input: {
+  runtime: RuntimeStatus | null;
+  connect: OpenWorkConnectStatus | null;
+  developerMode: boolean;
+}): AccountStatusLine[] {
+  const { runtime, connect, developerMode } = input;
+  if (!runtime && !connect) return [];
+
+  if (developerMode) {
+    const lines: AccountStatusLine[] = [];
+    if (runtime) {
+      lines.push({
+        variant: runtime.variant,
+        label: runtime.label,
+        detail: runtime.detail,
+      });
+    }
+    if (connect) {
+      lines.push({
+        testId: "openwork-connect-status",
+        variant: connectDotVariant(connect),
+        label: `OpenWork Connect: ${connect.label}`,
+        detail: connect.description,
+      });
+    }
+    return lines;
+  }
+
+  if (connect?.state === "needs_attention") {
+    return [{
+      testId: "openwork-connect-status",
+      variant: "disconnected",
+      label: connect.label,
+      detail: connect.description,
+    }];
+  }
+
+  if (runtime && runtime.variant !== "connected") {
+    return [{
+      variant: runtime.variant,
+      label: runtime.label,
+      detail: runtime.detail,
+    }];
+  }
+
+  // Workspace is fine; Connect is still checking in the background — do not
+  // surface that as a second status for non-developers.
+  if (runtime?.variant === "connected" || connect?.state === "ready" || connect?.state === "checking") {
+    return [{
+      variant: "connected",
+      label: t("status.ready"),
+      detail: null,
+    }];
+  }
+
+  if (connect) {
+    return [{
+      testId: "openwork-connect-status",
+      variant: connectDotVariant(connect),
+      label: connect.label,
+      detail: connect.description,
+    }];
+  }
+
+  return [];
+}

--- a/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/account-status-menu.tsx
@@ -36,7 +36,6 @@ import {
 import {
   openWorkConnectAttentionTitle,
   resolveOpenWorkConnectStatus,
-  type OpenWorkConnectStatus,
 } from "../../connections/openwork-connect-status";
 import type { SessionCloudMcpMaintenanceState } from "../../connections/use-session-mcp-maintenance";
 import {
@@ -47,12 +46,15 @@ import {
   openWorkModelsPromoChangedEvent,
   useOpenWorkModelsPromoEligibility,
 } from "../../cloud/openwork-models-promo";
+import {
+  resolveAccountStatusLines,
+  type RuntimeStatus,
+  type StatusDotVariant,
+} from "./account-status-lines";
 
 const DOCS_URL = "https://openworklabs.com/docs";
 const BOOT_STARTED_AT = Date.now();
 const INITIALIZING_MS = 15_000;
-
-type StatusDotVariant = "connected" | "loading" | "partial" | "disconnected";
 
 function StatusDot({ variant }: { variant: StatusDotVariant }) {
   return (
@@ -72,12 +74,6 @@ function StatusDot({ variant }: { variant: StatusDotVariant }) {
     </span>
   );
 }
-
-type RuntimeStatus = {
-  variant: StatusDotVariant;
-  label: string;
-  detail: string | null;
-};
 
 type RuntimeStatusInput = {
   clientConnected: boolean;
@@ -117,12 +113,6 @@ function resolveRuntimeStatus(input: RuntimeStatusInput): RuntimeStatus {
     label: t("status.disconnected_label"),
     detail: t("status.disconnected_hint"),
   };
-}
-
-function connectDotVariant(status: OpenWorkConnectStatus): StatusDotVariant {
-  if (status.state === "ready") return "connected";
-  if (status.state === "checking") return "loading";
-  return "disconnected";
 }
 
 function accountInitials(name: string | null, email: string) {
@@ -253,7 +243,19 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
     props.openWorkConnectState,
   );
   const connectNeedsAttention = connectStatus?.state === "needs_attention";
-  const showStatus = shellConfig.statusBar && (runtimeStatus !== null || connectStatus !== null);
+  const statusLines = shellConfig.statusBar
+    ? resolveAccountStatusLines({
+      runtime: runtimeStatus,
+      connect: connectStatus,
+      developerMode: props.developerMode,
+    })
+    : [];
+  const showStatus = statusLines.length > 0 || (
+    shellConfig.statusBar && props.showConnectionStatus
+  );
+  const statusTitle = connectNeedsAttention && connectStatus
+    ? openWorkConnectAttentionTitle(connectStatus.description)
+    : statusLines.map((line) => line.label).join(" · ") || runtimeStatus?.label;
 
   const openSignIn = () => {
     platform.openLink(buildDenAuthUrl(readDenBootstrapConfig().baseUrl, "sign-up"));
@@ -283,11 +285,7 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
             /* ps-1.5 puts the 24px avatar 12px from the edge, so the name lands on the sidebar label lane. */
             className="flex w-full items-center gap-2 rounded-lg ps-1.5 pe-2 py-1.5 text-left transition-colors hover:bg-sidebar-accent"
             aria-label={signedIn ? `${user.email} — account and status` : "Account and status"}
-            title={connectNeedsAttention
-              ? openWorkConnectAttentionTitle(connectStatus.description)
-              : connectStatus
-                ? `${runtimeStatus ? `${runtimeStatus.label} · ` : ""}OpenWork Connect: ${connectStatus.label}`
-                : runtimeStatus?.label}
+            title={statusTitle}
           >
               {signedIn ? (
                 <span className="flex size-6 shrink-0 items-center justify-center rounded-full bg-primary/15 text-[10px] font-semibold text-primary">
@@ -322,36 +320,25 @@ export function AccountStatusMenu(props: AccountStatusMenuProps) {
 
         {showStatus ? (
           <div className="mx-1 mb-1 flex flex-col gap-2 rounded-lg bg-muted/50 p-2">
-            {runtimeStatus ? (
-              <div className="flex items-start gap-2">
+            {statusLines.map((line) => (
+              <div
+                key={line.testId ?? line.label}
+                data-testid={line.testId}
+                className="flex items-start gap-2"
+              >
                 <span className="mt-1">
-                  <StatusDot variant={runtimeStatus.variant} />
+                  <StatusDot variant={line.variant} />
                 </span>
                 <div className="min-w-0">
-                  <div className="text-[11.5px] font-medium text-foreground">{runtimeStatus.label}</div>
-                  {runtimeStatus.detail ? (
+                  <div className="text-[11.5px] font-medium text-foreground">{line.label}</div>
+                  {line.detail ? (
                     <div className="text-[10.5px] leading-tight text-muted-foreground">
-                      {runtimeStatus.detail}
+                      {line.detail}
                     </div>
                   ) : null}
                 </div>
               </div>
-            ) : null}
-            {connectStatus ? (
-              <div data-testid="openwork-connect-status" className="flex items-start gap-2">
-                <span className="mt-1">
-                  <StatusDot variant={connectDotVariant(connectStatus)} />
-                </span>
-                <div className="min-w-0">
-                  <div className="text-[11.5px] font-medium text-foreground">
-                    {`OpenWork Connect: ${connectStatus.label}`}
-                  </div>
-                  <div className="text-[10.5px] leading-tight text-muted-foreground">
-                    {connectStatus.description}
-                  </div>
-                </div>
-              </div>
-            ) : null}
+            ))}
             {props.showConnectionStatus ? (
               <div className="text-[10.5px] leading-tight text-muted-foreground">
                 {t("account.providers_connected", { count: props.providerConnectedIds.length })}

--- a/apps/app/tests/account-status-lines.test.ts
+++ b/apps/app/tests/account-status-lines.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, test } from "bun:test";
+
+import { resolveAccountStatusLines } from "../src/react-app/domains/session/sidebar/account-status-lines";
+import type { OpenWorkConnectStatus } from "../src/react-app/domains/connections/openwork-connect-status";
+
+const readyRuntime = {
+  variant: "connected" as const,
+  label: "Ready for new tasks",
+  detail: null,
+};
+
+const readyConnect: OpenWorkConnectStatus = {
+  state: "ready",
+  label: "Ready",
+  description: "Connected service tools are available.",
+};
+
+describe("account status lines", () => {
+  test("collapses a healthy workspace and Connect into a single Ready line", () => {
+    expect(resolveAccountStatusLines({
+      runtime: readyRuntime,
+      connect: readyConnect,
+      developerMode: false,
+    })).toEqual([{
+      variant: "connected",
+      label: "Ready",
+      detail: null,
+    }]);
+  });
+
+  test("keeps Connect background checks out of the non-developer summary", () => {
+    expect(resolveAccountStatusLines({
+      runtime: readyRuntime,
+      connect: {
+        state: "checking",
+        label: "Checking",
+        description: "Checking connected service tools in the background.",
+      },
+      developerMode: false,
+    })).toEqual([{
+      variant: "connected",
+      label: "Ready",
+      detail: null,
+    }]);
+  });
+
+  test("surfaces Connect attention without developer mode", () => {
+    expect(resolveAccountStatusLines({
+      runtime: readyRuntime,
+      connect: {
+        state: "needs_attention",
+        label: "Needs attention",
+        description: "Connected service tools could not be verified.",
+      },
+      developerMode: false,
+    })).toEqual([{
+      testId: "openwork-connect-status",
+      variant: "disconnected",
+      label: "Needs attention",
+      detail: "Connected service tools could not be verified.",
+    }]);
+  });
+
+  test("keeps the granular breakdown when developer mode is on", () => {
+    expect(resolveAccountStatusLines({
+      runtime: readyRuntime,
+      connect: readyConnect,
+      developerMode: true,
+    })).toEqual([
+      {
+        variant: "connected",
+        label: "Ready for new tasks",
+        detail: null,
+      },
+      {
+        testId: "openwork-connect-status",
+        variant: "connected",
+        label: "OpenWork Connect: Ready",
+        detail: "Connected service tools are available.",
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- When the workspace and OpenWork Connect are both healthy, the account menu shows one **Ready** line instead of two green statuses.
- Developer mode keeps the granular breakdown (`Ready for new tasks` + `OpenWork Connect: …`).
- Connect attention / workspace problems still surface for everyone; background Connect checks stay hidden when developer mode is off.

## Test plan
- [x] `bun test tests/account-status-lines.test.ts tests/openwork-connect-status.test.ts`
- [x] `tsc --noEmit` in `apps/app`
- [ ] Open the account menu with developer mode off → single Ready
- [ ] Turn developer mode on → both status rows return
- [ ] Force a Connect failure → Needs attention still shows without developer mode


Made with [Cursor](https://cursor.com)