### PR TITLE
feat: make cloud LLM providers engine-global so they actually reach opencode

### DIFF
--- a/apps/server/src/openwork-runtime-config.ts
+++ b/apps/server/src/openwork-runtime-config.ts
@@ -26,9 +26,11 @@ import type { ServerConfig } from "./types.js";
 import { runtimeStorageDir } from "./runtime-db.js";
 import {
   onRuntimeOpencodeConfigWrite,
-  readRuntimeOpencodeConfig,
+  isEngineGlobalRuntimeConfigId,
+  readEffectiveRuntimeOpencodeConfig,
   runtimeDisabledProviderList,
   runtimeMcpMap,
+  runtimeProviderMap,
   runtimePluginList,
   type RuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";
@@ -88,7 +90,7 @@ export async function buildOpenworkRuntimeConfigObject(
   config?: ServerConfig,
   workspaceId?: string,
 ): Promise<Record<string, unknown>> {
-  const runtimeConfig = config && workspaceId ? await readRuntimeOpencodeConfig(config, workspaceId) : {};
+  const runtimeConfig = config && workspaceId ? await readEffectiveRuntimeOpencodeConfig(config, workspaceId) : {};
   return buildOpenworkRuntimeConfigObjectFromSnapshot(runtimeConfig);
 }
 
@@ -96,6 +98,7 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
   runtimeConfig: RuntimeOpencodeConfig,
 ): Record<string, unknown> {
   const disabledProviders = runtimeDisabledProviderList(runtimeConfig);
+  const provider = runtimeProviderMap(runtimeConfig);
   return {
     ...runtimeConfig,
     default_agent: runtimeConfig.default_agent ?? "openwork",
@@ -129,6 +132,7 @@ export function buildOpenworkRuntimeConfigObjectFromSnapshot(
     ],
     ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),
     mcp: runtimeMcpMap(runtimeConfig),
+    ...(Object.keys(provider).length ? { provider } : {}),
   };
 }
 
