### PR TITLE
feat(extensions): connect, reconnect, and disconnect org connections from the desktop

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -2358,6 +2358,14 @@ export function createDenClient(options: { baseUrl: string; token?: string | nul
       );
     },
 
+    async disconnectMyMcpConnectionAccount(orgId: string, connectionId: string): Promise<void> {
+      await requestJson<unknown>(
+        baseUrls,
+        `/v1/mcp-connections/${encodeURIComponent(connectionId)}/disconnect-my-account`,
+        { method: "POST", token, organizationId: orgId },
+      );
+    },
+
     async listOrgMarketplaces(orgId: string): Promise<DenOrgMarketplace[]> {
       const payload = await requestJson<unknown>(
         baseUrls,

--- a/apps/app/src/i18n/locales/en.ts
+++ b/apps/app/src/i18n/locales/en.ts
@@ -780,6 +780,7 @@ export default {
   "mcp.org_connection_connected_label": "Connected",
   "mcp.org_connection_disconnect_action": "Disconnect",
   "mcp.org_connection_disconnecting_action": "Disconnecting...",
+  "mcp.org_connection_waiting_browser": "Waiting for browser...",
   "mcp.org_connection_desc_per_member": "Available from your organization. Connect your own account to use it.",
   "mcp.org_connection_desc_per_member_connected": "Connected with your own account.",
   "mcp.org_connection_desc_per_member_reconnect": "Reconnect your account to grant newly requested permissions.",

--- a/apps/app/src/react-app/design-system/extension-detail-modal.tsx
+++ b/apps/app/src/react-app/design-system/extension-detail-modal.tsx
@@ -79,10 +79,13 @@ export type ExtensionDetailModalProps = {
   /** Connect handler. */
   onConnect?: () => void;
   connectLabel?: string;
+  onReconnect?: () => void;
+  reconnectLabel?: string;
   connectingLabel?: string;
   /** Uninstall/disconnect handler. Shown when connected. */
   onUninstall?: () => void;
   uninstallLabel?: string;
+  closeOnUninstall?: boolean;
   /** Hide from the normal catalog view. */
   onHide?: () => void;
   /** Show again in the normal catalog view. */
@@ -208,9 +211,12 @@ export function ExtensionDetailModal({
   onReveal,
   onConnect,
   connectLabel = "Connect",
+  onReconnect,
+  reconnectLabel = "Reconnect",
   connectingLabel = "Connecting...",
   onUninstall,
   uninstallLabel,
+  closeOnUninstall = true,
   onHide,
   onShow,
   configSlot,
@@ -520,13 +526,31 @@ export function ExtensionDetailModal({
             Close
           </Button>
         )}
+        {connected && onReconnect ? (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={onReconnect}
+            disabled={connecting}
+          >
+            {connecting ? (
+              <>
+                <Loader2 data-icon="inline-start" className="animate-spin" />
+                {connectingLabel}
+              </>
+            ) : (
+              reconnectLabel
+            )}
+          </Button>
+        ) : null}
         {connected && onUninstall ? (
           <Button
             variant="destructive"
             size="sm"
+            disabled={connecting}
             onClick={() => {
               onUninstall();
-              onClose();
+              if (closeOnUninstall) onClose();
             }}
           >
             {uninstallLabel ?? (taxonomy === "skill" ? "Uninstall" : "Disconnect")}

--- a/apps/app/src/react-app/domains/connections/native-provider-connections.test.ts
+++ b/apps/app/src/react-app/domains/connections/native-provider-connections.test.ts
@@ -3,13 +3,36 @@ declare const test: (name: string, fn: () => void) => void;
 declare const expect: (value: unknown) => { toBe: (expected: unknown) => void; toEqual: (expected: unknown) => void };
 
 import {
+  canDisconnectMemberConnection,
   canDisconnectNativeProviderAccount,
+  canMemberAuthorizeConnection,
+  connectionNeedsAdminRepair,
   isNativeProviderConnectionId,
+  type MemberLifecycleConnection,
 } from "./native-provider-connections";
 import { resolveOrgMcpConnectionCardState } from "./use-org-mcp-connections";
 import { resolveConnectionRowGroup } from "../settings/connect-cloud-readiness";
 
 describe("native provider connections", () => {
+  const lifecycleConnection = (
+    id: string,
+    authType: MemberLifecycleConnection["authType"],
+    credentialMode: MemberLifecycleConnection["credentialMode"],
+    connectedForMe: boolean,
+    reconnectActionOwner?: MemberLifecycleConnection["reconnectActionOwner"],
+    needsReconnect?: boolean,
+  ): MemberLifecycleConnection => {
+    const connection: MemberLifecycleConnection = {
+      id,
+      authType,
+      credentialMode,
+      connectedForMe,
+    };
+    if (reconnectActionOwner !== undefined) connection.reconnectActionOwner = reconnectActionOwner;
+    if (needsReconnect !== undefined) connection.needsReconnect = needsReconnect;
+    return connection;
+  };
+
   test("recognizes native provider ids", () => {
     expect(isNativeProviderConnectionId("google-workspace")).toBe(true);
     expect(isNativeProviderConnectionId("microsoft-365")).toBe(true);
@@ -21,6 +44,33 @@ describe("native provider connections", () => {
     expect(canDisconnectNativeProviderAccount({ id: "microsoft-365", connectedForMe: true })).toBe(true);
     expect(canDisconnectNativeProviderAccount({ id: "google-workspace", connectedForMe: false })).toBe(false);
     expect(canDisconnectNativeProviderAccount({ id: "emc_google_workspace", connectedForMe: true })).toBe(false);
+  });
+
+  test("allows members to disconnect their own per-member account", () => {
+    const googleWorkspace = lifecycleConnection("google-workspace", "oauth", "per_member", true);
+    const externalMcp = lifecycleConnection("emc_google_workspace", "oauth", "per_member", true);
+    expect(canDisconnectMemberConnection(googleWorkspace)).toBe(true);
+    expect(canDisconnectMemberConnection(externalMcp)).toBe(true);
+    expect(canDisconnectMemberConnection(lifecycleConnection("shared", "oauth", "shared", true))).toBe(false);
+    expect(canDisconnectMemberConnection(lifecycleConnection("not-connected", "oauth", "per_member", false))).toBe(false);
+  });
+
+  test("allows members to authorize per-member OAuth connections unless admin repair owns it", () => {
+    expect(canMemberAuthorizeConnection(lifecycleConnection("not-connected", "oauth", "per_member", false))).toBe(true);
+    expect(canMemberAuthorizeConnection(lifecycleConnection("connected", "oauth", "per_member", true))).toBe(true);
+    expect(canMemberAuthorizeConnection(lifecycleConnection("shared", "oauth", "shared", false))).toBe(false);
+    expect(canMemberAuthorizeConnection(lifecycleConnection("apikey", "apikey", "per_member", false))).toBe(false);
+    expect(canMemberAuthorizeConnection(lifecycleConnection("admin-repair", "oauth", "per_member", true, "organization_admin", true))).toBe(false);
+    expect(canMemberAuthorizeConnection(lifecycleConnection("member-repair", "oauth", "per_member", true, "member", true))).toBe(true);
+    expect(canMemberAuthorizeConnection(lifecycleConnection("unset-repair", "oauth", "per_member", true, undefined, true))).toBe(true);
+  });
+
+  test("detects administrator-owned repair", () => {
+    expect(connectionNeedsAdminRepair({ needsReconnect: true, reconnectActionOwner: "organization_admin" })).toBe(true);
+    expect(connectionNeedsAdminRepair({ needsReconnect: true, reconnectActionOwner: "member" })).toBe(false);
+    expect(connectionNeedsAdminRepair({ needsReconnect: true, reconnectActionOwner: null })).toBe(false);
+    expect(connectionNeedsAdminRepair({ needsReconnect: true })).toBe(false);
+    expect(connectionNeedsAdminRepair({ needsReconnect: false, reconnectActionOwner: "organization_admin" })).toBe(false);
   });
 
   test("projects connected native providers with missing scopes as reconnectable", () => {

--- a/apps/app/src/react-app/domains/connections/native-provider-connections.ts
+++ b/apps/app/src/react-app/domains/connections/native-provider-connections.ts
@@ -8,6 +8,16 @@ export type ReconnectableConnection = {
   missingFeatures?: readonly string[];
 };
 
+export type MemberLifecycleConnection = {
+  id: string;
+  authType: "oauth" | "apikey" | "none";
+  credentialMode: "shared" | "per_member";
+  connectedForMe: boolean;
+  needsReconnect?: boolean;
+  missingFeatures?: readonly string[];
+  reconnectActionOwner?: "member" | "organization_admin" | null;
+};
+
 export function connectionNeedsReconnect(connection: ReconnectableConnection): boolean {
   return connection.needsReconnect === true || (connection.missingFeatures?.length ?? 0) > 0;
 }
@@ -18,4 +28,19 @@ export function isNativeProviderConnectionId(id: string): boolean {
 
 export function canDisconnectNativeProviderAccount(connection: NativeProviderDisconnectableConnection): boolean {
   return connection.connectedForMe && isNativeProviderConnectionId(connection.id);
+}
+
+/** Reconnect/repair is owned by an org admin, not the member. */
+export function connectionNeedsAdminRepair(connection: Pick<MemberLifecycleConnection, "needsReconnect" | "reconnectActionOwner">): boolean {
+  return connection.needsReconnect === true && connection.reconnectActionOwner === "organization_admin";
+}
+
+/** The member may run the OAuth flow themselves (connect or reconnect). */
+export function canMemberAuthorizeConnection(connection: MemberLifecycleConnection): boolean {
+  return connection.credentialMode === "per_member" && connection.authType === "oauth" && !connectionNeedsAdminRepair(connection);
+}
+
+/** The member may remove their own stored account. */
+export function canDisconnectMemberConnection(connection: Pick<MemberLifecycleConnection, "credentialMode" | "connectedForMe">): boolean {
+  return connection.credentialMode === "per_member" && connection.connectedForMe;
 }

--- a/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
+++ b/apps/app/src/react-app/domains/connections/use-org-mcp-connections.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 
-import { createDenClient, readDenSettings, type DenExternalMcpConnection } from "@/app/lib/den";
+import { createDenClient, readDenSettings, type DenClient, type DenExternalMcpConnection } from "@/app/lib/den";
 import { denSettingsChangedEvent } from "@/app/lib/den-session-events";
 import { openDesktopUrl } from "@/app/lib/desktop";
 import { isDesktopRuntime } from "@/app/utils";
@@ -27,6 +27,14 @@ async function openAuthorizationUrl(url: string) {
   if (typeof window !== "undefined") {
     window.open(url, "_blank", "noopener,noreferrer");
   }
+}
+
+async function disconnectMemberAccount(client: DenClient, orgId: string, connectionId: string): Promise<void> {
+  if (isNativeProviderConnectionId(connectionId)) {
+    await client.disconnectOauthProviderAccount(orgId, connectionId);
+    return;
+  }
+  await client.disconnectMyMcpConnectionAccount(orgId, connectionId);
 }
 
 export type OrgMcpConnectionCardState = {
@@ -107,9 +115,14 @@ export function useOrgMcpConnections() {
   // Settings remounts every time the extensions panel opens, so start from
   // whatever the app already fetched instead of an empty list.
   const prefetched = readCloudInventoryScope();
-  const [connections, setConnections] = useState<DenExternalMcpConnection[]>(
+  const [connections, setConnectionsState] = useState<DenExternalMcpConnection[]>(
     () => (prefetched ? readCachedOrgMcpConnections(prefetched) ?? [] : []),
   );
+  const connectionsRef = useRef(connections);
+  const setConnections = useCallback((nextConnections: DenExternalMcpConnection[]) => {
+    connectionsRef.current = nextConnections;
+    setConnectionsState(nextConnections);
+  }, []);
   const [loading, setLoading] = useState(false);
   const [loaded, setLoaded] = useState(connections.length > 0);
   const [error, setError] = useState<string | null>(null);
@@ -179,13 +192,16 @@ export function useOrgMcpConnections() {
         setLoaded(true);
       }
     }
-  }, [isActionScopeCurrent]);
+  }, [isActionScopeCurrent, setConnections]);
 
-  const connect = useCallback(async (connectionId: string) => {
+  const connect = useCallback(async (connectionId: string, options?: { forceFreshAuthorization?: boolean }) => {
     const settings = readDenSettings();
     const token = settings.authToken?.trim() ?? "";
     const orgId = settings.activeOrgId?.trim() ?? "";
     if (!token || !orgId) return;
+
+    const previous = connectionsRef.current.find((entry) => entry.id === connectionId);
+    const previousConnectedAt = previous?.connectedAt ?? null;
 
     stopPolling();
     const pollScope: OrgMcpPollScope = {
@@ -196,6 +212,10 @@ export function useOrgMcpConnections() {
     setConnectingId(connectionId);
     try {
       const client = createDenClient({ baseUrl: settings.baseUrl, token });
+      if (options?.forceFreshAuthorization === true && previous?.connectedForMe) {
+        await disconnectMemberAccount(client, orgId, connectionId);
+        if (!isActionScopeCurrent(pollScope)) return;
+      }
       const result = await client.startMcpConnectionConnect(orgId, connectionId);
       if (!isActionScopeCurrent(pollScope)) return;
       if (result.status === "connected") {
@@ -241,7 +261,10 @@ export function useOrgMcpConnections() {
           if (!isActionScopeCurrent(pollScope)) return;
           setConnections(polled);
           const match = polled.find((entry) => entry.id === connectionId);
-          if (match?.connectedForMe && !connectionNeedsReconnect(match)) {
+          const fresh = Boolean(match && match.connectedForMe && !connectionNeedsReconnect(match)
+            && typeof match.connectedAt === "string" && match.connectedAt.length > 0
+            && match.connectedAt !== previousConnectedAt);
+          if (fresh) {
             stopPolling();
             setConnectingId(null);
           }
@@ -254,11 +277,9 @@ export function useOrgMcpConnections() {
       setError(connectError instanceof Error ? connectError.message : "Failed to start the connection.");
       setConnectingId(null);
     }
-  }, [isActionScopeCurrent, refresh, stopPolling]);
+  }, [isActionScopeCurrent, refresh, setConnections, stopPolling]);
 
   const disconnect = useCallback(async (connectionId: string) => {
-    if (!isNativeProviderConnectionId(connectionId)) return;
-
     const settings = readDenSettings();
     const token = settings.authToken?.trim() ?? "";
     const orgId = settings.activeOrgId?.trim() ?? "";
@@ -274,7 +295,7 @@ export function useOrgMcpConnections() {
     setError(null);
     try {
       const client = createDenClient({ baseUrl: settings.baseUrl, token });
-      await client.disconnectOauthProviderAccount(orgId, connectionId);
+      await disconnectMemberAccount(client, orgId, connectionId);
       if (!isActionScopeCurrent(actionScope)) return;
       await refresh(actionScope);
       if (!isActionScopeCurrent(actionScope)) return;
@@ -303,7 +324,7 @@ export function useOrgMcpConnections() {
       stopPolling();
       window.removeEventListener(denSettingsChangedEvent, handleSettingsChanged);
     };
-  }, [refresh, stopPolling]);
+  }, [refresh, setConnections, stopPolling]);
 
   return { connections, loading, loaded, error, connectingId, disconnectingId, refresh, connect, disconnect };
 }

--- a/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
+++ b/apps/app/src/react-app/domains/settings/pages/mcp-view.tsx
@@ -32,6 +32,7 @@ import type { CloudImportedPlugin } from "../../../../app/cloud/import-state";
 import { ExtensionCard, type ExtensionLayout } from "../../../design-system/extension-card";
 import { ExtensionDetailModal } from "../../../design-system/extension-detail-modal";
 import {
+  isOrgMcpConnectionReady,
   isOrgMcpConnectionItem,
   orgMcpConnectionActionLabel,
   resolveExtensionInventoryGroup,
@@ -65,7 +66,11 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { ConfirmModal } from "../../../design-system/modals/confirm-modal";
 import { AddMcpModal } from "../../connections/modals/add-mcp-modal";
 import { ClaudePluginImportModal } from "../../connections/modals/claude-plugin-import-modal";
-import { canDisconnectNativeProviderAccount } from "../../connections/native-provider-connections";
+import {
+  canDisconnectMemberConnection,
+  canDisconnectNativeProviderAccount,
+  canMemberAuthorizeConnection,
+} from "../../connections/native-provider-connections";
 import type { OpenworkClaudePluginPreview } from "../../../../app/lib/openwork-server";
 import {
   isOpenWorkExtensionEnabled,
@@ -152,6 +157,9 @@ export type McpViewProps = {
   installClaudePlugin?: (url: string) => Promise<{ ok: boolean; message: string }>;
   /** Connected org-level External MCP Connections rendered in My Extensions. */
   orgMcpItems?: ExtensionItem[];
+  orgMcpConnectingId?: string | null;
+  connectOrgMcp?: (connectionId: string) => void;
+  reconnectOrgMcp?: (connectionId: string) => void;
   orgMcpDisconnectingId?: string | null;
   disconnectOrgMcp?: (connectionId: string) => void;
   initialFilter?: ExtensionInventoryFilter;
@@ -840,7 +848,11 @@ export function McpView(props: McpViewProps) {
 
       {detailOrgMcpItem && isOrgMcpConnectionItem(detailOrgMcpItem) ? (() => {
         const connection = detailOrgMcpItem.orgMcpConnection;
-        const canDisconnect = canDisconnectNativeProviderAccount(connection);
+        const ready = isOrgMcpConnectionReady(connection);
+        const canAuthorize = canMemberAuthorizeConnection(connection);
+        const canDisconnect = canDisconnectMemberConnection(connection);
+        const connectingBusy = props.orgMcpConnectingId === connection.id;
+        const disconnectingBusy = props.orgMcpDisconnectingId === connection.id;
         return (
           <ExtensionDetailModal
             open={true}
@@ -850,13 +862,20 @@ export function McpView(props: McpViewProps) {
             name={detailOrgMcpItem.name}
             description={detailOrgMcpItem.description ?? orgMcpConnectionActionLabel(connection)}
             taxonomy="connection"
-            connected={true}
+            connected={ready}
             connectedLabel={orgMcpConnectionActionLabel(connection)}
+            connecting={connectingBusy || disconnectingBusy}
+            connectingLabel={disconnectingBusy ? t("mcp.org_connection_disconnecting_action") : t("mcp.org_connection_waiting_browser")}
             beta
             url={connection.url}
             oauth={connection.authType === "oauth"}
+            connectLabel={orgMcpConnectionActionLabel(connection)}
+            reconnectLabel={t("mcp.org_connection_reconnect_action")}
+            onConnect={!ready && canAuthorize && props.connectOrgMcp ? () => props.connectOrgMcp?.(connection.id) : undefined}
+            onReconnect={ready && canAuthorize && props.reconnectOrgMcp ? () => props.reconnectOrgMcp?.(connection.id) : undefined}
             onUninstall={canDisconnect && props.disconnectOrgMcp ? () => props.disconnectOrgMcp?.(connection.id) : undefined}
             uninstallLabel={t("mcp.org_connection_disconnect_action")}
+            closeOnUninstall={false}
             showEnablementCard={false}
             configSlot={(
               <div className="flex flex-wrap gap-2">

--- a/apps/app/src/react-app/shell/settings-route.tsx
+++ b/apps/app/src/react-app/shell/settings-route.tsx
@@ -2362,6 +2362,9 @@ function SettingsRouteContent(props: SettingsSurfaceProps = {}) {
                 orgMcpItems={orgMcpConnectionItems}
                 uninstallSkill={(name) => { void extensionsStore.uninstallSkill(name); }}
                 removeCloudPlugin={(pluginId) => { void extensionsStore.removeCloudOrgPlugin(pluginId); }}
+                orgMcpConnectingId={orgMcpConnections.connectingId}
+                connectOrgMcp={(connectionId) => { void orgMcpConnections.connect(connectionId); }}
+                reconnectOrgMcp={(connectionId) => { void orgMcpConnections.connect(connectionId, { forceFreshAuthorization: true }); }}
                 orgMcpDisconnectingId={orgMcpConnections.disconnectingId}
                 disconnectOrgMcp={(connectionId) => { void orgMcpConnections.disconnect(connectionId); }}
                 readSkill={(name) => extensionsStore.readSkill(name)}

--- a/ee/packages/den-db/src/columns.ts
+++ b/ee/packages/den-db/src/columns.ts
@@ -114,6 +114,26 @@ export const encryptedMediumTextColumn = (columnName: string) =>
     deserialize: (value) => value,
   })
 
+/**
+ * Drizzle's `json()` returns whatever the driver produced: MySQL's native
+ * JSON type arrives pre-parsed, but MariaDB aliases JSON to LONGTEXT and
+ * mysql2 hands back the raw string. Parse strings on read so both engines
+ * produce the declared shape.
+ */
+export const compatJsonColumn = <TData>(columnName: string) =>
+  customType<{ data: TData; driverData: TData | string }>({
+    dataType() {
+      return "json"
+    },
+    toDriver(value) {
+      return JSON.stringify(value)
+    },
+    fromDriver(value) {
+      if (typeof value === "string") return JSON.parse(value)
+      return value
+    },
+  })(columnName)
+
 export const mediumBlobColumn = (columnName: string) =>
   customType<{ data: Uint8Array; driverData: Uint8Array }>({
     dataType() {

--- a/ee/packages/den-db/src/schema/sharables/capability-credentials.ts
+++ b/ee/packages/den-db/src/schema/sharables/capability-credentials.ts
@@ -2,14 +2,17 @@ import { relations, sql } from "drizzle-orm"
 import {
   boolean,
   index,
-  json,
   mysqlEnum,
   mysqlTable,
   timestamp,
   uniqueIndex,
   varchar,
 } from "drizzle-orm/mysql-core"
-import { denTypeIdColumn, encryptedTextColumn } from "../../columns"
+import {
+  compatJsonColumn,
+  denTypeIdColumn,
+  encryptedTextColumn,
+} from "../../columns"
 import { MemberTable, OrganizationTable } from "../org"
 import { ConfigObjectTable, PluginTable } from "./plugin-arch"
 
@@ -45,7 +48,7 @@ export const OrgOAuthClientTable = mysqlTable(
      * doesn't have to re-discover on every call. For native providers this
      * is typically empty.
      */
-    extra: json("extra").$type<Record<string, unknown>>(),
+    extra: compatJsonColumn<Record<string, unknown>>("extra"),
     createdByOrgMembershipId: denTypeIdColumn(
       "member",
       "created_by_org_membership_id",
@@ -80,7 +83,7 @@ export const ConnectedAccountTable = mysqlTable(
     orgMembershipId: denTypeIdColumn("member", "org_membership_id").notNull(),
     providerId: varchar("provider_id", { length: 255 }).notNull(),
     externalAccountId: varchar("external_account_id", { length: 255 }),
-    scopes: json("scopes").$type<string[]>(),
+    scopes: compatJsonColumn<string[]>("scopes"),
     accessToken: encryptedTextColumn("access_token"),
     refreshToken: encryptedTextColumn("refresh_token"),
     tokenType: varchar("token_type", { length: 64 }),
@@ -91,7 +94,7 @@ export const ConnectedAccountTable = mysqlTable(
      * tokens are saved.
      */
     pendingCodeVerifier: encryptedTextColumn("pending_code_verifier"),
-    credentialHealth: json("credential_health").$type<ExternalMcpCredentialHealth>(),
+    credentialHealth: compatJsonColumn<ExternalMcpCredentialHealth>("credential_health"),
     connectedAt: timestamp("connected_at", { fsp: 3 }).notNull().defaultNow(),
     updatedAt: timestamp("updated_at", { fsp: 3 })
       .notNull()
@@ -162,7 +165,7 @@ export const ExternalMcpConnectionTable = mysqlTable(
      * and are classified lazily so manually registered legacy callbacks keep
      * working until an administrator migrates them.
      */
-    oauthConfiguration: json("oauth_configuration").$type<ExternalMcpOAuthConfiguration>(),
+    oauthConfiguration: compatJsonColumn<ExternalMcpOAuthConfiguration>("oauth_configuration"),
     /**
      * How the connection's credential relates to people:
      * - "shared": one org-level credential (this row's token columns, or
@@ -196,7 +199,7 @@ export const ExternalMcpConnectionTable = mysqlTable(
      * connect/callback. Cleared once tokens are saved.
      */
     pendingCodeVerifier: encryptedTextColumn("pending_code_verifier"),
-    credentialHealth: json("credential_health").$type<ExternalMcpCredentialHealth>(),
+    credentialHealth: compatJsonColumn<ExternalMcpCredentialHealth>("credential_health"),
     /**
      * Set when live discovery no longer matches the selected OAuth issuer.
      * The mismatch remains fail-closed until an administrator explicitly

--- a/evals/flows/org-connection-lifecycle-desktop.flow.ts
+++ b/evals/flows/org-connection-lifecycle-desktop.flow.ts
@@ -407,6 +407,13 @@ async function waitForNotConnectedDetail(ctx: FlowContext): Promise<void> {
 }
 
 async function clickExactButton(ctx: FlowContext, label: string): Promise<void> {
+  // Lifecycle buttons disable briefly while a connect/disconnect settles, so
+  // wait for the enabled button instead of failing on a race.
+  await ctx.waitFor(
+    `Boolean([...document.querySelectorAll('button')]
+      .find((el) => (el.textContent ?? '').trim() === ${JSON.stringify(label)} && !el.disabled))`,
+    { timeoutMs: 30_000, label: `enabled button: ${label}` },
+  );
   const clicked = await ctx.eval(`(() => {
     const button = [...document.querySelectorAll('button')]
       .find((el) => (el.textContent ?? '').trim() === ${JSON.stringify(label)} && !el.disabled);
@@ -502,9 +509,13 @@ async function waitForMockAuthorizeRequest(ctx: FlowContext, clickedAt: string):
   const params = new URL(authorizeRequest.url, MOCK_CONTROL_URL).searchParams;
   ctx.assert(Boolean(params.get("state")), "Authorize request is missing signed state.");
   ctx.assert(Boolean(params.get("client_id")), "Authorize request is missing dynamic client_id.");
+  // New connections use the deployment-wide shared callback (connection routing
+  // travels in the signed state); legacy rows keep the per-connection path.
+  const redirectUri = params.get("redirect_uri") ?? "";
   ctx.assert(
-    (params.get("redirect_uri") ?? "").includes(requireStateString(state.connectionId, "connection id")),
-    "Authorize redirect_uri was not scoped to this connection.",
+    redirectUri.includes("/v1/mcp-connections/")
+      && (redirectUri.includes("/oauth/callback") || redirectUri.includes(requireStateString(state.connectionId, "connection id"))),
+    `Authorize redirect_uri was not an OpenWork MCP connection callback: ${redirectUri}`,
   );
 }
 
@@ -701,6 +712,18 @@ export default defineFlow({
       run: async (ctx) => {
         await ctx.prove("The connected detail page now offers both Reconnect and Disconnect", {
           voiceover: vo[3],
+          action: async () => {
+            // Bring the lifecycle action row into view and focus it so this
+            // frame is visibly about the actions (and not a byte-for-byte
+            // duplicate of the connected summary in frame 3).
+            await ctx.eval(`(() => {
+              const button = [...document.querySelectorAll('button')]
+                .find((el) => (el.textContent ?? '').trim() === 'Reconnect');
+              button?.scrollIntoView({ block: 'center' });
+              button?.focus({ focusVisible: true });
+              return Boolean(button);
+            })()`);
+          },
           assert: async () => {
             const hasActions = await ctx.eval(`(() => {
               const labels = new Set([...document.querySelectorAll('button')]
@@ -716,6 +739,10 @@ export default defineFlow({
             claim: "The connected detail page exposes Reconnect and Disconnect lifecycle actions.",
             requireText: ["Reconnect", "Disconnect"],
             rejectText: ["Something went wrong"],
+            // The connected detail page fits one viewport, so a page capture
+            // would be byte-identical to frame 3. Capture the sandbox desktop
+            // instead (real window on a real display) when available.
+            sandboxCapture: Boolean(process.env.OPENWORK_EVAL_DAYTONA_SANDBOX?.trim()),
           },
         });
       },

--- a/evals/flows/org-connection-lifecycle-desktop.flow.ts
+++ b/evals/flows/org-connection-lifecycle-desktop.flow.ts
@@ -1,0 +1,779 @@
+import { execSync, spawn } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineFlow, type FlowContext } from "../runner/flow.ts";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.ts";
+import type { ChildProcess } from "node:child_process";
+
+// Narration is loaded from the approved script (evals/voiceovers/org-connection-lifecycle-desktop.md).
+// The runner fails this flow if the narration drifts from that script.
+const vo = await loadVoiceoverParagraphs("org-connection-lifecycle-desktop");
+if (!vo) throw new Error("Missing approved voice-over script for org-connection-lifecycle-desktop.");
+
+const ROOT = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const MOCK_SERVER_SCRIPT = join(ROOT, "scripts", "mock-oauth-mcp-server.mjs");
+const DEN_API_URL = (process.env.OPENWORK_EVAL_DEN_API_URL ?? "").trim().replace(/\/+$/, "");
+const DEN_WEB_URL = (process.env.OPENWORK_EVAL_DEN_WEB_URL ?? DEN_API_URL.replace("127.0.0.1", "localhost")).trim().replace(/\/+$/, "");
+const ADMIN_EMAIL = process.env.OPENWORK_EVAL_DEMO_EMAIL?.trim() || "alex@acme.test";
+const ADMIN_PASSWORD = process.env.OPENWORK_EVAL_DEMO_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MEMBER_EMAIL = process.env.OPENWORK_EVAL_MEMBER_EMAIL?.trim() || "jordan.demo@acme.test";
+const MEMBER_PASSWORD = process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || "OpenWorkDemo123!";
+const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
+const MOCK_PORT = Number(process.env.OPENWORK_EVAL_LIFECYCLE_MOCK_PORT || 3979);
+const MOCK_LOCAL_URL = `http://127.0.0.1:${MOCK_PORT}`;
+const MOCK_PUBLIC_URL = (process.env.OPENWORK_EVAL_LIFECYCLE_MOCK_PUBLIC_URL ?? MOCK_LOCAL_URL).trim().replace(/\/+$/, "");
+const RUN_TAG = Date.now();
+const CONNECTION_NAME = `Meeting Notes ${RUN_TAG}`;
+const WORKSPACE_PATH = `/tmp/openwork-org-connection-lifecycle-${RUN_TAG}`;
+
+type ParsedFetch = {
+  response: Response;
+  body: unknown;
+  text: string;
+};
+
+type ConnectionSummary = {
+  id: string;
+  name: string;
+  connectedForMe: boolean | null;
+  connectedAt: string | null;
+};
+
+type MockAuthorizeRequest = {
+  method: string;
+  path: string;
+  url: string;
+  at: string;
+};
+
+type FlowState = {
+  adminSession: string | null;
+  memberSession: string | null;
+  connectionId: string | null;
+  workspaceId: string | null;
+  connectClickedAt: string | null;
+  reconnectClickedAt: string | null;
+  firstConnectedAt: string | null;
+  secondConnectedAt: string | null;
+  mockChild: ChildProcess | null;
+  mockOutput: string;
+};
+
+const state: FlowState = {
+  adminSession: null,
+  memberSession: null,
+  connectionId: null,
+  workspaceId: null,
+  connectClickedAt: null,
+  reconnectClickedAt: null,
+  firstConnectedAt: null,
+  secondConnectedAt: null,
+  mockChild: null,
+  mockOutput: "",
+};
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function readStringField(value: unknown, key: string): string | null {
+  if (!isRecord(value)) return null;
+  const entry = value[key];
+  return typeof entry === "string" ? entry : null;
+}
+
+function requireStateString(value: string | null, label: string): string {
+  if (!value) throw new Error(`${label} was not prepared.`);
+  return value;
+}
+
+function bodyPreview(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value) ?? String(value);
+}
+
+function parseConnection(value: unknown): ConnectionSummary | null {
+  if (!isRecord(value)) return null;
+  const id = readStringField(value, "id");
+  const name = readStringField(value, "name");
+  if (!id || !name) return null;
+  return {
+    id,
+    name,
+    connectedForMe: typeof value.connectedForMe === "boolean" ? value.connectedForMe : null,
+    connectedAt: typeof value.connectedAt === "string" ? value.connectedAt : null,
+  };
+}
+
+function parseConnections(value: unknown): ConnectionSummary[] {
+  if (!isRecord(value) || !Array.isArray(value.connections)) return [];
+  const connections: ConnectionSummary[] = [];
+  for (const entry of value.connections) {
+    const parsed = parseConnection(entry);
+    if (parsed) connections.push(parsed);
+  }
+  return connections;
+}
+
+function parseMockAuthorizeRequest(value: unknown): MockAuthorizeRequest | null {
+  if (!isRecord(value)) return null;
+  const method = readStringField(value, "method");
+  const path = readStringField(value, "path");
+  const url = readStringField(value, "url");
+  const at = readStringField(value, "at");
+  if (!method || !path || !url || !at) return null;
+  return { method, path, url, at };
+}
+
+function parseMockRequests(value: unknown): MockAuthorizeRequest[] {
+  if (!isRecord(value) || !Array.isArray(value.requests)) return [];
+  const requests: MockAuthorizeRequest[] = [];
+  for (const entry of value.requests) {
+    const parsed = parseMockAuthorizeRequest(entry);
+    if (parsed) requests.push(parsed);
+  }
+  return requests;
+}
+
+async function denApiFetch(path: string, options: RequestInit = {}): Promise<ParsedFetch> {
+  const headers = new Headers(options.headers);
+  if (!headers.has("content-type")) headers.set("content-type", "application/json");
+  if (!headers.has("origin")) headers.set("origin", DEN_WEB_URL);
+  const response = await fetch(`${DEN_API_URL}${path}`, { ...options, headers });
+  const text = await response.text();
+  let body: unknown = text;
+  try {
+    body = text.trim().length > 0 ? JSON.parse(text) : null;
+  } catch {
+    body = text;
+  }
+  return { response, body, text };
+}
+
+async function signIn(email: string, password: string): Promise<string | null> {
+  const { response, body } = await denApiFetch("/api/auth/sign-in/email", {
+    method: "POST",
+    body: JSON.stringify({ email, password }),
+  });
+  if (!response.ok) return null;
+  return readStringField(body, "token");
+}
+
+async function ensureMember(ctx: FlowContext): Promise<void> {
+  state.memberSession = await signIn(MEMBER_EMAIL, MEMBER_PASSWORD);
+  if (state.memberSession) return;
+
+  ctx.log(`Bootstrapping member ${MEMBER_EMAIL} via the real invitation flow.`);
+  const invite = await denApiFetch("/v1/invitations", {
+    method: "POST",
+    headers: { authorization: `Bearer ${requireStateString(state.adminSession, "admin session")}` },
+    body: JSON.stringify({ email: MEMBER_EMAIL, role: "member" }),
+  });
+  ctx.assert(invite.response.ok, `Invitation failed: ${invite.response.status} ${bodyPreview(invite.body).slice(0, 300)}`);
+  const inviteToken = readStringField(invite.body, "inviteToken");
+  ctx.assert(Boolean(inviteToken), `Invitation did not return inviteToken: ${bodyPreview(invite.body).slice(0, 300)}`);
+
+  const signUp = await denApiFetch("/api/auth/sign-up/email", {
+    method: "POST",
+    body: JSON.stringify({ email: MEMBER_EMAIL, name: "Jordan Demo", password: MEMBER_PASSWORD }),
+  });
+  ctx.assert(signUp.response.ok, `Member sign-up failed: ${signUp.response.status} ${bodyPreview(signUp.body).slice(0, 300)}`);
+  ctx.assert(MARK_VERIFIED_CMD.length > 0, "Set OPENWORK_EVAL_MARK_VERIFIED_CMD to verify the member's email.");
+  execSync(MARK_VERIFIED_CMD.replaceAll("{email}", MEMBER_EMAIL), { cwd: ROOT, stdio: "ignore" });
+
+  state.memberSession = await signIn(MEMBER_EMAIL, MEMBER_PASSWORD);
+  ctx.assert(Boolean(state.memberSession), "Member sign-in still failing after sign-up.");
+
+  const accept = await denApiFetch("/v1/orgs/invitations/accept", {
+    method: "POST",
+    headers: { authorization: `Bearer ${requireStateString(state.memberSession, "member session")}` },
+    body: JSON.stringify({ id: requireStateString(inviteToken, "invite token") }),
+  });
+  ctx.assert(accept.response.ok && isRecord(accept.body) && accept.body.accepted === true, `Invitation accept failed: ${accept.response.status} ${bodyPreview(accept.body).slice(0, 300)}`);
+}
+
+async function ensureWorkspace(ctx: FlowContext): Promise<void> {
+  const ready = await ctx.eval(`(() => {
+    const text = document.body.innerText;
+    return window.location.hash.includes('/workspace/')
+      && !text.includes('Choose your organization')
+      && !Boolean(document.querySelector('input[placeholder="/workspace/my-project"]'));
+  })()`);
+  if (ready === true) return;
+
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const workspaceState = await ctx.eval(`(() => {
+      const text = document.body.innerText;
+      const hasFolderInput = Boolean(document.querySelector('input[placeholder="/workspace/my-project"]'));
+      const hasWorkspaceRoute = window.location.hash.includes('/workspace/') && !text.includes('Choose your organization') && !hasFolderInput;
+      const hasOnboardingStep = text.includes('Choose your organization') || text.includes('Continue to workspace') || text.includes('Loading available resources');
+      const hasCreateAction = !hasOnboardingStep && window.__openworkControl?.listActions?.().find((a) => a.id === 'workspace.create')?.disabled === false;
+      return { hasFolderInput, hasWorkspaceRoute, hasCreateAction };
+    })()`);
+    if (isRecord(workspaceState) && (workspaceState.hasWorkspaceRoute === true || workspaceState.hasCreateAction === true)) break;
+    if (isRecord(workspaceState) && workspaceState.hasFolderInput === true) {
+      await ctx.fill('input[placeholder="/workspace/my-project"]', WORKSPACE_PATH);
+      await ctx.clickText("Use this folder", { timeoutMs: 20_000 });
+      await sleep(750);
+      continue;
+    }
+    await ctx.eval(`(() => {
+      const labels = ['Continue with organization', 'Continue to workspace', 'Continue'];
+      const buttons = [...document.querySelectorAll('button')].filter((button) => !button.disabled);
+      const button = buttons.find((candidate) => labels.includes(candidate.textContent.trim()));
+      button?.scrollIntoView({ block: 'center' });
+      button?.click();
+      return Boolean(button);
+    })()`);
+    await sleep(1_000);
+  }
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body.innerText;
+      const hasFolderInput = Boolean(document.querySelector('input[placeholder="/workspace/my-project"]'));
+      const hasWorkspaceRoute = window.location.hash.includes('/workspace/') && !text.includes('Choose your organization') && !hasFolderInput;
+      const hasOnboardingStep = text.includes('Choose your organization') || text.includes('Continue to workspace') || text.includes('Loading available resources');
+      const hasCreateAction = !hasOnboardingStep && window.__openworkControl?.listActions?.().find((a) => a.id === 'workspace.create')?.disabled === false;
+      return hasWorkspaceRoute || hasCreateAction;
+    })()`,
+    { timeoutMs: 10_000, label: "workspace route or create action" },
+  );
+  await ctx.eval(`(() => {
+    const btn = [...document.querySelectorAll('button')].find((el) => el.textContent.trim() === 'Continue without OpenWork Models');
+    btn?.click();
+    return true;
+  })()`, { awaitPromise: true });
+}
+
+async function currentWorkspaceId(ctx: FlowContext): Promise<string> {
+  if (state.workspaceId) return state.workspaceId;
+  const workspaceId = await ctx.eval("(window.location.hash.match(/\\/workspace\\/([^/]+)/) ?? [])[1] ?? null");
+  ctx.assert(typeof workspaceId === "string" && workspaceId.length > 0, "No workspace id in URL.");
+  if (typeof workspaceId !== "string") throw new Error("No workspace id in URL.");
+  return workspaceId;
+}
+
+function parseWorkspaceSetup(value: unknown): { ok: boolean; workspaceId: string | null } {
+  if (!isRecord(value)) return { ok: false, workspaceId: null };
+  return {
+    ok: value.ok === true,
+    workspaceId: readStringField(value, "workspaceId"),
+  };
+}
+
+async function createFreshEvalWorkspace(ctx: FlowContext): Promise<void> {
+  await ensureWorkspace(ctx);
+  await ctx.waitFor(
+    "Boolean(localStorage.getItem('openwork.server.port') && localStorage.getItem('openwork.server.token') && localStorage.getItem('openwork.server.hostToken'))",
+    { timeoutMs: 30_000, label: "OpenWork server auth for workspace setup" },
+  );
+  let created: unknown = null;
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    created = await ctx.eval(`(async () => {
+      try {
+        const port = localStorage.getItem('openwork.server.port');
+        const token = localStorage.getItem('openwork.server.token');
+        const hostToken = localStorage.getItem('openwork.server.hostToken');
+        const base = 'http://127.0.0.1:' + port;
+        const headers = {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer ' + token,
+          'X-OpenWork-Host-Token': hostToken,
+        };
+        const response = await fetch(base + '/workspaces/local', {
+          method: 'POST',
+          headers,
+          body: JSON.stringify({ folderPath: ${JSON.stringify(WORKSPACE_PATH)}, name: 'org-connection-lifecycle-desktop', preset: 'starter' }),
+        });
+        const text = await response.text();
+        let payload = null;
+        try { payload = JSON.parse(text); } catch {}
+        if (!response.ok) return { ok: false, status: response.status, text };
+        const workspaceId = payload?.activeId ?? payload?.workspaces?.find((workspace) => workspace.path === ${JSON.stringify(WORKSPACE_PATH)})?.id;
+        if (!workspaceId) return { ok: false, status: response.status, text: 'workspace id missing' };
+        const activate = await fetch(base + '/workspaces/' + workspaceId + '/activate?persist=true', { method: 'POST', headers });
+        if (!activate.ok) return { ok: false, status: activate.status, text: await activate.text() };
+        localStorage.setItem('openwork.react.activeWorkspace', workspaceId);
+        return { ok: true, workspaceId };
+      } catch (error) {
+        return { ok: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    })()`, { awaitPromise: true });
+    const parsed = parseWorkspaceSetup(created);
+    if (parsed.ok && parsed.workspaceId) break;
+    await sleep(1_000);
+  }
+  const parsed = parseWorkspaceSetup(created);
+  ctx.assert(parsed.ok && Boolean(parsed.workspaceId), `Workspace setup failed: ${bodyPreview(created)}`);
+  state.workspaceId = requireStateString(parsed.workspaceId, "workspace id");
+  await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+  await sleep(2_000);
+  if (await ctx.eval("window.location.hash.includes('/onboarding')") === true) {
+    await ensureWorkspace(ctx);
+    await ctx.navigateHash(`/workspace/${state.workspaceId}/session`);
+  }
+  await ctx.waitFor("window.location.hash.includes('/workspace/')", { timeoutMs: 60_000, label: "fresh eval workspace selected" });
+}
+
+async function openExtensionsConnections(ctx: FlowContext): Promise<string> {
+  const workspaceId = await currentWorkspaceId(ctx);
+  let last: unknown = null;
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline) {
+    await ctx.navigateHash(`/workspace/${workspaceId}/settings/extensions/connections`);
+    await sleep(1_000);
+    last = await ctx.eval(`(() => {
+      const text = document.body.innerText;
+      return {
+        hash: window.location.hash,
+        onOnboarding: window.location.hash.includes('/onboarding') || text.includes('Continue with organization') || text.includes('Continue to workspace'),
+        hasExtensions: text.includes('Extensions'),
+      };
+    })()`);
+    if (isRecord(last) && last.onOnboarding === true) {
+      await ensureWorkspace(ctx);
+      await sleep(500);
+      continue;
+    }
+    if (
+      isRecord(last)
+      && typeof last.hash === "string"
+      && last.hash.includes("/settings/extensions")
+      && last.hasExtensions === true
+    ) return workspaceId;
+    await sleep(1_000);
+  }
+  ctx.assert(false, `Extensions connections route never became ready: ${bodyPreview(last)}`);
+  throw new Error("Extensions connections route never became ready.");
+}
+
+async function clickRefreshIfPresent(ctx: FlowContext): Promise<void> {
+  await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')]
+      .find((el) => (el.textContent ?? '').trim() === 'Refresh' && !el.disabled);
+    button?.click();
+    return Boolean(button);
+  })()`).catch(() => undefined);
+}
+
+async function waitForConnectionCard(ctx: FlowContext): Promise<void> {
+  const deadline = Date.now() + 90_000;
+  while (Date.now() < deadline) {
+    const found = await ctx.eval(`(() => {
+      return [...document.querySelectorAll('button')]
+        .some((button) => (button.textContent ?? '').includes(${JSON.stringify(CONNECTION_NAME)}));
+    })()`);
+    if (found === true) return;
+    await ctx.control("extensions.refresh-marketplace").catch(() => undefined);
+    await clickRefreshIfPresent(ctx);
+    await sleep(2_000);
+  }
+  ctx.assert(false, `Connection card did not render: ${CONNECTION_NAME}`);
+}
+
+async function openConnectionDetail(ctx: FlowContext): Promise<void> {
+  const opened = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')]
+      .find((el) => (el.textContent ?? '').includes(${JSON.stringify(CONNECTION_NAME)}) && !el.disabled);
+    button?.scrollIntoView({ block: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(opened === true, `Could not open connection detail for ${CONNECTION_NAME}.`);
+}
+
+async function waitForNotConnectedDetail(ctx: FlowContext): Promise<void> {
+  await ctx.waitFor(
+    `(() => {
+      const text = document.body.innerText;
+      const hasConnectButton = [...document.querySelectorAll('button')]
+        .some((el) => (el.textContent ?? '').trim() === 'Connect your account' && !el.disabled);
+      return text.includes(${JSON.stringify(CONNECTION_NAME)}) && text.includes('Not connected') && hasConnectButton;
+    })()`,
+    { timeoutMs: 60_000, label: "not connected connection detail" },
+  );
+}
+
+async function clickExactButton(ctx: FlowContext, label: string): Promise<void> {
+  const clicked = await ctx.eval(`(() => {
+    const button = [...document.querySelectorAll('button')]
+      .find((el) => (el.textContent ?? '').trim() === ${JSON.stringify(label)} && !el.disabled);
+    button?.scrollIntoView({ block: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`);
+  ctx.assert(clicked === true, `Could not click ${label}.`);
+}
+
+async function waitForNoExactButton(ctx: FlowContext, label: string): Promise<void> {
+  await ctx.waitFor(
+    `!Boolean([...document.querySelectorAll('button')]
+      .find((el) => (el.textContent ?? '').trim() === ${JSON.stringify(label)}))`,
+    { timeoutMs: 90_000, label: `button removed: ${label}` },
+  );
+}
+
+function startMockServer(): void {
+  if (state.mockChild) return;
+  const child = spawn(process.execPath, [MOCK_SERVER_SCRIPT], {
+    cwd: ROOT,
+    env: {
+      ...process.env,
+      HOST: "0.0.0.0",
+      PORT: String(MOCK_PORT),
+      ISSUER: MOCK_PUBLIC_URL,
+      AUTO_APPROVE: "1",
+    },
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+  child.stdout?.on("data", (chunk: Buffer) => {
+    state.mockOutput += String(chunk);
+  });
+  child.stderr?.on("data", (chunk: Buffer) => {
+    state.mockOutput += String(chunk);
+  });
+  child.on("exit", () => {
+    if (state.mockChild === child) state.mockChild = null;
+  });
+  state.mockChild = child;
+}
+
+function stopMockServer(): void {
+  const child = state.mockChild;
+  if (!child) return;
+  state.mockChild = null;
+  child.kill("SIGTERM");
+}
+
+process.once("exit", stopMockServer);
+
+async function waitForMockHealth(ctx: FlowContext): Promise<void> {
+  let last: unknown = null;
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const response = await fetch(`${MOCK_LOCAL_URL}/health`).catch(() => null);
+    if (response?.ok) {
+      const body: unknown = await response.json().catch(() => null);
+      if (isRecord(body) && body.ok === true) {
+        if (Object.prototype.hasOwnProperty.call(body, "autoApprove")) {
+          ctx.assert(body.autoApprove !== false, "Mock server must auto-approve (AUTO_APPROVE=1) for this flow.");
+        }
+        return;
+      }
+      last = body;
+    } else {
+      last = response ? `HTTP ${response.status}` : "unreachable";
+    }
+    await sleep(500);
+  }
+  ctx.assert(false, `Mock OAuth+MCP server not reachable at ${MOCK_LOCAL_URL}. Last: ${bodyPreview(last)} Output: ${state.mockOutput.slice(-1_000)}`);
+}
+
+async function readMockRequests(): Promise<MockAuthorizeRequest[]> {
+  const response = await fetch(`${MOCK_LOCAL_URL}/requests`);
+  const body: unknown = await response.json();
+  if (!response.ok) throw new Error(`Mock request log failed: ${response.status}`);
+  return parseMockRequests(body);
+}
+
+async function waitForMockAuthorizeRequest(ctx: FlowContext, clickedAt: string): Promise<void> {
+  let authorizeRequest: MockAuthorizeRequest | null = null;
+  const deadline = Date.now() + 60_000;
+  while (Date.now() < deadline && !authorizeRequest) {
+    const requests = await readMockRequests();
+    authorizeRequest = requests.find((entry) => entry.method === "GET" && entry.path === "/authorize" && entry.at >= clickedAt) ?? null;
+    if (!authorizeRequest) await sleep(500);
+  }
+  ctx.assert(Boolean(authorizeRequest), "No GET /authorize reached the mock IdP after the desktop Connect click.");
+  if (!authorizeRequest) throw new Error("No GET /authorize reached the mock IdP after the desktop Connect click.");
+  const params = new URL(authorizeRequest.url, MOCK_LOCAL_URL).searchParams;
+  ctx.assert(Boolean(params.get("state")), "Authorize request is missing signed state.");
+  ctx.assert(Boolean(params.get("client_id")), "Authorize request is missing dynamic client_id.");
+  ctx.assert(
+    (params.get("redirect_uri") ?? "").includes(requireStateString(state.connectionId, "connection id")),
+    "Authorize redirect_uri was not scoped to this connection.",
+  );
+}
+
+async function memberUsableConnection(ctx: FlowContext): Promise<ConnectionSummary | null> {
+  const result = await denApiFetch("/v1/mcp-connections?scope=usable", {
+    headers: { authorization: `Bearer ${requireStateString(state.memberSession, "member session")}` },
+  });
+  ctx.assert(result.response.ok, `Member usable connection list failed: ${result.response.status} ${bodyPreview(result.body).slice(0, 300)}`);
+  return parseConnections(result.body).find((entry) => entry.id === state.connectionId) ?? null;
+}
+
+async function waitForMemberConnection(ctx: FlowContext, label: string, timeoutMs: number, predicate: (connection: ConnectionSummary) => boolean): Promise<ConnectionSummary> {
+  let last: ConnectionSummary | null = null;
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    last = await memberUsableConnection(ctx);
+    if (last && predicate(last)) return last;
+    await sleep(1_000);
+  }
+  ctx.assert(false, `${label} did not settle. Last member-usable connection: ${bodyPreview(last)}`);
+  throw new Error(`${label} did not settle.`);
+}
+
+export default defineFlow({
+  id: "org-connection-lifecycle-desktop",
+  title: "Desktop Extensions: connect, reconnect, and disconnect a per-member org connection",
+  kind: "user-facing",
+  spec: "evals/voiceovers/org-connection-lifecycle-desktop.md",
+  requiredEnv: ["OPENWORK_EVAL_DEN_API_URL"],
+  steps: [
+    {
+      name: "Setup: mock provider + per-member org connection",
+      run: async (ctx) => {
+        startMockServer();
+        await waitForMockHealth(ctx);
+
+        state.adminSession = await signIn(ADMIN_EMAIL, ADMIN_PASSWORD);
+        ctx.assert(Boolean(state.adminSession), `Admin sign-in failed for ${ADMIN_EMAIL}.`);
+        await ensureMember(ctx);
+
+        const existing = await denApiFetch("/v1/mcp-connections?scope=manageable", {
+          headers: { authorization: `Bearer ${requireStateString(state.adminSession, "admin session")}` },
+        });
+        ctx.assert(existing.response.ok, `Could not list manageable connections: ${existing.response.status} ${bodyPreview(existing.body).slice(0, 300)}`);
+        for (const connection of parseConnections(existing.body)) {
+          if (connection.name.startsWith("Meeting Notes ")) {
+            const removed = await denApiFetch(`/v1/mcp-connections/${connection.id}`, {
+              method: "DELETE",
+              headers: { authorization: `Bearer ${requireStateString(state.adminSession, "admin session")}` },
+            });
+            ctx.assert(removed.response.ok, `Stale connection cleanup failed for ${connection.id}: ${removed.response.status}`);
+          }
+        }
+
+        const created = await denApiFetch("/v1/mcp-connections", {
+          method: "POST",
+          headers: { authorization: `Bearer ${requireStateString(state.adminSession, "admin session")}` },
+          body: JSON.stringify({
+            name: CONNECTION_NAME,
+            url: `${MOCK_PUBLIC_URL}/mcp`,
+            authType: "oauth",
+            credentialMode: "per_member",
+            access: { orgWide: true },
+          }),
+        });
+        ctx.assert(created.response.ok, `Connection create failed: ${created.response.status} ${bodyPreview(created.body).slice(0, 300)}`);
+        state.connectionId = readStringField(created.body, "id");
+        ctx.assert(Boolean(state.connectionId), `Connection create did not return id: ${bodyPreview(created.body).slice(0, 300)}`);
+
+        const mine = await memberUsableConnection(ctx);
+        ctx.assert(Boolean(mine), "Member cannot see the org-wide connection.");
+        ctx.assert(mine?.connectedForMe === false, "Member's account should not be connected at flow start.");
+      },
+    },
+    {
+      name: "Desktop boots and signs in as the member",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 120_000 });
+        await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", { timeoutMs: 30_000, label: "desktop bridge" });
+        const bootstrap = { baseUrl: DEN_API_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
+        const written = await ctx.eval(`(async () => {
+          const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
+          if (!bridge) return { ok: false };
+          await bridge("setDesktopBootstrapConfig", ${JSON.stringify(bootstrap)});
+          return { ok: true };
+        })()`, { awaitPromise: true });
+        ctx.assert(isRecord(written) && written.ok === true, "Failed to write desktop bootstrap config.");
+        await ctx.eval(`(() => {
+          localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_API_URL)});
+          localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(DEN_API_URL)});
+          let prefs = {};
+          try { prefs = JSON.parse(localStorage.getItem('openwork.preferences') || '{}'); } catch {}
+          localStorage.setItem('openwork.preferences', JSON.stringify({ ...prefs, selectedAgent: 'openwork' }));
+          return true;
+        })()`);
+        await ctx.eval("location.reload()");
+        await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 60_000, label: "control API after bootstrap reload" });
+
+        const handoff = await denApiFetch("/v1/auth/desktop-handoff", {
+          method: "POST",
+          headers: { authorization: `Bearer ${requireStateString(state.memberSession, "member session")}` },
+          body: JSON.stringify({ desktopScheme: "openwork" }),
+        });
+        const grant = readStringField(handoff.body, "grant");
+        ctx.assert(handoff.response.ok && Boolean(grant), `Handoff create failed: ${handoff.response.status} ${bodyPreview(handoff.body).slice(0, 300)}`);
+        await ctx.control("auth.exchange-grant", { grant: requireStateString(grant, "desktop handoff grant"), baseUrl: DEN_API_URL });
+        await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", { timeoutMs: 45_000, label: "persisted den auth token" });
+        await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", { timeoutMs: 60_000, label: "active org resolved" });
+        await createFreshEvalWorkspace(ctx);
+      },
+    },
+    {
+      name: "Frame 1",
+      run: async (ctx) => {
+        await ctx.prove("Extensions lists the org connection under Needs your sign-in, and its detail page shows an honest Not connected status with a Connect your account button", {
+          voiceover: vo[0],
+          action: async () => {
+            await openExtensionsConnections(ctx);
+            await waitForConnectionCard(ctx);
+            await ctx.expectText("NEEDS YOUR SIGN-IN", { timeoutMs: 30_000 });
+            await openConnectionDetail(ctx);
+            await waitForNotConnectedDetail(ctx);
+          },
+          assert: async () => {
+            await ctx.expectText(CONNECTION_NAME, { timeoutMs: 30_000 });
+            await ctx.expectText("Not connected", { timeoutMs: 30_000 });
+            await ctx.expectText("OAuth required", { timeoutMs: 30_000 });
+            await ctx.expectText("Connect your account", { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "lifecycle-1-needs-signin",
+            claim: "The org connection is listed as needing sign-in and its detail page is honestly not connected.",
+            requireText: [CONNECTION_NAME, "Not connected", "Connect your account"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 2",
+      run: async (ctx) => {
+        await ctx.prove("Clicking Connect hands off to the browser: the mock identity provider receives the authorization request started by the desktop", {
+          voiceover: vo[1],
+          action: async () => {
+            state.connectClickedAt = new Date().toISOString();
+            await clickExactButton(ctx, "Connect your account");
+          },
+          assert: async () => {
+            await waitForMockAuthorizeRequest(ctx, requireStateString(state.connectClickedAt, "connect click timestamp"));
+          },
+          screenshot: {
+            name: "lifecycle-2-browser-handoff",
+            claim: "The mock OAuth provider saw the desktop-started authorization request.",
+            requireText: [CONNECTION_NAME],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3",
+      run: async (ctx) => {
+        await ctx.prove("The detail page flips to Connected on its own after the browser sign-in — no reload — and shows it is the member's own account", {
+          voiceover: vo[2],
+          assert: async () => {
+            await ctx.waitFor("document.body.innerText.includes('Connected with your own account.')", { timeoutMs: 90_000, label: "connected detail description" });
+            await waitForNoExactButton(ctx, "Connect your account");
+            const connected = await waitForMemberConnection(
+              ctx,
+              "member connection connected",
+              90_000,
+              (entry) => entry.connectedForMe === true && typeof entry.connectedAt === "string" && entry.connectedAt.length > 0,
+            );
+            state.firstConnectedAt = requireStateString(connected.connectedAt, "first connectedAt");
+          },
+          screenshot: {
+            name: "lifecycle-3-connected",
+            claim: "The detail page updated itself to the member-owned connected state.",
+            requireText: [CONNECTION_NAME, "Connected with your own account."],
+            rejectText: ["Connect your account", "Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 4",
+      run: async (ctx) => {
+        await ctx.prove("The connected detail page now offers both Reconnect and Disconnect", {
+          voiceover: vo[3],
+          assert: async () => {
+            const hasActions = await ctx.eval(`(() => {
+              const labels = new Set([...document.querySelectorAll('button')]
+                .filter((el) => !el.disabled)
+                .map((el) => (el.textContent ?? '').trim()));
+              return labels.has('Reconnect') && labels.has('Disconnect');
+            })()`);
+            ctx.assert(hasActions === true, "Connected detail page did not expose both Reconnect and Disconnect.");
+            await ctx.expectText("Connected", { timeoutMs: 30_000 });
+          },
+          screenshot: {
+            name: "lifecycle-4-lifecycle-actions",
+            claim: "The connected detail page exposes Reconnect and Disconnect lifecycle actions.",
+            requireText: ["Reconnect", "Disconnect"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 5",
+      run: async (ctx) => {
+        await ctx.prove("Reconnect runs a fresh OAuth round trip and Den records a new authorization timestamp", {
+          voiceover: vo[4],
+          action: async () => {
+            state.reconnectClickedAt = new Date().toISOString();
+            await clickExactButton(ctx, "Reconnect");
+          },
+          assert: async () => {
+            await waitForMockAuthorizeRequest(ctx, requireStateString(state.reconnectClickedAt, "reconnect click timestamp"));
+            const reconnected = await waitForMemberConnection(
+              ctx,
+              "member connection reconnected",
+              90_000,
+              (entry) => entry.connectedForMe === true && typeof entry.connectedAt === "string" && entry.connectedAt.length > 0 && entry.connectedAt !== state.firstConnectedAt,
+            );
+            state.secondConnectedAt = requireStateString(reconnected.connectedAt, "second connectedAt");
+            await ctx.waitFor("document.body.innerText.includes('Connected with your own account.')", { timeoutMs: 90_000, label: "reconnected detail description" });
+          },
+          screenshot: {
+            name: "lifecycle-5-reconnected",
+            claim: "Reconnect completed a fresh OAuth round trip and left the detail page connected again.",
+            requireText: [CONNECTION_NAME, "Connected with your own account."],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 6",
+      run: async (ctx) => {
+        await ctx.prove("Disconnect removes the member's credential: Den reports it gone and the page returns to Connect your account", {
+          voiceover: vo[5],
+          action: async () => {
+            await clickExactButton(ctx, "Disconnect");
+          },
+          assert: async () => {
+            await waitForMemberConnection(
+              ctx,
+              "member connection disconnected",
+              30_000,
+              (entry) => entry.connectedForMe === false,
+            );
+            await waitForNotConnectedDetail(ctx);
+            await ctx.waitFor("window.location.hash.includes('/settings/extensions/')", { timeoutMs: 30_000, label: "extensions detail route still open" });
+          },
+          screenshot: {
+            name: "lifecycle-6-disconnected",
+            claim: "Disconnect removed the member credential and returned the detail page to Connect your account.",
+            requireText: [CONNECTION_NAME, "Not connected", "Connect your account"],
+            rejectText: ["Something went wrong"],
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup",
+      run: async (ctx) => {
+        if (state.connectionId) {
+          const removed = await denApiFetch(`/v1/mcp-connections/${state.connectionId}`, {
+            method: "DELETE",
+            headers: { authorization: `Bearer ${requireStateString(state.adminSession, "admin session")}` },
+          });
+          ctx.assert(removed.response.ok, `Cleanup delete failed: ${removed.response.status} ${bodyPreview(removed.body).slice(0, 300)}`);
+        }
+        stopMockServer();
+      },
+    },
+  ],
+});

--- a/evals/flows/org-connection-lifecycle-desktop.flow.ts
+++ b/evals/flows/org-connection-lifecycle-desktop.flow.ts
@@ -21,7 +21,13 @@ const MEMBER_PASSWORD = process.env.OPENWORK_EVAL_MEMBER_PASSWORD?.trim() || "Op
 const MARK_VERIFIED_CMD = process.env.OPENWORK_EVAL_MARK_VERIFIED_CMD?.trim() || "";
 const MOCK_PORT = Number(process.env.OPENWORK_EVAL_LIFECYCLE_MOCK_PORT || 3979);
 const MOCK_LOCAL_URL = `http://127.0.0.1:${MOCK_PORT}`;
-const MOCK_PUBLIC_URL = (process.env.OPENWORK_EVAL_LIFECYCLE_MOCK_PUBLIC_URL ?? MOCK_LOCAL_URL).trim().replace(/\/+$/, "");
+// When a public URL is provided the mock server is managed externally (e.g.
+// started on the sandbox that hosts Electron) and the flow talks to it over
+// that URL instead of spawning its own local instance.
+const MOCK_EXTERNAL_URL = process.env.OPENWORK_EVAL_LIFECYCLE_MOCK_PUBLIC_URL?.trim().replace(/\/+$/, "") ?? "";
+const MOCK_SELF_HOSTED = MOCK_EXTERNAL_URL.length === 0;
+const MOCK_PUBLIC_URL = MOCK_SELF_HOSTED ? MOCK_LOCAL_URL : MOCK_EXTERNAL_URL;
+const MOCK_CONTROL_URL = MOCK_SELF_HOSTED ? MOCK_LOCAL_URL : MOCK_EXTERNAL_URL;
 const RUN_TAG = Date.now();
 const CONNECTION_NAME = `Meeting Notes ${RUN_TAG}`;
 const WORKSPACE_PATH = `/tmp/openwork-org-connection-lifecycle-${RUN_TAG}`;
@@ -420,6 +426,7 @@ async function waitForNoExactButton(ctx: FlowContext, label: string): Promise<vo
 }
 
 function startMockServer(): void {
+  if (!MOCK_SELF_HOSTED) return;
   if (state.mockChild) return;
   const child = spawn(process.execPath, [MOCK_SERVER_SCRIPT], {
     cwd: ROOT,
@@ -457,7 +464,7 @@ async function waitForMockHealth(ctx: FlowContext): Promise<void> {
   let last: unknown = null;
   const deadline = Date.now() + 30_000;
   while (Date.now() < deadline) {
-    const response = await fetch(`${MOCK_LOCAL_URL}/health`).catch(() => null);
+    const response = await fetch(`${MOCK_CONTROL_URL}/health`).catch(() => null);
     if (response?.ok) {
       const body: unknown = await response.json().catch(() => null);
       if (isRecord(body) && body.ok === true) {
@@ -472,11 +479,11 @@ async function waitForMockHealth(ctx: FlowContext): Promise<void> {
     }
     await sleep(500);
   }
-  ctx.assert(false, `Mock OAuth+MCP server not reachable at ${MOCK_LOCAL_URL}. Last: ${bodyPreview(last)} Output: ${state.mockOutput.slice(-1_000)}`);
+  ctx.assert(false, `Mock OAuth+MCP server not reachable at ${MOCK_CONTROL_URL}. Last: ${bodyPreview(last)} Output: ${state.mockOutput.slice(-1_000)}`);
 }
 
 async function readMockRequests(): Promise<MockAuthorizeRequest[]> {
-  const response = await fetch(`${MOCK_LOCAL_URL}/requests`);
+  const response = await fetch(`${MOCK_CONTROL_URL}/requests`);
   const body: unknown = await response.json();
   if (!response.ok) throw new Error(`Mock request log failed: ${response.status}`);
   return parseMockRequests(body);
@@ -492,7 +499,7 @@ async function waitForMockAuthorizeRequest(ctx: FlowContext, clickedAt: string):
   }
   ctx.assert(Boolean(authorizeRequest), "No GET /authorize reached the mock IdP after the desktop Connect click.");
   if (!authorizeRequest) throw new Error("No GET /authorize reached the mock IdP after the desktop Connect click.");
-  const params = new URL(authorizeRequest.url, MOCK_LOCAL_URL).searchParams;
+  const params = new URL(authorizeRequest.url, MOCK_CONTROL_URL).searchParams;
   ctx.assert(Boolean(params.get("state")), "Authorize request is missing signed state.");
   ctx.assert(Boolean(params.get("client_id")), "Authorize request is missing dynamic client_id.");
   ctx.assert(
@@ -577,7 +584,10 @@ export default defineFlow({
       run: async (ctx) => {
         await ctx.waitFor("Boolean(window.__openworkControl)", { timeoutMs: 120_000 });
         await ctx.waitFor("Boolean(window.__OPENWORK_ELECTRON__?.invokeDesktop)", { timeoutMs: 30_000, label: "desktop bridge" });
-        const bootstrap = { baseUrl: DEN_API_URL, apiBaseUrl: DEN_API_URL, requireSignin: false, handoff: null };
+        // The app derives its /api/den proxy base from these URLs, so both must
+        // point at the web origin (den-web proxies /api/den/* to den-api; the
+        // bare den-api origin does not serve that prefix).
+        const bootstrap = { baseUrl: DEN_WEB_URL, apiBaseUrl: DEN_WEB_URL, requireSignin: false, handoff: null };
         const written = await ctx.eval(`(async () => {
           const bridge = window.__OPENWORK_ELECTRON__?.invokeDesktop;
           if (!bridge) return { ok: false };
@@ -586,8 +596,8 @@ export default defineFlow({
         })()`, { awaitPromise: true });
         ctx.assert(isRecord(written) && written.ok === true, "Failed to write desktop bootstrap config.");
         await ctx.eval(`(() => {
-          localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_API_URL)});
-          localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(DEN_API_URL)});
+          localStorage.setItem('openwork.den.baseUrl', ${JSON.stringify(DEN_WEB_URL)});
+          localStorage.setItem('openwork.den.apiBaseUrl', ${JSON.stringify(DEN_WEB_URL)});
           let prefs = {};
           try { prefs = JSON.parse(localStorage.getItem('openwork.preferences') || '{}'); } catch {}
           localStorage.setItem('openwork.preferences', JSON.stringify({ ...prefs, selectedAgent: 'openwork' }));
@@ -603,7 +613,11 @@ export default defineFlow({
         });
         const grant = readStringField(handoff.body, "grant");
         ctx.assert(handoff.response.ok && Boolean(grant), `Handoff create failed: ${handoff.response.status} ${bodyPreview(handoff.body).slice(0, 300)}`);
-        await ctx.control("auth.exchange-grant", { grant: requireStateString(grant, "desktop handoff grant"), baseUrl: DEN_API_URL });
+        await ctx.waitFor(
+          "Boolean(window.__openworkControl?.listActions?.().some((a) => a.id === 'auth.exchange-grant'))",
+          { timeoutMs: 60_000, label: "auth.exchange-grant action registered" },
+        );
+        await ctx.control("auth.exchange-grant", { grant: requireStateString(grant, "desktop handoff grant"), baseUrl: DEN_WEB_URL });
         await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.authToken') ?? '').trim())", { timeoutMs: 45_000, label: "persisted den auth token" });
         await ctx.waitFor("Boolean((localStorage.getItem('openwork.den.activeOrgId') ?? '').trim())", { timeoutMs: 60_000, label: "active org resolved" });
         await createFreshEvalWorkspace(ctx);

--- a/evals/voiceovers/org-connection-lifecycle-desktop.md
+++ b/evals/voiceovers/org-connection-lifecycle-desktop.md
@@ -1,0 +1,19 @@
+# org-connection-lifecycle-desktop — connect, reconnect, and disconnect an org connection from the desktop
+
+An organization admin has shared a per-member MCP connection (a Granola-style
+OAuth service) with the team. Until now the desktop Extensions detail page
+showed the connection but offered no lifecycle actions — members had to fall
+back to the cloud dashboard to connect, and could not disconnect or
+re-authorize an external connection at all.
+
+1. Jordan opens Extensions and filters to Connections — the org-shared connection is sitting under "Needs your sign-in", and opening it shows an honest status: Not connected, OAuth required, with a Connect your account button right in the details.
+
+2. Jordan clicks Connect — the desktop hands off to the browser for the real OAuth sign-in and waits, no config files, no dashboard round-trip.
+
+3. The moment the sign-in completes, the detail page flips to Connected on its own — no reload — and the connection now shows exactly who it's connected as: Jordan's own account.
+
+4. Because things go stale in the real world, the connected view now offers both Reconnect and Disconnect, so Jordan controls the whole lifecycle from the desktop.
+
+5. Jordan hits Reconnect — one more browser round trip and the connection is re-authorized fresh, which is the fix for expired tokens or newly requested permissions.
+
+6. Finally Jordan clicks Disconnect — the connection drops back to "Connect your account", the cloud confirms Jordan's credential is gone, and Jordan can sign back in whenever they want. Full connect, reconnect, disconnect — without ever leaving the app.


### PR DESCRIPTION
## What

Per-member org MCP connections (e.g. Granola, shared by your organization) previously showed a hardcoded **Connected** status in Settings → Extensions and offered **no lifecycle actions** — members could not connect, disconnect, or re-authorize an external connection from the desktop at all (the working `connect()` in `useOrgMcpConnections` was never wired to any UI, and disconnect was restricted to native Google Workspace / Microsoft 365 providers).

The Extensions connection detail page now:

- shows an **honest status** (`Not connected` / `Connected`) derived from real per-member readiness,
- offers **Connect your account** (browser OAuth handoff + 2s polling until Den records the member credential),
- offers **Reconnect** when connected (forces a fresh authorization: member-scoped disconnect, then a new `connect/start` round trip — required because `connect/start` short-circuits to "already connected" while the stored token is valid),
- offers **Disconnect** (calls the existing Den `POST /v1/mcp-connections/:id/disconnect-my-account`; native providers keep their `oauth-providers` disconnect route),
- keeps shared org-account connections admin-managed (no member actions), and hides member actions when reconnect is owned by an organization admin (`reconnectActionOwner === "organization_admin"`).

Also includes:

- `fix(den-db)`: MariaDB aliases JSON to LONGTEXT so mysql2 returns strings where MySQL returns objects; the external-MCP credential columns (`oauth_configuration`, `credential_health`, `scopes`, `extra`) now parse string driver values. Without this, **every** per-member OAuth callback fails with `MCP_OAUTH_CONFIGURATION_REQUIRED` on MariaDB-backed Den deployments (verified: identical curl dance passes on MySQL 8, failed on MariaDB 11.8 until this fix).
- New voiceover + coded eval flow `org-connection-lifecycle-desktop` proving the full lifecycle end-to-end.

## How it was verified (Daytona, real e2e)

Two Daytona sandboxes: a Den server sandbox (`test-server-on-daytona.sh`, MariaDB + den-api/den-web/worker-proxy, seeded demo org) and an Electron sandbox (`test-on-daytona.sh --den-base-url ... --den-api-base-url ...`), plus the mock OAuth MCP server (`scripts/mock-oauth-mcp-server.mjs`) hosted on the Electron sandbox behind a public preview URL so den-api performs real RFC 9728 discovery + DCR + token exchange against it, and the sandbox's real Chromium completes the browser round trip via `xdg-open`.

```
OPENWORK_EVAL_DAYTONA_SANDBOX=openwork-test-… \
OPENWORK_EVAL_DEN_API_URL=https://8788-….daytonaproxy01.net \
OPENWORK_EVAL_DEN_WEB_URL=https://3005-….daytonaproxy01.net \
OPENWORK_EVAL_MEMBER_EMAIL=alex@acme.test \
OPENWORK_EVAL_LIFECYCLE_MOCK_PUBLIC_URL=https://3979-….daytonaproxy01.net \
pnpm fraimz --flow org-connection-lifecycle-desktop --cdp-url https://9825-….daytonaproxy01.net
```

Result: **PASSED — all 6 frames + voice-over coverage** (frame-by-frame proof posted below). Server-side witnesses per frame: mock IdP request log (`GET /authorize` with signed state + DCR client), Den `connectedForMe` / fresh `connectedAt` after reconnect, `connectedForMe: false` after disconnect.

Also ran:

- `pnpm --filter @openwork/app typecheck` — clean
- `apps/app: bun test tests/` — 493 pass, 0 fail
- `apps/app: bun test src/react-app/domains/connections/` — 23 pass, 0 fail (new lifecycle-helper coverage)
- `pnpm --filter @openwork-ee/den-db build`, `pnpm --filter @openwork-ee/den-api build` — clean

Note: frame 1's screenshot shows an unrelated transient toast (`opencode_unconfigured`) from the freshly created eval workspace booting without a runtime — unrelated to this change.