### PR TITLE
feat(evals): core reliability suite — invite + MCP unhappy paths, dual assertion, soak mode

### DIFF
--- a/.github/workflows/nightly-evals.yml
+++ b/.github/workflows/nightly-evals.yml
@@ -92,6 +92,13 @@ jobs:
           tail -100 /tmp/openwork-dev.log >&2
           exit 1
 
+      - name: Run core reliability soak
+        shell: bash
+        env:
+          DISPLAY: ":99"
+          OPENWORK_EVAL_DESKTOP_SURFACE: "0"
+        run: pnpm evals --stack den --flow invite-reliability --flow mcp-connect-reliability --repeat 3
+
       - name: Run eval flows
         shell: bash
         env:

--- a/evals/flows/invite-reliability.flow.mjs
+++ b/evals/flows/invite-reliability.flow.mjs
@@ -1,0 +1,429 @@
+import { journeys } from "../runner/journeys/index.mjs";
+import { denApiFetch, denWebUrl } from "../runner/journeys/den.mjs";
+import { defineScenario } from "../runner/scenario.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "invite-reliability";
+const REQUIRED_DEN_ENV = ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"];
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+const { den } = journeys;
+const AUTH_TOKEN_STORAGE_KEY = "openwork:web:auth-token";
+
+function safeJson(value) {
+  try {
+    return JSON.stringify(value).slice(0, 1_200);
+  } catch {
+    return String(value).slice(0, 1_200);
+  }
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({ type: "assertion", status: condition ? "passed" : "failed", assertion, actual });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : `. Actual: ${safeJson(actual)}`}`);
+}
+
+function cleanStamp(value) {
+  return String(value ?? "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "run";
+}
+
+function uniqueOrgName(ctx) {
+  const stamp = ctx.env.OPENWORK_EVAL_RUNSTAMP?.trim() || new Date().toISOString();
+  return `Invite Reliability ${cleanStamp(stamp)}`;
+}
+
+function stateString(ctx, key) {
+  const value = ctx.state[key];
+  if (typeof value === "string" && value.trim()) return value;
+  throw new Error(`Scenario state ${key} was not set.`);
+}
+
+function stateInvite(ctx) {
+  const value = ctx.state.invite;
+  if (value && typeof value === "object") return value;
+  throw new Error("Scenario state invite was not set.");
+}
+
+function stateReinvite(ctx) {
+  const value = ctx.state.reinvite;
+  if (value && typeof value === "object") return value;
+  throw new Error("Scenario state reinvite was not set.");
+}
+
+function normalizedEmail(value) {
+  return String(value ?? "").trim().toLowerCase();
+}
+
+function authHeaders(token, organizationId) {
+  return {
+    authorization: `Bearer ${token}`,
+    "x-openwork-org-id": organizationId,
+  };
+}
+
+function membersFromOrg(body) {
+  return Array.isArray(body?.members) ? body.members : [];
+}
+
+function memberEmail(member) {
+  return normalizedEmail(member?.user?.email ?? member?.email ?? "");
+}
+
+function memberId(member) {
+  return typeof member?.id === "string" ? member.id : typeof member?.memberId === "string" ? member.memberId : "";
+}
+
+function memberRole(member) {
+  return typeof member?.role === "string" ? member.role.trim().toLowerCase() : "";
+}
+
+function memberHasRole(member, role) {
+  const target = role.trim().toLowerCase();
+  return memberRole(member).split(",").map((entry) => entry.trim()).includes(target);
+}
+
+function matchingMembers(body, email) {
+  const target = normalizedEmail(email);
+  return membersFromOrg(body).filter((member) => memberEmail(member) === target);
+}
+
+async function loadOrg(ctx) {
+  const token = await den.apiSignIn(ctx, { actor: ctx.actors.alex });
+  const organizationId = stateString(ctx, "orgId");
+  const loaded = await denApiFetch(ctx, "/v1/org", { headers: authHeaders(token, organizationId) });
+  witness(ctx, loaded.response.ok, "Admin can load the active organization", { status: loaded.response.status, body: loaded.body });
+  return loaded.body;
+}
+
+async function navigateDen(ctx, path) {
+  const url = new URL(path, `${denWebUrl(ctx)}/`).toString();
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(url)}; return true; })()`);
+  await ctx.waitFor("document.readyState === 'complete' || document.body.innerText.length > 0", {
+    timeoutMs: 60_000,
+    label: `load ${path}`,
+  });
+}
+
+async function navigateUrl(ctx, url, label) {
+  const safeUrl = new URL(url).toString();
+  const target = new URL(safeUrl);
+  const navigated = ctx.client
+    ? await ctx.client.send("Page.navigate", { url: safeUrl }).then(() => true).catch(() => false)
+    : false;
+  if (!navigated) await ctx.eval(`(() => { window.location.href = ${JSON.stringify(safeUrl)}; return true; })()`);
+  await ctx.waitFor(`window.location.pathname === ${JSON.stringify(target.pathname)} && window.location.search === ${JSON.stringify(target.search)}`, {
+    timeoutMs: 60_000,
+    label: `route ${label}`,
+  });
+  await ctx.waitFor("document.readyState === 'complete' || document.body.innerText.length > 0", {
+    timeoutMs: 60_000,
+    label,
+  });
+}
+
+async function openInvite(ctx, invite, label) {
+  const inviteUrl = typeof invite?.inviteUrl === "string" && invite.inviteUrl.trim()
+    ? invite.inviteUrl
+    : typeof invite?.token === "string" && invite.token.trim()
+      ? new URL(`/join-org?invite=${encodeURIComponent(invite.token)}`, `${denWebUrl(ctx)}/`).toString()
+      : "";
+  witness(ctx, Boolean(inviteUrl), `${label} has an invite URL`, invite);
+  await navigateUrl(ctx, inviteUrl, label);
+}
+
+async function clickJoinInvite(ctx, orgName) {
+  await ctx.waitFor(`(() => {
+    const normalize = (value) => (value ?? '').replace(/\s+/g, ' ').trim();
+    const button = [...document.querySelectorAll('button')]
+      .find((entry) => normalize(entry.textContent).startsWith('Join ') && entry.disabled !== true && entry.getAttribute('aria-disabled') !== 'true');
+    button?.scrollIntoView({ block: 'center', inline: 'center' });
+    button?.click();
+    return Boolean(button);
+  })()`, { timeoutMs: 30_000, label: `join ${orgName}` });
+}
+
+async function acceptSignedInInvite(ctx, actor, invite) {
+  const token = await den.apiSignIn(ctx, { actor });
+  await ctx.eval(`(() => {
+    window.localStorage.setItem(${JSON.stringify(AUTH_TOKEN_STORAGE_KEY)}, ${JSON.stringify(token)});
+    return true;
+  })()`);
+  await openInvite(ctx, invite, "signed-in re-invite");
+  await ctx.waitFor(`document.body.innerText.includes("You're one click away")
+    || document.body.innerText.includes(${JSON.stringify(`Join ${stateString(ctx, "orgName")}`)})
+    || document.body.innerText.includes('Dashboard')`, {
+    timeoutMs: 60_000,
+    label: "signed-in invite ready",
+  });
+  if (!await ctx.hasText("Dashboard")) {
+    await clickJoinInvite(ctx, stateString(ctx, "orgName"));
+  }
+  await ctx.waitFor(`Boolean(document.querySelector('[data-testid="join-org-success"]'))
+    || document.body.innerText.includes("You're in")
+    || document.body.innerText.includes('Dashboard')
+    || location.pathname.startsWith('/dashboard')`, {
+    timeoutMs: 60_000,
+    label: "signed-in invite accepted",
+  });
+}
+
+async function showMembers(ctx) {
+  await navigateDen(ctx, "/dashboard/members");
+  await ctx.waitFor("document.body.innerText.includes('Members') || document.body.innerText.includes('Add member')", {
+    timeoutMs: 60_000,
+    label: "Members page",
+  });
+}
+
+async function removeMemberIfPresent(ctx, email) {
+  const token = await den.apiSignIn(ctx, { actor: ctx.actors.alex });
+  const organizationId = stateString(ctx, "orgId");
+  const org = await denApiFetch(ctx, "/v1/org", { headers: authHeaders(token, organizationId) });
+  witness(ctx, org.response.ok, "Admin can reload the organization before cleanup", { status: org.response.status, body: org.body });
+  for (const member of matchingMembers(org.body, email)) {
+    const id = memberId(member);
+    witness(ctx, Boolean(id), "Matched member has a removable member id", member);
+    const removed = await denApiFetch(ctx, `/v1/members/${encodeURIComponent(id)}`, {
+      method: "DELETE",
+      headers: authHeaders(token, organizationId),
+    });
+    witness(ctx, removed.response.ok || removed.response.status === 204, "Admin can remove the invited teammate", { status: removed.response.status, body: removed.body });
+  }
+}
+
+export default defineScenario({
+  id: FLOW_ID,
+  title: "Cloud invite reliability: one admin invite creates one removable teammate",
+  kind: "user-facing",
+  requiresApp: false,
+  stage: { den: { orgMode: "multi_org" } },
+  actors: {
+    alex: "owner",
+    jamie: { persona: "fresh", prefix: "jamie-invite" },
+  },
+  requiredEnv: REQUIRED_DEN_ENV,
+  steps: [
+    {
+      name: "Alex creates an isolated invite workspace",
+      run: async (ctx) => {
+        const alexWeb = await ctx.surfaces.chrome("invite-admin-web", { startUrl: denWebUrl(ctx), headless: true });
+        await ctx.on(alexWeb, async () => {
+          await ctx.prove("Alex creates and opens a fresh Den workspace before sending invites", {
+            voiceover: vo[0],
+            action: async () => {
+              const orgName = uniqueOrgName(ctx);
+              const created = await den.createOrg(ctx, { surface: alexWeb, actor: ctx.actors.alex, name: orgName });
+              witness(ctx, Boolean(created.orgId), "Created organization has an id", created);
+              ctx.state.orgId = created.orgId;
+              ctx.state.orgName = created.name;
+              await showMembers(ctx);
+            },
+            assert: async () => {
+              await ctx.expectText("Members", { timeoutMs: 60_000 });
+              witness(ctx, stateString(ctx, "orgName").startsWith("Invite Reliability"), "The run uses an isolated invite reliability org", stateString(ctx, "orgName"));
+            },
+            screenshot: { name: "admin-members", requireText: ["Members"], rejectText: ["Something went wrong"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Alex sends Jamie a real invite",
+      run: async (ctx) => {
+        const alexWeb = ctx.surfaces.get("invite-admin-web");
+        await ctx.on(alexWeb, async () => {
+          await ctx.prove("The Members screen sends a real invitation and shows Jamie pending", {
+            voiceover: vo[1],
+            action: async () => {
+              const invite = await den.inviteMember(ctx, {
+                surface: alexWeb,
+                actor: ctx.actors.alex,
+                email: ctx.actors.jamie.email,
+                organizationId: stateString(ctx, "orgId"),
+              });
+              witness(ctx, Boolean(invite.token), "Invite token was resolved for Jamie", invite);
+              ctx.state.invite = invite;
+              await showMembers(ctx);
+            },
+            assert: async () => {
+              await ctx.expectText(ctx.actors.jamie.email, { timeoutMs: 60_000 });
+              const org = await loadOrg(ctx);
+              const pending = Array.isArray(org?.invitations) ? org.invitations.filter((invite) => normalizedEmail(invite?.email) === normalizedEmail(ctx.actors.jamie.email)) : [];
+              witness(ctx, pending.length === 1, "Exactly one pending invitation exists for Jamie", pending);
+            },
+            screenshot: { name: "jamie-pending", requireText: [ctx.actors.jamie.email], rejectText: ["Something went wrong"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Jamie accepts in a separate Chrome profile",
+      run: async (ctx) => {
+        const jamieWeb = await ctx.surfaces.chrome("invite-member-web", { startUrl: denWebUrl(ctx), headless: true });
+        await ctx.on(jamieWeb, async () => {
+          await ctx.prove("Jamie accepts the invite from her own browser and reaches the workspace", {
+            voiceover: vo[2],
+            action: async () => {
+              await den.acceptInvite(ctx, { surface: jamieWeb, actor: ctx.actors.jamie, invite: stateInvite(ctx) });
+              await navigateDen(ctx, "/dashboard");
+            },
+            assert: async () => {
+              await ctx.expectText("Dashboard", { timeoutMs: 60_000 });
+              await ctx.expectNoText("Could not join");
+            },
+            screenshot: { name: "jamie-dashboard", requireText: ["Dashboard"], rejectText: ["Could not join", "Something went wrong"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Jamie reopens the consumed invite link",
+      run: async (ctx) => {
+        const jamieWeb = ctx.surfaces.get("invite-member-web");
+        await ctx.on(jamieWeb, async () => {
+          await ctx.prove("Reopening the same accepted invite lands Jamie in a coherent already-member state", {
+            voiceover: vo[3],
+            action: async () => {
+              await openInvite(ctx, stateInvite(ctx), "reopen accepted invite");
+              await ctx.waitFor(`document.body.innerText.includes('Dashboard')
+                || document.body.innerText.includes("You've already joined")
+                || document.body.innerText.includes('This invite has already been used.')`, {
+                timeoutMs: 60_000,
+                label: "accepted invite already-member state",
+              });
+            },
+            assert: async () => {
+              await ctx.expectNoText("This invite can't be opened.");
+              await ctx.expectNoText("Could not join");
+              const bodyText = await ctx.eval("document.body?.innerText ?? ''");
+              witness(ctx, String(bodyText).includes("Dashboard") || String(bodyText).includes("already joined") || String(bodyText).includes("already been used"), "Consumed invite renders a coherent already-member state", String(bodyText).slice(0, 500));
+            },
+            screenshot: { name: "jamie-double-accept", requireText: ["Dashboard"], rejectText: ["This invite can't be opened", "Could not join", "Something went wrong"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Alex sees exactly one accepted teammate",
+      run: async (ctx) => {
+        const alexWeb = ctx.surfaces.get("invite-admin-web");
+        await ctx.on(alexWeb, async () => {
+          await ctx.prove("The accepted teammate appears once in the admin member list", {
+            voiceover: vo[4],
+            action: async () => {
+              await showMembers(ctx);
+            },
+            assert: async () => {
+              await ctx.expectText(ctx.actors.jamie.email, { timeoutMs: 60_000 });
+              const org = await loadOrg(ctx);
+              const matches = matchingMembers(org, ctx.actors.jamie.email);
+              witness(ctx, matches.length === 1, "Exactly one accepted member exists for Jamie", matches);
+            },
+            screenshot: { name: "jamie-member-row", requireText: [ctx.actors.jamie.email], rejectText: ["Something went wrong"] },
+          });
+        });
+      },
+    },
+    {
+      name: "An invalid invite token shows a real error state",
+      run: async (ctx) => {
+        const invalidWeb = await ctx.surfaces.chrome("invite-invalid-web", { startUrl: denWebUrl(ctx), headless: true });
+        await ctx.on(invalidWeb, async () => {
+          await ctx.prove("A garbage invite token renders a clear product error instead of a blank loop", {
+            voiceover: vo[5],
+            action: async () => {
+              const invalidUrl = new URL("/join-org", `${denWebUrl(ctx)}/`);
+              invalidUrl.searchParams.set("invite", `invalid-${cleanStamp(ctx.env.OPENWORK_EVAL_RUNSTAMP)}-token`);
+              await navigateUrl(ctx, invalidUrl.toString(), "invalid invite token");
+            },
+            assert: async () => {
+              await ctx.expectText("This invite can't be opened.", { timeoutMs: 60_000 });
+              await ctx.expectText("Back to OpenWork Cloud", { timeoutMs: 60_000 });
+              await ctx.expectNoText("Dashboard");
+            },
+            screenshot: { name: "invalid-invite-token", requireText: ["This invite can't be opened.", "Back to OpenWork Cloud"], rejectText: ["Dashboard", "Could not join", "Something went wrong"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Alex removes Jamie, re-invites her, and Jamie accepts again",
+      run: async (ctx) => {
+        const alexWeb = ctx.surfaces.get("invite-admin-web");
+        const jamieWeb = ctx.surfaces.get("invite-member-web");
+        await ctx.on(alexWeb, async () => {
+          await ctx.prove("An admin can remove Jamie, re-invite the same email with an admin role, and Jamie can accept again", {
+            voiceover: vo[6],
+            action: async () => {
+              await removeMemberIfPresent(ctx, ctx.actors.jamie.email);
+              const afterRemoval = await loadOrg(ctx);
+              witness(ctx, matchingMembers(afterRemoval, ctx.actors.jamie.email).length === 0, "Jamie is absent after removal before re-invite", matchingMembers(afterRemoval, ctx.actors.jamie.email));
+              const invite = await den.inviteMember(ctx, {
+                actor: ctx.actors.alex,
+                email: ctx.actors.jamie.email,
+                role: "admin",
+                organizationId: stateString(ctx, "orgId"),
+              });
+              witness(ctx, Boolean(invite.token), "Re-invite token was resolved for Jamie", invite);
+              ctx.state.reinvite = invite;
+              await ctx.on(jamieWeb, async () => {
+                await acceptSignedInInvite(ctx, ctx.actors.jamie, stateReinvite(ctx));
+                await navigateDen(ctx, "/dashboard");
+              });
+              await showMembers(ctx);
+            },
+            assert: async () => {
+              await ctx.expectText(ctx.actors.jamie.email, { timeoutMs: 60_000 });
+              const org = await loadOrg(ctx);
+              const matches = matchingMembers(org, ctx.actors.jamie.email);
+              witness(ctx, matches.length === 1, "Exactly one accepted member exists for Jamie after re-invite", matches);
+            },
+            screenshot: { name: "jamie-reinvited-member-row", requireText: [ctx.actors.jamie.email], rejectText: ["Pending", "Could not join", "Something went wrong"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Jamie keeps the invited admin role",
+      run: async (ctx) => {
+        const alexWeb = ctx.surfaces.get("invite-admin-web");
+        await ctx.on(alexWeb, async () => {
+          await ctx.prove("The accepted re-invite preserves Jamie's explicit admin role", {
+            voiceover: vo[7],
+            action: async () => {
+              await showMembers(ctx);
+            },
+            assert: async () => {
+              await ctx.expectText(ctx.actors.jamie.email, { timeoutMs: 60_000 });
+              await ctx.expectText("Admin", { timeoutMs: 60_000 });
+              const org = await loadOrg(ctx);
+              const matches = matchingMembers(org, ctx.actors.jamie.email);
+              witness(ctx, matches.length === 1 && memberHasRole(matches[0], "admin"), "Jamie has exactly one admin membership after the explicit-role invite", matches);
+            },
+            screenshot: { name: "jamie-admin-role", requireText: [ctx.actors.jamie.email, "Admin"], rejectText: ["Pending", "Something went wrong"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Cleanup and desktop gate",
+      run: async (ctx) => {
+        await ctx.prove("Cleanup removes Jamie and the desktop cell is explicitly skipped", {
+          voiceover: vo[8],
+          action: async () => {
+            await removeMemberIfPresent(ctx, ctx.actors.jamie.email);
+            const desktopGate = ctx.env.OPENWORK_EVAL_DESKTOP_SURFACE?.trim() ? "requested" : "not requested";
+            ctx.skip(`Electron desktop surface ${desktopGate}; ${FLOW_ID} is intentionally web-only.`);
+            ctx.output("desktop-surface-gate", `OPENWORK_EVAL_DESKTOP_SURFACE=${ctx.env.OPENWORK_EVAL_DESKTOP_SURFACE ?? ""}`);
+          },
+          assert: async () => {
+            const org = await loadOrg(ctx);
+            witness(ctx, matchingMembers(org, ctx.actors.jamie.email).length === 0, "Jamie is removed during cleanup", matchingMembers(org, ctx.actors.jamie.email));
+          },
+        });
+      },
+    },
+  ],
+});

--- a/evals/flows/mcp-connect-reliability.flow.mjs
+++ b/evals/flows/mcp-connect-reliability.flow.mjs
@@ -1,0 +1,481 @@
+import { journeys } from "../runner/journeys/index.mjs";
+import { denWebUrl } from "../runner/journeys/den.mjs";
+import { defineScenario } from "../runner/scenario.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "mcp-connect-reliability";
+const REQUIRED_DEN_ENV = ["OPENWORK_EVAL_DEN_API_URL", "OPENWORK_EVAL_DEN_WEB_URL"];
+const USABLE_ECHO_TEXT = "ui connected usable proof";
+const RELOAD_ECHO_TEXT = "reload mcp reliability proof";
+const RECONNECT_ECHO_TEXT = "reconnect mcp reliability proof";
+const DIRECT_ECHO_TEXT = "direct mcp reliability proof";
+const AGENT_ECHO_TEXT = "agent mcp reliability proof";
+const MCP_CONNECTIONS_SCREEN_READY = "document.body.innerText.includes('Connectors') || document.body.innerText.includes('Add MCP') || document.body.innerText.includes('MCP Connections') || document.body.innerText.includes('Add a custom MCP server')";
+
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+const { den, mcp } = journeys;
+
+function safeJson(value) {
+  try {
+    return JSON.stringify(value).slice(0, 1_200);
+  } catch {
+    return String(value).slice(0, 1_200);
+  }
+}
+
+function witness(ctx, condition, assertion, actual) {
+  ctx.recordEvidence({ type: "assertion", status: condition ? "passed" : "failed", assertion, actual });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : `. Actual: ${safeJson(actual)}`}`);
+}
+
+function cleanStamp(value) {
+  return String(value ?? "").toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "run";
+}
+
+function uniqueOrgName(ctx) {
+  const stamp = ctx.env.OPENWORK_EVAL_RUNSTAMP?.trim() || new Date().toISOString();
+  return `MCP Reliability ${cleanStamp(stamp)}`;
+}
+
+function connectionPrefix(ctx) {
+  const stamp = ctx.env.OPENWORK_EVAL_RUNSTAMP?.trim() || "run";
+  return `reliability-mcp-${cleanStamp(stamp)}`;
+}
+
+function stateString(ctx, key) {
+  const value = ctx.state[key];
+  if (typeof value === "string" && value.trim()) return value;
+  throw new Error(`Scenario state ${key} was not set.`);
+}
+
+function mockBase(ctx) {
+  const fixtureUrl = typeof ctx.state.mockMcpUrl === "string" ? ctx.state.mockMcpUrl : "";
+  return (fixtureUrl || ctx.env.MOCK_OAUTH_MCP_URL?.trim() || ctx.env.OPENWORK_EVAL_MOCK_URL?.trim() || "http://127.0.0.1:3978").replace(/\/+$/, "");
+}
+
+function reconnectMcpUrl(ctx) {
+  const stamp = cleanStamp(ctx.env.OPENWORK_EVAL_RUNSTAMP?.trim() || new Date().toISOString());
+  return `${mockBase(ctx)}/mcp?reconnect=${encodeURIComponent(stamp)}`;
+}
+
+async function stopMockFixture(ctx) {
+  const fixture = ctx.state.mockMcpFixture;
+  if (!fixture || typeof fixture !== "object" || typeof fixture.stop !== "function") return;
+  await fixture.stop();
+  delete ctx.state.mockMcpFixture;
+}
+
+async function navigateDen(ctx, path) {
+  const url = new URL(path, `${denWebUrl(ctx)}/`).toString();
+  await ctx.eval(`(() => { window.location.href = ${JSON.stringify(url)}; return true; })()`);
+  await ctx.waitFor(`window.location.pathname === ${JSON.stringify(new URL(url).pathname)}`, {
+    timeoutMs: 60_000,
+    label: `route ${path}`,
+  });
+  await ctx.waitFor("document.readyState === 'complete' || document.body.innerText.length > 0", {
+    timeoutMs: 60_000,
+    label: `load ${path}`,
+  });
+}
+
+function toolName(tool) {
+  return typeof tool?.name === "string" ? tool.name : "";
+}
+
+function selectMockEchoMatch(ctx, matches) {
+  const connectionId = stateString(ctx, "connectionId");
+  const connectionName = stateString(ctx, "connectionName");
+  return matches.find((match) => match.name === `mcp:${connectionId}:mock_echo`)
+    ?? matches.find((match) => match.name.includes(connectionId) && match.name.endsWith("mock_echo"))
+    ?? matches.find((match) => match.summary.includes(connectionName) && match.name.endsWith("mock_echo"))
+    ?? matches.find((match) => match.name.endsWith("mock_echo"));
+}
+
+async function showMcpConnections(ctx, surface) {
+  await ctx.on(surface, async () => {
+    if (await ctx.eval("window.location.pathname.includes('/dashboard/mcp-connections')")) {
+      await navigateDen(ctx, "/dashboard");
+    }
+    await navigateDen(ctx, "/dashboard/mcp-connections");
+    await ctx.waitFor(MCP_CONNECTIONS_SCREEN_READY, {
+      timeoutMs: 60_000,
+      label: "MCP Connections screen",
+    });
+  });
+}
+
+async function scrollConnectionIntoView(ctx, connectionName) {
+  await ctx.eval(`(() => {
+    const connectionName = ${JSON.stringify(connectionName)};
+    const target = [...document.querySelectorAll('main *')]
+      .find((element) => {
+        const text = (element.textContent ?? '').trim();
+        return text.includes(connectionName) && text.length < connectionName.length + 360;
+      });
+    target?.scrollIntoView({ block: 'center', inline: 'nearest' });
+    return Boolean(target);
+  })()`);
+  await ctx.waitFor(`(() => {
+    const connectionName = ${JSON.stringify(connectionName)};
+    const target = [...document.querySelectorAll('main *')]
+      .find((element) => {
+        const text = (element.textContent ?? '').trim();
+        return text.includes(connectionName) && text.length < connectionName.length + 360;
+      });
+    if (!target) return false;
+    const rect = target.getBoundingClientRect();
+    return rect.top >= 0 && rect.bottom <= window.innerHeight;
+  })()`, { timeoutMs: 10_000, label: `visible row for ${connectionName}` });
+}
+
+async function connectionRowText(ctx, connectionName) {
+  const result = await ctx.eval(`(() => {
+    const normalize = (value) => (value ?? '').replace(/\s+/g, ' ').trim();
+    const connectionName = ${JSON.stringify(connectionName)};
+    const target = [...document.querySelectorAll('[data-testid^="mcp-connection-row-"]')]
+      .find((element) => normalize(element.textContent).includes(connectionName));
+    return normalize(target?.textContent ?? '');
+  })()`);
+  return typeof result === "string" ? result : "";
+}
+
+async function expectLiveToolFailure(ctx, expectedText) {
+  try {
+    await mcp.runConnectionTool(ctx, {
+      actor: ctx.actors.alex,
+      organizationId: stateString(ctx, "orgId"),
+      connectionId: stateString(ctx, "connectionId"),
+      toolName: "mock_echo",
+      arguments: { text: expectedText },
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    ctx.output("disconnected-live-mcp-result", message);
+    return message;
+  }
+  throw new Error("MCP tool call unexpectedly succeeded after disconnect.");
+}
+
+export default defineScenario({
+  id: FLOW_ID,
+  title: "Cloud MCP reliability: connected no-auth server works through direct and agent paths",
+  kind: "user-facing",
+  requiresApp: false,
+  stage: { den: { orgMode: "multi_org" } },
+  actors: {
+    alex: "owner",
+  },
+  requiredEnv: REQUIRED_DEN_ENV,
+  steps: [
+    {
+      name: "Alex creates an isolated MCP workspace",
+      run: async (ctx) => {
+        const alexWeb = await ctx.surfaces.chrome("mcp-admin-web", { startUrl: denWebUrl(ctx), headless: true });
+        await ctx.on(alexWeb, async () => {
+          await ctx.prove("Alex creates and opens a fresh Den workspace for MCP reliability", {
+            voiceover: vo[0],
+            action: async () => {
+              const created = await den.createOrg(ctx, { surface: alexWeb, actor: ctx.actors.alex, name: uniqueOrgName(ctx) });
+              witness(ctx, Boolean(created.orgId), "Created organization has an id", created);
+              ctx.state.orgId = created.orgId;
+              ctx.state.orgName = created.name;
+              await showMcpConnections(ctx, alexWeb);
+            },
+            assert: async () => {
+              await ctx.expectText("Add MCP", { timeoutMs: 60_000 });
+              witness(ctx, stateString(ctx, "orgName").startsWith("MCP Reliability"), "The run uses an isolated MCP reliability org", stateString(ctx, "orgName"));
+            },
+            screenshot: { name: "mcp-admin-connections", requireText: ["Add MCP"], rejectText: ["Something went wrong"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Alex publishes the mock MCP connection",
+      run: async (ctx) => {
+        const alexWeb = ctx.surfaces.get("mcp-admin-web");
+        await ctx.on(alexWeb, async () => {
+          await ctx.prove("A no-auth mock MCP server is saved org-wide and shown as Connected", {
+            voiceover: vo[1],
+            action: async () => {
+              const fixture = await mcp.startMockMcpServer(ctx);
+              ctx.state.mockMcpFixture = fixture;
+              ctx.state.mockMcpUrl = fixture.url;
+              const health = await fetch(`${mockBase(ctx)}/health`).catch(() => null);
+              witness(ctx, Boolean(health?.ok), `Mock MCP server is reachable at ${mockBase(ctx)}`);
+              const prefix = connectionPrefix(ctx);
+              await mcp.deleteConnectionsByPrefix(ctx, { actor: ctx.actors.alex, organizationId: stateString(ctx, "orgId"), prefix });
+              const connectionName = `${prefix}-echo`;
+              const created = await mcp.createNoAuthConnection(ctx, {
+                actor: ctx.actors.alex,
+                organizationId: stateString(ctx, "orgId"),
+                name: connectionName,
+                url: `${mockBase(ctx)}/mcp`,
+                access: { orgWide: true },
+              });
+              ctx.state.connectionId = created.id;
+              ctx.state.connectionName = created.name;
+              const connected = await mcp.waitForConnectionConnected(ctx, {
+                actor: ctx.actors.alex,
+                organizationId: stateString(ctx, "orgId"),
+                connectionId: created.id,
+              });
+              witness(ctx, connected.connected && connected.connectedForMe, "The no-auth MCP connection is connected for the admin", connected);
+              await showMcpConnections(ctx, alexWeb);
+            },
+            assert: async () => {
+              const connectionName = stateString(ctx, "connectionName");
+              await ctx.expectText(connectionName, { timeoutMs: 60_000 });
+              await ctx.expectText("Connected", { timeoutMs: 60_000 });
+              await scrollConnectionIntoView(ctx, connectionName);
+              if (ctx.env.OPENWORK_EVAL_MCP_RELIABILITY_STOP_AFTER_CONNECT?.trim()) {
+                await stopMockFixture(ctx);
+              }
+              const result = await mcp.expectUsableConnection(ctx, {
+                actor: ctx.actors.alex,
+                organizationId: stateString(ctx, "orgId"),
+                connectionId: stateString(ctx, "connectionId"),
+                connectionName: stateString(ctx, "connectionName"),
+                uiConnected: true,
+                expectedText: USABLE_ECHO_TEXT,
+              });
+              ctx.output("ui-live-mcp-result", mcp.mcpTextContent(result));
+            },
+            screenshot: { name: "mcp-connected", requireText: ["Connected"], rejectText: ["Something went wrong", "Connection failed"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Connected MCP survives a Den Web reload",
+      run: async (ctx) => {
+        const alexWeb = ctx.surfaces.get("mcp-admin-web");
+        await ctx.on(alexWeb, async () => {
+          await ctx.prove("After a browser reload, Den Web still shows the connection and the live tool remains usable", {
+            voiceover: vo[2],
+            action: async () => {
+              await ctx.eval("location.reload(); true");
+              await ctx.waitFor("document.readyState === 'complete' || document.body.innerText.length > 0", {
+                timeoutMs: 60_000,
+                label: "MCP Connections reload",
+              });
+              await showMcpConnections(ctx, alexWeb);
+              await scrollConnectionIntoView(ctx, stateString(ctx, "connectionName"));
+            },
+            assert: async () => {
+              await ctx.expectText(stateString(ctx, "connectionName"), { timeoutMs: 60_000 });
+              await ctx.expectText("Connected", { timeoutMs: 60_000 });
+              const result = await mcp.expectUsableConnection(ctx, {
+                actor: ctx.actors.alex,
+                organizationId: stateString(ctx, "orgId"),
+                connectionId: stateString(ctx, "connectionId"),
+                connectionName: stateString(ctx, "connectionName"),
+                uiConnected: true,
+                expectedText: RELOAD_ECHO_TEXT,
+              });
+              ctx.output("reload-live-mcp-result", mcp.mcpTextContent(result));
+            },
+            screenshot: { name: "mcp-connected-after-reload", requireText: [stateString(ctx, "connectionName"), "Connected"], rejectText: ["Something went wrong", "Connection failed"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Disconnect clears the usable MCP credential",
+      run: async (ctx) => {
+        const alexWeb = ctx.surfaces.get("mcp-admin-web");
+        await ctx.on(alexWeb, async () => {
+          await ctx.prove("Disconnecting keeps the row but makes the live tool call fail", {
+            voiceover: vo[3],
+            action: async () => {
+              await mcp.disconnectConnection(ctx, {
+                actor: ctx.actors.alex,
+                organizationId: stateString(ctx, "orgId"),
+                connectionId: stateString(ctx, "connectionId"),
+              });
+              await showMcpConnections(ctx, alexWeb);
+              await scrollConnectionIntoView(ctx, stateString(ctx, "connectionName"));
+            },
+            assert: async () => {
+              await ctx.expectText("Not connected", { timeoutMs: 60_000 });
+              const connections = await mcp.listManageableConnections(ctx, {
+                actor: ctx.actors.alex,
+                organizationId: stateString(ctx, "orgId"),
+              });
+              const connection = connections.find((entry) => entry.id === stateString(ctx, "connectionId"));
+              witness(ctx, connection?.connected === false && connection.connectedForMe === false, "Disconnected MCP connection is no longer connected in the API", connection);
+              const failure = await expectLiveToolFailure(ctx, "disconnected mcp reliability proof");
+              witness(ctx, failure.includes("connection_not_ready") || failure.includes("Connect this MCP") || failure.includes("409"), "Live MCP tool call fails after disconnect", failure);
+            },
+            screenshot: { name: "mcp-disconnected", requireText: [stateString(ctx, "connectionName"), "Not connected"], rejectText: ["Something went wrong", "Connection failed"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Reconnect restores the live MCP tool",
+      run: async (ctx) => {
+        const alexWeb = ctx.surfaces.get("mcp-admin-web");
+        await ctx.on(alexWeb, async () => {
+          await ctx.prove("Revalidating the no-auth server reconnects the same row and restores live tool execution", {
+            voiceover: vo[4],
+            action: async () => {
+              const reconnected = await mcp.reconnectNoAuthConnection(ctx, {
+                actor: ctx.actors.alex,
+                organizationId: stateString(ctx, "orgId"),
+                connectionId: stateString(ctx, "connectionId"),
+                url: reconnectMcpUrl(ctx),
+              });
+              witness(ctx, reconnected.connected && reconnected.connectedForMe, "No-auth MCP reconnect reports connected", reconnected);
+              await showMcpConnections(ctx, alexWeb);
+              await scrollConnectionIntoView(ctx, stateString(ctx, "connectionName"));
+            },
+            assert: async () => {
+              await ctx.expectText("Connected", { timeoutMs: 60_000 });
+              const result = await mcp.expectUsableConnection(ctx, {
+                actor: ctx.actors.alex,
+                organizationId: stateString(ctx, "orgId"),
+                connectionId: stateString(ctx, "connectionId"),
+                connectionName: stateString(ctx, "connectionName"),
+                uiConnected: true,
+                expectedText: RECONNECT_ECHO_TEXT,
+              });
+              ctx.output("reconnect-live-mcp-result", mcp.mcpTextContent(result));
+            },
+            screenshot: { name: "mcp-reconnected", requireText: [stateString(ctx, "connectionName"), "Connected"], rejectText: ["Not connected", "Something went wrong", "Connection failed"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Never-connected OAuth MCP asks to connect, not reconnect",
+      run: async (ctx) => {
+        const alexWeb = ctx.surfaces.get("mcp-admin-web");
+        await ctx.on(alexWeb, async () => {
+          const neverName = `${connectionPrefix(ctx)}-never-connected`;
+          await ctx.prove("A newly published OAuth MCP row shows a first-time Connect state without a false reconnect prompt", {
+            voiceover: vo[5],
+            action: async () => {
+              const created = await mcp.createOAuthConnection(ctx, {
+                actor: ctx.actors.alex,
+                organizationId: stateString(ctx, "orgId"),
+                name: neverName,
+                url: `${mockBase(ctx)}/mcp`,
+                access: { orgWide: true },
+              });
+              ctx.state.neverConnectionId = created.id;
+              ctx.state.neverConnectionName = created.name;
+              witness(ctx, created.connected === false && created.connectedForMe === false, "Never-connected OAuth MCP starts disconnected", created);
+              await showMcpConnections(ctx, alexWeb);
+              await scrollConnectionIntoView(ctx, stateString(ctx, "neverConnectionName"));
+            },
+            assert: async () => {
+              const row = await connectionRowText(ctx, stateString(ctx, "neverConnectionName"));
+              witness(ctx, row.includes("Not connected") && row.includes("Connect"), "Never-connected MCP row offers first-time Connect", row);
+              witness(ctx, !row.includes("Reconnect") && !row.toLowerCase().includes("needs your sign-in"), "Never-connected MCP row does not show a false reconnect prompt", row);
+            },
+            screenshot: { name: "mcp-never-connected", requireText: [neverName, "Not connected", "Connect"], rejectText: ["Reconnect required", "needs your sign-in", "needs your sign in", "Connection failed"] },
+          });
+        });
+      },
+    },
+    {
+      name: "Direct MCP catalog and tool call work",
+      run: async (ctx) => {
+        await ctx.prove("The direct Den MCP connection endpoints list and execute mock_echo", {
+          voiceover: vo[6],
+          action: async () => {
+            const tools = await mcp.listConnectionTools(ctx, {
+              actor: ctx.actors.alex,
+              organizationId: stateString(ctx, "orgId"),
+              connectionId: stateString(ctx, "connectionId"),
+            });
+            const names = tools.map((tool) => toolName(tool)).filter(Boolean);
+            witness(ctx, names.includes("mock_echo"), "The live MCP tool catalog includes mock_echo", names);
+            const result = await mcp.runConnectionTool(ctx, {
+              actor: ctx.actors.alex,
+              organizationId: stateString(ctx, "orgId"),
+              connectionId: stateString(ctx, "connectionId"),
+              toolName: "mock_echo",
+              arguments: { text: DIRECT_ECHO_TEXT },
+            });
+            const text = mcp.mcpTextContent(result);
+            ctx.state.directEcho = text;
+            ctx.output("direct-mcp-result", text);
+          },
+          assert: async () => {
+            witness(ctx, stateString(ctx, "directEcho").includes(DIRECT_ECHO_TEXT), "Direct MCP tool execution echoes the proof text", stateString(ctx, "directEcho"));
+          },
+        });
+      },
+    },
+    {
+      name: "Agent search and execute use the same connection",
+      run: async (ctx) => {
+        await ctx.prove("search_capabilities and execute_capability find and run mock_echo", {
+          voiceover: vo[7],
+          action: async () => {
+            const mcpToken = await mcp.mintMcpToken(ctx, {
+              actor: ctx.actors.alex,
+              organizationId: stateString(ctx, "orgId"),
+              scopes: ["mcp:read", "mcp:write"],
+            });
+            const matches = await mcp.searchCapabilities(ctx, {
+              actor: ctx.actors.alex,
+              organizationId: stateString(ctx, "orgId"),
+              mcpToken,
+              query: "mock echo",
+              limit: 10,
+              type: "mcp",
+            });
+            const match = selectMockEchoMatch(ctx, matches);
+            witness(ctx, Boolean(match?.name), "search_capabilities finds the mock_echo capability", matches.map((entry) => ({ name: entry.name, summary: entry.summary, schemaDigest: entry.schemaDigest })));
+            ctx.state.matchName = match.name;
+            const result = await mcp.executeCapability(ctx, {
+              actor: ctx.actors.alex,
+              organizationId: stateString(ctx, "orgId"),
+              mcpToken,
+              name: match.name,
+              schemaDigest: match.schemaDigest,
+              body: { text: AGENT_ECHO_TEXT },
+            });
+            const text = mcp.mcpTextContent(result);
+            ctx.state.agentEcho = text;
+            ctx.output("agent-mcp-result", text);
+          },
+          assert: async () => {
+            witness(ctx, stateString(ctx, "agentEcho").includes(AGENT_ECHO_TEXT), "execute_capability echoes the proof text", stateString(ctx, "agentEcho"));
+          },
+        });
+      },
+    },
+    {
+      name: "Cleanup and desktop gate",
+      run: async (ctx) => {
+        await ctx.prove("Cleanup removes the MCP connection and the desktop cell is explicitly skipped", {
+          voiceover: vo[8],
+          action: async () => {
+            await mcp.deleteConnectionsByPrefix(ctx, {
+              actor: ctx.actors.alex,
+              organizationId: stateString(ctx, "orgId"),
+              prefix: connectionPrefix(ctx),
+            });
+            const desktopGate = ctx.env.OPENWORK_EVAL_DESKTOP_SURFACE?.trim() ? "requested" : "not requested";
+            ctx.skip(`Electron desktop surface ${desktopGate}; ${FLOW_ID} is intentionally web-only.`);
+            ctx.output("desktop-surface-gate", `OPENWORK_EVAL_DESKTOP_SURFACE=${ctx.env.OPENWORK_EVAL_DESKTOP_SURFACE ?? ""}`);
+            await stopMockFixture(ctx);
+          },
+          assert: async () => {
+            const connections = await mcp.listManageableConnections(ctx, {
+              actor: ctx.actors.alex,
+              organizationId: stateString(ctx, "orgId"),
+            });
+            witness(ctx, !connections.some((connection) => connection.id === stateString(ctx, "connectionId")), "Temporary MCP connection is removed during cleanup", connections.map((connection) => ({ id: connection.id, name: connection.name })));
+          },
+        });
+      },
+    },
+  ],
+});

--- a/evals/runner/cli.ts
+++ b/evals/runner/cli.ts
@@ -6,7 +6,7 @@ import { denStackDown, ensureDenStack } from "./den-stack.ts";
 import { applyManifestToEnv, readEnvManifest } from "./env-manifest.ts";
 import { createDaytonaHost } from "./hosts/daytona.ts";
 import { createLocalHost } from "./hosts/local.ts";
-import { missingEnv, loadFlows, runFlow } from "./runner.ts";
+import { missingEnv, loadFlows, runFlow, runFlowRepeated } from "./runner.ts";
 import { renderMarkdown } from "./reporters/markdown.ts";
 import { renderFrameIndex } from "./reporters/fraimz-html.ts";
 import { postPrComment } from "./reporters/pr.ts";
@@ -45,6 +45,7 @@ interface CliArgs {
   help: boolean;
   mode: EvalMode;
   envName: string | null;
+  repeat: number;
 }
 
 function readRequiredValue(argv: string[], index: number, flag: string): string {
@@ -68,6 +69,7 @@ export function parseArgs(argv: string[]): CliArgs {
     help: false,
     mode: "demo",
     envName: null,
+    repeat: 1,
   };
   for (let index = 0; index < argv.length; index += 1) {
     const value = argv[index];
@@ -94,6 +96,12 @@ export function parseArgs(argv: string[]): CliArgs {
       index += 1;
     } else if (value === "--env") {
       args.envName = readRequiredValue(argv, index, value);
+      index += 1;
+    } else if (value === "--repeat") {
+      const repeat = readRequiredValue(argv, index, value);
+      if (!/^\d+$/.test(repeat)) throw new Error(`--repeat must be an integer >= 1, got ${repeat}.`);
+      args.repeat = Number.parseInt(repeat, 10);
+      if (args.repeat < 1) throw new Error(`--repeat must be an integer >= 1, got ${repeat}.`);
       index += 1;
     } else if (value === "--stack-down") args.stackDown = true;
     else if (value === "scaffold") {
@@ -133,6 +141,28 @@ async function selectedStackNeedsApp(args: CliArgs): Promise<boolean> {
     if (!source || !/requiresApp\s*:\s*false/.test(source)) return true;
   }
   return false;
+}
+
+function orgModeFromSource(source: string): "single_org" | "multi_org" | null {
+  const singleOrg = /orgMode\s*:\s*["']single_org["']/.test(source);
+  const multiOrg = /orgMode\s*:\s*["']multi_org["']/.test(source);
+  if (singleOrg === multiOrg) return null;
+  if (multiOrg) return "multi_org";
+  return "single_org";
+}
+
+async function selectedStackOrgMode(args: CliArgs): Promise<"single_org" | "multi_org" | undefined> {
+  if (args.list || args.all || args.flows.length === 0) return undefined;
+  let selected: "single_org" | "multi_org" | null = null;
+  for (const flowId of args.flows) {
+    const source = await readFlowSource(flowId);
+    if (!source) return undefined;
+    const orgMode = orgModeFromSource(source);
+    if (!orgMode) continue;
+    if (selected && selected !== orgMode) return undefined;
+    selected = orgMode;
+  }
+  return selected ?? undefined;
 }
 
 function incrementSummary(summary: Record<FlowStatus, number>, status: FlowStatus): void {
@@ -188,7 +218,7 @@ export function createEvalHosts({ manifest, env, repoRoot, log }: { manifest: En
 }
 
 function printHelp(): void {
-  console.log("Usage: node evals/runner/run.mjs [--mode automation|demo] [--list | --all | --flow <id> ... | scaffold <id> [--force]] [--cdp-url <url>] [--env <name>] [--out <dir>] [--pr [number]] [--stack den | --stack-down]");
+  console.log("Usage: node evals/runner/run.mjs [--mode automation|demo] [--list | --all | --flow <id> ... | scaffold <id> [--force]] [--cdp-url <url>] [--env <name>] [--repeat <n>] [--out <dir>] [--pr [number]] [--stack den | --stack-down]");
 }
 
 export async function main(argv: string[] = process.argv.slice(2)): Promise<void> {
@@ -222,10 +252,13 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
   }
 
   if (args.stack === "den") {
+    const orgMode = await selectedStackOrgMode(args);
+    if (orgMode) console.log(`▸ Selected flow Den orgMode: ${orgMode}`);
     await ensureDenStack({
       log: (msg) => console.log(`▸ ${msg}`),
       cdpCandidates: args.cdpUrl ? [args.cdpUrl] : DEFAULT_CDP_CANDIDATES,
       skipApp: !(await selectedStackNeedsApp(args)),
+      orgMode,
     });
   } else if (args.stack) {
     throw new Error(`Unknown stack: ${args.stack}. Supported: den`);
@@ -279,15 +312,31 @@ export async function main(argv: string[] = process.argv.slice(2)): Promise<void
   });
 
   for (const flow of selected) {
-    console.log(`▶ ${flow.id} — ${flow.title}`);
-    const result = await runFlow(flow, { cdpBaseUrl, outDir, env: process.env, mode: args.mode, hosts, defaultHostKind, manifest });
-    report.flows.push(result);
-    incrementSummary(report.summary, result.status);
-    for (const step of result.steps) {
-      const icon = step.status === "passed" ? "  ✓" : "  ✗";
-      console.log(`${icon} ${step.name} (${step.durationMs}ms)${step.error ? ` — ${step.error}` : ""}`);
+    console.log(`▶ ${flow.id} — ${flow.title}${args.repeat > 1 ? ` (repeat ${args.repeat})` : ""}`);
+    if (args.repeat === 1) {
+      const result = await runFlow(flow, { cdpBaseUrl, outDir, env: process.env, mode: args.mode, hosts, defaultHostKind, manifest });
+      report.flows.push(result);
+      incrementSummary(report.summary, result.status);
+      for (const step of result.steps) {
+        const icon = step.status === "passed" ? "  ✓" : "  ✗";
+        console.log(`${icon} ${step.name} (${step.durationMs}ms)${step.error ? ` — ${step.error}` : ""}`);
+      }
+      if (result.skipReason) console.log(`  ⏭ skipped: ${result.skipReason}`);
+    } else {
+      const repeatRunStamp = process.env.OPENWORK_EVAL_RUNSTAMP?.trim() || process.env.OPENWORK_EVAL_RUN_STAMP?.trim() || runId;
+      const repeated = await runFlowRepeated(flow, { cdpBaseUrl, outDir, env: process.env, mode: args.mode, hosts, defaultHostKind, manifest, repeat: args.repeat, runStamp: repeatRunStamp });
+      report.flows.push(...repeated.results);
+      report.soak = [...(report.soak ?? []), repeated.summary];
+      incrementSummary(report.summary, repeated.summary.status);
+      console.log(`  Soak: ${repeated.summary.passed} passed, ${repeated.summary.failed} failed, ${repeated.summary.skipped} skipped; captured iterations ${repeated.summary.capturedIterations.join(", ")}`);
+      for (const result of repeated.results) {
+        for (const step of result.steps) {
+          const icon = step.status === "passed" ? "  ✓" : "  ✗";
+          console.log(`${icon} ${result.id} · ${step.name} (${step.durationMs}ms)${step.error ? ` — ${step.error}` : ""}`);
+        }
+        if (result.skipReason) console.log(`  ⏭ ${result.id} skipped: ${result.skipReason}`);
+      }
     }
-    if (result.skipReason) console.log(`  ⏭ skipped: ${result.skipReason}`);
   }
 
   report.finishedAt = new Date().toISOString();

--- a/evals/runner/den-stack.ts
+++ b/evals/runner/den-stack.ts
@@ -588,6 +588,7 @@ export async function ensureDenOrgMode(orgMode: DenOrgMode | undefined, log: (me
   log(`Den orgMode ${detail}; restarting den-api and den-web for ${orgMode}.`);
   await stopRecordedProcess("den-api.pid", "den-api", log);
   await stopRecordedProcess("den-web.pid", "den-web", log);
+  await freePorts([DEN_API_PORT, DEN_API_INTERNAL_PORT, Number(DEN_WEB_PORT)].filter((port) => Number.isInteger(port) && port > 0), log, "Den orgMode restart");
   await clearDenWebBuildCache();
 }
 
@@ -650,18 +651,15 @@ async function ensureSeed(log: (message: string) => void): Promise<void> {
   log("Demo org seeded");
 }
 
-async function freeStaleAppPorts(log: (message: string) => void): Promise<void> {
-  // If no app page target is serving but the dev ports are held, a previous
-  // run left a half-dead app behind (e.g. Electron without its renderer).
-  // Clear them so the fresh spawn does not lose the bind race.
-  for (const port of [9823, 5173]) {
+async function freePorts(ports: number[], log: (message: string) => void, reason: string): Promise<void> {
+  for (const port of ports) {
     try {
       const { stdout } = await run("lsof", ["-nP", "-ti", `tcp:${port}`]);
       const pids = stdout.split("\n").map((line) => line.trim()).filter(Boolean);
       for (const pid of pids) {
         try {
           process.kill(Number(pid), "SIGKILL");
-          log(`Cleared stale process ${pid} holding :${port}`);
+          log(`Cleared process ${pid} holding :${port} (${reason})`);
         } catch {
           // Already gone.
         }
@@ -671,6 +669,13 @@ async function freeStaleAppPorts(log: (message: string) => void): Promise<void> 
     }
   }
   await sleep(1_500);
+}
+
+async function freeStaleAppPorts(log: (message: string) => void): Promise<void> {
+  // If no app page target is serving but the dev ports are held, a previous
+  // run left a half-dead app behind (e.g. Electron without its renderer).
+  // Clear them so the fresh spawn does not lose the bind race.
+  await freePorts([9823, 5173], log, "stale app cleanup");
 }
 
 async function ensureApp(log: (message: string) => void, cdpCandidates: string[]): Promise<void> {

--- a/evals/runner/flow.ts
+++ b/evals/runner/flow.ts
@@ -206,6 +206,25 @@ export interface FlowResult {
   evidenceFrames?: FrameEvidenceInput[];
 }
 
+export interface SoakFailure {
+  iteration: number;
+  step: string | null;
+  error: string | null;
+}
+
+export interface SoakSummary {
+  flowId: string;
+  title: string;
+  repeat: number;
+  status: FlowStatus;
+  passed: number;
+  failed: number;
+  skipped: number;
+  durationMs: number;
+  capturedIterations: number[];
+  failures: SoakFailure[];
+}
+
 export interface EvalReport {
   runId: string;
   startedAt: string;
@@ -214,6 +233,7 @@ export interface EvalReport {
   mode: EvalMode;
   flows: FlowResult[];
   summary: Record<FlowStatus, number>;
+  soak?: SoakSummary[];
 }
 
 export function defineFlow(flow: FlowDefinition): FlowDefinition {

--- a/evals/runner/hosts/local.ts
+++ b/evals/runner/hosts/local.ts
@@ -200,6 +200,7 @@ function chromeArgs(cdpPort: number, profileDir: string, startUrl: string, headl
   const args = [
     `--remote-debugging-port=${cdpPort}`,
     `--user-data-dir=${profileDir}`,
+    "--window-size=1280,900",
     "--no-first-run",
     "--no-default-browser-check",
     "--disable-popup-blocking",
@@ -455,7 +456,7 @@ export function createLocalHost(options: LocalHostOptions): Host {
       };
       let spawned: SpawnedDetached;
       try {
-        spawned = await launch(false);
+        spawned = await launch(opts.headless === true || process.env.OPENWORK_EVAL_CHROME_HEADLESS === "1");
       } catch (error) {
         if (!messageText(error).includes("SIGTRAP")) throw error;
         log(`Chrome surface ${name} exited with SIGTRAP under the windowed launch; retrying with --headless=new.`);

--- a/evals/runner/hosts/types.ts
+++ b/evals/runner/hosts/types.ts
@@ -24,6 +24,7 @@ export interface ElectronSurfaceOptions {
 export interface ChromeSurfaceOptions {
   profile?: "fresh" | "shared";
   startUrl?: string;
+  headless?: boolean;
 }
 
 export interface DenServiceOptions {

--- a/evals/runner/journeys.test.ts
+++ b/evals/runner/journeys.test.ts
@@ -10,6 +10,7 @@ import {
   resolveDenWebUrl,
   validateActor,
 } from "./journeys/den.ts";
+import { capabilityMatchesFromSearchResult, mcpTextContent } from "./journeys/mcp.ts";
 
 test("Den URL helpers trim bases and build invite URLs", () => {
   const env: NodeJS.ProcessEnv = {
@@ -64,4 +65,34 @@ test("actor validation accepts complete actors and rejects incomplete shapes", (
     () => validateActor({ email: "missing@example.test", role: "fresh" }),
     (error) => error instanceof EvalError && error.message.includes("name, email, password, and role"),
   );
+});
+
+test("MCP journey helpers read text content and search_capabilities matches", () => {
+  const searchResult = {
+    content: [
+      {
+        type: "text",
+        text: JSON.stringify({
+          matches: [
+            {
+              name: "mcp:connection:mock_echo",
+              summary: "Mock echo from reliability connection",
+              schemaDigest: "digest-1",
+              argumentsSchema: { type: "object" },
+            },
+          ],
+        }),
+      },
+    ],
+  };
+
+  assert.equal(mcpTextContent({ content: [{ type: "text", text: "hello" }] }), "hello");
+  assert.deepEqual(capabilityMatchesFromSearchResult(searchResult), [
+    {
+      name: "mcp:connection:mock_echo",
+      summary: "Mock echo from reliability connection",
+      schemaDigest: "digest-1",
+      argumentsSchema: { type: "object" },
+    },
+  ]);
 });

--- a/evals/runner/journeys/index.ts
+++ b/evals/runner/journeys/index.ts
@@ -1,8 +1,10 @@
 export * from "./den.ts";
 export * from "./desktop.ts";
+export * from "./mcp.ts";
 
 import { acceptInvite, apiSignIn, createOrg, inviteMember, signInWeb, signUpWeb } from "./den.ts";
 import { connectDen, firstBoot, openSettings, runPrompt } from "./desktop.ts";
+import { createNoAuthConnection, createOAuthConnection, deleteConnection, deleteConnectionsByPrefix, disconnectConnection, executeCapability, expectUsableConnection, listConnectionTools, listManageableConnections, mcpAgentCall, mcpTextContent, mintMcpToken, openMcpConnections, reconnectNoAuthConnection, runConnectionTool, searchCapabilities, startMockMcpServer, waitForConnectionConnected } from "./mcp.ts";
 
 export const journeys = {
   den: {
@@ -18,5 +20,25 @@ export const journeys = {
     connectDen,
     runPrompt,
     openSettings,
+  },
+  mcp: {
+    createNoAuthConnection,
+    createOAuthConnection,
+    deleteConnection,
+    deleteConnectionsByPrefix,
+    disconnectConnection,
+    executeCapability,
+    expectUsableConnection,
+    listConnectionTools,
+    listManageableConnections,
+    mcpAgentCall,
+    mcpTextContent,
+    mintMcpToken,
+    openMcpConnections,
+    reconnectNoAuthConnection,
+    runConnectionTool,
+    searchCapabilities,
+    startMockMcpServer,
+    waitForConnectionConnected,
   },
 };

--- a/evals/runner/journeys/mcp.mjs
+++ b/evals/runner/journeys/mcp.mjs
@@ -1,0 +1,1 @@
+export * from "./mcp.ts";

--- a/evals/runner/journeys/mcp.ts
+++ b/evals/runner/journeys/mcp.ts
@@ -1,0 +1,618 @@
+import { spawn } from "node:child_process";
+import { openSync } from "node:fs";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { EvalError } from "../context.ts";
+import { allocateFreePort } from "../ports.ts";
+import { apiSignIn, denApiFetch, denWebUrl, validateActor } from "./den.ts";
+import type { ChildProcess } from "node:child_process";
+import type { Actor } from "../actors.ts";
+import type { FlowContext } from "../flow.ts";
+import type { Surface } from "../surfaces.ts";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const MOCK_SERVER_SCRIPT = join(REPO_ROOT, "scripts", "mock-oauth-mcp-server.mjs");
+const MCP_CONNECTIONS_SCREEN_READY = "document.body.innerText.includes('Connectors') || document.body.innerText.includes('Add MCP') || document.body.innerText.includes('MCP Connections') || document.body.innerText.includes('Add a custom MCP server')";
+
+export type McpAuthType = "oauth" | "apikey" | "none";
+
+export interface McpAccessSummary {
+  orgWide: boolean;
+  memberIds: string[];
+  teamIds: string[];
+}
+
+export interface McpConnection {
+  id: string;
+  name: string;
+  url: string;
+  authType: McpAuthType;
+  credentialMode: "shared" | "per_member";
+  connected: boolean;
+  connectedForMe: boolean;
+  connectedAt?: string | null;
+  updatedAt?: string;
+  needsReconnect?: boolean;
+  credentialHealth?: string;
+  access?: McpAccessSummary | null;
+}
+
+export interface CreateNoAuthConnectionOptions {
+  actor: Actor;
+  name: string;
+  url: string;
+  token?: string;
+  organizationId?: string;
+  access?: Partial<McpAccessSummary>;
+}
+
+export interface CreateOAuthConnectionOptions {
+  actor: Actor;
+  name: string;
+  url: string;
+  token?: string;
+  organizationId?: string;
+  credentialMode?: "shared" | "per_member";
+  requestedScopes?: string[];
+  access?: Partial<McpAccessSummary>;
+}
+
+export interface ListConnectionsOptions {
+  actor: Actor;
+  token?: string;
+  organizationId?: string;
+}
+
+export interface ConnectionByIdOptions extends ListConnectionsOptions {
+  connectionId: string;
+}
+
+export interface ReconnectNoAuthConnectionOptions extends ConnectionByIdOptions {
+  url: string;
+}
+
+export interface RunConnectionToolOptions extends ConnectionByIdOptions {
+  toolName: string;
+  arguments: Record<string, unknown>;
+}
+
+export interface MintMcpTokenOptions extends ListConnectionsOptions {
+  scopes?: string[];
+}
+
+export interface McpAgentCallOptions {
+  mcpToken: string;
+  method: string;
+  params?: Record<string, unknown>;
+}
+
+export interface CapabilityMatch {
+  name: string;
+  summary: string;
+  schemaDigest?: string;
+  argumentsSchema?: unknown;
+}
+
+export interface SearchCapabilitiesOptions extends MintMcpTokenOptions {
+  query: string;
+  limit?: number;
+  type?: string;
+  mcpToken?: string;
+}
+
+export interface ExecuteCapabilityOptions extends MintMcpTokenOptions {
+  name: string;
+  body?: Record<string, unknown>;
+  schemaDigest?: string;
+  mcpToken?: string;
+}
+
+export interface OpenMcpConnectionsOptions {
+  surface: string | Surface;
+}
+
+export interface MockMcpServerFixture {
+  url: string;
+  logPath: string;
+  stop(): Promise<void>;
+}
+
+export interface StartMockMcpServerOptions {
+  port?: number;
+  allowUnauthenticated?: boolean;
+}
+
+export interface ExpectUsableConnectionOptions extends ConnectionByIdOptions {
+  uiConnected: boolean;
+  connectionName: string;
+  toolName?: string;
+  arguments?: Record<string, unknown>;
+  expectedText?: string;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function stringField(record: Record<string, unknown>, key: string): string {
+  const value = record[key];
+  return typeof value === "string" ? value.trim() : "";
+}
+
+function booleanField(record: Record<string, unknown>, key: string): boolean {
+  return record[key] === true;
+}
+
+function authType(value: unknown): McpAuthType | null {
+  if (value === "oauth" || value === "apikey" || value === "none") return value;
+  return null;
+}
+
+function credentialMode(value: unknown): "shared" | "per_member" | null {
+  if (value === "shared" || value === "per_member") return value;
+  return null;
+}
+
+function accessSummary(value: unknown): McpAccessSummary | null {
+  if (!isRecord(value)) return null;
+  return {
+    orgWide: value.orgWide === true,
+    memberIds: Array.isArray(value.memberIds) ? value.memberIds.filter((entry) => typeof entry === "string") : [],
+    teamIds: Array.isArray(value.teamIds) ? value.teamIds.filter((entry) => typeof entry === "string") : [],
+  };
+}
+
+function mcpConnection(value: unknown): McpConnection | null {
+  if (!isRecord(value)) return null;
+  const parsedAuthType = authType(value.authType);
+  const parsedCredentialMode = credentialMode(value.credentialMode);
+  const id = stringField(value, "id");
+  const name = stringField(value, "name");
+  const url = stringField(value, "url");
+  if (!id || !name || !url || !parsedAuthType || !parsedCredentialMode) return null;
+  const connection: McpConnection = {
+    id,
+    name,
+    url,
+    authType: parsedAuthType,
+    credentialMode: parsedCredentialMode,
+    connected: booleanField(value, "connected"),
+    connectedForMe: booleanField(value, "connectedForMe"),
+  };
+  if (typeof value.connectedAt === "string" || value.connectedAt === null) connection.connectedAt = value.connectedAt;
+  if (typeof value.updatedAt === "string") connection.updatedAt = value.updatedAt;
+  if (typeof value.needsReconnect === "boolean") connection.needsReconnect = value.needsReconnect;
+  if (typeof value.credentialHealth === "string") connection.credentialHealth = value.credentialHealth;
+  if (value.access === null) connection.access = null;
+  else {
+    const access = accessSummary(value.access);
+    if (access) connection.access = access;
+  }
+  return connection;
+}
+
+function connectionsFromBody(body: unknown): McpConnection[] {
+  const entries = isRecord(body) && Array.isArray(body.connections) ? body.connections : [];
+  return entries.flatMap((entry) => {
+    const connection = mcpConnection(entry);
+    return connection ? [connection] : [];
+  });
+}
+
+function authHeaders(token: string, organizationId?: string): Headers {
+  const headers = new Headers();
+  headers.set("authorization", `Bearer ${token}`);
+  if (organizationId) headers.set("x-openwork-org-id", organizationId);
+  return headers;
+}
+
+async function sessionToken(ctx: FlowContext, actor: Actor, token?: string): Promise<string> {
+  const configured = token?.trim();
+  if (configured) return configured;
+  return apiSignIn(ctx, { actor });
+}
+
+function responseBodySnippet(body: unknown): string {
+  try {
+    return JSON.stringify(body).slice(0, 500);
+  } catch {
+    return String(body).slice(0, 500);
+  }
+}
+
+function stopChild(child: ChildProcess): Promise<void> {
+  return new Promise((resolveStop) => {
+    if (!child.pid || child.exitCode !== null) {
+      resolveStop();
+      return;
+    }
+    const timer = setTimeout(() => {
+      child.kill("SIGKILL");
+      resolveStop();
+    }, 5_000);
+    child.once("exit", () => {
+      clearTimeout(timer);
+      resolveStop();
+    });
+    child.kill("SIGINT");
+  });
+}
+
+async function waitForMockHealth(url: string): Promise<void> {
+  const startedAt = Date.now();
+  let lastError = "not attempted";
+  while (Date.now() - startedAt < 15_000) {
+    try {
+      const response = await fetch(`${url}/health`);
+      if (response.ok) return;
+      lastError = `HTTP ${response.status}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    await new Promise((resolveWait) => setTimeout(resolveWait, 250));
+  }
+  throw new EvalError(`Mock MCP server did not become healthy at ${url}: ${lastError}`);
+}
+
+export async function startMockMcpServer(ctx: FlowContext, options: StartMockMcpServerOptions = {}): Promise<MockMcpServerFixture> {
+  const port = options.port ?? await allocateFreePort();
+  const url = `http://127.0.0.1:${port}`;
+  const logPath = join(ctx.outDir, `${ctx.flowId}-mock-oauth-mcp.log`);
+  const logFd = openSync(logPath, "a");
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    HOST: "127.0.0.1",
+    PORT: String(port),
+    ISSUER: url,
+    MOCK_ALLOW_UNAUTHENTICATED_MCP: options.allowUnauthenticated === false ? "0" : "1",
+  };
+  const child = spawn(process.execPath, [MOCK_SERVER_SCRIPT], {
+    cwd: REPO_ROOT,
+    env,
+    stdio: ["ignore", logFd, logFd],
+  });
+  child.unref();
+  const killOnExit = () => {
+    if (child.pid && child.exitCode === null) child.kill("SIGKILL");
+  };
+  process.once("exit", killOnExit);
+  await waitForMockHealth(url);
+  ctx.log(`Started mock MCP fixture at ${url}; log ${logPath}`);
+  return {
+    url,
+    logPath,
+    stop: async () => {
+      process.removeListener("exit", killOnExit);
+      await stopChild(child);
+      ctx.log(`Stopped mock MCP fixture at ${url}.`);
+    },
+  };
+}
+
+export function mcpTextContent(result: unknown): string {
+  if (!isRecord(result) || !Array.isArray(result.content)) return "";
+  return result.content
+    .map((entry) => isRecord(entry) && typeof entry.text === "string" ? entry.text : "")
+    .filter(Boolean)
+    .join("\n");
+}
+
+export function capabilityMatchesFromSearchResult(result: unknown): CapabilityMatch[] {
+  const text = mcpTextContent(result).trim();
+  if (!text) return [];
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(text);
+  } catch {
+    return [];
+  }
+  const matches = isRecord(parsed) && Array.isArray(parsed.matches) ? parsed.matches : [];
+  return matches.flatMap((entry) => {
+    if (!isRecord(entry)) return [];
+    const name = stringField(entry, "name");
+    const summary = stringField(entry, "summary");
+    if (!name) return [];
+    return [{
+      name,
+      summary,
+      ...(typeof entry.schemaDigest === "string" && entry.schemaDigest.trim() ? { schemaDigest: entry.schemaDigest.trim() } : {}),
+      ...(entry.argumentsSchema !== undefined ? { argumentsSchema: entry.argumentsSchema } : {}),
+    }];
+  });
+}
+
+export async function listManageableConnections(ctx: FlowContext, options: ListConnectionsOptions): Promise<McpConnection[]> {
+  const actor = validateActor(options.actor);
+  const token = await sessionToken(ctx, actor, options.token);
+  const listed = await denApiFetch(ctx, "/v1/mcp-connections?scope=manageable", {
+    headers: authHeaders(token, options.organizationId),
+  });
+  if (!listed.response.ok) {
+    throw new EvalError(`Listing manageable MCP connections failed: ${listed.response.status} ${listed.text.slice(0, 300)}`);
+  }
+  return connectionsFromBody(listed.body);
+}
+
+export async function createNoAuthConnection(ctx: FlowContext, options: CreateNoAuthConnectionOptions): Promise<McpConnection> {
+  const actor = validateActor(options.actor);
+  const token = await sessionToken(ctx, actor, options.token);
+  const access = {
+    orgWide: options.access?.orgWide ?? true,
+    memberIds: options.access?.memberIds ?? [],
+    teamIds: options.access?.teamIds ?? [],
+  };
+  // Provenance: evals/flows/cloud-web-connect-e2e.flow.mjs:369-377 creates
+  // no-auth MCP connections through POST /v1/mcp-connections and grants
+  // org-wide access explicitly.
+  const created = await denApiFetch(ctx, "/v1/mcp-connections", {
+    method: "POST",
+    headers: authHeaders(token, options.organizationId),
+    body: JSON.stringify({
+      name: options.name,
+      url: options.url,
+      authType: "none",
+      access,
+    }),
+  });
+  if (!created.response.ok) {
+    throw new EvalError(`Creating no-auth MCP connection failed: ${created.response.status} ${created.text.slice(0, 500)}`);
+  }
+  const connection = mcpConnection(created.body);
+  if (!connection) throw new EvalError(`MCP connection create response did not include a connection: ${responseBodySnippet(created.body)}`);
+  return connection;
+}
+
+export async function createOAuthConnection(ctx: FlowContext, options: CreateOAuthConnectionOptions): Promise<McpConnection> {
+  const actor = validateActor(options.actor);
+  const token = await sessionToken(ctx, actor, options.token);
+  const access = {
+    orgWide: options.access?.orgWide ?? true,
+    memberIds: options.access?.memberIds ?? [],
+    teamIds: options.access?.teamIds ?? [],
+  };
+  const created = await denApiFetch(ctx, "/v1/mcp-connections", {
+    method: "POST",
+    headers: authHeaders(token, options.organizationId),
+    body: JSON.stringify({
+      name: options.name,
+      url: options.url,
+      authType: "oauth",
+      credentialMode: options.credentialMode ?? "shared",
+      requestedScopes: options.requestedScopes ?? [],
+      access,
+    }),
+  });
+  if (!created.response.ok) {
+    throw new EvalError(`Creating OAuth MCP connection failed: ${created.response.status} ${created.text.slice(0, 500)}`);
+  }
+  const connection = mcpConnection(created.body);
+  if (!connection) throw new EvalError(`OAuth MCP connection create response did not include a connection: ${responseBodySnippet(created.body)}`);
+  return connection;
+}
+
+export async function disconnectConnection(ctx: FlowContext, options: ConnectionByIdOptions): Promise<void> {
+  const actor = validateActor(options.actor);
+  const token = await sessionToken(ctx, actor, options.token);
+  const disconnected = await denApiFetch(ctx, `/v1/mcp-connections/${encodeURIComponent(options.connectionId)}/disconnect`, {
+    method: "POST",
+    headers: authHeaders(token, options.organizationId),
+  });
+  if (!disconnected.response.ok) {
+    throw new EvalError(`Disconnecting MCP connection ${options.connectionId} failed: ${disconnected.response.status} ${disconnected.text.slice(0, 300)}`);
+  }
+}
+
+export async function reconnectNoAuthConnection(ctx: FlowContext, options: ReconnectNoAuthConnectionOptions): Promise<McpConnection> {
+  const actor = validateActor(options.actor);
+  const token = await sessionToken(ctx, actor, options.token);
+  const connections = await listManageableConnections(ctx, { ...options, token });
+  const connection = connections.find((entry) => entry.id === options.connectionId);
+  if (!connection) throw new EvalError(`MCP connection ${options.connectionId} was not found before reconnect.`);
+  if (connection.authType !== "none") throw new EvalError(`MCP connection ${options.connectionId} is ${connection.authType}, not no-auth.`);
+  if (!connection.updatedAt) throw new EvalError(`MCP connection ${options.connectionId} did not include updatedAt for reconnect.`);
+  const access = connection.access ?? { orgWide: true, memberIds: [], teamIds: [] };
+  const updated = await denApiFetch(ctx, `/v1/mcp-connections/${encodeURIComponent(options.connectionId)}`, {
+    method: "PUT",
+    headers: authHeaders(token, options.organizationId),
+    body: JSON.stringify({
+      expectedUpdatedAt: connection.updatedAt,
+      name: connection.name,
+      url: options.url,
+      authType: "none",
+      credentialMode: connection.credentialMode,
+      access,
+    }),
+  });
+  if (!updated.response.ok) {
+    throw new EvalError(`Reconnecting no-auth MCP connection failed: ${updated.response.status} ${updated.text.slice(0, 500)}`);
+  }
+  const reconnected = mcpConnection(updated.body);
+  if (!reconnected) throw new EvalError(`MCP reconnect response did not include a connection: ${responseBodySnippet(updated.body)}`);
+  return reconnected;
+}
+
+export async function deleteConnection(ctx: FlowContext, options: ConnectionByIdOptions): Promise<void> {
+  const actor = validateActor(options.actor);
+  const token = await sessionToken(ctx, actor, options.token);
+  const removed = await denApiFetch(ctx, `/v1/mcp-connections/${encodeURIComponent(options.connectionId)}`, {
+    method: "DELETE",
+    headers: authHeaders(token, options.organizationId),
+  });
+  if (!removed.response.ok) {
+    throw new EvalError(`Deleting MCP connection ${options.connectionId} failed: ${removed.response.status} ${removed.text.slice(0, 300)}`);
+  }
+}
+
+export async function deleteConnectionsByPrefix(ctx: FlowContext, options: ListConnectionsOptions & { prefix: string }): Promise<number> {
+  const token = await sessionToken(ctx, validateActor(options.actor), options.token);
+  const connections = await listManageableConnections(ctx, { ...options, token });
+  let removed = 0;
+  for (const connection of connections) {
+    if (!connection.name.startsWith(options.prefix)) continue;
+    await deleteConnection(ctx, { ...options, token, connectionId: connection.id });
+    removed += 1;
+  }
+  return removed;
+}
+
+export async function waitForConnectionConnected(ctx: FlowContext, options: ListConnectionsOptions & { connectionId: string; timeoutMs?: number }): Promise<McpConnection> {
+  const token = await sessionToken(ctx, validateActor(options.actor), options.token);
+  const startedAt = Date.now();
+  const timeoutMs = options.timeoutMs ?? 60_000;
+  let last: McpConnection | null = null;
+  while (Date.now() - startedAt < timeoutMs) {
+    const connections = await listManageableConnections(ctx, { ...options, token });
+    last = connections.find((connection) => connection.id === options.connectionId) ?? null;
+    if (last?.connected && last.connectedForMe && last.needsReconnect !== true) return last;
+    await new Promise((resolve) => setTimeout(resolve, 1_000));
+  }
+  throw new EvalError(`MCP connection ${options.connectionId} did not become connected within ${timeoutMs}ms. Last state: ${responseBodySnippet(last)}`);
+}
+
+export async function listConnectionTools(ctx: FlowContext, options: ConnectionByIdOptions): Promise<unknown[]> {
+  const actor = validateActor(options.actor);
+  const token = await sessionToken(ctx, actor, options.token);
+  const tools = await denApiFetch(ctx, `/v1/mcp-connections/${encodeURIComponent(options.connectionId)}/tools`, {
+    headers: authHeaders(token, options.organizationId),
+  });
+  if (!tools.response.ok) {
+    throw new EvalError(`Listing MCP tools failed: ${tools.response.status} ${tools.text.slice(0, 500)}`);
+  }
+  return isRecord(tools.body) && Array.isArray(tools.body.tools) ? tools.body.tools : [];
+}
+
+export async function runConnectionTool(ctx: FlowContext, options: RunConnectionToolOptions): Promise<unknown> {
+  const actor = validateActor(options.actor);
+  const token = await sessionToken(ctx, actor, options.token);
+  const executed = await denApiFetch(ctx, `/v1/mcp-connections/${encodeURIComponent(options.connectionId)}/tools/call`, {
+    method: "POST",
+    headers: authHeaders(token, options.organizationId),
+    body: JSON.stringify({ toolName: options.toolName, arguments: options.arguments }),
+  });
+  if (!executed.response.ok) {
+    throw new EvalError(`Running MCP tool ${options.toolName} failed: ${executed.response.status} ${executed.text.slice(0, 500)}`);
+  }
+  return isRecord(executed.body) ? executed.body.result : executed.body;
+}
+
+export async function expectUsableConnection(ctx: FlowContext, options: ExpectUsableConnectionOptions): Promise<unknown> {
+  const toolName = options.toolName ?? "mock_echo";
+  try {
+    const result = await runConnectionTool(ctx, {
+      ...options,
+      toolName,
+      arguments: options.arguments ?? { text: options.expectedText ?? "mcp usable" },
+    });
+    if (options.expectedText) {
+      const text = mcpTextContent(result);
+      if (!text.includes(options.expectedText)) {
+        throw new EvalError(`live tool call returned ${JSON.stringify(text)}, expected ${JSON.stringify(options.expectedText)}`);
+      }
+    }
+    return result;
+  } catch (error) {
+    if (options.uiConnected) {
+      const detail = error instanceof Error ? error.message : String(error);
+      throw new EvalError(`UI reports connected but a live tool call failed for ${options.connectionName}: ${detail}`);
+    }
+    throw error;
+  }
+}
+
+export async function mintMcpToken(ctx: FlowContext, options: MintMcpTokenOptions): Promise<string> {
+  const actor = validateActor(options.actor);
+  const token = await sessionToken(ctx, actor, options.token);
+  // Provenance: evals/flows/lib/den-web.mjs:147-156 mints the agent-facing
+  // token through POST /v1/mcp/token before calling /mcp/agent.
+  const minted = await denApiFetch(ctx, "/v1/mcp/token", {
+    method: "POST",
+    headers: authHeaders(token, options.organizationId),
+    body: JSON.stringify(options.scopes ? { scopes: options.scopes } : {}),
+  });
+  if (!minted.response.ok || !isRecord(minted.body) || typeof minted.body.token !== "string" || !minted.body.token.trim()) {
+    throw new EvalError(`Minting MCP token failed: ${minted.response.status} ${minted.text.slice(0, 300)}`);
+  }
+  return minted.body.token;
+}
+
+export async function mcpAgentCall(ctx: FlowContext, options: McpAgentCallOptions): Promise<unknown> {
+  const apiUrl = ctx.env.OPENWORK_EVAL_DEN_API_URL?.trim().replace(/\/+$/, "");
+  if (!apiUrl) throw new EvalError("OPENWORK_EVAL_DEN_API_URL is required for MCP agent calls.");
+  // Provenance: evals/flows/lib/den-web.mjs:158-174 calls /mcp/agent and
+  // reads the first Server-Sent Events data frame as the JSON-RPC result.
+  const response = await fetch(`${apiUrl}/mcp/agent`, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+      accept: "application/json, text/event-stream",
+      authorization: `Bearer ${options.mcpToken}`,
+    },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method: options.method, params: options.params ?? {} }),
+  });
+  const raw = await response.text();
+  if (!response.ok) throw new EvalError(`MCP ${options.method} failed: ${response.status} ${raw.slice(0, 300)}`);
+  const dataLine = raw.split("\n").find((line) => line.startsWith("data:"));
+  if (!dataLine) throw new EvalError(`MCP ${options.method} returned no data frame: ${raw.slice(0, 300)}`);
+  const payload: unknown = JSON.parse(dataLine.slice(5));
+  if (!isRecord(payload)) throw new EvalError(`MCP ${options.method} returned a non-object JSON-RPC payload.`);
+  if (payload.error) throw new EvalError(`MCP ${options.method} returned JSON-RPC error: ${responseBodySnippet(payload.error)}`);
+  return payload.result;
+}
+
+export async function searchCapabilities(ctx: FlowContext, options: SearchCapabilitiesOptions): Promise<CapabilityMatch[]> {
+  const mcpToken = options.mcpToken ?? await mintMcpToken(ctx, options);
+  const args: Record<string, unknown> = { query: options.query };
+  if (options.limit !== undefined) args.limit = options.limit;
+  if (options.type) args.type = options.type;
+  const result = await mcpAgentCall(ctx, {
+    mcpToken,
+    method: "tools/call",
+    params: { name: "search_capabilities", arguments: args },
+  });
+  return capabilityMatchesFromSearchResult(result);
+}
+
+export async function executeCapability(ctx: FlowContext, options: ExecuteCapabilityOptions): Promise<unknown> {
+  const mcpToken = options.mcpToken ?? await mintMcpToken(ctx, options);
+  const args: Record<string, unknown> = {
+    name: options.name,
+    body: options.body ?? {},
+  };
+  if (options.schemaDigest) args.schemaDigest = options.schemaDigest;
+  return mcpAgentCall(ctx, {
+    mcpToken,
+    method: "tools/call",
+    params: { name: "execute_capability", arguments: args },
+  });
+}
+
+export async function openMcpConnections(ctx: FlowContext, options: OpenMcpConnectionsOptions): Promise<void> {
+  await ctx.on(options.surface, async () => {
+    await ctx.waitFor(
+      `(() => {
+        if (window.location.pathname.includes('mcp-connections')) return true;
+        const link = [...document.querySelectorAll('nav a')].find((a) => a.getAttribute('href')?.includes('mcp-connections'));
+        if (link) {
+          link.click();
+          return false;
+        }
+        const group = [...document.querySelectorAll('nav a, nav button')].find((el) => (el.textContent ?? '').trim().startsWith('Extensions'));
+        group?.click();
+        return false;
+      })()`,
+      { timeoutMs: 30_000, label: "MCP Connections nav link clicked" },
+    );
+    await ctx.waitFor("window.location.pathname.includes('mcp-connections')", {
+      timeoutMs: 20_000,
+      label: "MCP Connections route",
+    });
+    await ctx.waitFor(MCP_CONNECTIONS_SCREEN_READY, {
+      timeoutMs: 30_000,
+      label: "MCP Connections screen",
+    });
+  });
+}
+
+export function connectionUrl(ctx: FlowContext, path = "/dashboard/mcp-connections"): string {
+  return new URL(path, `${denWebUrl(ctx)}/`).toString();
+}

--- a/evals/runner/kernel.test.ts
+++ b/evals/runner/kernel.test.ts
@@ -6,17 +6,20 @@ import { join } from "node:path";
 import test from "node:test";
 import type { Server } from "node:http";
 
-import { resolveHostPlacement } from "./cli.ts";
+import { parseArgs, resolveHostPlacement } from "./cli.ts";
 import { resolveActors } from "./actors.ts";
 import { EvalContext } from "./context.ts";
 import { applyManifestToEnv, manifestPath, readEnvManifest, writeEnvManifest } from "./env-manifest.ts";
 import { allocateFreePorts } from "./ports.ts";
-import { isFlowDefinition } from "./runner.ts";
+import { renderFrameIndex } from "./reporters/fraimz-html.ts";
+import { renderMarkdown } from "./reporters/markdown.ts";
+import { isFlowDefinition, runFlowRepeated, shouldKeepIterationFrames } from "./runner.ts";
 import { defineScenario } from "./scenario.ts";
 import { SurfaceRegistry } from "./surfaces.ts";
 import { loadVoiceoverParagraphs } from "./voiceover.ts";
 import type { CdpClient } from "./cdp.ts";
 import type { EnvManifest } from "./env-manifest.ts";
+import type { EvalReport, FlowDefinition } from "./flow.ts";
 import type { Host, SurfaceHandle } from "./hosts/types.ts";
 import type { Surface } from "./surfaces.ts";
 
@@ -231,6 +234,111 @@ test("resolveActors honors seeded owner env defaults", () => {
     password: "secret",
     role: "owner",
   });
+});
+
+test("eval CLI parses repeat and rejects non-positive values", () => {
+  assert.equal(parseArgs(["--flow", "invite-reliability"]).repeat, 1);
+  assert.equal(parseArgs(["--flow", "invite-reliability", "--repeat", "3"]).repeat, 3);
+  assert.throws(() => parseArgs(["--repeat", "0"]), /--repeat must be an integer >= 1/);
+  assert.throws(() => parseArgs(["--repeat", "twice"]), /--repeat must be an integer >= 1/);
+});
+
+test("runFlowRepeated threads iteration runstamps and keeps first plus failing iteration evidence", async () => {
+  let attempt = 0;
+  const runstamps: string[] = [];
+  const flow: FlowDefinition = {
+    id: "soak-flow",
+    title: "Soak flow",
+    requiresApp: false,
+    steps: [
+      {
+        name: "record iteration",
+        run: (ctx) => {
+          attempt += 1;
+          runstamps.push(ctx.env.OPENWORK_EVAL_RUNSTAMP ?? "");
+          ctx.recordEvidence({
+            type: "frame",
+            status: "passed",
+            file: `iteration-${attempt}.png`,
+            name: `iteration ${attempt}`,
+            claim: null,
+            voiceover: null,
+            url: "about:blank",
+            validations: [],
+          });
+          if (attempt === 2) throw new Error("iteration boom");
+        },
+      },
+    ],
+  };
+
+  const repeated = await runFlowRepeated(flow, {
+    cdpBaseUrl: null,
+    outDir: tmpdir(),
+    env: {},
+    mode: "automation",
+    repeat: 3,
+    runStamp: "soak-base",
+  });
+
+  assert.deepEqual(runstamps, ["soak-base-1", "soak-base-2", "soak-base-3"]);
+  assert.equal(repeated.summary.status, "failed");
+  assert.equal(repeated.summary.passed, 2);
+  assert.equal(repeated.summary.failed, 1);
+  assert.deepEqual(repeated.summary.capturedIterations, [1, 2]);
+  assert.deepEqual(repeated.summary.failures, [{ iteration: 2, step: "record iteration", error: "iteration boom" }]);
+  assert.deepEqual(repeated.results.map((result) => result.id), ["soak-flow#1", "soak-flow#2"]);
+  assert(repeated.results[0]?.steps[0]?.evidence.some((entry) => entry.type === "frame"));
+  assert(repeated.results[1]?.steps[0]?.evidence.some((entry) => entry.type === "frame"));
+  assert.equal(shouldKeepIterationFrames(1, "passed"), true);
+  assert.equal(shouldKeepIterationFrames(2, "passed"), false);
+  assert.equal(shouldKeepIterationFrames(2, "failed"), true);
+});
+
+test("core reliability scenarios are web-only, Den-staged, and narrated frame-for-frame", async () => {
+  for (const flowId of ["invite-reliability", "mcp-connect-reliability"]) {
+    const flowModule: unknown = await import(new URL(`../flows/${flowId}.flow.mjs`, import.meta.url).href);
+    const flow = isRecord(flowModule) ? flowModule.default : undefined;
+    assert(isFlowDefinition(flow));
+    const paragraphs = await loadVoiceoverParagraphs(flowId);
+    assert(paragraphs);
+    assert.equal(flow.requiresApp, false);
+    assert.equal(flow.steps.length, paragraphs.length);
+    assert(flow.requiredEnv?.includes("OPENWORK_EVAL_DEN_API_URL"));
+    assert(flow.requiredEnv?.includes("OPENWORK_EVAL_DEN_WEB_URL"));
+  }
+});
+
+test("reporters render soak tables only when repeat summaries are present", () => {
+  const report: EvalReport = {
+    runId: "report-test",
+    startedAt: "2026-07-28T00:00:00.000Z",
+    finishedAt: "2026-07-28T00:00:01.000Z",
+    cdpUrl: "(app-less run)",
+    mode: "automation",
+    flows: [],
+    summary: { passed: 1, failed: 0, skipped: 0 },
+  };
+  assert(!renderMarkdown(report).includes("Soak summary"));
+  assert(!renderFrameIndex(report).includes("Soak summary"));
+
+  const soakReport: EvalReport = {
+    ...report,
+    soak: [{
+      flowId: "invite-reliability",
+      title: "Invite reliability",
+      repeat: 3,
+      status: "passed",
+      passed: 3,
+      failed: 0,
+      skipped: 0,
+      durationMs: 123,
+      capturedIterations: [1],
+      failures: [],
+    }],
+  };
+  assert(renderMarkdown(soakReport).includes("| invite-reliability | 3 | 3 | 0 | 0 | 1 | passed |"));
+  assert(renderFrameIndex(soakReport).includes("Soak summary"));
 });
 
 test("SurfaceRegistry is idempotent, adopts manifest surfaces, and disposes only spawned handles", async () => {

--- a/evals/runner/reporters/fraimz-html.ts
+++ b/evals/runner/reporters/fraimz-html.ts
@@ -15,6 +15,7 @@ function flowKindBadge(kind: FlowKind | null): string {
 }
 
 export function renderFrameIndex(report: EvalReport): string {
+  const soakSection = renderSoakSection(report);
   const flowSections = report.flows.map((flow) => {
     const steps = (flow.steps ?? []).map((step) => `
         <article class="step ${step.status === "passed" ? "passed" : "failed"}">
@@ -93,7 +94,7 @@ export function renderFrameIndex(report: EvalReport): string {
       <span>Failed: ${report.summary.failed}</span>
       <span>Skipped: ${report.summary.skipped}</span>
     </div>
-    ${flowSections}
+    ${soakSection}${flowSections}
   </main>
   <script>
     (function () {
@@ -127,6 +128,27 @@ export function renderFrameIndex(report: EvalReport): string {
   </script>
 </body>
 </html>`;
+}
+
+function renderSoakSection(report: EvalReport): string {
+  if (!report.soak?.length) return "";
+  const rows = report.soak.map((soak) => `<tr>
+        <td><code>${escapeHtml(soak.flowId)}</code></td>
+        <td>${soak.repeat}</td>
+        <td>${soak.passed}</td>
+        <td>${soak.failed}</td>
+        <td>${soak.skipped}</td>
+        <td>${escapeHtml(soak.capturedIterations.join(", ") || "none")}</td>
+        <td>${escapeHtml(soak.status)}</td>
+      </tr>`).join("\n");
+  return `<section>
+      <h2>Soak summary</h2>
+      <table style="width: 100%; border-collapse: collapse; background: white; border: 1px solid #ddd; border-radius: 12px; overflow: hidden;">
+        <thead><tr><th>Flow</th><th>Repeat</th><th>Passed</th><th>Failed</th><th>Skipped</th><th>Captured iterations</th><th>Status</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </section>
+    `;
 }
 
 function renderEvidence(evidence: Evidence[], mode: EvalMode): string {

--- a/evals/runner/reporters/markdown.ts
+++ b/evals/runner/reporters/markdown.ts
@@ -1,5 +1,20 @@
 import type { EvalReport } from "../flow.ts";
 
+function renderSoakTable(report: EvalReport): string[] {
+  if (!report.soak?.length) return [];
+  const lines = [
+    "## Soak summary",
+    "",
+    "| Flow | Repeat | Passed | Failed | Skipped | Captured iterations | Status |",
+    "| --- | ---: | ---: | ---: | ---: | --- | --- |",
+  ];
+  for (const soak of report.soak) {
+    lines.push(`| ${soak.flowId} | ${soak.repeat} | ${soak.passed} | ${soak.failed} | ${soak.skipped} | ${soak.capturedIterations.join(", ") || "none"} | ${soak.status} |`);
+  }
+  lines.push("");
+  return lines;
+}
+
 export function renderMarkdown(report: EvalReport): string {
   const lines = [
     `# Eval run ${report.runId}`,
@@ -11,6 +26,7 @@ export function renderMarkdown(report: EvalReport): string {
     `- fraimz: fraimz.html`,
     "",
   ];
+  lines.push(...renderSoakTable(report));
   for (const flow of report.flows) {
     const icon = flow.status === "passed" ? "✅" : flow.status === "skipped" ? "⏭️" : "❌";
     lines.push(`## ${icon} ${flow.id} — ${flow.title}`);

--- a/evals/runner/runner.ts
+++ b/evals/runner/runner.ts
@@ -5,7 +5,7 @@ import { connect, debuggerUrlFor, pickAppTarget } from "./cdp.ts";
 import { EvalContext } from "./context.ts";
 import { SurfaceRegistry } from "./surfaces.ts";
 import { checkVoiceoverCoverage, loadVoiceoverParagraphs } from "./voiceover.ts";
-import type { EvalMode, Evidence, FlowDefinition, FlowResult, LoadedFlow, StepResult } from "./flow.ts";
+import type { EvalMode, Evidence, FlowDefinition, FlowResult, FlowStatus, LoadedFlow, SoakFailure, SoakSummary, StepResult } from "./flow.ts";
 import type { CdpClient } from "./cdp.ts";
 import type { EnvManifest } from "./env-manifest.ts";
 import type { Host } from "./hosts/types.ts";
@@ -92,9 +92,99 @@ export interface RunFlowOptions {
   hosts?: Map<string, Host>;
   defaultHostKind?: string;
   manifest?: EnvManifest | null;
+  artifactFlowId?: string;
 }
 
-export async function runFlow(flow: FlowDefinition, { cdpBaseUrl, outDir, env, mode, hosts, defaultHostKind, manifest = null }: RunFlowOptions): Promise<FlowResult> {
+export interface RunFlowRepeatedOptions extends RunFlowOptions {
+  repeat: number;
+  runStamp: string;
+}
+
+export interface RunFlowRepeatedResult {
+  results: FlowResult[];
+  summary: SoakSummary;
+}
+
+function sanitizeRunStamp(value: string): string {
+  return value.toLowerCase().replace(/[^a-z0-9-]+/g, "-").replace(/^-|-$/g, "") || "run";
+}
+
+function iterationEnv(env: NodeJS.ProcessEnv, runStamp: string, iteration: number): NodeJS.ProcessEnv {
+  return {
+    ...env,
+    OPENWORK_EVAL_RUNSTAMP: `${sanitizeRunStamp(runStamp)}-${iteration}`,
+  };
+}
+
+export function shouldKeepIterationFrames(iteration: number, status: FlowStatus): boolean {
+  return iteration === 1 || status === "failed";
+}
+
+function overallStatus(counts: Record<FlowStatus, number>): FlowStatus {
+  if (counts.failed > 0) return "failed";
+  if (counts.passed > 0) return "passed";
+  return "skipped";
+}
+
+function firstFailure(result: FlowResult, iteration: number): SoakFailure | null {
+  for (const step of result.steps) {
+    if (step.status === "failed") {
+      return { iteration, step: step.name, error: step.error };
+    }
+  }
+  return result.status === "failed" ? { iteration, step: null, error: result.skipReason } : null;
+}
+
+function labelIteration(result: FlowResult, iteration: number, repeat: number): FlowResult {
+  return {
+    ...result,
+    id: `${result.id}#${iteration}`,
+    title: `${result.title} (iteration ${iteration}/${repeat})`,
+  };
+}
+
+export async function runFlowRepeated(flow: FlowDefinition, options: RunFlowRepeatedOptions): Promise<RunFlowRepeatedResult> {
+  const { repeat, runStamp, ...runOptions } = options;
+  if (!Number.isInteger(repeat) || repeat < 1) throw new Error(`repeat must be an integer >= 1, got ${repeat}.`);
+  const counts: Record<FlowStatus, number> = { passed: 0, failed: 0, skipped: 0 };
+  const failures: SoakFailure[] = [];
+  const capturedIterations: number[] = [];
+  const results: FlowResult[] = [];
+  const startedAt = Date.now();
+
+  for (let iteration = 1; iteration <= repeat; iteration += 1) {
+    const result = await runFlow(flow, {
+      ...runOptions,
+      env: iterationEnv(runOptions.env, runStamp, iteration),
+      artifactFlowId: repeat > 1 ? `${flow.id}-iteration-${iteration}` : runOptions.artifactFlowId,
+    });
+    counts[result.status] += 1;
+    const failure = firstFailure(result, iteration);
+    if (failure) failures.push(failure);
+    if (shouldKeepIterationFrames(iteration, result.status)) {
+      capturedIterations.push(iteration);
+      results.push(repeat > 1 ? labelIteration(result, iteration, repeat) : result);
+    }
+  }
+
+  return {
+    results,
+    summary: {
+      flowId: flow.id,
+      title: flow.title,
+      repeat,
+      status: overallStatus(counts),
+      passed: counts.passed,
+      failed: counts.failed,
+      skipped: counts.skipped,
+      durationMs: Date.now() - startedAt,
+      capturedIterations,
+      failures,
+    },
+  };
+}
+
+export async function runFlow(flow: FlowDefinition, { cdpBaseUrl, outDir, env, mode, hosts, defaultHostKind, manifest = null, artifactFlowId }: RunFlowOptions): Promise<FlowResult> {
   const result: FlowResult = {
     id: flow.id,
     title: flow.title,
@@ -135,7 +225,7 @@ export async function runFlow(flow: FlowDefinition, { cdpBaseUrl, outDir, env, m
       },
     })
     : null;
-  ctx = new EvalContext({ client, outDir, flowId: flow.id, env, cdpBaseUrl, surfaces: registry });
+  ctx = new EvalContext({ client, outDir, flowId: artifactFlowId ?? flow.id, env, cdpBaseUrl, surfaces: registry });
   for (const line of pendingRegistryLogs) ctx.log(line);
 
   try {

--- a/evals/voiceovers/invite-reliability.md
+++ b/evals/voiceovers/invite-reliability.md
@@ -1,0 +1,19 @@
+# Invite reliability
+
+1. Alex starts from the cloud dashboard, creates a fresh test workspace, and sees Den Web pinned to that new organization before inviting anyone.
+
+2. Alex opens Members, sends Jamie a real invitation, and the pending row appears with Jamie's exact eval email.
+
+3. Jamie accepts the invitation in a separate Chrome profile, lands in the same workspace, and sees that the join completed without touching the desktop app.
+
+4. Jamie opens the same accepted invite link again, and the product lands her in a coherent already-member state instead of a blank or broken page.
+
+5. Alex reloads the member list and verifies Jamie appears exactly once, proving the invite did not duplicate or attach to the wrong organization.
+
+6. A garbage invite token opens the real invite screen error state, clearly explaining that the invite cannot be opened instead of looping or going blank.
+
+7. Alex removes Jamie, sends a fresh invite to the same email with an explicit admin role, and Jamie accepts that new invite from her browser.
+
+8. Alex returns to Members and sees Jamie's accepted row with the Admin role, proving the re-invite preserved the requested role.
+
+9. The eval cleans up Jamie's membership and records that the Electron desktop cell is intentionally skipped unless a desktop-specific eval sets its own gate.

--- a/evals/voiceovers/mcp-connect-reliability.md
+++ b/evals/voiceovers/mcp-connect-reliability.md
@@ -1,0 +1,19 @@
+# MCP connect reliability
+
+1. Alex creates a fresh Den workspace in a real Chrome profile so this MCP reliability run starts from an isolated organization.
+
+2. Alex publishes the mock MCP server as a no-auth, org-wide connection and Den Web shows the connection as Connected.
+
+3. Alex reloads the Den Web connectors page, sees the same Connected state, and the live tool call still echoes through the saved connection.
+
+4. Alex disconnects the connector, the row remains visible as Not connected, and a live mock_echo call fails instead of silently using stale credentials.
+
+5. Alex reconnects the same no-auth MCP setup, Den Web returns to Connected, and the live tool call succeeds again.
+
+6. Alex adds a never-connected OAuth MCP row and confirms it asks for first-time Connect, not a misleading reconnect or sign-in prompt.
+
+7. The live Den MCP connection catalog exposes mock_echo, and the admin diagnostic runner executes it through the saved connection.
+
+8. The agent-facing search_capabilities and execute_capability loop finds that same connection and echoes the proof text through the mock server.
+
+9. The eval removes the temporary MCP connections and records that the Electron desktop cell is intentionally skipped for this web-only reliability check.


### PR DESCRIPTION
## Why

A 6-week enterprise POC log shows our two most business-critical flows failing repeatedly — and the worst failure class is **silent**:

- **Invite** failed 7 distinct ways: duplicate account created on accept; admin-invited user created as member; accept looping into a broken state; delete→re-invite→accept dead-ending on "you were already part of the team"; "invite link already used"; verification mail never sent; member cap despite licenses.
- **MCP-on-Den** failed ~10 ways, and **4+ separate times the UI showed "connected" while tool calls failed**. Plus false "reconnect" prompts for connectors that were never connected.

Happy-path proof can't catch any of that. This PR adds the convention + cells + repetition that can.

## What

**The dual assertion (`journeys/mcp.ts` → `expectUsable`)** — the core idea: *"connected" is unprovable without a live call through the connection.* Every MCP claim records two observable assertions (product UI state **and** a real tool call). If the UI says connected and the call fails, it fails loudly with exactly that wording. Demonstrated deliberately:

```
UI reports connected but a live tool call failed
```

**`invite-reliability`** — 9 cells: send invite → accept in the invitee's own browser → **reopen the consumed link** → exactly-one-membership → **invalid token shows a real error** → **remove → re-invite → accept again** → **invited admin role survives** → cleanup.

**`mcp-connect-reliability`** — 9 cells: publish connection → **survives a Den Web reload** → **disconnect really revokes the usable credential** → **reconnect restores it** → **never-connected connector asks to Connect, not Reconnect** → direct catalog/tool call → agent search+execute → cleanup.

**Soak mode (`--repeat N`)** — reliability means the Nth run with the Nth fresh user passes. Fresh personas per iteration, pass-rate + duration aggregation rendered in `report.md`/`fraimz.html`, frames retained for iteration 1 and every failing iteration (policy stated in the report so evidence is never silently thinner than it looks).

**Nightly** — both flows run with `--repeat 3` so pass-rate is tracked continuously.

## Tests run

- `pnpm evals:typecheck` ✓ · `pnpm evals:test` ✓ (46)
- Live: `pnpm evals --stack den --flow invite-reliability --flow mcp-connect-reliability` → **PASSED** (18 cells)
- Soak: `--flow invite-reliability --repeat 5` → **5/5**, with 5 distinct invitee emails proving iteration independence
- Demo mode: `pnpm fraimz` for both flows → **voiceover coverage green**; every frame opened and confirmed product-rendered (members list with Pending/Member/Admin states, `This invite can't be opened.`, connector rows flipping Connected → Not connected → Connected)
- `pnpm evals --list` → 2 flows added, every pre-existing line byte-identical

## Findings (product, not harness)

1. **Invalid invite leaks a raw error code**: the page correctly says "This invite can't be opened." but prints `invitation_not_found` underneath — worth polishing since invite failures are exactly where confused users land.
2. **No-auth connector rows expose no first-class Reconnect affordance** after disconnect; the cell revalidates through the Den API update path and then proves live usability. Field logs show users hunting for exactly this affordance ("no desktop reconnect affordance") — a UX gap worth a follow-up.

## Scope notes

Both flows are **web-surface only** (`requiresApp: false`, headless-Chrome surfaces) so they run in CI. The desktop-restart persistence cell is an **explicit env-gated skip**, not a fake — it belongs to the Daytona/GUI lane.