### PR TITLE
feat(app): boot states take over the main area; kill the stale workspace-not-found error

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/session-page.tsx
+++ b/apps/app/src/react-app/domains/session/chat/session-page.tsx
@@ -203,6 +203,7 @@ export type SessionPageProps = {
   respondQuestion?: (requestID: string, answers: string[][]) => void;
   statusBar?: Partial<StatusBarOverrides>;
   notFoundMessage?: string | null;
+  mainContentTakeover?: React.ReactNode;
   onOpenProviderAuth?: () => void;
   /** Chat-first: create a default workspace and start a task from the empty-state composer. */
   onChatFirstTask?: (prompt: string, attachments?: ComposerAttachment[]) => void;
@@ -778,8 +779,10 @@ export function SessionPage(props: SessionPageProps) {
   );
   const providerCount = props.hasUsableModel ? 1 : props.providerConnectedIds.length;
   const messageCountVisible = props.selectedSessionId ? 1 : 0;
+  const hasMainContentTakeover = Boolean(props.mainContentTakeover);
   const showWorkspaceSetupEmptyState = props.workspaces.length === 0 && !props.selectedSessionId;
   const showStartupSkeleton =
+    !hasMainContentTakeover &&
     !props.selectedSessionId &&
     !props.clientConnected &&
     props.startupPhase !== "sessionIndexReady" &&
@@ -834,6 +837,7 @@ export function SessionPage(props: SessionPageProps) {
   const showSessionLoadingState =
     Boolean(props.selectedSessionId) &&
     props.sessionLoadingById(props.selectedSessionId) &&
+    !hasMainContentTakeover &&
     !showWorkspaceSetupEmptyState &&
     !canRenderReactSurface;
   const selectedWorkspaceIsRemote = props.workspaces.some(
@@ -1165,6 +1169,8 @@ export function SessionPage(props: SessionPageProps) {
           <ResizablePanelGroup orientation="vertical" className="min-h-0 flex-1 overflow-hidden">
             <ResizablePanel minSize="180px" className="min-h-0">
             <div className="relative h-full min-w-0 overflow-hidden bg-dls-surface mac:bg-dls-surface/85 mac:backdrop-blur-2xl mac:backdrop-saturate-150">
+              {hasMainContentTakeover ? props.mainContentTakeover : null}
+
               {showStartupSkeleton ? (
                 <div className="px-6 py-14" role="status" aria-live="polite">
                   <div className="mx-auto max-w-2xl space-y-6">
@@ -1193,7 +1199,7 @@ export function SessionPage(props: SessionPageProps) {
                 </div>
               ) : null}
 
-              {showDelayedSessionLoadingState ? (
+              {!hasMainContentTakeover && showDelayedSessionLoadingState ? (
                 selectedWorkspaceIsRemote ? (
                   // Cloud workers sync over the network all the time; the full
                   // loading pane reads as "something is wrong". Keep it to a
@@ -1219,7 +1225,7 @@ export function SessionPage(props: SessionPageProps) {
                 )
               ) : null}
 
-              {!showDelayedSessionLoadingState && canRenderReactSurface ? (
+              {!hasMainContentTakeover && !showDelayedSessionLoadingState && canRenderReactSurface ? (
                 <div className="flex h-full min-h-0 flex-col">
                   <ResizablePanelGroup
                     key={canRenderSplitSurface ? "workbench-split" : "workbench-single"}
@@ -1290,7 +1296,7 @@ export function SessionPage(props: SessionPageProps) {
                 </div>
               ) : null}
 
-              {!showDelayedSessionLoadingState && !canRenderReactSurface && !showStartupSkeleton ? (
+              {!hasMainContentTakeover && !showDelayedSessionLoadingState && !canRenderReactSurface && !showStartupSkeleton ? (
                 <div className={`mx-auto max-w-[800px] px-6 ${showWorkspaceSetupEmptyState ? "pt-20" : "pt-10"}`}>
                   {props.notFoundMessage ? (
                     <div className="px-6 py-16 text-center">

--- a/apps/app/src/react-app/shell/app-root.tsx
+++ b/apps/app/src/react-app/shell/app-root.tsx
@@ -31,7 +31,7 @@ import { useDesktopFontZoomBehavior } from "./font-zoom";
 import { LoadingOverlay } from "./loading-overlay";
 import { DevProfiler, DevProfilerOverlay } from "./dev-profiler";
 import { ReactRenderWatchdogOverlay } from "./react-render-watchdog-overlay";
-import { CloudWorkspaceOverlay } from "./cloud-workspace-overlay";
+import { CloudWorkspaceOverlay, CloudWorkspaceStatusProvider } from "./cloud-workspace-overlay";
 import { AppMenuProvider } from "./app-menu";
 import {
   OpenworkControlProvider,
@@ -351,6 +351,7 @@ export function AppRoot() {
           <OpenworkContextPublisher />
           <DenAuthControlActions />
           <BrandThemeControlActions />
+          <CloudWorkspaceStatusProvider>
           <EnterpriseActivationGate>
           <DenSigninGate>
             <Routes>
@@ -435,6 +436,8 @@ export function AppRoot() {
           </DenSigninGate>
           <LoadingOverlay />
           </EnterpriseActivationGate>
+          <CloudWorkspaceOverlay />
+          </CloudWorkspaceStatusProvider>
         </OpenworkControlProvider>
         </AppMenuProvider>
         </ShellConfigProvider>
@@ -449,7 +452,6 @@ export function AppRoot() {
         true app-level signal.
       */}
       <NewProvidersListener />
-      <CloudWorkspaceOverlay />
       <DevProfilerOverlay />
       <ReactRenderWatchdogOverlay />
     </>

--- a/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
+++ b/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
@@ -1,5 +1,6 @@
 /** @jsxImportSource react */
-import { useCallback, useEffect, useMemo, useState, useSyncExternalStore } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, useSyncExternalStore, type ReactNode } from "react";
+import { AlertTriangle, Loader2 } from "lucide-react";
 
 import { clearDenSession, createDenClient, readDenSettings } from "@/app/lib/den";
 import { isOpenworkGatewayRuntime } from "@/app/lib/gateway-runtime";
@@ -8,8 +9,42 @@ import { Button } from "@/components/ui/button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover";
 import { cn } from "@/lib/utils";
 import { useDenAuth } from "@/react-app/domains/cloud/den-auth-provider";
-import { mapCloudWorkspaceState } from "./cloud-workspace-status";
+import { softCardClass } from "@/react-app/domains/workspace/modal-styles";
+import { mapCloudWorkspaceState, type CloudWorkspaceMainContentDecision, type CloudWorkspacePillVariant, type CloudWorkspaceViewModel } from "./cloud-workspace-status";
 import type { DenCloudInstance } from "@/app/lib/den";
+import { OwDotTicker } from "./dot-ticker";
+
+type CloudWorkspaceStatusContextValue = {
+  gatewayMode: boolean;
+  visible: boolean;
+  instance: DenCloudInstance | null;
+  requestFailed: boolean;
+  updating: boolean;
+  viewModel: CloudWorkspaceViewModel;
+  refresh: () => Promise<void>;
+  signOut: () => void;
+  updateNow: () => void;
+};
+
+const fallbackViewModel = mapCloudWorkspaceState({ instance: null, updating: false });
+
+async function noopRefresh() {}
+
+function noopAction() {}
+
+const fallbackCloudWorkspaceStatus: CloudWorkspaceStatusContextValue = {
+  gatewayMode: false,
+  visible: false,
+  instance: null,
+  requestFailed: false,
+  updating: false,
+  viewModel: fallbackViewModel,
+  refresh: noopRefresh,
+  signOut: noopAction,
+  updateNow: noopAction,
+};
+
+const CloudWorkspaceStatusContext = createContext<CloudWorkspaceStatusContextValue | null>(null);
 
 const readDenSettingsSnapshot = () => {
   const settings = readDenSettings();
@@ -26,12 +61,16 @@ function subscribeToDenSettings(onStoreChange: () => void) {
   return () => window.removeEventListener(denSettingsChangedEvent, onStoreChange);
 }
 
-function CloudWorkspaceOverlayInner() {
+export function useCloudWorkspaceStatus() {
+  return useContext(CloudWorkspaceStatusContext) ?? fallbackCloudWorkspaceStatus;
+}
+
+export function CloudWorkspaceStatusProvider(props: { children: ReactNode }) {
   const denAuth = useDenAuth();
-  const [open, setOpen] = useState(false);
   const [instance, setInstance] = useState<DenCloudInstance | null>(null);
   const [requestFailed, setRequestFailed] = useState(false);
   const [updating, setUpdating] = useState(false);
+  const gatewayMode = isOpenworkGatewayRuntime();
   const settingsSnapshot = useSyncExternalStore(
     subscribeToDenSettings,
     readDenSettingsSnapshot,
@@ -40,12 +79,14 @@ function CloudWorkspaceOverlayInner() {
   const settings = useMemo(() => readDenSettings(), [settingsSnapshot]);
   const authToken = settings.authToken?.trim() ?? "";
   const orgId = settings.activeOrgId?.trim() ?? "";
+  const visible = denAuth.isSignedIn || authToken.length > 0;
   const denClient = useMemo(
     () => createDenClient({ baseUrl: settings.baseUrl, token: authToken }),
     [authToken, settings.baseUrl],
   );
 
   const refresh = useCallback(async () => {
+    if (!gatewayMode) return;
     if (!authToken || !orgId) {
       setRequestFailed(true);
       return;
@@ -58,29 +99,33 @@ function CloudWorkspaceOverlayInner() {
     } catch {
       setRequestFailed(true);
     }
-  }, [authToken, denClient, orgId]);
+  }, [authToken, denClient, gatewayMode, orgId]);
 
-  const viewModel = mapCloudWorkspaceState({ instance, updating, requestFailed });
+  const viewModel = useMemo(
+    () => mapCloudWorkspaceState({ instance, updating, requestFailed }),
+    [instance, requestFailed, updating],
+  );
 
   useEffect(() => {
+    if (!gatewayMode || !visible) return;
     void refresh();
-  }, [refresh]);
+  }, [gatewayMode, refresh, visible]);
 
   useEffect(() => {
-    if (!authToken || !orgId) return;
+    if (!gatewayMode || !authToken || !orgId || !visible) return;
     const timeoutId = window.setTimeout(() => {
       void refresh();
     }, viewModel.pollMs);
     return () => window.clearTimeout(timeoutId);
-  }, [authToken, instance, orgId, refresh, requestFailed, updating, viewModel.pollMs]);
+  }, [authToken, gatewayMode, instance, orgId, refresh, requestFailed, updating, viewModel.pollMs, visible]);
 
   useEffect(() => {
-    if (!updating) return;
+    if (!gatewayMode || !updating) return;
     const nextModel = mapCloudWorkspaceState({ instance, updating: false, requestFailed });
     if (instance?.status === "ready" && !nextModel.updateAvailable) {
       setUpdating(false);
     }
-  }, [instance, requestFailed, updating]);
+  }, [gatewayMode, instance, requestFailed, updating]);
 
   const signOut = useCallback(() => {
     if (authToken) {
@@ -88,11 +133,10 @@ function CloudWorkspaceOverlayInner() {
     }
     clearDenSession();
     void denAuth.refresh();
-    setOpen(false);
   }, [authToken, denAuth, denClient]);
 
   const updateNow = useCallback(() => {
-    if (!orgId || updating) return;
+    if (!gatewayMode || !orgId || updating) return;
     setUpdating(true);
     setRequestFailed(false);
     void denClient
@@ -108,9 +152,131 @@ function CloudWorkspaceOverlayInner() {
         setUpdating(false);
         setRequestFailed(true);
       });
-  }, [denClient, orgId, refresh, updating]);
+  }, [denClient, gatewayMode, orgId, refresh, updating]);
 
-  if (!denAuth.isSignedIn && !authToken) return null;
+  const value = useMemo<CloudWorkspaceStatusContextValue>(() => ({
+    gatewayMode,
+    visible,
+    instance,
+    requestFailed,
+    updating,
+    viewModel,
+    refresh,
+    signOut,
+    updateNow,
+  }), [gatewayMode, instance, refresh, requestFailed, signOut, updateNow, updating, viewModel, visible]);
+
+  return (
+    <CloudWorkspaceStatusContext.Provider value={value}>
+      {props.children}
+    </CloudWorkspaceStatusContext.Provider>
+  );
+}
+
+function cloudWorkspaceTakeoverCopy(variant: CloudWorkspacePillVariant) {
+  if (variant === "provisioning") {
+    return {
+      title: "Starting your workspace…",
+      body: "We’re preparing your sandbox and reconnecting the app. This usually takes less than a minute.",
+    };
+  }
+  if (variant === "updating") {
+    return {
+      title: "Updating your workspace…",
+      body: "We’re applying the latest OpenWork image. Your files and sessions come along.",
+    };
+  }
+  if (variant === "failed") {
+    return {
+      title: "Workspace needs attention",
+      body: "We couldn’t start the sandbox. Retry, or sign out and reconnect.",
+    };
+  }
+  return {
+    title: "Waking your workspace…",
+    body: "Your sandbox is coming back online. We’ll open your workspace as soon as it’s ready.",
+  };
+}
+
+export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMainContentDecision }) {
+  const cloudWorkspace = useCloudWorkspaceStatus();
+  if (!cloudWorkspace.gatewayMode || !cloudWorkspace.visible || props.decision !== "takeover") return null;
+
+  const { viewModel } = cloudWorkspace;
+  const failed = viewModel.variant === "failed";
+  const copy = cloudWorkspaceTakeoverCopy(viewModel.variant);
+
+  return (
+    <div
+      className="flex h-full min-h-[420px] items-center justify-center px-6 py-16"
+      role={failed ? "alert" : "status"}
+      aria-live="polite"
+      data-testid="cloud-workspace-takeover"
+      data-cloud-workspace-state={viewModel.variant}
+    >
+      <div
+        className={cn(
+          "w-full max-w-md rounded-[20px] border p-6 shadow-[var(--dls-card-shadow)]",
+          failed
+            ? "border-amber-7/35 bg-amber-3/30"
+            : "border-dls-border bg-dls-surface",
+        )}
+      >
+        <div className="flex items-start gap-4">
+          <div
+            className={cn(
+              "flex size-12 shrink-0 items-center justify-center rounded-2xl border",
+              failed
+                ? "border-amber-7/35 bg-amber-3/60 text-amber-11"
+                : "border-dls-border bg-dls-hover text-dls-accent",
+            )}
+          >
+            {failed ? <AlertTriangle className="size-5" aria-hidden="true" /> : <OwDotTicker size="lg" />}
+          </div>
+          <div className="min-w-0 flex-1">
+            <h2 className="text-[24px] font-semibold leading-tight tracking-[-0.03em] text-dls-text">
+              {copy.title}
+            </h2>
+            <p className="mt-2 text-[14px] leading-6 text-dls-secondary">
+              {copy.body}
+            </p>
+          </div>
+        </div>
+
+        {failed ? (
+          <div className="mt-6 flex flex-wrap gap-2">
+            <Button type="button" size="sm" variant="outline" onClick={() => void cloudWorkspace.refresh()}>
+              Retry
+            </Button>
+            <Button type="button" size="sm" variant="ghost" onClick={cloudWorkspace.signOut}>
+              Sign out
+            </Button>
+          </div>
+        ) : (
+          <div className={cn("mt-6", softCardClass)}>
+            <div className="flex items-center gap-2 text-[12px] font-semibold text-dls-text">
+              <Loader2 size={14} className="animate-spin text-dls-accent" aria-hidden="true" />
+              Sandbox setup
+            </div>
+            <div className="mt-4 overflow-hidden rounded-full bg-dls-surface">
+              <div className="h-1.5 w-2/3 animate-pulse rounded-full bg-dls-accent/60" />
+            </div>
+            <p className="mt-3 text-[12px] leading-5 text-dls-secondary">
+              We’ll refresh your workspace automatically when it’s ready.
+            </p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function CloudWorkspaceOverlayInner() {
+  const cloudWorkspace = useCloudWorkspaceStatus();
+  const [open, setOpen] = useState(false);
+  const viewModel = cloudWorkspace.viewModel;
+
+  if (!cloudWorkspace.gatewayMode || !cloudWorkspace.visible) return null;
 
   return (
     <div className="fixed bottom-4 right-4 z-[100]">
@@ -146,7 +312,7 @@ function CloudWorkspaceOverlayInner() {
           </div>
           {viewModel.showUpdate ? (
             <div className="rounded-2xl border border-border bg-muted/30 p-3">
-              <Button type="button" size="sm" className="w-full" onClick={updateNow} disabled={updating}>
+              <Button type="button" size="sm" className="w-full" onClick={cloudWorkspace.updateNow} disabled={cloudWorkspace.updating}>
                 Update now
               </Button>
               <p className="mt-2 text-xs text-muted-foreground">
@@ -156,11 +322,14 @@ function CloudWorkspaceOverlayInner() {
           ) : null}
           <div className="flex items-center justify-end gap-2">
             {viewModel.showRetry ? (
-              <Button type="button" size="sm" variant="outline" onClick={() => void refresh()}>
+              <Button type="button" size="sm" variant="outline" onClick={() => void cloudWorkspace.refresh()}>
                 Retry
               </Button>
             ) : null}
-            <Button type="button" size="sm" variant="ghost" onClick={signOut}>
+            <Button type="button" size="sm" variant="ghost" onClick={() => {
+              cloudWorkspace.signOut();
+              setOpen(false);
+            }}>
               Sign out
             </Button>
           </div>
@@ -171,6 +340,5 @@ function CloudWorkspaceOverlayInner() {
 }
 
 export function CloudWorkspaceOverlay() {
-  if (!isOpenworkGatewayRuntime()) return null;
   return <CloudWorkspaceOverlayInner />;
 }

--- a/apps/app/src/react-app/shell/cloud-workspace-status.ts
+++ b/apps/app/src/react-app/shell/cloud-workspace-status.ts
@@ -22,6 +22,8 @@ export type CloudWorkspaceViewModel = {
   pollMs: number;
 };
 
+export type CloudWorkspaceMainContentDecision = "takeover" | "error" | "content";
+
 export function formatCloudWorkspaceVersion(version: string | null): string | null {
   const trimmed = version?.trim() ?? "";
   if (!trimmed) return null;
@@ -34,6 +36,33 @@ export function formatCloudWorkspaceVersion(version: string | null): string | nu
 export function cloudWorkspaceUpdateAvailable(instance: DenCloudInstance | null): boolean {
   if (!instance?.latestVersion) return false;
   return instance.imageVersion === null || instance.imageVersion !== instance.latestVersion;
+}
+
+export function cloudWorkspaceStatusHasReadyContent(variant: CloudWorkspacePillVariant): boolean {
+  return variant === "ready" || variant === "stale";
+}
+
+export function mapCloudWorkspaceMainContentDecision(input: {
+  status: CloudWorkspacePillVariant;
+  hasWorkspaces: boolean;
+  gatewayMode: boolean;
+}): CloudWorkspaceMainContentDecision {
+  if (!input.gatewayMode) return "content";
+  if (input.status === "failed") return "takeover";
+  if (!cloudWorkspaceStatusHasReadyContent(input.status)) {
+    return input.hasWorkspaces ? "content" : "takeover";
+  }
+  return input.hasWorkspaces ? "content" : "error";
+}
+
+export function shouldRefetchCloudWorkspaceOnReadyTransition(input: {
+  previousStatus: CloudWorkspacePillVariant | null;
+  nextStatus: CloudWorkspacePillVariant;
+  gatewayMode: boolean;
+}): boolean {
+  if (!input.gatewayMode || input.previousStatus === null) return false;
+  if (cloudWorkspaceStatusHasReadyContent(input.previousStatus)) return false;
+  return cloudWorkspaceStatusHasReadyContent(input.nextStatus);
 }
 
 function versionDisplay(instance: DenCloudInstance | null) {

--- a/apps/app/src/react-app/shell/session-route.tsx
+++ b/apps/app/src/react-app/shell/session-route.tsx
@@ -186,6 +186,12 @@ import { useShellShortcuts } from "./use-shell-shortcuts";
 import { useEngineReload } from "./use-engine-reload";
 import { useSessionGroupSync } from "./use-session-group-sync";
 import { useWorkspaceRouteState } from "./use-workspace-route-state";
+import { CloudWorkspaceBootTakeover, useCloudWorkspaceStatus } from "./cloud-workspace-overlay";
+import {
+  cloudWorkspaceStatusHasReadyContent,
+  mapCloudWorkspaceMainContentDecision,
+  shouldRefetchCloudWorkspaceOnReadyTransition,
+} from "./cloud-workspace-status";
 import { getReactQueryClient } from "@/react-app/infra/query-client";
 import { useSessionControlActions } from "@/react-app/domains/session/control/session-control-actions";
 import { legacySessionRoute, workspaceSessionRoute, workspaceSettingsRoute } from "./workspace-routes";
@@ -507,6 +513,19 @@ export function SessionRoute() {
     onServerSettingsChanged: () => setOpenworkServerSettingsVersion((value) => value + 1),
     onHostInfo: setOpenworkServerHostInfoState,
   });
+  const cloudWorkspace = useCloudWorkspaceStatus();
+  const previousCloudWorkspaceStatusRef = useRef<typeof cloudWorkspace.viewModel.variant | null>(null);
+  useEffect(() => {
+    const previousStatus = previousCloudWorkspaceStatusRef.current;
+    previousCloudWorkspaceStatusRef.current = cloudWorkspace.viewModel.variant;
+    if (!shouldRefetchCloudWorkspaceOnReadyTransition({
+      previousStatus,
+      nextStatus: cloudWorkspace.viewModel.variant,
+      gatewayMode: cloudWorkspace.gatewayMode && cloudWorkspace.visible,
+    })) return;
+    refreshInFlightRef.current = false;
+    void refreshRouteState();
+  }, [cloudWorkspace.gatewayMode, cloudWorkspace.viewModel.variant, cloudWorkspace.visible, refreshInFlightRef, refreshRouteState]);
   const cloudMcpProviderModel = useMemo(() => local.prefs.defaultModel
     ? {
         provider: local.prefs.defaultModel.providerID,
@@ -1349,6 +1368,19 @@ export function SessionRoute() {
     submitWithCloudMcpReadiness,
     token,
   ]);
+  const cloudWorkspaceMainContentDecision = mapCloudWorkspaceMainContentDecision({
+    status: cloudWorkspace.viewModel.variant,
+    hasWorkspaces: Boolean(surfaceProps),
+    gatewayMode: cloudWorkspace.gatewayMode && cloudWorkspace.visible,
+  });
+  const cloudWorkspaceReadyForRouteErrors =
+    !cloudWorkspace.gatewayMode ||
+    !cloudWorkspace.visible ||
+    cloudWorkspaceStatusHasReadyContent(cloudWorkspace.viewModel.variant);
+  const cloudWorkspaceMainContentTakeover = cloudWorkspaceMainContentDecision === "takeover" ? (
+    <CloudWorkspaceBootTakeover decision={cloudWorkspaceMainContentDecision} />
+  ) : null;
+  const gatedRouteNotFoundMessage = cloudWorkspaceReadyForRouteErrors ? routeNotFoundMessage : null;
 
   // Workspace-scoped wiring for the empty-state hero's full composer. Unlike
   // `surfaceProps` this exists without a selected session, so the hero offers
@@ -2615,7 +2647,8 @@ export function SessionRoute() {
         reloadError: reloadCoordinator.reloadError,
         openWorkConnectState: sessionMcpMaintenance,
       }}
-      notFoundMessage={routeNotFoundMessage}
+      notFoundMessage={gatedRouteNotFoundMessage}
+      mainContentTakeover={cloudWorkspaceMainContentTakeover}
       onAccessibleTargetsChange={setPaletteAccessibleTargets}
     />
     <OpenWorkModelsStartupDialog

--- a/apps/app/tests/cloud-workspace-overlay.test.tsx
+++ b/apps/app/tests/cloud-workspace-overlay.test.tsx
@@ -4,9 +4,13 @@ import { renderToStaticMarkup } from "react-dom/server";
 import type { DenCloudInstance } from "../src/app/lib/den";
 import { CloudWorkspaceOverlay } from "../src/react-app/shell/cloud-workspace-overlay";
 import {
+  cloudWorkspaceStatusHasReadyContent,
   cloudWorkspaceUpdateAvailable,
+  mapCloudWorkspaceMainContentDecision,
   mapCloudWorkspaceState,
+  shouldRefetchCloudWorkspaceOnReadyTransition,
 } from "../src/react-app/shell/cloud-workspace-status";
+import type { CloudWorkspaceMainContentDecision, CloudWorkspacePillVariant } from "../src/react-app/shell/cloud-workspace-status";
 
 const originalWindow = globalThis.window;
 
@@ -75,6 +79,80 @@ describe("cloud workspace overlay state", () => {
     expect(state.label).toBe("Updating your workspace…");
     expect(state.showUpdate).toBe(false);
     expect(state.pollMs).toBe(5_000);
+  });
+
+  test("maps gateway main content decisions for every worker state", () => {
+    const withoutReadyContent: [CloudWorkspacePillVariant, CloudWorkspaceMainContentDecision][] = [
+      ["ready", "error"],
+      ["stale", "error"],
+      ["waking", "takeover"],
+      ["provisioning", "takeover"],
+      ["updating", "takeover"],
+      ["failed", "takeover"],
+    ];
+    const withReadyContent: [CloudWorkspacePillVariant, CloudWorkspaceMainContentDecision][] = [
+      ["ready", "content"],
+      ["stale", "content"],
+      ["waking", "content"],
+      ["provisioning", "content"],
+      ["updating", "content"],
+      ["failed", "takeover"],
+    ];
+
+    for (const [status, decision] of withoutReadyContent) {
+      expect(mapCloudWorkspaceMainContentDecision({ status, hasWorkspaces: false, gatewayMode: true })).toBe(decision);
+    }
+    for (const [status, decision] of withReadyContent) {
+      expect(mapCloudWorkspaceMainContentDecision({ status, hasWorkspaces: true, gatewayMode: true })).toBe(decision);
+    }
+  });
+
+  test("passes all cloud states through outside gateway mode", () => {
+    const statuses: CloudWorkspacePillVariant[] = ["ready", "stale", "waking", "provisioning", "updating", "failed"];
+
+    for (const status of statuses) {
+      expect(mapCloudWorkspaceMainContentDecision({ status, hasWorkspaces: false, gatewayMode: false })).toBe("content");
+      expect(mapCloudWorkspaceMainContentDecision({ status, hasWorkspaces: true, gatewayMode: false })).toBe("content");
+    }
+  });
+
+  test("does not allow not-found errors before a gateway worker is ready", () => {
+    const notReady: CloudWorkspacePillVariant[] = ["waking", "provisioning", "updating", "failed"];
+
+    for (const status of notReady) {
+      expect(cloudWorkspaceStatusHasReadyContent(status)).toBe(false);
+      expect(mapCloudWorkspaceMainContentDecision({ status, hasWorkspaces: false, gatewayMode: true })).toBe("takeover");
+    }
+    expect(mapCloudWorkspaceMainContentDecision({ status: "ready", hasWorkspaces: false, gatewayMode: true })).toBe("error");
+    expect(mapCloudWorkspaceMainContentDecision({ status: "stale", hasWorkspaces: false, gatewayMode: true })).toBe("error");
+  });
+
+  test("fires a refetch callback when gateway workers transition back to ready", () => {
+    let refetches = 0;
+    if (shouldRefetchCloudWorkspaceOnReadyTransition({
+      previousStatus: "waking",
+      nextStatus: "ready",
+      gatewayMode: true,
+    })) {
+      refetches += 1;
+    }
+
+    expect(refetches).toBe(1);
+    expect(shouldRefetchCloudWorkspaceOnReadyTransition({
+      previousStatus: "provisioning",
+      nextStatus: "stale",
+      gatewayMode: true,
+    })).toBe(true);
+    expect(shouldRefetchCloudWorkspaceOnReadyTransition({
+      previousStatus: "waking",
+      nextStatus: "ready",
+      gatewayMode: false,
+    })).toBe(false);
+    expect(shouldRefetchCloudWorkspaceOnReadyTransition({
+      previousStatus: "ready",
+      nextStatus: "ready",
+      gatewayMode: true,
+    })).toBe(false);
   });
 });
 


### PR DESCRIPTION
Direct production feedback on #3233: while a sandbox was waking/recycling, the main area showed "Workspace or session not found" and the user never saw any boot state — the corner pill only said "Connected" after the fact. Their ask: "a nice loading screen similar to creating a workspace".

## What changes

- **Boot takeover** (gateway mode only): `provisioning / waking / updating` with no ready content now takes over the main content area — friendly status, progress affordance, same visual language as the existing loading surfaces. `failed` is an amber takeover with Retry + Sign out. The pill stays for steady state.
- **One poller**: pill and takeover share a `CloudWorkspaceStatusProvider`; no duplicate polling.
- **Stale error killed**: "Workspace or session not found" is gated on instance readiness — it can only render when the instance is `ready` and the workspace is genuinely missing. On the non-ready -> ready transition the workspace/session queries re-run automatically, so the app recovers without a reload (previously the error stuck).

Decision table: non-gateway -> always content (desktop untouched); gateway failed -> takeover; gateway waking/provisioning/updating -> takeover unless content already live; gateway ready -> content, or not-found only if truly missing.

## Tests

| Command | Result |
| --- | --- |
| `apps/app` full suite (incl. decision table, not-found gating, ready-refetch) | 493 pass / 0 fail |
| `tsc --noEmit` + `build:web` | clean |

## After deploy

Live proof planned: stop the canary sandbox, load the app during wake — expect the takeover (not the not-found error), then automatic recovery to the workspace on ready. Will be part of the fraimz run for #3233.