### PR TITLE
feat(evals): release lab — hermetic update feed driving real version resolution

### DIFF
--- a/evals/flows/release-allowlist-targeting.flow.mjs
+++ b/evals/flows/release-allowlist-targeting.flow.mjs
@@ -1,0 +1,77 @@
+import { ReleaseFeedLab, createReleaseCatalog } from "../runner/labs/release-feed.mjs";
+import { expectDownloadUrl, expectOfferedVersion, releaseLabProductImportPrecondition } from "../runner/journeys/update.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "release-allowlist-targeting";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+export default {
+  id: FLOW_ID,
+  title: "Hermetic release lab targets the highest admin-allowed desktop version",
+  kind: "internal",
+  requiresApp: false,
+  precondition: releaseLabProductImportPrecondition,
+  steps: [
+    {
+      name: "Frame 1 — allowlist caps below latest",
+      run: async (ctx) => {
+        const feed = await new ReleaseFeedLab({
+          catalog: createReleaseCatalog(["0.17.20", "0.17.30", "0.17.40"], { platforms: ["win-x64"], distribution: "enterprise" }),
+        }).start();
+        try {
+          await ctx.prove("A client allowed through 0.17.30 is offered 0.17.30, never public latest 0.17.40", {
+            voiceover: vo[0],
+            assert: async () => {
+              await expectOfferedVersion(ctx, {
+                feed,
+                client: { currentVersion: "0.17.20", platform: "win-x64", allowedVersions: ["0.17.30"] },
+                expected: "0.17.30",
+              });
+              await expectDownloadUrl(ctx, {
+                feed,
+                version: "0.17.30",
+                platform: "win-x64",
+                expected: `${feed.baseUrl}/different-ai/openwork/releases/download/v0.17.30/openwork-enterprise-win-x64-0.17.30.exe`,
+              });
+            },
+          });
+        } finally {
+          await feed.stop();
+        }
+      },
+    },
+    {
+      name: "Frame 2 — allowed release predates installer support",
+      run: async (ctx) => {
+        const feed = await new ReleaseFeedLab({
+          catalog: createReleaseCatalog(["0.17.20", "0.17.40"], {
+            platforms: ["win-x64"],
+            distribution: "enterprise",
+            preInstallerVersions: ["0.17.20"],
+          }),
+        }).start();
+        try {
+          await ctx.prove("An approved release without installer-capable assets fails with an actionable error", {
+            voiceover: vo[1],
+            assert: async () => {
+              await expectOfferedVersion(ctx, {
+                feed,
+                client: { currentVersion: "0.17.10", platform: "win-x64", allowedVersions: ["0.17.20"] },
+                expected: "0.17.20",
+              });
+              await expectDownloadUrl(ctx, {
+                feed,
+                version: "0.17.20",
+                platform: "win-x64",
+                expected: { errorCode: "release_asset_not_installer_capable" },
+              });
+            },
+          });
+        } finally {
+          await feed.stop();
+        }
+      },
+    },
+  ],
+};

