### PR TITLE
feat(inference): add Claude Fable 5 to OpenWork models

### DIFF
--- a/ee/apps/inference/src/models/openwork-models.json
+++ b/ee/apps/inference/src/models/openwork-models.json
@@ -297,5 +297,52 @@
       "output": 15,
       "cache_read": 0.3
     }
+  },
+  "anthropic/claude-fable-5": {
+    "id": "anthropic/claude-fable-5",
+    "name": "Claude Fable 5",
+    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
+    "family": "claude-fable",
+    "attachment": true,
+    "reasoning": true,
+    "reasoning_options": [
+      {
+        "type": "effort",
+        "values": [
+          "low",
+          "medium",
+          "high",
+          "xhigh",
+          "max"
+        ]
+      }
+    ],
+    "tool_call": true,
+    "structured_output": true,
+    "temperature": false,
+    "knowledge": "2026-01-31",
+    "release_date": "2026-06-09",
+    "last_updated": "2026-06-09",
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "pdf"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": false,
+    "limit": {
+      "context": 1000000,
+      "output": 128000
+    },
+    "cost": {
+      "input": 10,
+      "output": 50,
+      "cache_read": 1,
+      "cache_write": 12.5
+    }
   }
 }

--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -54,12 +54,6 @@ export const INFERENCE_WINDOW_DURATIONS_MS: Record<
 // For upstreamModel values, please get from models.dev/api.json provider = openrouter.models.id
 
 export const INFERENCE_MODEL_ALIASES = {
-  "moonshotai/kimi-k3": {
-    upstreamModel: "moonshotai/kimi-k3",
-    displayName: "OpenWork: Kimi K3",
-    enabled: true,
-    usageFactor: 1,
-  },
   "z-ai/glm-5.2": {
     upstreamModel: "z-ai/glm-5.2",
     displayName: "OpenWork: GLM-5.2",
@@ -105,6 +99,18 @@ export const INFERENCE_MODEL_ALIASES = {
   "z-ai/glm-5.1": {
     upstreamModel: "z-ai/glm-5.1",
     displayName: "OpenWork: GLM-5.1",
+    enabled: true,
+    usageFactor: 1,
+  },
+  "moonshotai/kimi-k3": {
+    upstreamModel: "moonshotai/kimi-k3",
+    displayName: "OpenWork: Kimi K3",
+    enabled: true,
+    usageFactor: 1,
+  },
+  "anthropic/claude-fable-5": {
+    upstreamModel: "anthropic/claude-fable-5",
+    displayName: "OpenWork: Claude Fable 5",
     enabled: true,
     usageFactor: 1,
   },


### PR DESCRIPTION
Users on current instances (0.18.8, providers syncing correctly) reported Fable missing from the OpenWork Models picker. Root cause: `anthropic/claude-fable-5` exists in the upstream base catalog but was never added to the curated `openwork-models.json` — provider sync was faithfully delivering a catalog that didn't contain it.

Added via the documented `openwork-models` skill add-workflow: full model block copied from the upstream base, alias generated with the standard shape (`displayName: "OpenWork: Claude Fable 5"`, `usageFactor: 1`, `enabled: true`), aliases synced into `packages/types/src/den/inference.ts`.

Deliberately NOT added: `~anthropic/claude-fable-latest` (the tilde-prefixed rolling alias) — no other tilde entries exist in the curated list, so pinning the concrete model follows the existing convention.

| Check | Result |
| --- | --- |
| `openwork-models.mjs validate` | 10 OpenWork models validated |
| `ee/apps/inference/scripts/build-models.mjs` | generated cleanly (prod URL) |

After merge + inference deploy: verify the live catalog serves it and it appears in the web picker.