### PR TITLE
fix(app): allow attachments in the new-task composer before the session exists

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -4,7 +4,7 @@ import type { Agent } from "@opencode-ai/sdk/v2/client";
 
 import { createDenClient, readDenSettings } from "@/app/lib/den";
 import type { OpenworkServerClient } from "@/app/lib/openwork-server";
-import type { McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
+import type { ComposerAttachment, McpServerEntry, McpStatusMap, ModelRef, SkillCard, SlashCommandOption } from "@/app/types";
 import { t } from "@/i18n";
 import { ReactSessionComposer } from "@/react-app/domains/session/surface/composer/composer";
 import { encodeComposerMentionValue, type ComposerMentionKind } from "@/react-app/domains/session/surface/composer/mention-encoding";
@@ -14,6 +14,7 @@ import {
   type PastedTextChip,
 } from "@/react-app/domains/session/surface/composer/pasted-text";
 import { loadSessionConnectCapabilities } from "@/react-app/domains/connections/cloud-inventory-cache";
+import { resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/attachment-file-part";
 
 /**
  * Workspace-scoped wiring for the new-task composer. Everything here is
@@ -50,8 +51,8 @@ export type NewTaskComposerContext = {
 export type NewTaskComposerProps = {
   draft: string;
   onDraftChange: (value: string) => void;
-  /** Called with a non-empty draft; the caller creates the session (and workspace if needed). */
-  onRunTask: (resolvedDraft: string) => void;
+  /** Called with a non-empty draft and in-memory attachments; the caller creates the session (and workspace if needed). */
+  onRunTask: (resolvedDraft: string, attachments: ComposerAttachment[]) => void;
   /** Disable submission while a default workspace is being prepared. */
   busy: boolean;
   context: NewTaskComposerContext | null;
@@ -67,11 +68,12 @@ const FALLBACK_MODEL: ModelRef = { providerID: "", modelID: "" };
  * The real session composer, reused for the "What do you need done?" empty
  * state. The draft (including skill/mention tokens) is seeded into the
  * created session's composer, so pills typed here survive the handoff.
- * Attachments stay disabled: they are uploaded per session, which does not
- * exist yet.
+ * Attachments are collected before the session exists and seeded into the
+ * created session, where the normal send path uploads them into the workspace.
  */
 export function NewTaskComposer(props: NewTaskComposerProps) {
   const [mentions, setMentions] = useState<Record<string, ComposerMentionKind>>({});
+  const [attachments, setAttachments] = useState<ComposerAttachment[]>([]);
   const [skills, setSkills] = useState<SkillCard[]>([]);
   const [mcpServers, setMcpServers] = useState<McpServerEntry[]>([]);
   const [mcpStatuses, setMcpStatuses] = useState<McpStatusMap>({});
@@ -152,8 +154,50 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     setPastedText((current) => current.filter((item) => item.id !== id));
   };
 
+  const handleDraftChange = (value: string) => {
+    props.onDraftChange(value);
+    const idsInDraft = new Set(
+      [...value.matchAll(/\[attachment ([^\]]+)\]/g)].map((match) => match[1]).filter((id): id is string => Boolean(id)),
+    );
+    setAttachments((current) => {
+      const retained = current.filter((attachment) => idsInDraft.has(attachment.id));
+      if (retained.length === current.length) return current;
+      for (const attachment of current) {
+        if (!idsInDraft.has(attachment.id)) revokeAttachmentPreview(attachment);
+      }
+      return retained;
+    });
+  };
+
+  const handleAttachFiles = (files: File[]) => {
+    if (!files.length) return;
+    const next: ComposerAttachment[] = files.map((file) => {
+      const metadata = resolveAttachmentFileMetadata(file);
+      return {
+        id: `att-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`,
+        name: file.name,
+        mimeType: metadata.mime,
+        size: file.size,
+        kind: metadata.kind,
+        file,
+        previewUrl: metadata.kind === "image" ? URL.createObjectURL(file) : undefined,
+      };
+    });
+    setAttachments((current) => [...current, ...next]);
+    props.onDraftChange(`${props.draft}${next.map((attachment) => `[attachment ${attachment.id}]`).join("")}`);
+  };
+
+  const handleRemoveAttachment = (id: string) => {
+    setAttachments((current) => {
+      const target = current.find((item) => item.id === id);
+      if (target) revokeAttachmentPreview(target);
+      return current.filter((item) => item.id !== id);
+    });
+    props.onDraftChange(props.draft.replaceAll(`[attachment ${id}]`, ""));
+  };
+
   const handleRunTask = () => {
-    props.onRunTask(resolvePastedTextPlaceholders(props.draft, pastedText));
+    props.onRunTask(resolvePastedTextPlaceholders(props.draft, pastedText), attachments);
   };
 
   const handleUnsupportedFileLinks = (links: string[]) => {
@@ -165,7 +209,7 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
     <ReactSessionComposer
       draft={props.draft}
       mentions={mentions}
-      onDraftChange={props.onDraftChange}
+      onDraftChange={handleDraftChange}
       onSend={handleRunTask}
       onSteer={noop}
       onQueue={noop}
@@ -184,11 +228,11 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       onRefreshOrganizationModels={context?.onRefreshOrganizationModels}
       onModelPickerOpenChange={context?.onModelPickerOpenChange ?? noop}
       onModelChange={context?.onModelChange ?? noop}
-      attachments={[]}
-      onAttachFiles={noop}
-      onRemoveAttachment={noop}
-      attachmentsEnabled={false}
-      attachmentsDisabledReason="Attachments become available once the task starts."
+      attachments={attachments}
+      onAttachFiles={handleAttachFiles}
+      onRemoveAttachment={handleRemoveAttachment}
+      attachmentsEnabled
+      attachmentsDisabledReason={null}
       modelVariantLabel={context?.modelVariantLabel ?? ""}
       modelVariant={context?.modelVariant ?? null}
       modelBehaviorOptions={context?.modelBehaviorOptions}
@@ -221,4 +265,9 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
       draftScopeKey={`new-task:${workspaceId ?? "chat-first"}`}
     />
   );
+}
+
+function revokeAttachmentPreview(attachment: { previewUrl?: string | undefined }) {
+  if (!attachment.previewUrl) return;
+  URL.revokeObjectURL(attachment.previewUrl);
 }

--- a/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-empty-hero.tsx
@@ -2,6 +2,7 @@
 import { useState } from "react";
 import { Zap } from "lucide-react";
 
+import type { ComposerAttachment } from "@/app/types";
 import { resolveOrganizationPromptCardContent } from "@/components/chat/task-suggestions";
 import { useCheckDesktopRestriction, useOrgRestrictions } from "@/react-app/domains/cloud/desktop-config-provider";
 import { NewTaskComposer, type NewTaskComposerContext } from "./new-task-composer";
@@ -39,8 +40,8 @@ export type SessionEmptyHeroProps = {
   providerCount: number;
   /** Disable submission while a default workspace is being prepared. */
   busy?: boolean;
-  /** Called with the task prompt; the caller creates the session (and workspace if needed). */
-  onRunTask: (prompt: string) => void;
+  /** Called with the task prompt and attachments; the caller creates the session (and workspace if needed). */
+  onRunTask: (prompt: string, attachments: ComposerAttachment[]) => void;
   onOpenProviderAuth?: () => void;
   /** Workspace-scoped wiring for the full composer (skills, agents, models). */
   composer?: NewTaskComposerContext | null;
@@ -70,10 +71,10 @@ export function SessionEmptyHero(props: SessionEmptyHeroProps) {
     })
     : DEFAULT_SUGGESTIONS;
 
