### PR TITLE
style(sidebar): align search and footer with resize rail

### DIFF
--- a/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
+++ b/apps/app/src/react-app/domains/session/sidebar/app-sidebar.tsx
@@ -1085,7 +1085,7 @@ export function AppSidebar(props: AppSidebarProps) {
           </div>
         ) : null}
         {props.onOpenSessionSearch ? (
-          <SidebarHeader className="pb-0">
+          <SidebarHeader className="pb-0 pe-0">
             <SidebarMenu>
               <SidebarMenuItem>
                 <SidebarMenuButton
@@ -1157,7 +1157,7 @@ export function AppSidebar(props: AppSidebarProps) {
           </m.div>
         </LazyMotion>
 
-        <SidebarFooter className="border-t border-sidebar-border/60 p-1.5">
+        <SidebarFooter className="border-t border-sidebar-border/60 p-1.5 pe-0">
           <AccountStatusMenu {...props.status} onOpenAccountSettings={props.onOpenAccountSettings} />
         </SidebarFooter>
 


### PR DESCRIPTION
## Summary
- remove only the right-side wrapper padding from the sidebar search header
- remove only the right-side wrapper padding from the sidebar footer
- preserve the existing left alignment and internal control padding

## Why
PR #3248 compensated workspace and session rows for the resize rail, but this two-line follow-up was pushed after that PR had already merged. Search and the account footer therefore still retained extra apparent right spacing from the rail overlap.

## Impact
Search and footer hover surfaces now use the same right-edge treatment as the content rows merged in #3248.

## Checks
- `./bin/openwork-hub check desktop sidebar-search-footer-rail` — passed environment readiness
- `git diff --check upstream/dev...HEAD` — passed during publish
- Product tests, typechecks, builds, and app launch not run (level 0)

## Manual verification
1. Hover Search sessions and compare its left/right inset around the resize rail.
2. Hover the footer account row and confirm its right edge matches the sidebar content rows.
3. Confirm the search and footer text/icons retain their existing left alignment.

## Risk / untested paths
- Two visual-only Tailwind class changes.
- Narrow sidebar widths and non-macOS rendering have not been runtime-verified.