### PR TITLE
feat(den-api): materialize org LLM providers into Cloud sandboxes server-side

### DIFF
--- a/apps/app/src/react-app/domains/connections/provider-auth/store.ts
+++ b/apps/app/src/react-app/domains/connections/provider-auth/store.ts
@@ -392,12 +392,21 @@ export function createProviderAuthStore(options: CreateProviderAuthStoreOptions)
   };
 
   const mirrorOpenWorkModelsVoiceEnv = async (provider: DenOrgLlmProviderConnection, apiKey: string) => {
-    if (provider.source !== "openwork" || !apiKey.trim()) return;
+    const trimmedKey = apiKey.trim();
+    if (!trimmedKey) return;
     const openworkClient = options.openworkServer.getSnapshot().openworkServerClient;
     if (!openworkClient) return;
-    const baseUrl = readCloudProviderBaseUrl(provider);
-    const entries = [{ key: "OPENWORK_API_KEY", value: apiKey.trim() }];
-    if (baseUrl) entries.push({ key: "OPENWORK_INFERENCE_BASE_URL", value: baseUrl });
+    const entries = getCloudProviderEnv(provider.providerConfig)
+      .slice(0, 1)
+      .map((key) => ({ key, value: trimmedKey }));
+    if (provider.source === "openwork") {
+      if (!entries.some((entry) => entry.key === "OPENWORK_API_KEY")) {
+        entries.unshift({ key: "OPENWORK_API_KEY", value: trimmedKey });
+      }
+      const baseUrl = readCloudProviderBaseUrl(provider);
+      if (baseUrl) entries.push({ key: "OPENWORK_INFERENCE_BASE_URL", value: baseUrl });
+    }
+    if (entries.length === 0) return;
     await openworkClient.upsertUserEnv(entries);
   };
 

--- a/apps/app/tests/cloud-provider-reimport.test.ts
+++ b/apps/app/tests/cloud-provider-reimport.test.ts
@@ -148,4 +148,17 @@ describe("cloud provider runtime patch (re-import diff #2346)", () => {
     expect(source).not.toContain("refreshDesktop" + "CloudSync");
     expect(source).not.toContain("getResource" + "Snapshot");
   });