-  const submit = (resolvedPrompt: string) => {
+  const submit = (resolvedPrompt: string, attachments: ComposerAttachment[]) => {
     const trimmedPrompt = resolvedPrompt.trim();
     if (!trimmedPrompt || props.busy) return;
-    props.onRunTask(trimmedPrompt);
+    props.onRunTask(trimmedPrompt, attachments);
   };
 
   const fillPrompt = (value: string) => {

--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -13,6 +13,7 @@ import { getDisplaySessionTitle } from "../../../../app/lib/session-title";
 import type { BootPhase } from "../../../../app/lib/startup-boot";
 import { openDesktopPath, revealDesktopItemInDir, type WorkspaceInfo } from "../../../../app/lib/desktop";
 import type {
+  ComposerAttachment,
   PendingPermission,
   PendingQuestion,
   ProviderListItem,
@@ -133,7 +134,7 @@ export type SessionPageSidebarProps = {
   onOpenSession: (workspaceId: string, sessionId: string) => void;
   onPrefetchSession?: (workspaceId: string, sessionId: string) => void;
   onCreateTaskInWorkspace: (workspaceId: string, groupId?: string) => void;
-  onCreateTaskWithPrompt?: (workspaceId: string, prompt: string) => void;
+  onCreateTaskWithPrompt?: (workspaceId: string, prompt: string, attachments?: ComposerAttachment[]) => void;
   onOpenRenameWorkspace: (workspaceId: string) => void;
   onShareWorkspace: (workspaceId: string) => void;
   onRevealWorkspace: (workspaceId: string) => void;
@@ -204,7 +205,7 @@ export type SessionPageProps = {
   notFoundMessage?: string | null;
   onOpenProviderAuth?: () => void;
   /** Chat-first: create a default workspace and start a task from the empty-state composer. */
-  onChatFirstTask?: (prompt: string) => void;
+  onChatFirstTask?: (prompt: string, attachments?: ComposerAttachment[]) => void;
   chatFirstBusy?: boolean;
   /** Workspace-scoped wiring for the empty-state hero's full composer. */
   newTaskComposer?: NewTaskComposerContext | null;
@@ -1304,7 +1305,7 @@ export function SessionPage(props: SessionPageProps) {
                     <SessionEmptyHero
                       providerCount={providerCount}
                       busy={props.chatFirstBusy}
-                      onRunTask={(prompt) => props.onChatFirstTask?.(prompt)}
+                      onRunTask={(prompt, attachments) => props.onChatFirstTask?.(prompt, attachments)}
                       onOpenProviderAuth={props.onOpenProviderAuth}
                       composer={props.newTaskComposer}
                     />
@@ -1357,8 +1358,8 @@ export function SessionPage(props: SessionPageProps) {
                     <div className="flex flex-1 items-center justify-center py-16">
                       <SessionEmptyHero
                         providerCount={providerCount}
-                        onRunTask={(prompt) =>
-                          props.sidebar.onCreateTaskWithPrompt?.(props.selectedWorkspaceId, prompt)
+                        onRunTask={(prompt, attachments) =>
+                          props.sidebar.onCreateTaskWithPrompt?.(props.selectedWorkspaceId, prompt, attachments)
                         }
                         onOpenProviderAuth={props.onOpenProviderAuth}
                         composer={props.newTaskComposer}

--- a/apps/app/src/react-app/domains/workspace/types.ts
+++ b/apps/app/src/react-app/domains/workspace/types.ts
@@ -1,4 +1,4 @@
-import type { WorkspacePreset } from "../../../app/types";
+import type { ComposerAttachment, WorkspacePreset } from "../../../app/types";
 
 export type CreateWorkspaceScreen = "chooser" | "local" | "remote";
 
@@ -16,6 +16,8 @@ export type CreateWorkspaceOptions = {
   projectLabel?: string | null;
   /** Saved as the first session's composer draft after the workspace is created. */
   firstTaskPrompt?: string | null;
+  /** Seeded into the first session's composer with the draft, then sent by auto-send. */
+  firstTaskAttachments?: ComposerAttachment[] | null;
 };
 
 export type CreateWorkspaceProgress = {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -47,6 +47,7 @@ import {
   type WorkspaceList,
 } from "@/app/lib/desktop";
 import type {
+  ComposerAttachment,
   ComposerDraft,
   ComposerPart,
   ModelOption,
@@ -2163,10 +2164,16 @@ export function SessionRoute() {
           captureAnalyticsEvent("task_created", { source: "workspace_created", workspace_type: "local" });
           const firstTaskPrompt = options?.firstTaskPrompt?.trim();
           if (firstTaskPrompt) {
-            saveSessionDraft(targetWorkspaceId, session.id, { text: firstTaskPrompt, mode: "prompt" });
+            const firstTaskAttachments = options?.firstTaskAttachments ?? [];
+            // Attachment chips only survive in-memory (File objects), so the
+            // persisted fallback draft drops their tokens.
+            saveSessionDraft(targetWorkspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
             // The composer reads its draft from the composer state store, not
             // the persisted draft store — seed both so the prompt shows up.
             useComposerStateStore.getState().setDraft(session.id, firstTaskPrompt);
+            if (firstTaskAttachments.length) {
+              useComposerStateStore.getState().setAttachments(session.id, firstTaskAttachments);
+            }
             // One-step run: the session surface sends the seeded draft itself.
             markComposerAutoSend(session.id);
           }
@@ -2196,7 +2203,7 @@ export function SessionRoute() {
    * workspace under the user's home folder instead of asking where to put
    * it. Falls back to the create-workspace modal off desktop.
    */
-  const handleChatFirstTask = useCallback((prompt: string) => {
+  const handleChatFirstTask = useCallback((prompt: string, attachments?: ComposerAttachment[]) => {
     void (async () => {
       if (!isDesktopRuntime()) {
         handleOpenCreateWorkspace();
@@ -2212,7 +2219,7 @@ export function SessionRoute() {
         handleOpenCreateWorkspace();
         return;
       }
-      await handleCreateWorkspace("starter", folder, { firstTaskPrompt: prompt });
+      await handleCreateWorkspace("starter", folder, { firstTaskPrompt: prompt, firstTaskAttachments: attachments ?? [] });
     })();
   }, [handleCreateWorkspace, handleOpenCreateWorkspace]);
 
@@ -2467,7 +2474,7 @@ export function SessionRoute() {
             }
           });
         },
-        onCreateTaskWithPrompt: (workspaceId, prompt) => {
+        onCreateTaskWithPrompt: (workspaceId, prompt, attachments) => {
           void (async () => {
             const workspace = workspaces.find((item) => item.id === workspaceId);
             if (!workspace) return;
@@ -2485,12 +2492,21 @@ export function SessionRoute() {
               if (workspaceId === selectedWorkspaceId) {
                 void sessionProviderAuthStore.runCloudProviderSync("new_chat");
               }
-              saveSessionDraft(workspaceId, session.id, { text: prompt, mode: "prompt" });
-              // The composer reads its draft from the composer state store,
-              // not the persisted draft store — seed both.
-              useComposerStateStore.getState().setDraft(session.id, prompt);
-              // One-step run: the session surface sends the seeded draft itself.
-              markComposerAutoSend(session.id);
+              const firstTaskPrompt = prompt.trim();
+              if (firstTaskPrompt) {
+                const firstTaskAttachments = attachments ?? [];
+                // Attachment chips only survive in-memory (File objects), so the
+                // persisted fallback draft drops their tokens.
+                saveSessionDraft(workspaceId, session.id, { text: firstTaskPrompt.replace(/\[attachment [^\]]+\]/g, "").trim(), mode: "prompt" });
+                // The composer reads its draft from the composer state store,
+                // not the persisted draft store — seed both.
+                useComposerStateStore.getState().setDraft(session.id, firstTaskPrompt);
+                if (firstTaskAttachments.length) {
+                  useComposerStateStore.getState().setAttachments(session.id, firstTaskAttachments);
+                }
+                // One-step run: the session surface sends the seeded draft itself.
+                markComposerAutoSend(session.id);
+              }
               writeActiveWorkspaceId(workspaceId || null);
               writeLastSessionFor(workspaceId, session.id);
               rememberPendingCreatedSession(workspaceId, session.id);

--- a/evals/flows/new-task-composer-attachments-chat-first.flow.mjs
+++ b/evals/flows/new-task-composer-attachments-chat-first.flow.mjs
@@ -1,0 +1,372 @@
+/**
+ * The other half of the new-task attachment fix: the New Task composer also
+ * renders when **no workspace exists at all** (chat-first onboarding —
+ * `showWorkspaceSetupEmptyState` is `workspaces.length === 0`). This flow
+ * proves a file can be attached in that state and survives the workspace +
+ * session creation that Run task performs.
+ *
+ * Scope note: the "first message actually sent" half of chat-first is covered
+ * by `new-task-composer-attachments` (workspace-selected hero), which drives
+ * the same seeding + auto-send + upload path end to end. Chat-first creates
+ * the workspace on the fly, so its engine cannot be pointed at a mock provider
+ * beforehand; this flow therefore stops at the handoff it can observe
+ * deterministically.
+ *
+ * Requires a genuinely fresh desktop profile (no chat workspace folder yet).
+ * Required env:
+ * - OPENWORK_EVAL_DAYTONA_SANDBOX  Daytona sandbox running the Electron app.
+ */
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "new-task-composer-attachments-chat-first";
+const FILENAME = "quarterly-costs.csv";
+const CSV_SOURCE = [
+  "month,team,cost",
+  "2026-01,Platform,12400",
+  "2026-02,Platform,11875",
+  "2026-03,Platform,13210",
+  "",
+].join("\n");
+const PROMPT = "Summarize the attached quarterly costs spreadsheet.";
+const EXPECTED_BYTES = Buffer.from(CSV_SOURCE, "utf8");
+const EXPECTED_SHA256 = createHash("sha256").update(EXPECTED_BYTES).digest("hex");
+const MOCK_PORT = 18093;
+const PROVIDER_ID = "new-task-attachments-mock";
+const MODEL_ID = "new-task-attachment-mock";
+const ASSISTANT_SENTINEL = "Quarterly costs received";
+const OLD_BLOCK_MESSAGE = "Attachments become available once the task starts.";
+
+// Fixed by the Daytona devcontainer profile; the desktop "home" the chat-first
+// path writes into lives under the dev data dir, not $HOME.
+const DEV_PROFILE_DIR = "/home/daytona/.config/com.differentai.openwork.dev";
+const DEV_HOME = `${DEV_PROFILE_DIR}/openwork-dev-data/home`;
+const CHAT_WORKSPACE_PATH = `${DEV_HOME}/OpenWork Chat`;
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const execFileAsync = promisify(execFile);
+
+function assertEvidence(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${String(actual).slice(0, 400)})` : ""}`);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function daytonaBash(ctx, script, timeout = 90_000) {
+  const sandbox = ctx.env.OPENWORK_EVAL_DAYTONA_SANDBOX.trim();
+  const encoded = Buffer.from(script, "utf8").toString("base64");
+  try {
+    return await execFileAsync(
+      "daytona",
+      ["exec", sandbox, "--", "echo", encoded, "|", "base64", "-d", "|", "bash"],
+      { timeout, maxBuffer: 1024 * 1024 },
+    );
+  } catch (error) {
+    const stdout = error && typeof error === "object" && "stdout" in error ? error.stdout : "";
+    const stderr = error && typeof error === "object" && "stderr" in error ? error.stderr : "";
+    throw new Error(`daytona exec failed: ${errorMessage(error)} stdout=${String(stdout ?? "").slice(0, 400)} stderr=${String(stderr ?? "").slice(0, 400)}`);
+  }
+}
+
+/**
+ * The workspace registry is owned by the running in-process server, so a true
+ * zero-workspace state cannot be forced by editing state files underneath it.
+ * This flow requires a fresh profile instead and fails loudly otherwise.
+ */
+async function requireSeededMockProvider(ctx) {
+  const script = `set -euo pipefail
+curl -sf http://127.0.0.1:${MOCK_PORT}/v1/models >/dev/null && echo mock-ready
+grep -q ${JSON.stringify(PROVIDER_ID)} ${JSON.stringify(`${CHAT_WORKSPACE_PATH}/opencode.jsonc`)} && echo provider-seeded
+`;
+  const result = await daytonaBash(ctx, script, 30_000);
+  ctx.assert(result.stdout.includes("mock-ready"), `Mock provider is not listening on ${MOCK_PORT}: ${result.stdout} ${result.stderr}`);
+  ctx.assert(
+    result.stdout.includes("provider-seeded"),
+    `Harness setup missing: ${CHAT_WORKSPACE_PATH}/opencode.jsonc must pre-declare the mock provider (the workspace does not exist until Run task, so its engine cannot be configured later). Wipe ${DEV_PROFILE_DIR}, seed that file, and restart Electron.`,
+  );
+}
+
+async function loadZeroWorkspaceProfile(ctx) {
+  await ctx.eval(`(() => {
+    const raw = localStorage.getItem("openwork.preferences");
+    let prefs = {};
+    try {
+      prefs = raw ? JSON.parse(raw) : {};
+    } catch {
+      prefs = {};
+    }
+    if (!prefs || typeof prefs !== "object" || Array.isArray(prefs)) prefs = {};
+    // Skip the welcome redirect so we land on the chat-first hero with no
+    // workspace, which is exactly the state under test.
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...prefs,
+      hasCompletedOnboarding: true,
+      defaultModel: { providerID: ${JSON.stringify(PROVIDER_ID)}, modelID: ${JSON.stringify(MODEL_ID)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${PROVIDER_ID}/${MODEL_ID}`)});
+    localStorage.removeItem("openwork.react.activeWorkspace");
+    location.hash = "#/session";
+    location.reload();
+    return true;
+  })()`);
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 90_000, label: "control API after reload" });
+  await ctx.waitFor(
+    `(() => {
+      const inspector = window.__openwork;
+      if (!inspector) return null;
+      const workspaces = inspector.slice("route").workspaces || [];
+      if (workspaces.length !== 0) return null;
+      return document.body.innerText.includes("What do you need done?") || null;
+    })()`,
+    { timeoutMs: 60_000, label: "chat-first hero with zero workspaces" },
+  );
+}
+
+async function workspaceCount(ctx) {
+  return await ctx.eval(`(window.__openwork.slice("route").workspaces || []).length`);
+}
+
+const MODEL_UPSELL_TITLE = "Start working without API keys";
+
+/**
+ * A fresh, signed-out profile pops the OpenWork Models upsell over the
+ * transcript once the first session opens. Dismiss it so the frames show the
+ * actual experience instead of an unrelated overlay.
+ */
+async function dismissOpenWorkModelsModal(ctx) {
+  await ctx.eval(`(() => {
+    const dialogs = Array.from(document.querySelectorAll('[role="dialog"], [data-slot="dialog-content"]'));
+    const dialog = dialogs.find((item) => (item.textContent || "").includes(${JSON.stringify(MODEL_UPSELL_TITLE)}));
+    if (!dialog) return false;
+    const buttons = Array.from(dialog.querySelectorAll("button"));
+    const keep = buttons.find((button) => (button.textContent || "").trim().includes("Continue with my own provider keys"));
+    const close = buttons.find((button) => (button.getAttribute("aria-label") || "") === "Close");
+    const target = keep || close;
+    if (!target) return false;
+    target.click();
+    return true;
+  })()`);
+  await ctx.waitFor(
+    `(() => {
+      const dialogs = Array.from(document.querySelectorAll('[role="dialog"], [data-slot="dialog-content"]'));
+      return dialogs.some((item) => (item.textContent || "").includes(${JSON.stringify(MODEL_UPSELL_TITLE)})) ? null : true;
+    })()`,
+    { timeoutMs: 20_000, label: "OpenWork Models upsell dismissed" },
+  );
+}
+
+async function typePromptIntoHeroComposer(ctx) {
+  const result = await ctx.eval(`(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!editor) return { ok: false, reason: "hero composer editor not found" };
+    editor.focus();
+    const data = new DataTransfer();
+    data.setData("text/plain", ${JSON.stringify(PROMPT)});
+    editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+    return { ok: true };
+  })()`);
+  ctx.assert(result?.ok, result?.reason ?? "Failed to paste the prompt into the new-task composer.");
+}
+
+async function attachCsvThroughFileInput(ctx) {
+  const result = await ctx.eval(`(() => {
+    const input = document.querySelector('input[type="file"][multiple]');
+    if (!(input instanceof HTMLInputElement)) return { ok: false, reason: "composer file input not found" };
+    const transfer = new DataTransfer();
+    transfer.items.add(new File([${JSON.stringify(CSV_SOURCE)}], ${JSON.stringify(FILENAME)}, { type: "text/csv", lastModified: 1767225600000 }));
+    input.files = transfer.files;
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    return { ok: true };
+  })()`);
+  ctx.assert(result?.ok, result?.reason ?? "Failed to hand the CSV to the composer file input.");
+}
+
+const SEEDED_COMPOSER_STATE = `(() => {
+  const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+  const text = editor ? String(editor.innerText || "") : "";
+  const chip = Array.from(document.querySelectorAll("*")).some((node) => node.childElementCount === 0 && (node.textContent || "").trim() === ${JSON.stringify(FILENAME)});
+  return { promptCarried: text.includes("quarterly costs"), chip, rawToken: text.includes("[attachment "), text: text.slice(0, 200) };
+})()`;
+
+export default {
+  id: FLOW_ID,
+  title: "New Task composer accepts attachments when no workspace exists yet",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DAYTONA_SANDBOX"],
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API" });
+    return null;
+  },
+  steps: [
+    {
+      name: "Land on the chat-first composer with no workspace",
+      run: async (ctx) => {
+        await requireSeededMockProvider(ctx);
+        await loadZeroWorkspaceProfile(ctx);
+        ctx.output("profile", JSON.stringify({ workspaces: await workspaceCount(ctx), chatWorkspacePath: CHAT_WORKSPACE_PATH }, null, 2));
+      },
+    },
+    {
+      name: "Attach a spreadsheet with no workspace at all",
+      run: async (ctx) => {
+        await ctx.prove("The New Task composer takes a file before any workspace exists", {
+          voiceover: vo[0],
+          action: async () => {
+            await typePromptIntoHeroComposer(ctx);
+            await attachCsvThroughFileInput(ctx);
+          },
+          assert: async () => {
+            await ctx.waitForText(FILENAME, { timeoutMs: 10_000 });
+            const count = await workspaceCount(ctx);
+            assertEvidence(ctx, count === 0, "No workspace exists while the file sits in the composer", `workspaces=${count}`);
+            const route = await ctx.eval(`String(window.__openworkControl.snapshot().route || "")`);
+            assertEvidence(ctx, !String(route).includes("/workspace/"), "The route has no workspace yet", String(route));
+            const state = await ctx.eval(`(() => {
+              const buttons = Array.from(document.querySelectorAll("button"));
+              const attach = buttons.find((button) => button.title === "Attach files");
+              const run = buttons.find((button) => button.textContent.trim() === "Run task");
+              return { attachFound: Boolean(attach), attachDisabled: attach ? attach.disabled : null, runDisabled: run ? run.disabled : null };
+            })()`);
+            assertEvidence(ctx, state?.attachFound === true && state?.attachDisabled === false, "The attach button is enabled with no workspace", JSON.stringify(state));
+            assertEvidence(ctx, state?.runDisabled === false, "Run task is enabled with the attachment in place", JSON.stringify(state));
+            const bodyText = await ctx.eval("document.body.innerText");
+            assertEvidence(ctx, !String(bodyText).includes(OLD_BLOCK_MESSAGE), "The old 'attachments become available once the task starts' block is gone", OLD_BLOCK_MESSAGE);
+          },
+          screenshot: {
+            name: "attached-with-no-workspace",
+            requireText: [FILENAME, "What do you need done?"],
+            rejectText: [OLD_BLOCK_MESSAGE],
+          },
+        });
+      },
+    },
+    {
+      name: "Run the task: the workspace is created and the file rides the first message",
+      run: async (ctx) => {
+        await ctx.prove("One press creates the workspace and sends the attachment with the first message", {
+          voiceover: vo[1],
+          action: async () => {
+            const clicked = await ctx.eval(`(() => {
+              const button = Array.from(document.querySelectorAll("button")).find((item) => item.textContent.trim() === "Run task" && !item.disabled);
+              if (!button) return false;
+              button.click();
+              return true;
+            })()`);
+            ctx.assert(clicked === true, "Could not click Run task on the chat-first hero.");
+            await ctx.waitFor(`String(window.__openworkControl.snapshot().route || "").includes("/session/ses_")`, { timeoutMs: 120_000, label: "session route after workspace creation" });
+            await ctx.waitFor(`(() => {
+              const messages = Array.from(document.querySelectorAll('[data-message-role="assistant"]'));
+              return messages.some((message) => (message.innerText || "").includes(${JSON.stringify(ASSISTANT_SENTINEL)})) || null;
+            })()`, { timeoutMs: 120_000, label: "assistant reply in the created session" });
+            await dismissOpenWorkModelsModal(ctx);
+          },
+          assert: async () => {
+            const count = await workspaceCount(ctx);
+            assertEvidence(ctx, count === 1, "Running the task created exactly one workspace", `workspaces=${count}`);
+            const route = await ctx.eval(`String(window.__openworkControl.snapshot().route || "")`);
+            assertEvidence(ctx, route.includes("/workspace/ws_") && route.includes("/session/ses_"), "The route now points at the created workspace and session", route);
+            const workspacePath = await ctx.eval(`(() => {
+              const workspaces = window.__openwork.slice("route").workspaces || [];
+              return workspaces[0] ? String(workspaces[0].path || "") : "";
+            })()`);
+            assertEvidence(ctx, workspacePath === CHAT_WORKSPACE_PATH, "The created workspace is the chat-first default folder", workspacePath);
+            const sent = await ctx.eval(`(() => {
+              const cards = Array.from(document.querySelectorAll("button[aria-label], a[aria-label]"))
+                .map((node) => node.getAttribute("aria-label") || "")
+                .filter((label) => label.includes(${JSON.stringify(FILENAME)}));
+              return { userTurns: document.querySelectorAll('[data-message-role="user"]').length, cards };
+            })()`);
+            assertEvidence(ctx, sent?.userTurns >= 1, "A first user turn was sent in the created session", JSON.stringify(sent));
+            assertEvidence(ctx, (sent?.cards ?? []).length >= 1, "The sent user turn shows the attachment card", JSON.stringify(sent));
+            const transcript = await ctx.control("session.read_transcript", { count: 8 });
+            const text = transcriptText(transcript);
+            assertEvidence(ctx, text.includes(".opencode/openwork/inbox/chat-attachments/"), "The first turn exposes the new workspace's inbox path", text.slice(0, 600));
+            assertEvidence(ctx, !text.includes("[attachment "), "No raw attachment token leaked into the message text", text.slice(0, 600));
+            ctx.output("created workspace", workspacePath);
+          },
+          screenshot: {
+            name: "workspace-created-with-attachment",
+            requireText: [FILENAME, ASSISTANT_SENTINEL],
+            rejectText: [MODEL_UPSELL_TITLE],
+            hashIncludes: "/session/",
+          },
+        });
+      },
+    },
+    {
+      name: "Verify the bytes inside the freshly created workspace",
+      run: async (ctx) => {
+        await ctx.prove("The exact bytes landed in the inbox of the workspace Run task created", {
+          voiceover: vo[2],
+          action: async () => {
+            const clicked = await ctx.eval(`(() => {
+              const button = Array.from(document.querySelectorAll("button")).find((node) => /-quarterly-costs\\.csv$/.test((node.textContent || "").trim()));
+              if (!button) return false;
+              button.click();
+              return true;
+            })()`);
+            ctx.assert(clicked === true, "Could not open the uploaded CSV from the FILES panel.");
+            await ctx.waitForText(`${EXPECTED_BYTES.length} bytes`, { timeoutMs: 15_000 });
+            await dismissOpenWorkModelsModal(ctx);
+          },
+          assert: async () => {
+            const transcript = await ctx.control("session.read_transcript", { count: 8 });
+            const text = transcriptText(transcript);
+            const fileUrl = extractAttachmentFileUrl(text);
+            assertEvidence(ctx, Boolean(fileUrl), "The first turn includes a file:// URL for the uploaded CSV", text.slice(0, 600));
+            const filePath = fileURLToPath(fileUrl);
+            assertEvidence(ctx, filePath.startsWith(`${CHAT_WORKSPACE_PATH}/`), "The uploaded file lives inside the workspace Run task created", filePath);
+            const digest = await readSandboxFileDigest(ctx, filePath);
+            assertEvidence(ctx, digest.bytes === EXPECTED_BYTES.length, "Uploaded CSV byte count matches the fixture", `${digest.bytes} bytes`);
+            assertEvidence(ctx, digest.sha256 === EXPECTED_SHA256, "Uploaded CSV sha256 matches the fixture exactly", digest.sha256);
+            ctx.output("created workspace inbox path", filePath);
+          },
+          screenshot: {
+            name: "bytes-in-created-workspace",
+            requireText: [FILENAME, `${EXPECTED_BYTES.length} bytes`],
+            rejectText: [MODEL_UPSELL_TITLE],
+          },
+        });
+      },
+    },
+  ],
+};
+
+function transcriptText(transcript) {
+  return (transcript?.messages ?? []).map((message) => message?.text ?? "").join("\n\n");
+}
+
+function extractAttachmentFileUrl(text) {
+  const match = text.match(/file:\/\/[^\s)]+quarterly-costs\.csv/);
+  return match ? match[0] : "";
+}
+
+async function readSandboxFileDigest(ctx, filePath) {
+  const pathBase64 = Buffer.from(filePath, "utf8").toString("base64");
+  const script = `set -euo pipefail
+node <<'NODE'
+const { createHash } = require("node:crypto");
+const { readFileSync } = require("node:fs");
+const filePath = Buffer.from(${JSON.stringify(pathBase64)}, "base64").toString("utf8");
+const bytes = readFileSync(filePath);
+console.log(JSON.stringify({ bytes: bytes.length, sha256: createHash("sha256").update(bytes).digest("hex") }));
+NODE
+`;
+  const result = await daytonaBash(ctx, script, 30_000);
+  const line = result.stdout.split(/\r?\n/).map((entry) => entry.trim()).find((entry) => entry.startsWith("{"));
+  if (!line) throw new Error(`No digest JSON returned: ${result.stdout}`);
+  return JSON.parse(line);
+}

--- a/evals/flows/new-task-composer-attachments.flow.mjs
+++ b/evals/flows/new-task-composer-attachments.flow.mjs
@@ -1,0 +1,442 @@
+/**
+ * User feedback (#new-task attachments): the attachment entry on the New Task
+ * page was disabled until the first message created the session, so tasks
+ * that need a file up front hit a circular dependency. This flow proves the
+ * fix end-to-end: attach a spreadsheet on the empty new-task screen, run the
+ * task, and witness the same file land in the worker workspace inbox and ride
+ * the first message.
+ *
+ * Required env:
+ * - OPENWORK_EVAL_DAYTONA_SANDBOX  Daytona sandbox running the Electron app
+ *   (used to start the mock provider and hash the uploaded file bytes).
+ */
+import { execFile } from "node:child_process";
+import { createHash } from "node:crypto";
+import { fileURLToPath } from "node:url";
+import { promisify } from "node:util";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "new-task-composer-attachments";
+const FILENAME = "quarterly-costs.csv";
+const CSV_SOURCE = [
+  "month,team,cost",
+  "2026-01,Platform,12400",
+  "2026-02,Platform,11875",
+  "2026-03,Platform,13210",
+  "",
+].join("\n");
+const EXPECTED_BYTES = Buffer.from(CSV_SOURCE, "utf8");
+const EXPECTED_SHA256 = createHash("sha256").update(EXPECTED_BYTES).digest("hex");
+const PROMPT = "Summarize the attached quarterly costs spreadsheet.";
+const OLD_BLOCK_MESSAGE = "Attachments become available once the task starts.";
+
+const MOCK_PORT = 18093;
+const PROVIDER_ID = "new-task-attachments-mock";
+const MODEL_ID = "new-task-attachment-mock";
+const MODEL_NAME = "New task attachment mock";
+const ASSISTANT_SENTINEL = "Quarterly costs received";
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+const execFileAsync = promisify(execFile);
+
+function assertEvidence(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual ? ` (actual: ${String(actual).slice(0, 400)})` : ""}`);
+}
+
+function errorMessage(error) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function daytonaBash(ctx, script, timeout = 60_000) {
+  const sandbox = ctx.env.OPENWORK_EVAL_DAYTONA_SANDBOX.trim();
+  const encoded = Buffer.from(script, "utf8").toString("base64");
+  try {
+    return await execFileAsync(
+      "daytona",
+      ["exec", sandbox, "--", "echo", encoded, "|", "base64", "-d", "|", "bash"],
+      { timeout, maxBuffer: 1024 * 1024 },
+    );
+  } catch (error) {
+    const stdout = error && typeof error === "object" && "stdout" in error ? error.stdout : "";
+    const stderr = error && typeof error === "object" && "stderr" in error ? error.stderr : "";
+    throw new Error(`daytona exec failed: ${errorMessage(error)} stdout=${String(stdout ?? "").slice(0, 400)} stderr=${String(stderr ?? "").slice(0, 400)}`);
+  }
+}
+
+// Minimal OpenAI-compatible endpoint inside the sandbox: list one model and
+// stream one canned completion so the auto-sent first message completes
+// deterministically without a real provider.
+const MOCK_SERVER_SOURCE = `import http from "node:http";
+const chunks = (text) => [
+  { id: "chatcmpl-ntca", object: "chat.completion.chunk", choices: [{ index: 0, delta: { role: "assistant" }, finish_reason: null }] },
+  { id: "chatcmpl-ntca", object: "chat.completion.chunk", choices: [{ index: 0, delta: { content: text }, finish_reason: null }] },
+  { id: "chatcmpl-ntca", object: "chat.completion.chunk", choices: [{ index: 0, delta: {}, finish_reason: "stop" }] },
+];
+http.createServer((req, res) => {
+  if (req.method === "GET" && req.url.startsWith("/v1/models")) {
+    res.writeHead(200, { "content-type": "application/json" });
+    res.end(JSON.stringify({ object: "list", data: [{ id: ${JSON.stringify(MODEL_ID)}, object: "model" }] }));
+    return;
+  }
+  if (req.method === "POST" && (req.url === "/v1/chat/completions" || req.url === "/chat/completions")) {
+    let body = "";
+    req.on("data", (part) => { body += part; });
+    req.on("end", () => {
+      res.writeHead(200, { "content-type": "text/event-stream", "cache-control": "no-cache", connection: "keep-alive" });
+      for (const chunk of chunks(${JSON.stringify(`${ASSISTANT_SENTINEL}: the workspace inbox copy of ${FILENAME} lists Platform team costs for 2026-01 through 2026-03.`)})) {
+        res.write("data: " + JSON.stringify(chunk) + "\\n\\n");
+      }
+      res.write("data: [DONE]\\n\\n");
+      res.end();
+    });
+    return;
+  }
+  res.writeHead(404, { "content-type": "application/json" });
+  res.end(JSON.stringify({ error: { message: "not found" } }));
+}).listen(${MOCK_PORT}, "127.0.0.1");
+console.log("ntca mock listening on ${MOCK_PORT}");
+`;
+
+async function startMockProvider(ctx) {
+  const script = `set -euo pipefail
+cat > /tmp/ntca-mock.mjs <<'MOCK'
+${MOCK_SERVER_SOURCE}
+MOCK
+(pgrep -f "node /tmp/ntca-mock.mjs" >/dev/null && exit 0) || true
+nohup node /tmp/ntca-mock.mjs > /tmp/ntca-mock.log 2>&1 < /dev/null &
+for i in $(seq 1 20); do
+  if curl -sf http://127.0.0.1:${MOCK_PORT}/v1/models >/dev/null; then echo mock-ready; exit 0; fi
+  sleep 0.5
+done
+cat /tmp/ntca-mock.log >&2
+exit 1
+`;
+  const result = await daytonaBash(ctx, script, 60_000);
+  ctx.assert(result.stdout.includes("mock-ready"), `Mock provider did not become ready: ${result.stdout} ${result.stderr}`);
+}
+
+async function appRouteState(ctx) {
+  return await ctx.eval(`(() => {
+    const hash = location.hash;
+    const control = window.__openworkControl;
+    const snapshot = control && typeof control.snapshot === "function" ? control.snapshot() : null;
+    const route = (snapshot && snapshot.route) || (hash.startsWith("#") ? hash.slice(1) : hash);
+    const pathSegment = (value, segment) => {
+      const marker = "/" + segment + "/";
+      const text = String(value || "");
+      const index = text.indexOf(marker);
+      if (index < 0) return "";
+      const rest = text.slice(index + marker.length);
+      const end = rest.indexOf("/");
+      return end < 0 ? rest : rest.slice(0, end);
+    };
+    const workspaceId = pathSegment(hash, "workspace") || localStorage.getItem("openwork.react.activeWorkspace") || "";
+    const sessionId = pathSegment(hash, "session") || pathSegment(route, "session") || "";
+    return { hash, route, workspaceId, sessionId };
+  })()`);
+}
+
+async function serverJson(ctx, path, init = {}) {
+  const method = init.method || "GET";
+  const raw = await ctx.eval(`(async () => {
+    const port = localStorage.getItem("openwork.server.port");
+    const token = localStorage.getItem("openwork.server.token");
+    if (!port || !token) return JSON.stringify({ ok: false, status: 0, text: "missing server port/token" });
+    const response = await fetch("http://127.0.0.1:" + port + ${JSON.stringify(path)}, {
+      method: ${JSON.stringify(method)},
+      headers: { Authorization: "Bearer " + token, "Content-Type": "application/json" },
+      body: ${init.body === undefined ? "undefined" : JSON.stringify(JSON.stringify(init.body))},
+    });
+    const text = await response.text();
+    return JSON.stringify({ ok: response.ok, status: response.status, text });
+  })()`, { awaitPromise: true });
+  const result = JSON.parse(raw);
+  ctx.assert(result.ok, `${method} ${path} failed: ${result.status} ${String(result.text).slice(0, 500)}`);
+  return result.text ? JSON.parse(result.text) : null;
+}
+
+async function waitForControlReady(ctx) {
+  await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 90_000, label: "control API" });
+  await ctx.waitFor(
+    `window.__openworkControl.listActions().some((item) => item.id === "session.create_task" && !item.disabled)`,
+    { timeoutMs: 60_000, label: "session.create_task enabled" },
+  );
+}
+
+async function configureMockProvider(ctx) {
+  const state = await appRouteState(ctx);
+  ctx.assert(Boolean(state.workspaceId), `Could not determine workspace id from ${state.hash}`);
+  ctx.workspaceId = state.workspaceId;
+
+  await serverJson(ctx, `/workspace/${encodeURIComponent(ctx.workspaceId)}/config`, {
+    method: "PATCH",
+    body: {
+      opencode: {
+        provider: {
+          [PROVIDER_ID]: {
+            npm: "@ai-sdk/openai-compatible",
+            name: MODEL_NAME,
+            options: { baseURL: `http://127.0.0.1:${MOCK_PORT}/v1`, apiKey: "sk-openwork-ntca-eval" },
+            models: {
+              [MODEL_ID]: {
+                name: MODEL_NAME,
+                attachment: true,
+                modalities: { input: ["text", "image", "pdf"], output: ["text"] },
+              },
+            },
+          },
+        },
+      },
+    },
+  });
+  await serverJson(ctx, `/workspace/${encodeURIComponent(ctx.workspaceId)}/engine/reload`, { method: "POST" });
+  await ctx.eval(`(() => {
+    const prefsRaw = localStorage.getItem("openwork.preferences");
+    let prefs = {};
+    try {
+      prefs = prefsRaw ? JSON.parse(prefsRaw) : {};
+    } catch {
+      prefs = {};
+    }
+    if (!prefs || typeof prefs !== "object" || Array.isArray(prefs)) prefs = {};
+    localStorage.setItem("openwork.preferences", JSON.stringify({
+      ...prefs,
+      defaultModel: { providerID: ${JSON.stringify(PROVIDER_ID)}, modelID: ${JSON.stringify(MODEL_ID)} },
+      modelVariant: null,
+      providerStepCompleted: true,
+    }));
+    localStorage.setItem("openwork.defaultModel", ${JSON.stringify(`${PROVIDER_ID}/${MODEL_ID}`)});
+    localStorage.removeItem("openwork.sessionModels." + ${JSON.stringify(ctx.workspaceId)});
+    location.reload();
+    return true;
+  })()`);
+  await waitForControlReady(ctx);
+  ctx.output("mock provider", JSON.stringify({ provider: PROVIDER_ID, model: MODEL_ID, port: MOCK_PORT }, null, 2));
+}
+
+async function openNewTaskScreen(ctx) {
+  const emptyRoute = await ctx.eval(`(() => {
+    const route = String(window.__openworkControl.snapshot().route || "");
+    const at = route.indexOf("/session/");
+    return at === -1 ? "" : route.slice(0, at) + "/session";
+  })()`);
+  if (typeof emptyRoute === "string" && emptyRoute.length > 0) await ctx.navigateHash(emptyRoute);
+  await ctx.waitForText("What do you need done?", { timeoutMs: 30_000 });
+}
+
+async function typePromptIntoHeroComposer(ctx) {
+  const result = await ctx.eval(`(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    if (!editor) return { ok: false, reason: "hero composer editor not found" };
+    editor.focus();
+    const data = new DataTransfer();
+    data.setData("text/plain", ${JSON.stringify(PROMPT)});
+    editor.dispatchEvent(new ClipboardEvent("paste", { bubbles: true, cancelable: true, clipboardData: data }));
+    return { ok: true };
+  })()`);
+  ctx.assert(result?.ok, result?.reason ?? "Failed to paste prompt into the new-task composer.");
+  await ctx.waitFor(`(() => {
+    const editor = document.querySelector('[contenteditable="true"][data-lexical-editor="true"]');
+    return Boolean(editor && String(editor.innerText || "").includes("quarterly costs"));
+  })()`, { timeoutMs: 10_000, label: "prompt text visible in hero composer" });
+}
+
+async function attachCsvThroughFileInput(ctx) {
+  const result = await ctx.eval(`(() => {
+    const input = document.querySelector('input[type="file"][multiple]');
+    if (!(input instanceof HTMLInputElement)) return { ok: false, reason: "composer file input not found" };
+    const transfer = new DataTransfer();
+    transfer.items.add(new File([${JSON.stringify(CSV_SOURCE)}], ${JSON.stringify(FILENAME)}, { type: "text/csv", lastModified: 1767225600000 }));
+    input.files = transfer.files;
+    input.dispatchEvent(new Event("change", { bubbles: true }));
+    return { ok: true };
+  })()`);
+  ctx.assert(result?.ok, result?.reason ?? "Failed to hand the CSV to the composer file input.");
+}
+
+function transcriptText(transcript) {
+  return (transcript?.messages ?? [])
+    .map((message) => message?.text ?? "")
+    .join("\n\n");
+}
+
+function extractAttachmentFileUrl(text) {
+  const match = text.match(/file:\/\/[^\s)]+quarterly-costs\.csv/);
+  return match ? match[0] : "";
+}
+
+async function readSandboxFileDigest(ctx, filePath) {
+  const pathBase64 = Buffer.from(filePath, "utf8").toString("base64");
+  const script = `set -euo pipefail
+node <<'NODE'
+const { createHash } = require("node:crypto");
+const { readFileSync } = require("node:fs");
+const filePath = Buffer.from(${JSON.stringify(pathBase64)}, "base64").toString("utf8");
+const bytes = readFileSync(filePath);
+console.log(JSON.stringify({
+  bytes: bytes.length,
+  sha256: createHash("sha256").update(bytes).digest("hex"),
+}));
+NODE
+`;
+  const result = await daytonaBash(ctx, script, 30_000);
+  const line = result.stdout.split(/\r?\n/).map((entry) => entry.trim()).find((entry) => entry.startsWith("{"));
+  if (!line) throw new Error(`No digest JSON returned: ${result.stdout}`);
+  return JSON.parse(line);
+}
+
+export default {
+  id: FLOW_ID,
+  title: "New Task composer accepts attachments before the session exists",
+  kind: "user-facing",
+  requiredEnv: ["OPENWORK_EVAL_DAYTONA_SANDBOX"],
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 60_000,
+      label: "control API",
+    });
+    const state = await ctx.waitFor(
+      `(() => {
+        const control = window.__openworkControl;
+        const route = control.snapshot().route;
+        if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+        const action = control.listActions().find((item) => item.id === "session.create_task");
+        if (action && !action.disabled) return "ready";
+        return null;
+      })()`,
+      { timeoutMs: 30_000, label: "session.create_task enabled" },
+    );
+    return state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); the new-task attachment proof requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "Point the workspace at the mock provider",
+      run: async (ctx) => {
+        await startMockProvider(ctx);
+        await configureMockProvider(ctx);
+      },
+    },
+    {
+      name: "Attach a spreadsheet on the New Task screen",
+      run: async (ctx) => {
+        await ctx.prove("The New Task composer accepts a file before any session exists", {
+          voiceover: vo[0],
+          action: async () => {
+            await openNewTaskScreen(ctx);
+            await typePromptIntoHeroComposer(ctx);
+            await attachCsvThroughFileInput(ctx);
+          },
+          assert: async () => {
+            await ctx.waitForText(FILENAME, { timeoutMs: 10_000 });
+            const route = await ctx.eval(`String(window.__openworkControl.snapshot().route || "")`);
+            assertEvidence(ctx, !String(route).includes("/session/ses_"), "No session exists yet while the file sits in the composer", String(route));
+            const attachState = await ctx.eval(`(() => {
+              const buttons = Array.from(document.querySelectorAll("button"));
+              const attach = buttons.find((button) => button.title === "Attach files");
+              return {
+                found: Boolean(attach),
+                disabled: attach ? attach.disabled : null,
+                title: attach ? attach.title : null,
+              };
+            })()`);
+            assertEvidence(ctx, attachState?.found === true && attachState?.disabled === false, "The attach button on the New Task screen is enabled", JSON.stringify(attachState));
+            const bodyText = await ctx.eval("document.body.innerText");
+            assertEvidence(ctx, !String(bodyText).includes(OLD_BLOCK_MESSAGE), "The old 'attachments become available once the task starts' block is gone", OLD_BLOCK_MESSAGE);
+          },
+          screenshot: {
+            name: "csv-attached-before-task",
+            requireText: [FILENAME, "What do you need done?"],
+            rejectText: [OLD_BLOCK_MESSAGE],
+          },
+        });
+      },
+    },
+    {
+      name: "Run the task and send the attachment with the first message",
+      run: async (ctx) => {
+        await ctx.prove("Run task creates the session and the first message carries the attachment", {
+          voiceover: vo[1],
+          action: async () => {
+            const clicked = await ctx.eval(`(() => {
+              const button = Array.from(document.querySelectorAll("button")).find((item) => item.textContent.trim() === "Run task" && !item.disabled);
+              if (!button) return false;
+              button.click();
+              return true;
+            })()`);
+            ctx.assert(clicked === true, "Could not click the Run task button on the New Task screen.");
+            await ctx.waitFor(`String(window.__openworkControl.snapshot().route || "").includes("/session/ses_")`, { timeoutMs: 60_000, label: "session route after run task" });
+            // Scope to the transcript's assistant message: sidebar titles of
+            // previous runs can also contain the sentinel.
+            await ctx.waitFor(`(() => {
+              const messages = Array.from(document.querySelectorAll('[data-message-role="assistant"]'));
+              return messages.some((message) => (message.innerText || "").includes(${JSON.stringify(ASSISTANT_SENTINEL)})) || null;
+            })()`, { timeoutMs: 120_000, label: "assistant reply with mock sentinel" });
+          },
+          assert: async () => {
+            // Text-like attachments render an "Open … in default app" card in
+            // the sent turn (images/office files render a Download card).
+            const sentCard = await ctx.waitFor(`(() => {
+              const nodes = Array.from(document.querySelectorAll("button[aria-label], a[aria-label]"));
+              return nodes.some((node) => (node.getAttribute("aria-label") || "").includes(${JSON.stringify(FILENAME)})) || null;
+            })()`, { timeoutMs: 30_000, label: "sent attachment card in transcript" });
+            assertEvidence(ctx, sentCard === true, "The sent user turn shows the attachment card", String(sentCard));
+            const transcript = await ctx.control("session.read_transcript", { count: 8 });
+            const text = transcriptText(transcript);
+            assertEvidence(ctx, text.includes(".opencode/openwork/inbox/chat-attachments/"), "The submitted turn exposes the worker inbox path", text.slice(0, 600));
+            assertEvidence(ctx, text.includes(ASSISTANT_SENTINEL), "The mock model answered, proving the auto-send completed", text.slice(-400));
+            assertEvidence(ctx, !text.includes("[attachment "), "The raw composer attachment token is not leaked into the message text", text.slice(0, 600));
+          },
+          screenshot: {
+            name: "first-message-with-attachment",
+            requireText: [FILENAME, ASSISTANT_SENTINEL],
+            hashIncludes: "/session/",
+          },
+        });
+      },
+    },
+    {
+      name: "Verify the uploaded bytes in the worker workspace inbox",
+      run: async (ctx) => {
+        await ctx.prove("The attachment bytes were copied into the worker workspace inbox unchanged", {
+          voiceover: vo[2],
+          action: async () => {
+            // Open the uploaded inbox copy from the FILES panel so the frame
+            // shows the workspace artifact (name + byte count), not just chat.
+            const clicked = await ctx.eval(`(() => {
+              const button = Array.from(document.querySelectorAll("button")).find((node) => /-quarterly-costs\\.csv$/.test((node.textContent || "").trim()));
+              if (!button) return false;
+              button.click();
+              return true;
+            })()`);
+            ctx.assert(clicked === true, "Could not open the uploaded CSV from the FILES panel.");
+            await ctx.waitForText(`${EXPECTED_BYTES.length} bytes`, { timeoutMs: 15_000 });
+          },
+          assert: async () => {
+            const transcript = await ctx.control("session.read_transcript", { count: 8 });
+            const text = transcriptText(transcript);
+            const fileUrl = extractAttachmentFileUrl(text);
+            assertEvidence(ctx, Boolean(fileUrl), "Submitted turn includes a file:// URL for the uploaded CSV", text.slice(0, 600));
+            const filePath = fileURLToPath(fileUrl);
+            assertEvidence(ctx, filePath.includes(".opencode/openwork/inbox/chat-attachments/"), "File path is inside the worker chat-attachments inbox", filePath);
+            const digest = await readSandboxFileDigest(ctx, filePath);
+            assertEvidence(ctx, digest.bytes === EXPECTED_BYTES.length, "Uploaded CSV byte count matches the fixture", `${digest.bytes} bytes`);
+            assertEvidence(ctx, digest.sha256 === EXPECTED_SHA256, "Uploaded CSV sha256 matches the fixture exactly", digest.sha256);
+            ctx.output("worker inbox path", filePath);
+          },
+          screenshot: {
+            name: "workspace-inbox-proof",
+            requireText: [FILENAME, `${EXPECTED_BYTES.length} bytes`],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/voiceovers/new-task-composer-attachments-chat-first.md
+++ b/evals/voiceovers/new-task-composer-attachments-chat-first.md
@@ -1,0 +1,7 @@
+# new-task-composer-attachments-chat-first — Attach a file before any workspace exists
+
+1. This is a brand-new OpenWork with no workspace at all, and the New Task composer still takes my spreadsheet — I attach it before there is anywhere to put it.
+
+2. One press of Run task sets up my chat workspace, opens the task, and sends my file with the very first message — nothing was dropped on the way.
+
+3. The bytes landed in the workspace that was created moments earlier, at a real path tools can open.

--- a/evals/voiceovers/new-task-composer-attachments.md
+++ b/evals/voiceovers/new-task-composer-attachments.md
@@ -1,0 +1,7 @@
+# new-task-composer-attachments — Attach files before the task exists
+
+1. I'm on the New Task screen, no task has started yet, and I add a spreadsheet straight into the composer — the file chip appears right away instead of the old "attachments become available once the task starts" block.
+
+2. I press Run task, and the task starts with my file already on board — the very first message shows the attachment, no need to wait for the session and re-attach.
+
+3. Behind the scenes the file was copied into the worker's workspace inbox as the task began — the exact same bytes, at a real path tools can open.


### PR DESCRIPTION
## Summary

User feedback (in-app, Jul 27 — OpenWork v0.18.7): the attachment button on the **New Task page** is disabled until the first message creates the session, so tasks that need a file up front hit a circular dependency ("upload is only enabled *after* the task starts, but I need the file *to describe* the task").

This PR lets the empty-session (New Task) composer accept attachments **before any session exists**:

- `new-task-composer.tsx` collects attachments in memory (chips in the draft, same `[attachment <id>]` token mechanics as the session composer) instead of hard-disabling the paperclip.
- Running the task passes the attachments up through `SessionEmptyHero` → `onChatFirstTask` / `onCreateTaskWithPrompt`.
- After the session is created, the route seeds the composer state store with the draft **and** the attachments before `markComposerAutoSend`, so the surface's normal auto-send uploads them into the worker workspace inbox and sends them with the first message — exactly the behavior the feedback asked for. The persisted draft fallback stores a cleaned copy (File objects don't survive restarts).

Both hero variants are wired: workspace-selected (proven by the eval below) and chat-first (same seeding path in `handleCreateWorkspace`).

## Tests

- `pnpm --filter @openwork/app typecheck` — passed
- `pnpm --filter @openwork/app test` — 480 pass / 0 fail (90 files)
- New coded fraimz flow: `pnpm fraimz --flow new-task-composer-attachments --cdp-url <daytona-electron>` — **PASSED** (frame proof comment below): attach CSV on the New Task screen with no session → Run task → first message carries the attachment → exact bytes (sha256-verified) in `.opencode/openwork/inbox/chat-attachments/` inside the sandbox workspace.

Validated in a Daytona Electron sandbox (local macOS GUI launch was unavailable from the agent session).