### PR TITLE
feat(den-web): align onboarding layout with the Paper design

### DIFF
--- a/ee/apps/den-web/app/(den)/_components/ui/choice-card.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/choice-card.tsx
@@ -5,7 +5,13 @@ import { buttonVariants } from "./button";
 export type DenChoiceCardProps = {
   icon: ReactNode;
   title: string;
+  /** Short qualifier rendered under the title (e.g. "Your providers, your billing"). */
+  subtitle?: string;
+  /** Right-aligned slot in the header row (e.g. a "Recommended" badge). */
+  badge?: ReactNode;
   description: string;
+  /** Extra content between the description and the CTA (e.g. provider logos). */
+  children?: ReactNode;
   href: string;
   ctaLabel: string;
   ctaVariant?: "primary" | "secondary";
@@ -19,7 +25,10 @@ export type DenChoiceCardProps = {
 export function DenChoiceCard({
   icon,
   title,
+  subtitle,
+  badge,
   description,
+  children,
   href,
   ctaLabel,
   ctaVariant = "primary",
@@ -28,16 +37,21 @@ export function DenChoiceCard({
   return (
     <div
       data-testid={testId}
-      className="flex h-full flex-col gap-5 rounded-[28px] border border-gray-200 bg-white p-6"
+      className="flex h-full flex-col gap-4 rounded-[18px] border border-gray-200 bg-white p-5"
     >
-      <div className="flex h-10 w-10 items-center justify-center rounded-[12px] border border-gray-100 bg-gray-50">
-        {icon}
+      <div className="flex items-center gap-3">
+        <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[11px] border border-gray-100 bg-gray-50">
+          {icon}
+        </div>
+        <div className="min-w-0">
+          <h3 className="text-[15px] font-semibold tracking-[-0.02em] text-gray-950">{title}</h3>
+          {subtitle ? <p className="mt-0.5 text-[13px] leading-4 text-gray-400">{subtitle}</p> : null}
+        </div>
+        {badge ? <div className="ml-auto shrink-0">{badge}</div> : null}
       </div>
-      <div className="min-w-0 flex-1">
-        <h3 className="text-[16px] font-medium tracking-[-0.02em] text-gray-950">{title}</h3>
-        <p className="mt-2 text-[13px] leading-6 text-gray-500">{description}</p>
-      </div>
-      <Link href={href} className={buttonVariants({ variant: ctaVariant })}>
+      <p className="text-[13px] leading-[21px] text-gray-500">{description}</p>
+      {children}
+      <Link href={href} className={buttonVariants({ variant: ctaVariant, className: "mt-auto" })}>
         {ctaLabel}
       </Link>
     </div>

--- a/ee/apps/den-web/app/(den)/_components/ui/section-header.tsx
+++ b/ee/apps/den-web/app/(den)/_components/ui/section-header.tsx
@@ -5,12 +5,18 @@ export type DenSectionHeaderProps = {
   description?: ReactNode;
   /** Right-aligned slot for the section's primary action. */
   action?: ReactNode;
+  /** "center" stacks the header and centers text (used on onboarding). */
+  align?: "start" | "center";
   className?: string;
 };
 
-export function DenSectionHeader({ title, description, action, className = "" }: DenSectionHeaderProps) {
+export function DenSectionHeader({ title, description, action, align = "start", className = "" }: DenSectionHeaderProps) {
+  const layout =
+    align === "center"
+      ? "flex flex-col items-center gap-2 text-center"
+      : "flex flex-wrap items-start justify-between gap-4";
   return (
-    <div className={`flex flex-wrap items-start justify-between gap-4 ${className}`}>
+    <div className={`${layout} ${className}`}>
       <div className="min-w-0">
         <h2 className="text-[16px] font-medium tracking-[-0.02em] text-gray-950">{title}</h2>
         {description ? <p className="mt-1 text-[13px] leading-6 text-gray-500">{description}</p> : null}

--- a/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-logos.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/llm-provider-logos.tsx
@@ -35,19 +35,19 @@ const PROVIDER_LOGOS: { name: string; color: string; path: string }[] = [
 
 export function LlmProviderLogos() {
   return (
-    <div className="flex flex-wrap items-center gap-2">
+    <div className="flex flex-wrap items-center gap-1.5">
       {PROVIDER_LOGOS.map((provider) => (
         <div
           key={provider.name}
           title={provider.name}
-          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-[10px] border border-gray-100 bg-white shadow-sm"
+          className="flex h-7 w-7 shrink-0 items-center justify-center rounded-lg border border-gray-100 bg-white"
         >
-          <svg viewBox="0 0 24 24" role="img" aria-label={provider.name} fill={provider.color} className="h-4 w-4">
+          <svg viewBox="0 0 24 24" role="img" aria-label={provider.name} fill={provider.color} className="h-3.5 w-3.5">
             <path d={provider.path} />
           </svg>
         </div>
       ))}
-      <span className="text-[12px] font-medium text-gray-500">+ more</span>
+      <span className="ml-0.5 text-[13px] text-gray-400">and every models.dev provider</span>
     </div>
   );
 }

--- a/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/marketplace-onboarding-screen.tsx
@@ -15,6 +15,7 @@ import {
 } from "../../_lib/den-org";
 import { requestJson } from "../../_lib/den-flow";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
+import { LlmProviderLogos } from "./llm-provider-logos";
 
 const APP_INSTALLED_KEY = "openwork:onboarding:app-installed";
 
@@ -81,53 +82,49 @@ export function MarketplaceOnboardingScreen({
   const requiredDone = appInstalled && modelsEnabled;
 
   return (
-    <div className="mx-auto max-w-3xl px-4 pb-12 pt-8 sm:px-6" data-testid="marketplace-onboarding">
-      <header className="max-w-xl">
-        <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-gray-500">Get started</p>
-        <h1 className="mt-3 text-[28px] font-semibold leading-[1.1] tracking-[-0.04em] text-gray-950 sm:text-[32px]">
+    <div className="mx-auto max-w-4xl px-4 pb-16 pt-12 sm:px-6" data-testid="marketplace-onboarding">
+      <header className="mx-auto max-w-xl text-center">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gray-500">Get started</p>
+        <h1 className="mt-3 text-[30px] font-semibold leading-[1.15] tracking-[-0.04em] text-gray-950 sm:text-[34px]">
           {requiredDone ? `${orgName} is ready.` : `Get the OpenWork app`}
         </h1>
-        <p className="mt-3 text-[14px] leading-6 text-gray-500">
+        <p className="mx-auto mt-3 max-w-lg text-[15px] leading-6 text-gray-500">
           {requiredDone
             ? "The desktop app is installed and models are available. Jump into your dashboard whenever you're ready."
-            : "OpenWork runs on the desktop. Install the app, then choose OpenWork Models or bring your own keys."}
+            : "OpenWork runs on the desktop app. Install it, sign in, and this workspace syncs automatically."}
         </p>
       </header>
 
-      <section className="mt-8 grid gap-3">
-        <DenSectionHeader
-          title="1. Install the desktop app"
-          description="Computer Use, Browser, Image Gen, and Google Workspace only run in the app."
-          action={
-            appInstalled ? (
-              <DenBadge tone="success" icon={Check}>
-                Installed
-              </DenBadge>
-            ) : null
-          }
-        />
+      <section className="mt-8 grid gap-4">
         <DownloadOpenWorkCard installers={installers} releaseTag={releaseTag} />
-        {!appInstalled ? (
-          <button
-            type="button"
-            data-testid="onboarding-app-installed"
-            onClick={() => setAppInstalled(true)}
-            className="w-fit text-[13px] font-medium text-gray-500 transition hover:text-gray-950"
-          >
-            I&apos;ve already installed it →
-          </button>
-        ) : null}
+        <div className="flex justify-center">
+          {appInstalled ? (
+            <DenBadge tone="success" icon={Check}>
+              Installed
+            </DenBadge>
+          ) : (
+            <button
+              type="button"
+              data-testid="onboarding-app-installed"
+              onClick={() => setAppInstalled(true)}
+              className="text-[13px] font-medium text-gray-500 transition hover:text-gray-950"
+            >
+              I&apos;ve already installed it →
+            </button>
+          )}
+        </div>
       </section>
 
-      <section className="mt-10 grid gap-4">
+      <section className="mt-12 grid gap-5">
         <DenSectionHeader
-          title="2. Choose how your team uses models"
+          align="center"
+          title="Then bring your own keys, or use OpenWork Models"
           description={
             modelsLoading
               ? "Checking whether OpenWork Models are already on…"
               : modelsEnabled
                 ? "OpenWork Models are on for this workspace."
-                : "Pick one path. You can change this later under Models."
+                : "Pick one now, change it whenever — both live under Models."
           }
           action={
             modelsEnabled ? (
@@ -142,28 +139,33 @@ export function MarketplaceOnboardingScreen({
             testId="onboarding-choice-openwork-models"
             icon={<OpenWorkMark />}
             title="OpenWork Models"
-            description="Hosted frontier models for knowledge work. No API keys to manage — every member is provisioned automatically."
+            subtitle="No API keys, nothing to configure"
+            badge={<DenBadge tone="info">Recommended</DenBadge>}
+            description="Hand-picked frontier and open models, billed per member. Turn it on and everyone has models in the app immediately."
             href={getInferenceRoute(orgSlug)}
             ctaLabel={modelsEnabled ? "Manage models" : "Turn on models"}
             ctaVariant="primary"
           />
           <DenChoiceCard
             testId="onboarding-choice-byok"
-            icon={<KeyRound className="h-5 w-5 text-gray-700" aria-hidden />}
+            icon={<KeyRound className="h-[18px] w-[18px] text-gray-700" aria-hidden />}
             title="Bring your Own Keys"
-            description="Connect Anthropic, OpenAI, Azure, or any models.dev provider with credentials your org already has."
+            subtitle="Your providers, your billing"
+            description="Connect Anthropic, OpenAI, Azure, Mistral or your own gateway, and choose exactly which models the team sees."
             href={getCustomLlmProvidersRoute(orgSlug)}
-            ctaLabel="Add providers"
+            ctaLabel="Add a provider"
             ctaVariant="secondary"
-          />
+          >
+            <LlmProviderLogos />
+          </DenChoiceCard>
         </div>
       </section>
 
-      <footer className="mt-10 border-t border-gray-100 pt-5">
+      <footer className="mt-12 border-t border-gray-100 pt-5 text-center">
         <p className="text-[13px] text-gray-500">
           Already set up?{" "}
           <Link href={getOrgDashboardRoute(orgSlug)} className="font-medium text-gray-900 underline-offset-2 hover:underline">
-            Go to dashboard
+            Go to dashboard →
           </Link>
         </p>
       </footer>


### PR DESCRIPTION
## Summary

- Centers the `/dashboard/onboarding` layout (header, install link, models heading, footer) and widens the column to the design's 896px with more vertical breathing room
- Restyles `DenChoiceCard` to the design's header row — icon tile, title, subtitle, optional badge — adding the Recommended pill on OpenWork Models and adopting the design copy
- Shows the provider logo row inside the Bring your Own Keys card ("and every models.dev provider"), reusing the existing `LlmProviderLogos`
- Adds `align="center"` to `DenSectionHeader` (a real prop rather than a Tailwind class override, since `items-start`/`items-center` conflicts resolve by stylesheet order)

## Evidence

### Screenshots
After (local dev at 1440px, matching the Paper "Dashboard · Onboarding" frame):

![onboarding after](https://litter.catbox.moe/bljd6f.png)

### Build verification
- `pnpm --filter @openwork-ee/den-web build` — passed

### Test verification
- `pnpm test` (den-web curated suite) — 95 pass, 0 fail, including `onboarding-page.test.ts` and `byok-page-primitives.test.ts` which pin the "Bring your Own Keys" product name and the e2e test IDs
- Bare `bun test` shows 8 failures (branding favicon, models page copy, MCP dialog contracts) — verified pre-existing on clean `origin/dev` with these changes stashed

### API verification
- No API changes

### UI verification
- Verified via Playwright against `pnpm dev:local` with mocked `/v1/me`, `/v1/me/orgs`, `/v1/org`, `/v1/inference` responses (no seeded stack was running); screen renders the centered layout, Recommended pill, and provider logos
- Console errors: none on the onboarding route

## Test instructions

1. `pnpm dev:den` + `pnpm dev:den:seed-demo`
2. Sign in as `alex@acme.test` / `OpenWorkDemo123!`
3. Navigate to `/dashboard/onboarding`
4. Verify: centered header and footer, centered "I've already installed it →", "Then bring your own keys, or use OpenWork Models" heading, Recommended pill on the OpenWork Models card, and provider logos inside the Bring your Own Keys card

Made with [Cursor](https://cursor.com)