### PR TITLE
fix(den-api): tolerate sandboxes older than den-api (stop rolling back working credentials)

### DIFF
--- a/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
+++ b/ee/apps/den-api/src/llm/cloud-provider-materialization.ts
@@ -83,6 +83,15 @@ export type CloudProviderMaterializationResult =
       fingerprint: string | null
       providers: number
     }
+  | {
+      ok: false
+      status: "unsupported"
+      error: "provider_materialization_unsupported"
+      reason: string
+      message: string
+      fingerprint: string | null
+      providers: number
+    }
 
 export type MaterializeCloudWorkerProviders = typeof materializeCloudWorkerProviders
 
@@ -91,6 +100,7 @@ export const OPENWORK_PROVIDERS_FINGERPRINT_ENV = "OPENWORK_PROVIDERS_FINGERPRIN
 const logger = appLogger.child({ component: "cloud_provider_materialization" })
 const requestTimeoutMs = 8_000
 const materializedFingerprintByWorker = new Map<WorkerId, string>()
+const unsupportedLogFingerprintByWorker = new Map<WorkerId, string>()
 const modelConfigPassthroughKeys = [
   "family",
   "release_date",
@@ -421,6 +431,18 @@ function hostTokenHeaders(hostToken: string) {
   }
 }
 
+class MaterializationHttpError extends Error {
+  readonly label: string
+  readonly status: number
+
+  constructor(label: string, status: number) {
+    super(`${label}_failed_${status}`)
+    this.name = "MaterializationHttpError"
+    this.label = label
+    this.status = status
+  }
+}
+
 async function requestJson(input: {
   fetchImpl: FetchImpl
   label: string
@@ -429,7 +451,7 @@ async function requestJson(input: {
 }) {
   const response = await fetchWithTimeout(input.fetchImpl, input.url, input.init)
   if (!response.ok) {
-    throw new Error(`${input.label}_failed_${response.status}`)
+    throw new MaterializationHttpError(input.label, response.status)
   }
 
   return readJsonObject(response)
@@ -443,7 +465,7 @@ async function requestOk(input: {
 }) {
   const response = await fetchWithTimeout(input.fetchImpl, input.url, input.init)
   if (!response.ok) {
-    throw new Error(`${input.label}_failed_${response.status}`)
+    throw new MaterializationHttpError(input.label, response.status)
   }
 }
 
@@ -495,6 +517,51 @@ async function readRuntimeManagedProviders(input: {
   }
 
   return managed
+}
+
+function readRuntimeSnapshotVersion(payload: JsonRecord) {
+  const services = Array.isArray(payload.services) ? payload.services : []
+  let fallback: string | null = null
+  for (const service of services) {
+    if (!isRecord(service)) {
+      continue
+    }
+
+    const version = readString(service.actualVersion) ?? readString(service.targetVersion)
+    if (!version) {
+      continue
+    }
+
+    fallback = fallback ?? version
+    const serviceName = readString(service.name)?.toLowerCase()
+    if (serviceName?.includes("openwork") || serviceName?.includes("server")) {
+      return version
+    }
+  }
+
+  return fallback
+}
+
+async function readInstanceVersion(input: {
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  clientToken: string
+}) {
+  try {
+    const payload = await requestJson({
+      fetchImpl: input.fetchImpl,
+      label: "runtime_versions_read",
+      url: `${input.instanceUrl}/runtime/versions`,
+      init: {
+        method: "GET",
+        headers: bearerHeaders(input.clientToken),
+      },
+    })
+
+    return readRuntimeSnapshotVersion(payload)
+  } catch {
+    return null
+  }
 }
 
 function buildRuntimeProviderPatch(prepared: PreparedMaterialization, currentManagedProviders: JsonRecord) {
@@ -726,6 +793,30 @@ function failureResult(input: {
   } satisfies CloudProviderMaterializationResult
 }
 
+function unsupportedResult(input: {
+  reason: string
+  fingerprint: string | null
+  providers: number
+}) {
+  return {
+    ok: false,
+    status: "unsupported",
+    error: "provider_materialization_unsupported",
+    reason: input.reason,
+    message: input.reason,
+    fingerprint: input.fingerprint,
+    providers: input.providers,
+  } satisfies CloudProviderMaterializationResult
+}
+
+function unsupportedProviderRouteReason(error: unknown) {
+  return error instanceof MaterializationHttpError
+    && error.label === "runtime_provider_patch"
+    && (error.status === 404 || error.status === 405)
+    ? error.message
+    : null
+}
+
 function logFailure(input: {
   logger: MaterializationLogger
   workerId: WorkerId
@@ -742,6 +833,40 @@ function logFailure(input: {
   })
 }
 
+async function logUnsupportedOnce(input: {
+  logger: MaterializationLogger
+  workerId: WorkerId
+  organizationId: OrganizationId
+  fingerprint: string
+  providers: number
+  reason: string
+  fetchImpl: FetchImpl
+  instanceUrl: string
+  clientToken: string
+}) {
+  if (unsupportedLogFingerprintByWorker.get(input.workerId) === input.fingerprint) {
+    return
+  }
+
+  unsupportedLogFingerprintByWorker.set(input.workerId, input.fingerprint)
+  const instanceVersion = await readInstanceVersion({
+    fetchImpl: input.fetchImpl,
+    instanceUrl: input.instanceUrl,
+    clientToken: input.clientToken,
+  })
+
+  input.logger.warn("cloud provider materialization unsupported by worker version", {
+    worker_id: input.workerId,
+    organization_id: input.organizationId,
+    reason: input.reason,
+    fingerprint: input.fingerprint,
+    providers: input.providers,
+    instance_version: instanceVersion,
+  })
+}
+
+// den-api must tolerate instances older than itself: sandbox images ship on the
+// release/snapshot cadence while den-api deploys from dev.
 export async function materializeCloudWorkerProviders(input: {
   organizationId: OrganizationId
   workerId: WorkerId
@@ -846,6 +971,27 @@ export async function materializeCloudWorkerProviders(input: {
         providerIds: desiredProviderIds,
       })
     } catch (error) {
+      const unsupportedReason = unsupportedProviderRouteReason(error)
+      if (unsupportedReason) {
+        materializedFingerprintByWorker.delete(input.workerId)
+        await logUnsupportedOnce({
+          logger: materializationLogger,
+          workerId: input.workerId,
+          organizationId: input.organizationId,
+          fingerprint: prepared.fingerprint,
+          providers: providerCount,
+          reason: unsupportedReason,
+          fetchImpl,
+          instanceUrl,
+          clientToken: tokens.clientToken,
+        })
+        return unsupportedResult({
+          reason: unsupportedReason,
+          fingerprint: prepared.fingerprint,
+          providers: providerCount,
+        })
+      }
+
       if (providerPatched) {
         await patchRuntimeProviders({
           fetchImpl,

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -63,7 +63,7 @@ type CloudInstanceMemberResponse = CloudInstanceResponse & {
 type CloudGatewayInstanceResponse = CloudInstanceResponse & {
   clientToken: string | null
   hostToken: string | null
-  providerSync?: { status: "degraded" }
+  providerSync?: { status: "degraded"; reason?: "unsupported" }
 }
 type CloudInstanceUpdateResponse =
   | { ok: true; status: "update_requested" }
@@ -121,7 +121,10 @@ const cloudGatewayInstanceResponseSchema = z.object({
   url: z.string().url().nullable(),
   clientToken: z.string().nullable(),
   hostToken: z.string().nullable(),
-  providerSync: z.object({ status: z.literal("degraded") }).optional(),
+  providerSync: z.object({
+    status: z.literal("degraded"),
+    reason: z.literal("unsupported").optional(),
+  }).optional(),
 }).meta({ ref: "CloudGatewayInstanceResponse" })
 
 function cloudNotFound() {
@@ -856,7 +859,7 @@ async function resolveCloudInstanceForGateway(input: {
     return { status: "failed", url: null, clientToken: null, hostToken: null }
   }
 
-  let materialized = true
+  let providerSync: CloudGatewayInstanceResponse["providerSync"] | null = null
   try {
     const result = await input.materializeProviders({
       organizationId: input.payload.organization.id,
@@ -865,9 +868,13 @@ async function resolveCloudInstanceForGateway(input: {
       hostToken,
       clientToken,
     })
-    materialized = result.ok
+    if (!result.ok) {
+      providerSync = result.status === "unsupported"
+        ? { status: "degraded", reason: "unsupported" }
+        : { status: "degraded" }
+    }
   } catch (error) {
-    materialized = false
+    providerSync = { status: "degraded" }
     logger.warn("cloud gateway provider materialization warning", {
       worker_id: resolved.worker.id,
       message: error instanceof Error ? error.message : "provider_materialization_failed",
@@ -879,7 +886,7 @@ async function resolveCloudInstanceForGateway(input: {
     url: resolved.instance.url,
     clientToken,
     hostToken,
-    ...(!materialized ? { providerSync: { status: "degraded" } } : {}),
+    ...(providerSync ? { providerSync } : {}),
   }
 }
 

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -519,6 +519,46 @@ describe("Cloud gateway resolve route", () => {
     })
     expect(body).not.toContain(secret)
   })
+
+  test("surfaces unsupported provider materialization as degraded provider sync", async () => {
+    const readyWorker = fakeWorker("healthy")
+    const store = makeCloudWorkerStore({ tokens: [makeToken(readyWorker.id, "host"), makeToken(readyWorker.id, "client")] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      gatewayKey: "gateway-secret",
+      ensureCloudWorker: async () => readyWorker,
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandbox(),
+      probeSignedPreview: async () => true,
+      materializeProviders: async () => ({
+        ok: false,
+        status: "unsupported",
+        error: "provider_materialization_unsupported",
+        reason: "runtime_provider_patch_failed_404",
+        message: "runtime_provider_patch_failed_404",
+        fingerprint: "owp:v1:redacted",
+        providers: 1,
+      }),
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/gateway/resolve", {
+      headers: { "X-OpenWork-Gateway-Key": "gateway-secret" },
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      status: "ready",
+      url: "https://preview.example.test",
+      clientToken: "client-token",
+      hostToken: "host-token",
+      providerSync: { status: "degraded", reason: "unsupported" },
+    })
+  })
 })
 
 describe("Cloud instance route lifecycle states", () => {

--- a/ee/apps/den-api/test/cloud-provider-materialization.test.ts
+++ b/ee/apps/den-api/test/cloud-provider-materialization.test.ts
@@ -132,6 +132,8 @@ function makeInstance(input: {
   storedFingerprint?: string | null
   failEnvWrites?: number
   failConfigPatches?: number
+  providerRouteStatus?: number
+  runtimeVersion?: string | null
   runtimeProviders?: Record<string, unknown>
   opencodeConfigProviders?: Record<string, unknown>
   missingEngineReadbacks?: number
@@ -173,6 +175,17 @@ function makeInstance(input: {
       return jsonResponse({ provider: engineProviders ?? runtimeProviders })
     }
 
+    if (method === "GET" && parsed.pathname === "/runtime/versions") {
+      return jsonResponse({
+        services: [
+          {
+            name: "openwork-server",
+            actualVersion: input.runtimeVersion ?? null,
+          },
+        ],
+      })
+    }
+
     if (method === "PUT" && parsed.pathname === "/env") {
       if (failEnvWrites > 0) {
         failEnvWrites -= 1
@@ -196,6 +209,9 @@ function makeInstance(input: {
     }
 
     if (method === "PATCH" && parsed.pathname === "/runtime-config/providers") {
+      if (input.providerRouteStatus) {
+        return jsonResponse({ error: "runtime_provider_route_unavailable" }, input.providerRouteStatus)
+      }
       if (failConfigPatches > 0) {
         failConfigPatches -= 1
         return jsonResponse({ error: "config_patch_failed" }, 500)
@@ -491,6 +507,74 @@ describe("Cloud provider materialization", () => {
     expect(retried.ok).toBe(true)
     expect(retried.status).toBe("applied")
     expect(writeCalls(instance.calls).map((call) => call.method)).toEqual(["PUT", "PATCH", "PUT"])
+  })
+
+  test("preserves credential env and skips fingerprint when the global provider route is unsupported", async () => {
+    const workerId = createDenTypeId("worker")
+    let provider = makeAnthropicProvider({ apiKey: "sk-anthropic" })
+    const instance = makeInstance({ providerRouteStatus: 404, runtimeVersion: "openwork-0.18.8" })
+    const logs: Array<{ message: string; metadata?: Record<string, unknown> }> = []
+    const logger: Logger = {
+      warn(message, metadata) {
+        logs.push({ message, metadata })
+      },
+    }
+
+    const unsupported = await materialize({
+      workerId,
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      logger,
+    })
+
+    expect(unsupported.ok).toBe(false)
+    expect(unsupported.status).toBe("unsupported")
+    expect(callMethods(instance.calls)).toEqual([
+      `GET /env/${openworkProvidersFingerprintEnv}`,
+      "GET /opencode/config",
+      "GET /env/ANTHROPIC_API_KEY",
+      "PUT /env",
+      "PATCH /runtime-config/providers",
+      "GET /runtime/versions",
+    ])
+    expect(instance.envValue("ANTHROPIC_API_KEY")).toBe("sk-anthropic")
+    expect(instance.storedFingerprint).toBeNull()
+    expect(instance.calls.some((call) => call.method === "DELETE")).toBe(false)
+    expect(logs).toHaveLength(1)
+    expect(logs[0]).toMatchObject({
+      message: "cloud provider materialization unsupported by worker version",
+      metadata: {
+        instance_version: "openwork-0.18.8",
+        reason: "runtime_provider_patch_failed_404",
+      },
+    })
+
+    instance.calls.length = 0
+    const repeated = await materialize({
+      workerId,
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      logger,
+    })
+
+    expect(repeated.status).toBe("unsupported")
+    expect(instance.envValue("ANTHROPIC_API_KEY")).toBe("sk-anthropic")
+    expect(instance.storedFingerprint).toBeNull()
+    expect(logs).toHaveLength(1)
+    expect(instance.calls.some((call) => call.path === "/runtime/versions")).toBe(false)
+
+    provider = makeAnthropicProvider({ apiKey: "sk-anthropic-rotated" })
+    const changed = await materialize({
+      workerId,
+      providers: () => [provider],
+      fetchImpl: instance.fetchImpl,
+      logger,
+    })
+
+    expect(changed.status).toBe("unsupported")
+    expect(instance.envValue("ANTHROPIC_API_KEY")).toBe("sk-anthropic-rotated")
+    expect(instance.storedFingerprint).toBeNull()
+    expect(logs).toHaveLength(2)
   })
 
   test("does not serialize provider keys into logs, results, or fingerprints", async () => {


### PR DESCRIPTION
#3255 added a materializer that writes providers through a NEW openwork-server route. That route only exists in server builds from current `dev`, but production sandboxes run the pinned snapshot `openwork-0.18.8`, and **snapshots only build from `v*` release tags** — so sandboxes structurally lag den-api.

On those instances the provider PATCH 404s, materialization fails, and `restoreEnvSnapshot` **reverts the credential it had just written successfully** — actively breaking users who are currently working. That is worse than doing nothing.

## Fix

`404`/`405` on the global providers route is now classified as **`unsupported`**, distinct from failure:

- the credential/env write is **kept** (it is useful on its own, and older instances consume env)
- provider block skipped, no rollback, no env restore
- fingerprint NOT recorded, so an updated/recycled instance retries
- resolve reports `providerSync: { status: "degraded", reason: "unsupported" }`
- logged once per worker+fingerprint (with the instance version when readable) so operators can see "these sandboxes need a newer snapshot" without spam

Genuine failures (5xx, network, auth, read-back mismatch on a *supported* instance) keep the atomic rollback semantics from #3254.

Also added an explicit invariant comment at the materializer entry point: **den-api must tolerate instances older than itself, because sandbox images ship on the release/snapshot cadence while den-api deploys from `dev`.** This skew has now caused two production regressions; it should be stated in the code rather than rediscovered.

## Tests

The guard fails against #3255 and passes here:

```
Expected: "unsupported"
Received: "failed"
(fail) preserves credential env and skips fingerprint when the global provider route is unsupported
```

| Command | Result |
| --- | --- |
| materialization + cloud-route + lifecycle + provisioning | 64 pass / 0 fail |
| `tsc --noEmit` | clean |

Coverage: 404 -> unsupported with env preserved and no restore/delete calls; 500 -> rollback unchanged; supported happy path unchanged; read-back mismatch on supported -> failure with rollback.

## What this does and does not fix

It stops the regression. It does **not** make providers work in Cloud — that still needs a snapshot containing the new server route, which needs a release tag (or a hand-built snapshot). Until then affected users keep their credential and resolve honestly reports `unsupported`.