### PR TITLE
revert(inference): remove Claude Fable 5 from OpenWork models

### DIFF
--- a/ee/apps/inference/src/models/openwork-models.json
+++ b/ee/apps/inference/src/models/openwork-models.json
@@ -297,52 +297,5 @@
       "output": 15,
       "cache_read": 0.3
     }
-  },
-  "anthropic/claude-fable-5": {
-    "id": "anthropic/claude-fable-5",
-    "name": "Claude Fable 5",
-    "description": "Claude model for creative writing, analysis, and controlled agent workflows",
-    "family": "claude-fable",
-    "attachment": true,
-    "reasoning": true,
-    "reasoning_options": [
-      {
-        "type": "effort",
-        "values": [
-          "low",
-          "medium",
-          "high",
-          "xhigh",
-          "max"
-        ]
-      }
-    ],
-    "tool_call": true,
-    "structured_output": true,
-    "temperature": false,
-    "knowledge": "2026-01-31",
-    "release_date": "2026-06-09",
-    "last_updated": "2026-06-09",
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "pdf"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": false,
-    "limit": {
-      "context": 1000000,
-      "output": 128000
-    },
-    "cost": {
-      "input": 10,
-      "output": 50,
-      "cache_read": 1,
-      "cache_write": 12.5
-    }
   }
 }

--- a/packages/types/src/den/inference.ts
+++ b/packages/types/src/den/inference.ts
@@ -108,12 +108,6 @@ export const INFERENCE_MODEL_ALIASES = {
     enabled: true,
     usageFactor: 1,
   },
-  "anthropic/claude-fable-5": {
-    upstreamModel: "anthropic/claude-fable-5",
-    displayName: "OpenWork: Claude Fable 5",
-    enabled: true,
-    usageFactor: 1,
-  },
 } as const;
 
 export type InferenceModelAlias = keyof typeof INFERENCE_MODEL_ALIASES;


### PR DESCRIPTION
Reverts #3241. That change was wrong: Fable does not belong in the managed OpenWork Models catalog. Back to 9 models, validated, catalog regenerated.

Context: a user reported Fable missing in the web app but present on desktop. I misdiagnosed it as a catalog gap and added the model. The actual setup is a **custom inference provider configured at the Cloud/org level**, and the real bug is that org-assigned LLM providers are not reaching the web (gateway) instance while they do reach desktop. Chasing that separately; this revert removes the incorrect catalog change from production.