### PR TITLE
fix(landing): route contact and feedback links

### DIFF
--- a/ee/apps/den-web/app/(den)/_lib/feedback.ts
+++ b/ee/apps/den-web/app/(den)/_lib/feedback.ts
@@ -1,4 +1,4 @@
-export const OPENWORK_FEEDBACK_PATH = "/feedback";
+export const OPENWORK_FEEDBACK_URL = "https://openworklabs.com/feedback";
 
 export function buildDenFeedbackUrl(options?: {
   pathname?: string;
@@ -19,5 +19,5 @@ export function buildDenFeedbackUrl(options?: {
     params.set("topic", options.topic);
   }
 
-  return `${OPENWORK_FEEDBACK_PATH}?${params.toString()}`;
+  return `${OPENWORK_FEEDBACK_URL}?${params.toString()}`;
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/org-dashboard-shell.tsx
@@ -347,6 +347,7 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
       !profilePromptDismissed &&
       user.name?.trim() === DEFAULT_AUTH_NAME,
   );
+  const showFeedbackLink = runtimeConfigLoaded && runtimeConfig.orgMode === "multi_org";
   const feedbackHref = buildDenFeedbackUrl({
     pathname,
     orgSlug: activeOrg?.slug,
@@ -749,15 +750,17 @@ export function OrgDashboardShell({ children }: { children: React.ReactNode }) {
           </div>
 
           <div className="flex items-center gap-1">
-            <a
-              href={feedbackHref}
-              target="_blank"
-              rel="noreferrer"
-              className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
-            >
-              <MessageSquare className="h-4 w-4" />
-              <span className="hidden sm:inline">Feedback</span>
-            </a>
+            {showFeedbackLink ? (
+              <a
+                href={feedbackHref}
+                target="_blank"
+                rel="noreferrer"
+                className="flex items-center gap-1.5 rounded-lg px-3 py-1.5 text-[13px] text-gray-500 transition-colors hover:bg-gray-50 hover:text-gray-700"
+              >
+                <MessageSquare className="h-4 w-4" />
+                <span className="hidden sm:inline">Feedback</span>
+              </a>
+            ) : null}
             <a
               href={OPENWORK_DOCS_URL}
               target="_blank"

--- a/ee/apps/den-web/package.json
+++ b/ee/apps/den-web/package.json
@@ -10,7 +10,7 @@
     "start": "next start --hostname 0.0.0.0 --port 3005",
     "lint": "next lint",
     "typecheck": "tsc --noEmit --pretty false",
-    "test": "bun test tests/onboarding-page.test.ts tests/openwork-models-page.test.ts tests/web-page.test.ts tests/byok-page-primitives.test.ts tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/cloud-super-admins-role-hierarchy.test.ts tests/install-errors.test.ts tests/install-download-href.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts tests/scim-sso-readiness.test.ts app/api/_lib/upstream-proxy.test.mjs",
+    "test": "bun test tests/onboarding-page.test.ts tests/openwork-models-page.test.ts tests/web-page.test.ts tests/feedback-url.test.ts tests/byok-page-primitives.test.ts tests/observability-config.test.ts tests/desktop-version-options.test.ts tests/cloud-super-admins-role-hierarchy.test.ts tests/install-errors.test.ts tests/install-download-href.test.ts tests/desktop-handoff.test.ts tests/single-org-signup-ui.test.ts tests/auth-landing-contract.test.ts tests/mcp-connection-smart-add.test.ts tests/mcp-credential-autofill.test.ts tests/org-selection-background.test.ts tests/join-org-invite-clean.test.ts tests/scim-sso-readiness.test.ts app/api/_lib/upstream-proxy.test.mjs",
     "test:observability": "bun test tests/observability-config.test.ts app/api/_lib/upstream-proxy.test.mjs"
   },
   "dependencies": {

--- a/ee/apps/den-web/tests/feedback-url.test.ts
+++ b/ee/apps/den-web/tests/feedback-url.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, test } from "bun:test";
+
+import { buildDenFeedbackUrl, OPENWORK_FEEDBACK_URL } from "../app/(den)/_lib/feedback";
+
+describe("Den feedback links", () => {
+  test("point to the public landing feedback form with dashboard context", () => {
+    const url = buildDenFeedbackUrl({
+      pathname: "/dashboard/org-settings",
+      orgSlug: "org_123",
+      topic: "workspace-limits",
+    });
+
+    expect(url.startsWith(`${OPENWORK_FEEDBACK_URL}?`)).toBe(true);
+    expect(url).toContain("source=openwork-web-app");
+    expect(url).toContain("deployment=web");
+    expect(url).toContain("entrypoint=%2Fdashboard%2Forg-settings");
+    expect(url).toContain("org=org_123");
+    expect(url).toContain("topic=workspace-limits");
+  });
+});

--- a/ee/apps/landing/app/api/app-feedback/route.ts
+++ b/ee/apps/landing/app/api/app-feedback/route.ts
@@ -19,6 +19,7 @@ type FeedbackPayload = {
   message?: string;
   website?: string;
   startedAt?: number | string;
+  mode?: string;
   context?: FeedbackContext;
 };
 
@@ -107,6 +108,7 @@ export async function POST(request: Request) {
   const message = sanitizeValue(payload.message, 5000);
   const name = sanitizeValue(payload.name, 120);
   const email = sanitizeValue(payload.email, 240);
+  const mode = sanitizeValue(payload.mode, 40) === "contact" ? "contact" : "feedback";
 
   if (!name) {
     return jsonResponse(request,
@@ -137,6 +139,7 @@ export async function POST(request: Request) {
     name,
     email,
     message,
+    mode,
     source: context.source || "openwork-app",
     entrypoint: context.entrypoint || "unknown",
     deployment: context.deployment || "desktop",

--- a/ee/apps/landing/app/contact/page.tsx
+++ b/ee/apps/landing/app/contact/page.tsx
@@ -1,0 +1,55 @@
+import Link from "next/link";
+import { AppFeedbackForm, type AppFeedbackPrefill } from "../../components/app-feedback-form";
+import { OpenWorkMark } from "../../components/openwork-mark";
+import { SiteFooter } from "../../components/site-footer";
+import { baseOpenGraph } from "../../lib/seo";
+
+export const metadata = {
+  title: "OpenWork — Contact",
+  description: "Contact the OpenWork team for product, support, security, and sales questions.",
+  alternates: {
+    canonical: "/contact",
+  },
+  openGraph: {
+    ...baseOpenGraph,
+    url: "https://openworklabs.com/contact",
+  },
+};
+
+const prefill: AppFeedbackPrefill = {
+  source: "openwork-contact-page",
+  entrypoint: "/contact",
+  deployment: "landing",
+  appVersion: "",
+  openworkServerVersion: "",
+  opencodeVersion: "",
+  osName: "",
+  osVersion: "",
+  platform: "web",
+};
+
+export default function ContactPage() {
+  return (
+    <div className="min-h-screen bg-[radial-gradient(circle_at_top,_rgba(72,187,255,0.14),_transparent_34%),linear-gradient(180deg,_#f7fbff_0%,_#edf4fb_100%)]">
+      <div className="mx-auto max-w-5xl px-6 pb-20 pt-6 md:px-8 md:pt-8">
+        <header className="mb-10 flex items-center justify-between gap-4">
+          <Link href="/" className="inline-flex items-center gap-3 text-[#011627]">
+            <OpenWorkMark className="h-[30px] w-[38px]" />
+            <span className="text-[1.2rem] font-semibold tracking-tight lowercase">
+              OpenWork
+            </span>
+          </Link>
+          <Link
+            href="/download"
+            className="rounded-full border border-white/80 bg-white/80 px-4 py-2 text-[13px] font-medium text-slate-700 shadow-sm transition hover:bg-white"
+          >
+            Download latest app
+          </Link>
+        </header>
+
+        <AppFeedbackForm prefill={prefill} mode="contact" />
+        <SiteFooter />
+      </div>
+    </div>
+  );
+}

--- a/ee/apps/landing/components/app-feedback-form.tsx
+++ b/ee/apps/landing/components/app-feedback-form.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { AlertCircle, CheckCircle2, MessageSquareText, Send } from "lucide-react";
+import { AlertCircle, CheckCircle2, Copy, Mail, MessageSquareText, Send } from "lucide-react";
 import { useMemo, useState } from "react";
 
 export type AppFeedbackPrefill = {
@@ -17,16 +17,20 @@ export type AppFeedbackPrefill = {
 
 type Props = {
   prefill: AppFeedbackPrefill;
+  mode?: "feedback" | "contact";
 };
 
 type SubmitState = "idle" | "loading" | "success" | "error";
 
 const INITIAL_MESSAGE = "";
+const TEAM_EMAIL = "team@openworklabs.com";
 
 export function AppFeedbackForm(props: Props) {
+  const mode = props.mode ?? "feedback";
   const [name, setName] = useState("");
   const [email, setEmail] = useState("");
   const [message, setMessage] = useState(INITIAL_MESSAGE);
+  const [emailCopied, setEmailCopied] = useState(false);
   const [website, setWebsite] = useState("");
   const [startedAt, setStartedAt] = useState(() => Date.now());
   const [state, setState] = useState<SubmitState>("idle");
@@ -58,6 +62,12 @@ export function AppFeedbackForm(props: Props) {
     setErrorMessage("");
   };
 
+  const copyTeamEmail = async () => {
+    await navigator.clipboard.writeText(TEAM_EMAIL);
+    setEmailCopied(true);
+    window.setTimeout(() => setEmailCopied(false), 1800);
+  };
+
   const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault();
     const trimmedName = name.trim();
@@ -77,7 +87,11 @@ export function AppFeedbackForm(props: Props) {
 
     if (!trimmed) {
       setState("error");
-      setErrorMessage("Please describe the issue before sending feedback.");
+      setErrorMessage(
+        mode === "contact"
+          ? "Please add your question before sending."
+          : "Please describe the issue before sending feedback.",
+      );
       return;
     }
 
@@ -96,6 +110,7 @@ export function AppFeedbackForm(props: Props) {
           message: trimmed,
           website,
           startedAt,
+          mode,
           context: props.prefill,
         }),
       });
@@ -128,15 +143,18 @@ export function AppFeedbackForm(props: Props) {
       <div className="grid gap-6 lg:grid-cols-[1.2fr_0.8fr]">
         <div className="rounded-[1.5rem] border border-white/70 bg-white/85 p-6 shadow-sm backdrop-blur">
           <div className="mb-4 inline-flex items-center gap-2 rounded-full border border-slate-200/80 bg-slate-50 px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] text-slate-500">
-            <MessageSquareText size={12} />
-            app feedback
+            {mode === "contact" ? <Mail size={12} /> : <MessageSquareText size={12} />}
+            {mode === "contact" ? "contact the team" : "app feedback"}
           </div>
           <h1 className="max-w-2xl text-3xl font-semibold tracking-tight text-[#011627] md:text-4xl">
-            Tell us what broke, felt rough, or needs polish.
+            {mode === "contact"
+              ? "Have questions about OpenWork?"
+              : "Tell us what broke, felt rough, or needs polish."}
           </h1>
           <p className="mt-3 max-w-2xl text-[15px] leading-relaxed text-slate-600">
-            Your note goes to the OpenWork team with your contact details, app
-            version, and runtime context already attached.
+            {mode === "contact"
+              ? "Send the OpenWork team a note about sales, security, support, or anything else you want to ask."
+              : "Your note goes to the OpenWork team with your contact details, app version, and runtime context already attached."}
           </p>
 
           {state === "success" ? (
@@ -144,16 +162,20 @@ export function AppFeedbackForm(props: Props) {
               <div className="flex items-start gap-3">
                 <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0" />
                 <div>
-                  <div className="text-[15px] font-semibold">Feedback sent</div>
+                  <div className="text-[15px] font-semibold">
+                    {mode === "contact" ? "Message sent" : "Feedback sent"}
+                  </div>
                   <p className="mt-1 text-[14px] leading-relaxed text-emerald-800">
-                    Thanks. We received your note and the attached diagnostics.
+                    {mode === "contact"
+                      ? "Thanks. We received your note and will follow up by email."
+                      : "Thanks. We received your note and the attached diagnostics."}
                   </p>
                   <button
                     type="button"
                     onClick={reset}
                     className="mt-4 inline-flex items-center rounded-full border border-emerald-300 bg-white px-4 py-2 text-[13px] font-medium text-emerald-900 transition hover:border-emerald-400 hover:bg-emerald-100"
                   >
-                    Send another message
+                    {mode === "contact" ? "Send another question" : "Send another message"}
                   </button>
                 </div>
               </div>
@@ -207,12 +229,16 @@ export function AppFeedbackForm(props: Props) {
 
               <div>
                 <label className="mb-2 block text-[12px] font-semibold uppercase tracking-[0.16em] text-slate-500">
-                  What happened?
+                  {mode === "contact" ? "How can we help?" : "What happened?"}
                 </label>
                 <textarea
                   value={message}
                   onChange={(event) => setMessage(event.target.value)}
-                  placeholder="What were you trying to do? What did you expect? What actually happened?"
+                  placeholder={
+                    mode === "contact"
+                      ? "Tell us what you are working on or what you would like to know."
+                      : "What were you trying to do? What did you expect? What actually happened?"
+                  }
                   className="min-h-[220px] w-full rounded-[1.5rem] border border-slate-200 bg-white px-4 py-4 text-[15px] leading-relaxed text-[#011627] outline-none transition focus:border-slate-300 focus:ring-4 focus:ring-slate-100"
                   disabled={state === "loading"}
                   required
@@ -232,36 +258,74 @@ export function AppFeedbackForm(props: Props) {
                 className="doc-button inline-flex items-center gap-2 disabled:cursor-not-allowed disabled:opacity-60"
               >
                 <Send size={16} />
-                {state === "loading" ? "Sending..." : "Send feedback"}
+                {state === "loading"
+                  ? "Sending..."
+                  : mode === "contact"
+                    ? "Send question"
+                    : "Send feedback"}
               </button>
             </form>
           )}
         </div>
 
         <aside className="rounded-[1.5rem] border border-slate-200/80 bg-[#0b1728] p-5 text-white shadow-sm">
-          <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-200/80">
-            Attached context
-          </div>
-          <p className="mt-3 text-[14px] leading-relaxed text-slate-300">
-            These details are captured from the app link so the team can triage
-            the issue faster.
-          </p>
-
-          <div className="mt-5 grid gap-3">
-            {contextItems.map((item) => (
-              <div
-                key={item.label}
-                className="rounded-[1.15rem] border border-white/10 bg-white/5 px-4 py-3"
-              >
+          {mode === "contact" ? (
+            <>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-200/80">
+                Prefer to email us instead?
+              </div>
+              <p className="mt-3 text-[14px] leading-relaxed text-slate-300">
+                Send a message directly and we will route it to the right person.
+              </p>
+              <div className="mt-5 rounded-[1.15rem] border border-white/10 bg-white/5 px-4 py-3">
                 <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
-                  {item.label}
+                  Team email
                 </div>
-                <div className="mt-1 break-words font-mono text-[13px] text-white">
-                  {item.value}
+                <div className="mt-2 flex flex-wrap items-center gap-3">
+                  <a
+                    className="font-mono text-[14px] text-white underline-offset-4 hover:underline"
+                    href={`mailto:${TEAM_EMAIL}`}
+                  >
+                    {TEAM_EMAIL}
+                  </a>
+                  <button
+                    type="button"
+                    onClick={() => void copyTeamEmail()}
+                    className="inline-flex items-center gap-1.5 rounded-full border border-white/15 bg-white/10 px-3 py-1.5 text-[12px] font-medium text-white transition hover:bg-white/15"
+                  >
+                    <Copy size={13} />
+                    {emailCopied ? "Copied" : "Copy"}
+                  </button>
                 </div>
               </div>
-            ))}
-          </div>
+            </>
+          ) : (
+            <>
+              <div className="text-[11px] font-semibold uppercase tracking-[0.18em] text-sky-200/80">
+                Attached context
+              </div>
+              <p className="mt-3 text-[14px] leading-relaxed text-slate-300">
+                These details are captured from the app link so the team can triage
+                the issue faster.
+              </p>
+
+              <div className="mt-5 grid gap-3">
+                {contextItems.map((item) => (
+                  <div
+                    key={item.label}
+                    className="rounded-[1.15rem] border border-white/10 bg-white/5 px-4 py-3"
+                  >
+                    <div className="text-[11px] font-semibold uppercase tracking-[0.16em] text-slate-400">
+                      {item.label}
+                    </div>
+                    <div className="mt-1 break-words font-mono text-[13px] text-white">
+                      {item.value}
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </>
+          )}
         </aside>
       </div>
     </section>

--- a/ee/apps/landing/components/site-footer.tsx
+++ b/ee/apps/landing/components/site-footer.tsx
@@ -41,6 +41,9 @@ export function SiteFooter() {
           <Link href="/enterprise" className="transition-colors hover:text-gray-800">
             Enterprise
           </Link>
+          <Link href="/contact" className="transition-colors hover:text-gray-800">
+            Contact
+          </Link>
           <Link href="/trust" className="transition-colors hover:text-gray-800">
             Trust Center
           </Link>

--- a/ee/apps/landing/test/contact-page.test.tsx
+++ b/ee/apps/landing/test/contact-page.test.tsx
@@ -1,0 +1,39 @@
+import { describe, expect, test } from "bun:test";
+import { createElement } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import { AppFeedbackForm } from "../components/app-feedback-form";
+import { SiteFooter } from "../components/site-footer";
+
+const contactPrefill = {
+  source: "openwork-contact-page",
+  entrypoint: "/contact",
+  deployment: "landing",
+  appVersion: "",
+  openworkServerVersion: "",
+  opencodeVersion: "",
+  osName: "",
+  osVersion: "",
+  platform: "web",
+};
+
+describe("Contact page affordances", () => {
+  test("renders contact-oriented copy and the direct team email", () => {
+    const html = renderToStaticMarkup(createElement(AppFeedbackForm, {
+      prefill: contactPrefill,
+      mode: "contact",
+    }));
+
+    expect(html).toContain("Have questions about OpenWork?");
+    expect(html).toContain("Prefer to email us instead?");
+    expect(html).toContain("team@openworklabs.com");
+    expect(html).toContain("Send question");
+  });
+
+  test("footer links to the contact page", () => {
+    const html = renderToStaticMarkup(createElement(SiteFooter));
+
+    expect(html).toContain('href="/contact"');
+    expect(html).toContain("Contact");
+  });
+});

--- a/packages/email/src/templates/feedback.tsx
+++ b/packages/email/src/templates/feedback.tsx
@@ -4,6 +4,7 @@ export type FeedbackEmailProps = {
   name: string
   email: string
   message: string
+  mode?: "feedback" | "contact"
   source: string
   entrypoint: string
   deployment: string
@@ -21,6 +22,7 @@ export function FeedbackEmail({
   name,
   email,
   message,
+  mode = "feedback",
   source,
   entrypoint,
   deployment,
@@ -34,6 +36,8 @@ export function FeedbackEmail({
   submittedAt,
 }: FeedbackEmailProps) {
   const osLabel = [osName, osVersion].filter(Boolean).join(" ")
+  const isContact = mode === "contact"
+  const label = isContact ? "contact message" : "feedback"
   const metadata = [
     ["Source", source],
     ["Entrypoint", entrypoint],
@@ -49,11 +53,11 @@ export function FeedbackEmail({
   return (
     <Html>
       <Head />
-      <Preview>{name} sent OpenWork feedback from {entrypoint || source || "unknown"}</Preview>
+      <Preview>{name} sent an OpenWork {label} from {entrypoint || source || "unknown"}</Preview>
       <Body style={styles.body}>
         <Container style={styles.container}>
-          <Text style={styles.eyebrow}>OpenWork feedback</Text>
-          <Heading style={styles.heading}>Feedback from {name}</Heading>
+          <Text style={styles.eyebrow}>{isContact ? "OpenWork contact" : "OpenWork feedback"}</Text>
+          <Heading style={styles.heading}>{isContact ? "Contact message" : "Feedback"} from {name}</Heading>
           <Text style={styles.contact}>{email}</Text>
 
           <Section style={styles.messageBox}>


### PR DESCRIPTION
## Summary\n- Point Den Web feedback links to the public landing feedback form on openworklabs.com\n- Hide the feedback button for self-hosted single-org installs\n- Add a /contact landing page with contact-oriented copy, team@openworklabs.com, and a copy button while reusing the feedback sender\n- Add focused tests for the Den feedback URL and contact page affordances\n\n## Tests\n- pnpm --dir ee/apps/den-web exec bun test tests/feedback-url.test.ts\n- pnpm --dir ee/apps/landing exec bun test test/contact-page.test.tsx\n- pnpm --dir ee/apps/den-web typecheck\n- pnpm --dir ee/apps/landing exec tsc --noEmit --pretty false\n\n## Proof\n- Fraimz not run for this small routing/contact-page change; focused unit tests and typechecks passed.