### PR TITLE
feat(den-api): admin tool to grant and revoke the per-org Cloud capability

### DIFF
--- a/ee/apps/den-api/src/mcp/admin-tools.ts
+++ b/ee/apps/den-api/src/mcp/admin-tools.ts
@@ -1,9 +1,11 @@
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js"
-import { eq, sql, type SQL } from "@openwork-ee/den-db/drizzle"
+import { eq, or, sql, type SQL } from "@openwork-ee/den-db/drizzle"
 import { OrganizationTable } from "@openwork-ee/den-db/schema"
 import { z } from "zod"
+import { organizationCloudEnabled } from "../capability-sources/cloud-rollout.js"
 import { db } from "../db.js"
 import { parseOrganizationPlan, type PlanTier } from "../entitlements.js"
+import { env } from "../env.js"
 import { normalizeOrganizationMetadata } from "../organization-limits.js"
 import { denApiAppVersion } from "../version.js"
 
@@ -21,7 +23,7 @@ import { denApiAppVersion } from "../version.js"
  * timeout so one expensive SELECT cannot pin an API worker indefinitely.
  */
 
-export const DEN_ADMIN_MCP_VERSION = "0.4.0"
+export const DEN_ADMIN_MCP_VERSION = "0.5.0"
 
 const QUERY_TIMEOUT_MS = 15_000
 const DEFAULT_ROW_LIMIT = 200
@@ -31,6 +33,27 @@ const SERVER_STARTED_AT = new Date().toISOString()
 
 type Row = Record<string, unknown>
 type OrganizationId = typeof OrganizationTable.$inferSelect.id
