### PR TITLE
feat(den-web): make the member dashboard a single download action

### DIFF
--- a/ee/apps/den-web/app/(den)/dashboard/_components/member-dashboard-screen.tsx
+++ b/ee/apps/den-web/app/(den)/dashboard/_components/member-dashboard-screen.tsx
@@ -1,274 +1,111 @@
 "use client";
 
-import { useQuery } from "@tanstack/react-query";
-import {
-  CheckCircle2,
-  ChevronRight,
-  Users,
-} from "lucide-react";
-import { getErrorMessage, requestJson } from "../../_lib/den-flow";
-import { formatRoleLabel } from "../../_lib/den-org";
+import { useState } from "react";
+import { Download } from "lucide-react";
+import { DenButton } from "../../_components/ui/button";
+import { createOrganizationInstallLink } from "../../_lib/install-link-data";
 import { useOrgDashboard } from "../_providers/org-dashboard-provider";
-import {
-  formatProviderTimestamp,
-  getProviderEnvNames,
-  useOrgLlmProviders,
-} from "./llm-provider-data";
-import { useMarketplaces } from "./marketplace-data";
-import { OrganizationDownloadCard } from "./organization-download-card";
-import { getPluginPartsSummary, usePlugins } from "./plugin-data";
 
-type MemberInferenceStatus = {
-  enabled: boolean;
-  subscribed: boolean | null;
-  memberCount: number;
-};
+const OPEN_APP_URL = "openwork://open";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function parseInferenceStatus(payload: unknown): MemberInferenceStatus | null {
-  if (!isRecord(payload) || !isRecord(payload.inference)) {
-    return null;
-  }
-
-  const inference = payload.inference;
-  if (typeof inference.enabled !== "boolean") {
-    return null;
-  }
-
-  return {
-    enabled: inference.enabled,
-    subscribed: typeof inference.subscribed === "boolean" ? inference.subscribed : null,
-    memberCount: typeof inference.memberCount === "number" ? inference.memberCount : 0,
-  };
-}
-
-async function fetchInferenceStatus() {
-  const { response, payload } = await requestJson("/v1/inference", { method: "GET" }, 12000);
-  if (!response.ok) {
-    throw new Error(getErrorMessage(payload, `Failed to load OpenWork Models status (${response.status}).`));
-  }
-
-  const parsed = parseInferenceStatus(payload);
-  if (!parsed) {
-    throw new Error("OpenWork Models status response was incomplete.");
-  }
-
-  return parsed;
-}
-
-function getErrorText(error: unknown) {
-  return error instanceof Error ? error.message : "Something went wrong.";
-}
-
-function ErrorNotice({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="rounded-2xl border border-amber-200 bg-amber-50 px-4 py-3 text-[13px] leading-5 text-amber-800">
-      {children}
-    </div>
-  );
-}
-
-function EmptyList({ children }: { children: React.ReactNode }) {
-  return (
-    <div className="rounded-2xl border border-dashed border-gray-200 bg-gray-50 px-4 py-6 text-center text-[13px] text-gray-500">
-      {children}
-    </div>
-  );
-}
-
+/**
+ * Members have exactly one job on the dashboard: install the app. The
+ * install link is minted by the workspace's own den (cloud or self-hosted),
+ * so the download is preconfigured to connect to the right server — models,
+ * marketplaces, and plugins all sync inside the app after sign-in.
+ */
 export function MemberDashboardScreen() {
-  const { activeOrg, orgContext, orgId } = useOrgDashboard();
-  const { llmProviders, busy: providersBusy, error: providersError } = useOrgLlmProviders(orgId, { scope: "usable" });
-  const { data: marketplaces = [], isLoading: marketplacesLoading, error: marketplacesError } = useMarketplaces();
-  const { data: plugins = [], isLoading: pluginsLoading, error: pluginsError } = usePlugins();
-  const { data: inference, isLoading: inferenceLoading, error: inferenceError } = useQuery({
-    enabled: Boolean(orgId),
-    queryKey: ["member-dashboard", "inference", orgId],
-    queryFn: fetchInferenceStatus,
-  });
+  const { activeOrg, orgId } = useOrgDashboard();
+  const [busyAction, setBusyAction] = useState<"download" | "copy" | null>(null);
+  const [copied, setCopied] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
-  const customProviders = llmProviders.filter((provider) => provider.source !== "openwork");
+  const orgName = activeOrg?.name ?? "Your workspace";
 
-  const currentMember = orgContext?.currentMember;
-  const teamNames = orgContext?.currentMemberTeams.map((team) => team.name).sort((a, b) => a.localeCompare(b)) ?? [];
-  const roleLabel = currentMember ? formatRoleLabel(currentMember.role) : "Member";
-  const inferenceLabel = inferenceLoading ? "Checking" : inference?.enabled ? "Enabled" : "Disabled";
+  async function mintInstallLink() {
+    if (!orgId) {
+      throw new Error("No active workspace. Reload and try again.");
+    }
+    return createOrganizationInstallLink(orgId, false);
+  }
+
+  async function handleDownload() {
+    setBusyAction("download");
+    setError(null);
+    try {
+      window.open(await mintInstallLink(), "_blank");
+    } catch (downloadError) {
+      setError(downloadError instanceof Error ? downloadError.message : "Could not open the install page.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
+
+  async function handleCopyInstallLink() {
+    setBusyAction("copy");
+    setError(null);
+    setCopied(false);
+    try {
+      await navigator.clipboard.writeText(await mintInstallLink());
+      setCopied(true);
+      window.setTimeout(() => setCopied(false), 1800);
+    } catch (copyError) {
+      setError(copyError instanceof Error ? copyError.message : "Could not copy the install link.");
+    } finally {
+      setBusyAction(null);
+    }
+  }
 
   return (
-    <div className="mx-auto max-w-[1100px] px-4 pb-10 pt-4 sm:px-6 md:px-8" data-testid="member-dashboard">
-      <div className="flex flex-wrap items-center gap-2.5 border-b border-[#e7e9f0] pb-3">
-        <span className="text-[14px] font-semibold tracking-[-0.01em] text-[#07192C]">
-          {activeOrg?.name ?? "OpenWork Cloud"}
-        </span>
-        <ChevronRight className="h-3.5 w-3.5 text-[#9AA5BA]" aria-hidden="true" />
-        <span className="text-[14px] font-medium tracking-[-0.01em] text-[#5A6886]">Dashboard</span>
-      </div>
+    <div className="flex min-h-[72vh] items-center justify-center px-4" data-testid="member-dashboard">
+      <div className="flex w-full max-w-xl flex-col items-center pb-12 text-center">
+        <p className="text-[11px] font-semibold uppercase tracking-[0.22em] text-gray-500">Your workspace</p>
+        <h1 className="mt-3 text-[30px] font-semibold leading-[1.15] tracking-[-0.04em] text-gray-950 sm:text-[34px]">
+          {orgName} is set up for you
+        </h1>
+        <p className="mt-3 max-w-md text-[15px] leading-6 text-gray-500">
+          {`Your download is already preconfigured for ${orgName} — open it, sign in, and your team's models and plugins are there.`}
+        </p>
 
-      <div className="mt-4 grid gap-3 md:grid-cols-[1fr_auto] md:items-end">
-        <div>
-          <h1 className="text-[22px] font-semibold tracking-[-0.03em] text-[#07192C]">Your workspace</h1>
-          <p className="mt-1 max-w-[680px] text-[14px] leading-6 text-[#5A6886]">
-            The models, marketplaces, and plugins available to you in OpenWork.
+        <DenButton
+          className="mt-8"
+          data-testid="member-download-app"
+          icon={Download}
+          loading={busyAction === "download"}
+          disabled={busyAction !== null}
+          onClick={() => void handleDownload()}
+        >
+          Download OpenWork
+        </DenButton>
+
+        <div className="mt-3 flex items-center gap-1.5 text-[12px] text-gray-400">
+          <span>macOS · Windows · Linux</span>
+          <span aria-hidden className="text-gray-300">
+            ·
+          </span>
+          <button
+            type="button"
+            data-testid="member-copy-install-link"
+            onClick={() => void handleCopyInstallLink()}
+            disabled={busyAction !== null}
+            className="font-medium text-gray-600 transition hover:text-gray-950"
+          >
+            {copied ? "Copied" : "Copy install link instead"}
+          </button>
+        </div>
+
+        {error ? (
+          <p role="alert" className="mt-4 text-[13px] text-red-600">
+            {error}
           </p>
-        </div>
-        <div className="flex items-center gap-3 rounded-2xl border border-gray-100 bg-white px-4 py-3">
-          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-[10px] bg-gray-50 text-gray-500">
-            <Users className="h-4 w-4" aria-hidden="true" />
-          </div>
-          <div className="min-w-0">
-            <p className="text-[12px] text-gray-500">Signed in as {roleLabel}</p>
-            <p className="max-w-[320px] truncate text-[13px] font-medium text-gray-900">
-              {teamNames.length > 0 ? teamNames.join(", ") : "No team assignment"}
-            </p>
-          </div>
-        </div>
-      </div>
+        ) : null}
 
-      {activeOrg && orgContext?.capabilities.installLinks ? (
-        <div className="mt-5">
-          <OrganizationDownloadCard organizationId={activeOrg.id} organizationName={activeOrg.name} />
-        </div>
-      ) : null}
-
-      <div className="mt-5 grid gap-5 lg:grid-cols-[1fr_1fr]">
-        <section className="rounded-2xl border border-gray-100 bg-white p-5">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">LLM providers</h2>
-              <p className="mt-1 text-[13px] text-gray-500">Custom providers you can use from OpenWork.</p>
-            </div>
-            <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-              {customProviders.length} available
-            </span>
-          </div>
-
-          <div className="mt-5 grid gap-3">
-            {providersError ? <ErrorNotice>{providersError}</ErrorNotice> : null}
-            {providersBusy ? (
-              <EmptyList>Loading providers...</EmptyList>
-            ) : customProviders.length === 0 ? (
-              <EmptyList>No custom providers are available to you yet.</EmptyList>
-            ) : (
-              customProviders.slice(0, 5).map((provider) => {
-                const envNames = getProviderEnvNames(provider.providerConfig);
-                return (
-                  <div key={provider.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
-                    <div className="flex items-start justify-between gap-3">
-                      <div className="min-w-0">
-                        <p className="truncate text-[14px] font-semibold text-gray-950">{provider.name}</p>
-                        <p className="mt-1 text-[12px] text-gray-500">{provider.models.length} model{provider.models.length === 1 ? "" : "s"}</p>
-                      </div>
-                      <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] text-gray-500">
-                        {provider.source === "custom" ? "Custom" : "Catalog"}
-                      </span>
-                    </div>
-                    <p className="mt-3 text-[12px] text-gray-500">
-                      {envNames.length > 0 ? envNames.slice(0, 3).join(", ") : "No environment keys listed"} - Updated {formatProviderTimestamp(provider.updatedAt)}
-                    </p>
-                  </div>
-                );
-              })
-            )}
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-gray-100 bg-white p-5">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">OpenWork Models</h2>
-              <p className="mt-1 text-[13px] text-gray-500">Org-provided inference status.</p>
-            </div>
-            <span className={`rounded-full px-3 py-1 text-[12px] font-medium ${inference?.enabled ? "bg-emerald-50 text-emerald-700" : "bg-amber-50 text-amber-700"}`}>
-              {inferenceLabel}
-            </span>
-          </div>
-
-          <div className="mt-5 grid gap-3">
-            {inferenceError ? <ErrorNotice>{getErrorText(inferenceError)}</ErrorNotice> : null}
-            <div className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-4">
-              <div className="flex items-center gap-3">
-                <CheckCircle2 className={`h-5 w-5 ${inference?.enabled ? "text-emerald-600" : "text-gray-400"}`} aria-hidden="true" />
-                <div>
-                  <p className="text-[14px] font-semibold text-gray-950">
-                    {inference?.enabled ? "Enabled for this workspace" : "Not enabled for this workspace"}
-                  </p>
-                  <p className="mt-1 text-[12px] text-gray-500">
-                    {inference?.subscribed === false ? "The workspace needs an active subscription before members can use OpenWork Models." : `${inference?.memberCount ?? 0} member${inference?.memberCount === 1 ? "" : "s"} included in usage limits.`}
-                  </p>
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-      </div>
-
-      <div className="mt-5 grid gap-5 lg:grid-cols-[1fr_1fr]">
-        <section className="rounded-2xl border border-gray-100 bg-white p-5">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">Marketplaces</h2>
-              <p className="mt-1 text-[13px] text-gray-500">Marketplaces contain plugins and sync into the app after sign-in.</p>
-            </div>
-            <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-              {marketplaces.length} visible
-            </span>
-          </div>
-
-          <div className="mt-5 grid gap-3">
-            {marketplacesError ? <ErrorNotice>{getErrorText(marketplacesError)}</ErrorNotice> : null}
-            {marketplacesLoading ? (
-              <EmptyList>Loading marketplaces...</EmptyList>
-            ) : marketplaces.length === 0 ? (
-              <EmptyList>No marketplaces are available to you yet.</EmptyList>
-            ) : (
-              marketplaces.slice(0, 5).map((marketplace) => (
-                <div key={marketplace.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
-                  <div className="flex items-start justify-between gap-3">
-                    <div className="min-w-0">
-                      <p className="truncate text-[14px] font-semibold text-gray-950">{marketplace.name}</p>
-                      {marketplace.description ? <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-gray-500">{marketplace.description}</p> : null}
-                    </div>
-                    <span className="shrink-0 rounded-full bg-white px-2 py-1 text-[11px] text-gray-500">
-                      {marketplace.pluginCount} plugin{marketplace.pluginCount === 1 ? "" : "s"}
-                    </span>
-                  </div>
-                </div>
-              ))
-            )}
-          </div>
-        </section>
-
-        <section className="rounded-2xl border border-gray-100 bg-white p-5">
-          <div className="flex items-center justify-between gap-4">
-            <div>
-              <h2 className="text-[18px] font-semibold tracking-[-0.03em] text-gray-950">Plugins</h2>
-              <p className="mt-1 text-[13px] text-gray-500">Skills, hooks, MCPs, agents, and commands you can use.</p>
-            </div>
-            <span className="rounded-full bg-gray-100 px-3 py-1 text-[12px] font-medium text-gray-600">
-              {plugins.length} visible
-            </span>
-          </div>
-
-          <div className="mt-5 grid gap-3">
-            {pluginsError ? <ErrorNotice>{getErrorText(pluginsError)}</ErrorNotice> : null}
-            {pluginsLoading ? (
-              <EmptyList>Loading plugins...</EmptyList>
-            ) : plugins.length === 0 ? (
-              <EmptyList>No plugins are available to you yet.</EmptyList>
-            ) : (
-              plugins.slice(0, 5).map((plugin) => (
-                <div key={plugin.id} className="rounded-2xl border border-gray-100 bg-gray-50 px-4 py-3">
-                  <p className="truncate text-[14px] font-semibold text-gray-950">{plugin.name}</p>
-                  <p className="mt-1 line-clamp-2 text-[12px] leading-5 text-gray-500">{plugin.description}</p>
-                  <p className="mt-3 text-[12px] text-gray-500">{getPluginPartsSummary(plugin)}</p>
-                </div>
-              ))
-            )}
-          </div>
-        </section>
+        <p className="mt-10 w-full border-t border-gray-100 pt-5 text-[13px] text-gray-500">
+          Already installed?{" "}
+          <a href={OPEN_APP_URL} className="font-medium text-gray-900 underline-offset-2 hover:underline">
+            Open OpenWork →
+          </a>
+        </p>
       </div>
     </div>
   );

--- a/ee/apps/den-web/tests/dashboard-home-layout.test.ts
+++ b/ee/apps/den-web/tests/dashboard-home-layout.test.ts
@@ -20,28 +20,29 @@ describe("dashboard home layouts", () => {
     expect(promotion).toContain("Download the app to unlock extensions");
   });
 
-  test("retains the organization download card on both dashboard experiences", () => {
+  test("retains the organization download card on the admin overview", () => {
     const overview = readDashboardComponent("dashboard-overview-screen.tsx");
-    const member = readDashboardComponent("member-dashboard-screen.tsx");
     const downloadCard = readDashboardComponent("organization-download-card.tsx");
 
     expect(overview).toContain("<OrganizationDownloadCard");
-    expect(member).toContain("<OrganizationDownloadCard");
     expect(downloadCard).toContain('data-testid="workspace-install-card"');
     expect(downloadCard).toContain('data-testid="workspace-install-open"');
   });
 
-  test("member dashboard lists usable resources without a summary strip of empty counts", () => {
+  test("member dashboard is a single download action, not a resource inventory", () => {
     const member = readDashboardComponent("member-dashboard-screen.tsx");
 
     expect(member).toContain('data-testid="member-dashboard"');
-    expect(member).not.toContain('data-testid="member-resource-overview"');
-    expect(member).not.toContain('data-testid="member-resource-card"');
-    expect(member).not.toContain("Available resources");
-    expect(member).toContain('useOrgLlmProviders(orgId, { scope: "usable" })');
-    expect(member).toContain("useMarketplaces()");
-    expect(member).toContain("usePlugins()");
-    expect(member).toContain('requestJson("/v1/inference"');
+    expect(member).toContain('data-testid="member-download-app"');
+    expect(member).toContain('data-testid="member-copy-install-link"');
+    // The install link is minted by the workspace's own den, so the same
+    // action works for OpenWork Cloud and self-hosted orgs.
+    expect(member).toContain("createOrganizationInstallLink");
+    expect(member).toContain('"openwork://open"');
+    expect(member).not.toContain("useOrgLlmProviders");
+    expect(member).not.toContain("useMarketplaces");
+    expect(member).not.toContain("usePlugins");
+    expect(member).not.toContain('requestJson("/v1/inference"');
     expect(member).not.toContain("Paper");
     expect(member).not.toContain('bg-[#07192C]');
   });


### PR DESCRIPTION
## Summary

- Replaces the member dashboard's read-only inventory (LLM providers, OpenWork Models status, marketplaces, plugins) with a single centered action: **Download OpenWork** — implementing the approved Paper design ("Dashboard · Member Home — Single Action")
- The button mints the workspace install link (`createOrganizationInstallLink`), so the download is preconfigured for the org's own den. `installPageUrlOnCurrentOrigin` keeps the link on the current origin, so **the same action works for OpenWork Cloud and self-hosted/enterprise orgs** — no variant logic
- Secondary affordances only: "Copy install link instead" and "Already installed? Open OpenWork →" (`openwork://open`)
- Kills the raw `forbidden` chip self-hosted members saw: this screen no longer calls `/v1/inference` at all
- Net −162 lines

## Evidence

### Screenshots
After (local dev, member role):

![member dashboard after](https://litter.catbox.moe/2fy0a6.png)

### Build verification
- `pnpm --filter @openwork-ee/den-web build` — passed

### Test verification
- `pnpm test` (den-web curated suite) — 97 pass, 0 fail
- `bun test tests/dashboard-home-layout.test.ts` — 3 pass; the member-dashboard contract test was rewritten to pin the new behavior (single download action, install-link minting, `openwork://open`, no resource hooks)
- Full `bun test` sweep: only pre-existing failures on clean `dev` (MCP dialog contracts, branding favicon) — unrelated to this change

### UI verification
Verified via Playwright against `pnpm dev:local` with mocked member-role API responses (no seeded stack running):
- Member role lands on the new screen (`member-dashboard` + `member-download-app` present)
- Clicking **Download OpenWork** opened a new tab at the minted install page URL returned by `POST /v1/orgs/o1/install-links`
- **Copy install link instead** wrote to the clipboard and flipped to "Copied"
- Console errors: none on the dashboard route

## Notes for reviewers

- `evals/flows/member-dashboard-no-resource-overview.flow.mjs` asserts the old resource-inventory layout and is superseded by this design; it needs a rewrite against the new screen (flagged rather than blind-edited, since I could not run the seeded eval stack here).

## Test instructions

1. `pnpm dev:den` + `pnpm dev:den:seed-demo`
2. Sign in as a **member** (not owner/admin)
3. `/dashboard` should show only: "{org} is set up for you", one Download OpenWork button, "Copy install link instead", and "Already installed? Open OpenWork →"
4. The download button must open the org install page (preconfigured installer), including on a self-hosted den

Made with [Cursor](https://cursor.com)