### PR TITLE
fix(gateway): inject client bearer + host-token header, and send Den auth on all app instance calls

### DIFF
--- a/apps/app/src/react-app/domains/connections/openwork-server-store.ts
+++ b/apps/app/src/react-app/domains/connections/openwork-server-store.ts
@@ -9,6 +9,10 @@ import {
   type OpenworkServerInfo,
 } from "../../../app/lib/desktop";
 import {
+  getOpenworkGatewayOrigin,
+  readOpenworkGatewayDenToken,
+} from "../../../app/lib/gateway-runtime";
+import {
   clearOpenworkServerSettings,
   createOpenworkServerClient,
   isLoopbackOpenworkServerUrl,
@@ -130,6 +134,9 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
   };
 
   const getBaseUrl = () => {
+    const gatewayOrigin = getOpenworkGatewayOrigin();
+    if (gatewayOrigin) return normalizeOpenworkServerUrl(gatewayOrigin) ?? "";
+
     const pref = options.startupPreference();
     const hostInfo = state.openworkServerHostInfo;
     const settingsUrl = normalizeOpenworkServerUrl(state.openworkServerSettings.urlOverride ?? "") ?? "";
@@ -143,6 +150,12 @@ export function createOpenworkServerStore(options: CreateOpenworkServerStoreOpti
   };
 
   const getAuth = () => {
+    const gatewayOrigin = getOpenworkGatewayOrigin();
+    if (gatewayOrigin) {
+      const token = readOpenworkGatewayDenToken().trim();
+      return { token: token || undefined, hostToken: undefined };
+    }
+
     const pref = options.startupPreference();
     const hostInfo = state.openworkServerHostInfo;
     const settingsUrl = normalizeOpenworkServerUrl(state.openworkServerSettings.urlOverride ?? "") ?? "";

--- a/apps/app/src/react-app/kernel/server-provider.tsx
+++ b/apps/app/src/react-app/kernel/server-provider.tsx
@@ -12,6 +12,10 @@ import {
 import { createOpencodeClient } from "@opencode-ai/sdk/v2/client";
 
 import { desktopFetch } from "../../app/lib/desktop";
+import {
+  getOpenworkGatewayOrigin,
+  readOpenworkGatewayDenToken,
+} from "../../app/lib/gateway-runtime";
 import { isWebDeployment } from "../../app/lib/openwork-deployment";
 import { normalizeOpenworkServerUrl } from "../../app/lib/openwork-server";
 import { isDesktopRuntime } from "../../app/utils";
@@ -60,6 +64,8 @@ function readStoredActive(): string {
 }
 
 function readOpenworkToken(): string {
+  if (getOpenworkGatewayOrigin()) return readOpenworkGatewayDenToken();
+
   if (typeof window === "undefined") return "";
   try {
     return (window.localStorage.getItem("openwork.server.token") ?? "").trim();
@@ -68,11 +74,14 @@ function readOpenworkToken(): string {
   }
 }
 
+export function buildOpenworkHealthHeaders(url: string): Record<string, string> | undefined {
+  const token = readOpenworkToken();
+  return token && url.includes("/opencode") ? { Authorization: `Bearer ${token}` } : undefined;
+}
+
 async function checkHealth(url: string): Promise<boolean> {
   if (!url) return false;
-  const token = readOpenworkToken();
-  const headers =
-    token && url.includes("/opencode") ? { Authorization: `Bearer ${token}` } : undefined;
+  const headers = buildOpenworkHealthHeaders(url);
   const client = createOpencodeClient({
     baseUrl: url,
     headers,
@@ -98,16 +107,18 @@ export function ServerProvider({ children, defaultUrl }: ServerProviderProps) {
     if (readyRef.current) return;
     if (typeof window === "undefined") return;
 
-    const fallback = normalizeServerUrl(defaultUrl) ?? "";
+    const gatewayOrigin = getOpenworkGatewayOrigin();
+    const fallback = normalizeServerUrl(gatewayOrigin ? `${gatewayOrigin}/opencode` : defaultUrl) ?? "";
 
     // Hosted web deployments served by OpenWork must reuse the OpenCode proxy
     // rather than any persisted localhost target.
     const forceProxy =
-      !isDesktopRuntime() &&
-      isWebDeployment() &&
-      (import.meta.env.PROD ||
-        (typeof import.meta.env?.VITE_OPENWORK_URL === "string" &&
-          import.meta.env.VITE_OPENWORK_URL.trim().length > 0));
+      Boolean(gatewayOrigin) ||
+      (!isDesktopRuntime() &&
+        isWebDeployment() &&
+        (import.meta.env.PROD ||
+          (typeof import.meta.env?.VITE_OPENWORK_URL === "string" &&
+            import.meta.env.VITE_OPENWORK_URL.trim().length > 0)));
 
     if (forceProxy && fallback) {
       dispatchServer({ type: "ready", list: [fallback], active: fallback });

--- a/apps/app/tests/gateway-runtime.test.ts
+++ b/apps/app/tests/gateway-runtime.test.ts
@@ -12,6 +12,8 @@ import {
   hydrateOpenworkServerSettingsFromEnv,
   readOpenworkServerSettings,
 } from "../src/app/lib/openwork-server";
+import { createOpenworkServerStore } from "../src/react-app/domains/connections/openwork-server-store";
+import { buildOpenworkHealthHeaders } from "../src/react-app/kernel/server-provider";
 import { resolveOpenworkConnection } from "../src/react-app/shell/openwork-connection";
 
 const originalWindow = globalThis.window;
@@ -46,6 +48,25 @@ function getRequestUrl(input: RequestInfo | URL): string {
   if (input instanceof URL) return input.toString();
   if (typeof input === "string") return input;
   return input.url;
+}
+
+function createTestOpenworkServerStore() {
+  return createOpenworkServerStore({
+    startupPreference: () => "server",
+    documentVisible: () => true,
+    developerMode: () => false,
+    runtimeWorkspaceId: () => "workspace_test",
+    activeClient: () => null,
+    selectedWorkspaceDisplay: () => ({
+      id: "workspace_test",
+      name: "Test workspace",
+      path: "/tmp/workspace_test",
+      preset: "default",
+      workspaceType: "local",
+    }),
+    restartLocalServer: async () => false,
+    createRemoteWorkspaceFlow: async () => false,
+  });
 }
 
 function installWindow(options: {
@@ -206,6 +227,67 @@ describe("gateway runtime mode", () => {
     expect(storage.getItem("openwork.server.token")).toBeNull();
     expect(readOpenworkServerSettings().token).toBeUndefined();
   });
+
+  test("uses same-origin and the Den bearer for OpenWork server store env calls behind the gateway", async () => {
+    const storage = installWindow({ origin: "https://gw.example", gateway: true });
+    storage.setItem("openwork.den.authToken", "den-session-token");
+    storage.setItem("openwork.server.urlOverride", "https://direct-instance.example.com");
+    storage.setItem("openwork.server.token", "stale-instance-token");
+    storage.setItem("openwork.server.hostToken", "stale-host-token");
+    const requests: Array<{ url: string; authorization: string | null; hostToken: string | null }> = [];
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      value: async (input: RequestInfo | URL, init?: RequestInit) => {
+        const headers = new Headers(init?.headers);
+        requests.push({
+          url: getRequestUrl(input),
+          authorization: headers.get("authorization"),
+          hostToken: headers.get("x-openwork-host-token"),
+        });
+        return new Response(JSON.stringify({ runtimeKey: "runtime-a", pendingChanges: false, ok: true, count: 1 }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      },
+    });
+
+    const store = createTestOpenworkServerStore();
+    const snapshot = store.getSnapshot();
+    const client = snapshot.openworkServerClient;
+    if (!client) throw new Error("Expected a gateway OpenWork server client");
+
+    expect(snapshot.openworkServerBaseUrl).toBe("https://gw.example");
+    expect(snapshot.openworkServerAuth.token).toBe("den-session-token");
+    expect(snapshot.openworkServerAuth.hostToken).toBeUndefined();
+    expect(client.baseUrl).toBe("https://gw.example");
+    expect(client.token).toBe("den-session-token");
+
+    await client.getUserEnvStatus("runtime-a");
+    await client.upsertUserEnv([{ key: "OPENAI_API_KEY", value: "sk-test" }]);
+
+    expect(requests).toEqual([
+      {
+        url: "https://gw.example/env/status?runtimeKey=runtime-a",
+        authorization: "Bearer den-session-token",
+        hostToken: null,
+      },
+      {
+        url: "https://gw.example/env",
+        authorization: "Bearer den-session-token",
+        hostToken: null,
+      },
+    ]);
+  });
+
+  test("uses the Den bearer for same-origin OpenCode health polling behind the gateway", () => {
+    const storage = installWindow({ origin: "https://gw.example", gateway: true });
+    storage.setItem("openwork.den.authToken", "den-session-token");
+    storage.setItem("openwork.server.token", "stale-instance-token");
+
+    expect(buildOpenworkHealthHeaders("https://gw.example/opencode")).toEqual({
+      Authorization: "Bearer den-session-token",
+    });
+  });
 });
 
 describe("non-gateway connection modes", () => {
@@ -253,6 +335,24 @@ describe("non-gateway connection modes", () => {
     expect(connection.resolvedToken).toBe("manual-token");
     expect(connection.resolvedHostToken).toBe("");
     expect(connection.source).toBe("stored-settings");
+
+    const store = createTestOpenworkServerStore();
+    const snapshot = store.getSnapshot();
+
+    expect(snapshot.openworkServerBaseUrl).toBe("https://manual.example.com");
+    expect(snapshot.openworkServerAuth.token).toBe("manual-token");
+    expect(snapshot.openworkServerAuth.hostToken).toBeUndefined();
+    expect(snapshot.openworkServerClient?.baseUrl).toBe("https://manual.example.com");
+    expect(snapshot.openworkServerClient?.token).toBe("manual-token");
+  });
+
+  test("OpenCode health polling still uses the stored instance token without the gateway marker", () => {
+    const storage = installWindow({ origin: "https://instance.example.com" });
+    storage.setItem("openwork.server.token", "instance-token");
+
+    expect(buildOpenworkHealthHeaders("https://instance.example.com/opencode")).toEqual({
+      Authorization: "Bearer instance-token",
+    });
   });
 
   test("plain web Den settings still use a stored custom base URL without the marker", () => {

--- a/ee/apps/den-gateway/src/app.ts
+++ b/ee/apps/den-gateway/src/app.ts
@@ -490,16 +490,18 @@ async function requestBody(request: Request) {
   return body.byteLength > 0 ? body : undefined
 }
 
-function upstreamRequestHeaders(headers: Headers, hostToken: string) {
+function upstreamRequestHeaders(headers: Headers, clientToken: string, hostToken: string) {
   const upstream = new Headers(headers)
   upstream.delete("authorization")
+  upstream.delete("x-openwork-host-token")
   upstream.delete("cookie")
   upstream.delete("host")
   upstream.delete("connection")
   upstream.delete("content-length")
   upstream.delete("transfer-encoding")
   upstream.delete(gatewayKeyHeader)
-  upstream.set("Authorization", `Bearer ${hostToken}`)
+  upstream.set("Authorization", `Bearer ${clientToken}`)
+  upstream.set("x-openwork-host-token", hostToken)
   return upstream
 }
 
@@ -511,6 +513,7 @@ function denApiRequestHeaders(request: Request) {
     if (normalized === "host" || normalized === "content-length" || normalized === "cookie") return
     if (spoofableForwardingHeaders.has(normalized)) return
     if (normalized === gatewayKeyHeader.toLowerCase()) return
+    if (normalized === "x-openwork-host-token") return
     upstream.append(name, value)
   })
 
@@ -574,7 +577,7 @@ async function proxyToInstance(input: {
   try {
     response = await input.config.fetchImpl(buildProxyUrl(input.resolution.url, input.request.url), {
       method: input.request.method,
-      headers: upstreamRequestHeaders(input.request.headers, input.resolution.hostToken),
+      headers: upstreamRequestHeaders(input.request.headers, input.resolution.clientToken, input.resolution.hostToken),
       body: await requestBody(input.request),
       redirect: "manual",
     })

--- a/ee/apps/den-gateway/test/gateway.test.mjs
+++ b/ee/apps/den-gateway/test/gateway.test.mjs
@@ -86,6 +86,7 @@ function startPassthroughDenApi() {
       method: request.method,
       path: `${url.pathname}${url.search}`,
       authorization: request.headers.get("authorization"),
+      hostToken: request.headers.get("x-openwork-host-token"),
       cookie: request.headers.get("cookie"),
       gatewayKey: request.headers.get("x-openwork-gateway-key"),
       forwardedPrefix: request.headers.get("x-forwarded-prefix"),
@@ -131,6 +132,7 @@ function startUpstream() {
       method: request.method,
       path: `${url.pathname}${url.search}`,
       authorization: request.headers.get("authorization"),
+      hostToken: request.headers.get("x-openwork-host-token"),
       cookie: request.headers.get("cookie"),
     })
 
@@ -216,6 +218,7 @@ describe("den-gateway proxy", () => {
       method: "POST",
       headers: {
         Authorization: "Bearer den-session",
+        "X-OpenWork-Host-Token": "browser-host-token",
         Cookie: "ow_session=must_not_leak",
         "Content-Type": "application/json",
       },
@@ -229,12 +232,14 @@ describe("den-gateway proxy", () => {
       method: "POST",
       path: "/v1/me?expand=org",
       authorization: "Bearer den-session",
+      hostToken: null,
       cookie: null,
       gatewayKey: null,
       forwardedPrefix: "/api/den",
       body: '{"hello":"world"}',
     })
     expect(denApi.observed.requests[0].authorization).not.toBe("Bearer host-token")
+    expect(denApi.observed.requests[0].authorization).not.toBe("Bearer client-token")
     expect(upstream.observed.requests).toHaveLength(0)
   })
 
@@ -281,7 +286,7 @@ describe("den-gateway proxy", () => {
     expect(denApi.observed.gatewayKey).toBe("gateway-secret")
   })
 
-  test("injects the host token upstream and strips the Den bearer and cookies", async () => {
+  test("injects client and host tokens upstream while stripping browser-supplied credentials", async () => {
     const upstream = startUpstream()
     const denApi = startDenApi(() => readyResolvePayload(serverBase(upstream.server)))
     const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret" })
@@ -289,14 +294,16 @@ describe("den-gateway proxy", () => {
     const response = await fetch(`${serverBase(gateway)}/status`, {
       headers: {
         Authorization: "Bearer den-bearer",
+        "X-OpenWork-Host-Token": "browser-host-token",
         Cookie: "ow_session=must_not_leak",
       },
     })
 
     expect(response.status).toBe(200)
-    expect(upstream.observed.requests[0].authorization).toBe("Bearer host-token")
-    expect(upstream.observed.requests[0].authorization).not.toBe("Bearer client-token")
+    expect(upstream.observed.requests[0].authorization).toBe("Bearer client-token")
     expect(upstream.observed.requests[0].authorization).not.toBe("Bearer den-bearer")
+    expect(upstream.observed.requests[0].hostToken).toBe("host-token")
+    expect(upstream.observed.requests[0].hostToken).not.toBe("browser-host-token")
     expect(upstream.observed.requests[0].cookie).toBeNull()
   })
 
@@ -306,7 +313,10 @@ describe("den-gateway proxy", () => {
     let resolveResponses = 0
     const denApi = startDenApi(() => {
       resolveResponses += 1
-      return readyResolvePayload(serverBase(upstream.server), { hostToken: `host-token-${resolveResponses}` })
+      return readyResolvePayload(serverBase(upstream.server), {
+        clientToken: `client-token-${resolveResponses}`,
+        hostToken: `host-token-${resolveResponses}`,
+      })
     })
     const gateway = startGateway({ denApiBase: serverBase(denApi.server), gatewayKey: "gateway-secret", resolveTtlMs: 1_000, now: () => now })
     const base = serverBase(gateway)
@@ -323,9 +333,14 @@ describe("den-gateway proxy", () => {
     expect(denApi.observed.calls).toBe(2)
     expect(upstream.observed.requests).toHaveLength(3)
     expect(upstream.observed.requests.map((request) => request.authorization)).toEqual([
-      "Bearer host-token-1",
-      "Bearer host-token-1",
-      "Bearer host-token-2",
+      "Bearer client-token-1",
+      "Bearer client-token-1",
+      "Bearer client-token-2",
+    ])
+    expect(upstream.observed.requests.map((request) => request.hostToken)).toEqual([
+      "host-token-1",
+      "host-token-1",
+      "host-token-2",
     ])
   })
 


### PR DESCRIPTION
Follow-up to #3232, which encoded a wrong assumption (mine, stated in the brief): that the host token supersedes the client token as the Authorization bearer. Measured against a live production instance, openwork-server's contract is actually per-slot:

| endpoint | HOST bearer | CLIENT bearer | none |
|---|---|---|---|
| `/health` | 200 | 200 | 200 (public) |
| `/opencode/global/health` | 401 | **200** | 401 |
| `/env/status` | 401 | 401 | 401 |

`requireHostToken` (apps/server/src/server.ts) accepts the host token only via the dedicated `x-openwork-host-token` header (or an owner-scoped bearer); `/opencode/global/*` requires the client token as the bearer and rejects host. So #3232 broke `/opencode/global/*` and did not fix `/env*`.

## Fix 1 — gateway injects both tokens in their own slots

Proxied instance requests now carry `Authorization: Bearer <clientToken>` (restoring pre-#3232 behavior) AND `x-openwork-host-token: <hostToken>`. Browser-supplied `authorization` / `x-openwork-host-token` are stripped first — client-supplied values are never trusted. `/api/den/*` passthrough is unchanged (Den bearer only; host header stripped there too) and the HTML/no-token assertions now also cover the host header.

## Fix 2 — the app attaches its Den bearer on every instance call in gateway mode

The remaining 401s never reached the instance: the env-status, provider-sync, and health-poll modules fetch with no Authorization (the per-server token store is empty in gateway mode), and the gateway's resolve is deliberately fail-closed without user auth. The main session UI already used the Den session token via `resolveOpenworkConnection`; now the openwork-server store and the health poller resolve the same way in gateway mode — same-origin base + Den session token. Desktop/self-host paths are untouched, and the bootstrap-snapshot identity guard (React #185) holds.

## Tests

| Command | Result |
| --- | --- |
| den-gateway suite (dual headers, host-header stripping, Den passthrough) | 13 pass / 0 fail |
| apps/app full suite (incl. new gateway auth-header tests) | 489 pass / 0 fail |
| tsc gateway + app, `build:web` | clean |

## After deploy

Live check: `/health`, `/opencode/global/health`, `/env/status` all 200 through `web.openworklabs.com` from the app itself (no manual bearer), and the `cloud-provider-sync` console errors gone.