### PR TITLE
fix(chat): fold finished turns behind 'Worked for…' and keep tool aggregates intact

### DIFF
--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -940,12 +940,6 @@ function MessageGroup({
   // Server timestamps, so this survives a reload.
   const stepsStartedAt = stepItems.length > 0 ? getMessageCreated(stepItems[0].message) : null
   const stepsEndedAt = getMessageCompleted(lastItem.message) ?? getMessageCreated(lastItem.message)
-  const stepRunLabel =
-    stepsStartedAt !== null && stepsEndedAt !== null && stepsEndedAt > stepsStartedAt
-      ? `Worked for ${formatToolCallDuration(stepsEndedAt - stepsStartedAt)}`
-      : stepItems.length === 1
-        ? "1 step"
-        : `${stepItems.length} steps`
 
   // The answer message's own thinking belongs to the work, not the answer, so
   // a collapsed run shows it and the message below renders text only.
@@ -972,6 +966,12 @@ function MessageGroup({
           : 1),
       0
     ) + proseReasoning.length
+  const stepRunLabel =
+    stepsStartedAt !== null && stepsEndedAt !== null && stepsEndedAt > stepsStartedAt
+      ? `Worked for ${formatToolCallDuration(stepsEndedAt - stepsStartedAt)}`
+      : stepRowCount === 1
+        ? "1 step"
+        : `${stepRowCount} steps`
   // A short finished run reads fine as a list, so only long ones fold away.
   const collapseSteps =
     !isLiveGroup && stepItems.length > 0 && stepRowCount > COLLAPSED_STEP_RUN_MIN_ROWS

--- a/apps/app/src/components/chat/message-list.tsx
+++ b/apps/app/src/components/chat/message-list.tsx
@@ -97,7 +97,7 @@ import {
 } from "@/lib/tool-activity"
 import { faviconUrlForHref } from "@/lib/favicon"
 import { cn } from "@/lib/utils"
-import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCreated, formatMessageTimestamp, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl } from "./utils"
+import { groupMessages, isMessageGroup, getLastTextPart, getAggregateOnlyParts, getAssistantRenderGroups, getFileTitle, getMediaBadge, getMessageCompleted, getMessageCreated, formatMessageTimestamp, splitTurnAtAnswer, type UIMessageWithIndex, getMessagesText, getSafeFileDownloadUrl } from "./utils"
 import type { AnyToolPart } from "@/lib/tool-aggregate"
 
 const SEARCH_HIGHLIGHT_MARK_CLASS = "rounded px-0.5 bg-amber-4/70 text-current"
@@ -922,12 +922,24 @@ function MessageGroup({
   while (stepCount < items.length && !getRenderableMessage(items[stepCount].message)) {
     stepCount += 1
   }
-  const stepItems = items.slice(0, stepCount)
-  const proseItems = items.slice(stepCount)
-  // How long the turn spent working, from the first step to the message
-  // carrying the answer. Server timestamps, so this survives a reload.
+  let stepItems = items.slice(0, stepCount)
+  let proseItems = items.slice(stepCount)
+  // OpenCode delivers a whole turn as one assistant message with steps and
+  // the answer interleaved in its parts. Split the first prose message so
+  // its leading steps fold with the rest instead of pinning the run open.
+  const firstProse = proseItems[0]
+  if (firstProse && firstProse.message.role === "assistant" && !isSessionErrorMessage(firstProse.message)) {
+    const split = splitTurnAtAnswer(firstProse.message)
+    if (split) {
+      stepItems = [...stepItems, { index: firstProse.index, message: split.steps }]
+      proseItems = [{ index: firstProse.index, message: split.answer }, ...proseItems.slice(1)]
+    }
+  }
+  // How long the turn spent working, from the first step to when the answer
+  // finished (or started, for older history without a completed timestamp).
+  // Server timestamps, so this survives a reload.
   const stepsStartedAt = stepItems.length > 0 ? getMessageCreated(stepItems[0].message) : null
-  const stepsEndedAt = getMessageCreated(lastItem.message)
+  const stepsEndedAt = getMessageCompleted(lastItem.message) ?? getMessageCreated(lastItem.message)
   const stepRunLabel =
     stepsStartedAt !== null && stepsEndedAt !== null && stepsEndedAt > stepsStartedAt
       ? `Worked for ${formatToolCallDuration(stepsEndedAt - stepsStartedAt)}`
@@ -946,12 +958,17 @@ function MessageGroup({
       )
       : []
   )
+  // An aggregate line counts each call it absorbed: it reads as one row but
+  // stands for that much work, and folding should key off the work done.
   const stepRowCount =
     stepItems.reduce(
       (total, item) =>
         total +
         (item.message.role === "assistant" && !isSessionErrorMessage(item.message)
-          ? getAssistantRenderGroups(item.message.parts, showThinking).length
+          ? getAssistantRenderGroups(item.message.parts, showThinking).reduce(
+            (rows, group) => rows + (group.kind === "tool-aggregate" ? group.parts.length : 1),
+            0
+          )
           : 1),
       0
     ) + proseReasoning.length

--- a/apps/app/src/components/chat/utils.ts
+++ b/apps/app/src/components/chat/utils.ts
@@ -81,15 +81,27 @@ export function getSafeFileDownloadUrl(part: Pick<FileUIPart, "url">) {
   }
 }
 
-export function getMessageCreated(message: UIMessage): number | null {
+function getMessageOpencodeMetadata(message: UIMessage): object | null {
   const metadata: unknown = message.metadata
   if (!metadata || typeof metadata !== "object" || !("opencode" in metadata)) return null
 
   const opencode: unknown = metadata.opencode
-  if (!opencode || typeof opencode !== "object" || !("created" in opencode)) return null
+  return opencode && typeof opencode === "object" ? opencode : null
+}
 
+export function getMessageCreated(message: UIMessage): number | null {
+  const opencode = getMessageOpencodeMetadata(message)
+  if (!opencode || !("created" in opencode)) return null
   const created: unknown = opencode.created
   return typeof created === "number" ? created : null
+}
+
+/** When the assistant finished the turn (server timestamp), if known. */
+export function getMessageCompleted(message: UIMessage): number | null {
+  const opencode = getMessageOpencodeMetadata(message)
+  if (!opencode || !("completed" in opencode)) return null
+  const completed: unknown = opencode.completed
+  return typeof completed === "number" ? completed : null
 }
 
 export function formatMessageTimestamp(timestampMs: number): string {
@@ -178,6 +190,36 @@ export function getAggregateOnlyParts(
   return tools.length > 0 ? tools : null
 }
 
+/**
+ * An OpenCode turn usually arrives as ONE assistant message with steps
+ * (reasoning, tool calls, narration) and the final answer interleaved in
+ * `parts`. Split at the last non-empty text part so the step portion can
+ * fold into the "Worked for…" run while the answer stays visible. Returns
+ * null when there is nothing to fold (pure prose, or no work before the
+ * answer).
+ */
+export function splitTurnAtAnswer(message: UIMessage): { steps: UIMessage; answer: UIMessage } | null {
+  const parts = message.parts
+  let answerStart = -1
+  for (let index = parts.length - 1; index >= 0; index -= 1) {
+    const part = parts[index]
+    if (part.type === "text" && part.text.trim()) {
+      answerStart = index
+      break
+    }
+  }
+  if (answerStart <= 0) return null
+
+  const stepParts = parts.slice(0, answerStart)
+  const hasWork = stepParts.some((part) => isToolUIPart(part) || isReasoningUIPart(part))
+  if (!hasWork) return null
+
+  return {
+    steps: { ...message, id: `${message.id}:steps`, parts: stepParts },
+    answer: { ...message, parts: parts.slice(answerStart) },
+  }
+}
+
 export function getAssistantRenderGroups(
   parts: UIMessage["parts"],
   showThinking: boolean
@@ -241,9 +283,12 @@ export function getAssistantRenderGroups(
 
     if (isToolUIPart(part)) {
       // Paper aggregation rule: consecutive command/edit/read/search calls
-      // collapse into one aggregate group; any other part breaks the run.
+      // collapse into one aggregate group. Prose, files, and other tools
+      // break the run; reasoning does not — thinking models emit a
+      // reasoning part before nearly every call, and letting it split the
+      // run degrades every aggregate to a single call.
       if (isAggregatableToolPart(part)) {
-        const previous = groups.at(-1)
+        const previous = groups.findLast((group) => group.kind !== "reasoning")
         if (previous?.kind === "tool-aggregate") {
           previous.parts.push(part)
         } else {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -231,7 +231,9 @@ function createChatTranscriptEvalMessages(sessionId: string) {
           text: "Your plan is drafted — details in [OpenWork](https://openworklabs.com). Search token: chat-transcript-proof.",
         },
       ],
-      metadata: { opencode: { created: now + 1 } },
+      // `completed` makes the finished turn fold behind a real
+      // "Worked for 1m 35s" line, like server-synced turns do.
+      metadata: { opencode: { created: now + 1, completed: now + 95_001 } },
     },
   ];
 

--- a/apps/app/src/react-app/domains/session/sync/session-sync.ts
+++ b/apps/app/src/react-app/domains/session/sync/session-sync.ts
@@ -809,7 +809,7 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
 
   if (event.type === "message.updated") {
     const props = (event.properties ?? {}) as {
-      info?: { id?: string; role?: UIMessage["role"] | string; sessionID?: string; time?: { created?: number } };
+      info?: { id?: string; role?: UIMessage["role"] | string; sessionID?: string; time?: { created?: number; completed?: number } };
     };
     const info = props.info;
     if (!info?.id || !info.sessionID || (info.role !== "user" && info.role !== "assistant" && info.role !== "system")) {
@@ -818,10 +818,13 @@ function applyEvent(entry: SyncEntry, workspaceId: string, event: OpencodeEvent)
     useSessionActivityStore.getState().markMessageRole(workspaceId, info.sessionID, info.id, info.role);
     if (!isTrackedSession(entry, info.sessionID)) return;
     const created = info.time?.created;
+    const completed = info.time?.completed;
     const next = {
       id: info.id,
       role: info.role,
-      ...(typeof created === "number" ? { metadata: { opencode: { created } } } : {}),
+      ...(typeof created === "number"
+        ? { metadata: { opencode: { created, ...(typeof completed === "number" ? { completed } : {}) } } }
+        : {}),
       parts: [],
     } satisfies UIMessage;
     queryClient.setQueryData<UIMessage[]>(transcriptKey(workspaceId, info.sessionID), (current = []) =>

--- a/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
+++ b/apps/app/src/react-app/domains/session/sync/usechat-adapter.ts
@@ -201,10 +201,14 @@ function mapSnapshotToolParts(part: ToolPart): UIMessage["parts"] {
 export function snapshotToUIMessages(snapshot: OpenworkSessionSnapshot): UIMessage[] {
   return snapshot.messages.flatMap((message) => {
     const created = message.info.time?.created;
+    const time = message.info.time;
+    const completed = time && "completed" in time ? time.completed : undefined;
     const uiMessage = {
       id: message.info.id,
       role: message.info.role,
-      ...(typeof created === "number" ? { metadata: { opencode: { created } } } : {}),
+      ...(typeof created === "number"
+        ? { metadata: { opencode: { created, ...(typeof completed === "number" ? { completed } : {}) } } }
+        : {}),
       parts: message.parts.flatMap<UIMessage["parts"][number]>((part) => {
         if (part.type === "text") {
           if (part.synthetic || part.ignored) return [];

--- a/apps/app/tests/chat-message-grouping.test.ts
+++ b/apps/app/tests/chat-message-grouping.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, test } from "bun:test";
+import type { DynamicToolUIPart, UIMessage } from "ai";
+
+import {
+  getAssistantRenderGroups,
+  getMessageCompleted,
+  getMessageCreated,
+  splitTurnAtAnswer,
+} from "../src/components/chat/utils";
+
+function bashPart(id: string): DynamicToolUIPart {
+  return {
+    type: "dynamic-tool",
+    toolName: "bash",
+    toolCallId: id,
+    state: "output-available",
+    input: { command: "ls", description: "list files" },
+    output: "ok",
+  };
+}
+
+function editPart(id: string, filePath: string): DynamicToolUIPart {
+  return {
+    type: "dynamic-tool",
+    toolName: "edit",
+    toolCallId: id,
+    state: "output-available",
+    input: { filePath, oldString: "a", newString: "b" },
+    output: "ok",
+  };
+}
+
+function reasoningPart(text: string): UIMessage["parts"][number] {
+  return { type: "reasoning", text, state: "done" };
+}
+
+function textPart(text: string): UIMessage["parts"][number] {
+  return { type: "text", text, state: "done" };
+}
+
+describe("getAssistantRenderGroups tool aggregation", () => {
+  test("merges consecutive aggregatable tool calls into one group", () => {
+    const groups = getAssistantRenderGroups(
+      [bashPart("c1"), bashPart("c2"), editPart("c3", "/tmp/a.ts")],
+      false
+    );
+
+    expect(groups).toHaveLength(1);
+    expect(groups[0].kind).toBe("tool-aggregate");
+    if (groups[0].kind === "tool-aggregate") {
+      expect(groups[0].parts).toHaveLength(3);
+    }
+  });
+
+  test("reasoning between tool calls does not break the run (thinking models)", () => {
+    const groups = getAssistantRenderGroups(
+      [
+        reasoningPart("let me look"),
+        bashPart("c1"),
+        reasoningPart("now edit"),
+        editPart("c2", "/tmp/a.ts"),
+        reasoningPart("one more"),
+        bashPart("c3"),
+        textPart("Done."),
+      ],
+      true
+    );
+
+    const aggregates = groups.filter((group) => group.kind === "tool-aggregate");
+    expect(aggregates).toHaveLength(1);
+    if (aggregates[0].kind === "tool-aggregate") {
+      expect(aggregates[0].parts.map((part) => part.toolCallId)).toEqual(["c1", "c2", "c3"]);
+    }
+    // Reasoning still renders, just without splitting the aggregate.
+    expect(groups.filter((group) => group.kind === "reasoning").length).toBeGreaterThan(0);
+    expect(groups.at(-1)?.kind).toBe("text");
+  });
+
+  test("prose between tool calls breaks the run", () => {
+    const groups = getAssistantRenderGroups(
+      [bashPart("c1"), textPart("Now editing:"), editPart("c2", "/tmp/a.ts")],
+      false
+    );
+
+    const aggregates = groups.filter((group) => group.kind === "tool-aggregate");
+    expect(aggregates).toHaveLength(2);
+  });
+});
+
+describe("splitTurnAtAnswer", () => {
+  test("splits a single-message turn into steps and the final answer", () => {
+    const message: UIMessage = {
+      id: "msg-1",
+      role: "assistant",
+      parts: [
+        { type: "step-start" },
+        reasoningPart("thinking"),
+        bashPart("c1"),
+        textPart("Let me also check something."),
+        bashPart("c2"),
+        textPart("All done — here is the summary."),
+      ],
+    };
+
+    const split = splitTurnAtAnswer(message);
+    expect(split).not.toBeNull();
+    expect(split?.steps.id).toBe("msg-1:steps");
+    expect(split?.steps.parts).toHaveLength(5);
+    expect(split?.answer.id).toBe("msg-1");
+    expect(split?.answer.parts).toHaveLength(1);
+    const answerPart = split?.answer.parts[0];
+    expect(answerPart?.type === "text" && answerPart.text).toBe("All done — here is the summary.");
+  });
+
+  test("returns null for a pure prose message", () => {
+    const message: UIMessage = {
+      id: "msg-2",
+      role: "assistant",
+      parts: [textPart("Just an answer.")],
+    };
+    expect(splitTurnAtAnswer(message)).toBeNull();
+  });
+
+  test("returns null when there is no answer text after the work", () => {
+    const message: UIMessage = {
+      id: "msg-3",
+      role: "assistant",
+      parts: [bashPart("c1"), bashPart("c2")],
+    };
+    expect(splitTurnAtAnswer(message)).toBeNull();
+  });
+});
+
+describe("message timestamps", () => {
+  test("reads created and completed from opencode metadata", () => {
+    const message: UIMessage = {
+      id: "msg-4",
+      role: "assistant",
+      metadata: { opencode: { created: 1000, completed: 61000 } },
+      parts: [textPart("hi")],
+    };
+    expect(getMessageCreated(message)).toBe(1000);
+    expect(getMessageCompleted(message)).toBe(61000);
+  });
+
+  test("returns null when completed is absent", () => {
+    const message: UIMessage = {
+      id: "msg-5",
+      role: "assistant",
+      metadata: { opencode: { created: 1000 } },
+      parts: [textPart("hi")],
+    };
+    expect(getMessageCompleted(message)).toBeNull();
+  });
+});

--- a/apps/app/tests/message-list-step-fold.test.tsx
+++ b/apps/app/tests/message-list-step-fold.test.tsx
@@ -1,0 +1,147 @@
+/** @jsxImportSource react */
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import type { DynamicToolUIPart, UIMessage } from "ai";
+
+import { MessageList } from "../src/components/chat/message-list";
+import { MessageListProvider } from "../src/components/chat/message-list-provider";
+
+function bashPart(id: string): DynamicToolUIPart {
+  return {
+    type: "dynamic-tool",
+    toolName: "bash",
+    toolCallId: id,
+    state: "output-available",
+    input: { command: `echo ${id}`, description: "run" },
+    output: "ok",
+  };
+}
+
+function editPart(id: string, filePath: string): DynamicToolUIPart {
+  return {
+    type: "dynamic-tool",
+    toolName: "edit",
+    toolCallId: id,
+    state: "output-available",
+    input: { filePath, oldString: "a", newString: "b" },
+    output: "ok",
+  };
+}
+
+/**
+ * Other test files stub `globalThis.window` and can leak it into a shared
+ * bun test worker. Static SSR rendering must not see a partial window stub
+ * (components probe it for addEventListener), so hide it for the render.
+ */
+function withoutWindow<T>(run: () => T): T {
+  const descriptor = Object.getOwnPropertyDescriptor(globalThis, "window");
+  if (descriptor?.configurable) {
+    Reflect.deleteProperty(globalThis, "window");
+  }
+  try {
+    return run();
+  } finally {
+    if (descriptor?.configurable) {
+      Object.defineProperty(globalThis, "window", descriptor);
+    }
+  }
+}
+
+function renderList(messages: UIMessage[]) {
+  return withoutWindow(() => renderToStaticMarkup(
+    <MessageListProvider
+      workspaceId="ws"
+      sessionId="session"
+      showThinking={true}
+      developerMode={false}
+      displaySuggestions={false}
+      providerConnectedCount={1}
+      dispatchAction={() => {}}
+      setPrompt={() => {}}
+      onRevertToUserMessage={() => {}}
+      onForkAtMessage={() => {}}
+      onEditUserMessage={() => {}}
+      onMcpReconnect={() => Promise.reject(new Error("unused"))}
+      onMcpReopenAuthorization={() => Promise.resolve()}
+      onMcpRetry={() => {}}
+    >
+      <MessageList messages={messages} status="ready" />
+    </MessageListProvider>
+  ));
+}
+
+const userMessage: UIMessage = {
+  id: "user-1",
+  role: "user",
+  metadata: { opencode: { created: 1_000 } },
+  parts: [{ type: "text", text: "do the thing", state: "done" }],
+};
+
+describe("finished turn step fold (single OpenCode message per turn)", () => {
+  test("folds interleaved steps into a 'Worked for …' line and keeps the answer", () => {
+    const assistant: UIMessage = {
+      id: "assistant-1",
+      role: "assistant",
+      metadata: { opencode: { created: 1_000, completed: 80_000 } },
+      parts: [
+        { type: "step-start" },
+        { type: "reasoning", text: "planning the change", state: "done" },
+        bashPart("c1"),
+        editPart("c2", "/repo/src/a.ts"),
+        { type: "text", text: "Now checking the result:", state: "done" },
+        bashPart("c3"),
+        bashPart("c4"),
+        bashPart("c5"),
+        { type: "text", text: "Everything passed — the change is in.", state: "done" },
+      ],
+    };
+
+    const markup = renderList([userMessage, assistant]);
+
+    // 79 seconds of work between created and completed.
+    expect(markup).toContain("Worked for 1m 19s");
+    // The answer stays visible outside the fold.
+    expect(markup).toContain("Everything passed — the change is in.");
+  });
+
+  test("a short turn stays inline with one aggregate line", () => {
+    const assistant: UIMessage = {
+      id: "assistant-2",
+      role: "assistant",
+      metadata: { opencode: { created: 1_000, completed: 5_000 } },
+      parts: [
+        { type: "step-start" },
+        bashPart("c1"),
+        editPart("c2", "/repo/src/a.ts"),
+        { type: "text", text: "Done.", state: "done" },
+      ],
+    };
+
+    const markup = renderList([userMessage, assistant]);
+
+    expect(markup).not.toContain("Worked for");
+    // Both calls merge into one aggregate summary line.
+    expect(markup).toContain("Edited 1 file, ran 1 command");
+    expect(markup).toContain("Done.");
+  });
+
+  test("reasoning between calls does not fragment the aggregate", () => {
+    const assistant: UIMessage = {
+      id: "assistant-3",
+      role: "assistant",
+      metadata: { opencode: { created: 1_000, completed: 4_000 } },
+      parts: [
+        { type: "step-start" },
+        { type: "reasoning", text: "first", state: "done" },
+        bashPart("c1"),
+        { type: "reasoning", text: "second", state: "done" },
+        bashPart("c2"),
+        { type: "text", text: "Done.", state: "done" },
+      ],
+    };
+
+    const markup = renderList([userMessage, assistant]);
+
+    expect(markup).toContain("Ran 2 commands");
+  });
+});

--- a/evals/flows/chat-step-fold.flow.mjs
+++ b/evals/flows/chat-step-fold.flow.mjs
@@ -1,0 +1,112 @@
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const vo = await loadVoiceoverParagraphs("chat-step-fold");
+
+/**
+ * A finished turn's steps fold behind a "Worked for …" line (real duration
+ * from the assistant's completed timestamp), and reasoning between tool
+ * calls no longer fragments the aggregate summary. Proven on the
+ * deterministic seeded turn (dev-only `eval.chat_transcript.seed`), which
+ * ships steps and the final answer interleaved in ONE assistant message —
+ * the exact shape OpenCode delivers.
+ */
+export default {
+  id: "chat-step-fold",
+  title: "Finished turns fold behind 'Worked for …'; aggregates survive thinking",
+  kind: "user-facing",
+  precondition: async (ctx) => {
+    await ctx.waitFor("Boolean(window.__openworkControl)", {
+      timeoutMs: 60_000,
+      label: "control API",
+    });
+    const state = await ctx.waitFor(
+      `(() => {
+        const control = window.__openworkControl;
+        const route = control.snapshot().route;
+        if (route.startsWith("/welcome") || route.startsWith("/signin")) return "blocked";
+        const action = control.listActions().find((a) => a.id === "session.create_task");
+        if (action && !action.disabled) return "ready";
+        return null;
+      })()`,
+      { timeoutMs: 30_000, label: "session.create_task enabled (or welcome/signin)" },
+    );
+    return state === "blocked"
+      ? "Profile is not onboarded (welcome/signin); this flow requires a workspace."
+      : null;
+  },
+  steps: [
+    {
+      name: "A finished turn folds behind a duration line, answer stays visible",
+      run: async (ctx) => {
+        // Idempotency: reload resets any panels a previous run left open.
+        await ctx.eval("location.reload()");
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after reload" });
+        await ctx.waitFor(
+          `window.__openworkControl.listActions().some((a) => a.id === "session.create_task" && !a.disabled)`,
+          { timeoutMs: 30_000, label: "task creation ready" },
+        );
+        await ctx.control("session.create_task");
+        await ctx.waitFor(
+          `window.__openworkControl.listActions().some((a) => a.id === "eval.chat_transcript.seed" && !a.disabled)`,
+          { timeoutMs: 30_000, label: "chat transcript seed action" },
+        );
+        await ctx.control("eval.chat_transcript.seed");
+
+        await ctx.prove("Steps fold into one 'Worked for 1m 35s' line; the answer stays visible", {
+          voiceover: vo[0],
+          action: async () => {
+            await ctx.waitForText("Worked for 1m 35s", { timeoutMs: 30_000 });
+          },
+          assert: async () => {
+            await ctx.expectText("Worked for 1m 35s");
+            // The answer is outside the fold.
+            await ctx.expectText("Your plan is drafted");
+            // Step-level content is folded away until expanded.
+            await ctx.expectNoText("git status --short");
+            await ctx.expectNoText("Fetched Google Workspace Calendar Events");
+          },
+          screenshot: {
+            name: "turn-folded-worked-for",
+            requireText: ["Worked for 1m 35s", "Your plan is drafted"],
+            rejectText: ["git status --short"],
+          },
+        });
+      },
+    },
+    {
+      name: "Expanding the fold shows one aggregate line despite interleaved reasoning",
+      run: async (ctx) => {
+        await ctx.prove("The reopened run keeps tool work merged into a single aggregate line", {
+          voiceover: vo[1],
+          action: async () => {
+            await ctx.waitFor(`(() => {
+              const trigger = [...document.querySelectorAll("button")]
+                .find((node) => node.textContent.includes("Worked for"));
+              if (!trigger) return false;
+              if (trigger.getAttribute("aria-expanded") !== "true") trigger.click();
+              return trigger.getAttribute("aria-expanded") === "true";
+            })()`, { timeoutMs: 15_000, label: "step fold expanded" });
+            await ctx.waitForText("Edited 1 file, ran 2 commands, read 1 file", { timeoutMs: 15_000 });
+            await ctx.eval(`document.querySelector("[data-tool-aggregate]")?.scrollIntoView({ block: "center" })`);
+          },
+          assert: async () => {
+            // One merged summary — the seeded turn has reasoning before the
+            // calls, which previously fragmented this into per-call lines.
+            await ctx.expectText("Edited 1 file, ran 2 commands, read 1 file");
+            const aggregateCount = await ctx.eval(
+              `document.querySelectorAll("[data-tool-aggregate]").length`,
+            );
+            ctx.assert(
+              aggregateCount === 1,
+              `Expected exactly one aggregate group, got ${aggregateCount}.`,
+            );
+          },
+          screenshot: {
+            name: "fold-expanded-single-aggregate",
+            requireText: ["Edited 1 file, ran 2 commands, read 1 file"],
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/chat-transcript-sentences.flow.mjs
+++ b/evals/flows/chat-transcript-sentences.flow.mjs
@@ -50,6 +50,16 @@ export default {
           { timeoutMs: 30_000, label: "chat transcript seed action" },
         );
         await ctx.control("eval.chat_transcript.seed");
+        // The finished turn folds its steps behind a "Worked for …" line;
+        // expand it so the step-level assertions below can see the run.
+        await ctx.waitForText("Worked for 1m 35s", { timeoutMs: 30_000 });
+        await ctx.waitFor(`(() => {
+          const trigger = [...document.querySelectorAll("button")]
+            .find((node) => node.textContent.includes("Worked for"));
+          if (!trigger) return false;
+          if (trigger.getAttribute("aria-expanded") !== "true") trigger.click();
+          return trigger.getAttribute("aria-expanded") === "true";
+        })()`, { timeoutMs: 15_000, label: "step fold expanded" });
         await ctx.waitForText("Fetched Google Workspace Calendar Events", { timeoutMs: 30_000 });
 
         await ctx.prove("Capability call reads as a sentence; the pasted link gets a favicon", {

--- a/evals/voiceovers/chat-step-fold.md
+++ b/evals/voiceovers/chat-step-fold.md
@@ -1,0 +1,5 @@
+# chat-step-fold — Finished work folds away, the answer stays
+
+1. When the agent finishes a long turn, the intermediate work tucks itself behind a single line telling me how long it worked — while the final answer stays right in front of me.
+
+2. One click on that line reopens the whole run — and the routine tool work still reads as one tidy summary line, one file edited, two commands run, one file read, even though the model was thinking between every call.


### PR DESCRIPTION
## Summary

- **The completed-turn fold never fired.** It only collapsed leading prose-free *messages*, but OpenCode delivers a whole turn as one assistant message with steps and the answer interleaved in `parts`. `splitTurnAtAnswer` now splits the turn at its final answer text so the steps fold behind a `Worked for 1m 19s`-style line while the answer stays visible.
- **Real durations.** The assistant's `time.completed` is now mapped through both snapshot and live sync (`metadata.opencode.completed`), so the fold shows how long the turn actually worked and survives reloads. The fallback label counts step rows instead of messages.
- **Aggregates survive thinking models.** Reasoning parts no longer break a tool-aggregate run (thinking models emit reasoning before nearly every call, which degraded every aggregate to "Ran 1 command"). Prose and other tools still break runs. The fold threshold counts calls absorbed into an aggregate, not rendered rows.
- The dev-only seeded transcript (`eval.chat_transcript.seed`) carries `completed` so it demos the fold; the `chat-transcript-sentences` flow expands the fold before asserting step content; new `chat-step-fold` flow + voiceover prove the feature.

## Evidence

fraimz posted as a comment below (`pnpm fraimz --flow chat-step-fold --pr`).

### Build verification
- `pnpm --filter @openwork/app build` — passed

### Tests
- `bun test --isolate tests/` (apps/app) — **504 pass, 0 fail** (includes new `chat-message-grouping.test.ts` unit tests and `message-list-step-fold.test.tsx` render-level tests of the fold/aggregate behavior)
- `pnpm exec tsc --noEmit` (apps/app) — clean

### UI verification (fraimz, real Electron via CDP)
- `pnpm fraimz --flow chat-step-fold --cdp-url http://127.0.0.1:9826` — **PASSED** (turn folds behind "Worked for 1m 35s" with the answer visible; expanding shows exactly one aggregate line despite interleaved reasoning)
- `pnpm fraimz --flow chat-transcript-sentences --cdp-url http://127.0.0.1:9826` — **PASSED** (no regression: sentences, aggregate rows, thinking toggle, failure card, FILES strip)

## Test instructions

1. `OPENWORK_ELECTRON_REMOTE_DEBUG_PORT=9826 pnpm dev`
2. `pnpm fraimz --flow chat-step-fold --cdp-url http://127.0.0.1:9826`
3. Or manually: create a task, run `eval.chat_transcript.seed` via `__openworkControl`, and check the turn folds behind "Worked for 1m 35s"; expand it and confirm "Edited 1 file, ran 2 commands, read 1 file" is one line.

Made with [Cursor](https://cursor.com)