### PR TITLE
feat(den-api): checkpoint sandbox state and recycle stale sandboxes onto the pinned snapshot

### DIFF
--- a/ee/apps/den-api/src/env.ts
+++ b/ee/apps/den-api/src/env.ts
@@ -144,6 +144,8 @@ const EnvSchema = z.object({
   DAYTONA_DELETE_TIMEOUT_SECONDS: z.string().optional(),
   DAYTONA_STOP_TIMEOUT_SECONDS: z.string().optional(),
   DAYTONA_HEALTHCHECK_TIMEOUT_MS: z.string().optional(),
+  DEN_CKPT_INTERVAL_SECONDS: z.string().optional(),
+  DEN_CKPT_KEEP: z.string().optional(),
   INFERENCE_PROXY_BASE_URL: z.string().optional(),
   OPENROUTER_MANAGEMENT_API_KEY: z.string().optional(),
   OPENROUTER_WORKSPACE_ID: z.string().optional(),
@@ -621,6 +623,8 @@ export const env = {
     healthcheckTimeoutMs: Number(
       parsed.DAYTONA_HEALTHCHECK_TIMEOUT_MS ?? "300000",
     ),
+    checkpointIntervalSeconds: Number(parsed.DEN_CKPT_INTERVAL_SECONDS ?? "300"),
+    checkpointKeep: Number(parsed.DEN_CKPT_KEEP ?? "3"),
     pollIntervalMs: DEN_WORKER_POLL_INTERVAL_MS,
   },
 }

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -1,5 +1,5 @@
 import { timingSafeEqual } from "node:crypto"
-import { and, asc, eq, isNull } from "@openwork-ee/den-db/drizzle"
+import { and, asc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
 import { WorkerTable, WorkerTokenTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import type { Hono, MiddlewareHandler } from "hono"
@@ -34,10 +34,12 @@ type CloudRouteOptions = {
   now?: () => number
 }
 
-type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "name" | "status">
+type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "name" | "status"> & {
+  image_version?: typeof WorkerTable.$inferSelect.image_version
+}
 type WorkerToken = Pick<typeof WorkerTokenTable.$inferSelect, "scope" | "token">
 type CloudSandboxRecord = Pick<NonNullable<Awaited<ReturnType<typeof getDaytonaSandboxRecord>>>, "signed_preview_url" | "signed_preview_url_expires_at">
-type CloudSandboxInspection = { state: string | null } | null
+type CloudSandboxInspection = { state: string | null; hasCheckpoint?: boolean } | null
 type OrgId = typeof WorkerTable.$inferSelect.org_id
 type UserId = NonNullable<typeof WorkerTable.$inferSelect.created_by_user_id>
 type WorkerId = typeof WorkerTable.$inferSelect.id
@@ -59,6 +61,7 @@ type CloudWorkerStore = {
   insertWorkerTokens: (input: { workerId: WorkerId; hostToken: string; clientToken: string; activityToken: string }) => Promise<void>
   deleteCreateRaceLoser: (workerId: WorkerId) => Promise<void>
   claimFailedWorker: (workerId: WorkerId) => Promise<boolean>
+  claimRecycleWorker: (workerId: WorkerId) => Promise<boolean>
   getActiveTokens: (workerId: WorkerId) => Promise<WorkerToken[]>
   markProvisioningWorkerFailed: (workerId: WorkerId) => Promise<void>
   markHealthyWorkerFailed: (workerId: WorkerId) => Promise<void>
@@ -262,6 +265,14 @@ const databaseCloudWorkerStore: CloudWorkerStore = {
       .update(WorkerTable)
       .set({ status: "provisioning" })
       .where(and(eq(WorkerTable.id, workerId), eq(WorkerTable.status, "failed")))
+
+    return hasChangedRows(result)
+  },
+  async claimRecycleWorker(workerId) {
+    const result: unknown = await db
+      .update(WorkerTable)
+      .set({ status: "provisioning" })
+      .where(and(eq(WorkerTable.id, workerId), inArray(WorkerTable.status, ["healthy", "stopped"])))
 
     return hasChangedRows(result)
   },
@@ -540,6 +551,44 @@ async function refreshAndProbeSignedPreview(input: {
   }
 }
 
+function isStoppedSandboxState(state: string | null) {
+  return state?.toLowerCase() === "stopped"
+}
+
+function workerNeedsSnapshotRecycle(worker: CloudWorker) {
+  const snapshot = env.daytona.snapshot
+  return Boolean(snapshot && worker.image_version !== snapshot)
+}
+
+async function startStaleStoppedRecycle(input: {
+  worker: CloudWorker
+  sandboxExists: boolean
+  inspectSandbox: InspectSandbox
+  startWake: (workerId: CloudWorker["id"]) => void
+  store: CloudWorkerStore
+}): Promise<boolean> {
+  if (!input.sandboxExists || !workerNeedsSnapshotRecycle(input.worker)) {
+    return false
+  }
+
+  let inspection: CloudSandboxInspection = null
+  try {
+    inspection = await input.inspectSandbox(input.worker.id)
+  } catch {
+    return false
+  }
+
+  if (!isStoppedSandboxState(inspection?.state ?? null) || inspection?.hasCheckpoint !== true) {
+    return false
+  }
+
+  const claimed = await input.store.claimRecycleWorker(input.worker.id)
+  if (claimed) {
+    input.startWake(input.worker.id)
+  }
+  return true
+}
+
 async function recoverUnhealthyCloudSandbox(input: {
   worker: CloudWorker
   continueProvisioning: typeof continueCloudProvisioning
@@ -580,6 +629,17 @@ async function resolveCloudInstance(input: {
   }
 
   if (input.worker.status === "stopped") {
+    const sandbox = await input.getSandboxRecord(input.worker.id)
+    if (await startStaleStoppedRecycle({
+      worker: input.worker,
+      sandboxExists: Boolean(sandbox),
+      inspectSandbox: input.inspectSandbox,
+      startWake: input.startWake,
+      store: input.store,
+    })) {
+      return { status: "waking", url: null }
+    }
+
     input.startWake(input.worker.id)
     return { status: "waking", url: null }
   }
@@ -597,6 +657,16 @@ async function resolveCloudInstance(input: {
     }
 
     return { status: "provisioning", url: null }
+  }
+
+  if (await startStaleStoppedRecycle({
+    worker: input.worker,
+    sandboxExists: true,
+    inspectSandbox: input.inspectSandbox,
+    startWake: input.startWake,
+    store: input.store,
+  })) {
+    return { status: "waking", url: null }
   }
 
   if (sandbox.signed_preview_url_expires_at.getTime() > input.now()) {

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -39,7 +39,7 @@ type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "name" | "status
 }
 type WorkerToken = Pick<typeof WorkerTokenTable.$inferSelect, "scope" | "token">
 type CloudSandboxRecord = Pick<NonNullable<Awaited<ReturnType<typeof getDaytonaSandboxRecord>>>, "signed_preview_url" | "signed_preview_url_expires_at">
-type CloudSandboxInspection = { state: string | null; hasCheckpoint?: boolean } | null
+type CloudSandboxInspection = { state: string | null } | null
 type OrgId = typeof WorkerTable.$inferSelect.org_id
 type UserId = NonNullable<typeof WorkerTable.$inferSelect.created_by_user_id>
 type WorkerId = typeof WorkerTable.$inferSelect.id
@@ -557,7 +557,7 @@ function isStoppedSandboxState(state: string | null) {
 
 function workerNeedsSnapshotRecycle(worker: CloudWorker) {
   const snapshot = env.daytona.snapshot
-  return Boolean(snapshot && worker.image_version !== snapshot)
+  return Boolean(snapshot && "image_version" in worker && worker.image_version !== snapshot)
 }
 
 async function startStaleStoppedRecycle(input: {
@@ -578,7 +578,7 @@ async function startStaleStoppedRecycle(input: {
     return false
   }
 
-  if (!isStoppedSandboxState(inspection?.state ?? null) || inspection?.hasCheckpoint !== true) {
+  if (!isStoppedSandboxState(inspection?.state ?? null)) {
     return false
   }
 

--- a/ee/apps/den-api/src/routes/workers/shared.ts
+++ b/ee/apps/den-api/src/routes/workers/shared.ts
@@ -66,6 +66,7 @@ type CloudProvisioningStore = {
   updateWorkerStatus: (input: {
     workerId: WorkerId
     status: WorkerStatus
+    imageVersion?: string | null
     onlyWhenStatus?: WorkerStatus
     onlyWhenStatusIn?: WorkerStatus[]
   }) => Promise<void>
@@ -88,9 +89,13 @@ const databaseCloudProvisioningStore: CloudProvisioningStore = {
         ? eq(WorkerTable.status, input.onlyWhenStatus)
         : undefined
 
+    const update = input.imageVersion === undefined
+      ? { status: input.status }
+      : { status: input.status, image_version: input.imageVersion }
+
     await db
       .update(WorkerTable)
-      .set({ status: input.status })
+      .set(update)
       .where(statusPredicate
         ? and(eq(WorkerTable.id, input.workerId), statusPredicate)
         : eq(WorkerTable.id, input.workerId))
@@ -389,6 +394,7 @@ async function runCloudProvisioning(input: {
     await store.updateWorkerStatus({
       workerId: input.workerId,
       status: provisioned.status,
+      imageVersion: provisioned.imageVersion,
       onlyWhenStatusIn: provisioningSuccessWritableStatuses,
     })
 

--- a/ee/apps/den-api/src/workers/cloud-lifecycle.ts
+++ b/ee/apps/den-api/src/workers/cloud-lifecycle.ts
@@ -25,7 +25,7 @@ type CloudLifecycleStore = {
   getWorker: (workerId: WorkerId) => Promise<CloudWorker | null>
   getActiveTokens: (workerId: WorkerId) => Promise<WorkerToken[]>
   listIdleWorkers: (input: { idleBefore: Date; limit: number }) => Promise<CloudWorker[]>
-  updateWorkerStatus: (input: { workerId: WorkerId; status: WorkerStatus; onlyWhenStatus?: WorkerStatus }) => Promise<void>
+  updateWorkerStatus: (input: { workerId: WorkerId; status: WorkerStatus; imageVersion?: string | null; onlyWhenStatus?: WorkerStatus }) => Promise<void>
 }
 
 type WakeCloudWorkerOptions = {
@@ -94,9 +94,13 @@ const databaseCloudLifecycleStore: CloudLifecycleStore = {
       .limit(input.limit)
   },
   async updateWorkerStatus(input) {
+    const update = input.imageVersion === undefined
+      ? { status: input.status }
+      : { status: input.status, image_version: input.imageVersion }
+
     await db
       .update(WorkerTable)
-      .set({ status: input.status })
+      .set(update)
       .where(input.onlyWhenStatus
         ? and(eq(WorkerTable.id, input.workerId), eq(WorkerTable.status, input.onlyWhenStatus))
         : eq(WorkerTable.id, input.workerId))
@@ -168,7 +172,7 @@ async function runWakeCloudWorker(workerId: WorkerId, options: WakeCloudWorkerOp
       woken = await provisionWorker(wakeInput)
     }
 
-    await store.updateWorkerStatus({ workerId, status: woken.status, onlyWhenStatus: "provisioning" })
+    await store.updateWorkerStatus({ workerId, status: woken.status, imageVersion: woken.imageVersion, onlyWhenStatus: "provisioning" })
   } catch (error) {
     await safelyMarkWorkerFailed(store, workerId)
     logger.error("worker wake failed", { worker_id: workerId, error })

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -1,6 +1,7 @@
+import { randomUUID } from "node:crypto"
 import { Daytona, DaytonaConflictError, type CreateSandboxFromImageParams, type CreateSandboxFromSnapshotParams, type Sandbox } from "@daytonaio/sdk"
 import { eq } from "@openwork-ee/den-db/drizzle"
-import { DaytonaSandboxTable } from "@openwork-ee/den-db/schema"
+import { DaytonaSandboxTable, WorkerTable } from "@openwork-ee/den-db/schema"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { db } from "../db.js"
 import { env } from "../env.js"
@@ -21,6 +22,7 @@ type ProvisionedInstance = {
   url: string
   status: "provisioning" | "healthy"
   region?: string
+  imageVersion?: string | null
 }
 
 export class DaytonaSandboxMissingError extends Error {
@@ -78,6 +80,8 @@ export type DaytonaProvisioningRuntime = {
   getSandbox: (sandboxIdOrName: string) => Promise<DaytonaSandboxRuntime>
   createSandbox: (params: DaytonaCreateParams) => Promise<DaytonaSandboxRuntime>
   upsertSandbox: (input: UpsertDaytonaSandboxInput) => Promise<void>
+  checkpointExists: (input: { workerId: WorkerId; sharedVolume: DaytonaVolumeRuntime }) => Promise<boolean>
+  verifyRestoreMarker: (sandbox: DaytonaSandboxRuntime) => Promise<boolean>
   waitForHealth: typeof waitForHealth
 }
 
@@ -189,6 +193,40 @@ export function daytonaSandboxName(input: ProvisionInput) {
   return slug(
     `${env.daytona.sandboxNamePrefix}-${input.name}-${workerHint(input.workerId)}`,
   ).slice(0, 63)
+}
+
+function currentDaytonaImageVersion() {
+  return env.daytona.snapshot ?? null
+}
+
+function snapshotShortVersion(snapshot: string) {
+  return slug(snapshot).slice(0, 24) || "snapshot"
+}
+
+export function daytonaSandboxNameForSnapshot(input: ProvisionInput, snapshot: string) {
+  const shortVersion = snapshotShortVersion(snapshot)
+  const base = daytonaSandboxName(input)
+  const baseLength = Math.max(1, 63 - shortVersion.length - 1)
+  return slug(`${base.slice(0, baseLength)}-${shortVersion}`).slice(0, 63)
+}
+
+function currentDaytonaSandboxName(input: ProvisionInput) {
+  const snapshot = currentDaytonaImageVersion()
+  return snapshot ? daytonaSandboxNameForSnapshot(input, snapshot) : daytonaSandboxName(input)
+}
+
+function daytonaSandboxLookupNames(input: ProvisionInput) {
+  const names: string[] = []
+  for (const name of [currentDaytonaSandboxName(input), daytonaSandboxName(input)]) {
+    if (!names.includes(name)) {
+      names.push(name)
+    }
+  }
+  return names
+}
+
+function isStoppedSandboxState(state: string | null) {
+  return state?.toLowerCase() === "stopped"
 }
 
 function sharedVolumeName() {
@@ -575,6 +613,49 @@ async function waitForHealth(url: string, timeoutMs: number, sandbox: DaytonaSan
   )
 }
 
+async function waitForSessionCommandExit(sandbox: DaytonaSandboxRuntime, sessionId: string, commandId: string, timeoutMs: number) {
+  const startedAt = Date.now()
+
+  while (Date.now() - startedAt < timeoutMs) {
+    const command = await sandbox.process.getSessionCommand(sessionId, commandId)
+    if (typeof command.exitCode === "number") {
+      return command.exitCode
+    }
+
+    await sleep(env.daytona.pollIntervalMs)
+  }
+
+  return null
+}
+
+async function runSandboxShellCommand(sandbox: DaytonaSandboxRuntime, sessionId: string, command: string, timeoutSeconds: number) {
+  await sandbox.process.createSession(sessionId)
+  const result = await sandbox.process.executeSessionCommand(
+    sessionId,
+    { command: `sh -lc ${shellQuote(command)}`, runAsync: false },
+    timeoutSeconds,
+  )
+  return waitForSessionCommandExit(sandbox, sessionId, result.cmdId, timeoutSeconds * 1000)
+}
+
+function checkpointExistsCommand() {
+  return `test -n "$(find ${shellQuote(`${env.daytona.dataMountPath}/checkpoints`)} -maxdepth 1 -type f -name 'ckpt-*.tar' -print -quit 2>/dev/null)"`
+}
+
+function restoreMarkerExistsCommand() {
+  return `test -s ${shellQuote(checkpointRestoreMarkerPath())}`
+}
+
+async function verifyRestoreMarker(sandbox: DaytonaSandboxRuntime) {
+  const exitCode = await runSandboxShellCommand(
+    sandbox,
+    `openwork-restore-verify-${Date.now()}`,
+    restoreMarkerExistsCommand(),
+    env.daytona.createTimeoutSeconds,
+  )
+  return exitCode === 0
+}
+
 async function upsertDaytonaSandbox(input: UpsertDaytonaSandboxInput) {
   const existing = await db
     .select({ id: DaytonaSandboxTable.id })
@@ -631,7 +712,19 @@ export async function inspectDaytonaSandbox(workerId: WorkerId) {
   try {
     const sandbox = await daytona.get(record.sandbox_id)
     await sandbox.refreshData()
-    return { state: sandbox.state ?? null }
+    const state = sandbox.state ?? null
+    let hasCheckpoint: boolean | undefined
+    if (isStoppedSandboxState(state)) {
+      try {
+        const runtime = createDaytonaProvisioningRuntime(daytona)
+        const sharedVolume = await getSharedDaytonaVolume(runtime)
+        hasCheckpoint = await runtime.checkpointExists({ workerId, sharedVolume })
+      } catch (error) {
+        logger.warn("failed to inspect Daytona checkpoint state", { worker_id: workerId, error })
+        hasCheckpoint = false
+      }
+    }
+    return { state, hasCheckpoint }
   } catch (error) {
     if (isDaytonaNotFoundError(error)) {
       return null
@@ -712,6 +805,53 @@ function toDaytonaSandboxRuntime(sandbox: Sandbox): DaytonaSandboxRuntime {
   }
 }
 
+async function checkpointExistsOnDaytonaVolume(daytona: Daytona, workerId: WorkerId, sharedVolume: DaytonaVolumeRuntime) {
+  let probeSandbox: DaytonaSandboxRuntime | null = null
+
+  try {
+    const suffix = randomUUID().replace(/-/g, "").slice(0, 8)
+    probeSandbox = toDaytonaSandboxRuntime(await daytona.create(
+      {
+        name: slug(`den-daytona-ckpt-${workerHint(workerId)}-${suffix}`).slice(0, 63),
+        image: env.daytona.image,
+        public: false,
+        autoStopInterval: 0,
+        autoArchiveInterval: 0,
+        autoDeleteInterval: 0,
+        ephemeral: true,
+        envVars: {
+          DEN_RUNTIME_PROVIDER: "daytona-checkpoint-probe",
+          DEN_WORKER_ID: workerId,
+        },
+        resources: {
+          cpu: 1,
+          memory: 1,
+          disk: 4,
+        },
+        volumes: sharedVolumeMounts(workerId, sharedVolume.id),
+      },
+      { timeout: env.daytona.createTimeoutSeconds },
+    ))
+
+    const exitCode = await runSandboxShellCommand(
+      probeSandbox,
+      `openwork-ckpt-probe-${workerHint(workerId)}-${Date.now()}`,
+      checkpointExistsCommand(),
+      env.daytona.createTimeoutSeconds,
+    )
+    return exitCode === 0
+  } catch (error) {
+    logger.warn("failed to inspect Daytona checkpoint volume", { worker_id: workerId, error })
+    return false
+  } finally {
+    if (probeSandbox) {
+      await probeSandbox.delete(env.daytona.deleteTimeoutSeconds).catch((error) => {
+        logger.warn("failed to delete Daytona checkpoint probe sandbox", { worker_id: workerId, error })
+      })
+    }
+  }
+}
+
 function createDaytonaProvisioningRuntime(daytona: Daytona): DaytonaProvisioningRuntime {
   return {
     getVolume: (name, create) => daytona.volume.get(name, create),
@@ -724,6 +864,8 @@ function createDaytonaProvisioningRuntime(daytona: Daytona): DaytonaProvisioning
       return toDaytonaSandboxRuntime(await daytona.create(params, { timeout: env.daytona.createTimeoutSeconds }))
     },
     upsertSandbox: upsertDaytonaSandbox,
+    checkpointExists: (input) => checkpointExistsOnDaytonaVolume(daytona, input.workerId, input.sharedVolume),
+    verifyRestoreMarker,
     waitForHealth,
   }
 }
@@ -786,14 +928,27 @@ async function getSandboxByName(runtime: DaytonaProvisioningRuntime, name: strin
   }
 }
 
-async function startOpenWorkOnDaytonaSandbox(input: {
+type StartedOpenWorkProcess = {
+  signedPreviewUrl: string
+  signedPreviewUrlExpiresAt: Date
+}
+
+function provisionedInstance(workerId: WorkerId, region: string | null): ProvisionedInstance {
+  return {
+    provider: "daytona",
+    url: workerProxyUrl(workerId),
+    status: "healthy",
+    region: region ?? undefined,
+    imageVersion: currentDaytonaImageVersion(),
+  }
+}
+
+async function startOpenWorkProcessOnDaytonaSandbox(input: {
   provisionInput: ProvisionInput
   runtime: DaytonaProvisioningRuntime
   sandbox: DaytonaSandboxRuntime
   sessionId: string
-  workspaceVolumeId: string
-  dataVolumeId: string
-}): Promise<ProvisionedInstance> {
+}): Promise<StartedOpenWorkProcess> {
   await input.sandbox.process.createSession(input.sessionId)
   const command = await input.sandbox.process.executeSessionCommand(
     input.sessionId,
@@ -807,21 +962,128 @@ async function startOpenWorkOnDaytonaSandbox(input: {
   const expiresInSeconds = normalizedSignedPreviewExpirySeconds()
   const preview = await input.sandbox.getSignedPreviewUrl(env.daytona.openworkPort, expiresInSeconds)
   await input.runtime.waitForHealth(preview.url, env.daytona.healthcheckTimeoutMs, input.sandbox, input.sessionId, command.cmdId)
+  return {
+    signedPreviewUrl: preview.url,
+    signedPreviewUrlExpiresAt: signedPreviewRefreshAt(expiresInSeconds),
+  }
+}
+
+async function persistDaytonaSandbox(input: {
+  provisionInput: ProvisionInput
+  runtime: DaytonaProvisioningRuntime
+  sandbox: DaytonaSandboxRuntime
+  started: StartedOpenWorkProcess
+  workspaceVolumeId: string
+  dataVolumeId: string
+}) {
   await input.runtime.upsertSandbox({
     workerId: input.provisionInput.workerId,
     sandboxId: input.sandbox.id,
     workspaceVolumeId: input.workspaceVolumeId,
     dataVolumeId: input.dataVolumeId,
-    signedPreviewUrl: preview.url,
-    signedPreviewUrlExpiresAt: signedPreviewRefreshAt(expiresInSeconds),
+    signedPreviewUrl: input.started.signedPreviewUrl,
+    signedPreviewUrlExpiresAt: input.started.signedPreviewUrlExpiresAt,
     region: input.sandbox.target,
   })
+}
 
-  return {
-    provider: "daytona",
-    url: workerProxyUrl(input.provisionInput.workerId),
-    status: "healthy",
-    region: input.sandbox.target ?? undefined,
+async function startOpenWorkOnDaytonaSandbox(input: {
+  provisionInput: ProvisionInput
+  runtime: DaytonaProvisioningRuntime
+  sandbox: DaytonaSandboxRuntime
+  sessionId: string
+  workspaceVolumeId: string
+  dataVolumeId: string
+}): Promise<ProvisionedInstance> {
+  const started = await startOpenWorkProcessOnDaytonaSandbox(input)
+  await persistDaytonaSandbox({
+    provisionInput: input.provisionInput,
+    runtime: input.runtime,
+    sandbox: input.sandbox,
+    started,
+    workspaceVolumeId: input.workspaceVolumeId,
+    dataVolumeId: input.dataVolumeId,
+  })
+
+  return provisionedInstance(input.provisionInput.workerId, input.sandbox.target)
+}
+
+function shouldRecycleDaytonaSandbox(input: { workerImageVersion: string | null; sandboxState: string | null }) {
+  const imageVersion = currentDaytonaImageVersion()
+  return Boolean(imageVersion && input.workerImageVersion !== imageVersion && isStoppedSandboxState(input.sandboxState))
+}
+
+async function wakeExistingDaytonaSandbox(input: {
+  provisionInput: ProvisionInput
+  runtime: DaytonaProvisioningRuntime
+  sandbox: DaytonaSandboxRuntime
+  workspaceVolumeId: string
+  dataVolumeId: string
+}) {
+  if (isStoppedSandboxState(input.sandbox.state)) {
+    await input.sandbox.start(env.daytona.createTimeoutSeconds)
+  }
+
+  return startOpenWorkOnDaytonaSandbox({
+    provisionInput: input.provisionInput,
+    runtime: input.runtime,
+    sandbox: input.sandbox,
+    sessionId: `openwork-wake-${workerHint(input.provisionInput.workerId)}-${Date.now()}`,
+    workspaceVolumeId: input.workspaceVolumeId,
+    dataVolumeId: input.dataVolumeId,
+  })
+}
+
+async function recycleDaytonaSandbox(input: {
+  provisionInput: ProvisionInput
+  runtime: DaytonaProvisioningRuntime
+  oldSandbox: DaytonaSandboxRuntime
+  sharedVolume: DaytonaVolumeRuntime
+  oldWorkspaceVolumeId: string
+  oldDataVolumeId: string
+}): Promise<ProvisionedInstance> {
+  let replacementSandbox: DaytonaSandboxRuntime | null = null
+
+  try {
+    replacementSandbox = await input.runtime.createSandbox(
+      buildDaytonaCreateParams(input.provisionInput, currentDaytonaSandboxName(input.provisionInput), input.sharedVolume),
+    )
+    const started = await startOpenWorkProcessOnDaytonaSandbox({
+      provisionInput: input.provisionInput,
+      runtime: input.runtime,
+      sandbox: replacementSandbox,
+      sessionId: `openwork-recycle-${workerHint(input.provisionInput.workerId)}-${Date.now()}`,
+    })
+    const restored = await input.runtime.verifyRestoreMarker(replacementSandbox)
+    if (!restored) {
+      throw new Error("Daytona replacement did not restore an OpenWork checkpoint")
+    }
+
+    await persistDaytonaSandbox({
+      provisionInput: input.provisionInput,
+      runtime: input.runtime,
+      sandbox: replacementSandbox,
+      started,
+      workspaceVolumeId: input.sharedVolume.id,
+      dataVolumeId: input.sharedVolume.id,
+    })
+    await input.oldSandbox.delete(env.daytona.deleteTimeoutSeconds)
+    return provisionedInstance(input.provisionInput.workerId, replacementSandbox.target)
+  } catch (error) {
+    if (replacementSandbox) {
+      await replacementSandbox.delete(env.daytona.deleteTimeoutSeconds).catch((deleteError) => {
+        logger.warn("failed to delete failed Daytona replacement sandbox", { worker_id: input.provisionInput.workerId, error: deleteError })
+      })
+    }
+
+    logger.warn("Daytona sandbox recycle failed; waking existing sandbox", { worker_id: input.provisionInput.workerId, error })
+    return wakeExistingDaytonaSandbox({
+      provisionInput: input.provisionInput,
+      runtime: input.runtime,
+      sandbox: input.oldSandbox,
+      workspaceVolumeId: input.oldWorkspaceVolumeId,
+      dataVolumeId: input.oldDataVolumeId,
+    })
   }
 }
 
@@ -831,15 +1093,10 @@ async function adoptDaytonaSandbox(input: {
   sandbox: DaytonaSandboxRuntime
   sharedVolume: DaytonaVolumeRuntime
 }): Promise<ProvisionedInstance> {
-  if (input.sandbox.state === "stopped") {
-    await input.sandbox.start(env.daytona.createTimeoutSeconds)
-  }
-
-  return startOpenWorkOnDaytonaSandbox({
+  return wakeExistingDaytonaSandbox({
     provisionInput: input.provisionInput,
     runtime: input.runtime,
     sandbox: input.sandbox,
-    sessionId: `openwork-wake-${workerHint(input.provisionInput.workerId)}-${Date.now()}`,
     workspaceVolumeId: input.sharedVolume.id,
     dataVolumeId: input.sharedVolume.id,
   })
@@ -849,11 +1106,14 @@ export async function provisionWorkerOnDaytonaWithRuntime(
   input: ProvisionInput,
   runtime: DaytonaProvisioningRuntime,
 ): Promise<ProvisionedInstance> {
-  const name = daytonaSandboxName(input)
+  const name = currentDaytonaSandboxName(input)
+  const lookupNames = daytonaSandboxLookupNames(input)
   const sharedVolume = await getSharedDaytonaVolume(runtime)
-  const existingSandbox = await getSandboxByName(runtime, name)
-  if (existingSandbox) {
-    return adoptDaytonaSandbox({ provisionInput: input, runtime, sandbox: existingSandbox, sharedVolume })
+  for (const lookupName of lookupNames) {
+    const existingSandbox = await getSandboxByName(runtime, lookupName)
+    if (existingSandbox) {
+      return adoptDaytonaSandbox({ provisionInput: input, runtime, sandbox: existingSandbox, sharedVolume })
+    }
   }
 
   let createdSandbox: DaytonaSandboxRuntime | null = null
@@ -873,9 +1133,11 @@ export async function provisionWorkerOnDaytonaWithRuntime(
     }
 
     if (isDaytonaConflictError(error)) {
-      const conflictSandbox = await getSandboxByName(runtime, name)
-      if (conflictSandbox) {
-        return adoptDaytonaSandbox({ provisionInput: input, runtime, sandbox: conflictSandbox, sharedVolume })
+      for (const lookupName of lookupNames) {
+        const conflictSandbox = await getSandboxByName(runtime, lookupName)
+        if (conflictSandbox) {
+          return adoptDaytonaSandbox({ provisionInput: input, runtime, sandbox: conflictSandbox, sharedVolume })
+        }
       }
     }
 
@@ -913,6 +1175,55 @@ export async function stopWorkerOnDaytona(workerId: WorkerId): Promise<StopWorke
   return { status: "stopped" }
 }
 
+export type DaytonaSandboxWakeRecord = {
+  sandbox_id: string
+  workspace_volume_id: string
+  data_volume_id: string
+}
+
+async function getWorkerImageVersion(workerId: WorkerId) {
+  const rows = await db
+    .select({ image_version: WorkerTable.image_version })
+    .from(WorkerTable)
+    .where(eq(WorkerTable.id, workerId))
+    .limit(1)
+
+  return rows[0]?.image_version ?? null
+}
+
+export async function wakeWorkerOnDaytonaWithRuntime(
+  input: ProvisionInput,
+  runtime: DaytonaProvisioningRuntime,
+  record: DaytonaSandboxWakeRecord,
+  workerImageVersion: string | null,
+): Promise<ProvisionedInstance> {
+  const sandbox = await runtime.getSandbox(record.sandbox_id)
+  await sandbox.refreshData()
+
+  if (shouldRecycleDaytonaSandbox({ workerImageVersion, sandboxState: sandbox.state })) {
+    const sharedVolume = await getSharedDaytonaVolume(runtime)
+    const hasCheckpoint = await runtime.checkpointExists({ workerId: input.workerId, sharedVolume })
+    if (hasCheckpoint) {
+      return recycleDaytonaSandbox({
+        provisionInput: input,
+        runtime,
+        oldSandbox: sandbox,
+        sharedVolume,
+        oldWorkspaceVolumeId: record.workspace_volume_id,
+        oldDataVolumeId: record.data_volume_id,
+      })
+    }
+  }
+
+  return wakeExistingDaytonaSandbox({
+    provisionInput: input,
+    runtime,
+    sandbox,
+    workspaceVolumeId: record.workspace_volume_id,
+    dataVolumeId: record.data_volume_id,
+  })
+}
+
 export async function wakeWorkerOnDaytona(
   input: ProvisionInput,
 ): Promise<ProvisionedInstance> {
@@ -925,9 +1236,9 @@ export async function wakeWorkerOnDaytona(
 
   const daytona = createDaytonaClient()
   const runtime = createDaytonaProvisioningRuntime(daytona)
-  let sandbox: DaytonaSandboxRuntime
+  const workerImageVersion = await getWorkerImageVersion(input.workerId)
   try {
-    sandbox = await runtime.getSandbox(record.sandbox_id)
+    return await wakeWorkerOnDaytonaWithRuntime(input, runtime, record, workerImageVersion)
   } catch (error) {
     if (isDaytonaNotFoundError(error)) {
       throw new DaytonaSandboxMissingError(`Daytona sandbox ${record.sandbox_id} missing for worker ${input.workerId}`)
@@ -935,24 +1246,6 @@ export async function wakeWorkerOnDaytona(
 
     throw error
   }
-  try {
-    await sandbox.start(env.daytona.createTimeoutSeconds)
-  } catch (error) {
-    if (isDaytonaNotFoundError(error)) {
-      throw new DaytonaSandboxMissingError(`Daytona sandbox ${record.sandbox_id} missing for worker ${input.workerId}`)
-    }
-
-    throw error
-  }
-
-  return startOpenWorkOnDaytonaSandbox({
-    provisionInput: input,
-    runtime,
-    sandbox,
-    sessionId: `openwork-wake-${workerHint(input.workerId)}-${Date.now()}`,
-    workspaceVolumeId: record.workspace_volume_id,
-    dataVolumeId: record.data_volume_id,
-  })
 }
 
 export async function deprovisionWorkerOnDaytona(workerId: WorkerId) {

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -222,7 +222,11 @@ function sharedVolumeMounts(workerId: WorkerId, volumeId: string) {
   ]
 }
 
-function buildOpenWorkStartCommand(input: ProvisionInput) {
+function checkpointRestoreMarkerPath() {
+  return `${env.daytona.runtimeDataPath}/.openwork-restore-marker`
+}
+
+export function buildOpenWorkStartCommand(input: ProvisionInput) {
   const verifyRuntimeStep = [
     "if ! command -v openwork-server >/dev/null 2>&1; then echo 'openwork-server binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
     "if ! command -v opencode >/dev/null 2>&1; then echo 'opencode binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
@@ -267,6 +271,9 @@ function buildOpenWorkStartCommand(input: ProvisionInput) {
     ` --approval manual`,
     ` --verbose`,
   ].join("")
+  const stateManifest = `${env.daytona.runtimeDataPath} ${env.daytona.runtimeWorkspacePath}`
+  const checkpointDir = `${env.daytona.dataMountPath}/checkpoints`
+  const lastFlushMarker = `${env.daytona.sidecarDir}/checkpoint.last-flush`
 
   const script = `
 set -u
@@ -274,16 +281,149 @@ mkdir -p ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(env.daytona.
 ln -sfn ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/workspace`) }
 ln -sfn ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/data`) }
 ${verifyRuntimeStep}
+OPENWORK_STATE_MANIFEST=${shellQuote(stateManifest)}
+CHECKPOINT_DIR=${shellQuote(checkpointDir)}
+RESTORE_MARKER=${shellQuote(checkpointRestoreMarkerPath())}
+LAST_FLUSH_MARKER=${shellQuote(lastFlushMarker)}
+DEN_CKPT_INTERVAL_SECONDS=\${DEN_CKPT_INTERVAL_SECONDS:-${shellQuote(String(env.daytona.checkpointIntervalSeconds))}}
+DEN_CKPT_KEEP=\${DEN_CKPT_KEEP:-${shellQuote(String(env.daytona.checkpointKeep))}}
+
+state_dirs_pristine() {
+  if [ -e "$RESTORE_MARKER" ]; then
+    return 1
+  fi
+  data_entry=$(find ${shellQuote(env.daytona.runtimeDataPath)} -mindepth 1 -print -quit 2>/dev/null || true)
+  if [ -n "$data_entry" ]; then
+    return 1
+  fi
+  workspace_entry=$(find ${shellQuote(env.daytona.runtimeWorkspacePath)} -mindepth 1 ! -path ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)} ! -path ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/*`)} -print -quit 2>/dev/null || true)
+  if [ -n "$workspace_entry" ]; then
+    return 1
+  fi
+  return 0
+}
+
+hydrate_checkpoint() {
+  mkdir -p "$CHECKPOINT_DIR"
+  latest_checkpoint=$(find "$CHECKPOINT_DIR" -maxdepth 1 -type f -name 'ckpt-*.tar' -print 2>/dev/null | sort | tail -n 1 || true)
+  if [ -z "$latest_checkpoint" ]; then
+    return 0
+  fi
+  if ! state_dirs_pristine; then
+    echo "checkpoint hydrate skipped; local OpenWork state is not pristine or was already restored"
+    return 0
+  fi
+  echo "checkpoint hydrate restoring $latest_checkpoint"
+  if tar -C / -xf "$latest_checkpoint"; then
+    printf '%s\n' "$latest_checkpoint" > "$RESTORE_MARKER"
+    return 0
+  fi
+  echo "checkpoint hydrate failed for $latest_checkpoint; continuing with fresh OpenWork state" >&2
+  rm -rf ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(env.daytona.runtimeWorkspacePath)}
+  mkdir -p ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)}
+  ln -sfn ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/workspace`) }
+  ln -sfn ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/data`) }
+}
+
+checkpoint_changed() {
+  if [ ! -e "$LAST_FLUSH_MARKER" ]; then
+    return 0
+  fi
+  for state_path in $OPENWORK_STATE_MANIFEST; do
+    changed_entry=$(find "$state_path" -newer "$LAST_FLUSH_MARKER" -print -quit 2>/dev/null || true)
+    if [ -n "$changed_entry" ]; then
+      return 0
+    fi
+  done
+  return 1
+}
+
+prune_checkpoints() {
+  keep_count=$DEN_CKPT_KEEP
+  if ! [ "$keep_count" -gt 0 ] 2>/dev/null; then
+    keep_count=3
+  fi
+  checkpoint_count=0
+  find "$CHECKPOINT_DIR" -maxdepth 1 -type f -name 'ckpt-*.tar' -print 2>/dev/null | sort -r | while IFS= read -r checkpoint_path; do
+    checkpoint_count=$((checkpoint_count + 1))
+    if [ "$checkpoint_count" -gt "$keep_count" ]; then
+      rm -f "$checkpoint_path" || echo "checkpoint prune failed for $checkpoint_path" >&2
+    fi
+  done
+}
+
+flush_checkpoint() {
+  mkdir -p "$CHECKPOINT_DIR" ${shellQuote(env.daytona.sidecarDir)}
+  if ! checkpoint_changed; then
+    return 0
+  fi
+  epoch=$(date +%s)
+  tmp_checkpoint=${shellQuote(env.daytona.sidecarDir)}/ckpt-$epoch.tar
+  set --
+  for state_path in $OPENWORK_STATE_MANIFEST; do
+    set -- "$@" "\${state_path#/}"
+  done
+  if tar -C / -cf "$tmp_checkpoint" "$@"; then
+    if cp "$tmp_checkpoint" "$CHECKPOINT_DIR/ckpt-$epoch.tar"; then
+      touch "$LAST_FLUSH_MARKER"
+      rm -f "$tmp_checkpoint"
+      prune_checkpoints
+      return 0
+    fi
+    echo "checkpoint flush copy failed for $CHECKPOINT_DIR/ckpt-$epoch.tar" >&2
+  else
+    echo "checkpoint flush tar failed for $tmp_checkpoint" >&2
+  fi
+  rm -f "$tmp_checkpoint"
+  return 0
+}
+
+checkpoint_loop() {
+  while true; do
+    sleep "$DEN_CKPT_INTERVAL_SECONDS"
+    flush_checkpoint
+  done
+}
+
+server_pid=""
+checkpoint_pid=""
+on_term() {
+  echo "termination requested; flushing OpenWork checkpoint"
+  flush_checkpoint
+  if [ -n "$server_pid" ]; then
+    kill -TERM "$server_pid" 2>/dev/null || true
+    wait "$server_pid" 2>/dev/null || true
+  fi
+  if [ -n "$checkpoint_pid" ]; then
+    kill "$checkpoint_pid" 2>/dev/null || true
+    wait "$checkpoint_pid" 2>/dev/null || true
+  fi
+  exit 143
+}
+trap on_term TERM INT
+
+hydrate_checkpoint
 attempt=0
 while [ "$attempt" -lt 3 ]; do
   attempt=$((attempt + 1))
-  if ${openworkServe}; then
+  ${openworkServe} &
+  server_pid=$!
+  checkpoint_loop &
+  checkpoint_pid=$!
+  wait "$server_pid"
+  status=$?
+  kill "$checkpoint_pid" 2>/dev/null || true
+  wait "$checkpoint_pid" 2>/dev/null || true
+  server_pid=""
+  checkpoint_pid=""
+  if [ "$status" -eq 0 ]; then
+    flush_checkpoint
     exit 0
   fi
-  status=$?
   echo "openwork-server failed (attempt $attempt, exit $status); rebuild and republish the Daytona snapshot if this persists; retrying in 3s"
   sleep 3
 done
+flush_checkpoint
 exit 1
 `.trim()
 

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -712,19 +712,7 @@ export async function inspectDaytonaSandbox(workerId: WorkerId) {
   try {
     const sandbox = await daytona.get(record.sandbox_id)
     await sandbox.refreshData()
-    const state = sandbox.state ?? null
-    let hasCheckpoint: boolean | undefined
-    if (isStoppedSandboxState(state)) {
-      try {
-        const runtime = createDaytonaProvisioningRuntime(daytona)
-        const sharedVolume = await getSharedDaytonaVolume(runtime)
-        hasCheckpoint = await runtime.checkpointExists({ workerId, sharedVolume })
-      } catch (error) {
-        logger.warn("failed to inspect Daytona checkpoint state", { worker_id: workerId, error })
-        hasCheckpoint = false
-      }
-    }
-    return { state, hasCheckpoint }
+    return { state: sandbox.state ?? null }
   } catch (error) {
     if (isDaytonaNotFoundError(error)) {
       return null
@@ -811,25 +799,11 @@ async function checkpointExistsOnDaytonaVolume(daytona: Daytona, workerId: Worke
   try {
     const suffix = randomUUID().replace(/-/g, "").slice(0, 8)
     probeSandbox = toDaytonaSandboxRuntime(await daytona.create(
-      {
+      buildCheckpointProbeCreateParams({
+        workerId,
         name: slug(`den-daytona-ckpt-${workerHint(workerId)}-${suffix}`).slice(0, 63),
-        image: env.daytona.image,
-        public: false,
-        autoStopInterval: 0,
-        autoArchiveInterval: 0,
-        autoDeleteInterval: 0,
-        ephemeral: true,
-        envVars: {
-          DEN_RUNTIME_PROVIDER: "daytona-checkpoint-probe",
-          DEN_WORKER_ID: workerId,
-        },
-        resources: {
-          cpu: 1,
-          memory: 1,
-          disk: 4,
-        },
-        volumes: sharedVolumeMounts(workerId, sharedVolume.id),
-      },
+        sharedVolume,
+      }),
       { timeout: env.daytona.createTimeoutSeconds },
     ))
 
@@ -849,6 +823,39 @@ async function checkpointExistsOnDaytonaVolume(daytona: Daytona, workerId: Worke
         logger.warn("failed to delete Daytona checkpoint probe sandbox", { worker_id: workerId, error })
       })
     }
+  }
+}
+
+function buildCheckpointProbeCreateParams(input: { workerId: WorkerId; name: string; sharedVolume: DaytonaVolumeRuntime }): DaytonaCreateParams {
+  const base = {
+    name: input.name,
+    public: false,
+    autoStopInterval: 0,
+    autoArchiveInterval: 0,
+    autoDeleteInterval: 0,
+    ephemeral: true,
+    envVars: {
+      DEN_RUNTIME_PROVIDER: "daytona-checkpoint-probe",
+      DEN_WORKER_ID: input.workerId,
+    },
+    volumes: sharedVolumeMounts(input.workerId, input.sharedVolume.id),
+  }
+
+  if (env.daytona.snapshot) {
+    return {
+      ...base,
+      snapshot: env.daytona.snapshot,
+    }
+  }
+
+  return {
+    ...base,
+    image: env.daytona.image,
+    resources: {
+      cpu: 1,
+      memory: 1,
+      disk: 4,
+    },
   }
 }
 
@@ -933,13 +940,13 @@ type StartedOpenWorkProcess = {
   signedPreviewUrlExpiresAt: Date
 }
 
-function provisionedInstance(workerId: WorkerId, region: string | null): ProvisionedInstance {
+function provisionedInstance(workerId: WorkerId, region: string | null, imageVersion: string | null | undefined = currentDaytonaImageVersion()): ProvisionedInstance {
   return {
     provider: "daytona",
     url: workerProxyUrl(workerId),
     status: "healthy",
     region: region ?? undefined,
-    imageVersion: currentDaytonaImageVersion(),
+    imageVersion,
   }
 }
 
@@ -994,6 +1001,7 @@ async function startOpenWorkOnDaytonaSandbox(input: {
   sessionId: string
   workspaceVolumeId: string
   dataVolumeId: string
+  imageVersion?: string | null
 }): Promise<ProvisionedInstance> {
   const started = await startOpenWorkProcessOnDaytonaSandbox(input)
   await persistDaytonaSandbox({
@@ -1005,7 +1013,7 @@ async function startOpenWorkOnDaytonaSandbox(input: {
     dataVolumeId: input.dataVolumeId,
   })
 
-  return provisionedInstance(input.provisionInput.workerId, input.sandbox.target)
+  return provisionedInstance(input.provisionInput.workerId, input.sandbox.target, input.imageVersion)
 }
 
 function shouldRecycleDaytonaSandbox(input: { workerImageVersion: string | null; sandboxState: string | null }) {
@@ -1019,6 +1027,7 @@ async function wakeExistingDaytonaSandbox(input: {
   sandbox: DaytonaSandboxRuntime
   workspaceVolumeId: string
   dataVolumeId: string
+  imageVersion?: string | null
 }) {
   if (isStoppedSandboxState(input.sandbox.state)) {
     await input.sandbox.start(env.daytona.createTimeoutSeconds)
@@ -1031,6 +1040,7 @@ async function wakeExistingDaytonaSandbox(input: {
     sessionId: `openwork-wake-${workerHint(input.provisionInput.workerId)}-${Date.now()}`,
     workspaceVolumeId: input.workspaceVolumeId,
     dataVolumeId: input.dataVolumeId,
+    imageVersion: input.imageVersion,
   })
 }
 
@@ -1041,6 +1051,7 @@ async function recycleDaytonaSandbox(input: {
   sharedVolume: DaytonaVolumeRuntime
   oldWorkspaceVolumeId: string
   oldDataVolumeId: string
+  oldImageVersion: string | null
 }): Promise<ProvisionedInstance> {
   let replacementSandbox: DaytonaSandboxRuntime | null = null
 
@@ -1083,6 +1094,7 @@ async function recycleDaytonaSandbox(input: {
       sandbox: input.oldSandbox,
       workspaceVolumeId: input.oldWorkspaceVolumeId,
       dataVolumeId: input.oldDataVolumeId,
+      imageVersion: input.oldImageVersion,
     })
   }
 }
@@ -1211,6 +1223,7 @@ export async function wakeWorkerOnDaytonaWithRuntime(
         sharedVolume,
         oldWorkspaceVolumeId: record.workspace_volume_id,
         oldDataVolumeId: record.data_volume_id,
+        oldImageVersion: workerImageVersion,
       })
     }
   }
@@ -1221,6 +1234,7 @@ export async function wakeWorkerOnDaytonaWithRuntime(
     sandbox,
     workspaceVolumeId: record.workspace_volume_id,
     dataVolumeId: record.data_volume_id,
+    imageVersion: workerImageVersion,
   })
 }
 

--- a/ee/apps/den-api/src/workers/provisioner.ts
+++ b/ee/apps/den-api/src/workers/provisioner.ts
@@ -26,6 +26,7 @@ export type ProvisionedInstance = {
   url: string
   status: "provisioning" | "healthy"
   region?: string
+  imageVersion?: string | null
 }
 
 type RenderService = {

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -483,7 +483,7 @@ describe("Cloud instance route lifecycle states", () => {
     expect(wakeExecutions).toBe(0)
   })
 
-  test("claims and wakes a stale stopped sandbox with a checkpoint instead of reporting it ready", async () => {
+  test("claims and wakes a stale stopped sandbox without checkpoint probing on resolve", async () => {
     const worker = { ...storedWorker({ status: "healthy" }), image_version: "openwork-0.18.7" }
     const store = makeCloudWorkerStore({ initialWorkers: [worker] })
     const app = new Hono<{ Variables: OrgRouteVariables }>()
@@ -498,7 +498,7 @@ describe("Cloud instance route lifecycle states", () => {
       ensureCloudWorker: async () => worker,
       cloudWorkerStore: store.store,
       getSandboxRecord: async () => fakeSandbox(),
-      inspectSandbox: async () => ({ state: "stopped", hasCheckpoint: true }),
+      inspectSandbox: async () => ({ state: "stopped" }),
       probeSignedPreview: async () => {
         probes += 1
         return true
@@ -516,6 +516,36 @@ describe("Cloud instance route lifecycle states", () => {
     expect(worker.status).toBe("provisioning")
     expect(wakeCalls).toBe(1)
     expect(probes).toBe(0)
+  })
+
+  test("does not inspect the sandbox for an up-to-date stopped worker wake", async () => {
+    const worker = { ...fakeWorker("stopped"), image_version: "openwork-0.18.8" }
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let wakeCalls = 0
+    let inspectCalls = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      getSandboxRecord: async () => fakeSandbox(),
+      inspectSandbox: async () => {
+        inspectCalls += 1
+        return { state: "stopped" }
+      },
+      wakeCloudWorker: async () => {
+        wakeCalls += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
+    expect(inspectCalls).toBe(0)
+    expect(wakeCalls).toBe(1)
   })
 
   test("keeps first provisioning without a sandbox row as provisioning", async () => {

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -24,6 +24,7 @@ function seedRequiredEnv() {
   process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
   process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
   process.env.PROVISIONER_MODE = "stub"
+  process.env.DAYTONA_SNAPSHOT = "openwork-0.18.8"
 }
 
 let routes: typeof import("../src/routes/cloud/index.js")
@@ -155,6 +156,7 @@ function makeCloudWorkerStore(input: {
   const deletedWorkerIds: StoredCloudWorker["id"][] = []
   const deletedTokenWorkerIds: StoredCloudWorker["id"][] = []
   let claimAttempts = 0
+  let recycleClaimAttempts = 0
   let healthyFailures = 0
   let provisioningFailures = 0
   const store: CloudWorkerStore = {
@@ -203,6 +205,16 @@ function makeCloudWorkerStore(input: {
       worker.status = "provisioning"
       return true
     },
+    async claimRecycleWorker(workerId) {
+      recycleClaimAttempts += 1
+      const worker = workers.find((entry) => entry.id === workerId)
+      if (!worker || (worker.status !== "healthy" && worker.status !== "stopped")) {
+        return false
+      }
+
+      worker.status = "provisioning"
+      return true
+    },
     async getActiveTokens(workerId) {
       return tokens.filter((entry) => entry.workerId === workerId)
     },
@@ -230,6 +242,9 @@ function makeCloudWorkerStore(input: {
     deletedTokenWorkerIds,
     get claimAttempts() {
       return claimAttempts
+    },
+    get recycleClaimAttempts() {
+      return recycleClaimAttempts
     },
     get healthyFailures() {
       return healthyFailures
@@ -466,6 +481,41 @@ describe("Cloud instance route lifecycle states", () => {
     expect(response.status).toBe(200)
     await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
     expect(wakeExecutions).toBe(0)
+  })
+
+  test("claims and wakes a stale stopped sandbox with a checkpoint instead of reporting it ready", async () => {
+    const worker = { ...storedWorker({ status: "healthy" }), image_version: "openwork-0.18.7" }
+    const store = makeCloudWorkerStore({ initialWorkers: [worker] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let wakeCalls = 0
+    let probes = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandbox(),
+      inspectSandbox: async () => ({ state: "stopped", hasCheckpoint: true }),
+      probeSignedPreview: async () => {
+        probes += 1
+        return true
+      },
+      wakeCloudWorker: async () => {
+        wakeCalls += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
+    expect(store.recycleClaimAttempts).toBe(1)
+    expect(worker.status).toBe("provisioning")
+    expect(wakeCalls).toBe(1)
+    expect(probes).toBe(0)
   })
 
   test("keeps first provisioning without a sandbox row as provisioning", async () => {

--- a/ee/apps/den-api/test/cloud-lifecycle.test.ts
+++ b/ee/apps/den-api/test/cloud-lifecycle.test.ts
@@ -240,6 +240,32 @@ describe("cloud lifecycle wake", () => {
     expect(worker.status).toBe("healthy")
   })
 
+  test("writes the image version returned by a successful Daytona wake", async () => {
+    const worker = makeWorker({ status: "stopped" })
+    const { store, updates } = makeStore({
+      workers: [worker],
+      tokens: [
+        makeToken(worker.id, "host"),
+        makeToken(worker.id, "client"),
+        makeToken(worker.id, "activity"),
+      ],
+    })
+
+    await lifecycle.wakeCloudWorker(worker.id, {
+      store,
+      wakeWorker: async () => ({
+        provider: "daytona",
+        url: "https://cloud.example",
+        status: "healthy",
+        imageVersion: "openwork-0.18.8",
+      }),
+    })
+
+    expect(worker.status).toBe("healthy")
+    expect(updates[1]?.status).toBe("healthy")
+    expect(updates[1]?.imageVersion).toBe("openwork-0.18.8")
+  })
+
   test("marks the worker failed when an existing sandbox cannot be started", async () => {
     const worker = makeWorker({ status: "stopped" })
     const { store } = makeStore({

--- a/ee/apps/den-api/test/cloud-provisioning-image-version.test.ts
+++ b/ee/apps/den-api/test/cloud-provisioning-image-version.test.ts
@@ -1,0 +1,61 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, describe, expect, test } from "bun:test"
+
+type WorkerSharedModule = typeof import("../src/routes/workers/shared.js")
+type ContinueOptions = NonNullable<Parameters<WorkerSharedModule["continueCloudProvisioning"]>[1]>
+type Store = NonNullable<ContinueOptions["store"]>
+type StatusUpdate = Parameters<Store["updateWorkerStatus"]>[0]
+type InstanceInsert = Parameters<Store["insertWorkerInstance"]>[0]
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+let shared: WorkerSharedModule
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  shared = await import("../src/routes/workers/shared.js")
+})
+
+describe("cloud provisioning image version", () => {
+  test("writes the provisioned image version on successful cloud provisioning", async () => {
+    const updates: StatusUpdate[] = []
+    const inserts: InstanceInsert[] = []
+    const store: Store = {
+      async updateWorkerStatus(input) {
+        updates.push(input)
+      },
+      async insertWorkerInstance(input) {
+        inserts.push(input)
+      },
+    }
+    const workerId = createDenTypeId("worker")
+
+    await shared.continueCloudProvisioning({
+      workerId,
+      name: "Cloud",
+      hostToken: "host-token",
+      clientToken: "client-token",
+      activityToken: "activity-token",
+    }, {
+      store,
+      provisionWorker: async () => ({
+        provider: "daytona",
+        url: "https://workers.example.test/cloud",
+        status: "healthy",
+        imageVersion: "openwork-0.18.8",
+      }),
+    })
+
+    expect(updates).toHaveLength(1)
+    expect(updates[0]?.workerId).toBe(workerId)
+    expect(updates[0]?.status).toBe("healthy")
+    expect(updates[0]?.imageVersion).toBe("openwork-0.18.8")
+    expect(inserts).toHaveLength(1)
+  })
+})

--- a/ee/apps/den-api/test/daytona-checkpoint-command.test.ts
+++ b/ee/apps/den-api/test/daytona-checkpoint-command.test.ts
@@ -1,0 +1,60 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, describe, expect, test } from "bun:test"
+
+type DaytonaModule = typeof import("../src/workers/daytona.js")
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+  process.env.DAYTONA_API_KEY = "daytona-test-key"
+  process.env.DAYTONA_WORKER_PROXY_BASE_URL = "https://workers.example.test"
+  process.env.DAYTONA_RUNTIME_DATA_PATH = "/tmp/openwork-data"
+  process.env.DAYTONA_RUNTIME_WORKSPACE_PATH = "/tmp/openwork-workspace"
+  process.env.DAYTONA_DATA_MOUNT_PATH = "/persist/openwork"
+  process.env.DAYTONA_WORKSPACE_MOUNT_PATH = "/workspace"
+  process.env.DAYTONA_SIDECAR_DIR = "/tmp/openwork-sidecars"
+  process.env.DEN_CKPT_INTERVAL_SECONDS = "300"
+  process.env.DEN_CKPT_KEEP = "3"
+}
+
+let daytona: DaytonaModule
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  daytona = await import("../src/workers/daytona.js")
+})
+
+describe("Daytona OpenWork checkpoint start command", () => {
+  test("keeps checkpoint seams and safety invariants in the sandbox script", () => {
+    const command = daytona.buildOpenWorkStartCommand({
+      workerId: createDenTypeId("worker"),
+      name: "Cloud",
+      hostToken: "host-token",
+      clientToken: "client-token",
+      activityToken: "activity-token",
+    })
+
+    expect(command).toContain("OPENWORK_STATE_MANIFEST=")
+    expect(command).toContain("/tmp/openwork-data /tmp/openwork-workspace")
+    expect(command).toContain("CHECKPOINT_DIR=")
+    expect(command).toContain("/persist/openwork/checkpoints")
+    expect(command).toContain("hydrate_checkpoint")
+    expect(command).toContain("flush_checkpoint")
+    expect(command).toContain("trap on_term TERM INT")
+    expect(command).toContain("DEN_CKPT_KEEP")
+    expect(command).toContain("find \"$CHECKPOINT_DIR\" -maxdepth 1 -type f -name")
+    expect(command).toContain("ckpt-*.tar")
+    expect(command).toContain("tar -C / -cf")
+    expect(command).toContain("tar -C / -xf")
+    expect(command).not.toContain("tar -h")
+    expect(command).not.toContain("tar -ch")
+
+    const hydrateCall = command.indexOf("\nhydrate_checkpoint\n")
+    const serverStart = command.indexOf(" openwork-server --workspace")
+    expect(hydrateCall).toBeGreaterThan(-1)
+    expect(serverStart).toBeGreaterThan(hydrateCall)
+  })
+})

--- a/ee/apps/den-api/test/daytona-provisioning.test.ts
+++ b/ee/apps/den-api/test/daytona-provisioning.test.ts
@@ -291,6 +291,7 @@ describe("Daytona Cloud version-aware recycle", () => {
     )
 
     expect(result.status).toBe("healthy")
+    expect(result.imageVersion).toBe("openwork-0.18.7")
     expect(runtime.createCalls).toBe(0)
     expect(runtime.checkpointChecks).toBe(0)
     expect(old.deleteCalls).toBe(0)
@@ -313,6 +314,7 @@ describe("Daytona Cloud version-aware recycle", () => {
     )
 
     expect(result.status).toBe("healthy")
+    expect(result.imageVersion).toBe("openwork-0.18.7")
     expect(runtime.createCalls).toBe(0)
     expect(runtime.checkpointChecks).toBe(1)
     expect(old.startCalls).toBe(1)
@@ -339,6 +341,7 @@ describe("Daytona Cloud version-aware recycle", () => {
     )
 
     expect(result.status).toBe("healthy")
+    expect(result.imageVersion).toBe("openwork-0.18.7")
     expect(runtime.createCalls).toBe(1)
     expect(runtime.restoreMarkerChecks).toBe(1)
     expect(runtime.healthChecks).toBe(2)
@@ -365,6 +368,7 @@ describe("Daytona Cloud version-aware recycle", () => {
     )
 
     expect(result.status).toBe("healthy")
+    expect(result.imageVersion).toBe("openwork-0.18.8")
     expect(runtime.createCalls).toBe(0)
     expect(runtime.checkpointChecks).toBe(0)
     expect(old.startCalls).toBe(1)

--- a/ee/apps/den-api/test/daytona-provisioning.test.ts
+++ b/ee/apps/den-api/test/daytona-provisioning.test.ts
@@ -6,6 +6,7 @@ import type { DaytonaProvisioningRuntime, DaytonaSandboxRuntime } from "../src/w
 type DaytonaModule = typeof import("../src/workers/daytona.js")
 type ProvisionInput = Parameters<DaytonaModule["provisionWorkerOnDaytonaWithRuntime"]>[0]
 type UpsertInput = Parameters<DaytonaProvisioningRuntime["upsertSandbox"]>[0]
+type CreateInput = Parameters<DaytonaProvisioningRuntime["createSandbox"]>[0]
 
 function seedRequiredEnv() {
   process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
@@ -15,6 +16,7 @@ function seedRequiredEnv() {
   process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
   process.env.DAYTONA_API_KEY = "daytona-test-key"
   process.env.DAYTONA_WORKER_PROXY_BASE_URL = "https://workers.example.test"
+  process.env.DAYTONA_SNAPSHOT = "openwork-0.18.8"
 }
 
 let daytona: DaytonaModule
@@ -90,25 +92,39 @@ function makeSandbox(input: {
 }
 
 function makeRuntime(input: {
-  sandboxName: string
-  nameResults: Array<DaytonaSandboxRuntime | null>
+  sandboxName?: string
+  nameResults?: Array<DaytonaSandboxRuntime | null>
+  nameResultsByName?: Array<{ name: string; results: Array<DaytonaSandboxRuntime | null> }>
   createdSandbox?: DaytonaSandboxRuntime
   createError?: Error
+  checkpointExists?: boolean
+  restoreMarkerVerified?: boolean
 }) {
   let createCalls = 0
-  let nameLookups = 0
   let healthChecks = 0
+  let checkpointChecks = 0
+  let restoreMarkerChecks = 0
+  const nameLookups: string[] = []
+  const createInputs: CreateInput[] = []
+  const lookupCounts = new Map<string, number>()
   const upserts: UpsertInput[] = []
+  const nameEntries = [...(input.nameResultsByName ?? [])]
+  if (input.sandboxName && input.nameResults) {
+    nameEntries.push({ name: input.sandboxName, results: input.nameResults })
+  }
   const runtime = {
     async getVolume() {
       return { id: "vol_shared", state: "ready" }
     },
     async getSandbox(sandboxIdOrName: string) {
-      if (sandboxIdOrName === input.sandboxName) {
-        const result = nameLookups < input.nameResults.length
-          ? input.nameResults[nameLookups]
-          : input.nameResults[input.nameResults.length - 1]
-        nameLookups += 1
+      nameLookups.push(sandboxIdOrName)
+      const entry = nameEntries.find((candidate) => candidate.name === sandboxIdOrName)
+      if (entry) {
+        const lookupCount = lookupCounts.get(sandboxIdOrName) ?? 0
+        const result = lookupCount < entry.results.length
+          ? entry.results[lookupCount]
+          : entry.results[entry.results.length - 1]
+        lookupCounts.set(sandboxIdOrName, lookupCount + 1)
         if (result) {
           return result
         }
@@ -116,8 +132,9 @@ function makeRuntime(input: {
 
       throw new Error(`sandbox ${sandboxIdOrName} not found`)
     },
-    async createSandbox() {
+    async createSandbox(params: CreateInput) {
       createCalls += 1
+      createInputs.push(params)
       if (input.createError) {
         throw input.createError
       }
@@ -129,6 +146,14 @@ function makeRuntime(input: {
     async upsertSandbox(row: UpsertInput) {
       upserts.push(row)
     },
+    async checkpointExists() {
+      checkpointChecks += 1
+      return input.checkpointExists ?? false
+    },
+    async verifyRestoreMarker() {
+      restoreMarkerChecks += 1
+      return input.restoreMarkerVerified ?? false
+    },
     async waitForHealth() {
       healthChecks += 1
     },
@@ -137,11 +162,19 @@ function makeRuntime(input: {
   return {
     runtime,
     upserts,
+    nameLookups,
+    createInputs,
     get createCalls() {
       return createCalls
     },
     get healthChecks() {
       return healthChecks
+    },
+    get checkpointChecks() {
+      return checkpointChecks
+    },
+    get restoreMarkerChecks() {
+      return restoreMarkerChecks
     },
   }
 }
@@ -160,6 +193,7 @@ describe("Daytona Cloud provisioning adoption", () => {
     const result = await daytona.provisionWorkerOnDaytonaWithRuntime(input, runtime.runtime)
 
     expect(result.status).toBe("healthy")
+    expect(result.imageVersion).toBe("openwork-0.18.8")
     expect(result.url).toBe(`https://workers.example.test/${encodeURIComponent(input.workerId)}`)
     expect(runtime.createCalls).toBe(1)
     expect(existing.startCalls).toBe(1)
@@ -182,6 +216,7 @@ describe("Daytona Cloud provisioning adoption", () => {
     const result = await daytona.provisionWorkerOnDaytonaWithRuntime(input, runtime.runtime)
 
     expect(result.status).toBe("healthy")
+    expect(result.imageVersion).toBe("openwork-0.18.8")
     expect(runtime.createCalls).toBe(1)
     expect(created.startCalls).toBe(0)
     expect(created.deleteCalls).toBe(0)
@@ -204,5 +239,177 @@ describe("Daytona Cloud provisioning adoption", () => {
     expect(existing.startCalls).toBe(1)
     expect(existing.deleteCalls).toBe(0)
     expect(runtime.upserts).toHaveLength(0)
+  })
+})
+
+describe("Daytona Cloud version-aware recycle", () => {
+  test("recycles a stale stopped sandbox with a checkpoint into a version-qualified replacement", async () => {
+    const input = provisionInput()
+    const old = makeSandbox({ id: "sbx_old", state: "stopped" })
+    const replacement = makeSandbox({ id: "sbx_replacement", state: "started" })
+    const runtime = makeRuntime({
+      nameResultsByName: [{ name: "sbx_old", results: [old.sandbox] }],
+      createdSandbox: replacement.sandbox,
+      checkpointExists: true,
+      restoreMarkerVerified: true,
+    })
+
+    const result = await daytona.wakeWorkerOnDaytonaWithRuntime(
+      input,
+      runtime.runtime,
+      { sandbox_id: "sbx_old", workspace_volume_id: "vol_shared", data_volume_id: "vol_shared" },
+      "openwork-0.18.7",
+    )
+
+    expect(result.status).toBe("healthy")
+    expect(result.imageVersion).toBe("openwork-0.18.8")
+    expect(runtime.createCalls).toBe(1)
+    expect(runtime.createInputs[0]?.name).toBe(daytona.daytonaSandboxNameForSnapshot(input, "openwork-0.18.8"))
+    expect(runtime.checkpointChecks).toBe(1)
+    expect(runtime.restoreMarkerChecks).toBe(1)
+    expect(runtime.upserts).toHaveLength(1)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_replacement")
+    expect(old.startCalls).toBe(0)
+    expect(old.deleteCalls).toBe(1)
+    expect(replacement.deleteCalls).toBe(0)
+  })
+
+  test("does not recycle a stale running sandbox", async () => {
+    const input = provisionInput()
+    const old = makeSandbox({ id: "sbx_running", state: "started" })
+    const runtime = makeRuntime({
+      nameResultsByName: [{ name: "sbx_running", results: [old.sandbox] }],
+      checkpointExists: true,
+      restoreMarkerVerified: true,
+    })
+
+    const result = await daytona.wakeWorkerOnDaytonaWithRuntime(
+      input,
+      runtime.runtime,
+      { sandbox_id: "sbx_running", workspace_volume_id: "vol_shared", data_volume_id: "vol_shared" },
+      "openwork-0.18.7",
+    )
+
+    expect(result.status).toBe("healthy")
+    expect(runtime.createCalls).toBe(0)
+    expect(runtime.checkpointChecks).toBe(0)
+    expect(old.deleteCalls).toBe(0)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_running")
+  })
+
+  test("does not recycle a stale stopped sandbox before a checkpoint exists", async () => {
+    const input = provisionInput()
+    const old = makeSandbox({ id: "sbx_no_checkpoint", state: "stopped" })
+    const runtime = makeRuntime({
+      nameResultsByName: [{ name: "sbx_no_checkpoint", results: [old.sandbox] }],
+      checkpointExists: false,
+    })
+
+    const result = await daytona.wakeWorkerOnDaytonaWithRuntime(
+      input,
+      runtime.runtime,
+      { sandbox_id: "sbx_no_checkpoint", workspace_volume_id: "vol_shared", data_volume_id: "vol_shared" },
+      "openwork-0.18.7",
+    )
+
+    expect(result.status).toBe("healthy")
+    expect(runtime.createCalls).toBe(0)
+    expect(runtime.checkpointChecks).toBe(1)
+    expect(old.startCalls).toBe(1)
+    expect(old.deleteCalls).toBe(0)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_no_checkpoint")
+  })
+
+  test("deletes a failed replacement, keeps the old sandbox, and wakes the old sandbox", async () => {
+    const input = provisionInput()
+    const old = makeSandbox({ id: "sbx_old_safe", state: "stopped" })
+    const replacement = makeSandbox({ id: "sbx_bad_replacement", state: "started" })
+    const runtime = makeRuntime({
+      nameResultsByName: [{ name: "sbx_old_safe", results: [old.sandbox] }],
+      createdSandbox: replacement.sandbox,
+      checkpointExists: true,
+      restoreMarkerVerified: false,
+    })
+
+    const result = await daytona.wakeWorkerOnDaytonaWithRuntime(
+      input,
+      runtime.runtime,
+      { sandbox_id: "sbx_old_safe", workspace_volume_id: "vol_shared", data_volume_id: "vol_shared" },
+      "openwork-0.18.7",
+    )
+
+    expect(result.status).toBe("healthy")
+    expect(runtime.createCalls).toBe(1)
+    expect(runtime.restoreMarkerChecks).toBe(1)
+    expect(runtime.healthChecks).toBe(2)
+    expect(replacement.deleteCalls).toBe(1)
+    expect(old.deleteCalls).toBe(0)
+    expect(old.startCalls).toBe(1)
+    expect(runtime.upserts).toHaveLength(1)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_old_safe")
+  })
+
+  test("keeps the same-version stopped sandbox on the normal wake path", async () => {
+    const input = provisionInput()
+    const old = makeSandbox({ id: "sbx_current", state: "stopped" })
+    const runtime = makeRuntime({
+      nameResultsByName: [{ name: "sbx_current", results: [old.sandbox] }],
+      checkpointExists: true,
+    })
+
+    const result = await daytona.wakeWorkerOnDaytonaWithRuntime(
+      input,
+      runtime.runtime,
+      { sandbox_id: "sbx_current", workspace_volume_id: "vol_shared", data_volume_id: "vol_shared" },
+      "openwork-0.18.8",
+    )
+
+    expect(result.status).toBe("healthy")
+    expect(runtime.createCalls).toBe(0)
+    expect(runtime.checkpointChecks).toBe(0)
+    expect(old.startCalls).toBe(1)
+    expect(old.deleteCalls).toBe(0)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_current")
+  })
+})
+
+describe("Daytona Cloud sandbox name lookup", () => {
+  test("checks the current version-qualified sandbox name before the legacy base name", async () => {
+    const input = provisionInput()
+    const currentName = daytona.daytonaSandboxNameForSnapshot(input, "openwork-0.18.8")
+    const legacyName = daytona.daytonaSandboxName(input)
+    const current = makeSandbox({ id: "sbx_current_name", state: "stopped" })
+    const legacy = makeSandbox({ id: "sbx_legacy_name", state: "stopped" })
+    const runtime = makeRuntime({
+      nameResultsByName: [
+        { name: currentName, results: [current.sandbox] },
+        { name: legacyName, results: [legacy.sandbox] },
+      ],
+    })
+
+    await daytona.provisionWorkerOnDaytonaWithRuntime(input, runtime.runtime)
+
+    expect(runtime.nameLookups[0]).toBe(currentName)
+    expect(runtime.nameLookups).not.toContain(legacyName)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_current_name")
+    expect(legacy.startCalls).toBe(0)
+  })
+
+  test("falls back to the legacy base name when no current version-qualified sandbox exists", async () => {
+    const input = provisionInput()
+    const currentName = daytona.daytonaSandboxNameForSnapshot(input, "openwork-0.18.8")
+    const legacyName = daytona.daytonaSandboxName(input)
+    const legacy = makeSandbox({ id: "sbx_legacy_fallback", state: "stopped" })
+    const runtime = makeRuntime({
+      nameResultsByName: [
+        { name: currentName, results: [null] },
+        { name: legacyName, results: [legacy.sandbox] },
+      ],
+    })
+
+    await daytona.provisionWorkerOnDaytonaWithRuntime(input, runtime.runtime)
+
+    expect(runtime.nameLookups.slice(0, 2)).toEqual([currentName, legacyName])
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_legacy_fallback")
   })
 })


### PR DESCRIPTION
Cloud sandboxes are pets today: their filesystem is the only copy of user state, so they can never be replaced — which is why every existing instance is stuck on whatever snapshot it was born with (the provider-sync bug was exactly this, six releases of drift). This PR makes sandboxes disposable-with-bounded-loss and makes every worker converge onto `DAYTONA_SNAPSHOT` automatically.

## Grounding

Built on semantics measured against the production volume (S3-FUSE): sequential whole-file writes, overwrite, and delete all work; random writes, rename, and locks do not. So live databases can never sit on the volume, but whole-file checkpoint artifacts can — write-local-then-copy, prune by delete.

## Part 1 — checkpoint/restore inside the sandbox

`buildOpenWorkStartCommand` gains three named seams (deliberately — the transport behind them is swappable later for Litestream/Archil without touching callers):

- **State manifest**: exactly `runtimeDataPath` + `runtimeWorkspacePath`, nothing else. Tar stores the `volumes/` symlinks as links (never `-h`), so mounts are not duplicated.
- **Hydrate hook**: before openwork-server starts, restore the newest `ckpt-*.tar` from `${dataMountPath}/checkpoints/` if local state is pristine, and write a restore marker. Restore failure logs loudly and boots fresh — it never bricks the instance.
- **Flush hook**: background loop (default 300s, env-tunable, `find -newer` dirty check) tars locally, copies to the volume, prunes to the newest 3; one final flush on TERM. Failures never kill the server.

## Part 2 — version-aware recycle in resolve/wake

- `image_version` is now written on successful provision, adopt, and wake (cloud workers had NULL before).
- Resolve claims a recycle only when `image_version !== env.daytona.snapshot` AND the sandbox is **stopped** (running-but-stale is left alone until its next stop — no drain problem in v1). Claim uses the same race-safe status-write pattern as `claimFailedWorker`, so concurrent resolves cannot storm.
- The **wake path** owns the decision: it probes the volume for a checkpoint (one ephemeral micro-sandbox, created from the pinned snapshot, always deleted). No checkpoint -> plain wake of the old sandbox, exactly today's behavior. Checkpoint present -> recycle: create replacement under a **version-qualified name** -> boot -> hydrate restores the checkpoint -> verify health AND restore marker -> only then delete the old sandbox. Verification failure deletes the *replacement*, keeps the old sandbox, and wakes it — the user can never end up with zero sandboxes.
- Adoption lookup checks the version-qualified name first, then the legacy base name, so every existing sandbox keeps being adopted.

Deletion of a pre-existing sandbox happens in exactly one place — after replacement verification — and is impossible without a checkpoint. All other deletes are of sandboxes the same call created (probe, failed replacement, failed create).

## Review round worth noting

The first version probed for checkpoints inside `inspectDaytonaSandbox`, i.e. on the resolve hot path — every ordinary wake of an up-to-date worker would have created+deleted a probe sandbox, with concurrent probes under app polling, and stale workers paid it twice. Caught in review; the probe now runs only inside the claimed wake of a stale stopped worker, once, and creates from the cached snapshot instead of a raw docker image.

## Rollout behavior (existing fleet)

Existing sandboxes have `image_version = NULL` (stale by definition) and no checkpoint sidecar yet. Their next wake re-execs the *newly generated* start command, which starts the sidecar and begins producing checkpoints; the wake preserves their old image_version. On the following stop+resolve cycle the probe finds a checkpoint and the recycle converges them onto the pin with state restored. So the fleet migrates itself: wake -> checkpoints begin -> next cycle -> recycled onto current. No manual migration, no data loss window beyond the checkpoint interval.

## Tests

41 pass / 0 fail across `cloud-instance-route`, `daytona-provisioning`, `cloud-lifecycle`, `daytona-checkpoint-command`, `cloud-provisioning-image-version`; `tsc --noEmit` clean. Coverage includes: start-command invariants (hydrate-before-server, TERM trap, prune K, no `tar -h`), image_version on provision/adopt/wake, recycle success, stale+running untouched, stale+no-checkpoint plain-wakes with nothing deleted, failed verification keeps the old sandbox, same-version adopt regression (#3219), name-lookup precedence, and a probe-storm regression asserting inspection never probes.

## Not verified here

No live Daytona recycle has run yet — unit/type coverage only. I am live-verifying on the production canary org immediately after deploy (write file -> checkpoint -> stop -> resolve -> recycled onto the pin -> file survives) and will post the evidence.