@@ -191,7 +195,7 @@ export async function writeOpenworkRuntimeConfigFile(config: ServerConfig, works
  */
 export function keepOpenworkRuntimeConfigFileFresh(config: ServerConfig, workspaceId: string): () => void {
   return onRuntimeOpencodeConfigWrite((writeConfig, writtenWorkspaceId) => {
-    if (writtenWorkspaceId !== workspaceId) return;
+    if (writtenWorkspaceId !== workspaceId && !isEngineGlobalRuntimeConfigId(writtenWorkspaceId)) return;
     void writeOpenworkRuntimeConfigFile(writeConfig, workspaceId).catch(() => undefined);
   });
 }

--- a/apps/server/src/runtime-config-global-providers.test.ts
+++ b/apps/server/src/runtime-config-global-providers.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { mkdtemp, readdir, readFile, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { openworkRuntimeConfigFilePath, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
+import {
+  mergeRuntimeProviderUpdate,
+  readGlobalRuntimeOpencodeConfig,
+  runtimeProviderMap,
+  runtimeStorageDir,
+  writeGlobalRuntimeOpencodeConfig,
+} from "./runtime-opencode-config-store.js";
+import { startServer } from "./server.js";
+import type { ServerConfig } from "./types.js";
+
+const CLIENT_TOKEN = "owt_global_provider_client";
+const HOST_TOKEN = "owt_global_provider_host";
+const roots: string[] = [];
+const stops: Array<() => void | Promise<void>> = [];
+let previousRuntimeDb: string | undefined;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function providerFromPayload(payload: Record<string, unknown>): Record<string, unknown> {
+  return isRecord(payload.provider) ? payload.provider : {};
+}
+
+function clientHeaders() {
+  return { authorization: `Bearer ${CLIENT_TOKEN}`, "content-type": "application/json" };
+}
+
+function hostHeaders() {
+  return { "x-openwork-host-token": HOST_TOKEN, "content-type": "application/json" };
+}
+
+async function readJsonObject(response: Response): Promise<Record<string, unknown>> {
+  const payload: unknown = await response.json();
+  if (!isRecord(payload)) throw new Error("Expected JSON object");
+  return payload;
+}
+
+async function createTempRoot() {
+  const root = await mkdtemp(join(tmpdir(), "openwork-global-providers-"));
+  roots.push(root);
+  previousRuntimeDb = process.env.OPENWORK_RUNTIME_DB;
+  process.env.OPENWORK_RUNTIME_DB = join(root, "runtime.sqlite");
+  return root;
+}
+
+function serverConfig(root: string, baseUrl?: string): ServerConfig {
+  return {
+    host: "127.0.0.1",
+    port: 0,
+    configPath: join(root, "server.json"),
+    token: CLIENT_TOKEN,
+    hostToken: HOST_TOKEN,
+    approval: { mode: "auto", timeoutMs: 1000 },
+    corsOrigins: ["*"],
+    workspaces: [{ id: "ws_1", name: "Workspace", path: root, preset: "starter", workspaceType: "local", baseUrl }],
+    authorizedRoots: [root],
+    readOnly: false,
+    startedAt: Date.now(),
+    tokenSource: "cli",
+    hostTokenSource: "cli",
+    logFormat: "pretty",
+    logRequests: false,
+  } satisfies ServerConfig;
+}
+
+afterEach(async () => {
+  while (stops.length) await stops.pop()?.();
+  while (roots.length) {
+    const root = roots.pop();
+    if (root) await rm(root, { recursive: true, force: true });
+  }
+  if (previousRuntimeDb === undefined) delete process.env.OPENWORK_RUNTIME_DB;
+  else process.env.OPENWORK_RUNTIME_DB = previousRuntimeDb;
+});
+
+describe("global runtime providers", () => {
+  test("round-trips provider upserts and null deletes into the engine-visible file", async () => {
+    const root = await createTempRoot();
+    const config = serverConfig(root);
+    const anthropic = { id: "anthropic", name: "Anthropic", env: ["ANTHROPIC_API_KEY"] };
+    const openrouter = { id: "openrouter", name: "OpenRouter", env: ["OPENROUTER_API_KEY"] };
+
+    await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
+      ...current,
+      provider: mergeRuntimeProviderUpdate(current.provider, { lpr_anthropic: anthropic }),
+    }));
+    await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
+      ...current,
+      provider: mergeRuntimeProviderUpdate(current.provider, { lpr_openrouter: openrouter, lpr_anthropic: null }),
+    }));
+
+    const globalRuntime = await readGlobalRuntimeOpencodeConfig(config);
+    expect(runtimeProviderMap(globalRuntime)).toEqual({ lpr_openrouter: openrouter });
+
+    const path = await writeOpenworkRuntimeConfigFile(config, "ws_1");
+    expect(path).toBe(openworkRuntimeConfigFilePath(config));
+    const raw = await readFile(path, "utf8");
+    const parsed: unknown = JSON.parse(raw);
+    if (!isRecord(parsed)) throw new Error("Expected runtime config object");
+    expect(providerFromPayload(parsed)).toEqual({ lpr_openrouter: openrouter });
+
+    const storageEntries = await readdir(runtimeStorageDir(config));
+    expect(storageEntries.filter((entry) => entry.includes("runtime-opencode-config.json.")).length).toBe(0);
+  });
+
+  test("global provider route requires the host token and reaches the engine-visible config", async () => {
+    const root = await createTempRoot();
+    const engineRequests: string[] = [];
+    const config = serverConfig(root);
+    const engine = Bun.serve({
+      port: 0,
+      async fetch(request) {
+        const url = new URL(request.url);
+        engineRequests.push(`${request.method} ${url.pathname}`);
+        if (request.method === "POST" && url.pathname === "/instance/dispose") {
+          return new Response(JSON.stringify({ ok: true }), { headers: { "content-type": "application/json" } });
+        }
+        if (request.method === "GET" && url.pathname === "/config") {
+          const content = await readFile(openworkRuntimeConfigFilePath(config), "utf8");
+          return new Response(content, { headers: { "content-type": "application/json" } });
+        }
+        return new Response(JSON.stringify({ error: "not_found" }), { status: 404, headers: { "content-type": "application/json" } });
+      },
+    });
+    stops.push(() => engine.stop(true));
+    config.workspaces[0].baseUrl = `http://127.0.0.1:${engine.port}`;
+
+    const server = await startServer(config);
+    stops.push(() => server.stop());
+    const base = `http://127.0.0.1:${server.port}`;
+    const provider = { id: "anthropic", name: "Anthropic", env: ["ANTHROPIC_API_KEY"] };
+
+    const clientAttempt = await fetch(`${base}/runtime-config/providers`, {
+      method: "PATCH",
+      headers: clientHeaders(),
+      body: JSON.stringify({ provider: { lpr_anthropic: provider } }),
+    });
+    expect(clientAttempt.status).toBe(401);
+
+    const hostAttempt = await fetch(`${base}/runtime-config/providers`, {
+      method: "PATCH",
+      headers: hostHeaders(),
+      body: JSON.stringify({ provider: { lpr_anthropic: provider } }),
+    });
+    expect(hostAttempt.status).toBe(200);
+    expect(await readJsonObject(hostAttempt)).toMatchObject({ ok: true, reload: "reloaded" });
+    expect(engineRequests).toContain("POST /instance/dispose");
+
+    const readback = await fetch(`${base}/opencode/config`, { headers: clientHeaders() });
+    expect(readback.status).toBe(200);
+    expect(providerFromPayload(await readJsonObject(readback))).toMatchObject({ lpr_anthropic: provider });
+
+    const globalRuntime = await readGlobalRuntimeOpencodeConfig(config);
+    expect(runtimeProviderMap(globalRuntime)).toEqual({ lpr_anthropic: provider });
+  });
+});

--- a/apps/server/src/runtime-opencode-config-store.ts
+++ b/apps/server/src/runtime-opencode-config-store.ts
@@ -16,6 +16,12 @@ export type RuntimeOpencodeConfig = {
   provider?: Record<string, unknown>;
 };
 
+export const ENGINE_GLOBAL_RUNTIME_CONFIG_ID = "__openwork_engine_global__";
+
+export function isEngineGlobalRuntimeConfigId(workspaceId: string): boolean {
+  return workspaceId === ENGINE_GLOBAL_RUNTIME_CONFIG_ID;
+}
+
 function normalizeRuntimeOpencodeConfig(value: unknown): RuntimeOpencodeConfig {
   if (!isRecord(value)) return {};
   const defaultAgent = typeof value.default_agent === "string" ? value.default_agent : undefined;
@@ -80,6 +86,15 @@ export function runtimeMcpMap(config: RuntimeOpencodeConfig): Record<string, Rec
   return isRecord(config.mcp) ? config.mcp as Record<string, Record<string, unknown>> : {};
 }
 
