### PR TITLE
fix(den-api): converge concurrent wake starts instead of flashing failed

### DIFF
--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -88,6 +88,9 @@ export type DaytonaProvisioningRuntime = {
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms))
 const maxSignedPreviewExpirySeconds = 60 * 60 * 24
 const signedPreviewRefreshLeadMs = 5 * 60 * 1000
+const wakeStartMaxAttempts = 3
+const wakeStartRetryBackoffMs = 250
+const wakeStartStateChangeTimeoutMs = 60_000
 const logger = appLogger.child({ component: "daytona_provisioner" })
 
 const slug = (value: string) =>
@@ -227,6 +230,64 @@ function daytonaSandboxLookupNames(input: ProvisionInput) {
 
 function isStoppedSandboxState(state: string | null) {
   return state?.toLowerCase() === "stopped"
+}
+
+function isStartedSandboxState(state: string | null) {
+  return state?.toLowerCase() === "started"
+}
+
+function daytonaErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message.toLowerCase() : ""
+}
+
+function isDaytonaStateChangeInProgressConflict(error: unknown) {
+  const message = daytonaErrorMessage(error)
+  return isDaytonaConflictError(error) && message.includes("state change") && message.includes("progress")
+}
+
+function isTransientDaytonaStartError(error: unknown) {
+  const message = daytonaErrorMessage(error)
+  if (!message) {
+    return false
+  }
+
+  return /\b5\d\d\b/.test(message)
+    || [
+      "econnreset",
+      "econnrefused",
+      "etimedout",
+      "enotfound",
+      "fetch failed",
+      "network",
+      "socket hang up",
+      "temporarily unavailable",
+      "timeout",
+    ].some((marker) => message.includes(marker))
+}
+
+async function waitForDaytonaStartConflictToSettle(sandbox: DaytonaSandboxRuntime) {
+  const startedAt = Date.now()
+  let sawTransitionState = false
+
+  while (Date.now() - startedAt < wakeStartStateChangeTimeoutMs) {
+    await sandbox.refreshData()
+
+    if (isStartedSandboxState(sandbox.state)) {
+      return "started"
+    }
+
+    if (isStoppedSandboxState(sandbox.state) && (sawTransitionState || Date.now() - startedAt >= env.daytona.pollIntervalMs)) {
+      return "stopped"
+    }
+
+    if (!isStoppedSandboxState(sandbox.state)) {
+      sawTransitionState = true
+    }
+
+    await sleep(env.daytona.pollIntervalMs)
+  }
+
+  throw new Error(`Timed out waiting for Daytona sandbox ${sandbox.id} state change to settle`)
 }
 
 function sharedVolumeName() {
@@ -1040,6 +1101,41 @@ async function startOpenWorkOnDaytonaSandbox(input: {
   return provisionedInstance(input.provisionInput.workerId, input.sandbox.target, input.imageVersion)
 }
 
+async function startDaytonaSandboxForWake(input: { workerId: WorkerId; sandbox: DaytonaSandboxRuntime }) {
+  let lastError: unknown
+
+  for (let attempt = 1; attempt <= wakeStartMaxAttempts; attempt += 1) {
+    try {
+      await input.sandbox.start(env.daytona.createTimeoutSeconds)
+      return
+    } catch (error) {
+      lastError = error
+
+      if (isDaytonaStateChangeInProgressConflict(error)) {
+        logger.warn("Daytona sandbox start already in progress; waiting for convergence", { worker_id: input.workerId, sandbox_id: input.sandbox.id, error })
+        const settledState = await waitForDaytonaStartConflictToSettle(input.sandbox)
+        if (settledState === "started") {
+          return
+        }
+        continue
+      }
+
+      if (!isTransientDaytonaStartError(error) || attempt === wakeStartMaxAttempts) {
+        throw error
+      }
+
+      logger.warn("transient Daytona sandbox start failure; retrying", { worker_id: input.workerId, sandbox_id: input.sandbox.id, attempt, error })
+      await sleep(wakeStartRetryBackoffMs)
+      await input.sandbox.refreshData().catch(() => undefined)
+      if (isStartedSandboxState(input.sandbox.state)) {
+        return
+      }
+    }
+  }
+
+  throw lastError ?? new Error(`Daytona sandbox ${input.sandbox.id} start failed`)
+}
+
 function shouldRecycleDaytonaSandbox(input: { workerImageVersion: string | null; sandboxState: string | null }) {
   const imageVersion = currentDaytonaImageVersion()
   return Boolean(imageVersion && input.workerImageVersion !== imageVersion && isStoppedSandboxState(input.sandboxState))
@@ -1054,7 +1150,7 @@ async function wakeExistingDaytonaSandbox(input: {
   imageVersion?: string | null
 }) {
   if (isStoppedSandboxState(input.sandbox.state)) {
-    await input.sandbox.start(env.daytona.createTimeoutSeconds)
+    await startDaytonaSandboxForWake({ workerId: input.provisionInput.workerId, sandbox: input.sandbox })
   }
 
   return startOpenWorkOnDaytonaSandbox({

--- a/ee/apps/den-api/test/cloud-lifecycle.test.ts
+++ b/ee/apps/den-api/test/cloud-lifecycle.test.ts
@@ -1,5 +1,7 @@
+import { DaytonaConflictError } from "@daytonaio/sdk"
 import { createDenTypeId } from "@openwork-ee/utils/typeid"
 import { beforeAll, describe, expect, test } from "bun:test"
+import type { DaytonaProvisioningRuntime, DaytonaSandboxRuntime } from "../src/workers/daytona.js"
 
 type CloudLifecycleModule = typeof import("../src/workers/cloud-lifecycle.js")
 type DaytonaModule = typeof import("../src/workers/daytona.js")
@@ -84,6 +86,87 @@ function makeStore(input: { workers: TestWorker[]; tokens?: TestWorkerToken[] })
   }
 
   return { store, updates }
+}
+
+function makeDaytonaWakeRuntime(input: {
+  startError?: Error
+  refreshStates?: string[]
+} = {}) {
+  let state = "stopped"
+  let startCalls = 0
+  let refreshCalls = 0
+  let healthChecks = 0
+  const sandbox = {
+    id: "sbx_wake_test",
+    get state() {
+      return state
+    },
+    get target() {
+      return "us-test"
+    },
+    async refreshData() {
+      const refreshState = input.refreshStates?.[refreshCalls]
+      refreshCalls += 1
+      if (refreshState !== undefined) {
+        state = refreshState
+      }
+    },
+    async start() {
+      startCalls += 1
+      if (input.startError) {
+        throw input.startError
+      }
+      state = "started"
+    },
+    async delete() {},
+    async getSignedPreviewUrl() {
+      return { url: "https://wake.preview.example.test" }
+    },
+    process: {
+      async createSession() {},
+      async executeSessionCommand() {
+        return { cmdId: "cmd_1" }
+      },
+      async getSessionCommand() {
+        return { exitCode: null }
+      },
+      async getSessionCommandLogs() {
+        return { stdout: "", stderr: "" }
+      },
+    },
+  } satisfies DaytonaSandboxRuntime
+  const runtime = {
+    async getVolume() {
+      return { id: "vol_shared", state: "ready" }
+    },
+    async getSandbox() {
+      return sandbox
+    },
+    async createSandbox() {
+      throw new Error("unexpected sandbox create")
+    },
+    async upsertSandbox() {},
+    async checkpointExists() {
+      return false
+    },
+    async verifyRestoreMarker() {
+      return false
+    },
+    async waitForHealth() {
+      healthChecks += 1
+    },
+  } satisfies DaytonaProvisioningRuntime
+
+  return {
+    runtime,
+    record: { sandbox_id: sandbox.id, workspace_volume_id: "vol_shared", data_volume_id: "vol_shared" },
+    get startCalls() {
+      return startCalls
+    },
+    get healthChecks() {
+      return healthChecks
+    },
+  }
 }
 
 function deferred() {
@@ -240,6 +323,37 @@ describe("cloud lifecycle wake", () => {
     expect(worker.status).toBe("healthy")
   })
 
+  test("keeps a worker provisioning while a Daytona start conflict converges healthy", async () => {
+    const worker = makeWorker({ status: "stopped" })
+    const { store, updates } = makeStore({
+      workers: [worker],
+      tokens: [
+        makeToken(worker.id, "host"),
+        makeToken(worker.id, "client"),
+        makeToken(worker.id, "activity"),
+      ],
+    })
+    const wakeRuntime = makeDaytonaWakeRuntime({
+      startError: new DaytonaConflictError("Sandbox state change in progress"),
+      refreshStates: ["stopped", "started"],
+    })
+
+    await lifecycle.wakeCloudWorker(worker.id, {
+      store,
+      wakeWorker: (wakeInput) => daytona.wakeWorkerOnDaytonaWithRuntime(
+        wakeInput,
+        wakeRuntime.runtime,
+        wakeRuntime.record,
+        "openwork-0.18.8",
+      ),
+    })
+
+    expect(worker.status).toBe("healthy")
+    expect(wakeRuntime.startCalls).toBe(1)
+    expect(wakeRuntime.healthChecks).toBe(1)
+    expect(updates.map((update) => update.status)).toEqual(["provisioning", "healthy"])
+  })
+
   test("writes the image version returned by a successful Daytona wake", async () => {
     const worker = makeWorker({ status: "stopped" })
     const { store, updates } = makeStore({
@@ -294,6 +408,36 @@ describe("cloud lifecycle wake", () => {
     expect(wakeExecutions).toBe(1)
     expect(provisionExecutions).toBe(0)
     expect(worker.status).toBe("failed")
+  })
+
+  test("marks the worker failed after bounded Daytona start retries", async () => {
+    const worker = makeWorker({ status: "stopped" })
+    const { store, updates } = makeStore({
+      workers: [worker],
+      tokens: [
+        makeToken(worker.id, "host"),
+        makeToken(worker.id, "client"),
+        makeToken(worker.id, "activity"),
+      ],
+    })
+    const wakeRuntime = makeDaytonaWakeRuntime({
+      startError: new Error("Request failed with status code 502"),
+    })
+
+    await lifecycle.wakeCloudWorker(worker.id, {
+      store,
+      wakeWorker: (wakeInput) => daytona.wakeWorkerOnDaytonaWithRuntime(
+        wakeInput,
+        wakeRuntime.runtime,
+        wakeRuntime.record,
+        "openwork-0.18.8",
+      ),
+    })
+
+    expect(worker.status).toBe("failed")
+    expect(wakeRuntime.startCalls).toBe(3)
+    expect(wakeRuntime.healthChecks).toBe(0)
+    expect(updates.map((update) => update.status)).toEqual(["provisioning", "failed"])
   })
 
   test("falls back to full provisioning when the Daytona sandbox is missing during wake", async () => {

--- a/ee/apps/den-api/test/daytona-provisioning.test.ts
+++ b/ee/apps/den-api/test/daytona-provisioning.test.ts
@@ -40,10 +40,13 @@ function makeSandbox(input: {
   id: string
   state: string
   startError?: Error
+  startErrors?: Error[]
+  refreshStates?: string[]
 }) {
   let state = input.state
   let startCalls = 0
   let deleteCalls = 0
+  let refreshCalls = 0
   const sandbox = {
     id: input.id,
     get state() {
@@ -52,11 +55,18 @@ function makeSandbox(input: {
     get target() {
       return "us-test"
     },
-    async refreshData() {},
+    async refreshData() {
+      const refreshState = input.refreshStates?.[refreshCalls]
+      refreshCalls += 1
+      if (refreshState !== undefined) {
+        state = refreshState
+      }
+    },
     async start() {
       startCalls += 1
-      if (input.startError) {
-        throw input.startError
+      const startError = input.startErrors?.[startCalls - 1] ?? input.startError
+      if (startError) {
+        throw startError
       }
       state = "started"
     },
@@ -87,6 +97,9 @@ function makeSandbox(input: {
     },
     get deleteCalls() {
       return deleteCalls
+    },
+    get refreshCalls() {
+      return refreshCalls
     },
   }
 }
@@ -374,6 +387,81 @@ describe("Daytona Cloud version-aware recycle", () => {
     expect(old.startCalls).toBe(1)
     expect(old.deleteCalls).toBe(0)
     expect(runtime.upserts[0]?.sandboxId).toBe("sbx_current")
+  })
+})
+
+describe("Daytona Cloud wake start convergence", () => {
+  test("converges when a Daytona state-change conflict is already starting the sandbox", async () => {
+    const input = provisionInput()
+    const sandbox = makeSandbox({
+      id: "sbx_conflict_start",
+      state: "stopped",
+      startError: new DaytonaConflictError("Sandbox state change in progress"),
+      refreshStates: ["stopped", "started"],
+    })
+    const runtime = makeRuntime({
+      nameResultsByName: [{ name: "sbx_conflict_start", results: [sandbox.sandbox] }],
+    })
+
+    const result = await daytona.wakeWorkerOnDaytonaWithRuntime(
+      input,
+      runtime.runtime,
+      { sandbox_id: "sbx_conflict_start", workspace_volume_id: "vol_shared", data_volume_id: "vol_shared" },
+      "openwork-0.18.8",
+    )
+
+    expect(result.status).toBe("healthy")
+    expect(sandbox.startCalls).toBe(1)
+    expect(sandbox.refreshCalls).toBe(2)
+    expect(runtime.healthChecks).toBe(1)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_conflict_start")
+  })
+
+  test("retries a transient Daytona 502 during start before waking the sandbox", async () => {
+    const input = provisionInput()
+    const sandbox = makeSandbox({
+      id: "sbx_transient_start",
+      state: "stopped",
+      startErrors: [new Error("Request failed with status code 502")],
+    })
+    const runtime = makeRuntime({
+      nameResultsByName: [{ name: "sbx_transient_start", results: [sandbox.sandbox] }],
+    })
+
+    const result = await daytona.wakeWorkerOnDaytonaWithRuntime(
+      input,
+      runtime.runtime,
+      { sandbox_id: "sbx_transient_start", workspace_volume_id: "vol_shared", data_volume_id: "vol_shared" },
+      "openwork-0.18.8",
+    )
+
+    expect(result.status).toBe("healthy")
+    expect(sandbox.startCalls).toBe(2)
+    expect(runtime.healthChecks).toBe(1)
+    expect(runtime.upserts[0]?.sandboxId).toBe("sbx_transient_start")
+  })
+
+  test("bounds persistent transient Daytona start failures", async () => {
+    const input = provisionInput()
+    const sandbox = makeSandbox({
+      id: "sbx_persistent_start_failure",
+      state: "stopped",
+      startError: new Error("Request failed with status code 502"),
+    })
+    const runtime = makeRuntime({
+      nameResultsByName: [{ name: "sbx_persistent_start_failure", results: [sandbox.sandbox] }],
+    })
+
+    await expect(daytona.wakeWorkerOnDaytonaWithRuntime(
+      input,
+      runtime.runtime,
+      { sandbox_id: "sbx_persistent_start_failure", workspace_volume_id: "vol_shared", data_volume_id: "vol_shared" },
+      "openwork-0.18.8",
+    )).rejects.toThrow("Request failed with status code 502")
+
+    expect(sandbox.startCalls).toBe(3)
+    expect(runtime.healthChecks).toBe(0)
+    expect(runtime.upserts).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
Watching a live wake in production: the boot takeover showed "Waking your workspace…", flashed amber "We couldn't start the sandbox" at ~t+9s, and the worker converged healthy seconds later anyway. den-api logs at that moment:

```
DaytonaConflictError: "Sandbox state change in progress"
DaytonaError: Request failed with status code 502
```

A page load fires several resolves; one wake starts the sandbox, a concurrent one calls start() mid-transition and gets a 409, plus a transient Daytona 502 — and the wake path treated both as terminal, writing `failed`. Same disease as the create-conflict bug (#3219): "this is already happening" treated as failure.

## Fix

- State-change-in-progress conflicts: don't mark failed — poll the sandbox state (bounded, 60s cap at the existing poll interval) until it settles, then continue the normal wake flow. Another actor is doing the work; converge on the outcome.
- Transient 5xx/network on start(): 3 attempts with short backoff before declaring failure.
- Genuine failures still mark `failed` within the existing bounds; race-safe status writes and recycle semantics unchanged; all waits bounded.

## Tests

51 pass / 0 fail across cloud-lifecycle, daytona-provisioning, cloud-instance-route — including: conflict convergence never writes `failed`, single-502-then-success converges, persistent failure still bounded-fails. tsc clean.