### PR TITLE
fix: Resolve Windows Automations not mapping to workspace in UI

### DIFF
--- a/apps/server/src/connect-state.test.ts
+++ b/apps/server/src/connect-state.test.ts
@@ -7,6 +7,7 @@ import { OPENWORK_CLOUD_EXPECTED_TOOLS, OPENWORK_CLOUD_PLUGIN_CANARIES } from ".
 import { writeRuntimeOpencodeConfig } from "./runtime-opencode-config-store.js";
 import { startServer } from "./server.js";
 import type { ServerConfig, WorkspaceInfo } from "./types.js";
+import { closeWorkspaceKvDbsForTests } from "./workspace-kv-store.js";
 
 const CLIENT_TOKEN = "owt_connect_state_client";
 const HOST_TOKEN = "owt_connect_state_host";
@@ -16,6 +17,7 @@ const roots: string[] = [];
 
 afterEach(async () => {
   while (stops.length) await stops.pop()?.();
+  await closeWorkspaceKvDbsForTests();
   while (roots.length) await rm(roots.pop() ?? "", { recursive: true, force: true });
   if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
   else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
@@ -167,5 +169,23 @@ describe("connect state Cloud health scoping", () => {
     expect(unknown.cloudMcpPresent).toBe(false);
     expect(unknown.cloudHealth).toBeNull();
     expect(requireRecord(unknown.workspace, "workspace").resolution).toBe("unknown");
+
+    // Test Windows-specific path variations
+    const rootAUpper = rootA.toUpperCase();
+    const rootABackslashes = rootA.replace(/\//g, "\\");
+    const rootATrailingSlash = rootABackslashes.endsWith("\\") ? rootABackslashes : rootABackslashes + "\\";
+    const rootAExtendedLength = "\\\\?\\" + rootABackslashes;
+
+    const upperRes = await responseRecord(await fetch(`${openwork.base}/experimental/connect/state?directory=${encodeURIComponent(rootAUpper)}`, { headers: clientHeaders() }));
+    expect(requireRecord(upperRes.workspace, "workspace").id).toBe("ws_a");
+
+    const backslashesRes = await responseRecord(await fetch(`${openwork.base}/experimental/connect/state?directory=${encodeURIComponent(rootABackslashes)}`, { headers: clientHeaders() }));
+    expect(requireRecord(backslashesRes.workspace, "workspace").id).toBe("ws_a");
+
+    const trailingSlashRes = await responseRecord(await fetch(`${openwork.base}/experimental/connect/state?directory=${encodeURIComponent(rootATrailingSlash)}`, { headers: clientHeaders() }));
+    expect(requireRecord(trailingSlashRes.workspace, "workspace").id).toBe("ws_a");
+
+    const extendedLengthRes = await responseRecord(await fetch(`${openwork.base}/experimental/connect/state?directory=${encodeURIComponent(rootAExtendedLength)}`, { headers: clientHeaders() }));
+    expect(requireRecord(extendedLengthRes.workspace, "workspace").id).toBe("ws_a");
   });
 });

--- a/apps/server/src/connect-state.ts
+++ b/apps/server/src/connect-state.ts
@@ -196,7 +196,14 @@ export async function writeConnectCloudMcp(
 }
 
 function normalizeDirectory(directory: string): string {
-  return directory.trim().replace(/[\/]+$/, "");
+  let cleaned = directory.trim();
+  if (process.platform === "win32") {
+    cleaned = cleaned.replace(/^\\\\\?\\/, "").replace(/^\/\/\?\//, "");
+    cleaned = cleaned.replace(/\\/g, "/").toLowerCase();
+  } else {
+    cleaned = cleaned.replace(/\/+$/, "");
+  }
+  return cleaned.replace(/\/+$/, "");
 }
 
 function workspaceDirectory(workspace: WorkspaceInfo, resolveOpencodeDirectory?: (workspace: WorkspaceInfo) => string | null): string | null {

--- a/apps/server/src/workspace-kv-store.ts
+++ b/apps/server/src/workspace-kv-store.ts
@@ -241,3 +241,19 @@ export function workspaceKvStoreCacheStatsForTests(path: string): { connectionEn
     tableEntries: tableDbByPath.get(path)?.size ?? 0,
   };
 }
+
+export async function closeWorkspaceKvDbsForTests(): Promise<void> {
+  for (const [path, dbPromise] of dbByPath.entries()) {
+    try {
+      const db = await dbPromise;
+      db.close();
+    } catch {
+      // ignore
+    }
+  }
+  dbByPath.clear();
+  tableDbByPath.clear();
+  if (typeof Bun !== "undefined") {
+    Bun.gc(true);
+  }
+}


### PR DESCRIPTION
## Summary
- Normalizes directory paths inside `resolveConnectWorkspace` to match workspaces correctly on Windows.
- Adds teardown capability in `workspace-kv-store.ts` to release SQLite database file handles on Windows during test teardown.

## Why
- Background scheduled automation runs and CLI executions on Windows use standard Windows directory formats (backslashes, casing).
- The Electron UI registers workspaces with forward slashes, extended-length path prefixes (`\\?\`), or different casing.
- This format discrepancy fails the server's path-matching logic, meaning background automation runs execute but are never linked to their workspace in the UI.

## Issue
- Closes #1533

## Scope
- Directory path normalization in `apps/server/src/connect-state.ts`'s `normalizeDirectory`.
- Database hook/teardown adjustments in `workspace-kv-store.ts`.
- Additional unit tests inside `connect-state.test.ts`.

## Out of scope
- Modifying how the desktop UI registers workspaces or how the Task Scheduler invokes execution commands directly.

## Testing
### Ran
- `bun test src/connect-state.test.ts` (run in `apps/server`)

### Result
- pass/fail: pass

## CI status
- pass: N/A (local runner only)
- code-related failures: None
- external/env/auth blockers: None

## Manual verification
1. Start the server locally on Windows.
2. Query `/experimental/connect/state?directory=<path>` with varied casing, backslashes, trailing slashes, and `\\?\` prefixes matching a workspace root.
3. Verify that the response returns the matching workspace metadata rather than `resolution: "unknown"`.

## Evidence
- Unit test passing output:
src\connect-state.test.ts: Reload watcher enabled (2) (pass) connect state Cloud health scoping > uses verified health for the exact requested directory without borrowing another workspace [250.00ms]

## Risk
- Low. Path normalization changes are scoped entirely to workspace retrieval matching logic.
## Rollback
- Revert changes to `apps/server/src/connect-state.ts`, `workspace-kv-store.ts`, and `connect-state.test.ts`.