### PR TITLE
feat: cloud workspace overlay — status, version, and one-click update

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -164,6 +164,17 @@ export type DenWorkerTokens = {
   workspaceId: string | null;
 };
 
+export type DenCloudInstance = {
+  status: "provisioning" | "waking" | "ready" | "failed";
+  url: string | null;
+  imageVersion: string | null;
+  latestVersion: string | null;
+};
+
+export type DenCloudInstanceUpdateResult =
+  | { ok: true; status: "update_requested" }
+  | { ok: false; error: "already_current" | "flush_failed" };
+
 export type DenMemoryContext = {
   id: string;
   snippet: string;
@@ -1212,6 +1223,39 @@ function getWorkerTokens(payload: unknown): DenWorkerTokens | null {
   };
 }
 
+function parseCloudInstance(payload: unknown): DenCloudInstance | null {
+  if (
+    !isRecord(payload) ||
+    (payload.status !== "provisioning" && payload.status !== "waking" && payload.status !== "ready" && payload.status !== "failed") ||
+    (typeof payload.url !== "string" && payload.url !== null)
+  ) {
+    return null;
+  }
+
+  return {
+    status: payload.status,
+    url: payload.url,
+    imageVersion: typeof payload.imageVersion === "string" ? payload.imageVersion : null,
+    latestVersion: typeof payload.latestVersion === "string" ? payload.latestVersion : null,
+  };
+}
+
+function parseCloudInstanceUpdateResult(payload: unknown): DenCloudInstanceUpdateResult | null {
+  if (!isRecord(payload) || typeof payload.ok !== "boolean") {
+    return null;
+  }
+
+  if (payload.ok === true && payload.status === "update_requested") {
+    return { ok: true, status: "update_requested" };
+  }
+
+  if (payload.ok === false && (payload.error === "already_current" || payload.error === "flush_failed")) {
+    return { ok: false, error: payload.error };
+  }
+
+  return null;
+}
+
 function getMcpToken(payload: unknown): DenMcpToken | null {
   if (
     !isRecord(payload) ||
@@ -2229,6 +2273,33 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
         throw new DenApiError(500, "invalid_worker_token_payload", "Worker token response was missing token values.");
       }
       return tokens;
+    },
+
+    async getCloudInstance(orgId: string): Promise<DenCloudInstance> {
+      const payload = await requestJson<unknown>(baseUrls, "/v1/cloud/instance", {
+        method: "GET",
+        token,
+        organizationId: orgId,
+      });
+      const instance = parseCloudInstance(payload);
+      if (!instance) {
+        throw new DenApiError(500, "invalid_cloud_instance_payload", "Cloud instance response was invalid.");
+      }
+      return instance;
+    },
+
+    async updateCloudInstance(orgId: string): Promise<DenCloudInstanceUpdateResult> {
+      const payload = await requestJson<unknown>(baseUrls, "/v1/cloud/instance/update", {
+        method: "POST",
+        token,
+        organizationId: orgId,
+        body: {},
+      });
+      const result = parseCloudInstanceUpdateResult(payload);
+      if (!result) {
+        throw new DenApiError(500, "invalid_cloud_update_payload", "Cloud update response was invalid.");
+      }
+      return result;
     },
 
     async listOrgLlmProviders(orgId: string): Promise<DenOrgLlmProvider[]> {

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -31,6 +31,7 @@ import { useDesktopFontZoomBehavior } from "./font-zoom";
 import { LoadingOverlay } from "./loading-overlay";
 import { DevProfiler, DevProfilerOverlay } from "./dev-profiler";
 import { ReactRenderWatchdogOverlay } from "./react-render-watchdog-overlay";
+import { CloudWorkspaceOverlay } from "./cloud-workspace-overlay";
 import { AppMenuProvider } from "./app-menu";
 import {
   OpenworkControlProvider,
@@ -448,6 +449,7 @@ export function AppRoot() {
         true app-level signal.
       */}
       <NewProvidersListener />
+      <CloudWorkspaceOverlay />
       <DevProfilerOverlay />
       <ReactRenderWatchdogOverlay />
     </>

--- a/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
+++ b/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
@@ -1,0 +1,176 @@
+/** @jsxImportSource react */
+import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+
+import { clearDenSession, createDenClient, readDenSettings } from "@/app/lib/den";
+import { isOpenworkGatewayRuntime } from "@/app/lib/gateway-runtime";
+import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
+import { Button } from "@/components/ui/button";
+import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
+import { cn } from "@/lib/utils";
+import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
+import { mapCloudWorkspaceState } from "./cloud-workspace-status";
+import type { DenCloudInstance } from "@/app/lib/den";
+
+const readDenSettingsSnapshot = () => {
+  const settings = readDenSettings();
+  return JSON.stringify({
+    baseUrl: settings.baseUrl,
+    authToken: settings.authToken ?? "",
+    activeOrgId: settings.activeOrgId ?? "",
+  });
+};
+
+function subscribeToDenSettings(onStoreChange: () => void) {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener(denSettingsChangedEvent, onStoreChange);
+  return () => window.removeEventListener(denSettingsChangedEvent, onStoreChange);
+}
+
+function CloudWorkspaceOverlayInner() {
+  const denAuth = useDenAuth();
+  const [open, setOpen] = useState(false);
+  const [instance, setInstance] = useState<DenCloudInstance | null>(null);
+  const [requestFailed, setRequestFailed] = useState(false);
+  const [updating, setUpdating] = useState(false);
+  const settingsSnapshot = useSyncExternalStore(
+    subscribeToDenSettings,
+    readDenSettingsSnapshot,
+    readDenSettingsSnapshot,
+  );
+  const settings = useMemo(() => readDenSettings(), [settingsSnapshot]);
+  const authToken = settings.authToken?.trim() ?? "";
+  const orgId = settings.activeOrgId?.trim() ?? "";
+  const denClient = useMemo(
+    () => createDenClient({ baseUrl: settings.baseUrl, token: authToken }),
+    [authToken, settings.baseUrl],
+  );
+
+  const refresh = useCallback(async () => {
+    if (!authToken || !orgId) {
+      setRequestFailed(true);
+      return;
+    }
+
+    try {
+      const next = await denClient.getCloudInstance(orgId);
+      setInstance(next);
+      setRequestFailed(false);
+    } catch {
+      setRequestFailed(true);
+    }
+  }, [authToken, denClient, orgId]);
+
+  const viewModel = mapCloudWorkspaceState({ instance, updating, requestFailed });
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!authToken || !orgId) return;
+    const timeoutId = window.setTimeout(() => {
+      void refresh();
+    }, viewModel.pollMs);
+    return () => window.clearTimeout(timeoutId);
+  }, [authToken, instance, orgId, refresh, requestFailed, updating, viewModel.pollMs]);
+
+  useEffect(() => {
+    if (!updating) return;
+    const nextModel = mapCloudWorkspaceState({ instance, updating: false, requestFailed });
+    if (instance?.status === "ready" && !nextModel.updateAvailable) {
+      setUpdating(false);
+    }
+  }, [instance, requestFailed, updating]);
+
+  const signOut = useCallback(() => {
+    if (authToken) {
+      void denClient.signOut().catch(() => undefined);
+    }
+    clearDenSession();
+    void denAuth.refresh();
+    setOpen(false);
+  }, [authToken, denAuth, denClient]);
+
+  const updateNow = useCallback(() => {
+    if (!orgId || updating) return;
+    setUpdating(true);
+    setRequestFailed(false);
+    void denClient
+      .updateCloudInstance(orgId)
+      .then((result) => {
+        if (!result.ok) {
+          setUpdating(false);
+          setRequestFailed(result.error === "flush_failed");
+        }
+        void refresh();
+      })
+      .catch(() => {
+        setUpdating(false);
+        setRequestFailed(true);
+      });
+  }, [denClient, orgId, refresh, updating]);
+
+  if (!denAuth.isSignedIn && !authToken) return null;
+
+  return (
+    <div className="fixed bottom-4 right-4 z-[100]">
+      <Popover open={open} onOpenChange={setOpen}>
+        <PopoverTrigger
+          render={
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              data-testid="cloud-workspace-pill"
+              data-cloud-workspace-state={viewModel.variant}
+              className={cn(
+                "h-8 rounded-full border bg-popover/90 px-3 text-xs shadow-sm backdrop-blur-sm",
+                viewModel.tone === "amber"
+                  ? "border-amber-7/70 bg-amber-3 text-amber-12 hover:bg-amber-4"
+                  : "border-border/80 text-muted-foreground hover:text-foreground",
+              )}
+              aria-label={`Open cloud workspace status: ${viewModel.label}`}
+            >
+              {viewModel.label}
+            </Button>
+          }
+        />
+        <PopoverContent align="end" side="top" sideOffset={8} className="w-80 gap-3 p-4">
+          <div className="space-y-1">
+            <p className="text-sm font-medium" data-testid="cloud-workspace-status-line">
+              {viewModel.statusLine}
+            </p>
+            <p className="text-xs text-muted-foreground">{viewModel.versionLine}</p>
+            <p className="text-xs text-muted-foreground">{viewModel.latestLine}</p>
+            <p className="text-xs text-muted-foreground">{viewModel.backupsLine}</p>
+          </div>
+          {viewModel.showUpdate ? (
+            <div className="rounded-2xl border border-border bg-muted/30 p-3">
+              <Button type="button" size="sm" className="w-full" onClick={updateNow} disabled={updating}>
+                Update now
+              </Button>
+              <p className="mt-2 text-xs text-muted-foreground">
+                Takes about 30 seconds. Your files and sessions come along.
+              </p>
+            </div>
+          ) : null}
+          <div className="flex items-center justify-end gap-2">
+            {viewModel.showRetry ? (
+              <Button type="button" size="sm" variant="outline" onClick={() => void refresh()}>
+                Retry
+              </Button>
+            ) : null}
+            <Button type="button" size="sm" variant="ghost" onClick={signOut}>
+              Sign out
+            </Button>
+          </div>
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+export function CloudWorkspaceOverlay() {
+  if (!isOpenworkGatewayRuntime()) return null;
+  return <CloudWorkspaceOverlayInner />;
+}

--- a/apps/app/src/react-app/shell/cloud-workspace-status.ts
+++ b/apps/app/src/react-app/shell/cloud-workspace-status.ts
@@ -1,0 +1,155 @@
+import type { DenCloudInstance } from "@/app/lib/den";
+
+export type CloudWorkspacePillVariant =
+  | "ready"
+  | "stale"
+  | "waking"
+  | "provisioning"
+  | "updating"
+  | "failed";
+
+export type CloudWorkspaceViewModel = {
+  variant: CloudWorkspacePillVariant;
+  label: string;
+  tone: "neutral" | "amber";
+  statusLine: string;
+  versionLine: string;
+  latestLine: string;
+  backupsLine: string;
+  updateAvailable: boolean;
+  showUpdate: boolean;
+  showRetry: boolean;
+  pollMs: number;
+};
+
+export function formatCloudWorkspaceVersion(version: string | null): string | null {
+  const trimmed = version?.trim() ?? "";
+  if (!trimmed) return null;
+  const openworkPrefix = "openwork-";
+  if (!trimmed.toLowerCase().startsWith(openworkPrefix)) return trimmed;
+  const withoutPrefix = trimmed.slice(openworkPrefix.length);
+  return withoutPrefix.toLowerCase().startsWith("v") ? withoutPrefix : `v${withoutPrefix}`;
+}
+
+export function cloudWorkspaceUpdateAvailable(instance: DenCloudInstance | null): boolean {
+  if (!instance?.latestVersion) return false;
+  return instance.imageVersion === null || instance.imageVersion !== instance.latestVersion;
+}
+
+function versionDisplay(instance: DenCloudInstance | null) {
+  return formatCloudWorkspaceVersion(instance?.imageVersion ?? null) ?? "Legacy workspace";
+}
+
+function latestDisplay(instance: DenCloudInstance | null) {
+  return formatCloudWorkspaceVersion(instance?.latestVersion ?? null) ?? "Not available";
+}
+
+function connectedStatusLine(instance: DenCloudInstance, updateAvailable: boolean) {
+  const version = formatCloudWorkspaceVersion(instance.imageVersion) ?? "legacy workspace";
+  const latest = formatCloudWorkspaceVersion(instance.latestVersion);
+  if (updateAvailable) return latest ? `Connected · ${version} -> ${latest}` : `Connected · ${version}`;
+  return `Connected · ${version} (latest)`;
+}
+
+function baseLines(instance: DenCloudInstance | null, updateAvailable: boolean) {
+  const version = versionDisplay(instance);
+  const latest = latestDisplay(instance);
+  const latestSuffix = !updateAvailable && instance?.latestVersion ? " (up to date)" : "";
+  return {
+    versionLine: `Version: ${version}`,
+    latestLine: `Latest: ${latest}${latestSuffix}`,
+    backupsLine: "Backups on",
+  };
+}
+
+export function mapCloudWorkspaceState(input: {
+  instance: DenCloudInstance | null;
+  updating: boolean;
+  requestFailed?: boolean;
+}): CloudWorkspaceViewModel {
+  const updateAvailable = cloudWorkspaceUpdateAvailable(input.instance);
+  const lines = baseLines(input.instance, updateAvailable);
+
+  if (input.requestFailed || input.instance?.status === "failed") {
+    return {
+      variant: "failed",
+      label: "Workspace needs attention",
+      tone: "amber",
+      statusLine: "Workspace needs attention",
+      ...lines,
+      updateAvailable,
+      showUpdate: false,
+      showRetry: true,
+      pollMs: 5_000,
+    };
+  }
+
+  if (input.updating) {
+    return {
+      variant: "updating",
+      label: "Updating your workspace…",
+      tone: "neutral",
+      statusLine: "Updating your workspace…",
+      ...lines,
+      updateAvailable,
+      showUpdate: false,
+      showRetry: false,
+      pollMs: 5_000,
+    };
+  }
+
+  if (!input.instance || input.instance.status === "waking") {
+    return {
+      variant: "waking",
+      label: "Waking your workspace…",
+      tone: "neutral",
+      statusLine: "Waking your workspace…",
+      ...lines,
+      updateAvailable,
+      showUpdate: false,
+      showRetry: false,
+      pollMs: 5_000,
+    };
+  }
+
+  if (input.instance.status === "provisioning") {
+    return {
+      variant: "provisioning",
+      label: "Provisioning your workspace…",
+      tone: "neutral",
+      statusLine: "Provisioning your workspace…",
+      ...lines,
+      updateAvailable,
+      showUpdate: false,
+      showRetry: false,
+      pollMs: 5_000,
+    };
+  }
+
+  if (updateAvailable) {
+    return {
+      variant: "stale",
+      label: "Update available",
+      tone: "neutral",
+      statusLine: connectedStatusLine(input.instance, true),
+      ...lines,
+      updateAvailable,
+      showUpdate: true,
+      showRetry: false,
+      pollMs: 60_000,
+    };
+  }
+
+  const version = formatCloudWorkspaceVersion(input.instance.imageVersion) ?? formatCloudWorkspaceVersion(input.instance.latestVersion);
+  return {
+    variant: "ready",
+    label: version ? `Cloud · ${version}` : "Cloud",
+    tone: "neutral",
+    statusLine: connectedStatusLine(input.instance, false),
+    ...lines,
+    updateAvailable,
+    showUpdate: false,
+    showRetry: false,
+    pollMs: 60_000,
+  };
+}

--- a/apps/app/tests/cloud-workspace-overlay.test.tsx
+++ b/apps/app/tests/cloud-workspace-overlay.test.tsx
@@ -1,0 +1,97 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+
+import type { DenCloudInstance } from "../src/app/lib/den";
+import { CloudWorkspaceOverlay } from "../src/react-app/shell/cloud-workspace-overlay";
+import {
+  cloudWorkspaceUpdateAvailable,
+  mapCloudWorkspaceState,
+} from "../src/react-app/shell/cloud-workspace-status";
+
+const originalWindow = globalThis.window;
+
+function instance(input: Partial<DenCloudInstance> = {}): DenCloudInstance {
+  return {
+    status: input.status ?? "ready",
+    url: input.url ?? "https://workspace.example.test",
+    imageVersion: "imageVersion" in input ? input.imageVersion ?? null : "openwork-0.18.8",
+    latestVersion: "latestVersion" in input ? input.latestVersion ?? null : "openwork-0.18.8",
+  };
+}
+
+describe("cloud workspace overlay state", () => {
+  test("maps ready and current workers to the quiet Cloud pill", () => {
+    const state = mapCloudWorkspaceState({ instance: instance(), updating: false });
+
+    expect(state.variant).toBe("ready");
+    expect(state.label).toBe("Cloud · v0.18.8");
+    expect(state.statusLine).toBe("Connected · v0.18.8 (latest)");
+    expect(state.latestLine).toBe("Latest: v0.18.8 (up to date)");
+    expect(state.showUpdate).toBe(false);
+  });
+
+  test("maps stale and legacy workers to Update available", () => {
+    const stale = mapCloudWorkspaceState({
+      instance: instance({ imageVersion: "openwork-0.18.2", latestVersion: "openwork-0.18.8" }),
+      updating: false,
+    });
+    const legacyInstance = instance({ imageVersion: null, latestVersion: "openwork-0.18.8" });
+    const legacy = mapCloudWorkspaceState({
+      instance: legacyInstance,
+      updating: false,
+    });
+
+    expect(stale.variant).toBe("stale");
+    expect(stale.label).toBe("Update available");
+    expect(stale.statusLine).toBe("Connected · v0.18.2 -> v0.18.8");
+    expect(stale.versionLine).toBe("Version: v0.18.2");
+    expect(stale.latestLine).toBe("Latest: v0.18.8");
+    expect(stale.showUpdate).toBe(true);
+    expect(cloudWorkspaceUpdateAvailable(legacyInstance)).toBe(true);
+    expect(legacy.label).toBe("Update available");
+    expect(legacy.versionLine).toBe("Version: Legacy workspace");
+  });
+
+  test("maps not-ready and failed workers to user-facing labels", () => {
+    expect(mapCloudWorkspaceState({ instance: instance({ status: "waking" }), updating: false }).label)
+      .toBe("Waking your workspace…");
+    expect(mapCloudWorkspaceState({ instance: instance({ status: "provisioning" }), updating: false }).label)
+      .toBe("Provisioning your workspace…");
+
+    const failed = mapCloudWorkspaceState({ instance: instance({ status: "failed" }), updating: false });
+    expect(failed.variant).toBe("failed");
+    expect(failed.tone).toBe("amber");
+    expect(failed.label).toBe("Workspace needs attention");
+    expect(failed.showRetry).toBe(true);
+  });
+
+  test("keeps the pill in updating state after the user clicks update", () => {
+    const state = mapCloudWorkspaceState({
+      instance: instance({ imageVersion: "openwork-0.18.2", latestVersion: "openwork-0.18.8" }),
+      updating: true,
+    });
+
+    expect(state.variant).toBe("updating");
+    expect(state.label).toBe("Updating your workspace…");
+    expect(state.showUpdate).toBe(false);
+    expect(state.pollMs).toBe(5_000);
+  });
+});
+
+describe("cloud workspace overlay gateway gating", () => {
+  afterEach(() => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: originalWindow,
+    });
+  });
+
+  test("renders nothing outside gateway mode", () => {
+    Object.defineProperty(globalThis, "window", {
+      configurable: true,
+      value: { location: { origin: "https://instance.example.test" } },
+    });
+
+    expect(renderToStaticMarkup(<CloudWorkspaceOverlay />)).toBe("");
+  });
+});

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -10,7 +10,7 @@ import { db } from "../../db.js"
 import { env, type DenOrgMode } from "../../env.js"
 import { orgMemberRoute } from "../../middleware/index.js"
 import { jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
-import { getDaytonaSandboxRecord, inspectDaytonaSandbox, refreshDaytonaSignedPreview } from "../../workers/daytona.js"
+import { flushWorkerCheckpointOnDaytona, getDaytonaSandboxRecord, inspectDaytonaSandbox, refreshDaytonaSignedPreview, stopWorkerOnDaytona } from "../../workers/daytona.js"
 import { CLOUD_INSTANCE_BACKEND, CLOUD_INSTANCE_NAME } from "../../workers/cloud-constants.js"
 import { wakeCloudWorker as defaultWakeCloudWorker } from "../../workers/cloud-lifecycle.js"
 import { appLogger } from "../../observability/logger.js"
@@ -31,6 +31,8 @@ type CloudRouteOptions = {
   inspectSandbox?: InspectSandbox
   probeSignedPreview?: ProbeSignedPreview
   wakeCloudWorker?: WakeCloudWorker
+  flushWorkerCheckpoint?: FlushWorkerCheckpoint
+  stopCloudWorker?: StopCloudWorker
   now?: () => number
 }
 
@@ -52,10 +54,17 @@ type CloudInstanceResponse = {
   status: "provisioning" | "waking" | "ready" | "failed"
   url: string | null
 }
+type CloudInstanceMemberResponse = CloudInstanceResponse & {
+  imageVersion?: string | null
+  latestVersion?: string | null
+}
 type CloudGatewayInstanceResponse = CloudInstanceResponse & {
   clientToken: string | null
   hostToken: string | null
 }
+type CloudInstanceUpdateResponse =
+  | { ok: true; status: "update_requested" }
+  | { ok: false; error: "already_current" | "flush_failed" }
 type CloudWorkerStore = {
   getCloudWorker: (input: { orgId: OrgId; userId: UserId }) => Promise<CloudWorker | null>
   insertCloudWorker: (input: { workerId: WorkerId; orgId: OrgId; userId: UserId; name: string }) => Promise<void>
@@ -78,6 +87,8 @@ type GetSandboxRecord = (workerId: CloudWorker["id"]) => Promise<CloudSandboxRec
 type InspectSandbox = (workerId: CloudWorker["id"]) => Promise<CloudSandboxInspection>
 type ProbeSignedPreview = (signedPreviewUrl: string) => Promise<boolean>
 type WakeCloudWorker = (workerId: CloudWorker["id"]) => Promise<void>
+type FlushWorkerCheckpoint = (workerId: CloudWorker["id"]) => Promise<boolean>
+type StopCloudWorker = (workerId: CloudWorker["id"]) => Promise<unknown>
 
 type UpdateResultRecord = {
   rowsAffected?: unknown
@@ -87,7 +98,20 @@ type UpdateResultRecord = {
 const cloudInstanceResponseSchema = z.object({
   status: z.enum(["provisioning", "waking", "ready", "failed"]),
   url: z.string().url().nullable(),
+  imageVersion: z.string().nullable().optional(),
+  latestVersion: z.string().nullable().optional(),
 }).meta({ ref: "CloudInstanceResponse" })
+
+const cloudInstanceUpdateResponseSchema = z.union([
+  z.object({
+    ok: z.literal(true),
+    status: z.literal("update_requested"),
+  }),
+  z.object({
+    ok: z.literal(false),
+    error: z.enum(["already_current", "flush_failed"]),
+  }),
+]).meta({ ref: "CloudInstanceUpdateResponse" })
 
 const cloudGatewayInstanceResponseSchema = z.object({
   status: z.enum(["provisioning", "waking", "ready", "failed"]),
@@ -562,6 +586,24 @@ function workerNeedsSnapshotRecycle(worker: CloudWorker) {
   return Boolean(snapshot && "image_version" in worker && worker.image_version !== snapshot)
 }
 
+function workerNeedsUserRequestedUpdate(worker: CloudWorker) {
+  const snapshot = env.daytona.snapshot
+  return Boolean(snapshot && (worker.image_version ?? null) !== snapshot)
+}
+
+function isRunningSandboxState(state: string | null) {
+  const normalized = state?.toLowerCase() ?? ""
+  return normalized === "running" || normalized === "started"
+}
+
+function memberCloudInstanceResponse(worker: CloudWorker, instance: CloudInstanceResponse): CloudInstanceMemberResponse {
+  return {
+    ...instance,
+    imageVersion: worker.image_version ?? null,
+    latestVersion: env.daytona.snapshot ?? null,
+  }
+}
+
 async function startStaleStoppedRecycle(input: {
   worker: CloudWorker
   sandboxExists: boolean
@@ -731,6 +773,51 @@ async function resolveCloudInstanceForMember(input: {
   return { worker, instance }
 }
 
+async function requestCloudInstanceUpdate(input: {
+  worker: CloudWorker | null
+  getSandboxRecord: GetSandboxRecord
+  inspectSandbox: InspectSandbox
+  flushWorkerCheckpoint: FlushWorkerCheckpoint
+  stopCloudWorker: StopCloudWorker
+}): Promise<CloudInstanceUpdateResponse> {
+  if (!input.worker) {
+    return { ok: true, status: "update_requested" }
+  }
+
+  if (!workerNeedsUserRequestedUpdate(input.worker)) {
+    return { ok: false, error: "already_current" }
+  }
+
+  const sandbox = await input.getSandboxRecord(input.worker.id)
+  if (!sandbox) {
+    return { ok: true, status: "update_requested" }
+  }
+
+  let inspection: CloudSandboxInspection = null
+  try {
+    inspection = await input.inspectSandbox(input.worker.id)
+  } catch (error) {
+    logger.warn("cloud update failed to inspect sandbox", { worker_id: input.worker.id, error })
+    return { ok: false, error: "flush_failed" }
+  }
+
+  const state = inspection?.state ?? null
+  if (isStoppedSandboxState(state) || !isRunningSandboxState(state)) {
+    return { ok: true, status: "update_requested" }
+  }
+
+  const flushed = await input.flushWorkerCheckpoint(input.worker.id).catch((error) => {
+    logger.warn("cloud update checkpoint flush failed", { worker_id: input.worker?.id, error })
+    return false
+  })
+  if (!flushed) {
+    return { ok: false, error: "flush_failed" }
+  }
+
+  await input.stopCloudWorker(input.worker.id)
+  return { ok: true, status: "update_requested" }
+}
+
 async function resolveCloudInstanceForGateway(input: {
   payload: NonNullable<OrgRouteVariables["organizationContext"]>
   user: CloudRouteUser
@@ -773,6 +860,8 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
   const inspectSandbox = options.inspectSandbox ?? inspectDaytonaSandbox
   const signedPreviewProbe = options.probeSignedPreview ?? probeSignedPreview
   const wakeCloudWorker = options.wakeCloudWorker ?? defaultWakeCloudWorker
+  const flushWorkerCheckpoint = options.flushWorkerCheckpoint ?? flushWorkerCheckpointOnDaytona
+  const stopCloudWorker = options.stopCloudWorker ?? stopWorkerOnDaytona
   const now = options.now ?? Date.now
   const gatewayKey = options.gatewayKey !== undefined ? options.gatewayKey : env.gatewayKey
   const wakingWorkers = new Set<CloudWorker["id"]>()
@@ -828,7 +917,44 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
         now,
       })
 
-      return c.json(resolved.instance)
+      return c.json(memberCloudInstanceResponse(resolved.worker, resolved.instance))
+    },
+  )
+
+  app.post(
+    "/v1/cloud/instance/update",
+    describeRoute({
+      tags: ["Cloud"],
+      summary: "Request an update for the active organization's Cloud instance",
+      description: "Flushes a running Cloud workspace checkpoint and stops the sandbox so the next resolve can recycle it onto the latest snapshot.",
+      responses: {
+        200: jsonResponse("Cloud instance update request handled.", cloudInstanceUpdateResponseSchema),
+        401: jsonResponse("The caller must be signed in to update Cloud.", unauthorizedSchema),
+        404: jsonResponse("Cloud is not available for this organization.", notFoundSchema),
+      },
+    }),
+    orgMemberRouteMiddleware,
+    async (c) => {
+      const payload = c.get("organizationContext")
+      if (!cloudAvailable(payload, options)) {
+        return c.json(cloudNotFound(), 404)
+      }
+
+      const user = c.get("user")
+      if (!hasCloudUserId(user)) {
+        return c.json({ error: "unauthorized" }, 401)
+      }
+
+      const worker = await getCloudWorker(payload.organization.id, user.id, store)
+      const result = await requestCloudInstanceUpdate({
+        worker,
+        getSandboxRecord,
+        inspectSandbox,
+        flushWorkerCheckpoint,
+        stopCloudWorker,
+      })
+
+      return c.json(result)
     },
   )
 

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -264,106 +264,30 @@ function checkpointRestoreMarkerPath() {
   return `${env.daytona.runtimeDataPath}/.openwork-restore-marker`
 }
 
-export function buildOpenWorkStartCommand(input: ProvisionInput) {
-  const verifyRuntimeStep = [
-    "if ! command -v openwork-server >/dev/null 2>&1; then echo 'openwork-server binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
-    "if ! command -v opencode >/dev/null 2>&1; then echo 'opencode binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
-  ].join("; ")
-  const openworkServe = [
-    "OPENWORK_DATA_DIR=",
-    shellQuote(env.daytona.runtimeDataPath),
-    " OPENWORK_SERVER_CONFIG=",
-    shellQuote(`${env.daytona.runtimeDataPath}/server.json`),
-    " OPENWORK_TOKEN=",
-    shellQuote(input.clientToken),
-    " OPENWORK_HOST_TOKEN=",
-    shellQuote(input.hostToken),
-    " OPENWORK_MANAGE_OPENCODE=",
-    shellQuote("1"),
-    " OPENWORK_OPENCODE_BIN=",
-    shellQuote("/usr/local/bin/opencode"),
-    " OPENWORK_WEB_ROOT=",
-    shellQuote("/opt/openwork/web"),
-    // The instance still serves its own SPA copy for direct/debug access, but
-    // without a bootstrap token that path is intentionally inert; the gateway
-    // is the supported entry.
-    " OPENWORK_WEB_BOOTSTRAP_TOKEN=",
-    shellQuote("0"),
-    " OPENWORK_EXTENSIONS_PLUGIN_DIR=",
-    shellQuote("/opt/openwork/opencode-plugins"),
-    " DEN_RUNTIME_PROVIDER=",
-    shellQuote("daytona"),
-    " DEN_WORKER_ID=",
-    shellQuote(input.workerId),
-    " DEN_ACTIVITY_HEARTBEAT_ENABLED=",
-    shellQuote("1"),
-    " DEN_ACTIVITY_HEARTBEAT_URL=",
-    shellQuote(workerActivityHeartbeatUrl(input.workerId)),
-    " DEN_ACTIVITY_HEARTBEAT_TOKEN=",
-    shellQuote(input.activityToken),
-    " openwork-server",
-    ` --workspace ${shellQuote(env.daytona.runtimeWorkspacePath)}`,
-    ` --host 0.0.0.0`,
-    ` --port ${shellQuote(String(env.daytona.openworkPort))}`,
-    ` --cors '*'`,
-    ` --approval manual`,
-    ` --verbose`,
-  ].join("")
-  const stateManifest = `${env.daytona.runtimeDataPath} ${env.daytona.runtimeWorkspacePath}`
-  const checkpointDir = `${env.daytona.dataMountPath}/checkpoints`
-  const lastFlushMarker = `${env.daytona.sidecarDir}/checkpoint.last-flush`
+function checkpointStateManifest() {
+  return `${env.daytona.runtimeDataPath} ${env.daytona.runtimeWorkspacePath}`
+}
 
-  const script = `
-set -u
-mkdir -p ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(env.daytona.runtimeWorkspacePath)} ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(env.daytona.sidecarDir)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)}
-ln -sfn ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/workspace`) }
-ln -sfn ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/data`) }
-${verifyRuntimeStep}
-OPENWORK_STATE_MANIFEST=${shellQuote(stateManifest)}
-CHECKPOINT_DIR=${shellQuote(checkpointDir)}
+function checkpointDir() {
+  return `${env.daytona.dataMountPath}/checkpoints`
+}
+
+function checkpointLastFlushMarkerPath() {
+  return `${env.daytona.sidecarDir}/checkpoint.last-flush`
+}
+
+function checkpointEnvironmentScript() {
+  return `OPENWORK_STATE_MANIFEST=${shellQuote(checkpointStateManifest())}
+CHECKPOINT_DIR=${shellQuote(checkpointDir())}
 RESTORE_MARKER=${shellQuote(checkpointRestoreMarkerPath())}
-LAST_FLUSH_MARKER=${shellQuote(lastFlushMarker)}
+LAST_FLUSH_MARKER=${shellQuote(checkpointLastFlushMarkerPath())}
 DEN_CKPT_INTERVAL_SECONDS=\${DEN_CKPT_INTERVAL_SECONDS:-${shellQuote(String(env.daytona.checkpointIntervalSeconds))}}
-DEN_CKPT_KEEP=\${DEN_CKPT_KEEP:-${shellQuote(String(env.daytona.checkpointKeep))}}
-
-state_dirs_pristine() {
-  if [ -e "$RESTORE_MARKER" ]; then
-    return 1
-  fi
-  data_entry=$(find ${shellQuote(env.daytona.runtimeDataPath)} -mindepth 1 -print -quit 2>/dev/null || true)
-  if [ -n "$data_entry" ]; then
-    return 1
-  fi
-  workspace_entry=$(find ${shellQuote(env.daytona.runtimeWorkspacePath)} -mindepth 1 ! -path ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)} ! -path ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/*`)} -print -quit 2>/dev/null || true)
-  if [ -n "$workspace_entry" ]; then
-    return 1
-  fi
-  return 0
+DEN_CKPT_KEEP=\${DEN_CKPT_KEEP:-${shellQuote(String(env.daytona.checkpointKeep))}}`
 }
 
-hydrate_checkpoint() {
-  mkdir -p "$CHECKPOINT_DIR"
-  latest_checkpoint=$(find "$CHECKPOINT_DIR" -maxdepth 1 -type f -name 'ckpt-*.tar' -print 2>/dev/null | sort | tail -n 1 || true)
-  if [ -z "$latest_checkpoint" ]; then
-    return 0
-  fi
-  if ! state_dirs_pristine; then
-    echo "checkpoint hydrate skipped; local OpenWork state is not pristine or was already restored"
-    return 0
-  fi
-  echo "checkpoint hydrate restoring $latest_checkpoint"
-  if tar -C / -xf "$latest_checkpoint"; then
-    printf '%s\n' "$latest_checkpoint" > "$RESTORE_MARKER"
-    return 0
-  fi
-  echo "checkpoint hydrate failed for $latest_checkpoint; continuing with fresh OpenWork state" >&2
-  rm -rf ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(env.daytona.runtimeWorkspacePath)}
-  mkdir -p ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)}
-  ln -sfn ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/workspace`) }
-  ln -sfn ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/data`) }
-}
-
-checkpoint_changed() {
+function checkpointFlushFunctions(input: { failOnError: boolean }) {
+  const failureReturn = input.failOnError ? "1" : "0"
+  return `checkpoint_changed() {
   if [ ! -e "$LAST_FLUSH_MARKER" ]; then
     return 0
   fi
@@ -413,8 +337,108 @@ flush_checkpoint() {
     echo "checkpoint flush tar failed for $tmp_checkpoint" >&2
   fi
   rm -f "$tmp_checkpoint"
+  return ${failureReturn}
+}`
+}
+
+export function checkpointFlushCommand() {
+  return `set -u
+${checkpointEnvironmentScript()}
+${checkpointFlushFunctions({ failOnError: true })}
+flush_checkpoint`
+}
+
+export function buildOpenWorkStartCommand(input: ProvisionInput) {
+  const verifyRuntimeStep = [
+    "if ! command -v openwork-server >/dev/null 2>&1; then echo 'openwork-server binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
+    "if ! command -v opencode >/dev/null 2>&1; then echo 'opencode binary missing from Daytona runtime image; rebuild and republish the Daytona snapshot' >&2; exit 1; fi",
+  ].join("; ")
+  const openworkServe = [
+    "OPENWORK_DATA_DIR=",
+    shellQuote(env.daytona.runtimeDataPath),
+    " OPENWORK_SERVER_CONFIG=",
+    shellQuote(`${env.daytona.runtimeDataPath}/server.json`),
+    " OPENWORK_TOKEN=",
+    shellQuote(input.clientToken),
+    " OPENWORK_HOST_TOKEN=",
+    shellQuote(input.hostToken),
+    " OPENWORK_MANAGE_OPENCODE=",
+    shellQuote("1"),
+    " OPENWORK_OPENCODE_BIN=",
+    shellQuote("/usr/local/bin/opencode"),
+    " OPENWORK_WEB_ROOT=",
+    shellQuote("/opt/openwork/web"),
+    // The instance still serves its own SPA copy for direct/debug access, but
+    // without a bootstrap token that path is intentionally inert; the gateway
+    // is the supported entry.
+    " OPENWORK_WEB_BOOTSTRAP_TOKEN=",
+    shellQuote("0"),
+    " OPENWORK_EXTENSIONS_PLUGIN_DIR=",
+    shellQuote("/opt/openwork/opencode-plugins"),
+    " DEN_RUNTIME_PROVIDER=",
+    shellQuote("daytona"),
+    " DEN_WORKER_ID=",
+    shellQuote(input.workerId),
+    " DEN_ACTIVITY_HEARTBEAT_ENABLED=",
+    shellQuote("1"),
+    " DEN_ACTIVITY_HEARTBEAT_URL=",
+    shellQuote(workerActivityHeartbeatUrl(input.workerId)),
+    " DEN_ACTIVITY_HEARTBEAT_TOKEN=",
+    shellQuote(input.activityToken),
+    " openwork-server",
+    ` --workspace ${shellQuote(env.daytona.runtimeWorkspacePath)}`,
+    ` --host 0.0.0.0`,
+    ` --port ${shellQuote(String(env.daytona.openworkPort))}`,
+    ` --cors '*'`,
+    ` --approval manual`,
+    ` --verbose`,
+  ].join("")
+  const script = `
+set -u
+mkdir -p ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(env.daytona.runtimeWorkspacePath)} ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(env.daytona.sidecarDir)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)}
+ln -sfn ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/workspace`) }
+ln -sfn ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/data`) }
+${verifyRuntimeStep}
+${checkpointEnvironmentScript()}
+
+state_dirs_pristine() {
+  if [ -e "$RESTORE_MARKER" ]; then
+    return 1
+  fi
+  data_entry=$(find ${shellQuote(env.daytona.runtimeDataPath)} -mindepth 1 -print -quit 2>/dev/null || true)
+  if [ -n "$data_entry" ]; then
+    return 1
+  fi
+  workspace_entry=$(find ${shellQuote(env.daytona.runtimeWorkspacePath)} -mindepth 1 ! -path ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)} ! -path ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/*`)} -print -quit 2>/dev/null || true)
+  if [ -n "$workspace_entry" ]; then
+    return 1
+  fi
   return 0
 }
+
+hydrate_checkpoint() {
+  mkdir -p "$CHECKPOINT_DIR"
+  latest_checkpoint=$(find "$CHECKPOINT_DIR" -maxdepth 1 -type f -name 'ckpt-*.tar' -print 2>/dev/null | sort | tail -n 1 || true)
+  if [ -z "$latest_checkpoint" ]; then
+    return 0
+  fi
+  if ! state_dirs_pristine; then
+    echo "checkpoint hydrate skipped; local OpenWork state is not pristine or was already restored"
+    return 0
+  fi
+  echo "checkpoint hydrate restoring $latest_checkpoint"
+  if tar -C / -xf "$latest_checkpoint"; then
+    printf '%s\n' "$latest_checkpoint" > "$RESTORE_MARKER"
+    return 0
+  fi
+  echo "checkpoint hydrate failed for $latest_checkpoint; continuing with fresh OpenWork state" >&2
+  rm -rf ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(env.daytona.runtimeWorkspacePath)}
+  mkdir -p ${shellQuote(env.daytona.runtimeDataPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes`)}
+  ln -sfn ${shellQuote(env.daytona.workspaceMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/workspace`) }
+  ln -sfn ${shellQuote(env.daytona.dataMountPath)} ${shellQuote(`${env.daytona.runtimeWorkspacePath}/volumes/data`) }
+}
+
+${checkpointFlushFunctions({ failOnError: false })}
 
 checkpoint_loop() {
   while true; do
@@ -1185,6 +1209,27 @@ export async function stopWorkerOnDaytona(workerId: WorkerId): Promise<StopWorke
   await sandbox.stop(env.daytona.stopTimeoutSeconds ?? env.daytona.deleteTimeoutSeconds)
 
   return { status: "stopped" }
+}
+
+export async function flushWorkerCheckpointOnDaytona(workerId: WorkerId) {
+  assertDaytonaConfig()
+
+  const record = await getDaytonaSandboxRecord(workerId)
+  if (!record) {
+    return false
+  }
+
+  const daytona = createDaytonaClient()
+  const sandbox = await daytona.get(record.sandbox_id)
+  await sandbox.refreshData()
+  const exitCode = await runSandboxShellCommand(
+    toDaytonaSandboxRuntime(sandbox),
+    `openwork-update-flush-${workerHint(workerId)}-${Date.now()}`,
+    checkpointFlushCommand(),
+    env.daytona.createTimeoutSeconds,
+  )
+
+  return exitCode === 0
 }
 
 export type DaytonaSandboxWakeRecord = {

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -469,7 +469,9 @@ describe("Cloud gateway resolve route", () => {
     const payload = await response.json()
 
     expect(response.status).toBe(200)
-    expect(payload).toEqual({ status: "ready", url: "https://preview.example.test" })
+    // The member payload may gain additive fields (imageVersion, latestVersion);
+    // this test's contract is only that tokens never serialize here.
+    expect(payload).toMatchObject({ status: "ready", url: "https://preview.example.test" })
     expect(payload).not.toHaveProperty("hostToken")
     expect(payload).not.toHaveProperty("clientToken")
   })

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -5,6 +5,7 @@ import type { OrganizationContext } from "../src/orgs.js"
 import type { OrgRouteVariables } from "../src/routes/org/shared.js"
 
 type CloudWorkerStatus = "provisioning" | "healthy" | "failed" | "stopped"
+type CloudInstanceStatus = "provisioning" | "waking" | "ready" | "failed"
 type CloudRoutesModule = typeof import("../src/routes/cloud/index.js")
 type CloudRouteOptions = NonNullable<Parameters<CloudRoutesModule["registerCloudRoutes"]>[1]>
 type CloudWorkerStore = NonNullable<CloudRouteOptions["cloudWorkerStore"]>
@@ -110,6 +111,19 @@ function fakeSandbox() {
   return {
     signed_preview_url: "https://preview.example.test",
     signed_preview_url_expires_at: new Date(Date.now() + 60_000),
+  }
+}
+
+function expectedCloudInstance(input: {
+  status: CloudInstanceStatus
+  url: string | null
+  imageVersion?: string | null
+}) {
+  return {
+    status: input.status,
+    url: input.url,
+    imageVersion: input.imageVersion ?? null,
+    latestVersion: "openwork-0.18.8",
   }
 }
 
@@ -462,6 +476,30 @@ describe("Cloud gateway resolve route", () => {
 })
 
 describe("Cloud instance route lifecycle states", () => {
+  test("returns worker and latest image versions on the member instance response", async () => {
+    const worker = { ...fakeWorker("healthy"), image_version: "openwork-0.18.7" }
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      getSandboxRecord: async () => fakeSandbox(),
+      probeSignedPreview: async () => true,
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual(expectedCloudInstance({
+      status: "ready",
+      url: "https://preview.example.test",
+      imageVersion: "openwork-0.18.7",
+    }))
+  })
+
   test("returns waking and starts one wake for concurrent stopped-worker requests", async () => {
     const worker = fakeWorker("stopped")
     const app = new Hono<{ Variables: OrgRouteVariables }>()
@@ -492,8 +530,8 @@ describe("Cloud instance route lifecycle states", () => {
 
     expect(first.status).toBe(200)
     expect(second.status).toBe(200)
-    await expect(first.json()).resolves.toEqual({ status: "waking", url: null })
-    await expect(second.json()).resolves.toEqual({ status: "waking", url: null })
+    await expect(first.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null }))
+    await expect(second.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null }))
     expect(wakeExecutions).toBe(1)
 
     wakeHold.resolve()
@@ -520,7 +558,7 @@ describe("Cloud instance route lifecycle states", () => {
     const response = await app.request("http://den.local/v1/cloud/instance")
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
+    await expect(response.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null }))
     expect(wakeExecutions).toBe(0)
   })
 
@@ -552,7 +590,7 @@ describe("Cloud instance route lifecycle states", () => {
     const response = await app.request("http://den.local/v1/cloud/instance")
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
+    await expect(response.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null, imageVersion: "openwork-0.18.7" }))
     expect(store.recycleClaimAttempts).toBe(1)
     expect(worker.status).toBe("provisioning")
     expect(wakeCalls).toBe(1)
@@ -584,7 +622,7 @@ describe("Cloud instance route lifecycle states", () => {
     const response = await app.request("http://den.local/v1/cloud/instance")
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
+    await expect(response.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null, imageVersion: "openwork-0.18.8" }))
     expect(inspectCalls).toBe(0)
     expect(wakeCalls).toBe(1)
   })
@@ -609,8 +647,141 @@ describe("Cloud instance route lifecycle states", () => {
     const response = await app.request("http://den.local/v1/cloud/instance")
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ status: "provisioning", url: null })
+    await expect(response.json()).resolves.toEqual(expectedCloudInstance({ status: "provisioning", url: null }))
     expect(wakeExecutions).toBe(0)
+  })
+})
+
+describe("Cloud instance update route", () => {
+  test("flushes and stops a running stale sandbox", async () => {
+    const orgId = createDenTypeId("organization")
+    const userId = createDenTypeId("user")
+    const worker = { ...storedWorker({ orgId, userId, status: "healthy" }), image_version: "openwork-0.18.7" }
+    const store = makeCloudWorkerStore({ initialWorkers: [worker] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    const flushCalls: StoredCloudWorker["id"][] = []
+    const stopCalls: StoredCloudWorker["id"][] = []
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }), { orgId, userId })),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandbox(),
+      inspectSandbox: async () => ({ state: "running" }),
+      flushWorkerCheckpoint: async (workerId) => {
+        flushCalls.push(workerId)
+        return true
+      },
+      stopCloudWorker: async (workerId) => {
+        stopCalls.push(workerId)
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance/update", { method: "POST" })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true, status: "update_requested" })
+    expect(flushCalls).toEqual([worker.id])
+    expect(stopCalls).toEqual([worker.id])
+  })
+
+  test("no-ops for a stopped stale sandbox", async () => {
+    const orgId = createDenTypeId("organization")
+    const userId = createDenTypeId("user")
+    const worker = { ...storedWorker({ orgId, userId, status: "healthy" }), image_version: "openwork-0.18.7" }
+    const store = makeCloudWorkerStore({ initialWorkers: [worker] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let flushCalls = 0
+    let stopCalls = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }), { orgId, userId })),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandbox(),
+      inspectSandbox: async () => ({ state: "stopped" }),
+      flushWorkerCheckpoint: async () => {
+        flushCalls += 1
+        return true
+      },
+      stopCloudWorker: async () => {
+        stopCalls += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance/update", { method: "POST" })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: true, status: "update_requested" })
+    expect(flushCalls).toBe(0)
+    expect(stopCalls).toBe(0)
+  })
+
+  test("refuses to stop an already-current worker", async () => {
+    const orgId = createDenTypeId("organization")
+    const userId = createDenTypeId("user")
+    const worker = { ...storedWorker({ orgId, userId, status: "healthy" }), image_version: "openwork-0.18.8" }
+    const store = makeCloudWorkerStore({ initialWorkers: [worker] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let inspectCalls = 0
+    let stopCalls = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }), { orgId, userId })),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandbox(),
+      inspectSandbox: async () => {
+        inspectCalls += 1
+        return { state: "running" }
+      },
+      flushWorkerCheckpoint: async () => true,
+      stopCloudWorker: async () => {
+        stopCalls += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance/update", { method: "POST" })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: false, error: "already_current" })
+    expect(inspectCalls).toBe(0)
+    expect(stopCalls).toBe(0)
+  })
+
+  test("leaves a running sandbox up when checkpoint flush fails", async () => {
+    const orgId = createDenTypeId("organization")
+    const userId = createDenTypeId("user")
+    const worker = { ...storedWorker({ orgId, userId, status: "healthy" }), image_version: "openwork-0.18.7" }
+    const store = makeCloudWorkerStore({ initialWorkers: [worker] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    let stopCalls = 0
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }), { orgId, userId })),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandbox(),
+      inspectSandbox: async () => ({ state: "running" }),
+      flushWorkerCheckpoint: async () => false,
+      stopCloudWorker: async () => {
+        stopCalls += 1
+      },
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance/update", { method: "POST" })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({ ok: false, error: "flush_failed" })
+    expect(stopCalls).toBe(0)
   })
 })
 
@@ -646,11 +817,11 @@ describe("Cloud instance per-user workers", () => {
     const userTwoApp = appForUser(userTwo, "grace@example.com")
 
     await expect(userOneApp.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
-      .resolves.toEqual({ status: "provisioning", url: null })
+      .resolves.toEqual(expectedCloudInstance({ status: "provisioning", url: null }))
     await expect(userOneApp.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
-      .resolves.toEqual({ status: "provisioning", url: null })
+      .resolves.toEqual(expectedCloudInstance({ status: "provisioning", url: null }))
     await expect(userTwoApp.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
-      .resolves.toEqual({ status: "provisioning", url: null })
+      .resolves.toEqual(expectedCloudInstance({ status: "provisioning", url: null }))
 
     expect(store.workers.filter((worker) => !store.deletedWorkerIds.includes(worker.id))).toHaveLength(2)
     expect(new Set(store.workers.map((worker) => worker.userId)).size).toBe(2)
@@ -685,7 +856,7 @@ describe("Cloud instance per-user workers", () => {
     const response = await app.request("http://den.local/v1/cloud/instance")
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ status: "provisioning", url: null })
+    await expect(response.json()).resolves.toEqual(expectedCloudInstance({ status: "provisioning", url: null }))
     const activeWorkers = store.workers.filter((worker) => !store.deletedWorkerIds.includes(worker.id))
     expect(activeWorkers).toHaveLength(1)
     expect(activeWorkers[0]?.name).toBe("Cloud — Canonical")
@@ -755,7 +926,7 @@ describe("Cloud instance failed self-heal", () => {
 
     const first = await app.request("http://den.local/v1/cloud/instance")
     expect(first.status).toBe(200)
-    await expect(first.json()).resolves.toEqual({ status: "waking", url: null })
+    await expect(first.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null }))
     await flushMicrotasks()
 
     expect(store.claimAttempts).toBe(1)
@@ -764,7 +935,7 @@ describe("Cloud instance failed self-heal", () => {
     expect(worker.status).not.toBe("failed")
 
     await expect(app.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
-      .resolves.toEqual({ status: "ready", url: "https://preview.example.test" })
+      .resolves.toEqual(expectedCloudInstance({ status: "ready", url: "https://preview.example.test" }))
   })
 
   test("claims a failed worker, kicks provisioning, then throttles another failed GET for 60 seconds", async () => {
@@ -793,7 +964,7 @@ describe("Cloud instance failed self-heal", () => {
 
     const first = await app.request("http://den.local/v1/cloud/instance")
     expect(first.status).toBe(200)
-    await expect(first.json()).resolves.toEqual({ status: "provisioning", url: null })
+    await expect(first.json()).resolves.toEqual(expectedCloudInstance({ status: "provisioning", url: null }))
     await flushMicrotasks()
     expect(store.claimAttempts).toBe(1)
     expect(provisionCalls).toBe(1)
@@ -802,7 +973,7 @@ describe("Cloud instance failed self-heal", () => {
     now += 10_000
     const second = await app.request("http://den.local/v1/cloud/instance")
     expect(second.status).toBe(200)
-    await expect(second.json()).resolves.toEqual({ status: "failed", url: null })
+    await expect(second.json()).resolves.toEqual(expectedCloudInstance({ status: "failed", url: null }))
     await flushMicrotasks()
     expect(store.claimAttempts).toBe(1)
     expect(provisionCalls).toBe(1)
@@ -837,8 +1008,8 @@ describe("Cloud instance failed self-heal", () => {
     ])
     const payloads = await Promise.all([first.json(), second.json()])
 
-    expect(payloads).toContainEqual({ status: "provisioning", url: null })
-    expect(payloads).toContainEqual({ status: "failed", url: null })
+    expect(payloads).toContainEqual(expectedCloudInstance({ status: "provisioning", url: null }))
+    expect(payloads).toContainEqual(expectedCloudInstance({ status: "failed", url: null }))
     await flushMicrotasks()
     expect(store.claimAttempts).toBe(1)
     expect(provisionCalls).toBe(1)
@@ -873,7 +1044,7 @@ describe("Cloud instance ready liveness", () => {
     const response = await app.request("http://den.local/v1/cloud/instance")
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
+    await expect(response.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null }))
     expect(probes).toBe(1)
     expect(wakeCalls).toBe(1)
   })
@@ -906,7 +1077,7 @@ describe("Cloud instance ready liveness", () => {
     const response = await app.request("http://den.local/v1/cloud/instance")
 
     expect(response.status).toBe(200)
-    await expect(response.json()).resolves.toEqual({ status: "waking", url: null })
+    await expect(response.json()).resolves.toEqual(expectedCloudInstance({ status: "waking", url: null }))
     await flushMicrotasks()
     expect(store.healthyFailures).toBe(1)
     expect(store.claimAttempts).toBe(1)
@@ -934,10 +1105,10 @@ describe("Cloud instance ready liveness", () => {
     })
 
     await expect(app.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
-      .resolves.toEqual({ status: "ready", url: "https://preview.example.test" })
+      .resolves.toEqual(expectedCloudInstance({ status: "ready", url: "https://preview.example.test" }))
     now += 1_000
     await expect(app.request("http://den.local/v1/cloud/instance").then((response) => response.json()))
-      .resolves.toEqual({ status: "ready", url: "https://preview.example.test" })
+      .resolves.toEqual(expectedCloudInstance({ status: "ready", url: "https://preview.example.test" }))
 
     expect(probes).toBe(1)
   })

--- a/evals/flows/den-gateway.flow.ts
+++ b/evals/flows/den-gateway.flow.ts
@@ -1,149 +1,543 @@
-import { defineFlow } from "../runner/flow.ts";
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
 import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
 
-// Narration is loaded from the approved script (evals/voiceovers/den-gateway.md).
-// The runner fails this flow if the narration drifts from that script.
-const vo = await loadVoiceoverParagraphs("den-gateway");
+const FLOW_ID = "den-gateway";
+const DEFAULT_FLOW_BASE_URL = "https://web.openworklabs.com";
+const DEFAULT_DEN_WEB_URL = "https://app.openworklabs.com";
+const MARKER_PATH = `cloud-workspace-overlay-${Date.now()}.txt`;
+const MARKER_CONTENT = `cloud workspace overlay proof ${Date.now()}`;
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
 if (!vo) throw new Error("Missing approved voice-over script for den-gateway.");
 
+type CloudStatus = "provisioning" | "waking" | "ready" | "failed";
+type CloudInstance = {
+  status: CloudStatus;
+  url: string | null;
+  imageVersion: string | null;
+  latestVersion: string | null;
+};
+type Org = {
+  id: string;
+  slug: string | null;
+  name: string | null;
+};
+type JsonResult = {
+  response: Response;
+  body: unknown;
+  text: string;
+};
+
+const state: {
+  denToken: string;
+  org: Org | null;
+  cloudInstance: CloudInstance | null;
+  staleAvailable: boolean;
+  updateClicked: boolean;
+  markerWritten: boolean;
+} = {
+  denToken: "",
+  org: null,
+  cloudInstance: null,
+  staleAvailable: false,
+  updateClicked: false,
+  markerWritten: false,
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function safeJson(value: unknown) {
+  try {
+    return JSON.stringify(value).slice(0, 1_200);
+  } catch {
+    return String(value).slice(0, 1_200);
+  }
+}
+
+function witness(ctx: FlowContext, condition: unknown, assertion: string, actual?: unknown) {
+  ctx.recordEvidence({
+    type: "assertion",
+    status: condition ? "passed" : "failed",
+    assertion,
+    actual,
+  });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : `. Actual: ${safeJson(actual)}`}`);
+}
+
+function trimBase(value: string | undefined, fallback: string) {
+  return (value?.trim() || fallback).replace(/\/+$/, "");
+}
+
+function flowBase(ctx: FlowContext) {
+  return trimBase(ctx.env.OPENWORK_FLOW_BASE_URL, DEFAULT_FLOW_BASE_URL);
+}
+
+function denWebBase(ctx: FlowContext) {
+  return trimBase(ctx.env.OPENWORK_FLOW_DEN_URL, DEFAULT_DEN_WEB_URL);
+}
+
+function joinUrl(base: string, path: string) {
+  return `${base}${path.startsWith("/") ? path : `/${path}`}`;
+}
+
+function requiredEnv(ctx: FlowContext, name: "OPENWORK_FLOW_EMAIL" | "OPENWORK_FLOW_PASSWORD") {
+  const value = ctx.env[name]?.trim() ?? "";
+  witness(ctx, value.length > 0, `${name} is set`);
+  return value;
+}
+
+function authHeaders(ctx: FlowContext) {
+  const org = state.org;
+  return {
+    "content-type": "application/json",
+    authorization: `Bearer ${state.denToken}`,
+    ...(org ? { "x-openwork-legacy-org-id": org.id } : {}),
+  };
+}
+
+async function fetchJson(url: string, init: RequestInit = {}): Promise<JsonResult> {
+  const response = await fetch(url, init);
+  const text = await response.text();
+  let body: unknown = null;
+  try {
+    body = text ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+async function withTimeout<T>(promise: Promise<T>, timeoutMs: number, message: string): Promise<T> {
+  let timeoutId: NodeJS.Timeout | null = null;
+  const timeout = new Promise<T>((_, reject) => {
+    timeoutId = setTimeout(() => reject(new Error(message)), timeoutMs);
+  });
+  try {
+    return await Promise.race([promise, timeout]);
+  } finally {
+    if (timeoutId) clearTimeout(timeoutId);
+  }
+}
+
+async function signIn(ctx: FlowContext) {
+  const result = await fetchJson(joinUrl(denWebBase(ctx), "/api/auth/sign-in/email"), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      origin: flowBase(ctx),
+    },
+    body: JSON.stringify({
+      email: requiredEnv(ctx, "OPENWORK_FLOW_EMAIL"),
+      password: requiredEnv(ctx, "OPENWORK_FLOW_PASSWORD"),
+    }),
+  });
+  witness(ctx, result.response.ok, "Email/password sign-in returns HTTP 200", {
+    status: result.response.status,
+    body: result.body,
+  });
+  const token = isRecord(result.body) && typeof result.body.token === "string" ? result.body.token.trim() : "";
+  witness(ctx, token.length > 0, "Sign-in response includes a bearer token");
+  state.denToken = token;
+}
+
+function parseOrg(value: unknown): Org | null {
+  if (!isRecord(value) || typeof value.id !== "string") return null;
+  return {
+    id: value.id,
+    slug: typeof value.slug === "string" ? value.slug : null,
+    name: typeof value.name === "string" ? value.name : null,
+  };
+}
+
+async function resolveOrg(ctx: FlowContext) {
+  const result = await fetchJson(joinUrl(denWebBase(ctx), "/api/den/v1/me/orgs"), {
+    headers: { authorization: `Bearer ${state.denToken}` },
+  });
+  witness(ctx, result.response.ok, "Signed-in user can read their organizations", {
+    status: result.response.status,
+    body: result.body,
+  });
+  const orgs = isRecord(result.body) && Array.isArray(result.body.orgs) ? result.body.orgs : [];
+  const activeOrgId = isRecord(result.body) && typeof result.body.activeOrgId === "string" ? result.body.activeOrgId : "";
+  const parsed = orgs.flatMap((entry) => {
+    const org = parseOrg(entry);
+    return org ? [org] : [];
+  });
+  const selected = parsed.find((org) => org.id === activeOrgId) ?? parsed[0] ?? null;
+  witness(ctx, Boolean(selected), "Signed-in user belongs to an organization", result.body);
+  state.org = selected;
+}
+
+async function setActiveOrg(ctx: FlowContext) {
+  const org = state.org;
+  if (!org) return;
+  const result = await fetchJson(joinUrl(denWebBase(ctx), "/api/den/v1/me/active-organization"), {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      authorization: `Bearer ${state.denToken}`,
+    },
+    body: JSON.stringify({ organizationId: org.id }),
+  });
+  witness(ctx, result.response.ok, "The eval organization is selected for org-scoped cloud calls", {
+    status: result.response.status,
+    body: result.body,
+  });
+}
+
+async function navigateAbsolute(ctx: FlowContext, url: string, timeoutMs = 90_000) {
+  await ctx.eval(`location.href = ${JSON.stringify(url)}`);
+  await ctx.waitFor("document.readyState === 'complete' || document.body.innerText.length > 0", {
+    timeoutMs,
+    label: `loaded ${url}`,
+  });
+}
+
+async function seedBrowserSession(ctx: FlowContext) {
+  const org = state.org;
+  witness(ctx, Boolean(org), "An organization is available before browser session seeding", org);
+  await navigateAbsolute(ctx, flowBase(ctx));
+  await ctx.waitFor("window.__OPENWORK_GATEWAY__?.version === 1", {
+    timeoutMs: 30_000,
+    label: "gateway marker is injected",
+  });
+  await ctx.eval(`(() => {
+    localStorage.setItem("openwork.den.baseUrl", ${JSON.stringify(denWebBase(ctx))});
+    localStorage.setItem("openwork.den.authToken", ${JSON.stringify(state.denToken)});
+    localStorage.setItem("openwork.den.activeOrgId", ${JSON.stringify(org?.id ?? "")});
+    localStorage.setItem("openwork.den.activeOrgSlug", ${JSON.stringify(org?.slug ?? "")});
+    localStorage.setItem("openwork.den.activeOrgName", ${JSON.stringify(org?.name ?? "")});
+    location.href = ${JSON.stringify(joinUrl(flowBase(ctx), "/session"))};
+    return true;
+  })()`);
+  await ctx.waitFor("document.body.innerText.length > 0", { timeoutMs: 90_000, label: "workspace page rendered" });
+}
+
+function parseCloudInstance(body: unknown): CloudInstance | null {
+  if (!isRecord(body)) return null;
+  if (body.status !== "provisioning" && body.status !== "waking" && body.status !== "ready" && body.status !== "failed") return null;
+  return {
+    status: body.status,
+    url: typeof body.url === "string" ? body.url : null,
+    imageVersion: typeof body.imageVersion === "string" ? body.imageVersion : null,
+    latestVersion: typeof body.latestVersion === "string" ? body.latestVersion : null,
+  };
+}
+
+async function readCloudInstance(ctx: FlowContext) {
+  const result = await fetchJson(joinUrl(flowBase(ctx), "/api/den/v1/cloud/instance"), {
+    headers: authHeaders(ctx),
+  });
+  witness(ctx, result.response.ok, "Cloud instance status is readable through the gateway Den API", {
+    status: result.response.status,
+    body: result.body,
+  });
+  const instance = parseCloudInstance(result.body);
+  witness(ctx, Boolean(instance), "Cloud instance payload has status and version fields", result.body);
+  state.cloudInstance = instance;
+  return instance;
+}
+
+function formatVersion(version: string | null) {
+  const trimmed = version?.trim() ?? "";
+  if (!trimmed) return null;
+  const prefix = "openwork-";
+  if (!trimmed.toLowerCase().startsWith(prefix)) return trimmed;
+  const withoutPrefix = trimmed.slice(prefix.length);
+  return withoutPrefix.toLowerCase().startsWith("v") ? withoutPrefix : `v${withoutPrefix}`;
+}
+
+function updateAvailable(instance: CloudInstance | null) {
+  if (!instance?.latestVersion) return false;
+  return instance.imageVersion === null || instance.imageVersion !== instance.latestVersion;
+}
+
+function latestLabel(instance: CloudInstance | null) {
+  return formatVersion(instance?.latestVersion ?? null) ?? "latest";
+}
+
+async function pillText(ctx: FlowContext) {
+  const value = await ctx.eval(`document.querySelector('[data-testid="cloud-workspace-pill"]')?.textContent?.trim() ?? ""`);
+  return typeof value === "string" ? value : "";
+}
+
+async function waitForPillContaining(ctx: FlowContext, text: string, timeoutMs = 90_000) {
+  await ctx.waitFor(`(() => {
+    const pill = document.querySelector('[data-testid="cloud-workspace-pill"]');
+    return pill?.textContent?.includes(${JSON.stringify(text)}) === true;
+  })()`, { timeoutMs, label: `cloud workspace pill contains ${text}` });
+}
+
+async function openStatusPanel(ctx: FlowContext) {
+  await ctx.trustedClick('[data-testid="cloud-workspace-pill"]', { timeoutMs: 10_000 });
+  await ctx.waitForText("Version:", { timeoutMs: 10_000 });
+}
+
+async function skippedFrame(ctx: FlowContext, claim: string, voiceover: string, reason: string) {
+  await ctx.prove(claim, {
+    voiceover,
+    action: () => {
+      ctx.skip(reason);
+    },
+    assert: () => {
+      witness(ctx, true, `Skipped: ${reason}`);
+    },
+  });
+}
+
+function pickWorkspaceId(body: unknown) {
+  if (!isRecord(body)) return "";
+  const items = Array.isArray(body.items)
+    ? body.items
+    : Array.isArray(body.workspaces)
+      ? body.workspaces
+      : Array.isArray(body)
+        ? body
+        : [];
+  const activeId = typeof body.activeId === "string" ? body.activeId : "";
+  const active = items.find((item) => isRecord(item) && item.id === activeId);
+  const selected = active ?? items.find(isRecord) ?? null;
+  return isRecord(selected) && typeof selected.id === "string" ? selected.id : "";
+}
+
+async function gatewayInstanceFetch(ctx: FlowContext, path: string, init: RequestInit = {}) {
+  return fetchJson(joinUrl(flowBase(ctx), path), {
+    ...init,
+    headers: {
+      ...authHeaders(ctx),
+      accept: "application/json",
+    },
+  });
+}
+
+async function clickApprovalIfPresent(ctx: FlowContext) {
+  for (const label of ["Allow", "Approve"]) {
+    try {
+      await ctx.clickText(label, { selector: "button", timeoutMs: 3_000 });
+      return;
+    } catch {
+      // No approval button with this label is visible yet.
+    }
+  }
+}
+
+async function writeWorkspaceMarker(ctx: FlowContext) {
+  const workspaces = await gatewayInstanceFetch(ctx, "/workspaces");
+  witness(ctx, workspaces.response.ok, "The gateway can list the current workspace", {
+    status: workspaces.response.status,
+    body: workspaces.body,
+  });
+  const workspaceId = pickWorkspaceId(workspaces.body);
+  witness(ctx, workspaceId.length > 0, "A workspace id is available for the persistence marker", workspaces.body);
+
+  const controller = new AbortController();
+  const writePromise = gatewayInstanceFetch(ctx, `/workspace/${encodeURIComponent(workspaceId)}/files/content`, {
+    method: "POST",
+    signal: controller.signal,
+    body: JSON.stringify({
+      path: MARKER_PATH,
+      content: MARKER_CONTENT,
+      force: true,
+    }),
+  });
+  await sleep(1_000);
+  await clickApprovalIfPresent(ctx);
+
+  let write: JsonResult;
+  try {
+    write = await withTimeout(writePromise, 30_000, "Timed out waiting for the workspace marker write");
+  } catch (error) {
+    controller.abort();
+    throw error;
+  }
+  witness(ctx, write.response.ok, "The workspace marker file is written before the update", {
+    status: write.response.status,
+    body: write.body,
+  });
+
+  const read = await gatewayInstanceFetch(ctx, `/workspace/${encodeURIComponent(workspaceId)}/files/content?path=${encodeURIComponent(MARKER_PATH)}`);
+  witness(ctx, read.response.ok && isRecord(read.body) && read.body.content === MARKER_CONTENT, "The workspace marker file can be read before the update", {
+    status: read.response.status,
+    body: read.body,
+  });
+  state.markerWritten = true;
+  ctx.output("workspace-marker.json", { workspaceId, path: MARKER_PATH, content: MARKER_CONTENT });
+}
+
+async function readWorkspaceMarker(ctx: FlowContext) {
+  const workspaces = await gatewayInstanceFetch(ctx, "/workspaces");
+  const workspaceId = pickWorkspaceId(workspaces.body);
+  witness(ctx, workspaces.response.ok && workspaceId.length > 0, "The workspace is reachable after the update", {
+    status: workspaces.response.status,
+    body: workspaces.body,
+  });
+  const read = await gatewayInstanceFetch(ctx, `/workspace/${encodeURIComponent(workspaceId)}/files/content?path=${encodeURIComponent(MARKER_PATH)}`);
+  witness(ctx, read.response.ok && isRecord(read.body) && read.body.content === MARKER_CONTENT, "The workspace marker file survives the update", {
+    status: read.response.status,
+    body: read.body,
+  });
+}
+
+async function waitForUpdatedWorkspace(ctx: FlowContext) {
+  const deadline = Date.now() + 120_000;
+  let last: CloudInstance | null = null;
+  while (Date.now() < deadline) {
+    const instance = await readCloudInstance(ctx);
+    last = instance;
+    if (instance?.status === "ready" && !updateAvailable(instance)) {
+      state.cloudInstance = instance;
+      return instance;
+    }
+    await sleep(5_000);
+  }
+  witness(ctx, false, "Cloud instance returns to ready on the latest version after update", last);
+  return null;
+}
+
 export default defineFlow({
-  id: "den-gateway",
-  title: "TODO: one-line claim — user can do X and sees Y",
+  id: FLOW_ID,
+  title: "Cloud workspace overlay shows current, stale, updating, persistent, and failed workspace states",
   kind: "user-facing",
+  preserveTheme: true,
+  requiresApp: true,
+  requiredEnv: ["OPENWORK_FLOW_EMAIL", "OPENWORK_FLOW_PASSWORD"],
   steps: [
     {
-      name: "Frame 1",
+      name: "Frame 1 — current cloud pill",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 1", {
+        await ctx.prove("Signed-in browser workspace shows a quiet Cloud version pill", {
           voiceover: vo[0],
-          // "I go to ui.openworklabs.com and get a sign-in page. Nothing is running for m"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await signIn(ctx);
+            await resolveOrg(ctx);
+            await setActiveOrg(ctx);
+            await seedBrowserSession(ctx);
+            await waitForPillContaining(ctx, "Cloud ·");
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 1 not implemented yet");
+            const label = await pillText(ctx);
+            witness(ctx, label.startsWith("Cloud · "), "The bottom-right pill shows Cloud plus a version", label);
           },
-          screenshot: { name: "frame-1", requireText: [] },
+          screenshot: { name: "cloud-pill-current", requireText: ["Cloud"] },
         });
       },
     },
     {
-      name: "Frame 2",
+      name: "Frame 2 — current panel truth",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 2", {
+        await ctx.prove("Opening the pill shows connection, version, latest, backups, and sign out", {
           voiceover: vo[1],
-          // "I sign in with my work account and land in OpenWork with the cursor already "
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await openStatusPanel(ctx);
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 2 not implemented yet");
+            await ctx.expectText("Version:");
+            await ctx.expectText("Latest:");
+            await ctx.expectText("Backups on");
+            await ctx.expectText("Sign out");
           },
-          screenshot: { name: "frame-2", requireText: [] },
+          screenshot: { name: "cloud-panel-current", requireText: ["Version:", "Latest:", "Backups on", "Sign out"] },
         });
       },
     },
     {
-      name: "Frame 3",
+      name: "Frame 3 — stale update available",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 3", {
+        const instance = await readCloudInstance(ctx);
+        state.staleAvailable = updateAvailable(instance);
+        if (!state.staleAvailable) {
+          await skippedFrame(ctx, "Stale worker state is unavailable in this environment", vo[2], "Cloud worker is already current, so the stale update panel cannot be produced.");
+          return;
+        }
+
+        await ctx.prove("A stale workspace shows Update available and one Update now action", {
           voiceover: vo[2],
-          // "My workspace is mine. A teammate signing in gets their own, and neither of u"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await waitForPillContaining(ctx, "Update available");
+            await openStatusPanel(ctx);
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 3 not implemented yet");
+            const label = await pillText(ctx);
+            witness(ctx, label === "Update available", "The stale pill says Update available", label);
+            await ctx.expectText("Update now");
+            await ctx.expectText("Takes about 30 seconds. Your files and sessions come along.");
           },
-          screenshot: { name: "frame-3", requireText: [] },
+          screenshot: { name: "cloud-panel-stale", requireText: ["Update available", "Update now", "Takes about 30 seconds"] },
         });
       },
     },
     {
-      name: "Frame 4",
+      name: "Frame 4 — updating transition",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 4", {
+        if (!state.staleAvailable) {
+          await skippedFrame(ctx, "Update click is skipped because no stale worker is available", vo[3], "Cloud worker is already current.");
+          return;
+        }
+
+        await ctx.prove("Clicking Update now keeps the page visible and changes the pill to updating", {
           voiceover: vo[3],
-          // "I ask what's on my calendar and it answers. My organization's connections ar"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            if (!state.markerWritten) await writeWorkspaceMarker(ctx);
+            await ctx.clickText("Update now", { selector: "button", timeoutMs: 10_000 });
+            state.updateClicked = true;
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 4 not implemented yet");
+            await waitForPillContaining(ctx, "Updating your workspace…", 10_000);
+            await ctx.expectNoText("This site can’t be reached");
           },
-          screenshot: { name: "frame-4", requireText: [] },
+          screenshot: { name: "cloud-pill-updating", requireText: ["Updating your workspace…"], rejectText: ["This site can’t be reached"] },
         });
       },
     },
     {
-      name: "Frame 5",
+      name: "Frame 5 — updated and preserved workspace",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 5", {
+        if (!state.updateClicked) {
+          await skippedFrame(ctx, "Updated workspace proof is skipped because no update was requested", vo[4], "Cloud worker was already current or the stale update action was unavailable.");
+          return;
+        }
+
+        await ctx.prove("After the update, the pill returns to the latest version and the workspace marker file remains", {
           voiceover: vo[4],
-          // "I ask it to save a summary to a file, and the file appears in my workspace."
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            const instance = await waitForUpdatedWorkspace(ctx);
+            await waitForPillContaining(ctx, `Cloud · ${latestLabel(instance)}`, 120_000);
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 5 not implemented yet");
+            await readWorkspaceMarker(ctx);
+            const label = await pillText(ctx);
+            witness(ctx, label === `Cloud · ${latestLabel(state.cloudInstance)}`, "The pill shows Cloud plus the latest version after update", label);
           },
-          screenshot: { name: "frame-5", requireText: [] },
+          screenshot: { name: "cloud-pill-updated", requireText: ["Cloud"] },
         });
       },
     },
     {
-      name: "Frame 6",
+      name: "Frame 6 — failed state with exits",
       run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 6", {
+        const instance = await readCloudInstance(ctx);
+        if (instance?.status !== "failed") {
+          await skippedFrame(ctx, "Failed worker state is unavailable in this environment", vo[5], "Cloud worker is not failed, so the amber recovery panel cannot be produced.");
+          return;
+        }
+
+        await ctx.prove("A failed workspace shows the amber needs-attention pill with Retry and Sign out", {
           voiceover: vo[5],
-          // "The address bar says ui.openworklabs.com and nothing else — no tokens, no ma"
           action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
+            await navigateAbsolute(ctx, joinUrl(flowBase(ctx), "/session"));
+            await waitForPillContaining(ctx, "Workspace needs attention");
+            await openStatusPanel(ctx);
           },
           assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 6 not implemented yet");
+            await ctx.expectText("Workspace needs attention");
+            await ctx.expectText("Retry");
+            await ctx.expectText("Sign out");
           },
-          screenshot: { name: "frame-6", requireText: [] },
-        });
-      },
-    },
-    {
-      name: "Frame 7",
-      run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 7", {
-          voiceover: vo[6],
-          // "I close the tab and come back the next morning from a different laptop. The "
-          action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
-          },
-          assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 7 not implemented yet");
-          },
-          screenshot: { name: "frame-7", requireText: [] },
-        });
-      },
-    },
-    {
-      name: "Frame 8",
-      run: async (ctx) => {
-        await ctx.prove("TODO: claim for frame 8", {
-          voiceover: vo[7],
-          // "I sign out and reload. It asks me to sign in again — my workspace is not rea"
-          action: async () => {
-            // TODO: drive the app as the end user (ctx.clickText, ctx.fill, ...)
-          },
-          assert: async () => {
-            // TODO: witness the side effect (ctx.expectText, ctx.eval, ...)
-            ctx.assert(false, "frame 8 not implemented yet");
-          },
-          screenshot: { name: "frame-8", requireText: [] },
+          screenshot: { name: "cloud-panel-failed", requireText: ["Workspace needs attention", "Retry", "Sign out"] },
         });
       },
     },

--- a/evals/runner/context.ts
+++ b/evals/runner/context.ts
@@ -264,6 +264,11 @@ export class EvalContext implements FlowContext {
     this.logs.push(`[${new Date().toISOString()}] ${message}`);
   }
 
+  skip(reason: string): void {
+    this.log(`Skipped: ${reason}`);
+    this.output("skip", reason);
+  }
+
   async eval(expression: string, options: EvalOptions = {}): Promise<unknown> {
     return evaluate(this.requireClient(), expression, options);
   }

--- a/evals/runner/flow.ts
+++ b/evals/runner/flow.ts
@@ -129,6 +129,7 @@ export interface FlowContext {
 
   eval(expression: string, options?: EvalOptions): Promise<unknown>;
   assert(condition: unknown, message: string): void;
+  skip(reason: string): void;
   log(message: string): void;
   output(name: string, text: unknown): OutputEvidence;
   prove(name: string, options?: ProveOptions): Promise<void>;

--- a/evals/voiceovers/den-gateway.md
+++ b/evals/voiceovers/den-gateway.md
@@ -1,30 +1,13 @@
-# den-gateway — OpenWork in the browser at one address, with the machine invisible
+# den-gateway — Cloud workspace overlay
 
-web.openworklabs.com is served by den-gateway: it signs the user in, routes them
-to their own instance, and injects that instance's credentials server-side. The
-browser never holds an instance token, never sees a machine name, and never
-learns which compute vendor is behind it. den-api remains the only thing that
-talks to Daytona.
+1. I'm working in OpenWork in my browser. In the corner there's a quiet pill: "Cloud · v0.18.8". That's my workspace — healthy, current, out of my way.
 
-1. I go to web.openworklabs.com and get a sign-in page. Nothing is running for me
-   yet, and there is nothing to install.
+2. I click it. A small panel: Connected · v0.18.8 (latest) · Backups on, and Sign out. Nothing to configure; it's just the truth about my machine.
 
-2. I sign in with my work account and land in OpenWork with the cursor already
-   in the composer.
+3. A teammate is on an older workspace. Their pill says "Update available". The panel shows v0.18.2 -> v0.18.8 and one button: "Update now — takes about 30 seconds. Your files and sessions come along."
 
-3. My workspace is mine. A teammate signing in gets their own, and neither of us
-   can see the other's sessions or files.
+4. They click it. The pill becomes "Updating your workspace…". The page never goes blank, never bounces them somewhere else.
 
-4. I ask what's on my calendar and it answers. My organization's connections are
-   already wired in — I never pasted a key.
+5. Half a minute later: "Cloud · v0.18.8". Files exactly where they left them — same workspace, newer machine.
 
-5. I ask it to save a summary to a file, and the file appears in my workspace.
-
-6. The address bar says web.openworklabs.com and nothing else — no tokens, no
-   machine names, nothing I'd think twice about screen-sharing.
-
-7. I close the tab and come back the next morning from a different laptop. The
-   same address opens my workspace with that file still in it.
-
-8. I sign out and reload. It asks me to sign in again — my workspace is not
-   reachable without my account.
+6. And when something's genuinely wrong, the pill turns amber: "Workspace needs attention" — with Retry and Sign out right there. No more silent redirect loops; the worst case is now a labeled state with an exit.


### PR DESCRIPTION
Implements the approved voiceover: a quiet pill in the corner of the gateway-served app that tells the truth about your cloud workspace, and a panel that can update it.

## What ships

**Pill states** (gateway mode only — renders nothing without `window.__OPENWORK_GATEWAY__`): `Cloud · <version>`, `Update available`, `Provisioning your workspace…`, `Waking your workspace…`, `Updating your workspace…`, and amber `Workspace needs attention` with Retry + Sign out. The silent-redirect-loop failure mode is now a labeled state with an exit.

**Panel**: status, `Version` / `Latest` (with "up to date"), "Backups on", and — when stale — **Update now** ("Takes about 30 seconds. Your files and sessions come along.").

**den-api** (additive): member `/v1/cloud/instance` gains `imageVersion` + `latestVersion`; new `POST /v1/cloud/instance/update` which **flushes a checkpoint first, then stops** the sandbox — the existing recycle machinery (#3228) does the actual upgrade on the next resolve. If the flush fails on a running sandbox it refuses to stop (never lose the last minutes); already-current returns `already_current`; legacy workers (`imageVersion: null`) count as update-available by definition.

**fraimz flow**: `evals/flows/den-gateway.flow.ts` — previously 25 `ctx.assert(false)` stubs — now encodes the six voiceover frames against a configurable target (`OPENWORK_FLOW_BASE_URL`, creds via env), with honest `ctx.skip` (new runner capability) for frames the environment can't produce. The voiceover file is updated to the approved script.

## Semantic-conflict note

Rebasing over #3232 (host token) surfaced one collision: its member-response test asserted the payload shape with strict `toEqual`, which the new additive fields break. The test's contract is token *absence*, so it now uses `toMatchObject` + the token assertions. Everything else rebased clean.

## Tests

| Command | Result |
| --- | --- |
| den-api `cloud-instance-route` (incl. update endpoint + token-absence) | 28 pass / 0 fail |
| `apps/app` full suite (incl. overlay state mapper + gateway gating) | 486 pass / 0 fail |
| `tsc --noEmit` den-api / app + `pnpm evals:typecheck` | 0 errors |
| `pnpm --dir apps/app run build:web` | success |

## Proof plan (after deploy)

Running the fraimz flow against production with the canary org: frames 1-2 (pill + panel) directly; frames 3-5 (update available -> Update now -> back current with files intact) by making the canary stale; frame 6 honestly skipped unless a failed worker exists. Posting `fraimz.html` on this PR via `pnpm fraimz --flow den-gateway --pr`.