+export function runtimeProviderMap(config: RuntimeOpencodeConfig): Record<string, Record<string, unknown>> {
+  const provider: Record<string, Record<string, unknown>> = {};
+  if (!isRecord(config.provider)) return provider;
+  for (const [providerId, value] of Object.entries(config.provider)) {
+    if (isRecord(value)) provider[providerId] = value;
+  }
+  return provider;
+}
+
 /** Narrow server-owned read port for consumers that need one runtime MCP endpoint. */
 export async function readRuntimeMcpConfig(
   config: ServerConfig,
@@ -118,6 +133,77 @@ export function mergeRuntimeProviderUpdate(
 
 export async function readRuntimeOpencodeConfig(config: ServerConfig, workspaceId: string): Promise<RuntimeOpencodeConfig> {
   return await runtimeOpencodeConfigStore.get(config, workspaceId) ?? {};
+}
+
+export async function readGlobalRuntimeOpencodeConfig(config: ServerConfig): Promise<RuntimeOpencodeConfig> {
+  return await readRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID);
+}
+
+export async function writeGlobalRuntimeOpencodeConfig(
+  config: ServerConfig,
+  updater: (current: RuntimeOpencodeConfig) => RuntimeOpencodeConfig,
+): Promise<{ config: RuntimeOpencodeConfig; changed: boolean }> {
+  return await writeRuntimeOpencodeConfig(config, ENGINE_GLOBAL_RUNTIME_CONFIG_ID, updater);
+}
+
+function uniqueStrings(items: string[]): string[] {
+  return items.filter((item, index, list) => list.indexOf(item) === index);
+}
+
+function mergeRuntimeOpencodeConfigLayers(
+  base: RuntimeOpencodeConfig,
+  overlay: RuntimeOpencodeConfig,
+): RuntimeOpencodeConfig {
+  const plugin = uniqueStrings([
+    ...runtimePluginList(base),
+    ...runtimePluginList(overlay),
+  ]);
+  const disabledProviders = uniqueStrings([
+    ...runtimeDisabledProviderList(base),
+    ...runtimeDisabledProviderList(overlay),
+  ]);
+  const mcp = {
+    ...runtimeMcpMap(base),
+    ...runtimeMcpMap(overlay),
+  };
+  const basePermission = isRecord(base.permission) ? base.permission : {};
+  const overlayPermission = isRecord(overlay.permission) ? overlay.permission : {};
+  const externalDirectory = {
+    ...runtimeExternalDirectory(base),
+    ...runtimeExternalDirectory(overlay),
+  };
+  const permission = {
+    ...basePermission,
+    ...overlayPermission,
+    ...(Object.keys(externalDirectory).length ? { external_directory: externalDirectory } : {}),
+  };
+  const provider = {
+    ...runtimeProviderMap(base),
+    ...runtimeProviderMap(overlay),
+  };
+
+  return normalizeRuntimeOpencodeConfig({
+    ...(base.default_agent || overlay.default_agent ? { default_agent: overlay.default_agent ?? base.default_agent } : {}),
+    ...(plugin.length ? { plugin } : {}),
+    ...(disabledProviders.length ? { disabled_providers: disabledProviders } : {}),
+    ...(Object.keys(mcp).length ? { mcp } : {}),
+    ...(Object.keys(permission).length ? { permission } : {}),
+    ...(Object.keys(provider).length ? { provider } : {}),
+  });
+}
+
+export async function readEffectiveRuntimeOpencodeConfig(
+  config: ServerConfig,
+  workspaceId: string,
+): Promise<RuntimeOpencodeConfig> {
+  if (isEngineGlobalRuntimeConfigId(workspaceId)) {
+    return await readRuntimeOpencodeConfig(config, workspaceId);
+  }
+  const [globalRuntime, workspaceRuntime] = await Promise.all([
+    readGlobalRuntimeOpencodeConfig(config),
+    readRuntimeOpencodeConfig(config, workspaceId),
+  ]);
+  return mergeRuntimeOpencodeConfigLayers(globalRuntime, workspaceRuntime);
 }
 
 export type RuntimeOpencodeConfigInspection = {
@@ -305,6 +391,7 @@ export function mergeOpencodeConfigs(
   const persistedExternalDirectory = isRecord(persistedPermission.external_directory)
     ? persistedPermission.external_directory
     : {};
+  const runtimeProvider = runtimeProviderMap(runtime);
   return {
     ...persisted,
     plugin: [
@@ -326,7 +413,7 @@ export function mergeOpencodeConfigs(
         ...runtimeExternalDirectory(runtime),
       },
     },
-    ...(runtime.provider ? { provider: { ...(isRecord(persisted.provider) ? persisted.provider : {}), ...runtime.provider } } : {}),
+    ...(Object.keys(runtimeProvider).length ? { provider: { ...(isRecord(persisted.provider) ? persisted.provider : {}), ...runtimeProvider } } : {}),
     ...(runtime.default_agent ? { default_agent: runtime.default_agent } : {}),
   };
 }

--- a/apps/server/src/server.ts
+++ b/apps/server/src/server.ts
@@ -76,10 +76,13 @@ import { sanitizeDiagnosticString } from "./diagnostic-sanitizer.js";
 import {
   mergeOpencodeConfigs,
   mergeRuntimeProviderUpdate,
+  readGlobalRuntimeOpencodeConfig,
   readRuntimeOpencodeConfig,
   runtimeDisabledProviderList,
   runtimeMcpMap,
+  runtimeProviderMap,
   type RuntimeOpencodeConfig,
+  writeGlobalRuntimeOpencodeConfig,
   writeRuntimeOpencodeConfig,
 } from "./runtime-opencode-config-store.js";
 import {
@@ -89,8 +92,9 @@ import {
   seedOpenworkWorkspaceConfigIfEmpty,
   writeOpenworkWorkspaceConfig,
 } from "./openwork-workspace-config-store.js";
-import { buildOpenworkRuntimeConfigObject, openworkRuntimeConfigFilePath } from "./openwork-runtime-config.js";
+import { buildOpenworkRuntimeConfigObject, openworkRuntimeConfigFilePath, writeOpenworkRuntimeConfigFile } from "./openwork-runtime-config.js";
 import { readLegacyConfigSweepState } from "./legacy-config-sweep.js";
+import { findManagedEngineWorkspace } from "./workspaces.js";
 import pkg from "../package.json" with { type: "json" };
 import constants from "../../../constants.json" with { type: "json" };
 
@@ -323,6 +327,30 @@ function parseDisabledProvidersPayload(value: unknown): string[] {
     if (!providers.includes(provider)) providers.push(provider);
   }
   return providers;
+}
+
+function parseRuntimeProviderPatchPayload(body: Record<string, unknown>): Record<string, unknown> {
+  const provider = body.provider;
+  if (!isRecord(provider)) {
+    throw new ApiError(400, "invalid_payload", "provider must be an object");
+  }
+  for (const [providerId, value] of Object.entries(provider)) {
+    if (!providerId.trim()) {
+      throw new ApiError(400, "invalid_payload", "provider keys must be non-empty strings");
+    }
+    if (value !== null && !isRecord(value)) {
+      throw new ApiError(400, "invalid_payload", "provider values must be objects or null");
+    }
+  }
+  return provider;
+}
+
+function resolveEngineRuntimeWorkspace(config: ServerConfig): WorkspaceInfo {
+  const workspace = findManagedEngineWorkspace(config.workspaces) ?? config.workspaces[0];
+  if (!workspace) {
+    throw new ApiError(400, "workspace_missing", "At least one workspace is required for engine runtime config");
+  }
+  return workspace;
 }
 
 function redactBearerTokens(value: string): string {
@@ -1989,6 +2017,33 @@ function createRoutes(
     return jsonResponse({
       ok: true,
       disabledProviders: runtimeDisabledProviderList(result.config),
+    });
+  });
+
+  addRoute(routes, "GET", "/runtime-config/providers", "host-token", async () => {
+    const runtime = await readGlobalRuntimeOpencodeConfig(config);
+    return jsonResponse({ provider: runtimeProviderMap(runtime) });
+  });
+
+  addRoute(routes, "PATCH", "/runtime-config/providers", "host-token", async (ctx) => {
+    ensureWritable(config);
+    const workspace = resolveEngineRuntimeWorkspace(config);
+    const body = await readJsonBody(ctx.request);
+    const providerPatch = parseRuntimeProviderPatchPayload(body);
+    const result = await writeGlobalRuntimeOpencodeConfig(config, (current) => ({
+      ...current,
+      provider: mergeRuntimeProviderUpdate(current.provider, providerPatch),
+    }));
+
+    await writeOpenworkRuntimeConfigFile(config, workspace.id);
+    await reloadOpencodeEngine(config, workspace, engineMcpServerState);
+
+    return jsonResponse({
+      ok: true,
+      changed: result.changed,
+      provider: runtimeProviderMap(result.config),
+      runtimeConfigPath: openworkRuntimeConfigFilePath(config),
+      reload: "reloaded",
     });
   });
 

--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -447,65 +447,6 @@ async function requestOk(input: {
   }
 }
 
-function workspaceItemId(item: JsonRecord) {
-  return readString(item.id)
-}
-
-function isManagedEngineWorkspaceItem(item: JsonRecord) {
-  const workspaceType = readString(item.workspaceType)
-  const path = readString(item.path)
-  return workspaceType !== "remote" && Boolean(path)
-}
-
-function readWorkspaceId(payload: JsonRecord) {
-  const activeId = readString(payload.activeId)
-  const rawItems = Array.isArray(payload.items)
-    ? payload.items
-    : Array.isArray(payload.workspaces)
-      ? payload.workspaces
-      : []
-  const items = rawItems.filter(isRecord)
-  const managedWorkspace = items.find(isManagedEngineWorkspaceItem)
-  if (managedWorkspace) {
-    return workspaceItemId(managedWorkspace)
-  }
-
-  if (activeId && items.some((item) => workspaceItemId(item) === activeId)) {
-    return activeId
-  }
-
-  for (const item of items) {
-    const id = workspaceItemId(item)
-    if (id) {
-      return id
-    }
-  }
-
-  return activeId
-}
-
-async function discoverWorkspaceId(input: {
-  fetchImpl: FetchImpl
-  instanceUrl: string
-  clientToken: string
-}) {
-  const payload = await requestJson({
-    fetchImpl: input.fetchImpl,
-    label: "workspace_discovery",
-    url: `${input.instanceUrl}/workspaces`,
-    init: {
-      method: "GET",
-      headers: bearerHeaders(input.clientToken),
-    },
-  })
-  const workspaceId = readWorkspaceId(payload)
-  if (!workspaceId) {
-    throw new Error("workspace_discovery_missing_workspace")
-  }
-
-  return workspaceId
-}
-
 async function readStoredFingerprint(input: {
   fetchImpl: FetchImpl
   instanceUrl: string
@@ -531,19 +472,17 @@ async function readRuntimeManagedProviders(input: {
   fetchImpl: FetchImpl
   instanceUrl: string
   clientToken: string
-  workspaceId: string
 }) {
   const payload = await requestJson({
     fetchImpl: input.fetchImpl,
-    label: "runtime_config_read",
-    url: `${input.instanceUrl}/workspace/${encodeURIComponent(input.workspaceId)}/runtime-config`,
+    label: "engine_config_read",
+    url: `${input.instanceUrl}/opencode/config`,
     init: {
       method: "GET",
       headers: bearerHeaders(input.clientToken),
     },
   })
-  const runtime = isRecord(payload.runtime) ? payload.runtime : null
-  const provider = runtime && isRecord(runtime.provider) ? runtime.provider : null
+  const provider = isRecord(payload.provider) ? payload.provider : null
   const managed: JsonRecord = {}
   if (!provider) {
     return managed
@@ -709,39 +648,17 @@ async function restoreEnvSnapshot(input: {
 async function patchRuntimeProviders(input: {
   fetchImpl: FetchImpl
   instanceUrl: string
-  clientToken: string
-  workspaceId: string
+  hostToken: string
   patch: JsonRecord
 }) {
-  if (Object.keys(input.patch).length === 0) {
-    return
-  }
-
   await requestOk({
     fetchImpl: input.fetchImpl,
-    label: "runtime_config_patch",
-    url: `${input.instanceUrl}/workspace/${encodeURIComponent(input.workspaceId)}/config`,
+    label: "runtime_provider_patch",
+    url: `${input.instanceUrl}/runtime-config/providers`,
     init: {
       method: "PATCH",
-      headers: bearerHeaders(input.clientToken),
-      body: JSON.stringify({ opencode: { provider: input.patch } }),
-    },
-  })
-}
-
-async function reloadOpencode(input: {
-  fetchImpl: FetchImpl
-  instanceUrl: string
-  clientToken: string
-  workspaceId: string
-}) {
-  await requestOk({
-    fetchImpl: input.fetchImpl,
-    label: "opencode_reload",
-    url: `${input.instanceUrl}/workspace/${encodeURIComponent(input.workspaceId)}/engine/reload`,
-    init: {
-      method: "POST",
-      headers: bearerHeaders(input.clientToken),
+      headers: hostTokenHeaders(input.hostToken),
+      body: JSON.stringify({ provider: input.patch }),
     },
   })
 }
@@ -750,7 +667,6 @@ async function verifyRuntimeProviders(input: {
   fetchImpl: FetchImpl
   instanceUrl: string
   clientToken: string
-  workspaceId: string
   providerIds: string[]
 }) {
   if (input.providerIds.length === 0) {
@@ -760,14 +676,13 @@ async function verifyRuntimeProviders(input: {
   const payload = await requestJson({
     fetchImpl: input.fetchImpl,
     label: "provider_readback",
-    url: `${input.instanceUrl}/workspace/${encodeURIComponent(input.workspaceId)}/config`,
+    url: `${input.instanceUrl}/opencode/config`,
     init: {
       method: "GET",
       headers: bearerHeaders(input.clientToken),
     },
   })
-  const opencode = isRecord(payload.opencode) ? payload.opencode : null
-  const provider = opencode && isRecord(opencode.provider) ? opencode.provider : null
+  const provider = isRecord(payload.provider) ? payload.provider : null
   for (const providerId of input.providerIds) {
     if (!provider || !Object.prototype.hasOwnProperty.call(provider, providerId)) {
       throw new Error(`provider_readback_missing_${providerId}`)
@@ -877,7 +792,6 @@ export async function materializeCloudWorkerProviders(input: {
       instanceUrl,
       hostToken: tokens.hostToken,
     })
-    const workspaceId = await discoverWorkspaceId({ fetchImpl, instanceUrl, clientToken: tokens.clientToken })
     const desiredProviderIds = prepared.providers.map((provider) => provider.runtimeProviderId)
     if (storedFingerprint === fingerprint) {
       try {
@@ -885,7 +799,6 @@ export async function materializeCloudWorkerProviders(input: {
           fetchImpl,
           instanceUrl,
           clientToken: tokens.clientToken,
-          workspaceId,
           providerIds: desiredProviderIds,
         })
         materializedFingerprintByWorker.set(input.workerId, fingerprint)
@@ -899,7 +812,6 @@ export async function materializeCloudWorkerProviders(input: {
       fetchImpl,
       instanceUrl,
       clientToken: tokens.clientToken,
-      workspaceId,
     })
     const providerPatch = buildRuntimeProviderPatch(prepared, currentManagedProviders)
     const providerRollbackPatch = buildRuntimeProviderRollbackPatch(prepared, currentManagedProviders)
@@ -920,20 +832,17 @@ export async function materializeCloudWorkerProviders(input: {
         entries: prepared.envEntries,
       })
       envWritten = prepared.envEntries.length > 0
+      providerPatched = true
       await patchRuntimeProviders({
         fetchImpl,
         instanceUrl,
-        clientToken: tokens.clientToken,
-        workspaceId,
+        hostToken: tokens.hostToken,
         patch: providerPatch,
       })
-      providerPatched = Object.keys(providerPatch).length > 0
-      await reloadOpencode({ fetchImpl, instanceUrl, clientToken: tokens.clientToken, workspaceId })
       await verifyRuntimeProviders({
         fetchImpl,
         instanceUrl,
         clientToken: tokens.clientToken,
-        workspaceId,
         providerIds: desiredProviderIds,
       })
     } catch (error) {
@@ -941,8 +850,7 @@ export async function materializeCloudWorkerProviders(input: {
         await patchRuntimeProviders({
           fetchImpl,
           instanceUrl,
-          clientToken: tokens.clientToken,
-          workspaceId,
+          hostToken: tokens.hostToken,
           patch: providerRollbackPatch,
         }).catch((rollbackError) => {
           materializationLogger.warn("cloud provider rollback failed", {

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -13,11 +13,6 @@ type FetchCall = {
   headers: Record<string, string>
   body: unknown
 }
-type WorkspaceFixture = {
-  id: string
-  workspaceType?: string
-  path?: string
-}
 
 const organizationId = createDenTypeId("organization")
 const instanceUrl = "https://worker.example.test"
@@ -80,20 +75,11 @@ function bodyEntries(body: unknown) {
 }
 
 function providerPatchFromBody(body: unknown) {
-  if (!isRecord(body) || !isRecord(body.opencode) || !isRecord(body.opencode.provider)) {
+  if (!isRecord(body) || !isRecord(body.provider)) {
     return {}
   }
 
-  return body.opencode.provider
-}
-
-function workspaceRouteId(path: string, suffix: string) {
-  if (!path.startsWith("/workspace/") || !path.endsWith(suffix)) {
-    return null
-  }
-
-  const encoded = path.slice("/workspace/".length, path.length - suffix.length)
-  return encoded ? decodeURIComponent(encoded) : null
+  return body.provider
 }
 
 function makeAnthropicProvider(input: {
@@ -147,10 +133,8 @@ function makeInstance(input: {
   failEnvWrites?: number
   failConfigPatches?: number
   runtimeProviders?: Record<string, unknown>
-  configReadProviders?: Record<string, unknown>
-  missingConfigReadbacks?: number
-  workspaces?: WorkspaceFixture[]
-  activeId?: string | null
+  opencodeConfigProviders?: Record<string, unknown>
+  missingEngineReadbacks?: number
 } = {}) {
   const calls: FetchCall[] = []
   const envValues = new Map<string, string>()
@@ -159,10 +143,9 @@ function makeInstance(input: {
   }
   let failEnvWrites = input.failEnvWrites ?? 0
   let failConfigPatches = input.failConfigPatches ?? 0
-  let missingConfigReadbacks = input.missingConfigReadbacks ?? 0
+  let missingEngineReadbacks = input.missingEngineReadbacks ?? 0
   const runtimeProviders: Record<string, unknown> = { ...(input.runtimeProviders ?? {}) }
-  const workspaces = input.workspaces ?? [{ id: "workspace-one" }]
-  const activeId = input.activeId === undefined ? workspaces[0]?.id ?? null : input.activeId
+  const engineProviders = input.opencodeConfigProviders ? { ...input.opencodeConfigProviders } : null
   const fetchImpl: FetchImpl = async (url, init) => {
     const parsed = new URL(url)
     const method = init?.method ?? "GET"
@@ -182,20 +165,12 @@ function makeInstance(input: {
         : jsonResponse({ error: "env_not_found" }, 404)
     }
 
-    if (method === "GET" && parsed.pathname === "/workspaces") {
-      return jsonResponse({ activeId, items: workspaces })
-    }
-
-    if (method === "GET" && workspaceRouteId(parsed.pathname, "/runtime-config")) {
-      return jsonResponse({ runtime: { provider: runtimeProviders } })
-    }
-
-    if (method === "GET" && workspaceRouteId(parsed.pathname, "/config")) {
-      if (missingConfigReadbacks > 0) {
-        missingConfigReadbacks -= 1
-        return jsonResponse({ opencode: { provider: {} } })
+    if (method === "GET" && parsed.pathname === "/opencode/config") {
+      if (missingEngineReadbacks > 0) {
+        missingEngineReadbacks -= 1
+        return jsonResponse({ provider: {} })
       }
-      return jsonResponse({ opencode: { provider: input.configReadProviders ?? runtimeProviders } })
+      return jsonResponse({ provider: engineProviders ?? runtimeProviders })
     }
 
     if (method === "PUT" && parsed.pathname === "/env") {
@@ -220,7 +195,7 @@ function makeInstance(input: {
       return jsonResponse({ ok: true })
     }
 
-    if (method === "PATCH" && workspaceRouteId(parsed.pathname, "/config")) {
+    if (method === "PATCH" && parsed.pathname === "/runtime-config/providers") {
       if (failConfigPatches > 0) {
         failConfigPatches -= 1
         return jsonResponse({ error: "config_patch_failed" }, 500)
@@ -234,10 +209,6 @@ function makeInstance(input: {
         }
       }
       return jsonResponse({ updatedAt: Date.now() })
-    }
-
-    if (method === "POST" && workspaceRouteId(parsed.pathname, "/engine/reload")) {
-      return jsonResponse({ ok: true, reloadedAt: Date.now() })
     }
 
     return jsonResponse({ error: "not_found" }, 404)
@@ -298,37 +269,34 @@ describe("Cloud provider materialization", () => {
     expect(result.status).toBe("applied")
     expect(callMethods(instance.calls)).toEqual([
       `GET /env/${openworkProvidersFingerprintEnv}`,
-      "GET /workspaces",
-      "GET /workspace/workspace-one/runtime-config",
+      "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
-      "PATCH /workspace/workspace-one/config",
-      "POST /workspace/workspace-one/engine/reload",
-      "GET /workspace/workspace-one/config",
+      "PATCH /runtime-config/providers",
+      "GET /opencode/config",
       "PUT /env",
     ])
-    expect(instance.calls[4]?.headers["x-openwork-host-token"]).toBe("host-token")
-    expect(instance.calls[4]?.body).toEqual({
+    expect(instance.calls[3]?.headers["x-openwork-host-token"]).toBe("host-token")
+    expect(instance.calls[3]?.body).toEqual({
       entries: [{ key: "ANTHROPIC_API_KEY", value: "sk-anthropic" }],
     })
-    expect(instance.calls[5]?.headers.authorization).toBe("Bearer client-token")
-    expect(instance.calls[5]?.body).toEqual({
-      opencode: {
-        provider: {
-          [provider.id]: {
-            id: "anthropic",
-            name: "Anthropic",
-            env: ["ANTHROPIC_API_KEY"],
-            models: {
-              "claude-fable-5": {
-                id: "claude-fable-5",
-                name: "claude-fable-5",
-                tool_call: true,
-              },
+    expect(instance.calls[4]?.headers["x-openwork-host-token"]).toBe("host-token")
+    expect(instance.calls[4]?.headers.authorization).toBeUndefined()
+    expect(instance.calls[4]?.body).toEqual({
+      provider: {
+        [provider.id]: {
+          id: "anthropic",
+          name: "Anthropic",
+          env: ["ANTHROPIC_API_KEY"],
+          models: {
+            "claude-fable-5": {
+              id: "claude-fable-5",
+              name: "claude-fable-5",
+              tool_call: true,
             },
-            npm: "@ai-sdk/anthropic",
-            api: "https://api.anthropic.com/v1",
           },
+          npm: "@ai-sdk/anthropic",
+          api: "https://api.anthropic.com/v1",
         },
       },
     })
@@ -349,8 +317,7 @@ describe("Cloud provider materialization", () => {
     expect(result).toEqual({ ok: true, status: "noop", fingerprint, providers: 1 })
     expect(callMethods(instance.calls)).toEqual([
       `GET /env/${openworkProvidersFingerprintEnv}`,
-      "GET /workspaces",
-      "GET /workspace/workspace-one/config",
+      "GET /opencode/config",
     ])
     expect(writeCalls(instance.calls)).toHaveLength(0)
   })
@@ -358,7 +325,7 @@ describe("Cloud provider materialization", () => {
   test("retries a stored fingerprint when provider read-back is missing", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
     const fingerprint = computeCloudProviderMaterializationFingerprint([provider])
-    const instance = makeInstance({ storedFingerprint: fingerprint, missingConfigReadbacks: 1 })
+    const instance = makeInstance({ storedFingerprint: fingerprint, missingEngineReadbacks: 1 })
 
     const result = await materialize({
       providers: () => [provider],
@@ -370,14 +337,12 @@ describe("Cloud provider materialization", () => {
     expect(result.status).toBe("applied")
     expect(callMethods(instance.calls)).toEqual([
       `GET /env/${openworkProvidersFingerprintEnv}`,
-      "GET /workspaces",
-      "GET /workspace/workspace-one/config",
-      "GET /workspace/workspace-one/runtime-config",
+      "GET /opencode/config",
+      "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
-      "PATCH /workspace/workspace-one/config",
-      "POST /workspace/workspace-one/engine/reload",
-      "GET /workspace/workspace-one/config",
+      "PATCH /runtime-config/providers",
+      "GET /opencode/config",
       "PUT /env",
     ])
     expect(instance.storedFingerprint).toBe(result.fingerprint)
@@ -385,7 +350,7 @@ describe("Cloud provider materialization", () => {
 
   test("treats missing provider read-back as materialization failure", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
-    const instance = makeInstance({ configReadProviders: {} })
+    const instance = makeInstance({ opencodeConfigProviders: {} })
 
     const result = await materialize({
       providers: () => [provider],
@@ -399,29 +364,37 @@ describe("Cloud provider materialization", () => {
     }
     expect(callMethods(instance.calls)).toEqual([
       `GET /env/${openworkProvidersFingerprintEnv}`,
-      "GET /workspaces",
-      "GET /workspace/workspace-one/runtime-config",
+      "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
-      "PATCH /workspace/workspace-one/config",
-      "POST /workspace/workspace-one/engine/reload",
-      "GET /workspace/workspace-one/config",
-      "PATCH /workspace/workspace-one/config",
+      "PATCH /runtime-config/providers",
+      "GET /opencode/config",
+      "PATCH /runtime-config/providers",
       "DELETE /env/ANTHROPIC_API_KEY",
     ])
     expect(instance.storedFingerprint).toBeNull()
     expect(instance.envValue("ANTHROPIC_API_KEY")).toBeNull()
   })
 
-  test("patches the local session workspace when discovery lists a remote workspace first", async () => {
+  test("fails when the provider is absent from engine-visible config", async () => {
     const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
-    const instance = makeInstance({
-      activeId: "rem_ws_remote",
-      workspaces: [
-        { id: "rem_ws_remote", workspaceType: "remote", path: "/remote" },
-        { id: "ws_session", workspaceType: "local", path: "/tmp/openwork-runtime" },
-      ],
+    const instance = makeInstance({ opencodeConfigProviders: {} })
+
+    const result = await materialize({
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      force: true,
     })
+
+    expect(result.ok).toBe(false)
+    if (!result.ok) {
+      expect(result.reason).toBe(`provider_readback_missing_${provider.id}`)
+    }
+  })
+
+  test("uses the global provider route without workspace discovery", async () => {
+    const provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const instance = makeInstance()
 
     const result = await materialize({
       providers: () => [provider],
@@ -430,8 +403,9 @@ describe("Cloud provider materialization", () => {
     })
 
     expect(result.ok).toBe(true)
-    expect(instance.calls.some((call) => call.method === "PATCH" && call.path === "/workspace/ws_session/config")).toBe(true)
-    expect(instance.calls.some((call) => call.method === "PATCH" && call.path === "/workspace/rem_ws_remote/config")).toBe(false)
+    expect(instance.calls.some((call) => call.path === "/workspaces")).toBe(false)
+    expect(instance.calls.some((call) => call.method === "PATCH" && call.path === "/runtime-config/providers")).toBe(true)
+    expect(instance.calls.some((call) => call.path.startsWith("/workspace/"))).toBe(false)
   })
 
   test("reapplies exactly once when providers drift, then caches the resolve check", async () => {
@@ -446,7 +420,7 @@ describe("Cloud provider materialization", () => {
     const drift = await materialize({ workerId, providers: () => providers, fetchImpl: instance.fetchImpl })
     expect(drift.ok).toBe(true)
     expect(drift.status).toBe("applied")
-    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "POST", "PUT"])
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "PUT"])
 
     instance.calls.length = 0
     const cached = await materialize({ workerId, providers: () => providers, fetchImpl: instance.fetchImpl })
@@ -467,13 +441,11 @@ describe("Cloud provider materialization", () => {
     expect(failed.ok).toBe(false)
     expect(callMethods(instance.calls)).toEqual([
       `GET /env/${openworkProvidersFingerprintEnv}`,
-      "GET /workspaces",
-      "GET /workspace/workspace-one/runtime-config",
+      "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
     ])
     expect(instance.calls.some((call) => call.method === "PATCH")).toBe(false)
-    expect(instance.calls.some((call) => call.path.endsWith("/engine/reload"))).toBe(false)
     expect(instance.storedFingerprint).toBeNull()
 
     instance.calls.length = 0
@@ -483,7 +455,7 @@ describe("Cloud provider materialization", () => {
     })
     expect(retried.ok).toBe(true)
     expect(retried.status).toBe("applied")
-    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "POST", "PUT"])
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "PUT"])
   })
 
   test("rolls back credential env, skips fingerprint, and retries when config patch fails", async () => {
@@ -497,18 +469,17 @@ describe("Cloud provider materialization", () => {
 
     expect(failed.ok).toBe(false)
     if (!failed.ok) {
-      expect(failed.reason).toBe("runtime_config_patch_failed_500")
+      expect(failed.reason).toBe("runtime_provider_patch_failed_500")
     }
     expect(callMethods(instance.calls)).toEqual([
       `GET /env/${openworkProvidersFingerprintEnv}`,
-      "GET /workspaces",
-      "GET /workspace/workspace-one/runtime-config",
+      "GET /opencode/config",
       "GET /env/ANTHROPIC_API_KEY",
       "PUT /env",
-      "PATCH /workspace/workspace-one/config",
+      "PATCH /runtime-config/providers",
+      "PATCH /runtime-config/providers",
       "DELETE /env/ANTHROPIC_API_KEY",
     ])
-    expect(instance.calls.some((call) => call.path.endsWith("/engine/reload"))).toBe(false)
     expect(instance.storedFingerprint).toBeNull()
     expect(instance.envValue("ANTHROPIC_API_KEY")).toBeNull()
 
@@ -519,7 +490,7 @@ describe("Cloud provider materialization", () => {
     })
     expect(retried.ok).toBe(true)
     expect(retried.status).toBe("applied")
-    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "POST", "PUT"])
+    expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "PUT"])
   })
 
   test("does not serialize provider keys into logs, results, or fingerprints", async () => {


### PR DESCRIPTION
Providers were written **per-workspace** while the sandbox runs a **single shared opencode engine**, so they never reached it. Two previous attempts reported success because they read back from the same workspace layer they had just written — the engine was never consulted.

## Evidence

The instance's global runtime config already carries the engine-wide layers:

```
runtime-opencode-config.json → ["$schema","agent","default_agent","mcp","plugin"]
```

`mcp` and `plugin` are already engine-global. `provider` was absent — it lived per-workspace in `runtime.sqlite`, and the engine's injected config "covers workspaces[0] only" (hence the existing `syncAllWorkspacesRuntimeMcpToEngine` re-push for MCPs). Live after the previous fix: `GET /opencode/config` → `provider: []`, picker empty, while credentials arrived fine (the env store is instance-global).

So per-workspace was simply the wrong layer for a shared engine. Providers now sit where plugins and MCPs already sit.

## Changes

- **openwork-server**: global providers stored under an engine-global runtime config id, merged into the managed `OPENCODE_CONFIG` file alongside workspace config; new host-token route `GET/PATCH /runtime-config/providers` with per-key upsert and explicit `null` delete, atomic rewrite, then engine reload. Host-token auth matches `/env` because this is instance-level configuration, not a per-workspace collaborator action.
- **den-api**: materializes through the global route and — the important part — **asserts read-back against the engine-visible config** (`GET /opencode/config`), not the layer it just wrote. Atomicity, rollback, and `providerSync: degraded` preserved. The workspace-discovery heuristic is deleted; nothing needs it now.

A reload suffices; no sandbox restart. Evidence: the server test observes the dispose/reload call and then sees the provider in `GET /opencode/config`.

## The guard that matters

The regression test asserts "workspace write reported success but the engine has no provider" is a **failure**. It fails against the current code and passes here — that exact false-success shipped twice.

## Tests

| Suite | Result |
| --- | --- |
| openwork-server (global store, auth, reload, engine visibility) | 26 pass / 0 fail |
| den-api (materialization, cloud route, lifecycle, provisioning) | 62 pass / 0 fail |
| `tsc --noEmit` server + den-api | clean |

## Deployment ordering (important)

The new route lives in **openwork-server**, which runs inside the sandbox from the Daytona snapshot — not in den-api. So merging this alone is not enough: den-api will call `/runtime-config/providers` against `openwork-0.18.8`, get a 404, and correctly report `providerSync: degraded`. The full chain is:

1. merge + den-api deploys,
2. build a new Daytona snapshot from `dev` (the snapshot builds openwork-server from source),
3. promote `DAYTONA_SNAPSHOT` to it,
4. existing sandboxes recycle onto it automatically via the checkpoint/recycle machinery (#3228) and materialize providers on the next resolve.

I am doing 2-4 immediately after this merge and will verify against the engine-visible config.