### PR TITLE
fix(app): stop a malformed workspace list from making the app unloadable; add computer name to the pill

### DIFF
--- a/apps/app/src/app/lib/den.ts
+++ b/apps/app/src/app/lib/den.ts
@@ -168,6 +168,7 @@ export type DenCloudInstance = {
   status: "provisioning" | "waking" | "ready" | "failed";
   url: string | null;
   imageVersion: string | null;
+  instanceName?: string | null;
   latestVersion: string | null;
 };
 
@@ -1236,6 +1237,7 @@ function parseCloudInstance(payload: unknown): DenCloudInstance | null {
     status: payload.status,
     url: payload.url,
     imageVersion: typeof payload.imageVersion === "string" ? payload.imageVersion : null,
+    ...(typeof payload.instanceName === "string" ? { instanceName: payload.instanceName } : {}),
     latestVersion: typeof payload.latestVersion === "string" ? payload.latestVersion : null,
   };
 }

--- a/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
+++ b/apps/app/src/react-app/shell/cloud-workspace-overlay.tsx
@@ -271,6 +271,57 @@ export function CloudWorkspaceBootTakeover(props: { decision: CloudWorkspaceMain
   );
 }
 
+export function CloudWorkspaceStatusPanel(props: {
+  viewModel: CloudWorkspaceViewModel;
+  updating: boolean;
+  onRefresh: () => void;
+  onSignOut: () => void;
+  onUpdateNow: () => void;
+}) {
+  const { viewModel } = props;
+  return (
+    <>
+      <div className="space-y-1">
+        <p className="text-sm font-medium" data-testid="cloud-workspace-status-line">
+          {viewModel.statusLine}
+        </p>
+        {viewModel.computerLine ? (
+          <p
+            className="select-all break-all text-xs text-muted-foreground"
+            data-testid="cloud-workspace-computer-line"
+            title="Select and copy for support"
+          >
+            {viewModel.computerLine}
+          </p>
+        ) : null}
+        <p className="text-xs text-muted-foreground">{viewModel.versionLine}</p>
+        <p className="text-xs text-muted-foreground">{viewModel.latestLine}</p>
+        <p className="text-xs text-muted-foreground">{viewModel.backupsLine}</p>
+      </div>
+      {viewModel.showUpdate ? (
+        <div className="rounded-2xl border border-border bg-muted/30 p-3">
+          <Button type="button" size="sm" className="w-full" onClick={props.onUpdateNow} disabled={props.updating}>
+            Update now
+          </Button>
+          <p className="mt-2 text-xs text-muted-foreground">
+            Takes about 30 seconds. Your files and sessions come along.
+          </p>
+        </div>
+      ) : null}
+      <div className="flex items-center justify-end gap-2">
+        {viewModel.showRetry ? (
+          <Button type="button" size="sm" variant="outline" onClick={props.onRefresh}>
+            Retry
+          </Button>
+        ) : null}
+        <Button type="button" size="sm" variant="ghost" onClick={props.onSignOut}>
+          Sign out
+        </Button>
+      </div>
+    </>
+  );
+}
+
 function CloudWorkspaceOverlayInner() {
   const cloudWorkspace = useCloudWorkspaceStatus();
   const [open, setOpen] = useState(false);
@@ -302,37 +353,16 @@ function CloudWorkspaceOverlayInner() {
           }
         />
         <PopoverContent align="end" side="top" sideOffset={8} className="w-80 gap-3 p-4">
-          <div className="space-y-1">
-            <p className="text-sm font-medium" data-testid="cloud-workspace-status-line">
-              {viewModel.statusLine}
-            </p>
-            <p className="text-xs text-muted-foreground">{viewModel.versionLine}</p>
-            <p className="text-xs text-muted-foreground">{viewModel.latestLine}</p>
-            <p className="text-xs text-muted-foreground">{viewModel.backupsLine}</p>
-          </div>
-          {viewModel.showUpdate ? (
-            <div className="rounded-2xl border border-border bg-muted/30 p-3">
-              <Button type="button" size="sm" className="w-full" onClick={cloudWorkspace.updateNow} disabled={cloudWorkspace.updating}>
-                Update now
-              </Button>
-              <p className="mt-2 text-xs text-muted-foreground">
-                Takes about 30 seconds. Your files and sessions come along.
-              </p>
-            </div>
-          ) : null}
-          <div className="flex items-center justify-end gap-2">
-            {viewModel.showRetry ? (
-              <Button type="button" size="sm" variant="outline" onClick={() => void cloudWorkspace.refresh()}>
-                Retry
-              </Button>
-            ) : null}
-            <Button type="button" size="sm" variant="ghost" onClick={() => {
+          <CloudWorkspaceStatusPanel
+            viewModel={viewModel}
+            updating={cloudWorkspace.updating}
+            onRefresh={() => void cloudWorkspace.refresh()}
+            onUpdateNow={cloudWorkspace.updateNow}
+            onSignOut={() => {
               cloudWorkspace.signOut();
               setOpen(false);
-            }}>
-              Sign out
-            </Button>
-          </div>
+            }}
+          />
         </PopoverContent>
       </Popover>
     </div>

--- a/apps/app/src/react-app/shell/cloud-workspace-status.ts
+++ b/apps/app/src/react-app/shell/cloud-workspace-status.ts
@@ -13,6 +13,7 @@ export type CloudWorkspaceViewModel = {
   label: string;
   tone: "neutral" | "amber";
   statusLine: string;
+  computerLine: string | null;
   versionLine: string;
   latestLine: string;
   backupsLine: string;
@@ -84,7 +85,9 @@ function baseLines(instance: DenCloudInstance | null, updateAvailable: boolean) 
   const version = versionDisplay(instance);
   const latest = latestDisplay(instance);
   const latestSuffix = !updateAvailable && instance?.latestVersion ? " (up to date)" : "";
+  const instanceName = instance?.instanceName?.trim() ?? "";
   return {
+    computerLine: instanceName ? `Computer: ${instanceName}` : null,
     versionLine: `Version: ${version}`,
     latestLine: `Latest: ${latest}${latestSuffix}`,
     backupsLine: "Backups on",

--- a/apps/app/src/react-app/shell/route-workspaces.ts
+++ b/apps/app/src/react-app/shell/route-workspaces.ts
@@ -108,6 +108,71 @@ export function classifyRouteSessionReadError(error: unknown): "not-found" | "re
   return "error";
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isOpenworkWorkspaceArray(value: unknown): value is OpenworkWorkspaceInfo[] {
+  return Array.isArray(value);
+}
+
+function routeListActiveId(list: unknown) {
+  if (!isRecord(list)) return null;
+  return typeof list.activeId === "string" ? list.activeId.trim() || null : null;
+}
+
+export type RouteWorkspaceListState = {
+  activeId: string | null;
+  error: unknown | null;
+  usable: boolean;
+  workspaces: RouteWorkspace[];
+};
+
+export function resolveRouteWorkspaceListState(input: {
+  list: unknown;
+  desktopWorkspaces: RouteWorkspace[];
+  previousWorkspaces: RouteWorkspace[];
+  orderIds: string[];
+}): RouteWorkspaceListState {
+  const serverItems = isRecord(input.list) && isOpenworkWorkspaceArray(input.list.items) ? input.list.items : null;
+  const workspaces = serverItems
+    ? mergeRouteWorkspaces(serverItems, input.desktopWorkspaces)
+    : input.previousWorkspaces.length > 0
+      ? input.previousWorkspaces
+      : input.desktopWorkspaces;
+
+  return {
+    activeId: routeListActiveId(input.list),
+    error: null,
+    usable: serverItems !== null,
+    workspaces: orderRouteWorkspaces(workspaces, input.orderIds),
+  };
+}
+
+export async function refreshRouteWorkspaceListState(input: {
+  load: () => Promise<unknown>;
+  desktopWorkspaces: RouteWorkspace[];
+  previousWorkspaces: RouteWorkspace[];
+  orderIds: string[];
+}): Promise<RouteWorkspaceListState> {
+  try {
+    return resolveRouteWorkspaceListState({
+      list: await input.load(),
+      desktopWorkspaces: input.desktopWorkspaces,
+      previousWorkspaces: input.previousWorkspaces,
+      orderIds: input.orderIds,
+    });
+  } catch (error) {
+    const state = resolveRouteWorkspaceListState({
+      list: null,
+      desktopWorkspaces: input.desktopWorkspaces,
+      previousWorkspaces: input.previousWorkspaces,
+      orderIds: input.orderIds,
+    });
+    return { ...state, error };
+  }
+}
+
 export function describeWorkspaceCreateError(error: unknown) {
   const message = describeRouteError(error);
   const lower = message.toLowerCase();
@@ -122,9 +187,10 @@ export function describeWorkspaceCreateError(error: unknown) {
 }
 
 export function mergeRouteWorkspaces(
-  serverWorkspaces: OpenworkWorkspaceInfo[],
+  serverWorkspaces: unknown,
   desktopWorkspaces: RouteWorkspace[],
 ): RouteWorkspace[] {
+  const serverWorkspaceList = isOpenworkWorkspaceArray(serverWorkspaces) ? serverWorkspaces : [];
   const desktopById = new Map(desktopWorkspaces.map((workspace) => [workspace.id, workspace]));
   const desktopByPath = new Map(
     desktopWorkspaces.flatMap((workspace) => {
@@ -142,7 +208,7 @@ export function mergeRouteWorkspaces(
   const remoteDesktopIds = new Set(
     desktopWorkspaces.flatMap((workspace) => workspace.workspaceType === "remote" ? [workspace.id] : []),
   );
-  const filteredServer = serverWorkspaces.filter((workspace) => !remoteDesktopIds.has(workspace.id));
+  const filteredServer = serverWorkspaceList.filter((workspace) => !remoteDesktopIds.has(workspace.id));
 
   const mergedServer = filteredServer.map((workspace) => {
     const match =

--- a/apps/app/src/react-app/shell/use-workspace-route-state.ts
+++ b/apps/app/src/react-app/shell/use-workspace-route-state.ts
@@ -47,8 +47,8 @@ import {
   describeRouteError,
   isTransientStartupError,
   mapDesktopWorkspace,
-  mergeRouteWorkspaces,
   orderRouteWorkspaces,
+  refreshRouteWorkspaceListState,
   type RouteSession,
   type RouteWorkspace,
 } from "./route-workspaces";
@@ -429,11 +429,25 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
         token: resolvedToken,
         hostToken: resolvedHostToken || undefined,
       });
-      const list = await withRouteRefreshTimeout(openworkClient.listWorkspaces(), "Workspace list");
-      const nextWorkspaces = orderRouteWorkspaces(
-        mergeRouteWorkspaces(list.items, desktopWorkspaces),
-        workspaceOrderIdsRef.current,
-      );
+      const workspaceListState = await refreshRouteWorkspaceListState({
+        load: () => withRouteRefreshTimeout(openworkClient.listWorkspaces(), "Workspace list"),
+        desktopWorkspaces,
+        previousWorkspaces: workspacesRef.current,
+        orderIds: workspaceOrderIdsRef.current,
+      });
+      if (!workspaceListState.usable || workspaceListState.error) {
+        const message = workspaceListState.error
+          ? describeRouteError(workspaceListState.error)
+          : "Workspace list response did not include items.";
+        console.warn("[session-route] workspace list degraded", workspaceListState.error ?? message);
+        recordInspectorEvent("route.workspace_list.degraded", {
+          route: "session",
+          message,
+          preservedWorkspaceCount: workspacesRef.current.length,
+        });
+        setRouteError(message);
+      }
+      const nextWorkspaces = workspaceListState.workspaces;
 
       // Preserve any sessions we already have cached so switching routes
       // doesn't erase the sidebar while we refetch.
@@ -454,7 +468,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
           ? persistedActiveId
           : "") ||
         resolveWorkspaceListSelectedId(desktopList) ||
-        list.activeId?.trim() ||
+        workspaceListState.activeId ||
         nextWorkspaces[0]?.id ||
         "";
       if (workspaceInferenceSessionId) {
@@ -494,7 +508,7 @@ export function useWorkspaceRouteState(input: UseWorkspaceRouteStateInput) {
       // OpenCode engine bound to it re-reads opencode.jsonc and applies
       // permissions. Fire-and-forget; the route is idempotent and any
       // transport failure is non-fatal. See issue #870.
-      if (nextWorkspaceId && list.activeId !== nextWorkspaceId && !launchActivatedWorkspaceIdsRef.current.has(nextWorkspaceId)) {
+      if (nextWorkspaceId && workspaceListState.activeId !== nextWorkspaceId && !launchActivatedWorkspaceIdsRef.current.has(nextWorkspaceId)) {
         launchActivatedWorkspaceIdsRef.current.add(nextWorkspaceId);
         const nextWorkspace = nextWorkspaces.find((workspace) => workspace.id === nextWorkspaceId) ?? null;
         const nextEndpoint = routeWorkspaceServerClientResolver(nextWorkspace);

--- a/apps/app/tests/cloud-workspace-overlay.test.tsx
+++ b/apps/app/tests/cloud-workspace-overlay.test.tsx
@@ -2,7 +2,7 @@ import { afterEach, describe, expect, test } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
 
 import type { DenCloudInstance } from "../src/app/lib/den";
-import { CloudWorkspaceOverlay } from "../src/react-app/shell/cloud-workspace-overlay";
+import { CloudWorkspaceOverlay, CloudWorkspaceStatusPanel } from "../src/react-app/shell/cloud-workspace-overlay";
 import {
   cloudWorkspaceStatusHasReadyContent,
   cloudWorkspaceUpdateAvailable,
@@ -19,6 +19,7 @@ function instance(input: Partial<DenCloudInstance> = {}): DenCloudInstance {
     status: input.status ?? "ready",
     url: input.url ?? "https://workspace.example.test",
     imageVersion: "imageVersion" in input ? input.imageVersion ?? null : "openwork-0.18.8",
+    ...(typeof input.instanceName === "string" ? { instanceName: input.instanceName } : {}),
     latestVersion: "latestVersion" in input ? input.latestVersion ?? null : "openwork-0.18.8",
   };
 }
@@ -32,6 +33,15 @@ describe("cloud workspace overlay state", () => {
     expect(state.statusLine).toBe("Connected · v0.18.8 (latest)");
     expect(state.latestLine).toBe("Latest: v0.18.8 (up to date)");
     expect(state.showUpdate).toBe(false);
+  });
+
+  test("maps a sandbox name to a quiet computer diagnostic line", () => {
+    const state = mapCloudWorkspaceState({
+      instance: instance({ instanceName: "den-daytona-worker-cloud-test" }),
+      updating: false,
+    });
+
+    expect(state.computerLine).toBe("Computer: den-daytona-worker-cloud-test");
   });
 
   test("maps stale and legacy workers to Update available", () => {
@@ -171,5 +181,44 @@ describe("cloud workspace overlay gateway gating", () => {
     });
 
     expect(renderToStaticMarkup(<CloudWorkspaceOverlay />)).toBe("");
+  });
+});
+
+describe("cloud workspace overlay diagnostics", () => {
+  test("renders the computer diagnostic in the expanded panel when present", () => {
+    const viewModel = mapCloudWorkspaceState({
+      instance: instance({ instanceName: "den-daytona-worker-cloud-test" }),
+      updating: false,
+    });
+
+    const html = renderToStaticMarkup(
+      <CloudWorkspaceStatusPanel
+        viewModel={viewModel}
+        updating={false}
+        onRefresh={() => {}}
+        onSignOut={() => {}}
+        onUpdateNow={() => {}}
+      />,
+    );
+
+    expect(html).toContain("Computer: den-daytona-worker-cloud-test");
+    expect(html).toContain("cloud-workspace-computer-line");
+  });
+
+  test("omits the computer diagnostic from the expanded panel when absent", () => {
+    const viewModel = mapCloudWorkspaceState({ instance: instance(), updating: false });
+
+    const html = renderToStaticMarkup(
+      <CloudWorkspaceStatusPanel
+        viewModel={viewModel}
+        updating={false}
+        onRefresh={() => {}}
+        onSignOut={() => {}}
+        onUpdateNow={() => {}}
+      />,
+    );
+
+    expect(html).not.toContain("Computer:");
+    expect(html).not.toContain("cloud-workspace-computer-line");
   });
 });

--- a/apps/app/tests/workspace-routes.test.ts
+++ b/apps/app/tests/workspace-routes.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, test } from "bun:test";
 
-import { classifyRouteSessionReadError } from "../src/react-app/shell/route-workspaces";
+import {
+  classifyRouteSessionReadError,
+  mergeRouteWorkspaces,
+  refreshRouteWorkspaceListState,
+} from "../src/react-app/shell/route-workspaces";
 import {
   mergeWorkspaceRouteSession,
   preserveWorkspaceRouteSession,
@@ -65,5 +69,67 @@ describe("workspace route session read errors", () => {
     expect(classifyRouteSessionReadError(Object.assign(new Error("upstream"), { status: 502 }))).toBe("retryable");
     expect(classifyRouteSessionReadError(new Error("request timed out"))).toBe("retryable");
     expect(classifyRouteSessionReadError(Object.assign(new Error("forbidden"), { status: 403 }))).toBe("error");
+  });
+});
+
+describe("workspace route list merging", () => {
+  const previouslyKnownWorkspaces = [{
+    id: "workspace-known",
+    name: "Known workspace",
+    path: "/tmp/known",
+    workspaceType: "local",
+    displayNameResolved: "Known workspace",
+  }];
+  const desktopWorkspaces = [{
+    id: "workspace-desktop",
+    name: "Desktop workspace",
+    path: "/tmp/openwork",
+    workspaceType: "local",
+    displayNameResolved: "Desktop workspace",
+  }];
+
+  test("keeps desktop workspaces when the server workspace list is not an array", () => {
+    expect(mergeRouteWorkspaces({ items: undefined }, desktopWorkspaces)).toEqual(desktopWorkspaces);
+  });
+
+  test("preserves known workspaces when the route list payload is missing items", async () => {
+    await expect(refreshRouteWorkspaceListState({
+      load: async () => ({}),
+      desktopWorkspaces,
+      previousWorkspaces: previouslyKnownWorkspaces,
+      orderIds: [],
+    })).resolves.toMatchObject({
+      error: null,
+      usable: false,
+      workspaces: previouslyKnownWorkspaces,
+    });
+  });
+
+  test("preserves known workspaces when the route list payload has undefined items", async () => {
+    await expect(refreshRouteWorkspaceListState({
+      load: async () => ({ items: undefined }),
+      desktopWorkspaces,
+      previousWorkspaces: previouslyKnownWorkspaces,
+      orderIds: [],
+    })).resolves.toMatchObject({
+      error: null,
+      usable: false,
+      workspaces: previouslyKnownWorkspaces,
+    });
+  });
+
+  test("preserves known workspaces when the route list request rejects", async () => {
+    const result = await refreshRouteWorkspaceListState({
+      load: async () => {
+        throw new Error("workspace list unavailable");
+      },
+      desktopWorkspaces,
+      previousWorkspaces: previouslyKnownWorkspaces,
+      orderIds: [],
+    });
+
+    expect(result.usable).toBe(false);
+    expect(result.workspaces).toEqual(previouslyKnownWorkspaces);
+    expect(result.error).toBeInstanceOf(Error);
   });
 });

--- a/ee/apps/den-api/src/routes/cloud/index.ts
+++ b/ee/apps/den-api/src/routes/cloud/index.ts
@@ -11,7 +11,7 @@ import { env, type DenOrgMode } from "../../env.js"
 import { orgMemberRoute } from "../../middleware/index.js"
 import { jsonResponse, notFoundSchema, unauthorizedSchema } from "../../openapi.js"
 import { materializeCloudWorkerProviders } from "../../llm/cloud-provider-materialization.js"
-import { flushWorkerCheckpointOnDaytona, getDaytonaSandboxRecord, inspectDaytonaSandbox, refreshDaytonaSignedPreview, stopWorkerOnDaytona } from "../../workers/daytona.js"
+import { currentDaytonaSandboxName, flushWorkerCheckpointOnDaytona, getDaytonaSandboxRecord, inspectDaytonaSandbox, refreshDaytonaSignedPreview, stopWorkerOnDaytona } from "../../workers/daytona.js"
 import { CLOUD_INSTANCE_BACKEND, CLOUD_INSTANCE_NAME } from "../../workers/cloud-constants.js"
 import { wakeCloudWorker as defaultWakeCloudWorker } from "../../workers/cloud-lifecycle.js"
 import { appLogger } from "../../observability/logger.js"
@@ -42,7 +42,9 @@ type CloudWorker = Pick<typeof WorkerTable.$inferSelect, "id" | "name" | "status
   image_version?: typeof WorkerTable.$inferSelect.image_version
 }
 type WorkerToken = Pick<typeof WorkerTokenTable.$inferSelect, "scope" | "token">
-type CloudSandboxRecord = Pick<NonNullable<Awaited<ReturnType<typeof getDaytonaSandboxRecord>>>, "signed_preview_url" | "signed_preview_url_expires_at">
+type CloudSandboxRecord = Pick<NonNullable<Awaited<ReturnType<typeof getDaytonaSandboxRecord>>>, "signed_preview_url" | "signed_preview_url_expires_at"> & {
+  sandbox_id?: string | null
+}
 type CloudSandboxInspection = { state: string | null } | null
 type OrgId = typeof WorkerTable.$inferSelect.org_id
 type UserId = NonNullable<typeof WorkerTable.$inferSelect.created_by_user_id>
@@ -58,6 +60,7 @@ type CloudInstanceResponse = {
 }
 type CloudInstanceMemberResponse = CloudInstanceResponse & {
   imageVersion?: string | null
+  instanceName?: string | null
   latestVersion?: string | null
 }
 type CloudGatewayInstanceResponse = CloudInstanceResponse & {
@@ -102,6 +105,7 @@ const cloudInstanceResponseSchema = z.object({
   status: z.enum(["provisioning", "waking", "ready", "failed"]),
   url: z.string().url().nullable(),
   imageVersion: z.string().nullable().optional(),
+  instanceName: z.string().nullable().optional(),
   latestVersion: z.string().nullable().optional(),
 }).meta({ ref: "CloudInstanceResponse" })
 
@@ -607,10 +611,22 @@ function isRunningSandboxState(state: string | null) {
   return normalized === "running" || normalized === "started"
 }
 
-function memberCloudInstanceResponse(worker: CloudWorker, instance: CloudInstanceResponse): CloudInstanceMemberResponse {
+function cloudInstanceName(worker: CloudWorker, sandbox: CloudSandboxRecord | null) {
+  if (!sandbox) return null
+  const storedName = sandbox.sandbox_id?.trim() ?? ""
+  if (storedName) return storedName
+  if ("sandbox_id" in sandbox) {
+    return currentDaytonaSandboxName({ workerId: worker.id, name: worker.name })
+  }
+  return null
+}
+
+function memberCloudInstanceResponse(worker: CloudWorker, instance: CloudInstanceResponse, sandbox: CloudSandboxRecord | null): CloudInstanceMemberResponse {
+  const instanceName = cloudInstanceName(worker, sandbox)
   return {
     ...instance,
     imageVersion: worker.image_version ?? null,
+    ...(instanceName ? { instanceName } : {}),
     latestVersion: env.daytona.snapshot ?? null,
   }
 }
@@ -962,7 +978,8 @@ export function registerCloudRoutes<T extends { Variables: OrgRouteVariables }>(
         now,
       })
 
-      return c.json(memberCloudInstanceResponse(resolved.worker, resolved.instance))
+      const sandbox = await getSandboxRecord(resolved.worker.id)
+      return c.json(memberCloudInstanceResponse(resolved.worker, resolved.instance, sandbox))
     },
   )
 

--- a/ee/apps/den-api/src/workers/daytona.ts
+++ b/ee/apps/den-api/src/workers/daytona.ts
@@ -16,6 +16,7 @@ type ProvisionInput = {
   clientToken: string
   activityToken: string
 }
+type SandboxNameInput = Pick<ProvisionInput, "workerId" | "name">
 
 type ProvisionedInstance = {
   provider: string
@@ -192,7 +193,7 @@ function sandboxLabels(workerId: WorkerId) {
   }
 }
 
-export function daytonaSandboxName(input: ProvisionInput) {
+export function daytonaSandboxName(input: SandboxNameInput) {
   return slug(
     `${env.daytona.sandboxNamePrefix}-${input.name}-${workerHint(input.workerId)}`,
   ).slice(0, 63)
@@ -206,14 +207,14 @@ function snapshotShortVersion(snapshot: string) {
   return slug(snapshot).slice(0, 24) || "snapshot"
 }
 
-export function daytonaSandboxNameForSnapshot(input: ProvisionInput, snapshot: string) {
+export function daytonaSandboxNameForSnapshot(input: SandboxNameInput, snapshot: string) {
   const shortVersion = snapshotShortVersion(snapshot)
   const base = daytonaSandboxName(input)
   const baseLength = Math.max(1, 63 - shortVersion.length - 1)
   return slug(`${base.slice(0, baseLength)}-${shortVersion}`).slice(0, 63)
 }
 
-function currentDaytonaSandboxName(input: ProvisionInput) {
+export function currentDaytonaSandboxName(input: SandboxNameInput) {
   const snapshot = currentDaytonaImageVersion()
   return snapshot ? daytonaSandboxNameForSnapshot(input, snapshot) : daytonaSandboxName(input)
 }

--- a/ee/apps/den-api/test/cloud-instance-route.test.ts
+++ b/ee/apps/den-api/test/cloud-instance-route.test.ts
@@ -114,6 +114,13 @@ function fakeSandbox() {
   }
 }
 
+function fakeSandboxWithId(sandboxId: string) {
+  return {
+    ...fakeSandbox(),
+    sandbox_id: sandboxId,
+  }
+}
+
 function expectedCloudInstance(input: {
   status: CloudInstanceStatus
   url: string | null
@@ -477,6 +484,36 @@ describe("Cloud gateway resolve route", () => {
     expect(payload).not.toHaveProperty("clientToken")
   })
 
+  test("does not add instanceName to the gateway resolve response", async () => {
+    const readyWorker = fakeWorker("healthy")
+    const store = makeCloudWorkerStore({ tokens: [makeToken(readyWorker.id, "host"), makeToken(readyWorker.id, "client")] })
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      gatewayKey: "gateway-secret",
+      ensureCloudWorker: async () => readyWorker,
+      cloudWorkerStore: store.store,
+      getSandboxRecord: async () => fakeSandboxWithId("den-daytona-worker-cloud-test"),
+      probeSignedPreview: async () => true,
+      materializeProviders: async () => ({ ok: true, status: "noop", fingerprint: "owp:v1:test", providers: 0 }),
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/gateway/resolve", {
+      headers: { "X-OpenWork-Gateway-Key": "gateway-secret" },
+    })
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      status: "ready",
+      url: "https://preview.example.test",
+      clientToken: "client-token",
+      hostToken: "host-token",
+    })
+  })
+
   test("surfaces degraded provider materialization failures without leaking provider keys", async () => {
     const readyWorker = fakeWorker("healthy")
     const store = makeCloudWorkerStore({ tokens: [makeToken(readyWorker.id, "host"), makeToken(readyWorker.id, "client")] })
@@ -562,6 +599,54 @@ describe("Cloud gateway resolve route", () => {
 })
 
 describe("Cloud instance route lifecycle states", () => {
+  test("returns the Daytona sandbox identifier on the member instance response", async () => {
+    const worker = { ...fakeWorker("healthy"), image_version: "openwork-0.18.7" }
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      getSandboxRecord: async () => fakeSandboxWithId("den-daytona-worker-cloud-test"),
+      probeSignedPreview: async () => true,
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+
+    expect(response.status).toBe(200)
+    await expect(response.json()).resolves.toEqual({
+      ...expectedCloudInstance({
+        status: "ready",
+        url: "https://preview.example.test",
+        imageVersion: "openwork-0.18.7",
+      }),
+      instanceName: "den-daytona-worker-cloud-test",
+    })
+  })
+
+  test("omits instanceName on the member instance response without a sandbox record", async () => {
+    const worker = fakeWorker("provisioning")
+    const app = new Hono<{ Variables: OrgRouteVariables }>()
+
+    routes.registerCloudRoutes(app, {
+      memberRoute: contextMiddleware(organizationContext(JSON.stringify({ capabilities: { cloud: true } }))),
+      orgMode: "multi_org",
+      provisionerMode: "daytona",
+      daytonaApiKey: "daytona-test-key",
+      ensureCloudWorker: async () => worker,
+      getSandboxRecord: async () => null,
+    })
+
+    const response = await app.request("http://den.local/v1/cloud/instance")
+    const payload = await response.json()
+
+    expect(response.status).toBe(200)
+    expect(payload).toEqual(expectedCloudInstance({ status: "provisioning", url: null }))
+    expect(payload).not.toHaveProperty("instanceName")
+  })
+
   test("returns worker and latest image versions on the member instance response", async () => {
     const worker = { ...fakeWorker("healthy"), image_version: "openwork-0.18.7" }
     const app = new Hono<{ Variables: OrgRouteVariables }>()


### PR DESCRIPTION
A user could not load the web app at all. Production console, repeating:

```
[session-route] refreshRouteState failed
TypeError: Cannot read properties of undefined (reading 'filter')
```

They were stuck on "Workspace needs attention" with no way in.

## Cause

`use-workspace-route-state.ts` passed `list.items` straight into `mergeRouteWorkspaces`, which immediately maps/flatMaps it. A waking or degraded instance can return a payload without `items`, so the whole route refresh threw — and because the throw happened before the route finished, the app never rendered. Notably the desktop path 50 lines above was already defensive (`desktopList.workspaces ?? []`); this one wasn't.

The recent ready-transition refetch made this path run more often against half-ready instances, which is what turned a latent hazard into a hard block.

## Fix

- Guard the payload **and** make `mergeRouteWorkspaces` itself tolerate a non-array argument, so no future caller can crash the route the same way.
- A degraded workspace list now **preserves previously known workspaces** instead of wiping the sidebar (mirroring the existing desktop-bootstrap degradation), records a degraded event, and continues.
- The refresh always reaches `setLoading(false)` / route-ready in `finally`, so the app renders the boot/takeover state rather than a dead screen. A failed workspace fetch must never make the app unrenderable.

## Computer name in the pill (user request)

> *"in the pill at bottom right we could have some diagnostic info around computer name (the daytona sandbox name, that will help for debugging)"*

- den-api's member endpoint gains an optional `instanceName`, sourced from the Daytona sandbox record (falling back to the deterministic name helper). Additive; the gateway resolve shape is unchanged and asserted so in tests.
- The overlay shows a quiet, copyable `Computer: …` line in the **expanded panel**, not the collapsed pill — invisible to non-technical users, readable for support. Omitted when unavailable.

## Tests

Regression guard fails before, passes after:

```
TypeError: serverWorkspaces.filter is not a function.
(fail) keeps desktop workspaces when the server workspace list is not an array
```

| Suite | Result |
| --- | --- |
| `apps/app` full suite | 514 pass / 0 fail |
| den-api `cloud-instance-route` | 33 pass / 0 fail |
| `tsc --noEmit` app + den-api | clean |

Coverage: `{}`, `{items: undefined}`, and rejected promises all degrade without throwing; non-array merge input; `instanceName` present/absent; gateway resolve unchanged; panel renders/omits the computer line.