### PR TITLE
fix(app): render dark theme previews correctly

### DIFF
--- a/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
+++ b/apps/app/src/react-app/domains/settings/appearance/theme-section.tsx
@@ -76,7 +76,7 @@ function ThemePicker(props: ThemePickerProps) {
         value="dark"
         label={t("settings.theme_dark")}
       >
-        <ThemePreview value="dark" className="bg-zinc-950" />
+        <ThemePreview value="dark" className="bg-black" />
         <ThemePickerLabel>{t("settings.theme_dark")}</ThemePickerLabel>
       </ThemePickerItem>
     </ToggleGroup>
@@ -117,7 +117,7 @@ function ThemePreview(props: ThemePreviewProps) {
       {props.value === "system" && (
         <div className="flex h-full">
           <div className="w-1/2 bg-white" />
-          <div className="w-1/2 bg-zinc-950" />
+          <div className="w-1/2 bg-black" />
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary

- render the Dark appearance preview with a supported black background utility
- render the dark half of the System preview with the same background

## Root cause

The previews used `bg-zinc-950`, but the app's Tailwind configuration replaces the default color palette and does not include `zinc`. Tailwind therefore emits no background rule for that class, leaving the preview transparent so the light-gray settings surface shows through.

The replacement, `bg-black`, is explicitly defined in the app's Tailwind palette.

## Impact

The appearance selector now visually distinguishes Light, Dark, and System while the app is in light mode.

## Checks

Checks not run (level 0).

## Manual verification

1. Open Settings → Appearance while OpenWork is in light mode.
2. Confirm the Dark preview is black.
3. Confirm the System preview is split into white and black halves.
4. Confirm selecting each theme still updates the selected state.

## Risk

Low. The change only replaces two unsupported preview background utility classes and does not affect theme persistence or switching behavior.