--- a/evals/flows/release-bootstrap-precedence.flow.mjs
+++ b/evals/flows/release-bootstrap-precedence.flow.mjs
@@ -1,0 +1,45 @@
+import { expectBootstrapPrecedenceSurvives, releaseLabProductImportPrecondition } from "../runner/journeys/update.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "release-bootstrap-precedence";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+const ORG_URL = "http://openwork.example-manufacturing.internal:48765";
+const HOSTED_URL = "https://app.openworklabs.com";
+
+export default {
+  id: FLOW_ID,
+  title: "Update-like bootstrap re-resolution preserves the configured organization server URL",
+  kind: "internal",
+  requiresApp: false,
+  precondition: releaseLabProductImportPrecondition,
+  steps: [
+    {
+      name: "Frame 1 — organization bootstrap outranks hosted update bundle",
+      run: async (ctx) => {
+        await ctx.prove("The real desktop bootstrap precedence keeps the organization server URL across canonical and legacy update paths", {
+          voiceover: vo[0],
+          assert: async () => {
+            await expectBootstrapPrecedenceSurvives(ctx, {
+              before: {
+                serverUrl: ORG_URL,
+                bundleServerUrl: HOSTED_URL,
+                installedPath: "canonical",
+              },
+              after: { serverUrl: ORG_URL },
+            });
+            await expectBootstrapPrecedenceSurvives(ctx, {
+              before: {
+                serverUrl: ORG_URL,
+                bundleServerUrl: HOSTED_URL,
+                installedPath: "legacy",
+              },
+              after: { serverUrl: ORG_URL },
+            });
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/flows/release-feed-degraded.flow.mjs
+++ b/evals/flows/release-feed-degraded.flow.mjs
@@ -1,0 +1,82 @@
+import { ReleaseFeedLab, createReleaseCatalog } from "../runner/labs/release-feed.mjs";
+import { expectActionableFeedError, releaseLabProductImportPrecondition } from "../runner/journeys/update.mjs";
+import { loadVoiceoverParagraphs } from "../runner/voiceover.mjs";
+
+const FLOW_ID = "release-feed-degraded";
+const vo = await loadVoiceoverParagraphs(FLOW_ID);
+if (!vo) throw new Error(`Missing approved voice-over script for ${FLOW_ID}.`);
+
+export default {
+  id: FLOW_ID,
+  title: "Release feed degradation produces named actionable errors",
+  kind: "internal",
+  requiresApp: false,
+  precondition: releaseLabProductImportPrecondition,
+  steps: [
+    {
+      name: "Frame 1 — artifact propagation 504",
+      run: async (ctx) => {
+        const feed = await new ReleaseFeedLab({
+          catalog: [{
+            version: "0.17.40",
+            assets: [{
+              platform: "win-x64",
+              distribution: "enterprise",
+              fault: { kind: "status", status: 504, message: "release propagation lag" },
+            }],
+          }],
+          actionableProbe: { kind: "asset", version: "0.17.40", platform: "win-x64" },
+        }).start();
+        try {
+          await ctx.prove("A 504 from the artifact route surfaces as release_asset_propagation_lag", {
+            voiceover: vo[0],
+            assert: async () => {
+              const error = await expectActionableFeedError(ctx, { feed });
+              ctx.assert(error.code === "release_asset_propagation_lag", `Expected release_asset_propagation_lag, got ${error.code}`);
+            },
+          });
+        } finally {
+          await feed.stop();
+        }
+      },
+    },
+    {
+      name: "Frame 2 — stale version cache",
+      run: async (ctx) => {
+        const feed = new ReleaseFeedLab({
+          initialCatalog: createReleaseCatalog(["0.17.20"], { platforms: ["win-x64"], distribution: "enterprise" }),
+          catalog: createReleaseCatalog(["0.17.20", "0.17.40"], { platforms: ["win-x64"], distribution: "enterprise" }),
+          staleUntil: Date.now() + 60_000,
+          actionableProbe: { kind: "cache", expectedVersion: "0.17.40" },
+        });
+        await ctx.prove("A stale release metadata cache surfaces as release_feed_cache_stale", {
+          voiceover: vo[1],
+          assert: async () => {
+            const error = await expectActionableFeedError(ctx, { feed });
+            ctx.assert(error.code === "release_feed_cache_stale", `Expected release_feed_cache_stale, got ${error.code}`);
+          },
+        });
+      },
+    },
+    {
+      name: "Frame 3 — denied release host",
+      run: async (ctx) => {
+        const feed = new ReleaseFeedLab({
+          catalog: createReleaseCatalog(["0.17.40"], { platforms: ["win-x64"], distribution: "enterprise" }),
+          actionableProbe: {
+            kind: "host",
+            url: "https://github.com/different-ai/openwork/releases/download/v0.17.40/openwork-enterprise-win-x64-0.17.40.exe",
+            allowedHosts: ["app.openworklabs.com", "api.openworklabs.com"],
+          },
+        });
+        await ctx.prove("A corporate policy that denies GitHub surfaces as release_host_denied", {
+          voiceover: vo[2],
+          assert: async () => {
+            const error = await expectActionableFeedError(ctx, { feed });
+            ctx.assert(error.code === "release_host_denied", `Expected release_host_denied, got ${error.code}`);
+          },
+        });
+      },
+    },
+  ],
+};

--- a/evals/runner/journeys/index.ts
+++ b/evals/runner/journeys/index.ts
@@ -1,5 +1,6 @@
 export * from "./den.ts";
 export * from "./desktop.ts";
+export * from "./update.ts";
 
 import { acceptInvite, apiSignIn, createOrg, inviteMember, signInWeb, signUpWeb } from "./den.ts";
 import { connectDen, firstBoot, openSettings, runPrompt } from "./desktop.ts";

--- a/evals/runner/journeys/update.mjs
+++ b/evals/runner/journeys/update.mjs
@@ -1,0 +1,1 @@
+export * from "./update.ts";

--- a/evals/runner/journeys/update.ts
+++ b/evals/runner/journeys/update.ts
@@ -1,0 +1,454 @@
+import { execFile } from "node:child_process";
+import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { EvalError } from "../context.ts";
+import {
+  ReleaseFeedLab,
+  ReleaseLabError,
+  compareReleaseVersions,
+  isReleaseLabError,
+} from "../labs/release-feed.ts";
+import type { FlowContext } from "../flow.ts";
+import type { ReleaseDistribution, ReleaseLabErrorCode, ReleasePlatform } from "../labs/release-feed.ts";
+
+type StableDesktopUpdateSelection =
+  | { kind: "update"; targetVersion: string; latestPublishedVersion: string }
+  | { kind: "blocked"; latestPublishedVersion: string }
+  | { kind: "current"; latestPublishedVersion: string };
+
+export interface ReleaseClientInput {
+  currentVersion: string;
+  platform: ReleasePlatform;
+  allowedVersions?: string[] | null;
+}
+
+export type ExpectedOfferedVersion = string | null | StableDesktopUpdateSelection;
+
+export interface ExpectOfferedVersionOptions {
+  feed: ReleaseFeedLab;
+  client: ReleaseClientInput;
+  expected: ExpectedOfferedVersion;
+}
+
+export type ExpectedDownloadUrl = string | {
+  url?: string;
+  fileName?: string;
+  errorCode?: ReleaseLabErrorCode;
+  renamedFileName?: string;
+};
+
+export interface ExpectDownloadUrlOptions {
+  feed: ReleaseFeedLab;
+  version: string;
+  platform: ReleasePlatform;
+  expected: ExpectedDownloadUrl;
+  distribution?: ReleaseDistribution;
+}
+
+export interface BootstrapPrecedenceBefore {
+  serverUrl: string;
+  bundleServerUrl: string;
+  installedPath?: "canonical" | "legacy";
+  installedWrittenAt?: string;
+  bundleWrittenAt?: string;
+}
+
+export interface BootstrapPrecedenceAfter {
+  serverUrl: string;
+}
+
+export interface BootstrapPrecedenceOptions {
+  before: BootstrapPrecedenceBefore;
+  after: BootstrapPrecedenceAfter;
+}
+
+export interface BootstrapPrecedenceResult {
+  installedPath: "canonical" | "legacy";
+  importedBeforeRead: boolean;
+  importedAfterRestart: boolean;
+  firstBaseUrl: string;
+  restartedBaseUrl: string;
+  persistedBaseUrl: string;
+  canonicalPath: string;
+  legacyPath: string;
+}
+
+export interface ExpectActionableFeedErrorOptions {
+  feed: ReleaseFeedLab;
+}
+
+interface ProductDownloadUrlResult {
+  fileName: string;
+  githubUrl: string;
+}
+
+interface FilenameTagResult {
+  host: string;
+  token: string;
+}
+
+interface WorkspaceStore {
+  importBundledDesktopBootstrapConfigIfPreferred(): Promise<boolean>;
+  getDesktopBootstrapConfig(): Promise<unknown>;
+}
+
+interface WorkspaceStoreModule {
+  createWorkspaceStore(input: {
+    app: { getPath(name: string): string };
+    defaultDenBaseUrl: string;
+    defaultRequireSignin: boolean;
+    forceRequireSignin: boolean;
+  }): WorkspaceStore;
+}
+
+interface DesktopUpdaterModule {
+  targetedStableUpdaterFeed(currentVersion: string, targetVersion: string): string;
+}
+
+const ROOT = path.join(path.dirname(fileURLToPath(import.meta.url)), "..", "..", "..");
+const WORKSPACE_STORE_PATH = path.join(ROOT, "apps", "desktop", "electron", "workspace-store.mjs");
+const DESKTOP_UPDATER_PATH = path.join(ROOT, "apps", "desktop", "electron", "updater.mjs");
+const PRODUCT_ENV: NodeJS.ProcessEnv = {
+  ...process.env,
+  DATABASE_URL: process.env.DATABASE_URL ?? "mysql://root:password@127.0.0.1:3306/openwork_den",
+  DEN_DB_ENCRYPTION_KEY: process.env.DEN_DB_ENCRYPTION_KEY ?? "local-dev-db-encryption-key-please-change-1234567890",
+  BETTER_AUTH_SECRET: process.env.BETTER_AUTH_SECRET ?? "local-dev-secret-not-for-production-use!!",
+  BETTER_AUTH_URL: process.env.BETTER_AUTH_URL ?? "http://localhost:3005",
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function restoreEnv(name: string, value: string | undefined): void {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+function stringifyActual(value: unknown): string {
+  if (typeof value === "string") return value;
+  return JSON.stringify(value, null, 2);
+}
+
+function witness(ctx: FlowContext, condition: unknown, assertion: string, actual?: unknown): void {
+  ctx.recordEvidence({ type: "assertion", status: condition ? "passed" : "failed", assertion, actual });
+  ctx.assert(condition, `${assertion}${actual === undefined ? "" : ` (actual: ${stringifyActual(actual).slice(0, 500)})`}`);
+}
+
+export function releaseLabProductImportPrecondition(): Promise<string | null> {
+  return new Promise((resolve) => {
+    execFile("bun", ["--version"], { encoding: "utf8", timeout: 5_000 }, (error) => {
+      if (!error) {
+        resolve(null);
+        return;
+      }
+      resolve(
+        "Release lab flows drive real product TypeScript modules through bun, but `bun` is not available on PATH. "
+        + "Install Bun and add it to PATH (nightly CI uses oven-sh/setup-bun@v2 with bun 1.3.9), then rerun the flow.",
+      );
+    });
+  });
+}
+
+function execBunJson(script: string, input: unknown, moduleLabel: string, env: NodeJS.ProcessEnv = PRODUCT_ENV): Promise<unknown> {
+  return new Promise((resolve, reject) => {
+    execFile(
+      "bun",
+      ["-e", script, JSON.stringify(input)],
+      { cwd: ROOT, env, encoding: "utf8", timeout: 60_000, maxBuffer: 1024 * 1024 },
+      (error, stdout, stderr) => {
+        if (error) {
+          const missingBun = error.code === "ENOENT";
+          reject(new EvalError(
+            missingBun
+              ? `Product import through bun failed while importing ${moduleLabel}: bun was not found on PATH. Install Bun and add it to PATH (nightly CI uses oven-sh/setup-bun@v2 with bun 1.3.9). stderr: ${stderr}`
+              : `Product import through bun failed while importing ${moduleLabel}. The release lab uses bun so real product TS modules resolve the same way they do in app/package workspaces. stderr: ${stderr}\nerror: ${error.message}`,
+          ));
+          return;
+        }
+        try {
+          resolve(JSON.parse(stdout.trim() || "null"));
+        } catch (parseError) {
+          reject(new EvalError(`Product import returned non-JSON output: ${parseError instanceof Error ? parseError.message : String(parseError)}\n${stdout}`));
+        }
+      },
+    );
+  });
+}
+
+function stableSelectionFromUnknown(value: unknown): StableDesktopUpdateSelection | null {
+  if (value === null) return null;
+  if (!isRecord(value) || typeof value.kind !== "string") return null;
+  if (value.kind === "update" && typeof value.targetVersion === "string" && typeof value.latestPublishedVersion === "string") {
+    return { kind: "update", targetVersion: value.targetVersion, latestPublishedVersion: value.latestPublishedVersion };
+  }
+  if (value.kind === "blocked" && typeof value.latestPublishedVersion === "string") {
+    return { kind: "blocked", latestPublishedVersion: value.latestPublishedVersion };
+  }
+  if (value.kind === "current" && typeof value.latestPublishedVersion === "string") {
+    return { kind: "current", latestPublishedVersion: value.latestPublishedVersion };
+  }
+  return null;
+}
+
+function productDownloadUrlResultFromUnknown(value: unknown): ProductDownloadUrlResult {
+  if (isRecord(value) && typeof value.fileName === "string" && typeof value.githubUrl === "string") {
+    return { fileName: value.fileName, githubUrl: value.githubUrl };
+  }
+  throw new EvalError(`Product download URL result had the wrong shape: ${JSON.stringify(value)}`);
+}
+
+function filenameTagFromUnknown(value: unknown): FilenameTagResult | null {
+  if (value === null) return null;
+  if (isRecord(value) && typeof value.host === "string" && typeof value.token === "string") {
+    return { host: value.host, token: value.token };
+  }
+  return null;
+}
+
+function expectedSelectionMatches(actual: StableDesktopUpdateSelection | null, expected: ExpectedOfferedVersion): boolean {
+  if (typeof expected === "string") return actual?.kind === "update" && compareReleaseVersions(actual.targetVersion, expected) === 0;
+  if (expected === null) return actual === null || actual.kind !== "update";
+  if (!actual || actual.kind !== expected.kind) return false;
+  if (actual.kind === "update" && expected.kind === "update") return compareReleaseVersions(actual.targetVersion, expected.targetVersion) === 0;
+  return actual.latestPublishedVersion === expected.latestPublishedVersion;
+}
+
+function expectedDownloadObject(expected: ExpectedDownloadUrl): { url?: string; fileName?: string; errorCode?: ReleaseLabErrorCode; renamedFileName?: string } {
+  return typeof expected === "string" ? { url: expected } : expected;
+}
+
+async function selectStableDesktopUpdateWithProduct(input: {
+  currentVersion: string;
+  metadata: unknown;
+  allowedVersions?: string[] | null;
+}): Promise<StableDesktopUpdateSelection | null> {
+  const script = `
+const input = JSON.parse(process.argv[1]);
+const module = await import("./apps/app/src/app/lib/version-gate.ts");
+const desktopConfig = Array.isArray(input.allowedVersions) ? { allowedDesktopVersions: input.allowedVersions } : {};
+const selection = module.selectStableDesktopUpdate({ currentVersion: input.currentVersion, metadata: input.metadata, desktopConfig });
+console.log(JSON.stringify(selection));
+`;
+  return stableSelectionFromUnknown(await execBunJson(script, input, "apps/app/src/app/lib/version-gate.ts"));
+}
+
+async function productDownloadUrl(input: {
+  version: string;
+  platform: ReleasePlatform;
+  distribution: ReleaseDistribution;
+}): Promise<ProductDownloadUrlResult> {
+  const script = `
+const input = JSON.parse(process.argv[1]);
+const module = await import("./ee/apps/den-api/src/utils/installer-artifacts.ts");
+const releaseTag = input.version.startsWith("v") ? input.version : "v" + input.version;
+const fileName = input.distribution === "cloud"
+  ? module.cloudDesktopReleaseAssetName(input.platform, releaseTag)
+  : input.distribution === "public"
+    ? module.desktopReleaseAssetName(input.platform, releaseTag)
+    : module.enterpriseDesktopReleaseAssetName(input.platform, releaseTag);
+const githubUrl = module.installerReleaseAssetUrl(fileName, { releaseTag, releaseRepo: "different-ai/openwork" });
+console.log(JSON.stringify({ fileName, githubUrl }));
+`;
+  return productDownloadUrlResultFromUnknown(await execBunJson(script, input, "ee/apps/den-api/src/utils/installer-artifacts.ts"));
+}
+
+async function parseInstallerFilenameTagWithProduct(fileName: string): Promise<FilenameTagResult | null> {
+  const script = `
+const input = JSON.parse(process.argv[1]);
+const module = await import("./packages/install-config/src/index.ts");
+console.log(JSON.stringify(module.parseInstallerFilenameTag(input.fileName)));
+`;
+  return filenameTagFromUnknown(await execBunJson(script, { fileName }, "packages/install-config/src/index.ts"));
+}
+
+function baseUrlFromUnknown(value: unknown): string {
+  if (isRecord(value) && typeof value.baseUrl === "string") return value.baseUrl;
+  return "";
+}
+
+function isWorkspaceStoreModule(value: unknown): value is WorkspaceStoreModule {
+  return isRecord(value) && typeof value.createWorkspaceStore === "function";
+}
+
+function isDesktopUpdaterModule(value: unknown): value is DesktopUpdaterModule {
+  return isRecord(value) && typeof value.targetedStableUpdaterFeed === "function";
+}
+
+async function targetedStableUpdaterFeedWithProduct(currentVersion: string, targetVersion: string): Promise<string> {
+  const moduleUrl = new URL(`file://${DESKTOP_UPDATER_PATH}?release-lab=${Date.now()}-${Math.random()}`);
+  const module = await import(moduleUrl.href);
+  if (!isDesktopUpdaterModule(module)) throw new EvalError("updater.mjs did not export targetedStableUpdaterFeed.");
+  return module.targetedStableUpdaterFeed(currentVersion, targetVersion);
+}
+
+async function writeJsonFile(targetPath: string, value: unknown): Promise<void> {
+  await mkdir(path.dirname(targetPath), { recursive: true });
+  await writeFile(targetPath, `${JSON.stringify(value, null, 2)}\n`, "utf8");
+}
+
+async function readPersistedBaseUrl(canonicalPath: string): Promise<string> {
+  const parsed: unknown = JSON.parse(await readFile(canonicalPath, "utf8"));
+  return baseUrlFromUnknown(parsed);
+}
+
+export async function expectOfferedVersion(ctx: FlowContext, options: ExpectOfferedVersionOptions): Promise<StableDesktopUpdateSelection | null> {
+  const metadata = options.feed.metadata();
+  const selection = await selectStableDesktopUpdateWithProduct({
+    currentVersion: options.client.currentVersion,
+    metadata,
+    allowedVersions: options.client.allowedVersions,
+  });
+  witness(
+    ctx,
+    expectedSelectionMatches(selection, options.expected),
+    "apps/app/src/app/lib/version-gate.ts selectStableDesktopUpdate offered the expected version",
+    { client: options.client, metadata, selection, expected: options.expected },
+  );
+  if (selection?.kind === "update") {
+    const targetedFeedUrl = await targetedStableUpdaterFeedWithProduct(options.client.currentVersion, selection.targetVersion);
+    witness(
+      ctx,
+      targetedFeedUrl.endsWith(`/v${selection.targetVersion}`) && !targetedFeedUrl.includes("/latest/"),
+      "apps/desktop/electron/updater.mjs targetedStableUpdaterFeed built a version-specific stable feed URL",
+      { targetedFeedUrl, labFeedUrl: options.feed.localizeGitHubUrl(targetedFeedUrl) },
+    );
+    ctx.output("product version selection", JSON.stringify({ client: options.client, metadata, selection, targetedFeedUrl }, null, 2));
+    return selection;
+  }
+  ctx.output("product version selection", JSON.stringify({ client: options.client, metadata, selection }, null, 2));
+  return selection;
+}
+
+export async function expectDownloadUrl(ctx: FlowContext, options: ExpectDownloadUrlOptions): Promise<string | null> {
+  const expected = expectedDownloadObject(options.expected);
+  const distribution = options.distribution ?? "enterprise";
+  try {
+    const product = await productDownloadUrl({ version: options.version, platform: options.platform, distribution });
+    options.feed.assertInstallableAsset(options.version, options.platform, distribution);
+    const localUrl = options.feed.localizeGitHubUrl(product.githubUrl);
+    witness(
+      ctx,
+      expected.url === undefined || localUrl === expected.url,
+      "ee/apps/den-api/src/utils/installer-artifacts.ts constructed the expected release asset URL when localized to the lab host",
+      { product, localUrl, expected: expected.url },
+    );
+    if (expected.fileName) {
+      witness(ctx, product.fileName === expected.fileName, "Den installer artifact code selected the expected filename", { product, expected: expected.fileName });
+    }
+    if (expected.renamedFileName) {
+      const asset = options.feed.resolveClientDownloadedAsset(options.version, options.platform, expected.renamedFileName);
+      const parsedTag = await parseInstallerFilenameTagWithProduct(expected.renamedFileName);
+      witness(ctx, asset.fileName === product.fileName, "Release lab resolves a browser-renamed downloaded file back to the original asset", { renamedFileName: expected.renamedFileName, asset: asset.fileName, parsedTag });
+    }
+    ctx.output("product download URL", JSON.stringify({ ...product, localUrl }, null, 2));
+    return localUrl;
+  } catch (error) {
+    if (isReleaseLabError(error) && expected.errorCode === error.code) {
+      witness(ctx, true, `Release lab surfaced actionable ${error.code}`, { message: error.message, action: error.action });
+      ctx.output("actionable release error", JSON.stringify({ code: error.code, message: error.message, action: error.action }, null, 2));
+      return null;
+    }
+    throw error;
+  }
+}
+
+export async function resolveBootstrapPrecedence(options: BootstrapPrecedenceOptions): Promise<BootstrapPrecedenceResult> {
+  const root = await mkdtemp(path.join(tmpdir(), "openwork-release-bootstrap-"));
+  const home = path.join(root, "home");
+  const xdg = path.join(root, "xdg");
+  const userData = path.join(root, "userData");
+  const bundleDir = path.join(root, "downloads", "OpenWork update bundle");
+  const canonicalPath = path.join(xdg, "openwork", "desktop-bootstrap.json");
+  const legacyPath = path.join(home, ".config", "openwork", "desktop-bootstrap.json");
+  const installedPath = options.before.installedPath ?? "canonical";
+  const installedBootstrapPath = installedPath === "legacy" ? legacyPath : canonicalPath;
+  const previousHome = process.env.HOME;
+  const previousXdg = process.env.XDG_CONFIG_HOME;
+  const previousOverride = process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH;
+  const previousBundle = process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR;
+  const previousDevMode = process.env.OPENWORK_DEV_MODE;
+
+  process.env.HOME = home;
+  process.env.XDG_CONFIG_HOME = xdg;
+  process.env.OPENWORK_BOOTSTRAP_BUNDLE_DIR = bundleDir;
+  delete process.env.OPENWORK_DESKTOP_BOOTSTRAP_PATH;
+  delete process.env.OPENWORK_DEV_MODE;
+
+  try {
+    await writeJsonFile(installedBootstrapPath, {
+      baseUrl: options.before.serverUrl,
+      apiBaseUrl: options.before.serverUrl,
+      requireSignin: true,
+      writtenAt: options.before.installedWrittenAt ?? "2026-07-09T12:00:00.000Z",
+    });
+    await mkdir(bundleDir, { recursive: true });
+    await writeFile(path.join(bundleDir, "openwork-win-x64-0.17.40.exe"), "signed installer", "utf8");
+    await writeJsonFile(path.join(bundleDir, "desktop-bootstrap.json"), {
+      baseUrl: options.before.bundleServerUrl,
+      apiBaseUrl: options.before.bundleServerUrl,
+      requireSignin: false,
+      writtenAt: options.before.bundleWrittenAt ?? "2026-07-10T12:00:00.000Z",
+    });
+
+    const moduleUrl = new URL(`file://${WORKSPACE_STORE_PATH}?release-lab=${Date.now()}-${Math.random()}`);
+    const module = await import(moduleUrl.href);
+    if (!isWorkspaceStoreModule(module)) throw new EvalError("workspace-store.mjs did not export createWorkspaceStore.");
+    const createStore = () => module.createWorkspaceStore({
+      app: { getPath: (name) => name === "userData" ? userData : root },
+      defaultDenBaseUrl: "https://default.openworklabs.com",
+      defaultRequireSignin: false,
+      forceRequireSignin: false,
+    });
+    const store = createStore();
+    const importedBeforeRead = await store.importBundledDesktopBootstrapConfigIfPreferred();
+    const firstConfig = await store.getDesktopBootstrapConfig();
+    const restartedStore = createStore();
+    const importedAfterRestart = await restartedStore.importBundledDesktopBootstrapConfigIfPreferred();
+    const restartedConfig = await restartedStore.getDesktopBootstrapConfig();
+    const persistedBaseUrl = await readPersistedBaseUrl(canonicalPath);
+
+    return {
+      installedPath,
+      importedBeforeRead,
+      importedAfterRestart,
+      firstBaseUrl: baseUrlFromUnknown(firstConfig),
+      restartedBaseUrl: baseUrlFromUnknown(restartedConfig),
+      persistedBaseUrl,
+      canonicalPath,
+      legacyPath,
+    };
+  } finally {
+    restoreEnv("HOME", previousHome);
+    restoreEnv("XDG_CONFIG_HOME", previousXdg);
+    restoreEnv("OPENWORK_DESKTOP_BOOTSTRAP_PATH", previousOverride);
+    restoreEnv("OPENWORK_BOOTSTRAP_BUNDLE_DIR", previousBundle);
+    restoreEnv("OPENWORK_DEV_MODE", previousDevMode);
+    await rm(root, { recursive: true, force: true });
+  }
+}
+
+export async function expectBootstrapPrecedenceSurvives(ctx: FlowContext, options: BootstrapPrecedenceOptions): Promise<BootstrapPrecedenceResult> {
+  const result = await resolveBootstrapPrecedence(options);
+  witness(ctx, result.firstBaseUrl === options.after.serverUrl, "workspace-store.mjs getDesktopBootstrapConfig keeps the installed server URL", result);
+  witness(ctx, result.restartedBaseUrl === options.after.serverUrl, "workspace-store.mjs keeps the server URL after update-like re-resolution", result);
+  witness(ctx, result.persistedBaseUrl === options.after.serverUrl, "desktop-bootstrap.json persisted the organization server URL", result);
+  ctx.output(`bootstrap precedence (${result.installedPath})`, JSON.stringify(result, null, 2));
+  return result;
+}
+
+export async function expectActionableFeedError(ctx: FlowContext, options: ExpectActionableFeedErrorOptions): Promise<ReleaseLabError> {
+  try {
+    await options.feed.runActionableProbe();
+  } catch (error) {
+    if (isReleaseLabError(error) && error.code !== "release_probe_unexpected_success" && error.action.trim()) {
+      witness(ctx, true, `Release feed failure surfaced as actionable ${error.code}`, { code: error.code, message: error.message, action: error.action, status: error.status });
+      ctx.output(`actionable ${error.code}`, JSON.stringify({ code: error.code, message: error.message, action: error.action, status: error.status }, null, 2));
+      return error;
+    }
+    throw error;
+  }
+  throw new EvalError("Expected the release feed probe to fail with an actionable error, but it succeeded.");
+}

--- a/evals/runner/labs/release-feed.mjs
+++ b/evals/runner/labs/release-feed.mjs
@@ -1,0 +1,1 @@
+export * from "./release-feed.ts";

--- a/evals/runner/labs/release-feed.ts
+++ b/evals/runner/labs/release-feed.ts
@@ -1,0 +1,800 @@
+import { createServer } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import { setTimeout as sleep } from "node:timers/promises";
+
+export type ReleasePlatform = "mac-arm64" | "mac-x64" | "win-x64" | "linux-x64" | "linux-arm64";
+export type ReleaseDistribution = "public" | "enterprise" | "cloud";
+
+export type ReleaseLabErrorCode =
+  | "release_asset_missing"
+  | "release_asset_not_installer_capable"
+  | "release_asset_propagation_lag"
+  | "release_asset_unavailable"
+  | "release_feed_cache_stale"
+  | "release_host_denied"
+  | "release_probe_unexpected_success";
+
+export type ReleaseAssetFault =
+  | { kind: "status"; status: number; message?: string }
+  | { kind: "slow-chunked"; chunkSize: number; delayMs: number };
+
+export interface ReleaseAssetInput {
+  platform: ReleasePlatform;
+  distribution?: ReleaseDistribution;
+  fileName?: string;
+  body?: string | Uint8Array;
+  contentType?: string;
+  installerCapable?: boolean;
+  rewrittenFileName?: string;
+  fault?: ReleaseAssetFault;
+}
+
+export interface ReleaseVersionInput {
+  version: string;
+  publishedAt?: string;
+  prerelease?: boolean;
+  installerCapable?: boolean;
+  assets?: ReleaseAssetInput[];
+}
+
+export interface ReleaseAsset {
+  platform: ReleasePlatform;
+  distribution: ReleaseDistribution;
+  fileName: string;
+  body: Uint8Array;
+  size: number;
+  contentType: string;
+  installerCapable: boolean;
+  rewrittenFileName: string | null;
+  fault: ReleaseAssetFault | null;
+}
+
+export interface ReleaseVersion {
+  version: string;
+  tagName: string;
+  publishedAt: string;
+  prerelease: boolean;
+  installerCapable: boolean;
+  assets: ReleaseAsset[];
+}
+
+export interface DenAppVersionMetadataFixture {
+  minAppVersion: string;
+  latestAppVersion: string;
+  publishedDesktopVersions: string[];
+}
+
+export interface CatalogOptions {
+  platforms?: ReleasePlatform[];
+  distribution?: ReleaseDistribution;
+  preInstallerVersions?: string[];
+}
+
+export interface ResolveAllowedUpdateInput {
+  catalog: ReleaseVersion[];
+  currentVersion: string;
+  allowedVersions?: string[] | null;
+}
+
+export type ReleaseFeedProbe =
+  | { kind: "asset"; version: string; platform: ReleasePlatform; allowedHosts?: string[] }
+  | { kind: "cache"; expectedVersion: string }
+  | { kind: "host"; url?: string; version?: string; platform?: ReleasePlatform; allowedHosts: string[] };
+
+export interface ReleaseFeedLabConfig {
+  catalog: ReleaseVersionInput[];
+  initialCatalog?: ReleaseVersionInput[];
+  allowedVersions?: string[] | null;
+  cacheTtlMs?: number;
+  staleUntil?: number | Date;
+  repo?: string;
+  actionableProbe?: ReleaseFeedProbe;
+}
+
+export interface ReleaseSnapshot {
+  catalog: ReleaseVersion[];
+  metadata: DenAppVersionMetadataFixture;
+  stale: boolean;
+  cachedUntil: number | null;
+}
+
+export interface ReleaseAssetUrlInput {
+  baseUrl: string;
+  version: string;
+  fileName: string;
+  repo?: string;
+}
+
+type ComparableVersion = {
+  release: number[];
+  prerelease: string[];
+};
+
+const DEFAULT_REPO = "different-ai/openwork";
+const DEFAULT_PLATFORMS: ReleasePlatform[] = ["mac-arm64", "mac-x64", "win-x64", "linux-x64", "linux-arm64"];
+const DEFAULT_DISTRIBUTION: ReleaseDistribution = "enterprise";
+const textEncoder = new TextEncoder();
+
+export class ReleaseLabError extends Error {
+  code: ReleaseLabErrorCode;
+  action: string;
+  status: number | null;
+
+  constructor(code: ReleaseLabErrorCode, message: string, action: string, status: number | null = null) {
+    super(message);
+    this.name = code;
+    this.code = code;
+    this.action = action;
+    this.status = status;
+  }
+}
+
+export function isReleaseLabError(value: unknown): value is ReleaseLabError {
+  return value instanceof ReleaseLabError;
+}
+
+function parseComparableVersion(value: string): ComparableVersion | null {
+  const normalized = value.trim().replace(/^v/i, "");
+  if (!normalized) return null;
+
+  const [withoutBuild] = normalized.split("+", 1);
+  if (!withoutBuild) return null;
+
+  const [releasePart, prereleasePart = ""] = withoutBuild.split("-", 2);
+  const release = releasePart.split(".").map((part) => Number(part));
+  if (release.length !== 3 || release.some((part) => !Number.isInteger(part) || part < 0)) {
+    return null;
+  }
+
+  const prerelease = prereleasePart
+    .split(".")
+    .flatMap((part) => {
+      const trimmed = part.trim();
+      return trimmed ? [trimmed] : [];
+    });
+  return { release, prerelease };
+}
+
+function comparePrerelease(left: string[], right: string[]): number {
+  if (!left.length && !right.length) return 0;
+  if (!left.length) return 1;
+  if (!right.length) return -1;
+
+  const count = Math.max(left.length, right.length);
+  for (let index = 0; index < count; index += 1) {
+    const leftPart = left[index];
+    const rightPart = right[index];
+    if (leftPart === undefined) return -1;
+    if (rightPart === undefined) return 1;
+
+    const leftNumeric = /^\d+$/.test(leftPart) ? Number(leftPart) : null;
+    const rightNumeric = /^\d+$/.test(rightPart) ? Number(rightPart) : null;
+    if (leftNumeric !== null && rightNumeric !== null) {
+      if (leftNumeric !== rightNumeric) return leftNumeric < rightNumeric ? -1 : 1;
+      continue;
+    }
+    if (leftNumeric !== null) return -1;
+    if (rightNumeric !== null) return 1;
+
+    const comparison = leftPart.localeCompare(rightPart);
+    if (comparison !== 0) return comparison < 0 ? -1 : 1;
+  }
+  return 0;
+}
+
+export function normalizeReleaseVersion(value: string): string | null {
+  const normalized = value.trim().replace(/^v/i, "");
+  return /^\d+\.\d+\.\d+$/.test(normalized) ? normalized : null;
+}
+
+export function compareReleaseVersions(left: string, right: string): number | null {
+  const parsedLeft = parseComparableVersion(left);
+  const parsedRight = parseComparableVersion(right);
+  if (!parsedLeft || !parsedRight) return null;
+
+  for (let index = 0; index < 3; index += 1) {
+    const leftPart = parsedLeft.release[index];
+    const rightPart = parsedRight.release[index];
+    if (leftPart === undefined || rightPart === undefined) return null;
+    if (leftPart !== rightPart) return leftPart < rightPart ? -1 : 1;
+  }
+  return comparePrerelease(parsedLeft.prerelease, parsedRight.prerelease);
+}
+
+function requireVersion(value: string): string {
+  const normalized = normalizeReleaseVersion(value);
+  if (!normalized) {
+    throw new ReleaseLabError(
+      "release_asset_missing",
+      `Release version ${JSON.stringify(value)} is not a stable x.y.z version.`,
+      "Use a stable desktop version tag like 0.17.40 or v0.17.40.",
+    );
+  }
+  return normalized;
+}
+
+function versionTag(value: string): string {
+  return `v${requireVersion(value)}`;
+}
+
+function platformFilePart(platform: ReleasePlatform): string {
+  if (platform === "linux-x64") return "linux-x86_64";
+  return platform;
+}
+
+export function desktopReleaseAssetFileName(
+  version: string,
+  platform: ReleasePlatform,
+  distribution: ReleaseDistribution = DEFAULT_DISTRIBUTION,
+): string {
+  const normalized = requireVersion(version);
+  const prefix = distribution === "public" ? "openwork" : `openwork-${distribution}`;
+  if (platform === "win-x64") return `${prefix}-win-x64-${normalized}.exe`;
+  if (platform === "mac-arm64" || platform === "mac-x64") return `${prefix}-${platform}-${normalized}.dmg`;
+  return `${prefix}-${platformFilePart(platform)}-${normalized}.AppImage`;
+}
+
+function contentTypeForPlatform(platform: ReleasePlatform): string {
+  if (platform.startsWith("mac-")) return "application/x-apple-diskimage";
+  if (platform === "win-x64") return "application/vnd.microsoft.portable-executable";
+  return "application/vnd.appimage";
+}
+
+function assetBody(input: ReleaseAssetInput, version: string): Uint8Array {
+  if (typeof input.body === "string") return textEncoder.encode(input.body);
+  if (input.body) return input.body;
+  return textEncoder.encode(`openwork release ${version} ${input.platform}\n`);
+}
+
+function normalizeAsset(input: ReleaseAssetInput, version: string, installerCapable: boolean): ReleaseAsset {
+  const distribution = input.distribution ?? DEFAULT_DISTRIBUTION;
+  const fileName = input.fileName ?? desktopReleaseAssetFileName(version, input.platform, distribution);
+  const body = assetBody(input, version);
+  return {
+    platform: input.platform,
+    distribution,
+    fileName,
+    body,
+    size: body.byteLength,
+    contentType: input.contentType ?? contentTypeForPlatform(input.platform),
+    installerCapable: input.installerCapable ?? installerCapable,
+    rewrittenFileName: input.rewrittenFileName ?? null,
+    fault: input.fault ?? null,
+  };
+}
+
+export function normalizeReleaseCatalog(input: ReleaseVersionInput[]): ReleaseVersion[] {
+  const catalog = input.map((entry, index) => {
+    const version = requireVersion(entry.version);
+    const installerCapable = entry.installerCapable ?? true;
+    const assetsInput = entry.assets ?? DEFAULT_PLATFORMS.map((platform) => ({ platform }));
+    return {
+      version,
+      tagName: versionTag(version),
+      publishedAt: entry.publishedAt ?? new Date(Date.UTC(2026, 0, 1, 12, 0, index)).toISOString(),
+      prerelease: entry.prerelease ?? false,
+      installerCapable,
+      assets: assetsInput.map((asset) => normalizeAsset(asset, version, installerCapable)),
+    };
+  });
+  return sortReleaseCatalog(catalog);
+}
+
+export function createReleaseCatalog(versions: string[], options: CatalogOptions = {}): ReleaseVersionInput[] {
+  const preInstallerVersions = options.preInstallerVersions ?? [];
+  const platforms = options.platforms ?? DEFAULT_PLATFORMS;
+  const distribution = options.distribution ?? DEFAULT_DISTRIBUTION;
+  return versions.map((version) => {
+    const normalized = requireVersion(version);
+    const installerCapable = !preInstallerVersions.some((entry) => compareReleaseVersions(entry, normalized) === 0);
+    return {
+      version: normalized,
+      installerCapable,
+      assets: platforms.map((platform) => ({ platform, distribution, installerCapable })),
+    };
+  });
+}
+
+export function sortReleaseCatalog(catalog: ReleaseVersion[]): ReleaseVersion[] {
+  return [...catalog].sort((left, right) => compareReleaseVersions(left.version, right.version) ?? 0);
+}
+
+export function releaseCatalogMetadata(catalog: ReleaseVersion[]): DenAppVersionMetadataFixture {
+  const sorted = sortReleaseCatalog(catalog);
+  const versions = sorted.map((entry) => entry.version);
+  const minAppVersion = versions[0] ?? "0.0.0";
+  const latestAppVersion = versions.at(-1) ?? "0.0.0";
+  return { minAppVersion, latestAppVersion, publishedDesktopVersions: versions };
+}
+
+export function allowedReleaseCatalog(catalog: ReleaseVersion[], allowedVersions?: string[] | null): ReleaseVersion[] {
+  const sorted = sortReleaseCatalog(catalog);
+  if (!allowedVersions || allowedVersions.length === 0) return sorted;
+  return sorted.filter((release) => allowedVersions.some((allowed) => compareReleaseVersions(release.version, allowed) === 0));
+}
+
+export function highestAllowedVersion(catalog: ReleaseVersion[], allowedVersions?: string[] | null): string | null {
+  return allowedReleaseCatalog(catalog, allowedVersions).at(-1)?.version ?? null;
+}
+
+export function resolveAllowedUpdate(input: ResolveAllowedUpdateInput): string | null {
+  const currentVersion = requireVersion(input.currentVersion);
+  return allowedReleaseCatalog(input.catalog, input.allowedVersions)
+    .filter((release) => compareReleaseVersions(release.version, currentVersion) === 1)
+    .at(-1)?.version ?? null;
+}
+
+function cleanBaseUrl(value: string): string {
+  return value.trim().replace(/\/+$/, "");
+}
+
+export function buildReleaseAssetUrl(input: ReleaseAssetUrlInput): string {
+  const repo = input.repo ?? DEFAULT_REPO;
+  return `${cleanBaseUrl(input.baseUrl)}/${repo}/releases/download/${versionTag(input.version)}/${encodeURIComponent(input.fileName)}`;
+}
+
+export function simulateBrowserRenamedFileName(fileName: string, suffix = " (1)"): string {
+  const extensionIndex = fileName.lastIndexOf(".");
+  if (extensionIndex <= 0) return `${fileName}${suffix}`;
+  return `${fileName.slice(0, extensionIndex)}${suffix}${fileName.slice(extensionIndex)}`;
+}
+
+function stripBrowserRenameSuffix(fileName: string): string {
+  return fileName.replace(/ \(\d+\)(?=\.[^.]+$)/, "");
+}
+
+export function clientFileNameMatchesAsset(asset: ReleaseAsset, clientFileName: string): boolean {
+  const normalized = clientFileName.trim();
+  return normalized === asset.fileName
+    || normalized === asset.rewrittenFileName
+    || stripBrowserRenameSuffix(normalized) === asset.fileName;
+}
+
+function hostFromUrl(value: string): string {
+  try {
+    return new URL(value).host;
+  } catch {
+    return "";
+  }
+}
+
+export function assertReleaseHostAllowed(url: string, allowedHosts: string[]): void {
+  const host = hostFromUrl(url);
+  if (allowedHosts.includes(host)) return;
+  throw new ReleaseLabError(
+    "release_host_denied",
+    `Release download host ${host || "<invalid>"} is not in the allowed outbound host list.`,
+    "Add the release host to enterprise outbound allow rules or configure an internal artifact mirror.",
+  );
+}
+
+export async function fetchAssetOrThrow(url: string, allowedHosts?: string[]): Promise<Uint8Array> {
+  if (allowedHosts) assertReleaseHostAllowed(url, allowedHosts);
+  const response = await fetch(url);
+  if (!response.ok) throw actionableHttpError(response.status, url);
+  return new Uint8Array(await response.arrayBuffer());
+}
+
+function actionableHttpError(status: number, url: string): ReleaseLabError {
+  if (status === 504) {
+    return new ReleaseLabError(
+      "release_asset_propagation_lag",
+      `Release asset ${url} returned HTTP 504 while the release was still propagating.`,
+      "Retry against the mirrored artifact host or wait for release propagation before offering the update.",
+      status,
+    );
+  }
+  return new ReleaseLabError(
+    "release_asset_unavailable",
+    `Release asset ${url} returned HTTP ${status}.`,
+    "Surface the failed artifact URL and status to the user instead of silently reporting no update.",
+    status,
+  );
+}
+
+function cacheStaleError(expectedVersion: string): ReleaseLabError {
+  return new ReleaseLabError(
+    "release_feed_cache_stale",
+    `The release feed cache has not exposed ${versionTag(expectedVersion)} yet.`,
+    "Bypass or expire the release metadata cache before forcing an update during an enterprise rollout.",
+  );
+}
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8" });
+  res.end(`${JSON.stringify(body, null, 2)}\n`);
+}
+
+function sendText(res: ServerResponse, status: number, body: string, headers: Record<string, string> = {}): void {
+  res.writeHead(status, { "content-type": "text/plain; charset=utf-8", ...headers });
+  res.end(body);
+}
+
+function serverBaseUrl(server: Server): string {
+  const address = server.address();
+  if (typeof address === "object" && address !== null && typeof address.port === "number") {
+    return `http://127.0.0.1:${address.port}`;
+  }
+  throw new ReleaseLabError(
+    "release_asset_unavailable",
+    "Release lab server did not expose a TCP port.",
+    "Restart the hermetic release lab fixture before running update assertions.",
+  );
+}
+
+function decodePathSegments(url: URL): string[] {
+  return url.pathname.split("/").filter(Boolean).map((segment) => decodeURIComponent(segment));
+}
+
+function repoFromSegments(segments: string[]): string | null {
+  const releaseIndex = segments.indexOf("releases");
+  if (releaseIndex >= 2) return `${segments[releaseIndex - 2]}/${segments[releaseIndex - 1]}`;
+  return null;
+}
+
+function fileNameFromSegments(segments: string[]): string | null {
+  const downloadIndex = segments.indexOf("download");
+  if (downloadIndex < 0) return null;
+  const fileName = segments.slice(downloadIndex + 2).join("/");
+  return fileName || null;
+}
+
+function tagFromSegments(segments: string[]): string | null {
+  const downloadIndex = segments.indexOf("download");
+  if (downloadIndex < 0) return null;
+  const tag = segments[downloadIndex + 1];
+  return tag || null;
+}
+
+function latestDownloadFileNameFromSegments(segments: string[]): string | null {
+  const releasesIndex = segments.indexOf("releases");
+  if (releasesIndex < 0) return null;
+  if (segments[releasesIndex + 1] !== "latest" || segments[releasesIndex + 2] !== "download") return null;
+  const fileName = segments.slice(releasesIndex + 3).join("/");
+  return fileName || null;
+}
+
+function isGitHubReleasesApi(segments: string[]): boolean {
+  if (segments.length === 4 && segments[0] === "repos" && segments[3] === "releases") return true;
+  return segments.length === 5 && segments[0] === "api" && segments[1] === "repos" && segments[4] === "releases";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+export class ReleaseFeedLab {
+  private catalog: ReleaseVersion[];
+  private initialCatalog: ReleaseVersion[];
+  private cachedSnapshot: ReleaseSnapshot | null;
+  private server: Server | null;
+  private baseUrlValue: string | null;
+  private readonly allowedVersions: string[] | null;
+  private readonly cacheTtlMs: number;
+  private readonly staleUntilMs: number | null;
+  private readonly repo: string;
+  private readonly actionableProbe: ReleaseFeedProbe | null;
+
+  constructor(config: ReleaseFeedLabConfig) {
+    this.catalog = normalizeReleaseCatalog(config.catalog);
+    this.initialCatalog = normalizeReleaseCatalog(config.initialCatalog ?? config.catalog);
+    this.cachedSnapshot = null;
+    this.server = null;
+    this.baseUrlValue = null;
+    this.allowedVersions = config.allowedVersions ? [...config.allowedVersions] : null;
+    this.cacheTtlMs = Math.max(0, config.cacheTtlMs ?? 0);
+    this.staleUntilMs = config.staleUntil instanceof Date ? config.staleUntil.getTime() : config.staleUntil ?? null;
+    this.repo = config.repo ?? DEFAULT_REPO;
+    this.actionableProbe = config.actionableProbe ?? null;
+  }
+
+  get baseUrl(): string {
+    if (!this.baseUrlValue) {
+      throw new ReleaseLabError(
+        "release_asset_unavailable",
+        "Release lab server has not been started.",
+        "Call feed.start() before constructing hermetic artifact URLs.",
+      );
+    }
+    return this.baseUrlValue;
+  }
+
+  updateCatalog(catalog: ReleaseVersionInput[]): void {
+    this.catalog = normalizeReleaseCatalog(catalog);
+  }
+
+  clearCache(): void {
+    this.cachedSnapshot = null;
+  }
+
+  snapshot(now = Date.now()): ReleaseSnapshot {
+    const staleByKnob = this.staleUntilMs !== null && now < this.staleUntilMs;
+    if (staleByKnob) return this.makeSnapshot(this.initialCatalog, true, this.staleUntilMs);
+
+    if (this.cachedSnapshot && this.cachedSnapshot.cachedUntil !== null && now < this.cachedSnapshot.cachedUntil) {
+      return this.cachedSnapshot;
+    }
+
+    const cachedUntil = this.cacheTtlMs > 0 ? now + this.cacheTtlMs : null;
+    const snapshot = this.makeSnapshot(this.catalog, false, cachedUntil);
+    if (cachedUntil !== null) this.cachedSnapshot = snapshot;
+    return snapshot;
+  }
+
+  metadata(now = Date.now()): DenAppVersionMetadataFixture {
+    return this.snapshot(now).metadata;
+  }
+
+  highestAllowedVersion(now = Date.now()): string | null {
+    return highestAllowedVersion(this.snapshot(now).catalog, this.allowedVersions);
+  }
+
+  resolveAllowedUpdate(currentVersion: string, now = Date.now()): string | null {
+    return resolveAllowedUpdate({ catalog: this.snapshot(now).catalog, currentVersion, allowedVersions: this.allowedVersions });
+  }
+
+  assetUrl(version: string, platform: ReleasePlatform, distribution: ReleaseDistribution = DEFAULT_DISTRIBUTION): string {
+    const asset = this.resolveAsset(version, platform, distribution);
+    return buildReleaseAssetUrl({ baseUrl: this.baseUrl, repo: this.repo, version, fileName: asset.fileName });
+  }
+
+  githubAssetUrl(version: string, platform: ReleasePlatform, distribution: ReleaseDistribution = DEFAULT_DISTRIBUTION): string {
+    const asset = this.resolveAsset(version, platform, distribution);
+    return buildReleaseAssetUrl({ baseUrl: "https://github.com", repo: this.repo, version, fileName: asset.fileName });
+  }
+
+  localizeGitHubUrl(url: string): string {
+    const parsed = new URL(url);
+    return `${this.baseUrl}${parsed.pathname}`;
+  }
+
+  resolveAsset(version: string, platform: ReleasePlatform, distribution: ReleaseDistribution = DEFAULT_DISTRIBUTION): ReleaseAsset {
+    const normalized = requireVersion(version);
+    const release = this.snapshot().catalog.find((entry) => compareReleaseVersions(entry.version, normalized) === 0);
+    if (!release) {
+      throw new ReleaseLabError(
+        "release_asset_missing",
+        `Release ${versionTag(normalized)} is not present in the hermetic catalog.`,
+        "Publish the requested version in the release feed before allowing clients to target it.",
+      );
+    }
+    const asset = release.assets.find((entry) => entry.platform === platform && entry.distribution === distribution)
+      ?? release.assets.find((entry) => entry.platform === platform);
+    if (!asset) {
+      throw new ReleaseLabError(
+        "release_asset_missing",
+        `Release ${versionTag(normalized)} has no ${platform} artifact.`,
+        "Keep the update hidden for this platform until the matching installer asset exists.",
+      );
+    }
+    return asset;
+  }
+
+  assertInstallableAsset(version: string, platform: ReleasePlatform, distribution: ReleaseDistribution = DEFAULT_DISTRIBUTION): ReleaseAsset {
+    const asset = this.resolveAsset(version, platform, distribution);
+    if (asset.installerCapable) return asset;
+    throw new ReleaseLabError(
+      "release_asset_not_installer_capable",
+      `Release ${versionTag(version)} has ${platform} assets that predate installer-capable desktop releases.`,
+      "Approve a newer desktop version with signed installer assets, or mount a compatible artifact before exposing the install path.",
+    );
+  }
+
+  resolveClientDownloadedAsset(version: string, platform: ReleasePlatform, clientFileName: string): ReleaseAsset {
+    const release = this.snapshot().catalog.find((entry) => compareReleaseVersions(entry.version, version) === 0);
+    const asset = release?.assets.find((entry) => entry.platform === platform && clientFileNameMatchesAsset(entry, clientFileName));
+    if (!asset) {
+      throw new ReleaseLabError(
+        "release_asset_missing",
+        `Downloaded filename ${JSON.stringify(clientFileName)} did not resolve to a ${platform} release asset.`,
+        "Resolve install metadata from the URL or bundle manifest, not solely from a browser-controlled filename.",
+      );
+    }
+    return asset;
+  }
+
+  async start(): Promise<this> {
+    if (this.server) return this;
+    const server = createServer((req, res) => {
+      void this.handleRequest(req, res);
+    });
+    await new Promise<void>((resolve, reject) => {
+      const onError = (error: Error) => reject(error);
+      server.once("error", onError);
+      server.listen(0, "127.0.0.1", () => {
+        server.off("error", onError);
+        resolve();
+      });
+    });
+    this.server = server;
+    this.baseUrlValue = serverBaseUrl(server);
+    return this;
+  }
+
+  async stop(): Promise<void> {
+    const server = this.server;
+    if (!server) return;
+    await new Promise<void>((resolve, reject) => {
+      server.close((error) => {
+        if (error) reject(error);
+        else resolve();
+      });
+    });
+    this.server = null;
+    this.baseUrlValue = null;
+  }
+
+  async runActionableProbe(): Promise<never> {
+    const probe = this.actionableProbe;
+    if (!probe) {
+      throw new ReleaseLabError(
+        "release_probe_unexpected_success",
+        "No degraded release-feed probe was configured.",
+        "Configure the lab with a 504 asset, stale cache, or denied-host probe before asserting actionable errors.",
+      );
+    }
+
+    if (probe.kind === "cache") {
+      const metadata = this.metadata();
+      if (!metadata.publishedDesktopVersions.some((version) => compareReleaseVersions(version, probe.expectedVersion) === 0)) {
+        throw cacheStaleError(probe.expectedVersion);
+      }
+      throw new ReleaseLabError(
+        "release_probe_unexpected_success",
+        `Expected ${versionTag(probe.expectedVersion)} to be hidden by cache lag, but it was visible.`,
+        "Tighten the cache-lag fixture before asserting stale-feed behavior.",
+      );
+    }
+
+    if (probe.kind === "host") {
+      const url = probe.url
+        ?? this.githubAssetUrl(probe.version ?? this.metadata().latestAppVersion, probe.platform ?? "win-x64");
+      assertReleaseHostAllowed(url, probe.allowedHosts);
+      throw new ReleaseLabError(
+        "release_probe_unexpected_success",
+        `Expected ${url} to be denied by host policy, but it was allowed.`,
+        "Use an allowed-host list that excludes the release host for this degraded-flow frame.",
+      );
+    }
+
+    const url = this.assetUrl(probe.version, probe.platform);
+    await fetchAssetOrThrow(url, probe.allowedHosts);
+    throw new ReleaseLabError(
+      "release_probe_unexpected_success",
+      `Expected ${url} to fail, but it downloaded successfully.`,
+      "Attach a fault knob to the release asset before asserting propagation failures.",
+    );
+  }
+
+  private makeSnapshot(catalog: ReleaseVersion[], stale: boolean, cachedUntil: number | null): ReleaseSnapshot {
+    const allowedCatalog = allowedReleaseCatalog(catalog, this.allowedVersions);
+    return {
+      catalog: allowedCatalog,
+      metadata: releaseCatalogMetadata(allowedCatalog.length > 0 ? allowedCatalog : catalog),
+      stale,
+      cachedUntil,
+    };
+  }
+
+  private githubReleasesJson(): unknown[] {
+    return this.snapshot().catalog.slice().reverse().map((release) => ({
+      url: `${this.baseUrl}/repos/${this.repo}/releases/tags/${release.tagName}`,
+      html_url: `${this.baseUrl}/${this.repo}/releases/tag/${release.tagName}`,
+      tag_name: release.tagName,
+      name: release.tagName,
+      draft: false,
+      prerelease: release.prerelease,
+      published_at: release.publishedAt,
+      assets: release.assets.map((asset, index) => ({
+        id: `${release.version}-${index}`,
+        name: asset.fileName,
+        label: asset.fileName,
+        state: "uploaded",
+        size: asset.size,
+        content_type: asset.contentType,
+        browser_download_url: buildReleaseAssetUrl({ baseUrl: this.baseUrl, repo: this.repo, version: release.version, fileName: asset.fileName }),
+      })),
+    }));
+  }
+
+  private async handleRequest(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    try {
+      const requestUrl = new URL(req.url ?? "/", `http://${req.headers.host ?? "127.0.0.1"}`);
+      const segments = decodePathSegments(requestUrl);
+
+      if (requestUrl.pathname === "/v1/app-version") {
+        sendJson(res, 200, this.metadata());
+        return;
+      }
+
+      if (isGitHubReleasesApi(segments)) {
+        sendJson(res, 200, this.githubReleasesJson());
+        return;
+      }
+
+      if (requestUrl.pathname.endsWith(".yml")) {
+        this.sendElectronUpdaterManifest(res, segments);
+        return;
+      }
+
+      const latestFileName = latestDownloadFileNameFromSegments(segments);
+      if (latestFileName) {
+        const latestVersion = this.metadata().latestAppVersion;
+        await this.sendAsset(res, latestVersion, latestFileName);
+        return;
+      }
+
+      const tag = tagFromSegments(segments);
+      const fileName = fileNameFromSegments(segments);
+      if (tag && fileName) {
+        await this.sendAsset(res, tag, fileName);
+        return;
+      }
+
+      sendJson(res, 404, { error: "not_found", path: requestUrl.pathname, repo: repoFromSegments(segments) });
+    } catch (error) {
+      const body = isReleaseLabError(error)
+        ? { error: error.code, message: error.message, action: error.action }
+        : { error: "release_lab_internal_error", message: error instanceof Error ? error.message : String(error) };
+      sendJson(res, 500, body);
+    }
+  }
+
+  private sendElectronUpdaterManifest(res: ServerResponse, segments: string[]): void {
+    const tag = tagFromSegments(segments) ?? this.metadata().latestAppVersion;
+    const version = requireVersion(tag);
+    const asset = this.resolveAsset(version, "mac-arm64", "enterprise");
+    const url = buildReleaseAssetUrl({ baseUrl: this.baseUrl, repo: this.repo, version, fileName: asset.fileName });
+    sendText(res, 200, `version: ${version}\nfiles:\n  - url: ${asset.fileName}\n    sha512: release-lab-fixture\n    size: ${asset.size}\npath: ${asset.fileName}\nsha512: release-lab-fixture\nreleaseDate: ${this.snapshot().catalog.find((entry) => entry.version === version)?.publishedAt ?? new Date(0).toISOString()}\n`, {
+      "x-release-lab-asset-url": url,
+    });
+  }
+
+  private async sendAsset(res: ServerResponse, version: string, fileName: string): Promise<void> {
+    const normalizedVersion = requireVersion(version);
+    const release = this.snapshot().catalog.find((entry) => compareReleaseVersions(entry.version, normalizedVersion) === 0);
+    const asset = release?.assets.find((entry) => entry.fileName === fileName);
+    if (!asset) {
+      sendJson(res, 404, { error: "release_asset_missing", version: normalizedVersion, fileName });
+      return;
+    }
+
+    if (asset.fault?.kind === "status") {
+      sendJson(res, asset.fault.status, { error: "release_asset_fault", message: asset.fault.message ?? `HTTP ${asset.fault.status}` });
+      return;
+    }
+
+    const headers = {
+      "content-type": asset.contentType,
+      "content-length": String(asset.size),
+      "connection": "close",
+      "content-disposition": `attachment; filename="${(asset.rewrittenFileName ?? asset.fileName).replace(/["\\]/g, "-")}"`,
+      "cache-control": "private, max-age=300",
+      "x-release-lab-version": normalizedVersion,
+      "x-release-lab-installer-capable": String(asset.installerCapable),
+    };
+    res.writeHead(200, headers);
+
+    if (asset.fault?.kind === "slow-chunked") {
+      for (let index = 0; index < asset.body.byteLength; index += asset.fault.chunkSize) {
+        res.write(asset.body.slice(index, index + asset.fault.chunkSize));
+        await sleep(asset.fault.delayMs);
+      }
+      res.end();
+      return;
+    }
+
+    res.end(asset.body);
+  }
+}
+
+export function denMetadataFromUnknown(value: unknown): DenAppVersionMetadataFixture | null {
+  if (!isRecord(value)) return null;
+  const minAppVersion = typeof value.minAppVersion === "string" ? value.minAppVersion : "";
+  const latestAppVersion = typeof value.latestAppVersion === "string" ? value.latestAppVersion : "";
+  const publishedDesktopVersions = Array.isArray(value.publishedDesktopVersions)
+    ? value.publishedDesktopVersions.filter((entry): entry is string => typeof entry === "string")
+    : [];
+  if (!minAppVersion || !latestAppVersion) return null;
+  return { minAppVersion, latestAppVersion, publishedDesktopVersions };
+}

--- a/evals/runner/release-feed.test.ts
+++ b/evals/runner/release-feed.test.ts
@@ -1,0 +1,130 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  ReleaseFeedLab,
+  buildReleaseAssetUrl,
+  createReleaseCatalog,
+  fetchAssetOrThrow,
+  highestAllowedVersion,
+  isReleaseLabError,
+  normalizeReleaseCatalog,
+  resolveAllowedUpdate,
+  simulateBrowserRenamedFileName,
+} from "./labs/release-feed.ts";
+import { resolveBootstrapPrecedence } from "./journeys/update.ts";
+
+describe("release feed catalog resolution", () => {
+  test("selects highest allowed instead of latest and treats empty allowlist as unrestricted", () => {
+    const catalog = normalizeReleaseCatalog(createReleaseCatalog(["0.17.20", "0.17.30", "0.17.40"]));
+
+    assert.equal(highestAllowedVersion(catalog, ["0.17.30"]), "0.17.30");
+    assert.equal(resolveAllowedUpdate({ catalog, currentVersion: "0.17.20", allowedVersions: ["0.17.30"] }), "0.17.30");
+    assert.equal(resolveAllowedUpdate({ catalog, currentVersion: "0.17.20", allowedVersions: [] }), "0.17.40");
+    assert.equal(resolveAllowedUpdate({ catalog, currentVersion: "0.17.20", allowedVersions: ["0.17.99"] }), null);
+  });
+});
+
+describe("release feed URL and filename handling", () => {
+  test("constructs release asset URLs and resolves browser-renamed filenames", async () => {
+    const feed = await new ReleaseFeedLab({
+      catalog: createReleaseCatalog(["0.17.40"], { platforms: ["win-x64"], distribution: "enterprise" }),
+    }).start();
+    try {
+      const fileName = "openwork-enterprise-win-x64-0.17.40.exe";
+      assert.equal(
+        buildReleaseAssetUrl({ baseUrl: feed.baseUrl, version: "0.17.40", fileName }),
+        `${feed.baseUrl}/different-ai/openwork/releases/download/v0.17.40/openwork-enterprise-win-x64-0.17.40.exe`,
+      );
+      const renamed = simulateBrowserRenamedFileName(fileName);
+      assert.equal(feed.resolveClientDownloadedAsset("0.17.40", "win-x64", renamed).fileName, fileName);
+      assert.equal(feed.resolveClientDownloadedAsset("0.17.40", "win-x64", fileName).fileName, fileName);
+    } finally {
+      await feed.stop();
+    }
+  });
+});
+
+describe("release feed cache semantics", () => {
+  test("honors cache TTL and explicit staleUntil", () => {
+    const feed = new ReleaseFeedLab({
+      catalog: createReleaseCatalog(["0.17.20"]),
+      cacheTtlMs: 1_000,
+    });
+
+    assert.equal(feed.snapshot(1_000).metadata.latestAppVersion, "0.17.20");
+    feed.updateCatalog(createReleaseCatalog(["0.17.20", "0.17.40"]));
+    assert.equal(feed.snapshot(1_500).metadata.latestAppVersion, "0.17.20");
+    assert.equal(feed.snapshot(2_001).metadata.latestAppVersion, "0.17.40");
+
+    const stale = new ReleaseFeedLab({
+      initialCatalog: createReleaseCatalog(["0.17.20"]),
+      catalog: createReleaseCatalog(["0.17.20", "0.17.40"]),
+      staleUntil: 5_000,
+    });
+    assert.equal(stale.snapshot(4_999).metadata.latestAppVersion, "0.17.20");
+    assert.equal(stale.snapshot(5_000).metadata.latestAppVersion, "0.17.40");
+  });
+});
+
+describe("release feed fault knobs", () => {
+  test("turns a 504 artifact response into an actionable error", async () => {
+    const feed = await new ReleaseFeedLab({
+      catalog: [{
+        version: "0.17.40",
+        assets: [{
+          platform: "win-x64",
+          distribution: "enterprise",
+          fault: { kind: "status", status: 504, message: "GitHub propagation lag" },
+        }],
+      }],
+    }).start();
+    try {
+      await assert.rejects(
+        () => fetchAssetOrThrow(feed.assetUrl("0.17.40", "win-x64")),
+        (error) => isReleaseLabError(error) && error.code === "release_asset_propagation_lag" && error.action.includes("Retry"),
+      );
+    } finally {
+      await feed.stop();
+    }
+  });
+
+  test("serves slow chunked assets without corrupting the artifact body", async () => {
+    const feed = await new ReleaseFeedLab({
+      catalog: [{
+        version: "0.17.40",
+        assets: [{
+          platform: "win-x64",
+          distribution: "enterprise",
+          body: "chunk-one\nchunk-two\n",
+          fault: { kind: "slow-chunked", chunkSize: 5, delayMs: 1 },
+        }],
+      }],
+    }).start();
+    try {
+      const body = await fetchAssetOrThrow(feed.assetUrl("0.17.40", "win-x64"));
+      assert.equal(new TextDecoder().decode(body), "chunk-one\nchunk-two\n");
+    } finally {
+      await feed.stop();
+    }
+  });
+});
+
+describe("bootstrap precedence helper", () => {
+  test("drives workspace-store precedence so an installed organization URL outranks a newer hosted bundle", async () => {
+    const organizationUrl = "https://openwork.organization.internal.example";
+    const result = await resolveBootstrapPrecedence({
+      before: {
+        serverUrl: organizationUrl,
+        bundleServerUrl: "https://app.openworklabs.com",
+        installedPath: "canonical",
+      },
+      after: { serverUrl: organizationUrl },
+    });
+
+    assert.equal(result.importedBeforeRead, false);
+    assert.equal(result.importedAfterRestart, false);
+    assert.equal(result.firstBaseUrl, organizationUrl);
+    assert.equal(result.restartedBaseUrl, organizationUrl);
+    assert.equal(result.persistedBaseUrl, organizationUrl);
+  });
+});

--- a/evals/voiceovers/release-allowlist-targeting.md
+++ b/evals/voiceovers/release-allowlist-targeting.md
@@ -1,0 +1,5 @@
+# Release allowlist targeting
+
+1. The release lab publishes several desktop versions, then applies the same organization allowlist that admins use in production. A client behind that policy is offered the highest approved release, not the public latest.
+
+2. The lab also keeps the old edge case where the only approved version predates installer-capable builds. Instead of handing users a broken installer path, the check stops on a named error with the next action for admins.

--- a/evals/voiceovers/release-bootstrap-precedence.md
+++ b/evals/voiceovers/release-bootstrap-precedence.md
@@ -1,0 +1,3 @@
+# Release bootstrap precedence
+
+1. The lab recreates an update bundle beside an already configured desktop and asks the real bootstrap resolver to choose again. The organization server URL remains the winner before and after the update-like restart.

--- a/evals/voiceovers/release-feed-degraded.md
+++ b/evals/voiceovers/release-feed-degraded.md
@@ -1,0 +1,7 @@
+# Release feed degraded
+
+1. First the artifact host behaves like GitHub during a propagation lag and returns 504. The lab proves that this becomes a clear propagation error instead of a quiet no-update.
+
+2. Next the version feed is intentionally stale, just like the thirty-minute cache lag seen in the field. The lab names the stale cache and tells the operator how to force fresh release metadata.
+
+3. Finally the download host is denied by enterprise outbound policy. The check reports the blocked host and the allowlist or mirror action needed before users try another reinstall.


### PR DESCRIPTION
## Why

A 6-week enterprise POC log shows the update path failing for **four straight weeks**, in ways that keep recurring because we only ever test against real GitHub releases:

- Auto-update **never offered the admin-enabled versions** → repeated manual reinstalls.
- Download served the **latest** build instead of the **highest admin-allowed** version; separately, the highest-approved version **predated installer support**, which broke the install path outright.
- "Allowed desktop versions" is **owner-only** → upgrades deadlocked twice while the owner was OOO.
- **30-minute cache lag** on version propagation; version list showed only oldest+latest.
- GitHub **504** during download; GitHub not on the corporate allow list at all; a filename-metadata hack broke in browsers (Arc) that rename downloads.
- **The app reverted to the wrong server after an update** (bootstrap precedence) — the most damaging one.

## What

**`evals/runner/labs/release-feed.ts`** — a local feed + artifact host mimicking the shapes our updater consumes: version catalog with per-platform assets, `allowedVersions` gating, `cacheTtlMs`/staleness knobs, and fault knobs (`504`, slow chunked delivery, client-renamed downloads, versions predating installer support).

**`evals/runner/journeys/update.ts`** — the key design point: these assertions **drive the real product decision paths** rather than reimplementing them, so the tests can actually catch the field bugs:

| Assertion | Real code path exercised |
|---|---|
| `expectOfferedVersion` | `apps/app/src/app/lib/version-gate.ts` → `selectStableDesktopUpdate` |
| targeted feed URL | `apps/desktop/electron/updater.mjs` → `targetedStableUpdaterFeed` |
| `expectDownloadUrl` | `ee/apps/den-api/src/utils/installer-artifacts.ts` |
| `expectBootstrapPrecedenceSurvives` | `apps/desktop/electron/workspace-store.mjs` |

**Flows** (all `requiresApp: false`, so they run in CI): `release-allowlist-targeting` (highest-allowed never latest; pre-installer-support version surfaces an actionable error instead of a broken install), `release-feed-degraded` (504 / cache lag / denied host each produce a **named** error — nothing swallowed), `release-bootstrap-precedence` (configured server URL survives an update-like re-resolution).

## Tests run

- `pnpm evals:typecheck` ✓ · `pnpm evals:test` ✓ (47)
- `pnpm evals --flow release-allowlist-targeting --flow release-feed-degraded --flow release-bootstrap-precedence` → **3 passed**
- `pnpm fraimz --flow release-allowlist-targeting` → voiceover coverage green
- `pnpm evals --list` → 3 flows added, pre-existing lines byte-identical

## Toolchain note

Product TS modules (Vite/Bun-flavored) are imported by shelling out to `bun`, which nightly CI already provisions (`oven-sh/setup-bun@v2`, bun 1.3.9). Without bun the flows **skip with an actionable reason** rather than failing — verified by running with bun removed from PATH:

```
⏭ skipped: Release lab flows drive real product TypeScript modules through bun, but `bun` is not available on PATH. Install Bun and add it to PATH (nightly CI uses oven-sh/setup-bun@v2 with bun 1.3.9), then rerun the flow.
```

## Follow-up (not in this PR)

Den's installer release-tag resolver is private to a route, so it can't be asserted directly. Smallest fix: extract `installerReleaseTagForMetadata` + version-compare helpers from `ee/apps/den-api/src/routes/org/install-links.ts` into a pure `ee/apps/den-api/src/utils/installer-release-policy.ts` taking `(metadataInput, fallbackReleaseTag)`, so route/db/env side effects aren't pulled into tests. Happy to fold in on request.