### PR TITLE
fix(den-api): make provider materialization atomic and verify it from the instance

### DIFF
--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -22,6 +22,8 @@ type EnvEntry = {
   value: string
 }
 
+type EnvSnapshot = Map<string, string | null>
+
 type WorkerToken = {
   scope: WorkerTokenScope
   token: string
@@ -445,6 +447,16 @@ async function requestOk(input: {
   }
 }
 
+function workspaceItemId(item: JsonRecord) {
+  return readString(item.id)
+}
+
+function isManagedEngineWorkspaceItem(item: JsonRecord) {
+  const workspaceType = readString(item.workspaceType)
+  const path = readString(item.path)
+  return workspaceType !== "remote" && Boolean(path)
+}
+
 function readWorkspaceId(payload: JsonRecord) {
   const activeId = readString(payload.activeId)
   const rawItems = Array.isArray(payload.items)
@@ -453,12 +465,17 @@ function readWorkspaceId(payload: JsonRecord) {
       ? payload.workspaces
       : []
   const items = rawItems.filter(isRecord)
-  if (activeId && items.some((item) => readString(item.id) === activeId)) {
+  const managedWorkspace = items.find(isManagedEngineWorkspaceItem)
+  if (managedWorkspace) {
+    return workspaceItemId(managedWorkspace)
+  }
+
+  if (activeId && items.some((item) => workspaceItemId(item) === activeId)) {
     return activeId
   }
 
   for (const item of items) {
-    const id = readString(item.id)
+    const id = workspaceItemId(item)
     if (id) {
       return id
     }
@@ -510,7 +527,7 @@ async function readStoredFingerprint(input: {
   return item ? readString(item.value) : null
 }
 
-async function readRuntimeManagedProviderIds(input: {
+async function readRuntimeManagedProviders(input: {
   fetchImpl: FetchImpl
   instanceUrl: string
   clientToken: string
@@ -527,13 +544,24 @@ async function readRuntimeManagedProviderIds(input: {
   })
   const runtime = isRecord(payload.runtime) ? payload.runtime : null
   const provider = runtime && isRecord(runtime.provider) ? runtime.provider : null
-  return provider ? Object.keys(provider).filter(isCloudManagedProviderKey) : []
+  const managed: JsonRecord = {}
+  if (!provider) {
+    return managed
+  }
+
+  for (const [providerId, config] of Object.entries(provider)) {
+    if (isCloudManagedProviderKey(providerId) && isRecord(config)) {
+      managed[providerId] = config
+    }
+  }
+
+  return managed
 }
 
-function buildRuntimeProviderPatch(prepared: PreparedMaterialization, currentManagedProviderIds: string[]) {
+function buildRuntimeProviderPatch(prepared: PreparedMaterialization, currentManagedProviders: JsonRecord) {
   const desiredIds = new Set(prepared.providers.map((provider) => provider.runtimeProviderId))
   const patch: JsonRecord = {}
-  for (const providerId of currentManagedProviderIds) {
+  for (const providerId of Object.keys(currentManagedProviders)) {
     if (!desiredIds.has(providerId)) {
       patch[providerId] = null
     }
@@ -544,6 +572,64 @@ function buildRuntimeProviderPatch(prepared: PreparedMaterialization, currentMan
   }
 
   return patch
+}
+
+function buildRuntimeProviderRollbackPatch(prepared: PreparedMaterialization, currentManagedProviders: JsonRecord) {
+  const affectedIds = new Set([
+    ...Object.keys(currentManagedProviders),
+    ...prepared.providers.map((provider) => provider.runtimeProviderId),
+  ])
+  const patch: JsonRecord = {}
+  for (const providerId of affectedIds) {
+    patch[providerId] = currentManagedProviders[providerId] ?? null
+  }
+
+  return patch
+}
+
+async function readEnvEntry(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  hostToken: string
+  key: string
+}) {
+  const response = await fetchWithTimeout(input.fetchImpl, `${input.instanceUrl}/env/${encodeURIComponent(input.key)}`, {
+    method: "GET",
+    headers: hostTokenHeaders(input.hostToken),
+  })
+  if (response.status === 404) {
+    return null
+  }
+  if (!response.ok) {
+    throw new Error(`env_read_failed_${response.status}`)
+  }
+
+  const payload = await readJsonObject(response)
+  const item = isRecord(payload.item) ? payload.item : null
+  return item && typeof item.value === "string" ? { key: input.key, value: item.value } : null
+}
+
+async function readEnvSnapshot(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  hostToken: string
+  entries: EnvEntry[]
+}): Promise<EnvSnapshot> {
+  const snapshot: EnvSnapshot = new Map()
+  for (const entry of input.entries) {
+    if (snapshot.has(entry.key)) {
+      continue
+    }
+    const existing = await readEnvEntry({
+      fetchImpl: input.fetchImpl,
+      instanceUrl: input.instanceUrl,
+      hostToken: input.hostToken,
+      key: entry.key,
+    })
+    snapshot.set(entry.key, existing?.value ?? null)
+  }
+
+  return snapshot
 }
 
 async function writeEnvEntries(input: {
@@ -566,6 +652,58 @@ async function writeEnvEntries(input: {
       body: JSON.stringify({ entries: input.entries }),
     },
   })
+}
+
+async function deleteEnvEntry(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  hostToken: string
+  key: string
+  ignoreNotFound?: boolean
+}) {
+  const response = await fetchWithTimeout(input.fetchImpl, `${input.instanceUrl}/env/${encodeURIComponent(input.key)}`, {
+    method: "DELETE",
+    headers: hostTokenHeaders(input.hostToken),
+  })
+  if (response.status === 404 && input.ignoreNotFound) {
+    return
+  }
+  if (!response.ok) {
+    throw new Error(`env_delete_failed_${response.status}`)
+  }
+}
+
+async function restoreEnvSnapshot(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  hostToken: string
+  snapshot: EnvSnapshot
+}) {
+  const entries: EnvEntry[] = []
+  const deleteKeys: string[] = []
+  for (const [key, value] of input.snapshot) {
+    if (value === null) {
+      deleteKeys.push(key)
+    } else {
+      entries.push({ key, value })
+    }
+  }
+
+  await writeEnvEntries({
+    fetchImpl: input.fetchImpl,
+    instanceUrl: input.instanceUrl,
+    hostToken: input.hostToken,
+    entries,
+  })
+  for (const key of deleteKeys) {
+    await deleteEnvEntry({
+      fetchImpl: input.fetchImpl,
+      instanceUrl: input.instanceUrl,
+      hostToken: input.hostToken,
+      key,
+      ignoreNotFound: true,
+    })
+  }
 }
 
 async function patchRuntimeProviders(input: {
@@ -606,6 +744,35 @@ async function reloadOpencode(input: {
       headers: bearerHeaders(input.clientToken),
     },
   })
+}
+
+async function verifyRuntimeProviders(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  clientToken: string
+  workspaceId: string
+  providerIds: string[]
+}) {
+  if (input.providerIds.length === 0) {
+    return
+  }
+
+  const payload = await requestJson({
+    fetchImpl: input.fetchImpl,
+    label: "provider_readback",
+    url: `${input.instanceUrl}/workspace/${encodeURIComponent(input.workspaceId)}/config`,
+    init: {
+      method: "GET",
+      headers: bearerHeaders(input.clientToken),
+    },
+  })
+  const opencode = isRecord(payload.opencode) ? payload.opencode : null
+  const provider = opencode && isRecord(opencode.provider) ? opencode.provider : null
+  for (const providerId of input.providerIds) {
+    if (!provider || !Object.prototype.hasOwnProperty.call(provider, providerId)) {
+      throw new Error(`provider_readback_missing_${providerId}`)
+    }
+  }
 }
 
 async function resolveTokens(input: {
@@ -677,6 +844,8 @@ export async function materializeCloudWorkerProviders(input: {
   const instanceUrl = normalizeBaseUrl(input.instanceUrl)
   let fingerprint: string | null = null
   let providerCount = 0
+  let cleanupHostToken: string | null = null
+  let clearStoredFingerprintOnFailure = false
 
   try {
     if (!instanceUrl) {
@@ -701,40 +870,104 @@ export async function materializeCloudWorkerProviders(input: {
     if (!tokens.hostToken || !tokens.clientToken) {
       throw new Error("worker_tokens_missing")
     }
+    cleanupHostToken = tokens.hostToken
 
     const storedFingerprint = await readStoredFingerprint({
       fetchImpl,
       instanceUrl,
       hostToken: tokens.hostToken,
     })
+    const workspaceId = await discoverWorkspaceId({ fetchImpl, instanceUrl, clientToken: tokens.clientToken })
+    const desiredProviderIds = prepared.providers.map((provider) => provider.runtimeProviderId)
     if (storedFingerprint === fingerprint) {
-      materializedFingerprintByWorker.set(input.workerId, fingerprint)
-      return { ok: true, status: "noop", fingerprint, providers: providerCount }
+      try {
+        await verifyRuntimeProviders({
+          fetchImpl,
+          instanceUrl,
+          clientToken: tokens.clientToken,
+          workspaceId,
+          providerIds: desiredProviderIds,
+        })
+        materializedFingerprintByWorker.set(input.workerId, fingerprint)
+        return { ok: true, status: "noop", fingerprint, providers: providerCount }
+      } catch {
+        clearStoredFingerprintOnFailure = true
+      }
     }
 
-    const workspaceId = await discoverWorkspaceId({ fetchImpl, instanceUrl, clientToken: tokens.clientToken })
-    const currentManagedProviderIds = await readRuntimeManagedProviderIds({
+    const currentManagedProviders = await readRuntimeManagedProviders({
       fetchImpl,
       instanceUrl,
       clientToken: tokens.clientToken,
       workspaceId,
     })
-    const providerPatch = buildRuntimeProviderPatch(prepared, currentManagedProviderIds)
-
-    await writeEnvEntries({
+    const providerPatch = buildRuntimeProviderPatch(prepared, currentManagedProviders)
+    const providerRollbackPatch = buildRuntimeProviderRollbackPatch(prepared, currentManagedProviders)
+    const envSnapshot = await readEnvSnapshot({
       fetchImpl,
       instanceUrl,
       hostToken: tokens.hostToken,
       entries: prepared.envEntries,
     })
-    await patchRuntimeProviders({
-      fetchImpl,
-      instanceUrl,
-      clientToken: tokens.clientToken,
-      workspaceId,
-      patch: providerPatch,
-    })
-    await reloadOpencode({ fetchImpl, instanceUrl, clientToken: tokens.clientToken, workspaceId })
+    let envWritten = false
+    let providerPatched = false
+
+    try {
+      await writeEnvEntries({
+        fetchImpl,
+        instanceUrl,
+        hostToken: tokens.hostToken,
+        entries: prepared.envEntries,
+      })
+      envWritten = prepared.envEntries.length > 0
+      await patchRuntimeProviders({
+        fetchImpl,
+        instanceUrl,
+        clientToken: tokens.clientToken,
+        workspaceId,
+        patch: providerPatch,
+      })
+      providerPatched = Object.keys(providerPatch).length > 0
+      await reloadOpencode({ fetchImpl, instanceUrl, clientToken: tokens.clientToken, workspaceId })
+      await verifyRuntimeProviders({
+        fetchImpl,
+        instanceUrl,
+        clientToken: tokens.clientToken,
+        workspaceId,
+        providerIds: desiredProviderIds,
+      })
+    } catch (error) {
+      if (providerPatched) {
+        await patchRuntimeProviders({
+          fetchImpl,
+          instanceUrl,
+          clientToken: tokens.clientToken,
+          workspaceId,
+          patch: providerRollbackPatch,
+        }).catch((rollbackError) => {
+          materializationLogger.warn("cloud provider rollback failed", {
+            worker_id: input.workerId,
+            organization_id: input.organizationId,
+            reason: rollbackError instanceof Error ? rollbackError.message : "runtime_config_rollback_failed",
+          })
+        })
+      }
+      if (envWritten) {
+        await restoreEnvSnapshot({
+          fetchImpl,
+          instanceUrl,
+          hostToken: tokens.hostToken,
+          snapshot: envSnapshot,
+        }).catch((rollbackError) => {
+          materializationLogger.warn("cloud provider env rollback failed", {
+            worker_id: input.workerId,
+            organization_id: input.organizationId,
+            reason: rollbackError instanceof Error ? rollbackError.message : "env_rollback_failed",
+          })
+        })
+      }
+      throw error
+    }
 
     // The fingerprint is intentionally stored inside the instance's env store:
     // it survives restarts with the rest of the sandbox state, contains only
@@ -750,6 +983,15 @@ export async function materializeCloudWorkerProviders(input: {
     materializedFingerprintByWorker.set(input.workerId, fingerprint)
     return { ok: true, status: "applied", fingerprint, providers: providerCount }
   } catch (error) {
+    if (clearStoredFingerprintOnFailure && cleanupHostToken && fingerprint) {
+      await deleteEnvEntry({
+        fetchImpl,
+        instanceUrl,
+        hostToken: cleanupHostToken,
+        key: OPENWORK_PROVIDERS_FINGERPRINT_ENV,
+        ignoreNotFound: true,
+      }).catch(() => undefined)
+    }
     const result = failureResult({
       reason: error instanceof Error ? error.message : "provider_materialization_failed",
       error,

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -477,7 +477,7 @@ describe("Cloud gateway resolve route", () => {
     expect(payload).not.toHaveProperty("clientToken")
   })
 
-  test("surfaces degraded provider materialization without leaking provider keys", async () => {
+  test("surfaces degraded provider materialization failures without leaking provider keys", async () => {
     const readyWorker = fakeWorker("healthy")
     const store = makeCloudWorkerStore({ tokens: [makeToken(readyWorker.id, "host"), makeToken(readyWorker.id, "client")] })
     const app = new Hono<{ Variables: OrgRouteVariables }>()
@@ -497,8 +497,8 @@ describe("Cloud gateway resolve route", () => {
         ok: false,
         status: "failed",
         error: "provider_materialization_failed",
-        reason: "env_write_failed_500",
-        message: `env_write_failed_500 ${secret}`,
+        reason: "runtime_config_patch_failed_500",
+        message: `runtime_config_patch_failed_500 ${secret}`,
         fingerprint: "owp:v1:redacted",
         providers: 1,
       }),

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -13,6 +13,11 @@ type FetchCall = {
   headers: Record<string, string>
   body: unknown
 }
+type WorkspaceFixture = {
+  id: string
+  workspaceType?: string
+  path?: string
+}
 
 const organizationId = createDenTypeId("organization")
 const instanceUrl = "https://worker.example.test"
@@ -51,6 +56,10 @@ function parseBody(body: BodyInit | null | undefined) {
   return JSON.parse(body)
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+}
+
 function headersRecord(headers: HeadersInit | undefined) {
   const record: Record<string, string> = {}
   new Headers(headers).forEach((value, key) => {
@@ -70,13 +79,21 @@ function bodyEntries(body: unknown) {
     : []
 }
 
-function bodyEntryValue(body: unknown, key: string) {
-  for (const entry of bodyEntries(body)) {
-    if (entry.key === key && typeof entry.value === "string") {
-      return entry.value
-    }
+function providerPatchFromBody(body: unknown) {
+  if (!isRecord(body) || !isRecord(body.opencode) || !isRecord(body.opencode.provider)) {
+    return {}
   }
-  return null
+
+  return body.opencode.provider
+}
+
+function workspaceRouteId(path: string, suffix: string) {
+  if (!path.startsWith("/workspace/") || !path.endsWith(suffix)) {
+    return null
+  }
+
+  const encoded = path.slice("/workspace/".length, path.length - suffix.length)
+  return encoded ? decodeURIComponent(encoded) : null
 }
 
 function makeAnthropicProvider(input: {
@@ -128,12 +145,24 @@ function makeStore(providers: () => CloudProviderMaterializationProvider[]): Sto
 function makeInstance(input: {
   storedFingerprint?: string | null
   failEnvWrites?: number
+  failConfigPatches?: number
   runtimeProviders?: Record<string, unknown>
+  configReadProviders?: Record<string, unknown>
+  missingConfigReadbacks?: number
+  workspaces?: WorkspaceFixture[]
+  activeId?: string | null
 } = {}) {
   const calls: FetchCall[] = []
-  let storedFingerprint = input.storedFingerprint ?? null
+  const envValues = new Map<string, string>()
+  if (input.storedFingerprint) {
+    envValues.set(openworkProvidersFingerprintEnv, input.storedFingerprint)
+  }
   let failEnvWrites = input.failEnvWrites ?? 0
-  const runtimeProviders = input.runtimeProviders ?? {}
+  let failConfigPatches = input.failConfigPatches ?? 0
+  let missingConfigReadbacks = input.missingConfigReadbacks ?? 0
+  const runtimeProviders: Record<string, unknown> = { ...(input.runtimeProviders ?? {}) }
+  const workspaces = input.workspaces ?? [{ id: "workspace-one" }]
+  const activeId = input.activeId === undefined ? workspaces[0]?.id ?? null : input.activeId
   const fetchImpl: FetchImpl = async (url, init) => {
     const parsed = new URL(url)
     const method = init?.method ?? "GET"
@@ -145,18 +174,28 @@ function makeInstance(input: {
       body,
     })
 
-    if (method === "GET" && parsed.pathname === `/env/${openworkProvidersFingerprintEnv}`) {
-      return storedFingerprint
-        ? jsonResponse({ item: { key: openworkProvidersFingerprintEnv, value: storedFingerprint } })
+    if (method === "GET" && parsed.pathname.startsWith("/env/")) {
+      const key = decodeURIComponent(parsed.pathname.slice("/env/".length))
+      const value = envValues.get(key) ?? null
+      return value
+        ? jsonResponse({ item: { key, value } })
         : jsonResponse({ error: "env_not_found" }, 404)
     }
 
     if (method === "GET" && parsed.pathname === "/workspaces") {
-      return jsonResponse({ activeId: "workspace-one", items: [{ id: "workspace-one" }] })
+      return jsonResponse({ activeId, items: workspaces })
     }
 
-    if (method === "GET" && parsed.pathname === "/workspace/workspace-one/runtime-config") {
+    if (method === "GET" && workspaceRouteId(parsed.pathname, "/runtime-config")) {
       return jsonResponse({ runtime: { provider: runtimeProviders } })
+    }
+
+    if (method === "GET" && workspaceRouteId(parsed.pathname, "/config")) {
+      if (missingConfigReadbacks > 0) {
+        missingConfigReadbacks -= 1
+        return jsonResponse({ opencode: { provider: {} } })
+      }
+      return jsonResponse({ opencode: { provider: input.configReadProviders ?? runtimeProviders } })
     }
 
     if (method === "PUT" && parsed.pathname === "/env") {
@@ -164,18 +203,40 @@ function makeInstance(input: {
         failEnvWrites -= 1
         return jsonResponse({ error: "env_write_failed" }, 500)
       }
-      const nextFingerprint = bodyEntryValue(body, openworkProvidersFingerprintEnv)
-      if (nextFingerprint) {
-        storedFingerprint = nextFingerprint
+      for (const entry of bodyEntries(body)) {
+        if (typeof entry.key === "string" && typeof entry.value === "string") {
+          envValues.set(entry.key, entry.value)
+        }
       }
       return jsonResponse({ ok: true })
     }
 
-    if (method === "PATCH" && parsed.pathname === "/workspace/workspace-one/config") {
+    if (method === "DELETE" && parsed.pathname.startsWith("/env/")) {
+      const key = decodeURIComponent(parsed.pathname.slice("/env/".length))
+      if (!envValues.has(key)) {
+        return jsonResponse({ error: "env_not_found" }, 404)
+      }
+      envValues.delete(key)
+      return jsonResponse({ ok: true })
+    }
+
+    if (method === "PATCH" && workspaceRouteId(parsed.pathname, "/config")) {
+      if (failConfigPatches > 0) {
+        failConfigPatches -= 1
+        return jsonResponse({ error: "config_patch_failed" }, 500)
+      }
+      const providerPatch = providerPatchFromBody(body)
+      for (const [providerId, value] of Object.entries(providerPatch)) {
+        if (value === null) {
+          delete runtimeProviders[providerId]
+        } else if (isRecord(value)) {
+          runtimeProviders[providerId] = value
+        }
+      }
       return jsonResponse({ updatedAt: Date.now() })
     }
 
-    if (method === "POST" && parsed.pathname === "/workspace/workspace-one/engine/reload") {
+    if (method === "POST" && workspaceRouteId(parsed.pathname, "/engine/reload")) {
       return jsonResponse({ ok: true, reloadedAt: Date.now() })
     }
 
@@ -186,7 +247,10 @@ function makeInstance(input: {
     calls,
     fetchImpl,
     get storedFingerprint() {
-      return storedFingerprint
+      return envValues.get(openworkProvidersFingerprintEnv) ?? null
+    },
+    envValue(key: string) {
+      return envValues.get(key) ?? null
     },
   }
 }
@@ -236,17 +300,19 @@ describe("Cloud provider materialization", () => {
       `GET /env/${openworkProvidersFingerprintEnv}`,
       "GET /workspaces",
       "GET /workspace/workspace-one/runtime-config",
+      "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
       "PATCH /workspace/workspace-one/config",
       "POST /workspace/workspace-one/engine/reload",
+      "GET /workspace/workspace-one/config",
       "PUT /env",
     ])
-    expect(instance.calls[3]?.headers["x-openwork-host-token"]).toBe("host-token")
-    expect(instance.calls[3]?.body).toEqual({
+    expect(instance.calls[4]?.headers["x-openwork-host-token"]).toBe("host-token")
+    expect(instance.calls[4]?.body).toEqual({
       entries: [{ key: "ANTHROPIC_API_KEY", value: "sk-anthropic" }],
     })
-    expect(instance.calls[4]?.headers.authorization).toBe("Bearer client-token")
-    expect(instance.calls[4]?.body).toEqual({
+    expect(instance.calls[5]?.headers.authorization).toBe("Bearer client-token")
+    expect(instance.calls[5]?.body).toEqual({
       opencode: {
         provider: {
           [provider.id]: {
@@ -272,7 +338,7 @@ describe("Cloud provider materialization", () => {
   test("skips writes and reloads when the stored fingerprint is unchanged", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const fingerprint = computeCloudProviderMaterializationFingerprint([provider])
-    const instance = makeInstance({ storedFingerprint: fingerprint })
+    const instance = makeInstance({ storedFingerprint: fingerprint, runtimeProviders: { [provider.id]: { id: "anthropic" } } })
 
     const result = await materialize({
       providers: () => [provider],
@@ -281,8 +347,91 @@ describe("Cloud provider materialization", () => {
     })
 
     expect(result).toEqual({ ok: true, status: "noop", fingerprint, providers: 1 })
-    expect(callMethods(instance.calls)).toEqual([`GET /env/${openworkProvidersFingerprintEnv}`])
+    expect(callMethods(instance.calls)).toEqual([
+      `GET /env/${openworkProvidersFingerprintEnv}`,
+      "GET /workspaces",
+      "GET /workspace/workspace-one/config",
+    ])
     expect(writeCalls(instance.calls)).toHaveLength(0)
+  })
+
+  test("retries a stored fingerprint when provider read-back is missing", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const fingerprint = computeCloudProviderMaterializationFingerprint([provider])
+    const instance = makeInstance({ storedFingerprint: fingerprint, missingConfigReadbacks: 1 })
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.status).toBe("applied")
+    expect(callMethods(instance.calls)).toEqual([
+      `GET /env/${openworkProvidersFingerprintEnv}`,
+      "GET /workspaces",
+      "GET /workspace/workspace-one/config",
+      "GET /workspace/workspace-one/runtime-config",
+      "GET /env/ANTHROPIC_API_KEY",
+      "PUT /env",
+      "PATCH /workspace/workspace-one/config",
+      "POST /workspace/workspace-one/engine/reload",
+      "GET /workspace/workspace-one/config",
+      "PUT /env",
+    ])
+    expect(instance.storedFingerprint).toBe(result.fingerprint)
+  })
+
+  test("treats missing provider read-back as materialization failure", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const instance = makeInstance({ configReadProviders: {} })
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toBe(`provider_readback_missing_${provider.id}`)
+    }
+    expect(callMethods(instance.calls)).toEqual([
+      `GET /env/${openworkProvidersFingerprintEnv}`,
+      "GET /workspaces",
+      "GET /workspace/workspace-one/runtime-config",
+      "GET /env/ANTHROPIC_API_KEY",
+      "PUT /env",
+      "PATCH /workspace/workspace-one/config",
+      "POST /workspace/workspace-one/engine/reload",
+      "GET /workspace/workspace-one/config",
+      "PATCH /workspace/workspace-one/config",
+      "DELETE /env/ANTHROPIC_API_KEY",
+    ])
+    expect(instance.storedFingerprint).toBeNull()
+    expect(instance.envValue("ANTHROPIC_API_KEY")).toBeNull()
+  })
+
+  test("patches the local session workspace when discovery lists a remote workspace first", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const instance = makeInstance({
+      activeId: "rem_ws_remote",
+      workspaces: [
+        { id: "rem_ws_remote", workspaceType: "remote", path: "/remote" },
+        { id: "ws_session", workspaceType: "local", path: "/tmp/openwork-runtime" },
+      ],
+    })
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(instance.calls.some((call) => call.method === "PATCH" && call.path === "/workspace/ws_session/config")).toBe(true)
+    expect(instance.calls.some((call) => call.method === "PATCH" && call.path === "/workspace/rem_ws_remote/config")).toBe(false)
   })
 
   test("reapplies exactly once when providers drift, then caches the resolve check", async () => {
@@ -320,11 +469,48 @@ describe("Cloud provider materialization", () => {
       `GET /env/${openworkProvidersFingerprintEnv}`,
       "GET /workspaces",
       "GET /workspace/workspace-one/runtime-config",
+      "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
     ])
     expect(instance.calls.some((call) => call.method === "PATCH")).toBe(false)
     expect(instance.calls.some((call) => call.path.endsWith("/engine/reload"))).toBe(false)
     expect(instance.storedFingerprint).toBeNull()
+
+    instance.calls.length = 0
+    const retried = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+    })
+    expect(retried.ok).toBe(true)
+    expect(retried.status).toBe("applied")
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "POST", "PUT"])
+  })
+
+  test("rolls back credential env, skips fingerprint, and retries when config patch fails", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const instance = makeInstance({ failConfigPatches: 1 })
+
+    const failed = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+    })
+
+    expect(failed.ok).toBe(false)
+    if (!failed.ok) {
+      expect(failed.reason).toBe("runtime_config_patch_failed_500")
+    }
+    expect(callMethods(instance.calls)).toEqual([
+      `GET /env/${openworkProvidersFingerprintEnv}`,
+      "GET /workspaces",
+      "GET /workspace/workspace-one/runtime-config",
+      "GET /env/ANTHROPIC_API_KEY",
+      "PUT /env",
+      "PATCH /workspace/workspace-one/config",
+      "DELETE /env/ANTHROPIC_API_KEY",
+    ])
+    expect(instance.calls.some((call) => call.path.endsWith("/engine/reload"))).toBe(false)
+    expect(instance.storedFingerprint).toBeNull()
+    expect(instance.envValue("ANTHROPIC_API_KEY")).toBeNull()
 
     instance.calls.length = 0
     const retried = await materialize({


### PR DESCRIPTION
#3250 delivered credentials to Cloud sandboxes but not provider blocks, so users got a key with no provider — nothing in the model picker, and no error, because materialization failures are non-blocking. Measured on a real affected instance:

```
env store:                       ANTHROPIC_API_KEY present     ✅
runtime-opencode-config.json:    ["$schema","agent","default_agent","mcp","plugin"]
                                 opencode.provider MISSING     ❌
```

## Root cause

The materializer resolved the target workspace from `/workspaces` (`activeId` / first entry), but **managed opencode boots against the first local workspace**. When a remote workspace sorted first, the provider patch landed in a different workspace's runtime config while the engine-visible config stayed providerless. Env writes are instance-global, so the credential landed — producing exactly the half-configured state.

Auth contracts confirmed from the server source (not assumed — the earlier assumption-driven attempts are what caused this):

| route | auth |
| --- | --- |
| `GET /workspaces` | client bearer |
| `PATCH /workspace/:id/config` | client bearer, per-provider merge |
| `POST /workspace/:id/engine/reload` | client bearer |
| `/env`, `/env/:key` | **host token** |

## The fix

- Workspace discovery prefers the **local managed engine/session workspace** — the one opencode actually reads.
- **Atomic**: credential env + provider patch + reload + read-back must all succeed before the fingerprint is recorded. On failure after a write, prior provider config and env values are **restored**, and resolve reports `providerSync: { status: "degraded" }` so the next resolve retries instead of leaving a permanent half-state.
- **Correct success assertion**: the provider must be **readable back from the instance after reload**. "The key exists in a store" is no longer treated as success — that mistaken assertion is what let the broken state ship.

## Tests

The read-back guard fails against the previous code and passes now:

```
Expected: false
Received: true
(fail) treats missing provider read-back as materialization failure
```

| Command | Result |
| --- | --- |
| materialization + cloud-instance-route + lifecycle + provisioning | 61 pass / 0 fail |
| `tsc --noEmit` | clean |

Coverage: happy path with read-back, stale-fingerprint retry, read-back failure, workspace selection pinning, env failure, config-patch failure with rollback, and no secret leakage in serialized output.

## After deploy

Verifying against the real affected instance with the right assertion: the provider must be enumerable from the workspace config opencode actually reads.