### PR TITLE
feat(den): assign MCP connections to existing plugins

### DIFF
--- a/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/contracts.ts
@@ -450,7 +450,7 @@ export const pluginArchEndpointContracts: Record<string, EndpointContract> = {
   },
   configurePluginMcpRequirement: {
     audience: "admin",
-    description: "Configure one declared remote MCP server from a plugin by deriving its URL and audience server-side.",
+    description: "Configure one declared remote MCP server or assign an existing organization MCP connection to a plugin.",
     method: "POST",
     path: pluginArchRoutePaths.pluginMcpConnections,
     request: { body: pluginMcpRequirementConfigureSchema, params: pluginParamsSchema },

--- a/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/routes.ts
@@ -114,6 +114,7 @@ import { isAgentOAuthClientConnection } from "../mcp-connections.js"
 import {
   PluginArchRouteFailure,
   addPluginMembership,
+  attachExistingMcpConnectionToPlugin,
   attachConfigObjectToPlugin,
   createConfigObject,
   createConfigObjectVersion,
@@ -235,11 +236,18 @@ async function configurePluginMcpConnectionResponse(c: OrgContext) {
   try {
     const params = validParam<z.infer<typeof pluginParamsSchema>>(c)
     const body = validJson<z.infer<typeof pluginMcpRequirementConfigureSchema>>(c)
-    if (isAgentPluginMcpSecretSetup({ apiKey: body.apiKey, oauthClient: body.oauthClient, sessionId: c.get("session")?.id })) {
+    if (!("externalMcpConnectionId" in body) && isAgentPluginMcpSecretSetup({ apiKey: body.apiKey, oauthClient: body.oauthClient, sessionId: c.get("session")?.id })) {
       return c.json({ error: "invalid_request", message: "Plugin MCP credentials cannot be set from the agent. Add them in the OpenWork Cloud dashboard under Connections." }, 400)
     }
     const admin = ensureOrganizationAdmin(c, "Only workspace owners and admins can configure plugin MCP requirements.")
     if (!admin.ok) return c.json(admin.response, orgAccessFailureStatus(admin.response))
+    if ("externalMcpConnectionId" in body) {
+      return c.json({ ok: true, item: await attachExistingMcpConnectionToPlugin({
+        connectionId: body.externalMcpConnectionId,
+        context: actorContext(c),
+        pluginId: normalizeDenTypeId("plugin", params.pluginId),
+      }) })
+    }
     return c.json({ ok: true, item: await configureMarketplacePluginMcpRequirement({
       authType: body.authType,
       apiKey: body.apiKey,
@@ -903,13 +911,14 @@ export function registerPluginArchRoutes<T extends { Variables: OrgRouteVariable
     describeRoute({
       tags: ["Plugins"],
       summary: "Configure plugin MCP requirement",
-      description: "Admin-only privileged setup for one declared remote MCP server. The server name and URL are derived from the active plugin config object; the request never supplies a URL and does not start OAuth.",
+      description: "Admin-only setup for one declared remote MCP server or assignment of an existing organization MCP connection. The request never supplies a URL and does not start OAuth.",
       responses: {
         200: jsonResponse("Plugin MCP requirement configured successfully.", pluginMcpRequirementConfigureResponseSchema),
         400: jsonResponse("The plugin MCP requirement request was invalid.", invalidRequestSchema),
         401: jsonResponse("The caller must be signed in to configure plugin MCP requirements.", unauthorizedSchema),
         403: jsonResponse("Only workspace owners and admins can configure plugin MCP requirements.", forbiddenSchema),
         404: jsonResponse("The plugin MCP requirement could not be found.", notFoundSchema),
+        409: jsonResponse("The MCP connection is already assigned to the plugin.", invalidRequestSchema),
       },
     }),
     configurePluginMcpConnectionResponse)

--- a/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/schemas.ts
@@ -44,6 +44,7 @@ export const marketplaceIdSchema = denTypeIdSchema("marketplace")
 export const marketplacePluginIdSchema = denTypeIdSchema("marketplacePlugin")
 export const marketplaceAccessGrantIdSchema = denTypeIdSchema("marketplaceAccessGrant")
 export const pluginMcpRequirementBindingIdSchema = denTypeIdSchema("pluginMcpRequirementBinding")
+export const externalMcpConnectionIdSchema = denTypeIdSchema("externalMcpConnection")
 export const connectorAccountIdSchema = denTypeIdSchema("connectorAccount")
 export const connectorInstanceIdSchema = denTypeIdSchema("connectorInstance")
 export const connectorInstanceAccessGrantIdSchema = denTypeIdSchema("connectorInstanceAccessGrant")
@@ -421,7 +422,7 @@ export const githubPluginMcpImportSchema = githubPluginMcpImportPreviewSchema.ex
   selectedServerNames: z.array(z.string().trim().min(1).max(255)).max(200).optional(),
 })
 
-export const pluginMcpRequirementConfigureSchema = z.object({
+const pluginMcpRequirementDeclaredConfigureSchema = z.object({
   configObjectId: configObjectIdSchema,
   serverName: z.string().trim().min(1).max(255),
   authType: z.enum(["oauth", "apikey", "none"]).optional().default("oauth"),
@@ -432,6 +433,11 @@ export const pluginMcpRequirementConfigureSchema = z.object({
     clientSecret: z.string().trim().min(1).max(4096).optional(),
   }).optional(),
 })
+
+export const pluginMcpRequirementConfigureSchema = z.union([
+  pluginMcpRequirementDeclaredConfigureSchema,
+  z.object({ externalMcpConnectionId: externalMcpConnectionIdSchema }),
+])
 
 export const githubDiscoveryTreeQuerySchema = z.object({
   cursor: z.string().trim().min(1).max(255).optional(),

--- a/ee/apps/den-api/src/routes/org/plugin-system/store.ts
+++ b/ee/apps/den-api/src/routes/org/plugin-system/store.ts
@@ -4408,6 +4408,95 @@ function importedConnectionBackedMcpPayload(input: {
   }
 }
 
+export async function attachExistingMcpConnectionToPlugin(input: {
+  connectionId: ExternalMcpConnectionRow["id"]
+  context: PluginArchActorContext
+  pluginId: PluginId
+}) {
+  const organizationId = input.context.organizationContext.organization.id
+  const plugin = await ensureEditablePlugin(input.context, input.pluginId)
+  const connection = await getExternalMcpConnection({
+    connectionId: input.connectionId,
+    organizationId,
+  })
+  if (!connection) {
+    throw new PluginArchRouteFailure(404, "mcp_connection_not_found", "MCP connection not found.")
+  }
+
+  const existingBindings = await db
+    .select({
+      externalMcpConnectionId: PluginMcpRequirementBindingTable.externalMcpConnectionId,
+      serverName: PluginMcpRequirementBindingTable.serverName,
+    })
+    .from(PluginMcpRequirementBindingTable)
+    .where(and(
+      eq(PluginMcpRequirementBindingTable.organizationId, organizationId),
+      eq(PluginMcpRequirementBindingTable.pluginId, plugin.id),
+    ))
+  if (existingBindings.some((binding) => binding.externalMcpConnectionId === connection.id)) {
+    throw new PluginArchRouteFailure(409, "mcp_connection_already_assigned", "This MCP connection is already assigned to the plugin.")
+  }
+
+  const baseServerName = slugifyPluginMcpName(connection.name)
+  const serverName = existingBindings.some((binding) => binding.serverName === baseServerName)
+    ? `${baseServerName}-${connection.id.slice(-6)}`
+    : baseServerName
+  const payload = {
+    mcpServers: {
+      [serverName]: {
+        type: "remote",
+        url: connection.url,
+        openworkManaged: "den_external_mcp",
+        externalMcpConnectionId: connection.id,
+        externalMcpConnectionOwnedByPlugin: false,
+        requiredAuthType: connection.authType,
+        ...(connection.authType === "oauth" ? { oauth: true } : {}),
+      },
+    },
+    openworkManaged: "den_external_mcp",
+    externalMcpConnectionId: connection.id,
+    externalMcpConnectionOwnedByPlugin: false,
+    requiredAuthType: connection.authType,
+  }
+  const configObject = await createConfigObject({
+    context: input.context,
+    objectType: "mcp",
+    pluginIds: [plugin.id],
+    sourceMode: "cloud",
+    value: {
+      metadata: {
+        description: "Existing Den-managed MCP connection.",
+        externalMcpConnectionId: connection.id,
+        externalMcpConnectionOwnedByPlugin: false,
+        name: connection.name,
+        openworkManaged: "den_external_mcp",
+        requiredAuthType: connection.authType,
+      },
+      normalizedPayloadJson: payload,
+      schemaVersion: "openwork.den_external_mcp.v1",
+    },
+  })
+  const binding = await upsertPluginMcpRequirementBinding({
+    configObjectId: configObject.id,
+    createdByOrgMembershipId: input.context.organizationContext.currentMember.id,
+    externalMcpConnectionId: connection.id,
+    organizationId,
+    pluginId: plugin.id,
+    serverName,
+    requiredAuthType: connection.authType,
+    connectionOwnedByPlugin: false,
+  })
+  await syncPluginMcpRequirementBindingAccess(binding)
+
+  return {
+    binding: serializePluginMcpRequirementBinding(binding),
+    connection: serializePluginMcpRequirementConnection(connection),
+    links: {
+      yourConnections: openworkYourConnectionsUrl(connection.id),
+    },
+  }
+}
+
 function importedPluginName(plan: GithubPluginMcpImportPlan) {
   if (plan.plugins.length === 1) return plan.plugins[0].name
   return plan.marketplace?.name?.trim() || plan.rootPath.split("/").filter(Boolean).at(-1) || plan.repositoryFullName.split("/").at(-1) || "GitHub MCP Plugin"

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-data.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-data.tsx
@@ -7,6 +7,7 @@ import {
   type ConnectedIntegration,
   integrationQueryKeys,
 } from "./integration-data";
+import { mcpConnectionQueryKeys } from "./mcp-connections-data";
 
 /**
  * Plugin primitives — mirror OpenCode / Claude Code's plugin surface:
@@ -64,6 +65,7 @@ export type PluginMcpTransport = "stdio" | "http" | "sse";
 
 export type PluginMcp = {
   configObjectId?: string;
+  externalMcpConnectionId?: string;
   id: string;
   name: string;
   description: string;
@@ -477,16 +479,20 @@ export function pluginMcpEntries(item: {
     ? entries
     : [[item.title, payload] satisfies [string, Record<string, unknown>]];
 
-  return servers.map(([serverName, config], index) => ({
-    configObjectId: item.id,
-    description: item.description,
-    id: servers.length === 1 ? item.id : `${item.id}:${index}`,
-    name: servers.length === 1 ? item.title : serverName,
-    serverName,
-    toolCount: typeof config.toolCount === "number" ? config.toolCount : 0,
-    transport: pluginMcpTransport(config),
-    url: asString(config.url),
-  }));
+  return servers.map(([serverName, config], index) => {
+    const externalMcpConnectionId = asString(config.externalMcpConnectionId);
+    return {
+      configObjectId: item.id,
+      description: item.description,
+      ...(externalMcpConnectionId ? { externalMcpConnectionId } : {}),
+      id: servers.length === 1 ? item.id : `${item.id}:${index}`,
+      name: servers.length === 1 ? item.title : serverName,
+      serverName,
+      toolCount: typeof config.toolCount === "number" ? config.toolCount : 0,
+      transport: pluginMcpTransport(config),
+      url: asString(config.url),
+    };
+  });
 }
 
 function parseMembershipConfigObject(entry: unknown) {
@@ -705,6 +711,61 @@ export function useArchivePlugin() {
     onSuccess: (pluginId) => {
       queryClient.removeQueries({ queryKey: pluginQueryKeys.detail(pluginId) });
       queryClient.invalidateQueries({ queryKey: pluginQueryKeys.list() });
+    },
+  });
+}
+
+export function useAttachPluginMcpConnection() {
+  const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (input: { pluginId: string; connectionId: string }) => {
+      await runReauthableAction("attach-plugin-mcp-connection", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/plugins/${encodeURIComponent(input.pluginId)}/mcp-connections`,
+          {
+            method: "POST",
+            body: JSON.stringify({ externalMcpConnectionId: input.connectionId }),
+          },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to add MCP connection (${response.status}).`);
+        }
+      });
+      return input.pluginId;
+    },
+    onSuccess: (pluginId) => {
+      queryClient.invalidateQueries({ queryKey: pluginQueryKeys.detail(pluginId) });
+      queryClient.invalidateQueries({ queryKey: pluginQueryKeys.list() });
+      queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });
+    },
+  });
+}
+
+export function useRemovePluginMcpConnection() {
+  const queryClient = useQueryClient();
+  const { runReauthableAction } = useOrgDashboard();
+
+  return useMutation({
+    mutationFn: async (input: { pluginId: string; configObjectId: string }) => {
+      await runReauthableAction("remove-plugin-mcp-connection", async () => {
+        const { response, payload } = await requestJson(
+          `/v1/plugins/${encodeURIComponent(input.pluginId)}/config-objects/${encodeURIComponent(input.configObjectId)}`,
+          { method: "DELETE" },
+          15000,
+        );
+        if (!response.ok) {
+          throw getRequestError(payload, response, `Failed to remove MCP connection (${response.status}).`);
+        }
+      });
+      return input.pluginId;
+    },
+    onSuccess: (pluginId) => {
+      queryClient.invalidateQueries({ queryKey: pluginQueryKeys.detail(pluginId) });
+      queryClient.invalidateQueries({ queryKey: pluginQueryKeys.list() });
+      queryClient.invalidateQueries({ queryKey: mcpConnectionQueryKeys.all });
     },
   });
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/plugin-detail-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/plugin-detail-screen.tsx
@@ -3,12 +3,13 @@
 import Link from "next/link";
 import { useRouter } from "next/navigation";
 import { useEffect, useRef, useState } from "react";
-import { Archive, ArrowLeft, FileText, MoreHorizontal, Pencil, Plus, Puzzle, Server, Store, Terminal, Users, Webhook } from "lucide-react";
+import { Archive, ArrowLeft, FileText, MoreHorizontal, Pencil, Plus, Puzzle, Server, Store, Terminal, Trash2, Users, Webhook } from "lucide-react";
 import { PaperMeshGradient } from "@openwork/ui/react";
 
 import { getNewPluginSkillRoute, getOrgAccessFlags, getPluginSkillRoute, getPluginsRoute } from "../../_lib/den-org";
 import { buttonVariants, DenButton } from "../../_components/ui/button";
 import { DenInput } from "../../_components/ui/input";
+import { DenSelect } from "../../_components/ui/select";
 import { DenTextarea } from "../../_components/ui/textarea";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
 import {
@@ -19,10 +20,13 @@ import {
   type PluginAgent,
   type PluginCommand,
   formatPluginTimestamp,
+  useAttachPluginMcpConnection,
   useArchivePlugin,
   usePlugin,
+  useRemovePluginMcpConnection,
   useUpdatePlugin,
 } from "./plugin-data";
+import { useMcpConnections } from "./mcp-connections-data";
 
 export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
   const router = useRouter();
@@ -75,7 +79,6 @@ export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
   if (plugin.agents.length === 0) missingLabels.push("agents");
   if (plugin.commands.length === 0) missingLabels.push("commands");
   if (plugin.hooks.length === 0) missingLabels.push("hooks");
-  if (plugin.mcps.length === 0) missingLabels.push("MCP servers");
 
   async function handleArchivePlugin() {
     try {
@@ -204,7 +207,7 @@ export function PluginDetailScreen({ pluginId }: { pluginId: string }) {
         <PrimitiveSection icon={Users} label="Agents" items={plugin.agents} render={renderAgentRow} />
         <PrimitiveSection icon={Terminal} label="Commands" items={plugin.commands} render={renderCommandRow} />
         <PrimitiveSection icon={Webhook} label="Hooks" items={plugin.hooks} render={renderHookRow} />
-        <PrimitiveSection icon={Server} label="MCP Servers" items={plugin.mcps} render={renderMcpRow} />
+        <McpSection canManage={access.isAdmin} plugin={plugin} />
       </div>
 
       {missingLabels.length > 0 ? (
@@ -487,21 +490,182 @@ function renderHookRow(hook: PluginHook) {
   );
 }
 
-function renderMcpRow(mcp: PluginMcp) {
+function McpSection({ canManage, plugin }: { canManage: boolean; plugin: DenPlugin }) {
+  const [addOpen, setAddOpen] = useState(false);
+  const removeConnection = useRemovePluginMcpConnection();
+
+  async function handleRemove(mcp: PluginMcp) {
+    if (!mcp.configObjectId) return;
+    try {
+      await removeConnection.mutateAsync({ configObjectId: mcp.configObjectId, pluginId: plugin.id });
+    } catch {
+      // The mutation error is rendered below the list.
+    }
+  }
+
   return (
-    <div
-      key={mcp.id}
-      className="flex items-start justify-between gap-3 rounded-xl border border-gray-100 bg-white px-4 py-3 transition hover:border-gray-200"
-    >
-      <div className="min-w-0 flex-1">
-        <p className="truncate text-[14px] font-semibold tracking-[-0.01em] text-gray-900">{mcp.name}</p>
-        {mcp.description ? (
-          <p className="mt-0.5 line-clamp-2 text-[12.5px] leading-[1.55] text-gray-500">{mcp.description}</p>
+    <section>
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <div>
+          <h2 className="inline-flex items-center gap-1.5 text-[11px] font-semibold uppercase tracking-[0.16em] text-gray-400">
+            <Server className="h-3.5 w-3.5" />
+            MCP Servers
+          </h2>
+          <p className="mt-1 text-[12px] text-gray-400">Connections whose tools are available through this plugin.</p>
+        </div>
+        {canManage ? (
+          <DenButton size="sm" onClick={() => setAddOpen(true)} data-testid="plugin-add-mcp">
+            <Plus className="h-3.5 w-3.5" aria-hidden />
+            Add MCP
+          </DenButton>
         ) : null}
       </div>
-      <span className="shrink-0 rounded-full bg-gray-50 px-2 py-0.5 text-[11px] text-gray-500">
-        {mcp.transport === "stdio" ? "Desktop only" : "Remote"} · {mcp.toolCount} tool{mcp.toolCount === 1 ? "" : "s"}
-      </span>
+      {plugin.mcps.length === 0 ? (
+        <div className="rounded-xl border border-dashed border-gray-200 bg-white px-5 py-8 text-center">
+          <p className="text-[14px] font-medium text-gray-900">No MCP servers in this plugin yet.</p>
+          <p className="mt-1 text-[12.5px] text-gray-500">Add an existing organization connection to give the plugin more tools.</p>
+        </div>
+      ) : (
+        <div className="grid gap-2">
+          {plugin.mcps.map((mcp) => (
+            <div
+              key={mcp.id}
+              className="flex items-start justify-between gap-3 rounded-xl border border-gray-100 bg-white px-4 py-3 transition hover:border-gray-200"
+            >
+              <div className="min-w-0 flex-1">
+                <p className="truncate text-[14px] font-semibold tracking-[-0.01em] text-gray-900">{mcp.name}</p>
+                {mcp.description ? (
+                  <p className="mt-0.5 line-clamp-2 text-[12.5px] leading-[1.55] text-gray-500">{mcp.description}</p>
+                ) : null}
+              </div>
+              <div className="flex shrink-0 items-center gap-2">
+                <span className="rounded-full bg-gray-50 px-2 py-0.5 text-[11px] text-gray-500">
+                  {mcp.transport === "stdio" ? "Desktop only" : "Remote"} · {mcp.toolCount} tool{mcp.toolCount === 1 ? "" : "s"}
+                </span>
+                {canManage && mcp.configObjectId ? (
+                  <button
+                    type="button"
+                    className="flex h-7 w-7 items-center justify-center rounded-lg text-gray-400 transition hover:bg-red-50 hover:text-red-600"
+                    aria-label={`Remove ${mcp.name} from ${plugin.name}`}
+                    disabled={removeConnection.isPending}
+                    onClick={() => void handleRemove(mcp)}
+                    data-testid={`plugin-remove-mcp-${mcp.configObjectId}`}
+                  >
+                    <Trash2 className="h-3.5 w-3.5" aria-hidden />
+                  </button>
+                ) : null}
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {removeConnection.error ? (
+        <p className="mt-2 text-[12.5px] text-red-600">
+          {removeConnection.error instanceof Error ? removeConnection.error.message : "Failed to remove MCP connection."}
+        </p>
+      ) : null}
+      {addOpen ? (
+        <AddMcpDialog
+          plugin={plugin}
+          onClose={() => setAddOpen(false)}
+          onAdded={() => setAddOpen(false)}
+        />
+      ) : null}
+    </section>
+  );
+}
+
+function AddMcpDialog({
+  plugin,
+  onClose,
+  onAdded,
+}: {
+  plugin: DenPlugin;
+  onClose: () => void;
+  onAdded: () => void;
+}) {
+  const { data: connections = [], isLoading, error } = useMcpConnections("manageable");
+  const attachConnection = useAttachPluginMcpConnection();
+  const assignedConnectionIds = new Set(plugin.mcps.flatMap((mcp) => mcp.externalMcpConnectionId ? [mcp.externalMcpConnectionId] : []));
+  const availableConnections = connections.filter((connection) => !assignedConnectionIds.has(connection.id));
+  const [connectionId, setConnectionId] = useState("");
+  const selectedConnectionId = connectionId || availableConnections[0]?.id || "";
+
+  async function handleAdd() {
+    if (!selectedConnectionId) return;
+    try {
+      await attachConnection.mutateAsync({ connectionId: selectedConnectionId, pluginId: plugin.id });
+      onAdded();
+    } catch {
+      // The mutation error is rendered in the dialog.
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-950/45 px-4 py-6" onClick={attachConnection.isPending ? undefined : onClose}>
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-plugin-mcp-title"
+        className="w-full max-w-[480px] rounded-2xl border border-gray-100 bg-white p-6 shadow-[0_24px_60px_-24px_rgba(15,23,42,0.4)]"
+        onClick={(event) => event.stopPropagation()}
+      >
+        <h2 id="add-plugin-mcp-title" className="text-[16px] font-semibold tracking-[-0.01em] text-gray-950">
+          Add an MCP connection
+        </h2>
+        <p className="mt-1 text-[13px] leading-6 text-gray-500">
+          Choose an existing organization connection. Removing it later only detaches it from this plugin.
+        </p>
+        {isLoading ? (
+          <p className="mt-4 text-[13px] text-gray-500">Loading connections…</p>
+        ) : availableConnections.length > 0 ? (
+          <label className="mt-4 block">
+            <span className="mb-1.5 block text-[12px] font-medium text-gray-700">MCP connection</span>
+            <DenSelect
+              value={selectedConnectionId}
+              onChange={(event) => setConnectionId(event.target.value)}
+              disabled={attachConnection.isPending}
+              data-testid="plugin-mcp-connection-select"
+            >
+              {availableConnections.map((connection) => (
+                <option key={connection.id} value={connection.id}>
+                  {connection.name} — {connection.connected ? "Connected" : "Setup required"}
+                </option>
+              ))}
+            </DenSelect>
+            <p className="mt-2 truncate text-[11.5px] text-gray-400">
+              {availableConnections.find((connection) => connection.id === selectedConnectionId)?.url}
+            </p>
+          </label>
+        ) : (
+          <div className="mt-4 rounded-xl border border-dashed border-gray-200 bg-gray-50 px-4 py-5 text-center">
+            <p className="text-[13px] font-medium text-gray-800">No connections available to add.</p>
+            <p className="mt-1 text-[12px] text-gray-500">Create an organization MCP connection first, or every connection is already assigned.</p>
+          </div>
+        )}
+        {error || attachConnection.error ? (
+          <p className="mt-3 text-[12.5px] text-red-600">
+            {attachConnection.error instanceof Error
+              ? attachConnection.error.message
+              : error instanceof Error
+                ? error.message
+                : "Failed to load MCP connections."}
+          </p>
+        ) : null}
+        <div className="mt-5 flex items-center justify-end gap-2">
+          <DenButton variant="secondary" onClick={onClose} disabled={attachConnection.isPending}>
+            Cancel
+          </DenButton>
+          <DenButton
+            loading={attachConnection.isPending}
+            disabled={!selectedConnectionId || isLoading}
+            onClick={() => void handleAdd()}
+            data-testid="plugin-add-mcp-confirm"
+          >
+            Add MCP
+          </DenButton>
+        </div>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
> **Review readiness — 2026-09-04: Incomplete.** This PR is open for review. Required current-head journey evidence and upstream review have not yet been verified in this cleanup. Historical checks below retain their original scope and do not establish current merge readiness.

## Summary

- add an MCP Servers management section to existing Plugin detail pages
- let workspace admins choose from existing organization MCP connections
- persist a tenant-scoped Plugin-to-MCP requirement binding and inherit Plugin access grants
- allow detaching an MCP from a Plugin without deleting or disconnecting the organization connection

## Manual verification

1. Start the Den API and Web app with a seeded organization.
2. Create or connect an organization MCP under Connections.
3. Open an existing Plugin and select **Add MCP**.
4. Choose the connection and confirm it appears in the Plugin MCP Servers section.
5. Confirm the connection lists the Plugin under its required-by provenance.
6. Remove the MCP from the Plugin and confirm the organization MCP connection still exists.

## Checks

Checks not run (level 0). The change was implemented and the complete diff was reviewed, but no tests, typechecks, builds, services, or fraimz flow were run.

## Risk

The new assignment path reuses existing tenant-scoped Den connection records and creates no credentials. Removal deletes only the Plugin binding and membership; it does not delete the shared MCP connection.