+
+  test("client env mirror includes non-openwork provider credentials", () => {
+    const source = readFileSync(providerAuthStoreSourcePath, "utf8");
+    const mirrorStart = source.indexOf("const mirrorOpenWorkModelsVoiceEnv = async");
+    const mirrorEnd = source.indexOf("const readWorkspaceOpenworkConfigRecord", mirrorStart);
+    expect(mirrorStart).toBeGreaterThanOrEqual(0);
+    expect(mirrorEnd).toBeGreaterThan(mirrorStart);
+
+    const mirrorSource = source.slice(mirrorStart, mirrorEnd);
+    expect(mirrorSource).not.toContain('provider.source !== "openwork"');
+    expect(mirrorSource).toContain("getCloudProviderEnv(provider.providerConfig)");
+    expect(mirrorSource).toContain(".slice(0, 1)");
+  });
 });

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -1,0 +1,767 @@
+import { createHash } from "node:crypto"
+import { and, asc, eq, inArray, isNull } from "@openwork-ee/den-db/drizzle"
+import {
+  LlmProviderModelTable,
+  LlmProviderTable,
+  WorkerTable,
+  WorkerTokenTable,
+} from "@openwork-ee/den-db/schema"
+import { db } from "../db.js"
+import { appLogger } from "../observability/logger.js"
+import { decodeProviderCredential, readProviderEnvNames } from "./provider-credentials.js"
+
+type JsonRecord = Record<string, unknown>
+type OrganizationId = typeof LlmProviderTable.$inferSelect.organizationId
+type WorkerId = typeof WorkerTable.$inferSelect.id
+type WorkerTokenScope = typeof WorkerTokenTable.$inferSelect.scope
+type LlmProviderId = typeof LlmProviderTable.$inferSelect.id
+type LlmProviderSource = typeof LlmProviderTable.$inferSelect.source
+
+type EnvEntry = {
+  key: string
+  value: string
+}
+
+type WorkerToken = {
+  scope: WorkerTokenScope
+  token: string
+}
+
+export type CloudProviderMaterializationProvider = {
+  id: LlmProviderId
+  source: LlmProviderSource
+  providerId: string
+  name: string
+  providerConfig: JsonRecord
+  apiKey: string | null
+  models: Array<{
+    modelId: string
+    name: string
+    modelConfig: JsonRecord
+  }>
+}
+
+export type CloudProviderMaterializationStore = {
+  listProviders: (organizationId: OrganizationId) => Promise<CloudProviderMaterializationProvider[]>
+  getActiveTokens: (workerId: WorkerId) => Promise<WorkerToken[]>
+}
+
+type MaterializedProvider = {
+  provider: CloudProviderMaterializationProvider
+  runtimeProviderId: string
+  config: JsonRecord
+  envEntries: EnvEntry[]
+}
+
+type PreparedMaterialization = {
+  fingerprint: string
+  providers: MaterializedProvider[]
+  envEntries: EnvEntry[]
+}
+
+type FetchImpl = (input: string, init?: RequestInit) => Promise<Response>
+
+type MaterializationLogger = {
+  warn: (message: string, metadata?: JsonRecord) => void
+}
+
+export type CloudProviderMaterializationResult =
+  | {
+      ok: true
+      status: "applied" | "noop" | "cached"
+      fingerprint: string
+      providers: number
+    }
+  | {
+      ok: false
+      status: "failed"
+      error: "provider_materialization_failed"
+      reason: string
+      message: string
+      fingerprint: string | null
+      providers: number
+    }
+
+export type MaterializeCloudWorkerProviders = typeof materializeCloudWorkerProviders
+
+export const OPENWORK_PROVIDERS_FINGERPRINT_ENV = "OPENWORK_PROVIDERS_FINGERPRINT"
+
+const logger = appLogger.child({ component: "cloud_provider_materialization" })
+const requestTimeoutMs = 8_000
+const materializedFingerprintByWorker = new Map<WorkerId, string>()
+const modelConfigPassthroughKeys = [
+  "family",
+  "release_date",
+  "attachment",
+  "reasoning",
+  "temperature",
+  "tool_call",
+  "interleaved",
+  "cost",
+  "limit",
+  "modalities",
+  "status",
+  "options",
+  "headers",
+  "provider",
+  "variants",
+]
+
+const databaseMaterializationStore: CloudProviderMaterializationStore = {
+  async listProviders(organizationId) {
+    const providers = await db
+      .select()
+      .from(LlmProviderTable)
+      .where(eq(LlmProviderTable.organizationId, organizationId))
+      .orderBy(asc(LlmProviderTable.id))
+
+    if (providers.length === 0) {
+      return []
+    }
+
+    const providerIds = providers.map((provider) => provider.id)
+    const models = await db
+      .select()
+      .from(LlmProviderModelTable)
+      .where(inArray(LlmProviderModelTable.llmProviderId, providerIds))
+      .orderBy(asc(LlmProviderModelTable.llmProviderId), asc(LlmProviderModelTable.modelId))
+
+    const modelsByProvider = new Map<LlmProviderId, CloudProviderMaterializationProvider["models"]>()
+    for (const model of models) {
+      const existing = modelsByProvider.get(model.llmProviderId) ?? []
+      existing.push({
+        modelId: model.modelId,
+        name: model.name,
+        modelConfig: model.modelConfig,
+      })
+      modelsByProvider.set(model.llmProviderId, existing)
+    }
+
+    return providers.map((provider) => ({
+      id: provider.id,
+      source: provider.source,
+      providerId: provider.providerId,
+      name: provider.name,
+      providerConfig: provider.providerConfig,
+      apiKey: provider.apiKey ?? null,
+      models: modelsByProvider.get(provider.id) ?? [],
+    }))
+  },
+  async getActiveTokens(workerId) {
+    return db
+      .select({ scope: WorkerTokenTable.scope, token: WorkerTokenTable.token })
+      .from(WorkerTokenTable)
+      .where(and(eq(WorkerTokenTable.worker_id, workerId), isNull(WorkerTokenTable.revoked_at)))
+  },
+}
+
+function isRecord(value: unknown): value is JsonRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
+function stableValue(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableValue)
+  }
+
+  if (!isRecord(value)) {
+    return value
+  }
+
+  return Object.fromEntries(
+    Object.keys(value)
+      .sort()
+      .map((key) => [key, stableValue(value[key])]),
+  )
+}
+
+function stableJson(value: unknown) {
+  return JSON.stringify(stableValue(value))
+}
+
+function hashString(value: string) {
+  return createHash("sha256").update(value).digest("hex")
+}
+
+function normalizeBaseUrl(value: string) {
+  return value.trim().replace(/\/+$/, "")
+}
+
+function readString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value.trim() : null
+}
+
+function readStringList(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((entry): entry is string => typeof entry === "string" && entry.trim().length > 0)
+    : []
+}
+
+function runtimeProviderId(provider: Pick<CloudProviderMaterializationProvider, "id" | "source">) {
+  return provider.source === "openwork" ? "openwork" : provider.id.trim()
+}
+
+function isCloudManagedProviderKey(providerId: string) {
+  return /^lpr_/i.test(providerId) || providerId.trim() === "openwork"
+}
+
+function upsertEnvEntry(entries: EnvEntry[], key: string, value: string) {
+  const trimmedKey = key.trim()
+  const trimmedValue = value.trim()
+  if (!trimmedKey || !trimmedValue) {
+    return
+  }
+
+  const existing = entries.find((entry) => entry.key === trimmedKey)
+  if (existing) {
+    existing.value = trimmedValue
+    return
+  }
+
+  entries.push({ key: trimmedKey, value: trimmedValue })
+}
+
+function readOpenWorkInferenceBaseUrl(providerConfig: JsonRecord) {
+  const options = providerConfig.options
+  if (isRecord(options)) {
+    const baseUrl = readString(options.baseURL)
+    if (baseUrl) {
+      return baseUrl.replace(/\/api\/v1\/?$/, "")
+    }
+  }
+
+  const api = readString(providerConfig.api)
+  return api ? api.replace(/\/api\/v1\/?$/, "") : null
+}
+
+function providerEnvEntries(provider: CloudProviderMaterializationProvider): EnvEntry[] {
+  const entries: EnvEntry[] = []
+  const envNames = readProviderEnvNames(provider.providerConfig)
+  const credential = decodeProviderCredential(provider.apiKey)
+
+  if (credential.apiKeys) {
+    const keys = Object.keys(credential.apiKeys)
+    const orderedNames = [
+      ...envNames.filter((name) => keys.includes(name)),
+      ...keys.filter((name) => !envNames.includes(name)),
+    ]
+    for (const name of orderedNames) {
+      upsertEnvEntry(entries, name, credential.apiKeys[name] ?? "")
+    }
+  }
+
+  if (credential.apiKey && envNames[0]) {
+    upsertEnvEntry(entries, envNames[0], credential.apiKey)
+  }
+
+  const primaryCredential = credential.apiKey?.trim() || entries[0]?.value || ""
+  if (provider.source === "openwork" && primaryCredential) {
+    upsertEnvEntry(entries, "OPENWORK_API_KEY", primaryCredential)
+    const baseUrl = readOpenWorkInferenceBaseUrl(provider.providerConfig)
+    if (baseUrl) {
+      upsertEnvEntry(entries, "OPENWORK_INFERENCE_BASE_URL", baseUrl)
+    }
+  }
+
+  return entries
+}
+
+function buildModelConfig(model: CloudProviderMaterializationProvider["models"][number]) {
+  const next: JsonRecord = {
+    id: model.modelId,
+    name: model.name,
+  }
+
+  for (const key of modelConfigPassthroughKeys) {
+    const value = model.modelConfig[key]
+    if (value !== undefined) {
+      next[key] = value
+    }
+  }
+
+  return next
+}
+
+function buildProviderConfig(provider: CloudProviderMaterializationProvider) {
+  const models: JsonRecord = {}
+  const sortedModels = [...provider.models].sort((left, right) => left.modelId.localeCompare(right.modelId))
+  for (const model of sortedModels) {
+    models[model.modelId] = buildModelConfig(model)
+  }
+
+  const config: JsonRecord = {
+    id: provider.providerId,
+    name: provider.name,
+    env: readProviderEnvNames(provider.providerConfig),
+  }
+
+  if (Object.keys(models).length > 0 || provider.source !== "openwork") {
+    config.models = models
+  }
+
+  const npm = readString(provider.providerConfig.npm)
+  if (npm) {
+    config.npm = npm
+  }
+
+  const api = readString(provider.providerConfig.api)
+  if (api) {
+    config.api = api
+  }
+
+  const options = provider.providerConfig.options
+  if (isRecord(options)) {
+    config.options = options
+  }
+
+  const whitelist = readStringList(provider.providerConfig.whitelist)
+  if (whitelist.length > 0) {
+    config.whitelist = whitelist
+  }
+
+  const blacklist = readStringList(provider.providerConfig.blacklist)
+  if (blacklist.length > 0) {
+    config.blacklist = blacklist
+  }
+
+  return config
+}
+
+function providerHasRequiredCredential(provider: CloudProviderMaterializationProvider, envEntries: EnvEntry[]) {
+  const envNames = readProviderEnvNames(provider.providerConfig)
+  if (envNames.length === 0) {
+    return true
+  }
+
+  return envEntries.some((entry) => envNames.includes(entry.key))
+}
+
+function prepareMaterialization(providers: CloudProviderMaterializationProvider[]): PreparedMaterialization {
+  const materialized = providers
+    .map((provider) => {
+      const envEntries = providerEnvEntries(provider)
+      if (!providerHasRequiredCredential(provider, envEntries)) {
+        return null
+      }
+
+      return {
+        provider,
+        runtimeProviderId: runtimeProviderId(provider),
+        config: buildProviderConfig(provider),
+        envEntries,
+      }
+    })
+    .filter((entry): entry is MaterializedProvider => entry !== null)
+    .sort((left, right) => left.runtimeProviderId.localeCompare(right.runtimeProviderId))
+
+  const envEntries: EnvEntry[] = []
+  for (const provider of materialized) {
+    for (const entry of provider.envEntries) {
+      upsertEnvEntry(envEntries, entry.key, entry.value)
+    }
+  }
+
+  const fingerprintPayload = materialized.map((entry) => ({
+    id: entry.provider.id,
+    runtimeProviderId: entry.runtimeProviderId,
+    source: entry.provider.source,
+    providerId: entry.provider.providerId,
+    config: entry.config,
+    keyHashes: entry.envEntries
+      .map((envEntry) => ({ key: envEntry.key, hash: hashString(envEntry.value) }))
+      .sort((left, right) => left.key.localeCompare(right.key)),
+  }))
+
+  return {
+    fingerprint: `owp:v1:${hashString(stableJson(fingerprintPayload))}`,
+    providers: materialized,
+    envEntries,
+  }
+}
+
+export function computeCloudProviderMaterializationFingerprint(providers: CloudProviderMaterializationProvider[]) {
+  return prepareMaterialization(providers).fingerprint
+}
+
+async function fetchWithTimeout(fetchImpl: FetchImpl, url: string, init: RequestInit = {}) {
+  const controller = new AbortController()
+  const timeout = setTimeout(() => controller.abort(), requestTimeoutMs)
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timeout)
+  }
+}
+
+async function readJsonObject(response: Response) {
+  const text = await response.text()
+  if (!text.trim()) {
+    return {}
+  }
+
+  const parsed = JSON.parse(text)
+  return isRecord(parsed) ? parsed : {}
+}
+
+function bearerHeaders(clientToken: string) {
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${clientToken}`,
+  }
+}
+
+function hostTokenHeaders(hostToken: string) {
+  return {
+    Accept: "application/json",
+    "Content-Type": "application/json",
+    "X-OpenWork-Host-Token": hostToken,
+  }
+}
+
+async function requestJson(input: {
+  fetchImpl: FetchImpl
+  label: string
+  url: string
+  init: RequestInit
+}) {
+  const response = await fetchWithTimeout(input.fetchImpl, input.url, input.init)
+  if (!response.ok) {
+    throw new Error(`${input.label}_failed_${response.status}`)
+  }
+
+  return readJsonObject(response)
+}
+
+async function requestOk(input: {
+  fetchImpl: FetchImpl
+  label: string
+  url: string
+  init: RequestInit
+}) {
+  const response = await fetchWithTimeout(input.fetchImpl, input.url, input.init)
+  if (!response.ok) {
+    throw new Error(`${input.label}_failed_${response.status}`)
+  }
+}
+
+function readWorkspaceId(payload: JsonRecord) {
+  const activeId = readString(payload.activeId)
+  const rawItems = Array.isArray(payload.items)
+    ? payload.items
+    : Array.isArray(payload.workspaces)
+      ? payload.workspaces
+      : []
+  const items = rawItems.filter(isRecord)
+  if (activeId && items.some((item) => readString(item.id) === activeId)) {
+    return activeId
+  }
+
+  for (const item of items) {
+    const id = readString(item.id)
+    if (id) {
+      return id
+    }
+  }
+
+  return activeId
+}
+
+async function discoverWorkspaceId(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  clientToken: string
+}) {
+  const payload = await requestJson({
+    fetchImpl: input.fetchImpl,
+    label: "workspace_discovery",
+    url: `${input.instanceUrl}/workspaces`,
+    init: {
+      method: "GET",
+      headers: bearerHeaders(input.clientToken),
+    },
+  })
+  const workspaceId = readWorkspaceId(payload)
+  if (!workspaceId) {
+    throw new Error("workspace_discovery_missing_workspace")
+  }
+
+  return workspaceId
+}
+
+async function readStoredFingerprint(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  hostToken: string
+}) {
+  const response = await fetchWithTimeout(input.fetchImpl, `${input.instanceUrl}/env/${OPENWORK_PROVIDERS_FINGERPRINT_ENV}`, {
+    method: "GET",
+    headers: hostTokenHeaders(input.hostToken),
+  })
+  if (response.status === 404) {
+    return null
+  }
+  if (!response.ok) {
+    throw new Error(`fingerprint_read_failed_${response.status}`)
+  }
+
+  const payload = await readJsonObject(response)
+  const item = isRecord(payload.item) ? payload.item : null
+  return item ? readString(item.value) : null
+}
+
+async function readRuntimeManagedProviderIds(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  clientToken: string
+  workspaceId: string
+}) {
+  const payload = await requestJson({
+    fetchImpl: input.fetchImpl,
+    label: "runtime_config_read",
+    url: `${input.instanceUrl}/workspace/${encodeURIComponent(input.workspaceId)}/runtime-config`,
+    init: {
+      method: "GET",
+      headers: bearerHeaders(input.clientToken),
+    },
+  })
+  const runtime = isRecord(payload.runtime) ? payload.runtime : null
+  const provider = runtime && isRecord(runtime.provider) ? runtime.provider : null
+  return provider ? Object.keys(provider).filter(isCloudManagedProviderKey) : []
+}
+
+function buildRuntimeProviderPatch(prepared: PreparedMaterialization, currentManagedProviderIds: string[]) {
+  const desiredIds = new Set(prepared.providers.map((provider) => provider.runtimeProviderId))
+  const patch: JsonRecord = {}
+  for (const providerId of currentManagedProviderIds) {
+    if (!desiredIds.has(providerId)) {
+      patch[providerId] = null
+    }
+  }
+
+  for (const provider of prepared.providers) {
+    patch[provider.runtimeProviderId] = provider.config
+  }
+
+  return patch
+}
+
+async function writeEnvEntries(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  hostToken: string
+  entries: EnvEntry[]
+}) {
+  if (input.entries.length === 0) {
+    return
+  }
+
+  await requestOk({
+    fetchImpl: input.fetchImpl,
+    label: "env_write",
+    url: `${input.instanceUrl}/env`,
+    init: {
+      method: "PUT",
+      headers: hostTokenHeaders(input.hostToken),
+      body: JSON.stringify({ entries: input.entries }),
+    },
+  })
+}
+
+async function patchRuntimeProviders(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  clientToken: string
+  workspaceId: string
+  patch: JsonRecord
+}) {
+  if (Object.keys(input.patch).length === 0) {
+    return
+  }
+
+  await requestOk({
+    fetchImpl: input.fetchImpl,
+    label: "runtime_config_patch",
+    url: `${input.instanceUrl}/workspace/${encodeURIComponent(input.workspaceId)}/config`,
+    init: {
+      method: "PATCH",
+      headers: bearerHeaders(input.clientToken),
+      body: JSON.stringify({ opencode: { provider: input.patch } }),
+    },
+  })
+}
+
+async function reloadOpencode(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  clientToken: string
+  workspaceId: string
+}) {
+  await requestOk({
+    fetchImpl: input.fetchImpl,
+    label: "opencode_reload",
+    url: `${input.instanceUrl}/workspace/${encodeURIComponent(input.workspaceId)}/engine/reload`,
+    init: {
+      method: "POST",
+      headers: bearerHeaders(input.clientToken),
+    },
+  })
+}
+
+async function resolveTokens(input: {
+  workerId: WorkerId
+  hostToken?: string
+  clientToken?: string
+  store: CloudProviderMaterializationStore
+}) {
+  let hostToken = input.hostToken?.trim() ?? ""
+  let clientToken = input.clientToken?.trim() ?? ""
+  if (hostToken && clientToken) {
+    return { hostToken, clientToken }
+  }
+
+  const tokens = await input.store.getActiveTokens(input.workerId)
+  hostToken = hostToken || tokens.find((token) => token.scope === "host")?.token.trim() || ""
+  clientToken = clientToken || tokens.find((token) => token.scope === "client")?.token.trim() || ""
+  return { hostToken, clientToken }
+}
+
+function failureResult(input: {
+  reason: string
+  error: unknown
+  fingerprint: string | null
+  providers: number
+}) {
+  const message = input.error instanceof Error ? input.error.message : input.reason
+  return {
+    ok: false,
+    status: "failed",
+    error: "provider_materialization_failed",
+    reason: input.reason,
+    message,
+    fingerprint: input.fingerprint,
+    providers: input.providers,
+  } satisfies CloudProviderMaterializationResult
+}
+
+function logFailure(input: {
+  logger: MaterializationLogger
+  workerId: WorkerId
+  organizationId: OrganizationId
+  result: Extract<CloudProviderMaterializationResult, { ok: false }>
+}) {
+  input.logger.warn("cloud provider materialization failed", {
+    worker_id: input.workerId,
+    organization_id: input.organizationId,
+    reason: input.result.reason,
+    message: input.result.message,
+    fingerprint: input.result.fingerprint,
+    providers: input.result.providers,
+  })
+}
+
+export async function materializeCloudWorkerProviders(input: {
+  organizationId: OrganizationId
+  workerId: WorkerId
+  instanceUrl: string
+  hostToken?: string
+  clientToken?: string
+  force?: boolean
+  store?: CloudProviderMaterializationStore
+  fetchImpl?: FetchImpl
+  logger?: MaterializationLogger
+}): Promise<CloudProviderMaterializationResult> {
+  const materializationLogger = input.logger ?? logger
+  const store = input.store ?? databaseMaterializationStore
+  const fetchImpl = input.fetchImpl ?? fetch
+  const instanceUrl = normalizeBaseUrl(input.instanceUrl)
+  let fingerprint: string | null = null
+  let providerCount = 0
+
+  try {
+    if (!instanceUrl) {
+      throw new Error("instance_url_missing")
+    }
+
+    const providers = await store.listProviders(input.organizationId)
+    const prepared = prepareMaterialization(providers)
+    fingerprint = prepared.fingerprint
+    providerCount = prepared.providers.length
+
+    if (!input.force && materializedFingerprintByWorker.get(input.workerId) === fingerprint) {
+      return { ok: true, status: "cached", fingerprint, providers: providerCount }
+    }
+
+    const tokens = await resolveTokens({
+      workerId: input.workerId,
+      hostToken: input.hostToken,
+      clientToken: input.clientToken,
+      store,
+    })
+    if (!tokens.hostToken || !tokens.clientToken) {
+      throw new Error("worker_tokens_missing")
+    }
+
+    const storedFingerprint = await readStoredFingerprint({
+      fetchImpl,
+      instanceUrl,
+      hostToken: tokens.hostToken,
+    })
+    if (storedFingerprint === fingerprint) {
+      materializedFingerprintByWorker.set(input.workerId, fingerprint)
+      return { ok: true, status: "noop", fingerprint, providers: providerCount }
+    }
+
+    const workspaceId = await discoverWorkspaceId({ fetchImpl, instanceUrl, clientToken: tokens.clientToken })
+    const currentManagedProviderIds = await readRuntimeManagedProviderIds({
+      fetchImpl,
+      instanceUrl,
+      clientToken: tokens.clientToken,
+      workspaceId,
+    })
+    const providerPatch = buildRuntimeProviderPatch(prepared, currentManagedProviderIds)
+
+    await writeEnvEntries({
+      fetchImpl,
+      instanceUrl,
+      hostToken: tokens.hostToken,
+      entries: prepared.envEntries,
+    })
+    await patchRuntimeProviders({
+      fetchImpl,
+      instanceUrl,
+      clientToken: tokens.clientToken,
+      workspaceId,
+      patch: providerPatch,
+    })
+    await reloadOpencode({ fetchImpl, instanceUrl, clientToken: tokens.clientToken, workspaceId })
+
+    // The fingerprint is intentionally stored inside the instance's env store:
+    // it survives restarts with the rest of the sandbox state, contains only
+    // hashes/non-secret metadata, and avoids a Den schema migration for a value
+    // whose truth is scoped to that one runtime.
+    await writeEnvEntries({
+      fetchImpl,
+      instanceUrl,
+      hostToken: tokens.hostToken,
+      entries: [{ key: OPENWORK_PROVIDERS_FINGERPRINT_ENV, value: fingerprint }],
+    })
+
+    materializedFingerprintByWorker.set(input.workerId, fingerprint)
+    return { ok: true, status: "applied", fingerprint, providers: providerCount }
+  } catch (error) {
+    const result = failureResult({
+      reason: error instanceof Error ? error.message : "provider_materialization_failed",
+      error,
+      fingerprint,
+      providers: providerCount,
+    })
+    logFailure({
+      logger: materializationLogger,
+      workerId: input.workerId,
+      organizationId: input.organizationId,
+      result,
+    })
+    return result
+  }
+}

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -10,6 +10,7 @@ import { db } from "../../db.js"
 import { env, type DenOrgMode } from "../../env.js"
 import { orgMemberRoute } from "../../middleware/index.js"
 import { jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
+import { materializeCloudWorkerProviders } from "../../llm/cloud-provider-materialization.js"
 import { flushWorkerCheckpointOnDaytona, getDaytonaSandboxRecord, inspectDaytonaSandbox, refreshDaytonaSignedPreview, stopWorkerOnDaytona } from "../../workers/daytona.js"
 import { CLOUD_INSTANCE_BACKEND, CLOUD_INSTANCE_NAME } from "../../workers/cloud-constants.js"
 import { wakeCloudWorker as defaultWakeCloudWorker } from "../../workers/cloud-lifecycle.js"
@@ -33,6 +34,7 @@ type CloudRouteOptions = {
   wakeCloudWorker?: WakeCloudWorker
   flushWorkerCheckpoint?: FlushWorkerCheckpoint
   stopCloudWorker?: StopCloudWorker
+  materializeProviders?: typeof materializeCloudWorkerProviders
   now?: () => number
 }
 
@@ -61,6 +63,7 @@ type CloudInstanceMemberResponse = CloudInstanceResponse & {
 type CloudGatewayInstanceResponse = CloudInstanceResponse & {
   clientToken: string | null
   hostToken: string | null
+  providerSync?: { status: "degraded" }
 }
 type CloudInstanceUpdateResponse =
   | { ok: true; status: "update_requested" }
@@ -118,6 +121,7 @@ const cloudGatewayInstanceResponseSchema = z.object({
   url: z.string().url().nullable(),
   clientToken: z.string().nullable(),
   hostToken: z.string().nullable(),
+  providerSync: z.object({ status: z.literal("degraded") }).optional(),
 }).meta({ ref: "CloudGatewayInstanceResponse" })
 
 function cloudNotFound() {
@@ -414,6 +418,7 @@ async function createCloudWorker(input: {
 
   void input.continueProvisioning({
     workerId,
+    orgId: input.orgId,
     name: input.name,
     hostToken,
     clientToken,
@@ -465,6 +470,7 @@ function rememberHealthyPreview(workerId: WorkerId, url: string, now: number) {
 
 async function startFailedCloudHeal(input: {
   worker: CloudWorker
+  orgId: OrgId
   continueProvisioning: typeof continueCloudProvisioning
   store: CloudWorkerStore
 }) {
@@ -487,6 +493,7 @@ async function startFailedCloudHeal(input: {
 
     await input.continueProvisioning({
       workerId: input.worker.id,
+      orgId: input.orgId,
       name: input.worker.name,
       hostToken,
       clientToken,
@@ -503,6 +510,7 @@ async function startFailedCloudHeal(input: {
 
 async function resolveFailedCloudInstance(input: {
   worker: CloudWorker
+  orgId: OrgId
   continueProvisioning: typeof continueCloudProvisioning
   getSandboxRecord: GetSandboxRecord
   startWake: (workerId: CloudWorker["id"]) => void
@@ -635,6 +643,7 @@ async function startStaleStoppedRecycle(input: {
 
 async function recoverUnhealthyCloudSandbox(input: {
   worker: CloudWorker
+  orgId: OrgId
   continueProvisioning: typeof continueCloudProvisioning
   inspectSandbox: InspectSandbox
   startWake: (workerId: CloudWorker["id"]) => void
@@ -659,6 +668,7 @@ async function recoverUnhealthyCloudSandbox(input: {
 
 async function resolveCloudInstance(input: {
   worker: CloudWorker
+  orgId: OrgId
   continueProvisioning: typeof continueCloudProvisioning
   refreshSignedPreview: typeof refreshDaytonaSignedPreview
   getSandboxRecord: GetSandboxRecord
@@ -760,6 +770,7 @@ async function resolveCloudInstanceForMember(input: {
   })
   const instance = await resolveCloudInstance({
     worker,
+    orgId: input.payload.organization.id,
     continueProvisioning: input.continueProvisioning,
     refreshSignedPreview: input.refreshSignedPreview,
     getSandboxRecord: input.getSandboxRecord,
@@ -829,6 +840,7 @@ async function resolveCloudInstanceForGateway(input: {
   inspectSandbox: InspectSandbox
   probeSignedPreview: ProbeSignedPreview
   startWake: (workerId: CloudWorker["id"]) => void
+  materializeProviders: typeof materializeCloudWorkerProviders
   now: () => number
 }): Promise<CloudGatewayInstanceResponse> {
   const resolved = await resolveCloudInstanceForMember(input)
@@ -844,7 +856,31 @@ async function resolveCloudInstanceForGateway(input: {
     return { status: "failed", url: null, clientToken: null, hostToken: null }
   }
 
-  return { status: "ready", url: resolved.instance.url, clientToken, hostToken }
+  let materialized = true
+  try {
+    const result = await input.materializeProviders({
+      organizationId: input.payload.organization.id,
+      workerId: resolved.worker.id,
+      instanceUrl: resolved.instance.url,
+      hostToken,
+      clientToken,
+    })
+    materialized = result.ok
+  } catch (error) {
+    materialized = false
+    logger.warn("cloud gateway provider materialization warning", {
+      worker_id: resolved.worker.id,
+      message: error instanceof Error ? error.message : "provider_materialization_failed",
+    })
+  }
+
+  return {
+    status: "ready",
+    url: resolved.instance.url,
+    clientToken,
+    hostToken,
+    ...(!materialized ? { providerSync: { status: "degraded" } } : {}),
+  }
 }
 
 export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
@@ -852,7 +888,9 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
   options: CloudRouteOptions = {},
 ) {
   const orgMemberRouteMiddleware = options.memberRoute ?? orgMemberRoute()
-  const continueProvisioning = options.continueProvisioning ?? continueCloudProvisioning
+  const materializeProviders = options.materializeProviders ?? materializeCloudWorkerProviders
+  const continueProvisioning: typeof continueCloudProvisioning = options.continueProvisioning
+    ?? ((input, continueOptions = {}) => continueCloudProvisioning(input, { ...continueOptions, materializeProviders }))
   const refreshSignedPreview = options.refreshSignedPreview ?? refreshDaytonaSignedPreview
   const store = options.cloudWorkerStore ?? databaseCloudWorkerStore
   const ensureWorker = options.ensureCloudWorker ?? ensureCloudWorker
@@ -1000,6 +1038,7 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
         inspectSandbox,
         probeSignedPreview: signedPreviewProbe,
         startWake,
+        materializeProviders,
         now,
       })
 

--- a/ee/apps/den-api/src/routes/workers/core.ts
+++ b/ee/apps/den-api/src/routes/workers/core.ts
@@ -273,6 +273,7 @@ export function registerWorkerCoreRoutes<T extends { Variables: WorkerRouteVaria
     if (input.destination === "cloud") {
       void continueCloudProvisioning({
         workerId,
+        orgId,
         name: input.name,
         hostToken,
         clientToken,

--- a/ee/apps/den-api/src/routes/workers/shared.ts
+++ b/ee/apps/den-api/src/routes/workers/shared.ts
@@ -19,6 +19,7 @@ import type { UserOrganizationsContext } from "../../middleware/index.js"
 import { denTypeIdSchema } from "../../openapi.js"
 import { appLogger } from "../../observability/logger.js"
 import type { AuthContextVariables } from "../../session.js"
+import { materializeCloudWorkerProviders } from "../../llm/cloud-provider-materialization.js"
 import { deprovisionWorker, provisionWorker } from "../../workers/provisioner.js"
 import { customDomainForWorker } from "../../workers/vanity-domain.js"
 
@@ -75,6 +76,7 @@ type CloudProvisioningStore = {
 type ContinueCloudProvisioningOptions = {
   provisionWorker?: ProvisionWorker
   store?: CloudProvisioningStore
+  materializeProviders?: typeof materializeCloudWorkerProviders
 }
 
 export const token = () => randomBytes(32).toString("hex")
@@ -374,6 +376,7 @@ export function toWorkerResponse(row: WorkerRow, userId: string) {
 
 async function runCloudProvisioning(input: {
   workerId: WorkerId
+  orgId?: OrgId
   name: string
   hostToken: string
   clientToken: string
@@ -381,6 +384,7 @@ async function runCloudProvisioning(input: {
 }, options: ContinueCloudProvisioningOptions) {
   const provision = options.provisionWorker ?? provisionWorker
   const store = options.store ?? databaseCloudProvisioningStore
+  const materializeProviders = options.materializeProviders ?? materializeCloudWorkerProviders
 
   try {
     const provisioned = await provision({
@@ -390,6 +394,24 @@ async function runCloudProvisioning(input: {
       clientToken: input.clientToken,
       activityToken: input.activityToken,
     })
+
+    if (provisioned.status === "healthy" && input.orgId) {
+      try {
+        await materializeProviders({
+          organizationId: input.orgId,
+          workerId: input.workerId,
+          instanceUrl: provisioned.url,
+          hostToken: input.hostToken,
+          clientToken: input.clientToken,
+          force: true,
+        })
+      } catch (error) {
+        logger.warn("worker provisioning provider materialization warning", {
+          worker_id: input.workerId,
+          message: error instanceof Error ? error.message : "provider_materialization_failed",
+        })
+      }
+    }
 
     await store.updateWorkerStatus({
       workerId: input.workerId,
@@ -408,6 +430,7 @@ async function runCloudProvisioning(input: {
 
 export async function continueCloudProvisioning(input: {
   workerId: WorkerId
+  orgId?: OrgId
   name: string
   hostToken: string
   clientToken: string

--- a/ee/apps/den-api/src/workers/cloud-lifecycle.ts
+++ b/ee/apps/den-api/src/workers/cloud-lifecycle.ts
@@ -2,6 +2,7 @@ import { and, asc, eq, isNull, lt, or } from "@openwork-ee/den-db/drizzle"
 import { WorkerTable, WorkerTokenTable } from "@openwork-ee/den-db/schema"
 import { db } from "../db.js"
 import { env } from "../env.js"
+import { materializeCloudWorkerProviders } from "../llm/cloud-provider-materialization.js"
 import { appLogger } from "../observability/logger.js"
 import { captureException } from "../observability/runtime.js"
 import { CLOUD_INSTANCE_BACKEND } from "./cloud-constants.js"
@@ -15,7 +16,7 @@ import {
 
 type WorkerId = typeof WorkerTable.$inferSelect.id
 type WorkerStatus = typeof WorkerTable.$inferSelect.status
-type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "name" | "status" | "last_active_at" | "updated_at">
+type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "name" | "status" | "last_active_at" | "updated_at"> & Partial<Pick<typeof WorkerTable.$inferSelect, "org_id">>
 type WorkerToken = typeof WorkerTokenTable.$inferSelect
 type WakeWorkerOnDaytona = typeof wakeWorkerOnDaytona
 type ProvisionWorkerOnDaytona = typeof provisionWorkerOnDaytona
@@ -32,6 +33,7 @@ type WakeCloudWorkerOptions = {
   store?: CloudLifecycleStore
   wakeWorker?: WakeWorkerOnDaytona
   provisionWorker?: ProvisionWorkerOnDaytona
+  materializeProviders?: typeof materializeCloudWorkerProviders
 }
 
 type StopIdleCloudWorkersOptions = {
@@ -131,6 +133,7 @@ async function runWakeCloudWorker(workerId: WorkerId, options: WakeCloudWorkerOp
   const store = options.store ?? databaseCloudLifecycleStore
   const wakeWorker = options.wakeWorker ?? wakeWorkerOnDaytona
   const provisionWorker = options.provisionWorker ?? provisionWorkerOnDaytona
+  const materializeProviders = options.materializeProviders ?? materializeCloudWorkerProviders
 
   try {
     const worker = await store.getWorker(workerId)
@@ -170,6 +173,24 @@ async function runWakeCloudWorker(workerId: WorkerId, options: WakeCloudWorkerOp
 
       logger.warn("worker wake sandbox missing; reprovisioning", { worker_id: workerId, error })
       woken = await provisionWorker(wakeInput)
+    }
+
+    if (woken.status === "healthy" && worker.org_id) {
+      try {
+        await materializeProviders({
+          organizationId: worker.org_id,
+          workerId,
+          instanceUrl: woken.url,
+          hostToken,
+          clientToken,
+          force: true,
+        })
+      } catch (error) {
+        logger.warn("worker wake provider materialization warning", {
+          worker_id: workerId,
+          message: error instanceof Error ? error.message : "provider_materialization_failed",
+        })
+      }
     }
 
     await store.updateWorkerStatus({ workerId, status: woken.status, imageVersion: woken.imageVersion, onlyWhenStatus: "provisioning" })

--- a/ee/apps/den-api/src/workers/reconciler.ts
+++ b/ee/apps/den-api/src/workers/reconciler.ts
@@ -40,6 +40,7 @@ async function reconcileWorker(worker: ProvisioningWorker) {
 
   await continueCloudProvisioning({
     workerId: worker.id,
+    orgId: worker.org_id,
     name: worker.name,
     hostToken,
     clientToken,

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -435,6 +435,7 @@ describe("Cloud gateway resolve route", () => {
       cloudWorkerStore: store.store,
       getSandboxRecord: async () => fakeSandbox(),
       probeSignedPreview: async () => true,
+      materializeProviders: async () => ({ ok: true, status: "noop", fingerprint: "owp:v1:test", providers: 0 }),
     })
 
     const ready = await readyApp.request("http://den.local/v1/cloud/gateway/resolve", {
@@ -474,6 +475,49 @@ describe("Cloud gateway resolve route", () => {
     expect(payload).toMatchObject({ status: "ready", url: "https://preview.example.test" })
     expect(payload).not.toHaveProperty("hostToken")
     expect(payload).not.toHaveProperty("clientToken")
+  })
+
+  test("surfaces degraded provider materialization without leaking provider keys", async () => {
+    const readyWorker = fakeWorker("healthy")
+    const store = makeCloudWorkerStore({ tokens: [makeToken(readyWorker.id, "host"), makeToken(readyWorker.id, "client")] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    const secret = "sk-secret-never"
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      gatewayKey: "gateway-secret",
+      ensureCloudWorker: async () => readyWorker,
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandbox(),
+      probeSignedPreview: async () => true,
+      materializeProviders: async () => ({
+        ok: false,
+        status: "failed",
+        error: "provider_materialization_failed",
+        reason: "env_write_failed_500",
+        message: `env_write_failed_500 ${secret}`,
+        fingerprint: "owp:v1:redacted",
+        providers: 1,
+      }),
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/gateway/resolve", {
+      headers: { "X-OpenWork-Gateway-Key": "gateway-secret" },
+    })
+    const body = await response.text()
+
+    expect(response.status).toBe(200)
+    expect(JSON.parse(body)).toEqual({
+      status: "ready",
+      url: "https://preview.example.test",
+      clientToken: "client-token",
+      hostToken: "host-token",
+      providerSync: { status: "degraded" },
+    })
+    expect(body).not.toContain(secret)
   })
 })
 

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -1,0 +1,362 @@
+import { createDenTypeId } from "@openwork-ee/utils/typeid"
+import { beforeAll, describe, expect, test } from "bun:test"
+import type { CloudProviderMaterializationProvider } from "../src/llm/cloud-provider-materialization.js"
+
+type MaterializerModule = typeof import("../src/llm/cloud-provider-materialization.js")
+type MaterializeInput = Parameters<MaterializerModule["materializeCloudWorkerProviders"]>[0]
+type Store = NonNullable<MaterializeInput["store"]>
+type FetchImpl = NonNullable<MaterializeInput["fetchImpl"]>
+type Logger = NonNullable<MaterializeInput["logger"]>
+type FetchCall = {
+  method: string
+  path: string
+  headers: Record<string, string>
+  body: unknown
+}
+
+const organizationId = createDenTypeId("organization")
+const instanceUrl = "https://worker.example.test"
+let materializeCloudWorkerProviders: MaterializerModule["materializeCloudWorkerProviders"]
+let computeCloudProviderMaterializationFingerprint: MaterializerModule["computeCloudProviderMaterializationFingerprint"]
+let openworkProvidersFingerprintEnv: string
+
+function seedRequiredEnv() {
+  process.env.DATABASE_URL = process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_test"
+  process.env.DEN_DB_ENCRYPTION_KEY = process.env.DEN_DB_ENCRYPTION_KEY ?? "x".repeat(32)
+  process.env.BETTER_AUTH_SECRET = process.env.BETTER_AUTH_SECRET ?? "y".repeat(32)
+  process.env.BETTER_AUTH_URL = process.env.BETTER_AUTH_URL ?? "http://127.0.0.1:8790"
+  process.env.CORS_ORIGINS = process.env.CORS_ORIGINS ?? "http://127.0.0.1:8790"
+}
+
+beforeAll(async () => {
+  seedRequiredEnv()
+  const materializer = await import("../src/llm/cloud-provider-materialization.js")
+  materializeCloudWorkerProviders = materializer.materializeCloudWorkerProviders
+  computeCloudProviderMaterializationFingerprint = materializer.computeCloudProviderMaterializationFingerprint
+  openworkProvidersFingerprintEnv = materializer.OPENWORK_PROVIDERS_FINGERPRINT_ENV
+})
+
+function jsonResponse(body: unknown, status = 200) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  })
+}
+
+function parseBody(body: BodyInit | null | undefined) {
+  if (typeof body !== "string" || !body.trim()) {
+    return null
+  }
+
+  return JSON.parse(body)
+}
+
+function headersRecord(headers: HeadersInit | undefined) {
+  const record: Record<string, string> = {}
+  new Headers(headers).forEach((value, key) => {
+    record[key] = value
+  })
+  return record
+}
+
+function bodyEntries(body: unknown) {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return []
+  }
+
+  const entries = Object.entries(body).find(([key]) => key === "entries")?.[1]
+  return Array.isArray(entries)
+    ? entries.filter((entry): entry is Record<string, unknown> => typeof entry === "object" && entry !== null && !Array.isArray(entry))
+    : []
+}
+
+function bodyEntryValue(body: unknown, key: string) {
+  for (const entry of bodyEntries(body)) {
+    if (entry.key === key && typeof entry.value === "string") {
+      return entry.value
+    }
+  }
+  return null
+}
+
+function makeAnthropicProvider(input: {
+  apiKey: string
+  modelId?: string
+}): CloudProviderMaterializationProvider {
+  const modelId = input.modelId ?? "claude-fable-5"
+  return {
+    id: createDenTypeId("llmProvider"),
+    source: "models_dev",
+    providerId: "anthropic",
+    name: "Anthropic",
+    providerConfig: {
+      id: "anthropic",
+      name: "Anthropic",
+      npm: "@ai-sdk/anthropic",
+      env: ["ANTHROPIC_API_KEY"],
+      api: "https://api.anthropic.com/v1",
+    },
+    apiKey: input.apiKey,
+    models: [
+      {
+        modelId,
+        name: modelId,
+        modelConfig: {
+          id: modelId,
+          name: modelId,
+          tool_call: true,
+        },
+      },
+    ],
+  }
+}
+
+function makeStore(providers: () => CloudProviderMaterializationProvider[]): Store {
+  return {
+    async listProviders() {
+      return providers()
+    },
+    async getActiveTokens() {
+      return [
+        { scope: "host", token: "host-token" },
+        { scope: "client", token: "client-token" },
+      ]
+    },
+  }
+}
+
+function makeInstance(input: {
+  storedFingerprint?: string | null
+  failEnvWrites?: number
+  runtimeProviders?: Record<string, unknown>
+} = {}) {
+  const calls: FetchCall[] = []
+  let storedFingerprint = input.storedFingerprint ?? null
+  let failEnvWrites = input.failEnvWrites ?? 0
+  const runtimeProviders = input.runtimeProviders ?? {}
+  const fetchImpl: FetchImpl = async (url, init) => {
+    const parsed = new URL(url)
+    const method = init?.method ?? "GET"
+    const body = parseBody(init?.body)
+    calls.push({
+      method,
+      path: parsed.pathname,
+      headers: headersRecord(init?.headers),
+      body,
+    })
+
+    if (method === "GET" && parsed.pathname === `/env/${openworkProvidersFingerprintEnv}`) {
+      return storedFingerprint
+        ? jsonResponse({ item: { key: openworkProvidersFingerprintEnv, value: storedFingerprint } })
+        : jsonResponse({ error: "env_not_found" }, 404)
+    }
+
+    if (method === "GET" && parsed.pathname === "/workspaces") {
+      return jsonResponse({ activeId: "workspace-one", items: [{ id: "workspace-one" }] })
+    }
+
+    if (method === "GET" && parsed.pathname === "/workspace/workspace-one/runtime-config") {
+      return jsonResponse({ runtime: { provider: runtimeProviders } })
+    }
+
+    if (method === "PUT" && parsed.pathname === "/env") {
+      if (failEnvWrites > 0) {
+        failEnvWrites -= 1
+        return jsonResponse({ error: "env_write_failed" }, 500)
+      }
+      const nextFingerprint = bodyEntryValue(body, openworkProvidersFingerprintEnv)
+      if (nextFingerprint) {
+        storedFingerprint = nextFingerprint
+      }
+      return jsonResponse({ ok: true })
+    }
+
+    if (method === "PATCH" && parsed.pathname === "/workspace/workspace-one/config") {
+      return jsonResponse({ updatedAt: Date.now() })
+    }
+
+    if (method === "POST" && parsed.pathname === "/workspace/workspace-one/engine/reload") {
+      return jsonResponse({ ok: true, reloadedAt: Date.now() })
+    }
+
+    return jsonResponse({ error: "not_found" }, 404)
+  }
+
+  return {
+    calls,
+    fetchImpl,
+    get storedFingerprint() {
+      return storedFingerprint
+    },
+  }
+}
+
+function callMethods(calls: FetchCall[]) {
+  return calls.map((call) => `${call.method} ${call.path}`)
+}
+
+function writeCalls(calls: FetchCall[]) {
+  return calls.filter((call) => ["PUT", "PATCH", "POST"].includes(call.method))
+}
+
+async function materialize(input: {
+  workerId?: MaterializeInput["workerId"]
+  providers: () => CloudProviderMaterializationProvider[]
+  fetchImpl: FetchImpl
+  logger?: Logger
+  force?: boolean
+}) {
+  return materializeCloudWorkerProviders({
+    organizationId,
+    workerId: input.workerId ?? createDenTypeId("worker"),
+    instanceUrl,
+    hostToken: "host-token",
+    clientToken: "client-token",
+    store: makeStore(input.providers),
+    fetchImpl: input.fetchImpl,
+    logger: input.logger,
+    force: input.force,
+  })
+}
+
+describe("Cloud provider materialization", () => {
+  test("writes a models.dev provider block, credential env, and reloads OpenCode", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const instance = makeInstance()
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.status).toBe("applied")
+    expect(callMethods(instance.calls)).toEqual([
+      `GET /env/${openworkProvidersFingerprintEnv}`,
+      "GET /workspaces",
+      "GET /workspace/workspace-one/runtime-config",
+      "PUT /env",
+      "PATCH /workspace/workspace-one/config",
+      "POST /workspace/workspace-one/engine/reload",
+      "PUT /env",
+    ])
+    expect(instance.calls[3]?.headers["x-openwork-host-token"]).toBe("host-token")
+    expect(instance.calls[3]?.body).toEqual({
+      entries: [{ key: "ANTHROPIC_API_KEY", value: "sk-anthropic" }],
+    })
+    expect(instance.calls[4]?.headers.authorization).toBe("Bearer client-token")
+    expect(instance.calls[4]?.body).toEqual({
+      opencode: {
+        provider: {
+          [provider.id]: {
+            id: "anthropic",
+            name: "Anthropic",
+            env: ["ANTHROPIC_API_KEY"],
+            models: {
+              "claude-fable-5": {
+                id: "claude-fable-5",
+                name: "claude-fable-5",
+                tool_call: true,
+              },
+            },
+            npm: "@ai-sdk/anthropic",
+            api: "https://api.anthropic.com/v1",
+          },
+        },
+      },
+    })
+    expect(instance.storedFingerprint).toBe(result.fingerprint)
+  })
+
+  test("skips writes and reloads when the stored fingerprint is unchanged", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const fingerprint = computeCloudProviderMaterializationFingerprint([provider])
+    const instance = makeInstance({ storedFingerprint: fingerprint })
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result).toEqual({ ok: true, status: "noop", fingerprint, providers: 1 })
+    expect(callMethods(instance.calls)).toEqual([`GET /env/${openworkProvidersFingerprintEnv}`])
+    expect(writeCalls(instance.calls)).toHaveLength(0)
+  })
+
+  test("reapplies exactly once when providers drift, then caches the resolve check", async () => {
+    const workerId = createDenTypeId("worker")
+    let providers = [makeAnthropicProvider({ apiKey: "sk-first" })]
+    const instance = makeInstance()
+
+    await materialize({ workerId, providers: () => providers, fetchImpl: instance.fetchImpl })
+    instance.calls.length = 0
+
+    providers = [makeAnthropicProvider({ apiKey: "sk-second", modelId: "claude-fable-5-updated" })]
+    const drift = await materialize({ workerId, providers: () => providers, fetchImpl: instance.fetchImpl })
+    expect(drift.ok).toBe(true)
+    expect(drift.status).toBe("applied")
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "POST", "PUT"])
+
+    instance.calls.length = 0
+    const cached = await materialize({ workerId, providers: () => providers, fetchImpl: instance.fetchImpl })
+    expect(cached.ok).toBe(true)
+    expect(cached.status).toBe("cached")
+    expect(instance.calls).toHaveLength(0)
+  })
+
+  test("does not patch provider blocks when credential env write fails, and retries next resolve", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const instance = makeInstance({ failEnvWrites: 1 })
+
+    const failed = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+    })
+
+    expect(failed.ok).toBe(false)
+    expect(callMethods(instance.calls)).toEqual([
+      `GET /env/${openworkProvidersFingerprintEnv}`,
+      "GET /workspaces",
+      "GET /workspace/workspace-one/runtime-config",
+      "PUT /env",
+    ])
+    expect(instance.calls.some((call) => call.method === "PATCH")).toBe(false)
+    expect(instance.calls.some((call) => call.path.endsWith("/engine/reload"))).toBe(false)
+    expect(instance.storedFingerprint).toBeNull()
+
+    instance.calls.length = 0
+    const retried = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+    })
+    expect(retried.ok).toBe(true)
+    expect(retried.status).toBe("applied")
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "POST", "PUT"])
+  })
+
+  test("does not serialize provider keys into logs, results, or fingerprints", async () => {
+    const secret = "sk-secret-never"
+    const provider = makeAnthropicProvider({ apiKey: secret })
+    const instance = makeInstance()
+    const logs: Array<{ message: string; metadata?: Record<string, unknown> }> = []
+    const logger: Logger = {
+      warn(message, metadata) {
+        logs.push({ message, metadata })
+      },
+    }
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      logger,
+      force: true,
+    })
+    const fingerprint = computeCloudProviderMaterializationFingerprint([provider])
+
+    expect(result.ok).toBe(true)
+    expect(JSON.stringify({ logs, result, fingerprint })).not.toContain(secret)
+    expect(fingerprint).not.toContain(secret)
+  })
+})


### PR DESCRIPTION
Org-assigned LLM providers worked on desktop but never worked in the web app. Reproduced on a canary org with an Anthropic (`models_dev`) provider exposing `claude-fable-5`:

```
Den serves it:        anthropic: true, fable: true          ✅
Inside the sandbox:   runtime-opencode-config.json has "anthropic"  ✅
                      ANTHROPIC_API_KEY                      ❌ absent
Console:              [cloud-provider-sync:app_launch] failed. Request timed out.
```

opencode ends up with a provider it cannot use, and **reloading cannot fix it** — the same sync re-runs and times out at the same place, so users are stuck in a half-configured state.

## Three stacked defects

1. `PUT /env` on the instance 401'd for all web users (fixed earlier in #3232/#3234).
2. The client mirrored credentials **only** when `provider.source === "openwork"`, so `models_dev`/`custom` providers never got their key written — by construction, not by accident. The provider block landed without it.
3. Delivery was client-mediated (browser → gateway → instance, multi-call) and timed out mid-sequence, failing **silently and partially**.

## The fix: den-api materializes providers itself

den-api already holds the org's providers, their decryptable keys, the worker's host token, and the instance URL — so it can configure the instance directly, with no browser involved. The materializer:

- loads all org providers (`openwork`, `models_dev`, `custom`), decrypting keys;
- writes each credential to the instance env via `PUT /env` with the **host token** in `x-openwork-host-token` (the actual contract of `requireHostToken`; a client bearer does not work there);
- writes the provider blocks into the runtime opencode config **together with** the credential — never one without the other, which is what produced the unusable state;
- triggers an opencode reload so env-backed providers take effect without a manual restart;
- records a fingerprint (provider ids + config + key **hashes**, never keys) so repeat calls are no-ops.

Called at **provision** (before first paint), at **wake**, and on **resolve when the fingerprint drifts** — that last one is what **recovers sandboxes that are already running in the broken state**, which matters because real users are in it right now. It's fingerprint-gated, so it does not run on every poll.

Failure never blocks serving: resolve returns `providerSync: { status: "degraded" }` and retries on the next drift check, rather than persisting a provider block with no credential.

The client path is kept as a fallback (desktop depends on it) with defect 2 fixed — the mirror no longer skips non-`openwork` providers.

## Secrets hygiene

Keys are never placed in the sandbox start command (process argv is world-readable), never logged, never included in errors or fingerprints (hashed only), and never returned in any den-api response including the gateway resolve payload. Tests assert on serialized output.

## Tests

| Suite | Result |
| --- | --- |
| den-api: materialization, cloud-instance-route, lifecycle, provisioning, recycle, checkpoint | 59 pass / 0 fail |
| apps/app full suite | 494 pass / 0 fail |
| `tsc --noEmit` den-api + app | clean |

Coverage: writes both artifacts + reload; fingerprint no-op; drift reapplies exactly once; credential failure retried with no partial-only state; secret redaction; existing provision/wake/recycle behavior unchanged; client mirror no longer skips non-`openwork` providers.

## Known trade-off

Resolve awaits materialization, so the first resolve after a provider change pays the write latency (subsequent ones are fingerprint no-ops). That is deliberate: providers must exist before first paint, otherwise we are back to a visibly broken picker.

## After deploy

Verifying on the canary org, which is currently in exactly the broken state (provider block present, key missing) — it should self-recover on the next resolve with no user action.