### PR TITLE
fix(gateway): proxy instance requests with the host token so host-scoped features work on web

### DIFF
--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -54,6 +54,7 @@ type CloudInstanceResponse = {
 }
 type CloudGatewayInstanceResponse = CloudInstanceResponse & {
   clientToken: string | null
+  hostToken: string | null
 }
 type CloudWorkerStore = {
   getCloudWorker: (input: { orgId: OrgId; userId: UserId }) => Promise<CloudWorker | null>
@@ -92,6 +93,7 @@ const cloudGatewayInstanceResponseSchema = z.object({
   status: z.enum(["provisioning", "waking", "ready", "failed"]),
   url: z.string().url().nullable(),
   clientToken: z.string().nullable(),
+  hostToken: z.string().nullable(),
 }).meta({ ref: "CloudGatewayInstanceResponse" })
 
 function cloudNotFound() {
@@ -744,17 +746,18 @@ async function resolveCloudInstanceForGateway(input: {
 }): Promise<CloudGatewayInstanceResponse> {
   const resolved = await resolveCloudInstanceForMember(input)
   if (resolved.instance.status !== "ready") {
-    return { status: resolved.instance.status, url: null, clientToken: null }
+    return { status: resolved.instance.status, url: null, clientToken: null, hostToken: null }
   }
 
   const tokens = await input.store.getActiveTokens(resolved.worker.id)
   const clientToken = tokenByScope(tokens, "client")
-  if (!resolved.instance.url || !clientToken) {
-    logger.error("cloud gateway ready instance missing client token", { worker_id: resolved.worker.id })
-    return { status: "failed", url: null, clientToken: null }
+  const hostToken = tokenByScope(tokens, "host")
+  if (!resolved.instance.url || !clientToken || !hostToken) {
+    logger.error("cloud gateway ready instance missing gateway token", { worker_id: resolved.worker.id })
+    return { status: "failed", url: null, clientToken: null, hostToken: null }
   }
 
-  return { status: "ready", url: resolved.instance.url, clientToken }
+  return { status: "ready", url: resolved.instance.url, clientToken, hostToken }
 }
 
 export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -354,6 +354,22 @@ describe("Cloud gateway resolve route", () => {
     await expect(response.json()).resolves.toEqual({ error: "cloud_not_found" })
   })
 
+  test("returns 404 when the gateway key header is missing", async () => {
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      gatewayKey: "gateway-secret",
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/gateway/resolve")
+
+    expect(response.status).toBe(404)
+    await expect(response.json()).resolves.toEqual({ error: "cloud_not_found" })
+  })
+
   test("returns 404 when the Cloud capability is off", async () => {
     const app = new Hono<{ Variables: OrgRouteVariables }>()
     routes.registerCloudRoutes(app, {
@@ -372,7 +388,7 @@ describe("Cloud gateway resolve route", () => {
     await expect(response.json()).resolves.toEqual({ error: "cloud_not_found" })
   })
 
-  test("returns the client token only when the instance is ready", async () => {
+  test("returns the gateway tokens only when the instance is ready", async () => {
     const provisioningWorker = fakeWorker("provisioning")
     const provisioningApp = new Hono<{ Variables: OrgRouteVariables }>()
     routes.registerCloudRoutes(provisioningApp, {
@@ -390,10 +406,10 @@ describe("Cloud gateway resolve route", () => {
     })
 
     expect(provisioning.status).toBe(200)
-    await expect(provisioning.json()).resolves.toEqual({ status: "provisioning", url: null, clientToken: null })
+    await expect(provisioning.json()).resolves.toEqual({ status: "provisioning", url: null, clientToken: null, hostToken: null })
 
     const readyWorker = fakeWorker("healthy")
-    const store = makeCloudWorkerStore({ tokens: [makeToken(readyWorker.id, "client")] })
+    const store = makeCloudWorkerStore({ tokens: [makeToken(readyWorker.id, "host"), makeToken(readyWorker.id, "client")] })
     const readyApp = new Hono<{ Variables: OrgRouteVariables }>()
     routes.registerCloudRoutes(readyApp, {
       memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
@@ -416,7 +432,32 @@ describe("Cloud gateway resolve route", () => {
       status: "ready",
       url: "https://preview.example.test",
       clientToken: "client-token",
+      hostToken: "host-token",
     })
+  })
+
+  test("does not expose the host token on the member instance response", async () => {
+    const readyWorker = fakeWorker("healthy")
+    const store = makeCloudWorkerStore({ tokens: [makeToken(readyWorker.id, "host"), makeToken(readyWorker.id, "client")] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => readyWorker,
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandbox(),
+      probeSignedPreview: async () => true,
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload).toEqual({ status: "ready", url: "https://preview.example.test" })
+    expect(payload).not.toHaveProperty("hostToken")
+    expect(payload).not.toHaveProperty("clientToken")
   })
 })
 

--- a/ee/apps/den-gateway/src/app.ts
+++ b/ee/apps/den-gateway/src/app.ts
@@ -13,10 +13,11 @@ type ResolvePayload = {
   status: InstanceStatus
   url: string | null
   clientToken: string | null
+  hostToken: string | null
 }
 
 type InstanceResolution =
-  | { kind: "ready"; url: string; clientToken: string }
+  | { kind: "ready"; url: string; clientToken: string; hostToken: string }
   | { kind: "not_ready"; status: NonReadyStatus }
   | { kind: "error"; statusCode: number; error: string }
 
@@ -133,11 +134,12 @@ function readResolvePayload(value: unknown): ResolvePayload | null {
   const status = readStatus(value.status)
   const url = typeof value.url === "string" ? value.url : value.url === null ? null : undefined
   const clientToken = typeof value.clientToken === "string" ? value.clientToken : value.clientToken === null ? null : undefined
-  if (!status || url === undefined || clientToken === undefined) {
+  const hostToken = typeof value.hostToken === "string" ? value.hostToken : value.hostToken === null ? null : undefined
+  if (!status || url === undefined || clientToken === undefined || hostToken === undefined) {
     return null
   }
 
-  return { status, url, clientToken }
+  return { status, url, clientToken, hostToken }
 }
 
 function isUsableUpstreamUrl(value: string) {
@@ -154,11 +156,11 @@ function parseResolvedInstance(payload: ResolvePayload): InstanceResolution {
     return { kind: "not_ready", status: payload.status }
   }
 
-  if (!payload.url || !payload.clientToken || !isUsableUpstreamUrl(payload.url)) {
+  if (!payload.url || !payload.clientToken || !payload.hostToken || !isUsableUpstreamUrl(payload.url)) {
     return { kind: "error", statusCode: 502, error: "gateway_resolve_invalid_ready_instance" }
   }
 
-  return { kind: "ready", url: payload.url, clientToken: payload.clientToken }
+  return { kind: "ready", url: payload.url, clientToken: payload.clientToken, hostToken: payload.hostToken }
 }
 
 function readBearerAuthorization(headers: Headers) {
@@ -488,7 +490,7 @@ async function requestBody(request: Request) {
   return body.byteLength > 0 ? body : undefined
 }
 
-function upstreamRequestHeaders(headers: Headers, clientToken: string) {
+function upstreamRequestHeaders(headers: Headers, hostToken: string) {
   const upstream = new Headers(headers)
   upstream.delete("authorization")
   upstream.delete("cookie")
@@ -497,7 +499,7 @@ function upstreamRequestHeaders(headers: Headers, clientToken: string) {
   upstream.delete("content-length")
   upstream.delete("transfer-encoding")
   upstream.delete(gatewayKeyHeader)
-  upstream.set("Authorization", `Bearer ${clientToken}`)
+  upstream.set("Authorization", `Bearer ${hostToken}`)
   return upstream
 }
 
@@ -572,7 +574,7 @@ async function proxyToInstance(input: {
   try {
     response = await input.config.fetchImpl(buildProxyUrl(input.resolution.url, input.request.url), {
       method: input.request.method,
-      headers: upstreamRequestHeaders(input.request.headers, input.resolution.clientToken),
+      headers: upstreamRequestHeaders(input.request.headers, input.resolution.hostToken),
       body: await requestBody(input.request),
       redirect: "manual",
     })

--- a/ee/apps/den-gateway/test/gateway.test.mjs
+++ b/ee/apps/den-gateway/test/gateway.test.mjs
@@ -68,6 +68,15 @@ function startDenApi(resolvePayload) {
   return { server, observed }
 }
 
+function readyResolvePayload(url, input = {}) {
+  return {
+    status: "ready",
+    url,
+    clientToken: input.clientToken ?? "client-token",
+    hostToken: input.hostToken ?? "host-token",
+  }
+}
+
 function startPassthroughDenApi() {
   const observed = { requests: [] }
   const encoder = new TextEncoder()
@@ -193,6 +202,7 @@ describe("den-gateway static UI", () => {
     expect(html).toContain("window.__OPENWORK_GATEWAY__ = {\"version\":1}")
     expect(html).not.toContain("__OPENWORK_BOOTSTRAP__")
     expect(html).not.toContain("client-token")
+    expect(html).not.toContain("host-token")
   })
 })
 
@@ -224,6 +234,7 @@ describe("den-gateway proxy", () => {
       forwardedPrefix: "/api/den",
       body: '{"hello":"world"}',
     })
+    expect(denApi.observed.requests[0].authorization).not.toBe("Bearer host-token")
     expect(upstream.observed.requests).toHaveLength(0)
   })
 
@@ -254,7 +265,7 @@ describe("den-gateway proxy", () => {
 
   test("answers gateway health while /health proxies to the instance", async () => {
     const upstream = startUpstream()
-    const denApi = startDenApi(() => ({ status: "ready", url: serverBase(upstream.server), clientToken: "client-token" }))
+    const denApi = startDenApi(() => readyResolvePayload(serverBase(upstream.server)))
     const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
     const base = serverBase(gateway)
 
@@ -270,9 +281,9 @@ describe("den-gateway proxy", () => {
     expect(denApi.observed.gatewayKey).toBe("gateway-secret")
   })
 
-  test("injects the client token upstream and strips the Den bearer and cookies", async () => {
+  test("injects the host token upstream and strips the Den bearer and cookies", async () => {
     const upstream = startUpstream()
-    const denApi = startDenApi(() => ({ status: "ready", url: serverBase(upstream.server), clientToken: "client-token" }))
+    const denApi = startDenApi(() => readyResolvePayload(serverBase(upstream.server)))
     const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
 
     const response = await fetch(`${serverBase(gateway)}/status`, {
@@ -283,30 +294,44 @@ describe("den-gateway proxy", () => {
     })
 
     expect(response.status).toBe(200)
-    expect(upstream.observed.requests[0].authorization).toBe("Bearer client-token")
+    expect(upstream.observed.requests[0].authorization).toBe("Bearer host-token")
+    expect(upstream.observed.requests[0].authorization).not.toBe("Bearer client-token")
     expect(upstream.observed.requests[0].authorization).not.toBe("Bearer den-bearer")
     expect(upstream.observed.requests[0].cookie).toBeNull()
   })
 
-  test("caches ready resolution per Den bearer for rapid proxied requests", async () => {
+  test("caches ready resolution per Den bearer until the TTL expires", async () => {
     const upstream = startUpstream()
-    const denApi = startDenApi(() => ({ status: "ready", url: serverBase(upstream.server), clientToken: "client-token" }))
-    const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
+    let now = 1_000
+    let resolveResponses = 0
+    const denApi = startDenApi(() => {
+      resolveResponses += 1
+      return readyResolvePayload(serverBase(upstream.server), { hostToken: `host-token-${resolveResponses}` })
+    })
+    const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret", resolveTtlMs: 1_000, now: () => now })
     const base = serverBase(gateway)
     const headers = { Authorization: "Bearer den-cache" }
 
     const first = await fetch(`${base}/status`, { headers })
     const second = await fetch(`${base}/capabilities`, { headers })
+    now += 1_001
+    const third = await fetch(`${base}/whoami`, { headers })
 
     expect(first.status).toBe(200)
     expect(second.status).toBe(200)
-    expect(denApi.observed.calls).toBe(1)
-    expect(upstream.observed.requests).toHaveLength(2)
+    expect(third.status).toBe(200)
+    expect(denApi.observed.calls).toBe(2)
+    expect(upstream.observed.requests).toHaveLength(3)
+    expect(upstream.observed.requests.map((request) => request.authorization)).toEqual([
+      "Bearer host-token-1",
+      "Bearer host-token-1",
+      "Bearer host-token-2",
+    ])
   })
 
   test("proxies namespaced allowlist subpaths", async () => {
     const upstream = startUpstream()
-    const denApi = startDenApi(() => ({ status: "ready", url: serverBase(upstream.server), clientToken: "client-token" }))
+    const denApi = startDenApi(() => readyResolvePayload(serverBase(upstream.server)))
     const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
     const base = serverBase(gateway)
     const headers = { Authorization: "Bearer den-api", Accept: "application/json" }
@@ -336,7 +361,7 @@ describe("den-gateway proxy", () => {
   test("serves workspace document navigations from the SPA but proxies workspace API calls", async () => {
     const root = await makeWebRoot()
     const upstream = startUpstream()
-    const denApi = startDenApi(() => ({ status: "ready", url: serverBase(upstream.server), clientToken: "client-token" }))
+    const denApi = startDenApi(() => readyResolvePayload(serverBase(upstream.server)))
     const gateway = startGateway({ webRoot: root, denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
     const base = serverBase(gateway)
 
@@ -356,7 +381,7 @@ describe("den-gateway proxy", () => {
 
   test("proxies workspace opencode SSE without buffering", async () => {
     const upstream = startUpstream()
-    const denApi = startDenApi(() => ({ status: "ready", url: serverBase(upstream.server), clientToken: "client-token" }))
+    const denApi = startDenApi(() => readyResolvePayload(serverBase(upstream.server)))
     const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
     const base = serverBase(gateway)
 
@@ -377,7 +402,7 @@ describe("den-gateway proxy", () => {
   test("keeps /w navigations proxied and non-api navigations on the SPA", async () => {
     const root = await makeWebRoot()
     const upstream = startUpstream()
-    const denApi = startDenApi(() => ({ status: "ready", url: serverBase(upstream.server), clientToken: "client-token" }))
+    const denApi = startDenApi(() => readyResolvePayload(serverBase(upstream.server)))
     const gateway = startGateway({ webRoot: root, denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
     const base = serverBase(gateway)
 
@@ -398,7 +423,7 @@ describe("den-gateway proxy", () => {
 
   test("returns non-ready JSON status and does not proxy", async () => {
     const upstream = startUpstream()
-    const denApi = startDenApi(() => ({ status: "waking", url: null, clientToken: null }))
+    const denApi = startDenApi(() => ({ status: "waking", url: null, clientToken: null, hostToken: null }))
     const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
 
     const base = serverBase(gateway)
@@ -415,7 +440,7 @@ describe("den-gateway proxy", () => {
 
   test("streams SSE without buffering and strips stale compression headers", async () => {
     const upstream = startUpstream()
-    const denApi = startDenApi(() => ({ status: "ready", url: serverBase(upstream.server), clientToken: "client-token" }))
+    const denApi = startDenApi(() => readyResolvePayload(serverBase(upstream.server)))
     const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
     const base = serverBase(gateway)
 


### PR DESCRIPTION
Every web user's console showed a 401 storm, and host-scoped features were broken behind the gateway:

```
GET /opencode/global/health -> 401
GET /env/status?...         -> 401
PUT /env                    -> 401   ("Invalid host token")
[cloud-provider-sync:app_launch] Authentication failed
```

Reproduced on two accounts — systemic, not account-specific.

## Cause

The gateway injected the **client**-scoped token on proxied instance paths. openwork-server treats `/env*`, `/opencode/global/*`, and `/health` as **host**-scoped. On desktop the app holds both tokens locally; behind the gateway the browser holds neither (by design), so every host-scoped call failed. App-side provider sync push and BYO-keys-from-web were casualties; server-side provider pull still worked, which is why fresh instances showed providers connected while the console burned.

## Fix

The gateway is the credential holder — this completes that principle:

- den-api's **gateway-only** resolve (`/v1/cloud/gateway/resolve`, key-gated, 404 fail-closed) additionally returns `hostToken`. Additive schema.
- den-gateway caches it with the existing resolve cache and injects `Authorization: Bearer <hostToken>` on **all proxied instance requests**, replacing any incoming Authorization (host supersedes client within a single-user instance).

## Where the token provably does NOT go

- The member endpoint `/v1/cloud/instance` — regression test asserts neither `hostToken` nor `clientToken` serialize there.
- Served HTML / `window.__OPENWORK_GATEWAY__` — existing no-token assertions extended to cover it.
- `/api/den/*` — the user's own Den bearer is forwarded untouched; test asserts the host token never leaks onto Den API calls.
- Logs and browser-facing headers.

## Tests

| Command | Result |
| --- | --- |
| den-api `cloud-instance-route` (incl. new key-gating + schema assertions) | 23 pass / 0 fail |
| den-gateway suite (injection, Den passthrough, HTML, cache TTL) | 13 pass / 0 fail |
| `tsc --noEmit` both packages | 0 errors |

## After deploy

Live verification planned: signed-in `/env/status` and `/opencode/global/health` return 200 through `web.openworklabs.com`, and the `cloud-provider-sync` console errors disappear.