### PR TITLE
fix(den-web): resume reaccepted organization invites

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
+++ b/ee/apps/den-web/app/(den)/_components/join-org-screen.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { useRouter } from "next/navigation";
-import { useEffect, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useRef, useState, type ReactNode } from "react";
 import { getErrorMessage, requestJson } from "../_lib/den-flow";
 import {
   PENDING_ORG_INVITATION_STORAGE_KEY,
@@ -162,6 +162,8 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
   const [joinBusy, setJoinBusy] = useState(false);
   const [joinError, setJoinError] = useState<string | null>(null);
   const [joinedOrg, setJoinedOrg] = useState<JoinedOrg | null>(null);
+  const [unavailableAcceptedInviteId, setUnavailableAcceptedInviteId] = useState<string | null>(null);
+  const acceptedInviteResolutionKey = useRef<string | null>(null);
 
   const invitedEmailMatches = preview && user
     ? preview.invitation.email.trim().toLowerCase() === user.email.trim().toLowerCase()
@@ -237,18 +239,18 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
     };
   }, [invitationId]);
 
-  function clearPendingInvitation() {
+  const clearPendingInvitation = useCallback(() => {
     if (typeof window !== "undefined") {
       window.sessionStorage.removeItem(PENDING_ORG_INVITATION_STORAGE_KEY);
     }
-  }
+  }, []);
 
   function handleNotNow() {
     clearPendingInvitation();
     router.replace("/");
   }
 
-  async function handleAcceptInvitation() {
+  const acceptInvitation = useCallback(async (options: { silentUnavailable?: boolean } = {}) => {
     if (!invitationId) {
       setJoinError("Missing invitation link.");
       return;
@@ -272,6 +274,13 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
       );
 
       if (!response.ok) {
+        if (options.silentUnavailable && response.status === 404) {
+          setUnavailableAcceptedInviteId(invitationId);
+          return;
+        }
+        if (options.silentUnavailable) {
+          setUnavailableAcceptedInviteId(invitationId);
+        }
         setJoinError(getErrorMessage(payload, response.status === 404 ? "This invite could not be accepted." : `Could not join the organization (${response.status}).`));
         return;
       }
@@ -287,11 +296,34 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
         brand: preview.organization.branding,
       });
     } catch (error) {
+      if (options.silentUnavailable) {
+        setUnavailableAcceptedInviteId(invitationId);
+      }
       setJoinError(error instanceof Error ? error.message : "Could not join the organization.");
     } finally {
       setJoinBusy(false);
     }
+  }, [clearPendingInvitation, invitationId, preview]);
+
+  function handleAcceptInvitation() {
+    void acceptInvitation();
   }
+
+  useEffect(() => {
+    if (
+      !sessionHydrated
+      || !user
+      || !preview
+      || preview.invitation.status !== "accepted"
+      || !invitedEmailMatches
+      || acceptedInviteResolutionKey.current === invitationId
+    ) {
+      return;
+    }
+
+    acceptedInviteResolutionKey.current = invitationId;
+    void acceptInvitation({ silentUnavailable: true });
+  }, [acceptInvitation, invitationId, invitedEmailMatches, preview, sessionHydrated, user]);
 
   async function handleSwitchAccount() {
     await signOut();
@@ -316,6 +348,16 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
         onContinueInBrowser={() => router.replace(joinedOrg.slug ? getOrgDashboardRoute(joinedOrg.slug) : "/dashboard")}
       />
     );
+  }
+
+  if (
+    preview
+    && preview.invitation.status === "accepted"
+    && user
+    && invitedEmailMatches
+    && unavailableAcceptedInviteId !== invitationId
+  ) {
+    return <LoadingState />;
   }
 
   if (!preview) {
@@ -470,7 +512,7 @@ export function JoinOrgScreen({ invitationId }: { invitationId: string }) {
               <button
                 type="button"
                 className="den-button-primary w-full focus:outline-none focus:ring-4 focus:ring-slate-950/10 sm:w-auto"
-                onClick={() => void handleAcceptInvitation()}
+                onClick={handleAcceptInvitation}
                 disabled={!showAcceptAction || joinBusy}
               >
                 {joinBusy ? "Joining..." : `Join ${preview.organization.name}`}

--- a/ee/apps/den-web/tests/join-org-invite-clean.test.ts
+++ b/ee/apps/den-web/tests/join-org-invite-clean.test.ts
@@ -116,6 +116,15 @@ describe("join organization invite clean layout contract", () => {
     expect(source).toContain("Join ${preview.organization.name}");
   });
 
+  test("resolves an invite accepted during sign-in before showing it as already used", () => {
+    const source = readJoinOrgScreenSource();
+
+    expect(source).toContain('preview.invitation.status !== "accepted"');
+    expect(source).toContain("acceptedInviteResolutionKey.current === invitationId");
+    expect(source).toContain("acceptInvitation({ silentUnavailable: true })");
+    expect(source).toContain("unavailableAcceptedInviteId !== invitationId");
+  });
+
   test("carries explicit organization branding through the invitation preview", () => {
     const preview = parseInvitationPreviewPayload({
       invitation: {


### PR DESCRIPTION
## Summary

- resume a freshly re-added member's invitation when single-organization sign-in accepted it during membership bootstrap
- show the normal joined-success step after confirming the signed-in user still has the accepted membership
- preserve the existing unavailable state for genuinely old or already-used invite links
- add a focused Den Web regression contract for the accepted-during-sign-in handoff

## Root cause

In single-organization deployments, authentication bootstrap can accept a pending invitation before the join page finishes the sign-in flow. When the page reloaded the invitation preview, it saw `accepted` and rendered “This invite has already been used,” even though that acceptance had just re-added the current user.

The join page now resolves that accepted state through the existing idempotent invitation-accept endpoint. A live membership proceeds to the standard success screen; a missing membership keeps the existing unavailable-invite behavior.

## Checks

Checks not run (level 0, per the requested/default verification scope). `git diff --check` passed.

## Manual verification

1. In a single-organization deployment, remove an existing non-owner member.
2. Invite the same email address again and open the new invitation link.
3. Sign in with that existing account.
4. Confirm the flow reaches the normal “You’re in” success step without briefly showing “This invite has already been used.”
5. Open an older accepted invite for an account without a live membership and confirm it still shows the unavailable/already-used state.

## Risk and untested paths

The change is limited to Den Web invitation-state handling. The live single-organization re-add journey and other authentication methods were not exercised automatically or manually in this pass.
