### PR TITLE
feat(extensions): denser default list view for the inventory

### DIFF
--- a/apps/app/src/react-app/design-system/extension-card.tsx
+++ b/apps/app/src/react-app/design-system/extension-card.tsx
@@ -1,5 +1,5 @@
 /** @jsxImportSource react */
-import { AlertCircle, CheckCircle2, Loader2 } from "lucide-react";
+import { AlertCircle, CheckCircle2, ChevronRight, Loader2 } from "lucide-react";
 import type { EnablementResult } from "../../app/extensions";
 import { t } from "../../i18n";
 import {
@@ -99,7 +99,8 @@ function ExtensionIcon(props: {
           />
         )}
       </div>
-      {props.readiness === "ready" ? (
+      {/* In the dense list, readiness lives as a dot next to the name instead of a corner overlay. */}
+      {props.compact ? null : props.readiness === "ready" ? (
         <div className="absolute -bottom-0.5 -right-0.5 flex size-4 items-center justify-center rounded-full border-2 border-dls-surface bg-green-9">
           <CheckCircle2 size={9} className="text-white" strokeWidth={3} />
         </div>
@@ -240,27 +241,59 @@ export function ExtensionCard(props: ExtensionCardProps) {
   ) : null;
 
   if (layout === "list") {
+    // Dense single-line row. Readiness is carried by the group header and a
+    // small dot; the per-row badge only says what kind of extension this is.
     return (
       <button
         type="button"
         disabled={disabled || connecting}
         onClick={onClick}
-        className={`${shellClassName} flex items-center gap-3 rounded-lg px-3 py-2`}
+        className={`group flex w-full items-center gap-3 px-3.5 py-2 text-left transition-colors hover:bg-dls-hover ${hidden ? "opacity-60" : ""}`}
       >
         {icon}
-        <div className="min-w-0 flex-1">
-          <div className="flex flex-wrap items-center gap-1.5">
-            <h4 className="min-w-0 truncate text-sm font-semibold text-dls-text">{name}</h4>
-            {badges}
-          </div>
-          <p className="truncate text-xs text-dls-secondary">
-            {disabledReason ?? description}
-          </p>
+        <div className="flex w-44 shrink-0 items-center gap-1.5">
+          <h4 className="min-w-0 truncate text-[13px] font-medium text-dls-text">{name}</h4>
+          {readiness === "ready" ? (
+            <span className="size-1.5 shrink-0 rounded-full bg-green-9" />
+          ) : readiness === "partial" ? (
+            <span className="size-1.5 shrink-0 rounded-full bg-amber-9" />
+          ) : null}
         </div>
-        {meta ? (
-          <div className="hidden shrink-0 text-[11px] text-dls-secondary sm:block">{meta}</div>
+        <div className="flex w-20 shrink-0 items-center">
+          <span className="rounded-md bg-dls-hover px-1.5 py-0.5 text-[10px] font-medium text-dls-secondary">
+            {extensionTaxonomyLabel(taxonomy)}
+          </span>
+        </div>
+        <p className="hidden min-w-0 flex-1 truncate text-xs text-dls-secondary sm:block">
+          {disabledReason ?? description}
+        </p>
+        {preview ? (
+          <span className="shrink-0 rounded-md bg-blue-3 px-1.5 py-0.5 text-[10px] font-medium text-blue-11">
+            Preview
+          </span>
         ) : null}
-        {nextAction ? <div className="shrink-0">{nextAction}</div> : null}
+        {beta ? (
+          <span className="shrink-0 rounded-md bg-amber-3 px-1.5 py-0.5 text-[10px] font-medium text-amber-11">
+            {t("common.beta")}
+          </span>
+        ) : null}
+        {meta ? (
+          <div className="hidden shrink-0 text-[11px] text-dls-secondary md:block">{meta}</div>
+        ) : null}
+        {!disabledReason && !connecting && nextActionLabel ? (
+          <span
+            className="inline-flex h-7 shrink-0 items-center rounded-lg border border-dls-border px-3 text-xs font-medium text-dls-text transition-colors group-hover:border-dls-secondary/40"
+            onClick={(event) => {
+              if (!onNextAction) return;
+              event.stopPropagation();
+              onNextAction();
+            }}
+          >
+            {nextActionLabel}
+          </span>
+        ) : (
+          <ChevronRight size={14} className="shrink-0 text-dls-secondary" />
+        )}
       </button>
     );
   }

--- a/apps/app/src/react-app/domains/settings/extension-state.ts
+++ b/apps/app/src/react-app/domains/settings/extension-state.ts
@@ -7,10 +7,10 @@ const EXTENSION_ENABLED_KEY_PREFIX = "openwork.extension.enabled.";
 const EXTENSION_HIDDEN_KEY_PREFIX = "openwork.extension.hidden.";
 export const OPENWORK_EXTENSION_STATE_CHANGED = "openwork:extension-state-changed";
 
-/** Whether the inventory shows tiles or dense rows. Remembered across sessions. */
+/** Whether the inventory shows tiles or dense rows. Remembered across sessions; defaults to the dense list. */
 export function readExtensionLayout(): ExtensionLayout {
-  if (typeof window === "undefined") return "grid";
-  return window.localStorage.getItem(EXTENSION_LAYOUT_KEY) === "list" ? "list" : "grid";
+  if (typeof window === "undefined") return "list";
+  return window.localStorage.getItem(EXTENSION_LAYOUT_KEY) === "grid" ? "grid" : "list";
 }
 
 export function writeExtensionLayout(layout: ExtensionLayout) {

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -1400,7 +1400,7 @@ function McpQuickConnectSection(props: {
           {[0, 1, 2].map((index) => (
             <Skeleton
               key={index}
-              className={props.layout === "list" ? "h-[52px] rounded-lg" : "h-[104px] rounded-xl"}
+              className={props.layout === "list" ? "h-[42px] rounded-lg" : "h-[104px] rounded-xl"}
             />
           ))}
         </div>
@@ -1424,7 +1424,14 @@ function McpQuickConnectSection(props: {
               count={groupCards.length}
               hint={group === "available" ? t("extensions.group_ready_to_set_up_hint") : undefined}
             />
-            <div className={props.layout === "list" ? "flex flex-col gap-2" : "grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3"}>
+            {/* List mode: one quiet container per readiness group, rows divided by hairlines. */}
+            <div
+              className={
+                props.layout === "list"
+                  ? "overflow-hidden rounded-xl border border-dls-border bg-dls-surface [&>div+div]:border-t [&>div+div]:border-dls-border/60"
+                  : "grid grid-cols-[repeat(auto-fill,minmax(min(100%,20rem),1fr))] gap-3"
+              }
+            >
               {groupCards.map((card) => (
                 <div key={card.key}>{card.node}</div>
               ))}


### PR DESCRIPTION
## What

Reworks the Extensions inventory list mode per the Paper design ("13 — Extensions · List Rework") and makes it the default layout.

- **List is the default** — grid is still one click away and remembered if chosen (`openwork.extensions.layout`).
- **One quiet container per readiness group** — flat single-line rows with hairline dividers instead of a stack of individually tinted cards (~46px/row vs ~70px+gap).
- **Row anatomy**: icon tile / name in a fixed lane with a small green/amber status dot / taxonomy tag pill (App · Connection · MCP · Skill · Plugin) / truncated description / source meta ("This device" / cloud) / action.
- **Redundant per-row readiness badges dropped** in list mode — the section header ("Ready to use", "Needs your sign-in") already carries the status. Sign-in/connect actions render as a bordered chip, details as a chevron.
- **Grid layout unchanged**; `cloud-marketplaces-view` uses grid only and is unaffected.

## Design

Paper file "OpenWork Extensions — Latest", artboard *13 — Extensions · List Rework*.

## Evidence

| Before (list mode) | After (new default list) | Grid (unchanged) |
| --- | --- | --- |
| ![before](https://litter.catbox.moe/vq12kl.png) | ![after](https://litter.catbox.moe/86krvl.png) | ![grid](https://litter.catbox.moe/qadorf.png) |

Validated live in the Electron dev app (isolated profile) via CDP: fresh profile defaults to list, rows render grouped with tags/chips/chevrons, grid toggle still works and persists.

## Tests

- `pnpm exec tsc --noEmit` (apps/app) — pass
- `bun test --isolate tests/` (apps/app) — 493 pass, 0 fail
- `pnpm --filter @openwork/app build` — pass

Note: org-provided connections/skills did not sync in the validation profile during screenshots (cloud inventory environmental issue, unrelated); those rows render through the same `ExtensionCard` list branch shown.

Made with [Cursor](https://cursor.com)