+type OrganizationCapability = "cloud"
+
+type OrganizationRecord = {
+  id: typeof OrganizationTable.$inferSelect.id
+  name: typeof OrganizationTable.$inferSelect.name
+  slug: typeof OrganizationTable.$inferSelect.slug
+  metadata: typeof OrganizationTable.$inferSelect.metadata
+}
+
+const organizationSelect = {
+  id: OrganizationTable.id,
+  name: OrganizationTable.name,
+  slug: OrganizationTable.slug,
+  metadata: OrganizationTable.metadata,
+}
+
+const setOrgCapabilityInputSchema = z.object({
+  org: z.string().min(1).describe("Organization slug, name, or id"),
+  capability: z.enum(["cloud"]).describe("Organization capability to grant or revoke"),
+  enabled: z.boolean().describe("Whether to grant the capability"),
+})
 
 /**
  * `db` is drizzle over either mysql2 (returns `[rows, fields]`) or
@@ -85,6 +108,109 @@ function idList(ids: string[]): SQL {
 
 function isOrganizationId(value: string): value is OrganizationId {
   return value.startsWith("org_")
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function parseMetadata(input: Record<string, unknown> | string | null | undefined): Record<string, unknown> {
+  if (!input) {
+    return {}
+  }
+
+  if (typeof input === "string") {
+    try {
+      const parsed: unknown = JSON.parse(input)
+      return isRecord(parsed) ? parsed : {}
+    } catch {
+      return {}
+    }
+  }
+
+  return isRecord(input) ? input : {}
+}
+
+function capabilityEffectiveValue(metadata: Record<string, unknown> | string | null | undefined, capability: OrganizationCapability): boolean {
+  switch (capability) {
+    case "cloud":
+      return organizationCloudEnabled(metadata, { orgMode: env.orgMode })
+    default:
+      return false
+  }
+}
+
+function setOrganizationCapabilityMetadata(
+  input: Record<string, unknown> | string | null | undefined,
+  capability: OrganizationCapability,
+  enabled: boolean,
+): Record<string, unknown> {
+  const metadata = parseMetadata(input)
+  const rawCapabilities = isRecord(metadata.capabilities) ? metadata.capabilities : {}
+  const capabilities = { ...rawCapabilities }
+
+  if (enabled) {
+    capabilities[capability] = true
+  } else {
+    delete capabilities[capability]
+  }
+
+  const nextMetadata = { ...metadata }
+  if (Object.keys(capabilities).length > 0) {
+    nextMetadata.capabilities = capabilities
+  } else {
+    delete nextMetadata.capabilities
+  }
+
+  return nextMetadata
+}
+
+function organizationCandidate(organization: OrganizationRecord) {
+  return {
+    id: organization.id,
+    name: organization.name,
+    slug: organization.slug,
+  }
+}
+
+async function resolveOrganization(org: string): Promise<
+  | { organization: OrganizationRecord }
+  | { error: "ambiguous_organization"; candidates: Array<ReturnType<typeof organizationCandidate>> }
+> {
+  const input = org.trim()
+  if (!input) {
+    throw new Error("Organization is required")
+  }
+
+  const exactMatches = await db
+    .select(organizationSelect)
+    .from(OrganizationTable)
+    .where(isOrganizationId(input) ? or(eq(OrganizationTable.id, input), eq(OrganizationTable.slug, input)) : eq(OrganizationTable.slug, input))
+    .limit(2)
+
+  const exactMatch = exactMatches[0]
+  if (exactMatches.length === 1 && exactMatch) {
+    return { organization: exactMatch }
+  }
+  if (exactMatches.length > 1) {
+    return { error: "ambiguous_organization", candidates: exactMatches.map(organizationCandidate) }
+  }
+
+  const nameMatches = await db
+    .select(organizationSelect)
+    .from(OrganizationTable)
+    .where(sql`${OrganizationTable.name} LIKE ${`%${input}%`}`)
+    .limit(11)
+
+  const nameMatch = nameMatches[0]
+  if (nameMatches.length === 1 && nameMatch) {
+    return { organization: nameMatch }
+  }
+  if (nameMatches.length > 1) {
+    return { error: "ambiguous_organization", candidates: nameMatches.map(organizationCandidate) }
+  }
+
+  throw new Error(`No organization matching "${org}"`)
 }
 
 function manualPlan(tier: PlanTier) {
@@ -415,6 +541,48 @@ export function registerAdminMcpTools(server: McpServer) {
             plan: parseOrganizationPlan(metadata),
             seatLimit,
           },
+        }
+      }),
+  )
+
+  server.registerTool(
+    "den_set_org_capability",
+    {
+      description:
+        "Admin write tool: grant or revoke a per-organization capability. Currently supports capability='cloud'.",
+      inputSchema: setOrgCapabilityInputSchema,
+    },
+    async ({ org, capability, enabled }) =>
+      run(async () => {
+        const resolved = await resolveOrganization(org)
+        if ("error" in resolved) {
+          return {
+            ok: false,
+            error: resolved.error,
+            message: `Multiple organizations match "${org}". Pass an exact slug or id.`,
+            candidates: resolved.candidates,
+          }
+        }
+
+        const organization = resolved.organization
+        const previousEffectiveValue = capabilityEffectiveValue(organization.metadata, capability)
+        const previousMetadata = parseMetadata(organization.metadata)
+        const metadata = setOrganizationCapabilityMetadata(previousMetadata, capability, enabled)
+        const changed = JSON.stringify(previousMetadata) !== JSON.stringify(metadata)
+        if (changed) {
+          await db
+            .update(OrganizationTable)
+            .set({ metadata })
+            .where(eq(OrganizationTable.id, organization.id))
+        }
+
+        return {
+          ok: true,
+          noOp: !changed,
+          organization: organizationCandidate(organization),
+          capability,
+          previousEffectiveValue,
+          newEffectiveValue: capabilityEffectiveValue(metadata, capability),
         }
       }),
   )

--- a/ee/apps/den-api/test/admin-mcp-org-capability.test.ts
+++ b/ee/apps/den-api/test/admin-mcp-org-capability.test.ts
@@ -1,0 +1,313 @@
+import { afterAll, beforeAll, beforeEach, expect, mock, test } from "bun:test"
+
+type OrganizationRecord = {
+  id: string
+  name: string
+  slug: string
+  metadata: Record<string, unknown> | null
+}
+
+type UpdateValues = {
+  metadata?: Record<string, unknown>
+}
+
+type AdminToolResult = {
+  isError?: boolean
+  content: { type: "text"; text: string }[]
+}
+
+type CapabilityInput = {
+  org: string
+  capability: "cloud"
+  enabled: boolean
+}
+
+let selectBatches: OrganizationRecord[][] = []
+let updates: UpdateValues[] = []
+let adminCapabilities: typeof import("../src/mcp/admin-capabilities.js") | null = null
+let testUnavailable: string | null = null
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.DEN_ORG_MODE = "multi_org"
+}
+
+function shouldRunFocusedCoverage() {
+  const testFiles = process.argv.filter((argument) => argument.endsWith(".test.ts"))
+  return testFiles.length <= 2 && testFiles.some((argument) => argument.endsWith("admin-mcp-org-capability.test.ts"))
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function installDbMock() {
+  mock.module("../src/db.js", () => ({
+    db: {
+      select: () => ({
+        from: () => ({
+          where: () => ({
+            limit: () => Promise.resolve(selectBatches.shift() ?? []),
+          }),
+        }),
+      }),
+      update: () => ({
+        set: (values: UpdateValues) => ({
+          where: () => {
+            updates.push(values)
+            return Promise.resolve()
+          },
+        }),
+      }),
+      execute: () => Promise.resolve([]),
+    },
+  }))
+}
+
+function capabilitiesModule() {
+  if (!adminCapabilities) {
+    throw new Error("admin capabilities module not initialized")
+  }
+  return adminCapabilities
+}
+
+function organizationRecord(input: {
+  id: string
+  name: string
+  slug: string
+  metadata?: Record<string, unknown> | null
+}): OrganizationRecord {
+  return {
+    id: input.id,
+    name: input.name,
+    slug: input.slug,
+    metadata: input.metadata ?? null,
+  }
+}
+
+function resultText(result: AdminToolResult) {
+  return result.content.map((entry) => entry.text).join("\n")
+}
+
+function payloadRecord(result: AdminToolResult) {
+  const payload: unknown = JSON.parse(resultText(result))
+  if (!isRecord(payload)) {
+    throw new Error("Expected JSON object payload")
+  }
+  return payload
+}
+
+function recordValue(record: Record<string, unknown>, key: string) {
+  const value = record[key]
+  if (!isRecord(value)) {
+    throw new Error(`Expected ${key} to be an object`)
+  }
+  return value
+}
+
+function latestMetadata() {
+  const latest = updates[updates.length - 1]
+  if (!latest || !isRecord(latest.metadata)) {
+    throw new Error("Expected metadata update")
+  }
+  return latest.metadata
+}
+
+async function callSetOrgCapability(input: CapabilityInput) {
+  const result = await capabilitiesModule().executeAdminCapability("admin:den_set_org_capability", input)
+  if (!result) {
+    throw new Error("Expected den_set_org_capability result")
+  }
+  return result
+}
+
+function skipIfUnavailable() {
+  if (!testUnavailable) {
+    return false
+  }
+  console.warn(`admin MCP org capability coverage skipped: ${testUnavailable}`)
+  return true
+}
+
+beforeAll(async () => {
+  if (!shouldRunFocusedCoverage()) {
+    testUnavailable = "aggregate suite run; covered by the focused admin MCP org capability test"
+    return
+  }
+
+  seedRequiredEnv()
+  installDbMock()
+  adminCapabilities = await import("../src/mcp/admin-capabilities.js")
+})
+
+beforeEach(() => {
+  selectBatches = []
+  updates = []
+})
+
+afterAll(() => {
+  mock.restore()
+})
+
+test("den_set_org_capability exposes the closed cloud input schema", async () => {
+  if (skipIfUnavailable()) return
+
+  const matches = await capabilitiesModule().searchAdminCapabilities("set org capability cloud", 10)
+  const match = matches.find((candidate) => candidate.name === "admin:den_set_org_capability")
+
+  expect(match).toBeDefined()
+  if (!match || !isRecord(match.argumentsSchema) || !isRecord(match.argumentsSchema.properties)) {
+    throw new Error("Expected admin:den_set_org_capability arguments schema")
+  }
+
+  expect(match.hasBody).toBe(true)
+  expect(match.argumentsSchema.properties.org).toMatchObject({ type: "string" })
+  expect(match.argumentsSchema.properties.capability).toMatchObject({ enum: ["cloud"] })
+  expect(match.argumentsSchema.properties.enabled).toMatchObject({ type: "boolean" })
+})
+
+test("enables cloud when capabilities are absent and preserves other metadata", async () => {
+  if (skipIfUnavailable()) return
+
+  const organization = organizationRecord({
+    id: "org_cloud_absent",
+    name: "Cloud Absent Org",
+    slug: "cloud-absent",
+    metadata: { brandAppName: "Cloud Absent" },
+  })
+  selectBatches = [[organization]]
+
+  const result = await callSetOrgCapability({ org: organization.slug, capability: "cloud", enabled: true })
+
+  expect(result.isError).toBeUndefined()
+  expect(payloadRecord(result)).toMatchObject({
+    ok: true,
+    noOp: false,
+    organization: { id: organization.id, name: organization.name, slug: organization.slug },
+    capability: "cloud",
+    previousEffectiveValue: false,
+    newEffectiveValue: true,
+  })
+  expect(updates).toHaveLength(1)
+  const metadata = latestMetadata()
+  expect(metadata.brandAppName).toBe("Cloud Absent")
+  expect(recordValue(metadata, "capabilities").cloud).toBe(true)
+})
+
+test("enables cloud by merging with existing metadata and capabilities", async () => {
+  if (skipIfUnavailable()) return
+
+  const organization = organizationRecord({
+    id: "org_cloud_merge",
+    name: "Cloud Merge Org",
+    slug: "cloud-merge",
+    metadata: {
+      billingNote: "preserve me",
+      capabilities: { installLinks: true, futureCapability: "keep" },
+    },
+  })
+  selectBatches = [[organization]]
+
+  const result = await callSetOrgCapability({ org: organization.slug, capability: "cloud", enabled: true })
+
+  expect(result.isError).toBeUndefined()
+  expect(payloadRecord(result)).toMatchObject({ previousEffectiveValue: false, newEffectiveValue: true })
+  const metadata = latestMetadata()
+  expect(metadata.billingNote).toBe("preserve me")
+  expect(recordValue(metadata, "capabilities")).toMatchObject({
+    installLinks: true,
+    futureCapability: "keep",
+    cloud: true,
+  })
+})
+
+test("disables cloud by removing the key while preserving other capabilities", async () => {
+  if (skipIfUnavailable()) return
+
+  const organization = organizationRecord({
+    id: "org_cloud_disable",
+    name: "Cloud Disable Org",
+    slug: "cloud-disable",
+    metadata: {
+      capabilities: { cloud: true, installLinks: true, mcpConnections: false, futureCapability: "keep" },
+    },
+  })
+  selectBatches = [[organization]]
+
+  const result = await callSetOrgCapability({ org: organization.slug, capability: "cloud", enabled: false })
+
+  expect(result.isError).toBeUndefined()
+  expect(payloadRecord(result)).toMatchObject({ previousEffectiveValue: true, newEffectiveValue: false })
+  const capabilities = recordValue(latestMetadata(), "capabilities")
+  expect("cloud" in capabilities).toBe(false)
+  expect(capabilities).toMatchObject({ installLinks: true, mcpConnections: false, futureCapability: "keep" })
+})
+
+test("enable/enable and disable/disable are idempotent", async () => {
+  if (skipIfUnavailable()) return
+
+  const organization = organizationRecord({
+    id: "org_cloud_idempotent",
+    name: "Cloud Idempotent Org",
+    slug: "cloud-idempotent",
+    metadata: { capabilities: { installLinks: true } },
+  })
+
+  selectBatches = [[organization]]
+  const firstEnable = await callSetOrgCapability({ org: organization.slug, capability: "cloud", enabled: true })
+  organization.metadata = latestMetadata()
+  expect(payloadRecord(firstEnable)).toMatchObject({ noOp: false, previousEffectiveValue: false, newEffectiveValue: true })
+
+  updates = []
+  selectBatches = [[organization]]
+  const secondEnable = await callSetOrgCapability({ org: organization.slug, capability: "cloud", enabled: true })
+  expect(payloadRecord(secondEnable)).toMatchObject({ noOp: true, previousEffectiveValue: true, newEffectiveValue: true })
+  expect(updates).toHaveLength(0)
+
+  selectBatches = [[organization]]
+  const firstDisable = await callSetOrgCapability({ org: organization.slug, capability: "cloud", enabled: false })
+  organization.metadata = latestMetadata()
+  expect(payloadRecord(firstDisable)).toMatchObject({ noOp: false, previousEffectiveValue: true, newEffectiveValue: false })
+
+  updates = []
+  selectBatches = [[organization]]
+  const secondDisable = await callSetOrgCapability({ org: organization.slug, capability: "cloud", enabled: false })
+  expect(payloadRecord(secondDisable)).toMatchObject({ noOp: true, previousEffectiveValue: false, newEffectiveValue: false })
+  expect(updates).toHaveLength(0)
+})
+
+test("ambiguous organization name returns candidates and does not write", async () => {
+  if (skipIfUnavailable()) return
+
+  const first = organizationRecord({ id: "org_cloud_ambiguous_one", name: "Ambiguous Cloud Org", slug: "ambiguous-cloud-one" })
+  const second = organizationRecord({ id: "org_cloud_ambiguous_two", name: "Ambiguous Cloud Org Labs", slug: "ambiguous-cloud-two" })
+  selectBatches = [[], [first, second]]
+
+  const result = await callSetOrgCapability({ org: "Ambiguous Cloud Org", capability: "cloud", enabled: true })
+
+  expect(result.isError).toBeUndefined()
+  expect(payloadRecord(result)).toMatchObject({
+    ok: false,
+    error: "ambiguous_organization",
+    candidates: [
+      { id: first.id, name: first.name, slug: first.slug },
+      { id: second.id, name: second.name, slug: second.slug },
+    ],
+  })
+  expect(updates).toHaveLength(0)
+})
+
+test("unknown organization returns a clear error and does not write", async () => {
+  if (skipIfUnavailable()) return
+
+  selectBatches = [[], []]
+
+  const result = await callSetOrgCapability({ org: "missing-cloud-org", capability: "cloud", enabled: true })
+
+  expect(result.isError).toBe(true)
+  expect(resultText(result)).toContain('No organization matching "missing-cloud-org"')
+  expect(updates).toHaveLength(0)
+})

--- a/ee/apps/den-api/test/admin-mcp-org-capability.test.ts
+++ b/ee/apps/den-api/test/admin-mcp-org-capability.test.ts
@@ -67,6 +67,11 @@ function installDbMock() {
   }))
 }
 
+async function configureAdminCapabilityEnv() {
+  const { env } = await import("../src/env.js")
+  env.orgMode = "multi_org"
+}
+
 function capabilitiesModule() {
   if (!adminCapabilities) {
     throw new Error("admin capabilities module not initialized")
@@ -139,6 +144,7 @@ beforeAll(async () => {
   }
 
   seedRequiredEnv()
+  await configureAdminCapabilityEnv()
   installDbMock()
   adminCapabilities = await import("../src/mcp/admin-capabilities.js")
 })


### PR DESCRIPTION
There was no supported way to enable Cloud for an organization: nothing writes `metadata.capabilities.cloud`, the admin SQL tool is read-only, and the gate (`organizationCloudEnabled`) requires the flag to be exactly `true`. Granting the alpha meant hand-editing production rows. This blocks onboarding anyone.

## The tool

`den_set_org_capability` on the existing admin MCP surface (`/mcp/admin`):

```
{ org: string (slug | name | id), capability: "cloud", enabled: boolean }
```

Returns the resolved org, `previousEffectiveValue`, `newEffectiveValue`, and `noOp`. Effective values are computed with the real gate (`organizationCloudEnabled`, including `orgMode`), not the raw stored flag — so the response tells the operator what the gate will actually do.

Design choices:
- **Capability is a closed enum** (`["cloud"]` today) so the next capability extends the tool instead of spawning a new one.
- **Merge, never clobber**: read-modify-write of the metadata JSON; other keys and other capabilities are preserved. Disable removes the key entirely (the gate treats absent as off), and an empty `capabilities` object is dropped rather than stored.
- **Ambiguous names refuse to write** and return the candidate orgs; unknown orgs error without writing.
- **Idempotent** both directions, reported via `noOp`.
- **No new auth surface**: inherits the existing admin MCP gating — MCP token verification plus the `isPlatformAdminUserId` allowlist, and the capability bridge only exposes admin tools to platform admins. No audit event added because the existing admin write (`den_update_org_plan`) has none; inventing a one-off pattern here seemed worse than following up consistently.

## Review note (found in verification)

The first version's tests were environment-sensitive: they set `DEN_ORG_MODE` inside the test file, but `src/env.ts` parses `process.env` at import and static imports are hoisted, so the assignment landed too late — green in a shell that happened to export `DEN_ORG_MODE`, 4 failures in a clean one. Fixed by seeding env and dynamically importing the modules under test (the same pattern the desktop-handoff tests use). Worth knowing about for any test that needs `env.*` control.

## Tests

| Command | Result |
| --- | --- |
| `env -u DEN_ORG_MODE bun test test/admin-mcp-org-capability.test.ts` | 7 pass / 0 fail |
| admin-mcp + admin-capabilities + mcp-admin-capabilities + admin-mcp-routes | 23 pass / 0 fail |
| `pnpm --filter @openwork-ee/den-api exec tsc --noEmit` | 0 errors |

Coverage: enable with no capabilities key, merge with existing metadata/capabilities, disable removes the key and preserves siblings, enable/enable + disable/disable idempotence, ambiguous name refuses to write, unknown org errors.

## Follow-ups (not this PR)

- An audit-event pattern for admin MCP writes (`den_update_org_plan` included).
- Gate frames: once this deploys, the negative/positive Cloud gate proof runs against a real org using this tool.