### PR TITLE
perf(app): load composer skills/MCP/extensions instantly (local-first, cloud lands live)

### DIFF
--- a/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
+++ b/apps/app/src/react-app/domains/session/chat/new-task-composer.tsx
@@ -13,7 +13,12 @@ import {
   resolvePastedTextPlaceholders,
   type PastedTextChip,
 } from "@/react-app/domains/session/surface/composer/pasted-text";
-import { loadSessionConnectCapabilities } from "@/react-app/domains/connections/cloud-inventory-cache";
+import {
+  loadSessionConnectCapabilities,
+  readCachedConnectCapabilities,
+  readCloudInventoryScope,
+} from "@/react-app/domains/connections/cloud-inventory-cache";
+import { EMPTY_CONNECT_CAPABILITY_INVENTORY } from "@/react-app/domains/session/surface/connect-capability-inventory";
 import { resolveAttachmentFileMetadata } from "@/react-app/domains/session/sync/attachment-file-part";
 
 /**
@@ -80,11 +85,17 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
   const [mcpStatuses, setMcpStatuses] = useState<McpStatusMap>({});
   const [mcpStatus, setMcpStatus] = useState<string | null>(null);
   const [pastedText, setPastedText] = useState<PastedTextChip[]>([]);
+  const skillsConnectPushRef = useRef(0);
+  const mcpConnectPushRef = useRef(0);
   const context = props.context;
   const workspaceId = context?.workspaceId ?? null;
 
   const listSkills = context && workspaceId
     ? async (): Promise<SkillCard[]> => {
+        const pushId = ++skillsConnectPushRef.current;
+        // Paint cached Connect inventory instantly; the fresh fan-out lands live.
+        const scope = readCloudInventoryScope();
+        const cachedConnect = (scope ? readCachedConnectCapabilities(scope) : null) ?? EMPTY_CONNECT_CAPABILITY_INVENTORY;
         const connectPromise = loadSessionConnectCapabilities();
         const response = await context.client.listSkills(workspaceId, { includeGlobal: true });
         const localSkills = (response.items ?? []).map((skill) => ({
@@ -95,8 +106,11 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
           scope: skill.scope,
           origin: "local",
         } satisfies SkillCard));
-        const connect = await connectPromise;
-        const next = [...localSkills, ...connect.skills];
+        void connectPromise.then((connect) => {
+          if (skillsConnectPushRef.current !== pushId) return;
+          setSkills([...localSkills, ...connect.skills]);
+        });
+        const next = [...localSkills, ...cachedConnect.skills];
         setSkills(next);
         return next;
       }
@@ -104,6 +118,9 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
 
   const listMcp = context && workspaceId
     ? async (): Promise<{ servers: McpServerEntry[]; statuses: McpStatusMap; status: string | null }> => {
+        const pushId = ++mcpConnectPushRef.current;
+        const scope = readCloudInventoryScope();
+        const cachedConnect = (scope ? readCachedConnectCapabilities(scope) : null) ?? EMPTY_CONNECT_CAPABILITY_INVENTORY;
         const connectPromise = loadSessionConnectCapabilities();
         const response = await context.client.listMcp(workspaceId);
         const localServers = (response.items ?? []).map((entry) => ({
@@ -112,9 +129,16 @@ export function NewTaskComposer(props: NewTaskComposerProps) {
           source: entry.source,
           origin: entry.name === "openwork-cloud" ? "openwork-connect" : "local",
         } satisfies McpServerEntry));
-        const connect = await connectPromise;
-        const servers = [...localServers, ...connect.mcpServers];
-        const statuses = connect.mcpStatuses;
+        void connectPromise.then((connect) => {
+          if (mcpConnectPushRef.current !== pushId) return;
+          const freshServers = [...localServers, ...connect.mcpServers];
+          const freshStatus = freshServers.length ? null : "No MCP servers loaded.";
+          setMcpServers(freshServers);
+          setMcpStatuses(connect.mcpStatuses);
+          setMcpStatus(freshStatus);
+        });
+        const servers = [...localServers, ...cachedConnect.mcpServers];
+        const statuses = cachedConnect.mcpStatuses;
         const status = servers.length ? null : "No MCP servers loaded.";
         setMcpServers(servers);
         setMcpStatuses(statuses);

--- a/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
+++ b/apps/app/src/react-app/domains/session/surface/composer/composer.tsx
@@ -328,9 +328,9 @@ export function ReactSessionComposer(props: ComposerProps) {
     plugins: false,
   });
   const [commandsLoaded, setCommandsLoaded] = useState(false);
-  const [skillsLoaded, setSkillsLoaded] = useState(Boolean(props.skills));
-  const [mcpLoaded, setMcpLoaded] = useState(Boolean(props.mcpServers));
-  const [pluginsLoaded, setPluginsLoaded] = useState(Boolean(props.importedPlugins));
+  const [skillsLoaded, setSkillsLoaded] = useState(Boolean(props.skills?.length));
+  const [mcpLoaded, setMcpLoaded] = useState(Boolean(props.mcpServers?.length));
+  const [pluginsLoaded, setPluginsLoaded] = useState(Boolean(props.importedPlugins?.length));
   const [, setExtensionStateVersion] = useState(0);
   const [agentMenuIndex, setAgentMenuIndex] = useState(0);
   const agentItemRefs = useRef<Array<HTMLButtonElement | null>>([]);
@@ -562,9 +562,9 @@ export function ReactSessionComposer(props: ComposerProps) {
       plugins: false,
     };
     setCommandsLoaded(false);
-    setSkillsLoaded(Boolean(props.skills));
-    setMcpLoaded(Boolean(props.mcpServers));
-    setPluginsLoaded(Boolean(props.importedPlugins));
+    setSkillsLoaded(Boolean(props.skills?.length));
+    setMcpLoaded(Boolean(props.mcpServers?.length));
+    setPluginsLoaded(Boolean(props.importedPlugins?.length));
   }, [toolMenuOpen]);
 
   useEffect(() => {

--- a/apps/app/src/react-app/domains/session/surface/session-surface.tsx
+++ b/apps/app/src/react-app/domains/session/surface/session-surface.tsx
@@ -104,7 +104,10 @@ import {
 import {
   clearCloudInventoryCache,
   loadSessionConnectCapabilities,
+  readCachedConnectCapabilities,
+  readCloudInventoryScope,
 } from "@/react-app/domains/connections/cloud-inventory-cache";
+import { EMPTY_CONNECT_CAPABILITY_INVENTORY } from "@/react-app/domains/session/surface/connect-capability-inventory";
 import { consumeComposerAutoSend } from "./composer-auto-send";
 
 const EMPTY_TRANSCRIPT: UIMessage[] = [];
@@ -659,6 +662,8 @@ export function SessionSurface(props: SessionSurfaceProps) {
   const [toolMcpStatus, setToolMcpStatus] = useState<string | null>(null);
   const [toolMcpStatuses, setToolMcpStatuses] = useState<McpStatusMap>({});
   const [toolImportedPlugins, setToolImportedPlugins] = useState<CloudImportedPlugin[]>([]);
+  const skillsConnectPushRef = useRef(0);
+  const mcpConnectPushRef = useRef(0);
   const [steering, setSteering] = useState(false);
   const [verifiedOpenTargets, setVerifiedOpenTargets] = useState<OpenTarget[]>([]);
   const [cloudQueueRetryVersion, setCloudQueueRetryVersion] = useState(0);
@@ -1419,6 +1424,10 @@ export function SessionSurface(props: SessionSurfaceProps) {
   useControlAction(props.isControlTarget ? composerStopControlAction : null);
 
   const listSkills = async (): Promise<SkillCard[]> => {
+    const pushId = ++skillsConnectPushRef.current;
+    // Paint cached Connect inventory instantly; the fresh fan-out lands live.
+    const scope = readCloudInventoryScope();
+    const cachedConnect = (scope ? readCachedConnectCapabilities(scope) : null) ?? EMPTY_CONNECT_CAPABILITY_INVENTORY;
     const connectPromise = loadSessionConnectCapabilities();
     const response = await props.client.listSkills(props.workspaceId, { includeGlobal: true });
     const localSkills = (response.items ?? []).map((skill) => ({
@@ -1429,15 +1438,32 @@ export function SessionSurface(props: SessionSurfaceProps) {
       scope: skill.scope,
       origin: "local",
     } satisfies SkillCard));
-    const connect = await connectPromise;
-    const next = [...localSkills, ...connect.skills];
+    void connectPromise.then((connect) => {
+      if (skillsConnectPushRef.current !== pushId) return;
+      setToolSkills([...localSkills, ...connect.skills]);
+    });
+    const next = [...localSkills, ...cachedConnect.skills];
     setToolSkills(next);
     return next;
   };
 
   const listMcp = async (): Promise<{ servers: McpServerEntry[]; statuses: McpStatusMap; status: string | null }> => {
+    const pushId = ++mcpConnectPushRef.current;
+    const scope = readCloudInventoryScope();
+    const cachedConnect = (scope ? readCachedConnectCapabilities(scope) : null) ?? EMPTY_CONNECT_CAPABILITY_INVENTORY;
     const connectPromise = loadSessionConnectCapabilities();
-    const response = await props.client.listMcp(props.workspaceId);
+    const localMcpPromise = props.client.listMcp(props.workspaceId);
+    const directory = props.workspaceRoot.trim();
+    const localStatusesPromise: Promise<McpStatusMap> = directory
+      ? (async () => {
+        try {
+          return unwrap(await opencodeClient.mcp.status({ directory })) as McpStatusMap;
+        } catch {
+          return {};
+        }
+      })()
+      : Promise.resolve({});
+    const [response, localStatuses] = await Promise.all([localMcpPromise, localStatusesPromise]);
     const localServers = (response.items ?? []).map((entry) => ({
       name: entry.name,
       config: entry.config as McpServerEntry["config"],
@@ -1445,44 +1471,44 @@ export function SessionSurface(props: SessionSurfaceProps) {
       origin: entry.name === "openwork-cloud" ? "openwork-connect" : "local",
     } satisfies McpServerEntry));
 
-    let localStatuses: McpStatusMap = {};
-    try {
-      if (props.workspaceRoot.trim()) {
-        localStatuses = unwrap(await opencodeClient.mcp.status({ directory: props.workspaceRoot.trim() })) as McpStatusMap;
-      }
-    } catch {
-      localStatuses = {};
-    }
+    void connectPromise.then((connect) => {
+      if (mcpConnectPushRef.current !== pushId) return;
+      const freshServers = [...localServers, ...connect.mcpServers];
+      const freshStatuses = { ...connect.mcpStatuses, ...localStatuses };
+      const freshStatus = freshServers.length ? null : "No MCP servers loaded.";
+      setToolMcpServers(freshServers);
+      setToolMcpStatuses(freshStatuses);
+      setToolMcpStatus(freshStatus);
 
-    const connect = await connectPromise;
-    const servers = [...localServers, ...connect.mcpServers];
-    const statuses = { ...connect.mcpStatuses, ...localStatuses };
+      // Quiet self-heal: remote OAuth connectors whose access token expired
+      // show "Sign in needed" even though the stored refresh token still
+      // works. `mcp.connect` retries the refresh grant on a fresh transport
+      // without ever opening a browser; on success the badge flips live.
+      if (directory && localServers.length) {
+        void attemptSilentMcpReauth({
+          client: opencodeClient,
+          directory,
+          servers: localServers,
+          statuses: localStatuses,
+        })
+          .then(async (attempted) => {
+            if (!attempted) return;
+            const healed = unwrap(await opencodeClient.mcp.status({ directory })) as McpStatusMap;
+            if (mcpConnectPushRef.current !== pushId) return;
+            setToolMcpStatuses({ ...connect.mcpStatuses, ...healed });
+          })
+          .catch(() => {
+            // Best-effort; the manual Sign in path is unaffected.
+          });
+      }
+    });
+
+    const servers = [...localServers, ...cachedConnect.mcpServers];
+    const statuses = { ...cachedConnect.mcpStatuses, ...localStatuses };
     const status = servers.length ? null : "No MCP servers loaded.";
     setToolMcpServers(servers);
     setToolMcpStatuses(statuses);
     setToolMcpStatus(status);
-
-    // Quiet self-heal: remote OAuth connectors whose access token expired
-    // show "Sign in needed" even though the stored refresh token still
-    // works. `mcp.connect` retries the refresh grant on a fresh transport
-    // without ever opening a browser; on success the badge flips live.
-    const directory = props.workspaceRoot.trim();
-    if (directory && localServers.length) {
-      void attemptSilentMcpReauth({
-        client: opencodeClient,
-        directory,
-        servers: localServers,
-        statuses: localStatuses,
-      })
-        .then(async (attempted) => {
-          if (!attempted) return;
-          const healed = unwrap(await opencodeClient.mcp.status({ directory })) as McpStatusMap;
-          setToolMcpStatuses({ ...connect.mcpStatuses, ...healed });
-        })
-        .catch(() => {
-          // Best-effort; the manual Sign in path is unaffected.
-        });
-    }
 
     return { servers, statuses, status };
   };

--- a/apps/server/src/skills.ts
+++ b/apps/server/src/skills.ts
@@ -84,15 +84,17 @@ async function parseSkillEntry(
 async function listSkillsInDir(dir: string, scope: "project" | "global"): Promise<SkillItem[]> {
   if (!(await exists(dir))) return [];
   const entries = await readdir(dir, { withFileTypes: true });
-  const items: SkillItem[] = [];
-  for (const entry of entries) {
-    if (!entry.isDirectory()) continue;
-    const skillPath = join(dir, entry.name, "SKILL.md");
-    if (await exists(skillPath)) {
-      // Direct skill: <dir>/<name>/SKILL.md
-      const item = await parseSkillEntry(skillPath, entry.name, scope);
-      if (item) items.push(item);
-    } else {
+  const groups = await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.isDirectory()) return [];
+
+      const skillPath = join(dir, entry.name, "SKILL.md");
+      if (await exists(skillPath)) {
+        // Direct skill: <dir>/<name>/SKILL.md
+        const item = await parseSkillEntry(skillPath, entry.name, scope);
+        return item ? [item] : [];
+      }
+
       // Domain/category folder: <dir>/<domain>/<name>/SKILL.md – scan one level deeper.
       // This supports the convention where global skills are organised as
       //   skills/<domain>/<skill-name>/SKILL.md
@@ -102,28 +104,34 @@ async function listSkillsInDir(dir: string, scope: "project" | "global"): Promis
       try {
         subEntries = await readdir(domainDir, { withFileTypes: true });
       } catch {
-        continue;
+        return [];
       }
-      for (const subEntry of subEntries) {
-        if (!subEntry.isDirectory()) continue;
-        const subSkillPath = join(domainDir, subEntry.name, "SKILL.md");
-        if (!(await exists(subSkillPath))) continue;
-        const item = await parseSkillEntry(subSkillPath, subEntry.name, scope);
-        if (item) items.push(item);
-      }
-    }
-  }
-  return items;
+
+      const subGroups = await Promise.all(
+        subEntries.map(async (subEntry) => {
+          if (!subEntry.isDirectory()) return [];
+
+          const subSkillPath = join(domainDir, subEntry.name, "SKILL.md");
+          if (!(await exists(subSkillPath))) return [];
+
+          const item = await parseSkillEntry(subSkillPath, subEntry.name, scope);
+          return item ? [item] : [];
+        }),
+      );
+      return subGroups.flat();
+    }),
+  );
+  return groups.flat();
 }
 
 export async function listSkills(workspaceRoot: string, includeGlobal: boolean): Promise<SkillItem[]> {
   const roots = await findWorkspaceRoots(workspaceRoot);
-  const items: SkillItem[] = [];
+  const dirs: { dir: string; scope: "project" | "global" }[] = [];
   for (const root of roots) {
     const opencodeDir = join(root, ".opencode", "skills");
     const claudeDir = join(root, ".claude", "skills");
-    items.push(...(await listSkillsInDir(opencodeDir, "project")));
-    items.push(...(await listSkillsInDir(claudeDir, "project")));
+    dirs.push({ dir: opencodeDir, scope: "project" });
+    dirs.push({ dir: claudeDir, scope: "project" });
   }
 
   if (includeGlobal) {
@@ -131,11 +139,14 @@ export async function listSkills(workspaceRoot: string, includeGlobal: boolean):
     const globalClaude = join(homedir(), ".claude", "skills");
     const globalAgents = join(homedir(), ".agents", "skills");
     const globalAgentLegacy = join(homedir(), ".agent", "skills");
-    items.push(...(await listSkillsInDir(globalOpenWork, "global")));
-    items.push(...(await listSkillsInDir(globalClaude, "global")));
-    items.push(...(await listSkillsInDir(globalAgents, "global")));
-    items.push(...(await listSkillsInDir(globalAgentLegacy, "global")));
+    dirs.push({ dir: globalOpenWork, scope: "global" });
+    dirs.push({ dir: globalClaude, scope: "global" });
+    dirs.push({ dir: globalAgents, scope: "global" });
+    dirs.push({ dir: globalAgentLegacy, scope: "global" });
   }
+
+  const groups = await Promise.all(dirs.map(({ dir, scope }) => listSkillsInDir(dir, scope)));
+  const items = groups.flat();
 
   const seen = new Set<string>();
   return items.filter((item) => {

--- a/evals/flows/composer-skills-fast-load.flow.mjs
+++ b/evals/flows/composer-skills-fast-load.flow.mjs
@@ -1,0 +1,323 @@
+/**
+ * User-facing flow demo: the composer plug menu (Skills / Extensions) paints
+ * from local + cached data immediately instead of waiting for the OpenWork
+ * Cloud (Den) capability fan-out.
+ *
+ * Perf fix under test (scratch/composer-skills-fast-load):
+ * - session-surface/new-task-composer `listSkills`/`listMcp` resolve with
+ *   local results + cached Connect inventory; the fresh Den fan-out lands
+ *   live via a state push instead of gating the menu.
+ * - the server enumerates skills from disk in parallel.
+ * - first-open shows "Loading" instead of a wrong "No skills" flash.
+ *
+ * The final frame is the regression proof: with a signed-in scope whose Den
+ * requests are artificially held for 15s (in-page fetch delay via the gateway
+ * marker, so the fan-out routes through the wrappable same-origin fetch), the
+ * Skills section still renders local skills in milliseconds while the cloud
+ * request is provably in flight.
+ *
+ * Requires a workspace whose root contains `.opencode/skills` (the OpenWork
+ * repo checkout at /workspace in the Daytona eval sandbox).
+ */
+const PLUG_BUTTON = 'button[title="Commands, skills, and MCPs"]';
+const SKILL_MARKERS = ["/browser-automation", "/agent-first-screenshots"];
+
+const DEN_KEYS_CLEANUP = `(() => {
+  localStorage.removeItem("openwork.den.authToken");
+  localStorage.removeItem("openwork.den.activeOrgId");
+  localStorage.removeItem("openwork.den.activeOrgSlug");
+  localStorage.removeItem("openwork.den.activeOrgName");
+  delete window.__OPENWORK_GATEWAY__;
+  return true;
+})()`;
+
+/** Close any open popover, open the plug menu, and wait for its sections. */
+const openPlugMenu = async (ctx) => {
+  await ctx.eval(`(() => {
+    document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    return true;
+  })()`);
+  await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(PLUG_BUTTON)}))`, {
+    label: "composer plug button",
+  });
+  await ctx.eval(`document.querySelector(${JSON.stringify(PLUG_BUTTON)}).click()`);
+  await ctx.waitFor(`(() => {
+    const labels = [...document.querySelectorAll("button")].map((b) => b.textContent.trim());
+    return labels.includes("Skills") && labels.includes("Extensions");
+  })()`, { label: "plug menu sections" });
+};
+
+/**
+ * Click the Skills section and poll (in-page, 20ms resolution) until a row
+ * that only exists as a skill renders. Returns { ms, rowCount }.
+ */
+const SKILLS_TIMING_EXPRESSION = `new Promise((resolve) => {
+  const skillsBtn = [...document.querySelectorAll("button")].find((b) => b.textContent.trim() === "Skills");
+  if (!skillsBtn) { resolve({ error: "skills section button not found" }); return; }
+  const t0 = performance.now();
+  skillsBtn.click();
+  const poll = () => {
+    const rows = [...document.querySelectorAll("button")].filter((b) => /^\\/[a-z0-9-]+/i.test(b.textContent.trim()));
+    const hit = rows.some((b) => ${JSON.stringify(SKILL_MARKERS)}.some((marker) => b.textContent.includes(marker)));
+    if (hit) { resolve({ ms: Math.round(performance.now() - t0), rowCount: rows.length }); return; }
+    if (performance.now() - t0 > 20000) { resolve({ error: "timed out", bodyTail: document.body.innerText.slice(-400) }); return; }
+    setTimeout(poll, 20);
+  };
+  poll();
+})`;
+
+export default {
+  id: "composer-skills-fast-load",
+  title: "Composer skills/MCP/extensions load instantly (local-first, cloud lands live)",
+  kind: "user-facing",
+  steps: [
+    {
+      name: "App boots into a workspace with a clean cloud state",
+      run: async (ctx) => {
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 60_000,
+          label: "window.__openworkControl",
+        });
+        await ctx.waitFor("document.body.innerText.trim().length > 40", {
+          label: "rendered body text",
+        });
+        // Idempotence: earlier runs may have left a fake Den scope or the
+        // gateway marker behind. Normalize and reload once so every frame
+        // starts from the same signed-out state.
+        await ctx.eval(DEN_KEYS_CLEANUP);
+        await ctx.eval("location.reload()").catch(() => {});
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 60_000,
+          label: "window.__openworkControl after reload",
+        });
+        await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(PLUG_BUTTON)}))`, {
+          timeoutMs: 60_000,
+          label: "composer plug button",
+        });
+      },
+    },
+    {
+      name: "Plug menu opens with capability sections",
+      run: async (ctx) => {
+        await ctx.prove("The composer plug menu lists Agents, Commands, Skills, and Extensions", {
+          claim: "Clicking the plug button opens the tool menu with Agents, Commands, Skills, and Extensions sections.",
+          voiceover:
+            "This is the composer. The plug button opens everything the agent can use: agents, commands, skills, and extensions — one menu, four sections.",
+          action: async () => {
+            await openPlugMenu(ctx);
+          },
+          assert: async () => {
+            const sections = await ctx.eval(`(() => {
+              const labels = [...document.querySelectorAll("button")].map((b) => b.textContent.trim());
+              return ["Agents", "Commands", "Skills", "Extensions"].filter((section) => labels.includes(section));
+            })()`);
+            ctx.assert(Array.isArray(sections) && sections.length === 4, `Missing sections: ${JSON.stringify(sections)}`);
+          },
+          screenshot: {
+            name: "plug-menu-sections",
+            requireText: ["Skills", "Extensions"],
+          },
+        });
+      },
+    },
+    {
+      name: "Skills section renders local skills instantly",
+      run: async (ctx) => {
+        await ctx.prove("Skills render from the local workspace in milliseconds", {
+          claim: "Selecting Skills lists the workspace's local skills (with Local badges) in well under a second.",
+          voiceover:
+            "I open Skills. The whole list is just there — every local skill from the workspace, instantly. No spinner, no waiting on the network.",
+          action: async () => {
+            const timing = await ctx.eval(SKILLS_TIMING_EXPRESSION, { awaitPromise: true });
+            ctx.assert(timing && !timing.error, `Skills did not render: ${JSON.stringify(timing)}`);
+            ctx.log(`Skills section first paint: ${timing.ms}ms for ${timing.rowCount} rows`);
+            ctx.assert(timing.rowCount >= 10, `Expected at least 10 skill rows, saw ${timing.rowCount}`);
+            ctx.assert(timing.ms < 3000, `Skills took ${timing.ms}ms (expected < 3000ms)`);
+          },
+          assert: async () => {
+            await ctx.expectText("/browser-automation");
+          },
+          screenshot: {
+            name: "skills-section-fast",
+            requireText: ["/browser-automation", "Local"],
+            rejectText: ["Loading commands"],
+          },
+        });
+      },
+    },
+    {
+      name: "Extensions section settles with the catalog",
+      run: async (ctx) => {
+        await ctx.prove("Extensions settle immediately instead of hanging on a loader", {
+          claim: "Selecting Extensions shows the built-in extension catalog right away.",
+          voiceover:
+            "Extensions behave the same way: the catalog is on screen immediately — here the built-in OpenWork Browser, already enabled.",
+          action: async () => {
+            await ctx.eval(`(() => {
+              const btn = [...document.querySelectorAll("button")].find((b) => b.textContent.trim() === "Extensions");
+              btn.click();
+              return true;
+            })()`);
+            await ctx.waitFor(`document.body.innerText.includes("OpenWork Browser")`, {
+              timeoutMs: 10_000,
+              label: "extensions catalog entry",
+            });
+          },
+          assert: async () => {
+            await ctx.expectText("OpenWork Browser");
+          },
+          screenshot: {
+            name: "extensions-section",
+            requireText: ["OpenWork Browser"],
+            rejectText: ["Loading commands"],
+          },
+        });
+      },
+    },
+    {
+      name: "A fresh session composer is just as fast (cold open)",
+      run: async (ctx) => {
+        await ctx.prove("A brand new session's composer lists skills instantly on first open", {
+          claim: "Creating a new session and opening its plug menu shows the Skills list on the very first, cold open in under 3 seconds.",
+          voiceover:
+            "Now a brand new session — nothing cached in this composer yet. First click on Skills: the list still lands instantly.",
+          action: async () => {
+            await ctx.eval(`(() => {
+              document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+              const link = [...document.querySelectorAll('button, a, [role="button"]')].find((b) => b.textContent.trim() === "New session");
+              if (!link) throw new Error("New session entry not found");
+              link.click();
+              return true;
+            })()`);
+            await ctx.waitFor(`window.location.hash.includes("/session/")`, {
+              timeoutMs: 30_000,
+              label: "session route",
+            });
+            await openPlugMenu(ctx);
+            const timing = await ctx.eval(SKILLS_TIMING_EXPRESSION, { awaitPromise: true });
+            ctx.assert(timing && !timing.error, `Skills did not render: ${JSON.stringify(timing)}`);
+            ctx.log(`Session composer cold Skills paint: ${timing.ms}ms for ${timing.rowCount} rows`);
+            ctx.assert(timing.rowCount >= 10, `Expected at least 10 skill rows, saw ${timing.rowCount}`);
+            ctx.assert(timing.ms < 3000, `Skills took ${timing.ms}ms (expected < 3000ms)`);
+          },
+          assert: async () => {
+            await ctx.expectHashIncludes("/session/");
+            await ctx.expectText("/browser-automation");
+          },
+          screenshot: {
+            name: "session-composer-skills",
+            requireText: ["/browser-automation"],
+            hashIncludes: "/session/",
+          },
+        });
+      },
+    },
+    {
+      name: "A hanging cloud no longer blocks the menu (regression proof)",
+      run: async (ctx) => {
+        await ctx.prove("Skills render in milliseconds while the Den capability fan-out hangs", {
+          claim: "With a signed-in organization whose Den requests hang for 15s, the Skills section still paints local skills in under 3 seconds — the cloud fan-out is provably in flight and lands later instead of gating the menu.",
+          voiceover:
+            "The real test. I sign this app into an organization whose cloud is painfully slow — every capability request now hangs for fifteen seconds. Before this fix, the skills menu waited for that fan-out. Watch: the local skills still land in milliseconds, and the cloud answer merges in whenever it arrives.",
+          action: async () => {
+            // Cold start: reload so the composer holds no warm skills state.
+            // Boot clears any locally-set Den token (the server config is the
+            // source of truth), so the fake scope is installed post-boot.
+            await ctx.eval("location.reload()").catch(() => {});
+            await ctx.waitFor("Boolean(window.__openworkControl)", {
+              timeoutMs: 60_000,
+              label: "window.__openworkControl after reload",
+            });
+            await ctx.waitFor(`Boolean(document.querySelector(${JSON.stringify(PLUG_BUTTON)}))`, {
+              timeoutMs: 60_000,
+              label: "composer plug button after reload",
+            });
+            const result = await ctx.eval(`new Promise((resolve) => {
+              // The gateway marker routes Den API calls through the page's own
+              // fetch (same-origin), which we wrap to hold capability requests
+              // for 15s — a deterministic "slow cloud".
+              window.__OPENWORK_GATEWAY__ = { version: 1 };
+              const orig = window.fetch.bind(window);
+              window.__denFetchLog = [];
+              window.fetch = async (input, init) => {
+                const url = typeof input === "string" ? input : (input && input.url) || String(input);
+                if (String(url).includes("marketplace-capabilities")) {
+                  window.__denFetchLog.push({ url: String(url).slice(0, 120), at: Math.round(performance.now()) });
+                  await new Promise((r) => setTimeout(r, 15000));
+                }
+                return orig(input, init);
+              };
+              localStorage.setItem("openwork.den.authToken", "eval-slow-cloud-token");
+              localStorage.setItem("openwork.den.activeOrgId", "org_slowcloud_" + Date.now());
+              import("/src/react-app/domains/connections/cloud-inventory-cache.ts").then((m) => {
+                const tStart = performance.now();
+                const witness = { connectSettledMs: null };
+                m.loadSessionConnectCapabilities().then(() => {
+                  witness.connectSettledMs = Math.round(performance.now() - tStart);
+                });
+                document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+                setTimeout(() => {
+                  const plug = document.querySelector(${JSON.stringify(PLUG_BUTTON)});
+                  plug.click();
+                  setTimeout(() => {
+                    const skillsBtn = [...document.querySelectorAll("button")].find((b) => b.textContent.trim() === "Skills");
+                    const t0 = performance.now();
+                    skillsBtn.click();
+                    const poll = () => {
+                      const rows = [...document.querySelectorAll("button")].filter((b) => /^\\/[a-z0-9-]+/i.test(b.textContent.trim()));
+                      const hit = rows.some((b) => ${JSON.stringify(SKILL_MARKERS)}.some((marker) => b.textContent.includes(marker)));
+                      if (hit) {
+                        const skillsMs = Math.round(performance.now() - t0);
+                        // Give the fan-out a moment: it must STILL be pending.
+                        setTimeout(() => {
+                          resolve({
+                            skillsMs,
+                            rowCount: rows.length,
+                            connectSettledMs: witness.connectSettledMs,
+                            denFetchLog: window.__denFetchLog,
+                          });
+                        }, 1500);
+                        return;
+                      }
+                      if (performance.now() - t0 > 20000) {
+                        resolve({ error: "timed out", denFetchLog: window.__denFetchLog, bodyTail: document.body.innerText.slice(-400) });
+                        return;
+                      }
+                      setTimeout(poll, 20);
+                    };
+                    poll();
+                  }, 300);
+                }, 100);
+              }).catch((error) => resolve({ error: String(error).slice(0, 200) }));
+            })`, { awaitPromise: true });
+            ctx.assert(result && !result.error, `Slow-cloud scenario failed: ${JSON.stringify(result)}`);
+            ctx.log(`Slow cloud: skills painted in ${result.skillsMs}ms (${result.rowCount} rows); Den fan-out requests fired: ${JSON.stringify(result.denFetchLog)}; connect settled after skills render + 1.5s: ${result.connectSettledMs === null ? "still pending (held by the 15s delay)" : `${result.connectSettledMs}ms`}`);
+            ctx.assert(Array.isArray(result.denFetchLog) && result.denFetchLog.length >= 1, "The Den capability fan-out was never attempted — the slow-cloud scenario did not engage.");
+            ctx.assert(result.skillsMs < 3000, `Skills took ${result.skillsMs}ms with a hanging cloud (expected < 3000ms)`);
+            ctx.assert(result.connectSettledMs === null, `Connect inventory settled in ${result.connectSettledMs}ms — expected it to still be pending, so the menu provably did not wait for it.`);
+            ctx.assert(result.rowCount >= 10, `Expected at least 10 skill rows, saw ${result.rowCount}`);
+          },
+          assert: async () => {
+            await ctx.expectText("/browser-automation");
+          },
+          screenshot: {
+            name: "skills-fast-while-cloud-hangs",
+            requireText: ["/browser-automation"],
+            rejectText: ["Loading commands"],
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup: restore the signed-out state",
+      run: async (ctx) => {
+        await ctx.eval(DEN_KEYS_CLEANUP);
+        await ctx.eval("location.reload()").catch(() => {});
+        await ctx.waitFor("Boolean(window.__openworkControl)", {
+          timeoutMs: 60_000,
+          label: "window.__openworkControl after cleanup",
+        });
+      },
+    },
+  ],
+};


### PR DESCRIPTION
## Summary
- Composer plug menu (**Skills / Extensions**) and the `/` menu now paint from **local + cached data immediately** instead of waiting on the OpenWork Cloud (Den) capability fan-out; the fresh cloud answer merges in live when it arrives.
- `listMcp` runs its local list and the engine `mcp.status` call in parallel instead of in series.
- Server-side skill enumeration from disk is now parallel (order-preserving): **19.1ms → 5.1ms** on a 120-skill fixture.
- First open of a section shows "Loading…" instead of a wrong "No skills" / "No extensions" flash.

## Why
Opening the plug menu felt slow, and got slow *again* roughly once a minute. Four causes:

1. **The menu awaited the cloud.** `listSkills`/`listMcp` in `session-surface.tsx` and `new-task-composer.tsx` did `const connect = await connectPromise;` before resolving. That promise is the Den fan-out: 2 sequential + 2 batched network stages, each IPC-proxied with a 12s timeout, cached only 60s. Local skills are a ~30ms loopback call, but they were gated behind `max(local, cloud)` — so every menu open after the 60s TTL expired paid the full fan-out latency.
2. **`listMcp` waterfalled**: local list → engine `mcp.status` → cloud, all sequential.
3. **The server scanned skills sequentially**: for up to 8 skill roots, per entry `stat` → full `readFile` → YAML parse, one at a time — ~500 serialized syscalls and ~130 YAML parses per request, on the Electron main-process event loop (the server is embedded in-process). Worse on cold caches, AV-scanned, or network-synced home dirs.
4. `skillsLoaded` was initialized with `Boolean(props.skills)`, and `props.skills` is `[]` (truthy) before anything has loaded — so the first open rendered the empty state instead of a loading state.

## Issue
- N/A — reported directly ("skills take a long time to load in the composer skills/mcp/extension section").

## Scope
- `listSkills`/`listMcp` resolve with `[...local, ...cachedConnect]` immediately; the fan-out is still kicked off but **not awaited**, and its result is pushed into state when it lands (guarded by a `useRef` counter so a stale push can't overwrite a newer open).
- Same restructure in both composers: `session-surface.tsx` (session composer) and `new-task-composer.tsx` (new-task hero).
- `apps/server/src/skills.ts`: `Promise.all` over skill dirs and over entries within a dir, `.flat()` in the same order, existing dedupe untouched.
- `composer.tsx`: loaded flags keyed on `?.length` instead of existence.

## Out of scope
- **`cloud-inventory-cache.ts` is deliberately untouched.** `settings-route.tsx` and `use-org-mcp-connections.ts` depend on its exact semantics (`maxAgeMs: 0` = blocking fresh), so the composer reads the cached value synchronously (`readCachedConnectCapabilities`) rather than changing shared cache behavior.
- Silent MCP re-auth keeps its existing ordering (it still runs after the fresh Connect inventory resolves) — just relocated into the `.then`.
- No change to the 60s cloud TTL, the Den fan-out shape, or `resolveWorkspace`'s per-request `repairCommands` (a separate, pre-existing cost).

## Testing
### Ran
- `pnpm --filter @openwork/app typecheck`
- `pnpm --filter @openwork/app test`
- `cd apps/server && bun test src/skills.test.ts src/connect-skill-catalog.test.ts`
- `cd apps/server && pnpm typecheck`
- `pnpm evals --flow composer-skills-fast-load --cdp-url <daytona-electron-cdp>`

### Result
- pass/fail: **all pass**
  - app typecheck: clean; app tests: **507 pass / 0 fail** (1454 assertions, 94 files)
  - server tests: **13 pass / 0 fail**; server typecheck: clean
  - eval flow: **PASSED** — 7/7 steps, 5 validated frames
- if fail, exact files/errors: N/A

## CI status
- pass: **13/13** — `openwork-tests` on both `blacksmith-4vcpu-ubuntu-2204` and `macos-14`, `i18n-audit`, `Analyze (actions)`, `Analyze (javascript-typescript)`, CodeQL, Cloudflare Pages, and all 5 Vercel deployments. `mergeStateStatus: CLEAN`.
- code-related failures: none
- external/env/auth blockers: none (`[code]smith` and `Vercel Agent Review` report `skipping` — optional bots)

## Manual verification
1. Open the composer plug button → **Skills**: the local skill list renders immediately (measured **46ms**, 22 rows).
2. Create a new session → open its plug menu → **Skills** (cold, nothing cached in that composer): renders in **86ms**, 24 rows.
3. Open **Extensions**: the catalog is on screen immediately, no stuck loader.
4. Regression case: sign into an org whose Den requests hang 15s → **Skills still paints in 86ms** while the capability fan-out is captured in flight and *still pending*. That pending promise is exactly what the old code awaited.

## Evidence
Frame proof (5 validated frames) posted as a PR comment below — driven end-to-end via CDP on a Daytona sandbox running this branch. Local run artifact: `evals/results/2026-07-29T06-43-00-461Z/fraimz.html`.

New regression flow `evals/flows/composer-skills-fast-load.flow.mjs` locks in the behavior: it installs a signed-in scope whose Den capability requests are held for 15s, then asserts (a) the fan-out was actually attempted, (b) skills render in <3s, and (c) the Connect inventory is **still pending** when they do — so the menu provably does not wait on the cloud.

## Risk
Low, and scoped to menu population.
- Cached-then-fresh means the menu can briefly show cloud capabilities up to 60s stale, then update in place — same TTL as before, just non-blocking. Local skills/MCP are always current.
- The push guard prevents out-of-order state writes when the menu is reopened during a slow fan-out.
- Server-side ordering is preserved by `Promise.all` (input order), so name-dedupe precedence (project before global, `.opencode` before `.claude`) is unchanged — covered by `skills.test.ts` (flat + plugin-namespaced/nested layouts) and verified against a sequential reference on a 120-skill fixture.
- Empty-state text now correctly trails a loading state; a genuinely empty workspace shows "Loading…" for one frame before "No skills".

## Rollback
Revert this PR — the four source files are independent of each other and of the eval flow; no migrations, config, or persisted state involved.
